### PR TITLE
Set `num_scheduler_steps=1` for llama8b dp

### DIFF
--- a/workflows/model_config.py
+++ b/workflows/model_config.py
@@ -713,6 +713,9 @@ config_templates = [
                 max_concurrency=32 * 4,
                 max_context=64 * 1024,
                 default_impl=True,
+                vllm_override_args={
+                    "num_scheduler_steps": 1,
+                },
                 override_tt_config={
                     "data_parallel": 4,
                     "sample_on_device_mode": "decode_only",


### PR DESCRIPTION
https://github.com/tenstorrent/vllm/issues/137

Current vllm support for data-parallel assumes `num_scheduler_steps=1`.

- [ ] [llama 8B DP=4](https://github.com/tenstorrent/tt-shield/actions/runs/16523857111/job/46732015979)