### PR TITLE
Fix log file naming convention in build_docker_images.py to align with docker server logs

### DIFF
--- a/scripts/build_docker_images.py
+++ b/scripts/build_docker_images.py
@@ -40,7 +40,7 @@ def setup_individual_logger(tt_metal_commit, vllm_commit, log_dir):
 
     # Create log file path
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    log_file = log_dir / f"build_{combination_id}_{timestamp}.log"
+    log_file = log_dir / f"build_{timestamp}_{combination_id}.log"
 
     # Create logger
     process_logger = logging.getLogger(logger_name)


### PR DESCRIPTION
File name convention for docker builds is not using the same convention as docker server logs and run logs. This simply swaps timestamp with version combination.