### PR TITLE
Allow the handling of >1 TestTask in TestConfig

### DIFF
--- a/server_tests/conftest.py
+++ b/server_tests/conftest.py
@@ -89,7 +89,6 @@ def results_report(request, output_path):
 
     # 4. This code runs after the session finishes
     report_filename = f"parameter_report_{task_name}.json"
-    print(f"Generating {report_filename}...")
     filename = output_path / report_filename
     with open(filename, "w") as f:
         json.dump(report_data, f, indent=2)

--- a/server_tests/conftest.py
+++ b/server_tests/conftest.py
@@ -46,7 +46,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--task-name",
         action="store",
-        default="default",
+        default="unknown-task",
         help="Name of the test task, used to name the output report file",
     )
 
@@ -77,16 +77,17 @@ def output_path(request):
 # 3. Fixture for the session-wide report dictionary (now with metadata)
 @pytest.fixture(scope="session")
 def results_report(request, output_path):
+    task_name = request.config.getoption("--task-name")
     report_data = {
         "endpoint_url": request.config.getoption("--endpoint-url"),
         "model_name": request.config.getoption("--model-name"),
         "model_impl": request.config.getoption("--model-impl"),
+        "task_name": task_name,
         "results": {},
     }
     yield report_data
 
     # 4. This code runs after the session finishes
-    task_name = request.config.getoption("--task-name")
     report_filename = f"parameter_report_{task_name}.json"
     print(f"Generating {report_filename}...")
     filename = output_path / report_filename

--- a/server_tests/conftest.py
+++ b/server_tests/conftest.py
@@ -43,6 +43,12 @@ def pytest_addoption(parser):
         type=int,
         help="Maximum context length for the model",
     )
+    parser.addoption(
+        "--task-name",
+        action="store",
+        default="default",
+        help="Name of the test task, used to name the output report file",
+    )
 
 
 @pytest.fixture(scope="session")
@@ -80,11 +86,13 @@ def results_report(request, output_path):
     yield report_data
 
     # 4. This code runs after the session finishes
-    print("Generating parameter_report.json...")
-    filename = output_path / "parameter_report.json"
+    task_name = request.config.getoption("--task-name")
+    report_filename = f"parameter_report_{task_name}.json"
+    print(f"Generating {report_filename}...")
+    filename = output_path / report_filename
     with open(filename, "w") as f:
         json.dump(report_data, f, indent=2)
-    print("parameter_report.json generated.")
+    print(f"{report_filename} generated.")
 
 
 # 5. Helper fixture to make API calls (unchanged, it's already clean)

--- a/server_tests/run_tests.py
+++ b/server_tests/run_tests.py
@@ -9,7 +9,6 @@ import jwt
 import logging
 import sys
 from pathlib import Path
-from typing import List
 
 # Add the script's directory to the Python path
 # this for 0 setup python setup script
@@ -36,28 +35,20 @@ def build_test_command(
     task: TestTask,
     model_spec,
     device,
-    output_path,
+    output_dir_path,
     service_port,
 ):
     """
     Build the command for tests by templating command-line arguments using properties
     from the given task and model configuration.
 
-    Returns (cmd, output_dir_path) tuple.
+    Returns cmd list.
     """
-    run_timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     task_venv_config = VENV_CONFIGS[task.workflow_venv_type]
 
     test_exec = task_venv_config.venv_path / "bin" / "pytest"
 
     test_kwargs_list = [f"-{arg}" for arg in task.test_args]
-
-    # set output_dir
-    # results go to {output_dir_path}/{hf_repo}/results_{timestamp}
-    output_dir_path = (
-        Path(output_path)
-        / f"test_{model_spec.model_id}__{run_timestamp}_{task.task_name}"
-    )
 
     if task.task_name == "vllm_responses":
         # vLLM responses test needs the service port to connect to the server
@@ -73,13 +64,15 @@ def build_test_command(
         model_spec.impl.impl_name,
         "--output-path",
         output_dir_path,
+        "--task-name",
+        task.task_name,
         "--max-context",
         str(model_spec.device_model_spec.max_context),
     ]
     cmd.extend(test_kwargs_list)
     # force all cmd parts to be strs
     cmd = [str(c) for c in cmd]
-    return cmd, str(output_dir_path)
+    return cmd
 
 
 def parse_args():
@@ -177,34 +170,32 @@ def main():
     env_config.service_port = runtime_config.service_port
     env_config.vllm_model = model_spec.hf_model_repo
 
