### PR TITLE
uplift: update tt-metal to 555f240 for Blackhole P300/P300X2 LLMs

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1270,7 +1270,7 @@ llm_templates = [
                 mode=VersionMode.STRICT,
             ),
         ),
-        tt_metal_commit="e867533",
+        tt_metal_commit="555f240",
         vllm_commit="22be241",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
@@ -1641,7 +1641,7 @@ llm_templates = [
                 mode=VersionMode.STRICT,
             ),
         ),
-        tt_metal_commit="e867533",
+        tt_metal_commit="555f240",
         vllm_commit="22be241",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
@@ -1887,7 +1887,7 @@ llm_templates = [
                 mode=VersionMode.STRICT,
             ),
         ),
-        tt_metal_commit="e867533",
+        tt_metal_commit="555f240",
         vllm_commit="22be241",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[


### PR DESCRIPTION
Update tt_metal_commit from e867533 to 555f240 (vllm_commit unchanged at 22be241) for the following models on P300/P300X2 devices:
- Qwen/Qwen3-32B
- meta-llama/Llama-3.3-70B-Instruct and related 70B variants
- meta-llama/Llama-3.1-8B and Llama-3.1-8B-Instruct (P300 + P300X2)