### PR TITLE
Use github.token instead of personal one

### DIFF
--- a/.github/workflows/on-community-issue.yml
+++ b/.github/workflows/on-community-issue.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           gh ${{steps.set-variables.outputs.GH_COMMAND}} edit ${{ steps.set-variables.outputs.NUMBER }} --add-label ${{ env.LABELS }}
         env:
-          GH_TOKEN: ${{ secrets.LABEL_WRITE_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           LABELS: community
       - name: Send Notification


### PR DESCRIPTION
Issue notification workflow fails with
```
Run gh issue edit 1323 --add-label community
failed to update https://github.com/tenstorrent/tt-inference-server/issues/1323: GraphQL: milank94 does not have the correct permissions to execute `AddLabelsToLabelable` (addLabelsToLabelable)
failed to update 1 issue
Error: Process completed with exit code 1.
```

Example https://github.com/tenstorrent/tt-inference-server/actions/runs/19910362478/job/57077262457