### PR TITLE
Add GuideLLM as an opt-in Benchmarking Tool

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -8,7 +8,7 @@ See [Model Readiness Workflows User Guide](../docs/workflows_user_guide.md#perfo
 
 ## Benchmarking Tools
 
-The tt-inference-server supports three benchmarking tools:
+The tt-inference-server supports four benchmarking tools:
 
 
 ### vLLM (default) - server-side measurements
@@ -26,7 +26,12 @@ python run.py --model <model> --device <device> --workflow benchmarks --docker-s
 python run.py --model <model> --device <device> --workflow benchmarks --docker-server --tools aiperf
 ```
 
-**Key differences:** vLLM provides baseline metrics, GenAI-Perf validates against NVIDIA Triton standards, and AIPerf adds detailed latency percentiles for performance analysis.
+### GuideLLM - dataset-driven multi-turn and omni-modal benchmarking
+```
+python run.py --model <model> --device <device> --workflow benchmarks --docker-server --tools guidellm
+```
+
+**Key differences:** vLLM provides baseline metrics, GenAI-Perf validates against NVIDIA Triton standards, AIPerf adds detailed latency percentiles, and GuideLLM enables dataset-driven multi-turn/custom/omni-modal scenarios.
 
 For detailed comparison, TTFT measurement differences, and usage guide, see [Benchmarking Tools Guide](../docs/benchmarking_tools.md).
 
@@ -41,6 +46,10 @@ Purpose: Docker orchestration script for GenAI-Perf benchmarks using NVIDIA Trit
 ### `run_benchmarks_aiperf.py`
 
 Purpose: Main script for AIPerf benchmarks with detailed percentile metrics and warm-up logic.
+
+### `run_guidellm_benchmarks.py`
+
+Purpose: Main script for GuideLLM scenarios including multi-turn chat, custom datasets, and omni-modal workloads (text/image/video/audio).
 
 #### Workflow
 

--- a/benchmarking/guidellm_report.py
+++ b/benchmarking/guidellm_report.py
@@ -1,0 +1,632 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Encapsulated GuideLLM report generation.
+
+This module owns ALL GuideLLM-specific report logic so that
+`workflows/run_reports.py` only has to call a single entry point. When
+`run_reports.py` is refactored, the only thing the new orchestrator needs to
+do for GuideLLM is call `generate_guidellm_report(args, model_spec, report_id,
+metadata)` and consume the returned `(release_str, release_data, disp_md_path,
+data_file_path)` tuple — identical contract to the AIPerf / GenAI-Perf /
+vLLM helpers it already calls.
+
+Two data sources are used, chosen for what each is best at:
+
+1. The normalized `guidellm_benchmark_<model_id>_*_sweep-K.json` files in
+   `benchmarks_output/` — produced by
+   `benchmarking/run_guidellm_benchmarks.py::emit_normalized_guidellm_result`.
+   These are used to populate the AIPerf-compatible "Detailed Percentiles"
+   summary table and to discover which scenarios were executed.
+2. The native GuideLLM `benchmarks.json` files (referenced by the
+   `source_benchmarks_json` field of every normalized file). These are used
+   to render the five GuideLLM-native tables (Run Summary, Text Metrics,
+   Request Token Stats, Request Latency Stats, Server Throughput Stats) so
+   the report mirrors what GuideLLM prints to the console at the end of a
+   run, with one row per benchmark/sweep point.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import re
+from collections import OrderedDict
+from glob import glob
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------- #
+# Public entry point
+# --------------------------------------------------------------------------- #
+
+ReportTuple = Tuple[str, List[Dict[str, Any]], Optional[Path], Optional[Path]]
+
+
+def generate_guidellm_report(
+    args: Any,
+    model_spec: Any,
+    report_id: str,
+    metadata: Optional[Dict[str, Any]] = None,
+    benchmarks_output_dir: Optional[Path] = None,
+) -> ReportTuple:
+    """Generate the GuideLLM section of a benchmark report.
+
+    Returns the same `(release_str, release_data, disp_md_path, data_file_path)`
+    contract as the existing `aiperf_benchmark_generate_report` and
+    `genai_perf_benchmark_generate_report` helpers in
+    `workflows/run_reports.py`, so it is drop-in compatible with the current
+    orchestrator and any future refactor of it.
+    """
+    metadata = metadata or {}
+
+    if benchmarks_output_dir is None:
+        # Default: same directory all benchmark tools write to. Resolved
+        # lazily so this module does not import workflows.* eagerly.
+        from workflows.utils import get_default_workflow_root_log_dir
+
+        benchmarks_output_dir = Path(
+            f"{get_default_workflow_root_log_dir()}/benchmarks_output"
+        )
+
+    output_dir = Path(args.output_path) / "benchmarks_guidellm"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    normalized_files = _discover_normalized_files(
+        benchmarks_output_dir, model_spec.model_id
+    )
+    logger.info(
+        f"GuideLLM Benchmark Summary — found {len(normalized_files)} "
+        f"normalized result file(s) for model_id={model_spec.model_id}"
+    )
+    if not normalized_files:
+        logger.info("No GuideLLM benchmark files found. Skipping GuideLLM report.")
+        return "", [], None, None
+
+    # Deduplicate by (isl, osl, maxcon, n[, images, h, w], sweep_index) so
+    # GuideLLM sweep points sharing a base config are preserved end-to-end.
+    normalized_files = _deduplicate_by_config(normalized_files)
+    text_files = [f for f in normalized_files if "_images-" not in Path(f).name]
+    vlm_files = [f for f in normalized_files if "_images-" in Path(f).name]
+
+    text_results = sorted(
+        (_load_normalized_text(f) for f in text_files),
+        key=lambda r: (r["isl"], r["osl"], r["concurrency"]),
+    )
+    vlm_results = sorted(
+        filter(None, (_load_normalized_vlm(f) for f in vlm_files)),
+        key=lambda r: (
+            r["isl"],
+            r["osl"],
+            r["concurrency"],
+            r["image_height"],
+            r["image_width"],
+        ),
+    )
+
+    if not text_results and not vlm_results:
+        return "", [], None, None
+
+    sections: List[str] = [
+        f"### Benchmark Performance Results for {model_spec.model_name} on {args.device}\n"
+    ]
+
+    # ---- Detailed percentile summary tables (AIPerf-compatible style) ----
+    if text_results:
+        sections.append("#### GuideLLM Text Benchmarks - Detailed Percentiles\n")
+        sections.append(
+            "**Benchmarking Tool:** [GuideLLM](https://github.com/vllm-project/guidellm)\n"
+        )
+        sections.append(_render_percentile_table(text_results, vlm=False))
+    if vlm_results:
+        sections.append("#### GuideLLM VLM Benchmarks - Detailed Percentiles\n")
+        sections.append(
+            "**Benchmarking Tool:** [GuideLLM](https://github.com/vllm-project/guidellm)\n"
+        )
+        sections.append(_render_percentile_table(vlm_results, vlm=True))
+
+    sections.append(_metric_definitions_block())
+
+    # ---- Native GuideLLM-style tables (one block per source benchmarks.json) ----
+    native_blocks = _render_native_tables(text_results + vlm_results)
+    if native_blocks:
+        sections.append("#### GuideLLM Run Details (native tables)\n")
+        sections.append(
+            "Tables below mirror the summary GuideLLM prints to the console at "
+            "the end of each run, with one row per sweep point.\n"
+        )
+        sections.extend(native_blocks)
+
+    release_str = "\n\n".join(s for s in sections if s).strip() + "\n"
+
+    # ---- Persist markdown and CSV artifacts ----
+    disp_md_path = output_dir / f"guidellm_benchmark_display_{report_id}.md"
+    disp_md_path.write_text(release_str, encoding="utf-8")
+    logger.info(f"GuideLLM report saved to: {disp_md_path}")
+
+    data_dir = output_dir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    text_data_file_path = data_dir / f"guidellm_benchmark_text_stats_{report_id}.csv"
+    vlm_data_file_path = data_dir / f"guidellm_benchmark_vlm_stats_{report_id}.csv"
+
+    if text_results:
+        _write_csv(text_data_file_path, text_results)
+        logger.info(f"GuideLLM text CSV saved to: {text_data_file_path}")
+    if vlm_results:
+        _write_csv(vlm_data_file_path, vlm_results)
+        logger.info(f"GuideLLM VLM CSV saved to: {vlm_data_file_path}")
+
+    return (
+        release_str,
+        text_results + vlm_results,
+        disp_md_path,
+        text_data_file_path if text_results else None,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Discovery + per-row loading from the normalized files
+# --------------------------------------------------------------------------- #
+
+
+def _discover_normalized_files(
+    benchmarks_output_dir: Path, model_id: str
+) -> List[str]:
+    pattern = f"guidellm_benchmark_{model_id}_*.json"
+    return glob(f"{benchmarks_output_dir}/{pattern}")
+
+
+def _deduplicate_by_config(files: List[str]) -> List[str]:
+    """Latest file wins for each unique config; sweep_index is part of the key
+    so GuideLLM sweep points sharing (isl, osl, maxcon, n) are preserved."""
+    config_to_file: Dict[Tuple[Any, ...], str] = {}
+    for filepath in sorted(files, reverse=True):
+        filename = Path(filepath).name
+        m = re.search(r"isl-(\d+)_osl-(\d+)_maxcon-(\d+)_n-(\d+)", filename)
+        if not m:
+            config_to_file[(filepath,)] = filepath
+            continue
+        isl, osl, con, n = map(int, m.groups())
+        img_match = re.search(r"images-(\d+)_height-(\d+)_width-(\d+)", filename)
+        sweep_match = re.search(r"_sweep-(\d+)", filename)
+        sweep_idx = int(sweep_match.group(1)) if sweep_match else None
+        if img_match:
+            images, height, width = map(int, img_match.groups())
+            key = (isl, osl, con, n, images, height, width, sweep_idx)
+        else:
+            key = (isl, osl, con, n, 0, 0, 0, sweep_idx)
+        if key not in config_to_file:
+            config_to_file[key] = filepath
+    return list(config_to_file.values())
+
+
+def _load_normalized_text(filepath: str) -> Dict[str, Any]:
+    with open(filepath, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    filename = Path(filepath).name
+    m = re.search(r"isl-(\d+)_osl-(\d+)_maxcon-(\d+)_n-(\d+)", filename)
+    if m:
+        isl, osl, concurrency, num_requests = map(int, m.groups())
+    else:
+        isl = data.get("total_input_tokens", 0) // max(data.get("num_prompts", 1), 1)
+        osl = data.get("total_output_tokens", 0) // max(data.get("num_prompts", 1), 1)
+        concurrency = data.get("max_concurrency", 1)
+        num_requests = data.get("num_prompts", 0)
+
+    sweep_match = re.search(r"_sweep-(\d+)", filename)
+    return {
+        "source": "guidellm",
+        "scenario": data.get("scenario", ""),
+        "sweep_index": int(sweep_match.group(1)) if sweep_match else None,
+        "strategy_type": data.get("strategy_type"),
+        "strategy_rate": data.get("strategy_rate"),
+        "isl": isl,
+        "osl": osl,
+        "concurrency": concurrency,
+        "num_requests": num_requests,
+        # Latency
+        "mean_ttft_ms": data.get("mean_ttft_ms", 0),
+        "median_ttft_ms": data.get("median_ttft_ms", 0),
+        "p99_ttft_ms": data.get("p99_ttft_ms", 0),
+        "std_ttft_ms": data.get("std_ttft_ms", 0),
+        "mean_tpot_ms": data.get("mean_tpot_ms", 0),
+        "median_tpot_ms": data.get("median_tpot_ms", 0),
+        "p99_tpot_ms": data.get("p99_tpot_ms", 0),
+        "std_tpot_ms": data.get("std_tpot_ms", 0),
+        "mean_e2el_ms": data.get("mean_e2el_ms", 0),
+        "median_e2el_ms": data.get("median_e2el_ms", 0),
+        "p99_e2el_ms": data.get("p99_e2el_ms", 0),
+        "std_e2el_ms": data.get("std_e2el_ms", 0),
+        # Throughput
+        "output_token_throughput": data.get("output_token_throughput", 0),
+        "total_token_throughput": data.get("total_token_throughput", 0),
+        "request_throughput": data.get("request_throughput", 0),
+        # Volume
+        "completed": data.get("completed", 0),
+        "total_input_tokens": data.get("total_input_tokens", 0),
+        "total_output_tokens": data.get("total_output_tokens", 0),
+        "model_id": data.get("model_id", ""),
+        "backend": "guidellm",
+        # Source pointer used by the native-table renderer
+        "source_benchmarks_json": data.get("source_benchmarks_json", ""),
+    }
+
+
+def _load_normalized_vlm(filepath: str) -> Optional[Dict[str, Any]]:
+    filename = Path(filepath).name
+    m = re.search(
+        r"isl-(\d+)_osl-(\d+)_maxcon-(\d+)_n-(\d+)_images-(\d+)_height-(\d+)_width-(\d+)",
+        filename,
+    )
+    if not m:
+        logger.warning(f"Could not parse image params from GuideLLM file: {filename}")
+        return None
+    isl, osl, concurrency, num_requests, images, height, width = map(int, m.groups())
+    row = _load_normalized_text(filepath)
+    row.update(
+        {
+            "task_type": "vlm",
+            "isl": isl,
+            "osl": osl,
+            "concurrency": concurrency,
+            "max_con": concurrency,
+            "num_requests": num_requests,
+            "images": images,
+            "image_height": height,
+            "image_width": width,
+            "images_per_prompt": images,
+        }
+    )
+    return row
+
+
+# --------------------------------------------------------------------------- #
+# Detailed percentiles table (AIPerf-style; flat, easy to consume downstream)
+# --------------------------------------------------------------------------- #
+
+
+def _render_percentile_table(rows: List[Dict[str, Any]], vlm: bool) -> str:
+    """Render the AIPerf-style detailed percentiles markdown table."""
+    from benchmarking.summary_report import get_markdown_table
+
+    cols: List[Tuple[str, str]] = [
+        ("isl", "ISL"),
+        ("osl", "OSL"),
+        ("concurrency", "Concur"),
+    ]
+    if vlm:
+        cols.extend(
+            [
+                ("image_height", "Image Height"),
+                ("image_width", "Image Width"),
+                ("images_per_prompt", "Images per Prompt"),
+            ]
+        )
+    cols.extend(
+        [
+            ("num_requests", "N"),
+            ("mean_ttft_ms", "TTFT Avg (ms)"),
+            ("median_ttft_ms", "TTFT P50 (ms)"),
+            ("p99_ttft_ms", "TTFT P99 (ms)"),
+            ("mean_tpot_ms", "TPOT Avg (ms)"),
+            ("median_tpot_ms", "TPOT P50 (ms)"),
+            ("p99_tpot_ms", "TPOT P99 (ms)"),
+            ("mean_e2el_ms", "E2EL Avg (ms)"),
+            ("median_e2el_ms", "E2EL P50 (ms)"),
+            ("p99_e2el_ms", "E2EL P99 (ms)"),
+            ("output_token_throughput", "Output Tok/s"),
+            ("total_token_throughput", "Total Tok/s"),
+            ("request_throughput", "Req/s"),
+        ]
+    )
+
+    NA = "N/A"
+    display: List[Dict[str, str]] = []
+    for row in rows:
+        d: Dict[str, str] = {}
+        for key, header in cols:
+            v = row.get(key, NA)
+            if v is None or v == "":
+                d[header] = NA
+            elif isinstance(v, float):
+                if key == "request_throughput":
+                    d[header] = f"{v:.4f}"
+                elif key in ("output_token_throughput", "total_token_throughput"):
+                    d[header] = f"{v:.2f}"
+                else:
+                    d[header] = f"{v:.1f}"
+            else:
+                d[header] = str(v)
+        display.append(d)
+    return get_markdown_table(display) + "\n"
+
+
+def _metric_definitions_block() -> str:
+    return (
+        "**Metric Definitions:**\n"
+        "> - **ISL**: Input Sequence Length (tokens)\n"
+        "> - **OSL**: Output Sequence Length (tokens)\n"
+        "> - **Concur**: Concurrent requests (batch size)\n"
+        "> - **N**: Total number of requests\n"
+        "> - **TTFT Avg/P50/P99**: Time To First Token - Average, Median, 99th percentile (ms)\n"
+        "> - **TPOT Avg/P50/P99**: Time Per Output Token - Average, Median, 99th percentile (ms)\n"
+        "> - **E2EL Avg/P50/P99**: End-to-End Latency - Average, Median, 99th percentile (ms)\n"
+        "> - **Output Tok/s**: Output token throughput\n"
+        "> - **Total Tok/s**: Total token throughput (input + output tokens)\n"
+        "> - **Req/s**: Request throughput\n"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Native GuideLLM-style tables, sourced directly from benchmarks.json
+# --------------------------------------------------------------------------- #
+
+
+def _render_native_tables(rows: List[Dict[str, Any]]) -> List[str]:
+    """For every unique source `benchmarks.json` referenced by the normalized
+    rows, emit the same five tables GuideLLM prints to the console at the end
+    of a run (Run Summary, Text Metrics, Request Tokens, Request Latency,
+    Server Throughput) — each with one markdown row per benchmark/sweep point.
+    """
+    from benchmarking.summary_report import get_markdown_table
+
+    # Preserve insertion order so scenarios appear in a stable sequence
+    sources: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
+    for row in rows:
+        src = row.get("source_benchmarks_json")
+        if not src:
+            continue
+        meta = sources.setdefault(
+            src,
+            {"scenario": row.get("scenario") or "", "sweep_indexes": []},
+        )
+        if row.get("sweep_index") is not None:
+            meta["sweep_indexes"].append(row["sweep_index"])
+
+    blocks: List[str] = []
+    for source_path, meta in sources.items():
+        if not Path(source_path).is_file():
+            logger.warning(
+                f"GuideLLM source benchmarks.json not found, skipping native "
+                f"tables for: {source_path}"
+            )
+            continue
+        try:
+            with open(source_path, "r", encoding="utf-8") as fh:
+                source_data = json.load(fh)
+        except Exception as exc:
+            logger.warning(
+                f"Failed to read GuideLLM benchmarks.json '{source_path}': {exc}"
+            )
+            continue
+
+        benches = source_data.get("benchmarks") or []
+        if not benches:
+            continue
+
+        scenario = meta["scenario"] or Path(source_path).parent.name
+        block = [
+            f"##### GuideLLM Run Details — `{scenario}`",
+            f"**Source:** `{source_path}`",
+            "",
+            "###### Run Summary",
+            get_markdown_table(_table_run_summary(benches)) + "\n",
+            "###### Text Metrics (Completed Requests) — Input",
+            get_markdown_table(_table_text_metrics(benches, side="input")) + "\n",
+            "###### Text Metrics (Completed Requests) — Output",
+            get_markdown_table(_table_text_metrics(benches, side="output")) + "\n",
+            "###### Request Token Statistics (Completed Requests)",
+            get_markdown_table(_table_request_tokens(benches)) + "\n",
+            "###### Request Latency Statistics (Completed Requests)",
+            get_markdown_table(_table_request_latency(benches)) + "\n",
+            "###### Server Throughput Statistics (All Requests)",
+            get_markdown_table(_table_server_throughput(benches)) + "\n",
+        ]
+        blocks.append("\n".join(block))
+    return blocks
+
+
+# --- Per-table helpers -------------------------------------------------------
+
+# Order of statuses we sum across ("all requests" buckets in GuideLLM).
+_ALL_BUCKETS = ("successful", "incomplete", "errored")
+
+
+def _stat(
+    block: Optional[Dict[str, Any]],
+    bucket: str,
+    key: str,
+    default: float = 0.0,
+) -> float:
+    """Read a value out of `<metric>.<bucket>.<key>`; falls back to
+    `<metric>.<bucket>.percentiles.<key>` when the key looks like a percentile
+    (e.g. `p50`, `p95`)."""
+    if not isinstance(block, dict):
+        return default
+    bucket_block = block.get(bucket) or {}
+    if key in bucket_block:
+        v = bucket_block.get(key)
+    else:
+        v = (bucket_block.get("percentiles") or {}).get(key)
+    try:
+        return float(v) if v is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _strategy_label(bench: Dict[str, Any]) -> str:
+    cfg = bench.get("config") or {}
+    strat = cfg.get("strategy") or {}
+    label = strat.get("type_") or "unknown"
+    rate = strat.get("rate")
+    if rate is not None:
+        try:
+            label = f"{label}@{float(rate):g}rps"
+        except (TypeError, ValueError):
+            label = f"{label}@{rate}"
+    return label
+
+
+def _fmt_time(epoch_seconds: Optional[float]) -> str:
+    if not epoch_seconds:
+        return ""
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(float(epoch_seconds), tz=timezone.utc).strftime(
+        "%H:%M:%S"
+    )
+
+
+def _table_run_summary(benches: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    out: List[Dict[str, str]] = []
+    for i, b in enumerate(benches):
+        m = b.get("metrics") or {}
+        totals = m.get("request_totals") or {}
+        prompt = m.get("prompt_token_count")
+        output = m.get("output_token_count")
+        out.append(
+            {
+                "Sweep": str(i),
+                "Strategy": _strategy_label(b),
+                "Start": _fmt_time(b.get("start_time")),
+                "End": _fmt_time(b.get("end_time")),
+                "Dur (s)": f"{float(b.get('duration') or 0):.1f}",
+                "Warm (s)": f"{float(b.get('warmup_duration') or 0):.1f}",
+                "Cool (s)": f"{float(b.get('cooldown_duration') or 0):.1f}",
+                "Comp": str(int(totals.get("successful") or 0)),
+                "Inc": str(int(totals.get("incomplete") or 0)),
+                "Err": str(int(totals.get("errored") or 0)),
+                "In Tok (Comp)": f"{_stat(prompt, 'successful', 'total_sum'):.0f}",
+                "In Tok (Inc)": f"{_stat(prompt, 'incomplete', 'total_sum'):.0f}",
+                "In Tok (Err)": f"{_stat(prompt, 'errored', 'total_sum'):.0f}",
+                "Out Tok (Comp)": f"{_stat(output, 'successful', 'total_sum'):.0f}",
+                "Out Tok (Inc)": f"{_stat(output, 'incomplete', 'total_sum'):.0f}",
+                "Out Tok (Err)": f"{_stat(output, 'errored', 'total_sum'):.0f}",
+            }
+        )
+    return out
+
+
+def _table_text_metrics(
+    benches: List[Dict[str, Any]], side: str
+) -> List[Dict[str, str]]:
+    """One row per benchmark; columns mirror the GuideLLM "Text Metrics
+    Statistics" table for either the input or the output side, covering
+    tokens, words, and characters with median/p95 per-request and
+    median/mean per-second statistics."""
+    out: List[Dict[str, str]] = []
+    for i, b in enumerate(benches):
+        text_block = ((b.get("metrics") or {}).get("text") or {})
+        row = {"Sweep": str(i), "Strategy": _strategy_label(b)}
+        for unit in ("tokens", "words", "characters"):
+            unit_block = text_block.get(unit) or {}
+            per_req = unit_block.get(side)
+            per_sec = unit_block.get(f"{side}_per_second")
+            unit_short = {"tokens": "Tok", "words": "Wrd", "characters": "Chr"}[unit]
+            row[f"{unit_short}/Req Mdn"] = f"{_stat(per_req, 'successful', 'median'):.1f}"
+            row[f"{unit_short}/Req p95"] = f"{_stat(per_req, 'successful', 'p95'):.1f}"
+            row[f"{unit_short}/Sec Mdn"] = f"{_stat(per_sec, 'successful', 'median'):.1f}"
+            row[f"{unit_short}/Sec Mean"] = f"{_stat(per_sec, 'successful', 'mean'):.1f}"
+        out.append(row)
+    return out
+
+
+def _table_request_tokens(benches: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    out: List[Dict[str, str]] = []
+    for i, b in enumerate(benches):
+        m = b.get("metrics") or {}
+        in_tok = m.get("prompt_token_count")
+        out_tok = m.get("output_token_count")
+        tot_tok = m.get("total_token_count")
+        stream = m.get("request_streaming_iterations_count")
+        out_per_iter = m.get("output_tokens_per_iteration")
+        out.append(
+            {
+                "Sweep": str(i),
+                "Strategy": _strategy_label(b),
+                "In Tok/Req Mdn": f"{_stat(in_tok, 'successful', 'median'):.1f}",
+                "In Tok/Req p95": f"{_stat(in_tok, 'successful', 'p95'):.1f}",
+                "Out Tok/Req Mdn": f"{_stat(out_tok, 'successful', 'median'):.1f}",
+                "Out Tok/Req p95": f"{_stat(out_tok, 'successful', 'p95'):.1f}",
+                "Total Tok/Req Mdn": f"{_stat(tot_tok, 'successful', 'median'):.1f}",
+                "Total Tok/Req p95": f"{_stat(tot_tok, 'successful', 'p95'):.1f}",
+                "Stream Iter/Req Mdn": f"{_stat(stream, 'successful', 'median'):.1f}",
+                "Stream Iter/Req p95": f"{_stat(stream, 'successful', 'p95'):.1f}",
+                "Out Tok/Iter Mdn": f"{_stat(out_per_iter, 'successful', 'median'):.1f}",
+                "Out Tok/Iter p95": f"{_stat(out_per_iter, 'successful', 'p95'):.1f}",
+            }
+        )
+    return out
+
+
+def _table_request_latency(benches: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    out: List[Dict[str, str]] = []
+    for i, b in enumerate(benches):
+        m = b.get("metrics") or {}
+        lat = m.get("request_latency")  # seconds
+        ttft = m.get("time_to_first_token_ms")
+        itl = m.get("inter_token_latency_ms")
+        tpot = m.get("time_per_output_token_ms")
+        out.append(
+            {
+                "Sweep": str(i),
+                "Strategy": _strategy_label(b),
+                "Req Latency Mdn (s)": f"{_stat(lat, 'successful', 'median'):.2f}",
+                "Req Latency p95 (s)": f"{_stat(lat, 'successful', 'p95'):.2f}",
+                "TTFT Mdn (ms)": f"{_stat(ttft, 'successful', 'median'):.1f}",
+                "TTFT p95 (ms)": f"{_stat(ttft, 'successful', 'p95'):.1f}",
+                "ITL Mdn (ms)": f"{_stat(itl, 'successful', 'median'):.1f}",
+                "ITL p95 (ms)": f"{_stat(itl, 'successful', 'p95'):.1f}",
+                "TPOT Mdn (ms)": f"{_stat(tpot, 'successful', 'median'):.1f}",
+                "TPOT p95 (ms)": f"{_stat(tpot, 'successful', 'p95'):.1f}",
+            }
+        )
+    return out
+
+
+def _table_server_throughput(benches: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    """Mirrors GuideLLM's "Server Throughput Statistics (All Requests)" table.
+    The "All Requests" qualifier means we sum the `successful + incomplete +
+    errored` buckets for the per-second metrics (matching how GuideLLM itself
+    presents these on the console)."""
+    out: List[Dict[str, str]] = []
+    for i, b in enumerate(benches):
+        m = b.get("metrics") or {}
+        conc = m.get("request_concurrency")
+        req_per_sec = m.get("requests_per_second")
+        in_per_sec = m.get("prompt_tokens_per_second")
+        out_per_sec = m.get("output_tokens_per_second")
+        tot_per_sec = m.get("tokens_per_second")
+        out.append(
+            {
+                "Sweep": str(i),
+                "Strategy": _strategy_label(b),
+                "Concurrency Mdn": f"{_stat(conc, 'successful', 'median'):.1f}",
+                "Concurrency Mean": f"{_stat(conc, 'successful', 'mean'):.1f}",
+                "Req/s Mean (All)": f"{sum(_stat(req_per_sec, bk, 'mean') for bk in _ALL_BUCKETS):.2f}",
+                "In Tok/s Mean (All)": f"{sum(_stat(in_per_sec, bk, 'mean') for bk in _ALL_BUCKETS):.1f}",
+                "Out Tok/s Mean (All)": f"{sum(_stat(out_per_sec, bk, 'mean') for bk in _ALL_BUCKETS):.1f}",
+                "Total Tok/s Mean (All)": f"{sum(_stat(tot_per_sec, bk, 'mean') for bk in _ALL_BUCKETS):.1f}",
+            }
+        )
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# CSV writer
+# --------------------------------------------------------------------------- #
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    headers = list(rows[0].keys())
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(headers)
+        for row in rows:
+            writer.writerow([str(row.get(h, "")) for h in headers])

--- a/benchmarking/guidellm_report.py
+++ b/benchmarking/guidellm_report.py
@@ -55,7 +55,6 @@ def generate_guidellm_report(
     benchmarks_output_dir: Optional[Path] = None,
 ) -> ReportTuple:
     """Generate the GuideLLM section of a benchmark report.
-
     Returns the same `(release_str, release_data, disp_md_path, data_file_path)`
     contract as the existing `aiperf_benchmark_generate_report` and
     `genai_perf_benchmark_generate_report` helpers in
@@ -173,9 +172,7 @@ def generate_guidellm_report(
 # --------------------------------------------------------------------------- #
 
 
-def _discover_normalized_files(
-    benchmarks_output_dir: Path, model_id: str
-) -> List[str]:
+def _discover_normalized_files(benchmarks_output_dir: Path, model_id: str) -> List[str]:
     pattern = f"guidellm_benchmark_{model_id}_*.json"
     return glob(f"{benchmarks_output_dir}/{pattern}")
 
@@ -520,17 +517,23 @@ def _table_text_metrics(
     median/mean per-second statistics."""
     out: List[Dict[str, str]] = []
     for i, b in enumerate(benches):
-        text_block = ((b.get("metrics") or {}).get("text") or {})
+        text_block = (b.get("metrics") or {}).get("text") or {}
         row = {"Sweep": str(i), "Strategy": _strategy_label(b)}
         for unit in ("tokens", "words", "characters"):
             unit_block = text_block.get(unit) or {}
             per_req = unit_block.get(side)
             per_sec = unit_block.get(f"{side}_per_second")
             unit_short = {"tokens": "Tok", "words": "Wrd", "characters": "Chr"}[unit]
-            row[f"{unit_short}/Req Mdn"] = f"{_stat(per_req, 'successful', 'median'):.1f}"
+            row[f"{unit_short}/Req Mdn"] = (
+                f"{_stat(per_req, 'successful', 'median'):.1f}"
+            )
             row[f"{unit_short}/Req p95"] = f"{_stat(per_req, 'successful', 'p95'):.1f}"
-            row[f"{unit_short}/Sec Mdn"] = f"{_stat(per_sec, 'successful', 'median'):.1f}"
-            row[f"{unit_short}/Sec Mean"] = f"{_stat(per_sec, 'successful', 'mean'):.1f}"
+            row[f"{unit_short}/Sec Mdn"] = (
+                f"{_stat(per_sec, 'successful', 'median'):.1f}"
+            )
+            row[f"{unit_short}/Sec Mean"] = (
+                f"{_stat(per_sec, 'successful', 'mean'):.1f}"
+            )
         out.append(row)
     return out
 

--- a/benchmarking/run_guidellm_benchmarks.py
+++ b/benchmarking/run_guidellm_benchmarks.py
@@ -3,15 +3,13 @@
 #
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-"""
-GuideLLM benchmark runner for tt-inference-server.
+# GuideLLM benchmark runner for tt-inference-server.
+# This script integrates GuideLLM into the benchmarks workflow and exposes
+# three scenario presets:
+# - multi_turn_chat
+# - custom_dataset
+# - omni_modal
 
-This script integrates GuideLLM into the benchmarks workflow and exposes
-three scenario presets:
-- multi_turn_chat
-- custom_dataset
-- omni_modal
-"""
 
 import argparse
 import json
@@ -145,7 +143,9 @@ def create_default_multiturn_dataset(dataset_path: Path, samples: int = 50) -> P
     return dataset_path
 
 
-def wait_for_server(model_spec: ModelSpec, runtime_config: RuntimeConfig, jwt_secret: str):
+def wait_for_server(
+    model_spec: ModelSpec, runtime_config: RuntimeConfig, jwt_secret: str
+):
     env_config = EnvironmentConfig()
     env_config.jwt_secret = jwt_secret
     env_config.vllm_api_key = os.getenv("VLLM_API_KEY")
@@ -217,7 +217,9 @@ def build_scenario_runs(
     auth_token: str,
     supported_modalities: List[str],
 ) -> List[GuideRunConfig]:
-    selected_scenarios = workflow_params.get("scenarios") or workflow_params.get("scenario")
+    selected_scenarios = workflow_params.get("scenarios") or workflow_params.get(
+        "scenario"
+    )
     if selected_scenarios:
         scenarios = [value.strip() for value in selected_scenarios.split(",") if value]
     else:
@@ -233,7 +235,9 @@ def build_scenario_runs(
         if dataset:
             multiturn_dataset_path = Path(dataset)
         else:
-            multiturn_dataset_path = output_root / "guidellm_datasets" / "multiturn.jsonl"
+            multiturn_dataset_path = (
+                output_root / "guidellm_datasets" / "multiturn.jsonl"
+            )
             create_default_multiturn_dataset(multiturn_dataset_path)
         runs.append(
             GuideRunConfig(
@@ -241,8 +245,12 @@ def build_scenario_runs(
                 data=str(multiturn_dataset_path),
                 profile=workflow_params.get("multiturn_profile", "synchronous"),
                 output_dir=output_root / "guidellm_multi_turn_chat",
-                max_requests=_parse_int(workflow_params.get("multiturn_max_requests"), 10),
-                max_seconds=_parse_int(workflow_params.get("multiturn_max_seconds"), 120),
+                max_requests=_parse_int(
+                    workflow_params.get("multiturn_max_requests"), 10
+                ),
+                max_seconds=_parse_int(
+                    workflow_params.get("multiturn_max_seconds"), 120
+                ),
                 request_type=workflow_params.get(
                     "multiturn_request_type", "chat_completions"
                 ),
@@ -261,7 +269,9 @@ def build_scenario_runs(
                 data=workflow_params.get("custom_data", "mbpp"),
                 profile=workflow_params.get("custom_profile", "sweep"),
                 output_dir=output_root / "guidellm_custom_dataset",
-                max_requests=_parse_int(workflow_params.get("custom_max_requests"), None),
+                max_requests=_parse_int(
+                    workflow_params.get("custom_max_requests"), None
+                ),
                 max_seconds=_parse_int(workflow_params.get("custom_max_seconds"), 60),
                 data_args=workflow_params.get("custom_data_args"),
                 data_column_mapper=workflow_params.get(
@@ -274,7 +284,9 @@ def build_scenario_runs(
     if "omni_modal" in scenarios:
         modalities_value = workflow_params.get("omni_modalities")
         if modalities_value:
-            modalities = [value.strip().lower() for value in modalities_value.split(",")]
+            modalities = [
+                value.strip().lower() for value in modalities_value.split(",")
+            ]
         else:
             modalities = list(DEFAULT_OMNI_MODALITIES)
 
@@ -308,8 +320,12 @@ def build_scenario_runs(
                 runs.append(
                     GuideRunConfig(
                         name="omni_modal_image",
-                        data=workflow_params.get("omni_image_data", "lmms-lab/MMBench_EN"),
-                        profile=workflow_params.get("omni_image_profile", "synchronous"),
+                        data=workflow_params.get(
+                            "omni_image_data", "lmms-lab/MMBench_EN"
+                        ),
+                        profile=workflow_params.get(
+                            "omni_image_profile", "synchronous"
+                        ),
                         output_dir=output_root / "guidellm_omni_modal_image",
                         max_requests=_parse_int(
                             workflow_params.get("omni_image_max_requests"), 20
@@ -317,7 +333,9 @@ def build_scenario_runs(
                         request_type=workflow_params.get(
                             "omni_image_request_type", "chat_completions"
                         ),
-                        data_args=workflow_params.get("omni_image_data_args", '{"split":"test"}'),
+                        data_args=workflow_params.get(
+                            "omni_image_data_args", '{"split":"test"}'
+                        ),
                         data_column_mapper=workflow_params.get(
                             "omni_image_data_column_mapper",
                             '{"image_column":"image","text_column":"question"}',
@@ -332,8 +350,12 @@ def build_scenario_runs(
                 runs.append(
                     GuideRunConfig(
                         name="omni_modal_video",
-                        data=workflow_params.get("omni_video_data", "lmms-lab/Video-MME"),
-                        profile=workflow_params.get("omni_video_profile", "synchronous"),
+                        data=workflow_params.get(
+                            "omni_video_data", "lmms-lab/Video-MME"
+                        ),
+                        profile=workflow_params.get(
+                            "omni_video_profile", "synchronous"
+                        ),
                         output_dir=output_root / "guidellm_omni_modal_video",
                         max_requests=_parse_int(
                             workflow_params.get("omni_video_max_requests"), 20
@@ -341,7 +363,9 @@ def build_scenario_runs(
                         request_type=workflow_params.get(
                             "omni_video_request_type", "chat_completions"
                         ),
-                        data_args=workflow_params.get("omni_video_data_args", '{"split":"test"}'),
+                        data_args=workflow_params.get(
+                            "omni_video_data_args", '{"split":"test"}'
+                        ),
                         data_column_mapper=workflow_params.get(
                             "omni_video_data_column_mapper",
                             '{"video_column":"url","text_column":"question"}',
@@ -357,9 +381,12 @@ def build_scenario_runs(
                     GuideRunConfig(
                         name="omni_modal_audio",
                         data=workflow_params.get(
-                            "omni_audio_data", "hf-internal-testing/librispeech_asr_dummy"
+                            "omni_audio_data",
+                            "hf-internal-testing/librispeech_asr_dummy",
                         ),
-                        profile=workflow_params.get("omni_audio_profile", "synchronous"),
+                        profile=workflow_params.get(
+                            "omni_audio_profile", "synchronous"
+                        ),
                         output_dir=output_root / "guidellm_omni_modal_audio",
                         max_requests=_parse_int(
                             workflow_params.get("omni_audio_max_requests"), 20
@@ -515,7 +542,10 @@ def adapt_guidellm_to_vllm_metrics(
     if not benchmarks:
         raise ValueError(f"No benchmarks found in {benchmarks_json_path}")
 
-    return [_adapt_one_benchmark(bench, default_run_index=i) for i, bench in enumerate(benchmarks)]
+    return [
+        _adapt_one_benchmark(bench, default_run_index=i)
+        for i, bench in enumerate(benchmarks)
+    ]
 
 
 def emit_normalized_guidellm_result(

--- a/benchmarking/run_guidellm_benchmarks.py
+++ b/benchmarking/run_guidellm_benchmarks.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""
+GuideLLM benchmark runner for tt-inference-server.
+
+This script integrates GuideLLM into the benchmarks workflow and exposes
+three scenario presets:
+- multi_turn_chat
+- custom_dataset
+- omni_modal
+"""
+
+import argparse
+import json
+import logging
+import os
+import shlex
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import jwt
+
+# Add project root to Python path.
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from utils.prompt_client import PromptClient
+from utils.prompt_configs import EnvironmentConfig
+from workflows.log_setup import setup_workflow_script_logger
+from workflows.model_spec import ModelSpec
+from workflows.runtime_config import RuntimeConfig
+from workflows.utils import run_command
+from workflows.workflow_types import InferenceEngine, WorkflowVenvType
+from workflows.workflow_venvs import VENV_CONFIGS
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SCENARIOS = ["multi_turn_chat", "custom_dataset", "omni_modal"]
+DEFAULT_OMNI_MODALITIES = ["text", "image", "video", "audio"]
+
+
+@dataclass
+class GuideRunConfig:
+    name: str
+    data: str
+    profile: str
+    output_dir: Path
+    max_requests: Optional[int] = None
+    max_seconds: Optional[int] = None
+    request_type: Optional[str] = None
+    data_args: Optional[str] = None
+    data_column_mapper: Optional[str] = None
+    data_preprocessors: Optional[str] = None
+    backend_type: str = "openai_http"
+    backend_kwargs: Optional[str] = None
+    extra_args: Optional[List[str]] = None
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run GuideLLM benchmarks")
+    parser.add_argument(
+        "--runtime-model-spec-json",
+        type=str,
+        help="Use runtime model specification from JSON file",
+        required=True,
+    )
+    parser.add_argument(
+        "--output-path",
+        type=str,
+        help="Path for benchmark output",
+        required=True,
+    )
+    parser.add_argument(
+        "--jwt-secret",
+        type=str,
+        help="JWT secret for generating token to set API_KEY",
+        default=os.getenv("JWT_SECRET", ""),
+    )
+    parser.add_argument("--device", type=str, required=False)
+    parser.add_argument("--model", type=str, required=False)
+    return parser.parse_args()
+
+
+def parse_workflow_args(workflow_args: Optional[str]) -> Dict[str, str]:
+    if not workflow_args:
+        return {}
+    parsed: Dict[str, str] = {}
+    for token in shlex.split(workflow_args):
+        if "=" in token:
+            key, value = token.split("=", 1)
+            parsed[key.replace("-", "_")] = value
+        else:
+            parsed[token.replace("-", "_")] = "true"
+    return parsed
+
+
+def _parse_int(value: Optional[str], default_value: Optional[int]) -> Optional[int]:
+    if value is None:
+        return default_value
+    return int(value)
+
+
+def build_auth_token(jwt_secret: str) -> str:
+    if not jwt_secret:
+        return ""
+    payload = {"team_id": "tenstorrent", "token_id": "guidellm-bench"}
+    return jwt.encode(payload, jwt_secret, algorithm="HS256")
+
+
+def build_backend_kwargs_json(
+    auth_token: str, override_backend_kwargs: Optional[str]
+) -> str:
+    if override_backend_kwargs:
+        return override_backend_kwargs
+    kwargs = {
+        "validate_backend": "/v1/models",
+        "http2": False,
+        "stream": False,
+        "timeout": 300,
+        "max_tokens": 64,
+    }
+    if auth_token:
+        kwargs["api_key"] = auth_token
+    return json.dumps(kwargs)
+
+
+def create_default_multiturn_dataset(dataset_path: Path, samples: int = 50) -> Path:
+    dataset_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(dataset_path, "w", encoding="utf-8") as dataset_file:
+        for index in range(samples):
+            row = {
+                "system_context": (
+                    "You are a helpful assistant. Keep responses concise and accurate."
+                ),
+                "turn_1": f"What is {index} * 3?",
+                "turn_2": "Now add 10 to that result.",
+            }
+            dataset_file.write(json.dumps(row) + "\n")
+    return dataset_path
+
+
+def wait_for_server(model_spec: ModelSpec, runtime_config: RuntimeConfig, jwt_secret: str):
+    env_config = EnvironmentConfig()
+    env_config.jwt_secret = jwt_secret
+    env_config.vllm_api_key = os.getenv("VLLM_API_KEY")
+    env_config.service_port = runtime_config.service_port
+    env_config.vllm_model = model_spec.hf_model_repo
+
+    prompt_client = PromptClient(
+        env_config,
+        model_spec=model_spec,
+        runtime_config=runtime_config,
+    )
+    return prompt_client.wait_for_healthy()
+
+
+def build_guidellm_command(
+    venv_python: Path,
+    target: str,
+    model_name: str,
+    run_cfg: GuideRunConfig,
+) -> List[str]:
+    command = [
+        str(venv_python),
+        "-m",
+        "guidellm",
+        "benchmark",
+        "--disable-console-interactive",
+        "--target",
+        target,
+        "--model",
+        model_name,
+        "--profile",
+        run_cfg.profile,
+        "--backend-type",
+        run_cfg.backend_type,
+        "--output-dir",
+        str(run_cfg.output_dir),
+        "--data",
+        run_cfg.data,
+    ]
+    if run_cfg.request_type:
+        command.extend(["--request-type", run_cfg.request_type])
+    if run_cfg.max_requests is not None:
+        command.extend(["--max-requests", str(run_cfg.max_requests)])
+    if run_cfg.max_seconds is not None:
+        command.extend(["--max-seconds", str(run_cfg.max_seconds)])
+    if run_cfg.data_args:
+        command.extend(["--data-args", run_cfg.data_args])
+    if run_cfg.data_column_mapper:
+        command.extend(["--data-column-mapper", run_cfg.data_column_mapper])
+    if run_cfg.data_preprocessors:
+        command.extend(["--data-preprocessors", run_cfg.data_preprocessors])
+    if run_cfg.backend_kwargs:
+        command.extend(["--backend-kwargs", run_cfg.backend_kwargs])
+    if run_cfg.extra_args:
+        command.extend(run_cfg.extra_args)
+    return command
+
+
+def get_supported_modalities(model_spec: ModelSpec) -> List[str]:
+    modalities = getattr(model_spec, "supported_modalities", None)
+    if not modalities:
+        return ["text"]
+    return [str(modality).lower() for modality in modalities]
+
+
+def build_scenario_runs(
+    output_root: Path,
+    workflow_params: Dict[str, str],
+    auth_token: str,
+    supported_modalities: List[str],
+) -> List[GuideRunConfig]:
+    selected_scenarios = workflow_params.get("scenarios") or workflow_params.get("scenario")
+    if selected_scenarios:
+        scenarios = [value.strip() for value in selected_scenarios.split(",") if value]
+    else:
+        scenarios = list(DEFAULT_SCENARIOS)
+
+    backend_kwargs = build_backend_kwargs_json(
+        auth_token, workflow_params.get("backend_kwargs")
+    )
+    runs: List[GuideRunConfig] = []
+
+    if "multi_turn_chat" in scenarios:
+        dataset = workflow_params.get("multiturn_data")
+        if dataset:
+            multiturn_dataset_path = Path(dataset)
+        else:
+            multiturn_dataset_path = output_root / "guidellm_datasets" / "multiturn.jsonl"
+            create_default_multiturn_dataset(multiturn_dataset_path)
+        runs.append(
+            GuideRunConfig(
+                name="multi_turn_chat",
+                data=str(multiturn_dataset_path),
+                profile=workflow_params.get("multiturn_profile", "synchronous"),
+                output_dir=output_root / "guidellm_multi_turn_chat",
+                max_requests=_parse_int(workflow_params.get("multiturn_max_requests"), 10),
+                max_seconds=_parse_int(workflow_params.get("multiturn_max_seconds"), 120),
+                request_type=workflow_params.get(
+                    "multiturn_request_type", "chat_completions"
+                ),
+                data_column_mapper=workflow_params.get(
+                    "multiturn_data_column_mapper",
+                    '{"prefix_column":"system_context","text_column":"turn_1"}',
+                ),
+                backend_kwargs=backend_kwargs,
+            )
+        )
+
+    if "custom_dataset" in scenarios:
+        runs.append(
+            GuideRunConfig(
+                name="custom_dataset",
+                data=workflow_params.get("custom_data", "mbpp"),
+                profile=workflow_params.get("custom_profile", "sweep"),
+                output_dir=output_root / "guidellm_custom_dataset",
+                max_requests=_parse_int(workflow_params.get("custom_max_requests"), None),
+                max_seconds=_parse_int(workflow_params.get("custom_max_seconds"), 60),
+                data_args=workflow_params.get("custom_data_args"),
+                data_column_mapper=workflow_params.get(
+                    "custom_data_column_mapper", '{"text_column":"text"}'
+                ),
+                backend_kwargs=backend_kwargs,
+            )
+        )
+
+    if "omni_modal" in scenarios:
+        modalities_value = workflow_params.get("omni_modalities")
+        if modalities_value:
+            modalities = [value.strip().lower() for value in modalities_value.split(",")]
+        else:
+            modalities = list(DEFAULT_OMNI_MODALITIES)
+
+        for modality in modalities:
+            if modality != "text" and modality not in supported_modalities:
+                logger.info(
+                    f"Skipping omni-modal {modality} scenario: model does not advertise {modality} modality."
+                )
+                continue
+
+            if modality == "text":
+                runs.append(
+                    GuideRunConfig(
+                        name="omni_modal_text",
+                        data=workflow_params.get("omni_text_data", "mbpp"),
+                        profile=workflow_params.get("omni_text_profile", "synchronous"),
+                        output_dir=output_root / "guidellm_omni_modal_text",
+                        max_requests=_parse_int(
+                            workflow_params.get("omni_text_max_requests"), 20
+                        ),
+                        request_type=workflow_params.get(
+                            "omni_text_request_type", "chat_completions"
+                        ),
+                        data_column_mapper=workflow_params.get(
+                            "omni_text_data_column_mapper", '{"text_column":"text"}'
+                        ),
+                        backend_kwargs=backend_kwargs,
+                    )
+                )
+            elif modality == "image":
+                runs.append(
+                    GuideRunConfig(
+                        name="omni_modal_image",
+                        data=workflow_params.get("omni_image_data", "lmms-lab/MMBench_EN"),
+                        profile=workflow_params.get("omni_image_profile", "synchronous"),
+                        output_dir=output_root / "guidellm_omni_modal_image",
+                        max_requests=_parse_int(
+                            workflow_params.get("omni_image_max_requests"), 20
+                        ),
+                        request_type=workflow_params.get(
+                            "omni_image_request_type", "chat_completions"
+                        ),
+                        data_args=workflow_params.get("omni_image_data_args", '{"split":"test"}'),
+                        data_column_mapper=workflow_params.get(
+                            "omni_image_data_column_mapper",
+                            '{"image_column":"image","text_column":"question"}',
+                        ),
+                        data_preprocessors=workflow_params.get(
+                            "omni_image_data_preprocessors", "encode_media"
+                        ),
+                        backend_kwargs=backend_kwargs,
+                    )
+                )
+            elif modality == "video":
+                runs.append(
+                    GuideRunConfig(
+                        name="omni_modal_video",
+                        data=workflow_params.get("omni_video_data", "lmms-lab/Video-MME"),
+                        profile=workflow_params.get("omni_video_profile", "synchronous"),
+                        output_dir=output_root / "guidellm_omni_modal_video",
+                        max_requests=_parse_int(
+                            workflow_params.get("omni_video_max_requests"), 20
+                        ),
+                        request_type=workflow_params.get(
+                            "omni_video_request_type", "chat_completions"
+                        ),
+                        data_args=workflow_params.get("omni_video_data_args", '{"split":"test"}'),
+                        data_column_mapper=workflow_params.get(
+                            "omni_video_data_column_mapper",
+                            '{"video_column":"url","text_column":"question"}',
+                        ),
+                        data_preprocessors=workflow_params.get(
+                            "omni_video_data_preprocessors", "encode_media"
+                        ),
+                        backend_kwargs=backend_kwargs,
+                    )
+                )
+            elif modality == "audio":
+                runs.append(
+                    GuideRunConfig(
+                        name="omni_modal_audio",
+                        data=workflow_params.get(
+                            "omni_audio_data", "hf-internal-testing/librispeech_asr_dummy"
+                        ),
+                        profile=workflow_params.get("omni_audio_profile", "synchronous"),
+                        output_dir=output_root / "guidellm_omni_modal_audio",
+                        max_requests=_parse_int(
+                            workflow_params.get("omni_audio_max_requests"), 20
+                        ),
+                        request_type=workflow_params.get(
+                            "omni_audio_request_type", "chat_completions"
+                        ),
+                        data_column_mapper=workflow_params.get(
+                            "omni_audio_data_column_mapper",
+                            '{"audio_column":"audio","text_column":"text"}',
+                        ),
+                        data_preprocessors=workflow_params.get(
+                            "omni_audio_data_preprocessors", "encode_media"
+                        ),
+                        backend_kwargs=backend_kwargs,
+                    )
+                )
+
+    extra_args = workflow_params.get("guidellm_extra_args")
+    if extra_args:
+        parsed_extra = shlex.split(extra_args)
+        for run_cfg in runs:
+            run_cfg.extra_args = parsed_extra
+
+    return runs
+
+
+def main():
+    setup_workflow_script_logger(logger)
+    logger.info(f"Running {__file__} ...")
+
+    args = parse_args()
+    model_spec = ModelSpec.from_json(args.runtime_model_spec_json)
+    runtime_config = RuntimeConfig.from_json(args.runtime_model_spec_json)
+
+    if model_spec.inference_engine in (
+        InferenceEngine.MEDIA.value,
+        InferenceEngine.FORGE.value,
+    ):
+        os.environ["VLLM_API_KEY"] = "your-secret-key"
+
+    if not wait_for_server(model_spec, runtime_config, args.jwt_secret):
+        logger.error("vLLM server is not healthy. Aborting GuideLLM benchmarks.")
+        return 1
+
+    venv_config = VENV_CONFIGS[WorkflowVenvType.BENCHMARKS_GUIDELLM]
+    auth_token = build_auth_token(args.jwt_secret)
+    if auth_token:
+        os.environ["OPENAI_API_KEY"] = auth_token
+
+    output_root = Path(args.output_path)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    workflow_params = parse_workflow_args(runtime_config.workflow_args)
+    target = workflow_params.get(
+        "target", f"http://127.0.0.1:{runtime_config.service_port}/v1"
+    )
+
+    runs = build_scenario_runs(
+        output_root=output_root,
+        workflow_params=workflow_params,
+        auth_token=auth_token,
+        supported_modalities=get_supported_modalities(model_spec),
+    )
+    if not runs:
+        logger.error("No GuideLLM runs were configured. Nothing to execute.")
+        return 1
+
+    logger.info(f"Running {len(runs)} GuideLLM scenario(s): {[r.name for r in runs]}")
+
+    return_codes: List[int] = []
+    for run_cfg in runs:
+        run_cfg.output_dir.mkdir(parents=True, exist_ok=True)
+        cmd = build_guidellm_command(
+            venv_python=venv_config.venv_python,
+            target=target,
+            model_name=model_spec.hf_model_repo,
+            run_cfg=run_cfg,
+        )
+        logger.info(f"Running GuideLLM scenario: {run_cfg.name}")
+        logger.info(f"GuideLLM command: {' '.join(cmd)}")
+        return_code = run_command(command=cmd, logger=logger, env=os.environ.copy())
+        return_codes.append(return_code)
+
+    if all(return_code == 0 for return_code in return_codes):
+        logger.info("Completed GuideLLM benchmarks.")
+        return 0
+
+    logger.error(f"GuideLLM benchmark failures: return codes={return_codes}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarking/run_guidellm_benchmarks.py
+++ b/benchmarking/run_guidellm_benchmarks.py
@@ -20,8 +20,9 @@ import os
 import shlex
 import sys
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import jwt
 
@@ -108,7 +109,7 @@ def _parse_int(value: Optional[str], default_value: Optional[int]) -> Optional[i
 def build_auth_token(jwt_secret: str) -> str:
     if not jwt_secret:
         return ""
-    payload = {"team_id": "tenstorrent", "token_id": "guidellm-bench"}
+    payload = {"team_id": "tenstorrent", "token_id": "debug-test"}
     return jwt.encode(payload, jwt_secret, algorithm="HS256")
 
 
@@ -386,6 +387,216 @@ def build_scenario_runs(
     return runs
 
 
+def _stat(metric: Optional[Dict[str, Any]], key: str, default: float = 0.0) -> float:
+    """Read a stats value from a GuideLLM `<metric>.successful.<key>` block.
+
+    GuideLLM's benchmarks.json stores each metric as
+    {"successful": {mean, median, std_dev, percentiles: {p50, p99, ...}, ...},
+     "errored": {...}}. Percentiles are nested under `percentiles`.
+    """
+    if not isinstance(metric, dict):
+        return default
+    successful = metric.get("successful") or {}
+    if key in successful:
+        value = successful.get(key)
+    else:
+        value = (successful.get("percentiles") or {}).get(key)
+    try:
+        return float(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _adapt_one_benchmark(
+    bench: Dict[str, Any], default_run_index: int = 0
+) -> Tuple[Dict[str, float], Dict[str, int], Dict[str, Any]]:
+    """Convert a single GuideLLM benchmark dict to flat vLLM-compatible metrics.
+
+    Returns (metrics, params, extra) where:
+    - metrics is the flat schema used by AIPerf/vLLM downstream report code
+      (mean/median/p99/std_* for ttft/tpot/itl/e2el, throughput, token totals)
+    - params provides the (isl, osl, max_concurrency, num_requests) tuple used
+      to build the canonical filename
+    - extra carries sweep traceability fields (run_index, strategy_type, rate)
+      that are stored in the emitted JSON and used for filename disambiguation
+      when a single GuideLLM run produces multiple benchmark points.
+    """
+    metrics = bench.get("metrics") or {}
+    config = bench.get("config") or {}
+    strategy = config.get("strategy") or {}
+
+    ttft = metrics.get("time_to_first_token_ms")
+    tpot = metrics.get("time_per_output_token_ms")
+    itl = metrics.get("inter_token_latency_ms")
+    e2el = metrics.get("request_latency")  # GuideLLM reports this in seconds
+    rps = metrics.get("requests_per_second")
+    out_tps = metrics.get("output_tokens_per_second")
+    tot_tps = metrics.get("tokens_per_second")
+    prompt_tokens = metrics.get("prompt_token_count")
+    output_tokens = metrics.get("output_token_count")
+    request_totals = metrics.get("request_totals") or {}
+
+    flat = {
+        # TTFT
+        "mean_ttft_ms": _stat(ttft, "mean"),
+        "median_ttft_ms": _stat(ttft, "median"),
+        "p99_ttft_ms": _stat(ttft, "p99"),
+        "std_ttft_ms": _stat(ttft, "std_dev"),
+        # TPOT
+        "mean_tpot_ms": _stat(tpot, "mean"),
+        "median_tpot_ms": _stat(tpot, "median"),
+        "p99_tpot_ms": _stat(tpot, "p99"),
+        "std_tpot_ms": _stat(tpot, "std_dev"),
+        # ITL
+        "mean_itl_ms": _stat(itl, "mean"),
+        "median_itl_ms": _stat(itl, "median"),
+        "p99_itl_ms": _stat(itl, "p99"),
+        "std_itl_ms": _stat(itl, "std_dev"),
+        # E2EL: GuideLLM reports request_latency in seconds; convert to ms.
+        "mean_e2el_ms": _stat(e2el, "mean") * 1000.0,
+        "median_e2el_ms": _stat(e2el, "median") * 1000.0,
+        "p99_e2el_ms": _stat(e2el, "p99") * 1000.0,
+        "std_e2el_ms": _stat(e2el, "std_dev") * 1000.0,
+        # Throughput
+        "output_token_throughput": _stat(out_tps, "mean"),
+        "total_token_throughput": _stat(tot_tps, "mean"),
+        "request_throughput": _stat(rps, "mean"),
+        # Token totals
+        "completed": int(request_totals.get("successful") or 0),
+        "total_input_tokens": int(_stat(prompt_tokens, "total_sum")),
+        "total_output_tokens": int(_stat(output_tokens, "total_sum")),
+    }
+
+    isl = int(round(_stat(prompt_tokens, "mean"))) if prompt_tokens else 0
+    osl = int(round(_stat(output_tokens, "mean"))) if output_tokens else 0
+    max_concurrency = int(strategy.get("max_concurrency") or 1)
+    num_requests = int(request_totals.get("total") or flat["completed"])
+
+    params = {
+        "isl": isl,
+        "osl": osl,
+        "max_concurrency": max_concurrency,
+        "num_requests": num_requests,
+    }
+
+    # Sweep traceability — preserved in the emitted JSON and used to
+    # disambiguate filenames when (isl, osl, maxcon, n) collides between
+    # sweep points (e.g. rate sweeps at fixed concurrency).
+    rate_value = strategy.get("rate")
+    if rate_value is None:
+        # Some strategies use different keys; fall back to a few common names.
+        for key in ("rate_per_second", "max_rate", "constant_rate"):
+            if strategy.get(key) is not None:
+                rate_value = strategy.get(key)
+                break
+
+    extra = {
+        "run_index": int(config.get("run_index") or default_run_index),
+        "strategy_type": strategy.get("type_") or "unknown",
+        "strategy_rate": rate_value,
+        "duration_seconds": bench.get("duration"),
+        "start_time": bench.get("start_time"),
+        "end_time": bench.get("end_time"),
+    }
+    return flat, params, extra
+
+
+def adapt_guidellm_to_vllm_metrics(
+    benchmarks_json_path: Path,
+) -> List[Tuple[Dict[str, float], Dict[str, int], Dict[str, Any]]]:
+    """Convert a GuideLLM benchmarks.json file into a list of per-benchmark
+    vLLM-compatible flat metrics. Sweep profiles produce one entry per
+    completed strategy; non-sweep profiles produce a single entry.
+    """
+    with open(benchmarks_json_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    benchmarks = data.get("benchmarks") or []
+    if not benchmarks:
+        raise ValueError(f"No benchmarks found in {benchmarks_json_path}")
+
+    return [_adapt_one_benchmark(bench, default_run_index=i) for i, bench in enumerate(benchmarks)]
+
+
+def emit_normalized_guidellm_result(
+    scenario_name: str,
+    scenario_output_dir: Path,
+    benchmarks_output_dir: Path,
+    model_id: str,
+    model_name: str,
+) -> List[Path]:
+    """Write one normalized `guidellm_benchmark_*.json` per benchmark point in
+    the GuideLLM sweep, for consumption by the reports workflow.
+
+    Mirrors `benchmarking/run_aiperf_benchmarks.py::save_individual_result()`
+    so `workflows/run_reports.py` can discover GuideLLM runs alongside vLLM,
+    GenAI-Perf, and AIPerf using the unified `benchmarks_output/` dir.
+
+    For sweep profiles (multiple benchmarks in benchmarks.json), each point is
+    emitted as a separate file with a `_sweep-<run_index>` suffix so that
+    points sharing the same (isl, osl, maxcon, n) tuple (e.g. rate sweeps at
+    fixed concurrency) are not collapsed by the reports' deduplication step.
+    """
+    benchmarks_json = scenario_output_dir / "benchmarks.json"
+    if not benchmarks_json.is_file():
+        logger.warning(
+            f"GuideLLM scenario '{scenario_name}': benchmarks.json not found at "
+            f"{benchmarks_json}; skipping normalized report emission."
+        )
+        return []
+
+    try:
+        adapted = adapt_guidellm_to_vllm_metrics(benchmarks_json)
+    except Exception as exc:
+        logger.warning(
+            f"GuideLLM scenario '{scenario_name}': failed to adapt benchmarks.json "
+            f"({benchmarks_json}): {exc}"
+        )
+        return []
+
+    benchmarks_output_dir.mkdir(parents=True, exist_ok=True)
+    base_timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    is_sweep = len(adapted) > 1
+    out_paths: List[Path] = []
+
+    for flat_metrics, params, extra in adapted:
+        # Add the sweep suffix only for true sweeps so single-point runs
+        # keep producing the original filename shape.
+        sweep_suffix = f"_sweep-{extra['run_index']}" if is_sweep else ""
+        filename = (
+            f"guidellm_benchmark_{model_id}_{base_timestamp}"
+            f"_isl-{params['isl']}_osl-{params['osl']}"
+            f"_maxcon-{params['max_concurrency']}_n-{params['num_requests']}"
+            f"{sweep_suffix}.json"
+        )
+        out_path = benchmarks_output_dir / filename
+
+        record = {
+            "date": datetime.now().strftime("%Y%m%d-%H%M%S"),
+            "backend": "guidellm",
+            "scenario": scenario_name,
+            "model_id": model_name,
+            "tokenizer_id": model_name,
+            "num_prompts": params["num_requests"],
+            "max_concurrency": params["max_concurrency"],
+            "source_benchmarks_json": str(benchmarks_json),
+            "sweep_index": extra["run_index"],
+            "sweep_size": len(adapted),
+            "strategy_type": extra["strategy_type"],
+            "strategy_rate": extra["strategy_rate"],
+            **flat_metrics,
+        }
+        with open(out_path, "w", encoding="utf-8") as fh:
+            json.dump(record, fh, indent=2)
+        logger.info(
+            f"GuideLLM normalized result saved (sweep {extra['run_index'] + 1}/"
+            f"{len(adapted)}, strategy={extra['strategy_type']}): {out_path}"
+        )
+        out_paths.append(out_path)
+
+    return out_paths
+
+
 def main():
     setup_workflow_script_logger(logger)
     logger.info(f"Running {__file__} ...")
@@ -442,6 +653,18 @@ def main():
         logger.info(f"GuideLLM command: {' '.join(cmd)}")
         return_code = run_command(command=cmd, logger=logger, env=os.environ.copy())
         return_codes.append(return_code)
+
+        # Emit a vLLM/AIPerf-compatible result file into the unified
+        # benchmarks_output/ directory so workflows/run_reports.py can
+        # discover GuideLLM results via guidellm_benchmark_*.json globbing.
+        if return_code == 0:
+            emit_normalized_guidellm_result(
+                scenario_name=run_cfg.name,
+                scenario_output_dir=run_cfg.output_dir,
+                benchmarks_output_dir=output_root,
+                model_id=model_spec.model_id,
+                model_name=model_spec.hf_model_repo,
+            )
 
     if all(return_code == 0 for return_code in return_codes):
         logger.info("Completed GuideLLM benchmarks.")

--- a/benchmarking/run_guidellm_benchmarks.py
+++ b/benchmarking/run_guidellm_benchmarks.py
@@ -35,7 +35,7 @@ from utils.prompt_configs import EnvironmentConfig
 from workflows.log_setup import setup_workflow_script_logger
 from workflows.model_spec import ModelSpec
 from workflows.runtime_config import RuntimeConfig
-from workflows.utils import run_command
+from workflows.utils import get_default_workflow_root_log_dir, run_command
 from workflows.workflow_types import InferenceEngine, WorkflowVenvType
 from workflows.workflow_venvs import VENV_CONFIGS
 
@@ -597,6 +597,23 @@ def emit_normalized_guidellm_result(
     return out_paths
 
 
+def _resolve_safe_output_path(user_path: str) -> Path:
+    """Confine `--output-path` to the workflow logs root (`CACHE_ROOT` in
+    docker, repo `workflow_logs/` otherwise) to satisfy the SAST rule on
+    unsanitized user input in file path resolution. Symlinks and `..` are
+    flattened via `resolve()` before the prefix check, so traversal attempts
+    cannot escape the safelisted base."""
+    base = get_default_workflow_root_log_dir().resolve()
+    candidate = Path(user_path)
+    candidate = (candidate if candidate.is_absolute() else base / candidate).resolve()
+    if candidate != base and base not in candidate.parents:
+        raise ValueError(
+            f"--output-path {user_path!r} resolves outside the allowed base "
+            f"{str(base)!r}; refusing to write GuideLLM results there."
+        )
+    return candidate
+
+
 def main():
     setup_workflow_script_logger(logger)
     logger.info(f"Running {__file__} ...")
@@ -620,7 +637,7 @@ def main():
     if auth_token:
         os.environ["OPENAI_API_KEY"] = auth_token
 
-    output_root = Path(args.output_path)
+    output_root = _resolve_safe_output_path(args.output_path)
     output_root.mkdir(parents=True, exist_ok=True)
 
     workflow_params = parse_workflow_args(runtime_config.workflow_args)

--- a/benchmarking/summary_report.py
+++ b/benchmarking/summary_report.py
@@ -164,6 +164,82 @@ def extract_params_from_filename(filename: str) -> Dict[str, Any]:
             "backend": "aiperf",
         }
 
+    # GuideLLM image benchmark pattern (kept symmetric with AIPerf so omni-modal
+    # image runs are categorized as VLM in the reports). The optional
+    # `_sweep-<idx>` suffix appears when GuideLLM ran a sweep profile (one
+    # source benchmarks.json -> multiple normalized files, one per strategy).
+    guidellm_image_pattern = r"""
+        ^guidellm_benchmark_
+        (?P<model>.+?)                            # Model name (non-greedy, allows everything)
+        (?:_(?P<device>N150|N300|P100|P150|T3K|p150x4|p150x8|p300x2|P300x2|p300|P300|n150x4|TG|GALAXY|n150|n300|p100|p150|t3k|tg|galaxy))?  # Optional device
+        _(?P<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})
+        _isl-(?P<isl>\d+)
+        _osl-(?P<osl>\d+)
+        _maxcon-(?P<maxcon>\d+)
+        _n-(?P<n>\d+)
+        _images-(?P<images_per_prompt>\d+)
+        _height-(?P<image_height>\d+)
+        _width-(?P<image_width>\d+)
+        (?:_sweep-(?P<sweep_index>\d+))?           # Optional GuideLLM sweep index
+        \.json$
+    """
+    match = re.search(guidellm_image_pattern, filename, re.VERBOSE)
+    if match:
+        model_name = match.group("model")
+        is_image_generation = any(
+            img_gen in model_name.lower()
+            for img_gen in ["stable-diffusion", "sdxl", "sd-", "sd3"]
+        )
+        task_type = "image" if is_image_generation else "vlm"
+        sweep_idx = match.group("sweep_index")
+        return {
+            "model_name": model_name,
+            "timestamp": match.group("timestamp"),
+            "device": match.group("device"),
+            "input_sequence_length": int(match.group("isl")),
+            "output_sequence_length": int(match.group("osl")),
+            "max_con": int(match.group("maxcon")),
+            "num_requests": int(match.group("n")),
+            "images_per_prompt": int(match.group("images_per_prompt")),
+            "image_height": int(match.group("image_height")),
+            "image_width": int(match.group("image_width")),
+            "sweep_index": int(sweep_idx) if sweep_idx is not None else None,
+            "task_type": task_type,
+            "backend": "guidellm",
+        }
+
+    # GuideLLM text benchmark pattern (multi_turn_chat / custom_dataset /
+    # omni_modal_text scenarios all flatten to the same vLLM-compatible
+    # filename produced by run_guidellm_benchmarks.emit_normalized_guidellm_result).
+    # The optional `_sweep-<idx>` suffix is present only for sweep profiles.
+    guidellm_text_pattern = r"""
+        ^guidellm_benchmark_
+        (?P<model>.+?)                            # Model name (non-greedy, allows everything)
+        (?:_(?P<device>N150|N300|P100|P150|T3K|p150x4|p150x8|p300x2|P300x2|p300|P300|n150x4|TG|GALAXY|n150|n300|p100|p150|t3k|tg|galaxy))?  # Optional device
+        _(?P<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})
+        _isl-(?P<isl>\d+)
+        _osl-(?P<osl>\d+)
+        _maxcon-(?P<maxcon>\d+)
+        _n-(?P<n>\d+)
+        (?:_sweep-(?P<sweep_index>\d+))?           # Optional GuideLLM sweep index
+        \.json$
+    """
+    match = re.search(guidellm_text_pattern, filename, re.VERBOSE)
+    if match:
+        sweep_idx = match.group("sweep_index")
+        return {
+            "model_name": match.group("model"),
+            "timestamp": match.group("timestamp"),
+            "device": match.group("device"),
+            "input_sequence_length": int(match.group("isl")),
+            "output_sequence_length": int(match.group("osl")),
+            "max_con": int(match.group("maxcon")),
+            "num_requests": int(match.group("n")),
+            "sweep_index": int(sweep_idx) if sweep_idx is not None else None,
+            "task_type": "text",
+            "backend": "guidellm",
+        }
+
     # Try the image benchmark pattern
     image_pattern = r"""
         ^(?:genai_)?benchmark_                    # Optional "genai_" prefix, followed by "benchmark_"
@@ -339,10 +415,16 @@ def process_benchmark_file(filepath: str) -> Dict[str, Any]:
     filename = os.path.basename(filepath)
     params = extract_params_from_filename(filename)
 
-    # Handle aiperf benchmark files
-    if params.get("backend") == "aiperf":
-        logger.info(f"Processing AIPerf benchmark file: {filepath}")
-        # AIPerf files already contain metrics in vLLM-compatible format
+    # Handle aiperf and guidellm benchmark files. GuideLLM results are
+    # normalized into the same flat vLLM-compatible schema as AIPerf by
+    # benchmarking/run_guidellm_benchmarks.py::adapt_guidellm_to_vllm_metrics,
+    # so they share the processing branch and only differ in the `backend`
+    # tag carried through to the report.
+    backend_tag = params.get("backend")
+    if backend_tag in ("aiperf", "guidellm"):
+        logger.info(
+            f"Processing {backend_tag} benchmark file (vLLM-compatible schema): {filepath}"
+        )
         mean_tpot_ms = data.get("mean_tpot_ms", 0)
         if mean_tpot_ms and mean_tpot_ms > 0:
             mean_tps = 1000.0 / mean_tpot_ms
@@ -365,7 +447,7 @@ def process_benchmark_file(filepath: str) -> Dict[str, Any]:
             "timestamp": params["timestamp"],
             "model_name": params["model_name"],
             "model_id": data.get("model_id", ""),
-            "backend": "aiperf",
+            "backend": backend_tag,
             "device": params.get("device", ""),
             "input_sequence_length": params["input_sequence_length"],
             "output_sequence_length": params["output_sequence_length"],

--- a/docs/benchmarking_tools.md
+++ b/docs/benchmarking_tools.md
@@ -4,13 +4,14 @@ Comprehensive guide to performance benchmarking tools integrated with tt-inferen
 
 ## Overview
 
-tt-inference-server supports three benchmarking tools for measuring LLM inference performance on Tenstorrent accelerators:
+tt-inference-server supports four benchmarking tools for measuring LLM inference performance on Tenstorrent accelerators:
 
 | Tool | Source | Installation | Best For |
 |------|--------|--------------|----------|
 | **vLLM** | vLLM project | Docker | Baseline reference |
 | **GenAI-Perf** | NVIDIA Triton SDK | Docker (~10GB) | Official Triton validation |
 | **AIPerf** | NVIDIA ai-dynamo | `pip install` | Detailed percentiles, VLM support |
+| **GuideLLM** | vLLM project | `pip install` | Multi-turn, custom datasets, omni-modal scenarios |
 
 ## Quick Start
 
@@ -25,6 +26,9 @@ python run.py --model gemma-3-4b-it --device n300 --workflow benchmarks --docker
 
 # AIPerf
 python run.py --model gemma-3-4b-it --device n300 --workflow benchmarks --docker-server --tools aiperf
+
+# GuideLLM
+python run.py --model gemma-3-4b-it --device n300 --workflow benchmarks --docker-server --tools guidellm
 ```
 
 ## Tool Comparison

--- a/requirements/benchmarks-guidellm.txt
+++ b/requirements/benchmarks-guidellm.txt
@@ -8,27 +8,17 @@
 # GuideLLM is a benchmarking harness for LLM serving stacks.
 # Repository: https://github.com/neuralmagic/guidellm
 #
-# Extra runtime deps below are not covered by guidellm core or
-# guidellm[recommended] (which is just [perf, tokenizers]):
+# `guidellm[all]` pulls in every optional extra (perf, tokenizers, vision,
+# audio, ...). The audio extra ships `torchcodec`, which transitively pins
+# its own compatible `torch`, so we deliberately do not pin torch here.
+#
+# Extra runtime deps below are not covered by any guidellm extra:
 #   - requests, pyjwt: used by the wrapper benchmarking/run_guidellm_benchmarks.py
 #     for JWT auth-token generation and PromptClient server health checks
 #     (guidellm itself ships its own httpx client, not requests).
-#   - pillow: required by guidellm's `encode_media` preprocessor for image
-#     omni_modal scenarios (part of guidellm's [vision] extra).
-#   - imageio, imageio-ffmpeg: video decoding backends for video omni_modal
-#     scenarios. guidellm's [audio] extra pulls torchcodec which pins
-#     torch==2.10.*, conflicting with the torch==2.4.0+cpu pinned below, so
-#     imageio backends are installed instead.
-#
-# torch is pinned to a CPU build to keep the venv lightweight.
 
 -c constraints.txt
---extra-index-url https://download.pytorch.org/whl/cpu
 
-torch==2.4.0+cpu
-guidellm
+guidellm[all]
 requests
 pyjwt
-pillow
-imageio
-imageio-ffmpeg

--- a/requirements/benchmarks-guidellm.txt
+++ b/requirements/benchmarks-guidellm.txt
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# Dependencies for the BENCHMARKS_GUIDELLM workflow venv (Python 3.11).
+# Consumed by the BENCHMARKS_GUIDELLM VenvConfig in workflows/workflow_venvs.py.
+#
+# GuideLLM is a benchmarking harness for LLM serving stacks.
+# Repository: https://github.com/neuralmagic/guidellm
+#
+# torch is pulled in by transitive deps (e.g. prompt_client) and is pinned to
+# a CPU build to keep the venv lightweight.
+
+-c constraints.txt
+--extra-index-url https://download.pytorch.org/whl/cpu
+
+torch==2.4.0+cpu
+guidellm
+requests
+pyjwt
+datasets
+pillow
+imageio
+imageio-ffmpeg

--- a/requirements/benchmarks-guidellm.txt
+++ b/requirements/benchmarks-guidellm.txt
@@ -8,8 +8,19 @@
 # GuideLLM is a benchmarking harness for LLM serving stacks.
 # Repository: https://github.com/neuralmagic/guidellm
 #
-# torch is pulled in by transitive deps (e.g. prompt_client) and is pinned to
-# a CPU build to keep the venv lightweight.
+# Extra runtime deps below are not covered by guidellm core or
+# guidellm[recommended] (which is just [perf, tokenizers]):
+#   - requests, pyjwt: used by the wrapper benchmarking/run_guidellm_benchmarks.py
+#     for JWT auth-token generation and PromptClient server health checks
+#     (guidellm itself ships its own httpx client, not requests).
+#   - pillow: required by guidellm's `encode_media` preprocessor for image
+#     omni_modal scenarios (part of guidellm's [vision] extra).
+#   - imageio, imageio-ffmpeg: video decoding backends for video omni_modal
+#     scenarios. guidellm's [audio] extra pulls torchcodec which pins
+#     torch==2.10.*, conflicting with the torch==2.4.0+cpu pinned below, so
+#     imageio backends are installed instead.
+#
+# torch is pinned to a CPU build to keep the venv lightweight.
 
 -c constraints.txt
 --extra-index-url https://download.pytorch.org/whl/cpu
@@ -18,7 +29,6 @@ torch==2.4.0+cpu
 guidellm
 requests
 pyjwt
-datasets
 pillow
 imageio
 imageio-ffmpeg

--- a/run.py
+++ b/run.py
@@ -253,9 +253,11 @@ def parse_arguments():
     parser.add_argument(
         "--tools",
         type=str,
-        choices=["vllm", "genai", "aiperf"],
+        choices=["vllm", "genai", "aiperf", "guidellm"],
         default="vllm",
-        help="Benchmarking tool to use: 'vllm' for vLLM benchmark_serving.py (default), 'genai' for genai-perf (Triton SDK), 'aiperf' for AIPerf (https://github.com/ai-dynamo/aiperf)",
+        help="Benchmarking tool to use: 'vllm' for vLLM benchmark_serving.py (default), "
+        "'genai' for genai-perf (Triton SDK), 'aiperf' for AIPerf (https://github.com/ai-dynamo/aiperf), "
+        "'guidellm' for GuideLLM (https://github.com/vllm-project/guidellm).",
     )
     parser.add_argument(
         "--no-auth",

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -318,6 +318,8 @@ class TestModelSpecCliArgsCompatibility:
             "/opt/tt-metal",
             "--vllm-dir",
             "/opt/vllm",
+            "--tools",
+            "guidellm",
         ]
         with patch("sys.argv", ["run.py"] + full_args):
             args = parse_arguments()
@@ -338,6 +340,7 @@ class TestModelSpecCliArgsCompatibility:
         assert args.concurrency_sweeps is True
         assert args.tt_metal_home == "/opt/tt-metal"
         assert args.vllm_dir == "/opt/vllm"
+        assert args.tools == "guidellm"
 
         # Test defaults
         with patch("sys.argv", ["run.py"] + base_args):

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -189,6 +189,30 @@ class TestArgumentParsing:
                     or "error" in stderr_output.lower()
                 )
 
