### PR TITLE
Adding gemma-3-27b DP=4 on Galaxy6U into Models CI

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1099,6 +1099,7 @@ spec_templates = [
                     "limit-mm-per-prompt": json.dumps({"image": 10}),
                     "num_scheduler_steps": 1,
                     "data_parallel_size": 4,
+                    "disable_mm_preprocessor_cache": True,
                 },
                 override_tt_config={
                     "l1_small_size": 24576,


### PR DESCRIPTION
Issue link : https://github.com/tenstorrent/tt-metal/issues/32006

Added gemma-3-27b DP=4 configuration into `model_spec`.


shield-ci runs:
Gemma-3-27b Galaxy6U DP=4 (some prompts in **evals workflow** are skipped because of current **v1 vLLM state** that is why whole run fails) - https://github.com/tenstorrent/tt-shield/actions/runs/21316201011/job/61359288730
