### PR TITLE
Bump commits for Llama-8B DP=4 on Galaxy

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1201,8 +1201,8 @@ spec_templates = [
     ModelSpecTemplate(
         weights=["meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-8B-Instruct"],
         impl=tt_transformers_impl,
-        tt_metal_commit="528d71f",
-        vllm_commit="005baf4",
+        tt_metal_commit="3896b60",
+        vllm_commit="f6c6c29",
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.GALAXY,


### PR DESCRIPTION
The old ModelSpec was pointing to a tt-metal commit that did not exist in a tree. This PR uplifts the tt-metal & vLLM commits to the last passing Models CI nightly commits

https://github.com/tenstorrent/tt-shield/actions/runs/17714138695/job/50337585866