### PR TITLE
Fix DeviceModelSpec._infer_data() init order to set defaults before using them

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -215,6 +215,17 @@ class DeviceModelSpec:
 
     def _infer_data(self):
         """Infer missing data fields from other specification values."""
+        # Note: ONLY run this in __post_init__
+        # need to use __setattr__ because instance is frozen
+        # Set default concurrency and context if not provided FIRST
+        if not self.max_concurrency:
+            _default_max_concurrent = 32
+            object.__setattr__(self, "max_concurrency", _default_max_concurrent)
+
+        if not self.max_context:
+            _default_max_context = 128 * 1024
+            object.__setattr__(self, "max_context", _default_max_context)
+
         default_vllm_args = {
             "block_size": "64",
             "max_model_len": str(self.max_context),
@@ -227,17 +238,6 @@ class DeviceModelSpec:
         }
         merged_vllm_args = {**default_vllm_args, **self.vllm_args}
         object.__setattr__(self, "vllm_args", merged_vllm_args)
-
-        # Note: ONLY run this in __post_init__
-        # need to use __setattr__ because instance is frozen
-        # Set default concurrency and context if not provided
-        if not self.max_concurrency:
-            _default_max_concurrent = 32
-            object.__setattr__(self, "max_concurrency", _default_max_concurrent)
-
-        if not self.max_context:
-            _default_max_context = 128 * 1024
-            object.__setattr__(self, "max_context", _default_max_context)
 
         self._infer_env_vars()
 


### PR DESCRIPTION
`self.max_concurrency` and `self.max_context` must be used only after they are initialized.

cc @tstescoTT 