### PR TITLE
Cleanup C++ Checks for Test Gate

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1364,6 +1364,7 @@ jobs:
       - llm-streaming-performance
       - test-coverage
       - cpp-format-check
+      - cpp-build
       - cpp-server-llm-streaming
       - cpp-server-llm-streaming-mock-pipeline
       - cpp-server-prefill-decode-split

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1363,6 +1363,7 @@ jobs:
       - forge-runner-cpu-tests
       - llm-streaming-performance
       - test-coverage
+      - cpp-format-check
       - cpp-server-llm-streaming
       - cpp-server-llm-streaming-mock-pipeline
       - cpp-server-prefill-decode-split

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -494,8 +494,81 @@ jobs:
       - name: Check test result
         run: exit ${{ env.TEST_EXIT_CODE }}
 
-  cpp-server-llm-streaming:
+  cpp-format-check:
     needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.cpp-server == 'true' }}
+    name: C++ Format Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: tt-media-server
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install C++ build dependencies
+        run: cpp_server/install_dependencies.sh
+
+      - name: C++ format check (.clang-format)
+        run: |
+          cd cpp_server
+          if ! find include src tests benchmarks -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.h' \) -print0 \
+            | xargs -0 -r clang-format-20 --dry-run --Werror >/dev/null 2>&1; then
+            echo '::error::Some C++ files are not formatted per .clang-format.'
+            echo 'To fix locally, run from repo root:'
+            echo '  cd tt-media-server/cpp_server && find include src tests benchmarks -type f \( -name '"'"'*.cpp'"'"' -o -name '"'"'*.h'"'"' -o -name '"'"'*.hpp'"'"' \) -print0 | xargs -0 clang-format-20 -i'
+            exit 1
+          fi
+
+      - name: Build with clang-tidy
+        run: |
+          cd cpp_server
+          ./build.sh --clang-tidy
+
+  cpp-build:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.cpp-server == 'true' }}
+    name: C++ Build & Unit Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: tt-media-server
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install C++ build dependencies
+        run: cpp_server/install_dependencies.sh
+
+      - name: Build C++ server
+        run: |
+          cd cpp_server
+          ./build.sh
+          cd ..
+
+      - name: Run C++ unit tests
+        run: |
+          cd cpp_server/build
+          ctest --output-on-failure
+          cd ../..
+
+      - name: Upload C++ build
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpp-server-build
+          path: |
+            tt-media-server/cpp_server/build/
+            tt-media-server/cpp_server/tokenizers/
+          retention-days: 1
+
+  cpp-server-llm-streaming:
+    needs: [detect-changes, cpp-build]
     if: ${{ needs.detect-changes.outputs.cpp-server == 'true' }}
     name: C++ Server LLM Streaming Performance Test
     runs-on: ubuntu-latest
@@ -514,28 +587,14 @@ jobs:
       - name: Install C++ build dependencies
         run: cpp_server/install_dependencies.sh
 
-      - name: Build C++ server
-        run: |
-          cd cpp_server
-          ./build.sh --clang-tidy
-          cd ..
+      - name: Download C++ build
+        uses: actions/download-artifact@v4
+        with:
+          name: cpp-server-build
+          path: tt-media-server/cpp_server
 
-      - name: C++ format check (.clang-format)
-        run: |
-          cd cpp_server
-          if ! find include src tests benchmarks -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.h' \) -print0 \
-            | xargs -0 -r clang-format-20 --dry-run --Werror >/dev/null 2>&1; then
-            echo '::error::Some C++ files are not formatted per .clang-format.'
-            echo 'To fix locally, run from repo root:'
-            echo '  cd tt-media-server/cpp_server && find include src tests benchmarks -type f \( -name '"'"'*.cpp'"'"' -o -name '"'"'*.h'"'"' -o -name '"'"'*.hpp'"'"' \) -print0 | xargs -0 clang-format-20 -i'
-            exit 1
-          fi
-
-      - name: Run C++ unit tests
-        run: |
-          cd cpp_server/build
-          ctest --output-on-failure
-          cd ../..
+      - name: Make binaries executable
+        run: chmod +x cpp_server/build/tt_media_server_cpp
 
       - name: Start C++ server (test runner mode)
         run: |
