### PR TITLE
tstesco/example-model-cli-input

### DIFF
--- a/vllm-tt-metal-llama3/src/example_requests_client.py
+++ b/vllm-tt-metal-llama3/src/example_requests_client.py
@@ -27,9 +27,11 @@ def get_authorization():
     if authorization is None:
         jwt_secret = os.getenv("JWT_SECRET", None)
         if jwt_secret is None:
-            raise ValueError(
-                "Neither AUTHORIZATION or JWT_SECRET environment variables are set."
+            logger.warning(
+                "Neither AUTHORIZATION nor JWT_SECRET environment variables are set. "
+                "Proceeding without authorization."
             )
+            return None
         json_payload = json.loads('{"team_id": "tenstorrent", "token_id":"debug-test"}')
         encoded_jwt = jwt.encode(json_payload, jwt_secret, algorithm="HS256")
         authorization = f"{encoded_jwt}"
@@ -327,6 +329,11 @@ def main():
     )
     parser.add_argument("--prompt", type=str, help="Prompt to send to the model")
     parser.add_argument(
+        "--model",
+        type=str,
+        help="Model name to use (overrides HF_MODEL_REPO_ID environment variable)",
+    )
+    parser.add_argument(
         "--prompt_json_path",
         type=str,
         help="Path to a JSON file containing an array of prompts",
@@ -367,7 +374,14 @@ def main():
     assert args.num_concurrent > 0, f"num_concurrent:={args.num_concurrent} must be greater than 0"
     assert args.n_requests > 0, f"n_requests:={args.n_requests} must be greater than 0"
 
-    model = os.environ.get("HF_MODEL_REPO_ID")
+    model = args.model
+    if model is None:
+        model = os.environ.get("HF_MODEL_REPO_ID")
+        if model is None:
+            model = "default-model"  # Provide a default model name
+            raise ValueError(
+                "Model name is not specified via --model argument or HF_MODEL_REPO_ID environment variable. "
+            )
     print("\n")
 
     # Load prompts from JSON file if specified
@@ -410,14 +424,17 @@ def main():
         },
     ]
 
-    headers = {"Authorization": f"Bearer {get_authorization()}"}
+    headers = {}
+    authorization = get_authorization()
+    if authorization is not None:
+        headers["Authorization"] = f"Bearer {authorization}"
     api_url = get_api_url()
     stream = True
     logging.info(f"API_URL: {api_url}")
 
     # set API prompt and optional parameters
     json_data = {
-        "model": os.environ.get("HF_MODEL_REPO_ID"),
+        "model": model,
         "messages": messages,
         "temperature": args.temperature,
         "max_tokens": args.max_tokens,


### PR DESCRIPTION
# change log

* add --model arg and error message for envs without HF_MODEL_REPO_ID set 

# testing


```
(python_env) container_app_user@3a70bd8be669:~/app/src$ 
unset HF_TOKEN
unset HF_MODEL_REPO_ID
unset JWT_SECRET
(python_env) container_app_user@3a70bd8be669:~/app/src$ 
(python_env) container_app_user@3a70bd8be669:~/app/src$ python example_requests_client.py 
Traceback (most recent call last):
  File "/home/container_app_user/app/src/example_requests_client.py", line 585, in <module>
    main()
  File "/home/container_app_user/app/src/example_requests_client.py", line 382, in main
    raise ValueError(
ValueError: Model name is not specified via --model argument or HF_MODEL_REPO_ID environment variable. 
python example_requests_client.py  --model meta-llama/Llama-3.3-70B-Instruct
...
requests.exceptions.ConnectionError: HTTPConnectionPool(host='127.0.0.1', port=8000): Max retries exceeded with url: /v1/chat/completions (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fa3070c52d0>: Failed to establish a new connection: [Errno 111] Connection refused'))
```


