### PR TITLE
Add cancellation queue to cpp_server

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -204,6 +204,7 @@ endif()
 # LLM engine (include/runners/llm_runner/, src/runners/llm_runner/)
 set(LLM_ENGINE_SOURCES
     src/runners/llm_runner/block_manager.cpp
+    src/ipc/boost_ipc_cancel_queue.cpp
     src/ipc/boost_ipc_task_queue.cpp
     src/runners/llm_runner/hash.cpp
     src/runners/llm_runner.cpp
@@ -336,12 +337,20 @@ target_include_directories(test_tokenizer PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+add_executable(cancel_queue_test tests/cancel_queue_test.cpp)
+target_link_libraries(cancel_queue_test PRIVATE llm_engine GTest::gtest_main)
+target_include_directories(cancel_queue_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/runners
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
 include(GoogleTest)
 gtest_discover_tests(scheduler_test)
 gtest_discover_tests(llm_runner_test)
 gtest_discover_tests(sequence_test)
 gtest_discover_tests(lockfree_queue_test)
 gtest_discover_tests(test_tokenizer)
+gtest_discover_tests(cancel_queue_test)
 
 # IPC smoke test (2-process, Boost.Interprocess queue + scheduler)
 add_executable(ipc_scheduler_smoke_test tests/ipc_scheduler_smoke_test.cpp)
@@ -458,4 +467,6 @@ if(SANITIZE_ADDRESS)
     target_link_options(ipc_scheduler_smoke_test PRIVATE -fsanitize=address)
     target_compile_options(lockfree_queue_test PRIVATE ${ASAN_FLAGS})
     target_link_options(lockfree_queue_test PRIVATE -fsanitize=address)
+    target_compile_options(cancel_queue_test PRIVATE ${ASAN_FLAGS})
+    target_link_options(cancel_queue_test PRIVATE -fsanitize=address)
 endif()

--- a/tt-media-server/cpp_server/include/ipc/boost_ipc_cancel_queue.hpp
+++ b/tt-media-server/cpp_server/include/ipc/boost_ipc_cancel_queue.hpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <boost/interprocess/ipc/message_queue.hpp>
+#include <memory>
+#include <string>
+
+#include "ipc/cancel_queue.hpp"
+
+namespace tt::ipc {
+
+/**
+ * ICancelQueue implementation backed by a Boost.Interprocess message queue.
+ *
+ * One queue per worker. The main process creates the queue; the worker opens
+ * it.
+ */
+class BoostIpcCancelQueue : public ICancelQueue {
+ public:
+  /** Create a new queue (main process). */
+  BoostIpcCancelQueue(const std::string& name, size_t capacity);
+
+  /** Open an existing queue (worker process). */
+  explicit BoostIpcCancelQueue(const std::string& name);
+
+  void push(const domain::TaskID& taskId) override;
+  void tryPopAll(std::vector<domain::TaskID>& out) override;
+  void remove() override;
+
+  /** Remove a named queue (cleanup helper). */
+  static void removeByName(const std::string& name);
+
+ private:
+  std::string name_;
+  std::unique_ptr<boost::interprocess::message_queue> queue_;
+  std::vector<char> recv_buffer_;
+};
+
+}  // namespace tt::ipc

--- a/tt-media-server/cpp_server/include/ipc/boost_ipc_cancel_queue.hpp
+++ b/tt-media-server/cpp_server/include/ipc/boost_ipc_cancel_queue.hpp
@@ -25,6 +25,8 @@ class BoostIpcCancelQueue : public ICancelQueue {
   /** Open an existing queue (worker process). */
   explicit BoostIpcCancelQueue(const std::string& name);
 
+  ~BoostIpcCancelQueue() override;
+
   void push(const domain::TaskID& taskId) override;
   void tryPopAll(std::vector<domain::TaskID>& out) override;
   void remove() override;

--- a/tt-media-server/cpp_server/include/ipc/cancel_queue.hpp
+++ b/tt-media-server/cpp_server/include/ipc/cancel_queue.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <vector>
+
+#include "domain/task_id.hpp"
+
+namespace tt::ipc {
+
+/**
+ * Abstract interface for a cancel-signal queue (main process -> worker).
+ *
+ * - push      -- non-blocking enqueue of a cancel signal.
+ * - tryPopAll -- drain all pending cancel signals.
+ */
+class ICancelQueue {
+ public:
+  virtual ~ICancelQueue() = default;
+
+  /** Non-blocking push. Drops the message with a warning if the queue is full.
+   */
+  virtual void push(const domain::TaskID& taskId) = 0;
+
+  /** Drain all available cancel messages into @p out. Non-blocking. */
+  virtual void tryPopAll(std::vector<domain::TaskID>& out) = 0;
+
+  /** Remove the underlying IPC resource. Default no-op. */
+  virtual void remove() {}
+};
+
+}  // namespace tt::ipc

--- a/tt-media-server/cpp_server/include/ipc/queue_manager.hpp
+++ b/tt-media-server/cpp_server/include/ipc/queue_manager.hpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "ipc/boost_ipc_cancel_queue.hpp"
 #include "ipc/boost_ipc_task_queue.hpp"
 #include "ipc/token_ring_buffer.hpp"
 
@@ -15,25 +16,34 @@ namespace tt::ipc {
 using namespace std;
 
 constexpr const char* TASK_QUEUE_NAME = "tt_tasks";
+constexpr const char* CANCEL_QUEUE_PREFIX = "tt_cancels_";
 constexpr size_t RING_BUFFER_CAPACITY = 65536;
+constexpr size_t CANCEL_QUEUE_CAPACITY = 1024;
 
 /**
- * Manages task queue and result queues for LLM workers.
+ * Manages task queue, result queues, and cancel queues for LLM workers.
  * Handles creation, cleanup, and coordination of IPC queues.
  */
 class QueueManager {
  public:
   shared_ptr<BoostIpcTaskQueue> task_queue;
   vector<shared_ptr<TokenRingBuffer<RING_BUFFER_CAPACITY>>> result_queues;
+  vector<shared_ptr<BoostIpcCancelQueue>> cancel_queues;
 
   explicit QueueManager(int numWorkers) {
     BoostIpcTaskQueue::remove(TASK_QUEUE_NAME);
     task_queue = make_shared<BoostIpcTaskQueue>(TASK_QUEUE_NAME, 1024);
     result_queues.reserve(numWorkers);
+    cancel_queues.reserve(numWorkers);
     for (int i = 0; i < numWorkers; i++) {
       result_queues.emplace_back(
           make_shared<TokenRingBuffer<RING_BUFFER_CAPACITY>>(
               "/tt_tokens_" + to_string(i), true));
+
+      string cancelName = CANCEL_QUEUE_PREFIX + to_string(i);
+      BoostIpcCancelQueue::removeByName(cancelName);
+      cancel_queues.emplace_back(
+          make_shared<BoostIpcCancelQueue>(cancelName, CANCEL_QUEUE_CAPACITY));
     }
   }
 
@@ -43,6 +53,9 @@ class QueueManager {
     BoostIpcTaskQueue::remove(TASK_QUEUE_NAME);
     for (auto& queue : result_queues) {
       queue->shutdown();
+    }
+    for (size_t i = 0; i < cancel_queues.size(); i++) {
+      cancel_queues[i]->remove();
     }
   }
 

--- a/tt-media-server/cpp_server/include/worker/single_process_worker.hpp
+++ b/tt-media-server/cpp_server/include/worker/single_process_worker.hpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 
 #include "config/runner_config.hpp"
+#include "ipc/cancel_queue.hpp"
 #include "ipc/token_ring_buffer.hpp"
 #include "runners/llm_runner/task_queue.hpp"
 #include "runners/runner_interface.hpp"
@@ -19,6 +20,7 @@ struct WorkerConfig {
   unordered_map<string, string> env_vars;
   shared_ptr<llm_engine::ITaskQueue> task_queue;
   shared_ptr<tt::ipc::TokenRingBuffer<65536>> result_queue;
+  shared_ptr<tt::ipc::ICancelQueue> cancel_queue;
   int worker_id;
   tt::config::RunnerConfig runner_config;
 };

--- a/tt-media-server/cpp_server/src/ipc/boost_ipc_cancel_queue.cpp
+++ b/tt-media-server/cpp_server/src/ipc/boost_ipc_cancel_queue.cpp
@@ -23,6 +23,14 @@ BoostIpcCancelQueue::BoostIpcCancelQueue(const std::string& name)
           std::make_unique<bip::message_queue>(bip::open_only, name.c_str())),
       recv_buffer_(domain::TaskID::K_SERIALIZED_SIZE) {}
 
+BoostIpcCancelQueue::~BoostIpcCancelQueue() {
+  try {
+    queue_.reset();
+  } catch (const bip::interprocess_exception& e) {
+    TT_LOG_WARN("[BoostIpcCancelQueue] Destructor: {} (ignored)", e.what());
+  }
+}
+
 void BoostIpcCancelQueue::push(const domain::TaskID& taskId) {
   auto buf = taskId.ipcSerialize();
   if (!queue_->try_send(buf.data(), buf.size(), 0)) {

--- a/tt-media-server/cpp_server/src/ipc/boost_ipc_cancel_queue.cpp
+++ b/tt-media-server/cpp_server/src/ipc/boost_ipc_cancel_queue.cpp
@@ -15,13 +15,13 @@ BoostIpcCancelQueue::BoostIpcCancelQueue(const std::string& name,
       queue_(std::make_unique<bip::message_queue>(
           bip::create_only, name.c_str(), capacity,
           domain::TaskID::K_SERIALIZED_SIZE)),
-      recv_buffer_(domain::TaskID::K_SERIALIZED_SIZE) {}
+      recv_buffer_(queue_->get_max_msg_size()) {}
 
 BoostIpcCancelQueue::BoostIpcCancelQueue(const std::string& name)
     : name_(name),
       queue_(
           std::make_unique<bip::message_queue>(bip::open_only, name.c_str())),
-      recv_buffer_(domain::TaskID::K_SERIALIZED_SIZE) {}
+      recv_buffer_(queue_->get_max_msg_size()) {}
 
 BoostIpcCancelQueue::~BoostIpcCancelQueue() {
   try {

--- a/tt-media-server/cpp_server/src/ipc/boost_ipc_cancel_queue.cpp
+++ b/tt-media-server/cpp_server/src/ipc/boost_ipc_cancel_queue.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#include "ipc/boost_ipc_cancel_queue.hpp"
+
+#include "utils/logger.hpp"
+
+namespace tt::ipc {
+
+namespace bip = boost::interprocess;
+
+BoostIpcCancelQueue::BoostIpcCancelQueue(const std::string& name,
+                                         size_t capacity)
+    : name_(name),
+      queue_(std::make_unique<bip::message_queue>(
+          bip::create_only, name.c_str(), capacity,
+          domain::TaskID::K_SERIALIZED_SIZE)),
+      recv_buffer_(domain::TaskID::K_SERIALIZED_SIZE) {}
+
+BoostIpcCancelQueue::BoostIpcCancelQueue(const std::string& name)
+    : name_(name),
+      queue_(
+          std::make_unique<bip::message_queue>(bip::open_only, name.c_str())),
+      recv_buffer_(domain::TaskID::K_SERIALIZED_SIZE) {}
+
+void BoostIpcCancelQueue::push(const domain::TaskID& taskId) {
+  auto buf = taskId.ipcSerialize();
+  if (!queue_->try_send(buf.data(), buf.size(), 0)) {
+    TT_LOG_WARN("[CancelQueue] Queue '{}' full, dropping cancel for task_id={}",
+                name_, taskId.id);
+  }
+}
+
+void BoostIpcCancelQueue::tryPopAll(std::vector<domain::TaskID>& out) {
+  bip::message_queue::size_type recvdSize;
+  unsigned int priority;
+  while (queue_->try_receive(recv_buffer_.data(), recv_buffer_.size(),
+                             recvdSize, priority)) {
+    out.push_back(
+        domain::TaskID::ipcDeserialize(recv_buffer_.data(), recvdSize));
+  }
+}
+
+void BoostIpcCancelQueue::remove() { removeByName(name_); }
+
+void BoostIpcCancelQueue::removeByName(const std::string& name) {
+  bip::message_queue::remove(name.c_str());
+}
+
+}  // namespace tt::ipc

--- a/tt-media-server/cpp_server/src/worker/worker_manager.cpp
+++ b/tt-media-server/cpp_server/src/worker/worker_manager.cpp
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "config/settings.hpp"
+#include "ipc/boost_ipc_cancel_queue.hpp"
 #include "ipc/boost_ipc_task_queue.hpp"
 #include "ipc/boost_ipc_warmup_signal_queue.hpp"
 #include "ipc/queue_manager.hpp"
@@ -147,6 +148,8 @@ WorkerConfig WorkerManager::makeWorkerConfig(int workerId) {
   cfg.result_queue =
       std::make_shared<tt::ipc::TokenRingBuffer<tt::ipc::RING_BUFFER_CAPACITY>>(
           "/tt_tokens_" + std::to_string(workerId), false);
+  cfg.cancel_queue = std::make_shared<tt::ipc::BoostIpcCancelQueue>(
+      std::string(tt::ipc::CANCEL_QUEUE_PREFIX) + std::to_string(workerId));
   cfg.worker_id = workerId;
   cfg.runner_config = tt::config::llmEngineConfig();
   return cfg;
@@ -221,6 +224,8 @@ WorkerConfig makeWorkerConfigForProcess(int workerId) {
   cfg.result_queue =
       std::make_shared<tt::ipc::TokenRingBuffer<tt::ipc::RING_BUFFER_CAPACITY>>(
           "/tt_tokens_" + std::to_string(workerId), false);
+  cfg.cancel_queue = std::make_shared<tt::ipc::BoostIpcCancelQueue>(
+      std::string(tt::ipc::CANCEL_QUEUE_PREFIX) + std::to_string(workerId));
   cfg.worker_id = workerId;
   cfg.runner_config = tt::config::llmEngineConfig();
   return cfg;

--- a/tt-media-server/cpp_server/tests/cancel_queue_test.cpp
+++ b/tt-media-server/cpp_server/tests/cancel_queue_test.cpp
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <string>
+#include <vector>
+
+#include "domain/task_id.hpp"
+#include "ipc/boost_ipc_cancel_queue.hpp"
+
+namespace {
+
+// Use PID-based unique names to avoid interference between parallel test runs.
+std::string uniqueName(const std::string& base) {
+  return base + "_" + std::to_string(getpid());
+}
+
+class BoostIpcCancelQueueTest : public ::testing::Test {
+ protected:
+  std::string queueName;
+
+  void SetUp() override {
+    queueName = uniqueName("test_cancel_q");
+    tt::ipc::BoostIpcCancelQueue::removeByName(queueName);
+  }
+
+  void TearDown() override {
+    tt::ipc::BoostIpcCancelQueue::removeByName(queueName);
+  }
+};
+
+TEST_F(BoostIpcCancelQueueTest, PushAndPopRoundTrip) {
+  tt::ipc::BoostIpcCancelQueue queue(queueName, 16);
+
+  tt::domain::TaskID id1("task-abc-123");
+  tt::domain::TaskID id2("task-def-456");
+  queue.push(id1);
+  queue.push(id2);
+
+  std::vector<tt::domain::TaskID> out;
+  queue.tryPopAll(out);
+
+  ASSERT_EQ(out.size(), 2u);
+  EXPECT_EQ(out[0].id, "task-abc-123");
+  EXPECT_EQ(out[1].id, "task-def-456");
+}
+
+TEST_F(BoostIpcCancelQueueTest, PopEmptyReturnsNothing) {
+  tt::ipc::BoostIpcCancelQueue queue(queueName, 16);
+
+  std::vector<tt::domain::TaskID> out;
+  queue.tryPopAll(out);
+
+  EXPECT_TRUE(out.empty());
+}
+
+TEST_F(BoostIpcCancelQueueTest, PushWhenFullDropsWithoutThrow) {
+  tt::ipc::BoostIpcCancelQueue queue(queueName, 2);
+
+  queue.push(tt::domain::TaskID("t1"));
+  queue.push(tt::domain::TaskID("t2"));
+  // Queue is full — this should not throw, just log a warning and drop.
+  EXPECT_NO_THROW(queue.push(tt::domain::TaskID("t3")));
+
+  std::vector<tt::domain::TaskID> out;
+  queue.tryPopAll(out);
+  ASSERT_EQ(out.size(), 2u);
+  EXPECT_EQ(out[0].id, "t1");
+  EXPECT_EQ(out[1].id, "t2");
+}
+
+TEST_F(BoostIpcCancelQueueTest, MultiplePushDrainInOrder) {
+  tt::ipc::BoostIpcCancelQueue queue(queueName, 64);
+
+  for (int i = 0; i < 10; i++) {
+    queue.push(tt::domain::TaskID("id-" + std::to_string(i)));
+  }
+
+  std::vector<tt::domain::TaskID> out;
+  queue.tryPopAll(out);
+  ASSERT_EQ(out.size(), 10u);
+  for (int i = 0; i < 10; i++) {
+    EXPECT_EQ(out[i].id, "id-" + std::to_string(i));
+  }
+}
+
+TEST_F(BoostIpcCancelQueueTest, PopAllThenPopAgainIsEmpty) {
+  tt::ipc::BoostIpcCancelQueue queue(queueName, 16);
+
+  queue.push(tt::domain::TaskID("x"));
+
+  std::vector<tt::domain::TaskID> out;
+  queue.tryPopAll(out);
+  ASSERT_EQ(out.size(), 1u);
+
+  out.clear();
+  queue.tryPopAll(out);
+  EXPECT_TRUE(out.empty());
+}
+
+TEST_F(BoostIpcCancelQueueTest, OpenExistingQueue) {
+  // Create queue (simulates main process).
+  tt::ipc::BoostIpcCancelQueue creator(queueName, 16);
+  creator.push(tt::domain::TaskID("from-main"));
+
+  // Open existing queue (simulates worker process).
+  tt::ipc::BoostIpcCancelQueue opener(queueName);
+
+  std::vector<tt::domain::TaskID> out;
+  opener.tryPopAll(out);
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_EQ(out[0].id, "from-main");
+}
+
+TEST_F(BoostIpcCancelQueueTest, RemoveCleansUpResource) {
+  {
+    tt::ipc::BoostIpcCancelQueue queue(queueName, 16);
+    queue.remove();
+  }
+  // After removal, creating a new queue with the same name should succeed
+  // (the old resource was cleaned up).
+  EXPECT_NO_THROW(tt::ipc::BoostIpcCancelQueue(queueName, 16));
+}
+
+}  // namespace


### PR DESCRIPTION
https://github.com/tenstorrent/tt-inference-server/issues/2264

This a continuation of https://github.com/tenstorrent/tt-inference-server/pull/2619
Adding cancellation queue, next step to discard requests on the worker side.