### PR TITLE
Fix forge deployment stuck in provisioning

### DIFF
--- a/tt-media-server/Dockerfile.forge
+++ b/tt-media-server/Dockerfile.forge
@@ -116,6 +116,7 @@ RUN /bin/bash -c "cd ${APP_DIR}/server && source tt_model_runners/forge_runners/
     && chown -R ${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} ${HOME_DIR}
 USER ${CONTAINER_APP_USERNAME}
 ENV TT_METAL_HOME="${APP_DIR}/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal"
+ENV PYTHON_ENV_DIR="${APP_DIR}/server/venv-worker"
 
 # spinup inference server
 WORKDIR "${APP_DIR}"

--- a/tt-media-server/run_uvicorn.sh
+++ b/tt-media-server/run_uvicorn.sh
@@ -6,11 +6,6 @@
 set -eo pipefail
 
 if [ "$1" != "--skip-venv" ]; then
-    if [ -z "${TT_METAL_HOME}" ]; then
-        echo "Error: TT_METAL_HOME is not set" >&2
-        exit 1
-    fi
-    # shellcheck disable=SC1091
     source "${TT_METAL_HOME}/python_env/bin/activate"
 fi
 

--- a/tt-media-server/run_uvicorn.sh
+++ b/tt-media-server/run_uvicorn.sh
@@ -9,4 +9,4 @@ if [ "$1" != "--skip-venv" ]; then
     source "${TT_METAL_HOME}/python_env/bin/activate"
 fi
 
-exec uvicorn --host 0.0.0.0 main:app --lifespan on --port "${SERVICE_PORT:-8000}"
+uvicorn --host 0.0.0.0 main:app --lifespan on --port "${SERVICE_PORT:-8000}"

--- a/tt-media-server/run_uvicorn.sh
+++ b/tt-media-server/run_uvicorn.sh
@@ -1,12 +1,17 @@
+#!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
-#!/bin/bash
 set -eo pipefail
 
 if [ "$1" != "--skip-venv" ]; then
+    if [ -z "${TT_METAL_HOME}" ]; then
+        echo "Error: TT_METAL_HOME is not set" >&2
+        exit 1
+    fi
+    # shellcheck disable=SC1091
     source "${TT_METAL_HOME}/python_env/bin/activate"
 fi
 
-uvicorn --host 0.0.0.0 main:app --lifespan on --port "${SERVICE_PORT:-8000}"
+exec uvicorn --host 0.0.0.0 main:app --lifespan on --port "${SERVICE_PORT:-8000}"


### PR DESCRIPTION
## Summary

Fixes forge model deployments (e.g. resnet-50) getting stuck in provisioning due to container crash-looping.

**Root causes:**

1. **Shebang on wrong line in `run_uvicorn.sh`** — `#!/bin/bash` was on line 5 (after license headers) instead of line 1. When executed directly, the kernel falls back to `/bin/sh` which doesn't recognize `set -eo pipefail` and doesn't have the correct venv on PATH.

2. **Missing `PYTHON_ENV_DIR` in `Dockerfile.forge`** — The forge image builds its own `venv-worker` (via `setup_env.sh`) with uvicorn and forge dependencies, but never exposed its path as `PYTHON_ENV_DIR`. The deployment system was falling back to the base metalium image's `python_env`, which doesn't contain uvicorn or the inference server dependencies.

### Changes

- **`tt-media-server/run_uvicorn.sh`**: Move shebang to line 1
- **`tt-media-server/Dockerfile.forge`**: Add `PYTHON_ENV_DIR` pointing to `${APP_DIR}/server/venv-worker`

Fixes tenstorrent/tt-cloud-console#330

## Test plan

- [ ] Build forge Docker image and verify container starts without crash-looping
- [ ] Verify deployment override using `$PYTHON_ENV_DIR/bin/activate` activates the correct venv with uvicorn available
- [ ] Verify `/health` and `/tt-liveness` endpoints return 200 on a running forge deployment