### PR TITLE
Gemma3 Update

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -707,11 +707,33 @@ class ModelSpecTemplate:
 spec_templates = [
     ModelSpecTemplate(
         weights=[
-            "google/gemma-3-4b-it",
+            "google/gemma-3-1b-it",
         ],
         impl=tt_transformers_impl,
-        tt_metal_commit="87b758d",
-        vllm_commit="03cb300",
+        tt_metal_commit="dc85f59",
+        vllm_commit="87fe4a4",
+        device_model_specs=[
+            DeviceModelSpec(
+                device=DeviceTypes.N150,
+                max_concurrency=32,
+                max_context=32 * 1024,
+                default_impl=True,
+                override_tt_config={
+                    "l1_small_size": 768,
+                    "fabric_config": "FABRIC_1D",
+                },
+            ),
+        ],
+        status=ModelStatusTypes.EXPERIMENTAL,
+    ),
+    ModelSpecTemplate(
+        weights=[
+            "google/gemma-3-4b-it",
+            "google/medgemma-4b-it",
+        ],
+        impl=tt_transformers_impl,
+        tt_metal_commit="dc85f59",
+        vllm_commit="87fe4a4",
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.N150,
@@ -733,16 +755,6 @@ spec_templates = [
                     "fabric_config": "FABRIC_1D",
                 },
             ),
-            DeviceModelSpec(
-                device=DeviceTypes.T3K,
-                max_concurrency=32,
-                max_context=128 * 1024,
-                default_impl=True,
-                override_tt_config={
-                    "l1_small_size": 768,
-                    "fabric_config": "FABRIC_1D",
-                },
-            ),
         ],
         status=ModelStatusTypes.EXPERIMENTAL,
         supported_modalities=["text", "image"],
@@ -750,10 +762,11 @@ spec_templates = [
     ModelSpecTemplate(
         weights=[
             "google/gemma-3-27b-it",
+            "google/medgemma-27b-it",
         ],
         impl=tt_transformers_impl,
-        tt_metal_commit="87b758d",
-        vllm_commit="03cb300",
+        tt_metal_commit="dc85f59",
+        vllm_commit="87fe4a4",
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.T3K,


### PR DESCRIPTION
- New version of Gemma3 supports multi-image prompts and works with uplifted vLLM.
- Add `MedGemma` model - same architecture as `Gemma3`, but trained on medical data.
- Add support for `gemma-3-1b-it` text model; Context length is 32k, per specification.
- Remove T3K target for `gemma-3-4b-it`, as the model cannot be run across 8 devices.