### PR TITLE
uplift to tt-metal 25305db vllm 6e67d2d

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1688,8 +1688,8 @@ spec_templates = [
     ModelSpecTemplate(
         weights=["meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-8B-Instruct"],
         impl=tt_transformers_impl,
-        tt_metal_commit="9b67e09",
-        vllm_commit="a91b644",
+        tt_metal_commit="25305db",
+        vllm_commit="6e67d2d",
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.N150,


### PR DESCRIPTION
## testing

Below is release report from local run:

---

## Tenstorrent Model Release Summary: Llama-3.1-8B-Instruct on t3k

### Metadata: Llama-3.1-8B-Instruct on t3k
```json
{
    "report_id": "id_tt-transformers_Llama-3.1-8B-Instruct_t3k_2025-12-08_21-26-03",
    "model_name": "Llama-3.1-8B-Instruct",
    "model_id": "id_tt-transformers_Llama-3.1-8B-Instruct_t3k",
    "model_spec_json": "/home/tstesco/projects/tt-inference-server/workflow_logs/run_specs/tt_model_spec_2025-12-08_20-40-29_id_tt-transformers_Llama-3.1-8B-Instruct_t3k_release_l3-4Qh7o.json",
    "model_repo": "meta-llama/Llama-3.1-8B-Instruct",
    "model_impl": "tt-transformers",
    "device": "t3k",
    "server_mode": "API",
    "tt_metal_commit": "25305db",
    "vllm_commit": "6e67d2d",
    "run_command": "python run.py --model Llama-3.1-8B-Instruct --device t3k --workflow release "
}
```

### Performance Benchmark Sweeps for Llama-3.1-8B-Instruct on t3k

#### Text-to-Text Performance Benchmark Sweeps for Llama-3.1-8B-Instruct on t3k

|  ISL  | OSL  | Concurrency | N Req | TTFT (ms) | TPOT (ms) | Tput User (TPS) | Tput Decode (TPS) | Tput Prefill (TPS) | E2EL (ms) | Req Tput (RPS) |
|-------|------|-------------|-------|-----------|-----------|-----------------|-------------------|--------------------|-----------|----------------|
|   128 |  128 |           1 |     8 |      47.7 |      19.5 |           51.2  |              51.2 |             2682.7 |    2528.1 |          0.395 |
|   128 |  128 |           8 |   256 |     303.5 |      19.6 |           50.9  |             407.2 |             3373.8 |    2798.6 |          2.857 |
|   128 | 1024 |           1 |     4 |      51.6 |      19.9 |           50.3  |              50.3 |             2482.7 |   20391.0 |          0.049 |
|  1024 |  128 |           1 |     4 |     136.6 |      20.2 |           49.39 |              49.4 |             7498.1 |    2707.9 |          0.369 |
|  2048 |  128 |           1 |     4 |     252.3 |      20.7 |           48.3  |              48.3 |             8116.8 |    2881.9 |          0.347 |
|  3072 |  128 |           1 |     4 |     479.7 |      21.0 |           47.56 |              47.6 |             6403.8 |    3150.2 |          0.317 |
|  4096 |  128 |           1 |     2 |     482.5 |      21.6 |           46.3  |              46.3 |             8488.8 |    3225.5 |          0.31  |
|  8192 |  128 |           1 |     2 |     964.4 |      23.3 |           42.84 |              42.8 |             8494.2 |    3928.9 |          0.254 |
| 16384 |  128 |           1 |     2 |    2084.1 |      27.0 |           37.01 |              37.0 |             7861.3 |    5515.3 |          0.181 |
| 32000 |  128 |           1 |     2 |    4843.6 |      34.1 |           29.33 |              29.3 |             6606.7 |    9174.2 |          0.109 |
|   128 |  128 |          32 |   256 |    1176.4 |      20.5 |           48.71 |            1558.8 |             3481.9 |    3783.4 |          8.446 |
|   128 | 1024 |          32 |   128 |    1181.3 |      21.7 |           46.18 |            1477.9 |             3467.3 |   23331.8 |          1.371 |
|  2048 |  128 |          32 |   128 |    7620.0 |      23.8 |           41.99 |            1343.8 |             8600.5 |   10644.3 |          3.005 |
|  2048 | 2048 |          32 |    64 |    7595.0 |      24.8 |           40.29 |            1289.3 |             8628.8 |   58399.4 |          0.548 |
|  3000 |   64 |          32 |   128 |   14800.1 |      24.6 |           40.58 |            1298.5 |             6486.5 |   16352.7 |          1.956 |
|  4000 |   64 |          32 |   128 |   14825.5 |      26.3 |           37.96 |            1214.7 |             8633.8 |   16485.1 |          1.94  |
|  8000 |   64 |          16 |    32 |   15040.9 |      25.8 |           38.78 |             620.5 |             8510.2 |   16665.4 |          0.96  |
| 16000 |   64 |           8 |    16 |   16346.8 |      27.5 |           36.33 |             290.6 |             7830.3 |   18080.8 |          0.442 |
| 32000 |   64 |           4 |     8 |   19163.2 |      34.5 |           29.02 |             116.1 |             6679.5 |   21334.1 |          0.187 |

Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> N Req: total number of requests (sample size, N)
> TTFT: Time To First Token (ms)
> TPOT: Time Per Output Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)
> Tput Prefill: Throughput for prefill tokens (TPS)
> E2EL: End-to-End Latency (ms)
> Req Tput: Request Throughput (RPS)

### Performance Benchmark Targets Llama-3.1-8B-Instruct on t3k

#### Text-to-Text Performance Benchmark Targets Llama-3.1-8B-Instruct on t3k

| ISL | OSL | Concurrency | TTFT (ms) | Tput User (TPS) | Tput Decode (TPS) | Functional TTFT Check | Functional Tput User Check | Complete TTFT Check | Complete Tput User Check | Target TTFT Check | Target Tput User Check | Functional TTFT (ms) | Functional Tput User (TPS) | Complete TTFT (ms) | Complete Tput User (TPS) | Target TTFT (ms) | Target Tput User (TPS) |
|-----|-----|-------------|-----------|-----------------|-------------------|-----------------------|----------------------------|---------------------|--------------------------|-------------------|------------------------|----------------------|----------------------------|--------------------|--------------------------|------------------|------------------------|
| 128 | 128 |           1 |      47.7 |            51.2 |              51.2 | PASS ✅               | PASS ✅                    | FAIL ⛔             | FAIL ⛔                  | FAIL ⛔           | FAIL ⛔                |               230.00 |                      17.00 |              46.00 |                    85.00 |            23.00 |                 170.00 |
| 128 | 128 |           8 |     303.5 |            50.9 |             407.2 | PASS ✅               | PASS ✅                    | PASS ✅             | PASS ✅                  | PASS ✅           | FAIL ⛔                |             10880.00 |                       6.68 |            2176.00 |                    33.41 |          1088.00 |                  66.82 |

Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> TTFT: Time To First Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)

