### PR TITLE
Add Forge LLM support: Llama, Qwen models with VLLMForgeRunner

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -26,8 +26,11 @@ class SupportedModels(Enum):
     BGE_LARGE_EN_V1_5 = "BAAI/bge-large-en-v1.5"
     LLAMA_3_2_3B = "meta-llama/Llama-3.2-3B"
     LLAMA_3_1_8B = "meta-llama/Llama-3.1-8B"
+    LLAMA_3_2_3B_INSTRUCT = "meta-llama/Llama-3.2-3B-Instruct"
+    LLAMA_3_1_8B_INSTRUCT = "meta-llama/Llama-3.1-8B-Instruct"
     LLAMA_3_1_70B = "meta-llama/Llama-3.1-70B"
     QWEN_3_4B = "Qwen/Qwen3-4B"
+    QWEN_3_8B = "Qwen/Qwen3-8B"
     SPEECHT5_TTS = "microsoft/speecht5_tts"
     GEMMA_1_1_2B_IT = "google/gemma-1.1-2b-it"
 
@@ -62,8 +65,11 @@ class ModelNames(Enum):
     BGE_LARGE_EN_V1_5 = "bge-large-en-v1.5"
     LLAMA_3_2_3B = "Llama-3.2-3B"
     LLAMA_3_1_8B = "Llama-3.1-8B"
+    LLAMA_3_2_3B_INSTRUCT = "Llama-3.2-3B-Instruct"
+    LLAMA_3_1_8B_INSTRUCT = "Llama-3.1-8B-Instruct"
     LLAMA_3_1_70B = "Llama-3.1-70B"
     QWEN_3_4B = "Qwen3-4B"
+    QWEN_3_8B = "Qwen3-8B"
     SPEECHT5_TTS = "speecht5_tts"
     GEMMA_1_1_2B_IT = "gemma-1.1-2b-it"
 
@@ -81,7 +87,7 @@ class ModelRunners(Enum):
     TT_MOCHI_1 = "tt-mochi-1"
     TT_WAN_2_2 = "tt-wan2.2"
     TT_WHISPER = "tt-whisper"
-    VLLM = "vllm"
+    VLLMForge = "vllm_forge"
     TT_YOLOV4 = "tt-yolov4"
     VLLMForge_QWEN_EMBEDDING = "vllmforge_qwen_embedding"
     VLLMForge_LLAMA_70B = "vllm_forge_llama_70b"
