### PR TITLE
Enable Batching for SDXL Models

### DIFF
--- a/tt-media-server/tt_model_runners/base_sdxl_runner.py
+++ b/tt-media-server/tt_model_runners/base_sdxl_runner.py
@@ -124,10 +124,10 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
         pass
 
     def _process_prompts(
-        self, requests: list[ImageGenerateRequest]
+        self, request: ImageGenerateRequest
     ) -> tuple[list[str], str, int]:
-        prompts = [request.prompt for request in requests]
-        negative_prompt = requests[0].negative_prompt
+        prompts = request.prompt
+        negative_prompt = request.negative_prompt
         if isinstance(prompts, str):
             prompts = [prompts]
 
@@ -136,10 +136,10 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
         ) % self.batch_size
         prompts = prompts + [""] * needed_padding
 
-        prompts_2 = requests[0].prompt_2
-        negative_prompt_2 = requests[0].negative_prompt_2
+        prompts_2 = request.prompt_2
+        negative_prompt_2 = request.negative_prompt_2
         if prompts_2 is not None:
-            prompts_2 = [request.prompt_2 for request in requests]
+            prompts_2 = request.prompt_2
             if isinstance(prompts_2, str):
                 prompts_2 = [prompts_2]
 

--- a/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
@@ -77,45 +77,48 @@ class TTSDXLGenerateRunnerTrace(BaseSDXLRunner):
         os.environ.get("TT_VISIBLE_DEVICES"),
     )
     def run_inference(self, requests: list[ImageGenerateRequest]):
-        prompts, negative_prompt, prompts_2, negative_prompt_2, needed_padding = (
-            self._process_prompts(requests)
-        )
-
-        self._apply_request_settings(requests[0])
-
-        self.logger.debug(f"Device {self.device_id}: Starting text encoding...")
-        self.tt_sdxl.compile_text_encoding()
-
-        (
-            all_prompt_embeds_torch,
-            torch_add_text_embeds,
-        ) = self.tt_sdxl.encode_prompts(
-            prompts, negative_prompt, prompts_2, negative_prompt_2
-        )
-
-        self.logger.info(f"Device {self.device_id}: Generating input tensors...")
-
-        tt_latents, tt_prompt_embeds, tt_add_text_embeds = (
-            self.tt_sdxl.generate_input_tensors(
-                all_prompt_embeds_torch=all_prompt_embeds_torch,
-                torch_add_text_embeds=torch_add_text_embeds,
-                start_latent_seed=requests[0].seed,
-                timesteps=requests[0].timesteps,
-                sigmas=requests[0].sigmas,
+        outputs = []
+        for request in requests:
+            prompts, negative_prompt, prompts_2, negative_prompt_2, needed_padding = (
+                self._process_prompts(request)
             )
-        )
 
-        self.logger.debug(f"Device {self.device_id}: Preparing input tensors...")
+            self._apply_request_settings(request)
+            self.logger.debug(f"Device {self.device_id}: Starting text encoding...")
+            self.tt_sdxl.compile_text_encoding()
 
-        tensors = (
-            tt_latents,
-            tt_prompt_embeds,
-            tt_add_text_embeds,
-        )
-        self._prepare_input_tensors_for_iteration(tensors, 0)
+            (
+                all_prompt_embeds_torch,
+                torch_add_text_embeds,
+            ) = self.tt_sdxl.encode_prompts(
+                prompts, negative_prompt, prompts_2, negative_prompt_2
+            )
 
-        self.logger.debug(f"Device {self.device_id}: Compiling image processing...")
+            self.logger.info(f"Device {self.device_id}: Generating input tensors...")
 
-        self.tt_sdxl.compile_image_processing()
+            tt_latents, tt_prompt_embeds, tt_add_text_embeds = (
+                self.tt_sdxl.generate_input_tensors(
+                    all_prompt_embeds_torch=all_prompt_embeds_torch,
+                    torch_add_text_embeds=torch_add_text_embeds,
+                    start_latent_seed=request.seed,
+                    timesteps=request.timesteps,
+                    sigmas=request.sigmas,
+                )
+            )
 
-        return self._ttnn_inference(tensors, prompts, needed_padding)
+            self.logger.debug(f"Device {self.device_id}: Preparing input tensors...")
+
+            tensors = (
+                tt_latents,
+                tt_prompt_embeds,
+                tt_add_text_embeds,
+            )
+            self._prepare_input_tensors_for_iteration(tensors, 0)
+
+            self.logger.debug(f"Device {self.device_id}: Compiling image processing...")
+
+            self.tt_sdxl.compile_image_processing()
+
+            outputs.append(self._ttnn_inference(tensors, prompts, needed_padding))
+
+        return outputs

--- a/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
@@ -27,7 +27,8 @@ class TTSDXLImageToImageRunner(BaseSDXLRunner):
 
     def _load_pipeline(self):
         self.pipeline = StableDiffusionXLImg2ImgPipeline.from_pretrained(
-            self.settings.model_weights_path or SupportedModels.STABLE_DIFFUSION_XL_IMG2IMG.value,
+            self.settings.model_weights_path
+            or SupportedModels.STABLE_DIFFUSION_XL_IMG2IMG.value,
             torch_dtype=torch.float32,
             use_safetensors=True,
         )
@@ -46,24 +47,26 @@ class TTSDXLImageToImageRunner(BaseSDXLRunner):
         )
 
     def _warmup_inference_block(self):
