### PR TITLE
increase llama-3.1-8b n300 trace_region_size to 36410368

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1897,7 +1897,7 @@ spec_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 override_tt_config={
-                    "trace_region_size": 33000000,
+                    "trace_region_size": 36410368,
                 },
             ),
             DeviceModelSpec(


### PR DESCRIPTION
# change log
* address https://github.com/tenstorrent/tt-inference-server/issues/1839

---

## Tenstorrent Model Release Summary: Llama-3.1-8B-Instruct on n300



### Metadata: Llama-3.1-8B-Instruct on n300
```json
{
"report_id": "id_tt-transformers_Llama-3.1-8B-Instruct_n300_2026-01-21_13-42-56",
"model_name": "Llama-3.1-8B-Instruct",
"model_id": "id_tt-transformers_Llama-3.1-8B-Instruct_n300",
"model_spec_json": "/home/tstesco/projects/tt-inference-server/workflow_logs/run_specs/tt_model_spec_2026-01-21_13-16-50_id_tt-transformers_Llama-3.1-8B-Instruct_n300_evals_4eh8_7Ji.json",
"model_repo": "meta-llama/Llama-3.1-8B-Instruct",
"model_impl": "tt-transformers",
"inference_engine": "vLLM",
"device": "n300",
"server_mode": "API",
"tt_metal_commit": "25305db",
"vllm_commit": "6e67d2d",
"run_command": "python run.py --model Llama-3.1-8B-Instruct --device n300 --workflow release "
}
```

### Performance Benchmark Sweeps for Llama-3.1-8B-Instruct on n300

#### vLLM Text-to-Text Performance Benchmark Sweeps for Llama-3.1-8B-Instruct on n300

| Source |  ISL  | OSL  | Concurrency | N Req | TTFT (ms) | TPOT (ms) | Tput User (TPS) | Tput Decode (TPS) | Tput Prefill (TPS) | E2EL (ms) | Req Tput (RPS) | Total Token Throughput (tokens/duration) |
|--------|-------|------|-------------|-------|-----------|-----------|-----------------|-------------------|--------------------|-----------|----------------|------------------------------------------|
| vLLM   |   128 |  128 |           1 |     8 |      73.7 |      25.6 |           39.05 |              39.1 |             1736.2 |    3325.9 |          0.301 |                                    76.67 |
| vLLM   |   128 |  128 |          32 |   256 |    2134.1 |      27.4 |           36.5  |            1168.0 |             1919.3 |    5613.5 |          5.699 |                                  1453.37 |
| vLLM   |   128 | 1024 |           1 |     4 |      74.6 |      26.6 |           37.56 |              37.6 |             1715.7 |   27314.3 |          0.037 |                                    42.14 |
| vLLM   |   128 | 1024 |          32 |   128 |    2144.2 |      30.4 |           32.88 |            1052.2 |             1910.2 |   33256.2 |          0.962 |                                  1107.48 |
| vLLM   |  1024 |  128 |           1 |     4 |     225.6 |      27.5 |           36.35 |              36.3 |             4539.2 |    3719.4 |          0.269 |                                   309.44 |
| vLLM   |  2048 |  128 |           1 |     4 |     434.5 |      29.4 |           34.04 |              34.0 |             4713.0 |    4165.8 |          0.24  |                                   522.08 |
| vLLM   |  2048 |  128 |          32 |   128 |   13582.4 |      39.0 |           25.64 |             820.4 |             4825.1 |   18535.9 |          1.726 |                                  3754.59 |
| vLLM   |  2048 | 2048 |          32 |    64 |   13615.4 |      44.2 |           22.63 |             724.3 |             4813.4 |  104052.3 |          0.308 |                                  1259.34 |
| vLLM   |  3000 |   64 |          32 |   128 |   28099.7 |      43.3 |           23.11 |             739.5 |             3416.4 |   30825.8 |          1.038 |                                  3179.51 |
| vLLM   |  3072 |  128 |           1 |     4 |     882.0 |      31.3 |           31.98 |              32.0 |             3482.9 |    4853.6 |          0.206 |                                   659.07 |
| vLLM   |  4000 |   64 |          32 |   128 |   28289.2 |      48.9 |           20.46 |             654.8 |             4524.7 |   31367.9 |          1.02  |                                  4144.64 |
| vLLM   |  4096 |  128 |           1 |     2 |     897.8 |      33.2 |           30.11 |              30.1 |             4562.1 |    5115.7 |          0.195 |                                   825.46 |
| vLLM   |  8000 |   64 |          16 |    32 |   31311.7 |      48.7 |           20.53 |             328.5 |             4087.9 |   34379.9 |          0.465 |                                  3752.23 |
| vLLM   |  8192 |  128 |           1 |     2 |    1959.6 |      40.6 |           24.61 |              24.6 |             4180.5 |    7120.2 |          0.14  |                                  1168.33 |
| vLLM   | 16000 |   64 |           8 |    16 |   37091.5 |      55.7 |           17.95 |             143.6 |             3450.9 |   40601.1 |          0.197 |                                  3164.95 |
| vLLM   | 16384 |  128 |           1 |     2 |    4615.7 |      55.7 |           17.96 |              18.0 |             3549.7 |   11685.4 |          0.086 |                                  1412.93 |
| vLLM   | 32000 |   64 |           4 |     8 |   48189.0 |      84.2 |           11.87 |              47.5 |             2656.2 |   53495.4 |          0.075 |                                  2397.4  |
| vLLM   | 32000 |  128 |           1 |     2 |   11969.5 |      84.1 |           11.9  |              11.9 |             2673.5 |   22645.7 |          0.044 |                                  1418.66 |

Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> N Req: total number of requests (sample size, N)
> TTFT: Time To First Token (ms)
> TPOT: Time Per Output Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)
> Tput Prefill: Throughput for prefill tokens (TPS)
> E2EL: End-to-End Latency (ms)
> Req Tput: Request Throughput (RPS)

