### PR TITLE
Benchmarking for non-LLM

### DIFF
--- a/benchmarking/benchmark_config.py
+++ b/benchmarking/benchmark_config.py
@@ -8,7 +8,7 @@ from typing import List, Dict
 
 from workflows.workflow_types import WorkflowVenvType, BenchmarkTaskType, DeviceTypes
 from workflows.model_spec import MODEL_SPECS
-from workflows.utils import BenchmarkTaskParams
+from workflows.utils import BenchmarkTaskParams, BenchmarkTaskParamsCNN
 
 
 @dataclass(frozen=True)
@@ -19,6 +19,11 @@ class BenchmarkTask:
         WorkflowVenvType.BENCHMARKS_HTTP_CLIENT_VLLM_API
     )
 
+@dataclass(frozen=True)
+class BenchmarkTaskCNN(BenchmarkTask):
+    param_map: Dict[DeviceTypes, List[BenchmarkTaskParams]]
+    task_type: BenchmarkTaskType = BenchmarkTaskType.HTTP_CLIENT_CNN_API
+    workflow_venv_type: WorkflowVenvType = None  # no workflow venv needed for CNN benchmarks
 
 @dataclass(frozen=True)
 class BenchmarkConfig:
@@ -98,11 +103,14 @@ else:
     for model_id, model_spec in MODEL_SPECS.items():
         # Create performance reference task using the device_model_spec
         perf_ref_task = BenchmarkTask(param_map={model_spec.device_type: model_spec.device_model_spec.perf_reference})
