### PR TITLE
Add ENV variables for enabling automatic function calling in vLLM

### DIFF
--- a/vllm-tt-metal-llama3/src/run_vllm_api_server.py
+++ b/vllm-tt-metal-llama3/src/run_vllm_api_server.py
@@ -277,6 +277,8 @@ def model_setup(hf_model_id):
         "max-log-len": "64",
         "port": os.getenv("SERVICE_PORT", "7000"),
         "api-key": get_encoded_api_key(os.getenv("JWT_SECRET", None)),
+        "enable-auto-tool-choice": os.getenv("ENABLE_AUTO_TOOL_CHOICE", "false").lower() == "true",
+        "tool-call-parser": os.getenv("TOOL_CALL_PARSER", None),  # Available tool parsers: https://docs.vllm.ai/en/latest/features/tool_calling.html#automatic-function-calling
     }
 
     return args


### PR DESCRIPTION
## 🔧 Enable configurable tool calling via environment variables

This PR introduces environment-variable-based configuration for [vLLM tool calling](https://docs.vllm.ai/en/latest/features/tool_calling.html#tool-calling), allowing users to explicitly opt in to tool-related features.

### ✅ Changes

- Added two new configurable parameters to the model startup logic:
  - `enable-auto-tool-choice`: Enables vLLM's automatic tool selection if set to `"true"`.
  - `tool-call-parser`: Specifies the parser to interpret tool call outputs.

### 🌱 Default Behavior (safe defaults)

| ENV Variable              | Default Value | Description                                                                 |
|---------------------------|---------------|-----------------------------------------------------------------------------|
| `ENABLE_AUTO_TOOL_CHOICE` | `false`       | Enables automatic tool selection by the model. Accepts `"true"` or `"false"`. |
| `TOOL_CALL_PARSER`        | `None`        | Specifies the tool call parser. Options include: `"llama3_json"`, `"openai_tools"` |

Tool calling is now **disabled by default**, to avoid unintended behavior with models that do not support it.

### 💡 Usage Example

To enable tool calling for a LLaMA 3 model:

```bash
export ENABLE_AUTO_TOOL_CHOICE=true
export TOOL_CALL_PARSER=llama3_json
