### PR TITLE
Unify max_batch_size and max_in_flight_count Environment Variables

### DIFF
--- a/tt-media-server/cpp_server/CLAUDE.md
+++ b/tt-media-server/cpp_server/CLAUDE.md
@@ -110,7 +110,6 @@ Configuration follows the same pattern as the Python server - defaults in `confi
 - `MODEL_SERVICE`: `llm` or `embedding` (default: `llm`)
 - `LLM_DEVICE_BACKEND`: `mock` or `pipeline` (DeepSeek V3), `llama` (Llama 3.1 8B Instruct) — selects runner + tokenizer strategy (default: `mock`)
 - `DEVICE_IDS`: Bracket-pair device list like `(0,1,2,3),(4,5,6,7)` defining workers
-- `MAX_BATCH_SIZE`: Max requests per batch for both LLM inference and embedding service
 - `MAX_BATCH_DELAY_TIME_MS`: Max wait time to fill batches
 - `OPENAI_API_KEY`: Bearer token for API authentication (default: `your-secret-key`)
 

--- a/tt-media-server/cpp_server/README.md
+++ b/tt-media-server/cpp_server/README.md
@@ -79,7 +79,7 @@ The LLM engine supports two scheduling policies that trade off individual reques
 #### Max Occupancy
 **When to use:** High request rates, throughput-oriented applications
 
-**Behavior:** Keeps the device at full occupancy (`batch_size` from MAX_BATCH_SIZE env var) whenever possible. When decode sequences finish and free slots, immediately prefills enough new sequences to refill capacity, then resumes decode at full width.
+**Behavior:** Keeps the device at full occupancy (`max_in_flight_count` from MAX_IN_FLIGHT_COUNT env var) whenever possible. When decode sequences finish and free slots, immediately prefills enough new sequences to refill capacity, then resumes decode at full width.
 
 **Advantages:**
 - **Better average TTFT across all users** under high load
@@ -230,7 +230,6 @@ All environment variable reads go through `config/settings.hpp` (no direct `gete
 |----------|-------------|---------|
 | `DEVICE_IDS` | Bracket-pair device list, one worker per pair (e.g. `(0,1,2,3),(4,5,6,7)`). num_workers = number of pairs; each worker's `TT_VISIBLE_DEVICES` = that pair's contents. | `(0)` |
 | `MODEL_SERVICE` | Service mode: `embedding` or `llm`. Same as tt-media-server. | `llm` |
-| `MAX_BATCH_SIZE` | Max requests per batch. Used by both LLM scheduler and embedding service. | `1` |
 | `MAX_BATCH_DELAY_TIME_MS` | Max wait (ms) to fill batch (embedding). Same as tt-media-server. | `5` |
 | `MAX_QUEUE_SIZE` | Maximum number of requests that can be queued. | `1000` |
 | `MAX_IN_FLIGHT_COUNT` | Maximum number of requests being processed simultaneously. | `32` |

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -15,7 +15,6 @@ namespace tt::config::defaults {
 
 constexpr const char* DEVICE_IDS = "(0)";
 constexpr const char* MODEL_SERVICE = "llm";
-constexpr size_t MAX_BATCH_SIZE = 1;
 constexpr unsigned MAX_BATCH_DELAY_TIME_MS = 5;
 constexpr const char* TT_PYTHON_PATH = "..";
 constexpr const char* LLM_MODE = "regular";  // "regular", "prefill", "decode"

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -30,9 +30,6 @@ std::string runner_type();
 /** Number of worker processes = number of bracket pairs in DEVICE_IDS. */
 size_t num_workers();
 
-/** Max requests per batch (embedding). From MAX_BATCH_SIZE. Default: defaults::MAX_BATCH_SIZE. */
-size_t batch_size();
-
 /** Max wait (ms) to fill a batch. From MAX_BATCH_DELAY_TIME_MS. Default: defaults::MAX_BATCH_DELAY_TIME_MS. */
 unsigned batch_timeout_ms();
 

--- a/tt-media-server/cpp_server/include/runners/llm_runner/max_occupancy_scheduler.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/max_occupancy_scheduler.hpp
@@ -8,10 +8,10 @@
 namespace llm_engine {
 
 /**
- * Keeps the device at full occupancy (batch_size) whenever possible.
+ * Keeps the device at full occupancy (max_in_flight_count) whenever possible.
  *
  * When decode sequences finish and free slots, this scheduler immediately
- * prefills enough new sequences to refill to batch_size, then resumes
+ * prefills enough new sequences to refill to max_in_flight_count, then resumes
  * decode at full capacity. Inspired by vLLM's continuous batching, adapted
  * for pure prefill/decode batches.
  *
@@ -27,13 +27,13 @@ class MaxOccupancyScheduler : public Scheduler {
   using Scheduler::Scheduler;
 
  protected:
-  bool should_prefill_first(int decode_count, int batch_size) const override {
-    return decode_count < batch_size;
+  bool should_prefill_first(int decode_count, int max_in_flight_count) const override {
+    return decode_count < max_in_flight_count;
   }
 
   int max_prefill_seqs(int decode_count,
-                       int batch_size) const override {
-    return batch_size - decode_count;
+                       int max_in_flight_count) const override {
+    return max_in_flight_count - decode_count;
   }
 };
 

--- a/tt-media-server/cpp_server/include/runners/llm_runner/prefill_first_scheduler.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/prefill_first_scheduler.hpp
@@ -21,7 +21,7 @@ class PrefillFirstScheduler : public Scheduler {
 
  protected:
   bool should_prefill_first(int /*decode_count*/,
-                            int /*batch_size*/) const override {
+                            int /*max_in_flight_count*/) const override {
     return true;
   }
 };

