### PR TITLE
Initial session manager

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -357,6 +357,8 @@ set(SOURCES
     src/services/llm_service.cpp
     src/services/memory_manager.cpp
     src/services/reasoning_parser.cpp
+    src/services/session_manager.cpp
+    src/domain/session.cpp
     src/utils/tokenizer.cpp
     src/utils/logger.cpp
     src/utils/deepseek_tokenizer.cpp

--- a/tt-media-server/cpp_server/include/api/llm_controller.hpp
+++ b/tt-media-server/cpp_server/include/api/llm_controller.hpp
@@ -70,10 +70,9 @@ class LLMController : public drogon::HttpController<LLMController> {
    * GET /v1/sessions/{session_id}/slot
    * Get the slot ID for a session.
    */
-  void getSlotId(
-      const drogon::HttpRequestPtr& req,
-      std::function<void(const drogon::HttpResponsePtr&)>&& callback,
-      const std::string& sessionId) const;
+  void getSlotId(const drogon::HttpRequestPtr& req,
+                 std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+                 const std::string& sessionId) const;
 
  private:
   std::shared_ptr<services::LLMService> service;

--- a/tt-media-server/cpp_server/include/api/llm_controller.hpp
+++ b/tt-media-server/cpp_server/include/api/llm_controller.hpp
@@ -10,6 +10,7 @@
 
 #include "services/disaggregation_service.hpp"
 #include "services/llm_service.hpp"
+#include "services/session_manager.hpp"
 
 namespace tt::api {
 
@@ -23,6 +24,11 @@ class LLMController : public drogon::HttpController<LLMController> {
   ADD_METHOD_TO(LLMController::completions, "/v1/completions", drogon::Post);
   ADD_METHOD_TO(LLMController::chatCompletions, "/v1/chat/completions",
                 drogon::Post);
+  ADD_METHOD_TO(LLMController::createSession, "/v1/sessions", drogon::Post);
+  ADD_METHOD_TO(LLMController::closeSession, "/v1/sessions/{session_id}",
+                drogon::Delete);
+  ADD_METHOD_TO(LLMController::getSlotId, "/v1/sessions/{session_id}/slot",
+                drogon::Get);
   METHOD_LIST_END
 
   LLMController();
@@ -43,9 +49,36 @@ class LLMController : public drogon::HttpController<LLMController> {
       const drogon::HttpRequestPtr& req,
       std::function<void(const drogon::HttpResponsePtr&)>&& callback) const;
 
+  /**
+   * POST /v1/sessions
+   * Create a new session with optional slot assignment.
+   */
+  void createSession(
+      const drogon::HttpRequestPtr& req,
+      std::function<void(const drogon::HttpResponsePtr&)>&& callback) const;
+
+  /**
+   * DELETE /v1/sessions/{session_id}
+   * Close an existing session.
+   */
+  void closeSession(
+      const drogon::HttpRequestPtr& req,
+      std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+      const std::string& sessionId) const;
+
+  /**
+   * GET /v1/sessions/{session_id}/slot
+   * Get the slot ID for a session.
+   */
+  void getSlotId(
+      const drogon::HttpRequestPtr& req,
+      std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+      const std::string& sessionId) const;
+
  private:
   std::shared_ptr<services::LLMService> service;
   std::shared_ptr<services::DisaggregationService> disaggregationService;
+  std::shared_ptr<services::SessionManager> sessionManager;
 
   /**
    * Handle streaming completion (SSE). When is_chat is true, emits

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -30,5 +30,6 @@ constexpr size_t MAX_ACCUMULATED_TOKENS = 5;
 constexpr size_t MAX_IN_FLIGHT_COUNT = 32;
 constexpr size_t MAX_SESSIONS_COUNT = 64;
 constexpr unsigned SESSION_EVICTION_RATE = 90;
+constexpr size_t SESSION_EVICTION_COUNT = 10;
 
 }  // namespace tt::config::defaults

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -28,5 +28,7 @@ constexpr const char* LLM_DEVICE_BACKEND =
 constexpr const bool ENABLE_ACCUMULATED_STREAMING = false;
 constexpr size_t MAX_ACCUMULATED_TOKENS = 5;
 constexpr size_t MAX_IN_FLIGHT_COUNT = 32;
+constexpr size_t MAX_SESSIONS_COUNT = 64;
+constexpr unsigned SESSION_EVICTION_RATE = 90;
 
 }  // namespace tt::config::defaults

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -101,6 +101,10 @@ size_t maxSessionsCount();
  * defaults::SESSION_EVICTION_RATE. */
 unsigned sessionEvictionRate();
 
+/** Number of sessions to evict at once from SESSION_EVICTION_COUNT. Default:
+ * defaults::SESSION_EVICTION_COUNT. */
+size_t sessionEvictionCount();
+
 /** Build LLMConfig from environment variables and runtime settings. Implemented
  * in src/config/settings.cpp. */
 LLMConfig llmEngineConfig();

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -93,6 +93,14 @@ SchedulingPolicy schedulingPolicy();
  * defaults::MAX_IN_FLIGHT_COUNT. */
 size_t maxInFlightCount();
 
+/** Max sessions count from MAX_SESSIONS_COUNT. Default:
+ * defaults::MAX_SESSIONS_COUNT. */
+size_t maxSessionsCount();
+
+/** Session eviction rate percentage from SESSION_EVICTION_RATE. Default:
+ * defaults::SESSION_EVICTION_RATE. */
+unsigned sessionEvictionRate();
+
 /** Build LLMConfig from environment variables and runtime settings. Implemented
  * in src/config/settings.cpp. */
 LLMConfig llmEngineConfig();

--- a/tt-media-server/cpp_server/include/domain/chat_completion_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/chat_completion_request.hpp
@@ -70,6 +70,9 @@ struct ChatCompletionRequest : BaseRequest {
   std::optional<int> prompt_logprobs;
   std::optional<int> truncate_prompt_tokens;
 
+  // Session management
+  std::optional<std::string> session_id;
+
   static ChatCompletionRequest fromJson(const Json::Value& json,
                                         TaskID taskId) {
     ChatCompletionRequest req(std::move(taskId));
@@ -164,6 +167,10 @@ struct ChatCompletionRequest : BaseRequest {
           json["spaces_between_special_tokens"].asBool();
     }
 
+    if (json.isMember("session_id") && !json["session_id"].isNull()) {
+      req.session_id = json["session_id"].asString();
+    }
+
     return req;
   }
 
@@ -226,6 +233,7 @@ struct ChatCompletionRequest : BaseRequest {
     out.allowed_token_ids = allowed_token_ids;
     out.prompt_logprobs = prompt_logprobs;
     out.truncate_prompt_tokens = truncate_prompt_tokens;
+    out.session_id = session_id;
     return out;
   }
 };

--- a/tt-media-server/cpp_server/include/domain/completion_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/completion_request.hpp
@@ -109,6 +109,9 @@ struct CompletionRequest : BaseRequest {
   std::optional<int> truncate_prompt_tokens;
   int prompt_tokens_count = 0;
 
+  // Session management
+  std::optional<std::string> session_id;
+
   static CompletionRequest fromJson(const Json::Value& json, TaskID taskId) {
     CompletionRequest req(std::move(taskId));
 

--- a/tt-media-server/cpp_server/include/domain/completion_response.hpp
+++ b/tt-media-server/cpp_server/include/domain/completion_response.hpp
@@ -22,7 +22,8 @@ struct CompletionUsage {
   int total_tokens = 0;
   std::optional<double> ttft_ms;  // Time to first token in milliseconds
   std::optional<double> tps;      // Tokens per second (excluding first token)
-  std::optional<std::string> session_id;  // Session ID if session management is used
+  std::optional<std::string>
+      session_id;  // Session ID if session management is used
 
   Json::Value toJson() const {
     Json::Value json;

--- a/tt-media-server/cpp_server/include/domain/completion_response.hpp
+++ b/tt-media-server/cpp_server/include/domain/completion_response.hpp
@@ -22,6 +22,7 @@ struct CompletionUsage {
   int total_tokens = 0;
   std::optional<double> ttft_ms;  // Time to first token in milliseconds
   std::optional<double> tps;      // Tokens per second (excluding first token)
+  std::optional<std::string> session_id;  // Session ID if session management is used
 
   Json::Value toJson() const {
     Json::Value json;
@@ -33,6 +34,9 @@ struct CompletionUsage {
     }
     if (tps.has_value()) {
       json["tps"] = tps.value();
+    }
+    if (session_id.has_value()) {
+      json["session_id"] = session_id.value();
     }
     return json;
   }

--- a/tt-media-server/cpp_server/include/domain/session.hpp
+++ b/tt-media-server/cpp_server/include/domain/session.hpp
@@ -5,6 +5,7 @@
 
 #include <json/json.h>
 
+#include <chrono>
 #include <optional>
 #include <random>
 #include <sstream>
@@ -45,6 +46,20 @@ class Session {
   bool hasSlot() const { return slot_id_ != -1; }
 
   /**
+   * Get the last activity time.
+   */
+  std::chrono::system_clock::time_point getLastActivityTime() const {
+    return last_activity_time_;
+  }
+
+  /**
+   * Update the last activity time to now.
+   */
+  void updateActivityTime() {
+    last_activity_time_ = std::chrono::system_clock::now();
+  }
+
+  /**
    * Convert to JSON representation.
    */
   Json::Value toJson() const {
@@ -57,6 +72,7 @@ class Session {
  private:
   std::string session_id_;
   int slot_id_;
+  std::chrono::system_clock::time_point last_activity_time_;
 
   /**
    * Generate a UUID v4 string.

--- a/tt-media-server/cpp_server/include/domain/session.hpp
+++ b/tt-media-server/cpp_server/include/domain/session.hpp
@@ -6,6 +6,8 @@
 #include <json/json.h>
 
 #include <chrono>
+#include <cstdint>
+#include <limits>
 #include <optional>
 #include <random>
 #include <sstream>
@@ -20,9 +22,9 @@ class Session {
  public:
   /**
    * Create a new session with a generated UUID.
-   * @param slotId Optional slot ID (-1 means unassigned)
+   * @param slotId Optional slot ID (max uint32_t means unassigned)
    */
-  explicit Session(int slotId = -1);
+  explicit Session(uint32_t slotId = std::numeric_limits<uint32_t>::max());
 
   /**
    * Get the session ID (UUID).
@@ -31,19 +33,21 @@ class Session {
 
   /**
    * Get the assigned slot ID.
-   * @return Slot ID, or -1 if unassigned
+   * @return Slot ID, or max uint32_t if unassigned
    */
-  int getSlotId() const { return slot_id_; }
+  uint32_t getSlotId() const { return slot_id_; }
 
   /**
    * Assign a slot ID to this session.
    */
-  void setSlotId(int slotId) { slot_id_ = slotId; }
+  void setSlotId(uint32_t slotId) { slot_id_ = slotId; }
 
   /**
    * Check if a slot is assigned.
    */
-  bool hasSlot() const { return slot_id_ != -1; }
+  bool hasSlot() const {
+    return slot_id_ != std::numeric_limits<uint32_t>::max();
+  }
 
   /**
    * Get the last activity time.
@@ -71,7 +75,7 @@ class Session {
 
  private:
   std::string session_id_;
-  int slot_id_;
+  uint32_t slot_id_;
   std::chrono::system_clock::time_point last_activity_time_;
 
   /**

--- a/tt-media-server/cpp_server/include/domain/session.hpp
+++ b/tt-media-server/cpp_server/include/domain/session.hpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <json/json.h>
+
+#include <optional>
+#include <random>
+#include <sstream>
+#include <string>
+
+namespace tt::domain {
+
+/**
+ * Session represents a user session with an optional slot assignment.
+ */
+class Session {
+ public:
+  /**
+   * Create a new session with a generated UUID.
+   * @param slotId Optional slot ID (-1 means unassigned)
+   */
+  explicit Session(int slotId = -1);
+
+  /**
+   * Get the session ID (UUID).
+   */
+  std::string getSessionId() const { return session_id_; }
+
+  /**
+   * Get the assigned slot ID.
+   * @return Slot ID, or -1 if unassigned
+   */
+  int getSlotId() const { return slot_id_; }
+
+  /**
+   * Assign a slot ID to this session.
+   */
+  void setSlotId(int slotId) { slot_id_ = slotId; }
+
+  /**
+   * Check if a slot is assigned.
+   */
+  bool hasSlot() const { return slot_id_ != -1; }
+
+  /**
+   * Convert to JSON representation.
+   */
+  Json::Value toJson() const {
+    Json::Value json;
+    json["session_id"] = session_id_;
+    json["slot_id"] = slot_id_;
+    return json;
+  }
+
+ private:
+  std::string session_id_;
+  int slot_id_;
+
+  /**
+   * Generate a UUID v4 string.
+   */
+  static std::string generateUuid();
+};
+
+}  // namespace tt::domain

--- a/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_model_runner.hpp
@@ -9,8 +9,8 @@
 #include <string>
 #include <vector>
 
-#include "runners/sp_prefill_runner/i_sp_prefill_model_runner.hpp"
 #include "runners/sp_pipeline_runner/shared_memory.hpp"
+#include "runners/sp_prefill_runner/i_sp_prefill_model_runner.hpp"
 
 namespace sp_prefill {
 

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -67,6 +67,18 @@ class SessionManager {
   size_t getActiveSessionCount() const;
 
  private:
+  /**
+   * Evict old sessions if the eviction threshold is exceeded.
+   * Called automatically when creating new sessions.
+   */
+  void evictOldSessions();
+
+  /**
+   * Find the oldest session (by last activity time).
+   * @return Optional session ID of the oldest session
+   */
+  std::optional<std::string> findOldestSession() const;
+
   mutable std::mutex mutex_;
   std::unordered_map<std::string, domain::Session> sessions_;
 };

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "domain/session.hpp"
+
+namespace tt::services {
+
+/**
+ * SessionManager manages user sessions and slot assignments.
+ */
+class SessionManager {
+ public:
+  SessionManager() = default;
+  ~SessionManager() = default;
+
+  // Non-copyable
+  SessionManager(const SessionManager&) = delete;
+  SessionManager& operator=(const SessionManager&) = delete;
+
+  /**
+   * Create a new session.
+   * @param slotId Optional slot ID to assign (-1 means unassigned)
+   * @return The created session
+   */
+  domain::Session createSession(std::optional<int> slotId = std::nullopt);
+
+  /**
+   * Close a session and remove it from the manager.
+   * @param sessionId The session ID to close
+   * @return true if session was found and closed, false otherwise
+   */
+  bool closeSession(const std::string& sessionId);
+
+  /**
+   * Assign a slot ID to an existing session.
+   * @param sessionId The session ID
+   * @param slotId The slot ID to assign
+   * @return true if session was found and slot assigned, false otherwise
+   */
+  bool assignSlotId(const std::string& sessionId, int slotId);
+
+  /**
+   * Get the slot ID for a session.
+   * @param sessionId The session ID
+   * @return The slot ID, or -1 if session not found or no slot assigned
+   */
+  int getSlotIdBySessionId(const std::string& sessionId) const;
+
+  /**
+   * Get a session by ID.
+   * @param sessionId The session ID
+   * @return Optional session object
+   */
+  std::optional<domain::Session> getSession(const std::string& sessionId) const;
+
+  /**
+   * Get the count of active sessions.
+   */
+  size_t getActiveSessionCount() const;
+
+ private:
+  mutable std::mutex mutex_;
+  std::unordered_map<std::string, domain::Session> sessions_;
+};
+
+}  // namespace tt::services

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -27,10 +27,10 @@ class SessionManager {
 
   /**
    * Create a new session.
-   * @param slotId Optional slot ID to assign (-1 means unassigned)
+   * @param slotId Optional slot ID to assign (max uint32_t means unassigned)
    * @return The created session
    */
-  domain::Session createSession(std::optional<int> slotId = std::nullopt);
+  domain::Session createSession(std::optional<uint32_t> slotId = std::nullopt);
 
   /**
    * Close a session and remove it from the manager.
@@ -45,14 +45,15 @@ class SessionManager {
    * @param slotId The slot ID to assign
    * @return true if session was found and slot assigned, false otherwise
    */
-  bool assignSlotId(const std::string& sessionId, int slotId);
+  bool assignSlotId(const std::string& sessionId, uint32_t slotId);
 
   /**
    * Get the slot ID for a session.
    * @param sessionId The session ID
-   * @return The slot ID, or -1 if session not found or no slot assigned
+   * @return The slot ID, or max uint32_t if session not found or no slot
+   * assigned
    */
-  int getSlotIdBySessionId(const std::string& sessionId) const;
+  uint32_t getSlotIdBySessionId(const std::string& sessionId) const;
 
   /**
    * Get a session by ID.

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -80,6 +80,13 @@ class SessionManager {
    */
   std::vector<std::string> findOldestSessions(size_t count) const;
 
+  /**
+   * Close a session without locking (assumes mutex is already locked).
+   * @param sessionId The session ID to close
+   * @return true if session was found and closed, false otherwise
+   */
+  bool closeSessionLocked(const std::string& sessionId);
+
   mutable std::mutex mutex_;
   std::unordered_map<std::string, domain::Session> sessions_;
 };

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -74,10 +74,11 @@ class SessionManager {
   void evictOldSessions();
 
   /**
-   * Find the oldest session (by last activity time).
-   * @return Optional session ID of the oldest session
+   * Find the N oldest sessions (by last activity time).
+   * @param count Number of oldest sessions to find
+   * @return Vector of session IDs, sorted from oldest to newest
    */
-  std::optional<std::string> findOldestSession() const;
+  std::vector<std::string> findOldestSessions(size_t count) const;
 
   mutable std::mutex mutex_;
   std::unordered_map<std::string, domain::Session> sessions_;

--- a/tt-media-server/cpp_server/include/utils/service_container.hpp
+++ b/tt-media-server/cpp_server/include/utils/service_container.hpp
@@ -10,6 +10,7 @@ namespace tt::services {
 class LLMService;
 class EmbeddingService;
 class DisaggregationService;
+class SessionManager;
 class IService;
 }  // namespace tt::services
 
@@ -35,7 +36,8 @@ class ServiceContainer {
       std::shared_ptr<services::LLMService> llm,
       std::shared_ptr<services::EmbeddingService> embedding,
       std::shared_ptr<sockets::InterServerService> socket,
-      std::shared_ptr<services::DisaggregationService> disaggregation);
+      std::shared_ptr<services::DisaggregationService> disaggregation,
+      std::shared_ptr<services::SessionManager> sessionMgr);
 
   std::shared_ptr<services::IService> configuredService() const;
 
@@ -49,6 +51,9 @@ class ServiceContainer {
   std::shared_ptr<services::DisaggregationService> disaggregation() const {
     return disaggregation_;
   }
+  std::shared_ptr<services::SessionManager> sessionManager() const {
+    return sessionManager_;
+  }
 
  private:
   ServiceContainer() = default;
@@ -57,6 +62,7 @@ class ServiceContainer {
   std::shared_ptr<services::EmbeddingService> embedding_;
   std::shared_ptr<sockets::InterServerService> socket_;
   std::shared_ptr<services::DisaggregationService> disaggregation_;
+  std::shared_ptr<services::SessionManager> sessionManager_;
 };
 
 }  // namespace tt::utils

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -531,14 +531,6 @@ void LLMController::handleStreaming(
 void LLMController::createSession(
     const drogon::HttpRequestPtr& req,
     std::function<void(const drogon::HttpResponsePtr&)>&& callback) const {
-  if (!sessionManager) {
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-        errorJson("Session management not available", "not_implemented"));
-    resp->setStatusCode(drogon::k501NotImplemented);
-    callback(resp);
-    return;
-  }
-
   try {
     std::optional<int> slotId;
 
@@ -574,14 +566,6 @@ void LLMController::closeSession(
     const drogon::HttpRequestPtr& req,
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     const std::string& sessionId) const {
-  if (!sessionManager) {
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-        errorJson("Session management not available", "not_implemented"));
-    resp->setStatusCode(drogon::k501NotImplemented);
-    callback(resp);
-    return;
-  }
-
   bool success = sessionManager->closeSession(sessionId);
 
   if (success) {
@@ -602,14 +586,6 @@ void LLMController::getSlotId(
     const drogon::HttpRequestPtr& req,
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     const std::string& sessionId) const {
-  if (!sessionManager) {
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-        errorJson("Session management not available", "not_implemented"));
-    resp->setStatusCode(drogon::k501NotImplemented);
-    callback(resp);
-    return;
-  }
-
   int slotId = sessionManager->getSlotIdBySessionId(sessionId);
 
   if (slotId == -1) {

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -381,16 +381,23 @@ void LLMController::handleStreaming(
         std::optional<domain::CompletionUsage> usage;
         if (CONTINUOUS_USAGE) {
           usage = domain::CompletionUsage{reqPtr->prompt_tokens_count,
-                                          CURRENT_TOKENS, CURRENT_TOKENS,
-                                          std::nullopt, std::nullopt, std::nullopt};
+                                          CURRENT_TOKENS,
+                                          CURRENT_TOKENS,
+                                          std::nullopt,
+                                          std::nullopt,
+                                          std::nullopt};
         }
         auto streamChunk = domain::ChatCompletionStreamChunk::makeContentChunk(
             COMPLETION_ID, MODEL, CREATED, chunk.choices[0], usage);
         if (firstContentChunk->exchange(false)) {
           std::optional<domain::CompletionUsage> initialUsage;
           if (CONTINUOUS_USAGE) {
-            initialUsage = domain::CompletionUsage{
-                reqPtr->prompt_tokens_count, 0, 0, std::nullopt, std::nullopt, std::nullopt};
+            initialUsage = domain::CompletionUsage{reqPtr->prompt_tokens_count,
+                                                   0,
+                                                   0,
+                                                   std::nullopt,
+                                                   std::nullopt,
+                                                   std::nullopt};
           }
           auto initialChunk =
               domain::ChatCompletionStreamChunk::makeInitialChunk(
@@ -423,8 +430,12 @@ void LLMController::handleStreaming(
           flushAccumulated(accumulator, streamPtr);
           if (INCLUDE_USAGE) {
             const int TOKENS = completionTokens->load();
-            domain::CompletionUsage usage{reqPtr->prompt_tokens_count, TOKENS,
-                                          TOKENS, std::nullopt, std::nullopt, std::nullopt};
+            domain::CompletionUsage usage{reqPtr->prompt_tokens_count,
+                                          TOKENS,
+                                          TOKENS,
+                                          std::nullopt,
+                                          std::nullopt,
+                                          std::nullopt};
 
             if (firstTokenTime->has_value()) {
               auto ttftDuration =
@@ -539,8 +550,7 @@ void LLMController::createSession(
       std::string errs;
 
       if (Json::parseFromStream(builder, bodyStream, &requestBody, &errs)) {
-        if (requestBody.isMember("slot_id") &&
-            requestBody["slot_id"].isInt()) {
+        if (requestBody.isMember("slot_id") && requestBody["slot_id"].isInt()) {
           slotId = requestBody["slot_id"].asInt();
         }
       }

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -534,7 +534,7 @@ void LLMController::createSession(
     const drogon::HttpRequestPtr& req,
     std::function<void(const drogon::HttpResponsePtr&)>&& callback) const {
   try {
-    std::optional<int> slotId;
+    std::optional<uint32_t> slotId;
 
     // Try to parse request body for optional slot_id
     if (req->getBody().length() > 0) {
@@ -544,8 +544,9 @@ void LLMController::createSession(
       std::string errs;
 
       if (Json::parseFromStream(builder, bodyStream, &requestBody, &errs)) {
-        if (requestBody.isMember("slot_id") && requestBody["slot_id"].isInt()) {
-          slotId = requestBody["slot_id"].asInt();
+        if (requestBody.isMember("slot_id") &&
+            requestBody["slot_id"].isUInt()) {
+          slotId = requestBody["slot_id"].asUInt();
         }
       }
     }
@@ -588,9 +589,9 @@ void LLMController::getSlotId(
     const drogon::HttpRequestPtr& req,
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     const std::string& sessionId) const {
-  int slotId = sessionManager->getSlotIdBySessionId(sessionId);
+  uint32_t slotId = sessionManager->getSlotIdBySessionId(sessionId);
 
-  if (slotId == -1) {
+  if (slotId == std::numeric_limits<uint32_t>::max()) {
     // Check if session exists at all
     auto session = sessionManager->getSession(sessionId);
     if (!session.has_value()) {

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -71,6 +71,7 @@ LLMController::LLMController() {
   const auto& c = tt::utils::ServiceContainer::instance();
   service = c.llm();
   disaggregationService = c.disaggregation();
+  sessionManager = c.sessionManager();
 
   if (!service) {
     throw std::runtime_error(
@@ -150,6 +151,15 @@ void LLMController::completions(
     handleStreaming(request, std::move(callback), false);
   } else {
     try {
+      // Create session if not provided
+      if (!request->session_id.has_value() && sessionManager) {
+        auto session = sessionManager->createSession(std::nullopt);
+        request->session_id = session.getSessionId();
+      }
+
+      // Save session_id before moving request
+      auto sessionId = request->session_id;
+
       auto startTime = std::chrono::high_resolution_clock::now();
       auto response = service->submitRequest(std::move(*request));
       auto endTime = std::chrono::high_resolution_clock::now();
@@ -166,6 +176,11 @@ void LLMController::completions(
           response.usage.tps =
               response.usage.completion_tokens * 1000.0 / totalDuration.count();
         }
+      }
+
+      // Include session_id in response if present
+      if (sessionId.has_value()) {
+        response.usage.session_id = sessionId;
       }
 
       auto resp = drogon::HttpResponse::newHttpResponse();
@@ -237,6 +252,15 @@ void LLMController::chatCompletions(
     handleStreaming(request, std::move(callback), true);
   } else {
     try {
+      // Create session if not provided
+      if (!request->session_id.has_value() && sessionManager) {
+        auto session = sessionManager->createSession(std::nullopt);
+        request->session_id = session.getSessionId();
+      }
+
+      // Save session_id before moving request
+      auto sessionId = request->session_id;
+
       auto startTime = std::chrono::high_resolution_clock::now();
       auto completion = service->submitRequest(std::move(*request));
       auto endTime = std::chrono::high_resolution_clock::now();
@@ -253,6 +277,11 @@ void LLMController::chatCompletions(
           completion.usage.tps = completion.usage.completion_tokens * 1000.0 /
                                  totalDuration.count();
         }
+      }
+
+      // Include session_id in response if present
+      if (sessionId.has_value()) {
+        completion.usage.session_id = sessionId;
       }
 
       auto chatResponse =
@@ -275,6 +304,12 @@ void LLMController::handleStreaming(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     bool isChat) const {
   ZoneScopedN("API::handleStreaming");
+
+  // Create session if not provided
+  if (!reqPtr->session_id.has_value() && sessionManager) {
+    auto session = sessionManager->createSession(std::nullopt);
+    reqPtr->session_id = session.getSessionId();
+  }
 
   const std::string COMPLETION_ID =
       (isChat ? "chatcmpl-" : "cmpl-") + reqPtr->task_id.id;
@@ -347,7 +382,7 @@ void LLMController::handleStreaming(
         if (CONTINUOUS_USAGE) {
           usage = domain::CompletionUsage{reqPtr->prompt_tokens_count,
                                           CURRENT_TOKENS, CURRENT_TOKENS,
-                                          std::nullopt, std::nullopt};
+                                          std::nullopt, std::nullopt, std::nullopt};
         }
         auto streamChunk = domain::ChatCompletionStreamChunk::makeContentChunk(
             COMPLETION_ID, MODEL, CREATED, chunk.choices[0], usage);
@@ -355,7 +390,7 @@ void LLMController::handleStreaming(
           std::optional<domain::CompletionUsage> initialUsage;
           if (CONTINUOUS_USAGE) {
             initialUsage = domain::CompletionUsage{
-                reqPtr->prompt_tokens_count, 0, 0, std::nullopt, std::nullopt};
+                reqPtr->prompt_tokens_count, 0, 0, std::nullopt, std::nullopt, std::nullopt};
           }
           auto initialChunk =
               domain::ChatCompletionStreamChunk::makeInitialChunk(
@@ -389,7 +424,7 @@ void LLMController::handleStreaming(
           if (INCLUDE_USAGE) {
             const int TOKENS = completionTokens->load();
             domain::CompletionUsage usage{reqPtr->prompt_tokens_count, TOKENS,
-                                          TOKENS, std::nullopt, std::nullopt};
+                                          TOKENS, std::nullopt, std::nullopt, std::nullopt};
 
             if (firstTokenTime->has_value()) {
               auto ttftDuration =
@@ -416,6 +451,11 @@ void LLMController::handleStreaming(
                 TT_LOG_DEBUG("[LLMController] Final TPS: {} tokens/sec",
                              usage.tps.value());
               }
+            }
+
+            // Include session_id in usage if present
+            if (reqPtr->session_id.has_value()) {
+              usage.session_id = reqPtr->session_id;
             }
 
             if (isChat) {
@@ -474,6 +514,110 @@ void LLMController::handleStreaming(
   resp->addHeader("Connection", "keep-alive");
   resp->addHeader("X-Accel-Buffering", "no");
 
+  callback(resp);
+}
+
+void LLMController::createSession(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback) const {
+  if (!sessionManager) {
+    auto resp = drogon::HttpResponse::newHttpJsonResponse(
+        errorJson("Session management not available", "not_implemented"));
+    resp->setStatusCode(drogon::k501NotImplemented);
+    callback(resp);
+    return;
+  }
+
+  try {
+    std::optional<int> slotId;
+
+    // Try to parse request body for optional slot_id
+    if (req->getBody().length() > 0) {
+      Json::Value requestBody;
+      Json::CharReaderBuilder builder;
+      std::istringstream bodyStream(std::string(req->getBody()));
+      std::string errs;
+
+      if (Json::parseFromStream(builder, bodyStream, &requestBody, &errs)) {
+        if (requestBody.isMember("slot_id") &&
+            requestBody["slot_id"].isInt()) {
+          slotId = requestBody["slot_id"].asInt();
+        }
+      }
+    }
+
+    auto session = sessionManager->createSession(slotId);
+
+    Json::Value response = session.toJson();
+    auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
+    resp->setStatusCode(drogon::k201Created);
+    callback(resp);
+  } catch (const std::exception& e) {
+    auto resp = drogon::HttpResponse::newHttpJsonResponse(
+        errorJson(e.what(), "internal_error"));
+    resp->setStatusCode(drogon::k500InternalServerError);
+    callback(resp);
+  }
+}
+
+void LLMController::closeSession(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    const std::string& sessionId) const {
+  if (!sessionManager) {
+    auto resp = drogon::HttpResponse::newHttpJsonResponse(
+        errorJson("Session management not available", "not_implemented"));
+    resp->setStatusCode(drogon::k501NotImplemented);
+    callback(resp);
+    return;
+  }
+
+  bool success = sessionManager->closeSession(sessionId);
+
+  if (success) {
+    Json::Value response;
+    response["success"] = true;
+    response["message"] = "Session closed";
+    auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
+    callback(resp);
+  } else {
+    auto resp = drogon::HttpResponse::newHttpJsonResponse(
+        errorJson("Session not found", "not_found"));
+    resp->setStatusCode(drogon::k404NotFound);
+    callback(resp);
+  }
+}
+
+void LLMController::getSlotId(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    const std::string& sessionId) const {
+  if (!sessionManager) {
+    auto resp = drogon::HttpResponse::newHttpJsonResponse(
+        errorJson("Session management not available", "not_implemented"));
+    resp->setStatusCode(drogon::k501NotImplemented);
+    callback(resp);
+    return;
+  }
+
+  int slotId = sessionManager->getSlotIdBySessionId(sessionId);
+
+  if (slotId == -1) {
+    // Check if session exists at all
+    auto session = sessionManager->getSession(sessionId);
+    if (!session.has_value()) {
+      auto resp = drogon::HttpResponse::newHttpJsonResponse(
+          errorJson("Session not found", "not_found"));
+      resp->setStatusCode(drogon::k404NotFound);
+      callback(resp);
+      return;
+    }
+  }
+
+  Json::Value response;
+  response["session_id"] = sessionId;
+  response["slot_id"] = slotId;
+  auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
   callback(resp);
 }
 

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -380,10 +380,14 @@ void LLMController::handleStreaming(
       if (isChat) {
         std::optional<domain::CompletionUsage> usage;
         if (continuousUsage) {
-          usage = domain::CompletionUsage{reqPtr->prompt_tokens_count,
-                                          currentTokens, currentTokens,
-                                          std::nullopt,
-                                          std::nullopt, std::nullopt, };
+          usage = domain::CompletionUsage{
+              reqPtr->prompt_tokens_count,
+              currentTokens,
+              currentTokens,
+              std::nullopt,
+              std::nullopt,
+              std::nullopt,
+          };
         }
         auto streamChunk = domain::ChatCompletionStreamChunk::makeContentChunk(
             completionId, model, created, chunk.choices[0], usage);

--- a/tt-media-server/cpp_server/src/api/openapi.cpp
+++ b/tt-media-server/cpp_server/src/api/openapi.cpp
@@ -141,8 +141,7 @@ class OpenAPIController : public drogon::HttpController<OpenAPIController> {
     paths["/v1/sessions"]["post"] = buildCreateSessionEndpoint();
 
     // DELETE /v1/sessions/{session_id}
-    paths["/v1/sessions/{session_id}"]["delete"] =
-        buildCloseSessionEndpoint();
+    paths["/v1/sessions/{session_id}"]["delete"] = buildCloseSessionEndpoint();
 
     // GET /v1/sessions/{session_id}/slot
     paths["/v1/sessions/{session_id}/slot"]["get"] = buildGetSlotIdEndpoint();

--- a/tt-media-server/cpp_server/src/api/openapi.cpp
+++ b/tt-media-server/cpp_server/src/api/openapi.cpp
@@ -118,6 +118,10 @@ class OpenAPIController : public drogon::HttpController<OpenAPIController> {
     completionsTag["description"] =
         "OpenAI-compatible text completion endpoints";
     tags.append(completionsTag);
+    Json::Value sessionsTag;
+    sessionsTag["name"] = "Sessions";
+    sessionsTag["description"] = "Session management for slot assignments";
+    tags.append(sessionsTag);
     Json::Value healthTag;
     healthTag["name"] = "Health";
     healthTag["description"] = "Server health and liveness endpoints";
@@ -132,6 +136,16 @@ class OpenAPIController : public drogon::HttpController<OpenAPIController> {
 
     // POST /v1/chat/completions
     paths["/v1/chat/completions"]["post"] = buildChatCompletionsEndpoint();
+
+    // POST /v1/sessions
+    paths["/v1/sessions"]["post"] = buildCreateSessionEndpoint();
+
+    // DELETE /v1/sessions/{session_id}
+    paths["/v1/sessions/{session_id}"]["delete"] =
+        buildCloseSessionEndpoint();
+
+    // GET /v1/sessions/{session_id}/slot
+    paths["/v1/sessions/{session_id}/slot"]["get"] = buildGetSlotIdEndpoint();
 
     // GET /health
     paths["/health"]["get"] = buildHealthEndpoint();
@@ -331,6 +345,152 @@ class OpenAPIController : public drogon::HttpController<OpenAPIController> {
 
     endpoint["responses"] = responses;
 
+    return endpoint;
+  }
+
+  Json::Value buildCreateSessionEndpoint() {
+    Json::Value endpoint;
+    endpoint["tags"].append("Sessions");
+    endpoint["summary"] = "Create a new session";
+    endpoint["description"] =
+        "Create a new session with optional slot assignment";
+    endpoint["operationId"] = "createSession";
+
+    // Security requirement - Bearer token
+    Json::Value security(Json::arrayValue);
+    Json::Value bearerAuth;
+    bearerAuth["BearerAuth"] = Json::Value(Json::arrayValue);
+    security.append(bearerAuth);
+    endpoint["security"] = security;
+
+    // Request body
+    Json::Value requestBody;
+    requestBody["description"] = "Optional slot ID to assign";
+    Json::Value schema;
+    schema["type"] = "object";
+    schema["properties"]["slot_id"]["type"] = "integer";
+    schema["properties"]["slot_id"]["description"] =
+        "Slot ID to assign (-1 means unassigned)";
+    requestBody["content"]["application/json"]["schema"] = schema;
+    endpoint["requestBody"] = requestBody;
+
+    // Responses
+    Json::Value responses;
+    Json::Value resp201;
+    resp201["description"] = "Session created successfully";
+    Json::Value respSchema;
+    respSchema["type"] = "object";
+    respSchema["properties"]["session_id"]["type"] = "string";
+    respSchema["properties"]["session_id"]["format"] = "uuid";
+    respSchema["properties"]["slot_id"]["type"] = "integer";
+    resp201["content"]["application/json"]["schema"] = respSchema;
+    responses["201"] = resp201;
+
+    Json::Value resp500;
+    resp500["description"] = "Internal server error";
+    resp500["content"]["application/json"]["schema"]["$ref"] =
+        "#/components/schemas/Error";
+    responses["500"] = resp500;
+
+    endpoint["responses"] = responses;
+    return endpoint;
+  }
+
+  Json::Value buildCloseSessionEndpoint() {
+    Json::Value endpoint;
+    endpoint["tags"].append("Sessions");
+    endpoint["summary"] = "Close a session";
+    endpoint["description"] = "Close an existing session by ID";
+    endpoint["operationId"] = "closeSession";
+
+    // Security requirement - Bearer token
+    Json::Value security(Json::arrayValue);
+    Json::Value bearerAuth;
+    bearerAuth["BearerAuth"] = Json::Value(Json::arrayValue);
+    security.append(bearerAuth);
+    endpoint["security"] = security;
+
+    // Path parameters
+    Json::Value parameters(Json::arrayValue);
+    Json::Value param;
+    param["name"] = "session_id";
+    param["in"] = "path";
+    param["required"] = true;
+    param["description"] = "The session ID to close";
+    param["schema"]["type"] = "string";
+    param["schema"]["format"] = "uuid";
+    parameters.append(param);
+    endpoint["parameters"] = parameters;
+
+    // Responses
+    Json::Value responses;
+    Json::Value resp200;
+    resp200["description"] = "Session closed successfully";
+    Json::Value respSchema;
+    respSchema["type"] = "object";
+    respSchema["properties"]["success"]["type"] = "boolean";
+    respSchema["properties"]["message"]["type"] = "string";
+    resp200["content"]["application/json"]["schema"] = respSchema;
+    responses["200"] = resp200;
+
+    Json::Value resp404;
+    resp404["description"] = "Session not found";
+    resp404["content"]["application/json"]["schema"]["$ref"] =
+        "#/components/schemas/Error";
+    responses["404"] = resp404;
+
+    endpoint["responses"] = responses;
+    return endpoint;
+  }
+
+  Json::Value buildGetSlotIdEndpoint() {
+    Json::Value endpoint;
+    endpoint["tags"].append("Sessions");
+    endpoint["summary"] = "Get slot ID for a session";
+    endpoint["description"] =
+        "Retrieve the slot ID assigned to a session (-1 if unassigned)";
+    endpoint["operationId"] = "getSlotId";
+
+    // Security requirement - Bearer token
+    Json::Value security(Json::arrayValue);
+    Json::Value bearerAuth;
+    bearerAuth["BearerAuth"] = Json::Value(Json::arrayValue);
+    security.append(bearerAuth);
+    endpoint["security"] = security;
+
+    // Path parameters
+    Json::Value parameters(Json::arrayValue);
+    Json::Value param;
+    param["name"] = "session_id";
+    param["in"] = "path";
+    param["required"] = true;
+    param["description"] = "The session ID";
+    param["schema"]["type"] = "string";
+    param["schema"]["format"] = "uuid";
+    parameters.append(param);
+    endpoint["parameters"] = parameters;
+
+    // Responses
+    Json::Value responses;
+    Json::Value resp200;
+    resp200["description"] = "Slot ID retrieved successfully";
+    Json::Value respSchema;
+    respSchema["type"] = "object";
+    respSchema["properties"]["session_id"]["type"] = "string";
+    respSchema["properties"]["session_id"]["format"] = "uuid";
+    respSchema["properties"]["slot_id"]["type"] = "integer";
+    respSchema["properties"]["slot_id"]["description"] =
+        "Slot ID (-1 if unassigned)";
+    resp200["content"]["application/json"]["schema"] = respSchema;
+    responses["200"] = resp200;
+
+    Json::Value resp404;
+    resp404["description"] = "Session not found";
+    resp404["content"]["application/json"]["schema"]["$ref"] =
+        "#/components/schemas/Error";
+    responses["404"] = resp404;
+
+    endpoint["responses"] = responses;
     return endpoint;
   }
 

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -237,4 +237,9 @@ unsigned sessionEvictionRate() {
       envUlong("SESSION_EVICTION_RATE", defaults::SESSION_EVICTION_RATE));
 }
 
+size_t sessionEvictionCount() {
+  return static_cast<size_t>(
+      envUlong("SESSION_EVICTION_COUNT", defaults::SESSION_EVICTION_COUNT));
+}
+
 }  // namespace tt::config

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -227,4 +227,14 @@ size_t maxQueueSize() {
       envUlong("MAX_QUEUE_SIZE", defaults::MAX_QUEUE_SIZE));
 }
 
+size_t maxSessionsCount() {
+  return static_cast<size_t>(
+      envUlong("MAX_SESSIONS_COUNT", defaults::MAX_SESSIONS_COUNT));
+}
+
+unsigned sessionEvictionRate() {
+  return static_cast<unsigned>(
+      envUlong("SESSION_EVICTION_RATE", defaults::SESSION_EVICTION_RATE));
+}
+
 }  // namespace tt::config

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -16,22 +16,23 @@ std::string Session::generateUuid() {
   static std::mutex genMutex;
   static std::random_device rd;
   static std::mt19937_64 gen(rd());
-  
+
   std::lock_guard<std::mutex> lock(genMutex);
-  
+
   // Generate two 64-bit random numbers
   uint64_t part1 = gen();
   uint64_t part2 = gen();
-  
+
   // Format as UUID v4: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
   std::ostringstream ss;
   ss << std::hex << std::setfill('0');
   ss << std::setw(8) << (part1 & 0xFFFFFFFF) << '-';
   ss << std::setw(4) << ((part1 >> 32) & 0xFFFF) << '-';
   ss << "4" << std::setw(3) << ((part1 >> 48) & 0x0FFF) << '-';
-  ss << std::setw(1) << (8 | ((part2 & 0x3))) << std::setw(3) << ((part2 >> 2) & 0xFFF) << '-';
+  ss << std::setw(1) << (8 | ((part2 & 0x3))) << std::setw(3)
+     << ((part2 >> 2) & 0xFFF) << '-';
   ss << std::setw(12) << ((part2 >> 14) & 0xFFFFFFFFFFFF);
-  
+
   return ss.str();
 }
 

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -9,8 +9,7 @@
 namespace tt::domain {
 
 Session::Session(int slotId)
-    : slot_id_(slotId),
-      last_activity_time_(std::chrono::system_clock::now()) {
+    : slot_id_(slotId), last_activity_time_(std::chrono::system_clock::now()) {
   session_id_ = generateUuid();
 }
 

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -8,7 +8,7 @@
 
 namespace tt::domain {
 
-Session::Session(int slotId)
+Session::Session(uint32_t slotId)
     : slot_id_(slotId), last_activity_time_(std::chrono::system_clock::now()) {
   session_id_ = generateUuid();
 }

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -8,7 +8,9 @@
 
 namespace tt::domain {
 
-Session::Session(int slotId) : slot_id_(slotId) {
+Session::Session(int slotId)
+    : slot_id_(slotId),
+      last_activity_time_(std::chrono::system_clock::now()) {
   session_id_ = generateUuid();
 }
 

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#include "domain/session.hpp"
+
+#include <iomanip>
+#include <mutex>
+
+namespace tt::domain {
+
+Session::Session(int slotId) : slot_id_(slotId) {
+  session_id_ = generateUuid();
+}
+
+std::string Session::generateUuid() {
+  static std::mutex genMutex;
+  static std::random_device rd;
+  static std::mt19937_64 gen(rd());
+  
+  std::lock_guard<std::mutex> lock(genMutex);
+  
+  // Generate two 64-bit random numbers
+  uint64_t part1 = gen();
+  uint64_t part2 = gen();
+  
+  // Format as UUID v4: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+  std::ostringstream ss;
+  ss << std::hex << std::setfill('0');
+  ss << std::setw(8) << (part1 & 0xFFFFFFFF) << '-';
+  ss << std::setw(4) << ((part1 >> 32) & 0xFFFF) << '-';
+  ss << "4" << std::setw(3) << ((part1 >> 48) & 0x0FFF) << '-';
+  ss << std::setw(1) << (8 | ((part2 & 0x3))) << std::setw(3) << ((part2 >> 2) & 0xFFF) << '-';
+  ss << std::setw(12) << ((part2 >> 14) & 0xFFFFFFFFFFFF);
+  
+  return ss.str();
+}
+
+}  // namespace tt::domain

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -304,7 +304,7 @@ domain::CompletionResponse LLMService::processRequest(
 
   response.usage = {PROMPT_TOKENS, completionTokens,
                     PROMPT_TOKENS + completionTokens, std::nullopt,
-                    std::nullopt};
+                    std::nullopt, std::nullopt};
 
   return response;
 }

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -302,9 +302,9 @@ domain::CompletionResponse LLMService::processRequest(
   choice.finish_reason = finishReason;
   response.choices.push_back(std::move(choice));
 
-  response.usage = {PROMPT_TOKENS, completionTokens,
-                    PROMPT_TOKENS + completionTokens, std::nullopt,
-                    std::nullopt, std::nullopt};
+  response.usage = {
+      PROMPT_TOKENS, completionTokens, PROMPT_TOKENS + completionTokens,
+      std::nullopt,  std::nullopt,     std::nullopt};
 
   return response;
 }

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -362,9 +362,9 @@ domain::CompletionResponse LLMService::processRequest(
   choice.finish_reason = finishReason;
   response.choices.push_back(std::move(choice));
 
-  response.usage = {promptTokens, completionTokens,
-                    promptTokens + completionTokens, std::nullopt,
-                    std::nullopt, std::nullopt};
+  response.usage = {
+      promptTokens, completionTokens, promptTokens + completionTokens,
+      std::nullopt, std::nullopt,     std::nullopt};
 
   return response;
 }

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -30,7 +30,11 @@ domain::Session SessionManager::createSession(std::optional<int> slotId) {
 
 bool SessionManager::closeSession(const std::string& sessionId) {
   std::lock_guard<std::mutex> lock(mutex_);
+  return closeSessionLocked(sessionId);
+}
 
+bool SessionManager::closeSessionLocked(const std::string& sessionId) {
+  // Note: mutex_ must already be locked by caller
   auto it = sessions_.find(sessionId);
   if (it == sessions_.end()) {
     TT_LOG_WARN("[SessionManager] Session not found: {}", sessionId);
@@ -106,7 +110,7 @@ void SessionManager::evictOldSessions() {
 
     if (!oldestSessions.empty()) {
       for (const auto& sessionId : oldestSessions) {
-        sessions_.erase(sessionId);
+        closeSessionLocked(sessionId);
       }
 
       TT_LOG_INFO(

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -3,12 +3,16 @@
 
 #include "services/session_manager.hpp"
 
+#include "config/settings.hpp"
 #include "utils/logger.hpp"
 
 namespace tt::services {
 
 domain::Session SessionManager::createSession(std::optional<int> slotId) {
   std::lock_guard<std::mutex> lock(mutex_);
+
+  // Check if we need to evict old sessions
+  evictOldSessions();
 
   int slot = slotId.value_or(-1);
   domain::Session session(slot);
@@ -60,6 +64,9 @@ int SessionManager::getSlotIdBySessionId(const std::string& sessionId) const {
     return -1;
   }
 
+  // Update activity time (mutable access through const_cast for this use case)
+  const_cast<domain::Session&>(it->second).updateActivityTime();
+
   return it->second.getSlotId();
 }
 
@@ -78,6 +85,49 @@ std::optional<domain::Session> SessionManager::getSession(
 size_t SessionManager::getActiveSessionCount() const {
   std::lock_guard<std::mutex> lock(mutex_);
   return sessions_.size();
+}
+
+void SessionManager::evictOldSessions() {
+  // Note: mutex_ is already locked by the caller (createSession)
+
+  size_t maxSessions = tt::config::maxSessionsCount();
+  unsigned evictionRate = tt::config::sessionEvictionRate();
+
+  size_t activeCount = sessions_.size();
+
+  // Calculate if we've exceeded the eviction threshold
+  // (activeCount / maxSessions) * 100 > evictionRate
+  if (activeCount * 100 > maxSessions * evictionRate) {
+    auto oldestSessionId = findOldestSession();
+    if (oldestSessionId.has_value()) {
+      closeSession(oldestSessionId.value());
+      TT_LOG_INFO(
+          "[SessionManager] Evicted oldest session: {} (active: {}/{}, "
+          "threshold: {}%)",
+          oldestSessionId.value(), activeCount, maxSessions, evictionRate);
+    }
+  }
+}
+
+std::optional<std::string> SessionManager::findOldestSession() const {
+  // Note: mutex_ is already locked by the caller
+
+  if (sessions_.empty()) {
+    return std::nullopt;
+  }
+
+  auto oldestIt = sessions_.begin();
+  auto oldestTime = oldestIt->second.getLastActivityTime();
+
+  for (auto it = sessions_.begin(); it != sessions_.end(); ++it) {
+    auto activityTime = it->second.getLastActivityTime();
+    if (activityTime < oldestTime) {
+      oldestTime = activityTime;
+      oldestIt = it;
+    }
+  }
+
+  return oldestIt->first;
 }
 
 }  // namespace tt::services

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -16,8 +16,8 @@ domain::Session SessionManager::createSession(std::optional<int> slotId) {
   std::string sessionId = session.getSessionId();
   sessions_[sessionId] = session;
 
-  TT_LOG_INFO("[SessionManager] Created session: {} with slot: {}",
-              sessionId, slot);
+  TT_LOG_INFO("[SessionManager] Created session: {} with slot: {}", sessionId,
+              slot);
 
   return session;
 }

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#include "services/session_manager.hpp"
+
+#include "utils/logger.hpp"
+
+namespace tt::services {
+
+domain::Session SessionManager::createSession(std::optional<int> slotId) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  int slot = slotId.value_or(-1);
+  domain::Session session(slot);
+
+  std::string sessionId = session.getSessionId();
+  sessions_[sessionId] = session;
+
+  TT_LOG_INFO("[SessionManager] Created session: {} with slot: {}",
+              sessionId, slot);
+
+  return session;
+}
+
+bool SessionManager::closeSession(const std::string& sessionId) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = sessions_.find(sessionId);
+  if (it == sessions_.end()) {
+    TT_LOG_WARN("[SessionManager] Session not found: {}", sessionId);
+    return false;
+  }
+
+  sessions_.erase(it);
+  TT_LOG_INFO("[SessionManager] Closed session: {}", sessionId);
+  return true;
+}
+
+bool SessionManager::assignSlotId(const std::string& sessionId, int slotId) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = sessions_.find(sessionId);
+  if (it == sessions_.end()) {
+    TT_LOG_WARN("[SessionManager] Session not found for slot assignment: {}",
+                sessionId);
+    return false;
+  }
+
+  it->second.setSlotId(slotId);
+  TT_LOG_INFO("[SessionManager] Assigned slot {} to session {}", slotId,
+              sessionId);
+  return true;
+}
+
+int SessionManager::getSlotIdBySessionId(const std::string& sessionId) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = sessions_.find(sessionId);
+  if (it == sessions_.end()) {
+    return -1;
+  }
+
+  return it->second.getSlotId();
+}
+
+std::optional<domain::Session> SessionManager::getSession(
+    const std::string& sessionId) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = sessions_.find(sessionId);
+  if (it == sessions_.end()) {
+    return std::nullopt;
+  }
+
+  return it->second;
+}
+
+size_t SessionManager::getActiveSessionCount() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return sessions_.size();
+}
+
+}  // namespace tt::services

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -3,6 +3,8 @@
 
 #include "services/session_manager.hpp"
 
+#include <algorithm>
+
 #include "config/settings.hpp"
 #include "utils/logger.hpp"
 
@@ -92,42 +94,63 @@ void SessionManager::evictOldSessions() {
 
   size_t maxSessions = tt::config::maxSessionsCount();
   unsigned evictionRate = tt::config::sessionEvictionRate();
+  size_t evictionCount = tt::config::sessionEvictionCount();
 
   size_t activeCount = sessions_.size();
 
   // Calculate if we've exceeded the eviction threshold
   // (activeCount / maxSessions) * 100 > evictionRate
   if (activeCount * 100 > maxSessions * evictionRate) {
-    auto oldestSessionId = findOldestSession();
-    if (oldestSessionId.has_value()) {
-      closeSession(oldestSessionId.value());
+    // Find and evict the oldest sessions
+    auto oldestSessions = findOldestSessions(evictionCount);
+
+    if (!oldestSessions.empty()) {
+      for (const auto& sessionId : oldestSessions) {
+        sessions_.erase(sessionId);
+      }
+
       TT_LOG_INFO(
-          "[SessionManager] Evicted oldest session: {} (active: {}/{}, "
+          "[SessionManager] Evicted {} oldest session(s) (active: {}/{}, "
           "threshold: {}%)",
-          oldestSessionId.value(), activeCount, maxSessions, evictionRate);
+          oldestSessions.size(), activeCount, maxSessions, evictionRate);
     }
   }
 }
 
-std::optional<std::string> SessionManager::findOldestSession() const {
+std::vector<std::string> SessionManager::findOldestSessions(size_t count) const {
   // Note: mutex_ is already locked by the caller
 
   if (sessions_.empty()) {
-    return std::nullopt;
+    return {};
   }
 
-  auto oldestIt = sessions_.begin();
-  auto oldestTime = oldestIt->second.getLastActivityTime();
+  // Create a vector of (sessionId, activityTime) pairs
+  std::vector<std::pair<std::string, std::chrono::system_clock::time_point>> sessionTimes;
+  sessionTimes.reserve(sessions_.size());
 
-  for (auto it = sessions_.begin(); it != sessions_.end(); ++it) {
-    auto activityTime = it->second.getLastActivityTime();
-    if (activityTime < oldestTime) {
-      oldestTime = activityTime;
-      oldestIt = it;
-    }
+  for (const auto& [sessionId, session] : sessions_) {
+    sessionTimes.emplace_back(sessionId, session.getLastActivityTime());
   }
 
-  return oldestIt->first;
+  // Sort by activity time (oldest first)
+  std::partial_sort(
+      sessionTimes.begin(),
+      sessionTimes.begin() + std::min(count, sessionTimes.size()),
+      sessionTimes.end(),
+      [](const auto& a, const auto& b) {
+        return a.second < b.second;
+      });
+
+  // Extract session IDs
+  std::vector<std::string> result;
+  size_t numToEvict = std::min(count, sessionTimes.size());
+  result.reserve(numToEvict);
+
+  for (size_t i = 0; i < numToEvict; ++i) {
+    result.push_back(sessionTimes[i].first);
+  }
+
+  return result;
 }
 
 }  // namespace tt::services

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -4,19 +4,20 @@
 #include "services/session_manager.hpp"
 
 #include <algorithm>
+#include <limits>
 
 #include "config/settings.hpp"
 #include "utils/logger.hpp"
 
 namespace tt::services {
 
-domain::Session SessionManager::createSession(std::optional<int> slotId) {
+domain::Session SessionManager::createSession(std::optional<uint32_t> slotId) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   // Check if we need to evict old sessions
   evictOldSessions();
 
-  int slot = slotId.value_or(-1);
+  uint32_t slot = slotId.value_or(std::numeric_limits<uint32_t>::max());
   domain::Session session(slot);
 
   std::string sessionId = session.getSessionId();
@@ -46,7 +47,8 @@ bool SessionManager::closeSessionLocked(const std::string& sessionId) {
   return true;
 }
 
-bool SessionManager::assignSlotId(const std::string& sessionId, int slotId) {
+bool SessionManager::assignSlotId(const std::string& sessionId,
+                                  uint32_t slotId) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   auto it = sessions_.find(sessionId);
@@ -62,12 +64,13 @@ bool SessionManager::assignSlotId(const std::string& sessionId, int slotId) {
   return true;
 }
 
-int SessionManager::getSlotIdBySessionId(const std::string& sessionId) const {
+uint32_t SessionManager::getSlotIdBySessionId(
+    const std::string& sessionId) const {
   std::lock_guard<std::mutex> lock(mutex_);
 
   auto it = sessions_.find(sessionId);
   if (it == sessions_.end()) {
-    return -1;
+    return std::numeric_limits<uint32_t>::max();
   }
 
   // Update activity time (mutable access through const_cast for this use case)

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -117,7 +117,8 @@ void SessionManager::evictOldSessions() {
   }
 }
 
-std::vector<std::string> SessionManager::findOldestSessions(size_t count) const {
+std::vector<std::string> SessionManager::findOldestSessions(
+    size_t count) const {
   // Note: mutex_ is already locked by the caller
 
   if (sessions_.empty()) {
@@ -125,7 +126,8 @@ std::vector<std::string> SessionManager::findOldestSessions(size_t count) const 
   }
 
   // Create a vector of (sessionId, activityTime) pairs
-  std::vector<std::pair<std::string, std::chrono::system_clock::time_point>> sessionTimes;
+  std::vector<std::pair<std::string, std::chrono::system_clock::time_point>>
+      sessionTimes;
   sessionTimes.reserve(sessions_.size());
 
   for (const auto& [sessionId, session] : sessions_) {
@@ -133,13 +135,11 @@ std::vector<std::string> SessionManager::findOldestSessions(size_t count) const 
   }
 
   // Sort by activity time (oldest first)
-  std::partial_sort(
-      sessionTimes.begin(),
-      sessionTimes.begin() + std::min(count, sessionTimes.size()),
-      sessionTimes.end(),
-      [](const auto& a, const auto& b) {
-        return a.second < b.second;
-      });
+  std::partial_sort(sessionTimes.begin(),
+                    sessionTimes.begin() + std::min(count, sessionTimes.size()),
+                    sessionTimes.end(), [](const auto& a, const auto& b) {
+                      return a.second < b.second;
+                    });
 
   // Extract session IDs
   std::vector<std::string> result;

--- a/tt-media-server/cpp_server/src/utils/service_container.cpp
+++ b/tt-media-server/cpp_server/src/utils/service_container.cpp
@@ -13,11 +13,13 @@ void ServiceContainer::initialize(
     std::shared_ptr<services::LLMService> llm,
     std::shared_ptr<services::EmbeddingService> embedding,
     std::shared_ptr<sockets::InterServerService> socket,
-    std::shared_ptr<services::DisaggregationService> disaggregation) {
+    std::shared_ptr<services::DisaggregationService> disaggregation,
+    std::shared_ptr<services::SessionManager> sessionMgr) {
   llm_ = std::move(llm);
   embedding_ = std::move(embedding);
   socket_ = std::move(socket);
   disaggregation_ = std::move(disaggregation);
+  sessionManager_ = std::move(sessionMgr);
 }
 
 std::shared_ptr<services::IService> ServiceContainer::configuredService()

--- a/tt-media-server/cpp_server/src/utils/service_factory.cpp
+++ b/tt-media-server/cpp_server/src/utils/service_factory.cpp
@@ -10,6 +10,7 @@
 #include "services/disaggregation_service.hpp"
 #include "services/embedding_service.hpp"
 #include "services/llm_service.hpp"
+#include "services/session_manager.hpp"
 #include "sockets/inter_server_service.hpp"
 #include "utils/logger.hpp"
 
@@ -24,6 +25,10 @@ void initializeServices() {
   std::shared_ptr<services::EmbeddingService> embedding;
   std::shared_ptr<sockets::InterServerService> socket;
   std::shared_ptr<services::DisaggregationService> disaggregation;
+  std::shared_ptr<services::SessionManager> sessionManager;
+
+  // Create SessionManager for all modes
+  sessionManager = std::make_shared<services::SessionManager>();
 
   // Only construct services for MODEL_SERVICE (see config::modelService()).
   // Additional modes (e.g. videogen) extend config::ModelService and add cases.
@@ -45,7 +50,7 @@ void initializeServices() {
   }
 
   c.initialize(std::move(llm), std::move(embedding), std::move(socket),
-               std::move(disaggregation));
+               std::move(disaggregation), std::move(sessionManager));
 
   if (c.llm()) {
     c.llm()->start();
@@ -58,6 +63,9 @@ void initializeServices() {
   if (c.embedding()) {
     c.embedding()->start();
     TT_LOG_INFO("[ServiceFactory] Embedding service started");
+  }
+  if (c.sessionManager()) {
+    TT_LOG_INFO("[ServiceFactory] Session manager initialized");
   }
 }
 


### PR DESCRIPTION
Features:

New API methods:

- Create session
- Close session
- Get slot by session id (can be removed, just for testing)

Session manager that manages session_id (uuid) and associated slot_id (int) is introduced.

LLM service will check if the requests have session_id and if not a new session_id will be created and returned to the user:

<img width="464" height="265" alt="image" src="https://github.com/user-attachments/assets/8ff96458-e86a-49c2-9566-3341890469dd" />


Remaining scope:

- Get slot_id if not assigned
- If session_id is just created it might go to prefill, otherwise if exists it's always prefill by decode


Issues:

- #2606
- #2646