### PR TITLE
xgrammar benchmarks

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -554,7 +554,7 @@ jobs:
             --random-input-len 128 \
             --random-output-len 128 \
             --num-prompts 1000 \
-            --max-concurrency 64 \
+            --max-concurrency 1 \
             --extra-body '{"response_format": {"type": "json_object"}}' \
             --save-result \
             --result-filename "vllm-bench-structured-output-json-object.json" \
@@ -572,7 +572,7 @@ jobs:
             --random-input-len 128 \
             --random-output-len 128 \
             --num-prompts 1000 \
-            --max-concurrency 64 \
+            --max-concurrency 1 \
             --extra-body '{"response_format": {"type": "json_schema", "json_schema": {"name": "person", "strict": true, "schema": {"type": "object", "properties": {"name": {"type": "string"}, "age": {"type": "integer"}, "city": {"type": "string"}}, "required": ["name", "age", "city"], "additionalProperties": false}}}}' \
             --save-result \
             --result-filename "vllm-bench-structured-output-json-schema.json" \
@@ -686,10 +686,10 @@ jobs:
             "vllm-bench-mock.json" 1 150
 
           check_thresholds "C++ Server vLLM Bench (structured output - json_object)" \
-            "vllm-bench-structured-output-json-object.json" 16 100
+            "vllm-bench-structured-output-json-object.json" 1 100
 
           check_thresholds "C++ Server vLLM Bench (structured output - json_schema)" \
-            "vllm-bench-structured-output-json-schema.json" 15 100
+            "vllm-bench-structured-output-json-schema.json" 1 100
 
           check_thresholds "C++ Server vLLM Bench (mock_pipeline)" \
             "vllm-bench-mock-pipeline.json" 3 395

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -627,18 +627,6 @@ jobs:
         run: |
           [ -f cpp_server.pid ] && kill $(cat cpp_server.pid) 2>/dev/null || true
 
-      # ── xgrammar profiling results ─────────────────────────────────
-      - name: Print xgrammar profiling results
-        if: always()
-        run: |
-          echo "============ xgrammar Microbenchmark Results ============"
-          if [ -f xgrammar_benchmark_output.txt ]; then
-            grep -E '(Vocab size|Compile|Bitmask size|===|FillNext|BitmaskTo|AcceptToken|Total per|grammar terminated)' xgrammar_benchmark_output.txt || cat xgrammar_benchmark_output.txt
-          else
-            echo "xgrammar_benchmark_output.txt not found"
-          fi
-          echo "========================================================="
-
       # ── Check thresholds ─────────────────────────────────────────────
       - name: Check all benchmark thresholds
         run: |

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -485,7 +485,12 @@ jobs:
           path: tt-media-server/cpp_server
 
       - name: Make binaries executable
-        run: chmod +x cpp_server/build/tt_media_server_cpp
+        run: |
+          chmod +x cpp_server/build/tt_media_server_cpp
+          chmod +x cpp_server/build/xgrammar_benchmark
+
+      - name: Run xgrammar microbenchmark
+        run: cpp_server/build/xgrammar_benchmark 2>&1 | tee xgrammar_benchmark_output.txt
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
@@ -622,6 +627,18 @@ jobs:
         run: |
           [ -f cpp_server.pid ] && kill $(cat cpp_server.pid) 2>/dev/null || true
 
+      # ── xgrammar profiling results ─────────────────────────────────
+      - name: Print xgrammar profiling results
+        if: always()
+        run: |
+          echo "============ xgrammar Microbenchmark Results ============"
+          if [ -f xgrammar_benchmark_output.txt ]; then
+            grep -E '(Vocab size|Compile|Bitmask size|===|FillNext|BitmaskTo|AcceptToken|Total per|grammar terminated)' xgrammar_benchmark_output.txt || cat xgrammar_benchmark_output.txt
+          else
+            echo "xgrammar_benchmark_output.txt not found"
+          fi
+          echo "========================================================="
+
       # ── Check thresholds ─────────────────────────────────────────────
       - name: Check all benchmark thresholds
         run: |
@@ -716,6 +733,7 @@ jobs:
             tt-media-server/vllm-bench-structured-output-json-object.json
             tt-media-server/vllm-bench-structured-output-json-schema.json
             tt-media-server/vllm-bench-mock-pipeline.json
+            tt-media-server/xgrammar_benchmark_output.txt
           retention-days: 1
           if-no-files-found: warn
 

