### PR TITLE
acceptance_criteria.py to disambiguate between job failures and acceptance thresholds not being met

### DIFF
--- a/run.py
+++ b/run.py
@@ -624,17 +624,19 @@ def main():
         run_local_server(model_spec, runtime_config, json_fpath, setup_config)
 
     # step 5: run workflows
-    main_return_code = 0
-
     skip_workflows = {WorkflowType.SERVER}
     if WorkflowType.from_string(runtime_config.workflow) not in skip_workflows:
-        return_codes = run_workflows(model_spec, runtime_config, json_fpath)
-        if all(return_code == 0 for return_code in return_codes):
-            logger.info("Completed run.py successfully.")
+        workflow_results = run_workflows(model_spec, runtime_config, json_fpath)
+        if all(result.return_code == 0 for result in workflow_results):
+            logger.info("Completed run.py.")
         else:
-            main_return_code = 1
+            failed_workflows = [
+                f"{result.workflow_name} ({result.return_code})"
+                for result in workflow_results
+                if result.return_code != 0
+            ]
             logger.error(
-                f"run.py failed with return codes: {return_codes}. "
+                f"run.py failed workflows: {failed_workflows}. "
                 "See logs above for details."
             )
     else:
@@ -651,8 +653,6 @@ def main():
         "issue and server log if available."
     )
     logger.info(f"This log file is saved on local machine at: {run_log_path}")
-
-    return main_return_code
 
 
 if __name__ == "__main__":

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -17,7 +17,7 @@ from workflows.model_spec import (
     MODEL_SPECS,
     get_model_id,
 )
