### PR TITLE
Update Qwen DeviceModelSpecs for Galaxy

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1009,7 +1009,6 @@ spec_templates = [
                 default_impl=True,
                 override_tt_config={
                     "data_parallel": 4,
-                    "sample_on_device_mode": "decode_only",
                 },
                 env_vars={
                     "TT_MM_THROTTLE_PERF": 3,


### PR DESCRIPTION
This PR:
* Adds a Galaxy DP=4 DeviceModelSpec for Qwen3-8B
* Remove on-device sampling for Galaxy DP=4 Qwen3-32B