### PR TITLE
Enable Evals for Llama-3.1-8B-Instruct in Cpp Server

### DIFF
--- a/tt-media-server/cpp_server/include/domain/completion_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/completion_request.hpp
@@ -94,19 +94,71 @@ struct CompletionRequest: BaseRequest {
             if (json["prompt"].isString()) {
                 req.prompt = json["prompt"].asString();
             } else if (json["prompt"].isArray()) {
-                std::vector<int> tokens;
-                for (const auto& token : json["prompt"]) {
-                    tokens.push_back(token.asInt());
+                // Check if it's a batched request (array of prompts)
+                if (json["prompt"].size() > 0 && json["prompt"][0].isArray()) {
+                    // Batched requests are not currently supported
+                    throw std::runtime_error(
+                        "Batched completion requests (array of prompts) are not supported. "
+                        "Please send one prompt per request. Received " +
+                        std::to_string(json["prompt"].size()) + " prompts in batch.");
+                } else {
+                    // Flat array of token IDs for a single prompt
+                    std::vector<int> tokens;
+                    for (const auto& token : json["prompt"]) {
+                        tokens.push_back(token.asInt());
+                    }
+                    req.prompt = tokens;
                 }
-                req.prompt = tokens;
             }
         }
 
-        if (json.isMember("echo")) req.echo = json["echo"].asBool();
-        if (json.isMember("max_tokens")) req.max_tokens = json["max_tokens"].asInt();
-        if (json.isMember("n")) req.n = json["n"].asInt();
-        if (json.isMember("presence_penalty")) req.presence_penalty = json["presence_penalty"].asFloat();
-        if (json.isMember("frequency_penalty")) req.frequency_penalty = json["frequency_penalty"].asFloat();
+        try {
+            if (json.isMember("echo")) req.echo = json["echo"].asBool();
+        } catch (const std::exception& e) {
+            throw std::runtime_error(std::string("Failed to parse 'echo': ") + e.what());
+        }
+        try {
+            if (json.isMember("max_tokens")) {
+                // Support both int and string values for compatibility
+                if (json["max_tokens"].isInt()) {
+                    req.max_tokens = json["max_tokens"].asInt();
+                } else if (json["max_tokens"].isString()) {
+                    req.max_tokens = std::stoi(json["max_tokens"].asString());
+                } else {
+                    req.max_tokens = json["max_tokens"].asInt();  // Let it throw if wrong type
+                }
+            }
+        } catch (const std::exception& e) {
+            throw std::runtime_error(std::string("Failed to parse 'max_tokens': ") + e.what());
+        }
+        try {
+            if (json.isMember("n")) {
+                if (json["n"].isInt()) {
+                    req.n = json["n"].asInt();
+                } else if (json["n"].isString()) {
+                    req.n = std::stoi(json["n"].asString());
+                } else {
+                    req.n = json["n"].asInt();
+                }
+            }
+        } catch (const std::exception& e) {
+            throw std::runtime_error(std::string("Failed to parse 'n': ") + e.what());
+        }
+        // Parse float fields with string fallback
+        if (json.isMember("presence_penalty")) {
+            if (json["presence_penalty"].isNumeric()) {
+                req.presence_penalty = json["presence_penalty"].asFloat();
+            } else if (json["presence_penalty"].isString()) {
+                req.presence_penalty = std::stof(json["presence_penalty"].asString());
+            }
+        }
+        if (json.isMember("frequency_penalty")) {
+            if (json["frequency_penalty"].isNumeric()) {
+                req.frequency_penalty = json["frequency_penalty"].asFloat();
+            } else if (json["frequency_penalty"].isString()) {
+                req.frequency_penalty = std::stof(json["frequency_penalty"].asString());
+            }
+        }
         if (json.isMember("suffix") && !json["suffix"].isNull()) {
             req.suffix = json["suffix"].asString();
         }
@@ -125,17 +177,45 @@ struct CompletionRequest: BaseRequest {
             }
         }
 
