### PR TITLE
Add detailed report

### DIFF
--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -629,6 +629,7 @@ def main():
 
         json.dump(
             {
+                "metadata": metadata,
                 "benchmarks_summary": benchmarks_release_data,
                 "evals": evals_release_data,
                 "benchmarks": benchmarks_detailed_data,


### PR DESCRIPTION
We want to include each run’s information in Superset as well  -  so I added info from csv to output json.
To maintain backward compatibility I moved the separate run info back into `benchmarks` and Benchmark Targets into `benchmark_summary`. I'm open to changing this if it breaks something else, just let me know.
Other formatting changes were made by the pre-commit hook.