### PR TITLE
Fix mesh shape

### DIFF
--- a/model_specs_output.json
+++ b/model_specs_output.json
@@ -2279,7 +2279,8 @@
         "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
-        "TT_MM_THROTTLE_PERF": 5
+        "TT_MM_THROTTLE_PERF": 5,
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       }
     },
     "system_requirements": null,
@@ -2290,7 +2291,8 @@
       "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
-      "TT_MM_THROTTLE_PERF": 5
+      "TT_MM_THROTTLE_PERF": 5,
+      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
     },
     "vllm_commit": "48eba14",
     "custom_inference_server": null,
@@ -2562,7 +2564,8 @@
         "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
-        "TT_MM_THROTTLE_PERF": 5
+        "TT_MM_THROTTLE_PERF": 5,
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       }
     },
     "system_requirements": null,
@@ -2574,7 +2577,8 @@
       "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
-      "TT_MM_THROTTLE_PERF": 5
+      "TT_MM_THROTTLE_PERF": 5,
+      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
     },
     "vllm_commit": "48eba14",
     "custom_inference_server": null,
@@ -3271,7 +3275,8 @@
         "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
-        "TT_MM_THROTTLE_PERF": 5
+        "TT_MM_THROTTLE_PERF": 5,
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       }
     },
     "system_requirements": null,
@@ -3283,7 +3288,8 @@
       "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
-      "TT_MM_THROTTLE_PERF": 5
+      "TT_MM_THROTTLE_PERF": 5,
+      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
     },
     "vllm_commit": "48eba14",
     "custom_inference_server": null,
@@ -3642,7 +3648,8 @@
         "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
-        "TT_MM_THROTTLE_PERF": 5
+        "TT_MM_THROTTLE_PERF": 5,
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       }
     },
     "system_requirements": null,
@@ -3655,7 +3662,8 @@
       "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
-      "TT_MM_THROTTLE_PERF": 5
+      "TT_MM_THROTTLE_PERF": 5,
+      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
     },
     "vllm_commit": "0edd242",
     "custom_inference_server": null,
@@ -4016,7 +4024,8 @@
         "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
-        "TT_MM_THROTTLE_PERF": 5
+        "TT_MM_THROTTLE_PERF": 5,
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       }
     },
     "system_requirements": null,
@@ -4029,7 +4038,8 @@
       "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
-      "TT_MM_THROTTLE_PERF": 5
+      "TT_MM_THROTTLE_PERF": 5,
+      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
     },
     "vllm_commit": "0edd242",
     "custom_inference_server": null,
@@ -6464,7 +6474,8 @@
         "ARCH_NAME": "wormhole_b0",
         "TT_MM_THROTTLE_PERF": 5,
         "MAX_PREFILL_CHUNK_SIZE": "32",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       }
     },
     "system_requirements": {
@@ -6486,7 +6497,8 @@
       "ARCH_NAME": "wormhole_b0",
       "TT_MM_THROTTLE_PERF": 5,
       "MAX_PREFILL_CHUNK_SIZE": "32",
-      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
     },
     "vllm_commit": "e7c329b",
     "custom_inference_server": null,
@@ -6545,7 +6557,8 @@
         "ARCH_NAME": "wormhole_b0",
         "TT_MM_THROTTLE_PERF": 5,
         "MAX_PREFILL_CHUNK_SIZE": "32",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       }
     },
     "system_requirements": {
@@ -6567,7 +6580,8 @@
       "ARCH_NAME": "wormhole_b0",
       "TT_MM_THROTTLE_PERF": 5,
       "MAX_PREFILL_CHUNK_SIZE": "32",
-      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
     },
     "vllm_commit": "e7c329b",
     "custom_inference_server": null,
@@ -6626,7 +6640,8 @@
         "ARCH_NAME": "wormhole_b0",
         "TT_MM_THROTTLE_PERF": 5,
         "MAX_PREFILL_CHUNK_SIZE": "32",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       }
     },
     "system_requirements": {
@@ -6648,7 +6663,8 @@
       "ARCH_NAME": "wormhole_b0",
       "TT_MM_THROTTLE_PERF": 5,
       "MAX_PREFILL_CHUNK_SIZE": "32",
-      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
     },
     "vllm_commit": "e7c329b",
     "custom_inference_server": null,
