### PR TITLE
Improvements for tt-xla device runners

### DIFF
--- a/tt-media-server/tt_model_runners/forge_runners/forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/forge_runner.py
@@ -24,8 +24,8 @@ from PIL import Image
 from .loaders.tools.utils import output_to_tensor
 
 xla_backend = "tt"
-runs_on_cpu = False
-use_optimizer = False
+runs_on_cpu = os.getenv("RUNS_ON_CPU", "false").lower() == "true"
+use_optimizer = os.getenv("USE_OPTIMIZER", "true").lower() == "true"
 
 
 class ForgeRunner(BaseDeviceRunner):

--- a/tt-media-server/tt_model_runners/forge_runners/loaders/resnet/pytorch/loader.py
+++ b/tt-media-server/tt_model_runners/forge_runners/loaders/resnet/pytorch/loader.py
@@ -116,8 +116,11 @@ class ModelLoader(ForgeModel):
     }
 
     # Default variant to use
-    # DEFAULT_VARIANT = ModelVariant.RESNET_50_HF # ❌
-    DEFAULT_VARIANT = ModelVariant.RESNET_18 # ✅
+    DEFAULT_VARIANT = ModelVariant.RESNET_50_HF # ❌
+    # DEFAULT_VARIANT = ModelVariant.RESNET_18 # ✅
+    # DEFAULT_VARIANT = ModelVariant.RESNET_34 # ✅
+    # DEFAULT_VARIANT = ModelVariant.RESNET_101 # ✅
+    # DEFAULT_VARIANT = ModelVariant.RESNET_50_HIGH_RES # ✅
 
     def __init__(self, variant: Optional[ModelVariant] = None):
         """Initialize ModelLoader with specified variant.
@@ -334,7 +337,7 @@ class ModelLoader(ForgeModel):
     def output_to_prediction(self, output):
         """Convert model output tensor to human-readable predictions dictionary."""
         compiled_model_top1_class_prob, compiled_model_top1_class_idx = output.softmax(-1).max(-1)   
-        prob = compiled_model_top1_class_prob[0].item() 
+        prob = compiled_model_top1_class_prob[0].item() * 100
         class_idx = compiled_model_top1_class_idx[0].item()    
         predicted_label = get_label_for_index(class_idx)
         print(f"Predicted class index: {class_idx}, label: {predicted_label}, confidence: {prob:.4f}%")            

--- a/tt-media-server/tt_model_runners/forge_runners/loaders/resnet/pytorch/loader.py
+++ b/tt-media-server/tt_model_runners/forge_runners/loaders/resnet/pytorch/loader.py
@@ -116,11 +116,7 @@ class ModelLoader(ForgeModel):
     }
 
     # Default variant to use
-    DEFAULT_VARIANT = ModelVariant.RESNET_50_HF # ❌
-    # DEFAULT_VARIANT = ModelVariant.RESNET_18 # ✅
-    # DEFAULT_VARIANT = ModelVariant.RESNET_34 # ✅
-    # DEFAULT_VARIANT = ModelVariant.RESNET_101 # ✅
-    # DEFAULT_VARIANT = ModelVariant.RESNET_50_HIGH_RES # ✅
+    DEFAULT_VARIANT = ModelVariant.RESNET_50_HF
 
     def __init__(self, variant: Optional[ModelVariant] = None):
         """Initialize ModelLoader with specified variant.

--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
-pjrt-plugin-tt==0.4.0
+pjrt-plugin-tt==0.5.0.dev20251017
 torchvision
 
 timm # input preprocessing

--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
-pjrt-plugin-tt==0.5.0.dev20251017
+pjrt-plugin-tt==0.5.0
 torchvision
 
 timm # input preprocessing


### PR DESCRIPTION
Use latest tt-xla version and enable optimizer
- add runtime program cache support
- bump tt-xla version to 0.5.0
- enable optimizer