### PR TITLE
Change Logger Format

### DIFF
--- a/tt-media-server/model_services/base_service.py
+++ b/tt-media-server/model_services/base_service.py
@@ -17,7 +17,7 @@ class BaseService(ABC):
     def __init__(self):
         self.result_futures = {}
         self.scheduler: Scheduler = get_scheduler()
-        self.logger = TTLogger()
+        self.logger = TTLogger("BaseService")
 
     @log_execution_time("Scheduler request processing")
     async def process_request(self, input_request: BaseRequest):

--- a/tt-media-server/model_services/cpu_workload_handler.py
+++ b/tt-media-server/model_services/cpu_workload_handler.py
@@ -15,7 +15,7 @@ from utils.logger import TTLogger
 
 def _process_worker_tasks(task_queue, result_queue, error_queue, worker_name, worker_id, worker_function, worker_context_setup=None):
     """Worker process - similar to device_worker"""
-    logger = TTLogger()
+    logger = TTLogger(f"ProcessWorker-{worker_id}")
     logger.info(f"{worker_name} worker {worker_id} started")
 
     setup_cpu_threading_limits("2")
@@ -59,7 +59,7 @@ class CpuWorkloadHandler:
         self.worker_count = worker_count
         self.worker_function = worker_function
         self.worker_context_setup = worker_context_setup
-        self.logger = TTLogger()
+        self.logger = TTLogger("CpuWorkloadHandler")
         self._init_queues()
 
         self.result_futures = {}

--- a/tt-media-server/model_services/device_worker.py
+++ b/tt-media-server/model_services/device_worker.py
@@ -43,7 +43,7 @@ def setup_worker_environment(worker_id: str):
 
 def device_worker(worker_id: str, task_queue: Queue, result_queue: Queue, warmup_signals_queue: Queue, error_queue: Queue):
     setup_worker_environment(worker_id)
-    logger = TTLogger()
+    logger = TTLogger(f"DeviceWorker-{worker_id}")
 
     device_runner: BaseDeviceRunner = None
     try:

--- a/tt-media-server/model_services/scheduler.py
+++ b/tt-media-server/model_services/scheduler.py
@@ -18,7 +18,7 @@ class Scheduler:
     @log_execution_time("Scheduler init")
     def __init__(self):
         self.settings = get_settings()
-        self.logger = TTLogger()
+        self.logger = TTLogger("Scheduler")
         self._setup_initial_variables()
         self._start_queues()
 

