### PR TITLE
Uplift for Qwen2.5-72B and QwQ-32B

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -946,24 +946,6 @@ spec_templates = [
     ),
     ModelSpecTemplate(
         weights=["Qwen/Qwen2.5-72B", "Qwen/Qwen2.5-72B-Instruct"],
-        impl=llama3_impl,
-        tt_metal_commit="834686671ea3",
-        vllm_commit="44f8562",
-        device_model_specs=[
-            DeviceModelSpec(
-                device=DeviceTypes.T3K,
-                max_concurrency=32,
-                max_context=128 * 1024,
-                default_impl=False,
-            ),
-        ],
-        status=ModelStatusTypes.COMPLETE,
-        env_vars={
-            "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
-        },
-    ),
-    ModelSpecTemplate(
-        weights=["Qwen/Qwen2.5-72B", "Qwen/Qwen2.5-72B-Instruct"],
         impl=tt_transformers_impl,
         tt_metal_commit="834686671ea3",
         vllm_commit="44f8562",


### PR DESCRIPTION
Successful release run with the following results

### Performance Benchmark Targets Qwen2.5-72B-Instruct on t3k

#### Text-to-Text Performance Benchmark Targets Qwen2.5-72B-Instruct on t3k

| ISL | OSL | Concurrency | TTFT (ms) | Tput User (TPS) | Tput Decode (TPS) | Functional TTFT Check | Functional Tput User Check | Complete TTFT Check | Complete Tput User Check | Target TTFT Check | Target Tput User Check | Functional TTFT (ms) | Functional Tput User (TPS) | Complete TTFT (ms) | Complete Tput User (TPS) | Target TTFT (ms) | Target Tput User (TPS) |
|-----|-----|-------------|-----------|-----------------|-------------------|-----------------------|----------------------------|---------------------|--------------------------|-------------------|------------------------|----------------------|----------------------------|--------------------|--------------------------|------------------|------------------------|
| 128 | 128 |           1 |     211.9 |           14.94 |              14.9 | PASS ✅               | PASS ✅                    | PASS ✅             | PASS ✅                  | FAIL ⛔           | FAIL ⛔                |              1210.00 |                       2.00 |             242.00 |                    10.00 |           121.00 |                  20.00 |
| 128 | 128 |          32 |    5913.2 |           14.64 |             468.6 | PASS ✅               | PASS ✅                    | PASS ✅             | PASS ✅                  | FAIL ⛔           | FAIL ⛔                |             38720.00 |                       2.00 |            7744.00 |                    10.00 |          3872.00 |                  20.00 |

Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> TTFT: Time To First Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)

### Accuracy Evaluations for Qwen2.5-72B-Instruct on t3k

| model                | device | task_name                      | accuracy_check | score | ratio_to_reference | gpu_reference_score                                                                            | ratio_to_published | published_score                           |
|----------------------|--------|--------------------------------|----------------|-------|--------------------|------------------------------------------------------------------------------------------------|--------------------|-------------------------------------------|
| Qwen2.5-72B-Instruct | t3k    | leaderboard_ifeval             | PASS ✅         | 84.10 | 1.01               | [82.99](https://github.com/tenstorrent/tt-inference-server/issues/143#issuecomment-2770711161) | 1.00               | [84.10](https://arxiv.org/abs/2412.15115) |
| Qwen2.5-72B-Instruct | t3k    | leaderboard_math_hard          | N/A            | 1.97  | N/A                | None                                                                                           | N/A                | None                                      |
| Qwen2.5-72B-Instruct | t3k    | gpqa_diamond_generative_n_shot | PASS ✅         | 42.93 | 1.00               | [42.93](https://github.com/tenstorrent/tt-inference-server/issues/143#issuecomment-2770711161) | N/A                | None                                      |
| Qwen2.5-72B-Instruct | t3k    | mmlu_pro                       | PASS ✅         | 44.09 | 1.27               | [34.79](https://github.com/tenstorrent/tt-inference-server/issues/143#issuecomment-2770711161) | N/A                | None                                      |
