### PR TITLE
benchmark and evals changes for Llama 3.1 70B v0 drop testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,7 @@ __pycache__
 env
 .testvenv
 python_env
-.venv
-venv/
+.venv*
 
 # persistent storage volume
 persistent_volume

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -6,7 +6,7 @@
 
 The vLLM benchmarking script is https://github.com/tenstorrent/vllm/blob/dev/examples/offline_inference_tt.py
 
-It is recommended to run the vLLM model implementation via `docker run`, at tt-inference-server/vllm-tt-metal-llama3-70b/README.md.
+It is recommended to run the vLLM model implementation via `docker run`, at tt-inference-server/vllm-tt-metal-llama3/README.md.
 
 To measure performance for a single batch (with the default prompt length of 128 tokens):
 ```bash

--- a/benchmarking/benchmark_serving.patch
+++ b/benchmarking/benchmark_serving.patch
@@ -1,5 +1,19 @@
+diff --git a/benchmarks/backend_request_func.py b/benchmarks/backend_request_func.py
+index 4813fde2..0cb3e72e 100644
+--- a/benchmarks/backend_request_func.py
++++ b/benchmarks/backend_request_func.py
+@@ -235,9 +235,7 @@ async def async_request_openai_completions(
+             "model": request_func_input.model,
+             "prompt": request_func_input.prompt,
+             "temperature": 0.0,
+-            "best_of": request_func_input.best_of,
+             "max_tokens": request_func_input.output_len,
+-            "logprobs": request_func_input.logprobs,
+             "stream": True,
+             "ignore_eos": request_func_input.ignore_eos,
+         }
 diff --git a/benchmarks/benchmark_serving.py b/benchmarks/benchmark_serving.py
-index c1a396c8..463e0e93 100644
+index c1a396c8..74f75a15 100644
 --- a/benchmarks/benchmark_serving.py
 +++ b/benchmarks/benchmark_serving.py
 @@ -22,6 +22,12 @@ On the client side, run:
@@ -24,30 +38,3 @@ index c1a396c8..463e0e93 100644
          multi_modal_content=test_mm_content,
          ignore_eos=ignore_eos,
      )
-@@ -458,7 +464,7 @@ async def benchmark(
-                                               prompt_len=prompt_len,
-                                               output_len=output_len,
-                                               logprobs=logprobs,
--                                              best_of=best_of,
-+                                              best_of=None,
-                                               multi_modal_content=mm_content,
-                                               ignore_eos=ignore_eos)
-         tasks.append(
-diff --git a/vllm/worker/tt_model_runner.py b/vllm/worker/tt_model_runner.py
-index 1c586dd3..2e77bf72 100644
---- a/vllm/worker/tt_model_runner.py
-+++ b/vllm/worker/tt_model_runner.py
-@@ -425,12 +425,7 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
-             )
-     
-     def _validate_sampling_params(self, sampling_params):
--        assert sampling_params.n == 1, "Currently only supporting n=1"
--        assert sampling_params.best_of is None, "Currently not supporting best_of"
--        assert sampling_params.logprobs is None, "Currently not supporting logprobs"
--        assert sampling_params.prompt_logprobs is None, "Currently not supporting prompt_logprobs"
--
--    ## Destructor (used to delete ttnn trace if using trace mode)
-+        return
-     
-     def __del__(self):
-         if self.trace_mode and self.execute_trace_kwargs is not None:

--- a/benchmarking/benchmark_summary.py
+++ b/benchmarking/benchmark_summary.py
@@ -1,0 +1,374 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+import json
+import glob
+import os
+import csv
+from datetime import datetime
+import re
+from typing import Dict, List, Any, Union, Tuple
+import argparse
+from pathlib import Path
+
+
+DATE_STR_FORMAT = "%Y-%m-%d_%H-%M-%S"
+NOT_MEASURED_STR = "n/a"
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Process vLLM benchmark results from multiple directories."
+    )
+    parser.add_argument(
+        "directories",
+        nargs="+",
+        type=str,
+        help="One or more directories containing benchmark files",
+    )
+    parser.add_argument(
+        "--pattern",
+        type=str,
+        default="*_benchmark_*.json",
+        help="File pattern to match (default: vllm_online_benchmark_*.json)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="",
+        help="Output CSV file name",
+    )
+    return parser.parse_args()
+
+
+def extract_params_from_filename(filename: str) -> Dict[str, Any]:
+    pattern = r"""
+        benchmark_
+        (?P<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})  # Timestamp
+        _isl-(?P<isl>\d+)                                    # Input sequence length
+        _osl-(?P<osl>\d+)                                    # Output sequence length
+        _bsz-(?P<bsz>\d+)                                    # Batch size
+        _n-(?P<n>\d+)                                        # Number of requests
+    """
+
+    match = re.search(pattern, filename, re.VERBOSE)
+    if not match:
+        raise ValueError(f"Could not extract parameters from filename: {filename}")
+
+    # Convert timestamp string to datetime
+    timestamp_str = match.group("timestamp")
+    timestamp = datetime.strptime(timestamp_str, "%Y-%m-%d_%H-%M-%S")
+
+    # Extract and convert numeric parameters
+    params = {
+        "timestamp": timestamp,
+        "input_sequence_length": int(match.group("isl")),
+        "output_sequence_length": int(match.group("osl")),
+        "batch_size": int(match.group("bsz")),
+        "num_requests": int(match.group("n")),
+    }
+
+    return params
+
+
+def extract_timestamp(directories):
+    pattern = r"""
+        results_
+        (?P<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})  # Timestamp
+    """
+    first_dir = directories[0]
+    match = re.search(pattern, first_dir, re.VERBOSE)
+    if not match:
+        raise ValueError(f"Could not extract parameters from: {first_dir}")
+
+    # Convert timestamp string to datetime
+    timestamp_str = match.group("timestamp")
+
+    return timestamp_str
+
+
+def format_metrics(metrics):
+    formatted_metrics = {}
+
+    for key, value in metrics.items():
+        # Skip None values and NOT_MEASURED_STR
+        if value is None or value == NOT_MEASURED_STR:
+            formatted_metrics[key] = NOT_MEASURED_STR
+        elif isinstance(value, float):
+            # Format numeric values to 2 decimal places
+            formatted_metrics[key] = round(float(value), 2)
+        else:
+            formatted_metrics[key] = value
+
+    return formatted_metrics
+
+
+def process_benchmark_file(filepath: str) -> Dict[str, Any]:
+    """Process a single benchmark file and extract relevant metrics."""
+    with open(filepath, "r") as f:
+        data = json.load(f)
+
+    filename = os.path.basename(filepath)
+
+    params = extract_params_from_filename(filename)
+
+    # Calculate statistics
+
+    mean_tpot_ms = data.get("mean_tpot_ms")
+    if data.get("mean_tpot_ms"):
+        mean_tpot = max(data.get("mean_tpot_ms"), 1e-6)  # Avoid division by zero
+        mean_tps = 1000.0 / mean_tpot
+        if data.get("std_tpot_ms"):
+            std_tps = mean_tps - (1000.0 / (mean_tpot + data.get("std_tpot_ms")))
+        else:
+            std_tps = None
+    else:
+        mean_tps = None
+        std_tps = None
+
+    metrics = {
+        "timestamp": params["timestamp"],
+        "model_id": data.get("model_id", ""),
+        "backend": data.get("backend", ""),
+        "input_sequence_length": params["input_sequence_length"],
+        "output_sequence_length": params["output_sequence_length"],
+        "batch_size": params["batch_size"],
+        "mean_ttft_ms": data.get("mean_ttft_ms"),
+        "std_ttft_ms": data.get("std_ttft_ms"),
+        "mean_tpot_ms": mean_tpot_ms,
+        "std_tpot_ms": data.get("std_tpot_ms"),
+        "mean_tps": mean_tps,
+        "std_tps": std_tps,
+        "mean_e2el_ms": data.get("mean_e2el_ms"),
+        "request_throughput": data.get("request_throughput"),
+        "total_input_tokens": data.get("total_input_tokens"),
+        "total_output_tokens": data.get("total_output_tokens"),
+        "num_prompts": data.get("num_prompts", ""),
+        "num_requests": params["num_requests"],
+        "filename": filename,
+    }
+    metrics = format_metrics(metrics)
+
+    return metrics
+
+
+def process_benchmark_files(
+    directories: List[str], pattern: str
+) -> List[Dict[str, Any]]:
+    """Process benchmark files from multiple directories matching the given pattern."""
+    results = []
+
+    for directory in directories:
+        dir_path = Path(directory)
+        if not dir_path.exists():
+            print(f"Warning: Directory not found: {directory}")
+            continue
+
+        file_pattern = str(dir_path / pattern)
+        files = glob.glob(file_pattern)
+
+        if not files:
+            print(
+                f"Warning: No files found matching pattern '{pattern}' in {directory}"
+            )
+            continue
+
+        print(f"Processing {len(files)} files from {directory}")
+
+        for filepath in files:
+            print(f"Processing: {filepath} ...")
+            try:
+                metrics = process_benchmark_file(filepath)
+                results.append(metrics)
+            except Exception as e:
+                print(f"Error processing file {filepath}: {str(e)}")
+
+    if not results:
+        raise ValueError("No benchmark files were successfully processed")
+
+    # Sort by timestamp
+    return sorted(results, key=lambda x: x["timestamp"])
+
+
+def save_to_csv(results: List[Dict[str, Any]], file_path: Union[Path, str]) -> None:
+    if not results:
+        return
+
+    # Get headers from first result (assuming all results have same structure)
+    headers = list(results[0].keys())
+
+    try:
+        with open(file_path, "w", newline="") as f:
+            writer = csv.writer(f)
+            # Write headers
+            writer.writerow(headers)
+            # Write data rows
+            for result in results:
+                row = [str(result.get(header, NOT_MEASURED_STR)) for header in headers]
+                writer.writerow(row)
+
+        print(f"\nResults saved to: {file_path}")
+
+    except Exception as e:
+        print(f"Error saving CSV file: {e}")
+
+
+def create_display_dict(result: Dict[str, Any]) -> Dict[str, str]:
+    # Define display columns mapping
+    display_cols: List[Tuple[str, str]] = [
+        ("input_sequence_length", "ISL"),
+        ("output_sequence_length", "OSL"),
+        ("batch_size", "Batch Size"),
+        ("num_requests", "Num Requests"),
+        ("mean_ttft_ms", "TTFT (ms)"),
+        ("mean_tpot_ms", "TPOT (ms)"),
+        ("mean_tps", "TPS (user)"),
+        ("mean_e2el_ms", "Request latency (ms)"),
+        ("request_throughput", "Request Throughput (RPS)"),
+    ]
+
+    display_dict = {}
+    for col_name, display_header in display_cols:
+        value = result.get(col_name, NOT_MEASURED_STR)
+        display_dict[display_header] = str(value)
+
+    return display_dict
+
+
+def get_markdown_table(display_dicts: List[Dict[str, str]], metadata: str = "") -> str:
+    if not display_dicts:
+        return ""
+
+    def sanitize_cell(text: str) -> str:
+        """Sanitize cell content for Markdown compatibility"""
+        # Replace problematic characters
+        text = str(text)
+        text = text.replace("|", "\\|")  # Escape pipe characters
+        text = text.replace("\n", " ")  # Replace newlines with spaces
+        text = re.sub(r"[^\x00-\x7F]+", "", text)  # Remove non-ASCII characters
+        return text.strip()
+
+    # Get headers from first dictionary
+    headers = list(display_dicts[0].keys())
+
+    # Calculate column widths based on all values including headers
+    col_widths = {}
+    for header in headers:
+        # Include header length in width calculation
+        width = len(header)
+        # Check all values for this column
+        for d in display_dicts:
+            width = max(width, len(str(d.get(header, ""))))
+        # Add minimum width of 3
+        col_widths[header] = max(width, 3)
+
+    # Create header row with proper padding
+    header_row = (
+        "| "
+        + " | ".join(
+            sanitize_cell(header).ljust(col_widths[header]) for header in headers
+        )
+        + " |"
+    )
+
+    # Create separator row with proper alignment indicators
+    separator_row = (
+        "|"
+        + "|".join(":" + "-" * (col_widths[header]) + ":" for header in headers)
+        + "|"
+    )
+
+    # Create value rows with proper padding
+    value_rows = []
+    for d in display_dicts:
+        row = (
+            "| "
+            + " | ".join(
+                sanitize_cell(str(d.get(header, ""))).ljust(col_widths[header])
+                for header in headers
+            )
+            + " |"
+        )
+        value_rows.append(row)
+
+    # add notes
+    end_notes = (
+        "\nNote: all metrics are means across benchmark run unless otherwise stated.\n"
+    )
+    # Combine all rows
+    md_str = (
+        metadata
+        + f"\n{header_row}\n{separator_row}\n"
+        + "\n".join(value_rows)
+        + end_notes
+    )
+    return md_str
+
+
+def save_markdown_table(
+    markdown_str: str, filepath: str, add_title: str = None, add_notes: List[str] = None
+) -> None:
+    # Convert string path to Path object and ensure .md extension
+    path = Path(filepath)
+    if path.suffix.lower() != ".md":
+        path = path.with_suffix(".md")
+
+    # Create directory if it doesn't exist
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Prepare content
+    content = []
+    if add_title:
+        # Add title with markdown h1 formatting and blank line
+        content.extend([f"# {add_title}", ""])
+    content.append(markdown_str)
+    if add_notes:
+        content.extend(add_notes)
+
+    # Write to file with UTF-8 encoding
+    try:
+        path.write_text("\n".join(content), encoding="utf-8")
+        print(f"Successfully saved markdown table to: {path}")
+    except Exception as e:
+        print(f"Error saving markdown table: {str(e)}")
+
+
+def main():
+    args = parse_args()
+
+    results = process_benchmark_files(args.directories, args.pattern)
+    timestamp_str = extract_timestamp(args.directories)
+
+    # Display basic statistics
+    print("\nBenchmark Summary:")
+    print(f"Total files processed: {len(results)}")
+
+    # Save to CSV
+    output_dir = args.output_dir
+    if not output_dir:
+        output_dir = Path(os.environ.get("CACHE_ROOT", ""), "benchmark_results")
+        os.makedirs(output_dir, exist_ok=True)
+
+    # save stats
+    stats_file_path = Path(output_dir) / f"benchmark_stats_{timestamp_str}.csv"
+    save_to_csv(results, stats_file_path)
+
+    display_results = [create_display_dict(res) for res in results]
+    disp_file_path = Path(output_dir) / f"benchmark_display_{timestamp_str}.csv"
+    save_to_csv(display_results, disp_file_path)
+    # Generate and print Markdown table
+    print("\nMarkdown Table:\n")
+    metadata = (
+        f"Model ID: {results[0].get('model_id')}\n"
+        f"Backend: {results[0].get('backend')}\n"
+    )
+    display_md_str = get_markdown_table(display_results, metadata=metadata)
+    print(display_md_str)
+    disp_md_path = Path(output_dir) / f"benchmark_display_{timestamp_str}.md"
+    save_markdown_table(display_md_str, disp_md_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/prompt_client_online_benchmark.py
+++ b/benchmarking/prompt_client_online_benchmark.py
@@ -26,11 +26,11 @@ logger.setLevel(logging.INFO)
 
 
 def run_sequence_length_test(
+    model: str,
     combinations: List[Dict[str, int]],
     result_dir: str,
     file_prefix: str,
     num_iterations: int = 1,
-    model: str = "meta-llama/Llama-3.1-70B-Instruct",
 ) -> List[dict]:
     # Create save directory
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
@@ -174,9 +174,11 @@ if __name__ == "__main__":
     result_dir.mkdir(parents=True, exist_ok=True)
 
     # Run tests
+    default_model = "meta-llama/Llama-3.1-70B-Instruct"
+    model = os.environ.get("HF_MODEL_REPO_ID", default_model)
     results = run_sequence_length_test(
+        model=model,
         combinations=combinations,
         result_dir=result_dir,
         file_prefix="online_benchmark",
-        model="meta-llama/Llama-3.1-70B-Instruct",
     )

--- a/benchmarking/vllm_online_benchmark.py
+++ b/benchmarking/vllm_online_benchmark.py
@@ -83,15 +83,6 @@ def main():
         {"input_len": 128, "output_len": 4096, "batch_size": 32, "num_prompts": 32 * 4},
         {"input_len": 2048, "output_len": 128, "batch_size": 32, "num_prompts": 32 * 16},
         {"input_len": 2048, "output_len": 2048, "batch_size": 32, "num_prompts": 32 * 4},
-        # {"input_len": 128, "output_len": 128, "batch_size": 32, "num_prompts": 32},
-        # {"input_len": 128, "output_len": 2048, "batch_size": 32, "num_prompts": 32},
-        # {"input_len": 128, "output_len": 4096, "batch_size": 32, "num_prompts": 32},
-        # {"input_len": 2048, "output_len": 128, "batch_size": 32, "num_prompts": 32},
-        # {"input_len": 2048, "output_len": 2048, "batch_size": 32, "num_prompts": 32},
-        # {"input_len": 1000, "output_len": 1000, "batch_size": 32, "num_prompts": 32},
-        # {"input_len": 500, "output_len": 2000, "batch_size": 32, "num_prompts": 32},
-        # {"input_len": 5000, "output_len": 500, "batch_size": 32, "num_prompts": 32},
-        # {"input_len": 20000, "output_len": 2000, "batch_size": 32, "num_prompts": 32},
     ]
     # fmt: on
 

--- a/benchmarking/vllm_online_benchmark.py
+++ b/benchmarking/vllm_online_benchmark.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from typing import Dict
 from pathlib import Path
 
-from benchmarking.prompt_client_online_benchmark import get_test_combinations
 from utils.prompt_configs import EnvironmentConfig
 from utils.prompt_client import PromptClient
 
@@ -35,12 +34,12 @@ def run_benchmark(
         "--backend", "vllm",
         "--model", model,
         "--port", str(port),
-        # "--request-rate", "3",
         "--dataset-name", "random",
         "--num-prompts", str(params["num_prompts"]),
         "--random-input-len", str(params["input_len"]),
         "--random-output-len", str(params["output_len"]),
         "--ignore-eos",  # Ignore EOS tokens to force max output length as set
+        "--percentile-metrics", "ttft,tpot,itl,e2el",  # must add e2el in order for it to be logged
         "--save-result",
         "--result-filename", str(result_filename)
     ]
@@ -75,28 +74,30 @@ def main():
     # note: there isnt a better way to pass an api key to the vllm benchmarking script
     os.environ["OPENAI_API_KEY"] = prompt_client._get_authorization()
 
-    # Define benchmarking context length (isl, osl) pairs
-    context_lens = [
-        (128, 128),
-        # (128, 2048),
-        # (128, 4096),
-        # (2048, 128),
-        # (2048, 2048),
-        # (1000, 1000),
-        # (500, 2000),
-        # (5000, 500),
-        # (20000, 2000),
-        # (128, 2),
-        # (256, 2),
-        # (512, 32),
-        # (1000, 24),
-        # (2000, 32),
-        # (4000, 32),
-        # (8100, 32),
-    ]
-
     # Get all benchmark combinations using the original function
-    combinations = get_test_combinations(context_lens=context_lens)
+    # fmt: off
+    combinations = [
+        {"input_len": 128, "output_len": 128, "batch_size": 32, "num_prompts": 32 * 32},
+        {"input_len": 128, "output_len": 1024, "batch_size": 32, "num_prompts": 32 * 16},
+        {"input_len": 128, "output_len": 2048, "batch_size": 32, "num_prompts": 32 * 8},
+        {"input_len": 128, "output_len": 4096, "batch_size": 32, "num_prompts": 32 * 4},
+        {"input_len": 2048, "output_len": 128, "batch_size": 32, "num_prompts": 32 * 16},
+        {"input_len": 2048, "output_len": 2048, "batch_size": 32, "num_prompts": 32 * 4},
+        # {"input_len": 128, "output_len": 128, "batch_size": 32, "num_prompts": 32},
+        # {"input_len": 128, "output_len": 2048, "batch_size": 32, "num_prompts": 32},
+        # {"input_len": 128, "output_len": 4096, "batch_size": 32, "num_prompts": 32},
+        # {"input_len": 2048, "output_len": 128, "batch_size": 32, "num_prompts": 32},
+        # {"input_len": 2048, "output_len": 2048, "batch_size": 32, "num_prompts": 32},
+        # {"input_len": 1000, "output_len": 1000, "batch_size": 32, "num_prompts": 32},
+        # {"input_len": 500, "output_len": 2000, "batch_size": 32, "num_prompts": 32},
+        # {"input_len": 5000, "output_len": 500, "batch_size": 32, "num_prompts": 32},
+        # {"input_len": 20000, "output_len": 2000, "batch_size": 32, "num_prompts": 32},
+    ]
+    # fmt: on
+
+    context_lens = [(it["input_len"], it["output_len"]) for it in combinations]
+    # de-dupe
+    context_lens = list(set(context_lens))
 
     # pre-capture traces required for benchmarking
     prompt_client.capture_traces(context_lens=context_lens)

--- a/evals/README.md
+++ b/evals/README.md
@@ -9,7 +9,7 @@ Source code:
 
 Docker images are published to: https://ghcr.io/tenstorrent/tt-inference-server/tt-metal-llama3-70b-src-base-vllm
 
-For instructions on building the Docker image see: [vllm-tt-metal-llama3-70b/docs/development](../vllm-tt-metal-llama3-70b/docs/development.md#step-1-build-docker-image)
+For instructions on building the Docker image see: [vllm-tt-metal-llama3/docs/development](../vllm-tt-metal-llama3/docs/development.md#step-1-build-docker-image)
 
 ## Step 2: Run Docker container for LM evals development
 
@@ -17,160 +17,56 @@ note: this requires running `setup.sh` to set up the weights for a particular mo
 
 ```bash
 cd tt-inference-server
