### PR TITLE
Added documentation and script for running tt-triage on containers

### DIFF
--- a/docs/running_tt_triage.md
+++ b/docs/running_tt_triage.md
@@ -1,0 +1,180 @@
+# Running TT-Triage on TT-Inference-Server Docker Images
+
+## Motivation
+
+`tt-triage` is a debugging tool from the `tt-metal` repository designed to diagnose system hangs on Tenstorrent hardware. When a workload hangs or becomes unresponsive, `tt-triage` captures and analyzes the callstacks from each core on the device, providing crucial information to identify where and why the hang occurred.
+
+This is particularly useful when:
+- A Docker container running inference becomes unresponsive
+- Model execution hangs during serving
+- You need to debug performance issues or deadlocks
+- The system appears stuck but hasn't crashed
+
+The `run_tt_triage.py` script automates the process of running `tt-triage` inside a running Docker container, making it easy to debug hangs without manually entering the container or setting up the debugging environment.
+
+## Prerequisites
+
+- A running Docker container with tt-inference-server
+- The container must be accessible via its service port
+- Python 3.8+ on the host machine
+- Docker installed and accessible from the host
+
+## Usage Workflow
+
+### Step 1: Start the Docker Server
+
+First, start your inference server using the standard workflow:
+
+```bash
+# Example: Start server for Llama-3.1-8B on N300
+python run.py --model Llama-3.1-8B-Instruct --device n300 --workflow server --docker-server
+```
+
+The server will start and bind to a service port (default: 8000).
+
+### Step 2: Run Your Workload
+
+Start sending requests to your inference server to trigger the workload:
+
+```bash
+# Example: Run benchmarks or evals
+python run.py --model Llama-3.1-8B-Instruct --device n300 --workflow benchmarks --docker-server
+```
+
+### Step 3: Wait for Hang to Occur
+
+Monitor your workload. If it hangs or becomes unresponsive:
+- The container is still running but not making progress
+- Requests timeout or receive no response
+- System appears stuck without error messages
+
+**Do not stop the container!** The triage tool needs to analyze the live running state.
+
+### Step 4: Run TT-Triage
+
+While the container is still running in the hung state, execute the triage script from the host:
+
+```bash
+python scripts/run_tt_triage.py \
+    --service-port 8000 \
+    --model Llama-3.1-8B-Instruct \
+    --device n300
+```
+
+## Command Line Arguments
+
+### Required Arguments
+
+| Argument | Type | Description | Example |
+|----------|------|-------------|---------|
+| `--service-port` | int | Service port number used to identify the Docker container | `8000` |
+| `--model` | str | Model name exactly as specified when starting the server | `Llama-3.1-8B-Instruct` |
+| `--device` | str | Device type (must match what was used to start the server) | `n300`, `n150`, `t3000` |
+
+### Optional Arguments
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `--impl` | str | `tt-transformers` | Implementation name (only change if using non-default impl) |
+
+## Examples
+
+### Basic Usage (Default Implementation)
+
+```bash
+# For Llama-3.1-8B on N300
+python scripts/run_tt_triage.py \
+    --service-port 8000 \
+    --model Llama-3.1-8B-Instruct \
+    --device n300
+
+# For Qwen2.5-VL-3B on N300
+python scripts/run_tt_triage.py \
+    --service-port 8000 \
+    --model Qwen2.5-VL-3B-Instruct \
+    --device n300
+
+# For Mistral-7B on N150
+python scripts/run_tt_triage.py \
+    --service-port 8000 \
+    --model Mistral-7B-Instruct-v0.3 \
+    --device n150
+```
+
+### Multiple Containers
+
+If running multiple containers on different ports:
+
+```bash
+# Container 1 on port 8000
+python scripts/run_tt_triage.py \
+    --service-port 8000 \
+    --model Llama-3.1-8B-Instruct \
+    --device n300
+
+# Container 2 on port 8001
+python scripts/run_tt_triage.py \
+    --service-port 8001 \
+    --model Mistral-7B-Instruct-v0.3 \
+    --device n300
+```
+
+## Output
+
+### Output Location
+
+The triage report is automatically saved to:
+
+```
+workflow_logs/triage_output/triage_{model_spec_id}_{timestamp}.txt
+```
+
+Where:
+- `{model_spec_id}` is generated from the impl, model, and device (e.g., `id_tt-transformers_Llama-3.1-8B-Instruct_n300`)
+- `{timestamp}` is in format `YYYYMMDD_HHMMSS` (e.g., `20251014_143022`)
+
+**Example output path:**
+```
+workflow_logs/triage_output/triage_id_tt-transformers_Llama-3.1-8B-Instruct_n300_20251014_143022.txt
+```
+
+### Output Contents
+
+The triage report contains:
+
+1. **Header Information**
+   - Container ID
+   - Execution timestamp
+   - Model and device information
+
+2. **Debugging Sequence Output**
+   - Environment setup confirmation
+   - Debugger tools installation logs
+   - Python dependency installation status
+   - **Core callstacks from triage.py** - This is the critical information showing what each core was doing when the hang occurred
+
+3. **Return Codes**
+   - Success/failure status of each step
+
+
+## What the Script Does
+
+The script performs the following sequence of operations inside the Docker container:
+
+1. **Locates the container** by matching the service port
+2. **Navigates** to the tt-metal debugging scripts directory
+3. **Activates** the tt-metal Python environment
+4. **Unsets** `LD_LIBRARY_PATH` to avoid library conflicts
+5. **Installs** debugger tools using `install_debugger.sh`
+6. **Installs** Python dependencies required for triage
+7. **Runs** `triage.py` to capture core callstacks
+8. **Saves** all output to the host filesystem
+
+All commands are chained together in a single shell session to ensure environment variables and directory changes persist.
+
+## Additional Resources
+
+- [tt-triage tool documentation](https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/tools/triage.html)
+- [Workflows User Guide](./workflows_user_guide.md)
+- [Development Guide](./development.md)
+

