### PR TITLE
Enable Prefill and Decode Warmup for Llama Runner

### DIFF
--- a/tt-media-server/tt_model_runners/llama_runner.py
+++ b/tt-media-server/tt_model_runners/llama_runner.py
@@ -110,14 +110,14 @@ class Llama31_8BRunner(BaseMetalDeviceRunner):
         self._max_num_blocks_per_seq = 0
 
     def get_pipeline_device_params(self):
-        return {"num_command_queues": 1, "trace_region_size": 50_000_000}
+        return {"num_command_queues": 2, "trace_region_size": 50000000}
 
     def _page_table_from_block_ids(self, block_ids: list[int], torch) -> Any:
         """Build page_table tensor from block IDs (single sequence, shape [1, max_blocks]).
 
         Unused entries are set to -1 (SKIP_PAGE_TABLE_ENTRY in the paged_fill_cache
-        kernel).  Zero-padding would alias with physical block 0, causing
-        paged_fill_cache to overwrite block 0's KV data with padding tokens."""
+        kernel).
+        """
         max_blocks = self._max_num_blocks_per_seq
         page_table = torch.full((1, max_blocks), -1, dtype=torch.int32)
         n = min(len(block_ids), max_blocks)
@@ -188,7 +188,6 @@ class Llama31_8BRunner(BaseMetalDeviceRunner):
             f"Device {self.device_id}: Warmup done (max_batch_size={self.max_batch_size}, "
             "batched decode enabled when multiple sequences per step)"
         )
-
         return True
 
     def run(


### PR DESCRIPTION
## Issue
[#2275 [LlamaRunner][cpp-server] Warmup Llama Model with Trace for Supported ISL/OSL combinations](https://github.com/tenstorrent/tt-inference-server/issues/2275)

## Problem
Previously, the trace was captured during the first inference, which increased both the TTFT and the overall duration of the initial request. With these changes, the Llama model is warmed up before the first inference, allowing it to return correct results immediately.