### PR TITLE
Restore audio eval venv setup helpers for whisper and speecht5

### DIFF
--- a/tests/workflows/test_workflow_venvs.py
+++ b/tests/workflows/test_workflow_venvs.py
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 
-from workflows.workflow_venvs import ensure_librispeech_yaml_tasks
+from workflows.workflow_venvs import ensure_librispeech_yaml_tasks, ensure_whisper_tt_model
 
 
 class TestEnsureLibrispeechYamlTasks:
@@ -43,3 +43,34 @@ class TestEnsureLibrispeechYamlTasks:
             / "librispeech_test_other.yaml"
         )
         assert yaml_file.exists()
+
+
+class TestEnsureWhisperTtModel:
+    def test_copies_when_missing(self, tmp_path):
+        """whisper_tt.py is copied to models/simple/ when absent."""
+        src_dir = tmp_path / "lmms_eval" / "models"
+        src_dir.mkdir(parents=True)
+        src = src_dir / "whisper_tt.py"
+        src.write_text("# whisper_tt model")
+        ensure_whisper_tt_model(tmp_path)
+        dst = src_dir / "simple" / "whisper_tt.py"
+        assert dst.exists()
+        assert dst.read_text() == "# whisper_tt model"
+
+    def test_does_not_overwrite_existing(self, tmp_path):
+        """Existing file in simple/ is left unchanged (idempotent)."""
+        src_dir = tmp_path / "lmms_eval" / "models"
+        src_dir.mkdir(parents=True)
+        (src_dir / "whisper_tt.py").write_text("source content")
+        dst_dir = src_dir / "simple"
+        dst_dir.mkdir(parents=True)
+        dst = dst_dir / "whisper_tt.py"
+        dst.write_text("existing content")
+        ensure_whisper_tt_model(tmp_path)
+        assert dst.read_text() == "existing content"
+
+    def test_skips_when_source_missing(self, tmp_path):
+        """No error when source whisper_tt.py doesn't exist."""
+        ensure_whisper_tt_model(tmp_path)
+        dst = tmp_path / "lmms_eval" / "models" / "simple" / "whisper_tt.py"
+        assert not dst.exists()

--- a/tests/workflows/test_workflow_venvs.py
+++ b/tests/workflows/test_workflow_venvs.py
@@ -3,8 +3,11 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 
+from unittest.mock import patch
+
 from workflows.workflow_venvs import (
     ensure_librispeech_yaml_tasks,
+    ensure_whisper_normalizer_json,
     ensure_whisper_tt_model,
 )
 
@@ -46,6 +49,46 @@ class TestEnsureLibrispeechYamlTasks:
             / "librispeech_test_other.yaml"
         )
         assert yaml_file.exists()
+
+
+class TestEnsureWhisperNormalizerJson:
+    def test_downloads_when_missing(self, tmp_path):
+        """english.json is downloaded when absent."""
+        fake_json = '{"colour": "color"}'
+
+        def fake_urlretrieve(url, dest):
+            dest.write_text(fake_json) if hasattr(dest, "write_text") else open(
+                dest, "w"
+            ).write(fake_json)
+
+        with patch(
+            "urllib.request.urlretrieve", side_effect=fake_urlretrieve
+        ):
+            ensure_whisper_normalizer_json(tmp_path)
+        json_file = (
+            tmp_path
+            / "lmms_eval"
+            / "tasks"
+            / "librispeech"
+            / "whisper_normalizer"
+            / "english.json"
+        )
+        assert json_file.exists()
+
+    def test_does_not_overwrite_existing(self, tmp_path):
+        """Existing english.json is left unchanged (idempotent)."""
+        json_dir = (
+            tmp_path
+            / "lmms_eval"
+            / "tasks"
+            / "librispeech"
+            / "whisper_normalizer"
+        )
+        json_dir.mkdir(parents=True)
+        json_file = json_dir / "english.json"
+        json_file.write_text("existing content")
+        ensure_whisper_normalizer_json(tmp_path)
+        assert json_file.read_text() == "existing content"
 
 
 class TestEnsureWhisperTtModel:

--- a/tests/workflows/test_workflow_venvs.py
+++ b/tests/workflows/test_workflow_venvs.py
@@ -3,7 +3,10 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 
-from workflows.workflow_venvs import ensure_librispeech_yaml_tasks, ensure_whisper_tt_model
+from workflows.workflow_venvs import (
+    ensure_librispeech_yaml_tasks,
+    ensure_whisper_tt_model,
+)
 
 
 class TestEnsureLibrispeechYamlTasks:

