### PR TITLE
Add Forge vLLM Embedding Runner

### DIFF
--- a/tt-media-server/README.md
+++ b/tt-media-server/README.md
@@ -241,6 +241,14 @@ The TT Inference Server can be configured using environment variables or by modi
 |---------------------|---------------|-------------|
 | `DEFAULT_INFERENCE_TIMEOUT_SECONDS` | `90` | Default timeout for inference requests in seconds (1 minute) |
 
+## Text Processing Settings
+
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| `MAX_MODEL_LENGTH` | `2**14` | Sets the maximum number of tokens that can be processed per sequence, including both input and output tokens. Determines the model's context window size. Must be a power of two. |
+| `MAX_NUM_BATCHED_TOKENS` | `2**14` | Sets the maximum total number of tokens processed in a single iteration across all active sequences. Higher values improve throughput but increase memory usage and latency. Must be a power of two. |
+| `MAX_NUM_SEQS` | `1` | Defines the maximum number of sequences that can be batched and processed simultaneously in one iteration. |
+
 ## Image Processing Settings
 
 | Environment Variable | Default Value | Description |

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -15,6 +15,7 @@ class SupportedModels(Enum):
     DISTIL_WHISPER_LARGE_V3 = "distil-whisper/distil-large-v3"
     OPENAI_WHISPER_LARGE_V3 = "openai/whisper-large-v3"
     PYANNOTE_SPEAKER_DIARIZATION = "pyannote/speaker-diarization-3.0"
+    QWEN_3_EMBEDDING_4B = "Qwen/Qwen3-Embedding-4B"
 
 # MODEL environment variable
 # Model names should be unique
@@ -31,6 +32,7 @@ class ModelNames(Enum):
     MICROSOFT_RESNET_50 = "microsoft/resnet-50"
     VOVNET = "vovnet"
     MOBILENETV2 = "mobilenetv2"
+    QWEN_3_EMBEDDING_4B = "Qwen3-Embedding-4B"
 
 class ModelRunners(Enum):
     TT_SDXL_TRACE = "tt-sdxl-trace"
@@ -43,6 +45,7 @@ class ModelRunners(Enum):
     TT_WHISPER = "tt-whisper"
     TT_YOLOV4 = "tt-yolov4"
     VLLMForge = "vllm_forge"
+    VLLMForge_QWEN_EMBEDDING = "vllmforge_qwen_embedding"
     TT_XLA_RESNET = "tt-xla-resnet"
     TT_XLA_VOVNET = "tt-xla-vovnet"
     TT_XLA_MOBILENETV2 = "tt-xla-mobilenetv2"
@@ -72,6 +75,10 @@ MODEL_SERVICE_RUNNER_MAP = {
         ModelRunners.TT_XLA_VOVNET,
         ModelRunners.TT_XLA_MOBILENETV2,
         ModelRunners.TT_YOLOV4},
+    ModelServices.LLM: {
+        ModelRunners.VLLMForge,
+        ModelRunners.VLLMForge_QWEN_EMBEDDING
+    }
 }
 
 MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
@@ -109,6 +116,9 @@ MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.TT_XLA_MOBILENETV2: {
         ModelNames.MOBILENETV2
     },
+    ModelRunners.VLLMForge_QWEN_EMBEDDING: {
+        ModelNames.QWEN_3_EMBEDDING_4B
+    }
 }
 
 # DEVICE environment variable

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -45,6 +45,10 @@ class Settings(BaseSettings):
     # Timeout settings
     default_inference_timeout_seconds: int = 90
 
+    # Text processing settings
+    max_num_batched_tokens: int = 64
+    max_num_seqs: int = 2
+
     # Image processing settings
     num_inference_steps: int = 20 # has to be hardcoded since we cannot allow per image currently
     image_return_format: str = "JPEG"

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -46,8 +46,8 @@ class Settings(BaseSettings):
     default_inference_timeout_seconds: int = 90
 
     # Text processing settings
-    max_model_length: int = 64
-    max_num_batched_tokens: int = 64
+    max_model_length: int = 2**14
+    max_num_batched_tokens: int = 2**14
     max_num_seqs: int = 1
 
     # Image processing settings

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -46,8 +46,9 @@ class Settings(BaseSettings):
     default_inference_timeout_seconds: int = 90
 
     # Text processing settings
