### PR TITLE
Update spec test for flux and increase request timeout for Whisper on Galaxy

### DIFF
--- a/server_tests/test_cases/image_generation_param_test.py
+++ b/server_tests/test_cases/image_generation_param_test.py
@@ -11,6 +11,7 @@ import time
 import aiohttp
 import numpy as np
 from PIL import Image
+
 from server_tests.base_test import BaseTest
 
 # Set up logging
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 # Model-specific overrides for the "different params" payload.
 # Only the fields that differ from default_payload need to be specified.
 _MODEL_DIFF_PARAM_OVERRIDES = {
-    "FLUX.1-dev": {"guidance_scale": 20.0},
+    "FLUX.1-dev": {"seed": 0},
     "FLUX.1-schnell": {"seed": 0},
 }
 default_payload = {

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -664,7 +664,7 @@ ModelConfigs = {
         "device_ids": DeviceIds.DEVICE_IDS_32.value,
         "max_batch_size": 2,
         "queue_for_multiprocessing": QueueType.BatchFifo.value,
-        "request_processing_timeout_seconds": 3000,
+        "request_processing_timeout_seconds": 5000,
     },
     (ModelRunners.TT_WHISPER, DeviceTypes.T3K): {
         "device_mesh_shape": (1, 1),


### PR DESCRIPTION
### Link to GitHub issue
[2627](https://github.com/tenstorrent/tt-inference-server/issues/2627)

### Summary
This PR fixes the following:

- Use different seed for flux dev
- bump request timout for whisper on galaxy