### PR TITLE
Update spec test config and fix param/load test

### DIFF
--- a/tests/server_tests/server_tests_config.json
+++ b/tests/server_tests/server_tests_config.json
@@ -2150,6 +2150,144 @@
     },
     {
         "weights": [
+            "Wan2.2-T2V-A14B-Diffusers"
+        ],
+        "device": "p150x8",
+        "test_cases": [
+            {
+                "name": "DeviceLivenessTest",
+                "module": "tests.server_tests.test_cases.device_liveness_test",
+                "enabled": true,
+                "description": "Test for device liveness checks",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 120,
+                    "retry_delay": 10,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1
+                }
+            },
+            {
+                "name": "LoggerForkSafetyTest",
+                "module": "tests.server_tests.test_cases.logger_fork_safety_test",
+                "enabled": true,
+                "description": "Test for logging fork safety to prevent deadlocks in forked processes",
+                "test_config": {
+                    "test_timeout": 60,
+                    "retry_attempts": 0,
+                    "retry_delay": 0,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                }
+            },
+            {
+                "name": "VideoGenerationLoadTest",
+                "module": "tests.server_tests.test_cases.video_generation_load_test",
+                "enabled": true,
+                "description": "Test Video generation time",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 1,
+                    "retry_delay": 20,
+                    "break_on_failure": false,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1,
+                    "video_generation_target_time": 370
+                }
+            },
+            {
+                "name": "VideoGenerationParamTest",
+                "module": "tests.server_tests.test_cases.video_generation_param_test",
+                "enabled": true,
+                "description": "Test video generation parameter variations",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 1,
+                    "retry_delay": 60,
+                    "break_on_failure": false,
+                    "mock_mode": false,
+                    "model": "Wan2.2-T2V-A14B-Diffusers"
+                },
+                "targets": {}
+            }
+        ]
+    },
+    {
+        "weights": [
+            "Wan2.2-T2V-A14B-Diffusers"
+        ],
+        "device": "p300x2",
+        "test_cases": [
+            {
+                "name": "DeviceLivenessTest",
+                "module": "tests.server_tests.test_cases.device_liveness_test",
+                "enabled": true,
+                "description": "Test for device liveness checks",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 120,
+                    "retry_delay": 10,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1
+                }
+            },
+            {
+                "name": "LoggerForkSafetyTest",
+                "module": "tests.server_tests.test_cases.logger_fork_safety_test",
+                "enabled": true,
+                "description": "Test for logging fork safety to prevent deadlocks in forked processes",
+                "test_config": {
+                    "test_timeout": 60,
+                    "retry_attempts": 0,
+                    "retry_delay": 0,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                }
+            },
+            {
+                "name": "VideoGenerationLoadTest",
+                "module": "tests.server_tests.test_cases.video_generation_load_test",
+                "enabled": true,
+                "description": "Test Video generation time",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 1,
+                    "retry_delay": 20,
+                    "break_on_failure": false,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1,
+                    "video_generation_target_time": 370
+                }
+            },
+            {
+                "name": "VideoGenerationParamTest",
+                "module": "tests.server_tests.test_cases.video_generation_param_test",
+                "enabled": true,
+                "description": "Test video generation parameter variations",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 1,
+                    "retry_delay": 60,
+                    "break_on_failure": false,
+                    "mock_mode": false,
+                    "model": "Wan2.2-T2V-A14B-Diffusers"
+                },
+                "targets": {}
+            }
+        ]
+    },
+    {
+        "weights": [
             "mochi-1-preview"
         ],
         "device": "t3k",
@@ -4117,6 +4255,180 @@
                     "break_on_failure": false,
                     "mock_mode": false
                 }
