### PR TITLE
Set max_token limit on test_n requests

### DIFF
--- a/tests/server_tests/test_cases/test_vllm_server_parameters.py
+++ b/tests/server_tests/test_cases/test_vllm_server_parameters.py
@@ -41,7 +41,7 @@ PENALTY_PROMPTS = {
 @pytest.mark.parametrize("n_val", [2, 3])
 def test_n(report_test, api_client, n_val, request):
     """Tests the 'n' parameter (number of choices)."""
-    payload = {"messages": BASE_PROMPT, "n": n_val}
+    payload = {"messages": BASE_PROMPT, "n": n_val, "max_tokens": 32}
     response = api_client(payload)
     
     try:


### PR DESCRIPTION
This PR fixes the Models CI Qwen3-32B TP=8, DP=4 test_n request timeout by setting a max_token limit on the client requests
https://github.com/tenstorrent/tt-shield/actions/runs/19839010606/job/56845069454#step:11:125

See passing Models CI dispatch run with this fix https://github.com/tenstorrent/tt-shield/actions/runs/19897671522/job/57036554505#step:9:6946