### PR TITLE
Failures handling

### DIFF
--- a/benchmarking/run_benchmarks.py
+++ b/benchmarking/run_benchmarks.py
@@ -197,8 +197,13 @@ def main():
     env_config.jwt_secret = args.jwt_secret
     env_config.service_port = args.service_port
     env_config.vllm_model = model_config.hf_model_repo
+
     prompt_client = PromptClient(env_config)
-    prompt_client.wait_for_healthy(timeout=7200.0)
+    if not prompt_client.wait_for_healthy(timeout=30 * 60.0):
+        logger.error(
+            "⛔️ vLLM server is not healthy. Aborting benchmarks. "
+        )
+        return 1
 
     # keep track of captured traces to avoid re-running requests
     captured_traces = set()
@@ -221,6 +226,11 @@ def main():
                 )
                 captured_traces.update(sorted_context_lens_set)
             for i, params in enumerate(params_list, 1):
+                health_check = prompt_client.get_health()
+                if health_check.status_code != 200:
+                    logger.error("⛔️ vLLM server is not healthy. Aborting benchmarks.")
+                    return 1
+
                 logger.info(
                     f"Running benchmark {model_config.model_name}: {i}/{len(params_list)}"
                 )
@@ -250,4 +260,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -214,18 +214,30 @@ def main():
     env_config.jwt_secret = args.jwt_secret
     env_config.service_port = args.service_port
     env_config.vllm_model = model_config.hf_model_repo
+
     prompt_client = PromptClient(env_config)
+    if not prompt_client.wait_for_healthy(timeout=30 * 60.0):
+        logger.error(
+            "⛔️ vLLM server is not healthy. Aborting evaluations. "
+        )
+        return 1
+
     if not args.disable_trace_capture:
-        prompt_client.wait_for_healthy(timeout=7200.0)
         prompt_client.capture_traces()
 
     # Execute lm_eval for each task.
     logger.info("Running vLLM evals client ...")
     return_codes = []
     for task in eval_config.tasks:
+        health_check = prompt_client.get_health()
+        if health_check.status_code != 200:
+            logger.error("⛔️ vLLM server is not healthy. Aborting evaluations.")
+            return 1
+
         logger.info(
             f"Starting workflow: {workflow_config.name} task_name: {task.task_name}"
         )
+
         logger.info(f"Running lm_eval for:\n {task}")
         cmd = build_eval_command(
             task,
@@ -251,4 +263,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/run.py
+++ b/run.py
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import os
+import sys
 import argparse
 import getpass
 import logging
@@ -276,6 +277,8 @@ def main():
         raise NotImplementedError("TODO")
 
     # step 5: run workflows
+    main_return_code = 0
+
     skip_workflows = {WorkflowType.SERVER}
     if WorkflowType.from_string(args.workflow) not in skip_workflows:
         args.run_id = run_id
@@ -283,6 +286,7 @@ def main():
         if all(return_code == 0 for return_code in return_codes):
             logger.info("✅ Completed run.py successfully.")
         else:
+            main_return_code = 1
             logger.error(
                 f"⛔ run.py failed with return codes: {return_codes}. See logs above for details."
             )
@@ -297,6 +301,8 @@ def main():
     )
     logger.info(f"This log file is saved on local machine at: {run_log_path}")
 
+    return main_return_code
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -86,7 +86,7 @@ class PromptClient:
                 logger.warning(f"Health check failed: {e}")
 
             total_time_waited = time.time() - start_time
-            sleep_interval = max(2 - (time.time() - req_time), 0)
+            sleep_interval = max(10 - (time.time() - req_time), 0)
             logger.info(
                 f"Service not ready after {total_time_waited:.2f} seconds, "
                 f"waiting {sleep_interval:.2f} seconds before polling ..."

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -630,4 +630,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
- When vLLM server fails abort benchmarks/evals
- Reduce timeouts for server start
- Use sys.exit to propagate return codes between subprocesses