-        self.run_inference([ImageToImageRequest.model_construct(
-            prompt="Sunrise on a beach",
-            image="R0lGODdhAQABAPAAAP///wAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==",  # 1x1 transparent pixel
-            negative_prompt="low resolution",
-            num_inference_steps=2,
-            guidance_scale=5.0,
-            number_of_images=1,
-            strength=0.99,
-            aesthetic_score=6.0,
-            negative_aesthetic_score=2.5,
-        )])
+        self.run_inference(
+            [
+                ImageToImageRequest.model_construct(
+                    prompt="Sunrise on a beach",
+                    image="R0lGODdhAQABAPAAAP///wAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==",  # 1x1 transparent pixel
+                    negative_prompt="low resolution",
+                    num_inference_steps=2,
+                    guidance_scale=5.0,
+                    number_of_images=1,
+                    strength=0.99,
+                    aesthetic_score=6.0,
+                    negative_aesthetic_score=2.5,
+                )
+            ]
+        )
 
     def _preprocess_image(self, base64_image: str) -> torch.Tensor:
         try:
             pil_image = self.image_manager.base64_to_pil_image(
-                base64_image,
-                target_size=self.image_size,
-                target_mode=self.image_mode
+                base64_image, target_size=self.image_size, target_mode=self.image_mode
             )
 
             image_tensor = self.tt_sdxl.torch_pipeline.image_processor.preprocess(
@@ -71,75 +74,93 @@ class TTSDXLImageToImageRunner(BaseSDXLRunner):
                 height=self.image_size[1],
                 width=self.image_size[0],
                 crops_coords=None,
-                resize_mode="default"
+                resize_mode="default",
             ).to(dtype=torch.float32)
 
             return torch.cat([image_tensor], dim=0)
 
         except Exception as e:
-            self.logger.error(f"Device {self.device_id}: Failed to preprocess image: {e}")
+            self.logger.error(
+                f"Device {self.device_id}: Failed to preprocess image: {e}"
+            )
             raise
 
-    def _apply_image_to_image_request_settings(self, request: ImageToImageRequest) -> None:
+    def _apply_image_to_image_request_settings(
+        self, request: ImageToImageRequest
+    ) -> None:
         if request.strength is not None:
             self.tt_sdxl.set_strength(request.strength)
 
