### PR TITLE
Fix missing new MGD path for Galaxy_T3K

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1671,7 +1671,7 @@ spec_templates = [
                 },
                 override_tt_config={
                     "fabric_config": "FABRIC_1D",
-                }
+                },
             ),
         ],
         status=ModelStatusTypes.FUNCTIONAL,


### PR DESCRIPTION
For transition MGD2 on Galaxy_T3K, we need to specify a new MGD path into `TT_MESH_GRAPH_DESC_PATH ` with fabric config. If no fabric configuration is specified, the system assumes it is running on a T3K in Galaxy and therefore selects the TorusXY, which results in a fabric validation failure.