### PR TITLE
For continuation or small ISL do prefill on decode

### DIFF
--- a/tt-media-server/cpp_server/include/api/llm_controller.hpp
+++ b/tt-media-server/cpp_server/include/api/llm_controller.hpp
@@ -100,9 +100,8 @@ class LLMController : public drogon::HttpController<LLMController> {
   /**
    * Determine if disaggregated prefill should be used for this request.
    */
-  bool shouldDoPrefillOnDecode(
-      const domain::CompletionRequest& request,
-      bool validSessionFound) const;
+  bool shouldDoPrefillOnDecode(const domain::CompletionRequest& request,
+                               bool validSessionFound) const;
 };
 
 }  // namespace tt::api

--- a/tt-media-server/cpp_server/include/api/llm_controller.hpp
+++ b/tt-media-server/cpp_server/include/api/llm_controller.hpp
@@ -96,6 +96,13 @@ class LLMController : public drogon::HttpController<LLMController> {
                                const std::string& type,
                                const Json::Value& param = Json::nullValue,
                                const Json::Value& code = Json::nullValue);
+
+  /**
+   * Determine if disaggregated prefill should be used for this request.
+   */
+  bool shouldDoPrefillOnDecode(
+      const domain::CompletionRequest& request,
+      bool validSessionFound) const;
 };
 
 }  // namespace tt::api

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -31,5 +31,6 @@ constexpr size_t MAX_IN_FLIGHT_COUNT = 32;
 constexpr size_t MAX_SESSIONS_COUNT = 64;
 constexpr unsigned SESSION_EVICTION_RATE = 90;
 constexpr size_t SESSION_EVICTION_COUNT = 10;
+constexpr size_t MAX_TOKENS_TO_PREFILL_ON_DECODE = 100;
 
 }  // namespace tt::config::defaults

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -105,6 +105,10 @@ unsigned sessionEvictionRate();
  * defaults::SESSION_EVICTION_COUNT. */
 size_t sessionEvictionCount();
 
+/** Max tokens to prefill on decode server from MAX_TOKENS_TO_PREFILL_ON_DECODE.
+ * Default: defaults::MAX_TOKENS_TO_PREFILL_ON_DECODE. */
+size_t maxTokensToPrefillOnDecode();
+
 /** Build LLMConfig from environment variables and runtime settings. Implemented
  * in src/config/settings.cpp. */
 LLMConfig llmEngineConfig();

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -580,12 +580,13 @@ void LLMController::handleStreaming(
             "[LLMController] Using prefill on decode for sessionId: {}",
             reqPtr->sessionId.value_or("none"));
         service->submitStreamingRequest(*reqPtr, streamingCallback);
