### PR TITLE
fix: pass API_KEY to media and forge server engines

### DIFF
--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -144,7 +144,13 @@ def _setup_openai_api_key(args, logger):
         args: Parsed command line arguments
         logger: Logger instance
     """
-    api_key = args.jwt_secret or os.getenv("API_KEY", "your-secret-key")
+    api_key = os.getenv("API_KEY")
+    if not api_key:
+        api_key = "your-secret-key"
+        logger.warning(
+            "API_KEY is not set. Using a default key for media server auth. "
+            "Set API_KEY in .env or as an environment variable."
+        )
     os.environ["OPENAI_API_KEY"] = api_key
     logger.info("OPENAI_API_KEY environment variable set.")
 

--- a/run.py
+++ b/run.py
@@ -362,6 +362,18 @@ def handle_secrets(runtime_config):
     if huggingface_required:
         required_env_vars += ["HF_TOKEN"]
 
+    if (
+        workflow_type == WorkflowType.SERVER
+        and runtime_config.engine in ("media", "forge")
+        and not runtime_config.no_auth
+        and not runtime_config.interactive
+        and not os.getenv("API_KEY")
+    ):
+        logger.warning(
+            "API_KEY is not set. Using a default key for media/forge server auth. "
+            "Set API_KEY in .env or as an environment variable."
+        )
+
     # load secrets from env file or prompt user to enter them once
     if not load_dotenv():
         env_vars = {}

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -217,6 +217,9 @@ def generate_docker_run_command(
         or model_spec.inference_engine == InferenceEngine.MEDIA.value
     ):
         docker_env_vars.update(get_media_server_docker_env_vars(model_spec))
+        api_key = os.getenv("API_KEY")
+        if api_key:
+            docker_env_vars["API_KEY"] = api_key
 
     user_home_path = "/home/container_app_user"
     if runtime_config.dev_mode:

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -266,7 +266,7 @@ def generate_docker_run_command(
         if value:
             docker_command.extend(["-e", f"{key}={str(value)}"])
         else:
-            logger.info(f"Skipping {key} in docker run command, value={value}")
+            logger.info(f"Skipping {key} in docker run command (value not set)")
 
     if runtime_config.disable_metal_timeout:
         docker_command.extend(["-e", "DISABLE_METAL_OP_TIMEOUT=1"])

--- a/workflows/run_local_server.py
+++ b/workflows/run_local_server.py
@@ -193,6 +193,14 @@ def build_local_server_env(
     if runtime_config.disable_metal_timeout:
         env["DISABLE_METAL_OP_TIMEOUT"] = "1"
 
+    if model_spec.inference_engine in (
+        InferenceEngine.MEDIA.value,
+        InferenceEngine.FORGE.value,
+    ):
+        api_key = os.getenv("API_KEY")
+        if api_key:
+            env["API_KEY"] = api_key
+
     return env
 
 


### PR DESCRIPTION
## Summary

- Forward `API_KEY` environment variable to media and forge server engines in both docker and local server launch paths
- When `API_KEY` is set in the environment, inject it so the server can authenticate incoming requests correctly
- Uses `API_KEY` directly — the media-server uses a simple bearer token, not a JWT, so `JWT_SECRET` is not applicable to this code path
- Redact env var value from docker log message to avoid leaking sensitive keys

Closes #2636 (fixes Bug 2: API_KEY not forwarded to server launch paths)

## Context

Issue #2636 identifies two bugs. This PR fixes **Bug 2** only: the server launch paths (`run_docker_server.py`, `run_local_server.py`) were not forwarding `API_KEY` for media/forge engines, causing all auth-protected requests to return 401.

**Bug 1** (JWT_SECRET shadowing API_KEY in `run_evals.py`, and `--jwt-secret` not forwarded from `run_workflows.py`) is a separate change to the evals path and is tracked as a follow-up on #2636.

Split from #2642.

## Shield runs

- whisper-large-v3 (p150, bh-qb-ge): https://github.com/tenstorrent/tt-shield/actions/runs/24102745859
- speecht5_tts (p150, bh-qb-ge): https://github.com/tenstorrent/tt-shield/actions/runs/24102747131