### PR TITLE
Add pyproject.toml, update README.md, fix add_spdx_header.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ Please follow setup instructions found in each model folder's README.md doc
 ## Model Implementations
 | Model          | Hardware                    |
 |----------------|-----------------------------|
-| [LLaMa 3.1 70B](tt-metal-llama3-70b/README.md)  | TT-QuietBox & TT-LoudBox    |
+| [LLaMa 3.1 70B](vllm-tt-metal-llama3-70b/README.md)  | TT-QuietBox & TT-LoudBox    |
 | [Mistral 7B](tt-metal-mistral-7b/README.md) | n150 and n300|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+# departure from defaults, see: https://docs.astral.sh/ruff/configuration/ 
+[tool.ruff]
+
+# Python 3.8
+target-version = "py38"
+
+[tool.ruff.lint]
+ignore = ["E402"]

--- a/scripts/add_spdx_header.py
+++ b/scripts/add_spdx_header.py
@@ -16,6 +16,7 @@ SPDX_HEADER = """# SPDX-License-Identifier: Apache-2.0
 
 SPDX_DATE = str(current_year) + " Tenstorrent AI ULC\n"
 
+
 def add_spdx_header(file_path):
     with open(file_path, "r+") as file:
         content = file.read()
@@ -23,16 +24,24 @@ def add_spdx_header(file_path):
             file.seek(0, 0)
             file.write(SPDX_HEADER + SPDX_DATE + "\n" + content)
 
+
 if __name__ == "__main__":
     # List of directories to process here
     repo_root = Path(__file__).resolve().parent.parent
     directories_to_process = [
         repo_root / "tt-metal-llama3-70b",
+        repo_root / "vllm-tt-metal-llama3-70b",
         repo_root / "tt-metal-mistral-7b",
+        repo_root / "tests",
+        repo_root / "utils",
+        repo_root / "evals",
+        repo_root / "benchmarking",
     ]
     # Walk through the specified directories and add the header to all relevant files
     for directory in directories_to_process:
         for file_path in directory.rglob("*"):
             # Check if the file is Python, Dockerfile, or Bash
-            if file_path.suffix in (".py", ".sh") or file_path.name.endswith("Dockerfile"):
+            if file_path.suffix in (".py", ".sh") or file_path.name.endswith(
+                "Dockerfile"
+            ):
                 add_spdx_header(file_path)


### PR DESCRIPTION
# change log

- add pyproject.toml for ruff linter
- update README.md link to LLaMa 3.1 70B
- add new top level dirs to add_spdx_header.py