### PR TITLE
Increase timeout for r1_aime24 and limit concurrency for Qwen3-32B on r1_gpqa_diamond

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -378,6 +378,7 @@ _eval_config_list = [
                     "base_url": "http://127.0.0.1:8000/v1/completions",
                     "tokenizer_backend": "huggingface",
                     "max_length": 65536,
+                    "timeout": "3600",
                 },
                 # gen_kwargs chosen according to https://huggingface.co/Qwen/Qwen3-32B#best-practices
                 gen_kwargs={
@@ -446,6 +447,7 @@ _eval_config_list = [
                         "unit": "percent",
                     },
                 ),
+                max_concurrent=16,
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
                     "model": "Qwen/Qwen3-32B",
@@ -462,6 +464,10 @@ _eval_config_list = [
                     "temperature": 0.6,
                     "top_k": 20,
                     "top_p": 0.95,
+                },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01,
                 },
             ),
         ],
@@ -533,6 +539,7 @@ _eval_config_list = [
                     "base_url": "http://127.0.0.1:8000/v1/completions",
                     "tokenizer_backend": "huggingface",
                     "max_length": 65536,
+                    "timeout": "3600",
                 },
                 gen_kwargs={
                     "stream": "false",

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -98,7 +98,7 @@ class TestModelSpecTemplateSystem:
             weights=["test/model"],
         )
         assert template.repacked == 0
-        assert template.version == "0.0.5"
+        assert template.version == "0.1.0"
         assert template.status == ModelStatusTypes.EXPERIMENTAL
         assert template.docker_image is None
 

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -983,8 +983,8 @@ spec_templates = [
     ModelSpecTemplate(
         weights=["Qwen/Qwen3-32B"],
         impl=tt_transformers_impl,
-        tt_metal_commit="b207c55",
-        vllm_commit="e86b855",
+        tt_metal_commit="2496be4",
+        vllm_commit="2dcee0c",
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.T3K,


### PR DESCRIPTION
This PR addresses two issues related to Qwen3-32B and QwQ-32B evals:
* `r1_aime24` simply makes the models think too much, triggering the 1800sec=30 mins timeout
* `r1_gpqa_diamond` makes Qwen3-32B throttle the KV cache due to high concurrency + each request generating up to 15k reasoning tokens
* `r1_gpqa_diamond` on Qwen3-32B does not have a CI mode limit, causing the nightly to time out at 6 hours

This is addressed by:
* increasing the request timeout to 3600sec=60 mins for both Qwen3-32B and QwQ-32B on `r1_aime24`
* limit `max_concurrent=16` for Qwen3-32B on `r1_gpqa_diamond`
* re-introduce CI mode limit that was taken away in #870

Corresponding CI runs for:
* increased `r1_aime24` timeout https://github.com/tenstorrent/tt-shield/actions/runs/18731759279/job/53481545308
  * passed by `r1_aime24` without timeouts
* `max_concurrent=16` for Qwen3-32B on `r1_gpqa_diamond` https://github.com/tenstorrent/tt-shield/actions/runs/18731778627/job/53432904941
  * notice how in the docker server logs we only swaped requests ~4 times