### PR TITLE
Refactor long functions in LLM controller, consumer loop, and embedding service

### DIFF
--- a/tt-media-server/cpp_server/include/api/llm_controller.hpp
+++ b/tt-media-server/cpp_server/include/api/llm_controller.hpp
@@ -86,6 +86,16 @@ class LLMController : public drogon::HttpController<LLMController> {
                                const Json::Value& param = Json::nullValue,
                                const Json::Value& code = Json::nullValue);
 
+  struct SessionInfo {
+    bool validSessionFound = false;
+  };
+
+  /**
+   * Validate/create session, assign slot, populate request fields.
+   * Throws std::runtime_error if session creation fails.
+   */
+  SessionInfo resolveSession(domain::LLMRequest& req) const;
+
   /**
    * Determine if disaggregated prefill should be used for this request.
    */

--- a/tt-media-server/cpp_server/include/services/embedding_codec.hpp
+++ b/tt-media-server/cpp_server/include/services/embedding_codec.hpp
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "domain/embedding_request.hpp"
+#include "domain/embedding_response.hpp"
+
+namespace tt::services::embedding_codec {
+
+// Wire format (little-endian, native byte order):
+//   [num_responses : uint32_t]
+//   Per response:
+//     [task_id      : uint32_t]
+//     [has_error    : uint8_t]
+//     If has_error:
+//       [error_len  : uint32_t][error : chars]
+//     Else:
+//       [dim        : uint32_t][embedding : dim × float]
+//       [total_tokens : int32_t]
+//       [model_len  : uint32_t][model : chars]
+
+namespace detail {
+
+inline void appendRaw(std::vector<uint8_t>& buf, const void* data,
+                      size_t bytes) {
+  const auto* p = static_cast<const uint8_t*>(data);
+  buf.insert(buf.end(), p, p + bytes);
+}
+
+template <typename T>
+void appendScalar(std::vector<uint8_t>& buf, T val) {
+  appendRaw(buf, &val, sizeof(val));
+}
+
+inline void appendString(std::vector<uint8_t>& buf, const std::string& s) {
+  appendScalar(buf, static_cast<uint32_t>(s.size()));
+  buf.insert(buf.end(), s.begin(), s.end());
+}
+
+inline void appendFloats(std::vector<uint8_t>& buf,
+                         const std::vector<float>& v) {
+  appendScalar(buf, static_cast<uint32_t>(v.size()));
+  appendRaw(buf, v.data(), v.size() * sizeof(float));
+}
+
+class Reader {
+ public:
+  Reader(const uint8_t* data, size_t size) : data_(data), size_(size) {}
+
+  uint32_t readUint32() {
+    uint32_t v;
+    std::memcpy(&v, data_ + off_, sizeof(v));
+    off_ += sizeof(v);
+    return v;
+  }
+
+  int32_t readInt32() {
+    int32_t v;
+    std::memcpy(&v, data_ + off_, sizeof(v));
+    off_ += sizeof(v);
+    return v;
+  }
+
+  uint8_t readUint8() { return data_[off_++]; }
+
+  std::string readString() {
+    uint32_t len = readUint32();
+    std::string s(reinterpret_cast<const char*>(data_ + off_), len);
+    off_ += len;
+    return s;
+  }
+
+  std::vector<float> readFloats() {
+    uint32_t count = readUint32();
+    std::vector<float> v(count);
+    std::memcpy(v.data(), data_ + off_, count * sizeof(float));
+    off_ += count * sizeof(float);
+    return v;
+  }
+
+  bool atEnd() const { return off_ >= size_; }
+
+ private:
+  const uint8_t* data_;
+  size_t size_;
+  size_t off_ = 0;
+};
+
+}  // namespace detail
+
+inline std::vector<uint8_t> encodeResponses(
+    const std::vector<domain::EmbeddingRequest>& batch,
+    const std::vector<domain::EmbeddingResponse>& responses) {
+  std::vector<uint8_t> buf;
+  buf.reserve(batch.size() * 4200);
+
+  detail::appendScalar(buf, static_cast<uint32_t>(batch.size()));
+
+  for (size_t i = 0; i < batch.size(); ++i) {
+    detail::appendScalar(buf, batch[i].task_id);
+
+    if (i < responses.size() && responses[i].error.empty()) {
+      buf.push_back(0);
+      detail::appendFloats(buf, responses[i].embedding);
+      detail::appendScalar(buf,
+                           static_cast<int32_t>(responses[i].total_tokens));
+      detail::appendString(buf, responses[i].model);
+    } else {
+      buf.push_back(1);
+      std::string error = (i < responses.size()) ? responses[i].error
+                                                 : "No response from runner";
+      detail::appendString(buf, error);
+    }
+  }
+  return buf;
+}
+
+inline std::unordered_map<uint32_t, domain::EmbeddingResponse> decodeResponses(
+    const std::vector<uint8_t>& buffer) {
+  detail::Reader r(buffer.data(), buffer.size());
+  uint32_t count = r.readUint32();
+
+  std::unordered_map<uint32_t, domain::EmbeddingResponse> map;
+  map.reserve(count);
+
+  for (uint32_t i = 0; i < count && !r.atEnd(); ++i) {
+    domain::EmbeddingResponse resp{r.readUint32()};
+    uint8_t hasError = r.readUint8();
+
+    if (hasError) {
+      resp.error = r.readString();
+    } else {
+      resp.embedding = r.readFloats();
+      resp.total_tokens = r.readInt32();
+      resp.model = r.readString();
+    }
+    map.insert_or_assign(resp.task_id, std::move(resp));
+  }
+  return map;
+}
+
+}  // namespace tt::services::embedding_codec

--- a/tt-media-server/cpp_server/include/services/llm_service.hpp
+++ b/tt-media-server/cpp_server/include/services/llm_service.hpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -67,6 +68,9 @@ class LLMService
   void startConsumers();
 
   void consumerLoopForWorker(size_t workerIdx);
