### PR TITLE
Fix Parsing of Device IDs

### DIFF
--- a/tt-media-server/model_services/scheduler.py
+++ b/tt-media-server/model_services/scheduler.py
@@ -326,8 +326,8 @@ class Scheduler:
 
     def _calculate_worker_count(self) -> int:
         try:
-            worker_count = len(self.settings.device_ids.split("),("))
-            self.workers_to_open = self.settings.device_ids.split("),(")
+            worker_count = len(self.settings.device_ids.replace(" ", "").split("),("))
+            self.workers_to_open = self.settings.device_ids.replace(" ", "").split("),(")
             if worker_count < 1:
                 self.logger.error("Worker count is 0")
                 raise ValueError("Worker count must be at least 1")

--- a/tt-media-server/tests/test_scheduler.py
+++ b/tt-media-server/tests/test_scheduler.py
@@ -15,7 +15,7 @@ sys.modules['tt_model_runners.sdxl_runner'] = Mock()
 
 # Mock settings
 mock_settings = Mock()
-mock_settings.device_ids = "0,1"
+mock_settings.device_ids = "(0),(1)"
 mock_settings.max_queue_size = 10
 mock_settings.num_inference_steps = 30
 sys.modules['config.settings'] = Mock()
@@ -441,7 +441,7 @@ class TestScheduler:
         """Test _calculate_worker_count method with valid settings"""
         # Setup
         mock_settings = Mock()
-        mock_settings.device_ids = "0,1,2"  # 3 devices
+        mock_settings.device_ids = "(0),(1),(2)"  # 3 devices
         
         # Execute
         result = scheduler._calculate_worker_count(mock_settings)


### PR DESCRIPTION
## Problem:
A common configuration issue occurred when `settings.device_ids` was not formatted exactly as `(x),(x),...,(x)` - the system would fail if there were any spaces in the device ID string, making it fragile to common formatting variations.

## Implementation: 
- make `settings.device_ids parsing` resilient to whitespace by removing all spaces before processing
- set `mock_settings.device_ids` to use consistent formatting
