### PR TITLE
Fix chunk ID reset between speakers in streaming audio transcription

### DIFF
--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -342,6 +342,7 @@ class TTWhisperRunner(BaseDeviceRunner):
         segments = []
         full_text_parts = []
         speakers_set = set()
+        chunk_count = 0
         
         for i, segment in enumerate(request._audio_segments):
             start_time = segment["start"]
@@ -363,7 +364,6 @@ class TTWhisperRunner(BaseDeviceRunner):
             segment_prefix = f"[{speaker}] "
             first_token = True
             segment_text_parts = []
-            chunk_count = 0
             
             async for partial_result in async_generator:
                 if partial_result == "<EOS>":


### PR DESCRIPTION
Before:
```
curl -X 'POST'   'http://127.0.0.1:8014/audio/transcriptions'   -H 'accept: application/json'   -H 'Authorization: Bearer your-secret-key'   -H 'Content-Type: application/json'   --data-binary @data.json   --no-buffer
{"text": "[SPEAKER_01]", "chunk_id": 1}
{"text": "Less", "chunk_id": 4}
{"text": "on", "chunk_id": 5}
{"text": "1", "chunk_id": 6}
{"text": "C", "chunk_id": 7}
{"text": ".", "chunk_id": 8}
{"text": "Exercise", "chunk_id": 9}
{"text": "2", "chunk_id": 10}
{"text": ".", "chunk_id": 11}
{"text": "1", "chunk_id": 12}
{"text": ".", "chunk_id": 13}
{"text": "The", "chunk_id": 14}
{"text": "next", "chunk_id": 15}
{"text": "train", "chunk_id": 16}
{"text": "leaves", "chunk_id": 17}
{"text": "in", "chunk_id": 18}
{"text": "half", "chunk_id": 19}
{"text": "an", "chunk_id": 20}
{"text": "hour", "chunk_id": 21}
{"text": ".", "chunk_id": 22}
{"text": "2", "chunk_id": 23}
{"text": ".", "chunk_id": 24}
{"text": "2", "chunk_id": 25}
{"text": ".", "chunk_id": 26}
{"text": "[SPEAKER_00]", "chunk_id": 1}
{"text": "That", "chunk_id": 4}
{"text": "'s", "chunk_id": 5}
{"text": "made", "chunk_id": 6}
{"text": "me", "chunk_id": 7}
{"text": "feel", "chunk_id": 8}
{"text": "a", "chunk_id": 9}
{"text": "lot", "chunk_id": 10}
{"text": "better", "chunk_id": 11}
{"text": ".", "chunk_id": 12}
{"text": "[SPEAKER_02]", "chunk_id": 1}
{"text": "3", "chunk_id": 4}
{"text": ".", "chunk_id": 5}
{"text": "This", "chunk_id": 6}
{"text": "is", "chunk_id": 7}
{"text": "going", "chunk_id": 8}
{"text": "to", "chunk_id": 9}
{"text": "be", "chunk_id": 10}
{"text": "rather", "chunk_id": 11}
{"text": "painful", "chunk_id": 12}
{"text": ".", "chunk_id": 13}
{"text": "4", "chunk_id": 16}
{"text": ".", "chunk_id": 17}
{"text": "[SPEAKER_03]", "chunk_id": 1}
{"text": "We", "chunk_id": 4}
{"text": "were", "chunk_id": 5}
{"text": "too", "chunk_id": 6}
{"text": "poor", "chunk_id": 7}
{"text": "to", "chunk_id": 8}
{"text": "even", "chunk_id": 9}
{"text": "go", "chunk_id": 10}
{"text": "on", "chunk_id": 11}
{"text": "holiday", "chunk_id": 12}
{"text": ".", "chunk_id": 13}
{"text": "Less on 1 C. Exercise 2. 1. The next train leaves in half an hour. 2. 2. That 's made me feel a lot better. 3. This is going to be rather painful. 4. We were too poor to even go on holiday.", "task": "transcribe", "language": "english", "duration": 30.380375, "segments": [{"id": 0, "speaker": "SPEAKER_01", "start_time": 0.03096875, "end_time": 11.438468750000002, "text": "Less on 1 C. Exercise 2. 1. The next train leaves in half an hour. 2. 2."}, {"id": 1, "speaker": "SPEAKER_00", "start_time": 12.484718750000003, "end_time": 15.032843750000001, "text": "That 's made me feel a lot better."}, {"id": 2, "speaker": "SPEAKER_02", "start_time": 17.17596875, "end_time": 23.672843750000002, "text": "3. This is going to be rather painful. 4."}, {"id": 3, "speaker": "SPEAKER_03", "start_time": 24.668468750000002, "end_time": 27.60471875, "text": "We were too poor to even go on holiday."}], "speaker_count": 4, "speakers": ["SPEAKER_00", "SPEAKER_03", "SPEAKER_01", "SPEAKER_02"]}
```

