### PR TITLE
Logger & device management improvements

### DIFF
--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -106,7 +106,7 @@ class Settings(BaseSettings):
         self._set_device_pairs_overrides()
 
     def _set_device_pairs_overrides(self):
-        if (self.device_mesh_shape == (2, 1)):
+        if self.device_mesh_shape == (2, 1):
             # use device manager to pair devices
             device_manager = DeviceManager()
             device_pairs = device_manager.get_device_pairs_from_system()

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -22,9 +22,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     # General settings
-    log_level: str = "INFO"
     environment: str = "development"
-    log_file: Optional[str] = None
     device: Optional[str] = None
 
     # Device settings
@@ -110,7 +108,13 @@ class Settings(BaseSettings):
             # use device manager to pair devices
             device_manager = DeviceManager()
             device_pairs = device_manager.get_device_pairs_from_system()
-            self.device_ids = ','.join([f"{pair}" for pair in device_pairs])
+            if device_pairs:
+                self.device_ids = ','.join([f"{pair}" for pair in device_pairs])
+        elif self.device_mesh_shape == (2, 4):
+            device_manager = DeviceManager()
+            device_groups = device_manager.get_device_groups_of_eight_from_system()
+            if device_groups:
+                self.device_ids = ','.join([f"{group}" for group in device_groups])
 
     def _set_throttling_overrides(self):
         if self.model_runner in [

--- a/tt-media-server/model_services/device_worker.py
+++ b/tt-media-server/model_services/device_worker.py
@@ -42,6 +42,8 @@ def setup_worker_environment(worker_id: str):
             os.environ["TT_MESH_GRAPH_DESC_PATH"] = f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.textproto"
         elif settings.device_mesh_shape == (2, 1):
             os.environ["TT_MESH_GRAPH_DESC_PATH"] = f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto"
+        elif settings.device_mesh_shape == (2, 4):
+            os.environ["TT_MESH_GRAPH_DESC_PATH"] = f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
 
 def device_worker(
     worker_id: str,

--- a/tt-media-server/utils/logger.py
+++ b/tt-media-server/utils/logger.py
@@ -3,9 +3,8 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import logging
+import os
 from colorama import init as colorama_init, Fore, Style
-
-from config.settings import settings
 
 # Initialize colorama for ANSI color support across platforms.
 colorama_init(autoreset=True)
@@ -29,9 +28,12 @@ class ColoredFormatter(logging.Formatter):
 
 class TTLogger:
     def __init__(self, name='TTLogger'):
-        # Use the _nameToLevel dict to convert to numeric level
-        level = logging._nameToLevel.get(settings.log_level, logging.INFO)
-        log_file = settings.log_file or None
+        # Read log level from LOG_LEVEL environment variable
+        log_level_str = os.getenv('LOG_LEVEL', 'INFO').upper()
+        level = logging._nameToLevel.get(log_level_str, logging.INFO)
+        
+        # Read log file from LOG_FILE environment variable if needed
+        log_file = os.getenv('LOG_FILE') or None
 
         self.logger = logging.getLogger(name)
         self.logger.setLevel(level)


### PR DESCRIPTION
Changes:

- Logger doesn't use settings to avoid circular dependencies
- 8 chip mapping option
- Use T3K mesh graph descriptor when 2,4 mesh on Galaxy