### PR TITLE
Prefill runner and prefill SHM

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -209,6 +209,9 @@ set(LLM_ENGINE_SOURCES
     src/runners/sp_pipeline_runner/sp_pipeline_model_runner.cpp
     src/runners/sp_pipeline_runner/mock_device_pipeline.cpp
     src/runners/sp_pipeline_runner/mock_sp_pipeline_model_runner.cpp
+    src/runners/sp_prefill_runner/sp_prefill_runner.cpp
+    src/runners/sp_prefill_runner/i_sp_prefill_model_runner.cpp
+    src/runners/sp_prefill_runner/sp_prefill_model_runner.cpp
     src/services/memory_manager.cpp
 )
 # Add socket backend when tt-metal is available

--- a/tt-media-server/cpp_server/include/config/types.hpp
+++ b/tt-media-server/cpp_server/include/config/types.hpp
@@ -75,7 +75,7 @@ inline LLMMode llmModeFromString(const std::string& v) {
   return LLMMode::REGULAR;
 }
 
-enum class ModelRunnerType { MOCK, PIPELINE, LLAMA, MOCK_PIPELINE };
+enum class ModelRunnerType { MOCK, PIPELINE, LLAMA, MOCK_PIPELINE, PREFILL };
 
 enum class SchedulingPolicy {
   PREFILL_FIRST,

--- a/tt-media-server/cpp_server/include/runners/sp_prefill_runner/i_sp_prefill_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_prefill_runner/i_sp_prefill_model_runner.hpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "config/runner_config.hpp"
+#include "runners/llm_runner/sequence.hpp"
+#include "utils/concurrent_queue.hpp"
+
+namespace sp_prefill {
+
+using PrefillCallback = std::function<void(const llm_engine::TokenResult&)>;
+using PrefillQueue = LockFreeConcurrentQueue<llm_engine::TokenResult>;
+
+class ISpPrefillModelRunner {
+ public:
+  virtual ~ISpPrefillModelRunner() = default;
+
+  // Prefill runner always does prefill, returns one token
+  virtual void write(const std::string& taskId,
+                     const std::vector<int64_t>& tokenIds) = 0;
+  virtual void exit() = 0;
+};
+
+std::unique_ptr<ISpPrefillModelRunner> makeModelRunner(
+    const tt::config::LLMConfig& config, PrefillCallback callback);
+
+}  // namespace sp_prefill

--- a/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_model_runner.hpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "runners/sp_pipeline_runner/shared_memory.hpp"
+#include "runners/sp_prefill_runner/i_sp_prefill_model_runner.hpp"
+
+namespace sp_prefill {
+
+using PrefillCallback = std::function<void(const llm_engine::TokenResult&)>;
+
+class SpPrefillModelRunner : public ISpPrefillModelRunner {
+ public:
+  explicit SpPrefillModelRunner(PrefillCallback callback);
+  ~SpPrefillModelRunner() override;
+
+  SpPrefillModelRunner(const SpPrefillModelRunner&) = delete;
+  SpPrefillModelRunner& operator=(const SpPrefillModelRunner&) = delete;
+
+  void write(const std::string& taskId,
+             const std::vector<int64_t>& tokenIds) override;
+  void exit() override;
+
+ private:
+  struct ShmNames {
+    ShmNames() {
+      const char* c2p = std::getenv("TT_IPC_SHM_C2P");
+      const char* p2c = std::getenv("TT_IPC_SHM_P2C");
+      write = c2p ? std::string(c2p)
+                  : throw std::runtime_error("TT_IPC_SHM_C2P not set");
+      read = p2c ? std::string(p2c)
+                 : throw std::runtime_error("TT_IPC_SHM_P2C not set");
+    }
+    std::string write;
+    std::string read;
+  };
+
+  void readerLoop();
+
+  PrefillCallback prefillCallback;
+  ShmNames shmNames;
+  sp_pipeline::PrefillSharedMemory deviceInput;
+  sp_pipeline::DecodeSharedMemory deviceOutput;
+  std::atomic<bool> stop{false};
+  std::thread readerThread;
+};
+
+}  // namespace sp_prefill

--- a/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_model_runner.hpp
@@ -7,11 +7,10 @@
 #include <cstdint>
 #include <cstdlib>
 #include <string>
-#include <thread>
 #include <vector>
 
-#include "runners/sp_pipeline_runner/shared_memory.hpp"
 #include "runners/sp_prefill_runner/i_sp_prefill_model_runner.hpp"
+#include "runners/sp_pipeline_runner/shared_memory.hpp"
 
 namespace sp_prefill {
 
@@ -43,14 +42,11 @@ class SpPrefillModelRunner : public ISpPrefillModelRunner {
     std::string read;
   };
 
-  void readerLoop();
-
   PrefillCallback prefillCallback;
   ShmNames shmNames;
   sp_pipeline::PrefillSharedMemory deviceInput;
   sp_pipeline::DecodeSharedMemory deviceOutput;
   std::atomic<bool> stop{false};
-  std::thread readerThread;
 };
 
 }  // namespace sp_prefill

--- a/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_runner.hpp
@@ -39,7 +39,6 @@ class SpPrefillRunner : public IRunner {
   llm_engine::ITaskQueue* taskQueue;
   std::unique_ptr<sp_prefill::ISpPrefillModelRunner> modelRunner;
   sp_prefill::PrefillQueue prefillQueue;
-  std::unique_ptr<llm_engine::Sequence> activeSequence;
   std::atomic<bool> stopped{false};
 };
 

