### PR TITLE
Enable host-side sampling for structured outputs in Llama model runner

### DIFF
--- a/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
@@ -141,10 +141,19 @@ void LlamaModelRunner::run(const std::vector<Sequence*>& seqs, bool isPrefill) {
         double frequencyPenalty =
             sp ? static_cast<double>(sp->frequency_penalty) : 0.0;
 
+        py::object allowedTokenIds = py::none();
+        if (sp && sp->allowed_token_ids.has_value()) {
+          py::list pyAllowed;
+          for (int tid : *sp->allowed_token_ids) {
+            pyAllowed.append(tid);
+          }
+          allowedTokenIds = std::move(pyAllowed);
+        }
+
         pySeqs.append(gStepSeqClass(
             seq->taskId, tokenIds, temperature, ignoreEos, blockTable,
             currentPos, promptLen, seed, topP, topK, minP, repetitionPenalty,
-            presencePenalty, frequencyPenalty));
+            presencePenalty, frequencyPenalty, allowedTokenIds));
       }
 
       // First decode step after prefill must set reset_batch=true so on-device

--- a/tt-media-server/tt_model_runners/llama_runner.py
+++ b/tt-media-server/tt_model_runners/llama_runner.py
@@ -65,6 +65,7 @@ class StepSequence:
     repetition_penalty: float | None = None
     presence_penalty: float = 0.0
     frequency_penalty: float = 0.0
+    allowed_token_ids: list[int] | None = None
 
 
 @dataclass
@@ -128,6 +129,27 @@ class Llama31_8BRunner(BaseMetalDeviceRunner):
             else 1.0,
             seed=seq.seed,
         )
