### PR TITLE
Reduce Inference Server Forge Docker Image Size

### DIFF
--- a/tt-media-server/Dockerfile.forge
+++ b/tt-media-server/Dockerfile.forge
@@ -102,6 +102,9 @@ WORKDIR ${APP_DIR}
 COPY --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} "tt-media-server" "${APP_DIR}/server"
 RUN /bin/bash -c "cd ${APP_DIR}/server && source tt_model_runners/forge_runners/setup_env.sh"
 
+# Clear pip cache to reduce image size
+RUN rm -rf ${HOME_DIR}/.cache/pip
+
 # ==============================================================================
 # RUNTIME STAGE - final lightweight image
 # ==============================================================================
@@ -124,9 +127,10 @@ ENV LOGURU_LEVEL=INFO
 # System deps (runtime only)
 RUN apt-get update && apt-get install -y \
     libsndfile1 \
-    libgl1 \
     python3-yaml \
     git \
+    python3.11 \
+    python3.11-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # User setup

--- a/tt-media-server/Dockerfile.forge
+++ b/tt-media-server/Dockerfile.forge
@@ -2,10 +2,12 @@
 #
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
-#FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-20.04-amd64:$TT_METAL_DOCKERFILE_VERSION-dev
-FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest
 
-# Build stage
+# =========================
+# BUILDER STAGE
+# =========================
+FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-basic-dev-amd64:latest AS builder
+
 LABEL maintainer="Igor Djuric <idjuric@tenstorrent.com>"
 # connect Github repo with package
 LABEL org.opencontainers.image.source=https://github.com/tenstorrent/tt-inference-server
@@ -47,7 +49,6 @@ RUN apt-get update && apt-get install -y \
     jq \
     vim \
     python3-pip \
-    # pyluwen build dependencies (Rust package with protobuf)
     build-essential \
     python3-dev \
     libffi-dev \
@@ -71,6 +72,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y python3.11 python3.11-dev python3.11-venv python3.11-distutils
 
+# CMake
 RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4-linux-x86_64.sh -o cmake.sh && \
     chmod +x cmake.sh && \
     ./cmake.sh --skip-license --prefix=/usr/local && \
@@ -92,13 +94,13 @@ RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_
 
 USER ${CONTAINER_APP_USERNAME}
 
-# install tt-smi
+RUN pip3 install tomli
 RUN /bin/bash -c "export CARGO_HOME=${HOME_DIR}/.cargo \
     && export RUSTUP_HOME=${HOME_DIR}/.rustup \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --no-modify-path \
     && . ${HOME_DIR}/.cargo/env \
     && rustup update \
-    && pip3 install git+https://github.com/tenstorrent/tt-smi"
+    && pip3 install --no-build-isolation git+https://github.com/tenstorrent/tt-smi"
 
 WORKDIR ${HOME_DIR}
 
@@ -109,7 +111,55 @@ WORKDIR ${APP_DIR}
 COPY --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} "tt-media-server" "${APP_DIR}/server"
 RUN /bin/bash -c "cd ${APP_DIR}/server && source tt_model_runners/forge_runners/setup_env.sh"
 