@@ -6707,7 +6723,8 @@
         "ARCH_NAME": "wormhole_b0",
         "TT_MM_THROTTLE_PERF": 5,
         "MAX_PREFILL_CHUNK_SIZE": "32",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       }
     },
     "system_requirements": {
@@ -6729,7 +6746,8 @@
       "ARCH_NAME": "wormhole_b0",
       "TT_MM_THROTTLE_PERF": 5,
       "MAX_PREFILL_CHUNK_SIZE": "32",
-      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+      "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
     },
     "vllm_commit": "e7c329b",
     "custom_inference_server": null,
@@ -10451,7 +10469,8 @@
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
         "trace_region_size": 50000000,
-        "TT_MM_THROTTLE_PERF": 5
+        "TT_MM_THROTTLE_PERF": 5,
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       }
     },
     "system_requirements": {
@@ -10472,7 +10491,8 @@
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
       "trace_region_size": 50000000,
-      "TT_MM_THROTTLE_PERF": 5
+      "TT_MM_THROTTLE_PERF": 5,
+      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
     },
     "vllm_commit": "48eba14",
     "custom_inference_server": null,
@@ -10652,7 +10672,8 @@
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
         "trace_region_size": 50000000,
-        "TT_MM_THROTTLE_PERF": 5
+        "TT_MM_THROTTLE_PERF": 5,
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       }
     },
     "system_requirements": {
@@ -10673,7 +10694,8 @@
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
       "trace_region_size": 50000000,
-      "TT_MM_THROTTLE_PERF": 5
+      "TT_MM_THROTTLE_PERF": 5,
+      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
     },
     "vllm_commit": "48eba14",
     "custom_inference_server": null,
@@ -10836,7 +10858,8 @@
         "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
         "MESH_DEVICE": "T3K",
         "ARCH_NAME": "wormhole_b0",
-        "TT_MM_THROTTLE_PERF": 5
+        "TT_MM_THROTTLE_PERF": 5,
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       }
     },
     "system_requirements": null,
@@ -10848,7 +10871,8 @@
       "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
       "MESH_DEVICE": "T3K",
       "ARCH_NAME": "wormhole_b0",
-      "TT_MM_THROTTLE_PERF": 5
+      "TT_MM_THROTTLE_PERF": 5,
+      "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
     },
     "vllm_commit": "aa4ae1e",
     "custom_inference_server": null,

--- a/tt-media-server/model_services/device_worker.py
+++ b/tt-media-server/model_services/device_worker.py
@@ -36,6 +36,15 @@ def setup_worker_environment(worker_id: str):
 
     if settings.is_galaxy == True:
         os.environ["TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE"] = "7,7"
+        tt_metal_home = os.environ.get("TT_METAL_HOME", "")
+        # make sure to not override except 1,1 and 2,1 mesh sizes
+        if settings.device_mesh_shape == (1, 1):
+            mesh_desc = f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.textproto"
+        elif settings.device_mesh_shape == (2, 1):
+            mesh_desc = f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto"
+        else:
+            return
+        os.environ["TT_MESH_GRAPH_DESC_PATH"] = mesh_desc
 
 
 def device_worker(

--- a/tt-media-server/model_services/device_worker.py
+++ b/tt-media-server/model_services/device_worker.py
@@ -39,13 +39,9 @@ def setup_worker_environment(worker_id: str):
         tt_metal_home = os.environ.get("TT_METAL_HOME", "")
         # make sure to not override except 1,1 and 2,1 mesh sizes
         if settings.device_mesh_shape == (1, 1):
-            mesh_desc = f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.textproto"
+            os.environ["TT_MESH_GRAPH_DESC_PATH"] = f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.textproto"
         elif settings.device_mesh_shape == (2, 1):
-            mesh_desc = f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto"
-        else:
-            return
-        os.environ["TT_MESH_GRAPH_DESC_PATH"] = mesh_desc
-
+            os.environ["TT_MESH_GRAPH_DESC_PATH"] = f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto"
 
 def device_worker(
     worker_id: str,

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -793,7 +793,7 @@ spec_templates = [
         impl=tt_transformers_impl,
         tt_metal_commit="ae65ee5",
         vllm_commit="35f023f",
-        # need to add default sampling params here because they're 
+        # need to add default sampling params here because they're
         # not in generation_config.json
         # see: https://github.com/tenstorrent/tt-inference-server/issues/1066
         device_model_specs=[
@@ -1090,7 +1090,8 @@ spec_templates = [
                 max_context=40960,
                 default_impl=True,
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 5
+                    "TT_MM_THROTTLE_PERF": 5,
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto",
                 },
             ),
             DeviceModelSpec(
@@ -1126,7 +1127,8 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 5
+                    "TT_MM_THROTTLE_PERF": 5,
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto",
                 },
             ),
             DeviceModelSpec(
@@ -1236,7 +1238,8 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 5
+                    "TT_MM_THROTTLE_PERF": 5,
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto",
                 },
             ),
         ],
