### PR TITLE
Use correct default docker image name

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -21,7 +21,9 @@ from workflows.workflow_types import DeviceTypes, ModelStatusTypes, VersionMode
 VERSION = get_version()
 
 
-def generate_docker_tag(version: str, tt_metal_commit: str, vllm_commit: Optional[str]) -> str:
+def generate_docker_tag(
+    version: str, tt_metal_commit: str, vllm_commit: Optional[str]
+) -> str:
     max_tag_len = 12
     if vllm_commit:
         return f"{version}-{tt_metal_commit[:max_tag_len]}-{vllm_commit[:max_tag_len]}"


### PR DESCRIPTION
If vllm_commit is not present in the ModelSpec, dont use `ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64`, but rather `ghcr.io/tenstorrent/tt-media-inference-server`, as it is media-image