### PR TITLE
Add Z-Image-Turbo model support

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -34,6 +34,7 @@ class SupportedModels(Enum):
     QWEN_3_8B = "Qwen/Qwen3-8B"
     SPEECHT5_TTS = "microsoft/speecht5_tts"
     GEMMA_1_1_2B_IT = "google/gemma-1.1-2b-it"
+    Z_IMAGE_TURBO = "Tongyi-MAI/Z-Image-Turbo"
 
 
 # MODEL environment variable
@@ -74,6 +75,7 @@ class ModelNames(Enum):
     QWEN_3_8B = "Qwen3-8B"
     SPEECHT5_TTS = "speecht5_tts"
     GEMMA_1_1_2B_IT = "gemma-1.1-2b-it"
+    Z_IMAGE_TURBO = "Z-Image-Turbo"
 
 
 class ModelRunners(Enum):
@@ -112,6 +114,7 @@ class ModelRunners(Enum):
     LLAMA_RUNNER = "llama_runner"
     TT_SPEECHT5_TTS = "tt-speecht5-tts"
     TT_XLA_SDXL = "tt-xla-sdxl"
+    TT_Z_IMAGE_TURBO = "tt-z-image-turbo"
 
 
 class ModelServices(Enum):
@@ -137,6 +140,7 @@ MODEL_SERVICE_RUNNER_MAP = {
         ModelRunners.TT_QWEN_IMAGE,
         ModelRunners.TT_QWEN_IMAGE_2512,
         ModelRunners.TT_XLA_SDXL,
+        ModelRunners.TT_Z_IMAGE_TURBO,
     },
     ModelServices.LLM: {
         ModelRunners.VLLMForge,
@@ -223,6 +227,7 @@ MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
         ModelNames.STABLE_DIFFUSION_XL_BASE,
         ModelNames.STABLE_DIFFUSION_XL_512,
     },
+    ModelRunners.TT_Z_IMAGE_TURBO: {ModelNames.Z_IMAGE_TURBO},
 }
 
 
@@ -1088,6 +1093,12 @@ ModelConfigs = {
         "device_mesh_shape": (1, 2),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_2X2_GROUP.value,
+        "max_batch_size": 1,
+    },
+    (ModelRunners.TT_Z_IMAGE_TURBO, DeviceTypes.P150X4): {
+        "device_mesh_shape": (1, 4),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_4_GROUP.value,
         "max_batch_size": 1,
     },
 }

--- a/tt-media-server/domain/image_generate_request.py
+++ b/tt-media-server/domain/image_generate_request.py
@@ -8,10 +8,10 @@ from config.settings import get_settings
 from domain.base_request import BaseRequest
 from pydantic import Field, PrivateAttr, field_validator
 
-# Some models support fewer inference steps than the default minimum
-_LOW_STEP_RUNNERS = {"tt-flux.1-dev", "tt-flux.1-schnell", "tt-z-image-turbo"}
 _FLUX_RUNNERS = {"tt-flux.1-dev", "tt-flux.1-schnell"}
 _FLUX_MIN_INFERENCE_STEPS = 4
+_Z_IMAGE_TURBO_RUNNERS = {"tt-z-image-turbo"}
+_Z_IMAGE_TURBO_FIXED_STEPS = 8
 _DEFAULT_MIN_INFERENCE_STEPS = 12
 
 
@@ -35,7 +35,13 @@ class BaseImageRequest(BaseRequest):
         if v is None:
             return v
         model_runner = get_settings().model_runner
-        if model_runner in _LOW_STEP_RUNNERS:
+        if model_runner in _Z_IMAGE_TURBO_RUNNERS:
+            if v != _Z_IMAGE_TURBO_FIXED_STEPS:
+                raise ValueError(
+                    f"num_inference_steps must be exactly {_Z_IMAGE_TURBO_FIXED_STEPS} for {model_runner}, got {v}"
+                )
+            return v
+        if model_runner in _FLUX_RUNNERS:
             min_steps = _FLUX_MIN_INFERENCE_STEPS
         else:
             min_steps = _DEFAULT_MIN_INFERENCE_STEPS

--- a/tt-media-server/domain/image_generate_request.py
+++ b/tt-media-server/domain/image_generate_request.py
@@ -8,7 +8,8 @@ from config.settings import get_settings
 from domain.base_request import BaseRequest
 from pydantic import Field, PrivateAttr, field_validator
 
