### PR TITLE
fix: correct context length validation in get_trace_context_lens()

### DIFF
--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -61,7 +61,7 @@ def get_trace_context_lens(
     Returns:
         List of (input_seq_len, output_seq_len) tuples
     """
-    return [(seq_len, output_len) for seq_len in PADDED_SEQ_LENS if seq_len <= (max_context + output_len)]
+    return [(seq_len, output_len) for seq_len in PADDED_SEQ_LENS if seq_len <= (max_context - output_len)]
 
 
 class PromptClient:


### PR DESCRIPTION
Usually we ensure ISL + OSL ≤ max_context_length; that logic seems broken in `get_trace_context_lens()` cc@tstescoTT 