### PR TITLE
tstesco/limit-evals-mode

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -247,8 +247,6 @@ _eval_config_list = [
                     },
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS,
-                include_path="work_dir",
-                apply_chat_template=True,
                 model_kwargs={
                     "model": "Qwen/Qwen3-8B",
                     "base_url": "http://127.0.0.1:8000/v1/completions",
@@ -265,9 +263,6 @@ _eval_config_list = [
                     "top_k": 20,
                     "top_p": 0.95,
                 },
-                seed=42,
-                num_fewshot=0,
-                log_samples=True,
             ),
             EvalTask(
                 task_name="mmlu_pro",
@@ -286,8 +281,6 @@ _eval_config_list = [
                     },
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS,
-                include_path="work_dir",
-                apply_chat_template=True,
                 model_kwargs={
                     "model": "Qwen/Qwen3-8B",
                     "base_url": "http://127.0.0.1:8000/v1/completions",
@@ -304,8 +297,6 @@ _eval_config_list = [
                     "top_k": 20,
                     "top_p": 0.95,
                 },
-                seed=42,
-                log_samples=True,
                 limit_samples_map=={
                     EvalLimitMode.CI_NIGHTLY: 0.2,
                     EvalLimitMode.SMOKE_TEST: 0.01
@@ -332,8 +323,6 @@ _eval_config_list = [
                     },
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS,
-                include_path="work_dir",
-                apply_chat_template=True,
                 model_kwargs={
                     "model": "Qwen/Qwen3-32B",
                     "base_url": "http://127.0.0.1:8000/v1/completions",
@@ -350,9 +339,6 @@ _eval_config_list = [
                     "top_k": 20,
                     "top_p": 0.95,
                 },
-                seed=42,
-                num_fewshot=0,
-                log_samples=True,
             ),
             EvalTask(
                 task_name="r1_math500",
@@ -370,8 +356,6 @@ _eval_config_list = [
                     },
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS,
-                include_path="work_dir",
-                apply_chat_template=True,
                 model_kwargs={
                     "model": "Qwen/Qwen3-32B",
                     "base_url": "http://127.0.0.1:8000/v1/completions",
@@ -388,9 +372,6 @@ _eval_config_list = [
                     "top_k": 20,
                     "top_p": 0.95,
                 },
-                seed=42,
-                num_fewshot=0,
-                log_samples=True,
             ),
             EvalTask(
                 task_name="r1_gpqa_diamond",
@@ -408,8 +389,6 @@ _eval_config_list = [
                     },
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS,
-                include_path="work_dir",
-                apply_chat_template=True,
                 model_kwargs={
                     "model": "Qwen/Qwen3-32B",
                     "base_url": "http://127.0.0.1:8000/v1/completions",
@@ -426,9 +405,6 @@ _eval_config_list = [
                     "top_k": 20,
                     "top_p": 0.95,
                 },
-                seed=42,
-                num_fewshot=0,
-                log_samples=True,
             ),
         ],
     ),
@@ -494,8 +470,6 @@ _eval_config_list = [
                     },
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS,
-                include_path="work_dir",
-                apply_chat_template=True,
                 model_kwargs={
                     "model": "Qwen/QwQ-32B",
                     "base_url": "http://127.0.0.1:8000/v1/completions",
@@ -505,9 +479,6 @@ _eval_config_list = [
                 gen_kwargs={
                     "stream": "false",
                 },
-                seed=42,
-                num_fewshot=0,
-                log_samples=True,
             ),
             EvalTask(
                 task_name="r1_math500",
@@ -525,8 +496,6 @@ _eval_config_list = [
                     },
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS,
-                include_path="work_dir",
-                apply_chat_template=True,
                 model_kwargs={
                     "model": "Qwen/QwQ-32B",
                     "base_url": "http://127.0.0.1:8000/v1/completions",
@@ -536,9 +505,6 @@ _eval_config_list = [
                 gen_kwargs={
                     "stream": "false",
                 },
-                seed=42,
-                num_fewshot=0,
-                log_samples=True,
             ),
             EvalTask(
                 task_name="r1_gpqa_diamond",
@@ -556,8 +522,6 @@ _eval_config_list = [
                     },
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS,
-                include_path="work_dir",
-                apply_chat_template=True,
                 model_kwargs={
                     "model": "Qwen/QwQ-32B",
                     "base_url": "http://127.0.0.1:8000/v1/completions",
@@ -567,9 +531,6 @@ _eval_config_list = [
                 gen_kwargs={
                     "stream": "false",
                 },
-                seed=42,
-                num_fewshot=0,
-                log_samples=True,
             ),
         ],
     ),
@@ -592,8 +553,6 @@ _eval_config_list = [
                     },
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS,
-                include_path="work_dir",
-                apply_chat_template=True,
                 model_kwargs={
                     "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
                     "base_url": "http://127.0.0.1:8000/v1/completions",
@@ -602,8 +561,6 @@ _eval_config_list = [
                 },
                 gen_kwargs={"stream": "false", "max_gen_toks": "32768"},
                 seed=42,
-                num_fewshot=0,
-                log_samples=True,
             ),
             EvalTask(
                 task_name="r1_gpqa_diamond",
@@ -621,8 +578,6 @@ _eval_config_list = [
                     },
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS,
-                include_path="work_dir",
-                apply_chat_template=True,
                 model_kwargs={
                     "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
                     "base_url": "http://127.0.0.1:8000/v1/completions",
@@ -631,8 +586,6 @@ _eval_config_list = [
                 },
                 gen_kwargs={"stream": "false", "max_gen_toks": "32768"},
                 seed=42,
-                num_fewshot=0,
-                log_samples=True,
             ),
         ],
     ),

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -297,7 +297,7 @@ _eval_config_list = [
                     "top_k": 20,
                     "top_p": 0.95,
                 },
-                limit_samples_map=={
+                limit_samples_map={
                     EvalLimitMode.CI_NIGHTLY: 0.2,
                     EvalLimitMode.SMOKE_TEST: 0.01
                 },

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -51,7 +51,10 @@ class EvalTask:
     # Optional: limit the number of samples passed to lm_eval (--limit)
     # Limit the number of examples per task. 
     # If <1, limit is a percentage of the total number of examples.
-    limit_samples_map: Dict[EvalLimitMode, Union[float, int]] = field(default_factory=lambda: {})
+    limit_samples_map: Dict[EvalLimitMode, Union[float, int]] = field(default_factory=lambda: {
+        # this defines smoke test limit to 1% for all models unless overridden
+        EvalLimitMode.SMOKE_TEST: 0.01,
+    })
 
 
     def __post_init__(self):
@@ -155,6 +158,10 @@ _eval_config_list = [
                     "stop": "<|eot_id|>",
                     "stream": "False",
                 },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
+                },
             ),
         ]
     ),
@@ -224,6 +231,10 @@ _eval_config_list = [
                 gen_kwargs={
                     "stop": "<|eot_id|>",
                     "stream": "False",
+                },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
                 },
             ),
         ]
