### PR TITLE
for min_rab_gb assume fp16 equivalent weights, add 0.5x overhead buffer

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -447,7 +447,8 @@ class ModelSpec:
                 )
 
         if not self.min_ram_gb and self.param_count:
-            object.__setattr__(self, "min_ram_gb", self.param_count * 4)
+            # assume fp16 equivalent weights, add 0.5x overhead buffer
+            object.__setattr__(self, "min_ram_gb", self.param_count * 2.5)
 
         # Generate default docker image if not provided
         if not self.docker_image:


### PR DESCRIPTION
# change log

* addresses https://github.com/tenstorrent/tt-inference-server/issues/2041