### PR TITLE
Replace boolean flags with SessionState state machine

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -435,12 +435,21 @@ target_include_directories(concurrent_map_test PRIVATE
 add_executable(session_test
     tests/session_test.cpp
     src/domain/session.cpp
+)
+target_link_libraries(session_test PRIVATE JsonCpp::JsonCpp GTest::gtest_main)
+target_include_directories(session_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+add_executable(session_manager_test
+    tests/session_manager_test.cpp
+    src/domain/session.cpp
     src/services/session_manager.cpp
     src/metrics/metrics.cpp
 )
-target_link_libraries(session_test PRIVATE
+target_link_libraries(session_manager_test PRIVATE
     llm_runner_lib Drogon::Drogon prometheus-cpp::core GTest::gtest_main)
-target_include_directories(session_test PRIVATE
+target_include_directories(session_manager_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${prometheus-cpp_SOURCE_DIR}/core/include
 )
@@ -457,6 +466,7 @@ gtest_discover_tests(structured_output_test)
 gtest_discover_tests(worker_metrics_shm_test)
 gtest_discover_tests(concurrent_map_test)
 gtest_discover_tests(session_test)
+gtest_discover_tests(session_manager_test)
 
 # IPC smoke test (2-process, Boost.Interprocess queue + scheduler)
 add_executable(ipc_scheduler_smoke_test tests/ipc_scheduler_smoke_test.cpp)

--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -426,6 +426,25 @@ target_include_directories(worker_metrics_shm_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+add_executable(concurrent_map_test tests/concurrent_map_test.cpp)
+target_link_libraries(concurrent_map_test PRIVATE GTest::gtest_main)
+target_include_directories(concurrent_map_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+add_executable(session_test
+    tests/session_test.cpp
+    src/domain/session.cpp
+    src/services/session_manager.cpp
+    src/metrics/metrics.cpp
+)
+target_link_libraries(session_test PRIVATE
+    llm_runner_lib Drogon::Drogon prometheus-cpp::core GTest::gtest_main)
+target_include_directories(session_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${prometheus-cpp_SOURCE_DIR}/core/include
+)
+
 include(GoogleTest)
 gtest_discover_tests(scheduler_test)
 gtest_discover_tests(llm_runner_test)
@@ -436,6 +455,8 @@ gtest_discover_tests(cancel_queue_test)
 gtest_discover_tests(cancellation_test)
 gtest_discover_tests(structured_output_test)
 gtest_discover_tests(worker_metrics_shm_test)
+gtest_discover_tests(concurrent_map_test)
+gtest_discover_tests(session_test)
 
 # IPC smoke test (2-process, Boost.Interprocess queue + scheduler)
 add_executable(ipc_scheduler_smoke_test tests/ipc_scheduler_smoke_test.cpp)

--- a/tt-media-server/cpp_server/include/domain/session.hpp
+++ b/tt-media-server/cpp_server/include/domain/session.hpp
@@ -7,9 +7,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <optional>
-#include <random>
-#include <sstream>
 #include <string>
 
 #include "domain/manage_memory.hpp"
@@ -17,75 +14,53 @@
 namespace tt::domain {
 
 /**
- * Session represents a user session with an optional slot assignment.
+ * Lifecycle state of a Session.
+ *
+ * Transitions:
+ *   IDLE          --(markInFlight)-----> IN_FLIGHT
+ *   IN_FLIGHT     --(clearInFlight)----> IDLE
+ *   IN_FLIGHT     --(markPendingClose)-> PENDING_CLOSE
+ *   PENDING_CLOSE --(clearInFlight)----> CLOSING  (transient; immediately
+ *                                                  consumed by SessionManager)
  */
+enum class SessionState {
+  IDLE,           // no active request
+  IN_FLIGHT,      // request actively being processed
+  PENDING_CLOSE,  // closeSession called while in-flight; deferred until
+                  // complete
+  CLOSING,        // request completed, deferred close is being executed
+};
+
 class Session {
  public:
-  /**
-   * Create a new session with a generated UUID.
-   * @param slotId Optional slot ID (max uint32_t means unassigned)
-   */
   explicit Session(uint32_t slotId = INVALID_SLOT_ID);
 
-  /**
-   * Get the session ID (UUID).
-   */
   std::string getSessionId() const { return session_id_; }
-
-  /**
-   * Get the assigned slot ID.
-   * @return Slot ID, or max uint32_t if unassigned
-   */
   uint32_t getSlotId() const { return slot_id_; }
-
-  /**
-   * Assign a slot ID to this session.
-   */
   void setSlotId(uint32_t slotId) { slot_id_ = slotId; }
-
-  /**
-   * Check if a slot is assigned.
-   */
   bool hasSlot() const { return slot_id_ != INVALID_SLOT_ID; }
 
-  /**
-   * Check if the session is in-flight (has an active request).
-   */
-  bool isInFlight() const { return in_flight_; }
+  bool isIdle() const { return state_ == SessionState::IDLE; }
+  bool isInFlight() const { return state_ == SessionState::IN_FLIGHT; }
+  bool isPendingClose() const { return state_ == SessionState::PENDING_CLOSE; }
+  bool isClosing() const { return state_ == SessionState::CLOSING; }
 
-  /**
-   * Set the in-flight status of the session.
-   */
-  void setInFlight(bool inFlight) { in_flight_ = inFlight; }
+  SessionState getState() const { return state_; }
 
-  /**
-   * Returns true if closeSession was called while a request was in-flight.
-   * The close executes automatically when the in-flight request completes.
-   */
-  bool isPendingClose() const { return pending_close_; }
+  // Transition methods return false (without changing state) if the
+  // precondition is not met.
+  bool markInFlight();      // IDLE      -> IN_FLIGHT
+  bool clearInFlight();     // IN_FLIGHT -> IDLE  |  PENDING_CLOSE -> CLOSING
+  bool markPendingClose();  // IN_FLIGHT -> PENDING_CLOSE
 
-  /**
-   * Mark the session for deferred close.
-   */
-  void setPendingClose(bool pendingClose) { pending_close_ = pendingClose; }
-
-  /**
-   * Get the last activity time.
-   */
   std::chrono::system_clock::time_point getLastActivityTime() const {
     return last_activity_time_;
   }
 
-  /**
-   * Update the last activity time to now.
-   */
   void updateActivityTime() {
     last_activity_time_ = std::chrono::system_clock::now();
   }
 
-  /**
-   * Convert to JSON representation.
-   */
   Json::Value toJson() const {
     Json::Value json;
     json["session_id"] = session_id_;
@@ -96,13 +71,9 @@ class Session {
  private:
   std::string session_id_;
   uint32_t slot_id_;
-  bool in_flight_{false};
-  bool pending_close_{false};
+  SessionState state_{SessionState::IDLE};
   std::chrono::system_clock::time_point last_activity_time_;
 
-  /**
-   * Generate a UUID v4 string.
-   */
   static std::string generateUuid();
 };
 

--- a/tt-media-server/cpp_server/include/domain/session.hpp
+++ b/tt-media-server/cpp_server/include/domain/session.hpp
@@ -20,15 +20,13 @@ namespace tt::domain {
  *   IDLE          --(markInFlight)-----> IN_FLIGHT
  *   IN_FLIGHT     --(clearInFlight)----> IDLE
  *   IN_FLIGHT     --(markPendingClose)-> PENDING_CLOSE
- *   PENDING_CLOSE --(clearInFlight)----> CLOSING  (transient; immediately
- *                                                  consumed by SessionManager)
+ *   PENDING_CLOSE --(clearInFlight)----> CLOSING
  */
 enum class SessionState {
   IDLE,           // no active request
   IN_FLIGHT,      // request actively being processed
-  PENDING_CLOSE,  // closeSession called while in-flight; deferred until
-                  // complete
-  CLOSING,        // request completed, deferred close is being executed
+  PENDING_CLOSE,  // close requested; slot freed once in-flight request finishes
+  CLOSING,        // in-flight request finished; slot deallocation pending
 };
 
 class Session {

--- a/tt-media-server/cpp_server/include/domain/session.hpp
+++ b/tt-media-server/cpp_server/include/domain/session.hpp
@@ -17,16 +17,17 @@ namespace tt::domain {
  * Lifecycle state of a Session.
  *
  * Transitions:
- *   IDLE          --(markInFlight)-----> IN_FLIGHT
- *   IN_FLIGHT     --(clearInFlight)----> IDLE
- *   IN_FLIGHT     --(markPendingClose)-> PENDING_CLOSE
- *   PENDING_CLOSE --(clearInFlight)----> CLOSING
+ *   IDLE            --(markInFlight)-------> IN_FLIGHT
+ *   IN_FLIGHT       --(clearInFlight)------> IDLE
+ *   IN_FLIGHT       --(markCloseRequested)-> CLOSE_REQUESTED
+ *   CLOSE_REQUESTED --(clearInFlight)------> CLOSING
  */
 enum class SessionState {
-  IDLE,           // no active request
-  IN_FLIGHT,      // request actively being processed
-  PENDING_CLOSE,  // close requested; slot freed once in-flight request finishes
-  CLOSING,        // in-flight request finished; slot deallocation pending
+  IDLE,             // no active request
+  IN_FLIGHT,        // request actively being processed
+  CLOSE_REQUESTED,  // close requested while in-flight; waiting for request to
+                    // finish
+  CLOSING,          // request finished; slot deallocation pending
 };
 
 class Session {
@@ -40,16 +41,19 @@ class Session {
 
   bool isIdle() const { return state_ == SessionState::IDLE; }
   bool isInFlight() const { return state_ == SessionState::IN_FLIGHT; }
-  bool isPendingClose() const { return state_ == SessionState::PENDING_CLOSE; }
+  bool isCloseRequested() const {
+    return state_ == SessionState::CLOSE_REQUESTED;
+  }
   bool isClosing() const { return state_ == SessionState::CLOSING; }
 
   SessionState getState() const { return state_; }
 
   // Transition methods return false (without changing state) if the
   // precondition is not met.
-  bool markInFlight();      // IDLE      -> IN_FLIGHT
-  bool clearInFlight();     // IN_FLIGHT -> IDLE  |  PENDING_CLOSE -> CLOSING
-  bool markPendingClose();  // IN_FLIGHT -> PENDING_CLOSE
+  bool markInFlight();  // IDLE            -> IN_FLIGHT
+  bool
+  clearInFlight();  // IN_FLIGHT        -> IDLE  |  CLOSE_REQUESTED -> CLOSING
+  bool markCloseRequested();  // IN_FLIGHT        -> CLOSE_REQUESTED
 
   std::chrono::system_clock::time_point getLastActivityTime() const {
     return last_activity_time_;

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -101,6 +101,8 @@ class SessionManager {
   void sendAsyncAllocationRequest(PendingAllocation& pendingAllocation);
   void evictOldSessions();
   void sendDeallocRequest(const std::string& sessionId, uint32_t slotId);
+  void finalizeSessionClose(const std::string& sessionId,
+                            const domain::Session& session);
   void readerLoop();
   void retryFailedAllocations();
   void retryFailedDeallocs();

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -63,7 +63,7 @@ class SessionManager {
   std::optional<domain::Session> getSession(const std::string& sessionId) const;
   size_t getActiveSessionCount() const;
 
-  void setSessionInFlight(const std::string& sessionId, bool inFlight);
+  void releaseInFlight(const std::string& sessionId);
 
  private:
   struct PendingAllocation {

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -39,7 +39,6 @@ class SessionInFlightException : public SessionRateLimitException {
 enum class CloseSessionResult {
   SUCCESS,
   NOT_FOUND,
-  IN_FLIGHT,  // session exists but has an active request; dealloc deferred
 };
 
 class SessionManager {
@@ -64,6 +63,12 @@ class SessionManager {
   size_t getActiveSessionCount() const;
 
   void releaseInFlight(const std::string& sessionId);
+
+  // Register a callback to be invoked immediately if closeSession is called
+  // while the session has an in-flight request. The callback should abort the
+  // active request. It is cleared automatically once the session is released.
+  void setSessionAbortCallback(const std::string& sessionId,
+                               std::function<void()> onAbort);
 
  private:
   struct PendingAllocation {
@@ -103,6 +108,7 @@ class SessionManager {
   void updateSessionCountMetric();
 
   mutable utils::ConcurrentMap<std::string, domain::Session> sessions;
+  utils::ConcurrentMap<std::string, std::function<void()>> abortCallbacks_;
 
   std::unique_ptr<ipc::MemoryRequestQueue> memoryRequestQueue;
   std::unique_ptr<ipc::MemoryResultQueue> memoryResultQueue;

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -234,6 +234,13 @@ void LLMController::handleStreaming(
         try {
           service->preProcess(*reqPtr);
 
+          if (reqPtr->sessionId.has_value() && sessionManager) {
+            auto taskId = reqPtr->task_id;
+            sessionManager->setSessionAbortCallback(
+                reqPtr->sessionId.value(),
+                [svc = service, taskId]() { svc->abortRequest(taskId); });
+          }
+
           StreamParams params;
           params.completionId = "chatcmpl-" + std::to_string(reqPtr->task_id);
           params.model = reqPtr->model.value_or("default");
@@ -373,12 +380,6 @@ void LLMController::closeSession(
       callback(drogon::HttpResponse::newHttpJsonResponse(response));
       break;
     }
-    case CloseSessionResult::IN_FLIGHT:
-      callback(errorResponse(drogon::k409Conflict,
-                             "Session has an active request in flight; retry "
-                             "after the request completes",
-                             "session_in_flight"));
-      break;
     case CloseSessionResult::NOT_FOUND:
       callback(errorResponse(drogon::k404NotFound, "Session not found",
                              "not_found"));

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -188,14 +188,14 @@ void LLMController::chatCompletions(
             resp->setBody(chatResponse.toJsonString());
 
             if (sessionId.has_value() && sessionManager) {
-              sessionManager->setSessionInFlight(sessionId.value(), false);
+              sessionManager->releaseInFlight(sessionId.value());
             }
 
             (*cb)(resp);
           } catch (const services::QueueFullException& e) {
             auto sessionId = request->sessionId;
             if (sessionId.has_value() && sessionManager) {
-              sessionManager->setSessionInFlight(sessionId.value(), false);
+              sessionManager->releaseInFlight(sessionId.value());
             }
             (*cb)(errorResponse(drogon::k429TooManyRequests, e.what(),
                                 "rate_limit_exceeded"));

--- a/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
+++ b/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
@@ -168,8 +168,8 @@ void SseStreamWriter::finalizeStream() {
       (*self->stream_ptr_)->close();
 
       if (self->params_.sessionId.has_value() && self->params_.sessionManager) {
-        self->params_.sessionManager->setSessionInFlight(
-            self->params_.sessionId.value(), false);
+        self->params_.sessionManager->releaseInFlight(
+            self->params_.sessionId.value());
       }
     }
   });
@@ -181,8 +181,7 @@ void SseStreamWriter::abort() {
                 params_.taskId);
     params_.service->abortRequest(params_.taskId);
     if (params_.sessionId.has_value() && params_.sessionManager) {
-      params_.sessionManager->setSessionInFlight(params_.sessionId.value(),
-                                                 false);
+      params_.sessionManager->releaseInFlight(params_.sessionId.value());
     }
   }
 }

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -23,7 +23,7 @@ bool Session::markInFlight() {
 
 bool Session::clearInFlight() {
   if (state_ != SessionState::IN_FLIGHT &&
-      state_ != SessionState::PENDING_CLOSE) {
+      state_ != SessionState::CLOSE_REQUESTED) {
     return false;
   }
   state_ = (state_ == SessionState::IN_FLIGHT) ? SessionState::IDLE
@@ -31,9 +31,9 @@ bool Session::clearInFlight() {
   return true;
 }
 
-bool Session::markPendingClose() {
+bool Session::markCloseRequested() {
   if (state_ != SessionState::IN_FLIGHT) return false;
-  state_ = SessionState::PENDING_CLOSE;
+  state_ = SessionState::CLOSE_REQUESTED;
   return true;
 }
 

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -5,12 +5,36 @@
 
 #include <iomanip>
 #include <mutex>
+#include <random>
+#include <sstream>
 
 namespace tt::domain {
 
 Session::Session(uint32_t slotId)
     : slot_id_(slotId), last_activity_time_(std::chrono::system_clock::now()) {
   session_id_ = generateUuid();
+}
+
+bool Session::markInFlight() {
+  if (state_ != SessionState::IDLE) return false;
+  state_ = SessionState::IN_FLIGHT;
+  return true;
+}
+
+bool Session::clearInFlight() {
+  if (state_ != SessionState::IN_FLIGHT &&
+      state_ != SessionState::PENDING_CLOSE) {
+    return false;
+  }
+  state_ = (state_ == SessionState::IN_FLIGHT) ? SessionState::IDLE
+                                               : SessionState::CLOSING;
+  return true;
+}
+
+bool Session::markPendingClose() {
+  if (state_ != SessionState::IN_FLIGHT) return false;
+  state_ = SessionState::PENDING_CLOSE;
+  return true;
 }
 
 std::string Session::generateUuid() {

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -72,14 +72,18 @@ CloseSessionResult SessionManager::closeSession(const std::string& sessionId) {
   };
 
   auto session = sessions.takeIf(
-      sessionId, [](const domain::Session& s) { return !s.isInFlight(); });
+      sessionId, [](const domain::Session& s) { return s.isIdle(); });
   if (session.has_value()) {
     executeClose(*session);
     return CloseSessionResult::SUCCESS;
   }
 
-  bool found = sessions.modify(
-      sessionId, [](domain::Session& s) { s.setPendingClose(true); });
+  bool found = sessions.modify(sessionId, [](domain::Session& s) {
+    if (!s.markPendingClose()) {
+      TT_LOG_WARN("[Session] markPendingClose: unexpected state {}",
+                  static_cast<int>(s.getState()));
+    }
+  });
   if (!found) {
     TT_LOG_WARN("[SessionManager] Session not found: {}", sessionId);
     return CloseSessionResult::NOT_FOUND;
@@ -87,9 +91,8 @@ CloseSessionResult SessionManager::closeSession(const std::string& sessionId) {
 
   // The in-flight request may have completed between the takeIf and modify;
   // resolve the race with one more attempt.
-  auto deferred = sessions.takeIf(sessionId, [](const domain::Session& s) {
-    return s.isPendingClose() && !s.isInFlight();
-  });
+  auto deferred = sessions.takeIf(
+      sessionId, [](const domain::Session& s) { return s.isClosing(); });
   if (deferred.has_value()) {
     executeClose(*deferred);
     return CloseSessionResult::SUCCESS;
@@ -136,12 +139,12 @@ uint32_t SessionManager::acquireSessionSlot(const std::string& sessionId) {
   bool wasInFlight = false;
 
   sessions.modify(sessionId, [&result, &wasInFlight](domain::Session& s) {
-    wasInFlight = s.isInFlight();
+    wasInFlight = !s.isIdle();
     if (wasInFlight) {
       return;
     }
     s.updateActivityTime();
-    s.setInFlight(true);
+    s.markInFlight();
     result = s.getSlotId();
   });
 
@@ -165,31 +168,30 @@ std::optional<domain::Session> SessionManager::getSession(
 
 size_t SessionManager::getActiveSessionCount() const { return sessions.size(); }
 
-void SessionManager::setSessionInFlight(const std::string& sessionId,
-                                        bool inFlight) {
-  bool found = sessions.modify(
-      sessionId, [inFlight](domain::Session& s) { s.setInFlight(inFlight); });
+void SessionManager::releaseInFlight(const std::string& sessionId) {
+  bool found = sessions.modify(sessionId, [](domain::Session& s) {
+    if (!s.clearInFlight()) {
+      TT_LOG_WARN("[Session] clearInFlight: unexpected state {}",
+                  static_cast<int>(s.getState()));
+    }
+  });
 
   if (!found) {
     TT_LOG_WARN("[SessionManager] Session not found for in-flight update: {}",
                 sessionId);
     return;
   }
-  TT_LOG_DEBUG("[SessionManager] Set session {} in-flight: {}", sessionId,
-               inFlight);
+  TT_LOG_DEBUG("[SessionManager] Released in-flight for session {}", sessionId);
 
-  if (!inFlight) {
-    auto session = sessions.takeIf(sessionId, [](const domain::Session& s) {
-      return s.isPendingClose() && !s.isInFlight();
-    });
-    if (session.has_value()) {
-      uint32_t slotId = session->getSlotId();
-      if (slotId != domain::INVALID_SLOT_ID) {
-        sendDeallocRequest(sessionId, slotId);
-      }
-      TT_LOG_INFO("[SessionManager] Deferred close executed for session: {}",
-                  sessionId);
+  auto session = sessions.takeIf(
+      sessionId, [](const domain::Session& s) { return s.isClosing(); });
+  if (session.has_value()) {
+    uint32_t slotId = session->getSlotId();
+    if (slotId != domain::INVALID_SLOT_ID) {
+      sendDeallocRequest(sessionId, slotId);
     }
+    TT_LOG_INFO("[SessionManager] Deferred close executed for session: {}",
+                sessionId);
   }
 }
 
@@ -224,7 +226,7 @@ void SessionManager::evictOldSessions() {
 
   sessions.forEach([&heap, &newer, evictionCount](
                        const std::string& id, const domain::Session& session) {
-    if (session.isInFlight()) return;
+    if (!session.isIdle()) return;
 
     auto t = session.getLastActivityTime();
     if (heap.size() < evictionCount) {
@@ -244,7 +246,7 @@ void SessionManager::evictOldSessions() {
     // A concurrent acquireSessionSlot call may mark the session in-flight
     // between the forEach above and here; takeIf skips it atomically.
     auto session = sessions.takeIf(
-        sessionId, [](const domain::Session& s) { return !s.isInFlight(); });
+        sessionId, [](const domain::Session& s) { return s.isIdle(); });
     if (!session.has_value()) {
       TT_LOG_DEBUG(
           "[SessionManager] evictOldSessions: session {} already removed or "
@@ -420,7 +422,7 @@ void SessionManager::handleMemoryResult(
                  !result.slotIds.empty();
   if (success) {
     pendingAllocation.session.setSlotId(result.slotIds.front());
-    pendingAllocation.session.setInFlight(true);
+    pendingAllocation.session.markInFlight();
     sessions.insert(pendingAllocation.session.getSessionId(),
                     pendingAllocation.session);
     TT_LOG_DEBUG(

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -87,6 +87,7 @@ CloseSessionResult SessionManager::closeSession(const std::string& sessionId) {
                sessionId);
 
   auto executeClose = [&](const domain::Session& s) {
+    abortCallbacks_.take(sessionId);  // clean up any stale abort callback
     if (s.getSlotId() != domain::INVALID_SLOT_ID) {
       sendDeallocRequest(sessionId, s.getSlotId());
     }

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -112,20 +112,29 @@ CloseSessionResult SessionManager::closeSession(const std::string& sessionId) {
     return CloseSessionResult::NOT_FOUND;
   }
 
+  // Immediately abort the in-flight request if an abort callback was
+  // registered.
+  auto abortCallback = abortCallbacks_.take(sessionId);
+  if (abortCallback.has_value()) {
+    (*abortCallback)();
+    TT_LOG_INFO("[SessionManager] Aborted in-flight request for session: {}",
+                sessionId);
+  } else {
+    TT_LOG_WARN(
+        "[SessionManager] closeSession: sessionId={} is in-flight but no abort "
+        "callback registered; will close when request completes",
+        sessionId);
+  }
+
   // The in-flight request may have completed between the takeIf and modify;
   // resolve the race with one more attempt.
   auto deferred = sessions.takeIf(
       sessionId, [](const domain::Session& s) { return s.isClosing(); });
   if (deferred.has_value()) {
     executeClose(*deferred);
-    return CloseSessionResult::SUCCESS;
   }
 
-  TT_LOG_WARN(
-      "[SessionManager] closeSession: sessionId={} is in-flight, "
-      "will close when request completes",
-      sessionId);
-  return CloseSessionResult::IN_FLIGHT;
+  return CloseSessionResult::SUCCESS;
 }
 
 bool SessionManager::assignSlotId(const std::string& sessionId,
@@ -209,6 +218,8 @@ void SessionManager::releaseInFlight(const std::string& sessionId) {
   }
   TT_LOG_DEBUG("[SessionManager] Released in-flight for session {}", sessionId);
 
+  abortCallbacks_.take(sessionId);  // clear abort callback once request is done
+
   auto session = sessions.takeIf(
       sessionId, [](const domain::Session& s) { return s.isClosing(); });
   if (session.has_value()) {
@@ -220,6 +231,11 @@ void SessionManager::releaseInFlight(const std::string& sessionId) {
                 sessionId);
     updateSessionCountMetric();
   }
+}
+
+void SessionManager::setSessionAbortCallback(const std::string& sessionId,
+                                             std::function<void()> onAbort) {
+  abortCallbacks_.insert(sessionId, std::move(onAbort));
 }
 
 void SessionManager::evictOldSessions() {

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -82,29 +82,30 @@ void SessionManager::readerLoop() {
   }
 }
 
+void SessionManager::finalizeSessionClose(const std::string& sessionId,
+                                          const domain::Session& session) {
+  abortCallbacks_.take(sessionId);
+  if (session.getSlotId() != domain::INVALID_SLOT_ID) {
+    sendDeallocRequest(sessionId, session.getSlotId());
+  }
+  TT_LOG_INFO("[SessionManager] Closed session: {}", sessionId);
+  updateSessionCountMetric();
+}
+
 CloseSessionResult SessionManager::closeSession(const std::string& sessionId) {
   TT_LOG_DEBUG("[SessionManager] closeSession called for sessionId={}",
                sessionId);
 
-  auto executeClose = [&](const domain::Session& s) {
-    abortCallbacks_.take(sessionId);  // clean up any stale abort callback
-    if (s.getSlotId() != domain::INVALID_SLOT_ID) {
-      sendDeallocRequest(sessionId, s.getSlotId());
-    }
-    TT_LOG_INFO("[SessionManager] Closed session: {}", sessionId);
-    updateSessionCountMetric();
-  };
-
   auto session = sessions.takeIf(
       sessionId, [](const domain::Session& s) { return s.isIdle(); });
   if (session.has_value()) {
-    executeClose(*session);
+    finalizeSessionClose(sessionId, *session);
     return CloseSessionResult::SUCCESS;
   }
 
   bool found = sessions.modify(sessionId, [](domain::Session& s) {
-    if (!s.markPendingClose()) {
-      TT_LOG_WARN("[Session] markPendingClose: unexpected state {}",
+    if (!s.markCloseRequested()) {
+      TT_LOG_WARN("[Session] markCloseRequested: unexpected state {}",
                   static_cast<int>(s.getState()));
     }
   });
@@ -132,7 +133,7 @@ CloseSessionResult SessionManager::closeSession(const std::string& sessionId) {
   auto deferred = sessions.takeIf(
       sessionId, [](const domain::Session& s) { return s.isClosing(); });
   if (deferred.has_value()) {
-    executeClose(*deferred);
+    finalizeSessionClose(sessionId, *deferred);
   }
 
   return CloseSessionResult::SUCCESS;
@@ -219,18 +220,13 @@ void SessionManager::releaseInFlight(const std::string& sessionId) {
   }
   TT_LOG_DEBUG("[SessionManager] Released in-flight for session {}", sessionId);
 
-  abortCallbacks_.take(sessionId);  // clear abort callback once request is done
-
   auto session = sessions.takeIf(
       sessionId, [](const domain::Session& s) { return s.isClosing(); });
   if (session.has_value()) {
-    uint32_t slotId = session->getSlotId();
-    if (slotId != domain::INVALID_SLOT_ID) {
-      sendDeallocRequest(sessionId, slotId);
-    }
-    TT_LOG_INFO("[SessionManager] Deferred close executed for session: {}",
-                sessionId);
-    updateSessionCountMetric();
+    finalizeSessionClose(sessionId, *session);
+  } else {
+    abortCallbacks_.take(
+        sessionId);  // clear callback on normal (IDLE) completion
   }
 }
 

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -165,7 +165,10 @@ uint32_t SessionManager::acquireSessionSlot(const std::string& sessionId) {
       return;
     }
     s.updateActivityTime();
-    s.markInFlight();
+    if (!s.markInFlight()) {
+      TT_LOG_WARN("[Session] markInFlight: unexpected state {}",
+                  static_cast<int>(s.getState()));
+    }
     result = s.getSlotId();
   });
 
@@ -444,7 +447,11 @@ void SessionManager::handleMemoryResult(
                  !result.slotIds.empty();
   if (success) {
     pendingAllocation.session.setSlotId(result.slotIds.front());
-    pendingAllocation.session.markInFlight();
+    if (!pendingAllocation.session.markInFlight()) {
+      TT_LOG_WARN("[Session] markInFlight: unexpected state {} for session {}",
+                  static_cast<int>(pendingAllocation.session.getState()),
+                  pendingAllocation.session.getSessionId());
+    }
     sessions.insert(pendingAllocation.session.getSessionId(),
                     pendingAllocation.session);
     TT_LOG_DEBUG(

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -114,8 +114,6 @@ CloseSessionResult SessionManager::closeSession(const std::string& sessionId) {
     return CloseSessionResult::NOT_FOUND;
   }
 
-  // Immediately abort the in-flight request if an abort callback was
-  // registered.
   auto abortCallback = abortCallbacks_.take(sessionId);
   if (abortCallback.has_value()) {
     (*abortCallback)();

--- a/tt-media-server/cpp_server/tests/concurrent_map_test.cpp
+++ b/tt-media-server/cpp_server/tests/concurrent_map_test.cpp
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#include "utils/concurrent_map.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "utils/concurrent_queue.hpp"
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// ConcurrentMap::takeIf — unit tests
+// ---------------------------------------------------------------------------
+
+TEST(ConcurrentMapTakeIf, ReturnsNulloptWhenKeyAbsent) {
+  tt::utils::ConcurrentMap<int, std::string> map;
+  auto result = map.takeIf(42, [](const std::string&) { return true; });
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(ConcurrentMapTakeIf, ReturnsNulloptWhenPredicateFalse) {
+  tt::utils::ConcurrentMap<int, std::string> map;
+  map.insert(1, "hello");
+  auto result = map.takeIf(1, [](const std::string&) { return false; });
+  EXPECT_FALSE(result.has_value());
+  EXPECT_TRUE(map.contains(1));  // entry must remain in the map
+}
+
+TEST(ConcurrentMapTakeIf, TakesAndRemovesWhenPredicateTrue) {
+  tt::utils::ConcurrentMap<int, std::string> map;
+  map.insert(1, "hello");
+  auto result = map.takeIf(1, [](const std::string&) { return true; });
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, "hello");
+  EXPECT_FALSE(map.contains(1));
+}
+
+TEST(ConcurrentMapTakeIf, PredicateReceivesCorrectValue) {
+  tt::utils::ConcurrentMap<int, int> map;
+  map.insert(1, 99);
+  std::optional<int> seenValue;
+  map.takeIf(1, [&seenValue](const int& v) {
+    seenValue = v;
+    return false;
+  });
+  ASSERT_TRUE(seenValue.has_value());
+  EXPECT_EQ(*seenValue, 99);
+}
+
+// Simulates the eviction TOCTOU race: one thread races to mark items
+// in-flight while another tries to evict them. takeIf must never remove an
+// item whose predicate was made false by a concurrent modifier.
+TEST(ConcurrentMapTakeIf, NeverEvictsInFlightItemUnderContention) {
+  struct Item {
+    bool in_flight{false};
+  };
+
+  tt::utils::ConcurrentMap<int, Item> map;
+  constexpr int kNumItems = 1000;
+  for (int i = 0; i < kNumItems; ++i) {
+    map.insert(i, Item{});
+  }
+
+  std::atomic<int> falseEvictions{0};
+
+  std::thread marker([&] {
+    for (int i = 0; i < kNumItems; ++i) {
+      map.modify(i, [](Item& item) { item.in_flight = true; });
+    }
+  });
+
+  std::thread evictor([&] {
+    for (int i = 0; i < kNumItems; ++i) {
+      auto taken =
+          map.takeIf(i, [](const Item& item) { return !item.in_flight; });
+      if (taken.has_value() && taken->in_flight) ++falseEvictions;
+    }
+  });
+
+  marker.join();
+  evictor.join();
+
+  EXPECT_EQ(falseEvictions.load(), 0)
+      << "takeIf evicted an in-flight item — TOCTOU race not fixed";
+}
+
+// ---------------------------------------------------------------------------
+// ConcurrentQueue — move overload tests
+// ---------------------------------------------------------------------------
+
+TEST(ConcurrentQueueMoveOverload, MovedValueArrivesInQueue) {
+  tt::utils::ConcurrentQueue<std::string> q;
+  std::string s = "hello";
+  q.push(std::move(s));
+  EXPECT_TRUE(s.empty());  // must have been genuinely moved
+  auto items = q.drain();
+  ASSERT_EQ(items.size(), 1u);
+  EXPECT_EQ(items[0], "hello");
+}
+
+TEST(ConcurrentQueueMoveOverload, MoveOverloadUsedForRvalues) {
+  tt::utils::ConcurrentQueue<std::unique_ptr<int>> q;
+  q.push(std::make_unique<int>(42));
+  auto items = q.drain();
+  ASSERT_EQ(items.size(), 1u);
+  ASSERT_NE(items[0], nullptr);
+  EXPECT_EQ(*items[0], 42);
+}
+
+// ---------------------------------------------------------------------------
+// TOCTOU race — barrier-driven regression tests
+//
+// Two-phase barrier forces the exact race window open on every iteration:
+//   Phase 1 – evictor's forEach scan completes (lock released).
+//   Phase 2 – acquirer marks victim in-flight, signals done.
+//   Phase 3 – evictor calls take/takeIf.
+//
+// With take  (buggy):  victim is evicted even though it's now in-flight.
+// With takeIf (fixed): victim is skipped because predicate re-checks state.
+// ---------------------------------------------------------------------------
+
+struct Session {
+  bool in_flight{false};
+  int slot_id{-1};
+};
+
+struct TwoPhaseBarrier {
+  std::mutex mu;
+  std::condition_variable cv;
+  int phase{0};
+
+  void waitForPhase(int p) {
+    std::unique_lock lk(mu);
+    cv.wait(lk, [&] { return phase >= p; });
+  }
+  void advance() {
+    std::lock_guard lk(mu);
+    ++phase;
+    cv.notify_all();
+  }
+  void reset() {
+    std::lock_guard lk(mu);
+    phase = 0;
+  }
+};
+
+bool evictBuggy(tt::utils::ConcurrentMap<int, Session>& sessions, int victim,
+                TwoPhaseBarrier& barrier) {
+  std::vector<int> candidates;
+  sessions.forEach([&](const int& key, Session& s) {
+    if (!s.in_flight) candidates.push_back(key);
+  });
+  // Lock released — TOCTOU window is now open.
+  barrier.advance();        // signal acquirer: scan is done
+  barrier.waitForPhase(2);  // wait for acquirer to mark in-flight
+
+  for (int key : candidates) {
+    if (key == victim) return sessions.take(key).has_value();  // THE BUG
+  }
+  return false;
+}
+
+bool evictFixed(tt::utils::ConcurrentMap<int, Session>& sessions, int victim,
+                TwoPhaseBarrier& barrier) {
+  std::vector<int> candidates;
+  sessions.forEach([&](const int& key, Session& s) {
+    if (!s.in_flight) candidates.push_back(key);
+  });
+  barrier.advance();
+  barrier.waitForPhase(2);
+
+  for (int key : candidates) {
+    if (key == victim) {
+      // Atomically re-check predicate inside the lock — THE FIX.
+      return sessions.takeIf(key, [](const Session& s) { return !s.in_flight; })
+          .has_value();
+    }
+  }
+  return false;
+}
+
+template <typename EvictFn>
+int countWrongEvictions(EvictFn evictFn, int iterations = 200) {
+  constexpr int kNumSessions = 8;
+  constexpr int kVictim = 3;
+  int wrong = 0;
+
+  for (int iter = 0; iter < iterations; ++iter) {
+    tt::utils::ConcurrentMap<int, Session> sessions;
+    for (int i = 0; i < kNumSessions; ++i) {
+      sessions.insert(i, Session{false, i});
+    }
+
+    TwoPhaseBarrier barrier;
+    bool evictedVictim = false;
+
+    std::thread evictor(
+        [&] { evictedVictim = evictFn(sessions, kVictim, barrier); });
+
+    barrier.waitForPhase(1);
+    sessions.modify(kVictim, [](Session& s) { s.in_flight = true; });
+    barrier.advance();  // phase 1→2
+
+    evictor.join();
+    if (evictedVictim) ++wrong;
+
+    if (!sessions.contains(kVictim))
+      sessions.insert(kVictim, Session{false, kVictim});
+  }
+  return wrong;
+}
+
+TEST(ToctouRaceRepro, BuggyTakeEvictsInFlightSessionOnEveryIteration) {
+  constexpr int kIterations = 200;
+  int wrong = countWrongEvictions(evictBuggy, kIterations);
+  std::cout << "[buggy]  wrong_evictions=" << wrong << "/" << kIterations
+            << "\n";
+  // The barrier forces the race window open deterministically, so the bug
+  // must fire on every single iteration.
+  EXPECT_EQ(wrong, kIterations)
+      << "take() must evict the in-flight session on every iteration when the "
+         "TOCTOU window is forced open";
+}
+
+TEST(ToctouRaceRepro, FixedTakeIfNeverEvictsInFlightSession) {
+  constexpr int kIterations = 200;
+  int wrong = countWrongEvictions(evictFixed, kIterations);
+  std::cout << "[fixed]  wrong_evictions=" << wrong << "/" << kIterations
+            << "\n";
+  EXPECT_EQ(wrong, 0)
+      << "takeIf must atomically skip in-flight sessions even when the "
+         "TOCTOU window is fully open";
+}
+
+}  // namespace

--- a/tt-media-server/cpp_server/tests/session_manager_test.cpp
+++ b/tt-media-server/cpp_server/tests/session_manager_test.cpp
@@ -121,7 +121,8 @@ TEST(SessionManagerLifecycle, DeferredClose_FinalizedOnReleaseInFlight) {
   manager.closeSession(sessionId);        // IN_FLIGHT -> CLOSE_REQUESTED
   EXPECT_TRUE(manager.getSession(sessionId).has_value());  // still present
 
-  manager.releaseInFlight(sessionId);  // CLOSE_REQUESTED -> CLOSING -> finalized
+  manager.releaseInFlight(
+      sessionId);  // CLOSE_REQUESTED -> CLOSING -> finalized
   EXPECT_FALSE(manager.getSession(sessionId).has_value());  // now gone
 }
 
@@ -195,7 +196,8 @@ TEST(SessionManagerLifecycle, GetSlotIdBySessionId_ReturnsSlotId) {
   EXPECT_EQ(manager.getSlotIdBySessionId(sessionId), 13u);
 }
 
-TEST(SessionManagerLifecycle, GetSlotIdBySessionId_NotFound_ReturnsInvalidSlot) {
+TEST(SessionManagerLifecycle,
+     GetSlotIdBySessionId_NotFound_ReturnsInvalidSlot) {
   tt::services::SessionManager manager;
 
   EXPECT_EQ(manager.getSlotIdBySessionId("no-such-id"),

--- a/tt-media-server/cpp_server/tests/session_manager_test.cpp
+++ b/tt-media-server/cpp_server/tests/session_manager_test.cpp
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#include "services/session_manager.hpp"
+
+#include <gtest/gtest.h>
+#include <trantor/net/EventLoop.h>
+
+#include <atomic>
+#include <future>
+#include <string>
+#include <thread>
+
+#include "domain/session.hpp"
+#include "domain/slot_types.hpp"
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// Trantor requires an EventLoop to be both created and run on the same thread.
+struct LoopFixture {
+  std::promise<trantor::EventLoop*> promise_;
+  trantor::EventLoop* loop{nullptr};
+  std::thread loopThread;
+
+  LoopFixture() {
+    auto future = promise_.get_future();
+    loopThread = std::thread([this]() {
+      trantor::EventLoop eventLoop;
+      promise_.set_value(&eventLoop);
+      eventLoop.loop();
+    });
+    loop = future.get();
+  }
+
+  ~LoopFixture() {
+    if (loop) loop->quit();
+    if (loopThread.joinable()) loopThread.join();
+  }
+};
+
+std::string createSessionWithSlot(tt::services::SessionManager& manager,
+                                  trantor::EventLoop* loop, uint32_t slotId) {
+  std::promise<std::string> promise;
+  auto future = promise.get_future();
+
+  manager.createSession(
+      [&promise](const tt::domain::Session& s) {
+        promise.set_value(s.getSessionId());
+      },
+      [&promise](std::string_view err) {
+        promise.set_exception(
+            std::make_exception_ptr(std::runtime_error(std::string(err))));
+      },
+      loop, slotId);
+
+  return future.get();
+}
+
+// ---------------------------------------------------------------------------
+// SessionManager lifecycle tests
+// ---------------------------------------------------------------------------
+
+TEST(SessionManagerLifecycle, CloseIdleSession_ReturnsSuccess) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 10u);
+  ASSERT_FALSE(sessionId.empty());
+
+  EXPECT_EQ(manager.closeSession(sessionId),
+            tt::services::CloseSessionResult::SUCCESS);
+  EXPECT_FALSE(manager.getSession(sessionId).has_value());
+}
+
+TEST(SessionManagerLifecycle, CloseNonExistentSession_ReturnsNotFound) {
+  tt::services::SessionManager manager;
+
+  EXPECT_EQ(manager.closeSession("no-such-id"),
+            tt::services::CloseSessionResult::NOT_FOUND);
+}
+
+TEST(SessionManagerLifecycle, AcquireSlot_ReturnsPreAssignedSlotId) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 7u);
+  ASSERT_FALSE(sessionId.empty());
+
+  EXPECT_EQ(manager.acquireSessionSlot(sessionId), 7u);
+  manager.releaseInFlight(sessionId);
+}
+
+TEST(SessionManagerLifecycle, AcquireSlot_InFlightSession_Throws) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 8u);
+  ASSERT_FALSE(sessionId.empty());
+
+  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
+  EXPECT_THROW(manager.acquireSessionSlot(sessionId),
+               tt::services::SessionInFlightException);
+  manager.releaseInFlight(sessionId);
+}
+
+TEST(SessionManagerLifecycle, DeferredClose_FinalizedOnReleaseInFlight) {
+  // CLOSE_REQUESTED path: the session must stay in the map until
+  // releaseInFlight completes the CLOSE_REQUESTED -> CLOSING -> finalized
+  // transition.
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 9u);
+  ASSERT_FALSE(sessionId.empty());
+
+  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
+  manager.closeSession(sessionId);        // IN_FLIGHT -> CLOSE_REQUESTED
+  EXPECT_TRUE(manager.getSession(sessionId).has_value());  // still present
+
+  manager.releaseInFlight(sessionId);  // CLOSE_REQUESTED -> CLOSING -> finalized
+  EXPECT_FALSE(manager.getSession(sessionId).has_value());  // now gone
+}
+
+TEST(SessionManagerLifecycle, GetActiveSessionCount_ReflectsLifecycle) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  EXPECT_EQ(manager.getActiveSessionCount(), 0u);
+
+  auto s1 = createSessionWithSlot(manager, lf.loop, 20u);
+  EXPECT_EQ(manager.getActiveSessionCount(), 1u);
+
+  auto s2 = createSessionWithSlot(manager, lf.loop, 21u);
+  EXPECT_EQ(manager.getActiveSessionCount(), 2u);
+
+  manager.closeSession(s1);
+  EXPECT_EQ(manager.getActiveSessionCount(), 1u);
+
+  manager.closeSession(s2);
+  EXPECT_EQ(manager.getActiveSessionCount(), 0u);
+}
+
+TEST(SessionManagerLifecycle, AcquireAfterRelease_Succeeds) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 11u);
+  ASSERT_FALSE(sessionId.empty());
+
+  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
+  manager.releaseInFlight(sessionId);     // IN_FLIGHT -> IDLE
+
+  EXPECT_NO_THROW(manager.acquireSessionSlot(sessionId));
+  manager.releaseInFlight(sessionId);
+}
+
+TEST(SessionManagerLifecycle, GetSession_ReturnsCorrectData) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 12u);
+  ASSERT_FALSE(sessionId.empty());
+
+  auto session = manager.getSession(sessionId);
+  ASSERT_TRUE(session.has_value());
+  EXPECT_EQ(session->getSessionId(), sessionId);
+  EXPECT_EQ(session->getSlotId(), 12u);
+}
+
+TEST(SessionManagerLifecycle, AssignSlotId_UpdatesSession) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 30u);
+  ASSERT_FALSE(sessionId.empty());
+
+  EXPECT_TRUE(manager.assignSlotId(sessionId, 99u));
+
+  auto session = manager.getSession(sessionId);
+  ASSERT_TRUE(session.has_value());
+  EXPECT_EQ(session->getSlotId(), 99u);
+}
+
+TEST(SessionManagerLifecycle, GetSlotIdBySessionId_ReturnsSlotId) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 13u);
+  ASSERT_FALSE(sessionId.empty());
+
+  EXPECT_EQ(manager.getSlotIdBySessionId(sessionId), 13u);
+}
+
+TEST(SessionManagerLifecycle, GetSlotIdBySessionId_NotFound_ReturnsInvalidSlot) {
+  tt::services::SessionManager manager;
+
+  EXPECT_EQ(manager.getSlotIdBySessionId("no-such-id"),
+            tt::domain::INVALID_SLOT_ID);
+}
+
+// ---------------------------------------------------------------------------
+// SessionManager abort callback tests
+// ---------------------------------------------------------------------------
+
+TEST(SessionManagerAbort, AbortCallbackInvokedOnCloseWhileInFlight) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 42u);
+  ASSERT_FALSE(sessionId.empty());
+
+  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
+
+  std::atomic<bool> abortCalled{false};
+  manager.setSessionAbortCallback(sessionId,
+                                  [&abortCalled]() { abortCalled = true; });
+
+  auto result = manager.closeSession(sessionId);
+
+  EXPECT_EQ(result, tt::services::CloseSessionResult::SUCCESS);
+  EXPECT_TRUE(abortCalled.load());
+}
+
+TEST(SessionManagerAbort, CloseSessionReturnsSuccessRegardlessOfInFlight) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 43u);
+  ASSERT_FALSE(sessionId.empty());
+
+  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
+  // No abort callback registered (e.g. non-streaming request)
+
+  auto result = manager.closeSession(sessionId);
+  EXPECT_EQ(result, tt::services::CloseSessionResult::SUCCESS);
+}
+
+TEST(SessionManagerAbort, AbortCallbackClearedAfterRequestCompletesNormally) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 44u);
+  ASSERT_FALSE(sessionId.empty());
+
+  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
+
+  std::atomic<bool> abortCalled{false};
+  manager.setSessionAbortCallback(sessionId,
+                                  [&abortCalled]() { abortCalled = true; });
+
+  manager.releaseInFlight(sessionId);  // IN_FLIGHT -> IDLE, clears callback
+
+  manager.closeSession(sessionId);
+
+  EXPECT_FALSE(abortCalled.load());
+}
+
+}  // namespace

--- a/tt-media-server/cpp_server/tests/session_test.cpp
+++ b/tt-media-server/cpp_server/tests/session_test.cpp
@@ -4,19 +4,11 @@
 #include "domain/session.hpp"
 
 #include <gtest/gtest.h>
-#include <trantor/net/EventLoop.h>
-
-#include <atomic>
-#include <future>
-#include <string>
-#include <thread>
-
-#include "services/session_manager.hpp"
 
 namespace {
 
 // ---------------------------------------------------------------------------
-// Session state machine transition tests
+// Session state machine — all valid and invalid transitions
 // ---------------------------------------------------------------------------
 
 TEST(SessionState, InitialStateIsIdle) {
@@ -81,104 +73,6 @@ TEST(SessionState, MarkCloseRequestedFromCloseRequestedReturnsFalse) {
   s.markCloseRequested();
   EXPECT_FALSE(s.markCloseRequested());
   EXPECT_TRUE(s.isCloseRequested());  // state unchanged
-}
-
-// ---------------------------------------------------------------------------
-// SessionManager abort callback tests
-// ---------------------------------------------------------------------------
-
-// Helper: creates a trantor event loop on a background thread (Trantor
-// requires the loop to be created and run on the same thread).
-struct LoopFixture {
-  std::promise<trantor::EventLoop*> promise_;
-  trantor::EventLoop* loop{nullptr};
-  std::thread loopThread;
-
-  LoopFixture() {
-    auto future = promise_.get_future();
-    loopThread = std::thread([this]() {
-      trantor::EventLoop eventLoop;
-      promise_.set_value(&eventLoop);
-      eventLoop.loop();
-    });
-    loop = future.get();
-  }
-
-  ~LoopFixture() {
-    if (loop) loop->quit();
-    if (loopThread.joinable()) loopThread.join();
-  }
-};
-
-std::string createSessionWithSlot(tt::services::SessionManager& manager,
-                                  trantor::EventLoop* loop, uint32_t slotId) {
-  std::promise<std::string> promise;
-  auto future = promise.get_future();
-
-  manager.createSession(
-      [&promise](const tt::domain::Session& s) {
-        promise.set_value(s.getSessionId());
-      },
-      [&promise](std::string_view err) {
-        promise.set_exception(
-            std::make_exception_ptr(std::runtime_error(std::string(err))));
-      },
-      loop, slotId);
-
-  return future.get();
-}
-
-TEST(SessionManagerAbort, AbortCallbackInvokedOnCloseWhileInFlight) {
-  tt::services::SessionManager manager;
-  LoopFixture lf;
-
-  auto sessionId = createSessionWithSlot(manager, lf.loop, 42u);
-  ASSERT_FALSE(sessionId.empty());
-
-  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
-
-  std::atomic<bool> abortCalled{false};
-  manager.setSessionAbortCallback(sessionId,
-                                  [&abortCalled]() { abortCalled = true; });
-
-  auto result = manager.closeSession(sessionId);
-
-  EXPECT_EQ(result, tt::services::CloseSessionResult::SUCCESS);
-  EXPECT_TRUE(abortCalled.load());
-}
-
-TEST(SessionManagerAbort, CloseSessionReturnsSuccessRegardlessOfInFlight) {
-  tt::services::SessionManager manager;
-  LoopFixture lf;
-
-  auto sessionId = createSessionWithSlot(manager, lf.loop, 43u);
-  ASSERT_FALSE(sessionId.empty());
-
-  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
-  // No abort callback registered (e.g. non-streaming request)
-
-  auto result = manager.closeSession(sessionId);
-  EXPECT_EQ(result, tt::services::CloseSessionResult::SUCCESS);
-}
-
-TEST(SessionManagerAbort, AbortCallbackClearedAfterRequestCompletesNormally) {
-  tt::services::SessionManager manager;
-  LoopFixture lf;
-
-  auto sessionId = createSessionWithSlot(manager, lf.loop, 44u);
-  ASSERT_FALSE(sessionId.empty());
-
-  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
-
-  std::atomic<bool> abortCalled{false};
-  manager.setSessionAbortCallback(sessionId,
-                                  [&abortCalled]() { abortCalled = true; });
-
-  manager.releaseInFlight(sessionId);  // IN_FLIGHT -> IDLE, clears callback
-
-  manager.closeSession(sessionId);
-
-  EXPECT_FALSE(abortCalled.load());
 }
 
 }  // namespace

--- a/tt-media-server/cpp_server/tests/session_test.cpp
+++ b/tt-media-server/cpp_server/tests/session_test.cpp
@@ -110,8 +110,6 @@ struct LoopFixture {
   }
 };
 
-// Creates a session with a pre-assigned slot and returns its ID.
-// Uses the event loop to receive the async completion callback.
 std::string createSessionWithSlot(tt::services::SessionManager& manager,
                                   trantor::EventLoop* loop, uint32_t slotId) {
   std::promise<std::string> promise;
@@ -178,8 +176,6 @@ TEST(SessionManagerAbort, AbortCallbackClearedAfterRequestCompletesNormally) {
 
   manager.releaseInFlight(sessionId);  // IN_FLIGHT -> IDLE, clears callback
 
-  // Session is now IDLE; closing it should not invoke the (already cleared)
-  // abort callback.
   manager.closeSession(sessionId);
 
   EXPECT_FALSE(abortCalled.load());

--- a/tt-media-server/cpp_server/tests/session_test.cpp
+++ b/tt-media-server/cpp_server/tests/session_test.cpp
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#include "domain/session.hpp"
+
+#include <gtest/gtest.h>
+#include <trantor/net/EventLoop.h>
+
+#include <atomic>
+#include <future>
+#include <string>
+#include <thread>
+
+#include "services/session_manager.hpp"
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Session state machine transition tests
+// ---------------------------------------------------------------------------
+
+TEST(SessionState, InitialStateIsIdle) {
+  tt::domain::Session s;
+  EXPECT_TRUE(s.isIdle());
+  EXPECT_FALSE(s.isInFlight());
+  EXPECT_FALSE(s.isCloseRequested());
+  EXPECT_FALSE(s.isClosing());
+}
+
+TEST(SessionState, MarkInFlightFromIdle) {
+  tt::domain::Session s;
+  EXPECT_TRUE(s.markInFlight());
+  EXPECT_TRUE(s.isInFlight());
+  EXPECT_FALSE(s.isIdle());
+}
+
+TEST(SessionState, MarkInFlightFromNonIdleReturnsFalseAndPreservesState) {
+  tt::domain::Session s;
+  s.markInFlight();
+  EXPECT_FALSE(s.markInFlight());  // already IN_FLIGHT
+  EXPECT_TRUE(s.isInFlight());
+}
+
+TEST(SessionState, ClearInFlightFromInFlightTransitionsToIdle) {
+  tt::domain::Session s;
+  s.markInFlight();
+  EXPECT_TRUE(s.clearInFlight());
+  EXPECT_TRUE(s.isIdle());
+}
+
+TEST(SessionState, ClearInFlightFromCloseRequestedTransitionsToClosing) {
+  tt::domain::Session s;
+  s.markInFlight();
+  s.markCloseRequested();
+  EXPECT_TRUE(s.clearInFlight());
+  EXPECT_TRUE(s.isClosing());
+}
+
+TEST(SessionState, ClearInFlightFromIdleReturnsFalse) {
+  tt::domain::Session s;
+  EXPECT_FALSE(s.clearInFlight());
+  EXPECT_TRUE(s.isIdle());  // state unchanged
+}
+
+TEST(SessionState, MarkCloseRequestedFromInFlight) {
+  tt::domain::Session s;
+  s.markInFlight();
+  EXPECT_TRUE(s.markCloseRequested());
+  EXPECT_TRUE(s.isCloseRequested());
+}
+
+TEST(SessionState, MarkCloseRequestedFromIdleReturnsFalse) {
+  tt::domain::Session s;
+  EXPECT_FALSE(s.markCloseRequested());
+  EXPECT_TRUE(s.isIdle());  // state unchanged
+}
+
+TEST(SessionState, MarkCloseRequestedFromCloseRequestedReturnsFalse) {
+  tt::domain::Session s;
+  s.markInFlight();
+  s.markCloseRequested();
+  EXPECT_FALSE(s.markCloseRequested());
+  EXPECT_TRUE(s.isCloseRequested());  // state unchanged
+}
+
+// ---------------------------------------------------------------------------
+// SessionManager abort callback tests
+// ---------------------------------------------------------------------------
+
+// Helper: creates a trantor event loop on a background thread (Trantor
+// requires the loop to be created and run on the same thread).
+struct LoopFixture {
+  std::promise<trantor::EventLoop*> promise_;
+  trantor::EventLoop* loop{nullptr};
+  std::thread loopThread;
+
+  LoopFixture() {
+    auto future = promise_.get_future();
+    loopThread = std::thread([this]() {
+      trantor::EventLoop eventLoop;
+      promise_.set_value(&eventLoop);
+      eventLoop.loop();
+    });
+    loop = future.get();
+  }
+
+  ~LoopFixture() {
+    if (loop) loop->quit();
+    if (loopThread.joinable()) loopThread.join();
+  }
+};
+
+// Creates a session with a pre-assigned slot and returns its ID.
+// Uses the event loop to receive the async completion callback.
+std::string createSessionWithSlot(tt::services::SessionManager& manager,
+                                  trantor::EventLoop* loop, uint32_t slotId) {
+  std::promise<std::string> promise;
+  auto future = promise.get_future();
+
+  manager.createSession(
+      [&promise](const tt::domain::Session& s) {
+        promise.set_value(s.getSessionId());
+      },
+      [&promise](std::string_view err) {
+        promise.set_exception(
+            std::make_exception_ptr(std::runtime_error(std::string(err))));
+      },
+      loop, slotId);
+
+  return future.get();
+}
+
+TEST(SessionManagerAbort, AbortCallbackInvokedOnCloseWhileInFlight) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 42u);
+  ASSERT_FALSE(sessionId.empty());
+
+  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
+
+  std::atomic<bool> abortCalled{false};
+  manager.setSessionAbortCallback(sessionId,
+                                  [&abortCalled]() { abortCalled = true; });
+
+  auto result = manager.closeSession(sessionId);
+
+  EXPECT_EQ(result, tt::services::CloseSessionResult::SUCCESS);
+  EXPECT_TRUE(abortCalled.load());
+}
+
+TEST(SessionManagerAbort, CloseSessionReturnsSuccessRegardlessOfInFlight) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 43u);
+  ASSERT_FALSE(sessionId.empty());
+
+  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
+  // No abort callback registered (e.g. non-streaming request)
+
+  auto result = manager.closeSession(sessionId);
+  EXPECT_EQ(result, tt::services::CloseSessionResult::SUCCESS);
+}
+
+TEST(SessionManagerAbort, AbortCallbackClearedAfterRequestCompletesNormally) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 44u);
+  ASSERT_FALSE(sessionId.empty());
+
+  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
+
+  std::atomic<bool> abortCalled{false};
+  manager.setSessionAbortCallback(sessionId,
+                                  [&abortCalled]() { abortCalled = true; });
+
+  manager.releaseInFlight(sessionId);  // IN_FLIGHT -> IDLE, clears callback
+
+  // Session is now IDLE; closing it should not invoke the (already cleared)
+  // abort callback.
+  manager.closeSession(sessionId);
+
+  EXPECT_FALSE(abortCalled.load());
+}
+
+}  // namespace


### PR DESCRIPTION
Replaces the `in_flight_` / `pending_close_` boolean pair in Session with a `SessionState` enum and guarded transition methods. Adds an abort-callback mechanism so streaming requests are cancelled immediately when closeSession is called while a request is in flight.

State | Meaning
-- | --
IDLE | No active request; session is free to accept a new one
IN_FLIGHT | A request is actively being processed
CLOSE_REQUESTED | closeSession was called while in-flight; waiting for the current request to finish before deallocating the slot
CLOSING | Request has finished on a close-requested session; slot deallocation is pending

SessionManager now stores a per-session abort callback. LLMController registers one after resolving the session for a streaming request; it captures the taskId and calls LLMService::abortRequest. When closeSession is called on an in-flight session the callback is taken and invoked immediately, giving the client a fast response. Non-streaming requests continue to use the deferred-close path (no callback registered).

### Other changes
- setSessionInFlight(id, false) → releaseInFlight(id) — cleaner caller API
- Removed CloseSessionResult::IN_FLIGHT; closeSession now always returns SUCCESS for existing sessions
- Extracted finalizeSessionClose private method to eliminate duplicated dealloc/metric/log logic
- Warning logs on unexpected state transitions (returns false instead of asserting)
- concurrent_map_test — ConcurrentMap::takeIf unit tests + TOCTOU race regression
- session_test — Session state machine transitions + SessionManager abort callback behaviour