+    max_model_length: int = 64
     max_num_batched_tokens: int = 64
-    max_num_seqs: int = 2
+    max_num_seqs: int = 1
 
     # Image processing settings
     num_inference_steps: int = 20 # has to be hardcoded since we cannot allow per image currently

--- a/tt-media-server/domain/text_embedding_request.py
+++ b/tt-media-server/domain/text_embedding_request.py
@@ -3,6 +3,9 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 from domain.base_request import BaseRequest
+from pydantic import Field
+from typing import Optional
 
 class TextEmbeddingRequest(BaseRequest):
     input: str
+    dimensions: Optional[int] = Field(default=None, ge=0)

--- a/tt-media-server/domain/text_embedding_request.py
+++ b/tt-media-server/domain/text_embedding_request.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+from domain.base_request import BaseRequest
+
+class TextEmbeddingRequest(BaseRequest):
+    input: str

--- a/tt-media-server/open_ai_api/__init__.py
+++ b/tt-media-server/open_ai_api/__init__.py
@@ -12,8 +12,8 @@ from open_ai_api import audio, cnn, image, tt_maintenance_api, llm
 
 if settings.model_service == ModelServices.IMAGE.value:
     api_router.include_router(image.router, prefix='/image', tags=['Image processing'])
-if settings.model_service == ModelServices.LLM.value:
-    api_router.include_router(llm.router, prefix='/chat', tags=['Text completions'])
+elif settings.model_service == ModelServices.LLM.value:
+    api_router.include_router(llm.router, prefix='/v1', tags=['Text processing'])
 elif settings.model_service == ModelServices.AUDIO.value:
     api_router.include_router(audio.router, prefix='/audio', tags=['Audio processing'])
 elif settings.model_service == ModelServices.CNN.value:

--- a/tt-media-server/open_ai_api/llm.py
+++ b/tt-media-server/open_ai_api/llm.py
@@ -35,6 +35,13 @@ async def create_embedding(
     service: BaseService = Depends(service_resolver),
     api_key: str = Security(get_api_key)
 ):
+    """
+    Create text embeddings based on the provided request.
+    Returns:
+        JSONResponse: The generated embeddings as a list of float vectors.
+    Raises:
+        HTTPException: If embedding generation fails.
+    """
     try:
         return await service.process_request(text_embedding_request)
     except Exception as e:
@@ -42,6 +49,6 @@ async def create_embedding(
     
 router = APIRouter()
 if settings.model_runner == ModelRunners.VLLMForge_QWEN_EMBEDDING.value:
-    router.include_router(embedding_router, tags=['Text processing'])
+    router.include_router(embedding_router)
 else:
-    router.include_router(completions_router, tags=['Text processing'])
+    router.include_router(completions_router)

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -17,6 +17,7 @@ AVAILABLE_RUNNERS = {
     ModelRunners.TT_WHISPER: lambda wid: __import__("tt_model_runners.whisper_runner", fromlist=["TTWhisperRunner"]).TTWhisperRunner(wid),
     ModelRunners.TT_YOLOV4: lambda wid: __import__("tt_model_runners.yolov4_runner", fromlist=["TTYolov4Runner"]).TTYolov4Runner(wid),
     ModelRunners.VLLMForge: lambda wid: __import__("tt_model_runners.vllm_forge_runner", fromlist=["VLLMForgeRunner"]).VLLMForgeRunner(wid),
+    ModelRunners.VLLMForge_QWEN_EMBEDDING: lambda wid: __import__("tt_model_runners.vllm_forge_qwen_embedding_runner", fromlist=["VLLMForgeEmbeddingQwenRunner"]).VLLMForgeEmbeddingQwenRunner(wid),
     ModelRunners.TT_XLA_RESNET: lambda wid: __import__("tt_model_runners.forge_runners.runners", fromlist=["ForgeResnetRunner"]).ForgeResnetRunner(wid),
     ModelRunners.TT_XLA_VOVNET: lambda wid: __import__("tt_model_runners.forge_runners.runners", fromlist=["ForgeVovnetRunner"]).ForgeVovnetRunner(wid),
     ModelRunners.TT_XLA_MOBILENETV2: lambda wid: __import__("tt_model_runners.forge_runners.runners", fromlist=["ForgeMobilenetv2Runner"]).ForgeMobilenetv2Runner(wid),

--- a/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
@@ -34,14 +34,15 @@ class VLLMForgeEmbeddingQwenRunner(BaseDeviceRunner):
             "model": settings.SupportedModels.QWEN_3_EMBEDDING_4B.value,
             "task": "embed",
             "dtype": "bfloat16",
-            "max_model_len": 64,
             "disable_sliding_window": True,
+            "enable_prefix_caching": False,
+            "max_model_len": self.settings.max_model_length,
             "max_num_batched_tokens": self.settings.max_num_batched_tokens,
-            "max_num_seqs": self.settings.max_num_seqs,
+            "max_num_seqs": self.settings.max_num_seqs
         }
         self.llm = vllm.LLM(**llm_args)
 
-        output_embedding = self.llm.embed(prompts)
+        self.llm.embed(prompts)
         self.logger.info(f"Device {self.device_id}: Model warmup completed")
 
         return True

--- a/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
@@ -36,8 +36,8 @@ class VLLMForgeEmbeddingQwenRunner(BaseDeviceRunner):
             "dtype": "bfloat16",
             "max_model_len": 64,
             "disable_sliding_window": True,
-            "max_num_batched_tokens": 64,
-            "max_num_seqs": 2,
+            "max_num_batched_tokens": self.settings.max_num_batched_tokens,
+            "max_num_seqs": self.settings.max_num_seqs,
         }
         self.llm = vllm.LLM(**llm_args)
 

