### PR TITLE
Replace openapi.cpp with static JSON file

### DIFF
--- a/tt-media-server/cpp_server/.gitignore
+++ b/tt-media-server/cpp_server/.gitignore
@@ -19,3 +19,6 @@ logs/
 **/vllm-venv
 
 deps/
+
+# Override root-level *.json ignore
+!resources/openapi.json

--- a/tt-media-server/cpp_server/resources/openapi.json
+++ b/tt-media-server/cpp_server/resources/openapi.json
@@ -1,0 +1,530 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "TT Media Server API (C++ Drogon)",
+    "description": "High-performance C++ implementation of the TT Media Server using Drogon framework. Provides OpenAI-compatible chat completions API for benchmarking server overhead.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Tenstorrent",
+      "url": "https://tenstorrent.com"
+    },
+    "license": {
+      "name": "Apache-2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "servers": [
+    {
+      "url": "/",
+      "description": "Local server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Chat Completions",
+      "description": "OpenAI-compatible chat completion endpoints"
+    },
+    {
+      "name": "Sessions",
+      "description": "Session management for slot assignments"
+    },
+    {
+      "name": "Health",
+      "description": "Server health and liveness endpoints"
+    },
+    {
+      "name": "Monitoring",
+      "description": "Prometheus metrics scrape endpoint"
+    }
+  ],
+  "paths": {
+    "/v1/chat/completions": {
+      "post": {
+        "tags": ["Chat Completions"],
+        "summary": "Create chat completion",
+        "description": "Creates a chat completion for the provided messages. OpenAI-compatible endpoint. Messages are converted to a prompt internally; responses use object \"chat.completion\" and choices[].message with role and content.",
+        "operationId": "createChatCompletion",
+        "security": [{ "BearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ChatCompletionRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful chat completion (JSON) or streaming (text/event-stream)",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ChatCompletionResponse" }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "SSE stream; object \"chat.completion.chunk\", choices[].delta"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request (e.g. missing or empty messages)",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication token",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "503": {
+            "description": "Model not ready",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/sessions": {
+      "post": {
+        "tags": ["Sessions"],
+        "summary": "Create a new session",
+        "description": "Create a new session with optional slot assignment",
+        "operationId": "createSession",
+        "security": [{ "BearerAuth": [] }],
+        "requestBody": {
+          "description": "Optional slot ID to assign",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "slot_id": {
+                    "type": "integer",
+                    "description": "Slot ID to assign (-1 means unassigned)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Session created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "session_id": { "type": "string", "format": "uuid" },
+                    "slot_id": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/sessions/{session_id}": {
+      "delete": {
+        "tags": ["Sessions"],
+        "summary": "Close a session",
+        "description": "Close an existing session by ID",
+        "operationId": "closeSession",
+        "security": [{ "BearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session ID to close",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session closed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/sessions/{session_id}/slot": {
+      "get": {
+        "tags": ["Sessions"],
+        "summary": "Get slot ID for a session",
+        "description": "Retrieve the slot ID assigned to a session (-1 if unassigned)",
+        "operationId": "getSlotId",
+        "security": [{ "BearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session ID",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Slot ID retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "session_id": { "type": "string", "format": "uuid" },
+                    "slot_id": {
+                      "type": "integer",
+                      "description": "Slot ID (-1 if unassigned)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "tags": ["Health"],
+        "summary": "Health check",
+        "description": "Returns server health status.",
+        "operationId": "healthCheck",
+        "responses": {
+          "200": {
+            "description": "Server is healthy",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HealthResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tt-liveness": {
+      "get": {
+        "tags": ["Health"],
+        "summary": "Liveness check",
+        "description": "Liveness probe (same as Python tt-liveness). Returns 200 with {\"status\": \"alive\", ...system status} when the process can respond. model_ready in the body reflects whether any worker has warmed up. Does not return 503 for model not ready; 500 only on unrecoverable failure.",
+        "operationId": "livenessCheck",
+        "responses": {
+          "200": {
+            "description": "Process is alive; body includes status alive and system status (model_ready, workers, queue)",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ReadyResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Unrecoverable failure (e.g. no service configured, exception)",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ReadyResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "tags": ["Monitoring"],
+        "summary": "Prometheus metrics",
+        "description": "Exposes all server metrics in Prometheus text exposition format (version 0.0.4). No authentication required. Intended to be scraped by a Prometheus server every few seconds.",
+        "operationId": "getMetrics",
+        "responses": {
+          "200": {
+            "description": "Prometheus text format metrics",
+            "content": {
+              "text/plain; version=0.0.4": {
+                "schema": {
+                  "type": "string",
+                  "example": "# HELP tt_generation_tokens_total Total number of generation tokens produced\n# TYPE tt_generation_tokens_total counter\ntt_generation_tokens_total{model_name=\"llm\"} 42\n"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ChatCompletionRequest": {
+        "type": "object",
+        "required": ["messages"],
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "Model identifier",
+            "example": "test-model"
+          },
+          "messages": {
+            "type": "array",
+            "description": "Conversation messages (required, non-empty)",
+            "items": {
+              "type": "object",
+              "required": ["role", "content"],
+              "properties": {
+                "role": {
+                  "type": "string",
+                  "description": "Message role: system, user, or assistant",
+                  "default": "user"
+                },
+                "content": {
+                  "type": "string",
+                  "description": "Message content"
+                }
+              }
+            }
+          },
+          "max_tokens": {
+            "type": "integer",
+            "default": 16,
+            "minimum": 1,
+            "description": "Maximum number of tokens to generate"
+          },
+          "stream": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to stream the response as SSE"
+          },
+          "stream_options": {
+            "$ref": "#/components/schemas/StreamOptions"
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "description": "Sampling temperature"
+          },
+          "top_p": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Nucleus sampling probability"
+          },
+          "stop": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "array", "items": { "type": "string" } }
+            ],
+            "description": "Stop sequence(s)"
+          },
+          "presence_penalty": { "type": "number" },
+          "frequency_penalty": { "type": "number" },
+          "seed": { "type": "integer" },
+          "user": { "type": "string" }
+        }
+      },
+      "ChatCompletionResponse": {
+        "type": "object",
+        "required": ["id", "object", "created", "choices"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique chat completion identifier",
+            "example": "chatcmpl-abc123def456"
+          },
+          "object": {
+            "type": "string",
+            "enum": ["chat.completion"],
+            "description": "Object type"
+          },
+          "created": {
+            "type": "integer",
+            "description": "Unix timestamp of creation"
+          },
+          "model": {
+            "type": "string",
+            "description": "Model used for completion"
+          },
+          "choices": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "index": { "type": "integer" },
+                "message": {
+                  "type": "object",
+                  "properties": {
+                    "role": { "type": "string" },
+                    "content": { "type": "string" }
+                  }
+                },
+                "finish_reason": { "type": "string" }
+              }
+            }
+          },
+          "usage": {
+            "$ref": "#/components/schemas/CompletionUsage"
+          }
+        }
+      },
+      "StreamOptions": {
+        "type": "object",
+        "properties": {
+          "include_usage": {
+            "type": "boolean",
+            "default": true,
+            "description": "Include usage statistics in response"
+          },
+          "continuous_usage_stats": {
+            "type": "boolean",
+            "default": false,
+            "description": "Include usage stats in each streamed chunk"
+          }
+        }
+      },
+      "CompletionUsage": {
+        "type": "object",
+        "properties": {
+          "prompt_tokens": {
+            "type": "integer",
+            "description": "Number of tokens in the prompt"
+          },
+          "completion_tokens": {
+            "type": "integer",
+            "description": "Number of tokens in the completion"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "Total tokens used"
+          },
+          "ttft_ms": {
+            "type": "number",
+            "description": "Time to first token in milliseconds",
+            "nullable": true
+          },
+          "tps": {
+            "type": "number",
+            "description": "Tokens per second (excluding first token)",
+            "nullable": true
+          }
+        }
+      },
+      "HealthResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["healthy"],
+            "description": "Server health status"
+          },
+          "timestamp": {
+            "type": "integer",
+            "description": "Unix timestamp"
+          }
+        }
+      },
+      "ReadyResponse": {
+        "type": "object",
+        "properties": {
+          "model_ready": {
+            "type": "boolean",
+            "description": "Whether the model is ready for inference"
+          },
+          "queue_size": {
+            "type": "integer",
+            "description": "Current number of requests in queue"
+          },
+          "max_queue_size": {
+            "type": "integer",
+            "description": "Maximum queue capacity"
+          },
+          "device": {
+            "type": "string",
+            "description": "Device type"
+          },
+          "workers": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/WorkerInfo" }
+          }
+        }
+      },
+      "WorkerInfo": {
+        "type": "object",
+        "properties": {
+          "worker_id": {
+            "type": "string",
+            "description": "Worker identifier"
+          },
+          "is_ready": {
+            "type": "boolean",
+            "description": "Whether worker is ready"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "message": { "type": "string" },
+              "type": { "type": "string" },
+              "code": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "API Key",
+        "description": "Bearer token authentication using OPENAI_API_KEY environment variable. If not set, defaults to 'your-secret-key'."
+      }
+    }
+  }
+}

--- a/tt-media-server/cpp_server/src/api/openapi.cpp
+++ b/tt-media-server/cpp_server/src/api/openapi.cpp
@@ -4,12 +4,52 @@
 #include <drogon/drogon.h>
 #include <json/json.h>
 
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <sstream>
+#include <string>
+
 namespace tt::api {
 
-/**
- * OpenAPI specification controller.
- * Serves the OpenAPI JSON spec and Swagger UI.
- */
+static std::filesystem::path resolveResourcePath(
+    const std::string& relativePath) {
+  std::error_code ec;
+  auto exePath = std::filesystem::read_symlink("/proc/self/exe", ec);
+  if (ec) {
+    return {};
+  }
+  auto resourceDir = exePath.parent_path().parent_path() / "resources";
+  auto path = resourceDir / relativePath;
+  if (std::filesystem::exists(path)) {
+    return path;
+  }
+  return {};
+}
+
+static const Json::Value& cachedOpenAPISpec() {
+  static const Json::Value spec = [] {
+    auto path = resolveResourcePath("openapi.json");
+    if (path.empty()) {
+      throw std::runtime_error(
+          "OpenAPI spec not found at resources/openapi.json relative to "
+          "executable");
+    }
+    std::ifstream file(path);
+    if (!file.is_open()) {
+      throw std::runtime_error("Failed to open OpenAPI spec: " + path.string());
+    }
+    Json::Value root;
+    Json::CharReaderBuilder builder;
+    std::string errors;
+    if (!Json::parseFromStream(builder, file, &root, &errors)) {
+      throw std::runtime_error("Failed to parse OpenAPI spec: " + errors);
+    }
+    return root;
+  }();
+  return spec;
+}
+
 class OpenAPIController : public drogon::HttpController<OpenAPIController> {
  public:
   METHOD_LIST_BEGIN
@@ -22,8 +62,7 @@ class OpenAPIController : public drogon::HttpController<OpenAPIController> {
   void getOpenAPISpec(
       const drogon::HttpRequestPtr& /* req */,
       std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
-    auto spec = buildOpenAPISpec();
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(spec);
+    auto resp = drogon::HttpResponse::newHttpJsonResponse(cachedOpenAPISpec());
     resp->addHeader("Access-Control-Allow-Origin", "*");
     callback(resp);
   }
@@ -31,7 +70,7 @@ class OpenAPIController : public drogon::HttpController<OpenAPIController> {
   void getSwaggerUI(
       const drogon::HttpRequestPtr& /* req */,
       std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
-    std::string html = R"html(
+    static const std::string html = R"html(
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -84,641 +123,6 @@ class OpenAPIController : public drogon::HttpController<OpenAPIController> {
     resp->setBody(html);
     resp->setContentTypeCode(drogon::CT_TEXT_HTML);
     callback(resp);
-  }
-
- private:
-  Json::Value buildOpenAPISpec() {
-    Json::Value spec;
-
-    // OpenAPI version and info
-    spec["openapi"] = "3.1.0";
-
-    Json::Value info;
-    info["title"] = "TT Media Server API (C++ Drogon)";
-    info["description"] =
-        "High-performance C++ implementation of the TT Media Server using "
-        "Drogon framework. "
-        "Provides OpenAI-compatible chat completions API for benchmarking "
-        "server overhead.";
-    info["version"] = "1.0.0";
-    info["contact"]["name"] = "Tenstorrent";
-    info["contact"]["url"] = "https://tenstorrent.com";
-    info["license"]["name"] = "Apache-2.0";
-    info["license"]["url"] = "https://www.apache.org/licenses/LICENSE-2.0";
-    spec["info"] = info;
-
-    // Servers
-    Json::Value servers(Json::arrayValue);
-    Json::Value server;
-    server["url"] = "/";
-    server["description"] = "Local server";
-    servers.append(server);
-    spec["servers"] = servers;
-
-    // Tags
-    Json::Value tags(Json::arrayValue);
-    Json::Value completionsTag;
-    completionsTag["name"] = "Chat Completions";
-    completionsTag["description"] =
-        "OpenAI-compatible chat completion endpoints";
-    tags.append(completionsTag);
-    Json::Value sessionsTag;
-    sessionsTag["name"] = "Sessions";
-    sessionsTag["description"] = "Session management for slot assignments";
-    tags.append(sessionsTag);
-    Json::Value healthTag;
-    healthTag["name"] = "Health";
-    healthTag["description"] = "Server health and liveness endpoints";
-    tags.append(healthTag);
-    Json::Value monitoringTag;
-    monitoringTag["name"] = "Monitoring";
-    monitoringTag["description"] = "Prometheus metrics scrape endpoint";
-    tags.append(monitoringTag);
-    spec["tags"] = tags;
-
-    // Paths
-    Json::Value paths;
-
-    // POST /v1/chat/completions
-    paths["/v1/chat/completions"]["post"] = buildChatCompletionsEndpoint();
-
-    // POST /v1/sessions
-    paths["/v1/sessions"]["post"] = buildCreateSessionEndpoint();
-
-    // DELETE /v1/sessions/{session_id}
-    paths["/v1/sessions/{session_id}"]["delete"] = buildCloseSessionEndpoint();
-
-    // GET /v1/sessions/{session_id}/slot
-    paths["/v1/sessions/{session_id}/slot"]["get"] = buildGetSlotIdEndpoint();
-
-    // GET /health
-    paths["/health"]["get"] = buildHealthEndpoint();
-
-    // GET /tt-liveness
-    paths["/tt-liveness"]["get"] = buildLivenessEndpoint();
-
-    // GET /metrics
-    paths["/metrics"]["get"] = buildMetricsEndpoint();
-
-    spec["paths"] = paths;
-
-    // Components (schemas and security schemes)
-    spec["components"] = buildComponents();
-
-    // Global security (can be overridden per-endpoint)
-    // Note: Health endpoints don't require security, handled by not adding
-    // security to those endpoints
-
-    return spec;
-  }
-
-  Json::Value buildChatCompletionsEndpoint() {
-    Json::Value endpoint;
-    endpoint["tags"].append("Chat Completions");
-    endpoint["summary"] = "Create chat completion";
-    endpoint["description"] =
-        "Creates a chat completion for the provided messages. "
-        "OpenAI-compatible endpoint. Messages are converted to a prompt "
-        "internally; "
-        "responses use object \"chat.completion\" and choices[].message with "
-        "role and content.";
-    endpoint["operationId"] = "createChatCompletion";
-
-    // Security requirement - Bearer token
-    Json::Value security(Json::arrayValue);
-    Json::Value bearerAuth;
-    bearerAuth["BearerAuth"] = Json::Value(Json::arrayValue);
-    security.append(bearerAuth);
-    endpoint["security"] = security;
-
-    Json::Value requestBody;
-    requestBody["required"] = true;
-    requestBody["content"]["application/json"]["schema"]["$ref"] =
-        "#/components/schemas/ChatCompletionRequest";
-    endpoint["requestBody"] = requestBody;
-
-    Json::Value responses;
-
-    Json::Value resp200;
-    resp200["description"] =
-        "Successful chat completion (JSON) or streaming (text/event-stream)";
-    resp200["content"]["application/json"]["schema"]["$ref"] =
-        "#/components/schemas/ChatCompletionResponse";
-    resp200["content"]["text/event-stream"]["schema"]["type"] = "string";
-    resp200["content"]["text/event-stream"]["schema"]["description"] =
-        "SSE stream; object \"chat.completion.chunk\", choices[].delta";
-    responses["200"] = resp200;
-
-    Json::Value resp400;
-    resp400["description"] = "Invalid request (e.g. missing or empty messages)";
-    resp400["content"]["application/json"]["schema"]["$ref"] =
-        "#/components/schemas/Error";
-    responses["400"] = resp400;
-
-    Json::Value resp401;
-    resp401["description"] = "Missing or invalid authentication token";
-    resp401["content"]["application/json"]["schema"]["$ref"] =
-        "#/components/schemas/Error";
-    responses["401"] = resp401;
-
-    Json::Value resp503;
-    resp503["description"] = "Model not ready";
-    resp503["content"]["application/json"]["schema"]["$ref"] =
-        "#/components/schemas/Error";
-    responses["503"] = resp503;
-
-    endpoint["responses"] = responses;
-
-    return endpoint;
-  }
-
-  Json::Value buildHealthEndpoint() {
-    Json::Value endpoint;
-    endpoint["tags"].append("Health");
-    endpoint["summary"] = "Health check";
-    endpoint["description"] = "Returns server health status.";
-    endpoint["operationId"] = "healthCheck";
-
-    Json::Value responses;
-    Json::Value resp200;
-    resp200["description"] = "Server is healthy";
-    resp200["content"]["application/json"]["schema"]["$ref"] =
-        "#/components/schemas/HealthResponse";
-    responses["200"] = resp200;
-    endpoint["responses"] = responses;
-
-    return endpoint;
-  }
-
-  Json::Value buildLivenessEndpoint() {
-    Json::Value endpoint;
-    endpoint["tags"].append("Health");
-    endpoint["summary"] = "Liveness check";
-    endpoint["description"] =
-        "Liveness probe (same as Python tt-liveness). Returns 200 with "
-        "{\"status\": \"alive\", ...system status} when the process can "
-        "respond. "
-        "model_ready in the body reflects whether any worker has warmed up. "
-        "Does not return 503 for model not ready; 500 only on unrecoverable "
-        "failure.";
-    endpoint["operationId"] = "livenessCheck";
-
-    Json::Value responses;
-    Json::Value resp200;
-    resp200["description"] =
-        "Process is alive; body includes status alive and system status "
-        "(model_ready, workers, queue)";
-    resp200["content"]["application/json"]["schema"]["$ref"] =
-        "#/components/schemas/ReadyResponse";
-    responses["200"] = resp200;
-
-    Json::Value resp500;
-    resp500["description"] =
-        "Unrecoverable failure (e.g. no service configured, exception)";
-    resp500["content"]["application/json"]["schema"]["$ref"] =
-        "#/components/schemas/ReadyResponse";
-    responses["500"] = resp500;
-
-    endpoint["responses"] = responses;
-
-    return endpoint;
-  }
-
-  Json::Value buildCreateSessionEndpoint() {
-    Json::Value endpoint;
-    endpoint["tags"].append("Sessions");
-    endpoint["summary"] = "Create a new session";
-    endpoint["description"] =
-        "Create a new session with optional slot assignment";
-    endpoint["operationId"] = "createSession";
-
-    // Security requirement - Bearer token
-    Json::Value security(Json::arrayValue);
-    Json::Value bearerAuth;
-    bearerAuth["BearerAuth"] = Json::Value(Json::arrayValue);
-    security.append(bearerAuth);
-    endpoint["security"] = security;
-
-    // Request body
-    Json::Value requestBody;
-    requestBody["description"] = "Optional slot ID to assign";
-    Json::Value schema;
-    schema["type"] = "object";
-    schema["properties"]["slot_id"]["type"] = "integer";
-    schema["properties"]["slot_id"]["description"] =
-        "Slot ID to assign (-1 means unassigned)";
-    requestBody["content"]["application/json"]["schema"] = schema;
-    endpoint["requestBody"] = requestBody;
-
-    // Responses
-    Json::Value responses;
-    Json::Value resp201;
-    resp201["description"] = "Session created successfully";
-    Json::Value respSchema;
-    respSchema["type"] = "object";
-    respSchema["properties"]["session_id"]["type"] = "string";
-    respSchema["properties"]["session_id"]["format"] = "uuid";
-    respSchema["properties"]["slot_id"]["type"] = "integer";
-    resp201["content"]["application/json"]["schema"] = respSchema;
-    responses["201"] = resp201;
-
-    Json::Value resp500;
-    resp500["description"] = "Internal server error";
-    resp500["content"]["application/json"]["schema"]["$ref"] =
-        "#/components/schemas/Error";
-    responses["500"] = resp500;
-
-    endpoint["responses"] = responses;
-    return endpoint;
-  }
-
-  Json::Value buildCloseSessionEndpoint() {
-    Json::Value endpoint;
-    endpoint["tags"].append("Sessions");
-    endpoint["summary"] = "Close a session";
-    endpoint["description"] = "Close an existing session by ID";
-    endpoint["operationId"] = "closeSession";
-
-    // Security requirement - Bearer token
-    Json::Value security(Json::arrayValue);
-    Json::Value bearerAuth;
-    bearerAuth["BearerAuth"] = Json::Value(Json::arrayValue);
-    security.append(bearerAuth);
-    endpoint["security"] = security;
-
-    // Path parameters
-    Json::Value parameters(Json::arrayValue);
-    Json::Value param;
-    param["name"] = "session_id";
-    param["in"] = "path";
-    param["required"] = true;
-    param["description"] = "The session ID to close";
-    param["schema"]["type"] = "string";
-    param["schema"]["format"] = "uuid";
-    parameters.append(param);
-    endpoint["parameters"] = parameters;
-
-    // Responses
-    Json::Value responses;
-    Json::Value resp200;
-    resp200["description"] = "Session closed successfully";
-    Json::Value respSchema;
-    respSchema["type"] = "object";
-    respSchema["properties"]["success"]["type"] = "boolean";
-    respSchema["properties"]["message"]["type"] = "string";
-    resp200["content"]["application/json"]["schema"] = respSchema;
-    responses["200"] = resp200;
-
-    Json::Value resp404;
-    resp404["description"] = "Session not found";
-    resp404["content"]["application/json"]["schema"]["$ref"] =
-        "#/components/schemas/Error";
-    responses["404"] = resp404;
-
-    endpoint["responses"] = responses;
-    return endpoint;
-  }
-
-  Json::Value buildGetSlotIdEndpoint() {
-    Json::Value endpoint;
-    endpoint["tags"].append("Sessions");
-    endpoint["summary"] = "Get slot ID for a session";
-    endpoint["description"] =
-        "Retrieve the slot ID assigned to a session (-1 if unassigned)";
-    endpoint["operationId"] = "getSlotId";
-
-    // Security requirement - Bearer token
-    Json::Value security(Json::arrayValue);
-    Json::Value bearerAuth;
-    bearerAuth["BearerAuth"] = Json::Value(Json::arrayValue);
-    security.append(bearerAuth);
-    endpoint["security"] = security;
-
-    // Path parameters
-    Json::Value parameters(Json::arrayValue);
-    Json::Value param;
-    param["name"] = "session_id";
-    param["in"] = "path";
-    param["required"] = true;
-    param["description"] = "The session ID";
-    param["schema"]["type"] = "string";
-    param["schema"]["format"] = "uuid";
-    parameters.append(param);
-    endpoint["parameters"] = parameters;
-
-    // Responses
-    Json::Value responses;
-    Json::Value resp200;
-    resp200["description"] = "Slot ID retrieved successfully";
-    Json::Value respSchema;
-    respSchema["type"] = "object";
-    respSchema["properties"]["session_id"]["type"] = "string";
-    respSchema["properties"]["session_id"]["format"] = "uuid";
-    respSchema["properties"]["slot_id"]["type"] = "integer";
-    respSchema["properties"]["slot_id"]["description"] =
-        "Slot ID (-1 if unassigned)";
-    resp200["content"]["application/json"]["schema"] = respSchema;
-    responses["200"] = resp200;
-
-    Json::Value resp404;
-    resp404["description"] = "Session not found";
-    resp404["content"]["application/json"]["schema"]["$ref"] =
-        "#/components/schemas/Error";
-    responses["404"] = resp404;
-
-    endpoint["responses"] = responses;
-    return endpoint;
-  }
-
-  Json::Value buildMetricsEndpoint() {
-    Json::Value endpoint;
-    endpoint["tags"].append("Monitoring");
-    endpoint["summary"] = "Prometheus metrics";
-    endpoint["description"] =
-        "Exposes all server metrics in Prometheus text exposition format "
-        "(version 0.0.4). No authentication required. Intended to be scraped "
-        "by a Prometheus server every few seconds.";
-    endpoint["operationId"] = "getMetrics";
-
-    Json::Value responses;
-    Json::Value resp200;
-    resp200["description"] = "Prometheus text format metrics";
-    resp200["content"]["text/plain; version=0.0.4"]["schema"]["type"] =
-        "string";
-    resp200["content"]["text/plain; version=0.0.4"]["schema"]["example"] =
-        "# HELP tt_generation_tokens_total Total number of generation tokens "
-        "produced\n# TYPE tt_generation_tokens_total counter\n"
-        "tt_generation_tokens_total{model_name=\"llm\"} 42\n";
-    responses["200"] = resp200;
-    endpoint["responses"] = responses;
-
-    return endpoint;
-  }
-
-  Json::Value buildComponents() {
-    Json::Value components;
-    Json::Value schemas;
-
-    // ChatCompletionRequest schema
-    schemas["ChatCompletionRequest"] = buildChatCompletionRequestSchema();
-
-    // ChatCompletionResponse schema
-    schemas["ChatCompletionResponse"] = buildChatCompletionResponseSchema();
-
-    // StreamOptions schema
-    schemas["StreamOptions"] = buildStreamOptionsSchema();
-
-    // CompletionUsage schema
-    schemas["CompletionUsage"] = buildCompletionUsageSchema();
-
-    // HealthResponse schema
-    schemas["HealthResponse"] = buildHealthResponseSchema();
-
-    // ReadyResponse schema
-    schemas["ReadyResponse"] = buildReadyResponseSchema();
-
-    // WorkerInfo schema
-    schemas["WorkerInfo"] = buildWorkerInfoSchema();
-
-    // Error schema
-    schemas["Error"] = buildErrorSchema();
-
-    components["schemas"] = schemas;
-
-    // Security schemes
-    Json::Value securitySchemes;
-    Json::Value bearerAuth;
-    bearerAuth["type"] = "http";
-    bearerAuth["scheme"] = "bearer";
-    bearerAuth["bearerFormat"] = "API Key";
-    bearerAuth["description"] =
-        "Bearer token authentication using OPENAI_API_KEY environment "
-        "variable. "
-        "If not set, defaults to 'your-secret-key'.";
-    securitySchemes["BearerAuth"] = bearerAuth;
-    components["securitySchemes"] = securitySchemes;
-
-    return components;
-  }
-
-  Json::Value buildChatCompletionRequestSchema() {
-    Json::Value schema;
-    schema["type"] = "object";
-    schema["required"].append("messages");
-
-    Json::Value messageSchema;
-    messageSchema["type"] = "object";
-    messageSchema["required"].append("role");
-    messageSchema["required"].append("content");
-    messageSchema["properties"]["role"]["type"] = "string";
-    messageSchema["properties"]["role"]["description"] =
-        "Message role: system, user, or assistant";
-    messageSchema["properties"]["role"]["default"] = "user";
-    messageSchema["properties"]["content"]["type"] = "string";
-    messageSchema["properties"]["content"]["description"] = "Message content";
-
-    Json::Value props;
-    props["model"]["type"] = "string";
-    props["model"]["description"] = "Model identifier";
-    props["model"]["example"] = "test-model";
-
-    Json::Value messagesArr;
-    messagesArr["type"] = "array";
-    messagesArr["items"] = messageSchema;
-    messagesArr["description"] = "Conversation messages (required, non-empty)";
-    props["messages"] = messagesArr;
-
-    props["max_tokens"]["type"] = "integer";
-    props["max_tokens"]["default"] = 16;
-    props["max_tokens"]["minimum"] = 1;
-    props["max_tokens"]["description"] = "Maximum number of tokens to generate";
-
-    props["stream"]["type"] = "boolean";
-    props["stream"]["default"] = false;
-    props["stream"]["description"] = "Whether to stream the response as SSE";
-
-    props["stream_options"]["$ref"] = "#/components/schemas/StreamOptions";
-
-    props["temperature"]["type"] = "number";
-    props["temperature"]["minimum"] = 0;
-    props["temperature"]["maximum"] = 2;
-    props["temperature"]["description"] = "Sampling temperature";
-
-    props["top_p"]["type"] = "number";
-    props["top_p"]["minimum"] = 0;
-    props["top_p"]["maximum"] = 1;
-    props["top_p"]["description"] = "Nucleus sampling probability";
-
-    props["stop"]["oneOf"][0]["type"] = "string";
-    props["stop"]["oneOf"][1]["type"] = "array";
-    props["stop"]["oneOf"][1]["items"]["type"] = "string";
-    props["stop"]["description"] = "Stop sequence(s)";
-
-    props["presence_penalty"]["type"] = "number";
-    props["frequency_penalty"]["type"] = "number";
-    props["seed"]["type"] = "integer";
-    props["user"]["type"] = "string";
-
-    schema["properties"] = props;
-    return schema;
-  }
-
-  Json::Value buildChatCompletionResponseSchema() {
-    Json::Value schema;
-    schema["type"] = "object";
-
-    Json::Value props;
-    props["id"]["type"] = "string";
-    props["id"]["description"] = "Unique chat completion identifier";
-    props["id"]["example"] = "chatcmpl-abc123def456";
-
-    props["object"]["type"] = "string";
-    props["object"]["enum"].append("chat.completion");
-    props["object"]["description"] = "Object type";
-
-    props["created"]["type"] = "integer";
-    props["created"]["description"] = "Unix timestamp of creation";
-
-    props["model"]["type"] = "string";
-    props["model"]["description"] = "Model used for completion";
-
-    Json::Value choiceSchema;
-    choiceSchema["type"] = "object";
-    choiceSchema["properties"]["index"]["type"] = "integer";
-    choiceSchema["properties"]["message"]["type"] = "object";
-    choiceSchema["properties"]["message"]["properties"]["role"]["type"] =
-        "string";
-    choiceSchema["properties"]["message"]["properties"]["content"]["type"] =
-        "string";
-    choiceSchema["properties"]["finish_reason"]["type"] = "string";
-
-    props["choices"]["type"] = "array";
-    props["choices"]["items"] = choiceSchema;
-
-    props["usage"]["$ref"] = "#/components/schemas/CompletionUsage";
-
-    schema["properties"] = props;
-    schema["required"].append("id");
-    schema["required"].append("object");
-    schema["required"].append("created");
-    schema["required"].append("choices");
-    return schema;
-  }
-
-  Json::Value buildStreamOptionsSchema() {
-    Json::Value schema;
-    schema["type"] = "object";
-
-    Json::Value props;
-    props["include_usage"]["type"] = "boolean";
-    props["include_usage"]["default"] = true;
-    props["include_usage"]["description"] =
-        "Include usage statistics in response";
-
-    props["continuous_usage_stats"]["type"] = "boolean";
-    props["continuous_usage_stats"]["default"] = false;
-    props["continuous_usage_stats"]["description"] =
-        "Include usage stats in each streamed chunk";
-
-    schema["properties"] = props;
-    return schema;
-  }
-
-  Json::Value buildCompletionUsageSchema() {
-    Json::Value schema;
-    schema["type"] = "object";
-
-    Json::Value props;
-    props["prompt_tokens"]["type"] = "integer";
-    props["prompt_tokens"]["description"] = "Number of tokens in the prompt";
-
-    props["completion_tokens"]["type"] = "integer";
-    props["completion_tokens"]["description"] =
-        "Number of tokens in the completion";
-
-    props["total_tokens"]["type"] = "integer";
-    props["total_tokens"]["description"] = "Total tokens used";
-
-    props["ttft_ms"]["type"] = "number";
-    props["ttft_ms"]["description"] = "Time to first token in milliseconds";
-    props["ttft_ms"]["nullable"] = true;
-
-    props["tps"]["type"] = "number";
-    props["tps"]["description"] = "Tokens per second (excluding first token)";
-    props["tps"]["nullable"] = true;
-
-    schema["properties"] = props;
-    return schema;
-  }
-
-  Json::Value buildHealthResponseSchema() {
-    Json::Value schema;
-    schema["type"] = "object";
-
-    Json::Value props;
-    props["status"]["type"] = "string";
-    props["status"]["enum"].append("healthy");
-    props["status"]["description"] = "Server health status";
-
-    props["timestamp"]["type"] = "integer";
-    props["timestamp"]["description"] = "Unix timestamp";
-
-    schema["properties"] = props;
-    return schema;
-  }
-
-  Json::Value buildReadyResponseSchema() {
-    Json::Value schema;
-    schema["type"] = "object";
-
-    Json::Value props;
-    props["model_ready"]["type"] = "boolean";
-    props["model_ready"]["description"] =
-        "Whether the model is ready for inference";
-
-    props["queue_size"]["type"] = "integer";
-    props["queue_size"]["description"] = "Current number of requests in queue";
-
-    props["max_queue_size"]["type"] = "integer";
-    props["max_queue_size"]["description"] = "Maximum queue capacity";
-
-    props["device"]["type"] = "string";
-    props["device"]["description"] = "Device type";
-
-    props["workers"]["type"] = "array";
-    props["workers"]["items"]["$ref"] = "#/components/schemas/WorkerInfo";
-
-    schema["properties"] = props;
-    return schema;
-  }
-
-  Json::Value buildWorkerInfoSchema() {
-    Json::Value schema;
-    schema["type"] = "object";
-
-    Json::Value props;
-    props["worker_id"]["type"] = "string";
-    props["worker_id"]["description"] = "Worker identifier";
-
-    props["is_ready"]["type"] = "boolean";
-    props["is_ready"]["description"] = "Whether worker is ready";
-
-    schema["properties"] = props;
-    return schema;
-  }
-
-  Json::Value buildErrorSchema() {
-    Json::Value schema;
-    schema["type"] = "object";
-
-    Json::Value props;
-    props["error"]["type"] = "object";
-    props["error"]["properties"]["message"]["type"] = "string";
-    props["error"]["properties"]["type"]["type"] = "string";
-    props["error"]["properties"]["code"]["type"] = "string";
-
-    schema["properties"] = props;
-    return schema;
   }
 };
 


### PR DESCRIPTION
Moved the OpenAPI spec out of C++ code into `resources/openapi.json`. The controller now reads and caches the file at startup instead of building the JSON programmatically. The Swagger UI serving at /docs and /swagger is unchanged.

This makes the API spec editable without recompilation and enables validation with standard OpenAPI tooling.