### PR TITLE
fix link to development docs

### DIFF
--- a/docs/workflows_user_guide.md
+++ b/docs/workflows_user_guide.md
@@ -331,7 +331,7 @@ The logs have the following structure:
 
 # Additional Documentation
 
-- [Development](docs/development.md)
+- [Development](development.md)
 - [Benchmarking](../benchmarking/README.md)
 - [Evals](../evals/README.md)
 - [tests](../tests/README.md)


### PR DESCRIPTION
Fixes `development.md` docs link within `workflows_user_guide.md`