### PR TITLE
Add device-id argument and use persistent volume env variable if provided

### DIFF
--- a/run.py
+++ b/run.py
@@ -102,6 +102,12 @@ def parse_arguments():
         help="Override the Docker image used by --docker-server, ignoring the model config",
     )
 
+    parser.add_argument(
+        "--device-id",
+        type=str,
+        help="Tenstorrent device ID (e.g. '0' for /dev/tenstorrent/0)",
+    )
+
     args = parser.parse_args()
 
     return args

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -79,6 +79,10 @@ def run_docker_server(args, setup_config):
     mesh_device_str = DeviceTypes.to_mesh_device_str(device)
     container_name = f"tt-inference-server-{short_uuid()}"
 
+    device_path = "/dev/tenstorrent"
+    if hasattr(args, 'device_id') and args.device_id is not None:
+        device_path = f"{device_path}/{args.device_id}"
+
     if args.dev_mode:
         # use dev image
         docker_image = docker_image.replace("-release-", "-dev-")
@@ -114,7 +118,7 @@ def run_docker_server(args, setup_config):
         "--name", container_name,
         "--env-file", str(default_dotenv_path),
         "--cap-add", "ALL",
-        "--device", "/dev/tenstorrent:/dev/tenstorrent",
+        "--device", f"{device_path}:{device_path}",
         "--mount", "type=bind,src=/dev/hugepages-1G,dst=/dev/hugepages-1G",
         # note: order of mounts matters, model_volume_root must be mounted before nested mounts
         "--mount", f"type=bind,src={setup_config.host_model_volume_root},dst={setup_config.cache_root}",

--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -68,7 +68,9 @@ class SetupConfig:
 
     def _infer_data(self):
         self.repo_root = str(Path(__file__).resolve().parent.parent)
-        self.persistent_volume_root = Path(self.repo_root) / "persistent_volume"
+        self.persistent_volume_root = Path(
+            os.getenv("PERSISTENT_VOLUME_ROOT", str(Path(self.repo_root) / "persistent_volume"))
+        )
         volume_name = f"volume_id_{self.model_config.impl.impl_id}-{self.model_config.model_name}-v{self.model_config.version}"
         # host paths
         self.host_model_volume_root = self.persistent_volume_root / volume_name


### PR DESCRIPTION
- In our CI setup, we have a machine with two devices. To select which one to use, we need to provide a `device-id`.
- The `PERSISTENT_VOLUME_ROOT` environment variable was not used during the setup.

I ran 3 tests using this branch to validate the behavior with device-id:
- `llmbox` without `device-id` arg

- `N150` - `device-id=1`
https://github.com/tenstorrent/tt-shield/actions/runs/15163158332/job/42634094551
- `N300` - `device-id=0`
https://github.com/tenstorrent/tt-shield/actions/runs/15163984147/job/42636933194