### PR TITLE
remove sample_on_device_mode param for qwq galaxy

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1037,7 +1037,6 @@ spec_templates = [
                 override_tt_config={
                     "trace_region_size": 27381760,
                     "data_parallel": 4,
-                    "sample_on_device_mode": "decode_only",
                 },
                 env_vars={
                     "TT_MM_THROTTLE_PERF": 3,


### PR DESCRIPTION
# change log

* remove sample_on_device_mode param for qwq galaxy, addressed https://github.com/tenstorrent/tt-inference-server/issues/865