### PR TITLE
Move a bootstrap venv to prevent being skipped

### DIFF
--- a/run.py
+++ b/run.py
@@ -232,10 +232,10 @@ def validate_local_setup(model_spec, json_fpath):
     logger.info("Starting local setup validation")
     workflow_root_log_dir = get_default_workflow_root_log_dir()
     ensure_readwriteable_dir(workflow_root_log_dir)
+    WorkflowSetup.bootstrap_uv()
 
     def _validate_system_software_deps():
         # check, and enforce if necessary, system software dependency versions
-        WorkflowSetup.boostrap_uv()
         venv_python = create_local_setup_venv(WorkflowSetup.uv_exec)
 
         # fmt: off

--- a/workflows/run_workflows.py
+++ b/workflows/run_workflows.py
@@ -46,7 +46,7 @@ class WorkflowSetup:
             self.config = _config
 
     @classmethod
-    def boostrap_uv(cls):
+    def bootstrap_uv(cls):
         # Step 1: Check Python version
         python_version = sys.version_info
         if python_version < (3, 6):


### PR DESCRIPTION
Related to https://github.com/tenstorrent/tt-inference-server/pull/738

When the skip option is enabled, `run.py` fails because `self.uv_exec` is None. This happens since `self.uv_exec` is normally initialized in `bootstrap_uv`, which is skipped in this case. This PR fixes this issue.