### PR TITLE
Qwen3-32B Galaxy + Galaxy T3K stability

### DIFF
--- a/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/benchmarking/benchmark_targets/model_performance_reference.json
@@ -165,6 +165,20 @@
                     }
                 }
             }
+        ],
+        "galaxy_t3k": [
+            {
+                "isl": 128,
+                "osl": 128,
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 63,
+                        "tput_user": 42
+                    }
+                }
+            }
         ]
     },
     "Mistral-7B-Instruct-v0.3": {

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -98,7 +98,7 @@ class TestModelSpecTemplateSystem:
             weights=["test/model"],
         )
         assert template.repacked == 0
-        assert template.version == "0.0.5"
+        assert template.version == "0.1.0"
         assert template.status == ModelStatusTypes.EXPERIMENTAL
         assert template.docker_image is None
 

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -998,7 +998,7 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 2,
+                    "TT_MM_THROTTLE_PERF": 5,
                     "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
                 },
             ),
@@ -1011,7 +1011,7 @@ spec_templates = [
                     "data_parallel": 4,
                 },
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 3,
+                    "TT_MM_THROTTLE_PERF": 5,
                 },
             ),
         ],


### PR DESCRIPTION
This PR:
* Increases the MatMul throttle used for Qwen3-32B on Galaxy + Galaxy T3K to level 5, from level 3 and 2 respectively
  * level 2 and 3 was too low apparently - causing the model to hang during prefill https://github.com/tenstorrent/tt-shield/actions/runs/18619933184
* adds the performance benchmark target for Galaxy_T3K
  * re-uses the T3K target
  
On Dispatch for `--model Qwen3-32B --device galaxy_t3k` run here https://github.com/tenstorrent/tt-shield/actions/runs/18658146165