### PR TITLE
set subprocess.Popen log streaming to use INFO for stderr so uv logs are appropriately labeled

### DIFF
--- a/workflows/utils.py
+++ b/workflows/utils.py
@@ -250,7 +250,7 @@ def run_command(
         )
         stderr_thread = threading.Thread(
             target=stream_subprocess_output,
-            args=(process.stderr, logger, logging.ERROR),
+            args=(process.stderr, logger, logging.INFO),
         )
 
         stdout_thread.start()


### PR DESCRIPTION
# change log

* set subprocess.Popen log streaming to use INFO for stderr so uv logs are appropriately labeled

## discussion

This sets the ERROR logs like below to INFO appropriately:
```
2026-02-24 22:25:19,607 - utils.py:185 - ERROR: Using Python 3.10.18 environment at: .workflow_venvs/.venv_tt_smi                                                
2026-02-24 22:25:19,615 - utils.py:185 - ERROR: Audited 1 package in 8ms                                                                                         
2026-02-24 22:25:19,619 - run_system_software_validation.py:40 - INFO: Running tt-smi -s to get device telemetry                                                 
2026-02-24 22:25:20,208 - run_system_software_validation.py:64 - INFO: Successfully parsed tt-smi data                                                           
2026-02-24 22:25:20,210 - utils.py:234 - INFO: Running command: /home/tstesco/projects/tt-inference-server/.workflow_venvs/.venv_bootstrap_uv/bin/uv venv --manag
ed-python --python=3.10 /home/tstesco/projects/tt-inference-server/.workflow_venvs/.venv_tt_topology --allow-existing                                            2026-02-24 22:25:20,285 - utils.py:185 - ERROR: Using CPython 3.10.18                                                                                            
2026-02-24 22:25:20,285 - utils.py:185 - ERROR: Creating virtual environment at: .workflow_venvs/.venv_tt_topology                                               
2026-02-24 22:25:20,285 - utils.py:185 - ERROR: Activate with: source .workflow_venvs/.venv_tt_topology/bin/activate                                             
2026-02-24 22:25:20,289 - workflow_venvs.py:595 - INFO: running setup_tt_topology() ...                                                                          
2026-02-24 22:25:20,290 - utils.py:234 - INFO: Running command: /home/tstesco/projects/tt-inference-server/.workflow_venvs/.venv_bootstrap_uv/bin/uv pip install 
--managed-python --python /home/tstesco/projects/tt-inference-server/.workflow_venvs/.venv_tt_topology/bin/python tt-topology==1.2.16                            
2026-02-24 22:25:20,302 - utils.py:185 - ERROR: Using Python 3.10.18 environment at: .workflow_venvs/.venv_tt_topology                                           
2026-02-24 22:25:20,479 - utils.py:185 - ERROR: Resolved 44 packages in 159ms                                                                                    
2026-02-24 22:25:20,485 - utils.py:185 - ERROR: Downloading fonttools (4.6MiB)                                                                                   
2026-02-24 22:25:20,486 - utils.py:185 - ERROR: Downloading networkx (1.6MiB)                                                                                    
2026-02-24 22:25:20,486 - utils.py:185 - ERROR: Downloading kiwisolver (1.6MiB)                                                                                  
2026-02-24 22:25:20,487 - utils.py:185 - ERROR: Downloading pillow (6.7MiB)                                                                                      
2026-02-24 22:25:20,487 - utils.py:185 - ERROR: Downloading numpy (16.0MiB)                                                                                      
2026-02-24 22:25:20,488 - utils.py:185 - ERROR: Downloading matplotlib (8.3MiB)                                                                                  
2026-02-24 22:25:20,594 - utils.py:185 - ERROR: Downloaded kiwisolver                                                                                            
2026-02-24 22:25:20,831 - utils.py:185 - ERROR: Downloaded pillow                                                                                                
2026-02-24 22:25:20,857 - utils.py:185 - ERROR: Downloaded fonttools                                                                                             
2026-02-24 22:25:20,910 - utils.py:185 - ERROR: Downloaded networkx                                                                                              
2026-02-24 22:25:20,941 - utils.py:185 - ERROR: Downloaded matplotlib                                                                                            
2026-02-24 22:25:21,269 - utils.py:185 - ERROR: Downloaded numpy                                                                                                 
2026-02-24 22:25:21,270 - utils.py:185 - ERROR: Prepared 12 packages in 789ms                                                                                    
2026-02-24 22:25:21,357 - utils.py:185 - ERROR: Installed 44 packages in 87ms                                                                                    
2026-02-24 22:25:21,357 - utils.py:185 - ERROR: + annotated-types==0.7.0                 
```