### PR TITLE
Fixing reference map bug

### DIFF
--- a/workflows/model_config.py
+++ b/workflows/model_config.py
@@ -317,7 +317,7 @@ class ModelConfigTemplate:
         configs = []
 
         # Generate performance reference map
-        main_model_name = self.weights[0]
+        main_model_name = Path(self.weights[0]).name
         perf_reference_map = get_perf_reference_map(
             main_model_name, self.perf_targets_map
         )


### PR DESCRIPTION
## Problem
`get_perf_reference_map` always returns an empty map because we key on `self.weights[0]` instead of the actual model name which can be given by `Path(self.weights[0]).name`.

## Solution
Changed it to `Path(self.weights[0]).name`.