### PR TITLE
Revert "Mount tt-metal built directory to prevent Docker overlay filesystem disk space issues"

### DIFF
--- a/docs/workflows_user_guide.md
+++ b/docs/workflows_user_guide.md
@@ -113,12 +113,6 @@ python3 run.py --model Llama-3.2-1B-Instruct --device n300 --workflow server --d
 ```
 Note: add `--dev-mode` flag if you are making changes to the tt-inference-server files and want those to be mounted into the Docker container and used.
 
-**⚠️ Disk Space Warning:** Large model compilations (e.g., SDXL) can use ~100GB+ of disk space. The `tt-metal/built` directory is automatically mounted to the persistent volume when using `--docker-server`, so kernel compilation artifacts are stored on the host filesystem instead of Docker's overlay filesystem. 
-
-**Container Isolation:** Each Docker container gets a unique container ID, and kernel compilation artifacts are stored in isolated directories: `{persistent_volume_root}/volume_id_{impl_id}-{model_name}-v{version}/tt_metal_built/{container_id}/{worker_id}/`. This allows multiple containers (even with the same model/device/version) to run in parallel without conflicts. For example, running 32 containers in parallel will create 32 separate directories, each with its own kernel compilation cache.
-
-**Storage Location:** Artifacts are stored at `{persistent_volume_root}/volume_id_{impl_id}-{model_name}-v{version}/tt_metal_built/{container_id}/{worker_id}/`. Ensure this location has sufficient space (accounting for multiple containers), or set `PERSISTENT_VOLUME_ROOT` environment variable to point to a filesystem with more space.
-
 ```log
 2025-03-26 01:29:38,051 - run_docker_server.py:113 - INFO: Created Docker container ID: 6b8c7038a44a
 2025-03-26 01:29:38,051 - run_docker_server.py:114 - INFO: Access container logs via: docker logs -f 6b8c7038a44a

--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -192,7 +192,6 @@ ENV TT_METAL_COMMIT_SHA_OR_TAG=${TT_METAL_COMMIT_SHA_OR_TAG} \
     SHELL=/bin/bash \
     CONTAINER_APP_USERNAME=${CONTAINER_APP_USERNAME} \
     TT_METAL_HOME=${HOME_DIR}/tt-metal \
-    TT_METAL_BUILT_DIR=${HOME_DIR}/tt-metal/built \
     CONFIG=Release \
     TT_METAL_ENV=dev \
     LOGURU_LEVEL=INFO \
@@ -204,11 +203,9 @@ ENV TT_METAL_COMMIT_SHA_OR_TAG=${TT_METAL_COMMIT_SHA_OR_TAG} \
 
 # Install runtime dependencies
 # These packages are required for the application to run in production
-# Add Kitware GPG key (required by base image's apt sources)
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
-&& apt-get update && apt-get install -y \
-ffmpeg \
-&& rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create user
 RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_USERNAME} \

