### PR TITLE
Remove vLLM V0 engine config for Qwen3-VL-32B-Instruct

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -2109,13 +2109,11 @@ vlm_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
-                vllm_args={"num_scheduler_steps": 1},
             ),
         ],
         status=ModelStatusTypes.EXPERIMENTAL,
         env_vars={
             "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
-            "VLLM_USE_V1": "1",
         },
         supported_modalities=["text", "image"],
     ),


### PR DESCRIPTION
This PR addresses https://github.com/tenstorrent/tt-inference-server/issues/2009#issuecomment-4014250485

Models CI run: https://github.com/tenstorrent/tt-shield/actions/runs/22809352777