### PR TITLE
fix: correct false PASS on whisper WER=100 in evals release report

### DIFF
--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -2215,7 +2215,9 @@ def evals_release_report_data(args, results, meta_data, model_spec):
                 # do NOT extract results[t_key] here.
                 # The score_func expects the ROOT results dict so it can do results[task_name].
 
-                kwargs = task.score.score_func_kwargs
+                # Shallow-copy to avoid mutating the shared config dict: kwargs["task_name"] = t_key
+                # below would permanently alter score_func_kwargs for all subsequent tasks in this process.
+                kwargs = dict(task.score.score_func_kwargs)
                 # Update task_name so the score function looks up the specific subtask (e.g. longbench_2wikimqa)
                 kwargs["task_name"] = t_key
                 configured_keys = kwargs.get("result_keys", [])
@@ -2243,7 +2245,12 @@ def evals_release_report_data(args, results, meta_data, model_spec):
                     )
                 except Exception as e:
                     logger.warning(f"  Could not calculate score for {t_key}: {e}")
-                    score = 0.0
+                    if kwargs.get("unit") == "WER":
+                        # WER=100 is worst-case (100% word error rate). Using score=0.0 here
+                        # would be transformed to 100-0=100 and incorrectly pass the tolerance check.
+                        score = 100.0
+                    else:
+                        score = 0.0
                 if kwargs.get("unit") == "WER":
                     score = 100 - score
 


### PR DESCRIPTION
## Summary

Fix two bugs in `evals_release_report_data()` that caused WER=100 (total failure) to be reported as PASS:

1. **kwargs mutation**: `score_func_kwargs` was assigned by reference, so `kwargs["task_name"] = t_key` permanently mutated the shared config dict, corrupting scoring for subsequent tasks in the same process. Fixed with a shallow copy: `dict(...)`.

2. **WER exception fallback**: on any scoring exception, `score` defaulted to `0.0`, which the WER transform (`100 - score`) flipped to `100.0` — passing the tolerance check and masking catastrophic failure as PASS. Fixed by setting `score=100.0` in the exception path when `unit=="WER"`, so the transform yields `0.0` (worst possible accuracy) instead.

**Note:** The tuple key mismatch issue (multi-level result keys not matched in `key_found`) is a separate upstream concern tracked independently.

---

This PR was originally an omnibus (split per review feedback from bgoelTT). Other scopes:
- Auth fix (Closes #2636 Bug 2): #2701
- tt-metal bump (draft, blocked on tenstorrent/tt-metal#40970): #2702
- Logging/lmms-eval cleanup: #2704