### PR TITLE
Add support for Qwen3-8B model

### DIFF
--- a/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/benchmarking/benchmark_targets/model_performance_reference.json
@@ -1,4 +1,48 @@
 {
+    "Qwen3-8B": {
+        "n150": [
+            {
+                "isl": 128,
+                "osl": 128,
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 94,
+                        "tput_user": 21
+                    }
+                }
+            }
+        ],
+        "n300": [
+            {
+                "isl": 128,
+                "osl": 128,
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 62,
+                        "tput_user": 42
+                    }
+                }
+            }
+        ],
+        "t3k": [
+            {
+                "isl": 128,
+                "osl": 128,
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 24,
+                        "tput_user": 170
+                    }
+                }
+            }
+        ]
+    },
     "Qwen3-32B": {
         "t3k": [
             {

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -74,6 +74,92 @@ class EvalConfig:
 
 _eval_config_list = [
     EvalConfig(
+        hf_model_repo="Qwen/Qwen3-8B",
+        tasks=[
+            EvalTask(
+                task_name="r1_gpqa_diamond",
+                score=EvalTaskScore(
+                    published_score=62.0,  
+                    published_score_ref="https://arxiv.org/pdf/2505.09388",
+                    gpu_reference_score=64.14, 
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/384#issuecomment-3129960933",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": [
+                            "exact_match,none",
+                        ],
+                        "unit": "percent",
+                    },
+                ),
+                workflow_venv_type=WorkflowVenvType.EVALS,
+                include_path="work_dir",
+                max_concurrent=None,
+                apply_chat_template=True,
+                model_kwargs={
+                    "model": "Qwen/Qwen3-8B",
+                    "base_url": "http://127.0.0.1:8000/v1/completions",
+                    "tokenizer_backend": "huggingface",
+                    "max_length": 65536,
+                },
+                # gen_kwargs chosen according to https://huggingface.co/Qwen/Qwen3-8B#best-practices
+                gen_kwargs={
+                    "stream": "false",
+                    "max_gen_toks": 32768,
+                    "until": [],
+                    "do_sample": "true",
+                    "temperature": 0.6,
+                    "top_k": 20,
+                    "top_p": 0.95,
+                },
+                seed=42,
+                num_fewshot=0,
+                batch_size=32,
+                log_samples=True,
+            ),
+            EvalTask(
+                task_name="mmlu_pro",
+                num_fewshot=5,
+                score=EvalTaskScore(
+                    published_score=56.73,
+                    published_score_ref="https://arxiv.org/pdf/2505.09388",
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref="TBD",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": [
+                            "exact_match,custom-extract",
+                        ],
+                        "unit": "percent",
+                    },
+                ),
+                workflow_venv_type=WorkflowVenvType.EVALS,
+                include_path="work_dir",
+                max_concurrent=None,
+                apply_chat_template=True,
+                model_kwargs={
+                    "model": "Qwen/Qwen3-8B",
+                    "base_url": "http://127.0.0.1:8000/v1/completions",
+                    "tokenizer_backend": "huggingface",
+                    "max_length": 65536,
+                },
+                # gen_kwargs chosen according to https://huggingface.co/Qwen/Qwen3-8B#best-practices
+                gen_kwargs={
+                    "stream": "false",
+                    "max_gen_toks": 32768,
+                    "until": [],
+                    "do_sample": "true",
+                    "temperature": 0.6,
+                    "top_k": 20,
+                    "top_p": 0.95,
+                },
+                seed=42,
+                batch_size=32,
+                log_samples=True,
+                limit_samples=100,
+            )
+        ],
+    ),
+    EvalConfig(
         hf_model_repo="Qwen/Qwen3-32B",
         tasks=[
             EvalTask(
@@ -992,3 +1078,4 @@ EVAL_CONFIGS = {
     for _, model_spec in MODEL_SPECS.items()
     if model_spec.hf_model_repo in _eval_config_map
 }
+

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -682,6 +682,33 @@ class ModelSpecTemplate:
 # Model specification templates - these get expanded into individual specs
 spec_templates = [
     ModelSpecTemplate(
+        weights=["Qwen/Qwen3-8B"],
+        impl=tt_transformers_impl,
+        tt_metal_commit="v0.61.1-rc1",
+        vllm_commit="5cbc982",
+        device_model_specs=[
+            DeviceModelSpec(
+                device=DeviceTypes.N150,
+                max_concurrency=32,
+                max_context=40960,
+                default_impl=True,
+            ),
+            DeviceModelSpec(
+                device=DeviceTypes.N300,
+                max_concurrency=32,
+                max_context=40960,
+                default_impl=True,
+            ),
+            DeviceModelSpec(
+                device=DeviceTypes.T3K,
+                max_concurrency=32,
+                max_context=40960,
+                default_impl=True,
+            ),
+        ],
+        status=ModelStatusTypes.EXPERIMENTAL,
+    ),
+    ModelSpecTemplate(
         weights=["Qwen/Qwen3-32B"],
         impl=tt_transformers_impl,
         tt_metal_commit="v0.59.0-rc39",


### PR DESCRIPTION
### Summary
This PR adds initial support for the Qwen3-8B model, including benchmarking targets, evaluation tasks, and model specification for different devices.

### Changes Introduced
#### 1. Model Benchmarking
Added Qwen3-8B performance targets to benchmark_targets/model_performance_reference.json.
Benchmarks added for:
* N150: ttft_ms: 94, tput_user: 21
* N300: ttft_ms: 62, tput_user: 42
* T3K: ttft_ms: 24, tput_user: 170

#### 2. Model Spec Registration
Registered Qwen3-8B in workflows/model_spec.py under ModelSpecTemplate.
Device compatibility:
* N150, N300, T3K
* max_context: 40,960
* max_gen_toks: 
* Status: EXPERIMENTAL

#### 3. Eval Configuration
Added Qwen3-8B to evals/eval_config.py with two evaluation tasks:
* r1_gpqa_diamond: score = 64.14% (GPU reference)
* mmlu_pro: score = 56.73% (published)  - mmlu_pro capped to 100 samples for testing
Includes generation parameters tuned per [HuggingFace best practices](https://huggingface.co/Qwen/Qwen3-8B#best-practices).

### Follow-ups
Add Qwen3-8B to Shield CI 
Evaluate performance vs. GPU baselines (currently accuracy evaluation is NOT hitting threshold) 
Expand eval coverage to additional task (if necessary) 