### PR TITLE
SDXL core_grid fix

### DIFF
--- a/tt-media-server/utils/runner_utils.py
+++ b/tt-media-server/utils/runner_utils.py
@@ -4,7 +4,7 @@
 
 import os
 
-from config.constants import ModelRunners
+from config.constants import ModelRunners, DeviceTypes
 from config.settings import settings
 from telemetry.telemetry_client import get_telemetry_client
 
@@ -60,6 +60,14 @@ def setup_runner_environment(
             )
             _setup_blackhole_mesh_config(tt_metal_home)
 
+    _RUNNERS_REQUIRING_GRID_OVERRIDE = {
+        ModelRunners.TT_SDXL_TRACE.value,
+        ModelRunners.TT_SDXL_EDIT.value,
+        ModelRunners.TT_SDXL_IMAGE_TO_IMAGE.value,
+    }
+    if settings.is_galaxy and settings.model_runner in _RUNNERS_REQUIRING_GRID_OVERRIDE:
+        _setup_grid_override(settings.device)
+
 
 def setup_cpu_threading_limits(cpu_threads: str, num_torch_threads: int = 1):
     """Set up CPU threading limits for PyTorch to prevent CPU oversubscription"""
@@ -95,4 +103,17 @@ def _setup_galaxy_mesh_config(tt_metal_home: str):
     if descriptor:
         os.environ["TT_MESH_GRAPH_DESC_PATH"] = (
             f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/{descriptor}"
+        )
+
+
+def _setup_grid_override(device: str):
+    _logger = TTLogger()
+    if (
+        device == DeviceTypes.BLACKHOLE_GALAXY.value
+        or device == DeviceTypes.GALAXY.value
+    ):
+        expected = "7,7" if device == DeviceTypes.GALAXY.value else "10,9"
+        os.environ["TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE"] = expected
+        _logger.info(
+            f"Set TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE={expected} for {device}"
         )

--- a/tt-media-server/utils/runner_utils.py
+++ b/tt-media-server/utils/runner_utils.py
@@ -65,7 +65,7 @@ def setup_runner_environment(
         ModelRunners.TT_SDXL_EDIT.value,
         ModelRunners.TT_SDXL_IMAGE_TO_IMAGE.value,
     }
-    if settings.is_galaxy and settings.model_runner in _RUNNERS_REQUIRING_GRID_OVERRIDE:
+    if settings.model_runner in _RUNNERS_REQUIRING_GRID_OVERRIDE:
         _setup_grid_override(settings.device)
 
 


### PR DESCRIPTION
## Problem description
SDXL is failing on Galaxy for some time: [example_run_link](https://github.com/tenstorrent/tt-shield/actions/runs/24053679049/job/70160606666)

```
KeyError: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE'
```


## What's changed
- `TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE` is set for SDXL runners when device is galaxy

## Checklist
- [x] [n150 on dispach sdxl](https://github.com/tenstorrent/tt-shield/actions/runs/24100744347) passed✅
- [x] [6u galaxy on dispach sdxl](https://github.com/tenstorrent/tt-shield/actions/runs/24100730280) passed✅