@@ -372,6 +383,10 @@ _eval_config_list = [
                     "top_k": 20,
                     "top_p": 0.95,
                 },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
+                },
             ),
             EvalTask(
                 task_name="r1_gpqa_diamond",
@@ -505,6 +520,10 @@ _eval_config_list = [
                 gen_kwargs={
                     "stream": "false",
                 },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
+                },
             ),
             EvalTask(
                 task_name="r1_gpqa_diamond",
@@ -634,6 +653,10 @@ _eval_config_list = [
                         "unit": "percent",
                     },
                 ),
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
+                },
             ),
             EvalTask(
                 task_name="gpqa_diamond_generative_n_shot",
@@ -668,6 +691,10 @@ _eval_config_list = [
                         "unit": "percent",
                     },
                 ),
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
+                },
             ),
         ],
     ),
@@ -716,6 +743,10 @@ _eval_config_list = [
                         "unit": "percent",
                     },
                 ),
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
+                },
             ),
             EvalTask(
                 task_name="gpqa_diamond_generative_n_shot",
@@ -750,6 +781,10 @@ _eval_config_list = [
                         "unit": "percent",
                     },
                 ),
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
+                },
             ),
         ],
     ),
@@ -834,6 +869,10 @@ _eval_config_list = [
                     "stop": "<|eot_id|>",
                     "stream": "False",
                 },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
+                },
             ),
             EvalTask(
                 eval_class="openai_compatible",
@@ -866,6 +905,10 @@ _eval_config_list = [
                 gen_kwargs={
                     "stop": "<|eot_id|>",
                     "stream": "False",
+                },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
                 },
             ),
             EvalTask(
@@ -900,6 +943,10 @@ _eval_config_list = [
                     "stop": "<|eot_id|>",
                     "stream": "False",
                     "max_new_tokens": "512",
+                },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
                 },
             ),
         ],
@@ -939,6 +986,10 @@ _eval_config_list = [
                     "stop": "<|eot_id|>",
                     "stream": "False",
                 },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
+                },
             ),
             EvalTask(
                 eval_class="openai_compatible",
@@ -971,6 +1022,10 @@ _eval_config_list = [
                 gen_kwargs={
                     "stop": "<|eot_id|>",
                     "stream": "False",
+                },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
                 },
             ),
             EvalTask(
@@ -1005,6 +1060,10 @@ _eval_config_list = [
                     "stop": "<|eot_id|>",
                     "stream": "False",
                     "max_new_tokens": "512",
+                },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
                 },
             ),
         ],

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 from dataclasses import dataclass, field
-from typing import List, Dict, Callable
+from typing import List, Dict, Callable, Union
 
