### PR TITLE
Adding support for tt-forge SDXL pipeline + UI for demo 

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -35,6 +35,7 @@ class SupportedModels(Enum):
 # Model names should be unique
 class ModelNames(Enum):
     STABLE_DIFFUSION_XL_BASE = "stable-diffusion-xl-base-1.0"
+    STABLE_DIFFUSION_XL_512 = "SDXL-512"
     STABLE_DIFFUSION_XL_IMG2IMG = "stable-diffusion-xl-base-1.0-img-2-img"
     STABLE_DIFFUSION_XL_INPAINTING = "stable-diffusion-xl-1.0-inpainting-0.1"
     STABLE_DIFFUSION_3_5_LARGE = "stable-diffusion-3.5-large"
@@ -187,7 +188,10 @@ MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.VLLM: {ModelNames.LLAMA_3_2_3B, ModelNames.QWEN_3_4B},
     ModelRunners.TT_SPEECHT5_TTS: {ModelNames.SPEECHT5_TTS},
     ModelRunners.TRAINING_GEMMA_LORA: {ModelNames.GEMMA_1_1_2B_IT},
-    ModelRunners.TT_XLA_SDXL: {ModelNames.STABLE_DIFFUSION_XL_BASE},
+    ModelRunners.TT_XLA_SDXL: {
+        ModelNames.STABLE_DIFFUSION_XL_BASE,
+        ModelNames.STABLE_DIFFUSION_XL_512,
+    },
 }
 
 

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -842,20 +842,18 @@ ModelConfigs = {
         "device_ids": DeviceIds.DEVICE_IDS_32.value,
         "max_batch_size": 1,
     },
