### PR TITLE
Increase trace_region_size for Llama 70B P300x2 to fix trace capture

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1664,7 +1664,7 @@ llm_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 override_tt_config={
-                    "trace_region_size": 57000000,
+                    "trace_region_size": 58000000,
                 },
             ),
         ],

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1664,7 +1664,7 @@ llm_templates = [
                 max_context=128 * 1024,
                 default_impl=True,
                 override_tt_config={
-                    "trace_region_size": 56000000,
+                    "trace_region_size": 57000000,
                 },
             ),
         ],


### PR DESCRIPTION
## Summary

- Bumps `trace_region_size` from `56000000` to `58000000` for Llama 3.x 70B models (including DeepSeek-R1-Distill-Llama-70B) on P300x2 devices in `workflows/model_spec.py`
- Resolves trace capture failures caused by insufficient trace memory allocation on this device configuration