+    # Create a single shared output directory for all tasks in this run
+    run_timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    output_dir_path = (
+        Path(args.output_path) / f"test_{model_spec.model_id}__{run_timestamp}"
+    )
+    output_dir_path.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Test output directory: {output_dir_path}")
+
     # Execute pytest for each task.
     logger.info("Running test client ...")
     return_codes = []
-    test_manifest = []
     for task in test_config.tasks:
         logger.info(
             f"Starting workflow: {workflow_config.name} task_name: {task.task_name}"
         )
 
         logger.info(f"Running tests for:\n {task}")
-        cmd, output_dir_path = build_test_command(
+        cmd = build_test_command(
             task,
             model_spec,
             device_str,
-            args.output_path,
+            str(output_dir_path),
             runtime_config.service_port,
         )
         return_code = run_command(command=cmd, logger=logger, env=env_vars)
         return_codes.append(return_code)
-        test_manifest.append(
-            {"task_name": task.task_name, "output_dir": output_dir_path}
-        )
-
-    # Write manifest of test output directories for report generation
-    manifest_path = Path(args.output_path) / f"test_manifest_{model_spec.model_id}.json"
-    with open(manifest_path, "w", encoding="utf-8") as f:
-        json.dump(test_manifest, f, indent=2)
-    logger.info(f"Test manifest saved to: {manifest_path}")
 
     if all(return_code == 0 for return_code in return_codes):
         logger.info("✅ Completed tests")

--- a/server_tests/run_tests.py
+++ b/server_tests/run_tests.py
@@ -37,7 +37,7 @@ def build_test_command(
     device,
     output_dir_path,
     service_port,
-):
+) -> list[str]:
     """
     Build the command for tests by templating command-line arguments using properties
     from the given task and model configuration.
@@ -179,7 +179,9 @@ def main():
     logger.info(f"Test output directory: {output_dir_path}")
 
     # Execute pytest for each task.
-    logger.info("Running test client ...")
+    logger.info(
+        f"Running test client with {len(test_config.tasks)} task(s): {[t.task_name for t in test_config.tasks]}"
+    )
     return_codes = []
     for task in test_config.tasks:
         logger.info(

--- a/server_tests/run_tests.py
+++ b/server_tests/run_tests.py
@@ -38,10 +38,12 @@ def build_test_command(
     device,
     output_path,
     service_port,
-) -> List[str]:
+):
     """
     Build the command for tests by templating command-line arguments using properties
     from the given task and model configuration.