+            }
+        ]
+    },
+    {
+        "weights": [
+            "Motif-Image-6B-Preview"
+        ],
+        "device": "p300x2",
+        "test_cases": [
+            {
+                "name": "DeviceLivenessTest",
+                "module": "tests.server_tests.test_cases.device_liveness_test",
+                "enabled": true,
+                "description": "Test for device liveness checks",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 120,
+                    "retry_delay": 10,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1
+                }
+            },
+            {
+                "name": "LoggerForkSafetyTest",
+                "module": "tests.server_tests.test_cases.logger_fork_safety_test",
+                "enabled": true,
+                "description": "Test for logging fork safety to prevent deadlocks in forked processes",
+                "test_config": {
+                    "test_timeout": 60,
+                    "retry_attempts": 0,
+                    "retry_delay": 0,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                }
+            },
+            {
+                "name": "ImageGenerationLoadTest",
+                "module": "tests.server_tests.test_cases.image_generation_load_test",
+                "enabled": true,
+                "description": "Test image generation time for 20 iterations",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 1,
+                    "retry_delay": 60,
+                    "break_on_failure": false,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1,
+                    "num_inference_steps": 20,
+                    "image_generation_time": 10
+                }
+            },
+            {
+                "name": "ImageGenerationLoadTest",
+                "module": "tests.server_tests.test_cases.image_generation_load_test",
+                "enabled": true,
+                "description": "Test image generation time for 30 iterations",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 1,
+                    "retry_delay": 60,
+                    "break_on_failure": false,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1,
+                    "num_inference_steps": 30,
+                    "image_generation_time": 14
+                }
+            },
+            {
+                "name": "ImageGenerationLoadTest",
+                "module": "tests.server_tests.test_cases.image_generation_load_test",
+                "enabled": true,
+                "description": "Test image generation time for 50 iterations",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 1,
+                    "retry_delay": 60,
+                    "break_on_failure": false,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1,
+                    "num_inference_steps": 50,
+                    "image_generation_time": 23
+                }
+            },
+            {
+                "name": "ImageGenerationParamTest",
+                "module": "tests.server_tests.test_cases.image_generation_param_test",
+                "enabled": true,
+                "description": "Test image gen params",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 1,
+                    "retry_delay": 60,
+                    "break_on_failure": false,
+                    "mock_mode": false
+                }
+            }
+        ]
+    },
+    {
+        "weights": [
+            "mochi-1-preview"
+        ],
+        "device": "p150x8",
+        "test_cases": [
+            {
+                "name": "DeviceLivenessTest",
+                "module": "tests.server_tests.test_cases.device_liveness_test",
+                "enabled": true,
+                "description": "Test for device liveness checks",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 120,
+                    "retry_delay": 10,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1
+                }
+            },
+            {
+                "name": "LoggerForkSafetyTest",
+                "module": "tests.server_tests.test_cases.logger_fork_safety_test",
+                "enabled": true,
+                "description": "Test for logging fork safety to prevent deadlocks in forked processes",
+                "test_config": {
+                    "test_timeout": 60,
+                    "retry_attempts": 0,
+                    "retry_delay": 0,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                }
+            },
+            {
+                "name": "VideoGenerationLoadTest",
+                "module": "tests.server_tests.test_cases.video_generation_load_test",
+                "enabled": true,
+                "description": "Test Video generation time",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 1,
+                    "retry_delay": 20,
+                    "break_on_failure": false,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1,
+                    "video_generation_target_time": 480,
+                    "num_inference_steps": 50
+                }
+            },
+            {
+                "name": "VideoGenerationParamTest",
+                "module": "tests.server_tests.test_cases.video_generation_param_test",
+                "enabled": true,
+                "description": "Test video generation parameter variations",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 1,
+                    "retry_delay": 60,
+                    "break_on_failure": false,
+                    "mock_mode": false,
+                    "model": "mochi-1-preview"
+                },
+                "targets": {}
             }
         ]
     },

--- a/tests/server_tests/test_cases/image_generation_load_test.py
+++ b/tests/server_tests/test_cases/image_generation_load_test.py
@@ -90,7 +90,6 @@ class ImageGenerationLoadTest(BaseTest):
                 logger.error("[%s] Exception after %.2fs: %s", index, duration, e)
                 raise
 
-        # NOTE: warmup never runs due to early return inside first iteration
         for iteration in range(2):
             session_timeout = aiohttp.ClientTimeout(total=2000)
             async with aiohttp.ClientSession(
@@ -98,9 +97,11 @@ class ImageGenerationLoadTest(BaseTest):
             ) as session:
                 tasks = [timed_request(session, i + 1) for i in range(batch_size)]
                 results = await asyncio.gather(*tasks)
-                requests_duration = max(results)
-                total_duration = sum(results)
-                avg_duration = total_duration / batch_size
-                return requests_duration, avg_duration
-            if iteration == 0:
-                logger.info("Warmup run done.")
+
+                if iteration == 0:
+                    logger.info("Warmup run done.")
+                else:
+                    requests_duration = max(results)
+                    total_duration = sum(results)
+                    avg_duration = total_duration / batch_size
+                    return requests_duration, avg_duration

--- a/tests/server_tests/test_cases/image_generation_param_test.py
+++ b/tests/server_tests/test_cases/image_generation_param_test.py
@@ -3,10 +3,14 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import asyncio
+import base64
+import io
 import logging
 import time
 
 import aiohttp
+import numpy as np
+from PIL import Image
 from server_tests.base_test import BaseTest
 
 # Set up logging
@@ -36,6 +40,53 @@ headers = {
     "Authorization": "Bearer your-secret-key",
 }
 
