### PR TITLE
SD 3.5 Large support & mock mode & threads instead of queues

### DIFF
--- a/tt-metal-sdxl/config/settings.py
+++ b/tt-metal-sdxl/config/settings.py
@@ -13,7 +13,9 @@ class Settings(BaseSettings):
     devices_per_runner:int = 1
     max_queue_size:int = 4
     model_runner:str = "tt-sdxl"
-
+    #model_runner:str = "tt-sd3.5"
+    device_mesh_shape:tuple = (1, 1)
+    mock_devices_count:int = 5
     model_config = SettingsConfigDict(env_file=".env") 
 
 settings = Settings()

--- a/tt-metal-sdxl/model_services/sdxl_service.py
+++ b/tt-metal-sdxl/model_services/sdxl_service.py
@@ -5,8 +5,6 @@
 import asyncio
 from uuid import uuid4
 
-from fastapi import HTTPException
-
 from domain.image_generate_request import ImageGenerateRequest
 from model_services.device_worker import device_worker
 from model_services.base_model import BaseModel
@@ -43,7 +41,7 @@ class SDXLService(BaseModel):
     def checkIsModelReady(self):
         return self.scheduler.checkIsModelReady()
 
-    @log_execution_time("Workes creation")
+    @log_execution_time("Starting workers")
     def startWorkers(self):
         self.scheduler.startWorkers()
 

--- a/tt-metal-sdxl/tt_model_runners/base_device_runner.py
+++ b/tt-metal-sdxl/tt_model_runners/base_device_runner.py
@@ -5,15 +5,27 @@
 from abc import abstractmethod
 
 class DeviceRunner:
+    device_id: str = None
+
+    def __init__(self, device_id: str):
+        self.device_id = device_id
 
     @abstractmethod
     def load_model(self):
-        raise NotImplementedError()
+        pass
 
     @abstractmethod
     def runInference(self, prompt: str, num_inference_steps: int = 50):
-        raise NotImplementedError()
+        pass
 
     @abstractmethod
     def close_device(self):
-        raise NotImplementedError()
+        pass
+
+    @abstractmethod
+    def get_device(self):
+        pass
+
+    @abstractmethod
+    def get_devices(self):
+        pass

--- a/tt-metal-sdxl/tt_model_runners/mock_runner.py
+++ b/tt-metal-sdxl/tt_model_runners/mock_runner.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import time  # Add this import
+from config.settings import settings
+from tests.scripts.common import get_updated_device_params
+from tt_model_runners.base_device_runner import DeviceRunner
+from utils.logger import TTLogger
+
+class MockRunner(DeviceRunner):
+
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self.device_id = device_id
+        self.logger = TTLogger()
+        self.logger.info(f"MockRunner initialized for device {self.device_id}")
+
+    def close_device(self) -> bool:
+        self.logger.info("Closing device...")
+        time.sleep(5)  # Use time.sleep() instead of await asyncio.sleep()
+        return True
+
+    async def load_model(self) -> bool:
+        self.logger.info("Loading model...")
+        time.sleep(10)  # Use time.sleep() instead of await asyncio.sleep()
+        self.logger.info(f"Model loaded successfully on device {self.device_id}")
+        time.sleep(30)  # Use time.sleep() instead of await asyncio.sleep()
+        self.logger.info(f"Model warmup completed on device {self.device_id}")
+        return True
+
+    def get_device(self, device_id: int): 
+        self.logger.info(f"Getting device {device_id or self.device_id}")
+        return {"device_id": device_id or "MockDevice"}
+
+    def get_devices(self):
+        self.logger.info("Getting all devices")
+        return [self.get_device() for _ in range(settings.mock_devices_count)]
+
+    def runInference(self, prompt: str, num_inference_steps: int = 50):
+        self.logger.info(f"Running inference for prompt: {prompt} with {num_inference_steps} steps")
+        time.sleep(2 * num_inference_steps + 10)  # Use time.sleep() instead of await asyncio.sleep()
+        self.logger.info("Starting ttnn inference... on device: " + str(self.device_id))
+        return None

--- a/tt-metal-sdxl/tt_model_runners/runner_fabric.py
+++ b/tt-metal-sdxl/tt_model_runners/runner_fabric.py
@@ -5,12 +5,19 @@
 
 from config.settings import settings
 from tt_model_runners.base_device_runner import DeviceRunner
+from tt_model_runners.mock_runner import MockRunner
 
 
-def get_device_runner() -> DeviceRunner:
+def get_device_runner(worker_id: str) -> DeviceRunner:
         model_runner = settings.model_runner
         if model_runner == "tt-sdxl":
             from tt_model_runners.sdxl_runner import TTSDXLRunner
-            return TTSDXLRunner()
+            return TTSDXLRunner(worker_id)
+        elif model_runner == "tt-sd3.5":
+            from tt_model_runners.sd35_runner import TTSD35Runner
+            return TTSD35Runner(worker_id)
+        elif model_runner == "mock":
+            from tt_model_runners.mock_runner import MockRunner
+            return MockRunner(worker_id)
         else:
             raise ValueError(f"Unsupported model runner: {model_runner}")

