### PR TITLE
[Gemma-3] Change livecodebench -> mbpp_instruct and reduce CI runtime

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -281,10 +281,6 @@ _eval_config_list = [
                     EvalLimitMode.SMOKE_TEST: 0.01,
                 },
             ),
-            limit_samples_map={
-                    EvalLimitMode.CI_NIGHTLY: 0.5,
-                    EvalLimitMode.SMOKE_TEST: 0.01,
-                },
             EvalTask(
                 task_name="mbpp_instruct",
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,


### PR DESCRIPTION
Latest run with the `mbpp_instruct` : 

### Accuracy Evaluations for gemma-3-27b-it on t3k

| model          | device | task_name     | accuracy_check | score | ratio_to_reference | gpu_reference_score                                                                            | ratio_to_published | published_score                                                               |
|----------------|--------|---------------|----------------|-------|--------------------|------------------------------------------------------------------------------------------------|--------------------|-------------------------------------------------------------------------------|
| gemma-3-27b-it | t3k    | mbpp_instruct | PASS ✅         | 72.00 | N/A                | [None](TBD)                                                                                    | 1.10               | [65.60](https://storage.googleapis.com/deepmind-media/gemma/Gemma3Report.pdf) |


Still need to GPU reference scores. Will merge PR once we have the GPU scores. 