### PR TITLE
add target for 8b on galaxy

### DIFF
--- a/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/benchmarking/benchmark_targets/model_performance_reference.json
@@ -469,6 +469,20 @@
                     }
                 }
             }
+        ],
+        "galaxy": [
+            {
+                "isl": 128,
+                "osl": 128,
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 11,
+                        "tput_user": 170
+                    }
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
Added target metrics for Llama 8B on Galaxy. 
I used the values from the
https://docs.google.com/spreadsheets/d/1XMGIpOwpYCZqzY97AJRpT7KN_EUIPMJpTSNvLHwqdtM/edit?gid=1537587089#gid=1537587089