### PR TITLE
Return base64 image responses

### DIFF
--- a/tt-metal-sdxl/open_ai_api/image.py
+++ b/tt-metal-sdxl/open_ai_api/image.py
@@ -2,7 +2,8 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-from fastapi import APIRouter, Depends, Response, Security, HTTPException
+from fastapi import APIRouter, Depends, Security, HTTPException
+from fastapi.responses import JSONResponse
 from domain.image_generate_request import ImageGenerateRequest
 from model_services.base_service import BaseService
 from resolver.service_resolver import service_resolver
@@ -16,18 +17,18 @@ async def generate_image(
     image_generate_request: ImageGenerateRequest,
     service: BaseService = Depends(service_resolver),
     api_key: str = Security(get_api_key)
-) -> Response:
+):
     """
     Generate an image based on the provided request.
 
     Returns:
-        Response: The generated image as a PNG.
+        JSONResponse: The generated images as a list of base64 strings.
 
     Raises:
         HTTPException: If image generation fails.
     """
     try:
         result = await service.process_request(image_generate_request)
-        return Response(content=result, media_type="image/png")
+        return JSONResponse(content={"images": result})
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/tt-metal-sdxl/utils/image_manager.py
+++ b/tt-metal-sdxl/utils/image_manager.py
@@ -36,7 +36,7 @@ class ImageManager:
         file_path.unlink()
         return True
 
-    def convert_image_to_base64(self, image: Image.Image, format="JPEG", quality=85):
+    def _convert_image_to_base64(self, image: Image.Image, format="JPEG", quality=85):
         """
         Convert PIL Image directly to base64 string with optimized settings.
         
@@ -79,11 +79,11 @@ class ImageManager:
         
         # Handle single image
         if hasattr(images, 'save'):  # Single PIL Image
-            return [self.convert_image_to_base64(images)]
+            return [self._convert_image_to_base64(images)]
         
         # Handle list of images
         if isinstance(images, list):
-            return [self.convert_image_to_base64(img) for img in images if hasattr(img, 'save')]
+            return [self._convert_image_to_base64(img) for img in images if hasattr(img, 'save')]
         
         return []
 

--- a/tt-metal-sdxl/utils/image_manager.py
+++ b/tt-metal-sdxl/utils/image_manager.py
@@ -36,13 +36,56 @@ class ImageManager:
         file_path.unlink()
         return True
 
+    def convert_image_to_base64(self, image: Image.Image, format="JPEG", quality=85):
+        """
+        Convert PIL Image directly to base64 string with optimized settings.
+        
+        Args:
+            image: PIL Image object
+            format: Image format (JPEG is fastest for photos)
+            quality: JPEG quality (85 is good balance of size/speed)
+            
+        Returns:
+            Base64 encoded string
+        """
+        buffered = BytesIO()
+        # Optimized save parameters for speed
+        image.save(buffered, format=format, quality=quality, optimize=False, progressive=False)
+        # Use base64.encodebytes which is faster than b64encode for larger data
+        encoded_bytes = base64.encodebytes(buffered.getvalue())
+        # decode() is faster than str() conversion
+        return encoded_bytes.decode('ascii').replace('\n', '')
+
     def convert_image_from_file_to_base64(self, filename: str):
         file_path = self.get_image_path(filename)
         with open(file_path, "rb") as image_file:
             encoded_bytes = base64.b64encode(image_file.read())
             encoded_string = encoded_bytes.decode("utf-8")
-
         return encoded_string
+
+    def images_to_base64_list(self, images):
+        """
+        Convert PIL Images to base64 strings.
+        Simplified version - handles only flat lists of PIL Images.
+        
+        Args:
+            images: Single PIL Image or list of PIL Images
+            
+        Returns:
+            List of base64-encoded image strings
+        """
+        if not images:
+            return []
+        
+        # Handle single image
+        if hasattr(images, 'save'):  # Single PIL Image
+            return [self.convert_image_to_base64(images)]
+        
+        # Handle list of images
+        if isinstance(images, list):
+            return [self.convert_image_to_base64(img) for img in images if hasattr(img, 'save')]
+        
+        return []
 
     @log_execution_time("ImageManager converting image to bytes")
     def convert_image_to_bytes(self, image):


### PR DESCRIPTION
Added returning base64 responses for image generation.

Why: When returning multiple images this is the only proper way of returning those.

Response looks:

<img width="832" height="467" alt="image" src="https://github.com/user-attachments/assets/371101ff-d2cc-43aa-9703-0a7823e347b5" />


Note: Tested on both SDXL, SD-3.5 and image-client for benchmarks