### PR TITLE
Add community issue tagging workflow

### DIFF
--- a/.github/workflows/on-community-issue.yml
+++ b/.github/workflows/on-community-issue.yml
@@ -1,0 +1,66 @@
+name: "Issue Notification"
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  gh-slack-bridge:
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Set username and number based on event type
+        id: set-variables
+        run: |
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            echo "USERNAME=${{ github.event.issue.user.login }}" >> $GITHUB_OUTPUT
+            echo "NUMBER=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+            echo "EVENT_URL=${{ github.event.issue.html_url }}" >> $GITHUB_OUTPUT
+            echo "EVENT_TYPE=issue" >> $GITHUB_OUTPUT
+            echo "GH_COMMAND=issue" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            echo "USERNAME=${{ github.event.pull_request.user.login }}" >> $GITHUB_OUTPUT
+            echo "NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "EVENT_URL=${{ github.event.pull_request.html_url }}" >> $GITHUB_OUTPUT
+            echo "EVENT_TYPE=PR" >> $GITHUB_OUTPUT
+            echo "GH_COMMAND=pr" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            echo "USERNAME=${{ github.actor }}" >> $GITHUB_OUTPUT
+            echo "EVENT_URL=https://github.com/${{ github.repository }}/commit/${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "EVENT_TYPE=push" >> $GITHUB_OUTPUT
+          fi
+      - name: Check if organization member
+        id: is_organization_member
+        run: |
+          http_status=$(curl -o /dev/null -s -w '%{http_code}' -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" https://api.github.com/orgs/tenstorrent/members/${{ steps.set-variables.outputs.USERNAME }})
+          if [ "$http_status" -eq 204 ]; then
+            echo "Detected org member"
+            echo "is_member=true" >> $GITHUB_OUTPUT
+          else
+            echo "Detected community member"
+            echo "is_member=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Add community label
+        if: ${{ steps.is_organization_member.outputs.is_member == 'false' && steps.set-variables.outputs.GH_COMMAND && steps.set-variables.outputs.NUMBER }}
+        run: |
+          gh ${{steps.set-variables.outputs.GH_COMMAND}} edit ${{ steps.set-variables.outputs.NUMBER }} --add-label ${{ env.LABELS }}
+        env:
+          GH_TOKEN: ${{ secrets.LABEL_WRITE_GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          LABELS: community
+      - name: Send Notification
+        if: ${{ steps.is_organization_member.outputs.is_member == 'false' }}
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "A new ${{ steps.set-variables.outputs.EVENT_TYPE }} has been created by a non-org member `${{ steps.set-variables.outputs.USERNAME }}`: ${{ steps.set-variables.outputs.EVENT_URL }}",
+              "channel": ${{ secrets.CHANNEL }}
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CHANNEL_WEBHOOK_URL }}


### PR DESCRIPTION
This PR adds a workflow to automatically label any new Issues or PRs opened by community (non-Tenstorrent) members. It will also send a notification to the internal Slack group for awareness.