### PR TITLE
Replace huggingface-cli with hf

### DIFF
--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -477,12 +477,12 @@ class HostSetupManager:
             check=True,
         )
         subprocess.run(
-            [str(venv_python), "-m", "pip", "install", "huggingface_hub[cli]"],
+            [str(venv_python), "-m", "pip", "install", "huggingface_hub"],
             check=True,
         )
         os.environ["HF_HUB_DOWNLOAD_TIMEOUT"] = "60"
         os.environ["HF_TOKEN"] = self.hf_token
-        hf_cli = venv_dir / "bin" / "huggingface-cli"
+        hf_cli = venv_dir / "bin" / "hf"
         hf_repo = self.model_spec.hf_model_repo
         if hf_repo.startswith("meta-llama"):
             # fmt: off


### PR DESCRIPTION
`huggingface-cli` does not exist anymore. Use `hf` instead.

Fixes the following warning:

```
WARNING: huggingface-hub 1.0.1 does not provide the extra 'cli'

```

And, fixes the following error:

```
$ python3 run.py --model Llama-3.2-90B-Vision  --device t3k --workflow server --docker-server  --dev-mode   --skip-system-sw-validation --impl tt-transformers

...

2025-10-30 07:56:55,702 - setup_host.py:508 - INFO: Downloading model from Hugging Face: meta-llama/Llama-3.2-90B-Vision
2025-10-30 07:56:55,702 - setup_host.py:509 - INFO: Command: /home/user/tt-inference-server/.workflow_venvs/.venv_hf_setup/bin/huggingface-cli download meta-llama/Llama-3.2-90B-Vision original/params.json original/tokenizer.model 'original/consolidated.*'
Traceback (most recent call last):
  File "/home/user/tt-inference-server/run.py", line 508, in <module>
    sys.exit(main())
  File "/home/user/tt-inference-server/run.py", line 466, in main
    setup_config = setup_host(
  File "/home/user/tt-inference-server/workflows/setup_host.py", line 567, in setup_host
    manager.run_setup()
  File "/home/user/tt-inference-server/workflows/setup_host.py", line 552, in run_setup
    self.setup_weights()
  File "/home/user/tt-inference-server/workflows/setup_host.py", line 539, in setup_weights
    self.setup_weights_huggingface()
  File "/home/user/tt-inference-server/workflows/setup_host.py", line 510, in setup_weights_huggingface
    result = subprocess.run(cmd)
  File "/usr/lib/python3.10/subprocess.py", line 503, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.10/subprocess.py", line 1863, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/home/user/tt-inference-server/.workflow_venvs/.venv_hf_setup/bin/huggingface-cli'
```

Fixes: https://github.com/tenstorrent/tt-inference-server/issues/423

cc @tstescoTT 