### PR TITLE
fix: increase trace_region_size for Qwen3-32B and Llama-3.3-70B on P150x8

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1233,8 +1233,8 @@ llm_templates = [
                 mode=VersionMode.STRICT,
             ),
         ),
-        tt_metal_commit="55fd115",
-        vllm_commit="aa4ae1e",
+        tt_metal_commit="5fd3a04",
+        vllm_commit="1f567b7",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
             DeviceModelSpec(
@@ -1553,8 +1553,8 @@ llm_templates = [
             "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
         ],
         impl=tt_transformers_impl,
-        tt_metal_commit="55fd115",
-        vllm_commit="aa4ae1e",
+        tt_metal_commit="5fd3a04",
+        vllm_commit="1f567b7",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
             DeviceModelSpec(
@@ -1576,6 +1576,21 @@ llm_templates = [
                     ),
                 ),
             ),
+        ],
+        status=ModelStatusTypes.FUNCTIONAL,
+    ),
+    ModelSpecTemplate(
+        weights=[
+            "meta-llama/Llama-3.3-70B-Instruct",
+            "meta-llama/Llama-3.1-70B",
+            "meta-llama/Llama-3.1-70B-Instruct",
+            "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+        ],
+        impl=tt_transformers_impl,
+        tt_metal_commit="5fd3a04",
+        vllm_commit="1f567b7",
+        inference_engine=InferenceEngine.VLLM.value,
+        device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.P150X8,
                 max_concurrency=32,
@@ -1830,8 +1845,8 @@ llm_templates = [
                 mode=VersionMode.STRICT,
             ),
         ),
-        tt_metal_commit="55fd115",
-        vllm_commit="aa4ae1e",
+        tt_metal_commit="5fd3a04",
+        vllm_commit="1f567b7",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
             DeviceModelSpec(

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1242,6 +1242,9 @@ llm_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                override_tt_config={
+                    "trace_region_size": 61341696,
+                },
             ),
         ],
         status=ModelStatusTypes.FUNCTIONAL,
@@ -1578,6 +1581,9 @@ llm_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                override_tt_config={
+                    "trace_region_size": 51453952,
+                },
                 system_requirements=SystemRequirements(
                     firmware=VersionRequirement(
                         specifier=">=18.12.0",

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1576,21 +1576,6 @@ llm_templates = [
                     ),
                 ),
             ),
-        ],
-        status=ModelStatusTypes.FUNCTIONAL,
-    ),
-    ModelSpecTemplate(
-        weights=[
-            "meta-llama/Llama-3.3-70B-Instruct",
-            "meta-llama/Llama-3.1-70B",
-            "meta-llama/Llama-3.1-70B-Instruct",
-            "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
-        ],
-        impl=tt_transformers_impl,
-        tt_metal_commit="5fd3a04",
-        vllm_commit="1f567b7",
-        inference_engine=InferenceEngine.VLLM.value,
-        device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.P150X8,
                 max_concurrency=32,

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1233,8 +1233,8 @@ llm_templates = [
                 mode=VersionMode.STRICT,
             ),
         ),
-        tt_metal_commit="5fd3a04",
-        vllm_commit="1f567b7",
+        tt_metal_commit="555f240",
+        vllm_commit="22be241",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
             DeviceModelSpec(
@@ -1553,8 +1553,8 @@ llm_templates = [
             "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
         ],
         impl=tt_transformers_impl,
-        tt_metal_commit="5fd3a04",
-        vllm_commit="1f567b7",
+        tt_metal_commit="555f240",
+        vllm_commit="22be241",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
             DeviceModelSpec(
@@ -1830,8 +1830,8 @@ llm_templates = [
                 mode=VersionMode.STRICT,
             ),
         ),
-        tt_metal_commit="5fd3a04",
-        vllm_commit="1f567b7",
+        tt_metal_commit="555f240",
+        vllm_commit="22be241",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
             DeviceModelSpec(


### PR DESCRIPTION
## Summary

- Qwen3-32B on P150x8 was hitting `TT_FATAL` due to trace buffer size exceeding the 50 MB allocation — observed required size was up to 61,341,696 B (~58.5 MB)
- Llama-3.3-70B-Instruct on P150x8 had the same issue in early Feb — required 51,453,952 B (~49.1 MB)
- Added `override_tt_config: {trace_region_size: ...}` to the P150x8 `DeviceModelSpec` for both models in `model_spec.py`

## Test plan

- [x] Verify Qwen3-32B nightly on P150x8 no longer hits `TT_FATAL @ mesh_trace.cpp`
- [x] Verify Llama-3.3-70B-Instruct nightly on P150x8 passes cleanly