### PR TITLE
Make Embeddings Endpoint OpenAI Compatible

### DIFF
--- a/tt-media-server/domain/text_embedding_request.py
+++ b/tt-media-server/domain/text_embedding_request.py
@@ -11,4 +11,3 @@ from pydantic import Field
 class TextEmbeddingRequest(BaseRequest):
     input: str
     dimensions: Optional[int] = Field(default=None, ge=0)
-    model: str

--- a/tt-media-server/open_ai_api/llm.py
+++ b/tt-media-server/open_ai_api/llm.py
@@ -83,7 +83,6 @@ async def create_embedding(
         return {
             "object": "list",
             "data": [{"object": "embedding", "embedding": embeddings, "index": 0}],
-            "model": text_embedding_request.model,
         }
 
     except Exception as e:

--- a/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
@@ -71,7 +71,6 @@ class VLLMForgeEmbeddingQwenRunner(BaseDeviceRunner):
         if (
             self.num_tokens_in_batch + num_tokens > self.settings.max_num_batched_tokens
             or request.dimensions != self.dimensions_in_batch
-            or request.model != SupportedModels.QWEN_3_EMBEDDING_4B.value
         ):
             return False
 
@@ -90,11 +89,6 @@ class VLLMForgeEmbeddingQwenRunner(BaseDeviceRunner):
             if num_tokens > self.settings.max_model_length:
                 raise ValueError(
                     f"Batched input text exceeds maximum number of batched tokens of {self.settings.max_model_length}. Got {num_tokens} tokens."
-                )
-
-            if requests[0].model != SupportedModels.QWEN_3_EMBEDDING_4B.value:
-                raise ValueError(
-                    f"Model {requests[0].model} is not supported by VLLMForgeEmbeddingQwenRunner."
                 )
 
         self.logger.debug(f"Device {self.device_id}: Running inference")


### PR DESCRIPTION
## Problem
In order to reuse vLLM’s benchmarking capabilities, our embeddings endpoint must be compatible with the OpenAI API.

## Implementation
- Change response format to match openAI response format:
```
{
"object": "list",
  "data": [
    {
      "object": "embedding",
      "embedding": [...],
      "index": 0
      }
    ],
      "model": "model_name"
}     