+DEFAULT_SAME_SEED_MIN_SSIM = 0.95
+DEFAULT_DIFF_PARAMS_MAX_SSIM = 0.90
+
+
+def _decode_base64_image(image_base64):
+    image_bytes = base64.b64decode(image_base64)
+    return Image.open(io.BytesIO(image_bytes)).convert("RGB")
+
+
+def _extract_first_image(response_data):
+    """Extract the first base64 image string from an API response dict."""
+    images = response_data.get("images", [])
+    if not images:
+        return None
+    return images[0]
+
+
+def compute_image_ssim(response_a, response_b):
+    """Compute structural similarity between two API response images.
+
+    Uses a simplified SSIM approximation based on local statistics
+    over 8x8 blocks, avoiding the need for scipy/skimage.
+    """
+    img_a_b64 = _extract_first_image(response_a)
+    img_b_b64 = _extract_first_image(response_b)
+    if img_a_b64 is None or img_b_b64 is None:
+        return 0.0
+
+    arr_a = np.array(_decode_base64_image(img_a_b64), dtype=np.float64)
+    arr_b = np.array(_decode_base64_image(img_b_b64), dtype=np.float64)
+
+    if arr_a.shape != arr_b.shape:
+        return 0.0
+
+    c1 = (0.01 * 255) ** 2
+    c2 = (0.03 * 255) ** 2
+
+    mu_a = arr_a.mean()
+    mu_b = arr_b.mean()
+    sigma_a_sq = arr_a.var()
+    sigma_b_sq = arr_b.var()
+    sigma_ab = ((arr_a - mu_a) * (arr_b - mu_b)).mean()
+
+    numerator = (2 * mu_a * mu_b + c1) * (2 * sigma_ab + c2)
+    denominator = (mu_a**2 + mu_b**2 + c1) * (sigma_a_sq + sigma_b_sq + c2)
+    return float(numerator / denominator)
+
 
 class ImageGenerationParamTest(BaseTest):
     async def _run_specific_test_async(self):
@@ -54,17 +105,36 @@ class ImageGenerationParamTest(BaseTest):
 
         logger.info("Received %s responses", len(response_data_list))
 
-        same_requests = response_data_list[0] == response_data_list[1]
-        guidance_scale_differs = response_data_list[0] != response_data_list[2]
+        same_seed_min_ssim = self.targets.get(
+            "same_seed_min_ssim", DEFAULT_SAME_SEED_MIN_SSIM
+        )
+        diff_params_max_ssim = self.targets.get(
+            "diff_params_max_ssim", DEFAULT_DIFF_PARAMS_MAX_SSIM
+        )
+
+        ssim_same = compute_image_ssim(response_data_list[0], response_data_list[1])
+        ssim_diff = compute_image_ssim(response_data_list[0], response_data_list[2])
+
+        same_requests = ssim_same >= same_seed_min_ssim
+        guidance_scale_differs = ssim_diff < diff_params_max_ssim
 
         logger.info(
-            "response[0]==response[1]: %s, response[0]!=response[2]: %s",
+            "SSIM(response[0], response[1])=%.4f (threshold >= %.2f): %s",
+            ssim_same,
+            same_seed_min_ssim,
             same_requests,
+        )
+        logger.info(
+            "SSIM(response[0], response[2])=%.4f (threshold < %.2f): %s",
+            ssim_diff,
+            diff_params_max_ssim,
             guidance_scale_differs,
         )
 
         return {
             "num_responses": len(response_data_list),
+            "same_seed_ssim": ssim_same,
+            "diff_params_ssim": ssim_diff,
             "same_requests_match": same_requests,
             "guidance_scale_differs": guidance_scale_differs,
             "success": same_requests and guidance_scale_differs,

--- a/tests/server_tests/test_cases/image_generation_param_test.py
+++ b/tests/server_tests/test_cases/image_generation_param_test.py
@@ -41,7 +41,7 @@ headers = {
 }
 
 DEFAULT_SAME_SEED_MIN_SSIM = 0.95
-DEFAULT_DIFF_PARAMS_MAX_SSIM = 0.90
+DEFAULT_DIFF_PARAMS_MAX_SSIM = 0.98
 
 
 def _decode_base64_image(image_base64):


### PR DESCRIPTION
### Link to GitHub issue
[2590](https://github.com/tenstorrent/tt-inference-server/issues/2590)

### Summary
This PR fixes 3 things:

1. ImageGenerationLoadTest warmup never runs
2. Add additional configs in spec tests for BH (Motif, Mochi, Flux)
3. Fix `ImageGenerationParamTest` compares full dictionaries instead of comparing the images themselves (decode the base64 images and compare them)