### PR TITLE
Fix Ruff Formatting

### DIFF
--- a/benchmarking/genai_benchmark.py
+++ b/benchmarking/genai_benchmark.py
@@ -6,16 +6,15 @@
 # This script runs inside the nvcr.io/nvidia/tritonserver container
 # and uses the genai-perf CLI to profile LLM inference servers.
 
-import os
-import sys
-import subprocess
-import time
-import glob
-import csv
 import argparse
+import glob
 import json
-from dataclasses import dataclass, field
-from typing import List, Dict, Any, Optional
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List
 
 # --- Default Configuration ---
 DEFAULT_BATCH_1_ISL_OSL_PAIRS = [
@@ -152,45 +151,43 @@ def parse_metrics(artifact_dir) -> Dict[str, float]:
         # Extract metrics with vLLM-compatible naming
         metrics = {
             # TTFT metrics (Time To First Token)
-            'mean_ttft_ms': data['time_to_first_token']['avg'],
-            'median_ttft_ms': data['time_to_first_token']['p50'],
-            'p99_ttft_ms': data['time_to_first_token']['p99'],
-            'p95_ttft_ms': data['time_to_first_token']['p95'],
-            'p90_ttft_ms': data['time_to_first_token']['p90'],
-            'p75_ttft_ms': data['time_to_first_token']['p75'],
-            'std_ttft_ms': data['time_to_first_token']['std'],
-
+            "mean_ttft_ms": data["time_to_first_token"]["avg"],
+            "median_ttft_ms": data["time_to_first_token"]["p50"],
+            "p99_ttft_ms": data["time_to_first_token"]["p99"],
+            "p95_ttft_ms": data["time_to_first_token"]["p95"],
+            "p90_ttft_ms": data["time_to_first_token"]["p90"],
+            "p75_ttft_ms": data["time_to_first_token"]["p75"],
+            "std_ttft_ms": data["time_to_first_token"]["std"],
             # TPOT metrics (Time Per Output Token = Inter Token Latency)
-            'mean_tpot_ms': data['inter_token_latency']['avg'],
-            'median_tpot_ms': data['inter_token_latency']['p50'],
-            'p99_tpot_ms': data['inter_token_latency']['p99'],
-            'p95_tpot_ms': data['inter_token_latency']['p95'],
-            'p90_tpot_ms': data['inter_token_latency']['p90'],
-            'p75_tpot_ms': data['inter_token_latency']['p75'],
-            'std_tpot_ms': data['inter_token_latency']['std'],
-
+            "mean_tpot_ms": data["inter_token_latency"]["avg"],
+            "median_tpot_ms": data["inter_token_latency"]["p50"],
+            "p99_tpot_ms": data["inter_token_latency"]["p99"],
+            "p95_tpot_ms": data["inter_token_latency"]["p95"],
+            "p90_tpot_ms": data["inter_token_latency"]["p90"],
+            "p75_tpot_ms": data["inter_token_latency"]["p75"],
+            "std_tpot_ms": data["inter_token_latency"]["std"],
             # ITL metrics (Inter-Token Latency, same as TPOT for genai-perf)
-            'mean_itl_ms': data['inter_token_latency']['avg'],
-            'median_itl_ms': data['inter_token_latency']['p50'],
-            'p99_itl_ms': data['inter_token_latency']['p99'],
-            'std_itl_ms': data['inter_token_latency']['std'],
-
+            "mean_itl_ms": data["inter_token_latency"]["avg"],
+            "median_itl_ms": data["inter_token_latency"]["p50"],
+            "p99_itl_ms": data["inter_token_latency"]["p99"],
+            "std_itl_ms": data["inter_token_latency"]["std"],
             # E2EL metrics (End-to-End Latency = Request Latency)
-            'mean_e2el_ms': data['request_latency']['avg'],
-            'median_e2el_ms': data['request_latency']['p50'],
-            'p99_e2el_ms': data['request_latency']['p99'],
-            'std_e2el_ms': data['request_latency']['std'],
-
+            "mean_e2el_ms": data["request_latency"]["avg"],
+            "median_e2el_ms": data["request_latency"]["p50"],
+            "p99_e2el_ms": data["request_latency"]["p99"],
+            "std_e2el_ms": data["request_latency"]["std"],
             # Throughput metrics
-            'output_token_throughput': data['output_token_throughput']['avg'],
-            'request_throughput': data['request_throughput']['avg'],
-
+            "output_token_throughput": data["output_token_throughput"]["avg"],
+            "request_throughput": data["request_throughput"]["avg"],
             # Calculated token counts (approximations)
-            'total_input_tokens': int(data['input_sequence_length']['avg'] * data['request_count']['avg']),
-            'total_output_tokens': int(data['output_sequence_length']['avg'] * data['request_count']['avg']),
-
+            "total_input_tokens": int(
+                data["input_sequence_length"]["avg"] * data["request_count"]["avg"]
+            ),
+            "total_output_tokens": int(
+                data["output_sequence_length"]["avg"] * data["request_count"]["avg"]
+            ),
             # Request count
-            'completed': int(data['request_count']['avg']),
+            "completed": int(data["request_count"]["avg"]),
         }
 
         return metrics
@@ -208,51 +205,106 @@ def print_detailed_results(isl, osl, concurrency, num_requests, metrics):
     print("=" * 80)
 
     # Summary section
-    print(f"\nSuccessful requests:                     {metrics.get('completed', num_requests)}")
-    print(f"Request throughput (req/s):              {metrics.get('request_throughput', 0):.2f}")
-    print(f"Output token throughput (tok/s):         {metrics.get('output_token_throughput', 0):.2f}")
-    print(f"Total input tokens:                      {metrics.get('total_input_tokens', 0)}")
-    print(f"Total output tokens:                     {metrics.get('total_output_tokens', 0)}")
+    print(
+        f"\nSuccessful requests:                     {metrics.get('completed', num_requests)}"
+    )
+    print(
+        f"Request throughput (req/s):              {metrics.get('request_throughput', 0):.2f}"
+    )
+    print(
+        f"Output token throughput (tok/s):         {metrics.get('output_token_throughput', 0):.2f}"
+    )
+    print(
+        f"Total input tokens:                      {metrics.get('total_input_tokens', 0)}"
+    )
+    print(
+        f"Total output tokens:                     {metrics.get('total_output_tokens', 0)}"
+    )
 
     # TTFT section
     print(f"\n{'-' * 40}Time to First Token{'-' * 40}")
-    print(f"Mean TTFT (ms):                          {metrics.get('mean_ttft_ms', 0):.2f}")
-    print(f"Median TTFT (ms):                        {metrics.get('median_ttft_ms', 0):.2f}")
-    print(f"P99 TTFT (ms):                           {metrics.get('p99_ttft_ms', 0):.2f}")
-    print(f"P95 TTFT (ms):                           {metrics.get('p95_ttft_ms', 0):.2f}")
-    print(f"P90 TTFT (ms):                           {metrics.get('p90_ttft_ms', 0):.2f}")
-    print(f"P75 TTFT (ms):                           {metrics.get('p75_ttft_ms', 0):.2f}")
-    print(f"Std TTFT (ms):                           {metrics.get('std_ttft_ms', 0):.2f}")
+    print(
+        f"Mean TTFT (ms):                          {metrics.get('mean_ttft_ms', 0):.2f}"
+    )
+    print(
+        f"Median TTFT (ms):                        {metrics.get('median_ttft_ms', 0):.2f}"
+    )
+    print(
+        f"P99 TTFT (ms):                           {metrics.get('p99_ttft_ms', 0):.2f}"
+    )
+    print(
+        f"P95 TTFT (ms):                           {metrics.get('p95_ttft_ms', 0):.2f}"
+    )
+    print(
+        f"P90 TTFT (ms):                           {metrics.get('p90_ttft_ms', 0):.2f}"
+    )
+    print(
+        f"P75 TTFT (ms):                           {metrics.get('p75_ttft_ms', 0):.2f}"
+    )
+    print(
+        f"Std TTFT (ms):                           {metrics.get('std_ttft_ms', 0):.2f}"
+    )
 
     # TPOT section
     print(f"\n{'-' * 40}Time per Output Token (excl. 1st token){'-' * 40}")
-    print(f"Mean TPOT (ms):                          {metrics.get('mean_tpot_ms', 0):.2f}")
-    print(f"Median TPOT (ms):                        {metrics.get('median_tpot_ms', 0):.2f}")
-    print(f"P99 TPOT (ms):                           {metrics.get('p99_tpot_ms', 0):.2f}")
-    print(f"P95 TPOT (ms):                           {metrics.get('p95_tpot_ms', 0):.2f}")
-    print(f"P90 TPOT (ms):                           {metrics.get('p90_tpot_ms', 0):.2f}")
-    print(f"P75 TPOT (ms):                           {metrics.get('p75_tpot_ms', 0):.2f}")
-    print(f"Std TPOT (ms):                           {metrics.get('std_tpot_ms', 0):.2f}")
+    print(
+        f"Mean TPOT (ms):                          {metrics.get('mean_tpot_ms', 0):.2f}"
+    )
+    print(
+        f"Median TPOT (ms):                        {metrics.get('median_tpot_ms', 0):.2f}"
+    )
+    print(
+        f"P99 TPOT (ms):                           {metrics.get('p99_tpot_ms', 0):.2f}"
+    )
+    print(
+        f"P95 TPOT (ms):                           {metrics.get('p95_tpot_ms', 0):.2f}"
+    )
+    print(
+        f"P90 TPOT (ms):                           {metrics.get('p90_tpot_ms', 0):.2f}"
+    )
+    print(
+        f"P75 TPOT (ms):                           {metrics.get('p75_tpot_ms', 0):.2f}"
+    )
+    print(
+        f"Std TPOT (ms):                           {metrics.get('std_tpot_ms', 0):.2f}"
+    )
 
     # ITL section
     print(f"\n{'-' * 40}Inter-token Latency{'-' * 40}")
-    print(f"Mean ITL (ms):                           {metrics.get('mean_itl_ms', 0):.2f}")
-    print(f"Median ITL (ms):                         {metrics.get('median_itl_ms', 0):.2f}")
-    print(f"P99 ITL (ms):                            {metrics.get('p99_itl_ms', 0):.2f}")
-    print(f"Std ITL (ms):                            {metrics.get('std_itl_ms', 0):.2f}")
+    print(
+        f"Mean ITL (ms):                           {metrics.get('mean_itl_ms', 0):.2f}"
+    )
+    print(
+        f"Median ITL (ms):                         {metrics.get('median_itl_ms', 0):.2f}"
+    )
+    print(
+        f"P99 ITL (ms):                            {metrics.get('p99_itl_ms', 0):.2f}"
+    )
+    print(
+        f"Std ITL (ms):                            {metrics.get('std_itl_ms', 0):.2f}"
+    )
 
     # E2EL section
     print(f"\n{'-' * 40}End-to-end Latency{'-' * 40}")
-    print(f"Mean E2EL (ms):                          {metrics.get('mean_e2el_ms', 0):.2f}")
-    print(f"Median E2EL (ms):                        {metrics.get('median_e2el_ms', 0):.2f}")
-    print(f"P99 E2EL (ms):                           {metrics.get('p99_e2el_ms', 0):.2f}")
-    print(f"Std E2EL (ms):                           {metrics.get('std_e2el_ms', 0):.2f}")
+    print(
+        f"Mean E2EL (ms):                          {metrics.get('mean_e2el_ms', 0):.2f}"
+    )
+    print(
+        f"Median E2EL (ms):                        {metrics.get('median_e2el_ms', 0):.2f}"
+    )
+    print(
+        f"P99 E2EL (ms):                           {metrics.get('p99_e2el_ms', 0):.2f}"
+    )
+    print(
+        f"Std E2EL (ms):                           {metrics.get('std_e2el_ms', 0):.2f}"
+    )
 
     print("=" * 80 + "\n")
 
 
-def save_individual_result(metrics, isl, osl, concurrency, num_requests,
-                          model_name, model_id, output_dir):
+def save_individual_result(
+    metrics, isl, osl, concurrency, num_requests, model_name, model_id, output_dir
+):
     """Save individual benchmark result in genai-perf format"""
     from datetime import datetime
 
@@ -270,10 +322,10 @@ def save_individual_result(metrics, isl, osl, concurrency, num_requests,
         "tokenizer_id": model_name,
         "num_prompts": num_requests,
         "max_concurrency": concurrency,
-        **metrics  # All harmonized metrics
+        **metrics,  # All harmonized metrics
     }
 
-    with open(filepath, 'w') as f:
+    with open(filepath, "w") as f:
         json.dump(result, f, indent=2)
 
     print(f"Result saved to: {filepath}")
@@ -299,14 +351,18 @@ def run_benchmark(
     artifact_dir = os.path.join(artifact_base, run_id)
 
     if verbose:
-        print(f"\n{'='*80}")
+        print(f"\n{'=' * 80}")
         print(
             f"BENCHMARK: ISL={isl}, OSL={osl}, Concurrency={concurrency}, Requests={num_prompts}"
         )
         print(f"Artifact Dir: {artifact_dir}")
-        print(f"{'='*80}")
+        print(f"{'=' * 80}")
     else:
-        print(f"\nRunning: ISL={isl}, OSL={osl}, Concur={concurrency} ... ", end="", flush=True)
+        print(
+            f"\nRunning: ISL={isl}, OSL={osl}, Concur={concurrency} ... ",
+            end="",
+            flush=True,
+        )
 
     if not auth_token:
         print("FAILED (No AUTH_TOKEN)")
@@ -365,7 +421,7 @@ def run_benchmark(
     ]
 
     if verbose:
-        print(f"\nExecuting command:")
+        print("\nExecuting command:")
         print(f"  {' '.join(cmd)}\n")
 
     try:
@@ -373,10 +429,10 @@ def run_benchmark(
 
         if verbose:
             if result.stdout:
-                print(f"\n--- STDOUT ---")
+                print("\n--- STDOUT ---")
                 print(result.stdout)
             if result.stderr:
-                print(f"\n--- STDERR ---")
+                print("\n--- STDERR ---")
                 print(result.stderr)
 
         stats = parse_metrics(artifact_dir)
@@ -388,15 +444,20 @@ def run_benchmark(
             # Save individual result file
             # Get output directory from environment or config
             benchmarks_output_dir = os.environ.get(
-                'BENCHMARKS_OUTPUT_DIR',
-                '/workspace/benchmarks_output'
+                "BENCHMARKS_OUTPUT_DIR", "/workspace/benchmarks_output"
             )
             if not os.path.exists(benchmarks_output_dir):
                 os.makedirs(benchmarks_output_dir, exist_ok=True)
 
             save_individual_result(
-                stats, isl, osl, concurrency, num_prompts,
-                model_name, model_id, benchmarks_output_dir
+                stats,
+                isl,
+                osl,
+                concurrency,
+                num_prompts,
+                model_name,
+                model_id,
+                benchmarks_output_dir,
             )
 
             # Still add to aggregator for final summary table
@@ -405,21 +466,21 @@ def run_benchmark(
                 osl=osl,
                 concurrency=concurrency,
                 num_requests=num_prompts,
-                avg_ttft_ms=stats.get('mean_ttft_ms', 0),
-                avg_tpot_ms=stats.get('mean_tpot_ms', 0),
-                avg_tps=stats.get('output_token_throughput', 0),
-                p99_latency=stats.get('p99_itl_ms', 0),
+                avg_ttft_ms=stats.get("mean_ttft_ms", 0),
+                avg_tpot_ms=stats.get("mean_tpot_ms", 0),
+                avg_tps=stats.get("output_token_throughput", 0),
+                p99_latency=stats.get("p99_itl_ms", 0),
             )
             aggregator.add_result(bench_res)
             if verbose:
-                print(f"\n[OK] BENCHMARK COMPLETED SUCCESSFULLY")
+                print("\n[OK] BENCHMARK COMPLETED SUCCESSFULLY")
                 sys.stdout.flush()
             else:
                 print("DONE")
                 sys.stdout.flush()
         else:
             if verbose:
-                print(f"\n[FAIL] BENCHMARK FAILED: Empty Results")
+                print("\n[FAIL] BENCHMARK FAILED: Empty Results")
                 if result.stderr:
                     print(f"\nStderr output:\n{result.stderr}")
                 sys.stdout.flush()
@@ -427,17 +488,21 @@ def run_benchmark(
                 print("FAILED (Empty Results)")
                 sys.stdout.flush()
             aggregator.add_result(
-                BenchmarkResult(isl, osl, concurrency, num_prompts, error="Empty Results")
+                BenchmarkResult(
+                    isl, osl, concurrency, num_prompts, error="Empty Results"
+                )
             )
 
     except subprocess.CalledProcessError as e:
         if verbose:
-            print(f"\n[FAIL] BENCHMARK FAILED: Process Error (exit code {e.returncode})")
+            print(
+                f"\n[FAIL] BENCHMARK FAILED: Process Error (exit code {e.returncode})"
+            )
             if e.stdout:
-                print(f"\n--- STDOUT ---")
+                print("\n--- STDOUT ---")
                 print(e.stdout)
             if e.stderr:
-                print(f"\n--- STDERR ---")
+                print("\n--- STDERR ---")
                 print(e.stderr)
             sys.stdout.flush()
         else:
@@ -502,7 +567,9 @@ def main():
         config = load_config_from_env()
 
     model_name = config["model_name"]
-    model_id = config.get("model_id", model_name.replace('/', '__'))  # Fallback if not provided
+    model_id = config.get(
+        "model_id", model_name.replace("/", "__")
+    )  # Fallback if not provided
     tokenizer = config["tokenizer"]
     url = config["url"]
     max_context = config["max_context"]

--- a/benchmarking/run_benchmarks.py
+++ b/benchmarking/run_benchmarks.py
@@ -193,11 +193,14 @@ def main():
         debug_mode = False
         if limit_samples_mode_str:
             from workflows.workflow_types import EvalLimitMode
+
             limit_mode = EvalLimitMode.from_string(limit_samples_mode_str)
             # Enable debug mode for quick test modes
             if limit_mode in (EvalLimitMode.SMOKE_TEST, EvalLimitMode.CI_COMMIT):
                 debug_mode = True
-                logger.info(f"Enabling genai-perf debug mode (2 benchmarks) for limit_samples_mode={limit_samples_mode_str}")
+                logger.info(
+                    f"Enabling genai-perf debug mode (2 benchmarks) for limit_samples_mode={limit_samples_mode_str}"
+                )
 
         return run_genai_benchmarks(
             model_spec=model_spec,

--- a/benchmarking/run_genai_benchmarks.py
+++ b/benchmarking/run_genai_benchmarks.py
@@ -12,7 +12,6 @@ import logging
 import os
 import sys
 import uuid
-from datetime import datetime
 from pathlib import Path
 
 import jwt
@@ -24,8 +23,8 @@ sys.path.insert(0, str(project_root))
 from workflows.log_setup import setup_workflow_script_logger
 from workflows.model_spec import ModelSpec
 from workflows.utils import get_repo_root_path, run_command
-from workflows.workflow_venvs import VENV_CONFIGS
 from workflows.workflow_types import WorkflowVenvType
+from workflows.workflow_venvs import VENV_CONFIGS
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +115,7 @@ def run_genai_benchmarks(
 
     # Get benchmarks output directory for direct file output
     from workflows.workflow_config import get_default_workflow_root_log_dir
+
     benchmarks_output_dir = get_default_workflow_root_log_dir() / "benchmarks_output"
     benchmarks_output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -134,13 +134,14 @@ def run_genai_benchmarks(
     logger.info(f"Container name: {container_name}")
 
     # Get current user UID:GID for proper file permissions
-    import pwd
+
     uid = os.getuid()
     gid = os.getgid()
     user_spec = f"{uid}:{gid}"
 
     # Get host HF cache directory (reuse system's HF cache instead of creating new one)
     from workflows.utils import get_default_hf_home_path
+
     host_hf_cache = get_default_hf_home_path()
     logger.info(f"Using host HF cache: {host_hf_cache}")
 
@@ -168,11 +169,6 @@ def run_genai_benchmarks(
         json.dump(config, f, indent=2)
     logger.info(f"Config written to: {config_path}")
 
-    # Output JSON path
-    run_timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    output_json_name = f"genai_benchmark_{model_spec.model_id}_{run_timestamp}.json"
-    output_json_path = Path(output_path) / output_json_name
-
     # Build Docker command
     # fmt: off
     cmd = [
@@ -189,7 +185,7 @@ def run_genai_benchmarks(
         "-e", f"URL=localhost:{service_port}",
         "-e", f"MAX_CONTEXT={max_context}",
         "-e", f"MODEL_MAX_CONCURRENCY={max_concurrency}",
-        "-e", f"BENCHMARKS_OUTPUT_DIR=/workspace/benchmarks_output",
+        "-e", "BENCHMARKS_OUTPUT_DIR=/workspace/benchmarks_output",
         "-e", "PYTHONUNBUFFERED=1",  # Force unbuffered output for real-time logs
         "-e", "HF_HOME=/workspace/.cache/huggingface",  # Point to mounted HF cache
         "-e", "TRANSFORMERS_CACHE=/workspace/.cache/huggingface",  # Point to mounted HF cache
@@ -214,7 +210,9 @@ def run_genai_benchmarks(
         logger.info("[OK] genai-perf benchmarks completed successfully")
         logger.info(f"Individual results saved to: {benchmarks_output_dir}")
     else:
-        logger.error(f"[FAIL] genai-perf benchmarks failed with return code: {return_code}")
+        logger.error(
+            f"[FAIL] genai-perf benchmarks failed with return code: {return_code}"
+        )
 
     return return_code
 
@@ -247,7 +245,9 @@ def main():
     if return_code == 0:
         logger.info("[OK] Completed genai-perf benchmarks")
     else:
-        logger.error(f"[FAIL] genai-perf benchmarks failed with return code: {return_code}")
+        logger.error(
+            f"[FAIL] genai-perf benchmarks failed with return code: {return_code}"
+        )
 
     return return_code
 

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -331,7 +331,9 @@ def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata
     genai_files = glob(f"{benchmarks_output_dir}/{genai_pattern}")
 
     files = vllm_files + genai_files
-    logger.info(f"Found {len(vllm_files)} vLLM benchmark files and {len(genai_files)} genai-perf benchmark files")
+    logger.info(
+        f"Found {len(vllm_files)} vLLM benchmark files and {len(genai_files)} genai-perf benchmark files"
+    )
     output_dir = Path(args.output_path) / "benchmarks"
     logger.info("Benchmark Summary")
     logger.info(f"Processing: {len(files)} files")


### PR DESCRIPTION
## Problem
Some new files were not following the Ruff Linter specifications, causing PR Gate to fail

## Implementation
- run `ruff format` on all new files in tt-inference-server