### PR TITLE
Release Candidate v0.0.1

### DIFF
--- a/benchmarking/benchmark_summary.py
+++ b/benchmarking/benchmark_summary.py
@@ -45,13 +45,14 @@ def parse_args():
 
 def extract_params_from_filename(filename: str) -> Dict[str, Any]:
     pattern = r"""
-        benchmark_
+        .*?benchmark_                                       # Any prefix before benchmark_
         (?P<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})  # Timestamp
         (_(?P<mesh_device>N150|N300|T3K_LINE|T3K_RING|TG))? # MESH_DEVICE
         _isl-(?P<isl>\d+)                                   # Input sequence length
         _osl-(?P<osl>\d+)                                   # Output sequence length
-        _bsz-(?P<bsz>\d+)                                   # Batch size
-        _n-(?P<n>\d+)                                       # Number of requests
+        _maxcon-(?P<maxcon>\d+)                            # Max concurrency
+        _n-(?P<n>\d+)                                      # Number of requests
+        \.json$
     """
     match = re.search(pattern, filename, re.VERBOSE)
     if not match:
@@ -67,7 +68,7 @@ def extract_params_from_filename(filename: str) -> Dict[str, Any]:
         "mesh_device": match.group("mesh_device"),
         "input_sequence_length": int(match.group("isl")),
         "output_sequence_length": int(match.group("osl")),
-        "batch_size": int(match.group("bsz")),
+        "batch_size": int(match.group("maxcon")),
         "num_requests": int(match.group("n")),
     }
 

