### PR TITLE
Implement BaseMetalDeviceRunner

### DIFF
--- a/tt-media-server/tt_model_runners/base_device_runner.py
+++ b/tt-media-server/tt_model_runners/base_device_runner.py
@@ -7,7 +7,6 @@ from abc import ABC, abstractmethod
 
 import torch
 
-import ttnn
 from config.settings import get_settings
 from utils.logger import TTLogger
 
@@ -52,108 +51,19 @@ class BaseDeviceRunner(ABC):
         return None
 
     def set_device(self):
-        if self.ttnn_device is None:
-            # for now use all available devices
-            self.ttnn_device = self._mesh_device()
-        return self.ttnn_device
+        return {}
 
     def close_device(self):
-        try:
-            self.logger.info(f"Device {self.device_id}: Closing mesh device...")
-            if self.ttnn_device is not None:
-                ttnn.close_mesh_device(self.ttnn_device)
-                self.logger.info(
-                    f"Device {self.device_id}: Successfully closed mesh device"
-                )
-            else:
-                self.logger.info(
-                    f"Device {self.device_id}: Device is None, no need to close"
-                )
-        except Exception as e:
-            self.logger.error(f"Device {self.device_id}: Failed to close device: {e}")
-            raise RuntimeError(
-                f"Device {self.device_id}: Device cleanup failed: {str(e)}"
-            ) from e
+        return True
 
     def get_updated_device_params(self, device_params):
-        if device_params is None:
-            device_params = {}
-
-        new_device_params = device_params.copy()
-
-        dispatch_core_axis = new_device_params.pop("dispatch_core_axis", None)
-        dispatch_core_type = new_device_params.pop("dispatch_core_type", None)
-        fabric_tensix_config = new_device_params.get("fabric_tensix_config", None)
-
-        if ttnn.device.is_blackhole():
-            # Only when both fabric_config and fabric_tensix_config are set, we can use ROW dispatch, otherwise force to use COL dispatch
-            fabric_config = new_device_params.get("fabric_config", None)
-            if not (fabric_config and fabric_tensix_config):
-                # When not both are set, force COL dispatch
-                if dispatch_core_axis == ttnn.DispatchCoreAxis.ROW:
-                    self.logger.warning(
-                        "ROW dispatch requires both fabric and tensix config, using DispatchCoreAxis.COL instead."
-                    )
-                    dispatch_core_axis = ttnn.DispatchCoreAxis.COL
-            elif fabric_config and fabric_tensix_config:
-                self.logger.warning(
-                    f"Blackhole with fabric_config and fabric_tensix_config enabled, using fabric_tensix_config={fabric_tensix_config}"
-                )
-
-        dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis, fabric_tensix_config)
-        new_device_params["dispatch_core_config"] = dispatch_core_config
-
-        return new_device_params
+        return None
 
     def _mesh_device(self):
-        try:
-            # Get available devices
-            device_ids = ttnn.get_device_ids()
-            if not device_ids:
-                raise RuntimeError("No TTNN devices available")
-            self.logger.info(
-                f"Device {self.device_id}: Found {len(device_ids)} available TTNN devices: {device_ids}"
-            )
+        return None
 
-            mesh_shape = ttnn.MeshShape(self.settings.device_mesh_shape)
-
-            device_params = self.get_pipeline_device_params()
-            updated_device_params = self.get_updated_device_params(device_params)
-            fabric_config = self._configure_fabric(updated_device_params)
-            mesh_device = self._initialize_mesh_device(
-                mesh_shape, updated_device_params, fabric_config
-            )
-
-            self.logger.info(
-                f"Device {self.device_id}: Successfully created multidevice with {mesh_device.get_num_devices()} devices"
-            )
-            return mesh_device
-        except Exception as e:
-            self.logger.error(
-                f"Device {self.device_id}: Unexpected error during device initialization: {e}"
-            )
-            raise RuntimeError(
-                f"Unexpected device initialization error: {str(e)}"
-            ) from e
-
-
-    # override when needed
     def _configure_fabric(self, updated_device_params):
         return None
 
     def _initialize_mesh_device(self, mesh_shape, device_params, fabric_config):
-        try:
-            mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, **device_params)
-        except Exception as e:
-            try:
-                if fabric_config:
-                    ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
-            except Exception as reset_error:
-                self.logger.warning(
-                    f"Device {self.device_id}: Failed to reset fabric after device initialization failure: {reset_error}"
-                )
-            self.logger.error(
-                f"Device {self.device_id}: Mesh device initialization failed: {e}"
-            )
-            raise RuntimeError(f"Mesh device initialization failed: {str(e)}") from e
-        return mesh_device
+        return None

--- a/tt-media-server/tt_model_runners/base_device_runner.py
+++ b/tt-media-server/tt_model_runners/base_device_runner.py
@@ -47,23 +47,8 @@ class BaseDeviceRunner(ABC):
     def run_inference(self, *args, **kwargs):
         pass
 
-    def get_pipeline_device_params(self):
-        return None
-
     def set_device(self):
         return {}
 
     def close_device(self):
         return True