-from workflows.workflow_types import WorkflowVenvType
+from workflows.workflow_types import WorkflowVenvType, EvalLimitMode
 from workflows.utils import map_configs_by_attr
 from workflows.model_spec import MODEL_SPECS
 from evals.eval_utils import (
@@ -49,7 +49,10 @@ class EvalTask:
     # Note: include_path is specified relative to the respective venv
     include_path: str = None
     # Optional: limit the number of samples passed to lm_eval (--limit)
-    limit_samples: int = None
+    # Limit the number of examples per task. 
+    # If <1, limit is a percentage of the total number of examples.
+    limit_samples_map: Dict[EvalLimitMode, Union[float, int]] = field(default_factory=lambda: {})
+
 
     def __post_init__(self):
         self.validate_data()
@@ -303,7 +306,10 @@ _eval_config_list = [
                 },
                 seed=42,
                 log_samples=True,
-                limit_samples=100,
+                limit_samples_map=={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
+                },
             )
         ],
     ),
@@ -462,6 +468,10 @@ _eval_config_list = [
                         "unit": "percent",
                     },
                 ),
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01
+                },
             )
         ],
     ),

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -28,7 +28,7 @@ from workflows.workflow_config import (
 from workflows.utils import run_command
 from evals.eval_config import EVAL_CONFIGS, EvalTask
 from workflows.workflow_venvs import VENV_CONFIGS
-from workflows.workflow_types import WorkflowVenvType, DeviceTypes
+from workflows.workflow_types import WorkflowVenvType, DeviceTypes, EvalLimitMode
 from workflows.log_setup import setup_workflow_script_logger
 
 logger = logging.getLogger(__name__)
@@ -175,9 +175,13 @@ def build_eval_command(
     if task.apply_chat_template:
         cmd.append("--apply_chat_template")  # Flag argument (no value)
 
-    # Apply optional per-task sample limit for faster debugging cycles
-    if task.limit_samples is not None:
-        cmd.extend(["--limit", str(task.limit_samples)])
+    
+    # Check if limit_samples_mode is set in CLI args and get the corresponding limit
+    limit_samples_mode_str = model_spec.cli_args.get("limit_samples_mode")
+    if limit_samples_mode_str:
+        limit_mode = EvalLimitMode.from_string(limit_samples_mode_str)
+        limit_arg = task.limit_samples_map.get(limit_mode)
+        cmd.extend(["--limit", str(limit_arg)])
 
     # force all cmd parts to be strs
     cmd = [str(c) for c in cmd]

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -181,7 +181,8 @@ def build_eval_command(
     if limit_samples_mode_str:
         limit_mode = EvalLimitMode.from_string(limit_samples_mode_str)
         limit_arg = task.limit_samples_map.get(limit_mode)
-        cmd.extend(["--limit", str(limit_arg)])
+        if limit_arg is not None:
+            cmd.extend(["--limit", str(limit_arg)])
 
     # force all cmd parts to be strs
     cmd = [str(c) for c in cmd]

--- a/run.py
+++ b/run.py
@@ -145,6 +145,11 @@ def parse_arguments():
         type=str,
         help="[for --local-server] TT-Metal python venv directory, PYTHON_ENV_DIR in tt-metal usage, must be pre-built with python_env setup and vLLM installed.",
     )
+    parser.add_argument(
+        "--limit-samples-mode",
+        type=str,
+        help="Predefined eval dataset limit mappings: ['ci-nightly', 'ci-long', 'ci-commit', 'smoke-test']",
+    )
 
     args = parser.parse_args()
 

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -164,3 +164,19 @@ class ModelStatusTypes(IntEnum):
             ModelStatusTypes.TOP_PERF: "🚀 Top Performance",
         }
         return disp_map[check_type]
+
+
+class EvalLimitMode(IntEnum):
+    SMOKE_TEST = auto()
+    CI_COMMIT = auto()
+    CI_NIGHTLY = auto()
+    CI_LONG = auto()
+
+    @classmethod
+    def from_string(cls, name: str):
+        if name is None:
+            return None
+        try:
+            return cls[name.upper().replace('-', '_')]
+        except KeyError:
+            raise ValueError(f"Invalid EvalLimitMode: {name}")


### PR DESCRIPTION
# change log

* address https://github.com/tenstorrent/tt-inference-server/issues/580 by adding `--limit-samples-mode ci-nightly` option for CI usage. 


## Design
CLI arg added: `--limit-samples-mode` [ci-nightly, smoke-test] (more can be added easily)
--limit sampling thresholds are defined by default:
```
{
    EvalLimitMode.SMOKE_TEST: 0.01,
}
```
This means that 


these can be overridden per model, e.g. for `mmlu_pro` which takes 3-5 hours typically:
```
{
    EvalLimitMode.CI_NIGHTLY: 0.2,
    EvalLimitMode.SMOKE_TEST: 0.01,
}
```