### PR TITLE
Add --bind-host for docker server port publishing

### DIFF
--- a/run.py
+++ b/run.py
@@ -140,6 +140,12 @@ def parse_arguments():
         default=os.getenv("SERVICE_PORT", "8000"),
     )
     parser.add_argument(
+        "--bind-host",
+        type=str,
+        default="0.0.0.0",
+        help="Host interface to bind published docker service port to (default: 0.0.0.0)",
+    )
+    parser.add_argument(
         "--disable-trace-capture",
         action="store_true",
         help="Disables trace capture requests, use to speed up execution if inference server already runnning and traces captured.",
@@ -379,6 +385,7 @@ def format_cli_args_summary(runtime_config):
         f"  no_auth:                    {runtime_config.no_auth}",
         f"  tt_metal_python_venv_dir:   {runtime_config.tt_metal_python_venv_dir}",
         f"  service_port:               {runtime_config.service_port}",
+        f"  bind_host:                  {runtime_config.bind_host}",
         f"  docker_override_image:      {runtime_config.override_docker_image}",
         f"  docker_interactive:         {runtime_config.interactive}",
         f"  device_id:                  {runtime_config.device_id}",

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -203,6 +203,7 @@ Usage: python3 run.py --model <model> --workflow <workflow> [options]
 | `--local-server` | false | Run inference server on localhost. |
 | `-it`, `--interactive` | false | Run Docker in interactive mode. |
 | `--service-port` | `8000` | Service port. Also reads from `SERVICE_PORT` env var. |
+| `--bind-host` | `0.0.0.0` | Host interface for Docker port publishing. Use `127.0.0.1` for localhost-only access. |
 | `--no-auth` | false | Disable vLLM API key authorization (skips `JWT_SECRET` requirement). |
 | `--print-docker-cmd` | false | Print the Docker run command and exit without starting the server. |
 
@@ -224,10 +225,11 @@ Only one of `--host-volume`, `--host-hf-cache`, `--host-weights-dir` can be spec
 | `--dev-mode` | Enable developer mode (bind mounts source code into container). |
 | `--override-docker-image` | Override the Docker image used by `--docker-server`. |
 | `--device-id` | Tenstorrent device IDs, comma-separated PCI indices (e.g. `0` or `0,1,2`). |
-| `--override-tt-config` | Override TT config as JSON string (e.g., `'{"data_parallel": 16}'`). |
-| `--vllm-override-args` | Override vLLM arguments as JSON string (e.g., `'{"max_model_len": 4096}'`). |
+| `--override-tt-config` | Override TT config as JSON string (e.g., '{"data_parallel": 16}'). |
+| `--vllm-override-args` | Override vLLM arguments as JSON string (e.g., '{"max_model_len": 4096}'). |
 | `--disable-trace-capture` | Disable trace capture requests to speed up execution. |
-| `--workflow-args` | Additional workflow arguments (e.g., `'param1=value1 param2=value2'`). |
+| `--workflow-args` | Additional workflow arguments (e.g., 'param1=value1 param2=value2'). |
+
 
 ### Secrets
 
@@ -348,6 +350,10 @@ Run server workflow in Docker with interactive mode:
 ```bash
 python3 run.py --model Llama-3.3-70B-Instruct --workflow server --tt-device T3K --docker-server --interactive
 ```
+
+Run server workflow in Docker bound to localhost only:
+
+    python3 run.py --model Llama-3.3-70B-Instruct --workflow server --device T3K --docker-server --bind-host 127.0.0.1
 
 Run with custom service port and additional workflow arguments:
 ```bash

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -163,11 +163,6 @@ def generate_docker_run_command(
         "--publish", f"{runtime_config.bind_host}:{runtime_config.service_port}:{runtime_config.service_port}",
         *device_map_strs,
         "--mount", "type=bind,src=/dev/hugepages-1G,dst=/dev/hugepages-1G",
-        # note: order of mounts matters, model_volume_root must be mounted before nested mounts
-        "--mount", f"type=bind,src={setup_config.host_model_volume_root},dst={setup_config.cache_root}",
-        "--mount", f"type=bind,src={json_fpath},dst={docker_json_fpath},readonly",
-        "--shm-size", "32G",
-        "--publish", f"{model_spec.cli_args.bind_host}:{model_spec.cli_args.service_port}:{model_spec.cli_args.service_port}",  # map host port to container port
     ]
 
     # setup_config-dependent mounts (cache_root volume)

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -160,9 +160,14 @@ def generate_docker_run_command(
         *( ["--user", str(runtime_config.image_user)] if runtime_config.image_user and str(runtime_config.image_user) != "1000" else []),
         "--env-file", str(default_dotenv_path),
         "--ipc", "host",
-        "--publish", f"{runtime_config.service_port}:{runtime_config.service_port}",
+        "--publish", f"{runtime_config.bind_host}:{runtime_config.service_port}:{runtime_config.service_port}",
         *device_map_strs,
         "--mount", "type=bind,src=/dev/hugepages-1G,dst=/dev/hugepages-1G",
+        # note: order of mounts matters, model_volume_root must be mounted before nested mounts
+        "--mount", f"type=bind,src={setup_config.host_model_volume_root},dst={setup_config.cache_root}",
+        "--mount", f"type=bind,src={json_fpath},dst={docker_json_fpath},readonly",
+        "--shm-size", "32G",
+        "--publish", f"{model_spec.cli_args.bind_host}:{model_spec.cli_args.service_port}:{model_spec.cli_args.service_port}",  # map host port to container port
     ]
 
     # setup_config-dependent mounts (cache_root volume)

--- a/workflows/runtime_config.py
+++ b/workflows/runtime_config.py
@@ -43,6 +43,7 @@ class RuntimeConfig:
     local_server: bool = False
     interactive: bool = False
     service_port: str = "8000"
+    bind_host: str = "0.0.0.0"
 
     # Dev / override
     dev_mode: bool = False
@@ -108,6 +109,7 @@ class RuntimeConfig:
             local_server=args.local_server,
             interactive=args.interactive,
             service_port=args.service_port,
+            bind_host=args.bind_host,
             dev_mode=args.dev_mode,
             no_auth=args.no_auth,
             print_docker_cmd=args.print_docker_cmd,


### PR DESCRIPTION
Currently the docker server launched via `run.py --docker-server`
publishes the service port using:

    --publish <port>:<port>

Docker interprets this as binding to `0.0.0.0`, which exposes the
inference server on all host interfaces.

For local development or single-node setups it is often desirable to
restrict the API to localhost only.

This PR adds a `--bind-host` CLI option (default `0.0.0.0`) and uses it
when publishing the port:

    --publish <bind-host>:<port>:<port>

Example:

    python run.py --workflow server --docker-server --bind-host 127.0.0.1

This keeps the current default behavior unchanged while allowing users
to run the server in a localhost-only configuration.