### PR TITLE
Fix Prompt Token Calculation For Streaming Requests

### DIFF
--- a/tt-media-server/cpp_server/include/services/streamable.hpp
+++ b/tt-media-server/cpp_server/include/services/streamable.hpp
@@ -20,7 +20,6 @@ class Streamable {
   void submitStreamingRequest(
       RequestType& request,
       std::function<void(const ResponseType&, bool isFinal)> callback) {
-    preProcess(request);
     processStreamingRequest(
         std::move(request),
         [this, cb = std::move(callback)](ResponseType& response, bool isFinal) {

--- a/tt-media-server/cpp_server/include/services/streamable.hpp
+++ b/tt-media-server/cpp_server/include/services/streamable.hpp
@@ -19,7 +19,11 @@ class Streamable {
 
   void submitStreamingRequest(
       RequestType& request,
-      std::function<void(const ResponseType&, bool isFinal)> callback) {
+      std::function<void(const ResponseType&, bool isFinal)> callback,
+      bool skipPreProcess = false) {
+    if (!skipPreProcess) {
+      preProcess(request);
+    }
     processStreamingRequest(
         std::move(request),
         [this, cb = std::move(callback)](ResponseType& response, bool isFinal) {

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -219,38 +219,39 @@ void LLMController::handleStreaming(
   resolveSession(
       reqPtr, loop,
       [this, reqPtr, cb, loop](SessionInfo sessionInfo) {
-        StreamParams params;
-        params.completionId = "chatcmpl-" + std::to_string(reqPtr->task_id);
-        params.model = reqPtr->model.value_or("default");
-        params.created = static_cast<int64_t>(
-            std::chrono::duration_cast<std::chrono::seconds>(
-                std::chrono::system_clock::now().time_since_epoch())
-                .count());
-        params.includeUsage = !reqPtr->stream_options.has_value() ||
-                              reqPtr->stream_options->include_usage;
-        params.continuousUsage = reqPtr->stream_options.has_value() &&
-                                 reqPtr->stream_options->continuous_usage_stats;
-        params.promptTokensCount = reqPtr->prompt_tokens_count;
-        params.sessionId = reqPtr->sessionId;
-        params.taskId = reqPtr->task_id;
-        params.service = service;
-        params.sessionManager = sessionManager;
-
-        auto writer = SseStreamWriter::create(loop, std::move(params));
-
-        auto streamingCallback = [writer](const domain::LLMStreamChunk& chunk,
-                                          bool isFinal) {
-          if (writer->isDone()) return;
-          if (!chunk.choices.empty()) writer->handleTokenChunk(chunk);
-          if (isFinal) writer->finalizeStream();
-        };
-
         try {
+          service->preProcess(*reqPtr);
+
+          StreamParams params;
+          params.completionId = "chatcmpl-" + std::to_string(reqPtr->task_id);
+          params.model = reqPtr->model.value_or("default");
+          params.created = static_cast<int64_t>(
+              std::chrono::duration_cast<std::chrono::seconds>(
+                  std::chrono::system_clock::now().time_since_epoch())
+                  .count());
+          params.includeUsage = !reqPtr->stream_options.has_value() ||
+                                reqPtr->stream_options->include_usage;
+          params.continuousUsage = reqPtr->stream_options.has_value() &&
+                                   reqPtr->stream_options->continuous_usage_stats;
+          params.promptTokensCount = reqPtr->prompt_tokens_count;
+          params.sessionId = reqPtr->sessionId;
+          params.taskId = reqPtr->task_id;
+          params.service = service;
+          params.sessionManager = sessionManager;
+
+          auto writer = SseStreamWriter::create(loop, std::move(params));
+
+          auto streamingCallback = [writer](const domain::LLMStreamChunk& chunk,
+                                            bool isFinal) {
+            if (writer->isDone()) return;
+            if (!chunk.choices.empty()) writer->handleTokenChunk(chunk);
+            if (isFinal) writer->finalizeStream();
+          };
+
           if (tt::config::llmMode() == tt::config::LLMMode::REGULAR) {
             service->submitStreamingRequest(*reqPtr, streamingCallback);
           } else if (tt::config::llmMode() ==
                      tt::config::LLMMode::DECODE_ONLY) {
-            service->preProcess(*reqPtr);
             if (shouldDoPrefillOnDecode(*reqPtr,
                                         sessionInfo.validSessionFound)) {
               TT_LOG_DEBUG(
@@ -272,13 +273,12 @@ void LLMController::handleStreaming(
                 "internal_error"));
             return;
           }
+
+          (*cb)(writer->buildResponse());
         } catch (const services::QueueFullException& e) {
           (*cb)(errorResponse(drogon::k429TooManyRequests, e.what(),
                               "rate_limit_exceeded"));
-          return;
         }
-
-        (*cb)(writer->buildResponse());
       },
       [cb](const SessionError& err) {
         TT_LOG_ERROR("[LLMController] Session resolution failed: {}",

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -231,8 +231,9 @@ void LLMController::handleStreaming(
                   .count());
           params.includeUsage = !reqPtr->stream_options.has_value() ||
                                 reqPtr->stream_options->include_usage;
-          params.continuousUsage = reqPtr->stream_options.has_value() &&
-                                   reqPtr->stream_options->continuous_usage_stats;
+          params.continuousUsage =
+              reqPtr->stream_options.has_value() &&
+              reqPtr->stream_options->continuous_usage_stats;
           params.promptTokensCount = reqPtr->prompt_tokens_count;
           params.sessionId = reqPtr->sessionId;
           params.taskId = reqPtr->task_id;

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -250,7 +250,8 @@ void LLMController::handleStreaming(
           };
 
           if (tt::config::llmMode() == tt::config::LLMMode::REGULAR) {
-            service->submitStreamingRequest(*reqPtr, streamingCallback);
+            // preprocess is already called
+            service->submitStreamingRequest(*reqPtr, streamingCallback, true);
           } else if (tt::config::llmMode() ==
                      tt::config::LLMMode::DECODE_ONLY) {
             if (shouldDoPrefillOnDecode(*reqPtr,

--- a/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
+++ b/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
@@ -68,11 +68,12 @@ void SseStreamWriter::flushAccumulated() {
 }
 
 domain::CompletionUsage SseStreamWriter::buildFinalUsage() const {
-  const int tokens = completion_tokens_.load();
+  const int completionTokens = completion_tokens_.load();
+  const int totalTokens = params_.promptTokensCount + completionTokens;
 
   domain::CompletionUsage usage{params_.promptTokensCount,
-                                tokens,
-                                tokens,
+                                completionTokens,
+                                totalTokens,
                                 std::nullopt,
                                 std::nullopt,
                                 std::nullopt};
@@ -84,14 +85,14 @@ domain::CompletionUsage SseStreamWriter::buildFinalUsage() const {
         std::round(static_cast<double>(ttftUs.count()) / 10.0) / 100.0;
   }
 
-  if (tokens > 1 && first_token_time_.has_value()) {
+  if (completionTokens > 1 && first_token_time_.has_value()) {
     auto finalTime = std::chrono::high_resolution_clock::now();
     auto baseTime = second_token_time_.value_or(first_token_time_.value());
     auto totalUs = std::chrono::duration_cast<std::chrono::microseconds>(
         finalTime - baseTime);
     if (totalUs.count() > 0) {
       auto secs = static_cast<double>(totalUs.count()) / 1000000.0;
-      usage.tps = std::round((tokens - 1) / secs * 1000.0) / 1000.0;
+      usage.tps = std::round((completionTokens - 1) / secs * 1000.0) / 1000.0;
     }
   }
 
@@ -117,7 +118,7 @@ void SseStreamWriter::handleTokenChunk(const domain::LLMStreamChunk& chunk) {
   if (params_.continuousUsage) {
     usage = domain::CompletionUsage{params_.promptTokensCount,
                                     currentTokens,
-                                    currentTokens,
+                                    params_.promptTokensCount + currentTokens,
                                     std::nullopt,
                                     std::nullopt,
                                     params_.sessionId};

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -56,6 +56,7 @@ void DisaggregationService::setupSocketHandlers() {
             request.max_tokens = message.remaining_tokens;
             auto slotId = message.slot_id;
             request.slotId = slotId;
+            llmService->preProcess(request);
             llmService->submitStreamingRequest(request, callback.value());
           } else {
             auto finalResponse = domain::LLMStreamChunk(message.task_id);
@@ -96,6 +97,7 @@ void DisaggregationService::setupSocketHandlers() {
                                                    message.token_ids.end()));
           auto slotId = message.slot_id;
 
+          llmService->preProcess(request);
           llmService->submitStreamingRequest(
               request,
               [this, message, maxTokens, slotId](

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -56,7 +56,6 @@ void DisaggregationService::setupSocketHandlers() {
             request.max_tokens = message.remaining_tokens;
             auto slotId = message.slot_id;
             request.slotId = slotId;
-            llmService->preProcess(request);
             llmService->submitStreamingRequest(request, callback.value());
           } else {
             auto finalResponse = domain::LLMStreamChunk(message.task_id);
@@ -97,7 +96,6 @@ void DisaggregationService::setupSocketHandlers() {
                                                    message.token_ids.end()));
           auto slotId = message.slot_id;
 
-          llmService->preProcess(request);
           llmService->submitStreamingRequest(
               request,
               [this, message, maxTokens, slotId](


### PR DESCRIPTION
## Issue
When response streaming was enabled we were not calculating prompt_tokens correctly, which was resulting in observing in=0 for all requests in TT-Console:
<img width="952" height="202" alt="image" src="https://github.com/user-attachments/assets/7daa229d-b332-40ae-9a9e-d183e6526c3e" />

With these changes, preProcess is called before crating `StreamParams`, so `promptTokensCount` is calculated correctly.

OpenAi api reference: [usage field](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create#(resource)%20chat.completions%20%3E%20(model)%20chat_completion%20%3E%20(schema)%20%3E%20(property)%20usage)


### Before:
```
data: {"choices":[],"created":1776344554,"id":"chatcmpl-1","model":"default","object":"chat.completion.chunk","usage":{"completion_tokens":19,"prompt_tokens":0,"sessionId":"d33c5a19-1f1b-4232-9f24-ba40f20054db","total_tokens":19,"tps":374.58600000000001,"ttft_ms":6.4500000000000002}}
```

### After:
```
data: {"choices":[],"created":1776343989,"id":"chatcmpl-1","model":"default","object":"chat.completion.chunk","usage":{"completion_tokens":19,"prompt_tokens":4,"sessionId":"059a4602-d06b-45d7-99f7-a885f9ed8474","total_tokens":23,"tps":374.875,"ttft_ms":6.1600000000000001}}
```