+
+  std::optional<std::function<void(domain::LLMStreamChunk&, bool)>>
+  resolveCallback(uint32_t taskId, bool isFinal);
 
   std::vector<std::thread> consumer_threads_;
 

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -110,8 +110,9 @@ struct StreamContext {
 tt::domain::CompletionUsage buildFinalUsage(const StreamContext& ctx) {
   const int tokens = ctx.completionTokens.load();
 
-  tt::domain::CompletionUsage usage{ctx.promptTokensCount, tokens, tokens,
-                                    std::nullopt, std::nullopt, std::nullopt};
+  tt::domain::CompletionUsage usage{
+      ctx.promptTokensCount, tokens,       tokens,
+      std::nullopt,          std::nullopt, std::nullopt};
 
   if (ctx.firstTokenTime.has_value()) {
     auto ttftUs = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -186,10 +187,9 @@ void handleTokenChunk(const std::shared_ptr<StreamContext>& ctx,
   if (ctx->firstContentChunk.exchange(false)) {
     std::optional<tt::domain::CompletionUsage> initialUsage;
     if (ctx->continuousUsage) {
-      initialUsage =
-          tt::domain::CompletionUsage{ctx->promptTokensCount, 0,
-                                      0,                       std::nullopt,
-                                      std::nullopt,            ctx->sessionId};
+      initialUsage = tt::domain::CompletionUsage{
+          ctx->promptTokensCount, 0, 0, std::nullopt, std::nullopt,
+          ctx->sessionId};
     }
     auto initialChunk = tt::domain::ChatCompletionStreamChunk::makeInitialChunk(
         ctx->completionId, ctx->model, ctx->created, initialUsage);
@@ -246,8 +246,7 @@ LLMController::SessionInfo LLMController::resolveSession(
   SessionInfo info;
 
   if (req.sessionId.has_value() && sessionManager) {
-    auto slotId =
-        sessionManager->getSlotIdBySessionId(req.sessionId.value());
+    auto slotId = sessionManager->getSlotIdBySessionId(req.sessionId.value());
     if (slotId != services::INVALID_SLOT_ID) {
       req.slotId = slotId;
       info.validSessionFound = true;
@@ -266,8 +265,7 @@ LLMController::SessionInfo LLMController::resolveSession(
   }
 
   if (req.sessionId.has_value() && sessionManager) {
-    req.slotId =
-        sessionManager->getSlotIdBySessionId(req.sessionId.value());
+    req.slotId = sessionManager->getSlotIdBySessionId(req.sessionId.value());
     TT_LOG_DEBUG(
         "[LLMController] Session: {}, SlotID: {}", req.sessionId.value(),
         req.slotId.has_value() ? std::to_string(req.slotId.value()) : "none");
@@ -465,13 +463,12 @@ void LLMController::handleStreaming(
     }
   };
 
-  auto streamingCallback = [ctx, onDisconnect](
-                               const domain::LLMStreamChunk& chunk,
-                               bool isFinal) {
-    if (ctx->done.load()) return;
-    if (!chunk.choices.empty()) handleTokenChunk(ctx, chunk, onDisconnect);
-    if (isFinal) finalizeStream(ctx);
-  };
+  auto streamingCallback =
+      [ctx, onDisconnect](const domain::LLMStreamChunk& chunk, bool isFinal) {
+        if (ctx->done.load()) return;
+        if (!chunk.choices.empty()) handleTokenChunk(ctx, chunk, onDisconnect);
+        if (isFinal) finalizeStream(ctx);
+      };
 
   try {
     if (tt::config::llmMode() == tt::config::LLMMode::REGULAR) {

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -72,6 +72,138 @@ void flushAccumulated(
   }
 }
 
+// Bundles all shared state for a streaming SSE session, replacing 17+
+// individual shared_ptr captures with a single shared_ptr<StreamContext>.
+struct StreamContext {
+  // Stream infrastructure
+  trantor::EventLoop* loop;
+  std::shared_ptr<drogon::ResponseStreamPtr> streamPtr =
+      std::make_shared<drogon::ResponseStreamPtr>();
+  std::shared_ptr<std::vector<std::string>> earlyBuffer =
+      std::make_shared<std::vector<std::string>>();
+  std::shared_ptr<ConcurrentQueue<std::string>> accumulator;
+  std::atomic<bool> done{false};
+
+  // Token counting + timing
+  std::atomic<int> completionTokens{0};
+  std::chrono::high_resolution_clock::time_point startTime =
+      std::chrono::high_resolution_clock::now();
+  std::optional<std::chrono::high_resolution_clock::time_point> firstTokenTime;
+  std::optional<std::chrono::high_resolution_clock::time_point> secondTokenTime;
+  std::atomic<bool> firstContentChunk{true};
+
+  // Request metadata (immutable after construction)
+  std::string completionId;
+  std::string model;
+  int64_t created;
+  bool includeUsage;
+  bool continuousUsage;
+  int promptTokensCount;
+  std::optional<std::string> sessionId;
+  uint32_t taskId;
+
+  // Dependencies
+  std::shared_ptr<tt::services::LLMService> service;
+  std::shared_ptr<tt::services::SessionManager> sessionManager;
+};
+
+tt::domain::CompletionUsage buildFinalUsage(const StreamContext& ctx) {
+  const int tokens = ctx.completionTokens.load();
+
+  tt::domain::CompletionUsage usage{ctx.promptTokensCount, tokens, tokens,
+                                    std::nullopt, std::nullopt, std::nullopt};
+
+  if (ctx.firstTokenTime.has_value()) {
+    auto ttftUs = std::chrono::duration_cast<std::chrono::microseconds>(
+        ctx.firstTokenTime.value() - ctx.startTime);
+    usage.ttft_ms =
+        std::round(static_cast<double>(ttftUs.count()) / 10.0) / 100.0;
+  }
+
+  if (tokens > 1 && ctx.firstTokenTime.has_value()) {
+    auto finalTime = std::chrono::high_resolution_clock::now();
+    auto baseTime = ctx.secondTokenTime.value_or(ctx.firstTokenTime.value());
+    auto totalUs = std::chrono::duration_cast<std::chrono::microseconds>(
+        finalTime - baseTime);
+    if (totalUs.count() > 0) {
+      auto secs = static_cast<double>(totalUs.count()) / 1000000.0;
+      usage.tps = std::round((tokens - 1) / secs * 1000.0) / 1000.0;
+    }
+  }
+
+  if (ctx.sessionId.has_value()) {
+    usage.sessionId = ctx.sessionId;
+  }
+  return usage;
+}
+
+void finalizeStream(const std::shared_ptr<StreamContext>& ctx) {
+  ctx->loop->queueInLoop([ctx]() {
+    if (!ctx->done.exchange(true) && *ctx->streamPtr) {
+      flushAccumulated(ctx->accumulator, ctx->streamPtr);
+
+      if (ctx->includeUsage) {
+        auto usage = buildFinalUsage(*ctx);
+        (*ctx->streamPtr)
+            ->send(tt::domain::ChatCompletionStreamChunk::makeUsageChunk(
+                       ctx->completionId, ctx->model, ctx->created, usage)
+                       .toSSE());
+      }
+
+      (*ctx->streamPtr)->send("data: [DONE]\n\n");
+      (*ctx->streamPtr)->close();
+
+      if (ctx->sessionId.has_value() && ctx->sessionManager) {
+        ctx->sessionManager->setSessionInFlight(ctx->sessionId.value(), false);
+      }
+    }
+  });
+}
+
+void handleTokenChunk(const std::shared_ptr<StreamContext>& ctx,
+                      const tt::domain::LLMStreamChunk& chunk,
+                      const std::function<void()>& onDisconnect) {
+  const int currentTokens = ctx->completionTokens.fetch_add(1) + 1;
+
+  auto now = std::chrono::high_resolution_clock::now();
+  if (!ctx->firstTokenTime.has_value()) {
+    ctx->firstTokenTime = now;
+  } else if (currentTokens == 2 && !ctx->secondTokenTime.has_value()) {
+    ctx->secondTokenTime = now;
+  }
+
+  std::optional<tt::domain::CompletionUsage> usage;
+  if (ctx->continuousUsage) {
+    usage = tt::domain::CompletionUsage{ctx->promptTokensCount, currentTokens,
+                                        currentTokens,          std::nullopt,
+                                        std::nullopt,           ctx->sessionId};
+  }
+
+  auto streamChunk = tt::domain::ChatCompletionStreamChunk::makeContentChunk(
+      ctx->completionId, ctx->model, ctx->created, chunk.choices[0], usage);
+
+  std::string sse;
+  if (ctx->firstContentChunk.exchange(false)) {
+    std::optional<tt::domain::CompletionUsage> initialUsage;
+    if (ctx->continuousUsage) {
+      initialUsage =
+          tt::domain::CompletionUsage{ctx->promptTokensCount, 0,
+                                      0,                       std::nullopt,
+                                      std::nullopt,            ctx->sessionId};
+    }
+    auto initialChunk = tt::domain::ChatCompletionStreamChunk::makeInitialChunk(
+        ctx->completionId, ctx->model, ctx->created, initialUsage);
+    sse = initialChunk.toSSE() + streamChunk.toSSE();
+  } else {
+    sse = streamChunk.toSSE();
+  }
+
+  if (!sse.empty()) {
+    sseSend(sse, ctx->loop, ctx->streamPtr, ctx->accumulator, ctx->earlyBuffer,
+            onDisconnect);
+  }
+}
+
 }  // anonymous namespace
 
 namespace tt::api {
@@ -107,6 +239,43 @@ Json::Value LLMController::errorJson(const std::string& message,
   error["param"] = param;
   error["code"] = code;
   return error;
+}
+
+LLMController::SessionInfo LLMController::resolveSession(
+    domain::LLMRequest& req) const {
+  SessionInfo info;
+
+  if (req.sessionId.has_value() && sessionManager) {
+    auto slotId =
+        sessionManager->getSlotIdBySessionId(req.sessionId.value());
+    if (slotId != services::INVALID_SLOT_ID) {
+      req.slotId = slotId;
+      info.validSessionFound = true;
+    } else {
+      TT_LOG_INFO(
+          "Received request with non existing session, resetting session id");
+      req.sessionId.reset();
+    }
+  }
+
+  if (!req.sessionId.has_value() && sessionManager) {
+    auto session = sessionManager->createSession(std::nullopt);
+    req.sessionId = session.getSessionId();
+    TT_LOG_INFO("[LLMController] Created NEW session: {}",
+                req.sessionId.value());
+  }
+
+  if (req.sessionId.has_value() && sessionManager) {
+    req.slotId =
+        sessionManager->getSlotIdBySessionId(req.sessionId.value());
+    TT_LOG_DEBUG(
+        "[LLMController] Session: {}, SlotID: {}", req.sessionId.value(),
+        req.slotId.has_value() ? std::to_string(req.slotId.value()) : "none");
+  } else if (!sessionManager) {
+    TT_LOG_WARN("[LLMController] SessionManager not available");
+  }
+
+  return info;
 }
 
 void LLMController::chatCompletions(
@@ -164,22 +333,13 @@ void LLMController::chatCompletions(
     handleStreaming(request, std::move(callback));
   } else {
     try {
-      // Create session if not provided
-      if (!request->sessionId.has_value() && sessionManager) {
-        auto session = sessionManager->createSession(std::nullopt);
-        request->sessionId = session.getSessionId();
-      }
+      resolveSession(*request);
 
-      // Save sessionId before moving request
       auto sessionId = request->sessionId;
-
-      // Mark session as in-flight
       if (sessionId.has_value() && sessionManager) {
         sessionManager->setSessionInFlight(sessionId.value(), true);
       }
 
-      request->slotId =
-          sessionManager->getSlotIdBySessionId(request->sessionId.value());
       auto startTime = std::chrono::high_resolution_clock::now();
       auto completion = service->submitRequest(std::move(*request));
       auto endTime = std::chrono::high_resolution_clock::now();
@@ -256,265 +416,69 @@ void LLMController::handleStreaming(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback) const {
   ZoneScopedN("API::handleStreaming");
 
-  bool validSessionFound = false;
-
-  if (reqPtr->sessionId.has_value() && sessionManager) {
-    auto slotId =
-        sessionManager->getSlotIdBySessionId(reqPtr->sessionId.value());
-
-    if (slotId != tt::services::INVALID_SLOT_ID) {
-      reqPtr->slotId = slotId;
-      validSessionFound = true;  // Session is valid
-    } else {
-      TT_LOG_INFO(
-          "Received request with non existing session, resetting session id");
-      // reset sessionId since it's a stale session
-      reqPtr->sessionId.reset();
-    }
+  SessionInfo sessionInfo;
+  try {
+    sessionInfo = resolveSession(*reqPtr);
+  } catch (const std::runtime_error& e) {
+    TT_LOG_ERROR("[LLMController] Failed to create session: {}", e.what());
+    auto resp = drogon::HttpResponse::newHttpJsonResponse(errorJson(
+        std::string("Failed to allocate memory resources: ") + e.what(),
+        "service_unavailable"));
+    resp->setStatusCode(drogon::k503ServiceUnavailable);
+    callback(resp);
+    return;
   }
 
-  // Create session if not provided
-  if (!reqPtr->sessionId.has_value() && sessionManager) {
-    try {
-      auto session = sessionManager->createSession(std::nullopt);
-      reqPtr->sessionId = session.getSessionId();
-      TT_LOG_INFO("[LLMController] Created NEW session: {}",
-                  reqPtr->sessionId.value());
-    } catch (const std::runtime_error& e) {
-      TT_LOG_ERROR("[LLMController] Failed to create session: {}", e.what());
-      auto resp = drogon::HttpResponse::newHttpJsonResponse(errorJson(
-          std::string("Failed to allocate memory resources: ") + e.what(),
-          "service_unavailable"));
-      resp->setStatusCode(drogon::k503ServiceUnavailable);
-      callback(resp);
-      return;
-    }
-  }
-
-  if (reqPtr->sessionId.has_value() && sessionManager) {
-    reqPtr->slotId =
-        sessionManager->getSlotIdBySessionId(reqPtr->sessionId.value());
-    TT_LOG_DEBUG(
-        "[LLMController] Session: {}, SlotID: {}", reqPtr->sessionId.value(),
-        reqPtr->slotId.has_value() ? std::to_string(reqPtr->slotId.value())
-                                   : "none");
-  } else if (!sessionManager) {
-    TT_LOG_WARN("[LLMController] SessionManager not available");
-  }
-
-  const std::string completionId =
-      "chatcmpl-" + std::to_string(reqPtr->task_id);
-  const std::string model = reqPtr->model.value_or("default");
-  const int64_t created = static_cast<int64_t>(
+  auto ctx = std::make_shared<StreamContext>();
+  ctx->loop = trantor::EventLoop::getEventLoopOfCurrentThread();
+  ctx->accumulator = tt::config::enableAccumulatedStreaming()
+                         ? std::make_shared<ConcurrentQueue<std::string>>()
+                         : nullptr;
+  ctx->completionId = "chatcmpl-" + std::to_string(reqPtr->task_id);
+  ctx->model = reqPtr->model.value_or("default");
+  ctx->created = static_cast<int64_t>(
       std::chrono::duration_cast<std::chrono::seconds>(
           std::chrono::system_clock::now().time_since_epoch())
           .count());
+  ctx->includeUsage = !reqPtr->stream_options.has_value() ||
+                      reqPtr->stream_options->include_usage;
+  ctx->continuousUsage = reqPtr->stream_options.has_value() &&
+                         reqPtr->stream_options->continuous_usage_stats;
+  ctx->promptTokensCount = reqPtr->prompt_tokens_count;
+  ctx->sessionId = reqPtr->sessionId;
+  ctx->taskId = reqPtr->task_id;
+  ctx->service = service;
+  ctx->sessionManager = sessionManager;
 
-  const bool includeUsage =
-      !reqPtr->stream_options.has_value() ||
-      reqPtr->stream_options
-          ->include_usage;  // Default to true if not specified
-  const bool continuousUsage = reqPtr->stream_options.has_value() &&
-                               reqPtr->stream_options->continuous_usage_stats;
-
-  auto accumulator = tt::config::enableAccumulatedStreaming()
-                         ? std::make_shared<ConcurrentQueue<std::string>>()
-                         : nullptr;
-
-  // Request handlers run on the IO thread, so we can capture the loop here.
-  trantor::EventLoop* loop = trantor::EventLoop::getEventLoopOfCurrentThread();
-
-  // Shared state. All accesses happen on the IO thread: token callbacks via
-  // queueInLoop, and the stream setup lambda via Drogon's async stream
-  // machinery.
-  auto done = std::make_shared<std::atomic<bool>>(false);
-  // stream_ptr is null until the newAsyncStreamResponse lambda runs.
-  auto streamPtr = std::make_shared<drogon::ResponseStreamPtr>();
-  // Events that arrive before stream_ptr is set are buffered here.
-  auto earlyBuffer = std::make_shared<std::vector<std::string>>();
-  auto completionTokens = std::make_shared<std::atomic<int>>(0);
-
-  // Timing metrics for TTFT and TPS calculation
-  auto startTime =
-      std::make_shared<std::chrono::high_resolution_clock::time_point>(
-          std::chrono::high_resolution_clock::now());
-  auto firstTokenTime = std::make_shared<
-      std::optional<std::chrono::high_resolution_clock::time_point>>();
-  auto secondTokenTime = std::make_shared<
-      std::optional<std::chrono::high_resolution_clock::time_point>>();
-  auto firstContentChunk = std::make_shared<std::atomic<bool>>(true);
-
-  // Capture sessionId before submitting to service (request will be moved)
-  const std::optional<std::string> capturedSessionId = reqPtr->sessionId;
-
-  // Mark session as in-flight
-  if (capturedSessionId.has_value() && sessionManager) {
-    sessionManager->setSessionInFlight(capturedSessionId.value(), true);
+  if (ctx->sessionId.has_value() && sessionManager) {
+    sessionManager->setSessionInFlight(ctx->sessionId.value(), true);
   }
 
-  // Abort callback: fires when the TCP connection drops mid-stream.
-  // Captured by value so it stays alive for the duration of the streaming
-  // session. Called on the IO thread from inside sseSend().
-  const uint32_t taskId = reqPtr->task_id;
-  auto onDisconnect = [taskId, service = this->service, done, capturedSessionId,
-                       sessionManager = this->sessionManager]() {
-    if (!done->exchange(true)) {
+  auto onDisconnect = [ctx]() {
+    if (!ctx->done.exchange(true)) {
       TT_LOG_INFO("[LLMController] Client disconnected, aborting task {}",
-                  taskId);
-      service->abortRequest(taskId);
-      // Mark session as no longer in-flight
-      if (capturedSessionId.has_value() && sessionManager) {
-        sessionManager->setSessionInFlight(capturedSessionId.value(), false);
+                  ctx->taskId);
+      ctx->service->abortRequest(ctx->taskId);
+      if (ctx->sessionId.has_value() && ctx->sessionManager) {
+        ctx->sessionManager->setSessionInFlight(ctx->sessionId.value(), false);
       }
     }
   };
 
-  // Submit the streaming request before setting up the HTTP stream so that a
-  // full queue throws QueueFullException here, allowing us to return a proper
-  // 429.
-  auto sessionManagerPtr = this->sessionManager;
-  auto streamingCallback = [loop, streamPtr, earlyBuffer, done, completionId,
-                            model, created, includeUsage, continuousUsage,
-                            completionTokens, startTime, firstTokenTime,
-                            secondTokenTime, firstContentChunk, reqPtr,
-                            capturedSessionId, accumulator, onDisconnect,
-                            sessionManagerPtr](
+  auto streamingCallback = [ctx, onDisconnect](
                                const domain::LLMStreamChunk& chunk,
                                bool isFinal) {
-    if (done->load()) {
-      return;
-    }
-    if (!chunk.choices.empty()) {
-      const int currentTokens = completionTokens->fetch_add(1) + 1;
-
-      auto now = std::chrono::high_resolution_clock::now();
-      if (!firstTokenTime->has_value()) {
-        *firstTokenTime = now;
-      } else if (currentTokens == 2 && !secondTokenTime->has_value()) {
-        *secondTokenTime = now;
-      }
-
-      std::optional<domain::CompletionUsage> usage;
-      if (continuousUsage) {
-        usage = domain::CompletionUsage{
-            reqPtr->prompt_tokens_count,
-            currentTokens,
-            currentTokens,
-            std::nullopt,
-            std::nullopt,
-            capturedSessionId,
-        };
-      }
-      auto streamChunk = domain::ChatCompletionStreamChunk::makeContentChunk(
-          completionId, model, created, chunk.choices[0], usage);
-
-      std::string sse;
-      if (firstContentChunk->exchange(false)) {
-        std::optional<domain::CompletionUsage> initialUsage;
-        if (continuousUsage) {
-          initialUsage = domain::CompletionUsage{reqPtr->prompt_tokens_count,
-                                                 0,
-                                                 0,
-                                                 std::nullopt,
-                                                 std::nullopt,
-                                                 capturedSessionId};
-        }
-        auto initialChunk = domain::ChatCompletionStreamChunk::makeInitialChunk(
-            completionId, model, created, initialUsage);
-        sse = initialChunk.toSSE() + streamChunk.toSSE();
-      } else {
-        sse = streamChunk.toSSE();
-      }
-
-      if (!sse.empty()) {
-        sseSend(sse, loop, streamPtr, accumulator, earlyBuffer, onDisconnect);
-      }
-    }
-    if (isFinal) {
-      loop->queueInLoop([streamPtr, done, includeUsage, completionId, model,
-                         created, completionTokens, startTime, firstTokenTime,
-                         secondTokenTime, reqPtr, capturedSessionId,
-                         accumulator, sessionManagerPtr]() {
-        if (!done->exchange(true) && *streamPtr) {
-          flushAccumulated(accumulator, streamPtr);
-          if (includeUsage) {
-            const int tokens = completionTokens->load();
-
-            TT_LOG_DEBUG(
-                "[LLMController] Creating final usage - capturedSessionId: {}",
-                capturedSessionId.has_value()
-                    ? ("'" + capturedSessionId.value() + "'")
-                    : "none");
-
-            domain::CompletionUsage usage{reqPtr->prompt_tokens_count,
-                                          tokens,
-                                          tokens,
-                                          std::nullopt,
-                                          std::nullopt,
-                                          std::nullopt};
-
-            if (firstTokenTime->has_value()) {
-              auto ttftDuration =
-                  std::chrono::duration_cast<std::chrono::microseconds>(
-                      firstTokenTime->value() - *startTime);
-              usage.ttft_ms =
-                  std::round(static_cast<double>(ttftDuration.count()) / 10.0) /
-                  100.0;
-            }
-
-            if (tokens > 1) {
-              auto finalTime = std::chrono::high_resolution_clock::now();
-              auto baseTime = secondTokenTime->has_value()
-                                  ? secondTokenTime->value()
-                                  : firstTokenTime->value();
-              auto totalDuration =
-                  std::chrono::duration_cast<std::chrono::microseconds>(
-                      finalTime - baseTime);
-              if (totalDuration.count() > 0) {
-                auto timeSeconds =
-                    static_cast<double>(totalDuration.count()) / 1000000.0;
-                usage.tps =
-                    std::round((tokens - 1) / timeSeconds * 1000.0) / 1000.0;
-                TT_LOG_DEBUG("[LLMController] Final TPS: {} tokens/sec",
-                             usage.tps.value());
-              }
-            }
-
-            // Include sessionId in usage if present
-            if (capturedSessionId.has_value()) {
-              usage.sessionId = capturedSessionId;
-              TT_LOG_DEBUG("[LLMController] Set usage.sessionId to: '{}'",
-                           usage.sessionId.value());
-            } else {
-              TT_LOG_WARN(
-                  "[LLMController] capturedSessionId is empty, cannot set "
-                  "usage.sessionId");
-            }
-
-            (*streamPtr)
-                ->send(domain::ChatCompletionStreamChunk::makeUsageChunk(
-                           completionId, model, created, usage)
-                           .toSSE());
-          }
-          (*streamPtr)->send("data: [DONE]\n\n");
-          (*streamPtr)->close();
-
-          // Mark session as no longer in-flight
-          if (capturedSessionId.has_value() && sessionManagerPtr) {
-            sessionManagerPtr->setSessionInFlight(capturedSessionId.value(),
-                                                  false);
-          }
-        }
-      });
-    }
+    if (ctx->done.load()) return;
+    if (!chunk.choices.empty()) handleTokenChunk(ctx, chunk, onDisconnect);
+    if (isFinal) finalizeStream(ctx);
   };
+
   try {
     if (tt::config::llmMode() == tt::config::LLMMode::REGULAR) {
       service->submitStreamingRequest(*reqPtr, streamingCallback);
     } else if (tt::config::llmMode() == tt::config::LLMMode::DECODE_ONLY) {
-      // tokenize right away
       service->preProcess(*reqPtr);
-      if (shouldDoPrefillOnDecode(*reqPtr, validSessionFound)) {
+      if (shouldDoPrefillOnDecode(*reqPtr, sessionInfo.validSessionFound)) {
         TT_LOG_DEBUG(
             "[LLMController] Using prefill on decode for sessionId: {}",
             reqPtr->sessionId.value_or("none"));
@@ -541,14 +505,14 @@ void LLMController::handleStreaming(
   }
 
   auto resp = drogon::HttpResponse::newAsyncStreamResponse(
-      [streamPtr, earlyBuffer, done](drogon::ResponseStreamPtr stream) mutable {
-        *streamPtr = std::move(stream);
-        for (const auto& event : *earlyBuffer) {
-          (*streamPtr)->send(event);
+      [ctx](drogon::ResponseStreamPtr stream) mutable {
+        *ctx->streamPtr = std::move(stream);
+        for (const auto& event : *ctx->earlyBuffer) {
+          (*ctx->streamPtr)->send(event);
         }
-        earlyBuffer->clear();
-        if (done->load()) {
-          (*streamPtr)->close();
+        ctx->earlyBuffer->clear();
+        if (ctx->done.load()) {
+          (*ctx->streamPtr)->close();
         }
       });
 

--- a/tt-media-server/cpp_server/src/services/embedding_service.cpp
+++ b/tt-media-server/cpp_server/src/services/embedding_service.cpp
@@ -83,9 +83,9 @@ struct WorkerProcess {
              std::function<void(int readFd, int writeFd)> childMain) {
     worker_id = workerId;
 
-    int req_pipe[2] = {-1, -1};
-    int resp_pipe[2] = {-1, -1};
-    if (pipe(req_pipe) < 0 || pipe(resp_pipe) < 0) {
+    int reqPipe[2] = {-1, -1};
+    int respPipe[2] = {-1, -1};
+    if (pipe(reqPipe) < 0 || pipe(respPipe) < 0) {
       TT_LOG_ERROR("[EmbeddingService] Failed to create pipes for worker {}",
                    workerId);
       return false;
@@ -99,18 +99,18 @@ struct WorkerProcess {
 
     if (child == 0) {
       // Child: close parent ends, run child main.
-      close(req_pipe[1]);
-      close(resp_pipe[0]);
-      childMain(req_pipe[0], resp_pipe[1]);
+      close(reqPipe[1]);
+      close(respPipe[0]);
+      childMain(reqPipe[0], respPipe[1]);
       _exit(0);  // childMain is [[noreturn]], but just in case
     }
 
     // Parent: close child ends, record FDs.
-    close(req_pipe[0]);
-    close(resp_pipe[1]);
+    close(reqPipe[0]);
+    close(respPipe[1]);
     pid = child;
-    write_fd = req_pipe[1];
-    read_fd = resp_pipe[0];
+    write_fd = reqPipe[1];
+    read_fd = respPipe[0];
     is_ready.store(true);
     running.store(true);
 

--- a/tt-media-server/cpp_server/src/services/embedding_service.cpp
+++ b/tt-media-server/cpp_server/src/services/embedding_service.cpp
@@ -21,46 +21,168 @@
 #include "config/settings.hpp"
 #include "profiling/tracy.hpp"
 #include "runners/embedding_runner.hpp"
+#include "services/embedding_codec.hpp"
 #include "services/embedding_service.hpp"
 #include "utils/logger.hpp"
 
 namespace tt::services {
 
-/**
- * Implementation using fork-based multiprocessing.
- *
- * Each worker process:
- * - Has its own TT_VISIBLE_DEVICES environment variable
- * - Runs an EmbeddingRunner instance
- * - Communicates via pipes
- */
+namespace {
+
+// Length-prefixed pipe write: [len:u32][data].  Returns false on failure.
+bool pipeWrite(int fd, const void* data, size_t len) {
+  uint32_t header = static_cast<uint32_t>(len);
+  if (write(fd, &header, sizeof(header)) != sizeof(header)) return false;
+  return write(fd, data, len) == static_cast<ssize_t>(len);
+}
+
+// Length-prefixed pipe read.  Returns empty vector on failure.
+std::vector<uint8_t> pipeReadBinary(int fd) {
+  uint32_t len = 0;
+  ssize_t n = read(fd, &len, sizeof(len));
+  if (n != sizeof(len) || len > 100 * 1024 * 1024) return {};
+
+  std::vector<uint8_t> buf(len);
+  size_t total = 0;
+  while (total < len) {
+    n = read(fd, buf.data() + total, len - total);
+    if (n <= 0) return {};
+    total += static_cast<size_t>(n);
+  }
+  return buf;
+}
+
+// Length-prefixed pipe read into string.
+std::string pipeReadString(int fd) {
+  uint32_t len = 0;
+  ssize_t n = read(fd, &len, sizeof(len));
+  if (n <= 0) return {};
+
+  std::string data(len, '\0');
+  size_t total = 0;
+  while (total < len) {
+    n = read(fd, data.data() + total, len - total);
+    if (n <= 0) return {};
+    total += static_cast<size_t>(n);
+  }
+  return data;
+}
+
+}  // namespace
+
+struct WorkerProcess {
+  int worker_id = -1;
+  pid_t pid = -1;
+  int write_fd = -1;  // parent → child (request pipe write end)
+  int read_fd = -1;   // child → parent (response pipe read end)
+  std::atomic<bool> is_ready{false};
+  std::atomic<bool> running{false};
+  std::unique_ptr<std::thread> dispatch_thread;
+
+  bool spawn(int workerId,
+             std::function<void(int readFd, int writeFd)> childMain) {
+    worker_id = workerId;
+
+    int req_pipe[2] = {-1, -1};
+    int resp_pipe[2] = {-1, -1};
+    if (pipe(req_pipe) < 0 || pipe(resp_pipe) < 0) {
+      TT_LOG_ERROR("[EmbeddingService] Failed to create pipes for worker {}",
+                   workerId);
+      return false;
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+      TT_LOG_ERROR("[EmbeddingService] Failed to fork worker {}", workerId);
+      return false;
+    }
+
+    if (child == 0) {
+      // Child: close parent ends, run child main.
+      close(req_pipe[1]);
+      close(resp_pipe[0]);
+      childMain(req_pipe[0], resp_pipe[1]);
+      _exit(0);  // childMain is [[noreturn]], but just in case
+    }
+
+    // Parent: close child ends, record FDs.
+    close(req_pipe[0]);
+    close(resp_pipe[1]);
+    pid = child;
+    write_fd = req_pipe[1];
+    read_fd = resp_pipe[0];
+    is_ready.store(true);
+    running.store(true);
+
+    TT_LOG_INFO(
+        "[EmbeddingService] Spawned worker {} with PID {} "
+        "(TT_VISIBLE_DEVICES={}) write_fd={} read_fd={}",
+        workerId, pid, tt::config::visibleDevicesForWorker(workerId), write_fd,
+        read_fd);
+    return true;
+  }
+
+  bool checkAlive() {
+    if (pid <= 0) return false;
+    int status;
+    pid_t result = waitpid(pid, &status, WNOHANG);
+    if (result != pid) return true;
+
+    if (WIFEXITED(status)) {
+      TT_LOG_ERROR("[EmbeddingService] Worker {} exited with code {}",
+                   worker_id, WEXITSTATUS(status));
+    } else if (WIFSIGNALED(status)) {
+      TT_LOG_ERROR("[EmbeddingService] Worker {} killed by signal {}",
+                   worker_id, WTERMSIG(status));
+    }
+    is_ready.store(false);
+    return false;
+  }
+
+  bool sendRequest(const std::string& json) {
+    if (!pipeWrite(write_fd, json.data(), json.size())) {
+      TT_LOG_ERROR("[EmbeddingService] Worker {} pipe write failed: {}",
+                   worker_id, strerror(errno));
+      is_ready.store(false);
+      return false;
+    }
+    return true;
+  }
+
+  std::vector<uint8_t> receiveResponse() {
+    auto buf = pipeReadBinary(read_fd);
+    if (buf.empty()) {
+      TT_LOG_ERROR("[EmbeddingService] Worker {} response read failed",
+                   worker_id);
+      is_ready.store(false);
+    }
+    return buf;
+  }
+
+  void terminate() {
+    if (pid > 0) {
+      kill(pid, SIGTERM);
+      waitpid(pid, nullptr, 0);
+      TT_LOG_INFO("[EmbeddingService] Worker {} terminated", worker_id);
+    }
+    if (write_fd >= 0) close(write_fd);
+    if (read_fd >= 0) close(read_fd);
+    write_fd = -1;
+    read_fd = -1;
+  }
+};
+
 struct EmbeddingService::Impl {
-  // Forward declare PendingRequest first
   struct PendingRequest {
     domain::EmbeddingRequest request;
     std::promise<domain::EmbeddingResponse> promise;
-
     explicit PendingRequest(domain::EmbeddingRequest req)
         : request(std::move(req)) {}
   };
 
-  // Worker process info
-  struct WorkerProcess {
-    pid_t pid = -1;
-    int worker_id = -1;
-    int request_pipe[2] = {-1, -1};   // Parent writes, child reads
-    int response_pipe[2] = {-1, -1};  // Child writes, parent reads
-    std::atomic<bool> is_ready{false};
-
-    // Per-worker dispatch thread (pulls from shared queue)
-    std::unique_ptr<std::thread> dispatch_thread;
-    std::atomic<bool> running{false};
-  };
-
   std::vector<std::unique_ptr<WorkerProcess>> workers_;
-  size_t num_workers_ = 3;  // Default 3 workers for devices 1, 2, 3
+  size_t num_workers_ = 3;
 
-  // Shared request queue (all worker dispatch threads pull from this)
   TRACY_LOCKABLE(std::mutex, queue_mutex_);
   std::queue<std::shared_ptr<PendingRequest>> request_queue_;
   std::condition_variable_any queue_cv_;
@@ -68,12 +190,8 @@ struct EmbeddingService::Impl {
   std::atomic<bool> running_{false};
   std::atomic<bool> is_ready_{false};
 
-  // Batching configuration
-  // NOTE: max_batch_size_ must match Python's MAX_BATCH_SIZE setting
-  // Set TT_BATCH_SIZE and MAX_BATCH_SIZE env vars to the same value
-  size_t max_batch_size_ =
-      1;  // Max requests per batch (default 1 = no batching)
-  std::chrono::milliseconds batch_timeout_{5};  // Max wait time to fill batch
+  size_t max_batch_size_ = 1;
+  std::chrono::milliseconds batch_timeout_{5};
   size_t max_queue_size_ = tt::config::defaults::MAX_QUEUE_SIZE;
 
   Impl() {
@@ -89,175 +207,26 @@ struct EmbeddingService::Impl {
 
   ~Impl() { stop(); }
 
-  void start() {
-    if (running_.exchange(true)) {
-      return;
-    }
-
-    TT_LOG_INFO("[EmbeddingService] Starting with {} worker processes",
-                num_workers_);
-
-    workers_.reserve(num_workers_);
-
-    // First, fork all worker processes
-    for (size_t i = 0; i < num_workers_; ++i) {
-      auto worker = std::make_unique<WorkerProcess>();
-      worker->worker_id = static_cast<int>(i);
-
-      // Create pipes
-      if (pipe(worker->request_pipe) < 0 || pipe(worker->response_pipe) < 0) {
-        TT_LOG_ERROR("[EmbeddingService] Failed to create pipes for worker {}",
-                     i);
-        continue;
-      }
-
-      pid_t pid = fork();
-
-      if (pid < 0) {
-        TT_LOG_ERROR("[EmbeddingService] Failed to fork worker {}", i);
-        continue;
-      } else if (pid == 0) {
-        // Child process
-        workerProcessMain(static_cast<int>(i), worker->request_pipe,
-                          worker->response_pipe);
-        // Never returns
-      } else {
-        // Parent process
-        worker->pid = pid;
-
-        // Close unused pipe ends
-        close(worker->request_pipe[0]);   // Close read end of request pipe
-        close(worker->response_pipe[1]);  // Close write end of response pipe
-
-        worker->is_ready.store(true);
-        worker->running.store(true);
-
-        TT_LOG_INFO(
-            "[EmbeddingService] Spawned worker {} with PID {} "
-            "(TT_VISIBLE_DEVICES={}) request_pipe[1]={} response_pipe[0]={}",
-            i, pid, tt::config::visibleDevicesForWorker(i),
-            worker->request_pipe[1], worker->response_pipe[0]);
-
-        workers_.push_back(std::move(worker));
-      }
-    }
-
-    // Now start per-worker dispatch threads (after all workers are in the
-    // vector)
-    for (size_t i = 0; i < workers_.size(); ++i) {
-      workers_[i]->dispatch_thread =
-          std::make_unique<std::thread>(&Impl::workerDispatchLoop, this, i);
-    }
-
-    is_ready_ = true;
-    TT_LOG_INFO("[EmbeddingService] All {} workers started", workers_.size());
-  }
-
-  void stop() {
-    if (!running_.exchange(false)) {
-      return;
-    }
-
-    TT_LOG_INFO("[EmbeddingService] Stopping...");
-
-    // Wake up all dispatch threads
-    queue_cv_.notify_all();
-
-    // Stop and join per-worker dispatch threads
-    for (auto& worker : workers_) {
-      worker->running = false;
-    }
-    queue_cv_.notify_all();  // Wake them up again after setting running=false
-
-    size_t batchSize = tt::config::maxInFlightCount();
-    std::string batchStr = std::to_string(batchSize);
-    setenv("MAX_BATCH_SIZE", batchStr.c_str(), 1);
-
-    for (auto& worker : workers_) {
-      if (worker->dispatch_thread && worker->dispatch_thread->joinable()) {
-        worker->dispatch_thread->join();
-      }
-
-      if (worker->pid > 0) {
-        kill(worker->pid, SIGTERM);
-        waitpid(worker->pid, nullptr, 0);
-        TT_LOG_INFO("[EmbeddingService] Worker {} terminated",
-                    worker->worker_id);
-      }
-
-      // Close pipes
-      if (worker->request_pipe[1] >= 0) close(worker->request_pipe[1]);
-      if (worker->response_pipe[0] >= 0) close(worker->response_pipe[0]);
-    }
-
-    workers_.clear();
-    is_ready_ = false;
-
-    TT_LOG_INFO("[EmbeddingService] Stopped");
-  }
-
-  [[noreturn]] void workerProcessMain(int workerId, int requestPipe[2],
-                                      int responsePipe[2]) {
-    // Save our FDs first, before closing anything
-    int readFd = requestPipe[0];
-    int writeFd = responsePipe[1];
-
-    // Close unused pipe ends for THIS worker
-    close(requestPipe[1]);   // Close write end of request pipe
-    close(responsePipe[0]);  // Close read end of response pipe
-
+  [[noreturn]] static void workerProcessMain(int workerId, int readFd,
+                                             int writeFd) {
     size_t wid = static_cast<size_t>(workerId);
     std::string visibleDevices = tt::config::visibleDevicesForWorker(wid);
     setenv("TT_VISIBLE_DEVICES", visibleDevices.c_str(), 1);
 
-    TT_LOG_INFO("[Worker {}] Started with PID {}", workerId, getpid());
-    TT_LOG_INFO("[Worker {}] TT_VISIBLE_DEVICES={}", workerId, visibleDevices);
-    TT_LOG_INFO("[Worker {}] read_fd={}, write_fd={}", workerId, readFd,
-                writeFd);
+    TT_LOG_INFO("[Worker {}] Started (PID {}, TT_VISIBLE_DEVICES={})", workerId,
+                getpid(), visibleDevices);
 
-    runners::EmbeddingRunner runner(visibleDevices, static_cast<int>(wid));
-
-    // Warmup
+    runners::EmbeddingRunner runner(visibleDevices, workerId);
     if (!runner.warmup()) {
       TT_LOG_ERROR("[Worker {}] Warmup failed!", workerId);
       _exit(1);
     }
-
     TT_LOG_INFO("[Worker {}] Ready", workerId);
 
-    // Process requests (supports batching)
     while (true) {
-      // Read request length
-      uint32_t requestLen = 0;
-      ssize_t n = read(readFd, &requestLen, sizeof(requestLen));
-      if (n <= 0) {
-        TT_LOG_ERROR("[Worker {}] Pipe closed or read error (n={})", workerId,
-                     n);
-        break;  // Pipe closed or error
-      }
+      std::string requestJson = pipeReadString(readFd);
+      if (requestJson.empty()) break;
 
-      TT_LOG_DEBUG("[Worker {}] Reading request of {} bytes", workerId,
-                   requestLen);
-
-      // Read request JSON - loop until all bytes are read
-      std::string requestJson(requestLen, '\0');
-      size_t totalRead = 0;
-      while (totalRead < requestLen) {
-        n = read(readFd, requestJson.data() + totalRead,
-                 requestLen - totalRead);
-        if (n <= 0) {
-          TT_LOG_ERROR("[Worker {}] Read error at {}/{}", workerId, totalRead,
-                       requestLen);
-          break;
-        }
-        totalRead += n;
-      }
-      if (totalRead != requestLen) {
-        TT_LOG_ERROR("[Worker {}] Failed to read full request", workerId);
-        continue;
-      }
-
-      // Parse request (can be array for batch or object for single)
       Json::Value reqJson;
       Json::CharReaderBuilder builder;
       std::istringstream iss(requestJson);
@@ -268,19 +237,17 @@ struct EmbeddingService::Impl {
         continue;
       }
 
-      // Build batch of requests
-      std::vector<domain::EmbeddingRequest> batch;
       auto taskIdFromJson = [](const Json::Value& j) -> uint32_t {
-        if (j.isMember("task_id") && j["task_id"].isUInt()) {
-          return j["task_id"].asUInt();
-        }
-        return tt::utils::TaskIDGenerator::generate();
+        return (j.isMember("task_id") && j["task_id"].isUInt())
+                   ? j["task_id"].asUInt()
+                   : tt::utils::TaskIDGenerator::generate();
       };
+
+      std::vector<domain::EmbeddingRequest> batch;
       if (reqJson.isArray()) {
-        for (const auto& item : reqJson) {
+        for (const auto& item : reqJson)
           batch.push_back(
               domain::EmbeddingRequest::fromJson(item, taskIdFromJson(item)));
-        }
       } else {
         batch.push_back(domain::EmbeddingRequest::fromJson(
             reqJson, taskIdFromJson(reqJson)));
@@ -289,79 +256,11 @@ struct EmbeddingService::Impl {
       TT_LOG_INFO("[Worker {}] Processing batch of {} requests", workerId,
                   batch.size());
 
-      // Run inference on batch
       auto responses = runner.run(batch);
+      auto buf = embedding_codec::encodeResponses(batch, responses);
 
-      // Build binary response format:
-      // [num_responses: uint32_t]
-      // For each response:
-      //   [task_id_len: uint32_t][task_id: chars]
-      //   [has_error: uint8_t]
-      //   If has_error:
-      //     [error_len: uint32_t][error: chars]
-      //   Else:
-      //     [embedding_dim: uint32_t][embedding: floats]
-      //     [total_tokens: int32_t]
-      //     [model_len: uint32_t][model: chars]
-
-      std::vector<uint8_t> responseBuffer;
-      responseBuffer.reserve(batch.size() * (4 + 32 + 1 + 4 + 1024 * 4 + 4 + 4 +
-                                             32));  // Estimate size
-
-      // Helper to append data
-      auto appendUint32 = [&responseBuffer](uint32_t val) {
-        responseBuffer.insert(responseBuffer.end(),
-                              reinterpret_cast<uint8_t*>(&val),
-                              reinterpret_cast<uint8_t*>(&val) + sizeof(val));
-      };
-      auto appendInt32 = [&responseBuffer](int32_t val) {
-        responseBuffer.insert(responseBuffer.end(),
-                              reinterpret_cast<uint8_t*>(&val),
-                              reinterpret_cast<uint8_t*>(&val) + sizeof(val));
-      };
-      auto appendString = [&responseBuffer,
-                           &appendUint32](const std::string& s) {
-        appendUint32(static_cast<uint32_t>(s.size()));
-        responseBuffer.insert(responseBuffer.end(), s.begin(), s.end());
-      };
-      auto appendFloats = [&responseBuffer,
-                           &appendUint32](const std::vector<float>& floats) {
-        appendUint32(static_cast<uint32_t>(floats.size()));
-        const uint8_t* data = reinterpret_cast<const uint8_t*>(floats.data());
-        responseBuffer.insert(responseBuffer.end(), data,
-                              data + floats.size() * sizeof(float));
-      };
-
-      appendUint32(static_cast<uint32_t>(batch.size()));
-
-      for (size_t i = 0; i < batch.size(); ++i) {
-        appendUint32(batch[i].task_id);
-
-        if (i < responses.size() && responses[i].error.empty()) {
-          responseBuffer.push_back(0);  // has_error = false
-          appendFloats(responses[i].embedding);
-          appendInt32(responses[i].total_tokens);
-          appendString(responses[i].model);
-        } else {
-          responseBuffer.push_back(1);  // has_error = true
-          std::string error = (i < responses.size())
-                                  ? responses[i].error
-                                  : "No response from runner";
-          appendString(error);
-        }
-      }
-
-      uint32_t responseLen = static_cast<uint32_t>(responseBuffer.size());
-      TT_LOG_DEBUG("[Worker {}] Sending binary response of {} bytes", workerId,
-                   responseLen);
-
-      ssize_t w1 = write(writeFd, &responseLen, sizeof(responseLen));
-      ssize_t w2 = write(writeFd, responseBuffer.data(), responseLen);
-
-      if (w1 != sizeof(responseLen) ||
-          w2 != static_cast<ssize_t>(responseLen)) {
-        TT_LOG_ERROR("[Worker {}] Failed to write response: w1={} w2={}",
-                     workerId, w1, w2);
+      if (!pipeWrite(writeFd, buf.data(), buf.size())) {
+        TT_LOG_ERROR("[Worker {}] Failed to write response", workerId);
       }
     }
 
@@ -369,15 +268,60 @@ struct EmbeddingService::Impl {
     _exit(0);
   }
 
-  // Per-worker dispatch loop: pulls from shared queue, batches, and sends to
-  // worker process
+  void start() {
+    if (running_.exchange(true)) return;
+
+    TT_LOG_INFO("[EmbeddingService] Starting with {} worker processes",
+                num_workers_);
+    workers_.reserve(num_workers_);
+
+    for (size_t i = 0; i < num_workers_; ++i) {
+      auto w = std::make_unique<WorkerProcess>();
+      int wid = static_cast<int>(i);
+      if (!w->spawn(
+              wid, [wid](int rd, int wr) { workerProcessMain(wid, rd, wr); })) {
+        continue;
+      }
+      workers_.push_back(std::move(w));
+    }
+
+    for (size_t i = 0; i < workers_.size(); ++i) {
+      workers_[i]->dispatch_thread =
+          std::make_unique<std::thread>(&Impl::workerDispatchLoop, this, i);
+    }
+
+    is_ready_ = true;
+    TT_LOG_INFO("[EmbeddingService] All {} workers started", workers_.size());
+  }
+
+  void stop() {
+    if (!running_.exchange(false)) return;
+
+    TT_LOG_INFO("[EmbeddingService] Stopping...");
+    queue_cv_.notify_all();
+
+    for (auto& w : workers_) w->running = false;
+    queue_cv_.notify_all();
+
+    size_t batchSize = tt::config::maxInFlightCount();
+    std::string batchStr = std::to_string(batchSize);
+    setenv("MAX_BATCH_SIZE", batchStr.c_str(), 1);
+
+    for (auto& w : workers_) {
+      if (w->dispatch_thread && w->dispatch_thread->joinable())
+        w->dispatch_thread->join();
+      w->terminate();
+    }
+    workers_.clear();
+    is_ready_ = false;
+    TT_LOG_INFO("[EmbeddingService] Stopped");
+  }
+
   void workerDispatchLoop(size_t workerIdx) {
     auto& worker = workers_[workerIdx];
-
     TT_LOG_INFO("[EmbeddingService] Worker {} dispatch thread started",
                 workerIdx);
 
-    // Performance counters
     uint64_t totalBatches = 0;
     uint64_t totalRequests = 0;
     double totalQueueWaitMs = 0;
@@ -389,26 +333,15 @@ struct EmbeddingService::Impl {
       auto queueStart = std::chrono::steady_clock::now();
       {
         std::unique_lock lock(queue_mutex_);
-
-        // Wait for at least one request (with timeout to check running flag)
-        auto waitResult = queue_cv_.wait_for(
+        queue_cv_.wait_for(
             lock, std::chrono::milliseconds(100), [this, &worker] {
               return !request_queue_.empty() || !worker->running.load() ||
                      !worker->is_ready;
             });
 
-        // Check if we should exit
-        if (!worker->running.load() || !worker->is_ready) {
-          break;
-        }
+        if (!worker->running.load() || !worker->is_ready) break;
+        if (request_queue_.empty()) continue;
 
-        if (!waitResult || request_queue_.empty()) {
-          continue;  // Timeout or spurious wakeup, check again
-        }
-
-        // Grab up to max_batch_size_ requests that are already in the queue
-        // Don't wait for more - release lock quickly so other workers can grab
-        // work
         while (batch.size() < max_batch_size_ && !request_queue_.empty()) {
           batch.push_back(request_queue_.front());
           request_queue_.pop();
@@ -418,42 +351,35 @@ struct EmbeddingService::Impl {
       double queueWaitMs =
           std::chrono::duration<double, std::milli>(queueEnd - queueStart)
               .count();
-      // Lock released here - other workers can now grab from queue
 
-      if (!batch.empty() && worker->is_ready) {
-        totalQueueWaitMs += queueWaitMs;
-        totalBatches++;
-        totalRequests += batch.size();
+      if (batch.empty()) continue;
 
-        auto dispatchStart = std::chrono::steady_clock::now();
-        dispatchBatchToWorker(*worker, batch);
-        auto dispatchEnd = std::chrono::steady_clock::now();
-        double dispatchMs = std::chrono::duration<double, std::milli>(
-                                dispatchEnd - dispatchStart)
-                                .count();
-        totalDispatchMs += dispatchMs;
+      if (!worker->is_ready) {
+        failBatch(batch, "Worker died");
+        continue;
+      }
 
-        // Log every 10 batches
-        if (totalBatches % 10 == 0) {
-          double avgQueueWait = totalQueueWaitMs / totalBatches;
-          double avgDispatch = totalDispatchMs / totalBatches;
-          double throughput =
-              (totalRequests * 1000.0) / (totalQueueWaitMs + totalDispatchMs);
-          TT_LOG_DEBUG(
-              "[EmbeddingService] Worker {} batches={} requests={} "
-              "avg_queue_wait={}ms avg_dispatch={}ms throughput={} req/s",
-              workerIdx, totalBatches, totalRequests, avgQueueWait, avgDispatch,
-              throughput);
-        }
-      } else if (!batch.empty()) {
-        // Worker died while we were grabbing work, put it back or error out
-        TT_LOG_ERROR("[EmbeddingService] Worker {} died, failing {} requests",
-                     workerIdx, batch.size());
-        for (auto& pending : batch) {
-          domain::EmbeddingResponse errorResp(pending->request.task_id);
-          errorResp.error = "Worker died";
-          pending->promise.set_value(errorResp);
-        }
+      totalQueueWaitMs += queueWaitMs;
+      totalBatches++;
+      totalRequests += batch.size();
+
+      auto dispatchStart = std::chrono::steady_clock::now();
+      dispatchBatchToWorker(*worker, batch);
+      auto dispatchEnd = std::chrono::steady_clock::now();
+      totalDispatchMs +=
+          std::chrono::duration<double, std::milli>(dispatchEnd - dispatchStart)
+              .count();
+
+      if (totalBatches % 10 == 0) {
+        double avgQueue = totalQueueWaitMs / totalBatches;
+        double avgDispatch = totalDispatchMs / totalBatches;
+        double throughput =
+            (totalRequests * 1000.0) / (totalQueueWaitMs + totalDispatchMs);
+        TT_LOG_DEBUG(
+            "[EmbeddingService] Worker {} batches={} requests={} "
+            "avg_queue_wait={}ms avg_dispatch={}ms throughput={} req/s",
+            workerIdx, totalBatches, totalRequests, avgQueue, avgDispatch,
+            throughput);
       }
     }
 
@@ -462,231 +388,51 @@ struct EmbeddingService::Impl {
         workerIdx, worker->is_ready.load());
   }
 
-  // Send batch to specific worker and wait for response (blocking)
   void dispatchBatchToWorker(
       WorkerProcess& worker,
       std::vector<std::shared_ptr<PendingRequest>>& batch) {
-    auto t0 = std::chrono::steady_clock::now();
-
-    if (!worker.is_ready.load() || worker.pid <= 0) {
-      for (auto& pending : batch) {
-        domain::EmbeddingResponse errorResp(pending->request.task_id);
-        errorResp.error = "Worker not available";
-        pending->promise.set_value(errorResp);
-      }
+    if (!worker.is_ready.load() || !worker.checkAlive()) {
+      failBatch(batch, "Worker not available");
       return;
     }
 
-    // Check if worker process is still alive
-    int status;
-    pid_t result = waitpid(worker.pid, &status, WNOHANG);
-    if (result == worker.pid) {
-      // Worker has exited
-      if (WIFEXITED(status)) {
-        TT_LOG_ERROR("[EmbeddingService] Worker {} exited with code {}",
-                     worker.worker_id, WEXITSTATUS(status));
-      } else if (WIFSIGNALED(status)) {
-        TT_LOG_ERROR("[EmbeddingService] Worker {} killed by signal {}",
-                     worker.worker_id, WTERMSIG(status));
-      }
-      worker.is_ready.store(false);
-      for (auto& pending : batch) {
-        domain::EmbeddingResponse errorResp(pending->request.task_id);
-        errorResp.error = "Worker process died";
-        pending->promise.set_value(errorResp);
-      }
-      return;
-    }
-
-    auto t1 = std::chrono::steady_clock::now();
-
-    // Build batch request JSON
     Json::Value batchJson(Json::arrayValue);
-    for (const auto& pending : batch) {
-      batchJson.append(pending->request.toJson());
-    }
+    for (const auto& p : batch) batchJson.append(p->request.toJson());
 
     Json::StreamWriterBuilder builder;
     std::string requestStr = Json::writeString(builder, batchJson);
-    uint32_t requestLen = static_cast<uint32_t>(requestStr.size());
 
-    auto t2 = std::chrono::steady_clock::now();
-
-    // Send to worker
-    ssize_t written =
-        write(worker.request_pipe[1], &requestLen, sizeof(requestLen));
-    if (written != sizeof(requestLen)) {
-      TT_LOG_ERROR("[EmbeddingService] Worker {} failed to write length: {}",
-                   worker.worker_id, strerror(errno));
-      worker.is_ready.store(false);  // Mark worker as dead
-      for (auto& pending : batch) {
-        domain::EmbeddingResponse errorResp(pending->request.task_id);
-        errorResp.error = "Worker pipe broken - worker crashed";
-        pending->promise.set_value(errorResp);
-      }
-      return;
-    }
-    written = write(worker.request_pipe[1], requestStr.data(), requestLen);
-    if (written != static_cast<ssize_t>(requestLen)) {
-      TT_LOG_ERROR("[EmbeddingService] Worker {} failed to write data: {}",
-                   worker.worker_id, strerror(errno));
-      worker.is_ready.store(false);  // Mark worker as dead
-      for (auto& pending : batch) {
-        domain::EmbeddingResponse errorResp(pending->request.task_id);
-        errorResp.error = "Worker pipe broken - worker crashed";
-        pending->promise.set_value(errorResp);
-      }
+    if (!worker.sendRequest(requestStr)) {
+      failBatch(batch, "Worker pipe broken");
       return;
     }
 
-    auto t3 = std::chrono::steady_clock::now();
-
-    // Read response
-    uint32_t responseLen = 0;
-    ssize_t n =
-        read(worker.response_pipe[0], &responseLen, sizeof(responseLen));
-
-    TT_LOG_DEBUG(
-        "[EmbeddingService] Worker {} got binary response length: {} (read {} "
-        "bytes)",
-        worker.worker_id, responseLen, n);
-
-    // Sanity check - response should be reasonable size (< 100MB)
-    if (n != sizeof(responseLen) || responseLen > 100 * 1024 * 1024) {
-      TT_LOG_ERROR(
-          "[EmbeddingService] Worker {} invalid response length {} - pipe "
-          "corrupted?",
-          worker.worker_id, responseLen);
-      worker.is_ready.store(false);
-      for (auto& pending : batch) {
-        domain::EmbeddingResponse errorResp(pending->request.task_id);
-        errorResp.error = "Failed to read response from worker";
-        pending->promise.set_value(errorResp);
-      }
+    auto responseBuf = worker.receiveResponse();
+    if (responseBuf.empty()) {
+      failBatch(batch, "Failed to read response from worker");
       return;
     }
 
-    std::vector<uint8_t> responseBuffer(responseLen);
-    size_t totalRead = 0;
-    while (totalRead < responseLen) {
-      n = read(worker.response_pipe[0], responseBuffer.data() + totalRead,
-               responseLen - totalRead);
-      if (n <= 0) {
-        TT_LOG_ERROR("[EmbeddingService] Worker {} read error at {}/{} bytes",
-                     worker.worker_id, totalRead, responseLen);
-        break;
-      }
-      totalRead += n;
-    }
-    if (totalRead != responseLen) {
-      TT_LOG_ERROR("[EmbeddingService] Worker {} incomplete read: {}/{} bytes",
-                   worker.worker_id, totalRead, responseLen);
-      for (auto& pending : batch) {
-        domain::EmbeddingResponse errorResp(pending->request.task_id);
-        errorResp.error = "Failed to read full response from worker";
-        pending->promise.set_value(errorResp);
-      }
-      return;
-    }
+    auto responseMap = embedding_codec::decodeResponses(responseBuf);
 
-    auto t4 = std::chrono::steady_clock::now();
-
-    // Parse binary response
-    // Format:
-    // [num_responses: uint32_t]
-    // For each response:
-    //   [task_id_len: uint32_t][task_id: chars]
-    //   [has_error: uint8_t]
-    //   If has_error:
-    //     [error_len: uint32_t][error: chars]
-    //   Else:
-    //     [embedding_dim: uint32_t][embedding: floats]
-    //     [total_tokens: int32_t]
-    //     [model_len: uint32_t][model: chars]
-
-    size_t offset = 0;
-    auto readUint32 = [&responseBuffer, &offset]() -> uint32_t {
-      uint32_t val;
-      std::memcpy(&val, responseBuffer.data() + offset, sizeof(val));
-      offset += sizeof(val);
-      return val;
-    };
-    auto readInt32 = [&responseBuffer, &offset]() -> int32_t {
-      int32_t val;
-      std::memcpy(&val, responseBuffer.data() + offset, sizeof(val));
-      offset += sizeof(val);
-      return val;
-    };
-    auto readString = [&responseBuffer, &offset, &readUint32]() -> std::string {
-      uint32_t len = readUint32();
-      std::string s(
-          reinterpret_cast<const char*>(responseBuffer.data() + offset), len);
-      offset += len;
-      return s;
-    };
-    auto readFloats = [&responseBuffer, &offset,
-                       &readUint32]() -> std::vector<float> {
-      uint32_t count = readUint32();
-      std::vector<float> floats(count);
-      std::memcpy(floats.data(), responseBuffer.data() + offset,
-                  count * sizeof(float));
-      offset += count * sizeof(float);
-      return floats;
-    };
-
-    // Parse responses into a map by task_id
-    std::unordered_map<uint32_t, domain::EmbeddingResponse> responseMap;
-    uint32_t numResponses = readUint32();
-    responseMap.reserve(numResponses);
-
-    for (uint32_t i = 0; i < numResponses && offset < responseBuffer.size();
-         ++i) {
-      domain::EmbeddingResponse resp{readUint32()};
-      uint8_t hasError = responseBuffer[offset++];
-
-      if (hasError) {
-        resp.error = readString();
-      } else {
-        resp.embedding = readFloats();
-        resp.total_tokens = readInt32();
-        resp.model = readString();
-      }
-
-      responseMap.insert_or_assign(resp.task_id, std::move(resp));
-    }
-
-    auto t5 = std::chrono::steady_clock::now();
-
-    // Log timing breakdown
-    double checkMs = std::chrono::duration<double, std::milli>(t1 - t0).count();
-    double buildJsonMs =
-        std::chrono::duration<double, std::milli>(t2 - t1).count();
-    double writePipeMs =
-        std::chrono::duration<double, std::milli>(t3 - t2).count();
-    double waitWorkerMs =
-        std::chrono::duration<double, std::milli>(t4 - t3).count();
-    double parseBinaryMs =
-        std::chrono::duration<double, std::milli>(t5 - t4).count();
-    double totalMs = std::chrono::duration<double, std::milli>(t5 - t0).count();
-    double overheadMs = totalMs - waitWorkerMs;
-
-    // Always log timing for every batch
-    TT_LOG_DEBUG(
-        "[EmbeddingService] Worker {} batch={} check={}ms build={}ms "
-        "write={}ms wait={}ms parse={}ms overhead={}ms total={}ms",
-        worker.worker_id, batch.size(), checkMs, buildJsonMs, writePipeMs,
-        waitWorkerMs, parseBinaryMs, overheadMs, totalMs);
-
-    // Match responses to requests by task_id
     for (auto& pending : batch) {
       auto it = responseMap.find(pending->request.task_id);
       if (it != responseMap.end()) {
         pending->promise.set_value(std::move(it->second));
       } else {
-        domain::EmbeddingResponse errorResp(pending->request.task_id);
-        errorResp.error = "Response not found for task_id";
-        pending->promise.set_value(std::move(errorResp));
+        domain::EmbeddingResponse err(pending->request.task_id);
+        err.error = "Response not found for task_id";
+        pending->promise.set_value(std::move(err));
       }
+    }
+  }
+
+  static void failBatch(std::vector<std::shared_ptr<PendingRequest>>& batch,
+                        const std::string& error) {
+    for (auto& p : batch) {
+      domain::EmbeddingResponse err(p->request.task_id);
+      err.error = error;
+      p->promise.set_value(std::move(err));
     }
   }
 
@@ -699,13 +445,11 @@ struct EmbeddingService::Impl {
       std::lock_guard lock(queue_mutex_);
       request_queue_.push(pending);
     }
-    queue_cv_.notify_all();  // Wake all workers so they can compete for work
+    queue_cv_.notify_all();
 
     return future;
   }
 };
-
-// Public interface
 
 EmbeddingService::EmbeddingService() : impl_(std::make_unique<Impl>()) {
   max_queue_size_ = impl_->max_queue_size_;
@@ -724,9 +468,7 @@ size_t EmbeddingService::currentQueueSize() const {
   return impl_->request_queue_.size();
 }
 
-void EmbeddingService::postProcess(domain::EmbeddingResponse&) const {
-  // no-op
-}
+void EmbeddingService::postProcess(domain::EmbeddingResponse&) const {}
 
 domain::EmbeddingResponse EmbeddingService::processRequest(
     domain::EmbeddingRequest request) {

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -123,7 +123,7 @@ void LLMService::stop() {
 
 namespace {
 
-constexpr int kItlSampleStride = 5;
+constexpr int K_ITL_SAMPLE_STRIDE = 5;
 
 struct MetricsSamplingState {
   int token_count = 0;
@@ -143,7 +143,7 @@ std::string decodeToken(
   return delta;
 }
 
-// Observe ITL once every kItlSampleStride tokens. Reported quantiles remain
+// Observe ITL once every K_ITL_SAMPLE_STRIDE tokens. Reported quantiles remain
 // representative; actual ITL values are accurate because elapsed time is
 // divided by the stride (assumes roughly uniform decode step latency).
 void recordTokenMetrics(
@@ -153,11 +153,11 @@ void recordTokenMetrics(
   if (ms.token_count == 0) {
     tt::metrics::ServerMetrics::instance().onToken(taskId);
     ms.prev_token_time = std::chrono::steady_clock::now();
-  } else if (ms.token_count % kItlSampleStride == 0) {
+  } else if (ms.token_count % K_ITL_SAMPLE_STRIDE == 0) {
     auto now = std::chrono::steady_clock::now();
     double itl =
         std::chrono::duration<double>(now - ms.prev_token_time).count() /
-        kItlSampleStride;
+        K_ITL_SAMPLE_STRIDE;
     tt::metrics::ServerMetrics::instance().onITLSample(taskId, itl);
     ms.prev_token_time = now;
   }

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -121,6 +121,98 @@ void LLMService::stop() {
   queue_manager_->clear();
 }
 
+namespace {
+
+constexpr int kItlSampleStride = 5;
+
+struct MetricsSamplingState {
+  int token_count = 0;
+  std::chrono::steady_clock::time_point prev_token_time;
+};
+
+std::string decodeToken(
+    std::unordered_map<uint32_t,
+                       std::unique_ptr<tt::utils::Tokenizer::StreamDecoder>>&
+        decoders,
+    const tt::utils::Tokenizer* tokenizer, uint32_t taskId, uint32_t tokenId,
+    bool isFinal) {
+  auto& decoder = decoders[taskId];
+  if (!decoder) decoder = tokenizer->createStreamDecoder();
+  std::string delta = decoder->step(static_cast<int>(tokenId));
+  if (isFinal) delta += decoder->flush();
+  return delta;
+}
+
+// Observe ITL once every kItlSampleStride tokens. Reported quantiles remain
+// representative; actual ITL values are accurate because elapsed time is
+// divided by the stride (assumes roughly uniform decode step latency).
+void recordTokenMetrics(
+    std::unordered_map<uint32_t, MetricsSamplingState>& sampling,
+    uint32_t taskId) {
+  auto& ms = sampling[taskId];
+  if (ms.token_count == 0) {
+    tt::metrics::ServerMetrics::instance().onToken(taskId);
+    ms.prev_token_time = std::chrono::steady_clock::now();
+  } else if (ms.token_count % kItlSampleStride == 0) {
+    auto now = std::chrono::steady_clock::now();
+    double itl =
+        std::chrono::duration<double>(now - ms.prev_token_time).count() /
+        kItlSampleStride;
+    tt::metrics::ServerMetrics::instance().onITLSample(taskId, itl);
+    ms.prev_token_time = now;
+  }
+  ms.token_count++;
+}
+
+domain::LLMStreamChunk buildStreamChunk(
+    const ipc::SharedToken& token, const TokenParseResult& parseResult,
+    const std::unordered_set<int64_t>& stopTokenSet) {
+  domain::LLMStreamChunk response{token.task_id};
+  response.id = std::to_string(token.task_id);
+  response.created = std::chrono::duration_cast<std::chrono::seconds>(
+                         std::chrono::system_clock::now().time_since_epoch())
+                         .count();
+
+  domain::LLMChoice choice;
+  choice.index = token.token_index;
+
+  if (parseResult.type == ContentType::REASONING) {
+    choice.text = "";
+    choice.reasoning = parseResult.text;
+  } else {
+    choice.text = parseResult.text;
+    choice.reasoning = std::nullopt;
+  }
+
+  if (token.isError()) {
+    choice.finish_reason = "error";
+  } else {
+    choice.token_id = static_cast<int64_t>(token.token_id);
+    if (token.isFinal()) {
+      bool isStop =
+          stopTokenSet.count(static_cast<int64_t>(token.token_id)) > 0;
+      choice.finish_reason = isStop ? "stop" : "length";
+    }
+  }
+  response.choices.push_back(std::move(choice));
+  return response;
+}
+
+}  // namespace
+
+std::optional<std::function<void(domain::LLMStreamChunk&, bool)>>
+LLMService::resolveCallback(uint32_t taskId, bool isFinal) {
+  if (isFinal) {
+    auto val = stream_callbacks_.take(taskId);
+    if (!val.has_value()) return std::nullopt;
+    pending_tasks_.fetch_sub(1);
+    tt::metrics::ServerMetrics::instance().setQueueDepth(
+        static_cast<double>(pending_tasks_.load()));
+    return std::move(val.value());
+  }
+  return stream_callbacks_.get(taskId);
+}
+
 void LLMService::consumerLoopForWorker(size_t workerIdx) {
   ZoneScopedN("LLMService::consumer_loop");
   tracy_config::tracySetThreadName(
@@ -141,20 +233,6 @@ void LLMService::consumerLoopForWorker(size_t workerIdx) {
   std::unordered_map<uint32_t,
                      std::unique_ptr<tt::utils::Tokenizer::StreamDecoder>>
       streamDecoders;
-
-  // Per-request state used to throttle ITL metric events.
-  //
-  // Mitigation: observe ITL once every kItlSampleStride consecutive tokens.
-  // The reported quantiles remain statistically representative; the absolute
-  // ITL values are accurate because the caller pre-computes elapsed time
-  // between the two most recent CONSECUTIVE tokens rather than relying on the
-  // spacing between sampled events.
-  static constexpr int kItlSampleStride = 5;
-
-  struct MetricsSamplingState {
-    int token_count = 0;
-    std::chrono::steady_clock::time_point prev_token_time;
-  };
   std::unordered_map<uint32_t, MetricsSamplingState> metricsSampling;
 
   while (running_) {
@@ -173,62 +251,16 @@ void LLMService::consumerLoopForWorker(size_t workerIdx) {
       uint32_t taskId = token.task_id;
       bool isFinal = token.isFinal();
 
-      // For final tokens, atomically take ownership of the callback so that
-      // only one of {consumer, abortRequest} decrements pending_tasks_.
-      std::function<void(domain::LLMStreamChunk&, bool)> callback;
-      if (isFinal) {
-        auto val = stream_callbacks_.take(taskId);
-        if (!val.has_value()) {
-          // abortRequest already took the callback and finalized the task.
-          streamDecoders.erase(taskId);
-          metricsSampling.erase(taskId);
-          continue;
-        }
-        callback = std::move(val.value());
-        pending_tasks_.fetch_sub(1);
-        tt::metrics::ServerMetrics::instance().setQueueDepth(
-            static_cast<double>(pending_tasks_.load()));
-      } else {
-        auto val = stream_callbacks_.get(taskId);
-        if (!val.has_value()) {
-          // Client disconnected or task was cancelled — discard token.
-          // abortRequest() already finalized the reasoning parser state.
-          streamDecoders.erase(taskId);
-          metricsSampling.erase(taskId);
-          continue;
-        }
-        callback = std::move(val.value());
+      auto callback = resolveCallback(taskId, isFinal);
+      if (!callback.has_value()) {
+        streamDecoders.erase(taskId);
+        metricsSampling.erase(taskId);
+        continue;
       }
 
-      auto& decoder = streamDecoders[taskId];
-      if (!decoder) decoder = tokenizer_->createStreamDecoder();
-
-      std::string delta = decoder->step(static_cast<int>(token.token_id));
-      if (isFinal) delta += decoder->flush();
-
-      // Record token-level metrics before reasoning filtering so all
-      // generated tokens (including hidden reasoning tokens) are counted.
-      //
-      // Hot-path budget: only a map counter increment for non-sampled tokens.
-      // steady_clock::now() and metric queue pushes happen only on the first
-      // token (TTFT) and every kItlSampleStride-th subsequent token.
-      // The ITL value is divided by kItlSampleStride to yield a per-token
-      // estimate (assumes roughly uniform decode step latency).
-      {
-        auto& ms = metricsSampling[taskId];
-        if (ms.token_count == 0) {
-          tt::metrics::ServerMetrics::instance().onToken(taskId);
-          ms.prev_token_time = std::chrono::steady_clock::now();
-        } else if (ms.token_count % kItlSampleStride == 0) {
-          auto now = std::chrono::steady_clock::now();
-          double itl =
-              std::chrono::duration<double>(now - ms.prev_token_time).count() /
-              kItlSampleStride;
-          tt::metrics::ServerMetrics::instance().onITLSample(taskId, itl);
-          ms.prev_token_time = now;
-        }
-        ms.token_count++;
-      }
+      std::string delta = decodeToken(streamDecoders, tokenizer_, taskId,
+                                      token.token_id, isFinal);
+      recordTokenMetrics(metricsSampling, taskId);
 
       TokenParseResult parseResult{ContentType::ANSWER, delta, true};
       if (reasoning_parser_) {
@@ -240,40 +272,8 @@ void LLMService::consumerLoopForWorker(size_t workerIdx) {
         continue;
       }
 
-      domain::LLMStreamChunk response{token.task_id};
-      response.id = std::to_string(taskId);
-      response.created =
-          std::chrono::duration_cast<std::chrono::seconds>(
-              std::chrono::system_clock::now().time_since_epoch())
-              .count();
-
-      domain::LLMChoice choice;
-      choice.index = token.token_index;
-
-      // Set text based on content type
-      if (parseResult.type == ContentType::REASONING) {
-        // This is reasoning content - put in reasoning field
-        choice.text = "";  // Empty normal text
-        choice.reasoning = parseResult.text;
-      } else {
-        // This is answer content - put in text field
-        choice.text = parseResult.text;
-        choice.reasoning = std::nullopt;
-      }
-
-      if (token.isError()) {
-        choice.finish_reason = "error";
-      } else {
-        choice.token_id = static_cast<int64_t>(token.token_id);
-        if (isFinal) {
-          bool isStop =
-              stopTokenSet.count(static_cast<int64_t>(token.token_id)) > 0;
-          choice.finish_reason = isStop ? "stop" : "length";
-        }
-      }
-      response.choices.push_back(std::move(choice));
-
-      callback(response, isFinal);
+      auto response = buildStreamChunk(token, parseResult, stopTokenSet);
+      callback.value()(response, isFinal);
 
       if (isFinal) {
         streamDecoders.erase(taskId);


### PR DESCRIPTION
Broke down three large functions that were hard to follow:
- `consumerLoopForWorker` (178 lines) -- extracted `resolveCallback`, `decodeToken`, `recordTokenMetrics`, and `buildStreamChunk` helpers so the loop reads as a short pipeline
- `handleStreaming` (278 lines, 17-capture lambda) -- introduced `StreamContext` struct to replace 17 individual `shared_ptr` captures with one, extracted `handleTokenChunk`, `finalizeStream`, `buildFinalUsage` helpers, and shared session logic into `resolveSession` (also used by non-streaming path)
- `EmbeddingService::Impl` (738 lines) -- extracted binary wire format into `embedding_codec.hpp`, gave `WorkerProcess` proper lifecycle methods (`spawn`/`terminate`/`checkAlive`/`sendRequest`/`receiveResponse`), added `pipeWrite`/`pipeReadBinary` utilities, and consolidated the repeated error-batch pattern into `failBatch`

No behavior changes, pure refactoring.