### PR TITLE
Spec test missing configs and Flux spec tests fixes

### DIFF
--- a/tests/server_tests/server_tests_config.json
+++ b/tests/server_tests/server_tests_config.json
@@ -99,6 +99,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "stable-diffusion-xl-base-1.0"
                 }
             },
             {
@@ -275,6 +278,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "stable-diffusion-xl-base-1.0"
                 }
             }
         ]
@@ -379,6 +385,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "stable-diffusion-xl-base-1.0"
                 }
             },
             {
@@ -555,6 +564,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "stable-diffusion-xl-base-1.0"
                 }
             },
             {
@@ -2012,6 +2024,191 @@
     },
     {
         "weights": [
+            "resnet-50"
+        ],
+        "device": "n150",
+        "test_cases": [
+            {
+                "name": "DeviceLivenessTest",
+                "module": "tests.server_tests.test_cases.device_liveness_test",
+                "enabled": true,
+                "description": "Test for device liveness checks",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 120,
+                    "retry_delay": 10,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1
+                }
+            },
+            {
+                "name": "LoggerForkSafetyTest",
+                "module": "tests.server_tests.test_cases.logger_fork_safety_test",
+                "enabled": true,
+                "description": "Test for logging fork safety to prevent deadlocks in forked processes",
+                "test_config": {
+                    "test_timeout": 60,
+                    "retry_attempts": 0,
+                    "retry_delay": 0,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                }
+            }
+        ]
+    },
+    {
+        "weights": [
+            "vovnet"
+        ],
+        "device": "n150",
+        "test_cases": [
+            {
+                "name": "DeviceLivenessTest",
+                "module": "tests.server_tests.test_cases.device_liveness_test",
+                "enabled": true,
+                "description": "Test for device liveness checks",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 120,
+                    "retry_delay": 10,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1
+                }
+            },
+            {
+                "name": "LoggerForkSafetyTest",
+                "module": "tests.server_tests.test_cases.logger_fork_safety_test",
+                "enabled": true,
+                "description": "Test for logging fork safety to prevent deadlocks in forked processes",
+                "test_config": {
+                    "test_timeout": 60,
+                    "retry_attempts": 0,
+                    "retry_delay": 0,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                }
+            }
+        ]
+    },
+    {
+        "weights": [
+            "efficientnet"
+        ],
+        "device": "n150",
+        "test_cases": [
+            {
+                "name": "DeviceLivenessTest",
+                "module": "tests.server_tests.test_cases.device_liveness_test",
+                "enabled": true,
+                "description": "Test for device liveness checks",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 120,
+                    "retry_delay": 10,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1
+                }
+            },
+            {
+                "name": "LoggerForkSafetyTest",
+                "module": "tests.server_tests.test_cases.logger_fork_safety_test",
+                "enabled": true,
+                "description": "Test for logging fork safety to prevent deadlocks in forked processes",
+                "test_config": {
+                    "test_timeout": 60,
+                    "retry_attempts": 0,
+                    "retry_delay": 0,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                }
+            }
+        ]
+    },
+    {
+        "weights": [
+            "segformer"
+        ],
+        "device": "n150",
+        "test_cases": [
+            {
+                "name": "DeviceLivenessTest",
+                "module": "tests.server_tests.test_cases.device_liveness_test",
+                "enabled": true,
+                "description": "Test for device liveness checks",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 120,
+                    "retry_delay": 10,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1
+                }
+            },
+            {
+                "name": "LoggerForkSafetyTest",
+                "module": "tests.server_tests.test_cases.logger_fork_safety_test",
+                "enabled": true,
+                "description": "Test for logging fork safety to prevent deadlocks in forked processes",
+                "test_config": {
+                    "test_timeout": 60,
+                    "retry_attempts": 0,
+                    "retry_delay": 0,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                }
+            }
+        ]
+    },
+    {
+        "weights": [
+            "vit"
+        ],
+        "device": "n150",
+        "test_cases": [
+            {
+                "name": "DeviceLivenessTest",
+                "module": "tests.server_tests.test_cases.device_liveness_test",
+                "enabled": true,
+                "description": "Test for device liveness checks",
+                "test_config": {
+                    "test_timeout": 3600,
+                    "retry_attempts": 120,
+                    "retry_delay": 10,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                },
+                "targets": {
+                    "num_of_devices": 1
+                }
+            },
+            {
+                "name": "LoggerForkSafetyTest",
+                "module": "tests.server_tests.test_cases.logger_fork_safety_test",
+                "enabled": true,
+                "description": "Test for logging fork safety to prevent deadlocks in forked processes",
+                "test_config": {
+                    "test_timeout": 60,
+                    "retry_attempts": 0,
+                    "retry_delay": 0,
+                    "break_on_failure": true,
+                    "mock_mode": false
+                }
+            }
+        ]
+    },
+    {
+        "weights": [
             "Wan2.2-T2V-A14B-Diffusers"
         ],
         "device": "t3k",
@@ -2644,7 +2841,7 @@
                 "targets": {
                     "num_of_devices": 1,
                     "num_inference_steps": 20,
-                    "image_generation_time": 10
+                    "image_generation_time": 16
                 }
             },
             {
@@ -2662,7 +2859,7 @@
                 "targets": {
                     "num_of_devices": 1,
                     "num_inference_steps": 30,
-                    "image_generation_time": 14
+                    "image_generation_time": 23
                 }
             },
             {
@@ -2680,7 +2877,7 @@
                 "targets": {
                     "num_of_devices": 1,
                     "num_inference_steps": 50,
-                    "image_generation_time": 23
+                    "image_generation_time": 36
                 }
             },
             {
@@ -2694,6 +2891,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "FLUX.1-dev"
                 }
             }
         ]
