### PR TITLE
Fix: Add MAX_PREFILL_CHUNK_SIZE env var to Qwen2.5 72B

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -760,7 +760,6 @@ spec_templates = [
         status=ModelStatusTypes.EXPERIMENTAL,
         env_vars={
             "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
-            "MAX_PREFILL_CHUNK_SIZE": "16",
         },
     ),
     ModelSpecTemplate(

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -747,8 +747,8 @@ spec_templates = [
     ModelSpecTemplate(
         weights=["Qwen/Qwen2.5-72B", "Qwen/Qwen2.5-72B-Instruct"],
         impl=llama3_impl,
-        tt_metal_commit="v0.56.0-rc33",
-        vllm_commit="e2e0002ac7dc",
+        tt_metal_commit="v0.62.0-rc8",
+        vllm_commit="c348d08",
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.T3K,
@@ -760,13 +760,14 @@ spec_templates = [
         status=ModelStatusTypes.EXPERIMENTAL,
         env_vars={
             "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+            "MAX_PREFILL_CHUNK_SIZE": "16",
         },
     ),
     ModelSpecTemplate(
         weights=["Qwen/Qwen2.5-72B", "Qwen/Qwen2.5-72B-Instruct"],
         impl=tt_transformers_impl,
-        tt_metal_commit="v0.61.0-rc1",
-        vllm_commit="3dc6c31",
+        tt_metal_commit="v0.62.0-rc8",
+        vllm_commit="c348d08",
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.T3K,
@@ -781,6 +782,7 @@ spec_templates = [
         status=ModelStatusTypes.EXPERIMENTAL,
         env_vars={
             "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+            "MAX_PREFILL_CHUNK_SIZE": "16",
         },
     ),
     ModelSpecTemplate(

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -747,8 +747,8 @@ spec_templates = [
     ModelSpecTemplate(
         weights=["Qwen/Qwen2.5-72B", "Qwen/Qwen2.5-72B-Instruct"],
         impl=llama3_impl,
-        tt_metal_commit="v0.62.0-rc8",
-        vllm_commit="c348d08",
+        tt_metal_commit="v0.56.0-rc33",
+        vllm_commit="e2e0002ac7dc",
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.T3K,


### PR DESCRIPTION
Also, Update model specifications for Qwen2.5: bump tt_metal and vllm commit

Running fix and release workflow [here](https://github.com/tenstorrent/tt-shield/actions/runs/16790982178)