### Performance Benchmark Targets Llama-3.1-8B-Instruct on n300

#### Text-to-Text Performance Benchmark Targets Llama-3.1-8B-Instruct on n300

| ISL | OSL | Concurrency | TTFT (ms) | Tput User (TPS) | Tput Decode (TPS) | Functional TTFT Check | Functional Tput User Check | Complete TTFT Check | Complete Tput User Check | Target TTFT Check | Target Tput User Check | Functional TTFT (ms) | Functional Tput User (TPS) | Complete TTFT (ms) | Complete Tput User (TPS) | Target TTFT (ms) | Target Tput User (TPS) |
|-----|-----|-------------|-----------|-----------------|-------------------|-----------------------|----------------------------|---------------------|--------------------------|-------------------|------------------------|----------------------|----------------------------|--------------------|--------------------------|------------------|------------------------|
| 128 | 128 |           1 |      73.7 |           39.05 |              39.1 | PASS ✅               | PASS ✅                    | PASS ✅             | PASS ✅                  | FAIL ⛔           | FAIL ⛔                |               580.00 |                       4.20 |             116.00 |                    21.00 |            58.00 |                  42.00 |

Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> TTFT: Time To First Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)

### Benchmark Performance Results for Llama-3.1-8B-Instruct on n300

**Metric Definitions:**
> - **ISL**: Input Sequence Length (tokens)
> - **OSL**: Output Sequence Length (tokens)
> - **Concur**: Concurrent requests (batch size)
> - **N**: Total number of requests
> - **TTFT Avg/P50/P99**: Time To First Token - Average, Median (50th percentile), 99th percentile (ms)
> - **TPOT Avg/P50/P99**: Time Per Output Token - Average, Median, 99th percentile (ms)
> - **E2EL Avg/P50/P99**: End-to-End Latency - Average, Median, 99th percentile (ms)
> - **Tok/s**: Output token throughput
> - **Req/s**: Request throughput


### Accuracy Evaluations for Llama-3.1-8B-Instruct on n300

| model                 | device | task_name     | accuracy_check | score | ratio_to_reference | gpu_reference_score | ratio_to_published | published_score                                                                           |
|-----------------------|--------|---------------|----------------|-------|--------------------|---------------------|--------------------|-------------------------------------------------------------------------------------------|
| Llama-3.1-8B-Instruct | n300   | meta_ifeval   | PASS ✅         | 80.05 | 0.98               | 81.38               | 1.00               | [80.40](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct#instruction-tuned-models) |
| Llama-3.1-8B-Instruct | n300   | meta_gpqa_cot | PASS ✅         | 28.79 | 1.02               | 28.34               | 0.95               | [30.40](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct#instruction-tuned-models) |

Note: The ratio to published scores defines if eval ran roughly correctly, as the exact methodology of the model publisher cannot always be reproduced. For this reason the accuracy check is based first on being equivalent to the GPU reference within a +/- tolerance. If a value GPU reference is not available, the accuracy check is based on the direct ratio to the published score.
