### PR TITLE
Fix streaming chunk ID gaps in audio transcription

### DIFF
--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -359,21 +359,23 @@ class TTWhisperRunner(BaseDeviceRunner):
                 else:
                     streaming_display_text = text_part
                 
-                chunk_count += 1
-                
-                # Yield formatted PartialStreamingTranscriptionResponse
-                formatted_chunk = PartialStreamingTranscriptionResponse(
-                    text=TranscriptUtils.clean_text(streaming_display_text),
-                    chunk_id=chunk_count
-                )
-                    
-                yield {
-                    'type': 'streaming_chunk',
-                    'chunk': formatted_chunk,
-                    'segment_id': i,
-                    'speaker': speaker,
-                    'task_id': request._task_id
-                }
+                # Clean text and only yield non-empty chunks
+                cleaned_text = TranscriptUtils.clean_text(streaming_display_text)
+                if cleaned_text:
+                    chunk_count += 1
+
+                    formatted_chunk = PartialStreamingTranscriptionResponse(
+                        text=cleaned_text,
+                        chunk_id=chunk_count
+                    )
+
+                    yield {
+                        'type': 'streaming_chunk',
+                        'chunk': formatted_chunk,
+                        'segment_id': i,
+                        'speaker': speaker,
+                        'task_id': request._task_id
+                    }
                 
                 segment_text_parts.append(text_part)
             
@@ -469,20 +471,22 @@ class TTWhisperRunner(BaseDeviceRunner):
         
         async for chunk in result_generator:
             if isinstance(chunk, str) and chunk != "<EOS>":
