### PR TITLE
fix: correct impl_id comparison from "tt-transformers" to "tt_transformers"

### DIFF
--- a/vllm-tt-metal-llama3/src/run_vllm_api_server.py
+++ b/vllm-tt-metal-llama3/src/run_vllm_api_server.py
@@ -43,7 +43,7 @@ def handle_code_versions(model_spec_json):
     logger.info(f"commit SHA: {vllm_sha}")
 
     metal_tt_transformers_commit = "8815f46aa191d0b769ed1cc1eeb59649e9c77819"
-    if impl_id == "tt-transformers":
+    if impl_id == "tt_transformers":
         assert is_head_eq_or_after_commit(
             commit=metal_tt_transformers_commit, repo_path=tt_metal_home
         ), "tt-transformers model_impl requires tt-metal: v0.57.0-rc1 or later"


### PR DESCRIPTION
In`model_spec.py`:

```
tt_transformers_impl = ImplSpec(
    impl_id="tt_transformers",
    impl_name="tt-transformers",
    repo_url="https://github.com/tenstorrent/tt-metal",
    code_path="models/tt_transformers",
)
```
So `model_spec_json["impl"]["impl_id"]` contains `tt_transformers` not `tt-transformers`.


Even better,  the whole commit check should be removed. The function `is_head_eq_or_after_commit()` requires the complete git history of the `tt-metal` repo, which could lead to issues when the history is incomplete or inaccessible.

cc @tstescoTT 