### PR TITLE
Renaming audio response format request parameter

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -136,6 +136,11 @@ class DeviceIds(Enum):
     DEVICE_IDS_ALL = ""  # HACK to use all devices. device id split will return and empty string to be passed to os.environ[TT_VISIBLE_DEVICES] in device_worker.py
 
 
+class AudioResponseFormat(Enum):
+    VERBOSE_JSON = "verbose_json"
+    TEXT = "text"
+
+
 # Combined model-device specific configurations
 # useful when whole device is being used by a single model type
 # also for CI testing

--- a/tt-media-server/domain/audio_transcription_request.py
+++ b/tt-media-server/domain/audio_transcription_request.py
@@ -5,6 +5,7 @@
 from typing import Dict, List, Optional, Union
 
 import numpy as np
+from config.constants import AudioResponseFormat
 from domain.base_request import BaseRequest
 
 
@@ -14,9 +15,7 @@ class AudioTranscriptionRequest(BaseRequest):
 
     # Custom fields for our implementation
     stream: bool = False
-    return_json_response: bool = (
-        True  # If True, return full JSON response; if False, return plain text only
-    )
+    response_format: str = AudioResponseFormat.VERBOSE_JSON.value
     is_preprocessing_enabled: bool = (
         True  # Enable VAD and diarization for specific request
     )


### PR DESCRIPTION
Changing the audio response format request parameter to follow the standard naming:
https://console.groq.com/docs/speech-to-text