--- a/benchmarking/prompt_client_online_benchmark.py
+++ b/benchmarking/prompt_client_online_benchmark.py
@@ -102,8 +102,15 @@ def run_sequence_length_test(
         tokenizer = AutoTokenizer.from_pretrained(model)
 
         # pre-capture traces so benchmark does not include 1st run trace capture time
-        # TODO: add support for image input to capture_traces
-        prompt_client.capture_traces(context_lens=[(input_len, output_len)])
+        image_resolutions = []
+        if images:
+            image_resolutions = [
+                (prompt_config.image_width, prompt_config.image_height)
+            ]
+
+        prompt_client.capture_traces(
+            context_lens=[(input_len, output_len)], image_resolutions=image_resolutions
+        )
         # Process batches
         try:
             responses = batch_processor.process_batch(

--- a/benchmarking/vllm_online_benchmark.py
+++ b/benchmarking/vllm_online_benchmark.py
@@ -126,9 +126,10 @@ def main():
             / f"vllm_online_benchmark_{run_timestamp}_{mesh_device}_isl-{isl}_osl-{osl}_maxcon-{max_concurrent}_n-{num_prompts}.json"
         )
         logger.info(f"\nRunning benchmark {i}/{len(combinations)}")
-        user_home = os.environ.get("HOME")
+        vllm_dir = os.environ.get("vllm_dir")
+        assert vllm_dir is not None, "vllm_dir must be set."
         run_benchmark(
-            benchmark_script=f"{user_home}/vllm/benchmarks/benchmark_serving.py",
+            benchmark_script=f"{vllm_dir}/benchmarks/benchmark_serving.py",
             params=params,
             model=env_config.vllm_model,
             port=env_config.service_port,

--- a/benchmarking/vllm_online_benchmark.py
+++ b/benchmarking/vllm_online_benchmark.py
@@ -126,8 +126,9 @@ def main():
             / f"vllm_online_benchmark_{run_timestamp}_{mesh_device}_isl-{isl}_osl-{osl}_maxcon-{max_concurrent}_n-{num_prompts}.json"
         )
         logger.info(f"\nRunning benchmark {i}/{len(combinations)}")
+        user_home = os.environ.get("HOME")
         run_benchmark(
-            benchmark_script="/home/user/vllm/benchmarks/benchmark_serving.py",
+            benchmark_script=f"{user_home}/vllm/benchmarks/benchmark_serving.py",
             params=params,
             model=env_config.vllm_model,
             port=env_config.service_port,

--- a/evals/README.md
+++ b/evals/README.md
@@ -13,24 +13,9 @@ For instructions on building the Docker image see: [vllm-tt-metal-llama3/docs/de
 
 ## Step 2: Run Docker container for LM evals development
 
+Follow run guide: [vllm-tt-metal-llama3/README.md](../vllm-tt-metal-llama3/README.md)
+
 note: this requires running `setup.sh` to set up the weights for a particular model, in this example `llama-3.1-70b-instruct`.
-
-```bash
-cd tt-inference-server
-export MODEL_VOLUME=$PWD/persistent_volume/volume_id_tt-metal-llama-3.1-70b-instructv0.0.1/
-docker run \
-  --rm \
-  -it \
-  --env-file persistent_volume/model_envs/llama-3.1-70b-instruct.env \
-  --cap-add ALL \
-  --device /dev/tenstorrent:/dev/tenstorrent \
-  --volume /dev/hugepages-1G:/dev/hugepages-1G:rw \
-  --volume ${MODEL_VOLUME?ERROR env var MODEL_VOLUME must be set}:/home/user/cache_root:rw \
-  --shm-size 32G \
-  ghcr.io/tenstorrent/tt-inference-server/tt-metal-llama3-70b-src-base-vllm:${IMAGE_VERSION}-tt-metal-${TT_METAL_COMMIT_DOCKER_TAG}-${TT_VLLM_COMMIT_DOCKER_TAG}
-```
-
-The default Docker image command will start the vLLM server. 
 
 ## Step 3: Inside container set up llama-recipes LM evalulation harness templates
 
@@ -44,7 +29,7 @@ To access Meta Llama 3.1 evals, you must:
 #### Hugging Face authentication - option 1: HF_TOKEN (if not already passed into Docker container)
 ```bash
 # set up HF Token if not already set up in .env, needed for datasets
-echo "HF_TOKEN=hf_<your_token>" >> vllm-tt-metal-llama3/.env
+echo "HF_TOKEN=hf_<your_token>"
 ```
 
 #### Hugging Face authentication - option 2: huggingface_hub login

--- a/evals/run_evals.sh
+++ b/evals/run_evals.sh
@@ -45,7 +45,7 @@ lm_eval \
 --gen_kwargs model=${HF_MODEL_REPO_ID},stop="<|eot_id|>",stream=False \
 --tasks meta_gpqa \
 --batch_size auto \
---output_path /home/user/cache_root/eval_output \
+--output_path /home/container_app_user/cache_root/eval_output \
 --include_path ./work_dir \
 --seed 42  \
 --log_samples
@@ -57,7 +57,7 @@ lm_eval \
 --gen_kwargs model=${HF_MODEL_REPO_ID},stop="<|eot_id|>",stream=False \
 --tasks meta_ifeval \
 --batch_size auto \
---output_path /home/user/cache_root/eval_output \
+--output_path /home/container_app_user/cache_root/eval_output \
 --include_path ./work_dir \
 --seed 42  \
 --log_samples

--- a/evals/run_evals.sh
+++ b/evals/run_evals.sh
@@ -45,7 +45,7 @@ lm_eval \
 --gen_kwargs model=${HF_MODEL_REPO_ID},stop="<|eot_id|>",stream=False \
 --tasks meta_gpqa \
 --batch_size auto \
---output_path /home/container_app_user/cache_root/eval_output \
+--output_path ${CACHE_ROOT}/eval_output \
 --include_path ./work_dir \
 --seed 42  \
 --log_samples
@@ -57,7 +57,7 @@ lm_eval \
 --gen_kwargs model=${HF_MODEL_REPO_ID},stop="<|eot_id|>",stream=False \
 --tasks meta_ifeval \
 --batch_size auto \
---output_path /home/container_app_user/cache_root/eval_output \
+--output_path ${CACHE_ROOT}/eval_output \
 --include_path ./work_dir \
 --seed 42  \
 --log_samples

--- a/evals/run_evals_vision.sh
+++ b/evals/run_evals_vision.sh
@@ -35,7 +35,7 @@ lm_eval \
 --gen_kwargs model=${HF_MODEL_REPO_ID},stop="<|eot_id|>",stream=False \
 --tasks mmmu_val \
 --batch_size auto \
---output_path /home/user/cache_root/eval_output \
+--output_path /home/container_app_user/cache_root/eval_output \
 --seed 42  \
 --log_samples
 

--- a/setup.sh
+++ b/setup.sh
@@ -9,18 +9,19 @@ set -euo pipefail  # Exit on error, print commands, unset variables treated as e
 usage() {
     echo "Usage: $0 <model_type>"
     echo "Available model types:"
-    echo "  llama-3.3-70b-instruct"
-    echo "  llama-3.2-11b-vision-instruct"
-    echo "  llama-3.2-3b-instruct"
-    echo "  llama-3.2-1b-instruct"
-    echo "  llama-3.1-70b-instruct"
-    echo "  llama-3.1-70b"
-    echo "  llama-3.1-8b-instruct"
-    echo "  llama-3.1-8b"
-    echo "  llama-3-70b-instruct"
-    echo "  llama-3-70b"
-    echo "  llama-3-8b-instruct"
-    echo "  llama-3-8b"
+    echo "  DeepSeek-R1-Distill-Llama-70B"
+    echo "  Llama-3.3-70B-Instruct"
+    echo "  Llama-3.2-11B-Vision-Instruct"
+    echo "  Llama-3.2-3B-Instruct"
+    echo "  Llama-3.2-1B-Instruct"
+    echo "  Llama-3.1-70B-Instruct"
+    echo "  Llama-3.1-70B"
+    echo "  Llama-3.1-8B-Instruct"
+    echo "  Llama-3.1-8B"
+    echo "  Llama-3-70B-Instruct"
+    echo "  Llama-3-70B"
+    echo "  Llama-3-8B-Instruct"
+    echo "  Llama-3-8B"
     echo
     exit 1
 }
@@ -74,6 +75,7 @@ get_hf_env_vars() {
         echo "HF_TOKEN environment variable is not set. Please set it before running the script."
         read -r -s -p "Enter your HF_TOKEN: " input_hf_token
         echo
+        echo "entered HF_TOKEN contains: ${#input_hf_token} characters, expected 37."
         if [ -z "${input_hf_token:-}" ]; then
             echo "⛔ HF_TOKEN cannot be empty. Please try again."
             exit 1
@@ -111,84 +113,104 @@ setup_model_environment() {
     # Set environment variables based on the model selection
     # note: MODEL_NAME is the directory name for the model weights
     case "$1" in
-        "llama-3.3-70b-instruct")
+        "DeepSeek-R1-Distill-Llama-70B")
+        IMPL_ID="tt-metal"
+        MODEL_NAME="DeepSeek-R1-Distill-Llama-70B"
+        HF_MODEL_REPO_ID="deepseek-ai/DeepSeek-R1-Distill-Llama-70B"
+        META_MODEL_NAME=""
+        META_DIR_FILTER=""
+        REPACKED=1
+        ;;
+        "Llama-3.3-70B-Instruct")
+        IMPL_ID="tt-metal"
         MODEL_NAME="Llama-3.3-70B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.3-70B-Instruct"
         META_MODEL_NAME=""
         META_DIR_FILTER=""
         REPACKED=1
         ;;
-        "llama-3.2-11b-vision-instruct")
+        "Llama-3.2-11B-Vision-Instruct")
+        IMPL_ID="tt-metal"
         MODEL_NAME="Llama-3.2-11B-Vision-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.2-11B-Vision-Instruct"
         META_MODEL_NAME=""
         META_DIR_FILTER=""
         REPACKED=0
         ;;
