### PR TITLE
Add cli arg support for inference server url

### DIFF
--- a/benchmarking/run_aiperf_benchmarks.py
+++ b/benchmarking/run_aiperf_benchmarks.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
+from urllib.parse import urlparse
 
 import jwt
 import requests
@@ -471,8 +472,16 @@ def send_warmup_requests(
         try:
             logger.info(f"Sending warm-up request {i + 1}/{num_requests}...")
 
-            # Use the prompt client's URL and auth
-            url = f"http://localhost:{prompt_client.env_config.service_port}/v1/chat/completions"
+            # Use the prompt client's URL and auth. Honor an explicit port on
+            # env_config.deploy_url to avoid double-port URLs when --server-url
+            # already carries one.
+            _parsed = urlparse(prompt_client.env_config.deploy_url.rstrip("/"))
+            _base = (
+                prompt_client.env_config.deploy_url.rstrip("/")
+                if _parsed.port is not None
+                else f"{prompt_client.env_config.deploy_url.rstrip('/')}:{prompt_client.env_config.service_port}"
+            )
+            url = f"{_base}/v1/chat/completions"
             headers = {"Content-Type": "application/json"}
 
             # Add auth if available
@@ -561,6 +570,16 @@ def main():
     # runtime config loaded from JSON
     device_str = runtime_config.device
     service_port = runtime_config.service_port
+    deploy_url = (
+        getattr(runtime_config, "server_url", None)
+        or os.environ.get("DEPLOY_URL", "http://127.0.0.1")
+    )
+    # An explicit port on deploy_url wins over service_port so AIPerf doesn't
+    # connect to host:service_port when --server-url already carries a port.
+    _parsed = urlparse(deploy_url.rstrip("/"))
+    aiperf_host = _parsed.hostname or "localhost"
+    aiperf_port = str(_parsed.port) if _parsed.port is not None else str(service_port)
+    aiperf_url = f"{aiperf_host}:{aiperf_port}"
 
     device = DeviceTypes.from_string(device_str)
     logger.info(f"model_spec=: {model_spec}")
@@ -640,6 +659,7 @@ def main():
     env_config.jwt_secret = jwt_secret
     env_config.service_port = service_port
     env_config.vllm_model = model_spec.hf_model_repo
+    env_config.deploy_url = deploy_url
 
     prompt_client = PromptClient(
         env_config,
@@ -703,7 +723,7 @@ def main():
             model_name=model_spec.hf_model_repo,
             model_id=model_spec.model_id,
             tokenizer=model_spec.hf_model_repo,
-            url=f"localhost:{service_port}",
+            url=aiperf_url,
             auth_token=auth_token,
             artifact_base=str(artifact_base),
             output_dir=args.output_path,

--- a/benchmarking/run_aiperf_benchmarks.py
+++ b/benchmarking/run_aiperf_benchmarks.py
@@ -570,9 +570,8 @@ def main():
     # runtime config loaded from JSON
     device_str = runtime_config.device
     service_port = runtime_config.service_port
-    deploy_url = (
-        getattr(runtime_config, "server_url", None)
-        or os.environ.get("DEPLOY_URL", "http://127.0.0.1")
+    deploy_url = getattr(runtime_config, "server_url", None) or os.environ.get(
+        "DEPLOY_URL", "http://127.0.0.1"
     )
     # An explicit port on deploy_url wins over service_port so AIPerf doesn't
     # connect to host:service_port when --server-url already carries a port.

--- a/benchmarking/run_benchmarks.py
+++ b/benchmarking/run_benchmarks.py
@@ -308,9 +308,8 @@ def main():
     # Mirror EnvironmentConfig's default (os.environ.get("DEPLOY_URL",
     # "http://127.0.0.1")) so the genai-perf path (which runs before
     # env_config is constructed) sees the same value used later.
-    deploy_url = (
-        getattr(runtime_config, "server_url", None)
-        or os.environ.get("DEPLOY_URL", "http://127.0.0.1")
+    deploy_url = getattr(runtime_config, "server_url", None) or os.environ.get(
+        "DEPLOY_URL", "http://127.0.0.1"
     )
 
     # Automatically control trace capture based on has_builtin_warmup

--- a/benchmarking/run_benchmarks.py
+++ b/benchmarking/run_benchmarks.py
@@ -10,6 +10,7 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import urlparse
 
 import jwt
 import requests
@@ -135,6 +136,20 @@ def parse_args():
     return ret_args
 
 
+def _resolve_host_port(deploy_url: str, service_port) -> tuple[str, str]:
+    """Split a deploy URL into ``(host, port)`` for ``--host``/``--port`` args.
+
+    When ``deploy_url`` carries an explicit port (e.g. ``http://host:9000``) that
+    port wins over ``service_port`` so callers can't end up with mismatched
+    ``--host host --port <service_port>`` against a server that's actually
+    listening on a different port.
+    """
+    parsed = urlparse(deploy_url.rstrip("/"))
+    host = parsed.hostname or "localhost"
+    port = str(parsed.port) if parsed.port is not None else str(service_port)
+    return host, port
+
+
 def build_benchmark_command(
     task,
     benchmark_script,
@@ -143,6 +158,7 @@ def build_benchmark_command(
     service_port,
     benchmark_config,
     model_spec,
+    deploy_url: str = "http://127.0.0.1",
 ):
     run_timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     isl = params.isl
@@ -167,6 +183,8 @@ def build_benchmark_command(
     dataset_name = "random-mm" if params.task_type == "vlm" else "random"
     backend = "openai-chat"
 
+    host, port = _resolve_host_port(deploy_url, service_port)
+
     # fmt: off
     cmd = [
         str(benchmark_script),
@@ -175,7 +193,8 @@ def build_benchmark_command(
         "--backend", backend,
         "--endpoint", "/v1/chat/completions",
         "--model", model_spec.hf_model_repo,
-        "--port", str(service_port),
+        "--host", host,
+        "--port", port,
         "--dataset-name", dataset_name,
         "--max-concurrency", str(max_concurrency),
         "--num-prompts", str(num_prompts),
@@ -212,6 +231,7 @@ def build_structured_output_command(
     output_path,
     service_port,
     model_spec,
+    deploy_url: str = "http://127.0.0.1",
 ):
     run_timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     ratio_tag = (
@@ -226,13 +246,15 @@ def build_structured_output_command(
         f"_osl-{params.osl}_maxcon-{params.max_concurrency}_n-{params.num_prompts}.json"
     )
 
+    host, port = _resolve_host_port(deploy_url, service_port)
+
     # fmt: off
     cmd = [
         str(venv_python),
         str(structured_output_script),
         "--backend", "vllm",
-        "--host", "localhost",
-        "--port", str(service_port),
+        "--host", host,
+        "--port", port,
         "--model", model_spec.hf_model_repo,
         "--dataset", params.structured_dataset,
         "--max-concurrency", str(params.max_concurrency),
@@ -283,6 +305,13 @@ def main():
     device_str = runtime_config.device
     service_port = runtime_config.service_port
     disable_trace_capture = runtime_config.disable_trace_capture
+    # Mirror EnvironmentConfig's default (os.environ.get("DEPLOY_URL",
+    # "http://127.0.0.1")) so the genai-perf path (which runs before
+    # env_config is constructed) sees the same value used later.
+    deploy_url = (
+        getattr(runtime_config, "server_url", None)
+        or os.environ.get("DEPLOY_URL", "http://127.0.0.1")
+    )
 
     # Automatically control trace capture based on has_builtin_warmup
     # Only apply automatic logic if user hasn't explicitly set --disable-trace-capture
@@ -328,6 +357,7 @@ def main():
             jwt_secret=jwt_secret,
             service_port=service_port,
             debug=debug_mode,
+            deploy_url=deploy_url,
         )
         return return_code
 
@@ -408,7 +438,12 @@ def main():
 
     if model_spec.model_type in BENCHMARKS_TASK_TYPES:
         return_code = run_benchmarks(
-            all_params, model_spec, device, args.output_path, service_port
+            all_params,
+            model_spec,
+            device,
+            args.output_path,
+            service_port,
+            deploy_url=deploy_url,
         )
         return return_code
 
@@ -439,6 +474,7 @@ def main():
     env_config.vllm_api_key = os.getenv("VLLM_API_KEY")
     env_config.service_port = service_port
     env_config.vllm_model = model_spec.hf_model_repo
+    env_config.deploy_url = deploy_url
 
     prompt_client = PromptClient(
         env_config,
@@ -527,6 +563,7 @@ def main():
                             output_path=args.output_path,
                             service_port=service_port,
                             model_spec=model_spec,
+                            deploy_url=deploy_url,
                         )
                     )
                 else:
@@ -538,6 +575,7 @@ def main():
                         service_port=service_port,
                         benchmark_config=benchmark_config,
                         model_spec=model_spec,
+                        deploy_url=deploy_url,
                     )
                 return_code = run_command(command=cmd, logger=logger, env=env_vars)
                 return_codes.append(return_code)
@@ -556,7 +594,9 @@ def main():
     return main_return_code
 
 
-def run_benchmarks(all_params, model_spec, device, output_path, service_port):
+def run_benchmarks(
+    all_params, model_spec, device, output_path, service_port, deploy_url=None
+):
     """
     Run benchmarks for the given model and device. Here we are running IMAGE, CNN, AUDIO, VIDEO benchmarks.
     """
@@ -570,6 +610,7 @@ def run_benchmarks(all_params, model_spec, device, output_path, service_port):
         output_path,
         service_port,
         task_type=MediaTaskType.BENCHMARK,
+        deploy_url=deploy_url,
     )
 
 

--- a/benchmarking/run_genai_benchmarks.py
+++ b/benchmarking/run_genai_benchmarks.py
@@ -240,9 +240,8 @@ def main():
 
     # runtime config loaded from JSON
     service_port = runtime_config.service_port
-    deploy_url = (
-        getattr(runtime_config, "server_url", None)
-        or os.environ.get("DEPLOY_URL", "http://127.0.0.1")
+    deploy_url = getattr(runtime_config, "server_url", None) or os.environ.get(
+        "DEPLOY_URL", "http://127.0.0.1"
     )
 
     logger.info(f"Model: {model_spec.model_name}")

--- a/benchmarking/run_genai_benchmarks.py
+++ b/benchmarking/run_genai_benchmarks.py
@@ -13,6 +13,7 @@ import os
 import sys
 import uuid
 from pathlib import Path
+from urllib.parse import urlparse
 
 import jwt
 
@@ -89,6 +90,7 @@ def run_genai_benchmarks(
     jwt_secret: str,
     service_port: str = "8000",
     debug: bool = False,
+    deploy_url: str = "http://127.0.0.1",
 ) -> int:
     """
     Run genai-perf benchmarks using Docker container.
@@ -99,11 +101,21 @@ def run_genai_benchmarks(
         jwt_secret: JWT secret for authentication
         service_port: Service port for the inference server
         debug: If True, run in debug mode with verbose logging
+        deploy_url: Base URL of the inference server (scheme + host, optionally port).
+            Used to override the default localhost target when --server-url is set.
 
     Returns:
         Return code (0 for success, non-zero for failure)
     """
     logger.info("Starting genai-perf benchmarks...")
+
+    # genai-perf consumes URL as host[:port] without the scheme, so strip it
+    # here. An explicit port on the deploy URL wins over service_port to
+    # match the resolver used by the vLLM-bench path.
+    parsed = urlparse(deploy_url.rstrip("/"))
+    genai_host = parsed.hostname or "localhost"
+    genai_port = str(parsed.port) if parsed.port is not None else str(service_port)
+    genai_url = f"{genai_host}:{genai_port}"
 
     # Get venv config for artifacts directory
     venv_config = VENV_CONFIGS[WorkflowVenvType.BENCHMARKS_GENAI_PERF]
@@ -156,7 +168,7 @@ def run_genai_benchmarks(
         "model_name": hf_model_repo,
         "model_id": model_spec.model_id,
         "tokenizer": "hf-internal-testing/llama-tokenizer",
-        "url": f"localhost:{service_port}",
+        "url": genai_url,
         "max_context": max_context,
         "model_max_concurrency": max_concurrency,
         "auth_token": auth_token,
@@ -182,7 +194,7 @@ def run_genai_benchmarks(
         "-v", f"{host_hf_cache}:/workspace/.cache/huggingface",  # Mount host HF cache (reuse system cache)
         "-e", f"AUTH_TOKEN={auth_token}",
         "-e", f"MODEL_NAME={hf_model_repo}",
-        "-e", f"URL=localhost:{service_port}",
+        "-e", f"URL={genai_url}",
         "-e", f"MAX_CONTEXT={max_context}",
         "-e", f"MODEL_MAX_CONCURRENCY={max_concurrency}",
         "-e", "BENCHMARKS_OUTPUT_DIR=/workspace/benchmarks_output",
@@ -228,6 +240,10 @@ def main():
 
     # runtime config loaded from JSON
     service_port = runtime_config.service_port
+    deploy_url = (
+        getattr(runtime_config, "server_url", None)
+        or os.environ.get("DEPLOY_URL", "http://127.0.0.1")
+    )
 
     logger.info(f"Model: {model_spec.model_name}")
     logger.info(f"Device: {model_spec.device_type}")
@@ -240,6 +256,7 @@ def main():
         jwt_secret=args.jwt_secret,
         service_port=service_port,
         debug=args.debug,
+        deploy_url=deploy_url,
     )
 
     if return_code == 0:

--- a/benchmarking/run_guidellm_benchmarks.py
+++ b/benchmarking/run_guidellm_benchmarks.py
@@ -657,9 +657,8 @@ def main():
     model_spec = ModelSpec.from_json(args.runtime_model_spec_json)
     runtime_config = RuntimeConfig.from_json(args.runtime_model_spec_json)
 
-    deploy_url = (
-        getattr(runtime_config, "server_url", None)
-        or os.environ.get("DEPLOY_URL", "http://127.0.0.1")
+    deploy_url = getattr(runtime_config, "server_url", None) or os.environ.get(
+        "DEPLOY_URL", "http://127.0.0.1"
     )
 
     if model_spec.inference_engine in (
@@ -686,7 +685,8 @@ def main():
     # Honor an explicit port on deploy_url to avoid double-port targets.
     _parsed = urlparse(deploy_url.rstrip("/"))
     _base = (
-        deploy_url.rstrip("/") if _parsed.port is not None
+        deploy_url.rstrip("/")
+        if _parsed.port is not None
         else f"{deploy_url.rstrip('/')}:{runtime_config.service_port}"
     )
     target = workflow_params.get("target", f"{_base}/v1")

--- a/benchmarking/run_guidellm_benchmarks.py
+++ b/benchmarking/run_guidellm_benchmarks.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 import jwt
 
@@ -144,13 +145,17 @@ def create_default_multiturn_dataset(dataset_path: Path, samples: int = 50) -> P
 
 
 def wait_for_server(
-    model_spec: ModelSpec, runtime_config: RuntimeConfig, jwt_secret: str
+    model_spec: ModelSpec,
+    runtime_config: RuntimeConfig,
+    jwt_secret: str,
+    deploy_url: str = "http://127.0.0.1",
 ):
     env_config = EnvironmentConfig()
     env_config.jwt_secret = jwt_secret
     env_config.vllm_api_key = os.getenv("VLLM_API_KEY")
     env_config.service_port = runtime_config.service_port
     env_config.vllm_model = model_spec.hf_model_repo
+    env_config.deploy_url = deploy_url
 
     prompt_client = PromptClient(
         env_config,
@@ -652,13 +657,20 @@ def main():
     model_spec = ModelSpec.from_json(args.runtime_model_spec_json)
     runtime_config = RuntimeConfig.from_json(args.runtime_model_spec_json)
 
+    deploy_url = (
+        getattr(runtime_config, "server_url", None)
+        or os.environ.get("DEPLOY_URL", "http://127.0.0.1")
+    )
+
     if model_spec.inference_engine in (
         InferenceEngine.MEDIA.value,
         InferenceEngine.FORGE.value,
     ):
         os.environ["VLLM_API_KEY"] = "your-secret-key"
 
-    if not wait_for_server(model_spec, runtime_config, args.jwt_secret):
+    if not wait_for_server(
+        model_spec, runtime_config, args.jwt_secret, deploy_url=deploy_url
+    ):
         logger.error("vLLM server is not healthy. Aborting GuideLLM benchmarks.")
         return 1
 
@@ -671,9 +683,13 @@ def main():
     output_root.mkdir(parents=True, exist_ok=True)
 
     workflow_params = parse_workflow_args(runtime_config.workflow_args)
-    target = workflow_params.get(
-        "target", f"http://127.0.0.1:{runtime_config.service_port}/v1"
+    # Honor an explicit port on deploy_url to avoid double-port targets.
+    _parsed = urlparse(deploy_url.rstrip("/"))
+    _base = (
+        deploy_url.rstrip("/") if _parsed.port is not None
+        else f"{deploy_url.rstrip('/')}:{runtime_config.service_port}"
     )
+    target = workflow_params.get("target", f"{_base}/v1")
 
     runs = build_scenario_runs(
         output_root=output_root,

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -9,6 +9,7 @@ import os
 import sys
 from pathlib import Path
 from typing import List, Optional
+from urllib.parse import urlparse
 
 import jwt
 
@@ -194,6 +195,21 @@ def parse_args():
     return ret_args
 
 
+def _build_base_url(deploy_url: str, service_port: str) -> str:
+    """Construct a base URL from a deploy URL and service port.
+
+    Normalizes the deploy URL by stripping trailing slashes.  When the URL
+    already contains an explicit port (e.g. ``http://host:9000``) that port is
+    used and *service_port* is ignored so that the resulting URL is never of
+    the form ``http://host:9000:8000``.
+    """
+    parsed = urlparse(deploy_url.rstrip("/"))
+    if parsed.port is not None:
+        # URL already includes a port; use as-is
+        return deploy_url.rstrip("/")
+    return f"{deploy_url.rstrip('/')}:{service_port}"
+
+
 def build_eval_command(
     task: EvalTask,
     model_spec,
@@ -209,10 +225,11 @@ def build_eval_command(
     """
     # Audio models use tt-media-server which has endpoints at /audio (not /v1/audio)
     # Other models use vLLM which has endpoints at /v1
+    host_with_port = _build_base_url(deploy_url, service_port)
     if task.workflow_venv_type == WorkflowVenvType.EVALS_AUDIO:
-        base_url = f"{deploy_url}:{service_port}"
+        base_url = host_with_port
     else:
-        base_url = f"{deploy_url}:{service_port}/v1"
+        base_url = f"{host_with_port}/v1"
     eval_class = task.eval_class
     task_venv_config = VENV_CONFIGS[task.workflow_venv_type]
     if task.use_chat_api:
@@ -423,6 +440,7 @@ def main():
             device,
             args.output_path,
             runtime_config.service_port,
+            deploy_url=env_config.deploy_url,
         )
         return return_code
 
@@ -522,7 +540,7 @@ def main():
         return 1
 
 
-def run_media_evals(all_params, model_spec, device, output_path, service_port):
+def run_media_evals(all_params, model_spec, device, output_path, service_port, deploy_url=None):
     """
     Run media evals for cnn and image models only (not AUDIO models).
 
@@ -540,6 +558,7 @@ def run_media_evals(all_params, model_spec, device, output_path, service_port):
         output_path,
         service_port,
         task_type=MediaTaskType.EVALUATION,
+        deploy_url=deploy_url,
     )
 
 

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -201,6 +201,7 @@ def build_eval_command(
     output_path,
     service_port,
     runtime_config=None,
+    deploy_url: str = "http://127.0.0.1",
 ) -> List[str]:
     """
     Build the command for lm_eval by templating command-line arguments using properties
@@ -209,9 +210,9 @@ def build_eval_command(
     # Audio models use tt-media-server which has endpoints at /audio (not /v1/audio)
     # Other models use vLLM which has endpoints at /v1
     if task.workflow_venv_type == WorkflowVenvType.EVALS_AUDIO:
-        base_url = f"http://127.0.0.1:{service_port}"
+        base_url = f"{deploy_url}:{service_port}"
     else:
-        base_url = f"http://127.0.0.1:{service_port}/v1"
+        base_url = f"{deploy_url}:{service_port}/v1"
     eval_class = task.eval_class
     task_venv_config = VENV_CONFIGS[task.workflow_venv_type]
     if task.use_chat_api:
@@ -409,6 +410,8 @@ def main():
     env_config.jwt_secret = args.jwt_secret
     env_config.service_port = runtime_config.service_port
     env_config.vllm_model = model_spec.hf_model_repo
+    if getattr(runtime_config, "server_url", None):
+        env_config.deploy_url = runtime_config.server_url
 
     if (
         model_spec.model_type in EVAL_TASK_TYPES
@@ -450,6 +453,7 @@ def main():
                 args.output_path,
                 runtime_config.service_port,
                 runtime_config=runtime_config,
+                deploy_url=env_config.deploy_url,
             )
             return_code = run_command(command=cmd, logger=logger, env=env_vars)
             return_codes.append(return_code)
@@ -504,6 +508,7 @@ def main():
                 args.output_path,
                 runtime_config.service_port,
                 runtime_config=runtime_config,
+                deploy_url=env_config.deploy_url,
             )
             return_code = run_command(command=cmd, logger=logger, env=env_vars)
             return_codes.append(return_code)

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -541,7 +541,9 @@ def main():
         return 1
 
 
-def run_media_evals(all_params, model_spec, device, output_path, service_port, deploy_url=None):
+def run_media_evals(
+    all_params, model_spec, device, output_path, service_port, deploy_url=None
+):
     """
     Run media evals for cnn and image models only (not AUDIO models).
 

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -203,11 +203,12 @@ def _build_base_url(deploy_url: str, service_port: str) -> str:
     used and *service_port* is ignored so that the resulting URL is never of
     the form ``http://host:9000:8000``.
     """
-    parsed = urlparse(deploy_url.rstrip("/"))
+    normalized = deploy_url.rstrip("/")
+    parsed = urlparse(normalized)
     if parsed.port is not None:
         # URL already includes a port; use as-is
-        return deploy_url.rstrip("/")
-    return f"{deploy_url.rstrip('/')}:{service_port}"
+        return normalized
+    return f"{normalized}:{service_port}"
 
 
 def build_eval_command(

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import List, Optional
+from urllib.parse import urlparse
 
 import jwt
 
@@ -434,6 +435,21 @@ def parse_args():
     return ret_args
 
 
+def _build_base_url(deploy_url: str, service_port: str) -> str:
+    """Construct a base URL from a deploy URL and service port.
+
+    Normalizes the deploy URL by stripping trailing slashes.  When the URL
+    already contains an explicit port (e.g. ``http://host:9000``) that port is
+    used and *service_port* is ignored so that the resulting URL is never of
+    the form ``http://host:9000:8000``.
+    """
+    parsed = urlparse(deploy_url.rstrip("/"))
+    if parsed.port is not None:
+        # URL already includes a port; use as-is
+        return deploy_url.rstrip("/")
+    return f"{deploy_url.rstrip('/')}:{service_port}"
+
+
 def build_eval_command(
     task: EvalTask,
     model_spec,
@@ -458,10 +474,11 @@ def build_eval_command(
 
     # Audio models use tt-media-server which has endpoints at /audio (not /v1/audio)
     # Other models use vLLM which has endpoints at /v1
+    host_with_port = _build_base_url(deploy_url, service_port)
     if task.workflow_venv_type == WorkflowVenvType.EVALS_AUDIO:
-        base_url = f"{deploy_url}:{service_port}"
+        base_url = host_with_port
     else:
-        base_url = f"{deploy_url}:{service_port}/v1"
+        base_url = f"{host_with_port}/v1"
     eval_class = task.eval_class
     task_venv_config = VENV_CONFIGS[task.workflow_venv_type]
     if task.use_chat_api:
@@ -907,6 +924,7 @@ def main():
             device,
             args.output_path,
             runtime_config.service_port,
+            deploy_url=env_config.deploy_url,
         )
         return return_code
 
@@ -1025,7 +1043,7 @@ def main():
         return 1
 
 
-def run_media_evals(all_params, model_spec, device, output_path, service_port):
+def run_media_evals(all_params, model_spec, device, output_path, service_port, deploy_url=None):
     """
     Run media evals for cnn and image models only (not AUDIO models).
 
@@ -1043,6 +1061,7 @@ def run_media_evals(all_params, model_spec, device, output_path, service_port):
         output_path,
         service_port,
         task_type=MediaTaskType.EVALUATION,
+        deploy_url=deploy_url,
     )
 
 

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -441,6 +441,7 @@ def build_eval_command(
     output_path,
     service_port,
     runtime_config=None,
+    deploy_url: str = "http://127.0.0.1",
 ) -> List[str]:
     """
     Build the command for lm_eval by templating command-line arguments using properties
@@ -458,9 +459,9 @@ def build_eval_command(
     # Audio models use tt-media-server which has endpoints at /audio (not /v1/audio)
     # Other models use vLLM which has endpoints at /v1
     if task.workflow_venv_type == WorkflowVenvType.EVALS_AUDIO:
-        base_url = f"http://127.0.0.1:{service_port}"
+        base_url = f"{deploy_url}:{service_port}"
     else:
-        base_url = f"http://127.0.0.1:{service_port}/v1"
+        base_url = f"{deploy_url}:{service_port}/v1"
     eval_class = task.eval_class
     task_venv_config = VENV_CONFIGS[task.workflow_venv_type]
     if task.use_chat_api:
@@ -893,6 +894,8 @@ def main():
     # explicitly re-read so in-process PromptClient sees later env updates
     # (mirrors run_benchmarks.py:439).
     env_config.vllm_api_key = os.getenv("VLLM_API_KEY")
+    if getattr(runtime_config, "server_url", None):
+        env_config.deploy_url = runtime_config.server_url
 
     if (
         model_spec.model_type in EVAL_TASK_TYPES
@@ -934,6 +937,7 @@ def main():
                 args.output_path,
                 runtime_config.service_port,
                 runtime_config=runtime_config,
+                deploy_url=env_config.deploy_url,
             )
             return_code = run_command(command=cmd, logger=logger, env=env_vars)
             return_codes.append(return_code)
@@ -1003,6 +1007,7 @@ def main():
                 args.output_path,
                 runtime_config.service_port,
                 runtime_config=runtime_config,
+                deploy_url=env_config.deploy_url,
             )
             if not cmd:
                 logger.info("Skipping task %s (no command built)", task.task_name)

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -443,11 +443,12 @@ def _build_base_url(deploy_url: str, service_port: str) -> str:
     used and *service_port* is ignored so that the resulting URL is never of
     the form ``http://host:9000:8000``.
     """
-    parsed = urlparse(deploy_url.rstrip("/"))
+    normalized = deploy_url.rstrip("/")
+    parsed = urlparse(normalized)
     if parsed.port is not None:
         # URL already includes a port; use as-is
-        return deploy_url.rstrip("/")
-    return f"{deploy_url.rstrip('/')}:{service_port}"
+        return normalized
+    return f"{normalized}:{service_port}"
 
 
 def build_eval_command(

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -1044,7 +1044,9 @@ def main():
         return 1
 
 
-def run_media_evals(all_params, model_spec, device, output_path, service_port, deploy_url=None):
+def run_media_evals(
+    all_params, model_spec, device, output_path, service_port, deploy_url=None
+):
     """
     Run media evals for cnn and image models only (not AUDIO models).
 

--- a/run.py
+++ b/run.py
@@ -149,6 +149,13 @@ def parse_arguments():
         default=os.getenv("SERVICE_PORT", "8000"),
     )
     parser.add_argument(
+        "--server-url",
+        type=str,
+        default=None,
+        help="Base URL of an already-running inference server to target (e.g. 'http://192.168.1.10'). "
+        "Overrides the default http://127.0.0.1. Use together with --service-port when not using --docker-server or --local-server.",
+    )
+    parser.add_argument(
         "--bind-host",
         type=str,
         default="0.0.0.0",

--- a/run.py
+++ b/run.py
@@ -325,6 +325,14 @@ def parse_arguments():
         )
     args.device = args.tt_device or args.device
 
+    if args.server_url and (args.docker_server or args.local_server):
+        parser.error(
+            "--server-url cannot be used together with --docker-server or --local-server. "
+            "Use --server-url alone to target an already-running inference server."
+        )
+    if args.server_url:
+        args.server_url = args.server_url.rstrip("/")
+
     args.engine = (
         InferenceEngine.from_string(args.engine).value if args.engine else None
     )

--- a/run.py
+++ b/run.py
@@ -437,8 +437,17 @@ def handle_secrets(runtime_config):
     jwt_secret_required = jwt_secret_required and not runtime_config.interactive
     # --no-auth disables authorization, so JWT_SECRET is not required
     jwt_secret_required = jwt_secret_required and not runtime_config.no_auth
-    # HF_TOKEN is optional for client-side scripts workflows
-    client_side_workflows = {WorkflowType.BENCHMARKS, WorkflowType.EVALS}
+    # HF_TOKEN is optional for client-side scripts workflows. These run
+    # against an inference server (local, docker, or external via
+    # --server-url) and don't need to load HF weights/tokenizers themselves.
+    client_side_workflows = {
+        WorkflowType.BENCHMARKS,
+        WorkflowType.EVALS,
+        WorkflowType.STRESS_TESTS,
+        WorkflowType.TESTS,
+        WorkflowType.SPEC_TESTS,
+        WorkflowType.REPORTS,
+    }
     # --docker-server requires the HF_TOKEN env var to be available
     huggingface_required = (
         workflow_type not in client_side_workflows or runtime_config.docker_server

--- a/run.py
+++ b/run.py
@@ -396,6 +396,14 @@ def parse_arguments():
         )
     args.device = args.tt_device or args.device
 
+    if args.server_url and (args.docker_server or args.local_server):
+        parser.error(
+            "--server-url cannot be used together with --docker-server or --local-server. "
+            "Use --server-url alone to target an already-running inference server."
+        )
+    if args.server_url:
+        args.server_url = args.server_url.rstrip("/")
+
     args.engine = (
         InferenceEngine.from_string(args.engine).value if args.engine else None
     )

--- a/run.py
+++ b/run.py
@@ -402,8 +402,18 @@ def parse_arguments():
             "Use --server-url alone to target an already-running inference server."
         )
     if args.server_url:
-        args.server_url = args.server_url.rstrip("/")
+        from urllib.parse import urlparse
 
+        server_url = args.server_url.strip().rstrip("/")
+        parsed = urlparse(server_url)
+        if not parsed.scheme:
+            server_url = f"http://{server_url}"
+            parsed = urlparse(server_url)
+        if not parsed.hostname:
+            parser.error(
+                "--server-url must include a hostname (e.g. 'http://127.0.0.1')."
+            )
+        args.server_url = server_url
     args.engine = (
         InferenceEngine.from_string(args.engine).value if args.engine else None
     )

--- a/server_tests/base_test.py
+++ b/server_tests/base_test.py
@@ -54,7 +54,8 @@ class BaseTest(ABC):
 
         _parsed = _urlparse(self.deploy_url.rstrip("/"))
         self.base_url = (
-            self.deploy_url.rstrip("/") if _parsed.port is not None
+            self.deploy_url.rstrip("/")
+            if _parsed.port is not None
             else f"{self.deploy_url.rstrip('/')}:{self.service_port}"
         )
         self.timeout = config.get("timeout")
@@ -224,7 +225,8 @@ class BaseTest(ABC):
 
         parsed = urlparse(self.deploy_url.rstrip("/"))
         host_with_port = (
-            self.deploy_url.rstrip("/") if parsed.port is not None
+            self.deploy_url.rstrip("/")
+            if parsed.port is not None
             else f"{self.deploy_url.rstrip('/')}:{service_port}"
         )
         health_url = f"{host_with_port}/tt-liveness"

--- a/server_tests/base_test.py
+++ b/server_tests/base_test.py
@@ -44,6 +44,19 @@ class BaseTest(ABC):
         self.targets = targets
         self.description = description
         self.service_port = os.getenv("SERVICE_PORT", "8000")
+        # DEPLOY_URL is set by the workflow runner from --server-url; keep the
+        # localhost default for direct/manual test invocations.
+        self.deploy_url = os.getenv("DEPLOY_URL", "http://localhost")
+        # Pre-computed base URL (scheme://host[:port]) for test_cases to build
+        # endpoint URLs against. An explicit port on DEPLOY_URL wins over
+        # SERVICE_PORT so test_cases can't end up with a double-port URL.
+        from urllib.parse import urlparse as _urlparse
+
+        _parsed = _urlparse(self.deploy_url.rstrip("/"))
+        self.base_url = (
+            self.deploy_url.rstrip("/") if _parsed.port is not None
+            else f"{self.deploy_url.rstrip('/')}:{self.service_port}"
+        )
         self.timeout = config.get("timeout")
         self.retry_attempts = config.get("retry_attempts")
         self.break_on_failure = config.get("break_on_failure")
@@ -204,7 +217,17 @@ class BaseTest(ABC):
         retry_delay = (
             retry_delay if retry_delay is not None else HEALTH_CHECK_CONFIG.RETRY_DELAY
         )
-        health_url = f"http://localhost:{service_port}/tt-liveness"
+        # If DEPLOY_URL already carries a port, honor it; otherwise append
+        # service_port. Mirrors the urlparse-port-wins rule used by the
+        # benchmark/eval runners.
+        from urllib.parse import urlparse
+
+        parsed = urlparse(self.deploy_url.rstrip("/"))
+        host_with_port = (
+            self.deploy_url.rstrip("/") if parsed.port is not None
+            else f"{self.deploy_url.rstrip('/')}:{service_port}"
+        )
+        health_url = f"{host_with_port}/tt-liveness"
         logger.info("Waiting for server at %s ...", health_url)
 
         for attempt in range(1, max_attempts + 1):

--- a/server_tests/conftest.py
+++ b/server_tests/conftest.py
@@ -2,13 +2,31 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
+import os
 from pathlib import Path
+from urllib.parse import urlparse
+
 import pytest
 import requests
 import json
 from datetime import datetime
 from utils.prompt_client import PromptClient
 from utils.prompt_configs import EnvironmentConfig
+
+
+def _default_endpoint_url() -> str:
+    """Resolve the default --endpoint-url from DEPLOY_URL / SERVICE_PORT env
+    vars (set by the workflow runner from --server-url), falling back to the
+    localhost dev default for direct pytest invocations.
+    """
+    deploy_url = os.environ.get("DEPLOY_URL", "http://127.0.0.1").rstrip("/")
+    parsed = urlparse(deploy_url)
+    if parsed.port is not None:
+        base = deploy_url
+    else:
+        port = os.environ.get("SERVICE_PORT", "8000")
+        base = f"{deploy_url}:{port}"
+    return f"{base}/v1/chat/completions"
 
 
 # 1. Add command-line options for endpoint and metadata
@@ -22,7 +40,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--endpoint-url",
         action="store",
-        default="http://127.0.0.1:8000/v1/chat/completions",
+        default=_default_endpoint_url(),
         help="The URL of the API endpoint to test",
     )
     parser.addoption(

--- a/server_tests/run_spec_tests.py
+++ b/server_tests/run_spec_tests.py
@@ -375,10 +375,34 @@ def parse_args():
     return args
 
 
+def _propagate_deploy_url_from_spec(args: argparse.Namespace) -> None:
+    """Lift --server-url from the runtime spec JSON into the DEPLOY_URL env
+    var so downstream test harnesses (e.g. BaseTest, conftest fixtures) can
+    target the same inference server as the rest of the workflow. No-op when
+    no spec JSON was provided or it lacks server_url.
+    """
+    spec_path = getattr(args, "runtime_model_spec_json", None)
+    if not spec_path:
+        return
+    try:
+        from workflows.runtime_config import RuntimeConfig
+
+        runtime_config = RuntimeConfig.from_json(spec_path)
+    except Exception as exc:  # corrupt JSON / missing fields shouldn't block tests
+        logger.warning("Could not load runtime config from %s: %s", spec_path, exc)
+        return
+    server_url = getattr(runtime_config, "server_url", None)
+    if server_url:
+        os.environ["DEPLOY_URL"] = server_url
+    if getattr(runtime_config, "service_port", None):
+        os.environ.setdefault("SERVICE_PORT", str(runtime_config.service_port))
+
+
 def main() -> int:
     """CLI entry point."""
     _configure_logging()
     args = parse_args()
+    _propagate_deploy_url_from_spec(args)
     return TestFrameworkRunner(args).run()
 
 

--- a/server_tests/run_tests.py
+++ b/server_tests/run_tests.py
@@ -58,12 +58,12 @@ def build_test_command(
         from urllib.parse import urlparse
 
         parsed = urlparse(deploy_url.rstrip("/"))
-        base = deploy_url.rstrip("/") if parsed.port is not None else (
-            f"{deploy_url.rstrip('/')}:{service_port}"
+        base = (
+            deploy_url.rstrip("/")
+            if parsed.port is not None
+            else (f"{deploy_url.rstrip('/')}:{service_port}")
         )
-        test_kwargs_list.extend(
-            ["--endpoint-url", f"{base}/v1/responses"]
-        )
+        test_kwargs_list.extend(["--endpoint-url", f"{base}/v1/responses"])
     cmd = [
         str(test_exec),
         task.test_path,
@@ -145,9 +145,8 @@ def main():
     # runtime config loaded from JSON
     device_str = runtime_config.device
     service_port = runtime_config.service_port
-    deploy_url = (
-        getattr(runtime_config, "server_url", None)
-        or os.environ.get("DEPLOY_URL", "http://127.0.0.1")
+    deploy_url = getattr(runtime_config, "server_url", None) or os.environ.get(
+        "DEPLOY_URL", "http://127.0.0.1"
     )
     # Propagate to subprocesses (pytest, etc.) that read DEPLOY_URL.
     os.environ["DEPLOY_URL"] = deploy_url

--- a/server_tests/run_tests.py
+++ b/server_tests/run_tests.py
@@ -37,6 +37,7 @@ def build_test_command(
     device,
     output_dir_path,
     service_port,
+    deploy_url: str = "http://127.0.0.1",
 ) -> list[str]:
     """
     Build the command for tests by templating command-line arguments using properties
@@ -51,9 +52,17 @@ def build_test_command(
     test_kwargs_list = [f"-{arg}" for arg in task.test_args]
 
     if task.task_name == "vllm_responses":
-        # vLLM responses test needs the service port to connect to the server
+        # vLLM responses test needs the service port to connect to the server.
+        # An explicit port on deploy_url wins over service_port to avoid
+        # double-port URLs when --server-url already carries a port.
+        from urllib.parse import urlparse
+
+        parsed = urlparse(deploy_url.rstrip("/"))
+        base = deploy_url.rstrip("/") if parsed.port is not None else (
+            f"{deploy_url.rstrip('/')}:{service_port}"
+        )
         test_kwargs_list.extend(
-            ["--endpoint-url", f"http://127.0.0.1:{service_port}/v1/responses"]
+            ["--endpoint-url", f"{base}/v1/responses"]
         )
     cmd = [
         str(test_exec),
@@ -136,6 +145,12 @@ def main():
     # runtime config loaded from JSON
     device_str = runtime_config.device
     service_port = runtime_config.service_port
+    deploy_url = (
+        getattr(runtime_config, "server_url", None)
+        or os.environ.get("DEPLOY_URL", "http://127.0.0.1")
+    )
+    # Propagate to subprocesses (pytest, etc.) that read DEPLOY_URL.
+    os.environ["DEPLOY_URL"] = deploy_url
 
     workflow_config = WORKFLOW_TESTS_CONFIG
     logger.info(f"workflow_config=: {workflow_config}")
@@ -169,6 +184,7 @@ def main():
     env_config.jwt_secret = args.jwt_secret
     env_config.service_port = runtime_config.service_port
     env_config.vllm_model = model_spec.hf_model_repo
+    env_config.deploy_url = deploy_url
 
     # Create a single shared output directory for all tasks in this run
     run_timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
@@ -195,6 +211,7 @@ def main():
             device_str,
             str(output_dir_path),
             runtime_config.service_port,
+            deploy_url=deploy_url,
         )
         return_code = run_command(command=cmd, logger=logger, env=env_vars)
         return_codes.append(return_code)

--- a/server_tests/run_tests.py
+++ b/server_tests/run_tests.py
@@ -148,8 +148,13 @@ def main():
     deploy_url = getattr(runtime_config, "server_url", None) or os.environ.get(
         "DEPLOY_URL", "http://127.0.0.1"
     )
-    # Propagate to subprocesses (pytest, etc.) that read DEPLOY_URL.
+    # Propagate to subprocesses (pytest, etc.) that read DEPLOY_URL /
+    # SERVICE_PORT (conftest --endpoint-url default, BaseTest). Without
+    # exporting SERVICE_PORT, a non-default --service-port wouldn't reach
+    # pytest and tests would target :8000. setdefault so an explicit
+    # SERVICE_PORT already in the env still wins.
     os.environ["DEPLOY_URL"] = deploy_url
+    os.environ.setdefault("SERVICE_PORT", str(service_port))
 
     workflow_config = WORKFLOW_TESTS_CONFIG
     logger.info(f"workflow_config=: {workflow_config}")

--- a/server_tests/test_cases/audio_transcription_load_dp2_chunk30_test.py
+++ b/server_tests/test_cases/audio_transcription_load_dp2_chunk30_test.py
@@ -24,7 +24,7 @@ class AudioTranscriptionLoadDp2Chunk30Test(AudioTranscriptionLoadTest):
     """DP2 burst load, 60s audio, chunk 30s. Server: AUDIO_CHUNK_DURATION_SECONDS=30."""
 
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/audio/transcriptions"
+        self.url = f"{self.base_url}/v1/audio/transcriptions"
         num_concurrent = self.targets.get("num_concurrent", 64)
         target_max_duration_s = self.targets.get("max_duration_s", None)
 

--- a/server_tests/test_cases/audio_transcription_load_dp2_chunk5_test.py
+++ b/server_tests/test_cases/audio_transcription_load_dp2_chunk5_test.py
@@ -24,7 +24,7 @@ class AudioTranscriptionLoadDp2Chunk5Test(AudioTranscriptionLoadTest):
     """DP2 burst load, 60s audio, chunk 5s. Server: AUDIO_CHUNK_DURATION_SECONDS=5."""
 
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/audio/transcriptions"
+        self.url = f"{self.base_url}/v1/audio/transcriptions"
         num_concurrent = self.targets.get("num_concurrent", 64)
         target_max_duration_s = self.targets.get("max_duration_s", None)
 

--- a/server_tests/test_cases/audio_transcription_load_test.py
+++ b/server_tests/test_cases/audio_transcription_load_test.py
@@ -33,7 +33,7 @@ headers = {
 
 class AudioTranscriptionLoadTest(BaseTest):
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/audio/transcriptions"
+        self.url = f"{self.base_url}/v1/audio/transcriptions"
         logger.info("AudioTranscriptionLoadTest targets: %s", self.targets)
         num_concurrent_requests = self._get_num_concurrent_requests(default=1)
         audio_transcription_time = self.targets.get(

--- a/server_tests/test_cases/audio_transcription_param_test.py
+++ b/server_tests/test_cases/audio_transcription_param_test.py
@@ -110,7 +110,7 @@ headers = {
 
 class AudioTranscriptionParamTest(BaseTest):
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/audio/transcriptions"
+        self.url = f"{self.base_url}/v1/audio/transcriptions"
         logger.info(f"Testing audio transcription parameters at {self.url}")
 
         # Create list of payloads to test different parameters

--- a/server_tests/test_cases/cnn_load_test.py
+++ b/server_tests/test_cases/cnn_load_test.py
@@ -32,7 +32,7 @@ headers = {
 
 class CnnLoadTest(BaseTest):
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/cnn/search-image"
+        self.url = f"{self.base_url}/v1/cnn/search-image"
         logger.info("CnnLoadTest targets: %s", self.targets)
         num_concurrent_requests = self._get_num_concurrent_requests(default=1)
         cnn_target_time = self.targets.get("cnn_time", 5)  # in seconds

--- a/server_tests/test_cases/cnn_param_test.py
+++ b/server_tests/test_cases/cnn_param_test.py
@@ -58,7 +58,7 @@ headers = {
 
 class CnnParamTest(BaseTest):
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/cnn/search-image"
+        self.url = f"{self.base_url}/v1/cnn/search-image"
         logger.info(f"Testing CNN parameters at {self.url}")
 
         # Create list of payloads to test different parameters

--- a/server_tests/test_cases/device_liveness_test.py
+++ b/server_tests/test_cases/device_liveness_test.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class DeviceLivenessTest(BaseTest):
     async def _run_specific_test_async(self):
-        url = f"http://localhost:{self.service_port}/tt-liveness"
+        url = f"{self.base_url}/tt-liveness"
 
         if (
             self.targets["num_of_devices"] is None

--- a/server_tests/test_cases/device_stability_test.py
+++ b/server_tests/test_cases/device_stability_test.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class DeviceStabilityTest(BaseTest):
     async def _run_specific_test_async(self):
-        url = f"http://localhost:{self.service_port}/tt-liveness"
+        url = f"{self.base_url}/tt-liveness"
 
         if (
             self.targets.get("num_of_devices") is None

--- a/server_tests/test_cases/embedding_load_test.py
+++ b/server_tests/test_cases/embedding_load_test.py
@@ -26,7 +26,7 @@ headers = {
 
 class EmbeddingLoadTest(BaseTest):
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/embeddings"
+        self.url = f"{self.base_url}/v1/embeddings"
         logger.info("EmbeddingLoadTest targets: %s", self.targets)
         num_concurrent_requests = self._get_num_concurrent_requests(default=1)
         embedding_target_time = self.targets.get("embedding_time", 5)  # in seconds

--- a/server_tests/test_cases/embedding_param_test.py
+++ b/server_tests/test_cases/embedding_param_test.py
@@ -35,7 +35,7 @@ headers = {
 
 class EmbeddingParamTest(BaseTest):
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/embeddings"
+        self.url = f"{self.base_url}/v1/embeddings"
         logger.info(f"Testing embedding parameters at {self.url}")
 
         model = self.config.get("model", "test-model")

--- a/server_tests/test_cases/image_generation_eval_test.py
+++ b/server_tests/test_cases/image_generation_eval_test.py
@@ -261,7 +261,7 @@ class ImageGenerationEvalsTest(BaseTest):
             raise RuntimeError("Server health check failed")
 
         ctx = ImageGenContext(
-            base_url=request.server_url or f"http://localhost:{self.service_port}",
+            base_url=request.server_url or f"{self.base_url}",
             headers=self._build_headers(),
             num_inference_steps=request.num_inference_steps,
             request_timeout_sec=timeout_sec,

--- a/server_tests/test_cases/image_generation_load_test.py
+++ b/server_tests/test_cases/image_generation_load_test.py
@@ -31,7 +31,7 @@ headers = {
 
 class ImageGenerationLoadTest(BaseTest):
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/images/generations"
+        self.url = f"{self.base_url}/v1/images/generations"
         logger.info("ImageGenerationLoadTest targets: %s", self.targets)
         num_concurrent_requests = self._get_num_concurrent_requests(default=1)
         image_generation_target_time = self.targets.get(

--- a/server_tests/test_cases/image_generation_lora_load_test.py
+++ b/server_tests/test_cases/image_generation_lora_load_test.py
@@ -124,7 +124,7 @@ class ImageGenerationLoraLoadTest(BaseTest):
     async def _fire_batch(
         self, specs: list[RequestSpec], num_inference_steps: int
     ) -> list[RequestResult]:
-        base_url = f"http://localhost:{self.service_port}"
+        base_url = f"{self.base_url}"
         url = f"{base_url}/{ENDPOINT}"
         headers = {
             "accept": "application/json",

--- a/server_tests/test_cases/image_generation_param_test.py
+++ b/server_tests/test_cases/image_generation_param_test.py
@@ -107,7 +107,7 @@ def compute_image_ssim(response_a, response_b):
 
 class ImageGenerationParamTest(BaseTest):
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/images/generations"
+        self.url = f"{self.base_url}/v1/images/generations"
         logger.info(f"Targets: {self.targets}")
 
         model = self.targets.get("model", "")

--- a/server_tests/test_cases/img2img_generation_param_test.py
+++ b/server_tests/test_cases/img2img_generation_param_test.py
@@ -69,7 +69,7 @@ class Img2ImgGenerationParamTest(BaseTest):
     """
 
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/images/image-to-image"
+        self.url = f"{self.base_url}/v1/images/image-to-image"
         logger.info(f"Testing endpoint: {self.url}")
         logger.info(f"Test targets: {self.targets}")
 

--- a/server_tests/test_cases/inpainting_generation_param_test.py
+++ b/server_tests/test_cases/inpainting_generation_param_test.py
@@ -72,7 +72,7 @@ class InpaintingGenerationParamTest(BaseTest):
     """
 
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/images/edits"
+        self.url = f"{self.base_url}/v1/images/edits"
         logger.info(f"Testing endpoint: {self.url}")
         logger.info(f"Test targets: {self.targets}")
 

--- a/server_tests/test_cases/media_server_liveness_test.py
+++ b/server_tests/test_cases/media_server_liveness_test.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class MediaServerLivenessTest(BaseTest):
     async def _run_specific_test_async(self):
-        url = f"http://localhost:{self.service_port}/tt-liveness"
+        url = f"{self.base_url}/tt-liveness"
 
         try:
             timeout = aiohttp.ClientTimeout(total=30)  # 30 second timeout

--- a/server_tests/test_cases/server_helper.py
+++ b/server_tests/test_cases/server_helper.py
@@ -9,8 +9,25 @@ from pathlib import Path
 
 SERVER_STARTUP_TIMEOUT = 5 * 60  # wait up to 5 minutes for server to start
 SERVER_SHUTDOWN_TIMEOUT = 20
+
+
+def _build_server_base_url() -> str:
+    """Resolve the server base URL from DEPLOY_URL / SERVICE_PORT (set by
+    the workflow runner from --server-url), defaulting to localhost for
+    direct script invocations.
+    """
+    from urllib.parse import urlparse
+
+    deploy_url = os.environ.get("DEPLOY_URL", "http://127.0.0.1").rstrip("/")
+    parsed = urlparse(deploy_url)
+    if parsed.port is not None:
+        return deploy_url
+    port = os.environ.get("SERVICE_PORT", "8000")
+    return f"{deploy_url}:{port}"
+
+
 # Base URL (host:port only) for building v1 API paths in eval tests
-SERVER_BASE_URL = "http://127.0.0.1:8000"
+SERVER_BASE_URL = _build_server_base_url()
 # Full URL to CNN search-image endpoint
 SERVER_DEFAULT_URL = f"{SERVER_BASE_URL}/v1/cnn/search-image"
 DEFAULT_AUTHORIZATION = "your-secret-key"

--- a/server_tests/test_cases/speecht5_tts_test.py
+++ b/server_tests/test_cases/speecht5_tts_test.py
@@ -37,7 +37,7 @@ class SpeechT5TTSTest(BaseTest):
 
     async def _test_basic_tts(self):
         """Test basic text-to-speech generation"""
-        url = f"http://localhost:{self.service_port}/v1/audio/speech"
+        url = f"{self.base_url}/v1/audio/speech"
 
         # The TTS endpoint returns raw `audio/wav` bytes by default; the
         # JSON envelope (with `audio` base64, `duration`, `sample_rate`,

--- a/server_tests/test_cases/tts_integration_test.py
+++ b/server_tests/test_cases/tts_integration_test.py
@@ -40,7 +40,7 @@ class TTSIntegrationTest(BaseTest):
     async def _run_specific_test_async(self):
         """Run integration tests for TTS API."""
         test_start_time = time.time()
-        self.url = f"http://localhost:{self.service_port}/v1/audio/speech"
+        self.url = f"{self.base_url}/v1/audio/speech"
 
         results = {
             "empty_text": None,

--- a/server_tests/test_cases/tts_load_test.py
+++ b/server_tests/test_cases/tts_load_test.py
@@ -62,7 +62,7 @@ class TTSLoadTest(BaseTest):
 
     async def _run_specific_test_async(self):
         test_start_time = time.time()
-        self.url = f"http://localhost:{self.service_port}/v1/audio/speech"
+        self.url = f"{self.base_url}/v1/audio/speech"
 
         num_concurrent_requests = self._get_num_concurrent_requests(default=1)
         tts_target_time = self.targets.get("tts_generation_time", 10)

--- a/server_tests/test_cases/tts_param_test.py
+++ b/server_tests/test_cases/tts_param_test.py
@@ -51,7 +51,7 @@ headers = {
 
 class TTSParamTest(BaseTest):
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/audio/speech"
+        self.url = f"{self.base_url}/v1/audio/speech"
 
         payloads = [
             default_payload,

--- a/server_tests/test_cases/tts_quality_test.py
+++ b/server_tests/test_cases/tts_quality_test.py
@@ -53,7 +53,7 @@ class TTSQualityTest(BaseTest):
 
     async def _run_specific_test_async(self):
         test_start_time = time.time()
-        self.url = f"http://localhost:{self.service_port}/v1/audio/speech"
+        self.url = f"{self.base_url}/v1/audio/speech"
 
         # Configuration
         sample_count = self.targets.get("sample_count", 10)

--- a/server_tests/test_cases/video_generation_i2v_param_test.py
+++ b/server_tests/test_cases/video_generation_i2v_param_test.py
@@ -90,7 +90,7 @@ class VideoGenerationI2VParamTest(BaseTest):
     """Parameter-sweep happy-path coverage for the I2V endpoint."""
 
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/videos/generations/i2v"
+        self.url = f"{self.base_url}/v1/videos/generations/i2v"
         logger.info(f"Testing I2V parameters at {self.url}")
 
         model_name = self.config.get("model", "test-model")

--- a/server_tests/test_cases/video_generation_i2v_test.py
+++ b/server_tests/test_cases/video_generation_i2v_test.py
@@ -71,7 +71,7 @@ class VideoGenerationI2VTest(BaseTest):
     """Happy-path test for the I2V endpoint end-to-end."""
 
     async def _run_specific_test_async(self):
-        self.base_url = f"http://localhost:{self.service_port}"
+        self.base_url = f"{self.base_url}"
         self.poll_timeout = self.targets.get(
             "poll_timeout", DEFAULT_POLL_TIMEOUT_SECONDS
         )

--- a/server_tests/test_cases/video_generation_i2v_test.py
+++ b/server_tests/test_cases/video_generation_i2v_test.py
@@ -71,7 +71,7 @@ class VideoGenerationI2VTest(BaseTest):
     """Happy-path test for the I2V endpoint end-to-end."""
 
     async def _run_specific_test_async(self):
-        self.base_url = f"{self.base_url}"
+        # base_url is computed by BaseTest from DEPLOY_URL / SERVICE_PORT.
         self.poll_timeout = self.targets.get(
             "poll_timeout", DEFAULT_POLL_TIMEOUT_SECONDS
         )

--- a/server_tests/test_cases/video_generation_load_test.py
+++ b/server_tests/test_cases/video_generation_load_test.py
@@ -29,7 +29,7 @@ headers = {
 
 class VideoGenerationLoadTest(BaseTest):
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/videos/generations"
+        self.url = f"{self.base_url}/v1/videos/generations"
         logger.info("VideoGenerationLoadTest targets: %s", self.targets)
         num_concurrent_requests = self._get_num_concurrent_requests(default=1)
         video_generation_target_time = self.targets.get(

--- a/server_tests/test_cases/video_generation_param_test.py
+++ b/server_tests/test_cases/video_generation_param_test.py
@@ -64,7 +64,7 @@ headers = {
 
 class VideoGenerationParamTest(BaseTest):
     async def _run_specific_test_async(self):
-        self.url = f"http://localhost:{self.service_port}/v1/videos/generations"
+        self.url = f"{self.base_url}/v1/videos/generations"
         logger.info(f"Testing video generation parameters at {self.url}")
 
         # Determine model name and get appropriate num_inference_steps

--- a/stress_tests/stress_tests_args.py
+++ b/stress_tests/stress_tests_args.py
@@ -11,6 +11,7 @@ into a single well-typed dataclass with explicit precedence rules.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
@@ -39,6 +40,7 @@ class StressTestsArgs:
     model: str
     device: str
     service_port: str = "8000"
+    deploy_url: str = "http://127.0.0.1"
 
     # From RuntimeConfig (stress tests specific)
     disable_trace_capture: bool = False
@@ -88,6 +90,10 @@ class StressTestsArgs:
             model=runtime_config.model,
             device=runtime_config.device,
             service_port=runtime_config.service_port,
+            deploy_url=(
+                getattr(runtime_config, "server_url", None)
+                or os.environ.get("DEPLOY_URL", "http://127.0.0.1")
+            ),
             # From RuntimeConfig (stress tests configuration)
             # Auto-disable trace capture if model has builtin warmup and user hasn't explicitly overridden
             disable_trace_capture=runtime_config.disable_trace_capture

--- a/stress_tests/stress_tests_core.py
+++ b/stress_tests/stress_tests_core.py
@@ -722,7 +722,8 @@ class StressTests:
         parsed = urlparse(self.test_args.deploy_url.rstrip("/"))
         sub_host = parsed.hostname or "127.0.0.1"
         sub_port = (
-            str(parsed.port) if parsed.port is not None
+            str(parsed.port)
+            if parsed.port is not None
             else str(self.env_config.service_port)
         )
         cmd = [

--- a/stress_tests/stress_tests_core.py
+++ b/stress_tests/stress_tests_core.py
@@ -29,6 +29,7 @@ and automatically applies context limit constraints with adjustment when needed.
 import os
 import logging
 import subprocess
+from urllib.parse import urlparse
 import time
 from datetime import datetime
 from pathlib import Path
@@ -683,6 +684,7 @@ class StressTests:
         env_config.jwt_secret = self.test_args.jwt_secret
         env_config.service_port = self.test_args.service_port
         env_config.vllm_model = model_spec.hf_model_repo
+        env_config.deploy_url = self.test_args.deploy_url
 
         prompt_client = PromptClient(env_config)
         prompt_client.wait_for_healthy(timeout=7200.0)
@@ -714,6 +716,15 @@ class StressTests:
             str(self.test_args.project_root)
             + "/stress_tests/stress_tests_benchmarking_script.py"
         )
+        # An explicit port on deploy_url wins over service_port to avoid
+        # --host h --port <service_port> against a server actually on a
+        # different port (mirrors run_benchmarks._resolve_host_port).
+        parsed = urlparse(self.test_args.deploy_url.rstrip("/"))
+        sub_host = parsed.hostname or "127.0.0.1"
+        sub_port = (
+            str(parsed.port) if parsed.port is not None
+            else str(self.env_config.service_port)
+        )
         cmd = [
             str(self.test_args.project_root)
             + "/.workflow_venvs/.venv_stress_tests_run_script/bin/python",
@@ -722,8 +733,10 @@ class StressTests:
             "vllm",
             "--model",
             str(self.env_config.vllm_model),
+            "--host",
+            sub_host,
             "--port",
-            str(self.env_config.service_port),
+            sub_port,
             "--dataset-name",
             "cleaned-random",
             "--max-concurrency",

--- a/utils/media_clients/audio_client.py
+++ b/utils/media_clients/audio_client.py
@@ -38,8 +38,8 @@ logger = logging.getLogger(__name__)
 class AudioClientStrategy(BaseMediaStrategy):
     """Strategy for audio models (Whisper, etc.)."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port):
-        super().__init__(all_params, model_spec, device, output_path, service_port)
+    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
+        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
 
         # Initialize tokenizer
         self.tokenizer = None

--- a/utils/media_clients/audio_client.py
+++ b/utils/media_clients/audio_client.py
@@ -38,8 +38,17 @@ logger = logging.getLogger(__name__)
 class AudioClientStrategy(BaseMediaStrategy):
     """Strategy for audio models (Whisper, etc.)."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
-        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
+    def __init__(
+        self, all_params, model_spec, device, output_path, service_port, deploy_url=None
+    ):
+        super().__init__(
+            all_params,
+            model_spec,
+            device,
+            output_path,
+            service_port,
+            deploy_url=deploy_url,
+        )
 
         # Initialize tokenizer
         self.tokenizer = None

--- a/utils/media_clients/base_strategy_interface.py
+++ b/utils/media_clients/base_strategy_interface.py
@@ -4,6 +4,7 @@
 
 import logging
 from abc import ABC, abstractmethod
+from urllib.parse import urlparse
 
 from server_tests.test_cases.device_liveness_test import DeviceLivenessTest
 from server_tests.test_classes import TestConfig
@@ -26,8 +27,12 @@ class BaseMediaStrategy(ABC):
         self.device = device
         self.output_path = output_path
         self.service_port = service_port
-        host = deploy_url.rstrip("/") if deploy_url else "http://localhost"
-        self.base_url = f"{host}:{service_port}"
+        if deploy_url:
+            normalized = deploy_url.rstrip("/")
+            parsed = urlparse(normalized)
+            self.base_url = normalized if parsed.port is not None else f"{normalized}:{service_port}"
+        else:
+            self.base_url = f"http://localhost:{service_port}"
         self.test_payloads_path = "utils/test_payloads"
 
     @abstractmethod

--- a/utils/media_clients/base_strategy_interface.py
+++ b/utils/media_clients/base_strategy_interface.py
@@ -20,13 +20,14 @@ logger = logging.getLogger(__name__)
 class BaseMediaStrategy(ABC):
     """Interface for media strategies."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port):
+    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
         self.all_params = all_params
         self.model_spec = model_spec
         self.device = device
         self.output_path = output_path
         self.service_port = service_port
-        self.base_url = f"http://localhost:{service_port}"
+        host = deploy_url.rstrip("/") if deploy_url else "http://localhost"
+        self.base_url = f"{host}:{service_port}"
         self.test_payloads_path = "utils/test_payloads"
 
     @abstractmethod

--- a/utils/media_clients/base_strategy_interface.py
+++ b/utils/media_clients/base_strategy_interface.py
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)
 class BaseMediaStrategy(ABC):
     """Interface for media strategies."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
+    def __init__(
+        self, all_params, model_spec, device, output_path, service_port, deploy_url=None
+    ):
         self.all_params = all_params
         self.model_spec = model_spec
         self.device = device
@@ -30,7 +32,11 @@ class BaseMediaStrategy(ABC):
         if deploy_url:
             normalized = deploy_url.rstrip("/")
             parsed = urlparse(normalized)
-            self.base_url = normalized if parsed.port is not None else f"{normalized}:{service_port}"
+            self.base_url = (
+                normalized
+                if parsed.port is not None
+                else f"{normalized}:{service_port}"
+            )
         else:
             self.base_url = f"http://localhost:{service_port}"
         self.test_payloads_path = "utils/test_payloads"

--- a/utils/media_clients/base_strategy_interface.py
+++ b/utils/media_clients/base_strategy_interface.py
@@ -54,7 +54,9 @@ class PerfCheck:
 class BaseMediaStrategy(ABC):
     """Interface for media strategies."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
+    def __init__(
+        self, all_params, model_spec, device, output_path, service_port, deploy_url=None
+    ):
         self.all_params = all_params
         self.model_spec = model_spec
         self.device = device
@@ -63,7 +65,11 @@ class BaseMediaStrategy(ABC):
         if deploy_url:
             normalized = deploy_url.rstrip("/")
             parsed = urlparse(normalized)
-            self.base_url = normalized if parsed.port is not None else f"{normalized}:{service_port}"
+            self.base_url = (
+                normalized
+                if parsed.port is not None
+                else f"{normalized}:{service_port}"
+            )
         else:
             self.base_url = f"http://localhost:{service_port}"
         self.test_payloads_path = "utils/test_payloads"

--- a/utils/media_clients/base_strategy_interface.py
+++ b/utils/media_clients/base_strategy_interface.py
@@ -53,13 +53,14 @@ class PerfCheck:
 class BaseMediaStrategy(ABC):
     """Interface for media strategies."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port):
+    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
         self.all_params = all_params
         self.model_spec = model_spec
         self.device = device
         self.output_path = output_path
         self.service_port = service_port
-        self.base_url = f"http://localhost:{service_port}"
+        host = deploy_url.rstrip("/") if deploy_url else "http://localhost"
+        self.base_url = f"{host}:{service_port}"
         self.test_payloads_path = "utils/test_payloads"
 
     @abstractmethod

--- a/utils/media_clients/base_strategy_interface.py
+++ b/utils/media_clients/base_strategy_interface.py
@@ -7,6 +7,7 @@ import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence
+from urllib.parse import urlparse
 
 from server_tests.test_cases.device_liveness_test import DeviceLivenessTest
 from server_tests.test_classes import TestConfig
@@ -59,8 +60,12 @@ class BaseMediaStrategy(ABC):
         self.device = device
         self.output_path = output_path
         self.service_port = service_port
-        host = deploy_url.rstrip("/") if deploy_url else "http://localhost"
-        self.base_url = f"{host}:{service_port}"
+        if deploy_url:
+            normalized = deploy_url.rstrip("/")
+            parsed = urlparse(normalized)
+            self.base_url = normalized if parsed.port is not None else f"{normalized}:{service_port}"
+        else:
+            self.base_url = f"http://localhost:{service_port}"
         self.test_payloads_path = "utils/test_payloads"
 
     @abstractmethod

--- a/utils/media_clients/embedding_client.py
+++ b/utils/media_clients/embedding_client.py
@@ -35,8 +35,17 @@ MTEB_TASKS = ["STS12"]  # add AmazonCounterfactualClassification for classificat
 class EmbeddingClientStrategy(BaseMediaStrategy):
     """Strategy for embedding models."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
-        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
+    def __init__(
+        self, all_params, model_spec, device, output_path, service_port, deploy_url=None
+    ):
+        super().__init__(
+            all_params,
+            model_spec,
+            device,
+            output_path,
+            service_port,
+            deploy_url=deploy_url,
+        )
         self.model = self.model_spec.hf_model_repo
         self.isl = int(
             model_spec.device_model_spec.env_vars.get("VLLM__MAX_MODEL_LENGTH", 1024)

--- a/utils/media_clients/embedding_client.py
+++ b/utils/media_clients/embedding_client.py
@@ -35,8 +35,8 @@ MTEB_TASKS = ["STS12"]  # add AmazonCounterfactualClassification for classificat
 class EmbeddingClientStrategy(BaseMediaStrategy):
     """Strategy for embedding models."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port):
-        super().__init__(all_params, model_spec, device, output_path, service_port)
+    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
+        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
         self.model = self.model_spec.hf_model_repo
         self.isl = int(
             model_spec.device_model_spec.env_vars.get("VLLM__MAX_MODEL_LENGTH", 1024)

--- a/utils/media_clients/embedding_client.py
+++ b/utils/media_clients/embedding_client.py
@@ -52,8 +52,8 @@ def _ms_to_seconds_or_none(value_ms):
 class EmbeddingClientStrategy(BaseMediaStrategy):
     """Strategy for embedding models."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port):
-        super().__init__(all_params, model_spec, device, output_path, service_port)
+    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
+        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
         self.model = self.model_spec.hf_model_repo
         self.isl = int(
             model_spec.device_model_spec.env_vars.get("VLLM__MAX_MODEL_LENGTH", 1024)

--- a/utils/media_clients/embedding_client.py
+++ b/utils/media_clients/embedding_client.py
@@ -52,8 +52,17 @@ def _ms_to_seconds_or_none(value_ms):
 class EmbeddingClientStrategy(BaseMediaStrategy):
     """Strategy for embedding models."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
-        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
+    def __init__(
+        self, all_params, model_spec, device, output_path, service_port, deploy_url=None
+    ):
+        super().__init__(
+            all_params,
+            model_spec,
+            device,
+            output_path,
+            service_port,
+            deploy_url=deploy_url,
+        )
         self.model = self.model_spec.hf_model_repo
         self.isl = int(
             model_spec.device_model_spec.env_vars.get("VLLM__MAX_MODEL_LENGTH", 1024)

--- a/utils/media_clients/image_client.py
+++ b/utils/media_clients/image_client.py
@@ -65,8 +65,17 @@ STRENGTH_INPAINTING = 0.99
 class ImageClientStrategy(BaseMediaStrategy):
     """Strategy for image models (SDXL, etc)."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
-        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
+    def __init__(
+        self, all_params, model_spec, device, output_path, service_port, deploy_url=None
+    ):
+        super().__init__(
+            all_params,
+            model_spec,
+            device,
+            output_path,
+            service_port,
+            deploy_url=deploy_url,
+        )
 
         # Map runners to their benchmark methods
         self.benchmark_methods = {

--- a/utils/media_clients/image_client.py
+++ b/utils/media_clients/image_client.py
@@ -65,8 +65,8 @@ STRENGTH_INPAINTING = 0.99
 class ImageClientStrategy(BaseMediaStrategy):
     """Strategy for image models (SDXL, etc)."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port):
-        super().__init__(all_params, model_spec, device, output_path, service_port)
+    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
+        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
 
         # Map runners to their benchmark methods
         self.benchmark_methods = {

--- a/utils/media_clients/image_client.py
+++ b/utils/media_clients/image_client.py
@@ -67,8 +67,17 @@ STRENGTH_INPAINTING = 0.99
 class ImageClientStrategy(BaseMediaStrategy):
     """Strategy for image models (SDXL, etc)."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
-        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
+    def __init__(
+        self, all_params, model_spec, device, output_path, service_port, deploy_url=None
+    ):
+        super().__init__(
+            all_params,
+            model_spec,
+            device,
+            output_path,
+            service_port,
+            deploy_url=deploy_url,
+        )
 
         # Map runners to their benchmark methods
         self.benchmark_methods = {

--- a/utils/media_clients/image_client.py
+++ b/utils/media_clients/image_client.py
@@ -67,8 +67,8 @@ STRENGTH_INPAINTING = 0.99
 class ImageClientStrategy(BaseMediaStrategy):
     """Strategy for image models (SDXL, etc)."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port):
-        super().__init__(all_params, model_spec, device, output_path, service_port)
+    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
+        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
 
         # Map runners to their benchmark methods
         self.benchmark_methods = {

--- a/utils/media_clients/media_client_factory.py
+++ b/utils/media_clients/media_client_factory.py
@@ -64,7 +64,14 @@ class MediaClientFactory:
         strategy = STRATEGY_MAP.get(model_spec.model_type.name)
         if strategy:
             logger.info(f"Using strategy: {strategy.__name__} for client.")
-            return strategy(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
+            return strategy(
+                all_params,
+                model_spec,
+                device,
+                output_path,
+                service_port,
+                deploy_url=deploy_url,
+            )
 
         raise ValueError(
             f"Unsupported model type: {model_spec.model_type.name}. Supported types: {', '.join(STRATEGY_MAP.keys())}"
@@ -104,7 +111,12 @@ class MediaClientFactory:
         try:
             # Create appropriate test case
             test_case = MediaClientFactory._create_strategy(
-                model_spec, all_params, device, output_path, service_port, deploy_url=deploy_url
+                model_spec,
+                all_params,
+                device,
+                output_path,
+                service_port,
+                deploy_url=deploy_url,
             )
 
             # Run the specified task using test_case

--- a/utils/media_clients/media_client_factory.py
+++ b/utils/media_clients/media_client_factory.py
@@ -38,7 +38,7 @@ class MediaClientFactory:
 
     @staticmethod
     def _create_strategy(
-        model_spec, all_params, device, output_path, service_port
+        model_spec, all_params, device, output_path, service_port, deploy_url=None
     ) -> BaseMediaStrategy:
         """
         Create appropriate strategy based on model type.
@@ -49,6 +49,8 @@ class MediaClientFactory:
             device: Device information
             output_path: Output path for results
             service_port: Service port number
+            deploy_url: Optional base URL of the inference server. When omitted,
+                strategies default to ``http://localhost``.
 
         Returns:
             BaseMediaStrategy: Appropriate strategy instance
@@ -62,7 +64,7 @@ class MediaClientFactory:
         strategy = STRATEGY_MAP.get(model_spec.model_type.name)
         if strategy:
             logger.info(f"Using strategy: {strategy.__name__} for client.")
-            return strategy(all_params, model_spec, device, output_path, service_port)
+            return strategy(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
 
         raise ValueError(
             f"Unsupported model type: {model_spec.model_type.name}. Supported types: {', '.join(STRATEGY_MAP.keys())}"
@@ -76,6 +78,7 @@ class MediaClientFactory:
         output_path,
         service_port,
         task_type: MediaTaskType,
+        deploy_url=None,
     ) -> int:
         """
         Generic function to run media tasks (evaluation or benchmarking).
@@ -87,6 +90,8 @@ class MediaClientFactory:
             output_path: Output path for results
             service_port: Service port number
             task_type: MediaTaskType enum value (EVALUATION or BENCHMARK)
+            deploy_url: Optional base URL of the inference server. When omitted,
+                strategies default to ``http://localhost``.
 
         Returns:
             int: Return code (0 for success, 1 for failure)
@@ -99,7 +104,7 @@ class MediaClientFactory:
         try:
             # Create appropriate test case
             test_case = MediaClientFactory._create_strategy(
-                model_spec, all_params, device, output_path, service_port
+                model_spec, all_params, device, output_path, service_port, deploy_url=deploy_url
             )
 
             # Run the specified task using test_case

--- a/utils/media_clients/tts_client.py
+++ b/utils/media_clients/tts_client.py
@@ -35,8 +35,8 @@ DEFAULT_TTS_TEXT = "Hello, this is a test of the text to speech system."
 class TtsClientStrategy(BaseMediaStrategy):
     """Strategy for text-to-speech models (SpeechT5, etc.)."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port):
-        super().__init__(all_params, model_spec, device, output_path, service_port)
+    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
+        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
 
         self.tokenizer = None
         try:

--- a/utils/media_clients/tts_client.py
+++ b/utils/media_clients/tts_client.py
@@ -35,8 +35,17 @@ DEFAULT_TTS_TEXT = "Hello, this is a test of the text to speech system."
 class TtsClientStrategy(BaseMediaStrategy):
     """Strategy for text-to-speech models (SpeechT5, etc.)."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
-        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
+    def __init__(
+        self, all_params, model_spec, device, output_path, service_port, deploy_url=None
+    ):
+        super().__init__(
+            all_params,
+            model_spec,
+            device,
+            output_path,
+            service_port,
+            deploy_url=deploy_url,
+        )
 
         self.tokenizer = None
         try:

--- a/utils/media_clients/tts_client.py
+++ b/utils/media_clients/tts_client.py
@@ -34,8 +34,8 @@ DEFAULT_TTS_TEXT = "Hello, this is a test of the text to speech system."
 class TtsClientStrategy(BaseMediaStrategy):
     """Strategy for text-to-speech models (SpeechT5, etc.)."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port):
-        super().__init__(all_params, model_spec, device, output_path, service_port)
+    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
+        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
 
         self.tokenizer = None
         try:

--- a/utils/media_clients/tts_client.py
+++ b/utils/media_clients/tts_client.py
@@ -34,8 +34,17 @@ DEFAULT_TTS_TEXT = "Hello, this is a test of the text to speech system."
 class TtsClientStrategy(BaseMediaStrategy):
     """Strategy for text-to-speech models (SpeechT5, etc.)."""
 
-    def __init__(self, all_params, model_spec, device, output_path, service_port, deploy_url=None):
-        super().__init__(all_params, model_spec, device, output_path, service_port, deploy_url=deploy_url)
+    def __init__(
+        self, all_params, model_spec, device, output_path, service_port, deploy_url=None
+    ):
+        super().__init__(
+            all_params,
+            model_spec,
+            device,
+            output_path,
+            service_port,
+            deploy_url=deploy_url,
+        )
 
         self.tokenizer = None
         try:

--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -139,7 +139,8 @@ class PromptClient:
         deploy_url = self.env_config.deploy_url.rstrip("/")
         parsed = urlparse(deploy_url)
         base = (
-            deploy_url if parsed.port is not None
+            deploy_url
+            if parsed.port is not None
             else f"{deploy_url}:{self.env_config.service_port}"
         )
         return f"{base}/v1" if include_v1 else base

--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -131,7 +131,17 @@ class PromptClient:
             include_v1: If True, append /v1 for OpenAI-compatible endpoints.
                        If False, return root URL for vLLM-specific endpoints.
         """
-        base = f"{self.env_config.deploy_url}:{self.env_config.service_port}"
+        # An explicit port on deploy_url wins over service_port to avoid
+        # malformed double-port URLs like http://host:9000:8000 when
+        # --server-url already carries a port (e.g. via kubectl port-forward).
+        from urllib.parse import urlparse
+
+        deploy_url = self.env_config.deploy_url.rstrip("/")
+        parsed = urlparse(deploy_url)
+        base = (
+            deploy_url if parsed.port is not None
+            else f"{deploy_url}:{self.env_config.service_port}"
+        )
         return f"{base}/v1" if include_v1 else base
 
     def _get_api_completions_url(self) -> str:

--- a/workflows/runtime_config.py
+++ b/workflows/runtime_config.py
@@ -44,6 +44,7 @@ class RuntimeConfig:
     interactive: bool = False
     service_port: str = "8000"
     bind_host: str = "0.0.0.0"
+    server_url: Optional[str] = None
 
     # Dev / override
     dev_mode: bool = False
@@ -112,6 +113,7 @@ class RuntimeConfig:
             interactive=args.interactive,
             service_port=args.service_port,
             bind_host=args.bind_host,
+            server_url=args.server_url,
             dev_mode=args.dev_mode,
             no_auth=args.no_auth,
             print_docker_cmd=args.print_docker_cmd,

--- a/workflows/runtime_config.py
+++ b/workflows/runtime_config.py
@@ -44,6 +44,7 @@ class RuntimeConfig:
     interactive: bool = False
     service_port: str = "8000"
     bind_host: str = "0.0.0.0"
+    server_url: Optional[str] = None
 
     # Dev / override
     dev_mode: bool = False
@@ -113,6 +114,7 @@ class RuntimeConfig:
             interactive=args.interactive,
             service_port=args.service_port,
             bind_host=args.bind_host,
+            server_url=args.server_url,
             dev_mode=args.dev_mode,
             no_auth=args.no_auth,
             print_docker_cmd=args.print_docker_cmd,


### PR DESCRIPTION
Adds a new CLI option to target an already-running inference server by URL and propagates that configuration into runtime config / eval execution.

Addresses https://github.com/tenstorrent/tt-inference-server/issues/971

## How this was tested:

- Start a pod on the remote galaxy server via helm install
- Target it via ClusterIP
- Ru individual workflows and pass ClusetIP as cli arg:

```
python3 run.py --model Llama-3.1-8B-Instruct --workflow evals \
  --tt-device galaxy \
  --server-url http://10.43.210.204 --service-port 8000 \
  --disable-trace-capture --limit-samples-mode smoke-test
```

```
python3 run.py --model Llama-3.1-8B-Instruct --workflow benchmarks \
  --tt-device galaxy --tools vllm \
  --server-url http://10.43.210.204:8000 \
  --disable-trace-capture
```

```
python3 run.py --model Llama-3.1-8B-Instruct --workflow benchmarks \
  --tt-device galaxy --tools genai \
  --server-url http://10.43.210.204 --service-port 8000 \
  --disable-trace-capture --limit-samples-mode smoke-test
```

## One sanity Models CI release workflow run

https://github.com/tenstorrent/tt-shield/actions/runs/26751762414

## Changes Made

- **`--server-url` CLI argument** (`run.py`): Introduces `--server-url` for targeting an existing inference server. The flag is mutually exclusive with `--docker-server` and `--local-server` — an error is raised if they are combined. The URL is normalized (trailing slashes stripped) at parse time.
- **`RuntimeConfig.server_url`** (`workflows/runtime_config.py`): Stores the `--server-url` value in the persisted runtime configuration.
- **URL normalization** (`evals/run_evals.py`): Added `_build_base_url(deploy_url, service_port)` helper using `urllib.parse` that strips trailing slashes and correctly handles URLs that already include an explicit port, preventing invalid double-port URLs like `http://host:9000:8000`.
- **Eval command construction** (`evals/run_evals.py`): Uses the normalized `deploy_url` via `_build_base_url()` when building eval base URLs instead of raw string concatenation.
- **Media evals `deploy_url` threading** (`evals/run_evals.py`, `utils/media_clients/`): `server_url` from runtime config is now propagated through the full media evals call chain — `run_media_evals()` → `MediaClientFactory.run_media_task()` → `MediaClientFactory._create_strategy()` → `BaseMediaStrategy.__init__()` — replacing the previously hardcoded `http://localhost` base URL. All concrete strategy subclasses (`AudioClientStrategy`, `EmbeddingClientStrategy`, `ImageClientStrategy`, `TtsClientStrategy`) accept and forward the new optional `deploy_url` kwarg.