### PR TITLE
Fix Python 3.8 compatibility for type hints in multihost modules

### DIFF
--- a/workflows/multihost_config.py
+++ b/workflows/multihost_config.py
@@ -11,7 +11,7 @@ This module generates configuration files needed for multi-host deployment:
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from workflows.workflow_types import DeviceTypes
 

--- a/workflows/multihost_config.py
+++ b/workflows/multihost_config.py
@@ -11,7 +11,7 @@ This module generates configuration files needed for multi-host deployment:
 """
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Dict, List, Optional
 
 from workflows.workflow_types import DeviceTypes
 
@@ -37,7 +37,7 @@ ENV_PASSTHROUGH = [
 class MultiHostConfig:
     """Configuration for multi-host deployment."""
 
-    hosts: list[str]
+    hosts: List[str]
     mpi_interface: str
     shared_storage_root: str
     config_pkl_dir: str
@@ -55,7 +55,7 @@ class MultiHostConfig:
 
 
 def generate_ssh_config(
-    hosts: list[str],
+    hosts: List[str],
     ssh_port: int = WORKER_SSH_PORT,
     ssh_user: str = CONTAINER_USER,
     identity_file: str = DEFAULT_IDENTITY_FILE,
@@ -91,7 +91,7 @@ def generate_ssh_config(
     return "\n".join(config_lines)
 
 
-def generate_rankfile(hosts: list[str]) -> str:
+def generate_rankfile(hosts: List[str]) -> str:
     """Generate MPI rankfile for rank-to-host mapping.
 
     Each host gets one rank. Uses real hostnames directly so that