+
+    Returns (cmd, output_dir_path) tuple.
     """
     run_timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     task_venv_config = VENV_CONFIGS[task.workflow_venv_type]
@@ -77,7 +79,7 @@ def build_test_command(
     cmd.extend(test_kwargs_list)
     # force all cmd parts to be strs
     cmd = [str(c) for c in cmd]
-    return cmd
+    return cmd, str(output_dir_path)
 
 
 def parse_args():
@@ -178,13 +180,14 @@ def main():
     # Execute pytest for each task.
     logger.info("Running test client ...")
     return_codes = []
+    test_manifest = []
     for task in test_config.tasks:
         logger.info(
             f"Starting workflow: {workflow_config.name} task_name: {task.task_name}"
         )
 
         logger.info(f"Running tests for:\n {task}")
-        cmd = build_test_command(
+        cmd, output_dir_path = build_test_command(
             task,
             model_spec,
             device_str,
@@ -193,6 +196,15 @@ def main():
         )
         return_code = run_command(command=cmd, logger=logger, env=env_vars)
         return_codes.append(return_code)
+        test_manifest.append(
+            {"task_name": task.task_name, "output_dir": output_dir_path}
+        )
+
+    # Write manifest of test output directories for report generation
+    manifest_path = Path(args.output_path) / f"test_manifest_{model_spec.model_id}.json"
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(test_manifest, f, indent=2)
+    logger.info(f"Test manifest saved to: {manifest_path}")
 
     if all(return_code == 0 for return_code in return_codes):
         logger.info("✅ Completed tests")

--- a/server_tests/test_config.py
+++ b/server_tests/test_config.py
@@ -69,11 +69,11 @@ _test_config_list = [
     TestConfig(
         hf_model_repo="openai/gpt-oss-20b",
         tasks=[
-            TestTask(
-                task_name="vllm_chat_completions",
-                test_path=Path("server_tests/test_cases/test_vllm_chat_completions.py"),
-                test_args=("s", "v"),
-            ),
+            # TestTask(
+            #     task_name="vllm_chat_completions",
+            #     test_path=Path("server_tests/test_cases/test_vllm_chat_completions.py"),
+            #     test_args=("s", "v"),
+            # ),
             TestTask(
                 task_name="vllm_responses",
                 test_path=Path("server_tests/test_cases/test_vllm_responses.py"),

--- a/server_tests/test_config.py
+++ b/server_tests/test_config.py
@@ -71,16 +71,14 @@ _test_config_list = [
         tasks=[
             TestTask(
                 task_name="vllm_chat_completions",
-                test_path=Path(
-                    "server_tests/test_cases/test_vllm_chat_completions.py"
-                ),
+                test_path=Path("server_tests/test_cases/test_vllm_chat_completions.py"),
                 test_args=("s", "v"),
             ),
             TestTask(
                 task_name="vllm_responses",
                 test_path=Path("server_tests/test_cases/test_vllm_responses.py"),
                 test_args=("s", "v"),
-            )
+            ),
         ],
     ),
 ]

--- a/server_tests/test_config.py
+++ b/server_tests/test_config.py
@@ -69,11 +69,11 @@ _test_config_list = [
     TestConfig(
         hf_model_repo="openai/gpt-oss-20b",
         tasks=[
-            # TestTask(
-            #     task_name="vllm_chat_completions",
-            #     test_path=Path("server_tests/test_cases/test_vllm_chat_completions.py"),
-            #     test_args=("s", "v"),
-            # ),
+            TestTask(
+                task_name="vllm_chat_completions",
+                test_path=Path("server_tests/test_cases/test_vllm_chat_completions.py"),
+                test_args=("s", "v"),
+            ),
             TestTask(
                 task_name="vllm_responses",
                 test_path=Path("server_tests/test_cases/test_vllm_responses.py"),

--- a/server_tests/test_config.py
+++ b/server_tests/test_config.py
@@ -69,14 +69,13 @@ _test_config_list = [
     TestConfig(
         hf_model_repo="openai/gpt-oss-20b",
         tasks=[
-            # TODO: re-enable multiple test tasks once we have figure out how to create multiple output jsons
-            # TestTask(
-            #     task_name="vllm_chat_completions",
-            #     test_path=Path(
-            #         "server_tests/test_cases/test_vllm_chat_completions.py"
-            #     ),
-            #     test_args=("s", "v"),
-            # ),
+            TestTask(
+                task_name="vllm_chat_completions",
+                test_path=Path(
+                    "server_tests/test_cases/test_vllm_chat_completions.py"
+                ),
+                test_args=("s", "v"),
+            ),
             TestTask(
                 task_name="vllm_responses",
                 test_path=Path("server_tests/test_cases/test_vllm_responses.py"),

--- a/server_tests/utils/vllm_parameter_json_to_md.py
+++ b/server_tests/utils/vllm_parameter_json_to_md.py
@@ -180,8 +180,9 @@ def _load_report(report_file):
         raise json.JSONDecodeError(f"Error: Could not decode JSON from {report_file}")
 
 
-def _generate_single_report(report_data, task_name=None):
+def _generate_single_report(report_data):
     """Generate markdown sections for a single report's data."""
+    task_name = report_data.get("task_name")
     summary = analyze_report(report_data)
     metadata_md = format_metadata(report_data, task_name=task_name)
     summary_md = format_summary_table(summary, task_name=task_name)
@@ -189,26 +190,22 @@ def _generate_single_report(report_data, task_name=None):
     return f"{metadata_md}\n{summary_md}{details_md}"
 
 
-def main(report_file, *args, **kwargs):
-    # Accept a list of (task_name, file_path) tuples for multi-task reports
-    if (
-        isinstance(report_file, list)
-        and len(report_file) > 0
-        and isinstance(report_file[0], tuple)
-    ):
-        sections = []
-        for task_name, file_path in report_file:
-            report_data = _load_report(file_path)
-            sections.append(_generate_single_report(report_data, task_name=task_name))
-        return "\n---\n\n".join(sections)
+def main(report_files):
+    """Generate markdown report from one or more parameter report JSON files.
 
-    # Accept a single file path (backwards compatible)
-    if isinstance(report_file, list):
-        # list of file paths without task names — fall back to single merged report
-        report_file = report_file[0] if len(report_file) == 1 else report_file[0]
+    Each JSON file must contain a 'task_name' field.
 
-    report_data = _load_report(report_file)
-    return _generate_single_report(report_data)
+    Args:
+        report_files: A single file path string or a list of file path strings.
+    """
+    if isinstance(report_files, str):
+        report_files = [report_files]
+
+    sections = []
+    for file_path in report_files:
+        report_data = _load_report(file_path)
+        sections.append(_generate_single_report(report_data))
+    return "\n---\n\n".join(sections)
 
 
 if __name__ == "__main__":