After:
```
curl -X 'POST' 'http://127.0.0.1:8014/audio/transcriptions' -H 'accept: application/json' -H 'Authorization: Bearer your-secret-key' -H 'Content-Type: application/json' --data-binary @data.json --no-buffer
{"text": "[SPEAKER_01]", "chunk_id": 1}
{"text": "Less", "chunk_id": 4}
{"text": "on", "chunk_id": 5}
{"text": "1", "chunk_id": 6}
{"text": "C", "chunk_id": 7}
{"text": ".", "chunk_id": 8}
{"text": "Exercise", "chunk_id": 9}
{"text": "2", "chunk_id": 10}
{"text": ".", "chunk_id": 11}
{"text": "1", "chunk_id": 12}
{"text": ".", "chunk_id": 13}
{"text": "The", "chunk_id": 14}
{"text": "next", "chunk_id": 15}
{"text": "train", "chunk_id": 16}
{"text": "leaves", "chunk_id": 17}
{"text": "in", "chunk_id": 18}
{"text": "half", "chunk_id": 19}
{"text": "an", "chunk_id": 20}
{"text": "hour", "chunk_id": 21}
{"text": ".", "chunk_id": 22}
{"text": "2", "chunk_id": 23}
{"text": ".", "chunk_id": 24}
{"text": "2", "chunk_id": 25}
{"text": ".", "chunk_id": 26}
{"text": "[SPEAKER_00]", "chunk_id": 28}
{"text": "That", "chunk_id": 31}
{"text": "'s", "chunk_id": 32}
{"text": "made", "chunk_id": 33}
{"text": "me", "chunk_id": 34}
{"text": "feel", "chunk_id": 35}
{"text": "a", "chunk_id": 36}
{"text": "lot", "chunk_id": 37}
{"text": "better", "chunk_id": 38}
{"text": ".", "chunk_id": 39}
{"text": "[SPEAKER_02]", "chunk_id": 41}
{"text": "3", "chunk_id": 44}
{"text": ".", "chunk_id": 45}
{"text": "This", "chunk_id": 46}
{"text": "is", "chunk_id": 47}
{"text": "going", "chunk_id": 48}
{"text": "to", "chunk_id": 49}
{"text": "be", "chunk_id": 50}
{"text": "rather", "chunk_id": 51}
{"text": "painful", "chunk_id": 52}
{"text": ".", "chunk_id": 53}
{"text": "4", "chunk_id": 56}
{"text": ".", "chunk_id": 57}
{"text": "[SPEAKER_03]", "chunk_id": 60}
{"text": "We", "chunk_id": 63}
{"text": "were", "chunk_id": 64}
{"text": "too", "chunk_id": 65}
{"text": "poor", "chunk_id": 66}
{"text": "to", "chunk_id": 67}
{"text": "even", "chunk_id": 68}
{"text": "go", "chunk_id": 69}
{"text": "on", "chunk_id": 70}
{"text": "holiday", "chunk_id": 71}
{"text": ".", "chunk_id": 72}
{"text": "Less on 1 C. Exercise 2. 1. The next train leaves in half an hour. 2. 2. That 's made me feel a lot better. 3. This is going to be rather painful. 4. We were too poor to even go on holiday.", "task": "transcribe", "language": "english", "duration": 30.380375, "segments": [{"id": 0, "speaker": "SPEAKER_01", "start_time": 0.03096875, "end_time": 11.438468750000002, "text": "Less on 1 C. Exercise 2. 1. The next train leaves in half an hour. 2. 2."}, {"id": 1, "speaker": "SPEAKER_00", "start_time": 12.484718750000003, "end_time": 15.032843750000001, "text": "That 's made me feel a lot better."}, {"id": 2, "speaker": "SPEAKER_02", "start_time": 17.17596875, "end_time": 23.672843750000002, "text": "3. This is going to be rather painful. 4."}, {"id": 3, "speaker": "SPEAKER_03", "start_time": 24.668468750000002, "end_time": 27.60471875, "text": "We were too poor to even go on holiday."}], "speaker_count": 4, "speakers": ["SPEAKER_01", "SPEAKER_02", "SPEAKER_00", "SPEAKER_03"]}
```