### PR TITLE
Optimize structured output decoding by passing raw bitmasks instead of allowed token ID lists

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -687,10 +687,10 @@ jobs:
             "vllm-bench-mock.json" 1 150
 
           check_thresholds "C++ Server vLLM Bench (structured output - json_object)" \
-            "vllm-bench-structured-output-json-object.json" 16 100
+            "vllm-bench-structured-output-json-object.json" 5 150
 
           check_thresholds "C++ Server vLLM Bench (structured output - json_schema)" \
-            "vllm-bench-structured-output-json-schema.json" 15 100
+            "vllm-bench-structured-output-json-schema.json" 3 250
 
           check_thresholds "C++ Server vLLM Bench (mock_pipeline)" \
             "vllm-bench-mock-pipeline.json" 3 395

--- a/tt-media-server/cpp_server/include/runners/llm_runner/sampling_params.hpp
+++ b/tt-media-server/cpp_server/include/runners/llm_runner/sampling_params.hpp
@@ -38,6 +38,8 @@ struct SamplingParams {
   bool skip_special_tokens = true;
   bool spaces_between_special_tokens = true;
   std::optional<std::vector<int>> allowed_token_ids;
+  std::optional<std::vector<int32_t>> token_bitmask;
+  int bitmask_vocab_size = 0;
   std::optional<int> prompt_logprobs;
   std::optional<int> truncate_prompt_tokens;
   bool fast_mode = false;

--- a/tt-media-server/cpp_server/include/services/guided_decoder_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/guided_decoder_manager.hpp
@@ -17,6 +17,11 @@ struct TokenAcceptResult {
   bool completed = false;
 };
 
+struct BatchAllowedResult {
+  uint32_t taskId;
+  std::vector<int32_t> allowedTokenIds;
+};
+
 class GuidedDecoderManager {
  public:
   explicit GuidedDecoderManager(const std::vector<std::string>& encodedVocab,
@@ -30,6 +35,9 @@ class GuidedDecoderManager {
                    const tt::runners::llm_engine::SamplingParams& params);
 
   std::vector<int32_t> getNextAllowedTokenIds(uint32_t taskId);
+
+  std::vector<BatchAllowedResult> getNextAllowedTokenIdsBatch(
+      const std::vector<uint32_t>& taskIds);
 
   TokenAcceptResult acceptToken(uint32_t taskId, int32_t tokenId);
 

--- a/tt-media-server/cpp_server/include/services/guided_decoder_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/guided_decoder_manager.hpp
@@ -17,11 +17,6 @@ struct TokenAcceptResult {
   bool completed = false;
 };
 
-struct BatchAllowedResult {
-  uint32_t taskId;
-  std::vector<int32_t> allowedTokenIds;
-};
-
 class GuidedDecoderManager {
  public:
   explicit GuidedDecoderManager(const std::vector<std::string>& encodedVocab,
@@ -33,11 +28,6 @@ class GuidedDecoderManager {
 
   void initRequest(uint32_t taskId,
                    const tt::runners::llm_engine::SamplingParams& params);
-
-  std::vector<int32_t> getNextAllowedTokenIds(uint32_t taskId);
-
-  std::vector<BatchAllowedResult> getNextAllowedTokenIdsBatch(
-      const std::vector<uint32_t>& taskIds);
 
   void fillNextBitmask(uint32_t taskId, std::vector<int32_t>& bitmask);
 

--- a/tt-media-server/cpp_server/include/services/guided_decoder_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/guided_decoder_manager.hpp
@@ -39,6 +39,11 @@ class GuidedDecoderManager {
   std::vector<BatchAllowedResult> getNextAllowedTokenIdsBatch(
       const std::vector<uint32_t>& taskIds);
 
+  void fillNextBitmask(uint32_t taskId, std::vector<int32_t>& bitmask);
+
+  int vocabSize() const;
+  int bitmaskSize() const;
+
   TokenAcceptResult acceptToken(uint32_t taskId, int32_t tokenId);
 
   bool hasGuidedDecoding(uint32_t taskId) const;

--- a/tt-media-server/cpp_server/include/utils/thread_pool.hpp
+++ b/tt-media-server/cpp_server/include/utils/thread_pool.hpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+#pragma once
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+#include "profiling/tracy.hpp"
+
+namespace tt::utils {
+
+class ThreadPool {
+ public:
+  explicit ThreadPool(size_t numThreads) : stop_(false) {
+    for (size_t i = 0; i < numThreads; ++i) {
+      workers_.emplace_back([this] {
+        while (true) {
+          std::function<void()> task;
+          {
+            std::unique_lock lock(mutex_);
+            cv_.wait(lock, [this] { return stop_ || !tasks_.empty(); });
+            if (stop_ && tasks_.empty()) return;
+            task = std::move(tasks_.front());
+            tasks_.pop();
+          }
+          task();
+        }
+      });
+    }
+  }
+
+  ~ThreadPool() {
+    {
+      std::lock_guard lock(mutex_);
+      stop_ = true;
+    }
+    cv_.notify_all();
+    for (auto& worker : workers_) {
+      if (worker.joinable()) worker.join();
+    }
+  }
+
+  ThreadPool(const ThreadPool&) = delete;
+  ThreadPool& operator=(const ThreadPool&) = delete;
+
+  void submit(std::function<void()> task) {
+    {
+      std::lock_guard lock(mutex_);
+      tasks_.push(std::move(task));
+    }
+    cv_.notify_one();
+  }
+
+ private:
+  std::vector<std::thread> workers_;
+  std::queue<std::function<void()>> tasks_;
+  TRACY_LOCKABLE(std::mutex, mutex_);
+  std::condition_variable_any cv_;
+  bool stop_;
+};
+
+}  // namespace tt::utils

--- a/tt-media-server/cpp_server/src/api/embedding_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/embedding_controller.cpp
@@ -3,79 +3,23 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 #include <chrono>
-#include <condition_variable>
-#include <functional>
-#include <mutex>
 #include <optional>
-#include <queue>
-#include <random>
-#include <sstream>
-#include <thread>
-#include <vector>
 
 #include "api/embedding_controller.hpp"
 #include "api/error_response.hpp"
 #include "config/defaults.hpp"
 #include "config/settings.hpp"
-#include "profiling/tracy.hpp"
 #include "services/base_service.hpp"
 #include "utils/logger.hpp"
 #include "utils/service_container.hpp"
+#include "utils/thread_pool.hpp"
 
 namespace tt::api {
 
 namespace {
-// Simple thread pool for handling response callbacks
-class CallbackThreadPool {
- public:
-  CallbackThreadPool(size_t numThreads = 8) : stop(false) {
-    for (size_t i = 0; i < numThreads; ++i) {
-      workers.emplace_back([this] {
-        while (true) {
-          std::function<void()> task;
-          {
-            std::unique_lock lock(mutex);
-            cv.wait(lock, [this] { return stop || !tasks.empty(); });
-            if (stop && tasks.empty()) return;
-            task = std::move(tasks.front());
-            tasks.pop();
-          }
-          task();
-        }
-      });
-    }
-  }
-
-  ~CallbackThreadPool() {
-    {
-      std::lock_guard lock(mutex);
-      stop = true;
-    }
-    cv.notify_all();
-    for (auto& worker : workers) {
-      if (worker.joinable()) worker.join();
-    }
-  }
-
-  void submit(std::function<void()> task) {
-    {
-      std::lock_guard lock(mutex);
-      tasks.push(std::move(task));
-    }
-    cv.notify_one();
-  }
-
- private:
-  std::vector<std::thread> workers;
-  std::queue<std::function<void()>> tasks;
-  TRACY_LOCKABLE(std::mutex, mutex);
-  std::condition_variable_any cv;
-  bool stop;
-};
-
-// Global thread pool for callbacks
-CallbackThreadPool& getCallbackPool() {
-  static CallbackThreadPool pool(tt::config::defaults::CALLBACK_POOL_THREADS);
+tt::utils::ThreadPool& getCallbackPool() {
+  static tt::utils::ThreadPool pool(
+      tt::config::defaults::CALLBACK_POOL_THREADS);
   return pool;
 }
 }  // namespace

--- a/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llama_model_runner.cpp
@@ -142,7 +142,21 @@ void LlamaModelRunner::run(const std::vector<Sequence*>& seqs, bool isPrefill) {
             sp ? static_cast<double>(sp->frequency_penalty) : 0.0;
 
         py::object allowedTokenIds = py::none();
-        if (sp && sp->allowed_token_ids.has_value()) {
+        if (sp && sp->token_bitmask.has_value()) {
+          py::list pyAllowed;
+          const auto& bitmask = *sp->token_bitmask;
+          int vocabSize = sp->bitmask_vocab_size;
+          for (size_t w = 0; w < bitmask.size(); ++w) {
+            auto word = static_cast<uint32_t>(bitmask[w]);
+            while (word != 0) {
+              int bit = __builtin_ctz(word);
+              int tokenId = static_cast<int>(w) * 32 + bit;
+              if (tokenId < vocabSize) pyAllowed.append(tokenId);
+              word &= word - 1;
+            }
+          }
+          allowedTokenIds = std::move(pyAllowed);
+        } else if (sp && sp->allowed_token_ids.has_value()) {
           py::list pyAllowed;
           for (int tid : *sp->allowed_token_ids) {
             pyAllowed.append(tid);

--- a/tt-media-server/cpp_server/src/runners/llm_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner.cpp
@@ -139,23 +139,14 @@ void LLMRunner::applyGuidedDecodingMasks(const std::vector<Sequence*>& seqs,
     }
   }
 
-  std::vector<uint32_t> taskIds;
-  std::vector<Sequence*> guidedSeqs;
+  int vocabSize = guidedDecoder->vocabSize();
   for (Sequence* seq : seqs) {
-    if (guidedDecoder->hasGuidedDecoding(seq->taskId)) {
-      taskIds.push_back(seq->taskId);
-      guidedSeqs.push_back(seq);
-    }
-  }
-
-  if (taskIds.empty()) return;
-
-  auto batch = guidedDecoder->getNextAllowedTokenIdsBatch(taskIds);
-  for (size_t i = 0; i < batch.size(); ++i) {
-    std::vector<int> allowedInt(batch[i].allowedTokenIds.begin(),
-                                batch[i].allowedTokenIds.end());
-    guidedSeqs[i]->getMutableSamplingParams().allowed_token_ids =
-        std::move(allowedInt);
+    if (!guidedDecoder->hasGuidedDecoding(seq->taskId)) continue;
+    auto& sp = seq->getMutableSamplingParams();
+    std::vector<int32_t> bitmask;
+    guidedDecoder->fillNextBitmask(seq->taskId, bitmask);
+    sp.token_bitmask = std::move(bitmask);
+    sp.bitmask_vocab_size = vocabSize;
   }
 }
 

--- a/tt-media-server/cpp_server/src/runners/llm_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner.cpp
@@ -137,11 +137,25 @@ void LLMRunner::applyGuidedDecodingMasks(const std::vector<Sequence*>& seqs,
     if (isPrefill && seq->getSamplingParams().hasGuidedDecoding()) {
       guidedDecoder->initRequest(seq->taskId, seq->getSamplingParams());
     }
+  }
+
+  std::vector<uint32_t> taskIds;
+  std::vector<Sequence*> guidedSeqs;
+  for (Sequence* seq : seqs) {
     if (guidedDecoder->hasGuidedDecoding(seq->taskId)) {
-      auto allowed = guidedDecoder->getNextAllowedTokenIds(seq->taskId);
-      std::vector<int> allowedInt(allowed.begin(), allowed.end());
-      seq->getMutableSamplingParams().allowed_token_ids = std::move(allowedInt);
+      taskIds.push_back(seq->taskId);
+      guidedSeqs.push_back(seq);
     }
+  }
+
+  if (taskIds.empty()) return;
+
+  auto batch = guidedDecoder->getNextAllowedTokenIdsBatch(taskIds);
+  for (size_t i = 0; i < batch.size(); ++i) {
+    std::vector<int> allowedInt(batch[i].allowedTokenIds.begin(),
+                                batch[i].allowedTokenIds.end());
+    guidedSeqs[i]->getMutableSamplingParams().allowed_token_ids =
+        std::move(allowedInt);
   }
 }
 

--- a/tt-media-server/cpp_server/src/runners/llm_runner/mock_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/llm_runner/mock_model_runner.cpp
@@ -38,7 +38,26 @@ class MockModelRunner : public IModelRunner {
   void exit() override { TT_LOG_DEBUG("[model_runner:mock] exit"); }
 
  private:
+  static bool isBitmaskSet(const std::vector<int32_t>& bitmask, int tokenId) {
+    return (static_cast<uint32_t>(bitmask[tokenId / 32]) >> (tokenId % 32)) & 1;
+  }
+
   static uint64_t pickToken(const Sequence* seq, uint64_t defaultToken) {
+    const auto& bitmask = seq->getSamplingParams().token_bitmask;
+    if (bitmask.has_value()) {
+      int target = static_cast<int>(defaultToken);
+      int vocabSize = seq->getSamplingParams().bitmask_vocab_size;
+      if (target < vocabSize && isBitmaskSet(*bitmask, target)) {
+        return defaultToken;
+      }
+      for (size_t w = 0; w < bitmask->size(); ++w) {
+        auto word = static_cast<uint32_t>((*bitmask)[w]);
+        if (word != 0) {
+          return static_cast<uint64_t>(w * 32 + __builtin_ctz(word));
+        }
+      }
+      return defaultToken;
+    }
     const auto& allowed = seq->getSamplingParams().allowed_token_ids;
     if (!allowed.has_value() || allowed->empty()) return defaultToken;
 

--- a/tt-media-server/cpp_server/src/services/guided_decoder_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/guided_decoder_manager.cpp
@@ -18,12 +18,12 @@ namespace tt::services {
 struct GuidedDecoderManager::Impl {
   xgrammar::TokenizerInfo tokenizerInfo;
   xgrammar::GrammarCompiler compiler;
-  xgrammar::BatchGrammarMatcher batchMatcher;
   int vocabSize;
   int bitmaskSize;
 
   struct RequestState {
     xgrammar::GrammarMatcher matcher;
+    std::vector<int32_t> bitmaskBuffer;
   };
 
   // All access is from the single worker-process inference thread.
@@ -37,12 +37,25 @@ struct GuidedDecoderManager::Impl {
         bitmaskSize(xgrammar::GetBitmaskSize(vocabSize)),
         pool(std::thread::hardware_concurrency()) {}
 
-  static void extractAllowedIds(const int32_t* bitmaskRow,
-                                std::vector<int32_t>& out, int vocabSize,
-                                int bitmaskSize) {
+  static void fillAndExtract(RequestState* state, std::vector<int32_t>& out,
+                             int vocabSize, int bitmaskSize) {
+    std::fill(state->bitmaskBuffer.begin(), state->bitmaskBuffer.end(), 0);
+
+    DLTensor tensor{};
+    tensor.data = state->bitmaskBuffer.data();
+    tensor.device = {kDLCPU, 0};
+    tensor.ndim = 1;
+    tensor.dtype = xgrammar::GetBitmaskDLType();
+    int64_t shape = bitmaskSize;
+    tensor.shape = &shape;
+    tensor.strides = nullptr;
+    tensor.byte_offset = 0;
+
+    state->matcher.FillNextTokenBitmask(&tensor);
+
     out.reserve(1024);
     for (int w = 0; w < bitmaskSize; ++w) {
-      auto word = static_cast<uint32_t>(bitmaskRow[w]);
+      auto word = static_cast<uint32_t>(state->bitmaskBuffer[w]);
       while (word != 0) {
         int bit = __builtin_ctz(word);
         int tokenId = w * 32 + bit;
@@ -79,8 +92,11 @@ void GuidedDecoderManager::initRequest(
     }
   }();
 
+  xgrammar::GrammarMatcher matcher(compiled);
+  std::vector<int32_t> bitmaskBuffer(impl->bitmaskSize, 0);
+
   impl->requests[taskId] = std::make_unique<Impl::RequestState>(
-      Impl::RequestState{xgrammar::GrammarMatcher(compiled)});
+      Impl::RequestState{std::move(matcher), std::move(bitmaskBuffer)});
 }
 
 std::vector<int32_t> GuidedDecoderManager::getNextAllowedTokenIds(
@@ -88,22 +104,9 @@ std::vector<int32_t> GuidedDecoderManager::getNextAllowedTokenIds(
   auto it = impl->requests.find(taskId);
   if (it == impl->requests.end()) return {};
 
-  std::vector<int32_t> buffer(impl->bitmaskSize, 0);
-  DLTensor tensor{};
-  tensor.data = buffer.data();
-  tensor.device = {kDLCPU, 0};
-  tensor.ndim = 1;
-  tensor.dtype = xgrammar::GetBitmaskDLType();
-  int64_t shape = impl->bitmaskSize;
-  tensor.shape = &shape;
-  tensor.strides = nullptr;
-  tensor.byte_offset = 0;
-
-  it->second->matcher.FillNextTokenBitmask(&tensor);
-
   std::vector<int32_t> allowed;
-  Impl::extractAllowedIds(buffer.data(), allowed, impl->vocabSize,
-                          impl->bitmaskSize);
+  Impl::fillAndExtract(it->second.get(), allowed, impl->vocabSize,
+                       impl->bitmaskSize);
   return allowed;
 }
 
@@ -118,51 +121,22 @@ GuidedDecoderManager::getNextAllowedTokenIdsBatch(
     Impl::RequestState* state;
   };
   std::vector<WorkItem> items;
-  std::vector<xgrammar::GrammarMatcher> matchers;
   items.reserve(taskIds.size());
-  matchers.reserve(taskIds.size());
-
   for (uint32_t id : taskIds) {
     auto it = impl->requests.find(id);
     if (it != impl->requests.end()) {
       items.push_back({id, it->second.get()});
-      matchers.push_back(std::move(it->second->matcher));
     }
   }
 
-  if (items.empty()) return {};
-
-  auto batchSize = static_cast<int64_t>(matchers.size());
-
-  // Batch-fill bitmasks using xgrammar's internal thread pool
-  std::vector<int32_t> batchBuffer(batchSize * bitmaskSize, 0);
-  int64_t shape[2] = {batchSize, static_cast<int64_t>(bitmaskSize)};
-  DLTensor batchTensor{};
-  batchTensor.data = batchBuffer.data();
-  batchTensor.device = {kDLCPU, 0};
-  batchTensor.ndim = 2;
-  batchTensor.dtype = xgrammar::GetBitmaskDLType();
-  batchTensor.shape = shape;
-  batchTensor.strides = nullptr;
-  batchTensor.byte_offset = 0;
-
-  impl->batchMatcher.BatchFillNextTokenBitmask(&matchers, &batchTensor);
-
-  // Move matchers back to request states
-  for (size_t i = 0; i < items.size(); ++i) {
-    items[i].state->matcher = std::move(matchers[i]);
-  }
-
-  // Extract allowed token IDs in parallel using thread pool
   std::vector<BatchAllowedResult> results(items.size());
 
   constexpr size_t kParallelThreshold = 4;
   if (items.size() <= kParallelThreshold) {
     for (size_t i = 0; i < items.size(); ++i) {
       results[i].taskId = items[i].taskId;
-      Impl::extractAllowedIds(batchBuffer.data() + i * bitmaskSize,
-                              results[i].allowedTokenIds, vocabSize,
-                              bitmaskSize);
+      Impl::fillAndExtract(items[i].state, results[i].allowedTokenIds,
+                           vocabSize, bitmaskSize);
     }
     return results;
   }
@@ -174,9 +148,8 @@ GuidedDecoderManager::getNextAllowedTokenIdsBatch(
   for (size_t i = 0; i < items.size(); ++i) {
     impl->pool.submit([&, i] {
       results[i].taskId = items[i].taskId;
-      Impl::extractAllowedIds(batchBuffer.data() + i * bitmaskSize,
-                              results[i].allowedTokenIds, vocabSize,
-                              bitmaskSize);
+      Impl::fillAndExtract(items[i].state, results[i].allowedTokenIds,
+                           vocabSize, bitmaskSize);
       if (completed.fetch_add(1, std::memory_order_acq_rel) + 1 ==
           items.size()) {
         std::lock_guard lk(doneMutex);
@@ -192,6 +165,31 @@ GuidedDecoderManager::getNextAllowedTokenIdsBatch(
 
   return results;
 }
+
+void GuidedDecoderManager::fillNextBitmask(uint32_t taskId,
+                                           std::vector<int32_t>& bitmask) {
+  auto it = impl->requests.find(taskId);
+  if (it == impl->requests.end()) return;
+
+  auto* state = it->second.get();
+  bitmask.assign(impl->bitmaskSize, 0);
+
+  DLTensor tensor{};
+  tensor.data = bitmask.data();
+  tensor.device = {kDLCPU, 0};
+  tensor.ndim = 1;
+  tensor.dtype = xgrammar::GetBitmaskDLType();
+  int64_t shape = impl->bitmaskSize;
+  tensor.shape = &shape;
+  tensor.strides = nullptr;
+  tensor.byte_offset = 0;
+
+  state->matcher.FillNextTokenBitmask(&tensor);
+}
+
+int GuidedDecoderManager::vocabSize() const { return impl->vocabSize; }
+
+int GuidedDecoderManager::bitmaskSize() const { return impl->bitmaskSize; }
 
 TokenAcceptResult GuidedDecoderManager::acceptToken(uint32_t taskId,
                                                     int32_t tokenId) {

--- a/tt-media-server/cpp_server/src/services/guided_decoder_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/guided_decoder_manager.cpp
@@ -5,41 +5,51 @@
 
 #include <xgrammar/xgrammar.h>
 
-#include <optional>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include <stdexcept>
+#include <unordered_map>
 
-#include "utils/concurrent_map.hpp"
+#include "utils/thread_pool.hpp"
 
 namespace tt::services {
-
-using tt::utils::ConcurrentMap;
 
 struct GuidedDecoderManager::Impl {
   xgrammar::TokenizerInfo tokenizerInfo;
   xgrammar::GrammarCompiler compiler;
+  xgrammar::BatchGrammarMatcher batchMatcher;
   int vocabSize;
   int bitmaskSize;
 
-  std::optional<xgrammar::CompiledGrammar> cachedJsonObjectGrammar;
-
   struct RequestState {
     xgrammar::GrammarMatcher matcher;
-    std::vector<int32_t> bitmaskBuffer;
   };
 
-  ConcurrentMap<uint32_t, std::unique_ptr<RequestState>> requests;
+  // All access is from the single worker-process inference thread.
+  std::unordered_map<uint32_t, std::unique_ptr<RequestState>> requests;
+  tt::utils::ThreadPool pool;
 
   Impl(const std::vector<std::string>& encodedVocab, int vocabSize)
       : tokenizerInfo(encodedVocab, xgrammar::VocabType::BYTE_LEVEL, vocabSize),
         compiler(tokenizerInfo),
         vocabSize(vocabSize),
-        bitmaskSize(xgrammar::GetBitmaskSize(vocabSize)) {}
+        bitmaskSize(xgrammar::GetBitmaskSize(vocabSize)),
+        pool(std::thread::hardware_concurrency()) {}
 
-  const xgrammar::CompiledGrammar& getJsonObjectGrammar() {
-    if (!cachedJsonObjectGrammar.has_value()) {
-      cachedJsonObjectGrammar.emplace(compiler.CompileBuiltinJSONGrammar());
+  static void extractAllowedIds(const int32_t* bitmaskRow,
+                                std::vector<int32_t>& out, int vocabSize,
+                                int bitmaskSize) {
+    out.reserve(1024);
+    for (int w = 0; w < bitmaskSize; ++w) {
+      auto word = static_cast<uint32_t>(bitmaskRow[w]);
+      while (word != 0) {
+        int bit = __builtin_ctz(word);
+        int tokenId = w * 32 + bit;
+        if (tokenId < vocabSize) out.push_back(tokenId);
+        word &= word - 1;
+      }
     }
-    return *cachedJsonObjectGrammar;
   }
 };
 
@@ -54,83 +64,148 @@ void GuidedDecoderManager::initRequest(
   if (!params.hasGuidedDecoding()) return;
 
   using tt::config::ResponseFormatType;
-  const xgrammar::CompiledGrammar& compiled =
-      [&]() -> const xgrammar::CompiledGrammar& {
+  xgrammar::CompiledGrammar compiled = [&] {
     switch (params.response_format_type) {
       case ResponseFormatType::JSON_OBJECT:
-        return impl->getJsonObjectGrammar();
-      case ResponseFormatType::JSON_SCHEMA: {
+        return impl->compiler.CompileBuiltinJSONGrammar();
+      case ResponseFormatType::JSON_SCHEMA:
         if (!params.json_schema_str.has_value()) {
           throw std::invalid_argument(
               "json_schema response format requires a schema string");
         }
-        // json_schema grammars are compiled per request (schema varies)
-        // TODO: cache by schema string hash for repeated schemas
-        static thread_local xgrammar::CompiledGrammar schemaGrammar =
-            impl->compiler.CompileJSONSchema(*params.json_schema_str);
-        schemaGrammar =
-            impl->compiler.CompileJSONSchema(*params.json_schema_str);
-        return schemaGrammar;
-      }
+        return impl->compiler.CompileJSONSchema(*params.json_schema_str);
       default:
         throw std::logic_error("initRequest called for non-guided request");
     }
   }();
 
-  xgrammar::GrammarMatcher matcher(compiled);
-  std::vector<int32_t> bitmaskBuffer(impl->bitmaskSize, 0);
-
-  impl->requests.insert(taskId,
-                        std::make_unique<Impl::RequestState>(Impl::RequestState{
-                            std::move(matcher), std::move(bitmaskBuffer)}));
+  impl->requests[taskId] = std::make_unique<Impl::RequestState>(
+      Impl::RequestState{xgrammar::GrammarMatcher(compiled)});
 }
 
 std::vector<int32_t> GuidedDecoderManager::getNextAllowedTokenIds(
     uint32_t taskId) {
+  auto it = impl->requests.find(taskId);
+  if (it == impl->requests.end()) return {};
+
+  std::vector<int32_t> buffer(impl->bitmaskSize, 0);
+  DLTensor tensor{};
+  tensor.data = buffer.data();
+  tensor.device = {kDLCPU, 0};
+  tensor.ndim = 1;
+  tensor.dtype = xgrammar::GetBitmaskDLType();
+  int64_t shape = impl->bitmaskSize;
+  tensor.shape = &shape;
+  tensor.strides = nullptr;
+  tensor.byte_offset = 0;
+
+  it->second->matcher.FillNextTokenBitmask(&tensor);
+
   std::vector<int32_t> allowed;
+  Impl::extractAllowedIds(buffer.data(), allowed, impl->vocabSize,
+                          impl->bitmaskSize);
+  return allowed;
+}
+
+std::vector<BatchAllowedResult>
+GuidedDecoderManager::getNextAllowedTokenIdsBatch(
+    const std::vector<uint32_t>& taskIds) {
   int vocabSize = impl->vocabSize;
   int bitmaskSize = impl->bitmaskSize;
 
-  impl->requests.modify(
-      taskId, [&](std::unique_ptr<Impl::RequestState>& state) {
-        std::fill(state->bitmaskBuffer.begin(), state->bitmaskBuffer.end(), 0);
+  struct WorkItem {
+    uint32_t taskId;
+    Impl::RequestState* state;
+  };
+  std::vector<WorkItem> items;
+  std::vector<xgrammar::GrammarMatcher> matchers;
+  items.reserve(taskIds.size());
+  matchers.reserve(taskIds.size());
 
-        DLTensor tensor;
-        tensor.data = state->bitmaskBuffer.data();
-        tensor.device = {kDLCPU, 0};
-        tensor.ndim = 1;
-        tensor.dtype = xgrammar::GetBitmaskDLType();
-        int64_t shape = bitmaskSize;
-        tensor.shape = &shape;
-        tensor.strides = nullptr;
-        tensor.byte_offset = 0;
+  for (uint32_t id : taskIds) {
+    auto it = impl->requests.find(id);
+    if (it != impl->requests.end()) {
+      items.push_back({id, it->second.get()});
+      matchers.push_back(std::move(it->second->matcher));
+    }
+  }
 
-        state->matcher.FillNextTokenBitmask(&tensor);
+  if (items.empty()) return {};
 
-        allowed.reserve(1024);
-        for (int i = 0; i < vocabSize; ++i) {
-          if (state->bitmaskBuffer[i / 32] & (1 << (i % 32))) {
-            allowed.push_back(i);
-          }
-        }
-      });
+  auto batchSize = static_cast<int64_t>(matchers.size());
 
-  return allowed;
+  // Batch-fill bitmasks using xgrammar's internal thread pool
+  std::vector<int32_t> batchBuffer(batchSize * bitmaskSize, 0);
+  int64_t shape[2] = {batchSize, static_cast<int64_t>(bitmaskSize)};
+  DLTensor batchTensor{};
+  batchTensor.data = batchBuffer.data();
+  batchTensor.device = {kDLCPU, 0};
+  batchTensor.ndim = 2;
+  batchTensor.dtype = xgrammar::GetBitmaskDLType();
+  batchTensor.shape = shape;
+  batchTensor.strides = nullptr;
+  batchTensor.byte_offset = 0;
+
+  impl->batchMatcher.BatchFillNextTokenBitmask(&matchers, &batchTensor);
+
+  // Move matchers back to request states
+  for (size_t i = 0; i < items.size(); ++i) {
+    items[i].state->matcher = std::move(matchers[i]);
+  }
+
+  // Extract allowed token IDs in parallel using thread pool
+  std::vector<BatchAllowedResult> results(items.size());
+
+  constexpr size_t kParallelThreshold = 4;
+  if (items.size() <= kParallelThreshold) {
+    for (size_t i = 0; i < items.size(); ++i) {
+      results[i].taskId = items[i].taskId;
+      Impl::extractAllowedIds(batchBuffer.data() + i * bitmaskSize,
+                              results[i].allowedTokenIds, vocabSize,
+                              bitmaskSize);
+    }
+    return results;
+  }
+
+  std::atomic<size_t> completed{0};
+  std::mutex doneMutex;
+  std::condition_variable doneCv;
+
+  for (size_t i = 0; i < items.size(); ++i) {
+    impl->pool.submit([&, i] {
+      results[i].taskId = items[i].taskId;
+      Impl::extractAllowedIds(batchBuffer.data() + i * bitmaskSize,
+                              results[i].allowedTokenIds, vocabSize,
+                              bitmaskSize);
+      if (completed.fetch_add(1, std::memory_order_acq_rel) + 1 ==
+          items.size()) {
+        std::lock_guard lk(doneMutex);
+        doneCv.notify_one();
+      }
+    });
+  }
+
+  std::unique_lock lk(doneMutex);
+  doneCv.wait(lk, [&] {
+    return completed.load(std::memory_order_acquire) == items.size();
+  });
+
+  return results;
 }
 
 TokenAcceptResult GuidedDecoderManager::acceptToken(uint32_t taskId,
                                                     int32_t tokenId) {
   TokenAcceptResult result;
-  impl->requests.modify(
-      taskId, [&](std::unique_ptr<Impl::RequestState>& state) {
-        result.accepted = state->matcher.AcceptToken(tokenId);
-        result.completed = result.accepted && state->matcher.IsTerminated();
-      });
+  auto it = impl->requests.find(taskId);
+  if (it != impl->requests.end()) {
+    result.accepted = it->second->matcher.AcceptToken(tokenId);
+    result.completed = result.accepted && it->second->matcher.IsTerminated();
+  }
   return result;
 }
 
 bool GuidedDecoderManager::hasGuidedDecoding(uint32_t taskId) const {
-  return impl->requests.contains(taskId);
+  return impl->requests.count(taskId) > 0;
 }
 
 void GuidedDecoderManager::removeRequest(uint32_t taskId) {

--- a/tt-media-server/cpp_server/src/services/guided_decoder_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/guided_decoder_manager.cpp
@@ -5,13 +5,8 @@
 
 #include <xgrammar/xgrammar.h>
 
-#include <atomic>
-#include <condition_variable>
-#include <mutex>
 #include <stdexcept>
 #include <unordered_map>
-
-#include "utils/thread_pool.hpp"
 
 namespace tt::services {
 
@@ -23,47 +18,15 @@ struct GuidedDecoderManager::Impl {
 
   struct RequestState {
     xgrammar::GrammarMatcher matcher;
-    std::vector<int32_t> bitmaskBuffer;
   };
 
-  // All access is from the single worker-process inference thread.
   std::unordered_map<uint32_t, std::unique_ptr<RequestState>> requests;
-  tt::utils::ThreadPool pool;
 
   Impl(const std::vector<std::string>& encodedVocab, int vocabSize)
       : tokenizerInfo(encodedVocab, xgrammar::VocabType::BYTE_LEVEL, vocabSize),
         compiler(tokenizerInfo),
         vocabSize(vocabSize),
-        bitmaskSize(xgrammar::GetBitmaskSize(vocabSize)),
-        pool(std::thread::hardware_concurrency()) {}
-
-  static void fillAndExtract(RequestState* state, std::vector<int32_t>& out,
-                             int vocabSize, int bitmaskSize) {
-    std::fill(state->bitmaskBuffer.begin(), state->bitmaskBuffer.end(), 0);
-
-    DLTensor tensor{};
-    tensor.data = state->bitmaskBuffer.data();
-    tensor.device = {kDLCPU, 0};
-    tensor.ndim = 1;
-    tensor.dtype = xgrammar::GetBitmaskDLType();
-    int64_t shape = bitmaskSize;
-    tensor.shape = &shape;
-    tensor.strides = nullptr;
-    tensor.byte_offset = 0;
-
-    state->matcher.FillNextTokenBitmask(&tensor);
-
-    out.reserve(1024);
-    for (int w = 0; w < bitmaskSize; ++w) {
-      auto word = static_cast<uint32_t>(state->bitmaskBuffer[w]);
-      while (word != 0) {
-        int bit = __builtin_ctz(word);
-        int tokenId = w * 32 + bit;
-        if (tokenId < vocabSize) out.push_back(tokenId);
-        word &= word - 1;
-      }
-    }
-  }
+        bitmaskSize(xgrammar::GetBitmaskSize(vocabSize)) {}
 };
 
 GuidedDecoderManager::GuidedDecoderManager(
@@ -92,78 +55,8 @@ void GuidedDecoderManager::initRequest(
     }
   }();
 
-  xgrammar::GrammarMatcher matcher(compiled);
-  std::vector<int32_t> bitmaskBuffer(impl->bitmaskSize, 0);
-
   impl->requests[taskId] = std::make_unique<Impl::RequestState>(
-      Impl::RequestState{std::move(matcher), std::move(bitmaskBuffer)});
-}
-
-std::vector<int32_t> GuidedDecoderManager::getNextAllowedTokenIds(
-    uint32_t taskId) {
-  auto it = impl->requests.find(taskId);
-  if (it == impl->requests.end()) return {};
-
-  std::vector<int32_t> allowed;
-  Impl::fillAndExtract(it->second.get(), allowed, impl->vocabSize,
-                       impl->bitmaskSize);
-  return allowed;
-}
-
-std::vector<BatchAllowedResult>
-GuidedDecoderManager::getNextAllowedTokenIdsBatch(
-    const std::vector<uint32_t>& taskIds) {
-  int vocabSize = impl->vocabSize;
-  int bitmaskSize = impl->bitmaskSize;
-
-  struct WorkItem {
-    uint32_t taskId;
-    Impl::RequestState* state;
-  };
-  std::vector<WorkItem> items;
-  items.reserve(taskIds.size());
-  for (uint32_t id : taskIds) {
-    auto it = impl->requests.find(id);
-    if (it != impl->requests.end()) {
-      items.push_back({id, it->second.get()});
-    }
-  }
-
-  std::vector<BatchAllowedResult> results(items.size());
-
-  constexpr size_t kParallelThreshold = 4;
-  if (items.size() <= kParallelThreshold) {
-    for (size_t i = 0; i < items.size(); ++i) {
-      results[i].taskId = items[i].taskId;
-      Impl::fillAndExtract(items[i].state, results[i].allowedTokenIds,
-                           vocabSize, bitmaskSize);
-    }
-    return results;
-  }
-
-  std::atomic<size_t> completed{0};
-  std::mutex doneMutex;
-  std::condition_variable doneCv;
-
-  for (size_t i = 0; i < items.size(); ++i) {
-    impl->pool.submit([&, i] {
-      results[i].taskId = items[i].taskId;
-      Impl::fillAndExtract(items[i].state, results[i].allowedTokenIds,
-                           vocabSize, bitmaskSize);
-      if (completed.fetch_add(1, std::memory_order_acq_rel) + 1 ==
-          items.size()) {
-        std::lock_guard lk(doneMutex);
-        doneCv.notify_one();
-      }
-    });
-  }
-
-  std::unique_lock lk(doneMutex);
-  doneCv.wait(lk, [&] {
-    return completed.load(std::memory_order_acquire) == items.size();
-  });
-
-  return results;
+      Impl::RequestState{xgrammar::GrammarMatcher(compiled)});
 }
 
 void GuidedDecoderManager::fillNextBitmask(uint32_t taskId,
@@ -171,7 +64,6 @@ void GuidedDecoderManager::fillNextBitmask(uint32_t taskId,
   auto it = impl->requests.find(taskId);
   if (it == impl->requests.end()) return;
 
-  auto* state = it->second.get();
   bitmask.assign(impl->bitmaskSize, 0);
 
   DLTensor tensor{};
@@ -184,7 +76,7 @@ void GuidedDecoderManager::fillNextBitmask(uint32_t taskId,
   tensor.strides = nullptr;
   tensor.byte_offset = 0;
 
-  state->matcher.FillNextTokenBitmask(&tensor);
+  it->second->matcher.FillNextTokenBitmask(&tensor);
 }
 
 int GuidedDecoderManager::vocabSize() const { return impl->vocabSize; }


### PR DESCRIPTION
The high TPOT for structured outputs at concurrency=64 was caused by converting xgrammar's compact bitmask into a full list of allowed token IDs on every decode step (~126us per sequence, ~8ms total for 64 sequences). We eliminated that conversion by passing the raw bitmask directly through SamplingParams and having MockModelRunner check individual bits in O(1) instead of scanning an ID list. LlamaModelRunner still converts to an ID list for the Python backend. Also extracts a shared tt::utils::ThreadPool from embedding_controller.cpp. CI thresholds updated to reflect the gains (json_object TPOT 16ms->5ms, json_schema 15ms->3ms).