### PR TITLE
Record LongBench-e wh loudbox scores for Llama-3.1-8B-Instruct

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1999,6 +1999,90 @@ _eval_config_list = [
                     },
                 ),
             ),
+            EvalTask(
+                task_name="longbench_code_e",
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=48.12,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["score,none"],
+                        "unit": "percent",
+                    },
+                ),
+            ),
+            EvalTask(
+                task_name="longbench_fewshot_e",
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=63.34,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["score,none"],
+                        "unit": "percent",
+                    },
+                ),
+            ),
+            EvalTask(
+                task_name="longbench_multi_e",
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=20.84,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["score,none"],
+                        "unit": "percent",
+                    },
+                ),
+            ),
+            EvalTask(
+                task_name="longbench_single_e",
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=22.22,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["score,none"],
+                        "unit": "percent",
+                    },
+                ),
+            ),
+            EvalTask(
+                task_name="longbench_summarization_e",
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=26.09,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["score,none"],
+                        "unit": "percent",
+                    },
+                ),
+            ),
+            EvalTask(
+                task_name="longbench_synthetic_e",
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=14.86,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["score,none"],
+                        "unit": "percent",
+                    },
+                ),
+            ),
         ],
     ),
     EvalConfig(


### PR DESCRIPTION
local-completions ({'model': 'meta-llama/Llama-3.1-8B-Instruct', 'base_url': 'http://127.0.0.1:8000/v1/completions', 'tokenizer_backend': 'huggingface'}), gen_kwargs: ({'temperature': 0, 'max_gen_toks': 512}), limit: None, num_fewshot: None, batch_size: 1
|               Tasks               |Version|Filter|n-shot|       Metric       |   |Value |   |Stderr|
|-----------------------------------|------:|------|-----:|--------------------|---|-----:|---|-----:|
|Code Completion (LongBench-E)      |      0|none  |      |score               |↑  |0.4812|±  |0.0122|
| - longbench_lcc_e                 |      5|none  |     0|code_sim_score      |↑  |0.5662|±  |0.0183|
| - longbench_repobench-p_e         |      5|none  |     0|code_sim_score      |↑  |0.3963|±  |0.0162|
|Few-shot Learning (LongBench-E)    |      0|none  |      |score               |↑  |0.6334|±  |0.0112|
| - longbench_samsum_e              |      5|none  |     0|rouge_score         |↑  |0.4120|±  |0.0091|
| - longbench_trec_e                |      5|none  |     0|classification_score|↑  |0.6067|±  |0.0283|
| - longbench_triviaqa_e            |      5|none  |     0|qa_f1_score         |↑  |0.8816|±  |0.0157|
|Multi-Document QA (LongBench-E)    |      0|none  |      |score               |↑  |0.2084|±  |0.0147|
| - longbench_2wikimqa_e            |      5|none  |     0|qa_f1_score         |↑  |0.1807|±  |0.0195|
| - longbench_hotpotqa_e            |      5|none  |     0|qa_f1_score         |↑  |0.2361|±  |0.0219|
|Single-Document QA (LongBench-E)   |      0|none  |      |score               |↑  |0.2222|±  |0.0170|
| - longbench_multifieldqa_en_e     |      5|none  |     0|qa_f1_score         |↑  |0.1623|±  |0.0228|
| - longbench_qasper_e              |      5|none  |     0|qa_f1_score         |↑  |0.2820|±  |0.0239|
|Summarization (LongBench-E)        |      0|none  |      |score               |↑  |0.2609|±  |0.0027|
| - longbench_gov_report_e          |      5|none  |     0|rouge_score         |↑  |0.2874|±  |0.0035|
| - longbench_multi_news_e          |      5|none  |     0|rouge_score         |↑  |0.2344|±  |0.0041|
|Synthetic Tasks (LongBench-E)      |      0|none  |      |score               |↑  |0.1486|±  |0.0140|
| - longbench_passage_count_e       |      5|none  |     0|count_score         |↑  |0.0757|±  |0.0146|
| - longbench_passage_retrieval_en_e|      5|none  |     0|retrieval_score     |↑  |0.2214|±  |0.0239|

|             Groups             |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|--------------------------------|------:|------|------|------|---|-----:|---|-----:|
|Code Completion (LongBench-E)   |      0|none  |      |score |↑  |0.4812|±  |0.0122|
|Few-shot Learning (LongBench-E) |      0|none  |      |score |↑  |0.6334|±  |0.0112|
|Multi-Document QA (LongBench-E) |      0|none  |      |score |↑  |0.2084|±  |0.0147|
|Single-Document QA (LongBench-E)|      0|none  |      |score |↑  |0.2222|±  |0.0170|
|Summarization (LongBench-E)     |      0|none  |      |score |↑  |0.2609|±  |0.0027|
|Synthetic Tasks (LongBench-E)   |      0|none  |      |score |↑  |0.1486|±  |0.0140|