### PR TITLE
Pass EOS token ID to model pipeline

### DIFF
--- a/tt-media-server/cpp_server/src/runners/runner.py
+++ b/tt-media-server/cpp_server/src/runners/runner.py
@@ -110,6 +110,7 @@ def _run_shm_bridge(model_pipeline: ModelPipeline) -> None:
                 prompt_token_ids=msg.token_ids,
                 max_new_tokens=msg.max_tokens,
                 on_token=lambda tid: p2c.write_token(msg.task_id, tid),
+                eos_token_id=1,
             )
             print("Inference completed")
 


### PR DESCRIPTION
Model pipeline keeps running past EOS
<img width="1396" height="880" alt="image" src="https://github.com/user-attachments/assets/94e9cdbb-9d9a-47e7-bb17-d996a13c32c4" />

runner.py is not passing the EOS arg to run_inference
https://github.com/tenstorrent/tt-inference-server/blob/ds_stable/tt-media-server/cpp_server/src/runners/runner.py#L109-L112

On the model side we still have the condition - https://github.com/tenstorrent/tt-metal/blob/527c21ab96f9066b8cb6f503b1e80b8d78e6b4d7/models/demos/deepseek_v3_b1/demo/model_pipeline.py#L139-L141