### PR TITLE
adding arcee-ai/AFM-4.5B default sampling params in vllm --override_generation_config

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -804,18 +804,39 @@ spec_templates = [
         impl=tt_transformers_impl,
         tt_metal_commit="ae65ee5",
         vllm_commit="35f023f",
+        # need to add default sampling params here because they're 
+        # not in generation_config.json
+        # see: https://github.com/tenstorrent/tt-inference-server/issues/1066
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.N300,
                 max_concurrency=32,
                 max_context=64 * 1024,
                 default_impl=True,
+                vllm_args={
+                    "override_generation_config": json.dumps(
+                        {
+                            "temperature": 0.5,
+                            "top_k": 50,
+                            "top_p": 0.95,
+                        }
+                    ),
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.T3K,
                 max_concurrency=32,
                 max_context=64 * 1024,
                 default_impl=True,
+                vllm_args={
+                    "override_generation_config": json.dumps(
+                        {
+                            "temperature": 0.5,
+                            "top_k": 50,
+                            "top_p": 0.95,
+                        }
+                    ),
+                },
             ),
         ],
         status=ModelStatusTypes.EXPERIMENTAL,


### PR DESCRIPTION
Addressing: [#1066 arcee-ai/AFM-4.5B default sampling parameters are not in standard generation_config.json](https://github.com/tenstorrent/tt-inference-server/issues/1066)

Tested that this runs on `n300`

in `workflow_logs/docker_server/vllm_2025-11-04_03-31-31_AFM-4.5B_n300_release.log`:
```
2025-11-04 03:31:43,167 - __main__ - INFO - vllm_args:
{'block_size': '64',
 'max-log-len': '32',
 'max_model_len': '65536',
 'max_num_batched_tokens': '65536',
 'max_num_seqs': '32',
 'model': 'arcee-ai/AFM-4.5B',
 'num_scheduler_steps': '10',
 'override_generation_config': '{"temperature": 0.5, "top_k": 50, "top_p": '
                               '0.95}',
 'override_tt_config': '{}',
 'port': '8000',
 'seed': '9472'}
DEBUG 11-04 03:31:43 utils.py:135] Setting VLLM_WORKER_MULTIPROC_METHOD to 'spawn'
DEBUG 11-04 03:31:43 __init__.py:28] No plugins for group vllm.general_plugins found.
INFO 11-04 03:31:43 api_server.py:1042] vLLM API server version 0.1.dev5981+g35f023f05
```