### PR TITLE
Enable Single Device Batching for SDXL Based Models 

### DIFF
--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -48,7 +48,7 @@ class Settings(BaseSettings):
     # Queue and batch settings
     max_queue_size: int = 5000
     max_batch_size: int = 1
-    max_batch_delay_time_ms: int = 10
+    max_batch_delay_time_ms: Optional[int] = None
 
     # Worker management settings
     new_device_delay_seconds: int = 15

--- a/tt-media-server/tt_model_runners/base_metal_device_runner.py
+++ b/tt-media-server/tt_model_runners/base_metal_device_runner.py
@@ -2,13 +2,10 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import os
-from abc import abstractmethod
-
-import torch
 
 import ttnn
 from tt_model_runners.base_device_runner import BaseDeviceRunner
+
 
 class BaseMetalDeviceRunner(BaseDeviceRunner):
     def __init__(self, device_id: str):
@@ -21,6 +18,7 @@ class BaseMetalDeviceRunner(BaseDeviceRunner):
         if self.ttnn_device is None:
             # for now use all available devices
             self.ttnn_device = self._mesh_device()
+        self.max_batch_size = min(self.ttnn_device.get_num_devices(), self.settings.max_batch_size)
         return self.ttnn_device
 
     def close_device(self):
@@ -66,7 +64,9 @@ class BaseMetalDeviceRunner(BaseDeviceRunner):
                     f"Blackhole with fabric_config and fabric_tensix_config enabled, using fabric_tensix_config={fabric_tensix_config}"
                 )
 
-        dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis, fabric_tensix_config)
+        dispatch_core_config = ttnn.DispatchCoreConfig(
+            dispatch_core_type, dispatch_core_axis, fabric_tensix_config
+        )
         new_device_params["dispatch_core_config"] = dispatch_core_config
 
         return new_device_params
@@ -101,7 +101,6 @@ class BaseMetalDeviceRunner(BaseDeviceRunner):
             raise RuntimeError(
                 f"Unexpected device initialization error: {str(e)}"
             ) from e
-
 
     def _configure_fabric(self, updated_device_params):
         return None

--- a/tt-media-server/tt_model_runners/base_sdxl_runner.py
+++ b/tt-media-server/tt_model_runners/base_sdxl_runner.py
@@ -5,8 +5,8 @@
 import asyncio
 import os
 from abc import abstractmethod
-import ttnn
 
+import ttnn
 from domain.image_generate_request import ImageGenerateRequest
 from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     SDXL_FABRIC_CONFIG,
@@ -120,35 +120,29 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
         pass
 
     @abstractmethod
-    def _prepare_input_tensors_for_iteration(self, iter: int):
+    def _prepare_input_tensors_for_iteration(self, tensors):
         pass
 
     def _process_prompts(
-        self, request: ImageGenerateRequest
+        self, requests: list[ImageGenerateRequest]
     ) -> tuple[list[str], str, int]:
-        prompts = request.prompt
-        negative_prompt = request.negative_prompt
-        if isinstance(prompts, str):
-            prompts = [prompts]
+        batch_size = len(requests)
+        needed_padding = self.max_batch_size - batch_size
 
-        needed_padding = (
-            self.batch_size - len(prompts) % self.batch_size
-        ) % self.batch_size
-        prompts = prompts + [""] * needed_padding
+        prompts = [request.prompt for request in requests] + [""] * needed_padding
+        negative_prompts = [request.negative_prompt for request in requests] + [
+            ""
+        ] * needed_padding
 
-        prompts_2 = request.prompt_2
-        negative_prompt_2 = request.negative_prompt_2
+        prompts_2 = requests[0].prompt_2
+        if prompts_2 is not None and isinstance(requests[0].prompt_2, str):
+            prompts_2 = [requests[0].prompt_2]
         if prompts_2 is not None:
-            prompts_2 = request.prompt_2
-            if isinstance(prompts_2, str):
-                prompts_2 = [prompts_2]
-
-            needed_padding = (
-                self.batch_size - len(prompts_2) % self.batch_size
-            ) % self.batch_size
             prompts_2 = prompts_2 + [""] * needed_padding
 
-        return prompts, negative_prompt, prompts_2, negative_prompt_2, needed_padding
+        negative_prompt_2 = requests[0].negative_prompt_2
+
+        return prompts, negative_prompts, prompts_2, negative_prompt_2, needed_padding
 
     def _apply_request_settings(self, request: ImageGenerateRequest) -> None:
         if request.num_inference_steps is not None:
@@ -169,25 +163,35 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
     def _ttnn_inference(self, tensors, prompts, needed_padding):
         images = []
         self.logger.info(f"Device {self.device_id}: Starting ttnn inference...")
