### PR TITLE
Don't force C++ compilers for python

### DIFF
--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -94,7 +94,7 @@ RUN git clone --depth 1 https://github.com/tenstorrent-metal/tt-metal.git ${TT_M
     && git checkout ${TT_METAL_COMMIT_SHA_OR_TAG} \
     && git submodule update --init --recursive --depth 1 \
     && ./install_dependencies.sh --docker \
-    && CXX=clang++-17 CC=clang-17 bash ./create_venv.sh \
+    && bash ./create_venv.sh \
     && echo "source ${PYTHON_ENV_DIR}/bin/activate" >> ${HOME_DIR}/.bashrc \
     && pip3 install --upgrade setuptools wheel \
     && bash ./build_metal.sh --release -e \


### PR DESCRIPTION
Issue:  

DiT C++ compilers are failing on the CI but working properly locally.

Error:

Unable to convert function return value to a Python type! The signature was __repr__(self) -> std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >

CI run for fix:

https://github.com/tenstorrent/tt-shield/actions/runs/20615230318