### PR TITLE
Add Vision Token Support for VLM Max Concurrency Calculations

### DIFF
--- a/benchmarking/benchmark_config.py
+++ b/benchmarking/benchmark_config.py
@@ -93,7 +93,7 @@ def calculate_vision_tokens(image_height, image_width, images_per_prompt, model_
     
     Different VLM models use different methods to calculate vision tokens:
     - Gemma-3 models: Fixed 256 tokens per image (images normalized to 896x896)
-    - Qwen2.5-VL: ((height // 28) * 28 / 14) * ((width // 28) * 28 / 14)
+    - Qwen2.5-VL: (height // 28) * (width // 28)
     - Qwen3-VL: (height // 32) * (width // 32)
     
     Args:
@@ -118,7 +118,7 @@ def calculate_vision_tokens(image_height, image_width, images_per_prompt, model_
         tokens_per_image = 256
     # Qwen2.5-VL models
     elif "qwen2.5-vl" in model_name_lower or "qwen2-5-vl" in model_name_lower:
-        tokens_per_image = int(((image_height // 28) * 28 / 14) * ((image_width // 28) * 28 / 14))
+        tokens_per_image = (image_height // 28) * (image_width // 28)
     # Qwen3-VL models
     elif "qwen3-vl" in model_name_lower or "qwen3" in model_name_lower:
         tokens_per_image = (image_height // 32) * (image_width // 32)

--- a/benchmarking/benchmark_config.py
+++ b/benchmarking/benchmark_config.py
@@ -160,6 +160,66 @@ def get_benchmark_max_concurrency(isl, osl, max_context, model_max_concurrency=3
     return min(max_concurrency_by_context, model_max_concurrency)
 
 
+def cap_benchmark_params(params: BenchmarkTaskParams, max_context: int, model_max_concurrency: int, model_name: str = None) -> BenchmarkTaskParams:
+    """
+    Cap max_concurrency based on context limits (including vision tokens for VLM models) 
+    and recalculate num_prompts accordingly.
+    
+    Args:
+        params: Original benchmark task parameters
+        max_context: Maximum context length supported by the model
+        model_max_concurrency: Maximum concurrency supported by the model
+        model_name: Model name for vision token calculation (optional)
+        
+    Returns:
+        Updated BenchmarkTaskParams with capped concurrency and recalculated num_prompts
+    """
+    # Skip capping for CNN/Audio tasks that don't have isl/osl 
+    if params.isl is None or params.osl is None:
+        return params
+    
+    # Calculate vision tokens for VLM models
+    vision_tokens = 0
+    if params.task_type == "image" and params.image_height and params.image_width:
+        vision_tokens = calculate_vision_tokens(
+            params.image_height, 
+            params.image_width, 
+            params.images_per_prompt or 0,
+            model_name
+        )
+    
+    # Calculate the allowed max_concurrency based on sequence length (including vision tokens)
+    calculated_max_concurrency = get_benchmark_max_concurrency(
+        params.isl, params.osl, max_context, model_max_concurrency, vision_tokens
+    )
+    
+    # Cap the max_concurrency if it exceeds the calculated limit
+    capped_max_concurrency = min(params.max_concurrency, calculated_max_concurrency)
+    
+    # If concurrency was capped, recalculate num_prompts
+    if capped_max_concurrency < params.max_concurrency:
+        recalculated_num_prompts = get_num_prompts(params.isl, params.osl, capped_max_concurrency)
+        
+        # Create new params with capped values
+        return BenchmarkTaskParams(
+            isl=params.isl,
+            osl=params.osl,
+            max_concurrency=capped_max_concurrency,
+            num_prompts=recalculated_num_prompts,
+            task_type=params.task_type,
+            image_height=params.image_height,
+            image_width=params.image_width,
+            images_per_prompt=params.images_per_prompt,
+            targets=params.targets,
+            theoretical_ttft_ms=params.theoretical_ttft_ms,
+            theoretical_tput_user=params.theoretical_tput_user,
+            target_peak_perf=params.target_peak_perf,
+        )
+    
+    # No capping needed, return original params
+    return params
+
+
 # define benchmark configs for each model and each device configuration
 # uses:
 # 1. BATCH_1_BENCHMARK_COMMON_ISL_OSL_PAIRS
@@ -168,38 +228,54 @@ def get_benchmark_max_concurrency(isl, osl, max_context, model_max_concurrency=3
 # num_prompts is set dynamically based on OSL because that mostly sets how long the benchmark takes
 if os.getenv("ONLY_BENCHMARK_TARGETS"):
     # skip the benchmark sweeps and only run the benchmarks defined in the model config
-    BENCHMARK_CONFIGS = {
-        model_id: BenchmarkConfig(
+    BENCHMARK_CONFIGS = {}
+    for model_id, model_spec in MODEL_SPECS.items():
+        # Apply capping to performance reference entries even in ONLY_BENCHMARK_TARGETS mode
+        _device = model_spec.device_type
+        _model_max_concurrency = model_spec.device_model_spec.max_concurrency
+        _max_context = model_spec.device_model_spec.max_context
+        perf_reference = model_spec.device_model_spec.perf_reference
+        
+        capped_perf_reference = [
+            cap_benchmark_params(params, _max_context, _model_max_concurrency, model_spec.model_name)
+            for params in perf_reference
+        ]
+        
+        BENCHMARK_CONFIGS[model_id] = BenchmarkConfig(
             model_id=model_id,
-            tasks=[
-                BenchmarkTask(
-                    param_map={
-                        model_spec.device_type: model_spec.device_model_spec.perf_reference
-                    }
-                )
-            ],
+            tasks=[BenchmarkTask(param_map={_device: capped_perf_reference})],
         )
-        for model_id, model_spec in MODEL_SPECS.items()
-    }
 else:
     BENCHMARK_CONFIGS = {}
     for model_id, model_spec in MODEL_SPECS.items():
-        # Create performance reference task using the device_model_spec
+        # Since each ModelConfig now represents a single device, use that device and its max_concurrency
+        _device = model_spec.device_type
+        _model_max_concurrency = model_spec.device_model_spec.max_concurrency
+        _max_context = model_spec.device_model_spec.max_context
+        perf_reference = model_spec.device_model_spec.perf_reference
+
+        # Apply capping to each perf reference entry (including vision tokens for VLM models)
+        capped_perf_reference = [
+            cap_benchmark_params(params, _max_context, _model_max_concurrency, model_spec.model_name)
+            for params in perf_reference
+        ]
+
+        # Create performance reference task with capped values
         perf_ref_task = BenchmarkTask(
             param_map={
-                model_spec.device_type: model_spec.device_model_spec.perf_reference
+                _device: capped_perf_reference
             }
         )
         if model_spec.model_type == ModelType.CNN:
             perf_ref_task = BenchmarkTaskCNN(
                 param_map={
-                    model_spec.device_type: model_spec.device_model_spec.perf_reference
+                    _device: capped_perf_reference
                 }
             )
 
-        # get (isl, osl, max_concurrency) from perf_ref_task
+        # get (isl, osl, max_concurrency) from capped perf_ref_task
         perf_ref_task_runs = {
-            model_spec.device_type: [
+            _device: [
                 (
                     params.isl,
                     params.osl,
@@ -212,14 +288,9 @@ else:
                 else (params.num_inference_steps,)
                 if params.task_type == "cnn"
                 else (params.isl, params.osl, params.max_concurrency)
-                for params in model_spec.device_model_spec.perf_reference
+                for params in capped_perf_reference
             ]
         }
-
-        # Since each ModelConfig now represents a single device, use that device and its max_concurrency
-        _device = model_spec.device_type
-        _model_max_concurrency = model_spec.device_model_spec.max_concurrency
-        _max_context = model_spec.device_model_spec.max_context
 
         # make benchmark sweeps table for this device
         if model_spec.model_type == ModelType.CNN:

--- a/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/benchmarking/benchmark_targets/model_performance_reference.json
@@ -4721,22 +4721,6 @@
                         "tput": 773.0
                     }
                 }
-            },
-            {
-                "isl": 16000,
-                "osl": 64,
-                "max_concurrency": 1,
-                "num_prompts": 8,
-                "task_type": "image",
-                "image_height": 3500,
-                "image_width": 2500,
-                "images_per_prompt": 1,
-                "targets": {
-                    "theoretical": {
-                        "ttft_ms": 12121,
-                        "tput_user": 50
-                    }
-                }
             }
         ]
     },

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -361,7 +361,7 @@ def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata
             text_perf_results[p_ref_key] = {
                 "isl": p_ref.isl,
                 "osl": p_ref.osl,
-                "max_concurrency": p_ref.max_concurrency,
+                "max_concurrency": res["max_con"] if res else p_ref.max_concurrency,
                 "model": model_spec.model_name,
                 "device": args.device,
             }
@@ -509,7 +509,7 @@ def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata
             image_perf_results[p_ref_key] = {
                 "isl": p_ref.isl,
                 "osl": p_ref.osl,
-                "max_concurrency": p_ref.max_concurrency,
+                "max_concurrency": res["max_con"] if res else p_ref.max_concurrency,
                 "image_height": p_ref.image_height,
                 "image_width": p_ref.image_width,
                 "images_per_prompt": p_ref.images_per_prompt,


### PR DESCRIPTION
## Summary

This PR adds vision token awareness to benchmark `max_concurrency` calculations for Vision Language Models (VLMs). Previously, only text tokens were considered when calculating `max_concurrency`, leading to incorrect values for VLM benchmarks that also process image inputs.

## Problem

The `get_benchmark_max_concurrency()` function only accounted for text tokens (ISL + OSL) when calculating max_concurrency:

```python
total_seq_len = isl + osl  # Missing vision tokens!
```

For VLMs like Gemma-3-27B-IT processing images, this resulted in `max_concurrency` values that exceeded the actual context capacity, as vision tokens were not included in the calculation.

## Solution

### 1. Added `calculate_vision_tokens()` Function

Implements model-specific vision token calculations for three VLM families:

- **Gemma-3 models** (including MedGemma): Fixed 256 tokens per image (images normalized to 896×896)
- **Qwen2.5-VL models**: `(height // 28) * (width // 28)`
- **Qwen3-VL models**: `(height // 32) * (width // 32)`

Returns 0 for unknown models (backward compatible with LLMs).

### 2. Updated `get_benchmark_max_concurrency()`

Added `vision_tokens` parameter to include vision tokens in total sequence length:

```python
total_seq_len = isl + osl + vision_tokens
```

### 3. Added `cap_benchmark_params()` Function

Ensures benchmark parameters respect context limits by:
- Calculating vision tokens for VLM tasks
- Computing vision-aware max_concurrency
- Capping max_concurrency if it exceeds limits
- Recalculating num_prompts when capping occurs

### 4. Updated Benchmark Configuration

Applied vision-aware capping to:
- Performance reference entries in both `ONLY_BENCHMARK_TARGETS` and full sweep modes
- All image benchmark task generation (batch-1 and max-concurrency sweeps)

### 5. Updated Report Generation

- Applied `cap_benchmark_params()` to performance references before comparison
- Updated reports to use actual `max_con` from benchmark results instead of reference values

## Changes

### Files Modified

1. **`benchmarking/benchmark_config.py`**
   - Added `calculate_vision_tokens()` function
   - Updated `get_benchmark_max_concurrency()` with `vision_tokens` parameter
   - Added `cap_benchmark_params()` function
   - Applied vision-aware capping to all benchmark configurations
   - Updated all image benchmark generation to pass `model_spec.model_name`

2. **`workflows/run_reports.py`**
   - Imported `cap_benchmark_params`
   - Applied capping to performance references before report generation
   - Updated text and image benchmarks to use actual `max_con` from results

3. **`benchmarking/benchmark_targets/model_performance_reference.json`**
   - Removed invalid entry (ISL=16000, 3500×2500 image) that exceeded context limits


## References

- [Gemma-3 Model Card](https://ai.google.dev/gemma/docs/core/model_card_3) - Images normalized to 896×896, 256 tokens each
- [Qwen2.5-VL Documentation](https://www.emergentmind.com/topics/qwen2-5-vl-model) - Formula: `(height // 28) * (width // 28)`
- [Qwen3-VL Documentation](https://qwen-ai.chat/models/qwen3-vl/) - Formula: `(height // 32) * (width // 32)`