-                streaming_chunks.append(chunk)
-                chunk_count += 1
-                
-                # Yield formatted PartialStreamingTranscriptionResponse
-                formatted_chunk = PartialStreamingTranscriptionResponse(
-                    text=TranscriptUtils.clean_text(chunk),
-                    chunk_id=chunk_count
-                )
-                
-                yield {
-                    'type': 'streaming_chunk',
-                    'chunk': formatted_chunk,
-                    'task_id': task_id
-                }
+                # Clean text and only yield non-empty chunks
+                cleaned_text = TranscriptUtils.clean_text(chunk)
+                if cleaned_text:
+                    streaming_chunks.append(chunk)
+                    chunk_count += 1
+
+                    formatted_chunk = PartialStreamingTranscriptionResponse(
+                        text=cleaned_text,
+                        chunk_id=chunk_count
+                    )
+
+                    yield {
+                        'type': 'streaming_chunk',
+                        'chunk': formatted_chunk,
+                        'task_id': task_id
+                    }
         
         final_result = TranscriptionResponse(
             text=TranscriptUtils.concatenate_chunks(streaming_chunks),


### PR DESCRIPTION
Modified both streaming methods to only increment `chunk_count` when actually yielding non-empty chunks

Response before (with audio preprocessing):
```
{"text": "[SPEAKER_00]", "chunk_id": 1}
{"text": "Less", "chunk_id": 4}
{"text": "on", "chunk_id": 5}
{"text": "1", "chunk_id": 6}
{"text": "C", "chunk_id": 7}
{"text": ".", "chunk_id": 8}
{"text": "Exercise", "chunk_id": 9}
{"text": "2", "chunk_id": 10}
{"text": ".", "chunk_id": 11}
{"text": "1", "chunk_id": 12}
{"text": ".", "chunk_id": 13}
{"text": "The", "chunk_id": 14}
{"text": "next", "chunk_id": 15}
{"text": "train", "chunk_id": 16}
{"text": "leaves", "chunk_id": 17}
{"text": "in", "chunk_id": 18}
{"text": "half", "chunk_id": 19}
{"text": "an", "chunk_id": 20}
{"text": "hour", "chunk_id": 21}
{"text": ".", "chunk_id": 22}
{"text": "2", "chunk_id": 23}
{"text": ".", "chunk_id": 24}
{"text": "2", "chunk_id": 25}
{"text": ".", "chunk_id": 26}
{"text": "[SPEAKER_01]", "chunk_id": 28}
{"text": "That", "chunk_id": 31}
{"text": "'s", "chunk_id": 32}
{"text": "made", "chunk_id": 33}
{"text": "me", "chunk_id": 34}
{"text": "feel", "chunk_id": 35}
{"text": "a", "chunk_id": 36}
{"text": "lot", "chunk_id": 37}
{"text": "better", "chunk_id": 38}
{"text": ".", "chunk_id": 39}
{"text": "[SPEAKER_02]", "chunk_id": 41}
{"text": "3", "chunk_id": 44}
{"text": ".", "chunk_id": 45}
{"text": "This", "chunk_id": 46}
{"text": "is", "chunk_id": 47}
{"text": "going", "chunk_id": 48}
{"text": "to", "chunk_id": 49}
{"text": "be", "chunk_id": 50}
{"text": "rather", "chunk_id": 51}
{"text": "painful", "chunk_id": 52}
{"text": ".", "chunk_id": 53}
{"text": "4", "chunk_id": 56}
{"text": ".", "chunk_id": 57}
{"text": "[SPEAKER_03]", "chunk_id": 60}
{"text": "We", "chunk_id": 63}
{"text": "were", "chunk_id": 64}
{"text": "too", "chunk_id": 65}
{"text": "poor", "chunk_id": 66}
{"text": "to", "chunk_id": 67}
{"text": "even", "chunk_id": 68}
{"text": "go", "chunk_id": 69}
{"text": "on", "chunk_id": 70}
{"text": "holiday", "chunk_id": 71}
{"text": ".", "chunk_id": 72}
```

Response after (with audio preprocessing):
```
{"text": "[SPEAKER_00]", "chunk_id": 1}
{"text": "Less", "chunk_id": 2}
{"text": "on", "chunk_id": 3}
{"text": "1", "chunk_id": 4}
{"text": "C", "chunk_id": 5}
{"text": ".", "chunk_id": 6}
{"text": "Exercise", "chunk_id": 7}
{"text": "2", "chunk_id": 8}
{"text": ".", "chunk_id": 9}
{"text": "1", "chunk_id": 10}
{"text": ".", "chunk_id": 11}
{"text": "The", "chunk_id": 12}
{"text": "next", "chunk_id": 13}
{"text": "train", "chunk_id": 14}
{"text": "leaves", "chunk_id": 15}
{"text": "in", "chunk_id": 16}
{"text": "half", "chunk_id": 17}
{"text": "an", "chunk_id": 18}
{"text": "hour", "chunk_id": 19}
{"text": ".", "chunk_id": 20}
{"text": "2", "chunk_id": 21}
{"text": ".", "chunk_id": 22}
{"text": "2", "chunk_id": 23}
{"text": ".", "chunk_id": 24}
{"text": "[SPEAKER_01]", "chunk_id": 25}
{"text": "That", "chunk_id": 26}
{"text": "'s", "chunk_id": 27}
{"text": "made", "chunk_id": 28}
{"text": "me", "chunk_id": 29}
{"text": "feel", "chunk_id": 30}
{"text": "a", "chunk_id": 31}
{"text": "lot", "chunk_id": 32}
{"text": "better", "chunk_id": 33}
{"text": ".", "chunk_id": 34}
{"text": "[SPEAKER_02]", "chunk_id": 35}
{"text": "3", "chunk_id": 36}
{"text": ".", "chunk_id": 37}
{"text": "This", "chunk_id": 38}
{"text": "is", "chunk_id": 39}
{"text": "going", "chunk_id": 40}
{"text": "to", "chunk_id": 41}
{"text": "be", "chunk_id": 42}
{"text": "rather", "chunk_id": 43}
{"text": "painful", "chunk_id": 44}
{"text": ".", "chunk_id": 45}
{"text": "4", "chunk_id": 46}
{"text": ".", "chunk_id": 47}
{"text": "[SPEAKER_03]", "chunk_id": 48}
{"text": "We", "chunk_id": 49}
{"text": "were", "chunk_id": 50}
{"text": "too", "chunk_id": 51}
{"text": "poor", "chunk_id": 52}
{"text": "to", "chunk_id": 53}
{"text": "even", "chunk_id": 54}
{"text": "go", "chunk_id": 55}
{"text": "on", "chunk_id": 56}
{"text": "holiday", "chunk_id": 57}
{"text": ".", "chunk_id": 58}
```