-        for iter in range(len(prompts) // self.batch_size):
-            self.logger.info(
-                f"Device {self.device_id}: Running inference for prompts {iter * self.batch_size + 1}-{iter * self.batch_size + self.batch_size}/{len(prompts)}"
-            )
+        self._prepare_input_tensors_for_iteration(tensors)
 
-            self._prepare_input_tensors_for_iteration(tensors, iter)
+        imgs = self.tt_sdxl.generate_images()
 
-            imgs = self.tt_sdxl.generate_images()
+        for idx, img in enumerate(imgs):
+            if idx >= self.batch_size - needed_padding:
+                break
 
-            for idx, img in enumerate(imgs):
-                if (
-                    iter == len(prompts) // self.batch_size - 1
-                    and idx >= self.batch_size - needed_padding
-                ):
-                    break
-                img = img.unsqueeze(0)
-                img = self.pipeline.image_processor.postprocess(img, output_type="pil")[
-                    0
-                ]
-                images.append(img)
+            img = img.unsqueeze(0)
+            img = self.pipeline.image_processor.postprocess(img, output_type="pil")[0]
+            images.append(img)
 
         return images
+
+    def is_request_batchable(self, request, batch=None):
+        if len(batch or []) >= self.max_batch_size:
+            return False
+
+        if batch is None:
+            return True
+
+        first_request = batch[0]
+        return (
+            request.num_inference_steps == first_request.num_inference_steps
+            and request.guidance_scale == first_request.guidance_scale
+            and request.guidance_rescale == first_request.guidance_rescale
+            and request.crop_coords_top_left == first_request.crop_coords_top_left
+            and request.timesteps == first_request.timesteps
+            and request.sigmas == first_request.sigmas
+            and request.prompt_2 == first_request.prompt_2
+            and request.negative_prompt_2 == first_request.negative_prompt_2
+        )

--- a/tt-media-server/tt_model_runners/sdxl_edit_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_edit_runner_trace.py
@@ -93,7 +93,7 @@ class TTSDXLEditRunner(TTSDXLImageToImageRunner):
 
         return image, mask, masked_image
 
-    def _prepare_input_tensors_for_iteration(self, tensors, iter: int):
+    def _prepare_input_tensors_for_iteration(self, tensors):
         (
             tt_image_latents,
             tt_masked_image_latents,
@@ -106,8 +106,8 @@ class TTSDXLEditRunner(TTSDXLImageToImageRunner):
                 tt_image_latents,
                 tt_masked_image_latents,
                 tt_mask,
-                tt_prompt_embeds[iter],
-                tt_add_text_embeds[iter],
+                tt_prompt_embeds[0],
+                tt_add_text_embeds[0],
             ]
         )
 
@@ -118,8 +118,9 @@ class TTSDXLEditRunner(TTSDXLImageToImageRunner):
     )
     def run_inference(self, requests: list[ImageEditRequest]):
         outputs = []
+
         for request in requests:
-            prompts, negative_prompt, prompts_2, negative_prompt_2, needed_padding = (
+            prompts, negative_prompts, prompts_2, negative_prompt_2, needed_padding = (
                 self._process_prompts(request)
             )
 
@@ -131,7 +132,7 @@ class TTSDXLEditRunner(TTSDXLImageToImageRunner):
 
             all_prompt_embeds_torch, torch_add_text_embeds = (
                 self.tt_sdxl.encode_prompts(
-                    prompts, negative_prompt, prompts_2, negative_prompt_2
+                    prompts, negative_prompts, prompts_2, negative_prompt_2
                 )
             )
 
@@ -165,7 +166,7 @@ class TTSDXLEditRunner(TTSDXLImageToImageRunner):
                 tt_prompt_embeds,
                 tt_add_text_embeds,
             )
-            self._prepare_input_tensors_for_iteration(tensors, 0)
+            self._prepare_input_tensors_for_iteration(tensors)
 
             self.logger.debug(f"Device {self.device_id}: Compiling image processing...")
 

--- a/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
@@ -61,13 +61,13 @@ class TTSDXLGenerateRunnerTrace(BaseSDXLRunner):
             ]
         )
 
-    def _prepare_input_tensors_for_iteration(self, tensors, iter: int):
+    def _prepare_input_tensors_for_iteration(self, tensors):
         tt_image_latents, tt_prompt_embeds, tt_add_text_embeds = tensors
         self.tt_sdxl.prepare_input_tensors(
             [
                 tt_image_latents,
-                tt_prompt_embeds[iter],
-                tt_add_text_embeds[iter],
+                tt_prompt_embeds[0],
+                tt_add_text_embeds[0],
             ]
         )
 
@@ -78,47 +78,47 @@ class TTSDXLGenerateRunnerTrace(BaseSDXLRunner):
     )
     def run_inference(self, requests: list[ImageGenerateRequest]):
         outputs = []
