### PR TITLE
Add --trust_remote_code for LiveCodeBench 

### DIFF
--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -170,6 +170,10 @@ def build_eval_command(
     if task.apply_chat_template:
         cmd.append("--apply_chat_template")  # Flag argument (no value)
 
+    # Add --trust_remote_code for tasks that require custom dataset loading code
+    if task.task_name == "livecodebench":
+        cmd.append("--trust_remote_code")
+
     # force all cmd parts to be strs
     cmd = [str(c) for c in cmd]
     return cmd


### PR DESCRIPTION
#### Issue: 
The livecodebench evaluation was failing with:
```
ValueError: The repository for livecodebench/code_generation_lite contains custom code which must be executed to correctly load the dataset. Please pass the argument `trust_remote_code=True` to allow custom code to be run.
```

#### Root Cause:
The lm_eval command wasn't being passed the `--trust_remote_code` flag required by the livecodebench dataset, which contains custom loading code.

#### Solution: 
* Modified evals/run_evals.py to automatically add --trust_remote_code flag when evaluating livecodebench tasks
* Clean implementation that doesn't require configuration file changes
* Only applies to livecodebench, leaving other evaluation tasks unaffected

-> Enables livecodebench evaluations to work correctly for both first-time downloads and cached dataset usage.

##### Files Changed:
`evals/run_evals.py`: Added conditional `--trust_remote_code` flag for livecodebench tasks

