### PR TITLE
Fix Paged Memory Manager for Llama Model

### DIFF
--- a/tt-media-server/cpp_server/include/domain/manage_memory.hpp
+++ b/tt-media-server/cpp_server/include/domain/manage_memory.hpp
@@ -27,7 +27,6 @@ enum class KvMemoryLayout : std::uint8_t {
 struct ManageMemoryTask {
   uint32_t taskId;
   MemoryManagementAction action{MemoryManagementAction::ALLOCATE};
-  std::uint32_t inputSeqLen{0};
   KvMemoryLayout memoryLayout{KvMemoryLayout::Paged};
   std::vector<std::uint32_t> slotIds;
 
@@ -35,7 +34,6 @@ struct ManageMemoryTask {
     os.write(reinterpret_cast<const char*>(&taskId), sizeof(taskId));
     auto a = static_cast<std::uint8_t>(action);
     os.write(reinterpret_cast<const char*>(&a), sizeof(a));
-    os.write(reinterpret_cast<const char*>(&inputSeqLen), sizeof(inputSeqLen));
     auto ml = static_cast<std::uint8_t>(memoryLayout);
     os.write(reinterpret_cast<const char*>(&ml), sizeof(ml));
     std::uint32_t n = static_cast<std::uint32_t>(slotIds.size());
@@ -51,8 +49,6 @@ struct ManageMemoryTask {
     std::uint8_t a = 0;
     is.read(reinterpret_cast<char*>(&a), sizeof(a));
     task.action = static_cast<MemoryManagementAction>(a);
-    is.read(reinterpret_cast<char*>(&task.inputSeqLen),
-            sizeof(task.inputSeqLen));
     std::uint8_t ml = 0;
     is.read(reinterpret_cast<char*>(&ml), sizeof(ml));
     task.memoryLayout = static_cast<KvMemoryLayout>(ml);

--- a/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
@@ -156,14 +156,13 @@ void LlamaModelRunner::run(const std::vector<Sequence*>& seqs, bool isPrefill) {
 
       for (size_t i = 0; i < seqs.size(); ++i) {
         py::object item = results[py::int_(i)];
-        std::string taskIdStr = item.attr("task_id").cast<std::string>();
-        uint32_t drTaskId = std::hash<std::string>{}(taskIdStr);
+        uint32_t drTaskId = item.attr("task_id").cast<uint32_t>();
         uint64_t drTokenId =
             static_cast<uint64_t>(item.attr("token_id").cast<int64_t>());
         std::string error = item.attr("error").cast<std::string>();
         bool drIsError = !error.empty();
         if (drIsError) {
-          TT_LOG_ERROR("[LlamaModelRunner] sequence {} error: {}", taskIdStr,
+          TT_LOG_ERROR("[LlamaModelRunner] sequence {} error: {}", drTaskId,
                        error);
         }
         TokenResult dr(drTaskId, drTokenId, {}, drIsError);

--- a/tt-media-server/cpp_server/src/services/memory_services/paged_memory_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/memory_services/paged_memory_manager.cpp
@@ -3,6 +3,7 @@
 
 #include "services/memory_services/paged_memory_manager.hpp"
 
+#include <algorithm>
 #include <utility>
 
 #include "config/settings.hpp"
@@ -32,8 +33,7 @@ PagedMemoryManager::PagedMemoryManager(llm_engine::BlockManager& bm)
 
 ManageMemoryStatus PagedMemoryManager::allocateKv(
     const ManageMemoryTask& task, std::vector<int>& outSlotIds) {
-  std::vector<int64_t> placeholderTokens(static_cast<size_t>(task.inputSeqLen),
-                                         0);
+  std::vector<int64_t> placeholderTokens(1, 0);  // Hardcoded to use one block
   llm_engine::Sequence seq(task.taskId, blockManager->blockSize(),
                            std::move(placeholderTokens));
 

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -274,7 +274,6 @@ std::future<uint32_t> SessionManager::requestSlotIdFromMemoryManager(
 
   pendingAllocations.insert(requestTaskId, promise);
   task.action = domain::MemoryManagementAction::ALLOCATE;
-  task.inputSeqLen = 0;
   task.memoryLayout = domain::KvMemoryLayout::Paged;
   task.slotIds = {};
 
@@ -301,7 +300,6 @@ void SessionManager::sendDeallocRequest(const std::string& sessionId,
   domain::ManageMemoryTask task;
   task.taskId = utils::TaskIDGenerator::generate();
   task.action = domain::MemoryManagementAction::DEALLOCATE;
-  task.inputSeqLen = 0;
   task.memoryLayout = domain::KvMemoryLayout::Paged;
   task.slotIds = {slotId};
 

--- a/tt-media-server/tt_model_runners/llama_runner.py
+++ b/tt-media-server/tt_model_runners/llama_runner.py
@@ -51,7 +51,7 @@ KV_CACHE_BLOCK_SIZE = 32
 class StepSequence:
     """One sequence in a step request (mirrors C++ Sequence)."""
 
-    task_id: str
+    task_id: int
     token_ids: list[int]
     temperature: float
     ignore_eos: bool
@@ -71,7 +71,7 @@ class StepSequence:
 class StepResult:
     """One token result (mirrors C++ TokenResult)."""
 
-    task_id: str
+    task_id: int
     token_id: int
     error: str = ""
 


### PR DESCRIPTION
## Problem
We had runtime errors on `dev` branch for Llama model KV cache allocation due to this line:
```
// task.inputSeqLen=0
std::vector<int64_t> placeholderTokens(static_cast<size_t>(task.inputSeqLen), 0);
```

With these changes, we constrain `PagedMemoryManager` to allocate a single block (page).

Going forward, we can explore using actual token count, or even max_size. However, this is not currently valuable, as the rest of the stack is using a single block