-        for request in requests:
-            prompts, negative_prompt, prompts_2, negative_prompt_2, needed_padding = (
-                self._process_prompts(request)
+
+        self.logger.info(f"Requests received: {len(requests)} : {requests}")
+
+        prompts, negative_prompts, prompts_2, negative_prompt_2, needed_padding = (
+            self._process_prompts(requests)
+        )
+
+        self._apply_request_settings(requests[0])
+        self.logger.debug(f"Device {self.device_id}: Starting text encoding...")
+        self.tt_sdxl.compile_text_encoding()
+
+        (
+            all_prompt_embeds_torch,
+            torch_add_text_embeds,
+        ) = self.tt_sdxl.encode_prompts(
+            prompts, negative_prompts, prompts_2, negative_prompt_2
+        )
+
+        self.logger.debug(f"Device {self.device_id}: Generating input tensors...")
+
+        tt_latents, tt_prompt_embeds, tt_add_text_embeds = (
+            self.tt_sdxl.generate_input_tensors(
+                all_prompt_embeds_torch=all_prompt_embeds_torch,
+                torch_add_text_embeds=torch_add_text_embeds,
+                start_latent_seed=requests[0].seed,
+                timesteps=requests[0].timesteps,
+                sigmas=requests[0].sigmas,
             )
+        )
 
-            self._apply_request_settings(request)
-            self.logger.debug(f"Device {self.device_id}: Starting text encoding...")
-            self.tt_sdxl.compile_text_encoding()
+        self.logger.debug(f"Device {self.device_id}: Preparing input tensors...")
 
-            (
-                all_prompt_embeds_torch,
-                torch_add_text_embeds,
-            ) = self.tt_sdxl.encode_prompts(
-                prompts, negative_prompt, prompts_2, negative_prompt_2
-            )
+        tensors = (
+            tt_latents,
+            tt_prompt_embeds,
+            tt_add_text_embeds,
+        )
+        self._prepare_input_tensors_for_iteration(tensors)
 
-            self.logger.info(f"Device {self.device_id}: Generating input tensors...")
+        self.logger.debug(f"Device {self.device_id}: Compiling image processing...")
 
-            tt_latents, tt_prompt_embeds, tt_add_text_embeds = (
-                self.tt_sdxl.generate_input_tensors(
-                    all_prompt_embeds_torch=all_prompt_embeds_torch,
-                    torch_add_text_embeds=torch_add_text_embeds,
-                    start_latent_seed=request.seed,
-                    timesteps=request.timesteps,
-                    sigmas=request.sigmas,
-                )
-            )
+        self.tt_sdxl.compile_image_processing()
 
-            self.logger.debug(f"Device {self.device_id}: Preparing input tensors...")
-
-            tensors = (
-                tt_latents,
-                tt_prompt_embeds,
-                tt_add_text_embeds,
-            )
-            self._prepare_input_tensors_for_iteration(tensors, 0)
-
-            self.logger.debug(f"Device {self.device_id}: Compiling image processing...")
-
-            self.tt_sdxl.compile_image_processing()
-
-            outputs.append(self._ttnn_inference(tensors, prompts, needed_padding))
-
-        return outputs
+        return self._ttnn_inference(tensors, prompts, needed_padding)

--- a/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
@@ -99,13 +99,13 @@ class TTSDXLImageToImageRunner(BaseSDXLRunner):
             self.tt_sdxl.set_negative_aesthetic_score(request.negative_aesthetic_score)
         """
 
-    def _prepare_input_tensors_for_iteration(self, tensors, iter: int):
+    def _prepare_input_tensors_for_iteration(self, tensors):
         tt_image_latents, tt_prompt_embeds, tt_add_text_embeds = tensors
         self.tt_sdxl.prepare_input_tensors(
             [
                 tt_image_latents,
-                tt_prompt_embeds[iter],
-                tt_add_text_embeds[iter],
+                tt_prompt_embeds[0],
+                tt_add_text_embeds[0],
             ]
         )
 
@@ -116,8 +116,9 @@ class TTSDXLImageToImageRunner(BaseSDXLRunner):
     )
     def run_inference(self, requests: list[ImageToImageRequest]):
         outputs = []
+
         for request in requests:
-            prompts, negative_prompt, prompts_2, negative_prompt_2, needed_padding = (
+            prompts, negative_prompts, prompts_2, negative_prompt_2, needed_padding = (
                 self._process_prompts(request)
             )
 
@@ -131,7 +132,7 @@ class TTSDXLImageToImageRunner(BaseSDXLRunner):
                 all_prompt_embeds_torch,
                 torch_add_text_embeds,
             ) = self.tt_sdxl.encode_prompts(
-                prompts, negative_prompt, prompts_2, negative_prompt_2
+                prompts, negative_prompts, prompts_2, negative_prompt_2
             )
 
             image = self._preprocess_image(request.image)
@@ -156,7 +157,7 @@ class TTSDXLImageToImageRunner(BaseSDXLRunner):
                 tt_prompt_embeds,
                 tt_add_text_embeds,
             )
-            self._prepare_input_tensors_for_iteration(tensors, 0)
+            self._prepare_input_tensors_for_iteration(tensors)
 
             self.logger.debug(f"Device {self.device_id}: Compiling image processing...")
 


### PR DESCRIPTION
## Problem
When a batch was received for SDXL based models, each request was processed sequentially on the device, even though the device could contain multiple chips capable of parallel execution.

## Implementation
- Allow `batch_size` to scale up to the number of available chips on the device for SDXL models
- Process the entire batch simultaneously instead of one request at a time