### PR TITLE
handle data_parallel factor in performance targets

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -132,6 +132,7 @@ def scale_llm_perf_targets(task: BenchmarkTaskParams, data_parallel: int) -> Ben
 
 
 def get_perf_reference(device_model_spec, perf_reference_map):
+    # TODO: support other DP signaling conventions (i.e., for vLLM V1 it will be configured through vllm_args.data_parallel_size)
     data_parallel = device_model_spec.override_tt_config.get("data_parallel")
 
     if data_parallel:


### PR DESCRIPTION
# change log

* address https://github.com/tenstorrent/tt-inference-server/issues/945, handle data_parallel factor in performance targets

### Testing Results

Running:
```
python3 run.py --model Qwen3-32B --device galaxy --workflow server --docker-server --dev-mode
```

printing: `model_spec.device_model_spec.perf_reference[0].targets`
```
# no data_parallel
model_spec.device_model_spec.perf_reference[0].targets
{'functional': PerformanceTarget(ttft_ms=300.0, tput_user=15.600000000000001, tput=532.9, tolerance=0.0), 
'complete': PerformanceTarget(ttft_ms=60.0, tput_user=78.0, tput=2664.5, tolerance=0.0), 
'target': PerformanceTarget(ttft_ms=30.0, tput_user=156.0, tput=5329.0, tolerance=0.0)}

# "data_parallel": 1,
model_spec.device_model_spec.perf_reference[0].targets
{'functional': PerformanceTarget(ttft_ms=300.0, tput_user=15.600000000000001, tput=532.9, tolerance=0.0),
'complete': PerformanceTarget(ttft_ms=60.0, tput_user=78.0, tput=2664.5, tolerance=0.0),
'target': PerformanceTarget(ttft_ms=30.0, tput_user=156.0, tput=5329.0, tolerance=0.0)}

# "data_parallel": 2,
ValueError: Invalid DeviceType or data_parallel: 11, 2

# "data_parallel": 4,
model_spec.device_model_spec.perf_reference[0].targets
{'functional': PerformanceTarget(ttft_ms=620.0, tput_user=4.1000000000000005, tput=532.8000000000001, tolerance=0.0),
'complete': PerformanceTarget(ttft_ms=124.0, tput_user=20.5, tput=2664.0, tolerance=0.0),
'target': PerformanceTarget(ttft_ms=62.0, tput_user=41.0, tput=5328.0, tolerance=0.0)}

# "data_parallel": 10,
ValueError: Invalid DeviceType or data_parallel: 11, 10

# "data_parallel": 16,
model_spec.device_model_spec.perf_reference[0].targets
*** IndexError: list index out of range
```