### PR TITLE
fix HF download issue

### DIFF
--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -289,9 +289,10 @@ class HostSetupManager:
             )
             self.setup_config.host_hf_home = inp
 
-        self.setup_config.host_hf_home = default_hf_home
         hf_home = Path(self.setup_config.host_hf_home)
         hf_home.mkdir(parents=True, exist_ok=True)
+        # set HF_HOME so that huggingface cache is used correctly
+        os.environ["HF_HOME"] = str(hf_home)
         assert os.access(
             hf_home, os.W_OK
         ), f"⛔ HOST_HF_HOME={self.setup_config.host_hf_home} is not writable."

--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -515,6 +515,7 @@ class HostSetupManager:
             logger.info(
                 f"✅ Using weights directory: {self.setup_config.host_model_weights_mount_dir}"
             )
+            self.check_model_weights_dir(self.setup_config.host_model_weights_mount_dir)
         else:
             raise ValueError("⛔ Weights directory does not exist.")
 
@@ -523,11 +524,7 @@ class HostSetupManager:
         self.setup_config.host_tt_metal_cache_dir.mkdir(parents=True, exist_ok=True)
 
     def setup_weights(self):
-        target_dir = self.setup_config.host_model_weights_mount_dir
-
-        if target_dir and any(target_dir.iterdir()):
-            logger.info(f"Model weights already exist at {target_dir}")
-        else:
+        if not self.check_setup():
             if self.setup_config.model_source == "huggingface":
                 self.setup_weights_huggingface()
             elif self.setup_config.model_source == "local":


### PR DESCRIPTION
# changelog

* fix https://github.com/tenstorrent/tt-inference-server/issues/240 which seems to have been caused by making models re-download after failed detailed check for files present only to then gate re-download by check for dir existence.
* set HF_HOME from HOST_HF_HOME passed to run.py so its used correctly.
* fix related issues in https://github.com/tenstorrent/tt-inference-server/issues/262
* add default logging of the tt-inference-server git sha to run_8.log