### PR TITLE
adding vLLM arg parsing allow for default overrides and --service-por…

### DIFF
--- a/tests/test_run_vllm_api_server.py
+++ b/tests/test_run_vllm_api_server.py
@@ -3,6 +3,7 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+import argparse
 import importlib.util
 import json
 import sys
@@ -107,3 +108,179 @@ def test_load_model_spec_accepts_legacy_and_wrapped_catalogs(
 
     assert model_spec["model_id"] == "id_tt-transformers_Mistral-7B-Instruct-v0.3_n150"
     assert model_spec["impl"]["impl_name"] == "tt-transformers"
+
+
+def test_set_vllm_sys_argv_merges_defaults_and_passthrough_overrides(
+    monkeypatch, run_vllm_api_server_module
+):
+    monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py", "--stale-wrapper-arg"])
+
+    args = argparse.Namespace(service_port=7001)
+    default_vllm_args = {
+        "model": "mistralai/Mistral-7B-Instruct-v0.3",
+        "port": 8000,
+        "max_model_len": "8192",
+        "seed": "9472",
+        "disable-log-requests": False,
+    }
+
+    run_vllm_api_server_module.set_vllm_sys_argv(
+        args,
+        [
+            "--max-model-len",
+            "4096",
+            "--disable-log-requests",
+            "--guided-decoding-backend=outlines",
+        ],
+        default_vllm_args,
+    )
+
+    assert default_vllm_args == {
+        "model": "mistralai/Mistral-7B-Instruct-v0.3",
+        "port": 8000,
+        "max_model_len": "8192",
+        "seed": "9472",
+        "disable-log-requests": False,
+    }
+    assert sys.argv == [
+        "run_vllm_api_server.py",
+        "--max-model-len",
+        "4096",
+        "--disable-log-requests",
+        "--guided-decoding-backend=outlines",
+        "--port",
+        "7001",
+        "--model",
+        "mistralai/Mistral-7B-Instruct-v0.3",
+        "--seed",
+        "9472",
+    ]
+
+
+def test_set_vllm_sys_argv_honors_equals_style_overrides(
+    monkeypatch, run_vllm_api_server_module
+):
+    monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py"])
+
+    run_vllm_api_server_module.set_vllm_sys_argv(
+        argparse.Namespace(service_port=None),
+        [
+            "--max-model-len=4096",
+            "--max-log-len",
+            "64",
+        ],
+        {
+            "port": 8000,
+            "max_model_len": "8192",
+            "max-log-len": "32",
+        },
+    )
+
+    assert sys.argv == [
+        "run_vllm_api_server.py",
+        "--max-model-len=4096",
+        "--max-log-len",
+        "64",
+        "--port",
+        "8000",
+    ]
+
+
+def test_set_vllm_sys_argv_logs_multiline_bash_command(
+    monkeypatch, run_vllm_api_server_module
+):
+    monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py"])
+    mock_logger = MagicMock()
+    monkeypatch.setattr(run_vllm_api_server_module, "logger", mock_logger)
+
+    run_vllm_api_server_module.set_vllm_sys_argv(
+        argparse.Namespace(service_port=None),
+        [
+            "--disable-log-requests",
+            "--served-model-name",
+            "my model",
+            "--guided-decoding-backend=outlines backend",
+        ],
+        {
+            "port": 8000,
+        },
+    )
+
+    mock_logger.info.assert_called_once_with(
+        "vLLM command:\n"
+        "vllm serve \\\n"
+        "  --disable-log-requests \\\n"
+        "  --served-model-name 'my model' \\\n"
+        "  '--guided-decoding-backend=outlines backend' \\\n"
+        "  --port 8000"
+    )
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_port"),
+    [
+        (["run_vllm_api_server.py", "--port", "9001"], 9001),
+        (["run_vllm_api_server.py", "--port=9002"], 9002),
+        (["run_vllm_api_server.py"], 8000),
+    ],
+)
+def test_resolve_service_port_reads_port_from_sys_argv(
+    monkeypatch, run_vllm_api_server_module, argv, expected_port
+):
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("SERVICE_PORT", "8000")
+
+    assert run_vllm_api_server_module.resolve_service_port() == expected_port
+
+
+def test_main_passes_passthrough_port_to_trace_capture(
+    monkeypatch, run_vllm_api_server_module
+):
+    args = argparse.Namespace(
+        model="mistralai/Mistral-7B-Instruct-v0.3",
+        tt_device="n150",
+        device=None,
+        engine=None,
+        impl=None,
+        no_auth=False,
+        disable_trace_capture=False,
+        service_port=None,
+    )
+    model_spec = {
+        "model_id": "id_tt-transformers_Mistral-7B-Instruct-v0.3_n150",
+        "impl": {"impl_id": "tt-transformers"},
+        "device_model_spec": {"vllm_args": {"port": 8000}},
+    }
+
+    monkeypatch.setattr(
+        run_vllm_api_server_module, "parse_args", lambda: (args, ["--port", "9001"])
+    )
+    monkeypatch.setattr(
+        run_vllm_api_server_module,
+        "load_model_spec",
+        MagicMock(return_value=model_spec),
+    )
+    monkeypatch.setattr(run_vllm_api_server_module, "set_cache_paths", MagicMock())
+    monkeypatch.setattr(
+        run_vllm_api_server_module, "ensure_weights_available", MagicMock()
+    )
+    monkeypatch.setattr(run_vllm_api_server_module, "register_tt_models", MagicMock())
+    monkeypatch.setattr(
+        run_vllm_api_server_module, "set_metal_timeout_env_vars", MagicMock()
+    )
+    monkeypatch.setattr(run_vllm_api_server_module, "set_runtime_env_vars", MagicMock())
+    monkeypatch.setattr(run_vllm_api_server_module, "runtime_settings", MagicMock())
+    monkeypatch.setattr(run_vllm_api_server_module.runpy, "run_module", MagicMock())
+    monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py"])
+    start_trace_capture = MagicMock()
+    monkeypatch.setattr(
+        run_vllm_api_server_module, "start_trace_capture", start_trace_capture
+    )
+
+    run_vllm_api_server_module.main()
+
+    start_trace_capture.assert_called_once_with(
+        model_spec,
+        disable_trace_capture=False,
+        service_port=9001,
+    )

