### PR TITLE
Add API_KEY env variables support for inference server

### DIFF
--- a/benchmarking/run_benchmarks.py
+++ b/benchmarking/run_benchmarks.py
@@ -328,6 +328,7 @@ def main():
     env_config = EnvironmentConfig()
     env_config.jwt_secret = jwt_secret
     env_config.vllm_api_key = os.getenv("VLLM_API_KEY")
+    env_config.api_key = os.getenv("API_KEY")
     env_config.service_port = service_port
     env_config.vllm_model = model_spec.hf_model_repo
 

--- a/stress_tests/stress_tests_core.py
+++ b/stress_tests/stress_tests_core.py
@@ -766,6 +766,8 @@ class StressTests:
 
         if self.env_config.vllm_api_key:
             env["OPENAI_API_KEY"] = self.env_config.vllm_api_key
+        elif self.env_config.api_key:
+            env["OPENAI_API_KEY"] = self.env_config.api_key
         elif self.env_config.jwt_secret:
             env["OPENAI_API_KEY"] = self.env_config.jwt_secret
         else:

--- a/tests/server_tests/conftest.py
+++ b/tests/server_tests/conftest.py
@@ -7,8 +7,7 @@ import pytest
 import requests
 import json
 from datetime import datetime
-from utils.prompt_client import PromptClient
-from utils.prompt_configs import EnvironmentConfig
+from utils.prompt_configs import EnvironmentConfig, resolve_authorization_bearer
 
 
 # 1. Add command-line options for endpoint and metadata
@@ -80,8 +79,7 @@ def api_client(endpoint_url):
 
     def _make_request(json_payload, timeout=30):
         env_config = EnvironmentConfig()
-        prompt_client = PromptClient(env_config)
-        authorization = prompt_client._get_authorization()
+        authorization = resolve_authorization_bearer(env_config)
         headers = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {authorization}",

--- a/tests/test_vllm_api_key_env.py
+++ b/tests/test_vllm_api_key_env.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import os
+
+import pytest
+
+from utils.prompt_configs import EnvironmentConfig, resolve_authorization_bearer
+from utils.vllm_run_utils import configure_vllm_api_key_env, get_encoded_api_key
+
+
+@pytest.fixture
+def clean_vllm_auth_env():
+    keys = ("VLLM_API_KEY", "API_KEY", "JWT_SECRET")
+    saved = {k: os.environ.pop(k, None) for k in keys}
+    yield
+    for k in keys:
+        if saved[k] is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = saved[k]
+
+
+def test_configure_no_auth_removes_vllm_key(clean_vllm_auth_env):
+    os.environ["VLLM_API_KEY"] = "secret"
+    configure_vllm_api_key_env(no_auth=True)
+    assert "VLLM_API_KEY" not in os.environ
+
+
+def test_configure_prefers_vllm_api_key_over_api_key(clean_vllm_auth_env):
+    os.environ["VLLM_API_KEY"] = "vllm-val"
+    os.environ["API_KEY"] = "api-val"
+    configure_vllm_api_key_env(no_auth=False)
+    assert os.environ["VLLM_API_KEY"] == "vllm-val"
+
+
+def test_configure_api_key_copied_to_vllm_api_key(clean_vllm_auth_env):
+    os.environ["API_KEY"] = "shared-secret"
+    configure_vllm_api_key_env(no_auth=False)
+    assert os.environ["VLLM_API_KEY"] == "shared-secret"
+
+
+def test_configure_jwt_secret_when_no_vllm_or_api_key(clean_vllm_auth_env):
+    os.environ["JWT_SECRET"] = "jwt-secret-value"
+    configure_vllm_api_key_env(no_auth=False)
+    assert os.environ["VLLM_API_KEY"] == get_encoded_api_key("jwt-secret-value")
+
+
+def test_configure_no_keys_no_vllm_env_var(clean_vllm_auth_env):
+    configure_vllm_api_key_env(no_auth=False)
+    assert "VLLM_API_KEY" not in os.environ
+
+
+def test_configure_api_key_skips_jwt(clean_vllm_auth_env):
+    os.environ["API_KEY"] = "from-api-key"
+    os.environ["JWT_SECRET"] = "ignored"
+    configure_vllm_api_key_env(no_auth=False)
+    assert os.environ["VLLM_API_KEY"] == "from-api-key"
+
+
+def test_resolve_authorization_prefers_vllm_key_over_api_key():
+    env_config = EnvironmentConfig()
+    env_config.vllm_api_key = "v1"
+    env_config.api_key = "a1"
+    assert resolve_authorization_bearer(env_config) == "v1"
+
+
+def test_resolve_authorization_uses_api_key_when_no_vllm_key():
+    env_config = EnvironmentConfig()
+    env_config.vllm_api_key = None
+    env_config.api_key = "media-style-key"
+    assert resolve_authorization_bearer(env_config) == "media-style-key"

