### PR TITLE
Remove trust_remote_code for livecodebench

### DIFF
--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -170,10 +170,6 @@ def build_eval_command(
     if task.apply_chat_template:
         cmd.append("--apply_chat_template")  # Flag argument (no value)
 
-    # Add --trust_remote_code for tasks that require custom dataset loading code
-    if task.task_name == "livecodebench":
-        cmd.append("--trust_remote_code")
-
     # force all cmd parts to be strs
     cmd = [str(c) for c in cmd]
     return cmd


### PR DESCRIPTION
### Summary
This PR removes the deprecated --trust_remote_code flag that was previously required for the livecodebench evaluation task. With recent updates to the datasets python package, this flag is no longer needed and has been deprecated.

### Background
The `--trust_remote_code` flag was originally added when implementing `LiveCodeBench`, which required custom dataset loading code. However, with the datasets python package version update (3.6.0 -> 4.0.0), this command line option has been deprecated and is no longer necessary.

### Changes Made
#### File: `evals/run_evals.py` (lines 173-175)
Removed the conditional logic that added `--trust_remote_code` flag specifically for the livecodebench task
Eliminates usage of deprecated functionality

#### Note: 
Discussion revolving around this topic has been raised in this issue on the original repo of lm-evlaution-harness: https://github.com/EleutherAI/lm-evaluation-harness/issues/3171
