### PR TITLE
Galaxy test tweaks

### DIFF
--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -48,7 +48,7 @@ class Settings(BaseSettings):
     max_batch_size: int = 1
 
     # Worker management settings
-    new_device_delay_seconds: int = 30
+    new_device_delay_seconds: int = 15
     mock_devices_count: int = 5
     max_worker_restart_count: int = 5
     worker_check_sleep_timeout: float = 30.0

--- a/tt-media-server/model_services/device_worker.py
+++ b/tt-media-server/model_services/device_worker.py
@@ -30,6 +30,8 @@ def setup_worker_environment(worker_id: str):
     # Set device visibility
     os.environ["TT_VISIBLE_DEVICES"] = str(worker_id)
     os.environ["TT_METAL_VISIBLE_DEVICES"] = str(worker_id)
+    # Force JIT compile until binary locating is improved
+    os.environ["TT_METAL_FORCE_JIT_COMPILE"] = "1"
 
     if settings.enable_telemetry:
         get_telemetry_client()  # initialize telemetry client for the worker, it will save time from inference
@@ -37,6 +39,8 @@ def setup_worker_environment(worker_id: str):
     if settings.is_galaxy:
         os.environ["TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE"] = "7,7"
         tt_metal_home = os.environ.get("TT_METAL_HOME", "")
+        # use cache per device to reduce number of "binary not found" errors
+        os.environ["TT_METAL_CACHE"] = f"{tt_metal_home}/built/{str(worker_id)}"
         # make sure to not override except 1,1 and 2,1 mesh sizes
         if settings.device_mesh_shape == (1, 1):
             os.environ["TT_MESH_GRAPH_DESC_PATH"] = f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.textproto"

--- a/tt-media-server/performance_tests/test_audio_transcription.py
+++ b/tt-media-server/performance_tests/test_audio_transcription.py
@@ -80,8 +80,8 @@ async def test_concurrent_audio_transcription(
 ):
     async def timed_request(session, index):
         print_to_file(f"Starting request {index}", log_output_file)
-        start = time.perf_counter()
         try:
+            start = time.perf_counter()
             async with session.post(API_URL, json=payload, headers=headers) as response:
                 duration = time.perf_counter() - start
                 if response.status == 200:
@@ -114,7 +114,7 @@ async def test_concurrent_audio_transcription(
             start = time.perf_counter()
             tasks = [timed_request(session, i + 1) for i in range(batch_size)]
             results = await asyncio.gather(*tasks)
-            requests_duration = time.perf_counter() - start
+            requests_duration = max(results)
             total_duration = sum(results)
             avg_duration = total_duration / batch_size
         if iteration == 0:

--- a/tt-media-server/performance_tests/test_image_generation.py
+++ b/tt-media-server/performance_tests/test_image_generation.py
@@ -85,8 +85,8 @@ async def test_concurrent_image_generation(
 ):
     async def timed_request(session, index):
         print_to_file(f"Starting request {index}", log_output_file)
-        start = time.perf_counter()
         try:
+            start = time.perf_counter()
             async with session.post(API_URL, json=payload, headers=headers) as response:
                 duration = time.perf_counter() - start
                 if response.status == 200:
@@ -119,7 +119,7 @@ async def test_concurrent_image_generation(
             start = time.perf_counter()
             tasks = [timed_request(session, i + 1) for i in range(batch_size)]
             results = await asyncio.gather(*tasks)
-            requests_duration = time.perf_counter() - start
+            requests_duration = max(results)
             total_duration = sum(results)
             avg_duration = total_duration / batch_size
         if iteration == 0:

--- a/tt-media-server/tt_model_runners/base_device_runner.py
+++ b/tt-media-server/tt_model_runners/base_device_runner.py
@@ -5,6 +5,8 @@
 import os
 from abc import ABC, abstractmethod
 
+import torch
+
 import ttnn
 from config.settings import get_settings
 from utils.logger import TTLogger
@@ -16,6 +18,13 @@ class BaseDeviceRunner(ABC):
         self.logger = TTLogger()
         self.settings = get_settings()
         self.ttnn_device = None
+
+        # Limit the number of threads torch can create in order to avoid thread explosion when running multi-process scenarios (such as 32 processes on a galaxy).
+        # This way, torch can create only one thread per process, instead of predefined number of them (32).
+        if torch.get_num_threads() != 1:
+            torch.set_num_threads(1)
+        if torch.get_num_interop_threads() != 1:
+            torch.set_num_interop_threads(1)
 
         if not os.getenv("HF_TOKEN", None) and not (
             os.getenv("HF_HOME", None) and any(os.scandir(os.getenv("HF_HOME")))


### PR DESCRIPTION
Changes:

- Force JIT recompile and use a separate metal cache per runner
- Make audio & image tests a bit more precise
- Limit torch threads for all the runners 
- Reduce startup delay to 15s - seems to be enough + SDXL has some cache that makes it faster
- Limit torch threads to 1 inside runner