### PR TITLE
Revert "Gemma3 Processor Args"

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -750,13 +750,6 @@ spec_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
-                vllm_args={
-                    "mm_processor_kwargs": {
-                        "use_fast": True,
-                        "do_convert_rgb": True,
-                        "do_pan_and_scan": True,
-                    }
-                }
                 override_tt_config={
                     "l1_small_size": 768,
                     "fabric_config": "FABRIC_1D",
@@ -780,13 +773,6 @@ spec_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
-                vllm_args={
-                    "mm_processor_kwargs": {
-                        "use_fast": True,
-                        "do_convert_rgb": True,
-                        "do_pan_and_scan": True,
-                    }
-                }
                 override_tt_config={
                     "l1_small_size": 768,
                     "fabric_config": "FABRIC_1D",


### PR DESCRIPTION
Reverts tenstorrent/tt-inference-server#691

Causing error:
```
tstesco@xxxxx[dev]:~/projects/github/tt-inference-server$ git log -1
commit d32e555e56ceb70877d6c7d8bf37da7646cebe43 (HEAD -> dev, origin/dev)
Author: Pavle Petrovic <ppetrovic@tenstorrent.com>
Date:   Thu Sep 18 18:11:07 2025 +0200

    Gemma3 Processor Args (#691)

    Enable Gemma3 processor to handle large images and 4-channel images.
tstesco@xxxx[dev]:~/projects/github/tt-inference-server$ python3 run.py
Traceback (most recent call last):
  File "/Users/tstesco/projects/github/tt-inference-server/run.py", line 16, in <module>
    from workflows.model_spec import MODEL_SPECS, ModelSpec, get_runtime_model_spec
  File "/Users/tstesco/projects/github/tt-inference-server/workflows/model_spec.py", line 753
    vllm_args={
              ^
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```