--- a/tt-media-server/device_workers/worker_utils.py
+++ b/tt-media-server/device_workers/worker_utils.py
@@ -36,24 +36,11 @@ def setup_worker_environment(
     if settings.enable_telemetry:
         get_telemetry_client()
 
-    # Use mounted TT_METAL_BUILT_DIR if available (prevents Docker overlay filesystem usage)
-    # Otherwise fall back to default location inside container
     tt_metal_home = os.environ.get("TT_METAL_HOME", "")
-    tt_metal_built_dir = os.environ.get("TT_METAL_BUILT_DIR", "")
-    container_id = os.environ.get("CONTAINER_ID", "")
-    worker_id_text = str(worker_id).replace(",", "_")
-    if tt_metal_built_dir and container_id:
-        # Use the mounted directory to avoid Docker overlay filesystem
-        # Include container ID for isolation between multiple containers running in parallel
-        # Path structure: {tt_metal_built_dir}/{container_id}/{worker_id}/
-        os.environ["TT_METAL_CACHE"] = (
-            f"{tt_metal_built_dir}/{container_id}/{worker_id_text}"
-        )
-    elif tt_metal_built_dir:
-        os.environ["TT_METAL_CACHE"] = f"{tt_metal_built_dir}/{worker_id_text}"
-    else:
-        # Fallback to default location (for non-Docker runs or if mount not configured)
-        os.environ["TT_METAL_CACHE"] = f"{tt_metal_home}/built/{worker_id_text}"
+    # use cache per device to reduce number of "binary not found" errors
+    os.environ["TT_METAL_CACHE"] = (
+        f"{tt_metal_home}/built/{str(worker_id).replace(',', '_')}"
+    )
 
     if settings.is_galaxy:
         _setup_galaxy_mesh_config(tt_metal_home)

--- a/tt-media-server/tests/test_worker_utils.py
+++ b/tt-media-server/tests/test_worker_utils.py
@@ -144,63 +144,6 @@ class TestSetupWorkerEnvironment:
 
                 assert os.environ["TT_METAL_CACHE"] == "/opt/tt-metal/built/0_1"
 
-    def test_sets_metal_cache_with_container_id(self):
-        """Test that TT_METAL_CACHE includes container ID when CONTAINER_ID is set"""
-        worker_id = "0"
-
-        with patch.dict(
-            os.environ,
-            {
-                "TT_METAL_BUILT_DIR": "/home/container_app_user/tt-metal/built",
-                "CONTAINER_ID": "abc12345",
-            },
-            clear=True,
-        ):
-            with patch("device_workers.worker_utils.get_telemetry_client"):
-                setup_worker_environment(worker_id)
-
-                assert (
-                    os.environ["TT_METAL_CACHE"]
-                    == "/home/container_app_user/tt-metal/built/abc12345/0"
-                )
-
-    def test_sets_metal_cache_with_container_id_and_comma_worker_id(self):
-        """Test container ID isolation with comma-separated worker ID"""
-        worker_id = "0,1"
-
-        with patch.dict(
-            os.environ,
-            {
-                "TT_METAL_BUILT_DIR": "/home/container_app_user/tt-metal/built",
-                "CONTAINER_ID": "def67890",
-            },
-            clear=True,
-        ):
-            with patch("device_workers.worker_utils.get_telemetry_client"):
-                setup_worker_environment(worker_id)
-
-                assert (
-                    os.environ["TT_METAL_CACHE"]
-                    == "/home/container_app_user/tt-metal/built/def67890/0_1"
-                )
-
-    def test_fallback_without_container_id(self):
-        """Test backward compatibility when CONTAINER_ID is not set"""
-        worker_id = "0"
-
-        with patch.dict(
-            os.environ,
-            {"TT_METAL_BUILT_DIR": "/home/container_app_user/tt-metal/built"},
-            clear=True,
-        ):
-            with patch("device_workers.worker_utils.get_telemetry_client"):
-                setup_worker_environment(worker_id)
-
-                assert (
-                    os.environ["TT_METAL_CACHE"]
-                    == "/home/container_app_user/tt-metal/built/0"
-                )
-
     def test_initializes_telemetry_when_enabled(self):
         """Test that telemetry is initialized when enabled"""
         with patch.dict(os.environ, {}, clear=True):

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -9,7 +9,6 @@ import subprocess
 import time
 import uuid
 from datetime import datetime
-from pathlib import Path
 
 from workflows.log_setup import clean_log_file
 from workflows.model_spec import (
@@ -185,8 +184,7 @@ def run_docker_server(model_spec, setup_config, json_fpath):
     )
     device = DeviceTypes.from_string(args.device)
     mesh_device_str = device.to_mesh_device_str()
-    container_id = short_uuid()
-    container_name = f"tt-inference-server-{container_id}"
+    container_name = f"tt-inference-server-{short_uuid()}"
 
     # TODO: remove this once https://github.com/tenstorrent/tt-metal/issues/23785 has been closed
     device_cache_dir = (
@@ -221,30 +219,10 @@ def run_docker_server(model_spec, setup_config, json_fpath):
     elif model_spec.impl == llama3_70b_galaxy_impl:
         model_env_var = {"TT_LLAMA_TEXT_VER": model_spec.impl.impl_id}
     # TODO: Remove all of this model env var setting https://github.com/tenstorrent/tt-inference-server/issues/1346
-
-    # Update host_tt_metal_built_dir to use base directory (container ID will be added in worker_utils.py)
-    # This allows multiple containers with same model/device/version to run in parallel
-    # Mount the base tt_metal_built directory, container isolation happens via CONTAINER_ID in worker path
-    host_model_volume_root = Path(setup_config.host_model_volume_root)
-    setup_config.host_tt_metal_built_dir = host_model_volume_root / "tt_metal_built"
-    # Ensure base directory exists before mounting
-    # Skip mkdir if it's already a Path-like object (e.g., in tests with mocked paths)
-    if isinstance(setup_config.host_tt_metal_built_dir, Path):
-        try:
-            setup_config.host_tt_metal_built_dir.mkdir(parents=True, exist_ok=True)
-        except (PermissionError, FileNotFoundError):
-            # In test environments, directory creation may fail - this is expected
-            pass
-
     docker_env_vars = {
         "CACHE_ROOT": setup_config.cache_root,
         "TT_CACHE_PATH": setup_config.container_tt_metal_cache_dir / device_cache_dir,
         "MODEL_WEIGHTS_PATH": setup_config.container_model_weights_path,
-        # Set TT_METAL_BUILT_DIR to point to mounted directory to avoid using Docker overlay filesystem
-        # This prevents ~100GB+ of kernel compilation artifacts from filling up root filesystem
-        "TT_METAL_BUILT_DIR": str(setup_config.container_tt_metal_built_dir),
-        # Container ID for worker isolation - allows multiple containers to run in parallel
-        "CONTAINER_ID": container_id,
         **(model_env_var if model_env_var is not None else {}),
         "TT_MODEL_SPEC_JSON_PATH": docker_json_fpath,
     }
@@ -273,9 +251,6 @@ def run_docker_server(model_spec, setup_config, json_fpath):
         "--mount", "type=bind,src=/dev/hugepages-1G,dst=/dev/hugepages-1G",
         # note: order of mounts matters, model_volume_root must be mounted before nested mounts
         "--mount", f"type=bind,src={setup_config.host_model_volume_root},dst={setup_config.cache_root}",
-        # Mount tt-metal built directory to avoid using Docker overlay filesystem for kernel compilation artifacts
-        # This prevents ~100GB+ of disk usage from filling up the root filesystem
-        "--mount", f"type=bind,src={setup_config.host_tt_metal_built_dir},dst={setup_config.container_tt_metal_built_dir}",
         "--mount", f"type=bind,src={json_fpath},dst={docker_json_fpath},readonly",
         "--shm-size", "32G",
         "--publish", f"{model_spec.cli_args.service_port}:{model_spec.cli_args.service_port}",  # map host port 8000 to container port 8000

--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -24,8 +24,8 @@ if project_root not in sys.path:
     sys.path.insert(0, str(project_root))
 
 from workflows.model_spec import (
-    ModelSource,
     ModelSpec,
+    ModelSource,
 )
 from workflows.run_workflows import WorkflowSetup
 from workflows.utils import (
@@ -49,14 +49,12 @@ class SetupConfig:
     persistent_volume_root: Path = None
     host_model_volume_root: Path = None
     host_tt_metal_cache_dir: Path = None
-    host_tt_metal_built_dir: Path = None
     host_model_weights_snapshot_dir: Path = None
     host_model_weights_mount_dir: Path = None
     containter_user_home: Path = Path("/home/container_app_user/")
     cache_root: Path = containter_user_home / "cache_root"
     container_model_spec_dir: Path = containter_user_home / "model_spec"
     container_tt_metal_cache_dir: Path = None
-    container_tt_metal_built_dir: Path = None
     container_model_weights_snapshot_dir: Path = None
     container_model_weights_mount_dir: Path = None
     container_model_weights_path: Path = None
@@ -86,15 +84,9 @@ class SetupConfig:
             / "tt_metal_cache"
             / f"cache_{self.model_spec.model_name}"
         )
-        # host path for tt-metal built artifacts (kernel compilation cache)
-        self.host_tt_metal_built_dir = self.host_model_volume_root / "tt_metal_built"
         # container paths
         self.container_tt_metal_cache_dir = (
             self.cache_root / "tt_metal_cache" / f"cache_{self.model_spec.model_name}"
-        )
-        # container path for tt-metal built artifacts (mounted from host)
-        self.container_tt_metal_built_dir = (
-            self.containter_user_home / "tt-metal" / "built"
         )
         self.container_readonly_model_weights_dir = (
             self.containter_user_home / "readonly_weights_mount"
@@ -534,7 +526,6 @@ class HostSetupManager:
     def make_host_dirs(self):
         self.setup_config.host_model_volume_root.mkdir(parents=True, exist_ok=True)
         self.setup_config.host_tt_metal_cache_dir.mkdir(parents=True, exist_ok=True)
-        self.setup_config.host_tt_metal_built_dir.mkdir(parents=True, exist_ok=True)
 
     def setup_weights(self):
         if not self.check_setup():


### PR DESCRIPTION
Reverts tenstorrent/tt-inference-server#1683

This PR caused this error:
```
[SERVER] 2026-01-13 11:08:53,389 - ERROR - Failed to get device runner: Unexpected device initialization error: Mesh device initialization failed: TT_THROW @ /home/container_app_user/tt-metal/tt_metal/llrt/tt_elffile.cpp:292: tt::exception
[SERVER] /home/container_app_user/tt-metal/built/94b0387e/tt-metal-cache8db029d8ad/475068638972258054/firmware/7781187423536176149//brisc/brisc.elf: cannot map elf file into memory: No such file or directory
```

CI run with this PR merge commit: https://github.com/tenstorrent/tt-shield/actions/runs/20949657563
CI run with one merge commit before: https://github.com/tenstorrent/tt-shield/actions/runs/20949682852