### PR TITLE
Add Reasoning for Non-Streaming

### DIFF
--- a/tt-media-server/cpp_server/include/domain/chat_completion_response.hpp
+++ b/tt-media-server/cpp_server/include/domain/chat_completion_response.hpp
@@ -19,11 +19,15 @@ namespace tt::domain {
 struct ChatCompletionMessage {
   std::string role = "assistant";
   std::string content;
+  std::optional<std::string> reasoning;
 
   Json::Value toJson() const {
     Json::Value json;
     json["role"] = role;
     json["content"] = content;
+    if (reasoning.has_value()) {
+      json["reasoning"] = reasoning.value();
+    }
     return json;
   }
 };
@@ -93,6 +97,7 @@ struct ChatCompletionResponse {
       ChatCompletionChoice chatChoice;
       chatChoice.index = choice.index;
       chatChoice.message.content = choice.text;
+      chatChoice.message.reasoning = choice.reasoning;
       chatChoice.finish_reason = choice.finish_reason.value_or("stop");
       response.choices.push_back(std::move(chatChoice));
     }


### PR DESCRIPTION
## Problem
For non-streaming requests, the reasoning field was not included in the response. This PR makes responses aligned with vLLM standard.

This change also fixes cases where the `</think>` token wasn't generated (when the output exceeds max_tokens). In such scenarios, we now extract and return the available response correctly.


## Example
### Before
```
{"choices":[{"finish_reason":"stop","index":0,"logprobs":null,"message":{"content":"","role":"assistant"}}],"created":1774354768,"id":"chatcmpl-19233e621a5761d10f56f4e9","model":"default","object":"chat.completion","usage":{"completion_tokens":178,"prompt_tokens":4,"total_tokens":182,"tps":354.58167330677293,"ttft_ms":502.0}}
```

### After
```
{"choices":[{"finish_reason":"stop","index":0,"logprobs":null,"message":{"content":"","reasoning":"We are an expert computer scientist and educator. We are always as explicit in explaining as possible. You are always as explicit in explaining as possible.We are an expert computer scientist and educator. We are always as explicit in explaining as possible. You are always as explicit in explaining as possible.We are an expert computer scientist and educator. We are always as explicit in explaining as possible. You are always as explicit in explaining as possible.We are an expert computer scientist and educator. We are always as explicit in explaining as possible. You are always as explicit in explaining as possible.We are an expert computer scientist and educator. We are always as explicit in explaining as possible. You are always as explicit in explaining as possible.We are an expert computer scientist and educator. We are always as explicit in explaining as possible. You are always as explicit in explaining as possible. as","role":"assistant"}}],"created":1774354360,"id":"chatcmpl-2f5f06e0b165e86e004cd7de","model":"default","object":"chat.completion","usage":{"completion_tokens":178,"prompt_tokens":4,"total_tokens":182,"tps":354.58167330677293,"ttft_ms":502.0}}
```


### No reasoning:
```
{"choices":[{"finish_reason":"stop","index":0,"logprobs":null,"message":{"content":"We are an expert computer scientist and educator. We are always as explicit in explaining as possible. You are always as explicit in explaining as possible.We are an expert computer scientist and educator. We are always as explicit in explaining as possible. You are always as explicit in explaining as possible.We are an expert computer scientist and educator. We are always as explicit in explaining as possible. You are always as explicit in explaining as possible.We are an expert computer scientist and educator. We are always as explicit in explaining as possible. You are always as explicit in explaining as possible.We are an expert computer scientist and educator. We are always as explicit in explaining as possible. You are always as explicit in explaining as possible.We are an expert computer scientist and educator. We are always as explicit in explaining as possible. You are always as explicit in explaining as possible. as","role":"assistant"}}],"created":1774354842,"id":"chatcmpl-46feef2e9b99eeb23fd766fc","model":"default","object":"chat.completion","usage":{"completion_tokens":177,"prompt_tokens":4,"total_tokens":181,"tps":354.70941883767534,"ttft_ms":499.0}}
```