### PR TITLE
Add request cancellation support

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -191,6 +191,7 @@ endif()
 set(LLM_ENGINE_SOURCES
     src/runners/llm_runner/block_manager.cpp
     src/ipc/boost_ipc_task_queue.cpp
+    src/ipc/boost_ipc_cancel_queue.cpp
     src/runners/llm_runner/hash.cpp
     src/runners/llm_runner.cpp
     src/runners/llm_runner/model_runner.cpp
@@ -318,11 +319,19 @@ target_include_directories(test_tokenizer PRIVATE
 )
 
 include(GoogleTest)
+add_executable(cancellation_test tests/cancellation_test.cpp)
+target_link_libraries(cancellation_test PRIVATE llm_engine GTest::gtest_main)
+target_include_directories(cancellation_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/runners
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
 gtest_discover_tests(scheduler_test)
 gtest_discover_tests(llm_runner_test)
 gtest_discover_tests(sequence_test)
 gtest_discover_tests(lockfree_queue_test)
 gtest_discover_tests(test_tokenizer)
+gtest_discover_tests(cancellation_test)
 
 # IPC smoke test (2-process, Boost.Interprocess queue + scheduler)
 add_executable(ipc_scheduler_smoke_test tests/ipc_scheduler_smoke_test.cpp)
@@ -332,6 +341,17 @@ target_include_directories(ipc_scheduler_smoke_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 add_test(NAME IpcSchedulerSmoke COMMAND ipc_scheduler_smoke_test)
+
+# Cancellation E2E test (starts mock server, runs Python tests, tears down)
+add_test(
+    NAME CancellationE2E
+    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_e2e_with_server.sh
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_tests_properties(CancellationE2E PROPERTIES
+    TIMEOUT 120
+    LABELS "e2e"
+)
 
 # Tokenizer benchmark
 add_executable(tokenizer_benchmark benchmarks/tokenizer_benchmark.cpp src/utils/tokenizer.cpp src/utils/deepseek_tokenizer.cpp src/utils/llama_tokenizer.cpp src/utils/tokenizer_config_loader.cpp src/config/settings.cpp src/utils/logger.cpp)

--- a/tt-media-server/cpp_server/include/ipc/boost_ipc_cancel_queue.hpp
+++ b/tt-media-server/cpp_server/include/ipc/boost_ipc_cancel_queue.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "domain/task_id.hpp"
+#include "ipc/cancel_queue.hpp"
 
 namespace tt::ipc {
 
@@ -25,7 +26,7 @@ constexpr size_t CANCEL_QUEUE_CAPACITY = 1024;
  * push() is non-blocking (drops the message and logs a warning when full).
  * tryPopAll() drains every available message without blocking.
  */
-class BoostIpcCancelQueue {
+class BoostIpcCancelQueue : public ICancelQueue {
  public:
   /** Create the queue (main-process side). */
   BoostIpcCancelQueue(const std::string& name, size_t capacity);
@@ -33,22 +34,15 @@ class BoostIpcCancelQueue {
   /** Open an existing queue (worker-process side). */
   explicit BoostIpcCancelQueue(const std::string& name);
 
-  ~BoostIpcCancelQueue();
+  ~BoostIpcCancelQueue() override;
 
-  /**
-   * Non-blocking push. Silently drops the message if the queue is full
-   * (the request will finish on its own shortly anyway).
-   * Thread-safe.
-   */
-  void push(const tt::domain::TaskID& taskId);
+  void push(const tt::domain::TaskID& taskId) override;
 
-  /**
-   * Drain all available cancel messages into out without blocking.
-   * Intended to be called once per scheduler step from the worker thread.
-   */
-  void tryPopAll(std::vector<tt::domain::TaskID>& out);
+  void tryPopAll(std::vector<tt::domain::TaskID>& out) override;
 
-  static void remove(const std::string& name);
+  void remove() override;
+
+  static void removeByName(const std::string& name);
 
  private:
   std::string name_;

--- a/tt-media-server/cpp_server/include/ipc/boost_ipc_cancel_queue.hpp
+++ b/tt-media-server/cpp_server/include/ipc/boost_ipc_cancel_queue.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <boost/interprocess/ipc/message_queue.hpp>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "domain/task_id.hpp"
+
+namespace tt::ipc {
+
+constexpr const char* CANCEL_QUEUE_NAME = "tt_cancels";
+constexpr size_t CANCEL_QUEUE_CAPACITY = 1024;
+
+/**
+ * Lightweight IPC message queue for carrying request-cancel signals from the
+ * main process to worker processes. Each message is exactly one serialized
+ * TaskID (36 bytes).
+ *
+ * One queue per worker; the main process creates each queue and the
+ * corresponding worker process opens it to drain cancel signals.
+ * push() is non-blocking (drops the message and logs a warning when full).
+ * tryPopAll() drains every available message without blocking.
+ */
+class BoostIpcCancelQueue {
+ public:
+  /** Create the queue (main-process side). */
+  BoostIpcCancelQueue(const std::string& name, size_t capacity);
+
+  /** Open an existing queue (worker-process side). */
+  explicit BoostIpcCancelQueue(const std::string& name);
+
+  ~BoostIpcCancelQueue();
+
+  /**
+   * Non-blocking push. Silently drops the message if the queue is full
+   * (the request will finish on its own shortly anyway).
+   * Thread-safe.
+   */
+  void push(const tt::domain::TaskID& taskId);
+
+  /**
+   * Drain all available cancel messages into out without blocking.
+   * Intended to be called once per scheduler step from the worker thread.
+   */
+  void tryPopAll(std::vector<tt::domain::TaskID>& out);
+
+  static void remove(const std::string& name);
+
+ private:
+  std::string name_;
+  std::unique_ptr<boost::interprocess::message_queue> queue_;
+};
+
+}  // namespace tt::ipc

--- a/tt-media-server/cpp_server/include/ipc/cancel_queue.hpp
+++ b/tt-media-server/cpp_server/include/ipc/cancel_queue.hpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <vector>
+
+#include "domain/task_id.hpp"
+
+namespace tt::ipc {
+
+/**
+ * Abstract interface for request-cancel signaling (main → worker).
+ * Allows swapping implementation (e.g. Boost message_queue, shared memory)
+ * without changing call sites.
+ */
+class ICancelQueue {
+ public:
+  virtual ~ICancelQueue() = default;
+
+  /**
+   * Non-blocking push. Implementations should silently drop the message if
+   * the queue is full (the request will finish on its own shortly anyway).
+   * Thread-safe.
+   */
+  virtual void push(const tt::domain::TaskID& taskId) = 0;
+
+  /**
+   * Drain all available cancel messages into out without blocking.
+   * Intended to be called once per scheduler step from the worker thread.
+   */
+  virtual void tryPopAll(std::vector<tt::domain::TaskID>& out) = 0;
+
+  /** Remove the underlying queue resource. Default no-op. */
+  virtual void remove() {}
+};
+
+}  // namespace tt::ipc

--- a/tt-media-server/cpp_server/include/ipc/queue_manager.hpp
+++ b/tt-media-server/cpp_server/include/ipc/queue_manager.hpp
@@ -9,6 +9,7 @@
 
 #include "ipc/boost_ipc_cancel_queue.hpp"
 #include "ipc/boost_ipc_task_queue.hpp"
+#include "ipc/cancel_queue.hpp"
 #include "ipc/shared_memory.hpp"
 
 namespace tt::ipc {
@@ -25,7 +26,7 @@ class QueueManager {
   std::shared_ptr<BoostIpcTaskQueue> task_queue;
   std::vector<std::shared_ptr<TokenRingBuffer<RING_BUFFER_CAPACITY>>>
       result_queues;
-  std::vector<std::shared_ptr<BoostIpcCancelQueue>> cancel_queues;
+  std::vector<std::shared_ptr<ICancelQueue>> cancel_queues;
 
   explicit QueueManager(int numWorkers) {
     BoostIpcTaskQueue::remove(TASK_QUEUE_NAME);
@@ -39,7 +40,7 @@ class QueueManager {
 
       std::string cancelName =
           std::string(CANCEL_QUEUE_NAME) + "_" + std::to_string(i);
-      BoostIpcCancelQueue::remove(cancelName);
+      BoostIpcCancelQueue::removeByName(cancelName);
       cancel_queues.emplace_back(std::make_shared<BoostIpcCancelQueue>(
           cancelName, CANCEL_QUEUE_CAPACITY));
     }
@@ -52,10 +53,8 @@ class QueueManager {
     for (auto& queue : result_queues) {
       queue->shutdown();
     }
-    for (size_t i = 0; i < cancel_queues.size(); i++) {
-      std::string cancelName =
-          std::string(CANCEL_QUEUE_NAME) + "_" + std::to_string(i);
-      BoostIpcCancelQueue::remove(cancelName);
+    for (auto& cq : cancel_queues) {
+      cq->remove();
     }
     cancel_queues.clear();
   }

--- a/tt-media-server/cpp_server/include/ipc/queue_manager.hpp
+++ b/tt-media-server/cpp_server/include/ipc/queue_manager.hpp
@@ -7,33 +7,41 @@
 #include <string>
 #include <vector>
 
+#include "ipc/boost_ipc_cancel_queue.hpp"
 #include "ipc/boost_ipc_task_queue.hpp"
 #include "ipc/shared_memory.hpp"
 
 namespace tt::ipc {
 
-using namespace std;
-
 constexpr const char* TASK_QUEUE_NAME = "tt_tasks";
 constexpr size_t RING_BUFFER_CAPACITY = 65536;
 
 /**
- * Manages task queue and result queues for LLM workers.
+ * Manages task queue, result queues, and cancel queues for LLM workers.
  * Handles creation, cleanup, and coordination of IPC queues.
  */
 class QueueManager {
  public:
-  shared_ptr<BoostIpcTaskQueue> task_queue;
-  vector<shared_ptr<TokenRingBuffer<RING_BUFFER_CAPACITY>>> result_queues;
+  std::shared_ptr<BoostIpcTaskQueue> task_queue;
+  std::vector<std::shared_ptr<TokenRingBuffer<RING_BUFFER_CAPACITY>>>
+      result_queues;
+  std::vector<std::shared_ptr<BoostIpcCancelQueue>> cancel_queues;
 
   explicit QueueManager(int numWorkers) {
     BoostIpcTaskQueue::remove(TASK_QUEUE_NAME);
-    task_queue = make_shared<BoostIpcTaskQueue>(TASK_QUEUE_NAME, 1024);
+    task_queue = std::make_shared<BoostIpcTaskQueue>(TASK_QUEUE_NAME, 1024);
     result_queues.reserve(numWorkers);
+    cancel_queues.reserve(numWorkers);
     for (int i = 0; i < numWorkers; i++) {
       result_queues.emplace_back(
-          make_shared<TokenRingBuffer<RING_BUFFER_CAPACITY>>(
-              "/tt_tokens_" + to_string(i), true));
+          std::make_shared<TokenRingBuffer<RING_BUFFER_CAPACITY>>(
+              "/tt_tokens_" + std::to_string(i), true));
+
+      std::string cancelName =
+          std::string(CANCEL_QUEUE_NAME) + "_" + std::to_string(i);
+      BoostIpcCancelQueue::remove(cancelName);
+      cancel_queues.emplace_back(std::make_shared<BoostIpcCancelQueue>(
+          cancelName, CANCEL_QUEUE_CAPACITY));
     }
   }
 
@@ -44,6 +52,12 @@ class QueueManager {
     for (auto& queue : result_queues) {
       queue->shutdown();
     }
+    for (size_t i = 0; i < cancel_queues.size(); i++) {
+      std::string cancelName =
+          std::string(CANCEL_QUEUE_NAME) + "_" + std::to_string(i);
+      BoostIpcCancelQueue::remove(cancelName);
+    }
+    cancel_queues.clear();
   }
 
   // Delete copy constructor and assignment operator

--- a/tt-media-server/cpp_server/include/runners/llm_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "config/runner_config.hpp"
+#include "ipc/boost_ipc_cancel_queue.hpp"
 #include "ipc/shared_memory.hpp"
 #include "runners/llm_runner/model_runner.hpp"
 #include "runners/llm_runner/scheduler.hpp"
@@ -16,7 +17,8 @@ using namespace llm_engine;
 class LLMRunner : public IRunner {
  public:
   LLMRunner(const config::LLMConfig& config,
-            ipc::TokenRingBuffer<65536>* resultQueue, ITaskQueue* taskQueue);
+            ipc::TokenRingBuffer<65536>* resultQueue, ITaskQueue* taskQueue,
+            ipc::BoostIpcCancelQueue* cancelQueue = nullptr);
   ~LLMRunner() override;
 
   Scheduler& scheduler() { return *scheduler_; }
@@ -31,6 +33,7 @@ class LLMRunner : public IRunner {
 
   config::LLMConfig config_;
   ipc::TokenRingBuffer<65536>* result_queue_;
+  ipc::BoostIpcCancelQueue* cancel_queue_;  // nullable; owned by caller
   std::unique_ptr<IModelRunner> model_runner_;
   std::unique_ptr<Scheduler> scheduler_;
   std::atomic<bool> stopped_{false};

--- a/tt-media-server/cpp_server/include/runners/llm_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "config/runner_config.hpp"
-#include "ipc/boost_ipc_cancel_queue.hpp"
+#include "ipc/cancel_queue.hpp"
 #include "ipc/shared_memory.hpp"
 #include "runners/llm_runner/model_runner.hpp"
 #include "runners/llm_runner/scheduler.hpp"
@@ -18,7 +18,7 @@ class LLMRunner : public IRunner {
  public:
   LLMRunner(const config::LLMConfig& config,
             ipc::TokenRingBuffer<65536>* resultQueue, ITaskQueue* taskQueue,
-            ipc::BoostIpcCancelQueue* cancelQueue = nullptr);
+            ipc::ICancelQueue* cancelQueue = nullptr);
   ~LLMRunner() override;
 
   Scheduler& scheduler() { return *scheduler_; }
@@ -33,7 +33,7 @@ class LLMRunner : public IRunner {
 
   config::LLMConfig config_;
   ipc::TokenRingBuffer<65536>* result_queue_;
-  ipc::BoostIpcCancelQueue* cancel_queue_;  // nullable; owned by caller
+  ipc::ICancelQueue* cancel_queue_;  // nullable; owned by caller
   std::unique_ptr<IModelRunner> model_runner_;
   std::unique_ptr<Scheduler> scheduler_;
   std::atomic<bool> stopped_{false};

--- a/tt-media-server/cpp_server/include/runners/llm_runner/scheduler.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/scheduler.hpp
@@ -68,6 +68,13 @@ class Scheduler {
                    const std::vector<int64_t>& tokenIds);
   void removeSequence(TaskID taskId);
 
+  /**
+   * Abort a request by task ID. Frees KV cache blocks, removes the sequence
+   * from whichever queue it is currently in, and erases it from the sequences
+   * map. Idempotent: a second call for the same ID is a no-op.
+   */
+  void abortRequest(TaskID taskId);
+
   bool isStopToken(int64_t tokenId) const {
     return stop_token_ids_.count(tokenId) > 0;
   }
@@ -103,6 +110,9 @@ class Scheduler {
   ITaskQueue* prefill_queue_;
   std::unordered_map<TaskID, std::unique_ptr<Sequence>> sequences_;
   std::deque<Sequence*> decode_queue_;
+  // IDs aborted before their copy was dequeued from the prefill queue.
+  // Checked in trySchedulePrefill to skip stale copies.
+  std::unordered_set<TaskID> pending_aborts_;
 };
 
 std::unique_ptr<Scheduler> makeScheduler(const tt::config::LLMConfig& config,

--- a/tt-media-server/cpp_server/include/runners/llm_runner/sequence.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/sequence.hpp
@@ -15,7 +15,7 @@ namespace llm_engine {
 
 using TaskID = tt::domain::TaskID;
 
-enum class SequenceStatus { WAITING, RUNNING, IN_FLIGHT, FINISHED };
+enum class SequenceStatus { WAITING, RUNNING, IN_FLIGHT, FINISHED, ABORTED };
 
 struct TokenResult {
   TaskID taskId;
@@ -45,6 +45,7 @@ class Sequence {
   int64_t operator[](size_t i) const { return tokenIds[i]; }
 
   bool isFinished() const { return status == SequenceStatus::FINISHED; }
+  bool isAborted() const { return status == SequenceStatus::ABORTED; }
   size_t numCompletionTokens() const {
     return tokenIds.size() - numPromptTokens;
   }

--- a/tt-media-server/cpp_server/include/services/llm_service.hpp
+++ b/tt-media-server/cpp_server/include/services/llm_service.hpp
@@ -43,6 +43,17 @@ class LLMService
 
   void preProcess(domain::CompletionRequest& request) const override;
 
+  /**
+   * Abort an in-flight request. Detaches and removes any registered streaming
+   * callback for the given task ID and signals the worker to drop the
+   * sequence from its scheduler. The detached callback is invoked with
+   * isFinal=true and finish_reason="abort" to unblock any synchronous
+   * waiters (e.g. processRequest). For streaming requests, callers must set
+   * their done flag before calling this method so the callback returns
+   * immediately. Safe to call from any thread. Idempotent.
+   */
+  void abortRequest(const domain::TaskID& taskId);
+
  protected:
   void postProcess(domain::CompletionResponse& response) const override;
   size_t currentQueueSize() const override;

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -8,6 +8,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -27,10 +28,19 @@ namespace {
 
 void sseSend(const std::string& sse, trantor::EventLoop* loop,
              const std::shared_ptr<drogon::ResponseStreamPtr>& streamPtr,
-             const std::shared_ptr<ConcurrentQueue<std::string>>& accumulator) {
+             const std::shared_ptr<ConcurrentQueue<std::string>>& accumulator,
+             const std::shared_ptr<std::vector<std::string>>& earlyBuffer,
+             std::function<void()> onDisconnect = nullptr) {
   if (!accumulator) {
-    loop->queueInLoop([streamPtr, sse]() {
-      if (*streamPtr) (*streamPtr)->send(sse);
+    loop->queueInLoop([streamPtr, earlyBuffer, sse,
+                       onDisconnect = std::move(onDisconnect)]() {
+      if (*streamPtr) {
+        bool ok = (*streamPtr)->send(sse);
+        if (!ok && onDisconnect) onDisconnect();
+      } else if (earlyBuffer) {
+        // Stream not ready yet — buffer for flush when it opens.
+        earlyBuffer->push_back(sse);
+      }
     });
     return;
   }
@@ -39,8 +49,14 @@ void sseSend(const std::string& sse, trantor::EventLoop* loop,
     auto accumulated = accumulator->drain();
     std::string batch;
     for (auto& s : accumulated) batch.append(s);
-    loop->queueInLoop([streamPtr, batch = std::move(batch)]() {
-      if (*streamPtr) (*streamPtr)->send(batch);
+    loop->queueInLoop([streamPtr, earlyBuffer, batch = std::move(batch),
+                       onDisconnect = std::move(onDisconnect)]() {
+      if (*streamPtr) {
+        bool ok = (*streamPtr)->send(batch);
+        if (!ok && onDisconnect) onDisconnect();
+      } else if (earlyBuffer) {
+        earlyBuffer->push_back(batch);
+      }
     });
   }
 }
@@ -313,17 +329,29 @@ void LLMController::handleStreaming(
       std::optional<std::chrono::high_resolution_clock::time_point>>();
   auto firstContentChunk = std::make_shared<std::atomic<bool>>(true);
 
+  // Abort callback: fires when the TCP connection drops mid-stream.
+  // Captured by value so it stays alive for the duration of the streaming
+  // session. Called on the IO thread from inside sseSend().
+  const std::string TASK_ID_STR = reqPtr->task_id.id;
+  auto onDisconnect = [TASK_ID_STR, service = this->service, done]() {
+    if (!done->exchange(true)) {
+      TT_LOG_INFO("[LLMController] Client disconnected, aborting task {}",
+                  TASK_ID_STR);
+      service->abortRequest(domain::TaskID(TASK_ID_STR));
+    }
+  };
+
   // Submit the streaming request before setting up the HTTP stream so that a
   // full queue throws QueueFullException here, allowing us to return a proper
   // 429.
-  auto streamingCallback = [loop, streamPtr, done, COMPLETION_ID, MODEL,
-                            CREATED, isChat, INCLUDE_USAGE, CONTINUOUS_USAGE,
-                            completionTokens, startTime, firstTokenTime,
-                            secondTokenTime, firstContentChunk, reqPtr,
-                            accumulator](
+  auto streamingCallback = [loop, streamPtr, earlyBuffer, done, COMPLETION_ID,
+                            MODEL, CREATED, isChat, INCLUDE_USAGE,
+                            CONTINUOUS_USAGE, completionTokens, startTime,
+                            firstTokenTime, secondTokenTime, firstContentChunk,
+                            reqPtr, accumulator, onDisconnect](
                                const domain::StreamingChunkResponse& chunk,
                                bool isFinal) {
-    if (done->load() || !*streamPtr) {
+    if (done->load()) {
       return;
     }
     if (!chunk.choices.empty()) {
@@ -371,7 +399,7 @@ void LLMController::handleStreaming(
       }
 
       if (!sse.empty()) {
-        sseSend(sse, loop, streamPtr, accumulator);
+        sseSend(sse, loop, streamPtr, accumulator, earlyBuffer, onDisconnect);
       }
     }
     if (isFinal) {

--- a/tt-media-server/cpp_server/src/ipc/boost_ipc_cancel_queue.cpp
+++ b/tt-media-server/cpp_server/src/ipc/boost_ipc_cancel_queue.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#include "ipc/boost_ipc_cancel_queue.hpp"
+
+#include <boost/interprocess/errors.hpp>
+
+#include "utils/logger.hpp"
+
+namespace tt::ipc {
+
+namespace bi_ipc = boost::interprocess;
+
+using TaskID = tt::domain::TaskID;
+
+static constexpr size_t MSG_SIZE = TaskID::K_SERIALIZED_SIZE;
+
+BoostIpcCancelQueue::BoostIpcCancelQueue(const std::string& name,
+                                         size_t capacity)
+    : name_(name) {
+  queue_ = std::make_unique<bi_ipc::message_queue>(
+      bi_ipc::create_only, name.c_str(), capacity, MSG_SIZE);
+}
+
+BoostIpcCancelQueue::BoostIpcCancelQueue(const std::string& name)
+    : name_(name) {
+  queue_ =
+      std::make_unique<bi_ipc::message_queue>(bi_ipc::open_only, name.c_str());
+}
+
+BoostIpcCancelQueue::~BoostIpcCancelQueue() {
+  try {
+    queue_.reset();
+  } catch (const bi_ipc::interprocess_exception& e) {
+    TT_LOG_WARN("[BoostIpcCancelQueue] Destructor: {} (ignored)", e.what());
+  }
+}
+
+void BoostIpcCancelQueue::push(const TaskID& taskId) {
+  auto buf = taskId.ipcSerialize();
+  try {
+    bool sent = queue_->try_send(buf.data(), buf.size(), /*priority=*/0);
+    if (!sent) {
+      TT_LOG_WARN("[BoostIpcCancelQueue] Queue full, dropping cancel for {}",
+                  taskId.id);
+    }
+  } catch (const bi_ipc::interprocess_exception& e) {
+    TT_LOG_WARN("[BoostIpcCancelQueue] push failed: {}", e.what());
+  }
+}
+
+void BoostIpcCancelQueue::tryPopAll(std::vector<TaskID>& out) {
+  char buf[MSG_SIZE];
+  bi_ipc::message_queue::size_type recvSize = 0;
+  unsigned int priority = 0;
+  while (queue_->try_receive(buf, MSG_SIZE, recvSize, priority)) {
+    out.push_back(TaskID::ipcDeserialize(buf, recvSize));
+  }
+}
+
+void BoostIpcCancelQueue::remove(const std::string& name) {
+  bi_ipc::message_queue::remove(name.c_str());
+}
+
+}  // namespace tt::ipc

--- a/tt-media-server/cpp_server/src/ipc/boost_ipc_cancel_queue.cpp
+++ b/tt-media-server/cpp_server/src/ipc/boost_ipc_cancel_queue.cpp
@@ -58,7 +58,11 @@ void BoostIpcCancelQueue::tryPopAll(std::vector<TaskID>& out) {
   }
 }
 
-void BoostIpcCancelQueue::remove(const std::string& name) {
+void BoostIpcCancelQueue::remove() {
+  bi_ipc::message_queue::remove(name_.c_str());
+}
+
+void BoostIpcCancelQueue::removeByName(const std::string& name) {
   bi_ipc::message_queue::remove(name.c_str());
 }
 

--- a/tt-media-server/cpp_server/src/runners/llm_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "config/settings.hpp"
-#include "ipc/boost_ipc_cancel_queue.hpp"
+#include "ipc/cancel_queue.hpp"
 #include "profiling/tracy.hpp"
 
 namespace tt::runners {
@@ -14,8 +14,7 @@ using Config = tt::config::LLMConfig;
 
 LLMRunner::LLMRunner(const Config& config,
                      ipc::TokenRingBuffer<65536>* resultQueue,
-                     ITaskQueue* taskQueue,
-                     ipc::BoostIpcCancelQueue* cancelQueue)
+                     ITaskQueue* taskQueue, ipc::ICancelQueue* cancelQueue)
     : config_(config), result_queue_(resultQueue), cancel_queue_(cancelQueue) {
   scheduler_ =
       makeScheduler(config_, taskQueue, tt::config::maxInFlightCount());

--- a/tt-media-server/cpp_server/src/runners/llm_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner.cpp
@@ -2,8 +2,10 @@
 
 #include <cassert>
 #include <thread>
+#include <vector>
 
 #include "config/settings.hpp"
+#include "ipc/boost_ipc_cancel_queue.hpp"
 #include "profiling/tracy.hpp"
 
 namespace tt::runners {
@@ -12,8 +14,9 @@ using Config = tt::config::LLMConfig;
 
 LLMRunner::LLMRunner(const Config& config,
                      ipc::TokenRingBuffer<65536>* resultQueue,
-                     ITaskQueue* taskQueue)
-    : config_(config), result_queue_(resultQueue) {
+                     ITaskQueue* taskQueue,
+                     ipc::BoostIpcCancelQueue* cancelQueue)
+    : config_(config), result_queue_(resultQueue), cancel_queue_(cancelQueue) {
   scheduler_ =
       makeScheduler(config_, taskQueue, tt::config::maxInFlightCount());
 
@@ -21,7 +24,8 @@ LLMRunner::LLMRunner(const Config& config,
     ZoneScopedN("LLMRunner::process_token_result");
     Sequence* seq = scheduler_->findSequence(result.taskId);
 
-    assert(seq);
+    // Sequence was aborted between model run and token callback — discard.
+    if (!seq || seq->isAborted()) return;
 
     if (result.isError) {
       scheduler_->removeSequence(result.taskId);
@@ -91,6 +95,16 @@ void LLMRunner::run() {
 void LLMRunner::stop() { stopped_.store(true, std::memory_order_relaxed); }
 
 void LLMRunner::step() {
+  // Drain cancel queue before scheduling so aborted sequences are excluded
+  // from the next batch.
+  if (cancel_queue_) {
+    std::vector<TaskID> cancelled;
+    cancel_queue_->tryPopAll(cancelled);
+    for (const auto& taskId : cancelled) {
+      scheduler_->abortRequest(taskId);
+    }
+  }
+
   auto [seqs, is_prefill] = scheduler_->schedule();
   if (seqs.empty()) return;
   ZoneScopedN("LLMRunner::step");

--- a/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
@@ -3,6 +3,7 @@
 
 #include "runners/llm_runner/scheduler.hpp"
 
+#include <algorithm>
 #include <cassert>
 
 #include "profiling/tracy.hpp"
@@ -66,6 +67,15 @@ bool Scheduler::trySchedulePrefill(std::vector<Sequence*>& scheduledSeqs,
   while (numSeqs < seqLimit) {
     auto seq = prefill_queue_->tryPop();
     if (!seq) break;
+
+    // Skip sequences whose ID was aborted while the copy sat in the prefill
+    // queue. The copy's status field is WAITING (it's a snapshot), so we must
+    // check the pending_aborts_ set instead.
+    if (pending_aborts_.erase(seq->taskId)) {
+      sequences_.erase(seq->taskId);  // clean up the stale sequences_ entry
+      delete seq;
+      continue;
+    }
 
     if (numBatchedTokens + static_cast<int>(seq->size()) >
             max_num_batched_tokens_ ||
@@ -136,6 +146,15 @@ std::pair<std::vector<Sequence*>, bool> Scheduler::schedule() {
   }
 
   tryScheduleDecode(scheduledSeqs, numSeqs);
+
+  // Trim stale pending_aborts_ entries.  When the prefill queue is empty,
+  // remaining entries can never match a dequeued sequence — they are leftovers
+  // from broadcast aborts to workers that don't own those tasks.
+  if (prefill_queue_->empty() &&
+      pending_aborts_.size() > max_in_flight_count_) {
+    pending_aborts_.clear();
+  }
+
   return {scheduledSeqs, false};
 }
 
@@ -174,4 +193,40 @@ void Scheduler::postprocess(std::vector<Sequence*>& seqs,
 }
 
 void Scheduler::removeSequence(TaskID taskId) { sequences_.erase(taskId); }
+
+void Scheduler::abortRequest(TaskID taskId) {
+  auto* seq = findSequence(taskId);
+  if (!seq || seq->isAborted() || seq->isFinished()) {
+    // Task is not (yet) in the scheduler — it may still be sitting in the
+    // prefill IPC queue as an unscheduled copy.  Record the ID so that copy
+    // is silently skipped when trySchedulePrefill dequeues it.
+    // Cap the set size to avoid unbounded growth from broadcast aborts to
+    // workers that don't own the sequence.
+    if (!seq && pending_aborts_.size() < 2 * max_in_flight_count_) {
+      pending_aborts_.insert(taskId);
+    }
+    return;  // already gone or finished — idempotent
+  }
+
+  // A WAITING sequence was added to sequences_ but its copy in the prefill
+  // IPC queue has not been dequeued yet.  Record the abort so that copy is
+  // skipped when trySchedulePrefill pops it.
+  // A RUNNING/IN_FLIGHT sequence was already dequeued by trySchedulePrefill
+  // so there is no stale copy; pending_aborts_ does not need an entry.
+  if (seq->status == SequenceStatus::WAITING &&
+      pending_aborts_.size() < 2 * max_in_flight_count_) {
+    pending_aborts_.insert(taskId);
+  }
+
+  seq->status = SequenceStatus::ABORTED;
+  block_manager_.deallocate(*seq);
+
+  // Remove from decode_queue (O(n) but abort is rare)
+  decode_queue_.erase(
+      std::remove_if(decode_queue_.begin(), decode_queue_.end(),
+                     [&](Sequence* s) { return s->taskId == taskId; }),
+      decode_queue_.end());
+
+  sequences_.erase(taskId);
+}
 }  // namespace llm_engine

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -149,19 +149,21 @@ void LLMService::consumerLoopForWorker(size_t workerIdx) {
     while (worker->cfg.result_queue->blockingPop(token)) {
       anyActivity = true;
 
-      auto val = stream_callbacks_.get(token.task_id);
-      if (!val.has_value()) {
-        throw std::runtime_error("callback not found for task_id: " +
-                                 std::string(token.task_id));
-      }
-      auto callback = val.value();
-
       std::string taskId = std::string(token.task_id);
       bool isFinal = token.isFinal();
 
+      // For final tokens, atomically take ownership of the callback so that
+      // only one of {consumer, abortRequest} decrements pending_tasks_.
+      std::function<void(domain::StreamingChunkResponse&, bool)> callback;
       if (isFinal) {
-        stream_callbacks_.erase(token.task_id);
+        auto val = stream_callbacks_.take(token.task_id);
+        if (!val.has_value()) continue;  // abortRequest already took it
+        callback = std::move(val.value());
         pending_tasks_.fetch_sub(1);
+      } else {
+        auto val = stream_callbacks_.get(token.task_id);
+        if (!val.has_value()) continue;
+        callback = std::move(val.value());
       }
 
       // Process token through reasoning parser to determine content type
@@ -222,7 +224,7 @@ void LLMService::consumerLoopForWorker(size_t workerIdx) {
     }
 
     if (!anyActivity) {
-      std::this_thread::yield();
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
     }
   }
 
@@ -340,4 +342,41 @@ void LLMService::postProcess(domain::CompletionResponse& response) const {
     }
   }
 }
+void LLMService::abortRequest(const domain::TaskID& taskId) {
+  std::string taskKey = taskId.id;
+
+  // Atomically remove the stream callback and decrement pending_tasks_.
+  auto cb = stream_callbacks_.take(taskKey);
+  if (cb.has_value()) {
+    pending_tasks_.fetch_sub(1);
+  }
+
+  // Invoke the detached callback with isFinal=true so any blocking waiter
+  // (e.g. processRequest's cv.wait) is unblocked.  For streaming requests the
+  // controller sets done=true BEFORE calling abortRequest, so the callback's
+  // done->load() check returns immediately — no SSE data is sent.
+  if (cb.has_value()) {
+    domain::StreamingChunkResponse abortResponse{taskId};
+    domain::CompletionChoice choice;
+    choice.finish_reason = "abort";
+    abortResponse.choices.push_back(std::move(choice));
+    cb.value()(abortResponse, /*isFinal=*/true);
+  }
+
+  // Clean up any reasoning-parser state so task_states_ does not leak.
+  if (reasoning_parser_) {
+    reasoning_parser_->finalizeTask(taskKey);
+  }
+
+  // Broadcast the cancel signal to every per-worker cancel queue.
+  // Each worker's scheduler::abortRequest is idempotent for unknown task IDs.
+  if (queue_manager_) {
+    for (auto& cq : queue_manager_->cancel_queues) {
+      cq->push(taskId);
+    }
+  }
+
+  TT_LOG_INFO("[LLMService] Aborted request {}", taskKey);
+}
+
 }  // namespace tt::services

--- a/tt-media-server/cpp_server/tests/cancellation_test.cpp
+++ b/tt-media-server/cpp_server/tests/cancellation_test.cpp
@@ -1,0 +1,450 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// Unit and integration tests for request cancellation:
+//   1. Scheduler::abortRequest() — removes sequences, frees blocks, idempotent
+//   2. LLMRunner cancel queue — abort stops token emission for that request
+//   3. BoostIpcCancelQueue — IPC push/drain round-trip
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "config/runner_config.hpp"
+#include "ipc/boost_ipc_cancel_queue.hpp"
+#include "ipc/shared_memory.hpp"
+#include "runners/llm_runner.hpp"
+#include "runners/llm_runner/in_memory_task_queue.hpp"
+#include "runners/llm_runner/prefill_first_scheduler.hpp"
+#include "runners/llm_runner/sampling_params.hpp"
+#include "runners/llm_runner/scheduler.hpp"
+#include "runners/llm_runner/sequence.hpp"
+
+namespace llm_engine {
+
+using Config = tt::config::LLMConfig;
+
+namespace {
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers shared across test suites
+// ──────────────────────────────────────────────────────────────────────────────
+
+std::shared_ptr<ITaskQueue> makeQueue() {
+  return std::make_shared<InMemoryTaskQueue>();
+}
+
+Config makeConfig(int numBlocks = 32, int blockSize = 8,
+                  int maxBatchedTokens = 512) {
+  Config c;
+  c.num_kvcache_blocks = numBlocks;
+  c.kvcache_block_size = blockSize;
+  c.max_num_batched_tokens = maxBatchedTokens;
+  c.eos = 0;
+  return c;
+}
+
+std::vector<int64_t> prompt(size_t len) {
+  std::vector<int64_t> p;
+  for (size_t i = 0; i < len; ++i) p.push_back(static_cast<int64_t>(i + 1));
+  return p;
+}
+
+TaskID nextId() { return TaskID(TaskID::generate()); }
+
+// Advance a prefill batch and return the batch (mutates the scheduler decode
+// queue). Returns the scheduled batch or empty if nothing to schedule.
+std::vector<Sequence*> runPrefill(Scheduler& sched) {
+  auto [batch, is_prefill] = sched.schedule();
+  if (!is_prefill || batch.empty()) return {};
+  std::vector<int64_t> tokens(batch.size(), 1);
+  sched.postprocess(batch, tokens);
+  return batch;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Suite 1: Scheduler::abortRequest()
+// ──────────────────────────────────────────────────────────────────────────────
+
+// Abort a sequence that has not yet been scheduled (still in prefill queue).
+// The scheduler should report it as gone and skip it during the next schedule.
+TEST(SchedulerAbortTest, AbortWaiting_SequenceBecomesUnfindable) {
+  Config cfg = makeConfig();
+  auto queue = makeQueue();
+  PrefillFirstScheduler sched{cfg, queue.get(), 4};
+
+  TaskID id = nextId();
+  sched.addRequest(id, prompt(4), {.max_tokens = 10});
+
+  ASSERT_NE(sched.findSequence(id), nullptr);
+  sched.abortRequest(id);
+  EXPECT_EQ(sched.findSequence(id), nullptr);
+}
+
+// Abort a sequence that is in the decode queue (post-prefill, running).
+TEST(SchedulerAbortTest, AbortDecoding_SequenceBecomesUnfindable) {
+  Config cfg = makeConfig();
+  auto queue = makeQueue();
+  PrefillFirstScheduler sched{cfg, queue.get(), 4};
+
+  TaskID id = nextId();
+  sched.addRequest(id, prompt(4), {.max_tokens = 10});
+  runPrefill(sched);  // moves sequence to decode queue
+
+  ASSERT_NE(sched.findSequence(id), nullptr);
+  sched.abortRequest(id);
+  EXPECT_EQ(sched.findSequence(id), nullptr);
+}
+
+// After aborting a sequence, the scheduler is finished (no more work).
+TEST(SchedulerAbortTest, AbortDecoding_SchedulerReportsFinished) {
+  Config cfg = makeConfig();
+  auto queue = makeQueue();
+  PrefillFirstScheduler sched{cfg, queue.get(), 4};
+
+  TaskID id = nextId();
+  sched.addRequest(id, prompt(4), {.max_tokens = 10});
+  runPrefill(sched);
+
+  sched.abortRequest(id);
+  EXPECT_TRUE(sched.isFinished());
+}
+
+// Aborting one request must free KV blocks so a previously-blocked request
+// can be scheduled.
+TEST(SchedulerAbortTest, AbortFreesBlocks_AllowsNewRequest) {
+  // 1 block of size 8: there is room for exactly one prompt's KV allocation.
+  // seq1 occupies that block after prefill.
+  // seq2 then cannot be prefilled (no free blocks).
+  // Aborting seq1 frees the block so seq2 can prefill.
+  Config cfg = makeConfig(/*numBlocks=*/1, /*blockSize=*/8);
+  auto queue = makeQueue();
+  PrefillFirstScheduler sched{cfg, queue.get(), 4};
+
+  // seq1: 4 prompt tokens → 1 block needed.
+  TaskID id1 = nextId();
+  sched.addRequest(id1, prompt(4), {.max_tokens = 5});
+
+  // Prefill seq1: it occupies the single block.
+  auto [batch1, is_prefill1] = sched.schedule();
+  ASSERT_TRUE(is_prefill1);
+  ASSERT_EQ(batch1.size(), 1u);
+  sched.postprocess(batch1,
+                    {1});  // seq1 → decode queue, 5 tokens, still in block
+
+  // Now add seq2. seq2 also needs 1 block but there are none free.
+  TaskID id2 = nextId();
+  sched.addRequest(id2, prompt(4), {.max_tokens = 5});
+
+  // schedule() falls through to decode seq1 because seq2 cannot be prefilled.
+  auto [batch_decode, is_prefill_decode] = sched.schedule();
+  EXPECT_FALSE(is_prefill_decode) << "seq2 cannot prefill; decode seq1 instead";
+  // seq2 must not be in the scheduled batch (it's still stuck in prefill
+  // queue).
+  bool seq2InBatch =
+      std::any_of(batch_decode.begin(), batch_decode.end(),
+                  [&](const Sequence* s) { return s->taskId == id2; });
+  EXPECT_FALSE(seq2InBatch) << "seq2 must not appear in decode batch";
+
+  // Abort seq1: releases the block.
+  sched.abortRequest(id1);
+
+  // seq2 must now be prefillable.
+  auto [batch_after, is_prefill_after] = sched.schedule();
+  EXPECT_TRUE(is_prefill_after) << "seq2 should now get a prefill batch";
+  ASSERT_EQ(batch_after.size(), 1u);
+  EXPECT_EQ(batch_after[0]->taskId, id2);
+}
+
+// Calling abortRequest twice for the same ID must not crash or corrupt state.
+TEST(SchedulerAbortTest, AbortIsIdempotent) {
+  Config cfg = makeConfig();
+  auto queue = makeQueue();
+  PrefillFirstScheduler sched{cfg, queue.get(), 4};
+
+  TaskID id = nextId();
+  sched.addRequest(id, prompt(4), {.max_tokens = 10});
+
+  EXPECT_NO_FATAL_FAILURE(sched.abortRequest(id));
+  EXPECT_NO_FATAL_FAILURE(sched.abortRequest(id));
+  EXPECT_EQ(sched.findSequence(id), nullptr);
+}
+
+// Calling abortRequest with an unknown task ID must be a silent no-op.
+TEST(SchedulerAbortTest, AbortUnknownId_IsNoop) {
+  Config cfg = makeConfig();
+  auto queue = makeQueue();
+  PrefillFirstScheduler sched{cfg, queue.get(), 4};
+
+  TaskID unknown = nextId();
+  EXPECT_NO_FATAL_FAILURE(sched.abortRequest(unknown));
+  EXPECT_TRUE(sched.isFinished());
+}
+
+// A sequence aborted while still in the prefill queue must be silently skipped
+// (not scheduled) on the next schedule() call.
+TEST(SchedulerAbortTest, AbortedInPrefillQueue_SkippedDuringSchedule) {
+  Config cfg = makeConfig();
+  auto queue = makeQueue();
+  PrefillFirstScheduler sched{cfg, queue.get(), 4};
+
+  // Add two requests: abort the first one before it is ever scheduled.
+  TaskID id1 = nextId();
+  TaskID id2 = nextId();
+  sched.addRequest(id1, prompt(4), {.max_tokens = 10});
+  sched.addRequest(id2, prompt(4), {.max_tokens = 10});
+
+  sched.abortRequest(id1);
+
+  // The first scheduled batch must only contain id2.
+  auto [batch, is_prefill] = sched.schedule();
+  ASSERT_TRUE(is_prefill);
+  ASSERT_EQ(batch.size(), 1u);
+  EXPECT_EQ(batch[0]->taskId, id2);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Suite 2: LLMRunner + cancel queue
+// ──────────────────────────────────────────────────────────────────────────────
+
+Config makeEngineConfig() {
+  Config c;
+  c.num_kvcache_blocks = 128;
+  c.kvcache_block_size = 8;
+  c.max_num_batched_tokens = 512;
+  c.eos = 0;
+  return c;
+}
+
+// Abort a request before the engine starts. The aborted request must emit no
+// tokens at all; the other request must complete normally.
+TEST(LLMRunnerCancelTest, AbortBeforeStart_EmitsNoTokens) {
+  Config config = makeEngineConfig();
+  auto taskQueue = makeQueue();
+  std::string resultName = "/test_cancel_preabort_" + std::to_string(getpid());
+  tt::ipc::TokenRingBuffer<65536> resultQueue(resultName, true);
+
+  tt::runners::LLMRunner engine{config, &resultQueue, taskQueue.get()};
+
+  TaskID abortedId = TaskID(TaskID::generate());
+  TaskID normalId = TaskID(TaskID::generate());
+
+  engine.scheduler().addRequest(abortedId, prompt(4), {.max_tokens = 20});
+  engine.scheduler().addRequest(normalId, prompt(4), {.max_tokens = 5});
+
+  // Abort before start: no tokens should be generated for abortedId.
+  engine.scheduler().abortRequest(abortedId);
+
+  std::unordered_map<std::string, std::vector<int64_t>> received;
+  std::unordered_map<std::string, bool> finalSeen;
+  std::atomic<int> doneCount{0};
+
+  std::thread consumer([&]() {
+    tt::ipc::SharedToken token;
+    while (doneCount.load() < 1) {
+      if (resultQueue.pop(token)) {
+        std::string tid(token.task_id);
+        received[tid].push_back(static_cast<int64_t>(token.token_id));
+        if (token.isFinal()) {
+          finalSeen[tid] = true;
+          doneCount.fetch_add(1);
+        }
+      } else {
+        std::this_thread::yield();
+      }
+    }
+    engine.stop();
+  });
+
+  engine.start();
+  consumer.join();
+
+  // abortedId: must have produced zero tokens.
+  EXPECT_EQ(received.count(abortedId.id), 0u)
+      << "aborted request should emit no tokens";
+
+  // normalId: must have completed with FLAG_FINAL.
+  ASSERT_TRUE(finalSeen.count(normalId.id) && finalSeen[normalId.id])
+      << "normal request should complete";
+  EXPECT_EQ(received[normalId.id].size(), 5u)
+      << "normal request should produce exactly max_tokens tokens";
+
+  resultQueue.shutdown();
+}
+
+// Abort a request mid-stream via the IPC cancel queue. The aborted request
+// must stop emitting tokens after the abort is delivered; the other request
+// must complete normally.
+TEST(LLMRunnerCancelTest, AbortViaCancelQueue_StopsEmitting) {
+  std::string cancelQName = "tt_cancel_runner_test_" + std::to_string(getpid());
+  tt::ipc::BoostIpcCancelQueue::remove(cancelQName);
+
+  Config config = makeEngineConfig();
+  auto taskQueue = makeQueue();
+  std::string resultName = "/test_cancel_midstream_" + std::to_string(getpid());
+  tt::ipc::TokenRingBuffer<65536> resultQueue(resultName, true);
+
+  // Create the cancel queue (simulates the main-process side).
+  auto cancelQueue = std::make_shared<tt::ipc::BoostIpcCancelQueue>(
+      cancelQName, /*capacity=*/64);
+
+  tt::runners::LLMRunner engine{config, &resultQueue, taskQueue.get(),
+                                cancelQueue.get()};
+
+  TaskID abortedId = TaskID(TaskID::generate());
+  TaskID normalId = TaskID(TaskID::generate());
+
+  // normalId is short (5 tokens). abortedId is long (50 tokens).
+  engine.scheduler().addRequest(normalId, prompt(4), {.max_tokens = 5});
+  engine.scheduler().addRequest(abortedId, prompt(4), {.max_tokens = 50});
+
+  std::unordered_map<std::string, std::vector<int64_t>> received;
+  std::unordered_map<std::string, bool> finalSeen;
+  std::atomic<bool> abortPushed{false};
+  std::atomic<int> doneCount{0};
+
+  std::thread consumer([&]() {
+    tt::ipc::SharedToken token;
+    while (doneCount.load() < 1) {
+      if (resultQueue.pop(token)) {
+        std::string tid(token.task_id);
+        received[tid].push_back(static_cast<int64_t>(token.token_id));
+        if (token.isFinal()) {
+          finalSeen[tid] = true;
+          doneCount.fetch_add(1);
+
+          // Once normalId finishes, push cancel for abortedId.
+          if (tid == normalId.id && !abortPushed.exchange(true)) {
+            cancelQueue->push(abortedId);
+            // Give the engine a moment to process the cancel, then stop.
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            engine.stop();
+          }
+        }
+      } else {
+        std::this_thread::yield();
+      }
+    }
+  });
+
+  engine.start();
+  consumer.join();
+
+  // normalId must have completed.
+  ASSERT_TRUE(finalSeen.count(normalId.id) && finalSeen[normalId.id])
+      << "normal request should complete with FLAG_FINAL";
+  EXPECT_EQ(received[normalId.id].size(), 5u)
+      << "normal request must produce exactly max_tokens tokens";
+
+  // abortedId must never have received FLAG_FINAL.
+  EXPECT_FALSE(finalSeen.count(abortedId.id) && finalSeen[abortedId.id])
+      << "aborted request must not receive FLAG_FINAL";
+
+  // abortedId must have received fewer tokens than its max_tokens.
+  if (received.count(abortedId.id)) {
+    EXPECT_LT(received[abortedId.id].size(), 50u)
+        << "aborted request must not run to completion";
+  }
+
+  resultQueue.shutdown();
+  tt::ipc::BoostIpcCancelQueue::remove(cancelQName);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Suite 3: BoostIpcCancelQueue — IPC push/drain round-trip
+// ──────────────────────────────────────────────────────────────────────────────
+
+class CancelQueueTest : public ::testing::Test {
+ protected:
+  static constexpr const char* Q_NAME = "tt_cancel_queue_unit_test";
+
+  void SetUp() override { tt::ipc::BoostIpcCancelQueue::remove(Q_NAME); }
+  void TearDown() override { tt::ipc::BoostIpcCancelQueue::remove(Q_NAME); }
+};
+
+// Pushing a TaskID and immediately draining it returns the same ID.
+TEST_F(CancelQueueTest, PushAndDrain_RoundTrip) {
+  tt::ipc::BoostIpcCancelQueue q{Q_NAME, 64};
+
+  tt::domain::TaskID id(tt::domain::TaskID::generate());
+  q.push(id);
+
+  std::vector<tt::domain::TaskID> out;
+  q.tryPopAll(out);
+
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_EQ(out[0].id, id.id);
+}
+
+// Draining an empty queue returns an empty vector.
+TEST_F(CancelQueueTest, DrainEmpty_ReturnsEmpty) {
+  tt::ipc::BoostIpcCancelQueue q{Q_NAME, 64};
+
+  std::vector<tt::domain::TaskID> out;
+  q.tryPopAll(out);
+
+  EXPECT_TRUE(out.empty());
+}
+
+// Pushing multiple IDs and draining once returns all of them.
+TEST_F(CancelQueueTest, MultipleMessages_AllDrained) {
+  tt::ipc::BoostIpcCancelQueue q{Q_NAME, 64};
+
+  std::vector<std::string> pushed;
+  for (int i = 0; i < 5; ++i) {
+    tt::domain::TaskID id(tt::domain::TaskID::generate());
+    pushed.push_back(id.id);
+    q.push(id);
+  }
+
+  std::vector<tt::domain::TaskID> out;
+  q.tryPopAll(out);
+
+  ASSERT_EQ(out.size(), 5u);
+  std::vector<std::string> received;
+  for (const auto& tid : out) received.push_back(tid.id);
+  EXPECT_EQ(received, pushed);
+}
+
+// Pushing beyond capacity does not block or crash; excess messages are dropped.
+TEST_F(CancelQueueTest, PushWhenFull_DropsGracefully) {
+  tt::ipc::BoostIpcCancelQueue q{Q_NAME, /*capacity=*/2};
+
+  tt::domain::TaskID id1(tt::domain::TaskID::generate());
+  tt::domain::TaskID id2(tt::domain::TaskID::generate());
+  tt::domain::TaskID id3(tt::domain::TaskID::generate());  // will be dropped
+
+  EXPECT_NO_FATAL_FAILURE(q.push(id1));
+  EXPECT_NO_FATAL_FAILURE(q.push(id2));
+  EXPECT_NO_FATAL_FAILURE(q.push(id3));  // queue is full — should drop silently
+
+  std::vector<tt::domain::TaskID> out;
+  q.tryPopAll(out);
+  // Only the first two fit; the third was dropped.
+  EXPECT_LE(out.size(), 2u);
+}
+
+// Draining twice: second drain returns nothing.
+TEST_F(CancelQueueTest, DrainTwice_SecondDrainEmpty) {
+  tt::ipc::BoostIpcCancelQueue q{Q_NAME, 64};
+
+  tt::domain::TaskID id(tt::domain::TaskID::generate());
+  q.push(id);
+
+  std::vector<tt::domain::TaskID> first, second;
+  q.tryPopAll(first);
+  q.tryPopAll(second);
+
+  EXPECT_EQ(first.size(), 1u);
+  EXPECT_TRUE(second.empty());
+}
+
+}  // namespace
+}  // namespace llm_engine

--- a/tt-media-server/cpp_server/tests/cancellation_test.cpp
+++ b/tt-media-server/cpp_server/tests/cancellation_test.cpp
@@ -284,7 +284,7 @@ TEST(LLMRunnerCancelTest, AbortBeforeStart_EmitsNoTokens) {
 // must complete normally.
 TEST(LLMRunnerCancelTest, AbortViaCancelQueue_StopsEmitting) {
   std::string cancelQName = "tt_cancel_runner_test_" + std::to_string(getpid());
-  tt::ipc::BoostIpcCancelQueue::remove(cancelQName);
+  tt::ipc::BoostIpcCancelQueue::removeByName(cancelQName);
 
   Config config = makeEngineConfig();
   auto taskQueue = makeQueue();
@@ -354,7 +354,7 @@ TEST(LLMRunnerCancelTest, AbortViaCancelQueue_StopsEmitting) {
   }
 
   resultQueue.shutdown();
-  tt::ipc::BoostIpcCancelQueue::remove(cancelQName);
+  tt::ipc::BoostIpcCancelQueue::removeByName(cancelQName);
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -365,8 +365,10 @@ class CancelQueueTest : public ::testing::Test {
  protected:
   static constexpr const char* Q_NAME = "tt_cancel_queue_unit_test";
 
-  void SetUp() override { tt::ipc::BoostIpcCancelQueue::remove(Q_NAME); }
-  void TearDown() override { tt::ipc::BoostIpcCancelQueue::remove(Q_NAME); }
+  void SetUp() override { tt::ipc::BoostIpcCancelQueue::removeByName(Q_NAME); }
+  void TearDown() override {
+    tt::ipc::BoostIpcCancelQueue::removeByName(Q_NAME);
+  }
 };
 
 // Pushing a TaskID and immediately draining it returns the same ID.

--- a/tt-media-server/cpp_server/tests/run_e2e_with_server.sh
+++ b/tt-media-server/cpp_server/tests/run_e2e_with_server.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# Starts a mock C++ server, runs the Python e2e tests, and tears down.
+# Intended to be called via ctest so that `ctest --output-on-failure` runs
+# both C++ unit tests and Python e2e tests in a single invocation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/../build"
+SERVER_BIN="${BUILD_DIR}/tt_media_server_cpp"
+
+# Check Python dependencies; skip (exit 0) if missing so ctest doesn't fail.
+if ! command -v pytest >/dev/null 2>&1; then
+  # Fall back to python3 -m pytest
+  if ! python3 -c "import pytest, requests" 2>/dev/null; then
+    echo "SKIP: pytest/requests not available; install with: pip install requests pytest" >&2
+    exit 0
+  fi
+  PYTEST="python3 -m pytest"
+else
+  if ! python3 -c "import requests" 2>/dev/null; then
+    echo "SKIP: python requests not available; install with: pip install requests" >&2
+    exit 0
+  fi
+  PYTEST="pytest"
+fi
+PORT="${E2E_PORT:-18765}"
+PID_FILE="/tmp/tt_e2e_server_${PORT}.pid"
+LOG_FILE="/tmp/tt_e2e_server_${PORT}.log"
+
+cleanup() {
+  if [[ -f "$PID_FILE" ]]; then
+    local pid
+    pid=$(cat "$PID_FILE")
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+    rm -f "$PID_FILE"
+  fi
+}
+trap cleanup EXIT
+
+if [[ ! -x "$SERVER_BIN" ]]; then
+  echo "ERROR: Server binary not found at $SERVER_BIN" >&2
+  echo "Build the project first with ./build.sh" >&2
+  exit 1
+fi
+
+# Start mock server
+LLM_DEVICE_BACKEND=mock "$SERVER_BIN" -p "$PORT" > "$LOG_FILE" 2>&1 &
+SERVER_PID=$!
+echo "$SERVER_PID" > "$PID_FILE"
+
+# Wait for health
+for i in $(seq 1 30); do
+  if curl -sf "http://127.0.0.1:${PORT}/health" | grep -q healthy; then
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "ERROR: Server process died during startup. Log:" >&2
+    cat "$LOG_FILE" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+if ! curl -sf "http://127.0.0.1:${PORT}/health" | grep -q healthy; then
+  echo "ERROR: Server did not become healthy within 30s. Log:" >&2
+  cat "$LOG_FILE" >&2
+  exit 1
+fi
+
+echo "Server ready on port $PORT (PID $SERVER_PID)"
+
+# Run e2e tests
+SERVER_BASE_URL="http://127.0.0.1:${PORT}" \
+  $PYTEST "${SCRIPT_DIR}/test_cancellation_e2e.py" -v --tb=short

--- a/tt-media-server/cpp_server/tests/test_cancellation_e2e.py
+++ b/tt-media-server/cpp_server/tests/test_cancellation_e2e.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+"""
+End-to-end tests for request cancellation over HTTP.
+
+Verifies that when a streaming client drops its connection, the C++ server:
+  1. Does not crash (health endpoint remains responsive).
+  2. Continues serving subsequent requests correctly after the disconnect.
+  3. Handles multiple rapid disconnects without degradation.
+
+These tests run against a live C++ server started with LLM_DEVICE_BACKEND=mock.
+Set SERVER_BASE_URL to point at a running server (default: http://127.0.0.1:8000).
+"""
+
+import json
+import os
+import threading
+import time
+
+import requests
+
+SERVER_BASE_URL = os.environ.get("SERVER_BASE_URL", "http://127.0.0.1:8000")
+API_KEY = os.environ.get("OPENAI_API_KEY", "your-secret-key")
+
+_HEADERS = {
+    "Authorization": f"Bearer {API_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+def _payload(max_tokens: int) -> dict:
+    return {
+        "model": "test",
+        "prompt": "Hello",
+        "stream": True,
+        "max_tokens": max_tokens,
+        "temperature": 0,
+    }
+
+
+def _health_ok() -> bool:
+    try:
+        resp = requests.get(
+            f"{SERVER_BASE_URL}/health",
+            timeout=5,
+        )
+        return resp.status_code == 200 and resp.json().get("status") == "healthy"
+    except Exception:
+        return False
+
+
+def _stream_and_drop(max_tokens: int, drop_after: int) -> int:
+    """
+    Open a streaming completion, read up to *drop_after* SSE data lines, then
+    close the connection abruptly.  Returns the number of data chunks received
+    before the close.
+    """
+    resp = requests.post(
+        f"{SERVER_BASE_URL}/v1/completions",
+        json=_payload(max_tokens),
+        headers=_HEADERS,
+        stream=True,
+        timeout=30,
+    )
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+    received = 0
+    try:
+        for raw_line in resp.iter_lines():
+            if not raw_line:
+                continue
+            line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
+            if not line.startswith("data: ") or line[6:] == "[DONE]":
+                continue
+            try:
+                chunk = json.loads(line[6:])
+            except Exception:
+                continue
+            if not chunk.get("choices"):
+                continue  # skip usage/empty-choices events
+            received += 1
+            if received >= drop_after:
+                # Close the socket without consuming the rest — simulates
+                # an abrupt TCP close from the client side.
+                resp.close()
+                return received
+    except Exception:
+        pass
+    return received
+
+
+def _stream_full(max_tokens: int) -> int:
+    """Stream a completion to completion and return the total data-chunk count."""
+    resp = requests.post(
+        f"{SERVER_BASE_URL}/v1/completions",
+        json=_payload(max_tokens),
+        headers=_HEADERS,
+        stream=True,
+        timeout=30,
+    )
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+    received = 0
+    for raw_line in resp.iter_lines():
+        if not raw_line:
+            continue
+        line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
+        if not line.startswith("data: ") or line[6:] == "[DONE]":
+            continue
+        try:
+            chunk = json.loads(line[6:])
+        except Exception:
+            continue
+        if chunk.get("choices"):  # skip usage/empty-choices events
+            received += 1
+    return received
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 1 — Server stays healthy after a single mid-stream disconnect
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_health_after_single_disconnect():
+    """Server health endpoint returns 'healthy' after one dropped connection."""
+    received = _stream_and_drop(max_tokens=200, drop_after=5)
+
+    assert received == 5, f"Expected to drop after exactly 5 tokens, got {received}"
+
+    # Allow the server a moment to process the TCP close event.
+    time.sleep(0.3)
+
+    assert _health_ok(), "Health check failed after a single disconnect"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 2 — Subsequent request completes correctly after a disconnect
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_subsequent_request_completes_after_disconnect():
+    """A new request submitted after a disconnect receives all expected tokens."""
+    expected = 30
+
+    _stream_and_drop(max_tokens=200, drop_after=5)
+    time.sleep(0.3)
+
+    received = _stream_full(max_tokens=expected)
+
+    assert received == expected, (
+        f"Follow-up request received {received} tokens instead of {expected}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 3 — Multiple rapid disconnects don't degrade the server
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_multiple_rapid_disconnects_no_degradation():
+    """Repeated rapid disconnects leave the server able to serve a full request."""
+    num_disconnects = 8
+    final_tokens = 25
+
+    for _ in range(num_disconnects):
+        _stream_and_drop(max_tokens=100, drop_after=3)
+
+    time.sleep(0.5)
+
+    assert _health_ok(), (
+        f"Health check failed after {num_disconnects} rapid disconnects"
+    )
+
+    received = _stream_full(max_tokens=final_tokens)
+
+    assert received == final_tokens, (
+        f"Server degraded after {num_disconnects} disconnects: "
+        f"expected {final_tokens} tokens, got {received}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 4 — Disconnect at the very first token
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_disconnect_at_first_token():
+    """Dropping a connection after the very first token doesn't hang the server."""
+    received = _stream_and_drop(max_tokens=100, drop_after=1)
+    assert received == 1
+
+    time.sleep(0.3)
+
+    assert _health_ok(), "Health check failed after disconnect at first token"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 5 — Concurrent disconnect and new request
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_concurrent_disconnect_and_new_request():
+    """A new request started concurrently with a disconnect completes in full."""
+    expected = 20
+    drop_result: list[int] = []
+    new_result: list[int] = []
+
+    def _drop():
+        drop_result.append(_stream_and_drop(max_tokens=200, drop_after=5))
+
+    t = threading.Thread(target=_drop)
+    t.start()
+
+    # Small stagger so the disconnect is in-flight while the new request starts.
+    time.sleep(0.05)
+    new_result.append(_stream_full(max_tokens=expected))
+
+    t.join(timeout=30)
+
+    assert drop_result, "Drop thread did not complete"
+    assert drop_result[0] == 5, f"Expected to drop after 5 tokens, got {drop_result[0]}"
+    assert new_result[0] == expected, (
+        f"Concurrent request received {new_result[0]} tokens instead of {expected}"
+    )


### PR DESCRIPTION
https://github.com/tenstorrent/tt-inference-server/issues/2264

  Summary

  - Introduce per-worker IPC cancel queues (BoostIpcCancelQueue) so the main process can broadcast abort signals to worker processes when a streaming client disconnects                       
  - Add Scheduler::abortRequest() which removes sequences from prefill/decode queues, frees KV cache blocks, and is idempotent for repeated calls; includes pending_aborts_ set to handle races
   where abort arrives before the sequence is dequeued                                                                                                                                         
  - Add LLMService::abortRequest() which sends a final finish_reason="abort" chunk to unblock synchronous waiters, then broadcasts to all worker cancel queues
  - Register POST /v1/responses/{response_id}/cancel endpoint
                                                                                                                                                                                               
  Test plan                                                                                                                                                                                    
                                                                                                                                                                                               
  - Unit tests (cancellation_test.cpp): scheduler abort removes sequences and frees blocks, IPC cancel queue push/drain round-trip, LLMRunner cancel stops token emission                      
  - E2e test (test_cancellation_e2e.py): streaming client disconnect doesn't crash server, subsequent requests succeed, multiple rapid disconnects handled
  - E2e test harness (run_e2e_with_server.sh): starts mock server, runs e2e suite, tears down                                                                                                  
                                                                                                                                                                                               