### PR TITLE
fix(wan22): use mounted local weights and cache TT weights across restarts

### DIFF
--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -297,10 +297,15 @@ class TTMochi1Runner(TTDiTRunner):
 class TTWan22Runner(TTDiTRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
+        cache_root = os.environ.get("CACHE_ROOT", "/tmp")
+        os.environ["TT_DIT_CACHE_DIR"] = os.path.join(cache_root, "tt_dit_cache")
 
     def create_pipeline(self):
         try:
-            return WanPipeline.create_pipeline(mesh_device=self.ttnn_device)
+            return WanPipeline.create_pipeline(
+                checkpoint_name=self.settings.model_weights_path,
+                mesh_device=self.ttnn_device,
+            )
         except Exception as e:
             log_exception_chain(
                 self.logger,


### PR DESCRIPTION
## Problem

Wan2.2 inference server was consistently timing out during model warmup on multi-chip runners (BHQBGE, T3K), causing `500 Internal Server Error` on `/tt-liveness` and the job to fail with:

```
ttnn.distribute block timed out (1200 s)
SubDeviceManagerTracker is not initialized on MeshDevice 0
```

Two compounding root causes:

**1. HF weights re-downloaded on every run**

`TTWan22Runner.create_pipeline()` called `WanPipeline.create_pipeline()` without a `checkpoint_name`, so it fell back to the hardcoded HF repo ID default `"Wan-AI/Wan2.2-T2V-A14B-Diffusers"` and re-downloaded all 27 model files (~15-17 minutes) on every container start — even though `setup_host.py` had already downloaded them to the host before launching Docker.

`TTFlux1Runner` and `TTQwenImageRunner` already solve this correctly by passing `checkpoint_name=self.settings.model_weights_path`, which resolves to the already-mounted local snapshot directory. Wan2.2 was the only runner that didn't do this.

**2. TT-converted weights rebuilt on every run**

`TTWan22Runner` was the only DiT runner that did not set `TT_DIT_CACHE_DIR`, so `cache.load_model()` had no directory to write to and rebuilt TT-format weights from the PyTorch state dict on every container restart.

Together these pushed total startup time well past the 1200-second `weights_distribution_timeout`.

## Fix

Single file changed: `tt-media-server/tt_model_runners/dit_runners.py`

1. `create_pipeline()`: pass `checkpoint_name=self.settings.model_weights_path` — identical pattern to Flux and Qwen. `from_pretrained()` resolves the already-mounted local path and skips all network access.

2. `__init__()`: set `TT_DIT_CACHE_DIR` to `{CACHE_ROOT}/tt_dit_cache`, inside the bind-mounted host volume so converted weights survive container restarts. Falls back to `/tmp` for local dev / unit tests.

## First-run note

The TT weight cache will be empty on the first run after this lands; the runner will rebuild and cache the weights. That run will be slower than steady-state but should complete within the timeout since the ~15-17 min HF download is now eliminated. All subsequent runs will be fast on both axes.

Fixes: https://github.com/tenstorrent/tt-metal/issues/39307