### PR TITLE
Remove Deprecated TT_MESH_GRAPH_DESC_PATH

### DIFF
--- a/model_specs_output.json
+++ b/model_specs_output.json
@@ -2279,8 +2279,7 @@
         "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
-        "TT_MM_THROTTLE_PERF": 5,
-        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+        "TT_MM_THROTTLE_PERF": 5
       }
     },
     "system_requirements": null,
@@ -2291,8 +2290,7 @@
       "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
-      "TT_MM_THROTTLE_PERF": 5,
-      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+      "TT_MM_THROTTLE_PERF": 5
     },
     "vllm_commit": "48eba14",
     "custom_inference_server": null,
@@ -2564,8 +2562,7 @@
         "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
-        "TT_MM_THROTTLE_PERF": 5,
-        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+        "TT_MM_THROTTLE_PERF": 5
       }
     },
     "system_requirements": null,
@@ -2577,8 +2574,7 @@
       "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
-      "TT_MM_THROTTLE_PERF": 5,
-      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+      "TT_MM_THROTTLE_PERF": 5
     },
     "vllm_commit": "48eba14",
     "custom_inference_server": null,
@@ -3275,8 +3271,7 @@
         "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
-        "TT_MM_THROTTLE_PERF": 5,
-        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+        "TT_MM_THROTTLE_PERF": 5
       }
     },
     "system_requirements": null,
@@ -3288,8 +3283,7 @@
       "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
-      "TT_MM_THROTTLE_PERF": 5,
-      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+      "TT_MM_THROTTLE_PERF": 5
     },
     "vllm_commit": "48eba14",
     "custom_inference_server": null,
@@ -3648,8 +3642,7 @@
         "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
-        "TT_MM_THROTTLE_PERF": 5,
-        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+        "TT_MM_THROTTLE_PERF": 5
       }
     },
     "system_requirements": null,
@@ -3662,8 +3655,7 @@
       "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
-      "TT_MM_THROTTLE_PERF": 5,
-      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+      "TT_MM_THROTTLE_PERF": 5
     },
     "vllm_commit": "0edd242",
     "custom_inference_server": null,
@@ -4024,8 +4016,7 @@
         "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
-        "TT_MM_THROTTLE_PERF": 5,
-        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+        "TT_MM_THROTTLE_PERF": 5
       }
     },
     "system_requirements": null,
@@ -4038,8 +4029,7 @@
       "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
-      "TT_MM_THROTTLE_PERF": 5,
-      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+      "TT_MM_THROTTLE_PERF": 5
     },
     "vllm_commit": "0edd242",
     "custom_inference_server": null,
@@ -6474,8 +6464,7 @@
         "ARCH_NAME": "wormhole_b0",
         "TT_MM_THROTTLE_PERF": 5,
         "MAX_PREFILL_CHUNK_SIZE": "32",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
-        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       }
     },
     "system_requirements": {
@@ -6497,8 +6486,7 @@
       "ARCH_NAME": "wormhole_b0",
       "TT_MM_THROTTLE_PERF": 5,
       "MAX_PREFILL_CHUNK_SIZE": "32",
-      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
-      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
     },
     "vllm_commit": "e7c329b",
     "custom_inference_server": null,
@@ -6557,8 +6545,7 @@
         "ARCH_NAME": "wormhole_b0",
         "TT_MM_THROTTLE_PERF": 5,
         "MAX_PREFILL_CHUNK_SIZE": "32",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
-        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       }
     },
     "system_requirements": {
@@ -6580,8 +6567,7 @@
       "ARCH_NAME": "wormhole_b0",
       "TT_MM_THROTTLE_PERF": 5,
       "MAX_PREFILL_CHUNK_SIZE": "32",
-      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
-      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
     },
     "vllm_commit": "e7c329b",
     "custom_inference_server": null,
@@ -6640,8 +6626,7 @@
         "ARCH_NAME": "wormhole_b0",
         "TT_MM_THROTTLE_PERF": 5,
         "MAX_PREFILL_CHUNK_SIZE": "32",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
-        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       }
     },
     "system_requirements": {
@@ -6663,8 +6648,7 @@
       "ARCH_NAME": "wormhole_b0",
       "TT_MM_THROTTLE_PERF": 5,
       "MAX_PREFILL_CHUNK_SIZE": "32",
-      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
-      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
     },
     "vllm_commit": "e7c329b",
     "custom_inference_server": null,
@@ -6723,8 +6707,7 @@
         "ARCH_NAME": "wormhole_b0",
         "TT_MM_THROTTLE_PERF": 5,
         "MAX_PREFILL_CHUNK_SIZE": "32",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
-        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       }
     },
     "system_requirements": {
@@ -6746,8 +6729,7 @@
       "ARCH_NAME": "wormhole_b0",
       "TT_MM_THROTTLE_PERF": 5,
       "MAX_PREFILL_CHUNK_SIZE": "32",
-      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
-      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
     },
     "vllm_commit": "e7c329b",
     "custom_inference_server": null,
