### PR TITLE
Change python parameter validation to worrk with git worktrees

### DIFF
--- a/scripts/build_docker_images.py
+++ b/scripts/build_docker_images.py
@@ -530,9 +530,9 @@ def validate_inputs(ubuntu_version, container_app_uid):
     # Make sure we are in the git root
     try:
         git_root = subprocess.check_output(
-            ['git', 'rev-parse', '--show-toplevel'],
+            ["git", "rev-parse", "--show-toplevel"],
             stderr=subprocess.DEVNULL,
-            text=True
+            text=True,
         ).strip()
         current_dir = os.getcwd()
         if current_dir != git_root:


### PR DESCRIPTION
I work with git worktrees (and based on [this part](https://github.com/tenstorrent/tt-inference-server/blob/main/docs/development.md#git-worktree) of the docs, others are as well). 

The script for building releasa docker images was not compatible with worktrees, as it enforced pwd is named `tt-inference-server` exactly. This change still forces user to run the script from the root of the git repo, but that root folder can be called however.

Happy path:
<img width="876" height="469" alt="Screenshot 2025-12-23 at 16 29 10" src="https://github.com/user-attachments/assets/5375d6e0-af92-4da1-89b6-2e38a25369f0" />

Still throws error when user is not in the git root:
<img width="794" height="323" alt="Screenshot 2025-12-23 at 16 28 30" src="https://github.com/user-attachments/assets/349643c0-cf16-49b4-b9b6-f478558a8b89" />
