### PR TITLE
tstesco/override-remove-key-with-null

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -609,24 +609,49 @@ class ModelSpec:
         object.__setattr__(self, "cli_args", cli_args)
 
         if args.override_tt_config:
+            # Parse the override config from CLI
+            override_config_from_cli = json.loads(args.override_tt_config)
+
+            # Start with existing override_tt_config
+            merged_override_config = dict(self.device_model_spec.override_tt_config)
+
+            # Apply overrides from CLI, removing keys with null values
+            for key, value in override_config_from_cli.items():
+                if value is None:
+                    # Remove the key if it exists
+                    merged_override_config.pop(key, None)
+                else:
+                    # Add or update the key
+                    merged_override_config[key] = value
+
+            # Set the merged config
             object.__setattr__(
                 self.device_model_spec,
                 "override_tt_config",
-                json.loads(args.override_tt_config),
+                merged_override_config,
             )
             # Update vllm_args to include the new override_tt_config
             merged_vllm_args = {
                 **self.device_model_spec.vllm_args,
-                "override_tt_config": args.override_tt_config,
+                "override_tt_config": json.dumps(merged_override_config),
             }
             object.__setattr__(self.device_model_spec, "vllm_args", merged_vllm_args)
         if args.vllm_override_args:
-            # Get existing vllm_override_args and merge with new values
-            vllm_override_args = json.loads(args.vllm_override_args)
-            merged_vllm_args = {
-                **self.device_model_spec.vllm_args,
-                **vllm_override_args,
-            }
+            # Parse the vllm override args from CLI
+            vllm_override_args_from_cli = json.loads(args.vllm_override_args)
+
+            # Start with existing vllm_args
+            merged_vllm_args = dict(self.device_model_spec.vllm_args)
+
+            # Apply overrides from CLI, removing keys with null values
+            for key, value in vllm_override_args_from_cli.items():
+                if value is None:
+                    # Remove the key if it exists
+                    merged_vllm_args.pop(key, None)
+                else:
+                    # Add or update the key
+                    merged_vllm_args[key] = value
+
             object.__setattr__(self.device_model_spec, "vllm_args", merged_vllm_args)
 
         if args.service_port:


### PR DESCRIPTION
# change log

* when using --vllm-override-args or --override-tt-config, setting a JSON key value to null will remove it if the key is already set

for example
```
python3 run.py --model Llama-3.3-70B-Instruct --device galaxy --workflow server --docker-server --dev-mode \
--vllm-override-args '{"enable-auto-tool-choice": true, "tool-call-parser": "llama3_json"}' \
--override-tt-config '{"sample_on_device_mode": null}'
```

will remove sample_on_device_mode from the key because sending the `null` value breaks vLLM's input validation:
```
Traceback (most recent call last):
  File "/home/container_app_user/app/src/run_vllm_api_server.py", line 322, in <module>
    main()
  File "/home/container_app_user/app/src/run_vllm_api_server.py", line 318, in main
    runpy.run_module("vllm.entrypoints.openai.api_server", run_name="__main__")
  File "/usr/lib/python3.10/runpy.py", line 227, in run_module
    return _run_code(code, {}, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/container_app_user/vllm/vllm/entrypoints/openai/api_server.py", line 1857, in <module>
    uvloop.run(run_server(args))
  File "/home/container_app_user/tt-metal/python_env/lib/python3.10/site-packages/uvloop/__init__.py", line 82, in run
    return loop.run_until_complete(wrapper())
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/home/container_app_user/tt-metal/python_env/lib/python3.10/site-packages/uvloop/__init__.py", line 61, in wrapper
    return await main
  File "/home/container_app_user/vllm/vllm/entrypoints/openai/api_server.py", line 1792, in run_server
    await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
  File "/home/container_app_user/vllm/vllm/entrypoints/openai/api_server.py", line 1812, in run_server_worker
    async with build_async_engine_client(args, client_config) as engine_client:
  File "/usr/lib/python3.10/contextlib.py", line 199, in __aenter__
    return await anext(self.gen)
  File "/home/container_app_user/vllm/vllm/entrypoints/openai/api_server.py", line 158, in build_async_engine_client
    async with build_async_engine_client_from_engine_args(
  File "/usr/lib/python3.10/contextlib.py", line 199, in __aenter__
    return await anext(self.gen)
  File "/home/container_app_user/vllm/vllm/entrypoints/openai/api_server.py", line 180, in build_async_engine_client_from_engine_args
    vllm_config = engine_args.create_engine_config(usage_context=usage_context)
  File "/home/container_app_user/vllm/vllm/engine/arg_utils.py", line 1263, in create_engine_config
    config = VllmConfig(
  File "/home/container_app_user/tt-metal/python_env/lib/python3.10/site-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
pydantic_core._pydantic_core.ValidationError: 1 validation error for VllmConfig
  Assertion failed, Invalid sample_on_device_mode: None [type=assertion_error, input_value=ArgsKwargs((), {'model_co...additional_config': {}}), input_type=ArgsKwargs]
    For further information visit https://errors.pydantic.dev/2.12/v/assertion_error
```