### PR TITLE
Fix Summary Report for Image and CNN

### DIFF
--- a/benchmarking/summary_report.py
+++ b/benchmarking/summary_report.py
@@ -334,7 +334,7 @@ def process_benchmark_file(filepath: str) -> Dict[str, Any]:
 
     # Check if this is a CNN/SDXL-style benchmark (old format with benchmarks_data structure)
     # These have task_type "cnn" or "image" but use a different JSON format
-    benchmarks_data = data.get("benchmarks: ", None)
+    benchmarks_data = data.get("benchmarks: ", data)
     if benchmarks_data and benchmarks_data.get("benchmarks"):
         # This is a CNN/SDXL-style benchmark
         if params.get("task_type") == "cnn":


### PR DESCRIPTION
This issue was inadvertently re-introduced during this [PR](https://github.com/tenstorrent/tt-inference-server/pull/1659) merge. The change to `None` as the fallback breaks workflows where the JSON doesn't contain a "benchmarks: " key, causing downstream errors when trying to access `benchmarks_data.get("benchmarks")`. The original behaviour (using data as fallback) was previously fixed in commit `ef15810` (https://github.com/tenstorrent/tt-inference-server/pull/1684), but got lost during the rebase.