--- a/tt-media-server/cpp_server/include/runners/llm_runner/scheduler.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/scheduler.hpp
@@ -24,7 +24,7 @@ namespace llm_engine {
  */
 class Scheduler {
  public:
-  explicit Scheduler(const tt::config::LLMConfig& config, ITaskQueue* task_queue, size_t batch_size);
+  explicit Scheduler(const tt::config::LLMConfig& config, ITaskQueue* task_queue, size_t max_in_flight_count);
   virtual ~Scheduler() = default;
 
   /** @return true if there are no prefill_queue, decode_queue, or in-flight sequences. */
@@ -68,18 +68,18 @@ class Scheduler {
  protected:
   /**
    * @param decode_count  number of sequences currently in the decode_queue.
-   * @param batch_size    maximum batch / decode_queue capacity.
+   * @param max_in_flight_count    maximum batch / decode_queue capacity.
    * @return true if the scheduler should attempt prefill before decode.
    */
-  virtual bool should_prefill_first(int decode_count, int batch_size) const = 0;
+  virtual bool should_prefill_first(int decode_count, int max_in_flight_count) const = 0;
 
   /**
    * Maximum number of sequences to prefill in one step.
-   * Default: batch_size (full capacity). Override to limit prefill
+   * Default: max_in_flight_count (full capacity). Override to limit prefill
    * to available slots when decode sequences should be preserved.
    */
-  virtual int max_prefill_seqs(int /*decode_count*/, int batch_size) const {
-    return batch_size;
+  virtual int max_prefill_seqs(int /*decode_count*/, int max_in_flight_count) const {
+    return max_in_flight_count;
   }
 
  private:
@@ -90,7 +90,7 @@ class Scheduler {
   void try_schedule_decode(std::vector<Sequence*>& scheduled_seqs,
                            int& num_seqs);
 
-  size_t batch_size_;
+  size_t max_in_flight_count_;
   int max_num_batched_tokens_;
   std::unordered_set<int64_t> stop_token_ids_;
   BlockManager block_manager_;
@@ -101,6 +101,6 @@ class Scheduler {
 
 std::unique_ptr<Scheduler> make_scheduler(const tt::config::LLMConfig& config,
                                           ITaskQueue* task_queue,
-                                          size_t batch_size);
+                                          size_t max_in_flight_count);
 
 }  // namespace llm_engine

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -105,10 +105,6 @@ size_t num_workers() {
     return device_ids_parsed().size();
 }
 
-size_t batch_size() {
-    return static_cast<size_t>(env_ulong("MAX_BATCH_SIZE", defaults::MAX_BATCH_SIZE));
-}
-
 unsigned batch_timeout_ms() {
     return static_cast<unsigned>(env_ulong("MAX_BATCH_DELAY_TIME_MS", defaults::MAX_BATCH_DELAY_TIME_MS));
 }

--- a/tt-media-server/cpp_server/src/runners/llm_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner.cpp
@@ -12,7 +12,7 @@ namespace tt::runners {
 LLMRunner::LLMRunner(const Config& config, ipc::TokenRingBuffer<65536>* result_queue, ITaskQueue* task_queue)
     : config_(config), result_queue_(result_queue) {
 
-  scheduler_ = make_scheduler(config_, task_queue, tt::config::batch_size());
+  scheduler_ = make_scheduler(config_, task_queue, tt::config::max_in_flight_count());
 
   auto decode_cb = [this](const TokenResult& result) {
     ZoneScopedN("LLMRunner::process_token_result");

--- a/tt-media-server/cpp_server/src/runners/llm_runner/mock_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/mock_model_runner.cpp
@@ -18,7 +18,7 @@ class MockModelRunner : public IModelRunner {
   void run(const std::vector<Sequence*>& seqs, bool is_prefill) override {
     ZoneScopedN("MockModelRunner::run");
     LLM_ENGINE_LOG("model_runner:mock") << (is_prefill ? "prefill" : "decode")
-                                        << " batch_size=" << seqs.size() << std::endl;
+                                        << " max_in_flight_count=" << seqs.size() << std::endl;
     if (is_prefill) {
       ZoneScopedN("MockModelRunner::prefill");
       for (Sequence* seq : seqs) {

--- a/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
@@ -17,19 +17,19 @@ using SchedulingPolicy = tt::config::SchedulingPolicy;
 
 std::unique_ptr<Scheduler> make_scheduler(const Config& config,
                                           ITaskQueue* task_queue,
-                                          size_t batch_size) {
+                                          size_t max_in_flight_count) {
   switch (config.scheduling_policy) {
     case SchedulingPolicy::MAX_OCCUPANCY:
-      return std::make_unique<MaxOccupancyScheduler>(config, task_queue, batch_size);
+      return std::make_unique<MaxOccupancyScheduler>(config, task_queue, max_in_flight_count);
     case SchedulingPolicy::PREFILL_FIRST:
     default:
-      return std::make_unique<PrefillFirstScheduler>(config, task_queue, batch_size);
+      return std::make_unique<PrefillFirstScheduler>(config, task_queue, max_in_flight_count);
   }
 }
 
-Scheduler::Scheduler(const Config& config, ITaskQueue* task_queue, size_t batch_size)
+Scheduler::Scheduler(const Config& config, ITaskQueue* task_queue, size_t max_in_flight_count)
     : block_size_(config.kvcache_block_size),
-      batch_size_(batch_size),
+      max_in_flight_count_(max_in_flight_count),
       max_num_batched_tokens_(config.max_num_batched_tokens),
       stop_token_ids_(config.stop_token_ids.begin(), config.stop_token_ids.end()),
       block_manager_(config.num_kvcache_blocks, config.kvcache_block_size),
@@ -87,7 +87,7 @@ bool Scheduler::try_schedule_prefill(std::vector<Sequence*>& scheduled_seqs,
 
 void Scheduler::try_schedule_decode(std::vector<Sequence*>& scheduled_seqs,
                                     int& num_seqs) {
-  while (!decode_queue_.empty() && num_seqs < batch_size_) {
+  while (!decode_queue_.empty() && num_seqs < max_in_flight_count_) {
     Sequence* seq = decode_queue_.front();
     decode_queue_.pop_front();
     auto self_preempt = false;
@@ -122,10 +122,10 @@ std::pair<std::vector<Sequence*>, bool> Scheduler::schedule() {
   int num_batched_tokens = 0;
 
   int decode_count = static_cast<int>(decode_queue_.size());
-  bool should_prefill = !prefill_queue_->empty() && should_prefill_first(decode_count, batch_size_);
+  bool should_prefill = !prefill_queue_->empty() && should_prefill_first(decode_count, max_in_flight_count_);
 
   if (should_prefill) {
-    int seq_limit = max_prefill_seqs(decode_count, batch_size_);
+    int seq_limit = max_prefill_seqs(decode_count, max_in_flight_count_);
     if (seq_limit > 0 &&
         try_schedule_prefill(scheduled_seqs, num_seqs, num_batched_tokens, seq_limit)) {
       return {scheduled_seqs, true};

--- a/tt-media-server/cpp_server/src/services/embedding_service.cpp
+++ b/tt-media-server/cpp_server/src/services/embedding_service.cpp
@@ -75,7 +75,7 @@ struct EmbeddingService::Impl {
 
     Impl() {
         num_workers_ = tt::config::num_workers();
-        max_batch_size_ = tt::config::batch_size();
+        max_batch_size_ = tt::config::max_in_flight_count();
         batch_timeout_ = std::chrono::milliseconds(tt::config::batch_timeout_ms());
         max_queue_size_ = tt::config::max_queue_size();
         TT_LOG_INFO("[EmbeddingService] Initialized with {} workers, batch_size={}, batch_timeout={}ms",
@@ -193,8 +193,13 @@ struct EmbeddingService::Impl {
         std::string visible_devices = tt::config::visible_devices_for_worker(wid);
         setenv("TT_VISIBLE_DEVICES", visible_devices.c_str(), 1);
 
+        size_t batch_size = tt::config::max_in_flight_count();
+        std::string batch_str = std::to_string(batch_size);
+        setenv("MAX_BATCH_SIZE", batch_str.c_str(), 1);
+
         TT_LOG_INFO("[Worker {}] Started with PID {}", worker_id, getpid());
         TT_LOG_INFO("[Worker {}] TT_VISIBLE_DEVICES={}", worker_id, visible_devices);
+        TT_LOG_INFO("[Worker {}] MAX_BATCH_SIZE={}", worker_id, batch_size);
         TT_LOG_INFO("[Worker {}] read_fd={}, write_fd={}", worker_id, read_fd, write_fd);
 
         runners::EmbeddingRunner runner(visible_devices, static_cast<int>(wid));

--- a/tt-media-server/cpp_server/tests/ipc_scheduler_smoke_test.cpp
+++ b/tt-media-server/cpp_server/tests/ipc_scheduler_smoke_test.cpp
@@ -102,7 +102,7 @@ int main() {
       std::cout << "]\n";
     }
 
-    // --- Verify (batch size is 1 with current batch_size setting) ---
+    // --- Verify (batch size is 1 with current max_in_flight_count setting) ---
     bool ok = true;
     auto fail = [&](const char* msg) {
       std::cerr << "[child]  FAIL: " << msg << "\n";

--- a/tt-media-server/cpp_server/tests/scheduler_test.cpp
+++ b/tt-media-server/cpp_server/tests/scheduler_test.cpp
@@ -370,7 +370,7 @@ TEST(MaxOccupancySchedulerTest, PrefillsToFillGap) {
 
   auto [b1, pf1] = sched.schedule();
   ASSERT_TRUE(pf1);
-  EXPECT_EQ(b1.size(), 2u) << "Should prefill both to fill batch_size=2";
+  EXPECT_EQ(b1.size(), 2u) << "Should prefill both to fill max_in_flight_count=2";
   sched.postprocess(b1, {1, 1});
 
   auto [b2, pf2] = sched.schedule();
@@ -387,7 +387,7 @@ TEST(MaxOccupancySchedulerTest, PrefillsOnlyGapCount_WhenOneFinishes) {
   sched.add_request(next_id(), prompt(4), {.max_tokens = 20});
   sched.add_request(next_id(), prompt(4), {.max_tokens = 20});
 
-  // Prefill first 2 (batch_size=2)
+  // Prefill first 2 (max_in_flight_count=2)
   auto [b1, pf1] = sched.schedule();
   ASSERT_TRUE(pf1);
   EXPECT_EQ(b1.size(), 2u);


### PR DESCRIPTION
## Problem
Previously, two separate environment variables controlled the same behavior in different parts of the system. With this PR, `max_batch_size` and `max_in_flight_count` are unified and configured through a single variable: `MAX_IN_FLIGHT_COUNT`