### PR TITLE
Dev flag in Docker; Split .env into host and container; Auto-patch VLLM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ python_env
 
 # persistent storage volume
 persistent_volume
+model_envs
 
 # Output Files
 *netlist.yaml

--- a/benchmarking/vllm_online_benchmark.py
+++ b/benchmarking/vllm_online_benchmark.py
@@ -126,8 +126,9 @@ def main():
             / f"vllm_online_benchmark_{run_timestamp}_{mesh_device}_isl-{isl}_osl-{osl}_maxcon-{max_concurrent}_n-{num_prompts}.json"
         )
         logger.info(f"\nRunning benchmark {i}/{len(combinations)}")
+        vllm_dir = os.getenv("vllm_dir")
         run_benchmark(
-            benchmark_script="/home/user/vllm/benchmarks/benchmark_serving.py",
+            benchmark_script=f"{vllm_dir}/benchmarks/benchmark_serving.py",
             params=params,
             model=env_config.vllm_model,
             port=env_config.service_port,

--- a/setup.sh
+++ b/setup.sh
@@ -9,18 +9,18 @@ set -euo pipefail  # Exit on error, print commands, unset variables treated as e
 usage() {
     echo "Usage: $0 <model_type>"
     echo "Available model types:"
-    echo "  llama-3.3-70b-instruct"
-    echo "  llama-3.2-11b-vision-instruct"
-    echo "  llama-3.2-3b-instruct"
-    echo "  llama-3.2-1b-instruct"
-    echo "  llama-3.1-70b-instruct"
-    echo "  llama-3.1-70b"
-    echo "  llama-3.1-8b-instruct"
-    echo "  llama-3.1-8b"
-    echo "  llama-3-70b-instruct"
-    echo "  llama-3-70b"
-    echo "  llama-3-8b-instruct"
-    echo "  llama-3-8b"
+    echo "  Llama-3.3-70B-Instruct"
+    echo "  Llama-3.2-11B-Vision-Instruct"
+    echo "  Llama-3.2-3B-Instruct"
+    echo "  Llama-3.2-1B-Instruct"
+    echo "  Llama-3.1-70B-Instruct"
+    echo "  Llama-3.1-70B"
+    echo "  Llama-3.1-8B-Instruct"
+    echo "  Llama-3.1-8B"
+    echo "  Llama-3-70B-Instruct"
+    echo "  Llama-3-70B"
+    echo "  Llama-3-8B-Instruct"
+    echo "  Llama-3-8B"
     echo
     exit 1
 }
@@ -111,84 +111,84 @@ setup_model_environment() {
     # Set environment variables based on the model selection
     # note: MODEL_NAME is the directory name for the model weights
     case "$1" in
-        "llama-3.3-70b-instruct")
+        "Llama-3.3-70B-Instruct")
         MODEL_NAME="Llama-3.3-70B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.3-70B-Instruct"
         META_MODEL_NAME=""
         META_DIR_FILTER=""
         REPACKED=1
         ;;
-        "llama-3.2-11b-vision-instruct")
+        "Llama-3.2-11B-Vision-Instruct")
         MODEL_NAME="Llama-3.2-11B-Vision-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.2-11B-Vision-Instruct"
         META_MODEL_NAME=""
         META_DIR_FILTER=""
         REPACKED=0
         ;;
-        "llama-3.2-3b-instruct")
+        "Llama-3.2-3B-Instruct")
         MODEL_NAME="Llama-3.2-3B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.2-3B-Instruct"
         META_MODEL_NAME=""
         META_DIR_FILTER=""
         REPACKED=0
         ;;
-        "llama-3.2-1b-instruct")
+        "Llama-3.2-1B-Instruct")
         MODEL_NAME="Llama-3.2-1B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.2-1B-Instruct"
         META_MODEL_NAME=""
         META_DIR_FILTER=""
         REPACKED=0
         ;;
-        "llama-3.1-70b-instruct")
+        "Llama-3.1-70B-Instruct")
         MODEL_NAME="Llama-3.1-70B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.1-70B-Instruct"
         META_MODEL_NAME="Meta-Llama-3.1-70B-Instruct"
         META_DIR_FILTER="llama3_1"
         REPACKED=1
         ;;
-        "llama-3.1-70b")
+        "Llama-3.1-70B")
         MODEL_NAME="Llama-3.1-70B"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.1-70B"
         META_MODEL_NAME="Meta-Llama-3.1-70B"
         META_DIR_FILTER="llama3_1"
         REPACKED=1
         ;;
