### PR TITLE
Enable virtual warmup dispatch and non-blocking server startup

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -602,10 +602,18 @@ jobs:
           echo $! > ../../cpp_server.pid
           cd ../..
           for i in $(seq 1 30); do
-            curl -sf http://127.0.0.1:8000/health | grep -q '"status"' && break
+            LIVENESS=$(curl -sf "http://127.0.0.1:8000/tt-liveness" 2>/dev/null || true)
+            if echo "$LIVENESS" | grep -q '"model_ready":true'; then
+              echo "Server ready."
+              break
+            fi
             sleep 1
           done
-          curl -sf http://127.0.0.1:8000/health || exit 1
+          LIVENESS=$(curl -sf "http://127.0.0.1:8000/tt-liveness" 2>/dev/null || true)
+          if ! echo "$LIVENESS" | grep -q '"model_ready":true'; then
+            echo "ERROR: Server did not become ready within 30 seconds"
+            exit 1
+          fi
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
@@ -767,10 +775,18 @@ jobs:
           echo $! > ../../cpp_server.pid
           cd ../..
           for i in $(seq 1 30); do
-            curl -sf http://127.0.0.1:8000/health | grep -q '"status"' && break
+            LIVENESS=$(curl -sf "http://127.0.0.1:8000/tt-liveness" 2>/dev/null || true)
+            if echo "$LIVENESS" | grep -q '"model_ready":true'; then
+              echo "Server ready."
+              break
+            fi
             sleep 1
           done
-          curl -sf http://127.0.0.1:8000/health || exit 1
+          LIVENESS=$(curl -sf "http://127.0.0.1:8000/tt-liveness" 2>/dev/null || true)
+          if ! echo "$LIVENESS" | grep -q '"model_ready":true'; then
+            echo "ERROR: Server did not become ready within 30 seconds"
+            exit 1
+          fi
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
@@ -933,11 +949,18 @@ jobs:
           echo $! > ../../decode_server.pid
           cd ../..
           for i in $(seq 1 30); do
-            curl -sf http://127.0.0.1:8001/health | grep -q '"status"' && break
+            LIVENESS=$(curl -sf "http://127.0.0.1:8001/tt-liveness" 2>/dev/null || true)
+            if echo "$LIVENESS" | grep -q '"model_ready":true'; then
+              echo "✅ Decode server ready on port 8001"
+              break
+            fi
             sleep 1
           done
-          curl -sf http://127.0.0.1:8001/health || exit 1
-          echo "✅ Decode server started on port 8001"
+          LIVENESS=$(curl -sf "http://127.0.0.1:8001/tt-liveness" 2>/dev/null || true)
+          if ! echo "$LIVENESS" | grep -q '"model_ready":true'; then
+            echo "ERROR: Decode server did not become ready within 30 seconds"
+            exit 1
+          fi
 
       - name: Start Prefill server (connects to decode server)
         run: |
@@ -947,11 +970,18 @@ jobs:
           echo $! > ../../prefill_server.pid
           cd ../..
           for i in $(seq 1 30); do
-            curl -sf http://127.0.0.1:8002/health | grep -q '"status"' && break
+            LIVENESS=$(curl -sf "http://127.0.0.1:8002/tt-liveness" 2>/dev/null || true)
+            if echo "$LIVENESS" | grep -q '"model_ready":true'; then
+              echo "✅ Prefill server ready on port 8002"
+              break
+            fi
             sleep 1
           done
-          curl -sf http://127.0.0.1:8002/health || exit 1
-          echo "✅ Prefill server started on port 8002"
+          LIVENESS=$(curl -sf "http://127.0.0.1:8002/tt-liveness" 2>/dev/null || true)
+          if ! echo "$LIVENESS" | grep -q '"model_ready":true'; then
+            echo "ERROR: Prefill server did not become ready within 30 seconds"
+            exit 1
+          fi
           sleep 2
 
       - name: Set up uv

