### PR TITLE
Fix index in readme

### DIFF
--- a/tt-media-server/cpp_server/README.md
+++ b/tt-media-server/cpp_server/README.md
@@ -404,7 +404,7 @@ curl -X POST http://localhost:8001/v1/completions \
 ```
 data: {"id":"cmpl-abc123","choices":[{"text":"token_0","index":0}],...}
 
-data: {"id":"cmpl-abc123","choices":[{"text":"token_1","index":1}],...}
+data: {"id":"cmpl-abc123","choices":[{"text":"token_1","index":0}],...}
 
 ...
 


### PR DESCRIPTION
Index in choices doesn't refer to token index but to choice index i.e. index of decoding stream.

https://github.com/tenstorrent/tt-inference-server/issues/2322