### PR TITLE
Add ability to pass multiple device-id arguments as comma-separated list

### DIFF
--- a/run.py
+++ b/run.py
@@ -32,6 +32,21 @@ from workflows.workflow_types import DeviceTypes, WorkflowType
 logger = logging.getLogger("run_log")
 
 
+def parse_device_ids(value):
+    try:
+        # Split input by commas
+        parts = value.split(",")
+        # Convert to int and ensure all are non-negative
+        device_ids = [int(p) for p in parts]
+        if any(d < 0 for d in device_ids):
+            raise ValueError
+        return device_ids
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"Invalid device-id list: '{value}'. Must be comma-separated non-negative integers (e.g. '0' or '0,1,2')"
+        )
+
+
 def parse_arguments():
     valid_workflows = {w.name.lower() for w in WorkflowType}
     valid_devices = {device.name.lower() for device in DeviceTypes}
@@ -102,8 +117,8 @@ def parse_arguments():
     )
     parser.add_argument(
         "--device-id",
-        type=str,
-        help="Tenstorrent device ID (e.g. '0' for /dev/tenstorrent/0)",
+        type=parse_device_ids,
+        help="Tenstorrent device IDs, integer or comma-separated list of non-negative PCI indices (e.g. '0' for /dev/tenstorrent/0)",
     )
     parser.add_argument(
         "--override-tt-config",

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -15,7 +15,7 @@ from workflows.model_config import (
     MODEL_CONFIGS,
     config_templates,
 )
-from workflows.workflow_types import DeviceTypes
+from workflows.workflow_types import DeviceTypes, ModelStatusTypes
 
 
 @pytest.fixture
@@ -88,7 +88,7 @@ class TestModelConfigTemplateSystem:
         )
         assert minimal_template.repacked == 0
         assert minimal_template.version == "0.0.1"
-        assert minimal_template.status == "preview"
+        assert minimal_template.status == ModelStatusTypes.EXPERIMENTAL
         assert minimal_template.docker_image is None
 
         # Test template expansion

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -87,9 +87,17 @@ def run_docker_server(args, setup_config):
         else mesh_device_str
     )
 
+    # create device mapping string to pass to docker run
     device_path = "/dev/tenstorrent"
-    if hasattr(args, "device_id") and args.device_id is not None:
-        device_path = f"{device_path}/{args.device_id}"
+    device_map_strs = (
+        ["--device", f"{device_path}:{device_path}"]
+        if not getattr(args, "device_id", None)
+        else [
+            val
+            for d in args.device_id
+            for val in ("--device", f"{device_path}/{d}:{device_path}/{d}")
+        ]
+    )
 
     if args.dev_mode:
         # use dev image
@@ -152,7 +160,7 @@ def run_docker_server(args, setup_config):
         "--name", container_name,
         "--env-file", str(default_dotenv_path),
         "--cap-add", "ALL",
-        "--device", f"{device_path}:{device_path}",
+        *device_map_strs,
         "--mount", "type=bind,src=/dev/hugepages-1G,dst=/dev/hugepages-1G",
         # note: order of mounts matters, model_volume_root must be mounted before nested mounts
         "--mount", f"type=bind,src={setup_config.host_model_volume_root},dst={setup_config.cache_root}",


### PR DESCRIPTION
To support running multiple `--workflow server --docker-server`'s, we need to be able to map more than just one `--device-id` into the docker container.

This PR:
* adds this argument parsing to `run.py`
* adds unit tests
  * and fixes broken ones
* adds device string creation to be passed down to `docker run ...`