### PR TITLE
tstesco/qwen3-remove-eval-downsample

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -463,10 +463,6 @@ _eval_config_list = [
                     "top_k": 20,
                     "top_p": 0.95,
                 },
-                limit_samples_map={
-                    EvalLimitMode.CI_NIGHTLY: 0.2,
-                    EvalLimitMode.SMOKE_TEST: 0.01,
-                },
             ),
         ],
     ),


### PR DESCRIPTION
# change log 

* remove qwen3-32b r1_gpqa_diamond downsample, addressing https://github.com/tenstorrent/tt-inference-server/issues/826 in short term