### PR TITLE
Set GPU reference scores and sources for deepseek-ai/DeepSeek-R1-0528

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1289,7 +1289,7 @@ _eval_config_list = [
                     "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                 },
-                gen_kwargs={"stream": "false", "max_gen_toks": "32768"},
+                gen_kwargs={"stream": "false"},
                 seed=42,
                 limit_samples_map={
                     EvalLimitMode.CI_NIGHTLY: 0.2,
@@ -1318,7 +1318,7 @@ _eval_config_list = [
                     "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                 },
-                gen_kwargs={"stream": "false", "max_gen_toks": "32768"},
+                gen_kwargs={"stream": "false"},
                 seed=42,
             ),
         ],

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1289,7 +1289,7 @@ _eval_config_list = [
                     "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                 },
-                gen_kwargs={"stream": "false"},
+                gen_kwargs={"stream": "false", "max_gen_toks": "32768"},
                 seed=42,
                 limit_samples_map={
                     EvalLimitMode.CI_NIGHTLY: 0.2,
@@ -1318,7 +1318,7 @@ _eval_config_list = [
                     "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                 },
-                gen_kwargs={"stream": "false"},
+                gen_kwargs={"stream": "false", "max_gen_toks": "32768"},
                 seed=42,
             ),
         ],
@@ -1347,7 +1347,7 @@ _eval_config_list = [
                     "base_url": "http://127.0.0.1:8000/v1/completions",
                     "tokenizer_backend": "huggingface",
                 },
-                gen_kwargs={"stream": "false", "max_gen_toks": "32768"},
+                gen_kwargs={"stream": "false"},
                 seed=42,
                 limit_samples_map={
                     EvalLimitMode.CI_NIGHTLY: 0.2,
@@ -1375,7 +1375,7 @@ _eval_config_list = [
                     "base_url": "http://127.0.0.1:8000/v1/completions",
                     "tokenizer_backend": "huggingface",
                 },
-                gen_kwargs={"stream": "false", "max_gen_toks": "32768"},
+                gen_kwargs={"stream": "false"},
                 seed=42,
                 limit_samples_map={
                     EvalLimitMode.CI_NIGHTLY: 0.2,

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1329,10 +1329,10 @@ _eval_config_list = [
             EvalTask(
                 task_name="r1_aime24",
                 score=EvalTaskScore(
-                    published_score=None,
-                    published_score_ref=None,
-                    gpu_reference_score=None,
-                    gpu_reference_score_ref=None,
+                    published_score=91.40,
+                    published_score_ref="https://huggingface.co/deepseek-ai/DeepSeek-R1-0528#deepseek-r1-0528-1",
+                    gpu_reference_score=83.33,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/357#issuecomment-3048350923",
                     score_func=score_task_single_key,
                     score_func_kwargs={
                         "result_keys": [
@@ -1346,9 +1346,8 @@ _eval_config_list = [
                     "model": "deepseek-ai/DeepSeek-R1-0528",
                     "base_url": "http://127.0.0.1:8000/v1/completions",
                     "tokenizer_backend": "huggingface",
-                    "max_length": 2048,
                 },
-                gen_kwargs={"stream": "false", "max_gen_toks": "1536"},
+                gen_kwargs={"stream": "false", "max_gen_toks": "32768"},
                 seed=42,
                 limit_samples_map={
                     EvalLimitMode.CI_NIGHTLY: 0.2,
@@ -1358,10 +1357,10 @@ _eval_config_list = [
             EvalTask(
                 task_name="r1_gpqa_diamond",
                 score=EvalTaskScore(
-                    published_score=None,
-                    published_score_ref=None,
-                    gpu_reference_score=None,
-                    gpu_reference_score_ref=None,
+                    published_score=81.00,
+                    published_score_ref="https://huggingface.co/deepseek-ai/DeepSeek-R1-0528#deepseek-r1-0528-1",
+                    gpu_reference_score=81.31,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/357#issuecomment-3048350923",
                     score_func=score_task_single_key,
                     score_func_kwargs={
                         "result_keys": [
@@ -1375,9 +1374,8 @@ _eval_config_list = [
                     "model": "deepseek-ai/DeepSeek-R1-0528",
                     "base_url": "http://127.0.0.1:8000/v1/completions",
                     "tokenizer_backend": "huggingface",
-                    "max_length": 2048,
                 },
-                gen_kwargs={"stream": "false", "max_gen_toks": "1536"},
+                gen_kwargs={"stream": "false", "max_gen_toks": "32768"},
                 seed=42,
                 limit_samples_map={
                     EvalLimitMode.CI_NIGHTLY: 0.2,


### PR DESCRIPTION
Adds GPU and author scores to address part of https://github.com/tenstorrent/tt-inference-server/issues/1470

Note the default `max_gen_toks` defined in the task https://github.com/tstescoTT/lm-evaluation-harness/blob/evals-common/lm_eval/tasks/r1_evals/aime24.yaml