+        if (model_spec.model_type.name == "CNN"):
+            perf_ref_task = BenchmarkTaskCNN(param_map={model_spec.device_type: model_spec.device_model_spec.perf_reference})
         
         # get (isl, osl, max_concurrency) from perf_ref_task
         perf_ref_task_runs = {
             model_spec.device_type: [
                 (params.isl, params.osl, params.image_height, params.image_width, params.images_per_prompt, params.max_concurrency) if params.task_type == "image"
+                else (params.num_inference_steps,) if params.task_type == "cnn"
                 else (params.isl, params.osl, params.max_concurrency) 
                 for params in model_spec.device_model_spec.perf_reference
             ]
@@ -113,61 +121,77 @@ else:
         _max_concurrency = model_spec.device_model_spec.max_concurrency
         
         # make benchmark sweeps table for this device
-        benchmark_task_runs = BenchmarkTask(
-            param_map={
-                _device: 
-                [
-                    BenchmarkTaskParams(
-                        isl=isl,
-                        osl=osl,
-                        max_concurrency=1,
-                        num_prompts=get_num_prompts(isl, osl, 1),
+        if (model_spec.model_type.name == "CNN"):
+            benchmark_task_runs = BenchmarkTaskCNN(
+                param_map={
+                    _device: [
+                        BenchmarkTaskParamsCNN(
+                            num_inference_steps=20,
+                            num_eval_runs=15
+                        )
+                    ]
+                }
+            )
+        else:
+            benchmark_task_runs = BenchmarkTask(
+                param_map={
+                    _device: 
+                    [
+                        BenchmarkTaskParams(
+                            isl=isl,
+                            osl=osl,
+                            max_concurrency=1,
+                            num_prompts=get_num_prompts(isl, osl, 1),
+                        )
+                        for isl, osl in BATCH_1_BENCHMARK_COMMON_ISL_OSL_PAIRS
+                        if (isl, osl, 1) not in perf_ref_task_runs.get(_device, [])
+                    ]
+                    + [
+                        BenchmarkTaskParams(
+                            isl=isl,
+                            osl=osl,
+                            max_concurrency=_max_concurrency,
+                            num_prompts=get_num_prompts(isl, osl, _max_concurrency),
+                        )
+                        for isl, osl in MAX_CONCURRENCY_BENCHMARK_COMMON_ISL_OSL_PAIRS
+                        if (isl, osl, _max_concurrency)
+                        not in perf_ref_task_runs.get(_device, [])
+                    ]
+                    + (
+                        [
+                            BenchmarkTaskParams(
+                                isl=isl,
+                                osl=osl,
+                                max_concurrency=1,
+                                num_prompts=get_num_prompts(isl, osl, 1),
+                                task_type="image",
+                                image_height=height,
+                                image_width=width,
+                                images_per_prompt=images_per_prompt,
+                            )
+                            for isl, osl, height, width, images_per_prompt in ISL_OSL_IMAGE_RESOLUTION_PAIRS
+                            if (isl, osl, height, width, images_per_prompt, 1) not in perf_ref_task_runs.get(_device, [])
+                        ] if "image" in model_spec.supported_modalities else []
                     )
-                    for isl, osl in BATCH_1_BENCHMARK_COMMON_ISL_OSL_PAIRS
-                    if (isl, osl, 1) not in perf_ref_task_runs.get(_device, [])
-                ]
-                + [
-                    BenchmarkTaskParams(
-                        isl=isl,
-                        osl=osl,
-                        max_concurrency=_max_concurrency,
-                        num_prompts=get_num_prompts(isl, osl, _max_concurrency),
+                    + (
+                        [
+                            BenchmarkTaskParams(
+                                isl=isl,
+                                osl=osl,
+                                max_concurrency=_max_concurrency,
+                                num_prompts=get_num_prompts(isl, osl, _max_concurrency),
+                                task_type="image",
+                                image_height=height,
+                                image_width=width,
+                                images_per_prompt=images_per_prompt,
+                            )
+                            for isl, osl, height, width, images_per_prompt in ISL_OSL_IMAGE_RESOLUTION_PAIRS
+                            if (isl, osl, height, width, images_per_prompt, _max_concurrency) not in perf_ref_task_runs.get(_device, [])
+                        ] if "image" in model_spec.supported_modalities else []
                     )
-                    for isl, osl in MAX_CONCURRENCY_BENCHMARK_COMMON_ISL_OSL_PAIRS
-                    if (isl, osl, _max_concurrency)
-                    not in perf_ref_task_runs.get(_device, [])
-                ]
-                + 
-                ([
-                    BenchmarkTaskParams(
-                        isl=isl,
-                        osl=osl,
-                        max_concurrency=1,
-                        num_prompts=get_num_prompts(isl, osl, 1),
-                        task_type="image",
-                        image_height=height,
-                        image_width=width,
-                        images_per_prompt=images_per_prompt,
-                    )
-                    for isl, osl, height, width, images_per_prompt in ISL_OSL_IMAGE_RESOLUTION_PAIRS
-                    if (isl, osl, height, width, images_per_prompt, 1) not in perf_ref_task_runs.get(_device, [])
-                ] if "image" in model_spec.supported_modalities else [])
-                + ([
-                    BenchmarkTaskParams(
-                        isl=isl,
-                        osl=osl,
-                        max_concurrency=_max_concurrency,
-                        num_prompts=get_num_prompts(isl, osl, _max_concurrency),
-                        task_type="image",
-                        image_height=height,
-                        image_width=width,
-                        images_per_prompt=images_per_prompt,
-                    )
-                    for isl, osl, height, width, images_per_prompt in ISL_OSL_IMAGE_RESOLUTION_PAIRS
-                    if (isl, osl, height, width, images_per_prompt, _max_concurrency) not in perf_ref_task_runs.get(_device, [])
-                ] if "image" in model_spec.supported_modalities else [])
-            }
-        )
+                }
+            )
+
         BENCHMARK_CONFIGS[model_id] = BenchmarkConfig(
             model_id=model_id,
             tasks=[perf_ref_task, benchmark_task_runs],

--- a/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/benchmarking/benchmark_targets/model_performance_reference.json
@@ -448,5 +448,31 @@
                 }
             }
         ]
+    },
+    "stable-diffusion-xl-base-1.0": {
+        "n150": [
+            {
+                "max_concurrency": 1,
+                "num_inference_steps": 20,
+                "task_type": "cnn",
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 10000
+                    }
+                }
+            }
+        ],
+        "galaxy": [
+            {
+                "max_concurrency": 32,
+                "num_inference_steps": 20,
+                "task_type": "cnn",
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 5000
+                    }
+                }
+            }
+        ]
     }
 }