--- a/tests/workflows/test_workflow_venvs.py
+++ b/tests/workflows/test_workflow_venvs.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+from pathlib import Path
+
+from workflows.workflow_venvs import ensure_librispeech_yaml_tasks
+
+
+class TestEnsureLibrispeechYamlTasks:
+    def test_creates_yaml_when_missing(self, tmp_path):
+        """YAML file is written to the correct location when absent."""
+        ensure_librispeech_yaml_tasks(tmp_path)
+        yaml_file = (
+            tmp_path / "lmms_eval" / "tasks" / "librispeech" / "librispeech_test_other.yaml"
+        )
+        assert yaml_file.exists(), f"Expected YAML file at {yaml_file}"
+        content = yaml_file.read_text()
+        assert 'task: "librispeech_test_other"' in content
+        assert "librispeech_wer" in content
+
+    def test_does_not_overwrite_existing(self, tmp_path):
+        """Existing YAML files are left unchanged (idempotent)."""
+        yaml_dir = tmp_path / "lmms_eval" / "tasks" / "librispeech"
+        yaml_dir.mkdir(parents=True)
+        yaml_file = yaml_dir / "librispeech_test_other.yaml"
+        yaml_file.write_text("existing content")
+        ensure_librispeech_yaml_tasks(tmp_path)
+        assert yaml_file.read_text() == "existing content"
+
+    def test_creates_intermediate_directories(self, tmp_path):
+        """Parent directories are created if they don't exist."""
+        site_packages = tmp_path / "lib" / "python3.10" / "site-packages"
+        ensure_librispeech_yaml_tasks(site_packages)
+        yaml_file = (
+            site_packages / "lmms_eval" / "tasks" / "librispeech" / "librispeech_test_other.yaml"
+        )
+        assert yaml_file.exists()

--- a/tests/workflows/test_workflow_venvs.py
+++ b/tests/workflows/test_workflow_venvs.py
@@ -2,7 +2,6 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-from pathlib import Path
 
 from workflows.workflow_venvs import ensure_librispeech_yaml_tasks
 

--- a/tests/workflows/test_workflow_venvs.py
+++ b/tests/workflows/test_workflow_venvs.py
@@ -12,7 +12,11 @@ class TestEnsureLibrispeechYamlTasks:
         """YAML file is written to the correct location when absent."""
         ensure_librispeech_yaml_tasks(tmp_path)
         yaml_file = (
-            tmp_path / "lmms_eval" / "tasks" / "librispeech" / "librispeech_test_other.yaml"
+            tmp_path
+            / "lmms_eval"
+            / "tasks"
+            / "librispeech"
+            / "librispeech_test_other.yaml"
         )
         assert yaml_file.exists(), f"Expected YAML file at {yaml_file}"
         content = yaml_file.read_text()
@@ -33,6 +37,10 @@ class TestEnsureLibrispeechYamlTasks:
         site_packages = tmp_path / "lib" / "python3.10" / "site-packages"
         ensure_librispeech_yaml_tasks(site_packages)
         yaml_file = (
-            site_packages / "lmms_eval" / "tasks" / "librispeech" / "librispeech_test_other.yaml"
+            site_packages
+            / "lmms_eval"
+            / "tasks"
+            / "librispeech"
+            / "librispeech_test_other.yaml"
         )
         assert yaml_file.exists()

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -340,6 +340,39 @@ def ensure_librispeech_yaml_tasks(site_packages_path: Path) -> None:
         )
 
 
