### PR TITLE
Use Lean Metalium Docker Image as Base Image

### DIFF
--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -48,7 +48,7 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
     && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
 
 
-# extra system deps
+# These packages are required during the application build stage - they are not included in the runtime image
 RUN apt-get update && apt-get install -y \
     # required
     gosu \

--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -8,7 +8,7 @@
 # Note: Dependencies installed in this stage are NOT included in the final image.
 # Only the built artifacts and files are copied to the runtime stage.
 # Runtime dependencies must be installed separately in the runtime stage.
-FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest AS builder
+FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-basic-dev-amd64:latest AS builder
 
 # Build stage
 LABEL maintainer="Igor Djuric <idjuric@tenstorrent.com>"
@@ -168,7 +168,7 @@ RUN rm -rf ${HOME_DIR}/.rustup \
 # ==============================================================================
 # This is the final image that will be used. Only the built artifacts from the builder stage
 # are copied here. Any runtime dependencies needed by the application must be installed in this stage.
-FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest AS runtime
+FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-basic-dev-amd64:latest AS runtime
 
 LABEL maintainer="Igor Djuric <idjuric@tenstorrent.com>"
 LABEL org.opencontainers.image.source=https://github.com/tenstorrent/tt-inference-server
@@ -205,6 +205,8 @@ RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_
     && chown -R ${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} ${HOME_DIR} \
     && mkdir -p /run/sshd \
     && chmod 755 /run/sshd
