### PR TITLE
Fix import path for MODEL_SPECS in build_docker_images.py

### DIFF
--- a/scripts/build_docker_images.py
+++ b/scripts/build_docker_images.py
@@ -19,7 +19,7 @@ project_root = Path(__file__).resolve().parent.parent
 if project_root not in sys.path:
     sys.path.insert(0, str(project_root))
 
-from workflows.model_specification import MODEL_SPECS
+from workflows.model_spec import MODEL_SPECS
 from workflows.utils import get_repo_root_path
 from workflows.log_setup import setup_workflow_script_logger
 


### PR DESCRIPTION
Fix typo:

```
Traceback (most recent call last):
  File "/tmp/test/tt-inference-server/scripts/build_docker_images.py", line 22, in <module>
    from workflows.model_specification import MODEL_SPECS
ModuleNotFoundError: No module named 'workflows.model_specification'
```