@@ -2798,6 +2998,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "FLUX.1-dev"
                 }
             }
         ]
@@ -2902,6 +3105,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "FLUX.1-schnell"
                 }
             }
         ]
@@ -3006,6 +3212,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "FLUX.1-schnell"
                 }
             }
         ]
@@ -3110,6 +3319,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "Motif-Image-6B-Preview"
                 }
             }
         ]
@@ -3214,6 +3426,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "Motif-Image-6B-Preview"
                 }
             }
         ]
@@ -3318,6 +3533,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "FLUX.1-dev"
                 }
             }
         ]
@@ -3422,6 +3640,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "FLUX.1-dev"
                 }
             }
         ]
@@ -3526,6 +3747,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "FLUX.1-dev"
                 }
             }
         ]
@@ -3630,6 +3854,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "FLUX.1-dev"
                 }
             }
         ]
@@ -3734,6 +3961,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "FLUX.1-schnell"
                 }
             }
         ]
@@ -3838,6 +4068,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "FLUX.1-schnell"
                 }
             }
         ]
@@ -3942,6 +4175,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "FLUX.1-schnell"
                 }
             }
         ]
@@ -4046,6 +4282,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "FLUX.1-schnell"
                 }
             }
         ]
@@ -4150,6 +4389,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "Motif-Image-6B-Preview"
                 }
             }
         ]
@@ -4254,6 +4496,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "Motif-Image-6B-Preview"
                 }
             }
         ]
@@ -4358,6 +4603,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "Motif-Image-6B-Preview"
                 }
             }
         ]
@@ -4532,6 +4780,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "stable-diffusion-3.5-large"
                 }
             }
         ]
@@ -4636,6 +4887,9 @@
                     "retry_delay": 60,
                     "break_on_failure": false,
                     "mock_mode": false
+                },
+                "targets": {
+                    "model": "stable-diffusion-3.5-large"
                 }
             }
         ]

