### PR TITLE
#33058 (metal issue) Limit torch threads in SDXL inference.

### DIFF
--- a/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
@@ -68,6 +68,14 @@ class TTSDXLGenerateRunnerTrace(BaseSDXLRunner):
         self._apply_request_settings(requests[0])
         
         self.logger.debug(f"Device {self.device_id}: Starting text encoding...")
+
+        # Limit the number of threads torch can create in order to avoid thread explosion when running multi-process scenarios (such as 32 processes on a galaxy).
+        # This way, torch can create only one thread per process, instead of predefined number of them (32).
+        if torch.get_num_threads() != 1:
+            torch.set_num_threads(1)
+        if torch.get_num_interop_threads() != 1:
+            torch.set_num_interop_threads(1)
+
         self.tt_sdxl.compile_text_encoding()
 
         (

--- a/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
@@ -69,13 +69,6 @@ class TTSDXLGenerateRunnerTrace(BaseSDXLRunner):
         
         self.logger.debug(f"Device {self.device_id}: Starting text encoding...")
 
-        # Limit the number of threads torch can create in order to avoid thread explosion when running multi-process scenarios (such as 32 processes on a galaxy).
-        # This way, torch can create only one thread per process, instead of predefined number of them (32).
-        if torch.get_num_threads() != 1:
-            torch.set_num_threads(1)
-        if torch.get_num_interop_threads() != 1:
-            torch.set_num_interop_threads(1)
-
         self.tt_sdxl.compile_text_encoding()
 
         (

--- a/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
@@ -68,7 +68,6 @@ class TTSDXLGenerateRunnerTrace(BaseSDXLRunner):
         self._apply_request_settings(requests[0])
         
         self.logger.debug(f"Device {self.device_id}: Starting text encoding...")
-
         self.tt_sdxl.compile_text_encoding()
 
         (


### PR DESCRIPTION
SDXL has some torch code in encode_prompts path (such as concat, chunk etc).
When ran as 32 independent users, each process can spawn as many torch threads as it wants, leading to thread explosions in these cases, producing huge overheads (such as +3s for encoding prompts), if 32 requests arrive at the same time.

To avoid this, we can limit number of threads the torch is available to spawn.