### PR TITLE
Fix Qwen3 implementation registration

### DIFF
--- a/vllm-tt-metal-llama3/src/run_vllm_api_server.py
+++ b/vllm-tt-metal-llama3/src/run_vllm_api_server.py
@@ -76,9 +76,7 @@ def register_tt_models():
     # Qwen3 - Text
     qwen3_text_version = os.getenv("TT_QWEN3_TEXT_VER", "tt_transformers")
     if qwen3_text_version == "tt_transformers":
-        path_qwen3_text = (
-            "models.tt_transformers.tt.generator_vllm:QwenForCausalLM"
-        )
+        path_qwen3_text = "models.tt_transformers.tt.generator_vllm:QwenForCausalLM"
     elif qwen3_text_version == "qwen3_32b_galaxy":
         path_qwen3_text = (
             "models.demos.llama3_70b_galaxy.tt.generator_vllm:QwenForCausalLM"
@@ -86,7 +84,8 @@ def register_tt_models():
     else:
         raise ValueError(
             f"Unsupported TT Qwen3 version: {qwen3_text_version}, "
-            "pick one of [tt_transformers, qwen3_32b_galaxy]")
+            "pick one of [tt_transformers, qwen3_32b_galaxy]"
+        )
 
     ModelRegistry.register_model("TTQwen3ForCausalLM", path_qwen3_text)
 


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/tenstorrent/tt-inference-server/pull/1347 where we incorrectly aliased the Qwen2 model registration. The result was:
```shell
python3 ./run.py --model Qwen3-32B --workflow server --device t3k --docker-server 

File "/home/container_app_user/tt-metal/python_env/lib/python3.10/site-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
pydantic_core._pydantic_core.ValidationError: 1 validation error for VllmConfig
  Value error, Cannot find model module. 'TTQwen3ForCausalLM' is not a registered model in the Transformers library (only relevant if the model is meant to be in Transformers) and 'AutoModel' is not present in the model config's 'auto_map' (relevant if the model is custom). [type=value_error, input_value=ArgsKwargs((), {'model_co...additional_config': {}}), input_type=ArgsKwargs]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
```