--- a/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
@@ -1,0 +1,59 @@
+
+from config import settings
+from config.settings import get_settings
+from domain.text_completion_request import TextCompletionRequest
+from domain.text_embedding_request import TextEmbeddingRequest
+from tt_model_runners.base_device_runner import BaseDeviceRunner
+from utils.helpers import log_execution_time
+from utils.logger import TTLogger
+import vllm
+
+
+class VLLMForgeEmbeddingQwenRunner(BaseDeviceRunner):
+
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self.settings = get_settings()
+        self.pipeline = None
+        self.logger = TTLogger()
+
+    def get_device(self):
+        return None
+
+    def close_device(self, device) -> bool:
+        return True
+
+    @log_execution_time("Model warmpup")
+    async def load_model(self, device)->bool:
+        self.logger.info(f"Device {self.device_id}: Loading model...")
+
+        prompts = [
+            "The capital of France is Paris",
+        ]
+        llm_args = {
+            "model": settings.SupportedModels.QWEN_3_EMBEDDING_4B.value,
+            "task": "embed",
+            "dtype": "bfloat16",
+            "max_model_len": 64,
+            "disable_sliding_window": True,
+            "max_num_batched_tokens": 64,
+            "max_num_seqs": 2,
+        }
+        self.llm = vllm.LLM(**llm_args)
+
+        output_embedding = self.llm.embed(prompts)
+        self.logger.info(f"Device {self.device_id}: Model warmup completed")
+
+        return True
+
+    @log_execution_time("Qwen text embedding inference")
+    def run_inference(self, requests: list[TextEmbeddingRequest]):
+        self.logger.debug(f"Device {self.device_id}: Running inference")
+
+        output_embedding = self.llm.embed(requests[0].input)
+        embedding = output_embedding[0].outputs.embedding
+
+        self.logger.debug(f"Device {self.device_id}: Inference output: {embedding}")
+        self.logger.debug(f"Device {self.device_id}: Inference completed")
+        
+        return [embedding]


### PR DESCRIPTION
## Issue 
[#1042 Add embedding endpoint for LLMs](https://github.com/tenstorrent/tt-inference-server/issues/1042)

## Description
We want to add support for text embeddings by integrating Forge’s vLLM plugin.
With the new endpoint, the system can generate embeddings for text inputs, automatically truncating the output to fit the specified dimensions (if provided).
A current limitation for the maximum number of tokens is 2^14.

## Implementation
- Create new `TextEmbeddingRequest` with `input` and `dimensions` fields
- Create new `v1/embeddings` endpoint
- Add `VLLMForgeEmbeddingQwenRunner` model runner