### PR TITLE
tstesco/add-trace-capture-by-default

### DIFF
--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -29,13 +29,18 @@ DEFAULT_IMAGE_RESOLUTIONS = [
 ]
 
 # Hardcoded padded sequence lengths for trace capture
-# Based on TT hardware padding requirements (powers of 2 and multiples of 1024)
+# Based on TT hardware padding requirements (powers of 2)
 PADDED_SEQ_LENS = [
     1,
     128,
     256,
     512,
-] + [isl - 128 for isl in range(1024, 131072, 1024)]
+    1024,
+    2048,
+    4096,
+    8192,
+    16384,
+]
 
 
 def get_trace_context_lens(
@@ -51,7 +56,7 @@ def get_trace_context_lens(
     Returns:
         List of (input_seq_len, output_seq_len) tuples
     """
-    return [(seq_len, output_len) for seq_len in PADDED_SEQ_LENS if seq_len <= max_context]
+    return [(seq_len, output_len) for seq_len in PADDED_SEQ_LENS if seq_len <= (max_context + output_len)]
 
 
 class PromptClient:

--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -40,6 +40,9 @@ PADDED_SEQ_LENS = [
     4096,
     8192,
     16384,
+    32768 - 128,  # the - 128 is for models that have this as max context length
+    65536 - 128,
+    131072 - 128,
 ]
 
 

--- a/vllm-tt-metal-llama3/src/run_vllm_api_server.py
+++ b/vllm-tt-metal-llama3/src/run_vllm_api_server.py
@@ -91,7 +91,7 @@ def register_tt_models():
         "models.tt_transformers.tt.generator_vllm:Gemma3ForConditionalGeneration"
     )
 
-
+# Note: vLLM custom model architecture registry must happen at import time, before runtime
 register_tt_models()
 
 

--- a/vllm-tt-metal-llama3/src/run_vllm_api_server.py
+++ b/vllm-tt-metal-llama3/src/run_vllm_api_server.py
@@ -7,6 +7,7 @@ import sys
 import runpy
 import logging
 import json
+import multiprocessing
 from pprint import pprint
 from pathlib import Path
 
@@ -19,6 +20,7 @@ from utils.vllm_run_utils import (
     create_model_symlink,
     get_encoded_api_key,
 )
+from utils.prompt_client import run_background_trace_capture
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -241,6 +243,52 @@ def set_runtime_env_vars(model_spec_json):
         logger.info(f"setting env var: {key}={value}")
         os.environ[key] = value
 
+def start_trace_capture(model_spec_json):
+    # Check if trace capture should be disabled
+    disable_trace_capture = model_spec_json.get("cli_args", {}).get(
+        "disable_trace_capture", False
+    )
+
+    if not disable_trace_capture:
+        # Start background trace capture process
+        service_port = model_spec_json.get("cli_args", {}).get(
+            "service_port", int(os.getenv("SERVICE_PORT", "8000"))
+        )
+        jwt_secret = os.getenv("JWT_SECRET", "")
+        supported_modalities = model_spec_json.get("supported_modalities", ["text"])
+        
+        # Get max_context from device_model_spec for trace calculation
+        max_context = model_spec_json.get("device_model_spec", {}).get("max_context")
+        if max_context is None:
+            # Fallback to vllm_args if not in device_model_spec
+            max_model_len_str = model_spec_json.get("device_model_spec", {}).get(
+                "vllm_args", {}
+            ).get("max_model_len")
+            if max_model_len_str:
+                max_context = int(max_model_len_str)
+
+        logger.info("Starting background trace capture process...")
+        trace_process = multiprocessing.Process(
+            target=run_background_trace_capture,
+            args=(
+                model_spec_json["hf_model_repo"],
+                service_port,
+                jwt_secret,
+                supported_modalities,
+                max_context,
+            ),
+            daemon=True,
+            name="trace_capture",
+        )
+        trace_process.start()
+        logger.info(
+            f"Background trace capture process started (PID: {trace_process.pid}, "
+            f"max_context: {max_context})"
+        )
+    else:
+        logger.info("Trace capture is disabled via cli_args.disable_trace_capture")
+
+
 
 def main():
     # use raw model_spec_json to demonstrate interoperability
@@ -252,6 +300,8 @@ def main():
     handle_code_versions(model_spec_json)
 
     runtime_settings(model_spec_json)
+    start_trace_capture(model_spec_json)
+
     # vLLM CLI arguments
     logger.info(f"vllm_args:")
     pprint(model_spec_json["device_model_spec"]["vllm_args"])


### PR DESCRIPTION
# change log

* address https://github.com/tenstorrent/tt-inference-server/issues/781, force trace capture via vLLM inference calls on startup.

## Notes

- With the trace capture happening by default on vLLM server startup via `vllm-tt-metal-llama3/src/run_vllm_api_server.py` the benchmarks and evals still should not have their trace captures disabled because there is not a good way to ensure that the server has completed trace capture and is idle. This could be okay for evals but will not be good for benchmarks. For this reason the trace capture will still also run on both.