-        "llama-3.1-8b-instruct")
+        "Llama-3.1-8B-Instruct")
         MODEL_NAME="Llama-3.1-8B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.1-8B-Instruct"
         META_MODEL_NAME="Meta-Llama-3.1-8B-Instruct"
         META_DIR_FILTER="llama3_1"
         REPACKED=0
         ;;
-        "llama-3.1-8b")
+        "Llama-3.1-8B")
         MODEL_NAME="Llama-3.1-8B"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.1-8B"
         META_MODEL_NAME="Meta-Llama-3.1-8B"
         META_DIR_FILTER="llama3_1"
         REPACKED=0
         ;;
-        "llama-3-70b-instruct")
+        "Llama-3-70B-Instruct")
         MODEL_NAME="Llama-3-70B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3-70B-Instruct"
         META_MODEL_NAME="Meta-Llama-3-70B-Instruct"
         META_DIR_FILTER="llama3"
         REPACKED=1
         ;;
-        "llama-3-70b")
+        "Llama-3-70B")
         MODEL_NAME="Llama-3-70B"
         HF_MODEL_REPO_ID="meta-llama/Llama-3-70B"
         META_MODEL_NAME="Meta-Llama-3-70B"
         META_DIR_FILTER="llama3"
         REPACKED=1
         ;;
-        "llama-3-8b-instruct")
+        "Llama-3-8B-Instruct")
         MODEL_NAME="Llama-3-8B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3-8B-Instruct"
         META_MODEL_NAME="Meta-Llama-3-8B-Instruct"
         META_DIR_FILTER="llama3"
         REPACKED=0
         ;;
-        "llama-3-8b")
+        "Llama-3-8B")
         MODEL_NAME="Llama-3-8B"
         HF_MODEL_REPO_ID="meta-llama/Llama-3-8B"
         META_MODEL_NAME="Meta-Llama-3-8B"

--- a/setup.sh
+++ b/setup.sh
@@ -25,6 +25,20 @@ usage() {
     exit 1
 }
 
+# Check for sudo privileges
+check_sudo() {
+    if sudo -n true 2>/dev/null; then
+        echo "✅ Sudo privileges are available."
+    else
+        echo "🔒 Sudo privileges are required. Please enter your password."
+        sudo -v
+        if [ $? -ne 0 ]; then
+            echo "⛔ Sudo privileges are required to run this script. Exiting."
+            exit 1
+        fi
+    fi
+}
+
 # globals
 readonly REPO_ROOT=$(dirname "$(realpath "$0")")
 
