### PR TITLE
Add sleeping for 10 secs before checking liveness

### DIFF
--- a/utils/media_clients/image_client.py
+++ b/utils/media_clients/image_client.py
@@ -176,12 +176,25 @@ class ImageClientStrategy(BaseMediaStrategy):
     def get_health(self, attempt_number=1) -> bool:
         """Check the health of the server with retries."""
         # wait for server to start
-        time.sleep(10)
-        response = requests.get(f"{self.base_url}/tt-liveness")
+        try:
+            response = requests.get(f"{self.base_url}/tt-liveness")
+        except Exception as e:
+            if attempt_number < 5:
+                logger.warning(
+                    f"Health check connection failed: {e}. Retrying..."
+                )
+                time.sleep(5)
+                return self.get_health(attempt_number + 1)
+            else:
+                logger.error(
+                    f"Health check connection error: {e}"
+                )
+                raise
+        
         # server returns 200 if healthy only
         # otherwise it is 405
         if response.status_code != 200:
-            if attempt_number < 20:
+            if attempt_number < 25:
                 logger.warning(
                     f"Health check failed with status code: {response.status_code}. Retrying..."
                 )


### PR DESCRIPTION
When running run.py script with arguments to start media inference server in Docker container, run evals method fails on GET request for liveness check throwing 104 status code.
Example of command:
`python3 run.py --model stable-diffusion-xl-base-1.0 --device galaxy --workflow release --docker-server --dev-mode --ci-mode --override-docker-image ghcr.io/tenstorrent/tt-shield/tt-media-inference-server:c1d07a6c7c1c42f1aeb498a8bb9db5e5046fbc85_2a52055_56389736125`
Error log:
`2025-11-26 11:10:23,768 - utils.media_clients.image_client - ERROR - Eval execution encountered an error: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))`
`2025-11-26 11:10:23,769 - utils.media_clients.media_client_factory - ERROR - ❌ CNN MediaTaskType.EVALUATION failed: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))`

To prevent this, I have added sleep for 10 secs before sending GET request.