### PR TITLE
Add GenAI-Perf Detailed Percentiles Section to Benchmark Reports

### DIFF
--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -374,7 +374,7 @@ def aiperf_release_markdown(release_raw, is_image_benchmark=False):
 
     This follows NVIDIA's genai-perf style output with mean, median, and p99 percentiles
     for each key metric category.
-    
+
     Args:
         release_raw: Raw benchmark data
         is_image_benchmark: If True, includes image dimension columns (height, width, images per prompt)
@@ -385,33 +385,37 @@ def aiperf_release_markdown(release_raw, is_image_benchmark=False):
         ("osl", "OSL"),
         ("concurrency", "Concur"),
     ]
-    
+
     # Add image-specific columns for image benchmarks
     if is_image_benchmark:
-        display_cols.extend([
-            ("image_height", "Image Height"),
-            ("image_width", "Image Width"),
-            ("images_per_prompt", "Images per Prompt"),
-        ])
-    
-    display_cols.extend([
-        ("num_requests", "N"),
-        # TTFT metrics
-        ("mean_ttft_ms", "TTFT Avg (ms)"),
-        ("median_ttft_ms", "TTFT P50 (ms)"),
-        ("p99_ttft_ms", "TTFT P99 (ms)"),
-        # TPOT metrics (Time Per Output Token)
-        ("mean_tpot_ms", "TPOT Avg (ms)"),
-        ("median_tpot_ms", "TPOT P50 (ms)"),
-        ("p99_tpot_ms", "TPOT P99 (ms)"),
-        # E2EL metrics (End-to-End Latency)
-        ("mean_e2el_ms", "E2EL Avg (ms)"),
-        ("median_e2el_ms", "E2EL P50 (ms)"),
-        ("p99_e2el_ms", "E2EL P99 (ms)"),
-        # Throughput
-        ("output_token_throughput", "Tok/s"),
-        ("request_throughput", "Req/s"),
-    ])
+        display_cols.extend(
+            [
+                ("image_height", "Image Height"),
+                ("image_width", "Image Width"),
+                ("images_per_prompt", "Images per Prompt"),
+            ]
+        )
+
+    display_cols.extend(
+        [
+            ("num_requests", "N"),
+            # TTFT metrics
+            ("mean_ttft_ms", "TTFT Avg (ms)"),
+            ("median_ttft_ms", "TTFT P50 (ms)"),
+            ("p99_ttft_ms", "TTFT P99 (ms)"),
+            # TPOT metrics (Time Per Output Token)
+            ("mean_tpot_ms", "TPOT Avg (ms)"),
+            ("median_tpot_ms", "TPOT P50 (ms)"),
+            ("p99_tpot_ms", "TPOT P99 (ms)"),
+            # E2EL metrics (End-to-End Latency)
+            ("mean_e2el_ms", "E2EL Avg (ms)"),
+            ("median_e2el_ms", "E2EL P50 (ms)"),
+            ("p99_e2el_ms", "E2EL P99 (ms)"),
+            # Throughput
+            ("output_token_throughput", "Tok/s"),
+            ("request_throughput", "Req/s"),
+        ]
+    )
 
     NOT_MEASURED_STR = "N/A"
     display_dicts = []
@@ -1102,7 +1106,9 @@ def aiperf_benchmark_generate_report(
         )
 
         # Only show AIPerf-specific detailed percentiles (mean, median, P99)
-        nvidia_markdown_str = aiperf_release_markdown(aiperf_image_results, is_image_benchmark=True)
+        nvidia_markdown_str = aiperf_release_markdown(
+            aiperf_image_results, is_image_benchmark=True
+        )
         release_str += nvidia_markdown_str
         release_str += "\n\n"
 
