### PR TITLE
Reduce trace region size for LLM's that go OOM

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1854,9 +1854,7 @@ spec_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
-                override_tt_config={
-                    "trace_region_size": 10000000
-                },
+                override_tt_config={"trace_region_size": 10000000},
             ),
             DeviceModelSpec(
                 device=DeviceTypes.N300,


### PR DESCRIPTION
Issue link : https://github.com/tenstorrent/tt-metal/issues/35814

Reduced trace region size for Qwen2.5-VL-7B on N300, Llama-3.2-3B on N150 and Llama-3.3-70B on T3K so models don't run out of DRAM.

For Llama-3.3-70B on T3K also removed ISL 1K, 2k, 4k and 8k to be traced in prefill.
tt-metal commit that changes this - https://github.com/tenstorrent/tt-metal/pull/36165


shield-ci runs:
Llama-3.3-70B T3K - https://github.com/tenstorrent/tt-shield/actions/runs/21182425935
Llama-3.2-3B N150 - https://github.com/tenstorrent/tt-shield/actions/runs/21182465872
Qwen2.5-VL N300 - can't pick from on-dispatch run