### PR TITLE
Update dataset name from 'imagenet-1k' to 'ILSVRC/imagenet-1k'

### DIFF
--- a/tests/server_tests/test_cases/vision_evals_test.py
+++ b/tests/server_tests/test_cases/vision_evals_test.py
@@ -315,7 +315,7 @@ class VisionEvalsTest(BaseTest):
             raise ValueError("Sample count must be positive.")
 
         ds = load_dataset(
-            "imagenet-1k",
+            "ILSVRC/imagenet-1k",
             split="validation",
             streaming=True,
             download_config=DownloadConfig(num_proc=1),


### PR DESCRIPTION
Update dataset name in vision evals test from "imagenet-1k" to more exact "ILSVRC/imagenet-1k"