### PR TITLE
Fix presence penalty LLM API test

### DIFF
--- a/tests/server_tests/test_cases/test_vllm_server_parameters.py
+++ b/tests/server_tests/test_cases/test_vllm_server_parameters.py
@@ -32,7 +32,7 @@ def shannon_entropy(tokens):
 BASE_PROMPT = [{"role": "user", "content": "Tell me a short joke."}]
 REPRO_PROMPT = [{"role": "user", "content": "What is the capital of France? Be concise."}]
 PENALTY_PROMPTS = {
-    "repeat_trap": [{"role": "user", "content": "Repeat the following word 20 times: apple"}],
+    "repeat_trap": [{"role": "user", "content": "Write a very repetitive story."}],
     "natural_repetition": [{"role": "user", "content": "Write a paragraph about bananas using simple language."}],
     "semantic_repetition": [{"role": "user", "content": "Write a creative story about a dragon named Blaze."}]
 }


### PR DESCRIPTION
This PR addresses #1287 by changing the input prompt to one that will properly measure if the presence penalty feature is reducing the presence of repeated tokens

See the Models CI dispatch run on Llama-3.3-70B-Instruct Galaxy: https://github.com/tenstorrent/tt-shield/actions/runs/19769662025/job/56795507609