### PR TITLE
[cpp server] Remove dummy inference loop in runner.py

### DIFF
--- a/tt-media-server/cpp_server/src/runners/runner.py
+++ b/tt-media-server/cpp_server/src/runners/runner.py
@@ -41,7 +41,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--cache-path",
         type=Path,
-        default=Path("/mnt/models/deepseek-ai/cache-2026-03-22"),
+        default=Path("/mnt/models/deepseek-ai/cache-2026-03-09"),
         help="Path to the weight cache directory (required for --weights real)",
     )
     parser.add_argument(
@@ -146,11 +146,6 @@ def _open_mesh_device(
         return ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(4, 2))
 
 
-def _run_dummy_inference(model_pipeline: ModelPipeline) -> None:
-    while not _shutdown:
-        model_pipeline.run_inference(prompt_token_ids=None, max_new_tokens=1)
-
-
 def main() -> None:
     signal.signal(signal.SIGTERM, _handle_sigterm)
     rank = _rank()
@@ -191,7 +186,8 @@ def main() -> None:
             _run_shm_bridge(model_pipeline)
         else:
             print(f"Rank {rank}: Waiting (non-host)")
-            _run_dummy_inference(model_pipeline)
+            while not _shutdown:
+                signal.pause()
 
         model_pipeline.terminate()
     finally:

--- a/tt-media-server/cpp_server/src/runners/runner.py
+++ b/tt-media-server/cpp_server/src/runners/runner.py
@@ -41,7 +41,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--cache-path",
         type=Path,
-        default=Path("/mnt/models/deepseek-ai/cache-2026-03-09"),
+        default=Path("/mnt/models/deepseek-ai/cache-2026-03-22"),
         help="Path to the weight cache directory (required for --weights real)",
     )
     parser.add_argument(


### PR DESCRIPTION
- Dummy inference loop for non-0 ranks in runner.py can be removed now since pos id is no longer manually reset on the metal side and non-0 ranks don't need to call run_inference