### PR TITLE
Fix: pass CACHE_ROOT env var to docker container for all engine types

### DIFF
--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -197,6 +197,7 @@ def generate_docker_run_command(
 
     docker_env_vars = {}
     if setup_config:
+        docker_env_vars["CACHE_ROOT"] = str(setup_config.cache_root)
         if (
             setup_config.container_model_weights_path
             and setup_config.host_model_weights_mount_dir


### PR DESCRIPTION
## Summary

- `CACHE_ROOT` was only injected into the container for `FORGE`/`MEDIA` engines via `get_media_server_docker_env_vars`
- Non-media engines (vLLM, SGLang, etc.) never received `CACHE_ROOT`, breaking container entrypoints that depend on it
- Set `CACHE_ROOT` unconditionally from `setup_config.cache_root` whenever `setup_config` is present

Closes #2990