### PR TITLE
Reduce gpt-oss-120b system mem requirement

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -972,8 +972,10 @@ llm_templates = [
         tt_metal_commit="60ffb199",
         vllm_commit="3499ffa1",
         inference_engine=InferenceEngine.VLLM.value,
-        min_ram_gb=(120 * 2.5),  # weights come in bfloat16 container type from HF, add 0.5x overhead buffer
-                                 # also see memory profiling report https://github.com/tenstorrent/tt-inference-server/pull/2040
+        min_ram_gb=(
+            120 * 2.5
+        ),  # weights come in bfloat16 container type from HF, add 0.5x overhead buffer
+        # also see memory profiling report https://github.com/tenstorrent/tt-inference-server/pull/2040
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.T3K,


### PR DESCRIPTION
Currently, we globablly enforce a minimum default requirement on host sytem memory of (# model params * 4). This is too aggressive and assumes weights are loaded at float32, which is not the case for most models on HF. I've filed this as a larger issue here <INSERT LINK> but have immediately changed the memory limit for gpt-oss-120b in this PR to unblock intermittent Models CI OOMs.

I profiled the system memory usage from start to finishing the `--workflow release --docker-server` using a `free -m` polling script and produced the plot below.
<img width="775" height="432" alt="Screenshot 2026-02-08 at 12 10 30 AM" src="https://github.com/user-attachments/assets/11f41401-97c0-42cf-bf70-16233430e69e" />
It looks like system memory usage peaked at ~268GB, so I reduced the memory scaling factor from 4 to 2.5. (120B params * 2.5 = 300GB), which appears to be a reasonable decision.