### PR TITLE
Reasoning parsing for DeepSeek

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -355,6 +355,7 @@ set(SOURCES
     src/ipc/boost_ipc_warmup_signal_queue.cpp
     src/filters/security_filter.cpp
     src/services/llm_service.cpp
+    src/services/reasoning_parser.cpp
     src/utils/tokenizer.cpp
     src/utils/logger.cpp
     src/utils/deepseek_tokenizer.cpp

--- a/tt-media-server/cpp_server/include/domain/chat_completion_response.hpp
+++ b/tt-media-server/cpp_server/include/domain/chat_completion_response.hpp
@@ -231,7 +231,7 @@ struct ChatCompletionStreamChunk {
     ChatCompletionStreamChoice choice;
     choice.index = completionChoice.index;
     choice.delta.content = completionChoice.text;
-    
+
     // Include reasoning content if present (DeepSeek R1 style)
     if (completionChoice.reasoning.has_value()) {
       choice.delta.reasoning = completionChoice.reasoning;

--- a/tt-media-server/cpp_server/include/domain/chat_completion_response.hpp
+++ b/tt-media-server/cpp_server/include/domain/chat_completion_response.hpp
@@ -107,6 +107,7 @@ struct ChatCompletionResponse {
 struct ChatCompletionDelta {
   std::optional<std::string> role;
   std::optional<std::string> content;
+  std::optional<std::string> reasoning;  // Reasoning content for DeepSeek R1
 
   Json::Value toJson() const {
     Json::Value json;
@@ -115,6 +116,9 @@ struct ChatCompletionDelta {
     }
     if (content.has_value()) {
       json["content"] = content.value();
+    }
+    if (reasoning.has_value()) {
+      json["reasoning"] = reasoning.value();
     }
     return json;
   }
@@ -227,6 +231,11 @@ struct ChatCompletionStreamChunk {
     ChatCompletionStreamChoice choice;
     choice.index = completionChoice.index;
     choice.delta.content = completionChoice.text;
+    
+    // Include reasoning content if present (DeepSeek R1 style)
+    if (completionChoice.reasoning.has_value()) {
+      choice.delta.reasoning = completionChoice.reasoning;
+    }
 
     if (completionChoice.finish_reason.has_value()) {
       const std::string& reason = completionChoice.finish_reason.value();

--- a/tt-media-server/cpp_server/include/domain/completion_response.hpp
+++ b/tt-media-server/cpp_server/include/domain/completion_response.hpp
@@ -47,6 +47,7 @@ struct CompletionChoice {
   std::optional<Json::Value> logprobs;
   std::optional<std::string> finish_reason;
   std::optional<int64_t> token_id;
+  std::optional<std::string> reasoning;  // Reasoning content for DeepSeek R1
 
   Json::Value toJson() const {
     Json::Value json;
@@ -57,6 +58,9 @@ struct CompletionChoice {
       json["finish_reason"] = finish_reason.value();
     } else {
       json["finish_reason"] = Json::nullValue;
+    }
+    if (reasoning.has_value()) {
+      json["reasoning"] = reasoning.value();
     }
     return json;
   }
@@ -164,7 +168,16 @@ struct StreamingChunkResponse : BaseResponse {
       result.append(tt::utils::jsonEscape(choices[i].text));
       result.append("\",\"index\":");
       result.append(std::to_string(choices[i].index));
-      result.append(",\"logprobs\":null,\"finish_reason\":");
+      result.append(",\"logprobs\":null");
+      
+      // Add reasoning field if present
+      if (choices[i].reasoning.has_value()) {
+        result.append(",\"reasoning\":\"");
+        result.append(tt::utils::jsonEscape(choices[i].reasoning.value()));
+        result.append("\"");
+      }
+      
+      result.append(",\"finish_reason\":");
       if (choices[i].finish_reason.has_value()) {
         result.append("\"");
         result.append(choices[i].finish_reason.value());

--- a/tt-media-server/cpp_server/include/domain/completion_response.hpp
+++ b/tt-media-server/cpp_server/include/domain/completion_response.hpp
@@ -169,14 +169,14 @@ struct StreamingChunkResponse : BaseResponse {
       result.append("\",\"index\":");
       result.append(std::to_string(choices[i].index));
       result.append(",\"logprobs\":null");
-      
+
       // Add reasoning field if present
       if (choices[i].reasoning.has_value()) {
         result.append(",\"reasoning\":\"");
         result.append(tt::utils::jsonEscape(choices[i].reasoning.value()));
         result.append("\"");
       }
-      
+
       result.append(",\"finish_reason\":");
       if (choices[i].finish_reason.has_value()) {
         result.append("\"");

--- a/tt-media-server/cpp_server/include/services/llm_service.hpp
+++ b/tt-media-server/cpp_server/include/services/llm_service.hpp
@@ -17,6 +17,7 @@
 #include "domain/prefill_request.hpp"
 #include "ipc/queue_manager.hpp"
 #include "services/base_service.hpp"
+#include "services/reasoning_parser.hpp"
 #include "services/streamable.hpp"
 #include "sockets/inter_server_service.hpp"
 #include "utils/concurrent_map.hpp"
@@ -94,6 +95,7 @@ class LLMService
   std::unique_ptr<tt::worker::WorkerManager> worker_manager_;
   const tt::utils::Tokenizer* tokenizer_;
   std::shared_ptr<tt::sockets::InterServerService> socket_service_;
+  std::unique_ptr<ReasoningParser> reasoning_parser_;
 
   PrefillRequestCallback prefill_request_callback_;
 };

--- a/tt-media-server/cpp_server/include/services/reasoning_parser.hpp
+++ b/tt-media-server/cpp_server/include/services/reasoning_parser.hpp
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace tt::services {
+
+// Type of content being generated
+enum class ContentType {
+  REASONING,  // Inside <think>...</think> block
+  ANSWER      // Outside reasoning block (normal content)
+};
+
+// Result of parsing complete text for reasoning blocks
+struct ReasoningParseResult {
+  std::optional<std::string> reasoning;  // Reasoning content (inside <think>)
+  std::string answer;                     // Answer content (outside <think>)
+  bool has_reasoning;                     // Whether reasoning was found
+  bool is_malformed;  // Whether reasoning block is incomplete (missing </think>)
+};
+
+// Result of processing a single token
+struct TokenParseResult {
+  ContentType type;       // Type of content (reasoning or answer)
+  std::string text;       // Decoded text for this token
+  bool should_emit;       // Whether to send to client (always true)
+};
+
+// Per-task state for token-by-token parsing
+struct TaskState {
+  bool in_reasoning;      // Currently inside <think> block
+  bool seen_think_start;  // Has seen <think> token
+};
+
+/**
+ * Reasoning Parser for DeepSeek R1 style <think>...</think> tags.
+ * 
+ * This parser tags tokens as REASONING or ANSWER content but sends ALL tokens
+ * to the client (matching vLLM behavior). The client decides how to display them.
+ * 
+ * Token-based parsing for streaming (O(1) lookups, no string operations).
+ * Text-based parsing for complete responses.
+ */
+class ReasoningParser {
+ public:
+  // Token IDs for DeepSeek R1 reasoning markers
+  static constexpr int64_t THINK_START_TOKEN = 128798;  // <think>
+  static constexpr int64_t THINK_END_TOKEN = 128799;    // </think>
+  static constexpr int64_t NEWLINE_TOKEN = 201;         // \n
+
+  // String markers for text-based parsing
+  static constexpr const char* THINK_START_TAG = "<think>";
+  static constexpr const char* THINK_END_TAG = "</think>";
+
+  ReasoningParser() = default;
+  ~ReasoningParser() = default;
+
+  // Non-copyable
+  ReasoningParser(const ReasoningParser&) = delete;
+  ReasoningParser& operator=(const ReasoningParser&) = delete;
+
+  /**
+   * Parse complete text to extract reasoning and answer.
+   * Used for non-streaming requests.
+   */
+  ReasoningParseResult parseComplete(const std::string& text) const;
+
+  /**
+   * Initialize streaming state for a task.
+   * Call before processing first token.
+   */
+  void initializeTask(const std::string& task_id);
+
+  /**
+   * Process single token for streaming.
+   * Returns content type and whether to emit.
+   * 
+   * @param task_id Unique task identifier
+   * @param token_id Token ID to process
+   * @param decoded_text Decoded text for this token
+   * @return TokenParseResult with content type and emit flag
+   */
+  TokenParseResult processToken(const std::string& task_id, 
+                                 int64_t token_id, 
+                                 const std::string& decoded_text);
+
+  /**
+   * Finalize task state and cleanup.
+   * Call when generation completes.
+   */
+  void finalizeTask(const std::string& task_id);
+
+  /**
+   * Check if task is currently in reasoning mode.
+   */
+  bool isInReasoning(const std::string& task_id) const;
+
+  /**
+   * Get count of active tasks.
+   */
+  size_t activeTaskCount() const;
+
+ private:
+  mutable std::mutex mutex_;
+  std::unordered_map<std::string, TaskState> task_states_;
+};
+
+}  // namespace tt::services

--- a/tt-media-server/cpp_server/include/services/reasoning_parser.hpp
+++ b/tt-media-server/cpp_server/include/services/reasoning_parser.hpp
@@ -40,10 +40,10 @@ struct TaskState {
 
 /**
  * Reasoning Parser for DeepSeek R1 style <think>...</think> tags.
- * 
+ *
  * This parser tags tokens as REASONING or ANSWER content but sends ALL tokens
  * to the client (matching vLLM behavior). The client decides how to display them.
- * 
+ *
  * Token-based parsing for streaming (O(1) lookups, no string operations).
  * Text-based parsing for complete responses.
  */
@@ -80,14 +80,14 @@ class ReasoningParser {
   /**
    * Process single token for streaming.
    * Returns content type and whether to emit.
-   * 
+   *
    * @param task_id Unique task identifier
    * @param token_id Token ID to process
    * @param decoded_text Decoded text for this token
    * @return TokenParseResult with content type and emit flag
    */
-  TokenParseResult processToken(const std::string& task_id, 
-                                 int64_t token_id, 
+  TokenParseResult processToken(const std::string& task_id,
+                                 int64_t token_id,
                                  const std::string& decoded_text);
 
   /**

--- a/tt-media-server/cpp_server/include/services/reasoning_parser.hpp
+++ b/tt-media-server/cpp_server/include/services/reasoning_parser.hpp
@@ -20,16 +20,17 @@ enum class ContentType {
 // Result of parsing complete text for reasoning blocks
 struct ReasoningParseResult {
   std::optional<std::string> reasoning;  // Reasoning content (inside <think>)
-  std::string answer;                     // Answer content (outside <think>)
-  bool has_reasoning;                     // Whether reasoning was found
-  bool is_malformed;  // Whether reasoning block is incomplete (missing </think>)
+  std::string answer;                    // Answer content (outside <think>)
+  bool has_reasoning;                    // Whether reasoning was found
+  bool
+      is_malformed;  // Whether reasoning block is incomplete (missing </think>)
 };
 
 // Result of processing a single token
 struct TokenParseResult {
-  ContentType type;       // Type of content (reasoning or answer)
-  std::string text;       // Decoded text for this token
-  bool should_emit;       // Whether to send to client (always true)
+  ContentType type;  // Type of content (reasoning or answer)
+  std::string text;  // Decoded text for this token
+  bool should_emit;  // Whether to send to client (always true)
 };
 
 // Per-task state for token-by-token parsing
@@ -42,7 +43,8 @@ struct TaskState {
  * Reasoning Parser for DeepSeek R1 style <think>...</think> tags.
  *
  * This parser tags tokens as REASONING or ANSWER content but sends ALL tokens
- * to the client (matching vLLM behavior). The client decides how to display them.
+ * to the client (matching vLLM behavior). The client decides how to display
+ * them.
  *
  * Token-based parsing for streaming (O(1) lookups, no string operations).
  * Text-based parsing for complete responses.
@@ -86,9 +88,8 @@ class ReasoningParser {
    * @param decoded_text Decoded text for this token
    * @return TokenParseResult with content type and emit flag
    */
-  TokenParseResult processToken(const std::string& task_id,
-                                 int64_t token_id,
-                                 const std::string& decoded_text);
+  TokenParseResult processToken(const std::string& task_id, int64_t token_id,
+                                const std::string& decoded_text);
 
   /**
    * Finalize task state and cleanup.

--- a/tt-media-server/cpp_server/src/runners/llm_runner/block_manager.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/block_manager.cpp
@@ -61,7 +61,7 @@ Block& BlockManager::allocateBlock(int blockId) {
 
 void BlockManager::deallocateBlock(int blockId) {
   ZoneScopedN("BlockManager::deallocate_block");
-  assert(blocks_[static_cast<size_t>(block_id)].ref_count == 0);
+  assert(blocks_[static_cast<size_t>(blockId)].ref_count == 0);
   used_block_ids_.erase(blockId);
   free_block_ids_.push_back(blockId);
   LLM_ENGINE_LOG("block_manager")
@@ -76,7 +76,7 @@ bool BlockManager::canAllocate(const Sequence& seq) const {
 
 void BlockManager::allocate(Sequence& seq) {
   ZoneScopedN("BlockManager::allocate");
-  assert(seq.block_table_.empty());
+  assert(seq.blockTable.empty());
   LLM_ENGINE_LOG("block_manager")
       << "allocate task_id=" << seq.taskId << " num_blocks=" << seq.numBlocks()
       << " free=" << free_block_ids_.size() << std::endl;
@@ -147,12 +147,12 @@ void BlockManager::mayAppend(Sequence& seq) {
   if (len % static_cast<size_t>(block_size_) == 1) {
     LLM_ENGINE_LOG("block_manager") << "may_append task_id=" << seq.taskId
                                     << " new_block len=" << len << std::endl;
-    assert(last_block.hash != -1);
+    assert(lastBlock.hash != -1);
     int blockId = free_block_ids_.front();
     allocateBlock(blockId);
     blockTable.push_back(blockId);
   } else if (len % static_cast<size_t>(block_size_) == 0) {
-    assert(last_block.hash == -1);
+    assert(lastBlock.hash == -1);
     LLM_ENGINE_LOG("block_manager")
         << "may_append task_id=" << seq.taskId << " fill_last_block len=" << len
         << std::endl;
@@ -166,7 +166,7 @@ void BlockManager::mayAppend(Sequence& seq) {
     lastBlock.update(h, tokenIds);
     hash_to_block_id_[h] = lastBlock.block_id;
   } else {
-    assert(last_block.hash == -1);
+    assert(lastBlock.hash == -1);
   }
 }
 

--- a/tt-media-server/cpp_server/src/runners/mock_runner.py
+++ b/tt-media-server/cpp_server/src/runners/mock_runner.py
@@ -78,10 +78,49 @@ def _run_mock_bridge() -> None:
                     file=sys.stderr,
                 )
 
+                # DeepSeek R1 reasoning token IDs
+                THINK_START_TOKEN = 128798  # <think>
+                THINK_END_TOKEN = 128799  # </think>
+
+                # First 21 tokens: reasoning sequence <think> ... </think> + start of answer
+                reasoning_and_start_sequence = [
+                    THINK_START_TOKEN,  # <think>
+                    # Reasoning tokens (12 tokens)
+                    2810,  # "Let"
+                    502,  # " me"
+                    1781,  # " think"
+                    922,  # " about"
+                    420,  # " this"
+                    281,  # "."
+                    720,  # " The"
+                    3575,  # " problem"
+                    7612,  # " requires"
+                    8954,  # " careful"
+                    6685,  # " analysis"
+                    281,  # "."
+                    THINK_END_TOKEN,  # </think>
+                    # Start of answer tokens (7 tokens)
+                    791,  # "The"
+                    4320,  # " answer"
+                    374,  # " is"
+                    551,  # ":"
+                    220,  # " "
+                    2983,  # "42"
+                    281,  # "."
+                ]
+
+                # After reasoning sequence, repeat answer tokens
+                continuation_token = 281  # "."
+
                 for i in range(tokens_to_generate):
                     start_time = time.perf_counter()
 
-                    token_id = msg.token_ids[i] if i < len(msg.token_ids) else 12345
+                    # Use reasoning sequence for first 21 tokens, then repeat continuation
+                    if i < len(reasoning_and_start_sequence):
+                        token_id = reasoning_and_start_sequence[i]
+                    else:
+                        token_id = continuation_token
+
                     p2c.write_token(msg.task_id, token_id)
 
                     print(

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -170,8 +170,8 @@ void LLMService::consumerLoopForWorker(size_t workerIdx) {
       }
       auto callback = val.value();
 
-      const std::string taskId = std::string(token.task_id);
-      const bool isFinal = token.isFinal();
+      std::string taskId = std::string(token.task_id);
+      bool isFinal = token.isFinal();
 
       if (isFinal) {
         stream_callbacks_.erase(token.task_id);

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -181,7 +181,8 @@ void LLMService::consumerLoopForWorker(size_t workerIdx) {
       // Process token through reasoning parser to determine content type
       TokenParseResult parseResult{ContentType::ANSWER, "", true};
       if (reasoning_parser_) {
-        std::string decodedText = tokenizer_->decode({static_cast<int>(token.token_id)});
+        std::string decodedText =
+            tokenizer_->decode({static_cast<int>(token.token_id)});
         parseResult = reasoning_parser_->processToken(
             taskId, static_cast<int64_t>(token.token_id), decodedText);
       }

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -20,12 +20,17 @@
 
 namespace tt::services {
 
+// Bring ContentType and TokenParseResult into scope
+using tt::services::ContentType;
+using tt::services::TokenParseResult;
+
 LLMService::LLMService()
     : mode_(tt::config::llmMode()), tokenizer_(&tt::utils::activeTokenizer()) {
   size_t numWorkers = tt::config::numWorkers();
   max_queue_size_ = tt::config::maxQueueSize();
 
   worker_manager_ = std::make_unique<tt::worker::WorkerManager>(numWorkers);
+  reasoning_parser_ = std::make_unique<ReasoningParser>();
 
   TT_LOG_INFO("[LLMService] Initialized (mode={}, workers={})",
               tt::config::toString(mode_), numWorkers);
@@ -164,27 +169,50 @@ void LLMService::consumerLoopForWorker(size_t workerIdx) {
                                  std::string(token.task_id));
       }
       auto callback = val.value();
-      if (token.isFinal()) {
+
+      const std::string taskId = std::string(token.task_id);
+      const bool isFinal = token.isFinal();
+
+      if (isFinal) {
         stream_callbacks_.erase(token.task_id);
         pending_tasks_.fetch_sub(1);
       }
 
-      domain::StreamingChunkResponse response(
-          domain::TaskID(std::string(token.task_id)));
-      response.id = std::string(token.task_id);
+      // Process token through reasoning parser to determine content type
+      TokenParseResult parseResult{ContentType::ANSWER, "", true};
+      if (reasoning_parser_) {
+        std::string decodedText = tokenizer_->decode({static_cast<int>(token.token_id)});
+        parseResult = reasoning_parser_->processToken(
+            taskId, static_cast<int64_t>(token.token_id), decodedText);
+      }
+
+      // Always emit response (send all tokens to client)
+      domain::StreamingChunkResponse response{domain::TaskID(taskId)};
+      response.id = taskId;
       response.created =
           std::chrono::duration_cast<std::chrono::seconds>(
               std::chrono::system_clock::now().time_since_epoch())
               .count();
 
       domain::CompletionChoice choice;
-      choice.text = tokenizer_->decode({static_cast<int>(token.token_id)});
       choice.index = token.token_index;
+
+      // Set text based on content type
+      if (parseResult.type == ContentType::REASONING) {
+        // This is reasoning content - put in reasoning field
+        choice.text = "";  // Empty normal text
+        choice.reasoning = parseResult.text;
+      } else {
+        // This is answer content - put in text field
+        choice.text = parseResult.text;
+        choice.reasoning = std::nullopt;
+      }
+
       if (token.isError()) {
         choice.finish_reason = "error";
       } else {
         choice.token_id = static_cast<int64_t>(token.token_id);
-        if (token.isFinal()) {
+        if (isFinal) {
           bool isStop =
               STOP_TOKEN_SET.count(static_cast<int64_t>(token.token_id)) > 0;
           choice.finish_reason = isStop ? "stop" : "length";
@@ -192,8 +220,13 @@ void LLMService::consumerLoopForWorker(size_t workerIdx) {
       }
       response.choices.push_back(std::move(choice));
 
-      callback(response, token.isFinal());
-      if (token.isFinal()) {
+      callback(response, isFinal);
+
+      if (isFinal) {
+        // Clean up reasoning parser state for this task
+        if (reasoning_parser_) {
+          reasoning_parser_->finalizeTask(taskId);
+        }
         TRACY_PLOT("pending_tasks", static_cast<double>(pending_tasks_.load()));
       }
     }
@@ -229,6 +262,10 @@ domain::CompletionResponse LLMService::processRequest(
       std::move(request),
       [&](domain::StreamingChunkResponse& chunk, bool isFinal) {
         if (!chunk.choices.empty()) {
+          // Accumulate both reasoning and text content
+          if (chunk.choices[0].reasoning.has_value()) {
+            accumulatedText.append(chunk.choices[0].reasoning.value());
+          }
           accumulatedText.append(chunk.choices[0].text);
           completionTokens++;
           if (chunk.choices[0].finish_reason.has_value()) {
@@ -282,6 +319,11 @@ void LLMService::processStreamingRequest(
 
   stream_callbacks_.insert(taskId, std::move(callback));
 
+  // Initialize reasoning parser state for this task
+  if (reasoning_parser_) {
+    reasoning_parser_->initializeTask(taskId);
+  }
+
   auto prompt = std::get<std::vector<int>>(request.prompt);
   std::vector<int64_t> tokenIds(prompt.begin(), prompt.end());
 
@@ -318,8 +360,16 @@ void LLMService::processStreamingRequest(
   queue_manager_->task_queue->push(*std::move(sequence));
 }
 
-void LLMService::postProcess(domain::CompletionResponse&) const {
-  // no-op
+void LLMService::postProcess(domain::CompletionResponse& response) const {
+  // Parse and strip reasoning blocks from all choices
+  if (reasoning_parser_) {
+    for (auto& choice : response.choices) {
+      auto result = reasoning_parser_->parseComplete(choice.text);
+
+      // Replace text with answer only (reasoning stripped)
+      choice.text = std::move(result.answer);
+    }
+  }
 }
 
 std::shared_ptr<tt::sockets::InterServerService> LLMService::getSocketService()

--- a/tt-media-server/cpp_server/src/services/reasoning_parser.cpp
+++ b/tt-media-server/cpp_server/src/services/reasoning_parser.cpp
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#include "services/reasoning_parser.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+
+#include "utils/logger.hpp"
+
+namespace tt::services {
+
+ReasoningParseResult ReasoningParser::parseComplete(
+    const std::string& text) const {
+  ReasoningParseResult result;
+
+  // Check if text starts with <think>
+  const size_t start_len = std::strlen(THINK_START_TAG);
+  const size_t end_len = std::strlen(THINK_END_TAG);
+
+  if (text.size() < start_len ||
+      text.compare(0, start_len, THINK_START_TAG) != 0) {
+    // No <think> tag at start - treat entire text as answer
+    result.reasoning = std::nullopt;
+    result.answer = text;
+    result.has_reasoning = false;
+    result.is_malformed = false;
+    return result;
+  }
+
+  // Has <think> tag at start
+  result.has_reasoning = true;
+
+  // Find </think> delimiter
+  size_t end_pos = text.find(THINK_END_TAG, start_len);
+
+  if (end_pos == std::string::npos) {
+    // Malformed: has <think> but no </think>
+    // Treat everything after <think> as reasoning, no answer
+    std::string reasoning_content = text.substr(start_len);
+
+    // Trim leading/trailing whitespace from reasoning
+    size_t first = reasoning_content.find_first_not_of("\n\r\t ");
+    size_t last = reasoning_content.find_last_not_of("\n\r\t ");
+
+    if (first != std::string::npos && last != std::string::npos) {
+      result.reasoning = reasoning_content.substr(first, last - first + 1);
+    } else {
+      result.reasoning = reasoning_content;
+    }
+
+    result.answer = "";
+    result.is_malformed = true;
+
+    TT_LOG_WARN(
+        "[ReasoningParser] Malformed output: found <think> but no </think>");
+    return result;
+  }
+
+  // Extract reasoning (between <think> and </think>)
+  std::string reasoning_content = text.substr(start_len, end_pos - start_len);
+
+  // Trim leading/trailing whitespace from reasoning
+  size_t first = reasoning_content.find_first_not_of("\n\r\t ");
+  size_t last = reasoning_content.find_last_not_of("\n\r\t ");
+
+  if (first != std::string::npos && last != std::string::npos) {
+    result.reasoning = reasoning_content.substr(first, last - first + 1);
+  } else {
+    result.reasoning = reasoning_content;
+  }
+
+  // Extract answer (after </think>)
+  size_t answer_start = end_pos + end_len;
+  std::string answer_content = text.substr(answer_start);
+
+  // Trim leading whitespace from answer
+  first = answer_content.find_first_not_of("\n\r\t ");
+  if (first != std::string::npos) {
+    result.answer = answer_content.substr(first);
+  } else {
+    result.answer = answer_content;
+  }
+
+  result.is_malformed = false;
+  return result;
+}
+
+void ReasoningParser::initializeTask(const std::string& taskId) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Initialize or reset task state
+  TaskState& state = task_states_[taskId];
+  state.in_reasoning = false;
+  state.seen_think_start = false;
+
+  TT_LOG_DEBUG("[ReasoningParser] Initialized task: {}", taskId);
+}
+
+TokenParseResult ReasoningParser::processToken(const std::string& taskId,
+                                                int64_t tokenId,
+                                                const std::string& decodedText) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = task_states_.find(taskId);
+  if (it == task_states_.end()) {
+    // Task not initialized - treat as normal answer content
+    TT_LOG_WARN(
+        "[ReasoningParser] processToken called for uninitialized task: {}",
+        taskId);
+    return {ContentType::ANSWER, decodedText, true};
+  }
+
+  TaskState& state = it->second;
+
+  if (tokenId == THINK_START_TOKEN) {
+    // Entering reasoning block
+    state.in_reasoning = true;
+    state.seen_think_start = true;
+    TT_LOG_DEBUG("[ReasoningParser] Task {} entered reasoning block", taskId);
+    // Return as reasoning content (send to client with reasoning tag)
+    return {ContentType::REASONING, decodedText, true};
+
+  } else if (tokenId == THINK_END_TOKEN) {
+    // Exiting reasoning block
+    if (!state.in_reasoning) {
+      TT_LOG_WARN(
+          "[ReasoningParser] Task {} found </think> without matching <think>",
+          taskId);
+    }
+    state.in_reasoning = false;
+    TT_LOG_DEBUG("[ReasoningParser] Task {} exited reasoning block", taskId);
+    // Return as reasoning content (end marker, send to client)
+    return {ContentType::REASONING, decodedText, true};
+
+  } else if (state.in_reasoning) {
+    // Inside reasoning block - tag as reasoning content
+    return {ContentType::REASONING, decodedText, true};
+
+  } else {
+    // Outside reasoning block - tag as normal answer content
+    return {ContentType::ANSWER, decodedText, true};
+  }
+}
+
+void ReasoningParser::finalizeTask(const std::string& taskId) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = task_states_.find(taskId);
+  if (it == task_states_.end()) {
+    TT_LOG_WARN(
+        "[ReasoningParser] finalizeTask called for unknown task: {}", taskId);
+    return;
+  }
+
+  const TaskState& state = it->second;
+
+  // Warn if task ended while still in reasoning block
+  if (state.in_reasoning || (state.seen_think_start && state.in_reasoning)) {
+    TT_LOG_WARN(
+        "[ReasoningParser] Task {} ended while still in reasoning block "
+        "(incomplete reasoning)",
+        taskId);
+  }
+
+  task_states_.erase(it);
+  TT_LOG_DEBUG("[ReasoningParser] Finalized task: {}", taskId);
+}
+
+bool ReasoningParser::isInReasoning(const std::string& taskId) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = task_states_.find(taskId);
+  if (it == task_states_.end()) {
+    return false;
+  }
+
+  return it->second.in_reasoning;
+}
+
+size_t ReasoningParser::activeTaskCount() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return task_states_.size();
+}
+
+}  // namespace tt::services

--- a/tt-media-server/cpp_server/src/services/reasoning_parser.cpp
+++ b/tt-media-server/cpp_server/src/services/reasoning_parser.cpp
@@ -99,8 +99,8 @@ void ReasoningParser::initializeTask(const std::string& taskId) {
 }
 
 TokenParseResult ReasoningParser::processToken(const std::string& taskId,
-                                                int64_t tokenId,
-                                                const std::string& decodedText) {
+                                               int64_t tokenId,
+                                               const std::string& decodedText) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   auto it = task_states_.find(taskId);
@@ -149,8 +149,8 @@ void ReasoningParser::finalizeTask(const std::string& taskId) {
 
   auto it = task_states_.find(taskId);
   if (it == task_states_.end()) {
-    TT_LOG_WARN(
-        "[ReasoningParser] finalizeTask called for unknown task: {}", taskId);
+    TT_LOG_WARN("[ReasoningParser] finalizeTask called for unknown task: {}",
+                taskId);
     return;
   }
 

--- a/tt-media-server/cpp_server/src/services/reasoning_parser.cpp
+++ b/tt-media-server/cpp_server/src/services/reasoning_parser.cpp
@@ -16,11 +16,11 @@ ReasoningParseResult ReasoningParser::parseComplete(
   ReasoningParseResult result;
 
   // Check if text starts with <think>
-  const size_t start_len = std::strlen(THINK_START_TAG);
-  const size_t end_len = std::strlen(THINK_END_TAG);
+  size_t startLen = std::strlen(THINK_START_TAG);
+  size_t endLen = std::strlen(THINK_END_TAG);
 
-  if (text.size() < start_len ||
-      text.compare(0, start_len, THINK_START_TAG) != 0) {
+  if (text.size() < startLen ||
+      text.compare(0, startLen, THINK_START_TAG) != 0) {
     // No <think> tag at start - treat entire text as answer
     result.reasoning = std::nullopt;
     result.answer = text;
@@ -33,21 +33,21 @@ ReasoningParseResult ReasoningParser::parseComplete(
   result.has_reasoning = true;
 
   // Find </think> delimiter
-  size_t end_pos = text.find(THINK_END_TAG, start_len);
+  size_t endPos = text.find(THINK_END_TAG, startLen);
 
-  if (end_pos == std::string::npos) {
+  if (endPos == std::string::npos) {
     // Malformed: has <think> but no </think>
     // Treat everything after <think> as reasoning, no answer
-    std::string reasoning_content = text.substr(start_len);
+    std::string reasoningContent = text.substr(startLen);
 
     // Trim leading/trailing whitespace from reasoning
-    size_t first = reasoning_content.find_first_not_of("\n\r\t ");
-    size_t last = reasoning_content.find_last_not_of("\n\r\t ");
+    size_t first = reasoningContent.find_first_not_of("\n\r\t ");
+    size_t last = reasoningContent.find_last_not_of("\n\r\t ");
 
     if (first != std::string::npos && last != std::string::npos) {
-      result.reasoning = reasoning_content.substr(first, last - first + 1);
+      result.reasoning = reasoningContent.substr(first, last - first + 1);
     } else {
-      result.reasoning = reasoning_content;
+      result.reasoning = reasoningContent;
     }
 
     result.answer = "";
@@ -59,28 +59,28 @@ ReasoningParseResult ReasoningParser::parseComplete(
   }
 
   // Extract reasoning (between <think> and </think>)
-  std::string reasoning_content = text.substr(start_len, end_pos - start_len);
+  std::string reasoningContent = text.substr(startLen, endPos - startLen);
 
   // Trim leading/trailing whitespace from reasoning
-  size_t first = reasoning_content.find_first_not_of("\n\r\t ");
-  size_t last = reasoning_content.find_last_not_of("\n\r\t ");
+  size_t first = reasoningContent.find_first_not_of("\n\r\t ");
+  size_t last = reasoningContent.find_last_not_of("\n\r\t ");
 
   if (first != std::string::npos && last != std::string::npos) {
-    result.reasoning = reasoning_content.substr(first, last - first + 1);
+    result.reasoning = reasoningContent.substr(first, last - first + 1);
   } else {
-    result.reasoning = reasoning_content;
+    result.reasoning = reasoningContent;
   }
 
   // Extract answer (after </think>)
-  size_t answer_start = end_pos + end_len;
-  std::string answer_content = text.substr(answer_start);
+  size_t answerStart = endPos + endLen;
+  std::string answerContent = text.substr(answerStart);
 
   // Trim leading whitespace from answer
-  first = answer_content.find_first_not_of("\n\r\t ");
+  first = answerContent.find_first_not_of("\n\r\t ");
   if (first != std::string::npos) {
-    result.answer = answer_content.substr(first);
+    result.answer = answerContent.substr(first);
   } else {
-    result.answer = answer_content;
+    result.answer = answerContent;
   }
 
   result.is_malformed = false;

--- a/tt-media-server/cpp_server/tests/test_reasoning_parser.cpp
+++ b/tt-media-server/cpp_server/tests/test_reasoning_parser.cpp
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#include "services/reasoning_parser.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <string>
+
+using namespace tt::services;
+
+void testParseComplete() {
+  std::cout << "\n=== Testing parseComplete ===\n";
+
+  ReasoningParser parser;
+
+  // Test 1: Complete reasoning block
+  {
+    std::string input =
+        "<think>\nOkay, the user is asking about math.\n</think>\nThe answer "
+        "is 42.";
+    auto result = parser.parseComplete(input);
+
+    assert(result.has_reasoning);
+    assert(!result.is_malformed);
+    assert(result.reasoning.has_value());
+    assert(result.reasoning.value() ==
+           "Okay, the user is asking about math.");
+    assert(result.answer == "The answer is 42.");
+    std::cout << "✓ Test 1 passed: Complete reasoning block\n";
+  }
+
+  // Test 2: No reasoning block
+  {
+    std::string input = "The answer is 42.";
+    auto result = parser.parseComplete(input);
+
+    assert(!result.has_reasoning);
+    assert(!result.is_malformed);
+    assert(!result.reasoning.has_value());
+    assert(result.answer == "The answer is 42.");
+    std::cout << "✓ Test 2 passed: No reasoning block\n";
+  }
+
+  // Test 3: Malformed (missing </think>)
+  {
+    std::string input = "<think>\nOkay, the user is asking about math.";
+    auto result = parser.parseComplete(input);
+
+    assert(result.has_reasoning);
+    assert(result.is_malformed);
+    assert(result.reasoning.has_value());
+    assert(result.reasoning.value() ==
+           "Okay, the user is asking about math.");
+    assert(result.answer == "");
+    std::cout << "✓ Test 3 passed: Malformed (missing </think>)\n";
+  }
+
+  // Test 4: Empty reasoning
+  {
+    std::string input = "<think>\n\n</think>\nThe answer is 42.";
+    auto result = parser.parseComplete(input);
+
+    assert(result.has_reasoning);
+    assert(!result.is_malformed);
+    // Empty reasoning after trimming should be empty string
+    assert(result.answer == "The answer is 42.");
+    std::cout << "✓ Test 4 passed: Empty reasoning\n";
+  }
+
+  // Test 5: Multi-line reasoning
+  {
+    std::string input =
+        "<think>\nFirst, I need to understand the question.\nThen I'll "
+        "calculate.\nFinally, I'll provide the answer.\n</think>\nThe answer "
+        "is 42.";
+    auto result = parser.parseComplete(input);
+
+    assert(result.has_reasoning);
+    assert(!result.is_malformed);
+    assert(result.reasoning.has_value());
+    assert(result.reasoning.value().find("First") != std::string::npos);
+    assert(result.reasoning.value().find("Finally") != std::string::npos);
+    assert(result.answer == "The answer is 42.");
+    std::cout << "✓ Test 5 passed: Multi-line reasoning\n";
+  }
+
+  std::cout << "✅ All parseComplete tests passed!\n";
+}
+
+void testStreamingTokens() {
+  std::cout << "\n=== Testing Streaming Tokens ===\n";
+
+  ReasoningParser parser;
+  std::string taskId = "test-task-123";
+
+  // Initialize task
+  parser.initializeTask(taskId);
+  assert(parser.activeTaskCount() == 1);
+  std::cout << "✓ Task initialized\n";
+
+  // Simulate token sequence: <think> reasoning </think> answer
+  std::vector<int64_t> tokens = {
+      ReasoningParser::THINK_START_TOKEN,  // <think>
+      201,                                  // \n
+      12345,                                // "reasoning"
+      67890,                                // "text"
+      ReasoningParser::THINK_END_TOKEN,    // </think>
+      201,                                  // \n
+      11111,                                // "answer"
+      22222,                                // "text"
+      1                                     // EOS
+  };
+
+  std::vector<bool> expected = {
+      false,  // <think> - filtered
+      false,  // \n - filtered (in reasoning)
+      false,  // reasoning - filtered
+      false,  // text - filtered
+      false,  // </think> - filtered
+      true,   // \n - emitted
+      true,   // answer - emitted
+      true,   // text - emitted
+      true    // EOS - emitted
+  };
+
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    bool shouldEmit = parser.processToken(taskId, tokens[i]);
+    assert(shouldEmit == expected[i]);
+  }
+
+  std::cout << "✓ Token filtering correct\n";
+
+  // Check state
+  assert(!parser.isInReasoning(taskId));
+  std::cout << "✓ Final state: not in reasoning\n";
+
+  // Finalize
+  parser.finalizeTask(taskId);
+  assert(parser.activeTaskCount() == 0);
+  std::cout << "✓ Task finalized\n";
+
+  std::cout << "✅ All streaming token tests passed!\n";
+}
+
+void testMultipleTasks() {
+  std::cout << "\n=== Testing Multiple Concurrent Tasks ===\n";
+
+  ReasoningParser parser;
+
+  // Initialize multiple tasks
+  for (int i = 0; i < 512; ++i) {
+    std::string taskId = "task-" + std::to_string(i);
+    parser.initializeTask(taskId);
+  }
+
+  assert(parser.activeTaskCount() == 512);
+  std::cout << "✓ Initialized 512 tasks\n";
+
+  // Process tokens for different tasks in interleaved manner
+  for (int i = 0; i < 512; i += 2) {
+    std::string taskId = "task-" + std::to_string(i);
+    
+    // Task enters reasoning
+    bool shouldEmit = parser.processToken(taskId, ReasoningParser::THINK_START_TOKEN);
+    assert(!shouldEmit);
+    assert(parser.isInReasoning(taskId));
+  }
+
+  std::cout << "✓ Even-numbered tasks in reasoning\n";
+
+  // Check odd tasks are not in reasoning
+  for (int i = 1; i < 512; i += 2) {
+    std::string taskId = "task-" + std::to_string(i);
+    assert(!parser.isInReasoning(taskId));
+  }
+
+  std::cout << "✓ Odd-numbered tasks not in reasoning\n";
+
+  // Exit reasoning for even tasks
+  for (int i = 0; i < 512; i += 2) {
+    std::string taskId = "task-" + std::to_string(i);
+    bool shouldEmit = parser.processToken(taskId, ReasoningParser::THINK_END_TOKEN);
+    assert(!shouldEmit);  // </think> itself is filtered
+    assert(!parser.isInReasoning(taskId));
+  }
+
+  std::cout << "✓ Even-numbered tasks exited reasoning\n";
+
+  // Finalize all tasks
+  for (int i = 0; i < 512; ++i) {
+    std::string taskId = "task-" + std::to_string(i);
+    parser.finalizeTask(taskId);
+  }
+
+  assert(parser.activeTaskCount() == 0);
+  std::cout << "✓ All tasks finalized\n";
+
+  std::cout << "✅ All multi-task tests passed!\n";
+}
+
+void testEdgeCases() {
+  std::cout << "\n=== Testing Edge Cases ===\n";
+
+  ReasoningParser parser;
+
+  // Test 1: Uninitialized task
+  {
+    bool shouldEmit = parser.processToken("uninitialized", 12345);
+    assert(shouldEmit);  // Should emit by default
+    std::cout << "✓ Test 1 passed: Uninitialized task emits by default\n";
+  }
+
+  // Test 2: </think> without <think>
+  {
+    std::string taskId = "malformed-task";
+    parser.initializeTask(taskId);
+    
+    // Process </think> without <think>
+    bool shouldEmit = parser.processToken(taskId, ReasoningParser::THINK_END_TOKEN);
+    assert(!shouldEmit);  // Tag itself is filtered
+    assert(!parser.isInReasoning(taskId));
+    
+    parser.finalizeTask(taskId);
+    std::cout << "✓ Test 2 passed: </think> without <think> handled\n";
+  }
+
+  // Test 3: Multiple <think> tags
+  {
+    std::string taskId = "multi-think";
+    parser.initializeTask(taskId);
+    
+    parser.processToken(taskId, ReasoningParser::THINK_START_TOKEN);
+    assert(parser.isInReasoning(taskId));
+    
+    // Another <think> while already in reasoning
+    bool shouldEmit = parser.processToken(taskId, ReasoningParser::THINK_START_TOKEN);
+    assert(!shouldEmit);  // Still filtered
+    assert(parser.isInReasoning(taskId));
+    
+    parser.processToken(taskId, ReasoningParser::THINK_END_TOKEN);
+    assert(!parser.isInReasoning(taskId));
+    
+    parser.finalizeTask(taskId);
+    std::cout << "✓ Test 3 passed: Multiple <think> tags handled\n";
+  }
+
+  // Test 4: Finalize while in reasoning
+  {
+    std::string taskId = "incomplete";
+    parser.initializeTask(taskId);
+    
+    parser.processToken(taskId, ReasoningParser::THINK_START_TOKEN);
+    assert(parser.isInReasoning(taskId));
+    
+    // Finalize without closing tag (logs warning but doesn't crash)
+    parser.finalizeTask(taskId);
+    assert(parser.activeTaskCount() == 0);
+    
+    std::cout << "✓ Test 4 passed: Finalize while in reasoning handled\n";
+  }
+
+  std::cout << "✅ All edge case tests passed!\n";
+}
+
+int main() {
+  std::cout << "\n";
+  std::cout << "╔══════════════════════════════════════════════════════════╗\n";
+  std::cout << "║     DeepSeek R1 Reasoning Parser Test Suite             ║\n";
+  std::cout << "╚══════════════════════════════════════════════════════════╝\n";
+
+  try {
+    testParseComplete();
+    testStreamingTokens();
+    testMultipleTasks();
+    testEdgeCases();
+
+    std::cout << "\n";
+    std::cout << "╔══════════════════════════════════════════════════════════╗\n";
+    std::cout << "║              🎉 ALL TESTS PASSED! 🎉                    ║\n";
+    std::cout << "╚══════════════════════════════════════════════════════════╝\n";
+    std::cout << "\n";
+
+    return 0;
+  } catch (const std::exception& e) {
+    std::cerr << "\n❌ TEST FAILED: " << e.what() << "\n";
+    return 1;
+  }
+}

--- a/tt-media-server/cpp_server/tests/test_reasoning_parser.cpp
+++ b/tt-media-server/cpp_server/tests/test_reasoning_parser.cpp
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-#include "services/reasoning_parser.hpp"
-
 #include <cassert>
 #include <iostream>
 #include <string>
+
+#include "services/reasoning_parser.hpp"
 
 using namespace tt::services;
 
@@ -24,8 +24,7 @@ void testParseComplete() {
     assert(result.has_reasoning);
     assert(!result.is_malformed);
     assert(result.reasoning.has_value());
-    assert(result.reasoning.value() ==
-           "Okay, the user is asking about math.");
+    assert(result.reasoning.value() == "Okay, the user is asking about math.");
     assert(result.answer == "The answer is 42.");
     std::cout << "✓ Test 1 passed: Complete reasoning block\n";
   }
@@ -50,8 +49,7 @@ void testParseComplete() {
     assert(result.has_reasoning);
     assert(result.is_malformed);
     assert(result.reasoning.has_value());
-    assert(result.reasoning.value() ==
-           "Okay, the user is asking about math.");
+    assert(result.reasoning.value() == "Okay, the user is asking about math.");
     assert(result.answer == "");
     std::cout << "✓ Test 3 passed: Malformed (missing </think>)\n";
   }
@@ -102,14 +100,14 @@ void testStreamingTokens() {
   // Simulate token sequence: <think> reasoning </think> answer
   std::vector<int64_t> tokens = {
       ReasoningParser::THINK_START_TOKEN,  // <think>
-      201,                                  // \n
-      12345,                                // "reasoning"
-      67890,                                // "text"
+      201,                                 // \n
+      12345,                               // "reasoning"
+      67890,                               // "text"
       ReasoningParser::THINK_END_TOKEN,    // </think>
-      201,                                  // \n
-      11111,                                // "answer"
-      22222,                                // "text"
-      1                                     // EOS
+      201,                                 // \n
+      11111,                               // "answer"
+      22222,                               // "text"
+      1                                    // EOS
   };
 
   std::vector<bool> expected = {
@@ -160,9 +158,10 @@ void testMultipleTasks() {
   // Process tokens for different tasks in interleaved manner
   for (int i = 0; i < 512; i += 2) {
     std::string taskId = "task-" + std::to_string(i);
-    
+
     // Task enters reasoning
-    bool shouldEmit = parser.processToken(taskId, ReasoningParser::THINK_START_TOKEN);
+    bool shouldEmit =
+        parser.processToken(taskId, ReasoningParser::THINK_START_TOKEN);
     assert(!shouldEmit);
     assert(parser.isInReasoning(taskId));
   }
@@ -180,7 +179,8 @@ void testMultipleTasks() {
   // Exit reasoning for even tasks
   for (int i = 0; i < 512; i += 2) {
     std::string taskId = "task-" + std::to_string(i);
-    bool shouldEmit = parser.processToken(taskId, ReasoningParser::THINK_END_TOKEN);
+    bool shouldEmit =
+        parser.processToken(taskId, ReasoningParser::THINK_END_TOKEN);
     assert(!shouldEmit);  // </think> itself is filtered
     assert(!parser.isInReasoning(taskId));
   }
@@ -215,12 +215,13 @@ void testEdgeCases() {
   {
     std::string taskId = "malformed-task";
     parser.initializeTask(taskId);
-    
+
     // Process </think> without <think>
-    bool shouldEmit = parser.processToken(taskId, ReasoningParser::THINK_END_TOKEN);
+    bool shouldEmit =
+        parser.processToken(taskId, ReasoningParser::THINK_END_TOKEN);
     assert(!shouldEmit);  // Tag itself is filtered
     assert(!parser.isInReasoning(taskId));
-    
+
     parser.finalizeTask(taskId);
     std::cout << "✓ Test 2 passed: </think> without <think> handled\n";
   }
@@ -229,18 +230,19 @@ void testEdgeCases() {
   {
     std::string taskId = "multi-think";
     parser.initializeTask(taskId);
-    
+
     parser.processToken(taskId, ReasoningParser::THINK_START_TOKEN);
     assert(parser.isInReasoning(taskId));
-    
+
     // Another <think> while already in reasoning
-    bool shouldEmit = parser.processToken(taskId, ReasoningParser::THINK_START_TOKEN);
+    bool shouldEmit =
+        parser.processToken(taskId, ReasoningParser::THINK_START_TOKEN);
     assert(!shouldEmit);  // Still filtered
     assert(parser.isInReasoning(taskId));
-    
+
     parser.processToken(taskId, ReasoningParser::THINK_END_TOKEN);
     assert(!parser.isInReasoning(taskId));
-    
+
     parser.finalizeTask(taskId);
     std::cout << "✓ Test 3 passed: Multiple <think> tags handled\n";
   }
@@ -249,14 +251,14 @@ void testEdgeCases() {
   {
     std::string taskId = "incomplete";
     parser.initializeTask(taskId);
-    
+
     parser.processToken(taskId, ReasoningParser::THINK_START_TOKEN);
     assert(parser.isInReasoning(taskId));
-    
+
     // Finalize without closing tag (logs warning but doesn't crash)
     parser.finalizeTask(taskId);
     assert(parser.activeTaskCount() == 0);
-    
+
     std::cout << "✓ Test 4 passed: Finalize while in reasoning handled\n";
   }
 
@@ -276,9 +278,12 @@ int main() {
     testEdgeCases();
 
     std::cout << "\n";
-    std::cout << "╔══════════════════════════════════════════════════════════╗\n";
-    std::cout << "║              🎉 ALL TESTS PASSED! 🎉                    ║\n";
-    std::cout << "╚══════════════════════════════════════════════════════════╝\n";
+    std::cout
+        << "╔══════════════════════════════════════════════════════════╗\n";
+    std::cout
+        << "║              🎉 ALL TESTS PASSED! 🎉                    ║\n";
+    std::cout
+        << "╚══════════════════════════════════════════════════════════╝\n";
     std::cout << "\n";
 
     return 0;


### PR DESCRIPTION
Changes:

- Added reasoning parser for DeepSeek
- Fixed minor typos with block manager

Behavior:

If response contains <think> it'll go to reasoning block until </think> is present.

Both tokens will be sent to the client so different blocks can we displayed:

<img width="1293" height="399" alt="image" src="https://github.com/user-attachments/assets/71f1e231-e820-43a0-b710-2754ac2a1932" />


<img width="1293" height="399" alt="image" src="https://github.com/user-attachments/assets/9ddc45f2-5b80-46c0-8b05-80e57f1e50e5" />


