### PR TITLE
SDXL fix bug: trace region

### DIFF
--- a/tt-media-server/tt_model_runners/base_sdxl_runner.py
+++ b/tt-media-server/tt_model_runners/base_sdxl_runner.py
@@ -11,7 +11,6 @@ from domain.image_generate_request import ImageGenerateRequest
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     SDXL_FABRIC_CONFIG,
     SDXL_L1_SMALL_SIZE,
-    SDXL_TRACE_REGION_SIZE,
 )
 from models.demos.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import (
     TtSDXLPipeline,
@@ -35,8 +34,6 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
     def get_pipeline_device_params(self):
         device_params = {
             "l1_small_size": SDXL_L1_SMALL_SIZE,
-            "trace_region_size": self.settings.trace_region_size
-            or SDXL_TRACE_REGION_SIZE,
         }
         if self.is_tensor_parallel:
             device_params["fabric_config"] = SDXL_FABRIC_CONFIG


### PR DESCRIPTION
## Problem Description
After PR: [SDXL: BH optimizations](https://github.com/tenstorrent/tt-metal/commit/f27eb6d24bbdad394972e5a5977abc66a619be45) SDXL is failing in On-nightly [example_link](https://github.com/tenstorrent/tt-shield/actions/runs/23873327232/job/69613895905)

error:
```
ImportError: Failed to load model runner tt-sdxl-trace: cannot import name 'SDXL_TRACE_REGION_SIZE' from 'models.demos.stable_diffusion_xl_base.tests.test_common' 
```

## Checklist
- [x] [SDXL Shield Ci with inference server](https://github.com/tenstorrent/tt-shield/actions/runs/23916374352) ✅ passed