-        "llama-3.2-3b-instruct")
+        "Llama-3.2-3B-Instruct")
+        IMPL_ID="tt-metal"
         MODEL_NAME="Llama-3.2-3B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.2-3B-Instruct"
         META_MODEL_NAME=""
         META_DIR_FILTER=""
         REPACKED=0
         ;;
-        "llama-3.2-1b-instruct")
+        "Llama-3.2-1B-Instruct")
+        IMPL_ID="tt-metal"
         MODEL_NAME="Llama-3.2-1B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.2-1B-Instruct"
         META_MODEL_NAME=""
         META_DIR_FILTER=""
         REPACKED=0
         ;;
-        "llama-3.1-70b-instruct")
+        "Llama-3.1-70B-Instruct")
+        IMPL_ID="tt-metal"
         MODEL_NAME="Llama-3.1-70B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.1-70B-Instruct"
         META_MODEL_NAME="Meta-Llama-3.1-70B-Instruct"
         META_DIR_FILTER="llama3_1"
         REPACKED=1
         ;;
-        "llama-3.1-70b")
+        "Llama-3.1-70B")
+        IMPL_ID="tt-metal"
         MODEL_NAME="Llama-3.1-70B"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.1-70B"
         META_MODEL_NAME="Meta-Llama-3.1-70B"
         META_DIR_FILTER="llama3_1"
         REPACKED=1
         ;;