@@ -216,10 +213,9 @@ if __name__ == "__main__":
         description="Convert API test report JSON to Markdown."
     )
     parser.add_argument(
-        "report_file",
-        nargs="?",
-        default="report.json",
-        help="Path to the input report.json file (default: report.json)",
+        "report_files",
+        nargs="+",
+        help="Path(s) to input parameter report JSON file(s)",
     )
     parser.add_argument(
         "-o",
@@ -228,7 +224,7 @@ if __name__ == "__main__":
         help="Path to the output report.md file (default: report.md)",
     )
     args = parser.parse_args()
-    report_str = main(**vars(args))
+    report_str = main(args.report_files)
 
     # Write to output file
     with open(args.output, "w") as f:

--- a/server_tests/utils/vllm_parameter_json_to_md.py
+++ b/server_tests/utils/vllm_parameter_json_to_md.py
@@ -60,10 +60,15 @@ def analyze_report(report_data):
     return summary
 
 
-def format_metadata(report_data):
+def format_metadata(report_data, task_name=None):
     """Creates a Markdown table for the report metadata."""
+    title = (
+        f"### LLM API Test Metadata — {task_name}"
+        if task_name
+        else "### LLM API Test Metadata"
+    )
     lines = [
-        "### LLM API Test Metadata",
+        title,
         "",
         "| Attribute | Value |",
         "| --- | --- |",
@@ -84,10 +89,15 @@ def format_metadata(report_data):
     return "\n".join(lines)
 
 
-def format_summary_table(summary):
+def format_summary_table(summary, task_name=None):
     """Creates the main summary results table."""
+    title = (
+        f"### Parameter Conformance Summary — {task_name}"
+        if task_name
+        else "### Parameter Conformance Summary"
+    )
     lines = [
-        "### Parameter Conformance Summary",
+        title,
         "",
         "| Test Case | Status | Summary |",
         "| --- | :---: | --- |",
@@ -109,10 +119,15 @@ def format_summary_table(summary):
     return "\n".join(lines)
 
 
-def format_detailed_results_table(summary):
+def format_detailed_results_table(summary, task_name=None):
     """Creates a single Markdown table for all detailed test results."""
+    title = (
+        f"### Detailed Test Results — {task_name}"
+        if task_name
+        else "### Detailed Test Results"
+    )
     lines = [
-        "### Detailed Test Results",
+        title,
         "",
         "| Test Case | Parametrization | Status | Message |",
         "| --- | --- | :---: | --- |",
@@ -155,24 +170,45 @@ def format_detailed_results_table(summary):
     return "\n".join(lines)
 
 
-def main(report_file, *args, **kwargs):
+def _load_report(report_file):
     try:
         with open(report_file, "r") as f:
-            report_data = json.load(f)
+            return json.load(f)
     except FileNotFoundError:
         raise FileNotFoundError(f"Error: Input file not found at {report_file}")
     except json.JSONDecodeError:
         raise json.JSONDecodeError(f"Error: Could not decode JSON from {report_file}")
 
-    # Analyze and format
-    summary = analyze_report(report_data)
-    metadata_md = format_metadata(report_data)
-    summary_md = format_summary_table(summary)
-    # Call the new table-based formatter
-    details_md = format_detailed_results_table(summary)
 
-    report_str = f"{metadata_md}\n{summary_md}{details_md}"
-    return report_str
+def _generate_single_report(report_data, task_name=None):
+    """Generate markdown sections for a single report's data."""
+    summary = analyze_report(report_data)
+    metadata_md = format_metadata(report_data, task_name=task_name)
+    summary_md = format_summary_table(summary, task_name=task_name)
+    details_md = format_detailed_results_table(summary, task_name=task_name)
+    return f"{metadata_md}\n{summary_md}{details_md}"
+
+
+def main(report_file, *args, **kwargs):
+    # Accept a list of (task_name, file_path) tuples for multi-task reports
+    if (
+        isinstance(report_file, list)
+        and len(report_file) > 0
+        and isinstance(report_file[0], tuple)
+    ):
+        sections = []
+        for task_name, file_path in report_file:
+            report_data = _load_report(file_path)
+            sections.append(_generate_single_report(report_data, task_name=task_name))
+        return "\n---\n\n".join(sections)
+
+    # Accept a single file path (backwards compatible)
+    if isinstance(report_file, list):
+        # list of file paths without task names — fall back to single merged report
+        report_file = report_file[0] if len(report_file) == 1 else report_file[0]
+
+    report_data = _load_report(report_file)
+    return _generate_single_report(report_data)
 
 
 if __name__ == "__main__":

--- a/server_tests/utils/vllm_parameter_json_to_md.py
+++ b/server_tests/utils/vllm_parameter_json_to_md.py
@@ -214,7 +214,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "report_files",
-        nargs="+",
+        nargs="?",
         help="Path(s) to input parameter report JSON file(s)",
     )
     parser.add_argument(

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -2633,39 +2633,27 @@ def generate_tests_report(args, server_mode, model_spec, report_id, metadata={})
     latest_dir = matching_dirs[-1]
     logger.info(f"Using latest test output directory: {latest_dir}")
 
-    # Collect (task_name, report_path) from parameter_report_*.json files
-    report_entries = []
+    # Collect report file paths from parameter_report_*.json files
+    report_files = []
     for report_path in sorted(latest_dir.glob("parameter_report_*.json")):
-        # Extract task_name from filename: parameter_report_{task_name}.json
-        task_name = report_path.stem.replace("parameter_report_", "")
-        report_entries.append((task_name, str(report_path)))
-        logger.info(f"  Found report for task '{task_name}': {report_path}")
+        report_files.append(str(report_path))
+        logger.info(f"  Found report: {report_path}")
 
-    logger.info(f"Found {len(report_entries)} parameter report(s)")
+    logger.info(f"Found {len(report_files)} parameter report(s)")
 
-    if not report_entries:
-        logger.info("No parameter_report.json found in test output directories.")
+    if not report_files:
+        logger.info("No parameter report files found in test output directory.")
         return empty_result
 
-    logger.info(f"Processing {len(report_entries)} parameter report(s)")
+    logger.info(f"Processing {len(report_files)} parameter report(s)")
 
     # Generate vLLM parameter coverage report from all report files
-    # Pass (task_name, file_path) tuples for per-task sections when multiple tasks
-    if len(report_entries) == 1:
-        report_file_arg = report_entries[0][1]
-    else:
-        report_file_arg = report_entries
-    markdown_str = generate_vllm_parameter_report(
-        report_file_arg,
-        output_path,
-        report_id,
-        metadata,
-        model_spec=model_spec,
-    )
+    # Each JSON contains its own task_name field
+    markdown_str = generate_vllm_parameter_report(report_files)
 
-    # Merge all parameter_report.json data into combined release_raw
+    # Merge all parameter report data into combined release_raw
     release_raw_list = []
-    for _task_name, report_file in report_entries:
+    for report_file in report_files:
         try:
             with open(report_file, "r", encoding="utf-8") as f:
                 release_raw_list.append(json.load(f))

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -2622,7 +2622,7 @@ def generate_tests_report(args, server_mode, model_spec, report_id, metadata={})
     # Find the latest test output directory for this model
     tests_output_dir = get_default_workflow_root_log_dir() / "tests_output"
     dir_pattern = f"test_{model_spec.model_id}__*"
-    matching_dirs = sorted(tests_output_dir.glob(dir_pattern))
+    matching_dirs = list(tests_output_dir.glob(dir_pattern))
     if not matching_dirs:
         logger.info(
             f"No test output directories matching '{dir_pattern}' "
@@ -2630,7 +2630,7 @@ def generate_tests_report(args, server_mode, model_spec, report_id, metadata={})
         )
         return empty_result
 
-    latest_dir = matching_dirs[-1]
+    latest_dir = max(matching_dirs, key=lambda d: d.stat().st_mtime)
     logger.info(f"Using latest test output directory: {latest_dir}")
 
     # Collect report file paths from parameter_report_*.json files

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -2601,76 +2601,113 @@ def evals_generate_report(args, server_mode, model_spec, report_id, metadata={})
 
 
 def generate_tests_report(args, server_mode, model_spec, report_id, metadata={}):
-    # glob on all test reports - each test category might produce its own report
-    file_name_pattern = f"test_{model_spec.model_id}_*/*"
-    file_path_pattern = (
-        f"{get_default_workflow_root_log_dir()}/tests_output/{file_name_pattern}"
-    )
-    files = glob(file_path_pattern)
     output_dir = Path(args.output_path) / "tests"
     output_dir.mkdir(parents=True, exist_ok=True)
     data_dir = output_dir / "data"
     data_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / f"summary_{report_id}.md"
 
+    empty_result = (
+        "",
+        [
+            {
+                "model": getattr(args, "model", "unknown_model"),
+                "device": getattr(args, "device", "unknown_device"),
+            }
+        ],
+        None,
+        None,
+    )
+
+    # Read the test manifest written by run_tests.py
+    tests_output_dir = get_default_workflow_root_log_dir() / "tests_output"
+    manifest_path = tests_output_dir / f"test_manifest_{model_spec.model_id}.json"
+    if not manifest_path.exists():
+        logger.info(f"No test manifest found at {manifest_path}. Skipping.")
+        return empty_result
+
+    with open(manifest_path, "r", encoding="utf-8") as f:
+        test_manifest = json.load(f)
+
     logger.info("Tests Summary")
-    logger.info(f"Processing: {len(files)} files")
-    if not files:
-        logger.info("No tests report files found. Skipping.")
-        return (
-            "",
-            [
-                {
-                    "model": getattr(args, "model", "unknown_model"),
-                    "device": getattr(args, "device", "unknown_device"),
-                }
-            ],
-            None,
-            None,
-        )
-    # When multiple test runs exist, use only the most recent result
-    files = max(files, key=lambda f: Path(f).stat().st_mtime)
-    logger.info(f"Selected most recent test report: {files}")
+    logger.info(f"Test manifest contains {len(test_manifest)} task(s)")
 
-    # generate vLLM parameter coverage report
-    markdown_str = generate_vllm_parameter_report(
-        files, output_path, report_id, metadata, model_spec=model_spec
-    )
-
-    # Look for parameter_report.json in tests_output directory
-    release_raw = None
-    test_dir_pattern = f"test_{model_spec.model_id}_*"
-    test_dir_path_pattern = (
-        f"{get_default_workflow_root_log_dir()}/tests_output/{test_dir_pattern}"
-    )
-    test_dirs = sorted(
-        glob(test_dir_path_pattern),
-        key=lambda d: Path(d).stat().st_mtime,
-        reverse=True,
-    )
-    for test_dir in test_dirs:
-        parameter_report_path = Path(test_dir) / "parameter_report.json"
+    # Collect (task_name, parameter_report.json path) from manifest entries
+    report_entries = []
+    for entry in test_manifest:
+        task_name = entry["task_name"]
+        parameter_report_path = Path(entry["output_dir"]) / "parameter_report.json"
         if parameter_report_path.exists():
-            try:
-                with open(parameter_report_path, "r", encoding="utf-8") as f:
-                    release_raw = json.load(f)
-                logger.info(f"Loaded parameter report from: {parameter_report_path}")
-                break
-            except Exception as e:
-                logger.warning(
-                    f"Could not read parameter report {parameter_report_path}: {e}"
-                )
+            report_entries.append((task_name, str(parameter_report_path)))
+            logger.info(
+                f"  Found report for task '{task_name}': {parameter_report_path}"
+            )
+        else:
+            logger.warning(
+                f"  No parameter_report.json for task '{task_name}' "
+                f"at {parameter_report_path}"
+            )
 
-    if release_raw is None:
-        logger.info("No parameter_report.json found in tests_output directory.")
+    if not report_entries:
+        logger.info("No parameter_report.json found in test output directories.")
+        return empty_result
+
+    logger.info(f"Processing {len(report_entries)} parameter report(s)")
+
+    # Generate vLLM parameter coverage report from all report files
+    # Pass (task_name, file_path) tuples for per-task sections when multiple tasks
+    if len(report_entries) == 1:
+        report_file_arg = report_entries[0][1]
+    else:
+        report_file_arg = report_entries
+    markdown_str = generate_vllm_parameter_report(
+        report_file_arg,
+        output_path,
+        report_id,
+        metadata,
+        model_spec=model_spec,
+    )
+
+    # Merge all parameter_report.json data into combined release_raw
+    release_raw_list = []
+    for _task_name, report_file in report_entries:
+        try:
+            with open(report_file, "r", encoding="utf-8") as f:
+                release_raw_list.append(json.load(f))
+            logger.info(f"Loaded parameter report from: {report_file}")
+        except Exception as e:
+            logger.warning(f"Could not read parameter report {report_file}: {e}")
+
+    if not release_raw_list:
         release_raw = [
             {
                 "model": getattr(args, "model", "unknown_model"),
                 "device": getattr(args, "device", "unknown_device"),
             }
         ]
+    elif len(release_raw_list) == 1:
+        release_raw = release_raw_list[0]
+    else:
+        # Merge results from multiple reports
+        release_raw = {
+            "endpoint_url": ", ".join(
+                r.get("endpoint_url", "N/A") for r in release_raw_list
+            ),
+            "model_name": release_raw_list[0].get("model_name", "unknown-model"),
+            "model_impl": release_raw_list[0].get("model_impl", "unknown-impl"),
+            "results": {},
+        }
+        for report_data in release_raw_list:
+            for test_case, tests in report_data.get("results", {}).items():
+                if test_case in release_raw["results"]:
+                    release_raw["results"][test_case].extend(tests)
+                else:
+                    release_raw["results"][test_case] = list(tests)
 
-    release_str = f"### Test Results for {model_spec.model_name} on {args.device}\n\n{markdown_str}"
+    release_str = (
+        f"### Test Results for {model_spec.model_name} on {args.device}"
+        f"\n\n{markdown_str}"
+    )
 
     # Write markdown report to file
     with output_path.open("w", encoding="utf-8") as f:

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -2619,34 +2619,29 @@ def generate_tests_report(args, server_mode, model_spec, report_id, metadata={})
         None,
     )
 
-    # Read the test manifest written by run_tests.py
+    # Find the latest test output directory for this model
     tests_output_dir = get_default_workflow_root_log_dir() / "tests_output"
-    manifest_path = tests_output_dir / f"test_manifest_{model_spec.model_id}.json"
-    if not manifest_path.exists():
-        logger.info(f"No test manifest found at {manifest_path}. Skipping.")
+    dir_pattern = f"test_{model_spec.model_id}__*"
+    matching_dirs = sorted(tests_output_dir.glob(dir_pattern))
+    if not matching_dirs:
+        logger.info(
+            f"No test output directories matching '{dir_pattern}' "
+            f"in {tests_output_dir}. Skipping."
+        )
         return empty_result
 
-    with open(manifest_path, "r", encoding="utf-8") as f:
-        test_manifest = json.load(f)
+    latest_dir = matching_dirs[-1]
+    logger.info(f"Using latest test output directory: {latest_dir}")
 
-    logger.info("Tests Summary")
-    logger.info(f"Test manifest contains {len(test_manifest)} task(s)")
-
-    # Collect (task_name, parameter_report.json path) from manifest entries
+    # Collect (task_name, report_path) from parameter_report_*.json files
     report_entries = []
-    for entry in test_manifest:
-        task_name = entry["task_name"]
-        parameter_report_path = Path(entry["output_dir"]) / "parameter_report.json"
-        if parameter_report_path.exists():
-            report_entries.append((task_name, str(parameter_report_path)))
-            logger.info(
-                f"  Found report for task '{task_name}': {parameter_report_path}"
-            )
-        else:
-            logger.warning(
-                f"  No parameter_report.json for task '{task_name}' "
-                f"at {parameter_report_path}"
-            )
+    for report_path in sorted(latest_dir.glob("parameter_report_*.json")):
+        # Extract task_name from filename: parameter_report_{task_name}.json
+        task_name = report_path.stem.replace("parameter_report_", "")
+        report_entries.append((task_name, str(report_path)))
+        logger.info(f"  Found report for task '{task_name}': {report_path}")
+
+    logger.info(f"Found {len(report_entries)} parameter report(s)")
 
     if not report_entries:
         logger.info("No parameter_report.json found in test output directories.")


### PR DESCRIPTION
closes https://github.com/tenstorrent/tt-inference-server/issues/2630

workflow:
- now one test_{model_id}__{timestamp}/ directory before the task loop instead of per-task directories
- build_test_command now takes output_dir_path directly (no longer creates its own), passes --task-name to conftest to generate the parameter_reports.json

CI test run:
https://github.com/tenstorrent/tt-shield/actions/runs/23817543061