### PR TITLE
Add TT_MESH_GRAPH_DESC_PATH to Blackhole device specs for whisper and speecht5

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -22,8 +22,6 @@
         },
         "release": {
           "devices": [
-            "GALAXY",
-            "P150X8",
             "P300X2"
           ]
         }
@@ -94,8 +92,6 @@
         },
         "release": {
           "devices": [
-            "GALAXY",
-            "P150X8",
             "P300X2"
           ]
         }
@@ -225,8 +221,6 @@
         },
         "release": {
           "devices": [
-            "GALAXY",
-            "P150X8",
             "P300X2"
           ]
         }
@@ -268,11 +262,6 @@
             "GALAXY",
             "N150"
           ]
-        },
-        "release": {
-          "devices": [
-            "GALAXY"
-          ]
         }
       }
     },
@@ -288,13 +277,6 @@
             "P300X2",
             "T3K"
           ]
-        },
-        "release": {
-          "devices": [
-            "GALAXY",
-            "P150X8",
-            "P300X2"
-          ]
         }
       }
     },
@@ -305,11 +287,6 @@
           "devices": [
             "GALAXY",
             "N150"
-          ]
-        },
-        "release": {
-          "devices": [
-            "GALAXY"
           ]
         }
       }
@@ -334,12 +311,6 @@
             "P300X2",
             "P150X4",
             "T3K"
-          ]
-        },
-        "release": {
-          "devices": [
-            "P150X8",
-            "P300X2"
           ]
         }
       }
@@ -414,11 +385,6 @@
             "GALAXY",
             "T3K"
           ]
-        },
-        "release": {
-          "devices": [
-            "GALAXY"
-          ]
         }
       }
     },
@@ -454,11 +420,6 @@
             "P150X8",
             "P300X2",
             "T3K"
-          ]
-        },
-        "release": {
-          "devices": [
-            "GALAXY"
           ]
         }
       }
@@ -541,11 +502,6 @@
               "throttle-perf": "5"
             }
           }
-        },
-        "release": {
-          "devices": [
-            "GALAXY"
-          ]
         }
       }
     },
@@ -587,11 +543,6 @@
             "GALAXY",
             "GALAXY_BH",
             "N150"
-          ]
-        },
-        "release": {
-          "devices": [
-            "GALAXY"
           ]
         }
       }

--- a/tests/test_run_vllm_api_server.py
+++ b/tests/test_run_vllm_api_server.py
@@ -3,6 +3,7 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+import argparse
 import importlib.util
 import json
 import sys
