### PR TITLE
Add C++ server jobs to PR gate block list

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -904,7 +904,7 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [lint, unit-tests, forge-runner-cpu-tests, llm-streaming-performance, test-coverage]
+    needs: [lint, unit-tests, forge-runner-cpu-tests, llm-streaming-performance, test-coverage, cpp-server-ttnn-build, cpp-server-llm-streaming]
     if: always()
     steps:
       - name: Check results
@@ -922,8 +922,20 @@ jobs:
             echo "❌ Forge runner tests failed"
             exit 1
           fi
+          if [[ "${{ needs.llm-streaming-performance.result }}" == "failure" ]]; then
+            echo "❌ LLM streaming performance test failed"
+            exit 1
+          fi
           if [[ "${{ needs.test-coverage.result }}" == "failure" ]]; then
             echo "❌ Test coverage below 50% threshold - PR blocked"
+            exit 1
+          fi
+          if [[ "${{ needs.cpp-server-ttnn-build.result }}" == "failure" ]]; then
+            echo "❌ C++ server TTNN build failed"
+            exit 1
+          fi
+          if [[ "${{ needs.cpp-server-llm-streaming.result }}" == "failure" ]]; then
+            echo "❌ C++ server LLM streaming test failed"
             exit 1
           fi
           echo "✅ All checks passed (or were skipped)"

--- a/tt-media-server/cpp_server/build.sh
+++ b/tt-media-server/cpp_server/build.sh
@@ -9,7 +9,6 @@ BUILD_DIR="${SCRIPT_DIR}/build"
 BUILD_TYPE="Release"
 
 # Parse arguments
-TEST="OFF"
 SANITIZE_THREAD="OFF"
 SANITIZE_ADDRESS="OFF"
 TOOLCHAIN_PATH_ARG=""
@@ -18,10 +17,6 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --debug)
             BUILD_TYPE="Debug"
-            shift
-            ;;
-        --test)
-            TEST="ON"
             shift
             ;;
         --tsan)
@@ -47,7 +42,6 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --debug              Build in Debug mode (default: Release)"
-            echo "  --test               Build for PR gate: LLM only (no Python required)"
             echo "  --tsan               Build with ThreadSanitizer for data-race detection"
             echo "  --asan               Build with AddressSanitizer + LeakSanitizer for memory/leak detection"
             echo "  --toolchain-path P   Use CMake toolchain file (overrides TT_METAL_HOME toolchain)"
@@ -71,7 +65,6 @@ fi
 echo "=============================================="
 echo "  Building TT Media Server (C++ Drogon)"
 echo "  Build type: ${BUILD_TYPE}"
-echo "  Test build: ${TEST}"
 echo "  ThreadSanitizer: ${SANITIZE_THREAD}"
 echo "  AddressSanitizer: ${SANITIZE_ADDRESS}"
 echo "=============================================="
@@ -218,7 +211,6 @@ CMAKE_ARGS=(
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     -DLLM_ENGINE_DEBUG_BUILD=OFF
-    -DTEST="${TEST}"
     -DSANITIZE_THREAD="${SANITIZE_THREAD}"
     -DSANITIZE_ADDRESS="${SANITIZE_ADDRESS}"
 )


### PR DESCRIPTION
- Add `cpp-server-ttnn-build`, `cpp-server-llm-streaming`, and `llm-streaming-performance` failure checks to the ci-gate job so they block PR merges on failure.
- Remove the `--test` build flag from build.sh