### PR TITLE
Refactor multihost validation to align with single-host pattern

### DIFF
--- a/run.py
+++ b/run.py
@@ -34,7 +34,7 @@ from workflows.multihost_orchestrator import (
     is_multihost_deployment,
     setup_multihost_config,
 )
-from workflows.validate_multihost import validate_multihost_args
+from workflows.validate_setup import run_multihost_validation_subprocess
 from workflows.run_workflows import run_workflows
 from workflows.runtime_config import RuntimeConfig
 from workflows.setup_host import setup_host
@@ -581,9 +581,10 @@ def main():
                 multihost_config = setup_multihost_config(
                     model_spec, expected_hosts, dry_run=True
                 )
-                hosts = validate_multihost_args(
+                hosts = run_multihost_validation_subprocess(
                     multihost_config,
-                    tt_smi_path=multihost_config.tt_smi_path,
+                    model_spec=model_spec,
+                    json_fpath=json_fpath,
                     dry_run=True,
                 )
                 orchestrator = MultiHostOrchestrator(

--- a/tests/test_multihost_config.py
+++ b/tests/test_multihost_config.py
@@ -26,7 +26,7 @@ from workflows.utils import (
     check_path_permissions_for_uid,
     get_groups_for_uid,
 )
-from workflows.validate_multihost import (
+from workflows.run_multihost_validation import (
     _run_ssh_command,
     validate_multihost_bind_mount_permissions,
 )

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -21,7 +21,7 @@ from workflows.multihost_orchestrator import (
     is_multihost_deployment,
     setup_multihost_config,
 )
-from workflows.validate_multihost import validate_multihost_args
+from workflows.validate_setup import run_multihost_validation_subprocess
 from workflows.utils import (
     default_dotenv_path,
     ensure_readwriteable_dir,
@@ -679,10 +679,10 @@ def run_multihost_server(model_spec, runtime_config, setup_config, json_fpath):
     multihost_config = setup_multihost_config(model_spec, expected_hosts)
 
     # Validate multi-host configuration (including system software versions)
-    hosts = validate_multihost_args(
+    hosts = run_multihost_validation_subprocess(
         multihost_config,
         model_spec=model_spec,
-        tt_smi_path=multihost_config.tt_smi_path,
+        json_fpath=json_fpath,
     )
     logger.info(f"Starting multi-host deployment with {len(hosts)} hosts: {hosts}")
 

--- a/workflows/run_multihost_validation.py
+++ b/workflows/run_multihost_validation.py
@@ -720,9 +720,7 @@ def main():
 
     from workflows.log_setup import setup_workflow_script_logger
 
-    parser = argparse.ArgumentParser(
-        description="Validation for multi-host deployment"
-    )
+    parser = argparse.ArgumentParser(description="Validation for multi-host deployment")
     parser.add_argument(
         "--hosts",
         required=True,

--- a/workflows/run_multihost_validation.py
+++ b/workflows/run_multihost_validation.py
@@ -23,9 +23,22 @@ import json
 import logging
 import socket
 import subprocess
+import sys
 from pathlib import Path
 from typing import List, Tuple
 
+# Add the project root to the Python path
+# this is for running with a separate venv python
+project_root = Path(__file__).resolve().parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from workflows.run_system_software_validation import (
+    enforce_version_requirement,
+    extract_board_types,
+    extract_fw_bundle_versions,
+    extract_kmd_version,
+)
 from workflows.utils import check_path_permissions_for_uid
 
 logger = logging.getLogger("run_log")
@@ -401,9 +414,10 @@ def validate_host_system_software(
     model_spec,
     tt_smi_path: str = "tt-smi",
 ) -> List[str]:
-    """Validate FW/KMD versions on all hosts via SSH.
+    """Validate FW/KMD versions and board types on all hosts via SSH.
 
     Runs 'tt-smi -s' on each host and validates:
+    - Board types are homogeneous across all devices/hosts
     - FW bundle versions match across all devices/hosts
     - KMD version meets model_spec requirements (if specified)
 
@@ -418,7 +432,9 @@ def validate_host_system_software(
     errors = []
     all_fw_versions = []
     all_kmd_versions = []
+    all_board_types = []
     host_fw_info = {}
+    host_board_info = {}
 
     for host in hosts:
         # Run tt-smi -s via SSH and parse JSON
@@ -430,34 +446,44 @@ def validate_host_system_software(
         try:
             tt_smi_data = json.loads(output)
 
-            # Extract FW bundle versions for all devices on this host
-            fw_versions_on_host = []
-            for info in tt_smi_data.get("device_info", []):
-                fw_versions = info.get("firmwares", {})
-                fw_bundle = fw_versions.get("fw_bundle_version")
-                if fw_bundle:
-                    fw_versions_on_host.append(fw_bundle)
-                    all_fw_versions.append(fw_bundle)
-
+            fw_versions_on_host = extract_fw_bundle_versions(tt_smi_data)
+            board_types_on_host = extract_board_types(tt_smi_data)
+            all_fw_versions.extend(fw_versions_on_host)
             host_fw_info[host] = fw_versions_on_host
+            all_board_types.extend(board_types_on_host)
+            host_board_info[host] = board_types_on_host
 
             # Extract KMD version
-            kmd_version = tt_smi_data.get("host_info", {}).get("Driver", "")
+            kmd_version = extract_kmd_version(tt_smi_data)
             if kmd_version:
-                # Format is "tenstorrent <version>" - extract version part
-                parts = kmd_version.split(" ", 1)
-                if len(parts) == 2:
-                    all_kmd_versions.append((host, parts[1]))
-                else:
-                    all_kmd_versions.append((host, kmd_version))
+                all_kmd_versions.append((host, kmd_version))
 
             logger.info(
-                f"✅ tt-smi on {host}: FW={fw_versions_on_host}, KMD={kmd_version}"
+                f"✅ tt-smi on {host}: FW={fw_versions_on_host}, KMD={kmd_version}, "
+                f"boards={board_types_on_host}"
             )
 
         except json.JSONDecodeError as e:
             errors.append(f"Failed to parse tt-smi JSON from {host}: {e}")
             continue
+
+    # Validate all board types are homogeneous across all hosts/devices
+    # Remove "local"/"remote" suffix for comparison
+    normalized_board_types = [bt.rsplit(" ", 1)[0] for bt in all_board_types]
+    unique_board_types = set(normalized_board_types)
+    if len(unique_board_types) > 1:
+        board_details = ", ".join(
+            f"{host}: {boards}" for host, boards in host_board_info.items()
+        )
+        errors.append(
+            f"Board types mismatch across hosts. "
+            f"All devices must have identical board types.\n"
+            f"  Found types: {board_details}"
+        )
+    elif unique_board_types:
+        logger.info(
+            f"✅ Board type consistent across all hosts: {unique_board_types.pop()}"
+        )
 
     # Validate all FW versions match across all hosts/devices
     unique_fw_versions = set(all_fw_versions)
@@ -479,51 +505,39 @@ def validate_host_system_software(
     if model_spec and hasattr(model_spec, "system_requirements"):
         system_requirements = model_spec.system_requirements
         if system_requirements:
-            try:
-                from packaging.specifiers import SpecifierSet
-                from packaging.version import Version
+            # Check firmware requirements using common function
+            if (
+                hasattr(system_requirements, "firmware")
+                and system_requirements.firmware
+            ):
+                fw_requirement = system_requirements.firmware
+                # Only check first FW version since all should match
+                if all_fw_versions:
+                    try:
+                        enforce_version_requirement(
+                            "FW bundle", all_fw_versions[0], fw_requirement
+                        )
+                    except ValueError as e:
+                        errors.append(str(e))
+                    except Exception as e:
+                        logger.warning(
+                            f"Could not validate FW version {all_fw_versions[0]}: {e}"
+                        )
 
-                # Check firmware requirements
-                if (
-                    hasattr(system_requirements, "firmware")
-                    and system_requirements.firmware
-                ):
-                    fw_requirement = system_requirements.firmware
-                    for fw_version in all_fw_versions:
-                        try:
-                            parsed_version = Version(fw_version)
-                            specifier = SpecifierSet(fw_requirement.specifier)
-                            if parsed_version not in specifier:
-                                errors.append(
-                                    f"FW bundle version ({fw_version}) does not meet "
-                                    f"requirement {fw_requirement.specifier}"
-                                )
-                                break  # Only report once since all FW versions should match
-                        except Exception as e:
-                            logger.warning(
-                                f"Could not parse FW version {fw_version}: {e}"
-                            )
-
-                # Check KMD requirements
-                if hasattr(system_requirements, "kmd") and system_requirements.kmd:
-                    kmd_requirement = system_requirements.kmd
-                    for host, kmd_version in all_kmd_versions:
-                        try:
-                            parsed_version = Version(kmd_version)
-                            specifier = SpecifierSet(kmd_requirement.specifier)
-                            if parsed_version not in specifier:
-                                errors.append(
-                                    f"KMD version on {host} ({kmd_version}) does not meet "
-                                    f"requirement {kmd_requirement.specifier}"
-                                )
-                        except Exception as e:
-                            logger.warning(
-                                f"Could not parse KMD version {kmd_version} on {host}: {e}"
-                            )
-            except ImportError:
-                logger.warning(
-                    "packaging module not available, skipping FW/KMD version validation"
-                )
+            # Check KMD requirements using common function
+            if hasattr(system_requirements, "kmd") and system_requirements.kmd:
+                kmd_requirement = system_requirements.kmd
+                for host, kmd_version in all_kmd_versions:
+                    try:
+                        enforce_version_requirement(
+                            f"KMD on {host}", kmd_version, kmd_requirement
+                        )
+                    except ValueError as e:
+                        errors.append(str(e))
+                    except Exception as e:
+                        logger.warning(
+                            f"Could not validate KMD version {kmd_version} on {host}: {e}"
+                        )
 
     return errors
 
@@ -688,16 +702,17 @@ def validate_multihost_args(
 
 
 def main():
-    """CLI entry point for dry-run validation of multi-host configuration.
+    """CLI entry point for multi-host validation.
 
     Usage:
-        python -m workflows.validate_multihost --hosts host1,host2 \\
+        python -m workflows.run_multihost_validation --hosts host1,host2 \\
             --shared-storage-root /mnt/shared \\
-            --mpi-interface cnx1 \\
-            --model DeepSeek-V3
+            --mpi-interface cnx1
 
-    Note: --config-pkl-dir is optional. If not specified, a temporary directory
-    will be auto-generated under shared-storage-root for validation purposes.
+    Optional:
+        --config-pkl-dir: Path to config pickle directory (auto-generated if not specified)
+        --runtime-model-spec-json: Path to model spec JSON for FW/KMD version validation
+        --dry-run: Skip directory existence and permission checks
     """
     import argparse
     import shutil
@@ -706,7 +721,7 @@ def main():
     from workflows.log_setup import setup_workflow_script_logger
 
     parser = argparse.ArgumentParser(
-        description="Dry-run validation for multi-host deployment"
+        description="Validation for multi-host deployment"
     )
     parser.add_argument(
         "--hosts",
@@ -741,6 +756,11 @@ def main():
         "--skip-ssh-checks",
         action="store_true",
         help="Skip SSH-based remote host checks (permissions only)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip directory existence and permission checks",
     )
 
     args = parser.parse_args()
@@ -789,7 +809,7 @@ def main():
             sys.exit(1)
 
     logger.info("=" * 60)
-    logger.info("Multi-host Validation (Dry-Run)")
+    logger.info("Multi-host Validation")
     logger.info("=" * 60)
     logger.info(f"Hosts: {hosts}")
     logger.info(f"Shared storage root: {args.shared_storage_root}")
@@ -808,6 +828,7 @@ def main():
             model_spec=model_spec,
             skip_environment_check=args.skip_ssh_checks,
             tt_smi_path=args.tt_smi_path,
+            dry_run=args.dry_run,
         )
         logger.info("✅ All validation checks passed")
         exit_code = 0

--- a/workflows/run_system_software_validation.py
+++ b/workflows/run_system_software_validation.py
@@ -23,7 +23,7 @@ project_root = Path(__file__).resolve().parent.parent
 if project_root not in sys.path:
     sys.path.insert(0, str(project_root))
 from workflows.log_setup import setup_workflow_script_logger
-from workflows.model_spec import ModelSpec, VersionRequirement
+from workflows.model_spec import ModelSpec
 from workflows.runtime_config import RuntimeConfig
 from workflows.workflow_types import SystemTopology, VersionMode, WorkflowVenvType
 from workflows.workflow_venvs import VENV_CONFIGS
@@ -161,6 +161,67 @@ class SystemResourceService:
         return topology
 
 
+def extract_fw_bundle_versions(tt_smi_data):
+    """Extract FW bundle versions from tt-smi data."""
+    versions = []
+    for info in tt_smi_data.get("device_info", []):
+        fw = info.get("firmwares", {}).get("fw_bundle_version")
+        if fw:
+            versions.append(fw)
+    return versions
+
+
+def extract_kmd_version(tt_smi_data):
+    """Extract KMD version from tt-smi data."""
+    driver = tt_smi_data.get("host_info", {}).get("Driver", "")
+    parts = driver.split(" ", 1)
+    return parts[1] if len(parts) == 2 else driver
+
+
+def extract_board_types(tt_smi_data):
+    """Extract board types from tt-smi data."""
+    board_types = []
+    for info in tt_smi_data.get("device_info", []):
+        board_type = info.get("board_info", {}).get("board_type", "")
+        if board_type:
+            board_types.append(board_type)
+    return board_types
+
+
+def enforce_version_requirement(requirement_name, version, version_requirement):
+    """Check version against VersionRequirement.
+
+    Raises ValueError if STRICT mode and requirement not met.
+    Logs warning if SUGGESTED mode and requirement not met.
+    """
+    version_specifier = version_requirement.specifier
+    enforcement_mode = version_requirement.mode
+    parsed_version = Version(version)
+    meets_requirement = parsed_version in SpecifierSet(version_specifier)
+
+    if meets_requirement:
+        return
+
+    if parsed_version.is_prerelease:
+        message = (
+            f"{requirement_name} version '{version}' does not satisfy the "
+            f"{enforcement_mode.name} requirement '{version_specifier}', "
+            "because this is a prerelease version. "
+            "Re-run with --skip-system-sw-validation to skip this check."
+        )
+    else:
+        message = (
+            f"{requirement_name} version '{version}' does not satisfy the "
+            f"{enforcement_mode.name} requirement '{version_specifier}'. "
+            "If you want to skip this check, re-run with --skip-system-sw-validation."
+        )
+
+    if enforcement_mode == VersionMode.STRICT:
+        raise ValueError(message)
+    elif enforcement_mode == VersionMode.SUGGESTED:
+        logger.warning(message)
+
+
 def parse_args():
     """
     Parse command line arguments.
@@ -198,13 +259,9 @@ def main():
             "This is likely because Tenstorrent devices must be reset.\n\n"
             "💡 Tip: Please run 'tt-smi -r' and try again, especially if 'tt-smi' is unresponsive.\n\n"
         )
-    fw_bundle_versions = []
-    board_types = []
-    for info in tt_smi_data["device_info"]:
-        fw_versions = info["firmwares"]
-        board_info = info["board_info"]
-        fw_bundle_versions.append(fw_versions["fw_bundle_version"])
-        board_types.append(board_info["board_type"])
+
+    fw_bundle_versions = extract_fw_bundle_versions(tt_smi_data)
+    board_types = extract_board_types(tt_smi_data)
 
     # remove local and remote designations, if they exist
     filtered_board_types = [board_type.rsplit(" ", 1)[0] for board_type in board_types]
@@ -238,8 +295,7 @@ def main():
             f"FW bundle versions must match among all devices: {fw_bundle_versions}"
         )
 
-    kmd_version = tt_smi_data["host_info"]["Driver"]
-    prefix, kmd_version = kmd_version.split(" ")
+    kmd_version = extract_kmd_version(tt_smi_data)
     system_info = (
         f"System info:\n"
         f"{'=' * 80}\n"
@@ -254,48 +310,20 @@ def main():
     # enforce ModelSpec system requirements
     system_requirements = model_spec.system_requirements
     if system_requirements is not None:
-
-        def _enforce_requirement(
-            requirement_name: str, version: str, version_requirement: VersionRequirement
-        ) -> None:
-            version_specifier = version_requirement.specifier
-            enforcement_mode = version_requirement.mode
-            parsed_version = Version(version)
-            meets_requirement = parsed_version in SpecifierSet(version_specifier)
-            if meets_requirement:
-                return
-            if parsed_version.is_prerelease:
-                message = (
-                    f"{requirement_name} version '{version}' does not satisfy the "
-                    f"{enforcement_mode.name} requirement '{version_specifier}', "
-                    "because this is a prerelease version. "
-                    "Re-run with --skip-system-sw-validation to skip this check."
-                )
-            else:
-                message = (
-                    f"{requirement_name} version '{version}' does not satisfy the "
-                    f"{enforcement_mode.name} requirement '{version_specifier}'. "
-                    "If you want to skip this check, re-run with --skip-system-sw-validation."
-                )
-            if enforcement_mode == VersionMode.STRICT:
-                raise ValueError(message)
-            elif enforcement_mode == VersionMode.SUGGESTED:
-                logger.warning(message)
-
         # enforce firmware versioning
         # by default, ModelSpecs have no FW requirement
-        firmware_requirement = model_spec.system_requirements.firmware
+        firmware_requirement = system_requirements.firmware
         if firmware_requirement is not None:
             for fw_bundle_version in fw_bundle_versions:
-                _enforce_requirement(
+                enforce_version_requirement(
                     "FW bundle", fw_bundle_version, firmware_requirement
                 )
 
         # enforce KMD versioning
         # by default, ModelSpecs have no KMD requirement
-        kmd_requirement = model_spec.system_requirements.kmd
+        kmd_requirement = system_requirements.kmd
         if kmd_requirement is not None:
-            _enforce_requirement("KMD", kmd_version, kmd_requirement)
+            enforce_version_requirement("KMD", kmd_version, kmd_requirement)
 
     # enforce system-level topology
     device = model_spec.device_model_spec.device

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -194,7 +194,9 @@ def validate_local_setup(model_spec, runtime_config, json_fpath):
     logger.info("✅ validating local setup completed")
 
 
-def run_multihost_validation_subprocess(multihost_config, model_spec, json_fpath, dry_run=False):
+def run_multihost_validation_subprocess(
+    multihost_config, model_spec, json_fpath, dry_run=False
+):
     """Run multihost validation via subprocess with dedicated venv.
 
     This aligns multihost validation with single-host validation pattern:
@@ -220,11 +222,16 @@ def run_multihost_validation_subprocess(multihost_config, model_spec, json_fpath
     cmd = [
         str(venv_config.venv_python),
         str(get_repo_root_path() / "workflows" / "run_multihost_validation.py"),
-        "--hosts", ",".join(multihost_config.hosts),
-        "--shared-storage-root", str(multihost_config.shared_storage_root),
-        "--config-pkl-dir", str(multihost_config.config_pkl_dir),
-        "--mpi-interface", multihost_config.mpi_interface,
-        "--tt-smi-path", multihost_config.tt_smi_path,
+        "--hosts",
+        ",".join(multihost_config.hosts),
+        "--shared-storage-root",
+        str(multihost_config.shared_storage_root),
+        "--config-pkl-dir",
+        str(multihost_config.config_pkl_dir),
+        "--mpi-interface",
+        multihost_config.mpi_interface,
+        "--tt-smi-path",
+        multihost_config.tt_smi_path,
     ]
 
     if json_fpath is not None:

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -194,6 +194,57 @@ def validate_local_setup(model_spec, runtime_config, json_fpath):
     logger.info("✅ validating local setup completed")
 
 
+def run_multihost_validation_subprocess(multihost_config, model_spec, json_fpath, dry_run=False):
+    """Run multihost validation via subprocess with dedicated venv.
+
+    This aligns multihost validation with single-host validation pattern:
+    - Uses SYSTEM_SOFTWARE_VALIDATION venv (with packaging library)
+    - Runs run_multihost_validation.py as subprocess
+    - Returns validated hosts list
+
+    Args:
+        multihost_config: MultiHostConfig object with hosts, paths, etc.
+        model_spec: ModelSpec for system software version validation
+        json_fpath: Path to runtime model spec JSON file
+        dry_run: If True, skip directory existence and permission checks
+
+    Returns:
+        List of validated hostnames
+
+    Raises:
+        ValueError: If validation fails
+    """
+    venv_config = VENV_CONFIGS[WorkflowVenvType.SYSTEM_SOFTWARE_VALIDATION]
+    venv_config.setup(model_spec=model_spec)
+
+    cmd = [
+        str(venv_config.venv_python),
+        str(get_repo_root_path() / "workflows" / "run_multihost_validation.py"),
+        "--hosts", ",".join(multihost_config.hosts),
+        "--shared-storage-root", str(multihost_config.shared_storage_root),
+        "--config-pkl-dir", str(multihost_config.config_pkl_dir),
+        "--mpi-interface", multihost_config.mpi_interface,
+        "--tt-smi-path", multihost_config.tt_smi_path,
+    ]
+
+    if json_fpath is not None:
+        cmd.extend(["--runtime-model-spec-json", str(json_fpath)])
+
+    if dry_run:
+        cmd.append("--dry-run")
+
+    return_code = run_command(cmd, logger=logger)
+
+    if return_code != 0:
+        raise ValueError(
+            "⛔ Multi-host validation failed. See errors above.\n"
+            "To skip system software validation, use the flag: --skip-system-sw-validation"
+        )
+
+    logger.info("✅ Multi-host validation completed")
+    return multihost_config.hosts
+
+
 def _try_fix_path_permissions_for_uid(path, uid, need_write=False):
     """Best-effort chmod to grant the target UID the required access bits.
 


### PR DESCRIPTION
Close #2436 

Refactor multihost validation to align with single-host pattern for re-use.

- Rename validate_multihost.py to run_multihost_validation.py
- Add run_multihost_validation_subprocess() to validate_setup.py:
  - reuses SYSTEM_SOFTWARE_VALIDATION venv
  - Matches single-host validation execution pattern to reuse functions
- Add board type homogeneity check to multihost validation