### PR TITLE
Fix BGE-Large Nightly Fails

### DIFF
--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -218,6 +218,8 @@ class Settings(BaseSettings):
             # Apply all configuration values
             for key, value in matching_config.items():
                 if hasattr(self, key):
+                    if key == "vllm" and isinstance(value, dict):
+                        value = VLLMSettings(**value)
                     setattr(self, key, value)
         if any(
             self.model_runner == r.value


### PR DESCRIPTION
## Problem
When the media server was started with `model` and `device` specified, vllm was parsed as a dictionary rather than an object due to its definition in `constants.py`, which led to failures in CI.

## Testing
### CI run:
https://github.com/tenstorrent/tt-shield/actions/runs/22345804125