### PR TITLE
Unify error JSON format to OpenAI-compatible structure

### DIFF
--- a/tt-media-server/cpp_server/include/api/error_response.hpp
+++ b/tt-media-server/cpp_server/include/api/error_response.hpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+#pragma once
+
+#include <drogon/drogon.h>
+#include <json/json.h>
+
+#include <string>
+
+namespace tt::api {
+
+// OpenAI-compatible error: {"error": {"message", "type", "param", "code"}}
+inline drogon::HttpResponsePtr errorResponse(
+    drogon::HttpStatusCode status, const std::string& message,
+    const std::string& type, const Json::Value& param = Json::nullValue,
+    const Json::Value& code = Json::nullValue) {
+  Json::Value body;
+  body["error"]["message"] = message;
+  body["error"]["type"] = type;
+  body["error"]["param"] = param;
+  body["error"]["code"] = code;
+  auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
+  resp->setStatusCode(status);
+  return resp;
+}
+
+}  // namespace tt::api

--- a/tt-media-server/cpp_server/include/api/llm_controller.hpp
+++ b/tt-media-server/cpp_server/include/api/llm_controller.hpp
@@ -78,14 +78,6 @@ class LLMController : public drogon::HttpController<LLMController> {
       std::shared_ptr<domain::LLMRequest> reqPtr,
       std::function<void(const drogon::HttpResponsePtr&)>&& callback) const;
 
-  /**
-   * Build OpenAI-style error JSON (flat object/message/type/param/code).
-   */
-  static Json::Value errorJson(const std::string& message,
-                               const std::string& type,
-                               const Json::Value& param = Json::nullValue,
-                               const Json::Value& code = Json::nullValue);
-
   struct SessionInfo {
     bool validSessionFound = false;
   };

--- a/tt-media-server/cpp_server/src/api/embedding_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/embedding_controller.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "api/embedding_controller.hpp"
+#include "api/error_response.hpp"
 #include "config/settings.hpp"
 #include "profiling/tracy.hpp"
 #include "services/base_service.hpp"
@@ -101,21 +102,15 @@ void EmbeddingController::createEmbedding(
   // Parse request body
   auto json = req->getJsonObject();
   if (!json) {
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-        Json::Value("Invalid JSON body"));
-    resp->setStatusCode(drogon::k400BadRequest);
-    callback(resp);
+    callback(errorResponse(drogon::k400BadRequest, "Invalid JSON body",
+                           "invalid_request_error"));
     return;
   }
 
-  // Validate required fields
   if (!json->isMember("input")) {
-    Json::Value error;
-    error["error"]["message"] = "Missing required field: input";
-    error["error"]["type"] = "invalid_request_error";
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(drogon::k400BadRequest);
-    callback(resp);
+    callback(errorResponse(drogon::k400BadRequest,
+                           "Missing required field: input",
+                           "invalid_request_error"));
     return;
   }
 
@@ -141,12 +136,8 @@ void EmbeddingController::createEmbedding(
       auto gotResponseTime = std::chrono::steady_clock::now();
 
       if (!response.error.empty()) {
-        Json::Value error;
-        error["error"]["message"] = response.error;
-        error["error"]["type"] = "server_error";
-        auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-        resp->setStatusCode(drogon::k500InternalServerError);
-        callback(resp);
+        callback(errorResponse(drogon::k500InternalServerError, response.error,
+                               "server_error"));
         return;
       }
 
@@ -177,19 +168,12 @@ void EmbeddingController::createEmbedding(
       callback(resp);
 
     } catch (const services::QueueFullException& e) {
-      Json::Value error;
-      error["error"]["message"] = e.what();
-      error["error"]["type"] = "rate_limit_exceeded";
-      auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(drogon::k429TooManyRequests);
-      callback(resp);
+      callback(errorResponse(drogon::k429TooManyRequests, e.what(),
+                             "rate_limit_exceeded"));
     } catch (const std::exception& e) {
-      Json::Value error;
-      error["error"]["message"] = std::string("Internal error: ") + e.what();
-      error["error"]["type"] = "server_error";
-      auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(drogon::k500InternalServerError);
-      callback(resp);
+      callback(errorResponse(drogon::k500InternalServerError,
+                             std::string("Internal error: ") + e.what(),
+                             "server_error"));
     }
   });
 }

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -12,6 +12,7 @@
 #include <optional>
 #include <sstream>
 
+#include "api/error_response.hpp"
 #include "api/llm_controller.hpp"
 #include "config/settings.hpp"
 #include "domain/chat_completion_request.hpp"
@@ -225,19 +226,6 @@ LLMController::LLMController() {
   TT_LOG_INFO("[LLMController] Initialized (service already started)");
 }
 
