### PR TITLE
Apply level 5 MM throttle to all Galaxy ModelSpecs

### DIFF
--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -98,7 +98,7 @@ class TestModelSpecTemplateSystem:
             weights=["test/model"],
         )
         assert template.repacked == 0
-        assert template.version == "0.1.0"
+        assert template.version == "0.2.0"
         assert template.status == ModelStatusTypes.EXPERIMENTAL
         assert template.docker_image is None
 

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -965,6 +965,7 @@ spec_templates = [
                 max_context=40960,
                 default_impl=True,
                 env_vars={
+                    "TT_MM_THROTTLE_PERF": 5,
                     "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
                 },
             ),
@@ -975,6 +976,9 @@ spec_templates = [
                 default_impl=True,
                 override_tt_config={
                     "data_parallel": 4,
+                },
+                env_vars={
+                    "TT_MM_THROTTLE_PERF": 5,
                 },
             ),
         ],
@@ -998,7 +1002,7 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 2,
+                    "TT_MM_THROTTLE_PERF": 5,
                     "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
                 },
             ),
@@ -1011,7 +1015,7 @@ spec_templates = [
                     "data_parallel": 4,
                 },
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 3,
+                    "TT_MM_THROTTLE_PERF": 5,
                 },
             ),
         ],
@@ -1072,7 +1076,7 @@ spec_templates = [
                     "data_parallel": 4,
                 },
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 3,
+                    "TT_MM_THROTTLE_PERF": 5,
                 },
             ),
             DeviceModelSpec(
@@ -1081,6 +1085,7 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 env_vars={
+                    "TT_MM_THROTTLE_PERF": 5,
                     "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
                 },
             ),
@@ -1114,6 +1119,9 @@ spec_templates = [
                     "trace_region_size": 27381760,
                     "data_parallel": 4,
                 },
+                env_vars={
+                    "TT_MM_THROTTLE_PERF": 5,
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.GALAXY_T3K,
@@ -1124,6 +1132,7 @@ spec_templates = [
                     "trace_region_size": 27381760,
                 },
                 env_vars={
+                    "TT_MM_THROTTLE_PERF": 5,
                     "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
                 },
             ),
@@ -1292,6 +1301,7 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 env_vars={
+                    "TT_MM_THROTTLE_PERF": 5,
                     "MAX_PREFILL_CHUNK_SIZE": "32",
                     "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
                     "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
@@ -1538,6 +1548,7 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 env_vars={
+                    "TT_MM_THROTTLE_PERF": 5,
                     "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
                 },
             ),


### PR DESCRIPTION
This PR addresses #966 and applies the workaround to all WH Galaxy 6U `ModelSpecTemplate`s