### PR TITLE
remove max_context and max_concurrency default value setting where is was never used because args were required

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -228,17 +228,6 @@ class DeviceModelSpec:
         merged_vllm_args = {**default_vllm_args, **self.vllm_args}
         object.__setattr__(self, "vllm_args", merged_vllm_args)
 
-        # Note: ONLY run this in __post_init__
-        # need to use __setattr__ because instance is frozen
-        # Set default concurrency and context if not provided
-        if not self.max_concurrency:
-            _default_max_concurrent = 32
-            object.__setattr__(self, "max_concurrency", _default_max_concurrent)
-
-        if not self.max_context:
-            _default_max_context = 128 * 1024
-            object.__setattr__(self, "max_context", _default_max_context)
-
         self._infer_env_vars()
 
     def _infer_env_vars(self):


### PR DESCRIPTION
# change log

* remove max_context and max_concurrency default value setting where is was never used because args were required

The code here is a bit confusing because DeviceModelSpec has these as required arguments they cannot not be initialized.
```
Traceback (most recent call last):
  File "run.py", line 16, in <module>
    from workflows.model_spec import MODEL_SPECS, ModelSpec, get_runtime_model_spec
  File "/home/tstesco/projects/tt-inference-server/workflows/model_spec.py", line 1116, in <module>
    DeviceModelSpec(
TypeError: __init__() missing 2 required positional arguments: 'max_concurrency' and 'max_context'
```

In any case the defaults should not be set this way so I am removing confusing default setting nop that never gets called.


This addresses issue in https://github.com/tenstorrent/tt-inference-server/pull/1006