### PR TITLE
Increase context length for llama3.1-8B on N150

### DIFF
--- a/benchmarking/benchmark_config.py
+++ b/benchmarking/benchmark_config.py
@@ -144,8 +144,7 @@ else:
                             num_prompts=get_num_prompts(isl, osl, 1),
                         )
                         for isl, osl in BATCH_1_BENCHMARK_COMMON_ISL_OSL_PAIRS
-                        if (isl, osl, 1) not in perf_ref_task_runs.get(_device, []) 
-                        and (isl + osl) <= model_spec.device_model_spec.max_context
+                        if (isl, osl, 1) not in perf_ref_task_runs.get(_device, [])
                     ]
                     + [
                         BenchmarkTaskParams(
@@ -157,7 +156,6 @@ else:
                         for isl, osl in MAX_CONCURRENCY_BENCHMARK_COMMON_ISL_OSL_PAIRS
                         if (isl, osl, _max_concurrency)
                         not in perf_ref_task_runs.get(_device, [])
-                        and (isl + osl) <= model_spec.device_model_spec.max_context
                     ]
                     + 
                     (

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1134,7 +1134,7 @@ spec_templates = [
             DeviceModelSpec(
                 device=DeviceTypes.N150,
                 max_concurrency=32,
-                max_context=8 * 1024, # revert back to 64 * 1024 once https://github.com/tenstorrent/tt-metal/issues/23854#issuecomment-3245384170 is resolved
+                max_context=64 * 1024,
                 default_impl=True,
             ),
             DeviceModelSpec(


### PR DESCRIPTION
### Issue

https://github.com/tenstorrent/tt-metal/issues/23854

### Description
This reverts commit b3a4a88a4ab2ca8c2a36a2d6561124530d08b565.
Increase context length for Llama3.1-8B on N150 due to fixing earlier [issue](https://github.com/tenstorrent/tt-metal/commit/2097ffd52bc53f01436e145a7a3e80fed2aa9fc4) with OOM on DRAM.

### Pipelines
tt-shield full release run: https://github.com/tenstorrent/tt-shield/actions/runs/17619165591