### PR TITLE
Fix shared memory bug

### DIFF
--- a/tt-media-server/ipc/video_shm.py
+++ b/tt-media-server/ipc/video_shm.py
@@ -205,7 +205,7 @@ class VideoShm:
                 f"/{self._name}", "shared_memory"
             )
         self._buf = self._shm.buf
-
+ 
     def close(self) -> None:
         if self._shm:
             self._shm.close()

--- a/tt-media-server/ipc/video_shm.py
+++ b/tt-media-server/ipc/video_shm.py
@@ -36,7 +36,7 @@ import struct
 import time
 from dataclasses import dataclass
 from enum import IntEnum
-from multiprocessing import shared_memory as _shm
+from multiprocessing import resource_tracker, shared_memory as _shm
 from typing import Callable
 
 
@@ -197,6 +197,13 @@ class VideoShm:
             os.chmod(f"/dev/shm/{self._name}", 0o666)
         else:
             self._shm = _shm.SharedMemory(name=self._name, create=False)
+            # Python 3.10 resource_tracker registers every SharedMemory opener
+            # and unlinks the segment on process exit — even for non-creators.
+            # Unregister immediately so the attaching process never destroys
+            # segments owned by another process.
+            resource_tracker.unregister(
+                f"/{self._name}", "shared_memory"
+            )
         self._buf = self._shm.buf
 
     def close(self) -> None:

--- a/tt-media-server/ipc/video_shm.py
+++ b/tt-media-server/ipc/video_shm.py
@@ -201,11 +201,9 @@ class VideoShm:
             # and unlinks the segment on process exit — even for non-creators.
             # Unregister immediately so the attaching process never destroys
             # segments owned by another process.
-            resource_tracker.unregister(
-                f"/{self._name}", "shared_memory"
-            )
+            resource_tracker.unregister(f"/{self._name}", "shared_memory")
         self._buf = self._shm.buf
- 
+
     def close(self) -> None:
         if self._shm:
             self._shm.close()

--- a/tt-media-server/tt_model_runners/sp_runner.py
+++ b/tt-media-server/tt_model_runners/sp_runner.py
@@ -68,6 +68,12 @@ class SPRunner(BaseDeviceRunner):
 
     def close_device(self):
         self._shutdown = True
+        if self._input_shm:
+            self._input_shm.close()
+            self._input_shm = None
+        if self._output_shm:
+            self._output_shm.close()
+            self._output_shm = None
         removed = cleanup_orphaned_video_files()
         if removed:
             self.logger.info(


### PR DESCRIPTION
## Issue

**Python 3.10's `SharedMemory` Resource Tracker Bug**

---

### Problem

Python 3.10's `SharedMemory` automatically registers every opener with an internal **resource tracker daemon** — even processes that only attach (`create=False`) and don't own the segment.

### Root Cause

When the `SPRunner` process exits, the resource tracker sees unregistered segments and calls `shm_unlink()`, destroying:

- `/dev/shm/tt_video_in`
- `/dev/shm/tt_video_out`

...while `video_runner.py` is still using them.