### PR TITLE
Fix Whisper transcription formatting issues in streaming and non-streaming modes

### DIFF
--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -455,6 +455,13 @@ class TTWhisperRunner(BaseDeviceRunner):
             if request._return_perf_metrics and isinstance(segment_result, tuple):
                 segment_result = segment_result[0]  # Extract text part
 
+            if isinstance(segment_result, list) and len(segment_result) > 0:
+                segment_result = segment_result[0]
+
+            # Remove trailing '<' character if present
+            if isinstance(segment_result, str) and segment_result.endswith('<'):
+                segment_result = segment_result[:-1]
+
             segment = TranscriptionSegment(
                 id=i,
                 speaker=speaker,
@@ -515,6 +522,13 @@ class TTWhisperRunner(BaseDeviceRunner):
 
     def _format_non_streaming_result(self, result, duration):
         """Format non-streaming result"""
+        if isinstance(result, list) and len(result) > 0:
+            result = result[0]
+        
+        # Remove trailing '<' character if present
+        if isinstance(result, str) and result.endswith('<'):
+            result = result[:-1]
+        
         final_result = TranscriptionResponse(
             text=TranscriptUtils.clean_text(result),
             task=WhisperConstants.TASK_TRANSCRIBE.lower(),

--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -458,9 +458,7 @@ class TTWhisperRunner(BaseDeviceRunner):
             if isinstance(segment_result, list) and len(segment_result) > 0:
                 segment_result = segment_result[0]
 
-            # Remove trailing '<' character if present
-            if isinstance(segment_result, str) and segment_result.endswith('<'):
-                segment_result = segment_result[:-1]
+            segment_result = TranscriptUtils.remove_trailing_angle_bracket(segment_result)
 
             segment = TranscriptionSegment(
                 id=i,
@@ -525,9 +523,7 @@ class TTWhisperRunner(BaseDeviceRunner):
         if isinstance(result, list) and len(result) > 0:
             result = result[0]
         
-        # Remove trailing '<' character if present
-        if isinstance(result, str) and result.endswith('<'):
-            result = result[:-1]
+        result = TranscriptUtils.remove_trailing_angle_bracket(result)
         
         final_result = TranscriptionResponse(
             text=TranscriptUtils.clean_text(result),

--- a/tt-media-server/utils/transcript_utils.py
+++ b/tt-media-server/utils/transcript_utils.py
@@ -3,16 +3,26 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 from typing import List
+import re
 
 class TranscriptUtils:
     """Utility functions for transcript processing"""
     
     @staticmethod
     def clean_text(text: str) -> str:
-        """Remove EOS tokens and clean text"""
+        """Clean text by removing EOS tokens and fixing punctuation spacing"""
         if not isinstance(text, str):
             return str(text)
-        return text.replace("<EOS>", "").strip()
+        
+        # Remove any remaining EOS tokens
+        cleaned = text.replace("<EOS>", "")
+        
+        # Remove spaces before punctuation
+        cleaned = re.sub(r'\s+([.,!?;:])', r'\1', cleaned)
+        # Ensure single space after punctuation (but not at end)
+        cleaned = re.sub(r'([.,!?;:])(?=[A-Za-z0-9])', r'\1 ', cleaned)
+        
+        return cleaned.strip()
     
     @staticmethod
     def concatenate_chunks(chunks: List[str]) -> str:
@@ -26,4 +36,4 @@ class TranscriptUtils:
             if clean_text:
                 texts.append(clean_text)
         
-        return " ".join(texts)
+        return TranscriptUtils.clean_text(" ".join(texts))

--- a/tt-media-server/utils/transcript_utils.py
+++ b/tt-media-server/utils/transcript_utils.py
@@ -25,6 +25,13 @@ class TranscriptUtils:
         return cleaned.strip()
     
     @staticmethod
+    def remove_trailing_angle_bracket(text: str) -> str:
+        """Remove trailing '<' character if present"""
+        if isinstance(text, str) and text.endswith('<'):
+            return text[:-1]
+        return text
+    
+    @staticmethod
     def concatenate_chunks(chunks: List[str]) -> str:
         """Concatenate text chunks into final transcript"""
         texts = []


### PR DESCRIPTION
This PR fixes two issues:
1. Trailing `<` in non-streaming responses
2. Spaces before punctuation in streaming responses

Non-streaming before:
```
{
  "text": "[\" Lesson 1C. Exercise 2. 1. The next train leaves in half an hour. 2. That's made me feel a lot better. 3. This is going to be rather painful. 4. We were too poor to even go on holiday.<\"]",
  "task": "transcribe",
  "language": "english",
  "duration": 30.380375
}
```

Non-streaming after:
```
{
  "text": "Lesson 1C. Exercise 2. 1. The next train leaves in half an hour. 2. That's made me feel a lot better. 3. This is going to be rather painful. 4. We were too poor to even go on holiday.",
  "task": "transcribe",
  "language": "english",
  "duration": 30.380375
}
```

Streaming before:
```
...
{"text": ".", "chunk_id": 55}
{
  "text": "Less on 1 C . Exercise 2 . 1 . The next train leaves in half an hour . 2 . That 's made me feel a lot better . 3 . This is going to be rather painful . 4 . We were too poor to even go on holiday .",
  "task": "transcribe",
  "language": "english",
  "duration": 30.380375
}
```

Streaming after:
```
...
{"text": ".", "chunk_id": 55}
{
  "text": "Less on 1 C. Exercise 2. 1. The next train leaves in half an hour. 2. That 's made me feel a lot better. 3. This is going to be rather painful. 4. We were too poor to even go on holiday.",
  "task": "transcribe",
  "language": "english",
  "duration": 30.380375
}
```