### PR TITLE
add tensor_cache_timeout and tensor cache stall handling.

### DIFF
--- a/benchmarking/run_aiperf_benchmarks.py
+++ b/benchmarking/run_aiperf_benchmarks.py
@@ -643,7 +643,11 @@ def main():
     env_config.service_port = service_port
     env_config.vllm_model = model_spec.hf_model_repo
 
-    prompt_client = PromptClient(env_config, model_spec=model_spec)
+    prompt_client = PromptClient(
+        env_config,
+        model_spec=model_spec,
+        runtime_config=runtime_config,
+    )
     if not prompt_client.wait_for_healthy():
         logger.error("vLLM server is not healthy. Aborting benchmarks.")
         return 1

--- a/benchmarking/run_benchmarks.py
+++ b/benchmarking/run_benchmarks.py
@@ -339,7 +339,9 @@ def main():
                 log_str += f"  {i:<3} {param.isl:<10} {param.osl:<10} {param.max_concurrency:<15} {param.images_per_prompt:<12} {param.image_height:<12} {param.image_width:<12} {param.num_prompts:<12}\n"
     logger.info(log_str)
 
-    assert all_params, f"No benchmark tasks defined for model: {model_spec.model_name} on device: {device.name}"
+    assert all_params, (
+        f"No benchmark tasks defined for model: {model_spec.model_name} on device: {device.name}"
+    )
 
     logger.info("Wait for the vLLM server to be ready ...")
     env_config = EnvironmentConfig()

--- a/benchmarking/run_benchmarks.py
+++ b/benchmarking/run_benchmarks.py
@@ -350,7 +350,11 @@ def main():
     env_config.service_port = service_port
     env_config.vllm_model = model_spec.hf_model_repo
 
-    prompt_client = PromptClient(env_config, model_spec=model_spec)
+    prompt_client = PromptClient(
+        env_config,
+        model_spec=model_spec,
+        runtime_config=runtime_config,
+    )
     logger.info(
         "Using tensor_cache_timeout:=%ss for first-run tensor cache generation when cache monitoring is active",
         prompt_client.cache_monitor.get_tensor_cache_timeout(),

--- a/benchmarking/run_benchmarks.py
+++ b/benchmarking/run_benchmarks.py
@@ -339,9 +339,7 @@ def main():
                 log_str += f"  {i:<3} {param.isl:<10} {param.osl:<10} {param.max_concurrency:<15} {param.images_per_prompt:<12} {param.image_height:<12} {param.image_width:<12} {param.num_prompts:<12}\n"
     logger.info(log_str)
 
-    assert all_params, (
-        f"No benchmark tasks defined for model: {model_spec.model_name} on device: {device.name}"
-    )
+    assert all_params, f"No benchmark tasks defined for model: {model_spec.model_name} on device: {device.name}"
 
     logger.info("Wait for the vLLM server to be ready ...")
     env_config = EnvironmentConfig()
@@ -350,8 +348,11 @@ def main():
     env_config.service_port = service_port
     env_config.vllm_model = model_spec.hf_model_repo
 
-    # Use intelligent timeout - automatically determines 90 minutes for first run, 30 minutes for subsequent runs
     prompt_client = PromptClient(env_config, model_spec=model_spec)
+    logger.info(
+        "Using tensor_cache_timeout:=%ss for first-run tensor cache generation when cache monitoring is active",
+        prompt_client.cache_monitor.get_tensor_cache_timeout(),
+    )
     if not prompt_client.wait_for_healthy():
         logger.error("⛔️ vLLM server is not healthy. Aborting benchmarks. ")
         return 1

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -465,7 +465,11 @@ def main():
 
     # For LLM models, use PromptClient for health checks and trace capture
     else:
-        prompt_client = PromptClient(env_config, model_spec=model_spec)
+        prompt_client = PromptClient(
+            env_config,
+            model_spec=model_spec,
+            runtime_config=runtime_config,
+        )
         logger.info(
             "Using tensor_cache_timeout:=%ss for first-run tensor cache generation when cache monitoring is active",
             prompt_client.cache_monitor.get_tensor_cache_timeout(),

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -465,8 +465,11 @@ def main():
 
     # For LLM models, use PromptClient for health checks and trace capture
     else:
-        # Use intelligent timeout - automatically determines 90 minutes for first run, 30 minutes for subsequent runs
         prompt_client = PromptClient(env_config, model_spec=model_spec)
+        logger.info(
+            "Using tensor_cache_timeout:=%ss for first-run tensor cache generation when cache monitoring is active",
+            prompt_client.cache_monitor.get_tensor_cache_timeout(),
+        )
         if not prompt_client.wait_for_healthy():
             logger.error("⛔️ vLLM server is not healthy. Aborting evaluations.")
             return 1

--- a/tests/test_cache_monitor.py
+++ b/tests/test_cache_monitor.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+from types import SimpleNamespace
+
+import pytest
+
+from utils.cache_monitor import CacheGenerationStatus, CacheMonitor
+
+
+def test_existing_tensor_cache_without_markers_is_not_treated_as_first_run(tmp_path):
+    tensor_file = tmp_path / "tensor.bin"
+    tensor_file.write_bytes(b"cached-tensor-data")
+
+    monitor = CacheMonitor(cache_dir=tmp_path)
+
+    status = monitor.get_cache_generation_status()
+
+    assert status.is_generating is False
+    assert status.is_first_run is False
+    assert status.is_stalled is False
+    assert status.file_count == 1
+    assert status.total_size_bytes == tensor_file.stat().st_size
+
+
+def test_tensor_cache_stall_detection_trips_after_no_growth_timeout(
+    tmp_path, monkeypatch
+):
+    fake_time = [1000.0]
+    monkeypatch.setattr("utils.cache_monitor.time.time", lambda: fake_time[0])
+
+    monitor = CacheMonitor(cache_dir=tmp_path)
+    tensor_file = tmp_path / "cache.bin"
+    tensor_file.write_bytes(b"1234")
+    assert monitor.mark_cache_first_run_started() is True
+
+    initial_status = monitor.get_cache_generation_status()
+    assert initial_status.is_generating is True
+    assert initial_status.is_stalled is False
+    assert initial_status.file_count == 1
+
+    fake_time[0] += 100.0
+    mid_status = monitor.get_cache_generation_status()
+    assert mid_status.is_stalled is False
+    assert mid_status.no_progress_duration == pytest.approx(100.0)
+
+    fake_time[0] += 81.0
+    stalled_status = monitor.get_cache_generation_status()
+    assert stalled_status.is_stalled is True
+    assert stalled_status.no_progress_duration == pytest.approx(181.0)
+
+    tensor_file.write_bytes(b"12345")
+    recovered_status = monitor.get_cache_generation_status()
+    assert recovered_status.is_stalled is False
+    assert recovered_status.no_progress_duration == pytest.approx(0.0)
+    assert recovered_status.total_size_bytes == 5
+
+
+def test_effective_timeout_uses_tensor_cache_timeout_only_during_generation(tmp_path):
+    model_spec = SimpleNamespace(
+        model_name="TestModel",
+        uses_tensor_model_cache=True,
+        device_model_spec=SimpleNamespace(tensor_cache_timeout=3600.0),
+    )
+    monitor = CacheMonitor(model_spec=model_spec, cache_dir=tmp_path)
+
+    generating_status = CacheGenerationStatus(is_generating=True)
+    ready_status = CacheGenerationStatus(is_generating=False)
+
+    assert monitor.get_tensor_cache_timeout() == 3600.0
+    assert monitor.get_effective_timeout(1200.0, generating_status) == 3600.0
+    assert monitor.get_effective_timeout(1200.0, ready_status) == 1200.0

--- a/tests/test_cache_monitor.py
+++ b/tests/test_cache_monitor.py
@@ -13,6 +13,7 @@ from utils.cache_monitor import (
     CacheGenerationStatus,
     CacheMonitor,
     DockerVolumeInfo,
+    inspect_docker_volume,
 )
 
 
@@ -210,6 +211,37 @@ def test_detect_cache_directory_uses_docker_volume_mountpoint(tmp_path, monkeypa
     )
 
 
+def test_inspect_docker_volume_treats_permission_error_as_unreadable(
+    tmp_path, monkeypatch
+):
+    volume_name = "volume_id_tt-transformers-TestModel"
+    original_exists = Path.exists
+
+    def fake_run(command, capture_output, text, check, timeout):
+        assert command[:4] == ["docker", "volume", "inspect", volume_name]
+        return SimpleNamespace(
+            returncode=0,
+            stdout=f"{tmp_path}\n",
+            stderr="",
+        )
+
+    def deny_exists(self):
+        if self == tmp_path:
+            raise PermissionError("permission denied")
+        return original_exists(self)
+
+    monkeypatch.setattr("utils.cache_monitor.subprocess.run", fake_run)
+    monkeypatch.setattr(Path, "exists", deny_exists)
+
+    volume_info = inspect_docker_volume(volume_name)
+
+    assert volume_info == DockerVolumeInfo(
+        volume_name=volume_name,
+        mountpoint=tmp_path,
+        is_readable=False,
+    )
+
+
 def test_unreadable_docker_volume_uses_cli_fallback(tmp_path, monkeypatch):
     model_spec = _make_tensor_cache_model_spec()
 
@@ -229,6 +261,37 @@ def test_unreadable_docker_volume_uses_cli_fallback(tmp_path, monkeypatch):
     assert (
         monitor.cache_target.docker_volume_name == "volume_id_tt-transformers-TestModel"
     )
+    assert monitor.cache_dir == Path("/cache/tt_metal_cache/cache_TestModel/N150")
+
+
+def test_cache_monitor_uses_cli_fallback_when_docker_mountpoint_probe_is_denied(
+    tmp_path, monkeypatch
+):
+    model_spec = _make_tensor_cache_model_spec()
+    volume_name = "volume_id_tt-transformers-TestModel"
+    original_exists = Path.exists
+
+    def fake_run(command, capture_output, text, check, timeout):
+        assert command[:4] == ["docker", "volume", "inspect", volume_name]
+        return SimpleNamespace(
+            returncode=0,
+            stdout=f"{tmp_path}\n",
+            stderr="",
+        )
+
+    def deny_exists(self):
+        if self == tmp_path:
+            raise PermissionError("permission denied")
+        return original_exists(self)
+
+    monkeypatch.setattr("utils.cache_monitor.subprocess.run", fake_run)
+    monkeypatch.setattr(Path, "exists", deny_exists)
+
+    monitor = CacheMonitor(model_spec=model_spec)
+
+    assert monitor.cache_target.uses_docker_cli() is True
+    assert monitor.cache_target.cache_dir is None
+    assert monitor.cache_target.docker_volume_name == volume_name
     assert monitor.cache_dir == Path("/cache/tt_metal_cache/cache_TestModel/N150")
 
 

--- a/tests/test_cache_monitor.py
+++ b/tests/test_cache_monitor.py
@@ -3,11 +3,32 @@
 #
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
+import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
-from utils.cache_monitor import CacheGenerationStatus, CacheMonitor
+from utils.cache_monitor import (
+    CacheGenerationStatus,
+    CacheMonitor,
+    DockerVolumeInfo,
+)
+
+
+def _make_tensor_cache_model_spec(**overrides):
+    defaults = {
+        "impl": SimpleNamespace(impl_id="tt-transformers"),
+        "model_name": "TestModel",
+        "version": "1.0.0",
+        "device_type": SimpleNamespace(name="N150"),
+        "subdevice_type": None,
+        "uses_tensor_model_cache": True,
+        "device_model_spec": SimpleNamespace(tensor_cache_timeout=3600.0),
+        "docker_image": "tt-inference-server:test",
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
 
 
 def test_existing_tensor_cache_without_markers_is_not_treated_as_first_run(tmp_path):
@@ -20,9 +41,40 @@ def test_existing_tensor_cache_without_markers_is_not_treated_as_first_run(tmp_p
 
     assert status.is_generating is False
     assert status.is_first_run is False
+    assert status.has_existing_cache is True
     assert status.is_stalled is False
     assert status.file_count == 1
     assert status.total_size_bytes == tensor_file.stat().st_size
+
+
+def test_empty_cache_without_markers_is_observational(tmp_path, monkeypatch):
+    fake_time = [1000.0]
+    monkeypatch.setattr("utils.cache_monitor.time.time", lambda: fake_time[0])
+
+    monitor = CacheMonitor(cache_dir=tmp_path)
+    started_file, completed_file = monitor.get_cache_marker_files()
+
+    initial_status = monitor.get_cache_generation_status()
+
+    assert initial_status.is_first_run is True
+    assert initial_status.is_generating is False
+    assert initial_status.has_existing_cache is False
+    assert initial_status.is_stalled is False
+    assert initial_status.file_count == 0
+    assert (
+        monitor.get_effective_timeout(1200.0, initial_status)
+        == monitor.DEFAULT_TENSOR_CACHE_TIMEOUT
+    )
+    assert started_file.exists() is False
+    assert completed_file.exists() is False
+
+    fake_time[0] += 600.0
+    later_status = monitor.get_cache_generation_status()
+
+    assert later_status.is_first_run is True
+    assert later_status.is_generating is False
+    assert later_status.has_existing_cache is False
+    assert later_status.is_stalled is False
 
 
 def test_tensor_cache_stall_detection_trips_after_no_growth_timeout(
@@ -30,6 +82,7 @@ def test_tensor_cache_stall_detection_trips_after_no_growth_timeout(
 ):
     fake_time = [1000.0]
     monkeypatch.setattr("utils.cache_monitor.time.time", lambda: fake_time[0])
+    monkeypatch.setattr(CacheMonitor, "TENSOR_CACHE_NO_CHANGE_TIMEOUT", 180)
 
     monitor = CacheMonitor(cache_dir=tmp_path)
     tensor_file = tmp_path / "cache.bin"
@@ -58,17 +111,276 @@ def test_tensor_cache_stall_detection_trips_after_no_growth_timeout(
     assert recovered_status.total_size_bytes == 5
 
 
-def test_effective_timeout_uses_tensor_cache_timeout_only_during_generation(tmp_path):
-    model_spec = SimpleNamespace(
-        model_name="TestModel",
-        uses_tensor_model_cache=True,
-        device_model_spec=SimpleNamespace(tensor_cache_timeout=3600.0),
+def test_effective_timeout_uses_tensor_cache_timeout_for_first_run_and_generation(
+    tmp_path,
+):
+    model_spec = _make_tensor_cache_model_spec(
+        impl=None,
+        version=None,
+        device_type=None,
     )
     monitor = CacheMonitor(model_spec=model_spec, cache_dir=tmp_path)
 
+    first_run_status = CacheGenerationStatus(is_generating=False, is_first_run=True)
     generating_status = CacheGenerationStatus(is_generating=True)
     ready_status = CacheGenerationStatus(is_generating=False)
 
     assert monitor.get_tensor_cache_timeout() == 3600.0
+    assert monitor.get_effective_timeout(1200.0, first_run_status) == 3600.0
     assert monitor.get_effective_timeout(1200.0, generating_status) == 3600.0
     assert monitor.get_effective_timeout(1200.0, ready_status) == 1200.0
+
+
+@pytest.mark.parametrize("configured_timeout", [None, "invalid", 0, -1])
+def test_invalid_tensor_cache_timeout_uses_default(tmp_path, configured_timeout):
+    model_spec = _make_tensor_cache_model_spec(
+        impl=None,
+        version=None,
+        device_type=None,
+        device_model_spec=SimpleNamespace(tensor_cache_timeout=configured_timeout),
+    )
+
+    monitor = CacheMonitor(model_spec=model_spec, cache_dir=tmp_path)
+
+    assert (
+        monitor.get_tensor_cache_timeout() == CacheMonitor.DEFAULT_TENSOR_CACHE_TIMEOUT
+    )
+
+
+def test_explicit_cache_dir_takes_precedence_over_tt_cache_path(tmp_path, monkeypatch):
+    explicit_cache_dir = tmp_path / "explicit-cache"
+    env_cache_dir = tmp_path / "env-cache"
+    monkeypatch.setenv("TT_CACHE_PATH", str(env_cache_dir))
+
+    monitor = CacheMonitor(cache_dir=explicit_cache_dir)
+
+    assert monitor.cache_dir == explicit_cache_dir
+
+
+def test_detect_cache_directory_uses_tt_cache_path_env(tmp_path, monkeypatch):
+    model_spec = _make_tensor_cache_model_spec(
+        impl=None,
+        version=None,
+        device_type=None,
+    )
+    env_cache_dir = tmp_path / "in-container-cache"
+    monkeypatch.setenv("TT_CACHE_PATH", str(env_cache_dir))
+
+    monitor = CacheMonitor(model_spec=model_spec)
+
+    assert monitor.cache_dir == env_cache_dir
+
+
+def test_detect_cache_directory_uses_runtime_host_volume(tmp_path):
+    model_spec = _make_tensor_cache_model_spec()
+    runtime_config = SimpleNamespace(
+        host_volume=str(tmp_path / "persistent_volume"),
+        local_server=False,
+        device="n150",
+    )
+
+    monitor = CacheMonitor(model_spec=model_spec, runtime_config=runtime_config)
+
+    assert monitor.cache_dir == (
+        tmp_path
+        / "persistent_volume"
+        / "volume_id_tt-transformers-TestModel-v1.0.0"
+        / "tt_metal_cache"
+        / "cache_TestModel"
+        / "N150"
+    )
+
+
+def test_detect_cache_directory_uses_docker_volume_mountpoint(tmp_path, monkeypatch):
+    model_spec = _make_tensor_cache_model_spec()
+
+    monkeypatch.setattr(
+        "utils.cache_monitor.inspect_docker_volume",
+        lambda volume_name: DockerVolumeInfo(
+            volume_name=volume_name,
+            mountpoint=tmp_path,
+            is_readable=True,
+        ),
+    )
+
+    monitor = CacheMonitor(model_spec=model_spec)
+
+    assert monitor.cache_dir == (
+        tmp_path / "tt_metal_cache" / "cache_TestModel" / "N150"
+    )
+
+
+def test_unreadable_docker_volume_uses_cli_fallback(tmp_path, monkeypatch):
+    model_spec = _make_tensor_cache_model_spec()
+
+    monkeypatch.setattr(
+        "utils.cache_monitor.inspect_docker_volume",
+        lambda volume_name: DockerVolumeInfo(
+            volume_name=volume_name,
+            mountpoint=tmp_path,
+            is_readable=False,
+        ),
+    )
+
+    monitor = CacheMonitor(model_spec=model_spec)
+
+    assert monitor.cache_target.uses_docker_cli() is True
+    assert monitor.cache_target.cache_dir is None
+    assert (
+        monitor.cache_target.docker_volume_name == "volume_id_tt-transformers-TestModel"
+    )
+    assert monitor.cache_dir == Path("/cache/tt_metal_cache/cache_TestModel/N150")
+
+
+def test_docker_cli_snapshot_returns_expected_size_and_count(tmp_path, monkeypatch):
+    model_spec = _make_tensor_cache_model_spec()
+
+    monkeypatch.setattr(
+        "utils.cache_monitor.inspect_docker_volume",
+        lambda volume_name: DockerVolumeInfo(
+            volume_name=volume_name,
+            mountpoint=tmp_path,
+            is_readable=False,
+        ),
+    )
+
+    def fake_run(command, capture_output, text, check, timeout):
+        assert command[:3] == ["docker", "run", "--rm"]
+        assert "volume_id_tt-transformers-TestModel:/cache:ro" in command
+        assert "tt-inference-server:test" in command
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"total_size_bytes": 1234, "file_count": 7}),
+            stderr="",
+        )
+
+    monkeypatch.setattr("utils.cache_monitor.subprocess.run", fake_run)
+
+    monitor = CacheMonitor(model_spec=model_spec)
+
+    assert monitor._get_tensor_cache_snapshot() == (1234, 7)
+
+
+def test_docker_cli_snapshot_failure_returns_empty_snapshot(tmp_path, monkeypatch):
+    model_spec = _make_tensor_cache_model_spec()
+
+    monkeypatch.setattr(
+        "utils.cache_monitor.inspect_docker_volume",
+        lambda volume_name: DockerVolumeInfo(
+            volume_name=volume_name,
+            mountpoint=tmp_path,
+            is_readable=False,
+        ),
+    )
+    monkeypatch.setattr(
+        "utils.cache_monitor.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="helper image missing",
+        ),
+    )
+
+    monitor = CacheMonitor(model_spec=model_spec)
+
+    assert monitor._get_tensor_cache_snapshot() == (0, 0)
+
+
+def test_docker_cli_snapshot_invalid_json_returns_empty_snapshot(tmp_path, monkeypatch):
+    model_spec = _make_tensor_cache_model_spec()
+
+    monkeypatch.setattr(
+        "utils.cache_monitor.inspect_docker_volume",
+        lambda volume_name: DockerVolumeInfo(
+            volume_name=volume_name,
+            mountpoint=tmp_path,
+            is_readable=False,
+        ),
+    )
+    monkeypatch.setattr(
+        "utils.cache_monitor.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="not-json",
+            stderr="",
+        ),
+    )
+
+    monitor = CacheMonitor(model_spec=model_spec)
+
+    assert monitor._get_tensor_cache_snapshot() == (0, 0)
+
+
+def test_docker_cli_fallback_stall_detection_trips_after_no_growth_timeout(
+    tmp_path, monkeypatch
+):
+    fake_time = [1000.0]
+    monkeypatch.setattr("utils.cache_monitor.time.time", lambda: fake_time[0])
+    monkeypatch.setattr(CacheMonitor, "TENSOR_CACHE_NO_CHANGE_TIMEOUT", 180)
+
+    model_spec = _make_tensor_cache_model_spec()
+    monkeypatch.setattr(
+        "utils.cache_monitor.inspect_docker_volume",
+        lambda volume_name: DockerVolumeInfo(
+            volume_name=volume_name,
+            mountpoint=tmp_path,
+            is_readable=False,
+        ),
+    )
+
+    monitor = CacheMonitor(model_spec=model_spec)
+    snapshots = iter([(0, 0), (4, 1), (4, 1), (4, 1), (4, 1)])
+    monkeypatch.setattr(monitor, "_get_docker_cache_snapshot", lambda: next(snapshots))
+
+    initial_status = monitor.get_cache_generation_status()
+    assert initial_status.is_first_run is True
+    assert initial_status.is_generating is False
+    assert initial_status.is_stalled is False
+    assert initial_status.file_count == 0
+
+    fake_time[0] += 1.0
+    generating_status = monitor.get_cache_generation_status()
+    assert generating_status.is_first_run is False
+    assert generating_status.is_generating is True
+    assert generating_status.file_count == 1
+    assert generating_status.is_stalled is False
+
+    fake_time[0] += 100.0
+    mid_status = monitor.get_cache_generation_status()
+    assert mid_status.is_generating is True
+    assert mid_status.file_count == 1
+    assert mid_status.is_stalled is False
+
+    fake_time[0] += 81.0
+    stalled_status = monitor.get_cache_generation_status()
+    assert stalled_status.is_generating is True
+    assert stalled_status.is_stalled is True
+    assert stalled_status.no_progress_duration == pytest.approx(181.0)
+
+    assert monitor.mark_cache_completed() is True
+    completed_status = monitor.get_cache_generation_status()
+    assert completed_status.is_generating is False
+
+
+def test_completed_marker_suppresses_first_run(tmp_path):
+    monitor = CacheMonitor(cache_dir=tmp_path)
+
+    assert monitor.mark_cache_completed() is True
+
+    status = monitor.get_cache_generation_status()
+
+    assert status.is_first_run is False
+    assert status.is_generating is False
+    assert status.has_existing_cache is True
+    assert status.is_stalled is False
+
+
+def test_monitoring_is_disabled_when_tensor_cache_is_unused(tmp_path):
+    model_spec = _make_tensor_cache_model_spec(uses_tensor_model_cache=False)
+
+    monitor = CacheMonitor(model_spec=model_spec, cache_dir=tmp_path)
+    status = monitor.get_cache_generation_status()
+
+    assert monitor.cache_dir is None
+    assert status.is_generating is False
+    assert status.cache_dir is None

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -49,6 +49,7 @@ def sample_device_model_spec():
         max_concurrency=16,
         max_context=64 * 1024,
         default_impl=True,
+        tensor_cache_timeout=2400.0,
     )
 
 
@@ -68,12 +69,14 @@ class TestModelSpecTemplateSystem:
                     max_concurrency=16,
                     max_context=64 * 1024,
                     default_impl=True,
+                    tensor_cache_timeout=1800.0,
                 ),
                 DeviceModelSpec(
                     device=DeviceTypes.N300,
                     max_concurrency=32,
                     max_context=128 * 1024,
                     default_impl=False,
+                    tensor_cache_timeout=3600.0,
                 ),
             ],
             weights=["test/model-7B", "test/model-7B-Instruct"],
