### PR TITLE
Fix Vision Token Calculation for Benchmarking

### DIFF
--- a/benchmarking/benchmark_config.py
+++ b/benchmarking/benchmark_config.py
@@ -110,6 +110,34 @@ def get_benchmark_max_concurrency(isl, osl, max_context, model_max_concurrency=3
     return min(max_concurrency_by_context, model_max_concurrency)
 
 
+def get_image_tokens(model_spec, image_height: int, image_width: int, images_per_prompt: int = 1) -> int:
+    """
+    Get exact number of vision tokens for the given model and image dimensions.
+    
+    For multimodal models, this calculates the precise token count that images will
+    contribute to the input sequence, allowing accurate max_concurrency calculation.
+    
+    Args:
+        model_spec: Model specification with vision_token_calculator
+        image_height: Image height in pixels
+        image_width: Image width in pixels  
+        images_per_prompt: Number of images per prompt (default: 1)
+        
+    Returns:
+        Total vision tokens (tokens_per_image * images_per_prompt)
+        Returns 0 if model doesn't have a vision_token_calculator
+        
+    Example:
+        For Gemma-3-27b-it with 3500x2500 image:
+        get_image_tokens(model_spec, 3500, 2500, 1) -> 268 tokens
+    """
+    if not hasattr(model_spec, 'vision_token_calculator') or model_spec.vision_token_calculator is None:
+        return 0  # Not a vision model or calculator not configured
+    
+    tokens_per_image = model_spec.vision_token_calculator(image_height, image_width)
+    return tokens_per_image * images_per_prompt
+
+
 # define benchmark configs for each model and each device configuration
 # uses:
 # 1. BATCH_1_BENCHMARK_COMMON_ISL_OSL_PAIRS
@@ -207,15 +235,34 @@ else:
                             BenchmarkTaskParams(
                                 isl=isl,
                                 osl=osl,
-                                max_concurrency=get_benchmark_max_concurrency(isl, osl, _max_context, _model_max_concurrency),
-                                num_prompts=get_num_prompts(isl, osl, get_benchmark_max_concurrency(isl, osl, _max_context, _model_max_concurrency)),
+                                max_concurrency=get_benchmark_max_concurrency(
+                                    isl + get_image_tokens(model_spec, height, width, images_per_prompt),
+                                    osl,
+                                    _max_context,
+                                    _model_max_concurrency
+                                ),
+                                num_prompts=get_num_prompts(
+                                    isl,
+                                    osl,
+                                    get_benchmark_max_concurrency(
+                                        isl + get_image_tokens(model_spec, height, width, images_per_prompt),
+                                        osl,
+                                        _max_context,
+                                        _model_max_concurrency
+                                    )
+                                ),
                                 task_type="image",
                                 image_height=height,
                                 image_width=width,
                                 images_per_prompt=images_per_prompt,
                             )
                             for isl, osl, height, width, images_per_prompt in ISL_OSL_IMAGE_RESOLUTION_PAIRS
-                            if (isl, osl, height, width, images_per_prompt, get_benchmark_max_concurrency(isl, osl, _max_context, _model_max_concurrency)) not in perf_ref_task_runs.get(_device, [])
+                            if (isl, osl, height, width, images_per_prompt, get_benchmark_max_concurrency(
+                                isl + get_image_tokens(model_spec, height, width, images_per_prompt),
+                                osl,
+                                _max_context,
+                                _model_max_concurrency
+                            )) not in perf_ref_task_runs.get(_device, [])
                         ] if "image" in model_spec.supported_modalities else []
                     )
                 }

