### PR TITLE
Migrate to hf CLI (replace deprecated huggingface-cli)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -545,7 +545,7 @@ setup_weights_huggingface() {
     pip install --upgrade pip setuptools wheel
     pip install "huggingface_hub[cli]"
 
-    # Step 5: Download model using huggingface-cli
+    # Step 5: Download model using hf
     echo "Downloading model from Hugging Face Hub..."
     # stop timeout issue: https://huggingface.co/docs/huggingface_hub/en/guides/cli#download-timeout
     export HF_HUB_DOWNLOAD_TIMEOUT=60
@@ -553,15 +553,15 @@ setup_weights_huggingface() {
     if [ "${HF_MODEL_REPO_ID}" = "Qwen/Qwen2.5-72B-Instruct" ] || [ "${HF_MODEL_REPO_ID}" = "Qwen/Qwen2.5-7B-Instruct" ]; then
         # download full repo
         HF_REPO_PATH_FILTER="*"
-        huggingface-cli download "${HF_MODEL_REPO_ID}" 
+        hf download "${HF_MODEL_REPO_ID}" 
     elif [ "${HF_MODEL_REPO_ID}" = "deepseek-ai/DeepSeek-R1-Distill-Llama-70B" ]; then
         # download full repo
         HF_REPO_PATH_FILTER="*"
-        huggingface-cli download "${HF_MODEL_REPO_ID}" 
+        hf download "${HF_MODEL_REPO_ID}" 
     else
         HF_REPO_PATH_FILTER="original/*"
         # using default Llama original convention for model weights
-        huggingface-cli download "${HF_MODEL_REPO_ID}" \
+        hf download "${HF_MODEL_REPO_ID}" \
             original/params.json \
             original/tokenizer.model \
             original/consolidated.* \
@@ -570,7 +570,7 @@ setup_weights_huggingface() {
     fi
 
     if [ $? -ne 0 ]; then
-        echo "⛔ Error occured during: huggingface-cli download ${HF_MODEL_REPO_ID}"
+        echo "⛔ Error occured during: hf download ${HF_MODEL_REPO_ID}"
         echo "🔔 check for common issues:"
         echo "  1. 401 Unauthorized error occurred."
         echo "    For example:"
@@ -580,7 +580,7 @@ setup_weights_huggingface() {
         exit 1
     fi
 
-    # symlinks are broken for huggingface-cli download with --local-dir option
+    # symlinks are broken for hf download with --local-dir option
     # see: https://github.com/huggingface/huggingface_hub/pull/2223
     # to use symlinks, find most recent snapshot and create symlink to that
     WEIGHTS_DIR=${PERSISTENT_VOLUME}/model_weights/${MODEL_NAME}

--- a/setup.sh
+++ b/setup.sh
@@ -570,7 +570,7 @@ setup_weights_huggingface() {
     fi
 
     if [ $? -ne 0 ]; then
-        echo "⛔ Error occured during: hf download ${HF_MODEL_REPO_ID}"
+        echo "⛔ Error occurred during: hf download ${HF_MODEL_REPO_ID}"
         echo "🔔 check for common issues:"
         echo "  1. 401 Unauthorized error occurred."
         echo "    For example:"

--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -483,8 +483,6 @@ class HostSetupManager:
         os.environ["HF_HUB_DOWNLOAD_TIMEOUT"] = "60"
         os.environ["HF_TOKEN"] = self.hf_token
         hf_cli = venv_dir / "bin" / "hf"
-        if not hf_cli.exists():
-            hf_cli = venv_dir / "bin" / "huggingface-cli"
         hf_repo = self.model_spec.hf_model_repo
         if hf_repo.startswith("meta-llama"):
             # fmt: off

--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -482,7 +482,9 @@ class HostSetupManager:
         )
         os.environ["HF_HUB_DOWNLOAD_TIMEOUT"] = "60"
         os.environ["HF_TOKEN"] = self.hf_token
-        hf_cli = venv_dir / "bin" / "huggingface-cli"
+        hf_cli = venv_dir / "bin" / "hf"
+        if not hf_cli.exists():
+            hf_cli = venv_dir / "bin" / "huggingface-cli"
         hf_repo = self.model_spec.hf_model_repo
         if hf_repo.startswith("meta-llama"):
             # fmt: off


### PR DESCRIPTION
### Summary
Fix CI FileNotFoundError by using hf (with Python fallback to huggingface-cli), no behavior changes.

### Changes
- `tt-inference-server/workflows/setup_host.py`: prefer venv/bin/hf, fallback to huggingface-cli.
- `tt-inference-server/setup.sh`: huggingface-cli download → hf download; messages updated.

### Notes
huggingface_hub[cli] remains installed; snapshot handling unchanged.

CI run with the changes: https://github.com/tenstorrent/tt-shield/actions/runs/18874387371/job/53872440822