-        ''' TODO: Reintroduce these fields when https://github.com/tenstorrent/tt-metal/issues/31032 is resolved
+        """ TODO: Reintroduce these fields when https://github.com/tenstorrent/tt-metal/issues/31032 is resolved
         if request.aesthetic_score is not None:
             self.tt_sdxl.set_aesthetic_score(request.aesthetic_score)
 
         if request.negative_aesthetic_score is not None:
             self.tt_sdxl.set_negative_aesthetic_score(request.negative_aesthetic_score)
-        '''
+        """
 
     def _prepare_input_tensors_for_iteration(self, tensors, iter: int):
         tt_image_latents, tt_prompt_embeds, tt_add_text_embeds = tensors
-        self.tt_sdxl.prepare_input_tensors([
-            tt_image_latents,
-            tt_prompt_embeds[iter],
-            tt_add_text_embeds[iter],
-        ])
+        self.tt_sdxl.prepare_input_tensors(
+            [
+                tt_image_latents,
+                tt_prompt_embeds[iter],
+                tt_add_text_embeds[iter],
+            ]
+        )
 
-    @log_execution_time("SDXL image-to-image inference", TelemetryEvent.MODEL_INFERENCE, os.environ.get("TT_VISIBLE_DEVICES"))
+    @log_execution_time(
+        "SDXL image-to-image inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
     def run_inference(self, requests: list[ImageToImageRequest]):
-        prompts, negative_prompt, prompts_2, negative_prompt_2, needed_padding = self._process_prompts(requests)
+        outputs = []
+        for request in requests:
+            prompts, negative_prompt, prompts_2, negative_prompt_2, needed_padding = (
+                self._process_prompts(request)
+            )
 
-        self._apply_request_settings(requests[0])
-        self._apply_image_to_image_request_settings(requests[0])
+            self._apply_request_settings(request)
+            self._apply_image_to_image_request_settings(request)
 
-        self.logger.debug(f"Device {self.device_id}: Starting text encoding...")
-        self.tt_sdxl.compile_text_encoding()
+            self.logger.debug(f"Device {self.device_id}: Starting text encoding...")
+            self.tt_sdxl.compile_text_encoding()
 
-        (
-            all_prompt_embeds_torch,
-            torch_add_text_embeds,
-        ) = self.tt_sdxl.encode_prompts(prompts, negative_prompt, prompts_2, negative_prompt_2)
+            (
+                all_prompt_embeds_torch,
+                torch_add_text_embeds,
+            ) = self.tt_sdxl.encode_prompts(
+                prompts, negative_prompt, prompts_2, negative_prompt_2
+            )
 
-        image = self._preprocess_image(requests[0].image)
+            image = self._preprocess_image(request.image)
 
-        self.logger.info(f"Device {self.device_id}: Generating input tensors...")
+            self.logger.info(f"Device {self.device_id}: Generating input tensors...")
 
-        tt_latents, tt_prompt_embeds, tt_add_text_embeds = self.tt_sdxl.generate_input_tensors(
-            torch_image=image,
-            all_prompt_embeds_torch=all_prompt_embeds_torch,
-            torch_add_text_embeds=torch_add_text_embeds,
-            start_latent_seed=requests[0].seed,
-            timesteps=requests[0].timesteps,
-            sigmas=requests[0].sigmas
+            tt_latents, tt_prompt_embeds, tt_add_text_embeds = (
+                self.tt_sdxl.generate_input_tensors(
+                    torch_image=image,
+                    all_prompt_embeds_torch=all_prompt_embeds_torch,
+                    torch_add_text_embeds=torch_add_text_embeds,
+                    start_latent_seed=request.seed,
+                    timesteps=request.timesteps,
+                    sigmas=request.sigmas,
+                )
+            )
 
-        )
+            self.logger.debug(f"Device {self.device_id}: Preparing input tensors...")
 
-        self.logger.debug(f"Device {self.device_id}: Preparing input tensors...")
+            tensors = (
+                tt_latents,
+                tt_prompt_embeds,
+                tt_add_text_embeds,
+            )
+            self._prepare_input_tensors_for_iteration(tensors, 0)
 
-        tensors = (
-            tt_latents,
-            tt_prompt_embeds,
-            tt_add_text_embeds,
-        )
-        self._prepare_input_tensors_for_iteration(tensors, 0)
+            self.logger.debug(f"Device {self.device_id}: Compiling image processing...")
 
-        self.logger.debug(f"Device {self.device_id}: Compiling image processing...")
+            self.tt_sdxl.compile_image_processing()
 
-        self.tt_sdxl.compile_image_processing()
-
-        return self._ttnn_inference(tensors, prompts, needed_padding)
+            outputs.append(self._ttnn_inference(tensors, prompts, needed_padding))
+        return outputs


### PR DESCRIPTION
## Problem
Previously, setting `max_batch_size` caused runtime errors for SDXL models (SDXL Trace, SDXL Image-To-Image and SDXL Inpainting). 
With these changes, it now runs successfully, but there are no performance gains yet since the current model does not support batching as is.