### PR TITLE
cpp server: self-terminate worker on model output hang

### DIFF
--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -51,6 +51,13 @@ constexpr unsigned PM_CONNECT_TIMEOUT_MS = 30000;
 constexpr size_t PM_MAX_USERS = 64;
 constexpr bool USE_DEEPSEEK_MD_FORMAT = false;
 constexpr unsigned WARMUP_TIMEOUT_MS = 10000;
+/**
+ * Max time (ms) the runner may go without producing a model output while at
+ * least one request is in flight before it self-terminates the worker
+ * process. Self-terminating lets the infrastructure monitoring stack notice
+ * the crash and restart the server instead of hanging silently.
+ */
+constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 10000;
 
 constexpr const char* MODEL = "deepseek-ai/DeepSeek-R1-0528";
 

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -144,6 +144,11 @@ size_t pmMaxUsers();
  * From WARMUP_TIMEOUT_MS. Default: defaults::WARMUP_TIMEOUT_MS. */
 unsigned warmupTimeoutMs();
 
+/** Max time (ms) without any model output while at least one request is in
+ * flight before the runner self-terminates the worker process. From
+ * OUTPUT_HANG_TIMEOUT_MS. Default: defaults::OUTPUT_HANG_TIMEOUT_MS. */
+unsigned outputHangTimeoutMs();
+
 /** Task queue name from TT_TASK_QUEUE. Default: defaults::TT_TASK_QUEUE. */
 std::string ttTaskQueueName();
 

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/blaze_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/blaze_runner.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <unordered_map>
@@ -47,6 +48,7 @@ class BlazeRunner : public IRunner {
   void handleRequest(
       std::unique_ptr<tt::runners::llm_engine::Sequence> request);
   void evictSlot(uint32_t slotId);
+  void checkOutputHang();
 
   tt::config::LLMConfig config;
   std::unordered_set<int64_t> stopTokenIds;
@@ -58,5 +60,8 @@ class BlazeRunner : public IRunner {
       running;
   std::atomic<bool> stopped{false};
   std::unique_ptr<tt::services::AsyncMemoryManager> memoryManager;
+
+  std::chrono::steady_clock::time_point lastOutputTime;
+  std::chrono::milliseconds outputHangTimeout;
 };
 }  // namespace tt::runners

--- a/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner_demo.hpp
+++ b/tt-media-server/cpp_server/include/runners/sp_pipeline_runner/sp_pipeline_runner_demo.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <thread>
@@ -40,6 +41,7 @@ class SpPipelineRunnerDemo : public IRunner {
   void step();
   void drainDecodeResults();
   void memoryLoop();
+  void checkOutputHang();
 
   tt::config::LLMConfig config;
   std::unordered_set<int64_t> stopTokenIds;
@@ -56,6 +58,9 @@ class SpPipelineRunnerDemo : public IRunner {
 
   std::unique_ptr<tt::services::MemoryManager> memoryManager;
   std::thread memoryThread;
+
+  std::chrono::steady_clock::time_point lastOutputTime;
+  std::chrono::milliseconds outputHangTimeout;
 };
 
 }  // namespace tt::runners

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -180,6 +180,11 @@ unsigned warmupTimeoutMs() {
       envUlong("WARMUP_TIMEOUT_MS", defaults::WARMUP_TIMEOUT_MS));
 }
 
