### PR TITLE
Uplift versions for Qwen3-32B & add Galaxy_T3K DeviceModelSpec

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -908,7 +908,7 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 env_vars={
-                    "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 3,
+                    "TT_MM_THROTTLE_PERF": 2,
                     "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
                 },
             ),


### PR DESCRIPTION
Experimentally verified that `TT_MM_THROTTLE_PERF=2` was the lowest throttle level that resolved hangs on GALAXY_T3K. Going to throttle level 1 still hit hang during prefill at ISL=8k