--- a/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_runner.hpp
@@ -5,18 +5,14 @@
 
 #include <atomic>
 #include <memory>
-#include <thread>
-#include <unordered_map>
 #include <unordered_set>
 
 #include "config/runner_config.hpp"
-#include "ipc/boost_ipc_memory_queue.hpp"
 #include "ipc/shared_memory.hpp"
 #include "runners/llm_runner/sequence.hpp"
 #include "runners/llm_runner/task_queue.hpp"
 #include "runners/runner_interface.hpp"
 #include "runners/sp_prefill_runner/i_sp_prefill_model_runner.hpp"
-#include "services/memory_manager.hpp"
 
 namespace tt::runners {
 
@@ -33,9 +29,6 @@ class SpPrefillRunner : public IRunner {
   const char* runnerType() const override { return "SpPrefillRunner"; }
 
  private:
-  void step();
-  void drainPrefillResults();
-  void memoryLoop();
   void pushToken(const llm_engine::TaskID& taskId, uint64_t tokenId,
                  bool finished);
   void pushErrorToken(const llm_engine::TaskID& taskId);
@@ -48,13 +41,6 @@ class SpPrefillRunner : public IRunner {
   sp_prefill::PrefillQueue prefillQueue;
   std::unique_ptr<llm_engine::Sequence> activeSequence;
   std::atomic<bool> stopped{false};
-
-  tt::services::MemoryManager memoryManager;
-  ipc::MemoryRequestQueue memoryRequests{ipc::k_memory_request_queue_name,
-                                         ipc::MEMORY_QUEUE_CAPACITY};
-  ipc::MemoryResultQueue memoryResults{ipc::k_memory_result_queue_name,
-                                       ipc::MEMORY_QUEUE_CAPACITY};
-  std::thread memoryThread;
 };
 
 }  // namespace tt::runners

--- a/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_runner.hpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "config/runner_config.hpp"
+#include "ipc/boost_ipc_memory_queue.hpp"
+#include "ipc/shared_memory.hpp"
+#include "runners/llm_runner/sequence.hpp"
+#include "runners/llm_runner/task_queue.hpp"
+#include "runners/runner_interface.hpp"
+#include "runners/sp_prefill_runner/i_sp_prefill_model_runner.hpp"
+#include "services/memory_manager.hpp"
+
+namespace tt::runners {
+
+class SpPrefillRunner : public IRunner {
+ public:
+  SpPrefillRunner(const tt::config::LLMConfig& config,
+                  ipc::TokenRingBuffer<65536>* resultQueue,
+                  llm_engine::ITaskQueue* taskQueue);
+  ~SpPrefillRunner() override;
+
+  void run() override;
+  void stop() override;
+  bool warmup();
+  const char* runnerType() const override { return "SpPrefillRunner"; }
+
+ private:
+  void step();
+  void drainPrefillResults();
+  void memoryLoop();
+  void pushToken(const llm_engine::TaskID& taskId, uint64_t tokenId,
+                 bool finished);
+  void pushErrorToken(const llm_engine::TaskID& taskId);
+
+  tt::config::LLMConfig config;
+  std::unordered_set<int64_t> stopTokenIds;
+  ipc::TokenRingBuffer<65536>* resultQueue;
+  llm_engine::ITaskQueue* taskQueue;
+  std::unique_ptr<sp_prefill::ISpPrefillModelRunner> modelRunner;
+  sp_prefill::PrefillQueue prefillQueue;
+  std::unique_ptr<llm_engine::Sequence> activeSequence;
+  std::atomic<bool> stopped{false};
+
+  tt::services::MemoryManager memoryManager;
+  ipc::MemoryRequestQueue memoryRequests{ipc::k_memory_request_queue_name,
+                                         ipc::MEMORY_QUEUE_CAPACITY};
+  ipc::MemoryResultQueue memoryResults{ipc::k_memory_result_queue_name,
+                                       ipc::MEMORY_QUEUE_CAPACITY};
+  std::thread memoryThread;
+};
+
+}  // namespace tt::runners

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -167,6 +167,9 @@ LLMConfig llmEngineConfig() {
   if (backend == "pipeline") {
     cfg.runner_type = ModelRunnerType::PIPELINE;
     cfg.max_in_flight_count = 1;
+  } else if (backend == "prefill") {
+    cfg.runner_type = ModelRunnerType::PREFILL;
+    cfg.max_in_flight_count = 1;
   } else if (backend == "llama") {
     cfg.kvcache_block_size = 32;
     cfg.max_num_batched_tokens = 16384;

--- a/tt-media-server/cpp_server/src/runners/mock_prefill_runner.py
+++ b/tt-media-server/cpp_server/src/runners/mock_prefill_runner.py
@@ -34,7 +34,7 @@ import sys
 import time
 from typing import Optional
 
-from shared_memory import PREFILL_MAX_TOKEN_IDS, SharedMemory, PrefillMessage
+from shared_memory import PREFILL_MAX_TOKEN_IDS, PrefillMessage, SharedMemory
 
 _shutdown = False
 
@@ -108,11 +108,11 @@ def _connect_to_workers() -> dict[int, socket.socket]:
             sock.close()
 
     if worker_sockets:
-        print(
-            f"Rank 0: Connected to {len(worker_sockets)} workers", file=sys.stderr
-        )
+        print(f"Rank 0: Connected to {len(worker_sockets)} workers", file=sys.stderr)
     else:
-        print("Rank 0: No workers connected, running in standalone mode", file=sys.stderr)
+        print(
+            "Rank 0: No workers connected, running in standalone mode", file=sys.stderr
+        )
     return worker_sockets
 
 
@@ -137,7 +137,9 @@ def run_rank0_coordinator() -> None:
         with SharedMemory(
             c2p_name, max_token_ids=PREFILL_MAX_TOKEN_IDS, is_shutdown=_is_shutdown
         ) as c2p, SharedMemory(
-            p2c_name, max_token_ids=1, is_shutdown=_is_shutdown  # Only 1 token output
+            p2c_name,
+            max_token_ids=1,
+            is_shutdown=_is_shutdown,  # Only 1 token output
         ) as p2c:
             print("Rank 0: SHM bridge started successfully", file=sys.stderr)
 
@@ -155,7 +157,7 @@ def run_rank0_coordinator() -> None:
                 task_id_str = msg.task_id.decode("utf-8", errors="ignore").rstrip(
                     "\x00"
                 )
-                
+
                 print(
                     f"Rank 0: Received prefill request task_id={task_id_str}, "
                     f"num_tokens={len(msg.token_ids)}, "
@@ -176,9 +178,9 @@ def run_rank0_coordinator() -> None:
 
                 # Return exactly one token (first token from reasoning sequence)
                 prefill_token = 128798  # <think> token
-                
+
                 p2c.write_token(msg.task_id, prefill_token)
-                
+
                 print(
                     f"Rank 0: Sent prefill token {prefill_token} for task {task_id_str}",
                     file=sys.stderr,
@@ -218,7 +220,7 @@ def run_worker_rank(rank: int) -> None:
                 break
 
             task_id_str = msg.task_id.decode("utf-8", errors="ignore").rstrip("\x00")
-            
+
             print(
                 f"Rank {rank}: Received prefill request task_id={task_id_str}, "
                 f"num_tokens={len(msg.token_ids)}, "

--- a/tt-media-server/cpp_server/src/runners/mock_prefill_runner.py
+++ b/tt-media-server/cpp_server/src/runners/mock_prefill_runner.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Mock pipeline runner with multi-rank support for testing prefill.
+
+This runner uses shared memory for the coordinator (rank 0) and sockets
+for distributing work to 3 worker processes (ranks 1-3). Returns exactly
+one token per request (prefill only).
+
+Environment variables required:
+    TT_IPC_SHM_C2P: Name of input  SHM segment (e.g., tt_ipc_c2p_12345)
+    TT_IPC_SHM_P2C: Name of output SHM segment (e.g., tt_ipc_p2c_12345)
+    OMPI_COMM_WORLD_RANK or RANK: Rank ID (0-3)
+
+Usage:
+    # Rank 0 (coordinator):
+    export RANK=0
+    export TT_IPC_SHM_C2P=tt_ipc_c2p_12345
+    export TT_IPC_SHM_P2C=tt_ipc_p2c_12345
+    python mock_pipeline_runner.py
+
+    # Ranks 1-3 (workers):
+    export RANK=1  # or 2, 3
+    python mock_pipeline_runner.py
+"""
+
+import os
+import pickle
+import signal
+import socket
+import struct
+import sys
+import time
+from typing import Optional
+
+from shared_memory import PREFILL_MAX_TOKEN_IDS, SharedMemory, PrefillMessage
+
+_shutdown = False
+
+
+def _handle_sigterm(signum, frame):
+    global _shutdown
+    _shutdown = True
+
+
+def _is_shutdown() -> bool:
+    return _shutdown
+
+
+def _rank() -> int:
+    r = os.environ.get("OMPI_COMM_WORLD_RANK") or os.environ.get("RANK")
+    return int(r) if r is not None else 0
+
+
+RANK_CONFIG = {
+    0: {"ip": "127.0.0.1", "port": 10000},
+    1: {"ip": "127.0.0.1", "port": 10001},
+    2: {"ip": "127.0.0.1", "port": 10002},
+    3: {"ip": "127.0.0.1", "port": 10003},
+}
+
+
+def _send_via_socket(sock: socket.socket, msg: PrefillMessage) -> None:
+    """Send PrefillMessage via socket using pickle."""
+    data = pickle.dumps(msg)
+    sock.sendall(struct.pack("<I", len(data)))
+    sock.sendall(data)
+
+
+def _recv_via_socket(conn: socket.socket) -> Optional[PrefillMessage]:
+    """Receive PrefillMessage via socket using pickle."""
+    try:
+        length_data = conn.recv(4)
+        if not length_data:
+            return None
+        length = struct.unpack("<I", length_data)[0]
+
+        data = b""
+        while len(data) < length:
+            chunk = conn.recv(min(length - len(data), 4096))
+            if not chunk:
+                return None
+            data += chunk
+
+        return pickle.loads(data)
+    except Exception as e:
+        print(f"Error receiving request: {e}", file=sys.stderr)
+        return None
+
+
+def _connect_to_workers() -> dict[int, socket.socket]:
+    """Connect to worker ranks 1-3, returning sockets for those that accepted."""
+    worker_sockets: dict[int, socket.socket] = {}
+    for rank in [1, 2, 3]:
+        config = RANK_CONFIG[rank]
+        print(
+            f"Rank 0: Connecting to rank {rank} at {config['ip']}:{config['port']}",
+            file=sys.stderr,
+        )
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.connect((config["ip"], config["port"]))
+            worker_sockets[rank] = sock
+            print(f"Rank 0: Connected to rank {rank}", file=sys.stderr)
+        except Exception as e:
+            print(f"Rank 0: Failed to connect to rank {rank}: {e}", file=sys.stderr)
+            sock.close()
+
+    if worker_sockets:
+        print(
+            f"Rank 0: Connected to {len(worker_sockets)} workers", file=sys.stderr
+        )
+    else:
+        print("Rank 0: No workers connected, running in standalone mode", file=sys.stderr)
+    return worker_sockets
+
+
+def run_rank0_coordinator() -> None:
+    """Rank 0: Read from input SHM, send to workers, return one token to output SHM."""
+    c2p_name = os.environ.get("TT_IPC_SHM_C2P")
+    p2c_name = os.environ.get("TT_IPC_SHM_P2C")
+
+    if not (c2p_name and p2c_name):
+        print(
+            "Error: TT_IPC_SHM_C2P or TT_IPC_SHM_P2C not set",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(
+        f"Rank 0: Opening shared memory C2P={c2p_name}, P2C={p2c_name}",
+        file=sys.stderr,
+    )
+
+    try:
+        with SharedMemory(
+            c2p_name, max_token_ids=PREFILL_MAX_TOKEN_IDS, is_shutdown=_is_shutdown
+        ) as c2p, SharedMemory(
+            p2c_name, max_token_ids=1, is_shutdown=_is_shutdown  # Only 1 token output
+        ) as p2c:
+            print("Rank 0: SHM bridge started successfully", file=sys.stderr)
+
+            print("Rank 0: Waiting 2s for workers to start...", file=sys.stderr)
+            time.sleep(2)
+            worker_sockets = _connect_to_workers()
+
+            print("Rank 0: Waiting for prefill requests...", file=sys.stderr)
+
+            while not _shutdown:
+                msg = c2p.read()
+                if msg is None:
+                    break
+
+                task_id_str = msg.task_id.decode("utf-8", errors="ignore").rstrip(
+                    "\x00"
+                )
+                
+                print(
+                    f"Rank 0: Received prefill request task_id={task_id_str}, "
+                    f"num_tokens={len(msg.token_ids)}, "
+                    f"tokens={msg.token_ids[:5]}{'...' if len(msg.token_ids) > 5 else ''}",
+                    file=sys.stderr,
+                )
+
+                # Send to all workers
+                for rank, sock in worker_sockets.items():
+                    try:
+                        _send_via_socket(sock, msg)
+                        print(f"Rank 0: Sent request to worker {rank}", file=sys.stderr)
+                    except Exception as e:
+                        print(
+                            f"Rank 0: Failed to send to rank {rank}: {e}",
+                            file=sys.stderr,
+                        )
+
+                # Return exactly one token (first token from reasoning sequence)
+                prefill_token = 128798  # <think> token
+                
+                p2c.write_token(msg.task_id, prefill_token)
+                
+                print(
+                    f"Rank 0: Sent prefill token {prefill_token} for task {task_id_str}",
+                    file=sys.stderr,
+                )
+
+    except KeyboardInterrupt:
+        print("Rank 0: Interrupted by user", file=sys.stderr)
+    finally:
+        for rank, sock in worker_sockets.items():
+            sock.close()
+
+    print("Rank 0: Shutdown complete", file=sys.stderr)
+
+
+def run_worker_rank(rank: int) -> None:
+    """Ranks 1-3: Listen on socket, receive requests from rank 0, and print them."""
+    config = RANK_CONFIG[rank]
+
+    print(
+        f"Rank {rank}: Starting worker on {config['ip']}:{config['port']}",
+        file=sys.stderr,
+    )
+    server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server_sock.bind((config["ip"], config["port"]))
+    server_sock.listen(1)
+
+    print(f"Rank {rank}: Listening for connections...", file=sys.stderr)
+
+    try:
+        conn, addr = server_sock.accept()
+        print(f"Rank {rank}: Accepted connection from {addr}", file=sys.stderr)
+
+        while not _shutdown:
+            msg = _recv_via_socket(conn)
+            if msg is None:
+                break
+
+            task_id_str = msg.task_id.decode("utf-8", errors="ignore").rstrip("\x00")
+            
+            print(
+                f"Rank {rank}: Received prefill request task_id={task_id_str}, "
+                f"num_tokens={len(msg.token_ids)}, "
+                f"tokens={msg.token_ids[:10]}{'...' if len(msg.token_ids) > 10 else ''}",
+                file=sys.stderr,
+            )
+
+    except KeyboardInterrupt:
+        print(f"Rank {rank}: Interrupted by user", file=sys.stderr)
+    except Exception as e:
+        print(f"Rank {rank}: Error: {e}", file=sys.stderr)
+    finally:
+        server_sock.close()
+
+    print(f"Rank {rank}: Shutdown complete", file=sys.stderr)
+
+
+def main() -> None:
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+    signal.signal(signal.SIGINT, _handle_sigterm)
+
+    rank = _rank()
+    print(f"Starting mock pipeline runner with rank={rank}", file=sys.stderr)
+
+    if rank == 0:
+        run_rank0_coordinator()
+    elif rank in [1, 2, 3]:
+        run_worker_rank(rank)
+    else:
+        print(f"Invalid rank: {rank}. Must be 0-3", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tt-media-server/cpp_server/src/runners/sp_prefill_runner/i_sp_prefill_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_prefill_runner/i_sp_prefill_model_runner.cpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#include "runners/sp_prefill_runner/i_sp_prefill_model_runner.hpp"
+
+#include "runners/sp_prefill_runner/sp_prefill_model_runner.hpp"
+#include "utils/logger.hpp"
+
+namespace sp_prefill {
+
+std::unique_ptr<ISpPrefillModelRunner> makeModelRunner(
+    const tt::config::LLMConfig& config, PrefillCallback callback) {
+  TT_LOG_INFO("Creating SpPrefillModelRunner with shared memory IPC");
+  return std::make_unique<SpPrefillModelRunner>(std::move(callback));
+}
+
+}  // namespace sp_prefill

--- a/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_model_runner.cpp
@@ -4,6 +4,7 @@
 #include "runners/sp_prefill_runner/sp_prefill_model_runner.hpp"
 
 #include "runners/llm_runner/debug.hpp"
+#include "utils/logger.hpp"
 
 namespace sp_prefill {
 
@@ -14,25 +15,16 @@ SpPrefillModelRunner::SpPrefillModelRunner(PrefillCallback callback)
       deviceOutput(shmNames.read) {
   deviceInput.open();
   deviceOutput.open();
-  readerThread = std::thread([this] { readerLoop(); });
 }
 
 SpPrefillModelRunner::~SpPrefillModelRunner() { exit(); }
 
 void SpPrefillModelRunner::write(const std::string& taskId,
                                  const std::vector<int64_t>& tokenIds) {
-  // For prefill, we always send tokens but don't need maxTokens since we only
-  // get 1 token back
+  // For prefill, we send tokens and immediately read back the single result
   deviceInput.write(taskId, tokenIds, 1);
-}
 
-void SpPrefillModelRunner::exit() {
-  if (stop.exchange(true)) return;
-  if (readerThread.joinable()) readerThread.join();
-  LLM_ENGINE_LOG("sp_prefill") << "model runner exit" << std::endl;
-}
-
-void SpPrefillModelRunner::readerLoop() {
+  // Synchronously wait for the single prefill token
   sp_pipeline::ReadResult readBuf;
   while (!stop.load(std::memory_order_relaxed)) {
     if (deviceOutput.tryRead(readBuf)) {
@@ -41,10 +33,15 @@ void SpPrefillModelRunner::readerLoop() {
       uint64_t tokenId = readBuf.tokenIds.empty() ? 0 : readBuf.tokenIds[0];
       llm_engine::TokenResult result(std::move(tid), tokenId);
       prefillCallback(result);
-    } else {
-      std::this_thread::yield();
+      break;  // Got the token, done
     }
+    std::this_thread::yield();
   }
+}
+
+void SpPrefillModelRunner::exit() {
+  stop.store(true, std::memory_order_relaxed);
+  TT_LOG_INFO("SpPrefillModelRunner: Model runner exit");
 }
 
 }  // namespace sp_prefill

--- a/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_model_runner.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#include "runners/sp_prefill_runner/sp_prefill_model_runner.hpp"
+
+#include "runners/llm_runner/debug.hpp"
+
+namespace sp_prefill {
+
+SpPrefillModelRunner::SpPrefillModelRunner(PrefillCallback callback)
+    : prefillCallback(std::move(callback)),
+      shmNames(),
+      deviceInput(shmNames.write),
+      deviceOutput(shmNames.read) {
+  deviceInput.open();
+  deviceOutput.open();
+  readerThread = std::thread([this] { readerLoop(); });
+}
+
+SpPrefillModelRunner::~SpPrefillModelRunner() { exit(); }
+
+void SpPrefillModelRunner::write(const std::string& taskId,
+                                 const std::vector<int64_t>& tokenIds) {
+  // For prefill, we always send tokens but don't need maxTokens since we only
+  // get 1 token back
+  deviceInput.write(taskId, tokenIds, 1);
+}
+
+void SpPrefillModelRunner::exit() {
+  if (stop.exchange(true)) return;
+  if (readerThread.joinable()) readerThread.join();
+  LLM_ENGINE_LOG("sp_prefill") << "model runner exit" << std::endl;
+}
+
+void SpPrefillModelRunner::readerLoop() {
+  sp_pipeline::ReadResult readBuf;
+  while (!stop.load(std::memory_order_relaxed)) {
+    if (deviceOutput.tryRead(readBuf)) {
+      llm_engine::TaskID tid = llm_engine::TaskID::ipcDeserialize(
+          readBuf.taskId.data(), llm_engine::TaskID::K_SERIALIZED_SIZE);
+      uint64_t tokenId = readBuf.tokenIds.empty() ? 0 : readBuf.tokenIds[0];
+      llm_engine::TokenResult result(std::move(tid), tokenId);
+      prefillCallback(result);
+    } else {
+      std::this_thread::yield();
+    }
+  }
+}
+
+}  // namespace sp_prefill

--- a/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
@@ -6,9 +6,7 @@
 #include <cassert>
 #include <chrono>
 #include <cstring>
-#include <thread>
 
-#include "domain/manage_memory.hpp"
 #include "ipc/shared_memory.hpp"
 #include "profiling/tracy.hpp"
 #include "utils/logger.hpp"
@@ -24,8 +22,6 @@ SpPrefillRunner::SpPrefillRunner(const config::LLMConfig& config,
       taskQueue(taskQueue),
       prefillQueue(256),  // Small queue since we only have 1 in flight
       activeSequence(nullptr) {
-  memoryThread = std::thread([this] { memoryLoop(); });
-
   auto prefillCb = [this](const llm_engine::TokenResult& result) {
     while (!prefillQueue.push(result)) {
       std::this_thread::yield();
@@ -37,9 +33,6 @@ SpPrefillRunner::SpPrefillRunner(const config::LLMConfig& config,
 
 SpPrefillRunner::~SpPrefillRunner() {
   stop();
-  if (memoryThread.joinable()) {
-    memoryThread.join();
-  }
   if (modelRunner) {
     modelRunner->exit();
   }
@@ -47,7 +40,45 @@ SpPrefillRunner::~SpPrefillRunner() {
 
 void SpPrefillRunner::run() {
   while (!stopped.load(std::memory_order_relaxed)) {
-    step();
+    // Get next sequence from task queue
+    auto* seq = taskQueue->tryPop();
+    if (!seq) {
+      std::this_thread::yield();
+      continue;
+    }
+
+    activeSequence.reset(seq);
+    TT_LOG_DEBUG("SpPrefillRunner: Starting prefill for task {}",
+                 activeSequence->taskId.id);
+
+    // Send prefill request
+    modelRunner->write(activeSequence->taskId.id, activeSequence->tokenIds);
+
+    // Wait synchronously for the single prefill token
+    llm_engine::TokenResult result;
+    while (!stopped.load(std::memory_order_relaxed)) {
+      if (prefillQueue.pop(result)) {
+        break;
+      }
+      std::this_thread::yield();
+    }
+
+    if (stopped.load(std::memory_order_relaxed)) {
+      break;
+    }
+
+    // Process the result
+    if (result.isError) {
+      TT_LOG_WARN("SpPrefillRunner: Error token for task {}", result.taskId.id);
+      pushErrorToken(result.taskId);
+    } else {
+      TT_LOG_DEBUG("SpPrefillRunner: Received prefill token {} for task {}",
+                   result.tokenId, result.taskId.id);
+      pushToken(result.taskId, result.tokenId, true);  // Always finished
+    }
+
+    // Clear active sequence
+    activeSequence.reset();
   }
 }
 
@@ -104,83 +135,6 @@ bool SpPrefillRunner::warmup() {
 void SpPrefillRunner::stop() {
   TT_LOG_INFO("SpPrefillRunner: Stopping");
   stopped.store(true, std::memory_order_relaxed);
-}
-
-void SpPrefillRunner::step() {
-  ZoneScopedN("SpPrefillRunner::step");
-
-  // Process incoming prefill results first
-  drainPrefillResults();
-
-  // If no active sequence, try to get one from the queue
-  if (!activeSequence) {
-    auto* seq = taskQueue->tryPop();
-    if (!seq) {
-      std::this_thread::yield();
-      return;
-    }
-
-    activeSequence.reset(seq);
-    TT_LOG_DEBUG("SpPrefillRunner: Starting prefill for task {}",
-                 activeSequence->taskId.id);
-
-    // Send prefill request
-    modelRunner->write(activeSequence->taskId.id, activeSequence->tokenIds);
-  }
-}
-
-void SpPrefillRunner::drainPrefillResults() {
-  ZoneScopedN("SpPrefillRunner::drainPrefillResults");
-
-  std::vector<llm_engine::TokenResult> results;
-  prefillQueue.popMany(results, 256);
-
-  for (const auto& dr : results) {
-    if (dr.isError) {
-      TT_LOG_WARN("SpPrefillRunner: Error token for task {}", dr.taskId.id);
-      pushErrorToken(dr.taskId);
-
-      // Clear active sequence if it matches
-      if (activeSequence && activeSequence->taskId == dr.taskId) {
-        activeSequence.reset();
-      }
-      continue;
-    }
-
-    TT_LOG_DEBUG("SpPrefillRunner: Received token {} for task {}", dr.tokenId,
-                 dr.taskId.id);
-
-    pushToken(dr.taskId, dr.tokenId, true);  // Always finished after prefill
-
-    // Clear active sequence if it matches
-    if (activeSequence && activeSequence->taskId == dr.taskId) {
-      activeSequence.reset();
-    }
-  }
-}
-
-void SpPrefillRunner::memoryLoop() {
-  tt::domain::ManageMemoryTask task{};
-  std::vector<tt::domain::ManageMemoryTask> retryQueue;
-
-  while (!stopped.load(std::memory_order_relaxed)) {
-    if (!retryQueue.empty()) {
-      auto result = memoryManager.handle_task(retryQueue.front());
-      if (result.status != domain::ManageMemoryStatus::WAITING) {
-        memoryResults.push(result);
-        retryQueue.erase(retryQueue.begin());
-      }
-    } else if (memoryRequests.tryPop(task)) {
-      auto result = memoryManager.handle_task(task);
-      if (result.status == domain::ManageMemoryStatus::WAITING) {
-        retryQueue.push_back(task);
-      } else {
-        memoryResults.push(result);
-      }
-    } else {
-      std::this_thread::yield();
-    }
-  }
 }
 
 void SpPrefillRunner::pushToken(const llm_engine::TaskID& taskId,

--- a/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#include "runners/sp_prefill_runner/sp_prefill_runner.hpp"
+
+#include <cassert>
+#include <chrono>
+#include <cstring>
+#include <thread>
+
+#include "domain/manage_memory.hpp"
+#include "ipc/shared_memory.hpp"
+#include "profiling/tracy.hpp"
+#include "utils/logger.hpp"
+
+namespace tt::runners {
+
+SpPrefillRunner::SpPrefillRunner(const config::LLMConfig& config,
+                                 ipc::TokenRingBuffer<65536>* resultQueue,
+                                 llm_engine::ITaskQueue* taskQueue)
+    : config(config),
+      stopTokenIds(config.stop_token_ids.begin(), config.stop_token_ids.end()),
+      resultQueue(resultQueue),
+      taskQueue(taskQueue),
+      prefillQueue(256),  // Small queue since we only have 1 in flight
+      activeSequence(nullptr) {
+  memoryThread = std::thread([this] { memoryLoop(); });
+
+  auto prefillCb = [this](const llm_engine::TokenResult& result) {
+    while (!prefillQueue.push(result)) {
+      std::this_thread::yield();
+    }
+  };
+
+  modelRunner = sp_prefill::makeModelRunner(config, std::move(prefillCb));
+}
+
+SpPrefillRunner::~SpPrefillRunner() {
+  stop();
+  if (memoryThread.joinable()) {
+    memoryThread.join();
+  }
+  if (modelRunner) {
+    modelRunner->exit();
+  }
+}
+
+void SpPrefillRunner::run() {
+  while (!stopped.load(std::memory_order_relaxed)) {
+    step();
+  }
+}
+
+bool SpPrefillRunner::warmup() {
+  // Create a warmup sequence with a single token
+  llm_engine::SamplingParams warmupParams;
+  warmupParams.max_tokens = 1;
+  warmupParams.ignore_eos = true;
+
+  std::vector<int64_t> warmupTokens = {1};  // Single token
+  llm_engine::TaskID warmupTaskId("warmup_task");
+
+  auto warmupSeq = std::make_unique<llm_engine::Sequence>(
+      warmupTaskId,
+      1,  // block_size (doesn't matter for warmup)
+      warmupTokens, warmupParams);
+
+  modelRunner->write(warmupSeq->taskId.id, warmupSeq->tokenIds);
+
+  // Wait for the response token (with timeout)
+  const int MAX_ATTEMPTS = 1000;  // ~10 seconds with 10ms sleep
+  int attempts = 0;
+  bool receivedToken = false;
+
+  while (attempts < MAX_ATTEMPTS && !receivedToken) {
+    std::vector<llm_engine::TokenResult> results;
+    prefillQueue.popMany(results, 256);
+    for (const auto& dr : results) {
+      if (dr.taskId == warmupTaskId) {
+        if (dr.isError) {
+          TT_LOG_ERROR("SpPrefillRunner: Warmup failed with error");
+          return false;
+        }
+        receivedToken = true;
+        break;
+      }
+    }
+
+    if (!receivedToken) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      attempts++;
+    }
+  }
+
+  if (!receivedToken) {
+    TT_LOG_ERROR("SpPrefillRunner: Warmup timed out waiting for token");
+    return false;
+  }
+
+  TT_LOG_INFO("SpPrefillRunner: Warmup successful");
+  return true;
+}
+
+void SpPrefillRunner::stop() {
+  TT_LOG_INFO("SpPrefillRunner: Stopping");
+  stopped.store(true, std::memory_order_relaxed);
+}
+
+void SpPrefillRunner::step() {
+  ZoneScopedN("SpPrefillRunner::step");
+
+  // Process incoming prefill results first
+  drainPrefillResults();
+
+  // If no active sequence, try to get one from the queue
+  if (!activeSequence) {
+    auto* seq = taskQueue->tryPop();
+    if (!seq) {
+      std::this_thread::yield();
+      return;
+    }
+
+    activeSequence.reset(seq);
+    TT_LOG_DEBUG("SpPrefillRunner: Starting prefill for task {}",
+                 activeSequence->taskId.id);
+
+    // Send prefill request
+    modelRunner->write(activeSequence->taskId.id, activeSequence->tokenIds);
+  }
+}
+
+void SpPrefillRunner::drainPrefillResults() {
+  ZoneScopedN("SpPrefillRunner::drainPrefillResults");
+
+  std::vector<llm_engine::TokenResult> results;
+  prefillQueue.popMany(results, 256);
+
+  for (const auto& dr : results) {
+    if (dr.isError) {
+      TT_LOG_WARN("SpPrefillRunner: Error token for task {}", dr.taskId.id);
+      pushErrorToken(dr.taskId);
+
+      // Clear active sequence if it matches
+      if (activeSequence && activeSequence->taskId == dr.taskId) {
+        activeSequence.reset();
+      }
+      continue;
+    }
+
+    TT_LOG_DEBUG("SpPrefillRunner: Received token {} for task {}",
+                 dr.tokenId, dr.taskId.id);
+
+    pushToken(dr.taskId, dr.tokenId, true);  // Always finished after prefill
+
+    // Clear active sequence if it matches
+    if (activeSequence && activeSequence->taskId == dr.taskId) {
+      activeSequence.reset();
+    }
+  }
+}
+
+void SpPrefillRunner::memoryLoop() {
+  tt::domain::ManageMemoryTask task{};
+  std::vector<tt::domain::ManageMemoryTask> retryQueue;
+
+  while (!stopped.load(std::memory_order_relaxed)) {
+    if (!retryQueue.empty()) {
+      auto result = memoryManager.handle_task(retryQueue.front());
+      if (result.status != domain::ManageMemoryStatus::WAITING) {
+        memoryResults.push(result);
+        retryQueue.erase(retryQueue.begin());
+      }
+    } else if (memoryRequests.tryPop(task)) {
+      auto result = memoryManager.handle_task(task);
+      if (result.status == domain::ManageMemoryStatus::WAITING) {
+        retryQueue.push_back(task);
+      } else {
+        memoryResults.push(result);
+      }
+    } else {
+      std::this_thread::yield();
+    }
+  }
+}
+
+void SpPrefillRunner::pushToken(const llm_engine::TaskID& taskId,
+                                uint64_t tokenId, bool finished) {
+  ipc::SharedToken shared{};
+  shared.token_index = 0;
+  shared.flags = finished ? ipc::SharedToken::FLAG_FINAL : 0u;
+  shared.token_id = tokenId;
+  std::strncpy(shared.task_id, taskId.id.c_str(), sizeof(shared.task_id) - 1);
+  shared.task_id[sizeof(shared.task_id) - 1] = '\0';
+  resultQueue->push(shared);
+}
+
+void SpPrefillRunner::pushErrorToken(const llm_engine::TaskID& taskId) {
+  ipc::SharedToken shared{};
+  shared.token_index = 0;
+  shared.flags = ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ERROR;
+  shared.token_id = 0;
+  std::strncpy(shared.task_id, taskId.id.c_str(), sizeof(shared.task_id) - 1);
+  shared.task_id[sizeof(shared.task_id) - 1] = '\0';
+  resultQueue->push(shared);
+}
+
+}  // namespace tt::runners

--- a/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
@@ -147,8 +147,8 @@ void SpPrefillRunner::drainPrefillResults() {
       continue;
     }
 
-    TT_LOG_DEBUG("SpPrefillRunner: Received token {} for task {}",
-                 dr.tokenId, dr.taskId.id);
+    TT_LOG_DEBUG("SpPrefillRunner: Received token {} for task {}", dr.tokenId,
+                 dr.taskId.id);
 
     pushToken(dr.taskId, dr.tokenId, true);  // Always finished after prefill
 

--- a/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
@@ -20,8 +20,7 @@ SpPrefillRunner::SpPrefillRunner(const config::LLMConfig& config,
       stopTokenIds(config.stop_token_ids.begin(), config.stop_token_ids.end()),
       resultQueue(resultQueue),
       taskQueue(taskQueue),
-      prefillQueue(256),  // Small queue since we only have 1 in flight
-      activeSequence(nullptr) {
+      prefillQueue(256) {  // Small queue since we only have 1 in flight
   auto prefillCb = [this](const llm_engine::TokenResult& result) {
     while (!prefillQueue.push(result)) {
       std::this_thread::yield();
@@ -47,12 +46,13 @@ void SpPrefillRunner::run() {
       continue;
     }
 
-    activeSequence.reset(seq);
+    // Use unique_ptr to ensure cleanup
+    std::unique_ptr<llm_engine::Sequence> sequence(seq);
     TT_LOG_DEBUG("SpPrefillRunner: Starting prefill for task {}",
-                 activeSequence->taskId.id);
+                 sequence->taskId.id);
 
     // Send prefill request
-    modelRunner->write(activeSequence->taskId.id, activeSequence->tokenIds);
+    modelRunner->write(sequence->taskId.id, sequence->tokenIds);
 
     // Wait synchronously for the single prefill token
     llm_engine::TokenResult result;
@@ -77,8 +77,7 @@ void SpPrefillRunner::run() {
       pushToken(result.taskId, result.tokenId, true);  // Always finished
     }
 
-    // Clear active sequence
-    activeSequence.reset();
+    // sequence automatically cleaned up at end of scope
   }
 }
 

--- a/tt-media-server/cpp_server/src/utils/runner_factory.cpp
+++ b/tt-media-server/cpp_server/src/utils/runner_factory.cpp
@@ -6,6 +6,7 @@
 #include "runners/embedding_runner.hpp"
 #include "runners/llm_runner.hpp"
 #include "runners/sp_pipeline_runner/sp_pipeline_runner.hpp"
+#include "runners/sp_prefill_runner/sp_prefill_runner.hpp"
 #include "utils/logger.hpp"
 
 namespace tt::utils::runner_factory {
@@ -28,6 +29,12 @@ std::unique_ptr<runners::IRunner> createRunner(
         TT_LOG_INFO("[RunnerFactory] Creating SP Pipeline runner");
         return std::make_unique<runners::SpPipelineRunner>(cfg, resultQueue,
                                                            taskQueue);
+      }
+
+      if (cfg.runner_type == config::ModelRunnerType::PREFILL) {
+        TT_LOG_INFO("[RunnerFactory] Creating SP Prefill runner");
+        return std::make_unique<runners::SpPrefillRunner>(cfg, resultQueue,
+                                                          taskQueue);
       }
 
       TT_LOG_INFO("[RunnerFactory] Creating LLM runner (mock)");


### PR DESCRIPTION
A dedicated runner for prefill that always returns one token.
In order to use it set: 

        "LLM_DEVICE_BACKEND": "prefill",

also it uses the same SHM variables as decode:

        "TT_IPC_SHM_C2P": "tt_ipc_c2p_12345",
        "TT_IPC_SHM_P2C": "tt_ipc_p2c_12345",

but it uses mock_prefill_runner that can run 4 workers that can be in sync and returns a single token

From mock prefill runner:

<img width="744" height="75" alt="image" src="https://github.com/user-attachments/assets/ca85ac7b-23a0-47f8-b76b-72d899de7a1b" />
