### PR TITLE
Fix data race on SingleProcessWorker::is_alive

### DIFF
--- a/tt-media-server/cpp_server/include/worker/single_process_worker.hpp
+++ b/tt-media-server/cpp_server/include/worker/single_process_worker.hpp
@@ -2,6 +2,7 @@
 
 #include <unistd.h>
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -37,7 +38,7 @@ class SingleProcessWorker {
 
   pid_t pid{-1};
   bool is_ready{false};
-  bool is_alive{true};
+  std::atomic<bool> is_alive{true};
   int worker_id{-1};
   WorkerConfig cfg;
 


### PR DESCRIPTION
## Summary
- `SingleProcessWorker::is_alive` is written by the liveness checker thread and read by HTTP handler threads via `getWorkerInfo()`. This is a data race (undefined behavior under the C++ memory model).
- Change `bool is_alive` to `std::atomic<bool> is_alive` to eliminate the race.

## Test plan
- [x] Build passes (`./build.sh`)
- [ ] Verify with ThreadSanitizer build (`./build.sh --tsan`)


Made with [Cursor](https://cursor.com)