### PR TITLE
Remove presence penalty for most comon assert

### DIFF
--- a/tests/server_tests/test_cases/test_vllm_server_parameters.py
+++ b/tests/server_tests/test_cases/test_vllm_server_parameters.py
@@ -269,7 +269,7 @@ def test_penalties(
 
         # 2. Heavy repetition should decrease
         #    For repetition-heavy prompts, penalties reduce top-token dominance
-        if prompt_name == "repeat_trap":
+        if prompt_name == "repeat_trap" and penalty_param != "presence_penalty":
             most_common_penalty = test_stats["most_common"][0][1]
             most_common_baseline = base_stats["most_common"][0][1]
             assert most_common_penalty <= most_common_baseline, (


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/34598

I think that this test is flawed, particularly since we don't have a way to force responses of the same size. On the other hand, presence penalty doesn't look into overall statistics which is why it also doesn't make sense to expect a big effect on this metric.
We see that it fails with host sampling for the same reason even though responses look good https://github.com/tenstorrent/tt-shield/actions/runs/20300724862/job/58308436867#step:9:3243

- [x] [llama 8b models ci run](https://github.com/tenstorrent/tt-shield/actions/runs/20371412564)