-from workflows.run_workflows import run_workflows
+from workflows.run_workflows import WorkflowResult, run_workflows
 from workflows.runtime_config import RuntimeConfig
 from workflows.setup_host import HostSetupManager
 from workflows.utils import (
@@ -182,23 +182,31 @@ class TestWorkflowExecution:
         workflow_calls = []
 
         def mock_run_single(model_spec_arg, runtime_config_arg, json_fpath):
-            workflow_calls.append(runtime_config_arg.workflow)
-            return 0
+            workflow_type = WorkflowType.from_string(runtime_config_arg.workflow)
+            workflow_calls.append(workflow_type.name)
+            return WorkflowResult(
+                workflow_name=workflow_type.name.lower(),
+                return_code=len(workflow_calls) - 1,
+            )
 
-        # Mock run_single_workflow to return success codes
+        # Mock run_single_workflow to return ordered named results
         with patch(
             "workflows.run_workflows.run_single_workflow", side_effect=mock_run_single
         ) as mock_run_single:
-            return_codes = run_workflows(
+            workflow_results = run_workflows(
                 model_spec, runtime_config, "test_json_path.json"
             )
 
-            # Verify all expected workflows were called
-            assert len(return_codes) == 4  # benchmarks, evals, reports, spec_tests
-            assert all(code == 0 for code in return_codes)
+            expected_results = [
+                WorkflowResult(workflow_name="evals", return_code=0),
+                WorkflowResult(workflow_name="benchmarks", return_code=1),
+                WorkflowResult(workflow_name="spec_tests", return_code=2),
+                WorkflowResult(workflow_name="reports", return_code=3),
+            ]
+
+            assert workflow_results == expected_results
             assert mock_run_single.call_count == 4
 
-            # The order should be BENCHMARKS, EVALS, REPORTS
             expected_order = ["EVALS", "BENCHMARKS", "SPEC_TESTS", "REPORTS"]
             assert workflow_calls == expected_order, (
                 f"Expected {expected_order}, got {workflow_calls}"
@@ -208,6 +216,41 @@ class TestWorkflowExecution:
             # Note: The args object is modified in place, so we rely on the implementation details
             # First workflow should start without trace capture disabled
             # Subsequent workflows should have trace capture disabled
+
+    def test_non_release_workflow_includes_reports_result(self):
+        """Test non-release workflows preserve result order and append reports."""
+        model_spec = Namespace(
+            model_name="meta-llama/Llama-3.1-8B-Instruct",
+        )
+        runtime_config = RuntimeConfig(
+            model="Llama-3.1-8B-Instruct",
+            workflow="benchmarks",
+            device="n150",
+            impl="tt-transformers",
+            disable_trace_capture=False,
+        )
+        workflow_calls = []
+
+        def mock_run_single(model_spec_arg, runtime_config_arg, json_fpath):
+            workflow_type = WorkflowType.from_string(runtime_config_arg.workflow)
+            workflow_calls.append(workflow_type.name)
+            return WorkflowResult(
+                workflow_name=workflow_type.name.lower(),
+                return_code=len(workflow_calls),
+            )
+
+        with patch(
+            "workflows.run_workflows.run_single_workflow", side_effect=mock_run_single
+        ):
+            workflow_results = run_workflows(
+                model_spec, runtime_config, "test_json_path.json"
+            )
+
+        assert workflow_calls == ["BENCHMARKS", "REPORTS"]
+        assert workflow_results == [
+            WorkflowResult(workflow_name="benchmarks", return_code=1),
+            WorkflowResult(workflow_name="reports", return_code=2),
+        ]
 
 
 class TestHostSetupIntegration:
@@ -480,21 +523,17 @@ class TestMainWorkflowIntegration:
         ]
 
         with patch("sys.argv", test_args), patch(
-            "run.run_workflows", return_value=[0]
+            "run.run_workflows",
+            return_value=[WorkflowResult(workflow_name="benchmarks", return_code=0)],
         ) as mock_run_workflows, patch(
-            "workflows.run_workflows.run_single_workflow"
-        ) as mock_run_single, patch(
             "workflows.utils.get_default_workflow_root_log_dir", return_value=temp_dir
         ), patch("workflows.log_setup.setup_run_logger"):
-            mock_run_workflows.return_value = [0]
-            mock_run_single.return_value = 0
-
             # Run main
             result = main()
 
             # Verify workflow ran without setup_host
             assert mock_run_workflows.called
-            assert result == 0
+            assert result is None
 
     def test_error_handling_invalid_model(self, mock_env_vars):
         """Test error handling for invalid model configuration."""

--- a/tests/workflows/test_acceptance_criteria.py
+++ b/tests/workflows/test_acceptance_criteria.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import copy
+
+import pytest
+
+from workflows.acceptance_criteria import (
+    acceptance_criteria_check,
+    format_acceptance_summary_markdown,
+)
+
+
+@pytest.fixture
+def report_data():
+    return {
+        "benchmarks_summary": [
+            {
+                "ttft": 1.2,
+                "tput_user": 42.0,
+                "target_checks": {
+                    "functional": {
+                        "ttft": 10.0,
+                        "ttft_ratio": 0.12,
+                        "ttft_check": 2,
+                        "tput_check": 1,
+                    },
+                    "complete": {
+                        "ttft": 2.0,
+                        "ttft_ratio": 0.6,
+                        "ttft_check": 2,
+                        "tput_check": 2,
+                    },
+                    "target": {
+                        "ttft": 1.0,
+                        "ttft_ratio": 1.2,
+                        "ttft_check": 2,
+                        "tput_check": 2,
+                    },
+                },
+            }
+        ],
+        "evals": [
+            {
+                "task_name": "hellaswag",
+                "accuracy_check": 2,
+                "score": 0.77,
+                "gpu_reference_score": 0.80,
+                "ratio_to_reference": 0.9625,
+            },
+            {
+                "task_name": "mmlu",
+                "accuracy_check": 1,
+                "score": 0.71,
+                "published_score": 0.72,
+                "ratio_to_published": 0.9861,
+            },
+        ],
+        "parameter_support_tests": {
+            "results": {
+                "test_temperature": [{"status": "passed", "message": ""}],
+                "test_top_p": [
+                    {"status": "passed", "message": ""},
+                    {"status": "passed", "message": ""},
+                ],
+            }
+        },
+    }
+
+
+def test_acceptance_criteria_check_returns_tuple_when_all_checks_pass(report_data):
+    accepted, blockers = acceptance_criteria_check(report_data)
+    summary_markdown = format_acceptance_summary_markdown(accepted, blockers)
+
+    assert accepted is True
+    assert blockers == {}
+    assert "### Acceptance Criteria" in summary_markdown
+    assert "- Acceptance status: `PASS`" in summary_markdown
+    assert "- All acceptance criteria passed." in summary_markdown
+
+
+def test_acceptance_criteria_check_allows_failed_higher_benchmark_levels_when_functional_passes(
+    report_data,
+):
+    failed_report_data = copy.deepcopy(report_data)
+    failed_report_data["benchmarks_summary"][0]["target_checks"]["target"][
+        "ttft_check"
+    ] = 3
+    failed_report_data["benchmarks_summary"][0]["target_checks"]["complete"][
+        "ttft_check"
+    ] = 3
+
+    accepted, blockers = acceptance_criteria_check(failed_report_data)
+
+    assert accepted is True
+    assert blockers == {}
+
+
+def test_acceptance_criteria_check_returns_blockers_when_all_benchmark_levels_fail(
+    report_data,
+):
+    failed_report_data = copy.deepcopy(report_data)
+    failed_report_data["benchmarks_summary"][0]["target_checks"]["functional"][
+        "ttft_check"
+    ] = 3
+    failed_report_data["benchmarks_summary"][0]["target_checks"]["complete"][
+        "ttft_check"
+    ] = 3
+    failed_report_data["benchmarks_summary"][0]["target_checks"]["target"][
+        "ttft_check"
+    ] = 3
+
+    accepted, blockers = acceptance_criteria_check(failed_report_data)
+
+    assert accepted is False
+    assert "benchmarks.functional.ttft_check" in blockers
+    assert "benchmarks.complete.ttft_check" in blockers
+    assert "benchmarks.target.ttft_check" in blockers
+    assert "actual ttft=1.2000" in blockers["benchmarks.functional.ttft_check"]
+    assert "threshold ttft=10.0000" in blockers["benchmarks.functional.ttft_check"]
+    assert "ratio=0.1200" in blockers["benchmarks.functional.ttft_check"]
+
+
+@pytest.mark.parametrize(
+    "eval_row,expected_blocker_key,expected_message",
+    [
+        (
+            {
+                "task_name": "hellaswag",
+                "accuracy_check": 3,
+                "score": 0.72,
+                "gpu_reference_score": 0.80,
+                "ratio_to_reference": 0.90,
+            },
+            "evals.hellaswag",
+            "reference gpu_reference_score=0.8000",
+        ),
+        (
+            {"task_name": "hellaswag"},
+            "evals.hellaswag",
+            "Missing accuracy_check",
+        ),
+    ],
+)
+def test_acceptance_criteria_check_returns_blocker_for_invalid_eval_checks(
+    report_data, eval_row, expected_blocker_key, expected_message
+):
+    failed_report_data = copy.deepcopy(report_data)
+    failed_report_data["evals"] = [eval_row]
+
+    accepted, blockers = acceptance_criteria_check(failed_report_data)
+
+    assert accepted is False
+    assert expected_blocker_key in blockers
+    assert expected_message in blockers[expected_blocker_key]
+
+
+def test_acceptance_criteria_check_returns_blocker_for_failed_parameter_support_test(
+    report_data,
+):
+    failed_report_data = copy.deepcopy(report_data)
+    failed_report_data["parameter_support_tests"]["results"]["test_temperature"][0][
+        "status"
+    ] = "failed"
+    failed_report_data["parameter_support_tests"]["results"]["test_temperature"][0][
+        "message"
+    ] = "temperature argument rejected"
+
+    accepted, blockers = acceptance_criteria_check(failed_report_data)
+
+    assert accepted is False
+    assert "parameter_support_tests.test_temperature.0" in blockers
+    assert (
+        "status=failed vs expected passed"
+        in blockers["parameter_support_tests.test_temperature.0"]
+    )
+    assert (
+        "message=temperature argument rejected"
+        in blockers["parameter_support_tests.test_temperature.0"]
+    )
+
+
+@pytest.mark.parametrize(
+    "field_name,field_value,expected_blocker_key",
+    [
+        (
+            "benchmarks_summary",
+            [{"model": "placeholder"}],
+            "benchmarks_summary.0.target_checks",
+        ),
+        ("evals", [{"model": "placeholder"}], "evals.index_0"),
+        (
+            "parameter_support_tests",
+            [{"model": "placeholder"}],
+            "parameter_support_tests",
+        ),
+    ],
+)
+def test_acceptance_criteria_check_returns_false_for_placeholder_shapes(
+    report_data, field_name, field_value, expected_blocker_key
+):
+    failed_report_data = copy.deepcopy(report_data)
+    failed_report_data[field_name] = field_value
+
+    accepted, blockers = acceptance_criteria_check(failed_report_data)
+    summary_markdown = format_acceptance_summary_markdown(accepted, blockers)
+
+    assert accepted is False
+    assert expected_blocker_key in blockers
+    assert expected_blocker_key in summary_markdown

--- a/tests/workflows/test_acceptance_criteria.py
+++ b/tests/workflows/test_acceptance_criteria.py
@@ -183,6 +183,24 @@ def test_acceptance_criteria_check_returns_blocker_for_failed_parameter_support_
 
 
 @pytest.mark.parametrize(
+    "field_value", [None, [], {}, {"results": {}}, {"configs": {}}]
+)
+def test_acceptance_criteria_check_allows_missing_parameter_support_test_results(
+    report_data, field_value
+):
+    updated_report_data = copy.deepcopy(report_data)
+    if field_value is None:
+        updated_report_data.pop("parameter_support_tests")
+    else:
+        updated_report_data["parameter_support_tests"] = field_value
+
+    accepted, blockers = acceptance_criteria_check(updated_report_data)
+
+    assert accepted is True
+    assert blockers == {}
+
+
+@pytest.mark.parametrize(
     "field_name,field_value,expected_blocker_key",
     [
         (
@@ -194,7 +212,7 @@ def test_acceptance_criteria_check_returns_blocker_for_failed_parameter_support_
         (
             "parameter_support_tests",
             [{"model": "placeholder"}],
-            "parameter_support_tests",
+            None,
         ),
     ],
 )
@@ -207,6 +225,10 @@ def test_acceptance_criteria_check_returns_false_for_placeholder_shapes(
     accepted, blockers = acceptance_criteria_check(failed_report_data)
     summary_markdown = format_acceptance_summary_markdown(accepted, blockers)
 
-    assert accepted is False
-    assert expected_blocker_key in blockers
-    assert expected_blocker_key in summary_markdown
+    if expected_blocker_key is not None:
+        assert accepted is False
+        assert expected_blocker_key in blockers
+        assert expected_blocker_key in summary_markdown
+    else:
+        assert accepted is True
+        assert blockers == {}

--- a/workflows/acceptance_criteria.py
+++ b/workflows/acceptance_criteria.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+from typing import Any, Dict, Tuple
+
+from workflows.workflow_types import ReportCheckTypes
+
+FAIL_CHECK = int(ReportCheckTypes.FAIL)
+TARGET_CHECK_LEVELS = ("functional", "complete", "target")
+CHECK_SUFFIX = "_check"
+BENCHMARK_ACTUAL_FIELDS = {
+    "ttft": ("ttft",),
+    "tput_user": ("tput_user",),
+    "tput_prefill": ("tput_prefill",),
+    "e2el_ms": ("e2el_ms",),
+    "rtr": ("rtr",),
+    "concurrency": ("concurrency",),
+    "tput": ("tput", "tput_user", "inference_steps_per_second"),
+}
+
+
+def acceptance_criteria_check(report_data: dict) -> Tuple[bool, Dict[str, str]]:
+    """Return acceptance status and blocker details for release report data."""
+    acceptance_blockers = {}
+    acceptance_blockers.update(
+        _benchmarks_acceptance(report_data.get("benchmarks_summary"))
+    )
+    acceptance_blockers.update(_evals_acceptance(report_data.get("evals")))
+    acceptance_blockers.update(
+        _parameter_support_acceptance(report_data.get("parameter_support_tests"))
+    )
+    return len(acceptance_blockers) == 0, acceptance_blockers
+
+
+def format_acceptance_summary_markdown(
+    accepted: bool, acceptance_blockers: Dict[str, str]
+) -> str:
+    """Format acceptance status and blockers as markdown."""
+    lines = [
+        "### Acceptance Criteria",
+        "",
+        f"- Acceptance status: `{'PASS' if accepted else 'FAIL'}`",
+    ]
+    if accepted:
+        lines.append("- All acceptance criteria passed.")
+        return "\n".join(lines)
+
+    for blocker_key, blocker_message in acceptance_blockers.items():
+        lines.append(f"- `{blocker_key}`: {blocker_message}")
+
+    return "\n".join(lines)
+
+
+def _benchmarks_acceptance(benchmarks_summary: Any) -> Dict[str, str]:
+    acceptance_blockers = {}
+    if not isinstance(benchmarks_summary, list) or not benchmarks_summary:
+        acceptance_blockers["benchmarks_summary"] = (
+            "Missing benchmarks summary entries in report data."
+        )
+        return acceptance_blockers
+
+    first_summary = benchmarks_summary[0]
+    if not isinstance(first_summary, dict):
+        acceptance_blockers["benchmarks_summary.0"] = (
+            "Benchmark summary entry is not a dictionary."
+        )
+        return acceptance_blockers
+
+    target_checks = first_summary.get("target_checks")
+    if not isinstance(target_checks, dict):
+        acceptance_blockers["benchmarks_summary.0.target_checks"] = (
+            "Missing target_checks in benchmark summary."
+        )
+        return acceptance_blockers
+
+    found_check = False
+    level_failures = {}
+    for level_name in TARGET_CHECK_LEVELS:
+        level_checks = target_checks.get(level_name)
+        if not isinstance(level_checks, dict):
+            acceptance_blockers[f"benchmarks.{level_name}"] = (
+                f"Missing target_checks.{level_name} in benchmark summary."
+            )
+            continue
+
+        level_found_check = False
+        for check_name, check_value in level_checks.items():
+            if not check_name.endswith(CHECK_SUFFIX):
+                continue
+            level_found_check = True
+            found_check = True
+            if not _passes_report_check(check_value):
+                blocker_key = f"benchmarks.{level_name}.{check_name}"
+                level_failures[blocker_key] = _format_benchmark_failure(
+                    level_name, check_name, first_summary, level_checks
+                )
+
+        if not level_found_check:
+            acceptance_blockers[f"benchmarks.{level_name}"] = (
+                f"No *_check fields found in target_checks.{level_name}."
+            )
+            continue
+
+        if _level_passes(level_checks):
+            return acceptance_blockers
+
+    if not found_check:
+        acceptance_blockers["benchmarks_summary.0.target_checks"] = (
+            "No benchmark *_check fields found in target_checks."
+        )
+        return acceptance_blockers
+
+    acceptance_blockers.update(level_failures)
+
+    return acceptance_blockers
+
+
+def _evals_acceptance(evals_data: Any) -> Dict[str, str]:
+    acceptance_blockers = {}
+    if not isinstance(evals_data, list) or not evals_data:
+        acceptance_blockers["evals"] = (
+            "Missing normalized eval rows with accuracy_check in report data."
+        )
+        return acceptance_blockers
+
+    for index, eval_row in enumerate(evals_data):
+        blocker_key = _eval_blocker_key(eval_row, index)
+        if not isinstance(eval_row, dict):
+            acceptance_blockers[blocker_key] = "Eval row is not a dictionary."
+            continue
+
+        accuracy_check = eval_row.get("accuracy_check")
+        if accuracy_check is None:
+            acceptance_blockers[blocker_key] = "Missing accuracy_check in eval row."
+            continue
+        if not _passes_report_check(accuracy_check):
+            acceptance_blockers[blocker_key] = _format_eval_failure(eval_row)
+
+    return acceptance_blockers
+
+
+def _parameter_support_acceptance(parameter_support_tests: Any) -> Dict[str, str]:
+    acceptance_blockers = {}
+    if not isinstance(parameter_support_tests, dict):
+        acceptance_blockers["parameter_support_tests"] = (
+            "Missing parameter_support_tests.results in report data."
+        )
+        return acceptance_blockers
+
+    results = parameter_support_tests.get("results")
+    if not isinstance(results, dict) or not results:
+        acceptance_blockers["parameter_support_tests.results"] = (
+            "Missing parameter_support_tests.results entries in report data."
+        )
+        return acceptance_blockers
+
+    for test_name, test_results in results.items():
+        if not isinstance(test_results, list) or not test_results:
+            acceptance_blockers[f"parameter_support_tests.{test_name}"] = (
+                "Parameter support test results are missing or malformed."
+            )
+            continue
+
+        for index, test_result in enumerate(test_results):
+            blocker_key = f"parameter_support_tests.{test_name}.{index}"
+            if not isinstance(test_result, dict):
+                acceptance_blockers[blocker_key] = (
+                    "Parameter support test entry is not a dictionary."
+                )
+                continue
+
+            if test_result.get("status") != "passed":
+                acceptance_blockers[blocker_key] = _format_parameter_support_failure(
+                    test_result
+                )
+
+    return acceptance_blockers
+
+
+def _passes_report_check(check_value: Any) -> bool:
+    if check_value is None:
+        return False
+
+    try:
+        return int(check_value) != FAIL_CHECK
+    except (TypeError, ValueError):
+        return False
+
+
+def _level_passes(level_checks: dict) -> bool:
+    check_values = [
+        check_value
+        for check_name, check_value in level_checks.items()
+        if check_name.endswith(CHECK_SUFFIX)
+    ]
+    return bool(check_values) and all(
+        _passes_report_check(check_value) for check_value in check_values
+    )
+
+
+def _format_benchmark_failure(
+    level_name: str, check_name: str, benchmark_summary: dict, level_checks: dict
+) -> str:
+    metric_name = check_name[: -len(CHECK_SUFFIX)]
+    actual_field_name, actual_value = _resolve_benchmark_actual(
+        metric_name, benchmark_summary
+    )
+    threshold_value = level_checks.get(metric_name)
+    ratio_value = level_checks.get(f"{metric_name}_ratio")
+
+    detail_parts = [f"{level_name} {check_name} failed"]
+    if actual_field_name is not None:
+        detail_parts.append(f"actual {actual_field_name}={_format_value(actual_value)}")
+    else:
+        detail_parts.append("actual value unavailable in report data")
+
+    if threshold_value is not None:
+        detail_parts.append(f"threshold {metric_name}={_format_value(threshold_value)}")
+    else:
+        detail_parts.append("threshold unavailable in report data")
+
+    if ratio_value not in (None, "Undefined"):
+        detail_parts.append(f"ratio={_format_value(ratio_value)}")
+
+    return "; ".join(detail_parts) + "."
+
+
+def _format_eval_failure(eval_row: dict) -> str:
+    reference_field_name = None
+    reference_value = None
+    ratio_value = None
+
+    if eval_row.get("gpu_reference_score") not in (None, "", "N/A"):
+        reference_field_name = "gpu_reference_score"
+        reference_value = eval_row.get("gpu_reference_score")
+        ratio_value = eval_row.get("ratio_to_reference")
+    elif eval_row.get("published_score") not in (None, "", "N/A"):
+        reference_field_name = "published_score"
+        reference_value = eval_row.get("published_score")
+        ratio_value = eval_row.get("ratio_to_published")
+
+    detail_parts = ["Accuracy check failed"]
+    if eval_row.get("score") not in (None, "", "N/A"):
+        detail_parts.append(f"actual score={_format_value(eval_row.get('score'))}")
+    else:
+        detail_parts.append("actual score unavailable in report data")
+
+    if reference_field_name is not None:
+        detail_parts.append(
+            f"reference {reference_field_name}={_format_value(reference_value)}"
+        )
+    else:
+        detail_parts.append("reference value unavailable in report data")
+
+    if ratio_value not in (None, "", "N/A"):
+        detail_parts.append(f"ratio={_format_value(ratio_value)}")
+
+    return "; ".join(detail_parts) + "."
+
+
+def _format_parameter_support_failure(test_result: dict) -> str:
+    detail_parts = [
+        f"status={_format_value(test_result.get('status'))} vs expected passed"
+    ]
+    message = test_result.get("message")
+    if message:
+        detail_parts.append(f"message={message}")
+    return "; ".join(detail_parts) + "."
+
+
+def _eval_blocker_key(eval_row: Any, index: int) -> str:
+    if isinstance(eval_row, dict):
+        task_name = eval_row.get("task_name")
+        if task_name:
+            return f"evals.{task_name}"
+    return f"evals.index_{index}"
+
+
+def _resolve_benchmark_actual(
+    metric_name: str, benchmark_summary: dict
+) -> Tuple[Any, Any]:
+    field_names = BENCHMARK_ACTUAL_FIELDS.get(metric_name, (metric_name,))
+    for field_name in field_names:
+        if field_name in benchmark_summary:
+            return field_name, benchmark_summary.get(field_name)
+    return None, None
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    if isinstance(value, ReportCheckTypes):
+        return str(int(value))
+    return str(value)

--- a/workflows/acceptance_criteria.py
+++ b/workflows/acceptance_criteria.py
@@ -143,34 +143,22 @@ def _evals_acceptance(evals_data: Any) -> Dict[str, str]:
 def _parameter_support_acceptance(parameter_support_tests: Any) -> Dict[str, str]:
     acceptance_blockers = {}
     if not isinstance(parameter_support_tests, dict):
-        acceptance_blockers["parameter_support_tests"] = (
-            "Missing parameter_support_tests.results in report data."
-        )
         return acceptance_blockers
 
     results = parameter_support_tests.get("results")
     if not isinstance(results, dict) or not results:
-        acceptance_blockers["parameter_support_tests.results"] = (
-            "Missing parameter_support_tests.results entries in report data."
-        )
         return acceptance_blockers
 
     for test_name, test_results in results.items():
-        if not isinstance(test_results, list) or not test_results:
-            acceptance_blockers[f"parameter_support_tests.{test_name}"] = (
-                "Parameter support test results are missing or malformed."
-            )
+        if not isinstance(test_results, list):
             continue
 
         for index, test_result in enumerate(test_results):
-            blocker_key = f"parameter_support_tests.{test_name}.{index}"
             if not isinstance(test_result, dict):
-                acceptance_blockers[blocker_key] = (
-                    "Parameter support test entry is not a dictionary."
-                )
                 continue
 
             if test_result.get("status") != "passed":
+                blocker_key = f"parameter_support_tests.{test_name}.{index}"
                 acceptance_blockers[blocker_key] = _format_parameter_support_failure(
                     test_result
                 )

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -28,6 +28,10 @@ from stress_tests.stress_tests_summary_report import (
     generate_report as stress_test_generate_report_helper,
 )
 from tests.utils.vllm_parameter_json_to_md import main as generate_vllm_parameter_report
+from workflows.acceptance_criteria import (
+    acceptance_criteria_check,
+    format_acceptance_summary_markdown,
+)
 from workflows.log_setup import setup_workflow_script_logger
 from workflows.model_spec import ModelSpec
 from workflows.runtime_config import RuntimeConfig
@@ -3419,9 +3423,9 @@ def main():
 
     # only show the impl run command if non-default impl is used
     if model_spec.device_model_spec.default_impl:
-        run_cmd = f"python run.py --model {model} --device {device_str} --workflow release {command_flag}"
+        run_cmd = f"python run.py --model {model} --tt-device {device_str} --workflow release {command_flag}"
     else:
-        run_cmd = f"python run.py --model {model} --device {device_str} --impl {model_spec.impl.impl_name} --workflow release {command_flag}"
+        run_cmd = f"python run.py --model {model} --tt-device {device_str} --impl {model_spec.impl.impl_name} --workflow release {command_flag}"
 
     metadata = {
         "report_id": report_id,
@@ -3554,18 +3558,13 @@ def main():
     if genai_perf_release_str:
         all_benchmarks_str += genai_perf_release_str + "\n\n"
 
-    release_str = f"{release_header}\n\n{metadata_str}\n\n{all_benchmarks_str}{evals_release_str}\n\n{tests_release_str}\n\n{stress_tests_release_str}\n\n{server_tests_release_str}"
-    print(release_str)
-    # save to file
     release_output_dir = Path(args.output_path) / "release"
     release_output_dir.mkdir(parents=True, exist_ok=True)
     release_data_dir = release_output_dir / "data"
     release_data_dir.mkdir(parents=True, exist_ok=True)
     release_file = release_output_dir / f"report_{report_id}.md"
     raw_file = release_data_dir / f"report_data_{report_id}.json"
-    with release_file.open("w", encoding="utf-8") as f:
-        f.write(release_str)
-
+    release_str = ""
     with raw_file.open("w", encoding="utf-8") as f:
         # Read detailed benchmark statistics from CSV if available
         benchmarks_detailed_data = None
@@ -3816,7 +3815,28 @@ def main():
         if parameter_support_tests_data:
             output_data["parameter_support_tests"] = parameter_support_tests_data
 
+        acceptance_criteria, acceptance_blockers = acceptance_criteria_check(
+            output_data
+        )
+        acceptance_summary_markdown = format_acceptance_summary_markdown(
+            acceptance_criteria, acceptance_blockers
+        )
+        output_data["acceptance_criteria"] = acceptance_criteria
+        output_data["acceptance_blockers"] = acceptance_blockers
+        output_data["acceptance_summary_markdown"] = acceptance_summary_markdown
+
+        release_str = (
+            f"{release_header}\n\n{metadata_str}\n\n"
+            f"{acceptance_summary_markdown}\n\n{all_benchmarks_str}"
+            f"{evals_release_str}\n\n{tests_release_str}\n\n"
+            f"{stress_tests_release_str}\n\n{server_tests_release_str}"
+        )
+        print(release_str)
+
         json.dump(output_data, f, indent=4)
+
+    with release_file.open("w", encoding="utf-8") as f:
+        f.write(release_str)
 
     main_return_code = 0
     return main_return_code

--- a/workflows/run_workflows.py
+++ b/workflows/run_workflows.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import logging
+from dataclasses import dataclass
 
 from benchmarking.benchmark_config import BENCHMARK_CONFIGS
 from evals.eval_config import EVAL_CONFIGS
@@ -17,6 +18,12 @@ from workflows.workflow_config import (
 from workflows.workflow_venvs import VENV_CONFIGS
 
 logger = logging.getLogger("run_log")
+
+
+@dataclass(frozen=True)
+class WorkflowResult:
+    workflow_name: str
+    return_code: int
 
 
 class WorkflowSetup:
@@ -110,11 +117,14 @@ def run_single_workflow(model_spec, runtime_config, json_fpath):
     manager = WorkflowSetup(model_spec, runtime_config, json_fpath)
     manager.setup_workflow()
     return_code = manager.run_workflow_script()
-    return return_code
+    return WorkflowResult(
+        workflow_name=manager.workflow_config.name,
+        return_code=return_code,
+    )
 
 
 def run_workflows(model_spec, runtime_config, json_fpath):
-    return_codes = []
+    workflow_results = []
     if WorkflowType.from_string(runtime_config.workflow) == WorkflowType.RELEASE:
         logger.info("Running release workflow ...")
         done_trace_capture = False
@@ -131,16 +141,19 @@ def run_workflows(model_spec, runtime_config, json_fpath):
                 runtime_config.disable_trace_capture = True
             logger.info(f"Next workflow in release: {wf.name}")
             runtime_config.workflow = wf.name
-            return_code = run_single_workflow(model_spec, runtime_config, json_fpath)
-            return_codes.append(return_code)
+            workflow_results.append(
+                run_single_workflow(model_spec, runtime_config, json_fpath)
+            )
             done_trace_capture = True
-        return return_codes
+        return workflow_results
     else:
-        return_codes.append(run_single_workflow(model_spec, runtime_config, json_fpath))
+        workflow_results.append(
+            run_single_workflow(model_spec, runtime_config, json_fpath)
+        )
         if WorkflowType.from_string(runtime_config.workflow) != WorkflowType.REPORTS:
             runtime_config.workflow = WorkflowType.REPORTS.name
-            return_codes.append(
+            workflow_results.append(
                 run_single_workflow(model_spec, runtime_config, json_fpath)
             )
 
-    return return_codes
+    return workflow_results


### PR DESCRIPTION
# change log

* acceptance_criteria.py to disambiguate between job failures and acceptance thresholds not being met.Aacceptance criteria checks and publishes acceptance status independent of job fail/success
* run.py no longer errors out and sends exit code 0 on run completed