--- a/tt-metal-sdxl/tt_model_runners/sd35_runner.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_runner.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import asyncio
+from pathlib import Path
+from typing import List
+
+from sklearn import utils
+from config.settings import settings
+from tests.scripts.common import get_updated_device_params
+from tt_model_runners.base_device_runner import DeviceRunner
+from tt_model_runners.sd35_utils.sd_35_pipeline import TtStableDiffusion3Pipeline
+from utils.logger import TTLogger
+import ttnn
+import torch
+from models.experimental.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
+from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
+from models.experimental.stable_diffusion_xl_base.tt.tt_euler_discrete_scheduler import TtEulerDiscreteScheduler
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.utility_functions import profiler
+
+class   TTSD35Runner(DeviceRunner):
+    device = None
+    batch_size = 0
+    tt_unet = None
+    tt_scheduler = None
+    ttnn_prompt_embeds = None
+    ttnn_time_ids = None
+    ttnn_text_embeds = None
+    ttnn_timesteps = []
+    extra_step_kwargs = None
+    scaling_factor = None
+    tt_vae = None
+    pipeline = None
+    latents = None
+
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self.logger = TTLogger()
+
+    def _set_fabric(self,fabric_config):
+        # If fabric_config is not None, set it to fabric_config
+        if fabric_config:
+            ttnn.set_fabric_config(fabric_config)
+
+    def _reset_fabric(self, fabric_config):
+        if fabric_config:
+            ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+    def get_device(self):
+        # for now use all availalbe devices
+        return self._mesh_device()
+
+    def _mesh_device(self):
+        device_params = {'l1_small_size': 57344}
+        device_ids = ttnn.get_device_ids()
+
+        param = len(device_ids)  # Default to using all available devices
+
+        if isinstance(param, tuple):
+            grid_dims = param
+            assert len(grid_dims) == 2, "Device mesh grid shape should have exactly two elements."
+            num_devices_requested = grid_dims[0] * grid_dims[1]
+            if num_devices_requested > len(device_ids):
+                print("Requested more devices than available. Test not applicable for machine")
+            mesh_shape = ttnn.MeshShape(*grid_dims)
+            assert num_devices_requested <= len(device_ids), "Requested more devices than available."
+        else:
+            num_devices_requested = min(param, len(device_ids))
+            mesh_shape = ttnn.MeshShape(1, num_devices_requested)
+
+
+        updated_device_params = get_updated_device_params(device_params)
+        fabric_config = updated_device_params.pop("fabric_config", None)
+        self._set_fabric(fabric_config)
+        mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, **updated_device_params)
+
+        self.logger.info(f"multidevice with {mesh_device.get_num_devices()} devices is created")
+        return mesh_device
+
+    def get_devices(self) -> List[ttnn.MeshDevice]:
+        device = self._mesh_device()
+        device_shape = settings.device_mesh_shape
+        return device.create_submeshes(ttnn.MeshShape(*device_shape))
+
+    def close_device(self) -> bool:
+        for submesh in self.mesh_device.get_submeshes():
+            ttnn.close_mesh_device(submesh)
+        ttnn.close_mesh_device(self.mesh_device)
+
+    async def load_model(self, device)->bool:
+        self.logger.info("Loading model...")
+        if (device is None):
+            self.ttnn_device = self._mesh_device()
+        else:
+            self.ttnn_device = device
+
+        # TODO chang this
+        model_version = "large"
+        guidance_scale = 5.0
+
+        if guidance_scale > 1:
+            guidance_cond = 2
+        else:
+            guidance_cond = 1
+
+        # 1. Load components
+        # TODO check how to point to a model file
+        self.pipeline = TtStableDiffusion3Pipeline(
+            checkpoint_name=f"stabilityai/stable-diffusion-3.5-{model_version}",
+            device=self.ttnn_device,
+            enable_t5_text_encoder=self.ttnn_device.get_num_devices() >= 4,
+            vae_cpu_fallback=True,
+            guidance_cond=guidance_cond,
+        )
+
+        self.pipeline.prepare(
+            width=1024,
+            height=1024,
+            guidance_scale=guidance_scale,
+            prompt_sequence_length=333,
+            spatial_sequence_length=4096,
+        )
+
+        self.logger.info("Model weights downloaded successfully")
+
+        self.logger.info("Model loaded successfully")
+
+        self.runInference("Sunrise on a beach", 20)
+
+        self.logger.info("Model warmup completed")
+
+        return True
+
+    def runInference(self, prompt: str, num_inference_steps: int = 50):
+        prompts = [prompt]
+
+        torch.manual_seed(0)
+
+        if isinstance(prompts, str):
+            prompts = [prompts]
+        
+        negative_prompt = "bad quality, low resolution, blurry, dark, noisy, bad lighting, bad composition"
+
+        images = self.pipeline(
+            prompt_1=[prompts[0]],
+            prompt_2=[prompt[0]],
+            prompt_3=[prompt[0]],
+            negative_prompt_1=[negative_prompt],
+            negative_prompt_2=[negative_prompt],
+            negative_prompt_3=[negative_prompt],
+            num_inference_steps=num_inference_steps,
+            seed=0,
+        )
+
+        return images

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/attention.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/attention.py
@@ -1,0 +1,325 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import ttnn
+
+from .linear import TtLinear, TtLinearParameters
+from .normalization import TtRmsNorm, TtRmsNormParameters
+from .substate import has_substate, substate
+from .utils import all_gather
+
+
+@dataclass
+class TtAttentionPartParameters:
+    qkv_proj: TtLinearParameters
+    norm_q: TtRmsNormParameters
+    norm_k: TtRmsNormParameters
+    out_proj: TtLinearParameters | None
+
+
+@dataclass
+class TtAttentionParameters:
+    spatial: TtAttentionPartParameters
+    prompt: TtAttentionPartParameters | None
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        num_heads: int,
+        unpadded_num_heads: int,
+        hidden_dim_padding: int,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+    ) -> TtAttentionParameters:
+        spatial_qkv_proj = _merge_qkv_proj(substate(state, "to_q"), substate(state, "to_k"), substate(state, "to_v"))
+        prompt_qkv_proj = _merge_qkv_proj(
+            substate(state, "add_q_proj"), substate(state, "add_k_proj"), substate(state, "add_v_proj")
+        )
+        n_local_heads = num_heads // device.get_num_devices()
+        return cls(
+            spatial=TtAttentionPartParameters(
+                qkv_proj=TtLinearParameters.from_torch_col_parallel(
+                    state=spatial_qkv_proj,
+                    n_local_heads=n_local_heads,
+                    unpadded_num_heads=unpadded_num_heads,
+                    hidden_dim_padding=hidden_dim_padding,
+                    dtype=dtype,
+                    device=device,
+                ),
+                norm_q=TtRmsNormParameters.from_torch(substate(state, "norm_q"), dtype=dtype, device=device),
+                norm_k=TtRmsNormParameters.from_torch(substate(state, "norm_k"), dtype=dtype, device=device),
+                out_proj=TtLinearParameters.from_torch(
+                    substate(state, "to_out.0"), dtype=dtype, device=device, shard_dim=-1
+                ),
+            ),
+            prompt=TtAttentionPartParameters(
+                qkv_proj=TtLinearParameters.from_torch_col_parallel(
+                    state=prompt_qkv_proj,
+                    n_local_heads=n_local_heads,
+                    unpadded_num_heads=unpadded_num_heads,
+                    hidden_dim_padding=hidden_dim_padding,
+                    dtype=dtype,
+                    device=device,
+                ),
+                norm_q=TtRmsNormParameters.from_torch(substate(state, "norm_added_q"), dtype=dtype, device=device),
+                norm_k=TtRmsNormParameters.from_torch(substate(state, "norm_added_k"), dtype=dtype, device=device),
+                out_proj=TtLinearParameters.from_torch(
+                    substate(state, "to_add_out"), dtype=dtype, device=device, shard_dim=-1
+                )
+                if has_substate(state, "to_add_out")
+                else None,
+            )
+            if has_substate(state, "add_q_proj")
+            else None,
+        )
+
+
+class TtAttentionPart:
+    def __init__(self, parameters: TtAttentionPartParameters, device: ttnn.MeshDevice) -> None:
+        super().__init__()
+
+        eps = 1e-6
+
+        self._device = device
+        self._qkv_proj = TtLinear(parameters.qkv_proj)
+        self._out_proj = TtLinear(parameters.out_proj) if parameters.out_proj is not None else None
+        self._norm_q = TtRmsNorm(parameters.norm_q, eps=eps)
+        self._norm_k = TtRmsNorm(parameters.norm_k, eps=eps)
+
+    def qkv(self, x: ttnn.Tensor, *, num_heads: int, deallocate: bool) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+        # tracy.signpost("enter TtAttentionPart")
+
+        _batch_size, sequence_length, _embedding_dim = x.shape
+
+        # Input sharding
+        if sequence_length > 1024:
+            # sharding leads to worse PCC, so disable it until further investigation
+            mm_a_x = 8
+            mm_a_y = 8
+            mm_a_x_memory_config = ttnn.DRAM_MEMORY_CONFIG
+        elif sequence_length >= 512:
+            mm_a_y = 8
+            mm_a_x = 8
+            # mm_a_x_strategy = ttnn.ShardStrategy.BLOCK
+            mm_a_x_memory_config = ttnn.DRAM_MEMORY_CONFIG
+            # x = to_memory_config(
+            #     x,
+            #     memory_config=ttnn.create_sharded_memory_config(
+            #         x.shape,
+            #         core_grid=ttnn.CoreGrid(y=mm_a_y, x=mm_a_x),
+            #         strategy=mm_a_x_strategy,
+            #         orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            #     ),
+            #     deallocate=deallocate,
+            # )
+            deallocate = True
+        else:
+            mm_a_x = 8
+            mm_a_y = 6
+            mm_a_x_memory_config = ttnn.DRAM_MEMORY_CONFIG
+
+        qkv = self._qkv_proj(
+            x,
+            memory_config=mm_a_x_memory_config,
+            core_grid=ttnn.CoreGrid(y=mm_a_y, x=mm_a_x),
+            dtype=ttnn.bfloat16,
+            deallocate=deallocate,
+        )
+
+        #        qkv = ttnn.reallocate(qkv)
+        #        qkv = to_memory_config(qkv, ttnn.DRAM_MEMORY_CONFIG, deallocate=True)
+
+        num_local_heads = num_heads // self._device.get_num_devices()
+        q, k, v = ttnn.transformer.split_query_key_value_and_split_heads(
+            qkv, num_heads=num_local_heads, transpose_key=False
+        )
+
+        ttnn.deallocate(qkv)
+
+        q = self._norm_q(q, deallocate=True)
+        k = self._norm_k(k, deallocate=True)
+
+        # q = to_memory_config(q, ttnn.DRAM_MEMORY_CONFIG, deallocate=True)
+        # k = to_memory_config(k, ttnn.DRAM_MEMORY_CONFIG, deallocate=True)
+        # v = to_memory_config(v, ttnn.DRAM_MEMORY_CONFIG, deallocate=True)
+
+        # tracy.signpost("exit TtAttentionPart")
+
+        return q, k, v
+
+    def out_proj(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        if self._out_proj is None:
+            return x
+
+        # Input sharding
+        """
+        if x.shape[-2] >= 512:
+            mm_a_y = 8
+            mm_a_x = 8
+            mm_a_x_strategy = ttnn.ShardStrategy.BLOCK
+            mm_a_x_memory_config = ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
+            x = ttnn.to_memory_config(
+                x,
+                memory_config=ttnn.create_sharded_memory_config(
+                    x.shape,
+                    core_grid=ttnn.CoreGrid(y=mm_a_y, x=mm_a_x),
+                    strategy=mm_a_x_strategy,
+                    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+                dtype=ttnn.bfloat8_b,
+            )
+        else:
+            mm_a_x = 8
+            mm_a_y = 6
+            mm_a_x_memory_config = ttnn.L1_MEMORY_CONFIG
+
+        return self._out_proj(
+                             x,
+                             memory_config=mm_a_x_memory_config,
+                             core_grid=ttnn.CoreGrid(y=mm_a_y, x=mm_a_x),
+                             dtype=ttnn.bfloat8_b,
+                             )
+        """
+
+        grid_size = x.device().compute_with_storage_grid_size()
+        core_grid = ttnn.CoreGrid(x=grid_size.x, y=grid_size.y)
+        result = self._out_proj(x, core_grid=core_grid)
+
+        # return to_memory_config(result, memory_config=ttnn.DRAM_MEMORY_CONFIG, dtype=ttnn.bfloat16, deallocate=True)
+        return result
+
+
+class TtAttention:
+    def __init__(self, parameters: TtAttentionParameters, *, num_heads: int, device) -> None:
+        super().__init__()
+
+        self._device = device
+        self._num_heads = num_heads
+
+        self._spatial_attn = TtAttentionPart(parameters.spatial, device=self._device)
+        self._prompt_attn = (
+            TtAttentionPart(parameters.prompt, device=self._device) if parameters.prompt is not None else None
+        )
+
+    def __call__(
+        self,
+        *,
+        spatial: ttnn.Tensor,
+        prompt: ttnn.Tensor | None = None,
+        deallocate: bool = False,
+        N: int,
+        L: int,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor | None]:
+        """
+        spatial: N ⊗ S1 ⊗ (H * E1)
+        prompt: N ⊗ S2 ⊗ (H * E2)
+        """
+        device = spatial.device()
+
+        spatial = ttnn.squeeze(spatial, 1)
+        prompt = ttnn.squeeze(prompt, 1)
+
+        # tracy.signpost("enter TtAttention")
+
+        q, k, v = self._spatial_attn.qkv(spatial, num_heads=self._num_heads, deallocate=deallocate)
+
+        program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+            q_chunk_size=768,
+            k_chunk_size=256,
+            exp_approx_mode=False,  # NOTE: False is more correct
+        )
+
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+
+        if prompt is None:
+            # operands must be in DRAM
+            attn = ttnn.transformer.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                is_causal=False,
+                program_config=program_config,
+                compute_kernel_config=compute_kernel_config,
+            )
+            ttnn.deallocate(q)
+            ttnn.deallocate(k)
+            ttnn.deallocate(v)
+
+            # attn = ttnn.to_memory_config(attn, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+            concatenated_attn = ttnn.transformer.concatenate_heads(
+                attn,
+                # memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+            )
+            ttnn.deallocate(attn)
+
+            spatial = self._spatial_attn.out_proj(concatenated_attn)
+
+            spatial = ttnn.unsqueeze(spatial, 1)
+            return spatial, None
+
+        assert self._prompt_attn is not None
+
+        q2, k2, v2 = self._prompt_attn.qkv(prompt, num_heads=self._num_heads, deallocate=deallocate)
+
+        spatial, prompt = ttnn.transformer.joint_scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            q2,
+            k2,
+            v2,
+            joint_strategy="rear",
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+        # spatial = ttnn.to_memory_config(spatial, memory_config=ttnn.L1_MEMORY_CONFIG)
+        # prompt = ttnn.to_memory_config(prompt, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+        spatial = ttnn.transformer.concatenate_heads(
+            spatial,
+            # memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+        )
+        prompt = ttnn.transformer.concatenate_heads(
+            prompt,
+            # memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+        )
+
+        spatial = ttnn.unsqueeze(spatial, 1)
+        prompt = ttnn.unsqueeze(prompt, 1)
+
+        if self._device.get_num_devices() > 1:
+            spatial = all_gather(spatial, dim=-1)
+            prompt = all_gather(prompt, dim=-1)
+
+        spatial = self._spatial_attn.out_proj(spatial)
+        prompt = self._prompt_attn.out_proj(prompt)
+
+        # tracy.signpost("exit TtAttention")
+        return spatial, prompt
+
+
+def _merge_qkv_proj(
+    q_state: dict[str, torch.Tensor],
+    k_state: dict[str, torch.Tensor],
+    v_state: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    return {
+        "weight": torch.cat([q_state["weight"], k_state["weight"], v_state["weight"]]) if "weight" in q_state else None,
+        "bias": torch.cat([q_state["bias"], k_state["bias"], v_state["bias"]]) if "bias" in q_state else None,
+    }

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/conv2d.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/conv2d.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import ttnn
+
+from .utils import from_torch_fast
+
+if TYPE_CHECKING:
+    import torch
+
+SLICE_COUNT_FACTOR = {
+    (16, 512, 128 * 128): 1024 // 2,
+    (20, 32, 128 * 256): 1024 // 16,
+    (32, 32, 64 * 64): 1024 // 128,
+    (128, 3, 256 * 256): 1024 * 4,  # hangs with lower slice_count
+    (128, 3, 512 * 512): 1024 * 16,  # hangs with lower slice_count
+    (128, 3, 1024 * 1024): 1024 * 64,  # hangs with lower slice_count
+    (128, 128, 512 * 512): 1024 * 4,
+    (128, 128, 1024 * 1024): 1024 * 16,
+    (256, 128, 256 * 256): 1024 * 2,
+    (256, 128, 512 * 512): 1024 * 8,
+    (256, 128, 1024 * 1024): 1024 * 32,
+    (256, 256, 512 * 512): 1024 * 8,
+    (256, 256, 1024 * 1024): 1024 * 32,
+    (512, 256, 256 * 256): 1024 * 4,
+    (512, 256, 512 * 512): 1024 * 16,
+    (512, 512, 128 * 128): 1024 // 2,
+    (512, 512, 256 * 256): 1024 * 2,
+    (512, 512, 512 * 512): 1024 * 8,
+}
+
+
+@dataclass
+class TtConv2dParameters:
+    weight: ttnn.Tensor
+    bias: ttnn.Tensor | None
+    device: ttnn.MeshDevice
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        device: ttnn.MeshDevice,
+        dtype: ttnn.DataType | None = None,
+    ) -> TtConv2dParameters:
+        mesh_mapper = ttnn.ReplicateTensorToMesh(device) if isinstance(device, ttnn.MeshDevice) else None
+
+        return cls(
+            weight=from_torch_fast(state["weight"], dtype=dtype, mesh_mapper=mesh_mapper),
+            bias=from_torch_fast(state["bias"].reshape((1, 1, 1, -1)), dtype=dtype, mesh_mapper=mesh_mapper)
+            if "bias" in state
+            else None,
+            device=device,
+        )
+
+    @property
+    def in_channels(self) -> int:
+        return self.weight.shape[1]
+
+    @property
+    def out_channels(self) -> int:
+        return self.weight.shape[0]
+
+    @property
+    def kernel_size(self) -> tuple[int, int]:
+        return self.weight.shape[-2], self.weight.shape[-1]
+
+
+class TtConv2d:
+    """
+    Limitations of DRAM slicing (slice_count > 1), taken from https://github.com/tenstorrent/tt-metal/pull/19686:
+    - Only works with activations of dtype BFloat16.
+    - No logic to check if preprocessed weights can be safely reused. This is okay if all slices are
+      approximately the same size.
+    - Slice output is interleaved. This needs an additional interleaved to sharded op.
+    - Doesn't support prepared weights.
+    """
+
+    def __init__(
+        self,
+        parameters: TtConv2dParameters,
+        *,
+        stride: tuple[int, int] = (1, 1),
+        padding: tuple[int, int] = (0, 0),
+    ) -> None:
+        self._stride = stride
+        self._padding = padding
+
+        self._in_channels = parameters.in_channels
+        self._out_channels = parameters.out_channels
+        self._kernel_size = parameters.kernel_size
+
+        self._weight = parameters.weight
+        self._bias = parameters.bias
+        self._device = parameters.device
+
+    def call_without_reshape(
+        self,
+        x: ttnn.Tensor,
+        *,
+        conv_config: ttnn.Conv2dConfig | None = None,
+        memory_config: ttnn.MemoryConfig | None = None,
+    ) -> tuple[ttnn.Tensor, list[int]]:
+        (batch_size, height, width, _) = x.shape
+
+        k = SLICE_COUNT_FACTOR.get((self._in_channels, self._out_channels, height * width), 1)
+        slice_count = -(-k * batch_size // 1024)
+
+        if slice_count > 1:
+            x = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
+
+        def call_conv2d(t: ttnn.Tensor, w: ttnn.Tensor, b: ttnn.Tensor | None) -> _Conv2dRawResult:
+            output, [output_height, output_width], [prepared_weight, prepared_bias] = ttnn.conv2d(
+                input_tensor=t,
+                weight_tensor=w,
+                bias_tensor=b,
+                in_channels=self._in_channels,
+                out_channels=self._out_channels,
+                device=t.device(),
+                kernel_size=self._kernel_size,
+                stride=self._stride,
+                padding=self._padding,
+                batch_size=batch_size,
+                input_height=height,
+                input_width=width,
+                return_output_dim=True,
+                return_weights_and_bias=True,
+                conv_config=conv_config,
+                memory_config=memory_config,
+                slice_config=(
+                    ttnn.Conv2dSliceConfig(slice_type=ttnn.Conv2dSliceWidth, num_slices=slice_count)
+                    if slice_count > 1
+                    else None
+                ),
+                dtype=ttnn.bfloat16,
+            )
+
+            return _Conv2dRawResult(
+                output=output,
+                output_height=output_height,
+                output_width=output_width,
+                prepared_weight=prepared_weight,
+                prepared_bias=prepared_bias,
+            )
+
+        results = call_conv2d(x, self._weight, self._bias)
+
+        x = results.output
+        self._weight = results.prepared_weight
+        self._bias = results.prepared_bias
+
+        if slice_count > 1:
+            x = ttnn.to_layout(x, ttnn.TILE_LAYOUT)
+
+        shape = [batch_size, results.output_height, results.output_width, self._out_channels]
+        return x, shape
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        memory_config: ttnn.MemoryConfig | None = None,
+    ) -> ttnn.Tensor:
+        x, shape = self.call_without_reshape(x, memory_config=memory_config)
+        return x.reshape(shape)
+
+    @property
+    def in_channels(self) -> int:
+        return self._in_channels
+
+    @property
+    def out_channels(self) -> int:
+        return self._out_channels
+
+    @property
+    def kernel_size(self) -> tuple[int, int]:
+        return self._kernel_size
+
+
+@dataclass
+class _Conv2dRawResult:
+    output: ttnn.Tensor
+    output_height: int
+    output_width: int
+    prepared_weight: ttnn.Tensor
+    prepared_bias: ttnn.Tensor | None

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/feed_forward.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/feed_forward.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import ttnn
+
+from .linear import TtLinear, TtLinearParameters
+from .substate import substate
+
+if TYPE_CHECKING:
+    import torch
+
+
+@dataclass
+class TtFeedForwardParameters:
+    in_proj: TtLinearParameters
+    out_proj: TtLinearParameters
+    distributed: bool
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.MeshDevice,
+    ) -> TtFeedForwardParameters:
+        return cls(
+            in_proj=TtLinearParameters.from_torch(
+                substate(state, "net.0.proj"), dtype=dtype, device=device, shard_dim=-1
+            ),
+            out_proj=TtLinearParameters.from_torch(substate(state, "net.2"), dtype=dtype, device=device, shard_dim=-2),
+            distributed=device.get_num_devices() > 1,
+        )
+
+
+class TtFeedForward:
+    def __init__(self, parameters: TtFeedForwardParameters) -> None:
+        super().__init__()
+
+        self.in_proj = TtLinear(parameters.in_proj)
+        self.out_proj = TtLinear(parameters.out_proj)
+        self._distributed = parameters.distributed
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        grid_size = x.device().compute_with_storage_grid_size()
+        core_grid = ttnn.CoreGrid(x=grid_size.x, y=grid_size.y)
+
+        x = self.in_proj(x, core_grid=core_grid, highest_quality=False)  # not enough L1 for highest quality
+        # Turning on fast_and_approximate_mode leads to big changes in the generated image.
+        # The image quality might still be okay.
+        x = ttnn.gelu(x, fast_and_approximate_mode=False)
+
+        result = self.out_proj(x, core_grid=core_grid)
+
+        if self._distributed:
+            result = ttnn.reduce_scatter(
+                result,
+                dim=-1,
+                math_op=ttnn.ReduceType.Sum,
+                num_links=1,
+                memory_config=ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+                topology=ttnn.Topology.Ring,
+            )
+
+        return result

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/group_norm.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/group_norm.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import ttnn
+from loguru import logger
+
+from .utils import from_torch_fast
+
+if TYPE_CHECKING:
+    import torch
+
+
+@dataclass
+class TtGroupNormParameters:
+    weight: torch.Tensor
+    bias: torch.Tensor
+    device: ttnn.Device
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        device: ttnn.Device,
+    ) -> TtGroupNormParameters:
+        return cls(
+            weight=state["weight"],
+            bias=state["bias"],
+            device=device,
+        )
+
+
+@dataclass
+class TtGroupNormPreparation:
+    batch_size: int
+    input_width: int
+    input_height: int
+    num_channels: int
+    weight: ttnn.Tensor
+    bias: ttnn.Tensor
+    mask: ttnn.Tensor
+    memory_config: ttnn.MemoryConfig
+    core_grid: ttnn.CoreGrid
+
+
+class TtGroupNorm:
+    def __init__(self, parameters: TtGroupNormParameters, *, eps: float, num_groups: int) -> None:
+        self._eps = eps
+        self._num_groups = num_groups
+        self._parameters = parameters
+        self._device = parameters.device
+        self._preparation = None
+
+    def _prepare(
+        self,
+        *,
+        batch_size: int,
+        input_width: int,
+        input_height: int,
+        num_channels: int,
+    ) -> TtGroupNormPreparation:
+        if self._preparation is not None:
+            if (
+                self._preparation.batch_size == batch_size
+                and self._preparation.input_width == input_width
+                and self._preparation.input_height == input_height
+                and self._preparation.num_channels == num_channels
+            ):
+                return self._preparation
+            logger.warning("shape of group norm input changed")
+
+        num_groups = self._num_groups
+
+        k_device = 256 * self._device.core_grid.x * self._device.core_grid.y
+        self._inplace = input_width * input_height <= k_device  # a heuristic
+
+        if self._inplace:
+            (
+                memory_config,
+                core_grid,
+            ) = ttnn.determine_expected_group_norm_sharded_config_and_grid_size(
+                device=self._device,
+                num_channels=num_channels,
+                num_groups=num_groups,
+                input_nhw=batch_size * input_height * input_width,
+                is_height_sharded=False,
+            )
+            self._num_out_blocks = 1
+
+            # if input_memory_config.memory_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
+            #     grid_y = self.group_norm_core_grid.y
+            # elif input_memory_config.memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
+            #     grid_y = 1
+            # else:
+            #     grid_y = int(self.group_norm_core_grid.x * self.group_norm_core_grid.y)
+        else:
+            # https://github.com/tenstorrent/tt-metal/issues/22149#issuecomment-2884093864
+            h = num_channels // num_groups * num_groups
+            assert h % 32 == 0
+            grid_y = self._device.core_grid.y
+            while h // grid_y % 32 != 0:
+                grid_y -= 1
+
+            core_grid = ttnn.CoreGrid(x=self._device.core_grid.x, y=grid_y)
+            k_grid = 256 * core_grid.x * core_grid.y
+            self._num_out_blocks = -(-input_width * input_height // k_grid)  # a heuristic
+            memory_config = ttnn.DRAM_MEMORY_CONFIG
+
+        torch_weight = ttnn.create_group_norm_weight_bias_rm(
+            self._parameters.weight,
+            num_channels,
+            core_grid.y,
+        )
+        torch_bias = ttnn.create_group_norm_weight_bias_rm(
+            self._parameters.bias,
+            num_channels,
+            core_grid.y,
+        )
+        torch_mask = ttnn.create_group_norm_input_mask(
+            num_channels,
+            num_groups,
+            core_grid.y,
+        )
+
+        self._preparation = TtGroupNormPreparation(
+            batch_size=batch_size,
+            input_width=input_width,
+            input_height=input_height,
+            num_channels=num_channels,
+            weight=from_torch_fast(
+                torch_weight,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=self._device,
+            ),
+            bias=from_torch_fast(
+                torch_bias,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=self._device,
+            ),
+            mask=from_torch_fast(
+                torch_mask,
+                dtype=ttnn.bfloat8_b,
+                layout=ttnn.TILE_LAYOUT,
+                device=self._device,
+            ),
+            memory_config=memory_config,
+            core_grid=core_grid,
+        )
+
+        return self._preparation
+
+    def __call__(self, x: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig | None = None) -> ttnn.Tensor:
+        [batch_size, height, width, channels] = list(x.shape)
+
+        prep = self._prepare(
+            batch_size=batch_size,
+            input_width=width,
+            input_height=height,
+            num_channels=channels,
+        )
+
+        x = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
+        x = x.reshape([batch_size, 1, width * height, channels])
+
+        if self._inplace:
+            x = ttnn.to_memory_config(x, prep.memory_config)
+            x = ttnn.reallocate(x)
+        else:
+            x = ttnn.tilize_with_zero_padding(x, use_multicore=True)
+
+        x = ttnn.group_norm(
+            x,
+            weight=prep.weight,
+            bias=prep.bias,
+            input_mask=prep.mask,
+            num_groups=self._num_groups,
+            epsilon=self._eps,
+            core_grid=prep.core_grid,
+            # memory_config=memory_config if memory_config is not None else prep.memory_config,
+            inplace=self._inplace,
+            num_out_blocks=self._num_out_blocks,
+        )
+
+        # to_layout does not work with block sharded tensors
+        if memory_config is None:
+            memory_config = ttnn.DRAM_MEMORY_CONFIG
+        x = ttnn.to_memory_config(x, memory_config)
+        x = ttnn.to_layout(x, ttnn.TILE_LAYOUT)
+
+        return x.reshape([batch_size, height, width, channels])

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/linear.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/linear.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+# if TYPE_CHECKING:
+import torch
+import ttnn
+
+from .utils import from_torch_fast
+
+
+@dataclass
+class TtLinearParameters:
+    weight: ttnn.Tensor
+    bias: ttnn.Tensor | None
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+        shard_dim: int = None,
+        unsqueeze_bias: bool = False,
+    ) -> TtLinearParameters:
+        if "bias" in state:
+            bias = state["bias"].unsqueeze(0)
+        else:
+            bias = None
+        weight = state["weight"]
+        if os.environ.get("MESH_DEVICE") == "T3K":
+            hidden_dim = 2432
+            hidden_dim_pad = 128
+            hidden_dim_new = 2560
+            weight_h, weight_w = weight.shape
+            weight_h_mult = weight_h // hidden_dim
+            weight_w_mult = weight_w // hidden_dim
+            if weight_h % hidden_dim == 0:
+                if weight_h_mult == 1:
+                    weight = torch.nn.functional.pad(weight, pad=(0, 0, 0, hidden_dim_pad), mode="constant", value=0)
+                elif weight_h_mult > 1:
+                    weight = weight.reshape(weight_h_mult, hidden_dim, weight_w)
+                    weight = torch.nn.functional.pad(weight, pad=(0, 0, 0, hidden_dim_pad), mode="constant", value=0)
+                    weight = weight.reshape(weight_h_mult * hidden_dim_new, weight_w)
+            weight_h, weight_w = weight.shape
+            if weight_w % hidden_dim == 0:
+                if weight_w_mult == 1:
+                    weight = torch.nn.functional.pad(weight, pad=(0, hidden_dim_pad), mode="constant", value=0)
+                elif weight_w_mult > 1:
+                    weight = weight.reshape(weight_h, weight_w_mult, hidden_dim)
+                    weight = torch.nn.functional.pad(weight, pad=(0, hidden_dim_pad), mode="constant", value=0)
+                    weight = weight.reshape(weight_h, weight_w_mult * hidden_dim_new)
+
+            if not bias == None:
+                bias_h, bias_w = bias.shape
+                bias_w_mult = bias_w // hidden_dim
+                if bias_w % hidden_dim == 0:
+                    if bias_w_mult == 1:
+                        bias = torch.nn.functional.pad(bias, pad=(0, hidden_dim_pad), mode="constant", value=0)
+                    elif bias_w_mult > 1:
+                        bias = bias.reshape(bias_h, bias_w_mult, hidden_dim)
+                        bias = torch.nn.functional.pad(bias, pad=(0, hidden_dim_pad), mode="constant", value=0)
+                        bias = bias.reshape(bias_h, bias_w_mult * hidden_dim_new)
+
+        if unsqueeze_bias:
+            # TODO: Once the issue is resolved, remove this workaround for https://github.com/tenstorrent/tt-metal/issues/16599
+            bias = bias.unsqueeze(0)
+
+        if shard_dim in [0, -2]:
+            # Shard the bias of a linear operation on the first dimension.
+            # A single device receive the bias as is, while the other ones receive zero tensors of the same
+            # shape so that the bias is not added multiple times after gathering.
+            mesh_height, mesh_width = device.shape
+            zeros = torch.zeros_like(bias)
+            bias = torch.cat([bias] + [zeros] * (mesh_width - 1), dim=0)
+            bias_mm = ttnn.ShardTensor2dMesh(device, mesh_shape=(mesh_height, mesh_width), dims=(None, 0))
+        elif shard_dim in [1, -1]:
+            bias_mm = ttnn.ShardTensorToMesh(device, 1)
+        else:
+            bias_mm = ttnn.ReplicateTensorToMesh(device)
+
+        return cls(
+            weight=from_torch_fast(
+                weight.transpose(0, 1),
+                dtype=dtype,
+                device=device,
+                shard_dim=shard_dim,
+                layout=ttnn.TILE_LAYOUT,
+            ),
+            bias=from_torch_fast(
+                bias,
+                dtype=dtype,
+                device=device,
+                mesh_mapper=bias_mm,
+                layout=ttnn.TILE_LAYOUT,
+            )
+            if bias is not None
+            else None,
+        )
+
+    @classmethod
+    def from_torch_col_parallel(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        n_local_heads: int,
+        unpadded_num_heads: int,
+        hidden_dim_padding: int,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+    ) -> TtLinearParameters:
+        if "bias" in state:
+            torch_bias = state["bias"].unsqueeze(0)
+        else:
+            torch_bias = None
+
+        weight = state["weight"]
+        torch_weight = weight.transpose(0, 1)
+
+        if os.environ.get("MESH_DEVICE") == "T3K":
+            head_size = torch_weight.shape[1] // 3 // unpadded_num_heads
+            head_padding = device.get_num_devices() - (unpadded_num_heads % device.get_num_devices())
+            weight_h, weight_w = torch_weight.shape
+
+            torch_weight = torch_weight.reshape(weight_h, 3, unpadded_num_heads, head_size)
+            torch_weight = torch.nn.functional.pad(
+                torch_weight, pad=(0, 0, 0, head_padding, 0, 0, 0, hidden_dim_padding), mode="constant", value=0
+            )
+            torch_weight = torch_weight.reshape(weight_h + hidden_dim_padding, -1)
+            if not torch_bias == None:
+                bias_h, bias_w = torch_bias.shape
+                torch_bias = torch_bias.reshape(bias_h, 3, unpadded_num_heads, head_size)
+                torch_bias = torch.nn.functional.pad(torch_bias, pad=(0, 0, 0, head_padding), mode="constant", value=0)
+                torch_bias = torch_bias.reshape(bias_h, -1)
+
+        def shuffle_heads(tensor):
+            # Given torch tensor with output features in the last dimension,
+            # shuffle heads to allow for column parallel computation
+            in_dim = tensor.shape[0]
+            tensor = tensor.reshape(in_dim, 3, device.get_num_devices(), n_local_heads, -1)  # [ID, 3, ND, NLH, DH]
+            tensor = tensor.permute(0, 2, 1, 3, 4)  # [ID, ND, 3, NLH, DH]
+            tensor = tensor.reshape(in_dim, -1)  # [ID, ND*3*NLH*DH]
+            return tensor
+
+        return cls(
+            weight=from_torch_fast(
+                shuffle_heads(torch_weight),
+                dtype=dtype,
+                device=device,
+                shard_dim=-1,
+                layout=ttnn.TILE_LAYOUT,
+            ),
+            bias=from_torch_fast(
+                shuffle_heads(torch_bias),
+                dtype=dtype,
+                device=device,
+                shard_dim=-1,
+                layout=ttnn.TILE_LAYOUT,
+            )
+            if torch_bias is not None
+            else None,
+        )
+
+    @classmethod
+    def from_torch_time_embed(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        num_chunks: int,
+        hidden_dim_padding: int,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+        unsqueeze_bias: bool = False,
+    ) -> TtLinearParameters:
+        if "bias" in state:
+            torch_bias = state["bias"].unsqueeze(0)
+        else:
+            torch_bias = None
+        weight = state["weight"]
+        torch_weight = weight.transpose(0, 1)
+
+        if os.environ.get("MESH_DEVICE") == "T3K":
+            weight_h, weight_w = torch_weight.shape
+            torch_weight = torch_weight.reshape(weight_h, num_chunks, -1)
+            torch_weight = torch.nn.functional.pad(
+                torch_weight, pad=(0, hidden_dim_padding, 0, 0, 0, hidden_dim_padding), mode="constant", value=0
+            )
+            torch_weight = torch_weight.reshape(weight_h + hidden_dim_padding, -1)
+
+            if not torch_bias == None:
+                bias_h, bias_w = torch_bias.shape
+                torch_bias = torch_bias.reshape(bias_h, num_chunks, -1)
+                torch_bias = torch.nn.functional.pad(torch_bias, pad=(0, hidden_dim_padding), mode="constant", value=0)
+                torch_bias = torch_bias.reshape(bias_h, -1)
+
+        def shuffle_chunks(tensor):
+            # Given torch tensor with output features in the last dimension,
+            # shuffle heads to allow for column parallel computation
+            in_dim = tensor.shape[0]
+            tensor = tensor.reshape(in_dim, num_chunks, device.get_num_devices(), -1)
+            tensor = tensor.permute(0, 2, 1, 3)
+            tensor = tensor.reshape(in_dim, -1)
+            return tensor
+
+        torch_weight = shuffle_chunks(torch_weight)
+        torch_bias = shuffle_chunks(torch_bias)
+
+        if unsqueeze_bias:
+            # TODO: Once the issue is resolved, remove this workaround for https://github.com/tenstorrent/tt-metal/issues/16599
+            torch_bias = torch_bias.unsqueeze(0)
+
+        return cls(
+            weight=from_torch_fast(
+                torch_weight,
+                dtype=dtype,
+                device=device,
+                shard_dim=-1,
+                layout=ttnn.TILE_LAYOUT,
+            ),
+            bias=from_torch_fast(
+                torch_bias,
+                dtype=dtype,
+                device=device,
+                shard_dim=-1,
+                layout=ttnn.TILE_LAYOUT,
+            )
+            if torch_bias is not None
+            else None,
+        )
+
+    @property
+    def in_channels(self) -> int:
+        return self.weight.shape[0]
+
+    @property
+    def out_channels(self) -> int:
+        return self.weight.shape[1]
+
+
+class TtLinear:
+    def __init__(self, parameters: TtLinearParameters) -> None:
+        self._in_channels = parameters.in_channels
+        self._weight = parameters.weight
+        self._bias = parameters.bias
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        *,
+        memory_config: ttnn.MemoryConfig | None = None,
+        program_config: ttnn.MatmulProgramConfig | None = None,
+        core_grid: ttnn.CoreGrid | None = None,
+        output_tile: list[int] | None = None,
+        dtype: ttnn.DataType | None = None,
+        activation: str | None = None,
+        deallocate: bool = False,
+        highest_quality: bool = True,
+    ) -> ttnn.Tensor:
+        msg = f"last value in input shape {list(x.shape)} should be equal to {self._in_channels}"
+        assert x.shape[-1] == self._in_channels, msg
+
+        weight = self._weight
+        bias = self._bias
+
+        # there is a correctness issue with tensors of shape Mx1x1xN, squeeze them to Mx1xN
+        squeeze = len(x.shape) == 4 and x.shape[1] == 1 and x.shape[2] == 1
+        if squeeze:
+            x = x.reshape([x.shape[0], 1, x.shape[-1]])
+
+        assert x.device() == weight.device()
+        if bias is not None:
+            assert x.device() == bias.device()
+
+        output = ttnn.linear(
+            x,
+            weight,
+            bias=bias,
+            memory_config=memory_config,
+            program_config=program_config,
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(
+                math_fidelity=ttnn.MathFidelity.HiFi4,
+                math_approx_mode=False,
+                fp32_dest_acc_en=True,
+                packer_l1_acc=True,
+            )
+            if highest_quality
+            else None,
+            core_grid=core_grid,
+            output_tile=output_tile,
+            dtype=dtype,
+            activation=activation,
+        )
+
+        if deallocate:
+            ttnn.deallocate(x)
+
+        if squeeze:
+            output = output.reshape([output.shape[0], 1, 1, output.shape[-1]])
+
+        return output

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/normalization.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/normalization.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import ttnn
+
+from . import utils
+from .utils import from_torch_fast
+
+
+@dataclass
+class TtRmsNormParameters:
+    weight: ttnn.Tensor
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+    ) -> TtRmsNormParameters:
+        return cls(
+            weight=from_torch_fast(state["weight"].unsqueeze(0), layout=ttnn.TILE_LAYOUT, dtype=dtype, device=device)
+        )
+
+
+class TtRmsNorm:
+    def __init__(self, parameters: TtRmsNormParameters, *, eps: float) -> None:
+        super().__init__()
+
+        self._eps = eps
+        self._weight = parameters.weight
+
+    def __call__(self, x: ttnn.Tensor, *, deallocate: bool = False) -> ttnn.Tensor:
+        output = ttnn.rms_norm(
+            x,
+            weight=self._weight,
+            epsilon=self._eps,
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(
+                math_fidelity=ttnn.MathFidelity.HiFi4,
+                math_approx_mode=False,
+                fp32_dest_acc_en=True,
+                packer_l1_acc=True,
+            ),
+        )
+
+        if deallocate:
+            ttnn.deallocate(x)
+
+        return output
+
+
+@dataclass
+class TtLayerNormParameters:
+    device: ttnn.MeshDevice
+    weight: ttnn.Tensor | None = None
+    bias: ttnn.Tensor | None = None
+    distributed: bool = False
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.MeshDevice,
+        distributed: bool = True,
+        weight_shape: list[int] | None = None,
+    ) -> TtLayerNormParameters:
+        _, mesh_width = device.shape
+        distributed = distributed and mesh_width > 1
+
+        weight = state.get("weight")
+        bias = state.get("bias")
+
+        if distributed:
+            # ttnn.layer_norm_post_all_gather currently requires weight and bias
+            if weight is None:
+                assert weight_shape is not None, "weight_shape is required when weight is missing"
+                weight = torch.ones(weight_shape)
+            if bias is None:
+                bias = torch.zeros_like(weight)
+
+            h = 32 * mesh_width
+            _, mesh_width = device.shape
+            weight = weight.reshape([-1, h])
+            bias = bias.reshape([-1, h])
+
+        mesh_mapper = ttnn.ShardTensor2dMesh(device, tuple(device.shape), (None, -1)) if distributed else None
+        layout = ttnn.ROW_MAJOR_LAYOUT if distributed else ttnn.TILE_LAYOUT
+        if distributed and dtype != ttnn.float32:
+            dtype = ttnn.bfloat16
+
+        return cls(
+            weight=from_torch_fast(
+                weight,
+                layout=layout,
+                dtype=dtype,
+                device=device,
+                mesh_mapper=mesh_mapper,
+            )
+            if weight is not None
+            else None,
+            bias=from_torch_fast(
+                bias,
+                layout=layout,
+                dtype=dtype,
+                device=device,
+                mesh_mapper=mesh_mapper,
+            )
+            if bias is not None
+            else None,
+            distributed=distributed,
+            device=device,
+        )
+
+
+class TtLayerNorm:
+    def __init__(self, parameters: TtLayerNormParameters, *, eps: float) -> None:
+        super().__init__()
+
+        self._eps = eps
+        self._distributed = parameters.distributed
+        self._weight = parameters.weight
+        self._bias = parameters.bias
+        self._device = parameters.device
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        memory_config: ttnn.MemoryConfig | None = None,
+        program_config: ttnn.ProgramConfig | None = None,
+    ) -> ttnn.Tensor:
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+
+        if not self._distributed:
+            return ttnn.layer_norm(
+                x,
+                weight=self._weight,
+                bias=self._bias,
+                epsilon=self._eps,
+                memory_config=memory_config,
+                program_config=program_config,
+                compute_kernel_config=compute_kernel_config,
+            )
+
+        rank = len(x.shape)
+        if rank < 4:
+            shape = [1] * (4 - rank) + list(x.shape)
+            x = ttnn.reshape(x, shape)
+
+        stats = ttnn.layer_norm_pre_all_gather(
+            x,
+            compute_kernel_config=compute_kernel_config,
+            dtype=ttnn.bfloat16,
+        )
+
+        stats = utils.all_gather(
+            stats,
+            dim=-1,
+            mesh_device=self._device,
+            # all_gather currently requires linear topology when specifying a cluster axis
+            topology=ttnn.Topology.Linear,
+        )
+
+        x = ttnn.layer_norm_post_all_gather(
+            x,
+            stats,
+            weight=self._weight,
+            bias=self._bias,
+            epsilon=self._eps,
+            memory_config=memory_config,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+        if rank < 4:
+            shape = list(x.shape)[4 - rank :]
+            x = ttnn.reshape(x, shape)
+
+        return x

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/patch_embedding.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/patch_embedding.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+
+import torch
+import ttnn
+
+from .patch_embedding_conv2d import TtPatchEmbeddingConv2d, TtPatchEmbeddingConv2dParameters
+from .substate import substate
+from .utils import from_torch_fast
+
+
+@dataclass
+class TtPatchEmbedParameters:
+    proj: TtPatchEmbeddingConv2dParameters
+    pos_embed: ttnn.Tensor
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        device: ttnn.Device,
+        hidden_dim_padding: int,
+        out_channels: int,
+    ) -> TtPatchEmbedParameters:
+        pos_embed_param = state["pos_embed"]
+        if os.environ.get("MESH_DEVICE") == "T3K":
+            pos_embed_param = torch.nn.functional.pad(
+                pos_embed_param, pad=(0, hidden_dim_padding), mode="constant", value=0
+            )
+
+        return cls(
+            proj=TtPatchEmbeddingConv2dParameters.from_torch(
+                substate(state, "proj"),
+                dtype=ttnn.bfloat16,
+                hidden_dim_padding=hidden_dim_padding,
+                out_channels=out_channels,
+                device=device,
+            ),
+            pos_embed=from_torch_fast(
+                pos_embed_param, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, shard_dim=-1
+            ),
+        )
+
+    @property
+    def pos_embed_max_size(self) -> int:
+        return math.isqrt(self.pos_embed.shape[1])
+
+
+class TtPatchEmbed:
+    def __init__(self, parameters: TtPatchEmbedParameters, mesh_device) -> None:
+        super().__init__()
+
+        self._pos_embed_max_size = parameters.pos_embed_max_size
+        self._proj = TtPatchEmbeddingConv2d(parameters.proj, device=mesh_device)
+        self._pos_embed = parameters.pos_embed
+        self._patch_size = 2
+
+    def __call__(self, latent: ttnn.Tensor) -> ttnn.Tensor:
+        batch_size_, in_height, in_width, c_ = latent.shape
+        out_height = in_height // self._patch_size
+        out_width = in_width // self._patch_size
+
+        latent = self._proj(latent)
+        latent = ttnn.reshape(latent, (batch_size_, out_height * out_width, -1))
+        pos_embed = self._cropped_pos_embed(out_height, out_width)
+        return latent + pos_embed
+
+    @property
+    def patch_size(self) -> int:
+        return self._patch_size
+
+    def _cropped_pos_embed(self, height: int, width: int) -> ttnn.Tensor:
+        top = (self._pos_embed_max_size - height) // 2
+        left = (self._pos_embed_max_size - width) // 2
+
+        spatial_pos_embed = self._pos_embed.reshape([1, self._pos_embed_max_size, self._pos_embed_max_size, -1])
+        spatial_pos_embed = spatial_pos_embed[:, top : top + height, left : left + width, :]
+        return spatial_pos_embed.reshape([1, -1, spatial_pos_embed.shape[-1]])

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/patch_embedding_conv2d.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/patch_embedding_conv2d.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from .conv2d import TtConv2dParameters
+
+import torch
+import ttnn
+
+from .utils import from_torch_fast
+
+
+@dataclass
+class TtPatchEmbeddingConv2dParameters:
+    weight: ttnn.Tensor
+    bias: ttnn.Tensor | None
+    out_channels: int
+    kernel_size: tuple[int, int]
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        hidden_dim_padding: int,
+        out_channels: int,
+        device,
+    ) -> TtConv2dParameters:
+        weight = state["weight"]
+        out_channels, in_c, kh, kw = weight.shape
+        weight = torch.permute(weight, (2, 3, 1, 0))
+        weight = torch.reshape(weight, (kh * kw * in_c, out_channels))
+
+        if "bias" in state:
+            bias = state["bias"].unsqueeze(0)
+        else:
+            bias = None
+
+        if os.environ.get("MESH_DEVICE") == "T3K":
+            weight = torch.nn.functional.pad(weight, pad=(0, hidden_dim_padding), mode="constant", value=0)
+            if not bias == None:
+                bias = torch.nn.functional.pad(bias, pad=(0, hidden_dim_padding), mode="constant", value=0)
+
+        return cls(
+            weight=from_torch_fast(
+                weight,
+                dtype=dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                shard_dim=-1,
+            ),
+            bias=(
+                from_torch_fast(
+                    bias.reshape((1, 1, 1, -1)),
+                    dtype=dtype,
+                    layout=ttnn.TILE_LAYOUT,
+                    device=device,
+                    shard_dim=-1,
+                )
+                if "bias" in state
+                else None
+            ),
+            out_channels=out_channels,
+            kernel_size=(kh, kw),
+        )
+
+
+class TtPatchEmbeddingConv2d:
+    def __init__(self, parameters: TtPatchEmbeddingConv2dParameters, device) -> None:
+        self._weight = parameters.weight
+        self._bias = parameters.bias
+        self._unfold = torch.nn.Unfold(kernel_size=parameters.kernel_size, stride=parameters.kernel_size)
+        self._device = device
+
+        self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        batch_size, img_h, img_w, img_c = x.shape  # permuted input NHWC
+        patch_size = 2
+        stride_h = patch_size
+        stride_w = 1
+        patches_h = img_h // patch_size
+        patches_w = img_w // patch_size
+
+        x = ttnn.reshape(x, (batch_size, patches_h, patch_size, patches_w, patch_size, img_c))
+        x = ttnn.permute(x, (0, 1, 3, 2, 4, 5))
+        x = ttnn.reshape(x, (batch_size, patches_h * patches_w, patch_size * patch_size * img_c))
+        out = ttnn.linear(
+            x,
+            self._weight,
+            bias=self._bias,
+            dtype=ttnn.bfloat16,
+            compute_kernel_config=self.compute_kernel_config,
+            core_grid=ttnn.CoreGrid(y=8, x=8),
+        )
+        out = ttnn.reshape(out, (batch_size, patches_h, patches_w, -1))
+        return out

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/sd_35_pipeline.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/sd_35_pipeline.py
@@ -1,0 +1,632 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+
+import torch
+import tqdm
+import ttnn
+from diffusers.image_processor import VaeImageProcessor
+from diffusers.models.autoencoders.autoencoder_kl import AutoencoderKL
+from diffusers.models.transformers.transformer_sd3 import SD3Transformer2DModel
+from diffusers.schedulers.scheduling_flow_match_euler_discrete import FlowMatchEulerDiscreteScheduler
+from loguru import logger
+from transformers import CLIPTextModelWithProjection, CLIPTokenizer, T5EncoderModel, T5TokenizerFast
+
+from .utils import from_torch_fast, to_torch
+from .t5_encoder import TtT5Encoder, TtT5EncoderParameters
+from .transformer import TtSD3Transformer2DModel, TtSD3Transformer2DModelParameters
+from .vae_decoder import TtVaeDecoder, TtVaeDecoderParameters
+
+TILE_SIZE = 32
+
+
+class TtStableDiffusion3Pipeline:
+    def __init__(
+        self,
+        *,
+        checkpoint_name: str,
+        device: ttnn.MeshDevice,
+        enable_t5_text_encoder: bool = True,
+        vae_cpu_fallback: bool = False,
+        guidance_cond: int,
+    ) -> None:
+        self._device = device
+
+        logger.info("loading models...")
+        model_name_checkpoint = checkpoint_name
+
+        self._tokenizer_1 = CLIPTokenizer.from_pretrained(model_name_checkpoint, subfolder="tokenizer")
+        self._tokenizer_2 = CLIPTokenizer.from_pretrained(model_name_checkpoint, subfolder="tokenizer_2")
+        self._tokenizer_3 = T5TokenizerFast.from_pretrained(model_name_checkpoint, subfolder="tokenizer_3")
+        self._text_encoder_1 = CLIPTextModelWithProjection.from_pretrained(
+            model_name_checkpoint, subfolder="text_encoder"
+        )
+        self._text_encoder_2 = CLIPTextModelWithProjection.from_pretrained(
+            model_name_checkpoint, subfolder="text_encoder_2"
+        )
+        if enable_t5_text_encoder:
+            torch_text_encoder_3 = T5EncoderModel.from_pretrained(
+                model_name_checkpoint,
+                subfolder="text_encoder_3",
+                torch_dtype=torch.bfloat16,
+            )
+        self._scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(model_name_checkpoint, subfolder="scheduler")
+        vae = AutoencoderKL.from_pretrained(
+            model_name_checkpoint,
+            subfolder="vae",
+            torch_dtype=None if vae_cpu_fallback else torch.bfloat16,
+        )
+        torch_transformer = SD3Transformer2DModel.from_pretrained(
+            model_name_checkpoint,
+            subfolder="transformer",
+            torch_dtype=torch.bfloat16,
+        )
+        torch_transformer.eval()
+
+        assert isinstance(self._tokenizer_1, CLIPTokenizer)
+        assert isinstance(self._tokenizer_2, CLIPTokenizer)
+        assert isinstance(self._tokenizer_3, T5TokenizerFast)
+        assert isinstance(self._text_encoder_1, CLIPTextModelWithProjection)
+        assert isinstance(self._text_encoder_2, CLIPTextModelWithProjection)
+        assert isinstance(self._scheduler, FlowMatchEulerDiscreteScheduler)
+        assert isinstance(vae, AutoencoderKL)
+        assert isinstance(torch_transformer, SD3Transformer2DModel)
+
+        logger.info("creating TT-NN transformer...")
+
+        if checkpoint_name == "stabilityai/stable-diffusion-3.5-medium":
+            embedding_dim = 1536
+        else:
+            embedding_dim = 2432
+
+        num_devices = device.get_num_devices()
+        ## heads padding for T3K TP
+        if os.environ.get("MESH_DEVICE") == "T3K" and embedding_dim == 2432:
+            hidden_dim_padding = (
+                ((embedding_dim // num_devices // TILE_SIZE) + 1) * TILE_SIZE
+            ) * num_devices - embedding_dim
+            num_heads = 40
+        else:
+            hidden_dim_padding = 0
+            num_heads = torch_transformer.config.num_attention_heads
+
+        parameters = TtSD3Transformer2DModelParameters.from_torch(
+            torch_transformer.state_dict(),
+            num_heads=num_heads,
+            unpadded_num_heads=torch_transformer.config.num_attention_heads,
+            embedding_dim=embedding_dim,
+            hidden_dim_padding=hidden_dim_padding,
+            device=self._device,
+            dtype=ttnn.bfloat8_b if device.get_num_devices() == 1 else ttnn.bfloat16,
+        )
+
+        self._tt_transformer = TtSD3Transformer2DModel(
+            parameters, guidance_cond=guidance_cond, num_heads=num_heads, device=self._device
+        )
+        self._num_channels_latents = torch_transformer.config.in_channels
+        self._joint_attention_dim = torch_transformer.config.joint_attention_dim
+
+        self._block_out_channels = vae.config.block_out_channels
+        self._vae_scaling_factor = vae.config.scaling_factor
+        self._vae_shift_factor = vae.config.shift_factor
+
+        self._vae_scale_factor = 2 ** (len(self._block_out_channels) - 1)
+        self._image_processor = VaeImageProcessor(vae_scale_factor=self._vae_scale_factor)
+
+        if enable_t5_text_encoder:
+            logger.info("creating TT-NN text encoder...")
+
+            parameters = TtT5EncoderParameters.from_torch(
+                torch_text_encoder_3.state_dict(),
+                device=self._device,
+                dtype=ttnn.bfloat16,
+            )
+            self._text_encoder_3 = TtT5Encoder(
+                parameters,
+                num_heads=torch_text_encoder_3.config.num_heads,
+                relative_attention_num_buckets=torch_text_encoder_3.config.relative_attention_num_buckets,
+                relative_attention_max_distance=torch_text_encoder_3.config.relative_attention_max_distance,
+                layer_norm_epsilon=torch_text_encoder_3.config.layer_norm_epsilon,
+            )
+        else:
+            self._text_encoder_3 = None
+
+        if not vae_cpu_fallback:
+            logger.info("creating VAE decoder...")
+
+            parameters = TtVaeDecoderParameters.from_torch(
+                vae.decoder.state_dict(),
+                device=self._device.get_devices()[0],
+                dtype=ttnn.bfloat16,
+            )
+            self._vae = TtVaeDecoder(parameters, norm_num_groups=vae.config.norm_num_groups)
+        else:
+            self._vae = vae
+
+    def prepare(
+        self,
+        *,
+        num_images_per_prompt: int = 1,
+        width: int = 1024,
+        height: int = 1024,
+        guidance_scale: float = 4.5,
+        max_t5_sequence_length: int = 256,
+        prompt_sequence_length: int = 333,
+        spatial_sequence_length: int = 4096,
+    ) -> None:
+        self._prepared_num_images_per_prompt = num_images_per_prompt
+        self._prepared_width = width
+        self._prepared_height = height
+        self._prepared_guidance_scale = guidance_scale
+        self._prepared_max_t5_sequence_length = max_t5_sequence_length
+        self._prepared_prompt_sequence_length = prompt_sequence_length
+
+    def __call__(
+        self,
+        *,
+        prompt_1: list[str],
+        prompt_2: list[str],
+        prompt_3: list[str],
+        negative_prompt_1: list[str],
+        negative_prompt_2: list[str],
+        negative_prompt_3: list[str],
+        num_inference_steps: int = 40,
+        seed: int | None = None,
+    ) -> None:
+        start_time = time.time()
+
+        batch_size = len(prompt_1)
+        num_images_per_prompt = self._prepared_num_images_per_prompt
+
+        assert (
+            batch_size * num_images_per_prompt == 1
+        ), "generating multiple images is not yet supported as it requires another mesh sharding stategy"
+
+        width = self._prepared_width
+        height = self._prepared_height
+        guidance_scale = self._prepared_guidance_scale
+        max_t5_sequence_length = self._prepared_max_t5_sequence_length
+
+        assert height % (self._vae_scale_factor * self._tt_transformer.patch_size) == 0
+        assert width % (self._vae_scale_factor * self._tt_transformer.patch_size) == 0
+        assert max_t5_sequence_length <= 512  # noqa: PLR2004
+
+        do_classifier_free_guidance = guidance_scale > 1
+
+        latents_shape = (
+            batch_size * num_images_per_prompt,
+            self._num_channels_latents,
+            height // self._vae_scale_factor,
+            width // self._vae_scale_factor,
+        )
+
+        logger.info("encoding prompts...")
+
+        prompt_encoding_start_time = time.time()
+        prompt_embeds, pooled_prompt_embeds = self._encode_prompts(
+            prompt_1=prompt_1,
+            prompt_2=prompt_2,
+            prompt_3=prompt_3,
+            negative_prompt_1=negative_prompt_1,
+            negative_prompt_2=negative_prompt_2,
+            negative_prompt_3=negative_prompt_3,
+            num_images_per_prompt=num_images_per_prompt,
+            max_t5_sequence_length=max_t5_sequence_length,
+            do_classifier_free_guidance=do_classifier_free_guidance,
+        )
+        prompt_encoding_end_time = time.time()
+
+        logger.info("preparing timesteps...")
+
+        self._scheduler.set_timesteps(num_inference_steps)
+        timesteps = self._scheduler.timesteps
+
+        logger.info("preparing latents...")
+
+        if seed is not None:
+            torch.manual_seed(seed)
+        # We let randn generate a permuted latent tensor, so that the generated noise matches the
+        # reference implementation.
+        latents = torch.randn(latents_shape, dtype=prompt_embeds.dtype).permute(0, 2, 3, 1)
+
+        tt_prompt_embeds = ttnn.from_torch(
+            prompt_embeds,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            device=self._device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self._device),
+        )
+        tt_pooled_prompt_embeds = ttnn.from_torch(
+            pooled_prompt_embeds,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            device=self._device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self._device),
+        )
+        tt_initial_latents = ttnn.from_torch(
+            latents,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            device=self._device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self._device),
+        )
+
+        logger.info("denoising...")
+        denoising_start_time = time.time()
+
+        # ttnn.copy_host_to_device_tensor(tt_prompt_embeds, self._trace.prompt_input)
+        # ttnn.copy_host_to_device_tensor(tt_pooled_prompt_embeds, self._trace.pooled_projection_input)
+        # ttnn.copy_host_to_device_tensor(tt_initial_latents, self._trace.spatial_input_output)
+
+        latents_step = tt_initial_latents
+
+        transformer_batch_size = batch_size * num_images_per_prompt
+        if do_classifier_free_guidance:
+            transformer_batch_size *= 2
+
+        for i, t in enumerate(tqdm.tqdm(timesteps)):
+            tt_timestep = ttnn.full(
+                [transformer_batch_size, 1],
+                fill_value=t,
+                dtype=ttnn.float32,
+                device=self._device,
+                layout=ttnn.TILE_LAYOUT,
+            )
+
+            sigma_difference = self._scheduler.sigmas[i + 1] - self._scheduler.sigmas[i]
+            tt_sigma_difference = ttnn.full(
+                [1, 1],
+                fill_value=sigma_difference,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat16,
+                device=self._device,
+            )
+
+            # ttnn.copy_host_to_device_tensor(tt_timestep, self._trace.timestep_input)
+            # ttnn.copy_host_to_device_tensor(tt_sigma_difference, self._trace.sigma_difference_input)
+            # self._trace.execute()
+
+            self._step(
+                timestep=tt_timestep,
+                latents=latents_step,  # tt_latents,
+                do_classifier_free_guidance=do_classifier_free_guidance,
+                prompt_embeds=tt_prompt_embeds,
+                pooled_prompt_embeds=tt_pooled_prompt_embeds,
+                guidance_scale=guidance_scale,
+                sigma_difference=tt_sigma_difference,
+                prompt_sequence_length=333,
+                spatial_sequence_length=4096,
+            )
+
+        latents_output = ttnn.get_device_tensors(latents_step)[0]
+
+        denoising_end_time = time.time()
+
+        logger.info("decoding image...")
+
+        image_decoding_start_time = time.time()
+
+        # scaled_latents = 1 / self._vae_scaling_factor * self._trace.spatial_input_output + self._vae_shift_factor
+        scaled_latents = 1 / self._vae_scaling_factor * latents_step + self._vae_shift_factor
+
+        if isinstance(self._vae, TtVaeDecoder):
+            images = self._vae(scaled_latents)
+            torch_images = to_torch(images, dtype=torch.float32).permute(0, 3, 1, 2)
+        else:
+            torch_latents = to_torch(scaled_latents, dtype=torch.float32).permute([0, 3, 1, 2])
+            with torch.no_grad():
+                torch_images = self._vae.decoder(torch_latents)
+
+        with torch.no_grad():
+            torch_images = self._image_processor.postprocess(torch_images, output_type="pt")
+            assert isinstance(torch_images, torch.Tensor)
+
+        image_decoding_end_time = time.time()
+
+        output = self._image_processor.numpy_to_pil(self._image_processor.pt_to_numpy(torch_images))
+
+        end_time = time.time()
+
+        logger.info(f"prompt encoding duration: {prompt_encoding_end_time - prompt_encoding_start_time}")
+        logger.info(f"denoising duration: {denoising_end_time - denoising_start_time}")
+        logger.info(f"image decoding duration: {image_decoding_end_time - image_decoding_start_time}")
+        logger.info(f"total runtime: {end_time - start_time}")
+
+        return output
+
+    def _step(
+        self,
+        *,
+        do_classifier_free_guidance: bool,
+        guidance_scale: float,
+        latents: ttnn.Tensor,
+        timestep: ttnn.Tensor,
+        pooled_prompt_embeds: ttnn.Tensor,
+        prompt_embeds: ttnn.Tensor,
+        sigma_difference: ttnn.Tensor,
+        prompt_sequence_length: int,
+        spatial_sequence_length: int,
+    ) -> None:
+        latent_model_input = ttnn.concat([latents, latents]) if do_classifier_free_guidance else latents
+
+        noise_pred = self._tt_transformer(
+            spatial=latent_model_input,
+            prompt=prompt_embeds,
+            pooled_projection=pooled_prompt_embeds,
+            timestep=timestep,
+            N=spatial_sequence_length,
+            L=prompt_sequence_length,
+        )
+
+        noise_pred = _reshape_noise_pred(
+            noise_pred,
+            height=latents.shape[-3],
+            width=latents.shape[-2],
+            patch_size=self._tt_transformer.patch_size,
+        )
+
+        if do_classifier_free_guidance:
+            split_pos = noise_pred.shape[0] // 2
+            uncond = noise_pred[0:split_pos]
+            cond = noise_pred[split_pos:]
+            noise_pred = uncond + guidance_scale * (cond - uncond)
+
+        ttnn.add_(latents, sigma_difference * noise_pred)
+
+    def _encode_prompts(
+        self,
+        *,
+        prompt_1: list[str],
+        prompt_2: list[str],
+        prompt_3: list[str],
+        negative_prompt_1: list[str],
+        negative_prompt_2: list[str],
+        negative_prompt_3: list[str],
+        num_images_per_prompt: int,
+        max_t5_sequence_length: int,
+        do_classifier_free_guidance: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        tokenizer_max_length = self._tokenizer_1.model_max_length
+
+        prompt_embed, pooled_prompt_embed = _get_clip_prompt_embeds(
+            prompt=prompt_1,
+            num_images_per_prompt=num_images_per_prompt,
+            tokenizer=self._tokenizer_1,
+            text_encoder=self._text_encoder_1,
+            tokenizer_max_length=tokenizer_max_length,
+        )
+
+        prompt_2_embed, pooled_prompt_2_embed = _get_clip_prompt_embeds(
+            prompt=prompt_2,
+            num_images_per_prompt=num_images_per_prompt,
+            tokenizer=self._tokenizer_2,
+            text_encoder=self._text_encoder_2,
+            tokenizer_max_length=tokenizer_max_length,
+        )
+        clip_prompt_embeds = torch.cat([prompt_embed, prompt_2_embed], dim=-1)
+
+        t5_prompt_embed = _get_t5_prompt_embeds(
+            device=self._device,
+            prompt=prompt_3,
+            num_images_per_prompt=num_images_per_prompt,
+            max_sequence_length=max_t5_sequence_length,
+            tokenizer=self._tokenizer_3,
+            text_encoder=self._text_encoder_3,
+            tokenizer_max_length=tokenizer_max_length,
+            joint_attention_dim=self._joint_attention_dim,
+        )
+
+        clip_prompt_embeds = torch.nn.functional.pad(
+            clip_prompt_embeds,
+            (0, t5_prompt_embed.shape[-1] - clip_prompt_embeds.shape[-1]),
+        )
+
+        prompt_embeds = torch.cat([clip_prompt_embeds, t5_prompt_embed], dim=-2)
+        pooled_prompt_embeds = torch.cat([pooled_prompt_embed, pooled_prompt_2_embed], dim=-1)
+
+        if not do_classifier_free_guidance:
+            return prompt_embeds, pooled_prompt_embeds
+
+        negative_prompt_embed, negative_pooled_prompt_embed = _get_clip_prompt_embeds(
+            prompt=negative_prompt_1,
+            num_images_per_prompt=num_images_per_prompt,
+            tokenizer=self._tokenizer_1,
+            text_encoder=self._text_encoder_1,
+            tokenizer_max_length=tokenizer_max_length,
+        )
+        negative_prompt_2_embed, negative_pooled_prompt_2_embed = _get_clip_prompt_embeds(
+            prompt=negative_prompt_2,
+            num_images_per_prompt=num_images_per_prompt,
+            tokenizer=self._tokenizer_2,
+            text_encoder=self._text_encoder_2,
+            tokenizer_max_length=tokenizer_max_length,
+        )
+        negative_clip_prompt_embeds = torch.cat([negative_prompt_embed, negative_prompt_2_embed], dim=-1)
+
+        t5_negative_prompt_embed = _get_t5_prompt_embeds(
+            device=self._device,
+            prompt=negative_prompt_3,
+            num_images_per_prompt=num_images_per_prompt,
+            max_sequence_length=max_t5_sequence_length,
+            tokenizer=self._tokenizer_3,
+            text_encoder=self._text_encoder_3,
+            tokenizer_max_length=tokenizer_max_length,
+            joint_attention_dim=self._joint_attention_dim,
+        )
+
+        negative_clip_prompt_embeds = torch.nn.functional.pad(
+            negative_clip_prompt_embeds,
+            (
+                0,
+                t5_negative_prompt_embed.shape[-1] - negative_clip_prompt_embeds.shape[-1],
+            ),
+        )
+
+        negative_prompt_embeds = torch.cat([negative_clip_prompt_embeds, t5_negative_prompt_embed], dim=-2)
+        negative_pooled_prompt_embeds = torch.cat(
+            [negative_pooled_prompt_embed, negative_pooled_prompt_2_embed], dim=-1
+        )
+
+        prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+        pooled_prompt_embeds = torch.cat([negative_pooled_prompt_embeds, pooled_prompt_embeds], dim=0)
+
+        return prompt_embeds, pooled_prompt_embeds
+
+
+@dataclass
+class PipelineTrace:
+    spatial_input_output: ttnn.Tensor
+    prompt_input: ttnn.Tensor
+    pooled_projection_input: ttnn.Tensor
+    timestep_input: ttnn.Tensor
+    sigma_difference_input: ttnn.Tensor
+    tid: int
+
+    def execute(self) -> None:
+        ttnn.execute_trace(self.spatial_input_output.device(), self.tid)
+
+
+# adapted from https://github.com/huggingface/diffusers/blob/v0.31.0/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
+def _get_clip_prompt_embeds(
+    *,
+    clip_skip: int | None = None,
+    device: torch.device | None = None,
+    num_images_per_prompt: int,
+    prompt: list[str],
+    text_encoder: CLIPTextModelWithProjection,
+    tokenizer_max_length: int,
+    tokenizer: CLIPTokenizer,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    batch_size = len(prompt)
+
+    text_inputs = tokenizer(
+        prompt,
+        padding="max_length",
+        max_length=tokenizer_max_length,
+        truncation=True,
+        return_tensors="pt",
+    )
+
+    text_input_ids = text_inputs.input_ids
+    untruncated_ids = tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
+    if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
+        removed_text = tokenizer.batch_decode(untruncated_ids[:, tokenizer_max_length - 1 : -1])
+        logger.warning(
+            "The following part of your input was truncated because CLIP can only handle sequences up to"
+            f" {tokenizer_max_length} tokens: {removed_text}"
+        )
+    prompt_embeds = text_encoder(text_input_ids.to(device), output_hidden_states=True)
+    pooled_prompt_embeds = prompt_embeds[0]
+
+    if clip_skip is None:
+        prompt_embeds = prompt_embeds.hidden_states[-2]
+    else:
+        prompt_embeds = prompt_embeds.hidden_states[-(clip_skip + 2)]
+
+    prompt_embeds = prompt_embeds.to(dtype=text_encoder.dtype, device=device)
+
+    _, seq_len, _ = prompt_embeds.shape
+    # duplicate text embeddings for each generation per prompt, using mps friendly method
+    prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+    prompt_embeds = prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, -1)
+
+    pooled_prompt_embeds = pooled_prompt_embeds.repeat(1, num_images_per_prompt, 1)
+    pooled_prompt_embeds = pooled_prompt_embeds.view(batch_size * num_images_per_prompt, -1)
+
+    return prompt_embeds, pooled_prompt_embeds
+
+
+# adapted from https://github.com/huggingface/diffusers/blob/v0.31.0/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
+def _get_t5_prompt_embeds(
+    prompt: list[str],
+    *,
+    torch_device: torch.device | None = None,
+    device: ttnn.Device,
+    joint_attention_dim: int,
+    max_sequence_length: int,
+    num_images_per_prompt: int,
+    text_encoder: TtT5Encoder | None,
+    tokenizer_max_length: int,
+    tokenizer: T5TokenizerFast,
+) -> torch.Tensor:
+    prompt = [prompt] if isinstance(prompt, str) else prompt
+    batch_size = len(prompt)
+
+    if text_encoder is None:
+        return torch.zeros(
+            (
+                batch_size * num_images_per_prompt,
+                tokenizer_max_length,
+                joint_attention_dim,
+            ),
+            device=torch_device,
+            dtype=torch.bfloat16,
+        )
+
+    text_inputs = tokenizer(
+        prompt,
+        padding="max_length",
+        max_length=max_sequence_length,
+        truncation=True,
+        add_special_tokens=True,
+        return_tensors="pt",
+    )
+    text_input_ids = text_inputs.input_ids
+    untruncated_ids = tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
+
+    if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
+        removed_text = tokenizer.batch_decode(untruncated_ids[:, tokenizer_max_length - 1 : -1])
+        logger.warning(
+            "The following part of your input was truncated because `max_sequence_length` is set to "
+            f" {max_sequence_length} tokens: {removed_text}"
+        )
+
+    tt_text_input_ids = from_torch_fast(text_input_ids, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+    tt_prompt_embeds = text_encoder(tt_text_input_ids, device)
+    tt_prompt_embeds = ttnn.get_device_tensors(tt_prompt_embeds)[0]
+    prompt_embeds = ttnn.to_torch(tt_prompt_embeds)
+
+    prompt_embeds = prompt_embeds.to(device=torch_device)
+
+    _, seq_len, _ = prompt_embeds.shape
+
+    # duplicate text embeddings and attention mask for each generation per prompt, using mps friendly method
+    prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+    return prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, -1)
+
+
+def _reshape_noise_pred(
+    noise_pred: ttnn.Tensor,
+    *,
+    height: int,
+    width: int,
+    patch_size: int,
+) -> ttnn.Tensor:
+    # B, H * W, P * Q * C -> B, H * P, W * Q, C
+
+    patch_count_y = height // patch_size
+    patch_count_x = width // patch_size
+
+    shape1 = (
+        noise_pred.shape[0] * patch_count_y,
+        patch_count_x,
+        patch_size,
+        -1,
+    )
+
+    shape2 = (
+        noise_pred.shape[0],
+        patch_count_y * patch_size,
+        patch_count_x * patch_size,
+        -1,
+    )
+
+    noise_pred = noise_pred.reshape(shape1)
+    noise_pred = ttnn.transpose(noise_pred, 1, 2)
+    return noise_pred.reshape(shape2)

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/substate.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/substate.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import itertools
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch
+
+
+def substate(state: dict[str, torch.Tensor], key: str) -> dict[str, torch.Tensor]:
+    prefix = f"{key}."
+    prefix_len = len(prefix)
+
+    return {k[prefix_len:]: v for k, v in state.items() if k.startswith(prefix)}
+
+
+def has_substate(state: dict[str, torch.Tensor], key: str) -> bool:
+    prefix = f"{key}."
+
+    return any(k.startswith(prefix) for k in state)
+
+
+def indexed_substates(state: dict[str, torch.Tensor], key: str) -> list[dict[str, torch.Tensor]]:
+    result = []
+    for i in itertools.count():
+        s = substate(state, f"{key}.{i}")
+        if not s:
+            return result
+        result.append(s)
+
+    return []

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/t5_encoder.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/t5_encoder.py
@@ -1,0 +1,378 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+import ttnn
+
+from .linear import TtLinear, TtLinearParameters
+from .substate import indexed_substates, substate
+from .utils import from_torch_fast
+
+
+@dataclass
+class TtT5Config:
+    vocab_size: int
+    d_model: int
+    d_ff: int
+    d_kv: int
+    num_heads: int
+    num_layers: int
+    relative_attention_num_buckets: int
+    relative_attention_max_distance: int
+    layer_norm_epsilon: float
+
+
+@dataclass
+class TtT5EncoderParameters:
+    token_embedding: ttnn.Tensor
+    blocks: [TtT5BlockParameters] # type: ignore
+    norm: TtT5LayerNorm
+    attention_bias: ttnn.Tensor
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+    ) -> TtT5EncoderParameters:
+        return cls(
+            token_embedding=from_torch_fast(
+                state["encoder.embed_tokens.weight"],
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                dtype=dtype,
+                device=device,
+                shard_dim=None,
+            ),
+            blocks=[
+                TtT5BlockParameters.from_torch(s, dtype=dtype, device=device)
+                for s in indexed_substates(state, "encoder.block")
+            ],
+            norm=TtT5LayerNormParameters.from_torch(
+                substate(state, "encoder.final_layer_norm"), dtype=dtype, device=device
+            ),
+            attention_bias=from_torch_fast(
+                state["encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight"],
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                dtype=dtype,
+                device=device,
+                shard_dim=None,
+            ),
+        )
+
+
+class TtT5Encoder:
+    def __init__(
+        self,
+        parameters: TtT5EncoderParameters,
+        num_heads: int,
+        relative_attention_num_buckets: int,
+        relative_attention_max_distance: int,
+        layer_norm_epsilon: float,
+    ) -> None:
+        self._token_embedding = parameters.token_embedding
+        self._blocks = [
+            TtT5Block(p, num_heads=num_heads, layer_norm_epsilon=layer_norm_epsilon) for p in parameters.blocks
+        ]
+        self._norm = TtT5LayerNorm(parameters.norm, eps=layer_norm_epsilon)
+        self._attention_bias = parameters.attention_bias
+        self._num_heads = num_heads
+        self._relative_attention_num_buckets = relative_attention_num_buckets
+        self._relative_attention_max_distance = relative_attention_max_distance
+
+    def __call__(self, input_ids: ttnn.Tensor, device) -> ttnn.Tensor:
+        _batch_size, seq_length = input_ids.shape
+
+        # TODO: Remove the conversion to row major layout once ttnn.embedding works with tiled input
+        # https://github.com/tenstorrent/tt-metal/issues/17643
+        input_ids = ttnn.to_layout(input_ids, ttnn.ROW_MAJOR_LAYOUT)
+        inputs_embeds = ttnn.embedding(input_ids, self._token_embedding, layout=ttnn.TILE_LAYOUT)
+
+        position_bias = _compute_bias(
+            seq_length=seq_length,
+            device=device,
+            relative_attention_num_buckets=self._relative_attention_num_buckets,
+            relative_attention_max_distance=self._relative_attention_max_distance,
+            relative_attention_bias=self._attention_bias,
+        )
+
+        x = inputs_embeds
+        for block in self._blocks:
+            x = block(x, position_bias=position_bias)
+
+        return self._norm(x)
+
+
+@dataclass
+class TtT5BlockParameters:
+    attention: TtT5LayerSelfAttentionParameters
+    ff: TtT5LayerFFParameters
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+    ) -> TtT5BlockParameters:
+        return cls(
+            attention=TtT5LayerSelfAttentionParameters.from_torch(
+                substate(state, "layer.0"), dtype=dtype, device=device
+            ),
+            ff=TtT5LayerFFParameters.from_torch(substate(state, "layer.1"), dtype=dtype, device=device),
+        )
+
+
+class TtT5Block:
+    def __init__(self, parameters: TtT5BlockParameters, *, num_heads: int, layer_norm_epsilon: float) -> None:
+        self._attention = TtT5LayerSelfAttention(
+            parameters.attention, num_heads=num_heads, layer_norm_epsilon=layer_norm_epsilon
+        )
+        self._ff = TtT5LayerFF(parameters.ff, layer_norm_epsilon=layer_norm_epsilon)
+
+    def __call__(self, x: ttnn.Tensor, *, position_bias: ttnn.Tensor) -> ttnn.Tensor:
+        x = self._attention(x, position_bias=position_bias)
+        return self._ff(x)
+
+
+@dataclass
+class TtT5LayerSelfAttentionParameters:
+    attention: TtT5AttentionParameters
+    norm: TtT5LayerNormParameters
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+    ) -> TtT5LayerSelfAttentionParameters:
+        return cls(
+            attention=TtT5AttentionParameters.from_torch(substate(state, "SelfAttention"), dtype=dtype, device=device),
+            norm=TtT5LayerNormParameters.from_torch(substate(state, "layer_norm"), dtype=dtype, device=device),
+        )
+
+
+class TtT5LayerSelfAttention:
+    def __init__(self, parameters: TtT5BlockParameters, *, num_heads: int, layer_norm_epsilon: float) -> None:
+        self._attention = TtT5Attention(parameters.attention, num_heads=num_heads)
+        self._norm = TtT5LayerNorm(parameters.norm, eps=layer_norm_epsilon)
+
+    def __call__(self, x: ttnn.Tensor, *, position_bias: ttnn.Tensor) -> ttnn.Tensor:
+        normed = self._norm(x)
+        attn = self._attention(normed, position_bias=position_bias)
+        return x + attn
+
+
+@dataclass
+class TtT5AttentionParameters:
+    q_proj: ttnn.Tensor
+    k_proj: ttnn.Tensor
+    v_proj: ttnn.Tensor
+    o_proj: ttnn.Tensor
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+    ) -> TtT5AttentionParameters:
+        return cls(
+            q_proj=TtLinearParameters.from_torch(substate(state, "q"), dtype=dtype, device=device, shard_dim=None),
+            k_proj=TtLinearParameters.from_torch(substate(state, "k"), dtype=dtype, device=device, shard_dim=None),
+            v_proj=TtLinearParameters.from_torch(substate(state, "v"), dtype=dtype, device=device, shard_dim=None),
+            o_proj=TtLinearParameters.from_torch(substate(state, "o"), dtype=dtype, device=device, shard_dim=None),
+        )
+
+
+class TtT5Attention:
+    def __init__(self, parameters: TtT5AttentionParameters, *, num_heads: int) -> None:
+        self._num_heads = num_heads
+
+        self._q_proj = TtLinear(parameters.q_proj)
+        self._k_proj = TtLinear(parameters.k_proj)
+        self._v_proj = TtLinear(parameters.v_proj)
+        self._o_proj = TtLinear(parameters.o_proj)
+
+    def __call__(self, x: ttnn.Tensor, *, position_bias: ttnn.Tensor) -> ttnn.Tensor:
+        batch_size, seq_length, _ = x.shape
+
+        q = self._q_proj(x)
+        k = self._k_proj(x)
+        v = self._v_proj(x)
+
+        qkv = ttnn.concat([q, k, v], dim=-1)
+        q, k, v = ttnn.transformer.split_query_key_value_and_split_heads(
+            qkv, num_heads=self._num_heads, transpose_key=True
+        )
+        scores = ttnn.matmul(q, k)
+        scores = scores + position_bias
+        attn_weights = ttnn.softmax(scores, dim=-1)
+        attn = ttnn.matmul(attn_weights, v)
+        attn = ttnn.transformer.concatenate_heads(attn)
+
+        return self._o_proj(attn)
+
+
+@dataclass
+class TtT5LayerFFParameters:
+    dense_gated_dense: TtT5DenseGatedActDenseParameters
+    norm: TtT5LayerNormParameters
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+    ) -> TtT5LayerFFParameters:
+        return cls(
+            dense_gated_dense=TtT5DenseGatedActDenseParameters.from_torch(
+                substate(state, "DenseReluDense"), dtype=dtype, device=device
+            ),
+            norm=TtT5LayerNormParameters.from_torch(substate(state, "layer_norm"), dtype=dtype, device=device),
+        )
+
+
+class TtT5LayerFF:
+    def __init__(self, parameters: TtT5LayerFFParameters, *, layer_norm_epsilon: float) -> None:
+        self._dense_gated_dense = TtT5DenseGatedActDense(parameters.dense_gated_dense)
+        self._norm = TtT5LayerNorm(parameters.norm, eps=layer_norm_epsilon)
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        fw = self._norm(x)
+        fw = self._dense_gated_dense(fw)
+        return x + fw
+
+
+@dataclass
+class TtT5DenseGatedActDenseParameters:
+    wi0: TtLinearParameters
+    wi1: TtLinearParameters
+    wo: TtLinearParameters
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+    ) -> TtT5DenseGatedActDenseParameters:
+        return cls(
+            wi0=TtLinearParameters.from_torch(substate(state, "wi_0"), dtype=dtype, device=device, shard_dim=None),
+            wi1=TtLinearParameters.from_torch(substate(state, "wi_1"), dtype=dtype, device=device, shard_dim=None),
+            wo=TtLinearParameters.from_torch(substate(state, "wo"), dtype=dtype, device=device, shard_dim=None),
+        )
+
+
+class TtT5DenseGatedActDense:
+    def __init__(self, parameters: TtT5DenseGatedActDenseParameters) -> None:
+        self._wi0 = TtLinear(parameters.wi0)
+        self._wi1 = TtLinear(parameters.wi1)
+        self._wo = TtLinear(parameters.wo)
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        gelu = new_gelu_activation(self._wi0(x))
+        linear = self._wi1(x)
+        x = gelu * linear
+        return self._wo(x)
+
+
+@dataclass
+class TtT5LayerNormParameters:
+    weight: ttnn.Tensor
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+    ) -> TtT5LayerNormParameters:
+        return cls(
+            weight=from_torch_fast(state["weight"], layout=ttnn.TILE_LAYOUT, dtype=dtype, device=device),
+        )
+
+
+class TtT5LayerNorm:
+    def __init__(self, parameters: TtT5LayerNormParameters, *, eps: float) -> None:
+        self._weight = parameters.weight
+        self._eps = eps
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        variance = ttnn.mean(ttnn.pow(x, 2), -1, keepdim=True)
+        x *= ttnn.rsqrt(variance + self._eps)
+        return self._weight * x
+
+
+def _relative_position_bucket(relative_position: torch.Tensor, num_buckets: int, max_distance: int) -> torch.Tensor:
+    num_buckets //= 2
+
+    relative_buckets = (relative_position > 0).to(torch.long) * num_buckets
+    relative_position = torch.abs(relative_position)
+
+    max_exact = num_buckets // 2
+    is_small = relative_position < max_exact
+
+    relative_position_if_large = max_exact + (
+        torch.log(relative_position.float() / max_exact)
+        / math.log(max_distance / max_exact)
+        * (num_buckets - max_exact)
+    ).to(torch.long)
+    relative_position_if_large = torch.min(
+        relative_position_if_large,
+        torch.full_like(relative_position_if_large, num_buckets - 1),
+    )
+
+    relative_buckets += torch.where(is_small, relative_position, relative_position_if_large)
+    return relative_buckets
+
+
+def _compute_bias(
+    *,
+    seq_length: int,
+    device: ttnn.Device,
+    relative_attention_num_buckets: int,
+    relative_attention_max_distance: int,
+    relative_attention_bias: ttnn.Tensor,
+) -> ttnn.Tensor:
+    context_position = torch.arange(seq_length)[:, None]
+    memory_position = torch.arange(seq_length)[None, :]
+    relative_position = memory_position - context_position
+
+    relative_position_bucket = _relative_position_bucket(
+        relative_position,
+        num_buckets=relative_attention_num_buckets,
+        max_distance=relative_attention_max_distance,
+    )
+
+    relative_attention_bias = ttnn.get_device_tensors(relative_attention_bias)[0]
+    torch_relative_attention_bias = ttnn.to_torch(relative_attention_bias)
+    # torch_relative_attention_bias = to_torch(relative_attention_bias, mesh_device=device, dtype=relative_attention_bias.get_dtype(), shard_dim=None)
+    output = torch.nn.functional.embedding(relative_position_bucket, torch_relative_attention_bias)
+    output = output.permute([2, 0, 1]).unsqueeze(0)
+    output = output[:, :, -seq_length:, :]
+
+    return from_torch_fast(
+        output, device=device, dtype=relative_attention_bias.get_dtype(), shard_dim=None, layout=ttnn.TILE_LAYOUT
+    )
+
+
+def new_gelu_activation(x: ttnn.Tensor) -> ttnn.Tensor:
+    c = math.sqrt(2.0 / math.pi)
+    y = 0.044715 * ttnn.pow(x, 3) + x
+    return 0.5 * x * (1.0 + ttnn.tanh(c * y))

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/timestep_embedding.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/timestep_embedding.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+import ttnn
+from models.experimental.stable_diffusion_35_large.tt.linear import TtLinear, TtLinearParameters
+
+from . import utils
+from .substate import substate
+
+
+@dataclass
+class TtEmbeddingParameters:
+    linear_1: TtLinearParameters
+    linear_2: TtLinearParameters
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, ttnn.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+    ) -> TtEmbeddingParameters:
+        return cls(
+            linear_1=TtLinearParameters.from_torch(
+                substate(state, "linear_1"), dtype=dtype, device=device, shard_dim=None
+            ),
+            linear_2=TtLinearParameters.from_torch(
+                substate(state, "linear_2"), dtype=dtype, device=device, shard_dim=None
+            ),
+        )
+
+
+@dataclass
+class TtCombinedTimestepTextProjEmbeddingsParameters:
+    timestep_embedder: TtEmbeddingParameters
+    text_embedder: TtEmbeddingParameters
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, ttnn.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+    ) -> TtCombinedTimestepTextProjEmbeddingsParameters:
+        return cls(
+            timestep_embedder=TtEmbeddingParameters.from_torch(
+                substate(state, "timestep_embedder"), dtype=dtype, device=device
+            ),
+            text_embedder=TtEmbeddingParameters.from_torch(
+                substate(state, "text_embedder"), dtype=dtype, device=device
+            ),
+        )
+
+
+class TtCombinedTimestepTextProjEmbeddings:
+    def __init__(self, batch_size, parameters: TtCombinedTimestepTextProjEmbeddingsParameters, device) -> None:
+        super().__init__()
+
+        self._timestep_embedder = _TimestepEmbedding(parameters.timestep_embedder)
+        self._text_embedder = _TimestepEmbedding(parameters.text_embedder)
+
+        self._time_proj_factor = self._create_time_proj_factor(num_channels=256, batch_size=batch_size, device=device)
+
+    def __call__(self, *, timestep: ttnn.Tensor, pooled_projection: ttnn.Tensor) -> ttnn.Tensor:
+        assert timestep.dtype == ttnn.float32
+
+        batch_size = timestep.shape[0]
+
+        # time_proj_factor = ttnn.repeat(self._time_proj_factor, ttnn.Shape([batch_size, 1]))
+        # time_proj_factor = ttnn.to_layout(time_proj_factor, ttnn.TILE_LAYOUT)
+        time_proj_factor = ttnn.to_layout(self._time_proj_factor, ttnn.TILE_LAYOUT)
+
+        emb = timestep * time_proj_factor
+
+        c = ttnn.cos(emb)
+        s = ttnn.sin(emb)
+
+        timesteps_proj = ttnn.concat([c, s], dim=-1)
+        timesteps_proj = ttnn.clone(timesteps_proj, dtype=pooled_projection.dtype)
+
+        time_embed = self._timestep_embedder(timesteps_proj)
+        text_embed = self._text_embedder(pooled_projection)
+
+        return time_embed + text_embed
+
+    @staticmethod
+    def _create_time_proj_factor(*, num_channels: int, batch_size: int, device: ttnn.Device) -> ttnn.Tensor:
+        assert num_channels % 2 == 0
+        half_dim = num_channels // 2
+
+        max_period = 10000
+
+        exponent = -math.log(max_period) * torch.arange(start=0, end=half_dim, dtype=torch.float32)
+        exponent = exponent / half_dim
+        factor = torch.exp(exponent).unsqueeze(0).repeat(batch_size, 1)
+
+        return ttnn.from_torch(factor, device=device, mesh_mapper=ttnn.ReplicateTensorToMesh(device))
+
+
+class _TimestepEmbedding:
+    def __init__(self, parameters: TtEmbeddingParameters) -> None:
+        super().__init__()
+
+        self._linear_1 = TtLinear(parameters.linear_1)
+        self._linear_2 = TtLinear(parameters.linear_2)
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        x = self._linear_1(x)
+        x = utils.silu(x)
+        return self._linear_2(x)
+
+    @property
+    def device(self) -> ttnn.Device:
+        return self._linear_1.device

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/transformer.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/transformer.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import ttnn
+from models.experimental.stable_diffusion_35_large.tt.linear import TtLinear, TtLinearParameters
+
+from . import utils
+from .normalization import TtLayerNorm, TtLayerNormParameters
+from .patch_embedding import TtPatchEmbed, TtPatchEmbedParameters
+from .substate import indexed_substates, substate
+from .timestep_embedding import TtCombinedTimestepTextProjEmbeddings, TtCombinedTimestepTextProjEmbeddingsParameters
+from .transformer_block import TtTransformerBlock, TtTransformerBlockParameters, chunk_time
+
+
+@dataclass
+class TtSD3Transformer2DModelParameters:
+    pos_embed: TtPatchEmbedParameters
+    time_text_embed: TtCombinedTimestepTextProjEmbeddingsParameters
+    context_embedder: TtLinearParameters
+    transformer_blocks: list[TtTransformerBlockParameters]
+    time_embed_out: TtLinearParameters
+    norm_out: TtLayerNormParameters
+    proj_out: TtLinearParameters
+    distributed: bool
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        num_heads: int,
+        unpadded_num_heads: int,
+        embedding_dim: int,
+        hidden_dim_padding: int,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.MeshDevice,
+    ) -> TtSD3Transformer2DModelParameters:
+        return cls(
+            pos_embed=TtPatchEmbedParameters.from_torch(
+                substate(state, "pos_embed"),
+                device=device,
+                hidden_dim_padding=hidden_dim_padding,
+                out_channels=embedding_dim,
+            ),
+            time_text_embed=TtCombinedTimestepTextProjEmbeddingsParameters.from_torch(
+                substate(state, "time_text_embed"), dtype=dtype, device=device
+            ),
+            context_embedder=TtLinearParameters.from_torch(
+                substate(state, "context_embedder"), dtype=dtype, device=device, shard_dim=-1
+            ),
+            transformer_blocks=[
+                TtTransformerBlockParameters.from_torch(
+                    s,
+                    num_heads=num_heads,
+                    unpadded_num_heads=unpadded_num_heads,
+                    hidden_dim_padding=hidden_dim_padding,
+                    dtype=dtype,
+                    device=device,
+                )
+                for s in indexed_substates(state, "transformer_blocks")
+            ],
+            time_embed_out=TtLinearParameters.from_torch(
+                substate(state, "norm_out.linear"), dtype=dtype, device=device, shard_dim=None, unsqueeze_bias=True
+            ),
+            norm_out=TtLayerNormParameters.from_torch(
+                substate(state, "norm_out.norm"), dtype=dtype, device=device, distributed=False
+            ),
+            proj_out=TtLinearParameters.from_torch(
+                substate(state, "proj_out"), dtype=dtype, device=device, shard_dim=None
+            ),
+            distributed=device.get_num_devices() > 1,
+        )
+
+
+class ShardingProjection:
+    def __init__(self, *, dim: int, device: ttnn.MeshDevice) -> None:
+        params = TtLinearParameters.from_torch(
+            dict(weight=torch.eye(dim)),
+            dtype=ttnn.bfloat16,
+            device=device,
+            shard_dim=-1,
+        )
+        self._projection = TtLinear(params)
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        return self._projection(x)
+
+
+class TtSD3Transformer2DModel:
+    def __init__(
+        self,
+        parameters: TtSD3Transformer2DModelParameters,
+        *,
+        guidance_cond: int = 2,
+        num_heads: int,
+        device,
+    ) -> None:
+        super().__init__()
+
+        self.mesh_device = device
+        self._pos_embed = TtPatchEmbed(parameters.pos_embed, device)
+        self._time_text_embed = TtCombinedTimestepTextProjEmbeddings(guidance_cond, parameters.time_text_embed, device)
+        self._context_embedder = TtLinear(parameters.context_embedder)
+        self._transformer_blocks = [
+            TtTransformerBlock(block, num_heads=num_heads, device=device) for block in parameters.transformer_blocks
+        ]
+        self._time_embed_out = TtLinear(parameters.time_embed_out)
+        self._norm_out = TtLayerNorm(parameters.norm_out, eps=1e-6)
+        self._proj_out = TtLinear(parameters.proj_out)
+
+        self._patch_size = self._pos_embed.patch_size
+
+        # TODO: get dimensions from other parameters
+        self._sharding = ShardingProjection(dim=2432, device=device)
+        self._distributed = parameters.distributed
+
+    def __call__(
+        self,
+        *,
+        spatial: ttnn.Tensor,
+        prompt: ttnn.Tensor,
+        pooled_projection: ttnn.Tensor,
+        timestep: ttnn.Tensor,
+        N: int,
+        L: int,
+    ) -> ttnn.Tensor:
+        spatial = self._pos_embed(spatial)
+        time_embed = self._time_text_embed(timestep=timestep, pooled_projection=pooled_projection)
+        prompt = self._context_embedder(prompt)
+        time_embed = time_embed.reshape([time_embed.shape[0], 1, 1, time_embed.shape[1]])
+        spatial = ttnn.unsqueeze(spatial, 1)
+        prompt = ttnn.unsqueeze(prompt, 1)
+
+        for i, block in enumerate(self._transformer_blocks, start=1):
+            spatial, prompt_out = block(
+                spatial=spatial,
+                prompt=prompt,
+                time_embed=time_embed,
+                N=N,  # spatial_sequence_length
+                L=L,  # prompt_sequence_length
+            )
+            if prompt_out is not None:
+                prompt = prompt_out
+
+        spatial_time = self._time_embed_out(utils.silu(time_embed))
+        [scale, shift] = chunk_time(spatial_time, 2)
+        if self._distributed:
+            spatial = utils.all_gather(spatial, dim=-1)
+        spatial = self._norm_out(spatial) * (1 + scale) + shift
+        return self._proj_out(spatial)
+
+    def cache_and_trace(
+        self,
+        *,
+        spatial: ttnn.Tensor,
+        prompt: ttnn.Tensor,
+        pooled_projection: ttnn.Tensor,
+        timestep: ttnn.Tensor,
+    ) -> TtSD3Transformer2DModelTrace:
+        device = spatial.device()
+
+        self(spatial=spatial, prompt=prompt, pooled_projection=pooled_projection, timestep=timestep)
+
+        tid = ttnn.begin_trace_capture(device)
+        output = self(spatial=spatial, prompt=prompt, pooled_projection=pooled_projection, timestep=timestep)
+        ttnn.end_trace_capture(device, tid)
+
+        return TtSD3Transformer2DModelTrace(
+            spatial_input=spatial,
+            prompt_input=prompt,
+            pooled_projection_input=pooled_projection,
+            timestep_input=timestep,
+            output=output,
+            tid=tid,
+        )
+
+    @property
+    def patch_size(self) -> int:
+        return self._patch_size
+
+
+@dataclass
+class TtSD3Transformer2DModelTrace:
+    spatial_input: ttnn.Tensor
+    prompt_input: ttnn.Tensor
+    pooled_projection_input: ttnn.Tensor
+    timestep_input: ttnn.Tensor
+    output: ttnn.Tensor
+    tid: int
+
+    def __call__(
+        self,
+        *,
+        spatial: ttnn.Tensor,
+        prompt: ttnn.Tensor,
+        pooled_projection: ttnn.Tensor,
+        timestep: ttnn.Tensor,
+    ) -> ttnn.Tensor:
+        device = self.spatial_input.device()
+
+        ttnn.copy_host_to_device_tensor(spatial, self.spatial_input)
+        ttnn.copy_host_to_device_tensor(prompt, self.prompt_input)
+        ttnn.copy_host_to_device_tensor(pooled_projection, self.pooled_projection_input)
+        ttnn.copy_host_to_device_tensor(timestep, self.timestep_input)
+
+        ttnn.execute_trace(device, self.tid)
+
+        return self.output

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/transformer_block.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/transformer_block.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import ttnn
+
+from . import utils
+from .attention import TtAttention, TtAttentionParameters
+from .feed_forward import TtFeedForward, TtFeedForwardParameters
+from .linear import TtLinear, TtLinearParameters
+from .normalization import TtLayerNorm, TtLayerNormParameters
+from .substate import has_substate, substate
+
+if TYPE_CHECKING:
+    import torch
+
+
+@dataclass
+class TtTransformerBlockParameters:
+    dual_attn: TtAttentionParameters
+    spatial_attn: TtAttentionParameters | None
+    prompt_time_embed: TtLinearParameters
+    spatial_time_embed: TtLinearParameters
+    prompt_norm_1: TtLayerNormParameters
+    prompt_norm_2: TtLayerNormParameters
+    spatial_norm_1: TtLayerNormParameters
+    spatial_norm_2: TtLayerNormParameters
+    prompt_ff: TtFeedForwardParameters | None
+    spatial_ff: TtFeedForwardParameters
+    distributed: bool
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        num_heads: int,
+        unpadded_num_heads: int,
+        hidden_dim_padding: int,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.Device,
+    ) -> TtTransformerBlockParameters:
+        embedding_dim = state["norm1.linear.weight"].shape[1]
+
+        def norm(state: dict[str, torch.Tensor]) -> TtLayerNormParameters:
+            return TtLayerNormParameters.from_torch(
+                state,
+                dtype=dtype,
+                device=device,
+                weight_shape=[embedding_dim + hidden_dim_padding],
+            )
+
+        has_spatial_attn = has_substate(state, "attn2")
+        has_ff_context = has_substate(state, "ff_context")
+        spatial_time_embed_chunks = 9 if has_spatial_attn else 6
+        prompt_time_embed_chunks = 2 if not has_ff_context else 6
+        return cls(
+            dual_attn=TtAttentionParameters.from_torch(
+                substate(state, "attn"),
+                num_heads=num_heads,
+                unpadded_num_heads=unpadded_num_heads,
+                hidden_dim_padding=hidden_dim_padding,
+                dtype=dtype,
+                device=device,
+            ),
+            spatial_attn=TtAttentionParameters.from_torch(
+                substate(state, "attn2"),
+                num_heads=num_heads,
+                unpadded_num_heads=unpadded_num_heads,
+                hidden_dim_padding=hidden_dim_padding,
+                dtype=dtype,
+                device=device,
+            )
+            if has_spatial_attn
+            else None,
+            spatial_norm_1=norm(substate(state, "norm1.norm")),
+            spatial_norm_2=norm(substate(state, "norm2")),
+            prompt_norm_1=norm(substate(state, "norm1_context.norm")),
+            prompt_norm_2=norm({}),
+            spatial_time_embed=TtLinearParameters.from_torch_time_embed(
+                substate(state, "norm1.linear"),
+                dtype=dtype,
+                device=device,
+                num_chunks=spatial_time_embed_chunks,
+                hidden_dim_padding=hidden_dim_padding,
+                unsqueeze_bias=True,
+            ),
+            prompt_time_embed=TtLinearParameters.from_torch_time_embed(
+                substate(state, "norm1_context.linear"),
+                dtype=dtype,
+                device=device,
+                num_chunks=prompt_time_embed_chunks,
+                hidden_dim_padding=hidden_dim_padding,
+                unsqueeze_bias=True,
+            ),
+            spatial_ff=TtFeedForwardParameters.from_torch(substate(state, "ff"), dtype=dtype, device=device),
+            prompt_ff=TtFeedForwardParameters.from_torch(substate(state, "ff_context"), dtype=dtype, device=device)
+            if has_ff_context
+            else None,
+            distributed=device.get_num_devices() > 1,
+        )
+
+
+class TtTransformerBlock:
+    def __init__(
+        self,
+        parameters: TtTransformerBlockParameters,
+        *,
+        num_heads: int,
+        device,
+    ) -> None:
+        eps = 1e-6
+
+        self._dual_attn = TtAttention(parameters.dual_attn, num_heads=num_heads, device=device)
+        self._spatial_attn = (
+            TtAttention(parameters.spatial_attn, num_heads=num_heads, device=device)
+            if parameters.spatial_attn is not None
+            else None
+        )
+
+        self._spatial_norm_1 = TtLayerNorm(parameters.spatial_norm_1, eps=eps)
+        self._spatial_norm_2 = TtLayerNorm(parameters.spatial_norm_2, eps=eps)
+        self._prompt_norm_1 = TtLayerNorm(parameters.prompt_norm_1, eps=eps)
+        self._prompt_norm_2 = TtLayerNorm(parameters.prompt_norm_2, eps=eps)
+
+        self._spatial_ff = TtFeedForward(parameters.spatial_ff)
+        self._prompt_ff = TtFeedForward(parameters.prompt_ff) if parameters.prompt_ff is not None else None
+
+        self._spatial_time_embed = TtLinear(parameters.spatial_time_embed)
+        self._prompt_time_embed = TtLinear(parameters.prompt_time_embed)
+
+        self._context_pre_only = self._prompt_ff is None
+        self._distributed = parameters.distributed
+
+    def _spatial_attn_block(
+        self, inp: ttnn.Tensor, *, gate: ttnn.Tensor, scale: ttnn.Tensor, shift: ttnn.Tensor
+    ) -> ttnn.Tensor:
+        assert self._spatial_attn is not None
+        scaled = inp * (1 + scale) + shift
+        attn, _ = self._spatial_attn(spatial=scaled, deallocate=True)
+
+        result = gate * attn
+        ttnn.deallocate(scaled)
+        ttnn.deallocate(attn)
+        return result
+
+    def _dual_attn_block(
+        self,
+        *,
+        spatial: ttnn.Tensor,
+        prompt: ttnn.Tensor,
+        spatial_gate: ttnn.Tensor,
+        prompt_gate: ttnn.Tensor | None,
+        prompt_scale: ttnn.Tensor,
+        prompt_shift: ttnn.Tensor,
+        spatial_scale: ttnn.Tensor,
+        spatial_shift: ttnn.Tensor,
+        N: int,
+        L: int,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor | None]:
+        spatial_scaled = spatial * (1 + spatial_scale) + spatial_shift
+        prompt_scaled = prompt * (1 + prompt_scale) + prompt_shift
+        if self._distributed:
+            spatial_scaled = utils.all_gather(spatial_scaled, dim=-1)
+            prompt_scaled = utils.all_gather(prompt_scaled, dim=-1)
+        spatial_attn, prompt_attn = self._dual_attn(
+            spatial=spatial_scaled, prompt=prompt_scaled, deallocate=True, N=N, L=L
+        )
+        spatial_attn_scaled = spatial_gate * spatial_attn
+        prompt_attn_scaled = prompt_gate * prompt_attn if prompt_gate is not None else None
+        ttnn.deallocate(spatial_attn)
+        ttnn.deallocate(prompt_attn)
+        return spatial_attn_scaled, prompt_attn_scaled
+
+    def _spatial_ff_block(
+        self, inp: ttnn.Tensor, *, gate: ttnn.Tensor, scale: ttnn.Tensor, shift: ttnn.Tensor
+    ) -> ttnn.Tensor:
+        scaled = inp * (1 + scale) + shift
+        if self._distributed:
+            scaled = utils.all_gather(scaled, dim=-1)
+        result = gate * self._spatial_ff(scaled)
+        ttnn.deallocate(scaled)
+        return result
+
+    def _prompt_ff_block(
+        self, inp: ttnn.Tensor, *, gate: ttnn.Tensor, scale: ttnn.Tensor, shift: ttnn.Tensor
+    ) -> ttnn.Tensor:
+        assert self._prompt_ff is not None
+
+        scaled = inp * (1 + scale) + shift
+        if self._distributed:
+            scaled = utils.all_gather(scaled, dim=-1)
+        result = gate * self._prompt_ff(scaled)
+        ttnn.deallocate(scaled)
+        return result
+
+    def __call__(  # noqa: PLR0915
+        self, *, spatial: ttnn.Tensor, prompt: ttnn.Tensor, time_embed: ttnn.Tensor, N: int, L: int
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor | None]:
+        t = utils.silu(time_embed)
+        spatial_time = self._spatial_time_embed(t, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        prompt_time = self._prompt_time_embed(t, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        ttnn.deallocate(t)
+        if self._spatial_attn is not None:
+            [
+                spatial_shift_dual_attn,
+                spatial_scale_dual_attn,
+                spatial_gate_dual_attn,
+                spatial_shift_ff,
+                spatial_scale_ff,
+                spatial_gate_ff,
+                spatial_shift_attn,
+                spatial_scale_attn,
+                spatial_gate_attn,
+            ] = chunk_time(spatial_time, 9)
+        else:
+            [
+                spatial_shift_dual_attn,
+                spatial_scale_dual_attn,
+                spatial_gate_dual_attn,
+                spatial_shift_ff,
+                spatial_scale_ff,
+                spatial_gate_ff,
+            ] = chunk_time(spatial_time, 6)
+
+            spatial_gate_attn = None
+            spatial_shift_attn = None
+            spatial_scale_attn = None
+
+        if self._context_pre_only:
+            # print(f"chunking prompt_time for context pre only: {prompt_time.shape}")
+            [
+                prompt_scale_attn,
+                prompt_shift_attn,
+            ] = chunk_time(prompt_time, 2)
+
+            prompt_gate_attn = None
+            prompt_shift_ff = None
+            prompt_scale_ff = None
+            prompt_gate_ff = None
+        else:
+            # print(f"not context pre only: {prompt_time.shape}")
+            [
+                prompt_shift_attn,
+                prompt_scale_attn,
+                prompt_gate_attn,
+                prompt_shift_ff,
+                prompt_scale_ff,
+                prompt_gate_ff,
+            ] = chunk_time(prompt_time, 6)
+
+        spatial_normed = self._spatial_norm_1(spatial)
+        prompt_normed = self._prompt_norm_1(prompt)
+        spatial_attn, prompt_attn = self._dual_attn_block(
+            spatial=spatial_normed,
+            prompt=prompt_normed,
+            spatial_gate=spatial_gate_dual_attn,
+            prompt_gate=prompt_gate_attn,
+            prompt_scale=prompt_scale_attn,
+            prompt_shift=prompt_shift_attn,
+            spatial_scale=spatial_scale_dual_attn,
+            spatial_shift=spatial_shift_dual_attn,
+            N=N,
+            L=L,
+        )
+        ttnn.deallocate(prompt_normed)
+        ttnn.deallocate(spatial_gate_dual_attn)
+        if prompt_gate_attn is not None:
+            ttnn.deallocate(prompt_gate_attn)
+        ttnn.deallocate(prompt_scale_attn)
+        ttnn.deallocate(prompt_shift_attn)
+        ttnn.deallocate(spatial_scale_dual_attn)
+        ttnn.deallocate(spatial_shift_dual_attn)
+
+        spatial += spatial_attn
+        ttnn.deallocate(spatial_attn)
+
+        # TODO Check with Colman how to handle this
+        self._spatial_attn = None
+        if self._spatial_attn is not None:
+            # assert False, "Not supporting right now on Colman's branch"
+            # assert spatial_gate_attn is not None
+            # assert spatial_scale_attn is not None
+            # assert spatial_shift_attn is not None
+
+            spatial += self._spatial_attn_block(
+                spatial_normed, gate=spatial_gate_attn, scale=spatial_scale_attn, shift=spatial_shift_attn
+            )
+            ttnn.deallocate(spatial_normed)
+            ttnn.deallocate(spatial_gate_attn)
+            ttnn.deallocate(spatial_scale_attn)
+            ttnn.deallocate(spatial_shift_attn)
+
+        spatial_normed = self._spatial_norm_2(spatial)
+        spatial += self._spatial_ff_block(
+            spatial_normed, gate=spatial_gate_ff, scale=spatial_scale_ff, shift=spatial_shift_ff
+        )
+        ttnn.deallocate(spatial_normed)
+        ttnn.deallocate(spatial_gate_ff)
+        ttnn.deallocate(spatial_scale_ff)
+        ttnn.deallocate(spatial_shift_ff)
+
+        if self._context_pre_only:
+            return spatial, None
+
+        assert prompt_scale_ff is not None
+        assert prompt_shift_ff is not None
+        assert prompt_gate_ff is not None
+
+        prompt += prompt_attn
+        ttnn.deallocate(prompt_attn)
+        prompt_normed = self._prompt_norm_2(prompt)
+        prompt += self._prompt_ff_block(
+            prompt_normed,
+            gate=prompt_gate_ff,
+            scale=prompt_scale_ff,
+            shift=prompt_shift_ff,
+        )
+        ttnn.deallocate(prompt_normed)
+        ttnn.deallocate(prompt_gate_ff)
+        ttnn.deallocate(prompt_scale_ff)
+        ttnn.deallocate(prompt_shift_ff)
+
+        return spatial, prompt
+
+
+def chunk_time(t: ttnn.Tensor, count: int) -> list[ttnn.Tensor]:
+    size = t.shape[-1] // count
+    return [t[:, :, :, i * size : (i + 1) * size] for i in range(count)]
+
+
+def chunk_device_tensors(ttnn_tensor: ttnn.Tensor, count: int) -> list[ttnn.Tensor]:
+    size = ttnn_tensor.shape[-1] // count
+    device_slices = []
+    for i, device_tensor in enumerate(ttnn.get_device_tensors(ttnn_tensor)):
+        device_slice = device_tensor[:, :, :, i * size : (i + 1) * size]
+        device_slices.append(device_slice)
+    return device_slices

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/utils.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/utils.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+
+import torch
+import ttnn
+from loguru import logger
+
+
+def allocate_tensor_on_device_like(
+    t: ttnn.Tensor, *, device: ttnn.Device, memory_config: ttnn.MemoryConfig | None = None
+) -> ttnn.Tensor:
+    return ttnn.allocate_tensor_on_device(t.shape, t.dtype, t.layout, device, memory_config=memory_config)
+
+
+def to_torch(
+    tensor: torch.Tensor,
+    *,
+    mesh_device: ttnn.MeshDevice | None = None,  # this is only used to construct a mesh composer
+    dtype: torch.dtype | None = None,
+    mesh_composer: ttnn.CppMeshToTensor | None = None,
+    shard_dim: int | None = None,
+    fix_special_numbers: bool = False,
+) -> torch.Tensor:
+    if shard_dim is not None:
+        mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=shard_dim)
+
+    if mesh_composer is None:
+        tensor = ttnn.get_device_tensors(tensor)[0]
+
+    result = ttnn.to_torch(tensor, mesh_composer=mesh_composer)
+
+    # ttnn.to_torch ignores the dtype argument if a mesh composer is supplied
+    if dtype is not None:
+        result = result.to(dtype)
+
+    if not fix_special_numbers:
+        return result
+
+    assert dtype in [torch.float32, torch.float64]
+
+    mask = torch.isnan(result) | torch.isinf(result)
+    negative = torch.signbit(result)
+
+    finfo = torch.finfo(dtype)
+    result[mask.logical_and(~negative)] = finfo.max
+    result[mask.logical_and(negative)] = finfo.min
+
+    return result
+
+
+def from_torch_fast(
+    t: torch.Tensor,
+    *,
+    device: ttnn.Device | ttnn.MeshDevice | None = None,
+    layout: ttnn.Layout | None = None,
+    dtype: ttnn.DataType | None = None,
+    memory_config: ttnn.MemoryConfig | None = None,
+    to_host: bool = False,
+    mesh_mapper: ttnn.TensorToMesh | None = None,
+    # The argument shard_dim is a bit problematic. If set, it creates a mesh mapper with the given
+    # device. But for a host tensor, the device is None, so a mesh mapper can not be created.
+    shard_dim: int | None = None,
+) -> ttnn.Tensor:
+    assert shard_dim is None or device is not None, "shard_dim requires device"
+
+    if isinstance(device, ttnn.MeshDevice):
+        if shard_dim is not None:
+            mesh_mapper = ttnn.ShardTensorToMesh(device, dim=shard_dim)
+        if mesh_mapper is None:
+            mesh_mapper = ttnn.ReplicateTensorToMesh(device)
+    elif isinstance(device, ttnn.Device):
+        mesh_mapper = None
+
+    float32_in = t.dtype == torch.float32
+    float32_out = dtype == ttnn.float32 or (dtype is None and float32_in)
+
+    # ttnn.to_layout does not support changing the datatype or memory_config if the layout already matches. ttnn.clone
+    # does not support changing the datatype if the input is not tiled. An option could be to tilize the input before
+    # changing the datatype and then untilize again, but it was not tested if this would be faster than converting the
+    # datatype on the host. Also ttnn.to_dtype does not support device tensors. Additionally, `ttnn.to_layout` is lossy
+    # for float32.
+    if device is None or layout is None or layout == ttnn.ROW_MAJOR_LAYOUT or (float32_in and float32_out):
+        return ttnn.from_torch(
+            t,
+            device=None if to_host else device,
+            layout=layout,
+            dtype=dtype,
+            memory_config=memory_config,
+            mesh_mapper=mesh_mapper,
+        )
+
+    tensor = ttnn.from_torch(t, device=device, mesh_mapper=mesh_mapper)
+
+    if tensor.shape[-2] == 32 and t.shape[-2] == 1:
+        # Work around the fact that the shape is erroneously set to the padded shape under certain conditions.
+        assert isinstance(device, ttnn.MeshDevice)
+        assert dtype in (ttnn.bfloat4_b, ttnn.bfloat8_b)
+        tensor = tensor.reshape(ttnn.Shape(t.shape))
+
+    tensor = ttnn.to_layout(tensor, layout, dtype=dtype, memory_config=memory_config)
+
+    if to_host:
+        tensor = tensor.cpu()
+
+    return tensor
+
+
+def to_memory_config(
+    t: ttnn.Tensor, memory_config: ttnn.MemoryConfig, *, dtype: ttnn.DataType | None = None, deallocate: bool = False
+) -> ttnn.Tensor:
+    result = ttnn.to_memory_config(t, memory_config, dtype=dtype)
+
+    result_is_same = result.memory_config() == t.memory_config() and result.buffer_address() == t.buffer_address()
+    if deallocate and not result_is_same:
+        ttnn.deallocate(t)
+
+    return result
+
+
+def assert_quality(
+    a: ttnn.Tensor | torch.Tensor,
+    b: ttnn.Tensor | torch.Tensor,
+    *,
+    num_devices: int | None = None,
+    pcc: float | None = None,
+    ccc: float | None = None,
+    mse: float | None = None,
+    relative_rmse: float | None = None,
+    shard_dim: int | None = None,
+) -> None:
+    if isinstance(a, ttnn.Tensor):
+        a = to_torch(
+            a,
+            mesh_device=a.device(),
+            dtype=torch.float32,
+            shard_dim=shard_dim,
+            fix_special_numbers=True,
+        )
+        if num_devices is not None:
+            assert shard_dim == 0
+            a = a[0 : a.shape[0] // num_devices, ...]
+
+    if isinstance(b, ttnn.Tensor):
+        b = to_torch(
+            b,
+            mesh_device=b.device(),
+            dtype=torch.float32,
+            shard_dim=shard_dim,
+            fix_special_numbers=True,
+        )
+        if num_devices is not None:
+            assert shard_dim == 0
+            b = b[0 : b.shape[0] // num_devices, ...]
+
+    if math.prod(a.shape) != math.prod(b.shape):
+        msg = f"incompatible shapes: {a.shape} != {b.shape}"
+        raise ValueError(msg)
+
+    if a.shape != b.shape:
+        logger.warning(f"shape mismatch: {a.shape} != {b.shape}")
+
+    a = a.detach().flatten().to(torch.float64)
+    b = b.detach().flatten().to(torch.float64)
+
+    cov = torch.cov(torch.stack([a, b])).numpy()
+
+    std_a = math.sqrt(cov[0, 0])
+    std_b = math.sqrt(cov[1, 1])
+    mean_a = a.mean().item()
+    mean_b = b.mean().item()
+
+    pcc_found = cov[0, 1] / (std_a * std_b)
+    beta_found = cov[0, 1] / cov[0, 0]
+    ccc_found = 2 * pcc_found * std_a * std_b / (std_a**2 + std_b**2 + (mean_a - mean_b) ** 2)
+    relative_rmse_found = torch.nn.functional.mse_loss(a, b).sqrt().item() / std_a
+
+    if mse is not None:
+        relative_rmse = math.sqrt(mse) / std_a
+
+    logger.info(f"μ₁ = {mean_a:.3g}, μ₂ = {mean_b:.3g}, σ₁ = {std_a:.3g}, σ₂ = {std_b:.3g}")
+    logger.info(
+        f"PCC = {pcc_found * 100:.4f} %, "
+        f"β = {beta_found * 100:.1f} %, "
+        f"CCC = {ccc_found * 100:.4f} %, "
+        f"RMSE/σ₁ = {relative_rmse_found * 100:.1f} %"
+    )
+
+    if pcc is not None and pcc_found < pcc:
+        msg = f"PCC = {pcc_found * 100:.4f} % >= {pcc * 100:.4f} %"
+        raise Exception(msg)  # noqa: TRY002
+
+    if ccc is not None and ccc_found < ccc:
+        msg = f"CCC = {ccc_found * 100:.4f} % >= {ccc * 100:.4f} %"
+        raise Exception(msg)  # noqa: TRY002
+
+    if relative_rmse is not None and relative_rmse_found > relative_rmse:
+        msg = f"RMSE/σ₁ = {relative_rmse_found * 100:.1f} % <= {relative_rmse * 100:.1f} %"
+        raise Exception(msg)  # noqa: TRY002
+
+
+def all_gather(
+    x: ttnn.Tensor,
+    dim: int,
+    *,
+    cluster_axis: int | None = None,
+    mesh_device: ttnn.MeshDevice | None = None,
+    num_links: int = 1,
+    topology: ttnn.Topology = ttnn.Topology.Ring,
+    memory_config: ttnn.MemoryConfig | None = None,
+) -> ttnn.Tensor:
+    assert cluster_axis is None or mesh_device is not None, "cluster_axis requires mesh_device to be set"
+    assert x.shape[dim] == x.padded_shape[dim], f"dimension {dim} of {x.shape} should not be padded"
+
+    shape = list(x.shape)
+
+    reshape = x.shape != x.padded_shape
+    if reshape:
+        x = ttnn.reshape(x, x.padded_shape, x.padded_shape)
+
+    if cluster_axis is not None:
+        x = ttnn.all_gather(
+            x,
+            dim,
+            cluster_axis,
+            mesh_device,
+            num_links=num_links,
+            topology=topology,
+            memory_config=memory_config,
+        )
+
+    x = ttnn.all_gather(
+        x,
+        dim,
+        num_links=num_links,
+        topology=topology,
+        memory_config=memory_config,
+    )
+
+    if reshape:
+        shape[dim] = x.shape[dim]
+        x = ttnn.reshape(x, shape, x.padded_shape)
+
+    return x
+
+
+def silu(x: ttnn.Tensor) -> ttnn.Tensor:
+    """More accurate version of `ttnn.silu`"""
+    return ttnn.div(x, ttnn.exp(ttnn.neg(x)) + 1)

--- a/tt-metal-sdxl/tt_model_runners/sd35_utils/vae_decoder.py
+++ b/tt-metal-sdxl/tt_model_runners/sd35_utils/vae_decoder.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import ttnn
+
+from .conv2d import TtConv2d, TtConv2dParameters
+from .group_norm import TtGroupNorm, TtGroupNormParameters
+from .linear import TtLinear, TtLinearParameters
+from .substate import has_substate, indexed_substates, substate
+
+if TYPE_CHECKING:
+    import torch
+
+
+@dataclass
+class TtVaeDecoderParameters:
+    conv_in: TtConv2dParameters
+    mid_block: TtUNetMidBlock2DParameters
+    up_blocks: list[TtUpDecoderBlock2DParameters]
+    conv_norm_out: TtGroupNormParameters
+    conv_out: TtConv2dParameters
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.MeshDevice,
+    ) -> TtVaeDecoderParameters:
+        return cls(
+            conv_in=TtConv2dParameters.from_torch(substate(state, "conv_in"), dtype=dtype, device=device),
+            conv_out=TtConv2dParameters.from_torch(substate(state, "conv_out"), dtype=dtype, device=device),
+            conv_norm_out=TtGroupNormParameters.from_torch(substate(state, "conv_norm_out"), device=device),
+            mid_block=TtUNetMidBlock2DParameters.from_torch(substate(state, "mid_block"), dtype=dtype, device=device),
+            up_blocks=[
+                TtUpDecoderBlock2DParameters.from_torch(s, dtype=dtype, device=device)
+                for s in indexed_substates(state, "up_blocks")
+            ],
+        )
+
+
+class TtVaeDecoder:
+    def __init__(self, parameters: TtVaeDecoderParameters, *, norm_num_groups: int = 32) -> None:
+        super().__init__()
+
+        attention_head_dim = parameters.up_blocks[0].resnets[0].conv1.in_channels
+
+        self._conv_in = TtConv2d(parameters.conv_in, padding=(1, 1))
+        self._mid_block = TtUNetMidBlock2D(
+            parameters.mid_block, attention_head_dim=attention_head_dim, resnet_groups=norm_num_groups
+        )
+        self._up_blocks = [TtUpDecoderBlock2D(p, resnet_groups=norm_num_groups) for p in parameters.up_blocks]
+        self._conv_norm_out = TtGroupNorm(parameters.conv_norm_out, num_groups=norm_num_groups, eps=1e-6)
+        self._conv_out = TtConv2d(parameters.conv_out, padding=(1, 1))
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        x = self._conv_in(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        x = self._mid_block(x)
+
+        for up_block in self._up_blocks:
+            x = up_block(x)
+
+        x = self._conv_norm_out(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        x = ttnn.silu(x)
+        return self._conv_out(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+
+@dataclass
+class TtUpDecoderBlock2DParameters:
+    resnets: list[TtResnetBlock2DParameters]
+    upsampler: TtConv2dParameters | None
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.MeshDevice,
+    ) -> TtUpDecoderBlock2DParameters:
+        return cls(
+            resnets=[
+                TtResnetBlock2DParameters.from_torch(s, dtype=dtype, device=device)
+                for s in indexed_substates(state, "resnets")
+            ],
+            upsampler=TtConv2dParameters.from_torch(substate(state, "upsamplers.0.conv"), dtype=dtype, device=device)
+            if has_substate(state, "upsamplers.0.conv")
+            else None,
+        )
+
+    @property
+    def in_channels(self) -> int:
+        return self.resnets[0].in_channels
+
+
+class TtUpDecoderBlock2D:
+    def __init__(self, parameters: TtUpDecoderBlock2DParameters, *, resnet_groups: int) -> None:
+        super().__init__()
+
+        self._resnets = [TtResnetBlock2D(p, num_groups=resnet_groups) for p in parameters.resnets]
+        self._upsampler_conv = (
+            TtConv2d(parameters.upsampler, padding=(1, 1)) if parameters.upsampler is not None else None
+        )
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        for resnet in self._resnets:
+            x = resnet(x)
+
+        if self._upsampler_conv is not None:
+            x = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
+            x = ttnn.upsample(x, 2)
+            x = self._upsampler_conv(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        return x
+
+
+@dataclass
+class TtUNetMidBlock2DParameters:
+    attention: TtAttentionParameters
+    resnet1: TtResnetBlock2DParameters
+    resnet2: TtResnetBlock2DParameters
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.MeshDevice,
+    ) -> TtUNetMidBlock2DParameters:
+        return cls(
+            resnet1=TtResnetBlock2DParameters.from_torch(substate(state, "resnets.0"), dtype=dtype, device=device),
+            resnet2=TtResnetBlock2DParameters.from_torch(substate(state, "resnets.1"), dtype=dtype, device=device),
+            attention=TtAttentionParameters.from_torch(substate(state, "attentions.0"), dtype=dtype, device=device),
+        )
+
+
+class TtUNetMidBlock2D:
+    def __init__(
+        self,
+        parameters: TtUNetMidBlock2DParameters,
+        *,
+        resnet_groups: int,
+        attention_head_dim: int,
+    ) -> None:
+        super().__init__()
+
+        self._attention = TtAttention(
+            parameters.attention,
+            dim_head=attention_head_dim,
+            norm_num_groups=resnet_groups,
+        )
+
+        self._resnet1 = TtResnetBlock2D(parameters.resnet1, num_groups=resnet_groups)
+        self._resnet2 = TtResnetBlock2D(parameters.resnet2, num_groups=resnet_groups)
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        x = self._resnet1(x)
+        x = self._attention(x)
+        return self._resnet2(x)
+
+
+@dataclass
+class TtResnetBlock2DParameters:
+    norm1: TtGroupNormParameters
+    norm2: TtGroupNormParameters
+    conv1: TtConv2dParameters
+    conv2: TtConv2dParameters
+    conv_shortcut: TtConv2dParameters | None
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.MeshDevice,
+    ) -> TtResnetBlock2DParameters:
+        return cls(
+            norm1=TtGroupNormParameters.from_torch(substate(state, "norm1"), device=device),
+            norm2=TtGroupNormParameters.from_torch(substate(state, "norm2"), device=device),
+            conv1=TtConv2dParameters.from_torch(substate(state, "conv1"), dtype=dtype, device=device),
+            conv2=TtConv2dParameters.from_torch(substate(state, "conv2"), dtype=dtype, device=device),
+            conv_shortcut=TtConv2dParameters.from_torch(substate(state, "conv_shortcut"), dtype=dtype, device=device)
+            if has_substate(state, "conv_shortcut")
+            else None,
+        )
+
+    @property
+    def in_channels(self) -> int:
+        return self.conv1.in_channels
+
+
+class TtResnetBlock2D:
+    def __init__(
+        self,
+        parameters: TtResnetBlock2DParameters,
+        *,
+        num_groups: int,
+        eps: float = 1e-6,
+    ) -> None:
+        super().__init__()
+
+        self.norm1 = TtGroupNorm(parameters.norm1, num_groups=num_groups, eps=eps)
+        self.norm2 = TtGroupNorm(parameters.norm2, num_groups=num_groups, eps=eps)
+        self.conv1 = TtConv2d(parameters.conv1, padding=(1, 1))
+        self.conv2 = TtConv2d(parameters.conv2, padding=(1, 1))
+        self.conv_shortcut = TtConv2d(parameters.conv_shortcut) if parameters.conv_shortcut is not None else None
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        residual = x
+
+        x = self.norm1(x)
+
+        x = ttnn.silu(x)
+        x = self.conv1(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        x = self.norm2(x)
+
+        x = ttnn.silu(x)
+        x = self.conv2(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        if self.conv_shortcut is not None:
+            residual = self.conv_shortcut(residual, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        return residual + x
+
+
+@dataclass
+class TtAttentionParameters:
+    group_norm: TtGroupNormParameters
+    to_q: TtLinearParameters
+    to_k: TtLinearParameters
+    to_v: TtLinearParameters
+    to_out: TtLinearParameters
+
+    @classmethod
+    def from_torch(
+        cls,
+        state: dict[str, torch.Tensor],
+        *,
+        dtype: ttnn.DataType | None = None,
+        device: ttnn.MeshDevice,
+    ) -> TtAttentionParameters:
+        return cls(
+            group_norm=TtGroupNormParameters.from_torch(substate(state, "group_norm"), device=device),
+            to_q=TtLinearParameters.from_torch(substate(state, "to_q"), dtype=dtype, device=device),
+            to_k=TtLinearParameters.from_torch(substate(state, "to_k"), dtype=dtype, device=device),
+            to_v=TtLinearParameters.from_torch(substate(state, "to_v"), dtype=dtype, device=device),
+            to_out=TtLinearParameters.from_torch(substate(state, "to_out.0"), dtype=dtype, device=device),
+        )
+
+
+class TtAttention:
+    def __init__(self, parameters: TtAttentionParameters, *, norm_num_groups: int, dim_head: int) -> None:
+        super().__init__()
+
+        self._num_heads = parameters.to_q.out_channels // dim_head
+
+        self._group_norm = TtGroupNorm(parameters.group_norm, num_groups=norm_num_groups, eps=1e-6)
+        self.to_q = TtLinear(parameters.to_q)
+        self.to_k = TtLinear(parameters.to_k)
+        self.to_v = TtLinear(parameters.to_v)
+        self.to_out = TtLinear(parameters.to_out)
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        residual = x
+
+        x = self._group_norm(x)
+
+        batch_size, height, width, features = list(x.shape)
+        x = x.reshape([batch_size, height * width, features])
+
+        q = self.to_q(x)
+        k = self.to_k(x)
+        v = self.to_v(x)
+
+        qkv = ttnn.concat([q, k, v], dim=-1)
+        q, k, v = ttnn.transformer.split_query_key_value_and_split_heads(
+            qkv, num_heads=self._num_heads, transpose_key=False
+        )
+
+        program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=[8, 8],
+            q_chunk_size=128,
+            k_chunk_size=128,
+            exp_approx_mode=True,
+        )
+
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+        )
+
+        # operands must be in DRAM
+        x = ttnn.transformer.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            is_causal=False,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+        )
+        ttnn.deallocate(q)
+        ttnn.deallocate(k)
+        ttnn.deallocate(v)
+
+        assert self._num_heads == 1
+        x = x.reshape([batch_size, height, width, features])
+
+        x = self.to_out(x)
+
+        return x + residual

--- a/tt-metal-sdxl/tt_model_runners/sdxl_runner.py
+++ b/tt-metal-sdxl/tt_model_runners/sdxl_runner.py
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import asyncio
+from typing import List
+from config.settings import settings
 from tests.scripts.common import get_updated_device_params
 from tt_model_runners.base_device_runner import DeviceRunner
 from utils.logger import TTLogger
@@ -30,14 +32,13 @@ class TTSDXLRunner(DeviceRunner):
     ttnn_text_embeds = None
     ttnn_timesteps = []
     extra_step_kwargs = None
-    guidance_scale = 5.0
     scaling_factor = None
     tt_vae = None
     pipeline = None
     latents = None
 
-    def __init__(self):
-        pass
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
         self.logger = TTLogger()
 
     def _set_fabric(self,fabric_config):
@@ -48,6 +49,10 @@ class TTSDXLRunner(DeviceRunner):
     def _reset_fabric(self, fabric_config):
         if fabric_config:
             ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+    def get_device(self):
+        # for now use all availalbe devices
+        return self._mesh_device()
 
     def _mesh_device(self):
         device_params = {'l1_small_size': 57344}
@@ -76,16 +81,25 @@ class TTSDXLRunner(DeviceRunner):
         self.logger.info(f"multidevice with {mesh_device.get_num_devices()} devices is created")
         return mesh_device
 
+    def get_devices(self) -> List[ttnn.MeshDevice]:
+        device = self._mesh_device()
+        device_shape = settings.device_mesh_shape
+        return device.create_submeshes(ttnn.MeshShape(*device_shape))
+
     def close_device(self) -> bool:
         for submesh in self.mesh_device.get_submeshes():
             ttnn.close_mesh_device(submesh)
         ttnn.close_mesh_device(self.mesh_device)
 
-    async def load_model(self)->bool:
+    async def load_model(self, device)->bool:
         self.logger.info("Loading model...")
-        self.ttnn_device = self._mesh_device()
+        if (device is None):
+            self.ttnn_device = self._mesh_device()
+        else:
+            self.ttnn_device = device
 
         # 1. Load components
+        # TODO check how to point to a model file
         self.pipeline = DiffusionPipeline.from_pretrained(
             "stabilityai/stable-diffusion-xl-base-1.0",
             torch_dtype=torch.float32,
@@ -177,7 +191,7 @@ class TTSDXLRunner(DeviceRunner):
         all_embeds = [
             self.pipeline.encode_prompt(
                 prompt=prompt,
-                prompt_2=None,
+                prompt_2=None, # Negative prompt
                 device=cpu_device,
                 num_images_per_prompt=1,
                 do_classifier_free_guidance=True,
@@ -319,7 +333,6 @@ class TTSDXLRunner(DeviceRunner):
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.ttnn_device),
         )
-
 
         images = []
         self.logger.info("Starting ttnn inference...")


### PR DESCRIPTION
Changes

* SD3.5 large basic support
* Mock mode for device runner
* Using sub mashes to max possible size
* Threads instead of processes (due to sharing of the objects)