### PR TITLE
Fix vision eval api

### DIFF
--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -190,10 +190,15 @@ def build_eval_command(
     if task.max_concurrent:
         optional_model_args.append(f"num_concurrent={task.max_concurrent}")
 
-    # newer lm-evals expect full completions api route
-    _base_url = (
-        base_url if task.workflow_venv_type == WorkflowVenvType.EVALS_META else api_url
-    )
+    # lm-eval (text) expects full completions api route in base_url
+    # lmms-eval (vision) expects base_url WITHOUT the endpoint path
+    if task.workflow_venv_type in [
+        WorkflowVenvType.EVALS_META,
+        WorkflowVenvType.EVALS_VISION,
+    ]:
+        _base_url = base_url
+    else:
+        _base_url = api_url
 
     # Set OPENAI_API_BASE for vision and audio models
     if task.workflow_venv_type in [


### PR DESCRIPTION
ChartQA eval was failing on Gemma3 with the following error:
```
2026-03-05 23:04:07 | INFO     | lmms_eval.models.chat.openai_compatible:process_single_request:111 - Attempt 1/1 failed with error: Error code: 404 - {'detail': 'Not Found'}
2026-03-05 23:04:07 | ERROR    | lmms_eval.models.chat.openai_compatible:process_single_request:114 - All 1 attempts failed. Last error: Error code: 404 - {'detail': 'Not Found'}
```
The API resolved was not ok.

With this fix, ChartQA evaluation successfully executes:
https://github.com/tenstorrent/tt-shield/actions/runs/22775673041