+def ensure_whisper_normalizer_json(site_packages_path: Path) -> None:
+    """Ensure english.json is present in the whisper_normalizer directory.
+
+    The TT fork of lmms-eval includes whisper_normalizer/english.json in its
+    source tree but pip does not install it as package data. This function
+    downloads the file from the fork if it is missing.
+    """
+    json_dir = (
+        Path(site_packages_path)
+        / "lmms_eval"
+        / "tasks"
+        / "librispeech"
+        / "whisper_normalizer"
+    )
+    json_file = json_dir / "english.json"
+    if json_file.exists():
+        logger.debug(f"english.json already exists at {json_file}, skipping")
+        return
+    json_dir.mkdir(parents=True, exist_ok=True)
+    url = (
+        "https://raw.githubusercontent.com/bgoelTT/lmms-eval"
+        "/ben/samt/whisper-tt"
+        "/lmms_eval/tasks/librispeech/whisper_normalizer/english.json"
+    )
+    import urllib.request
+
+    try:
+        urllib.request.urlretrieve(url, json_file)
+        logger.info(f"Downloaded english.json to {json_file}")
+    except Exception as e:
+        logger.warning(f"Failed to download english.json: {e}")
+
+
 def ensure_whisper_tt_model(site_packages_path: Path) -> None:
     """Ensure whisper_tt model module is in the lmms-eval simple models directory.
 
@@ -384,6 +417,7 @@ def setup_evals_audio(
     if setup_succeeded:
         site_packages = venv_config.venv_path / "lib" / "python3.10" / "site-packages"
         ensure_librispeech_yaml_tasks(site_packages)
+        ensure_whisper_normalizer_json(site_packages)
         ensure_whisper_tt_model(site_packages)
     return setup_succeeded
 

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -335,7 +335,9 @@ def ensure_librispeech_yaml_tasks(site_packages_path: Path) -> None:
         yaml_file.write_text(LIBRISPEECH_TEST_OTHER_YAML)
         logger.info(f"Wrote librispeech_test_other.yaml to {yaml_file}")
     else:
-        logger.debug(f"librispeech_test_other.yaml already exists at {yaml_file}, skipping")
+        logger.debug(
+            f"librispeech_test_other.yaml already exists at {yaml_file}, skipping"
+        )
 
 
 def setup_evals_audio(

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -340,6 +340,27 @@ def ensure_librispeech_yaml_tasks(site_packages_path: Path) -> None:
         )
 
 
+def ensure_whisper_tt_model(site_packages_path: Path) -> None:
+    """Ensure whisper_tt model module is in the lmms-eval simple models directory.
+
+    The TT fork of lmms-eval places whisper_tt.py at lmms_eval/models/whisper_tt.py,
+    but lmms-eval's get_model() expects simple models under lmms_eval/models/simple/.
+    This function copies the file to the correct location if absent.
+    """
+    src = Path(site_packages_path) / "lmms_eval" / "models" / "whisper_tt.py"
+    dst_dir = Path(site_packages_path) / "lmms_eval" / "models" / "simple"
+    dst = dst_dir / "whisper_tt.py"
+    if dst.exists():
+        logger.debug(f"whisper_tt.py already exists at {dst}, skipping")
+        return
+    if not src.exists():
+        logger.warning(f"whisper_tt.py source not found at {src}, cannot copy")
+        return
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+    logger.info(f"Copied whisper_tt.py to {dst}")
+
+
 def setup_evals_audio(
     venv_config: VenvConfig,
     model_spec: "ModelSpec",  # noqa: F821
@@ -363,6 +384,7 @@ def setup_evals_audio(
     if setup_succeeded:
         site_packages = venv_config.venv_path / "lib" / "python3.10" / "site-packages"
         ensure_librispeech_yaml_tasks(site_packages)
+        ensure_whisper_tt_model(site_packages)
     return setup_succeeded
 
 

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -288,6 +288,56 @@ def setup_evals_vision(
     return setup_succeeded
 
 
+LIBRISPEECH_TEST_OTHER_YAML = """\
+dataset_path: lmms-lab/librispeech
+dataset_kwargs:
+  token: True
+task: "librispeech_test_other"
+test_split: librispeech_test_other
+dataset_name: librispeech_test_other
+output_type: generate_until
+doc_to_visual: !function utils.librispeech_doc_to_audio
+doc_to_text: !function utils.librispeech_doc_to_text
+doc_to_target: "gt"
+generation_kwargs:
+  max_new_tokens: 256
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.librispeech_process_result
+metric_list:
+  - metric: wer
+    aggregation: !function utils.librispeech_wer
+    higher_is_better: false
+metadata:
+  - version: 0.0
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: ""
+  qwen2_audio:
+    pre_prompt: ""
+    post_prompt: " <|en|>"
+"""
+
+
+def ensure_librispeech_yaml_tasks(site_packages_path: Path) -> None:
+    """Ensure librispeech task YAML files are present in the lmms-eval installation.
+
+    The TT fork of lmms-eval includes librispeech task utils but the YAML task
+    definition files are not installed by pip. This function writes them if absent.
+    """
+    yaml_dir = Path(site_packages_path) / "lmms_eval" / "tasks" / "librispeech"
+    yaml_dir.mkdir(parents=True, exist_ok=True)
+    yaml_file = yaml_dir / "librispeech_test_other.yaml"
+    if not yaml_file.exists():
+        yaml_file.write_text(LIBRISPEECH_TEST_OTHER_YAML)
+        logger.info(f"Wrote librispeech_test_other.yaml to {yaml_file}")
+    else:
+        logger.debug(f"librispeech_test_other.yaml already exists at {yaml_file}, skipping")
+
+
 def setup_evals_audio(
     venv_config: VenvConfig,
     model_spec: "ModelSpec",  # noqa: F821
@@ -308,6 +358,9 @@ def setup_evals_audio(
         )
         == 0
     )
+    if setup_succeeded:
+        site_packages = venv_config.venv_path / "lib" / "python3.10" / "site-packages"
+        ensure_librispeech_yaml_tasks(site_packages)
     return setup_succeeded
 
 


### PR DESCRIPTION
## Summary

### Eval Infrastructure (closes #2545)
- Restores `ensure_librispeech_yaml_tasks` in `workflow_venvs.py` to inject the missing librispeech task YAML after audio eval venv setup
- Restores `ensure_whisper_tt_model` in `workflow_venvs.py` to copy `whisper_tt.py` from `lmms_eval/models/` into `lmms_eval/models/simple/` where `get_model()` expects it — fixes `No module named 'lmms_eval.models.simple.whisper_tt'` in CI
- Adds `ensure_whisper_normalizer_json` in `workflow_venvs.py` to fix missing `english.json` after pip install of `whisper-normalizer`
- Restores and extends corresponding unit tests for all three functions in `tests/workflows/test_workflow_venvs.py`

## Test plan
- [ ] On-dispatch CI run