### PR TITLE
Gemma3 Processor Args

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -740,6 +740,13 @@ spec_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                vllm_args={
+                    "mm-processor-kwargs": json.dumps({
+                        "use_fast": True,
+                        "do_convert_rgb": True,
+                        "do_pan_and_scan": True,
+                    }),
+                },
                 override_tt_config={
                     "l1_small_size": 768,
                     "fabric_config": "FABRIC_1D",
@@ -750,6 +757,13 @@ spec_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                vllm_args={
+                    "mm-processor-kwargs": json.dumps({
+                        "use_fast": True,
+                        "do_convert_rgb": True,
+                        "do_pan_and_scan": True,
+                    }),
+                },
                 override_tt_config={
                     "l1_small_size": 768,
                     "fabric_config": "FABRIC_1D",
@@ -773,6 +787,13 @@ spec_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                vllm_args={
+                    "mm-processor-kwargs": json.dumps({
+                        "use_fast": True,
+                        "do_convert_rgb": True,
+                        "do_pan_and_scan": True,
+                    }),
+                },
                 override_tt_config={
                     "l1_small_size": 768,
                     "fabric_config": "FABRIC_1D",


### PR DESCRIPTION
Enable Gemma3 processor to handle large images and 4-channel images.
CI Run in progress (already validated the change):
https://github.com/tenstorrent/tt-shield/actions/runs/17854658356/job/50772965866