### PR TITLE
Add Galaxy_T3K device type to support partitioning per tray on Galaxy

### DIFF
--- a/run.py
+++ b/run.py
@@ -258,6 +258,7 @@ def validate_local_setup(model_spec, json_fpath):
     if not model_spec.cli_args.skip_system_sw_validation:
         _validate_system_software_deps()
 
+
 def format_cli_args_summary(args, model_spec):
     """Format CLI arguments and runtime info in a clean, readable format."""
     lines = [
@@ -349,6 +350,14 @@ def validate_runtime_args(model_spec):
         if args.docker_server or args.local_server:
             raise NotImplementedError(
                 "GPU support for running inference server not implemented yet"
+            )
+
+    # For partitioning Galaxy per tray as T3K
+    # TODO: Add a check to verify whether these devices belong to the same tray
+    if DeviceTypes.from_string(args.device) == DeviceTypes.GALAXY_T3K:
+        if not args.device_id or len(args.device_id) != 8:
+            raise ValueError(
+                "Galaxy T3K requires exactly 8 device IDs specified with --device-id (e.g. '0,1,2,3,4,5,6,7'). These must be devices within the same tray."
             )
 
     assert not (

--- a/run.py
+++ b/run.py
@@ -250,7 +250,7 @@ def validate_local_setup(model_spec, json_fpath):
 
         if return_code != 0:
             raise ValueError(
-                f"⛔ validating local setup failed. See ValueErrors above for required version, and System Info section above for current system versions."
+                "⛔ validating local setup failed. See ValueErrors above for required version, and System Info section above for current system versions."
             )
         else:
             logger.info("✅ validating local setup completed")

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -22,7 +22,7 @@ from run import (
     get_current_commit_sha,
     validate_local_setup,
 )
-from workflows.model_spec import get_runtime_model_spec, MODEL_SPECS
+from workflows.model_spec import get_runtime_model_spec
 from workflows.run_docker_server import run_docker_server
 
 
@@ -606,20 +606,19 @@ class TestUtilityFunctions:
         self,
         mock_get_log_dir,
         mock_ensure_dir,
+        mock_model_spec,
     ):
         """Test local setup validation."""
         mock_log_dir = Path("/tmp/test_logs")
         mock_get_log_dir.return_value = mock_log_dir
 
-        # create sample ModelSpec
-        model_id = "id_tt-transformers_Llama-3.1-8B-Instruct_n150"
-        model_spec = MODEL_SPECS[model_id]
-
-        # write ModelSpec JSON to tempfile
-        with tempfile.TemporaryDirectory() as tempdir:
+        # Create a temporary directory for the model spec JSON
+        with patch.dict(
+            "run.MODEL_SPECS", {mock_model_spec.model_id: mock_model_spec}
+        ), tempfile.TemporaryDirectory() as tempdir:
             # dump the ModelSpec to a tempdir
-            model_spec_path = model_spec.to_json(run_id="temp", output_dir=tempdir)
-            validate_local_setup(model_spec, model_spec_path)
+            model_spec_path = mock_model_spec.to_json(run_id="temp", output_dir=tempdir)
+            validate_local_setup(mock_model_spec, model_spec_path)
 
         mock_get_log_dir.assert_called_once()
         mock_ensure_dir.assert_called_once_with(mock_log_dir)

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -235,7 +235,7 @@ class DeviceModelSpec:
 
     def _infer_env_vars(self):
         inferred_env_vars = {}
-        if self.device in [DeviceTypes.N300, DeviceTypes.T3K]:
+        if self.device in [DeviceTypes.N300, DeviceTypes.T3K, DeviceTypes.GALAXY_T3K]:
             inferred_env_vars["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
 
         inferred_env_vars["MESH_DEVICE"] = self.device.to_mesh_device_str()
@@ -1122,6 +1122,41 @@ spec_templates = [
         env_vars={
             "MAX_PREFILL_CHUNK_SIZE": "32",
         },
+    ),
+    ModelSpecTemplate(
+        weights=[
+            "meta-llama/Llama-3.3-70B-Instruct",
+            "meta-llama/Llama-3.1-70B",
+            "meta-llama/Llama-3.1-70B-Instruct",
+            "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+        ],
+        impl=tt_transformers_impl,
+        system_requirements=SystemRequirements(
+            firmware=VersionRequirement(
+                specifier=">=18.6.0",
+                mode=VersionMode.STRICT,
+            ),
+            kmd=VersionRequirement(
+                specifier=">=2.1.0",
+                mode=VersionMode.STRICT,
+            ),
+        ),
+        tt_metal_commit="v0.62.0-rc33",
+        vllm_commit="e7c329b",
+        device_model_specs=[
+            DeviceModelSpec(
+                device=DeviceTypes.GALAXY_T3K,
+                max_concurrency=32,
+                max_context=128 * 1024,
+                default_impl=True,
+                env_vars={
+                    "MAX_PREFILL_CHUNK_SIZE": "32",
+                    "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
+                },
+            ),
+        ],
+        status=ModelStatusTypes.FUNCTIONAL,
     ),
     ModelSpecTemplate(
         weights=[

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -795,11 +795,13 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 vllm_args={
-                    "mm-processor-kwargs": json.dumps({
-                        "use_fast": True,
-                        "do_convert_rgb": True,
-                        "do_pan_and_scan": True,
-                    }),
+                    "mm-processor-kwargs": json.dumps(
+                        {
+                            "use_fast": True,
+                            "do_convert_rgb": True,
+                            "do_pan_and_scan": True,
+                        }
+                    ),
                 },
                 override_tt_config={
                     "l1_small_size": 768,
@@ -812,11 +814,13 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 vllm_args={
-                    "mm-processor-kwargs": json.dumps({
-                        "use_fast": True,
-                        "do_convert_rgb": True,
-                        "do_pan_and_scan": True,
-                    }),
+                    "mm-processor-kwargs": json.dumps(
+                        {
+                            "use_fast": True,
+                            "do_convert_rgb": True,
+                            "do_pan_and_scan": True,
+                        }
+                    ),
                 },
                 override_tt_config={
                     "l1_small_size": 768,
@@ -842,11 +846,13 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 vllm_args={
-                    "mm-processor-kwargs": json.dumps({
-                        "use_fast": True,
-                        "do_convert_rgb": True,
-                        "do_pan_and_scan": True,
-                    }),
+                    "mm-processor-kwargs": json.dumps(
+                        {
+                            "use_fast": True,
+                            "do_convert_rgb": True,
+                            "do_pan_and_scan": True,
+                        }
+                    ),
                 },
                 override_tt_config={
                     "l1_small_size": 768,
@@ -1434,7 +1440,7 @@ spec_templates = [
                 default_impl=True,
             ),
         ],
-    )
+    ),
 ]
 
 

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -151,6 +151,7 @@ class DeviceTypes(IntEnum):
 
 class SystemTopology(Enum):
     """Enumerates all valid Wormhole system topologies"""
+
     MESH = "Mesh"
     LINEAR_TORUS = "Linear/Torus"
     ISOLATED = "Isolated or not configured"
@@ -230,5 +231,6 @@ class EvalLimitMode(IntEnum):
 
 class VersionMode(IntEnum):
     """Defines the enforcement mode for a version requirement."""
-    STRICT = auto()      # Requirement must be met, raises an error otherwise.
-    SUGGESTED = auto()   # A warning is issued if the requirement is not met.
+
+    STRICT = auto()  # Requirement must be met, raises an error otherwise.
+    SUGGESTED = auto()  # A warning is issued if the requirement is not met.

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -49,6 +49,7 @@ class DeviceTypes(IntEnum):
     N300 = auto()
     T3K = auto()
     GALAXY = auto()
+    GALAXY_T3K = auto()
     GPU = auto()
 
     @classmethod
@@ -70,6 +71,7 @@ class DeviceTypes(IntEnum):
             DeviceTypes.N300: "N300",
             DeviceTypes.T3K: "T3K",
             DeviceTypes.GALAXY: "TG",
+            DeviceTypes.GALAXY_T3K: "T3K",
             DeviceTypes.GPU: "GPU",
         }
         if self not in mapping:
@@ -88,6 +90,7 @@ class DeviceTypes(IntEnum):
             DeviceTypes.N300: "n300",
             DeviceTypes.T3K: "TT-LoudBox",
             DeviceTypes.GALAXY: "Tenstorrent Galaxy",
+            DeviceTypes.GALAXY_T3K: "Tenstorrent Galaxy",
         }
         if self not in mapping:
             raise ValueError(f"Invalid DeviceType: {self}")
@@ -113,6 +116,7 @@ class DeviceTypes(IntEnum):
             DeviceTypes.N150X4,
             DeviceTypes.T3K,
             DeviceTypes.GALAXY,
+            DeviceTypes.GALAXY_T3K,
         }
         return self in wormhole_devices
 
@@ -129,6 +133,9 @@ class DeviceTypes(IntEnum):
             (DeviceTypes.T3K, 1): DeviceTypes.T3K,
             (DeviceTypes.T3K, 4): DeviceTypes.N300,
             (DeviceTypes.T3K, 8): DeviceTypes.N150,
+            (DeviceTypes.GALAXY_T3K, 1): DeviceTypes.T3K,
+            (DeviceTypes.GALAXY_T3K, 4): DeviceTypes.N300,
+            (DeviceTypes.GALAXY_T3K, 8): DeviceTypes.N150,
             (DeviceTypes.N150X4, 1): DeviceTypes.N150X4,
             (DeviceTypes.N300, 1): DeviceTypes.N300,
             (DeviceTypes.N300, 2): DeviceTypes.N150,


### PR DESCRIPTION
Close #624 

This PR introduces a new Galaxy_T3K device type to enable partitioning per tray on Galaxy, addressing feedback from PR #686 .

- ModelSpec: Based on the T3K ModelSpecs with Llama 70B
- SystemRequirements: Aligned with other existing Galaxy ModelSpecs

Added `TT_MESH_GRAPH_DESC_PATH` to specify the mesh graph descriptor path to work it as T3K on Galaxy.