-
-    def get_updated_device_params(self, device_params):
-        return None
-
-    def _mesh_device(self):
-        return None
-
-    def _configure_fabric(self, updated_device_params):
-        return None
-
-    def _initialize_mesh_device(self, mesh_shape, device_params, fabric_config):
-        return None

--- a/tt-media-server/tt_model_runners/base_metal_device_runner.py
+++ b/tt-media-server/tt_model_runners/base_metal_device_runner.py
@@ -8,22 +8,11 @@ from abc import abstractmethod
 import torch
 
 import ttnn
-from config.settings import get_settings
 from tt_model_runners.base_device_runner import BaseDeviceRunner
-from utils.logger import TTLogger
-
 
 class BaseMetalDeviceRunner(BaseDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
-
-    @abstractmethod
-    def load_model(self):
-        pass
-
-    @abstractmethod
-    def run_inference(self, *args, **kwargs):
-        pass
 
     def get_pipeline_device_params(self):
         return None
@@ -114,7 +103,6 @@ class BaseMetalDeviceRunner(BaseDeviceRunner):
             ) from e
 
 
-    # override when needed
     def _configure_fabric(self, updated_device_params):
         return None
 

--- a/tt-media-server/tt_model_runners/base_metal_device_runner.py
+++ b/tt-media-server/tt_model_runners/base_metal_device_runner.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import os
+from abc import abstractmethod
+
+import torch
+
+import ttnn
+from config.settings import get_settings
+from tt_model_runners.base_device_runner import BaseDeviceRunner
+from utils.logger import TTLogger
+
+
+class BaseMetalDeviceRunner(BaseDeviceRunner):
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+
+    @abstractmethod
+    def load_model(self):
+        pass
+
+    @abstractmethod
+    def run_inference(self, *args, **kwargs):
+        pass
+
+    def get_pipeline_device_params(self):
+        return None
+
+    def set_device(self):
+        if self.ttnn_device is None:
+            # for now use all available devices
+            self.ttnn_device = self._mesh_device()
+        return self.ttnn_device
+
+    def close_device(self):
+        try:
+            self.logger.info(f"Device {self.device_id}: Closing mesh device...")
+            if self.ttnn_device is not None:
+                ttnn.close_mesh_device(self.ttnn_device)
+                self.logger.info(
+                    f"Device {self.device_id}: Successfully closed mesh device"
+                )
+            else:
+                self.logger.info(
+                    f"Device {self.device_id}: Device is None, no need to close"
+                )
+        except Exception as e:
+            self.logger.error(f"Device {self.device_id}: Failed to close device: {e}")
+            raise RuntimeError(
+                f"Device {self.device_id}: Device cleanup failed: {str(e)}"
+            ) from e
+
+    def get_updated_device_params(self, device_params):
+        if device_params is None:
+            device_params = {}
+
+        new_device_params = device_params.copy()
+
+        dispatch_core_axis = new_device_params.pop("dispatch_core_axis", None)
+        dispatch_core_type = new_device_params.pop("dispatch_core_type", None)
+        fabric_tensix_config = new_device_params.get("fabric_tensix_config", None)
+
+        if ttnn.device.is_blackhole():
+            # Only when both fabric_config and fabric_tensix_config are set, we can use ROW dispatch, otherwise force to use COL dispatch
+            fabric_config = new_device_params.get("fabric_config", None)
+            if not (fabric_config and fabric_tensix_config):
+                # When not both are set, force COL dispatch
+                if dispatch_core_axis == ttnn.DispatchCoreAxis.ROW:
+                    self.logger.warning(
+                        "ROW dispatch requires both fabric and tensix config, using DispatchCoreAxis.COL instead."
+                    )
+                    dispatch_core_axis = ttnn.DispatchCoreAxis.COL
+            elif fabric_config and fabric_tensix_config:
+                self.logger.warning(
+                    f"Blackhole with fabric_config and fabric_tensix_config enabled, using fabric_tensix_config={fabric_tensix_config}"
+                )
+
+        dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis, fabric_tensix_config)
+        new_device_params["dispatch_core_config"] = dispatch_core_config
+
+        return new_device_params
+
+    def _mesh_device(self):
+        try:
+            # Get available devices
+            device_ids = ttnn.get_device_ids()
+            if not device_ids:
+                raise RuntimeError("No TTNN devices available")
+            self.logger.info(
+                f"Device {self.device_id}: Found {len(device_ids)} available TTNN devices: {device_ids}"
+            )
+
+            mesh_shape = ttnn.MeshShape(self.settings.device_mesh_shape)
+
+            device_params = self.get_pipeline_device_params()
+            updated_device_params = self.get_updated_device_params(device_params)
+            fabric_config = self._configure_fabric(updated_device_params)
+            mesh_device = self._initialize_mesh_device(
+                mesh_shape, updated_device_params, fabric_config
+            )
+
+            self.logger.info(
+                f"Device {self.device_id}: Successfully created multidevice with {mesh_device.get_num_devices()} devices"
+            )
+            return mesh_device
+        except Exception as e:
+            self.logger.error(
+                f"Device {self.device_id}: Unexpected error during device initialization: {e}"
+            )
+            raise RuntimeError(
+                f"Unexpected device initialization error: {str(e)}"
+            ) from e
+
+
+    # override when needed
+    def _configure_fabric(self, updated_device_params):
+        return None
+
+    def _initialize_mesh_device(self, mesh_shape, device_params, fabric_config):
+        try:
+            mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, **device_params)
+        except Exception as e:
+            try:
+                if fabric_config:
+                    ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+            except Exception as reset_error:
+                self.logger.warning(
+                    f"Device {self.device_id}: Failed to reset fabric after device initialization failure: {reset_error}"
+                )
+            self.logger.error(
+                f"Device {self.device_id}: Mesh device initialization failed: {e}"
+            )
+            raise RuntimeError(f"Mesh device initialization failed: {str(e)}") from e
+        return mesh_device

