### PR TITLE
used VersionMode.SUGGESTED unless explicit need

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1189,11 +1189,11 @@ spec_templates = [
         system_requirements=SystemRequirements(
             firmware=VersionRequirement(
                 specifier=">=18.6.0",
-                mode=VersionMode.SUGGESTED,
+                mode=VersionMode.STRICT,
             ),
             kmd=VersionRequirement(
                 specifier=">=2.1.0",
-                mode=VersionMode.SUGGESTED,
+                mode=VersionMode.STRICT,
             ),
         ),
         status=ModelStatusTypes.COMPLETE,


### PR DESCRIPTION
# change log

* used VersionMode.SUGGESTED unless explicit need

For `Llama-3.3-70B` on Galaxy and T3K there is not a known explicit need for firmware/KMD minimum versions but we want to include the versions as suggested from what was tested and found to be working.