### PR TITLE
Fix `TT_CACHE_PATH` suffix

### DIFF
--- a/workflows/model_config.py
+++ b/workflows/model_config.py
@@ -179,6 +179,7 @@ class ModelConfig:
     device_model_spec: DeviceModelSpec
 
     # Optional configuration fields
+    subdevice_type: Optional[DeviceTypes] = None # Used for data-parallel configurations
     param_count: Optional[int] = None
     min_disk_gb: Optional[int] = None
     min_ram_gb: Optional[int] = None

--- a/workflows/model_config.py
+++ b/workflows/model_config.py
@@ -246,9 +246,7 @@ class ModelConfig:
             object.__setattr__(
                 self,
                 "subdevice_type",
-                DeviceTypes.get_data_parallel_subdevice(
-                    self.device_type, data_parallel
-                ),
+                self.device_type.get_data_parallel_subdevice(data_parallel),
             )
 
     def validate_data(self):

--- a/workflows/model_config.py
+++ b/workflows/model_config.py
@@ -179,7 +179,6 @@ class ModelConfig:
     device_model_spec: DeviceModelSpec
 
     # Optional configuration fields
-    subdevice_type: Optional[DeviceTypes] = None # Used for data-parallel configurations
     param_count: Optional[int] = None
     min_disk_gb: Optional[int] = None
     min_ram_gb: Optional[int] = None
@@ -190,6 +189,7 @@ class ModelConfig:
     code_link: Optional[str] = None
     override_tt_config: Dict[str, str] = field(default_factory=dict)
     supported_modalities: List[str] = field(default_factory=lambda: ["text"])
+    subdevice_type: Optional[DeviceTypes] = None # Used for data-parallel configurations
 
     def __post_init__(self):
         self.validate_data()
@@ -239,6 +239,16 @@ class ModelConfig:
                 self,
                 "code_link",
                 f"{self.impl.repo_url}/tree/{self.tt_metal_commit}/{self.impl.code_path}",
+            )
+
+        if self.override_tt_config and "data_parallel" in self.override_tt_config:
+            data_parallel = self.override_tt_config["data_parallel"]
+            object.__setattr__(
+                self,
+                "subdevice_type",
+                DeviceTypes.get_data_parallel_subdevice(
+                    self.device_type, data_parallel
+                ),
             )
 
     def validate_data(self):

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -79,18 +79,12 @@ def run_docker_server(args, setup_config):
     device = DeviceTypes.from_string(args.device)
     mesh_device_str = DeviceTypes.to_mesh_device_str(device)
     container_name = f"tt-inference-server-{short_uuid()}"
-    
-    # Read data-parallel configuration from override_tt_config if it exists
-    if (model_config.device_model_spec.override_tt_config 
-        and "data_parallel" in model_config.device_model_spec.override_tt_config):
-        data_parallel = model_config.device_model_spec.override_tt_config["data_parallel"]
-    else:
-        data_parallel = 1
 
-    if data_parallel > 1 and model_config.subdevice_type:
-        assert DeviceTypes.get_data_parallel_subdevice(device, data_parallel) == model_config.subdevice_type, \
-            f"Data parallel {data_parallel} is not supported for device {device} and subdevice {model_config.subdevice_type}. Please check your model configuration."
-    subdevice_str = DeviceTypes.to_mesh_device_str(DeviceTypes.get_data_parallel_subdevice(device, data_parallel))
+    subdevice_str = (
+        DeviceTypes.to_mesh_device_str(model_config.subdevice_type)
+        if model_config.subdevice_type
+        else mesh_device_str
+    )
 
     device_path = "/dev/tenstorrent"
     if hasattr(args, "device_id") and args.device_id is not None:

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -80,7 +80,7 @@ def run_docker_server(args, setup_config):
     mesh_device_str = DeviceTypes.to_mesh_device_str(device)
     container_name = f"tt-inference-server-{short_uuid()}"
 