@@ -570,6 +584,9 @@ fi
 if [ $# -lt 1 ]; then
     usage
 fi
+
+# Check sudo privileges at the beginning of the script
+check_sudo
 
 # Set up environment variables for the chosen model
 MODEL_TYPE=$1

--- a/setup.sh
+++ b/setup.sh
@@ -25,20 +25,6 @@ usage() {
     exit 1
 }
 
-# Check for sudo privileges
-check_sudo() {
-    if sudo -n true 2>/dev/null; then
-        echo "✅ Sudo privileges are available."
-    else
-        echo "🔒 Sudo privileges are required. Please enter your password."
-        sudo -v
-        if [ $? -ne 0 ]; then
-            echo "⛔ Sudo privileges are required to run this script. Exiting."
-            exit 1
-        fi
-    fi
-}
-
 # globals
 readonly REPO_ROOT=$(dirname "$(realpath "$0")")
 
@@ -611,9 +597,6 @@ fi
 if [ $# -lt 1 ]; then
     usage
 fi
-
-# Check sudo privileges at the beginning of the script
-check_sudo
 
 # Set up environment variables for the chosen model
 MODEL_TYPE=$1

--- a/tests/mock.vllm.openai.api.dockerfile
+++ b/tests/mock.vllm.openai.api.dockerfile
@@ -34,6 +34,10 @@ ENV PYTHONPATH=${TT_METAL_HOME}
 ENV PYTHON_ENV_DIR=${TT_METAL_HOME}/python_env
 ENV LD_LIBRARY_PATH=${TT_METAL_HOME}/build/lib
 
+# set up keyring for apt-get
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+    && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+
 # extra system deps
 RUN apt-get update && apt-get install -y \
     libsndfile1 \

--- a/tests/mock.vllm.openai.api.dockerfile
+++ b/tests/mock.vllm.openai.api.dockerfile
@@ -34,10 +34,6 @@ ENV PYTHONPATH=${TT_METAL_HOME}
 ENV PYTHON_ENV_DIR=${TT_METAL_HOME}/python_env
 ENV LD_LIBRARY_PATH=${TT_METAL_HOME}/build/lib
 
-# set up keyring for apt-get
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
-    && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-
 # extra system deps
 RUN apt-get update && apt-get install -y \
     libsndfile1 \
@@ -71,7 +67,7 @@ RUN useradd -u 1000 -s /bin/bash -d ${HOME_DIR} user \
     && mkdir -p ${HOME_DIR} \
     && chown -R user:user ${HOME_DIR} \
     && chown -R user:user ${TT_METAL_HOME}
-  
+
 USER user
 
 # tt-metal python env default

--- a/vllm-tt-metal-llama3/README.md
+++ b/vllm-tt-metal-llama3/README.md
@@ -32,7 +32,7 @@ docker run \
   --cap-add ALL \
   --device /dev/tenstorrent:/dev/tenstorrent \
   --volume /dev/hugepages-1G:/dev/hugepages-1G:rw \
-  --volume ${MODEL_VOLUME?ERROR env var MODEL_VOLUME must be set}:/home/user/cache_root:rw \
+  --volume ${MODEL_VOLUME?ERROR env var MODEL_VOLUME must be set}:/home/container_app_user/cache_root:rw \
   --shm-size 32G \
   --publish 7000:7000 \
   ghcr.io/tenstorrent/tt-inference-server/tt-metal-llama3-70b-src-base-vllm:v0.0.1-tt-metal-v0.54.0-rc2-953161188c50 

--- a/vllm-tt-metal-llama3/docs/development.md
+++ b/vllm-tt-metal-llama3/docs/development.md
@@ -66,15 +66,15 @@ docker run \
   --cap-add ALL \
   --device /dev/tenstorrent:/dev/tenstorrent \
   --volume /dev/hugepages-1G:/dev/hugepages-1G:rw \
-  --volume ${MODEL_VOLUME?ERROR env var MODEL_VOLUME must be set}:/home/user/cache_root:rw \
+  --volume ${MODEL_VOLUME?ERROR env var MODEL_VOLUME must be set}:/home/container_app_user/cache_root:rw \
   --shm-size 32G \
   ghcr.io/tenstorrent/tt-inference-server/tt-metal-llama3-70b-src-base-vllm:v0.0.1-tt-metal-${TT_METAL_COMMIT_DOCKER_TAG}-${TT_VLLM_COMMIT_DOCKER_TAG} bash
 ```
 
 additionally for development you can mount the volumes:
 ```bash
-  --volume $PWD/../vllm:/home/user/vllm \
-  --volume $PWD/../lm-evaluation-harness:/home/user/lm-evaluation-harness \
+  --volume $PWD/../vllm:/home/container_app_user/vllm \
+  --volume $PWD/../lm-evaluation-harness:/home/container_app_user/lm-evaluation-harness \
 ```
 
 ## Step 3: Inside container setup and run vLLM
@@ -93,7 +93,7 @@ Already built into Docker image, continue to run vLLM.
 
 ```bash
 # option 2: install from github
-cd /home/user/vllm
+cd /home/container_app_user/vllm
 git fetch
 git checkout <branch>
 git pull
@@ -104,7 +104,7 @@ echo "done vllm install."
 
 ```bash
 # option 3: install edittable (for development) - mount from outside container
-cd /home/user/vllm
+cd /home/container_app_user/vllm
 pip install -e .
 echo "done vllm install."
 ```
@@ -113,7 +113,7 @@ echo "done vllm install."
 
 ```bash
 # run vllm serving
-cd /home/user/vllm
+cd /home/container_app_user/vllm
 python examples/server_example_tt.py
 ```
 

--- a/vllm-tt-metal-llama3/vllm.llama3.src.dev.Dockerfile
+++ b/vllm-tt-metal-llama3/vllm.llama3.src.dev.Dockerfile
@@ -131,6 +131,10 @@ COPY --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} "locust" "${APP
 RUN /bin/bash -c "source ${PYTHON_ENV_DIR}/bin/activate \
 && pip install --default-timeout=240 --no-cache-dir -r requirements.txt"
 
+# apply patch to remove best-of argument from vllm
+WORKDIR ${vllm_dir}
+RUN git apply ${APP_DIR}/benchmarking/benchmark_serving.patch
+
 WORKDIR "${APP_DIR}/src"
 
 # Switch back to root for entrypoint


### PR DESCRIPTION
- Align casing in model names with tt-metal expectations
- Provide weights from a local folder
- Workaround non-working apt-get keyring
- Development flag in docker to allow sudo and debug symbols
- Patch VLLM for best-of arg while building docker
- Separate host and container .env files