### PR TITLE
Add Mistral-Small-3.1-24B-Instruct-2503 multimodal support on T3K

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -122,6 +122,16 @@
         }
       }
     },
+    "Mistral-Small-3.1-24B-Instruct-2503": {
+      "inference_engine": "vLLM",
+      "ci": {
+        "nightly": {
+          "devices": [
+            "T3K"
+          ]
+        }
+      }
+    },
     "QwQ-32B": {
       "inference_engine": "vLLM",
       "ci": {

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1171,23 +1171,25 @@ _eval_config_list = [
         hf_model_repo="mistralai/Mistral-Small-3.1-24B-Instruct-2503",
         tasks=[
             EvalTask(
-                task_name="mmlu_pro",
+                task_name="gpqa_diamond_generative_n_shot",
                 num_fewshot=5,
                 max_concurrent=8,
                 apply_chat_template=False,
                 score=EvalTaskScore(
-                    published_score=66.76,
-                    published_score_ref="https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503",
+                    published_score=45.96,
+                    published_score_ref="https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503#instruction-evals",
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref="TBD",
                     score_func=score_task_single_key,
                     score_func_kwargs={
                         "result_keys": [
-                            "exact_match,custom-extract",
+                            "exact_match,flexible-extract",
                         ],
                         "unit": "percent",
                     },
                 ),
                 limit_samples_map={
-                    EvalLimitMode.CI_NIGHTLY: 0.02,
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
                     EvalLimitMode.SMOKE_TEST: 0.01,
                 },
             ),

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1186,7 +1186,7 @@ _eval_config_list = [
                     },
                 ),
                 limit_samples_map={
-                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.CI_NIGHTLY: 0.05,
                     EvalLimitMode.SMOKE_TEST: 0.01,
                 },
             ),
@@ -1210,7 +1210,6 @@ _eval_config_list = [
                 batch_size=16,
                 model_kwargs={
                     "model": "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
                     "tokenizer_backend": "huggingface",
                     "fix_mistral_regex": True,
                     "max_length": 65536,

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1188,6 +1188,9 @@ _eval_config_list = [
                         "unit": "percent",
                     },
                 ),
+                model_kwargs={
+                    "fix_mistral_regex": True,
+                },
                 limit_samples_map={
                     EvalLimitMode.CI_NIGHTLY: 0.2,
                     EvalLimitMode.SMOKE_TEST: 0.01,
@@ -1213,11 +1216,8 @@ _eval_config_list = [
                 apply_chat_template=False,
                 batch_size=16,
                 model_kwargs={
-                    "model": "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
-                    "tokenizer_backend": "huggingface",
                     "fix_mistral_regex": True,
                     "max_length": 65536,
-                    "timeout": "3600",
                 },
                 gen_kwargs={
                     "max_gen_toks": "256",

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1209,7 +1209,7 @@ _eval_config_list = [
                     },
                 ),
                 apply_chat_template=False,
-                batch_size=16,
+                max_concurrent=32,
                 gen_kwargs={
                     "max_gen_toks": "256",
                     "do_sample": "false",

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1174,7 +1174,7 @@ _eval_config_list = [
                 task_name="gpqa_diamond_generative_n_shot",
                 num_fewshot=5,
                 max_concurrent=8,
-                apply_chat_template=False,
+                use_chat_api=True,
                 score=EvalTaskScore(
                     published_score=45.96,
                     published_score_ref="https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503#instruction-evals",
@@ -1230,9 +1230,12 @@ _eval_config_list = [
                 },
             ),
             EvalTask(
+                eval_class="openai_compatible",
                 task_name="chartqa",
                 max_concurrent=8,
-                workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
+                workflow_venv_type=WorkflowVenvType.EVALS_VISION,
+                apply_chat_template=False,
+                use_chat_api=True,
                 score=EvalTaskScore(
                     published_score=86.24,
                     published_score_ref="https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503",
@@ -1241,17 +1244,25 @@ _eval_config_list = [
                     score_func=score_task_single_key,
                     score_func_kwargs={
                         "result_keys": [
-                            "exact_match,none",
+                            "relaxed_overall,none",
                         ],
                         "unit": "percent",
                     },
                 ),
-                apply_chat_template=False,
-                batch_size=16,
+                model_kwargs={
+                    "max_retries": 1,
+                    "tokenized_requests": "False",
+                    "add_bos_token": "True",
+                    "timeout": "9999",
+                    "eos_string": "<|end_of_text|>",
+                },
                 gen_kwargs={
-                    "max_gen_toks": "256",
-                    "do_sample": "false",
-                    "stream": "false",
+                    "stop": "</s>",
+                    "stream": "False",
+                },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01,
                 },
             ),
         ],

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1173,7 +1173,6 @@ _eval_config_list = [
             EvalTask(
                 task_name="gpqa_diamond_generative_n_shot",
                 num_fewshot=5,
-                max_concurrent=8,
                 use_chat_api=True,
                 score=EvalTaskScore(
                     published_score=45.96,
@@ -1188,9 +1187,6 @@ _eval_config_list = [
                         "unit": "percent",
                     },
                 ),
-                model_kwargs={
-                    "fix_mistral_regex": True,
-                },
                 limit_samples_map={
                     EvalLimitMode.CI_NIGHTLY: 0.2,
                     EvalLimitMode.SMOKE_TEST: 0.01,
@@ -1198,7 +1194,6 @@ _eval_config_list = [
             ),
             EvalTask(
                 task_name="humaneval_instruct",
-                max_concurrent=8,
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 score=EvalTaskScore(
                     published_score=88.41,
@@ -1215,10 +1210,6 @@ _eval_config_list = [
                 ),
                 apply_chat_template=False,
                 batch_size=16,
-                model_kwargs={
-                    "fix_mistral_regex": True,
-                    "max_length": 65536,
-                },
                 gen_kwargs={
                     "max_gen_toks": "256",
                     "do_sample": "false",
@@ -1232,7 +1223,6 @@ _eval_config_list = [
             EvalTask(
                 eval_class="openai_compatible",
                 task_name="chartqa",
-                max_concurrent=8,
                 workflow_venv_type=WorkflowVenvType.EVALS_VISION,
                 apply_chat_template=False,
                 use_chat_api=True,

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1173,6 +1173,7 @@ _eval_config_list = [
             EvalTask(
                 task_name="mmlu_pro",
                 num_fewshot=5,
+                max_concurrent=8,
                 apply_chat_template=False,
                 score=EvalTaskScore(
                     published_score=66.76,
@@ -1186,12 +1187,13 @@ _eval_config_list = [
                     },
                 ),
                 limit_samples_map={
-                    EvalLimitMode.CI_NIGHTLY: 0.05,
+                    EvalLimitMode.CI_NIGHTLY: 0.02,
                     EvalLimitMode.SMOKE_TEST: 0.01,
                 },
             ),
             EvalTask(
                 task_name="humaneval_instruct",
+                max_concurrent=8,
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 score=EvalTaskScore(
                     published_score=88.41,
@@ -1227,6 +1229,7 @@ _eval_config_list = [
             ),
             EvalTask(
                 task_name="chartqa",
+                max_concurrent=8,
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 score=EvalTaskScore(
                     published_score=86.24,

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1168,6 +1168,91 @@ _eval_config_list = [
         ],
     ),
     EvalConfig(
+        hf_model_repo="mistralai/Mistral-Small-3.1-24B-Instruct-2503",
+        tasks=[
+            EvalTask(
+                task_name="mmlu_pro",
+                num_fewshot=5,
+                apply_chat_template=False,
+                score=EvalTaskScore(
+                    published_score=66.76,
+                    published_score_ref="https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": [
+                            "exact_match,custom-extract",
+                        ],
+                        "unit": "percent",
+                    },
+                ),
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01,
+                },
+            ),
+            EvalTask(
+                task_name="humaneval_instruct",
+                workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
+                score=EvalTaskScore(
+                    published_score=88.41,
+                    published_score_ref="https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503",
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref="TBD",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": [
+                            "pass@1,create_test",
+                        ],
+                        "unit": "percent",
+                    },
+                ),
+                apply_chat_template=False,
+                batch_size=16,
+                model_kwargs={
+                    "model": "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
+                    "base_url": "http://127.0.0.1:8000/v1/completions",
+                    "tokenizer_backend": "huggingface",
+                    "fix_mistral_regex": True,
+                    "max_length": 65536,
+                    "timeout": "3600",
+                },
+                gen_kwargs={
+                    "max_gen_toks": "256",
+                    "do_sample": "false",
+                    "stream": "false",
+                },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.5,
+                    EvalLimitMode.SMOKE_TEST: 0.05,
+                },
+            ),
+            EvalTask(
+                task_name="chartqa",
+                workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
+                score=EvalTaskScore(
+                    published_score=86.24,
+                    published_score_ref="https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503",
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref="TBD",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": [
+                            "exact_match,none",
+                        ],
+                        "unit": "percent",
+                    },
+                ),
+                apply_chat_template=False,
+                batch_size=16,
+                gen_kwargs={
+                    "max_gen_toks": "256",
+                    "do_sample": "false",
+                    "stream": "false",
+                }, 
+            ),
+        ],
+    ),
+    EvalConfig(
         hf_model_repo="Qwen/QwQ-32B",
         tasks=[
             EvalTask(

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1252,7 +1252,7 @@ _eval_config_list = [
                     "max_gen_toks": "256",
                     "do_sample": "false",
                     "stream": "false",
-                }, 
+                },
             ),
         ],
     ),

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1396,7 +1396,7 @@ llm_templates = [
     ModelSpecTemplate(
         weights=["mistralai/Mistral-Small-3.1-24B-Instruct-2503"],
         impl=tt_transformers_impl,
-        tt_metal_commit="81188eb",
+        tt_metal_commit="9e3b1b3",
         vllm_commit="1d0aa18",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1396,8 +1396,8 @@ llm_templates = [
     ModelSpecTemplate(
         weights=["mistralai/Mistral-Small-3.1-24B-Instruct-2503"],
         impl=tt_transformers_impl,
-        tt_metal_commit="1207449",
-        vllm_commit="a5e73cf",
+        tt_metal_commit="81188eb",
+        vllm_commit="1d0aa18",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
             DeviceModelSpec(

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1394,6 +1394,27 @@ llm_templates = [
         },
     ),
     ModelSpecTemplate(
+        weights=["mistralai/Mistral-Small-3.1-24B-Instruct-2503"],
+        impl=tt_transformers_impl,
+        tt_metal_commit="1207449",
+        vllm_commit="a5e73cf",
+        inference_engine=InferenceEngine.VLLM.value,
+        device_model_specs=[
+            DeviceModelSpec(
+                device=DeviceTypes.T3K,
+                max_concurrency=16,
+                max_context=128 * 1024,
+                default_impl=True,
+            ),
+        ],
+        model_type=ModelType.VLM,
+        status=ModelStatusTypes.EXPERIMENTAL,
+        supported_modalities=["text", "image"],
+        env_vars={
+            "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+        },
+    ),
+    ModelSpecTemplate(
         weights=["Qwen/QwQ-32B"],
         impl=tt_transformers_impl,
         tt_metal_commit="e95ffa5",

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1405,6 +1405,9 @@ llm_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                override_tt_config={
+                    "trace_region_size": 90000000,
+                },
                 vllm_args={
                     "limit-mm-per-prompt": json.dumps({"image": 1}),
                     "disable_mm_preprocessor_cache": True,
@@ -1413,6 +1416,7 @@ llm_templates = [
         ],
         model_type=ModelType.VLM,
         status=ModelStatusTypes.EXPERIMENTAL,
+        has_builtin_warmup=True,
         supported_modalities=["text", "image"],
         env_vars={
             "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1402,9 +1402,13 @@ llm_templates = [
         device_model_specs=[
             DeviceModelSpec(
                 device=DeviceTypes.T3K,
-                max_concurrency=16,
+                max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                vllm_args={
+                    "limit-mm-per-prompt": json.dumps({"image": 1}),
+                    "disable_mm_preprocessor_cache": True,
+                },
             ),
         ],
         model_type=ModelType.VLM,


### PR DESCRIPTION
## Summary
Model Readiness Ticket: https://github.com/tenstorrent/tt-inference-server/issues/1725
- Add `ModelSpecTemplate` for `Mistral-Small-3.1-24B-Instruct-2503` as `ModelType.VLM` on T3K
- Add eval configs for `gpqa_diamond`, `humaneval_instruct`, and `chartqa`
- Set `max_concurrency=32`, `max_context=128K` consistent with other T3K VLMs (Gemma-3-27b, Qwen2.5-VL-32B, etc.)
- Add VLM-specific vllm_args: `limit-mm-per-prompt: {"image": 1}` (Mistral 3.1 does not support multi-image), `disable_mm_preprocessor_cache: True`
- Eval `max_concurrent` set to 8 for evals as workaround for #2563 (device hang under high concurrency)

## Dependencies

| Repo | PR | Status | Notes |
|---|---|---|---|
| tenstorrent/vllm | [#331](https://github.com/tenstorrent/vllm/pull/331) | Merged to `dev` | Adds TT model support for Mistral 3.1 multimodal (`vllm_commit=1d0aa18`) |
| tenstorrent/tt-metal | [#40502](https://github.com/tenstorrent/tt-metal/pull/40502) | Merged to `main` | Add TT support for Mistral-Small-3.1-24B-Instruct-2503 multimodal model (`tt_metal_commit=81188eb`) |
| tenstorrent/tt-metal | #40108 | Open | Fixes batched prefill DRAM OOM affecting both Gemma and Mistral. `tt_metal_commit` should be updated once merged. |

## Changes

```
 .github/workflows/models-ci-config.json | +10 (add to Models CI)
 evals/eval_config.py    | +100 (3 eval tasks)
 workflows/model_spec.py | +25 (model spec template)
```

## Known issues

- **Batched prefill OOM** at ISL=16384 benchmark sweep: 6 requests co-scheduled for batched prefill with `padded_batch=32` instead of `padded_batch=8` causes a 2 GiB DRAM allocation failure. Fix is in tt-metal#40108.
- **Intermittent device hang** (#2563): AllGatherAsync deadlock under concurrency >= 16, unrelated to the OOM. Eval `max_concurrent=8` avoids this.

## Test plan

- [x] Server starts and serves requests on T3K
- [x] `gpqa_diamond` eval passes (`max_concurrent=8`)
- [x] `humaneval_instruct` eval passes (`max_concurrent=8`)
- [x] `chartqa` eval passes (`max_concurrent=8`)
- [x] Benchmark sweeps ISL=128 through ISL=8192 complete successfully
- [ ] Benchmark sweep ISL=16384 completes without OOM (requires tt-metal#40108)
- [x] Update `tt_metal_commit` once tt-metal#40108 merges