-# spinup inference server
-WORKDIR "${APP_DIR}"
+# =========================
+# RUNTIME STAGE
+# =========================
+FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-basic-dev-amd64:latest AS runner
+
+LABEL maintainer="Igor Djuric <idjuric@tenstorrent.com>"
+LABEL org.opencontainers.image.source=https://github.com/tenstorrent/tt-inference-server
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG CONTAINER_APP_UID=1000
+ARG HOME_DIR=/home/container_app_user
+
+ENV LOG_LEVEL=INFO
+ENV ENVIRONMENT=development
+ENV DEVICE_IDS=0
+ENV MAX_QUEUE_SIZE=1
+ENV MAX_BATCH_SIZE=1
+ENV MODEL_RUNNER=${MODEL_RUNNER}
+ENV SHELL=/bin/bash
+ENV CONTAINER_APP_USERNAME=container_app_user
+ENV CONFIG=Release
+ENV LOGURU_LEVEL=INFO
+
+# System deps (runtime only)
+RUN apt-get update && apt-get install -y \
+    libgl1 \
+    libsndfile1 \
+    python3.11 \
+    python3.11-venv \
+    python3.11-distutils \
+    python3.11-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# User setup
+RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_USERNAME} \
+    && mkdir -p ${HOME_DIR} \
+    && chown -R ${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} ${HOME_DIR} \
+    && mkdir -p /run/sshd \
+    && chmod 755 /run/sshd
+
+RUN apt-get update && apt-get install -y libnuma1 libgl1-mesa-glx && rm -rf /var/lib/apt/lists/*
+
+USER ${CONTAINER_APP_USERNAME}
+
+# Copy app from builder
+ARG APP_DIR="${HOME_DIR}/app"
+ENV APP_DIR=${APP_DIR}
+WORKDIR ${APP_DIR}
+COPY --from=builder --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} ${APP_DIR}/server ${APP_DIR}/server
+
 EXPOSE 8000
 CMD ["/bin/bash", "-c", "cd ${APP_DIR}/server/ && source venv-worker/bin/activate && source ./run_uvicorn.sh"]

--- a/tt-media-server/Dockerfile.forge
+++ b/tt-media-server/Dockerfile.forge
@@ -3,13 +3,12 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 
-# =========================
+# ==============================================================================
 # BUILDER STAGE
-# =========================
+# ==============================================================================
 FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-basic-dev-amd64:latest AS builder
 
 LABEL maintainer="Igor Djuric <idjuric@tenstorrent.com>"
-# connect Github repo with package
 LABEL org.opencontainers.image.source=https://github.com/tenstorrent/tt-inference-server
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -22,7 +21,6 @@ ARG CONTAINER_APP_UID=1000
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV ENVIRONMENT=development
-ENV MODEL_RUNNER=${MODEL_RUNNER}
 
 ENV SHELL=/bin/bash
 ENV CONTAINER_APP_USERNAME=container_app_user
@@ -72,13 +70,6 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y python3.11 python3.11-dev python3.11-venv python3.11-distutils
 
-# CMake
-RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4-linux-x86_64.sh -o cmake.sh && \
-    chmod +x cmake.sh && \
-    ./cmake.sh --skip-license --prefix=/usr/local && \
-    rm cmake.sh && \
-    cmake --version
-
 # build tt-metal
 RUN pip3 install --upgrade setuptools wheel \
     && pip3 install cmake \
@@ -111,9 +102,9 @@ WORKDIR ${APP_DIR}
 COPY --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} "tt-media-server" "${APP_DIR}/server"
 RUN /bin/bash -c "cd ${APP_DIR}/server && source tt_model_runners/forge_runners/setup_env.sh"
 
-# =========================
-# RUNTIME STAGE
-# =========================
+# ==============================================================================
+# RUNTIME STAGE - final lightweight image
+# ==============================================================================
 FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-basic-dev-amd64:latest AS runner
 
 LABEL maintainer="Igor Djuric <idjuric@tenstorrent.com>"
@@ -125,10 +116,6 @@ ARG HOME_DIR=/home/container_app_user
 
 ENV LOG_LEVEL=INFO
 ENV ENVIRONMENT=development
-ENV DEVICE_IDS=0
-ENV MAX_QUEUE_SIZE=1
-ENV MAX_BATCH_SIZE=1
-ENV MODEL_RUNNER=${MODEL_RUNNER}
 ENV SHELL=/bin/bash
 ENV CONTAINER_APP_USERNAME=container_app_user
 ENV CONFIG=Release
@@ -136,12 +123,10 @@ ENV LOGURU_LEVEL=INFO
 
 # System deps (runtime only)
 RUN apt-get update && apt-get install -y \
-    libgl1 \
     libsndfile1 \
-    python3.11 \
-    python3.11-venv \
-    python3.11-distutils \
-    python3.11-dev \
+    libgl1 \
+    python3-yaml \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # User setup
@@ -149,7 +134,8 @@ RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_
     && mkdir -p ${HOME_DIR} \
     && chown -R ${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} ${HOME_DIR} \
     && mkdir -p /run/sshd \
-    && chmod 755 /run/sshd
+    && chmod 755 /run/sshd \
+    && git config --global --add safe.directory '*'
 
 RUN apt-get update && apt-get install -y libnuma1 libgl1-mesa-glx && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem
It was possible to further reduce Docker image size.

## Implementation
- use lean base image for both runtime and build stages
- introduce two-stage build

## Results
```
REPOSITORY         TAG        IMAGE ID       CREATED       SIZE
inf-server-forge   original   c2fa70f9c552   1 day ago   25.9GB
```
```
REPOSITORY     TAG       IMAGE ID       CREATED         SIZE
forge-server   latest    8dd7886ef2e3   4 minutes ago   9.59GB
```