### PR TITLE
Update register_tt_models to use string paths instead of imports to support newer vLLM versions

### DIFF
--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -29,12 +29,17 @@ LOG_PATH = Path(os.getenv("CACHE_ROOT", ".")) / "logs" / f"vllm_{LOG_TIMESTAMP}.
 
 
 def get_logging_dict(log_path, level="DEBUG"):
+    # TODO: remove this once all vLLM versions have been updated to use the new logging formatter
+    if os.getenv("VLLM_LEGACY_LOGGING_FORMATTER", "0") == "1":
+        formatter_class = "vllm.logging.NewLineFormatter"
+    else:
+        formatter_class = "vllm.logging_utils.NewLineFormatter"
     logging_dict = {
         "version": 1,
         "disable_existing_loggers": False,
         "formatters": {
             "vllm": {
-                "class": "vllm.logging_utils.NewLineFormatter",
+                "class": formatter_class,
                 "format": "%(levelname)s %(asctime)s %(filename)s:%(lineno)d] %(message)s",
                 "datefmt": "%m-%d %H:%M:%S",
             }

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -34,7 +34,7 @@ def get_logging_dict(log_path, level="DEBUG"):
         "disable_existing_loggers": False,
         "formatters": {
             "vllm": {
-                "class": "vllm.logging.NewLineFormatter",
+                "class": "vllm.logging_utils.NewLineFormatter",
                 "format": "%(levelname)s %(asctime)s %(filename)s:%(lineno)d] %(message)s",
                 "datefmt": "%m-%d %H:%M:%S",
             }

--- a/vllm-tt-metal-llama3/src/run_vllm_api_server.py
+++ b/vllm-tt-metal-llama3/src/run_vllm_api_server.py
@@ -56,32 +56,25 @@ def handle_code_versions():
 def register_tt_models():
     model_impl = os.getenv("MODEL_IMPL", "tt-transformers")
     if model_impl == "tt-transformers":
-        from models.tt_transformers.tt.generator_vllm import LlamaForCausalLM
-        from models.tt_transformers.tt.generator_vllm import (
-            MllamaForConditionalGeneration,
-        )
-        from models.tt_transformers.tt.generator_vllm import Qwen2ForCausalLM
+        path_ttt_generators =  "models.tt_transformers.tt.generator_vllm"
+        path_llama_text = f"{path_ttt_generators}:LlamaForCausalLM"
 
-        ModelRegistry.register_model("TTQwen2ForCausalLM", Qwen2ForCausalLM)
+        ModelRegistry.register_model("TTQwen2ForCausalLM", f"{path_ttt_generators}:Qwen2ForCausalLM")
         ModelRegistry.register_model(
-            "TTMllamaForConditionalGeneration", MllamaForConditionalGeneration
+            "TTMllamaForConditionalGeneration", f"{path_ttt_generators}:MllamaForConditionalGeneration"
         )
         if os.getenv("HF_MODEL_REPO_ID") == "mistralai/Mistral-7B-Instruct-v0.3":
-            from models.tt_transformers.tt.generator_vllm import MistralForCausalLM
-
-            ModelRegistry.register_model("TTMistralForCausalLM", MistralForCausalLM)
+            ModelRegistry.register_model("TTMistralForCausalLM", f"{path_ttt_generators}:MistralForCausalLM")
     elif model_impl == "subdevices":
-        from models.demos.llama3_subdevices.tt.generator_vllm import LlamaForCausalLM
+        path_llama_text = "models.demos.llama3_subdevices.tt.generator_vllm:LlamaForCausalLM"
     elif model_impl == "t3000-llama2-70b":
-        from models.demos.t3000.llama2_70b.tt.generator_vllm import (
-            TtLlamaForCausalLM as LlamaForCausalLM,
-        )
+        path_llama_text = "models.demos.t3000.llama2_70b.tt.generator_vllm:TtLlamaForCausalLM"
     else:
         raise ValueError(
             f"Unsupported model_impl: {model_impl}, pick one of [tt-transformers, subdevices, llama2-t3000]"
         )
 
-    ModelRegistry.register_model("TTLlamaForCausalLM", LlamaForCausalLM)
+    ModelRegistry.register_model("TTLlamaForCausalLM", path_llama_text)
 
 
 register_tt_models()  # Import and register models from tt-metal

--- a/vllm-tt-metal-llama3/src/run_vllm_api_server.py
+++ b/vllm-tt-metal-llama3/src/run_vllm_api_server.py
@@ -51,6 +51,14 @@ def handle_code_versions():
             commit=metal_tt_transformers_commit, repo_path=tt_metal_home
         ), "tt-transformers model_impl requires tt-metal: v0.57.0-rc1 or later"
 
+    vllm_upstream_rebase_commit = "3accc8dc"
+    if not is_head_eq_or_after_commit(
+        commit=vllm_upstream_rebase_commit, repo_path=vllm_dir
+    ):
+        # TODO: remove this once all vLLM versions have been updated to use the new logging formatter
+        logger.warning("DEPRECATION WARNING: using legacy vLLM logging formatter.")
+        os.environ["VLLM_LEGACY_LOGGING_FORMATTER"] = "1"
+
 
 # Copied from vllm/examples/offline_inference_tt.py
 def register_tt_models():
@@ -313,8 +321,8 @@ def model_setup(hf_model_id):
 
 
 def main():
-    hf_model_id = get_hf_model_id()
     handle_code_versions()
+    hf_model_id = get_hf_model_id()
     # vLLM CLI arguments
     args = model_setup(hf_model_id)
     for key, value in args.items():

--- a/vllm-tt-metal-llama3/src/run_vllm_api_server.py
+++ b/vllm-tt-metal-llama3/src/run_vllm_api_server.py
@@ -56,19 +56,28 @@ def handle_code_versions():
 def register_tt_models():
     model_impl = os.getenv("MODEL_IMPL", "tt-transformers")
     if model_impl == "tt-transformers":
-        path_ttt_generators =  "models.tt_transformers.tt.generator_vllm"
+        path_ttt_generators = "models.tt_transformers.tt.generator_vllm"
         path_llama_text = f"{path_ttt_generators}:LlamaForCausalLM"
 
-        ModelRegistry.register_model("TTQwen2ForCausalLM", f"{path_ttt_generators}:Qwen2ForCausalLM")
         ModelRegistry.register_model(
-            "TTMllamaForConditionalGeneration", f"{path_ttt_generators}:MllamaForConditionalGeneration"
+            "TTQwen2ForCausalLM", f"{path_ttt_generators}:Qwen2ForCausalLM"
+        )
+        ModelRegistry.register_model(
+            "TTMllamaForConditionalGeneration",
+            f"{path_ttt_generators}:MllamaForConditionalGeneration",
         )
         if os.getenv("HF_MODEL_REPO_ID") == "mistralai/Mistral-7B-Instruct-v0.3":
-            ModelRegistry.register_model("TTMistralForCausalLM", f"{path_ttt_generators}:MistralForCausalLM")
+            ModelRegistry.register_model(
+                "TTMistralForCausalLM", f"{path_ttt_generators}:MistralForCausalLM"
+            )
     elif model_impl == "subdevices":
-        path_llama_text = "models.demos.llama3_subdevices.tt.generator_vllm:LlamaForCausalLM"
+        path_llama_text = (
+            "models.demos.llama3_subdevices.tt.generator_vllm:LlamaForCausalLM"
+        )
     elif model_impl == "t3000-llama2-70b":
-        path_llama_text = "models.demos.t3000.llama2_70b.tt.generator_vllm:TtLlamaForCausalLM"
+        path_llama_text = (
+            "models.demos.t3000.llama2_70b.tt.generator_vllm:TtLlamaForCausalLM"
+        )
     else:
         raise ValueError(
             f"Unsupported model_impl: {model_impl}, pick one of [tt-transformers, subdevices, llama2-t3000]"


### PR DESCRIPTION
- In newer versions of vLLM, registered model classes that are imported must be PyTorch classes. Modify model registration to use string paths instead of imports to use soft registration to bypass that requirement for TT models. Also with this change, only the model being evaluated will be imported and not other TT models.
- Fix renamed vLLM logging import
- Note: The changes from this PR are required when https://github.com/tenstorrent/vllm/tree/dev has been updated to a more recent upstream version (April 2025).

Shield CI for Llama1B-T3K (dispatched with https://github.com/tenstorrent/tt-metal/pull/22720, rebased vLLM branch, and the tt-inference-server commit from this PR): https://github.com/tenstorrent/tt-shield/actions/runs/15450428085