### PR TITLE
Updated Llama-8B top perf targets for Galaxy and T3K

### DIFF
--- a/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/benchmarking/benchmark_targets/model_performance_reference.json
@@ -323,9 +323,9 @@
                 "images_per_prompt": null,
                 "targets": {
                     "theoretical": {
-                        "ttft_ms": 21.0,
-                        "tput_user": 84.0,
-                        "tput": 5230.0
+                        "ttft_ms": 29.0,
+                        "tput_user": 73.0,
+                        "tput": 4483.0
                     }
                 }
             }


### PR DESCRIPTION
Current best  Llama-8B targets are:
TTFT : [56.90](https://github.com/tenstorrent/tt-shield/actions/runs/21076491467/job/60621726268#:~:text=|,-vLLM%20%20%20|%20%20%20128)
T/S/U: [68.07](https://github.com/tenstorrent/tt-shield/actions/runs/21076491467/job/60621726268#:~:text=|,-vLLM%20%20%20|%20%20%20128)

New top perf estimates show TTFT =29 ms  which should be around  58 ms for `Customer Complete`. 