--- a/tt-media-server/tt_model_runners/base_sdxl_runner.py
+++ b/tt-media-server/tt_model_runners/base_sdxl_runner.py
@@ -18,11 +18,11 @@ from models.experimental.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import (
     TtSDXLPipeline,
 )
 from telemetry.telemetry_client import TelemetryEvent
-from tt_model_runners.base_device_runner import BaseDeviceRunner
+from tt_model_runners.base_metal_device_runner import BaseMetalDeviceRunner
 from utils.helpers import log_execution_time
 
 
-class BaseSDXLRunner(BaseDeviceRunner):
+class BaseSDXLRunner(BaseMetalDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
         self.tt_sdxl: TtSDXLPipeline = None

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -25,7 +25,7 @@ from models.experimental.tt_dit.pipelines.stable_diffusion_35_large.pipeline_sta
 )
 from models.experimental.tt_dit.pipelines.wan.pipeline_wan import WanPipeline
 from telemetry.telemetry_client import TelemetryEvent
-from tt_model_runners.base_device_runner import BaseDeviceRunner
+from tt_model_runners.base_metal_device_runner import BaseMetalDeviceRunner
 from utils.helpers import log_execution_time
 
 dit_runner_log_map = {
@@ -37,7 +37,7 @@ dit_runner_log_map = {
 }
 
 
-class TTDiTRunner(BaseDeviceRunner):
+class TTDiTRunner(BaseMetalDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
         self.pipeline = None

--- a/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
@@ -6,11 +6,11 @@ import vllm
 from config.settings import SupportedModels
 from domain.text_embedding_request import TextEmbeddingRequest
 from transformers import AutoTokenizer
-from tt_model_runners.base_device_runner import BaseDeviceRunner
+from tt_model_runners.base_metal_device_runner import BaseMetalDeviceRunner
 from utils.helpers import log_execution_time
 
 
-class VLLMForgeEmbeddingQwenRunner(BaseDeviceRunner):
+class VLLMForgeEmbeddingQwenRunner(BaseMetalDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
 

--- a/tt-media-server/tt_model_runners/vllm_forge_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_runner.py
@@ -4,11 +4,11 @@
 
 import vllm
 from domain.text_completion_request import TextCompletionRequest
-from tt_model_runners.base_device_runner import BaseDeviceRunner
+from tt_model_runners.base_metal_device_runner import BaseMetalDeviceRunner
 from utils.helpers import log_execution_time
 
 
-class VLLMForgeRunner(BaseDeviceRunner):
+class VLLMForgeRunner(BaseMetalDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
         self.pipeline = None

--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -34,13 +34,13 @@ from transformers import (
     AutoProcessor,
     WhisperForConditionalGeneration,
 )
-from tt_model_runners.base_device_runner import BaseDeviceRunner
+from tt_model_runners.base_metal_device_runner import BaseMetalDeviceRunner
 from ttnn.model_preprocessing import preprocess_model_parameters
 from utils.helpers import log_execution_time
 from utils.text_utils import TextUtils
 
 
-class TTWhisperRunner(BaseDeviceRunner):
+class TTWhisperRunner(BaseMetalDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
         self.pipeline = None


### PR DESCRIPTION
## Problem:
Forge models were [failing](https://github.com/tenstorrent/tt-shield/actions/runs/19805478766/job/56740664470) because of use of `ttnn` library in `BaseMetalDeviceRunner`. 

```
[SERVER]   File "/home/container_app_user/app/server/model_services/device_worker.py", line 12, in <module>
[SERVER]     from tt_model_runners.base_device_runner import BaseDeviceRunner
[SERVER]   File "/home/container_app_user/app/server/tt_model_runners/base_device_runner.py", line 10, in <module>
[SERVER]     import ttnn
[SERVER] ModuleNotFoundError: No module named 'ttnn'
```

## Implementation:
- Create a separate `BaseMetalDeviceRunner` for all metal-based models

## Testing
Passing CI runs:
- [resnet-50](https://github.com/tenstorrent/tt-shield/actions/runs/19817653781)
- [distil-large-v3](https://github.com/tenstorrent/tt-shield/actions/runs/19817259127)
- [stable-diffusion-xl-base-1.0](https://github.com/tenstorrent/tt-shield/actions/runs/19817097298)

