### PR TITLE
Remove model registration duplication for vLLM

### DIFF
--- a/vllm-tt-metal-llama3/src/run_vllm_api_server.py
+++ b/vllm-tt-metal-llama3/src/run_vllm_api_server.py
@@ -61,7 +61,7 @@ def _load_model_spec_json():
 
 
 def register_tt_models(impl_id=None):
-    """Register TT models with vLLM ModelRegistry.
+    """Configure vLLM ModelRegistry according to ModelSpec.impl.impl_id.
 
     Args:
         impl_id: Implementation ID from ModelSpec JSON (e.g., "tt_transformers",


### PR DESCRIPTION
This PR addresses the issue of aliased vLLM model registration, preventing us from selecting the Galaxy-specific model implementations of:
* Llama-70B
* Qwen3-32B
https://github.com/tenstorrent/tt-shield/actions/runs/21415976205/job/61668169585#step:18:229