### PR TITLE
Fix namespace inconsistency for concurrent containers and sp_pipeline

### DIFF
--- a/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
+++ b/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
@@ -61,7 +61,7 @@ class SseStreamWriter : public std::enable_shared_from_this<SseStreamWriter> {
       std::make_shared<drogon::ResponseStreamPtr>();
   std::shared_ptr<std::vector<std::string>> early_buffer_ =
       std::make_shared<std::vector<std::string>>();
-  std::shared_ptr<ConcurrentQueue<std::string>> accumulator_;
+  std::shared_ptr<tt::utils::ConcurrentQueue<std::string>> accumulator_;
   std::atomic<bool> done_{false};
 
   std::atomic<int> completion_tokens_{0};

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/i_sp_pipeline_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/i_sp_pipeline_model_runner.hpp
@@ -13,10 +13,10 @@
 #include "runners/llm_runner/sequence.hpp"
 #include "utils/concurrent_queue.hpp"
 
-namespace sp_pipeline {
+namespace tt::runners::sp_pipeline {
 
 using DecodeCallback = std::function<void(const llm_engine::TokenResult&)>;
-using DecodeQueue = LockFreeSPSCQueue<llm_engine::TokenResult>;
+using DecodeQueue = tt::utils::LockFreeSPSCQueue<llm_engine::TokenResult>;
 
 enum class RequestPhase { PREFILL, DECODE };
 
@@ -33,4 +33,4 @@ class ISpPipelineModelRunner {
 std::unique_ptr<ISpPipelineModelRunner> makeModelRunner(
     const tt::config::LLMConfig& config, DecodeCallback callback);
 
-}  // namespace sp_pipeline
+}  // namespace tt::runners::sp_pipeline

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/mock_device_pipeline.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/mock_device_pipeline.hpp
@@ -18,7 +18,7 @@
 #include "runners/llm_runner/sequence.hpp"
 #include "runners/sp_pipeline_runner/i_sp_pipeline_model_runner.hpp"
 
-namespace sp_pipeline {
+namespace tt::runners::sp_pipeline {
 
 struct MockDeviceConfig {
   size_t numStages = 64;
@@ -100,4 +100,4 @@ class MockDevicePipeline {
   std::thread pipelineThread;
 };
 
-}  // namespace sp_pipeline
+}  // namespace tt::runners::sp_pipeline

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/mock_sp_pipeline_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/mock_sp_pipeline_model_runner.hpp
@@ -12,7 +12,7 @@
 #include "runners/sp_pipeline_runner/i_sp_pipeline_model_runner.hpp"
 #include "runners/sp_pipeline_runner/mock_device_pipeline.hpp"
 
-namespace sp_pipeline {
+namespace tt::runners::sp_pipeline {
 
 /// Drop-in replacement for SpPipelineModelRunner that uses a simulated
 /// device pipeline instead of shared memory + an external Python process.
@@ -39,4 +39,4 @@ class MockSpPipelineModelRunner : public ISpPipelineModelRunner {
   std::thread reader_thread_;
 };
 
-}  // namespace sp_pipeline
+}  // namespace tt::runners::sp_pipeline

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_model_runner.hpp
@@ -13,7 +13,7 @@
 #include "ipc/slot_ring_buffer.hpp"
 #include "runners/sp_pipeline_runner/i_sp_pipeline_model_runner.hpp"
 
-namespace sp_pipeline {
+namespace tt::runners::sp_pipeline {
 
 using DecodeCallback = std::function<void(const llm_engine::TokenResult&)>;
 
@@ -53,4 +53,4 @@ class SpPipelineModelRunner : public ISpPipelineModelRunner {
   std::thread readerThread;
 };
 
-}  // namespace sp_pipeline
+}  // namespace tt::runners::sp_pipeline

--- a/tt-media-server/cpp_server/include/services/disaggregation_service.hpp
+++ b/tt-media-server/cpp_server/include/services/disaggregation_service.hpp
@@ -42,7 +42,7 @@ class DisaggregationService {
   tt::config::LLMMode mode;
   std::shared_ptr<LLMService> llmService;
   std::shared_ptr<sockets::InterServerService> socketService;
-  ConcurrentMap<uint32_t, StreamCallback> streamCallbacks;
+  utils::ConcurrentMap<uint32_t, StreamCallback> streamCallbacks;
 };
 
 }  // namespace tt::services

--- a/tt-media-server/cpp_server/include/services/llm_service.hpp
+++ b/tt-media-server/cpp_server/include/services/llm_service.hpp
@@ -79,7 +79,7 @@ class LLMService
 
   std::vector<std::thread> consumer_threads_;
 
-  ConcurrentMap<uint32_t, StreamCallbackEntry> stream_callbacks_;
+  utils::ConcurrentMap<uint32_t, StreamCallbackEntry> stream_callbacks_;
 
   std::atomic<size_t> pending_tasks_{0};
   std::atomic<bool> running_{false};

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -80,14 +80,14 @@ class SessionManager {
   void retryFailedDeallocs();
   void handleMemoryResult(const domain::ManageMemoryResult& result);
 
-  mutable ConcurrentMap<std::string, domain::Session> sessions;
+  mutable utils::ConcurrentMap<std::string, domain::Session> sessions;
 
   std::unique_ptr<ipc::MemoryRequestQueue> memoryRequestQueue;
   std::unique_ptr<ipc::MemoryResultQueue> memoryResultQueue;
 
-  ConcurrentMap<uint32_t, PendingAllocation> pendingAllocationsMap;
-  ConcurrentQueue<PendingAllocation> pendingAllocationsRetryQueue;
-  ConcurrentQueue<DeferredDealloc> deferredDeallocQueue;
+  utils::ConcurrentMap<uint32_t, PendingAllocation> pendingAllocationsMap;
+  utils::ConcurrentQueue<PendingAllocation> pendingAllocationsRetryQueue;
+  utils::ConcurrentQueue<DeferredDealloc> deferredDeallocQueue;
   std::atomic<bool> stopped{false};
   std::atomic<bool> evictionInProgress{false};
   std::thread drainThread;

--- a/tt-media-server/cpp_server/include/utils/concurrent_map.hpp
+++ b/tt-media-server/cpp_server/include/utils/concurrent_map.hpp
@@ -8,6 +8,8 @@
 
 #include "profiling/tracy.hpp"
 
+namespace tt::utils {
+
 template <typename Key, typename Value>
 class ConcurrentMap {
  public:
@@ -88,3 +90,5 @@ class ConcurrentMap {
   std::unordered_map<Key, Value> map_;
   mutable TRACY_LOCKABLE(std::mutex, mutex);
 };
+
+}  // namespace tt::utils

--- a/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
+++ b/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
@@ -10,6 +10,8 @@
 
 #include "profiling/tracy.hpp"
 
+namespace tt::utils {
+
 template <typename T>
 class ConcurrentQueue {
  public:
@@ -41,59 +43,62 @@ class ConcurrentQueue {
   TRACY_LOCKABLE(std::mutex, mutex);
 };
 
+namespace detail {
+
 #ifdef __cpp_lib_hardware_interference_size
-static constexpr size_t CACHE_LINE_SIZE =
+inline constexpr size_t CACHE_LINE_SIZE =
     std::hardware_destructive_interference_size;
 #else
-static constexpr size_t CACHE_LINE_SIZE = 64;
+inline constexpr size_t CACHE_LINE_SIZE = 64;
 #endif
-namespace {
+
 inline size_t nextPowerOfTwo(size_t n) { return std::bit_ceil(n); }
-constexpr std::memory_order RELAXED = std::memory_order_relaxed;
-constexpr std::memory_order ACQUIRE = std::memory_order_acquire;
-constexpr std::memory_order RELEASE = std::memory_order_release;
-}  // namespace
+inline constexpr std::memory_order RELAXED = std::memory_order_relaxed;
+inline constexpr std::memory_order ACQUIRE = std::memory_order_acquire;
+inline constexpr std::memory_order RELEASE = std::memory_order_release;
+
+}  // namespace detail
 
 template <typename T>
 class LockFreeSPSCQueue {
  public:
   LockFreeSPSCQueue(size_t capacity)
-      : capacity(nextPowerOfTwo(capacity + 1)),
-        buffer(nextPowerOfTwo(capacity + 1)) {
+      : capacity(detail::nextPowerOfTwo(capacity + 1)),
+        buffer(detail::nextPowerOfTwo(capacity + 1)) {
     mask = this->capacity - 1;
   }
   ~LockFreeSPSCQueue() = default;
 
   bool push(const T& value) {
-    const size_t HEAD = head.load(RELAXED);
+    const size_t HEAD = head.load(detail::RELAXED);
     const size_t NEXT_HEAD = (HEAD + 1) & mask;
 
-    if (NEXT_HEAD == tail.load(ACQUIRE)) {
+    if (NEXT_HEAD == tail.load(detail::ACQUIRE)) {
       return false;
     }
 
     buffer[HEAD] = value;
 
-    head.store(NEXT_HEAD, RELEASE);
+    head.store(NEXT_HEAD, detail::RELEASE);
     return true;
   }
 
   bool pop(T& value) {
-    const size_t TAIL = tail.load(RELAXED);
+    const size_t TAIL = tail.load(detail::RELAXED);
 
-    if (TAIL == head.load(ACQUIRE)) {
+    if (TAIL == head.load(detail::ACQUIRE)) {
       return false;
     }
 
     value = std::move(buffer[TAIL]);
 
-    tail.store((TAIL + 1) & mask, RELEASE);
+    tail.store((TAIL + 1) & mask, detail::RELEASE);
     return true;
   }
 
   size_t pushMany(const std::vector<T>& items) {
-    const size_t HEAD = head.load(RELAXED);
-    const size_t TAIL = tail.load(ACQUIRE);
+    const size_t HEAD = head.load(detail::RELAXED);
+    const size_t TAIL = tail.load(detail::ACQUIRE);
 
     size_t available = (TAIL - HEAD - 1) & mask;
     size_t toPush = std::min(items.size(), available);
@@ -104,13 +109,13 @@ class LockFreeSPSCQueue {
       buffer[(HEAD + i) & mask] = items[i];
     }
 
-    head.store((HEAD + toPush) & mask, RELEASE);
+    head.store((HEAD + toPush) & mask, detail::RELEASE);
     return toPush;
   }
 
   size_t popMany(std::vector<T>& outItems, size_t maxItems) {
-    const size_t TAIL = tail.load(RELAXED);
-    const size_t HEAD = head.load(ACQUIRE);
+    const size_t TAIL = tail.load(detail::RELAXED);
+    const size_t HEAD = head.load(detail::ACQUIRE);
 
     size_t occupied = (HEAD - TAIL) & mask;
     size_t toPop = std::min(maxItems, occupied);
@@ -121,7 +126,7 @@ class LockFreeSPSCQueue {
       outItems.push_back(std::move(buffer[(TAIL + i) & mask]));
     }
 
-    tail.store((TAIL + toPop) & mask, RELEASE);
+    tail.store((TAIL + toPop) & mask, detail::RELEASE);
     return toPop;
   }
 
@@ -134,6 +139,8 @@ class LockFreeSPSCQueue {
   size_t capacity;
   size_t mask;
   std::vector<T> buffer;
-  alignas(CACHE_LINE_SIZE) std::atomic<size_t> head{0};
-  alignas(CACHE_LINE_SIZE) std::atomic<size_t> tail{0};
+  alignas(detail::CACHE_LINE_SIZE) std::atomic<size_t> head{0};
+  alignas(detail::CACHE_LINE_SIZE) std::atomic<size_t> tail{0};
 };
+
+}  // namespace tt::utils

--- a/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
+++ b/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
@@ -15,7 +15,7 @@ namespace tt::api {
 SseStreamWriter::SseStreamWriter(trantor::EventLoop* loop, StreamParams params)
     : loop_(loop), params_(std::move(params)) {
   if (config::enableAccumulatedStreaming()) {
-    accumulator_ = std::make_shared<ConcurrentQueue<std::string>>();
+    accumulator_ = std::make_shared<tt::utils::ConcurrentQueue<std::string>>();
   }
 }
 

--- a/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/i_sp_pipeline_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/i_sp_pipeline_model_runner.cpp
@@ -8,7 +8,7 @@
 #include "runners/sp_pipeline_runner/mock_sp_pipeline_model_runner.hpp"
 #include "runners/sp_pipeline_runner/sp_pipeline_model_runner.hpp"
 
-namespace sp_pipeline {
+namespace tt::runners::sp_pipeline {
 
 using ModelRunnerType = tt::config::ModelRunnerType;
 
@@ -25,4 +25,4 @@ std::unique_ptr<ISpPipelineModelRunner> makeModelRunner(
   }
 }
 
-}  // namespace sp_pipeline
+}  // namespace tt::runners::sp_pipeline

--- a/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/mock_device_pipeline.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/mock_device_pipeline.cpp
@@ -9,7 +9,7 @@
 #include "profiling/tracy.hpp"
 #include "runners/llm_runner/debug.hpp"
 
-namespace sp_pipeline {
+namespace tt::runners::sp_pipeline {
 
 namespace {
 constexpr uint64_t FALLBACK_TOKEN_ID = 12345;
@@ -194,4 +194,4 @@ void MockDevicePipeline::pipelineLoop() {
   }
 }
 
-}  // namespace sp_pipeline
+}  // namespace tt::runners::sp_pipeline

--- a/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/mock_sp_pipeline_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/mock_sp_pipeline_model_runner.cpp
@@ -5,7 +5,7 @@
 
 #include "profiling/tracy.hpp"
 
-namespace sp_pipeline {
+namespace tt::runners::sp_pipeline {
 
 MockSpPipelineModelRunner::MockSpPipelineModelRunner(DecodeCallback callback,
                                                      MockDeviceConfig config)
@@ -40,4 +40,4 @@ void MockSpPipelineModelRunner::reader_loop() {
   }
 }
 
-}  // namespace sp_pipeline
+}  // namespace tt::runners::sp_pipeline

--- a/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_model_runner.cpp
@@ -5,7 +5,7 @@
 
 #include "runners/llm_runner/debug.hpp"
 
-namespace sp_pipeline {
+namespace tt::runners::sp_pipeline {
 
 SpPipelineModelRunner::SpPipelineModelRunner(DecodeCallback callback)
     : decodeCallback(std::move(callback)),
@@ -46,4 +46,4 @@ void SpPipelineModelRunner::readerLoop() {
   }
 }
 
-}  // namespace sp_pipeline
+}  // namespace tt::runners::sp_pipeline

--- a/tt-media-server/cpp_server/tests/lockfree_queue_test.cpp
+++ b/tt-media-server/cpp_server/tests/lockfree_queue_test.cpp
@@ -9,6 +9,9 @@
 
 #include "utils/concurrent_queue.hpp"
 
+using tt::utils::LockFreeSPSCQueue;
+using tt::utils::detail::nextPowerOfTwo;
+
 namespace {
 
 constexpr size_t QUEUE_CAPACITY = 1024;


### PR DESCRIPTION
Move `ConcurrentQueue`, `LockFreeSPSCQueue`, and `ConcurrentMap` from global namespace into `tt::utils`. Move `CACHE_LINE_SIZE` and memory order aliases from anonymous namespace into `tt::utils::detail`. Rename `sp_pipeline::` to `tt::runners::sp_pipeline` for consistency with tt:: hierarchy