### PR TITLE
Add min_context_length as Forge vLLM Plugin Argument

### DIFF
--- a/tt-media-server/README.md
+++ b/tt-media-server/README.md
@@ -328,6 +328,7 @@ The TT Inference Server can be configured using environment variables or by modi
 
 | Environment Variable | Default Value | Description |
 |---------------------|---------------|-------------|
+| `MIN_CONTEXT_LENGTH` | `1` | Sets the maximum number of tokens that can be processed per sequence, including both input and output tokens. Must be a power of two. |
 | `MAX_MODEL_LENGTH` | `2**14` | Sets the maximum number of tokens that can be processed per sequence, including both input and output tokens. Determines the model's context window size. Must be a power of two. |
 | `MAX_NUM_BATCHED_TOKENS` | `2**14` | Sets the maximum total number of tokens processed in a single iteration across all active sequences. Higher values improve throughput but increase memory usage and latency. Must be a power of two. |
 | `MAX_NUM_SEQS` | `1` | Defines the maximum number of sequences that can be batched and processed simultaneously in one iteration. |

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -58,6 +58,7 @@ class Settings(BaseSettings):
     inference_timeout_seconds: int = 1000
 
     # Text processing settings
+    min_context_length: int = 1
     max_model_length: int = 2**14
     max_num_batched_tokens: int = 2**14
     max_num_seqs: int = 1

--- a/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
@@ -36,6 +36,7 @@ class VLLMForgeEmbeddingQwenRunner(BaseDeviceRunner):
             "max_num_seqs": self.settings.max_num_seqs,
             "additional_config": {
                 "enable_const_eval": False,
+                "min_context_len": self.settings.min_context_length,
             },
             "hf_overrides": {
                 "is_matryoshka": True,
@@ -59,6 +60,10 @@ class VLLMForgeEmbeddingQwenRunner(BaseDeviceRunner):
         if num_tokens > self.settings.max_model_length:
             raise ValueError(
                 f"Input text exceeds maximum model length of {self.settings.max_model_length} tokens. Got {num_tokens} tokens."
+            )
+        if num_tokens < self.settings.min_context_length:
+            raise ValueError(
+                f"Input text is shorter than minimum context length of {self.settings.min_context_length} tokens. Got {num_tokens} tokens."
             )
 
         self.logger.debug(f"Device {self.device_id}: Running inference")


### PR DESCRIPTION
## Problem
With large batch sizes and long model sequences, precompilation of computation graphs could take a very long time due to the the number of possible input shapes (log(max_model_length)*batch_size). This leads to long model warmup times.

## Implementation
- use `min_context_length` as a configurable parameter for vLLM

## Note
It is not strictly necessary for the provided prompt to exceed the specified `min_context_length` as inference will still work with shorter prompts. However, doing so may significantly increase processing time for that request, which is probably not wanted from the customer’s perspective.