--- a/tt-media-server/cpp_server/include/domain/manage_memory.hpp
+++ b/tt-media-server/cpp_server/include/domain/manage_memory.hpp
@@ -11,6 +11,8 @@
 
 namespace tt::domain {
 
+constexpr uint32_t INVALID_SLOT_ID = std::numeric_limits<uint32_t>::max();
+
 enum class MemoryManagementAction : std::uint8_t {
   ALLOCATE = 0,
   DEALLOCATE = 1,
@@ -56,7 +58,7 @@ struct ManageMemoryTask {
     task.memoryLayout = static_cast<KvMemoryLayout>(ml);
     std::uint32_t n = 0;
     is.read(reinterpret_cast<char*>(&n), sizeof(n));
-    task.slotIds.resize(n, std::numeric_limits<std::uint32_t>::max());
+    task.slotIds.resize(n, INVALID_SLOT_ID);
     for (std::uint32_t i = 0; i < n; ++i) {
       is.read(reinterpret_cast<char*>(&task.slotIds[i]), sizeof(std::uint32_t));
     }
@@ -94,7 +96,7 @@ struct ManageMemoryResult {
     result.status = static_cast<ManageMemoryStatus>(s);
     std::uint32_t n = 0;
     is.read(reinterpret_cast<char*>(&n), sizeof(n));
-    result.slotIds.resize(n, std::numeric_limits<std::uint32_t>::max());
+    result.slotIds.resize(n, INVALID_SLOT_ID);
     for (std::uint32_t i = 0; i < n; ++i) {
       is.read(reinterpret_cast<char*>(&result.slotIds[i]),
               sizeof(std::uint32_t));

--- a/tt-media-server/cpp_server/include/domain/session.hpp
+++ b/tt-media-server/cpp_server/include/domain/session.hpp
@@ -46,9 +46,7 @@ class Session {
   /**
    * Check if a slot is assigned.
    */
-  bool hasSlot() const {
-    return slot_id_ != INVALID_SLOT_ID;
-  }
+  bool hasSlot() const { return slot_id_ != INVALID_SLOT_ID; }
 
   /**
    * Get the last activity time.

--- a/tt-media-server/cpp_server/include/domain/session.hpp
+++ b/tt-media-server/cpp_server/include/domain/session.hpp
@@ -7,11 +7,12 @@
 
 #include <chrono>
 #include <cstdint>
-#include <limits>
 #include <optional>
 #include <random>
 #include <sstream>
 #include <string>
+
+#include "domain/manage_memory.hpp"
 
 namespace tt::domain {
 
@@ -24,7 +25,7 @@ class Session {
    * Create a new session with a generated UUID.
    * @param slotId Optional slot ID (max uint32_t means unassigned)
    */
-  explicit Session(uint32_t slotId = std::numeric_limits<uint32_t>::max());
+  explicit Session(uint32_t slotId = INVALID_SLOT_ID);
 
   /**
    * Get the session ID (UUID).
@@ -46,7 +47,7 @@ class Session {
    * Check if a slot is assigned.
    */
   bool hasSlot() const {
-    return slot_id_ != std::numeric_limits<uint32_t>::max();
+    return slot_id_ != INVALID_SLOT_ID;
   }
 
   /**

--- a/tt-media-server/cpp_server/include/runners/embedding_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/embedding_runner.hpp
@@ -34,7 +34,7 @@ class EmbeddingRunner : public IRunner {
    * Initialize Python, import modules, create BGELargeENRunner instance,
    * and call warmup().
    */
-  bool warmup();
+  bool warmup() override;
 
   /**
    * Clean up Python objects and optionally finalize interpreter.

--- a/tt-media-server/cpp_server/include/runners/runner_interface.hpp
+++ b/tt-media-server/cpp_server/include/runners/runner_interface.hpp
@@ -25,7 +25,7 @@ class IRunner {
   /**
    * Warm up the runner by preloading models and resources.
    */
-  bool warmup() { return true; }
+  virtual bool warmup() { return true; }
 
   /**
    * Warm up then run the inference loop. Optional onWarmupDone is invoked

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
@@ -33,7 +33,7 @@ class SpPipelineRunner : public IRunner {
 
   void run() override;
   void stop() override;
-  bool warmup();
+  bool warmup() override;
   const char* runnerType() const override { return "SpPipelineRunner"; }
 
  private:

--- a/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_runner.hpp
@@ -24,7 +24,7 @@ class SpPrefillRunner : public IRunner {
 
   void run() override;
   void stop() override;
-  bool warmup();
+  bool warmup() override;
   const char* runnerType() const override { return "SpPrefillRunner"; }
 
  private:

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -6,7 +6,6 @@
 #include <atomic>
 #include <cstdint>
 #include <future>
-#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -18,8 +17,7 @@
 
 namespace tt::services {
 
-// Invalid slot ID constant
-constexpr uint32_t INVALID_SLOT_ID = std::numeric_limits<uint32_t>::max();
+using tt::domain::INVALID_SLOT_ID;
 
 class SessionManager {
  public:

--- a/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
@@ -6,10 +6,11 @@
 #include <cereal/types/string.hpp>
 #include <cereal/types/vector.hpp>
 #include <cstdint>
-#include <limits>
 #include <optional>
 #include <string>
 #include <vector>
+
+#include "domain/manage_memory.hpp"
 
 namespace tt::sockets {
 
@@ -28,7 +29,7 @@ struct PrefillRequestMessage {
   template <class Archive>
   void write(Archive& ar) const {
     int mt = max_tokens.has_value() ? max_tokens.value() : -1;
-    uint32_t sid = slot_id.value_or(std::numeric_limits<uint32_t>::max());
+    uint32_t sid = slot_id.value_or(tt::domain::INVALID_SLOT_ID);
     ar(task_id, prompt, token_ids, mt, sid);
   }
 
@@ -44,7 +45,7 @@ struct PrefillRequestMessage {
     msg.prompt = std::move(p);
     msg.token_ids = std::move(tids);
     msg.max_tokens = (mt == -1) ? std::nullopt : std::optional<int>(mt);
-    msg.slot_id = (sid == std::numeric_limits<uint32_t>::max())
+    msg.slot_id = (sid == tt::domain::INVALID_SLOT_ID)
                       ? std::nullopt
                       : std::optional<uint32_t>(sid);
     return msg;
@@ -73,7 +74,7 @@ struct PrefillResultMessage {
   template <class Archive>
   void write(Archive& ar) const {
     int rt = remaining_tokens.has_value() ? remaining_tokens.value() : -1;
-    uint32_t sid = slot_id.value_or(std::numeric_limits<uint32_t>::max());
+    uint32_t sid = slot_id.value_or(tt::domain::INVALID_SLOT_ID);
     ar(task_id, generated_text, finished, tokens_generated, processing_time_ms,
        token_ids, rt, sid);
   }
@@ -96,7 +97,7 @@ struct PrefillResultMessage {
     msg.processing_time_ms = pt;
     msg.token_ids = std::move(tids);
     msg.remaining_tokens = (rt == -1) ? std::nullopt : std::optional<int>(rt);
-    msg.slot_id = (sid == std::numeric_limits<uint32_t>::max())
+    msg.slot_id = (sid == tt::domain::INVALID_SLOT_ID)
                       ? std::nullopt
                       : std::optional<uint32_t>(sid);
     return msg;

--- a/tt-media-server/cpp_server/include/worker/worker_manager.hpp
+++ b/tt-media-server/cpp_server/include/worker/worker_manager.hpp
@@ -62,7 +62,6 @@ class WorkerManager {
 
   void startWorkers();
   void startWarmupListener();
-  void waitForFirstWarmup();
   void stopWarmupListener();
   void stopProcesses();
   WorkerConfig makeWorkerConfig(int workerId);

--- a/tt-media-server/cpp_server/src/worker/worker_manager.cpp
+++ b/tt-media-server/cpp_server/src/worker/worker_manager.cpp
@@ -61,7 +61,6 @@ WorkerManager::~WorkerManager() { stop(); }
 void WorkerManager::start() {
   startWarmupListener();
   startWorkers();
-  waitForFirstWarmup();
 }
 
 void WorkerManager::stop() {
@@ -207,12 +206,6 @@ void WorkerManager::startWarmupListener() {
       TT_LOG_WARN("[WorkerManager] Warmup listener failed: unknown exception");
     }
   });
-}
-
-void WorkerManager::waitForFirstWarmup() {
-  if (!warmupQueue) return;
-  std::unique_lock<std::mutex> lock(warmupMutex);
-  warmupCv.wait(lock, [this]() { return warmupReceived.load(); });
 }
 
 WorkerConfig makeWorkerConfigForProcess(int workerId) {

--- a/tt-media-server/cpp_server/tests/run_e2e_with_server.sh
+++ b/tt-media-server/cpp_server/tests/run_e2e_with_server.sh
@@ -44,10 +44,11 @@ export MODEL_SERVICE=llm
 "$SERVER_BIN" -p "$PORT" -h 127.0.0.1 > /dev/null 2>&1 &
 SERVER_PID=$!
 
-# Wait for server to be ready
+# Wait for server to be ready (model warmed up)
 echo "Waiting for server..."
-for i in $(seq 1 30); do
-    if curl -sf "http://127.0.0.1:$PORT/health" > /dev/null 2>&1; then
+for i in $(seq 1 60); do
+    LIVENESS=$(curl -sf "http://127.0.0.1:$PORT/tt-liveness" 2>/dev/null || true)
+    if echo "$LIVENESS" | grep -q '"model_ready":true'; then
         echo "Server ready."
         break
     fi
@@ -58,8 +59,9 @@ for i in $(seq 1 30); do
     sleep 1
 done
 
-if ! curl -sf "http://127.0.0.1:$PORT/health" > /dev/null 2>&1; then
-    echo "ERROR: Server did not become ready within 30 seconds"
+LIVENESS=$(curl -sf "http://127.0.0.1:$PORT/tt-liveness" 2>/dev/null || true)
+if ! echo "$LIVENESS" | grep -q '"model_ready":true'; then
+    echo "ERROR: Server did not become ready within 60 seconds"
     exit 1
 fi
 


### PR DESCRIPTION
- Make `IRunner::warmup()` a virtual method so subclass overrides (`SpPipelineRunner`, `SpPrefillRunner`, `EmbeddingRunner`) are properly dispatched through the base interface. 
- Removes the blocking `waitForFirstWarmup()` call from `WorkerManager::start()` so the server can begin accepting requests while workers warm up in the background. Removing the blocking wait is safe because the server already handles unready workers gracefully — the `isModelReady()` check on each request returns 503 until at least one worker has completed warmup, and the `/tt-liveness` endpoint reports `model_ready: false` in the meantime, so no requests are silently dropped.
- This also consolidates the `INVALID_SLOT_ID` constant into a single definition in `manage_memory.hpp` (replacing scattered `std::numeric_limits<uint32_t>::max()` usages across `session.hpp`, `session_manager.hpp`, and `socket_messages.hpp`).