### PR TITLE
adding detail to CODEOWNERS to make best reviewers more visible

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,11 +4,11 @@
 *       @tenstorrent/tt-inference-server-codeowners
 
 # tt-media-server
-tt-media-server/ @idjuricTT @ztorlakTT @fivanovicTT @ljovanovicTT @dmadicTT
+tt-media-server/ @idjuricTT @ztorlakTT @fivanovicTT @ljovanovicTT @dmadicTT @knovokmetTT @vpetrovicTT
 tt-media-server/tt_model_runners/forge_runners/ @vmilosevic
 
 # tt-vllm-plugin
-tt-vllm-plugin/ @idjuricTT @ztorlakTT @fivanovicTT @ljovanovicTT @dmadicTT @bgoelTT 
+tt-vllm-plugin/ @idjuricTT @ztorlakTT @fivanovicTT @ljovanovicTT @dmadicTT @bgoelTT @knovokmetTT @vpetrovicTT
 
 # vllm-tt-metal
 vllm-tt-metal-llama3/ @tstescoTT @bgoelTT @stisiTT


### PR DESCRIPTION
# change log
* 1st pass adding detail to CODEOWNERS to make best reviewers more visible

## Discussion

The purpose of is to take inspiration from https://github.com/tenstorrent/tt-metal/blob/main/.github/CODEOWNERS and make our CODEOWNERS file more useful in designating specific reviewers for parts of the code base.

This is just a 1st pass in adding this detail. As we add more modules and team members we need to make the ownership more explicit to expedite development. I encourage everyone to sign up for specific files they edit and review often. I tried to infer this based on recent commit trends but I am sure I have missed people and not added sufficient detail (e.g. within `tt-media-server/`!).