### PR TITLE
Fix namespace pollution and const-correctness

### DIFF
--- a/tt-media-server/cpp_server/include/ipc/queue_manager.hpp
+++ b/tt-media-server/cpp_server/include/ipc/queue_manager.hpp
@@ -13,8 +13,6 @@
 
 namespace tt::ipc {
 
-using namespace std;
-
 constexpr const char* TASK_QUEUE_NAME = "tt_tasks";
 constexpr const char* CANCEL_QUEUE_PREFIX = "tt_cancels_";
 constexpr size_t RING_BUFFER_CAPACITY = 65536;
@@ -26,22 +24,23 @@ constexpr size_t CANCEL_QUEUE_CAPACITY = 1024;
  */
 class QueueManager {
  public:
-  shared_ptr<BoostIpcTaskQueue> task_queue;
-  vector<shared_ptr<TokenRingBuffer<RING_BUFFER_CAPACITY>>> result_queues;
-  vector<shared_ptr<BoostIpcCancelQueue>> cancel_queues;
+  std::shared_ptr<BoostIpcTaskQueue> task_queue;
+  std::vector<std::shared_ptr<TokenRingBuffer<RING_BUFFER_CAPACITY>>>
+      result_queues;
+  std::vector<std::shared_ptr<BoostIpcCancelQueue>> cancel_queues;
 
   explicit QueueManager(int numWorkers) {
-    task_queue = make_shared<BoostIpcTaskQueue>(TASK_QUEUE_NAME, 1024);
+    task_queue = std::make_shared<BoostIpcTaskQueue>(TASK_QUEUE_NAME, 1024);
     result_queues.reserve(numWorkers);
     cancel_queues.reserve(numWorkers);
     for (int i = 0; i < numWorkers; i++) {
       result_queues.emplace_back(
-          make_shared<TokenRingBuffer<RING_BUFFER_CAPACITY>>(
-              "/tt_tokens_" + to_string(i), true));
+          std::make_shared<TokenRingBuffer<RING_BUFFER_CAPACITY>>(
+              "/tt_tokens_" + std::to_string(i), true));
 
-      string cancelName = CANCEL_QUEUE_PREFIX + to_string(i);
-      cancel_queues.emplace_back(
-          make_shared<BoostIpcCancelQueue>(cancelName, CANCEL_QUEUE_CAPACITY));
+      std::string cancelName = CANCEL_QUEUE_PREFIX + std::to_string(i);
+      cancel_queues.emplace_back(std::make_shared<BoostIpcCancelQueue>(
+          cancelName, CANCEL_QUEUE_CAPACITY));
     }
   }
 

--- a/tt-media-server/cpp_server/include/runners/llm_runner/sequence.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/sequence.hpp
@@ -35,48 +35,67 @@ class Sequence {
            const SamplingParams& samplingParams = SamplingParams());
 
   void serialize(std::ostream& os) const;
-
   static Sequence deserialize(std::istream& is);
 
-  size_t size() const { return tokenIds.size(); }
-  int64_t operator[](size_t i) const { return tokenIds[i]; }
+  uint32_t taskId;  // set at construction; not const due to IPC deserialization
 
-  bool isFinished() const { return status == SequenceStatus::FINISHED; }
-  bool isAborted() const { return status == SequenceStatus::ABORTED; }
+  size_t size() const { return tokenIds_.size(); }
+  int64_t operator[](size_t i) const { return tokenIds_[i]; }
+
+  bool isFinished() const { return status_ == SequenceStatus::FINISHED; }
+  bool isAborted() const { return status_ == SequenceStatus::ABORTED; }
   size_t numCompletionTokens() const {
-    return tokenIds.size() - numPromptTokens;
+    return tokenIds_.size() - numPromptTokens_;
   }
-  size_t numCachedBlocks() const { return numCachedTokens / blockSize; }
+  size_t numCachedBlocks() const { return numCachedTokens_ / blockSize_; }
   size_t numBlocks() const {
-    return (tokenIds.size() + blockSize - 1) / blockSize;
+    return (tokenIds_.size() + blockSize_ - 1) / blockSize_;
   }
   int lastBlockNumTokens() const {
-    return static_cast<int>(tokenIds.size()) -
-           static_cast<int>(numBlocks() - 1) * blockSize;
+    return static_cast<int>(tokenIds_.size()) -
+           static_cast<int>(numBlocks() - 1) * blockSize_;
   }
 
-  void setKVCacheAddress(uint64_t address) { this->address = address; }
-
-  uint64_t getKVCacheAddress() const { return this->address; }
+  void setKVCacheAddress(uint64_t addr) { address_ = addr; }
+  uint64_t getKVCacheAddress() const { return address_; }
 
   std::vector<int64_t> block(size_t i) const;
   std::vector<int64_t> completionTokenIds() const;
-
   void appendToken(int64_t tokenId);
 
-  uint32_t taskId;
-  SequenceStatus status = SequenceStatus::WAITING;
-  std::vector<int64_t> tokenIds;
-  int64_t lastToken = 0;
-  size_t numPromptTokens = 0;
-  size_t numCachedTokens = 0;
-  std::vector<int> blockTable;
-  std::unique_ptr<SamplingParams> samplingParams;
+  SequenceStatus status() const { return status_; }
+  void setStatus(SequenceStatus s) { status_ = s; }
+
+  const std::vector<int64_t>& tokenIds() const { return tokenIds_; }
+
+  int64_t lastToken() const { return lastToken_; }
+  void setLastToken(int64_t t) { lastToken_ = t; }
+
+  size_t numPromptTokens() const { return numPromptTokens_; }
+  void setNumPromptTokens(size_t n) { numPromptTokens_ = n; }
+
+  size_t numCachedTokens() const { return numCachedTokens_; }
+  void setNumCachedTokens(size_t n) { numCachedTokens_ = n; }
+
+  const std::vector<int>& blockTable() const { return blockTable_; }
+  std::vector<int>& mutableBlockTable() { return blockTable_; }
+
+  const SamplingParams& samplingParams() const { return *samplingParams_; }
+  SamplingParams& mutableSamplingParams() { return *samplingParams_; }
+  void setSamplingParams(std::unique_ptr<SamplingParams> p) {
+    samplingParams_ = std::move(p);
+  }
 
  private:
-  size_t numTokens() const { return tokenIds.size(); }
-  int blockSize;
-  uint64_t address = 0x0;
+  SequenceStatus status_ = SequenceStatus::WAITING;
+  std::vector<int64_t> tokenIds_;
+  int64_t lastToken_ = 0;
+  size_t numPromptTokens_ = 0;
+  size_t numCachedTokens_ = 0;
+  std::vector<int> blockTable_;
+  std::unique_ptr<SamplingParams> samplingParams_;
+  int blockSize_;
+  uint64_t address_ = 0x0;
 };
 
 }  // namespace llm_engine

