### PR TITLE
Bump versions of python and forge wheel in Dockerfile.forge

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -907,7 +907,7 @@ jobs:
   forge-runner-cpu-tests:
     needs: forge-runner-changes
     if: ${{ needs.forge-runner-changes.outputs.should-run == 'true' }}
-    name: Forge Runner CPU Tests (Python 3.11)
+    name: Forge Runner CPU Tests (Python 3.12)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -930,10 +930,10 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           # Dissable pip caching for now, it take longer than install sometimes
           # cache: 'pip'
           # cache-dependency-path: |
@@ -943,8 +943,8 @@ jobs:
       - name: Create venv, install dependencies
         shell: bash
         run: |
-          python3.11 -m venv venv-3.11
-          source venv-3.11/bin/activate
+          python3.12 -m venv venv-3.12
+          source venv-3.12/bin/activate
           export VLLM_TARGET_DEVICE="empty"
           pip install --upgrade pip
           pip install -r requirements.txt
@@ -954,7 +954,7 @@ jobs:
       - name: Run CPU-only tests
         shell: bash
         run: |
-          source venv-3.11/bin/activate
+          source venv-3.12/bin/activate
           pytest tt_model_runners/forge_runners/test_forge_models.py -k "cpu" -v
 
   test-coverage:

--- a/server_tests/test_suites/cnn.json
+++ b/server_tests/test_suites/cnn.json
@@ -83,7 +83,9 @@
         },
         {
             "id": "efficientnet-n150",
-            "weights": ["efficientnet"],
+            "weights": [
+                "efficientnet"
+            ],
             "device": "n150",
             "model_marker": "efficientnet",
             "test_cases": [
@@ -107,7 +109,9 @@
         },
         {
             "id": "segformer-n150",
-            "weights": ["segformer"],
+            "weights": [
+                "segformer"
+            ],
             "device": "n150",
             "model_marker": "segformer",
             "test_cases": [
@@ -131,7 +135,9 @@
         },
         {
             "id": "unet-n150",
-            "weights": ["unet"],
+            "weights": [
+                "unet"
+            ],
             "device": "n150",
             "model_marker": "unet",
             "test_cases": [
@@ -155,7 +161,9 @@
         },
         {
             "id": "vit-n150",
-            "weights": ["vit"],
+            "weights": [
+                "vit"
+            ],
             "device": "n150",
             "model_marker": "vit",
             "test_cases": [
@@ -179,7 +187,9 @@
         },
         {
             "id": "vovnet-n150",
-            "weights": ["vovnet"],
+            "weights": [
+                "vovnet"
+            ],
             "device": "n150",
             "model_marker": "vovnet",
             "test_cases": [

--- a/server_tests/test_suites/cnn.json
+++ b/server_tests/test_suites/cnn.json
@@ -1,5 +1,5 @@
 {
-    "_description": "Test suites for CNN model category (ResNet-50, MobileNetV2)",
+    "_description": "Test suites for CNN model category",
     "_category": "CNN",
     "test_suites": [
         {
@@ -62,6 +62,126 @@
             ],
             "device": "n150",
             "model_marker": "mobilenetv2",
+            "test_cases": [
+                {
+                    "template": "CnnLoadTest",
+                    "enabled": true,
+                    "description": "CNN image classification load test",
+                    "targets": {
+                        "cnn_time": 5,
+                        "response_format": "json",
+                        "top_k": 3,
+                        "min_confidence": 70.0
+                    }
+                },
+                {
+                    "template": "CnnParamTest",
+                    "enabled": true,
+                    "description": "CNN parameter variations test"
+                }
+            ]
+        },
+        {
+            "id": "efficientnet-n150",
+            "weights": ["efficientnet"],
+            "device": "n150",
+            "model_marker": "efficientnet",
+            "test_cases": [
+                {
+                    "template": "CnnLoadTest",
+                    "enabled": true,
+                    "description": "CNN image classification load test",
+                    "targets": {
+                        "cnn_time": 5,
+                        "response_format": "json",
+                        "top_k": 3,
+                        "min_confidence": 70.0
+                    }
+                },
+                {
+                    "template": "CnnParamTest",
+                    "enabled": true,
+                    "description": "CNN parameter variations test"
+                }
+            ]
+        },
+        {
+            "id": "segformer-n150",
+            "weights": ["segformer"],
+            "device": "n150",
+            "model_marker": "segformer",
+            "test_cases": [
+                {
+                    "template": "CnnLoadTest",
+                    "enabled": true,
+                    "description": "CNN image classification load test",
+                    "targets": {
+                        "cnn_time": 5,
+                        "response_format": "json",
+                        "top_k": 3,
+                        "min_confidence": 70.0
+                    }
+                },
+                {
+                    "template": "CnnParamTest",
+                    "enabled": true,
+                    "description": "CNN parameter variations test"
+                }
+            ]
+        },
+        {
+            "id": "unet-n150",
+            "weights": ["unet"],
+            "device": "n150",
+            "model_marker": "unet",
+            "test_cases": [
+                {
+                    "template": "CnnLoadTest",
+                    "enabled": true,
+                    "description": "CNN image classification load test",
+                    "targets": {
+                        "cnn_time": 5,
+                        "response_format": "json",
+                        "top_k": 3,
+                        "min_confidence": 70.0
+                    }
+                },
+                {
+                    "template": "CnnParamTest",
+                    "enabled": true,
+                    "description": "CNN parameter variations test"
+                }
+            ]
+        },
+        {
+            "id": "vit-n150",
+            "weights": ["vit"],
+            "device": "n150",
+            "model_marker": "vit",
+            "test_cases": [
+                {
+                    "template": "CnnLoadTest",
+                    "enabled": true,
+                    "description": "CNN image classification load test",
+                    "targets": {
+                        "cnn_time": 5,
+                        "response_format": "json",
+                        "top_k": 3,
+                        "min_confidence": 70.0
+                    }
+                },
+                {
+                    "template": "CnnParamTest",
+                    "enabled": true,
+                    "description": "CNN parameter variations test"
+                }
+            ]
+        },
+        {
+            "id": "vovnet-n150",
+            "weights": ["vovnet"],
+            "device": "n150",
+            "model_marker": "vovnet",
             "test_cases": [
                 {
                     "template": "CnnLoadTest",

--- a/server_tests/test_suites/cnn.json
+++ b/server_tests/test_suites/cnn.json
@@ -1,10 +1,65 @@
 {
-    "_description": "Test suites for CNN model category (MobileNetV2)",
+    "_description": "Test suites for CNN model category (ResNet-50, MobileNetV2)",
     "_category": "CNN",
     "test_suites": [
         {
+            "id": "resnet-50-n150",
+            "weights": [
+                "resnet-50"
+            ],
+            "device": "n150",
+            "model_marker": "resnet",
+            "test_cases": [
+                {
+                    "template": "CnnLoadTest",
+                    "enabled": true,
+                    "description": "CNN image classification load test",
+                    "targets": {
+                        "cnn_time": 5,
+                        "response_format": "json",
+                        "top_k": 3,
+                        "min_confidence": 70.0
+                    }
+                },
+                {
+                    "template": "CnnParamTest",
+                    "enabled": true,
+                    "description": "CNN parameter variations test"
+                }
+            ]
+        },
+        {
+            "id": "resnet-50-n300",
+            "weights": [
+                "resnet-50"
+            ],
+            "device": "n300",
+            "num_of_devices": 1,
+            "model_marker": "resnet",
+            "test_cases": [
+                {
+                    "template": "CnnLoadTest",
+                    "enabled": true,
+                    "description": "CNN image classification load test",
+                    "targets": {
+                        "cnn_time": 5,
+                        "response_format": "json",
+                        "top_k": 3,
+                        "min_confidence": 70.0
+                    }
+                },
+                {
+                    "template": "CnnParamTest",
+                    "enabled": true,
+                    "description": "CNN parameter variations test"
+                }
+            ]
+        },
+        {
             "id": "mobilenetv2-n150",
-            "weights": ["mobilenetv2"],
+            "weights": [
+                "mobilenetv2"
+            ],
             "device": "n150",
             "model_marker": "mobilenetv2",
             "test_cases": [
@@ -28,7 +83,9 @@
         },
         {
             "id": "mobilenetv2-n300",
-            "weights": ["mobilenetv2"],
+            "weights": [
+                "mobilenetv2"
+            ],
             "device": "n300",
             "num_of_devices": 1,
             "model_marker": "mobilenetv2",

--- a/tt-media-server/Dockerfile.forge
+++ b/tt-media-server/Dockerfile.forge
@@ -111,7 +111,9 @@ WORKDIR ${APP_DIR}
 COPY --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} "tt-media-server" "${APP_DIR}/server"
 # Remove private submodule source — cpp_server is not used in the forge image
 RUN rm -rf ${APP_DIR}/server/cpp_server
+USER root
 RUN /bin/bash -c "cd ${APP_DIR}/server && source tt_model_runners/forge_runners/setup_env.sh"
+USER ${CONTAINER_APP_USERNAME}
 ENV TT_METAL_HOME="${APP_DIR}/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal"
 
 # spinup inference server

--- a/tt-media-server/Dockerfile.forge
+++ b/tt-media-server/Dockerfile.forge
@@ -120,4 +120,4 @@ ENV TT_METAL_HOME="${APP_DIR}/server/venv-worker/lib/python3.12/site-packages/pj
 # spinup inference server
 WORKDIR "${APP_DIR}"
 EXPOSE 8000
-CMD ["/bin/bash", "-c", "cd ${APP_DIR}/server/ && source venv-worker/bin/activate && source ./run_uvicorn.sh"]
+CMD ["/bin/bash", "-c", "cd ${APP_DIR}/server/ && source venv-worker/bin/activate && source ./run_uvicorn.sh --skip-venv"]

--- a/tt-media-server/Dockerfile.forge
+++ b/tt-media-server/Dockerfile.forge
@@ -112,7 +112,8 @@ COPY --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} "tt-media-serve
 # Remove private submodule source — cpp_server is not used in the forge image
 RUN rm -rf ${APP_DIR}/server/cpp_server
 USER root
-RUN /bin/bash -c "cd ${APP_DIR}/server && source tt_model_runners/forge_runners/setup_env.sh"
+RUN /bin/bash -c "cd ${APP_DIR}/server && source tt_model_runners/forge_runners/setup_env.sh" \
+    && chown -R ${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} ${HOME_DIR}
 USER ${CONTAINER_APP_USERNAME}
 ENV TT_METAL_HOME="${APP_DIR}/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal"
 

--- a/tt-media-server/Dockerfile.forge
+++ b/tt-media-server/Dockerfile.forge
@@ -112,7 +112,7 @@ COPY --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} "tt-media-serve
 # Remove private submodule source — cpp_server is not used in the forge image
 RUN rm -rf ${APP_DIR}/server/cpp_server
 RUN /bin/bash -c "cd ${APP_DIR}/server && source tt_model_runners/forge_runners/setup_env.sh"
-ENV TT_METAL_HOME="${APP_DIR}/server/venv-worker/lib/python3.11/site-packages/pjrt_plugin_tt/tt-metal"
+ENV TT_METAL_HOME="${APP_DIR}/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal"
 
 # spinup inference server
 WORKDIR "${APP_DIR}"

--- a/tt-media-server/Dockerfile.forge
+++ b/tt-media-server/Dockerfile.forge
@@ -68,9 +68,9 @@ RUN apt-get update && apt-get install -y \
     && protoc --version
 
 # Install Python 3.11 which is required for forge
-RUN add-apt-repository ppa:deadsnakes/ppa && \
-    apt-get update && \
-    apt-get install -y python3.11 python3.11-dev python3.11-venv python3.11-distutils
+RUN add-apt-repository ppa:deadsnakes/ppa -y
+    apt-get update -qq
+    apt-get install -y -qq python3.12 python3.12-dev python3.12-venv
 
 RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4-linux-x86_64.sh -o cmake.sh && \
     chmod +x cmake.sh && \

--- a/tt-media-server/Dockerfile.forge
+++ b/tt-media-server/Dockerfile.forge
@@ -67,7 +67,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && protoc --version
 
-# Install Python 3.11 which is required for forge
+# Install Python 3.12 which is required for forge
 RUN add-apt-repository ppa:deadsnakes/ppa -y && \
     apt-get update -qq && \
     apt-get install -y -qq python3.12 python3.12-dev python3.12-venv

--- a/tt-media-server/Dockerfile.forge
+++ b/tt-media-server/Dockerfile.forge
@@ -68,8 +68,8 @@ RUN apt-get update && apt-get install -y \
     && protoc --version
 
 # Install Python 3.11 which is required for forge
-RUN add-apt-repository ppa:deadsnakes/ppa -y
-    apt-get update -qq
+RUN add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt-get update -qq && \
     apt-get install -y -qq python3.12 python3.12-dev python3.12-venv
 
 RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4-linux-x86_64.sh -o cmake.sh && \

--- a/tt-media-server/run_uvicorn.sh
+++ b/tt-media-server/run_uvicorn.sh
@@ -4,5 +4,9 @@
 
 #!/bin/bash
 set -eo pipefail
-source "${TT_METAL_HOME}/python_env/bin/activate"
+
+if [ "$1" != "--skip-venv" ]; then
+    source "${TT_METAL_HOME}/python_env/bin/activate"
+fi
+
 uvicorn --host 0.0.0.0 main:app --lifespan on --port "${SERVICE_PORT:-8000}"

--- a/tt-media-server/tt_model_runners/forge_runners/README.md
+++ b/tt-media-server/tt_model_runners/forge_runners/README.md
@@ -30,7 +30,6 @@ This module provides:
 
 3. **Install forge dependencies:**
    ```bash
-   export VLLM_TARGET_DEVICE="empty" # Fixes the vllm installation error "CUDA_HOME is not set"
    pip install -r tt_model_runners/forge_runners/requirements.txt
    ```
 
@@ -126,10 +125,10 @@ Model should first be tested locally:
 
 1. In tt-media-server, in `config/vllm_settings`, choose the desired model from the `SupportedModels` enum
 2. In `config/settings.py`, set your device id(s), `is_galaxy` bool, and most importantly, `model_runner` to `ModelRunners.VLLM.value`
-3. Create a python3.11 venv with the forge vllm plugin and activate
+3. Create a python3.12 venv with the forge vllm plugin and activate
 4. Do a `pip install -r` in both tt-inference-server and tt-media-server
 5. Do `export VLLM_TARGET_DEVICE="empty"`
-6. Run the tt-media-server with python3.11 venv (exec the `run_uvicorn.sh`)
+6. Run the tt-media-server with python3.12 venv (exec the `run_uvicorn.sh`)
 7. You can send completion requests via `localhost:8000/docs` page
 
 ### CI

--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
-tt-forge==0.9.0
+tt-forge==1.0.0
 torchvision
 
 tabulate

--- a/tt-media-server/tt_model_runners/forge_runners/setup_env.sh
+++ b/tt-media-server/tt_model_runners/forge_runners/setup_env.sh
@@ -14,9 +14,9 @@ unset ARCH_NAME
 
 virtual_env_name="venv-worker"
 # Create virtual environment with available Python version
-if command -v python3.11 >/dev/null 2>&1; then
-    echo "Using python3.11 for virtual environment..."
-    python3.11 -m venv ${virtual_env_name}
+if command -v python3.12 >/dev/null 2>&1; then
+    echo "Using python3.12 for virtual environment..."
+    python3.12 -m venv ${virtual_env_name}
 else
     echo "Error: No suitable Python version found!"
     exit 1

--- a/tt-media-server/tt_model_runners/forge_runners/setup_env.sh
+++ b/tt-media-server/tt_model_runners/forge_runners/setup_env.sh
@@ -41,7 +41,7 @@ fi
 if [ -f "tt_model_runners/forge_runners/requirements.txt" ]; then
     # Dissable pip's package cache, reducing disk usage during installation and Docker size
     pip install --no-cache-dir -r tt_model_runners/forge_runners/requirements.txt
-    sudo tt-forge-install
+    tt-forge-install
 fi
 
 echo "Setup complete in virtual environment ${virtual_env_name}."

--- a/tt-media-server/tt_model_runners/forge_runners/setup_env.sh
+++ b/tt-media-server/tt_model_runners/forge_runners/setup_env.sh
@@ -41,7 +41,7 @@ fi
 if [ -f "tt_model_runners/forge_runners/requirements.txt" ]; then
     # Dissable pip's package cache, reducing disk usage during installation and Docker size
     pip install --no-cache-dir -r tt_model_runners/forge_runners/requirements.txt
-    tt-forge-install
+    sudo tt-forge-install
 fi
 
 echo "Setup complete in virtual environment ${virtual_env_name}."

--- a/tt-media-server/tt_model_runners/forge_runners/setup_env.sh
+++ b/tt-media-server/tt_model_runners/forge_runners/setup_env.sh
@@ -41,6 +41,7 @@ fi
 if [ -f "tt_model_runners/forge_runners/requirements.txt" ]; then
     # Dissable pip's package cache, reducing disk usage during installation and Docker size
     pip install --no-cache-dir -r tt_model_runners/forge_runners/requirements.txt
+    tt-forge-install
 fi
 
 echo "Setup complete in virtual environment ${virtual_env_name}."


### PR DESCRIPTION
### Issue
#2778 

### Problem
`Dockerfile.forge` currently has python 3.11 installed, in order to use tt-forge 1.0.0 it needs to have python 3.12.

### Solution
Install python 3.12 in the forge Dockerfile.
Bump tt-forge version to 1.0.0.

### Validation
Examples of working "On dispatch runs":
- [resnet50](https://github.com/tenstorrent/tt-shield/actions/runs/24130236826)
- [segformer](https://github.com/tenstorrent/tt-shield/actions/runs/24133669226)