--- a/vllm-tt-metal/README.md
+++ b/vllm-tt-metal/README.md
@@ -163,8 +163,8 @@ Setting JWT authorization is optional, if unset the server will not require the 
 export JWT_SECRET="my-secret-string"
 export BEARER_TOKEN=$(python -c 'import os, json, jwt; print(jwt.encode({"team_id": "tenstorrent", "token_id": "debug-test"}, os.getenv("JWT_SECRET"), algorithm="HS256"))')
 
-# for example HTTP request using curl, assuming SERVICE_PORT=7000
-export API_URL="http://0.0.0.0:7000/v1/chat/completions"
+# for example HTTP request using curl, assuming SERVICE_PORT=8000
+export API_URL="http://0.0.0.0:8000/v1/chat/completions"
 curl -s --no-buffer -X POST "${API_URL}" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $BEARER_TOKEN" \

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -8,6 +8,7 @@ import logging
 import multiprocessing
 import os
 import runpy
+import shlex
 import sys
 from pathlib import Path
 from typing import Optional
@@ -31,12 +32,11 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def parse_args():
-    """Parse CLI arguments before any model loading.
+DEFAULT_VLLM_SERVER_PORT = "8000"
 
-    Also removes --model and --device from sys.argv so they don't get passed
-    to vLLM's argument parser (which doesn't recognize --device).
-    """
+
+def parse_args():
+    """Parse wrapper CLI args and return remaining vLLM passthrough args."""
     parser = argparse.ArgumentParser(description="TT vLLM API Server")
     parser.add_argument(
         "--model",
@@ -79,16 +79,12 @@ def parse_args():
         "--service-port",
         type=int,
         default=None,
-        help="Service port for trace capture (defaults to vllm_args port or 8000)",
+        help="Service port for vLLM server and trace capture client",
     )
     # Parse known args to allow vLLM args to pass through
