### PR TITLE
Integrate E2E BlazeDS ModelPipline (decode only) with runner.py

### DIFF
--- a/tt-media-server/cpp_server/src/runners/runner.py
+++ b/tt-media-server/cpp_server/src/runners/runner.py
@@ -14,28 +14,18 @@ Launch with:
 import mmap
 import os
 import signal
+import argparse
 import struct
 import sys
+from pathlib import Path
 
-import torch
 import ttnn
 
-from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
-from models.demos.deepseek_v3_b1.micro_ops.host_io.utils import (
-    ttnn_dtype_from_torch_dtype,
-)
+from models.demos.deepseek_v3_b1.demo.model_pipeline import ModelPipeline
+from models.demos.deepseek_v3_b1.demo.pipeline import create_fabric_router_config
 
-# ── Pipeline sizing ──────────────────────────────────────────────────────────
-# 64-byte end-to-end pages: 32 bfloat16 elements × 2 bytes = 64 bytes per row.
-# Matches the H2D token page size so the same page flows H2D → D2D → D2H.
-EMBEDDING_DIM = 32
-EMBEDDING_VOCAB = 131072  # covers max token id (~125836) in fixed_reply_sequence
-EMBEDDING_DTYPE = torch.bfloat16
-EMBEDDING_SIZE_BYTES = EMBEDDING_DIM * 2  # 32 × 2 = 64 bytes
+# ── Token sizing ─────────────────────────────────────────────────────────────
 TOKEN_SIZE_BYTES = 64  # H2D page: task_id (36 B) + token_id (8 B) + pad
-FIFO_SIZE = 128  # 2 × page size for minimal in-flight buffering
-PIPELINE_CORE = ttnn.CoreCoord(0, 0)
-FABRIC_MAX_PAYLOAD = 7168
 
 # ── Shared-memory layout ─────────────────────────────────────────────────────
 # Must match the C++ SharedMemory class in shared_memory.hpp.
@@ -63,6 +53,43 @@ def _handle_sigterm(signum, frame):
 def _rank() -> int:
     r = os.environ.get("OMPI_COMM_WORLD_RANK") or os.environ.get("RANK")
     return int(r) if r is not None else 0
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser("tt-cpp-server runner")
+    parser.add_argument(
+        "--cache-path",
+        type=Path,
+        default=Path("/mnt/models/deepseek-ai/cache-mar3-2/"),
+        help="Path to the weight cache directory (required for --weights real)",
+    )
+    parser.add_argument(
+        "--weights",
+        type=str,
+        choices=("synthetic", "real"),
+        default="synthetic",
+        help="Use synthetic or real (cached) weights (default: synthetic)",
+    )
+    parser.add_argument(
+        "--fabric-max-payload-bytes",
+        type=int,
+        default=15232,
+        help="Fabric router max packet payload bytes (must match DeepSeek V3 B1 pipeline config)",
+    )
+    parser.add_argument(
+        "--trace-region-size-bytes",
+        type=int,
+        default=573440,
+        help="TTNN trace region size bytes (must match DeepSeek V3 B1 pipeline config)",
+    )
+    parser.add_argument(
+        "--fabric-router-sync-timeout-ms",
+        type=int,
+        default=30000,
+        help="Set TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS (ms).",
+    )
+    args, _unknown = parser.parse_known_args(argv)
+    return args
 
 
 def _shm_recv(buf, pos: int):
@@ -109,11 +136,33 @@ def _open_shm(shm_name: str):
         os.close(fd)
 
 
-def _open_mesh_device():
-    fabric_router_config = ttnn._ttnn.fabric.FabricRouterConfig()
-    fabric_router_config.max_packet_payload_size_bytes = FABRIC_MAX_PAYLOAD
+def _shm_is_configured() -> bool:
+    c2p_name = os.environ.get("TT_IPC_SHM_C2P")
+    p2c_name = os.environ.get("TT_IPC_SHM_P2C")
+    if not (c2p_name and p2c_name):
+        return False
+    return os.path.exists(f"/dev/shm/{c2p_name}") and os.path.exists(f"/dev/shm/{p2c_name}")
+
+
+def _fabric_config_for_num_procs(num_procs: int):
+    if num_procs == 4:
+        return ttnn.FabricConfig.FABRIC_2D
+    if num_procs in (16, 64):
+        return ttnn.FabricConfig.FABRIC_2D_TORUS_Y
+    raise ValueError(f"Unsupported num_procs for fabric config: {num_procs} (expected 4, 16, or 64)")
+
+
+def _open_mesh_device(
+    fabric_max_payload_bytes: int,
+    trace_region_size_bytes: int,
+    fabric_router_sync_timeout_ms: int,
+):
+    os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = str(fabric_router_sync_timeout_ms)
+
+    num_procs = int(ttnn.distributed_context_get_size())
+    fabric_router_config = create_fabric_router_config(fabric_max_payload_bytes)
     ttnn.set_fabric_config(
-        ttnn.FabricConfig.FABRIC_2D,
+        _fabric_config_for_num_procs(num_procs),
         ttnn.FabricReliabilityMode.STRICT_INIT,
         None,
         ttnn.FabricTensixConfig.DISABLED,
@@ -121,50 +170,37 @@ def _open_mesh_device():
         ttnn.FabricManagerMode.DEFAULT,
         fabric_router_config,
     )