-        "llama-3.1-8b-instruct")
+        "Llama-3.1-8B-Instruct")
+        IMPL_ID="tt-metal"
         MODEL_NAME="Llama-3.1-8B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.1-8B-Instruct"
         META_MODEL_NAME="Meta-Llama-3.1-8B-Instruct"
         META_DIR_FILTER="llama3_1"
         REPACKED=0
         ;;
-        "llama-3.1-8b")
+        "Llama-3.1-8B")
+        IMPL_ID="tt-metal"
         MODEL_NAME="Llama-3.1-8B"
         HF_MODEL_REPO_ID="meta-llama/Llama-3.1-8B"
         META_MODEL_NAME="Meta-Llama-3.1-8B"
         META_DIR_FILTER="llama3_1"
         REPACKED=0
         ;;
-        "llama-3-70b-instruct")
+        "Llama-3-70B-Instruct")
+        IMPL_ID="tt-metal"
         MODEL_NAME="Llama-3-70B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3-70B-Instruct"
         META_MODEL_NAME="Meta-Llama-3-70B-Instruct"
         META_DIR_FILTER="llama3"
         REPACKED=1
         ;;
-        "llama-3-70b")
+        "Llama-3-70B")
+        IMPL_ID="tt-metal"
         MODEL_NAME="Llama-3-70B"
         HF_MODEL_REPO_ID="meta-llama/Llama-3-70B"
         META_MODEL_NAME="Meta-Llama-3-70B"
         META_DIR_FILTER="llama3"
         REPACKED=1
         ;;
-        "llama-3-8b-instruct")
+        "Llama-3-8B-Instruct")
+        IMPL_ID="tt-metal"
         MODEL_NAME="Llama-3-8B-Instruct"
         HF_MODEL_REPO_ID="meta-llama/Llama-3-8B-Instruct"
         META_MODEL_NAME="Meta-Llama-3-8B-Instruct"
         META_DIR_FILTER="llama3"
         REPACKED=0
         ;;
-        "llama-3-8b")
+        "Llama-3-8B")
+        IMPL_ID="tt-metal"
         MODEL_NAME="Llama-3-8B"
         HF_MODEL_REPO_ID="meta-llama/Llama-3-8B"
         META_MODEL_NAME="Meta-Llama-3-8B"