@@ -129,7 +135,7 @@ MODEL_SERVICE_RUNNER_MAP = {
         ModelRunners.TT_XLA_SDXL,
     },
     ModelServices.LLM: {
-        ModelRunners.VLLM,
+        ModelRunners.VLLMForge,
         ModelRunners.VLLMForge_LLAMA_70B,
         ModelRunners.LLM_TEST,
         ModelRunners.LLAMA_RUNNER,
@@ -195,7 +201,13 @@ MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.VLLMForge_LLAMA_70B: {ModelNames.LLAMA_3_1_70B},
     ModelRunners.QWEN_EMBEDDING_8B: {ModelNames.QWEN_3_EMBEDDING_8B},
     ModelRunners.BGELargeEN_V1_5: {ModelNames.BGE_LARGE_EN_V1_5},
-    ModelRunners.VLLM: {ModelNames.LLAMA_3_2_3B, ModelNames.QWEN_3_4B},
+    ModelRunners.VLLMForge: {
+        ModelNames.LLAMA_3_2_3B,
+        ModelNames.LLAMA_3_2_3B_INSTRUCT,
+        ModelNames.LLAMA_3_1_8B_INSTRUCT,
+        ModelNames.QWEN_3_4B,
+        ModelNames.QWEN_3_8B,
+    },
     ModelRunners.TT_SPEECHT5_TTS: {ModelNames.SPEECHT5_TTS},
     ModelRunners.TRAINING_GEMMA_LORA: {ModelNames.GEMMA_1_1_2B_IT},
     ModelRunners.TRAINING_LLAMA_LORA: {ModelNames.LLAMA_3_1_8B},
@@ -963,28 +975,46 @@ ModelConfigs = {
         "default_throttle_level": 0,
         "use_queue_per_worker": True,
     },
-    (ModelRunners.VLLM, DeviceTypes.N150): {
+    (ModelRunners.VLLMForge, DeviceTypes.N150): {
         "device_mesh_shape": (1, 1),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_1.value,
         "max_batch_size": 1,
     },
-    (ModelRunners.VLLM, DeviceTypes.N300): {
+    (ModelRunners.VLLMForge, DeviceTypes.N300): {
         "device_mesh_shape": (1, 1),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_1.value,
         "max_batch_size": 1,
     },
-    (ModelRunners.VLLM, DeviceTypes.T3K): {
+    (ModelRunners.VLLMForge, DeviceTypes.T3K): {
         "device_mesh_shape": (1, 1),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_4.value,
         "max_batch_size": 1,
     },
-    (ModelRunners.VLLM, DeviceTypes.GALAXY): {
+    (ModelRunners.VLLMForge, DeviceTypes.GALAXY): {
         "device_mesh_shape": (1, 1),
         "is_galaxy": True,
         "device_ids": DeviceIds.DEVICE_IDS_32.value,
+        "max_batch_size": 1,
+    },
+    (ModelRunners.VLLMForge, DeviceTypes.P150): {
+        "device_mesh_shape": (1, 1),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_1.value,
+        "max_batch_size": 1,
+    },
+    (ModelRunners.VLLMForge, DeviceTypes.P300): {
+        "device_mesh_shape": (1, 1),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_2.value,
+        "max_batch_size": 1,
+    },
+    (ModelRunners.VLLMForge, DeviceTypes.P300X2): {
+        "device_mesh_shape": (1, 1),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_4.value,
         "max_batch_size": 1,
     },
     (ModelRunners.TT_XLA_SDXL, DeviceTypes.P150X4): {
@@ -1020,6 +1050,13 @@ for runner in [
         "device_mesh_shape": (1, 1),
         "device_ids": DeviceIds.DEVICE_IDS_1.value,
     }
+
+
+# Per-model overrides applied after device config (keyed by ModelNames enum value)
+MODEL_NAME_OVERRIDES = {
+    ModelNames.QWEN_3_4B: {"chat_template_kwargs": {"enable_thinking": False}},
+    ModelNames.QWEN_3_8B: {"chat_template_kwargs": {"enable_thinking": False}},
+}
 
 
 # Default sampling parameters for vLLM inference

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 from typing import Optional
 
 from config.constants import (
+    MODEL_NAME_OVERRIDES,
     MODEL_RUNNER_TO_MODEL_NAMES_MAP,
     MODEL_SERVICE_RUNNER_MAP,
     SDXL_VALID_IMAGE_RESOLUTIONS,
@@ -48,6 +49,7 @@ class Settings(BaseSettings):
         None  # model_service can be deduced from model_runner using MODEL_SERVICE_RUNNER_MAP
     )
     model_weights_path: str = ""
+    chat_template_kwargs: dict = {}  # extra kwargs passed to apply_chat_template
     preprocessing_model_weights_path: str = ""
     trace_region_size: int = 34541598
     download_weights_from_service: bool = True
@@ -185,6 +187,7 @@ class Settings(BaseSettings):
             logger.warning(
                 f"max_batch_size {self.max_batch_size} is less than max_num_seqs {self.vllm.max_num_seqs} in vllm settings, set max_batch_size to {self.vllm.max_num_seqs}"
             )
+            self.max_batch_size = self.vllm.max_num_seqs
 
     def _set_device_pairs_overrides(self) -> None:
         logger.info(
@@ -307,6 +310,12 @@ class Settings(BaseSettings):
                 if hasattr(self, key):
                     if key == "vllm" and isinstance(value, dict):
                         value = VLLMSettings(**value)
+                    setattr(self, key, value)
+
+            # Apply per-model overrides (e.g. chat_template_kwargs for Qwen3)
+            model_overrides = MODEL_NAME_OVERRIDES.get(model_name_enum, {})
+            for key, value in model_overrides.items():
+                if hasattr(self, key):
                     setattr(self, key, value)
         if any(
             self.model_runner == r.value

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -305,9 +305,11 @@ class Settings(BaseSettings):
             if supported_model:
                 self.model_weights_path = supported_model.value
 
-            # Apply all configuration values
+            # Apply all configuration values (env vars take precedence)
             for key, value in matching_config.items():
                 if hasattr(self, key):
+                    if key.upper() in os.environ:
+                        continue
                     if key == "vllm" and isinstance(value, dict):
                         value = VLLMSettings(**value)
                     setattr(self, key, value)

--- a/tt-media-server/config/vllm_settings.py
+++ b/tt-media-server/config/vllm_settings.py
@@ -2,6 +2,8 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
+import os
+
 from config.constants import SupportedModels
 from pydantic import BaseModel
 
@@ -9,7 +11,7 @@ from pydantic import BaseModel
 class VLLMSettings(BaseModel):
     model: str = SupportedModels.QWEN_3_4B.value
     min_context_length: int = 32
-    max_model_length: int = 2048
-    max_num_seqs: int = 1
+    max_model_length: int = int(os.environ.get("MAX_MODEL_LENGTH", 4096))
+    max_num_seqs: int = int(os.environ.get("MAX_NUM_SEQS", 1))
     max_num_batched_tokens: int = max_model_length * max_num_seqs
     gpu_memory_utilization: float = 0.1

--- a/tt-media-server/model_services/scheduler.py
+++ b/tt-media-server/model_services/scheduler.py
@@ -280,15 +280,15 @@ class Scheduler:
                     self.error_queue.get
                 )
 
+                if result_key is None:
+                    self.listener_running = False
+                    break
+
                 self.worker_info[worker_id]["error_count"] += 1
 
                 self.logger.warning(
                     f"Worker {worker_id} error count is : {self.worker_info[worker_id]['error_count']}"
                 )
-
-                if result_key is None:
-                    self.listener_running = False
-                    break
 
                 self.logger.error(f"Error in worker {result_key}: {error}")
 
@@ -304,7 +304,7 @@ class Scheduler:
                     await queue.put(Exception(error))
 
             except Exception as e:
-                self.logger.error(f"Error in error_listener: {e}", exc_info=True)
+                self.logger.error(f"Error in error_listener: {e}")
 
         self.logger.info("Error listener stopped")
 

--- a/tt-media-server/open_ai_api/chat.py
+++ b/tt-media-server/open_ai_api/chat.py
@@ -35,6 +35,7 @@ def _apply_chat_template(messages: list[dict]) -> str:
         messages,
         tokenize=False,
         add_generation_prompt=True,
+        **settings.chat_template_kwargs,
     )
 
 

--- a/tt-media-server/tests/test_runner_fabric.py
+++ b/tt-media-server/tests/test_runner_fabric.py
@@ -13,7 +13,7 @@ from tt_model_runners.runner_fabric import get_device_runner
 @pytest.mark.parametrize(
     "runner_name_param, expected_class_name",
     [
-        ("vllm", "VLLMRunner"),
+        ("vllm_forge", "VLLMForgeRunner"),
     ],
 )
 def test_runner_creation_unique(

--- a/tt-media-server/tests/test_sampling_params_builder.py
+++ b/tt-media-server/tests/test_sampling_params_builder.py
@@ -249,3 +249,49 @@ class TestBuildSamplingParamsDirectPassthrough:
 
             kwargs = mock_sp.call_args.kwargs
             assert kwargs["skip_special_tokens"] is False
+
+
+class TestBuildSamplingParamsRunnerOverrides:
+    """Test that runner-level defaults override global defaults."""
+
+    def test_runner_defaults_override_global(self):
+        with patch("utils.sampling_params_builder.SamplingParams") as mock_sp:
+            from utils.sampling_params_builder import build_sampling_params
+
+            runner_defaults = {"temperature": 0.6, "repetition_penalty": 1.1}
+            request = CompletionRequest(prompt="test")
+            build_sampling_params(request, defaults=runner_defaults)
+
+            kwargs = mock_sp.call_args.kwargs
+            assert kwargs["temperature"] == 0.6
+            assert kwargs["repetition_penalty"] == 1.1
+
+    def test_runner_defaults_preserve_unoverridden_globals(self):
+        with patch("utils.sampling_params_builder.SamplingParams") as mock_sp:
+            from utils.sampling_params_builder import build_sampling_params
+
+            runner_defaults = {"temperature": 0.6}
+            request = CompletionRequest(prompt="test")
+            build_sampling_params(request, defaults=runner_defaults)
+
+            kwargs = mock_sp.call_args.kwargs
+            assert kwargs["temperature"] == 0.6
+            # Global defaults still apply for non-overridden params
+            assert (
+                kwargs["repetition_penalty"]
+                == _DEFAULT_SAMPLING_PARAMS["repetition_penalty"]
+            )
+
+    def test_request_values_override_runner_defaults(self):
+        with patch("utils.sampling_params_builder.SamplingParams") as mock_sp:
+            from utils.sampling_params_builder import build_sampling_params
+
+            runner_defaults = {"temperature": 0.6, "repetition_penalty": 1.1}
+            request = CompletionRequest(prompt="test", temperature=0.9)
+            build_sampling_params(request, defaults=runner_defaults)
+
+            kwargs = mock_sp.call_args.kwargs
+            # Request value wins over runner default
+            assert kwargs["temperature"] == 0.9
+            # Runner default still applies when request doesn't specify
+            assert kwargs["repetition_penalty"] == 1.1

--- a/tt-media-server/tests/test_vllm_runner.py
+++ b/tt-media-server/tests/test_vllm_runner.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from domain.completion_request import CompletionRequest
-from tt_model_runners.vllm_runner import VLLMRunner
+from tt_model_runners.vllm_runner import VLLMForgeRunner
 
 
 @dataclass
@@ -47,7 +47,7 @@ async def test_run_async_non_streaming_concatenates_output_tokens_correctly(
     mock_settings.device_mesh_shape = (1, 8)  # Ensure device_mesh_shape[0] is an int
     mock_get_settings.return_value = mock_settings
 
-    runner = VLLMRunner(device_id="test-device")
+    runner = VLLMForgeRunner(device_id="test-device")
     runner.llm_engine = MockAsyncLLMEngine(
         [
             "!",
@@ -89,7 +89,7 @@ async def test_run_async_streaming_yields_each_token(mock_get_settings):
     mock_settings.device_mesh_shape = (1, 8)  # Ensure device_mesh_shape[0] is an int
     mock_get_settings.return_value = mock_settings
 
-    runner = VLLMRunner(device_id="test-device")
+    runner = VLLMForgeRunner(device_id="test-device")
     tokens = [
         "!",
         " I",

--- a/tt-media-server/tt_model_runners/llm_test_runner.py
+++ b/tt-media-server/tt_model_runners/llm_test_runner.py
@@ -40,7 +40,7 @@ class LLMTestRunner(BaseDeviceRunner):
         return True
 
     async def _run_async(self, requests: list[CompletionRequest]):
-        """Match VLLMRunner behavior: async generator for streaming, list for non-streaming."""
+        """Match VLLMForgeRunner behavior: async generator for streaming, list for non-streaming."""
         request = requests[0]
         if request.stream:
             return self._generate_streaming(request)

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -46,9 +46,9 @@ AVAILABLE_RUNNERS = {
     ModelRunners.TT_WHISPER: lambda wid: __import__(
         "tt_model_runners.whisper_runner", fromlist=["TTWhisperRunner"]
     ).TTWhisperRunner(wid),
-    ModelRunners.VLLM: lambda wid: __import__(
-        "tt_model_runners.vllm_runner", fromlist=["VLLMRunner"]
-    ).VLLMRunner(wid),
+    ModelRunners.VLLMForge: lambda wid: __import__(
+        "tt_model_runners.vllm_runner", fromlist=["VLLMForgeRunner"]
+    ).VLLMForgeRunner(wid),
     ModelRunners.BGELargeEN_V1_5: lambda wid: __import__(
         "tt_model_runners.embedding_runner", fromlist=["BGELargeENRunner"]
     ).BGELargeENRunner(wid),

--- a/tt-media-server/tt_model_runners/vllm_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_runner.py
@@ -19,6 +19,12 @@ FINAL_TYPE = "final_result"
 
 
 class VLLMForgeRunner(BaseDeviceRunner):
+    # Sampling defaults for Forge LLM inference (overrides global greedy defaults)
+    SAMPLING_DEFAULTS = {
+        "temperature": 0.6,
+        "repetition_penalty": 1.1,
+    }
+
     def __init__(self, device_id: str):
         super().__init__(device_id)
 
@@ -51,7 +57,10 @@ class VLLMForgeRunner(BaseDeviceRunner):
         self.llm_engine = AsyncLLMEngine.from_engine_args(engine_args)
 
         self.logger.info(f"Device {self.device_id}: Starting model warmup")
-        warmup_sampling_params = SamplingParams(temperature=0.0, max_tokens=10)
+        warmup_sampling_params = SamplingParams(
+            **self.SAMPLING_DEFAULTS,
+            max_tokens=10,
+        )
         warmup_generator = self.llm_engine.generate(
             prompt, warmup_sampling_params, "warmup_task_id"
         )
@@ -100,7 +109,7 @@ class VLLMForgeRunner(BaseDeviceRunner):
 
         chunks = []
         strip_eos = TextUtils.strip_eos
-        sampling_params = build_sampling_params(request)
+        sampling_params = build_sampling_params(request, self.SAMPLING_DEFAULTS)
 
         async for request_output in self.llm_engine.generate(
             self._build_vllm_input(request), sampling_params, request._task_id
@@ -138,7 +147,7 @@ class VLLMForgeRunner(BaseDeviceRunner):
     ) -> CompletionOutput:
         self.logger.info(f"Device {self.device_id}: Starting non-streaming generation")
 
-        sampling_params = build_sampling_params(request)
+        sampling_params = build_sampling_params(request, self.SAMPLING_DEFAULTS)
 
         generated_text = []
         async for request_output in self.llm_engine.generate(

--- a/tt-media-server/tt_model_runners/vllm_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_runner.py
@@ -18,7 +18,7 @@ CHUNK_TYPE = "streaming_chunk"
 FINAL_TYPE = "final_result"
 
 
-class VLLMRunner(BaseDeviceRunner):
+class VLLMForgeRunner(BaseDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
 
@@ -38,9 +38,15 @@ class VLLMRunner(BaseDeviceRunner):
             enable_chunked_prefill=False,
             gpu_memory_utilization=self.settings.vllm.gpu_memory_utilization,
             additional_config={
-                "enable_const_eval": False,
+                "enable_const_eval": True,
                 "min_context_len": self.settings.vllm.min_context_length,
+                "experimental_weight_dtype": "bfp_bf8",
+                "cpu_sampling": True,
+                "optimization_level": 1,
             },
+        )
+        self.logger.info(
+            f"Device {self.device_id}: additional_config={engine_args.additional_config}"
         )
         self.llm_engine = AsyncLLMEngine.from_engine_args(engine_args)
 

--- a/tt-media-server/utils/logger.py
+++ b/tt-media-server/utils/logger.py
@@ -104,6 +104,7 @@ class TTLogger:
 
         self.logger = logging.getLogger(name)
         self.logger.setLevel(level)
+        self.logger.propagate = False
 
         # Avoid adding duplicate handlers if the logger is reused.
         if not self.logger.handlers:

--- a/tt-media-server/utils/sampling_params_builder.py
+++ b/tt-media-server/utils/sampling_params_builder.py
@@ -8,15 +8,23 @@ from vllm import SamplingParams
 from vllm.sampling_params import RequestOutputKind
 
 
-def build_sampling_params(request: CompletionRequest) -> SamplingParams:
+def build_sampling_params(
+    request: CompletionRequest, defaults: dict = None
+) -> SamplingParams:
     """
     Build SamplingParams from request, applying defaults for unspecified values.
 
     Extracts sampling parameters from the request object, applies default values
     when parameters are not specified, validates parameter combinations,
     and constructs SamplingParams with the appropriate values.
+
+    Args:
+        defaults: Optional dict to override _DEFAULT_SAMPLING_PARAMS.
     """
-    defaults = _DEFAULT_SAMPLING_PARAMS
+    if defaults is None:
+        defaults = _DEFAULT_SAMPLING_PARAMS
+    else:
+        defaults = {**_DEFAULT_SAMPLING_PARAMS, **defaults}
 
     # Extract and resolve parameters from request, falling back to defaults
     temperature = (
@@ -90,7 +98,5 @@ def build_sampling_params(request: CompletionRequest) -> SamplingParams:
         skip_special_tokens=request.skip_special_tokens,
         spaces_between_special_tokens=request.spaces_between_special_tokens,
         truncate_prompt_tokens=request.truncate_prompt_tokens,
-        guided_decoding=defaults["guided_decoding"],
-        extra_args=defaults["extra_args"],
         output_kind=RequestOutputKind.DELTA,
     )


### PR DESCRIPTION
## Summary

Adds support for running Llama and Qwen LLM models on TT-Forge (Blackhole) hardware via a consolidated VLLMForgeRunner, along with several reliability fixes discovered during bringup.

These changes have been running in production for 2+ weeks, serving TT-Forge LLM demos on tt-cloud-console (Llama-3.1-8B-Instruct, Qwen3-8B, others during dev/testing on P150/P300/P300X2 devices). Would like to eventually move to managed deployments once dependent changes on tt-xla/tt-mlir side are merged.

## Commits

### `00f0a80a` — Add Forge LLM models (Qwen, Llama) and optimize VLLMForgeRunner
- Add Llama-3.2-3B-Instruct, Llama-3.1-8B-Instruct, Qwen3-8B models
- Rename VLLMRunner → VLLMForgeRunner (ModelRunners.VLLM → VLLMForge) since it was said Forge is only user of VLLM right now, and because tt-cloud-console currently looks for "forge" in runner name.
- Hardcode TT-Forge optimizations: consteval, bfp8, cpu_sampling=True, optimization_level=1 for perf gains.
- Add MAX_MODEL_LENGTH and MAX_NUM_SEQS env var support in VLLMSettings for easier testing
- Bump default max_model_length from 2048 → 4096 to match what tt-cloud-console defaults to
- Auto-bump max_batch_size when less than max_num_seqs
- Add device configs for P150, P300, P300X2 (single-chip data parallel)
- Add MODEL_NAME_OVERRIDES for per-model chat_template_kwargs (Qwen3 thinking disabled)

### `2c81fc1f` — Fix error_listener crash on shutdown sentinel and exc_info kwarg
- Fix KeyError on clean shutdown when sentinel `(None, None, None)` reaches error_listener
- Remove unsupported `exc_info` kwarg from TTLogger.error()

### `89fbc878` — Allow env vars to override model config values (e.g. DEVICE_IDS)
- Skip ModelConfigs override when env var is explicitly set
- Enables running a subset of devices (e.g. `DEVICE_IDS="(2),(3)"` for the second P300C)

### `36bee2d0` — Fix TTLogger duplicate log output (propagate=False)
- Set `propagate=False` on TTLogger to prevent duplicate log lines

### `09a185c6` — Improve SamplingParams: per-runner defaults, remove unsupported fields
- Add optional `defaults` param to `build_sampling_params` for runner-level overrides
- VLLMForgeRunner uses temperature=0.6, repetition_penalty=1.1 for inference
- Client request params still take priority over runner defaults
- Remove `guided_decoding` and `extra_args` (unsupported in vLLM 0.16.0)
- Add tests for runner defaults override priority chain

## Note on sampling

Non-greedy sampling (temperature=0.6, repetition_penalty=1.1) is used to reduce repetition in generated output. CPU sampling is currently faster than device sampling for non-greedy decoding, which is why `cpu_sampling=True` is hardcoded. There are WIP changes in tt-xla to improve device sampling performance and better support batch_size>1 with sampling on device.

## Test plan
- [x] Serving Llama-3.1-8B-Instruct and Qwen3-8B on Blackhole P150/P300 via tt-cloud-console for 2 weeks
- [x] Multi-model deployment: 2 models on 1 P300X2 (2 chips each) on different ports
- [x] Unit tests: per-runner sampling defaults override priority chain
- [x] Batch=4 concurrent requests verified with some WIP changes from tt-xla for batch_size>1 perf + correctness issues not yet merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
