### PR TITLE
Add Cpp Server TTNN Build Check In Test Gate

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -494,6 +494,42 @@ jobs:
       - name: Check test result
         run: exit ${{ env.TEST_EXIT_CODE }}
 
+  cpp-server-ttnn-build:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.cpp-server == 'true' }}
+    name: C++ Server TTNN Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      PYTHONPATH: ${{ github.workspace }}/tt-media-server
+    defaults:
+      run:
+        working-directory: tt-media-server
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install C++ build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq cmake g++ pkg-config \
+            libjsoncpp-dev uuid-dev zlib1g-dev
+
+      - name: Clone Drogon for build
+        run: |
+          mkdir -p cpp_server/deps
+          git clone --depth 1 --branch v1.9.8 https://github.com/drogonframework/drogon.git cpp_server/deps/drogon
+          cd cpp_server/deps/drogon
+          git submodule update --init
+          cd ../../..
+
+      - name: Build C++ server
+        run: |
+          cd cpp_server
+          ./build.sh --ttnn
+
   cpp-server-llm-streaming:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.cpp-server == 'true' }}


### PR DESCRIPTION
## Problem
We need a way to track regressions in PRs. This check ensures that the `ttnn` build passes