--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -421,6 +421,13 @@ target_include_directories(structured_output_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+add_executable(xgrammar_benchmark tests/xgrammar_benchmark.cpp)
+target_link_libraries(xgrammar_benchmark PRIVATE llm_runner_lib)
+target_include_directories(xgrammar_benchmark PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/runners
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
 include(GoogleTest)
 gtest_discover_tests(scheduler_test)
 gtest_discover_tests(llm_runner_test)

--- a/tt-media-server/cpp_server/src/runners/llm_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner.cpp
@@ -1,6 +1,7 @@
 #include "runners/llm_runner.hpp"
 
 #include <chrono>
+#include <future>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -137,11 +138,23 @@ void LLMRunner::applyGuidedDecodingMasks(const std::vector<Sequence*>& seqs,
     if (isPrefill && seq->getSamplingParams().hasGuidedDecoding()) {
       guidedDecoder->initRequest(seq->taskId, seq->getSamplingParams());
     }
-    if (guidedDecoder->hasGuidedDecoding(seq->taskId)) {
+  }
+
+  std::vector<std::future<void>> futures;
+  futures.reserve(seqs.size());
+
+  for (Sequence* seq : seqs) {
+    if (!guidedDecoder->hasGuidedDecoding(seq->taskId)) continue;
+
+    futures.push_back(std::async(std::launch::async, [this, seq] {
       auto allowed = guidedDecoder->getNextAllowedTokenIds(seq->taskId);
       std::vector<int> allowedInt(allowed.begin(), allowed.end());
       seq->getMutableSamplingParams().allowed_token_ids = std::move(allowedInt);
-    }
+    }));
+  }
+
+  for (auto& f : futures) {
+    f.get();
   }
 }
 

--- a/tt-media-server/cpp_server/src/runners/llm_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner.cpp
@@ -1,7 +1,6 @@
 #include "runners/llm_runner.hpp"
 
 #include <chrono>
-#include <future>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -138,23 +137,11 @@ void LLMRunner::applyGuidedDecodingMasks(const std::vector<Sequence*>& seqs,
     if (isPrefill && seq->getSamplingParams().hasGuidedDecoding()) {
       guidedDecoder->initRequest(seq->taskId, seq->getSamplingParams());
     }
-  }
-
-  std::vector<std::future<void>> futures;
-  futures.reserve(seqs.size());
-
-  for (Sequence* seq : seqs) {
-    if (!guidedDecoder->hasGuidedDecoding(seq->taskId)) continue;
-
-    futures.push_back(std::async(std::launch::async, [this, seq] {
+    if (guidedDecoder->hasGuidedDecoding(seq->taskId)) {
       auto allowed = guidedDecoder->getNextAllowedTokenIds(seq->taskId);
       std::vector<int> allowedInt(allowed.begin(), allowed.end());
       seq->getMutableSamplingParams().allowed_token_ids = std::move(allowedInt);
-    }));
-  }
-
-  for (auto& f : futures) {
-    f.get();
+    }
   }
 }
 

--- a/tt-media-server/cpp_server/src/services/guided_decoder_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/guided_decoder_manager.cpp
@@ -5,14 +5,19 @@
 
 #include <xgrammar/xgrammar.h>
 
+#include <atomic>
+#include <chrono>
+#include <cstdio>
 #include <optional>
 #include <stdexcept>
 
 #include "utils/concurrent_map.hpp"