--- a/benchmarking/run_benchmarks.py
+++ b/benchmarking/run_benchmarks.py
@@ -19,6 +19,7 @@ project_root = Path(__file__).resolve().parent.parent
 if project_root not in sys.path:
     sys.path.insert(0, str(project_root))
 
+from utils.image_client import ImageClient
 from utils.prompt_configs import EnvironmentConfig
 from utils.prompt_client import PromptClient
 from workflows.model_spec import ModelSpec
@@ -176,6 +177,16 @@ def main():
         if device in task.param_map
         for param in task.param_map[device]
     ]
+    
+    if (model_spec.model_type.name == "CNN"):
+        return run_cnn_benchmarks(
+            all_params,
+            model_spec,
+            device,
+            args.output_path,
+            service_port
+        )
+    
 
     log_str = "Running benchmarks for:\n"
     log_str += f"  {'#':<3} {'isl':<10} {'osl':<10} {'max_concurrency':<15} {'num_prompts':<12}\n"
@@ -259,6 +270,21 @@ def main():
         main_return_code = 1
 
     return main_return_code
+
+
+def run_cnn_benchmarks(all_params, model_spec, device, output_path, service_port):
+    """
+    Run CNN benchmarks for the given model and device.
+    """
+    # TODO two tasks are picked up here instead of BenchmarkTaskCNN only!!!
+    logger.info(f"Running CNN benchmarks for model: {model_spec.model_name} on device: {device.name}")
+
+    image_client = ImageClient(all_params, model_spec, device, output_path, service_port)
+    
+    image_client.run_benchmarks()
+
+    logger.info("✅ Completed CNN benchmarks")
+    return 0  # Assuming success
 
 
 if __name__ == "__main__":