@@ -109,7 +109,7 @@ def generate_rankfile(hosts: list[str]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def build_mpi_args(hosts: list[str], rankfile_path: str) -> str:
+def build_mpi_args(hosts: List[str], rankfile_path: str) -> str:
     """Build mpi_args string for override_tt_config.
 
     MPI requires --host to know available hosts, and rankfile for
@@ -153,7 +153,7 @@ def get_rank_binding_path(device_type: DeviceTypes) -> str:
 
 
 def build_override_tt_config(
-    hosts: list[str],
+    hosts: List[str],
     mpi_interface: str,
     config_pkl_dir: str,
     rankfile_path: str,

--- a/workflows/multihost_orchestrator.py
+++ b/workflows/multihost_orchestrator.py
@@ -32,7 +32,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional
 
 from workflows.multihost_config import (
     CONTAINER_USER,
@@ -293,7 +293,7 @@ class MultiHostSetup:
     ssh_key_path: Path
     rankfile_path: Path
     override_tt_config: dict
-    worker_container_ids: dict[str, str]  # host -> container_id
+    worker_container_ids: Dict[str, str]  # host -> container_id
 
 
 class MultiHostOrchestrator:
@@ -304,7 +304,7 @@ class MultiHostOrchestrator:
 
     def __init__(
         self,
-        hosts: list[str],
+        hosts: List[str],
         mpi_interface: str,
         shared_storage_root: str,
         config_pkl_dir: str,
@@ -399,7 +399,7 @@ class MultiHostOrchestrator:
 
     def generate_worker_docker_command(
         self, host: str, rank: int
-    ) -> tuple[list[str], str]:
+    ) -> tuple[List[str], str]:
         """Generate docker run command for a Worker container.
 
         Worker containers run sshd and wait for MPI processes from Controller.
@@ -449,7 +449,7 @@ class MultiHostOrchestrator:
 
         return cmd, container_name
 
-    def generate_controller_docker_command(self) -> tuple[list[str], str]:
+    def generate_controller_docker_command(self) -> tuple[List[str], str]:
         """Generate docker run command for Controller container.
 
         Controller runs vLLM API server and initiates MPI processes.
@@ -794,7 +794,7 @@ class MultiHostOrchestrator:
                 return False
         return True
 
-    def start_all_workers(self) -> dict[str, str]:
+    def start_all_workers(self) -> Dict[str, str]:
         """Start Worker containers on all hosts.
 
         Ensures image and SSH public key are available on all hosts before starting.

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -12,6 +12,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
+from typing import List
 
 from workflows.log_setup import clean_log_file
 from workflows.multihost_orchestrator import (
@@ -567,7 +568,7 @@ def _monitor_multihost_containers(
 
 def run_multihost_with_monitoring(
     orchestrator,
-    controller_cmd: list[str],
+    controller_cmd: List[str],
     controller_name: str,
     runtime_config,
     model_spec,

--- a/workflows/validate_multihost.py
+++ b/workflows/validate_multihost.py
@@ -24,6 +24,7 @@ import logging
 import socket
 import subprocess
 from pathlib import Path
+from typing import List, Tuple
 
 from workflows.utils import check_path_permissions_for_uid
 
@@ -36,8 +37,8 @@ logger = logging.getLogger("run_log")
 
 
 def _run_ssh_command(
-    host: str, command: list[str], timeout: int = 10
-) -> tuple[bool, str]:
+    host: str, command: List[str], timeout: int = 10
+) -> Tuple[bool, str]:
     """Run a command on a remote host via SSH.
 
     Args:
@@ -180,7 +181,7 @@ def validate_multihost_bind_mount_permissions(
 # =============================================================================
 
 
-def validate_controller_is_rank0_host(hosts: list[str]) -> list[str]:
+def validate_controller_is_rank0_host(hosts: List[str]) -> List[str]:
     """Validate that run.py is executed on the rank-0 host (first in MULTIHOST_HOSTS).
 
     Controller container runs locally, and MPI rank-0 must be on the same host
@@ -221,7 +222,7 @@ def validate_controller_is_rank0_host(hosts: list[str]) -> list[str]:
 # =============================================================================
 
 
-def validate_host_ssh_connectivity(hosts: list[str]) -> list[str]:
+def validate_host_ssh_connectivity(hosts: List[str]) -> List[str]:
     """Validate SSH connectivity to all hosts.
 
     Args:
@@ -241,7 +242,7 @@ def validate_host_ssh_connectivity(hosts: list[str]) -> list[str]:
     return errors
 
 
-def validate_host_docker_availability(hosts: list[str]) -> list[str]:
+def validate_host_docker_availability(hosts: List[str]) -> List[str]:
     """Validate Docker is available and running on all hosts.
 
     Args:
@@ -263,7 +264,7 @@ def validate_host_docker_availability(hosts: list[str]) -> list[str]:
     return errors
 
 
-def validate_host_network_interface(hosts: list[str], interface: str) -> list[str]:
+def validate_host_network_interface(hosts: List[str], interface: str) -> List[str]:
     """Validate MPI network interface exists on all hosts.
 
     Args:
@@ -285,8 +286,8 @@ def validate_host_network_interface(hosts: list[str], interface: str) -> list[st
 
 
 def validate_host_shared_directory(
-    hosts: list[str], shared_storage_root: str
-) -> list[str]:
+    hosts: List[str], shared_storage_root: str
+) -> List[str]:
     """Validate shared storage root is accessible on all hosts.
 
     Args:
@@ -325,7 +326,7 @@ def validate_host_shared_directory(
     return errors
 
 
-def validate_host_tt_device(hosts: list[str]) -> list[str]:
+def validate_host_tt_device(hosts: List[str]) -> List[str]:
     """Validate Tenstorrent device is available on all hosts.
 
     Args:
@@ -347,7 +348,7 @@ def validate_host_tt_device(hosts: list[str]) -> list[str]:
     return errors
 
 
-def validate_host_tt_smi(hosts: list[str], tt_smi_path: str = "tt-smi") -> list[str]:
+def validate_host_tt_smi(hosts: List[str], tt_smi_path: str = "tt-smi") -> List[str]:
     """Validate tt-smi command is available on all hosts.
 
     Args:
@@ -368,7 +369,7 @@ def validate_host_tt_smi(hosts: list[str], tt_smi_path: str = "tt-smi") -> list[
     return errors
 
 
-def validate_host_hugepages(hosts: list[str]) -> list[str]:
+def validate_host_hugepages(hosts: List[str]) -> List[str]:
     """Validate hugepages are available on all hosts.
 
     Args:
@@ -396,10 +397,10 @@ def validate_host_hugepages(hosts: list[str]) -> list[str]:
 
 
 def validate_host_system_software(
-    hosts: list[str],
+    hosts: List[str],
     model_spec,
     tt_smi_path: str = "tt-smi",
-) -> list[str]:
+) -> List[str]:
     """Validate FW/KMD versions on all hosts via SSH.
 
     Runs 'tt-smi -s' on each host and validates:
@@ -533,7 +534,7 @@ def validate_host_system_software(
 
 
 def validate_multihost_environment(
-    hosts: list[str],
+    hosts: List[str],
     mpi_interface: str,
     shared_storage_root: str,
     model_spec=None,
@@ -620,7 +621,7 @@ def validate_multihost_args(
     skip_environment_check: bool = False,
     tt_smi_path: str = "tt-smi",
     dry_run: bool = False,
-) -> list[str]:
+) -> List[str]:
     """Validate multi-host configuration.
 
     Args:


### PR DESCRIPTION
Replace Python 3.9+ generic type syntax (PEP 585) with typing module equivalents to support older Python versions in CI environments.

failed CI: https://github.com/tenstorrent/tt-shield/actions/runs/23168241443/job/67317866538