### PR TITLE
Make entrypoint permission setup best-effort for restricted environments

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,12 +30,18 @@ set_group_permissions() {
     
     # Set group if needed
     if [ "$current_group" != "$shared_group" ]; then
-        chown -R :"$shared_group" "$var_dir"
+        if ! chown -R :"$shared_group" "$var_dir" 2>/dev/null; then
+            echo "WARNING: could not chown ${var_dir} to group ${shared_group}"
+            return 0
+        fi
     fi
     
     # Set permissions if needed
     if [ "$current_perms" != "2775" ]; then
-        chmod -R 2775 "$var_dir"
+        if ! chmod -R 2775 "$var_dir" 2>/dev/null; then
+            echo "WARNING: could not chmod ${var_dir} to 2775"
+            return 0
+        fi
     fi
 }
 
@@ -54,8 +60,10 @@ fi
 # Get the created/existing group name
 SHARED_GROUP_NAME=$(getent group "$VOLUME_GROUP" | cut -d: -f1)
 
-# Add container user to the shared group
-usermod -a -G "$SHARED_GROUP_NAME" "${CONTAINER_APP_USERNAME}"
+# Add container user to the shared group (best-effort, may fail in restricted environments)
+if ! usermod -a -G "$SHARED_GROUP_NAME" "${CONTAINER_APP_USERNAME}" 2>/dev/null; then
+    echo "WARNING: could not add ${CONTAINER_APP_USERNAME} to group ${SHARED_GROUP_NAME} (usermod failed, likely restricted security context)"
+fi
 
 # Ensure new files get group write permissions (in current shell)
 umask 0002


### PR DESCRIPTION
- usermod, chown, and chmod in docker-entrypoint.sh fail in Kubernetes pods with restricted security contexts (e.g. read-only /etc/passwd), causing container crash loops with usermod: cannot lock /etc/passwd; Permission denied.
- These permission setup operations are now best-effort: they attempt the operation, log a warning on failure, and continue startup instead of crashing.
- No behavior change for VM/bare-metal environments where permissions work

**Context on why we need these changes:**
When running the container in Kubernetes, the entrypoint script tries to run usermod to add the app user to a shared group. That requires writing to /etc/passwd, which Kubernetes blocks in restricted security contexts. Because the script is set to exit on any error, that one failure kills the entire startup — the server never starts, and the pod crash-loops.
This fix wraps usermod, chown, and chmod so they warn on failure instead of crashing. The server continues to start because the cache directory (/tmp) is already world-writable, so the permission setup isn't actually needed for it to function.
On VMs and bare metal where the permissions aren't restricted, the commands still succeed and run exactly as before — the warning path is never hit. So existing deployments are unaffected.