### PR TITLE
Pin Transformers Version

### DIFF
--- a/tt-media-server/requirements.txt
+++ b/tt-media-server/requirements.txt
@@ -18,6 +18,6 @@ pytest-asyncio
 python-multipart
 torch
 tqdm
-transformers
+transformers==4.55.0
 uvicorn
 whisperx

--- a/tt-vllm-plugin/pyproject.toml
+++ b/tt-vllm-plugin/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     # Pin torch/numpy to versions compatible with tt-metal
     "torch>=2.7.1,<2.8",
     "numpy>=1.24.4,<2",
+    # Pin transformers to match requirements.txt
+    "transformers==4.55.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem
A lot of code on metal side is not yet compatible with new version `5.0.0`. of transformers library. This PR pins the library to the latest stable version `4.55.0`