-export PERSISTENT_VOLUME=$PWD/persistent_volume/volume_id_tt-metal-llama-3.1-70b-instructv0.0.1/
+export MODEL_VOLUME=$PWD/persistent_volume/volume_id_tt-metal-llama-3.1-70b-instructv0.0.1/
 docker run \
   --rm \
   -it \
-  --env-file tt-metal-llama3-70b/.env \
+  --env-file persistent_volume/model_envs/llama-3.1-70b-instruct.env \
   --cap-add ALL \
   --device /dev/tenstorrent:/dev/tenstorrent \
   --volume /dev/hugepages-1G:/dev/hugepages-1G:rw \
-  --volume ${PERSISTENT_VOLUME?ERROR env var PERSISTENT_VOLUME must be set}:/home/user/cache_root:rw \
+  --volume ${MODEL_VOLUME?ERROR env var MODEL_VOLUME must be set}:/home/user/cache_root:rw \
   --shm-size 32G \
-  ghcr.io/tenstorrent/tt-inference-server/tt-metal-llama3-70b-src-base-vllm:v0.0.1-tt-metal-${TT_METAL_COMMIT_DOCKER_TAG}-${TT_VLLM_COMMIT_DOCKER_TAG} bash
+  ghcr.io/tenstorrent/tt-inference-server/tt-metal-llama3-70b-src-base-vllm:${IMAGE_VERSION}-tt-metal-${TT_METAL_COMMIT_DOCKER_TAG}-${TT_VLLM_COMMIT_DOCKER_TAG}
 ```
 
-## Step 3: Inside container setup and run vLLM
+The default Docker image command will start the vLLM server. 
 
-#### Install vLLM - Option 1: use default installation in docker image
-
-already built into Docker image
-
-#### Install vLLM - option 2: install vLLM from github
-
-```bash
-# option 2: install from github
-cd /home/user/vllm
-git fetch
-git checkout <branch>
-git pull
-pip install -e .
-echo "done vllm install."
-```
-#### Install vLLM - option 3: install edittable (for development) from mounted volume
-
-```bash
-# option 3: install edittable (for development) - mount from outside container
-cd /home/user/vllm
-pip install -e .
-echo "done vllm install."
-```
-
-#### Run vllm serving openai compatible API server
-
-```bash
-# run vllm serving
-python run_vllm_api_server.py
-```
-
-## Step 4: Inside container setup LM evalulation harness
-
-Enter new bash shell in running container (this does so with newest running container):
-```bash
-docker exec -it $(docker ps -q | head -n1) bash
-```
-
-Now inside container:
-```bash
-# option 1: install from github: https://github.com/tstescoTT/lm-evaluation-harness
-pip install git+https://github.com/tstescoTT/lm-evaluation-harness.git#egg=lm-eval[ifeval]
-# option 2: install edittable (for development) - mounted to container
-cd ~/lm-evaluation-harness
-pip install -e .[ifeval]
-```
-
-## Step 5: Inside container set up llama-recipes LM evalulation harness templates
-
+## Step 3: Inside container set up llama-recipes LM evalulation harness templates
 
 Using Meta’s LM eval reproduce documentation: https://github.com/meta-llama/llama-recipes/tree/main/tools/benchmarks/llm_eval_harness/meta_eval 
 
 To access Meta Llama 3.1 evals, you must:
 
-1. Log in to the Hugging Face website (https://huggingface.co/collections/meta-llama/llama-31-evals-66a2c5a14c2093e58298ac7f ) and click the 3.1 evals dataset pages and agree to the terms.
+1. Log in to the Hugging Face website (https://huggingface.co/collections/meta-llama/llama-31-evals-66a2c5a14c2093e58298ac7f) and click the 3.1 evals dataset pages and agree to the terms.
 2. Follow the [Hugging Face authentication instructions](https://huggingface.co/docs/huggingface_hub/en/quick-start#authentication) to gain read access for your machine.
 
 #### Hugging Face authentication - option 1: HF_TOKEN (if not already passed into Docker container)
 ```bash
