### PR TITLE
tstesco/uplift-llama-70b-galaxy

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1057,8 +1057,8 @@ spec_templates = [
             "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
         ],
         impl=llama3_70b_galaxy_impl,
-        tt_metal_commit="7f115e4",
-        vllm_commit="d71184c",
+        tt_metal_commit="268dd67",
+        vllm_commit="91dddb0",
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.GALAXY,


### PR DESCRIPTION
# change log 

* using vLLM commits addressing crashes with https://github.com/tenstorrent/vllm/pull/201
* using tt-metal commit addressing output quality issue https://github.com/tenstorrent/tt-metal/pull/30157 and DRAM OOM https://github.com/tenstorrent/tt-metal/pull/30236

Release report below:

---

## Tenstorrent Model Release Summary: Llama-3.3-70B-Instruct on galaxy

### Metadata: Llama-3.3-70B-Instruct on galaxy
```json
{
    "report_id": "id_llama3-70b-galaxy_Llama-3.3-70B-Instruct_galaxy_2025-10-09_19-10-20",
    "model_name": "Llama-3.3-70B-Instruct",
    "model_id": "id_llama3-70b-galaxy_Llama-3.3-70B-Instruct_galaxy",
    "model_spec_json": "/home/tstesco/software/tt-inference-server/workflow_logs/run_specs/tt_model_spec_2025-10-09_18-53-10_id_llama3-70b-galaxy_Llama-3.3-70B-Instruct_galaxy_benchmarks_9wN1WJH-.json",
    "model_repo": "meta-llama/Llama-3.3-70B-Instruct",
    "model_impl": "llama3-70b-galaxy",
    "device": "galaxy",
    "server_mode": "API",
    "tt_metal_commit": "268dd67",
    "vllm_commit": "91dddb0",
    "run_command": "python run.py --model Llama-3.3-70B-Instruct --device galaxy --workflow release "
}
```

### Performance Benchmark Sweeps for Llama-3.3-70B-Instruct on galaxy

#### Text-to-Text Performance Benchmark Sweeps for Llama-3.3-70B-Instruct on galaxy
```
|  ISL  | OSL  | Concurrency | N Req | TTFT (ms) | TPOT (ms) | Tput User (TPS) | Tput Decode (TPS) | Tput Prefill (TPS) | E2EL (ms) | Req Tput (RPS) |
|-------|------|-------------|-------|-----------|-----------|-----------------|-------------------|--------------------|-----------|----------------|
|   128 |  128 |           1 |     8 |      76.4 |      15.8 |           63.38 |              63.4 |             1675.3 |    2080.1 |          0.481 |
|  2048 |  128 |           1 |     8 |     356.3 |      18.3 |           54.78 |              54.8 |             5748.0 |    2674.5 |          0.374 |
|   128 | 1024 |           1 |     4 |      78.2 |      16.5 |           60.77 |              60.8 |             1637.4 |   16911.9 |          0.059 |
|  1024 |  128 |           1 |     4 |     192.5 |      17.6 |           56.8  |              56.8 |             5318.7 |    2428.5 |          0.412 |
|  3072 |  128 |           1 |     4 |     677.8 |      18.9 |           52.85 |              52.8 |             4532.4 |    3081.0 |          0.325 |
|  4096 |  128 |           1 |     2 |     679.3 |      19.8 |           50.39 |              50.4 |             6029.4 |    3199.8 |          0.312 |
|  8192 |  128 |           1 |     2 |    1323.5 |      21.7 |           46.06 |              46.1 |             6189.6 |    4081.0 |          0.245 |
| 16384 |  128 |           1 |     2 |    2561.0 |      26.8 |           37.36 |              37.4 |             6397.6 |    5960.4 |          0.168 |
| 32000 |  128 |           1 |     2 |    5584.4 |      35.8 |           27.91 |              27.9 |             5730.2 |   10135.0 |          0.099 |
|   128 |  128 |          32 |   256 |    1512.6 |      16.5 |           60.67 |            1941.5 |             2708.0 |    3605.8 |          8.863 |
|   128 | 1024 |          32 |   128 |     703.7 |      18.5 |           54.03 |            1728.9 |             5821.1 |   19637.9 |          1.629 |
|  2048 |  128 |          32 |   128 |   12499.4 |      22.4 |           44.61 |            1427.5 |             5243.1 |   15346.3 |          2.084 |
|  2048 | 2048 |          32 |    64 |    9240.4 |      23.4 |           42.71 |            1366.7 |             7092.3 |   57169.8 |          0.56  |
|  3000 |   64 |          32 |   128 |   20951.6 |      23.4 |           42.7  |            1366.5 |             4582.0 |   22426.9 |          1.426 |
|  4000 |   64 |          32 |   128 |   20975.8 |      24.6 |           40.7  |            1302.5 |             6102.3 |   22523.5 |          1.42  |
|  8000 |   64 |          16 |    32 |   20432.8 |      30.2 |           33.13 |             530.0 |             6264.4 |   22334.6 |          0.716 |
| 16000 |   64 |           8 |    16 |   20133.3 |      42.2 |           23.71 |             189.7 |             6357.6 |   22790.4 |          0.351 |
| 32000 |   64 |           4 |     8 |   22094.7 |      40.6 |           24.6  |              98.4 |             5793.2 |   24655.1 |          0.162 |
```
Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> N Req: total number of requests (sample size, N)
> TTFT: Time To First Token (ms)
> TPOT: Time Per Output Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)
> Tput Prefill: Throughput for prefill tokens (TPS)
> E2EL: End-to-End Latency (ms)
> Req Tput: Request Throughput (RPS)

