### PR TITLE
add vllm --seed arg for reproducibility

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -222,6 +222,7 @@ class DeviceModelSpec:
             "max_num_batched_tokens": str(self.max_context),
             "num_scheduler_steps": "10",
             "max-log-len": "32",
+            "seed": "9472",
             "override_tt_config": json.dumps(self.override_tt_config),
         }
         merged_vllm_args = {**default_vllm_args, **self.vllm_args}


### PR DESCRIPTION
* add vllm --seed arg for reproducibility

For V0 in particular it is import to set by default for testing to be more reproducible.

See https://docs.vllm.ai/en/stable/usage/reproducibility.html



> Default  Behavior[¶](https://docs.vllm.ai/en/stable/usage/reproducibility.html#default-behavior)
> In V0, the seed parameter defaults to None. When the seed parameter is None, the random states for random, np.random, and torch.manual_seed are not set. This means that each run of vLLM will produce different results if temperature > 0, as expected.
> 
> In V1, the seed parameter defaults to 0 which sets the random state for each worker, so the results will remain consistent for each vLLM run even if temperature > 0.
