### PR TITLE
Set TtSDXLPipeline's start_latent_seed

### DIFF
--- a/tt-media-server/tt_model_runners/sdxl_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_runner_trace.py
@@ -165,14 +165,12 @@ class TTSDXLRunnerTrace(BaseDeviceRunner):
             torch_add_text_embeds,
         ) = self.tt_sdxl.encode_prompts(prompts, negative_prompt)
 
-        start_latent_seed = requests[0].seed
-
         self.logger.info(f"Device {self.device_id}: Generating input tensors...")
 
         tt_latents, tt_prompt_embeds, tt_add_text_embeds = self.tt_sdxl.generate_input_tensors(
             all_prompt_embeds_torch,
             torch_add_text_embeds,
-            start_latent_seed,
+            requests[0].seed,
         )
         
         self.logger.debug(f"Device {self.device_id}: Preparing input tensors...") 

--- a/tt-media-server/tt_model_runners/sdxl_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_runner_trace.py
@@ -151,9 +151,6 @@ class TTSDXLRunnerTrace(BaseDeviceRunner):
         needed_padding = (self.batch_size - len(prompts) % self.batch_size) % self.batch_size
         prompts = prompts + [""] * needed_padding
 
-        if requests[0].seed is not None:
-            torch.manual_seed(requests[0].seed)
-
         if requests[0].num_inference_steps is not None:
             self.tt_sdxl.set_num_inference_steps(requests[0].num_inference_steps)
         
@@ -168,11 +165,14 @@ class TTSDXLRunnerTrace(BaseDeviceRunner):
             torch_add_text_embeds,
         ) = self.tt_sdxl.encode_prompts(prompts, negative_prompt)
 
+        start_latent_seed = requests[0].seed
+
         self.logger.info(f"Device {self.device_id}: Generating input tensors...")
 
         tt_latents, tt_prompt_embeds, tt_add_text_embeds = self.tt_sdxl.generate_input_tensors(
             all_prompt_embeds_torch,
             torch_add_text_embeds,
+            start_latent_seed,
         )
         
         self.logger.debug(f"Device {self.device_id}: Preparing input tensors...") 


### PR DESCRIPTION
## Summary
This PR replaces manual seed setting (previously done using the `torch` module) with seed handling in TT-SDXL through the `start_latent_seed` parameter.

## Link to Github Issue:
[#798 Use seed setup through class](https://github.com/tenstorrent/tt-inference-server/issues/798)

## Test steps:
SDXL output for same prompt and seed should result in the same image:

<img width="353" height="178" alt="Screenshot 2025-10-15 at 18 48 32" src="https://github.com/user-attachments/assets/6187a886-13ce-4d42-a1bd-bd486d271e79" />