-        if (json.isMember("seed") && !json["seed"].isNull()) {
-            req.seed = json["seed"].asInt();
+        try {
+            if (json.isMember("seed") && !json["seed"].isNull()) {
+                if (json["seed"].isInt()) {
+                    req.seed = json["seed"].asInt();
+                } else if (json["seed"].isString()) {
+                    req.seed = std::stoi(json["seed"].asString());
+                } else {
+                    req.seed = json["seed"].asInt();
+                }
+            }
+        } catch (const std::exception& e) {
+            throw std::runtime_error(std::string("Failed to parse 'seed': ") + e.what());
         }
         if (json.isMember("temperature") && !json["temperature"].isNull()) {
-            req.temperature = json["temperature"].asFloat();
+            if (json["temperature"].isNumeric()) {
+                req.temperature = json["temperature"].asFloat();
+            } else if (json["temperature"].isString()) {
+                req.temperature = std::stof(json["temperature"].asString());
+            }
         }
         if (json.isMember("top_p") && !json["top_p"].isNull()) {
-            req.top_p = json["top_p"].asFloat();
+            if (json["top_p"].isNumeric()) {
+                req.top_p = json["top_p"].asFloat();
+            } else if (json["top_p"].isString()) {
+                req.top_p = std::stof(json["top_p"].asString());
+            }
         }
-        if (json.isMember("logprobs") && !json["logprobs"].isNull()) {
-            req.logprobs = json["logprobs"].asInt();
+        try {
+            if (json.isMember("logprobs") && !json["logprobs"].isNull()) {
+                if (json["logprobs"].isInt()) {
+                    req.logprobs = json["logprobs"].asInt();
+                } else if (json["logprobs"].isString()) {
+                    req.logprobs = std::stoi(json["logprobs"].asString());
+                } else {
+                    req.logprobs = json["logprobs"].asInt();
+                }
+            }
+        } catch (const std::exception& e) {
+            throw std::runtime_error(std::string("Failed to parse 'logprobs': ") + e.what());
         }
         if (json.isMember("user") && !json["user"].isNull()) {
             req.user = json["user"].asString();
@@ -146,12 +226,26 @@ struct CompletionRequest: BaseRequest {
             req.top_k = json["top_k"].asInt();
         }
         if (json.isMember("min_p") && !json["min_p"].isNull()) {
-            req.min_p = json["min_p"].asFloat();
+            if (json["min_p"].isNumeric()) {
+                req.min_p = json["min_p"].asFloat();
+            } else if (json["min_p"].isString()) {
+                req.min_p = std::stof(json["min_p"].asString());
+            }
         }
         if (json.isMember("repetition_penalty") && !json["repetition_penalty"].isNull()) {
-            req.repetition_penalty = json["repetition_penalty"].asFloat();
+            if (json["repetition_penalty"].isNumeric()) {
+                req.repetition_penalty = json["repetition_penalty"].asFloat();
+            } else if (json["repetition_penalty"].isString()) {
+                req.repetition_penalty = std::stof(json["repetition_penalty"].asString());
+            }
         }
-        if (json.isMember("length_penalty")) req.length_penalty = json["length_penalty"].asFloat();
+        if (json.isMember("length_penalty")) {
+            if (json["length_penalty"].isNumeric()) {
+                req.length_penalty = json["length_penalty"].asFloat();
+            } else if (json["length_penalty"].isString()) {
+                req.length_penalty = std::stof(json["length_penalty"].asString());
+            }
+        }
 
         if (json.isMember("stop_token_ids") && json["stop_token_ids"].isArray()) {
             for (const auto& id : json["stop_token_ids"]) {

--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -76,6 +76,7 @@ class PromptClient:
         cache_dir: Optional[Path] = None,
     ):
         self.env_config = env_config
+        self.model_spec = model_spec
         authorization = self._get_authorization()
         if authorization:
             self.headers = {"Authorization": f"Bearer {authorization}"}
@@ -260,21 +261,33 @@ class PromptClient:
 
         # Default input sizes if none provided
         if context_lens is None:
-            default_context_lens = {
-                (32, 4),
-                (64, 4),
-                (128, 4),
-                (256, 4),
-                (512, 4),
-                (1024, 4),
-                (2048, 4),
-                (3072, 4),
-                (4096, 4),
-                (8192, 4),
-                (16384, 4),
-            }
-            # ascending order of input sequence length
-            context_lens = sorted(default_context_lens)
+            # Get max_context from model_spec if available
+            if self.model_spec and hasattr(self.model_spec, "device_model_spec"):
+                max_context = self.model_spec.device_model_spec.max_context
+                # Use helper function to filter context lengths by max_context
+                context_lens = get_trace_context_lens(
+                    max_context=max_context, output_len=4
+                )
+                logger.info(
+                    f"Using trace context lengths filtered by max_context={max_context}: {context_lens}"
+                )
+            else:
+                # Fallback to hardcoded values if model_spec not available
+                default_context_lens = {
+                    (32, 4),
+                    (64, 4),
+                    (128, 4),
+                    (256, 4),
+                    (512, 4),
+                    (1024, 4),
+                    (2048, 4),
+                    (3072, 4),
+                    (4096, 4),
+                    (8192, 4),
+                    (16384, 4),
+                }
+                # ascending order of input sequence length
+                context_lens = sorted(default_context_lens)
 
         # Check service health before starting
         if not self.wait_for_healthy(timeout=timeout):

--- a/utils/prompt_configs.py
+++ b/utils/prompt_configs.py
@@ -48,7 +48,7 @@ class EnvironmentConfig:
     vllm_model: str = os.environ.get(
         "HF_MODEL_REPO_ID", "meta-llama/Llama-3.1-70B-Instruct"
     )
-    vllm_api_key: Optional[str] = os.environ.get("VLLM_API_KEY")
+    vllm_api_key: Optional[str] = os.environ.get("VLLM_API_KEY", "your-secret-key")
     jwt_secret: Optional[str] = os.environ.get("JWT_SECRET")
     deploy_url: str = os.environ.get("DEPLOY_URL", "http://127.0.0.1")
     service_port: str = os.environ.get("SERVICE_PORT", "7000")

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1754,7 +1754,7 @@ llm_templates = [
             DeviceModelSpec(
                 device=DeviceTypes.N300,
                 max_concurrency=32,
-                max_context=128 * 1024,
+                max_context=64 * 1024,
                 default_impl=True,
                 override_tt_config={
                     "trace_region_size": 36410368,


### PR DESCRIPTION
## Issue
[Wireup Cpp Server Llama Model in Shield CI](https://github.com/tenstorrent/tt-inference-server/issues/2314)

## Problem
We need to enable running `Eval` tasks for Llama model implementation in cpp server.