### PR TITLE
Fix No Device Set Error For DIT Runners

### DIFF
--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -72,7 +72,6 @@ class TTDiTRunner(BaseMetalDeviceRunner):
         os.environ.get("TT_VISIBLE_DEVICES"),
     )
     def load_weights(self):
-        self.create_pipeline()
         return True
 
     async def warmup(self) -> bool:


### PR DESCRIPTION
Before [#1750](https://github.com/tenstorrent/tt-inference-server/pull/1750) is merged, this PR will resolve issues when running DIT models.
The issue occurred because load_pipeline required already set device, which was not the case. 

Failing CI runs on nightly before changes: https://github.com/tenstorrent/tt-shield/actions/runs/21047899713/job/60531016453
Passing CI run with changes: https://github.com/tenstorrent/tt-shield/actions/runs/21073801893