### PR TITLE
Uplift Llama 70B WH Galaxy 6U commits to include non-uniform on-device sampling

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1113,8 +1113,8 @@ spec_templates = [
             "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
         ],
         impl=llama3_70b_galaxy_impl,
-        tt_metal_commit="268dd67",
-        vllm_commit="91dddb0",
+        tt_metal_commit="e1aaccb",
+        vllm_commit="2dcee0c",
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.GALAXY,


### PR DESCRIPTION
This PR uplifts the commits for Llama-3.X-70B on WH Galaxy 6U to include:
* https://github.com/tenstorrent/tt-metal/pull/30182
* https://github.com/tenstorrent/vllm/pull/214

Only after the release summary has been shared should this PR be merged