### PR TITLE
tstesco/uplift-llama-70b-glx

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1005,7 +1005,7 @@ spec_templates = [
         ],
         impl=llama3_70b_galaxy_impl,
         tt_metal_commit="473248d",
-        vllm_commit="2a73c50",
+        vllm_commit="aa6198b",
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.GALAXY,


### PR DESCRIPTION
# change log

* bump up trace_region_size=146933760, use tt-metal with host sampling perf improvement
* uplift vLLM to tstesco/fix-dp-kv-cache-slots