-      }
-      else {
+      } else {
         TT_LOG_DEBUG(
-            "[LLMController] Using disaggregated prefill for request with sessionId: {}",
+            "[LLMController] Using disaggregated prefill for request with "
+            "sessionId: {}",
             reqPtr->sessionId.value_or("none"));
-        disaggregationService->handleStreamingRequest(*reqPtr, streamingCallback);
+        disaggregationService->handleStreamingRequest(*reqPtr,
+                                                      streamingCallback);
       }
     } else {
       throw std::runtime_error(
@@ -621,8 +622,7 @@ void LLMController::handleStreaming(
 }
 
 bool LLMController::shouldDoPrefillOnDecode(
-    const domain::CompletionRequest& request,
-    bool validSessionFound) const {
+    const domain::CompletionRequest& request, bool validSessionFound) const {
   // for valid sessions always do prefill on decode
   if (validSessionFound) {
     return true;

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -323,12 +323,15 @@ void LLMController::handleStreaming(
     bool isChat) const {
   ZoneScopedN("API::handleStreaming");
 
+  bool validSessionFound = false;
+
   if (reqPtr->sessionId.has_value() && sessionManager) {
     auto slotId =
         sessionManager->getSlotIdBySessionId(reqPtr->sessionId.value());
 
     if (slotId != tt::services::INVALID_SLOT_ID) {
       reqPtr->slotId = slotId;
+      validSessionFound = true;  // Session is valid
     } else {
       TT_LOG_INFO(
           "Received request with non existing session, resetting session id");
@@ -570,7 +573,20 @@ void LLMController::handleStreaming(
     if (tt::config::llmMode() == tt::config::LLMMode::REGULAR) {
       service->submitStreamingRequest(*reqPtr, streamingCallback);
     } else if (tt::config::llmMode() == tt::config::LLMMode::DECODE_ONLY) {
-      disaggregationService->handleStreamingRequest(*reqPtr, streamingCallback);
+      // tokenize right away
+      service->preProcess(*reqPtr);
+      if (shouldDoPrefillOnDecode(*reqPtr, validSessionFound)) {
+        TT_LOG_DEBUG(
+            "[LLMController] Using prefill on decode for sessionId: {}",
+            reqPtr->sessionId.value_or("none"));
+        service->submitStreamingRequest(*reqPtr, streamingCallback);
+      }
+      else {
+        TT_LOG_DEBUG(
+            "[LLMController] Using disaggregated prefill for request with sessionId: {}",
+            reqPtr->sessionId.value_or("none"));
+        disaggregationService->handleStreamingRequest(*reqPtr, streamingCallback);
+      }
     } else {
       throw std::runtime_error(
           "[LLMController] LLM Mode must be regular or decode only to handle "
@@ -602,6 +618,22 @@ void LLMController::handleStreaming(
   resp->addHeader("X-Accel-Buffering", "no");
 
   callback(resp);
+}
+
+bool LLMController::shouldDoPrefillOnDecode(
+    const domain::CompletionRequest& request,
+    bool validSessionFound) const {
+  // for valid sessions always do prefill on decode
+  if (validSessionFound) {
+    return true;
+  }
+
+  // Check if the number of prompt tokens exceeds the threshold
+  // If tokens are below the threshold, prefill on decode server
+  const size_t maxTokens = tt::config::maxTokensToPrefillOnDecode();
+  const size_t promptTokens = static_cast<size_t>(request.prompt_tokens_count);
+
+  return promptTokens < maxTokens;
 }
 
 void LLMController::createSession(

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -243,8 +243,9 @@ size_t sessionEvictionCount() {
 }
 
 size_t maxTokensToPrefillOnDecode() {
-  return static_cast<size_t>(envUlong("MAX_TOKENS_TO_PREFILL_ON_DECODE",
-                                      defaults::MAX_TOKENS_TO_PREFILL_ON_DECODE));
+  return static_cast<size_t>(
+      envUlong("MAX_TOKENS_TO_PREFILL_ON_DECODE",
+               defaults::MAX_TOKENS_TO_PREFILL_ON_DECODE));
 }
 
 }  // namespace tt::config

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -242,4 +242,9 @@ size_t sessionEvictionCount() {
       envUlong("SESSION_EVICTION_COUNT", defaults::SESSION_EVICTION_COUNT));
 }
 
+size_t maxTokensToPrefillOnDecode() {
+  return static_cast<size_t>(envUlong("MAX_TOKENS_TO_PREFILL_ON_DECODE",
+                                      defaults::MAX_TOKENS_TO_PREFILL_ON_DECODE));
+}
+
 }  // namespace tt::config

--- a/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
@@ -156,13 +156,14 @@ void LlamaModelRunner::run(const std::vector<Sequence*>& seqs, bool isPrefill) {
 
       for (size_t i = 0; i < seqs.size(); ++i) {
         py::object item = results[py::int_(i)];
-        uint32_t drTaskId(item.attr("task_id").cast<std::string>());
+        std::string taskIdStr = item.attr("task_id").cast<std::string>();
+        uint32_t drTaskId = std::hash<std::string>{}(taskIdStr);
         uint64_t drTokenId =
             static_cast<uint64_t>(item.attr("token_id").cast<int64_t>());
         std::string error = item.attr("error").cast<std::string>();
         bool drIsError = !error.empty();
         if (drIsError) {
-          TT_LOG_ERROR("[LlamaModelRunner] sequence {} error: {}", drTaskId.id,
+          TT_LOG_ERROR("[LlamaModelRunner] sequence {} error: {}", taskIdStr,
                        error);
         }
         TokenResult dr(drTaskId, drTokenId, {}, drIsError);

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -135,7 +135,6 @@ void DisaggregationService::stop() { socketService->stop(); }
 void DisaggregationService::handleStreamingRequest(
     domain::CompletionRequest& request, const StreamCallback& callback) {
   if (mode == tt::config::LLMMode::DECODE_ONLY) {
-    llmService->preProcess(request);
     streamCallbacks.insert(request.task_id, callback);
 
     auto maxTokens = request.max_tokens;


### PR DESCRIPTION
Do prefill on decode if:

- Valid session is found
- ISL is below 100 tokens (move to 1000 when done with testing)