### PR TITLE
Fix Performance for Embedding Models on N300

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -415,13 +415,13 @@ ModelConfigs = {
         "max_batch_size": 8,
     },
     (ModelRunners.VLLMBGELargeEN_V1_5, DeviceTypes.N300): {
-        "device_mesh_shape": (1, 1),
+        "device_mesh_shape": (1, 2),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_ALL.value,
         "max_batch_size": 16,
     },
     (ModelRunners.VLLMBGELargeEN_V1_5, DeviceTypes.T3K): {
-        "device_mesh_shape": (1, 1),
+        "device_mesh_shape": (1, 2),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_4.value,
         "max_batch_size": 32,

--- a/tt-media-server/tt_model_runners/vllm_bge_large_en_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_bge_large_en_runner.py
@@ -30,7 +30,7 @@ class VLLMBGELargeENRunner(BaseDeviceRunner):
             "The capital of France is Paris",
         ]
         max_model_len = 384
-        max_num_seqs = 8
+        max_num_seqs = 8 * self.settings.device_mesh_shape[1]
         self.llm = LLM(
             model=SupportedModels.BGE_LARGE_EN_V1_5.value,
             max_model_len=max_model_len,


### PR DESCRIPTION
## Problem
The vLLM plugin was treating every opened device as an N150 chip, and in the media-server we had a hardcoded `max_num_seqs=8`. Once we accounted for the actual number of devices, we were able to achieve roughly a 1.5× performance improvement on the N300 chip.

Relevant model code:
```           
 self.batch_size = self.batch_size * self.device.get_num_devices()
```

## Implementation
- set `max_num_seqs = 8 * self.settings.device_mesh_shape[1]`
- update `mesh_shape` in predefined model configs

## Testing
**Command:**
```
vllm bench serve --model 'BAAI/bge-large-en-v1.5' --backend openai-embeddings --endpoint /v1/embeddings --dataset-name random --random-input-len 384
```
**Performance on N300 before changes:**
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  7.09      
Total input tokens:                      384000    
Request throughput (req/s):              141.08    
Total Token throughput (tok/s):          54174.14  
----------------End-to-end Latency----------------
Mean E2EL (ms):                          3946.50   
Median E2EL (ms):                        3950.00   
P99 E2EL (ms):                           6964.39   
==================================================
```


**Performance on N300 with changes:**
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  4.61      
Total input tokens:                      384000    
Request throughput (req/s):              217.09    
Total Token throughput (tok/s):          83361.64  
----------------End-to-end Latency----------------
Mean E2EL (ms):                          2722.86   
Median E2EL (ms):                        2701.23   
P99 E2EL (ms):                           4508.68   
==================================================