### PR TITLE
Add /v1/chat/completions endpoint and fix streaming artifacts

### DIFF
--- a/tt-media-server/domain/chat_completion_request.py
+++ b/tt-media-server/domain/chat_completion_request.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+from typing import Union
+
+from pydantic import BaseModel
+
+
+class ChatMessage(BaseModel):
+    """A single message in a chat conversation."""
+
+    role: str
+    content: str
+
+
+class ChatCompletionRequest(BaseModel):
+    """
+    OpenAI-compatible chat completion request.
+    See: https://platform.openai.com/docs/api-reference/chat/create
+    """
+
+    model: str | None = None
+    messages: list[ChatMessage]
+    max_tokens: int | None = 2048
+    temperature: float | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    repetition_penalty: float | None = None
+    frequency_penalty: float | None = 0.0
+    presence_penalty: float | None = 0.0
+    stream: bool | None = False
+    stop: Union[str, list[str], None] = []
+    n: int = 1
+    seed: int | None = None
+    user: str | None = None

--- a/tt-media-server/open_ai_api/__init__.py
+++ b/tt-media-server/open_ai_api/__init__.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter
 
 from open_ai_api import (
     audio,
+    chat,
     cnn,
     embedding,
     fine_tuning,
@@ -46,6 +47,7 @@ SERVICE_ROUTER_MAP: dict[str, list[ServiceRoute]] = {
     ModelServices.LLM.value: [
         ServiceRoute(tokenizer.router, "/v1", "", ["Tokenizer"]),
         ServiceRoute(llm.router, "/v1", None, ["Text processing"]),
+        ServiceRoute(chat.router, "/v1", None, ["Chat completions"]),
     ],
     ModelServices.CNN.value: [
         ServiceRoute(cnn.router, "/v1/cnn", "/cnn", ["CNN processing"]),

--- a/tt-media-server/open_ai_api/chat.py
+++ b/tt-media-server/open_ai_api/chat.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import json
+import time
+import uuid
+from functools import lru_cache
+
+from config.settings import settings
+from domain.chat_completion_request import ChatCompletionRequest
+from domain.completion_request import CompletionRequest
+from fastapi import APIRouter, Depends, HTTPException, Security
+from fastapi.responses import JSONResponse, StreamingResponse
+from model_services.base_service import BaseService
+from resolver.service_resolver import service_resolver
+from security.api_key_checker import get_api_key
+from transformers import AutoTokenizer
+from utils.logger import TTLogger
+
+router = APIRouter()
+logger = TTLogger()
+
+
+@lru_cache(maxsize=1)
+def _get_tokenizer():
+    model_name = settings.model_weights_path
+    logger.info(f"Loading tokenizer for chat template: {model_name}")
+    return AutoTokenizer.from_pretrained(model_name)
+
+
+def _apply_chat_template(messages: list[dict]) -> str:
+    tokenizer = _get_tokenizer()
+    return tokenizer.apply_chat_template(
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+
+
+def _count_tokens(text: str) -> int:
+    tokenizer = _get_tokenizer()
+    return len(tokenizer.encode(text))
+
+
+def _build_completion_request(
+    chat_request: ChatCompletionRequest, prompt: str
+) -> CompletionRequest:
+    return CompletionRequest(
+        model=chat_request.model,
+        prompt=prompt,
+        max_tokens=chat_request.max_tokens,
+        temperature=chat_request.temperature,
+        top_p=chat_request.top_p,
+        top_k=chat_request.top_k,
+        repetition_penalty=chat_request.repetition_penalty,
+        frequency_penalty=chat_request.frequency_penalty,
+        presence_penalty=chat_request.presence_penalty,
+        stream=chat_request.stream,
+        stop=chat_request.stop,
+        n=chat_request.n,
+        seed=chat_request.seed,
+    )
+
+
+@router.post("/chat/completions")
+async def chat_completions(
+    chat_request: ChatCompletionRequest,
+    service: BaseService = Depends(service_resolver),
+    api_key: str = Security(get_api_key),
+):
+    """
+    Create a chat completion. OpenAI-compatible endpoint.
+
+    Accepts messages in chat format, applies the model's chat template,
+    and returns completions in the chat completions response format.
+    See: https://platform.openai.com/docs/api-reference/chat/create
+    """
+    completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
+    created = int(time.time())
+    model = chat_request.model or (
+        settings.vllm.model
+        if hasattr(settings, "vllm")
+        else settings.model_weights_path
+    )
+
+    # Convert chat messages to a prompt using the model's chat template
+    messages = [{"role": m.role, "content": m.content} for m in chat_request.messages]
+    prompt = _apply_chat_template(messages)
+    prompt_tokens = _count_tokens(prompt)
+
+    # Build an internal CompletionRequest to reuse the existing inference pipeline
+    completion_request = _build_completion_request(chat_request, prompt)
+
+    try:
+        if not chat_request.stream:
+            result = await service.process_request(completion_request)
+            completion_tokens = _count_tokens(result.text) if result.text else 0
+            response = {
+                "id": completion_id,
+                "object": "chat.completion",
+                "created": created,
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": result.text},
+                        "finish_reason": result.finish_reason or "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                },
+            }
+            return JSONResponse(content=response)
+
+        # Streaming path
+        try:
+            service.scheduler.check_is_model_ready()
+        except Exception:
+            raise HTTPException(status_code=405, detail="Model is not ready")
+
+        async def result_stream():
+            accumulated_text = ""
+            async for partial in service.process_streaming_request(completion_request):
+                accumulated_text += partial.text
+                chunk = {
+                    "id": completion_id,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": partial.text},
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+                yield f"data: {json.dumps(chunk)}\n\n"
+
+            # Final chunk with finish_reason and usage stats
+            completion_tokens = (
+                _count_tokens(accumulated_text) if accumulated_text else 0
+            )
+            final_chunk = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                },
+            }
+            yield f"data: {json.dumps(final_chunk)}\n\n"
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(
+            result_stream(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/tt-media-server/open_ai_api/models.py
+++ b/tt-media-server/open_ai_api/models.py
@@ -38,7 +38,10 @@ def list_models():
     List current model. OpenAI-compatible endpoint.
     See: https://platform.openai.com/docs/api-reference/models/list
     """
-    model_id = settings.model_weights_path
+    if settings.model_service == "llm":
+        model_id = settings.vllm.model
+    else:
+        model_id = settings.model_weights_path
     if not model_id:
         return {"object": "list", "data": []}
 

--- a/tt-media-server/tests/test_chat_api.py
+++ b/tt-media-server/tests/test_chat_api.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from open_ai_api.chat import router
+from resolver.service_resolver import service_resolver
+from security.api_key_checker import get_api_key
+
+
+@dataclass
+class MockCompletionResult:
+    text: str
+    finish_reason: str = "stop"
+
+
+@pytest.fixture
+def mock_service():
+    service = Mock()
+    service.scheduler = Mock()
+    service.scheduler.check_is_model_ready = Mock()
+    service.process_request = AsyncMock(
+        return_value=MockCompletionResult(text="Hello! How can I help?")
+    )
+    return service
+
+
+@pytest.fixture
+def test_client(mock_service):
+    app = FastAPI()
+    app.include_router(router, prefix="/v1")
+    app.dependency_overrides[service_resolver] = lambda: mock_service
+    app.dependency_overrides[get_api_key] = lambda: "test-key"
+    return TestClient(app)
+
+
+CHAT_REQUEST = {
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 64,
+}
+
+
+class TestChatCompletionsNonStreaming:
+    """Test /v1/chat/completions non-streaming responses."""
+
+    @patch("open_ai_api.chat._apply_chat_template", return_value="<|user|>Hello<|end|>")
+    @patch("open_ai_api.chat._count_tokens", return_value=5)
+    def test_returns_chat_completion_format(
+        self, mock_count, mock_template, test_client, mock_service
+    ):
+        response = test_client.post("/v1/chat/completions", json=CHAT_REQUEST)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["object"] == "chat.completion"
+        assert data["choices"][0]["message"]["role"] == "assistant"
+        assert data["choices"][0]["message"]["content"] == "Hello! How can I help?"
+        assert data["choices"][0]["finish_reason"] == "stop"
+
+    @patch("open_ai_api.chat._apply_chat_template", return_value="<|user|>Hello<|end|>")
+    @patch("open_ai_api.chat._count_tokens", return_value=5)
+    def test_includes_usage_stats(
+        self, mock_count, mock_template, test_client, mock_service
+    ):
+        response = test_client.post("/v1/chat/completions", json=CHAT_REQUEST)
+
+        data = response.json()
+        assert "usage" in data
+        assert "prompt_tokens" in data["usage"]
+        assert "completion_tokens" in data["usage"]
+        assert "total_tokens" in data["usage"]
+
+    @patch("open_ai_api.chat._apply_chat_template", return_value="<|user|>Hello<|end|>")
+    @patch("open_ai_api.chat._count_tokens", return_value=5)
+    def test_completion_id_format(
+        self, mock_count, mock_template, test_client, mock_service
+    ):
+        response = test_client.post("/v1/chat/completions", json=CHAT_REQUEST)
+
+        data = response.json()
+        assert data["id"].startswith("chatcmpl-")
+
+    @patch("open_ai_api.chat._apply_chat_template", return_value="<|user|>Hello<|end|>")
+    @patch("open_ai_api.chat._count_tokens", return_value=5)
+    def test_applies_chat_template(
+        self, mock_count, mock_template, test_client, mock_service
+    ):
+        test_client.post("/v1/chat/completions", json=CHAT_REQUEST)
+
+        mock_template.assert_called_once_with([{"role": "user", "content": "Hello"}])
+
+    @patch("open_ai_api.chat._apply_chat_template", return_value="<|user|>Hello<|end|>")
+    @patch("open_ai_api.chat._count_tokens", return_value=5)
+    def test_passes_params_to_completion_request(
+        self, mock_count, mock_template, test_client, mock_service
+    ):
+        request = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 128,
+            "temperature": 0.7,
+            "top_p": 0.9,
+        }
+        test_client.post("/v1/chat/completions", json=request)
+
+        call_args = mock_service.process_request.call_args[0][0]
+        assert call_args.max_tokens == 128
+        assert call_args.temperature == 0.7
+        assert call_args.top_p == 0.9
+
+
+class TestChatCompletionsStreaming:
+    """Test /v1/chat/completions streaming SSE responses."""
+
+    @patch("open_ai_api.chat._apply_chat_template", return_value="<|user|>Hello<|end|>")
+    @patch("open_ai_api.chat._count_tokens", return_value=5)
+    def test_streaming_returns_sse_format(
+        self, mock_count, mock_template, test_client, mock_service
+    ):
+        async def mock_stream(request):
+            for text in ["Hello", " world"]:
+                yield MockCompletionResult(text=text)
+
+        mock_service.process_streaming_request = mock_stream
+
+        request = {**CHAT_REQUEST, "stream": True}
+        response = test_client.post("/v1/chat/completions", json=request)
+
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers["content-type"]
+
+        lines = [
+            line for line in response.text.split("\n") if line.startswith("data: ")
+        ]
+        assert len(lines) >= 3  # at least 2 chunks + final + [DONE]
+
+    @patch("open_ai_api.chat._apply_chat_template", return_value="<|user|>Hello<|end|>")
+    @patch("open_ai_api.chat._count_tokens", return_value=5)
+    def test_streaming_final_chunk_has_finish_reason(
+        self, mock_count, mock_template, test_client, mock_service
+    ):
+        async def mock_stream(request):
+            yield MockCompletionResult(text="Hello")
+
+        mock_service.process_streaming_request = mock_stream
+
+        request = {**CHAT_REQUEST, "stream": True}
+        response = test_client.post("/v1/chat/completions", json=request)
+
+        import json
+
+        lines = [
+            line
+            for line in response.text.split("\n")
+            if line.startswith("data: ") and line != "data: [DONE]"
+        ]
+        last_chunk = json.loads(lines[-1].removeprefix("data: "))
+        assert last_chunk["choices"][0]["finish_reason"] == "stop"
+
+    @patch("open_ai_api.chat._apply_chat_template", return_value="<|user|>Hello<|end|>")
+    @patch("open_ai_api.chat._count_tokens", return_value=5)
+    def test_streaming_ends_with_done(
+        self, mock_count, mock_template, test_client, mock_service
+    ):
+        async def mock_stream(request):
+            yield MockCompletionResult(text="Hi")
+
+        mock_service.process_streaming_request = mock_stream
+
+        request = {**CHAT_REQUEST, "stream": True}
+        response = test_client.post("/v1/chat/completions", json=request)
+
+        assert "data: [DONE]" in response.text
+
+
+class TestChatCompletionsValidation:
+    """Test request validation."""
+
+    def test_missing_messages_returns_422(self, test_client):
+        response = test_client.post("/v1/chat/completions", json={})
+        assert response.status_code == 422
+
+    def test_empty_messages_accepted(self, test_client):
+        # Empty messages list is valid per OpenAI spec
+        with patch("open_ai_api.chat._apply_chat_template", return_value=""):
+            with patch("open_ai_api.chat._count_tokens", return_value=0):
+                response = test_client.post(
+                    "/v1/chat/completions",
+                    json={"messages": []},
+                )
+                # Should not 422 — may fail at inference level but not validation
+                assert response.status_code != 422

--- a/tt-media-server/tests/test_vllm_runner.py
+++ b/tt-media-server/tests/test_vllm_runner.py
@@ -133,5 +133,5 @@ async def test_run_async_streaming_yields_each_token(mock_get_settings):
     # Verify final chunk contains concatenated text
     final_chunk = received_chunks[-1]
     assert final_chunk["type"] == "final_result"
-    expected_full_text = "final_text"
+    expected_full_text = ""
     assert final_chunk["data"].text == expected_full_text

--- a/tt-media-server/tt_model_runners/vllm_forge_llama_70b.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_llama_70b.py
@@ -130,7 +130,7 @@ class VLLMForgeLlama70BRunner(BaseDeviceRunner):
 
         yield CompletionOutput(
             type=FINAL_TYPE,
-            data=CompletionResult(text="final_text"),
+            data=CompletionResult(text=""),
         )
 
     async def process_request_non_streaming(

--- a/tt-media-server/tt_model_runners/vllm_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_runner.py
@@ -124,7 +124,7 @@ class VLLMRunner(BaseDeviceRunner):
 
         yield CompletionOutput(
             type=FINAL_TYPE,
-            data=CompletionResult(text="final_text"),
+            data=CompletionResult(text=""),
         )
 
     async def process_request_non_streaming(


### PR DESCRIPTION
## Issue

https://github.com/tenstorrent/tt-inference-server/issues/2544

## Summary
- Add OpenAI-compatible `/v1/chat/completions` endpoint that applies the model's chat template via the tokenizer, supporting both streaming SSE and non-streaming responses with real token usage stats
- Fix streaming artifact where `"final_text"` literal was emitted as the last token in both `vllm_runner` and `vllm_forge_llama_70b` runner
- Fix `/v1/models` returning HF cache path instead of model name for LLM models (hugging_face_utils overwrites `model_weights_path` with local snapshot path; use `settings.vllm.model` which retains the HuggingFace ID)

## What's changed
- `open_ai_api/chat.py` — New chat completions endpoint with chat template support
- `open_ai_api/__init__.py` — Register chat router in LLM service routes
- `open_ai_api/models.py` — Fix model ID for LLM models (use `vllm.model` instead of resolved cache path)
- `domain/chat_completion_request.py` — Request schema for chat completions
- `tt_model_runners/vllm_runner.py` — Fix final_text artifact in streaming
- `tt_model_runners/vllm_forge_llama_70b.py` — Fix final_text artifact in streaming
- `tests/test_chat_api.py` — Tests for streaming, non-streaming, validation

## Test plan
- [x] Verified `/v1/chat/completions` works with streaming and non-streaming requests
- [x] Verified `final_text` no longer appears in streaming output
- [x] Verified `/v1/models` returns correct model name (not HF cache path)
- [x] Tested with Llama-3.2-3B-Instruct and Llama-3.1-8B-Instruct on Blackhole (single device)
- [x] Model served on hosted tt-cloud-console using these changes
- [x] Added unit tests for chat completions endpoint (non-streaming format, usage stats, streaming SSE, validation)
