### PR TITLE
Use tt::runners::llm_engine consistently in the C++ LLM engine

### DIFF
--- a/tt-media-server/cpp_server/CLAUDE.md
+++ b/tt-media-server/cpp_server/CLAUDE.md
@@ -46,7 +46,7 @@ cd build && ctest --output-on-failure
 
 # Individual test binaries
 ./build/scheduler_test        # LLM engine scheduler tests
-./build/llm_engine_test      # LLM engine integration tests
+./build/llm_runner_test       # LLM runner integration tests
 ./build/sequence_test        # Sequence management tests
 ./build/test_tokenizer       # Tokenizer functionality tests
 
@@ -73,13 +73,13 @@ The server follows a layered architecture mirroring the Python implementation:
 - **API Layer**: Drogon HTTP controllers (`api/`) providing OpenAI-compatible endpoints
 - **Services Layer**: Business logic (`services/`) handling request processing and validation
 - **Workers**: Multiprocess worker architecture (`worker/`) with IPC communication
-- **LLM Engine**: Sophisticated inference engine (`runners/llm_engine/`) with paged attention
+- **LLM engine**: Inference engine (`runners/llm_runner/`; namespace `tt::runners::llm_engine`) with paged attention; CMake target `llm_runner_lib`
 - **Runners**: Multiple runner implementations (`runners/`) for different backends
 - **Domain Objects**: Request/response models (`domain/`) matching OpenAI API spec
 
 ### LLM Engine Features
 
-The core LLM engine (`include/runners/llm_engine/`) provides:
+The core LLM engine (`include/runners/llm_runner/`) provides:
 - **Paged Attention**: KV cache managed in fixed-size blocks with block tables
 - **Prefix Caching**: Content-addressable blocks for sharing common prefixes
 - **Prefill/Decode Separation**: Separate batch types, prefill prioritized over decode
@@ -139,7 +139,7 @@ The project uses modern C++20 with strict compiler warnings and sanitizer suppor
 ### Logging
 
 - Main server uses Drogon logging (in `./logs/` directory)
-- LLM engine uses structured logging with `[DEBUG] [llm_engine:...]` prefix
+- LLM engine uses structured logging with a `runners.llm_engine:` tag in `LLM_ENGINE_LOG` output when `LLM_ENGINE_DEBUG_BUILD` is enabled
 - Enable LLM engine debug logging with `-DLLM_ENGINE_DEBUG_BUILD=ON`
 
 ## Dependencies and Prerequisites

--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -213,8 +213,9 @@ else()
     endif()
 endif()
 
