### PR TITLE
fix openai sdk dep, it can be managed by vllm requirements

### DIFF
--- a/vllm-tt-metal-llama3/requirements.txt
+++ b/vllm-tt-metal-llama3/requirements.txt
@@ -1,5 +1,3 @@
-# inference server requirements
+# additional inference server and client script requirements
 pyjwt==2.7.0
 requests==2.32.3
-datasets==3.1.0
-openai==1.53.1


### PR DESCRIPTION
# change log

* fix openai sdk dep, it can be managed by vllm requirements

---

This currently leads to 
```
(python_env) container_app_user@7016ef1d0885:~/app/src$ pip freeze | grep openai
openai==1.90.0                                                                                            
(python_env) container_app_user@7016ef1d0885:~/app/src$ pip freeze | grep datasets                                                                                                                                   
datasets==2.9.0
```