### PR TITLE
Uplift Llama-3.1-8B-Instruct on Galaxy

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1301,8 +1301,8 @@ spec_templates = [
     ModelSpecTemplate(
         weights=["meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-8B-Instruct"],
         impl=tt_transformers_impl,
-        tt_metal_commit="3896b60",
-        vllm_commit="f6c6c29",
+        tt_metal_commit="a9dfadb",
+        vllm_commit="aa4ae1e",
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.GALAXY,


### PR DESCRIPTION
This PR uplifts the tt-metal and vLLM commits used in the Llama-3.1-8B-Instruct TP=8, DP=4 implementation on Galaxy.

Specifically, it was uplifted to include this commit https://github.com/tenstorrent/vllm/commit/aa4ae1edcb673d621bd7dedd7cad71c3f7fd19bf