-# LLM engine (include/runners/llm_runner/, src/runners/llm_runner/)
-set(LLM_ENGINE_SOURCES
+# LLM runner static library (sources under include/runners/llm_runner/,
+# src/runners/llm_runner/; C++ namespace tt::runners::llm_engine)
+set(LLM_RUNNER_LIB_SOURCES
     src/runners/llm_runner/block_manager.cpp
     src/runners/llm_runner/hash.cpp
     src/runners/llm_runner.cpp
@@ -245,15 +246,15 @@ set(LLM_ENGINE_SOURCES
 )
 # Add socket backend when tt-metal is available
 if(TT_METAL_API_FOUND AND TT_METAL_INCLUDE_DIRS)
-    list(APPEND LLM_ENGINE_SOURCES
+    list(APPEND LLM_RUNNER_LIB_SOURCES
         src/runners/llama_model_runner.cpp
     )
-    message(STATUS "LLM engine: building with tt-metal socket integration")
+    message(STATUS "llm_runner_lib: building with tt-metal socket integration")
 else()
-    message(STATUS "LLM engine: building without tt-metal (tt-metal not found)")
+    message(STATUS "llm_runner_lib: building without tt-metal (tt-metal not found)")
 endif()
-add_library(llm_engine ${LLM_ENGINE_SOURCES})
-target_include_directories(llm_engine PUBLIC
+add_library(llm_runner_lib ${LLM_RUNNER_LIB_SOURCES})
+target_include_directories(llm_runner_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include/runners
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${TT_METAL_INCLUDE_DIRS}
@@ -262,12 +263,12 @@ target_include_directories(llm_engine PUBLIC
 # Use PipelineManager::Full (with SocketPipeline + TT::Metalium) when available,
 # otherwise fall back to PipelineManager::Core (mock pipeline only).
 if(TARGET PipelineManager::Full)
-    target_link_libraries(llm_engine PUBLIC tokenizers_cpp JsonCpp::JsonCpp PipelineManager::Full)
+    target_link_libraries(llm_runner_lib PUBLIC tokenizers_cpp JsonCpp::JsonCpp PipelineManager::Full)
 else()
-    target_link_libraries(llm_engine PUBLIC tokenizers_cpp JsonCpp::JsonCpp PipelineManager::Core)
+    target_link_libraries(llm_runner_lib PUBLIC tokenizers_cpp JsonCpp::JsonCpp PipelineManager::Core)
 endif()
 if(TT_METAL_API_FOUND AND TT_METAL_INCLUDE_DIRS)
-    target_compile_definitions(llm_engine PUBLIC USE_METAL_CPP_LIB)
+    target_compile_definitions(llm_runner_lib PUBLIC USE_METAL_CPP_LIB)
     # Find tt_metal library directory
     set(_tt_metal_lib_dir "")
     if(EXISTS "${TT_METAL_HOME}/build_Release/lib/libtt_metal.so")
@@ -276,29 +277,29 @@ if(TT_METAL_API_FOUND AND TT_METAL_INCLUDE_DIRS)
         set(_tt_metal_lib_dir "${TT_METAL_HOME}/build/lib")
     endif()
     if(_tt_metal_lib_dir)
-        target_link_directories(llm_engine PUBLIC "${_tt_metal_lib_dir}")
-        target_link_libraries(llm_engine PUBLIC tt_metal tt_stl fmt)
+        target_link_directories(llm_runner_lib PUBLIC "${_tt_metal_lib_dir}")
+        target_link_libraries(llm_runner_lib PUBLIC tt_metal tt_stl fmt)
     endif()
-    target_link_libraries(llm_engine PUBLIC pybind11::embed)
+    target_link_libraries(llm_runner_lib PUBLIC pybind11::embed)
 endif()
 if(USE_EXTERNAL_FMT)
-    target_link_libraries(llm_engine PUBLIC Boost::boost spdlog::spdlog fmt::fmt)
+    target_link_libraries(llm_runner_lib PUBLIC Boost::boost spdlog::spdlog fmt::fmt)
 else()
-    target_link_libraries(llm_engine PUBLIC Boost::boost spdlog::spdlog)
+    target_link_libraries(llm_runner_lib PUBLIC Boost::boost spdlog::spdlog)
 endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    target_link_libraries(llm_engine PUBLIC rt)
+    target_link_libraries(llm_runner_lib PUBLIC rt)
 endif()
-target_compile_features(llm_engine PUBLIC cxx_std_20)
-target_compile_options(llm_engine PRIVATE -Wall -Wextra -Wpedantic)
+target_compile_features(llm_runner_lib PUBLIC cxx_std_20)
+target_compile_options(llm_runner_lib PRIVATE -Wall -Wextra -Wpedantic)
 
 if(ENABLE_TRACY)
-    target_link_libraries(llm_engine PUBLIC tracy_client)
+    target_link_libraries(llm_runner_lib PUBLIC tracy_client)
 endif()
 
 option(LLM_ENGINE_DEBUG_BUILD "Enable LLM engine debug logging (LLM_ENGINE_LOG)" OFF)
 if(LLM_ENGINE_DEBUG_BUILD)
-    target_compile_definitions(llm_engine PUBLIC LLM_ENGINE_DEBUG)
+    target_compile_definitions(llm_runner_lib PUBLIC LLM_ENGINE_DEBUG)
 endif()
 
 option(SANITIZE_THREAD "Build with ThreadSanitizer (TSan) for data-race detection" OFF)
@@ -307,33 +308,33 @@ if(SANITIZE_THREAD AND SANITIZE_ADDRESS)
     message(FATAL_ERROR "SANITIZE_THREAD and SANITIZE_ADDRESS are mutually exclusive; enable only one.")
 endif()
 if(SANITIZE_THREAD)
-    target_compile_options(llm_engine PUBLIC -fsanitize=thread -g)
-    target_link_options(llm_engine PUBLIC -fsanitize=thread)
+    target_compile_options(llm_runner_lib PUBLIC -fsanitize=thread -g)
+    target_link_options(llm_runner_lib PUBLIC -fsanitize=thread)
 endif()
 if(SANITIZE_ADDRESS)
     set(ASAN_FLAGS -fsanitize=address -fno-omit-frame-pointer -g)
-    target_compile_options(llm_engine PUBLIC ${ASAN_FLAGS})
-    target_link_options(llm_engine PUBLIC -fsanitize=address)
+    target_compile_options(llm_runner_lib PUBLIC ${ASAN_FLAGS})
+    target_link_options(llm_runner_lib PUBLIC -fsanitize=address)
 endif()
 
-# Unit tests (LLM engine)
+# Unit tests (link llm_runner_lib)
 enable_testing()
 add_executable(scheduler_test tests/scheduler_test.cpp)
-target_link_libraries(scheduler_test PRIVATE llm_engine GTest::gtest_main)
+target_link_libraries(scheduler_test PRIVATE llm_runner_lib GTest::gtest_main)
 target_include_directories(scheduler_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include/runners
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 add_executable(llm_runner_test tests/llm_runner_test.cpp)
-target_link_libraries(llm_runner_test PRIVATE llm_engine GTest::gtest_main)
+target_link_libraries(llm_runner_test PRIVATE llm_runner_lib GTest::gtest_main)
 target_include_directories(llm_runner_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include/runners
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 add_executable(sequence_test tests/sequence_test.cpp)
-target_link_libraries(sequence_test PRIVATE llm_engine GTest::gtest_main)
+target_link_libraries(sequence_test PRIVATE llm_runner_lib GTest::gtest_main)
 target_include_directories(sequence_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include/runners
     ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -347,17 +348,17 @@ target_include_directories(lockfree_queue_test PRIVATE
 
 # Tokenizer test
 add_executable(test_tokenizer tests/test_tokenizer.cpp)
-target_link_libraries(test_tokenizer PRIVATE llm_engine GTest::gtest_main)
+target_link_libraries(test_tokenizer PRIVATE llm_runner_lib GTest::gtest_main)
 
 add_executable(cancel_queue_test tests/cancel_queue_test.cpp)
-target_link_libraries(cancel_queue_test PRIVATE llm_engine GTest::gtest_main)
+target_link_libraries(cancel_queue_test PRIVATE llm_runner_lib GTest::gtest_main)
 target_include_directories(cancel_queue_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include/runners
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 add_executable(cancellation_test tests/cancellation_test.cpp)
-target_link_libraries(cancellation_test PRIVATE llm_engine GTest::gtest_main)
+target_link_libraries(cancellation_test PRIVATE llm_runner_lib GTest::gtest_main)
 target_include_directories(cancellation_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include/runners
     ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -374,7 +375,7 @@ gtest_discover_tests(cancellation_test)
 
 # IPC smoke test (2-process, Boost.Interprocess queue + scheduler)
 add_executable(ipc_scheduler_smoke_test tests/ipc_scheduler_smoke_test.cpp)
-target_link_libraries(ipc_scheduler_smoke_test PRIVATE llm_engine)
+target_link_libraries(ipc_scheduler_smoke_test PRIVATE llm_runner_lib)
 target_include_directories(ipc_scheduler_smoke_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include/runners
     ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -390,9 +391,9 @@ set_tests_properties(CancellationE2E PROPERTIES TIMEOUT 60)
 
 # Tokenizer benchmark
 add_executable(tokenizer_benchmark benchmarks/tokenizer_benchmark.cpp)
-target_link_libraries(tokenizer_benchmark PRIVATE llm_engine)
+target_link_libraries(tokenizer_benchmark PRIVATE llm_runner_lib)
 
-# Source files that aren't provided by llm_engine
+# Source files that aren't provided by llm_runner_lib
 set(SOURCES
     src/main.cpp
     src/profiling/tracy.cpp
@@ -432,11 +433,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     ${prometheus-cpp_SOURCE_DIR}/core/include
 )
 
-# Link Drogon, llm_engine, and prometheus-cpp core
+# Link Drogon, llm_runner_lib, and prometheus-cpp core
 if(USE_EXTERNAL_FMT)
-    target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon llm_engine cereal::cereal spdlog::spdlog fmt::fmt prometheus-cpp::core)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon llm_runner_lib cereal::cereal spdlog::spdlog fmt::fmt prometheus-cpp::core)
 else()
-    target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon llm_engine cereal::cereal spdlog::spdlog prometheus-cpp::core)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon llm_runner_lib cereal::cereal spdlog::spdlog prometheus-cpp::core)
 endif()
 if(ENABLE_TRACY)
     target_sources(${PROJECT_NAME} PRIVATE src/profiling/tracy_alloc.cpp)

--- a/tt-media-server/cpp_server/README.md
+++ b/tt-media-server/cpp_server/README.md
@@ -84,13 +84,11 @@ Available log levels (from most to least verbose):
 
 ## LLM engine
 
-The LLM engine lives under `include/runners/llm_engine/` (headers) and `src/runners/llm_engine/` (sources). The engine uses the server's logging (`[DEBUG] [llm_engine:...]`) instead of its own.dia Server - C++ Drogon Implementation
-
-A high-performance C++ implementation of the TT Media Server using the Drogon web framework. This implementation is designed to benchmark the overhead of the Python FastAPI server by providing an identical API with minimal overhead.
-
-## LLM engine
-
-The LLM engine lives under `include/runners/llm_runner/` (headers) and `src/runners/llm_runner/` (sources). The engine uses the server’s logging (`[DEBUG] [llm_engine:...]`) instead of its own.
+Inference engine code lives under `include/runners/llm_runner/` and
+`src/runners/llm_runner/`. Public C++ API types are in namespace
+`tt::runners::llm_engine`. With `-DLLM_ENGINE_DEBUG_BUILD=ON`, `LLM_ENGINE_LOG`
+lines include the tag `runners.llm_engine:` in the prefix. The static library
+CMake target is `llm_runner_lib`.
 
 ### Main features
 
@@ -266,7 +264,7 @@ and `create_tokenizer_strategy()` factory.
 Configuration follows a unified system with clear separation of concerns:
 - **Type definitions**: `config/types.hpp` - enums and type conversions (ModelService, ModelType, LLMMode, SchedulingPolicy, etc.)
 - **Default values**: `config/defaults.hpp` - default values for all environment variables
-- **Runner config**: `config/runner_config.hpp` - LLMConfig, EmbeddingConfig, RunnerConfig variant, and llm_engine_config()
+- **Runner config**: `config/runner_config.hpp` — LLMConfig, EmbeddingConfig, RunnerConfig variant; runtime values filled via `tt::config::llmEngineConfig()` in `config/settings.hpp` / `settings.cpp`
 - **Runtime settings**: `config/settings.hpp` - reads environment variables and provides runtime accessors
 
 All environment variable reads go through `config/settings.hpp` (no direct `getenv` elsewhere).
@@ -581,7 +579,7 @@ cpp_server/
 - `LLMService`: LLM-specific service implementation
 
 ### Runners
-- **Runner factory** (`utils/runner_factory.cpp`): Creates the runner based on `MODEL_SERVICE` and `LLM_DEVICE_BACKEND`. For LLM, builds `tt::config::LLMConfig` (via `llm_engine_config()` from `config/runner_config.hpp`) and passes it to `LLMRunner`; the model runner (stub or Llama pybind11) is created inside the engine via `make_model_runner(config)` (see `include/runners/llm_runner/model_runner.hpp` and `model_runner.cpp`).
+- **Runner factory** (`utils/runner_factory.cpp`): Creates the runner based on `MODEL_SERVICE` and `LLM_DEVICE_BACKEND`. For LLM, builds `tt::config::LLMConfig` via `tt::config::llmEngineConfig()` (`config/settings.hpp` / `settings.cpp`) and passes it to `LLMRunner`; the model runner (stub or Llama pybind11) is created inside the engine via `make_model_runner(config)` (see `include/runners/llm_runner/model_runner.hpp` and `model_runner.cpp`).
 
 ### API
 - `LLMController`: Drogon HTTP controller with OpenAI-compatible endpoints

--- a/tt-media-server/cpp_server/include/config/runner_config.hpp
+++ b/tt-media-server/cpp_server/include/config/runner_config.hpp
@@ -20,8 +20,8 @@ struct LLMConfig {
   static constexpr size_t MAX_INPUT_TOKENS = 131072;  // 128k
   size_t max_num_batched_tokens = 64 * MAX_INPUT_TOKENS;
   size_t max_in_flight_count = 64;
-  std::vector<int64_t> stop_token_ids;  // Set by llm_engine_config() from
-                                        // active tokenizer strategy
+  std::vector<int64_t> stop_token_ids;  // Set by tt::config::llmEngineConfig()
+                                        // from active tokenizer strategy
   int eos = 1;
   size_t kvcache_block_size = 256;
   size_t num_kvcache_blocks = 512;

--- a/tt-media-server/cpp_server/include/ipc/boost_ipc_task_queue.hpp
+++ b/tt-media-server/cpp_server/include/ipc/boost_ipc_task_queue.hpp
@@ -15,14 +15,15 @@ namespace tt::ipc {
 /**
  * ITaskQueue implementation backed by the generic BoostIpcMemoryQueue.
  */
-class BoostIpcTaskQueue : public llm_engine::ITaskQueue {
+class BoostIpcTaskQueue : public tt::runners::llm_engine::ITaskQueue {
  public:
   static constexpr size_t MAX_SEQUENCE_NON_TOKEN_BYTES = 4096;
   static constexpr size_t MAX_MSG_SIZE =
       tt::config::LLMConfig::MAX_INPUT_TOKENS * sizeof(int64_t) +
       MAX_SEQUENCE_NON_TOKEN_BYTES;
 
-  using Queue = BoostIpcMemoryQueue<llm_engine::Sequence, MAX_MSG_SIZE>;
+  using Queue =
+      BoostIpcMemoryQueue<tt::runners::llm_engine::Sequence, MAX_MSG_SIZE>;
 
   /** Create a new queue (main process). */
   BoostIpcTaskQueue(const std::string& name, int capacity)
@@ -32,18 +33,20 @@ class BoostIpcTaskQueue : public llm_engine::ITaskQueue {
   explicit BoostIpcTaskQueue(const std::string& name)
       : queue_(Queue::openExisting(name)) {}
 
-  void push(const llm_engine::Sequence& seq) override { queue_->push(seq); }
-
-  std::unique_ptr<llm_engine::Sequence> tryPop() override {
-    llm_engine::Sequence seq(0, 1, {});
-    if (!queue_->tryPop(seq)) return nullptr;
-    return std::make_unique<llm_engine::Sequence>(std::move(seq));
+  void push(const tt::runners::llm_engine::Sequence& seq) override {
+    queue_->push(seq);
   }
 
-  std::unique_ptr<llm_engine::Sequence> receive() override {
-    llm_engine::Sequence seq(0, 1, {});
+  std::unique_ptr<tt::runners::llm_engine::Sequence> tryPop() override {
+    tt::runners::llm_engine::Sequence seq(0, 1, {});
+    if (!queue_->tryPop(seq)) return nullptr;
+    return std::make_unique<tt::runners::llm_engine::Sequence>(std::move(seq));
+  }
+
+  std::unique_ptr<tt::runners::llm_engine::Sequence> receive() override {
+    tt::runners::llm_engine::Sequence seq(0, 1, {});
     queue_->receive(seq);
-    return std::make_unique<llm_engine::Sequence>(std::move(seq));
+    return std::make_unique<tt::runners::llm_engine::Sequence>(std::move(seq));
   }
 
   bool empty() const override { return queue_->empty(); }

--- a/tt-media-server/cpp_server/include/runners/llama_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/llama_model_runner.hpp
@@ -8,7 +8,7 @@
 #include "config/runner_config.hpp"
 #include "runners/llm_runner/model_runner.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 /**
  * IModelRunner that runs Llama-3.1-8B-Instruct via embedded Python interpreter
@@ -39,4 +39,4 @@ class LlamaModelRunner : public IModelRunner {
 std::unique_ptr<IModelRunner> makeLlamaModelRunner(
     const tt::config::LLMConfig& config, DecodeCallback callback);
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/include/runners/llm_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner.hpp
@@ -18,7 +18,7 @@ class MemoryManager;
 }
 
 namespace tt::runners {
-using namespace llm_engine;
+using namespace tt::runners::llm_engine;
 
 class LLMRunner : public IRunner {
  public:

--- a/tt-media-server/cpp_server/include/runners/llm_runner/block_manager.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/block_manager.hpp
@@ -9,7 +9,7 @@
 
 #include "runners/llm_runner/sequence.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 class Block {
  public:
@@ -51,4 +51,4 @@ class BlockManager {
   mutable std::mutex mutex;
 };
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/include/runners/llm_runner/debug.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/debug.hpp
@@ -7,7 +7,7 @@
 
 #ifdef LLM_ENGINE_DEBUG
 
-namespace llm_engine::detail {
+namespace tt::runners::llm_engine::detail {
 
 inline double elapsed_ms() {
   static const auto start = std::chrono::steady_clock::now();
@@ -43,9 +43,10 @@ class LogBuf {
   std::ostringstream buf_;
 };
 
-}  // namespace llm_engine::detail
+}  // namespace tt::runners::llm_engine::detail
 
-#define LLM_ENGINE_LOG(component) llm_engine::detail::LogBuf(component)
+#define LLM_ENGINE_LOG(component) \
+  tt::runners::llm_engine::detail::LogBuf(component)
 #else
 #define LLM_ENGINE_LOG(component) \
   if (false) std::cerr

--- a/tt-media-server/cpp_server/include/runners/llm_runner/debug.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/debug.hpp
@@ -23,7 +23,8 @@ inline std::mutex& log_mutex() {
 class LogBuf {
  public:
   explicit LogBuf(const char* component) : buf_() {
-    buf_ << "[" << elapsed_ms() << " ms llm_engine:" << component << "] ";
+    buf_ << "[" << elapsed_ms() << " ms runners.llm_engine:" << component
+         << "] ";
   }
   ~LogBuf() {
     std::lock_guard<std::mutex> lock(log_mutex());

--- a/tt-media-server/cpp_server/include/runners/llm_runner/fixed_reply_sequence.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/fixed_reply_sequence.hpp
@@ -3,7 +3,7 @@
 #include <array>
 #include <cstdint>
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 // This tells a story about Tenstorrent
 constexpr std::array<int64_t, 2953> K_FIXED_REPLY_SEQUENCE = {
@@ -337,4 +337,4 @@ constexpr std::array<int64_t, 2953> K_FIXED_REPLY_SEQUENCE = {
     2786,   366,    786,    1473,   2239,   14498,  294,    710,    16,
     1};
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/include/runners/llm_runner/hash.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/hash.hpp
@@ -3,8 +3,8 @@
 #include <cstdint>
 #include <vector>
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 int64_t hashTokenIds(const std::vector<int64_t>& tokenIds, int64_t prefix);
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/include/runners/llm_runner/in_memory_task_queue.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/in_memory_task_queue.hpp
@@ -9,7 +9,7 @@
 
 #include "runners/llm_runner/task_queue.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 /**
  * In-process ITaskQueue backed by a deque of owned pointers.
@@ -45,4 +45,4 @@ class InMemoryTaskQueue : public ITaskQueue {
   std::deque<std::unique_ptr<Sequence>> queue_;
 };
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/include/runners/llm_runner/max_occupancy_scheduler.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/max_occupancy_scheduler.hpp
@@ -5,7 +5,7 @@
 
 #include "runners/llm_runner/scheduler.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 /**
  * Keeps the device at full occupancy (max_in_flight_count) whenever possible.
@@ -38,4 +38,4 @@ class MaxOccupancyScheduler : public Scheduler {
   }
 };
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/include/runners/llm_runner/model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/model_runner.hpp
@@ -7,7 +7,7 @@
 #include "config/runner_config.hpp"
 #include "runners/llm_runner/sequence.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 using DecodeCallback = std::function<void(const TokenResult&)>;
 
@@ -21,4 +21,4 @@ class IModelRunner {
 std::unique_ptr<IModelRunner> makeModelRunner(
     const tt::config::LLMConfig& config, DecodeCallback callback);
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/include/runners/llm_runner/prefill_first_scheduler.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/prefill_first_scheduler.hpp
@@ -5,7 +5,7 @@
 
 #include "runners/llm_runner/scheduler.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 /**
  * Always prefills when the prefill_queue has requests (original behaviour).
@@ -26,4 +26,4 @@ class PrefillFirstScheduler : public Scheduler {
   }
 };
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/include/runners/llm_runner/sampling_params.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/sampling_params.hpp
@@ -5,7 +5,7 @@
 #include <optional>
 #include <vector>
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 /**
  * Sampling parameters aligned with OpenAI-compatible completion request.
@@ -40,4 +40,4 @@ struct SamplingParams {
   static std::unique_ptr<SamplingParams> deserialize(std::istream& is);
 };
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/include/runners/llm_runner/scheduler.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/scheduler.hpp
@@ -15,7 +15,7 @@
 #include "runners/llm_runner/sequence.hpp"
 #include "runners/llm_runner/task_queue.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 /**
  * Schedules prefill and decode batches. Each step returns either a prefill-only
@@ -124,4 +124,4 @@ std::unique_ptr<Scheduler> makeScheduler(const tt::config::LLMConfig& config,
                                          ITaskQueue* taskQueue,
                                          size_t maxInFlightCount);
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/include/runners/llm_runner/sequence.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/sequence.hpp
@@ -11,7 +11,7 @@
 #include "domain/slot_types.hpp"
 #include "runners/llm_runner/sampling_params.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 enum class SequenceStatus { WAITING, RUNNING, IN_FLIGHT, FINISHED, ABORTED };
 
@@ -99,4 +99,4 @@ class Sequence {
   uint32_t kvCacheSlot = tt::domain::INVALID_SLOT_ID;
 };
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/include/runners/llm_runner/task_queue.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/task_queue.hpp
@@ -5,7 +5,7 @@
 
 #include "runners/llm_runner/sequence.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 /**
  * Abstract interface for the scheduler's task queue.
@@ -24,4 +24,4 @@ class ITaskQueue {
   virtual bool empty() const = 0;
 };
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/i_sp_pipeline_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/i_sp_pipeline_model_runner.hpp
@@ -15,8 +15,10 @@
 
 namespace tt::runners::sp_pipeline {
 
-using DecodeCallback = std::function<void(const llm_engine::TokenResult&)>;
-using DecodeQueue = tt::utils::LockFreeSPSCQueue<llm_engine::TokenResult>;
+using DecodeCallback =
+    std::function<void(const tt::runners::llm_engine::TokenResult&)>;
+using DecodeQueue =
+    tt::utils::LockFreeSPSCQueue<tt::runners::llm_engine::TokenResult>;
 
 enum class RequestPhase { PREFILL, DECODE };
 

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/mock_device_pipeline.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/mock_device_pipeline.hpp
@@ -43,7 +43,7 @@ class MockDevicePipeline {
   void write(uint32_t taskId, const std::vector<int64_t>& tokenIds,
              uint32_t maxTokens, RequestPhase phase);
 
-  std::optional<llm_engine::TokenResult> read();
+  std::optional<tt::runners::llm_engine::TokenResult> read();
 
   void exit();
 
@@ -92,7 +92,7 @@ class MockDevicePipeline {
   std::condition_variable inputNotFull;
 
   // Output queue — read() blocks when empty.
-  std::deque<llm_engine::TokenResult> outputQueue;
+  std::deque<tt::runners::llm_engine::TokenResult> outputQueue;
   std::mutex outputMutex;
   std::condition_variable outputNotEmpty;
 

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_model_runner.hpp
@@ -15,7 +15,8 @@
 
 namespace tt::runners::sp_pipeline {
 
-using DecodeCallback = std::function<void(const llm_engine::TokenResult&)>;
+using DecodeCallback =
+    std::function<void(const tt::runners::llm_engine::TokenResult&)>;
 
 class SpPipelineModelRunner : public ISpPipelineModelRunner {
  public:

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
@@ -19,7 +19,7 @@
 #include "services/memory_services/async_memory_manager.hpp"
 namespace tt::runners {
 
-namespace pm = tt_blaze::pipeline_manager;
+namespace pm = pipeline_manager;
 
 class SpPipelineRunner : public IRunner {
  public:

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
@@ -19,7 +19,7 @@
 #include "services/memory_services/async_memory_manager.hpp"
 namespace tt::runners {
 
-namespace pm = tt_blaze::pipeline_manager;
+namespace pm = ::pipeline_manager;
 
 class SpPipelineRunner : public IRunner {
  public:

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
@@ -19,7 +19,7 @@
 #include "services/memory_services/async_memory_manager.hpp"
 namespace tt::runners {
 
-namespace pm = pipeline_manager;
+namespace pm = tt_blaze::pipeline_manager;
 
 class SpPipelineRunner : public IRunner {
  public:

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner.hpp
@@ -25,7 +25,7 @@ class SpPipelineRunner : public IRunner {
  public:
   SpPipelineRunner(const tt::config::LLMConfig& config,
                    ipc::TokenRingBuffer<65536>* resultQueue,
-                   llm_engine::ITaskQueue* taskQueue);
+                   tt::runners::llm_engine::ITaskQueue* taskQueue);
   ~SpPipelineRunner() override;
 
   void run() override;
@@ -42,16 +42,19 @@ class SpPipelineRunner : public IRunner {
   inline void handleMemoryRequest(const tt::domain::ManageMemoryTask& request);
   inline void handleResponse(const pm::PMResponse& response);
   void handleOutput(const pm::OutputMessage& output);
-  std::unique_ptr<llm_engine::Sequence> getRequest();
-  void handleRequest(std::unique_ptr<llm_engine::Sequence> request);
+  std::unique_ptr<tt::runners::llm_engine::Sequence> getRequest();
+  void handleRequest(
+      std::unique_ptr<tt::runners::llm_engine::Sequence> request);
   void evictSlot(uint32_t slotId);
 
   tt::config::LLMConfig config;
   std::unordered_set<int64_t> stopTokenIds;
   ipc::TokenRingBuffer<65536>* resultQueue;
-  llm_engine::ITaskQueue* taskQueue;
+  tt::runners::llm_engine::ITaskQueue* taskQueue;
   std::unique_ptr<pm::PipelineManager> pipelineManager;
-  std::unordered_map<uint32_t, std::unique_ptr<llm_engine::Sequence>> running;
+  std::unordered_map<uint32_t,
+                     std::unique_ptr<tt::runners::llm_engine::Sequence>>
+      running;
   std::atomic<bool> stopped{false};
   std::unique_ptr<tt::services::AsyncMemoryManager> memoryManager;
 };

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner_demo.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner_demo.hpp
@@ -28,7 +28,7 @@ class SpPipelineRunnerDemo : public IRunner {
  public:
   SpPipelineRunnerDemo(const tt::config::LLMConfig& config,
                        ipc::TokenRingBuffer<65536>* resultQueue,
-                       llm_engine::ITaskQueue* taskQueue);
+                       tt::runners::llm_engine::ITaskQueue* taskQueue);
   ~SpPipelineRunnerDemo() override;
 
   void run() override;
@@ -44,10 +44,11 @@ class SpPipelineRunnerDemo : public IRunner {
   tt::config::LLMConfig config;
   std::unordered_set<int64_t> stopTokenIds;
   ipc::TokenRingBuffer<65536>* resultQueue;
-  llm_engine::ITaskQueue* taskQueue;
+  tt::runners::llm_engine::ITaskQueue* taskQueue;
   std::unique_ptr<sp_pipeline::ISpPipelineModelRunner> modelRunner;
   sp_pipeline::DecodeQueue decodeQueue;
-  std::unordered_map<uint32_t, std::unique_ptr<llm_engine::Sequence>>
+  std::unordered_map<uint32_t,
+                     std::unique_ptr<tt::runners::llm_engine::Sequence>>
       activeSequences;
   std::atomic<bool> stopped{false};
   size_t maxInFlightCount;

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_utils.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_utils.hpp
@@ -9,7 +9,7 @@
 
 namespace tt::runners::sp_pipeline_utils {
 
-namespace pm = pipeline_manager;
+namespace pm = tt_blaze::pipeline_manager;
 
 inline pm::ISRequest makeAllocateRequest(uint32_t requestId) {
   return {

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_utils.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_utils.hpp
@@ -20,7 +20,7 @@ inline pm::ISRequest makeCancelRequest(uint32_t slotId) {
 }
 
 inline pm::GenerationParams makeGenerationParams(
-    const llm_engine::Sequence& seq) {
+    const tt::runners::llm_engine::Sequence& seq) {
   return {.max_new_tokens =
               static_cast<uint32_t>(seq.getSamplingParams().max_tokens.value_or(
                   static_cast<int>(config::LLMConfig::MAX_INPUT_TOKENS))),
@@ -32,13 +32,13 @@ inline pm::GenerationParams makeGenerationParams(
 }
 
 inline void fillSequenceFields(pm::ISRequest& req,
-                               const llm_engine::Sequence& seq) {
+                               const tt::runners::llm_engine::Sequence& seq) {
   req.tokens.assign(seq.getTokenIds().begin(), seq.getTokenIds().end());
   req.gen = makeGenerationParams(seq);
 }
 
-inline pm::ISRequest makeSubmitRequest(uint32_t slotId,
-                                       const llm_engine::Sequence& seq) {
+inline pm::ISRequest makeSubmitRequest(
+    uint32_t slotId, const tt::runners::llm_engine::Sequence& seq) {
   pm::ISRequest req{};
   req.type = pm::RequestType::SUBMIT;
   req.slot_id = slotId;
@@ -46,8 +46,8 @@ inline pm::ISRequest makeSubmitRequest(uint32_t slotId,
   return req;
 }
 
-inline pm::ISRequest makeContinueRequest(uint32_t slotId,
-                                         const llm_engine::Sequence& seq) {
+inline pm::ISRequest makeContinueRequest(
+    uint32_t slotId, const tt::runners::llm_engine::Sequence& seq) {
   pm::ISRequest req{};
   req.type = pm::RequestType::CONTINUE;
   req.slot_id = slotId;

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_utils.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_utils.hpp
@@ -9,14 +9,15 @@
 
 namespace tt::runners::sp_pipeline_utils {
 
-namespace pm = tt_blaze::pipeline_manager;
+namespace pm = pipeline_manager;
 
 inline pm::ISRequest makeAllocateRequest(uint32_t requestId) {
-  return {.type = pm::RequestType::ALLOCATE, .request_id = requestId};
+  return {
+      .type = pm::RequestType::ALLOCATE, .request_id = requestId, .tokens = {}};
 }
 
 inline pm::ISRequest makeCancelRequest(uint32_t slotId) {
-  return {.type = pm::RequestType::CANCEL, .slot_id = slotId};
+  return {.type = pm::RequestType::CANCEL, .slot_id = slotId, .tokens = {}};
 }
 
 inline pm::GenerationParams makeGenerationParams(

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_utils.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_utils.hpp
@@ -9,7 +9,7 @@
 
 namespace tt::runners::sp_pipeline_utils {
 
-namespace pm = tt_blaze::pipeline_manager;
+namespace pm = ::pipeline_manager;
 
 inline pm::ISRequest makeAllocateRequest(uint32_t requestId) {
   return {

--- a/tt-media-server/cpp_server/include/runners/sp_prefill_runner/i_sp_prefill_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_prefill_runner/i_sp_prefill_model_runner.hpp
@@ -20,7 +20,7 @@ class ISpPrefillModelRunner {
 
   // Prefill runner always does prefill, returns the single result token
   // (nullopt if stopped before result arrives)
-  virtual std::optional<llm_engine::TokenResult> forward(
+  virtual std::optional<tt::runners::llm_engine::TokenResult> forward(
       uint32_t taskId, const std::vector<int64_t>& tokenIds) = 0;
   virtual void exit() = 0;
 };

--- a/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_model_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_model_runner.hpp
@@ -22,7 +22,7 @@ class SpPrefillModelRunner : public ISpPrefillModelRunner {
   SpPrefillModelRunner(const SpPrefillModelRunner&) = delete;
   SpPrefillModelRunner& operator=(const SpPrefillModelRunner&) = delete;
 
-  std::optional<llm_engine::TokenResult> forward(
+  std::optional<tt::runners::llm_engine::TokenResult> forward(
       uint32_t taskId, const std::vector<int64_t>& tokenIds) override;
   void exit() override;
 

--- a/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_prefill_runner/sp_prefill_runner.hpp
@@ -19,7 +19,7 @@ class SpPrefillRunner : public IRunner {
  public:
   SpPrefillRunner(const tt::config::LLMConfig& config,
                   ipc::TokenRingBuffer<65536>* resultQueue,
-                  llm_engine::ITaskQueue* taskQueue);
+                  tt::runners::llm_engine::ITaskQueue* taskQueue);
   ~SpPrefillRunner() override;
 
   void run() override;
@@ -30,7 +30,7 @@ class SpPrefillRunner : public IRunner {
  private:
   tt::config::LLMConfig config;
   ipc::TokenRingBuffer<65536>* resultQueue;
-  llm_engine::ITaskQueue* taskQueue;
+  tt::runners::llm_engine::ITaskQueue* taskQueue;
   std::unique_ptr<sp_prefill::ISpPrefillModelRunner> modelRunner;
   std::atomic<bool> stopped{false};
 };

--- a/tt-media-server/cpp_server/include/services/memory_services/paged_memory_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/memory_services/paged_memory_manager.hpp
@@ -5,7 +5,7 @@
 
 #include "services/memory_services/memory_manager.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 class BlockManager;
 }
 
@@ -13,7 +13,8 @@ namespace tt::services {
 
 class PagedMemoryManager : public MemoryManager {
  public:
-  explicit PagedMemoryManager(llm_engine::BlockManager& blockManager);
+  explicit PagedMemoryManager(
+      tt::runners::llm_engine::BlockManager& blockManager);
 
   void handleRequest(const domain::ManageMemoryTask& request) override;
 
@@ -22,7 +23,7 @@ class PagedMemoryManager : public MemoryManager {
                                         std::vector<int>& outSlotIds);
   void deallocateKv(uint32_t taskId, std::vector<int> slotIds);
 
-  llm_engine::BlockManager* blockManager;
+  tt::runners::llm_engine::BlockManager* blockManager;
 };
 
 }  // namespace tt::services

--- a/tt-media-server/cpp_server/include/services/memory_services/sp_pipeline_memory_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/memory_services/sp_pipeline_memory_manager.hpp
@@ -15,9 +15,8 @@ class SpPipelineMemoryManager : public AsyncMemoryManager {
   using onEvictCb = std::function<void(uint32_t slotId)>;
 
  public:
-  SpPipelineMemoryManager(
-      ::pipeline_manager::PipelineManager& pipelineManager,
-      onEvictCb onEvict);
+  SpPipelineMemoryManager(::pipeline_manager::PipelineManager& pipelineManager,
+                          onEvictCb onEvict);
   ~SpPipelineMemoryManager() = default;
 
   void handleRequest(const domain::ManageMemoryTask& request) override;

--- a/tt-media-server/cpp_server/include/services/memory_services/sp_pipeline_memory_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/memory_services/sp_pipeline_memory_manager.hpp
@@ -15,7 +15,7 @@ class SpPipelineMemoryManager : public AsyncMemoryManager {
   using onEvictCb = std::function<void(uint32_t slotId)>;
 
  public:
-  SpPipelineMemoryManager(pipeline_manager::PipelineManager& pipelineManager,
+  SpPipelineMemoryManager(tt_blaze::pipeline_manager::PipelineManager& pipelineManager,
                           onEvictCb onEvict);
   ~SpPipelineMemoryManager() = default;
 
@@ -24,7 +24,7 @@ class SpPipelineMemoryManager : public AsyncMemoryManager {
   void handleResponse(uint32_t requestId, uint32_t slotId) override;
 
  private:
-  pipeline_manager::PipelineManager& pipelineManager;
+  tt_blaze::pipeline_manager::PipelineManager& pipelineManager;
   std::unordered_map<uint32_t, uint32_t> allocating;
   uint32_t nextRequestID{0};
   onEvictCb onEvict;

--- a/tt-media-server/cpp_server/include/services/memory_services/sp_pipeline_memory_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/memory_services/sp_pipeline_memory_manager.hpp
@@ -15,8 +15,9 @@ class SpPipelineMemoryManager : public AsyncMemoryManager {
   using onEvictCb = std::function<void(uint32_t slotId)>;
 
  public:
-  SpPipelineMemoryManager(tt_blaze::pipeline_manager::PipelineManager& pipelineManager,
-                          onEvictCb onEvict);
+  SpPipelineMemoryManager(
+      ::pipeline_manager::PipelineManager& pipelineManager,
+      onEvictCb onEvict);
   ~SpPipelineMemoryManager() = default;
 
   void handleRequest(const domain::ManageMemoryTask& request) override;
@@ -24,7 +25,7 @@ class SpPipelineMemoryManager : public AsyncMemoryManager {
   void handleResponse(uint32_t requestId, uint32_t slotId) override;
 
  private:
-  tt_blaze::pipeline_manager::PipelineManager& pipelineManager;
+  ::pipeline_manager::PipelineManager& pipelineManager;
   std::unordered_map<uint32_t, uint32_t> allocating;
   uint32_t nextRequestID{0};
   onEvictCb onEvict;

--- a/tt-media-server/cpp_server/include/services/memory_services/sp_pipeline_memory_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/memory_services/sp_pipeline_memory_manager.hpp
@@ -15,9 +15,8 @@ class SpPipelineMemoryManager : public AsyncMemoryManager {
   using onEvictCb = std::function<void(uint32_t slotId)>;
 
  public:
-  SpPipelineMemoryManager(
-      tt_blaze::pipeline_manager::PipelineManager& pipelineManager,
-      onEvictCb onEvict);
+  SpPipelineMemoryManager(pipeline_manager::PipelineManager& pipelineManager,
+                          onEvictCb onEvict);
   ~SpPipelineMemoryManager() = default;
 
   void handleRequest(const domain::ManageMemoryTask& request) override;
@@ -25,7 +24,7 @@ class SpPipelineMemoryManager : public AsyncMemoryManager {
   void handleResponse(uint32_t requestId, uint32_t slotId) override;
 
  private:
-  tt_blaze::pipeline_manager::PipelineManager& pipelineManager;
+  pipeline_manager::PipelineManager& pipelineManager;
   std::unordered_map<uint32_t, uint32_t> allocating;
   uint32_t nextRequestID{0};
   onEvictCb onEvict;

--- a/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
+++ b/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
@@ -45,8 +45,9 @@ class ConcurrentQueue {
 
 namespace detail {
 
-// Fixed size avoids -Winterference-size (std::hardware_destructive_interference_size
-// is not stable across compiler/tuning); 64 matches typical x86/ARM cache lines.
+// Fixed size avoids -Winterference-size
+// (std::hardware_destructive_interference_size is not stable across
+// compiler/tuning); 64 matches typical x86/ARM cache lines.
 inline constexpr size_t CACHE_LINE_SIZE = 64;
 
 inline size_t nextPowerOfTwo(size_t n) { return std::bit_ceil(n); }

--- a/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
+++ b/tt-media-server/cpp_server/include/utils/concurrent_queue.hpp
@@ -45,12 +45,9 @@ class ConcurrentQueue {
 
 namespace detail {
 
-#ifdef __cpp_lib_hardware_interference_size
-inline constexpr size_t CACHE_LINE_SIZE =
-    std::hardware_destructive_interference_size;
-#else
+// Fixed size avoids -Winterference-size (std::hardware_destructive_interference_size
+// is not stable across compiler/tuning); 64 matches typical x86/ARM cache lines.
 inline constexpr size_t CACHE_LINE_SIZE = 64;
-#endif
 
 inline size_t nextPowerOfTwo(size_t n) { return std::bit_ceil(n); }
 inline constexpr std::memory_order RELAXED = std::memory_order_relaxed;

--- a/tt-media-server/cpp_server/include/utils/mapper.hpp
+++ b/tt-media-server/cpp_server/include/utils/mapper.hpp
@@ -5,5 +5,6 @@
 
 namespace tt::utils::mapper {
 
-llm_engine::SamplingParams mapSamplingParams(const domain::LLMRequest&);
+tt::runners::llm_engine::SamplingParams mapSamplingParams(
+    const domain::LLMRequest&);
 }

--- a/tt-media-server/cpp_server/include/utils/runner_factory.hpp
+++ b/tt-media-server/cpp_server/include/utils/runner_factory.hpp
@@ -27,7 +27,8 @@ namespace tt::utils::runner_factory {
  */
 std::unique_ptr<runners::IRunner> createRunner(
     config::ModelService service, const config::RunnerConfig& config,
-    ipc::TokenRingBuffer<65536>* resultQueue, llm_engine::ITaskQueue* taskQueue,
+    ipc::TokenRingBuffer<65536>* resultQueue,
+    tt::runners::llm_engine::ITaskQueue* taskQueue,
     ipc::ICancelQueue* cancelQueue = nullptr);
 
 /**

--- a/tt-media-server/cpp_server/include/worker/single_process_worker.hpp
+++ b/tt-media-server/cpp_server/include/worker/single_process_worker.hpp
@@ -16,7 +16,7 @@ namespace tt::worker {
 
 struct WorkerConfig {
   std::unordered_map<std::string, std::string> env_vars;
-  std::shared_ptr<llm_engine::ITaskQueue> task_queue;
+  std::shared_ptr<tt::runners::llm_engine::ITaskQueue> task_queue;
   std::shared_ptr<tt::ipc::TokenRingBuffer<65536>> result_queue;
   std::shared_ptr<tt::ipc::ICancelQueue> cancel_queue;
   int worker_id;

--- a/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
@@ -14,7 +14,7 @@
 
 namespace py = pybind11;
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 using Config = tt::config::LLMConfig;
 
@@ -200,4 +200,4 @@ std::unique_ptr<IModelRunner> makeLlamaModelRunner(const Config& config,
   return runner;
 }
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/src/runners/llm_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner.cpp
@@ -11,7 +11,7 @@
 #include "services/memory_services/paged_memory_manager.hpp"
 
 namespace tt::runners {
-using namespace llm_engine;
+using namespace tt::runners::llm_engine;
 using Config = tt::config::LLMConfig;
 
 LLMRunner::LLMRunner(const Config& config,

--- a/tt-media-server/cpp_server/src/runners/llm_runner/block_manager.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/block_manager.cpp
@@ -8,7 +8,7 @@
 #include "runners/llm_runner/debug.hpp"
 #include "runners/llm_runner/hash.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 Block::Block(int blockId) : block_id(blockId) {}
 
@@ -177,4 +177,4 @@ void BlockManager::mayAppend(Sequence& seq) {
   }
 }
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/src/runners/llm_runner/hash.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/hash.cpp
@@ -2,7 +2,7 @@
 
 #include <cstring>
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 static constexpr uint64_t K_FNV_PRIME = 1099511628211ULL;
 static constexpr uint64_t K_FNV_OFFSET = 0xcbf29ce484222325ULL;
@@ -26,4 +26,4 @@ int64_t hashTokenIds(const std::vector<int64_t>& tokenIds, int64_t prefix) {
   return static_cast<int64_t>(h);
 }
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/src/runners/llm_runner/mock_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/mock_model_runner.cpp
@@ -2,7 +2,7 @@
 #include "runners/llm_runner/debug.hpp"
 #include "runners/llm_runner/model_runner.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 using Config = tt::config::LLMConfig;
 
@@ -50,4 +50,4 @@ std::unique_ptr<IModelRunner> makeMockModelRunner(const Config& config,
   return std::make_unique<MockModelRunner>(config, std::move(callback));
 }
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/src/runners/llm_runner/model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/model_runner.cpp
@@ -8,7 +8,7 @@
 
 #include <iostream>
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 using Config = tt::config::LLMConfig;
 using ModelRunnerType = tt::config::ModelRunnerType;
@@ -34,4 +34,4 @@ std::unique_ptr<IModelRunner> makeModelRunner(const Config& config,
   }
 }
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/src/runners/llm_runner/sampling_params.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/sampling_params.cpp
@@ -1,6 +1,6 @@
 #include "runners/llm_runner/sampling_params.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 namespace {
 
@@ -112,4 +112,4 @@ std::unique_ptr<SamplingParams> SamplingParams::deserialize(std::istream& is) {
   return params;
 }
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/scheduler.cpp
@@ -10,7 +10,7 @@
 #include "runners/llm_runner/max_occupancy_scheduler.hpp"
 #include "runners/llm_runner/prefill_first_scheduler.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 using Config = tt::config::LLMConfig;
 using SchedulingPolicy = tt::config::SchedulingPolicy;
@@ -212,4 +212,4 @@ void Scheduler::abortRequest(uint32_t taskId) {
                 [&](Sequence* s) { return s->taskId == taskId; });
   sequences_.erase(taskId);
 }
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/src/runners/llm_runner/sequence.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/sequence.cpp
@@ -7,7 +7,7 @@
 #include "config/runner_config.hpp"
 #include "llm_runner/sampling_params.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 using Config = tt::config::LLMConfig;
 
@@ -102,4 +102,4 @@ Sequence Sequence::deserialize(std::istream& is) {
   return seq;
 }
 
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/mock_device_pipeline.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/mock_device_pipeline.cpp
@@ -40,7 +40,7 @@ void MockDevicePipeline::write(uint32_t taskId,
   inputQueue.push_back(std::move(req));
 }
 
-std::optional<llm_engine::TokenResult> MockDevicePipeline::read() {
+std::optional<tt::runners::llm_engine::TokenResult> MockDevicePipeline::read() {
   ZoneScopedN("MockDevice::read");
   std::unique_lock lock(outputMutex);
   outputNotEmpty.wait(lock, [this] {

--- a/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_model_runner.cpp
@@ -38,7 +38,7 @@ void SpPipelineModelRunner::readerLoop() {
   while (!stop.load(std::memory_order_relaxed)) {
     if (deviceOutput.tryRead(readBuf)) {
       uint64_t tokenId = readBuf.tokenIds.empty() ? 0 : readBuf.tokenIds[0];
-      llm_engine::TokenResult result(readBuf.taskId, tokenId);
+      tt::runners::llm_engine::TokenResult result(readBuf.taskId, tokenId);
       decodeCallback(result);
     } else {
       std::this_thread::yield();

--- a/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner.cpp
@@ -20,9 +20,9 @@
 namespace tt::runners {
 namespace utils = sp_pipeline_utils;
 
-SpPipelineRunner::SpPipelineRunner(const config::LLMConfig& config,
-                                   ipc::TokenRingBuffer<65536>* resultQueue,
-                                   llm_engine::ITaskQueue* taskQueue)
+SpPipelineRunner::SpPipelineRunner(
+    const config::LLMConfig& config, ipc::TokenRingBuffer<65536>* resultQueue,
+    tt::runners::llm_engine::ITaskQueue* taskQueue)
     : config(config),
       stopTokenIds(config.stop_token_ids.begin(), config.stop_token_ids.end()),
       resultQueue(resultQueue),
@@ -67,14 +67,14 @@ void SpPipelineRunner::run() {
 }
 
 bool SpPipelineRunner::warmup() {
-  llm_engine::SamplingParams warmupParams;
+  tt::runners::llm_engine::SamplingParams warmupParams;
   warmupParams.max_tokens = 1;
   warmupParams.ignore_eos = true;
 
   std::vector<int64_t> warmupTokens = {1};
   uint32_t warmupTaskId = 0;
 
-  auto warmupSeq = std::make_unique<llm_engine::Sequence>(
+  auto warmupSeq = std::make_unique<tt::runners::llm_engine::Sequence>(
       warmupTaskId, 1, warmupTokens, warmupParams);
 
   TT_LOG_INFO("SpPipelineRunner: warmup - pushing ALLOCATE request...");
@@ -158,7 +158,8 @@ std::optional<pm::OutputMessage> SpPipelineRunner::getOutput() {
   return std::nullopt;
 }
 
-std::unique_ptr<llm_engine::Sequence> SpPipelineRunner::getRequest() {
+std::unique_ptr<tt::runners::llm_engine::Sequence>
+SpPipelineRunner::getRequest() {
   auto req = taskQueue->tryPop();
   if (!req) return nullptr;
   return req;
@@ -195,7 +196,7 @@ inline void SpPipelineRunner::evictSlot(uint32_t slotId) {
 }
 
 void SpPipelineRunner::handleRequest(
-    std::unique_ptr<llm_engine::Sequence> request) {
+    std::unique_ptr<tt::runners::llm_engine::Sequence> request) {
   auto slotId = request->getKVCacheSlot();
   assert(slotId != tt::domain::INVALID_SLOT_ID);
 

--- a/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner_demo.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_pipeline_runner/sp_pipeline_runner_demo.cpp
@@ -19,7 +19,7 @@ namespace tt::runners {
 
 SpPipelineRunnerDemo::SpPipelineRunnerDemo(
     const config::LLMConfig& config, ipc::TokenRingBuffer<65536>* resultQueue,
-    llm_engine::ITaskQueue* taskQueue)
+    tt::runners::llm_engine::ITaskQueue* taskQueue)
     : config(config),
       stopTokenIds(config.stop_token_ids.begin(), config.stop_token_ids.end()),
       resultQueue(resultQueue),
@@ -32,7 +32,7 @@ SpPipelineRunnerDemo::SpPipelineRunnerDemo(
     memoryThread = std::thread([this] { memoryLoop(); });
   }
 
-  auto decodeCb = [this](const llm_engine::TokenResult& result) {
+  auto decodeCb = [this](const tt::runners::llm_engine::TokenResult& result) {
     while (!decodeQueue.push(result)) {
       std::this_thread::yield();
     }
@@ -59,14 +59,14 @@ void SpPipelineRunnerDemo::run() {
 
 bool SpPipelineRunnerDemo::warmup() {
   // Create a warmup sequence with a single token
-  llm_engine::SamplingParams warmupParams;
+  tt::runners::llm_engine::SamplingParams warmupParams;
   warmupParams.max_tokens = 1;
   warmupParams.ignore_eos = true;
 
   std::vector<int64_t> warmupTokens = {1};  // Single token
   uint32_t warmupTaskId = 0;                // Use 0 for warmup task
 
-  auto warmupSeq = std::make_unique<llm_engine::Sequence>(
+  auto warmupSeq = std::make_unique<tt::runners::llm_engine::Sequence>(
       warmupTaskId,
       1,  // block_size (doesn't matter for warmup)
       warmupTokens, warmupParams);
@@ -80,7 +80,7 @@ bool SpPipelineRunnerDemo::warmup() {
   bool receivedToken = false;
 
   while (attempts < maxAttempts && !receivedToken) {
-    std::vector<llm_engine::TokenResult> results;
+    std::vector<tt::runners::llm_engine::TokenResult> results;
     decodeQueue.popMany(results, maxInFlightCount);
     for (const auto& dr : results) {
       if (dr.taskId == warmupTaskId) {
@@ -152,7 +152,7 @@ void SpPipelineRunnerDemo::step() {
 }
 
 void SpPipelineRunnerDemo::drainDecodeResults() {
-  std::vector<llm_engine::TokenResult> results;
+  std::vector<tt::runners::llm_engine::TokenResult> results;
   decodeQueue.popMany(results, maxInFlightCount);
   for (const auto& dr : results) {
     auto it = activeSequences.find(dr.taskId);
@@ -162,7 +162,7 @@ void SpPipelineRunnerDemo::drainDecodeResults() {
           dr.taskId);
       continue;
     }
-    llm_engine::Sequence* seq = it->second.get();
+    tt::runners::llm_engine::Sequence* seq = it->second.get();
 
     if (dr.isError) {
       ipc::pushErrorToken(*resultQueue, dr.taskId);

--- a/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_model_runner.cpp
@@ -15,8 +15,9 @@ SpPrefillModelRunner::SpPrefillModelRunner()
 
 SpPrefillModelRunner::~SpPrefillModelRunner() { exit(); }
 
-std::optional<llm_engine::TokenResult> SpPrefillModelRunner::forward(
-    uint32_t taskId, const std::vector<int64_t>& tokenIds) {
+std::optional<tt::runners::llm_engine::TokenResult>
+SpPrefillModelRunner::forward(uint32_t taskId,
+                              const std::vector<int64_t>& tokenIds) {
   TT_LOG_DEBUG(
       "SpPrefillModelRunner: Writing into shared memory input task_id={}, "
       "token count={}",
@@ -34,7 +35,7 @@ std::optional<llm_engine::TokenResult> SpPrefillModelRunner::forward(
           "SpPrefillModelRunner: Read from shared memory output task_id={}, "
           "token_id={}, token count={}",
           taskId, tokenId, readBuf.tokenIds.size());
-      return llm_engine::TokenResult(readBuf.taskId, tokenId);
+      return tt::runners::llm_engine::TokenResult(readBuf.taskId, tokenId);
     }
     TT_LOG_DEBUG("SpPrefillModelRunner: Shared memory read failed");
     std::this_thread::yield();

--- a/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/sp_prefill_runner/sp_prefill_runner.cpp
@@ -10,7 +10,7 @@ namespace tt::runners {
 
 SpPrefillRunner::SpPrefillRunner(const config::LLMConfig& config,
                                  ipc::TokenRingBuffer<65536>* resultQueue,
-                                 llm_engine::ITaskQueue* taskQueue)
+                                 tt::runners::llm_engine::ITaskQueue* taskQueue)
     : config(config), resultQueue(resultQueue), taskQueue(taskQueue) {
   modelRunner = sp_prefill::makeModelRunner(config);
 }

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -398,7 +398,7 @@ void LLMService::processStreamingRequest(
   tt::metrics::ServerMetrics::instance().onRequestSubmitted(
       taskId, static_cast<int>(prompt.size()));
 
-  auto sequence = std::make_unique<llm_engine::Sequence>(
+  auto sequence = std::make_unique<tt::runners::llm_engine::Sequence>(
       taskId,
       static_cast<int>(tt::config::llmEngineConfig().kvcache_block_size),
       std::move(tokenIds));
@@ -406,8 +406,9 @@ void LLMService::processStreamingRequest(
   if (request.slotId.has_value()) {
     sequence->setKVCacheSlot(request.slotId.value());
   }
-  sequence->setSamplingParams(std::make_unique<llm_engine::SamplingParams>(
-      tt::utils::mapper::mapSamplingParams(request)));
+  sequence->setSamplingParams(
+      std::make_unique<tt::runners::llm_engine::SamplingParams>(
+          tt::utils::mapper::mapSamplingParams(request)));
   queue_manager_->task_queue->push(*std::move(sequence));
 }
 

--- a/tt-media-server/cpp_server/src/services/memory_services/paged_memory_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/memory_services/paged_memory_manager.cpp
@@ -28,14 +28,15 @@ ManageMemoryResult makeResult(const ManageMemoryTask& task,
 
 }  // namespace
 
-PagedMemoryManager::PagedMemoryManager(llm_engine::BlockManager& bm)
+PagedMemoryManager::PagedMemoryManager(
+    tt::runners::llm_engine::BlockManager& bm)
     : blockManager(&bm) {}
 
 ManageMemoryStatus PagedMemoryManager::allocateKv(
     const ManageMemoryTask& task, std::vector<int>& outSlotIds) {
   std::vector<int64_t> placeholderTokens(1, 0);  // Hardcoded to use one block
-  llm_engine::Sequence seq(task.taskId, blockManager->blockSize(),
-                           std::move(placeholderTokens));
+  tt::runners::llm_engine::Sequence seq(task.taskId, blockManager->blockSize(),
+                                        std::move(placeholderTokens));
 
   if (!blockManager->allocate(seq)) {
     return ManageMemoryStatus::WAITING;
@@ -47,7 +48,7 @@ ManageMemoryStatus PagedMemoryManager::allocateKv(
 
 void PagedMemoryManager::deallocateKv(uint32_t taskId,
                                       std::vector<int> slotIds) {
-  llm_engine::Sequence seq(taskId, blockManager->blockSize(), {});
+  tt::runners::llm_engine::Sequence seq(taskId, blockManager->blockSize(), {});
   seq.getMutableBlockTable() = std::move(slotIds);
   blockManager->deallocate(seq);
 }

--- a/tt-media-server/cpp_server/src/services/memory_services/sp_pipeline_memory_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/memory_services/sp_pipeline_memory_manager.cpp
@@ -6,8 +6,7 @@ namespace tt::services {
 namespace utils = tt::runners::sp_pipeline_utils;
 
 SpPipelineMemoryManager::SpPipelineMemoryManager(
-    tt_blaze::pipeline_manager::PipelineManager& pipelineManager,
-    onEvictCb onEvict)
+    pipeline_manager::PipelineManager& pipelineManager, onEvictCb onEvict)
     : pipelineManager(pipelineManager), onEvict(onEvict) {}
 
 void SpPipelineMemoryManager::handleRequest(
@@ -41,9 +40,9 @@ void SpPipelineMemoryManager::handleResponse(uint32_t requestId,
   allocating.erase(requestId);
   domain::ManageMemoryResult result;
   result.taskId = taskId;
-  if (slotId == tt_blaze::pipeline_manager::INVALID_SLOT) {
+  if (slotId == pipeline_manager::INVALID_SLOT) {
     result.status = domain::ManageMemoryStatus::FAILURE;
-    result.slotIds = {tt_blaze::pipeline_manager::INVALID_SLOT};
+    result.slotIds = {pipeline_manager::INVALID_SLOT};
     resultQueue->push(result);
     return;
   }

--- a/tt-media-server/cpp_server/src/services/memory_services/sp_pipeline_memory_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/memory_services/sp_pipeline_memory_manager.cpp
@@ -6,7 +6,7 @@ namespace tt::services {
 namespace utils = tt::runners::sp_pipeline_utils;
 
 SpPipelineMemoryManager::SpPipelineMemoryManager(
-    tt_blaze::pipeline_manager::PipelineManager& pipelineManager, onEvictCb onEvict)
+    ::pipeline_manager::PipelineManager& pipelineManager, onEvictCb onEvict)
     : pipelineManager(pipelineManager), onEvict(onEvict) {}
 
 void SpPipelineMemoryManager::handleRequest(
@@ -40,9 +40,9 @@ void SpPipelineMemoryManager::handleResponse(uint32_t requestId,
   allocating.erase(requestId);
   domain::ManageMemoryResult result;
   result.taskId = taskId;
-  if (slotId == tt_blaze::pipeline_manager::INVALID_SLOT) {
+  if (slotId == ::pipeline_manager::INVALID_SLOT) {
     result.status = domain::ManageMemoryStatus::FAILURE;
-    result.slotIds = {tt_blaze::pipeline_manager::INVALID_SLOT};
+    result.slotIds = {::pipeline_manager::INVALID_SLOT};
     resultQueue->push(result);
     return;
   }

--- a/tt-media-server/cpp_server/src/services/memory_services/sp_pipeline_memory_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/memory_services/sp_pipeline_memory_manager.cpp
@@ -6,7 +6,7 @@ namespace tt::services {
 namespace utils = tt::runners::sp_pipeline_utils;
 
 SpPipelineMemoryManager::SpPipelineMemoryManager(
-    pipeline_manager::PipelineManager& pipelineManager, onEvictCb onEvict)
+    tt_blaze::pipeline_manager::PipelineManager& pipelineManager, onEvictCb onEvict)
     : pipelineManager(pipelineManager), onEvict(onEvict) {}
 
 void SpPipelineMemoryManager::handleRequest(
@@ -40,9 +40,9 @@ void SpPipelineMemoryManager::handleResponse(uint32_t requestId,
   allocating.erase(requestId);
   domain::ManageMemoryResult result;
   result.taskId = taskId;
-  if (slotId == pipeline_manager::INVALID_SLOT) {
+  if (slotId == tt_blaze::pipeline_manager::INVALID_SLOT) {
     result.status = domain::ManageMemoryStatus::FAILURE;
-    result.slotIds = {pipeline_manager::INVALID_SLOT};
+    result.slotIds = {tt_blaze::pipeline_manager::INVALID_SLOT};
     resultQueue->push(result);
     return;
   }

--- a/tt-media-server/cpp_server/src/utils/mapper.cpp
+++ b/tt-media-server/cpp_server/src/utils/mapper.cpp
@@ -2,9 +2,9 @@
 
 namespace tt::utils::mapper {
 
-llm_engine::SamplingParams mapSamplingParams(
+tt::runners::llm_engine::SamplingParams mapSamplingParams(
     const tt::domain::LLMRequest& request) {
-  llm_engine::SamplingParams params;
+  tt::runners::llm_engine::SamplingParams params;
   params.temperature = request.temperature.value_or(1.0f);
   params.max_tokens = request.max_tokens;
   params.ignore_eos = request.ignore_eos;

--- a/tt-media-server/cpp_server/src/utils/runner_factory.cpp
+++ b/tt-media-server/cpp_server/src/utils/runner_factory.cpp
@@ -14,7 +14,8 @@ namespace tt::utils::runner_factory {
 
 std::unique_ptr<runners::IRunner> createRunner(
     config::ModelService service, const config::RunnerConfig& config,
-    ipc::TokenRingBuffer<65536>* resultQueue, llm_engine::ITaskQueue* taskQueue,
+    ipc::TokenRingBuffer<65536>* resultQueue,
+    tt::runners::llm_engine::ITaskQueue* taskQueue,
     ipc::ICancelQueue* cancelQueue) {
   switch (service) {
     case config::ModelService::EMBEDDING: {

--- a/tt-media-server/cpp_server/tests/cancellation_test.cpp
+++ b/tt-media-server/cpp_server/tests/cancellation_test.cpp
@@ -17,7 +17,7 @@
 #include "runners/llm_runner/prefill_first_scheduler.hpp"
 #include "runners/llm_runner/sequence.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 using Config = tt::config::LLMConfig;
 
@@ -319,4 +319,4 @@ TEST(LLMRunnerCancelTest, CancelBeforeAnyProcessing) {
 }
 
 }  // namespace
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/tests/ipc_scheduler_smoke_test.cpp
+++ b/tt-media-server/cpp_server/tests/ipc_scheduler_smoke_test.cpp
@@ -35,7 +35,7 @@ static constexpr size_t MAX_NUM_MSGS = 64;
 static constexpr size_t MAX_MSG_SIZE = 4096;
 
 int main() {
-  using namespace llm_engine;
+  using namespace tt::runners::llm_engine;
   using Config = tt::config::LLMConfig;
 
   // Clean up any leftover queue from a previous failed run.

--- a/tt-media-server/cpp_server/tests/llm_runner_test.cpp
+++ b/tt-media-server/cpp_server/tests/llm_runner_test.cpp
@@ -14,7 +14,7 @@
 #include "runners/llm_runner.hpp"
 #include "runners/llm_runner/in_memory_task_queue.hpp"
 #include "runners/llm_runner/sequence.hpp"
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 using Config = tt::config::LLMConfig;
 
@@ -106,4 +106,4 @@ TEST(LLMRunnerTest, AllTokensPublishedInOrder) {
 }
 
 }  // namespace
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/tests/scheduler_test.cpp
+++ b/tt-media-server/cpp_server/tests/scheduler_test.cpp
@@ -14,7 +14,7 @@
 #include "runners/llm_runner/scheduler.hpp"
 #include "runners/llm_runner/sequence.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 
 using Config = tt::config::LLMConfig;
 using SchedulingPolicy = tt::config::SchedulingPolicy;
@@ -522,4 +522,4 @@ TEST(MaxOccupancySchedulerTest, ContinuousRefill_MaintainsFullOccupancy) {
   EXPECT_EQ(b3.size(), 2u);
 }
 }  // namespace
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/tests/sequence_test.cpp
+++ b/tt-media-server/cpp_server/tests/sequence_test.cpp
@@ -11,7 +11,7 @@
 #include "runners/llm_runner/sampling_params.hpp"
 #include "utils/id_generator.hpp"
 
-namespace llm_engine {
+namespace tt::runners::llm_engine {
 namespace {
 
 TEST(SamplingParamsTest, SerializeDeserialize_DefaultParams) {
@@ -195,4 +195,4 @@ TEST(SequenceTest, SerializeDeserialize_AfterAppendToken) {
 }
 
 }  // namespace
-}  // namespace llm_engine
+}  // namespace tt::runners::llm_engine


### PR DESCRIPTION
This PR standardizes on `tt::runners::llm_engine` everywhere that matters, updates the using namespace in `llm_runner`, and tweaks comments / log prefixes so they match. 