### PR TITLE
Fix checkWorkerAlive returning true for dead workers after zombie reap

### DIFF
--- a/tt-media-server/cpp_server/src/worker/worker_manager.cpp
+++ b/tt-media-server/cpp_server/src/worker/worker_manager.cpp
@@ -6,6 +6,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <chrono>
 #include <climits>
 #include <cstdio>
@@ -121,7 +122,7 @@ SingleProcessWorker* WorkerManager::worker(size_t idx) {
 
 bool WorkerManager::checkWorkerAlive(size_t workerIdx) {
   auto* w = workers[workerIdx].get();
-  if (w->pid <= 0) {
+  if (w->pid <= 0 || !w->is_alive.load()) {
     return false;
   }
   int status;
@@ -156,7 +157,14 @@ bool WorkerManager::checkWorkerAlive(size_t workerIdx) {
     }
     return false;
   }
-  return true;  // waitpid error -- assume alive
+  // waitpid returned -1 (e.g. ECHILD after zombie was already reaped).
+  // Mark the worker dead rather than silently assuming alive.
+  TT_LOG_ERROR(
+      "[WorkerManager] waitpid failed for worker {} (PID {}): {} -- "
+      "marking dead",
+      workerIdx, w->pid, strerror(errno));
+  w->is_alive = false;
+  return false;
 }
 
 void WorkerManager::restartWorker(size_t workerIdx) {


### PR DESCRIPTION
## Summary

- **Fixes a bug where `WorkerManager::checkWorkerAlive()` silently reported dead workers as alive** after the initial detection. On the first call after a worker dies, `waitpid()` correctly reaped the zombie and logged the death. On every subsequent 5-second poll, `waitpid()` returned `-1`/`ECHILD` (child already reaped) and the code fell through to `return true` — silently treating the dead worker as alive indefinitely.
- **Early-return `false`** when `is_alive` is already `false`, avoiding the stale `waitpid` call entirely.
- **Log `waitpid` errors with `errno`** instead of silently assuming the worker is alive, so unexpected failures are visible in server logs.

## Root Cause

```
                  ┌──────────────────────────────┐
                  │   checkWorkerAlive() called   │
                  │        every 5 seconds        │
                  └──────────┬───────────────────┘
                             │
                  ┌──────────▼───────────────────┐
                  │  waitpid(pid, WNOHANG)        │
                  └──────────┬───────────────────┘
                             │
              ┌──────────────┼──────────────────┐
              │              │                  │
         result == 0    result == pid      result == -1
         (running)      (exited)           (ECHILD)
              │              │                  │
         return true    is_alive=false     return true  ← BUG
                        log death          (silently assumes alive)
                        return false
```

After the first detection reaps the zombie, all subsequent checks hit the `-1`/`ECHILD` path and incorrectly report the worker as alive. This means:
1. The `/tt-liveness` health endpoint may flip back to reporting the worker alive on the next poll cycle.
2. The liveness checker stops logging errors for the dead worker.
3. Any future watchdog or auto-restart logic relying on `checkWorkerAlive()` would never trigger.

## Fix

1. Check `is_alive` at the top of the function — once a worker is known dead, skip `waitpid` entirely and return `false`.
2. When `waitpid` returns an unexpected error (`-1`), log the error with `errno` and mark the worker dead instead of assuming alive.