### PR TITLE
Limit in-flight super pod sequences

### DIFF
--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
@@ -44,6 +44,8 @@ class SpPipelineRunner : public IRunner {
   sp_pipeline::DecodeQueue decode_queue_;
   std::unordered_map<llm_engine::TaskID, std::unique_ptr<llm_engine::Sequence>> active_sequences_;
   std::atomic<bool> stopped_{false};
+  int max_in_flight_count_;
+  int in_flight_count_ = 0;
 };
 
 }  // namespace tt::runners

--- a/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner.cpp
@@ -17,7 +17,8 @@ SpPipelineRunner::SpPipelineRunner(
     : config_(config),
       stop_token_ids_(config.stop_token_ids.begin(), config.stop_token_ids.end()),
       result_queue_(result_queue),
-      task_queue_(task_queue) {
+      task_queue_(task_queue),
+      max_in_flight_count_(config.max_in_flight_count) {
   auto decode_cb = [this](const llm_engine::TokenResult& result) {
     decode_queue_.push(result);
   };
@@ -96,6 +97,11 @@ void SpPipelineRunner::stop() {
 void SpPipelineRunner::step() {
   drain_decode_results();
 
+  // Check if we can accept more in-flight requests
+  if (in_flight_count_ >= max_in_flight_count_) {
+    return;
+  }
+
   llm_engine::Sequence* seq = task_queue_->try_pop();
   if (!seq) return;
 
@@ -106,6 +112,7 @@ void SpPipelineRunner::step() {
       seq->task_id.id, seq->token_ids_, seq->sampling_params->max_tokens);
 
   active_sequences_.emplace(task_id, std::move(owned));
+  ++in_flight_count_;
 }
 
 void SpPipelineRunner::drain_decode_results() {
@@ -120,6 +127,7 @@ void SpPipelineRunner::drain_decode_results() {
     if (dr.is_error) {
       push_error_token(dr.task_id);
       active_sequences_.erase(it);
+      --in_flight_count_;
       continue;
     }
 
@@ -134,6 +142,7 @@ void SpPipelineRunner::drain_decode_results() {
 
     if (finished) {
       active_sequences_.erase(it);
+      --in_flight_count_;
     }
   }
 }


### PR DESCRIPTION
Sample with 2 requests:

First request:

<img width="1039" height="234" alt="image" src="https://github.com/user-attachments/assets/1cf723a7-4bca-4fe7-a08f-d2bc347fc71c" />


Debug:

<img width="1039" height="234" alt="image" src="https://github.com/user-attachments/assets/0b7a8278-6279-4232-93f6-188bad3a2ae8" />


Second request (ttft is way longer):

<img width="1039" height="234" alt="image" src="https://github.com/user-attachments/assets/c895350a-6355-41de-852a-4ea40260d1a8" />