### Accuracy Evaluations for Llama-3.1-8B-Instruct on t3k

| model                 | device | task_name     | accuracy_check | score | ratio_to_reference | gpu_reference_score | ratio_to_published | published_score                                                                           |
|-----------------------|--------|---------------|----------------|-------|--------------------|---------------------|--------------------|-------------------------------------------------------------------------------------------|
| Llama-3.1-8B-Instruct | t3k    | meta_ifeval   | PASS ✅         | 80.88 | 0.99               | 81.38               | 1.01               | [80.40](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct#instruction-tuned-models) |
| Llama-3.1-8B-Instruct | t3k    | meta_gpqa_cot | PASS ✅         | 30.36 | 1.07               | 28.34               | 1.00               | [30.40](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct#instruction-tuned-models) |

Note: The ratio to published scores defines if eval ran roughly correctly, as the exact methodology of the model publisher cannot always be reproduced. For this reason the accuracy check is based first on being equivalent to the GPU reference within a +/- tolerance. If a value GPU reference is not available, the accuracy check is based on the direct ratio to the published score.

### Test Results for Llama-3.1-8B-Instruct on t3k

### LLM API Test Metadata

| Attribute | Value |
| --- | --- |
| **Endpoint URL** | `http://127.0.0.1:8000/v1/chat/completions` |
| **Test Timestamp** | 2025-12-08 21:20:40 UTC |

### Parameter Conformance Summary

| Test Case | Status | Summary |
| --- | :---: | --- |
| `test_determinism_parameters` | ✅ PASS | 3/3 passed |
| `test_logprobs` | ✅ PASS | 1/1 passed |
| `test_max_tokens` | ✅ PASS | 2/2 passed |
| `test_n` | ✅ PASS | 2/2 passed |
| `test_penalties` | ❌ FAIL | 8/9 passed |
| `test_seed_reproducibility` | ✅ PASS | 1/1 passed |
| `test_stop` | ✅ PASS | 2/2 passed |

### Detailed Test Results

| Test Case | Parametrization | Status | Message |
| --- | --- | :---: | --- |
| `test_determinism_parameters` | `test_determinism_parameters[temperature-0.0]` | ✅ PASSED |  |
| `test_determinism_parameters` | `test_determinism_parameters[top_k-1]` | ✅ PASSED |  |
| `test_determinism_parameters` | `test_determinism_parameters[top_p-0.01]` | ✅ PASSED |  |
| `test_logprobs` | `test_logprobs` | ✅ PASSED |  |
| `test_max_tokens` | `test_max_tokens[10]` | ✅ PASSED |  |
| `test_max_tokens` | `test_max_tokens[5]` | ✅ PASSED |  |
| `test_n` | `test_n[2]` | ✅ PASSED |  |
| `test_n` | `test_n[3]` | ✅ PASSED |  |
| `test_penalties` | `test_penalties[presence_penalty-1.2-repeat_trap-messages0]` | ❌ FAILED | 2025-12-08T21:21:27.599846 –  Traceback: AssertionError: Test failed: Penalty didn't reduce repetition on repetition-trap prompt. assert 67 <= 44. Base: It was a sunny day in the small town of Willow Creek. The sun was shining brightly in the sky, ca... |
| `test_penalties` | `test_penalties[frequency_penalty-1.2-natural_repetition-messages1]` | ✅ PASSED |  |
| `test_penalties` | `test_penalties[frequency_penalty-1.2-repeat_trap-messages0]` | ✅ PASSED |  |
| `test_penalties` | `test_penalties[frequency_penalty-1.2-semantic_repetition-messages2]` | ✅ PASSED |  |
| `test_penalties` | `test_penalties[presence_penalty-1.2-natural_repetition-messages1]` | ✅ PASSED |  |
| `test_penalties` | `test_penalties[presence_penalty-1.2-semantic_repetition-messages2]` | ✅ PASSED |  |
| `test_penalties` | `test_penalties[repetition_penalty-1.5-natural_repetition-messages1]` | ✅ PASSED |  |
| `test_penalties` | `test_penalties[repetition_penalty-1.5-repeat_trap-messages0]` | ✅ PASSED |  |
| `test_penalties` | `test_penalties[repetition_penalty-1.5-semantic_repetition-messages2]` | ✅ PASSED |  |
| `test_seed_reproducibility` | `test_seed_reproducibility` | ✅ PASSED |  |
| `test_stop` | `test_stop[stop_seq0]` | ✅ PASSED |  |
| `test_stop` | `test_stop[stop_seq1]` | ✅ PASSED |  |