+    @pytest.mark.parametrize(
+        "invalid_value",
+        [
+            "not-a-real-tool",
+            "VLLM",  # case-sensitive: uppercase variant should be rejected
+            "guidellm ",  # trailing whitespace should be rejected
+            "",  # empty string
+        ],
+    )
+    def test_invalid_tools_choice(self, base_args, invalid_value):
+        """--tools must be restricted to the documented choice set."""
+        full_args = base_args + ["--tools", invalid_value]
+        with patch("sys.argv", ["run.py"] + full_args):
+            with patch("sys.stderr") as mock_stderr:
+                with pytest.raises(SystemExit) as exc_info:
+                    parse_arguments()
+
+                assert exc_info.value.code == 2
+
+                stderr_calls = [str(call) for call in mock_stderr.write.call_args_list]
+                stderr_output = "".join(stderr_calls).lower()
+                assert "--tools" in stderr_output
+                assert "invalid choice" in stderr_output
+
 
 class TestModelSpecCliArgsCompatibility:
     def test_populate_model_spec_cli_args_uses_runtime_config_values(self):

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -459,6 +459,7 @@ class TestInstallRequirementsReturnBool:
             "benchmarks-run-script.txt",
             "benchmarks-vllm.txt",
             "benchmarks-aiperf.txt",