-# set up HF Token, needed for IFEval dataset
-# echo "hf_<token>" > ${HF_HOME}/token
-export PYTHONPATH=${PYTHONPATH}:$PWD
+# set up HF Token if not already set up in .env, needed for datasets
+echo "HF_TOKEN=hf_<your_token>" >> vllm-tt-metal-llama3/.env
 ```
 
 #### Hugging Face authentication - option 2: huggingface_hub login
+Note: do this inside the container shell:
 ```python
 from huggingface_hub import login
 login()
 ```
 
-Finally,  build llama-recipe lm-evaluation-harness templates:
+## Step 4: Inside container setup and run vLLM via script
+
+Enter new bash shell in running container, oneliner below enters newest running container:
 ```bash
-git clone https://github.com/tstescoTT/llama-recipes.git
-cd llama-recipes/tools/benchmarks/llm_eval_harness/meta_eval
-python prepare_meta_eval.py --config_path ./eval_config.yaml
-mkdir -p ~/lm-evaluation-harness
-cp -rf work_dir/ ~/lm-evaluation-harness/
+docker exec -it $(docker ps -q | head -n1) bash
 ```
 
-## Step 6: Inside container run LM evals
+Running the `run_evals.sh` script will:
+1. set up lm_eval and evals datasets
+2. pre-capture the tt-metal execution traces so that evals do not trigger 1st run trace capture unexpectedly
+3. run evals via lm_eval as configured
 
-`run_evals.sh` can be run from where lm_eval CLI is available:
 ```bash
