### PR TITLE
Add socket status to health check endpoints

### DIFF
--- a/tt-media-server/cpp_server/include/api/health_controller.hpp
+++ b/tt-media-server/cpp_server/include/api/health_controller.hpp
@@ -9,6 +9,10 @@
 
 #include "services/base_service.hpp"
 
+namespace tt::sockets {
+class InterServerService;
+}
+
 namespace tt::api {
 
 class HealthController : public drogon::HttpController<HealthController> {
@@ -30,6 +34,7 @@ class HealthController : public drogon::HttpController<HealthController> {
 
  private:
   std::shared_ptr<services::IService> service_;
+  std::shared_ptr<sockets::InterServerService> socket_;
 };
 
 }  // namespace tt::api

--- a/tt-media-server/cpp_server/src/api/health_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/health_controller.cpp
@@ -6,15 +6,18 @@
 #include <chrono>
 
 #include "config/settings.hpp"
+#include "sockets/inter_server_service.hpp"
 #include "utils/logger.hpp"
 #include "utils/service_container.hpp"
 
 namespace tt::api {
 
 HealthController::HealthController() {
-  service_ = tt::utils::ServiceContainer::instance().configuredService();
-  TT_LOG_INFO("[HealthController] Initialized (service={})",
-              (service_ ? "yes" : "no"));
+  auto& container = tt::utils::ServiceContainer::instance();
+  service_ = container.configuredService();
+  socket_ = container.socket();
+  TT_LOG_INFO("[HealthController] Initialized (service={}, socket={})",
+              (service_ ? "yes" : "no"), (socket_ ? "yes" : "no"));
 }
 
 void HealthController::health(
@@ -26,7 +29,6 @@ void HealthController::health(
           std::chrono::system_clock::now().time_since_epoch())
           .count());
 
-  // Check if any workers are alive
   bool hasAliveWorkers = false;
   if (service_) {
     try {
@@ -43,12 +45,25 @@ void HealthController::health(
     }
   }
 
-  if (hasAliveWorkers) {
+  bool socketHealthy = true;
+  if (socket_) {
+    auto socketStatus = socket_->getStatus();
+    if (socketStatus != "disabled") {
+      response["socket_status"] = socketStatus;
+      socketHealthy = socket_->isConnected();
+    }
+  }
+
+  if (hasAliveWorkers && socketHealthy) {
     response["status"] = "healthy";
     callback(drogon::HttpResponse::newHttpJsonResponse(response));
   } else {
     response["status"] = "unhealthy";
-    response["error"] = "no workers are alive";
+    if (!hasAliveWorkers) {
+      response["error"] = "no workers are alive";
+    } else {
+      response["error"] = "socket not connected";
+    }
     auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
     resp->setStatusCode(drogon::k503ServiceUnavailable);
     callback(resp);
@@ -78,6 +93,13 @@ void HealthController::ready(
     response["queue_size"] = static_cast<Json::UInt64>(status.queue_size);
     response["max_queue_size"] =
         static_cast<Json::UInt64>(status.max_queue_size);
+
+    if (socket_) {
+      auto socketStatus = socket_->getStatus();
+      if (socketStatus != "disabled") {
+        response["socket_status"] = socketStatus;
+      }
+    }
 
     Json::Value workers(Json::arrayValue);
     for (const auto& w : status.worker_info) {

--- a/tt-media-server/cpp_server/src/api/health_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/health_controller.cpp
@@ -47,11 +47,8 @@ void HealthController::health(
 
   bool socketHealthy = true;
   if (socket_) {
-    auto socketStatus = socket_->getStatus();
-    if (socketStatus != "disabled") {
-      response["socket_status"] = socketStatus;
-      socketHealthy = socket_->isConnected();
-    }
+    response["socket_status"] = socket_->getStatus();
+    socketHealthy = socket_->isConnected();
   }
 
   if (hasAliveWorkers && socketHealthy) {
@@ -95,10 +92,7 @@ void HealthController::ready(
         static_cast<Json::UInt64>(status.max_queue_size);
 
     if (socket_) {
-      auto socketStatus = socket_->getStatus();
-      if (socketStatus != "disabled") {
-        response["socket_status"] = socketStatus;
-      }
+      response["socket_status"] = socket_->getStatus();
     }
 
     Json::Value workers(Json::arrayValue);


### PR DESCRIPTION
In disaggregated (prefill/decode) mode, GET /health and GET /tt-liveness now include a socket_status field.
/health also returns 503 when the socket is enabled but not connected.

Examples:
```
curl -s http://localhost:8001/health
{
    "socket_status": "server:connected",
    "status": "healthy",
    "timestamp": 1776436268
}
```
```
curl -s http://localhost:8001/tt-liveness
{
    "max_queue_size": 1000,
    "model_ready": true,
    "queue_size": 0,
    "socket_status": "server:connected",
    "status": "alive",
    "workers": [
        {
            "is_alive": true,
            "is_ready": true,
            "pid": 2862751,
            "worker_id": "0"
        }
    ]
}
```