@@ -201,23 +223,9 @@ setup_model_environment() {
         exit 1
         ;;
     esac
-    # Initialize OVERWRITE_ENV
-    OVERWRITE_ENV=false
 
     # Set default values for environment variables
     DEFAULT_PERSISTENT_VOLUME_ROOT=${REPO_ROOT}/persistent_volume
-    MODEL_ENV_DIR="${DEFAULT_PERSISTENT_VOLUME_ROOT}/model_envs"
-    
-    mkdir -p ${MODEL_ENV_DIR}
-    ENV_FILE="${MODEL_ENV_DIR}/${MODEL_NAME}.env"
-    export ENV_FILE
-    check_and_prompt_env_file
-
-
-    if [ "$OVERWRITE_ENV" = false ]; then
-        echo "✅ using existing .env file: ${ENV_FILE}."
-        return 0
-    fi
     # Safely handle potentially unset environment variables using default values
     PERSISTENT_VOLUME_ROOT=${PERSISTENT_VOLUME_ROOT:-$DEFAULT_PERSISTENT_VOLUME_ROOT}
     # Prompt user for PERSISTENT_VOLUME_ROOT if not already set or use default
@@ -225,8 +233,22 @@ setup_model_environment() {
     PERSISTENT_VOLUME_ROOT=${INPUT_PERSISTENT_VOLUME_ROOT:-$PERSISTENT_VOLUME_ROOT}
     echo # move to a new line after input   
     # Set environment variables with defaults if not already set
-    PERSISTENT_VOLUME=${PERSISTENT_VOLUME_ROOT}/volume_id_tt-metal-${MODEL_NAME}v0.0.1
-    
+    MODEL_VERSION="0.0.1"
+    MODEL_ID="id_${IMPL_ID}-${MODEL_NAME}-v${MODEL_VERSION}"
+    PERSISTENT_VOLUME="${PERSISTENT_VOLUME_ROOT}/volume_${MODEL_ID}"
+
+    # Initialize OVERWRITE_ENV
+    OVERWRITE_ENV=false
+    MODEL_ENV_DIR="${PERSISTENT_VOLUME_ROOT}/model_envs"
+    mkdir -p ${MODEL_ENV_DIR}
+    ENV_FILE="${MODEL_ENV_DIR}/${MODEL_NAME}.env"
+    export ENV_FILE
+    check_and_prompt_env_file
+
+    if [ "$OVERWRITE_ENV" = false ]; then
+        echo "✅ using existing .env file: ${ENV_FILE}."
+        return 0
+    fi
 
     read -p "Use 🤗 Hugging Face authorization token for downloading models? Alternative is direct authorization from Meta. (y/n) [default: y]: " input_use_hf_token
     choice_use_hf_token=${input_use_hf_token:-"y"}
@@ -283,15 +305,15 @@ setup_model_environment() {
     cat > ${ENV_FILE} <<EOF
 # Environment variables for the model setup
 USE_HF_DOWNLOAD=$choice_use_hf_token
-MODEL_NAME=$MODEL_NAME
-META_MODEL_NAME=$META_MODEL_NAME
 HF_MODEL_REPO_ID=$HF_MODEL_REPO_ID
+MODEL_NAME=$MODEL_NAME
+MODEL_VERSION=${MODEL_VERSION}
+IMPL_ID=${IMPL_ID}
+MODEL_ID=${MODEL_ID}
+META_MODEL_NAME=$META_MODEL_NAME
 REPACKED=${REPACKED}
 REPACKED_STR=${REPACKED_STR}
 # model runtime variables
-LLAMA_VERSION=llama3
-TT_METAL_ASYNC_DEVICE_QUEUE=1
-WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
 SERVICE_PORT=7000
 # host paths
 HOST_HF_HOME=${HF_HOME:-""}
@@ -467,16 +489,16 @@ setup_weights_huggingface() {
         mv "${WEIGHTS_DIR}/consolidated.pth" "${WEIGHTS_DIR}/consolidated.00.pth"  
     fi
 
-    # Step 6: Process and copy weights
+    # Step 6: Cleanup HF setup venv
+    deactivate
+    rm -rf ${VENV_NAME}
+    
+    # Step 7: Process and copy weights
     if [ "${REPACKED}" -eq 1 ]; then
         REPACKED_WEIGHTS_DIR="${PERSISTENT_VOLUME}/model_weights/${REPACKED_STR}${MODEL_NAME}"
         mkdir -p "${REPACKED_WEIGHTS_DIR}"
         repack_weights "${WEIGHTS_DIR}" "${REPACKED_WEIGHTS_DIR}"
     fi
-
-    # Step 7: Cleanup
-    deactivate
-    rm -rf ${VENV_NAME}
 
     echo "using weights directory: ${PERSISTENT_VOLUME}/model_weights/${REPACKED_STR}${MODEL_NAME}"
     echo "✅ setup_weights_huggingface completed!"

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,7 +18,7 @@ export VLLM_COMMIT_SHA=<vllm-commit>
 Add a volume mounting the `test` directory in the container before running with the following in the docker run command:
 
 ```bash
---volume $PWD/tests:/home/user/tests
+--volume $PWD/tests:/home/container_app_user/tests
 ```
 
 ## 3. Run The Mock Model
@@ -26,7 +26,7 @@ Add a volume mounting the `test` directory in the container before running with 
 Once in the docker container, run the mock script with:
 
 ```bash
-WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python /home/user/tests/mock_vllm_offline_inference_tt.py
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python /home/container_app_user/tests/mock_vllm_offline_inference_tt.py
 ```
 
 # Build mock model container

--- a/tests/benchmark_vllm_offline_inference.py
+++ b/tests/benchmark_vllm_offline_inference.py
@@ -30,7 +30,7 @@ def parse_args():
     parser.add_argument(
         "--prompts_json",
         type=str,
-        default="/home/user/vllm/tt_metal/prompts.json",
+        default="/home/container_app_user/vllm/tt_metal/prompts.json",
         help="Path to JSON file containing prompts",
     )
     parser.add_argument(

--- a/tests/mock.vllm.openai.api.dockerfile
+++ b/tests/mock.vllm.openai.api.dockerfile
@@ -62,8 +62,11 @@ RUN git clone --depth 1 https://github.com/tenstorrent-metal/tt-metal.git ${TT_M
     && bash ./create_venv.sh
 
 # user setup
-ARG HOME_DIR=/home/user
-RUN useradd -u 1000 -s /bin/bash -d ${HOME_DIR} user \
+# CONTAINER_APP_UID is a random ID, change this and rebuild if it collides with host
+ENV CONTAINER_APP_UID=15863
+ENV CONTAINER_APP_USERNAME=container_app_user
+ARG HOME_DIR=/home/${CONTAINER_APP_USERNAME}
+RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_USERNAME} \
     && mkdir -p ${HOME_DIR} \
     && chown -R user:user ${HOME_DIR} \
     && chown -R user:user ${TT_METAL_HOME}
@@ -108,9 +111,9 @@ CMD ["/bin/bash", "-c", "source ${PYTHON_ENV_DIR}/bin/activate && python mock_vl
 
 # Default environment variables for the Llama-3.1-70b-instruct inference server
 # Note: LLAMA3_CKPT_DIR and similar variables get set by mock_vllm_api_server.py
-ENV CACHE_ROOT=/home/user/cache_root
-ENV HF_HOME=/home/user/cache_root/huggingface
+ENV CACHE_ROOT=/home/container_app_user/cache_root
+ENV HF_HOME=/home/container_app_user/cache_root/huggingface
 ENV MODEL_WEIGHTS_ID=id_repacked-Llama-3.1-70B-Instruct
-ENV MODEL_WEIGHTS_PATH=/home/user/cache_root/model_weights/repacked-Llama-3.1-70B-Instruct
+ENV MODEL_WEIGHTS_PATH=/home/container_app_user/cache_root/model_weights/repacked-Llama-3.1-70B-Instruct
 ENV LLAMA_VERSION=llama3
 ENV SERVICE_PORT=7000

--- a/tests/mock_vllm_offline_inference_tt.py
+++ b/tests/mock_vllm_offline_inference_tt.py
@@ -214,7 +214,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--prompts_json",
         type=str,
-        default="/home/user/vllm/tt_metal/prompts.json",
+        default="/home/container_app_user/vllm/tt_metal/prompts.json",
         help="Path to JSON file containing prompts",
     )
     parser.add_argument(

--- a/utils/capture_traces.py
+++ b/utils/capture_traces.py
@@ -2,6 +2,7 @@
 #
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
+import argparse
 import logging
 
 from utils.prompt_configs import EnvironmentConfig
@@ -14,11 +15,38 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def capture_input_sizes():
+def add_cli_args(parser):
+    parser.add_argument(
+        "--include_images",
+        action="store_true",
+        help="Include randomly generated images with prompts",
+    )
+    parser.add_argument(
+        "--image_width",
+        type=int,
+        default=256,
+        help="Width of generated images",
+    )
+    parser.add_argument(
+        "--image_height",
+        type=int,
+        default=256,
+        help="Height of generated images",
+    )
+    return parser
+
+
+def capture_input_sizes(arg):
     env_config = EnvironmentConfig()
     prompt_client = PromptClient(env_config)
-    prompt_client.capture_traces()
+    image_resolutions = []
+    if args.include_images:
+        image_resolutions = [(args.image_width, args.image_height)]
+    prompt_client.capture_traces(image_resolutions=image_resolutions)
 
 
 if __name__ == "__main__":
-    capture_input_sizes()
+    parser = argparse.ArgumentParser()
+    parser = add_cli_args(parser)
+    args = parser.parse_args()
+    capture_input_sizes(args)

--- a/utils/prompt_client_cli.py
+++ b/utils/prompt_client_cli.py
@@ -214,8 +214,14 @@ def main():
 
     if not args.skip_trace_precapture:
         # pre-capture traces to not include 1st run trace capture time
+        image_resolutions = []
+        if images:
+            image_resolutions = [
+                (prompt_config.image_width, prompt_config.image_height)
+            ]
         prompt_client.capture_traces(
-            context_lens=[(args.input_seq_len, args.output_seq_len)]
+            context_lens=[(args.input_seq_len, args.output_seq_len)],
+            image_resolutions=image_resolutions,
         )
 
     # Process batches

--- a/utils/prompt_configs.py
+++ b/utils/prompt_configs.py
@@ -44,7 +44,7 @@ def get_mesh_device():
         # need record of what MESH_DEVICE configuration is running
         raise ValueError(
             "environment variable MESH_DEVICE must be set.\n",
-            "Possible values: N150, N300, T3K_LINE",
+            "Possible values: N150, N300, T3K_LINE, T3K_RING",
         )
     return mesh_device
 

--- a/vllm-tt-metal-llama3/README.md
+++ b/vllm-tt-metal-llama3/README.md
@@ -24,18 +24,19 @@ Run the container from the project root at `tt-inference-server`:
 ```bash
 cd tt-inference-server
 # make sure if you already set up the model weights and cache you use the correct persistent volume
-export MODEL_VOLUME=$PWD/persistent_volume/volume_id_tt-metal-Llama-3.3-70B-Instructv0.0.1/
+export MODEL_NAME=Llama-3.3-70B-Instruct
+export MODEL_VOLUME=$PWD/persistent_volume/volume_id_tt-metal-${MODEL_NAME}-v0.0.1/
 docker run \
   --rm \
   -it \
-  --env-file persistent_volume/model_envs/Llama-3.3-70B-Instruct.env \
+  --env-file persistent_volume/model_envs/${MODEL_NAME}.env \
   --cap-add ALL \
   --device /dev/tenstorrent:/dev/tenstorrent \
   --volume /dev/hugepages-1G:/dev/hugepages-1G:rw \
-  --volume ${MODEL_VOLUME?ERROR env var MODEL_VOLUME must be set}:/home/user/cache_root:rw \
+  --volume ${MODEL_VOLUME?ERROR env var MODEL_VOLUME must be set}:/home/container_app_user/cache_root:rw \
   --shm-size 32G \
   --publish 7000:7000 \
-  ghcr.io/tenstorrent/tt-inference-server/tt-metal-llama3-70b-src-base-vllm:v0.0.1-tt-metal-v0.54.0-rc2-953161188c50 
+  ghcr.io/tenstorrent/tt-inference-server/vllm-llama3-src-dev-ubuntu-20.04-amd64:v0.0.1-47fb1a2fb6e0-2f33504bad49
 ```
 
 By default the Docker container will start running the entrypoint command wrapped in `src/run_vllm_api_server.py`.
@@ -65,7 +66,6 @@ python example_requests_client_alpaca_eval.py --stream True --n_samples 1 --num_
 python example_requests_client_alpaca_eval.py --stream True --n_samples 805 --num_full_iterations 1 --batch_size 32
 ```
 
-
 ## First run setup
 
 Tested starting condition is from a fresh installation of Ubuntu 20.04 with Tenstorrent system dependencies installed.
@@ -78,11 +78,17 @@ Recommended to follow postinstall guide to allow $USER to run docker without sud
 
 ### 2. Ensure system dependencies installed
 
+Follow TT strating guide software installation at: https://docs.tenstorrent.com/quickstart.html
+
+Ensure all set up:
+- firmware: tt-firmware (https://github.com/tenstorrent/tt-firmware)
+- drivers: tt-kmd (https://github.com/tenstorrent/tt-kmd)
+- hugepages: see https://docs.tenstorrent.com/quickstart.html#step-4-setup-hugepages and https://github.com/tenstorrent/tt-system-tools
 - tt-smi: https://github.com/tenstorrent/tt-smi
-- firmware: bundle 80.10.1.0 (https://github.com/tenstorrent/tt-firmware/blob/02b4b6ed49b6ea2fb9a8664e99d4fed25e443bd6/experiments/fw_pack-80.10.1.0.fwbundle)
-- drivers: tt-kmd version 1.29 (https://github.com/tenstorrent/tt-kmd/tree/ttkmd-1.29)
-- topology: ensure mesh topology https://github.com/tenstorrent/tt-topology
-- hugepages: https://github.com/tenstorrent/tt-system-tools
+
+If running on a TT-LoudBox or TT-QuietBox, you will also need:
+- topology: tt-topology https://github.com/tenstorrent/tt-topology
+  - set up mesh topology, see https://github.com/tenstorrent/tt-topology?tab=readme-ov-file#mesh
 
 ### 3. CPU performance setting
 
@@ -105,7 +111,7 @@ Either download the Docker image from GitHub Container Registry (recommended for
 
 ```bash
 # pull image from GHCR
-docker pull ghcr.io/tenstorrent/tt-inference-server/tt-metal-llama3-70b-src-base-vllm:v0.0.1-tt-metal-v0.54.0-rc2-953161188c50
+docker pull ghcr.io/tenstorrent/tt-inference-server/vllm-llama3-src-dev-ubuntu-20.04-amd64:v0.0.1-47fb1a2fb6e0-2f33504bad49
 ```
 
 #### Option B: Build Docker Image
@@ -124,7 +130,7 @@ The script `setup.sh` automates:
 ```bash
 cd tt-inference-server
 chmod +x setup.sh
-./setup.sh llama-3.1-70b-instruct
+./setup.sh Llama-3.3-70B-instruct
 ```
 
 # Additional Documentation

--- a/vllm-tt-metal-llama3/docs/development.md
+++ b/vllm-tt-metal-llama3/docs/development.md
@@ -54,27 +54,29 @@ docker push ghcr.io/tenstorrent/tt-inference-server/tt-metal-llama3-70b-src-base
 
 ## Step 2: Run container for LM evals development
 
-note: this requires running `setup.sh` to set up the weights for a particular model, in this example `llama-3.1-70b-instruct`.
+note: this requires running `setup.sh` to set up the weights for a particular model, in this example `Llama-3.3-70B-Instruct`.
 
 ```bash
 cd tt-inference-server
-export MODEL_VOLUME=$PWD/persistent_volume/volume_id_tt-metal-Llama-3.3-70B-Instructv0.0.1/
+export MODEL_NAME=Llama-3.3-70B-Instruct
+export MODEL_VOLUME=$PWD/persistent_volume/volume_id_tt-metal-${MODEL_NAME}-v0.0.1/
+
 docker run \
   --rm \
   -it \
-  --env-file persistent_volume/model_envs/Llama-3.1-70B-Instruct.env \
+  --env-file persistent_volume/model_envs/${MODEL_NAME}.env \
   --cap-add ALL \
   --device /dev/tenstorrent:/dev/tenstorrent \
   --volume /dev/hugepages-1G:/dev/hugepages-1G:rw \
-  --volume ${MODEL_VOLUME?ERROR env var MODEL_VOLUME must be set}:/home/user/cache_root:rw \
+  --volume ${MODEL_VOLUME?ERROR env var MODEL_VOLUME must be set}:/home/container_app_user/cache_root:rw \
   --shm-size 32G \
-  ghcr.io/tenstorrent/tt-inference-server/tt-metal-llama3-70b-src-base-vllm:v0.0.1-tt-metal-${TT_METAL_COMMIT_DOCKER_TAG}-${TT_VLLM_COMMIT_DOCKER_TAG} bash
+  ghcr.io/tenstorrent/tt-inference-server/vllm-llama3-src-dev-ubuntu-20.04-amd64:v0.0.1-{TT_METAL_COMMIT_DOCKER_TAG}-${TT_VLLM_COMMIT_DOCKER_TAG} bash
 ```
 
 additionally for development you can mount the volumes:
 ```bash
-  --volume $PWD/../vllm:/home/user/vllm \
-  --volume $PWD/../lm-evaluation-harness:/home/user/lm-evaluation-harness \
+  --volume $PWD/../vllm:/home/container_app_user/vllm \
+  --volume $PWD/../lm-evaluation-harness:/home/container_app_user/lm-evaluation-harness \
 ```
 
 ## Step 3: Inside container setup and run vLLM
@@ -93,7 +95,7 @@ Already built into Docker image, continue to run vLLM.
 
 ```bash
 # option 2: install from github
-cd /home/user/vllm
+cd /home/container_app_user/vllm
 git fetch
 git checkout <branch>
 git pull
@@ -104,7 +106,7 @@ echo "done vllm install."
 
 ```bash
 # option 3: install edittable (for development) - mount from outside container
-cd /home/user/vllm
+cd /home/container_app_user/vllm
 pip install -e .
 echo "done vllm install."
 ```
@@ -113,7 +115,7 @@ echo "done vllm install."
 
 ```bash
 # run vllm serving
-cd /home/user/vllm
+cd /home/container_app_user/vllm
 python examples/server_example_tt.py
 ```
 


### PR DESCRIPTION
## change log

* Default handling of MESH_DEVICE for Llama 3.x models
* Modified setup script improvements:
    * Improved environment variable handling and persistence storage integration
    * Added IMPL_ID field (set to "tt-metal" for all current models)
    * Introduced MODEL_VERSION and MODEL_ID variables for better versioning
* Add image input support for image-text-to-text models in client scripts and tools
    * Added support for image input in trace capturing
    * Added new parameters for image width and height
    * Implemented handling of both text-only and image+text trace captures
* Rename client side scripts batch_size options to max_concurrent to indicate client side concurrent request limits
* Fixed the vLLM model registration logic. Added missing ModelRegistry.register_model call for TTLlamaForCausalLM for legacy implementation models
* Updated benchmark path handling to use $HOME environment variable instead of hardcoded /home/user path
* Add benchmark summary support handling for vllm benchmark script, add documentation example
* Added support for a new model "DeepSeek-R1-Distill-Llama-70B" in the model setup configurations