### PR TITLE
Overhaul vLLM logging to use V1 modules

### DIFF
--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -8,9 +8,7 @@ import logging
 import importlib
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
 
-from vllm.v1.metrics.loggers import logger
 
 LOG_TIMESTAMP = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 LOG_PATH = Path(os.getenv("CACHE_ROOT", ".")) / "logs" / f"vllm_{LOG_TIMESTAMP}.log"


### PR DESCRIPTION
Since the [vLLM V0 engine has been deprecated](https://github.com/tenstorrent/vllm/pull/323) our nightly has been failing due to some vLLM modules no longer existing, triggering import errors.

This PR overhauls the vLLM logging setup that we perform during server init