### PR TITLE
Llama-3.1-8B trace region sizes

### DIFF
--- a/benchmarking/benchmark_config.py
+++ b/benchmarking/benchmark_config.py
@@ -34,8 +34,6 @@ class BenchmarkConfig:
 BATCH_1_BENCHMARK_COMMON_ISL_OSL_PAIRS = [
     (128, 128),
     (128, 1024),
-    (256, 128),
-    (512, 128),
     (1024, 128),
     (2048, 128),
     (3072, 128),
@@ -48,9 +46,6 @@ BATCH_1_BENCHMARK_COMMON_ISL_OSL_PAIRS = [
 MAX_CONCURRENCY_BENCHMARK_COMMON_ISL_OSL_PAIRS = [
     (128, 128),
     (128, 1024),
-    (256, 128),
-    (512, 128),
-    (1024, 128),
     (2048, 128),
     (2048, 2048),
     (3000, 64),

--- a/benchmarking/benchmark_config.py
+++ b/benchmarking/benchmark_config.py
@@ -34,6 +34,8 @@ class BenchmarkConfig:
 BATCH_1_BENCHMARK_COMMON_ISL_OSL_PAIRS = [
     (128, 128),
     (128, 1024),
+    (256, 128),
+    (512, 128),
     (1024, 128),
     (2048, 128),
     (3072, 128),
@@ -46,6 +48,9 @@ BATCH_1_BENCHMARK_COMMON_ISL_OSL_PAIRS = [
 MAX_CONCURRENCY_BENCHMARK_COMMON_ISL_OSL_PAIRS = [
     (128, 128),
     (128, 1024),
+    (256, 128),
+    (512, 128),
+    (1024, 128),
     (2048, 128),
     (2048, 2048),
     (3000, 64),

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1404,7 +1404,7 @@ spec_templates = [
     ModelSpecTemplate(
         weights=["meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-8B-Instruct"],
         impl=tt_transformers_impl,
-        tt_metal_commit="9b67e09",
+        tt_metal_commit="20fbdc2",
         vllm_commit="a91b644",
         device_model_specs=[
             DeviceModelSpec(
@@ -1470,7 +1470,7 @@ spec_templates = [
     ModelSpecTemplate(
         weights=["meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-8B-Instruct"],
         impl=tt_transformers_impl,
-        tt_metal_commit="55fd115",
+        tt_metal_commit="20fbdc2",
         vllm_commit="aa4ae1e",
         device_model_specs=[
             DeviceModelSpec(

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1413,7 +1413,7 @@ spec_templates = [
                 max_context=64 * 1024,
                 default_impl=True,
                 override_tt_config= {
-                    "trace_region_size": 31000000,
+                    "trace_region_size": 24000000,
                 },
             ),
             DeviceModelSpec(

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1467,7 +1467,7 @@ spec_templates = [
     ModelSpecTemplate(
         weights=["meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-8B-Instruct"],
         impl=tt_transformers_impl,
-        tt_metal_commit="9b67e09",
+        tt_metal_commit="55fd115",
         vllm_commit="aa4ae1e",
         device_model_specs=[
             DeviceModelSpec(

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1412,18 +1412,27 @@ spec_templates = [
                 max_concurrency=32,
                 max_context=64 * 1024,
                 default_impl=True,
+                override_tt_config= {
+                    "trace_region_size": 33000000,
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.N300,
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                override_tt_config= {
+                    "trace_region_size": 33000000,
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.T3K,
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                override_tt_config= {
+                    "trace_region_size": 33000000,
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.GPU,
@@ -1472,6 +1481,7 @@ spec_templates = [
                 override_tt_config={
                     "data_parallel": 4,
                     "sample_on_device_mode": "decode_only",
+                    "trace_region_size": 33000000,
                 },
             ),
         ],

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1431,7 +1431,7 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 override_tt_config= {
-                    "trace_region_size": 33000000,
+                    "trace_region_size": 50000000,
                 },
             ),
             DeviceModelSpec(
@@ -1499,6 +1499,7 @@ spec_templates = [
                 max_context=64 * 1024,
                 default_impl=True,
                 override_tt_config={
+                    "trace_region_size": 50000000,
                     "data_parallel": 4,
                     "sample_on_device_mode": "decode_only",
                 },

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1413,7 +1413,7 @@ spec_templates = [
                 max_context=64 * 1024,
                 default_impl=True,
                 override_tt_config= {
-                    "trace_region_size": 33000000,
+                    "trace_region_size": 31000000,
                 },
             ),
             DeviceModelSpec(

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1404,7 +1404,7 @@ spec_templates = [
     ModelSpecTemplate(
         weights=["meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-8B-Instruct"],
         impl=tt_transformers_impl,
-        tt_metal_commit="20fbdc2",
+        tt_metal_commit="9b67e09",
         vllm_commit="a91b644",
         device_model_specs=[
             DeviceModelSpec(
@@ -1412,9 +1412,6 @@ spec_templates = [
                 max_concurrency=32,
                 max_context=64 * 1024,
                 default_impl=True,
-                override_tt_config= {
-                    "trace_region_size": 25000000,
-                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.N300,
@@ -1470,7 +1467,7 @@ spec_templates = [
     ModelSpecTemplate(
         weights=["meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-8B-Instruct"],
         impl=tt_transformers_impl,
-        tt_metal_commit="20fbdc2",
+        tt_metal_commit="9b67e09",
         vllm_commit="aa4ae1e",
         device_model_specs=[
             DeviceModelSpec(
@@ -1513,6 +1510,7 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 env_vars={
+                    "trace_region_size": 50000000,
                     "TT_MM_THROTTLE_PERF": 5,
                     "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
                 },

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1413,7 +1413,7 @@ spec_templates = [
                 max_context=64 * 1024,
                 default_impl=True,
                 override_tt_config= {
-                    "trace_region_size": 24000000,
+                    "trace_region_size": 25000000,
                 },
             ),
             DeviceModelSpec(


### PR DESCRIPTION
Llama-3.1-8B supports prefill tracing from https://github.com/tenstorrent/tt-metal/pull/29827

N150 - Up to 1k sequence length, as op-to-op gaps are too small above that limit
N300, T3K, Galaxy - Up to 8k sequence length

Due to memory limitations, the trace region sizes need to be different between platforms.