### PR TITLE
Increase request_processing_timeout_seconds for SD3.5

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -268,12 +268,14 @@ ModelConfigs = {
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_ALL.value,
         "max_batch_size": 1,
+        "request_processing_timeout_seconds": 2000,
     },
     (ModelRunners.TT_SD3_5, DeviceTypes.GALAXY): {
         "device_mesh_shape": (4, 8),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_ALL.value,
         "max_batch_size": 1,
+        "request_processing_timeout_seconds": 2000,
     },
     (ModelRunners.TT_FLUX_1_DEV, DeviceTypes.T3K): {
         "device_mesh_shape": (2, 4),


### PR DESCRIPTION
## Problem
Recently a new `request_processing_timeout_seconds` parameter was introduced. Since SD3-5 is a slower model, our benchmarking setup where 1000 requests are enqueued simultaneously and processed sequentially, and where the queue wait time is included in the overall request timing, some requests exceed the default 1000s timeout while waiting in the queue.
To ensure the CI pipeline for SD3.5 passes with the current benchmark configuration of 1000 requests, the timeout value was increased.

## Implementation
- Increase `request_processing_timeout_seconds` for SD3-5 to 2000s

## Testing
CI run before the changes:
https://github.com/tenstorrent/tt-shield/actions/runs/20820248502

CI run with changes:
https://github.com/tenstorrent/tt-shield/actions/runs/20823275071