### PR TITLE
Fix tool calling crash caused by torch.compile/triton on TT hardware

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -386,6 +386,7 @@ class ModelSpec:
             "VLLM_CONFIGURE_LOGGING": "1",
             "VLLM_RPC_TIMEOUT": "900000",
             "VLLM_TARGET_DEVICE": "tt",
+            "TORCHDYNAMO_DISABLE": "1",
         }
         # order of precedence: default, env_vars, device_model_spec
         merged_env_vars = {


### PR DESCRIPTION
## Summary

A customer reported that using **tool calling** with `tool_choice="required"` on Llama-3.3-70B-Instruct (T3K) crashes the vLLM engine process.

**Repro command:**
```bash
python3 run.py --model Llama-3.3-70B-Instruct --device t3k --workflow server --docker-server --dev-mode \
  --vllm-override-args '{"num_scheduler_steps": 1, "override_tt_config": null, "enable-auto-tool-choice": true, "tool-call-parser": "llama3_json"}' \
  --skip-system-sw-validation --no-auth
```

**Repro request** (first request with `response_format={"type": "json_object"}` succeeds; this second request crashes the engine):
```python
response = client.chat.completions.create(
    model="meta-llama/Llama-3.3-70B-Instruct",
    messages=[{"role": "user", "content": "hava nasıl"}],
    tools=[tool],
    tool_choice="required",
)
```

**Error chain from customer logs:**
```
WARNING  xgrammar does not support advanced JSON schema features like string length,
         item limits, or property bounds. Falling back to use outlines instead.

ERROR    torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
         ImportError: cannot import name 'triton_key' from 'triton.compiler.compiler'

ERROR    TypeError: cannot pickle 'frame' object
```

**Root cause:** `tool_choice="required"` triggers guided decoding with a JSON schema containing `minItems: 1`. xgrammar can't handle this, so it falls back to outlines. The outlines logits processor uses `@torch.compile`, which invokes the inductor backend, which tries to import `triton_key` from triton -- unavailable on TT hardware. The resulting `BackendCompilerFailed` exception contains a Python frame object that cannot be pickled for IPC, killing the engine process.

**Fix:** Set `TORCHDYNAMO_DISABLE=1` as a default env var for all vLLM-served models. This makes the outlines logits processor run in eager mode, which works correctly with no performance impact (it's a trivial CPU-side bitmask operation). This is applied globally rather than per-model because triton/inductor is non-functional on all TT hardware, and any model with tool calling enabled can trigger this crash path.

## Test plan

- [x] Reproduced the crash without the fix (engine dies on tool call request)
- [x] Verified the fix resolves the issue (tool call request returns 200 OK with correct tool call response)