-    args, remaining = parser.parse_known_args()
+    args, remaining_args = parser.parse_known_args()
 
-    # Remove --model and --device from sys.argv so vLLM doesn't see them
-    # Keep sys.argv[0] (script name) and add remaining args
-    sys.argv = [sys.argv[0]] + remaining
-
-    return args
+    return args, remaining_args
 
 
 def normalize_device_type(device_arg: str) -> str:
@@ -574,7 +570,7 @@ def start_trace_capture(
         return
 
     if service_port is None:
-        service_port = int(os.getenv("SERVICE_PORT", "8000"))
+        service_port = int(os.getenv("SERVICE_PORT", DEFAULT_VLLM_SERVER_PORT))
     supported_modalities = model_spec_json.get("supported_modalities", ["text"])
 
     # Get max_context from device_model_spec for trace calculation
@@ -608,9 +604,124 @@ def start_trace_capture(
     )
 
 
+def _normalize_vllm_arg_name(arg_name: str) -> str:
+    return arg_name.lstrip("-").split("=", 1)[0].replace("-", "_")
+
+
+def _append_vllm_arg(argv: list[str], arg_name: str, value) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool):
+        if value:
+            argv.append(arg_name)
+        return
+    argv.extend([arg_name, str(value)])
+
+
+def _extract_cli_arg_value(argv: list[str], arg_name: str) -> Optional[str]:
+    for index, token in enumerate(argv):
+        if token == arg_name:
+            if index + 1 < len(argv):
+                return argv[index + 1]
+            return None
+        if token.startswith(f"{arg_name}="):
+            return token.split("=", 1)[1]
+    return None
+
+
+def resolve_service_port() -> int:
+    port_value = _extract_cli_arg_value(sys.argv[1:], "--port")
+    if port_value is not None:
+        return int(port_value)
+    return int(os.getenv("SERVICE_PORT", DEFAULT_VLLM_SERVER_PORT))
+
+
+def format_vllm_serve_command(argv) -> str:
+    """Render the normalized argv as a multi-line bash command."""
+    command_lines = ["vllm serve"]
+    index = 1
+    while index < len(argv):
+        token = argv[index]
+        rendered_tokens = [shlex.quote(token)]
+        has_separate_value = (
+            token.startswith("--")
+            and "=" not in token
+            and index + 1 < len(argv)
+            and not argv[index + 1].startswith("--")
+        )
+        if has_separate_value:
+            rendered_tokens.append(shlex.quote(argv[index + 1]))
+            index += 1
+
+        command_lines.append(" ".join(rendered_tokens))
+        index += 1
+
+    return " \\\n  ".join(command_lines)
+
+
+def set_vllm_sys_argv(args, remaining_sys_argv, default_vllm_args):
+    # runpy uses sys.argv, rebuild it with the merged vLLM args.
+    vllm_argv = [sys.argv[0]]
+    remaining_default_vllm_args = dict(default_vllm_args)
+    default_arg_name_by_normalized_name = {
+        _normalize_vllm_arg_name(arg_name): arg_name
+        for arg_name in remaining_default_vllm_args
+    }
+    input_vllm_argv = list(remaining_sys_argv)
+    if args.service_port is not None:
+        already_set_port = _extract_cli_arg_value(input_vllm_argv, "--port")
+        if already_set_port is not None:
+            logger.warning(
+                f"vLLM server --port={already_set_port} already set direcly, ignoring --service-port={args.service_port}"
+            )
+        else:
+            # Remap wrapper --service-port to vLLM's --port.
+            input_vllm_argv.extend(["--port", str(args.service_port)])
+
+    index = 0
+    while index < len(input_vllm_argv):
+        token = input_vllm_argv[index]
+        if not token.startswith("--"):
+            vllm_argv.append(token)
+            index += 1
+            continue
+
+        cli_arg_name, separator, inline_value = token.partition("=")
+        overridden_default_arg_name = default_arg_name_by_normalized_name.pop(
+            _normalize_vllm_arg_name(cli_arg_name), None
+        )
+        if overridden_default_arg_name is not None:
+            remaining_default_vllm_args.pop(overridden_default_arg_name, None)
+
+        if separator:
+            vllm_argv.append(f"{cli_arg_name}={inline_value}")
+            index += 1
+            continue
+
+        vllm_argv.append(cli_arg_name)
+        next_token_is_value = index + 1 < len(input_vllm_argv) and not input_vllm_argv[
+            index + 1
+        ].startswith("--")
+        if next_token_is_value:
+            value = input_vllm_argv[index + 1]
+            vllm_argv.append(value)
+            index += 2
+            continue
+
+        index += 1
+
+    for key, value in remaining_default_vllm_args.items():
+        cli_arg_name = f"--{key}"
+        _append_vllm_arg(vllm_argv, cli_arg_name, value)
+
+    # finally set sys.argv to the vllm server args
+    sys.argv = vllm_argv
+    logger.info(f"vLLM command:\n{format_vllm_serve_command(sys.argv)}")
+
+
 def main():
     # Step 1: Parse --model argument (if provided)
