### PR TITLE
Model Spec fixes for Qwen 2.5 VL 3B and 7B

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -2029,19 +2029,13 @@ vlm_templates = [
             DeviceModelSpec(
                 device=DeviceTypes.N150,
                 max_concurrency=32,
-                max_context=128 * 1024,
+                max_context=32 * 1024,
                 default_impl=True,
             ),
             DeviceModelSpec(
                 device=DeviceTypes.N300,
                 max_concurrency=32,
-                max_context=128 * 1024,
-                default_impl=True,
-            ),
-            DeviceModelSpec(
-                device=DeviceTypes.T3K,
-                max_concurrency=32,
-                max_context=128 * 1024,
+                max_context=32 * 1024,
                 default_impl=True,
             ),
         ],
@@ -2064,23 +2058,17 @@ vlm_templates = [
             DeviceModelSpec(
                 device=DeviceTypes.N150,
                 max_concurrency=32,
-                max_context=128 * 1024,
+                max_context=32 * 1024,
                 default_impl=True,
             ),
             DeviceModelSpec(
                 device=DeviceTypes.N300,
                 max_concurrency=32,
-                max_context=128 * 1024,
+                max_context=32 * 1024,
                 default_impl=True,
                 override_tt_config={
                     "trace_region_size": 10000000,
                 },
-            ),
-            DeviceModelSpec(
-                device=DeviceTypes.T3K,
-                max_concurrency=32,
-                max_context=128 * 1024,
-                default_impl=True,
             ),
         ],
         status=ModelStatusTypes.EXPERIMENTAL,


### PR DESCRIPTION
1. Reduced max seq length from (128 * 1024) to (32 * 1024) due to OOM errors. These are occurring due to expanding intermediates and KV cache. 
2. Removed T3K spec as the tt-metal model does not support T3K.

Fixes issue: https://github.com/tenstorrent/tt-inference-server/issues/2024
