### PR TITLE
Fix Device Initialization for Forge vLLM Plugin Model Runners

### DIFF
--- a/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
@@ -48,6 +48,9 @@ class VLLMForgeEmbeddingQwenRunner(BaseDeviceRunner):
 
         return True
 
+    def set_device(self):
+        return {}
+
     @log_execution_time("Qwen text embedding inference")
     def run_inference(self, requests: list[TextEmbeddingRequest]):
         request = requests[0]

--- a/tt-media-server/tt_model_runners/vllm_forge_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_runner.py
@@ -12,6 +12,9 @@ class VLLMForgeRunner(BaseDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
         self.pipeline = None
+        
+    def set_device(self):
+        return {}
 
     @log_execution_time("Model warmpup")
     async def load_model(self) -> bool:


### PR DESCRIPTION
## Problem
The default `set_device` implementation in `BaseDeviceRunner` does not provides the correct behavior for forge-based model runners, causing runtime errors.

## Solution
- Implement `set_device` method in `VLLMForgeRunner`
- Implement `set_device` method in `VLLMForgeEmbeddingQwenRunner`

## Note
Configuration for running `N300`
```
device_ids: str = "(0)"
is_galaxy: bool = False
device_mesh_shape: tuple = (2, 1)
```