### PR TITLE
Fix SDXL accuracy bug

### DIFF
--- a/utils/sdxl_accuracy/requirements.txt
+++ b/utils/sdxl_accuracy/requirements.txt
@@ -4,3 +4,4 @@ torch
 open-clip-torch
 scipy
 loguru
+aiohttp


### PR DESCRIPTION
script was failing in Shield CI, [example link](https://github.com/tenstorrent/tt-shield/actions/runs/18633464391/job/53122680436) : 


updated requirements for the accuracy script