### PR TITLE
Support audio preprocessing request param

### DIFF
--- a/tt-media-server/README.md
+++ b/tt-media-server/README.md
@@ -28,8 +28,8 @@ For development running:
 
 1. Setup tt-metal and all the needed variables for it
 2. Make sure you're in tt-metal's python env
-3. Clone repo into the root of tt-metal
-4. ```pip install -r requirements.txt```
+3. Clone tt-inference-server repo and switch to dev branch
+4. ```pip install -r requirements.txt``` from tt-media-server
 5. ```uvicorn main:app --lifespan on --port 8000``` (lifespan methods are needed to init device and close the devices)
 
 ## SDXL setup
@@ -84,7 +84,7 @@ Please note that only quietbox and 6u galaxy are supported.
 
 ## Audio Preprocessing Setup and Model Terms
 
-When setting `enable_audio_preprocessing` for the first time and testing audio models, you must:
+When setting `allow_audio_preprocessing` for the first time and testing audio models, you must:
 
 **Accept Terms for All Required Models:**
 1. Main diarization model: https://hf.co/pyannote/speaker-diarization-3.0
@@ -226,7 +226,7 @@ The TT Inference Server can be configured using environment variables or by modi
 | `MAX_AUDIO_DURATION_SECONDS` | `60.0` | Maximum allowed audio duration for transcription requests (in seconds) |
 | `MAX_AUDIO_SIZE_BYTES` | `52428800` | Maximum allowed audio file size (50 MB in bytes) |
 | `DEFAULT_SAMPLE_RATE` | `16000` | Default audio sample rate for processing (16 kHz) |
-| `ENABLE_AUDIO_PREPROCESSING` | `True` | Boolean flag to enable/disable audio preprocessing before transcription |
+| `ALLOW_AUDIO_PREPROCESSING` | `True` | Boolean flag to allow audio preprocessing capabilities |
 
 ## Authentication Settings
 
@@ -335,7 +335,7 @@ export DEVICE="n300"
 export MAX_AUDIO_DURATION_SECONDS=300.0
 export MAX_AUDIO_SIZE_BYTES=104857600  # 100 MB
 export DEFAULT_SAMPLE_RATE=22050
