### PR TITLE
Revert #1974

### DIFF
--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -127,12 +127,11 @@ RUN /bin/bash -c "source ${PYTHON_ENV_DIR}/bin/activate \
     grep -v pyluwen requirements.txt > requirements_no_pyluwen.txt && \
     uv pip install --no-cache-dir -r requirements_no_pyluwen.txt)"
 
-# Install tt-vllm-plugin and remove xformers (CUDA-only, breaks CPU PyTorch)
+# Install tt-vllm-plugin
 COPY "tt-vllm-plugin" "${TT_METAL_HOME}/tt-vllm-plugin"
 RUN /bin/bash -c "source ${PYTHON_ENV_DIR}/bin/activate \
     && cd ${TT_METAL_HOME}/tt-vllm-plugin \
-    && uv pip install . \
-    && uv pip uninstall -y xformers || true"
+    && uv pip install ."
 
 # Cleanup build-only directories
 RUN rm -rf ${HOME_DIR}/.rustup \

--- a/tt-media-server/requirements.txt
+++ b/tt-media-server/requirements.txt
@@ -1,11 +1,10 @@
 aiohttp
 asyncio
 colorama
-datasets>=2.20.0,<3.3.0
 fastapi
 faster_fifo
 httpx
-huggingface_hub>=0.25.0,<0.28.0
+huggingface_hub
 imageio-ffmpeg
 loguru
 prometheus-client
@@ -15,10 +14,8 @@ pydantic-settings
 pytest
 pytest-asyncio
 python-multipart
-requests
 silero_vad
 tqdm
 uvicorn
 whisperx
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.7.1+cpu


### PR DESCRIPTION
## Problem
After adding HF datasets library into media-server requirements, due to version conflicts every media-server model was broken on last night's nightly: https://github.com/tenstorrent/tt-shield/actions/runs/21649698810/job/62410834353

(Whisper)
Job: https://github.com/tenstorrent/tt-shield/actions/runs/21649698810/job/62413581040
`[SERVER] 2026-02-03 22:39:39,415 - ERROR - [__init__] failed after 0.0318 seconds. Error: Missing required dependency: huggingface_hub`

(SD3.5, Mochi, Wan)
Job: https://github.com/tenstorrent/tt-shield/actions/runs/21649698810/job/62413581042
Job: https://github.com/tenstorrent/tt-shield/actions/runs/21649698810/job/62413581029
Job: https://github.com/tenstorrent/tt-shield/actions/runs/21649698810/job/62413581066
```
2026-02-03 22:44:01,456 - ERROR - Failed to get device runner: Failed to create model runner tt-sd3.5: Failed to import diffusers.models.autoencoders.autoencoder_kl because of the following error (look up to see its traceback):
2026-02-03 22:44:01,462 - ERROR - Error in worker -1: Failed to create model runner tt-sd3.5: Failed to import diffusers.models.autoencoders.autoencoder_kl because of the following error (look up to see its traceback):
libcudart.so.12: cannot open shared object file: No such file or directory
```

(SDXL)
Job: https://github.com/tenstorrent/tt-shield/actions/runs/21649698810/job/62413581054
`2026-02-03 22:40:41,160 - ERROR - Failed to get device runner: Failed to create model runner tt-sdxl-trace: Failed to import diffusers.pipelines.pipeline_utils because of the following error (look up to see its traceback):`