@@ -1282,7 +1285,8 @@ spec_templates = [
                     "trace_region_size": 27381760,
                 },
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 5
+                    "TT_MM_THROTTLE_PERF": 5,
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto",
                 },
             ),
         ],
@@ -1482,7 +1486,8 @@ spec_templates = [
                 env_vars={
                     "TT_MM_THROTTLE_PERF": 5,
                     "MAX_PREFILL_CHUNK_SIZE": "32",
-                    "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+                    "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto",
                 },
             ),
         ],
@@ -1729,7 +1734,8 @@ spec_templates = [
                 default_impl=True,
                 env_vars={
                     "trace_region_size": 50000000,
-                    "TT_MM_THROTTLE_PERF": 5
+                    "TT_MM_THROTTLE_PERF": 5,
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto",
                 },
             ),
         ],
@@ -1763,7 +1769,8 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MM_THROTTLE_PERF": 5
+                    "TT_MM_THROTTLE_PERF": 5,
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto",
                 },
             ),
         ],
@@ -1774,7 +1781,7 @@ spec_templates = [
     ),
     ModelSpecTemplate(
         weights=["stabilityai/stable-diffusion-xl-base-1.0"],
-        tt_metal_commit="e95ffa5",
+        tt_metal_commit="13f44c5",
         impl=tt_transformers_impl,
         min_disk_gb=15,
         min_ram_gb=6,
@@ -1810,7 +1817,7 @@ spec_templates = [
     ),
     ModelSpecTemplate(
         weights=["stabilityai/stable-diffusion-3.5-large"],
-        tt_metal_commit="e95ffa5",
+        tt_metal_commit="13f44c5",
         impl=tt_transformers_impl,
         min_disk_gb=15,
         min_ram_gb=6,
@@ -1834,7 +1841,7 @@ spec_templates = [
     ),
     ModelSpecTemplate(
         weights=["openai/whisper-large-v3", "distil-whisper/distil-large-v3"],
-        tt_metal_commit="e95ffa5",
+        tt_metal_commit="13f44c5",
         impl=whisper_impl,
         min_disk_gb=15,
         min_ram_gb=6,

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1781,7 +1781,7 @@ spec_templates = [
     ),
     ModelSpecTemplate(
         weights=["stabilityai/stable-diffusion-xl-base-1.0"],
-        tt_metal_commit="13f44c5",
+        tt_metal_commit="e95ffa5",
         impl=tt_transformers_impl,
         min_disk_gb=15,
         min_ram_gb=6,
@@ -1817,7 +1817,7 @@ spec_templates = [
     ),
     ModelSpecTemplate(
         weights=["stabilityai/stable-diffusion-3.5-large"],
-        tt_metal_commit="13f44c5",
+        tt_metal_commit="e95ffa5",
         impl=tt_transformers_impl,
         min_disk_gb=15,
         min_ram_gb=6,
@@ -1841,7 +1841,7 @@ spec_templates = [
     ),
     ModelSpecTemplate(
         weights=["openai/whisper-large-v3", "distil-whisper/distil-large-v3"],
-        tt_metal_commit="13f44c5",
+        tt_metal_commit="e95ffa5",
         impl=whisper_impl,
         min_disk_gb=15,
         min_ram_gb=6,


### PR DESCRIPTION
## Issue
In order to partition a galaxy (into 32 n150 for example) we need to update `TT_MESH_GRAPH_DESC_PATH` to point to the new `mesh_graph_descriptor.textproto` files.