### PR TITLE
uplift llama 3.3 70b t3k tt-metal and vllm

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1749,8 +1749,8 @@ spec_templates = [
                 mode=VersionMode.SUGGESTED,
             ),
         ),
-        tt_metal_commit="9b67e09",
-        vllm_commit="a91b644",
+        tt_metal_commit="0b10c51",
+        vllm_commit="3499ffa",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
             DeviceModelSpec(


### PR DESCRIPTION
#  change log
* uplift llama 3.3 70b t3k tt-metal and vllm 


Models CI: https://github.com/tenstorrent/tt-shield/actions/runs/21375693274/job/61533534523#step:10:3585


## Tenstorrent Model Release Summary: Llama-3.3-70B-Instruct on t3k


### Metadata: Llama-3.3-70B-Instruct on t3k
```json
{
"report_id": "id_tt-transformers_Llama-3.3-70B-Instruct_t3k_2026-01-27_01-27-27",
"model_name": "Llama-3.3-70B-Instruct",
"model_id": "id_tt-transformers_Llama-3.3-70B-Instruct_t3k",
"model_spec_json": "/home/ubuntu/actions-runner/_work/tt-shield/tt-shield/tt-inference-server/workflow_logs/run_specs/tt_model_spec_2026-01-26_23-04-47_id_tt-transformers_Llama-3.3-70B-Instruct_t3k_release_19r7Anba.json",
"model_repo": "meta-llama/Llama-3.3-70B-Instruct",
"model_impl": "tt-transformers",
"inference_engine": "vLLM",
"device": "t3k",
"server_mode": "docker",
"tt_metal_commit": "18ad9aeba94a5601cabc535cf5ff8f3a21713d71",
"vllm_commit": "3499ffa",
"run_command": "python run.py --model Llama-3.3-70B-Instruct --device t3k --workflow release --docker-server"
}
```

### Performance Benchmark Sweeps for Llama-3.3-70B-Instruct on t3k

#### vLLM Text-to-Text Performance Benchmark Sweeps for Llama-3.3-70B-Instruct on t3k

| Source |  ISL  | OSL  | Concurrency | N Req | TTFT (ms) | TPOT (ms) | Tput User (TPS) | Tput Decode (TPS) | Tput Prefill (TPS) | E2EL (ms) | Req Tput (RPS) |
|--------|-------|------|-------------|-------|-----------|-----------|-----------------|-------------------|--------------------|-----------|----------------|
| vLLM   |   128 |  128 |           1 |     8 |     180.9 |      65.1 |           15.35 |              15.4 |              707.5 |    8452.4 |          0.118 |
| vLLM   |   128 |  128 |          32 |   256 |    5311.6 |      66.9 |           14.95 |             478.5 |              771.1 |   13804.9 |          2.318 |
| vLLM   |   128 | 1024 |           1 |     4 |     189.6 |      65.4 |           15.29 |              15.3 |              675.2 |   67077.5 |          0.015 |
| vLLM   |   128 | 1024 |          32 |   128 |    5333.2 |      68.7 |           14.55 |             465.5 |              768.0 |   75650.0 |          0.423 |
| vLLM   |  1024 |  128 |           1 |     4 |     615.6 |      66.4 |           15.06 |              15.1 |             1663.4 |    9047.8 |          0.111 |
| vLLM   |  2048 |  128 |           1 |     4 |    1210.4 |      68.4 |           14.62 |              14.6 |             1692.0 |    9894.6 |          0.101 |
| vLLM   |  2048 |  128 |          32 |   128 |   38144.9 |      74.0 |           13.51 |             432.2 |             1718.1 |   47547.9 |          0.673 |
| vLLM   |  2048 | 2048 |          32 |    64 |   38113.5 |      77.7 |           12.87 |             411.7 |             1719.5 |  197214.9 |          0.162 |
| vLLM   |  3000 |   64 |          32 |   128 |   76876.3 |      78.0 |           12.82 |             410.3 |             1248.8 |   81790.0 |          0.391 |
| vLLM   |  3072 |  128 |           1 |     4 |    2416.1 |      69.8 |           14.32 |              14.3 |             1271.5 |   11281.8 |          0.089 |
| vLLM   |  4000 |   64 |          32 |   128 |   77259.1 |      81.6 |           12.26 |             392.3 |             1656.8 |   82398.0 |          0.388 |
| vLLM   |  4096 |  128 |           1 |     2 |    2431.9 |      71.5 |           13.99 |              14.0 |             1684.3 |   11511.1 |          0.087 |
| vLLM   |  8000 |   64 |          16 |    32 |   80365.4 |      80.4 |           12.43 |             199.0 |             1592.7 |   85431.7 |          0.187 |
| vLLM   |  8192 |  128 |           1 |     2 |    5036.1 |      78.6 |           12.72 |              12.7 |             1626.6 |   15019.4 |          0.067 |
| vLLM   | 16000 |   64 |           8 |    16 |   87324.5 |      93.4 |           10.71 |              85.6 |             1465.8 |   93209.3 |          0.086 |
| vLLM   | 16384 |  128 |           1 |     2 |   10918.8 |      92.8 |           10.78 |              10.8 |             1500.5 |   22703.0 |          0.044 |
| vLLM   | 32000 |   64 |           4 |     8 |  101305.9 |     120.7 |            8.29 |              33.1 |             1263.5 |  108909.9 |          0.037 |
| vLLM   | 32000 |  128 |           1 |     2 |   25256.1 |     119.7 |            8.35 |               8.4 |             1267.0 |   40463.9 |          0.025 |

Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> N Req: total number of requests (sample size, N)
> TTFT: Time To First Token (ms)
> TPOT: Time Per Output Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)
> Tput Prefill: Throughput for prefill tokens (TPS)
> E2EL: End-to-End Latency (ms)
> Req Tput: Request Throughput (RPS)