+
+    @staticmethod
+    def _sample_from_logits(logits_1d, seq: StepSequence, torch):
+        """Sample a single token from logits, applying allowed_token_ids mask and top-k filtering."""
+        if seq.allowed_token_ids is not None:
+            mask = torch.full_like(logits_1d, float("-inf"))
+            allowed = torch.tensor(seq.allowed_token_ids, dtype=torch.long)
+            mask[allowed] = 0.0
+            logits_1d = logits_1d + mask
+
+        temp = seq.temperature
+        if temp == 0 or temp is None:
+            return int(logits_1d.argmax().item())
+
+        scaled = logits_1d / temp
+
+        k = seq.top_k if seq.top_k is not None and seq.top_k > 0 else 10
+        top_vals, top_idx = torch.topk(scaled, min(k, scaled.size(0)))
+        probs = torch.softmax(top_vals, dim=-1)
+        chosen = top_idx[torch.multinomial(probs, 1)]
+        return int(chosen.item())
 
     def _build_batch_sampling_params(
         self, sequences: list[StepSequence]
@@ -265,18 +287,29 @@ class Llama31_8BRunner(BaseMetalDeviceRunner):
         prompt_len = len(seq.token_ids)
         page_table = self._page_table_from_block_ids(seq.block_table, torch)
         tokens = torch.tensor([seq.token_ids], dtype=torch.int64)
-        sampling_params = self._build_sampling_params(seq)
 
-        output_tokens, _log_probs = self.model.prefill_forward(
-            tokens,
-            page_table=page_table,
-            kv_cache=self._kv_cache,
-            prompt_lens=[prompt_len],
-            warmup_prefill=False,
-            sampling_params=sampling_params,
-        )
+        if seq.allowed_token_ids is not None:
+            logits_3d = self.model.prefill_forward(
+                tokens,
+                page_table=page_table,
+                kv_cache=self._kv_cache,
+                prompt_lens=[prompt_len],
+                warmup_prefill=False,
+                sampling_params=None,
+            )
+            next_token = self._sample_from_logits(logits_3d[0, 0, :], seq, torch)
+        else:
+            sampling_params = self._build_sampling_params(seq)
+            output_tokens, _log_probs = self.model.prefill_forward(
+                tokens,
+                page_table=page_table,
+                kv_cache=self._kv_cache,
+                prompt_lens=[prompt_len],
+                warmup_prefill=False,
+                sampling_params=sampling_params,
+            )
+            next_token = int(output_tokens[0].item())
 
-        next_token = int(output_tokens[0].item())
         return StepResult(task_id=seq.task_id, token_id=next_token)
 
     def _run_decode(
@@ -293,19 +326,32 @@ class Llama31_8BRunner(BaseMetalDeviceRunner):
         last_token = seq.token_ids[-1]
         tokens = torch.tensor([[last_token]], dtype=torch.int64)
         current_pos = torch.tensor([seq.current_pos], dtype=torch.int64)
-        sampling_params = self._build_sampling_params(seq)
 
-        output_tokens, _log_probs = self.model.decode_forward(
-            tokens,
-            current_pos,
-            page_table=page_table,
-            kv_cache=self._kv_cache,
-            enable_trace=True,
-            sampling_params=sampling_params,
-            reset_batch=reset_batch,
-        )
+        if seq.allowed_token_ids is not None:
+            result = self.model.decode_forward(
+                tokens,
+                current_pos,
+                page_table=page_table,
+                kv_cache=self._kv_cache,
+                enable_trace=True,
+                sampling_params=None,
+                reset_batch=reset_batch,
+            )
+            logits = result[0] if isinstance(result, tuple) else result
+            next_token = self._sample_from_logits(logits[0, 0, :], seq, torch)
+        else:
+            sampling_params = self._build_sampling_params(seq)
+            output_tokens, _log_probs = self.model.decode_forward(
+                tokens,
+                current_pos,
+                page_table=page_table,
+                kv_cache=self._kv_cache,
+                enable_trace=True,
+                sampling_params=sampling_params,
+                reset_batch=reset_batch,
+            )
+            next_token = int(output_tokens[0].item())
 
-        next_token = int(output_tokens[0].item())
         return StepResult(task_id=seq.task_id, token_id=next_token)
 
     def _run_decode_batch(
@@ -320,10 +366,17 @@ class Llama31_8BRunner(BaseMetalDeviceRunner):
         Per-sequence sampling parameters are supported: each sequence can have
         different temperature, top_p, top_k, etc. Parameters are passed as
         list-valued fields in SamplingParams.
+
+        When any sequence has allowed_token_ids (grammar constraints), the batch
+        falls back to host-side sampling: the model forward runs on device to
+        produce logits, then each token is sampled on the host with the grammar
+        mask applied.
         """
         B = self.max_batch_size
         if len(sequences) > B:
             return [self._run_decode(s, torch, reset_batch) for s in sequences]
+
+        has_constrained = any(s.allowed_token_ids is not None for s in sequences)
 
         n = len(sequences)
         tokens_list = []
@@ -341,10 +394,26 @@ class Llama31_8BRunner(BaseMetalDeviceRunner):
         start_pos_batch = torch.tensor(start_pos_list, dtype=torch.int64)
         page_table_batch = torch.cat(page_tables, dim=0)
 
-        # Build per-sequence sampling parameters for batched decode (including padded slots)
-        # Each field in SamplingParams is a list where element i corresponds to padded_sequences[i]
-        sampling_params = self._build_batch_sampling_params(padded_sequences)
+        if has_constrained:
+            result = self.model.decode_forward(
+                tokens_batch,
+                start_pos_batch,
+                page_table=page_table_batch,
+                kv_cache=self._kv_cache,
+                enable_trace=True,
+                sampling_params=None,
+                reset_batch=reset_batch,
+            )
+            logits = result[0] if isinstance(result, tuple) else result
+            return [
+                StepResult(
+                    task_id=seq.task_id,
+                    token_id=self._sample_from_logits(logits[i, 0, :], seq, torch),
+                )
+                for i, seq in enumerate(sequences)
+            ]
 
+        sampling_params = self._build_batch_sampling_params(padded_sequences)
         output_tokens, _log_probs = self.model.decode_forward(
             tokens_batch,
             start_pos_batch,
@@ -355,7 +424,6 @@ class Llama31_8BRunner(BaseMetalDeviceRunner):
             reset_batch=reset_batch,
         )
 
-        # Device sampling returns tokens directly, shape [batch]
         return [
             StepResult(
                 task_id=seq.task_id,

--- a/tt-media-server/tt_model_runners/llama_runner.py
+++ b/tt-media-server/tt_model_runners/llama_runner.py
@@ -132,12 +132,32 @@ class Llama31_8BRunner(BaseMetalDeviceRunner):
 
     @staticmethod
     def _sample_from_logits(logits_1d, seq: StepSequence, torch):
-        """Sample a single token from logits, applying allowed_token_ids mask and top-k filtering."""
+        """Host-side sampling with grammar mask, penalties, top-k/top-p filtering.
+
+        Temporary fallback until bitmask-based constrained decoding is supported
+        on device.  Mirrors the parameters that _build_sampling_params passes to
+        the on-device sampler so behaviour is consistent.
+        """
         if seq.allowed_token_ids is not None:
             mask = torch.full_like(logits_1d, float("-inf"))
             allowed = torch.tensor(seq.allowed_token_ids, dtype=torch.long)
             mask[allowed] = 0.0
             logits_1d = logits_1d + mask
+
+        rep_pen = seq.repetition_penalty if seq.repetition_penalty is not None else 1.0
+        if rep_pen != 1.0:
+            positive = logits_1d > 0
+            logits_1d = torch.where(positive, logits_1d / rep_pen, logits_1d * rep_pen)
+
+        pres_pen = seq.presence_penalty
+        freq_pen = seq.frequency_penalty
+        if pres_pen != 0.0 or freq_pen != 0.0:
+            token_counts = torch.zeros_like(logits_1d)
+            for tid in seq.token_ids:
+                if 0 <= tid < token_counts.size(0):
+                    token_counts[tid] += 1
+            appeared = (token_counts > 0).float()
+            logits_1d = logits_1d - freq_pen * token_counts - pres_pen * appeared
 
         temp = seq.temperature
         if temp == 0 or temp is None:
@@ -147,8 +167,27 @@ class Llama31_8BRunner(BaseMetalDeviceRunner):
 
         k = seq.top_k if seq.top_k is not None and seq.top_k > 0 else 10
         top_vals, top_idx = torch.topk(scaled, min(k, scaled.size(0)))
-        probs = torch.softmax(top_vals, dim=-1)
-        chosen = top_idx[torch.multinomial(probs, 1)]
+
+        top_p = seq.top_p if seq.top_p is not None else 1.0
+        if top_p < 1.0:
+            sorted_probs, sorted_order = torch.sort(
+                torch.softmax(top_vals, dim=-1), descending=True
+            )
+            cumulative = torch.cumsum(sorted_probs, dim=-1)
+            cutoff = (cumulative - sorted_probs) >= top_p
+            sorted_probs[cutoff] = 0.0
+            sorted_probs /= sorted_probs.sum()
+            orig_idx = sorted_order[torch.multinomial(sorted_probs, 1)]
+            chosen = top_idx[orig_idx]
+        else:
+            probs = torch.softmax(top_vals, dim=-1)
+            if seq.seed is not None:
+                g = torch.Generator()
+                g.manual_seed(seq.seed)
+                chosen = top_idx[torch.multinomial(probs, 1, generator=g)]
+            else:
+                chosen = top_idx[torch.multinomial(probs, 1)]
+
         return int(chosen.item())
 
     def _build_batch_sampling_params(


### PR DESCRIPTION
- The C++ LlamaModelRunner now passes allowed_token_ids (grammar constraints from xgrammar) through to the Python StepSequence dataclass, which previously had no way to receive them.
- When a request has grammar constraints (json_schema / json_object), the Python runner switches to host-side sampling: it calls prefill_forward / decode_forward with sampling_params=None to get raw logits back instead of pre-sampled tokens, then applies the grammar token mask and samples on the host with top-k filtering.
- Regular (unconstrained) requests continue using the original on-device sampling path, so there's no performance regression for normal chat completions.


This is a temporary solution. The host-side sampling path will be removed once on-device bitmask application is supported


Example output:
```
curl -s -X POST http://localhost:8000/v1/chat/completions   -H "Content-Type: application/json"   -H "Authorization: Bearer your-secret-key"   -d '{
    "model": "meta-llama/Llama-3.1-8B-Instruct",
    "messages": [{"role": "user", "content": "Give me a person"}],
    "max_tokens": 100,
    "response_format": {
      "type": "json_schema",
      "json_schema": {
        "name": "person",
        "strict": true,
        "schema": {
          "type": "object",
          "properties": {
            "name": {"type": "string"},
            "age": {"type": "integer"}
          },
          "required": ["name", "age"],
          "additionalProperties": false
        }
      }
    }
  }'

{
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "logprobs": null,
      "message": {
        "content": "{ \"age\": 32, \"name\": \"Evelyn Stone\" }",
        "role": "assistant"
      }
    }
  ],
  "created": 1776344573,
  "id": "chatcmpl-1",
  "model": "meta-llama/Llama-3.1-8B-Instruct",
  "object": "chat.completion",
  "usage": {
    "completion_tokens": 18,
    "prompt_tokens": 39,
    "sessionId": "53539aa0-7251-4d41-a940-385c37a4b900",
    "total_tokens": 57,
    "tps": 15.228426395939087,
    "ttft_ms": 1182
  }
}
```