### PR TITLE
Timebox mock token creation to 20us

### DIFF
--- a/tt-media-server/cpp_server/src/runners/mock_runner.py
+++ b/tt-media-server/cpp_server/src/runners/mock_runner.py
@@ -77,6 +77,8 @@ def _run_mock_bridge() -> None:
                 )
 
                 for i in range(tokens_to_generate):
+                    start_time = time.perf_counter()
+
                     token_id = msg.token_ids[i] if i < len(msg.token_ids) else 12345
                     p2c.write_token(msg.task_id, token_id)
 
@@ -84,7 +86,12 @@ def _run_mock_bridge() -> None:
                         f"Mock runner: Sent token {i + 1}/{tokens_to_generate}: {token_id}",
                         file=sys.stderr,
                     )
-                    time.sleep(0.0001)
+
+                    # Sleep for remaining time to reach 50 microseconds total
+                    elapsed = time.perf_counter() - start_time
+                    remaining = 0.00002 - elapsed  # 20 microseconds total
+                    if remaining > 0:
+                        time.sleep(remaining)
 
                 print(
                     f"Mock runner: Finished generating {tokens_to_generate} tokens for task {task_id_str}",


### PR DESCRIPTION
Limit mock runner budget to 20us per token:

<img width="533" height="307" alt="image" src="https://github.com/user-attachments/assets/d4d12120-3fe1-4660-9b8f-5ea525a2ab77" />
