### PR TITLE
Gemma3 4b and 1b use sampling on host

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -854,7 +854,6 @@ spec_templates = [
                     "worker_l1_size": 1344544,
                     "trace_region_size": 21448704,
                     "fabric_config": "FABRIC_1D",
-                    "sample_on_device_mode": "decode_only",
                 },
             ),
         ],
@@ -888,7 +887,6 @@ spec_templates = [
                     "worker_l1_size": 1344544,
                     "trace_region_size": 21448704,
                     "fabric_config": "FABRIC_1D",
-                    "sample_on_device_mode": "decode_only",
                 },
             ),
             DeviceModelSpec(
@@ -910,7 +908,6 @@ spec_templates = [
                     "worker_l1_size": 1344544,
                     "trace_region_size": 21448704,
                     "fabric_config": "FABRIC_1D",
-                    "sample_on_device_mode": "decode_only",
                 },
             ),
         ],


### PR DESCRIPTION
Current `sampling_on_device` implementation has a limit for up to 64k tokens per device.
As Gemma3 has `vocab_size=262208`, when split across devices, it's more than 64k for N150 and N300.

The workaround:
- Disable `sampling_on_device` for the targets with less devices until https://github.com/tenstorrent/tt-metal/issues/32249 is fixed.