### PR TITLE
Standardize signedness of count/size types

### DIFF
--- a/tt-media-server/cpp_server/include/config/runner_config.hpp
+++ b/tt-media-server/cpp_server/include/config/runner_config.hpp
@@ -18,13 +18,13 @@ namespace tt::config {
  */
 struct LLMConfig {
   static constexpr size_t MAX_INPUT_TOKENS = 131072;  // 128k
-  int max_num_batched_tokens = 64 * MAX_INPUT_TOKENS;
-  int max_in_flight_count = 64;
+  size_t max_num_batched_tokens = 64 * MAX_INPUT_TOKENS;
+  size_t max_in_flight_count = 64;
   std::vector<int64_t> stop_token_ids;  // Set by llm_engine_config() from
                                         // active tokenizer strategy
   int eos = 1;
-  int kvcache_block_size = 256;
-  int num_kvcache_blocks = 512;
+  size_t kvcache_block_size = 256;
+  size_t num_kvcache_blocks = 512;
   ModelRunnerType runner_type = ModelRunnerType::MOCK;
   SchedulingPolicy scheduling_policy = SchedulingPolicy::PREFILL_FIRST;
 };

--- a/tt-media-server/cpp_server/include/runners/llm_runner/block_manager.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/block_manager.hpp
@@ -26,7 +26,7 @@ class Block {
 
 class BlockManager {
  public:
-  BlockManager(int numBlocks, int blockSize);
+  BlockManager(size_t numBlocks, size_t blockSize);
 
   static int64_t computeHash(const std::vector<int64_t>& tokenIds,
                              int64_t prefix = -1);
@@ -36,14 +36,14 @@ class BlockManager {
   bool canAppend(const Sequence& seq) const;
   void mayAppend(Sequence& seq);
 
-  int blockSize() const { return block_size_; }
-  int numFreeBlocks() const;
+  int blockSize() const { return static_cast<int>(block_size_); }
+  size_t numFreeBlocks() const;
 
  private:
   Block& allocateBlock(int blockId);
   void deallocateBlock(int blockId);
 
-  int block_size_;
+  size_t block_size_;
   std::vector<Block> blocks_;
   std::unordered_map<int64_t, int> hash_to_block_id_;
   std::deque<int> free_block_ids_;

--- a/tt-media-server/cpp_server/include/runners/llm_runner/max_occupancy_scheduler.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/max_occupancy_scheduler.hpp
@@ -27,11 +27,13 @@ class MaxOccupancyScheduler : public Scheduler {
   using Scheduler::Scheduler;
 
  protected:
-  bool shouldPrefillFirst(int decodeCount, int maxInFlightCount) const {
+  bool shouldPrefillFirst(size_t decodeCount,
+                          size_t maxInFlightCount) const override {
     return decodeCount < maxInFlightCount;
   }
 
-  int maxPrefillSeqs(int decodeCount, int maxInFlightCount) const {
+  size_t maxPrefillSeqs(size_t decodeCount,
+                        size_t maxInFlightCount) const override {
     return maxInFlightCount - decodeCount;
   }
 };

--- a/tt-media-server/cpp_server/include/runners/llm_runner/prefill_first_scheduler.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/prefill_first_scheduler.hpp
@@ -20,8 +20,8 @@ class PrefillFirstScheduler : public Scheduler {
   using Scheduler::Scheduler;
 
  protected:
-  bool shouldPrefillFirst(int /*decode_count*/,
-                          int /*max_in_flight_count*/) const {
+  bool shouldPrefillFirst(size_t /*decode_count*/,
+                          size_t /*max_in_flight_count*/) const override {
     return true;
   }
 };

--- a/tt-media-server/cpp_server/include/runners/llm_runner/scheduler.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/scheduler.hpp
@@ -87,26 +87,29 @@ class Scheduler {
    * @param max_in_flight_count    maximum batch / decode_queue capacity.
    * @return true if the scheduler should attempt prefill before decode.
    */
-  virtual bool shouldPrefillFirst(int decodeCount,
-                                  int maxInFlightCount) const = 0;
+  virtual bool shouldPrefillFirst(size_t decodeCount,
+                                  size_t maxInFlightCount) const = 0;
 
   /**
    * Maximum number of sequences to prefill in one step.
    * Default: max_in_flight_count (full capacity). Override to limit prefill
    * to available slots when decode sequences should be preserved.
    */
-  virtual int maxPrefillSeqs(int /*decode_count*/, int maxInFlightCount) const {
+  virtual size_t maxPrefillSeqs(size_t /*decode_count*/,
+                                size_t maxInFlightCount) const {
     return maxInFlightCount;
   }
 
  private:
-  int block_size_;
-  bool trySchedulePrefill(std::vector<Sequence*>& scheduledSeqs, int& numSeqs,
-                          int& numBatchedTokens, int seqLimit);
-  void tryScheduleDecode(std::vector<Sequence*>& scheduledSeqs, int& numSeqs);
+  size_t block_size_;
+  bool trySchedulePrefill(std::vector<Sequence*>& scheduledSeqs,
+                          size_t& numSeqs, size_t& numBatchedTokens,
+                          size_t seqLimit);
+  void tryScheduleDecode(std::vector<Sequence*>& scheduledSeqs,
+                         size_t& numSeqs);
 
   size_t max_in_flight_count_;
-  int max_num_batched_tokens_;
+  size_t max_num_batched_tokens_;
   std::unordered_set<int64_t> stop_token_ids_;
   BlockManager block_manager_;
   ITaskQueue* prefill_queue_;

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
@@ -52,8 +52,8 @@ class SpPipelineRunner : public IRunner {
   std::unordered_map<uint32_t, std::unique_ptr<llm_engine::Sequence>>
       activeSequences;
   std::atomic<bool> stopped{false};
-  int maxInFlightCount;
-  int inFlightCount = 0;
+  size_t maxInFlightCount;
+  size_t inFlightCount = 0;
 
   std::unique_ptr<tt::services::MemoryManager> memoryManager;
   std::thread memoryThread;

--- a/tt-media-server/cpp_server/src/runners/llm_runner/block_manager.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/block_manager.cpp
@@ -23,19 +23,17 @@ void Block::reset() {
   token_ids.clear();
 }
 
-BlockManager::BlockManager(int numBlocks, int blockSize)
+BlockManager::BlockManager(size_t numBlocks, size_t blockSize)
     : block_size_(blockSize) {
-  if (numBlocks <= 0) {
-    throw std::invalid_argument(
-        "BlockManager: num_blocks must be positive, got " +
-        std::to_string(numBlocks));
+  if (numBlocks == 0) {
+    throw std::invalid_argument("BlockManager: num_blocks must be positive");
   }
-  blocks_.reserve(static_cast<size_t>(numBlocks));
-  for (int i = 0; i < numBlocks; ++i) {
-    blocks_.emplace_back(i);
+  blocks_.reserve(numBlocks);
+  for (size_t i = 0; i < numBlocks; ++i) {
+    blocks_.emplace_back(static_cast<int>(i));
   }
-  for (int i = 0; i < numBlocks; ++i) {
-    free_block_ids_.push_back(i);
+  for (size_t i = 0; i < numBlocks; ++i) {
+    free_block_ids_.push_back(static_cast<int>(i));
   }
 }
 
@@ -69,9 +67,9 @@ void BlockManager::deallocateBlock(int blockId) {
       << " free=" << free_block_ids_.size() << std::endl;
 }
 
-int BlockManager::numFreeBlocks() const {
+size_t BlockManager::numFreeBlocks() const {
   std::lock_guard<std::mutex> lock(mutex);
-  return static_cast<int>(free_block_ids_.size());
+  return free_block_ids_.size();
 }
 
 bool BlockManager::allocate(Sequence& seq) {
@@ -79,8 +77,7 @@ bool BlockManager::allocate(Sequence& seq) {
   std::lock_guard<std::mutex> lock(mutex);
   assert(seq.blockTable.empty());
 
-  if (static_cast<int>(free_block_ids_.size()) <
-      static_cast<int>(seq.numBlocks())) {
+  if (free_block_ids_.size() < seq.numBlocks()) {
     return false;
   }
 
@@ -91,9 +88,7 @@ bool BlockManager::allocate(Sequence& seq) {
   bool cacheMiss = false;
   for (size_t i = 0; i < seq.numBlocks(); ++i) {
     std::vector<int64_t> tokenIds = seq.block(i);
-    h = (tokenIds.size() == static_cast<size_t>(block_size_))
-            ? computeHash(tokenIds, h)
-            : -1;
+    h = (tokenIds.size() == block_size_) ? computeHash(tokenIds, h) : -1;
     auto it = hash_to_block_id_.find(h);
     int blockId = (it != hash_to_block_id_.end()) ? it->second : -1;
     if (blockId == -1 ||
@@ -109,7 +104,7 @@ bool BlockManager::allocate(Sequence& seq) {
       }
       seq.blockTable.push_back(blockId);
     } else {
-      seq.numCachedTokens += static_cast<size_t>(block_size_);
+      seq.numCachedTokens += block_size_;
       if (used_block_ids_.count(blockId)) {
         blocks_[static_cast<size_t>(blockId)].ref_count += 1;
       } else {
@@ -145,8 +140,8 @@ void BlockManager::deallocate(Sequence& seq) {
 
 bool BlockManager::canAppend(const Sequence& seq) const {
   std::lock_guard<std::mutex> lock(mutex);
-  int needOne = (seq.size() % block_size_ == 1) ? 1 : 0;
-  return static_cast<int>(free_block_ids_.size()) >= needOne;
+  size_t needOne = (seq.size() % block_size_ == 1) ? 1 : 0;
+  return free_block_ids_.size() >= needOne;
 }
 
 void BlockManager::mayAppend(Sequence& seq) {
@@ -155,14 +150,14 @@ void BlockManager::mayAppend(Sequence& seq) {
   std::vector<int>& blockTable = seq.blockTable;
   Block& lastBlock = blocks_[static_cast<size_t>(blockTable.back())];
   size_t len = seq.size();
-  if (len % static_cast<size_t>(block_size_) == 1) {
+  if (len % block_size_ == 1) {
     LLM_ENGINE_LOG("block_manager") << "may_append task_id=" << seq.taskId
                                     << " new_block len=" << len << std::endl;
     assert(lastBlock.hash != -1);
     int blockId = free_block_ids_.front();
     allocateBlock(blockId);
     blockTable.push_back(blockId);
-  } else if (len % static_cast<size_t>(block_size_) == 0) {
+  } else if (len % block_size_ == 0) {
     assert(lastBlock.hash == -1);
     LLM_ENGINE_LOG("block_manager")
         << "may_append task_id=" << seq.taskId << " fill_last_block len=" << len

--- a/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
@@ -32,10 +32,9 @@ std::unique_ptr<Scheduler> makeScheduler(const Config& config,
 
 Scheduler::Scheduler(const Config& config, ITaskQueue* taskQueue,
                      size_t maxInFlightCount)
-    : block_size_(static_cast<size_t>(config.kvcache_block_size)),
+    : block_size_(config.kvcache_block_size),
       max_in_flight_count_(maxInFlightCount),
-      max_num_batched_tokens_(
-          static_cast<size_t>(config.max_num_batched_tokens)),
+      max_num_batched_tokens_(config.max_num_batched_tokens),
       stop_token_ids_(config.stop_token_ids.begin(),
                       config.stop_token_ids.end()),
       block_manager_(config.num_kvcache_blocks, config.kvcache_block_size),

--- a/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
@@ -32,9 +32,10 @@ std::unique_ptr<Scheduler> makeScheduler(const Config& config,
 
 Scheduler::Scheduler(const Config& config, ITaskQueue* taskQueue,
                      size_t maxInFlightCount)
-    : block_size_(config.kvcache_block_size),
+    : block_size_(static_cast<size_t>(config.kvcache_block_size)),
       max_in_flight_count_(maxInFlightCount),
-      max_num_batched_tokens_(config.max_num_batched_tokens),
+      max_num_batched_tokens_(
+          static_cast<size_t>(config.max_num_batched_tokens)),
       stop_token_ids_(config.stop_token_ids.begin(),
                       config.stop_token_ids.end()),
       block_manager_(config.num_kvcache_blocks, config.kvcache_block_size),
@@ -46,7 +47,8 @@ bool Scheduler::isFinished() const {
 
 Sequence& Scheduler::addRequest(uint32_t taskId, std::vector<int64_t> prompt,
                                 const SamplingParams& params) {
-  auto seq = std::make_unique<Sequence>(std::move(taskId), block_size_,
+  auto seq = std::make_unique<Sequence>(std::move(taskId),
+                                        static_cast<int>(block_size_),
                                         std::move(prompt), params);
   auto id = seq->taskId;
   add(*seq);
@@ -62,30 +64,26 @@ Sequence* Scheduler::findSequence(uint32_t taskId) {
 }
 
 bool Scheduler::trySchedulePrefill(std::vector<Sequence*>& scheduledSeqs,
-                                   int& numSeqs, int& numBatchedTokens,
-                                   int seqLimit) {
+                                   size_t& numSeqs, size_t& numBatchedTokens,
+                                   size_t seqLimit) {
   while (numSeqs < seqLimit) {
     auto seq = prefill_queue_->tryPop();
     if (!seq) break;
 
-    // Skip sequences whose ID was aborted while the copy sat in the prefill
-    // queue. The copy's status field is WAITING (it's a snapshot), so we must
-    // check the pending_aborts_ set instead.
     if (pending_aborts_.erase(seq->taskId)) {
       sequences_.erase(seq->taskId);
       seq.reset();
       continue;
     }
 
-    if (numBatchedTokens + static_cast<int>(seq->size()) >
-            max_num_batched_tokens_ ||
+    if (numBatchedTokens + seq->size() > max_num_batched_tokens_ ||
         !block_manager_.allocate(*seq)) {
       prefill_queue_->push(*seq);
       seq.reset();
       break;
     }
     numSeqs += 1;
-    numBatchedTokens += static_cast<int>(seq->size() - seq->numCachedTokens);
+    numBatchedTokens += seq->size() - seq->numCachedTokens;
     auto id = seq->taskId;
     sequences_[id] = std::move(seq);
     scheduledSeqs.push_back(sequences_[id].get());
@@ -94,7 +92,7 @@ bool Scheduler::trySchedulePrefill(std::vector<Sequence*>& scheduledSeqs,
 }
 
 void Scheduler::tryScheduleDecode(std::vector<Sequence*>& scheduledSeqs,
-                                  int& numSeqs) {
+                                  size_t& numSeqs) {
   while (!decode_queue_.empty() && numSeqs < max_in_flight_count_) {
     Sequence* seq = decode_queue_.front();
     decode_queue_.pop_front();
@@ -126,16 +124,16 @@ std::pair<std::vector<Sequence*>, bool> Scheduler::schedule() {
       seq.reset();
     }
   }
-  int numSeqs = 0;
-  int numBatchedTokens = 0;
+  size_t numSeqs = 0;
+  size_t numBatchedTokens = 0;
 
-  int decodeCount = static_cast<int>(decode_queue_.size());
+  size_t decodeCount = decode_queue_.size();
 
   bool shouldPrefill = !prefill_queue_->empty() &&
                        shouldPrefillFirst(decodeCount, max_in_flight_count_);
 
   if (shouldPrefill) {
-    int seqLimit = maxPrefillSeqs(decodeCount, max_in_flight_count_);
+    size_t seqLimit = maxPrefillSeqs(decodeCount, max_in_flight_count_);
     if (seqLimit > 0 && trySchedulePrefill(scheduledSeqs, numSeqs,
                                            numBatchedTokens, seqLimit)) {
       return {scheduledSeqs, true};

--- a/tt-media-server/cpp_server/src/runners/llm_runner/sequence.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/sequence.cpp
@@ -75,7 +75,7 @@ Sequence Sequence::deserialize(std::istream& is) {
   is.read(reinterpret_cast<char*>(&taskId), sizeof(taskId));
 
   Config defaultConfig;
-  Sequence seq(taskId, defaultConfig.kvcache_block_size,
+  Sequence seq(taskId, static_cast<int>(defaultConfig.kvcache_block_size),
                std::vector<int64_t>{});
 
   is.read(reinterpret_cast<char*>(&seq.lastToken), sizeof(seq.lastToken));

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -395,7 +395,8 @@ void LLMService::processStreamingRequest(
       taskId, static_cast<int>(prompt.size()));
 
   auto sequence = std::make_unique<llm_engine::Sequence>(
-      taskId, tt::config::llmEngineConfig().kvcache_block_size,
+      taskId,
+      static_cast<int>(tt::config::llmEngineConfig().kvcache_block_size),
       std::move(tokenIds));
   sequence->numPromptTokens = prompt.size();
   if (request.slotId.has_value()) {

--- a/tt-media-server/cpp_server/tests/cancellation_test.cpp
+++ b/tt-media-server/cpp_server/tests/cancellation_test.cpp
@@ -100,7 +100,7 @@ TEST_F(SchedulerAbortTest, AbortDecodingSequence_FreesBlocks) {
   std::shared_ptr<ITaskQueue> q = makeQueue();
   PrefillFirstScheduler s{smallConfig, q.get(), 4};
 
-  int freeBlocksBefore = s.blockManager().numFreeBlocks();
+  size_t freeBlocksBefore = s.blockManager().numFreeBlocks();
 
   uint32_t id = nextId();
   s.addRequest(id, prompt(4), {.max_tokens = 100});


### PR DESCRIPTION
Replace int with size_t for internal counters and sizes in the scheduler and block manager that are never negative and interact with STL .size() returns. This eliminates signed/unsigned comparison warnings and removes 7 unnecessary static_cast calls.

Serialized fields (blockTable, Sequence::blockSize, block IDs) remain int to preserve the IPC wire format.