-# Flux models support fewer inference steps than other image models
+# Some models support fewer inference steps than the default minimum
+_LOW_STEP_RUNNERS = {"tt-flux.1-dev", "tt-flux.1-schnell", "tt-z-image-turbo"}
 _FLUX_RUNNERS = {"tt-flux.1-dev", "tt-flux.1-schnell"}
 _FLUX_MIN_INFERENCE_STEPS = 4
 _DEFAULT_MIN_INFERENCE_STEPS = 12
@@ -34,11 +35,10 @@ class BaseImageRequest(BaseRequest):
         if v is None:
             return v
         model_runner = get_settings().model_runner
-        min_steps = (
-            _FLUX_MIN_INFERENCE_STEPS
-            if model_runner in _FLUX_RUNNERS
-            else _DEFAULT_MIN_INFERENCE_STEPS
-        )
+        if model_runner in _LOW_STEP_RUNNERS:
+            min_steps = _FLUX_MIN_INFERENCE_STEPS
+        else:
+            min_steps = _DEFAULT_MIN_INFERENCE_STEPS
         if v < min_steps:
             raise ValueError(
                 f"num_inference_steps must be >= {min_steps} for {model_runner}, got {v}"

--- a/tt-media-server/domain/image_generate_request.py
+++ b/tt-media-server/domain/image_generate_request.py
@@ -8,11 +8,11 @@ from config.settings import get_settings
 from domain.base_request import BaseRequest
 from pydantic import Field, PrivateAttr, field_validator
 
+# Flux models support fewer inference steps than other image models
 _FLUX_RUNNERS = {"tt-flux.1-dev", "tt-flux.1-schnell"}
 _FLUX_MIN_INFERENCE_STEPS = 4
-_Z_IMAGE_TURBO_RUNNERS = {"tt-z-image-turbo"}
-_Z_IMAGE_TURBO_FIXED_STEPS = 8
 _DEFAULT_MIN_INFERENCE_STEPS = 12
+_SKIP_STEP_VALIDATION_RUNNERS = {"tt-z-image-turbo"}
 
 
 class BaseImageRequest(BaseRequest):
@@ -35,16 +35,13 @@ class BaseImageRequest(BaseRequest):
         if v is None:
             return v
         model_runner = get_settings().model_runner
-        if model_runner in _Z_IMAGE_TURBO_RUNNERS:
-            if v != _Z_IMAGE_TURBO_FIXED_STEPS:
-                raise ValueError(
-                    f"num_inference_steps must be exactly {_Z_IMAGE_TURBO_FIXED_STEPS} for {model_runner}, got {v}"
-                )
+        if model_runner in _SKIP_STEP_VALIDATION_RUNNERS:
             return v
-        if model_runner in _FLUX_RUNNERS:
-            min_steps = _FLUX_MIN_INFERENCE_STEPS
-        else:
-            min_steps = _DEFAULT_MIN_INFERENCE_STEPS
+        min_steps = (
+            _FLUX_MIN_INFERENCE_STEPS
+            if model_runner in _FLUX_RUNNERS
+            else _DEFAULT_MIN_INFERENCE_STEPS
+        )
         if v < min_steps:
             raise ValueError(
                 f"num_inference_steps must be >= {min_steps} for {model_runner}, got {v}"

--- a/tt-media-server/open_ai_api/image.py
+++ b/tt-media-server/open_ai_api/image.py
@@ -33,6 +33,7 @@ async def generate_image(
     """
     try:
         import time as _time
+
         _t0 = _time.time()
         result = await service.process_request(image_generate_request)
         _elapsed = round(_time.time() - _t0, 2)

--- a/tt-media-server/open_ai_api/image.py
+++ b/tt-media-server/open_ai_api/image.py
@@ -32,8 +32,11 @@ async def generate_image(
         HTTPException: If image generation fails.
     """
     try:
+        import time as _time
+        _t0 = _time.time()
         result = await service.process_request(image_generate_request)
-        return JSONResponse(content={"images": result})
+        _elapsed = round(_time.time() - _t0, 2)
+        return JSONResponse(content={"images": result, "generation_time": _elapsed})
     except HTTPException as e:
         raise e
     except Exception as e:

--- a/tt-media-server/scripts/fetch_z_image_turbo.sh
+++ b/tt-media-server/scripts/fetch_z_image_turbo.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Sparse checkout of z_image_turbo model from tt-metal.
+set -euo pipefail
+
+REPO_URL="https://github.com/tenstorrent/tt-metal.git"
+BRANCH="svuckovic/z-image-turbo-inference-server"
+CHECKOUT_DIR="${1:-$(dirname "$0")/../models/z_image_turbo_repo}"
+
+if [ -d "$CHECKOUT_DIR/z_image_turbo" ]; then
+    echo "Updating existing checkout at $CHECKOUT_DIR ..."
+    git -C "$CHECKOUT_DIR" fetch origin "$BRANCH"
+    git -C "$CHECKOUT_DIR" checkout "origin/$BRANCH" -- z_image_turbo models/tt_dit
+else
+    echo "Sparse checkout into $CHECKOUT_DIR ..."
+    mkdir -p "$CHECKOUT_DIR"
+    git -C "$CHECKOUT_DIR" init
+    git -C "$CHECKOUT_DIR" remote add origin "$REPO_URL" 2>/dev/null || true
+    git -C "$CHECKOUT_DIR" config core.sparseCheckout true
+    printf "z_image_turbo\nmodels/tt_dit\n" > "$CHECKOUT_DIR/.git/info/sparse-checkout"
+    git -C "$CHECKOUT_DIR" fetch --depth 1 origin "$BRANCH"
+    git -C "$CHECKOUT_DIR" checkout FETCH_HEAD
+fi
+
+echo "Done: $(realpath "$CHECKOUT_DIR/z_image_turbo")"

--- a/tt-media-server/scripts/fetch_z_image_turbo.sh
+++ b/tt-media-server/scripts/fetch_z_image_turbo.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
 # Sparse checkout of z_image_turbo model from tt-metal.
 set -euo pipefail
 

--- a/tt-media-server/static/z-image-turbo/index.html
+++ b/tt-media-server/static/z-image-turbo/index.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Z-Image-Turbo</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+            background: #0a0a0a; color: #e0e0e0;
+            min-height: 100vh; display: flex; justify-content: center; padding: 2rem;
+        }
+        .container { max-width: 720px; width: 100%; }
+        h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.25rem; }
+        .subtitle { color: #888; font-size: 0.85rem; margin-bottom: 1.5rem; }
+        .input-row {
+            display: flex; gap: 0.5rem; margin-bottom: 1rem;
+        }
+        input[type="text"] {
+            flex: 1; padding: 0.75rem 1rem; border-radius: 8px;
+            border: 1px solid #333; background: #141414; color: #e0e0e0;
+            font-size: 0.95rem; outline: none; transition: border-color 0.2s;
+        }
+        input[type="text"]:focus { border-color: #7c3aed; }
+        button {
+            padding: 0.75rem 1.5rem; border-radius: 8px; border: none;
+            background: #7c3aed; color: #fff; font-size: 0.95rem; font-weight: 500;
+            cursor: pointer; transition: background 0.2s; white-space: nowrap;
+        }
+        button:hover { background: #6d28d9; }
+        button:disabled { background: #333; color: #666; cursor: not-allowed; }
+        .image-box {
+            width: 100%; aspect-ratio: 1; border-radius: 12px;
+            border: 1px solid #222; background: #111; overflow: hidden;
+            display: flex; align-items: center; justify-content: center;
+            position: relative;
+        }
+        .image-box img {
+            width: 100%; height: 100%; object-fit: contain; display: none;
+        }
+        .placeholder { color: #444; font-size: 0.9rem; }
+        .spinner {
+            display: none; width: 36px; height: 36px;
+            border: 3px solid #333; border-top-color: #7c3aed;
+            border-radius: 50%; animation: spin 0.8s linear infinite;
+        }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        .timer {
+            position: absolute; bottom: 1rem; right: 1rem;
+            background: rgba(0,0,0,0.7); padding: 0.25rem 0.6rem;
+            border-radius: 6px; font-size: 0.8rem; color: #aaa; display: none;
+        }
+        .meta {
+            margin-top: 0.75rem; font-size: 0.8rem; color: #666;
+        }
+        .error {
+            margin-top: 0.5rem; color: #ef4444; font-size: 0.85rem; display: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Z-Image-Turbo</h1>
+        <p class="subtitle">512x512 text-to-image on TT-QuietBox™ 2</p>
+
+        <div class="input-row">
+            <input type="text" id="prompt" placeholder="Describe an image..."
+                   autofocus autocomplete="off">
+            <button id="btn" onclick="generate()">Generate</button>
+        </div>
+
+        <div class="error" id="error"></div>
+
+        <div class="image-box">
+            <span class="placeholder" id="placeholder">Your image will appear here</span>
+            <div class="spinner" id="spinner"></div>
+            <img id="img" alt="Generated image">
+            <div class="timer" id="timer">0s</div>
+        </div>
+
+        <p class="meta" id="meta"></p>
+    </div>
+
+    <script>
+    const $ = id => document.getElementById(id);
+    let busy = false, interval;
+
+    $('prompt').addEventListener('keydown', e => {
+        if (e.key === 'Enter' && !busy) generate();
+    });
+
+    async function generate() {
+        const prompt = $('prompt').value.trim();
+        if (!prompt || busy) return;
+
+        busy = true;
+        $('btn').disabled = true;
+        $('error').style.display = 'none';
+        $('placeholder').style.display = 'none';
+        $('img').style.display = 'none';
+        $('spinner').style.display = 'block';
+        $('timer').style.display = 'block';
+        $('meta').textContent = '';
+
+        const t0 = Date.now();
+        $('timer').textContent = '0s';
+        interval = setInterval(() => {
+            $('timer').textContent = Math.floor((Date.now() - t0) / 1000) + 's';
+        }, 1000);
+
+        try {
+            const res = await fetch('/v1/images/generations', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': 'Bearer your-secret-key',
+                },
+                body: JSON.stringify({ prompt, num_inference_steps: 9 }),
+            });
+
+            clearInterval(interval);
+            const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+
+            if (!res.ok) {
+                const err = await res.json().catch(() => ({}));
+                throw new Error(err.detail || `HTTP ${res.status}`);
+            }
+
+            const data = await res.json();
+            const b64 = data.images[0];
+            const serverTime = data.generation_time;
+
+            $('img').src = `data:image/png;base64,${b64}`;
+            $('img').style.display = 'block';
+            $('spinner').style.display = 'none';
+            const timingText = serverTime
+                ? `server: ${serverTime}s / client: ${elapsed}s`
+                : `${elapsed}s`;
+            $('meta').textContent = `"${prompt}" \u2014 ${timingText}`;
+
+        } catch (err) {
+            clearInterval(interval);
+            $('spinner').style.display = 'none';
+            $('placeholder').style.display = 'block';
+            $('error').textContent = err.message;
+            $('error').style.display = 'block';
+        } finally {
+            $('timer').style.display = 'none';
+            $('btn').disabled = false;
+            busy = false;
+        }
+    }
+    </script>
+</body>
+</html>

--- a/tt-media-server/static/z-image-turbo/index.html
+++ b/tt-media-server/static/z-image-turbo/index.html
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/tt-media-server/static/z-image-turbo/index.html
+++ b/tt-media-server/static/z-image-turbo/index.html
@@ -116,7 +116,7 @@
                     'Content-Type': 'application/json',
                     'Authorization': 'Bearer your-secret-key',
                 },
-                body: JSON.stringify({ prompt, num_inference_steps: 9 }),
+                body: JSON.stringify({ prompt, num_inference_steps: 8 }),
             });
 
             clearInterval(interval);

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -119,6 +119,10 @@ AVAILABLE_RUNNERS = {
         "tt_model_runners.forge_runners.sdxl_forge_runner",
         fromlist=["SDXLForgeRunner"],
     ).SDXLForgeRunner(wid),
+    ModelRunners.TT_Z_IMAGE_TURBO: lambda wid: __import__(
+        "tt_model_runners.z_image_turbo_runner",
+        fromlist=["ZImageTurboRunner"],
+    ).ZImageTurboRunner(wid),
 }
 
 

--- a/tt-media-server/tt_model_runners/z_image_turbo_runner.py
+++ b/tt-media-server/tt_model_runners/z_image_turbo_runner.py
@@ -20,8 +20,9 @@ from utils.decorators import log_execution_time
 # Fetched via: bash scripts/fetch_z_image_turbo.sh
 _ZIT_DEMO_DIR = os.environ.get(
     "Z_IMAGE_TURBO_MODEL_DIR",
-    os.path.join(os.path.dirname(__file__), "..", "models", "z_image_turbo_repo",
-                 "z_image_turbo"),
+    os.path.join(
+        os.path.dirname(__file__), "..", "models", "z_image_turbo_repo", "z_image_turbo"
+    ),
 )
 
 MODEL_ID = "Tongyi-MAI/Z-Image-Turbo"
@@ -84,8 +85,12 @@ def _copy_to_persistent(host_pt, persistent_tt, dtype=ttnn.DataType.BFLOAT16):
 
 
 def _compute_mu(
-    h=IMG_LATENT_H, w=IMG_LATENT_W,
-    base_seq=256, max_seq=4096, base_shift=0.5, max_shift=1.15,
+    h=IMG_LATENT_H,
+    w=IMG_LATENT_W,
+    base_seq=256,
+    max_seq=4096,
+    base_shift=0.5,
+    max_shift=1.15,
 ):
     seq = (h // 2) * (w // 2)
     m = (max_shift - base_shift) / (max_seq - base_seq)
@@ -158,15 +163,23 @@ class ZImageTurboRunner(BaseMetalDeviceRunner):
         messages = [{"role": "user", "content": prompt}]
         try:
             formatted = self.tokenizer.apply_chat_template(
-                messages, tokenize=False, add_generation_prompt=True, enable_thinking=True,
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+                enable_thinking=True,
             )
         except TypeError:
             formatted = self.tokenizer.apply_chat_template(
-                messages, tokenize=False, add_generation_prompt=True,
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
             )
         input_ids = self.tokenizer(
-            formatted, padding="max_length", truncation=True,
-            max_length=CAP_TOKENS, return_tensors="pt",
+            formatted,
+            padding="max_length",
+            truncation=True,
+            max_length=CAP_TOKENS,
+            return_tensors="pt",
         )["input_ids"]
 
         tt_ids = _to_device_int32(input_ids, mesh)
@@ -241,11 +254,15 @@ class ZImageTurboRunner(BaseMetalDeviceRunner):
         )
 
         self.logger.info(f"Device {self.device_id}: Running warmup generation ...")
-        self.run([ImageGenerateRequest.model_construct(
-            prompt="a cat sitting on a mat",
-            num_inference_steps=DEFAULT_STEPS,
-            seed=42,
-        )])
+        self.run(
+            [
+                ImageGenerateRequest.model_construct(
+                    prompt="a cat sitting on a mat",
+                    num_inference_steps=DEFAULT_STEPS,
+                    seed=42,
+                )
+            ]
+        )
 
         self.logger.info(f"Device {self.device_id}: Z-Image-Turbo warmup complete")
         return True

--- a/tt-media-server/tt_model_runners/z_image_turbo_runner.py
+++ b/tt-media-server/tt_model_runners/z_image_turbo_runner.py
@@ -16,10 +16,12 @@ from tt_model_runners.base_metal_device_runner import BaseMetalDeviceRunner
 from telemetry.telemetry_client import TelemetryEvent
 from utils.decorators import log_execution_time
 
-# Path to the Z-Image-Turbo TTNN model implementations in tt-xla.
-_ZIT_DEMO_DIR = os.path.join(
-    os.environ.get("TT_XLA_HOME", "/localdev/svuckovic/_workspace/repos/tt-xla"),
-    "z_image_turbo/proper_tp/demo",
+# Path to the Z-Image-Turbo TTNN model implementations.
+# Fetched via: bash scripts/fetch_z_image_turbo.sh
+_ZIT_DEMO_DIR = os.environ.get(
+    "Z_IMAGE_TURBO_MODEL_DIR",
+    os.path.join(os.path.dirname(__file__), "..", "models", "z_image_turbo_repo",
+                 "z_image_turbo"),
 )
 
 MODEL_ID = "Tongyi-MAI/Z-Image-Turbo"
@@ -117,7 +119,7 @@ class ZImageTurboRunner(BaseMetalDeviceRunner):
     def get_pipeline_device_params(self):
         return {
             "l1_small_size": 1 << 15,
-            "trace_region_size": 50_000_000,
+            "trace_region_size": 60_000_000,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
         }
 

--- a/tt-media-server/tt_model_runners/z_image_turbo_runner.py
+++ b/tt-media-server/tt_model_runners/z_image_turbo_runner.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
 import asyncio
 import copy

--- a/tt-media-server/tt_model_runners/z_image_turbo_runner.py
+++ b/tt-media-server/tt_model_runners/z_image_turbo_runner.py
@@ -29,7 +29,7 @@ CAP_TOKENS = 128
 IMG_LATENT_H = 64
 IMG_LATENT_W = 64
 LATENT_CHANNELS = 16
-DEFAULT_STEPS = 9
+DEFAULT_STEPS = 9  # Runs N-1 DiT steps (8)
 
 DRAM_RM = ttnn.MemoryConfig(
     ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None

--- a/tt-media-server/tt_model_runners/z_image_turbo_runner.py
+++ b/tt-media-server/tt_model_runners/z_image_turbo_runner.py
@@ -1,0 +1,300 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+import asyncio
+import copy
+import gc
+import os
+import sys
+import time
+
+import torch
+import ttnn
+from domain.image_generate_request import ImageGenerateRequest
+from tt_model_runners.base_metal_device_runner import BaseMetalDeviceRunner
+from telemetry.telemetry_client import TelemetryEvent
+from utils.decorators import log_execution_time
+
+# Path to the Z-Image-Turbo TTNN model implementations in tt-xla.
+_ZIT_DEMO_DIR = os.path.join(
+    os.environ.get("TT_XLA_HOME", "/localdev/svuckovic/_workspace/repos/tt-xla"),
+    "z_image_turbo/proper_tp/demo",
+)
+
+MODEL_ID = "Tongyi-MAI/Z-Image-Turbo"
+CAP_TOKENS = 128
+IMG_LATENT_H = 64
+IMG_LATENT_W = 64
+LATENT_CHANNELS = 16
+DEFAULT_STEPS = 9
+
+DRAM_RM = ttnn.MemoryConfig(
+    ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None
+)
+
+WARMUP_TIMEOUT_SECONDS = 6000
+
+
+def _ensure_zit_imports():
+    if _ZIT_DEMO_DIR not in sys.path:
+        sys.path.insert(0, _ZIT_DEMO_DIR)
+
+
+def _to_device_int32(pt, mesh_device):
+    return ttnn.from_torch(
+        pt.to(torch.int32),
+        dtype=ttnn.DataType.INT32,
+        layout=ttnn.Layout.ROW_MAJOR,
+        device=mesh_device,
+        memory_config=DRAM_RM,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+
+def _to_device_bf16(pt, mesh_device):
+    return ttnn.from_torch(
+        pt.bfloat16(),
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.Layout.ROW_MAJOR,
+        device=mesh_device,
+        memory_config=DRAM_RM,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+
+def _tt_to_torch(tt_tensor, mesh_device):
+    host = ttnn.to_torch(
+        ttnn.from_device(tt_tensor),
+        mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0),
+    )
+    return host[: host.shape[0] // 4].float()
+
+
+def _copy_to_persistent(host_pt, persistent_tt, dtype=ttnn.DataType.BFLOAT16):
+    host_tt = ttnn.from_torch(
+        host_pt.bfloat16() if dtype == ttnn.DataType.BFLOAT16 else host_pt,
+        dtype=dtype,
+        layout=ttnn.Layout.ROW_MAJOR,
+    )
+    for shard in ttnn.get_device_tensors(persistent_tt):
+        ttnn.copy_host_to_device_tensor(host_tt, shard, cq_id=0)
+
+
+def _compute_mu(
+    h=IMG_LATENT_H, w=IMG_LATENT_W,
+    base_seq=256, max_seq=4096, base_shift=0.5, max_shift=1.15,
+):
+    seq = (h // 2) * (w // 2)
+    m = (max_shift - base_shift) / (max_seq - base_seq)
+    return seq * m + (base_shift - m * base_seq)
+
+
+def _make_scheduler(template, steps):
+    scheduler = copy.deepcopy(template)
+    mu = _compute_mu()
+    try:
+        scheduler.set_timesteps(steps, mu=mu)
+    except TypeError:
+        scheduler.set_timesteps(steps)
+    return scheduler
+
+
+class ZImageTurboRunner(BaseMetalDeviceRunner):
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self.te = None
+        self.tr = None
+        self.vae = None
+        self.tokenizer = None
+        self.vae_processor = None
+        self.scheduler_template = None
+        self._trace_id = None
+        self._lat_buf = None
+        self._ts_buf = None
+        self._output_ref = None
+
+    def get_pipeline_device_params(self):
+        return {
+            "l1_small_size": 1 << 15,
+            "trace_region_size": 50_000_000,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        }
+
+    def _configure_fabric(self, updated_device_params):
+        fabric_config = updated_device_params.pop(
+            "fabric_config", ttnn.FabricConfig.FABRIC_1D
+        )
+        ttnn.set_fabric_config(fabric_config)
+        return fabric_config
+
+    def _load_models(self):
+        _ensure_zit_imports()
+        from text_encoder.model_ttnn import TextEncoderTTNN
+        from dit.model_ttnn import ZImageTransformerTTNN
+        from vae.model_ttnn import VaeDecoderTTNN
+        from diffusers.image_processor import VaeImageProcessor
+        from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+        from transformers import AutoTokenizer
+
+        mesh = self.ttnn_device
+        mesh.enable_program_cache()
+
+        self.tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, subfolder="tokenizer")
+        self.vae_processor = VaeImageProcessor(vae_scale_factor=16)
+        self.scheduler_template = FlowMatchEulerDiscreteScheduler.from_pretrained(
+            MODEL_ID, subfolder="scheduler"
+        )
+        self.scheduler_template.sigma_min = 0.0
+
+        self.te = TextEncoderTTNN(mesh)
+        self.tr = ZImageTransformerTTNN(mesh)
+        self.vae = VaeDecoderTTNN(mesh)
+
+    def _encode_prompt(self, prompt):
+        mesh = self.ttnn_device
+        messages = [{"role": "user", "content": prompt}]
+        try:
+            formatted = self.tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True, enable_thinking=True,
+            )
+        except TypeError:
+            formatted = self.tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True,
+            )
+        input_ids = self.tokenizer(
+            formatted, padding="max_length", truncation=True,
+            max_length=CAP_TOKENS, return_tensors="pt",
+        )["input_ids"]
+
+        tt_ids = _to_device_int32(input_ids, mesh)
+        tt_out = self.te(tt_ids)
+        cap_cpu = _tt_to_torch(tt_out, mesh)[:CAP_TOKENS].bfloat16()
+        ttnn.deallocate(tt_ids, force=True)
+        ttnn.deallocate(tt_out, force=True)
+        return cap_cpu.unsqueeze(0)
+
+    def _decode_latents(self, latents):
+        image_tensor = self.vae(latents)
+        gc.collect()
+        return self.vae_processor.postprocess(image_tensor, output_type="pil")[0]
+
+    def _capture_trace(self):
+        mesh = self.ttnn_device
+        steps = DEFAULT_STEPS
+
+        # Phase 1: Compile ALL programs before trace capture.
+        self.logger.info(f"Device {self.device_id}: Compiling TE ...")
+        cap_cpu = self._encode_prompt("a cat sitting on a mat")
+
+        self.logger.info(f"Device {self.device_id}: Compiling DIT ...")
+        self.tr.set_cap_feats(cap_cpu)
+        torch.manual_seed(42)
+        latents = torch.randn(1, LATENT_CHANNELS, IMG_LATENT_H, IMG_LATENT_W)
+        scheduler = _make_scheduler(self.scheduler_template, steps)
+
+        t0_step = scheduler.timesteps[0]
+        t_norm_0 = max((1000.0 - float(t0_step)) / 1000.0, 1e-3)
+        lat_pt = latents.squeeze(0).unsqueeze(1).bfloat16()
+        ts_pt = torch.tensor([t_norm_0], dtype=torch.bfloat16)
+
+        self._lat_buf = _to_device_bf16(lat_pt, mesh)
+        self._ts_buf = _to_device_bf16(ts_pt, mesh)
+
+        compile_out = self.tr._forward_impl([self._lat_buf], self._ts_buf)
+        dit_out_cpu = _tt_to_torch(compile_out[0], mesh)
+        dit_out_cpu = dit_out_cpu.squeeze(1).unsqueeze(0).bfloat16()
+        compile_latents = scheduler.step(
+            -dit_out_cpu.float(), scheduler.timesteps[0], latents, return_dict=False
+        )[0]
+        for t in compile_out:
+            ttnn.deallocate(t, force=True)
+
+        self.logger.info(f"Device {self.device_id}: Compiling VAE ...")
+        self._decode_latents(compile_latents)
+
+        # Phase 2: Capture DIT trace.
+        self.logger.info(f"Device {self.device_id}: Capturing DIT trace ...")
+        self._trace_id = ttnn.begin_trace_capture(mesh, cq_id=0)
+        trace_out = self.tr._forward_impl([self._lat_buf], self._ts_buf)
+        ttnn.end_trace_capture(mesh, self._trace_id, cq_id=0)
+        self._output_ref = trace_out[0]
+        self.logger.info(f"Device {self.device_id}: DIT trace captured")
+
+    @log_execution_time(
+        "Z-Image-Turbo warmup",
+        TelemetryEvent.DEVICE_WARMUP,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    async def warmup(self) -> bool:
+        self.logger.info(f"Device {self.device_id}: Loading Z-Image-Turbo ...")
+
+        def load_and_trace():
+            self._load_models()
+            self._capture_trace()
+
+        await asyncio.wait_for(
+            asyncio.to_thread(load_and_trace),
+            timeout=WARMUP_TIMEOUT_SECONDS,
+        )
+
+        self.logger.info(f"Device {self.device_id}: Running warmup generation ...")
+        self.run([ImageGenerateRequest.model_construct(
+            prompt="a cat sitting on a mat",
+            num_inference_steps=DEFAULT_STEPS,
+            seed=42,
+        )])
+
+        self.logger.info(f"Device {self.device_id}: Z-Image-Turbo warmup complete")
+        return True
+
+    @log_execution_time(
+        "Z-Image-Turbo inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    def run(self, requests: list[ImageGenerateRequest]):
+        request = requests[0]
+        mesh = self.ttnn_device
+        steps = DEFAULT_STEPS
+        seed = int(request.seed or 0)
+
+        torch.manual_seed(seed)
+        t_start = time.time()
+
+        t0 = time.time()
+        cap_cpu = self._encode_prompt(request.prompt)
+        _copy_to_persistent(cap_cpu, self.tr._cap_feats_buf)
+        te_ms = (time.time() - t0) * 1000
+
+        latents = torch.randn(1, LATENT_CHANNELS, IMG_LATENT_H, IMG_LATENT_W)
+        scheduler = _make_scheduler(self.scheduler_template, steps)
+        active_timesteps = scheduler.timesteps[:-1]
+
+        t0 = time.time()
+        for t in active_timesteps:
+            t_norm = max((1000.0 - float(t)) / 1000.0, 1e-3)
+            lat_pt = latents.squeeze(0).unsqueeze(1).bfloat16()
+            ts_pt = torch.tensor([t_norm], dtype=torch.bfloat16)
+
+            _copy_to_persistent(lat_pt, self._lat_buf)
+            _copy_to_persistent(ts_pt, self._ts_buf)
+
+            ttnn.execute_trace(mesh, self._trace_id, cq_id=0, blocking=True)
+
+            out = _tt_to_torch(self._output_ref, mesh)
+            out = out.squeeze(1).unsqueeze(0).bfloat16()
+            latents = scheduler.step(-out.float(), t, latents, return_dict=False)[0]
+        dit_ms = (time.time() - t0) * 1000
+
+        t0 = time.time()
+        image = self._decode_latents(latents)
+        vae_ms = (time.time() - t0) * 1000
+
+        elapsed = time.time() - t_start
+        self.logger.info(
+            f"Device {self.device_id}: Generated in {elapsed:.2f}s  "
+            f"TE={te_ms:.0f}ms  DIT={dit_ms:.0f}ms ({len(active_timesteps)} steps)  "
+            f"VAE={vae_ms:.0f}ms  seed={seed}"
+        )
+        return [image]


### PR DESCRIPTION
Add Z-Image-Turbo model support. Pure Python TTNN impl.

```
# Activate metal's python venv
# ...

# Upgrade the transformers lib, current one doesn't contain Z-Image-Turbo in diffusers
uv pip install --upgrade transformers

cd tt-media-server

# Fetch the model code + tt_dit lib, using sparse checkout from tt-metal repo
bash scripts/fetch_z_image_turbo.sh

# Run server locally on BH QB AE
MODEL=Z-Image-Turbo DEVICE=p150x4 uvicorn main:app --host 0.0.0.0 --port 8000
```

Landing page: http://localhost:8000/static/z-image-turbo/index.html

<img width="679" height="839" alt="image" src="https://github.com/user-attachments/assets/a94d24de-afc3-47fe-9990-a252702ebedd" />
