### PR TITLE
tstesco/fix-decode-tput-calc

### DIFF
--- a/benchmarking/benchmark_config.py
+++ b/benchmarking/benchmark_config.py
@@ -50,9 +50,9 @@ MAX_CONCURRENCY_BENCHMARK_COMMON_ISL_OSL_PAIRS = [
     (2048, 2048),
     (3000, 64),
     (4000, 64),
-    (4500, 64),
     (8000, 64),
     (16000, 64),
+    (32000, 64),
 ]
 
 # Image resolution pairs for multimodal benchmarks


### PR DESCRIPTION
# change log

* add get_benchmark_max_concurrency() to resolve concurrency depending on isl, osl, max_context, and model_max_concurrency. Quick fix for https://github.com/tenstorrent/tt-inference-server/issues/704
* improve MAX_CONCURRENCY_BENCHMARK_COMMON_ISL_OSL_PAIRS: remove 4500, add 32000


##  Example benchmark sweeps output:

```
### Performance Benchmark Sweeps for Llama-3.2-1B on n150

#### Text-to-Text Performance Benchmark Sweeps for Llama-3.2-1B on n150

|  ISL  | OSL  | Concurrency | N Req | TTFT (ms) | TPOT (ms) | Tput User (TPS) | Tput Decode (TPS) | Tput Prefill (TPS) | E2EL (ms) | Req Tput (RPS) |
|-------|------|-------------|-------|-----------|-----------|-----------------|-------------------|--------------------|-----------|----------------|
|   128 |  128 |           1 |     8 |      41.5 |      15.2 |           65.8  |              65.8 |             3083.5 |    1971.7 |          0.507 |
|   128 | 1024 |           1 |     4 |      42.3 |      16.2 |           61.73 |              61.7 |             3025.6 |   16614.6 |          0.06  |
|  1024 |  128 |           1 |     4 |      82.6 |      17.8 |           56.31 |              56.3 |            12390.9 |    2338.1 |          0.428 |
|  2048 |  128 |           1 |     4 |     141.8 |      19.6 |           50.97 |              51.0 |            14438.2 |    2633.8 |          0.38  |
|  3072 |  128 |           1 |     4 |     274.5 |      22.2 |           45.11 |              45.1 |            11190.9 |    3089.8 |          0.324 |
|  4096 |  128 |           1 |     2 |     277.0 |      24.3 |           41.07 |              41.1 |            14789.2 |    3369.3 |          0.297 |
|  8192 |  128 |           1 |     2 |     640.6 |      33.4 |           29.95 |              30.0 |            12788.8 |    4880.6 |          0.205 |
| 16384 |  128 |           1 |     2 |    1679.2 |      51.5 |           19.4  |              19.4 |             9757.2 |    8224.2 |          0.122 |
| 32000 |  128 |           1 |     2 |    5061.7 |      84.9 |           11.77 |              11.8 |             6322.0 |   15850.2 |          0.063 |
|   128 |  128 |          32 |   256 |     842.8 |      17.4 |           57.52 |            1840.7 |             4860.2 |    3050.7 |         10.451 |
|   128 | 1024 |          32 |   128 |     828.6 |      18.6 |           53.78 |            1721.1 |             4943.0 |   19849.5 |          1.611 |
|  2048 |  128 |          32 |   128 |    3669.7 |      24.3 |           41.19 |            1318.1 |            17858.5 |    6753.0 |          4.728 |
|  2048 | 2048 |          32 |    64 |    3668.5 |      26.1 |           38.38 |            1228.2 |            17864.6 |   57002.9 |          0.561 |
|  3000 |   64 |          32 |   128 |    7789.4 |      27.4 |           36.5  |            1168.0 |            12324.5 |    9515.5 |          3.357 |
|  4000 |   64 |          32 |   128 |    7847.2 |      30.1 |           33.23 |            1063.4 |            16311.5 |    9743.1 |          3.279 |
|  8000 |   64 |          16 |    32 |    9542.5 |      34.1 |           29.35 |             469.7 |            13413.7 |   11688.7 |          1.367 |
| 16000 |   64 |           8 |    16 |   13022.2 |      50.2 |           19.93 |             159.4 |             9829.4 |   16183.8 |          0.494 |
| 32000 |   64 |           4 |     8 |   20004.4 |      86.3 |           11.58 |              46.3 |             6398.6 |   25444.3 |          0.157 |


Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> N Req: total number of requests (sample size, N)
> TTFT: Time To First Token (ms)
> TPOT: Time Per Output Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)
> Tput Prefill: Throughput for prefill tokens (TPS)
> E2EL: End-to-End Latency (ms)
> Req Tput: Request Throughput (RPS)
```