+unsigned outputHangTimeoutMs() {
+  return static_cast<unsigned>(
+      envUlong("OUTPUT_HANG_TIMEOUT_MS", defaults::OUTPUT_HANG_TIMEOUT_MS));
+}
+
 bool useDeepseekMdFormat() {
   return static_cast<bool>(
       envUlong("USE_DEEPSEEK_MD_FORMAT", defaults::USE_DEEPSEEK_MD_FORMAT));

--- a/tt-media-server/cpp_server/src/runners/blaze_runner/blaze_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/blaze_runner/blaze_runner.cpp
@@ -4,6 +4,8 @@
 #include "runners/sp_pipeline_runner/blaze_runner.hpp"
 
 #include <cassert>
+#include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <pipeline_manager/pipeline_manager_types.hpp>
 #include <thread>
@@ -26,7 +28,9 @@ BlazeRunner::BlazeRunner(const config::LLMConfig& config,
     : config(config),
       stopTokenIds(config.stop_token_ids.begin(), config.stop_token_ids.end()),
       resultQueue(resultQueue),
-      taskQueue(taskQueue) {
+      taskQueue(taskQueue),
+      lastOutputTime(std::chrono::steady_clock::now()),
+      outputHangTimeout(tt::config::outputHangTimeoutMs()) {
   TT_LOG_INFO("BlazeRunner: Constructing PipelineManager with SocketConfig...");
   pm::SocketConfig socketConfig{
       .h2d_socket_id = tt::config::h2dSocketId(),
@@ -150,6 +154,7 @@ void BlazeRunner::step() {
         request->getNumPromptTokens(), request->getTokenIds().size());
     handleRequest(std::move(request));
   }
+  checkOutputHang();
 }
 
 std::optional<pm::PMResponse> BlazeRunner::getResponse() {
@@ -190,6 +195,7 @@ BlazeRunner::getMemoryRequest() {
 
 void BlazeRunner::handleOutput(const pm::OutputMessage& output) {
   tt::worker::SingleProcessWorkerMetrics::instance().updateOutputHeartbeat();
+  lastOutputTime = std::chrono::steady_clock::now();
   auto it = running.find(output.slot_id);
   if (it == running.end()) {
     TT_LOG_ERROR(
@@ -211,6 +217,28 @@ void BlazeRunner::handleOutput(const pm::OutputMessage& output) {
   }
 }
 
+void BlazeRunner::checkOutputHang() {
+  if (running.empty()) {
+    lastOutputTime = std::chrono::steady_clock::now();
+    return;
+  }
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - lastOutputTime);
+  if (elapsed <= outputHangTimeout) {
+    return;
+  }
+  TT_LOG_CRITICAL(
+      "[BlazeRunner] Output hang detected: no model output for {} ms with {} "
+      "active slot(s) (threshold={} ms). Self-terminating worker so "
+      "infrastructure can restart the server.",
+      elapsed.count(), running.size(), outputHangTimeout.count());
+  // Use abort() so the existing fatalSignalHandler prints a visible
+  // "killed by signal SIGABRT" line and the WorkerManager parent logs the
+  // worker crash. Skipping destructors is acceptable here: the model/device
+  // is already wedged and we want the worker gone ASAP.
+  std::abort();
+}
+
 inline void BlazeRunner::evictSlot(uint32_t slotId) {
   auto it = running.find(slotId);
   if (it != running.end()) {
@@ -225,6 +253,9 @@ inline void BlazeRunner::evictSlot(uint32_t slotId) {
 
 void BlazeRunner::handleRequest(
     std::unique_ptr<tt::runners::llm_engine::Sequence> request) {
+  if (running.empty()) {
+    lastOutputTime = std::chrono::steady_clock::now();
+  }
   tt::worker::SingleProcessWorkerMetrics::instance().incrementActiveRequests();
   auto slotId = request->getKVCacheSlot();
   assert(slotId != tt::domain::INVALID_SLOT_ID);

--- a/tt-media-server/cpp_server/src/runners/blaze_runner/sp_pipeline_runner_demo.cpp
+++ b/tt-media-server/cpp_server/src/runners/blaze_runner/sp_pipeline_runner_demo.cpp
@@ -5,6 +5,7 @@
 
 #include <cassert>
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <thread>
@@ -26,7 +27,9 @@ SpPipelineRunnerDemo::SpPipelineRunnerDemo(
       resultQueue(resultQueue),
       taskQueue(taskQueue),
       decodeQueue(config.max_in_flight_count),
-      maxInFlightCount(config.max_in_flight_count * 30) {
+      maxInFlightCount(config.max_in_flight_count * 30),
+      lastOutputTime(std::chrono::steady_clock::now()),
+      outputHangTimeout(tt::config::outputHangTimeoutMs()) {
   if (tt::config::llmMode() == config::LLMMode::DECODE_ONLY ||
       tt::config::llmMode() == config::LLMMode::REGULAR) {
     memoryManager = std::make_unique<services::ContiguousMemoryManager>();
@@ -127,6 +130,7 @@ void SpPipelineRunnerDemo::memoryLoop() {
 void SpPipelineRunnerDemo::step() {
   tt::worker::SingleProcessWorkerMetrics::instance().updateStepHeartbeat();
   drainDecodeResults();
+  checkOutputHang();
 
   if (inFlightCount >= maxInFlightCount) {
     return;
@@ -144,6 +148,10 @@ void SpPipelineRunnerDemo::step() {
           static_cast<int>(config::LLMConfig::MAX_INPUT_TOKENS);
     }
 
+    if (inFlightCount == 0) {
+      lastOutputTime = std::chrono::steady_clock::now();
+    }
+
     tt::worker::SingleProcessWorkerMetrics::instance()
         .incrementActiveRequests();
     modelRunner->write(
@@ -155,11 +163,31 @@ void SpPipelineRunnerDemo::step() {
   }
 }
 
+void SpPipelineRunnerDemo::checkOutputHang() {
+  if (inFlightCount == 0) {
+    lastOutputTime = std::chrono::steady_clock::now();
+    return;
+  }
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - lastOutputTime);
+  if (elapsed <= outputHangTimeout) {
+    return;
+  }
+  TT_LOG_CRITICAL(
+      "[SpPipelineRunnerDemo] Output hang detected: no model output for {} ms "
+      "with {} active request(s) (threshold={} ms). Self-terminating worker "
+      "so infrastructure can restart the server.",
+      elapsed.count(), inFlightCount, outputHangTimeout.count());
+  // See BlazeRunner::checkOutputHang for rationale on using abort() here.
+  std::abort();
+}
+
 void SpPipelineRunnerDemo::drainDecodeResults() {
   std::vector<tt::runners::llm_engine::TokenResult> results;
   decodeQueue.popMany(results, maxInFlightCount);
   for (const auto& dr : results) {
     tt::worker::SingleProcessWorkerMetrics::instance().updateOutputHeartbeat();
+    lastOutputTime = std::chrono::steady_clock::now();
     auto it = activeSequences.find(dr.taskId);
     if (it == activeSequences.end()) {
       TT_LOG_WARN(


### PR DESCRIPTION
## Summary

- When the SP pipeline stops producing output while requests are in flight, the inference server can't recover on its own. This change detects that condition in `BlazeRunner` and `SpPipelineRunnerDemo` and `abort()`s the worker so the infrastructure monitoring stack (Prometheus `tt_worker_alive`, WorkerManager `CRITICAL` log, `/tt-liveness`) notices the crash and restarts the server instead of hanging silently.
- Per-runner timer tracks the steady-clock time of the last model output; reset on output arrival and on the 0→1 idle→active transition. If ``elapsed > threshold`` while at least one request is in flight, the runner logs `TT_LOG_CRITICAL` and calls `std::abort()`, which routes through the existing `fatalSignalHandler` / `WorkerManager` crash path.
- Threshold defaults to 10 s (`defaults::OUTPUT_HANG_TIMEOUT_MS`) and is overridable via the `OUTPUT_HANG_TIMEOUT_MS` env var, same pattern as `WARMUP_TIMEOUT_MS` / `PM_CONNECT_TIMEOUT_MS`.

Refs: https://github.com/tenstorrent/tt-inference-server/issues/2946
