### PR TITLE
tstesco/uplift-llama-70b-t3k

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1163,7 +1163,7 @@ spec_templates = [
                 mode=VersionMode.STRICT,
             ),
         ),
-        tt_metal_commit="3335b44",
+        tt_metal_commit="a409240",
         vllm_commit="1d799da",
         device_model_specs=[
             DeviceModelSpec(


### PR DESCRIPTION
# change log

* Uplift Llama 3 70B tt-metal and vllm commits post fix to https://github.com/tenstorrent/tt-metal/issues/26796

https://github.com/tenstorrent/tt-metal/commit/a409240

Note: this works for all weights using the same architecture including DeepSeek-R1-Distill-Llama-70B (see https://github.com/tenstorrent/vllm/issues/132)

Release reports:
- [report_id_tt-transformers_Llama-3.3-70B-Instruct_t3k_2025-10-14_15-57-16.md](https://github.com/user-attachments/files/22913544/report_id_tt-transformers_Llama-3.3-70B-Instruct_t3k_2025-10-14_15-57-16.md)
- [report_id_tt-transformers_DeepSeek-R1-Distill-Llama-70B_t3k_2025-10-14_20-06-38.md](https://github.com/user-attachments/files/22913543/report_id_tt-transformers_DeepSeek-R1-Distill-Llama-70B_t3k_2025-10-14_20-06-38.md)


---

## Tenstorrent Model Release Summary: Llama-3.3-70B-Instruct on t3k

### Metadata: Llama-3.3-70B-Instruct on t3k
```json
{
    "report_id": "id_tt-transformers_Llama-3.3-70B-Instruct_t3k_2025-10-14_15-57-16",
    "model_name": "Llama-3.3-70B-Instruct",
    "model_id": "id_tt-transformers_Llama-3.3-70B-Instruct_t3k",
    "model_spec_json": "/home/tstesco/projects/tt-inference-server/workflow_logs/run_specs/tt_model_spec_2025-10-14_14-16-24_id_tt-transformers_Llama-3.3-70B-Instruct_t3k_release_ufmpqvzH.json",
    "model_repo": "meta-llama/Llama-3.3-70B-Instruct",
    "model_impl": "tt-transformers",
    "device": "t3k",
    "server_mode": "API",
    "tt_metal_commit": "a409240",
    "vllm_commit": "1d799da",
    "run_command": "python run.py --model Llama-3.3-70B-Instruct --device t3k --workflow release "
}
```

### Performance Benchmark Sweeps for Llama-3.3-70B-Instruct on t3k

#### Text-to-Text Performance Benchmark Sweeps for Llama-3.3-70B-Instruct on t3k

|  ISL  | OSL  | Concurrency | N Req | TTFT (ms) | TPOT (ms) | Tput User (TPS) | Tput Decode (TPS) | Tput Prefill (TPS) | E2EL (ms) | Req Tput (RPS) |
|-------|------|-------------|-------|-----------|-----------|-----------------|-------------------|--------------------|-----------|----------------|
|   128 |  128 |           1 |     8 |     191.9 |      63.4 |           15.77 |              15.8 |              666.9 |    8247.1 |          0.121 |
|   128 | 1024 |           1 |     4 |     193.2 |      63.9 |           15.65 |              15.7 |              662.7 |   65557.2 |          0.015 |
|  1024 |  128 |           1 |     4 |     644.0 |      64.9 |           15.4  |              15.4 |             1590.1 |    8890.7 |          0.112 |
|  2048 |  128 |           1 |     4 |    1271.6 |      66.3 |           15.08 |              15.1 |             1610.6 |    9690.8 |          0.103 |
|  3072 |  128 |           1 |     4 |    2556.2 |      67.2 |           14.89 |              14.9 |             1201.8 |   11088.1 |          0.09  |
|  4096 |  128 |           1 |     2 |    2574.1 |      68.4 |           14.62 |              14.6 |             1591.2 |   11258.4 |          0.089 |
|  8192 |  128 |           1 |     2 |    5344.9 |      72.8 |           13.73 |              13.7 |             1532.7 |   14592.6 |          0.069 |
| 16384 |  128 |           1 |     2 |   11633.5 |      82.1 |           12.19 |              12.2 |             1408.3 |   22053.9 |          0.045 |
| 32000 |  128 |           1 |     2 |   26903.2 |      99.6 |           10.04 |              10.0 |             1189.4 |   39548.2 |          0.025 |
|   128 |  128 |          32 |   256 |    5742.0 |      64.6 |           15.48 |             495.4 |              713.3 |   13945.9 |          2.294 |
|   128 | 1024 |          32 |   128 |    5733.4 |      66.9 |           14.95 |             478.5 |              714.4 |   74146.6 |          0.432 |
|  2048 |  128 |          32 |   128 |   40505.9 |      72.4 |           13.82 |             442.2 |             1617.9 |   49696.2 |          0.644 |
|  2048 | 2048 |          32 |    64 |   40446.6 |      75.2 |           13.3  |             425.5 |             1620.3 |  194380.6 |          0.165 |
|  3000 |   64 |          32 |   128 |   81791.7 |      75.0 |           13.33 |             426.6 |             1173.7 |   86517.7 |          0.37  |
|  4000 |   64 |          32 |   128 |   82158.8 |      78.5 |           12.75 |             407.9 |             1558.0 |   87101.6 |          0.367 |
|  8000 |   64 |          16 |    32 |   85721.3 |      78.0 |           12.82 |             205.1 |             1493.2 |   90637.0 |          0.177 |
| 16000 |   64 |           8 |    16 |   93504.2 |      83.4 |           12.0  |              96.0 |             1368.9 |   98756.2 |          0.081 |
| 32000 |   64 |           4 |     8 |  108236.8 |     100.2 |            9.98 |              39.9 |             1182.6 |  114552.0 |          0.035 |

Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> N Req: total number of requests (sample size, N)
> TTFT: Time To First Token (ms)
> TPOT: Time Per Output Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)
> Tput Prefill: Throughput for prefill tokens (TPS)
> E2EL: End-to-End Latency (ms)
> Req Tput: Request Throughput (RPS)

### Performance Benchmark Targets Llama-3.3-70B-Instruct on t3k

#### Text-to-Text Performance Benchmark Targets Llama-3.3-70B-Instruct on t3k

| ISL | OSL | Concurrency | TTFT (ms) | Tput User (TPS) | Tput Decode (TPS) | Functional TTFT Check | Functional Tput User Check | Complete TTFT Check | Complete Tput User Check | Target TTFT Check | Target Tput User Check | Functional TTFT (ms) | Functional Tput User (TPS) | Complete TTFT (ms) | Complete Tput User (TPS) | Target TTFT (ms) | Target Tput User (TPS) |
|-----|-----|-------------|-----------|-----------------|-------------------|-----------------------|----------------------------|---------------------|--------------------------|-------------------|------------------------|----------------------|----------------------------|--------------------|--------------------------|------------------|------------------------|
| 128 | 128 |           1 |     191.9 |           15.77 |              15.8 | PASS ✅               | PASS ✅                    | FAIL ⛔             | PASS ✅                  | FAIL ⛔           | FAIL ⛔                |               380.00 |                       2.80 |              76.00 |                    14.00 |            38.00 |                  28.00 |

Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> TTFT: Time To First Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)

### Accuracy Evaluations for Llama-3.3-70B-Instruct on t3k

| model                  | device | task_name     | accuracy_check | score | ratio_to_reference | gpu_reference_score                                                                                                     | ratio_to_published | published_score                                                                            |
|------------------------|--------|---------------|----------------|-------|--------------------|-------------------------------------------------------------------------------------------------------------------------|--------------------|--------------------------------------------------------------------------------------------|
| Llama-3.3-70B-Instruct | t3k    | meta_ifeval   | PASS ✅         | 91.09 | 1.00               | [91.35](https://docs.google.com/spreadsheets/d/1kFIUj9Bp5WJ0lW3QPwQRRWDyLRieedKrFZqfxWBfeNw/edit?gid=0#gid=0&range=J86) | 0.99               | [92.10](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct#instruction-tuned-models) |
| Llama-3.3-70B-Instruct | t3k    | meta_gpqa_cot | PASS ✅         | 61.16 | 1.02               | [60.04](https://docs.google.com/spreadsheets/d/1kFIUj9Bp5WJ0lW3QPwQRRWDyLRieedKrFZqfxWBfeNw/edit?gid=0#gid=0&range=J87) | 1.21               | [50.50](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct#instruction-tuned-models) |

Note: The ratio to published scores defines if eval ran roughly correctly, as the exact methodology of the model publisher cannot always be reproduced. For this reason the accuracy check is based first on being equivalent to the GPU reference within a +/- tolerance. If a value GPU reference is not available, the accuracy check is based on the direct ratio to the published score.