### PR TITLE
Parallelize streaming requests in device worker

### DIFF
--- a/tt-media-server/device_workers/device_worker.py
+++ b/tt-media-server/device_workers/device_worker.py
@@ -87,34 +87,46 @@ def device_worker(
             )
 
             if has_streaming_request:
-                # Handle streaming requests (one at a time for now)
-                for request in requests:
-                    if hasattr(request, "stream") and request.stream:
+
+                async def handle_all_streaming():
+                    import asyncio as _asyncio
+
+                    async def stream_one(req):
                         logger.info(
-                            f"Worker {worker_id} processing streaming request for task {request._task_id}"
+                            f"Worker {worker_id} processing streaming request for task {req._task_id}"
+                        )
+                        result_generator = await device_runner._run_async([req])
+
+                        chunk_key = req._task_id
+                        async for chunk in result_generator:
+                            result_queue.put((worker_id, chunk_key, chunk))
+
+                        logger.info(
+                            f"Worker {worker_id} finished streaming chunks for task {req._task_id}"
                         )
 
-                        async def handle_streaming():
-                            result_generator = await device_runner._run_async([request])
+                    streaming_reqs = [
+                        r for r in requests if hasattr(r, "stream") and r.stream
+                    ]
+                    non_streaming_reqs = [
+                        r for r in requests if not (hasattr(r, "stream") and r.stream)
+                    ]
 
-                            chunk_key = request._task_id
-                            async for chunk in result_generator:
-                                result_queue.put((worker_id, chunk_key, chunk))
+                    # Run all streaming requests concurrently
+                    await _asyncio.gather(*[stream_one(req) for req in streaming_reqs])
 
-                            logger.info(
-                                f"Worker {worker_id} finished streaming chunks for task {request._task_id}"
-                            )
-
-                        loop.run_until_complete(handle_streaming())
-                    else:
-                        response = device_runner.run([request])
+                    # Handle any non-streaming requests in the batch
+                    for req in non_streaming_reqs:
+                        response = device_runner.run([req])
                         result_queue.put(
                             (
                                 worker_id,
-                                request._task_id,
+                                req._task_id,
                                 response[0] if response else None,
                             )
                         )
+
+                loop.run_until_complete(handle_all_streaming())
             else:
                 responses = device_runner.run(requests)
 


### PR DESCRIPTION
## Ticket
https://github.com/tenstorrent/tt-inference-server/issues/2549

## Problem
When multiple streaming completion requests arrive concurrently, the device worker processes them sequentially in a for loop with `run_until_complete` blocking on each request. This means the second request doesn't start until the first fully completes, resulting in wall time that scales linearly with the number of concurrent requests.

## What's changed
- `device_workers/device_worker.py` — Replace the sequential `for request in requests` streaming loop with `asyncio.gather` that runs all streaming requests concurrently. Non-streaming requests in the same batch are still handled sequentially after the streaming batch completes.

## Results
With 4 concurrent streaming requests (32 tokens each):

**Before (sequential):** ~59s wall time, staggered TTFTs (3.5s, 18.4s, 29.7s, 48.0s)
**After (concurrent):** ~9.5s wall time, requests batched by vLLM scheduler

## Test plan
- [x] Tested with 4 and 12 concurrent streaming requests
- [x] Verified single-request streaming still works correctly
- [x] Verified non-streaming requests still work correctly

## Note
Remaining TTFT stagger between batches is due to the AscendScheduler's prefill-first strategy in the TT vLLM plugin, not this change. See #2549 for details.