-Json::Value LLMController::errorJson(const std::string& message,
-                                     const std::string& type,
-                                     const Json::Value& param,
-                                     const Json::Value& code) {
-  Json::Value error;
-  error["object"] = "error";
-  error["message"] = message;
-  error["type"] = type;
-  error["param"] = param;
-  error["code"] = code;
-  return error;
-}
-
 LLMController::SessionInfo LLMController::resolveSession(
     domain::LLMRequest& req) const {
   SessionInfo info;
@@ -280,10 +268,8 @@ void LLMController::chatCompletions(
 
   auto json = req->getJsonObject();
   if (!json) {
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-        errorJson("Invalid JSON body", "invalid_request_error"));
-    resp->setStatusCode(drogon::k400BadRequest);
-    callback(resp);
+    callback(errorResponse(drogon::k400BadRequest, "Invalid JSON body",
+                           "invalid_request_error"));
     return;
   }
 
@@ -293,11 +279,9 @@ void LLMController::chatCompletions(
     chatReqOpt =
         domain::ChatCompletionRequest::fromJson(*json, std::move(taskId));
   } catch (const std::exception& e) {
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-        errorJson(std::string("Failed to parse request: ") + e.what(),
-                  "invalid_request_error"));
-    resp->setStatusCode(drogon::k400BadRequest);
-    callback(resp);
+    callback(errorResponse(drogon::k400BadRequest,
+                           std::string("Failed to parse request: ") + e.what(),
+                           "invalid_request_error"));
     return;
   }
 
@@ -306,19 +290,15 @@ void LLMController::chatCompletions(
   TT_LOG_INFO("[LLMController] /v1/chat/completions {}", chatReq.toString());
 
   if (chatReq.messages.empty()) {
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-        errorJson("messages is required and must be a non-empty array",
-                  "invalid_request_error", Json::Value("messages")));
-    resp->setStatusCode(drogon::k400BadRequest);
-    callback(resp);
+    callback(errorResponse(drogon::k400BadRequest,
+                           "messages is required and must be a non-empty array",
+                           "invalid_request_error", Json::Value("messages")));
     return;
   }
 
   if (!service->isModelReady()) {
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-        errorJson("Model is not ready", "service_unavailable"));
-    resp->setStatusCode(drogon::k503ServiceUnavailable);
-    callback(resp);
+    callback(errorResponse(drogon::k503ServiceUnavailable, "Model is not ready",
+                           "service_unavailable"));
     return;
   }
 
@@ -373,10 +353,8 @@ void LLMController::chatCompletions(
         sessionManager->setSessionInFlight(sessionId.value(), false);
       }
 
-      auto resp = drogon::HttpResponse::newHttpJsonResponse(
-          errorJson(e.what(), "rate_limit_exceeded"));
-      resp->setStatusCode(drogon::k429TooManyRequests);
-      callback(resp);
+      callback(errorResponse(drogon::k429TooManyRequests, e.what(),
+                             "rate_limit_exceeded"));
     } catch (const std::runtime_error& e) {
       // Mark session as no longer in-flight on error
       auto sessionId = request->sessionId;
@@ -389,11 +367,10 @@ void LLMController::chatCompletions(
       if (errMsg.find("Failed to allocate memory slot") != std::string::npos ||
           errMsg.find("memory resources") != std::string::npos) {
         TT_LOG_ERROR("[LLMController] Session creation failed: {}", e.what());
-        auto resp = drogon::HttpResponse::newHttpJsonResponse(errorJson(
+        callback(errorResponse(
+            drogon::k503ServiceUnavailable,
             std::string("Failed to allocate memory resources: ") + errMsg,
             "service_unavailable"));
-        resp->setStatusCode(drogon::k503ServiceUnavailable);
-        callback(resp);
         return;
       }
       // Re-throw if it's not a memory allocation error
@@ -412,11 +389,10 @@ void LLMController::handleStreaming(
     sessionInfo = resolveSession(*reqPtr);
   } catch (const std::runtime_error& e) {
     TT_LOG_ERROR("[LLMController] Failed to create session: {}", e.what());
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(errorJson(
+    callback(errorResponse(
+        drogon::k503ServiceUnavailable,
         std::string("Failed to allocate memory resources: ") + e.what(),
         "service_unavailable"));
-    resp->setStatusCode(drogon::k503ServiceUnavailable);
-    callback(resp);
     return;
   }
 
@@ -483,10 +459,8 @@ void LLMController::handleStreaming(
           "streaming requests via HTTP");
     }
   } catch (const services::QueueFullException& e) {
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-        errorJson(e.what(), "rate_limit_exceeded"));
-    resp->setStatusCode(drogon::k429TooManyRequests);
-    callback(resp);
+    callback(errorResponse(drogon::k429TooManyRequests, e.what(),
+                           "rate_limit_exceeded"));
     return;
   }
 
@@ -553,10 +527,8 @@ void LLMController::createSession(
     resp->setStatusCode(drogon::k201Created);
     callback(resp);
   } catch (const std::exception& e) {
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-        errorJson(e.what(), "internal_error"));
-    resp->setStatusCode(drogon::k500InternalServerError);
-    callback(resp);
+    callback(errorResponse(drogon::k500InternalServerError, e.what(),
+                           "internal_error"));
   }
 }
 
@@ -573,10 +545,8 @@ void LLMController::closeSession(
     auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
     callback(resp);
   } else {
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-        errorJson("Session not found", "not_found"));
-    resp->setStatusCode(drogon::k404NotFound);
-    callback(resp);
+    callback(
+        errorResponse(drogon::k404NotFound, "Session not found", "not_found"));
   }
 }
 