--- a/tt-media-server/cpp_server/include/runners/llm_runner/sequence.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/sequence.hpp
@@ -37,65 +37,65 @@ class Sequence {
   void serialize(std::ostream& os) const;
   static Sequence deserialize(std::istream& is);
 
-  uint32_t taskId;  // set at construction; not const due to IPC deserialization
+  uint32_t taskId;
 
-  size_t size() const { return tokenIds_.size(); }
-  int64_t operator[](size_t i) const { return tokenIds_[i]; }
+  size_t size() const { return tokenIds.size(); }
+  int64_t operator[](size_t i) const { return tokenIds[i]; }
 
-  bool isFinished() const { return status_ == SequenceStatus::FINISHED; }
-  bool isAborted() const { return status_ == SequenceStatus::ABORTED; }
+  bool isFinished() const { return status == SequenceStatus::FINISHED; }
+  bool isAborted() const { return status == SequenceStatus::ABORTED; }
   size_t numCompletionTokens() const {
-    return tokenIds_.size() - numPromptTokens_;
+    return tokenIds.size() - numPromptTokens;
   }
-  size_t numCachedBlocks() const { return numCachedTokens_ / blockSize_; }
+  size_t numCachedBlocks() const { return numCachedTokens / blockSize; }
   size_t numBlocks() const {
-    return (tokenIds_.size() + blockSize_ - 1) / blockSize_;
+    return (tokenIds.size() + blockSize - 1) / blockSize;
   }
   int lastBlockNumTokens() const {
-    return static_cast<int>(tokenIds_.size()) -
-           static_cast<int>(numBlocks() - 1) * blockSize_;
+    return static_cast<int>(tokenIds.size()) -
+           static_cast<int>(numBlocks() - 1) * blockSize;
   }
 
-  void setKVCacheAddress(uint64_t addr) { address_ = addr; }
-  uint64_t getKVCacheAddress() const { return address_; }
+  void setKVCacheAddress(uint64_t addr) { address = addr; }
+  uint64_t getKVCacheAddress() const { return address; }
 
   std::vector<int64_t> block(size_t i) const;
   std::vector<int64_t> completionTokenIds() const;
   void appendToken(int64_t tokenId);
 
-  SequenceStatus status() const { return status_; }
-  void setStatus(SequenceStatus s) { status_ = s; }
+  SequenceStatus getStatus() const { return status; }
+  void setStatus(SequenceStatus s) { status = s; }
 
-  const std::vector<int64_t>& tokenIds() const { return tokenIds_; }
+  const std::vector<int64_t>& getTokenIds() const { return tokenIds; }
 
-  int64_t lastToken() const { return lastToken_; }
-  void setLastToken(int64_t t) { lastToken_ = t; }
+  int64_t getLastToken() const { return lastToken; }
+  void setLastToken(int64_t t) { lastToken = t; }
 
-  size_t numPromptTokens() const { return numPromptTokens_; }
-  void setNumPromptTokens(size_t n) { numPromptTokens_ = n; }
+  size_t getNumPromptTokens() const { return numPromptTokens; }
+  void setNumPromptTokens(size_t n) { numPromptTokens = n; }
 
-  size_t numCachedTokens() const { return numCachedTokens_; }
-  void setNumCachedTokens(size_t n) { numCachedTokens_ = n; }
+  size_t getNumCachedTokens() const { return numCachedTokens; }
+  void setNumCachedTokens(size_t n) { numCachedTokens = n; }
 
-  const std::vector<int>& blockTable() const { return blockTable_; }
-  std::vector<int>& mutableBlockTable() { return blockTable_; }
+  const std::vector<int>& getBlockTable() const { return blockTable; }
+  std::vector<int>& getMutableBlockTable() { return blockTable; }
 
-  const SamplingParams& samplingParams() const { return *samplingParams_; }
-  SamplingParams& mutableSamplingParams() { return *samplingParams_; }
+  const SamplingParams& getSamplingParams() const { return *samplingParams; }
+  SamplingParams& getMutableSamplingParams() { return *samplingParams; }
   void setSamplingParams(std::unique_ptr<SamplingParams> p) {
-    samplingParams_ = std::move(p);
+    samplingParams = std::move(p);
   }
 
  private:
-  SequenceStatus status_ = SequenceStatus::WAITING;
-  std::vector<int64_t> tokenIds_;
-  int64_t lastToken_ = 0;
-  size_t numPromptTokens_ = 0;
-  size_t numCachedTokens_ = 0;
-  std::vector<int> blockTable_;
-  std::unique_ptr<SamplingParams> samplingParams_;
-  int blockSize_;
-  uint64_t address_ = 0x0;
+  SequenceStatus status = SequenceStatus::WAITING;
+  std::vector<int64_t> tokenIds;
+  int64_t lastToken = 0;
+  size_t numPromptTokens = 0;
+  size_t numCachedTokens = 0;
+  std::vector<int> blockTable;
+  std::unique_ptr<SamplingParams> samplingParams;
+  int blockSize;
+  uint64_t address = 0x0;
 };
 
 }  // namespace llm_engine

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/i_sp_pipeline_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/i_sp_pipeline_model_runner.hpp
@@ -16,7 +16,7 @@
 namespace sp_pipeline {
 
 using DecodeCallback = std::function<void(const llm_engine::TokenResult&)>;
-using DecodeQueue = LockFreeConcurrentQueue<llm_engine::TokenResult>;
+using DecodeQueue = LockFreeSpscQueue<llm_engine::TokenResult>;
 
 enum class RequestPhase { PREFILL, DECODE };
 

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/i_sp_pipeline_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/i_sp_pipeline_model_runner.hpp
@@ -16,7 +16,7 @@
 namespace sp_pipeline {
 
 using DecodeCallback = std::function<void(const llm_engine::TokenResult&)>;
-using DecodeQueue = LockFreeSingleProducerQueue<llm_engine::TokenResult>;
+using DecodeQueue = LockFreeSPSCQueue<llm_engine::TokenResult>;
 
 enum class RequestPhase { PREFILL, DECODE };
 

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/i_sp_pipeline_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/i_sp_pipeline_model_runner.hpp
@@ -16,7 +16,7 @@
 namespace sp_pipeline {
 
 using DecodeCallback = std::function<void(const llm_engine::TokenResult&)>;
-using DecodeQueue = LockFreeSpscQueue<llm_engine::TokenResult>;
+using DecodeQueue = LockFreeSingleProducerQueue<llm_engine::TokenResult>;
 
 enum class RequestPhase { PREFILL, DECODE };
 

--- a/tt-media-server/cpp_server/include/utils/concurrent_map.hpp
+++ b/tt-media-server/cpp_server/include/utils/concurrent_map.hpp
@@ -19,7 +19,7 @@ class ConcurrentMap {
     map_[key] = value;
   }
 
-  std::optional<Value> get(const Key& key) {
+  std::optional<Value> get(const Key& key) const {
     std::lock_guard lock(mutex);
     auto it = map_.find(key);
     if (it != map_.end()) {
@@ -44,7 +44,7 @@ class ConcurrentMap {
     return value;
   }
 
-  bool contains(const Key& key) {
+  bool contains(const Key& key) const {
     std::lock_guard lock(mutex);
     return map_.find(key) != map_.end();
   }
@@ -54,7 +54,7 @@ class ConcurrentMap {
     map_.clear();
   }
 
-  size_t size() {
+  size_t size() const {
     std::lock_guard lock(mutex);
     return map_.size();
   }
@@ -81,5 +81,5 @@ class ConcurrentMap {
 
  private:
   std::unordered_map<Key, Value> map_;
-  TRACY_LOCKABLE(std::mutex, mutex);
+  mutable TRACY_LOCKABLE(std::mutex, mutex);
 };

--- a/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
+++ b/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
@@ -55,14 +55,14 @@ constexpr std::memory_order RELEASE = std::memory_order_release;
 }  // namespace
 
 template <typename T>
-class LockFreeSpscQueue {
+class LockFreeSingleProducerQueue {
  public:
-  LockFreeSpscQueue(size_t capacity)
+  LockFreeSingleProducerQueue(size_t capacity)
       : capacity(nextPowerOfTwo(capacity + 1)),
         buffer(nextPowerOfTwo(capacity + 1)) {
     mask = this->capacity - 1;
   }
-  ~LockFreeSpscQueue() = default;
+  ~LockFreeSingleProducerQueue() = default;
 
   bool push(const T& value) {
     const size_t HEAD = head.load(RELAXED);
@@ -127,8 +127,8 @@ class LockFreeSpscQueue {
 
   size_t size() const { return (head.load() - tail.load()) & mask; }
 
-  LockFreeSpscQueue(const LockFreeSpscQueue&) = delete;
-  LockFreeSpscQueue& operator=(const LockFreeSpscQueue&) = delete;
+  LockFreeSingleProducerQueue(const LockFreeSingleProducerQueue&) = delete;
+  LockFreeSingleProducerQueue& operator=(const LockFreeSingleProducerQueue&) = delete;
 
  private:
   size_t capacity;

--- a/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
+++ b/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
@@ -55,14 +55,14 @@ constexpr std::memory_order RELEASE = std::memory_order_release;
 }  // namespace
 
 template <typename T>
-class LockFreeConcurrentQueue {
+class LockFreeSpscQueue {
  public:
-  LockFreeConcurrentQueue(size_t capacity)
+  LockFreeSpscQueue(size_t capacity)
       : capacity(nextPowerOfTwo(capacity + 1)),
         buffer(nextPowerOfTwo(capacity + 1)) {
     mask = this->capacity - 1;
   }
-  ~LockFreeConcurrentQueue() = default;
+  ~LockFreeSpscQueue() = default;
 
   bool push(const T& value) {
     const size_t HEAD = head.load(RELAXED);
@@ -127,8 +127,8 @@ class LockFreeConcurrentQueue {
 
   size_t size() const { return (head.load() - tail.load()) & mask; }
 
-  LockFreeConcurrentQueue(const LockFreeConcurrentQueue&) = delete;
-  LockFreeConcurrentQueue& operator=(const LockFreeConcurrentQueue&) = delete;
+  LockFreeSpscQueue(const LockFreeSpscQueue&) = delete;
+  LockFreeSpscQueue& operator=(const LockFreeSpscQueue&) = delete;
 
  private:
   size_t capacity;

--- a/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
+++ b/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
@@ -128,8 +128,7 @@ class LockFreeSPSCQueue {
   size_t size() const { return (head.load() - tail.load()) & mask; }
 
   LockFreeSPSCQueue(const LockFreeSPSCQueue&) = delete;
-  LockFreeSPSCQueue& operator=(const LockFreeSPSCQueue&) =
-      delete;
+  LockFreeSPSCQueue& operator=(const LockFreeSPSCQueue&) = delete;
 
  private:
   size_t capacity;

--- a/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
+++ b/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
@@ -128,7 +128,8 @@ class LockFreeSingleProducerQueue {
   size_t size() const { return (head.load() - tail.load()) & mask; }
 
   LockFreeSingleProducerQueue(const LockFreeSingleProducerQueue&) = delete;
-  LockFreeSingleProducerQueue& operator=(const LockFreeSingleProducerQueue&) = delete;
+  LockFreeSingleProducerQueue& operator=(const LockFreeSingleProducerQueue&) =
+      delete;
 
  private:
   size_t capacity;

--- a/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
+++ b/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
@@ -55,14 +55,14 @@ constexpr std::memory_order RELEASE = std::memory_order_release;
 }  // namespace
 
 template <typename T>
-class LockFreeSingleProducerQueue {
+class LockFreeSPSCQueue {
  public:
-  LockFreeSingleProducerQueue(size_t capacity)
+  LockFreeSPSCQueue(size_t capacity)
       : capacity(nextPowerOfTwo(capacity + 1)),
         buffer(nextPowerOfTwo(capacity + 1)) {
     mask = this->capacity - 1;
   }
-  ~LockFreeSingleProducerQueue() = default;
+  ~LockFreeSPSCQueue() = default;
 
   bool push(const T& value) {
     const size_t HEAD = head.load(RELAXED);
@@ -127,8 +127,8 @@ class LockFreeSingleProducerQueue {
 
   size_t size() const { return (head.load() - tail.load()) & mask; }
 
-  LockFreeSingleProducerQueue(const LockFreeSingleProducerQueue&) = delete;
-  LockFreeSingleProducerQueue& operator=(const LockFreeSingleProducerQueue&) =
+  LockFreeSPSCQueue(const LockFreeSPSCQueue&) = delete;
+  LockFreeSPSCQueue& operator=(const LockFreeSPSCQueue&) =
       delete;
 
  private:

--- a/tt-media-server/cpp_server/include/worker/single_process_worker.hpp
+++ b/tt-media-server/cpp_server/include/worker/single_process_worker.hpp
@@ -14,13 +14,11 @@
 
 namespace tt::worker {
 
-using namespace std;
-
 struct WorkerConfig {
-  unordered_map<string, string> env_vars;
-  shared_ptr<llm_engine::ITaskQueue> task_queue;
-  shared_ptr<tt::ipc::TokenRingBuffer<65536>> result_queue;
-  shared_ptr<tt::ipc::ICancelQueue> cancel_queue;
+  std::unordered_map<std::string, std::string> env_vars;
+  std::shared_ptr<llm_engine::ITaskQueue> task_queue;
+  std::shared_ptr<tt::ipc::TokenRingBuffer<65536>> result_queue;
+  std::shared_ptr<tt::ipc::ICancelQueue> cancel_queue;
   int worker_id;
   tt::config::RunnerConfig runner_config;
 };
@@ -37,7 +35,6 @@ class SingleProcessWorker {
   void start();
   void stop();
 
-  // Public member variables for compatibility with existing LLMService
   pid_t pid{-1};
   bool is_ready{false};
   bool is_alive{true};
@@ -45,7 +42,7 @@ class SingleProcessWorker {
   WorkerConfig cfg;
 
  private:
-  unique_ptr<tt::runners::IRunner> runner_;
+  std::unique_ptr<tt::runners::IRunner> runner_;
 };
 
 }  // namespace tt::worker

--- a/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
@@ -93,21 +93,21 @@ void LlamaModelRunner::run(const std::vector<Sequence*>& seqs, bool isPrefill) {
       for (Sequence* seq : seqs) {
         py::list tokenIds;
         if (isPrefill) {
-          for (int64_t t : seq->tokenIds()) tokenIds.append(t);
+          for (int64_t t : seq->getTokenIds()) tokenIds.append(t);
         } else {
-          tokenIds.append(seq->tokenIds().back());
+          tokenIds.append(seq->getTokenIds().back());
         }
 
         py::list blockTable;
-        for (int bid : seq->blockTable()) {
+        for (int bid : seq->getBlockTable()) {
           blockTable.append(bid);
         }
 
         int currentPos =
-            isPrefill ? 0 : static_cast<int>(seq->tokenIds().size() - 1);
-        int promptLen = static_cast<int>(seq->numPromptTokens());
+            isPrefill ? 0 : static_cast<int>(seq->getTokenIds().size() - 1);
+        int promptLen = static_cast<int>(seq->getNumPromptTokens());
 
-        const SamplingParams* sp = &seq->samplingParams();
+        const SamplingParams* sp = &seq->getSamplingParams();
         double temperature = sp ? static_cast<double>(sp->temperature) : 1.0;
         bool ignoreEos = sp ? sp->ignore_eos : false;
 

--- a/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
@@ -93,21 +93,21 @@ void LlamaModelRunner::run(const std::vector<Sequence*>& seqs, bool isPrefill) {
       for (Sequence* seq : seqs) {
         py::list tokenIds;
         if (isPrefill) {
-          for (int64_t t : seq->tokenIds) tokenIds.append(t);
+          for (int64_t t : seq->tokenIds()) tokenIds.append(t);
         } else {
-          tokenIds.append(seq->tokenIds.back());
+          tokenIds.append(seq->tokenIds().back());
         }
 
         py::list blockTable;
-        for (int bid : seq->blockTable) {
+        for (int bid : seq->blockTable()) {
           blockTable.append(bid);
         }
 
         int currentPos =
-            isPrefill ? 0 : static_cast<int>(seq->tokenIds.size() - 1);
-        int promptLen = static_cast<int>(seq->numPromptTokens);
+            isPrefill ? 0 : static_cast<int>(seq->tokenIds().size() - 1);
+        int promptLen = static_cast<int>(seq->numPromptTokens());
 
-        const SamplingParams* sp = seq->samplingParams.get();
+        const SamplingParams* sp = &seq->samplingParams();
         double temperature = sp ? static_cast<double>(sp->temperature) : 1.0;
         bool ignoreEos = sp ? sp->ignore_eos : false;
 

--- a/tt-media-server/cpp_server/src/runners/llm_runner/block_manager.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/block_manager.cpp
@@ -75,7 +75,7 @@ size_t BlockManager::numFreeBlocks() const {
 bool BlockManager::allocate(Sequence& seq) {
   ZoneScopedN("BlockManager::allocate");
   std::lock_guard<std::mutex> lock(mutex);
-  assert(seq.blockTable().empty());
+  assert(seq.getBlockTable().empty());
 
   if (free_block_ids_.size() < seq.numBlocks()) {
     return false;
@@ -102,9 +102,9 @@ bool BlockManager::allocate(Sequence& seq) {
         block.update(h, tokenIds);
         hash_to_block_id_[h] = blockId;
       }
-      seq.mutableBlockTable().push_back(blockId);
+      seq.getMutableBlockTable().push_back(blockId);
     } else {
-      seq.setNumCachedTokens(seq.numCachedTokens() + block_size_);
+      seq.setNumCachedTokens(seq.getNumCachedTokens() + block_size_);
       if (used_block_ids_.count(blockId)) {
         blocks_[static_cast<size_t>(blockId)].ref_count += 1;
       } else {
@@ -114,7 +114,7 @@ bool BlockManager::allocate(Sequence& seq) {
           hash_to_block_id_[h] = blockId;
         }
       }
-      seq.mutableBlockTable().push_back(blockId);
+      seq.getMutableBlockTable().push_back(blockId);
     }
   }
   return true;
@@ -125,8 +125,8 @@ void BlockManager::deallocate(Sequence& seq) {
   std::lock_guard<std::mutex> lock(mutex);
   LLM_ENGINE_LOG("block_manager")
       << "deallocate task_id=" << seq.taskId
-      << " num_blocks=" << seq.blockTable().size() << std::endl;
-  for (auto it = seq.blockTable().rbegin(); it != seq.blockTable().rend();
+      << " num_blocks=" << seq.getBlockTable().size() << std::endl;
+  for (auto it = seq.getBlockTable().rbegin(); it != seq.getBlockTable().rend();
        ++it) {
     int blockId = *it;
     Block& block = blocks_[static_cast<size_t>(blockId)];
@@ -136,7 +136,7 @@ void BlockManager::deallocate(Sequence& seq) {
     }
   }
   seq.setNumCachedTokens(0);
-  seq.mutableBlockTable().clear();
+  seq.getMutableBlockTable().clear();
 }
 
 bool BlockManager::canAppend(const Sequence& seq) const {
@@ -148,7 +148,7 @@ bool BlockManager::canAppend(const Sequence& seq) const {
 void BlockManager::mayAppend(Sequence& seq) {
   ZoneScopedN("BlockManager::may_append");
   std::lock_guard<std::mutex> lock(mutex);
-  std::vector<int>& blockTable = seq.mutableBlockTable();
+  std::vector<int>& blockTable = seq.getMutableBlockTable();
   Block& lastBlock = blocks_[static_cast<size_t>(blockTable.back())];
   size_t len = seq.size();
   if (len % block_size_ == 1) {

--- a/tt-media-server/cpp_server/src/runners/llm_runner/block_manager.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/block_manager.cpp
@@ -75,7 +75,7 @@ size_t BlockManager::numFreeBlocks() const {
 bool BlockManager::allocate(Sequence& seq) {
   ZoneScopedN("BlockManager::allocate");
   std::lock_guard<std::mutex> lock(mutex);
-  assert(seq.blockTable.empty());
+  assert(seq.blockTable().empty());
 
   if (free_block_ids_.size() < seq.numBlocks()) {
     return false;
@@ -102,9 +102,9 @@ bool BlockManager::allocate(Sequence& seq) {
         block.update(h, tokenIds);
         hash_to_block_id_[h] = blockId;
       }
-      seq.blockTable.push_back(blockId);
+      seq.mutableBlockTable().push_back(blockId);
     } else {
-      seq.numCachedTokens += block_size_;
+      seq.setNumCachedTokens(seq.numCachedTokens() + block_size_);
       if (used_block_ids_.count(blockId)) {
         blocks_[static_cast<size_t>(blockId)].ref_count += 1;
       } else {
@@ -114,7 +114,7 @@ bool BlockManager::allocate(Sequence& seq) {
           hash_to_block_id_[h] = blockId;
         }
       }
-      seq.blockTable.push_back(blockId);
+      seq.mutableBlockTable().push_back(blockId);
     }
   }
   return true;
@@ -125,8 +125,9 @@ void BlockManager::deallocate(Sequence& seq) {
   std::lock_guard<std::mutex> lock(mutex);
   LLM_ENGINE_LOG("block_manager")
       << "deallocate task_id=" << seq.taskId
-      << " num_blocks=" << seq.blockTable.size() << std::endl;
-  for (auto it = seq.blockTable.rbegin(); it != seq.blockTable.rend(); ++it) {
+      << " num_blocks=" << seq.blockTable().size() << std::endl;
+  for (auto it = seq.blockTable().rbegin(); it != seq.blockTable().rend();
+       ++it) {
     int blockId = *it;
     Block& block = blocks_[static_cast<size_t>(blockId)];
     block.ref_count -= 1;
@@ -134,8 +135,8 @@ void BlockManager::deallocate(Sequence& seq) {
       deallocateBlock(blockId);
     }
   }
-  seq.numCachedTokens = 0;
-  seq.blockTable.clear();
+  seq.setNumCachedTokens(0);
+  seq.mutableBlockTable().clear();
 }
 
 bool BlockManager::canAppend(const Sequence& seq) const {
@@ -147,7 +148,7 @@ bool BlockManager::canAppend(const Sequence& seq) const {
 void BlockManager::mayAppend(Sequence& seq) {
   ZoneScopedN("BlockManager::may_append");
   std::lock_guard<std::mutex> lock(mutex);
-  std::vector<int>& blockTable = seq.blockTable;
+  std::vector<int>& blockTable = seq.mutableBlockTable();
   Block& lastBlock = blocks_[static_cast<size_t>(blockTable.back())];
   size_t len = seq.size();
   if (len % block_size_ == 1) {

--- a/tt-media-server/cpp_server/src/runners/llm_runner/mock_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/mock_model_runner.cpp
@@ -29,7 +29,7 @@ class MockModelRunner : public IModelRunner {
       ZoneScopedN("MockModelRunner::decode");
       for (Sequence* seq : seqs) {
         decodeCallback(TokenResult(
-            seq->taskId, static_cast<uint64_t>(seq->lastToken() + 1)));
+            seq->taskId, static_cast<uint64_t>(seq->getLastToken() + 1)));
       }
     }
   }

--- a/tt-media-server/cpp_server/src/runners/llm_runner/mock_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/mock_model_runner.cpp
@@ -28,8 +28,8 @@ class MockModelRunner : public IModelRunner {
     } else {
       ZoneScopedN("MockModelRunner::decode");
       for (Sequence* seq : seqs) {
-        decodeCallback(TokenResult(seq->taskId,
-                                   static_cast<uint64_t>(seq->lastToken + 1)));
+        decodeCallback(TokenResult(
+            seq->taskId, static_cast<uint64_t>(seq->lastToken() + 1)));
       }
     }
   }

--- a/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
@@ -81,7 +81,7 @@ bool Scheduler::trySchedulePrefill(std::vector<Sequence*>& scheduledSeqs,
       break;
     }
     numSeqs += 1;
-    numBatchedTokens += seq->size() - seq->numCachedTokens();
+    numBatchedTokens += seq->size() - seq->getNumCachedTokens();
     auto id = seq->taskId;
     sequences_[id] = std::move(seq);
     scheduledSeqs.push_back(sequences_[id].get());
@@ -168,11 +168,11 @@ void Scheduler::postprocess(std::vector<Sequence*>& seqs,
 
     bool isStopToken = stop_token_ids_.count(tokenId) > 0;
     bool reachedMaxTokens =
-        seq->samplingParams().max_tokens.has_value() &&
+        seq->getSamplingParams().max_tokens.has_value() &&
         seq->numCompletionTokens() >=
-            static_cast<size_t>(seq->samplingParams().max_tokens.value());
-    bool finished =
-        (!seq->samplingParams().ignore_eos && isStopToken) || reachedMaxTokens;
+            static_cast<size_t>(seq->getSamplingParams().max_tokens.value());
+    bool finished = (!seq->getSamplingParams().ignore_eos && isStopToken) ||
+                    reachedMaxTokens;
 
     if (finished) {
       seq->setStatus(SequenceStatus::FINISHED);
@@ -191,7 +191,7 @@ void Scheduler::abortRequest(uint32_t taskId) {
 
   // If the task isn't tracked or is still waiting, it might have a stale
   // copy in the IPC queue. Mark it for skipping.
-  bool isWaiting = seq && seq->status() == SequenceStatus::WAITING;
+  bool isWaiting = seq && seq->getStatus() == SequenceStatus::WAITING;
   if (!seq || isWaiting) {
     if (pending_aborts_.size() < 2 * max_in_flight_count_) {
       pending_aborts_.insert(taskId);

--- a/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
@@ -81,7 +81,7 @@ bool Scheduler::trySchedulePrefill(std::vector<Sequence*>& scheduledSeqs,
       break;
     }
     numSeqs += 1;
-    numBatchedTokens += seq->size() - seq->numCachedTokens;
+    numBatchedTokens += seq->size() - seq->numCachedTokens();
     auto id = seq->taskId;
     sequences_[id] = std::move(seq);
     scheduledSeqs.push_back(sequences_[id].get());
@@ -153,7 +153,7 @@ std::pair<std::vector<Sequence*>, bool> Scheduler::schedule() {
 
 void Scheduler::preempt(Sequence& seq) {
   ZoneScopedN("Scheduler::preempt");
-  seq.status = SequenceStatus::WAITING;
+  seq.setStatus(SequenceStatus::WAITING);
   block_manager_.deallocate(seq);
   prefill_queue_->push(seq);
 }
@@ -168,17 +168,17 @@ void Scheduler::postprocess(std::vector<Sequence*>& seqs,
 
     bool isStopToken = stop_token_ids_.count(tokenId) > 0;
     bool reachedMaxTokens =
-        seq->samplingParams->max_tokens.has_value() &&
+        seq->samplingParams().max_tokens.has_value() &&
         seq->numCompletionTokens() >=
-            static_cast<size_t>(seq->samplingParams->max_tokens.value());
+            static_cast<size_t>(seq->samplingParams().max_tokens.value());
     bool finished =
-        (!seq->samplingParams->ignore_eos && isStopToken) || reachedMaxTokens;
+        (!seq->samplingParams().ignore_eos && isStopToken) || reachedMaxTokens;
 
     if (finished) {
-      seq->status = SequenceStatus::FINISHED;
+      seq->setStatus(SequenceStatus::FINISHED);
       block_manager_.deallocate(*seq);
     } else {
-      seq->status = SequenceStatus::RUNNING;
+      seq->setStatus(SequenceStatus::RUNNING);
       decode_queue_.push_back(seq);
     }
   }
@@ -191,7 +191,7 @@ void Scheduler::abortRequest(uint32_t taskId) {
 
   // If the task isn't tracked or is still waiting, it might have a stale
   // copy in the IPC queue. Mark it for skipping.
-  bool isWaiting = seq && seq->status == SequenceStatus::WAITING;
+  bool isWaiting = seq && seq->status() == SequenceStatus::WAITING;
   if (!seq || isWaiting) {
     if (pending_aborts_.size() < 2 * max_in_flight_count_) {
       pending_aborts_.insert(taskId);
@@ -204,7 +204,7 @@ void Scheduler::abortRequest(uint32_t taskId) {
   }
 
   // Clean up resources for active sequences
-  seq->status = SequenceStatus::ABORTED;
+  seq->setStatus(SequenceStatus::ABORTED);
   block_manager_.deallocate(*seq);
 
   // Remove from decode_queue (O(n) but abort should be rare)

--- a/tt-media-server/cpp_server/src/runners/llm_runner/sequence.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/sequence.cpp
@@ -12,16 +12,16 @@ namespace llm_engine {
 using Config = tt::config::LLMConfig;
 
 Sequence::Sequence(uint32_t taskId, int blockSize,
-                   std::vector<int64_t> tokenIds,
-                   const SamplingParams& samplingParams)
+                   std::vector<int64_t> inputTokenIds,
+                   const SamplingParams& inputSamplingParams)
     : taskId(taskId),
-      status_(SequenceStatus::WAITING),
-      tokenIds_(std::move(tokenIds)),
-      numPromptTokens_(tokenIds_.size()),
-      samplingParams_(std::make_unique<SamplingParams>(samplingParams)),
-      blockSize_(blockSize) {
-  if (!tokenIds_.empty()) {
-    lastToken_ = tokenIds_.back();
+      status(SequenceStatus::WAITING),
+      tokenIds(std::move(inputTokenIds)),
+      numPromptTokens(tokenIds.size()),
+      samplingParams(std::make_unique<SamplingParams>(inputSamplingParams)),
+      blockSize(blockSize) {
+  if (!tokenIds.empty()) {
+    lastToken = tokenIds.back();
   }
 }
 
@@ -30,43 +30,43 @@ std::vector<int64_t> Sequence::block(size_t i) const {
   if (i >= n) {
     throw std::out_of_range("block index out of range");
   }
-  size_t start = i * blockSize_;
-  size_t end = std::min(start + blockSize_, tokenIds_.size());
-  return {tokenIds_.begin() + start, tokenIds_.begin() + end};
+  size_t start = i * blockSize;
+  size_t end = std::min(start + blockSize, tokenIds.size());
+  return {tokenIds.begin() + start, tokenIds.begin() + end};
 }
 
 std::vector<int64_t> Sequence::completionTokenIds() const {
-  if (numPromptTokens_ >= tokenIds_.size()) {
+  if (numPromptTokens >= tokenIds.size()) {
     return {};
   }
-  return {tokenIds_.begin() + numPromptTokens_, tokenIds_.end()};
+  return {tokenIds.begin() + numPromptTokens, tokenIds.end()};
 }
 
 void Sequence::appendToken(int64_t tokenId) {
-  tokenIds_.push_back(tokenId);
-  lastToken_ = tokenId;
+  tokenIds.push_back(tokenId);
+  lastToken = tokenId;
 }
 
 void Sequence::serialize(std::ostream& os) const {
-  size_t tokenIdsSize = tokenIds_.size();
-  size_t blockTableSize = blockTable_.size();
+  size_t tokenIdsSize = tokenIds.size();
+  size_t blockTableSize = blockTable.size();
   os.write(reinterpret_cast<const char*>(&taskId), sizeof(taskId));
-  os.write(reinterpret_cast<const char*>(&lastToken_), sizeof(lastToken_));
-  os.write(reinterpret_cast<const char*>(&numPromptTokens_),
-           sizeof(numPromptTokens_));
-  os.write(reinterpret_cast<const char*>(&numCachedTokens_),
-           sizeof(numCachedTokens_));
+  os.write(reinterpret_cast<const char*>(&lastToken), sizeof(lastToken));
+  os.write(reinterpret_cast<const char*>(&numPromptTokens),
+           sizeof(numPromptTokens));
+  os.write(reinterpret_cast<const char*>(&numCachedTokens),
+           sizeof(numCachedTokens));
   os.write(reinterpret_cast<const char*>(&tokenIdsSize), sizeof(tokenIdsSize));
-  os.write(reinterpret_cast<const char*>(tokenIds_.data()),
+  os.write(reinterpret_cast<const char*>(tokenIds.data()),
            tokenIdsSize * sizeof(int64_t));
   os.write(reinterpret_cast<const char*>(&blockTableSize),
            sizeof(blockTableSize));
-  os.write(reinterpret_cast<const char*>(blockTable_.data()),
+  os.write(reinterpret_cast<const char*>(blockTable.data()),
            blockTableSize * sizeof(int));
-  os.write(reinterpret_cast<const char*>(&status_), sizeof(status_));
-  os.write(reinterpret_cast<const char*>(&blockSize_), sizeof(blockSize_));
-  os.write(reinterpret_cast<const char*>(&address_), sizeof(address_));
-  samplingParams_->serialize(os);
+  os.write(reinterpret_cast<const char*>(&status), sizeof(status));
+  os.write(reinterpret_cast<const char*>(&blockSize), sizeof(blockSize));
+  os.write(reinterpret_cast<const char*>(&address), sizeof(address));
+  samplingParams->serialize(os);
 }
 
 Sequence Sequence::deserialize(std::istream& is) {
@@ -77,28 +77,28 @@ Sequence Sequence::deserialize(std::istream& is) {
   Sequence seq(taskId, static_cast<int>(defaultConfig.kvcache_block_size),
                std::vector<int64_t>{});
 
-  is.read(reinterpret_cast<char*>(&seq.lastToken_), sizeof(seq.lastToken_));
-  is.read(reinterpret_cast<char*>(&seq.numPromptTokens_),
-          sizeof(seq.numPromptTokens_));
-  is.read(reinterpret_cast<char*>(&seq.numCachedTokens_),
-          sizeof(seq.numCachedTokens_));
+  is.read(reinterpret_cast<char*>(&seq.lastToken), sizeof(seq.lastToken));
+  is.read(reinterpret_cast<char*>(&seq.numPromptTokens),
+          sizeof(seq.numPromptTokens));
+  is.read(reinterpret_cast<char*>(&seq.numCachedTokens),
+          sizeof(seq.numCachedTokens));
 
   size_t tokenIdsSize;
   is.read(reinterpret_cast<char*>(&tokenIdsSize), sizeof(tokenIdsSize));
-  seq.tokenIds_.resize(tokenIdsSize);
-  is.read(reinterpret_cast<char*>(seq.tokenIds_.data()),
+  seq.tokenIds.resize(tokenIdsSize);
+  is.read(reinterpret_cast<char*>(seq.tokenIds.data()),
           tokenIdsSize * sizeof(int64_t));
 
   size_t blockTableSize;
   is.read(reinterpret_cast<char*>(&blockTableSize), sizeof(blockTableSize));
-  seq.blockTable_.resize(blockTableSize);
-  is.read(reinterpret_cast<char*>(seq.blockTable_.data()),
+  seq.blockTable.resize(blockTableSize);
+  is.read(reinterpret_cast<char*>(seq.blockTable.data()),
           blockTableSize * sizeof(int));
 
-  is.read(reinterpret_cast<char*>(&seq.status_), sizeof(seq.status_));
-  is.read(reinterpret_cast<char*>(&seq.blockSize_), sizeof(seq.blockSize_));
-  is.read(reinterpret_cast<char*>(&seq.address_), sizeof(seq.address_));
-  seq.samplingParams_ = SamplingParams::deserialize(is);
+  is.read(reinterpret_cast<char*>(&seq.status), sizeof(seq.status));
+  is.read(reinterpret_cast<char*>(&seq.blockSize), sizeof(seq.blockSize));
+  is.read(reinterpret_cast<char*>(&seq.address), sizeof(seq.address));
+  seq.samplingParams = SamplingParams::deserialize(is);
   return seq;
 }
 

--- a/tt-media-server/cpp_server/src/runners/llm_runner/sequence.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/sequence.cpp
@@ -14,14 +14,14 @@ using Config = tt::config::LLMConfig;
 Sequence::Sequence(uint32_t taskId, int blockSize,
                    std::vector<int64_t> tokenIds,
                    const SamplingParams& samplingParams)
-    : taskId(std::move(taskId)),
-      status(SequenceStatus::WAITING),
-      tokenIds(std::move(tokenIds)),
-      numPromptTokens(this->tokenIds.size()),
-      samplingParams(std::make_unique<SamplingParams>(samplingParams)),
-      blockSize(blockSize) {
-  if (!this->tokenIds.empty()) {
-    lastToken = this->tokenIds.back();
+    : taskId(taskId),
+      status_(SequenceStatus::WAITING),
+      tokenIds_(std::move(tokenIds)),
+      numPromptTokens_(tokenIds_.size()),
+      samplingParams_(std::make_unique<SamplingParams>(samplingParams)),
+      blockSize_(blockSize) {
+  if (!tokenIds_.empty()) {
+    lastToken_ = tokenIds_.back();
   }
 }
 
@@ -30,44 +30,43 @@ std::vector<int64_t> Sequence::block(size_t i) const {
   if (i >= n) {
     throw std::out_of_range("block index out of range");
   }
-  size_t start = i * blockSize;
-  size_t end = std::min(start + blockSize, tokenIds.size());
-  return std::vector<int64_t>(tokenIds.begin() + start, tokenIds.begin() + end);
+  size_t start = i * blockSize_;
+  size_t end = std::min(start + blockSize_, tokenIds_.size());
+  return {tokenIds_.begin() + start, tokenIds_.begin() + end};
 }
 
 std::vector<int64_t> Sequence::completionTokenIds() const {
-  if (numPromptTokens >= tokenIds.size()) {
+  if (numPromptTokens_ >= tokenIds_.size()) {
     return {};
   }
-  return std::vector<int64_t>(tokenIds.begin() + numPromptTokens,
-                              tokenIds.end());
+  return {tokenIds_.begin() + numPromptTokens_, tokenIds_.end()};
 }
 
 void Sequence::appendToken(int64_t tokenId) {
-  tokenIds.push_back(tokenId);
-  lastToken = tokenId;
+  tokenIds_.push_back(tokenId);
+  lastToken_ = tokenId;
 }
 
 void Sequence::serialize(std::ostream& os) const {
-  size_t tokenIdsSize = tokenIds.size();
-  size_t blockTableSize = blockTable.size();
+  size_t tokenIdsSize = tokenIds_.size();
+  size_t blockTableSize = blockTable_.size();
   os.write(reinterpret_cast<const char*>(&taskId), sizeof(taskId));
-  os.write(reinterpret_cast<const char*>(&lastToken), sizeof(lastToken));
-  os.write(reinterpret_cast<const char*>(&numPromptTokens),
-           sizeof(numPromptTokens));
-  os.write(reinterpret_cast<const char*>(&numCachedTokens),
-           sizeof(numCachedTokens));
+  os.write(reinterpret_cast<const char*>(&lastToken_), sizeof(lastToken_));
+  os.write(reinterpret_cast<const char*>(&numPromptTokens_),
+           sizeof(numPromptTokens_));
+  os.write(reinterpret_cast<const char*>(&numCachedTokens_),
+           sizeof(numCachedTokens_));
   os.write(reinterpret_cast<const char*>(&tokenIdsSize), sizeof(tokenIdsSize));
-  os.write(reinterpret_cast<const char*>(tokenIds.data()),
+  os.write(reinterpret_cast<const char*>(tokenIds_.data()),
            tokenIdsSize * sizeof(int64_t));
   os.write(reinterpret_cast<const char*>(&blockTableSize),
            sizeof(blockTableSize));
-  os.write(reinterpret_cast<const char*>(blockTable.data()),
+  os.write(reinterpret_cast<const char*>(blockTable_.data()),
            blockTableSize * sizeof(int));
-  os.write(reinterpret_cast<const char*>(&status), sizeof(status));
-  os.write(reinterpret_cast<const char*>(&blockSize), sizeof(blockSize));
-  os.write(reinterpret_cast<const char*>(&address), sizeof(address));
-  samplingParams->serialize(os);
+  os.write(reinterpret_cast<const char*>(&status_), sizeof(status_));
+  os.write(reinterpret_cast<const char*>(&blockSize_), sizeof(blockSize_));
+  os.write(reinterpret_cast<const char*>(&address_), sizeof(address_));
+  samplingParams_->serialize(os);
 }
 
 Sequence Sequence::deserialize(std::istream& is) {
@@ -78,28 +77,28 @@ Sequence Sequence::deserialize(std::istream& is) {
   Sequence seq(taskId, static_cast<int>(defaultConfig.kvcache_block_size),
                std::vector<int64_t>{});
 
-  is.read(reinterpret_cast<char*>(&seq.lastToken), sizeof(seq.lastToken));
-  is.read(reinterpret_cast<char*>(&seq.numPromptTokens),
-          sizeof(seq.numPromptTokens));
-  is.read(reinterpret_cast<char*>(&seq.numCachedTokens),
-          sizeof(seq.numCachedTokens));
+  is.read(reinterpret_cast<char*>(&seq.lastToken_), sizeof(seq.lastToken_));
+  is.read(reinterpret_cast<char*>(&seq.numPromptTokens_),
+          sizeof(seq.numPromptTokens_));
+  is.read(reinterpret_cast<char*>(&seq.numCachedTokens_),
+          sizeof(seq.numCachedTokens_));
 
   size_t tokenIdsSize;
   is.read(reinterpret_cast<char*>(&tokenIdsSize), sizeof(tokenIdsSize));
-  seq.tokenIds.resize(tokenIdsSize);
-  is.read(reinterpret_cast<char*>(seq.tokenIds.data()),
+  seq.tokenIds_.resize(tokenIdsSize);
+  is.read(reinterpret_cast<char*>(seq.tokenIds_.data()),
           tokenIdsSize * sizeof(int64_t));
 
   size_t blockTableSize;
   is.read(reinterpret_cast<char*>(&blockTableSize), sizeof(blockTableSize));
-  seq.blockTable.resize(blockTableSize);
-  is.read(reinterpret_cast<char*>(seq.blockTable.data()),
+  seq.blockTable_.resize(blockTableSize);
+  is.read(reinterpret_cast<char*>(seq.blockTable_.data()),
           blockTableSize * sizeof(int));
 
-  is.read(reinterpret_cast<char*>(&seq.status), sizeof(seq.status));
-  is.read(reinterpret_cast<char*>(&seq.blockSize), sizeof(seq.blockSize));
-  is.read(reinterpret_cast<char*>(&seq.address), sizeof(seq.address));
-  seq.samplingParams = SamplingParams::deserialize(is);
+  is.read(reinterpret_cast<char*>(&seq.status_), sizeof(seq.status_));
+  is.read(reinterpret_cast<char*>(&seq.blockSize_), sizeof(seq.blockSize_));
+  is.read(reinterpret_cast<char*>(&seq.address_), sizeof(seq.address_));
+  seq.samplingParams_ = SamplingParams::deserialize(is);
   return seq;
 }
 

--- a/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner.cpp
@@ -142,10 +142,9 @@ void SpPipelineRunner::step() {
           static_cast<int>(config::LLMConfig::MAX_INPUT_TOKENS);
     }
 
-    modelRunner->write(taskId, seq->getTokenIds(),
-                       seq->getSamplingParams().max_tokens.value(),
-                       sp_pipeline::RequestPhase::PREFILL,
-                       seq->getSamplingParams().fast_mode);
+    modelRunner->write(
+        taskId, seq->getTokenIds(), seq->getSamplingParams().max_tokens.value(),
+        sp_pipeline::RequestPhase::PREFILL, seq->getSamplingParams().fast_mode);
 
     activeSequences.emplace(taskId, std::move(seq));
     ++inFlightCount;

--- a/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner.cpp
@@ -71,7 +71,7 @@ bool SpPipelineRunner::warmup() {
       1,  // block_size (doesn't matter for warmup)
       warmupTokens, warmupParams);
 
-  modelRunner->write(warmupSeq->taskId, warmupSeq->tokenIds(), 1,
+  modelRunner->write(warmupSeq->taskId, warmupSeq->getTokenIds(), 1,
                      sp_pipeline::RequestPhase::PREFILL);
 
   // Wait for the response token (with timeout)
@@ -137,13 +137,13 @@ void SpPipelineRunner::step() {
     ZoneScopedN("SpPipelineRunner::write_to_device");
     uint32_t taskId = seq->taskId;
 
-    if (!seq->samplingParams().max_tokens.has_value()) {
-      seq->mutableSamplingParams().max_tokens =
+    if (!seq->getSamplingParams().max_tokens.has_value()) {
+      seq->getMutableSamplingParams().max_tokens =
           static_cast<int>(config::LLMConfig::MAX_INPUT_TOKENS);
     }
 
-    modelRunner->write(taskId, seq->tokenIds(),
-                       seq->samplingParams().max_tokens.value(),
+    modelRunner->write(taskId, seq->getTokenIds(),
+                       seq->getSamplingParams().max_tokens.value(),
                        sp_pipeline::RequestPhase::PREFILL);
 
     activeSequences.emplace(taskId, std::move(seq));
@@ -175,11 +175,11 @@ void SpPipelineRunner::drainDecodeResults() {
 
     bool isStop = stopTokenIds.count(static_cast<int64_t>(dr.tokenId)) > 0;
     bool reachedMaxTokens =
-        seq->samplingParams().max_tokens.has_value() &&
+        seq->getSamplingParams().max_tokens.has_value() &&
         seq->numCompletionTokens() >=
-            static_cast<size_t>(seq->samplingParams().max_tokens.value());
+            static_cast<size_t>(seq->getSamplingParams().max_tokens.value());
     bool finished =
-        (!seq->samplingParams().ignore_eos && isStop) || reachedMaxTokens;
+        (!seq->getSamplingParams().ignore_eos && isStop) || reachedMaxTokens;
 
     ipc::pushToken(*resultQueue, dr.taskId, dr.tokenId, finished);
 

--- a/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner.cpp
@@ -71,7 +71,7 @@ bool SpPipelineRunner::warmup() {
       1,  // block_size (doesn't matter for warmup)
       warmupTokens, warmupParams);
 
-  modelRunner->write(warmupSeq->taskId, warmupSeq->tokenIds, 1,
+  modelRunner->write(warmupSeq->taskId, warmupSeq->tokenIds(), 1,
                      sp_pipeline::RequestPhase::PREFILL);
 
   // Wait for the response token (with timeout)
@@ -137,13 +137,13 @@ void SpPipelineRunner::step() {
     ZoneScopedN("SpPipelineRunner::write_to_device");
     uint32_t taskId = seq->taskId;
 
-    if (!seq->samplingParams->max_tokens.has_value()) {
-      seq->samplingParams->max_tokens =
+    if (!seq->samplingParams().max_tokens.has_value()) {
+      seq->mutableSamplingParams().max_tokens =
           static_cast<int>(config::LLMConfig::MAX_INPUT_TOKENS);
     }
 
-    modelRunner->write(taskId, seq->tokenIds,
-                       seq->samplingParams->max_tokens.value(),
+    modelRunner->write(taskId, seq->tokenIds(),
+                       seq->samplingParams().max_tokens.value(),
                        sp_pipeline::RequestPhase::PREFILL);
 
     activeSequences.emplace(taskId, std::move(seq));
@@ -175,11 +175,11 @@ void SpPipelineRunner::drainDecodeResults() {
 
     bool isStop = stopTokenIds.count(static_cast<int64_t>(dr.tokenId)) > 0;
     bool reachedMaxTokens =
-        seq->samplingParams->max_tokens.has_value() &&
+        seq->samplingParams().max_tokens.has_value() &&
         seq->numCompletionTokens() >=
-            static_cast<size_t>(seq->samplingParams->max_tokens.value());
+            static_cast<size_t>(seq->samplingParams().max_tokens.value());
     bool finished =
-        (!seq->samplingParams->ignore_eos && isStop) || reachedMaxTokens;
+        (!seq->samplingParams().ignore_eos && isStop) || reachedMaxTokens;
 
     ipc::pushToken(*resultQueue, dr.taskId, dr.tokenId, finished);
 

--- a/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
@@ -33,7 +33,7 @@ void SpPrefillRunner::run() {
     TT_LOG_DEBUG("SpPrefillRunner: Starting prefill for task {}",
                  sequence->taskId);
 
-    auto result = modelRunner->forward(sequence->taskId, sequence->tokenIds);
+    auto result = modelRunner->forward(sequence->taskId, sequence->tokenIds());
 
     if (!result) {
       break;  // stopped

--- a/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
@@ -33,7 +33,8 @@ void SpPrefillRunner::run() {
     TT_LOG_DEBUG("SpPrefillRunner: Starting prefill for task {}",
                  sequence->taskId);
 
-    auto result = modelRunner->forward(sequence->taskId, sequence->tokenIds());
+    auto result =
+        modelRunner->forward(sequence->taskId, sequence->getTokenIds());
 
     if (!result) {
       break;  // stopped

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -400,12 +400,12 @@ void LLMService::processStreamingRequest(
       taskId,
       static_cast<int>(tt::config::llmEngineConfig().kvcache_block_size),
       std::move(tokenIds));
-  sequence->numPromptTokens = prompt.size();
+  sequence->setNumPromptTokens(prompt.size());
   if (request.slotId.has_value()) {
     sequence->setKVCacheAddress(request.slotId.value());
   }
-  sequence->samplingParams = std::make_unique<llm_engine::SamplingParams>(
-      tt::utils::mapper::mapSamplingParams(request));
+  sequence->setSamplingParams(std::make_unique<llm_engine::SamplingParams>(
+      tt::utils::mapper::mapSamplingParams(request)));
   queue_manager_->task_queue->push(*std::move(sequence));
 }
 

--- a/tt-media-server/cpp_server/src/services/paged_memory_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/paged_memory_manager.cpp
@@ -41,14 +41,14 @@ ManageMemoryStatus PagedMemoryManager::allocateKv(
     return ManageMemoryStatus::WAITING;
   }
 
-  outSlotIds = std::move(seq.mutableBlockTable());
+  outSlotIds = std::move(seq.getMutableBlockTable());
   return ManageMemoryStatus::SUCCESS;
 }
 
 void PagedMemoryManager::deallocateKv(uint32_t taskId,
                                       std::vector<int> slotIds) {
   llm_engine::Sequence seq(taskId, blockManager->blockSize(), {});
-  seq.mutableBlockTable() = std::move(slotIds);
+  seq.getMutableBlockTable() = std::move(slotIds);
   blockManager->deallocate(seq);
 }
 

--- a/tt-media-server/cpp_server/src/services/paged_memory_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/paged_memory_manager.cpp
@@ -41,14 +41,14 @@ ManageMemoryStatus PagedMemoryManager::allocateKv(
     return ManageMemoryStatus::WAITING;
   }
 
-  outSlotIds = std::move(seq.blockTable);
+  outSlotIds = std::move(seq.mutableBlockTable());
   return ManageMemoryStatus::SUCCESS;
 }
 
 void PagedMemoryManager::deallocateKv(uint32_t taskId,
                                       std::vector<int> slotIds) {
   llm_engine::Sequence seq(taskId, blockManager->blockSize(), {});
-  seq.blockTable = std::move(slotIds);
+  seq.mutableBlockTable() = std::move(slotIds);
   blockManager->deallocate(seq);
 }
 

--- a/tt-media-server/cpp_server/src/worker/single_process_worker.cpp
+++ b/tt-media-server/cpp_server/src/worker/single_process_worker.cpp
@@ -26,7 +26,7 @@ SingleProcessWorker::~SingleProcessWorker() = default;
 
 void SingleProcessWorker::start() {
   tracy_config::tracySetThreadName(
-      ("Worker-" + to_string(cfg.worker_id)).c_str());
+      ("Worker-" + std::to_string(cfg.worker_id)).c_str());
 
   for (const auto& [key, value] : cfg.env_vars) {
     setenv(key.c_str(), value.c_str(), 1);
@@ -68,15 +68,15 @@ void SingleProcessWorker::stop() {
     int status;
     int waitResult = waitpid(pid, &status, WNOHANG);
     if (waitResult == 0) {
-      this_thread::sleep_for(chrono::milliseconds(500));
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
       waitResult = waitpid(pid, &status, WNOHANG);
       if (waitResult == 0) {
         killpg(pid, SIGKILL);
         waitpid(pid, &status, 0);
       }
     }
-    cout << "[SingleProcessWorker] Worker " << worker_id << " exited\n"
-         << flush;
+    std::cout << "[SingleProcessWorker] Worker " << worker_id << " exited\n"
+              << std::flush;
   }
 }
 

--- a/tt-media-server/cpp_server/tests/ipc_scheduler_smoke_test.cpp
+++ b/tt-media-server/cpp_server/tests/ipc_scheduler_smoke_test.cpp
@@ -91,10 +91,10 @@ int main() {
     for (auto* s : batch) {
       std::cout << "[child]    task_id=" << s->taskId << " size=" << s->size()
                 << " max_tokens="
-                << (s->samplingParams->max_tokens.has_value()
-                        ? std::to_string(s->samplingParams->max_tokens.value())
+                << (s->samplingParams().max_tokens.has_value()
+                        ? std::to_string(s->samplingParams().max_tokens.value())
                         : "none")
-                << " temperature=" << s->samplingParams->temperature
+                << " temperature=" << s->samplingParams().temperature
                 << " tokens=[";
       for (size_t i = 0; i < s->size(); ++i) {
         if (i > 0) std::cout << ",";
@@ -116,7 +116,7 @@ int main() {
     if (ok) {
       if (batch[0]->taskId != seq1Id) fail("seq1 task_id mismatch");
       if (batch[0]->size() != 4) fail("seq1 size mismatch");
-      if (batch[0]->samplingParams->max_tokens != 10)
+      if (batch[0]->samplingParams().max_tokens != 10)
         fail("seq1 max_tokens mismatch");
       if ((*batch[0])[0] != 1 || (*batch[0])[1] != 2 || (*batch[0])[2] != 3 ||
           (*batch[0])[3] != 4)

--- a/tt-media-server/cpp_server/tests/ipc_scheduler_smoke_test.cpp
+++ b/tt-media-server/cpp_server/tests/ipc_scheduler_smoke_test.cpp
@@ -91,10 +91,11 @@ int main() {
     for (auto* s : batch) {
       std::cout << "[child]    task_id=" << s->taskId << " size=" << s->size()
                 << " max_tokens="
-                << (s->samplingParams().max_tokens.has_value()
-                        ? std::to_string(s->samplingParams().max_tokens.value())
+                << (s->getSamplingParams().max_tokens.has_value()
+                        ? std::to_string(
+                              s->getSamplingParams().max_tokens.value())
                         : "none")
-                << " temperature=" << s->samplingParams().temperature
+                << " temperature=" << s->getSamplingParams().temperature
                 << " tokens=[";
       for (size_t i = 0; i < s->size(); ++i) {
         if (i > 0) std::cout << ",";
@@ -116,7 +117,7 @@ int main() {
     if (ok) {
       if (batch[0]->taskId != seq1Id) fail("seq1 task_id mismatch");
       if (batch[0]->size() != 4) fail("seq1 size mismatch");
-      if (batch[0]->samplingParams().max_tokens != 10)
+      if (batch[0]->getSamplingParams().max_tokens != 10)
         fail("seq1 max_tokens mismatch");
       if ((*batch[0])[0] != 1 || (*batch[0])[1] != 2 || (*batch[0])[2] != 3 ||
           (*batch[0])[3] != 4)

--- a/tt-media-server/cpp_server/tests/lockfree_queue_test.cpp
+++ b/tt-media-server/cpp_server/tests/lockfree_queue_test.cpp
@@ -17,7 +17,7 @@ constexpr size_t ITEM_COUNT = 500'000;
 // ---- SPSC single-element push/pop ------------------------------------
 
 TEST(LockFreeQueueTest, SpscOrdering) {
-  LockFreeConcurrentQueue<uint64_t> q(QUEUE_CAPACITY);
+  LockFreeSpscQueue<uint64_t> q(QUEUE_CAPACITY);
   std::vector<uint64_t> received;
   received.reserve(ITEM_COUNT);
   std::atomic<bool> producerDone{false};
@@ -56,7 +56,7 @@ TEST(LockFreeQueueTest, SpscOrdering) {
 
 TEST(LockFreeQueueTest, SpscBatchAligned) {
   constexpr size_t batchSize = 64;
-  LockFreeConcurrentQueue<uint64_t> q(QUEUE_CAPACITY);
+  LockFreeSpscQueue<uint64_t> q(QUEUE_CAPACITY);
   std::vector<uint64_t> received;
   received.reserve(ITEM_COUNT);
   std::atomic<bool> producerDone{false};
@@ -105,7 +105,7 @@ TEST(LockFreeQueueTest, SpscBatchAligned) {
 
 TEST(LockFreeQueueTest, SpscBatchOddSize) {
   constexpr size_t batchSize = 7;
-  LockFreeConcurrentQueue<uint64_t> q(QUEUE_CAPACITY);
+  LockFreeSpscQueue<uint64_t> q(QUEUE_CAPACITY);
   std::vector<uint64_t> received;
   received.reserve(ITEM_COUNT);
   std::atomic<bool> producerDone{false};
@@ -159,7 +159,7 @@ struct Payload {
 };
 
 TEST(LockFreeQueueTest, SpscNoTornReads) {
-  LockFreeConcurrentQueue<Payload> q(QUEUE_CAPACITY);
+  LockFreeSpscQueue<Payload> q(QUEUE_CAPACITY);
   std::atomic<bool> producerDone{false};
   std::atomic<bool> integiryOk{true};
   std::atomic<size_t> count{0};
@@ -201,7 +201,7 @@ TEST(LockFreeQueueTest, SpscNoTornReads) {
 TEST(LockFreeQueueTest, FillDrainCycles) {
   constexpr size_t cap = 64;
   constexpr size_t cycles = 1000;
-  LockFreeConcurrentQueue<int> q(cap);
+  LockFreeSpscQueue<int> q(cap);
 
   // Usable slots = nextPowerOfTwo(cap+1) - 1 (sentinel gap for SPSC).
   const size_t expectedCapacity = nextPowerOfTwo(cap + 1) - 1;
@@ -223,7 +223,7 @@ TEST(LockFreeQueueTest, FillDrainCycles) {
 // ---- Mixed single + batch ops ----------------------------------------
 
 TEST(LockFreeQueueTest, SpscMixedSingleAndBatch) {
-  LockFreeConcurrentQueue<uint64_t> q(QUEUE_CAPACITY);
+  LockFreeSpscQueue<uint64_t> q(QUEUE_CAPACITY);
   std::vector<uint64_t> received;
   received.reserve(ITEM_COUNT);
   std::atomic<bool> producerDone{false};

--- a/tt-media-server/cpp_server/tests/lockfree_queue_test.cpp
+++ b/tt-media-server/cpp_server/tests/lockfree_queue_test.cpp
@@ -17,7 +17,7 @@ constexpr size_t ITEM_COUNT = 500'000;
 // ---- SPSC single-element push/pop ------------------------------------
 
 TEST(LockFreeQueueTest, SpscOrdering) {
-  LockFreeSpscQueue<uint64_t> q(QUEUE_CAPACITY);
+  LockFreeSingleProducerQueue<uint64_t> q(QUEUE_CAPACITY);
   std::vector<uint64_t> received;
   received.reserve(ITEM_COUNT);
   std::atomic<bool> producerDone{false};
@@ -56,7 +56,7 @@ TEST(LockFreeQueueTest, SpscOrdering) {
 
 TEST(LockFreeQueueTest, SpscBatchAligned) {
   constexpr size_t batchSize = 64;
-  LockFreeSpscQueue<uint64_t> q(QUEUE_CAPACITY);
+  LockFreeSingleProducerQueue<uint64_t> q(QUEUE_CAPACITY);
   std::vector<uint64_t> received;
   received.reserve(ITEM_COUNT);
   std::atomic<bool> producerDone{false};
@@ -105,7 +105,7 @@ TEST(LockFreeQueueTest, SpscBatchAligned) {
 
 TEST(LockFreeQueueTest, SpscBatchOddSize) {
   constexpr size_t batchSize = 7;
-  LockFreeSpscQueue<uint64_t> q(QUEUE_CAPACITY);
+  LockFreeSingleProducerQueue<uint64_t> q(QUEUE_CAPACITY);
   std::vector<uint64_t> received;
   received.reserve(ITEM_COUNT);
   std::atomic<bool> producerDone{false};
@@ -159,7 +159,7 @@ struct Payload {
 };
 
 TEST(LockFreeQueueTest, SpscNoTornReads) {
-  LockFreeSpscQueue<Payload> q(QUEUE_CAPACITY);
+  LockFreeSingleProducerQueue<Payload> q(QUEUE_CAPACITY);
   std::atomic<bool> producerDone{false};
   std::atomic<bool> integiryOk{true};
   std::atomic<size_t> count{0};
@@ -201,7 +201,7 @@ TEST(LockFreeQueueTest, SpscNoTornReads) {
 TEST(LockFreeQueueTest, FillDrainCycles) {
   constexpr size_t cap = 64;
   constexpr size_t cycles = 1000;
-  LockFreeSpscQueue<int> q(cap);
+  LockFreeSingleProducerQueue<int> q(cap);
 
   // Usable slots = nextPowerOfTwo(cap+1) - 1 (sentinel gap for SPSC).
   const size_t expectedCapacity = nextPowerOfTwo(cap + 1) - 1;
@@ -223,7 +223,7 @@ TEST(LockFreeQueueTest, FillDrainCycles) {
 // ---- Mixed single + batch ops ----------------------------------------
 
 TEST(LockFreeQueueTest, SpscMixedSingleAndBatch) {
-  LockFreeSpscQueue<uint64_t> q(QUEUE_CAPACITY);
+  LockFreeSingleProducerQueue<uint64_t> q(QUEUE_CAPACITY);
   std::vector<uint64_t> received;
   received.reserve(ITEM_COUNT);
   std::atomic<bool> producerDone{false};

--- a/tt-media-server/cpp_server/tests/lockfree_queue_test.cpp
+++ b/tt-media-server/cpp_server/tests/lockfree_queue_test.cpp
@@ -17,7 +17,7 @@ constexpr size_t ITEM_COUNT = 500'000;
 // ---- SPSC single-element push/pop ------------------------------------
 
 TEST(LockFreeQueueTest, SpscOrdering) {
-  LockFreeSingleProducerQueue<uint64_t> q(QUEUE_CAPACITY);
+  LockFreeSPSCQueue<uint64_t> q(QUEUE_CAPACITY);
   std::vector<uint64_t> received;
   received.reserve(ITEM_COUNT);
   std::atomic<bool> producerDone{false};
@@ -56,7 +56,7 @@ TEST(LockFreeQueueTest, SpscOrdering) {
 
 TEST(LockFreeQueueTest, SpscBatchAligned) {
   constexpr size_t batchSize = 64;
-  LockFreeSingleProducerQueue<uint64_t> q(QUEUE_CAPACITY);
+  LockFreeSPSCQueue<uint64_t> q(QUEUE_CAPACITY);
   std::vector<uint64_t> received;
   received.reserve(ITEM_COUNT);
   std::atomic<bool> producerDone{false};
@@ -105,7 +105,7 @@ TEST(LockFreeQueueTest, SpscBatchAligned) {
 
 TEST(LockFreeQueueTest, SpscBatchOddSize) {
   constexpr size_t batchSize = 7;
-  LockFreeSingleProducerQueue<uint64_t> q(QUEUE_CAPACITY);
+  LockFreeSPSCQueue<uint64_t> q(QUEUE_CAPACITY);
   std::vector<uint64_t> received;
   received.reserve(ITEM_COUNT);
   std::atomic<bool> producerDone{false};
@@ -159,7 +159,7 @@ struct Payload {
 };
 
 TEST(LockFreeQueueTest, SpscNoTornReads) {
-  LockFreeSingleProducerQueue<Payload> q(QUEUE_CAPACITY);
+  LockFreeSPSCQueue<Payload> q(QUEUE_CAPACITY);
   std::atomic<bool> producerDone{false};
   std::atomic<bool> integiryOk{true};
   std::atomic<size_t> count{0};
@@ -201,7 +201,7 @@ TEST(LockFreeQueueTest, SpscNoTornReads) {
 TEST(LockFreeQueueTest, FillDrainCycles) {
   constexpr size_t cap = 64;
   constexpr size_t cycles = 1000;
-  LockFreeSingleProducerQueue<int> q(cap);
+  LockFreeSPSCQueue<int> q(cap);
 
   // Usable slots = nextPowerOfTwo(cap+1) - 1 (sentinel gap for SPSC).
   const size_t expectedCapacity = nextPowerOfTwo(cap + 1) - 1;
@@ -223,7 +223,7 @@ TEST(LockFreeQueueTest, FillDrainCycles) {
 // ---- Mixed single + batch ops ----------------------------------------
 
 TEST(LockFreeQueueTest, SpscMixedSingleAndBatch) {
-  LockFreeSingleProducerQueue<uint64_t> q(QUEUE_CAPACITY);
+  LockFreeSPSCQueue<uint64_t> q(QUEUE_CAPACITY);
   std::vector<uint64_t> received;
   received.reserve(ITEM_COUNT);
   std::atomic<bool> producerDone{false};

--- a/tt-media-server/cpp_server/tests/scheduler_test.cpp
+++ b/tt-media-server/cpp_server/tests/scheduler_test.cpp
@@ -212,7 +212,7 @@ TEST(PrefillFirstSchedulerTest, Preempt_MovesSequenceBackToWaiting) {
   ASSERT_TRUE(is_prefill);
   ASSERT_EQ(batch.size(), 1u);
   sched.preempt(*batch[0]);
-  EXPECT_EQ(batch[0]->status, SequenceStatus::WAITING);
+  EXPECT_EQ(batch[0]->status(), SequenceStatus::WAITING);
   auto [batch2, is_prefill2] = sched.schedule();
   EXPECT_TRUE(is_prefill2);
   EXPECT_EQ(batch2.size(), 1u);

--- a/tt-media-server/cpp_server/tests/scheduler_test.cpp
+++ b/tt-media-server/cpp_server/tests/scheduler_test.cpp
@@ -212,7 +212,7 @@ TEST(PrefillFirstSchedulerTest, Preempt_MovesSequenceBackToWaiting) {
   ASSERT_TRUE(is_prefill);
   ASSERT_EQ(batch.size(), 1u);
   sched.preempt(*batch[0]);
-  EXPECT_EQ(batch[0]->status(), SequenceStatus::WAITING);
+  EXPECT_EQ(batch[0]->getStatus(), SequenceStatus::WAITING);
   auto [batch2, is_prefill2] = sched.schedule();
   EXPECT_TRUE(is_prefill2);
   EXPECT_EQ(batch2.size(), 1u);

--- a/tt-media-server/cpp_server/tests/sequence_test.cpp
+++ b/tt-media-server/cpp_server/tests/sequence_test.cpp
@@ -120,10 +120,10 @@ TEST(SequenceTest, SerializeDeserialize_RoundTrip_PreservesAllFields) {
 
   Sequence orig(tt::utils::TaskIDGenerator::generate(), 256, {1, 2, 3, 4, 5},
                 params);
-  orig.numCachedTokens = 256;
-  orig.blockTable = {0, 1};
-  orig.status = SequenceStatus::IN_FLIGHT;
-  orig.lastToken = 5;
+  orig.setNumCachedTokens(256);
+  orig.mutableBlockTable() = {0, 1};
+  orig.setStatus(SequenceStatus::IN_FLIGHT);
+  orig.setLastToken(5);
 
   std::ostringstream os;
   orig.serialize(os);
@@ -132,15 +132,15 @@ TEST(SequenceTest, SerializeDeserialize_RoundTrip_PreservesAllFields) {
   Sequence restored = Sequence::deserialize(is);
 
   EXPECT_EQ(restored.taskId, orig.taskId);
-  EXPECT_EQ(restored.lastToken, orig.lastToken);
-  EXPECT_EQ(restored.numPromptTokens, orig.numPromptTokens);
-  EXPECT_EQ(restored.numCachedTokens, orig.numCachedTokens);
-  EXPECT_EQ(restored.tokenIds, orig.tokenIds);
-  EXPECT_EQ(restored.blockTable, orig.blockTable);
-  EXPECT_EQ(restored.status, orig.status);
+  EXPECT_EQ(restored.lastToken(), orig.lastToken());
+  EXPECT_EQ(restored.numPromptTokens(), orig.numPromptTokens());
+  EXPECT_EQ(restored.numCachedTokens(), orig.numCachedTokens());
+  EXPECT_EQ(restored.tokenIds(), orig.tokenIds());
+  EXPECT_EQ(restored.blockTable(), orig.blockTable());
+  EXPECT_EQ(restored.status(), orig.status());
 
-  const auto& sp = *restored.samplingParams;
-  const auto& spOrig = *orig.samplingParams;
+  const auto& sp = restored.samplingParams();
+  const auto& spOrig = orig.samplingParams();
   EXPECT_FLOAT_EQ(sp.temperature, spOrig.temperature);
   EXPECT_EQ(sp.max_tokens, spOrig.max_tokens);
   EXPECT_EQ(sp.ignore_eos, spOrig.ignore_eos);
@@ -155,7 +155,7 @@ TEST(SequenceTest, SerializeDeserialize_RoundTrip_PreservesAllFields) {
 
 TEST(SequenceTest, SerializeDeserialize_EmptyTokenIds) {
   Sequence orig(12345, 256, {}, SamplingParams{.max_tokens = 10});
-  orig.lastToken = 0;
+  orig.setLastToken(0);
 
   std::ostringstream os;
   orig.serialize(os);
@@ -164,16 +164,16 @@ TEST(SequenceTest, SerializeDeserialize_EmptyTokenIds) {
   Sequence restored = Sequence::deserialize(is);
 
   EXPECT_EQ(restored.taskId, orig.taskId);
-  EXPECT_TRUE(restored.tokenIds.empty());
-  EXPECT_EQ(restored.numPromptTokens, 0u);
-  EXPECT_EQ(restored.lastToken, 0);
+  EXPECT_TRUE(restored.tokenIds().empty());
+  EXPECT_EQ(restored.numPromptTokens(), 0u);
+  EXPECT_EQ(restored.lastToken(), 0);
 }
 
 TEST(SequenceTest, SerializeDeserialize_AfterAppendToken) {
   Sequence orig(12345, 256, {10, 20}, SamplingParams{.max_tokens = 5});
   orig.appendToken(30);
   orig.appendToken(40);
-  orig.numCachedTokens = 256;
+  orig.setNumCachedTokens(256);
 
   std::ostringstream os;
   orig.serialize(os);
@@ -186,9 +186,9 @@ TEST(SequenceTest, SerializeDeserialize_AfterAppendToken) {
   EXPECT_EQ(restored[1], 20);
   EXPECT_EQ(restored[2], 30);
   EXPECT_EQ(restored[3], 40);
-  EXPECT_EQ(restored.lastToken, 40);
-  EXPECT_EQ(restored.numPromptTokens, 2u);
-  EXPECT_EQ(restored.numCachedTokens, 256u);
+  EXPECT_EQ(restored.lastToken(), 40);
+  EXPECT_EQ(restored.numPromptTokens(), 2u);
+  EXPECT_EQ(restored.numCachedTokens(), 256u);
 }
 
 }  // namespace

--- a/tt-media-server/cpp_server/tests/sequence_test.cpp
+++ b/tt-media-server/cpp_server/tests/sequence_test.cpp
@@ -121,7 +121,7 @@ TEST(SequenceTest, SerializeDeserialize_RoundTrip_PreservesAllFields) {
   Sequence orig(tt::utils::TaskIDGenerator::generate(), 256, {1, 2, 3, 4, 5},
                 params);
   orig.setNumCachedTokens(256);
-  orig.mutableBlockTable() = {0, 1};
+  orig.getMutableBlockTable() = {0, 1};
   orig.setStatus(SequenceStatus::IN_FLIGHT);
   orig.setLastToken(5);
 
@@ -132,15 +132,15 @@ TEST(SequenceTest, SerializeDeserialize_RoundTrip_PreservesAllFields) {
   Sequence restored = Sequence::deserialize(is);
 
   EXPECT_EQ(restored.taskId, orig.taskId);
-  EXPECT_EQ(restored.lastToken(), orig.lastToken());
-  EXPECT_EQ(restored.numPromptTokens(), orig.numPromptTokens());
-  EXPECT_EQ(restored.numCachedTokens(), orig.numCachedTokens());
-  EXPECT_EQ(restored.tokenIds(), orig.tokenIds());
-  EXPECT_EQ(restored.blockTable(), orig.blockTable());
-  EXPECT_EQ(restored.status(), orig.status());
+  EXPECT_EQ(restored.getLastToken(), orig.getLastToken());
+  EXPECT_EQ(restored.getNumPromptTokens(), orig.getNumPromptTokens());
+  EXPECT_EQ(restored.getNumCachedTokens(), orig.getNumCachedTokens());
+  EXPECT_EQ(restored.getTokenIds(), orig.getTokenIds());
+  EXPECT_EQ(restored.getBlockTable(), orig.getBlockTable());
+  EXPECT_EQ(restored.getStatus(), orig.getStatus());
 
-  const auto& sp = restored.samplingParams();
-  const auto& spOrig = orig.samplingParams();
+  const auto& sp = restored.getSamplingParams();
+  const auto& spOrig = orig.getSamplingParams();
   EXPECT_FLOAT_EQ(sp.temperature, spOrig.temperature);
   EXPECT_EQ(sp.max_tokens, spOrig.max_tokens);
   EXPECT_EQ(sp.ignore_eos, spOrig.ignore_eos);
@@ -164,9 +164,9 @@ TEST(SequenceTest, SerializeDeserialize_EmptyTokenIds) {
   Sequence restored = Sequence::deserialize(is);
 
   EXPECT_EQ(restored.taskId, orig.taskId);
-  EXPECT_TRUE(restored.tokenIds().empty());
-  EXPECT_EQ(restored.numPromptTokens(), 0u);
-  EXPECT_EQ(restored.lastToken(), 0);
+  EXPECT_TRUE(restored.getTokenIds().empty());
+  EXPECT_EQ(restored.getNumPromptTokens(), 0u);
+  EXPECT_EQ(restored.getLastToken(), 0);
 }
 
 TEST(SequenceTest, SerializeDeserialize_AfterAppendToken) {
@@ -186,9 +186,9 @@ TEST(SequenceTest, SerializeDeserialize_AfterAppendToken) {
   EXPECT_EQ(restored[1], 20);
   EXPECT_EQ(restored[2], 30);
   EXPECT_EQ(restored[3], 40);
-  EXPECT_EQ(restored.lastToken(), 40);
-  EXPECT_EQ(restored.numPromptTokens(), 2u);
-  EXPECT_EQ(restored.numCachedTokens(), 256u);
+  EXPECT_EQ(restored.getLastToken(), 40);
+  EXPECT_EQ(restored.getNumPromptTokens(), 2u);
+  EXPECT_EQ(restored.getNumCachedTokens(), 256u);
 }
 
 }  // namespace


### PR DESCRIPTION
Removed using namespace `std` from `single_process_worker.hpp` and `queue_manager.hpp` so they don't pollute the global namespace for every includer. 
Made `ConcurrentMap::get`/`contains`/`size` const with a mutable mutex. 
Encapsulated `Sequence`'s public mutable members (`status`, `tokenIds`, `blockTable`, etc.) behind getters/setters so callers go through a proper API instead of touching internals directly. 
Also renamed `LockFreeConcurrentQueue` to `LockFreeConcurrentQueue` since it's single-producer single-consumer only.