-    args = parse_args()
+    args, remaining_sys_argv = parse_args()
     args.device = args.tt_device or args.device
     args.engine = normalize_engine_type(args.engine)
 
@@ -643,28 +754,19 @@ def main():
     impl_id = model_spec.get("impl", {}).get("impl_id")
     register_tt_models(impl_id)
 
-    # Step 4: Set runtime environment variables and run setup
+    # Step 4: Set runtime environment variables and vLLM server args
     set_metal_timeout_env_vars()
     set_runtime_env_vars(model_spec)
     runtime_settings(model_spec, no_auth=args.no_auth)
+    default_vllm_args = model_spec["device_model_spec"]["vllm_args"]
+    set_vllm_sys_argv(args, remaining_sys_argv, default_vllm_args)
+
+    # Step 5: Start trace capture if needed
     start_trace_capture(
         model_spec,
         disable_trace_capture=args.disable_trace_capture,
-        service_port=args.service_port,
+        service_port=resolve_service_port(),
     )
-
-    # Step 5: Add vLLM CLI arguments
-    logger.info(
-        f"vllm_args: {json.dumps(model_spec['device_model_spec']['vllm_args'], indent=4)}"
-    )
-    for key, value in model_spec["device_model_spec"]["vllm_args"].items():
-        if value is not None:
-            # Handle boolean flags
-            if isinstance(value, bool):
-                if value:  # Only add the flag if True
-                    sys.argv.append("--" + key)
-            else:
-                sys.argv.extend(["--" + key, str(value)])
 
     # Step 6: Launch vLLM server
     # runpy uses the same process and environment so the registered models are available

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -555,7 +555,7 @@ def set_runtime_env_vars(model_spec_json):
 
 
 def start_trace_capture(
-    model_spec_json, disable_trace_capture=False, service_port=None
+    model_spec_json, service_port: int, disable_trace_capture: bool = False
 ):
     # Models with builtin warmup handle their own trace capture internally
     if not disable_trace_capture and model_spec_json.get("has_builtin_warmup", False):
