### PR TITLE
Allow Flux to use inference steps 4

### DIFF
--- a/tests/test_dit_runners_validation.py
+++ b/tests/test_dit_runners_validation.py
@@ -2,143 +2,159 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-"""Tests for MIN_INFERENCE_STEPS validation in DiT runners.
+"""Tests for num_inference_steps validation in ImageGenerateRequest.
 
-Tests the _validate_inference_steps logic without importing the actual
-runner classes (which require TT hardware dependencies).
+Validates that the field_validator enforces per-model minimum inference steps:
+- Flux models (tt-flux.1-dev, tt-flux.1-schnell): min 4 steps
+- All other image models (SDXL, SD3.5, Motif, etc.): min 12 steps
 """
 
 import sys
-from dataclasses import dataclass
-from typing import Optional
+from unittest.mock import MagicMock
 
 import pytest
 
+# Mock config.settings before importing ImageGenerateRequest,
+# since config.settings depends on pydantic_settings which is not
+# available in the local test environment.
+_mock_settings_module = MagicMock()
+_mock_settings_instance = MagicMock()
+_mock_settings_instance.model_runner = "tt-sdxl-trace"  # default
+_mock_settings_module.get_settings.return_value = _mock_settings_instance
+sys.modules.setdefault("config", MagicMock())
+sys.modules["config.settings"] = _mock_settings_module
 
-@dataclass
-class MockRequest:
-    """Minimal mock of ImageGenerateRequest for validation testing."""
-
-    prompt: str = "test"
-    negative_prompt: Optional[str] = ""
-    num_inference_steps: int = 20
-    seed: int = 0
-    guidance_scale: float = 8.0
-
-
-def _make_validate_fn(min_steps: int):
-    """Create a validate function matching TTDiTRunner._validate_inference_steps."""
-
-    def validate(request):
-        if request.num_inference_steps < min_steps:
-            raise ValueError(
-                f"num_inference_steps must be >= {min_steps}, "
-                f"got {request.num_inference_steps}"
-            )
-
-    return validate
+# Now safe to add tt-media-server to path and import
+sys.path.insert(0, "tt-media-server")
+from domain.image_generate_request import ImageGenerateRequest  # noqa: E402
 
 
-class TestFlux1InferenceStepsValidation:
-    """Flux.1 (dev and schnell) should accept num_inference_steps >= 4."""
+def _set_model_runner(runner: str):
+    """Set the mocked model_runner for subsequent requests."""
+    _mock_settings_instance.model_runner = runner
 
-    validate = staticmethod(_make_validate_fn(4))
+
+def _make_request(num_inference_steps: int):
+    """Create an ImageGenerateRequest with given inference steps."""
+    return ImageGenerateRequest(
+        prompt="test",
+        guidance_scale=8.0,
+        num_inference_steps=num_inference_steps,
+    )
+
+
+class TestFluxInferenceStepsValidation:
+    """Flux models should accept num_inference_steps >= 4."""
+
+    def setup_method(self):
+        _set_model_runner("tt-flux.1-dev")
 
     def test_accepts_4_steps(self):
-        self.validate(MockRequest(num_inference_steps=4))
+        req = _make_request(4)
+        assert req.num_inference_steps == 4
+
+    def test_accepts_4_steps_schnell(self):
+        _set_model_runner("tt-flux.1-schnell")
+        req = _make_request(4)
+        assert req.num_inference_steps == 4
 
     def test_accepts_20_steps(self):
-        self.validate(MockRequest(num_inference_steps=20))
+        req = _make_request(20)
+        assert req.num_inference_steps == 20
 
     def test_accepts_50_steps(self):
-        self.validate(MockRequest(num_inference_steps=50))
+        req = _make_request(50)
+        assert req.num_inference_steps == 50
 
     def test_rejects_3_steps(self):
-        with pytest.raises(ValueError, match="num_inference_steps must be >= 4"):
-            self.validate(MockRequest(num_inference_steps=3))
+        """Rejected by Pydantic ge=4 before field_validator runs."""
+        with pytest.raises(Exception):
+            _make_request(3)
 
     def test_rejects_1_step(self):
-        with pytest.raises(ValueError, match="num_inference_steps must be >= 4"):
-            self.validate(MockRequest(num_inference_steps=1))
+        """Rejected by Pydantic ge=4 before field_validator runs."""
+        _set_model_runner("tt-flux.1-schnell")
+        with pytest.raises(Exception):
+            _make_request(1)
 
 
 class TestSD35InferenceStepsValidation:
     """SD3.5 should reject num_inference_steps < 12."""
 
-    validate = staticmethod(_make_validate_fn(12))
+    def setup_method(self):
+        _set_model_runner("tt-sd3.5")
 
     def test_accepts_12_steps(self):
-        self.validate(MockRequest(num_inference_steps=12))
+        req = _make_request(12)
+        assert req.num_inference_steps == 12
 
     def test_accepts_20_steps(self):
-        self.validate(MockRequest(num_inference_steps=20))
+        req = _make_request(20)
+        assert req.num_inference_steps == 20
 
     def test_rejects_4_steps(self):
-        with pytest.raises(ValueError, match="num_inference_steps must be >= 12"):
-            self.validate(MockRequest(num_inference_steps=4))
+        with pytest.raises(Exception, match="num_inference_steps must be >= 12"):
+            _make_request(4)
 
     def test_rejects_11_steps(self):
-        with pytest.raises(ValueError, match="num_inference_steps must be >= 12"):
-            self.validate(MockRequest(num_inference_steps=11))
+        with pytest.raises(Exception, match="num_inference_steps must be >= 12"):
+            _make_request(11)
 
 
 class TestMotifInferenceStepsValidation:
-    """Motif should reject num_inference_steps < 12 (same as base default)."""
+    """Motif should reject num_inference_steps < 12."""
 
-    validate = staticmethod(_make_validate_fn(12))
+    def setup_method(self):
+        _set_model_runner("tt-motif-image-6b-preview")
 
     def test_accepts_12_steps(self):
-        self.validate(MockRequest(num_inference_steps=12))
-
-    def test_rejects_4_steps(self):
-        with pytest.raises(ValueError, match="num_inference_steps must be >= 12"):
-            self.validate(MockRequest(num_inference_steps=4))
-
-
-class TestImageGenerateRequestPydanticValidation:
-    """Test that Pydantic allows num_inference_steps=4 after ge=4 change."""
-
-    def test_pydantic_accepts_4(self):
-        sys.path.insert(0, "tt-media-server")
-        from domain.image_generate_request import ImageGenerateRequest
-
-        req = ImageGenerateRequest(
-            prompt="test", guidance_scale=8.0, num_inference_steps=4
-        )
-        assert req.num_inference_steps == 4
-
-    def test_pydantic_rejects_3(self):
-        sys.path.insert(0, "tt-media-server")
-        from domain.image_generate_request import ImageGenerateRequest
-
-        with pytest.raises(Exception):  # Pydantic ValidationError
-            ImageGenerateRequest(
-                prompt="test", guidance_scale=8.0, num_inference_steps=3
-            )
-
-    def test_pydantic_accepts_12(self):
-        sys.path.insert(0, "tt-media-server")
-        from domain.image_generate_request import ImageGenerateRequest
-
-        req = ImageGenerateRequest(
-            prompt="test", guidance_scale=8.0, num_inference_steps=12
-        )
+        req = _make_request(12)
         assert req.num_inference_steps == 12
 
-    def test_pydantic_accepts_50(self):
-        sys.path.insert(0, "tt-media-server")
-        from domain.image_generate_request import ImageGenerateRequest
+    def test_rejects_4_steps(self):
+        with pytest.raises(Exception, match="num_inference_steps must be >= 12"):
+            _make_request(4)
 
-        req = ImageGenerateRequest(
-            prompt="test", guidance_scale=8.0, num_inference_steps=50
-        )
-        assert req.num_inference_steps == 50
+
+class TestSDXLInferenceStepsValidation:
+    """SDXL should reject num_inference_steps < 12."""
+
+    def setup_method(self):
+        _set_model_runner("tt-sdxl-trace")
+
+    def test_accepts_12_steps(self):
+        req = _make_request(12)
+        assert req.num_inference_steps == 12
+
+    def test_accepts_20_steps(self):
+        req = _make_request(20)
+        assert req.num_inference_steps == 20
+
+    def test_rejects_4_steps(self):
+        with pytest.raises(Exception, match="num_inference_steps must be >= 12"):
+            _make_request(4)
+
+    def test_rejects_11_steps(self):
+        with pytest.raises(Exception, match="num_inference_steps must be >= 12"):
+            _make_request(11)
+
+
+class TestPydanticBoundaryValidation:
+    """Test absolute Pydantic boundaries (ge=4, le=50)."""
+
+    def setup_method(self):
+        _set_model_runner("tt-flux.1-dev")
+
+    def test_pydantic_rejects_3_even_for_flux(self):
+        """ge=4 in Field rejects 3 before field_validator even runs."""
+        with pytest.raises(Exception):
+            _make_request(3)
 
     def test_pydantic_rejects_51(self):
-        sys.path.insert(0, "tt-media-server")
-        from domain.image_generate_request import ImageGenerateRequest
+        """le=50 in Field rejects 51."""
+        with pytest.raises(Exception):
+            _make_request(51)
 
-        with pytest.raises(Exception):  # Pydantic ValidationError
-            ImageGenerateRequest(
-                prompt="test", guidance_scale=8.0, num_inference_steps=51
-            )
+    def test_pydantic_accepts_50(self):
+        req = _make_request(50)
+        assert req.num_inference_steps == 50

--- a/tt-media-server/domain/image_generate_request.py
+++ b/tt-media-server/domain/image_generate_request.py
@@ -4,8 +4,14 @@
 
 from typing import List, Optional, Tuple, Union
 
+from config.settings import get_settings
 from domain.base_request import BaseRequest
 from pydantic import Field, PrivateAttr, field_validator
+
+# Flux models support fewer inference steps than other image models
+_FLUX_RUNNERS = {"tt-flux.1-dev", "tt-flux.1-schnell"}
+_FLUX_MIN_INFERENCE_STEPS = 4
+_DEFAULT_MIN_INFERENCE_STEPS = 12
 
 
 class ImageGenerateRequest(BaseRequest):
@@ -28,6 +34,23 @@ class ImageGenerateRequest(BaseRequest):
 
     # Private fields for internal processing
     _segments: Optional[List[int]] = PrivateAttr(default=None)
+
+    @field_validator("num_inference_steps")
+    @classmethod
+    def validate_num_inference_steps(cls, v):
+        if v is None:
+            return v
+        model_runner = get_settings().model_runner
+        min_steps = (
+            _FLUX_MIN_INFERENCE_STEPS
+            if model_runner in _FLUX_RUNNERS
+            else _DEFAULT_MIN_INFERENCE_STEPS
+        )
+        if v < min_steps:
+            raise ValueError(
+                f"num_inference_steps must be >= {min_steps} for {model_runner}, got {v}"
+            )
+        return v
 
     @field_validator("image_return_format")
     @classmethod

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -38,8 +38,6 @@ dit_runner_log_map = {
 
 
 class TTDiTRunner(BaseMetalDeviceRunner):
-    MIN_INFERENCE_STEPS = 12
-
     def __init__(self, device_id: str, num_torch_threads: int = 1):
         super().__init__(device_id, num_torch_threads)
         self.pipeline = None
@@ -107,7 +105,8 @@ class TTDiTRunner(BaseMetalDeviceRunner):
 
         self.logger.info(f"Device {self.device_id}: Model loaded successfully")
 
-        # we use model construct to create the request without validation
+        # we use model_construct to create the request without validation
+        # (warmup uses 2 inference steps which is below the normal minimum)
         if self.settings.model_service == ModelServices.IMAGE.value:
             self.run(
                 [
@@ -117,7 +116,6 @@ class TTDiTRunner(BaseMetalDeviceRunner):
                         num_inference_steps=2,
                     )
                 ],
-                _skip_validation=True,
             )
         elif self.settings.model_service == ModelServices.VIDEO.value:
             self.run(
@@ -128,7 +126,6 @@ class TTDiTRunner(BaseMetalDeviceRunner):
                         num_inference_steps=2,
                     )
                 ],
-                _skip_validation=True,
             )
 
         self.logger.info(f"Device {self.device_id}: Model warmup completed")
@@ -140,11 +137,9 @@ class TTDiTRunner(BaseMetalDeviceRunner):
         TelemetryEvent.MODEL_INFERENCE,
         os.environ.get("TT_VISIBLE_DEVICES"),
     )
-    def run(self, requests: list[ImageGenerateRequest], _skip_validation: bool = False):
+    def run(self, requests: list[ImageGenerateRequest]):
         self.logger.debug(f"Device {self.device_id}: Running inference")
         request = requests[0]
-        if not _skip_validation:
-            self._validate_inference_steps(request)
         image = self.pipeline.run_single_prompt(
             prompt=request.prompt,
             negative_prompt=request.negative_prompt,
@@ -153,14 +148,6 @@ class TTDiTRunner(BaseMetalDeviceRunner):
         )
         self.logger.debug(f"Device {self.device_id}: Inference completed")
         return image
-
-    def _validate_inference_steps(self, request: ImageGenerateRequest) -> None:
-        """Validate request parameters for this specific model."""
-        if request.num_inference_steps < self.MIN_INFERENCE_STEPS:
-            raise ValueError(
-                f"num_inference_steps must be >= {self.MIN_INFERENCE_STEPS}, "
-                f"got {request.num_inference_steps}"
-            )
 
 
 class TTSD35Runner(TTDiTRunner):
@@ -179,8 +166,6 @@ class TTSD35Runner(TTDiTRunner):
 
 # Runner for Flux.1 dev and schnell. Model weights from settings.model_weights_path determine the exact model variant.
 class TTFlux1Runner(TTDiTRunner):
-    MIN_INFERENCE_STEPS = 4
-
     def __init__(self, device_id: str, num_torch_threads: int = 1):
         super().__init__(device_id, num_torch_threads)
 


### PR DESCRIPTION
Enable Flux models to run with 4 inference steps and add unit tests for per-model validation.