--- a/utils/vision_token_utils.py
+++ b/utils/vision_token_utils.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+"""
+Client-side vision token calculator utilities.
+
+This module provides functions to calculate the number of vision tokens
+that images will contribute to multimodal model inputs. These calculations
+are used client-side to properly account for image tokens when determining
+max_concurrency and context length limits.
+"""
+
+import math
+from typing import Callable, Dict, Optional
+
+
+def calculate_gemma_vision_tokens(image_height: int, image_width: int) -> int:
+    """
+    Calculate vision tokens for Gemma/PaliGemma models.
+    
+    Based on empirical observations from vLLM with SigLIP vision encoder.
+    Images are resized to max 1120x1120 while maintaining aspect ratio.
+    
+    Args:
+        image_height: Image height in pixels
+        image_width: Image width in pixels
+        
+    Returns:
+        Number of vision tokens
+        
+    Example:
+        3500x2500 image -> 268 tokens (empirically verified from vLLM logs)
+    """
+    MAX_DIMENSION = 1120
+    
+    # Resize logic: maintain aspect ratio, fit within MAX_DIMENSION
+    scale = min(MAX_DIMENSION / image_width, MAX_DIMENSION / image_height, 1.0)
+    resized_width = int(image_width * scale)
+    resized_height = int(image_height * scale)
+    
+    # Empirical pixel-to-token ratio from vLLM observations
+    # 3500x2500 -> resized to 800x1120 (896,000 pixels) -> 268 tokens
+    PIXELS_PER_TOKEN = 3343
+    
+    total_pixels = resized_width * resized_height
+    tokens = total_pixels // PIXELS_PER_TOKEN
+    
+    return max(tokens, 1)
+
+
+def calculate_qwen_vision_tokens(image_height: int, image_width: int) -> int:
+    """
+    Calculate exact vision tokens for Qwen2.5-VL models.
+    
+    Based on ViT with dynamic resolution support and 14x14 patches.
+    Images are processed with dynamic resolution within pixel limits.
+    
+    Args:
+        image_height: Image height in pixels
+        image_width: Image width in pixels
+        
+    Returns:
+        Exact number of vision tokens
+    """
+    PATCH_SIZE = 14
+    MIN_PIXELS = 256 * 28 * 28  # 200704
+    MAX_PIXELS = 1280 * 28 * 28  # 1003520
+    
+    total_pixels = image_height * image_width
+    
+    # Scale image to fit within model's pixel limits
+    if total_pixels < MIN_PIXELS:
+        scale = math.sqrt(MIN_PIXELS / total_pixels)
+        image_height = int(image_height * scale)
+        image_width = int(image_width * scale)
+    elif total_pixels > MAX_PIXELS:
+        scale = math.sqrt(MAX_PIXELS / total_pixels)
+        image_height = int(image_height * scale)
+        image_width = int(image_width * scale)
+    
+    # Calculate number of patches
+    num_patches_h = math.ceil(image_height / PATCH_SIZE)
+    num_patches_w = math.ceil(image_width / PATCH_SIZE)
+    
+    return num_patches_h * num_patches_w
+
+
+# Model ID to vision token calculator mapping
+# Keys are model repository IDs from HuggingFace
+VISION_TOKEN_CALCULATORS: Dict[str, Callable[[int, int], int]] = {
+    # Gemma models
+    "google/gemma-3-27b-it": calculate_gemma_vision_tokens,
+    "google/paligemma-3b-mix-448": calculate_gemma_vision_tokens,
+    
+    # Qwen models
+    "Qwen/Qwen2-VL-2B-Instruct": calculate_qwen_vision_tokens,
+    "Qwen/Qwen2-VL-7B-Instruct": calculate_qwen_vision_tokens,
+    "Qwen/Qwen2.5-VL-7B-Instruct": calculate_qwen_vision_tokens,
+    "Qwen/Qwen2.5-VL-72B-Instruct": calculate_qwen_vision_tokens,
+}
+
+
+def get_vision_token_calculator(model_id: str) -> Optional[Callable[[int, int], int]]:
+    """
+    Get the vision token calculator for a given model ID.
+    
+    Args:
+        model_id: HuggingFace model repository ID
+        
+    Returns:
+        Vision token calculator function, or None if model is not a VL model
+        or not supported
+    """
+    return VISION_TOKEN_CALCULATORS.get(model_id)
+
+
+def calculate_image_tokens(
+    model_id: str,
+    image_height: int,
+    image_width: int,
+    images_per_prompt: int = 1
+) -> int:
+    """
+    Calculate total image tokens for a given model and image configuration.
+    
+    Args:
+        model_id: HuggingFace model repository ID
+        image_height: Image height in pixels
+        image_width: Image width in pixels
+        images_per_prompt: Number of images per prompt (default: 1)
+        
+    Returns:
+        Total vision tokens (tokens_per_image * images_per_prompt)
+        Returns 0 if model is not a VL model or not supported
+        
+    Example:
+        For Gemma-3-27b-it with 3500x2500 image:
+        calculate_image_tokens("google/gemma-3-27b-it", 3500, 2500, 1) -> 268 tokens
+    """
+    calculator = get_vision_token_calculator(model_id)
+    if calculator is None:
+        return 0
+    
+    tokens_per_image = calculator(image_height, image_width)
+    return tokens_per_image * images_per_prompt
+
+
+def is_vision_language_model(model_id: str) -> bool:
+    """
+    Check if a model is a vision-language model.
+    
+    Args:
+        model_id: HuggingFace model repository ID
+        
+    Returns:
+        True if model is a vision-language model, False otherwise
+    """
+    return model_id in VISION_TOKEN_CALCULATORS
+

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -6,6 +6,7 @@ from enum import IntEnum, auto
 import os
 import re
 import json