-    return ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(4, 2))
+    try:
+        return ttnn.open_mesh_device(
+            mesh_shape=ttnn.MeshShape(4, 2),
+            trace_region_size=trace_region_size_bytes,
+        )
+    except TypeError:
+        return ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(4, 2))
 
 
-def _create_embedding_tensor(mesh_device):
-    torch_embedding = torch.randn(
-        (1, 1, EMBEDDING_VOCAB, EMBEDDING_DIM), dtype=EMBEDDING_DTYPE
-    )
-    embedding_tensor = ttnn.from_torch(
-        torch_embedding,
-        dtype=ttnn_dtype_from_torch_dtype(EMBEDDING_DTYPE),
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-    )
-    return ttnn.to_device(
-        embedding_tensor, mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-    )
+def _parse_token_id(payload: bytes) -> int:
+    if len(payload) < (_TOKEN_ID_OFFSET + _TOKEN_ID_SIZE):
+        raise ValueError(f"payload too small: expected at least {_TOKEN_ID_OFFSET + _TOKEN_ID_SIZE} bytes")
+    # Extract token_id as little-endian uint64 from payload[36:44].
+    return int(struct.unpack_from("<Q", payload, _TOKEN_ID_OFFSET)[0])
 
 
-def _create_pipeline_block(mesh_device) -> PipelineBlock:
-    pipeline_args = (
-        mesh_device,
-        PIPELINE_CORE,
-        FIFO_SIZE,  # upstream d2d socket fifo size
-        FIFO_SIZE,  # downstream d2d socket fifo size
-        EMBEDDING_SIZE_BYTES,  # upstream d2d socket page size
-        EMBEDDING_SIZE_BYTES,  # downstream d2d socket page size
-    )
-    if mesh_device.get_system_mesh_id() != 0:
-        return PipelineBlock(*pipeline_args)
-    return PipelineBlock(
-        *pipeline_args,
-        h2d_socket_fifo_size=FIFO_SIZE,
-        d2h_socket_fifo_size=FIFO_SIZE,
-        d2h_socket_page_size=EMBEDDING_SIZE_BYTES,
-        embedding_tensor=_create_embedding_tensor(mesh_device),
-    )
+def _write_token_id(payload: bytes, token_id: int) -> bytes:
+    if len(payload) < _PAYLOAD_SIZE:
+        payload = payload.ljust(_PAYLOAD_SIZE, b"\x00")
+    out = bytearray(payload[:_PAYLOAD_SIZE])
+    # Overwrite token_id as little-endian uint64 at payload[36:44], preserving task_id bytes.
+    struct.pack_into("<Q", out, _TOKEN_ID_OFFSET, int(token_id))
+    return bytes(out)
 
 
-def _shm_pipeline_bridge(pipeline_block, c2p_buf, p2c_buf) -> None:
-    """Single-thread bridge: recv → tensor → write_token → read_output → send.
+def _shm_pipeline_bridge(model_pipeline: ModelPipeline, c2p_buf, p2c_buf) -> None:
+    """Single-thread bridge: recv → decode_forward(token_id) → send(updated token_id).
 
     A single-thread design avoids Python GIL contention (~5 ms switch interval)
     that a two-thread design would introduce.
     """
-    token_elems = TOKEN_SIZE_BYTES // 4
     recv_pos = 0
     send_pos = 0
 
@@ -173,28 +209,13 @@ def _shm_pipeline_bridge(pipeline_block, c2p_buf, p2c_buf) -> None:
         if payload is None:
             break
 
-        page = bytearray(TOKEN_SIZE_BYTES)
-        page[: len(payload)] = payload
-        token_ints = struct.unpack_from(f"<{token_elems}I", page)
-
-        input_tensor = ttnn.from_torch(
-            torch.tensor(token_ints, dtype=torch.uint32).reshape(1, -1),
-            dtype=ttnn.uint32,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-        pipeline_block.write_token(input_tensor)
-
-        output_tensor = ttnn.from_torch(
-            torch.zeros(1, EMBEDDING_DIM, dtype=EMBEDDING_DTYPE),
-            dtype=ttnn_dtype_from_torch_dtype(EMBEDDING_DTYPE),
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-        pipeline_block.read_output(output_tensor)
-
-        send_pos = _shm_send(p2c_buf, payload, send_pos)
+        input_token_id = _parse_token_id(payload)
+        output_token_id = model_pipeline.decode_forward(input_token_id)
+        out_payload = _write_token_id(payload, output_token_id)
+        send_pos = _shm_send(p2c_buf, out_payload, send_pos)
 
 
-def _run_shm_bridge(pipeline_block) -> None:
+def _run_shm_bridge(model_pipeline: ModelPipeline) -> None:
     """Open shared-memory buffers and run the pipeline bridge if env vars are set."""
     c2p_name = os.environ.get("TT_IPC_SHM_C2P")
     p2c_name = os.environ.get("TT_IPC_SHM_P2C")
@@ -203,9 +224,9 @@ def _run_shm_bridge(pipeline_block) -> None:
     c2p_buf = _open_shm(c2p_name)
     p2c_buf = _open_shm(p2c_name)
     if not (c2p_buf and p2c_buf):
-        return
+        raise RuntimeError("Shared memory configured but could not be opened")
     try:
-        _shm_pipeline_bridge(pipeline_block, c2p_buf, p2c_buf)
+        _shm_pipeline_bridge(model_pipeline, c2p_buf, p2c_buf)
     finally:
         c2p_buf.close()
         p2c_buf.close()
@@ -214,24 +235,49 @@ def _run_shm_bridge(pipeline_block) -> None:
 def main() -> None:
     signal.signal(signal.SIGTERM, _handle_sigterm)
     rank = _rank()
+    args = _parse_args(sys.argv[1:])
 
     try:
-        mesh_device = _open_mesh_device()
+        try:
+            ttnn.init_distributed_context()
+        except Exception as e:
+            # Some launchers may initialize distributed context before invoking this script.
+            if "already" not in str(e).lower():
+                raise
+        mesh_device = _open_mesh_device(
+            fabric_max_payload_bytes=args.fabric_max_payload_bytes,
+            trace_region_size_bytes=args.trace_region_size_bytes,
+            fabric_router_sync_timeout_ms=args.fabric_router_sync_timeout_ms,
+        )
     except Exception as e:
         print(f"Rank {rank}: failed to open mesh device: {e}", file=sys.stderr)
         sys.exit(1)
 
-    ttnn.enable_asynchronous_slow_dispatch(mesh_device)
-
     try:
-        pipeline_block = _create_pipeline_block(mesh_device)
-        pipeline_block.run()
+        shm_enabled = _shm_is_configured()
+        if not shm_enabled:
+            raise RuntimeError(
+                "Shared memory bridge not configured. Set TT_IPC_SHM_C2P and TT_IPC_SHM_P2C "
+                "and ensure both exist under /dev/shm/."
+            )
+        
+        cache_path = args.cache_path
+        use_real_weights = args.weights == "real"
 
-        if pipeline_block.is_first_pipeline_stage():
-            _run_shm_bridge(pipeline_block)
+        model_pipeline = ModelPipeline(
+            mesh_device=mesh_device,
+            cache_path=cache_path,
+            use_real_weights=use_real_weights,
+        )
+
+        if mesh_device.get_system_mesh_id() == 0:
+            _run_shm_bridge(model_pipeline)
+        else:
+            while not _shutdown:
+                signal.pause()
 
         # All ranks must reach terminate() together — it acts as a collective barrier.
-        pipeline_block.terminate()
+        model_pipeline.pipeline.terminate()
     finally:
         ttnn.close_mesh_device(mesh_device)
         ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)


### PR DESCRIPTION
- Integrated BlazeDS ModelPipeline interface with runner.py (only decode initially)
- For each shm message parse token_id → decode_forward(token_id) → write the output token_id back into the payload and send it back
- Aligned device/pipeline configuration with the DeepSeek demo and made it configurable: added additional CLI args and updated mesh-device setup accordingly
- This PR relies on https://github.com/tenstorrent/tt-metal/pull/39162

EDIT: The changes from this PR have been merged in https://github.com/tenstorrent/tt-inference-server/pull/2308 instead. 