@@ -95,6 +98,10 @@ class TestModelSpecTemplateSystem:
             assert isinstance(spec, ModelSpec)
             assert spec.impl == template.impl
             assert spec.status == "testing"
+            expected_timeout = (
+                1800.0 if spec.device_type == DeviceTypes.N150 else 3600.0
+            )
+            assert spec.device_model_spec.tensor_cache_timeout == expected_timeout
 
     def test_template_defaults(self, sample_impl):
         """Test template creation with defaults."""
@@ -342,6 +349,10 @@ class TestModelSpecSystem:
         assert loaded_spec.model_id == original_spec.model_id
         assert loaded_spec.model_name == original_spec.model_name
         assert loaded_spec.status == original_spec.status
+        assert (
+            loaded_spec.device_model_spec.tensor_cache_timeout
+            == original_spec.device_model_spec.tensor_cache_timeout
+        )
 
     def test_apply_overrides_commits_from_docker_image(
         self, sample_impl, sample_device_model_spec
@@ -441,6 +452,12 @@ class TestSystemIntegration:
                 spec.inference_engine
             ][spec.impl.impl_id]["model_id"]
             == spec.model_id
+        )
+        assert (
+            data["model_specs"][spec.hf_model_repo][spec.device_type.to_string()][
+                spec.inference_engine
+            ][spec.impl.impl_id]["device_model_spec"]["tensor_cache_timeout"]
+            == spec.device_model_spec.tensor_cache_timeout
         )
 
     def test_real_spec_templates(self):