+            "benchmarks-guidellm.txt",
             "reports-run-script.txt",
             "hf-setup.txt",
             "system-software-validation.txt",

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -657,6 +657,10 @@ def aiperf_benchmark_generate_report(
         Config key includes:
         - isl, osl, concurrency, num_requests (base params)
         - images, height, width (for image benchmarks - treated as separate configs)
+        - sweep_index (for GuideLLM sweep profiles - keeps each sweep point as
+          a distinct config so points sharing (isl, osl, maxcon, n) are not
+          collapsed). Files without a `_sweep-K` suffix get sweep_index=None,
+          preserving original AIPerf/vLLM/GenAI dedup behavior.
         """
         config_to_file = {}
         # Sort in reverse order so latest files come first
@@ -671,12 +675,14 @@ def aiperf_benchmark_generate_report(
                 img_match = re.search(
                     r"images-(\d+)_height-(\d+)_width-(\d+)", filename
                 )
+                sweep_match = re.search(r"_sweep-(\d+)", filename)
+                sweep_idx = int(sweep_match.group(1)) if sweep_match else None
                 if img_match:
                     images, height, width = map(int, img_match.groups())
-                    config_key = (isl, osl, con, n, images, height, width)
+                    config_key = (isl, osl, con, n, images, height, width, sweep_idx)
                 else:
                     # Text-only benchmark
-                    config_key = (isl, osl, con, n, 0, 0, 0)
+                    config_key = (isl, osl, con, n, 0, 0, 0, sweep_idx)
 
                 # Only keep the first (latest) file for each config
                 if config_key not in config_to_file:
@@ -1224,6 +1230,30 @@ def aiperf_benchmark_generate_report(
     return release_str, all_aiperf_results, disp_md_path, text_data_file_path
 
 
+def guidellm_benchmark_generate_report(
+    args, server_mode, model_spec, report_id, metadata={}
+):
+    """Thin orchestration shim for GuideLLM report generation.
+
+    All GuideLLM-specific logic (discovery, percentile table, native-style
+    tables sourced from `benchmarks.json`, CSV output) lives in
+    `benchmarking/guidellm_report.py` so this orchestrator stays free of any
+    one tool's reporting details. When `run_reports.py` is refactored, this
+    shim is the only thing that needs to be re-wired for GuideLLM.
+    """
+    from benchmarking.guidellm_report import generate_guidellm_report
+
+    return generate_guidellm_report(
+        args=args,
+        model_spec=model_spec,
+        report_id=report_id,
+        metadata=metadata,
+        benchmarks_output_dir=Path(
+            f"{get_default_workflow_root_log_dir()}/benchmarks_output"
+        ),
+    )
+
+
 def genai_perf_benchmark_generate_report(
     args, server_mode, model_spec, report_id, metadata={}
 ):
@@ -1252,7 +1282,11 @@ def genai_perf_benchmark_generate_report(
 
     # Helper function to keep only the latest file for each config
     def deduplicate_by_config(files):
-        """Keep only the latest file for each unique benchmark configuration."""
+        """Keep only the latest file for each unique benchmark configuration.
+
+        Sweep index (from GuideLLM `_sweep-K` filename suffix) is part of the
+        key so sweep points sharing (isl, osl, maxcon, n) are preserved.
+        """
         config_to_file = {}
         # Sort in reverse order so latest files come first
         for filepath in sorted(files, reverse=True):
@@ -1265,11 +1299,13 @@ def genai_perf_benchmark_generate_report(
                 image_match = re.search(
                     r"images-(\d+)_height-(\d+)_width-(\d+)", filename
                 )
+                sweep_match = re.search(r"_sweep-(\d+)", filename)
+                sweep_idx = sweep_match.group(1) if sweep_match else None
                 if image_match:
                     images, height, width = image_match.groups()
-                    config_key = (isl, osl, maxcon, n, images, height, width)
+                    config_key = (isl, osl, maxcon, n, images, height, width, sweep_idx)
                 else:
-                    config_key = (isl, osl, maxcon, n)
+                    config_key = (isl, osl, maxcon, n, sweep_idx)
 
                 # Only keep the first (latest) file for each config
                 if config_key not in config_to_file:
@@ -1516,12 +1552,14 @@ def genai_perf_benchmark_generate_report(
 
 
 def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata={}):
-    # Look for vLLM, genai-perf, and AIPerf benchmark files (all stack together)
-    # All benchmark tools now use the same unified output directory
+    # Look for vLLM, genai-perf, AIPerf, and GuideLLM benchmark files
+    # (all stack together). All benchmark tools now use the same unified
+    # output directory.
     vllm_pattern = f"benchmark_{model_spec.model_id}_*.json"
     genai_pattern = f"genai_benchmark_{model_spec.model_id}_*.json"
     aiperf_pattern = f"aiperf_benchmark_{model_spec.model_id}_*.json"
     structured_pattern = f"benchmark_structured_{model_spec.model_id}_*.json"
+    guidellm_pattern = f"guidellm_benchmark_{model_spec.model_id}_*.json"
 
     benchmarks_output_dir = f"{get_default_workflow_root_log_dir()}/benchmarks_output"
 
@@ -1529,12 +1567,13 @@ def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata
     genai_files = glob(f"{benchmarks_output_dir}/{genai_pattern}")
     aiperf_files = glob(f"{benchmarks_output_dir}/{aiperf_pattern}")
     structured_files = glob(f"{benchmarks_output_dir}/{structured_pattern}")
+    guidellm_files = glob(f"{benchmarks_output_dir}/{guidellm_pattern}")
     # vllm_pattern also matches structured files; subtract them so they're processed once.
     vllm_files = [f for f in vllm_files if f not in set(structured_files)]
 
     # Mirror the runtime gate from run_benchmarks.py: when only structured-output
-    # tasks were executed, the report should not surface stale text/vlm/aiperf
-    # JSONs left in the shared benchmarks_output/ directory by prior runs.
+    # tasks were executed, the report should not surface stale text/vlm/aiperf/
+    # guidellm JSONs left in the shared benchmarks_output/ directory by prior runs.
     if os.getenv("ONLY_STRUCTURED_OUTPUT_BENCHMARKS"):
         logger.info(
             "ONLY_STRUCTURED_OUTPUT_BENCHMARKS set; restricting report to "
@@ -1543,16 +1582,23 @@ def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata
         vllm_files = []
         genai_files = []
         aiperf_files = []
+        guidellm_files = []
 
     logger.info(
         f"Found {len(vllm_files)} vLLM, {len(genai_files)} genai-perf, "
-        f"{len(aiperf_files)} AIPerf, {len(structured_files)} structured-output "
+        f"{len(aiperf_files)} AIPerf, {len(structured_files)} structured-output, "
+        f"and {len(guidellm_files)} GuideLLM "
         "benchmark files before deduplication"
     )
 
     # Deduplicate files - keep only latest run for each config
     def deduplicate_by_config(files):
-        """Keep only the latest file for each unique benchmark configuration."""
+        """Keep only the latest file for each unique benchmark configuration.
+
+        GuideLLM sweep points (filenames carrying a `_sweep-K` suffix) are
+        kept distinct via sweep_index in the config key. Files without that
+        suffix get sweep_index=None, preserving prior dedup behavior.
+        """
         config_to_file = {}
         # Sort in reverse order so latest files come first
         for filepath in sorted(files, reverse=True):
@@ -1566,12 +1612,14 @@ def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata
                 img_match = re.search(
                     r"images-(\d+)_height-(\d+)_width-(\d+)", filename
                 )
+                sweep_match = re.search(r"_sweep-(\d+)", filename)
+                sweep_idx = int(sweep_match.group(1)) if sweep_match else None
                 if img_match:
                     images, height, width = map(int, img_match.groups())
-                    config_key = (isl, osl, con, n, images, height, width)
+                    config_key = (isl, osl, con, n, images, height, width, sweep_idx)
                 else:
                     # Text-only benchmark
-                    config_key = (isl, osl, con, n, 0, 0, 0)
+                    config_key = (isl, osl, con, n, 0, 0, 0, sweep_idx)
 
                 # Only keep the first (latest) file for each config
                 if config_key not in config_to_file:
@@ -1584,13 +1632,21 @@ def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata
     vllm_files = deduplicate_by_config(vllm_files)
     genai_files = deduplicate_by_config(genai_files)
     aiperf_files = deduplicate_by_config(aiperf_files)
+    guidellm_files = deduplicate_by_config(guidellm_files)
 
     logger.info(
-        f"After deduplication: {len(vllm_files)} vLLM, {len(genai_files)} genai-perf, {len(aiperf_files)} AIPerf benchmark files"
+        f"After deduplication: {len(vllm_files)} vLLM, {len(genai_files)} genai-perf, "
+        f"{len(aiperf_files)} AIPerf, {len(guidellm_files)} GuideLLM benchmark files"
     )
     output_dir = Path(args.output_path) / "benchmarks"
 
-    if not vllm_files and not genai_files and not aiperf_files and not structured_files:
+    if (
+        not vllm_files
+        and not genai_files
+        and not aiperf_files
+        and not structured_files
+        and not guidellm_files
+    ):
         logger.info("No benchmark files found. Skipping.")
         return (
             "",
@@ -1787,6 +1843,35 @@ def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata
             genai_vlm_md = get_markdown_table(genai_vlm_display)
             image_sections.append(
                 f"#### GenAI-Perf VLM Benchmark Sweeps for {model_spec.model_name} on {args.device}\n\n{genai_vlm_md}"
+            )
+
+    # Process GuideLLM benchmarks
+    if guidellm_files:
+        _, guidellm_release_raw, _, _ = benchmark_generate_report_helper(
+            guidellm_files, output_dir, report_id, metadata, model_spec=model_spec
+        )
+        all_tool_results.extend(guidellm_release_raw)
+
+        # Separate text and vlm for GuideLLM (omni_modal image runs land in vlm)
+        guidellm_text = [
+            r for r in guidellm_release_raw if r.get("task_type") == "text"
+        ]
+        guidellm_vlm = [
+            r for r in guidellm_release_raw if r.get("task_type") == "vlm"
+        ]
+
+        if guidellm_text:
+            guidellm_text_display = [create_display_dict(r) for r in guidellm_text]
+            guidellm_text_md = get_markdown_table(guidellm_text_display)
+            text_sections.append(
+                f"#### GuideLLM Text-to-Text Performance Benchmark Sweeps for {model_spec.model_name} on {args.device}\n\n{guidellm_text_md}"
+            )
+
+        if guidellm_vlm:
+            guidellm_vlm_display = [create_vlm_display_dict(r) for r in guidellm_vlm]
+            guidellm_vlm_md = get_markdown_table(guidellm_vlm_display)
+            image_sections.append(
+                f"#### GuideLLM VLM Benchmark Sweeps for {model_spec.model_name} on {args.device}\n\n{guidellm_vlm_md}"
             )
 
     # Combine sections: text, image, audio, embedding, then cnn (matching original order)
@@ -3579,6 +3664,16 @@ def main():
         simple_args, server_mode, model_spec, report_id=report_id, metadata=metadata
     )
 
+    # generate GuideLLM benchmarks report (separate detailed report)
+    (
+        guidellm_release_str,
+        guidellm_release_data,
+        guidellm_disp_md_path,
+        guidellm_data_file_path,
+    ) = guidellm_benchmark_generate_report(
+        simple_args, server_mode, model_spec, report_id=report_id, metadata=metadata
+    )
+
     # generate evals report
     evals_release_str, evals_release_data, evals_disp_md_path, evals_data_file_path = (
         evals_generate_report(
@@ -3635,6 +3730,8 @@ def main():
         all_benchmarks_str += aiperf_release_str + "\n\n"
     if genai_perf_release_str:
         all_benchmarks_str += genai_perf_release_str + "\n\n"
+    if guidellm_release_str:
+        all_benchmarks_str += guidellm_release_str + "\n\n"
 
     release_output_dir = Path(args.output_path) / "release"
     release_output_dir.mkdir(parents=True, exist_ok=True)
@@ -3846,6 +3943,18 @@ def main():
             except Exception as e:
                 logger.warning(f"Could not read AIPerf CSV data: {e}")
 
+        # Read GuideLLM benchmark data if available
+        guidellm_detailed_data = None
+        if guidellm_data_file_path:
+            try:
+                with open(
+                    guidellm_data_file_path, "r", encoding="utf-8"
+                ) as csv_file:
+                    csv_reader = csv.DictReader(csv_file)
+                    guidellm_detailed_data = list(csv_reader)
+            except Exception as e:
+                logger.warning(f"Could not read GuideLLM CSV data: {e}")
+
         # Read server tests data if available
         server_tests_data = []
         server_tests_path = Path(project_root) / "test_reports"
@@ -3882,6 +3991,12 @@ def main():
             ],
             "aiperf_benchmarks_detailed": aiperf_detailed_data
             if aiperf_detailed_data
+            else [],
+            "guidellm_benchmarks": guidellm_release_data
+            if guidellm_release_data
+            else [],
+            "guidellm_benchmarks_detailed": guidellm_detailed_data
+            if guidellm_detailed_data
             else [],
         }
 

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -1856,9 +1856,7 @@ def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata
         guidellm_text = [
             r for r in guidellm_release_raw if r.get("task_type") == "text"
         ]
-        guidellm_vlm = [
-            r for r in guidellm_release_raw if r.get("task_type") == "vlm"
-        ]
+        guidellm_vlm = [r for r in guidellm_release_raw if r.get("task_type") == "vlm"]
 
         if guidellm_text:
             guidellm_text_display = [create_display_dict(r) for r in guidellm_text]
@@ -3947,9 +3945,7 @@ def main():
         guidellm_detailed_data = None
         if guidellm_data_file_path:
             try:
-                with open(
-                    guidellm_data_file_path, "r", encoding="utf-8"
-                ) as csv_file:
+                with open(guidellm_data_file_path, "r", encoding="utf-8") as csv_file:
                     csv_reader = csv.DictReader(csv_file)
                     guidellm_detailed_data = list(csv_reader)
             except Exception as e:

--- a/workflows/run_workflows.py
+++ b/workflows/run_workflows.py
@@ -12,6 +12,7 @@ from server_tests.test_config import TEST_CONFIGS
 from workflows.utils import ensure_readwriteable_dir, run_command
 from workflows.workflow_config import (
     WORKFLOW_BENCHMARKS_AIPERF_CONFIG,
+    WORKFLOW_BENCHMARKS_GUIDELLM_CONFIG,
     WORKFLOW_CONFIGS,
     WorkflowType,
     get_default_workflow_root_log_dir,
@@ -37,6 +38,8 @@ class WorkflowSetup:
         tools = getattr(self.runtime_config, "tools", "vllm")
         if _workflow_type == WorkflowType.BENCHMARKS and tools == "aiperf":
             self.workflow_config = WORKFLOW_BENCHMARKS_AIPERF_CONFIG
+        elif _workflow_type == WorkflowType.BENCHMARKS and tools == "guidellm":
+            self.workflow_config = WORKFLOW_BENCHMARKS_GUIDELLM_CONFIG
         else:
             self.workflow_config = WORKFLOW_CONFIGS[_workflow_type]
 

--- a/workflows/workflow_config.py
+++ b/workflows/workflow_config.py
@@ -68,7 +68,9 @@ WORKFLOW_BENCHMARKS_AIPERF_CONFIG = WorkflowConfig(
 )
 WORKFLOW_BENCHMARKS_GUIDELLM_CONFIG = WorkflowConfig(
     workflow_type=WorkflowType.BENCHMARKS,
-    run_script_path=get_repo_root_path() / "benchmarking" / "run_guidellm_benchmarks.py",
+    run_script_path=get_repo_root_path()
+    / "benchmarking"
+    / "run_guidellm_benchmarks.py",
     workflow_run_script_venv_type=WorkflowVenvType.BENCHMARKS_GUIDELLM,
     # Use default name="benchmarks" for unified output directory across tools.
 )

--- a/workflows/workflow_config.py
+++ b/workflows/workflow_config.py
@@ -66,6 +66,12 @@ WORKFLOW_BENCHMARKS_AIPERF_CONFIG = WorkflowConfig(
     workflow_run_script_venv_type=WorkflowVenvType.BENCHMARKS_AIPERF,
     # Use default name="benchmarks" (same as vLLM and GenAI-Perf) for unified output directory
 )
+WORKFLOW_BENCHMARKS_GUIDELLM_CONFIG = WorkflowConfig(
+    workflow_type=WorkflowType.BENCHMARKS,
+    run_script_path=get_repo_root_path() / "benchmarking" / "run_guidellm_benchmarks.py",
+    workflow_run_script_venv_type=WorkflowVenvType.BENCHMARKS_GUIDELLM,
+    # Use default name="benchmarks" for unified output directory across tools.
+)
 WORKFLOW_EVALS_CONFIG = WorkflowConfig(
     workflow_type=WorkflowType.EVALS,
     run_script_path=get_repo_root_path() / "evals" / "run_evals.py",

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -43,6 +43,7 @@ class WorkflowVenvType(IntEnum):
     BENCHMARKS_VLLM = auto()
     BENCHMARKS_GENAI_PERF = auto()
     BENCHMARKS_AIPERF = auto()
+    BENCHMARKS_GUIDELLM = auto()
     HF_SETUP = auto()
     SERVER = auto()
     TT_SMI = auto()

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -373,6 +373,11 @@ _venv_config_list = [
         extra_dirs=("artifacts",),
         python_version="3.11",
     ),
+    VenvConfig(
+        venv_type=WorkflowVenvType.BENCHMARKS_GUIDELLM,
+        requirements_file="benchmarks-guidellm.txt",
+        python_version="3.11",
+    ),
     # No pip; directory and/or runtime check
     VenvConfig(
         venv_type=WorkflowVenvType.BENCHMARKS_VIDEO,


### PR DESCRIPTION
# Add GuideLLM as an opt-in Benchmarking Tool

## Summary

Integrates [GuideLLM](https://github.com/vllm-project/guidellm) into the inference-server benchmarking stack alongside the existing `aiperf` and `genai-perf` tools. GuideLLM is opt-in via `run.py --tools guidellm`, runs in its own venv, supports multi-turn chat / custom dataset / omni-modal scenarios, and is fully wired into the unified report (`workflows/run_reports.py`) — including per-sweep-point ingestion and the five native GuideLLM-style summary tables, sourced directly from each scenario's `benchmarks.json`.

All GuideLLM report logic is encapsulated in a single new module (`benchmarking/guidellm_report.py`) so future refactors of `run_reports.py` only need to keep one delegating call alive.

## What changed, by area

### 1. CLI / workflow plumbing — opt-in `--tools guidellm`

- `run.py` — adds `guidellm` to the valid `--tools` choices.
- `workflows/workflow_types.py` — new `WorkflowVenvType.BENCHMARKS_GUIDELLM`.
- `workflows/workflow_config.py` — new `WORKFLOW_BENCHMARKS_GUIDELLM_CONFIG` linking the workflow to the runner script and venv.
- `workflows/run_workflows.py` — routes `--workflow benchmarks --tools guidellm` to the GuideLLM config.
- `workflows/workflow_venvs.py` — new `setup_benchmarks_guidellm` installer (`guidellm`, `torch`, `requests`, `pyjwt`, `datasets`, `pillow`, `imageio`, `imageio-ffmpeg`).
- `tests/test_run_arguments.py`, `tests/test_run_command.py` — extended parametrized coverage.
- `benchmarking/README.md`, `docs/benchmarking_tools.md` — list GuideLLM in the supported tools.

### 2. GuideLLM runner — `benchmarking/run_guidellm_benchmarks.py`

- **Initial runner** — scenario parsing (`multi_turn_chat`, `custom_dataset`, `omni_modal_*`), output to `benchmarks_output/guidellm_<scenario>/benchmarks.json`.
- **Auth fix** — `build_auth_token` now uses `token_id="debug-test"` to match the server's exact-string check (was `"guidellm-bench"`, which produced `401 Unauthorized`).
- **GuideLLM → vLLM-compatible adapter** — `_stat`, `_adapt_one_benchmark`, `adapt_guidellm_to_vllm_metrics` flatten each benchmark point in `benchmarks.json` (TTFT/TPOT/ITL/E2EL mean/median/p99/std, throughput, token totals) and convert `request_latency` from seconds to ms.
- **Per-sweep-point emitter** — `emit_normalized_guidellm_result` writes one normalized `guidellm_benchmark_<model_id>_<ts>_isl-X_osl-Y_maxcon-Z_n-N[_sweep-K].json` per benchmark point into the unified `benchmarks_output/`. The `_sweep-K` suffix is added only for sweep profiles, preserving the existing single-point filename shape; `source_benchmarks_json`, `sweep_index`, `sweep_size`, `strategy_type`, `strategy_rate` are preserved for downstream traceability.
- `main` calls the emitter for each scenario after a successful run.

### 3. Filename / file processing — `benchmarking/summary_report.py`

- Two new GuideLLM regexes (`guidellm_image_pattern`, `guidellm_text_pattern`) recognize the normalized filenames including the optional `_sweep-(\d+)` segment, returning a parsed `task_type` (`text` / `vlm` / `image`) and `sweep_index`.
- `process_benchmark_file` — the `aiperf` branch now also handles `backend == "guidellm"` (identical on-disk schema), with the `backend` tag carried through to the report instead of hard-coded `"aiperf"`.

### 4. Report integration — `workflows/run_reports.py`

- All four `deduplicate_by_config` helpers (in `aiperf_benchmark_generate_report`, `genai_perf_benchmark_generate_report`, `benchmark_generate_report`, and the legacy variant) now parse the optional `_sweep-K` suffix and include `sweep_index` in the dedup key. Files without the suffix get `sweep_index=None`, preserving prior dedup behavior for vLLM/AIPerf/GenAI-Perf.
- **Combined report (`benchmark_generate_report`)** — adds GuideLLM globbing/dedup, refuses to short-circuit when only GuideLLM files exist, and appends GuideLLM Text and VLM sections to `text_sections` / `image_sections`.
- **`main`** — calls a new `guidellm_benchmark_generate_report`, appends `guidellm_release_str` to `all_benchmarks_str`, and adds `guidellm_benchmarks` + `guidellm_benchmarks_detailed` to the final JSON.
- **`guidellm_benchmark_generate_report` is now a 12-line shim** that delegates to `benchmarking/guidellm_report.generate_guidellm_report`

### 5. Encapsulated GuideLLM report module — **new file** `benchmarking/guidellm_report.py`

Owns *all* GuideLLM-specific report logic behind a single entry point with the same return contract as `aiperf_benchmark_generate_report` / `genai_perf_benchmark_generate_report`:

```python
generate_guidellm_report(args, model_spec, report_id, metadata, benchmarks_output_dir)
    -> (release_str, results, md_path, csv_path)
```

## How to test

```bash
# Run a sweep benchmark (exercises sweep-point emission + report path)
python run.py --model Qwen3-8B --device n300 --workflow benchmarks \
  --docker-server \
  --tools guidellm \
  --workflow-args "scenarios=multi_turn_chat multiturn_profile=sweep multiturn_max_seconds=30 multiturn_max_requests=200"

# Generate the report
python run.py --model Qwen3-8B --device n300 --workflow reports
```

Expected Outputs:

- `workflow_logs/benchmarks_output/guidellm_benchmark_<model_id>_*_sweep-K.json` — one per sweep point.
- `workflow_logs/.../benchmarks_guidellm/guidellm_benchmark_display_<report_id>.md` containing the percentile summary table followed by five native GuideLLM tables per scenario.
- Final combined report includes a "GuideLLM Text-to-Text Performance Benchmark Sweeps" section and a top-level `guidellm_benchmarks` / `guidellm_benchmarks_detailed` block in the JSON output.

**Co-authored-by**: Claude 🤖