### PR TITLE
OpenAPI Spec Validation

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -400,6 +400,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Validate OpenAPI spec against registered routes
+        run: |
+          pip install openapi-spec-validator --quiet
+          cd cpp_server
+          python3 tools/validate_openapi.py
+
       - name: Install C++ build dependencies
         run: cpp_server/install_dependencies.sh
 
@@ -418,11 +424,6 @@ jobs:
         run: |
           cd cpp_server
           ./build.sh --clang-tidy
-
-      - name: Validate OpenAPI spec against registered routes
-        run: |
-          cd cpp_server
-          python3 tools/validate_openapi.py
 
   cpp-build:
     needs: detect-changes

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -419,6 +419,11 @@ jobs:
           cd cpp_server
           ./build.sh --clang-tidy
 
+      - name: Validate OpenAPI spec against registered routes
+        run: |
+          cd cpp_server
+          python3 tools/validate_openapi.py
+
   cpp-build:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.cpp-server == 'true' }}

--- a/tt-media-server/cpp_server/resources/openapi.json
+++ b/tt-media-server/cpp_server/resources/openapi.json
@@ -25,6 +25,10 @@
       "description": "OpenAI-compatible chat completion endpoints"
     },
     {
+      "name": "Embeddings",
+      "description": "OpenAI-compatible text embedding endpoints"
+    },
+    {
       "name": "Sessions",
       "description": "Session management for slot assignments"
     },
@@ -78,6 +82,49 @@
           },
           "401": {
             "description": "Missing or invalid authentication token",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "503": {
+            "description": "Model not ready",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/embeddings": {
+      "post": {
+        "tags": ["Embeddings"],
+        "summary": "Create embeddings",
+        "description": "Creates an embedding vector for the provided input text. OpenAI-compatible endpoint.",
+        "operationId": "createEmbedding",
+        "security": [{ "BearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/EmbeddingRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Embedding created successfully",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EmbeddingResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Error" }
@@ -535,6 +582,57 @@
           "is_ready": {
             "type": "boolean",
             "description": "Whether worker is ready"
+          }
+        }
+      },
+      "EmbeddingRequest": {
+        "type": "object",
+        "required": ["model", "input"],
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "Model identifier to use for embedding",
+            "example": "text-embedding-ada-002"
+          },
+          "input": {
+            "type": "string",
+            "description": "Text to embed"
+          },
+          "user": {
+            "type": "string",
+            "description": "Optional user identifier"
+          }
+        }
+      },
+      "EmbeddingResponse": {
+        "type": "object",
+        "properties": {
+          "object": {
+            "type": "string",
+            "enum": ["list"]
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "object": { "type": "string", "enum": ["embedding"] },
+                "index": { "type": "integer" },
+                "embedding": {
+                  "type": "array",
+                  "items": { "type": "number" },
+                  "description": "Embedding vector"
+                }
+              }
+            }
+          },
+          "model": { "type": "string" },
+          "usage": {
+            "type": "object",
+            "properties": {
+              "prompt_tokens": { "type": "integer" },
+              "total_tokens": { "type": "integer" }
+            }
           }
         }
       },

--- a/tt-media-server/cpp_server/tools/validate_openapi.py
+++ b/tt-media-server/cpp_server/tools/validate_openapi.py
@@ -1,12 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-"""Validate that resources/openapi.json matches routes registered with ADD_METHOD_TO macros.
+"""Validate resources/openapi.json in two ways:
+
+1. Schema validity  -- the spec is valid OpenAPI 3.x (via openapi-spec-validator).
+2. Route coverage   -- every ADD_METHOD_TO route in C++ is documented in the spec
+                       and every spec path has a matching C++ route.
 
 Usage:
+    pip install openapi-spec-validator
     python3 tools/validate_openapi.py
 