--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -10,11 +10,14 @@ from typing import List, Tuple, Optional
 from pathlib import Path
 
 import requests
-import jwt
 from transformers import AutoTokenizer
 
 from utils.prompt_generation import generate_prompts
-from utils.prompt_configs import PromptConfig, EnvironmentConfig
+from utils.prompt_configs import (
+    EnvironmentConfig,
+    PromptConfig,
+    resolve_authorization_bearer,
+)
 from utils.cache_monitor import CacheMonitor
 
 logging.basicConfig(
@@ -76,7 +79,7 @@ class PromptClient:
         cache_dir: Optional[Path] = None,
     ):
         self.env_config = env_config
-        authorization = self._get_authorization()
+        authorization = resolve_authorization_bearer(env_config)
         if authorization:
             self.headers = {"Authorization": f"Bearer {authorization}"}
         else:
@@ -85,25 +88,6 @@ class PromptClient:
         self.health_url = self._get_api_health_url()
         self.cache_monitor = CacheMonitor(model_spec=model_spec, cache_dir=cache_dir)
         self.server_ready = False
-
-    def _get_authorization(self) -> Optional[str]:
-        if self.env_config.vllm_api_key:
-            return self.env_config.vllm_api_key
-
-        if self.env_config.jwt_secret:
-            json_payload = json.loads(
-                '{"team_id": "tenstorrent", "token_id":"debug-test"}'
-            )
-            encoded_jwt = jwt.encode(
-                json_payload, self.env_config.jwt_secret, algorithm="HS256"
-            )
-            return encoded_jwt
-
-        logger.warning(
-            "Neither VLLM_API_KEY nor JWT_SECRET environment variables are set. "
-            "Proceeding without authorization."
-        )
-        return None
 
     def _get_api_base_url(self, include_v1: bool = True) -> str:
         """Get base API URL, optionally with /v1 suffix.

--- a/utils/prompt_configs.py
+++ b/utils/prompt_configs.py
@@ -2,9 +2,15 @@
 #
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
+import json
+import logging
+import os
 from dataclasses import dataclass
 from typing import List, Optional
-import os
+
+import jwt
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -49,8 +55,28 @@ class EnvironmentConfig:
         "HF_MODEL_REPO_ID", "meta-llama/Llama-3.1-70B-Instruct"
     )
     vllm_api_key: Optional[str] = os.environ.get("VLLM_API_KEY")
+    api_key: Optional[str] = os.environ.get("API_KEY")
     jwt_secret: Optional[str] = os.environ.get("JWT_SECRET")
     deploy_url: str = os.environ.get("DEPLOY_URL", "http://127.0.0.1")
     service_port: str = os.environ.get("SERVICE_PORT", "7000")
     cache_root: str = os.environ.get("CACHE_ROOT", ".")
     mesh_device: str = get_mesh_device()
+
+
+def resolve_authorization_bearer(env_config: EnvironmentConfig) -> Optional[str]:
+    """Bearer token for API requests: VLLM_API_KEY, then API_KEY, then JWT from JWT_SECRET."""
+    if env_config.vllm_api_key:
+        return env_config.vllm_api_key
+
+    if env_config.api_key:
+        return env_config.api_key
+
+    if env_config.jwt_secret:
+        json_payload = json.loads('{"team_id": "tenstorrent", "token_id":"debug-test"}')
+        return jwt.encode(json_payload, env_config.jwt_secret, algorithm="HS256")
+
+    logger.warning(
+        "Neither VLLM_API_KEY, API_KEY, nor JWT_SECRET environment variables are set. "
+        "Proceeding without authorization."
+    )
+    return None

--- a/utils/vllm_run_utils.py
+++ b/utils/vllm_run_utils.py
@@ -4,11 +4,59 @@
 
 import json
 import logging
+import os
 from pathlib import Path
 import subprocess
 import jwt
 
 logger = logging.getLogger(__name__)
+
+
+def configure_vllm_api_key_env(no_auth: bool) -> None:
+    """Populate ``VLLM_API_KEY`` for vLLM's OpenAI API server from the environment.
+
+    When ``no_auth`` is True, ``VLLM_API_KEY`` is removed so the server does not
+    require authorization.
+
+    Otherwise, resolution order is:
+    1. ``VLLM_API_KEY`` — use as-is if set
+    2. ``API_KEY`` — copy to ``VLLM_API_KEY`` (parity with tt-media-server)
+    3. ``JWT_SECRET`` — derive a bearer token and set ``VLLM_API_KEY``
+    """
+    if no_auth:
+        if "VLLM_API_KEY" in os.environ:
+            del os.environ["VLLM_API_KEY"]
+        logger.info(
+            "--no-auth is set: requests to vLLM API will not require authorization. "
+            "HTTP Authorization header will not be checked."
+        )
+        return
+
+    if os.getenv("VLLM_API_KEY"):
+        logger.info("VLLM_API_KEY is already set, using existing value")
+        return
+
+    api_key = os.getenv("API_KEY")
+    if api_key:
+        os.environ["VLLM_API_KEY"] = api_key
+        logger.info(
+            "API_KEY is set: using it for vLLM API authorization (same role as VLLM_API_KEY)"
+        )
+        return
+
+    jwt_secret = os.getenv("JWT_SECRET")
+    if not jwt_secret:
+        logger.warning(
+            "Neither VLLM_API_KEY, API_KEY, nor JWT_SECRET are set: HTTP requests to vLLM API will not require authorization"
+        )
+        return
+
+    encoded_api_key = get_encoded_api_key(jwt_secret)
+    if encoded_api_key is not None:
+        os.environ["VLLM_API_KEY"] = encoded_api_key
+        logger.info(
+            "JWT_SECRET is set: HTTP requests to vLLM API require bearer token in 'Authorization' header. See docs for how to get bearer token."
+        )
 
 
 def create_model_symlink(symlinks_dir, model_name, weights_dir, file_symlinks_map={}):

--- a/vllm-tt-metal-llama3/src/run_vllm_api_server.py
+++ b/vllm-tt-metal-llama3/src/run_vllm_api_server.py
@@ -16,8 +16,8 @@ from vllm import ModelRegistry
 from utils.logging_utils import set_vllm_logging_config
 from utils.prompt_client import run_background_trace_capture
 from utils.vllm_run_utils import (
+    configure_vllm_api_key_env,
     create_model_symlink,
-    get_encoded_api_key,
     resolve_commit,
 )
 
@@ -172,38 +172,8 @@ def handle_secrets(model_spec_json):
             "HF_TOKEN is not set - this may cause issues accessing private models or models requiring authorization"
         )
 
-    # Check if --no-auth was passed via CLI args
     no_auth = model_spec_json.get("cli_args", {}).get("no_auth", False)
-    if no_auth:
-        # Remove VLLM_API_KEY if present to disable authorization
-        if "VLLM_API_KEY" in os.environ:
-            del os.environ["VLLM_API_KEY"]
-        logger.info(
-            "--no-auth is set: requests to vLLM API will not require authorization. "
-            "HTTP Authorization header will not be checked."
-        )
-        return
-
-    # Check for VLLM_API_KEY first, then fall back to JWT_SECRET
-    vllm_api_key = os.getenv("VLLM_API_KEY")
-    if vllm_api_key:
-        logger.info("VLLM_API_KEY is already set, using existing value")
-        return
-
-    # VLLM_API_KEY is not set, check if JWT_SECRET is available
-    jwt_secret = os.getenv("JWT_SECRET")
-    if not jwt_secret:
-        logger.warning(
-            "Neither VLLM_API_KEY nor JWT_SECRET are set: HTTP requests to vLLM API will not require authorization"
-        )
-        return
-
-    encoded_api_key = get_encoded_api_key(jwt_secret)
-    if encoded_api_key is not None:
-        os.environ["VLLM_API_KEY"] = encoded_api_key
-        logger.info(
-            "JWT_SECRET is set: HTTP requests to vLLM API require bearer token in 'Authorization' header. See docs for how to get bearer token."
-        )
+    configure_vllm_api_key_env(no_auth)
 
 
 def runtime_settings(model_spec_json, impl_id):


### PR DESCRIPTION
This aligns all three inference servers together to provide support for using the API_KEY env variable for auth.

* vllm inference-server
* cpp inference-server
* media-server

We can leave VLLM_API_KEY in for the vllm based servers to keep compatibility with stock vllm. The ordering is here:

    1. ``VLLM_API_KEY`` — use as-is if set
    2. ``API_KEY`` — copy to ``VLLM_API_KEY`` (parity with tt-media-server)
    3. ``JWT_SECRET`` — derive a bearer token and set ``VLLM_API_KEY``