### PR TITLE
[Gemma-3] Bump tt-metal commit SHA to apply batched prefill DRAM OOM fix in tt-metal

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -2270,8 +2270,8 @@ vlm_templates = [
             "google/medgemma-4b-it",
         ],
         impl=tt_transformers_impl,
-        tt_metal_commit="c254ee3",
-        vllm_commit="c4f2327",
+        tt_metal_commit="aecd1d7",
+        vllm_commit="0da90eb",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
             DeviceModelSpec(
@@ -2314,8 +2314,8 @@ vlm_templates = [
             "google/medgemma-27b-it",
         ],
         impl=tt_transformers_impl,
-        tt_metal_commit="0b10c51",
-        vllm_commit="3499ffa",
+        tt_metal_commit="aecd1d7",
+        vllm_commit="0da90eb",
         inference_engine=InferenceEngine.VLLM.value,
         device_model_specs=[
             DeviceModelSpec(


### PR DESCRIPTION
Gemma-3-27b-it no longer fails the RULER eval with DRAM OOM: 
```
TT_FATAL: Out of Memory: Not enough space to allocate 11274289152 B DRAM buffer across 12 banks (bank size: 1021821792 B, allocated: 908831392 B, free: 112990400 B)
```
ref: https://github.com/tenstorrent/tt-inference-server/issues/2389