### PR TITLE
Extract shared token-push utilities into ipc/token_push.hpp

### DIFF
--- a/tt-media-server/cpp_server/include/ipc/token_push.hpp
+++ b/tt-media-server/cpp_server/include/ipc/token_push.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <cstdint>
+#include <thread>
+
+#include "ipc/token_ring_buffer.hpp"
+
+namespace tt::ipc {
+
+template <size_t N>
+void pushToken(TokenRingBuffer<N>& queue, uint32_t taskId, uint64_t tokenId,
+               bool finished) {
+  SharedToken token{};
+  token.task_id = taskId;
+  token.token_id = tokenId;
+  token.flags = finished ? SharedToken::FLAG_FINAL : 0u;
+  while (!queue.push(token)) {
+    std::this_thread::yield();
+  }
+}
+
+template <size_t N>
+void pushErrorToken(TokenRingBuffer<N>& queue, uint32_t taskId) {
+  SharedToken token{};
+  token.task_id = taskId;
+  token.flags = SharedToken::FLAG_FINAL | SharedToken::FLAG_ERROR;
+  while (!queue.push(token)) {
+    std::this_thread::yield();
+  }
+}
+
+}  // namespace tt::ipc

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
@@ -40,8 +40,6 @@ class SpPipelineRunner : public IRunner {
   void step();
   void drainDecodeResults();
   void memoryLoop();
-  void pushToken(uint32_t taskId, uint64_t tokenId, bool finished);
-  void pushErrorToken(uint32_t taskId);
 
   tt::config::LLMConfig config;
   std::unordered_set<int64_t> stopTokenIds;

--- a/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_runner.hpp
@@ -28,9 +28,6 @@ class SpPrefillRunner : public IRunner {
   const char* runnerType() const override { return "SpPrefillRunner"; }
 
  private:
-  void pushToken(uint32_t taskId, uint64_t tokenId, bool finished);
-  void pushErrorToken(uint32_t taskId);
-
   tt::config::LLMConfig config;
   ipc::TokenRingBuffer<65536>* resultQueue;
   llm_engine::ITaskQueue* taskQueue;

--- a/tt-media-server/cpp_server/src/runners/llm_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner.cpp
@@ -1,12 +1,12 @@
 #include "runners/llm_runner.hpp"
 
-#include <cassert>
 #include <chrono>
 #include <memory>
 #include <thread>
 #include <vector>
 
 #include "config/settings.hpp"
+#include "ipc/token_push.hpp"
 #include "profiling/tracy.hpp"
 #include "services/paged_memory_manager.hpp"
 
@@ -36,17 +36,7 @@ LLMRunner::LLMRunner(const Config& config,
 
     if (result.isError) {
       scheduler_->removeSequence(result.taskId);
-      auto shared = ipc::SharedToken{
-          .token_index = 0,
-          .flags = static_cast<uint32_t>(ipc::SharedToken::FLAG_FINAL |
-                                         ipc::SharedToken::FLAG_ERROR),
-          .token_id = 0,
-          .task_id = result.taskId,
-          .padding = {},
-      };
-      while (!result_queue_->push(shared)) {
-        std::this_thread::yield();
-      }
+      ipc::pushErrorToken(*result_queue_, result.taskId);
       return;
     }
 
@@ -55,21 +45,7 @@ LLMRunner::LLMRunner(const Config& config,
     scheduler_->postprocess(seqs, tokenIds);
 
     bool finished = seq->isFinished();
-
-    {
-      ZoneScopedN("ResultQueue::push");
-      auto shared = ipc::SharedToken{
-          .token_index = 0,
-          .flags = static_cast<uint32_t>(finished ? ipc::SharedToken::FLAG_FINAL
-                                                  : 0),
-          .token_id = result.tokenId,
-          .task_id = result.taskId,
-          .padding = {},
-      };
-      while (!result_queue_->push(shared)) {
-        std::this_thread::yield();
-      }
-    }
+    ipc::pushToken(*result_queue_, result.taskId, result.tokenId, finished);
 
     if (finished) {
       scheduler_->removeSequence(result.taskId);

--- a/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner.cpp
@@ -10,6 +10,7 @@
 #include <thread>
 
 #include "config/settings.hpp"
+#include "ipc/token_push.hpp"
 #include "profiling/tracy.hpp"
 #include "services/contiguous_memory_manager.hpp"
 #include "utils/logger.hpp"
@@ -164,7 +165,7 @@ void SpPipelineRunner::drainDecodeResults() {
     llm_engine::Sequence* seq = it->second.get();
 
     if (dr.isError) {
-      pushErrorToken(dr.taskId);
+      ipc::pushErrorToken(*resultQueue, dr.taskId);
       activeSequences.erase(it);
       --inFlightCount;
       continue;
@@ -180,34 +181,13 @@ void SpPipelineRunner::drainDecodeResults() {
     bool finished =
         (!seq->samplingParams->ignore_eos && isStop) || reachedMaxTokens;
 
-    {
-      pushToken(dr.taskId, dr.tokenId, finished);
-    }
+    ipc::pushToken(*resultQueue, dr.taskId, dr.tokenId, finished);
 
     if (finished) {
       activeSequences.erase(it);
       --inFlightCount;
     }
   }
-}
-
-void SpPipelineRunner::pushToken(uint32_t taskId, uint64_t tokenId,
-                                 bool finished) {
-  ipc::SharedToken shared{};
-  shared.token_index = 0;
-  shared.flags = finished ? ipc::SharedToken::FLAG_FINAL : 0u;
-  shared.token_id = tokenId;
-  shared.task_id = taskId;
-  resultQueue->push(shared);
-}
-
-void SpPipelineRunner::pushErrorToken(uint32_t taskId) {
-  ipc::SharedToken shared{};
-  shared.token_index = 0;
-  shared.flags = ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ERROR;
-  shared.token_id = 0;
-  shared.task_id = taskId;
-  resultQueue->push(shared);
 }
 
 }  // namespace tt::runners

--- a/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
@@ -3,6 +3,7 @@
 
 #include "runners/sp_prefill_runner/sp_prefill_runner.hpp"
 
+#include "ipc/token_push.hpp"
 #include "utils/logger.hpp"
 
 namespace tt::runners {
@@ -40,11 +41,11 @@ void SpPrefillRunner::run() {
 
     if (result->isError) {
       TT_LOG_WARN("SpPrefillRunner: Error token for task {}", result->taskId);
-      pushErrorToken(result->taskId);
+      ipc::pushErrorToken(*resultQueue, result->taskId);
     } else {
       TT_LOG_DEBUG("SpPrefillRunner: Received prefill token {} for task {}",
                    result->tokenId, result->taskId);
-      pushToken(result->taskId, result->tokenId, true);  // Always finished
+      ipc::pushToken(*resultQueue, result->taskId, result->tokenId, true);
     }
 
     // sequence automatically cleaned up at end of scope
@@ -68,25 +69,6 @@ bool SpPrefillRunner::warmup() {
 void SpPrefillRunner::stop() {
   TT_LOG_INFO("SpPrefillRunner: Stopping");
   stopped.store(true, std::memory_order_relaxed);
-}
-
-void SpPrefillRunner::pushToken(uint32_t taskId, uint64_t tokenId,
-                                bool finished) {
-  ipc::SharedToken shared{};
-  shared.token_index = 0;
-  shared.flags = finished ? ipc::SharedToken::FLAG_FINAL : 0u;
-  shared.token_id = tokenId;
-  shared.task_id = taskId;
-  resultQueue->push(shared);
-}
-
-void SpPrefillRunner::pushErrorToken(uint32_t taskId) {
-  ipc::SharedToken shared{};
-  shared.token_index = 0;
-  shared.flags = ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ERROR;
-  shared.token_id = 0;
-  shared.task_id = taskId;
-  resultQueue->push(shared);
 }
 
 }  // namespace tt::runners


### PR DESCRIPTION
Deduplicate identical `pushToken`/`pushErrorToken` implementations from `SpPrefillRunner`, `SpPipelineRunner`, and `LLMRunner` into two free functions in a new `ipc/token_push.hpp`. Also fixes a silent token-drop bug in the SP runners -- they previously ignored the push() return value, while the new utility retries with yield on a full ring buffer.