-Run from the cpp_server directory. Exits 0 if the spec and code agree, 1 if they diverge.
+Run from the cpp_server directory. Exits 0 only if both checks pass.
 """
 
 import json
@@ -14,8 +19,16 @@ import re
 import sys
 from pathlib import Path
 
-# Routes that are registered in code but intentionally omitted from the spec
-# (infrastructure / UI endpoints that callers don't need to know about).
+try:
+    from openapi_spec_validator import validate as validateOpenApiSpec
+    from openapi_spec_validator.readers import read_from_filename
+
+    HAS_VALIDATOR = True
+except ImportError:
+    HAS_VALIDATOR = False
+
+# Routes registered in code but intentionally absent from the spec
+# (infrastructure / Swagger UI endpoints).
 SPEC_ALLOWLIST = {
     ("GET", "/openapi.json"),
     ("GET", "/docs"),
@@ -33,6 +46,26 @@ DROGON_METHOD_MAP = {
 }
 
 CPP_SERVER_ROOT = Path(__file__).parent.parent
+SPEC_PATH = CPP_SERVER_ROOT / "resources" / "openapi.json"
+
+
+def checkSpecValidity() -> bool:
+    """Validate openapi.json against the OpenAPI 3.x JSON Schema."""
+    if not HAS_VALIDATOR:
+        print(
+            "SKIP: openapi-spec-validator not installed "
+            "(run: pip install openapi-spec-validator)"
+        )
+        return True
+
+    try:
+        spec_dict, _ = read_from_filename(str(SPEC_PATH))
+        validateOpenApiSpec(spec_dict)
+        print("OK: openapi.json is valid OpenAPI 3.x")
+        return True
+    except Exception as exc:
+        print(f"ERROR: openapi.json schema validation failed:\n  {exc}")
+        return False
 
 
 def extractCodeRoutes() -> set[tuple[str, str]]:
@@ -43,7 +76,7 @@ def extractCodeRoutes() -> set[tuple[str, str]]:
             if filepath.suffix in (".hpp", ".cpp", ".h"):
                 source_text += filepath.read_text(errors="replace") + "\n"
 
-    # Collapse continuation lines so a multi-line macro becomes one line.
+    # Collapse backslash-continuations so a multi-line macro becomes one line.
     source_text = re.sub(r"\\\n\s*", " ", source_text)
 
     routes: set[tuple[str, str]] = set()
@@ -61,8 +94,7 @@ def extractCodeRoutes() -> set[tuple[str, str]]:
 
 def extractSpecRoutes() -> set[tuple[str, str]]:
     """Return {(METHOD, path)} from openapi.json paths section."""
-    spec_path = CPP_SERVER_ROOT / "resources" / "openapi.json"
-    with spec_path.open() as f:
+    with SPEC_PATH.open() as f:
         spec = json.load(f)
 
     routes: set[tuple[str, str]] = set()
@@ -73,12 +105,11 @@ def extractSpecRoutes() -> set[tuple[str, str]]:
     return routes
 
 
-def main() -> int:
+def checkRouteCoverage() -> bool:
     code_routes = extractCodeRoutes()
     spec_routes = extractSpecRoutes()
 
     checkable_code = code_routes - SPEC_ALLOWLIST
-
     missing_from_spec = checkable_code - spec_routes
     stale_in_spec = spec_routes - code_routes
 
@@ -97,12 +128,17 @@ def main() -> int:
         ok = False
 
     if ok:
-        routes_list = sorted(checkable_code)
-        print(f"OK: {len(routes_list)} route(s) match between code and openapi.json")
-        for method, path in routes_list:
+        print(f"OK: {len(checkable_code)} route(s) match between code and openapi.json")
+        for method, path in sorted(checkable_code):
             print(f"  {method:8s} {path}")
 
-    return 0 if ok else 1
+    return ok
+
+
+def main() -> int:
+    spec_ok = checkSpecValidity()
+    routes_ok = checkRouteCoverage()
+    return 0 if (spec_ok and routes_ok) else 1
 
 
 if __name__ == "__main__":

--- a/tt-media-server/cpp_server/tools/validate_openapi.py
+++ b/tt-media-server/cpp_server/tools/validate_openapi.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Validate that resources/openapi.json matches routes registered with ADD_METHOD_TO macros.
+
+Usage:
+    python3 tools/validate_openapi.py
+
+Run from the cpp_server directory. Exits 0 if the spec and code agree, 1 if they diverge.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# Routes that are registered in code but intentionally omitted from the spec
+# (infrastructure / UI endpoints that callers don't need to know about).
+SPEC_ALLOWLIST = {
+    ("GET", "/openapi.json"),
+    ("GET", "/docs"),
+    ("GET", "/swagger"),
+}
+
+DROGON_METHOD_MAP = {
+    "drogon::Get": "GET",
+    "drogon::Post": "POST",
+    "drogon::Put": "PUT",
+    "drogon::Delete": "DELETE",
+    "drogon::Patch": "PATCH",
+    "drogon::Head": "HEAD",
+    "drogon::Options": "OPTIONS",
+}
+
+CPP_SERVER_ROOT = Path(__file__).parent.parent
+
+
+def extractCodeRoutes() -> set[tuple[str, str]]:
+    """Return {(METHOD, path)} from all ADD_METHOD_TO macros in include/ and src/."""
+    source_text = ""
+    for directory in ("include", "src"):
+        for filepath in (CPP_SERVER_ROOT / directory).rglob("*"):
+            if filepath.suffix in (".hpp", ".cpp", ".h"):
+                source_text += filepath.read_text(errors="replace") + "\n"
+
+    # Collapse continuation lines so a multi-line macro becomes one line.
+    source_text = re.sub(r"\\\n\s*", " ", source_text)
+
+    routes: set[tuple[str, str]] = set()
+    for match in re.finditer(r"ADD_METHOD_TO\s*\(([^)]+)\)", source_text):
+        args = [a.strip() for a in match.group(1).split(",")]
+        if len(args) < 3:
+            continue
+        path = args[1].strip('"').strip("'")
+        for raw_method, http_verb in DROGON_METHOD_MAP.items():
+            if any(raw_method in arg for arg in args[2:]):
+                routes.add((http_verb, path))
+
+    return routes
+
+
+def extractSpecRoutes() -> set[tuple[str, str]]:
+    """Return {(METHOD, path)} from openapi.json paths section."""
+    spec_path = CPP_SERVER_ROOT / "resources" / "openapi.json"
+    with spec_path.open() as f:
+        spec = json.load(f)
+
+    routes: set[tuple[str, str]] = set()
+    for path, methods in spec.get("paths", {}).items():
+        for method in methods:
+            routes.add((method.upper(), path))
+
+    return routes
+
+
+def main() -> int:
+    code_routes = extractCodeRoutes()
+    spec_routes = extractSpecRoutes()
+
+    checkable_code = code_routes - SPEC_ALLOWLIST
+
+    missing_from_spec = checkable_code - spec_routes
+    stale_in_spec = spec_routes - code_routes
+
+    ok = True
+
+    if missing_from_spec:
+        print("ERROR: routes registered in C++ but missing from openapi.json:")
+        for method, path in sorted(missing_from_spec):
+            print(f"  {method:8s} {path}")
+        ok = False
+
+    if stale_in_spec:
+        print("ERROR: paths in openapi.json with no matching C++ route:")
+        for method, path in sorted(stale_in_spec):
+            print(f"  {method:8s} {path}")
+        ok = False
+
+    if ok:
+        routes_list = sorted(checkable_code)
+        print(f"OK: {len(routes_list)} route(s) match between code and openapi.json")
+        for method, path in routes_list:
+            print(f"  {method:8s} {path}")
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a script (`tools/validate_openapi.py`) that checks `resources/openapi.json` in two ways: validates the spec is valid OpenAPI 3.x using `openapi-spec-validator`, and checks that every route registered via `ADD_METHOD_TO` in C++ is documented in the spec and vice versa. Runs in CI before the build step so it fails fast.

Also fixes a gap caught by the new check: POST /v1/embeddings was registered in code but missing from the spec.