-export ENABLE_AUDIO_PREPROCESSING=true
+export ALLOW_AUDIO_PREPROCESSING=true
 ```
 
 ### Authentication Configuration

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -35,7 +35,7 @@ MODEL_SERVICE_RUNNER_MAP = {
         ModelRunners.TT_YOLOV4},
 }
 
-# DEVICE engvironment variable
+# DEVICE environment variable
 class DeviceTypes(Enum):
     N150 = "n150"
     N300 = "n300"
@@ -78,14 +78,14 @@ ModelConfigs = {
         "model_runner": ModelRunners.TT_SD3_5.value,
         "device_mesh_shape": (2, 4),
         "is_galaxy": False,
-        "device_ids": "", #HACK to use all devices. device id split will retun and empty string to be passed to os.environ[TT_VISIBLE_DEVICES] in device_worker.py
+        "device_ids": "", #HACK to use all devices. device id split will return and empty string to be passed to os.environ[TT_VISIBLE_DEVICES] in device_worker.py
         "max_batch_size": 1
     },
     (SupportedModels.STABLE_DIFFUSION_3_5_LARGE, DeviceTypes.GALAXY): {
         "model_runner": ModelRunners.TT_SD3_5.value,
         "device_mesh_shape": (4, 8),
         "is_galaxy": False,
-        "device_ids": "", #HACK to use all devices. device id split will retun and empty string to be passed to os.environ[TT_VISIBLE_DEVICES] in device_worker.py
+        "device_ids": "", #HACK to use all devices. device id split will return and empty string to be passed to os.environ[TT_VISIBLE_DEVICES] in device_worker.py
         "max_batch_size": 1
     },
     (SupportedModels.DISTIL_WHISPER_LARGE_V3, DeviceTypes.N150): {

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
     # image specific settings
     num_inference_steps: int = 20 # has to be hardcoded since we cannot allow per image currently
     # audio specific settings
-    enable_audio_preprocessing: bool = True
+    allow_audio_preprocessing: bool = True
     max_audio_duration_seconds: float = 60.0
     max_audio_duration_with_preprocessing_seconds: float = 300.0  # 5 minutes when preprocessing enabled
     max_audio_size_bytes: int = 50 * 1024 * 1024

--- a/tt-media-server/domain/audio_transcription_request.py
+++ b/tt-media-server/domain/audio_transcription_request.py
@@ -12,6 +12,7 @@ class AudioTranscriptionRequest(BaseRequest):
     
     # Custom fields for our implementation
     stream: bool = False
+    is_preprocessing_enabled: bool = True  # Enable VAD and diarization for specific request
 
     # Private fields for internal processing
     _audio_array: Optional[np.ndarray] = None

--- a/tt-media-server/model_services/scheduler.py
+++ b/tt-media-server/model_services/scheduler.py
@@ -194,7 +194,7 @@ class Scheduler:
                 
                 self.worker_info[worker_id]['error_count'] += 1
                 
-                self.logger.warning(f"Worker {worker_id} error cound is : {self.worker_info[worker_id]['error_count']}")
+                self.logger.warning(f"Worker {worker_id} error count is : {self.worker_info[worker_id]['error_count']}")
                 
                 if task_id is None:
                     self.listener_running = False
@@ -333,7 +333,7 @@ class Scheduler:
                 raise ValueError("Worker count must be at least 1")
             return worker_count
         except Exception as e:
-            self.logger.error(f"Erros getting workers cannot: {e}")
+            self.logger.error(f"Error getting workers count: {e}")
             raise HTTPException(status_code=500, detail="Workers cannot be initialized")
 
     def _get_max_queue_size(self) -> int:
@@ -362,7 +362,7 @@ class Scheduler:
                         self.logger.error(f"Error checking worker {worker_id} health: {e}")
                         dead_workers.append(worker_id)
                 
-                # check for any workerrs that have too many errors
+                # check for any workers that have too many errors
                 for worker_id, info in self.worker_info.items():
                     if info['error_count'] > self.settings.max_worker_restart_count:
                         dead_workers.append(worker_id)

--- a/tt-media-server/tests/whisper_demo.py
+++ b/tt-media-server/tests/whisper_demo.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -23,11 +23,14 @@ from transformers import (
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
+from models.common.generation_utils import get_logits_processor
+from models.common.utility_functions import is_blackhole
+from models.demos.utils.common_demo_utils import get_mesh_mappers
 from models.demos.utils.llm_demo_utils import verify_perf
 from models.demos.whisper.tt import ttnn_optimized_functional_whisper
 from models.demos.whisper.tt.ttnn_optimized_functional_whisper import WHISPER_L1_SMALL_SIZE, init_kv_cache
-from models.common.generation_utils import get_logits_processor
-from models.common.utility_functions import is_blackhole
+
+available_devices = len(ttnn.get_device_ids()) if ttnn.get_device_ids() else 1
 
 
 def load_input_paths(folder_path):
@@ -49,12 +52,20 @@ def pad_input_32(tensor, value):
     return tensor
 
 
-def load_conditional_generation_ref_model():
-    hf_ref_model = (
-        WhisperForConditionalGeneration.from_pretrained("distil-whisper/distil-large-v3").to(torch.bfloat16).eval()
-    )
-    processor = AutoProcessor.from_pretrained("distil-whisper/distil-large-v3", language="English", task="transcribe")
-    feature_extractor = AutoFeatureExtractor.from_pretrained("distil-whisper/distil-large-v3")
+def load_conditional_generation_ref_model(model_repo):
+    """
+    Load Whisper model for conditional generation.
+
+    Args:
+        model_repo: HuggingFace model repository ID. Must be one of the supported models.
+    """
+    allowed_models = ["distil-whisper/distil-large-v3", "openai/whisper-large-v3"]
+    if model_repo not in allowed_models:
+        raise ValueError(f"Unknown model_repo: {model_repo}. Valid options are {allowed_models}")
+
+    hf_ref_model = WhisperForConditionalGeneration.from_pretrained(model_repo).to(torch.bfloat16).eval()
+    processor = AutoProcessor.from_pretrained(model_repo, language="English", task="transcribe")
+    feature_extractor = AutoFeatureExtractor.from_pretrained(model_repo)
     config = hf_ref_model.config
     return (
         hf_ref_model,
@@ -64,59 +75,76 @@ def load_conditional_generation_ref_model():
     )
 
 
-def init_conditional_generation_tt_model(hf_ref_model, config, ttnn_model, device, max_batch_size=1, max_seq_len=512):
+def init_conditional_generation_tt_model(
+    hf_ref_model, config, ttnn_model, mesh_device, weights_mesh_mapper, max_batch_size=1, max_seq_len=512
+):
     model = hf_ref_model.model
     linear_weight = hf_ref_model.proj_out.weight
-
-    ttnn_linear_weight = ttnn.from_torch(linear_weight, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+    ttnn_linear_weight = ttnn.from_torch(
+        linear_weight, layout=ttnn.TILE_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16, mesh_mapper=weights_mesh_mapper
+    )
     ttnn_linear_weight = ttnn.permute(ttnn_linear_weight, (1, 0))
     ttnn_linear_weight = ttnn.to_layout(ttnn_linear_weight, layout=ttnn.TILE_LAYOUT)
 
     parameters = preprocess_model_parameters(
         initialize_model=lambda: model,
         convert_to_ttnn=ttnn_model.convert_to_ttnn,
-        custom_preprocessor=ttnn_model.custom_preprocessor,
-        device=device,
+        custom_preprocessor=ttnn_model.create_custom_mesh_preprocessor(weights_mesh_mapper),
+        device=mesh_device,
     )
-
-    # Note: config.max_length is 448 for distil-whisper/distil-large-v3
-    kv_cache = init_kv_cache(config, device, max_batch_size, max_seq_len=max_seq_len)
+    # Note: config.max_length is typically 448 for whisper large models
+    kv_cache = init_kv_cache(
+        config, mesh_device, max_batch_size, max_seq_len=max_seq_len, weights_mesh_mapper=weights_mesh_mapper
+    )
 
     return parameters, ttnn_linear_weight, kv_cache
 
 
 def run_generate(
     config,
-    audio_data,
-    sampling_rate,
+    current_batch,
     feature_extractor,
     ttnn_model,
     parameters,
     processor,
     ttnn_linear_weight,
-    device,
+    mesh_device,
     generation_config,
+    input_mesh_mapper,
+    output_mesh_composer,
+    weights_mesh_mapper,
     kv_cache=None,
     stream_generation=False,
     feature_dtype_to_use=torch.bfloat16,
     return_perf_metrics=False,
 ):
+    all_input_features = []
     start_encode = time.time()
-
-    # Compute features
-    inputs = feature_extractor(audio_data, sampling_rate=sampling_rate, return_tensors="pt")
-    input_features = inputs.input_features.type(feature_dtype_to_use)
+    for sampling_rate, audio_array in current_batch:
+        inputs = feature_extractor(
+            audio_array,
+            sampling_rate=sampling_rate,
+            return_tensors="pt",
+        )
+        all_input_features.append(inputs.input_features)
+    input_features = torch.cat(all_input_features, dim=0)  # [B, x, y]
+    del all_input_features
     unpadded_batch_size = input_features.shape[0]
-    assert unpadded_batch_size == 1, "Only batch size 1 is supported for inference"
-
+    assert (
+        unpadded_batch_size == 1 * mesh_device.get_num_devices()
+    ), "Only batch size (per device) 1 is supported for inference"
     # Compute embeddings
     input_embeds = ttnn_model.preprocess_encoder_inputs(
-        config, input_features, parameters=parameters.encoder, device=device
+        config,
+        input_features,
+        parameters=parameters.encoder,
+        device=mesh_device,
+        weights_mesh_mapper=weights_mesh_mapper,
+        input_mesh_mapper=input_mesh_mapper,
     )
-
     # Run encoder
     encoder_hidden_states = ttnn_model.encoder(config, input_embeds, parameters=parameters.encoder)
-    ttnn.synchronize_device(device)
+    ttnn.synchronize_device(mesh_device)
     logger.info(f"Time to encoder states: {(time.time() - start_encode)*1000:.3f}ms")
 
     # Run decoder
@@ -124,31 +152,35 @@ def run_generate(
     def _run_generate():
         # Input ids
         input_ids = torch.tensor([[1]]) * config.decoder_start_token_id
+        input_ids = input_ids.repeat(input_features.shape[0], 1)
         logits_processor = get_logits_processor(input_ids, config)
         if not kv_cache:
             input_ids = pad_input_32(input_ids, config.pad_token_id).to(torch.long)
             decoder_start_values = generation_config.pad_token_id * torch.ones(1, 32).to(torch.long)
-
         # Initial decode position
         current_decode_pos = (
-            ttnn.from_torch(torch.zeros(unpadded_batch_size), device=device, dtype=ttnn.int32) if kv_cache else None
+            ttnn.from_torch(
+                torch.zeros(unpadded_batch_size), device=mesh_device, dtype=ttnn.int32, mesh_mapper=input_mesh_mapper
+            )
+            if kv_cache
+            else None
         )
-
-        MAX_GEN_LEN = config.max_length  # 448 for distil-whisper/distil-large-v3
+        MAX_GEN_LEN = config.max_length  # typically 448 for whisper large models
         print_each_iter = False
         output_ids = []
         total_decode_time = 0
+        prompt_is_done = [False for _ in range(unpadded_batch_size)]
         for i in tqdm(range(MAX_GEN_LEN), desc="Decode inference iterations"):
             start_iter = time.time()
-
             decoder_hidden_states, decoder_attention_mask = ttnn_model.preprocess_decoder_inputs(
                 config=config,
                 input_ids=input_ids,
                 attention_mask=None,
                 parameters=parameters.decoder,
-                device=device,
+                device=mesh_device,
                 decode_pos=i if kv_cache else None,
                 create_attention_mask=(not kv_cache),
+                input_mesh_mapper=input_mesh_mapper,
             )
 
             output = ttnn_model.decoder(
@@ -171,9 +203,8 @@ def run_generate(
                 output_idx = 0
 
             output = output @ ttnn_linear_weight
-            logits_to_torch = ttnn.to_torch(output)
+            logits_to_torch = ttnn.to_torch(output, mesh_composer=output_mesh_composer)
             next_token_logits = logits_to_torch[:, output_idx, :]
-
             next_tokens_scores = logits_processor(input_features, next_token_logits)
             next_tokens = torch.argmax(next_tokens_scores, dim=-1)
             output_ids.append(next_tokens)
@@ -193,111 +224,166 @@ def run_generate(
 
             total_decode_time += time.time() - start_iter
             avg_decode_throughput = (i + 1) / total_decode_time
-
-            ttnn_transcription = processor.batch_decode(next_tokens.unsqueeze(dim=1), skip_special_tokens=True)[0]
+            for user_id, user_decode_id in enumerate(next_tokens[:unpadded_batch_size]):
+                if user_decode_id == config.eos_token_id:
+                    prompt_is_done[user_id] = True
+                if prompt_is_done[user_id]:
+                    next_tokens[user_id] = config.eos_token_id
+            ttnn_transcription = processor.batch_decode(next_tokens.unsqueeze(dim=1), skip_special_tokens=True)
             if print_each_iter:
-                logger.info(processor.batch_decode(torch.stack(output_ids, dim=1), skip_special_tokens=True)[0])
+                logger.info(processor.batch_decode(torch.stack(output_ids, dim=1), skip_special_tokens=True))
 
             if return_perf_metrics:
                 yield ttnn_transcription, ttft, avg_decode_throughput
             else:
                 yield ttnn_transcription
 
-            if next_tokens == config.eos_token_id:
+            if all(prompt_is_done):
                 break
-
         total_generate_time = time.time() - start_encode
         logger.info(f"Time to first token: {(ttft*1000):.3f}ms")
         logger.info(f"Total decode time: {total_decode_time:.3f}s")
         logger.info(f"Total generate time: {total_generate_time:.3f}s")
-        logger.info(f"Average decode throughput: {avg_decode_throughput:.3f} t/s/u")
+        logger.info(f"Average decode throughput (per user): {avg_decode_throughput:.3f} t/s/u")
+        logger.info(f"Average decode throughput (total batch): {(avg_decode_throughput * unpadded_batch_size):.3f} t/s")
 
     # conditionally return generator or full response
     if stream_generation:
         return _run_generate()
     else:
-        output = []
+        output = [[] for _ in range(input_features.shape[0])]
         for x in _run_generate():
             if return_perf_metrics:
                 out_cur, ttft, avg_decode_throughput = x
             else:
                 out_cur = x
-            output.append(out_cur)
-        output = "".join(output)
-
+            for idx in range(input_features.shape[0]):
+                output[idx].append(out_cur[idx])
+        output = ["".join(tokens) for tokens in output]
         if return_perf_metrics:
             return output, ttft, avg_decode_throughput
         else:
             return output
 
 
-def create_functional_whisper_for_conditional_generation_inference_pipeline(ttnn_model, device):
+def create_functional_whisper_for_conditional_generation_inference_pipeline(ttnn_model, mesh_device, model_repo):
     """
     Returns a callable with signature (data, sampling_rate, stream), where data is is a 1D numpy array
     and sampling_rate is an int representing the sampling rate used to acquire data, and stream turns
     signals the callable to return a generator if True, yielding the decoded tokens as they are processed, else
     the callable returns the full decoded output.
+
+    Args:
+        ttnn_model: The TTNN model
+        device: The target device
+        model_repo: HuggingFace model repository ID. Must be one of the supported models.
     """
-    hf_ref_model, config, processor, feature_extractor = load_conditional_generation_ref_model()
+    input_mesh_mapper, weights_mesh_mapper, output_mesh_composer = get_mesh_mappers(mesh_device)
+    hf_ref_model, config, processor, feature_extractor = load_conditional_generation_ref_model(model_repo)
     parameters, ttnn_linear_weight, kv_cache = init_conditional_generation_tt_model(
-        hf_ref_model, config, ttnn_model, device
+        hf_ref_model, config, ttnn_model, mesh_device, weights_mesh_mapper=weights_mesh_mapper
     )
 
-    def _model_pipeline(data, sampling_rate, stream=False, return_perf_metrics=False):
-        logger.info(f"Running model on audio data with duration {data.shape[0]/sampling_rate:.3f}s")
+    def _model_pipeline(
+        current_batch,
+        stream=False,
+        return_perf_metrics=False,
+    ):
+        durations = [audio_array.shape[0] / sampling_rate for (sampling_rate, audio_array) in current_batch]
+        logger.info(
+            f"Running model on batch of {len(current_batch)} samples with durations: {['{:.3f}s'.format(d) for d in durations]}"
+        )
 
         return run_generate(
             config,
-            data,
-            sampling_rate,
+            current_batch,
             feature_extractor,
             ttnn_model,
             parameters=parameters,
             processor=processor,
             ttnn_linear_weight=ttnn_linear_weight,
-            device=device,
+            mesh_device=mesh_device,
             generation_config=hf_ref_model.generation_config,
             kv_cache=kv_cache,
             stream_generation=stream,
             return_perf_metrics=return_perf_metrics,
+            input_mesh_mapper=input_mesh_mapper,
+            output_mesh_composer=output_mesh_composer,
+            weights_mesh_mapper=weights_mesh_mapper,
         )
 
     return _model_pipeline
 
 
-def run_demo_whisper_for_audio_classification_inference(input_path, ttnn_model, device, num_inputs):
+def run_demo_whisper_for_audio_classification_inference(
+    input_path,
+    ttnn_model,
+    mesh_device,
+    num_inputs,
+    batch_size_per_device=1,
+    label=False,
+    dataset=None,
+):
     torch.manual_seed(1234)
-
     feature_extractor = AutoFeatureExtractor.from_pretrained("sanchit-gandhi/whisper-medium-fleurs-lang-id")
     model = WhisperForAudioClassification.from_pretrained("sanchit-gandhi/whisper-medium-fleurs-lang-id")
-
     model.eval()
-    input_data = load_input_paths(input_path)
-
+    config = model.config
+    if label:
+        assert dataset is not None, "Dataset must be provided when label=True"
+        data_iter = iter(dataset)
+    else:
+        input_data = load_input_paths(input_path)
+    inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer = get_mesh_mappers(mesh_device)
     parameters = preprocess_model_parameters(
         initialize_model=lambda: model,
         convert_to_ttnn=ttnn_model.convert_to_ttnn,
-        custom_preprocessor=ttnn_model.custom_preprocessor,
-        device=device,
+        custom_preprocessor=ttnn_model.create_custom_mesh_preprocessor(weights_mesh_mapper),
+        device=mesh_device,
     )
-    if len(input_data) < num_inputs:
-        assert False, "num_inputs exceeds number of audio files available in folder"
+    batch_size = batch_size_per_device * mesh_device.get_num_devices()
+    total_inputs = num_inputs * batch_size
 
-    for i in range(num_inputs):
-        input_file_path = input_data[i]
-        samplerate, data = wavfile.read(input_file_path)
+    if not label and len(input_data) < total_inputs:
+        raise ValueError("num_inputs exceeds number of audio files available in folder")
 
-        inputs = feature_extractor(
-            data,
-            sampling_rate=samplerate,
-            return_tensors="pt",
-        )
+    for i in tqdm(range(0, total_inputs, batch_size), desc="Running Inference"):
+        current_batch_size = min(batch_size, total_inputs - i)
+        logger.info(f"Running batch {(i // batch_size) + 1} | Batch size: {current_batch_size}")
 
-        input_features = inputs.input_features
+        all_input_features = []
+        true_labels = []
 
-        config = model.config
+        for j in range(current_batch_size):
+            if label:
+                sample = next(data_iter)
+                audio_array = sample["audio"]["array"]
+                sampling_rate = sample["audio"]["sampling_rate"]
+                true_labels.append(sample["lang_id"])
+            else:
+                input_file_path = input_data[i + j]
+                logger.info(f"Input path: {input_file_path}")
+                sampling_rate, audio_array = wavfile.read(input_file_path)
+
+            # Feature extraction
+            inputs = feature_extractor(
+                audio_array,
+                sampling_rate=sampling_rate,
+                return_tensors="pt",
+            )
+            all_input_features.append(inputs.input_features)
+
+        # Combine input features into batch tensor
+        input_features = torch.cat(all_input_features, dim=0)  # Shape: [current_batch_size, x, y]
+        del all_input_features
+        # Encode inputs
         input_embedding = ttnn_model.preprocess_encoder_inputs(
-            config=config, input_features=input_features, parameters=parameters.encoder, device=device
+            config=config,
+            input_features=input_features,
+            parameters=parameters.encoder,
+            device=mesh_device,
+            input_mesh_mapper=inputs_mesh_mapper,
+            weights_mesh_mapper=weights_mesh_mapper,
         )
 
         encoder_outputs = ttnn_model.encoder(
@@ -312,123 +398,105 @@ def run_demo_whisper_for_audio_classification_inference(input_path, ttnn_model, 
         logits = ttnn.matmul(pooled_output, parameters.classifier.weight)
         logits = ttnn.add(logits, parameters.classifier.bias)
 
-        logits_torch = ttnn.to_torch(logits)
-        predicted_class_ids = torch.argmax(logits_torch).item()
-        predicted_label = model.config.id2label[predicted_class_ids]
+        # Convert logits to torch
+        logits_torch = ttnn.to_torch(logits, mesh_composer=output_mesh_composer)
 
-        logger.info("predicted_label")
-        logger.info(predicted_label)
+        # Argmax over class dimension
+        predicted_class_ids = torch.argmax(logits_torch.squeeze(1), dim=1)
+        predicted_labels = [model.config.id2label[class_id.item()] for class_id in predicted_class_ids]
 
-
-def run_demo_whisper_for_audio_classification_dataset(ttnn_model, device):
-    torch.manual_seed(1234)
-
-    feature_extractor = AutoFeatureExtractor.from_pretrained("sanchit-gandhi/whisper-medium-fleurs-lang-id")
-    model = WhisperForAudioClassification.from_pretrained("sanchit-gandhi/whisper-medium-fleurs-lang-id")
-
-    model.eval()
-
-    ds = load_dataset("google/fleurs", "all", split="validation", streaming=True)
-    sample = next(iter(ds))
-
-    inputs = feature_extractor(
-        sample["audio"]["array"],
-        sampling_rate=sample["audio"]["sampling_rate"],
-        return_tensors="pt",
-    )
-
-    input_features = inputs.input_features
-
-    logger.debug("Input audio language:")
-    logger.debug(sample["language"])
-
-    parameters = preprocess_model_parameters(
-        initialize_model=lambda: model,
-        convert_to_ttnn=ttnn_model.convert_to_ttnn,
-        custom_preprocessor=ttnn_model.custom_preprocessor,
-        device=device,
-    )
-
-    config = model.config
-    input_embedding = ttnn_model.preprocess_encoder_inputs(
-        config=config, input_features=input_features, parameters=parameters.encoder, device=device
-    )
-
-    encoder_outputs = ttnn_model.encoder(config=config, inputs_embeds=input_embedding, parameters=parameters.encoder)
-
-    hidden_states = ttnn.matmul(encoder_outputs, parameters.projector.weight)
-    hidden_states = ttnn.add(hidden_states, parameters.projector.bias)
-
-    pooled_output = ttnn.mean(hidden_states, dim=-2, keepdim=True)
-
-    logits = ttnn.matmul(pooled_output, parameters.classifier.weight)
-    logits = ttnn.add(logits, parameters.classifier.bias)
-
-    logits_torch = ttnn.to_torch(logits)
-    predicted_class_ids = torch.argmax(logits_torch).item()
-    predicted_label = model.config.id2label[predicted_class_ids]
-
-    logger.info("predicted_label")
-    logger.info(predicted_label)
+        for idx, label_str in enumerate(predicted_labels):
+            log_msg = f"Sample {i + idx} - Predicted: {label_str}"
+            if label:
+                true_label_str = model.config.id2label[true_labels[idx]]
+                log_msg += f" | True: {true_label_str}"
+            logger.info(log_msg)
 
 
-def run_demo_whisper_for_conditional_generation_inference(input_path, ttnn_model, device, num_inputs):
+def run_demo_whisper_for_conditional_generation_inference(
+    input_path, ttnn_model, mesh_device, num_inputs, model_repo, batch_size_per_device=1
+):
     torch.manual_seed(0)
-
     # instantiate model inference pipeline
-    model_pipeline = create_functional_whisper_for_conditional_generation_inference_pipeline(ttnn_model, device)
+    model_pipeline = create_functional_whisper_for_conditional_generation_inference_pipeline(
+        ttnn_model, mesh_device, model_repo
+    )
 
     # load data
     input_data = load_input_paths(input_path)
 
-    if len(input_data) < num_inputs:
-        assert False, "num_inputs exceeds number of audio files available in folder"
+    batch_size = batch_size_per_device * mesh_device.get_num_devices()
+    total_inputs = num_inputs * batch_size
+
+    if len(input_data) < total_inputs:
+        raise ValueError("num_inputs exceeds number of audio files available in folder")
 
     total_ttft = 0
     total_decode_throughput = 0
     num_warmup_runs = 1
-    for i in range(num_inputs):
-        input_file_path = input_data[i]
-        samplerate, data = wavfile.read(input_file_path)
-
+    for i in tqdm(range(0, total_inputs, batch_size), desc="Running Inference"):
+        current_batch_size = min(batch_size, total_inputs - i)
+        current_batch = []
+        for j in range(current_batch_size):
+            input_file_path = input_data[i + j]
+            logger.info(f"Input path: {input_file_path}")
+            samplerate, data = wavfile.read(input_file_path)
+            current_batch.append((samplerate, data))
         # perform model inference
-        ttnn_output, ttft, avg_decode_throughput = model_pipeline(
-            data, samplerate, stream=False, return_perf_metrics=True
-        )
+        ttnn_output, ttft, avg_decode_throughput = model_pipeline(current_batch, stream=False, return_perf_metrics=True)
         if i >= num_warmup_runs:  # Exclude first compile run
             total_ttft += ttft
             total_decode_throughput += avg_decode_throughput
-        logger.info(f"Model Output (Input {i+1}): {ttnn_output}")
-
+        batch_start = i + 1
+        batch_end = i + current_batch_size
+        logger.info(f"Model Output (Inputs {batch_start}--{batch_end}) Sample: {ttnn_output}")
     avg_ttft = total_ttft / (num_inputs - num_warmup_runs)
     avg_decode_throughput = total_decode_throughput / (num_inputs - num_warmup_runs)
     return avg_ttft, avg_decode_throughput
 
 
-def run_demo_whisper_for_conditional_generation_dataset(ttnn_model, device):
+def run_demo_whisper_for_conditional_generation_dataset(ttnn_model, mesh_device, model_repo, batch_size_per_device=1):
     torch.manual_seed(0)
-
     # instantiate model inference pipeline
-    model_pipeline = create_functional_whisper_for_conditional_generation_inference_pipeline(ttnn_model, device)
+    model_pipeline = create_functional_whisper_for_conditional_generation_inference_pipeline(
+        ttnn_model, mesh_device, model_repo
+    )
 
     # load data
     ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
-
+    batch_size = batch_size_per_device * mesh_device.get_num_devices()
     # perform model inference
     total_wer = 0
     total_cer = 0
-    for ds_input in tqdm(ds, desc="Processing dataset inputs"):
-        data = ds_input["audio"]["array"]
-        sampling_rate = 16000
-        ttnn_output = model_pipeline(data, sampling_rate, stream=False)
-        logger.info(f"Model output: {ttnn_output}")
-
-        # Compute word and character error rates
-        reference = ds_input["text"].lower()
-        predicted = ttnn_output.lower()
-        total_wer += jiwer.wer(reference, predicted)
-        total_cer += jiwer.cer(reference, predicted)
-
+    total_inputs = len(ds)
+    for i in tqdm(range(0, total_inputs, batch_size), desc="Running Inference"):
+        current_batch_size = min(batch_size, total_inputs - i)
+        current_batch = []
+        reference_sentences = []
+        if current_batch_size < batch_size:
+            logger.info(f"Skipping last batch with size {current_batch_size}")
+            continue
+        for j in range(current_batch_size):
+            sample = ds[i + j]
+            logger.info(f"Sample ID: {i + j}")
+            samplerate = sample["audio"]["sampling_rate"]
+            data = sample["audio"]["array"]
+            current_batch.append((samplerate, data))
+            reference_sentences.append(sample["text"].lower())
+        ttnn_output = model_pipeline(
+            current_batch,
+            stream=False,
+            return_perf_metrics=False,
+        )
+        batch_start = i + 1
+        batch_end = i + current_batch_size
+        logger.debug(f"Dataset text (Inputs {batch_start}--{batch_end}) Sample: {reference_sentences}")
+        logger.debug(f"ttnn Model Output (Inputs {batch_start}--{batch_end}) Sample: {ttnn_output}")
+        for j in range(current_batch_size):
+            reference = ds[i + j]["text"].lower()
+            predicted = ttnn_output[j].lower()
+            total_wer += jiwer.wer(reference, predicted)
+            total_cer += jiwer.cer(reference, predicted)
     logger.info(f"Average Word Error Rate: {total_wer / len(ds):.4f}")
     logger.info(f"Average Character Error Rate: {total_cer / len(ds):.4f}")
 
@@ -438,23 +506,31 @@ def run_demo_whisper_for_conditional_generation_dataset(ttnn_model, device):
     (ttnn_optimized_functional_whisper,),
 )
 @pytest.mark.parametrize(
-    "num_inputs",
-    ((1),),
+    "num_inputs,batch_size_per_device",
+    [(1, 1)],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
-def test_demo_for_audio_classification(input_path, ttnn_model, device, num_inputs):
-    return run_demo_whisper_for_audio_classification_inference(input_path, ttnn_model, device, num_inputs)
-
-
 @pytest.mark.parametrize(
-    "ttnn_model",
-    (ttnn_optimized_functional_whisper,),
+    "mesh_device",
+    [available_devices]
+    if os.getenv("CI") != "true"
+    else ([1, available_devices] if available_devices != 1 else [available_devices]),
+    indirect=True,
 )
-@pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
-def test_demo_for_audio_classification_dataset(ttnn_model, device, is_ci_env):
+# To run the demo with specific device configurations, provide the desired number of devices under the `mesh_device` parameter.
+def test_demo_for_audio_classification_inference(
+    input_path, ttnn_model, mesh_device, num_inputs, batch_size_per_device, is_ci_env, request
+):
     if is_ci_env:
         pytest.skip("Skipping test in CI since it provides redundant testing")
-    return run_demo_whisper_for_audio_classification_dataset(ttnn_model, device)
+
+    return run_demo_whisper_for_audio_classification_inference(
+        input_path,
+        ttnn_model,
+        mesh_device,
+        num_inputs,
+        batch_size_per_device,
+    )
 
 
 @pytest.mark.parametrize(
@@ -462,24 +538,80 @@ def test_demo_for_audio_classification_dataset(ttnn_model, device, is_ci_env):
     (ttnn_optimized_functional_whisper,),
 )
 @pytest.mark.parametrize(
-    "num_inputs",
-    (2,),
+    "num_inputs,batch_size_per_device",
+    [(1, 1)],
+)
+# To run the demo with specific device configurations, provide the desired number of devices under the `mesh_device` parameter.
+@pytest.mark.parametrize(
+    "mesh_device",
+    [available_devices]
+    if os.getenv("CI") != "true"
+    else ([1, available_devices] if available_devices != 1 else [available_devices]),
+    indirect=True,
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
-def test_demo_for_conditional_generation(input_path, ttnn_model, device, num_inputs, is_ci_env):
-    ttft, decode_throughput = run_demo_whisper_for_conditional_generation_inference(
-        input_path, ttnn_model, device, num_inputs
-    )
+def test_demo_for_audio_classification_dataset(
+    input_path, ttnn_model, mesh_device, num_inputs, batch_size_per_device, is_ci_env, request
+):
     if is_ci_env:
+        pytest.skip("Skipping test in CI since it provides redundant testing")
+
+    ds = load_dataset("google/fleurs", "all", split="validation", streaming=True)
+    return run_demo_whisper_for_audio_classification_inference(
+        input_path,
+        ttnn_model,
+        mesh_device,
+        num_inputs,
+        batch_size_per_device,
+        label=True,
+        dataset=ds,
+    )
+
+
+@pytest.mark.parametrize(
+    "ttnn_model",
+    (ttnn_optimized_functional_whisper,),
+)
+@pytest.mark.parametrize(
+    "num_inputs,batch_size_per_device",
+    [(2, 1)],
+)
+@pytest.mark.parametrize(
+    "model_repo",
+    ("openai/whisper-large-v3", "distil-whisper/distil-large-v3"),
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [available_devices]
+    if os.getenv("CI") != "true"
+    else ([1, available_devices] if available_devices != 1 else [available_devices]),
+    indirect=True,
+)
+# To run the demo with specific device configurations, provide the desired number of devices under the `mesh_device` parameter.
+@pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
+def test_demo_for_conditional_generation(
+    input_path, ttnn_model, mesh_device, num_inputs, model_repo, is_ci_env, batch_size_per_device, request
+):
+    param_mesh = request.node.callspec.params.get("mesh_device")
+
+    ttft, decode_throughput = run_demo_whisper_for_conditional_generation_inference(
+        input_path, ttnn_model, mesh_device, num_inputs, model_repo, batch_size_per_device
+    )
+    if is_ci_env and model_repo == "distil-whisper/distil-large-v3" and param_mesh == 1:
         if is_blackhole():
-            if device.dram_grid_size().x == 7:  # P100 DRAM grid is 7x1
+            if mesh_device.dram_grid_size().x == 7:  # P100 DRAM grid is 7x1
                 expected_perf_metrics = {"prefill_t/s": 7.85, "decode_t/s/u": 87.0}
             else:
                 expected_perf_metrics = {"prefill_t/s": 8.40, "decode_t/s/u": 94.0}
         else:  # wormhole_b0
             expected_perf_metrics = {"prefill_t/s": 3.85, "decode_t/s/u": 51.8}
-        expected_perf_metrics["decode_t/s"] = expected_perf_metrics["decode_t/s/u"]  # Only supporting batch 1
-        measurements = {"prefill_t/s": 1 / ttft, "decode_t/s": decode_throughput, "decode_t/s/u": decode_throughput}
+        total_batch = mesh_device.get_num_devices() * batch_size_per_device
+        expected_perf_metrics["decode_t/s"] = expected_perf_metrics["decode_t/s/u"] * total_batch
+        measurements = {
+            "prefill_t/s": (1 / ttft) * total_batch,
+            "decode_t/s": decode_throughput * total_batch,
+            "decode_t/s/u": decode_throughput,
+        }
         verify_perf(measurements, expected_perf_metrics)
 
 
@@ -487,8 +619,29 @@ def test_demo_for_conditional_generation(input_path, ttnn_model, device, num_inp
     "ttnn_model",
     (ttnn_optimized_functional_whisper,),
 )
+@pytest.mark.parametrize(
+    "model_repo",
+    ("openai/whisper-large-v3", "distil-whisper/distil-large-v3"),
+)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
-def test_demo_for_conditional_generation_dataset(ttnn_model, device, is_ci_env):
+@pytest.mark.parametrize(
+    "batch_size_per_device",
+    [(1)],
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [available_devices]
+    if os.getenv("CI") != "true"
+    else ([1, available_devices] if available_devices != 1 else [available_devices]),
+    indirect=True,
+)
+# To run the demo with specific device configurations, provide the desired number of devices under the `mesh_device` parameter.
+def test_demo_for_conditional_generation_dataset(
+    ttnn_model, mesh_device, model_repo, is_ci_env, batch_size_per_device, request
+):
     if is_ci_env:
         pytest.skip("Skipping test in CI since it provides redundant testing")
-    return run_demo_whisper_for_conditional_generation_dataset(ttnn_model, device)
+
+    return run_demo_whisper_for_conditional_generation_dataset(
+        ttnn_model, mesh_device, model_repo, batch_size_per_device
+    )

--- a/tt-media-server/tt_model_runners/sd35_runner.py
+++ b/tt-media-server/tt_model_runners/sd35_runner.py
@@ -36,7 +36,7 @@ class TTSD35Runner(BaseDeviceRunner):
         ttnn.close_mesh_device(device)
         return True
 
-    @log_execution_time("SD35 warmpup")
+    @log_execution_time("SD35 warmup")
     async def load_model(self, device)->bool:
         self.logger.info(f"Device {self.device_id}: Loading model...")
 

--- a/tt-media-server/tt_model_runners/sdxl_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_runner_trace.py
@@ -42,7 +42,7 @@ class TTSDXLRunnerTrace(BaseDeviceRunner):
             ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
 
     def get_device(self):
-        # for now use all availalbe devices
+        # for now use all available devices
         return self._mesh_device()
 
     def _mesh_device(self):
@@ -69,7 +69,7 @@ class TTSDXLRunnerTrace(BaseDeviceRunner):
             ttnn.close_mesh_device(device)
         return True
 
-    @log_execution_time("SDXL warmpup")
+    @log_execution_time("SDXL warmup")
     async def load_model(self, device)->bool:
         self.logger.info(f"Device {self.device_id}: Loading model...")
         if device is None:
@@ -210,7 +210,7 @@ class TTSDXLRunnerTrace(BaseDeviceRunner):
             )
             self.logger.info(f"Device {self.device_id}: Image gen for {self.batch_size} prompts completed in {profiler.times['image_gen'][-1]:.2f} seconds")
             self.logger.info(
-                f"Device {self.device_id}: Denoising loop for {self.batch_size} promts completed in {profiler.times['denoising_loop'][-1]:.2f} seconds"
+                f"Device {self.device_id}: Denoising loop for {self.batch_size} prompts completed in {profiler.times['denoising_loop'][-1]:.2f} seconds"
             )
             self.logger.info(
                 f"Device {self.device_id}: On device VAE decoding completed in {profiler.times['vae_decode'][-1]:.2f} seconds"

--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -115,16 +115,6 @@ class TTWhisperRunner(BaseDeviceRunner):
             raise DeviceInitializationError(f"Mesh device initialization failed: {str(e)}") from e
         return mesh_device
 
-    def _verify_device_initialization(self, mesh_device, num_devices_requested):
-        try:
-            actual_device_count = mesh_device.get_num_devices()
-            if actual_device_count != num_devices_requested:
-                self.logger.warning(
-                    f"Device {self.device_id}: Requested {num_devices_requested} devices but got {actual_device_count}"
-                )
-        except Exception as e:
-            self.logger.warning(f"Device {self.device_id}: Could not verify device count: {e}")
-
     def _mesh_device(self):
         try:
             # Get available devices
@@ -133,21 +123,10 @@ class TTWhisperRunner(BaseDeviceRunner):
                 raise DeviceInitializationError("No TTNN devices available")
             self.logger.info(f"Device {self.device_id}: Found {len(device_ids)} available TTNN devices: {device_ids}")
 
-            # Always fixed for whisper!
             mesh_shape = ttnn.MeshShape(settings.device_mesh_shape)
-            num_devices_requested =1
-
-            # Prepare device parameters
             updated_device_params = self._prepare_device_params()
-
-            # Configure fabric
             fabric_config = self._configure_fabric(updated_device_params)
-
-            # Initialize mesh device
             mesh_device = self._initialize_mesh_device(mesh_shape, updated_device_params, fabric_config)
-
-            # Verify initialization
-            self._verify_device_initialization(mesh_device, num_devices_requested)
 
             self.logger.info(f"Device {self.device_id}: Successfully created multidevice with {mesh_device.get_num_devices()} devices")
             return mesh_device

--- a/tt-media-server/utils/audio_manager.py
+++ b/tt-media-server/utils/audio_manager.py
@@ -22,16 +22,16 @@ class AudioManager:
         self._logger = TTLogger()
         self._diarization_model = None
         
-        if settings.enable_audio_preprocessing:
+        if settings.allow_audio_preprocessing:
             self._initialize_diarization_model()
 
-    def to_audio_array(self, file):
+    def to_audio_array(self, file, should_preprocess):
         """Convert base64-encoded audio file to numpy array for audio model inference."""
         try:
             audio_bytes = base64.b64decode(file)
             self._validate_file_size(audio_bytes)
             audio_array = self._convert_to_audio_array(audio_bytes)
-            return self._validate_and_truncate_duration(audio_array)
+            return self._validate_and_truncate_duration(audio_array, should_preprocess)
         except Exception as e:
             self._logger.error(f"Failed to decode audio data: {e}")
             raise ValueError(f"Failed to process audio data: {str(e)}")
@@ -234,13 +234,13 @@ class AudioManager:
             self._logger.error(f"Failed to decode WAV file: {e}")
             raise ValueError(f"Could not decode WAV file: {str(e)}")
 
-    def _validate_and_truncate_duration(self, audio_array):
+    def _validate_and_truncate_duration(self, audio_array, should_preprocess):
         duration_seconds = len(audio_array) / settings.default_sample_rate
         
-        # Use extended duration limit when preprocessing is enabled
+        # Use extended duration limit when preprocessing is allowed and requested
         max_duration = (
             settings.max_audio_duration_seconds 
-            if settings.enable_audio_preprocessing and self._diarization_model is not None
+            if should_preprocess and self._diarization_model is not None
             else settings.max_audio_duration_seconds
         )
         


### PR DESCRIPTION
Renamed `enable_audio_preprocessing` → `allow_audio_preprocessing` in settings. It controls if preprocessing is available at all.
Added `is_preprocessing_enabled` field to audio transcription requests which lets individual requests turn preprocessing on/off.
WhisperX preprocessing only happens when both are `True`.

I also updated the whisper demo to be aligned with the latest `tt-metal`: https://github.com/tenstorrent/tt-metal/blob/main/models/demos/whisper/demo/demo.py