+import math
 from pathlib import Path
 from dataclasses import dataclass, field, asdict, make_dataclass
 from typing import Dict, List, Optional, Union
@@ -128,9 +129,6 @@ def get_model_id(impl_name: str, model_name: str, device: str) -> str:
 
 
 # Vision token calculators for multimodal models
-import math
-
-
 def calculate_gemma_vision_tokens(image_height: int, image_width: int) -> int:
     """
     Calculate vision tokens for Gemma/PaliGemma models.

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -127,6 +127,81 @@ def get_model_id(impl_name: str, model_name: str, device: str) -> str:
     return model_id
 
 
+# Vision token calculators for multimodal models
+import math
+
+
+def calculate_gemma_vision_tokens(image_height: int, image_width: int) -> int:
+    """
+    Calculate vision tokens for Gemma/PaliGemma models.
+    
+    Based on empirical observations from vLLM with SigLIP vision encoder.
+    Images are resized to max 1120x1120 while maintaining aspect ratio.
+    
+    Args:
+        image_height: Image height in pixels
+        image_width: Image width in pixels
+        
+    Returns:
+        Number of vision tokens
+        
+    Example:
+        3500x2500 image -> 268 tokens (empirically verified from vLLM logs)
+    """
+    MAX_DIMENSION = 1120
+    
+    # Resize logic: maintain aspect ratio, fit within MAX_DIMENSION
+    scale = min(MAX_DIMENSION / image_width, MAX_DIMENSION / image_height, 1.0)
+    resized_width = int(image_width * scale)
+    resized_height = int(image_height * scale)
+    
+    # Empirical pixel-to-token ratio from vLLM observations
+    # 3500x2500 -> resized to 800x1120 (896,000 pixels) -> 268 tokens
+    PIXELS_PER_TOKEN = 3343
+    
+    total_pixels = resized_width * resized_height
+    tokens = total_pixels // PIXELS_PER_TOKEN
+    
+    return max(tokens, 1)
+
+
+def calculate_qwen_vision_tokens(image_height: int, image_width: int) -> int:
+    """
+    Calculate exact vision tokens for Qwen2.5-VL models.
+    
+    Based on ViT with dynamic resolution support and 14x14 patches.
+    Images are processed with dynamic resolution within pixel limits.
+    
+    Args:
+        image_height: Image height in pixels
+        image_width: Image width in pixels
+        
+    Returns:
+        Exact number of vision tokens
+    """
+    PATCH_SIZE = 14
+    MIN_PIXELS = 256 * 28 * 28  # 200704
+    MAX_PIXELS = 1280 * 28 * 28  # 1003520
+    
+    total_pixels = image_height * image_width
+    
+    # Scale image to fit within model's pixel limits
+    if total_pixels < MIN_PIXELS:
+        scale = math.sqrt(MIN_PIXELS / total_pixels)
+        image_height = int(image_height * scale)
+        image_width = int(image_width * scale)
+    elif total_pixels > MAX_PIXELS:
+        scale = math.sqrt(MAX_PIXELS / total_pixels)
+        image_height = int(image_height * scale)
+        image_width = int(image_width * scale)
+    
+    # Calculate number of patches
+    num_patches_h = math.ceil(image_height / PATCH_SIZE)
+    num_patches_w = math.ceil(image_width / PATCH_SIZE)
+    
+    return num_patches_h * num_patches_w
+
+
 class ModelType(IntEnum):
     LLM = auto()
     CNN = auto()
@@ -288,6 +363,7 @@ class ModelSpec:
     uses_tensor_model_cache: bool = True
     cli_args: Dict[str, str] = field(default_factory=dict)
     display_name: Optional[str] = None
+    vision_token_calculator: Optional[callable] = None  # Function to calculate image tokens from dimensions
 
     def __post_init__(self):
         default_env_vars = {
@@ -699,6 +775,7 @@ class ModelSpecTemplate:
     custom_inference_server: Optional[str] = None
     uses_tensor_model_cache: bool = True
     display_name: Optional[str] = None
+    vision_token_calculator: Optional[callable] = None  # Function to calculate image tokens from dimensions
 
     def __post_init__(self):
         self.validate_data()
@@ -723,6 +800,59 @@ class ModelSpecTemplate:
             }
             object.__setattr__(self, "perf_targets_map", default_perf_targets_map)
 
+    def _adjust_image_task_concurrency(
+        self,
+        perf_reference: List[BenchmarkTaskParams],
+        max_context: int,
+        model_max_concurrency: int
+    ) -> List[BenchmarkTaskParams]:
+        """
+        Recalculate max_concurrency for image tasks to account for vision tokens.
+        
+        For vision models, the ISL should include image tokens when calculating capacity.
+        This ensures max_concurrency doesn't exceed what the model can actually handle.
+        """
+        adjusted_tasks = []
+        for task in perf_reference:
+            if task.task_type == "image" and task.image_height and task.image_width:
+                # Calculate image tokens using the vision token calculator
+                image_tokens = self.vision_token_calculator(
+                    task.image_height,
+                    task.image_width
+                ) * (task.images_per_prompt or 1)
+                
+                # Effective ISL includes text ISL + image tokens
+                effective_isl = task.isl + image_tokens
+                total_seq_len = effective_isl + task.osl
+                
+                # Recalculate max_concurrency based on actual token usage
+                if total_seq_len > max_context:
+                    calculated_max_concurrency = 1
+                else:
+                    calculated_max_concurrency = min(
+                        max_context // total_seq_len,
+                        model_max_concurrency
+                    )
+                
+                # Create new task with adjusted max_concurrency
+                adjusted_task = BenchmarkTaskParams(
+                    isl=task.isl,
+                    osl=task.osl,
+                    max_concurrency=calculated_max_concurrency,
+                    num_prompts=task.num_prompts,
+                    task_type=task.task_type,
+                    image_height=task.image_height,
+                    image_width=task.image_width,
+                    images_per_prompt=task.images_per_prompt,
+                    targets=task.targets,
+                )
+                adjusted_tasks.append(adjusted_task)
+            else:
+                # Keep non-image tasks as-is
+                adjusted_tasks.append(task)
+        
+        return adjusted_tasks
+
     def expand_to_specs(self) -> List["ModelSpec"]:
         """Expand this template into individual ModelSpec instances."""
         specs = []
@@ -741,6 +871,15 @@ class ModelSpecTemplate:
                     self.impl.impl_name, model_name, device_type.name.lower()
                 )
 
+                # Adjust max_concurrency for image tasks in perf_reference if vision_token_calculator exists
+                adjusted_perf_reference = perf_reference_map.get(device_type, [])
+                if self.vision_token_calculator and adjusted_perf_reference:
+                    adjusted_perf_reference = self._adjust_image_task_concurrency(
+                        adjusted_perf_reference,
+                        device_model_spec.max_context,
+                        device_model_spec.max_concurrency
+                    )
+
                 # Create a new device_model_spec with performance reference data
                 device_model_spec_with_perf = DeviceModelSpec(
                     device=device_model_spec.device,
@@ -748,7 +887,7 @@ class ModelSpecTemplate:
                     max_context=device_model_spec.max_context,
                     perf_targets_map=device_model_spec.perf_targets_map,
                     default_impl=device_model_spec.default_impl,
-                    perf_reference=perf_reference_map.get(device_type, []),
+                    perf_reference=adjusted_perf_reference,
                     vllm_args=device_model_spec.vllm_args,
                     override_tt_config=device_model_spec.override_tt_config,
                     env_vars=device_model_spec.env_vars,
@@ -779,6 +918,7 @@ class ModelSpecTemplate:
                     model_type=self.model_type,
                     custom_inference_server=self.custom_inference_server,
                     uses_tensor_model_cache=self.uses_tensor_model_cache,
+                    vision_token_calculator=self.vision_token_calculator,
                 )
 
 
@@ -913,6 +1053,7 @@ spec_templates = [
         ],
         status=ModelStatusTypes.EXPERIMENTAL,
         supported_modalities=["text", "image"],
+        vision_token_calculator=calculate_gemma_vision_tokens,
     ),
     ModelSpecTemplate(
         weights=[
@@ -948,6 +1089,7 @@ spec_templates = [
         ],
         status=ModelStatusTypes.EXPERIMENTAL,
         supported_modalities=["text", "image"],
+        vision_token_calculator=calculate_gemma_vision_tokens,
     ),
     ModelSpecTemplate(
         weights=[
@@ -981,6 +1123,7 @@ spec_templates = [
             "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
         },
         supported_modalities=["text", "image"],
+        vision_token_calculator=calculate_qwen_vision_tokens,
     ),
     ModelSpecTemplate(
         weights=[
@@ -1014,6 +1157,7 @@ spec_templates = [
             "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
         },
         supported_modalities=["text", "image"],
+        vision_token_calculator=calculate_qwen_vision_tokens,
     ),
     ModelSpecTemplate(
         weights=[
@@ -1035,6 +1179,7 @@ spec_templates = [
             "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
         },
         supported_modalities=["text", "image"],
+        vision_token_calculator=calculate_qwen_vision_tokens,
     ),
     ModelSpecTemplate(
         weights=[
@@ -1059,6 +1204,7 @@ spec_templates = [
             "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
         },
         supported_modalities=["text", "image"],
+        vision_token_calculator=calculate_qwen_vision_tokens,
     ),
     ModelSpecTemplate(
         weights=["Qwen/Qwen3-8B"],


### PR DESCRIPTION
## Problem
Vision language model benchmarks (e.g., `gemma-3-27b-it`) were calculating `max_concurrency` without accounting for image tokens, causing capacity overruns and 5-minute TTFT failures.

## Solution
Add vision token counting to capacity calculations only for vision models.
### Files Changed
- `workflows/model_spec.py` - Core vision token support
- `benchmarking/benchmark_config.py` - Helper function
### Impact Analysis
#### Vision Models (Intended Changes)
- Gemma-3, Qwen VL models now account for image tokens
- Example: gemma-3-27b-it (16000, 64) → max_concurrency 32 → 8 
- Fixes capacity calculation: effective_isl = text_isl + image_tokens
#### Text-Only Models (No Changes)
- vision_token_calculator = None (default)
- No image tasks processed
- All calculations remain identical

## Code Safety
- All changes gated by if `vision_token_calculator` exists
- `get_image_tokens()` returns 0 for non-vision models
- Only processes tasks with `task_type == "image"`
- Only affects models with "image" in supported_modalities
