### PR TITLE
Remove reduntant environment reading

### DIFF
--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -12,10 +12,10 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     environment: str = "development"
     device_ids: str = "(0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31)"
-    device: Optional[str] = os.getenv("DEVICE") or None
+    device: Optional[str] = None
     max_queue_size: int = 64
     max_batch_size: int = 1
-    model_runner: str = os.getenv("MODEL_RUNNER", ModelRunners.TT_SDXL_TRACE.value)
+    model_runner: str = ModelRunners.TT_SDXL_TRACE.value
     model_service: Optional[str] = None # model_service can be deduced from model_runner using MODEL_SERVICE_RUNNER_MAP
     is_galaxy: bool = False # used for graph device split and class init
     model_weights_path: str = ""


### PR DESCRIPTION
Since config is overridden by settings already no need to double read it