@@ -107,3 +108,179 @@ def test_load_model_spec_accepts_legacy_and_wrapped_catalogs(
 
     assert model_spec["model_id"] == "id_tt-transformers_Mistral-7B-Instruct-v0.3_n150"
     assert model_spec["impl"]["impl_name"] == "tt-transformers"
+
+
+def test_set_vllm_sys_argv_merges_defaults_and_passthrough_overrides(
+    monkeypatch, run_vllm_api_server_module
+):
+    monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py", "--stale-wrapper-arg"])
+
+    args = argparse.Namespace(service_port=7001)
+    default_vllm_args = {
+        "model": "mistralai/Mistral-7B-Instruct-v0.3",
+        "port": 8000,
+        "max_model_len": "8192",
+        "seed": "9472",
+        "disable-log-requests": False,
+    }
+
+    run_vllm_api_server_module.set_vllm_sys_argv(
+        args,
+        [
+            "--max-model-len",
+            "4096",
+            "--disable-log-requests",
+            "--guided-decoding-backend=outlines",
+        ],
+        default_vllm_args,
+    )
+
+    assert default_vllm_args == {
+        "model": "mistralai/Mistral-7B-Instruct-v0.3",
+        "port": 8000,
+        "max_model_len": "8192",
+        "seed": "9472",
+        "disable-log-requests": False,
+    }
+    assert sys.argv == [
+        "run_vllm_api_server.py",
+        "--max-model-len",
+        "4096",
+        "--disable-log-requests",
+        "--guided-decoding-backend=outlines",
+        "--port",
+        "7001",
+        "--model",
+        "mistralai/Mistral-7B-Instruct-v0.3",
+        "--seed",
+        "9472",
+    ]
+
+
+def test_set_vllm_sys_argv_honors_equals_style_overrides(
+    monkeypatch, run_vllm_api_server_module
+):
+    monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py"])
+
+    run_vllm_api_server_module.set_vllm_sys_argv(
+        argparse.Namespace(service_port=None),
+        [
+            "--max-model-len=4096",
+            "--max-log-len",
+            "64",
+        ],
+        {
+            "port": 8000,
+            "max_model_len": "8192",
+            "max-log-len": "32",
+        },
+    )
+
+    assert sys.argv == [
+        "run_vllm_api_server.py",
+        "--max-model-len=4096",
+        "--max-log-len",
+        "64",
+        "--port",
+        "8000",
+    ]
+
+
+def test_set_vllm_sys_argv_logs_multiline_bash_command(
+    monkeypatch, run_vllm_api_server_module
+):
+    monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py"])
+    mock_logger = MagicMock()
+    monkeypatch.setattr(run_vllm_api_server_module, "logger", mock_logger)
+
+    run_vllm_api_server_module.set_vllm_sys_argv(
+        argparse.Namespace(service_port=None),
+        [
+            "--disable-log-requests",
+            "--served-model-name",
+            "my model",
+            "--guided-decoding-backend=outlines backend",
+        ],
+        {
+            "port": 8000,
+        },
+    )
+
+    mock_logger.info.assert_called_once_with(
+        "vLLM command:\n"
+        "vllm serve \\\n"
+        "  --disable-log-requests \\\n"
+        "  --served-model-name 'my model' \\\n"
+        "  '--guided-decoding-backend=outlines backend' \\\n"
+        "  --port 8000"
+    )
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_port"),
+    [
+        (["run_vllm_api_server.py", "--port", "9001"], 9001),
+        (["run_vllm_api_server.py", "--port=9002"], 9002),
+        (["run_vllm_api_server.py"], 8000),
+    ],
+)
+def test_resolve_service_port_reads_port_from_sys_argv(
+    monkeypatch, run_vllm_api_server_module, argv, expected_port
+):
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("SERVICE_PORT", "8000")
+
+    assert run_vllm_api_server_module.resolve_service_port() == expected_port
+
+
+def test_main_passes_passthrough_port_to_trace_capture(
+    monkeypatch, run_vllm_api_server_module
+):
+    args = argparse.Namespace(
+        model="mistralai/Mistral-7B-Instruct-v0.3",
+        tt_device="n150",
+        device=None,
+        engine=None,
+        impl=None,
+        no_auth=False,
+        disable_trace_capture=False,
+        service_port=None,
+    )
+    model_spec = {
+        "model_id": "id_tt-transformers_Mistral-7B-Instruct-v0.3_n150",
+        "impl": {"impl_id": "tt-transformers"},
+        "device_model_spec": {"vllm_args": {"port": 8000}},
+    }
+
+    monkeypatch.setattr(
+        run_vllm_api_server_module, "parse_args", lambda: (args, ["--port", "9001"])
+    )
+    monkeypatch.setattr(
+        run_vllm_api_server_module,
+        "load_model_spec",
+        MagicMock(return_value=model_spec),
+    )
+    monkeypatch.setattr(run_vllm_api_server_module, "set_cache_paths", MagicMock())
+    monkeypatch.setattr(
+        run_vllm_api_server_module, "ensure_weights_available", MagicMock()
+    )
+    monkeypatch.setattr(run_vllm_api_server_module, "register_tt_models", MagicMock())
+    monkeypatch.setattr(
+        run_vllm_api_server_module, "set_metal_timeout_env_vars", MagicMock()
+    )
+    monkeypatch.setattr(run_vllm_api_server_module, "set_runtime_env_vars", MagicMock())
+    monkeypatch.setattr(run_vllm_api_server_module, "runtime_settings", MagicMock())
+    monkeypatch.setattr(run_vllm_api_server_module.runpy, "run_module", MagicMock())
+    monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py"])
+    start_trace_capture = MagicMock()
+    monkeypatch.setattr(
+        run_vllm_api_server_module, "start_trace_capture", start_trace_capture
+    )
+
+    run_vllm_api_server_module.main()
+
+    start_trace_capture.assert_called_once_with(
+        model_spec,
+        disable_trace_capture=False,
+        service_port=9001,
+    )

--- a/tt-media-server/utils/runner_utils.py
+++ b/tt-media-server/utils/runner_utils.py
@@ -10,6 +10,15 @@ from telemetry.telemetry_client import get_telemetry_client
 from utils.logger import TTLogger
 from utils.torch_utils import set_torch_thread_limits
 
