### PR TITLE
ML commons open-clip version

### DIFF
--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -345,7 +345,7 @@ def setup_evals_video(
     )
     setup_succeeded = (
         run_command(
-            command=f"{UV_EXEC} pip install --managed-python --python {venv_config.venv_python} requests datasets open-clip-torch pyjwt==2.7.0 pillow==11.1 imageio imageio-ffmpeg",
+            command=f"{UV_EXEC} pip install --managed-python --python {venv_config.venv_python} requests datasets open-clip-torch==2.26.1 pyjwt==2.7.0 pillow==11.1 imageio imageio-ffmpeg",
             logger=logger,
         )
         == 0


### PR DESCRIPTION
## Problem description
PR in TT-metal: SDXL change open-clip-torch==2.26.1 [link](https://github.com/tenstorrent/tt-metal/pull/38878) changes version of open-clip-torch==2.26.1 to MLcommons reference version - which changes clip score in many accuracy tests

This PR makes sure open-clip-torch is same in tt-inference-server and tt-metal - so clip scores stay identical between tt-metal and tt-inference-server 

## Checklist
- [x] sd35 with inference server: passed: [link](https://github.com/tenstorrent/tt-shield/actions/runs/22636362859)
- [ ] flux.1-dev with inference server: failed [link](https://github.com/tenstorrent/tt-shield/actions/runs/22636376637/job/65606356390), same error on main (On nightly) [link](https://github.com/tenstorrent/tt-shield/actions/runs/22597865268/job/65477926532)
- [x] motif with inference server: passed [link](https://github.com/tenstorrent/tt-shield/actions/runs/22636399710)
- [ ] flux.1-schenel with inference server: failed [link](https://github.com/tenstorrent/tt-shield/actions/runs/22636387290), same error on main (On nightly) [link](https://github.com/tenstorrent/tt-shield/actions/runs/22553793579/job/65329602526)
