### PR TITLE
default_throttle_level missing a type annotation

### DIFF
--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
     worker_check_sleep_timeout: float = 30.0
     default_inference_timeout_seconds: int = 90
     allow_deep_reset: bool = False
-    default_throttle_level = "5"
+    default_throttle_level: str = "5"
     # image specific settings
     num_inference_steps: int = 20 # has to be hardcoded since we cannot allow per image currently
     image_return_format: str = "JPEG"


### PR DESCRIPTION
Pydantic v2 requires all fields to have type annotations

<img width="1171" height="680" alt="Screenshot 2025-10-28 at 11 30 41" src="https://github.com/user-attachments/assets/6eb163fe-eac3-4289-9e05-9f3916c8ef5d" />