-cd ~/lm-evaluation-harness
-export OPENAI_API_KEY=$(python -c 'import os; import json; import jwt; json_payload = json.loads("{\"team_id\": \"tenstorrent\", \"token_id\": \"debug-test\"}"); encoded_jwt = jwt.encode(json_payload, os.environ["JWT_SECRET"], algorithm="HS256"); print(encoded_jwt)')
-run_evals.sh
+cd ~/app/evals
+. run_evals.sh
 ```
-
-For example, running GPQA manually:
-
-The model args (`Meta-Llama-3.1-70B` below) need only correspond to the model defined by running the server, not the actual weights.
-```bash
-lm_eval \
---model local-completions \
---model_args model=meta-llama/Llama-3.1-70B-Instruct,base_url=http://127.0.0.1:7000/v1/completions,num_concurrent=32,max_retries=4,tokenized_requests=False,add_bos_token=True \
---gen_kwargs model=meta-llama/Llama-3.1-70B-Instruct,stop="<|eot_id|>",stream=False \
---tasks meta_ifeval \
---batch_size auto \
---output_path /home/user/cache_root/eval_output \
---include_path ./work_dir \
---seed 42  \
---log_samples
-```
-
-## Notes:
-
-### Chat templating
-
-As mentioned in: https://github.com/meta-llama/llama-recipes/tree/main/tools/benchmarks/llm_eval_harness/meta_eval#run-eval-tasks 
-
-“As for add_bos_token=True, since our prompts in the evals dataset has already included all the special tokens required by instruct model, such as <|start_header_id|>user<|end_header_id|>, we will not use --apply_chat_template argument for instruct models anymore. However, we need to use add_bos_token=True flag to add the BOS_token back during VLLM inference, as the BOS_token is removed by default in this PR.”
-
-Though it is recommended to use the pre-templated prompts following the build instructions for llama-recipes, the chat template can be manually added via the `lm_eval` runtime argument:
-```bash
---apply_chat_template utils/prompt_templates/llama_instruct_example.jinja
-```
-
-llama_instruct_example.jinja: text file jinja template for llama 3.1 instruct:
-```
-{{- bos_token }}
-
-{#- System message #}
-{{- "<|start_header_id|>system<|end_header_id|>\n\n" }}
-{{- "Cutting Knowledge Date: December 2023\n" }}
-{{- "Today Date: " + date_string + "\n\n" }}
-{{- system_message }}
-{{- "<|eot_id|>" }}
-
-{#- Messages #}
-{%- for message in messages %}
-    {%- if message.role in ['user', 'assistant'] %}
-        {{- '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' }}
-    {%- endif %}
-{%- endfor %}
-
-{%- if add_generation_prompt %}
-    {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' }}
-{%- endif %}
-```
-
-The instruct chat template could also be applied on the vLLM server side, but this implementation gives more flexibility to the caller of vLLM.
-

--- a/evals/README.md
+++ b/evals/README.md
@@ -68,5 +68,5 @@ Running the `run_evals.sh` script will:
 
 ```bash
 cd ~/app/evals
-. run_evals.sh
+./run_evals
 ```

--- a/evals/run_evals.sh
+++ b/evals/run_evals.sh
@@ -3,10 +3,38 @@
 #
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
+# set up lm_eval and evals datasets
+cd $HOME
+if python -c "import lm_eval" 2>/dev/null; then
+    echo "lm_eval is installed."
+else
+    echo "Installing lm_eval ..."
+    pip install git+https://github.com/tstescoTT/lm-evaluation-harness.git#egg=lm-eval[ifeval]
+fi
+
+if [ -d "$HOME/llama-recipes" ]; then
+    echo "The directory $HOME/llama-recipes exists."
+else
+    echo "The directory ~/llama-recipes does not exist."
+    git clone https://github.com/tstescoTT/llama-recipes.git $HOME/llama-recipes
+    cd $HOME/llama-recipes/tools/benchmarks/llm_eval_harness/meta_eval
+    python prepare_meta_eval.py --config_path ./eval_config.yaml
+    mkdir -p $HOME/lm-evaluation-harness
+    cp -rf work_dir/ $HOME/lm-evaluation-harness/
+fi
+
+# trace capture so that evals do not trigger 1st run trace capture unexpectedly
+cd $HOME/app
+python utils/capture_traces.py
+
+# run evals
+export OPENAI_API_KEY=$(python -c 'import os; import json; import jwt; json_payload = json.loads("{\"team_id\": \"tenstorrent\", \"token_id\": \"debug-test\"}"); encoded_jwt = jwt.encode(json_payload, os.environ["JWT_SECRET"], algorithm="HS256"); print(encoded_jwt)')
+cd $HOME/lm-evaluation-harness/
+
 # GPQA
 lm_eval \
 --model local-completions \
---model_args model=meta-llama/Llama-3.1-70B-Instruct,base_url=http://127.0.0.1:7000/v1/completions,num_concurrent=1,max_retries=4,tokenized_requests=False,add_bos_token=True \
+--model_args model=meta-llama/Llama-3.1-70B-Instruct,base_url=http://127.0.0.1:7000/v1/completions,num_concurrent=32,max_retries=4,tokenized_requests=False,add_bos_token=True,timeout=None \
 --gen_kwargs model=meta-llama/Llama-3.1-70B-Instruct,stop="<|eot_id|>",stream=False \
 --tasks meta_gpqa \
 --batch_size auto \
@@ -18,7 +46,7 @@ lm_eval \
 # IFEval
 lm_eval \
 --model local-completions \
---model_args model=meta-llama/Llama-3.1-70B-Instruct,base_url=http://127.0.0.1:7000/v1/completions,num_concurrent=32,max_retries=4,tokenized_requests=False,add_bos_token=True \
+--model_args model=meta-llama/Llama-3.1-70B-Instruct,base_url=http://127.0.0.1:7000/v1/completions,num_concurrent=32,max_retries=4,tokenized_requests=False,add_bos_token=True,timeout=None \
 --gen_kwargs model=meta-llama/Llama-3.1-70B-Instruct,stop="<|eot_id|>",stream=False \
 --tasks meta_ifeval \
 --batch_size auto \

--- a/locust/locust_config.conf
+++ b/locust/locust_config.conf
@@ -2,5 +2,5 @@ locustfile = locustfile.py
 headless = true
 host = http://localhost:7000
 users = 32
-spawn-rate = 1
-run-time = 3m
+spawn-rate = 6
+run-time = 10m

--- a/locust/locustfile.py
+++ b/locust/locustfile.py
@@ -18,6 +18,7 @@ DEFAULT_PARAMS = {
     "temperature": 1.0,
     "top_k": 10,
     "top_p": 0.9,
+    "ignore_eos": True,
 }
 
 # Global variable to store data iterator

--- a/tests/test_vllm_seq_lens.py
+++ b/tests/test_vllm_seq_lens.py
@@ -37,11 +37,13 @@ TEST_PARAMS = [
 @pytest.mark.parametrize("param", TEST_PARAMS)
 def test_sequence_length(param: Dict[str, int]):
     # Run the sequence length test
+    default_model = "meta-llama/Llama-3.1-70B-Instruct"
+    model = os.environ.get("HF_MODEL_REPO_ID", default_model)
     results = run_sequence_length_test(
+        model=model,
         combinations=[param],  # Pass as single-item list for compatibility
         save_dir="vllm_test_seq_lens",
         file_prefix="vllm_test_seq_lens",
-        model="meta-llama/Llama-3.1-70B-Instruct",
     )
 
     # Add assertions to verify the results

--- a/utils/README.md
+++ b/utils/README.md
@@ -156,14 +156,14 @@ The client saves responses in JSON format with the following structure:
 
 ```json
 {
-  "response_idx": number,    // Response index in batch
+  "response_idx": number,   // Response index in batch
   "prompt": string,         // Input prompt
   "response": string,       // Generated completion text
   "input_seq_len": number,  // Prompt length in tokens
   "output_seq_len": number, // Completion length in tokens
-  "inter_token_latencies": number[],  // Per-token generation times in seconds
-  "time_per_output_token": number,    // Average seconds per token
-  "ttft": number            // Time to first token in seconds
+  "itl_ms": number[],        // Inter Token Latency (ITL) ms
+  "tpot_ms": number,        // Time Per Output Token (TPOT) average, ms 
+  "ttft_ms": number         // Time To First Token (TTFT) ms
 }
 ```
 

--- a/utils/batch_processor.py
+++ b/utils/batch_processor.py
@@ -24,17 +24,6 @@ logger.setLevel(logging.INFO)
 
 
 class BatchProcessor:
-    """
-    BatchProcessor runs multiple concurrent requests to the backend inference
-    server (vLLM in this case). This adds some functionality for sending requests
-    with a specific max number of requests allowed that is independent with the
-    backend batch_size. Mostly this is for testing continous batching and seq lens,
-    but can be used as an alternative method for benchmarking as in
-    benchmarking/prompt_client_online_benchmark.py measuring TTFT as experienced
-    by users by not exceeding the backend concurrent user capacity and having
-    requests queued on the backend server before processing starts by the model.
-    """
-
     def __init__(self, prompt_client: PromptClient, batch_config: BatchConfig):
         self.prompt_client = prompt_client
         self.batch_config = batch_config
@@ -274,8 +263,8 @@ class BatchProcessor:
     ):
         logger.info(
             f"Processed {response_counter}/{total_prompts} responses. "
-            f"TPOT: {response_data['time_per_output_token']:.4f}, "
-            f"TTFT: {response_data['ttft']:.4f}, "
+            f"TPOT: {response_data['tpot_ms']:.4f}, "
+            f"TTFT: {response_data['ttft_ms']:.4f}, "
             f"input_seq_len: {response_data['input_seq_len']}, "
             f"output_seq_len: {response_data['output_seq_len']}"
         )

--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -158,8 +158,8 @@ class PromptClient:
                     )
                     logger.info(
                         f"tokens generated: {response_data['output_seq_len']}, "
-                        f"TTFT: {response_data['ttft']:.3f}s, "
-                        f"TPOT: {response_data['time_per_output_token']:.3f}s"
+                        f"TTFT: {response_data['ttft_ms']:.3f} ms, "
+                        f"TPOT: {response_data['tpot_ms']:.3f} ms"
                     )
                 except Exception as e:
                     logger.error(f"Error processing prompt: {e}")
@@ -253,11 +253,13 @@ class PromptClient:
             usage_dict = data["usage"]
             first_token_time = req_time
 
-        # Calculate inter-token latencies
+        latency = time.perf_counter() - req_time
+
+        # Calculate inter-token latencies (ms)
         inter_token_latencies = []
         if len(token_timestamps) > 1:
             inter_token_latencies = [
-                token_timestamps[i] - token_timestamps[i - 1]
+                (token_timestamps[i] - token_timestamps[i - 1]) * 1000.0
                 for i in range(1, len(token_timestamps))
             ]
 
@@ -294,7 +296,8 @@ class PromptClient:
             "response": full_text,
             "input_seq_len": prompt_len,
             "output_seq_len": num_completion_tokens,
-            "inter_token_latencies": inter_token_latencies,
-            "time_per_output_token": time_per_output_token,
-            "ttft": ttft,
+            "itl_ms": inter_token_latencies,
+            "tpot_ms": time_per_output_token * 1000.0,
+            "ttft_ms": ttft * 1000.0,
+            "latency": latency,
         }

--- a/utils/prompt_client_cli.py
+++ b/utils/prompt_client_cli.py
@@ -191,8 +191,8 @@ def main():
 
     # Calculate and log summary statistics
     if responses:
-        mean_tpot = np.mean([r["time_per_output_token"] for r in responses])
-        mean_ttft = np.mean([r["ttft"] for r in responses])
+        mean_tpot = np.mean([r["tpot_ms"] for r in responses])
+        mean_ttft = np.mean([r["ttft_ms"] for r in responses])
         logger.info(f"Mean TTFT: {mean_ttft:.4f}")
         logger.info(f"Mean TPOT: {mean_tpot:.4f}")
         mean_tps = 1.0 / max(mean_tpot, 1e-6)

--- a/utils/prompt_configs.py
+++ b/utils/prompt_configs.py
@@ -15,7 +15,7 @@ class PromptConfig:
     distribution: str = "fixed"
     dataset: str = "random"
     tokenizer_model: str = os.environ.get(
-        "VLLM_MODEL", "meta-llama/Llama-3.1-70B-Instruct"
+        "HF_MODEL_REPO_ID", "meta-llama/Llama-3.1-70B-Instruct"
     )
     template: Optional[str] = None
     save_path: Optional[str] = None
@@ -34,7 +34,9 @@ class BatchConfig:
 
 @dataclass
 class EnvironmentConfig:
-    vllm_model: str = os.environ.get("VLLM_MODEL", "meta-llama/Llama-3.1-70B-Instruct")
+    vllm_model: str = os.environ.get(
+        "HF_MODEL_REPO_ID", "meta-llama/Llama-3.1-70B-Instruct"
+    )
     authorization: Optional[str] = os.environ.get("AUTHORIZATION")
     jwt_secret: Optional[str] = os.environ.get("JWT_SECRET")
     deploy_url: str = os.environ.get("DEPLOY_URL", "http://127.0.0.1")

--- a/utils/prompt_generation.py
+++ b/utils/prompt_generation.py
@@ -38,7 +38,12 @@ def load_alpaca_eval_dataset_samples(num_prompts):
 
 
 def tokenize_encode(prompt, tokenizer, max_length, tokenizer_model):
-    if tokenizer_model == "meta-llama/Llama-3.1-70B-Instruct":
+    llama_tokenizer_models = [
+        "meta-llama/Llama-3.1-70B-Instruct",
+        "meta-llama/Llama-3.3-70B-Instruct",
+        "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    ]
+    if tokenizer_model in llama_tokenizer_models:
         return tokenizer.encode(
             prompt, add_special_tokens=False, truncation=True, max_length=max_length
         )
@@ -47,7 +52,12 @@ def tokenize_encode(prompt, tokenizer, max_length, tokenizer_model):
 
 
 def tokenize_decode(encoded_prompt, tokenizer, tokenizer_model):
-    if tokenizer_model == "meta-llama/Llama-3.1-70B-Instruct":
+    llama_tokenizer_models = [
+        "meta-llama/Llama-3.1-70B-Instruct",
+        "meta-llama/Llama-3.3-70B-Instruct",
+        "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    ]
+    if tokenizer_model in llama_tokenizer_models:
         return tokenizer.decode(encoded_prompt)
     else:
         raise ValueError(f"Unsupported tokenizer model: '{tokenizer_model}'.")


### PR DESCRIPTION
# change log

- add benchmark_summary.py to give readable markdown summary stats and store .csv
- update benchmark scripts for stats calculation and context length pairs
- add setup to evals/run_evals.sh
- update documentation for new v0 drop