### PR TITLE
Detect request cancellation

### DIFF
--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -27,10 +27,20 @@ namespace {
 
 void sseSend(const std::string& sse, trantor::EventLoop* loop,
              const std::shared_ptr<drogon::ResponseStreamPtr>& streamPtr,
-             const std::shared_ptr<ConcurrentQueue<std::string>>& accumulator) {
+             const std::shared_ptr<ConcurrentQueue<std::string>>& accumulator,
+             const std::shared_ptr<std::atomic<bool>>& cancelled,
+             const std::string& taskId) {
+  if (cancelled->load()) return;
   if (!accumulator) {
-    loop->queueInLoop([streamPtr, sse]() {
-      if (*streamPtr) (*streamPtr)->send(sse);
+    loop->queueInLoop([streamPtr, sse, cancelled, taskId]() {
+      if (*streamPtr && !cancelled->load()) {
+        if (!(*streamPtr)->send(sse)) {
+          cancelled->store(true);
+          TT_LOG_WARN(
+              "[LLMController] Client disconnected mid-stream task_id={}",
+              taskId);
+        }
+      }
     });
     return;
   }
@@ -39,21 +49,35 @@ void sseSend(const std::string& sse, trantor::EventLoop* loop,
     auto accumulated = accumulator->drain();
     std::string batch;
     for (auto& s : accumulated) batch.append(s);
-    loop->queueInLoop([streamPtr, batch = std::move(batch)]() {
-      if (*streamPtr) (*streamPtr)->send(batch);
-    });
+    loop->queueInLoop(
+        [streamPtr, batch = std::move(batch), cancelled, taskId]() {
+          if (*streamPtr && !cancelled->load()) {
+            if (!(*streamPtr)->send(batch)) {
+              cancelled->store(true);
+              TT_LOG_WARN(
+                  "[LLMController] Client disconnected mid-stream task_id={}",
+                  taskId);
+            }
+          }
+        });
   }
 }
 
 void flushAccumulated(
     const std::shared_ptr<ConcurrentQueue<std::string>>& accumulator,
-    const std::shared_ptr<drogon::ResponseStreamPtr>& streamPtr) {
-  if (!accumulator) return;
+    const std::shared_ptr<drogon::ResponseStreamPtr>& streamPtr,
+    const std::shared_ptr<std::atomic<bool>>& cancelled,
+    const std::string& taskId) {
+  if (!accumulator || cancelled->load()) return;
   auto accumulated = accumulator->drain();
   if (!accumulated.empty()) {
     std::string batch;
     for (auto& s : accumulated) batch.append(s);
-    (*streamPtr)->send(batch);
+    if (!(*streamPtr)->send(batch)) {
+      cancelled->store(true);
+      TT_LOG_WARN("[LLMController] Client disconnected mid-stream task_id={}",
+                  taskId);
+    }
   }
 }
 
@@ -337,6 +361,7 @@ void LLMController::handleStreaming(
   // queueInLoop, and the stream setup lambda via Drogon's async stream
   // machinery.
   auto done = std::make_shared<std::atomic<bool>>(false);
+  auto cancelled = std::make_shared<std::atomic<bool>>(false);
   // stream_ptr is null until the newAsyncStreamResponse lambda runs.
   auto streamPtr = std::make_shared<drogon::ResponseStreamPtr>();
   // Events that arrive before stream_ptr is set are buffered here.
@@ -356,14 +381,14 @@ void LLMController::handleStreaming(
   // Submit the streaming request before setting up the HTTP stream so that a
   // full queue throws QueueFullException here, allowing us to return a proper
   // 429.
-  auto streamingCallback = [loop, streamPtr, done, completionId, model, created,
-                            isChat, includeUsage, continuousUsage,
-                            completionTokens, startTime, firstTokenTime,
-                            secondTokenTime, firstContentChunk, reqPtr,
-                            accumulator](
+  auto streamingCallback = [loop, streamPtr, done, cancelled, completionId,
+                            model, created, isChat, includeUsage,
+                            continuousUsage, completionTokens, startTime,
+                            firstTokenTime, secondTokenTime, firstContentChunk,
+                            reqPtr, accumulator](
                                const domain::StreamingChunkResponse& chunk,
                                bool isFinal) {
-    if (done->load() || !*streamPtr) {
+    if (done->load() || cancelled->load() || !*streamPtr) {
       return;
     }
     if (!chunk.choices.empty()) {
@@ -420,16 +445,23 @@ void LLMController::handleStreaming(
       }
 
       if (!sse.empty()) {
-        sseSend(sse, loop, streamPtr, accumulator);
+        sseSend(sse, loop, streamPtr, accumulator, cancelled, completionId);
       }
     }
     if (isFinal) {
-      loop->queueInLoop([streamPtr, done, isChat, includeUsage, completionId,
-                         model, created, completionTokens, startTime,
-                         firstTokenTime, secondTokenTime, reqPtr,
+      loop->queueInLoop([streamPtr, done, cancelled, isChat, includeUsage,
+                         completionId, model, created, completionTokens,
+                         startTime, firstTokenTime, secondTokenTime, reqPtr,
                          accumulator]() {
         if (!done->exchange(true) && *streamPtr) {
-          flushAccumulated(accumulator, streamPtr);
+          if (cancelled->load()) {
+            TT_LOG_WARN(
+                "[LLMController] Streaming task_id={} completed after client "
+                "disconnect, skipping final flush",
+                completionId);
+            return;
+          }
+          flushAccumulated(accumulator, streamPtr, cancelled, completionId);
           if (includeUsage) {
             const int tokens = completionTokens->load();
             domain::CompletionUsage usage{reqPtr->prompt_tokens_count,


### PR DESCRIPTION
https://github.com/tenstorrent/tt-inference-server/issues/2264

First step in a line of changes to stop cancelled requests from using up hardware resources.