@@ -590,10 +560,8 @@ void LLMController::getSlotId(
     // Check if session exists at all
     auto session = sessionManager->getSession(sessionId);
     if (!session.has_value()) {
-      auto resp = drogon::HttpResponse::newHttpJsonResponse(
-          errorJson("Session not found", "not_found"));
-      resp->setStatusCode(drogon::k404NotFound);
-      callback(resp);
+      callback(errorResponse(drogon::k404NotFound, "Session not found",
+                             "not_found"));
       return;
     }
   }

--- a/tt-media-server/cpp_server/src/main.cpp
+++ b/tt-media-server/cpp_server/src/main.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <thread>
 
+#include "api/error_response.hpp"
 #include "config/settings.hpp"
 #include "filters/security_filter.hpp"
 #include "profiling/tracy.hpp"
@@ -131,9 +132,10 @@ int main(int argc, char* argv[]) {
 
     if (authHeader.size() <= bearerPrefix.size() ||
         authHeader.compare(0, bearerPrefix.size(), bearerPrefix) != 0) {
-      auto resp = drogon::HttpResponse::newHttpJsonResponse(Json::Value(
-          "Missing or invalid Authorization header. Expected: Bearer <token>"));
-      resp->setStatusCode(drogon::k401Unauthorized);
+      auto resp = tt::api::errorResponse(
+          drogon::k401Unauthorized,
+          "Missing or invalid Authorization header. Expected: Bearer <token>",
+          "authentication_error");
       resp->addHeader("WWW-Authenticate", "Bearer");
       callback(resp);
       return;
@@ -143,9 +145,8 @@ int main(int argc, char* argv[]) {
                                    authHeader.size() - bearerPrefix.size());
 
     if (providedToken != SecurityFilter::getExpectedToken()) {
-      auto resp = drogon::HttpResponse::newHttpJsonResponse(
-          Json::Value("Invalid API key"));
-      resp->setStatusCode(drogon::k401Unauthorized);
+      auto resp = tt::api::errorResponse(
+          drogon::k401Unauthorized, "Invalid API key", "authentication_error");
       resp->addHeader("WWW-Authenticate", "Bearer error=\"invalid_token\"");
       callback(resp);
       return;


### PR DESCRIPTION
Extract shared `errorResponse()` utility and standardize all API error responses to the OpenAI-compatible `{"error": {"message", "type", "param", "code"}}` format.

Response examples:
```
(venv) ztorlak@wh-qb-08-special-ztorlak-for-reservation-21641:/localdev/ztorl
ak/tt-inference-server/tt-media-server$ curl -s http://localhost:8002/v1/chat/completions -H "Authorization: Bearer test" -H "Content-Type: application/json" -d "not json" | python3 -m json.tool
{
    "error": {
        "code": null,
        "message": "Invalid JSON body",
        "param": null,
        "type": "invalid_request_error"
    }
}
(venv) ztorlak@wh-qb-08-special-ztorlak-for-reservation-21641:/localdev/ztorl
ak/tt-inference-server/tt-media-server$ curl -s curl -s http://localhost:8002/v1/chat/completions -H "Authorization: Bearer test" -H "Content-Type: application/json" -d '{"model":"test"}' | python3 -m json.tool
{
    "error": {
        "code": null,
        "message": "messages is required and must be a non-empty array",
        "param": "messages",
        "type": "invalid_request_error"
    }
}
(venv) ztorlak@wh-qb-08-special-ztorlak-for-reservation-21641:/localdev/ztorl
ak/tt-inference-server/tt-media-server$ curl -s http://localhost:8002/v1/chat/completions -H "Content-Type: application/json" -d '{}' | python3 -m json.tool
{
    "error": {
        "code": null,
        "message": "Missing or invalid Authorization header. Expected: Bearer <token>",
        "param": null,
        "type": "authentication_error"
    }
}
(venv) ztorlak@wh-qb-08-special-ztorlak-for-reservation-21641:/localdev/ztorl
ak/tt-inference-server/tt-media-server$ curl -s http://localhost:8002/v1/chat/completions -H "Authorization: Bearer wrong" -H "Content-Type: application/json" -d '{}' | python3 -m json.tool
{
    "error": {
        "code": null,
        "message": "Invalid API key",
        "param": null,
        "type": "authentication_error"
    }
}
```