### PR TITLE
Enable configuration of vLLM args in model_config

### DIFF
--- a/workflows/model_config.py
+++ b/workflows/model_config.py
@@ -133,6 +133,7 @@ class DeviceModelSpec:
     perf_targets_map: Dict[str, float] = field(default_factory=dict)
     default_impl: bool = False
     perf_reference: List[BenchmarkTaskParams] = field(default_factory=list)
+    vllm_override_args: Dict[str, str] = field(default_factory=dict)
     override_tt_config: Dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self):
@@ -351,6 +352,7 @@ class ModelConfigTemplate:
                     perf_targets_map=device_model_spec.perf_targets_map,
                     default_impl=device_model_spec.default_impl,
                     perf_reference=perf_reference_map.get(device_type, []),
+                    vllm_override_args=device_model_spec.vllm_override_args,
                     override_tt_config=device_model_spec.override_tt_config,
                 )
 
@@ -471,6 +473,9 @@ config_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                vllm_override_args={
+                    "num_scheduler_steps": 1,
+                },
                 override_tt_config={
                     "dispatch_core_axis": "col",
                     "sample_on_device_mode": "all",
@@ -487,8 +492,8 @@ config_templates = [
             "meta-llama/Llama-3.1-70B-Instruct",
             "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
         ],
-        tt_metal_commit="60e367fcc471",
-        vllm_commit="8a43c881e",
+        tt_metal_commit="bb67eb0b5dbb",
+        vllm_commit="f028da1",
         status="testing",
     ),
     ModelConfigTemplate(

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -115,6 +115,7 @@ def run_docker_server(args, setup_config):
         "VLLM_MAX_NUM_SEQS": model_config.device_model_spec.max_concurrency,
         "VLLM_MAX_MODEL_LEN": model_config.device_model_spec.max_context,
         "VLLM_MAX_NUM_BATCHED_TOKENS": model_config.device_model_spec.max_context,
+        "TT_METAL_ENABLE_ERISC_IRAM": 1,
     }
 
     # Pass model config override_tt_config if it exists
@@ -123,6 +124,14 @@ def run_docker_server(args, setup_config):
         docker_env_vars["OVERRIDE_TT_CONFIG"] = json_str
         logger.info(
             f"setting from model config: OVERRIDE_TT_CONFIG={model_config.device_model_spec.override_tt_config}"
+        )
+
+    # Pass model config vLLM override args if it exists
+    if model_config.device_model_spec.vllm_override_args:
+        json_str = json.dumps(model_config.device_model_spec.vllm_override_args)
+        docker_env_vars["VLLM_OVERRIDE_ARGS"] = json_str
+        logger.info(
+            f"setting from model config: VLLM_OVERRIDE_ARGS={model_config.device_model_spec.vllm_override_args}"
         )
 
     # Pass CLI override_tt_config if provided

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -115,7 +115,6 @@ def run_docker_server(args, setup_config):
         "VLLM_MAX_NUM_SEQS": model_config.device_model_spec.max_concurrency,
         "VLLM_MAX_MODEL_LEN": model_config.device_model_spec.max_context,
         "VLLM_MAX_NUM_BATCHED_TOKENS": model_config.device_model_spec.max_context,
-        "TT_METAL_ENABLE_ERISC_IRAM": 1,
     }
 
     # Pass model config override_tt_config if it exists


### PR DESCRIPTION
This PR:
* enables configuration of vLLM args in model_config
* sets `num_scheduler_steps=1` for TG on Llama-3.3-70B(-Instruct)
* uses a new tt-metal commit which fixes the 32k OOM issue (https://github.com/tenstorrent/tt-metal/pull/23786)