### PR TITLE
Update tt_metal_commit for Qwen3, Llama-3.3, and Llama-3.1 P300x2 specs

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1285,7 +1285,7 @@ llm_templates = [
                 mode=VersionMode.STRICT,
             ),
         ),
-        tt_metal_commit="555f240",
+        tt_metal_commit="e4a2dea",
         vllm_commit="22be241",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
@@ -1668,7 +1668,7 @@ llm_templates = [
                 mode=VersionMode.STRICT,
             ),
         ),
-        tt_metal_commit="555f240",
+        tt_metal_commit="e4a2dea",
         vllm_commit="22be241",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
@@ -1916,7 +1916,7 @@ llm_templates = [
                 mode=VersionMode.STRICT,
             ),
         ),
-        tt_metal_commit="555f240",
+        tt_metal_commit="e4a2dea",
         vllm_commit="22be241",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[


### PR DESCRIPTION
## Summary

Update `tt_metal_commit` from `555f240` to `e4a2dea` for LLM model specs on P300x2 hardware.

## Changes

- **Qwen3-32B**: Updated tt_metal_commit to e4a2dea
- **Llama-3.3-70B**: Updated tt_metal_commit to e4a2dea
- **Llama-3.1-8B**: Updated tt_metal_commit to e4a2dea

## Test Status

Tests are currently running:
- [Qwen3-32B P300x2](https://github.com/tenstorrent/tt-shield/actions/runs/23464378906)
- [Llama-3.3-70B P300x2](https://github.com/tenstorrent/tt-shield/actions/runs/23464381446)
- [Llama-3.1-8B P300x2](https://github.com/tenstorrent/tt-shield/actions/runs/23464384106)