### PR TITLE
Fix models.utility_functions import path

### DIFF
--- a/tt-media-server/tests/whisper_demo.py
+++ b/tt-media-server/tests/whisper_demo.py
@@ -27,7 +27,7 @@ from models.demos.utils.llm_demo_utils import verify_perf
 from models.demos.whisper.tt import ttnn_optimized_functional_whisper
 from models.demos.whisper.tt.ttnn_optimized_functional_whisper import WHISPER_L1_SMALL_SIZE, init_kv_cache
 from models.generation_utils import get_logits_processor
-from models.utility_functions import is_blackhole
+from models.common.utility_functions import is_blackhole
 
 
 def load_input_paths(folder_path):

--- a/tt-media-server/tt_model_runners/sdxl_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_runner_trace.py
@@ -17,7 +17,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     SDXL_FABRIC_CONFIG
 )
 from domain.image_generate_request import ImageGenerateRequest
-from models.utility_functions import profiler
+from models.common.utility_functions import profiler
 from models.experimental.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import TtSDXLPipeline, TtSDXLPipelineConfig
 
 class TTSDXLRunnerTrace(BaseDeviceRunner):


### PR DESCRIPTION
Update imports from `models.utility_functions` to `models.common.utility_functions` to match recent tt-metal changes:
https://github.com/tenstorrent/tt-metal/pull/28666

The tt-sdxl-trace model runner was failing to load with the error:
```
[SERVER] 2025-09-28 14:13:37,094 - ERROR - Failed to get device runner: Failed to load model runner 'tt-sdxl-trace': No module named 'models.utility_functions'
[SERVER] 2025-09-28 14:13:37,096 - WARNING - Worker 0 error cound is : 1
[SERVER] 2025-09-28 14:13:37,096 - ERROR - Error in worker -1: Failed to load model runner 'tt-sdxl-trace': No module named 'models.utility_functions'
```
https://github.com/tenstorrent/tt-shield/actions/runs/18073867188/job/51429862717

Run with the fix:
https://github.com/tenstorrent/tt-shield/actions/runs/18075613132/job/51431613402