### PR TITLE
Save detailed performance metrics in vLLM benchmarking

### DIFF
--- a/benchmarking/run_benchmarks.py
+++ b/benchmarking/run_benchmarks.py
@@ -164,6 +164,7 @@ def build_benchmark_command(
         "--random-output-len", str(osl),
         "--percentile-metrics", "ttft,tpot,itl,e2el",  # must add e2el in order for it to be logged
         "--save-result",
+        "--save-detailed",
         "--result-filename", str(result_filename),
     ]
 


### PR DESCRIPTION
This PR closes #2269 

Turns out `vllm bench serve ...` has a CLI flag for this https://docs.vllm.ai/en/stable/cli/bench/serve/#-save-detailed

Llama-3.2-1B run on n300: https://github.com/tenstorrent/tt-shield/actions/runs/22699685844, check out the benchmark workflow logs to see the correct metrics