@@ -674,7 +733,7 @@ jobs:
         run: exit ${{ env.BENCH_FAIL }}
 
   cpp-server-llm-streaming-mock-pipeline:
-    needs: detect-changes
+    needs: [detect-changes, cpp-build]
     if: ${{ needs.detect-changes.outputs.cpp-server == 'true' }}
     name: C++ Server LLM Streaming (mock_pipeline)
     runs-on: ubuntu-latest
@@ -693,11 +752,14 @@ jobs:
       - name: Install C++ build dependencies
         run: cpp_server/install_dependencies.sh
 
-      - name: Build C++ server
-        run: |
-          cd cpp_server
-          ./build.sh
-          cd ..
+      - name: Download C++ build
+        uses: actions/download-artifact@v4
+        with:
+          name: cpp-server-build
+          path: tt-media-server/cpp_server
+
+      - name: Make binaries executable
+        run: chmod +x cpp_server/build/tt_media_server_cpp
 
       - name: Start C++ server (mock_pipeline backend)
         run: |
@@ -836,7 +898,7 @@ jobs:
         run: exit ${{ env.BENCH_FAIL }}
 
   cpp-server-prefill-decode-split:
-    needs: detect-changes
+    needs: [detect-changes, cpp-build]
     if: ${{ needs.detect-changes.outputs.cpp-server == 'true' }}
     name: C++ Server Prefill/Decode Split Test
     runs-on: ubuntu-latest
@@ -855,11 +917,14 @@ jobs:
       - name: Install C++ build dependencies
         run: cpp_server/install_dependencies.sh
 
-      - name: Build C++ server
-        run: |
-          cd cpp_server
-          ./build.sh
-          cd ..
+      - name: Download C++ build
+        uses: actions/download-artifact@v4
+        with:
+          name: cpp-server-build
+          path: tt-media-server/cpp_server
+
+      - name: Make binaries executable
+        run: chmod +x cpp_server/build/tt_media_server_cpp
 
       - name: Start Decode server (receives HTTP, listens for prefill)
         run: |

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -402,7 +402,6 @@ jobs:
               });
             }
 
-
   llm-streaming-performance:
     needs: detect-changes
     name: LLM Streaming Performance Test
@@ -497,7 +496,7 @@ jobs:
   cpp-format-check:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.cpp-server == 'true' }}
-    name: C++ Format Check
+    name: C++ Lint & Format Check
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -523,7 +522,7 @@ jobs:
             exit 1
           fi
 
-      - name: Build with clang-tidy
+      - name: C++ lint check (build with clang-tidy)
         run: |
           cd cpp_server
           ./build.sh --clang-tidy

--- a/tt-media-server/cpp_server/include/domain/base_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/base_request.hpp
@@ -6,6 +6,7 @@ namespace tt::domain {
 
 struct BaseRequest {
   TaskID task_id;
+   int i = 0;
 
   explicit BaseRequest(TaskID taskId) : task_id(std::move(taskId)) {}
 };

--- a/tt-media-server/cpp_server/include/domain/base_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/base_request.hpp
@@ -6,7 +6,7 @@ namespace tt::domain {
 
 struct BaseRequest {
   TaskID task_id;
-   int i = 0;
+   int i = 0
 
   explicit BaseRequest(TaskID taskId) : task_id(std::move(taskId)) {}
 };

--- a/tt-media-server/cpp_server/include/domain/base_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/base_request.hpp
@@ -6,7 +6,6 @@ namespace tt::domain {
 
 struct BaseRequest {
   TaskID task_id;
-   int i = 0
 
   explicit BaseRequest(TaskID taskId) : task_id(std::move(taskId)) {}
 };


### PR DESCRIPTION
## Problem
With this PR C++ server CI pipelines is separating lint/format (clang-format + clang-tidy build) into its own job, and introducing a dedicated cpp-build job that performs the full build, executes unit tests, and publishes build/ and tokenizers/ as artifacts.
Performance jobs then reuse these artifacts, eliminating redundant builds and decoupling lint/format from build and performance stages.
