### PR TITLE
Add service port to vLLM args

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -575,6 +575,14 @@ class ModelSpec:
             }
             object.__setattr__(self.device_model_spec, "vllm_args", merged_vllm_args)
 
+        if args.service_port:
+            # Add service port to vllm_args
+            merged_vllm_args = {
+                **self.device_model_spec.vllm_args,
+                **{"port": args.service_port}
+            }
+            object.__setattr__(self.device_model_spec, "vllm_args", merged_vllm_args)
+
         if args.dev_mode:
             object.__setattr__(
                 self, "docker_image", self.docker_image.replace("-release-", "-dev-")


### PR DESCRIPTION
This PR addresses #470 

By simply adding the service port passed by the user at runtime to the vLLM args in the device model spec, we can control the port that the vLLM server is hosted on