### PR TITLE
Params for SD-3.5 deployment

### DIFF
--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.source=https://github.com/tenstorrent/tt-inferenc
 
 ARG DEBIAN_FRONTEND=noninteractive
 # default commit sha, override with --build-arg TT_METAL_COMMIT_SHA_OR_TAG=<sha>
-ARG TT_METAL_COMMIT_SHA_OR_TAG=81989dcdb8f9b340c932ae7a71a346f4f08703eb
+ARG TT_METAL_COMMIT_SHA_OR_TAG=93d6484a7718c02cb6f3ac712d7d3ffe1d7ceb82
 
 
 # CONTAINER_APP_UID is a random ID, change this and rebuild if it collides with host

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -66,6 +66,7 @@ ModelConfigs = {
     (SupportedModels.STABLE_DIFFUSION_3_5_LARGE, DeviceTypes.T3K): {
         "model_runner": ModelRunners.TT_SD3_5.value,
         "model_service": ModelServices.IMAGE.value,
+        "device_ids": "", # enfornce no device split, we need the whole machine
         "device_mesh_shape": (2, 4),
         "is_galaxy": False,
         "device_ids": "", #HACK to use all devices. device id split will retun and empty string to be passed to os.environ[TT_VISIBLE_DEVICES] in device_worker.py
@@ -74,6 +75,7 @@ ModelConfigs = {
     (SupportedModels.STABLE_DIFFUSION_3_5_LARGE, DeviceTypes.GALAXY): {
         "model_runner": ModelRunners.TT_SD3_5.value,
         "model_service": ModelServices.IMAGE.value,
+        "device_ids": "", # enfornce no device split, we need the whole machine
         "device_mesh_shape": (4, 8),
         "is_galaxy": False,
         "device_ids": "", #HACK to use all devices. device id split will retun and empty string to be passed to os.environ[TT_VISIBLE_DEVICES] in device_worker.py

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -66,7 +66,7 @@ ModelConfigs = {
     (SupportedModels.STABLE_DIFFUSION_3_5_LARGE, DeviceTypes.T3K): {
         "model_runner": ModelRunners.TT_SD3_5.value,
         "model_service": ModelServices.IMAGE.value,
-        "device_ids": "", # enfornce no device split, we need the whole machine
+        "device_ids": "", # enforce no device split, we need the whole machine
         "device_mesh_shape": (2, 4),
         "is_galaxy": False,
         "device_ids": "", #HACK to use all devices. device id split will retun and empty string to be passed to os.environ[TT_VISIBLE_DEVICES] in device_worker.py

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -75,7 +75,7 @@ ModelConfigs = {
     (SupportedModels.STABLE_DIFFUSION_3_5_LARGE, DeviceTypes.GALAXY): {
         "model_runner": ModelRunners.TT_SD3_5.value,
         "model_service": ModelServices.IMAGE.value,
-        "device_ids": "", # enfornce no device split, we need the whole machine
+        "device_ids": "", # enforce no device split, we need the whole machine
         "device_mesh_shape": (4, 8),
         "is_galaxy": False,
         "device_ids": "", #HACK to use all devices. device id split will retun and empty string to be passed to os.environ[TT_VISIBLE_DEVICES] in device_worker.py


### PR DESCRIPTION
Changes to enable SD-3.5 docker image to run:

- Changed metal commit to cover for SD-3.5
- Changed device params to always leverage the whole T3k