### PR TITLE
adding Llama-3.1-8B-Instruct with tt_metal_commit=v0.62.0-rc11

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1128,8 +1128,8 @@ spec_templates = [
     ModelSpecTemplate(
         weights=["meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-8B-Instruct"],
         impl=tt_transformers_impl,
-        tt_metal_commit="v0.57.0-rc71",
-        vllm_commit="2a8debd",
+        tt_metal_commit="v0.62.0-rc11",
+        vllm_commit="bd7dd31",
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.N150,


### PR DESCRIPTION
# change log

* adding Llama-3.1-8B-Instruct with tt_metal_commit=v0.62.0-rc11, vllm_commit=bd7dd31


---

## Tenstorrent Model Release Summary: Llama-3.1-8B-Instruct on n300

### Metadata: Llama-3.1-8B-Instruct on n300
```json
{
    "report_id": "id_tt-transformers_Llama-3.1-8B-Instruct_n300_2025-09-08_21-37-23",
    "model_name": "Llama-3.1-8B-Instruct",
    "model_id": "id_tt-transformers_Llama-3.1-8B-Instruct_n300",
    "model_spec_json": "/home/tstesco/projects/tt-inference-server/workflow_logs/run_specs/tt_model_spec_2025-09-08_20-19-07_id_tt-transformers_Llama-3.1-8B-Instruct_n300_release.json",
    "model_repo": "meta-llama/Llama-3.1-8B-Instruct",
    "model_impl": "tt-transformers",
    "device": "n300",
    "server_mode": "docker",
    "tt_metal_commit": "v0.62.0-rc11",
    "vllm_commit": "bd7dd31",
    "run_command": "python run.py --model Llama-3.1-8B-Instruct --device n300 --workflow release --docker-server --dev-mode"
}
```

### Performance Benchmark Sweeps for Llama-3.1-8B-Instruct on n300

#### Text-to-Text Performance Benchmark Sweeps for Llama-3.1-8B-Instruct on n300

|  ISL  | OSL  | Concurrency | N Req | TTFT (ms) | TPOT (ms) | Tput User (TPS) | Tput Decode (TPS) | Tput Prefill (TPS) | E2EL (ms) | Req Tput (RPS) |
|-------|------|-------------|-------|-----------|-----------|-----------------|-------------------|--------------------|-----------|----------------|
|   128 |  128 |           1 |     8 |      72.9 |      24.8 |           40.27 |              40.3 |             1754.7 |    3226.4 |          0.31  |
|   128 | 1024 |           1 |     4 |      72.7 |      25.6 |           38.99 |              39.0 |             1761.4 |   26312.5 |          0.038 |
|  1024 |  128 |           1 |     4 |     211.6 |      26.7 |           37.4  |              37.4 |             4838.3 |    3607.5 |          0.277 |
|  2048 |  128 |           1 |     4 |     409.5 |      28.7 |           34.85 |              34.9 |             5000.8 |    4053.4 |          0.247 |
|  3072 |  128 |           1 |     4 |     815.6 |      30.6 |           32.72 |              32.7 |             3766.7 |    4696.4 |          0.213 |
|  4096 |  128 |           1 |     2 |     818.9 |      32.7 |           30.56 |              30.6 |             5001.7 |    4975.0 |          0.201 |
|  8192 |  128 |           1 |     2 |    1830.0 |      40.7 |           24.55 |              24.6 |             4476.5 |    7002.8 |          0.143 |
| 16384 |  128 |           1 |     2 |    4378.7 |      56.7 |           17.64 |              17.6 |             3741.8 |   11577.5 |          0.086 |
| 32000 |  128 |           1 |     2 |   11560.1 |      87.7 |           11.4  |              11.4 |             2768.1 |   22696.9 |          0.044 |
|   128 |  128 |          32 |   256 |    2088.2 |      26.9 |           37.13 |            1188.2 |             1961.5 |    5508.6 |          5.803 |
|   128 | 1024 |          32 |   128 |    2079.5 |      29.8 |           33.51 |            1072.4 |             1969.7 |   32605.4 |          0.981 |
|  2048 |  128 |          32 |   128 |   12740.7 |      38.5 |           25.95 |             830.6 |             5143.8 |   17633.8 |          1.814 |
|  2048 | 2048 |          32 |    64 |   12706.5 |      43.3 |           23.11 |             739.5 |             5157.7 |  101287.4 |          0.316 |
|  3000 |   64 |          32 |   128 |   25968.2 |      42.8 |           23.38 |             748.0 |             3696.8 |   28663.3 |          1.116 |
|  4000 |   64 |          32 |   128 |   26274.2 |      48.7 |           20.55 |             657.5 |             4871.7 |   29340.3 |          1.09  |
|  4500 |   64 |          32 |    64 |   38907.3 |      47.9 |           20.89 |             668.4 |             3701.1 |   41923.4 |          0.696 |
|  8000 |   64 |          32 |    64 |   53620.8 |      47.4 |           21.12 |             675.7 |             4774.3 |   56604.2 |          0.494 |
| 16000 |   64 |          32 |    64 |  124169.3 |      56.3 |           17.77 |             568.5 |             4123.4 |  127715.5 |          0.204 |

Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> N Req: total number of requests (sample size, N)
> TTFT: Time To First Token (ms)
> TPOT: Time Per Output Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)
> Tput Prefill: Throughput for prefill tokens (TPS)
> E2EL: End-to-End Latency (ms)
> Req Tput: Request Throughput (RPS)

### Performance Benchmark Targets Llama-3.1-8B-Instruct on n300

#### Text-to-Text Performance Benchmark Targets Llama-3.1-8B-Instruct on n300

| ISL | OSL | Concurrency | TTFT (ms) | Tput User (TPS) | Tput Decode (TPS) | Functional TTFT Check | Functional Tput User Check | Complete TTFT Check | Complete Tput User Check | Target TTFT Check | Target Tput User Check | Functional TTFT (ms) | Functional Tput User (TPS) | Complete TTFT (ms) | Complete Tput User (TPS) | Target TTFT (ms) | Target Tput User (TPS) |
|-----|-----|-------------|-----------|-----------------|-------------------|-----------------------|----------------------------|---------------------|--------------------------|-------------------|------------------------|----------------------|----------------------------|--------------------|--------------------------|------------------|------------------------|
| 128 | 128 |           1 |      72.9 |           40.27 |              40.3 | PASS ✅               | PASS ✅                    | PASS ✅             | PASS ✅                  | FAIL ⛔           | FAIL ⛔                |               580.00 |                       4.20 |             116.00 |                    21.00 |            58.00 |                  42.00 |

Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> TTFT: Time To First Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)

### Accuracy Evaluations for Llama-3.1-8B-Instruct on n300

| model                 | device | task_name     | accuracy_check | score | ratio_to_reference | gpu_reference_score | ratio_to_published | published_score                                                                           |
|-----------------------|--------|---------------|----------------|-------|--------------------|---------------------|--------------------|-------------------------------------------------------------------------------------------|
| Llama-3.1-8B-Instruct | n300   | meta_ifeval   | PASS ✅         | 77.50 | 0.95               | 81.38               | 0.96               | [80.40](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct#instruction-tuned-models) |
| Llama-3.1-8B-Instruct | n300   | meta_gpqa_cot | PASS ✅         | 30.80 | 1.09               | 28.34               | 1.01               | [30.40](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct#instruction-tuned-models) |

Note: The ratio to published scores defines if eval ran roughly correctly, as the exact methodology of the model publisher cannot always be reproduced. For this reason the accuracy check is based first on being equivalent to the GPU reference within a +/- tolerance. If a value GPU reference is not available, the accuracy check is based on the direct ratio to the published score.