### PR TITLE
Cleanup tt-toplogy and system SW validation

### DIFF
--- a/run.py
+++ b/run.py
@@ -49,10 +49,11 @@ def parse_device_ids(value):
             f"Invalid device-id list: '{value}'. Must be comma-separated non-negative integers (e.g. '0' or '0,1,2')"
         )
 
+
 def parse_arguments():
     valid_workflows = {w.name.lower() for w in WorkflowType}
     valid_devices = {device.name.lower() for device in DeviceTypes}
-    
+
     # Build valid models set, including full HF repo names for whisper models
     valid_models = set()
     for _, config in MODEL_SPECS.items():
@@ -279,7 +280,10 @@ def validate_local_setup(model_spec, json_fpath):
         else:
             logger.info("✅ validating local setup completed")
 
-    if not model_spec.cli_args.skip_system_sw_validation:
+    if (
+        WorkflowType.from_string(model_spec.cli_args.workflow)
+        in (WorkflowType.SERVER, WorkflowType.RELEASE)
+    ) and (not model_spec.cli_args.skip_system_sw_validation):
         _validate_system_software_deps()
 
 

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -98,7 +98,7 @@ class TestModelSpecTemplateSystem:
             weights=["test/model"],
         )
         assert template.repacked == 0
-        assert template.version == "0.2.0"
+        assert template.version == "0.3.0"
         assert template.status == ModelStatusTypes.EXPERIMENTAL
         assert template.docker_image is None
 

--- a/workflows/run_local_setup_validation.py
+++ b/workflows/run_local_setup_validation.py
@@ -187,14 +187,35 @@ def main():
     model_spec = ModelSpec.from_json(args.model_spec_json)
 
     # parse tt-smi FW & KMD version data
+    # also get board type for all devices
     tt_smi_data = SystemResourceService.get_tt_smi_data()
     fw_bundle_versions = []
+    board_types = []
     for info in tt_smi_data["device_info"]:
         fw_versions = info["firmwares"]
+        board_info = info["board_info"]
         fw_bundle_versions.append(fw_versions["fw_bundle_version"])
+        board_types.append(board_info["board_type"])
 
-    # parse system topology
-    topology = SystemResourceService.get_system_topology()
+    # remove local and remote designations, if they exist
+    filtered_board_types = [board_type.rsplit(" ", 1)[0] for board_type in board_types]
+
+    unique_board_types = set(filtered_board_types)
+    assert (
+        len(unique_board_types) == 1
+    ), f"Only homogeneous board types are supported at this time, detected: {unique_board_types}"
+    unique_board_type = unique_board_types.pop()
+
+    # parse system topology if board type requires it
+    # collect board IDs for WH PCIe-card products
+    # https://github.com/tenstorrent/tt-smi/blob/bb86769f4bf5e2ca052c9be0b36dffa61e5384a0/tt_smi/tt_smi_backend.py#L694-L704
+    compat_board_types = {"n300", "n150"}
+    topology = SystemTopology.ISOLATED
+    if any(
+        compat_board_type in unique_board_type
+        for compat_board_type in compat_board_types
+    ):
+        topology = SystemResourceService.get_system_topology()
 
     # enforce matching FW bundle versions across all devices
     cli_args = model_spec.cli_args
@@ -212,6 +233,7 @@ def main():
         f"{'='*80}\n"
         f"FW bundle versions (across all devices): {fw_bundle_versions}\n"
         f"KMD version (on host): {kmd_version}\n"
+        f"Board types: {board_types}\n"
         f"Topology: {topology}\n"
         f"{'='*80}"
     )

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -88,10 +88,10 @@ def setup_evals_common(
 
 def setup_audio_venv(venv_config: VenvConfig) -> bool:
     """Setup audio-specific virtual environment.
-    
+
     Args:
         venv_config: Virtual environment configuration
-        
+
     Returns:
         True if setup was successful
     """
@@ -106,10 +106,10 @@ def setup_audio_venv(venv_config: VenvConfig) -> bool:
 
 def setup_cnn_venv(venv_config: VenvConfig) -> bool:
     """Setup CNN-specific virtual environment.
-    
+
     Args:
         venv_config: Virtual environment configuration
-        
+
     Returns:
         True if setup was successful
     """
@@ -131,7 +131,6 @@ def setup_evals_meta(
         return setup_audio_venv(venv_config)
     elif model_spec.model_type == ModelType.CNN:
         return setup_cnn_venv(venv_config)
-
 
     # Default: Llama-specific setup
     cookbook_dir = venv_config.venv_path / "llama-cookbook"
@@ -290,7 +289,9 @@ def setup_evals_audio(
     Setup audio evaluation environment on HOST using lmms-eval.
     Uses TT-specific fork with whisper_tt model support.
     """
-    logger.warning("Installing lmms-eval for audio - this might take 5 to 15+ minutes on first run ...")
+    logger.warning(
+        "Installing lmms-eval for audio - this might take 5 to 15+ minutes on first run ..."
+    )
     run_command(
         f"{uv_exec} pip install --managed-python --python {venv_config.venv_python} "
         f"'git+https://github.com/bgoelTT/lmms-eval.git@ben/samt/whisper-tt#egg=lmms-eval[audio]' "
@@ -390,7 +391,7 @@ def create_local_setup_venv(
     # NOTE: Install latest version of {tt-smi, tt-topology} but pin packaging
     # this is to test for regressions in tt-smi and tt-topology
     run_command(
-        command=f"{uv_exec} pip install --managed-python --python {venv_config.venv_python} tt-smi tt-topology packaging==25.0",
+        command=f"{uv_exec} pip install --managed-python --python {venv_config.venv_python} tt-smi==3.0.34 tt-topology==1.2.15 packaging==25.0",
         logger=logger,
     )
     return venv_config.venv_python
@@ -405,7 +406,9 @@ _venv_config_list = [
         venv_type=WorkflowVenvType.BENCHMARKS_RUN_SCRIPT,
         setup_function=setup_benchmarks_run_script,
     ),
-    VenvConfig(venv_type=WorkflowVenvType.EVALS_COMMON, setup_function=setup_evals_common),
+    VenvConfig(
+        venv_type=WorkflowVenvType.EVALS_COMMON, setup_function=setup_evals_common
+    ),
     VenvConfig(venv_type=WorkflowVenvType.EVALS_META, setup_function=setup_evals_meta),
     VenvConfig(
         venv_type=WorkflowVenvType.EVALS_VISION, setup_function=setup_evals_vision


### PR DESCRIPTION
This PR addresses #1105 

It specifically:
1. Only performs system SW validation for SERVER and RELEASE workflows
2. Only performs tt-topology check on WH PCIe card products (n150 & n300)
3. Pins tt-topology==1.2.15 and tt-smi==3.0.34 to prevent deps from moving underneath us in the future