### Performance Benchmark Targets Llama-3.3-70B-Instruct on t3k

#### Text-to-Text Performance Benchmark Targets Llama-3.3-70B-Instruct on t3k

| ISL | OSL | Concurrency | TTFT (ms) | Tput User (TPS) | Tput Decode (TPS) | Functional TTFT Check | Functional Tput User Check | Complete TTFT Check | Complete Tput User Check | Target TTFT Check | Target Tput User Check | Functional TTFT (ms) | Functional Tput User (TPS) | Complete TTFT (ms) | Complete Tput User (TPS) | Target TTFT (ms) | Target Tput User (TPS) |
|-----|-----|-------------|-----------|-----------------|-------------------|-----------------------|----------------------------|---------------------|--------------------------|-------------------|------------------------|----------------------|----------------------------|--------------------|--------------------------|------------------|------------------------|
| 128 | 128 |           1 |     180.9 |           15.35 |              15.4 | PASS ✅               | PASS ✅                    | FAIL ⛔             | PASS ✅                  | FAIL ⛔           | FAIL ⛔                |               380.00 |                       2.80 |              76.00 |                    14.00 |            38.00 |                  28.00 |

Note: all metrics are means across benchmark run unless otherwise stated.
> ISL: Input Sequence Length (tokens)
> OSL: Output Sequence Length (tokens)
> Concurrency: number of concurrent requests (batch size)
> TTFT: Time To First Token (ms)
> Tput User: Throughput per user (TPS)
> Tput Decode: Throughput for decode tokens, across all users (TPS)

### Accuracy Evaluations for Llama-3.3-70B-Instruct on t3k

| model                  | device | task_name     | accuracy_check | score | ratio_to_reference | gpu_reference_score                                                                                                     | ratio_to_published | published_score                                                                            |
|------------------------|--------|---------------|----------------|-------|--------------------|-------------------------------------------------------------------------------------------------------------------------|--------------------|--------------------------------------------------------------------------------------------|
| Llama-3.3-70B-Instruct | t3k    | meta_ifeval   | PASS ✅         | 90.07 | 0.99               | [91.35](https://docs.google.com/spreadsheets/d/1kFIUj9Bp5WJ0lW3QPwQRRWDyLRieedKrFZqfxWBfeNw/edit?gid=0#gid=0&range=J86) | 0.98               | [92.10](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct#instruction-tuned-models) |
| Llama-3.3-70B-Instruct | t3k    | meta_gpqa_cot | PASS ✅         | 59.60 | 0.99               | [60.04](https://docs.google.com/spreadsheets/d/1kFIUj9Bp5WJ0lW3QPwQRRWDyLRieedKrFZqfxWBfeNw/edit?gid=0#gid=0&range=J87) | 1.18               | [50.50](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct#instruction-tuned-models) |

Note: The ratio to published scores defines if eval ran roughly correctly, as the exact methodology of the model publisher cannot always be reproduced. For this reason the accuracy check is based first on being equivalent to the GPU reference within a +/- tolerance. If a value GPU reference is not available, the accuracy check is based on the direct ratio to the published score.