@@ -1382,7 +1388,9 @@ def genai_perf_benchmark_generate_report(
         release_str += "**Benchmarking Tool:** [GenAI-Perf](https://github.com/triton-inference-server/perf_analyzer)\n\n"
 
         # Show GenAI-Perf detailed percentiles (mean, median, P99)
-        nvidia_markdown_str = aiperf_release_markdown(genai_image_results, is_image_benchmark=True)
+        nvidia_markdown_str = aiperf_release_markdown(
+            genai_image_results, is_image_benchmark=True
+        )
         release_str += nvidia_markdown_str
         release_str += "\n\n"
 


### PR DESCRIPTION
## Summary

This PR adds detailed percentile reporting for GenAI-Perf benchmarks, similar to what we already have for AIPerf benchmarks (https://github.com/tenstorrent/tt-inference-server/pull/1571). Currently GenAI-Perf results are only shown in the throughput comparison table, but the tool provides rich percentile data (mean, median, P99) that wasn't being displayed.

## Changes

- Added `genai_perf_benchmark_generate_report()` function that directly processes GenAI-Perf JSON files to extract detailed metrics
- Extracts ISL, OSL, and Concurrency from filenames
- Properly extracts percentile data (mean, median, P99) for TTFT, TPOT, and E2EL from JSON
- Separates text and image benchmarks by filename pattern
- Generates markdown reports and CSV files for GenAI-Perf results
- Integrated into main report generation workflow

## Implementation Details

The implementation follows the same pattern as the existing AIPerf report generation:
- Direct JSON file processing instead of using the generic helper
- Filename-based parameter extraction
- Deduplication to keep only latest run for each config
- Separate handling of text-only and image benchmarks
- Reuses existing `aiperf_release_markdown()` function for consistent table formatting

## Testing

Verified with actual GenAI-Perf benchmark files. Check the output for gemma-3-4b-it on N300 below: 

--------


### GenAI-Perf Benchmark Performance Results for gemma-3-4b-it on n300

#### GenAI-Perf Text Benchmarks - Detailed Percentiles

**Benchmarking Tool:** [GenAI-Perf](https://github.com/triton-inference-server/perf_analyzer)

|  ISL  | OSL  | Concur |  N  | TTFT Avg (ms) | TTFT P50 (ms) | TTFT P99 (ms) | TPOT Avg (ms) | TPOT P50 (ms) | TPOT P99 (ms) | E2EL Avg (ms) | E2EL P50 (ms) | E2EL P99 (ms) | Tok/s  | Req/s  |
|-------|------|--------|-----|---------------|---------------|---------------|---------------|---------------|---------------|---------------|---------------|---------------|--------|--------|
|   128 |  128 |      1 |   8 |        1289.6 |          73.2 |        9124.2 |          32.9 |          32.8 |          34.6 |        6287.4 |        5057.1 |       14170.5 |  24.33 | 0.1590 |
|   128 |  128 |     32 | 256 |        3148.9 |        2133.8 |       11531.8 |          35.7 |          34.8 |          48.2 |        8530.8 |        7398.6 |       16906.5 | 567.28 | 3.7336 |
|   128 | 1024 |      1 |   4 |          73.3 |          73.3 |          73.8 |          33.5 |          33.6 |          35.2 |       29536.6 |       27932.6 |       40468.7 |  24.17 | 0.0276 |
|   128 | 1024 |     32 | 128 |        2037.8 |        2126.4 |        2154.9 |          35.3 |          35.4 |          39.3 |       34731.6 |       36037.1 |       47790.4 | 646.52 | 0.6976 |
|  1024 |  128 |      1 |   4 |         321.3 |         231.8 |         582.1 |          33.0 |          33.4 |          34.4 |        5398.0 |        5329.7 |        5650.3 |  28.71 | 0.1853 |
|  2048 |  128 |      1 |   4 |         707.8 |         791.8 |         798.2 |          33.5 |          33.4 |          34.6 |        5903.5 |        5937.4 |        6024.2 |  26.47 | 0.1694 |
|  2048 |  128 |     32 | 128 |       13731.5 |       14066.1 |       14455.3 |          39.4 |          36.5 |         126.6 |       19840.8 |       19752.1 |       20179.9 | 251.77 | 1.6128 |
|  2048 | 2048 |     32 |  64 |       13661.9 |       13988.2 |       14193.2 |          39.2 |          38.0 |          58.8 |       64683.3 |       60474.3 |      112436.6 | 371.07 | 0.2864 |
|  3000 |   64 |     32 | 128 |       27405.7 |       28103.8 |       28740.8 |          49.0 |          37.7 |         395.0 |       31127.0 |       30973.3 |       31633.2 |  79.07 | 1.0278 |
|  3072 |  128 |      1 |   4 |        1146.9 |        1232.8 |        1238.1 |          30.3 |          30.4 |          31.6 |        5960.8 |        6023.1 |        6071.1 |  26.84 | 0.1678 |
|  4000 |   64 |     32 | 128 |       27493.7 |       28246.6 |       29540.9 |          52.6 |          38.3 |         407.9 |       31437.5 |       31128.1 |       32445.4 |  77.73 | 1.0173 |
|  4096 |  128 |      1 |   2 |        1069.4 |        1069.4 |        1239.6 |          31.5 |          31.5 |          32.1 |        6026.0 |        6026.0 |        6224.2 |  26.30 | 0.1659 |
|  8000 |   64 |     16 |  32 |       27789.3 |       29649.1 |       30941.0 |          66.5 |          33.8 |         409.0 |       32871.4 |       32871.6 |       33543.2 |  37.92 | 0.4867 |
|  8192 |  128 |      1 |   2 |        6494.0 |        6494.0 |       11057.5 |          38.9 |          38.9 |          42.6 |        9892.1 |        9892.1 |       16154.6 |   9.45 | 0.1011 |
| 16000 |   64 |      8 |  16 |       26169.3 |       27891.8 |       32370.8 |         112.5 |          83.4 |         357.5 |       34732.8 |       34732.9 |       35129.6 |  17.89 | 0.2303 |
| 16384 |  128 |      1 |   2 |        8965.5 |        8965.5 |       13654.4 |          36.4 |          36.4 |          36.9 |       14650.2 |       14650.2 |       19343.3 |  10.72 | 0.0683 |
| 32000 |   64 |      4 |   8 |       29684.9 |       35697.7 |       37223.1 |         130.6 |          38.5 |         413.5 |       39246.3 |       39246.3 |       40009.6 |   7.62 | 0.1019 |
| 32000 |  128 |      1 |   2 |       18309.6 |       18309.6 |       18487.4 |          40.4 |          40.4 |          41.1 |       24435.5 |       24435.5 |       24659.9 |   6.24 | 0.0409 |

Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)

#### GenAI-Perf Image Benchmarks - Detailed Percentiles

**Benchmarking Tool:** [GenAI-Perf](https://github.com/triton-inference-server/perf_analyzer)

| ISL | OSL | Concur |  N  | TTFT Avg (ms) | TTFT P50 (ms) | TTFT P99 (ms) | TPOT Avg (ms) | TPOT P50 (ms) | TPOT P99 (ms) | E2EL Avg (ms) | E2EL P50 (ms) | E2EL P99 (ms) | Tok/s  | Req/s  |
|-----|-----|--------|-----|---------------|---------------|---------------|---------------|---------------|---------------|---------------|---------------|---------------|--------|--------|
| 128 | 128 |      1 |   8 |         650.5 |         645.4 |         662.0 |          30.5 |          30.8 |          32.2 |        4410.1 |        5062.7 |        5214.7 |  24.69 | 0.1964 |
| 128 | 128 |      1 |   8 |         655.0 |         651.1 |         666.0 |          31.0 |          30.8 |          33.7 |        4728.4 |        5042.8 |        5140.0 |  26.24 | 0.1970 |
| 128 | 128 |      1 |   8 |         698.9 |         652.0 |         989.0 |          29.5 |          30.3 |          31.3 |        4691.8 |        5070.8 |        5175.2 |  27.09 | 0.1971 |
| 128 | 128 |      1 |   8 |         655.2 |         650.8 |         667.2 |          30.8 |          30.7 |          32.5 |        4678.9 |        5057.2 |        5169.5 |  26.47 | 0.2003 |
| 128 | 128 |      1 |   8 |         662.0 |         656.1 |         677.5 |          31.0 |          30.9 |          34.3 |        4863.8 |        5045.9 |        5199.7 |  26.78 | 0.1947 |
| 128 | 128 |     32 | 256 |       19698.1 |       20327.3 |       20403.8 |          39.0 |          34.1 |         166.1 |       25112.8 |       25280.5 |       25708.3 | 179.54 | 1.2607 |
| 128 | 128 |     32 | 256 |       19703.7 |       20291.8 |       20428.9 |          38.8 |          33.6 |         168.7 |       24866.7 |       25236.0 |       25440.8 | 172.19 | 1.2644 |
| 128 | 128 |     32 | 256 |       19656.2 |       20281.2 |       20365.9 |          38.0 |          33.6 |         169.2 |       24849.4 |       25198.6 |       25391.0 | 174.80 | 1.2683 |
| 128 | 128 |     32 | 256 |       19908.7 |       20554.7 |       20622.9 |          37.5 |          33.1 |         163.0 |       25239.9 |       25462.9 |       25680.0 | 180.52 | 1.2569 |

Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)

**Metric Definitions:**
> - **ISL**: Input Sequence Length (tokens)
> - **OSL**: Output Sequence Length (tokens)
> - **Concur**: Concurrent requests (batch size)
> - **N**: Total number of requests
> - **TTFT Avg/P50/P99**: Time To First Token - Average, Median (50th percentile), 99th percentile (ms)
> - **TPOT Avg/P50/P99**: Time Per Output Token - Average, Median, 99th percentile (ms)
> - **E2EL Avg/P50/P99**: End-to-End Latency - Average, Median, 99th percentile (ms)
> - **Tok/s**: Output token throughput
> - **Req/s**: Request throughput

