### PR TITLE
Update whisper tt-metal commit from cce3da6 to 3b3f62b for WH

### DIFF
--- a/default_model_spec.json
+++ b/default_model_spec.json
@@ -17390,7 +17390,7 @@
           "model_name": "whisper-large-v3",
           "inference_engine": "media",
           "device_type": "N150",
-          "tt_metal_commit": "cce3da6",
+          "tt_metal_commit": "3b3f62b",
           "device_model_spec": {
             "device": "N150",
             "max_concurrency": 1,
@@ -17470,9 +17470,9 @@
           "model_type": "AUDIO",
           "repacked": 0,
           "version": "0.9.0",
-          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-cce3da6",
+          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-3b3f62b",
           "status": "COMPLETE",
-          "code_link": "https://github.com/tenstorrent/tt-metal/tree/cce3da6/models/demos/whisper",
+          "code_link": "https://github.com/tenstorrent/tt-metal/tree/3b3f62b/models/demos/whisper",
           "override_tt_config": {},
           "supported_modalities": [
             "text"
@@ -17498,7 +17498,7 @@
           "model_name": "whisper-large-v3",
           "inference_engine": "media",
           "device_type": "N300",
-          "tt_metal_commit": "cce3da6",
+          "tt_metal_commit": "3b3f62b",
           "device_model_spec": {
             "device": "N300",
             "max_concurrency": 1,
@@ -17541,9 +17541,9 @@
           "model_type": "AUDIO",
           "repacked": 0,
           "version": "0.9.0",
-          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-cce3da6",
+          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-3b3f62b",
           "status": "COMPLETE",
-          "code_link": "https://github.com/tenstorrent/tt-metal/tree/cce3da6/models/demos/whisper",
+          "code_link": "https://github.com/tenstorrent/tt-metal/tree/3b3f62b/models/demos/whisper",
           "override_tt_config": {},
           "supported_modalities": [
             "text"
@@ -17569,7 +17569,7 @@
           "model_name": "whisper-large-v3",
           "inference_engine": "media",
           "device_type": "GALAXY",
-          "tt_metal_commit": "cce3da6",
+          "tt_metal_commit": "3b3f62b",
           "device_model_spec": {
             "device": "GALAXY",
             "max_concurrency": 32,
@@ -17649,9 +17649,9 @@
           "model_type": "AUDIO",
           "repacked": 0,
           "version": "0.9.0",
-          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-cce3da6",
+          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-3b3f62b",
           "status": "COMPLETE",
-          "code_link": "https://github.com/tenstorrent/tt-metal/tree/cce3da6/models/demos/whisper",
+          "code_link": "https://github.com/tenstorrent/tt-metal/tree/3b3f62b/models/demos/whisper",
           "override_tt_config": {},
           "supported_modalities": [
             "text"
@@ -17677,7 +17677,7 @@
           "model_name": "whisper-large-v3",
           "inference_engine": "media",
           "device_type": "T3K",
-          "tt_metal_commit": "cce3da6",
+          "tt_metal_commit": "3b3f62b",
           "device_model_spec": {
             "device": "T3K",
             "max_concurrency": 4,
@@ -17759,9 +17759,9 @@
           "model_type": "AUDIO",
           "repacked": 0,
           "version": "0.9.0",
-          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-cce3da6",
+          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-3b3f62b",
           "status": "COMPLETE",
-          "code_link": "https://github.com/tenstorrent/tt-metal/tree/cce3da6/models/demos/whisper",
+          "code_link": "https://github.com/tenstorrent/tt-metal/tree/3b3f62b/models/demos/whisper",
           "override_tt_config": {},
           "supported_modalities": [
             "text"
@@ -17789,7 +17789,7 @@
           "model_name": "distil-large-v3",
           "inference_engine": "media",
           "device_type": "N150",
-          "tt_metal_commit": "cce3da6",
+          "tt_metal_commit": "3b3f62b",
           "device_model_spec": {
             "device": "N150",
             "max_concurrency": 1,
@@ -17869,9 +17869,9 @@
           "model_type": "AUDIO",
           "repacked": 0,
           "version": "0.9.0",
-          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-cce3da6",
+          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-3b3f62b",
           "status": "COMPLETE",
-          "code_link": "https://github.com/tenstorrent/tt-metal/tree/cce3da6/models/demos/whisper",
+          "code_link": "https://github.com/tenstorrent/tt-metal/tree/3b3f62b/models/demos/whisper",
           "override_tt_config": {},
           "supported_modalities": [
             "text"
@@ -17897,7 +17897,7 @@
           "model_name": "distil-large-v3",
           "inference_engine": "media",
           "device_type": "N300",
-          "tt_metal_commit": "cce3da6",
+          "tt_metal_commit": "3b3f62b",
           "device_model_spec": {
             "device": "N300",
             "max_concurrency": 1,
@@ -17940,9 +17940,9 @@
           "model_type": "AUDIO",
           "repacked": 0,
           "version": "0.9.0",
-          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-cce3da6",
+          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-3b3f62b",
           "status": "COMPLETE",
-          "code_link": "https://github.com/tenstorrent/tt-metal/tree/cce3da6/models/demos/whisper",
+          "code_link": "https://github.com/tenstorrent/tt-metal/tree/3b3f62b/models/demos/whisper",
           "override_tt_config": {},
           "supported_modalities": [
             "text"
@@ -17968,7 +17968,7 @@
           "model_name": "distil-large-v3",
           "inference_engine": "media",
           "device_type": "GALAXY",
-          "tt_metal_commit": "cce3da6",
+          "tt_metal_commit": "3b3f62b",
           "device_model_spec": {
             "device": "GALAXY",
             "max_concurrency": 32,
@@ -18048,9 +18048,9 @@
           "model_type": "AUDIO",
           "repacked": 0,
           "version": "0.9.0",
-          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-cce3da6",
+          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-3b3f62b",
           "status": "COMPLETE",
-          "code_link": "https://github.com/tenstorrent/tt-metal/tree/cce3da6/models/demos/whisper",
+          "code_link": "https://github.com/tenstorrent/tt-metal/tree/3b3f62b/models/demos/whisper",
           "override_tt_config": {},
           "supported_modalities": [
             "text"
@@ -18076,7 +18076,7 @@
           "model_name": "distil-large-v3",
           "inference_engine": "media",
           "device_type": "T3K",
-          "tt_metal_commit": "cce3da6",
+          "tt_metal_commit": "3b3f62b",
           "device_model_spec": {
             "device": "T3K",
             "max_concurrency": 4,
@@ -18158,9 +18158,9 @@
           "model_type": "AUDIO",
           "repacked": 0,
           "version": "0.9.0",
-          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-cce3da6",
+          "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-3b3f62b",
           "status": "COMPLETE",
-          "code_link": "https://github.com/tenstorrent/tt-metal/tree/cce3da6/models/demos/whisper",
+          "code_link": "https://github.com/tenstorrent/tt-metal/tree/3b3f62b/models/demos/whisper",
           "override_tt_config": {},
           "supported_modalities": [
             "text"

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -2496,7 +2496,7 @@ image_templates = [
 audio_tts_templates = [
     ModelSpecTemplate(
         weights=["openai/whisper-large-v3", "distil-whisper/distil-large-v3"],
-        tt_metal_commit="cce3da6",
+        tt_metal_commit="3b3f62b",
         impl=whisper_impl,
         min_disk_gb=15,
         min_ram_gb=6,

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -2214,7 +2214,11 @@ def evals_release_report_data(args, results, meta_data, model_spec):
                 configured_keys = kwargs.get("result_keys", [])
                 actual_data = results.get(t_key, {})
 
-                key_found = any(k in actual_data for k in configured_keys)
+                # For multilevel (tuple) keys, check the terminal key against actual_data
+                key_found = any(
+                    (k[-1] if isinstance(k, tuple) else k) in actual_data
+                    for k in configured_keys
+                )
 
                 if not key_found:
                     valid_candidates = [
@@ -2236,32 +2240,37 @@ def evals_release_report_data(args, results, meta_data, model_spec):
                     )
                 except Exception as e:
                     logger.warning(f"  Could not calculate score for {t_key}: {e}")
-                    score = 0.0
-                if kwargs.get("unit") == "WER":
+                    score = None
+                if score is not None and kwargs.get("unit") == "WER":
                     score = 100 - score
 
-                if task.score.published_score:
+                if score is None:
+                    ratio_to_published = "N/A"
+                    ratio_to_reference = "N/A"
+                    accuracy_check = ReportCheckTypes.FAIL
+                elif task.score.published_score:
                     assert task.score.published_score > 0, "Published score is not > 0"
                     ratio_to_published = score / task.score.published_score
                 else:
                     ratio_to_published = "N/A"
 
-                if task.score.gpu_reference_score:
-                    assert task.score.gpu_reference_score > 0, (
-                        "Reference score is not > 0"
-                    )
-                    ratio_to_reference = score / task.score.gpu_reference_score
-                    accuracy_check = ReportCheckTypes.from_result(
-                        ratio_to_reference >= (1.0 - task.score.tolerance)
-                    )
-                else:
-                    ratio_to_reference = "N/A"
-                    if task.score.published_score:
+                if score is not None:
+                    if task.score.gpu_reference_score:
+                        assert task.score.gpu_reference_score > 0, (
+                            "Reference score is not > 0"
+                        )
+                        ratio_to_reference = score / task.score.gpu_reference_score
                         accuracy_check = ReportCheckTypes.from_result(
-                            ratio_to_published >= (1.0 - task.score.tolerance)
+                            ratio_to_reference >= (1.0 - task.score.tolerance)
                         )
                     else:
-                        accuracy_check = ReportCheckTypes.NA
+                        ratio_to_reference = "N/A"
+                        if task.score.published_score:
+                            accuracy_check = ReportCheckTypes.from_result(
+                                ratio_to_published >= (1.0 - task.score.tolerance)
+                            )
+                        else:
+                            accuracy_check = ReportCheckTypes.NA
 
                 report_rows.append(
                     {
@@ -3119,10 +3128,8 @@ def benchmarks_release_data_format(
                 self.model_spec = model_spec
 
         wrapper = ModelSpecWrapper(model_spec)
-        streaming_enabled = is_streaming_enabled_for_whisper(wrapper, runtime_config)
-        preprocessing_enabled = is_preprocessing_enabled_for_whisper(
-            wrapper, runtime_config
-        )
+        streaming_enabled = is_streaming_enabled_for_whisper(wrapper)
+        preprocessing_enabled = is_preprocessing_enabled_for_whisper(wrapper)
 
         benchmark_summary["streaming_enabled"] = streaming_enabled
         benchmark_summary["preprocessing_enabled"] = preprocessing_enabled


### PR DESCRIPTION
## Summary

- Fixes whisper server startup failure: `No module named 'ttnn.model_preprocessing'`
- The Docker image built from `cce3da6` no longer ships `ttnn.model_preprocessing`; commit `3b3f62b` resolves this
- Updates `audio_tts_templates` in `workflows/model_spec.py` to point to the correct tt-metal commit