--- a/scripts/run_tt_triage.py
+++ b/scripts/run_tt_triage.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+import argparse
+import subprocess
+import logging
+import sys
+from pathlib import Path
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+project_root = Path(__file__).resolve().parent.parent
+if project_root not in sys.path:
+    sys.path.insert(0, str(project_root))
+from workflows.log_setup import setup_workflow_script_logger
+from workflows.model_spec import get_model_id
+from workflows.utils import get_default_workflow_root_log_dir, ensure_readwriteable_dir
+
+
+def find_container_by_port(service_port):
+    """
+    Find Docker container ID by service port mapping.
+    
+    Args:
+        service_port: Port number the container is listening on
+        
+    Returns:
+        Container ID if found, None otherwise
+    """
+    logger.info(f"Searching for Docker container with port {service_port}")
+    
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "--format", "{{.ID}}\t{{.Ports}}"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        
+        for line in result.stdout.strip().split("\n"):
+            if not line:
+                continue
+            container_id, ports = line.split("\t", 1)
+            if f":{service_port}->" in ports or f"->{service_port}/" in ports:
+                logger.info(f"Found container {container_id} with port {service_port}")
+                return container_id
+                
+        logger.error(f"No container found with port {service_port}")
+        return None
+        
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to list Docker containers: {e}")
+        return None
+
+
+def run_command_in_container(container_id, command):
+    """
+    Execute a command in the Docker container.
+    
+    Args:
+        container_id: Docker container ID
+        command: Command to execute
+        
+    Returns:
+        Tuple of (return_code, stdout, stderr)
+    """
+    logger.info(f"Executing command in container {container_id}: {command}")
+    
+    try:
+        result = subprocess.run(
+            ["docker", "exec", container_id, "bash", "-c", command],
+            capture_output=True,
+            text=True
+        )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to execute command: {e}")
+        return e.returncode, e.stdout if hasattr(e, "stdout") else "", e.stderr if hasattr(e, "stderr") else ""
+
+
+def run_debugger_in_container(container_id, output_file):
+    """
+    Run the debugging sequence in the Docker container.
+    
+    Args:
+        container_id: Docker container ID
+        output_file: Path to save triage output
+        
+    Returns:
+        True if successful, False otherwise
+    """
+    logger.info("Building chained command sequence")
+    
+    # Chain all commands together with && to run in a single shell session
+    # This ensures environment changes and directory changes persist
+    chained_command = """
+cd /home/container_app_user/tt-metal/scripts/debugging_scripts && \
+source /home/container_app_user/tt-metal/python_env/bin/activate && \
+unset LD_LIBRARY_PATH && \
+echo "=== Environment configured ===" && \
+/home/container_app_user/tt-metal/scripts/install_debugger.sh && \
+echo "=== Debugger tools installed ===" && \
+pip install -r /home/container_app_user/tt-metal/scripts/debugging_scripts/requirements.txt && \
+echo "=== Python dependencies installed ===" && \
+python triage.py
+"""
+    
+    combined_output = []
+    combined_output.append(f"{'='*80}")
+    combined_output.append(f"TT-Metal Debugger Triage Report")
+    combined_output.append(f"Container ID: {container_id}")
+    combined_output.append(f"Timestamp: {datetime.now().isoformat()}")
+    combined_output.append(f"{'='*80}\n")
+    
+    logger.info("Executing chained command in container")
+    combined_output.append(f"\n{'='*80}")
+    combined_output.append(f"Executing debugging sequence")
+    combined_output.append(f"{'='*80}\n")
+    
+    return_code, stdout, stderr = run_command_in_container(container_id, chained_command)
+    
+    if stdout:
+        combined_output.append("STDOUT:")
+        combined_output.append(stdout)
+        
+    if stderr:
+        combined_output.append("\nSTDERR:")
+        combined_output.append(stderr)
+        
+    combined_output.append(f"\nReturn code: {return_code}\n")
+    
+    if return_code != 0:
+        logger.warning(f"Command sequence returned non-zero exit code: {return_code}")
+    
+    output_content = "\n".join(combined_output)
+    
+    try:
+        with open(output_file, "w") as f:
+            f.write(output_content)
+        logger.info(f"✅ Debugger output saved to: {output_file}")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to write output file: {e}")
+        return False
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run TT-Metal debugger triage in a Docker container identified by service port"
+    )
+    parser.add_argument(
+        "--service-port",
+        type=int,
+        required=True,
+        help="Service port number to identify the Docker container"
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        required=True,
+        help="Model name (e.g., Llama-3.1-8B-Instruct)"
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        required=True,
+        help="Device type (e.g., n300, n150)"
+    )
+    parser.add_argument(
+        "--impl",
+        type=str,
+        default="tt-transformers",
+        help="Implementation name (default: tt-transformers)"
+    )
+    return parser.parse_args()
+
+
+def main():
+    setup_workflow_script_logger(logger)
+    logger.info(f"Running {__file__} ...")
+    
+    args = parse_args()
+    
+    # Generate model spec ID from model, device, and impl
+    model_spec_id = get_model_id(args.impl, args.model, args.device)
+    logger.info(f"Model spec ID: {model_spec_id}")
+    
+    # Create triage output directory
+    workflow_root_log_dir = get_default_workflow_root_log_dir()
+    triage_output_dir = workflow_root_log_dir / "triage_output"
+    ensure_readwriteable_dir(triage_output_dir)
+    logger.info(f"Triage output directory: {triage_output_dir}")
+    
+    # Generate output filename with model spec ID and timestamp
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_filename = f"triage_{model_spec_id}_{timestamp}.txt"
+    output_file = triage_output_dir / output_filename
+    logger.info(f"Output file: {output_file}")
+    
+    container_id = find_container_by_port(args.service_port)
+    if container_id is None:
+        logger.error(f"⛔ Could not find container with service port {args.service_port}")
+        return 1
+    
+    success = run_debugger_in_container(container_id, output_file)
+    
+    if success:
+        logger.info("✅ Debugger triage completed successfully")
+        return 0
+    else:
+        logger.error("⛔ Debugger triage failed")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+


### PR DESCRIPTION
## Related issue
#829 
## Motivation
`tt-triage` is a tool used to debug model hangs and gather diagnostic information of devices in their hung state. However, running it inside containers currently requires manual setup of dependencies and manual handling of logs and outputs. 

This PR aims to simplify that process by providing a script that automates environment setup and execution, making tt-triage easier to use within containerized environments.

## Changelog
- Added a helper script to run tt-triage inside containers.
   - Automatically installs required dependencies.
   - Handles log and output redirection to the `workflow_logs/tt_triage` folder.
- Added documentation detailing how to use the tt-triage script for inference-server–specific workloads.