### PR TITLE
Set `data_parallel=16` for llama 8b on tg

### DIFF
--- a/workflows/model_config.py
+++ b/workflows/model_config.py
@@ -658,7 +658,7 @@ config_templates = [
                 max_context=64 * 1024,
                 default_impl=True,
                 override_tt_config={
-                    "data_parallel": 32,
+                    "data_parallel": 16,
                 },
             ),
         },


### PR DESCRIPTION
Currently `data_parallel=32` is not working https://github.com/tenstorrent/tt-shield/issues/48
Switching to `data_parallel=16` until the above issue is closed.
- [x] [test run for dp=16](https://github.com/tenstorrent/tt-shield/actions/runs/15778222334)