### PR TITLE
Memory queue updates

### DIFF
--- a/tt-media-server/config/vllm_settings.py
+++ b/tt-media-server/config/vllm_settings.py
@@ -2,14 +2,14 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-from config.constants import SupportedModels
 from pydantic import BaseModel
 
 
 class VLLMSettings(BaseModel):
-    model: str = SupportedModels.QWEN_3_4B.value
+    model: str = "meta-llama/Llama-3.1-8B-Instruct"
     min_context_length: int = 32
-    max_model_length: int = 2048
+    max_model_length: int = 65536
     max_num_batched_tokens: int = 2048
-    max_num_seqs: int = 1  # tt-xla only supports max_num_seqs=1 currently
-    gpu_memory_utilization: float = 0.1
+    seed: int = 9472
+    max_num_seqs: int = 32  # tt-xla only supports max_num_seqs=1 currently
+    gpu_memory_utilization: float = 1

--- a/tt-media-server/device_workers/device_worker_dynamic_batch.py
+++ b/tt-media-server/device_workers/device_worker_dynamic_batch.py
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import asyncio
-import time
 from multiprocessing import Queue
 
 from device_workers.worker_utils import (
@@ -72,18 +71,8 @@ def device_worker(
             task_id = request._task_id
             result_generator = await device_runner._run_async([request])
             slot_id = request._queue_name
-            ### REMOVE THIS!!!
-            token_count = 0
-            start_time = None
-            ### REMOVE THIS!!!
             async for task_id, is_final, text in result_generator:
-                if token_count == 0:
-                    start_time = time.perf_counter()
-                token_count += 1
                 result_queue.put(is_final, text, slot_id)
-            elapsed = time.perf_counter() - start_time
-            rate = token_count / elapsed
-            logger.info(f"rate={rate:.0f} tok/s")
             logger.info(
                 f"Worker {worker_id} finished streaming chunks for task {request._task_id}"
             )

--- a/tt-media-server/domain/base_request.py
+++ b/tt-media-server/domain/base_request.py
@@ -10,3 +10,4 @@ from pydantic import BaseModel, PrivateAttr
 
 class BaseRequest(BaseModel, ABC):
     _task_id: str = PrivateAttr(default_factory=lambda: str(uuid4()))
+    _queue_name: str = PrivateAttr(default_factory=lambda: "")

--- a/tt-media-server/model_services/memory_queue.py
+++ b/tt-media-server/model_services/memory_queue.py
@@ -3,15 +3,12 @@ import time
 from multiprocessing import shared_memory
 
 import numpy as np
-from domain.completion_response import CompletionStreamChunk
 from utils.logger import TTLogger
 
 MAX_TEXT_LEN = 450
-MAX_TASK_ID_LEN = 100
 
 chunk_dtype = np.dtype(
     [
-        ("task_id", f"U{MAX_TASK_ID_LEN}"),
         ("is_final", "i4"),
         ("text", f"U{MAX_TEXT_LEN}"),
         ("item_available", "i4"),
@@ -20,16 +17,12 @@ chunk_dtype = np.dtype(
 
 
 class SharedMemoryChunkQueue:
-    def __init__(self, capacity=200000, name="chunk_queue", create=True):
+    def __init__(self, capacity=2000, name="chunk_queue", create=True):
         self.capacity = capacity
         self.chunk_size = chunk_dtype.itemsize
         self.name = name
         self.logger = TTLogger()
 
-        # Header layout:
-        # [write_idx(8)] [write_lock(4)] [pad(52)]
-        # [read_idx(8)] [read_lock(4)] [pad(52)]
-        # = 128 bytes total, with locks on separate cache lines
         self.header_offset_write = 0
         self.header_offset_write_lock = 8
         self.header_offset_read = 64
@@ -43,7 +36,6 @@ class SharedMemoryChunkQueue:
                 existing_shm = shared_memory.SharedMemory(name=name)
                 existing_shm.close()
                 existing_shm.unlink()
-                print(f"[MemoryQueue] Cleaned up existing: {name}")
             except FileNotFoundError:
                 pass
             except Exception as e:
@@ -52,24 +44,15 @@ class SharedMemoryChunkQueue:
             self.shm = shared_memory.SharedMemory(
                 name=name, create=True, size=total_size
             )
-
             self._initialize_header()
-
             self.buffer = np.ndarray(
                 (capacity,),
                 dtype=chunk_dtype,
                 buffer=self.shm.buf,
                 offset=self.header_size,
-            )
-
-            self.logger.info(
-                f"[MemoryQueue] Created: {name}, capacity={capacity}, "
-                f"size={total_size / 1024 / 1024:.2f} MB, header_size={self.header_size}"
             )
         else:
             self.shm = shared_memory.SharedMemory(name=name)
-
-            # Create buffer reference
             self.buffer = np.ndarray(
                 (capacity,),
                 dtype=chunk_dtype,
@@ -77,18 +60,11 @@ class SharedMemoryChunkQueue:
                 offset=self.header_size,
             )
 
-            self.logger.info(f"[MemoryQueue] Attached: {name}")
-
     def _initialize_header(self):
-        """Initialize header indices and locks"""
-        struct.pack_into("Q", self.shm.buf, self.header_offset_write, 0)  # write_idx
-        struct.pack_into(
-            "I", self.shm.buf, self.header_offset_write_lock, 0
-        )  # write_lock
-        struct.pack_into("Q", self.shm.buf, self.header_offset_read, 0)  # read_idx
-        struct.pack_into(
-            "I", self.shm.buf, self.header_offset_read_lock, 0
-        )  # read_lock
+        struct.pack_into("Q", self.shm.buf, self.header_offset_write, 0)
+        struct.pack_into("I", self.shm.buf, self.header_offset_write_lock, 0)
+        struct.pack_into("Q", self.shm.buf, self.header_offset_read, 0)
+        struct.pack_into("I", self.shm.buf, self.header_offset_read_lock, 0)
 
     def _get_write_idx(self) -> int:
         return struct.unpack_from("Q", self.shm.buf, self.header_offset_write)[0]
@@ -97,46 +73,14 @@ class SharedMemoryChunkQueue:
         return struct.unpack_from("Q", self.shm.buf, self.header_offset_read)[0]
 
     def _set_write_idx(self, val: int):
-        if val < 0:
-            raise ValueError(f"write_idx cannot be negative: {val}")
-
         next_write_idx = val % self.capacity
-
-        current = struct.unpack_from("Q", self.shm.buf, self.header_offset_write)[0]
-        if abs(next_write_idx - current) > 1000:
-            self.logger.warning(
-                f"Large jump in write_idx: {current} → {next_write_idx} "
-                f"(from unbounded val={val})"
-            )
-
         struct.pack_into("Q", self.shm.buf, self.header_offset_write, next_write_idx)
 
     def _set_read_idx(self, val: int):
-        if val < 0:
-            raise ValueError(f"read_idx cannot be negative: {val}")
-
         next_read_idx = val % self.capacity
-
-        current = struct.unpack_from("Q", self.shm.buf, self.header_offset_read)[0]
-        if abs(next_read_idx - current) > 1000:
-            self.logger.warning(
-                f"Large jump in read_idx: {current} → {next_read_idx} "
-                f"(from unbounded val={val})"
-            )
-
         struct.pack_into("Q", self.shm.buf, self.header_offset_read, next_read_idx)
 
-    def _get_size(self) -> int:
-        write_idx = self._get_write_idx()
-        read_idx = self._get_read_idx()
-
-        if write_idx >= read_idx:
-            return write_idx - read_idx
-        else:
-            return (self.capacity - read_idx) + write_idx
-
     def _get_next_write_slot(self) -> int:
-        # Rough size check without lock (acceptable race)
         write_idx = self._get_write_idx()
         read_idx = self._get_read_idx()
 
@@ -145,155 +89,104 @@ class SharedMemoryChunkQueue:
         else:
             size = (self.capacity - read_idx) + write_idx
 
-        if size >= self.capacity - 10:  # Leave margin
+        if size >= self.capacity - 10:
             return -1
 
-        write_idx = self._get_write_idx()
         next_write_idx = (write_idx + 1) % self.capacity
         self._set_write_idx(next_write_idx)
         return write_idx
 
-    def put(self, task_id: str, is_final: int, text: str) -> bool:
+    def put(self, is_final: int, text: str) -> bool:
         slot_idx = self._get_next_write_slot()
-
         if slot_idx == -1:
             return False
 
-        if len(task_id) > MAX_TASK_ID_LEN:
-            task_id = task_id[:MAX_TASK_ID_LEN]
         if len(text) > MAX_TEXT_LEN:
             text = text[:MAX_TEXT_LEN]
 
-        try:
-            self.buffer[slot_idx]["task_id"] = task_id
-            self.buffer[slot_idx]["text"] = text
-            self.buffer[slot_idx]["is_final"] = is_final
-            self.buffer[slot_idx]["item_available"] = 2  # ✅ Mark ready
-        except Exception as e:
-            self.logger.error(f"Error writing to slot {slot_idx}: {e}")
-            raise
-
+        self.buffer[slot_idx]["text"] = text
+        self.buffer[slot_idx]["is_final"] = is_final
+        self.buffer[slot_idx]["item_available"] = 1
         return True
 
-    def get_nowait(self):
-        """NON-BLOCKING GET - Returns None if queue is empty"""
-        try:
-            read_idx = self._get_read_idx()
-            write_idx = self._get_write_idx()
+    def get_nowait_raw(self):
+        """
+        Non-blocking get. Returns (is_final, text) or None.
+        """
+        read_idx = self._get_read_idx()
+        write_idx = self._get_write_idx()
 
-            if read_idx == write_idx:
-                return None
-
-            current_state = int(self.buffer[read_idx]["item_available"])
-
-            if current_state == 0:
-                return None
-
-            self.buffer[read_idx]["item_available"] = 0
-            self._set_read_idx(read_idx + 1)
-
-            data = self.buffer[read_idx].copy()
-
-            task_id = str(data["task_id"]).rstrip("\x00")
-            text = str(data["text"]).rstrip("\x00")
-
-            is_final = int(data["is_final"])
-
-            chunk = CompletionStreamChunk(
-                text=text,
-                index=None,
-                finish_reason=None,
-            )
-
-            if is_final == 1:
-                chunk_dict = {
-                    "type": "final_result",
-                    "result": chunk,
-                    "task_id": task_id,
-                    "return_result": False,
-                }
-            else:
-                chunk_dict = {
-                    "type": "streaming_chunk",
-                    "chunk": chunk,
-                    "task_id": task_id,
-                }
-
-            return ("1", task_id, chunk_dict)
-        except Exception as e:
-            self.logger.error(f"Error in get_nowait: {e}")
-            import traceback
-
-            self.logger.error(traceback.format_exc())
+        if read_idx == write_idx:
             return None
 
-    def get(self, timeout: float = None):
-        start_time = time.time() if timeout else None
+        if self.buffer[read_idx]["item_available"] == 0:
+            return None
+
+        self.buffer[read_idx]["item_available"] = 0
+        self._set_read_idx(read_idx + 1)
+
+        # Read directly without copy
+        is_final = int(self.buffer[read_idx]["is_final"])
+        text = str(self.buffer[read_idx]["text"]).rstrip("\x00")
+
+        return (is_final, text)
+
+    def get_blocking(self, timeout: float = 0.001):
+        """
+        ✅ Blocking get with short timeout.
+        More efficient than polling with sleep.
+
+        Returns (is_final, text) or None on timeout.
+        """
+        deadline = time.perf_counter() + timeout
+        spin_count = 0
+        max_spins = 100  # Spin briefly before sleeping
 
         while True:
-            if timeout and (time.time() - start_time) > timeout:
-                size = self._get_size()
-                print(f"[MemoryQueue] GET TIMEOUT - size={size}")
-                raise TimeoutError(f"Queue get timed out after {timeout}s")
-
             read_idx = self._get_read_idx()
             write_idx = self._get_write_idx()
 
-            if read_idx == write_idx:
-                time.sleep(0.0001)
-                continue
+            # Check if data available
+            if read_idx != write_idx and self.buffer[read_idx]["item_available"] != 0:
+                self.buffer[read_idx]["item_available"] = 0
+                self._set_read_idx(read_idx + 1)
 
-            if read_idx < 0 or read_idx >= self.capacity:
-                self.logger.error(f"CORRUPTION: read_idx {read_idx} out of bounds!")
-                raise RuntimeError("read_idx corrupted")
+                is_final = int(self.buffer[read_idx]["is_final"])
+                text = str(self.buffer[read_idx]["text"]).rstrip("\x00")
+                return (is_final, text)
 
-            slot_idx = read_idx
-            data = self.buffer[slot_idx].copy()
-            self.buffer[slot_idx]["item_available"] = 0
+            # Check timeout
+            if time.perf_counter() >= deadline:
+                return None
 
-            self._set_read_idx(read_idx + 1)
-            break
+            # Spin briefly, then sleep
+            spin_count += 1
+            if spin_count > max_spins:
+                time.sleep(0.00001)  # 10μs - much shorter than asyncio.sleep minimum
+                spin_count = 0
 
-        task_id = str(data["task_id"]).rstrip("\x00")
-        text = str(data["text"]).rstrip("\x00")
-        is_final = int(data["is_final"])
+    async def get_async(self, timeout: float = 0.1):
+        """
+        ✅ Async-friendly blocking get.
+        Runs blocking get in thread pool to not block event loop.
+        """
+        import asyncio
 
-        chunk = CompletionStreamChunk(
-            text=text,
-            index=None,
-            finish_reason=None,
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None,  # Default thread pool
+            self.get_blocking,
+            timeout,
         )
-
-        if is_final == 1:
-            chunk_dict = {
-                "type": "final_result",
-                "result": chunk,
-                "task_id": task_id,
-                "return_result": False,
-            }
-        else:
-            chunk_dict = {
-                "type": "streaming_chunk",
-                "chunk": chunk,
-                "task_id": task_id,
-            }
-
-        return ("1", task_id, chunk_dict)
 
     def close(self):
         try:
             self.shm.close()
-            print(f"[MemoryQueue] Closed: {self.name}")
         except Exception as e:
             self.logger.error(f"[MemoryQueue] Error closing: {e}")
-
-    def join_thread(self):
-        """Placeholder method to mimic a multiprocessing queue"""
-        return True
 
     def unlink(self):
         try:
             self.shm.unlink()
-            print(f"[MemoryQueue] Unlinked: {self.name}")
         except Exception as e:
             self.logger.error(f"[MemoryQueue] Error unlinking: {e}")

--- a/tt-media-server/model_services/memory_queue.py
+++ b/tt-media-server/model_services/memory_queue.py
@@ -1,12 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
 import struct
+import threading
 import time
 from multiprocessing import shared_memory
+from typing import Optional
 
 import numpy as np
 from utils.logger import TTLogger
 
 MAX_TEXT_LEN = 450
+MAX_SLOTS = 1000  # Maximum concurrent requests
+CHUNKS_PER_SLOT = 4000  # Maximum chunks per request/slot
 
+# Chunk data structure
 chunk_dtype = np.dtype(
     [
         ("is_final", "i4"),
@@ -15,178 +24,756 @@ chunk_dtype = np.dtype(
     ]
 )
 
+# Slot header structure (per-slot read/write indices)
+# Each slot has: write_idx (8 bytes), read_idx (8 bytes), in_use flag (4 bytes), padding (12 bytes) = 32 bytes
+SLOT_HEADER_SIZE = 32
+
+# Global header structure (128 bytes):
+# - bytes 0-7: capacity_per_slot (Q)
+# - bytes 8-15: max_slots (Q)
+# - bytes 16-23: chunk_size (Q)
+# - bytes 24-127: reserved
+GLOBAL_HEADER_SIZE = 128
+
 
 class SharedMemoryChunkQueue:
-    def __init__(self, capacity=2000, name="chunk_queue", create=True):
-        self.capacity = capacity
-        self.chunk_size = chunk_dtype.itemsize
+    """
+    Shared memory queue with support for multiple concurrent request slots.
+
+    Memory Layout:
+    - Global header (128 bytes): metadata including capacity_per_slot, max_slots
+    - Slot headers (MAX_SLOTS * SLOT_HEADER_SIZE): per-slot read/write indices
+    - Chunk data (MAX_SLOTS * CHUNKS_PER_SLOT * chunk_size): actual data
+
+    Each slot has its own circular buffer of CHUNKS_PER_SLOT chunks.
+    Writers attach with a specific offset (slot_id) to write to their reserved slot.
+    """
+
+    def __init__(
+        self,
+        capacity_per_slot: int = CHUNKS_PER_SLOT,
+        max_slots: int = MAX_SLOTS,
+        name: str = "chunk_queue",
+        create: bool = True,
+        slot_id: Optional[int] = None,
+    ):
+        """
+        Initialize the shared memory queue.
+
+        Args:
+            capacity_per_slot: Number of chunks per slot (default: 4000) - ignored when create=False
+            max_slots: Maximum number of concurrent slots/requests (default: 1000) - ignored when create=False
+            name: Shared memory name
+            create: If True, create new shared memory; if False, attach to existing
+            slot_id: Slot ID for writers to attach to (None for creator/manager)
+        """
         self.name = name
+        self.slot_id = slot_id
+        self.chunk_size = chunk_dtype.itemsize
         self.logger = TTLogger()
 
-        self.header_offset_write = 0
-        self.header_offset_write_lock = 8
-        self.header_offset_read = 64
-        self.header_offset_read_lock = 72
-        self.header_size = 128
-
-        total_size = self.header_size + (self.chunk_size * capacity)
+        # Global header layout
+        self.global_header_size = GLOBAL_HEADER_SIZE
+        self.slot_manager = SlotManager(self)
 
         if create:
-            try:
-                existing_shm = shared_memory.SharedMemory(name=name)
-                existing_shm.close()
-                existing_shm.unlink()
-            except FileNotFoundError:
-                pass
-            except Exception as e:
-                self.logger.error(f"[MemoryQueue] Cleanup warning: {e}")
-
-            self.shm = shared_memory.SharedMemory(
-                name=name, create=True, size=total_size
-            )
-            self._initialize_header()
-            self.buffer = np.ndarray(
-                (capacity,),
-                dtype=chunk_dtype,
-                buffer=self.shm.buf,
-                offset=self.header_size,
-            )
+            # Use provided parameters for creation
+            self.capacity_per_slot = capacity_per_slot
+            self.max_slots = max_slots
+            self._calculate_layout()
+            total_size = self.data_offset + (self.chunk_size * self.total_chunks)
+            self._create_shared_memory(name, total_size)
         else:
-            self.shm = shared_memory.SharedMemory(name=name)
-            self.buffer = np.ndarray(
-                (capacity,),
-                dtype=chunk_dtype,
-                buffer=self.shm.buf,
-                offset=self.header_size,
+            # Attach first, then read parameters from header
+            self._attach_shared_memory(name)
+
+    def _calculate_layout(self):
+        """Calculate memory layout based on capacity_per_slot and max_slots."""
+        # Slot headers layout
+        self.slot_headers_offset = self.global_header_size
+        self.slot_headers_size = self.max_slots * SLOT_HEADER_SIZE
+
+        # Chunk data layout
+        self.data_offset = self.slot_headers_offset + self.slot_headers_size
+        self.total_chunks = self.max_slots * self.capacity_per_slot
+
+    def _create_shared_memory(self, name: str, total_size: int):
+        """Create new shared memory and initialize headers."""
+        try:
+            existing_shm = shared_memory.SharedMemory(name=name)
+            existing_shm.close()
+            existing_shm.unlink()
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            self.logger.error(f"[MemoryQueue] Cleanup warning: {e}")
+
+        self.shm = shared_memory.SharedMemory(name=name, create=True, size=total_size)
+        self._write_global_header()
+        self._initialize_all_headers()
+        self._create_buffer()
+
+    def _attach_shared_memory(self, name: str):
+        """Attach to existing shared memory and read configuration from header."""
+        self.shm = shared_memory.SharedMemory(name=name)
+        self._read_global_header()
+        self._calculate_layout()
+        self._create_buffer()
+
+    def _write_global_header(self):
+        """Write configuration to global header."""
+        struct.pack_into("Q", self.shm.buf, 0, self.capacity_per_slot)
+        struct.pack_into("Q", self.shm.buf, 8, self.max_slots)
+        struct.pack_into("Q", self.shm.buf, 16, self.chunk_size)
+
+    def _read_global_header(self):
+        """Read configuration from global header."""
+        self.capacity_per_slot = struct.unpack_from("Q", self.shm.buf, 0)[0]
+        self.max_slots = struct.unpack_from("Q", self.shm.buf, 8)[0]
+        stored_chunk_size = struct.unpack_from("Q", self.shm.buf, 16)[0]
+
+        # Validate chunk size matches
+        if stored_chunk_size != 0 and stored_chunk_size != self.chunk_size:
+            self.logger.warning(
+                f"[MemoryQueue] Chunk size mismatch: stored={stored_chunk_size}, current={self.chunk_size}"
             )
 
-    def _initialize_header(self):
-        struct.pack_into("Q", self.shm.buf, self.header_offset_write, 0)
-        struct.pack_into("I", self.shm.buf, self.header_offset_write_lock, 0)
-        struct.pack_into("Q", self.shm.buf, self.header_offset_read, 0)
-        struct.pack_into("I", self.shm.buf, self.header_offset_read_lock, 0)
+        self.logger.debug(
+            f"[MemoryQueue] Attached with capacity_per_slot={self.capacity_per_slot}, "
+            f"max_slots={self.max_slots}"
+        )
 
-    def _get_write_idx(self) -> int:
-        return struct.unpack_from("Q", self.shm.buf, self.header_offset_write)[0]
+    def _create_buffer(self):
+        """Create numpy buffer view over shared memory."""
+        self.buffer = np.ndarray(
+            (self.total_chunks,),
+            dtype=chunk_dtype,
+            buffer=self.shm.buf,
+            offset=self.data_offset,
+        )
 
-    def _get_read_idx(self) -> int:
-        return struct.unpack_from("Q", self.shm.buf, self.header_offset_read)[0]
+    def _initialize_all_headers(self):
+        """Initialize global header and all slot headers."""
+        # Initialize all slot headers
+        for slot in range(self.max_slots):
+            self._initialize_slot_header(slot)
 
-    def _set_write_idx(self, val: int):
-        next_write_idx = val % self.capacity
-        struct.pack_into("Q", self.shm.buf, self.header_offset_write, next_write_idx)
+    def _initialize_slot_header(self, slot_id: int):
+        """Initialize a single slot's header."""
+        base = self._get_slot_header_offset(slot_id)
+        struct.pack_into("Q", self.shm.buf, base, 0)  # write_idx
+        struct.pack_into("Q", self.shm.buf, base + 8, 0)  # read_idx
+        struct.pack_into("I", self.shm.buf, base + 16, 0)  # in_use flag (0 = free)
+        struct.pack_into("I", self.shm.buf, base + 20, 0)  # reserved
 
-    def _set_read_idx(self, val: int):
-        next_read_idx = val % self.capacity
-        struct.pack_into("Q", self.shm.buf, self.header_offset_read, next_read_idx)
+    def _get_slot_header_offset(self, slot_id: int) -> int:
+        """Get the byte offset for a slot's header."""
+        return self.slot_headers_offset + (slot_id * SLOT_HEADER_SIZE)
 
-    def _get_next_write_slot(self) -> int:
-        write_idx = self._get_write_idx()
-        read_idx = self._get_read_idx()
+    def _get_slot_data_offset(self, slot_id: int) -> int:
+        """Get the starting chunk index for a slot's data."""
+        return slot_id * self.capacity_per_slot
 
+    # Slot header accessors
+    def _get_write_idx(self, slot_id: int) -> int:
+        base = self._get_slot_header_offset(slot_id)
+        return struct.unpack_from("Q", self.shm.buf, base)[0]
+
+    def _set_write_idx(self, slot_id: int, val: int):
+        base = self._get_slot_header_offset(slot_id)
+        struct.pack_into("Q", self.shm.buf, base, val % self.capacity_per_slot)
+
+    def _get_read_idx(self, slot_id: int) -> int:
+        base = self._get_slot_header_offset(slot_id)
+        return struct.unpack_from("Q", self.shm.buf, base + 8)[0]
+
+    def _set_read_idx(self, slot_id: int, val: int):
+        base = self._get_slot_header_offset(slot_id)
+        struct.pack_into("Q", self.shm.buf, base + 8, val % self.capacity_per_slot)
+
+    def _get_slot_in_use(self, slot_id: int) -> bool:
+        base = self._get_slot_header_offset(slot_id)
+        return struct.unpack_from("I", self.shm.buf, base + 16)[0] == 1
+
+    def _set_slot_in_use(self, slot_id: int, in_use: bool):
+        base = self._get_slot_header_offset(slot_id)
+        struct.pack_into("I", self.shm.buf, base + 16, 1 if in_use else 0)
+
+    def _get_chunk_index(self, slot_id: int, local_idx: int) -> int:
+        """Convert slot-local index to global buffer index."""
+        return self._get_slot_data_offset(slot_id) + local_idx
+
+    # Write operations (for workers)
+    def put(self, is_final: int, text: str, slot_id: Optional[int] = None) -> bool:
+        """
+        Write a chunk to a slot.
+
+        Args:
+            is_final: 1 if this is the final chunk, 0 otherwise
+            text: Text content to write
+            slot_id: Slot to write to (uses self.slot_id if not provided)
+
+        Returns:
+            True if successful, False if slot is full
+        """
+        slot = slot_id if slot_id is not None else self.slot_id
+        if slot is None:
+            raise ValueError("No slot_id specified for write operation")
+
+        write_idx = self._get_write_idx(slot)
+        read_idx = self._get_read_idx(slot)
+
+        # Calculate current size
         if write_idx >= read_idx:
             size = write_idx - read_idx
         else:
-            size = (self.capacity - read_idx) + write_idx
+            size = (self.capacity_per_slot - read_idx) + write_idx
 
-        if size >= self.capacity - 10:
-            return -1
-
-        next_write_idx = (write_idx + 1) % self.capacity
-        self._set_write_idx(next_write_idx)
-        return write_idx
-
-    def put(self, is_final: int, text: str) -> bool:
-        slot_idx = self._get_next_write_slot()
-        if slot_idx == -1:
+        # Check if full (leave some buffer)
+        if size >= self.capacity_per_slot - 2:
             return False
 
+        # Truncate text if needed
         if len(text) > MAX_TEXT_LEN:
             text = text[:MAX_TEXT_LEN]
 
-        self.buffer[slot_idx]["text"] = text
-        self.buffer[slot_idx]["is_final"] = is_final
-        self.buffer[slot_idx]["item_available"] = 1
+        # Write to buffer
+        chunk_idx = self._get_chunk_index(slot, write_idx)
+        self.buffer[chunk_idx]["text"] = text
+        self.buffer[chunk_idx]["is_final"] = is_final
+        self.buffer[chunk_idx]["item_available"] = 1
+
+        # Advance write index
+        self._set_write_idx(slot, write_idx + 1)
         return True
 
-    def get_nowait_raw(self):
+    # Read operations (for consumers)
+    def get_nowait(self, slot_id: int) -> Optional[tuple]:
         """
-        Non-blocking get. Returns (is_final, text) or None.
+        Non-blocking read from a slot.
+
+        Args:
+            slot_id: Slot to read from
+
+        Returns:
+            (is_final, text) tuple or None if no data available
         """
-        read_idx = self._get_read_idx()
-        write_idx = self._get_write_idx()
+        read_idx = self._get_read_idx(slot_id)
+        write_idx = self._get_write_idx(slot_id)
 
         if read_idx == write_idx:
             return None
 
-        if self.buffer[read_idx]["item_available"] == 0:
+        chunk_idx = self._get_chunk_index(slot_id, read_idx)
+
+        if self.buffer[chunk_idx]["item_available"] == 0:
             return None
 
-        self.buffer[read_idx]["item_available"] = 0
-        self._set_read_idx(read_idx + 1)
+        # Mark as read
+        self.buffer[chunk_idx]["item_available"] = 0
 
-        # Read directly without copy
-        is_final = int(self.buffer[read_idx]["is_final"])
-        text = str(self.buffer[read_idx]["text"]).rstrip("\x00")
+        # Read data
+        is_final = int(self.buffer[chunk_idx]["is_final"])
+        text = str(self.buffer[chunk_idx]["text"]).rstrip("\x00")
+
+        # Advance read index
+        self._set_read_idx(slot_id, read_idx + 1)
 
         return (is_final, text)
 
-    def get_blocking(self, timeout: float = 0.001):
+    def read_batch(self, slot_id: int, max_items: int = 1000) -> list:
         """
-        ✅ Blocking get with short timeout.
-        More efficient than polling with sleep.
+        Read all available data from a slot (batch read).
 
-        Returns (is_final, text) or None on timeout.
+        Args:
+            slot_id: Slot to read from
+            max_items: Maximum number of items to read in one batch
+
+        Returns:
+            List of (is_final, text) tuples
+        """
+        results = []
+
+        read_idx = self._get_read_idx(slot_id)
+        write_idx = self._get_write_idx(slot_id)
+
+        # Nothing to read
+        if read_idx == write_idx:
+            return results  # Return empty list, not None
+
+        for _ in range(max_items):
+            if read_idx == write_idx:
+                break  # No more data
+
+            chunk_idx = self._get_chunk_index(slot_id, read_idx)
+
+            if self.buffer[chunk_idx]["item_available"] == 0:
+                break
+
+            # Mark as read
+            self.buffer[chunk_idx]["item_available"] = 0
+
+            # Read data
+            is_final = int(self.buffer[chunk_idx]["is_final"])
+            text = str(self.buffer[chunk_idx]["text"]).rstrip("\x00")
+
+            # Advance read index
+            read_idx += 1
+
+            # Add to results (including final chunk!)
+            results.append((is_final, text))
+
+            # Stop after final chunk
+            if is_final == 1:
+                break
+
+        # Update read index after all reads
+        self._set_read_idx(slot_id, read_idx)
+
+        return results
+
+    def read_all_slots_batch(
+        self, slot_ids: list[int], max_items_per_slot: int = 100
+    ) -> dict[int, list[tuple[int, str]]]:
+        """
+        Batch read from multiple slots at once.
+
+        Reads all available data from each specified slot and returns
+        a dictionary mapping slot IDs to their data.
+
+        Args:
+            slot_ids: List of slot IDs to read from
+            max_items_per_slot: Maximum items to read per slot
+
+        Returns:
+            Dictionary mapping slot_id -> list of (is_final, text) tuples.
+            Only slots with data are included in the result.
+
+        Example:
+            {
+                0: [(0, "token1"), (0, "token2"), (1, "[DONE]")],
+                3: [(0, "hello"), (0, "world")],
+            }
+        """
+        results = {}
+
+        for slot_id in slot_ids:
+            batch = self.read_batch(slot_id, max_items_per_slot)
+            if batch:  # Only include slots that have data
+                results[slot_id] = batch
+
+        return results
+
+    def read_all_active_slots_batch(
+        self, max_items_per_slot: int = 15000
+    ) -> dict[int, list[tuple[int, str]]]:
+        """
+        Batch read from ALL active (in-use) slots.
+
+        Uses SlotManager to get only allocated slots instead of scanning all slots.
+
+        Args:
+            max_items_per_slot: Maximum items to read per slot
+
+        Returns:
+            Dictionary mapping slot_id -> list of (is_final, text) tuples.
+            Only slots with data are included in the result.
+
+        Example:
+            {
+                0: [(0, "token1"), (0, "token2")],
+                5: [(0, "data"), (1, "[DONE]")],
+                12: [(0, "more"), (0, "tokens")],
+            }
+        """
+        results = {}
+
+        # Get only the allocated slots from slot_manager
+        allocated_slots = self.slot_manager.get_all_allocated_slots()
+
+        for slot_id in allocated_slots:
+            batch = self.read_batch(slot_id, max_items_per_slot)
+            if batch:  # Only include slots that have data
+                results[slot_id] = batch
+
+        return results
+
+    def get_blocking(self, slot_id: int, timeout: float = 0.001) -> Optional[tuple]:
+        """
+        Blocking read with timeout.
+
+        Args:
+            slot_id: Slot to read from
+            timeout: Maximum time to wait in seconds
+
+        Returns:
+            (is_final, text) tuple or None on timeout
         """
         deadline = time.perf_counter() + timeout
         spin_count = 0
-        max_spins = 100  # Spin briefly before sleeping
+        max_spins = 100
 
         while True:
-            read_idx = self._get_read_idx()
-            write_idx = self._get_write_idx()
+            result = self.get_nowait(slot_id)
+            if result is not None:
+                return result
 
-            # Check if data available
-            if read_idx != write_idx and self.buffer[read_idx]["item_available"] != 0:
-                self.buffer[read_idx]["item_available"] = 0
-                self._set_read_idx(read_idx + 1)
-
-                is_final = int(self.buffer[read_idx]["is_final"])
-                text = str(self.buffer[read_idx]["text"]).rstrip("\x00")
-                return (is_final, text)
-
-            # Check timeout
             if time.perf_counter() >= deadline:
                 return None
 
-            # Spin briefly, then sleep
             spin_count += 1
             if spin_count > max_spins:
-                time.sleep(0.00001)  # 10μs - much shorter than asyncio.sleep minimum
+                time.sleep(0.00001)  # 10μs
                 spin_count = 0
 
-    async def get_async(self, timeout: float = 0.1):
+    async def get_async(self, slot_id: int, timeout: float = 0.1) -> Optional[tuple]:
         """
-        ✅ Async-friendly blocking get.
-        Runs blocking get in thread pool to not block event loop.
+        Async-friendly blocking read.
+
+        Args:
+            slot_id: Slot to read from
+            timeout: Maximum time to wait in seconds
+
+        Returns:
+            (is_final, text) tuple or None on timeout
         """
         import asyncio
 
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(
-            None,  # Default thread pool
+            None,
             self.get_blocking,
+            slot_id,
             timeout,
         )
 
+    def get_slot_size(self, slot_id: int) -> int:
+        """Get the number of unread items in a slot."""
+        write_idx = self._get_write_idx(slot_id)
+        read_idx = self._get_read_idx(slot_id)
+
+        if write_idx >= read_idx:
+            return write_idx - read_idx
+        else:
+            return (self.capacity_per_slot - read_idx) + write_idx
+
+    def is_slot_empty(self, slot_id: int) -> bool:
+        """Check if a slot has no unread data."""
+        return self._get_read_idx(slot_id) == self._get_write_idx(slot_id)
+
     def close(self):
+        """Close the shared memory (does not unlink)."""
         try:
             self.shm.close()
         except Exception as e:
             self.logger.error(f"[MemoryQueue] Error closing: {e}")
 
     def unlink(self):
+        """Unlink (delete) the shared memory."""
         try:
             self.shm.unlink()
         except Exception as e:
             self.logger.error(f"[MemoryQueue] Error unlinking: {e}")
+
+
+class SlotManager:
+    """
+    Thread-safe manager for allocating and freeing slots in SharedMemoryChunkQueue.
+
+    This manager handles:
+    - Reserving slots for new requests with thread-safe locking
+    - Freeing slots when requests complete
+    - Tracking which slots are in use and which request IDs own them
+    - Circular buffer allocation pattern for efficient slot reuse
+
+    Usage:
+        manager = SlotManager(queue)
+        slot_id = manager.reserve_slot(request_id="abc-123")  # Get a free slot
+        # ... use slot_id for reading/writing ...
+        manager.free_slot(slot_id)  # Release the slot
+    """
+
+    def __init__(self, queue: SharedMemoryChunkQueue):
+        """
+        Initialize the slot manager.
+
+        Args:
+            queue: The SharedMemoryChunkQueue to manage slots for
+        """
+        self.queue = queue
+        self.lock = threading.Lock()
+        self.logger = TTLogger()
+
+        # Local tracking of allocated slots (for faster lookups)
+        self._allocated_slots: set = set()
+
+        # Mapping: slot_id -> request_id
+        self._slot_to_request: dict[int, str] = {}
+
+        # Mapping: request_id -> slot_id (reverse lookup)
+        self._request_to_slot: dict[str, int] = {}
+
+        # Circular buffer pointer - next slot to check for allocation
+        self._next_slot_pointer: int = 0
+
+    def reserve_slot(self, request_id: str) -> Optional[int]:
+        """
+        Reserve a free slot for a new request.
+
+        Args:
+            request_id: UUID4 string identifying the request
+
+        Returns:
+            slot_id if successful, None if no slots available
+
+        Thread-safe: Uses locking to prevent race conditions.
+        """
+        with self.lock:
+            # Check if request already has a slot
+            if request_id in self._request_to_slot:
+                existing_slot = self._request_to_slot[request_id]
+                self.logger.warning(
+                    f"[SlotManager] Request {request_id} already has slot {existing_slot}"
+                )
+                return existing_slot
+
+            slot_id = self._find_next_free_slot_unlocked()
+            if slot_id is None:
+                self.logger.warning("[SlotManager] No free slots available")
+                return None
+
+            # Reserve the slot
+            self.queue._set_slot_in_use(slot_id, True)
+            self.queue._initialize_slot_header(slot_id)
+            self.queue._set_slot_in_use(slot_id, True)  # Re-set after init
+
+            # Track allocation
+            self._allocated_slots.add(slot_id)
+            self._slot_to_request[slot_id] = request_id
+            self._request_to_slot[request_id] = slot_id
+
+            self.logger.debug(
+                f"[SlotManager] Reserved slot {slot_id} for request {request_id}"
+            )
+            return slot_id
+
+    def _find_next_free_slot_unlocked(self) -> Optional[int]:
+        """
+        Find the next free slot using circular buffer pattern.
+        Must be called with lock held.
+
+        Returns:
+            slot_id if found, None if all slots are full
+        """
+        max_slots = self.queue.max_slots
+
+        # Start from current pointer and wrap around
+        for _ in range(max_slots):
+            slot_id = self._next_slot_pointer
+
+            # Advance pointer (circular)
+            self._next_slot_pointer = (self._next_slot_pointer + 1) % max_slots
+
+            # Check if slot is free
+            if slot_id not in self._allocated_slots and not self.queue._get_slot_in_use(
+                slot_id
+            ):
+                return slot_id
+
+        return None
+
+    def get_next_free_slot(self) -> Optional[int]:
+        """
+        Get the next free slot ID without reserving it.
+        Useful for checking availability before committing.
+
+        Returns:
+            slot_id if a free slot exists, None if all slots are full
+
+        Thread-safe: Uses locking.
+        """
+        with self.lock:
+            max_slots = self.queue.max_slots
+            pointer = self._next_slot_pointer
+
+            for _ in range(max_slots):
+                slot_id = pointer
+                pointer = (pointer + 1) % max_slots
+
+                if (
+                    slot_id not in self._allocated_slots
+                    and not self.queue._get_slot_in_use(slot_id)
+                ):
+                    return slot_id
+
+            return None
+
+    def release_slot(self, slot_id: int) -> bool:
+        """
+        Free a previously reserved slot.
+
+        Args:
+            slot_id: The slot to free
+
+        Returns:
+            True if successful, False if slot was not allocated
+
+        Thread-safe: Uses locking to prevent race conditions.
+        """
+        with self.lock:
+            if slot_id < 0 or slot_id >= self.queue.max_slots:
+                self.logger.error(f"[SlotManager] Invalid slot_id: {slot_id}")
+                return False
+
+            if slot_id not in self._allocated_slots:
+                self.logger.warning(
+                    f"[SlotManager] Slot {slot_id} was not allocated by this manager"
+                )
+                return False
+
+            # Get request_id for logging
+            request_id = self._slot_to_request.get(slot_id, "unknown")
+
+            # Clear the slot data
+            self._clear_slot_data(slot_id)
+
+            # Mark as free
+            self.queue._set_slot_in_use(slot_id, False)
+            self._allocated_slots.discard(slot_id)
+
+            # Remove from mappings
+            if slot_id in self._slot_to_request:
+                del self._slot_to_request[slot_id]
+            if request_id in self._request_to_slot:
+                del self._request_to_slot[request_id]
+
+            self.logger.debug(
+                f"[SlotManager] Freed slot {slot_id} (was request {request_id})"
+            )
+            return True
+
+    def free_slot_by_request(self, request_id: str) -> bool:
+        """
+        Free a slot by request ID.
+
+        Args:
+            request_id: The request ID whose slot should be freed
+
+        Returns:
+            True if successful, False if request not found
+
+        Thread-safe: Uses locking.
+        """
+        with self.lock:
+            if request_id not in self._request_to_slot:
+                self.logger.warning(
+                    f"[SlotManager] Request {request_id} has no allocated slot"
+                )
+                return False
+
+            slot_id = self._request_to_slot[request_id]
+
+            # Clear the slot data
+            self._clear_slot_data(slot_id)
+
+            # Mark as free
+            self.queue._set_slot_in_use(slot_id, False)
+            self._allocated_slots.discard(slot_id)
+
+            # Remove from mappings
+            del self._slot_to_request[slot_id]
+            del self._request_to_slot[request_id]
+
+            self.logger.debug(
+                f"[SlotManager] Freed slot {slot_id} for request {request_id}"
+            )
+            return True
+
+    def get_slot_by_request(self, request_id: str) -> Optional[int]:
+        """
+        Get the slot ID for a given request ID.
+
+        Args:
+            request_id: The request ID to look up
+
+        Returns:
+            slot_id if found, None otherwise
+
+        Thread-safe: Uses locking.
+        """
+        with self.lock:
+            return self._request_to_slot.get(request_id)
+
+    def get_request_by_slot(self, slot_id: int) -> Optional[str]:
+        """
+        Get the request ID for a given slot ID.
+
+        Args:
+            slot_id: The slot ID to look up
+
+        Returns:
+            request_id if found, None otherwise
+
+        Thread-safe: Uses locking.
+        """
+        with self.lock:
+            return self._slot_to_request.get(slot_id)
+
+    def _clear_slot_data(self, slot_id: int):
+        """Clear all data in a slot's buffer."""
+        start_idx = self.queue._get_slot_data_offset(slot_id)
+        end_idx = start_idx + self.queue.capacity_per_slot
+
+        for idx in range(start_idx, end_idx):
+            self.queue.buffer[idx]["item_available"] = 0
+            self.queue.buffer[idx]["is_final"] = 0
+            self.queue.buffer[idx]["text"] = ""
+
+    def get_allocated_count(self) -> int:
+        """Get the number of currently allocated slots."""
+        with self.lock:
+            return len(self._allocated_slots)
+
+    def get_free_count(self) -> int:
+        """Get the number of available slots."""
+        with self.lock:
+            return self.queue.max_slots - len(self._allocated_slots)
+
+    def is_slot_allocated(self, slot_id: int) -> bool:
+        """Check if a slot is currently allocated."""
+        with self.lock:
+            return slot_id in self._allocated_slots
+
+    def get_all_allocated_slots(self) -> list:
+        """Get a list of all currently allocated slot IDs."""
+        with self.lock:
+            return list(self._allocated_slots)
+
+    def get_all_request_mappings(self) -> dict[str, int]:
+        """
+        Get a copy of all request_id -> slot_id mappings.
+
+        Returns:
+            Dictionary mapping request IDs to slot IDs
+
+        Thread-safe: Uses locking.
+        """
+        with self.lock:
+            return dict(self._request_to_slot)
+
+    def force_free_all(self):
+        """
+        Force free all slots (use with caution, for cleanup/reset).
+
+        This will free all slots regardless of their state.
+        """
+        with self.lock:
+            for slot_id in list(self._allocated_slots):
+                self._clear_slot_data(slot_id)
+                self.queue._set_slot_in_use(slot_id, False)
+
+            self._allocated_slots.clear()
+            self._slot_to_request.clear()
+            self._request_to_slot.clear()
+            self._next_slot_pointer = 0
+            self.logger.info("[SlotManager] Force freed all slots")

--- a/tt-media-server/model_services/scheduler.py
+++ b/tt-media-server/model_services/scheduler.py
@@ -107,7 +107,7 @@ class Scheduler:
     @log_execution_time("Scheduler - starting workers")
     def start_workers(self):
         # keep result listener in the main event loop
-        self.listener_task_ref = asyncio.create_task(self.result_listener())
+        # self.listener_task_ref = asyncio.create_task(self.result_listener())
 
         # keep device warmup listener in the main event loop, it'll close soon
         self.device_warmup_listener_ref = asyncio.create_task(

--- a/tt-media-server/model_services/scheduler.py
+++ b/tt-media-server/model_services/scheduler.py
@@ -107,7 +107,9 @@ class Scheduler:
     @log_execution_time("Scheduler - starting workers")
     def start_workers(self):
         # keep result listener in the main event loop
-        # self.listener_task_ref = asyncio.create_task(self.result_listener())
+        # listener is not needed for the memory queue results
+        if not self.settings.use_memory_queue:
+            self.listener_task_ref = asyncio.create_task(self.result_listener())
 
         # keep device warmup listener in the main event loop, it'll close soon
         self.device_warmup_listener_ref = asyncio.create_task(
@@ -253,82 +255,6 @@ class Scheduler:
                 self.logger.error(f"Error in result_listener: {e}")
 
         self.logger.info("Result listener stopped")
-
-    async def demux_result_listener(self, slot_manager):
-        """
-        Demultiplexed result listener that batch reads from all active slots
-        and distributes results to appropriate result queues.
-
-        Uses read_all_slots_batch for efficient batch reading from SharedMemoryChunkQueue.
-
-        Args:
-            slot_manager: SlotManager instance for slot_id -> task_id mapping
-        """
-        self.logger.info("Demux result listener started")
-
-        # Local cache for slot_id -> task_id mapping (for slots not in slot_manager)
-        local_slot_mapping: dict[int, str] = {}
-
-        while self.listener_running:
-            try:
-                result_found = False
-
-                # Batch read from all worker queues
-                for worker_index, result_queue in self.result_queues_by_worker.items():
-                    # Batch read from all active slots
-                    all_slot_data = result_queue.read_all_active_slots_batch()
-
-                    if not all_slot_data:
-                        continue
-
-                    result_found = True
-
-                    # Process each slot's data
-                    for slot_id, chunks in all_slot_data.items():
-                        # Get task_id from slot_manager first
-                        task_id = slot_manager.get_request_by_slot(slot_id)
-
-                        # Fall back to local mapping if not found
-                        if task_id is None:
-                            continue
-
-                        # Get the result queue for this task
-                        queue_obj = self.result_queues.get(task_id)
-
-                        if queue_obj is None:
-                            self.logger.warning(
-                                f"[DemuxListener] No result queue for task {task_id} "
-                                f"(slot {slot_id}), skipping {len(chunks)} chunks"
-                            )
-                            continue
-
-                        # Distribute all chunks to the result queue
-                        for is_final, text in chunks:
-                            try:
-                                queue_obj.put_nowait(text)
-
-                                # If final chunk, clean up mapping
-                                if is_final:
-                                    local_slot_mapping.pop(slot_id, None)
-                                    self.logger.debug(
-                                        f"[DemuxListener] Final chunk for slot {slot_id}, "
-                                        f"task {task_id}"
-                                    )
-                            except Exception as e:
-                                self.logger.error(
-                                    f"[DemuxListener] Error putting to queue for "
-                                    f"task {task_id}: {e}"
-                                )
-
-                # Yield to event loop if no results found
-                if not result_found:
-                    await asyncio.sleep(0)
-
-            except Exception as e:
-                self.logger.error(f"Error in demux_result_listener: {e}", exc_info=True)
-                await asyncio.sleep(0.001)
-
-        self.logger.info("Demux result listener stopped")
 
     async def error_listener(self):
         while self.listener_running:

--- a/tt-media-server/model_services/scheduler.py
+++ b/tt-media-server/model_services/scheduler.py
@@ -46,7 +46,7 @@ class Scheduler:
                 )
         else:
             self.result_queues_by_worker[0] = (
-                SharedMemoryChunkQueue(4000, 100, name="chunk_queue_0", create=True)
+                SharedMemoryChunkQueue(16000, 100, name="chunk_queue_0", create=True)
                 if self.settings.use_memory_queue
                 else Queue()
             )

--- a/tt-media-server/performance_tests/tpot_test.py
+++ b/tt-media-server/performance_tests/tpot_test.py
@@ -1,0 +1,506 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import asyncio
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import aiohttp
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@dataclass
+class TokenTimingMetrics:
+    request_id: int = 1
+    total_tokens: int = 0
+    first_token_time_ms: float = 0
+    total_time_ms: float = 0
+    tokens_per_second: float = 0
+    token_timestamps: List[float] = field(default_factory=list)
+    batch_sizes: List[int] = field(default_factory=list)  # Track batch sizes
+
+    def __str__(self) -> str:
+        return (
+            f"Request {self.request_id}: "
+            f"{self.total_tokens} tokens in {self.total_time_ms:.1f}ms "
+            f"({self.tokens_per_second:.0f} tok/s)"
+        )
+
+
+@dataclass
+class AggregatedMetrics:
+    num_requests: int = 0
+    total_tokens: int = 0
+    total_time_ms: float = 0
+    aggregate_tokens_per_second: float = 0
+    per_request_metrics: List[TokenTimingMetrics] = field(default_factory=list)
+    avg_first_token_time_ms: float = 0
+    avg_tokens_per_request: float = 0
+
+    def __str__(self) -> str:
+        lines = [
+            "=" * 60,
+            "AGGREGATED RESULTS",
+            "=" * 60,
+            f"Parallel requests: {self.num_requests}",
+            f"Total tokens (all requests): {self.total_tokens}",
+            f"Total time: {self.total_time_ms:.2f}ms",
+            "",
+            "=== THROUGHPUT ===",
+            f"Aggregate throughput: {self.aggregate_tokens_per_second:.0f} tokens/sec",
+            f"Avg tokens per request: {self.avg_tokens_per_request:.0f}",
+            f"Avg first token time: {self.avg_first_token_time_ms:.2f}ms",
+            "",
+            "=== PER-REQUEST BREAKDOWN ===",
+        ]
+        for m in self.per_request_metrics:
+            lines.append(f"  {m}")
+        return "\n".join(lines)
+
+
+class TokenTimingClient:
+    def __init__(self, url: str, api_key: str):
+        self.url = url
+        self.api_key = api_key
+
+    def _count_tokens_in_text(self, text: str) -> int:
+        """
+        Estimate token count from text.
+        Server may batch multiple tokens into one text chunk.
+        Simple heuristic: split by spaces and count.
+        For more accurate counting, use tiktoken or similar.
+        """
+        if not text:
+            return 0
+        # Simple word-based estimation (rough approximation)
+        # Most LLMs have ~1.3 tokens per word on average
+        words = text.split()
+        # For streaming, each "token" from server is roughly one token
+        # But if batched, we need to estimate
+        # Use character-based heuristic: ~4 chars per token average
+        char_estimate = max(1, len(text) // 4)
+        word_estimate = max(1, len(words))
+        # Return the higher estimate to be conservative
+        return max(char_estimate, word_estimate)
+
+    def _extract_text_from_chunk(self, chunk: dict) -> str:
+        """Extract text content from a chunk."""
+        if "choices" not in chunk or not chunk["choices"]:
+            return ""
+        choice = chunk["choices"][0]
+        if "text" in choice and choice["text"]:
+            return choice["text"]
+        elif "delta" in choice:
+            delta = choice["delta"]
+            if delta:
+                return delta.get("content", "") or delta.get("text", "")
+        return ""
+
+    def _has_content(self, chunk: dict) -> bool:
+        return bool(self._extract_text_from_chunk(chunk))
+
+    async def _stream_single_request(
+        self,
+        request_id: int,
+        prompt: str,
+        max_tokens: int,
+    ) -> TokenTimingMetrics:
+        """Each request gets its own session to ensure true parallelism."""
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "stream": True,
+            "temperature": 0.7,
+            "n": 1,
+            "stream_options": {"include_usage": True, "continuous_usage_stats": True},
+        }
+
+        token_timestamps = []
+        batch_sizes = []
+        start_time = time.perf_counter()
+        first_token_time = None
+        tokens_received = 0
+        chunks_received = 0
+
+        print(f"[Request {request_id}] Starting - requesting {max_tokens} tokens")
+
+        timeout = aiohttp.ClientTimeout(total=3000, sock_read=1200)
+
+        # Each request gets its own session
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            try:
+                async with session.post(
+                    self.url, headers=headers, json=payload
+                ) as response:
+                    print(
+                        f"[Request {request_id}] Connected - status {response.status}"
+                    )
+
+                    if response.status != 200:
+                        error_text = await response.text()
+                        print(
+                            f"[Request {request_id}] HTTP {response.status}: {error_text}"
+                        )
+                        raise RuntimeError(f"HTTP {response.status}")
+
+                    try:
+                        async for line in response.content:
+                            if not line:
+                                continue
+                            line_str = line.decode("utf-8").strip()
+                            if not line_str:
+                                continue
+
+                            data_str = None
+                            if line_str.startswith("data: "):
+                                data_str = line_str[6:]
+                                if data_str == "[DONE]":
+                                    break
+                            elif line_str.startswith("{"):
+                                data_str = line_str
+
+                            if data_str:
+                                try:
+                                    chunk = json.loads(data_str)
+                                    text = self._extract_text_from_chunk(chunk)
+
+                                    if text:
+                                        current_time = time.perf_counter()
+                                        chunks_received += 1
+
+                                        # Count tokens in this batch/chunk
+                                        # If server sends batched tokens, text will be longer
+                                        batch_token_count = self._count_tokens_in_text(
+                                            text
+                                        )
+                                        tokens_received += batch_token_count
+                                        batch_sizes.append(batch_token_count)
+
+                                        token_timestamps.append(
+                                            (current_time - start_time) * 1000
+                                        )
+
+                                        if first_token_time is None:
+                                            first_token_time = (
+                                                current_time - start_time
+                                            ) * 1000
+                                            print(
+                                                f"[Request {request_id}] First token at {first_token_time:.1f}ms"
+                                            )
+
+                                        # Log progress every 1000 tokens
+                                        if tokens_received % 1000 < batch_token_count:
+                                            elapsed = (current_time - start_time) * 1000
+                                            rate = tokens_received / (elapsed / 1000)
+                                            avg_batch = (
+                                                tokens_received / chunks_received
+                                            )
+                                            print(
+                                                f"[Request {request_id}] {tokens_received} tokens ({chunks_received} chunks, avg batch {avg_batch:.1f}), {rate:.0f} tok/s"
+                                            )
+                                except json.JSONDecodeError:
+                                    continue
+
+                    except aiohttp.ClientPayloadError as e:
+                        print(f"[Request {request_id}] Stream ended: {e}")
+
+            except aiohttp.ClientError as e:
+                print(f"[Request {request_id}] Client error: {e}")
+                raise
+
+        end_time = time.perf_counter()
+        total_time_ms = (end_time - start_time) * 1000
+        tps = (tokens_received / (total_time_ms / 1000)) if total_time_ms > 0 else 0
+
+        avg_batch_size = tokens_received / chunks_received if chunks_received > 0 else 0
+        print(
+            f"[Request {request_id}] Completed: {tokens_received} tokens in {chunks_received} chunks "
+            f"(avg batch {avg_batch_size:.1f}) in {total_time_ms:.1f}ms ({tps:.0f} tok/s)"
+        )
+
+        return TokenTimingMetrics(
+            request_id=request_id,
+            total_tokens=tokens_received,
+            first_token_time_ms=first_token_time or 0,
+            total_time_ms=total_time_ms,
+            tokens_per_second=tps,
+            token_timestamps=token_timestamps,
+            batch_sizes=batch_sizes,
+        )
+
+    async def measure_token_timing(
+        self, token_count: int = 100, prompt: Optional[str] = None
+    ) -> TokenTimingMetrics:
+        if prompt is None:
+            prompt = f"Generate {token_count} tokens of text about AI:"
+
+        print(f"Measuring {token_count} tokens...")
+        print(f"URL: {self.url}")
+
+        metrics = await self._stream_single_request(1, prompt, token_count)
+        return metrics
+
+    def analyze_token_intervals(self, metrics: TokenTimingMetrics) -> dict:
+        if len(metrics.token_timestamps) < 2:
+            return {"error": "Not enough tokens"}
+
+        intervals = []
+        for i in range(1, len(metrics.token_timestamps)):
+            intervals.append(
+                metrics.token_timestamps[i] - metrics.token_timestamps[i - 1]
+            )
+
+        buckets = {
+            "< 0.1ms": 0,
+            "0.1-0.5ms": 0,
+            "0.5-1ms": 0,
+            "1-5ms": 0,
+            "5-10ms": 0,
+            "> 10ms": 0,
+        }
+        for iv in intervals:
+            if iv < 0.1:
+                buckets["< 0.1ms"] += 1
+            elif iv < 0.5:
+                buckets["0.1-0.5ms"] += 1
+            elif iv < 1:
+                buckets["0.5-1ms"] += 1
+            elif iv < 5:
+                buckets["1-5ms"] += 1
+            elif iv < 10:
+                buckets["5-10ms"] += 1
+            else:
+                buckets["> 10ms"] += 1
+
+        # Batch size analysis
+        batch_analysis = {}
+        if metrics.batch_sizes:
+            batch_analysis = {
+                "avg_batch_size": sum(metrics.batch_sizes) / len(metrics.batch_sizes),
+                "max_batch_size": max(metrics.batch_sizes),
+                "min_batch_size": min(metrics.batch_sizes),
+                "num_chunks": len(metrics.batch_sizes),
+            }
+
+        return {
+            "intervals_count": len(intervals),
+            "avg_interval_ms": sum(intervals) / len(intervals),
+            "max_interval_ms": max(intervals),
+            "min_interval_ms": min(intervals),
+            "slow_intervals_count": sum(1 for iv in intervals if iv > 1.0),
+            "histogram": buckets,
+            "batch_analysis": batch_analysis,
+        }
+
+    async def run_parallel_requests(
+        self, num_requests: int = 3, tokens_per_request: int = 1000
+    ) -> AggregatedMetrics:
+        print("=" * 60)
+        print("PARALLEL REQUEST TEST")
+        print("=" * 60)
+        print(f"URL: {self.url}")
+        print(f"Parallel requests: {num_requests}")
+        print(f"Tokens per request: {tokens_per_request}")
+        print(f"Total tokens expected: {num_requests * tokens_per_request}")
+        print()
+
+        # Create separate tasks - each with its own session
+        tasks = []
+        for i in range(num_requests):
+            prompt = f"Write a very long detailed story about topic {i + 1}. Include many paragraphs:"
+            # Each task is independent with its own session
+            task = asyncio.create_task(
+                self._stream_single_request(i + 1, prompt, tokens_per_request)
+            )
+            tasks.append(task)
+
+        print(f">>> Launching {num_requests} requests in PARALLEL...")
+        start = time.perf_counter()
+
+        # Wait for all tasks to complete
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        total_time_ms = (time.perf_counter() - start) * 1000
+        print(
+            f"\n>>> All {num_requests} parallel requests completed in {total_time_ms:.1f}ms\n"
+        )
+
+        successful = []
+        for r in results:
+            if isinstance(r, TokenTimingMetrics):
+                successful.append(r)
+                print(f"  ✓ {r}")
+            else:
+                print(f"  ✗ Failed: {r}")
+
+        if not successful:
+            raise RuntimeError("All requests failed")
+
+        total_tokens = sum(m.total_tokens for m in successful)
+        agg_tps = (total_tokens / (total_time_ms / 1000)) if total_time_ms > 0 else 0
+
+        return AggregatedMetrics(
+            num_requests=len(successful),
+            total_tokens=total_tokens,
+            total_time_ms=total_time_ms,
+            aggregate_tokens_per_second=agg_tps,
+            per_request_metrics=successful,
+            avg_first_token_time_ms=sum(m.first_token_time_ms for m in successful)
+            / len(successful),
+            avg_tokens_per_request=total_tokens / len(successful),
+        )
+
+
+async def run_parallel_test():
+    """Run parallel requests test."""
+    url = os.getenv("TEST_SERVER_URL", "http://localhost:8099/v1/completions")
+    api_key = os.getenv("TEST_API_KEY", "your-secret-key")
+    num_requests = int(os.getenv("TEST_NUM_REQUESTS", "3"))
+    tokens_per_request = int(os.getenv("TEST_TOKENS_PER_REQUEST", "15000"))
+
+    print("=" * 60)
+    print("PARALLEL THROUGHPUT TEST")
+    print("=" * 60)
+    print(f"Requests: {num_requests}")
+    print(f"Tokens per request: {tokens_per_request}")
+    print(f"Total tokens expected: {num_requests * tokens_per_request}")
+    print("Target: 15,000 aggregate tokens/sec")
+    print()
+
+    try:
+        client = TokenTimingClient(url, api_key)
+        metrics = await client.run_parallel_requests(num_requests, tokens_per_request)
+
+        print(f"\n{metrics}")
+
+        # Detailed throughput logging
+        print("\n" + "=" * 60)
+        print("THROUGHPUT SUMMARY")
+        print("=" * 60)
+        print(f"Total tokens received: {metrics.total_tokens}")
+        print(
+            f"Total time: {metrics.total_time_ms:.2f}ms ({metrics.total_time_ms / 1000:.2f}s)"
+        )
+        print(
+            f"Aggregate throughput: {metrics.aggregate_tokens_per_second:.0f} tokens/sec"
+        )
+        print("Target throughput: 15,000 tokens/sec")
+        print(f"Efficiency: {(metrics.aggregate_tokens_per_second / 15000) * 100:.1f}%")
+
+        # Per-request throughput breakdown
+        print("\nPer-request throughput:")
+        for m in metrics.per_request_metrics:
+            avg_batch = sum(m.batch_sizes) / len(m.batch_sizes) if m.batch_sizes else 1
+            print(
+                f"  Request {m.request_id}: {m.tokens_per_second:.0f} tok/s "
+                f"({m.total_tokens} tokens in {len(m.batch_sizes)} chunks, "
+                f"avg batch {avg_batch:.1f}, {m.total_time_ms:.1f}ms)"
+            )
+
+        sum_individual_tps = sum(
+            m.tokens_per_second for m in metrics.per_request_metrics
+        )
+        print(f"\nSum of individual throughputs: {sum_individual_tps:.0f} tok/s")
+        print(
+            f"Aggregate throughput (total tokens / wall time): {metrics.aggregate_tokens_per_second:.0f} tok/s"
+        )
+
+        # Batch size analysis
+        all_batch_sizes = []
+        for m in metrics.per_request_metrics:
+            all_batch_sizes.extend(m.batch_sizes)
+
+        if all_batch_sizes:
+            print("\n" + "=" * 60)
+            print("BATCH SIZE ANALYSIS")
+            print("=" * 60)
+            print(f"Total chunks received: {len(all_batch_sizes)}")
+            print(
+                f"Average batch size: {sum(all_batch_sizes) / len(all_batch_sizes):.1f} tokens/chunk"
+            )
+            print(f"Max batch size: {max(all_batch_sizes)} tokens/chunk")
+            print(f"Min batch size: {min(all_batch_sizes)} tokens/chunk")
+
+        print(
+            f"\n>>> AGGREGATE THROUGHPUT: {metrics.aggregate_tokens_per_second:.0f} tokens/sec <<<"
+        )
+
+        if metrics.aggregate_tokens_per_second >= 15000:
+            print("\n✅ PASSED: >= 15,000 tok/s")
+            return True
+        else:
+            print("\n❌ FAILED: < 15,000 tok/s")
+            return False
+
+    except Exception as e:
+        print(f"❌ FAILED: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+async def run_single_test():
+    """Run single request test."""
+    url = os.getenv("TEST_SERVER_URL", "http://localhost:8099/v1/completions")
+    api_key = os.getenv("TEST_API_KEY", "your-secret-key")
+    token_count = int(os.getenv("TEST_TOKEN_COUNT", "15000"))
+
+    print("=" * 60)
+    print("SINGLE REQUEST TEST")
+    print("=" * 60)
+    print(f"Tokens: {token_count}")
+    print()
+
+    try:
+        client = TokenTimingClient(url, api_key)
+        metrics = await client.measure_token_timing(token_count=token_count)
+
+        print(f"\n{metrics}")
+
+        intervals = client.analyze_token_intervals(metrics)
+        if "error" not in intervals:
+            print("\nInterval Analysis:")
+            print(f"  Avg: {intervals['avg_interval_ms']:.4f}ms")
+            print(f"  Min: {intervals['min_interval_ms']:.4f}ms")
+            print(f"  Max: {intervals['max_interval_ms']:.4f}ms")
+
+            if intervals.get("batch_analysis"):
+                ba = intervals["batch_analysis"]
+                print("\nBatch Analysis:")
+                print(f"  Chunks received: {ba['num_chunks']}")
+                print(f"  Avg batch size: {ba['avg_batch_size']:.1f} tokens/chunk")
+                print(f"  Max batch size: {ba['max_batch_size']} tokens/chunk")
+                print(f"  Min batch size: {ba['min_batch_size']} tokens/chunk")
+
+        return metrics.tokens_per_second >= 15000
+
+    except Exception as e:
+        print(f"❌ FAILED: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+if __name__ == "__main__":
+    mode = sys.argv[1] if len(sys.argv) > 1 else "parallel"
+
+    print(f"Running TPOT performance test in '{mode}' mode...\n")
+
+    if mode == "single":
+        success = asyncio.run(run_single_test())
+    else:
+        success = asyncio.run(run_parallel_test())
+
+    sys.exit(0 if success else 1)

--- a/tt-media-server/tt_model_runners/vllm_forge_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_runner.py
@@ -10,7 +10,6 @@ from domain.completion_response import CompletionStreamChunk
 from telemetry.telemetry_client import TelemetryEvent
 from tt_model_runners.base_device_runner import BaseDeviceRunner
 from utils.decorators import log_execution_time
-from utils.text_utils import TextUtils
 from vllm import AsyncEngineArgs, AsyncLLMEngine, SamplingParams
 from vllm.sampling_params import RequestOutputKind
 
@@ -107,42 +106,14 @@ class VLLMForgeRunner(BaseDeviceRunner):
             )
             raise RuntimeError(f"Inference failed: {str(e)}") from e
 
-    async def _generate_streaming(
+    def _generate_streaming(
         self, request: CompletionRequest, sampling_params: SamplingParams
     ):
         """✅ Yields tuples of (task_id, is_final, text) to avoid pickling"""
         task_id = request._task_id
 
-        chunks = []
-        chunks_append = chunks.append
-
-        strip_eos = TextUtils.strip_eos
-
-        async for request_output in self.llm_engine.generate(
-            request.prompt, sampling_params, task_id
-        ):
-            outputs = request_output.outputs
-            if not outputs:
-                continue
-
-            for output in outputs:
-                chunk_text = output.text
-                if not chunk_text:
-                    continue
-
-                if chunk_text.endswith(("</s>", "<|endoftext|>", "<|im_end|>")):
-                    chunk_text = strip_eos(chunk_text)
-                    if not chunk_text:
-                        continue
-
-                chunks_append(chunk_text)
-
-                yield (task_id, 0, chunk_text)
-
-        # do this on purpose to avoid over max decode issues
-        yield (task_id, 1, "final_text")
-
-        self.logger.info(f"Device {self.device_id}: Streaming generation completed")
+        iterator = self.llm_engine.generate(request.prompt, sampling_params, task_id)
+        return iterator
 
     async def _generate_non_streaming(
         self, request: CompletionRequest, sampling_params: SamplingParams


### PR DESCRIPTION
Changes:

- Use one memory queue per request and skip asyncio.queues
- Memory queue needs chunks only since there is one queue per request
- Base service minor changes

Outstanding items:

- Try this for SDXL & Whisper
- Check are there still blocking items, TPOT drops on 4 parallel workers
- Experiment with torch threads

Architecture of changes:

<img width="1083" height="460" alt="image" src="https://github.com/user-attachments/assets/65d4294f-ead0-491e-a86b-d842744b9da4" />