### Performance Benchmark Targets Llama-3.3-70B-Instruct on galaxy

#### Text-to-Text Performance Benchmark Targets Llama-3.3-70B-Instruct on galaxy
```
| ISL  | OSL | Concurrency | TTFT (ms) | Tput User (TPS) | Tput Decode (TPS) | Functional TTFT Check | Functional Tput User Check | Complete TTFT Check | Complete Tput User Check | Target TTFT Check | Target Tput User Check | Functional TTFT (ms) | Functional Tput User (TPS) | Complete TTFT (ms) | Complete Tput User (TPS) | Target TTFT (ms) | Target Tput User (TPS) |
|------|-----|-------------|-----------|-----------------|-------------------|-----------------------|----------------------------|---------------------|--------------------------|-------------------|------------------------|----------------------|----------------------------|--------------------|--------------------------|------------------|------------------------|
|  128 | 128 |           1 |      76.4 |           63.38 |              63.4 | PASS ✅               | PASS ✅                    | PASS ✅             | PASS ✅                  | FAIL ⛔           | FAIL ⛔                |               500.00 |                       8.00 |             100.00 |                    40.00 |            50.00 |                  80.00 |
| 2048 | 128 |           1 |     356.3 |           54.78 |              54.8 | PASS ✅               | PASS ✅                    | PASS ✅             | PASS ✅                  | PASS ✅           | FAIL ⛔                |              8000.00 |                       8.00 |            1600.00 |                    40.00 |           800.00 |                  80.00 |
```
Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> TTFT: Time To First Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)

### Accuracy Evaluations for Llama-3.3-70B-Instruct on galaxy
```
| model                  | device | task_name     | accuracy_check | score | ratio_to_reference | gpu_reference_score                                                                                                     | ratio_to_published | published_score                                                                            |
|------------------------|--------|---------------|----------------|-------|--------------------|-------------------------------------------------------------------------------------------------------------------------|--------------------|--------------------------------------------------------------------------------------------|
| Llama-3.3-70B-Instruct | galaxy | meta_ifeval   | PASS ✅         | 90.83 | 0.99               | [91.35](https://docs.google.com/spreadsheets/d/1kFIUj9Bp5WJ0lW3QPwQRRWDyLRieedKrFZqfxWBfeNw/edit?gid=0#gid=0&range=J86) | 0.99               | [92.10](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct#instruction-tuned-models) |
| Llama-3.3-70B-Instruct | galaxy | meta_gpqa_cot | PASS ✅         | 61.83 | 1.03               | [60.04](https://docs.google.com/spreadsheets/d/1kFIUj9Bp5WJ0lW3QPwQRRWDyLRieedKrFZqfxWBfeNw/edit?gid=0#gid=0&range=J87) | 1.22               | [50.50](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct#instruction-tuned-models) |
```
Note: The ratio to published scores defines if eval ran roughly correctly, as the exact methodology of the model publisher cannot always be reproduced. For this reason the accuracy check is based first on being equivalent to the GPU reference within a +/- tolerance. If a value GPU reference is not available, the accuracy check is based on the direct ratio to the published score.
