### PR TITLE
Add AIPerf benchmarking tool integration

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -6,6 +6,26 @@ Performance Benchmarks for Tenstorrent LLM (model) implementations. These benchm
 
 See [Model Readiness Workflows User Guide](../docs/workflows_user_guide.md#performance-benchmarks)
 
+## Benchmarking Tools
+
+The tt-inference-server supports multiple benchmarking tools. Use the `--tools` argument to select:
+
+### vLLM benchmark_serving.py (default)
+```bash
+python run.py --model <model> --device <device> --workflow benchmarks --docker-server
+# or explicitly:
+python run.py --model <model> --device <device> --workflow benchmarks --docker-server --tools vllm
+```
+
+### AIPerf (ai-dynamo/aiperf)
+[AIPerf](https://github.com/ai-dynamo/aiperf) is a comprehensive benchmarking tool that measures the performance of generative AI models.
+
+```bash
+python run.py --model <model> --device <device> --workflow benchmarks --docker-server --tools aiperf
+```
+
+For manual usage of AIPerf, see [AIPerf Manual Usage Guide](../docs/aiperf_manual.md).
+
 ### `run_benchmarks.py`
 
 Purpose: Main script for performance benchmarks defined in `BENCHMARK_CONFIGS`, called by `run.py` via `run_workflows.py`.

--- a/benchmarking/run_benchmarks_aiperf.py
+++ b/benchmarking/run_benchmarks_aiperf.py
@@ -1,0 +1,530 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+"""
+AIPerf Benchmark Runner for tt-inference-server.
+
+This script runs performance benchmarks using the AIPerf tool
+(https://github.com/ai-dynamo/aiperf) against a vLLM-compatible server.
+
+AIPerf is a comprehensive benchmarking tool that measures the performance
+of generative AI models served by inference solutions like vLLM.
+"""
+
+import argparse
+import glob
+import json
+import logging
+import os
+import shutil
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import jwt
+
+# Add project root to Python path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from benchmarking.benchmark_config import BENCHMARK_CONFIGS
+from utils.prompt_client import PromptClient
+from utils.prompt_configs import EnvironmentConfig
+from workflows.log_setup import setup_workflow_script_logger
+from workflows.model_spec import ModelSpec
+from workflows.utils import run_command
+from workflows.workflow_types import DeviceTypes
+from workflows.workflow_venvs import VENV_CONFIGS
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BenchmarkResult:
+    """Container for a single benchmark run result."""
+
+    isl: int
+    osl: int
+    concurrency: int
+    num_prompts: int
+    avg_ttft_ms: float = 0.0
+    avg_tpot_ms: float = 0.0
+    avg_tps: float = 0.0
+    p99_latency: float = 0.0
+    error: Optional[str] = None
+
+
+class BenchmarkAggregator:
+    """Aggregates benchmark results across multiple runs."""
+
+    def __init__(self):
+        self.results: List[BenchmarkResult] = []
+
+    def add_result(self, result: BenchmarkResult):
+        self.results.append(result)
+
+    def to_dict(self) -> List[Dict]:
+        return [
+            {
+                "isl": r.isl,
+                "osl": r.osl,
+                "concurrency": r.concurrency,
+                "num_prompts": r.num_prompts,
+                "avg_ttft_ms": r.avg_ttft_ms,
+                "avg_tpot_ms": r.avg_tpot_ms,
+                "avg_tps": r.avg_tps,
+                "p99_latency": r.p99_latency,
+                "error": r.error,
+            }
+            for r in self.results
+        ]
+
+
+def get_num_prompts(input_len: int, output_len: int, max_concurrency: int) -> int:
+    """Calculate number of prompts based on sequence lengths and concurrency."""
+    if output_len > 1024 or input_len > 4000:
+        return 2 * max_concurrency
+    if (output_len > 128 and output_len <= 1024) or (
+        input_len > 128 and input_len <= 4000
+    ):
+        return 4 * max_concurrency
+    if output_len <= 128:
+        return 8 * max_concurrency
+    raise ValueError(f"Invalid output_len: {output_len}")
+
+
+def parse_aiperf_output(artifact_dir: str) -> Dict[str, float]:
+    """
+    Parse metrics from AIPerf profile export JSON file.
+
+    AIPerf stores aggregated results in profile_export_aiperf.json in the artifact directory.
+    This function extracts key metrics compatible with vLLM benchmark format.
+    """
+    # Prefer profile_export_aiperf.json as it contains aggregated summary metrics
+    # The JSONL file contains per-request records which require different parsing
+    json_candidates = [
+        os.path.join(artifact_dir, "profile_export_aiperf.json"),
+        os.path.join(artifact_dir, "profile_export.json"),
+    ]
+
+    # Also search in subdirectories
+    for subdir in glob.glob(os.path.join(artifact_dir, "*")):
+        if os.path.isdir(subdir):
+            json_candidates.extend([
+                os.path.join(subdir, "profile_export_aiperf.json"),
+                os.path.join(subdir, "profile_export.json"),
+            ])
+
+    json_path = None
+    for candidate in json_candidates:
+        if os.path.exists(candidate):
+            json_path = candidate
+            logger.info(f"Found AIPerf output file: {json_path}")
+            break
+
+    if not json_path:
+        logger.warning(f"AIPerf output not found in {artifact_dir}")
+        return {}
+
+    try:
+        # Parse the JSON file containing aggregated metrics
+        with open(json_path, "r") as f:
+            summary = json.load(f)
+
+        # Map AIPerf metrics to vLLM-compatible format
+        # AIPerf summary format: {"metric_name": {"unit": "...", "avg": X, "p50": Y, ...}}
+        metrics = {
+            # TTFT metrics (Time To First Token)
+            "mean_ttft_ms": summary.get("time_to_first_token", {}).get("avg", 0),
+            "median_ttft_ms": summary.get("time_to_first_token", {}).get("p50", 0),
+            "p99_ttft_ms": summary.get("time_to_first_token", {}).get("p99", 0),
+            "std_ttft_ms": summary.get("time_to_first_token", {}).get("std", 0),
+            # TPOT metrics (Time Per Output Token)
+            "mean_tpot_ms": summary.get("inter_token_latency", {}).get("avg", 0),
+            "median_tpot_ms": summary.get("inter_token_latency", {}).get("p50", 0),
+            "p99_tpot_ms": summary.get("inter_token_latency", {}).get("p99", 0),
+            "std_tpot_ms": summary.get("inter_token_latency", {}).get("std", 0),
+            # ITL metrics (Inter-Token Latency)
+            "mean_itl_ms": summary.get("inter_token_latency", {}).get("avg", 0),
+            "median_itl_ms": summary.get("inter_token_latency", {}).get("p50", 0),
+            "p99_itl_ms": summary.get("inter_token_latency", {}).get("p99", 0),
+            "std_itl_ms": summary.get("inter_token_latency", {}).get("std", 0),
+            # E2EL metrics (End-to-End Latency)
+            "mean_e2el_ms": summary.get("request_latency", {}).get("avg", 0),
+            "median_e2el_ms": summary.get("request_latency", {}).get("p50", 0),
+            "p99_e2el_ms": summary.get("request_latency", {}).get("p99", 0),
+            "std_e2el_ms": summary.get("request_latency", {}).get("std", 0),
+            # Throughput metrics
+            "output_token_throughput": summary.get(
+                "output_token_throughput", {}
+            ).get("avg", 0),
+            "request_throughput": summary.get("request_throughput", {}).get(
+                "avg", 0
+            ),
+            # Request counts
+            "completed": int(summary.get("request_count", {}).get("avg", 0)),
+            "total_input_tokens": int(
+                summary.get("input_sequence_length", {}).get("avg", 0)
+                * summary.get("request_count", {}).get("avg", 0)
+            ),
+            "total_output_tokens": int(
+                summary.get("output_sequence_length", {}).get("avg", 0)
+                * summary.get("request_count", {}).get("avg", 0)
+            ),
+        }
+
+        return metrics
+
+    except Exception as e:
+        logger.error(f"Error parsing AIPerf output: {e}")
+        import traceback
+        logger.error(traceback.format_exc())
+        return {}
+
+
+def print_detailed_results(
+    isl: int, osl: int, concurrency: int, num_requests: int, metrics: Dict[str, float]
+) -> None:
+    """Print detailed benchmark results matching vLLM format."""
+    logger.info("=" * 80)
+    logger.info(
+        f"Serving Benchmark Result: ISL={isl}, OSL={osl}, Concurrency={concurrency}"
+    )
+    logger.info("=" * 80)
+    logger.info(
+        f"Successful requests:                     {metrics.get('completed', num_requests)}"
+    )
+    logger.info(
+        f"Request throughput (req/s):              {metrics.get('request_throughput', 0):.2f}"
+    )
+    logger.info(
+        f"Output token throughput (tok/s):         {metrics.get('output_token_throughput', 0):.2f}"
+    )
+    logger.info(
+        f"Total input tokens:                      {metrics.get('total_input_tokens', 0)}"
+    )
+    logger.info(
+        f"Total output tokens:                     {metrics.get('total_output_tokens', 0)}"
+    )
+    logger.info(f"Mean TTFT (ms):                          {metrics.get('mean_ttft_ms', 0):.2f}")
+    logger.info(f"Mean TPOT (ms):                          {metrics.get('mean_tpot_ms', 0):.2f}")
+    logger.info(f"Mean E2EL (ms):                          {metrics.get('mean_e2el_ms', 0):.2f}")
+    logger.info("=" * 80)
+
+
+def save_individual_result(
+    metrics: Dict[str, float],
+    isl: int,
+    osl: int,
+    concurrency: int,
+    num_requests: int,
+    model_name: str,
+    model_id: str,
+    output_dir: str,
+) -> str:
+    """Save individual benchmark result in aiperf format."""
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
+    # Use aiperf_ prefix to differentiate from vLLM benchmarks
+    filename = f"aiperf_benchmark_{model_id}_{timestamp}_isl-{isl}_osl-{osl}_maxcon-{concurrency}_n-{num_requests}.json"
+    filepath = os.path.join(output_dir, filename)
+
+    # Build vLLM-compatible JSON structure
+    result = {
+        "date": datetime.now().strftime("%Y%m%d-%H%M%S"),
+        "backend": "aiperf",
+        "model_id": model_name,
+        "tokenizer_id": model_name,
+        "num_prompts": num_requests,
+        "max_concurrency": concurrency,
+        **metrics,  # All harmonized metrics
+    }
+
+    with open(filepath, "w") as f:
+        json.dump(result, f, indent=2)
+
+    logger.info(f"Result saved to: {filepath}")
+    return filepath
+
+
+def run_benchmark(
+    isl: int,
+    osl: int,
+    concurrency: int,
+    aggregator,
+    model_name: str,
+    model_id: str,
+    tokenizer: str,
+    url: str,
+    auth_token: str,
+    artifact_base: str,
+    output_dir: str,
+    venv_python: Path,
+    verbose: bool = False,
+) -> int:
+    """Run a single AIPerf benchmark with specified parameters."""
+    num_prompts = get_num_prompts(isl, osl, concurrency)
+
+    run_id = f"bench_{isl}_{osl}_{concurrency}"
+    artifact_dir = os.path.join(artifact_base, run_id)
+
+    logger.info(f"Running: ISL={isl}, OSL={osl}, Concur={concurrency}, N={num_prompts}")
+
+    if not auth_token:
+        logger.warning("No auth token provided, benchmark may fail")
+
+    # Clean up previous artifact dir
+    if os.path.exists(artifact_dir):
+        shutil.rmtree(artifact_dir)
+    os.makedirs(artifact_dir, exist_ok=True)
+
+    # Build aiperf command
+    # Format URL properly
+    if not url.startswith("http"):
+        url = f"http://{url}"
+
+    cmd = [
+        str(venv_python),
+        "-m",
+        "aiperf",
+        "profile",
+        "--model",
+        model_name,
+        "--tokenizer",
+        tokenizer,
+        "--endpoint-type",
+        "chat",
+        "--streaming",
+        "--concurrency",
+        str(concurrency),
+        "--request-count",
+        str(num_prompts),
+        "--synthetic-input-tokens-mean",
+        str(isl),
+        "--synthetic-input-tokens-stddev",
+        "0",
+        "--output-tokens-mean",
+        str(osl),
+        "--output-tokens-stddev",
+        "0",
+        "--url",
+        url,
+        "--artifact-dir",
+        artifact_dir,
+    ]
+
+    # Add auth token if available
+    if auth_token:
+        cmd.extend(["--api-key", auth_token])
+
+    # Set environment
+    env_vars = os.environ.copy()
+
+    # Run the benchmark
+    logger.info(f"Executing: {' '.join(cmd)}")
+    return_code = run_command(command=cmd, logger=logger, env=env_vars)
+
+    if return_code != 0:
+        logger.error(f"AIPerf benchmark failed with return code: {return_code}")
+        aggregator.add_result(
+            BenchmarkResult(isl, osl, concurrency, num_prompts, error="Benchmark failed")
+        )
+        return return_code
+
+    # Parse results
+    metrics = parse_aiperf_output(artifact_dir)
+
+    if metrics:
+        print_detailed_results(isl, osl, concurrency, num_prompts, metrics)
+        save_individual_result(
+            metrics, isl, osl, concurrency, num_prompts, model_name, model_id, output_dir
+        )
+        aggregator.add_result(
+            BenchmarkResult(
+                isl,
+                osl,
+                concurrency,
+                num_prompts,
+                avg_ttft_ms=metrics.get("mean_ttft_ms", 0),
+                avg_tpot_ms=metrics.get("mean_tpot_ms", 0),
+                avg_tps=1000 / max(metrics.get("mean_tpot_ms", 1), 0.001),
+            )
+        )
+    else:
+        aggregator.add_result(
+            BenchmarkResult(
+                isl, osl, concurrency, num_prompts, error="Failed to parse output"
+            )
+        )
+
+    return return_code
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Run AIPerf benchmarks")
+    parser.add_argument(
+        "--model-spec-json",
+        type=str,
+        help="Use model specification from JSON file",
+        required=True,
+    )
+    parser.add_argument(
+        "--output-path",
+        type=str,
+        help="Path for benchmark output",
+        required=True,
+    )
+    parser.add_argument(
+        "--jwt-secret",
+        type=str,
+        help="JWT secret for generating token to set API_KEY",
+        default=os.getenv("JWT_SECRET", ""),
+    )
+    parser.add_argument(
+        "--hf-token",
+        type=str,
+        help="HF_TOKEN",
+        default=os.getenv("HF_TOKEN", ""),
+    )
+    return parser.parse_args()
+
+
+def main():
+    """Main entry point for AIPerf benchmarks."""
+    setup_workflow_script_logger(logger)
+    logger.info(f"Running {__file__} ...")
+
+    args = parse_args()
+    jwt_secret = args.jwt_secret
+    model_spec = ModelSpec.from_json(args.model_spec_json)
+
+    # Extract CLI args from model_spec
+    cli_args = model_spec.cli_args
+    device_str = cli_args.get("device")
+    service_port = cli_args.get("service_port", os.getenv("SERVICE_PORT", "8000"))
+
+    device = DeviceTypes.from_string(device_str)
+    logger.info(f"model_spec=: {model_spec}")
+    logger.info(f"device=: {device_str}")
+    logger.info(f"service_port=: {service_port}")
+    logger.info(f"output_path=: {args.output_path}")
+
+    # Set environment vars
+    auth_token = ""
+    if jwt_secret:
+        json_payload = json.loads(
+            '{"team_id": "tenstorrent", "token_id": "debug-test"}'
+        )
+        encoded_jwt = jwt.encode(json_payload, jwt_secret, algorithm="HS256")
+        os.environ["OPENAI_API_KEY"] = encoded_jwt
+        auth_token = encoded_jwt
+        logger.info("OPENAI_API_KEY environment variable set using provided JWT secret.")
+
+    # Get venv config for aiperf
+    from workflows.workflow_types import WorkflowVenvType
+
+    venv_config = VENV_CONFIGS[WorkflowVenvType.BENCHMARKS_AIPERF]
+
+    # Look up the benchmark configuration for the model
+    if model_spec.model_id not in BENCHMARK_CONFIGS:
+        raise ValueError(
+            f"No benchmark tasks defined for model: {model_spec.model_name}"
+        )
+    benchmark_config = BENCHMARK_CONFIGS[model_spec.model_id]
+
+    # Get all benchmark params for this device
+    all_params = [
+        param
+        for task in benchmark_config.tasks
+        if device in task.param_map
+        for param in task.param_map[device]
+    ]
+
+    if not all_params:
+        raise ValueError(
+            f"No benchmark tasks defined for model: {model_spec.model_name} on device: {device.name}"
+        )
+
+    # Log benchmark parameters
+    log_str = "Running AIPerf benchmarks for:\n"
+    log_str += f"  {'#':<3} {'isl':<10} {'osl':<10} {'max_concurrency':<15} {'num_prompts':<12}\n"
+    log_str += f"  {'-' * 3:<3} {'-' * 10:<10} {'-' * 10:<10} {'-' * 15:<15} {'-' * 12:<12}\n"
+    for i, param in enumerate(all_params, 1):
+        if param.task_type == "text":
+            log_str += f"  {i:<3} {param.isl:<10} {param.osl:<10} {param.max_concurrency:<15} {param.num_prompts:<12}\n"
+    logger.info(log_str)
+
+    # Wait for server to be ready
+    logger.info("Wait for the vLLM server to be ready ...")
+    env_config = EnvironmentConfig()
+    env_config.jwt_secret = jwt_secret
+    env_config.service_port = service_port
+    env_config.vllm_model = model_spec.hf_model_repo
+
+    prompt_client = PromptClient(env_config, model_spec=model_spec)
+    if not prompt_client.wait_for_healthy():
+        logger.error("vLLM server is not healthy. Aborting benchmarks.")
+        return 1
+
+    # Create artifact directory
+    artifact_base = venv_config.venv_path / "artifacts" / model_spec.model_id
+    artifact_base.mkdir(parents=True, exist_ok=True)
+
+    # Ensure output path exists
+    os.makedirs(args.output_path, exist_ok=True)
+
+    # Run benchmarks
+    aggregator = BenchmarkAggregator()
+    return_codes = []
+
+    for i, params in enumerate(all_params, 1):
+        # Skip non-text benchmarks for now
+        if params.task_type != "text":
+            continue
+
+        # Health check
+        health_check = prompt_client.get_health()
+        if health_check.status_code != 200:
+            logger.error("vLLM server is not healthy. Aborting benchmarks.")
+            return 1
+
+        logger.info(f"Running benchmark {model_spec.model_name}: {i}/{len(all_params)}")
+
+        # Add delay between runs
+        time.sleep(2)
+
+        return_code = run_benchmark(
+            isl=params.isl,
+            osl=params.osl,
+            concurrency=params.max_concurrency,
+            aggregator=aggregator,
+            model_name=model_spec.hf_model_repo,
+            model_id=model_spec.model_id,
+            tokenizer=model_spec.hf_model_repo,
+            url=f"localhost:{service_port}",
+            auth_token=auth_token,
+            artifact_base=str(artifact_base),
+            output_dir=args.output_path,
+            venv_python=venv_config.venv_python,
+        )
+        return_codes.append(return_code)
+
+    if all(return_code == 0 for return_code in return_codes):
+        logger.info("Completed AIPerf benchmarks")
+        main_return_code = 0
+    else:
+        logger.error(
+            f"AIPerf benchmarks failed with return codes: {return_codes}. See logs above for details."
+        )
+        main_return_code = 1
+
+    return main_return_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarking/summary_report.py
+++ b/benchmarking/summary_report.py
@@ -47,7 +47,35 @@ def parse_args():
 
 
 def extract_params_from_filename(filename: str) -> Dict[str, Any]:
-    # First try the image benchmark pattern
+    # First try the aiperf benchmark pattern
+    aiperf_pattern = r"""
+        ^aiperf_benchmark_
+        (?P<model>.+?)                            # Model name (non-greedy, allows everything)
+        (?:_(?P<device>N150|N300|P100|P150|T3K|p150x4|p150x8|n150x4|TG|GALAXY|n150|n300|p100|p150|t3k|tg|galaxy))?  # Optional device
+        _(?P<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})
+        _isl-(?P<isl>\d+)
+        _osl-(?P<osl>\d+)
+        _maxcon-(?P<maxcon>\d+)
+        _n-(?P<n>\d+)
+        \.json$
+    """
+
+    # Try aiperf pattern first
+    match = re.search(aiperf_pattern, filename, re.VERBOSE)
+    if match:
+        return {
+            "model_name": match.group("model"),
+            "timestamp": match.group("timestamp"),
+            "device": match.group("device"),
+            "input_sequence_length": int(match.group("isl")),
+            "output_sequence_length": int(match.group("osl")),
+            "max_con": int(match.group("maxcon")),
+            "num_requests": int(match.group("n")),
+            "task_type": "text",
+            "backend": "aiperf",
+        }
+
+    # Try the image benchmark pattern
     image_pattern = r"""
         ^benchmark_
         (?P<model>.+?)                            # Model name (non-greedy, allows everything)
@@ -63,7 +91,7 @@ def extract_params_from_filename(filename: str) -> Dict[str, Any]:
         \.json$
     """
 
-    # Try image pattern first
+    # Try image pattern
     match = re.search(image_pattern, filename, re.VERBOSE)
     if match:
         # Extract and convert numeric parameters for image benchmarks
@@ -166,6 +194,55 @@ def process_benchmark_file(filepath: str) -> Dict[str, Any]:
 
     filename = os.path.basename(filepath)
     params = extract_params_from_filename(filename)
+
+    # Handle aiperf benchmark files
+    if params.get("backend") == "aiperf":
+        # AIPerf files already contain metrics in vLLM-compatible format
+        mean_tpot_ms = data.get("mean_tpot_ms", 0)
+        if mean_tpot_ms and mean_tpot_ms > 0:
+            mean_tps = 1000.0 / mean_tpot_ms
+            std_tps = None
+            if data.get("std_tpot_ms"):
+                std_tps = mean_tps - (1000.0 / (mean_tpot_ms + data.get("std_tpot_ms")))
+        else:
+            mean_tps = None
+            std_tps = None
+
+        actual_max_con = min(params["max_con"], params["num_requests"])
+        tps_decode_throughput = mean_tps * actual_max_con if mean_tps else None
+        tps_prefill_throughput = None
+        if data.get("mean_ttft_ms") and data.get("mean_ttft_ms") > 0:
+            tps_prefill_throughput = (params["input_sequence_length"] * actual_max_con) / (
+                data.get("mean_ttft_ms") / 1000
+            )
+
+        metrics = {
+            "timestamp": params["timestamp"],
+            "model_name": params["model_name"],
+            "model_id": data.get("model_id", ""),
+            "backend": "aiperf",
+            "device": params.get("device", ""),
+            "input_sequence_length": params["input_sequence_length"],
+            "output_sequence_length": params["output_sequence_length"],
+            "max_con": actual_max_con,
+            "mean_ttft_ms": data.get("mean_ttft_ms"),
+            "std_ttft_ms": data.get("std_ttft_ms"),
+            "mean_tpot_ms": mean_tpot_ms,
+            "std_tpot_ms": data.get("std_tpot_ms"),
+            "mean_tps": mean_tps,
+            "std_tps": std_tps,
+            "tps_decode_throughput": tps_decode_throughput,
+            "tps_prefill_throughput": tps_prefill_throughput,
+            "mean_e2el_ms": data.get("mean_e2el_ms"),
+            "request_throughput": data.get("request_throughput"),
+            "total_input_tokens": data.get("total_input_tokens"),
+            "total_output_tokens": data.get("total_output_tokens"),
+            "num_prompts": data.get("num_prompts", ""),
+            "num_requests": params["num_requests"],
+            "filename": filename,
+            "task_type": params["task_type"],
+        }
+        return format_metrics(metrics)
 
     if params.get("task_type") == "cnn":
         # For CNN benchmarks, extract data from JSON content

--- a/docs/aiperf_manual.md
+++ b/docs/aiperf_manual.md
@@ -1,0 +1,161 @@
+# [AIPerf](https://github.com/ai-dynamo/aiperf) Benchmarking for Tenstorrent Hardware
+
+AIPerf benchmarks measure LLM inference performance on Tenstorrent accelerators, providing detailed latency percentiles (mean, P50, P99) and throughput metrics.
+
+## Usage
+
+Run AIPerf benchmarks through tt-inference-server:
+
+```bash
+python run.py --model <model> --device <device> --workflow benchmarks --docker-server --tools aiperf
+```
+
+### Example: gemma-3-4b-it on N300
+
+```bash
+python run.py --model gemma-3-4b-it --device n300 --workflow benchmarks --docker-server --tools aiperf
+```
+
+### Example: gemma-3-27b-it on T3K
+
+```bash
+python run.py --model gemma-3-27b-it --device t3k --workflow benchmarks --docker-server --tools aiperf
+```
+
+## What the Workflow Does
+
+1. **Starts vLLM server** in Docker container on Tenstorrent hardware
+2. **Waits for server health** check to pass
+3. **Runs benchmark sweep** across multiple ISL/OSL/concurrency configurations
+4. **Parses AIPerf output** and saves standardized JSON results
+5. **Generates markdown report** with detailed performance tables
+
+## Benchmark Configurations
+
+The benchmark sweep runs multiple configurations defined in `benchmark_config.py`:
+
+| Batch | ISL Range | OSL | Concurrency | Requests |
+|-------|-----------|-----|-------------|----------|
+| Low concurrency | 128 - 32000 | 128 | 1 | 2-8 |
+| High concurrency | 128 - 16000 | 64-2048 | 8-32 | 16-256 |
+
+## Output Files
+
+### Individual Benchmark Results
+
+Results are saved to `workflow_logs/benchmarks_aiperf_output/`:
+
+```
+aiperf_benchmark_<model_id>_<timestamp>_isl-<isl>_osl-<osl>_maxcon-<concurrency>_n-<requests>.json
+```
+
+### Sample Result: gemma-3-4b-it on N300 (ISL=128, OSL=128, Concurrency=32)
+
+```json
+{
+  "date": "20251210-160152",
+  "backend": "aiperf",
+  "model_id": "google/gemma-3-4b-it",
+  "num_prompts": 256,
+  "max_concurrency": 32,
+  "mean_ttft_ms": 2396.53,
+  "median_ttft_ms": 2580.12,
+  "p99_ttft_ms": 2729.42,
+  "std_ttft_ms": 614.01,
+  "mean_tpot_ms": 44.69,
+  "median_tpot_ms": 43.35,
+  "p99_tpot_ms": 62.83,
+  "std_tpot_ms": 4.82,
+  "mean_e2el_ms": 8026.66,
+  "median_e2el_ms": 8090.18,
+  "p99_e2el_ms": 8234.98,
+  "output_token_throughput": 502.62,
+  "request_throughput": 3.96,
+  "completed": 256,
+  "total_input_tokens": 32768,
+  "total_output_tokens": 32486
+}
+```
+
+### Raw AIPerf Artifacts
+
+AIPerf also generates raw output in `.workflow_venvs/.venv_benchmarks_aiperf/artifacts/`:
+
+| File | Description |
+|------|-------------|
+| `profile_export_aiperf.json` | Aggregated metrics with percentiles |
+| `profile_export.jsonl` | Per-request detailed metrics |
+| `profile_export_aiperf.csv` | CSV format for analysis |
+
+## Generated Report
+
+The workflow generates a markdown report in `workflow_logs/reports_output/benchmarks_aiperf/`:
+
+| ISL | OSL | Concur | N | TTFT Avg (ms) | TTFT P50 (ms) | TTFT P99 (ms) | TPOT Avg (ms) | TPOT P50 (ms) | TPOT P99 (ms) | Tok/s |
+|-----|-----|--------|---|---------------|---------------|---------------|---------------|---------------|---------------|-------|
+| 128 | 128 | 1 | 8 | 8905.3 | 95.6 | 46478.1 | 337.9 | 273.2 | 1093.1 | 2.47 |
+| 128 | 128 | 32 | 256 | 2396.5 | 2580.1 | 2729.4 | 44.7 | 43.3 | 62.8 | 502.62 |
+| 2048 | 128 | 32 | 128 | 27276.2 | 28142.1 | 31245.8 | 285.3 | 278.6 | 312.4 | 3.51 |
+
+## Metrics Reference
+
+| Metric | Description | Unit |
+|--------|-------------|------|
+| **TTFT** | Time To First Token - latency until first token generated | ms |
+| **TPOT** | Time Per Output Token - average inter-token latency | ms |
+| **ITL** | Inter-Token Latency - same as TPOT | ms |
+| **E2EL** | End-to-End Latency - total request duration | ms |
+| **Tok/s** | Output token throughput | tokens/sec |
+| **Req/s** | Request throughput | requests/sec |
+
+### Percentile Statistics
+
+Each latency metric includes:
+- **Avg (mean)**: Average across all requests
+- **P50 (median)**: 50th percentile - typical latency
+- **P99**: 99th percentile - worst-case latency
+- **std**: Standard deviation
+
+## Comparison: AIPerf vs vLLM Benchmarks
+
+| Feature | `--tools vllm` | `--tools aiperf` |
+|---------|----------------|------------------|
+| Metrics | Mean only | Mean, P50, P99, std |
+| Output format | Basic JSON | Detailed JSON + JSONL (see [Raw AIPerf Artifacts](#raw-aiperf-artifacts)) |
+| Report columns | 6 metrics | 12+ metrics |
+| Tool source | vLLM repo | NVIDIA ai-dynamo |
+
+> **Note:** The JSONL file (`profile_export.jsonl`) contains per-request metrics and is saved in `.workflow_venvs/.venv_benchmarks_aiperf/artifacts/<model_id>/bench_<isl>_<osl>_<concurrency>/`.
+
+Use `--tools vllm` (default) for quick benchmarks, `--tools aiperf` for detailed performance analysis.
+
+## File Structure
+
+```
+workflow_logs/
+├── benchmarks_aiperf_output/           # Individual benchmark JSONs
+│   ├── aiperf_benchmark_*_isl-128_osl-128_maxcon-1_n-8.json
+│   ├── aiperf_benchmark_*_isl-128_osl-128_maxcon-32_n-256.json
+│   └── ...
+└── reports_output/
+    └── benchmarks_aiperf/              # Generated reports
+        ├── aiperf_benchmark_display_*.md
+        └── data/
+            └── aiperf_benchmark_stats_*.csv
+
+.workflow_venvs/.venv_benchmarks_aiperf/
+└── artifacts/<model_id>/               # Raw AIPerf output
+    └── bench_<isl>_<osl>_<concurrency>/
+        ├── profile_export_aiperf.json
+        ├── profile_export.jsonl
+        └── profile_export_aiperf.csv
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Server not starting | Check Docker logs: `docker logs <container>` |
+| All metrics are 0 | Verify server health: `curl http://localhost:8000/health` or delete previously generated json files under `./tt-inference-server/workflow_logs/benchmarks_aiperf_output`|
+| Missing dependencies | Delete `.workflow_venvs/.venv_benchmarks_aiperf/` and re-run |
+| Authentication errors | Check `JWT_SECRET` is set in `.env` file |

--- a/run.py
+++ b/run.py
@@ -185,6 +185,13 @@ def parse_arguments():
         help="Number of prompts to use for SDXL (default: 1)",
         default="100",
     )
+    parser.add_argument(
+        "--tools",
+        type=str,
+        choices=["vllm", "aiperf"],
+        default="vllm",
+        help="Benchmarking tool to use: 'vllm' for vLLM benchmark_serving.py (default), 'aiperf' for AIPerf (https://github.com/ai-dynamo/aiperf)",
+    )
 
     args = parser.parse_args()
 
@@ -315,6 +322,7 @@ def format_cli_args_summary(args, model_spec):
         f"  reset_venvs:                {args.reset_venvs}",
         f"  limit-samples-mode:         {args.limit_samples_mode}",
         f"  skip_system_sw_validation:  {args.skip_system_sw_validation}",
+        f"  tools:                      {args.tools}",
         "",
         "=" * 60,
     ]

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -309,15 +309,194 @@ def benchmark_image_release_markdown(release_raw, target_checks=None):
     return markdown_str
 
 
+def aiperf_release_markdown(release_raw):
+    """Generate markdown table for AIPerf benchmarks with detailed metrics.
+
+    This follows NVIDIA's genai-perf style output with mean, median, and p99 percentiles
+    for each key metric category.
+    """
+    # Define display columns mapping - NVIDIA style with detailed percentiles
+    display_cols = [
+        ("isl", "ISL"),
+        ("osl", "OSL"),
+        ("concurrency", "Concur"),
+        ("num_requests", "N"),
+        # TTFT metrics
+        ("mean_ttft_ms", "TTFT Avg (ms)"),
+        ("median_ttft_ms", "TTFT P50 (ms)"),
+        ("p99_ttft_ms", "TTFT P99 (ms)"),
+        # TPOT metrics (Time Per Output Token)
+        ("mean_tpot_ms", "TPOT Avg (ms)"),
+        ("median_tpot_ms", "TPOT P50 (ms)"),
+        ("p99_tpot_ms", "TPOT P99 (ms)"),
+        # E2EL metrics (End-to-End Latency)
+        ("mean_e2el_ms", "E2EL Avg (ms)"),
+        ("median_e2el_ms", "E2EL P50 (ms)"),
+        ("p99_e2el_ms", "E2EL P99 (ms)"),
+        # Throughput
+        ("output_token_throughput", "Tok/s"),
+        ("request_throughput", "Req/s"),
+    ]
+
+    NOT_MEASURED_STR = "N/A"
+    display_dicts = []
+    for row in release_raw:
+        row_dict = {}
+        for col_name, display_header in display_cols:
+            value = row.get(col_name, NOT_MEASURED_STR)
+            if value is None or value == "":
+                row_dict[display_header] = NOT_MEASURED_STR
+            elif isinstance(value, float):
+                # Format floats with appropriate precision
+                if col_name in ("request_throughput",):
+                    row_dict[display_header] = f"{value:.4f}"
+                elif col_name in ("output_token_throughput",):
+                    row_dict[display_header] = f"{value:.2f}"
+                else:
+                    row_dict[display_header] = f"{value:.1f}"
+            else:
+                row_dict[display_header] = str(value)
+        display_dicts.append(row_dict)
+
+    # Create the markdown table
+    markdown_str = get_markdown_table(display_dicts)
+    return markdown_str
+
+
+def aiperf_benchmark_generate_report(args, server_mode, model_spec, report_id, metadata={}):
+    """Generate benchmark report specifically for AIPerf results.
+
+    AIPerf provides more detailed metrics than vLLM's benchmark_serving.py,
+    including mean, median, and p99 percentiles for TTFT, TPOT, and E2EL.
+    This function creates a separate report in NVIDIA's genai-perf style.
+    """
+    # Look for aiperf benchmark files
+    aiperf_pattern = f"aiperf_benchmark_{model_spec.model_id}_*.json"
+    benchmarks_aiperf_output_dir = f"{get_default_workflow_root_log_dir()}/benchmarks_aiperf_output"
+    aiperf_files = glob(f"{benchmarks_aiperf_output_dir}/{aiperf_pattern}")
+
+    output_dir = Path(args.output_path) / "benchmarks_aiperf"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info("AIPerf Benchmark Summary")
+    logger.info(f"Found {len(aiperf_files)} AIPerf benchmark files")
+
+    if not aiperf_files:
+        logger.info("No AIPerf benchmark files found. Skipping AIPerf report.")
+        return "", [], None, None
+
+    # Process AIPerf files
+    aiperf_results = []
+    for filepath in sorted(aiperf_files):
+        try:
+            with open(filepath, "r") as f:
+                data = json.load(f)
+
+            # Extract parameters from filename
+            filename = Path(filepath).name
+            # Pattern: aiperf_benchmark_*_isl-{isl}_osl-{osl}_maxcon-{con}_n-{n}.json
+            import re
+            match = re.search(r"isl-(\d+)_osl-(\d+)_maxcon-(\d+)_n-(\d+)", filename)
+            if match:
+                isl, osl, concurrency, num_requests = map(int, match.groups())
+            else:
+                # Fallback to data fields
+                isl = data.get("total_input_tokens", 0) // max(data.get("num_prompts", 1), 1)
+                osl = data.get("total_output_tokens", 0) // max(data.get("num_prompts", 1), 1)
+                concurrency = data.get("max_concurrency", 1)
+                num_requests = data.get("num_prompts", 0)
+
+            result = {
+                "isl": isl,
+                "osl": osl,
+                "concurrency": concurrency,
+                "num_requests": num_requests,
+                # TTFT metrics
+                "mean_ttft_ms": data.get("mean_ttft_ms", 0),
+                "median_ttft_ms": data.get("median_ttft_ms", 0),
+                "p99_ttft_ms": data.get("p99_ttft_ms", 0),
+                "std_ttft_ms": data.get("std_ttft_ms", 0),
+                # TPOT metrics
+                "mean_tpot_ms": data.get("mean_tpot_ms", 0),
+                "median_tpot_ms": data.get("median_tpot_ms", 0),
+                "p99_tpot_ms": data.get("p99_tpot_ms", 0),
+                "std_tpot_ms": data.get("std_tpot_ms", 0),
+                # E2EL metrics
+                "mean_e2el_ms": data.get("mean_e2el_ms", 0),
+                "median_e2el_ms": data.get("median_e2el_ms", 0),
+                "p99_e2el_ms": data.get("p99_e2el_ms", 0),
+                "std_e2el_ms": data.get("std_e2el_ms", 0),
+                # Throughput
+                "output_token_throughput": data.get("output_token_throughput", 0),
+                "request_throughput": data.get("request_throughput", 0),
+                # Tokens
+                "completed": data.get("completed", 0),
+                "total_input_tokens": data.get("total_input_tokens", 0),
+                "total_output_tokens": data.get("total_output_tokens", 0),
+                # Metadata
+                "model_id": data.get("model_id", ""),
+                "backend": "aiperf",
+            }
+            aiperf_results.append(result)
+        except Exception as e:
+            logger.warning(f"Error processing AIPerf file {filepath}: {e}")
+            continue
+
+    if not aiperf_results:
+        return "", [], None, None
+
+    # Sort by ISL, OSL, concurrency
+    aiperf_results.sort(key=lambda x: (x["isl"], x["osl"], x["concurrency"]))
+
+    # Generate markdown report
+    markdown_str = aiperf_release_markdown(aiperf_results)
+
+    # Add header and notes
+    release_str = f"### AIPerf Performance Benchmark Results for {model_spec.model_name} on {args.device}\n\n"
+    release_str += "**Benchmarking Tool:** [AIPerf](https://github.com/ai-dynamo/aiperf)\n\n"
+    release_str += markdown_str
+    release_str += "\n\n**Metric Definitions:**\n"
+    release_str += "> - **ISL**: Input Sequence Length (tokens)\n"
+    release_str += "> - **OSL**: Output Sequence Length (tokens)\n"
+    release_str += "> - **Concur**: Concurrent requests (batch size)\n"
+    release_str += "> - **N**: Total number of requests\n"
+    release_str += "> - **TTFT**: Time To First Token (ms)\n"
+    release_str += "> - **TPOT**: Time Per Output Token (ms)\n"
+    release_str += "> - **E2EL**: End-to-End Latency (ms)\n"
+    release_str += "> - **Tok/s**: Output token throughput\n"
+    release_str += "> - **Req/s**: Request throughput\n"
+
+    # Save markdown report
+    disp_md_path = output_dir / f"aiperf_benchmark_display_{report_id}.md"
+    with open(disp_md_path, "w", encoding="utf-8") as f:
+        f.write(release_str)
+    logger.info(f"AIPerf report saved to: {disp_md_path}")
+
+    # Save CSV data
+    data_file_path = output_dir / "data" / f"aiperf_benchmark_stats_{report_id}.csv"
+    data_file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if aiperf_results:
+        headers = list(aiperf_results[0].keys())
+        with open(data_file_path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(headers)
+            for result in aiperf_results:
+                writer.writerow([str(result.get(h, "")) for h in headers])
+        logger.info(f"AIPerf data saved to: {data_file_path}")
+
+    return release_str, aiperf_results, disp_md_path, data_file_path
+
+
 def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata={}):
-    file_name_pattern = f"benchmark_{model_spec.model_id}_*.json"
-    file_path_pattern = (
-        f"{get_default_workflow_root_log_dir()}/benchmarks_output/{file_name_pattern}"
-    )
-    files = glob(file_path_pattern)
+    # Look for vLLM benchmark files only (aiperf has its own function)
+    vllm_pattern = f"benchmark_{model_spec.model_id}_*.json"
+    benchmarks_output_dir = f"{get_default_workflow_root_log_dir()}/benchmarks_output"
+    vllm_files = glob(f"{benchmarks_output_dir}/{vllm_pattern}")
+    files = vllm_files
     output_dir = Path(args.output_path) / "benchmarks"
-    logger.info("Benchmark Summary")
-    logger.info(f"Processing: {len(files)} files")
+    logger.info("vLLM Benchmark Summary")
+    logger.info(f"Found {len(vllm_files)} vLLM benchmark files")
     if not files:
         logger.info("No benchmark files found. Skipping.")
         return (
@@ -1352,13 +1531,23 @@ def main():
 
     simple_args = SimpleArgs(args.output_path, model, device_str, args.model_spec_json)
 
-    # generate benchmarks report
+    # generate vLLM benchmarks report
     (
         benchmarks_release_str,
         benchmarks_release_data,
         benchmarks_disp_md_path,
         benchmarks_data_file_path,
     ) = benchmark_generate_report(
+        simple_args, server_mode, model_spec, report_id=report_id, metadata=metadata
+    )
+
+    # generate AIPerf benchmarks report (separate detailed report)
+    (
+        aiperf_release_str,
+        aiperf_release_data,
+        aiperf_disp_md_path,
+        aiperf_data_file_path,
+    ) = aiperf_benchmark_generate_report(
         simple_args, server_mode, model_spec, report_id=report_id, metadata=metadata
     )
 
@@ -1374,19 +1563,40 @@ def main():
         simple_args, server_mode, model_spec, report_id=report_id, metadata=metadata
     )
 
-    # if no benchmark data exists, do not
+    # Collect benchmark display content
+    benchmarks_disp_md_str = ""
     try:
-        with open(benchmarks_disp_md_path, "r", encoding="utf-8") as f:
-            benchmarks_disp_md_str = f.read()
-    except TypeError:
-        benchmarks_disp_md_str = ""
+        if benchmarks_disp_md_path:
+            with open(benchmarks_disp_md_path, "r", encoding="utf-8") as f:
+                benchmarks_disp_md_str = f.read()
+    except (TypeError, FileNotFoundError):
+        pass
+
+    # Collect AIPerf display content
+    aiperf_disp_md_str = ""
+    try:
+        if aiperf_disp_md_path:
+            with open(aiperf_disp_md_path, "r", encoding="utf-8") as f:
+                aiperf_disp_md_str = f.read()
+    except (TypeError, FileNotFoundError):
+        pass
 
     logging.info("Release Summary\n\n")
 
     release_header = (
         f"## Tenstorrent Model Release Summary: {model_spec.model_name} on {device_str}"
     )
-    release_str = f"{release_header}\n\n{metadata_str}\n\n{benchmarks_disp_md_str}\n\n{benchmarks_release_str}\n\n{evals_release_str}\n\n{tests_release_str}"
+
+    # Combine all benchmark sections
+    all_benchmarks_str = ""
+    if benchmarks_disp_md_str:
+        all_benchmarks_str += benchmarks_disp_md_str + "\n\n"
+    if benchmarks_release_str:
+        all_benchmarks_str += benchmarks_release_str + "\n\n"
+    if aiperf_release_str:
+        all_benchmarks_str += aiperf_release_str + "\n\n"
+
+    release_str = f"{release_header}\n\n{metadata_str}\n\n{all_benchmarks_str}{evals_release_str}\n\n{tests_release_str}"
     print(release_str)
     # save to file
     release_output_dir = Path(args.output_path) / "release"
@@ -1487,10 +1697,21 @@ def main():
             if benchmarks_release_data:
                 benchmarks_release_data[0]["target_checks"] = target_checks
 
+        # Read AIPerf benchmark data if available
+        aiperf_detailed_data = None
+        if aiperf_data_file_path:
+            try:
+                with open(aiperf_data_file_path, "r", encoding="utf-8") as csv_file:
+                    csv_reader = csv.DictReader(csv_file)
+                    aiperf_detailed_data = list(csv_reader)
+            except Exception as e:
+                logger.warning(f"Could not read AIPerf CSV data: {e}")
+
         json.dump(
             {
                 "metadata": metadata,
                 "benchmarks_summary": benchmarks_release_data,
+                "aiperf_benchmarks": aiperf_release_data if aiperf_release_data else [],
                 "evals": evals_release_data,
                 "benchmarks": benchmarks_detailed_data
                 if benchmarks_detailed_data
@@ -1500,6 +1721,7 @@ def main():
                         "device": getattr(args, "device", "unknown_device"),
                     }
                 ],
+                "aiperf_benchmarks_detailed": aiperf_detailed_data if aiperf_detailed_data else [],
             },
             f,
             indent=4,

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -459,9 +459,56 @@ def aiperf_benchmark_generate_report(args, server_mode, model_spec, report_id, m
         logger.info("No benchmark files found. Skipping AIPerf report.")
         return "", [], None, None
 
+    # Helper function to keep only the latest file for each (isl, osl, concurrency, task_type) config
+    def deduplicate_by_config(files):
+        """Keep only the latest file for each unique benchmark configuration.
+        
+        Files are sorted by name (which includes timestamp) in reverse order,
+        so we keep the first occurrence of each config.
+        
+        Config key includes:
+        - isl, osl, concurrency, num_requests (base params)
+        - images, height, width (for image benchmarks - treated as separate configs)
+        """
+        config_to_file = {}
+        # Sort in reverse order so latest files come first
+        for filepath in sorted(files, reverse=True):
+            filename = Path(filepath).name
+            # Extract base config from filename
+            match = re.search(r"isl-(\d+)_osl-(\d+)_maxcon-(\d+)_n-(\d+)", filename)
+            if match:
+                isl, osl, con, n = map(int, match.groups())
+                
+                # Check if this is an image benchmark (has images-X in filename)
+                img_match = re.search(r"images-(\d+)_height-(\d+)_width-(\d+)", filename)
+                if img_match:
+                    images, height, width = map(int, img_match.groups())
+                    config_key = (isl, osl, con, n, images, height, width)
+                else:
+                    # Text-only benchmark
+                    config_key = (isl, osl, con, n, 0, 0, 0)
+                
+                # Only keep the first (latest) file for each config
+                if config_key not in config_to_file:
+                    config_to_file[config_key] = filepath
+            else:
+                # If no match, include the file anyway
+                config_to_file[filepath] = filepath
+        return list(config_to_file.values())
+
+    # Deduplicate files to keep only latest run for each config
+    vllm_files = deduplicate_by_config(vllm_files)
+    aiperf_files = deduplicate_by_config(aiperf_files)
+    
+    logger.info(f"After deduplication: {len(vllm_files)} vLLM, {len(aiperf_files)} AIPerf files")
+
     # Process vLLM benchmark files first (for comparison table)
+    # Filter out image benchmarks for fair comparison with AIPerf (which doesn't support images)
+    vllm_text_only_files = [f for f in vllm_files if "images" not in Path(f).name]
+    logger.info(f"Using {len(vllm_text_only_files)} text-only vLLM files (excluded {len(vllm_files) - len(vllm_text_only_files)} image benchmarks)")
+    
     vllm_results = []
-    for filepath in sorted(vllm_files):
+    for filepath in sorted(vllm_text_only_files):
         try:
             with open(filepath, "r") as f:
                 data = json.load(f)

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -363,39 +363,112 @@ def aiperf_release_markdown(release_raw):
     return markdown_str
 
 
+def aiperf_throughput_markdown(release_raw):
+    """Generate markdown table for benchmarks with derived throughput metrics.
+
+    This follows the genai-perf comparison style with Tput User, Tput Decode, and Tput Prefill
+    columns for easy comparison between vLLM, AIPerf, and genai-perf benchmarks.
+    """
+    # Define display columns - genai-perf comparison style with Source column
+    display_cols = [
+        ("source", "Source"),
+        ("isl", "ISL"),
+        ("osl", "OSL"),
+        ("concurrency", "Concur"),
+        ("num_requests", "N"),
+        ("mean_ttft_ms", "TTFT (ms)"),
+        ("mean_tpot_ms", "TPOT (ms)"),
+        ("tput_user", "Tput User (TPS)"),
+        ("tput_decode", "Tput Decode (TPS)"),
+        ("tput_prefill", "Tput Prefill (TPS)"),
+        ("mean_e2el_ms", "E2EL (ms)"),
+        ("request_throughput", "Req Tput (RPS)"),
+    ]
+
+    NOT_MEASURED_STR = "N/A"
+    display_dicts = []
+    for row in release_raw:
+        # Calculate derived throughput metrics
+        tpot = row.get("mean_tpot_ms", 0)
+        ttft = row.get("mean_ttft_ms", 0)
+        isl = row.get("isl", 0)
+        concurrency = row.get("concurrency", 1)
+
+        tput_user = 1000.0 / tpot if tpot > 0 else 0
+        tput_decode = tput_user * concurrency
+        tput_prefill = (isl * concurrency) / (ttft / 1000.0) if ttft > 0 else 0
+
+        # Add derived metrics to row
+        row_with_derived = dict(row)
+        row_with_derived["tput_user"] = tput_user
+        row_with_derived["tput_decode"] = tput_decode
+        row_with_derived["tput_prefill"] = tput_prefill
+
+        row_dict = {}
+        for col_name, display_header in display_cols:
+            value = row_with_derived.get(col_name, NOT_MEASURED_STR)
+            if value is None or value == "":
+                row_dict[display_header] = NOT_MEASURED_STR
+            elif isinstance(value, float):
+                # Format floats with appropriate precision
+                if col_name == "request_throughput":
+                    row_dict[display_header] = f"{value:.3f}"
+                elif col_name in ("tput_user", "tput_decode", "tput_prefill"):
+                    row_dict[display_header] = f"{value:.1f}"
+                elif col_name in ("mean_ttft_ms", "mean_tpot_ms", "mean_e2el_ms"):
+                    row_dict[display_header] = f"{value:.1f}"
+                else:
+                    row_dict[display_header] = f"{value:.2f}"
+            else:
+                row_dict[display_header] = str(value)
+        display_dicts.append(row_dict)
+
+    # Create the markdown table
+    markdown_str = get_markdown_table(display_dicts)
+    return markdown_str
+
+
 def aiperf_benchmark_generate_report(args, server_mode, model_spec, report_id, metadata={}):
     """Generate benchmark report specifically for AIPerf results.
 
     AIPerf provides more detailed metrics than vLLM's benchmark_serving.py,
     including mean, median, and p99 percentiles for TTFT, TPOT, and E2EL.
     This function creates a separate report in NVIDIA's genai-perf style.
+    Table 2 (Comparison) combines both vLLM and AIPerf results for easy comparison.
     """
+    import re
+
     # Look for aiperf benchmark files
     aiperf_pattern = f"aiperf_benchmark_{model_spec.model_id}_*.json"
     benchmarks_aiperf_output_dir = f"{get_default_workflow_root_log_dir()}/benchmarks_aiperf_output"
     aiperf_files = glob(f"{benchmarks_aiperf_output_dir}/{aiperf_pattern}")
+
+    # Also look for vLLM benchmark files for comparison table
+    vllm_pattern = f"benchmark_{model_spec.model_id}_*.json"
+    benchmarks_output_dir = f"{get_default_workflow_root_log_dir()}/benchmarks_output"
+    vllm_files = glob(f"{benchmarks_output_dir}/{vllm_pattern}")
 
     output_dir = Path(args.output_path) / "benchmarks_aiperf"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     logger.info("AIPerf Benchmark Summary")
     logger.info(f"Found {len(aiperf_files)} AIPerf benchmark files")
+    logger.info(f"Found {len(vllm_files)} vLLM benchmark files for comparison")
 
-    if not aiperf_files:
-        logger.info("No AIPerf benchmark files found. Skipping AIPerf report.")
+    if not aiperf_files and not vllm_files:
+        logger.info("No benchmark files found. Skipping AIPerf report.")
         return "", [], None, None
 
-    # Process AIPerf files
-    aiperf_results = []
-    for filepath in sorted(aiperf_files):
+    # Process vLLM benchmark files first (for comparison table)
+    vllm_results = []
+    for filepath in sorted(vllm_files):
         try:
             with open(filepath, "r") as f:
                 data = json.load(f)
 
             # Extract parameters from filename
             filename = Path(filepath).name
-            # Pattern: aiperf_benchmark_*_isl-{isl}_osl-{osl}_maxcon-{con}_n-{n}.json
-            import re
+            # Pattern: benchmark_*_isl-{isl}_osl-{osl}_maxcon-{con}_n-{n}*.json
             match = re.search(r"isl-(\d+)_osl-(\d+)_maxcon-(\d+)_n-(\d+)", filename)
             if match:
                 isl, osl, concurrency, num_requests = map(int, match.groups())
@@ -407,6 +480,64 @@ def aiperf_benchmark_generate_report(args, server_mode, model_spec, report_id, m
                 num_requests = data.get("num_prompts", 0)
 
             result = {
+                "source": "vLLM",
+                "isl": isl,
+                "osl": osl,
+                "concurrency": concurrency,
+                "num_requests": num_requests,
+                # TTFT metrics
+                "mean_ttft_ms": data.get("mean_ttft_ms", 0),
+                "median_ttft_ms": data.get("median_ttft_ms", 0),
+                "p99_ttft_ms": data.get("p99_ttft_ms", 0),
+                "std_ttft_ms": data.get("std_ttft_ms", 0),
+                # TPOT metrics
+                "mean_tpot_ms": data.get("mean_tpot_ms", 0),
+                "median_tpot_ms": data.get("median_tpot_ms", 0),
+                "p99_tpot_ms": data.get("p99_tpot_ms", 0),
+                "std_tpot_ms": data.get("std_tpot_ms", 0),
+                # E2EL metrics
+                "mean_e2el_ms": data.get("mean_e2el_ms", 0),
+                "median_e2el_ms": data.get("median_e2el_ms", 0),
+                "p99_e2el_ms": data.get("p99_e2el_ms", 0),
+                "std_e2el_ms": data.get("std_e2el_ms", 0),
+                # Throughput
+                "output_token_throughput": data.get("output_throughput", 0),
+                "request_throughput": data.get("request_throughput", 0),
+                # Tokens
+                "completed": data.get("completed", 0),
+                "total_input_tokens": data.get("total_input_tokens", 0),
+                "total_output_tokens": data.get("total_output_tokens", 0),
+                # Metadata
+                "model_id": data.get("model_id", ""),
+                "backend": "vllm",
+            }
+            vllm_results.append(result)
+        except Exception as e:
+            logger.warning(f"Error processing vLLM file {filepath}: {e}")
+            continue
+
+    # Process AIPerf files
+    aiperf_results = []
+    for filepath in sorted(aiperf_files):
+        try:
+            with open(filepath, "r") as f:
+                data = json.load(f)
+
+            # Extract parameters from filename
+            filename = Path(filepath).name
+            # Pattern: aiperf_benchmark_*_isl-{isl}_osl-{osl}_maxcon-{con}_n-{n}.json
+            match = re.search(r"isl-(\d+)_osl-(\d+)_maxcon-(\d+)_n-(\d+)", filename)
+            if match:
+                isl, osl, concurrency, num_requests = map(int, match.groups())
+            else:
+                # Fallback to data fields
+                isl = data.get("total_input_tokens", 0) // max(data.get("num_prompts", 1), 1)
+                osl = data.get("total_output_tokens", 0) // max(data.get("num_prompts", 1), 1)
+                concurrency = data.get("max_concurrency", 1)
+                num_requests = data.get("num_prompts", 0)
+
+            result = {
+                "source": "aiperf",
                 "isl": isl,
                 "osl": osl,
                 "concurrency": concurrency,
@@ -442,20 +573,46 @@ def aiperf_benchmark_generate_report(args, server_mode, model_spec, report_id, m
             logger.warning(f"Error processing AIPerf file {filepath}: {e}")
             continue
 
-    if not aiperf_results:
+    if not aiperf_results and not vllm_results:
         return "", [], None, None
 
-    # Sort by ISL, OSL, concurrency
+    # Sort each by ISL, OSL, concurrency
+    vllm_results.sort(key=lambda x: (x["isl"], x["osl"], x["concurrency"]))
     aiperf_results.sort(key=lambda x: (x["isl"], x["osl"], x["concurrency"]))
 
-    # Generate markdown report
-    markdown_str = aiperf_release_markdown(aiperf_results)
+    # Combine for comparison table: vLLM first, then AIPerf
+    combined_results = vllm_results + aiperf_results
 
-    # Add header and notes
-    release_str = f"### AIPerf Performance Benchmark Results for {model_spec.model_name} on {args.device}\n\n"
-    release_str += "**Benchmarking Tool:** [AIPerf](https://github.com/ai-dynamo/aiperf)\n\n"
-    release_str += markdown_str
-    release_str += "\n\n**Metric Definitions:**\n"
+    # Generate genai-perf comparison style markdown report (Table 2: Derived throughputs with Source column)
+    # This uses combined_results (vLLM first, then AIPerf)
+    throughput_markdown_str = aiperf_throughput_markdown(combined_results)
+
+    # Build the complete report
+    release_str = f"### Benchmark Performance Results for {model_spec.model_name} on {args.device}\n\n"
+
+    # Table 1: NVIDIA-style detailed percentiles (only if AIPerf results exist)
+    if aiperf_results:
+        nvidia_markdown_str = aiperf_release_markdown(aiperf_results)
+        release_str += "#### Table 1: AIPerf Detailed Latency Percentiles (NVIDIA Format)\n\n"
+        release_str += "**Benchmarking Tool:** [AIPerf](https://github.com/ai-dynamo/aiperf)\n\n"
+        release_str += nvidia_markdown_str
+        release_str += "\n\n"
+
+    # Table 2: Throughput comparison (genai-perf style) - combines vLLM and AIPerf
+    # Dynamic header based on available results
+    if vllm_results and aiperf_results:
+        table2_header = "#### Table 2: Throughput Comparison (vLLM vs AIPerf)\n\n"
+    elif vllm_results:
+        table2_header = "#### Table 2: Throughput Summary (vLLM)\n\n"
+    else:
+        table2_header = "#### Table 2: Throughput Summary (AIPerf)\n\n"
+    release_str += table2_header
+    release_str += throughput_markdown_str
+    release_str += "\n\n"
+
+    # Metric definitions
+    release_str += "**Metric Definitions:**\n"
+    release_str += "> - **Source**: Benchmarking tool used (vLLM or aiperf)\n"
     release_str += "> - **ISL**: Input Sequence Length (tokens)\n"
     release_str += "> - **OSL**: Output Sequence Length (tokens)\n"
     release_str += "> - **Concur**: Concurrent requests (batch size)\n"
@@ -465,6 +622,9 @@ def aiperf_benchmark_generate_report(args, server_mode, model_spec, report_id, m
     release_str += "> - **E2EL**: End-to-End Latency (ms)\n"
     release_str += "> - **Tok/s**: Output token throughput\n"
     release_str += "> - **Req/s**: Request throughput\n"
+    release_str += "> - **Tput User**: Tokens per second per user (1000 / TPOT)\n"
+    release_str += "> - **Tput Decode**: Total decode throughput (Tput User × Concurrency)\n"
+    release_str += "> - **Tput Prefill**: Prefill throughput ((ISL × Concurrency) / (TTFT / 1000))\n"
 
     # Save markdown report
     disp_md_path = output_dir / f"aiperf_benchmark_display_{report_id}.md"

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -428,6 +428,72 @@ def aiperf_throughput_markdown(release_raw):
     return markdown_str
 
 
+def aiperf_throughput_markdown_with_images(release_raw):
+    """Generate markdown table for image benchmarks with image parameters.
+    Similar to aiperf_throughput_markdown but includes image dimensions.
+    """
+    # Define display columns for image benchmarks
+    display_cols = [
+        ("source", "Source"),
+        ("isl", "ISL"),
+        ("osl", "OSL"),
+        ("concurrency", "Concur"),
+        ("num_requests", "N"),
+        ("images", "Images"),
+        ("image_width", "Width"),
+        ("image_height", "Height"),
+        ("mean_ttft_ms", "TTFT (ms)"),
+        ("mean_tpot_ms", "TPOT (ms)"),
+        ("tput_user", "Tput User (TPS)"),
+        ("tput_decode", "Tput Decode (TPS)"),
+        ("tput_prefill", "Tput Prefill (TPS)"),
+        ("mean_e2el_ms", "E2EL (ms)"),
+        ("request_throughput", "Req Tput (RPS)"),
+    ]
+
+    NOT_MEASURED_STR = "N/A"
+    display_dicts = []
+    for row in release_raw:
+        # Calculate derived throughput metrics
+        tpot = row.get("mean_tpot_ms", 0)
+        ttft = row.get("mean_ttft_ms", 0)
+        isl = row.get("isl", 0)
+        concurrency = row.get("concurrency", 1)
+
+        tput_user = 1000.0 / tpot if tpot > 0 else 0
+        tput_decode = tput_user * concurrency
+        tput_prefill = (isl * concurrency) / (ttft / 1000.0) if ttft > 0 else 0
+
+        # Add derived metrics to row
+        row_with_derived = dict(row)
+        row_with_derived["tput_user"] = tput_user
+        row_with_derived["tput_decode"] = tput_decode
+        row_with_derived["tput_prefill"] = tput_prefill
+
+        row_dict = {}
+        for col_name, display_header in display_cols:
+            value = row_with_derived.get(col_name, NOT_MEASURED_STR)
+            if value is None or value == "":
+                row_dict[display_header] = NOT_MEASURED_STR
+            elif isinstance(value, float):
+                # Format floats with appropriate precision
+                if col_name == "request_throughput":
+                    row_dict[display_header] = f"{value:.3f}"
+                elif col_name in ("tput_user", "tput_decode", "tput_prefill"):
+                    row_dict[display_header] = f"{value:.1f}"
+                elif col_name in ("mean_ttft_ms", "mean_tpot_ms", "mean_e2el_ms"):
+                    row_dict[display_header] = f"{value:.1f}"
+                else:
+                    row_dict[display_header] = f"{value:.2f}"
+            else:
+                row_dict[display_header] = str(value)
+        display_dicts.append(row_dict)
+
+    # Create the markdown table
+    markdown_str = get_markdown_table(display_dicts)
+    return markdown_str
+
+
 def aiperf_benchmark_generate_report(args, server_mode, model_spec, report_id, metadata={}):
     """Generate benchmark report specifically for AIPerf results.
 
@@ -502,12 +568,17 @@ def aiperf_benchmark_generate_report(args, server_mode, model_spec, report_id, m
     
     logger.info(f"After deduplication: {len(vllm_files)} vLLM, {len(aiperf_files)} AIPerf files")
 
-    # Process vLLM benchmark files first (for comparison table)
-    # Filter out image benchmarks for fair comparison with AIPerf (which doesn't support images)
+    # Separate text-only and image benchmarks
     vllm_text_only_files = [f for f in vllm_files if "images" not in Path(f).name]
-    logger.info(f"Using {len(vllm_text_only_files)} text-only vLLM files (excluded {len(vllm_files) - len(vllm_text_only_files)} image benchmarks)")
+    vllm_image_files = [f for f in vllm_files if "images" in Path(f).name]
+    aiperf_text_only_files = [f for f in aiperf_files if "images" not in Path(f).name]
+    aiperf_image_files = [f for f in aiperf_files if "images" in Path(f).name]
     
-    vllm_results = []
+    logger.info(f"Text benchmarks: {len(vllm_text_only_files)} vLLM, {len(aiperf_text_only_files)} AIPerf")
+    logger.info(f"Image benchmarks: {len(vllm_image_files)} vLLM, {len(aiperf_image_files)} AIPerf")
+    
+    # Process text-only vLLM benchmarks
+    vllm_text_results = []
     for filepath in sorted(vllm_text_only_files):
         try:
             with open(filepath, "r") as f:
@@ -558,14 +629,14 @@ def aiperf_benchmark_generate_report(args, server_mode, model_spec, report_id, m
                 "model_id": data.get("model_id", ""),
                 "backend": "vllm",
             }
-            vllm_results.append(result)
+            vllm_text_results.append(result)
         except Exception as e:
             logger.warning(f"Error processing vLLM file {filepath}: {e}")
             continue
 
-    # Process AIPerf files
-    aiperf_results = []
-    for filepath in sorted(aiperf_files):
+    # Process text-only AIPerf files
+    aiperf_text_results = []
+    for filepath in sorted(aiperf_text_only_files):
         try:
             with open(filepath, "r") as f:
                 data = json.load(f)
@@ -615,47 +686,196 @@ def aiperf_benchmark_generate_report(args, server_mode, model_spec, report_id, m
                 "model_id": data.get("model_id", ""),
                 "backend": "aiperf",
             }
-            aiperf_results.append(result)
+            aiperf_text_results.append(result)
         except Exception as e:
             logger.warning(f"Error processing AIPerf file {filepath}: {e}")
             continue
 
-    if not aiperf_results and not vllm_results:
+    # Process image vLLM benchmarks
+    vllm_image_results = []
+    for filepath in sorted(vllm_image_files):
+        try:
+            with open(filepath, "r") as f:
+                data = json.load(f)
+
+            # Extract parameters from filename
+            filename = Path(filepath).name
+            match = re.search(r"isl-(\d+)_osl-(\d+)_maxcon-(\d+)_n-(\d+)_images-(\d+)_height-(\d+)_width-(\d+)", filename)
+            if match:
+                isl, osl, concurrency, num_requests, images, height, width = map(int, match.groups())
+            else:
+                logger.warning(f"Could not parse image parameters from {filename}")
+                continue
+
+            result = {
+                "source": "vLLM",
+                "isl": isl,
+                "osl": osl,
+                "concurrency": concurrency,
+                "num_requests": num_requests,
+                "images": images,
+                "image_height": height,
+                "image_width": width,
+                # TTFT metrics
+                "mean_ttft_ms": data.get("mean_ttft_ms", 0),
+                "median_ttft_ms": data.get("median_ttft_ms", 0),
+                "p99_ttft_ms": data.get("p99_ttft_ms", 0),
+                "std_ttft_ms": data.get("std_ttft_ms", 0),
+                # TPOT metrics
+                "mean_tpot_ms": data.get("mean_tpot_ms", 0),
+                "median_tpot_ms": data.get("median_tpot_ms", 0),
+                "p99_tpot_ms": data.get("p99_tpot_ms", 0),
+                "std_tpot_ms": data.get("std_tpot_ms", 0),
+                # E2EL metrics
+                "mean_e2el_ms": data.get("mean_e2el_ms", 0),
+                "median_e2el_ms": data.get("median_e2el_ms", 0),
+                "p99_e2el_ms": data.get("p99_e2el_ms", 0),
+                "std_e2el_ms": data.get("std_e2el_ms", 0),
+                # Throughput
+                "output_token_throughput": data.get("output_throughput", 0),
+                "request_throughput": data.get("request_throughput", 0),
+                # Tokens
+                "completed": data.get("completed", 0),
+                "total_input_tokens": data.get("total_input_tokens", 0),
+                "total_output_tokens": data.get("total_output_tokens", 0),
+                # Metadata
+                "model_id": data.get("model_id", ""),
+                "backend": "vllm",
+            }
+            vllm_image_results.append(result)
+        except Exception as e:
+            logger.warning(f"Error processing vLLM image file {filepath}: {e}")
+            continue
+
+    # Process image AIPerf files
+    aiperf_image_results = []
+    for filepath in sorted(aiperf_image_files):
+        try:
+            with open(filepath, "r") as f:
+                data = json.load(f)
+
+            # Extract parameters from filename
+            filename = Path(filepath).name
+            match = re.search(r"isl-(\d+)_osl-(\d+)_maxcon-(\d+)_n-(\d+)_images-(\d+)_height-(\d+)_width-(\d+)", filename)
+            if match:
+                isl, osl, concurrency, num_requests, images, height, width = map(int, match.groups())
+            else:
+                logger.warning(f"Could not parse image parameters from {filename}")
+                continue
+
+            result = {
+                "source": "aiperf",
+                "isl": isl,
+                "osl": osl,
+                "concurrency": concurrency,
+                "num_requests": num_requests,
+                "images": images,
+                "image_height": height,
+                "image_width": width,
+                # TTFT metrics
+                "mean_ttft_ms": data.get("mean_ttft_ms", 0),
+                "median_ttft_ms": data.get("median_ttft_ms", 0),
+                "p99_ttft_ms": data.get("p99_ttft_ms", 0),
+                "std_ttft_ms": data.get("std_ttft_ms", 0),
+                # TPOT metrics
+                "mean_tpot_ms": data.get("mean_tpot_ms", 0),
+                "median_tpot_ms": data.get("median_tpot_ms", 0),
+                "p99_tpot_ms": data.get("p99_tpot_ms", 0),
+                "std_tpot_ms": data.get("std_tpot_ms", 0),
+                # E2EL metrics
+                "mean_e2el_ms": data.get("mean_e2el_ms", 0),
+                "median_e2el_ms": data.get("median_e2el_ms", 0),
+                "p99_e2el_ms": data.get("p99_e2el_ms", 0),
+                "std_e2el_ms": data.get("std_e2el_ms", 0),
+                # Throughput
+                "output_token_throughput": data.get("output_token_throughput", 0),
+                "request_throughput": data.get("request_throughput", 0),
+                # Tokens
+                "completed": data.get("completed", 0),
+                "total_input_tokens": data.get("total_input_tokens", 0),
+                "total_output_tokens": data.get("total_output_tokens", 0),
+                # Metadata
+                "model_id": data.get("model_id", ""),
+                "backend": "aiperf",
+            }
+            aiperf_image_results.append(result)
+        except Exception as e:
+            logger.warning(f"Error processing AIPerf image file {filepath}: {e}")
+            continue
+
+    if not aiperf_text_results and not vllm_text_results and not aiperf_image_results and not vllm_image_results:
         return "", [], None, None
 
-    # Sort each by ISL, OSL, concurrency
-    vllm_results.sort(key=lambda x: (x["isl"], x["osl"], x["concurrency"]))
-    aiperf_results.sort(key=lambda x: (x["isl"], x["osl"], x["concurrency"]))
+    # Sort text benchmarks by ISL, OSL, concurrency
+    vllm_text_results.sort(key=lambda x: (x["isl"], x["osl"], x["concurrency"]))
+    aiperf_text_results.sort(key=lambda x: (x["isl"], x["osl"], x["concurrency"]))
 
-    # Combine for comparison table: vLLM first, then AIPerf
-    combined_results = vllm_results + aiperf_results
-
-    # Generate genai-perf comparison style markdown report (Table 2: Derived throughputs with Source column)
-    # This uses combined_results (vLLM first, then AIPerf)
-    throughput_markdown_str = aiperf_throughput_markdown(combined_results)
+    # Sort image benchmarks by ISL, OSL, concurrency, image size
+    vllm_image_results.sort(key=lambda x: (x["isl"], x["osl"], x["concurrency"], x["image_height"], x["image_width"]))
+    aiperf_image_results.sort(key=lambda x: (x["isl"], x["osl"], x["concurrency"], x["image_height"], x["image_width"]))
 
     # Build the complete report
     release_str = f"### Benchmark Performance Results for {model_spec.model_name} on {args.device}\n\n"
 
-    # Table 1: NVIDIA-style detailed percentiles (only if AIPerf results exist)
-    if aiperf_results:
-        nvidia_markdown_str = aiperf_release_markdown(aiperf_results)
-        release_str += "#### Table 1: AIPerf Detailed Latency Percentiles (NVIDIA Format)\n\n"
-        release_str += "**Benchmarking Tool:** [AIPerf](https://github.com/ai-dynamo/aiperf)\n\n"
-        release_str += nvidia_markdown_str
+    # TEXT BENCHMARKS SECTION
+    if vllm_text_results or aiperf_text_results:
+        release_str += "## Text-to-Text Benchmarks\n\n"
+
+        # Combine text results for comparison table: vLLM first, then AIPerf
+        combined_text_results = vllm_text_results + aiperf_text_results
+
+        # Table 1: NVIDIA-style detailed percentiles (only if AIPerf text results exist)
+        if aiperf_text_results:
+            nvidia_markdown_str = aiperf_release_markdown(aiperf_text_results)
+            release_str += "#### Table 1: AIPerf Text Benchmark - Detailed Latency Percentiles (NVIDIA Format)\n\n"
+            release_str += "**Benchmarking Tool:** [AIPerf](https://github.com/ai-dynamo/aiperf)\n\n"
+            release_str += nvidia_markdown_str
+            release_str += "\n\n"
+
+        # Table 2: Text throughput comparison (genai-perf style) - combines vLLM and AIPerf
+        # Dynamic header based on available results
+        if vllm_text_results and aiperf_text_results:
+            table2_header = "#### Table 2: Text Benchmark Throughput Comparison (vLLM vs AIPerf)\n\n"
+        elif vllm_text_results:
+            table2_header = "#### Table 2: Text Benchmark Throughput Summary (vLLM)\n\n"
+        else:
+            table2_header = "#### Table 2: Text Benchmark Throughput Summary (AIPerf)\n\n"
+        release_str += table2_header
+        
+        # Generate throughput comparison table for text benchmarks
+        throughput_markdown_str = aiperf_throughput_markdown(combined_text_results)
+        release_str += throughput_markdown_str
         release_str += "\n\n"
 
-    # Table 2: Throughput comparison (genai-perf style) - combines vLLM and AIPerf
-    # Dynamic header based on available results
-    if vllm_results and aiperf_results:
-        table2_header = "#### Table 2: Throughput Comparison (vLLM vs AIPerf)\n\n"
-    elif vllm_results:
-        table2_header = "#### Table 2: Throughput Summary (vLLM)\n\n"
-    else:
-        table2_header = "#### Table 2: Throughput Summary (AIPerf)\n\n"
-    release_str += table2_header
-    release_str += throughput_markdown_str
-    release_str += "\n\n"
+    # IMAGE BENCHMARKS SECTION
+    if vllm_image_results or aiperf_image_results:
+        release_str += "## Image (VLM) Benchmarks\n\n"
+
+        # Combine image results for comparison table: vLLM first, then AIPerf
+        combined_image_results = vllm_image_results + aiperf_image_results
+
+        # Table 3: NVIDIA-style detailed percentiles (only if AIPerf image results exist)
+        if aiperf_image_results:
+            nvidia_markdown_str = aiperf_release_markdown(aiperf_image_results)
+            release_str += "#### Table 3: AIPerf Image Benchmark - Detailed Latency Percentiles (NVIDIA Format)\n\n"
+            release_str += "**Benchmarking Tool:** [AIPerf](https://github.com/ai-dynamo/aiperf)\n\n"
+            release_str += nvidia_markdown_str
+            release_str += "\n\n"
+
+        # Table 4: Image throughput comparison (genai-perf style) - combines vLLM and AIPerf
+        # Dynamic header based on available results
+        if vllm_image_results and aiperf_image_results:
+            table4_header = "#### Table 4: Image Benchmark Throughput Comparison (vLLM vs AIPerf)\n\n"
+        elif vllm_image_results:
+            table4_header = "#### Table 4: Image Benchmark Throughput Summary (vLLM)\n\n"
+        else:
+            table4_header = "#### Table 4: Image Benchmark Throughput Summary (AIPerf)\n\n"
+        release_str += table4_header
+        
+        # Generate throughput comparison table for image benchmarks (with image columns)
+        throughput_markdown_str = aiperf_throughput_markdown_with_images(combined_image_results)
+        release_str += throughput_markdown_str
+        release_str += "\n\n"
 
     # Metric definitions
     release_str += "**Metric Definitions:**\n"
@@ -679,20 +899,33 @@ def aiperf_benchmark_generate_report(args, server_mode, model_spec, report_id, m
         f.write(release_str)
     logger.info(f"AIPerf report saved to: {disp_md_path}")
 
-    # Save CSV data
-    data_file_path = output_dir / "data" / f"aiperf_benchmark_stats_{report_id}.csv"
-    data_file_path.parent.mkdir(parents=True, exist_ok=True)
+    # Save CSV data for text benchmarks
+    text_data_file_path = output_dir / "data" / f"aiperf_benchmark_text_stats_{report_id}.csv"
+    text_data_file_path.parent.mkdir(parents=True, exist_ok=True)
 
-    if aiperf_results:
-        headers = list(aiperf_results[0].keys())
-        with open(data_file_path, "w", newline="") as f:
+    if aiperf_text_results:
+        headers = list(aiperf_text_results[0].keys())
+        with open(text_data_file_path, "w", newline="") as f:
             writer = csv.writer(f)
             writer.writerow(headers)
-            for result in aiperf_results:
+            for result in aiperf_text_results:
                 writer.writerow([str(result.get(h, "")) for h in headers])
-        logger.info(f"AIPerf data saved to: {data_file_path}")
+        logger.info(f"AIPerf text benchmark data saved to: {text_data_file_path}")
 
-    return release_str, aiperf_results, disp_md_path, data_file_path
+    # Save CSV data for image benchmarks
+    image_data_file_path = output_dir / "data" / f"aiperf_benchmark_image_stats_{report_id}.csv"
+    if aiperf_image_results:
+        headers = list(aiperf_image_results[0].keys())
+        with open(image_data_file_path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(headers)
+            for result in aiperf_image_results:
+                writer.writerow([str(result.get(h, "")) for h in headers])
+        logger.info(f"AIPerf image benchmark data saved to: {image_data_file_path}")
+
+    # Return combined results for both text and image
+    all_aiperf_results = aiperf_text_results + aiperf_image_results
+    return release_str, all_aiperf_results, disp_md_path, text_data_file_path
 
 
 def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata={}):

--- a/workflows/run_workflows.py
+++ b/workflows/run_workflows.py
@@ -11,6 +11,7 @@ from tests.test_config import TEST_CONFIGS
 from workflows.utils import ensure_readwriteable_dir, run_command
 from workflows.workflow_config import (
     WORKFLOW_CONFIGS,
+    WORKFLOW_BENCHMARKS_AIPERF_CONFIG,
     WorkflowType,
     get_default_workflow_root_log_dir,
 )
@@ -26,7 +27,13 @@ class WorkflowSetup:
         self.model_spec = model_spec
         self.model_spec_json_path = json_fpath
         _workflow_type = WorkflowType.from_string(self.model_spec.cli_args.workflow)
-        self.workflow_config = WORKFLOW_CONFIGS[_workflow_type]
+
+        # Check for --tools argument to select appropriate benchmarking workflow
+        tools = getattr(self.model_spec.cli_args, "tools", "vllm")
+        if _workflow_type == WorkflowType.BENCHMARKS and tools == "aiperf":
+            self.workflow_config = WORKFLOW_BENCHMARKS_AIPERF_CONFIG
+        else:
+            self.workflow_config = WORKFLOW_CONFIGS[_workflow_type]
 
         # only the server workflow does not require a venv
         assert self.workflow_config.workflow_run_script_venv_type is not None

--- a/workflows/workflow_config.py
+++ b/workflows/workflow_config.py
@@ -59,6 +59,13 @@ WORKFLOW_BENCHMARKS_CONFIG = WorkflowConfig(
     run_script_path=get_repo_root_path() / "benchmarking" / "run_benchmarks.py",
     workflow_run_script_venv_type=WorkflowVenvType.BENCHMARKS_RUN_SCRIPT,
 )
+
+WORKFLOW_BENCHMARKS_AIPERF_CONFIG = WorkflowConfig(
+    workflow_type=WorkflowType.BENCHMARKS,
+    run_script_path=get_repo_root_path() / "benchmarking" / "run_benchmarks_aiperf.py",
+    workflow_run_script_venv_type=WorkflowVenvType.BENCHMARKS_AIPERF,
+    name="benchmarks_aiperf",
+)
 WORKFLOW_EVALS_CONFIG = WorkflowConfig(
     workflow_type=WorkflowType.EVALS,
     run_script_path=get_repo_root_path() / "evals" / "run_evals.py",

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -32,6 +32,7 @@ class WorkflowVenvType(IntEnum):
     EVALS_VISION = auto()
     EVALS_AUDIO = auto()
     BENCHMARKS_HTTP_CLIENT_VLLM_API = auto()
+    BENCHMARKS_AIPERF = auto()
     HF_SETUP = auto()
     SERVER = auto()
 
@@ -39,6 +40,7 @@ class WorkflowVenvType(IntEnum):
 class BenchmarkTaskType(IntEnum):
     HTTP_CLIENT_VLLM_API = auto()
     HTTP_CLIENT_CNN_API = auto()
+    AIPERF = auto()
 
 
 class DeviceTypes(IntEnum):

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -355,6 +355,43 @@ def setup_hf_setup(
     return True
 
 
+def setup_benchmarks_aiperf(
+    venv_config: VenvConfig,
+    model_spec: "ModelSpec",  # noqa: F821
+    uv_exec: Path,
+) -> bool:
+    """Setup for aiperf benchmarks (pip-based installation).
+
+    AIPerf is a comprehensive benchmarking tool for generative AI models.
+    Repository: https://github.com/ai-dynamo/aiperf
+    """
+    logger.info("running setup_benchmarks_aiperf() ...")
+
+    # Install torch CPU for dependencies that require it (like prompt_client)
+    run_command(
+        command=f"{uv_exec} pip install --managed-python --python {venv_config.venv_python} 'torch==2.4.0+cpu' --index-url https://download.pytorch.org/whl/cpu",
+        logger=logger,
+    )
+
+    # Install aiperf from PyPI
+    run_command(
+        command=f"{uv_exec} pip install --managed-python --python {venv_config.venv_python} aiperf",
+        logger=logger,
+    )
+
+    # Install additional dependencies for tokenization and prompt client
+    run_command(
+        command=f"{uv_exec} pip install --managed-python --python {venv_config.venv_python} transformers pyjwt requests datasets",
+        logger=logger,
+    )
+
+    # Create artifacts directory for benchmark outputs
+    artifacts_dir = venv_config.venv_path / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    return True
+
+
 def create_local_setup_venv(
     uv_exec: Path,
 ) -> bool:
@@ -425,6 +462,11 @@ _venv_config_list = [
     VenvConfig(
         venv_type=WorkflowVenvType.BENCHMARKS_HTTP_CLIENT_VLLM_API,
         setup_function=setup_benchmarks_http_client_vllm_api,
+        python_version="3.11",
+    ),
+    VenvConfig(
+        venv_type=WorkflowVenvType.BENCHMARKS_AIPERF,
+        setup_function=setup_benchmarks_aiperf,
         python_version="3.11",
     ),
     VenvConfig(


### PR DESCRIPTION
## Summary

Integrate [AIPerf](https://github.com/ai-dynamo/aiperf) as an alternative benchmarking tool for LLM performance testing ([#1150](https://github.com/tenstorrent/tt-inference-server/issues/1150)).

**Key Features:**
- Add `--tools aiperf` CLI option to select AIPerf instead of vLLM's `benchmark_serving.py`
- Generate NVIDIA-style reports with mean, median, and P99 percentiles for TTFT, TPOT, and E2EL
- Unified comparison table in `--workflow reports` combining vLLM and AIPerf results

## Implementation Approach

Follows the same integration pattern as `genai-perf` ([#1365](https://github.com/tenstorrent/tt-inference-server/pull/1365) by @stisiTT):

| Component | genai-perf | aiperf |
|-----------|------------|--------|
| CLI selection | `--tools genai` | `--tools aiperf` |
| Workflow config | `WORKFLOW_BENCHMARKS_GENAI_CONFIG` | `WORKFLOW_BENCHMARKS_AIPERF_CONFIG` |
| Venv type | `BENCHMARKS_GENAI` | `BENCHMARKS_AIPERF` |
| Run script | `run_genai_benchmarks.py` | `run_benchmarks_aiperf.py` |
| Output directory | `benchmarks_genai_output/` | `benchmarks_aiperf_output/` |

## Report Generation

The `--workflow reports` command now generates two tables for AIPerf results:

**Table 1: AIPerf Detailed Latency Percentiles (NVIDIA Format)**
- Shows P50 and P99 for TTFT, TPOT, and E2EL
- Only appears when AIPerf results exist

**Table 2: Throughput Comparison**
- Combines vLLM and AIPerf results with a `Source` column
- vLLM results listed first, then AIPerf
- Includes derived metrics: Tput User, Tput Decode, Tput Prefill
- Dynamic header based on available data (shows "vLLM vs AIPerf" when both exist)

## Usage

### Default vLLM benchmarks
```
python run.py --model gemma-3-4b-it --device n300 --workflow benchmarks --docker-server
```

### AIPerf benchmarks
```
python run.py --model gemma-3-4b-it --device n300 --workflow benchmarks --docker-server --tools aiperf
```

### Generate combined report
```
python run.py --model gemma-3-4b-it --device n300 --workflow reports## Files Changed
```

## Files Changed 
| File | Change |
|------|--------|
| `run.py` | Add `--tools` argument |
| `workflows/workflow_types.py` | Add `BENCHMARKS_AIPERF` enum |
| `workflows/workflow_config.py` | Add AIPerf workflow config |
| `workflows/workflow_venvs.py` | Add AIPerf venv setup |
| `workflows/run_workflows.py` | Route to AIPerf when `--tools aiperf` |
| `workflows/run_reports.py` | Add AIPerf report generation with comparison table |
| `benchmarking/summary_report.py` | Parse AIPerf result files |
| `benchmarking/run_benchmarks_aiperf.py` | New AIPerf benchmark runner |
| `benchmarking/README.md` | Document tool selection |
| `docs/aiperf_manual.md` | AIPerf usage guide |

## AIPerf vs genai-perf

| Feature | genai-perf | AIPerf |
|---------|------------|--------|
| **Source** | NVIDIA Triton SDK | ai-dynamo (NVIDIA) |
| **Focus** | Triton Inference Server | OpenAI-compatible endpoints |
| **Installation** | Triton container required | `pip install aiperf` |
| **Metrics** | TTFT, throughput | TTFT, TPOT, E2EL with P50/P99 |

Both tools can coexist and can be merged once validated.

## Test Plan

- [x] Run `python run.py --model gemma-3-4b-it --device n300 --workflow benchmarks --docker-server --tools aiperf`
- [x] Verify results saved to `workflow_logs/benchmarks_aiperf_output/`
- [x] Run `python run.py --workflow reports` and verify:
  - [x] Table 1 shows AIPerf percentiles
  - [x] Table 2 shows combined vLLM + AIPerf with Source column
- [ ] Verify `--tools vllm` (default) still works unchanged
- [ ] Verify reports work with only vLLM results (no AIPerf)
- [ ] Verify reports work with only AIPerf results (no vLLM)