--- a/tt-media-server/resolver/service_resolver.py
+++ b/tt-media-server/resolver/service_resolver.py
@@ -17,7 +17,7 @@ _SUPPORTED_MODEL_SERVICES = {
 
 # Singleton holders per service type
 _service_holders = {}
-logger = TTLogger()
+logger = TTLogger("ServiceResolver")
 _service_holders_lock = threading.Lock()
 
 def service_resolver() -> BaseService:

--- a/tt-media-server/tt_model_runners/forge_runners/forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/forge_runner.py
@@ -27,7 +27,7 @@ class ForgeRunner(BaseDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
         self.device_id = device_id
-        self.logger = TTLogger()
+        self.logger = TTLogger("ForgeRunner")
         self.logger.info(f"ForgeRunner initialized for device {self.device_id}")
         self.logger.info(f"Using XLA runner ({__file__})")
 

--- a/tt-media-server/tt_model_runners/forge_runners/loaders/tools/utils.py
+++ b/tt-media-server/tt_model_runners/forge_runners/loaders/tools/utils.py
@@ -14,7 +14,7 @@ import yaml
 from typing import Optional
 from utils.logger import TTLogger
 
-logger = TTLogger()
+logger = TTLogger("Utils")
 
 def get_file(path):
     """Get a file from local filesystem, cache, or URL.

--- a/tt-media-server/tt_model_runners/mock_runner.py
+++ b/tt-media-server/tt_model_runners/mock_runner.py
@@ -12,7 +12,7 @@ class MockRunner(BaseDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
         self.device_id = device_id
-        self.logger = TTLogger()
+        self.logger = TTLogger("MockRunner")
         self.logger.info(f"MockRunner initialized for device {self.device_id}")
 
     def close_device(self) -> bool:

--- a/tt-media-server/tt_model_runners/sd35_runner.py
+++ b/tt-media-server/tt_model_runners/sd35_runner.py
@@ -17,7 +17,7 @@ class TTSD35Runner(BaseDeviceRunner):
         super().__init__(device_id)
         self.settings = get_settings()
         self.pipeline = None
-        self.logger = TTLogger()
+        self.logger = TTLogger("TTSD35Runner")
         self.mesh_device = self._mesh_device(ttnn.MeshShape(*self.settings.device_mesh_shape))
 
     def get_device(self):

--- a/tt-media-server/tt_model_runners/sdxl_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_runner_trace.py
@@ -25,7 +25,7 @@ class TTSDXLRunnerTrace(BaseDeviceRunner):
         super().__init__(device_id)
         self.tt_sdxl: TtSDXLPipeline = None
         self.settings = get_settings()
-        self.logger = TTLogger()
+        self.logger = TTLogger("TTSDXLRunnerTrace")
         # setup is tensor parallel if device mesh shape first param starts with 2
         self.is_tensor_parallel = self.settings.device_mesh_shape[0] > 1
         if (self.is_tensor_parallel):

--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -66,7 +66,7 @@ class DeviceCleanupError(WhisperModelError):
 class TTWhisperRunner(BaseDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
-        self.logger = TTLogger()
+        self.logger = TTLogger("TTWhisperRunner")
         self.ttnn_device = None
         self.pipeline = None
         self.ttnn_model = None

--- a/tt-media-server/tt_model_runners/yolov4_runner.py
+++ b/tt-media-server/tt_model_runners/yolov4_runner.py
@@ -55,7 +55,7 @@ class InferenceTimeoutError(InferenceError):
 class TTYolov4Runner(BaseDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
-        self.logger = TTLogger()
+        self.logger = TTLogger("TTYolov4Runner")
         self.tt_device = None
         self.model = None
         self.class_names: List[str] = []

--- a/tt-media-server/utils/audio_manager.py
+++ b/tt-media-server/utils/audio_manager.py
@@ -19,7 +19,7 @@ class AudioManager:
     _whisperx_device: str = "cpu"
 
     def __init__(self):
-        self._logger = TTLogger()
+        self._logger = TTLogger("AudioManager")
         self._diarization_model = None
         
         if settings.allow_audio_preprocessing:

--- a/tt-media-server/utils/logger.py
+++ b/tt-media-server/utils/logger.py
@@ -38,8 +38,8 @@ class TTLogger:
 
         # Avoid adding duplicate handlers if the logger is reused.
         if not self.logger.handlers:
-            log_format = '%(asctime)s - %(levelname)s - %(message)s'
-
+            log_format = "%(asctime)s - %(levelname)s - [%(name)s] - %(message)s"
+            
             # Console handler with colored output.
             console_handler = logging.StreamHandler()
             console_handler.setFormatter(ColoredFormatter(log_format))


### PR DESCRIPTION
## Issue:
[#991 Change Logger Format](https://github.com/tenstorrent/tt-inference-server/issues/991)

## Description
With multiple model runners now sharing the same base class, log messages lack clear identification of which specific runner is executing. Instead of manually adding runner names to each log message, we should modify the logger format for better traceability.

## Example
```
2025-10-24 12:40:49,471 - INFO - [ServiceResolver] - Creating new Image service instance
2025-10-24 12:40:50,772 - INFO - [Scheduler] - Starting worker 1
2025-10-24 12:41:54,220 - INFO - [TTSDXLRunnerTrace] - Device 1: Generating input tensors...