### PR TITLE
Fix Wan fabric configuration

### DIFF
--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -341,8 +341,6 @@ class TTWan22Runner(TTDiTRunner):
 
     def get_pipeline_device_params(self):
         device_params = {
-            "l1_small_size": 32768,
-            "trace_region_size": 34000000,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
         }
         if ttnn.device.is_blackhole():


### PR DESCRIPTION
This fixes a memory issue on T3K when running the Wan2.2 video generation model:
```
2025-12-22 15:04:56,443 - ERROR - Failed to get device runner: TT_THROW @ /localdev/ztorlak/tt-metal/tt_metal/impl/program/program.cpp:925: tt::exception
info:
Statically allocated circular buffers in program 340 clash with L1 buffers on core range [(x=0,y=0) - (x=7,y=7)]. L1 buffer allocated at 1464320 and static circular buffer region ends at 1464576
```
After the fix the model runs successfully on T3K.