### PR TITLE
Add system sw skip to CLI, add extra 8-char UUID to ModelSpec JSON path

### DIFF
--- a/run.py
+++ b/run.py
@@ -158,8 +158,20 @@ def parse_arguments():
         action="store_true",
         help="Skips the system software validation step (no tt-smi or tt-topology verification)",
     )
+    parser.add_argument(
+        "--ci-mode",
+        action="store_true",
+        help="Enables CI-mode, which indirectly sets other flags to facilitate CI environments",
+    )
 
     args = parser.parse_args()
+
+    # indirectly set additional flags for CI-mode
+    if args.ci_mode:
+        if "--limit-samples-mode" not in args:
+            args.limit_samples_mode = "ci-nightly"
+        if "--skip-system-sw-validation" not in args:
+            args.skip_system_sw_validation = True
 
     return args
 
@@ -275,6 +287,7 @@ def format_cli_args_summary(args, model_spec):
         f"  model_spec_json:            {args.model_spec_json}",
         f"  workflow_args:              {args.workflow_args}",
         f"  reset_venvs:                {args.reset_venvs}",
+        f"  limit-samples-mode:         {args.limit_samples_mode}",
         f"  skip_system_sw_validation:  {args.skip_system_sw_validation}",
         "",
         "=" * 60,

--- a/run.py
+++ b/run.py
@@ -153,6 +153,11 @@ def parse_arguments():
         type=str,
         help="Predefined eval dataset limit mappings: ['ci-nightly', 'ci-long', 'ci-commit', 'smoke-test']",
     )
+    parser.add_argument(
+        "--skip-system-sw-validation",
+        action="store_true",
+        help="Skips the system software validation step (no tt-smi or tt-topology verification)",
+    )
 
     args = parser.parse_args()
 
@@ -216,27 +221,30 @@ def validate_local_setup(model_spec, json_fpath):
     workflow_root_log_dir = get_default_workflow_root_log_dir()
     ensure_readwriteable_dir(workflow_root_log_dir)
 
-    # check, and enforce if necessary, system software dependency versions
-    WorkflowSetup.boostrap_uv()
-    venv_python = create_local_setup_venv(WorkflowSetup.uv_exec)
+    def _validate_system_software_deps():
+        # check, and enforce if necessary, system software dependency versions
+        WorkflowSetup.boostrap_uv()
+        venv_python = create_local_setup_venv(WorkflowSetup.uv_exec)
 
-    # fmt: off
-    cmd = [
-        str(venv_python),
-        str(get_repo_root_path() / "workflows" / "run_local_setup_validation.py"),
-        "--model-spec-json", str(json_fpath),
-    ]
-    # fmt: on
+        # fmt: off
+        cmd = [
+            str(venv_python),
+            str(get_repo_root_path() / "workflows" / "run_local_setup_validation.py"),
+            "--model-spec-json", str(json_fpath),
+        ]
+        # fmt: on
 
-    return_code = run_command(cmd, logger=logger)
+        return_code = run_command(cmd, logger=logger)
 
-    if return_code != 0:
-        raise ValueError(
-            f"⛔ validating local setup failed. See ValueErrors above for required version, and System Info section above for current system versions."
-        )
-    else:
-        logger.info("✅ validating local setup completed")
+        if return_code != 0:
+            raise ValueError(
+                f"⛔ validating local setup failed. See ValueErrors above for required version, and System Info section above for current system versions."
+            )
+        else:
+            logger.info("✅ validating local setup completed")
 
+    if not model_spec.cli_args.skip_system_sw_validation:
+        _validate_system_software_deps()
 
 def format_cli_args_summary(args, model_spec):
     """Format CLI arguments and runtime info in a clean, readable format."""
@@ -267,6 +275,7 @@ def format_cli_args_summary(args, model_spec):
         f"  model_spec_json:            {args.model_spec_json}",
         f"  workflow_args:              {args.workflow_args}",
         f"  reset_venvs:                {args.reset_venvs}",
+        f"  skip_system_sw_validation:  {args.skip_system_sw_validation}",
         "",
         "=" * 60,
     ]


### PR DESCRIPTION
This PR enables the tt-inference-server CLI to be executed in multiple, instantaneously concurrent processes, addressing #737 and #731

Specifically, I added:
* `--skip-system-sw-validation` flag to CLI
  * this skips the FW & KMD version checking via `tt-smi` as it is not multi-process safe
  * this skips the Wormhole system topology checks via `tt-topology` as it is not multi-process safe
* `--ci-mode` flag to CLI
  * sets `--skip-system-sw-validation`
  * sets `--limit-samples-mode ci-nightly`
* a new, random 8-character UUID to the end of the `run_id`
  * `ModelSpec` JSON filenames now look like: `tt_model_spec_2025-09-25_15-32-40_id_tt-transformers_Llama-3.1-8B-Instruct_n300_server_sUuVu3Kv.json`
  * `/run_logs` filenames now look like: `run_2025-09-25_15-32-40_id_tt-transformers_Llama-3.1-8B-Instruct_n300_server_sUuVu3Kv.log`
  
**Result**
With these changes, this bash script can now be executed:
```bash
#!/bin/bash

# Run N instances of run.py server workflow concurrently
concurrency=$1

for (( i = 0; i < concurrency; i++ )); do
    python3 run.py \
        --model Llama-3.1-8B-Instruct \
        --device n300 \
        --workflow server \
        --docker-server \
        --dev-mode \
        --device-id "$i" \
        --service-port "$((8000 + i))" \
        --skip-system-sw-validation &
done
```