### PR TITLE
Add TT_MESH_GRAPH_DESC_PATH to Blackhole device specs for whisper and speecht5

### DIFF
--- a/tt-media-server/tests/test_worker_utils.py
+++ b/tt-media-server/tests/test_worker_utils.py
@@ -44,6 +44,7 @@ sys.modules["tt_model_runners.runner_fabric"] = Mock()
 # Now import the modules under test
 from device_workers.worker_utils import initialize_device_worker
 from utils.runner_utils import (
+    _setup_blackhole_mesh_config,
     _setup_galaxy_mesh_config,
     setup_cpu_threading_limits,
     setup_runner_environment,
@@ -423,6 +424,93 @@ def reset_mocks():
     mock_settings.enable_telemetry = False
     mock_settings.is_galaxy = False
     mock_settings.device_mesh_shape = (1, 1)
+
+
+class TestSetupBlackholeMeshConfig:
+    """Test cases for _setup_blackhole_mesh_config function"""
+
+    def test_sets_p150_mesh_descriptor(self):
+        """Test mesh descriptor is set for p150 device"""
+        mock_settings_bh = Mock()
+        mock_settings_bh.device = "p150"
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("utils.runner_utils.settings", mock_settings_bh):
+                _setup_blackhole_mesh_config("/opt/tt-metal")
+
+                expected_path = (
+                    "/opt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/"
+                    "p150_mesh_graph_descriptor.textproto"
+                )
+                assert os.environ["TT_MESH_GRAPH_DESC_PATH"] == expected_path
+
+    def test_sets_p300_mesh_descriptor(self):
+        """Test mesh descriptor is set for p300 device"""
+        mock_settings_bh = Mock()
+        mock_settings_bh.device = "p300"
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("utils.runner_utils.settings", mock_settings_bh):
+                _setup_blackhole_mesh_config("/opt/tt-metal")
+
+                expected_path = (
+                    "/opt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/"
+                    "p300_mesh_graph_descriptor.textproto"
+                )
+                assert os.environ["TT_MESH_GRAPH_DESC_PATH"] == expected_path
+
+    def test_skips_descriptor_for_unknown_device(self):
+        """Test that TT_MESH_GRAPH_DESC_PATH is not set for unknown BH device"""
+        mock_settings_bh = Mock()
+        mock_settings_bh.device = "unknown_device"
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("utils.runner_utils.settings", mock_settings_bh):
+                _setup_blackhole_mesh_config("/opt/tt-metal")
+
+                assert "TT_MESH_GRAPH_DESC_PATH" not in os.environ
+
+
+class TestSetupRunnerEnvironmentBlackhole:
+    """Test BH device branch in setup_runner_environment"""
+
+    def test_calls_blackhole_setup_for_bh_device(self):
+        """Test that _setup_blackhole_mesh_config is called for a BH device"""
+        with patch.dict(os.environ, {"TT_METAL_HOME": "/opt/tt-metal"}, clear=True):
+            with patch("utils.runner_utils.set_torch_thread_limits"):
+                with patch("utils.runner_utils.get_telemetry_client"):
+                    with patch(
+                        "utils.runner_utils._setup_blackhole_mesh_config"
+                    ) as mock_bh:
+                        mock_settings_bh = Mock()
+                        mock_settings_bh.enable_telemetry = False
+                        mock_settings_bh.is_galaxy = False
+                        mock_settings_bh.device = "p150"
+                        mock_settings_bh.default_throttle_level = None
+
+                        with patch("utils.runner_utils.settings", mock_settings_bh):
+                            setup_runner_environment("0")
+
+                            mock_bh.assert_called_once_with("/opt/tt-metal")
+
+    def test_does_not_call_blackhole_setup_for_non_bh_device(self):
+        """Test that _setup_blackhole_mesh_config is not called for non-BH device"""
+        with patch.dict(os.environ, {"TT_METAL_HOME": "/opt/tt-metal"}, clear=True):
+            with patch("utils.runner_utils.set_torch_thread_limits"):
+                with patch("utils.runner_utils.get_telemetry_client"):
+                    with patch(
+                        "utils.runner_utils._setup_blackhole_mesh_config"
+                    ) as mock_bh:
+                        mock_settings_non_bh = Mock()
+                        mock_settings_non_bh.enable_telemetry = False
+                        mock_settings_non_bh.is_galaxy = False
+                        mock_settings_non_bh.device = "n300"
+                        mock_settings_non_bh.default_throttle_level = None
+
+                        with patch("utils.runner_utils.settings", mock_settings_non_bh):
+                            setup_runner_environment("0")
+
+                            mock_bh.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tt-media-server/utils/runner_utils.py
+++ b/tt-media-server/utils/runner_utils.py
@@ -10,6 +10,15 @@ from telemetry.telemetry_client import get_telemetry_client
 from utils.logger import TTLogger
 from utils.torch_utils import set_torch_thread_limits
 
+_BH_DEVICE_MESH_DESCRIPTORS = {
+    "p150": "p150_mesh_graph_descriptor.textproto",
+    "p150x4": "p150x4_mesh_graph_descriptor.textproto",
+    "p150x8": "p150x8_mesh_graph_descriptor.textproto",
+    "p300": "p300_mesh_graph_descriptor.textproto",
+    "p300x2": "p300_x2_mesh_graph_descriptor.textproto",
+    "p100": "p100_mesh_graph_descriptor.textproto",
+}
+
 
 def setup_runner_environment(
     device_id: str, cpu_threads: str = "2", num_torch_threads: int = 1
@@ -39,6 +48,11 @@ def setup_runner_environment(
     if settings.is_galaxy:
         _logger.info("setup_runner_environment: applying galaxy mesh config")
         _setup_galaxy_mesh_config(tt_metal_home)
+    elif (settings.device or "").lower() in _BH_DEVICE_MESH_DESCRIPTORS:
+        _logger.info(
+            f"setup_runner_environment: applying blackhole mesh config for device={settings.device!r}"
+        )
+        _setup_blackhole_mesh_config(tt_metal_home)
 
 
 def setup_cpu_threading_limits(cpu_threads: str, num_torch_threads: int = 1):
@@ -49,6 +63,16 @@ def setup_cpu_threading_limits(cpu_threads: str, num_torch_threads: int = 1):
     set_torch_thread_limits(num_threads=num_torch_threads)
     if settings.default_throttle_level:
         os.environ["TT_MM_THROTTLE_PERF"] = settings.default_throttle_level
+
+
+def _setup_blackhole_mesh_config(tt_metal_home: str):
+    """Configure mesh graph descriptors for Blackhole hardware"""
+    device = (settings.device or "").lower()
+    descriptor = _BH_DEVICE_MESH_DESCRIPTORS.get(device)
+    if descriptor:
+        os.environ["TT_MESH_GRAPH_DESC_PATH"] = (
+            f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/{descriptor}"
+        )
 
 
 def _setup_galaxy_mesh_config(tt_metal_home: str):

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -2716,18 +2716,27 @@ audio_tts_templates = [
                 max_concurrency=1,
                 max_context=64 * 1024,
                 default_impl=True,
+                env_vars={
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.P300,
                 max_concurrency=2,
                 max_context=64 * 1024,
                 default_impl=True,
+                env_vars={
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto",
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.P300X2,
                 max_concurrency=4,
                 max_context=64 * 1024,
                 default_impl=True,
+                env_vars={
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto",
+                },
             ),
         ],
         status=ModelStatusTypes.COMPLETE,
@@ -2770,18 +2779,27 @@ audio_tts_templates = [
                 max_concurrency=1,
                 max_context=64 * 1024,
                 default_impl=True,
+                env_vars={
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.P300,
                 max_concurrency=2,
                 max_context=64 * 1024,
                 default_impl=True,
+                env_vars={
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto",
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.P300X2,
                 max_concurrency=4,
                 max_context=64 * 1024,
                 default_impl=True,
+                env_vars={
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto",
+                },
             ),
         ],
         status=ModelStatusTypes.EXPERIMENTAL,

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -273,13 +273,12 @@ def generate_docker_run_command(
     if model_spec.inference_engine == InferenceEngine.VLLM.value:
         docker_command.extend(["--model", model_spec.hf_model_repo])
         docker_command.extend(["--tt-device", runtime_config.device])
-
-    if runtime_config.no_auth:
-        docker_command.append("--no-auth")
-    if runtime_config.disable_trace_capture:
-        docker_command.append("--disable-trace-capture")
-    if runtime_config.service_port and str(runtime_config.service_port) != "8000":
-        docker_command.extend(["--service-port", str(runtime_config.service_port)])
+        if runtime_config.no_auth:
+            docker_command.append("--no-auth")
+        if runtime_config.disable_trace_capture:
+            docker_command.append("--disable-trace-capture")
+        if runtime_config.service_port and str(runtime_config.service_port) != "8000":
+            docker_command.extend(["--service-port", str(runtime_config.service_port)])
     if runtime_config.interactive:
         docker_command.extend(["bash", "-c", "sleep infinity"])
 


### PR DESCRIPTION
## Summary

### Device Spec Fix
- Adds `TT_MESH_GRAPH_DESC_PATH` env var to all Blackhole `DeviceModelSpec` entries for the whisper and speecht5_tts BH model spec templates
- Fixes a runtime fatal error introduced in tt-metal `e4a2dea` that requires a mesh graph descriptor path when a CUSTOM cluster type is detected (P300 with 1 chip present)
- Applies to P150, P300, and P300X2 device types for both models

### Runner Utils Fix
- Adds `_setup_blackhole_mesh_config()` in `runner_utils.py` to set `TT_MESH_GRAPH_DESC_PATH` for Blackhole devices (P150, P300, etc.) — previously only Galaxy (WH) hardware was handled

### Docker Fix
- Fixes media server docker command receiving vLLM-only flags

### Tests
- Adds unit tests for Blackhole mesh config validation in `runner_utils`

## Test plan
- [x] On-dispatch CI run