@@ -569,8 +569,6 @@ def start_trace_capture(
         logger.info("Trace capture is disabled via --disable-trace-capture")
         return
 
-    if service_port is None:
-        service_port = int(os.getenv("SERVICE_PORT", DEFAULT_VLLM_SERVER_PORT))
     supported_modalities = model_spec_json.get("supported_modalities", ["text"])
 
     # Get max_context from device_model_spec for trace calculation
@@ -633,7 +631,7 @@ def resolve_service_port() -> int:
     port_value = _extract_cli_arg_value(sys.argv[1:], "--port")
     if port_value is not None:
         return int(port_value)
-    return int(os.getenv("SERVICE_PORT", DEFAULT_VLLM_SERVER_PORT))
+    return int(DEFAULT_VLLM_SERVER_PORT)
 
 
 def format_vllm_serve_command(argv) -> str:
@@ -764,8 +762,8 @@ def main():
     # Step 5: Start trace capture if needed
     start_trace_capture(
         model_spec,
-        disable_trace_capture=args.disable_trace_capture,
         service_port=resolve_service_port(),
+        disable_trace_capture=args.disable_trace_capture,
     )
 
     # Step 6: Launch vLLM server

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -202,7 +202,7 @@ Usage: python3 run.py --model <model> --workflow <workflow> [options]
 | `--docker-server` | false | Run inference server in a Docker container. |
 | `--local-server` | false | Run the vLLM inference server directly on the host. Requires `--tt-metal-home` and always uses host filesystem persistence for logs and TT caches. |
 | `-it`, `--interactive` | false | Run Docker in interactive mode. |
-| `--service-port` | `8000` | Service port. Also reads from `SERVICE_PORT` env var. |
+| `--service-port` | `8000` | Service port for inference HTTP server, e.g. vLLM. |
 | `--bind-host` | `0.0.0.0` | Host interface for Docker port publishing. Use `127.0.0.1` for localhost-only access. |
 | `--no-auth` | false | Disable vLLM API key authorization (skips `JWT_SECRET` requirement). |
 | `--print-docker-cmd` | false | Print the Docker run command and exit without starting the server. |
@@ -415,8 +415,8 @@ Run benchmarks against an external vLLM server:
 # Server running on localhost:8000
 python3 run.py --model Llama-3.3-70B-Instruct --workflow benchmarks --tt-device T3K --disable-trace-capture
 
-# can use --service-port or SERVICE_PORT env var to set another port
-SERVICE_PORT=9000 python3 run.py --model Qwen2.5-72B-Instruct --workflow benchmarks --tt-device N150 --disable-trace-capture
+# can use --service-port env var to set another port
+python3 run.py --model Qwen2.5-72B-Instruct --workflow benchmarks --tt-device N150 --disable-trace-capture --service-port 9000  
 ```
 
 Run evaluations against an external vLLM server:
@@ -424,7 +424,7 @@ Run evaluations against an external vLLM server:
 # Server running on localhost:8000
 python3 run.py --model Llama-3.3-70B-Instruct --workflow evals --tt-device T3K --disable-trace-capture
 
-# can use --service-port or SERVICE_PORT env var to set another port
+# can use --service-port to set another port
 python3 run.py --model Qwen2.5-72B-Instruct --workflow evals --tt-device N150 --disable-trace-capture --service-port 7592
 ```
 
@@ -456,7 +456,7 @@ python3 run.py --model Llama-3.1-8B-Instruct --workflow server --tt-device n300 
 
 - **Model Mismatch**: Ensure the model served by the external server matches the model specified in the `--model` parameter.
 
-- **Port Conflicts**: Make sure the `SERVICE_PORT` environment variable matches the actual port your external server is listening on.
+- **Port Conflicts**: Make sure the `--service-port` arg, or `SERVICE_PORT` environment variable matches the actual port your external server is listening on.
 
 
 ## Workflow Setup

--- a/workflows/run_local_server.py
+++ b/workflows/run_local_server.py
@@ -173,7 +173,6 @@ def build_local_server_env(
     env["TT_CACHE_PATH"] = str(tt_cache_path)
     env["TT_METAL_LOGS_PATH"] = str(logs_path)
     env["RUNTIME_MODEL_SPEC_JSON_PATH"] = str(Path(json_fpath).resolve())
-    env["SERVICE_PORT"] = str(runtime_config.service_port)
 
     if setup_config.host_weights_dir:
         env["MODEL_WEIGHTS_DIR"] = str(


### PR DESCRIPTION
# change log

* address https://github.com/tenstorrent/tt-inference-server/issues/2578
* adding vLLM arg parsing allow for default overrides 
* special handling for both --service-port and --port
* printing raw vLLM args sent to runpy