--- a/tests/server_tests/test_cases/image_generation_param_test.py
+++ b/tests/server_tests/test_cases/image_generation_param_test.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 # Only the fields that differ from default_payload need to be specified.
 _MODEL_DIFF_PARAM_OVERRIDES = {
     "FLUX.1-dev": {"guidance_scale": 20.0},
-    "FLUX.1-schnell": {"num_inference_steps": 8},
+    "FLUX.1-schnell": {"seed": 0},
 }
 default_payload = {
     "prompt": "A beautiful sunset over a mountain landscape with vibrant colors",

--- a/tests/server_tests/test_cases/image_generation_param_test.py
+++ b/tests/server_tests/test_cases/image_generation_param_test.py
@@ -16,6 +16,12 @@ from server_tests.base_test import BaseTest
 # Set up logging
 logger = logging.getLogger(__name__)
 
+# Model-specific overrides for the "different params" payload.
+# Only the fields that differ from default_payload need to be specified.
+_MODEL_DIFF_PARAM_OVERRIDES = {
+    "FLUX.1-dev": {"guidance_scale": 20.0},
+    "FLUX.1-schnell": {"num_inference_steps": 8},
+}
 default_payload = {
     "prompt": "A beautiful sunset over a mountain landscape with vibrant colors",
     "negative_prompt": "blurry, low quality, distorted",
@@ -42,6 +48,16 @@ headers = {
 
 DEFAULT_SAME_SEED_MIN_SSIM = 0.95
 DEFAULT_DIFF_PARAMS_MAX_SSIM = 0.98
+
+
+def _build_diff_payload(model: str) -> dict:
+    overrides = _MODEL_DIFF_PARAM_OVERRIDES.get(model)
+    if overrides is None:
+        return guidance_scale_change_payload
+
+    payload = dict(default_payload)
+    payload.update(overrides)
+    return payload
 
 
 def _decode_base64_image(image_base64):
@@ -91,14 +107,12 @@ def compute_image_ssim(response_a, response_b):
 class ImageGenerationParamTest(BaseTest):
     async def _run_specific_test_async(self):
         self.url = f"http://localhost:{self.service_port}/v1/images/generations"
-        print(self.targets)
+        logger.info(f"Targets: {self.targets}")
 
-        # Create list of payloads (one per device)
-        payloads = []
-        # use two payloads with same params to compare
-        payloads.append(default_payload)
-        payloads.append(default_payload)
-        payloads.append(guidance_scale_change_payload)
+        model = self.targets.get("model", "")
+        diff_payload = _build_diff_payload(model)
+
+        payloads = [default_payload, default_payload, diff_payload]
 
         # Get response data from all requests
         response_data_list = await self.test_concurrent_image_generation(payloads)
@@ -116,7 +130,7 @@ class ImageGenerationParamTest(BaseTest):
         ssim_diff = compute_image_ssim(response_data_list[0], response_data_list[2])
 
         same_requests = ssim_same >= same_seed_min_ssim
-        guidance_scale_differs = ssim_diff < diff_params_max_ssim
+        diff_params_differs = ssim_diff < diff_params_max_ssim
 
         logger.info(
             "SSIM(response[0], response[1])=%.4f (threshold >= %.2f): %s",
@@ -128,7 +142,7 @@ class ImageGenerationParamTest(BaseTest):
             "SSIM(response[0], response[2])=%.4f (threshold < %.2f): %s",
             ssim_diff,
             diff_params_max_ssim,
-            guidance_scale_differs,
+            diff_params_differs,
         )
 
         return {
@@ -136,8 +150,8 @@ class ImageGenerationParamTest(BaseTest):
             "same_seed_ssim": ssim_same,
             "diff_params_ssim": ssim_diff,
             "same_requests_match": same_requests,
-            "guidance_scale_differs": guidance_scale_differs,
-            "success": same_requests and guidance_scale_differs,
+            "diff_params_differs": diff_params_differs,
+            "success": same_requests and diff_params_differs,
         }
 
     async def test_concurrent_image_generation(self, payloads):

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -664,6 +664,7 @@ ModelConfigs = {
         "device_ids": DeviceIds.DEVICE_IDS_32.value,
         "max_batch_size": 2,
         "queue_for_multiprocessing": QueueType.BatchFifo.value,
+        "request_processing_timeout_seconds": 2000,
     },
     (ModelRunners.TT_WHISPER, DeviceTypes.T3K): {
         "device_mesh_shape": (1, 1),


### PR DESCRIPTION
### Link to GitHub issue
[2613](https://github.com/tenstorrent/tt-inference-server/issues/2613)

### Summary
This PR fixes the following:

- Add spec test configs for (resnet, efficient, segformer, vit, vovnet) base tests - DeviceLivenessTest and LoggerForkSafetyTest
- Fix Flux.1-dev and Flux.1-schnell spec test issues