--- a/tests/test_prompt_client.py
+++ b/tests/test_prompt_client.py
@@ -3,6 +3,7 @@
 #
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -15,6 +16,7 @@ class _StalledCacheMonitor:
     def get_cache_generation_status(self):
         return SimpleNamespace(
             is_generating=True,
+            is_first_run=False,
             is_stalled=True,
             no_progress_duration=181.0,
             cache_dir=Path("/tmp/tensor-cache"),
@@ -24,6 +26,46 @@ class _StalledCacheMonitor:
 
     def get_effective_timeout(self, default_timeout, cache_status=None):
         return 3600.0
+
+
+class _GeneratingCacheMonitor:
+    def __init__(self):
+        self.marked_completed = False
+
+    def get_cache_generation_status(self):
+        return SimpleNamespace(
+            is_generating=True,
+            is_first_run=False,
+            is_stalled=False,
+            no_progress_duration=0.0,
+            cache_dir=Path("/tmp/tensor-cache"),
+            file_count=2,
+            total_size_bytes=2048,
+        )
+
+    def get_effective_timeout(self, default_timeout, cache_status=None):
+        return 3600.0
+
+    def mark_cache_completed(self):
+        self.marked_completed = True
+        return True
+
+
+class _ExistingCacheMonitor:
+    def get_cache_generation_status(self):
+        return SimpleNamespace(
+            is_generating=False,
+            is_first_run=False,
+            has_existing_cache=True,
+            is_stalled=False,
+            no_progress_duration=0.0,
+            cache_dir=Path("/tmp/tensor-cache"),
+            file_count=4,
+            total_size_bytes=8192,
+        )
+
+    def get_effective_timeout(self, default_timeout, cache_status=None):
+        return float(default_timeout)
 
 
 def test_wait_for_healthy_aborts_when_tensor_cache_stalls(monkeypatch):
@@ -38,3 +80,36 @@ def test_wait_for_healthy_aborts_when_tensor_cache_stalls(monkeypatch):
     monkeypatch.setattr(prompt_client_module.requests, "get", fail_health_check)
 
     assert prompt_client.wait_for_healthy(timeout=1200.0, interval=1) is False
+
+
+def test_wait_for_healthy_marks_cache_complete_after_success(monkeypatch):
+    prompt_client = PromptClient(EnvironmentConfig())
+    prompt_client.cache_monitor = _GeneratingCacheMonitor()
+
+    monkeypatch.setattr(
+        prompt_client_module.requests,
+        "get",
+        lambda *args, **kwargs: SimpleNamespace(status_code=200),
+    )
+
+    assert prompt_client.wait_for_healthy(timeout=1200.0, interval=1) is True
+    assert prompt_client.cache_monitor.marked_completed is True
+
+
+def test_wait_for_healthy_logs_existing_tensor_cache_details(monkeypatch, caplog):
+    prompt_client = PromptClient(EnvironmentConfig())
+    prompt_client.cache_monitor = _ExistingCacheMonitor()
+
+    monkeypatch.setattr(
+        prompt_client_module.requests,
+        "get",
+        lambda *args, **kwargs: SimpleNamespace(status_code=200),
+    )
+
+    with caplog.at_level(logging.INFO):
+        assert prompt_client.wait_for_healthy(timeout=1200.0, interval=1) is True
+
+    assert (
+        "Existing tensor cache detected - tracking 4 file(s), 8.0 KB; "
+        "using standard timeout:=1200.0s" in caplog.text
+    )

--- a/tests/test_prompt_client.py
+++ b/tests/test_prompt_client.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import utils.prompt_client as prompt_client_module
+from utils.prompt_client import PromptClient
+from utils.prompt_configs import EnvironmentConfig
+
+
+class _StalledCacheMonitor:
+    def get_cache_generation_status(self):
+        return SimpleNamespace(
+            is_generating=True,
+            is_stalled=True,
+            no_progress_duration=181.0,
+            cache_dir=Path("/tmp/tensor-cache"),
+            file_count=1,
+            total_size_bytes=1024,
+        )
+
+    def get_effective_timeout(self, default_timeout, cache_status=None):
+        return 3600.0
+
+
+def test_wait_for_healthy_aborts_when_tensor_cache_stalls(monkeypatch):
+    prompt_client = PromptClient(EnvironmentConfig())
+    prompt_client.cache_monitor = _StalledCacheMonitor()
+
+    def fail_health_check(*args, **kwargs):
+        raise AssertionError(
+            "Health check should not run after a stalled cache is detected"
+        )
+
+    monkeypatch.setattr(prompt_client_module.requests, "get", fail_health_check)
+
+    assert prompt_client.wait_for_healthy(timeout=1200.0, interval=1) is False

--- a/tests/test_run_vllm_api_server.py
+++ b/tests/test_run_vllm_api_server.py
@@ -60,7 +60,7 @@ def run_vllm_api_server_module(monkeypatch):
     monkeypatch.setitem(sys.modules, "vllm", vllm)
 
     utils = types.ModuleType("utils")
-    utils.__path__ = []
+    utils.__path__ = [str(Path(__file__).resolve().parents[1] / "utils")]
     monkeypatch.setitem(sys.modules, "utils", utils)
 
     logging_utils = types.ModuleType("utils.logging_utils")

--- a/tests/test_tensor_cache_timeout_workflows.py
+++ b/tests/test_tensor_cache_timeout_workflows.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+from types import SimpleNamespace
+
+import benchmarking.run_benchmarks as run_benchmarks_module
+import evals.run_evals as run_evals_module
+from workflows.workflow_types import DeviceTypes, ModelType
+
+
+class _FakeCacheMonitor:
+    def __init__(self, timeout):
+        self.timeout = timeout
+        self.get_tensor_cache_timeout_calls = 0
+
+    def get_tensor_cache_timeout(self):
+        self.get_tensor_cache_timeout_calls += 1
+        return self.timeout
+
+
+class _FakePromptClient:
+    created_instances = []
+
+    def __init__(self, env_config, model_spec=None):
+        self.env_config = env_config
+        self.model_spec = model_spec
+        self.cache_monitor = _FakeCacheMonitor(
+            model_spec.device_model_spec.tensor_cache_timeout
+        )
+        self.wait_for_healthy_calls = 0
+        self.capture_traces_calls = 0
+        self.get_health_calls = 0
+        self.__class__.created_instances.append(self)
+
+    def wait_for_healthy(self):
+        self.wait_for_healthy_calls += 1
+        return True
+
+    def capture_traces(self, *args, **kwargs):
+        self.capture_traces_calls += 1
+
+    def get_health(self):
+        self.get_health_calls += 1
+        return SimpleNamespace(status_code=200)
+
+
+def _build_model_spec():
+    return SimpleNamespace(
+        model_name="TestModel-7B",
+        model_id="id_tt-transformers_TestModel-7B_n150",
+        hf_model_repo="test/TestModel-7B",
+        model_type=ModelType.LLM,
+        device_type=DeviceTypes.N150,
+        supported_modalities=["text"],
+        has_builtin_warmup=False,
+        device_model_spec=SimpleNamespace(
+            tensor_cache_timeout=3600.0,
+            max_context=4096,
+            max_tokens_all_users=4096,
+            max_concurrency=1,
+        ),
+    )
+
+
+def test_run_evals_uses_prompt_client_with_model_spec_tensor_cache_timeout(
+    monkeypatch, tmp_path
+):
+    _FakePromptClient.created_instances.clear()
+    model_spec = _build_model_spec()
+    runtime_config = SimpleNamespace(
+        device="n150",
+        disable_trace_capture=True,
+        service_port="8000",
+    )
+    args = SimpleNamespace(
+        runtime_model_spec_json=str(tmp_path / "runtime.json"),
+        output_path=str(tmp_path),
+        jwt_secret="",
+        hf_token="",
+    )
+
+    monkeypatch.setattr(run_evals_module, "parse_args", lambda: args)
+    monkeypatch.setattr(
+        run_evals_module.ModelSpec, "from_json", lambda _path: model_spec
+    )
+    monkeypatch.setattr(
+        run_evals_module.RuntimeConfig, "from_json", lambda _path: runtime_config
+    )
+    monkeypatch.setattr(run_evals_module, "PromptClient", _FakePromptClient)
+    monkeypatch.setattr(
+        run_evals_module,
+        "EVAL_CONFIGS",
+        {model_spec.model_name: SimpleNamespace(tasks=[])},
+    )
+    monkeypatch.setattr(
+        run_evals_module, "setup_workflow_script_logger", lambda _logger: None
+    )
+
+    assert run_evals_module.main() == 0
+    prompt_client = _FakePromptClient.created_instances[0]
+    assert prompt_client.model_spec is model_spec
+    assert prompt_client.cache_monitor.get_tensor_cache_timeout_calls == 1
+    assert prompt_client.wait_for_healthy_calls == 1
+
+
+def test_run_benchmarks_uses_prompt_client_with_model_spec_tensor_cache_timeout(
+    monkeypatch, tmp_path
+):
+    _FakePromptClient.created_instances.clear()
+    model_spec = _build_model_spec()
+    runtime_config = SimpleNamespace(
+        device="n150",
+        disable_trace_capture=True,
+        service_port="8000",
+        tools=None,
+        concurrency_sweeps=False,
+    )
+    args = SimpleNamespace(
+        runtime_model_spec_json=str(tmp_path / "runtime.json"),
+        output_path=str(tmp_path),
+        jwt_secret="",
+        hf_token="",
+        concurrency_sweeps=False,
+    )
+    benchmark_param = SimpleNamespace(
+        task_type="text",
+        isl=32,
+        osl=4,
+        max_concurrency=1,
+        num_prompts=1,
+    )
+    workflow_venv_type = next(iter(run_benchmarks_module.VENV_CONFIGS))
+    benchmark_task = SimpleNamespace(
+        workflow_venv_type=workflow_venv_type,
+        param_map={DeviceTypes.N150: [benchmark_param]},
+    )
+    benchmark_config = SimpleNamespace(tasks=[benchmark_task])
+
+    monkeypatch.setattr(run_benchmarks_module, "parse_args", lambda: args)
+    monkeypatch.setattr(
+        run_benchmarks_module.ModelSpec, "from_json", lambda _path: model_spec
+    )
+    monkeypatch.setattr(
+        run_benchmarks_module.RuntimeConfig, "from_json", lambda _path: runtime_config
+    )
+    monkeypatch.setattr(run_benchmarks_module, "PromptClient", _FakePromptClient)
+    monkeypatch.setattr(
+        run_benchmarks_module,
+        "BENCHMARK_CONFIGS",
+        {model_spec.model_id: benchmark_config},
+    )
+    monkeypatch.setattr(
+        run_benchmarks_module, "setup_workflow_script_logger", lambda _logger: None
+    )
+    monkeypatch.setattr(run_benchmarks_module, "run_command", lambda **kwargs: 0)
+    monkeypatch.setattr(run_benchmarks_module.time, "sleep", lambda _seconds: None)
+
+    assert run_benchmarks_module.main() == 0
+    prompt_client = _FakePromptClient.created_instances[0]
+    assert prompt_client.model_spec is model_spec
+    assert prompt_client.cache_monitor.get_tensor_cache_timeout_calls == 1
+    assert prompt_client.wait_for_healthy_calls == 1

--- a/tests/test_tensor_cache_timeout_workflows.py
+++ b/tests/test_tensor_cache_timeout_workflows.py
@@ -20,3 +20,43 @@ def test_prompt_client_uses_model_spec_tensor_cache_timeout(tmp_path):
 
     assert prompt_client.cache_monitor.model_spec is model_spec
     assert prompt_client.cache_monitor.get_tensor_cache_timeout() == 3600.0
+
+
+def test_prompt_client_accepts_cache_dir_as_string(tmp_path):
+    prompt_client = PromptClient(
+        EnvironmentConfig(), cache_dir=str(tmp_path / "cache_monitor")
+    )
+
+    assert prompt_client.cache_monitor.cache_dir == tmp_path / "cache_monitor"
+
+
+def test_prompt_client_resolves_host_cache_dir_from_runtime_config(tmp_path):
+    model_spec = SimpleNamespace(
+        impl=SimpleNamespace(impl_id="tt-transformers"),
+        model_name="TestModel",
+        version="1.0.0",
+        device_type=SimpleNamespace(name="N150"),
+        subdevice_type=None,
+        uses_tensor_model_cache=True,
+        device_model_spec=SimpleNamespace(tensor_cache_timeout=3600.0),
+    )
+    runtime_config = SimpleNamespace(
+        host_volume=str(tmp_path / "persistent_volume"),
+        local_server=False,
+        device="n150",
+    )
+
+    prompt_client = PromptClient(
+        EnvironmentConfig(),
+        model_spec=model_spec,
+        runtime_config=runtime_config,
+    )
+
+    assert prompt_client.cache_monitor.cache_dir == (
+        tmp_path
+        / "persistent_volume"
+        / "volume_id_tt-transformers-TestModel-v1.0.0"
+        / "tt_metal_cache"
+        / "cache_TestModel"
+        / "N150"
+    )

--- a/tests/test_tensor_cache_timeout_workflows.py
+++ b/tests/test_tensor_cache_timeout_workflows.py
@@ -5,160 +5,18 @@
 
 from types import SimpleNamespace
 
-import benchmarking.run_benchmarks as run_benchmarks_module
-import evals.run_evals as run_evals_module
-from workflows.workflow_types import DeviceTypes, ModelType
+from utils.prompt_client import PromptClient
+from utils.prompt_configs import EnvironmentConfig
 
 
-class _FakeCacheMonitor:
-    def __init__(self, timeout):
-        self.timeout = timeout
-        self.get_tensor_cache_timeout_calls = 0
-
-    def get_tensor_cache_timeout(self):
-        self.get_tensor_cache_timeout_calls += 1
-        return self.timeout
-
-
-class _FakePromptClient:
-    created_instances = []
-
-    def __init__(self, env_config, model_spec=None):
-        self.env_config = env_config
-        self.model_spec = model_spec
-        self.cache_monitor = _FakeCacheMonitor(
-            model_spec.device_model_spec.tensor_cache_timeout
-        )
-        self.wait_for_healthy_calls = 0
-        self.capture_traces_calls = 0
-        self.get_health_calls = 0
-        self.__class__.created_instances.append(self)
-
-    def wait_for_healthy(self):
-        self.wait_for_healthy_calls += 1
-        return True
-
-    def capture_traces(self, *args, **kwargs):
-        self.capture_traces_calls += 1
-
-    def get_health(self):
-        self.get_health_calls += 1
-        return SimpleNamespace(status_code=200)
-
-
-def _build_model_spec():
-    return SimpleNamespace(
-        model_name="TestModel-7B",
-        model_id="id_tt-transformers_TestModel-7B_n150",
-        hf_model_repo="test/TestModel-7B",
-        model_type=ModelType.LLM,
-        device_type=DeviceTypes.N150,
-        supported_modalities=["text"],
-        has_builtin_warmup=False,
-        device_model_spec=SimpleNamespace(
-            tensor_cache_timeout=3600.0,
-            max_context=4096,
-            max_tokens_all_users=4096,
-            max_concurrency=1,
-        ),
+def test_prompt_client_uses_model_spec_tensor_cache_timeout(tmp_path):
+    model_spec = SimpleNamespace(
+        device_model_spec=SimpleNamespace(tensor_cache_timeout=3600.0)
     )
 
-
-def test_run_evals_uses_prompt_client_with_model_spec_tensor_cache_timeout(
-    monkeypatch, tmp_path
-):
-    _FakePromptClient.created_instances.clear()
-    model_spec = _build_model_spec()
-    runtime_config = SimpleNamespace(
-        device="n150",
-        disable_trace_capture=True,
-        service_port="8000",
-    )
-    args = SimpleNamespace(
-        runtime_model_spec_json=str(tmp_path / "runtime.json"),
-        output_path=str(tmp_path),
-        jwt_secret="",
-        hf_token="",
+    prompt_client = PromptClient(
+        EnvironmentConfig(), model_spec=model_spec, cache_dir=tmp_path
     )
 
-    monkeypatch.setattr(run_evals_module, "parse_args", lambda: args)
-    monkeypatch.setattr(
-        run_evals_module.ModelSpec, "from_json", lambda _path: model_spec
-    )
-    monkeypatch.setattr(
-        run_evals_module.RuntimeConfig, "from_json", lambda _path: runtime_config
-    )
-    monkeypatch.setattr(run_evals_module, "PromptClient", _FakePromptClient)
-    monkeypatch.setattr(
-        run_evals_module,
-        "EVAL_CONFIGS",
-        {model_spec.model_name: SimpleNamespace(tasks=[])},
-    )
-    monkeypatch.setattr(
-        run_evals_module, "setup_workflow_script_logger", lambda _logger: None
-    )
-
-    assert run_evals_module.main() == 0
-    prompt_client = _FakePromptClient.created_instances[0]
-    assert prompt_client.model_spec is model_spec
-    assert prompt_client.cache_monitor.get_tensor_cache_timeout_calls == 1
-    assert prompt_client.wait_for_healthy_calls == 1
-
-
-def test_run_benchmarks_uses_prompt_client_with_model_spec_tensor_cache_timeout(
-    monkeypatch, tmp_path
-):
-    _FakePromptClient.created_instances.clear()
-    model_spec = _build_model_spec()
-    runtime_config = SimpleNamespace(
-        device="n150",
-        disable_trace_capture=True,
-        service_port="8000",
-        tools=None,
-        concurrency_sweeps=False,
-    )
-    args = SimpleNamespace(
-        runtime_model_spec_json=str(tmp_path / "runtime.json"),
-        output_path=str(tmp_path),
-        jwt_secret="",
-        hf_token="",
-        concurrency_sweeps=False,
-    )
-    benchmark_param = SimpleNamespace(
-        task_type="text",
-        isl=32,
-        osl=4,
-        max_concurrency=1,
-        num_prompts=1,
-    )
-    workflow_venv_type = next(iter(run_benchmarks_module.VENV_CONFIGS))
-    benchmark_task = SimpleNamespace(
-        workflow_venv_type=workflow_venv_type,
-        param_map={DeviceTypes.N150: [benchmark_param]},
-    )
-    benchmark_config = SimpleNamespace(tasks=[benchmark_task])
-
-    monkeypatch.setattr(run_benchmarks_module, "parse_args", lambda: args)
-    monkeypatch.setattr(
-        run_benchmarks_module.ModelSpec, "from_json", lambda _path: model_spec
-    )
-    monkeypatch.setattr(
-        run_benchmarks_module.RuntimeConfig, "from_json", lambda _path: runtime_config
-    )
-    monkeypatch.setattr(run_benchmarks_module, "PromptClient", _FakePromptClient)
-    monkeypatch.setattr(
-        run_benchmarks_module,
-        "BENCHMARK_CONFIGS",
-        {model_spec.model_id: benchmark_config},
-    )
-    monkeypatch.setattr(
-        run_benchmarks_module, "setup_workflow_script_logger", lambda _logger: None
-    )
-    monkeypatch.setattr(run_benchmarks_module, "run_command", lambda **kwargs: 0)
-    monkeypatch.setattr(run_benchmarks_module.time, "sleep", lambda _seconds: None)
-
-    assert run_benchmarks_module.main() == 0
-    prompt_client = _FakePromptClient.created_instances[0]
-    assert prompt_client.model_spec is model_spec
-    assert prompt_client.cache_monitor.get_tensor_cache_timeout_calls == 1
-    assert prompt_client.wait_for_healthy_calls == 1
+    assert prompt_client.cache_monitor.model_spec is model_spec
+    assert prompt_client.cache_monitor.get_tensor_cache_timeout() == 3600.0

--- a/utils/cache_monitor.py
+++ b/utils/cache_monitor.py
@@ -257,8 +257,9 @@ class CacheMonitor:
         self, is_generating: bool
     ) -> Tuple[int, int, Optional[float], float, bool]:
         if not is_generating:
+            total_size_bytes, file_count = self._get_tensor_cache_snapshot()
             self._reset_progress_tracking()
-            return 0, 0, None, 0.0, False
+            return total_size_bytes, file_count, None, 0.0, False
 
         current_time = time.time()
         total_size_bytes, file_count = self._get_tensor_cache_snapshot()

--- a/utils/cache_monitor.py
+++ b/utils/cache_monitor.py
@@ -2,18 +2,414 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import time
+"""Host-side tensor cache monitoring used by benchmark and eval startup waits.
+
+`PromptClient.wait_for_healthy()` uses this module to decide whether startup is
+still generating tensor cache, whether cache files are growing, and whether
+generation appears stalled.
+
+Cache location resolution order:
+1. Use the explicit `cache_dir` argument when provided.
+2. Otherwise use the host `TT_CACHE_PATH` environment variable when set.
+3. Otherwise derive a persistent cache target from `model_spec` and
+   `runtime_config` using the cache suffix
+   `tt_metal_cache/cache_<model_name>/<mesh_device>`:
+   - `host_volume`: monitor
+     `<host_volume>/volume_id_<impl>-<model>-v<version>/<cache suffix>`
+   - `local_server` without `host_volume`: monitor the repo default
+     `<repo_root>/persistent_volume/...`
+   - Docker named volume mode: inspect `volume_id_<impl>-<model>`. If the
+     mountpoint is readable by the current host user, monitor the resolved host
+     path directly. If the volume exists but the mountpoint is not readable,
+     fall back to Docker CLI and inspect the same cache subtree through a
+     read-only helper container mounted at `/cache`.
+4. If none of the above can be resolved, monitoring is disabled.
+
+Permissions:
+- Direct-path modes require the host process to read the cache directory. When
+  marker files are writable, explicit lifecycle methods can create
+  `TT_METAL_CACHE_FIRST_RUN_STARTED` and `TT_METAL_CACHE_COMPLETED` in the
+  cache directory.
+- Docker CLI fallback is used specifically when the named volume exists but the
+  host user cannot read its mountpoint directly. It does not change host
+  permissions or write real marker files into the volume. Instead it reads file
+  count and total size via `docker run` and keeps in-memory started/completed
+  marker state for the lifetime of the host-side process.
+"""
+
 import logging
-from pathlib import Path
-from typing import Optional, Tuple
+import os
+import json
+import subprocess
+import time
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple, Union
+
+from utils.device_utils import get_mesh_device_name
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_CACHE_ROOT = Path("/home/container_app_user/cache_root")
+DEFAULT_DOCKER_CACHE_MONITOR_ROOT = Path("/cache")
+DEFAULT_DOCKER_CACHE_MONITOR_HELPER_IMAGE = "python:3.8-slim"
+
+DOCKER_VOLUME_SNAPSHOT_SCRIPT = """
+import json
+import sys
+from pathlib import Path
+
+target = Path("/cache") / sys.argv[1]
+marker_files = set(sys.argv[2:])
+total_size_bytes = 0
+file_count = 0
+
+if target.exists():
+    for cache_file in target.rglob("*"):
+        if not cache_file.is_file() or cache_file.name in marker_files:
+            continue
+        try:
+            total_size_bytes += cache_file.stat().st_size
+            file_count += 1
+        except OSError:
+            continue
+
+print(
+    json.dumps(
+        {
+            "file_count": file_count,
+            "total_size_bytes": total_size_bytes,
+        }
+    )
+)
+""".strip()
+
+
+def _get_value(obj, key: str, default=None):
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _normalize_optional_path(path_value: Optional[Union[str, Path]]) -> Optional[Path]:
+    if path_value is None:
+        return None
+    return Path(path_value).expanduser()
+
+
+def _resolve_repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def get_default_persistent_volume_root(repo_root: Optional[Path] = None) -> Path:
+    root = repo_root or _resolve_repo_root()
+    return Path(root).resolve() / "persistent_volume"
+
+
+def get_docker_volume_name(model_spec) -> Optional[str]:
+    impl = _get_value(model_spec, "impl")
+    impl_id = _get_value(impl, "impl_id")
+    model_name = _get_value(model_spec, "model_name")
+    if not impl_id or not model_name:
+        return None
+    return f"volume_id_{impl_id}-{model_name}"
+
+
+def get_host_model_volume_root(
+    model_spec, host_volume: Optional[Union[str, Path]]
+) -> Optional[Path]:
+    host_volume_path = _normalize_optional_path(host_volume)
+    impl = _get_value(model_spec, "impl")
+    impl_id = _get_value(impl, "impl_id")
+    model_name = _get_value(model_spec, "model_name")
+    version = _get_value(model_spec, "version")
+    if (
+        host_volume_path is None
+        or not impl_id
+        or not model_name
+        or version in (None, "")
+    ):
+        return None
+
+    volume_dir_name = f"volume_id_{impl_id}-{model_name}-v{version}"
+    return host_volume_path.resolve() / volume_dir_name
+
+
+@dataclass(frozen=True)
+class DockerVolumeInfo:
+    volume_name: str
+    mountpoint: Path
+    is_readable: bool
+
+
+@dataclass(frozen=True)
+class CacheMonitorTarget:
+    cache_dir: Optional[Path] = None
+    docker_volume_name: Optional[str] = None
+    docker_cache_dir: Optional[Path] = None
+    docker_helper_image: Optional[str] = None
+
+    def is_enabled(self) -> bool:
+        return self.cache_dir is not None or self.uses_docker_cli()
+
+    def uses_docker_cli(self) -> bool:
+        return (
+            self.cache_dir is None
+            and self.docker_volume_name is not None
+            and self.docker_cache_dir is not None
+        )
+
+    def get_display_cache_dir(self) -> Optional[Path]:
+        return self.cache_dir or self.docker_cache_dir
+
+
+def get_cache_relative_dir(
+    model_spec, runtime_config=None, device: Optional[str] = None
+) -> Optional[Path]:
+    model_name = _get_value(model_spec, "model_name")
+    if not model_name:
+        return None
+    if device is None and runtime_config is not None:
+        device = _get_value(runtime_config, "device")
+    return (
+        Path("tt_metal_cache")
+        / f"cache_{model_name}"
+        / get_mesh_device_name(model_spec, device=device)
+    )
+
+
+def inspect_docker_volume(volume_name: str) -> Optional[DockerVolumeInfo]:
+    try:
+        result = subprocess.run(
+            [
+                "docker",
+                "volume",
+                "inspect",
+                volume_name,
+                "--format",
+                "{{ .Mountpoint }}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except FileNotFoundError:
+        logger.info(
+            "Docker CLI is unavailable; host-side cache monitoring is disabled for volume %s.",
+            volume_name,
+        )
+        return None
+    except subprocess.TimeoutExpired:
+        logger.info(
+            "Timed out inspecting Docker volume %s; host-side cache monitoring is disabled.",
+            volume_name,
+        )
+        return None
+    except Exception as exc:
+        logger.warning(
+            "Could not inspect Docker volume %s for cache monitoring: %s",
+            volume_name,
+            exc,
+        )
+        return None
+
+    if result.returncode != 0:
+        reason = str(getattr(result, "stderr", "") or "").strip()
+        reason = reason or "volume not found or daemon unavailable"
+        logger.info(
+            "Could not inspect Docker volume %s for cache monitoring: %s",
+            volume_name,
+            reason,
+        )
+        return None
+
+    mountpoint_str = str(getattr(result, "stdout", "") or "").strip()
+    if not mountpoint_str:
+        logger.info(
+            "Docker volume %s did not report a mountpoint; cache monitoring is disabled.",
+            volume_name,
+        )
+        return None
+
+    mountpoint = Path(mountpoint_str)
+    if not mountpoint.exists():
+        logger.info(
+            "Docker volume %s mountpoint is not accessible on this host: %s",
+            volume_name,
+            mountpoint,
+        )
+        return None
+    if not mountpoint.is_dir():
+        logger.info(
+            "Docker volume %s mountpoint is not a directory: %s",
+            volume_name,
+            mountpoint,
+        )
+        return None
+
+    resolved_mountpoint = mountpoint.resolve()
+    is_readable = os.access(resolved_mountpoint, os.R_OK | os.X_OK)
+    if not is_readable:
+        logger.info(
+            "Docker volume %s mountpoint is not readable by the current user: %s",
+            volume_name,
+            resolved_mountpoint,
+        )
+
+    return DockerVolumeInfo(
+        volume_name=volume_name,
+        mountpoint=resolved_mountpoint,
+        is_readable=is_readable,
+    )
+
+
+def inspect_docker_volume_mountpoint(volume_name: str) -> Optional[Path]:
+    volume_info = inspect_docker_volume(volume_name)
+    if volume_info is None or not volume_info.is_readable:
+        return None
+    return volume_info.mountpoint
+
+
+def get_environment_cache_dir() -> Optional[Path]:
+    return _normalize_optional_path(os.getenv("TT_CACHE_PATH"))
+
+
+def get_container_cache_dir(
+    model_spec,
+    device: Optional[str] = None,
+    cache_root: Optional[Union[str, Path]] = None,
+) -> Optional[Path]:
+    cache_root_path = _normalize_optional_path(
+        cache_root or os.getenv("CACHE_ROOT") or DEFAULT_CACHE_ROOT
+    )
+    cache_relative_dir = get_cache_relative_dir(model_spec, device=device)
+    if cache_relative_dir is None:
+        return None
+    return cache_root_path / cache_relative_dir
+
+
+def get_host_cache_monitor_root(
+    model_spec, runtime_config=None, repo_root: Optional[Path] = None
+) -> Optional[Path]:
+    host_volume = _normalize_optional_path(_get_value(runtime_config, "host_volume"))
+    is_local_server = bool(_get_value(runtime_config, "local_server", False))
+
+    if is_local_server and host_volume is None:
+        host_volume = get_default_persistent_volume_root(repo_root=repo_root)
+
+    host_model_volume_root = get_host_model_volume_root(model_spec, host_volume)
+    if host_model_volume_root is not None:
+        return host_model_volume_root
+
+    if is_local_server:
+        return None
+
+    docker_volume_name = get_docker_volume_name(model_spec)
+    if docker_volume_name is None:
+        return None
+    return inspect_docker_volume_mountpoint(docker_volume_name)
+
+
+def _get_host_cache_monitor_target(
+    model_spec, runtime_config=None, repo_root: Optional[Path] = None
+) -> CacheMonitorTarget:
+    cache_relative_dir = get_cache_relative_dir(
+        model_spec, runtime_config=runtime_config
+    )
+    if cache_relative_dir is None:
+        return CacheMonitorTarget()
+
+    host_volume = _normalize_optional_path(_get_value(runtime_config, "host_volume"))
+    is_local_server = bool(_get_value(runtime_config, "local_server", False))
+
+    if is_local_server and host_volume is None:
+        host_volume = get_default_persistent_volume_root(repo_root=repo_root)
+
+    host_model_volume_root = get_host_model_volume_root(model_spec, host_volume)
+    if host_model_volume_root is not None:
+        return CacheMonitorTarget(cache_dir=host_model_volume_root / cache_relative_dir)
+
+    if is_local_server:
+        return CacheMonitorTarget()
+
+    docker_volume_name = get_docker_volume_name(model_spec)
+    if docker_volume_name is None:
+        return CacheMonitorTarget()
+
+    volume_info = inspect_docker_volume(docker_volume_name)
+    if volume_info is None:
+        return CacheMonitorTarget()
+    if volume_info.is_readable:
+        return CacheMonitorTarget(cache_dir=volume_info.mountpoint / cache_relative_dir)
+
+    docker_cache_dir = DEFAULT_DOCKER_CACHE_MONITOR_ROOT / cache_relative_dir
+    docker_helper_image = (
+        _get_value(model_spec, "docker_image")
+        or os.getenv("CACHE_MONITOR_DOCKER_HELPER_IMAGE")
+        or DEFAULT_DOCKER_CACHE_MONITOR_HELPER_IMAGE
+    )
+    logger.info(
+        "Using Docker CLI fallback to monitor unreadable volume %s at %s",
+        docker_volume_name,
+        docker_cache_dir,
+    )
+    return CacheMonitorTarget(
+        docker_volume_name=docker_volume_name,
+        docker_cache_dir=docker_cache_dir,
+        docker_helper_image=docker_helper_image,
+    )
+
+
+def resolve_host_cache_monitor_dir(
+    model_spec, runtime_config=None, repo_root: Optional[Path] = None
+) -> Optional[Path]:
+    return _get_host_cache_monitor_target(
+        model_spec, runtime_config=runtime_config, repo_root=repo_root
+    ).cache_dir
+
+
+def detect_cache_monitor_target(
+    model_spec=None,
+    cache_dir: Optional[Union[str, Path]] = None,
+    runtime_config=None,
+    repo_root: Optional[Path] = None,
+) -> CacheMonitorTarget:
+    normalized_cache_dir = _normalize_optional_path(cache_dir)
+    if normalized_cache_dir is not None:
+        return CacheMonitorTarget(cache_dir=normalized_cache_dir)
+
+    environment_cache_dir = get_environment_cache_dir()
+    if environment_cache_dir is not None:
+        return CacheMonitorTarget(cache_dir=environment_cache_dir)
+
+    if model_spec is None:
+        return CacheMonitorTarget()
+
+    return _get_host_cache_monitor_target(
+        model_spec, runtime_config=runtime_config, repo_root=repo_root
+    )
+
+
+def detect_cache_monitor_dir(
+    model_spec=None,
+    cache_dir: Optional[Union[str, Path]] = None,
+    runtime_config=None,
+    repo_root: Optional[Path] = None,
+) -> Optional[Path]:
+    return detect_cache_monitor_target(
+        model_spec=model_spec,
+        cache_dir=cache_dir,
+        runtime_config=runtime_config,
+        repo_root=repo_root,
+    ).cache_dir
 
 
 @dataclass
 class CacheGenerationStatus:
-    """Status of cache generation process"""
+    """Status of cache generation process."""
 
     is_generating: bool
     cache_dir: Optional[Path] = None
@@ -21,57 +417,163 @@ class CacheGenerationStatus:
     last_activity_time: Optional[float] = None
     estimated_completion_time: Optional[float] = None
     is_first_run: bool = False
+    has_existing_cache: bool = False
     is_stalled: bool = False
     file_count: int = 0
     total_size_bytes: int = 0
     no_progress_duration: float = 0.0
 
 
+@dataclass(frozen=True)
+class _CacheMarkerStatus:
+    is_first_run: bool = False
+    is_generating: bool = False
+    is_completed: bool = False
+    has_existing_cache: bool = False
+
+
+@dataclass(frozen=True)
+class _CacheSnapshot:
+    total_size_bytes: int = 0
+    file_count: int = 0
+
+    def has_content(self) -> bool:
+        return self.file_count > 0
+
+
+@dataclass(frozen=True)
+class _CacheProgressStatus:
+    last_activity_time: Optional[float] = None
+    no_progress_duration: float = 0.0
+    is_stalled: bool = False
+
+
+@dataclass
+class _DockerMarkerState:
+    started: bool = False
+    completed: bool = False
+
+
+class _CacheProgressTracker:
+    def __init__(self, stall_timeout: float):
+        self._stall_timeout = stall_timeout
+        self.reset()
+
+    def reset(self):
+        self._last_snapshot: Optional[_CacheSnapshot] = None
+        self._last_activity_time: Optional[float] = None
+        self._has_seen_content = False
+
+    def update(
+        self, snapshot: _CacheSnapshot, is_generating: bool
+    ) -> _CacheProgressStatus:
+        if not is_generating:
+            self.reset()
+            return _CacheProgressStatus()
+
+        current_time = time.time()
+        snapshot_changed = snapshot != self._last_snapshot
+        if snapshot_changed:
+            self._last_snapshot = snapshot
+            if snapshot.has_content() or self._has_seen_content:
+                self._last_activity_time = current_time
+            if snapshot.has_content():
+                self._has_seen_content = True
+            return _CacheProgressStatus(last_activity_time=self._last_activity_time)
+
+        if not self._has_seen_content or self._last_activity_time is None:
+            return _CacheProgressStatus(last_activity_time=self._last_activity_time)
+
+        no_progress_duration = current_time - self._last_activity_time
+        return _CacheProgressStatus(
+            last_activity_time=self._last_activity_time,
+            no_progress_duration=no_progress_duration,
+            is_stalled=no_progress_duration >= self._stall_timeout,
+        )
+
+
 class CacheMonitor:
-    """Monitor TT_METAL_CACHE generation progress using file markers on host filesystem"""
+    """Monitor TT_METAL_CACHE generation progress using file markers."""
 
     TT_METAL_CACHE_FIRST_RUN_STARTED = "TT_METAL_CACHE_FIRST_RUN_STARTED"
     TT_METAL_CACHE_COMPLETED = "TT_METAL_CACHE_COMPLETED"
     DEFAULT_TENSOR_CACHE_TIMEOUT = 1200.0
-    TENSOR_CACHE_NO_CHANGE_TIMEOUT = 180
+    TENSOR_CACHE_NO_CHANGE_TIMEOUT = 300
 
-    def __init__(self, model_spec=None, cache_dir: Optional[Path] = None):
+    def __init__(
+        self,
+        model_spec=None,
+        cache_dir: Optional[Union[str, Path]] = None,
+        runtime_config=None,
+    ):
         self.model_spec = model_spec
+        self.runtime_config = runtime_config
         self.tensor_cache_timeout = self._get_tensor_cache_timeout(model_spec)
-        self._last_progress_time: Optional[float] = None
-        self._last_cache_size_bytes: Optional[int] = None
-        self._last_cache_file_count: Optional[int] = None
+        self.cache_target = CacheMonitorTarget()
+        self._docker_markers = _DockerMarkerState()
+        self._progress_tracker = _CacheProgressTracker(
+            self.TENSOR_CACHE_NO_CHANGE_TIMEOUT
+        )
+        self._saw_empty_cache_without_markers = False
+        self._inferred_generation_without_markers = False
 
-        if cache_dir is not None:
-            self.cache_dir = cache_dir
-        elif model_spec is not None and self._uses_tensor_model_cache(model_spec):
-            self.cache_dir = self._detect_cache_directory(model_spec)
-        elif model_spec is not None and not self._uses_tensor_model_cache(model_spec):
+        if model_spec is not None and not self._uses_tensor_model_cache(model_spec):
             logger.info(
-                f"🔍 Model {getattr(model_spec, 'model_name', 'unknown')} does not use tensor cache - cache monitoring disabled"
+                "🔍 Model %s does not use tensor cache - cache monitoring disabled",
+                _get_value(model_spec, "model_name", "unknown"),
             )
             self.cache_dir = None
-        else:
-            self.cache_dir = cache_dir
+            return
+
+        self.cache_target = detect_cache_monitor_target(
+            model_spec=model_spec,
+            cache_dir=cache_dir,
+            runtime_config=runtime_config,
+        )
+        self.cache_dir = self.cache_target.get_display_cache_dir()
 
     def _uses_tensor_model_cache(self, model_spec) -> bool:
         return bool(
-            getattr(
+            _get_value(
                 model_spec,
                 "uses_tensor_model_cache",
-                getattr(model_spec, "uses_model_cache", True),
+                _get_value(model_spec, "uses_model_cache", True),
             )
         )
+
+    @classmethod
+    def _coerce_tensor_cache_timeout(cls, timeout_value) -> float:
+        try:
+            timeout = float(timeout_value)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid tensor_cache_timeout=%r; using default timeout=%ss",
+                timeout_value,
+                cls.DEFAULT_TENSOR_CACHE_TIMEOUT,
+            )
+            return cls.DEFAULT_TENSOR_CACHE_TIMEOUT
+
+        if timeout <= 0:
+            logger.warning(
+                "Non-positive tensor_cache_timeout=%r; using default timeout=%ss",
+                timeout_value,
+                cls.DEFAULT_TENSOR_CACHE_TIMEOUT,
+            )
+            return cls.DEFAULT_TENSOR_CACHE_TIMEOUT
+
+        return timeout
 
     def _get_tensor_cache_timeout(self, model_spec) -> float:
         if model_spec is None:
             return self.DEFAULT_TENSOR_CACHE_TIMEOUT
 
-        device_model_spec = getattr(model_spec, "device_model_spec", None)
-        timeout = getattr(
-            device_model_spec, "tensor_cache_timeout", self.DEFAULT_TENSOR_CACHE_TIMEOUT
+        device_model_spec = _get_value(model_spec, "device_model_spec")
+        timeout_value = _get_value(
+            device_model_spec,
+            "tensor_cache_timeout",
+            self.DEFAULT_TENSOR_CACHE_TIMEOUT,
         )
-        return float(timeout)
+        return self._coerce_tensor_cache_timeout(timeout_value)
 
     def get_tensor_cache_timeout(self) -> float:
         return self.tensor_cache_timeout
@@ -84,145 +586,132 @@ class CacheMonitor:
         if cache_status is None:
             cache_status = self.get_cache_generation_status()
 
-        if cache_status.is_generating:
+        if cache_status.is_generating or cache_status.is_first_run:
             return self.get_tensor_cache_timeout()
 
         return float(default_timeout)
 
-    def _detect_cache_directory(self, model_spec):
-        """
-        Detect cache directory for cache monitoring.
-        Uses the correct persistent volume structure with device-specific paths.
+    def _is_monitoring_enabled(self) -> bool:
+        return self.cache_target.is_enabled()
 
-        Returns:
-            Optional[Path]: cache_dir
-        """
-        cache_dir = None
+    def _supports_local_marker_files(self) -> bool:
+        return self.cache_target.cache_dir is not None
 
-        try:
-            # Import here to avoid circular imports
-            from workflows.setup_host import SetupConfig
-            from workflows.workflow_types import DeviceTypes
+    def _uses_docker_cli_fallback(self) -> bool:
+        return self.cache_target.uses_docker_cli()
 
-            # Try to create a SetupConfig to get cache directory info
-            setup_config = SetupConfig(model_spec=model_spec)
+    def _reset_observed_first_run(self):
+        self._saw_empty_cache_without_markers = False
+        self._inferred_generation_without_markers = False
 
-            device_str = model_spec.device_type.name.lower()
-            device = DeviceTypes.from_string(device_str)
-            mesh_device_str = device.to_mesh_device_str()
-            device_cache_str = (
-                DeviceTypes.to_mesh_device_str(model_spec.subdevice_type)
-                if model_spec.subdevice_type
-                else mesh_device_str
-            )
-
-            # Build the full cache path: .../tt_metal_cache/cache_{model_name}/{device_str}
-            base_cache_dir = setup_config.host_tt_metal_cache_dir
-            cache_dir = base_cache_dir / device_cache_str
-
-            logger.info(f"Detected cache directory: {cache_dir}")
-            logger.info(f"Device cache string: {device_cache_str}")
-
-        except Exception as e:
-            logger.warning(f"Could not detect cache directory from SetupConfig: {e}")
-
-        return cache_dir
+    @staticmethod
+    def _build_marker_status(
+        started_exists: bool, completed_exists: bool
+    ) -> _CacheMarkerStatus:
+        if completed_exists:
+            return _CacheMarkerStatus(is_completed=True, has_existing_cache=True)
+        if started_exists:
+            return _CacheMarkerStatus(is_generating=True)
+        return _CacheMarkerStatus(is_first_run=True)
 
     def get_cache_marker_files(self) -> Tuple[Optional[Path], Optional[Path]]:
-        """Get paths to cache marker files"""
-        if not self.cache_dir:
+        """Get paths to cache marker files."""
+        if not self._supports_local_marker_files():
             return None, None
 
-        started_file = self.cache_dir / self.TT_METAL_CACHE_FIRST_RUN_STARTED
-        completed_file = self.cache_dir / self.TT_METAL_CACHE_COMPLETED
-
+        started_file = (
+            self.cache_target.cache_dir / self.TT_METAL_CACHE_FIRST_RUN_STARTED
+        )
+        completed_file = self.cache_target.cache_dir / self.TT_METAL_CACHE_COMPLETED
         return started_file, completed_file
 
-    def mark_cache_first_run_started(self) -> bool:
-        """Create CACHE_FIRST_RUN_STARTED marker file"""
-        started_file, _ = self.get_cache_marker_files()
-        if not started_file:
-            logger.warning(
-                "Cannot create cache first run marker: no cache directory configured"
-            )
+    def _write_marker_file(self, marker_path: Path, message: str) -> bool:
+        try:
+            logger.info("Creating cache directory: %s", marker_path.parent)
+            marker_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(marker_path, "w") as marker_file:
+                marker_file.write(f"{message} at: {time.time()}\n")
+                marker_file.write(f"Timestamp: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+            logger.info("Created cache marker: %s", marker_path)
+            return True
+        except (OSError, PermissionError) as error:
+            logger.warning("Failed to create cache marker %s: %s", marker_path, error)
             return False
 
-        try:
-            # Ensure cache directory exists
-            logger.info(f"Creating cache directory: {started_file.parent}")
-            started_file.parent.mkdir(parents=True, exist_ok=True)
+    def mark_cache_first_run_started(self) -> bool:
+        """Create CACHE_FIRST_RUN_STARTED marker file."""
+        started_file, _ = self.get_cache_marker_files()
+        if started_file is None:
+            if not self._uses_docker_cli_fallback():
+                logger.warning(
+                    "Cannot create cache first run marker: no cache directory configured"
+                )
+                return False
 
-            # Create marker file with timestamp
-            with open(started_file, "w") as f:
-                f.write(f"Cache first run started at: {time.time()}\n")
-                f.write(f"Timestamp: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
-
-            logger.info(f"✅ Created cache first run marker: {started_file}")
+            self._docker_markers.started = True
+            self._docker_markers.completed = False
+            self._reset_observed_first_run()
             return True
 
-        except (OSError, PermissionError) as e:
-            logger.error(f"❌ Failed to create cache first run marker: {e}")
-            logger.error(f"   Cache directory: {started_file.parent}")
-            logger.error(f"   Marker file: {started_file}")
-            return False
+        return self._write_marker_file(started_file, "Cache first run started")
 
     def mark_cache_completed(self) -> bool:
-        """Create CACHE_COMPLETED marker file"""
+        """Create CACHE_COMPLETED marker file."""
         _, completed_file = self.get_cache_marker_files()
-        if not completed_file:
+        if completed_file is None:
+            if self._uses_docker_cli_fallback():
+                self._docker_markers.completed = True
+                self._docker_markers.started = False
+                self._progress_tracker.reset()
+                self._reset_observed_first_run()
+                return True
             return False
 
-        try:
-            # Ensure cache directory exists
-            completed_file.parent.mkdir(parents=True, exist_ok=True)
+        success = self._write_marker_file(completed_file, "Cache completed")
+        if success:
+            self._progress_tracker.reset()
+            self._reset_observed_first_run()
+        return success
 
-            # Create marker file with timestamp
-            with open(completed_file, "w") as f:
-                f.write(f"Cache completed at: {time.time()}\n")
-                f.write(f"Timestamp: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+    def _read_marker_status(self) -> _CacheMarkerStatus:
+        started_file, completed_file = self.get_cache_marker_files()
+        if started_file is not None and completed_file is not None:
+            started_exists = started_file.exists()
+            completed_exists = completed_file.exists()
+            logger.debug(
+                "Cache marker status: started_exists=%s, completed_exists=%s",
+                started_exists,
+                completed_exists,
+            )
+            logger.debug("Started file: %s", started_file)
+            logger.debug("Completed file: %s", completed_file)
+            return self._build_marker_status(started_exists, completed_exists)
 
-            logger.info(f"Created cache completed marker: {completed_file}")
-            return True
+        if self._uses_docker_cli_fallback():
+            return self._build_marker_status(
+                self._docker_markers.started,
+                self._docker_markers.completed,
+            )
 
-        except (OSError, PermissionError) as e:
-            logger.warning(f"Failed to create cache completed marker: {e}")
-            return False
+        logger.debug("No cache marker files configured")
+        return _CacheMarkerStatus()
 
     def check_cache_status_from_markers(self) -> Tuple[bool, bool, bool]:
         """
-        Check cache status from marker files
+        Check cache status from marker files.
 
         Returns:
             Tuple[bool, bool, bool]: (is_first_run, is_generating, is_completed)
         """
-        started_file, completed_file = self.get_cache_marker_files()
-
-        if not started_file or not completed_file:
-            logger.debug("No cache marker files configured")
-            return False, False, False
-
-        started_exists = started_file.exists()
-        completed_exists = completed_file.exists()
-
-        logger.debug(
-            f"Cache marker status: started_exists={started_exists}, completed_exists={completed_exists}"
+        marker_status = self._read_marker_status()
+        return (
+            marker_status.is_first_run,
+            marker_status.is_generating,
+            marker_status.is_completed,
         )
-        logger.debug(f"Started file: {started_file}")
-        logger.debug(f"Completed file: {completed_file}")
 
-        # Markers have strict precedence:
-        # completed -> done
-        # started without completed -> generation in progress
-        # no markers -> determine first-run using cache content
-        if completed_exists:
-            return False, False, True
-        if started_exists:
-            return False, True, False
-
-        return True, False, False
-
-    def _get_tensor_cache_snapshot(self) -> Tuple[int, int]:
-        if not self.cache_dir or not self.cache_dir.exists():
+    def _get_path_cache_snapshot(self, cache_dir: Path) -> Tuple[int, int]:
+        if not cache_dir.exists():
             return 0, 0
 
         total_size_bytes = 0
@@ -233,77 +722,198 @@ class CacheMonitor:
         }
 
         try:
-            for cache_file in self.cache_dir.rglob("*"):
+            for cache_file in cache_dir.rglob("*"):
                 if not cache_file.is_file() or cache_file.name in marker_files:
                     continue
-
                 try:
                     total_size_bytes += cache_file.stat().st_size
                     file_count += 1
                 except (OSError, PermissionError):
-                    logger.debug(f"Skipping unreadable cache file: {cache_file}")
-        except (OSError, PermissionError) as e:
-            logger.warning(f"Failed to inspect cache directory content: {e}")
+                    logger.debug("Skipping unreadable cache file: %s", cache_file)
+        except (OSError, PermissionError) as error:
+            logger.warning("Failed to inspect cache directory content: %s", error)
             return 0, 0
 
         return total_size_bytes, file_count
 
-    def _reset_progress_tracking(self):
-        self._last_progress_time = None
-        self._last_cache_size_bytes = None
-        self._last_cache_file_count = None
+    def _get_docker_cache_snapshot(self) -> Tuple[int, int]:
+        docker_volume_name = self.cache_target.docker_volume_name
+        docker_cache_dir = self.cache_target.docker_cache_dir
+        helper_image = self.cache_target.docker_helper_image
+        if not docker_volume_name or not docker_cache_dir or not helper_image:
+            return 0, 0
 
-    def _get_progress_state(
-        self, is_generating: bool
-    ) -> Tuple[int, int, Optional[float], float, bool]:
-        if not is_generating:
-            total_size_bytes, file_count = self._get_tensor_cache_snapshot()
-            self._reset_progress_tracking()
-            return total_size_bytes, file_count, None, 0.0, False
+        try:
+            relative_cache_dir = docker_cache_dir.relative_to(
+                DEFAULT_DOCKER_CACHE_MONITOR_ROOT
+            )
+        except ValueError:
+            logger.warning(
+                "Invalid Docker cache directory for cache monitoring: %s",
+                docker_cache_dir,
+            )
+            return 0, 0
 
-        current_time = time.time()
-        total_size_bytes, file_count = self._get_tensor_cache_snapshot()
-        cache_changed = (
-            self._last_cache_size_bytes is None
-            or self._last_cache_file_count is None
-            or total_size_bytes != self._last_cache_size_bytes
-            or file_count != self._last_cache_file_count
-        )
+        command = [
+            "docker",
+            "run",
+            "--rm",
+            "--user",
+            "0:0",
+            "--volume",
+            f"{docker_volume_name}:{DEFAULT_DOCKER_CACHE_MONITOR_ROOT}:ro",
+            "--entrypoint",
+            "python3",
+            helper_image,
+            "-c",
+            DOCKER_VOLUME_SNAPSHOT_SCRIPT,
+            relative_cache_dir.as_posix(),
+            self.TT_METAL_CACHE_FIRST_RUN_STARTED,
+            self.TT_METAL_CACHE_COMPLETED,
+        ]
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        except FileNotFoundError:
+            logger.info(
+                "Docker CLI is unavailable; Docker cache fallback is disabled for volume %s.",
+                docker_volume_name,
+            )
+            return 0, 0
+        except subprocess.TimeoutExpired:
+            logger.info(
+                "Timed out collecting Docker cache snapshot for volume %s.",
+                docker_volume_name,
+            )
+            return 0, 0
+        except Exception as exc:
+            logger.warning(
+                "Could not collect Docker cache snapshot for volume %s: %s",
+                docker_volume_name,
+                exc,
+            )
+            return 0, 0
 
-        if cache_changed:
-            self._last_cache_size_bytes = total_size_bytes
-            self._last_cache_file_count = file_count
-            self._last_progress_time = current_time
-            return total_size_bytes, file_count, self._last_progress_time, 0.0, False
+        if result.returncode != 0:
+            reason = str(getattr(result, "stderr", "") or "").strip()
+            reason = reason or "docker run failed"
+            logger.info(
+                "Docker cache snapshot command failed for volume %s: %s",
+                docker_volume_name,
+                reason,
+            )
+            return 0, 0
 
-        no_progress_duration = current_time - self._last_progress_time
-        is_stalled = no_progress_duration >= self.TENSOR_CACHE_NO_CHANGE_TIMEOUT
+        output = str(getattr(result, "stdout", "") or "").strip()
+        if not output:
+            return 0, 0
+
+        try:
+            snapshot = json.loads(output)
+        except json.JSONDecodeError:
+            logger.warning(
+                "Could not parse Docker cache snapshot output for volume %s: %s",
+                docker_volume_name,
+                output,
+            )
+            return 0, 0
+
         return (
-            total_size_bytes,
-            file_count,
-            self._last_progress_time,
-            no_progress_duration,
-            is_stalled,
+            int(snapshot.get("total_size_bytes", 0)),
+            int(snapshot.get("file_count", 0)),
         )
+
+    def _read_cache_snapshot(self) -> _CacheSnapshot:
+        total_size_bytes, file_count = self._get_tensor_cache_snapshot()
+        return _CacheSnapshot(
+            total_size_bytes=total_size_bytes,
+            file_count=file_count,
+        )
+
+    def _get_tensor_cache_snapshot(self) -> Tuple[int, int]:
+        if self.cache_target.cache_dir is not None:
+            return self._get_path_cache_snapshot(self.cache_target.cache_dir)
+        if self._uses_docker_cli_fallback():
+            return self._get_docker_cache_snapshot()
+        return 0, 0
+
+    def _infer_unmarked_cache_status(
+        self, snapshot: _CacheSnapshot
+    ) -> _CacheMarkerStatus:
+        # Distinguish an existing cache from a cold start without writing markers.
+        if snapshot.has_content():
+            if (
+                self._saw_empty_cache_without_markers
+                or self._inferred_generation_without_markers
+            ):
+                self._inferred_generation_without_markers = True
+                return _CacheMarkerStatus(is_generating=True)
+
+            self._reset_observed_first_run()
+            return _CacheMarkerStatus(has_existing_cache=True)
+
+        self._saw_empty_cache_without_markers = True
+        self._inferred_generation_without_markers = False
+        return _CacheMarkerStatus(is_first_run=True)
+
+    def _resolve_cache_lifecycle(
+        self, marker_status: _CacheMarkerStatus, snapshot: _CacheSnapshot
+    ) -> _CacheMarkerStatus:
+        if marker_status.is_completed:
+            self._reset_observed_first_run()
+            return marker_status
+
+        if marker_status.is_generating:
+            return marker_status
+
+        return self._infer_unmarked_cache_status(snapshot)
+
+    def _build_generation_status(
+        self,
+        marker_status: _CacheMarkerStatus,
+        snapshot: _CacheSnapshot,
+        progress_status: _CacheProgressStatus,
+    ) -> CacheGenerationStatus:
+        status = CacheGenerationStatus(
+            is_generating=marker_status.is_generating,
+            cache_dir=self.cache_dir,
+            container_id=None,
+            last_activity_time=progress_status.last_activity_time,
+            estimated_completion_time=None,
+            is_first_run=marker_status.is_first_run,
+            has_existing_cache=marker_status.has_existing_cache,
+            is_stalled=progress_status.is_stalled,
+            file_count=snapshot.file_count,
+            total_size_bytes=snapshot.total_size_bytes,
+            no_progress_duration=progress_status.no_progress_duration,
+        )
+        status.estimated_completion_time = self.estimate_cache_completion_time(status)
+        return status
 
     def check_cache_directory_has_content(self) -> bool:
-        """Check if cache directory has actual cache content (not just empty directories)"""
-        if not self.cache_dir or not self.cache_dir.exists():
+        """Check if cache directory has actual cache content."""
+        if not self._is_monitoring_enabled():
             return False
 
         try:
-            _, file_count = self._get_tensor_cache_snapshot()
-            logger.debug(f"Found {file_count} cache files in {self.cache_dir}")
-            return file_count > 0
-        except (OSError, PermissionError) as e:
-            logger.warning(f"Failed to check cache directory content: {e}")
+            snapshot = self._read_cache_snapshot()
+            logger.debug(
+                "Found %s cache files in %s", snapshot.file_count, self.cache_dir
+            )
+            return snapshot.has_content()
+        except (OSError, PermissionError) as error:
+            logger.warning("Failed to check cache directory content: %s", error)
             return False
 
     def get_cache_generation_status(self) -> CacheGenerationStatus:
-        """Get comprehensive cache generation status using file markers"""
+        """Get comprehensive cache generation status without mutating markers."""
 
-        # If no cache directory is configured, return non-generating status
-        if not self.cache_dir:
+        if not self._is_monitoring_enabled():
             logger.info("🔍 No cache directory configured - cache monitoring disabled")
             return CacheGenerationStatus(
                 is_generating=False,
@@ -312,75 +922,41 @@ class CacheMonitor:
                 last_activity_time=None,
             )
 
-        # Check cache status from marker files (primary method)
-        is_first_run, is_generating_from_markers, is_completed_from_markers = (
-            self.check_cache_status_from_markers()
+        snapshot = self._read_cache_snapshot()
+        marker_status = self._resolve_cache_lifecycle(
+            self._read_marker_status(),
+            snapshot,
         )
+        if marker_status.is_first_run:
+            logger.info("🔍 No cache content found - treating as first run")
 
-        # If there are no marker files, inspect the tensor cache directory directly.
-        if not is_generating_from_markers and not is_completed_from_markers:
-            has_cache_content = self.check_cache_directory_has_content()
-            is_first_run = not has_cache_content
-            if is_first_run:
-                logger.info("🔍 No cache content found - treating as first run")
-
-        # If this is a first run and no started marker exists, create it
-        if is_first_run and self.cache_dir:
-            success = self.mark_cache_first_run_started()
-            if success:
-                is_generating_from_markers = True
-
-        # Determine final status based on marker files and cache content
-        if is_completed_from_markers:
-            is_generating = False
-        elif is_generating_from_markers:
-            is_generating = True
-        else:
-            # If no markers, assume first run if no cache content
-            is_generating = is_first_run
-
-        (
-            total_size_bytes,
-            file_count,
-            last_progress_time,
-            no_progress_duration,
-            is_stalled,
-        ) = self._get_progress_state(is_generating=is_generating)
-
-        if is_stalled:
+        progress_status = self._progress_tracker.update(
+            snapshot,
+            is_generating=marker_status.is_generating,
+        )
+        if progress_status.is_stalled:
             logger.error(
                 "⛔ Tensor cache generation stalled in %s after %.1fs without file size change",
                 self.cache_dir,
-                no_progress_duration,
+                progress_status.no_progress_duration,
             )
 
-        status = CacheGenerationStatus(
-            is_generating=is_generating,
-            cache_dir=self.cache_dir,
-            container_id=None,
-            last_activity_time=last_progress_time,
-            is_first_run=is_first_run,
-            is_stalled=is_stalled,
-            file_count=file_count,
-            total_size_bytes=total_size_bytes,
-            no_progress_duration=no_progress_duration,
+        return self._build_generation_status(
+            marker_status,
+            snapshot,
+            progress_status,
         )
-        status.estimated_completion_time = self.estimate_cache_completion_time(status)
-        return status
 
     def estimate_cache_completion_time(
         self, current_status: CacheGenerationStatus
     ) -> Optional[float]:
         """
-        Estimate cache completion time based on historical data
-        This is a simple heuristic - could be improved with more sophisticated modeling
+        Estimate cache completion time based on historical data.
+
+        This is a simple heuristic that can be improved later.
         """
         if not current_status.is_generating:
             return None
 
-        # Simple heuristic: if cache is actively being generated,
-        # estimate 40-60 minutes total time (as mentioned in docs)
-        # This could be made more sophisticated by tracking progress
-        base_estimate = 50 * 60  # 50 minutes in seconds
-
+        base_estimate = 50 * 60
         return time.time() + base_estimate

--- a/utils/cache_monitor.py
+++ b/utils/cache_monitor.py
@@ -37,6 +37,7 @@ Permissions:
   marker state for the lifetime of the host-side process.
 """
 
+import errno
 import logging
 import os
 import json
@@ -83,6 +84,9 @@ print(
     )
 )
 """.strip()
+
+
+_PERMISSION_DENIED_ERRNOS = {errno.EACCES, errno.EPERM}
 
 
 def _get_value(obj, key: str, default=None):
@@ -165,6 +169,29 @@ class CacheMonitorTarget:
         return self.cache_dir or self.docker_cache_dir
 
 
+def _is_permission_denied(error: OSError) -> bool:
+    return (
+        isinstance(error, PermissionError)
+        or getattr(error, "errno", None) in _PERMISSION_DENIED_ERRNOS
+    )
+
+
+def _get_unreadable_docker_volume_info(
+    volume_name: str, mountpoint: Path, error: OSError
+) -> DockerVolumeInfo:
+    logger.info(
+        "Docker volume %s mountpoint could not be inspected by the current user: %s (%s)",
+        volume_name,
+        mountpoint,
+        error,
+    )
+    return DockerVolumeInfo(
+        volume_name=volume_name,
+        mountpoint=mountpoint,
+        is_readable=False,
+    )
+
+
 def get_cache_relative_dir(
     model_spec, runtime_config=None, device: Optional[str] = None
 ) -> Optional[Path]:
@@ -235,14 +262,41 @@ def inspect_docker_volume(volume_name: str) -> Optional[DockerVolumeInfo]:
         return None
 
     mountpoint = Path(mountpoint_str)
-    if not mountpoint.exists():
+    try:
+        mountpoint_exists = mountpoint.exists()
+    except OSError as error:
+        if _is_permission_denied(error):
+            return _get_unreadable_docker_volume_info(volume_name, mountpoint, error)
+        logger.info(
+            "Could not inspect Docker volume %s mountpoint %s: %s",
+            volume_name,
+            mountpoint,
+            error,
+        )
+        return None
+
+    if not mountpoint_exists:
         logger.info(
             "Docker volume %s mountpoint is not accessible on this host: %s",
             volume_name,
             mountpoint,
         )
         return None
-    if not mountpoint.is_dir():
+
+    try:
+        mountpoint_is_dir = mountpoint.is_dir()
+    except OSError as error:
+        if _is_permission_denied(error):
+            return _get_unreadable_docker_volume_info(volume_name, mountpoint, error)
+        logger.info(
+            "Could not inspect Docker volume %s mountpoint type %s: %s",
+            volume_name,
+            mountpoint,
+            error,
+        )
+        return None
+
+    if not mountpoint_is_dir:
         logger.info(
             "Docker volume %s mountpoint is not a directory: %s",
             volume_name,
@@ -250,8 +304,34 @@ def inspect_docker_volume(volume_name: str) -> Optional[DockerVolumeInfo]:
         )
         return None
 
-    resolved_mountpoint = mountpoint.resolve()
-    is_readable = os.access(resolved_mountpoint, os.R_OK | os.X_OK)
+    try:
+        resolved_mountpoint = mountpoint.resolve()
+    except OSError as error:
+        if _is_permission_denied(error):
+            return _get_unreadable_docker_volume_info(volume_name, mountpoint, error)
+        logger.info(
+            "Could not resolve Docker volume %s mountpoint %s: %s",
+            volume_name,
+            mountpoint,
+            error,
+        )
+        return None
+
+    try:
+        is_readable = os.access(resolved_mountpoint, os.R_OK | os.X_OK)
+    except OSError as error:
+        if _is_permission_denied(error):
+            return _get_unreadable_docker_volume_info(
+                volume_name, resolved_mountpoint, error
+            )
+        logger.info(
+            "Could not inspect Docker volume %s mountpoint permissions %s: %s",
+            volume_name,
+            resolved_mountpoint,
+            error,
+        )
+        return None
+
     if not is_readable:
         logger.info(
             "Docker volume %s mountpoint is not readable by the current user: %s",

--- a/utils/cache_monitor.py
+++ b/utils/cache_monitor.py
@@ -20,6 +20,11 @@ class CacheGenerationStatus:
     container_id: Optional[str] = None
     last_activity_time: Optional[float] = None
     estimated_completion_time: Optional[float] = None
+    is_first_run: bool = False
+    is_stalled: bool = False
+    file_count: int = 0
+    total_size_bytes: int = 0
+    no_progress_duration: float = 0.0
 
 
 class CacheMonitor:
@@ -27,19 +32,62 @@ class CacheMonitor:
 
     TT_METAL_CACHE_FIRST_RUN_STARTED = "TT_METAL_CACHE_FIRST_RUN_STARTED"
     TT_METAL_CACHE_COMPLETED = "TT_METAL_CACHE_COMPLETED"
+    DEFAULT_TENSOR_CACHE_TIMEOUT = 1200.0
+    TENSOR_CACHE_NO_CHANGE_TIMEOUT = 180
 
     def __init__(self, model_spec=None, cache_dir: Optional[Path] = None):
-        if model_spec is not None and getattr(model_spec, "uses_model_cache", True):
+        self.model_spec = model_spec
+        self.tensor_cache_timeout = self._get_tensor_cache_timeout(model_spec)
+        self._last_progress_time: Optional[float] = None
+        self._last_cache_size_bytes: Optional[int] = None
+        self._last_cache_file_count: Optional[int] = None
+
+        if cache_dir is not None:
+            self.cache_dir = cache_dir
+        elif model_spec is not None and self._uses_tensor_model_cache(model_spec):
             self.cache_dir = self._detect_cache_directory(model_spec)
-        elif model_spec is not None and not getattr(
-            model_spec, "uses_model_cache", True
-        ):
+        elif model_spec is not None and not self._uses_tensor_model_cache(model_spec):
             logger.info(
-                f"🔍 Model {getattr(model_spec, 'model_name', 'unknown')} does not use model cache - cache monitoring disabled"
+                f"🔍 Model {getattr(model_spec, 'model_name', 'unknown')} does not use tensor cache - cache monitoring disabled"
             )
             self.cache_dir = None
         else:
             self.cache_dir = cache_dir
+
+    def _uses_tensor_model_cache(self, model_spec) -> bool:
+        return bool(
+            getattr(
+                model_spec,
+                "uses_tensor_model_cache",
+                getattr(model_spec, "uses_model_cache", True),
+            )
+        )
+
+    def _get_tensor_cache_timeout(self, model_spec) -> float:
+        if model_spec is None:
+            return self.DEFAULT_TENSOR_CACHE_TIMEOUT
+
+        device_model_spec = getattr(model_spec, "device_model_spec", None)
+        timeout = getattr(
+            device_model_spec, "tensor_cache_timeout", self.DEFAULT_TENSOR_CACHE_TIMEOUT
+        )
+        return float(timeout)
+
+    def get_tensor_cache_timeout(self) -> float:
+        return self.tensor_cache_timeout
+
+    def get_effective_timeout(
+        self,
+        default_timeout: float,
+        cache_status: Optional[CacheGenerationStatus] = None,
+    ) -> float:
+        if cache_status is None:
+            cache_status = self.get_cache_generation_status()
+
+        if cache_status.is_generating:
+            return self.get_tensor_cache_timeout()
+
+        return float(default_timeout)
 
     def _detect_cache_directory(self, model_spec):
         """
@@ -162,12 +210,80 @@ class CacheMonitor:
         logger.debug(f"Started file: {started_file}")
         logger.debug(f"Completed file: {completed_file}")
 
-        # Determine status based on marker files
-        is_first_run = not started_exists
-        is_generating = started_exists and not completed_exists
-        is_completed = completed_exists
+        # Markers have strict precedence:
+        # completed -> done
+        # started without completed -> generation in progress
+        # no markers -> determine first-run using cache content
+        if completed_exists:
+            return False, False, True
+        if started_exists:
+            return False, True, False
 
-        return is_first_run, is_generating, is_completed
+        return True, False, False
+
+    def _get_tensor_cache_snapshot(self) -> Tuple[int, int]:
+        if not self.cache_dir or not self.cache_dir.exists():
+            return 0, 0
+
+        total_size_bytes = 0
+        file_count = 0
+        marker_files = {
+            self.TT_METAL_CACHE_FIRST_RUN_STARTED,
+            self.TT_METAL_CACHE_COMPLETED,
+        }
+
+        try:
+            for cache_file in self.cache_dir.rglob("*"):
+                if not cache_file.is_file() or cache_file.name in marker_files:
+                    continue
+
+                try:
+                    total_size_bytes += cache_file.stat().st_size
+                    file_count += 1
+                except (OSError, PermissionError):
+                    logger.debug(f"Skipping unreadable cache file: {cache_file}")
+        except (OSError, PermissionError) as e:
+            logger.warning(f"Failed to inspect cache directory content: {e}")
+            return 0, 0
+
+        return total_size_bytes, file_count
+
+    def _reset_progress_tracking(self):
+        self._last_progress_time = None
+        self._last_cache_size_bytes = None
+        self._last_cache_file_count = None
+
+    def _get_progress_state(
+        self, is_generating: bool
+    ) -> Tuple[int, int, Optional[float], float, bool]:
+        if not is_generating:
+            self._reset_progress_tracking()
+            return 0, 0, None, 0.0, False
+
+        current_time = time.time()
+        total_size_bytes, file_count = self._get_tensor_cache_snapshot()
+        cache_changed = (
+            self._last_cache_size_bytes is None
+            or self._last_cache_file_count is None
+            or total_size_bytes != self._last_cache_size_bytes
+            or file_count != self._last_cache_file_count
+        )
+
+        if cache_changed:
+            self._last_cache_size_bytes = total_size_bytes
+            self._last_cache_file_count = file_count
+            self._last_progress_time = current_time
+            return total_size_bytes, file_count, self._last_progress_time, 0.0, False
+
+        no_progress_duration = current_time - self._last_progress_time
+        is_stalled = no_progress_duration >= self.TENSOR_CACHE_NO_CHANGE_TIMEOUT
+        return (
+            total_size_bytes,
+            file_count,
+            self._last_progress_time,
+            no_progress_duration,
+            is_stalled,
+        )
 
     def check_cache_directory_has_content(self) -> bool:
         """Check if cache directory has actual cache content (not just empty directories)"""
@@ -175,18 +291,9 @@ class CacheMonitor:
             return False
 
         try:
-            # Look for actual cache files (not just directories)
-            # Cache files typically have extensions like .bin, .cache, etc.
-            cache_files = list(self.cache_dir.rglob("*"))
-            actual_files = [
-                f
-                for f in cache_files
-                if f.is_file() and not f.name.startswith("CACHE_")
-            ]
-
-            logger.debug(f"Found {len(actual_files)} cache files in {self.cache_dir}")
-            return len(actual_files) > 0
-
+            _, file_count = self._get_tensor_cache_snapshot()
+            logger.debug(f"Found {file_count} cache files in {self.cache_dir}")
+            return file_count > 0
         except (OSError, PermissionError) as e:
             logger.warning(f"Failed to check cache directory content: {e}")
             return False
@@ -209,12 +316,11 @@ class CacheMonitor:
             self.check_cache_status_from_markers()
         )
 
-        # Fallback: if no marker files but cache directory exists, check for actual cache content
+        # If there are no marker files, inspect the tensor cache directory directly.
         if not is_generating_from_markers and not is_completed_from_markers:
             has_cache_content = self.check_cache_directory_has_content()
-            if not has_cache_content:
-                # No cache content found, this is likely a first run
-                is_first_run = True
+            is_first_run = not has_cache_content
+            if is_first_run:
                 logger.info("🔍 No cache content found - treating as first run")
 
         # If this is a first run and no started marker exists, create it
@@ -232,12 +338,34 @@ class CacheMonitor:
             # If no markers, assume first run if no cache content
             is_generating = is_first_run
 
-        return CacheGenerationStatus(
+        (
+            total_size_bytes,
+            file_count,
+            last_progress_time,
+            no_progress_duration,
+            is_stalled,
+        ) = self._get_progress_state(is_generating=is_generating)
+
+        if is_stalled:
+            logger.error(
+                "⛔ Tensor cache generation stalled in %s after %.1fs without file size change",
+                self.cache_dir,
+                no_progress_duration,
+            )
+
+        status = CacheGenerationStatus(
             is_generating=is_generating,
             cache_dir=self.cache_dir,
             container_id=None,
-            last_activity_time=time.time() if is_generating else None,
+            last_activity_time=last_progress_time,
+            is_first_run=is_first_run,
+            is_stalled=is_stalled,
+            file_count=file_count,
+            total_size_bytes=total_size_bytes,
+            no_progress_duration=no_progress_duration,
         )
+        status.estimated_completion_time = self.estimate_cache_completion_time(status)
+        return status
 
     def estimate_cache_completion_time(
         self, current_status: CacheGenerationStatus

--- a/utils/device_utils.py
+++ b/utils/device_utils.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+from typing import Optional
+
+DEVICE_TO_MESH_STR = {
+    "CPU": "CPU",
+    "E150": "E150",
+    "N150": "N150",
+    "P100": "P100",
+    "P150": "P150",
+    "P150X4": "P150x4",
+    "P150X8": "P150x8",
+    "N150X4": "N150x4",
+    "N300": "N300",
+    "P300": "P300",
+    "P300X2": "P300x2",
+    "T3K": "T3K",
+    "GALAXY": "TG",
+    "GALAXY_T3K": "T3K",
+    "DUAL_GALAXY": "(8,8)",
+    "QUAD_GALAXY": "(8,16)",
+    "GPU": "GPU",
+}
+
+
+def _get_value(obj, key: str, default=None):
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def to_mesh_device_str(device) -> str:
+    if hasattr(device, "to_mesh_device_str"):
+        return device.to_mesh_device_str()
+
+    device_name = _get_value(device, "name", device)
+    if device_name is None:
+        raise ValueError("Device name is required to resolve a tensor cache path.")
+
+    mesh_device_str = DEVICE_TO_MESH_STR.get(str(device_name).upper())
+    if mesh_device_str is None:
+        raise ValueError(f"Unknown device type: {device_name}")
+    return mesh_device_str
+
+
+def get_mesh_device_name(model_spec=None, device: Optional[str] = None) -> str:
+    subdevice_type = _get_value(model_spec, "subdevice_type")
+    if subdevice_type is not None:
+        return to_mesh_device_str(subdevice_type)
+
+    device_value = device
+    if device_value is None:
+        device_value = _get_value(_get_value(model_spec, "device_type"), "name")
+    return to_mesh_device_str(device_value)

--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -145,46 +145,59 @@ class PromptClient:
         Returns:
             bool: True if service becomes healthy, False if timeout exceeded
         """
-        timeout = float(timeout)
+        base_timeout = float(timeout)
+        effective_timeout = base_timeout
         if self.server_ready:
             return True
 
         start_time = time.time()
-        original_timeout = timeout
-        cache_generation_detected = False
+        using_tensor_cache_timeout = False
         last_cache_status_log = 0
         cache_status_log_interval = 60  # Log cache status every 60 seconds
 
         logger.info(
-            f"Waiting for vLLM service to become healthy (base timeout: {timeout}s)"
+            f"Waiting for vLLM service to become healthy (base timeout: {base_timeout}s)"
         )
 
-        while time.time() - start_time < timeout:
+        while time.time() - start_time < effective_timeout:
             req_time = time.time()
 
             # Check cache generation status
             cache_status = self.cache_monitor.get_cache_generation_status()
             current_time = time.time()
+            effective_timeout = self.cache_monitor.get_effective_timeout(
+                default_timeout=base_timeout, cache_status=cache_status
+            )
+
+            if cache_status.is_stalled:
+                logger.error(
+                    "⛔ Tensor cache generation stalled after %.1fs without cache growth in %s. "
+                    "Aborting server startup wait so the workflow can stop the server cleanly.",
+                    cache_status.no_progress_duration,
+                    cache_status.cache_dir,
+                )
+                return False
 
             # Log cache status periodically
             if current_time - last_cache_status_log > cache_status_log_interval:
                 if cache_status.is_generating:
-                    logger.info(
-                        "🔄 Cache generation in progress - this may take 40-60 minutes for new models"
-                    )
-                    if not cache_generation_detected:
-                        # First time detecting cache generation - extend timeout
-                        extended_timeout = 90 * 60.0
-                        timeout = extended_timeout
-                        cache_generation_detected = True
+                    if not using_tensor_cache_timeout:
                         logger.info(
-                            f"⏰ using extended timeout:={timeout}s due to cache generation"
+                            "⏰ Using tensor_cache_timeout:=%ss for first-run tensor cache generation",
+                            effective_timeout,
                         )
-                else:
+                        using_tensor_cache_timeout = True
                     logger.info(
-                        f"📁 No active cache generation detected, using standard timeout:={timeout}s"
+                        "🔄 Tensor cache generation in progress - tracking %s file(s), %s total bytes",
+                        cache_status.file_count,
+                        cache_status.total_size_bytes,
                     )
-                    timeout = original_timeout
+                else:
+                    if using_tensor_cache_timeout:
+                        using_tensor_cache_timeout = False
+                    logger.info(
+                        f"📁 No active tensor cache generation detected, using standard timeout:={effective_timeout}s"
+                    )
                 last_cache_status_log = current_time
 
             # Try health check
@@ -219,27 +232,35 @@ class PromptClient:
             # Provide different messaging based on cache status
             if cache_status.is_generating:
                 logger.info(
-                    f"🔄 Cache generation in progress. Waited {total_time_waited:.1f}s, "
-                    f"next check in {sleep_interval:.1f}s (timeout: {timeout}s)"
+                    f"🔄 Tensor cache generation in progress. Waited {total_time_waited:.1f}s, "
+                    f"next check in {sleep_interval:.1f}s (timeout: {effective_timeout}s, "
+                    f"no progress: {cache_status.no_progress_duration:.1f}s)"
                 )
             else:
                 logger.info(
                     f"⏳ Service not ready after {total_time_waited:.1f}s, "
-                    f"waiting {sleep_interval:.1f}s before polling (timeout: {timeout}s)"
+                    f"waiting {sleep_interval:.1f}s before polling (timeout: {effective_timeout}s)"
                 )
 
             time.sleep(sleep_interval)
 
         # Final status check
         final_cache_status = self.cache_monitor.get_cache_generation_status()
-        if final_cache_status.is_generating:
+        if final_cache_status.is_stalled:
             logger.error(
-                f"⛔ Service did not become healthy within {timeout}s. "
-                f"Cache generation appears to still be in progress. "
+                f"⛔ Tensor cache generation stalled for {final_cache_status.no_progress_duration:.1f}s "
+                f"in {final_cache_status.cache_dir}"
+            )
+        elif final_cache_status.is_generating:
+            logger.error(
+                f"⛔ Service did not become healthy within {effective_timeout}s. "
+                f"Tensor cache generation appears to still be in progress. "
                 f"Consider increasing the timeout or checking the docker logs."
             )
         else:
-            logger.error(f"⛔ Service did not become healthy within {timeout}s")
+            logger.error(
+                f"⛔ Service did not become healthy within {effective_timeout}s"
+            )
 
         return False
 
@@ -419,9 +440,9 @@ class PromptClient:
             }
             completions_url = f"{self._get_api_base_url()}/chat/completions"
         else:
-            assert len(images) == 0, (
-                "legacy API does not support images, use --use_chat_api option."
-            )
+            assert (
+                len(images) == 0
+            ), "legacy API does not support images, use --use_chat_api option."
             json_data = {
                 "model": vllm_model,
                 "prompt": prompt,

--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -440,9 +440,9 @@ class PromptClient:
             }
             completions_url = f"{self._get_api_base_url()}/chat/completions"
         else:
-            assert (
-                len(images) == 0
-            ), "legacy API does not support images, use --use_chat_api option."
+            assert len(images) == 0, (
+                "legacy API does not support images, use --use_chat_api option."
+            )
             json_data = {
                 "model": vllm_model,
                 "prompt": prompt,

--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -3,10 +3,9 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 import logging
-import os
 import json
 import time
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple, Union
 from pathlib import Path
 
 import requests
@@ -15,7 +14,7 @@ from transformers import AutoTokenizer
 
 from utils.prompt_generation import generate_prompts
 from utils.prompt_configs import PromptConfig, EnvironmentConfig
-from utils.cache_monitor import CacheMonitor
+from utils.cache_monitor import CacheMonitor, get_environment_cache_dir
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -68,12 +67,26 @@ def get_trace_context_lens(
     ]
 
 
+def format_human_readable_bytes(total_bytes: int) -> str:
+    """Format a byte count using human-readable storage units."""
+    size = float(max(total_bytes, 0))
+    for unit in ["B", "KB", "MB", "GB", "TB", "PB"]:
+        if size < 1024.0 or unit == "PB":
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1024.0
+
+    return "0 B"
+
+
 class PromptClient:
     def __init__(
         self,
         env_config: EnvironmentConfig,
         model_spec=None,
-        cache_dir: Optional[Path] = None,
+        cache_dir: Optional[Union[str, Path]] = None,
+        runtime_config=None,
     ):
         self.env_config = env_config
         authorization = self._get_authorization()
@@ -83,7 +96,11 @@ class PromptClient:
             self.headers = {}
         self.completions_url = self._get_api_completions_url()
         self.health_url = self._get_api_health_url()
-        self.cache_monitor = CacheMonitor(model_spec=model_spec, cache_dir=cache_dir)
+        self.cache_monitor = CacheMonitor(
+            model_spec=model_spec,
+            cache_dir=cache_dir,
+            runtime_config=runtime_config,
+        )
         self.server_ready = False
 
     def _get_authorization(self) -> Optional[str]:
@@ -165,6 +182,10 @@ class PromptClient:
             # Check cache generation status
             cache_status = self.cache_monitor.get_cache_generation_status()
             current_time = time.time()
+            has_existing_cache = getattr(cache_status, "has_existing_cache", False)
+            tensor_cache_wait_active = (
+                cache_status.is_first_run or cache_status.is_generating
+            )
             effective_timeout = self.cache_monitor.get_effective_timeout(
                 default_timeout=base_timeout, cache_status=cache_status
             )
@@ -180,24 +201,38 @@ class PromptClient:
 
             # Log cache status periodically
             if current_time - last_cache_status_log > cache_status_log_interval:
-                if cache_status.is_generating:
+                if tensor_cache_wait_active:
                     if not using_tensor_cache_timeout:
                         logger.info(
                             "⏰ Using tensor_cache_timeout:=%ss for first-run tensor cache generation",
                             effective_timeout,
                         )
                         using_tensor_cache_timeout = True
-                    logger.info(
-                        "🔄 Tensor cache generation in progress - tracking %s file(s), %s total bytes",
-                        cache_status.file_count,
-                        cache_status.total_size_bytes,
-                    )
+                    if cache_status.is_generating:
+                        logger.info(
+                            "🔄 Tensor cache generation in progress - tracking %s file(s), %s total bytes",
+                            cache_status.file_count,
+                            cache_status.total_size_bytes,
+                        )
+                    else:
+                        logger.info(
+                            "📁 First-run cache directory is still empty; waiting for tensor cache activity"
+                        )
                 else:
                     if using_tensor_cache_timeout:
                         using_tensor_cache_timeout = False
-                    logger.info(
-                        f"📁 No active tensor cache generation detected, using standard timeout:={effective_timeout}s"
-                    )
+                    if has_existing_cache:
+                        logger.info(
+                            "📁 Existing tensor cache detected - tracking %s file(s), %s; using standard timeout:=%ss",
+                            cache_status.file_count,
+                            format_human_readable_bytes(cache_status.total_size_bytes),
+                            effective_timeout,
+                        )
+                    else:
+                        logger.info(
+                            "📁 No active tensor cache generation detected, using standard timeout:=%ss",
+                            effective_timeout,
+                        )
                 last_cache_status_log = current_time
 
             # Try health check
@@ -236,6 +271,21 @@ class PromptClient:
                     f"next check in {sleep_interval:.1f}s (timeout: {effective_timeout}s, "
                     f"no progress: {cache_status.no_progress_duration:.1f}s)"
                 )
+            elif cache_status.is_first_run:
+                logger.info(
+                    f"⏳ First-run tensor cache warmup detected. Waited {total_time_waited:.1f}s, "
+                    f"waiting {sleep_interval:.1f}s before polling (timeout: {effective_timeout}s)"
+                )
+            elif has_existing_cache:
+                logger.info(
+                    "📁 Existing tensor cache detected (%s file(s), %s total bytes). "
+                    "Service not ready after %.1fs, waiting %.1fs before polling (timeout: %ss)",
+                    cache_status.file_count,
+                    cache_status.total_size_bytes,
+                    total_time_waited,
+                    sleep_interval,
+                    effective_timeout,
+                )
             else:
                 logger.info(
                     f"⏳ Service not ready after {total_time_waited:.1f}s, "
@@ -256,6 +306,18 @@ class PromptClient:
                 f"⛔ Service did not become healthy within {effective_timeout}s. "
                 f"Tensor cache generation appears to still be in progress. "
                 f"Consider increasing the timeout or checking the docker logs."
+            )
+        elif final_cache_status.is_first_run:
+            logger.error(
+                f"⛔ Service did not become healthy within {effective_timeout}s during first-run tensor cache startup"
+            )
+        elif getattr(final_cache_status, "has_existing_cache", False):
+            logger.error(
+                "⛔ Service did not become healthy within %ss even though tensor cache already appears present "
+                "(%s file(s), %s total bytes)",
+                effective_timeout,
+                final_cache_status.file_count,
+                final_cache_status.total_size_bytes,
             )
         else:
             logger.error(
@@ -798,15 +860,9 @@ def run_background_trace_capture(
         env_config.service_port = service_port
         env_config.vllm_model = hf_model_repo
 
-        # Create prompt client
-        # TODO: since this is only called inside the vLLM container this env var should be set.
-        # TODO: I know the whole purpose of the ModelSpec is to not parse env vars, but it was hard
-        # TODO: to infer the path without importing the SetupConfig (which is not copied to the container)
-        # TODO: Eventually this will not be necessary when we perform trace capture / warmup inside vLLM
-        # TODO: https://github.com/tenstorrent/vllm/issues/220
-        if "TT_CACHE_PATH" not in os.environ:
+        tt_cache_path = get_environment_cache_dir()
+        if tt_cache_path is None:
             raise RuntimeError("TT_CACHE_PATH environment variable is not set.")
-        tt_cache_path = Path(os.environ["TT_CACHE_PATH"])
         prompt_client = PromptClient(env_config, cache_dir=tt_cache_path)
 
         # Use intelligent timeout - automatically determines 90 minutes for first run, 30 minutes for subsequent runs

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -15,6 +15,8 @@ from typing import Optional
 from huggingface_hub import snapshot_download
 from vllm import ModelRegistry
 
+from utils.cache_monitor import get_container_cache_dir
+from utils.device_utils import get_mesh_device_name
 from utils.logging_utils import set_vllm_logging_config
 from utils.prompt_client import run_background_trace_capture
 from utils.vllm_run_utils import (
@@ -89,30 +91,6 @@ def parse_args():
     return args
 
 
-# Device type name to mesh device string mapping
-# This maps the canonical device type names (used in model specs JSON) to
-# the mesh device strings used for cache paths
-DEVICE_TO_MESH_STR = {
-    "CPU": "CPU",
-    "E150": "E150",
-    "N150": "N150",
-    "P100": "P100",
-    "P150": "P150",
-    "P150X4": "P150x4",
-    "P150X8": "P150x8",
-    "N150X4": "N150x4",
-    "N300": "N300",
-    "P300": "P300",
-    "P300X2": "P300x2",
-    "T3K": "T3K",
-    "GALAXY": "TG",
-    "GALAXY_T3K": "T3K",
-    "DUAL_GALAXY": "(8,8)",
-    "QUAD_GALAXY": "(8,16)",
-    "GPU": "GPU",
-}
-
-
 def normalize_device_type(device_arg: str) -> str:
     """Convert user-provided device string to canonical device type name.
 
@@ -134,20 +112,6 @@ def normalize_engine_type(engine_arg: Optional[str]) -> Optional[str]:
         "forge": "forge",
     }
     return engine_map[engine_arg.lower()]
-
-
-def device_to_mesh_str(device_type: str) -> str:
-    """Convert device type name to mesh device string for cache paths.
-
-    Args:
-        device_type: Canonical device type name (e.g., "N300", "GALAXY")
-
-    Returns:
-        Mesh device string (e.g., "N300", "TG")
-    """
-    if device_type not in DEVICE_TO_MESH_STR:
-        raise ValueError(f"Unknown device type: {device_type}")
-    return DEVICE_TO_MESH_STR[device_type]
 
 
 def unwrap_model_specs_catalog(model_specs: dict) -> dict:
@@ -366,16 +330,15 @@ def set_cache_paths(model_spec: dict, device_type: str):
         model_spec: The model specification dictionary
         device_type: Canonical device type name (e.g., "N300", "GALAXY")
     """
-    cache_root = Path(os.getenv("CACHE_ROOT", "/home/container_app_user/cache_root"))
-    model_name = model_spec["model_name"]
-    mesh_device = device_to_mesh_str(device_type)
+    mesh_device = get_mesh_device_name(device=device_type)
+    tt_cache_path = get_container_cache_dir(model_spec, device=device_type)
+    if tt_cache_path is None:
+        raise RuntimeError("Could not resolve TT cache path from model spec.")
 
     # Set MESH_DEVICE env var for other components that need it
     os.environ["MESH_DEVICE"] = mesh_device
     logger.info(f"Set MESH_DEVICE to {mesh_device}")
 
-    # Preserve model/device-specific cache structure
-    tt_cache_path = cache_root / "tt_metal_cache" / f"cache_{model_name}" / mesh_device
     tt_cache_path.mkdir(parents=True, exist_ok=True)
     os.environ["TT_CACHE_PATH"] = str(tt_cache_path)
     logger.info(f"Set TT_CACHE_PATH to {tt_cache_path}")

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -179,12 +179,12 @@ def model_weights_to_model_name(model_weights: str) -> str:
 
 def get_model_id(impl_name: str, model_name: str, device: str) -> str:
     # Validate that all parameters are strings
-    assert isinstance(
-        impl_name, str
-    ), f"Impl name must be a string, got {type(impl_name)}"
-    assert isinstance(
-        model_name, str
-    ), f"Model name must be a string, got {type(model_name)}"
+    assert isinstance(impl_name, str), (
+        f"Impl name must be a string, got {type(impl_name)}"
+    )
+    assert isinstance(model_name, str), (
+        f"Model name must be a string, got {type(model_name)}"
+    )
     assert isinstance(device, str), f"Device must be a string, got {type(device)}"
 
     # Validate that all parameters are non-empty
@@ -496,9 +496,9 @@ class ModelSpec:
         assert self.hf_model_repo, "hf_model_repo must be set"
         assert self.model_name, "model_name must be set"
         assert self.model_id, "model_id must be set"
-        assert self.inference_engine in [
-            e.value for e in InferenceEngine
-        ], f"inference_engine must be one of {[e.value for e in InferenceEngine]}"
+        assert self.inference_engine in [e.value for e in InferenceEngine], (
+            f"inference_engine must be one of {[e.value for e in InferenceEngine]}"
+        )
 
     @staticmethod
     def infer_param_count(hf_model_repo: str) -> Optional[int]:
@@ -817,10 +817,10 @@ class ModelSpecTemplate:
         """Validate that required specification is present."""
         assert self.device_model_specs, "device_model_specs must be provided"
         assert self.weights, "weights must be provided"
-        assert self.inference_engine in [
-            engine.value for engine in InferenceEngine
-        ], f"inference_engine must be a valid InferenceEngine! \
+        assert self.inference_engine in [engine.value for engine in InferenceEngine], (
+            f"inference_engine must be a valid InferenceEngine! \
             Available: {[engine for engine in InferenceEngine]}"
+        )
 
     def _infer_data(self):
         """Infer missing data fields from other specification values."""

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -179,12 +179,12 @@ def model_weights_to_model_name(model_weights: str) -> str:
 
 def get_model_id(impl_name: str, model_name: str, device: str) -> str:
     # Validate that all parameters are strings
-    assert isinstance(impl_name, str), (
-        f"Impl name must be a string, got {type(impl_name)}"
-    )
-    assert isinstance(model_name, str), (
-        f"Model name must be a string, got {type(model_name)}"
-    )
+    assert isinstance(
+        impl_name, str
+    ), f"Impl name must be a string, got {type(impl_name)}"
+    assert isinstance(
+        model_name, str
+    ), f"Model name must be a string, got {type(model_name)}"
     assert isinstance(device, str), f"Device must be a string, got {type(device)}"
 
     # Validate that all parameters are non-empty
@@ -291,6 +291,7 @@ class DeviceModelSpec:
     vllm_args: Dict[str, str] = field(default_factory=dict)
     override_tt_config: Dict[str, str] = field(default_factory=dict)
     env_vars: Dict[str, str] = field(default_factory=dict)
+    tensor_cache_timeout: float = 3600.0
     system_requirements: Optional[SystemRequirements] = None
 
     def __post_init__(self):
@@ -495,9 +496,9 @@ class ModelSpec:
         assert self.hf_model_repo, "hf_model_repo must be set"
         assert self.model_name, "model_name must be set"
         assert self.model_id, "model_id must be set"
-        assert self.inference_engine in [e.value for e in InferenceEngine], (
-            f"inference_engine must be one of {[e.value for e in InferenceEngine]}"
-        )
+        assert self.inference_engine in [
+            e.value for e in InferenceEngine
+        ], f"inference_engine must be one of {[e.value for e in InferenceEngine]}"
 
     @staticmethod
     def infer_param_count(hf_model_repo: str) -> Optional[int]:
@@ -816,10 +817,10 @@ class ModelSpecTemplate:
         """Validate that required specification is present."""
         assert self.device_model_specs, "device_model_specs must be provided"
         assert self.weights, "weights must be provided"
-        assert self.inference_engine in [engine.value for engine in InferenceEngine], (
-            f"inference_engine must be a valid InferenceEngine! \
+        assert self.inference_engine in [
+            engine.value for engine in InferenceEngine
+        ], f"inference_engine must be a valid InferenceEngine! \
             Available: {[engine for engine in InferenceEngine]}"
-        )
 
     def _infer_data(self):
         """Infer missing data fields from other specification values."""
@@ -870,6 +871,8 @@ class ModelSpecTemplate:
                     vllm_args=device_model_spec.vllm_args,
                     override_tt_config=device_model_spec.override_tt_config,
                     env_vars=device_model_spec.env_vars,
+                    tensor_cache_timeout=device_model_spec.tensor_cache_timeout,
+                    system_requirements=device_model_spec.system_requirements,
                 )
                 spec = ModelSpec(
                     # Core identity
@@ -975,6 +978,7 @@ llm_templates = [
                 max_concurrency=1,
                 max_context=16 * 1024,
                 default_impl=True,
+                tensor_cache_timeout=5400.0,
             ),
             DeviceModelSpec(
                 device=DeviceTypes.GALAXY,
@@ -982,6 +986,7 @@ llm_templates = [
                 # complete else they will timeout due to hitting the vLLM RPC recv 30min timeout
                 max_context=128 * 1024,
                 default_impl=True,
+                tensor_cache_timeout=5400.0,
                 env_vars={
                     "MESH_DEVICE": "(4, 8)",  # Override default TG->(8,4) to use (4,8) mesh grid
                     "TT_MM_THROTTLE_PERF": 2,
@@ -1384,6 +1389,7 @@ llm_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                tensor_cache_timeout=5400.0,
                 override_tt_config={
                     "trace_region_size": 30712832,
                 },
@@ -1393,6 +1399,7 @@ llm_templates = [
                 max_concurrency=32 * 4,
                 max_context=128 * 1024,
                 default_impl=True,
+                tensor_cache_timeout=5400.0,
                 override_tt_config={
                     "trace_region_size": 30712832,
                     "data_parallel": 4,
@@ -1406,6 +1413,7 @@ llm_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                tensor_cache_timeout=5400.0,
                 override_tt_config={
                     "trace_region_size": 30712832,
                     "fabric_config": "FABRIC_1D",
@@ -1464,6 +1472,7 @@ llm_templates = [
                 max_concurrency=8 * 4,
                 max_context=128 * 1024,
                 default_impl=True,
+                tensor_cache_timeout=5400.0,
                 vllm_args={
                     "data_parallel_size": 4,
                 },
@@ -1503,6 +1512,7 @@ llm_templates = [
                 max_concurrency=32 * 8,
                 max_context=2048,
                 default_impl=True,
+                tensor_cache_timeout=6400.0,
                 vllm_args={
                     "max_model_len": "2048",
                 },
@@ -1512,6 +1522,7 @@ llm_templates = [
                 max_concurrency=32 * 8,  # 32 per DP rank * 8 ranks
                 max_context=2048,
                 default_impl=True,
+                tensor_cache_timeout=6400.0,
                 vllm_args={
                     "data_parallel_size": 8,
                     "block_size": "32",
@@ -1572,6 +1583,7 @@ llm_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                tensor_cache_timeout=5400.0,
                 override_tt_config={
                     "trace_region_size": 30000000,
                 },
@@ -1600,6 +1612,7 @@ llm_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                tensor_cache_timeout=5400.0,
                 override_tt_config={
                     "trace_region_size": 30000000,
                 },
@@ -1619,6 +1632,7 @@ llm_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                tensor_cache_timeout=5400.0,
                 override_tt_config={
                     "trace_region_size": 51453952,
                 },
@@ -1663,6 +1677,7 @@ llm_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                tensor_cache_timeout=5400.0,
                 override_tt_config={
                     "trace_region_size": 56000000,
                 },
@@ -1697,6 +1712,7 @@ llm_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                tensor_cache_timeout=5400.0,
                 env_vars={
                     "TT_MM_THROTTLE_PERF": 5,
                     "MAX_PREFILL_CHUNK_SIZE": "32",


### PR DESCRIPTION
# change log 

* addresses https://github.com/tenstorrent/tt-inference-server/issues/2505
* add tensor_cache_timeout to model_spec.py configurable per model-hardware
* make cache_monitor.py track stalled cache generation. After 180 seconds of no cache growth, the workflow aborts startup waiting, logs the stall, returns exit code 1, and run.py ultimately reports failure rather than waiting all the way to tensor_cache_timeout.