+_BH_DEVICE_MESH_DESCRIPTORS = {
+    "p150": "p150_mesh_graph_descriptor.textproto",
+    "p150x4": "p150x4_mesh_graph_descriptor.textproto",
+    "p150x8": "p150x8_mesh_graph_descriptor.textproto",
+    "p300": "p300_mesh_graph_descriptor.textproto",
+    "p300x2": "p300_x2_mesh_graph_descriptor.textproto",
+    "p100": "p100_mesh_graph_descriptor.textproto",
+}
+
 
 def setup_runner_environment(
     device_id: str, cpu_threads: str = "2", num_torch_threads: int = 1
@@ -39,6 +48,11 @@ def setup_runner_environment(
     if settings.is_galaxy:
         _logger.info("setup_runner_environment: applying galaxy mesh config")
         _setup_galaxy_mesh_config(tt_metal_home)
+    elif (settings.device or "").lower() in _BH_DEVICE_MESH_DESCRIPTORS:
+        _logger.info(
+            f"setup_runner_environment: applying blackhole mesh config for device={settings.device!r}"
+        )
+        _setup_blackhole_mesh_config(tt_metal_home)
 
 
 def setup_cpu_threading_limits(cpu_threads: str, num_torch_threads: int = 1):
@@ -49,6 +63,16 @@ def setup_cpu_threading_limits(cpu_threads: str, num_torch_threads: int = 1):
     set_torch_thread_limits(num_threads=num_torch_threads)
     if settings.default_throttle_level:
         os.environ["TT_MM_THROTTLE_PERF"] = settings.default_throttle_level
+
+
+def _setup_blackhole_mesh_config(tt_metal_home: str):
+    """Configure mesh graph descriptors for Blackhole hardware"""
+    device = (settings.device or "").lower()
+    descriptor = _BH_DEVICE_MESH_DESCRIPTORS.get(device)
+    if descriptor:
+        os.environ["TT_MESH_GRAPH_DESC_PATH"] = (
+            f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/{descriptor}"
+        )
 
 
 def _setup_galaxy_mesh_config(tt_metal_home: str):

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -8,6 +8,7 @@ import logging
 import multiprocessing
 import os
 import runpy
+import shlex
 import sys
 from pathlib import Path
 from typing import Optional
@@ -31,12 +32,11 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def parse_args():
-    """Parse CLI arguments before any model loading.
+DEFAULT_VLLM_SERVER_PORT = "8000"
 
-    Also removes --model and --device from sys.argv so they don't get passed
-    to vLLM's argument parser (which doesn't recognize --device).
-    """
+
+def parse_args():
+    """Parse wrapper CLI args and return remaining vLLM passthrough args."""
     parser = argparse.ArgumentParser(description="TT vLLM API Server")
     parser.add_argument(
         "--model",
@@ -79,16 +79,12 @@ def parse_args():
         "--service-port",
         type=int,
         default=None,
-        help="Service port for trace capture (defaults to vllm_args port or 8000)",
+        help="Service port for vLLM server and trace capture client",
     )
     # Parse known args to allow vLLM args to pass through
-    args, remaining = parser.parse_known_args()
+    args, remaining_args = parser.parse_known_args()
 
-    # Remove --model and --device from sys.argv so vLLM doesn't see them
-    # Keep sys.argv[0] (script name) and add remaining args
-    sys.argv = [sys.argv[0]] + remaining
-
-    return args
+    return args, remaining_args
 
 
 def normalize_device_type(device_arg: str) -> str:
@@ -574,7 +570,7 @@ def start_trace_capture(
         return
 
     if service_port is None:
-        service_port = int(os.getenv("SERVICE_PORT", "8000"))
+        service_port = int(os.getenv("SERVICE_PORT", DEFAULT_VLLM_SERVER_PORT))
     supported_modalities = model_spec_json.get("supported_modalities", ["text"])
 
     # Get max_context from device_model_spec for trace calculation
@@ -608,9 +604,124 @@ def start_trace_capture(
     )
 
 
+def _normalize_vllm_arg_name(arg_name: str) -> str:
+    return arg_name.lstrip("-").split("=", 1)[0].replace("-", "_")
+
+
+def _append_vllm_arg(argv: list[str], arg_name: str, value) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool):
+        if value:
+            argv.append(arg_name)
+        return
+    argv.extend([arg_name, str(value)])
+
+
+def _extract_cli_arg_value(argv: list[str], arg_name: str) -> Optional[str]:
+    for index, token in enumerate(argv):
+        if token == arg_name:
+            if index + 1 < len(argv):
+                return argv[index + 1]
+            return None
+        if token.startswith(f"{arg_name}="):
+            return token.split("=", 1)[1]
+    return None
+
+
+def resolve_service_port() -> int:
+    port_value = _extract_cli_arg_value(sys.argv[1:], "--port")
+    if port_value is not None:
+        return int(port_value)
+    return int(os.getenv("SERVICE_PORT", DEFAULT_VLLM_SERVER_PORT))
+
+
+def format_vllm_serve_command(argv) -> str:
+    """Render the normalized argv as a multi-line bash command."""
+    command_lines = ["vllm serve"]
+    index = 1
+    while index < len(argv):
+        token = argv[index]
+        rendered_tokens = [shlex.quote(token)]
+        has_separate_value = (
+            token.startswith("--")
+            and "=" not in token
+            and index + 1 < len(argv)
+            and not argv[index + 1].startswith("--")
+        )
+        if has_separate_value:
+            rendered_tokens.append(shlex.quote(argv[index + 1]))
+            index += 1
+
+        command_lines.append(" ".join(rendered_tokens))
+        index += 1
+
+    return " \\\n  ".join(command_lines)
+
+
+def set_vllm_sys_argv(args, remaining_sys_argv, default_vllm_args):
+    # runpy uses sys.argv, rebuild it with the merged vLLM args.
+    vllm_argv = [sys.argv[0]]
+    remaining_default_vllm_args = dict(default_vllm_args)
+    default_arg_name_by_normalized_name = {
+        _normalize_vllm_arg_name(arg_name): arg_name
+        for arg_name in remaining_default_vllm_args
+    }
+    input_vllm_argv = list(remaining_sys_argv)
+    if args.service_port is not None:
+        already_set_port = _extract_cli_arg_value(input_vllm_argv, "--port")
+        if already_set_port is not None:
+            logger.warning(
+                f"vLLM server --port={already_set_port} already set direcly, ignoring --service-port={args.service_port}"
+            )
+        else:
+            # Remap wrapper --service-port to vLLM's --port.
+            input_vllm_argv.extend(["--port", str(args.service_port)])
+
+    index = 0
+    while index < len(input_vllm_argv):
+        token = input_vllm_argv[index]
+        if not token.startswith("--"):
+            vllm_argv.append(token)
+            index += 1
+            continue
+
+        cli_arg_name, separator, inline_value = token.partition("=")
+        overridden_default_arg_name = default_arg_name_by_normalized_name.pop(
+            _normalize_vllm_arg_name(cli_arg_name), None
+        )
+        if overridden_default_arg_name is not None:
+            remaining_default_vllm_args.pop(overridden_default_arg_name, None)
+
+        if separator:
+            vllm_argv.append(f"{cli_arg_name}={inline_value}")
+            index += 1
+            continue
+
+        vllm_argv.append(cli_arg_name)
+        next_token_is_value = index + 1 < len(input_vllm_argv) and not input_vllm_argv[
+            index + 1
+        ].startswith("--")
+        if next_token_is_value:
+            value = input_vllm_argv[index + 1]
+            vllm_argv.append(value)
+            index += 2
+            continue
+
+        index += 1
+
+    for key, value in remaining_default_vllm_args.items():
+        cli_arg_name = f"--{key}"
+        _append_vllm_arg(vllm_argv, cli_arg_name, value)
+
+    # finally set sys.argv to the vllm server args
+    sys.argv = vllm_argv
+    logger.info(f"vLLM command:\n{format_vllm_serve_command(sys.argv)}")
+
+
 def main():
     # Step 1: Parse --model argument (if provided)
-    args = parse_args()
+    args, remaining_sys_argv = parse_args()
     args.device = args.tt_device or args.device
     args.engine = normalize_engine_type(args.engine)
 
@@ -643,28 +754,19 @@ def main():
     impl_id = model_spec.get("impl", {}).get("impl_id")
     register_tt_models(impl_id)
 
-    # Step 4: Set runtime environment variables and run setup
+    # Step 4: Set runtime environment variables and vLLM server args
     set_metal_timeout_env_vars()
     set_runtime_env_vars(model_spec)
     runtime_settings(model_spec, no_auth=args.no_auth)
+    default_vllm_args = model_spec["device_model_spec"]["vllm_args"]
+    set_vllm_sys_argv(args, remaining_sys_argv, default_vllm_args)
+
+    # Step 5: Start trace capture if needed
     start_trace_capture(
         model_spec,
         disable_trace_capture=args.disable_trace_capture,
-        service_port=args.service_port,
+        service_port=resolve_service_port(),
     )
-
-    # Step 5: Add vLLM CLI arguments
-    logger.info(
-        f"vllm_args: {json.dumps(model_spec['device_model_spec']['vllm_args'], indent=4)}"
-    )
-    for key, value in model_spec["device_model_spec"]["vllm_args"].items():
-        if value is not None:
-            # Handle boolean flags
-            if isinstance(value, bool):
-                if value:  # Only add the flag if True
-                    sys.argv.append("--" + key)
-            else:
-                sys.argv.extend(["--" + key, str(value)])
 
     # Step 6: Launch vLLM server
     # runpy uses the same process and environment so the registered models are available

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1300,6 +1300,7 @@ llm_templates = [
         env_vars={
             "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
         },
+        has_builtin_warmup=True,
     ),
     ModelSpecTemplate(
         weights=["mistralai/Mistral-7B-Instruct-v0.3"],
@@ -1684,6 +1685,7 @@ llm_templates = [
             ),
         ],
         status=ModelStatusTypes.FUNCTIONAL,
+        has_builtin_warmup=True,
     ),
     ModelSpecTemplate(
         weights=[
@@ -1942,6 +1944,7 @@ llm_templates = [
             ),
         ],
         status=ModelStatusTypes.FUNCTIONAL,
+        has_builtin_warmup=True,
     ),
     ModelSpecTemplate(
         weights=["meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-8B-Instruct"],

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -2719,18 +2719,27 @@ audio_tts_templates = [
                 max_concurrency=1,
                 max_context=64 * 1024,
                 default_impl=True,
+                env_vars={
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.P300,
                 max_concurrency=2,
                 max_context=64 * 1024,
                 default_impl=True,
+                env_vars={
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto",
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.P300X2,
                 max_concurrency=4,
                 max_context=64 * 1024,
                 default_impl=True,
+                env_vars={
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto",
+                },
             ),
         ],
         status=ModelStatusTypes.COMPLETE,
@@ -2773,18 +2782,27 @@ audio_tts_templates = [
                 max_concurrency=1,
                 max_context=64 * 1024,
                 default_impl=True,
+                env_vars={
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.P300,
                 max_concurrency=2,
                 max_context=64 * 1024,
                 default_impl=True,
+                env_vars={
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto",
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.P300X2,
                 max_concurrency=4,
                 max_context=64 * 1024,
                 default_impl=True,
+                env_vars={
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto",
+                },
             ),
         ],
         status=ModelStatusTypes.EXPERIMENTAL,

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -273,13 +273,12 @@ def generate_docker_run_command(
     if model_spec.inference_engine == InferenceEngine.VLLM.value:
         docker_command.extend(["--model", model_spec.hf_model_repo])
         docker_command.extend(["--tt-device", runtime_config.device])
-
-    if runtime_config.no_auth:
-        docker_command.append("--no-auth")
-    if runtime_config.disable_trace_capture:
-        docker_command.append("--disable-trace-capture")
-    if runtime_config.service_port and str(runtime_config.service_port) != "8000":
-        docker_command.extend(["--service-port", str(runtime_config.service_port)])
+        if runtime_config.no_auth:
+            docker_command.append("--no-auth")
+        if runtime_config.disable_trace_capture:
+            docker_command.append("--disable-trace-capture")
+        if runtime_config.service_port and str(runtime_config.service_port) != "8000":
+            docker_command.extend(["--service-port", str(runtime_config.service_port)])
     if runtime_config.interactive:
         docker_command.extend(["bash", "-c", "sleep infinity"])
 


### PR DESCRIPTION
## Summary
- Adds `TT_MESH_GRAPH_DESC_PATH` env var to all Blackhole `DeviceModelSpec` entries for the whisper and speecht5_tts BH model spec templates
- Fixes a runtime fatal error introduced in tt-metal `e4a2dea` that requires a mesh graph descriptor path when a CUSTOM cluster type is detected (P300 with 1 chip present)
- Applies to P150, P300, and P300X2 device types for both models