### PR TITLE
Extract SSE streaming from LLM controller into SseStreamWriter

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -377,6 +377,7 @@ set(SOURCES
     src/main.cpp
     src/profiling/tracy.cpp
     src/api/llm_controller.cpp
+    src/api/sse_stream_writer.cpp
     src/api/health_controller.cpp
     src/api/openapi.cpp
     src/filters/security_filter.cpp

--- a/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
+++ b/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
@@ -33,14 +33,6 @@ struct StreamParams {
   std::shared_ptr<services::SessionManager> sessionManager;
 };
 
-/**
- * Encapsulates SSE streaming infrastructure for chat completions.
- *
- * Manages the Drogon async response stream, optional token batching,
- * timing metrics, and final usage emission. Thread-safe: token callbacks
- * may arrive from service worker threads while the event loop drives
- * the HTTP response.
- */
 class SseStreamWriter : public std::enable_shared_from_this<SseStreamWriter> {
  public:
   static std::shared_ptr<SseStreamWriter> create(trantor::EventLoop* loop,

--- a/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
+++ b/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
@@ -43,8 +43,8 @@ struct StreamParams {
  */
 class SseStreamWriter : public std::enable_shared_from_this<SseStreamWriter> {
  public:
-  static std::shared_ptr<SseStreamWriter> create(
-      trantor::EventLoop* loop, StreamParams params);
+  static std::shared_ptr<SseStreamWriter> create(trantor::EventLoop* loop,
+                                                 StreamParams params);
 
   SseStreamWriter(const SseStreamWriter&) = delete;
   SseStreamWriter& operator=(const SseStreamWriter&) = delete;

--- a/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
+++ b/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <drogon/drogon.h>
+#include <trantor/net/EventLoop.h>
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "domain/llm_response.hpp"
+#include "services/llm_service.hpp"
+#include "services/session_manager.hpp"
+#include "utils/concurrent_queue.hpp"
+
+namespace tt::api {
+
+struct StreamParams {
+  std::string completionId;
+  std::string model;
+  int64_t created;
+  bool includeUsage;
+  bool continuousUsage;
+  int promptTokensCount;
+  std::optional<std::string> sessionId;
+  uint32_t taskId;
+  std::shared_ptr<services::LLMService> service;
+  std::shared_ptr<services::SessionManager> sessionManager;
+};
+
+/**
+ * Encapsulates SSE streaming infrastructure for chat completions.
+ *
+ * Manages the Drogon async response stream, optional token batching,
+ * timing metrics, and final usage emission. Thread-safe: token callbacks
+ * may arrive from service worker threads while the event loop drives
+ * the HTTP response.
+ */
+class SseStreamWriter : public std::enable_shared_from_this<SseStreamWriter> {
+ public:
+  static std::shared_ptr<SseStreamWriter> create(
+      trantor::EventLoop* loop, StreamParams params);
+
+  SseStreamWriter(const SseStreamWriter&) = delete;
+  SseStreamWriter& operator=(const SseStreamWriter&) = delete;
+
+  void handleTokenChunk(const domain::LLMStreamChunk& chunk);
+  void finalizeStream();
+  void abort();
+  bool isDone() const { return done_.load(); }
+
+  drogon::HttpResponsePtr buildResponse();
+
+ private:
+  explicit SseStreamWriter(trantor::EventLoop* loop, StreamParams params);
+
+  void sendSse(const std::string& sse,
+               std::function<void()> onDisconnect = nullptr);
+  void flushAccumulated();
+  domain::CompletionUsage buildFinalUsage() const;
+
+  trantor::EventLoop* loop_;
+  std::shared_ptr<drogon::ResponseStreamPtr> stream_ptr_ =
+      std::make_shared<drogon::ResponseStreamPtr>();
+  std::shared_ptr<std::vector<std::string>> early_buffer_ =
+      std::make_shared<std::vector<std::string>>();
+  std::shared_ptr<ConcurrentQueue<std::string>> accumulator_;
+  std::atomic<bool> done_{false};
+
+  std::atomic<int> completion_tokens_{0};
+  std::chrono::high_resolution_clock::time_point start_time_ =
+      std::chrono::high_resolution_clock::now();
+  std::optional<std::chrono::high_resolution_clock::time_point>
+      first_token_time_;
+  std::optional<std::chrono::high_resolution_clock::time_point>
+      second_token_time_;
+  std::atomic<bool> first_content_chunk_{true};
+
+  StreamParams params_;
+};
+
+}  // namespace tt::api

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -226,12 +226,12 @@ void LLMController::handleStreaming(
   auto writer = SseStreamWriter::create(
       trantor::EventLoop::getEventLoopOfCurrentThread(), std::move(params));
 
-  auto streamingCallback =
-      [writer](const domain::LLMStreamChunk& chunk, bool isFinal) {
-        if (writer->isDone()) return;
-        if (!chunk.choices.empty()) writer->handleTokenChunk(chunk);
-        if (isFinal) writer->finalizeStream();
-      };
+  auto streamingCallback = [writer](const domain::LLMStreamChunk& chunk,
+                                    bool isFinal) {
+    if (writer->isDone()) return;
+    if (!chunk.choices.empty()) writer->handleTokenChunk(chunk);
+    if (isFinal) writer->finalizeStream();
+  };
 
   try {
     if (tt::config::llmMode() == tt::config::LLMMode::REGULAR) {

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -1,208 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
-#include "utils/id_generator.hpp"
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+#include "api/llm_controller.hpp"
+
 #include <json/json.h>
-#include <trantor/net/EventLoop.h>
 
 #include <chrono>
-#include <cmath>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <sstream>
 
 #include "api/error_response.hpp"
-#include "api/llm_controller.hpp"
+#include "api/sse_stream_writer.hpp"
 #include "config/settings.hpp"
 #include "domain/chat_completion_request.hpp"
 #include "domain/chat_completion_response.hpp"
 #include "profiling/tracy.hpp"
-#include "utils/concurrent_queue.hpp"
+#include "utils/id_generator.hpp"
 #include "utils/logger.hpp"
 #include "utils/service_container.hpp"
-
-namespace {
-
-void sseSend(const std::string& sse, trantor::EventLoop* loop,
-             const std::shared_ptr<drogon::ResponseStreamPtr>& streamPtr,
-             const std::shared_ptr<ConcurrentQueue<std::string>>& accumulator,
-             const std::shared_ptr<std::vector<std::string>>& earlyBuffer,
-             std::function<void()> onDisconnect = nullptr) {
-  if (!accumulator) {
-    loop->queueInLoop([streamPtr, earlyBuffer, sse,
-                       onDisconnect = std::move(onDisconnect)]() {
-      if (*streamPtr) {
-        bool ok = (*streamPtr)->send(sse);
-        if (!ok && onDisconnect) onDisconnect();
-      } else if (earlyBuffer) {
-        earlyBuffer->push_back(sse);
-      }
-    });
-    return;
-  }
-  accumulator->push(sse);
-  if (accumulator->size() >= tt::config::maxAccumulatedTokens()) {
-    auto accumulated = accumulator->drain();
-    std::string batch;
-    for (auto& s : accumulated) batch.append(s);
-    loop->queueInLoop([streamPtr, earlyBuffer, batch = std::move(batch),
-                       onDisconnect = std::move(onDisconnect)]() {
-      if (*streamPtr) {
-        bool ok = (*streamPtr)->send(batch);
-        if (!ok && onDisconnect) onDisconnect();
-      } else if (earlyBuffer) {
-        earlyBuffer->push_back(batch);
-      }
-    });
-  }
-}
-
-void flushAccumulated(
-    const std::shared_ptr<ConcurrentQueue<std::string>>& accumulator,
-    const std::shared_ptr<drogon::ResponseStreamPtr>& streamPtr) {
-  if (!accumulator) return;
-  auto accumulated = accumulator->drain();
-  if (!accumulated.empty()) {
-    std::string batch;
-    for (auto& s : accumulated) batch.append(s);
-    if (*streamPtr) (*streamPtr)->send(batch);
-  }
-}
-
-// Bundles all shared state for a streaming SSE session, replacing 17+
-// individual shared_ptr captures with a single shared_ptr<StreamContext>.
-struct StreamContext {
-  // Stream infrastructure
-  trantor::EventLoop* loop;
-  std::shared_ptr<drogon::ResponseStreamPtr> streamPtr =
-      std::make_shared<drogon::ResponseStreamPtr>();
-  std::shared_ptr<std::vector<std::string>> earlyBuffer =
-      std::make_shared<std::vector<std::string>>();
-  std::shared_ptr<ConcurrentQueue<std::string>> accumulator;
-  std::atomic<bool> done{false};
-
-  // Token counting + timing
-  std::atomic<int> completionTokens{0};
-  std::chrono::high_resolution_clock::time_point startTime =
-      std::chrono::high_resolution_clock::now();
-  std::optional<std::chrono::high_resolution_clock::time_point> firstTokenTime;
-  std::optional<std::chrono::high_resolution_clock::time_point> secondTokenTime;
-  std::atomic<bool> firstContentChunk{true};
-
-  // Request metadata (immutable after construction)
-  std::string completionId;
-  std::string model;
-  int64_t created;
-  bool includeUsage;
-  bool continuousUsage;
-  int promptTokensCount;
-  std::optional<std::string> sessionId;
-  uint32_t taskId;
-
-  // Dependencies
-  std::shared_ptr<tt::services::LLMService> service;
-  std::shared_ptr<tt::services::SessionManager> sessionManager;
-};
-
-tt::domain::CompletionUsage buildFinalUsage(const StreamContext& ctx) {
-  const int tokens = ctx.completionTokens.load();
-
-  tt::domain::CompletionUsage usage{
-      ctx.promptTokensCount, tokens,       tokens,
-      std::nullopt,          std::nullopt, std::nullopt};
-
-  if (ctx.firstTokenTime.has_value()) {
-    auto ttftUs = std::chrono::duration_cast<std::chrono::microseconds>(
-        ctx.firstTokenTime.value() - ctx.startTime);
-    usage.ttft_ms =
-        std::round(static_cast<double>(ttftUs.count()) / 10.0) / 100.0;
-  }
-
-  if (tokens > 1 && ctx.firstTokenTime.has_value()) {
-    auto finalTime = std::chrono::high_resolution_clock::now();
-    auto baseTime = ctx.secondTokenTime.value_or(ctx.firstTokenTime.value());
-    auto totalUs = std::chrono::duration_cast<std::chrono::microseconds>(
-        finalTime - baseTime);
-    if (totalUs.count() > 0) {
-      auto secs = static_cast<double>(totalUs.count()) / 1000000.0;
-      usage.tps = std::round((tokens - 1) / secs * 1000.0) / 1000.0;
-    }
-  }
-
-  if (ctx.sessionId.has_value()) {
-    usage.sessionId = ctx.sessionId;
-  }
-  return usage;
-}
-
-void finalizeStream(const std::shared_ptr<StreamContext>& ctx) {
-  ctx->loop->queueInLoop([ctx]() {
-    if (!ctx->done.exchange(true) && *ctx->streamPtr) {
-      flushAccumulated(ctx->accumulator, ctx->streamPtr);
-
-      if (ctx->includeUsage) {
-        auto usage = buildFinalUsage(*ctx);
-        (*ctx->streamPtr)
-            ->send(tt::domain::ChatCompletionStreamChunk::makeUsageChunk(
-                       ctx->completionId, ctx->model, ctx->created, usage)
-                       .toSSE());
-      }
-
-      (*ctx->streamPtr)->send("data: [DONE]\n\n");
-      (*ctx->streamPtr)->close();
-
-      if (ctx->sessionId.has_value() && ctx->sessionManager) {
-        ctx->sessionManager->setSessionInFlight(ctx->sessionId.value(), false);
-      }
-    }
-  });
-}
-
-void handleTokenChunk(const std::shared_ptr<StreamContext>& ctx,
-                      const tt::domain::LLMStreamChunk& chunk,
-                      const std::function<void()>& onDisconnect) {
-  const int currentTokens = ctx->completionTokens.fetch_add(1) + 1;
-
-  auto now = std::chrono::high_resolution_clock::now();
-  if (!ctx->firstTokenTime.has_value()) {
-    ctx->firstTokenTime = now;
-  } else if (currentTokens == 2 && !ctx->secondTokenTime.has_value()) {
-    ctx->secondTokenTime = now;
-  }
-
-  std::optional<tt::domain::CompletionUsage> usage;
-  if (ctx->continuousUsage) {
-    usage = tt::domain::CompletionUsage{ctx->promptTokensCount, currentTokens,
-                                        currentTokens,          std::nullopt,
-                                        std::nullopt,           ctx->sessionId};
-  }
-
-  auto streamChunk = tt::domain::ChatCompletionStreamChunk::makeContentChunk(
-      ctx->completionId, ctx->model, ctx->created, chunk.choices[0], usage);
-
-  std::string sse;
-  if (ctx->firstContentChunk.exchange(false)) {
-    std::optional<tt::domain::CompletionUsage> initialUsage;
-    if (ctx->continuousUsage) {
-      initialUsage = tt::domain::CompletionUsage{
-          ctx->promptTokensCount, 0, 0, std::nullopt, std::nullopt,
-          ctx->sessionId};
-    }
-    auto initialChunk = tt::domain::ChatCompletionStreamChunk::makeInitialChunk(
-        ctx->completionId, ctx->model, ctx->created, initialUsage);
-    sse = initialChunk.toSSE() + streamChunk.toSSE();
-  } else {
-    sse = streamChunk.toSSE();
-  }
-
-  if (!sse.empty()) {
-    sseSend(sse, ctx->loop, ctx->streamPtr, ctx->accumulator, ctx->earlyBuffer,
-            onDisconnect);
-  }
-}
-
-}  // anonymous namespace
 
 namespace tt::api {
 
@@ -317,7 +134,6 @@ void LLMController::chatCompletions(
 
       completion.id = "chatcmpl-" + completion.id;
 
-      // Add timing metrics to non-streaming response
       auto totalDuration =
           std::chrono::duration_cast<std::chrono::milliseconds>(endTime -
                                                                 startTime);
@@ -329,7 +145,6 @@ void LLMController::chatCompletions(
         }
       }
 
-      // Include sessionId in response if present
       if (sessionId.has_value()) {
         completion.usage.sessionId = sessionId;
       }
@@ -340,14 +155,12 @@ void LLMController::chatCompletions(
       resp->setContentTypeCode(drogon::CT_APPLICATION_JSON);
       resp->setBody(chatResponse.toJsonString());
 
-      // Mark session as no longer in-flight
       if (sessionId.has_value() && sessionManager) {
         sessionManager->setSessionInFlight(sessionId.value(), false);
       }
 
       callback(resp);
     } catch (const services::QueueFullException& e) {
-      // Mark session as no longer in-flight on error
       auto sessionId = request->sessionId;
       if (sessionId.has_value() && sessionManager) {
         sessionManager->setSessionInFlight(sessionId.value(), false);
@@ -356,13 +169,11 @@ void LLMController::chatCompletions(
       callback(errorResponse(drogon::k429TooManyRequests, e.what(),
                              "rate_limit_exceeded"));
     } catch (const std::runtime_error& e) {
-      // Mark session as no longer in-flight on error
       auto sessionId = request->sessionId;
       if (sessionId.has_value() && sessionManager) {
         sessionManager->setSessionInFlight(sessionId.value(), false);
       }
 
-      // Check if this is a memory allocation error
       std::string errMsg = e.what();
       if (errMsg.find("Failed to allocate memory slot") != std::string::npos ||
           errMsg.find("memory resources") != std::string::npos) {
@@ -373,7 +184,6 @@ void LLMController::chatCompletions(
             "service_unavailable"));
         return;
       }
-      // Re-throw if it's not a memory allocation error
       throw;
     }
   }
@@ -396,43 +206,31 @@ void LLMController::handleStreaming(
     return;
   }
 
-  auto ctx = std::make_shared<StreamContext>();
-  ctx->loop = trantor::EventLoop::getEventLoopOfCurrentThread();
-  ctx->accumulator = tt::config::enableAccumulatedStreaming()
-                         ? std::make_shared<ConcurrentQueue<std::string>>()
-                         : nullptr;
-  ctx->completionId = "chatcmpl-" + std::to_string(reqPtr->task_id);
-  ctx->model = reqPtr->model.value_or("default");
-  ctx->created = static_cast<int64_t>(
+  StreamParams params;
+  params.completionId = "chatcmpl-" + std::to_string(reqPtr->task_id);
+  params.model = reqPtr->model.value_or("default");
+  params.created = static_cast<int64_t>(
       std::chrono::duration_cast<std::chrono::seconds>(
           std::chrono::system_clock::now().time_since_epoch())
           .count());
-  ctx->includeUsage = !reqPtr->stream_options.has_value() ||
-                      reqPtr->stream_options->include_usage;
-  ctx->continuousUsage = reqPtr->stream_options.has_value() &&
-                         reqPtr->stream_options->continuous_usage_stats;
-  ctx->promptTokensCount = reqPtr->prompt_tokens_count;
-  ctx->sessionId = reqPtr->sessionId;
-  ctx->taskId = reqPtr->task_id;
-  ctx->service = service;
-  ctx->sessionManager = sessionManager;
+  params.includeUsage = !reqPtr->stream_options.has_value() ||
+                        reqPtr->stream_options->include_usage;
+  params.continuousUsage = reqPtr->stream_options.has_value() &&
+                           reqPtr->stream_options->continuous_usage_stats;
+  params.promptTokensCount = reqPtr->prompt_tokens_count;
+  params.sessionId = reqPtr->sessionId;
+  params.taskId = reqPtr->task_id;
+  params.service = service;
+  params.sessionManager = sessionManager;
 
-  auto onDisconnect = [ctx]() {
-    if (!ctx->done.exchange(true)) {
-      TT_LOG_INFO("[LLMController] Client disconnected, aborting task {}",
-                  ctx->taskId);
-      ctx->service->abortRequest(ctx->taskId);
-      if (ctx->sessionId.has_value() && ctx->sessionManager) {
-        ctx->sessionManager->setSessionInFlight(ctx->sessionId.value(), false);
-      }
-    }
-  };
+  auto writer = SseStreamWriter::create(
+      trantor::EventLoop::getEventLoopOfCurrentThread(), std::move(params));
 
   auto streamingCallback =
-      [ctx, onDisconnect](const domain::LLMStreamChunk& chunk, bool isFinal) {
-        if (ctx->done.load()) return;
-        if (!chunk.choices.empty()) handleTokenChunk(ctx, chunk, onDisconnect);
-        if (isFinal) finalizeStream(ctx);
+      [writer](const domain::LLMStreamChunk& chunk, bool isFinal) {
+        if (writer->isDone()) return;
+        if (!chunk.choices.empty()) writer->handleTokenChunk(chunk);
+        if (isFinal) writer->finalizeStream();
       };
 
   try {
@@ -464,35 +262,15 @@ void LLMController::handleStreaming(
     return;
   }
 
-  auto resp = drogon::HttpResponse::newAsyncStreamResponse(
-      [ctx](drogon::ResponseStreamPtr stream) mutable {
-        *ctx->streamPtr = std::move(stream);
-        for (const auto& event : *ctx->earlyBuffer) {
-          (*ctx->streamPtr)->send(event);
-        }
-        ctx->earlyBuffer->clear();
-        if (ctx->done.load()) {
-          (*ctx->streamPtr)->close();
-        }
-      });
-
-  resp->setContentTypeString("text/event-stream");
-  resp->addHeader("Cache-Control", "no-cache");
-  resp->addHeader("Connection", "keep-alive");
-  resp->addHeader("X-Accel-Buffering", "no");
-
-  callback(resp);
+  callback(writer->buildResponse());
 }
 
 bool LLMController::shouldDoPrefillOnDecode(const domain::LLMRequest& request,
                                             bool validSessionFound) const {
-  // for valid sessions always do prefill on decode
   if (validSessionFound) {
     return true;
   }
 
-  // Check if the number of prompt tokens exceeds the threshold
-  // If tokens are below the threshold, prefill on decode server
   const size_t maxTokens = tt::config::maxTokensToPrefillOnDecode();
   const size_t promptTokens = static_cast<size_t>(request.prompt_tokens_count);
 
@@ -505,7 +283,6 @@ void LLMController::createSession(
   try {
     std::optional<uint32_t> slotId;
 
-    // Try to parse request body for optional slotId
     if (req->getBody().length() > 0) {
       Json::Value requestBody;
       Json::CharReaderBuilder builder;
@@ -557,7 +334,6 @@ void LLMController::getSlotId(
   uint32_t slotId = sessionManager->getSlotIdBySessionId(sessionId);
 
   if (slotId == tt::services::INVALID_SLOT_ID) {
-    // Check if session exists at all
     auto session = sessionManager->getSession(sessionId);
     if (!session.has_value()) {
       callback(errorResponse(drogon::k404NotFound, "Session not found",

--- a/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
+++ b/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#include "api/sse_stream_writer.hpp"
+
+#include <cmath>
+
+#include "config/settings.hpp"
+#include "domain/chat_completion_response.hpp"
+#include "utils/concurrent_queue.hpp"
+#include "utils/logger.hpp"
+
+namespace tt::api {
+
+SseStreamWriter::SseStreamWriter(trantor::EventLoop* loop, StreamParams params)
+    : loop_(loop), params_(std::move(params)) {
+  if (config::enableAccumulatedStreaming()) {
+    accumulator_ = std::make_shared<ConcurrentQueue<std::string>>();
+  }
+}
+
+std::shared_ptr<SseStreamWriter> SseStreamWriter::create(
+    trantor::EventLoop* loop, StreamParams params) {
+  return std::shared_ptr<SseStreamWriter>(
+      new SseStreamWriter(loop, std::move(params)));
+}
+
+void SseStreamWriter::sendSse(const std::string& sse,
+                               std::function<void()> onDisconnect) {
+  if (!accumulator_) {
+    loop_->queueInLoop(
+        [streamPtr = stream_ptr_, earlyBuffer = early_buffer_, sse,
+         onDisconnect = std::move(onDisconnect)]() {
+          if (*streamPtr) {
+            bool ok = (*streamPtr)->send(sse);
+            if (!ok && onDisconnect) onDisconnect();
+          } else if (earlyBuffer) {
+            earlyBuffer->push_back(sse);
+          }
+        });
+    return;
+  }
+  accumulator_->push(sse);
+  if (accumulator_->size() >= config::maxAccumulatedTokens()) {
+    auto accumulated = accumulator_->drain();
+    std::string batch;
+    for (auto& s : accumulated) batch.append(s);
+    loop_->queueInLoop(
+        [streamPtr = stream_ptr_, earlyBuffer = early_buffer_,
+         batch = std::move(batch),
+         onDisconnect = std::move(onDisconnect)]() {
+          if (*streamPtr) {
+            bool ok = (*streamPtr)->send(batch);
+            if (!ok && onDisconnect) onDisconnect();
+          } else if (earlyBuffer) {
+            earlyBuffer->push_back(batch);
+          }
+        });
+  }
+}
+
+void SseStreamWriter::flushAccumulated() {
+  if (!accumulator_) return;
+  auto accumulated = accumulator_->drain();
+  if (!accumulated.empty()) {
+    std::string batch;
+    for (auto& s : accumulated) batch.append(s);
+    if (*stream_ptr_) (*stream_ptr_)->send(batch);
+  }
+}
+
+domain::CompletionUsage SseStreamWriter::buildFinalUsage() const {
+  const int tokens = completion_tokens_.load();
+
+  domain::CompletionUsage usage{
+      params_.promptTokensCount, tokens,       tokens,
+      std::nullopt,              std::nullopt, std::nullopt};
+
+  if (first_token_time_.has_value()) {
+    auto ttftUs = std::chrono::duration_cast<std::chrono::microseconds>(
+        first_token_time_.value() - start_time_);
+    usage.ttft_ms =
+        std::round(static_cast<double>(ttftUs.count()) / 10.0) / 100.0;
+  }
+
+  if (tokens > 1 && first_token_time_.has_value()) {
+    auto finalTime = std::chrono::high_resolution_clock::now();
+    auto baseTime = second_token_time_.value_or(first_token_time_.value());
+    auto totalUs = std::chrono::duration_cast<std::chrono::microseconds>(
+        finalTime - baseTime);
+    if (totalUs.count() > 0) {
+      auto secs = static_cast<double>(totalUs.count()) / 1000000.0;
+      usage.tps = std::round((tokens - 1) / secs * 1000.0) / 1000.0;
+    }
+  }
+
+  if (params_.sessionId.has_value()) {
+    usage.sessionId = params_.sessionId;
+  }
+  return usage;
+}
+
+void SseStreamWriter::handleTokenChunk(
+    const domain::LLMStreamChunk& chunk) {
+  if (done_.load()) return;
+
+  const int currentTokens = completion_tokens_.fetch_add(1) + 1;
+
+  auto now = std::chrono::high_resolution_clock::now();
+  if (!first_token_time_.has_value()) {
+    first_token_time_ = now;
+  } else if (currentTokens == 2 && !second_token_time_.has_value()) {
+    second_token_time_ = now;
+  }
+
+  std::optional<domain::CompletionUsage> usage;
+  if (params_.continuousUsage) {
+    usage = domain::CompletionUsage{params_.promptTokensCount, currentTokens,
+                                    currentTokens,             std::nullopt,
+                                    std::nullopt,              params_.sessionId};
+  }
+
+  auto streamChunk = domain::ChatCompletionStreamChunk::makeContentChunk(
+      params_.completionId, params_.model, params_.created, chunk.choices[0],
+      usage);
+
+  std::string sse;
+  if (first_content_chunk_.exchange(false)) {
+    std::optional<domain::CompletionUsage> initialUsage;
+    if (params_.continuousUsage) {
+      initialUsage = domain::CompletionUsage{
+          params_.promptTokensCount, 0, 0, std::nullopt, std::nullopt,
+          params_.sessionId};
+    }
+    auto initialChunk = domain::ChatCompletionStreamChunk::makeInitialChunk(
+        params_.completionId, params_.model, params_.created, initialUsage);
+    sse = initialChunk.toSSE() + streamChunk.toSSE();
+  } else {
+    sse = streamChunk.toSSE();
+  }
+
+  if (!sse.empty()) {
+    auto self = shared_from_this();
+    sendSse(sse, [self]() { self->abort(); });
+  }
+}
+
+void SseStreamWriter::finalizeStream() {
+  auto self = shared_from_this();
+  loop_->queueInLoop([self]() {
+    if (!self->done_.exchange(true) && *self->stream_ptr_) {
+      self->flushAccumulated();
+
+      if (self->params_.includeUsage) {
+        auto usage = self->buildFinalUsage();
+        (*self->stream_ptr_)
+            ->send(domain::ChatCompletionStreamChunk::makeUsageChunk(
+                       self->params_.completionId, self->params_.model,
+                       self->params_.created, usage)
+                       .toSSE());
+      }
+
+      (*self->stream_ptr_)->send("data: [DONE]\n\n");
+      (*self->stream_ptr_)->close();
+
+      if (self->params_.sessionId.has_value() && self->params_.sessionManager) {
+        self->params_.sessionManager->setSessionInFlight(
+            self->params_.sessionId.value(), false);
+      }
+    }
+  });
+}
+
+void SseStreamWriter::abort() {
+  if (!done_.exchange(true)) {
+    TT_LOG_INFO("[SseStreamWriter] Client disconnected, aborting task {}",
+                params_.taskId);
+    params_.service->abortRequest(params_.taskId);
+    if (params_.sessionId.has_value() && params_.sessionManager) {
+      params_.sessionManager->setSessionInFlight(params_.sessionId.value(),
+                                                  false);
+    }
+  }
+}
+
+drogon::HttpResponsePtr SseStreamWriter::buildResponse() {
+  auto self = shared_from_this();
+  auto resp = drogon::HttpResponse::newAsyncStreamResponse(
+      [self](drogon::ResponseStreamPtr stream) mutable {
+        *self->stream_ptr_ = std::move(stream);
+        for (const auto& event : *self->early_buffer_) {
+          (*self->stream_ptr_)->send(event);
+        }
+        self->early_buffer_->clear();
+        if (self->done_.load()) {
+          (*self->stream_ptr_)->close();
+        }
+      });
+
+  resp->setContentTypeString("text/event-stream");
+  resp->addHeader("Cache-Control", "no-cache");
+  resp->addHeader("Connection", "keep-alive");
+  resp->addHeader("X-Accel-Buffering", "no");
+
+  return resp;
+}
+
+}  // namespace tt::api

--- a/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
+++ b/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
@@ -26,18 +26,17 @@ std::shared_ptr<SseStreamWriter> SseStreamWriter::create(
 }
 
 void SseStreamWriter::sendSse(const std::string& sse,
-                               std::function<void()> onDisconnect) {
+                              std::function<void()> onDisconnect) {
   if (!accumulator_) {
-    loop_->queueInLoop(
-        [streamPtr = stream_ptr_, earlyBuffer = early_buffer_, sse,
-         onDisconnect = std::move(onDisconnect)]() {
-          if (*streamPtr) {
-            bool ok = (*streamPtr)->send(sse);
-            if (!ok && onDisconnect) onDisconnect();
-          } else if (earlyBuffer) {
-            earlyBuffer->push_back(sse);
-          }
-        });
+    loop_->queueInLoop([streamPtr = stream_ptr_, earlyBuffer = early_buffer_,
+                        sse, onDisconnect = std::move(onDisconnect)]() {
+      if (*streamPtr) {
+        bool ok = (*streamPtr)->send(sse);
+        if (!ok && onDisconnect) onDisconnect();
+      } else if (earlyBuffer) {
+        earlyBuffer->push_back(sse);
+      }
+    });
     return;
   }
   accumulator_->push(sse);
@@ -45,17 +44,16 @@ void SseStreamWriter::sendSse(const std::string& sse,
     auto accumulated = accumulator_->drain();
     std::string batch;
     for (auto& s : accumulated) batch.append(s);
-    loop_->queueInLoop(
-        [streamPtr = stream_ptr_, earlyBuffer = early_buffer_,
-         batch = std::move(batch),
-         onDisconnect = std::move(onDisconnect)]() {
-          if (*streamPtr) {
-            bool ok = (*streamPtr)->send(batch);
-            if (!ok && onDisconnect) onDisconnect();
-          } else if (earlyBuffer) {
-            earlyBuffer->push_back(batch);
-          }
-        });
+    loop_->queueInLoop([streamPtr = stream_ptr_, earlyBuffer = early_buffer_,
+                        batch = std::move(batch),
+                        onDisconnect = std::move(onDisconnect)]() {
+      if (*streamPtr) {
+        bool ok = (*streamPtr)->send(batch);
+        if (!ok && onDisconnect) onDisconnect();
+      } else if (earlyBuffer) {
+        earlyBuffer->push_back(batch);
+      }
+    });
   }
 }
 
@@ -72,9 +70,12 @@ void SseStreamWriter::flushAccumulated() {
 domain::CompletionUsage SseStreamWriter::buildFinalUsage() const {
   const int tokens = completion_tokens_.load();
 
-  domain::CompletionUsage usage{
-      params_.promptTokensCount, tokens,       tokens,
-      std::nullopt,              std::nullopt, std::nullopt};
+  domain::CompletionUsage usage{params_.promptTokensCount,
+                                tokens,
+                                tokens,
+                                std::nullopt,
+                                std::nullopt,
+                                std::nullopt};
 
   if (first_token_time_.has_value()) {
     auto ttftUs = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -100,8 +101,7 @@ domain::CompletionUsage SseStreamWriter::buildFinalUsage() const {
   return usage;
 }
 
-void SseStreamWriter::handleTokenChunk(
-    const domain::LLMStreamChunk& chunk) {
+void SseStreamWriter::handleTokenChunk(const domain::LLMStreamChunk& chunk) {
   if (done_.load()) return;
 
   const int currentTokens = completion_tokens_.fetch_add(1) + 1;
@@ -115,9 +115,12 @@ void SseStreamWriter::handleTokenChunk(
 
   std::optional<domain::CompletionUsage> usage;
   if (params_.continuousUsage) {
-    usage = domain::CompletionUsage{params_.promptTokensCount, currentTokens,
-                                    currentTokens,             std::nullopt,
-                                    std::nullopt,              params_.sessionId};
+    usage = domain::CompletionUsage{params_.promptTokensCount,
+                                    currentTokens,
+                                    currentTokens,
+                                    std::nullopt,
+                                    std::nullopt,
+                                    params_.sessionId};
   }
 
   auto streamChunk = domain::ChatCompletionStreamChunk::makeContentChunk(
@@ -178,7 +181,7 @@ void SseStreamWriter::abort() {
     params_.service->abortRequest(params_.taskId);
     if (params_.sessionId.has_value() && params_.sessionManager) {
       params_.sessionManager->setSessionInFlight(params_.sessionId.value(),
-                                                  false);
+                                                 false);
     }
   }
 }


### PR DESCRIPTION
Moves all SSE streaming logic (StreamContext, token batching, timing, finalize/disconnect handling) out of llm_controller.cpp into a new SseStreamWriter class.