### PR TITLE
Add pytest exit code checks for Tests workflow

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -10,6 +10,7 @@ import logging
 import sys
 from pathlib import Path
 from typing import List
+from pytest import ExitCode
 
 # Add the script's directory to the Python path
 # this for 0 setup python setup script
@@ -184,7 +185,12 @@ def main():
             args.output_path,
             cli_args.get("service_port"),
         )
-        return_code = run_command(command=cmd, logger=logger, env=env_vars)
+        return_code = run_command(command=cmd, logger=logger, env=env_vars, check=False)
+        if return_code not in (ExitCode.OK, ExitCode.TESTS_FAILED):
+            raise RuntimeError(
+                f"⛔ Command: {cmd} exited with code {return_code} ({ExitCode(return_code).name}). "
+                "This indicates a error, not a test failure. See logs above."
+            )
         return_codes.append(return_code)
 
     if all(return_code == 0 for return_code in return_codes):


### PR DESCRIPTION
This PR fixes the crashing when pytest from `run_tests.py` returns a non-zero exit code by adding proper exit code handling. Previously, `run_command` with `check=True` would raise a `RuntimeError` immediately when tests failed, preventing the script from collecting and reporting results gracefully. Now the script uses `check=False` and explicitly handles pytest exit codes - allowing `OK` and `TESTS_FAILED` to continue while raising an error for actual pytest problems like `INTERNAL_ERROR`, `USAGE_ERROR`, or `NO_TESTS_COLLECTED`.