-}
-
-ModelConfigs[(ModelRunners.TT_XLA_SDXL, DeviceTypes.P150X4)] = {
-    "device_mesh_shape": (1, 1),
-    "is_galaxy": False,
-    "device_ids": DeviceIds.DEVICE_IDS_4.value,
-    "max_batch_size": 1,
-}
-
-ModelConfigs[(ModelRunners.TT_XLA_SDXL, DeviceTypes.P300X2)] = {
-    "device_mesh_shape": (1, 2),
-    "is_galaxy": False,
-    "device_ids": DeviceIds.DEVICE_IDS_2X2_GROUP.value,
-    "max_batch_size": 1,
+    (ModelRunners.TT_XLA_SDXL, DeviceTypes.P150X4): {
+        "device_mesh_shape": (1, 1),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_4.value,
+        "max_batch_size": 1,
+    },
+    (ModelRunners.TT_XLA_SDXL, DeviceTypes.P300X2): {
+        "device_mesh_shape": (1, 2),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_2X2_GROUP.value,
+        "max_batch_size": 1,
+    },
 }
 
 for runner in [

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -93,6 +93,7 @@ class ModelRunners(Enum):
     LLM_TEST = "llm_test"
     LLAMA_RUNNER = "llama_runner"
     TT_SPEECHT5_TTS = "tt-speecht5-tts"
+    TT_XLA_SDXL = "tt-xla-sdxl"
 
 
 class ModelServices(Enum):
@@ -117,6 +118,7 @@ MODEL_SERVICE_RUNNER_MAP = {
         ModelRunners.TT_MOTIF_IMAGE_6B_PREVIEW,
         ModelRunners.TT_QWEN_IMAGE,
         ModelRunners.TT_QWEN_IMAGE_2512,
+        ModelRunners.TT_XLA_SDXL,
     },
     ModelServices.LLM: {
         ModelRunners.VLLM,
@@ -184,6 +186,7 @@ MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.VLLM: {ModelNames.LLAMA_3_2_3B, ModelNames.QWEN_3_4B},
     ModelRunners.TT_SPEECHT5_TTS: {ModelNames.SPEECHT5_TTS},
     ModelRunners.TRAINING_GEMMA_LORA: {ModelNames.GEMMA_1_1_2B_IT},
+    ModelRunners.TT_XLA_SDXL: {ModelNames.STABLE_DIFFUSION_XL_BASE},
 }
 
 
@@ -837,6 +840,13 @@ ModelConfigs = {
         "device_ids": DeviceIds.DEVICE_IDS_32.value,
         "max_batch_size": 1,
     },
+}
+
+ModelConfigs[(ModelRunners.TT_XLA_SDXL, DeviceTypes.P150X4)] = {
+    "device_mesh_shape": (1, 1),
+    "is_galaxy": False,
+    "device_ids": DeviceIds.DEVICE_IDS_4.value,
+    "max_batch_size": 1,
 }
 
 for runner in [

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -214,6 +214,7 @@ class DeviceIds(Enum):
     DEVICE_IDS_1 = "(0)"
     DEVICE_IDS_2 = "(0),(1)"
     DEVICE_IDS_2_GROUP = "(0,1)"
+    DEVICE_IDS_2X2_GROUP = "(0,1),(2,3)"
     DEVICE_IDS_4 = "(0),(1),(2),(3)"
     DEVICE_IDS_4_GROUP = "(0,1,2,3)"
     DEVICE_IDS_8_GROUP = "(0,1,2,3,4,5,6,7)"
@@ -851,9 +852,9 @@ ModelConfigs[(ModelRunners.TT_XLA_SDXL, DeviceTypes.P150X4)] = {
 }
 
 ModelConfigs[(ModelRunners.TT_XLA_SDXL, DeviceTypes.P300X2)] = {
-    "device_mesh_shape": (1, 1),
+    "device_mesh_shape": (1, 2),
     "is_galaxy": False,
-    "device_ids": DeviceIds.DEVICE_IDS_4.value,
+    "device_ids": DeviceIds.DEVICE_IDS_2X2_GROUP.value,
     "max_batch_size": 1,
 }
 

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -849,6 +849,13 @@ ModelConfigs[(ModelRunners.TT_XLA_SDXL, DeviceTypes.P150X4)] = {
     "max_batch_size": 1,
 }
 
+ModelConfigs[(ModelRunners.TT_XLA_SDXL, DeviceTypes.P300X2)] = {
+    "device_mesh_shape": (1, 1),
+    "is_galaxy": False,
+    "device_ids": DeviceIds.DEVICE_IDS_4.value,
+    "max_batch_size": 1,
+}
+
 for runner in [
     ModelRunners.TT_XLA_RESNET,
     ModelRunners.TT_XLA_VOVNET,

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -7,6 +7,7 @@ from enum import Enum
 
 class SupportedModels(Enum):
     STABLE_DIFFUSION_XL_BASE = "stabilityai/stable-diffusion-xl-base-1.0"
+    STABLE_DIFFUSION_XL_512 = "hotshotco/SDXL-512"
     STABLE_DIFFUSION_XL_IMG2IMG = "stabilityai/stable-diffusion-xl-base-1.0"
     STABLE_DIFFUSION_XL_INPAINTING = "diffusers/stable-diffusion-xl-1.0-inpainting-0.1"
     STABLE_DIFFUSION_3_5_LARGE = "stabilityai/stable-diffusion-3.5-large"

--- a/tt-media-server/model_services/scheduler.py
+++ b/tt-media-server/model_services/scheduler.py
@@ -309,7 +309,6 @@ class Scheduler:
         self.logger.info("Error listener stopped")
 
     async def device_warmup_listener(self):
-        consecutive_errors = 0
         while self.device_warmup_listener_running:
             try:
                 device_id = await asyncio.to_thread(self.warmup_signals_queue.get)
@@ -344,7 +343,6 @@ class Scheduler:
                 self.logger.error(
                     f"Error in device_warmup_listener (#{consecutive_errors}): {e}\n"
                 )
-                consecutive_errors += 1
 
         self.logger.info("Device warmup listener is done")
 
@@ -541,7 +539,7 @@ class Scheduler:
         self.logger.info("Starting new workers after reset")
 
         # Start new workers
-        await self.start_workers()
+        self.start_workers()
 
         self.logger.info("All workers restarted successfully")
 

--- a/tt-media-server/model_services/scheduler.py
+++ b/tt-media-server/model_services/scheduler.py
@@ -309,6 +309,7 @@ class Scheduler:
         self.logger.info("Error listener stopped")
 
     async def device_warmup_listener(self):
+        consecutive_errors = 0
         while self.device_warmup_listener_running:
             try:
                 device_id = await asyncio.to_thread(self.warmup_signals_queue.get)
@@ -343,6 +344,7 @@ class Scheduler:
                 self.logger.error(
                     f"Error in device_warmup_listener (#{consecutive_errors}): {e}\n"
                 )
+                consecutive_errors += 1
 
         self.logger.info("Device warmup listener is done")
 
@@ -539,7 +541,7 @@ class Scheduler:
         self.logger.info("Starting new workers after reset")
 
         # Start new workers
-        self.start_workers()
+        await self.start_workers()
 
         self.logger.info("All workers restarted successfully")
 

--- a/tt-media-server/scripts/download_sdxl_weights.py
+++ b/tt-media-server/scripts/download_sdxl_weights.py
@@ -60,14 +60,18 @@ def _download_model(repo_id: str, local_dir: str, label: str):
             local_dir_use_symlinks=False,
         )
 
-        print(f"✓ {label} model downloaded successfully to: {os.path.abspath(local_dir)}")
+        print(
+            f"✓ {label} model downloaded successfully to: {os.path.abspath(local_dir)}"
+        )
 
         # Verify download
         model_index_path = os.path.join(local_dir, "model_index.json")
         if os.path.exists(model_index_path):
             print(f"✓ {label} model download verified")
         else:
-            print(f"⚠ Warning: model_index.json not found, {label} download may be incomplete")
+            print(
+                f"⚠ Warning: model_index.json not found, {label} download may be incomplete"
+            )
 
     except Exception as e:
         print(f"✗ Error downloading {label} model: {e}")

--- a/tt-media-server/scripts/download_sdxl_weights.py
+++ b/tt-media-server/scripts/download_sdxl_weights.py
@@ -26,33 +26,51 @@ def install_huggingface_hub():
 
 
 def download_sdxl_model(local_dir="./models/stable-diffusion-xl-base-1.0"):
-    """Download SDXL model weights"""
+    """Download SDXL 1024 model weights"""
+    _download_model(
+        repo_id=SupportedModels.STABLE_DIFFUSION_XL_BASE.value,
+        local_dir=local_dir,
+        label="SDXL 1024",
+    )
+
+
+def download_sdxl_512_model(local_dir="./models/SDXL-512"):
+    """Download SDXL 512 model weights (hotshotco/SDXL-512)"""
+    _download_model(
+        repo_id=SupportedModels.STABLE_DIFFUSION_XL_512.value,
+        local_dir=local_dir,
+        label="SDXL 512",
+    )
+
+
+def _download_model(repo_id: str, local_dir: str, label: str):
+    """Download a HuggingFace model to a local directory."""
     try:
         from huggingface_hub import snapshot_download
 
         # Create local directory if it doesn't exist
         Path(local_dir).mkdir(parents=True, exist_ok=True)
 
-        print(f"Downloading SDXL model to: {os.path.abspath(local_dir)}")
+        print(f"Downloading {label} model ({repo_id}) to: {os.path.abspath(local_dir)}")
         print("This may take several minutes...")
 
         snapshot_download(
-            repo_id=SupportedModels.STABLE_DIFFUSION_XL_BASE.value,
+            repo_id=repo_id,
             local_dir=local_dir,
             local_dir_use_symlinks=False,
         )
 
-        print(f"✓ Model downloaded successfully to: {os.path.abspath(local_dir)}")
+        print(f"✓ {label} model downloaded successfully to: {os.path.abspath(local_dir)}")
 
         # Verify download
         model_index_path = os.path.join(local_dir, "model_index.json")
         if os.path.exists(model_index_path):
-            print("✓ Model download verified")
+            print(f"✓ {label} model download verified")
         else:
-            print("⚠ Warning: model_index.json not found, download may be incomplete")
+            print(f"⚠ Warning: model_index.json not found, {label} download may be incomplete")
 
     except Exception as e:
-        print(f"✗ Error downloading model: {e}")
+        print(f"✗ Error downloading {label} model: {e}")
         sys.exit(1)
 
 
@@ -101,42 +119,63 @@ def get_directory_size(path):
         return 0
 
 
-def main():
-    """Main function"""
-    print("SDXL Model Downloader")
-    print("=" * 50)
-
-    # Default download location
-    default_dir = "./models/stable-diffusion-xl-base-1.0"
-
-    # Allow custom directory via command line argument
-    if len(sys.argv) > 1:
-        local_dir = sys.argv[1]
-    else:
-        local_dir = default_dir
-
-    # Check if model already exists
+def _check_and_download(download_fn, local_dir, label):
+    """Check if model exists, prompt for re-download, then download."""
     if os.path.exists(local_dir) and os.path.exists(
         os.path.join(local_dir, "model_index.json")
     ):
         size_gb = get_directory_size(local_dir)
-        print(f"Model already exists at: {os.path.abspath(local_dir)}")
+        print(f"{label} model already exists at: {os.path.abspath(local_dir)}")
         print(f"Directory size: {size_gb:.2f} GB")
 
-        response = input("Do you want to re-download? (y/N): ").strip().lower()
+        response = input(f"Do you want to re-download {label}? (y/N): ").strip().lower()
         if response not in ["y", "yes"]:
-            print("Skipping download.")
+            print(f"Skipping {label} download.")
             return
 
-    # Install dependencies and download
-    install_huggingface_hub()
-    download_sdxl_model(local_dir)
+    download_fn(local_dir)
 
-    # Show final stats
     size_gb = get_directory_size(local_dir)
-    print("\nDownload completed!")
+    print(f"\n{label} download completed!")
     print(f"Location: {os.path.abspath(local_dir)}")
     print(f"Size: {size_gb:.2f} GB")
+
+
+def main():
+    """Main function.
+
+    Usage:
+        python download_sdxl_weights.py [--all | --512 | --1024] [directory]
+
+    By default downloads the 1024 model. Use --512 for the 512 model,
+    or --all to download both.
+    """
+    print("SDXL Model Downloader")
+    print("=" * 50)
+
+    install_huggingface_hub()
+
+    args = sys.argv[1:]
+    mode = "1024"
+    custom_dir = None
+
+    for arg in args:
+        if arg == "--all":
+            mode = "all"
+        elif arg == "--512":
+            mode = "512"
+        elif arg == "--1024":
+            mode = "1024"
+        else:
+            custom_dir = arg
+
+    if mode in ("1024", "all"):
+        local_dir = custom_dir or "./models/stable-diffusion-xl-base-1.0"
+        _check_and_download(download_sdxl_model, local_dir, "SDXL 1024")
+
+    if mode in ("512", "all"):
+        local_dir = custom_dir or "./models/SDXL-512"
+        _check_and_download(download_sdxl_512_model, local_dir, "SDXL 512")
 
 
 if __name__ == "__main__":

--- a/tt-media-server/static/sdxl/app.js
+++ b/tt-media-server/static/sdxl/app.js
@@ -52,18 +52,6 @@ $('random-seed').addEventListener('change', () => {
 // Initialize disabled state
 $('seed').disabled = $('random-seed').checked;
 
-// ─── Resolution Toggle ───────────────────────────────────────────────────────
-document.querySelectorAll('.resolution-option').forEach(btn => {
-    btn.addEventListener('click', () => {
-        document.querySelectorAll('.resolution-option').forEach(b => b.classList.remove('active'));
-        btn.classList.add('active');
-    });
-});
-
-// ─── Guidance Rescale Slider ──────────────────────────────────────────────────
-$('guidance-rescale').addEventListener('input', () => {
-    $('guidance-rescale-label').textContent = parseFloat($('guidance-rescale').value).toFixed(2);
-});
 
 // ─── Parameter Collection & Validation ───────────────────────────────────────
 function clearErrors() {
@@ -81,10 +69,6 @@ function collectParams() {
     const guidance = parseFloat($('guidance').value);
     const useRandomSeed = $('random-seed').checked;
     const seedVal = $('seed').value.trim();
-    const prompt2 = $('prompt-2').value.trim();
-    const negativePrompt2 = $('negative-prompt-2').value.trim();
-    const guidanceRescale = parseFloat($('guidance-rescale').value);
-
     let valid = true;
 
     if (!prompt) {
@@ -111,9 +95,6 @@ function collectParams() {
     };
 
     if (negativePrompt) body.negative_prompt = negativePrompt;
-    if (prompt2) body.prompt_2 = prompt2;
-    if (negativePrompt2) body.negative_prompt_2 = negativePrompt2;
-    if (guidanceRescale !== 0.0) body.guidance_rescale = guidanceRescale;
 
     if (!useRandomSeed && seedVal !== '') {
         const seed = parseInt(seedVal, 10);
@@ -161,9 +142,7 @@ async function generateImage() {
     }, 1000);
 
     try {
-        const resolution = document.querySelector('.resolution-option.active').dataset.resolution;
-        const url = resolution === '512' ? `${API_URL}?resolution=512` : API_URL;
-        const res = await fetch(url, {
+        const res = await fetch(API_URL, {
             method: 'POST',
             headers: HEADERS,
             body: JSON.stringify(params),
@@ -204,7 +183,7 @@ async function generateImage() {
             steps: params.num_inference_steps,
             guidance: params.guidance_scale,
             seed: params.seed != null ? params.seed : 'random',
-            resolution: `${resolution}×${resolution}`,
+            resolution: '512×512',
             elapsed: `${elapsed}s`,
         };
 

--- a/tt-media-server/static/sdxl/app.js
+++ b/tt-media-server/static/sdxl/app.js
@@ -135,6 +135,7 @@ async function generateImage() {
 
     isGenerating = true;
     $('generate-btn').disabled = true;
+    $('generate-btn').closest('.btn-3d').classList.add('is-disabled');
 
     // Show loading overlay
     $('image-placeholder').style.display = 'none';
@@ -206,6 +207,7 @@ async function generateImage() {
     } finally {
         isGenerating = false;
         $('generate-btn').disabled = false;
+        $('generate-btn').closest('.btn-3d').classList.remove('is-disabled');
     }
 }
 
@@ -214,7 +216,7 @@ function showGenerationError(msg) {
     $('image-placeholder').style.display = 'flex';
     const placeholderText = $('image-placeholder').querySelector('p');
     placeholderText.textContent = msg;
-    placeholderText.style.color = '#e53e3e';
+    placeholderText.style.color = '#F54E00';
 }
 
 function displayMetadata(gen) {
@@ -255,7 +257,9 @@ $('fullscreen-btn').addEventListener('click', () => {
 $('save-gallery-btn').addEventListener('click', async () => {
     if (!currentGeneration) return;
     const btn = $('save-gallery-btn');
+    const btnWrap = btn.closest('.btn-3d');
     btn.disabled = true;
+    if (btnWrap) btnWrap.classList.add('is-disabled');
     btn.textContent = 'Saving...';
     try {
         await saveToGallery(currentGeneration);
@@ -263,12 +267,14 @@ $('save-gallery-btn').addEventListener('click', async () => {
         setTimeout(() => {
             btn.textContent = 'Save to Gallery';
             btn.disabled = false;
+            if (btnWrap) btnWrap.classList.remove('is-disabled');
         }, 2000);
     } catch (e) {
         btn.textContent = 'Save Failed';
         setTimeout(() => {
             btn.textContent = 'Save to Gallery';
             btn.disabled = false;
+            if (btnWrap) btnWrap.classList.remove('is-disabled');
         }, 2000);
     }
 });
@@ -378,7 +384,7 @@ async function renderGallery() {
     try {
         items = await getAllGalleryItems();
     } catch (e) {
-        grid.innerHTML = '<p style="color:#e53e3e">Failed to load gallery.</p>';
+        grid.innerHTML = '<p style="color:#F54E00">Failed to load gallery.</p>';
         return;
     }
 

--- a/tt-media-server/static/sdxl/app.js
+++ b/tt-media-server/static/sdxl/app.js
@@ -52,6 +52,14 @@ $('random-seed').addEventListener('change', () => {
 // Initialize disabled state
 $('seed').disabled = $('random-seed').checked;
 
+// ─── Resolution Toggle ───────────────────────────────────────────────────────
+document.querySelectorAll('.resolution-option').forEach(btn => {
+    btn.addEventListener('click', () => {
+        document.querySelectorAll('.resolution-option').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+    });
+});
+
 // ─── Guidance Rescale Slider ──────────────────────────────────────────────────
 $('guidance-rescale').addEventListener('input', () => {
     $('guidance-rescale-label').textContent = parseFloat($('guidance-rescale').value).toFixed(2);
@@ -153,7 +161,9 @@ async function generateImage() {
     }, 1000);
 
     try {
-        const res = await fetch(API_URL, {
+        const resolution = document.querySelector('.resolution-option.active').dataset.resolution;
+        const url = resolution === '512' ? `${API_URL}?resolution=512` : API_URL;
+        const res = await fetch(url, {
             method: 'POST',
             headers: HEADERS,
             body: JSON.stringify(params),
@@ -194,6 +204,7 @@ async function generateImage() {
             steps: params.num_inference_steps,
             guidance: params.guidance_scale,
             seed: params.seed != null ? params.seed : 'random',
+            resolution: `${resolution}×${resolution}`,
             elapsed: `${elapsed}s`,
         };
 
@@ -224,6 +235,7 @@ function displayMetadata(gen) {
     $('meta-steps').textContent = gen.steps;
     $('meta-guidance').textContent = gen.guidance;
     $('meta-seed').textContent = gen.seed;
+    $('meta-resolution').textContent = gen.resolution;
     $('meta-time').textContent = gen.elapsed;
 }
 

--- a/tt-media-server/static/sdxl/app.js
+++ b/tt-media-server/static/sdxl/app.js
@@ -1,0 +1,511 @@
+// ─── Constants ───────────────────────────────────────────────────────────────
+const API_URL = '/v1/images/generations';
+const API_KEY = 'sdxl';
+const HEADERS = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${API_KEY}`,
+};
+const $ = (id) => document.getElementById(id);
+
+// ─── State ────────────────────────────────────────────────────────────────────
+let isGenerating = false;
+let currentGeneration = null; // { base64, prompt, negativePrompt, steps, guidance, seed, elapsed }
+let activeObjectURLs = [];
+let currentModalId = null;
+let db = null;
+
+// ─── XSS Safety ──────────────────────────────────────────────────────────────
+function escapeHtml(str) {
+    if (str == null) return '';
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+// ─── Tab Navigation ───────────────────────────────────────────────────────────
+document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+        const tab = btn.dataset.tab;
+
+        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+
+        document.querySelectorAll('.tab-content').forEach(s => s.style.display = 'none');
+        $(`tab-${tab}`).style.display = 'block';
+
+        if (tab === 'gallery') {
+            renderGallery();
+        }
+    });
+});
+
+// ─── Random Seed Toggle ───────────────────────────────────────────────────────
+$('random-seed').addEventListener('change', () => {
+    $('seed').disabled = $('random-seed').checked;
+    if ($('random-seed').checked) {
+        $('seed').value = '';
+    }
+});
+// Initialize disabled state
+$('seed').disabled = $('random-seed').checked;
+
+// ─── Guidance Rescale Slider ──────────────────────────────────────────────────
+$('guidance-rescale').addEventListener('input', () => {
+    $('guidance-rescale-label').textContent = parseFloat($('guidance-rescale').value).toFixed(2);
+});
+
+// ─── Parameter Collection & Validation ───────────────────────────────────────
+function clearErrors() {
+    ['prompt-error', 'steps-error', 'guidance-error'].forEach(id => {
+        $(id).textContent = '';
+    });
+}
+
+function collectParams() {
+    clearErrors();
+
+    const prompt = $('prompt').value.trim();
+    const negativePrompt = $('negative-prompt').value.trim();
+    const steps = parseInt($('steps').value, 10);
+    const guidance = parseFloat($('guidance').value);
+    const useRandomSeed = $('random-seed').checked;
+    const seedVal = $('seed').value.trim();
+    const prompt2 = $('prompt-2').value.trim();
+    const negativePrompt2 = $('negative-prompt-2').value.trim();
+    const guidanceRescale = parseFloat($('guidance-rescale').value);
+
+    let valid = true;
+
+    if (!prompt) {
+        $('prompt-error').textContent = 'Prompt is required.';
+        valid = false;
+    }
+
+    if (isNaN(steps) || steps < 12 || steps > 50) {
+        $('steps-error').textContent = 'Steps must be between 12 and 50.';
+        valid = false;
+    }
+
+    if (isNaN(guidance) || guidance < 1.0 || guidance > 20.0) {
+        $('guidance-error').textContent = 'Guidance scale must be between 1.0 and 20.0.';
+        valid = false;
+    }
+
+    if (!valid) return null;
+
+    const body = {
+        prompt,
+        num_inference_steps: steps,
+        guidance_scale: guidance,
+    };
+
+    if (negativePrompt) body.negative_prompt = negativePrompt;
+    if (prompt2) body.prompt_2 = prompt2;
+    if (negativePrompt2) body.negative_prompt_2 = negativePrompt2;
+    if (guidanceRescale !== 0.0) body.guidance_rescale = guidanceRescale;
+
+    if (!useRandomSeed && seedVal !== '') {
+        const seed = parseInt(seedVal, 10);
+        if (!isNaN(seed)) body.seed = seed;
+    }
+
+    return body;
+}
+
+// ─── Generate Image ────────────────────────────────────────────────────────────
+$('generate-btn').addEventListener('click', generateImage);
+
+document.addEventListener('keydown', (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+        const generateTab = $('tab-generate');
+        if (generateTab.style.display !== 'none') {
+            generateImage();
+        }
+    }
+});
+
+async function generateImage() {
+    if (isGenerating) return;
+
+    const params = collectParams();
+    if (!params) return;
+
+    isGenerating = true;
+    $('generate-btn').disabled = true;
+
+    // Show loading overlay
+    $('image-placeholder').style.display = 'none';
+    $('generated-image').style.display = 'none';
+    $('loading-overlay').style.display = 'flex';
+    $('image-actions').style.display = 'none';
+    $('metadata-section').style.display = 'none';
+
+    const startTime = Date.now();
+    const timerEl = $('loading-timer');
+    timerEl.textContent = '0s';
+    const timerInterval = setInterval(() => {
+        const elapsed = Math.floor((Date.now() - startTime) / 1000);
+        timerEl.textContent = `${elapsed}s`;
+    }, 1000);
+
+    try {
+        const res = await fetch(API_URL, {
+            method: 'POST',
+            headers: HEADERS,
+            body: JSON.stringify(params),
+        });
+
+        clearInterval(timerInterval);
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
+        if (!res.ok) {
+            let errMsg;
+            if (res.status === 401) {
+                errMsg = 'Invalid API key.';
+            } else if (res.status === 422) {
+                const err = await res.json().catch(() => ({}));
+                errMsg = `Invalid parameters: ${err.detail || JSON.stringify(err)}`;
+            } else if (res.status >= 500) {
+                errMsg = 'Server error. Please try again.';
+            } else {
+                errMsg = `Request failed (HTTP ${res.status}).`;
+            }
+            showGenerationError(errMsg);
+            return;
+        }
+
+        const data = await res.json();
+        const base64 = data.images[0];
+
+        const imgEl = $('generated-image');
+        imgEl.src = `data:image/jpeg;base64,${base64}`;
+        imgEl.style.display = 'block';
+        $('loading-overlay').style.display = 'none';
+
+        // Store current generation
+        currentGeneration = {
+            base64,
+            prompt: params.prompt,
+            negativePrompt: params.negative_prompt || '',
+            steps: params.num_inference_steps,
+            guidance: params.guidance_scale,
+            seed: params.seed != null ? params.seed : 'random',
+            elapsed: `${elapsed}s`,
+        };
+
+        displayMetadata(currentGeneration);
+        $('image-actions').style.display = 'flex';
+        $('metadata-section').style.display = 'block';
+
+    } catch (err) {
+        clearInterval(timerInterval);
+        showGenerationError('Could not reach server. Check your connection.');
+    } finally {
+        isGenerating = false;
+        $('generate-btn').disabled = false;
+    }
+}
+
+function showGenerationError(msg) {
+    $('loading-overlay').style.display = 'none';
+    $('image-placeholder').style.display = 'flex';
+    const placeholderText = $('image-placeholder').querySelector('p');
+    placeholderText.textContent = msg;
+    placeholderText.style.color = '#e53e3e';
+}
+
+function displayMetadata(gen) {
+    $('meta-prompt').textContent = gen.prompt;
+    $('meta-steps').textContent = gen.steps;
+    $('meta-guidance').textContent = gen.guidance;
+    $('meta-seed').textContent = gen.seed;
+    $('meta-time').textContent = gen.elapsed;
+}
+
+// ─── Download ─────────────────────────────────────────────────────────────────
+$('download-btn').addEventListener('click', () => downloadAsPng($('generated-image'), 'sdxl-output.png'));
+
+function downloadAsPng(imgEl, filename) {
+    const canvas = document.createElement('canvas');
+    canvas.width = imgEl.naturalWidth || imgEl.width;
+    canvas.height = imgEl.naturalHeight || imgEl.height;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(imgEl, 0, 0);
+    const url = canvas.toDataURL('image/png');
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+}
+
+// ─── Fullscreen ───────────────────────────────────────────────────────────────
+$('fullscreen-btn').addEventListener('click', () => {
+    const container = $('image-container');
+    if (container.requestFullscreen) {
+        container.requestFullscreen();
+    } else if (container.webkitRequestFullscreen) {
+        container.webkitRequestFullscreen();
+    }
+});
+
+// ─── Save to Gallery ──────────────────────────────────────────────────────────
+$('save-gallery-btn').addEventListener('click', async () => {
+    if (!currentGeneration) return;
+    const btn = $('save-gallery-btn');
+    btn.disabled = true;
+    btn.textContent = 'Saving...';
+    try {
+        await saveToGallery(currentGeneration);
+        btn.textContent = 'Saved!';
+        setTimeout(() => {
+            btn.textContent = 'Save to Gallery';
+            btn.disabled = false;
+        }, 2000);
+    } catch (e) {
+        btn.textContent = 'Save Failed';
+        setTimeout(() => {
+            btn.textContent = 'Save to Gallery';
+            btn.disabled = false;
+        }, 2000);
+    }
+});
+
+// ─── IndexedDB ────────────────────────────────────────────────────────────────
+const DB_NAME = 'sdxl-gallery';
+const DB_STORE = 'images';
+const DB_VERSION = 1;
+
+function openDB() {
+    return new Promise((resolve, reject) => {
+        if (db) { resolve(db); return; }
+        const req = indexedDB.open(DB_NAME, DB_VERSION);
+        req.onupgradeneeded = (e) => {
+            const d = e.target.result;
+            if (!d.objectStoreNames.contains(DB_STORE)) {
+                const store = d.createObjectStore(DB_STORE, { keyPath: 'id', autoIncrement: true });
+                store.createIndex('timestamp', 'timestamp', { unique: false });
+            }
+        };
+        req.onsuccess = (e) => { db = e.target.result; resolve(db); };
+        req.onerror = () => reject(req.error);
+    });
+}
+
+async function saveToGallery(gen) {
+    const d = await openDB();
+    const blob = base64ToBlob(gen.base64, 'image/jpeg');
+    return new Promise((resolve, reject) => {
+        const tx = d.transaction(DB_STORE, 'readwrite');
+        const store = tx.objectStore(DB_STORE);
+        const entry = {
+            blob,
+            prompt: gen.prompt,
+            negative_prompt: gen.negativePrompt,
+            steps: gen.steps,
+            guidance: gen.guidance,
+            seed: gen.seed,
+            elapsed: gen.elapsed,
+            timestamp: Date.now(),
+        };
+        const req = store.add(entry);
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+    });
+}
+
+function base64ToBlob(base64, mimeType) {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return new Blob([bytes], { type: mimeType });
+}
+
+async function getAllGalleryItems() {
+    const d = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = d.transaction(DB_STORE, 'readonly');
+        const store = tx.objectStore(DB_STORE);
+        const index = store.index('timestamp');
+        const results = [];
+        const req = index.openCursor(null, 'prev'); // newest first
+        req.onsuccess = (e) => {
+            const cursor = e.target.result;
+            if (cursor) {
+                results.push(cursor.value);
+                cursor.continue();
+            } else {
+                resolve(results);
+            }
+        };
+        req.onerror = () => reject(req.error);
+    });
+}
+
+async function getGalleryItem(id) {
+    const d = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = d.transaction(DB_STORE, 'readonly');
+        const req = tx.objectStore(DB_STORE).get(id);
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+    });
+}
+
+async function deleteGalleryItem(id) {
+    const d = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = d.transaction(DB_STORE, 'readwrite');
+        const req = tx.objectStore(DB_STORE).delete(id);
+        req.onsuccess = () => resolve();
+        req.onerror = () => reject(req.error);
+    });
+}
+
+// ─── Gallery Rendering ────────────────────────────────────────────────────────
+async function renderGallery() {
+    // Revoke previous object URLs to prevent memory leaks
+    activeObjectURLs.forEach(url => URL.revokeObjectURL(url));
+    activeObjectURLs = [];
+
+    const grid = $('gallery-grid');
+    const emptyEl = $('gallery-empty');
+    grid.innerHTML = '';
+
+    let items;
+    try {
+        items = await getAllGalleryItems();
+    } catch (e) {
+        grid.innerHTML = '<p style="color:#e53e3e">Failed to load gallery.</p>';
+        return;
+    }
+
+    if (items.length === 0) {
+        emptyEl.style.display = 'flex';
+        grid.style.display = 'none';
+    } else {
+        emptyEl.style.display = 'none';
+        grid.style.display = 'grid';
+
+        for (const item of items) {
+            const objUrl = URL.createObjectURL(item.blob);
+            activeObjectURLs.push(objUrl);
+
+            const card = document.createElement('div');
+            card.className = 'gallery-card';
+            card.addEventListener('click', () => openModal(item.id));
+
+            const thumb = document.createElement('img');
+            thumb.className = 'gallery-card-thumb';
+            thumb.src = objUrl;
+            thumb.alt = 'Gallery thumbnail';
+
+            const info = document.createElement('div');
+            info.className = 'gallery-card-info';
+
+            const promptEl = document.createElement('div');
+            promptEl.className = 'gallery-card-prompt';
+            promptEl.textContent = item.prompt;
+
+            const badge = document.createElement('div');
+            badge.className = 'gallery-card-badge';
+            badge.textContent = `${item.steps} steps · cfg ${item.guidance}`;
+
+            const ts = document.createElement('div');
+            ts.className = 'gallery-card-timestamp';
+            ts.textContent = new Date(item.timestamp).toLocaleString();
+
+            info.appendChild(promptEl);
+            info.appendChild(badge);
+            info.appendChild(ts);
+            card.appendChild(thumb);
+            card.appendChild(info);
+            grid.appendChild(card);
+        }
+    }
+
+    // Storage estimate
+    if (navigator.storage && navigator.storage.estimate) {
+        try {
+            const est = await navigator.storage.estimate();
+            const used = (est.usage / 1024 / 1024).toFixed(1);
+            const quota = (est.quota / 1024 / 1024 / 1024).toFixed(1);
+            $('storage-usage').textContent = `Storage: ${used} MB used of ${quota} GB`;
+        } catch (_) {}
+    }
+}
+
+// ─── Gallery Modal ────────────────────────────────────────────────────────────
+async function openModal(id) {
+    currentModalId = id;
+    let item;
+    try {
+        item = await getGalleryItem(id);
+    } catch (e) {
+        return;
+    }
+    if (!item) return;
+
+    const objUrl = URL.createObjectURL(item.blob);
+    activeObjectURLs.push(objUrl);
+
+    $('modal-image').src = objUrl;
+
+    const metaEl = $('modal-metadata');
+    const rows = [
+        ['Prompt', item.prompt],
+        ['Negative Prompt', item.negative_prompt || '—'],
+        ['Steps', item.steps],
+        ['Guidance Scale', item.guidance],
+        ['Seed', item.seed],
+        ['Generation Time', item.elapsed],
+        ['Saved', new Date(item.timestamp).toLocaleString()],
+    ];
+    metaEl.innerHTML = rows.map(([k, v]) =>
+        `<dt>${escapeHtml(k)}</dt><dd>${escapeHtml(String(v))}</dd>`
+    ).join('');
+
+    $('modal-overlay').style.display = 'flex';
+    document.body.style.overflow = 'hidden';
+}
+
+function closeModal() {
+    $('modal-overlay').style.display = 'none';
+    $('modal-image').src = '';
+    document.body.style.overflow = '';
+    currentModalId = null;
+}
+
+$('modal-close').addEventListener('click', closeModal);
+
+$('modal-overlay').addEventListener('click', (e) => {
+    if (e.target === $('modal-overlay')) closeModal();
+});
+
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && $('modal-overlay').style.display !== 'none') {
+        closeModal();
+    }
+});
+
+$('modal-download-btn').addEventListener('click', () => {
+    const imgEl = $('modal-image');
+    if (imgEl.src) downloadAsPng(imgEl, 'sdxl-gallery.png');
+});
+
+$('modal-delete-btn').addEventListener('click', async () => {
+    if (currentModalId == null) return;
+    if (!confirm('Delete this image from your gallery?')) return;
+    try {
+        await deleteGalleryItem(currentModalId);
+        closeModal();
+        renderGallery();
+    } catch (e) {
+        alert('Failed to delete image.');
+    }
+});
+
+// ─── Init ─────────────────────────────────────────────────────────────────────
+openDB().catch(e => console.warn('IndexedDB unavailable:', e));

--- a/tt-media-server/static/sdxl/index.html
+++ b/tt-media-server/static/sdxl/index.html
@@ -82,31 +82,9 @@
 
                             <div class="form-group">
                                 <label>Resolution</label>
-                                <div class="resolution-toggle" id="resolution-toggle">
-                                    <button type="button" class="resolution-option active" data-resolution="1024">1024×1024</button>
-                                    <button type="button" class="resolution-option" data-resolution="512">512×512</button>
-                                </div>
+                                <div class="resolution-display">512×512</div>
                             </div>
 
-                            <details class="advanced-section">
-                                <summary>Advanced Options</summary>
-                                <div class="advanced-content">
-                                    <div class="form-group">
-                                        <label for="prompt-2">Prompt 2 (Refiner)</label>
-                                        <textarea id="prompt-2" rows="2" placeholder="Additional prompt for refiner..."></textarea>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="negative-prompt-2">Negative Prompt 2 (Refiner)</label>
-                                        <textarea id="negative-prompt-2" rows="2" placeholder="Additional negative prompt for refiner..."></textarea>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="guidance-rescale">
-                                            Guidance Rescale: <span id="guidance-rescale-label">0.0</span>
-                                        </label>
-                                        <input type="range" id="guidance-rescale" min="0.0" max="1.0" step="0.05" value="0.0">
-                                    </div>
-                                </div>
-                            </details>
 
                             <div class="btn-3d btn-3d-primary btn-3d-full">
                                 <button id="generate-btn" class="btn-face">Generate Image</button>

--- a/tt-media-server/static/sdxl/index.html
+++ b/tt-media-server/static/sdxl/index.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SDXL Image Generation</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>SDXL Image Generation</h1>
+            <p>High-quality AI image generation powered by Stable Diffusion XL</p>
+        </div>
+
+        <div class="app-layout">
+            <!-- Sidebar -->
+            <aside class="sidebar">
+                <button class="tab-btn active" data-tab="generate">Generate Image</button>
+                <button class="tab-btn" data-tab="gallery">My Gallery</button>
+            </aside>
+
+            <!-- Main Content -->
+            <main class="main-content">
+                <!-- Generate Tab -->
+                <section id="tab-generate" class="tab-content active">
+                    <div class="generate-layout">
+                        <!-- Params Panel -->
+                        <div class="params-panel">
+                            <h2>Parameters</h2>
+
+                            <div class="form-group">
+                                <label for="prompt">Prompt <span class="required">*</span></label>
+                                <textarea id="prompt" rows="4" placeholder="A majestic mountain landscape at sunset, photorealistic, 8k..."></textarea>
+                                <div class="field-error" id="prompt-error"></div>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="negative-prompt">Negative Prompt</label>
+                                <textarea id="negative-prompt" rows="3" placeholder="blurry, low quality, distorted..."></textarea>
+                            </div>
+
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="steps">Steps</label>
+                                    <input type="number" id="steps" value="50" min="12" max="50">
+                                    <div class="field-error" id="steps-error"></div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="guidance">Guidance Scale</label>
+                                    <input type="number" id="guidance" value="7.5" min="1.0" max="20.0" step="0.5">
+                                    <div class="field-error" id="guidance-error"></div>
+                                </div>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="seed">Seed</label>
+                                <div class="seed-row">
+                                    <input type="number" id="seed" placeholder="e.g. 42" min="0">
+                                    <label class="checkbox-label">
+                                        <input type="checkbox" id="random-seed" checked>
+                                        Random
+                                    </label>
+                                </div>
+                            </div>
+
+                            <details class="advanced-section">
+                                <summary>Advanced Options</summary>
+                                <div class="advanced-content">
+                                    <div class="form-group">
+                                        <label for="prompt-2">Prompt 2 (Refiner)</label>
+                                        <textarea id="prompt-2" rows="2" placeholder="Additional prompt for refiner..."></textarea>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="negative-prompt-2">Negative Prompt 2 (Refiner)</label>
+                                        <textarea id="negative-prompt-2" rows="2" placeholder="Additional negative prompt for refiner..."></textarea>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="guidance-rescale">
+                                            Guidance Rescale: <span id="guidance-rescale-label">0.0</span>
+                                        </label>
+                                        <input type="range" id="guidance-rescale" min="0.0" max="1.0" step="0.05" value="0.0">
+                                    </div>
+                                </div>
+                            </details>
+
+                            <button id="generate-btn" class="btn-primary">Generate Image</button>
+                        </div>
+
+                        <!-- Canvas Panel -->
+                        <div class="canvas-panel">
+                            <div class="image-container" id="image-container">
+                                <div class="image-placeholder" id="image-placeholder">
+                                    <div class="placeholder-text">
+                                        <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                                            <rect x="3" y="3" width="18" height="18" rx="2"/>
+                                            <circle cx="8.5" cy="8.5" r="1.5"/>
+                                            <path d="M21 15l-5-5L5 21"/>
+                                        </svg>
+                                        <p>Your generated image will appear here</p>
+                                    </div>
+                                </div>
+                                <img id="generated-image" alt="Generated image" style="display:none;">
+                                <div class="loading-overlay" id="loading-overlay" style="display:none;">
+                                    <div class="spinner"></div>
+                                    <div class="loading-text">Generating image...</div>
+                                    <div class="loading-timer" id="loading-timer">0s</div>
+                                </div>
+                            </div>
+
+                            <div class="image-actions" id="image-actions" style="display:none;">
+                                <button id="download-btn" class="btn-secondary">Download PNG</button>
+                                <button id="fullscreen-btn" class="btn-secondary">Fullscreen</button>
+                                <button id="save-gallery-btn" class="btn-secondary">Save to Gallery</button>
+                            </div>
+
+                            <div class="metadata-section" id="metadata-section" style="display:none;">
+                                <h3>Generation Details</h3>
+                                <dl class="metadata-list">
+                                    <dt>Prompt</dt><dd id="meta-prompt"></dd>
+                                    <dt>Steps</dt><dd id="meta-steps"></dd>
+                                    <dt>Guidance Scale</dt><dd id="meta-guidance"></dd>
+                                    <dt>Seed</dt><dd id="meta-seed"></dd>
+                                    <dt>Generation Time</dt><dd id="meta-time"></dd>
+                                </dl>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Gallery Tab -->
+                <section id="tab-gallery" class="tab-content" style="display:none;">
+                    <div class="gallery-header">
+                        <h2>My Gallery</h2>
+                        <div class="storage-usage" id="storage-usage"></div>
+                    </div>
+                    <div class="gallery-grid" id="gallery-grid"></div>
+                    <div class="empty-state" id="gallery-empty" style="display:none;">
+                        <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                            <rect x="3" y="3" width="18" height="18" rx="2"/>
+                            <circle cx="8.5" cy="8.5" r="1.5"/>
+                            <path d="M21 15l-5-5L5 21"/>
+                        </svg>
+                        <p>No images saved yet.</p>
+                        <p class="empty-hint">Generate an image and click "Save to Gallery" to get started.</p>
+                    </div>
+                </section>
+            </main>
+        </div>
+    </div>
+
+    <!-- Modal -->
+    <div class="modal-overlay" id="modal-overlay" style="display:none;">
+        <div class="modal">
+            <button class="modal-close" id="modal-close">&times;</button>
+            <div class="modal-body">
+                <img id="modal-image" alt="Full size image">
+                <div class="modal-meta">
+                    <h3>Generation Details</h3>
+                    <dl class="metadata-list" id="modal-metadata"></dl>
+                    <div class="modal-actions">
+                        <button id="modal-download-btn" class="btn-secondary">Download PNG</button>
+                        <button id="modal-delete-btn" class="btn-danger">Delete</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/tt-media-server/static/sdxl/index.html
+++ b/tt-media-server/static/sdxl/index.html
@@ -4,11 +4,27 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SDXL Image Generation</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <!-- SVG noise filter for background texture -->
+    <svg style="position:absolute;width:0;height:0" aria-hidden="true">
+        <filter id="noise">
+            <feTurbulence type="fractalNoise" baseFrequency="0.65" numOctaves="3" stitchTiles="stitch"/>
+            <feColorMatrix type="saturate" values="0"/>
+        </filter>
+    </svg>
+
     <div class="container">
         <div class="header">
+            <div class="window-dots">
+                <span class="dot dot-red"></span>
+                <span class="dot dot-yellow"></span>
+                <span class="dot dot-green"></span>
+            </div>
             <h1>SDXL Image Generation</h1>
             <p>High-quality AI image generation powered by Stable Diffusion XL</p>
         </div>
@@ -84,7 +100,9 @@
                                 </div>
                             </details>
 
-                            <button id="generate-btn" class="btn-primary">Generate Image</button>
+                            <div class="btn-3d btn-3d-primary btn-3d-full">
+                                <button id="generate-btn" class="btn-face">Generate Image</button>
+                            </div>
                         </div>
 
                         <!-- Canvas Panel -->
@@ -109,9 +127,15 @@
                             </div>
 
                             <div class="image-actions" id="image-actions" style="display:none;">
-                                <button id="download-btn" class="btn-secondary">Download PNG</button>
-                                <button id="fullscreen-btn" class="btn-secondary">Fullscreen</button>
-                                <button id="save-gallery-btn" class="btn-secondary">Save to Gallery</button>
+                                <div class="btn-3d btn-3d-secondary">
+                                    <button id="download-btn" class="btn-face">Download PNG</button>
+                                </div>
+                                <div class="btn-3d btn-3d-secondary">
+                                    <button id="fullscreen-btn" class="btn-face">Fullscreen</button>
+                                </div>
+                                <div class="btn-3d btn-3d-secondary">
+                                    <button id="save-gallery-btn" class="btn-face">Save to Gallery</button>
+                                </div>
                             </div>
 
                             <div class="metadata-section" id="metadata-section" style="display:none;">
@@ -159,8 +183,12 @@
                     <h3>Generation Details</h3>
                     <dl class="metadata-list" id="modal-metadata"></dl>
                     <div class="modal-actions">
-                        <button id="modal-download-btn" class="btn-secondary">Download PNG</button>
-                        <button id="modal-delete-btn" class="btn-danger">Delete</button>
+                        <div class="btn-3d btn-3d-secondary">
+                            <button id="modal-download-btn" class="btn-face">Download PNG</button>
+                        </div>
+                        <div class="btn-3d btn-3d-danger">
+                            <button id="modal-delete-btn" class="btn-face btn-face-danger">Delete</button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/tt-media-server/static/sdxl/index.html
+++ b/tt-media-server/static/sdxl/index.html
@@ -80,6 +80,14 @@
                                 </div>
                             </div>
 
+                            <div class="form-group">
+                                <label>Resolution</label>
+                                <div class="resolution-toggle" id="resolution-toggle">
+                                    <button type="button" class="resolution-option active" data-resolution="1024">1024×1024</button>
+                                    <button type="button" class="resolution-option" data-resolution="512">512×512</button>
+                                </div>
+                            </div>
+
                             <details class="advanced-section">
                                 <summary>Advanced Options</summary>
                                 <div class="advanced-content">
@@ -145,6 +153,7 @@
                                     <dt>Steps</dt><dd id="meta-steps"></dd>
                                     <dt>Guidance Scale</dt><dd id="meta-guidance"></dd>
                                     <dt>Seed</dt><dd id="meta-seed"></dd>
+                                    <dt>Resolution</dt><dd id="meta-resolution"></dd>
                                     <dt>Generation Time</dt><dd id="meta-time"></dd>
                                 </dl>
                             </div>

--- a/tt-media-server/static/sdxl/styles.css
+++ b/tt-media-server/static/sdxl/styles.css
@@ -343,40 +343,15 @@ body::before {
 }
 
 /* ─── Resolution Toggle ─────────────────────────────────────────────────── */
-.resolution-toggle {
-    display: flex;
+.resolution-display {
+    padding: 8px 12px;
     border: 1px solid var(--border-primary);
     border-radius: 6px;
-    overflow: hidden;
-    background: var(--bg-primary);
-}
-
-.resolution-option {
-    flex: 1;
-    padding: 8px 12px;
-    border: none;
     background: var(--bg-primary);
     color: var(--text-secondary);
     font-size: 13px;
     font-weight: 600;
-    font-family: inherit;
-    cursor: pointer;
-    transition: all 0.15s ease;
     text-align: center;
-}
-
-.resolution-option:first-child {
-    border-right: 1px solid var(--border-primary);
-}
-
-.resolution-option:hover:not(.active) {
-    background: var(--accent-primary);
-    color: var(--text-primary);
-}
-
-.resolution-option.active {
-    background: var(--brand-red);
-    color: white;
 }
 
 /* ─── Advanced Section ───────────────────────────────────────────────────── */

--- a/tt-media-server/static/sdxl/styles.css
+++ b/tt-media-server/static/sdxl/styles.css
@@ -1,0 +1,669 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Arial', sans-serif;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    min-height: 100vh;
+    padding: 20px;
+}
+
+.container {
+    max-width: 1400px;
+    margin: 0 auto;
+    background: white;
+    border-radius: 15px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+}
+
+/* Header */
+.header {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    padding: 30px;
+    text-align: center;
+}
+
+.header h1 {
+    font-size: 2.5em;
+    margin-bottom: 10px;
+}
+
+.header p {
+    font-size: 1.2em;
+    opacity: 0.9;
+}
+
+/* App Layout: sidebar + content */
+.app-layout {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    min-height: calc(100vh - 180px);
+}
+
+.sidebar {
+    background: #f8f9fa;
+    border-right: 1px solid #e9ecef;
+    padding: 20px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.tab-btn {
+    display: block;
+    width: 100%;
+    padding: 14px 20px;
+    background: none;
+    border: none;
+    text-align: left;
+    font-size: 0.95em;
+    cursor: pointer;
+    color: #555;
+    transition: all 0.2s ease;
+    border-left: 3px solid transparent;
+}
+
+.tab-btn:hover {
+    background: #e9ecef;
+    color: #333;
+}
+
+.tab-btn.active {
+    background: white;
+    color: #667eea;
+    font-weight: bold;
+    border-left-color: #667eea;
+}
+
+.main-content {
+    padding: 30px;
+    overflow-y: auto;
+}
+
+/* Generate Tab Layout */
+.generate-layout {
+    display: grid;
+    grid-template-columns: 380px 1fr;
+    gap: 30px;
+    align-items: start;
+}
+
+/* Params Panel */
+.params-panel {
+    background: #f8f9fa;
+    border-radius: 15px;
+    padding: 24px;
+}
+
+.params-panel h2 {
+    margin-bottom: 20px;
+    color: #333;
+    font-size: 1.2em;
+}
+
+.form-group {
+    margin-bottom: 18px;
+}
+
+.form-group label {
+    display: block;
+    font-size: 0.9em;
+    font-weight: bold;
+    color: #444;
+    margin-bottom: 6px;
+}
+
+.required {
+    color: #e53e3e;
+}
+
+.form-group textarea,
+.form-group input[type="number"],
+.form-group input[type="text"] {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    font-size: 0.9em;
+    transition: border-color 0.2s;
+    font-family: inherit;
+    resize: vertical;
+}
+
+.form-group textarea:focus,
+.form-group input:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
+}
+
+.form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+.seed-row {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+.seed-row input[type="number"] {
+    flex: 1;
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9em;
+    color: #555;
+    cursor: pointer;
+    white-space: nowrap;
+    font-weight: normal;
+}
+
+.checkbox-label input[type="checkbox"] {
+    width: auto;
+    cursor: pointer;
+}
+
+.field-error {
+    color: #e53e3e;
+    font-size: 0.8em;
+    margin-top: 4px;
+    min-height: 16px;
+}
+
+/* Advanced Section */
+.advanced-section {
+    margin-bottom: 20px;
+    border: 1px solid #e9ecef;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.advanced-section summary {
+    padding: 10px 14px;
+    cursor: pointer;
+    font-size: 0.9em;
+    color: #667eea;
+    font-weight: bold;
+    background: #f0f2ff;
+    user-select: none;
+}
+
+.advanced-section summary:hover {
+    background: #e8eaff;
+}
+
+.advanced-content {
+    padding: 16px;
+    background: white;
+}
+
+.advanced-content .form-group:last-child {
+    margin-bottom: 0;
+}
+
+input[type="range"] {
+    width: 100%;
+    cursor: pointer;
+    accent-color: #667eea;
+}
+
+/* Buttons */
+.btn-primary {
+    width: 100%;
+    padding: 14px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    border-radius: 25px;
+    font-size: 1em;
+    font-weight: bold;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.btn-primary:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(102, 126, 234, 0.4);
+}
+
+.btn-primary:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.btn-secondary {
+    padding: 10px 20px;
+    background: #667eea;
+    color: white;
+    border: none;
+    border-radius: 25px;
+    font-size: 0.9em;
+    font-weight: bold;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.btn-secondary:hover {
+    background: #5a67d8;
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px rgba(102, 126, 234, 0.4);
+}
+
+.btn-danger {
+    padding: 10px 20px;
+    background: #e53e3e;
+    color: white;
+    border: none;
+    border-radius: 25px;
+    font-size: 0.9em;
+    font-weight: bold;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.btn-danger:hover {
+    background: #c53030;
+    transform: translateY(-2px);
+}
+
+/* Canvas Panel */
+.canvas-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.image-container {
+    position: relative;
+    width: 100%;
+    max-width: 1024px;
+    aspect-ratio: 1 / 1;
+    border: 2px solid #e9ecef;
+    border-radius: 15px;
+    overflow: hidden;
+    background: #f8f9fa;
+}
+
+.image-placeholder {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #aaa;
+}
+
+.placeholder-text {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+}
+
+.placeholder-text p {
+    font-size: 1em;
+    color: #aaa;
+}
+
+.image-container img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    display: block;
+}
+
+/* Fullscreen */
+.image-container:fullscreen {
+    background: black;
+    max-width: unset;
+    border-radius: 0;
+}
+
+.image-container:fullscreen img {
+    object-fit: contain;
+}
+
+/* Loading Overlay */
+.loading-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    color: white;
+    border-radius: 13px;
+}
+
+.spinner {
+    border: 4px solid rgba(255, 255, 255, 0.3);
+    border-radius: 50%;
+    border-top: 4px solid white;
+    width: 48px;
+    height: 48px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.loading-text {
+    font-size: 1.1em;
+    font-weight: bold;
+}
+
+.loading-timer {
+    font-size: 1.5em;
+    font-weight: bold;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+/* Image Actions */
+.image-actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+/* Metadata Section */
+.metadata-section {
+    background: #f8f9fa;
+    border-radius: 10px;
+    padding: 20px;
+}
+
+.metadata-section h3 {
+    margin-bottom: 12px;
+    color: #333;
+    font-size: 1em;
+}
+
+.metadata-list {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 8px 16px;
+}
+
+.metadata-list dt {
+    font-weight: bold;
+    color: #555;
+    font-size: 0.9em;
+    white-space: nowrap;
+}
+
+.metadata-list dd {
+    color: #333;
+    font-size: 0.9em;
+    word-break: break-word;
+}
+
+/* Gallery */
+.gallery-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.gallery-header h2 {
+    color: #333;
+}
+
+.storage-usage {
+    font-size: 0.85em;
+    color: #888;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 20px;
+}
+
+.gallery-card {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    border: 1px solid #e9ecef;
+}
+
+.gallery-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.gallery-card-thumb {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+    display: block;
+    background: #f8f9fa;
+}
+
+.gallery-card-info {
+    padding: 12px;
+}
+
+.gallery-card-prompt {
+    font-size: 0.85em;
+    color: #333;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    margin-bottom: 8px;
+    line-height: 1.4;
+}
+
+.gallery-card-badge {
+    font-size: 0.75em;
+    color: #888;
+    background: #f0f2ff;
+    border-radius: 12px;
+    padding: 3px 10px;
+    display: inline-block;
+    margin-bottom: 6px;
+}
+
+.gallery-card-timestamp {
+    font-size: 0.75em;
+    color: #aaa;
+}
+
+/* Empty State */
+.empty-state {
+    text-align: center;
+    padding: 60px 20px;
+    color: #aaa;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+}
+
+.empty-state p {
+    font-size: 1.1em;
+}
+
+.empty-hint {
+    font-size: 0.9em !important;
+    color: #bbb;
+}
+
+/* Modal */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.75);
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+}
+
+.modal {
+    position: relative;
+    background: white;
+    border-radius: 15px;
+    max-width: 960px;
+    width: 100%;
+    max-height: 90vh;
+    overflow-y: auto;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+}
+
+.modal-close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    background: rgba(0, 0, 0, 0.5);
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    font-size: 1.2em;
+    cursor: pointer;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s;
+}
+
+.modal-close:hover {
+    background: rgba(0, 0, 0, 0.7);
+}
+
+.modal-body {
+    display: grid;
+    grid-template-columns: 1fr 300px;
+}
+
+.modal-body img {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    object-fit: contain;
+    border-radius: 15px 0 0 15px;
+    background: #111;
+    display: block;
+}
+
+.modal-meta {
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.modal-meta h3 {
+    color: #333;
+    font-size: 1em;
+}
+
+.modal-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: auto;
+}
+
+.modal-actions .btn-secondary,
+.modal-actions .btn-danger {
+    width: 100%;
+    text-align: center;
+}
+
+/* Responsive: stack at 1024px */
+@media (max-width: 1024px) {
+    .generate-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .params-panel {
+        order: 2;
+    }
+
+    .canvas-panel {
+        order: 1;
+    }
+}
+
+/* Responsive: sidebar becomes top bar at 768px */
+@media (max-width: 768px) {
+    .app-layout {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto 1fr;
+    }
+
+    .sidebar {
+        flex-direction: row;
+        border-right: none;
+        border-bottom: 1px solid #e9ecef;
+        padding: 0;
+    }
+
+    .tab-btn {
+        border-left: none;
+        border-bottom: 3px solid transparent;
+        padding: 14px 20px;
+        text-align: center;
+        flex: 1;
+    }
+
+    .tab-btn.active {
+        border-bottom-color: #667eea;
+        border-left-color: transparent;
+    }
+
+    .modal-body {
+        grid-template-columns: 1fr;
+    }
+
+    .modal-body img {
+        border-radius: 15px 15px 0 0;
+        aspect-ratio: 1 / 1;
+    }
+
+    .header h1 {
+        font-size: 1.8em;
+    }
+}
+
+@media (max-width: 480px) {
+    body {
+        padding: 10px;
+    }
+
+    .main-content {
+        padding: 16px;
+    }
+}

--- a/tt-media-server/static/sdxl/styles.css
+++ b/tt-media-server/static/sdxl/styles.css
@@ -342,6 +342,43 @@ body::before {
     min-height: 16px;
 }
 
+/* ─── Resolution Toggle ─────────────────────────────────────────────────── */
+.resolution-toggle {
+    display: flex;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--bg-primary);
+}
+
+.resolution-option {
+    flex: 1;
+    padding: 8px 12px;
+    border: none;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    font-size: 13px;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    text-align: center;
+}
+
+.resolution-option:first-child {
+    border-right: 1px solid var(--border-primary);
+}
+
+.resolution-option:hover:not(.active) {
+    background: var(--accent-primary);
+    color: var(--text-primary);
+}
+
+.resolution-option.active {
+    background: var(--brand-red);
+    color: white;
+}
+
 /* ─── Advanced Section ───────────────────────────────────────────────────── */
 .advanced-section {
     margin-bottom: 20px;

--- a/tt-media-server/static/sdxl/styles.css
+++ b/tt-media-server/static/sdxl/styles.css
@@ -47,7 +47,7 @@
 
 body {
     font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-    background: var(--bg-secondary);
+    background: #E8DCC8;
     min-height: 100vh;
     padding: 20px;
     color: var(--text-primary);
@@ -215,6 +215,7 @@ body::before {
     border-radius: 8px;
     border: 1px solid var(--border-primary);
     padding: 20px;
+    box-shadow: var(--shadow-xl);
 }
 
 .params-panel h2 {
@@ -303,8 +304,8 @@ body::before {
 }
 
 .checkbox-label input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
+    width: 16px;
+    height: 16px;
     border: 2px solid var(--text-muted);
     border-radius: 3px;
     appearance: none;
@@ -324,10 +325,10 @@ body::before {
 .checkbox-label input[type="checkbox"]:checked::after {
     content: '';
     position: absolute;
-    left: 4px;
-    top: 1px;
-    width: 6px;
-    height: 10px;
+    left: 3px;
+    top: 0px;
+    width: 5px;
+    height: 9px;
     border: solid white;
     border-width: 0 2px 2px 0;
     transform: rotate(45deg);
@@ -348,6 +349,7 @@ body::before {
     border-radius: 6px;
     overflow: hidden;
     background: var(--accent-primary);
+    box-shadow: var(--shadow-md);
 }
 
 .advanced-section summary {
@@ -496,7 +498,7 @@ input[type="range"] {
     border-radius: 8px;
     overflow: hidden;
     background: var(--bg-tertiary);
-    box-shadow: var(--shadow-md);
+    box-shadow: var(--shadow-xl);
 }
 
 .image-placeholder {
@@ -596,6 +598,7 @@ input[type="range"] {
     border-radius: 8px;
     border: 1px solid var(--border-primary);
     padding: 16px;
+    box-shadow: var(--shadow-lg);
 }
 
 .metadata-section h3 {
@@ -661,7 +664,7 @@ input[type="range"] {
     overflow: hidden;
     cursor: pointer;
     transition: all 0.2s ease;
-    box-shadow: var(--shadow-sm);
+    box-shadow: var(--shadow-lg);
 }
 
 .gallery-card:hover {

--- a/tt-media-server/static/sdxl/styles.css
+++ b/tt-media-server/static/sdxl/styles.css
@@ -1,3 +1,44 @@
+/* ─── PostHog-Inspired Design System ──────────────────────────────────────── */
+
+:root {
+    /* Backgrounds */
+    --bg-primary: #FDFDF8;
+    --bg-secondary: #EEEFE9;
+    --bg-tertiary: #E5E7E0;
+
+    /* Accents */
+    --accent-primary: #E5E7E0;
+    --accent-secondary: #D2D3CC;
+
+    /* Text */
+    --text-primary: #4D4F46;
+    --text-secondary: #65675E;
+    --text-muted: #9EA096;
+
+    /* Borders */
+    --border-primary: #BFC1B7;
+    --border-input: #D2D3CC;
+
+    /* Brand */
+    --brand-orange: #EB9D2A;
+    --brand-yellow: #F7A501;
+    --brand-red: #F54E00;
+    --brand-blue: #2F80FA;
+    --brand-green: #6AA84F;
+
+    /* Button */
+    --btn-shadow: #CD8407;
+    --btn-border: #B17816;
+    --btn-face: #EB9D2A;
+
+    /* Shadows */
+    --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+    --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -2px rgba(0,0,0,0.07);
+    --shadow-lg: 0 10px 15px -3px rgba(0,0,0,0.08), 0 4px 6px -4px rgba(0,0,0,0.08);
+    --shadow-xl: 0 20px 25px -5px rgba(0,0,0,0.1), 0 8px 10px -6px rgba(0,0,0,0.1);
+    --shadow-2xl: 0 25px 50px -12px rgba(0,0,0,0.2);
+}
+
 * {
     margin: 0;
     padding: 0;
@@ -5,141 +46,233 @@
 }
 
 body {
-    font-family: 'Arial', sans-serif;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    background: var(--bg-secondary);
     min-height: 100vh;
     padding: 20px;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: auto;
+    font-variant-ligatures: none;
 }
 
+/* ─── Noise Texture Overlay ──────────────────────────────────────────────── */
+body::before {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 10000;
+    opacity: 0.028;
+    filter: url(#noise);
+    mix-blend-mode: multiply;
+}
+
+/* ─── Custom Scrollbar ───────────────────────────────────────────────────── */
+::-webkit-scrollbar {
+    width: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    background: rgba(77, 79, 70, 0.2);
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: rgba(77, 79, 70, 0.35);
+}
+
+/* ─── Container (Browser Window) ─────────────────────────────────────────── */
 .container {
     max-width: 1400px;
     margin: 0 auto;
-    background: white;
-    border-radius: 15px;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+    background: var(--bg-primary);
+    border-radius: 8px;
+    border: 1px solid var(--border-primary);
+    box-shadow: var(--shadow-2xl);
     overflow: hidden;
 }
 
-/* Header */
+/* ─── Header (Window Title Bar) ──────────────────────────────────────────── */
 .header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    padding: 30px;
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    padding: 16px 24px 20px;
     text-align: center;
+    border-bottom: 1px solid var(--border-primary);
+    position: relative;
 }
 
 .header h1 {
-    font-size: 2.5em;
-    margin-bottom: 10px;
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin-bottom: 6px;
+    letter-spacing: -0.015em;
+    color: var(--text-primary);
 }
 
 .header p {
-    font-size: 1.2em;
-    opacity: 0.9;
+    font-size: 0.95em;
+    color: var(--text-secondary);
+    opacity: 1;
 }
 
-/* App Layout: sidebar + content */
+/* Window Traffic Light Dots */
+.window-dots {
+    position: absolute;
+    left: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    gap: 7px;
+}
+
+.dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 1px solid rgba(0,0,0,0.08);
+}
+
+.dot-red { background: #F54E00; }
+.dot-yellow { background: #F7A501; }
+.dot-green { background: #6AA84F; }
+
+/* ─── App Layout: sidebar + content ──────────────────────────────────────── */
 .app-layout {
     display: grid;
     grid-template-columns: 200px 1fr;
     min-height: calc(100vh - 180px);
 }
 
+/* ─── Sidebar ────────────────────────────────────────────────────────────── */
 .sidebar {
-    background: #f8f9fa;
-    border-right: 1px solid #e9ecef;
-    padding: 20px 0;
+    background: var(--bg-secondary);
+    border-right: 1px solid var(--border-primary);
+    padding: 12px 0;
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 2px;
 }
 
 .tab-btn {
     display: block;
     width: 100%;
-    padding: 14px 20px;
+    padding: 10px 16px;
     background: none;
     border: none;
     text-align: left;
-    font-size: 0.95em;
+    font-size: 14px;
+    font-family: inherit;
     cursor: pointer;
-    color: #555;
-    transition: all 0.2s ease;
+    color: var(--text-secondary);
+    transition: all 0.15s ease;
     border-left: 3px solid transparent;
+    position: relative;
 }
 
 .tab-btn:hover {
-    background: #e9ecef;
-    color: #333;
+    background: var(--accent-primary);
+    color: var(--text-primary);
+    transform: translateY(-1px);
+}
+
+.tab-btn:active {
+    transform: translateY(0.5px) scale(0.99);
 }
 
 .tab-btn.active {
-    background: white;
-    color: #667eea;
-    font-weight: bold;
-    border-left-color: #667eea;
+    background: var(--bg-primary);
+    color: var(--brand-red);
+    font-weight: 600;
+    border-left-color: var(--brand-red);
 }
 
+/* ─── Main Content ───────────────────────────────────────────────────────── */
 .main-content {
-    padding: 30px;
+    padding: 24px;
     overflow-y: auto;
 }
 
-/* Generate Tab Layout */
+/* ─── Generate Tab Layout ────────────────────────────────────────────────── */
 .generate-layout {
     display: grid;
     grid-template-columns: 380px 1fr;
-    gap: 30px;
+    gap: 24px;
     align-items: start;
 }
 
-/* Params Panel */
+/* ─── Params Panel (Sub-Window) ──────────────────────────────────────────── */
 .params-panel {
-    background: #f8f9fa;
-    border-radius: 15px;
-    padding: 24px;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    border: 1px solid var(--border-primary);
+    padding: 20px;
 }
 
 .params-panel h2 {
-    margin-bottom: 20px;
-    color: #333;
-    font-size: 1.2em;
+    margin-bottom: 16px;
+    color: var(--text-primary);
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: -0.015em;
 }
 
+/* ─── Form Elements ──────────────────────────────────────────────────────── */
 .form-group {
-    margin-bottom: 18px;
+    margin-bottom: 16px;
 }
 
 .form-group label {
     display: block;
-    font-size: 0.9em;
-    font-weight: bold;
-    color: #444;
-    margin-bottom: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: 4px;
 }
 
 .required {
-    color: #e53e3e;
+    color: var(--brand-red);
 }
 
 .form-group textarea,
 .form-group input[type="number"],
 .form-group input[type="text"] {
     width: 100%;
-    padding: 10px 12px;
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    font-size: 0.9em;
-    transition: border-color 0.2s;
+    padding: 8px 12px;
+    border: 1px solid var(--border-input);
+    border-radius: 6px;
+    font-size: 14px;
     font-family: inherit;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    transition: border-color 0.15s, box-shadow 0.15s;
     resize: vertical;
+}
+
+.form-group textarea::placeholder,
+.form-group input::placeholder {
+    color: var(--text-muted);
+}
+
+.form-group textarea:hover,
+.form-group input[type="number"]:hover,
+.form-group input[type="text"]:hover {
+    border-color: var(--border-primary);
 }
 
 .form-group textarea:focus,
 .form-group input:focus {
     outline: none;
-    border-color: #667eea;
-    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
+    border-color: var(--brand-blue);
+    box-shadow: 0 0 0 3px rgba(47, 128, 250, 0.15);
 }
 
 .form-row {
@@ -162,50 +295,84 @@ body {
     display: flex;
     align-items: center;
     gap: 6px;
-    font-size: 0.9em;
-    color: #555;
+    font-size: 13px;
+    color: var(--text-secondary);
     cursor: pointer;
     white-space: nowrap;
     font-weight: normal;
 }
 
 .checkbox-label input[type="checkbox"] {
-    width: auto;
+    width: 18px;
+    height: 18px;
+    border: 2px solid var(--text-muted);
+    border-radius: 3px;
+    appearance: none;
+    -webkit-appearance: none;
     cursor: pointer;
+    position: relative;
+    flex-shrink: 0;
+    background: var(--bg-primary);
+    transition: all 0.15s;
+}
+
+.checkbox-label input[type="checkbox"]:checked {
+    background: var(--brand-green);
+    border-color: var(--brand-green);
+}
+
+.checkbox-label input[type="checkbox"]:checked::after {
+    content: '';
+    position: absolute;
+    left: 4px;
+    top: 1px;
+    width: 6px;
+    height: 10px;
+    border: solid white;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
 }
 
 .field-error {
-    color: #e53e3e;
-    font-size: 0.8em;
+    color: var(--brand-red);
+    font-size: 12px;
+    font-weight: 500;
     margin-top: 4px;
     min-height: 16px;
 }
 
-/* Advanced Section */
+/* ─── Advanced Section ───────────────────────────────────────────────────── */
 .advanced-section {
     margin-bottom: 20px;
-    border: 1px solid #e9ecef;
-    border-radius: 8px;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
     overflow: hidden;
+    background: var(--accent-primary);
 }
 
 .advanced-section summary {
-    padding: 10px 14px;
+    padding: 8px 12px;
     cursor: pointer;
-    font-size: 0.9em;
-    color: #667eea;
-    font-weight: bold;
-    background: #f0f2ff;
+    font-size: 13px;
+    color: var(--brand-red);
+    font-weight: 600;
+    background: var(--accent-primary);
     user-select: none;
+    transition: all 0.15s;
 }
 
 .advanced-section summary:hover {
-    background: #e8eaff;
+    background: var(--accent-secondary);
+}
+
+.advanced-section summary:active {
+    transform: scale(0.99);
 }
 
 .advanced-content {
     padding: 16px;
-    background: white;
+    background: var(--bg-primary);
+    border-top: 1px solid var(--border-primary);
 }
 
 .advanced-content .form-group:last-child {
@@ -215,69 +382,105 @@ body {
 input[type="range"] {
     width: 100%;
     cursor: pointer;
-    accent-color: #667eea;
+    accent-color: var(--brand-orange);
 }
 
-/* Buttons */
-.btn-primary {
-    width: 100%;
-    padding: 14px;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    border: none;
-    border-radius: 25px;
-    font-size: 1em;
-    font-weight: bold;
+/* ─── 3D Buttons (PostHog Signature Effect) ──────────────────────────────── */
+
+/* Shadow layer container */
+.btn-3d {
+    display: inline-block;
+    border-radius: 8px;
+    border: 1.5px solid var(--btn-border);
+    position: relative;
+    top: 2px;
     cursor: pointer;
-    transition: all 0.3s ease;
+    vertical-align: middle;
 }
 
-.btn-primary:hover:not(:disabled) {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 20px rgba(102, 126, 234, 0.4);
+.btn-3d-primary {
+    background: var(--btn-shadow);
 }
 
-.btn-primary:disabled {
-    opacity: 0.6;
+.btn-3d-secondary {
+    background: var(--brand-orange);
+    border-color: var(--btn-border);
+}
+
+.btn-3d-danger {
+    background: #b82e2e;
+    border-color: #962525;
+}
+
+/* Visible button face */
+.btn-face {
+    display: block;
+    width: 100%;
+    padding: 10px 20px;
+    border: 1.5px solid var(--btn-border);
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 700;
+    font-family: inherit;
+    cursor: pointer;
+    transform: translateY(-3px);
+    transition: transform 100ms;
+    text-align: center;
+    line-height: 1.4;
+}
+
+.btn-3d-primary .btn-face {
+    background: var(--btn-face);
+    color: #000;
+}
+
+.btn-3d-secondary .btn-face {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    border-color: var(--btn-border);
+}
+
+.btn-face-danger {
+    background: #e53e3e !important;
+    color: white !important;
+    border-color: #b82e2e !important;
+}
+
+/* Hover: lift higher */
+.btn-3d:hover .btn-face {
+    transform: translateY(-4px);
+}
+
+/* Active: press down */
+.btn-3d:active .btn-face {
+    transform: translateY(-1px);
+    transition: transform 50ms;
+}
+
+/* Disabled */
+.btn-3d:has(.btn-face:disabled) {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.btn-3d.is-disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.btn-face:disabled {
     cursor: not-allowed;
 }
 
-.btn-secondary {
-    padding: 10px 20px;
-    background: #667eea;
-    color: white;
-    border: none;
-    border-radius: 25px;
-    font-size: 0.9em;
-    font-weight: bold;
-    cursor: pointer;
-    transition: all 0.3s ease;
+/* Full-width variant */
+.btn-3d-full {
+    display: block;
+    width: 100%;
 }
 
-.btn-secondary:hover {
-    background: #5a67d8;
-    transform: translateY(-2px);
-    box-shadow: 0 5px 15px rgba(102, 126, 234, 0.4);
-}
-
-.btn-danger {
-    padding: 10px 20px;
-    background: #e53e3e;
-    color: white;
-    border: none;
-    border-radius: 25px;
-    font-size: 0.9em;
-    font-weight: bold;
-    cursor: pointer;
-    transition: all 0.3s ease;
-}
-
-.btn-danger:hover {
-    background: #c53030;
-    transform: translateY(-2px);
-}
-
-/* Canvas Panel */
+/* ─── Canvas Panel ───────────────────────────────────────────────────────── */
 .canvas-panel {
     display: flex;
     flex-direction: column;
@@ -289,10 +492,11 @@ input[type="range"] {
     width: 100%;
     max-width: 1024px;
     aspect-ratio: 1 / 1;
-    border: 2px solid #e9ecef;
-    border-radius: 15px;
+    border: 1px solid var(--border-primary);
+    border-radius: 8px;
     overflow: hidden;
-    background: #f8f9fa;
+    background: var(--bg-tertiary);
+    box-shadow: var(--shadow-md);
 }
 
 .image-placeholder {
@@ -301,7 +505,7 @@ input[type="range"] {
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #aaa;
+    color: var(--text-muted);
 }
 
 .placeholder-text {
@@ -313,8 +517,8 @@ input[type="range"] {
 }
 
 .placeholder-text p {
-    font-size: 1em;
-    color: #aaa;
+    font-size: 14px;
+    color: var(--text-muted);
 }
 
 .image-container img {
@@ -335,29 +539,30 @@ input[type="range"] {
     object-fit: contain;
 }
 
-/* Loading Overlay */
+/* ─── Loading Overlay ────────────────────────────────────────────────────── */
 .loading-overlay {
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.7);
+    background: rgba(30, 31, 35, 0.8);
+    backdrop-filter: blur(8px);
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 16px;
+    gap: 14px;
     color: white;
-    border-radius: 13px;
+    border-radius: 7px;
 }
 
 .spinner {
-    border: 4px solid rgba(255, 255, 255, 0.3);
+    border: 3px solid rgba(255, 255, 255, 0.15);
     border-radius: 50%;
-    border-top: 4px solid white;
-    width: 48px;
-    height: 48px;
+    border-top: 3px solid var(--brand-orange);
+    width: 40px;
+    height: 40px;
     animation: spin 1s linear infinite;
 }
 
@@ -367,93 +572,106 @@ input[type="range"] {
 }
 
 .loading-text {
-    font-size: 1.1em;
-    font-weight: bold;
+    font-size: 14px;
+    font-weight: 600;
+    color: rgba(255,255,255,0.9);
 }
 
 .loading-timer {
-    font-size: 1.5em;
-    font-weight: bold;
-    color: rgba(255, 255, 255, 0.85);
+    font-size: 1.25em;
+    font-weight: 700;
+    color: var(--brand-orange);
 }
 
-/* Image Actions */
+/* ─── Image Actions ──────────────────────────────────────────────────────── */
 .image-actions {
     display: flex;
-    gap: 12px;
+    gap: 10px;
     flex-wrap: wrap;
 }
 
-/* Metadata Section */
+/* ─── Metadata Section ───────────────────────────────────────────────────── */
 .metadata-section {
-    background: #f8f9fa;
-    border-radius: 10px;
-    padding: 20px;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    border: 1px solid var(--border-primary);
+    padding: 16px;
 }
 
 .metadata-section h3 {
-    margin-bottom: 12px;
-    color: #333;
-    font-size: 1em;
+    margin-bottom: 10px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
 }
 
 .metadata-list {
     display: grid;
     grid-template-columns: auto 1fr;
-    gap: 8px 16px;
+    gap: 6px 16px;
 }
 
 .metadata-list dt {
-    font-weight: bold;
-    color: #555;
-    font-size: 0.9em;
+    font-weight: 600;
+    color: var(--text-secondary);
+    font-size: 13px;
     white-space: nowrap;
 }
 
 .metadata-list dd {
-    color: #333;
-    font-size: 0.9em;
+    color: var(--text-primary);
+    font-size: 13px;
     word-break: break-word;
 }
 
-/* Gallery */
+/* ─── Gallery ────────────────────────────────────────────────────────────── */
 .gallery-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 24px;
+    margin-bottom: 20px;
     flex-wrap: wrap;
     gap: 12px;
 }
 
 .gallery-header h2 {
-    color: #333;
+    color: var(--text-primary);
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: -0.015em;
 }
 
 .storage-usage {
-    font-size: 0.85em;
-    color: #888;
+    font-size: 12px;
+    color: var(--text-muted);
 }
 
 .gallery-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-    gap: 20px;
+    gap: 16px;
 }
 
 .gallery-card {
-    background: white;
-    border-radius: 12px;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.08);
+    background: var(--bg-primary);
+    border-radius: 8px;
+    border: 1px solid var(--border-primary);
     overflow: hidden;
     cursor: pointer;
-    transition: all 0.3s ease;
-    border: 1px solid #e9ecef;
+    transition: all 0.2s ease;
+    box-shadow: var(--shadow-sm);
 }
 
 .gallery-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-xl);
+    border-color: var(--accent-secondary);
+}
+
+.gallery-card:active {
+    transform: translateY(0.5px) scale(0.99);
 }
 
 .gallery-card-thumb {
@@ -461,16 +679,17 @@ input[type="range"] {
     aspect-ratio: 1 / 1;
     object-fit: cover;
     display: block;
-    background: #f8f9fa;
+    background: var(--bg-tertiary);
 }
 
 .gallery-card-info {
-    padding: 12px;
+    padding: 10px 12px;
+    border-top: 1px solid var(--border-primary);
 }
 
 .gallery-card-prompt {
-    font-size: 0.85em;
-    color: #333;
+    font-size: 13px;
+    color: var(--text-primary);
     overflow: hidden;
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -480,48 +699,55 @@ input[type="range"] {
 }
 
 .gallery-card-badge {
-    font-size: 0.75em;
-    color: #888;
-    background: #f0f2ff;
-    border-radius: 12px;
-    padding: 3px 10px;
+    font-size: 11px;
+    color: var(--text-secondary);
+    background: var(--accent-primary);
+    border: 1px solid var(--border-primary);
+    border-radius: 4px;
+    padding: 2px 8px;
     display: inline-block;
     margin-bottom: 6px;
 }
 
 .gallery-card-timestamp {
-    font-size: 0.75em;
-    color: #aaa;
+    font-size: 11px;
+    color: var(--text-muted);
 }
 
-/* Empty State */
+/* ─── Empty State ────────────────────────────────────────────────────────── */
 .empty-state {
     text-align: center;
     padding: 60px 20px;
-    color: #aaa;
+    color: var(--text-muted);
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 12px;
 }
 
+.empty-state svg {
+    stroke: var(--text-muted);
+}
+
 .empty-state p {
-    font-size: 1.1em;
+    font-size: 15px;
+    color: var(--text-muted);
 }
 
 .empty-hint {
-    font-size: 0.9em !important;
-    color: #bbb;
+    font-size: 13px !important;
+    color: var(--text-muted);
 }
 
-/* Modal */
+/* ─── Modal ──────────────────────────────────────────────────────────────── */
 .modal-overlay {
     position: fixed;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.75);
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(4px);
     z-index: 1000;
     display: flex;
     align-items: center;
@@ -531,36 +757,42 @@ input[type="range"] {
 
 .modal {
     position: relative;
-    background: white;
-    border-radius: 15px;
+    background: var(--bg-primary);
+    border-radius: 8px;
+    border: 1px solid var(--border-primary);
     max-width: 960px;
     width: 100%;
     max-height: 90vh;
     overflow-y: auto;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+    box-shadow: var(--shadow-2xl);
 }
 
 .modal-close {
     position: absolute;
-    top: 16px;
-    right: 16px;
-    background: rgba(0, 0, 0, 0.5);
-    color: white;
-    border: none;
-    border-radius: 50%;
-    width: 36px;
-    height: 36px;
-    font-size: 1.2em;
+    top: 12px;
+    right: 12px;
+    background: var(--accent-primary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    width: 32px;
+    height: 32px;
+    font-size: 1.1em;
     cursor: pointer;
     z-index: 10;
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: background 0.2s;
+    transition: all 0.15s;
 }
 
 .modal-close:hover {
-    background: rgba(0, 0, 0, 0.7);
+    background: var(--accent-secondary);
+    transform: translateY(-1px);
+}
+
+.modal-close:active {
+    transform: translateY(0.5px) scale(0.98);
 }
 
 .modal-body {
@@ -572,37 +804,38 @@ input[type="range"] {
     width: 100%;
     aspect-ratio: 1 / 1;
     object-fit: contain;
-    border-radius: 15px 0 0 15px;
-    background: #111;
+    border-radius: 8px 0 0 8px;
+    background: #1E1F23;
     display: block;
 }
 
 .modal-meta {
-    padding: 24px;
+    padding: 20px;
     display: flex;
     flex-direction: column;
     gap: 16px;
+    background: var(--bg-secondary);
+    border-left: 1px solid var(--border-primary);
 }
 
 .modal-meta h3 {
-    color: #333;
-    font-size: 1em;
+    color: var(--text-primary);
+    font-size: 14px;
+    font-weight: 700;
 }
 
 .modal-actions {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
     margin-top: auto;
 }
 
-.modal-actions .btn-secondary,
-.modal-actions .btn-danger {
+.modal-actions .btn-3d {
     width: 100%;
-    text-align: center;
 }
 
-/* Responsive: stack at 1024px */
+/* ─── Responsive: stack at 1024px ────────────────────────────────────────── */
 @media (max-width: 1024px) {
     .generate-layout {
         grid-template-columns: 1fr;
@@ -617,7 +850,7 @@ input[type="range"] {
     }
 }
 
-/* Responsive: sidebar becomes top bar at 768px */
+/* ─── Responsive: sidebar becomes top bar at 768px ───────────────────────── */
 @media (max-width: 768px) {
     .app-layout {
         grid-template-columns: 1fr;
@@ -627,21 +860,33 @@ input[type="range"] {
     .sidebar {
         flex-direction: row;
         border-right: none;
-        border-bottom: 1px solid #e9ecef;
+        border-bottom: 1px solid var(--border-primary);
         padding: 0;
     }
 
     .tab-btn {
         border-left: none;
         border-bottom: 3px solid transparent;
-        padding: 14px 20px;
+        padding: 12px 16px;
         text-align: center;
         flex: 1;
     }
 
+    .tab-btn:hover {
+        transform: none;
+    }
+
     .tab-btn.active {
-        border-bottom-color: #667eea;
+        border-bottom-color: var(--brand-red);
         border-left-color: transparent;
+    }
+
+    .window-dots {
+        display: none;
+    }
+
+    .header h1 {
+        font-size: 1.4rem;
     }
 
     .modal-body {
@@ -649,12 +894,13 @@ input[type="range"] {
     }
 
     .modal-body img {
-        border-radius: 15px 15px 0 0;
+        border-radius: 8px 8px 0 0;
         aspect-ratio: 1 / 1;
     }
 
-    .header h1 {
-        font-size: 1.8em;
+    .modal-meta {
+        border-left: none;
+        border-top: 1px solid var(--border-primary);
     }
 }
 
@@ -665,5 +911,9 @@ input[type="range"] {
 
     .main-content {
         padding: 16px;
+    }
+
+    .header {
+        padding: 12px 16px 16px;
     }
 }

--- a/tt-media-server/tt_model_runners/forge_runners/README.md
+++ b/tt-media-server/tt_model_runners/forge_runners/README.md
@@ -47,10 +47,11 @@ Use MODEL_RUNNER to select which model is run
    - TT_XLA_RESNET = "tt-xla-resnet"
    - TT_XLA_VOVNET = "tt-xla-vovnet"
    - TT_XLA_MOBILENETV2 = "tt-xla-mobilenetv2"
-   - TT_XLA_EFFICENNET = "tt-xla-efficientnet"
+   - TT_XLA_EFFICIENTNET = "tt-xla-efficientnet"
    - TT_XLA_SEGFORMER = "tt-xla-segformer"
    - TT_XLA_UNET = "tt-xla-unet"
    - TT_XLA_VIT = "tt-xla-vit"
+   - TT_XLA_SDXL = "tt-xla-sdxl"
 
 Set appropriate HF_TOKEN to load weights from Huggingface.
 IRD_LF_CACHE is out large file caching service, in IRD environment use http://aus2-lfcache.aus2.tenstorrent.com/
@@ -138,6 +139,10 @@ To run the forge model, select the `forge-vllm-plugin` implementation when runni
 Add the model into the options dropdown(under the model input) in on-dispatch.yml in .github/workflows/on-dispatch.yml file
 
 To add models into the on-nightly workflow, navigate to tt-shield repo, and add the model into the model matrix in .github/workflows/on-dispatch.yml , under   run-evals-on-media-inference-server-forge job
+
+### Model Specific Options
+
+- For TT_XLA_SDXL use TTXLA_SDXL_RESOLUTION [512|1024] to specify the output image resolution, default is 512.
 
 NOTES:
 - We are unable to run evaluations on Forge models that exist in metal.

--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -8,7 +8,7 @@ flax # input preprocessing
 pytorchcv # for vovnet
 tabulate
 
-diffusers
+diffusers==0.37.1
 transformers
 
 datasets # model training

--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -8,5 +8,8 @@ flax # input preprocessing
 pytorchcv # for vovnet
 tabulate
 
+diffusers
+transformers
+
 datasets # model training
 peft # model training

--- a/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
@@ -43,7 +43,6 @@ class SDXLForgeRunner(BaseDeviceRunner):
         self.tokenizer_2 = None
         self.scheduler = None
 
-        # Config
         env_resolution = os.getenv("TTXLA_SDXL_RESOLUTION")
         if env_resolution is not None:
             assert env_resolution in ("1024", "512"), (

--- a/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
@@ -25,8 +25,6 @@ class SDXLForgeRunner(BaseDeviceRunner):
 
     LOAD_TIMEOUT_SECONDS = 300
     WARMUP_TIMEOUT_SECONDS = 2000
-    DEFAULT_NUM_INFERENCE_STEPS = 20
-    DEFAULT_CFG_SCALE = 7.5
     DEFAULT_RESOLUTION = 512
 
     def __init__(self, device_id: str):
@@ -209,8 +207,8 @@ class SDXLForgeRunner(BaseDeviceRunner):
         self._generate(
             prompt="a photo of a cat",
             negative_prompt="",
-            cfg_scale=self.DEFAULT_CFG_SCALE,
-            num_inference_steps=self.DEFAULT_NUM_INFERENCE_STEPS,  # minimal steps for warmup
+            cfg_scale=7.5,
+            num_inference_steps=20,
             seed=42,
         )
         self.logger.info(f"Device {self.device_id}: Warmup inference done")
@@ -375,16 +373,8 @@ class SDXLForgeRunner(BaseDeviceRunner):
 
         prompt = request.prompt
         negative_prompt = request.negative_prompt or ""
-        cfg_scale = (
-            request.guidance_scale
-            if request.guidance_scale is not None
-            else self.DEFAULT_CFG_SCALE
-        )
-        num_inference_steps = (
-            request.num_inference_steps
-            if request.num_inference_steps is not None
-            else self.DEFAULT_NUM_INFERENCE_STEPS
-        )
+        cfg_scale = request.guidance_scale
+        num_inference_steps = request.num_inference_steps
         seed = request.seed
 
         image_tensor = self._generate(

--- a/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
@@ -67,7 +67,6 @@ class SDXLForgeRunner(BaseDeviceRunner):
             self.device = torch.device("cpu")
             self.logger.info(f"Device {self.device_id}: Using CPU fallback")
         else:
-            import torch_xla
             import torch_xla.core.xla_model as xm
             import torch_xla.runtime as xr
 
@@ -124,14 +123,26 @@ class SDXLForgeRunner(BaseDeviceRunner):
 
     def _load_pipeline(self):
         """Download weights, instantiate models, compile UNet for TT device."""
-        from diffusers import AutoencoderKL, EulerDiscreteScheduler, UNet2DConditionModel
-        from transformers import CLIPTextModel, CLIPTextModelWithProjection, CLIPTokenizer
+        from diffusers import (
+            AutoencoderKL,
+            EulerDiscreteScheduler,
+            UNet2DConditionModel,
+        )
+        from transformers import (
+            CLIPTextModel,
+            CLIPTextModelWithProjection,
+            CLIPTokenizer,
+        )
 
         # Select model based on resolution.
         # 512px uses hotshotco/SDXL-512, 1024px uses stabilityai/stable-diffusion-xl-base-1.0.
         if self.resolution == 512:
             model_id = SupportedModels.STABLE_DIFFUSION_XL_512.value
-            if self.settings.model_weights_path and self.settings.model_weights_path != SupportedModels.STABLE_DIFFUSION_XL_BASE.value:
+            if (
+                self.settings.model_weights_path
+                and self.settings.model_weights_path
+                != SupportedModels.STABLE_DIFFUSION_XL_BASE.value
+            ):
                 self.logger.warning(
                     f"Device {self.device_id}: model_weights_path={self.settings.model_weights_path!r} "
                     f"is set but resolution is 512 — using {model_id} instead"
@@ -143,7 +154,11 @@ class SDXLForgeRunner(BaseDeviceRunner):
             )
 
         # hotshotco/SDXL-512 doesn't ship native fp16 weights; load full precision and cast
-        variant = "fp16" if model_id == SupportedModels.STABLE_DIFFUSION_XL_BASE.value else None
+        variant = (
+            "fp16"
+            if model_id == SupportedModels.STABLE_DIFFUSION_XL_BASE.value
+            else None
+        )
 
         self.logger.info(
             f"Device {self.device_id}: Loading models from {model_id} "
@@ -237,7 +252,9 @@ class SDXLForgeRunner(BaseDeviceRunner):
             curr_hidden = torch.cat([uncond_hidden, cond_hidden], dim=0)  # (2, T, Di)
             encoder_hidden_states.append(curr_hidden)
 
-        encoder_hidden_states = torch.cat(encoder_hidden_states, dim=-1)  # (2, T, D1+D2)
+        encoder_hidden_states = torch.cat(
+            encoder_hidden_states, dim=-1
+        )  # (2, T, D1+D2)
         return encoder_hidden_states, pooled_text_embeds
 
     def _generate(
@@ -252,14 +269,18 @@ class SDXLForgeRunner(BaseDeviceRunner):
         runs_on_cpu = os.getenv("RUNS_ON_CPU", "false").lower() == "true"
 
         if runs_on_cpu:
-            tt_cast = lambda x: x.to(dtype=torch.bfloat16)
+
+            def tt_cast(x):
+                return x.to(dtype=torch.bfloat16)
         else:
-            tt_cast = lambda x: (
-                x.to(dtype=torch.bfloat16).to(device=self.device)
-                if x.device == torch.device("cpu")
-                else x.to(dtype=torch.bfloat16)
-            )
-        cpu_cast = lambda x: x.to("cpu").to(dtype=torch.float16)
+
+            def tt_cast(x):
+                if x.device == torch.device("cpu"):
+                    return x.to(dtype=torch.bfloat16).to(device=self.device)
+                return x.to(dtype=torch.bfloat16)
+
+        def cpu_cast(x):
+            return x.to("cpu").to(dtype=torch.float16)
 
         with torch.no_grad():
             # --- Text Encoding (CPU) ---

--- a/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import os
+import time
 
 os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
 
@@ -43,8 +44,21 @@ class SDXLForgeRunner(BaseDeviceRunner):
         self.scheduler = None
 
         # Config
-        self.resolution = self.DEFAULT_RESOLUTION
-        self.latent_size = self.resolution // 8  # 128 for 1024
+        env_resolution = os.getenv("TTXLA_SDXL_RESOLUTION")
+        if env_resolution is not None:
+            assert env_resolution in ("1024", "512"), (
+                f"TTXLA_SDXL_RESOLUTION must be 1024 or 512, got '{env_resolution}'"
+            )
+            self.resolution = int(env_resolution)
+            self.logger.info(
+                f"Device {self.device_id}: Resolution overridden by TTXLA_SDXL_RESOLUTION={self.resolution}"
+            )
+        else:
+            self.resolution = self.DEFAULT_RESOLUTION
+            self.logger.info(
+                f"Device {self.device_id}: TTXLA_SDXL_RESOLUTION not set, using default {self.resolution} resolution"
+            )
+        self.latent_size = self.resolution // 8
 
     def _init_device(self):
         """Initialize TT XLA device or fall back to CPU."""
@@ -234,8 +248,12 @@ class SDXLForgeRunner(BaseDeviceRunner):
 
         with torch.no_grad():
             # --- Text Encoding (CPU) ---
+            t0 = time.time()
             encoder_hidden_states, pooled_text_embeds = self._encode_prompts(
                 prompt, negative_prompt, cpu_cast
+            )
+            self.logger.info(
+                f"Device {self.device_id}: Text encoding took {time.time() - t0:.4f}s"
             )
 
             # --- Latent Initialization ---
@@ -266,6 +284,7 @@ class SDXLForgeRunner(BaseDeviceRunner):
             ).repeat(2, 1)  # (2, 6)
 
             # --- Diffusion Loop ---
+            t0 = time.time()
             for i, timestep in enumerate(self.scheduler.timesteps):
                 model_input = latents.repeat(2, 1, 1, 1)  # (2, 4, H, W) for CFG
                 model_input = self.scheduler.scale_model_input(model_input, timestep)
@@ -295,10 +314,18 @@ class SDXLForgeRunner(BaseDeviceRunner):
                     model_output, timestep, latents
                 ).prev_sample
 
+            self.logger.info(
+                f"Device {self.device_id}: UNet diffusion ({num_inference_steps} steps) took {time.time() - t0:.4f}s"
+            )
+
             # --- VAE Decode (CPU) ---
+            t0 = time.time()
             latents = latents / self.vae.config.scaling_factor
             latents = latents.to(dtype=torch.float32)
             images = self.vae.decode(latents).sample  # (1, 3, H, W)
+            self.logger.info(
+                f"Device {self.device_id}: VAE decode took {time.time() - t0:.4f}s"
+            )
 
             return images
 

--- a/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
@@ -1,0 +1,354 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import os
+
+os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
+
+import asyncio
+
+import torch
+from PIL import Image
+
+from config.constants import SupportedModels
+from domain.image_generate_request import ImageGenerateRequest
+from tt_model_runners.base_device_runner import BaseDeviceRunner
+from utils.decorators import log_execution_time
+from utils.logger import log_exception_chain
+
+
+class SDXLForgeRunner(BaseDeviceRunner):
+    """SDXL text-to-image pipeline via Forge compiler (tt-xla).
+
+    Runs on Blackhole (P100/P150) devices. One instance per chip.
+    """
+
+    LOAD_TIMEOUT_SECONDS = 300
+    WARMUP_TIMEOUT_SECONDS = 1000
+    DEFAULT_NUM_INFERENCE_STEPS = 20
+    DEFAULT_CFG_SCALE = 7.5
+    DEFAULT_RESOLUTION = 1024  # 1024x1024
+
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self._setup_done = False
+        self.device = None  # XLA or CPU device
+
+        # Pipeline components (set during _load_pipeline)
+        self.unet = None
+        self.vae = None
+        self.text_encoder = None
+        self.text_encoder_2 = None
+        self.tokenizer = None
+        self.tokenizer_2 = None
+        self.scheduler = None
+
+        # Config
+        self.resolution = self.DEFAULT_RESOLUTION
+        self.latent_size = self.resolution // 8  # 128 for 1024
+
+    def _init_device(self):
+        """Initialize TT XLA device or fall back to CPU."""
+        runs_on_cpu = os.getenv("RUNS_ON_CPU", "false").lower() == "true"
+        if runs_on_cpu:
+            self.device = torch.device("cpu")
+            self.logger.info(f"Device {self.device_id}: Using CPU fallback")
+        else:
+            import torch_xla
+            import torch_xla.core.xla_model as xm
+            import torch_xla.runtime as xr
+
+            xr.set_device_type("TT")
+            self.device = xm.xla_device()
+            self.logger.info(f"Device {self.device_id}: Using TT XLA device")
+
+    @log_execution_time("SDXL Forge warmup")
+    async def warmup(self) -> bool:
+        if self._setup_done:
+            self.logger.info(f"Device {self.device_id}: Already warmed up")
+            return True
+
+        self._init_device()
+
+        optimization_level = int(os.getenv("OPTIMIZATION_LEVEL", "1"))
+        runs_on_cpu = os.getenv("RUNS_ON_CPU", "false").lower() == "true"
+        if not runs_on_cpu:
+            import torch_xla
+
+            torch_xla.set_custom_compile_options(
+                {"optimization_level": optimization_level}
+            )
+
+        # Phase 1: Load pipeline (download weights, compile UNet)
+        try:
+            await asyncio.wait_for(
+                asyncio.to_thread(self._load_pipeline),
+                timeout=self.LOAD_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            self.logger.error(
+                f"Device {self.device_id}: Pipeline load timed out after {self.LOAD_TIMEOUT_SECONDS}s"
+            )
+            raise
+        except Exception as e:
+            log_exception_chain(self.logger, self.device_id, "Pipeline load failed", e)
+            raise
+
+        self.logger.info(f"Device {self.device_id}: Pipeline loaded")
+
+        # Phase 2: Warmup inference (trigger JIT compilation)
+        try:
+            await asyncio.wait_for(
+                asyncio.to_thread(self._warmup_inference_pass),
+                timeout=self.WARMUP_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            self.logger.error(
+                f"Device {self.device_id}: Warmup timed out after {self.WARMUP_TIMEOUT_SECONDS}s"
+            )
+            raise
+        except Exception as e:
+            log_exception_chain(
+                self.logger, self.device_id, "Warmup inference failed", e
+            )
+            raise
+
+        self.logger.info(f"Device {self.device_id}: Warmup completed")
+        self._setup_done = True
+        return True
+
+    def _load_pipeline(self):
+        """Download weights, instantiate models, compile UNet for TT device."""
+        from diffusers import AutoencoderKL, EulerDiscreteScheduler, UNet2DConditionModel
+        from transformers import CLIPTextModel, CLIPTextModelWithProjection, CLIPTokenizer
+
+        model_id = (
+            self.settings.model_weights_path
+            or SupportedModels.STABLE_DIFFUSION_XL_BASE.value
+        )
+        variant = "fp16" if "xl-base-1.0" in model_id else None
+
+        self.logger.info(f"Device {self.device_id}: Loading models from {model_id}")
+
+        # VAE — float32, stays on CPU
+        self.vae = AutoencoderKL.from_pretrained(
+            model_id, subfolder="vae", torch_dtype=torch.float32
+        )
+
+        # UNet — bfloat16, compiled for TT
+        self.unet = UNet2DConditionModel.from_pretrained(
+            model_id, subfolder="unet", variant=variant, torch_dtype=torch.bfloat16
+        )
+        runs_on_cpu = os.getenv("RUNS_ON_CPU", "false").lower() == "true"
+        if not runs_on_cpu:
+            self.unet.compile(backend="tt")
+        self.unet = self.unet.to(self.device)
+
+        # Text encoders — float16, stay on CPU
+        self.text_encoder = CLIPTextModel.from_pretrained(
+            model_id,
+            subfolder="text_encoder",
+            variant=variant,
+            torch_dtype=torch.float16,
+        )
+        self.text_encoder_2 = CLIPTextModelWithProjection.from_pretrained(
+            model_id,
+            subfolder="text_encoder_2",
+            variant=variant,
+            torch_dtype=torch.float16,
+        )
+
+        # Tokenizers
+        self.tokenizer = CLIPTokenizer.from_pretrained(model_id, subfolder="tokenizer")
+        self.tokenizer_2 = CLIPTokenizer.from_pretrained(
+            model_id, subfolder="tokenizer_2"
+        )
+
+        # Scheduler
+        self.scheduler = EulerDiscreteScheduler.from_pretrained(
+            model_id, subfolder="scheduler"
+        )
+
+    def _warmup_inference_pass(self):
+        """Run a short inference pass to trigger JIT compilation."""
+        self.logger.info(f"Device {self.device_id}: Running warmup inference")
+        self._generate(
+            prompt="a photo of a cat",
+            negative_prompt="",
+            cfg_scale=self.DEFAULT_CFG_SCALE,
+            num_inference_steps=5,  # minimal steps for warmup
+            seed=42,
+        )
+        self.logger.info(f"Device {self.device_id}: Warmup inference done")
+
+    def _encode_prompts(self, prompt: str, negative_prompt: str, cpu_cast):
+        """Encode prompts through both CLIP encoders. Returns hidden_states and pooled_embeds."""
+        encoder_hidden_states = []
+        pooled_text_embeds = None
+
+        for tokenizer, text_encoder in [
+            (self.tokenizer, self.text_encoder),
+            (self.tokenizer_2, self.text_encoder_2),
+        ]:
+            cond_tokens = torch.tensor(
+                tokenizer.batch_encode_plus(
+                    [prompt], padding="max_length", max_length=77
+                ).input_ids,
+                dtype=torch.long,
+            )
+            uncond_tokens = torch.tensor(
+                tokenizer.batch_encode_plus(
+                    [negative_prompt or ""], padding="max_length", max_length=77
+                ).input_ids,
+                dtype=torch.long,
+            )
+
+            cond_output = text_encoder(cond_tokens, output_hidden_states=True)
+            uncond_output = text_encoder(uncond_tokens, output_hidden_states=True)
+
+            cond_hidden = cond_output.hidden_states[-2]  # penultimate layer
+            uncond_hidden = uncond_output.hidden_states[-2]
+
+            if text_encoder is self.text_encoder_2:
+                pooled_text_embeds = torch.cat(
+                    [uncond_output.text_embeds, cond_output.text_embeds], dim=0
+                )  # (2, D)
+
+            curr_hidden = torch.cat([uncond_hidden, cond_hidden], dim=0)  # (2, T, Di)
+            encoder_hidden_states.append(curr_hidden)
+
+        encoder_hidden_states = torch.cat(encoder_hidden_states, dim=-1)  # (2, T, D1+D2)
+        return encoder_hidden_states, pooled_text_embeds
+
+    def _generate(
+        self,
+        prompt: str,
+        negative_prompt: str,
+        cfg_scale: float,
+        num_inference_steps: int,
+        seed: int | None,
+    ) -> torch.Tensor:
+        """Run the full SDXL pipeline. Returns image tensor (B, 3, H, W) in [-1, 1]."""
+        runs_on_cpu = os.getenv("RUNS_ON_CPU", "false").lower() == "true"
+
+        if runs_on_cpu:
+            tt_cast = lambda x: x.to(dtype=torch.bfloat16)
+        else:
+            tt_cast = lambda x: (
+                x.to(dtype=torch.bfloat16).to(device=self.device)
+                if x.device == torch.device("cpu")
+                else x.to(dtype=torch.bfloat16)
+            )
+        cpu_cast = lambda x: x.to("cpu").to(dtype=torch.float16)
+
+        with torch.no_grad():
+            # --- Text Encoding (CPU) ---
+            encoder_hidden_states, pooled_text_embeds = self._encode_prompts(
+                prompt, negative_prompt, cpu_cast
+            )
+
+            # --- Latent Initialization ---
+            generator = torch.Generator(device="cpu")
+            if seed is not None:
+                generator.manual_seed(seed)
+            else:
+                generator.seed()
+            latents = torch.randn(
+                (1, 4, self.latent_size, self.latent_size),
+                generator=generator,
+                dtype=torch.float16,
+            )
+
+            self.scheduler.set_timesteps(num_inference_steps)
+            latents = latents * self.scheduler.init_noise_sigma
+
+            # time_ids: [orig_h, orig_w, crop_top, crop_left, target_h, target_w]
+            time_ids = torch.tensor(
+                [
+                    self.resolution,
+                    self.resolution,
+                    0,
+                    0,
+                    self.resolution,
+                    self.resolution,
+                ]
+            ).repeat(2, 1)  # (2, 6)
+
+            # --- Diffusion Loop ---
+            for i, timestep in enumerate(self.scheduler.timesteps):
+                model_input = latents.repeat(2, 1, 1, 1)  # (2, 4, H, W) for CFG
+                model_input = self.scheduler.scale_model_input(model_input, timestep)
+
+                model_input = tt_cast(model_input)
+                t = tt_cast(timestep.unsqueeze(0))
+                enc_hs = tt_cast(encoder_hidden_states)
+                pooled = tt_cast(pooled_text_embeds)
+                tids = tt_cast(time_ids)
+
+                unet_output = self.unet(
+                    model_input,
+                    t,
+                    enc_hs,
+                    added_cond_kwargs={"text_embeds": pooled, "time_ids": tids},
+                ).sample
+
+                unet_output = cpu_cast(unet_output)
+
+                # CFG guidance
+                uncond_out, cond_out = unet_output.chunk(2)
+                model_output = uncond_out + (cond_out - uncond_out) * cfg_scale
+
+                timestep = cpu_cast(timestep)
+                latents = cpu_cast(latents)
+                latents = self.scheduler.step(
+                    model_output, timestep, latents
+                ).prev_sample
+
+            # --- VAE Decode (CPU) ---
+            latents = latents / self.vae.config.scaling_factor
+            latents = latents.to(dtype=torch.float32)
+            images = self.vae.decode(latents).sample  # (1, 3, H, W)
+
+            return images
+
+    @log_execution_time("SDXL Forge inference")
+    def run(self, requests: list[ImageGenerateRequest]) -> list[Image.Image]:
+        """Run SDXL inference for a batch of requests. Returns list of PIL Images."""
+        if not requests:
+            raise ValueError("Empty requests list")
+
+        # We process one request at a time (batch_size=1)
+        request = requests[0]
+
+        prompt = request.prompt
+        negative_prompt = request.negative_prompt or ""
+        cfg_scale = (
+            request.guidance_scale
+            if request.guidance_scale is not None
+            else self.DEFAULT_CFG_SCALE
+        )
+        num_inference_steps = (
+            request.num_inference_steps
+            if request.num_inference_steps is not None
+            else self.DEFAULT_NUM_INFERENCE_STEPS
+        )
+        seed = request.seed
+
+        image_tensor = self._generate(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            cfg_scale=cfg_scale,
+            num_inference_steps=num_inference_steps,
+            seed=seed,
+        )
+
+        # Convert tensor to PIL Image
+        # image_tensor is (1, 3, H, W) in range [-1, 1]
+        image_tensor = torch.clamp(image_tensor / 2 + 0.5, 0.0, 1.0)  # -> [0, 1]
+        image_tensor = (image_tensor * 255.0).to(dtype=torch.uint8)
+        image_np = image_tensor.cpu().squeeze(0).numpy()  # (3, H, W)
+        image_np = image_np.transpose(1, 2, 0)  # (H, W, 3)
+        pil_image = Image.fromarray(image_np)
+
+        return [pil_image]

--- a/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
@@ -28,7 +28,7 @@ class SDXLForgeRunner(BaseDeviceRunner):
     DEFAULT_CFG_SCALE = 7.5
     DEFAULT_RESOLUTION = 1024  # 1024x1024
 
-    def __init__(self, device_id: str):
+    def __init__(self, device_id: str, cpu_threads="8", num_torch_threads=8):
         super().__init__(device_id)
         self._setup_done = False
         self.device = None  # XLA or CPU device

--- a/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
@@ -6,8 +6,6 @@ import os
 
 os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
 
-import asyncio
-
 import torch
 from PIL import Image
 
@@ -80,17 +78,17 @@ class SDXLForgeRunner(BaseDeviceRunner):
                 {"optimization_level": optimization_level}
             )
 
+        # Run load and warmup synchronously on the current thread.
+        # This is critical: torch_xla/torch._dynamo compilation state is
+        # thread-local. If warmup runs on a different thread (e.g. via
+        # asyncio.to_thread) than inference (run()), the compiled XLA graph
+        # cache won't be found and the model will fully recompile on the
+        # first real request. The worker process has nothing else to do
+        # during warmup, so blocking the event loop is safe.
+
         # Phase 1: Load pipeline (download weights, compile UNet)
         try:
-            await asyncio.wait_for(
-                asyncio.to_thread(self._load_pipeline),
-                timeout=self.LOAD_TIMEOUT_SECONDS,
-            )
-        except asyncio.TimeoutError:
-            self.logger.error(
-                f"Device {self.device_id}: Pipeline load timed out after {self.LOAD_TIMEOUT_SECONDS}s"
-            )
-            raise
+            self._load_pipeline()
         except Exception as e:
             log_exception_chain(self.logger, self.device_id, "Pipeline load failed", e)
             raise
@@ -99,15 +97,7 @@ class SDXLForgeRunner(BaseDeviceRunner):
 
         # Phase 2: Warmup inference (trigger JIT compilation)
         try:
-            await asyncio.wait_for(
-                asyncio.to_thread(self._warmup_inference_pass),
-                timeout=self.WARMUP_TIMEOUT_SECONDS,
-            )
-        except asyncio.TimeoutError:
-            self.logger.error(
-                f"Device {self.device_id}: Warmup timed out after {self.WARMUP_TIMEOUT_SECONDS}s"
-            )
-            raise
+            self._warmup_inference_pass()
         except Exception as e:
             log_exception_chain(
                 self.logger, self.device_id, "Warmup inference failed", e

--- a/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
@@ -27,7 +27,7 @@ class SDXLForgeRunner(BaseDeviceRunner):
     WARMUP_TIMEOUT_SECONDS = 2000
     DEFAULT_NUM_INFERENCE_STEPS = 20
     DEFAULT_CFG_SCALE = 7.5
-    DEFAULT_RESOLUTION = 1024  # 1024x1024
+    DEFAULT_RESOLUTION = 512
 
     def __init__(self, device_id: str):
         super().__init__(device_id, cpu_threads="8", num_torch_threads=8)

--- a/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
@@ -25,7 +25,7 @@ class SDXLForgeRunner(BaseDeviceRunner):
     """
 
     LOAD_TIMEOUT_SECONDS = 300
-    WARMUP_TIMEOUT_SECONDS = 1000
+    WARMUP_TIMEOUT_SECONDS = 2000
     DEFAULT_NUM_INFERENCE_STEPS = 20
     DEFAULT_CFG_SCALE = 7.5
     DEFAULT_RESOLUTION = 1024  # 1024x1024
@@ -177,7 +177,7 @@ class SDXLForgeRunner(BaseDeviceRunner):
             prompt="a photo of a cat",
             negative_prompt="",
             cfg_scale=self.DEFAULT_CFG_SCALE,
-            num_inference_steps=5,  # minimal steps for warmup
+            num_inference_steps=self.DEFAULT_NUM_INFERENCE_STEPS,  # minimal steps for warmup
             seed=42,
         )
         self.logger.info(f"Device {self.device_id}: Warmup inference done")

--- a/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
@@ -127,13 +127,28 @@ class SDXLForgeRunner(BaseDeviceRunner):
         from diffusers import AutoencoderKL, EulerDiscreteScheduler, UNet2DConditionModel
         from transformers import CLIPTextModel, CLIPTextModelWithProjection, CLIPTokenizer
 
-        model_id = (
-            self.settings.model_weights_path
-            or SupportedModels.STABLE_DIFFUSION_XL_BASE.value
-        )
-        variant = "fp16" if "xl-base-1.0" in model_id else None
+        # Select model based on resolution.
+        # 512px uses hotshotco/SDXL-512, 1024px uses stabilityai/stable-diffusion-xl-base-1.0.
+        if self.resolution == 512:
+            model_id = SupportedModels.STABLE_DIFFUSION_XL_512.value
+            if self.settings.model_weights_path and self.settings.model_weights_path != SupportedModels.STABLE_DIFFUSION_XL_BASE.value:
+                self.logger.warning(
+                    f"Device {self.device_id}: model_weights_path={self.settings.model_weights_path!r} "
+                    f"is set but resolution is 512 — using {model_id} instead"
+                )
+        else:
+            model_id = (
+                self.settings.model_weights_path
+                or SupportedModels.STABLE_DIFFUSION_XL_BASE.value
+            )
 
-        self.logger.info(f"Device {self.device_id}: Loading models from {model_id}")
+        # hotshotco/SDXL-512 doesn't ship native fp16 weights; load full precision and cast
+        variant = "fp16" if model_id == SupportedModels.STABLE_DIFFUSION_XL_BASE.value else None
+
+        self.logger.info(
+            f"Device {self.device_id}: Loading models from {model_id} "
+            f"(resolution={self.resolution}, variant={variant})"
+        )
 
         # VAE — float32, stays on CPU
         self.vae = AutoencoderKL.from_pretrained(

--- a/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
@@ -28,8 +28,8 @@ class SDXLForgeRunner(BaseDeviceRunner):
     DEFAULT_CFG_SCALE = 7.5
     DEFAULT_RESOLUTION = 1024  # 1024x1024
 
-    def __init__(self, device_id: str, cpu_threads="8", num_torch_threads=8):
-        super().__init__(device_id)
+    def __init__(self, device_id: str):
+        super().__init__(device_id, cpu_threads="8", num_torch_threads=8)
         self._setup_done = False
         self.device = None  # XLA or CPU device
 

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -98,6 +98,10 @@ AVAILABLE_RUNNERS = {
     ModelRunners.TT_SPEECHT5_TTS: lambda wid: __import__(
         "tt_model_runners.speecht5_runner", fromlist=["TTSpeechT5Runner"]
     ).TTSpeechT5Runner(wid),
+    ModelRunners.TT_XLA_SDXL: lambda wid: __import__(
+        "tt_model_runners.forge_runners.sdxl_forge_runner",
+        fromlist=["SDXLForgeRunner"],
+    ).SDXLForgeRunner(wid),
 }
 
 


### PR DESCRIPTION
## TL;DR
- new SDXLForgeRunner for running SDXL on single blackhole chip (Unet on device + text encoder and vae decoder on CPU)
- Followup UI for making it easier to show SDXL Forge demo (look at image bellow)

## Perf
- generates single 512x512 image with num_inference_steps=20 in ~10s. For num_inference_steps=50 it is ~18s.

## Start commands 
After doing setup as noted in `tt-media-server/tt_model_runners/forge_runners/README.md` you can run the server with:
```
export MODEL_RUNNER=tt-xla-sdxl                                                                                                           
export CONFIG=Release                    
export API_KEY="sdxl"
export DEVICE=p150x4                                                                                                                                          
export DEVICE_IDS="(0),(1),(2),(3)"                       
export DEVICE_MESH_SHAPE="[1,1]"                                                                                                                                
export IS_GALAXY=false   
export VLLM_TARGET_DEVICE=empty

uvicorn main:app --lifespan on --host 0.0.0.0 --port 8000
```

<img width="1917" height="927" alt="Screenshot 2026-03-19 at 17 24 59" src="https://github.com/user-attachments/assets/7c86be2b-3365-45bd-9a6f-335b30757339" />