+
+RUN apt-get update && apt-get install -y libnuma1 && rm -rf /var/lib/apt/lists/*
 
 # Copy everything from builder
 COPY --from=builder --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} \

--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -10,7 +10,9 @@
 # Runtime dependencies must be installed separately in the runtime stage.
 FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-basic-dev-amd64:latest AS builder
 
+# Build stage
 LABEL maintainer="Igor Djuric <idjuric@tenstorrent.com>"
+# connect Github repo with package
 LABEL org.opencontainers.image.source=https://github.com/tenstorrent/tt-inference-server
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -53,7 +55,6 @@ RUN apt-get update && apt-get install -y \
     libgl1 \
     libsndfile1 \
     wget \
-    git \
     git-lfs \
     nano \
     acl \
@@ -66,8 +67,6 @@ RUN apt-get update && apt-get install -y \
     libffi-dev \
     libssl-dev \
     protobuf-compiler \
-    libgl1-mesa-glx \
-    libnuma1 \
     libprotobuf-dev \
     pkg-config \
     htop \
@@ -103,8 +102,6 @@ RUN git clone --depth 1 https://github.com/tenstorrent-metal/tt-metal.git ${TT_M
     && hash -r \
     && find ${TT_METAL_HOME} -name ".git" -type d -exec rm -rf {} + 2>/dev/null || true
 
-RUN git config --global --add safe.directory '*'
-
 # user setup
 RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_USERNAME} \
     && mkdir -p ${HOME_DIR} \
@@ -124,7 +121,8 @@ RUN /bin/bash -c "source ${PYTHON_ENV_DIR}/bin/activate \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --no-modify-path \
     && . ${HOME_DIR}/.cargo/env \
     && rustup update \
-    && pip3 install git+https://github.com/tenstorrent/tt-smi"
+    && pip3 install git+https://github.com/tenstorrent/tt-smi \
+    && find ${HOME_DIR} -name '.git' -type d -exec rm -rf {} + 2>/dev/null || true"
 
 WORKDIR ${HOME_DIR}
 
@@ -183,6 +181,7 @@ ARG HOME_DIR=/home/${CONTAINER_APP_USERNAME}
 
 ENV TT_METAL_COMMIT_SHA_OR_TAG=${TT_METAL_COMMIT_SHA_OR_TAG} \
     ENVIRONMENT=development \
+    TT_MM_THROTTLE_PERF=5 \
     SHELL=/bin/bash \
     CONTAINER_APP_USERNAME=${CONTAINER_APP_USERNAME} \
     TT_METAL_HOME=${HOME_DIR}/tt-metal \
@@ -197,8 +196,10 @@ ENV TT_METAL_COMMIT_SHA_OR_TAG=${TT_METAL_COMMIT_SHA_OR_TAG} \
 # These packages are required for the application to run in production
 RUN apt-get update && apt-get install -y \
     ffmpeg \
-    pyyaml \
-    gitpython \
+    libsndfile1 \
+    libgl1 \
+    python3-yaml \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # Create user
@@ -206,32 +207,12 @@ RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_
     && mkdir -p ${HOME_DIR} \
     && chown -R ${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} ${HOME_DIR} \
     && mkdir -p /run/sshd \
-    && chmod 755 /run/sshd
-
-# Copy git and its dependencies from builder stage
-COPY --from=builder /usr/bin/git* /usr/bin/
-COPY --from=builder /usr/share/git-core /usr/share/
-COPY --from=builder /usr/lib/git-core /usr/lib/
-
-# Copy system libraries from builder
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libcurl* \
-                    /usr/lib/x86_64-linux-gnu/libnuma* \
-                    /usr/lib/x86_64-linux-gnu/
-
-# Copy python3-yaml from builder
-COPY --from=builder /usr/lib/python3/dist-packages/yaml* \
-                    /usr/lib/python3/dist-packages/PyYAML* \
-                    /usr/lib/python3/dist-packages/
+    && chmod 755 /run/sshd \
+    && git config --global --add safe.directory '*'
 
 # Copy everything from builder
 COPY --from=builder --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} \
     /home/container_app_user ${HOME_DIR}
-
-# Copy system Python packages from builder
-COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10
-
-# Configure git for mounted volumes
-RUN git config --global --add safe.directory '*'
 
 USER ${CONTAINER_APP_USERNAME}
 WORKDIR ${HOME_DIR}/tt-metal

--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -208,9 +208,22 @@ RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_
 
 RUN apt-get update && apt-get install -y libnuma1 libgl1-mesa-glx && rm -rf /var/lib/apt/lists/*
 
+# Install python3-pip in runtime stage
+RUN apt-get update && apt-get install -y python3-pip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Copy everything from builder
 COPY --from=builder --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} \
     /home/container_app_user ${HOME_DIR}
+
+# Install pyyaml in both system Python and venv
+RUN pip3 install pyyaml && \
+    pip3 install gitpython && \
+    /bin/bash -c "source ${HOME_DIR}/tt-metal/python_env/bin/activate && pip3 install pyyaml" && \
+    python3 -c "import yaml; print('System Python: yaml imported successfully')" && \
+    /bin/bash -c "source ${HOME_DIR}/tt-metal/python_env/bin/activate && python3 -c 'import yaml; print(\"Venv Python: yaml imported successfully\")'" && \
+    chown -R ${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} ${HOME_DIR}/tt-metal/python_env && \
+    rm -rf /root/.cache/pip
 
 USER ${CONTAINER_APP_USERNAME}
 WORKDIR ${HOME_DIR}/tt-metal

--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -206,7 +206,7 @@ RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_
     && mkdir -p /run/sshd \
     && chmod 755 /run/sshd
 
-RUN apt-get update && apt-get install -y libnuma1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libnuma1 libgl1-mesa-glx && rm -rf /var/lib/apt/lists/*
 
 # Copy everything from builder
 COPY --from=builder --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} \

--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -99,7 +99,6 @@ RUN git clone --depth 1 https://github.com/tenstorrent-metal/tt-metal.git ${TT_M
     && pip3 install --upgrade setuptools wheel \
     && bash ./build_metal.sh --release -e \
     && pip3 install cmake \
-    && pip3 install pyyaml \
     && pip3 install cmake --upgrade \
     && hash -r \
     && find ${TT_METAL_HOME} -name ".git" -type d -exec rm -rf {} + 2>/dev/null || true
@@ -218,10 +217,6 @@ WORKDIR ${HOME_DIR}/tt-metal
 
 # Set up bashrc
 RUN echo "source ${PYTHON_ENV_DIR}/bin/activate" >> ${HOME_DIR}/.bashrc
-
-# Install PyYAML in runtime environment and system Python
-RUN /bin/bash -c "source ${PYTHON_ENV_DIR}/bin/activate && pip install pyyaml"
-RUN pip3 install pyyaml
 
 EXPOSE 8000
 CMD ["/bin/bash", "-c", "source ${PYTHON_ENV_DIR}/bin/activate && cd ${TT_METAL_HOME}/server/ && source ./run_uvicorn.sh"]

--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -197,6 +197,8 @@ ENV TT_METAL_COMMIT_SHA_OR_TAG=${TT_METAL_COMMIT_SHA_OR_TAG} \
 # These packages are required for the application to run in production
 RUN apt-get update && apt-get install -y \
     ffmpeg \
+    pyyaml \
+    gitpython \
     && rm -rf /var/lib/apt/lists/*
 
 # Create user

--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -10,15 +10,12 @@
 # Runtime dependencies must be installed separately in the runtime stage.
 FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-basic-dev-amd64:latest AS builder
 
-# Build stage
 LABEL maintainer="Igor Djuric <idjuric@tenstorrent.com>"
-# connect Github repo with package
 LABEL org.opencontainers.image.source=https://github.com/tenstorrent/tt-inference-server
 
 ARG DEBIAN_FRONTEND=noninteractive
 # default commit sha, override with --build-arg TT_METAL_COMMIT_SHA_OR_TAG=<sha>
 ARG TT_METAL_COMMIT_SHA_OR_TAG=915d9e67ad572b97fbaf5339bd3e518db6dc05e3
-
 
 # CONTAINER_APP_UID is a random ID, change this and rebuild if it collides with host
 ARG CONTAINER_APP_UID=1000
@@ -56,6 +53,7 @@ RUN apt-get update && apt-get install -y \
     libgl1 \
     libsndfile1 \
     wget \
+    git \
     git-lfs \
     nano \
     acl \
@@ -68,6 +66,8 @@ RUN apt-get update && apt-get install -y \
     libffi-dev \
     libssl-dev \
     protobuf-compiler \
+    libgl1-mesa-glx \
+    libnuma1 \
     libprotobuf-dev \
     pkg-config \
     htop \
@@ -80,9 +80,6 @@ RUN apt-get update && apt-get install -y \
     rsync \
     && rm -rf /var/lib/apt/lists/* \
     && protoc --version
-
-# Install pyyaml and gitpython in system Python during build stage
-RUN pip3 install pyyaml gitpython
 
 RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-linux-x86_64.sh -o cmake.sh && \
     chmod +x cmake.sh && \
@@ -106,6 +103,8 @@ RUN git clone --depth 1 https://github.com/tenstorrent-metal/tt-metal.git ${TT_M
     && hash -r \
     && find ${TT_METAL_HOME} -name ".git" -type d -exec rm -rf {} + 2>/dev/null || true
 
+RUN git config --global --add safe.directory '*'
+
 # user setup
 RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_USERNAME} \
     && mkdir -p ${HOME_DIR} \
@@ -125,8 +124,7 @@ RUN /bin/bash -c "source ${PYTHON_ENV_DIR}/bin/activate \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --no-modify-path \
     && . ${HOME_DIR}/.cargo/env \
     && rustup update \
-    && pip3 install git+https://github.com/tenstorrent/tt-smi \
-    && find ${HOME_DIR} -name '.git' -type d -exec rm -rf {} + 2>/dev/null || true"
+    && pip3 install git+https://github.com/tenstorrent/tt-smi"
 
 WORKDIR ${HOME_DIR}
 
@@ -185,7 +183,6 @@ ARG HOME_DIR=/home/${CONTAINER_APP_USERNAME}
 
 ENV TT_METAL_COMMIT_SHA_OR_TAG=${TT_METAL_COMMIT_SHA_OR_TAG} \
     ENVIRONMENT=development \
-    TT_MM_THROTTLE_PERF=5 \
     SHELL=/bin/bash \
     CONTAINER_APP_USERNAME=${CONTAINER_APP_USERNAME} \
     TT_METAL_HOME=${HOME_DIR}/tt-metal \
@@ -209,14 +206,30 @@ RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_
     && mkdir -p /run/sshd \
     && chmod 755 /run/sshd
 
-RUN apt-get update && apt-get install -y libnuma1 libgl1-mesa-glx && rm -rf /var/lib/apt/lists/*
+# Copy git and its dependencies from builder stage
+COPY --from=builder /usr/bin/git* /usr/bin/
+COPY --from=builder /usr/share/git-core /usr/share/
+COPY --from=builder /usr/lib/git-core /usr/lib/
 
-# Copy everything from builder (includes pip packages)
+# Copy system libraries from builder
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libcurl* \
+                    /usr/lib/x86_64-linux-gnu/libnuma* \
+                    /usr/lib/x86_64-linux-gnu/
+
+# Copy python3-yaml from builder
+COPY --from=builder /usr/lib/python3/dist-packages/yaml* \
+                    /usr/lib/python3/dist-packages/PyYAML* \
+                    /usr/lib/python3/dist-packages/
+
+# Copy everything from builder
 COPY --from=builder --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} \
     /home/container_app_user ${HOME_DIR}
 
 # Copy system Python packages from builder
 COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10
+
+# Configure git for mounted volumes
+RUN git config --global --add safe.directory '*'
 
 USER ${CONTAINER_APP_USERNAME}
 WORKDIR ${HOME_DIR}/tt-metal

--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -99,6 +99,7 @@ RUN git clone --depth 1 https://github.com/tenstorrent-metal/tt-metal.git ${TT_M
     && pip3 install --upgrade setuptools wheel \
     && bash ./build_metal.sh --release -e \
     && pip3 install cmake \
+    && pip3 install pyyaml \
     && pip3 install cmake --upgrade \
     && hash -r \
     && find ${TT_METAL_HOME} -name ".git" -type d -exec rm -rf {} + 2>/dev/null || true
@@ -217,6 +218,10 @@ WORKDIR ${HOME_DIR}/tt-metal
 
 # Set up bashrc
 RUN echo "source ${PYTHON_ENV_DIR}/bin/activate" >> ${HOME_DIR}/.bashrc
+
+# Install PyYAML in runtime environment and system Python
+RUN /bin/bash -c "source ${PYTHON_ENV_DIR}/bin/activate && pip install pyyaml"
+RUN pip3 install pyyaml
 
 EXPOSE 8000
 CMD ["/bin/bash", "-c", "source ${PYTHON_ENV_DIR}/bin/activate && cd ${TT_METAL_HOME}/server/ && source ./run_uvicorn.sh"]

--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -81,6 +81,9 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && protoc --version
 
+# Install pyyaml and gitpython in system Python during build stage
+RUN pip3 install pyyaml gitpython
+
 RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-linux-x86_64.sh -o cmake.sh && \
     chmod +x cmake.sh && \
     ./cmake.sh --skip-license --prefix=/usr/local && \
@@ -208,22 +211,12 @@ RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_
 
 RUN apt-get update && apt-get install -y libnuma1 libgl1-mesa-glx && rm -rf /var/lib/apt/lists/*
 
-# Install python3-pip in runtime stage
-RUN apt-get update && apt-get install -y python3-pip && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Copy everything from builder
+# Copy everything from builder (includes pip packages)
 COPY --from=builder --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} \
     /home/container_app_user ${HOME_DIR}
 
-# Install pyyaml in both system Python and venv
-RUN pip3 install pyyaml && \
-    pip3 install gitpython && \
-    /bin/bash -c "source ${HOME_DIR}/tt-metal/python_env/bin/activate && pip3 install pyyaml" && \
-    python3 -c "import yaml; print('System Python: yaml imported successfully')" && \
-    /bin/bash -c "source ${HOME_DIR}/tt-metal/python_env/bin/activate && python3 -c 'import yaml; print(\"Venv Python: yaml imported successfully\")'" && \
-    chown -R ${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} ${HOME_DIR}/tt-metal/python_env && \
-    rm -rf /root/.cache/pip
+# Copy system Python packages from builder
+COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10
 
 USER ${CONTAINER_APP_USERNAME}
 WORKDIR ${HOME_DIR}/tt-metal

--- a/tt-media-server/requirements.txt
+++ b/tt-media-server/requirements.txt
@@ -11,7 +11,6 @@ pydantic
 pydantic_settings
 pytest
 python-multipart
-pyyaml
 torch
 tqdm
 transformers

--- a/tt-media-server/requirements.txt
+++ b/tt-media-server/requirements.txt
@@ -11,6 +11,7 @@ pydantic
 pydantic_settings
 pytest
 python-multipart
+pyyaml
 torch
 tqdm
 transformers


### PR DESCRIPTION
## Problem
It was possible to further reduce Docker image size, by using metal's basic-dev as base image.

## Implementation
- use lean base image for both runtime and build stages

## Results
Previously:
```
inf-server  latest    3c2b66c9c0ca   48 minutes ago   20.6GB
```
Now:
```
inf-server   lean    e17676090f08   34 seconds ago   13.8GB