-    subdevice_str = (
+    device_cache_dir = (
         DeviceTypes.to_mesh_device_str(model_config.subdevice_type)
         if model_config.subdevice_type
         else mesh_device_str
@@ -107,7 +107,7 @@ def run_docker_server(args, setup_config):
         "MESH_DEVICE": mesh_device_str,
         "MODEL_IMPL": model_config.impl.impl_name,
         "CACHE_ROOT": setup_config.cache_root,
-        "TT_CACHE_PATH": setup_config.container_tt_metal_cache_dir / subdevice_str,
+        "TT_CACHE_PATH": setup_config.container_tt_metal_cache_dir / device_cache_dir,
         "MODEL_WEIGHTS_PATH": setup_config.container_model_weights_path,
         "HF_MODEL_REPO_ID": model_config.hf_model_repo,
         "MODEL_SOURCE": setup_config.model_source,

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -80,6 +80,7 @@ def run_docker_server(args, setup_config):
     mesh_device_str = DeviceTypes.to_mesh_device_str(device)
     container_name = f"tt-inference-server-{short_uuid()}"
 
+    # TODO: remove this once https://github.com/tenstorrent/tt-metal/issues/23785 has been closed
     device_cache_dir = (
         DeviceTypes.to_mesh_device_str(model_config.subdevice_type)
         if model_config.subdevice_type

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -86,6 +86,24 @@ class DeviceTypes(IntEnum):
         if device not in mapping:
             raise ValueError(f"Invalid DeviceType: {device}")
         return mapping[device]
+    
+    @classmethod
+    def get_data_parallel_subdevice(cls, device: "DeviceTypes", data_parallel: int) -> "DeviceTypes":
+        data_parallel_map = {
+            (cls.GALAXY, 1): cls.GALAXY,
+            (cls.GALAXY, 4): cls.T3K,
+            (cls.GALAXY, 16): cls.N300,
+            (cls.GALAXY, 32): cls.N150,
+            (cls.T3K, 1): cls.T3K,
+            (cls.T3K, 4): cls.N300,
+            (cls.T3K, 8): cls.N150,
+            (cls.N300, 1): cls.N300,
+            (cls.N300, 2): cls.N150,
+            (cls.N150, 1): cls.N150,
+        }
+        if (device, data_parallel) not in data_parallel_map:
+            raise ValueError(f"Invalid DeviceType or data_parallel: {device}, {data_parallel}")
+        return data_parallel_map[(device, data_parallel)]
 
     @classmethod
     def is_blackhole(cls, device: "DeviceTypes") -> bool:

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -86,29 +86,28 @@ class DeviceTypes(IntEnum):
         if device not in mapping:
             raise ValueError(f"Invalid DeviceType: {device}")
         return mapping[device]
-    
-    @classmethod
-    def get_data_parallel_subdevice(cls, device: "DeviceTypes", data_parallel: int) -> "DeviceTypes":
-        data_parallel_map = {
-            (cls.GALAXY, 1): cls.GALAXY,
-            (cls.GALAXY, 4): cls.T3K,
-            (cls.GALAXY, 16): cls.N300,
-            (cls.GALAXY, 32): cls.N150,
-            (cls.T3K, 1): cls.T3K,
-            (cls.T3K, 4): cls.N300,
-            (cls.T3K, 8): cls.N150,
-            (cls.N300, 1): cls.N300,
-            (cls.N300, 2): cls.N150,
-            (cls.N150, 1): cls.N150,
-        }
-        if (device, data_parallel) not in data_parallel_map:
-            raise ValueError(f"Invalid DeviceType or data_parallel: {device}, {data_parallel}")
-        return data_parallel_map[(device, data_parallel)]
 
     @classmethod
     def is_blackhole(cls, device: "DeviceTypes") -> bool:
         blackhole_devices = (cls.P100, cls.P150)
         return True if device in blackhole_devices else False
+
+    def get_data_parallel_subdevice(self, data_parallel: int) -> "DeviceTypes":
+        data_parallel_map = {
+            (DeviceTypes.GALAXY, 1): DeviceTypes.GALAXY,
+            (DeviceTypes.GALAXY, 4): DeviceTypes.T3K,
+            (DeviceTypes.GALAXY, 16): DeviceTypes.N300,
+            (DeviceTypes.GALAXY, 32): DeviceTypes.N150,
+            (DeviceTypes.T3K, 1): DeviceTypes.T3K,
+            (DeviceTypes.T3K, 4): DeviceTypes.N300,
+            (DeviceTypes.T3K, 8): DeviceTypes.N150,
+            (DeviceTypes.N300, 1): DeviceTypes.N300,
+            (DeviceTypes.N300, 2): DeviceTypes.N150,
+            (DeviceTypes.N150, 1): DeviceTypes.N150,
+        }
+        if (self, data_parallel) not in data_parallel_map:
+            raise ValueError(f"Invalid DeviceType or data_parallel: {self}, {data_parallel}")
+        return data_parallel_map[(self, data_parallel)]
 
 
 class ReportCheckTypes(IntEnum):


### PR DESCRIPTION
Issue https://github.com/tenstorrent/tt-inference-server/issues/322

When running data-parallel configurations we incorrectly set `TT_CACHE_PATH`.
- [x] [test run](https://github.com/tenstorrent/tt-shield/actions/runs/15760830625)