--- a/benchmarking/summary_report.py
+++ b/benchmarking/summary_report.py
@@ -91,22 +91,43 @@ def extract_params_from_filename(filename: str) -> Dict[str, Any]:
         \.json$
     """
     match = re.search(text_pattern, filename, re.VERBOSE)
-    if not match:
-        raise ValueError(f"Could not extract parameters from filename: {filename}")
 
-    # Extract and convert numeric parameters for text benchmarks
-    params = {
-        "model_name": match.group("model"),
-        "timestamp": match.group("timestamp"),
-        "device": match.group("device"),
-        "input_sequence_length": int(match.group("isl")),
-        "output_sequence_length": int(match.group("osl")),
-        "max_con": int(match.group("maxcon")),
-        "num_requests": int(match.group("n")),
-        "task_type": "text",
-    }
+    if match:
+        # Extract and convert numeric parameters for text benchmarks
+        params = {
+            "model_name": match.group("model"),
+            "timestamp": match.group("timestamp"),
+            "device": match.group("device"),
+            "input_sequence_length": int(match.group("isl")),
+            "output_sequence_length": int(match.group("osl")),
+            "max_con": int(match.group("maxcon")),
+            "num_requests": int(match.group("n")),
+            "task_type": "text",
+        }
+    
+    # Try CNN benchmark pattern (for SDXL and similar models)
+    cnn_pattern = r"""
+        ^benchmark_
+        (?P<model_id>id_.+?)                      # Model ID (starts with id_)
+        (?:_(?P<device>N150|N300|P100|P150|T3K|p150x4|TG|GALAXY|n150|n300|p100|p150|t3k|tg|galaxy))?  # Optional device
+        _(?P<timestamp>\d+\.?\d*)                 # Timestamp (can be float)
+        \.json$
+    """
 
-    return params
+    match = re.search(cnn_pattern, filename, re.VERBOSE)
+
+    if match:
+        # For CNN benchmarks, return basic info from filename
+        # Additional params will be extracted from JSON content in process_benchmark_file
+        return {
+            "model_id": match.group("model_id"),
+            "timestamp": match.group("timestamp"),
+            "device": match.group("device"),
+            "task_type": "cnn",
+        }
+
+    # If no patterns match, raise error
+    raise ValueError(f"Could not extract parameters from filename: {filename}")
 
 
 def format_metrics(metrics):
@@ -140,11 +161,28 @@ def process_benchmark_file(filepath: str) -> Dict[str, Any]:
         data = json.load(f)
 
     filename = os.path.basename(filepath)
-
     params = extract_params_from_filename(filename)
 
-    # Calculate statistics
+    # Handle CNN benchmarks differently
+    if params.get("task_type") == "cnn":
+        # For CNN benchmarks, extract data from JSON content
+        benchmarks_data = data.get("benchmarks: ", data)  # Handle typo in key or fallback to root
+        metrics = {
+            "timestamp": params["timestamp"],
+            "model_name": data.get("model", ""),
+            "model_id": data.get("model", ""),
+            "backend": "cnn",
+            "device": params["device"],
+            "num_requests": benchmarks_data.get("num_requests", 0),
+            "num_inference_steps": benchmarks_data.get("num_inference_steps", 0),
+            "mean_ttft_ms": benchmarks_data.get("ttft", 0) * 1000,  # ttft is already in seconds, convert to ms
+            "inference_steps_per_second": benchmarks_data[0].get("inference_steps_per_second", 0) if isinstance(benchmarks_data, list) and benchmarks_data else 0,
+            "filename": filename,
+            "task_type": "cnn",
+        }
+        return format_metrics(metrics)
 
+    # Calculate statistics for text/image benchmarks
     mean_tpot_ms = data.get("mean_tpot_ms")
     if data.get("mean_tpot_ms"):
         mean_tpot = max(data.get("mean_tpot_ms"), 1e-6)  # Avoid division by zero

--- a/utils/image_client.py
+++ b/utils/image_client.py
@@ -63,7 +63,9 @@ class ImageClient:
                 print("Health check failed.")
                 return False
 
-            num_calls = 2
+            # Get num_calls from CNN benchmark parameters
+            cnn_params = next((param for param in self.all_params if hasattr(param, 'num_eval_runs')), None)
+            num_calls = cnn_params.num_eval_runs if cnn_params and hasattr(cnn_params, 'num_eval_runs') else 2
 
             status_list = []
             

--- a/utils/image_client.py
+++ b/utils/image_client.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+from time import time
+import time as time_module
+
+
+class SDXLTestStatus:
+    status: bool
+    elapsed: float
+    num_inference_steps: int
+    inference_steps_per_second: float
+
+    def __init__(self, status: bool, elapsed: float, num_inference_steps: int, inference_steps_per_second: float):
+        self.status = status
+        self.elapsed = elapsed
+        self.num_inference_steps = num_inference_steps
+        self.inference_steps_per_second = inference_steps_per_second
+
+
+class ImageClient:
+    def __init__(self, all_params, model_spec, device, output_path, service_port):
+        self.base_url = "http://localhost:" + str(service_port)
+        self.all_params = all_params
+        self.model_spec = model_spec
+        self.device = device
+        self.output_path = output_path
+
+    def get_health(self, attempt_number = 1) -> bool:
+        import requests
+        response = requests.get(f"{self.base_url}/image/tt-liveness")
+        # server returns 200 if healthy only
+        # otherwise it is 405
+        if response.status_code != 200:
+            if attempt_number < 20:
+                print(f"Health check failed with status code: {response.status_code}. Retrying...")
+                time_module.sleep(15)
+                return self.get_health(attempt_number + 1)
+            else:
+                raise Exception(f"Health check failed with status code: {response.status_code}")
+        return True
+
+    def generate_image(self, num_inference_steps: int = 20) -> tuple[bool, float]:
+        import requests
+        headers = {
+            "accept": "application/json",
+            "Authorization": f"Bearer your-secret-key",
+            "Content-Type": "application/json"
+        }
+        payload = {
+            "prompt": "Michael Jordan blocked by Spud Webb",
+            "num_inference_step": num_inference_steps
+        }
+        start_time = time()
+        response = requests.post(f"{self.base_url}/image/generations", json=payload, headers=headers, timeout=90)
+        elapsed = time() - start_time
+        return (response.status_code == 200), elapsed
+
+    def run_benchmarks(self, attempt = 0) -> list[SDXLTestStatus]:
+        try:
+            health_status = self.get_health()
+            if health_status:
+                print("Health check passed.")
+            else:
+                print("Health check failed.")
+                return False
+
+            num_calls = 2
+
+            status_list = []
+            
+            for i in range(num_calls):
+                print(f"Generating image {i + 1}/{num_calls}...")
+                status, elapsed = self.generate_image()
+                inference_steps_per_second = 20 / elapsed if elapsed > 0 else 0
+                print(f"Generated image with {20} steps in {elapsed:.2f} seconds.")
+                status_list.append(SDXLTestStatus(
+                    status=status,
+                    elapsed=elapsed,
+                    num_inference_steps=20,
+                    inference_steps_per_second=inference_steps_per_second
+                ))
+
+
+            return self._generate_report(status_list)
+        except Exception as e:
+            print(f"Health check encountered an error: {e}")
+            return False
+    
+    def _generate_report(self, status_list: list[SDXLTestStatus]) -> None:
+        import json
+        result_filename = (
+            Path(self.output_path)
+            / f"benchmark_{self.model_spec.model_id}_{time()}.json"
+        )
+        # Convert SDXLTestStatus objects to dictionaries for JSON serialization
+        report_data = [
+            {
+                "status": status.status,
+                "elapsed": status.elapsed,
+                "num_inference_steps": status.num_inference_steps,
+                "inference_steps_per_second": status.inference_steps_per_second
+            } for status in status_list
+        ]
+        with open(result_filename, "w") as f:
+            json.dump(report_data, f, indent=4)
+        print(f"Report generated: {result_filename}")
+        return True

--- a/utils/image_client.py
+++ b/utils/image_client.py
@@ -92,14 +92,18 @@ class ImageClient:
             / f"benchmark_{self.model_spec.model_id}_{time()}.json"
         )
         # Convert SDXLTestStatus objects to dictionaries for JSON serialization
-        report_data = [
-            {
-                "status": status.status,
-                "elapsed": status.elapsed,
-                "num_inference_steps": status.num_inference_steps,
-                "inference_steps_per_second": status.inference_steps_per_second
-            } for status in status_list
-        ]
+        report_data = {
+            "benchmarks": {
+                    "num_requests": len(status_list),
+                    "num_inference_steps": status_list[0].num_inference_steps if status_list else 0,
+                    "ttft": sum(status.elapsed for status in status_list) / len(status_list) if status_list else 0,
+                    "inference_steps_per_second": sum(status.inference_steps_per_second for status in status_list) / len(status_list) if status_list else 0,
+                },
+            "model": self.model_spec.model_id,
+            "device": self.device.name,
+            "timestamp": time_module.strftime("%Y-%m-%d %H:%M:%S", time_module.localtime()),
+            "task_type": "cnn"
+        }
         with open(result_filename, "w") as f:
             json.dump(report_data, f, indent=4)
         print(f"Report generated: {result_filename}")

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -126,7 +126,6 @@ def get_model_id(impl_name: str, model_name: str, device: str) -> str:
     return model_id
 
 
-@dataclass(frozen=True)
 class ModelType(IntEnum):
     LLM = auto()
     CNN = auto()
@@ -390,6 +389,8 @@ class ModelSpec:
             # Handle enums first (they have __dict__ but aren't dataclasses)
             if hasattr(obj, "name") and hasattr(obj, "value"):  # Enum
                 return obj.name
+            elif isinstance(obj, ModelType):  # Explicit ModelType handling
+                return obj.name
             elif hasattr(obj, "__dict__") and hasattr(obj, "__dataclass_fields__"):
                 # Handle dataclasses by converting to dict
                 result = asdict(obj)
@@ -524,6 +525,8 @@ class ModelSpec:
             )
         if "status" in data:
             data["status"] = deserialize_enum(ModelStatusTypes, data["status"])
+        if "model_type" in data and data["model_type"] is not None:
+            data["model_type"] = deserialize_enum(ModelType, data["model_type"])
         if "device_model_spec" in data:
             data["device_model_spec"]["device"] = deserialize_enum(
                 DeviceTypes, data["device_model_spec"]["device"]

--- a/workflows/run_workflows.py
+++ b/workflows/run_workflows.py
@@ -88,6 +88,7 @@ class WorkflowSetup:
                 set([task.workflow_venv_type for task in self.config.tasks])
             )
         for venv_type in required_venv_types:
+            if venv_type is None: continue
             venv_config = VENV_CONFIGS[venv_type]
             # setup venv using uv if not exists
             if not venv_config.venv_path.exists():

--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -232,6 +232,10 @@ class HostSetupManager:
             return self.check_model_weights_dir(
                 self.setup_config.host_model_weights_mount_dir
             )
+        elif self.setup_config.model_source == "noaction":
+            logger.info(
+                f"Assuming that server self-provides the weights. "
+            )
         else:
             raise ValueError("⛔ Invalid model source.")
 

--- a/workflows/utils.py
+++ b/workflows/utils.py
@@ -272,10 +272,10 @@ class PerformanceTarget:
 
 @dataclass
 class BenchmarkTaskParams:
-    isl: int
-    osl: int
-    max_concurrency: int
-    num_prompts: int
+    isl: int = None
+    osl: int = None
+    max_concurrency: int = None
+    num_prompts: int = None
     image_height: int = None
     image_width: int = None
     images_per_prompt: int = 0
@@ -290,6 +290,10 @@ class BenchmarkTaskParams:
             "customer_sellable": 0.80,
         }
     )
+
+    # has to go in here so init can read it
+    num_inference_steps: int = None  # Used for CNN models
+
 
     def __post_init__(self):
         self._infer_data()
@@ -306,3 +310,20 @@ class BenchmarkTaskParams:
                         if self.theoretical_tput_user
                         else None,
                     )
+
+@dataclass
+class BenchmarkTaskParamsCNN(BenchmarkTaskParams):
+    num_eval_runs: int = 15
+    target_peak_perf: Dict[str, float] = field(
+        default_factory=lambda: {
+            "customer_functional": 0.30,
+            "customer_complete": 0.70,
+            "customer_sellable": 0.80,
+        }
+    )
+    
+    def __post_init__(self):
+        self._infer_data()
+    
+    def _infer_data(self):
+        super()._infer_data()

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -34,6 +34,7 @@ class WorkflowVenvType(IntEnum):
 
 class BenchmarkTaskType(IntEnum):
     HTTP_CLIENT_VLLM_API = auto()
+    HTTP_CLIENT_CNN_API = auto()
 
 
 class DeviceTypes(IntEnum):


### PR DESCRIPTION
Added:

* SDXL as a model for benchmarking
* A flag to distinguish CNN from LLM models
* CNN model perf attributes
* Target for CNN models
* A script to fork for CNN benchmarking and reporting - currently running image models only

Missing:

Metadata in the report


Sample benchmark report:

{
    "benchmarks": {
        "num_requests": 2,
        "num_inference_steps": 20,
        "ttft": 13.980923771858215,
        "inference_steps_per_second": 1.4305253844786237
    },
    "model": "id_tt-transformers_stable-diffusion-xl-base-1.0_n150",
    "device": "N150",
    "timestamp": "2025-08-08 12:43:21",
    "task_type": "cnn"
}

Related task #443 