### PR TITLE
Fix RULER eval task missing dependencies in evals_common venv

### DIFF
--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -79,7 +79,7 @@ def setup_evals_common(
         f"{uv_exec} pip install --managed-python --python {venv_config.venv_python} "
         "--index-strategy unsafe-best-match "
         "--extra-index-url https://download.pytorch.org/whl/cpu "
-        "git+https://github.com/tstescoTT/lm-evaluation-harness.git@evals-common#egg=lm-eval[api,ifeval,math,sentencepiece,r1_evals] "
+        "git+https://github.com/tstescoTT/lm-evaluation-harness.git@evals-common#egg=lm-eval[api,ifeval,math,sentencepiece,r1_evals,ruler] "
         "protobuf pillow==11.1 pyjwt==2.7.0 datasets==3.1.0",
         logger=logger,
     )


### PR DESCRIPTION
## Problem
The RULER evaluation task for Gemma-3 models failed with 
```
ModuleNotFoundError: No module named 'wonderwords'. 
```
The `wonderwords` and `nltk` packages required by RULER were not installed in the `.venv_evals_common` virtual environment.

## Solution
Added ruler extra to the lm-eval pip install command in `setup_evals_common()` function.
Changed line 82 in `workflows/workflow_venvs.py`:
```bash 
"git+https://github.com/tstescoTT/lm-evaluation-harness.git@evals-common#egg=lm-eval[api,ifeval,math,sentencepiece,r1_evals,ruler]"
```
## Impact
Fixes RULER evaluation for gemma-3-4b-it and gemma-3-27b-it models