@@ -10469,8 +10451,7 @@
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
         "trace_region_size": 50000000,
-        "TT_MM_THROTTLE_PERF": 5,
-        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+        "TT_MM_THROTTLE_PERF": 5
       }
     },
     "system_requirements": {
@@ -10491,8 +10472,7 @@
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
       "trace_region_size": 50000000,
-      "TT_MM_THROTTLE_PERF": 5,
-      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+      "TT_MM_THROTTLE_PERF": 5
     },
     "vllm_commit": "48eba14",
     "custom_inference_server": null,
@@ -10672,8 +10652,7 @@
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
         "trace_region_size": 50000000,
-        "TT_MM_THROTTLE_PERF": 5,
-        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+        "TT_MM_THROTTLE_PERF": 5
       }
     },
     "system_requirements": {
@@ -10694,8 +10673,7 @@
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
       "trace_region_size": 50000000,
-      "TT_MM_THROTTLE_PERF": 5,
-      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+      "TT_MM_THROTTLE_PERF": 5
     },
     "vllm_commit": "48eba14",
     "custom_inference_server": null,
@@ -10858,8 +10836,7 @@
         "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
-        "TT_MM_THROTTLE_PERF": 5,
-        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+        "TT_MM_THROTTLE_PERF": 5
       }
     },
     "system_requirements": null,
@@ -10871,8 +10848,7 @@
       "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
-      "TT_MM_THROTTLE_PERF": 5,
-      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml"
+      "TT_MM_THROTTLE_PERF": 5
     },
     "vllm_commit": "aa4ae1e",
     "custom_inference_server": null,

--- a/tt-media-server/model_services/device_worker.py
+++ b/tt-media-server/model_services/device_worker.py
@@ -36,16 +36,6 @@ def setup_worker_environment(worker_id: str):
 
     if settings.is_galaxy == True:
         os.environ['TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE'] = "7,7"
-        tt_metal_home = os.environ.get('TT_METAL_HOME', '')
-        # make sure to not override except 1,1 and 2,1 mesh sizes
-        if settings.device_mesh_shape == (1,1):
-            mesh_desc = f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.yaml"
-        elif settings.device_mesh_shape == (2,1):
-            mesh_desc = f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.yaml"
-        else:
-            return
-        os.environ['TT_MESH_GRAPH_DESC_PATH'] = mesh_desc
-
 
 def device_worker(worker_id: str, task_queue: Queue, result_queue: Queue, warmup_signals_queue: Queue, error_queue: Queue):
     setup_worker_environment(worker_id)

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1090,8 +1090,7 @@ spec_templates = [
                 max_context=40960,
                 default_impl=True,
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 5,
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
+                    "TT_MM_THROTTLE_PERF": 5
                 },
             ),
             DeviceModelSpec(
@@ -1127,8 +1126,7 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 5,
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
+                    "TT_MM_THROTTLE_PERF": 5
                 },
             ),
             DeviceModelSpec(
@@ -1238,8 +1236,7 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 5,
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
+                    "TT_MM_THROTTLE_PERF": 5
                 },
             ),
         ],
@@ -1285,8 +1282,7 @@ spec_templates = [
                     "trace_region_size": 27381760,
                 },
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 5,
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
+                    "TT_MM_THROTTLE_PERF": 5
                 },
             ),
         ],
@@ -1486,8 +1482,7 @@ spec_templates = [
                 env_vars={
                     "TT_MM_THROTTLE_PERF": 5,
                     "MAX_PREFILL_CHUNK_SIZE": "32",
-                    "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
+                    "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
                 },
             ),
         ],
@@ -1734,8 +1729,7 @@ spec_templates = [
                 default_impl=True,
                 env_vars={
                     "trace_region_size": 50000000,
-                    "TT_MM_THROTTLE_PERF": 5,
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
+                    "TT_MM_THROTTLE_PERF": 5
                 },
             ),
         ],
@@ -1769,8 +1763,7 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 5,
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml",
+                    "TT_MM_THROTTLE_PERF": 5
                 },
             ),
         ],


### PR DESCRIPTION
## Problem
`TT_MESH_GRAPH_DESC_PATH` was deprecated with this [PR](https://github.com/tenstorrent/tt-metal/pull/32028), causing runtime errors with newest metal commit 
```
2025-11-17 10:46:38,136 - ERROR - Failed to get device runner: TT_FATAL @ /tt-metal/tt_metal/impl/context/metal_context.cpp:611: std::filesystem::exists(mesh_graph_desc_path)
info:
Custom mesh graph descriptor file not found: tt-metal/tt_metal/fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.yaml
```

Failing nightly: [link](https://github.com/tenstorrent/tt-shield/actions/runs/19378842159/job/55475503891)