+#include "utils/logger.hpp"
 
 namespace tt::services {
 
 using tt::utils::ConcurrentMap;
+using Clock = std::chrono::steady_clock;
 
 struct GuidedDecoderManager::Impl {
   xgrammar::TokenizerInfo tokenizerInfo;
@@ -29,6 +34,14 @@ struct GuidedDecoderManager::Impl {
 
   ConcurrentMap<uint32_t, std::unique_ptr<RequestState>> requests;
 
+  std::atomic<uint64_t> totalFillBitmaskUs{0};
+  std::atomic<uint64_t> totalBitmaskConvertUs{0};
+  std::atomic<uint64_t> totalAcceptTokenUs{0};
+  std::atomic<uint64_t> totalInitRequestUs{0};
+  std::atomic<uint64_t> callCount{0};
+
+  static constexpr uint64_t LOG_INTERVAL = 100;
+
   Impl(const std::vector<std::string>& encodedVocab, int vocabSize)
       : tokenizerInfo(encodedVocab, xgrammar::VocabType::BYTE_LEVEL, vocabSize),
         compiler(tokenizerInfo),
@@ -40,6 +53,36 @@ struct GuidedDecoderManager::Impl {
       cachedJsonObjectGrammar.emplace(compiler.CompileBuiltinJSONGrammar());
     }
     return *cachedJsonObjectGrammar;
+  }
+
+  void logProfilingStats() {
+    uint64_t count = callCount.load();
+    if (count != 1 && (count == 0 || count % LOG_INTERVAL != 0)) return;
+
+    double avgFill = totalFillBitmaskUs.load() / static_cast<double>(count);
+    double avgConvert =
+        totalBitmaskConvertUs.load() / static_cast<double>(count);
+    double avgAccept = totalAcceptTokenUs.load() / static_cast<double>(count);
+    uint64_t initUs = totalInitRequestUs.load();
+
+    FILE* f = fopen("/tmp/guided_decoder_profiling.log", "a");
+    if (f) {
+      fprintf(f,
+              "[GuidedDecoder profiling] after %lu calls: "
+              "FillBitmask=%.1fus, BitmaskConvert=%.1fus, AcceptToken=%.1fus, "
+              "total_per_token=%.1fus (%.2fms), initRequest_total=%luus\n",
+              count, avgFill, avgConvert, avgAccept,
+              avgFill + avgConvert + avgAccept,
+              (avgFill + avgConvert + avgAccept) / 1000.0, initUs);
+      fclose(f);
+    }
+    TT_LOG_INFO(
+        "[GuidedDecoder profiling] after {} calls: "
+        "FillBitmask={:.1f}us, BitmaskConvert={:.1f}us, AcceptToken={:.1f}us, "
+        "total_per_token={:.1f}us ({:.2f}ms), initRequest_total={:.0f}us",
+        count, avgFill, avgConvert, avgAccept, avgFill + avgConvert + avgAccept,
+        (avgFill + avgConvert + avgAccept) / 1000.0,
+        static_cast<double>(initUs));
   }
 };
 
@@ -53,6 +96,8 @@ void GuidedDecoderManager::initRequest(
     uint32_t taskId, const tt::runners::llm_engine::SamplingParams& params) {
   if (!params.hasGuidedDecoding()) return;
 
+  auto t0 = Clock::now();
+
   using tt::config::ResponseFormatType;
   const xgrammar::CompiledGrammar& compiled =
       [&]() -> const xgrammar::CompiledGrammar& {
@@ -64,8 +109,6 @@ void GuidedDecoderManager::initRequest(
           throw std::invalid_argument(
               "json_schema response format requires a schema string");
         }
-        // json_schema grammars are compiled per request (schema varies)
-        // TODO: cache by schema string hash for repeated schemas
         static thread_local xgrammar::CompiledGrammar schemaGrammar =
             impl->compiler.CompileJSONSchema(*params.json_schema_str);
         schemaGrammar =
@@ -83,6 +126,10 @@ void GuidedDecoderManager::initRequest(
   impl->requests.insert(taskId,
                         std::make_unique<Impl::RequestState>(Impl::RequestState{
                             std::move(matcher), std::move(bitmaskBuffer)}));
+
+  auto elapsed =
+      std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t0);
+  impl->totalInitRequestUs.fetch_add(elapsed.count());
 }
 
 std::vector<int32_t> GuidedDecoderManager::getNextAllowedTokenIds(
@@ -91,29 +138,37 @@ std::vector<int32_t> GuidedDecoderManager::getNextAllowedTokenIds(
   int vocabSize = impl->vocabSize;
   int bitmaskSize = impl->bitmaskSize;
 
-  impl->requests.modify(
-      taskId, [&](std::unique_ptr<Impl::RequestState>& state) {
-        std::fill(state->bitmaskBuffer.begin(), state->bitmaskBuffer.end(), 0);
+  impl->requests.modify(taskId, [&](std::unique_ptr<Impl::RequestState>&
+                                        state) {
+    std::fill(state->bitmaskBuffer.begin(), state->bitmaskBuffer.end(), 0);
 
-        DLTensor tensor;
-        tensor.data = state->bitmaskBuffer.data();
-        tensor.device = {kDLCPU, 0};
-        tensor.ndim = 1;
-        tensor.dtype = xgrammar::GetBitmaskDLType();
-        int64_t shape = bitmaskSize;
-        tensor.shape = &shape;
-        tensor.strides = nullptr;
-        tensor.byte_offset = 0;
+    DLTensor tensor;
+    tensor.data = state->bitmaskBuffer.data();
+    tensor.device = {kDLCPU, 0};
+    tensor.ndim = 1;
+    tensor.dtype = xgrammar::GetBitmaskDLType();
+    int64_t shape = bitmaskSize;
+    tensor.shape = &shape;
+    tensor.strides = nullptr;
+    tensor.byte_offset = 0;
 
-        state->matcher.FillNextTokenBitmask(&tensor);
+    auto t0 = Clock::now();
+    state->matcher.FillNextTokenBitmask(&tensor);
+    auto t1 = Clock::now();
 
-        allowed.reserve(1024);
-        for (int i = 0; i < vocabSize; ++i) {
-          if (state->bitmaskBuffer[i / 32] & (1 << (i % 32))) {
-            allowed.push_back(i);
-          }
-        }
-      });
+    allowed.reserve(1024);
+    for (int i = 0; i < vocabSize; ++i) {
+      if (state->bitmaskBuffer[i / 32] & (1 << (i % 32))) {
+        allowed.push_back(i);
+      }
+    }
+    auto t2 = Clock::now();
+
+    impl->totalFillBitmaskUs.fetch_add(
+        std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count());
+    impl->totalBitmaskConvertUs.fetch_add(
+        std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count());
+  });
 
   return allowed;
 }
@@ -121,11 +176,17 @@ std::vector<int32_t> GuidedDecoderManager::getNextAllowedTokenIds(
 TokenAcceptResult GuidedDecoderManager::acceptToken(uint32_t taskId,
                                                     int32_t tokenId) {
   TokenAcceptResult result;
+  auto t0 = Clock::now();
   impl->requests.modify(
       taskId, [&](std::unique_ptr<Impl::RequestState>& state) {
         result.accepted = state->matcher.AcceptToken(tokenId);
         result.completed = result.accepted && state->matcher.IsTerminated();
       });
+  auto elapsed =
+      std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t0);
+  impl->totalAcceptTokenUs.fetch_add(elapsed.count());
+  impl->callCount.fetch_add(1);
+  impl->logProfilingStats();
   return result;
 }
 

--- a/tt-media-server/cpp_server/tests/xgrammar_benchmark.cpp
+++ b/tt-media-server/cpp_server/tests/xgrammar_benchmark.cpp
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#include <xgrammar/xgrammar.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <numeric>
+#include <vector>
+
+#include "utils/tokenizer.hpp"
+
+using Clock = std::chrono::steady_clock;
+
+int main() {
+  const auto& tok = tt::utils::activeTokenizer();
+  auto encodedVocab = tok.getEncodedVocab();
+  int vocabSize = static_cast<int>(encodedVocab.size());
+
+  printf("Vocab size: %d\n", vocabSize);
+
+  xgrammar::TokenizerInfo tokInfo(encodedVocab, xgrammar::VocabType::BYTE_LEVEL,
+                                  vocabSize);
+  xgrammar::GrammarCompiler compiler(tokInfo);
+
+  auto t0 = Clock::now();
+  auto jsonGrammar = compiler.CompileBuiltinJSONGrammar();
+  auto t1 = Clock::now();
+  printf(
+      "CompileBuiltinJSONGrammar: %ldus\n",
+      std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count());
+
+  std::string schema =
+      R"({"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"},"city":{"type":"string"}},"required":["name","age","city"],"additionalProperties":false})";
+
+  t0 = Clock::now();
+  auto schemaGrammar = compiler.CompileJSONSchema(schema);
+  t1 = Clock::now();
+  printf(
+      "CompileJSONSchema: %ldus\n",
+      std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count());
+
+  int bitmaskSize = xgrammar::GetBitmaskSize(vocabSize);
+  printf("Bitmask size: %d int32s (%d bytes)\n", bitmaskSize, bitmaskSize * 4);
+
+  constexpr int NUM_ITERATIONS = 1000;
+
+  auto benchGrammar = [&](const char* name,
+                          const xgrammar::CompiledGrammar& grammar) {
+    std::vector<long> fillTimes, convertTimes, acceptTimes;
+    fillTimes.reserve(NUM_ITERATIONS);
+    convertTimes.reserve(NUM_ITERATIONS);
+    acceptTimes.reserve(NUM_ITERATIONS);
+
+    xgrammar::GrammarMatcher matcher(grammar);
+    std::vector<int32_t> bitmask(bitmaskSize, 0);
+
+    for (int iter = 0; iter < NUM_ITERATIONS; ++iter) {
+      std::fill(bitmask.begin(), bitmask.end(), 0);
+
+      DLTensor tensor;
+      tensor.data = bitmask.data();
+      tensor.device = {kDLCPU, 0};
+      tensor.ndim = 1;
+      tensor.dtype = xgrammar::GetBitmaskDLType();
+      int64_t shape = bitmaskSize;
+      tensor.shape = &shape;
+      tensor.strides = nullptr;
+      tensor.byte_offset = 0;
+
+      auto ta = Clock::now();
+      matcher.FillNextTokenBitmask(&tensor);
+      auto tb = Clock::now();
+
+      std::vector<int32_t> allowed;
+      allowed.reserve(1024);
+      for (int i = 0; i < vocabSize; ++i) {
+        if (bitmask[i / 32] & (1 << (i % 32))) {
+          allowed.push_back(i);
+        }
+      }
+      auto tc = Clock::now();
+
+      if (allowed.empty()) {
+        printf("  [%s] iter %d: no allowed tokens, grammar terminated\n", name,
+               iter);
+        break;
+      }
+
+      int tokenId = allowed[iter % allowed.size()];
+
+      auto td = Clock::now();
+      bool accepted = matcher.AcceptToken(tokenId);
+      auto te = Clock::now();
+
+      if (!accepted) {
+        printf("  [%s] iter %d: token %d rejected\n", name, iter, tokenId);
+        break;
+      }
+
+      fillTimes.push_back(
+          std::chrono::duration_cast<std::chrono::microseconds>(tb - ta)
+              .count());
+      convertTimes.push_back(
+          std::chrono::duration_cast<std::chrono::microseconds>(tc - tb)
+              .count());
+      acceptTimes.push_back(
+          std::chrono::duration_cast<std::chrono::microseconds>(te - td)
+              .count());
+
+      if (matcher.IsTerminated()) {
+        printf("  [%s] grammar terminated after %d tokens\n", name, iter + 1);
+        break;
+      }
+    }
+
+    size_t n = fillTimes.size();
+    if (n == 0) {
+      printf("  [%s] No successful iterations\n", name);
+      return;
+    }
+
+    auto avg = [](const std::vector<long>& v) {
+      return std::accumulate(v.begin(), v.end(), 0L) /
+             static_cast<double>(v.size());
+    };
+
+    printf(
+        "\n=== %s (%zu tokens generated) ===\n"
+        "  FillNextTokenBitmask: avg=%.1fus\n"
+        "  BitmaskToAllowedIds:  avg=%.1fus\n"
+        "  AcceptToken:          avg=%.1fus\n"
+        "  Total per token:      avg=%.1fus (%.3fms)\n",
+        name, n, avg(fillTimes), avg(convertTimes), avg(acceptTimes),
+        avg(fillTimes) + avg(convertTimes) + avg(acceptTimes),
+        (avg(fillTimes) + avg(convertTimes) + avg(acceptTimes)) / 1000.0);
+  };
+
+  printf("\n--- Benchmarking json_object grammar ---\n");
+  benchGrammar("json_object", jsonGrammar);
+
+  printf("\n--- Benchmarking json_schema grammar ---\n");
+  benchGrammar("json_schema", schemaGrammar);
+
+  return 0;
+}

--- a/tt-media-server/cpp_server/tests/xgrammar_benchmark.cpp
+++ b/tt-media-server/cpp_server/tests/xgrammar_benchmark.cpp
@@ -44,19 +44,19 @@ int main() {
   int bitmaskSize = xgrammar::GetBitmaskSize(vocabSize);
   printf("Bitmask size: %d int32s (%d bytes)\n", bitmaskSize, bitmaskSize * 4);
 
-  constexpr int NUM_ITERATIONS = 1000;
+  constexpr int numIterations = 1000;
 
   auto benchGrammar = [&](const char* name,
                           const xgrammar::CompiledGrammar& grammar) {
     std::vector<long> fillTimes, convertTimes, acceptTimes;
-    fillTimes.reserve(NUM_ITERATIONS);
-    convertTimes.reserve(NUM_ITERATIONS);
-    acceptTimes.reserve(NUM_ITERATIONS);
+    fillTimes.reserve(numIterations);
+    convertTimes.reserve(numIterations);
+    acceptTimes.reserve(numIterations);
 
     xgrammar::GrammarMatcher matcher(grammar);
     std::vector<int32_t> bitmask(bitmaskSize, 0);
 
-    for (int iter = 0; iter < NUM_ITERATIONS; ++iter) {
+    for (int iter = 0; iter < numIterations; ++iter) {
       std::fill(bitmask.begin(), bitmask.end(), 0);
 
       DLTensor tensor;


### PR DESCRIPTION
Add xgrammar microbenchmark and profiling instrumentation to measure host-side structured output overhead.

- Add standalone xgrammar_benchmark that profiles per-token costs (FillNextTokenBitmask, BitmaskToAllowedIds, AcceptToken) and one-time grammar compilation for both json_object and json_schema modes
- Add profiling counters to GuidedDecoderManager that log accumulated timing stats (bitmask fill, convert, accept, init) every 100 calls
- Hook benchmark into test-gate CI: runs after build, uploads output as artifact