### PR TITLE
Refactor SessionManager: immediate cancel+dealloc on close, simplified state machine

### DIFF
--- a/tt-media-server/cpp_server/include/api/llm_controller.hpp
+++ b/tt-media-server/cpp_server/include/api/llm_controller.hpp
@@ -98,13 +98,16 @@ class LLMController : public drogon::HttpController<LLMController> {
   };
 
   /**
-   * Validate/create session, assign slot, populate request fields.
-   * Throws std::runtime_error if session creation fails.
+   * Validate/create session, mark it in-flight, and populate request fields.
+   * cancelFn is stored atomically with the in-flight state so that a concurrent
+   * closeSession always has a consistent view. Pass null for non-streaming
+   * requests that cannot be cancelled mid-flight.
    */
   void resolveSession(std::shared_ptr<domain::LLMRequest> req,
                       trantor::EventLoop* loop,
                       std::function<void(SessionInfo)> onResolved,
-                      std::function<void(const SessionError&)> onError) const;
+                      std::function<void(const SessionError&)> onError,
+                      std::function<void()> cancelFn = nullptr) const;
 
   /**
    * Determine if disaggregated prefill should be used for this request.

--- a/tt-media-server/cpp_server/include/domain/session.hpp
+++ b/tt-media-server/cpp_server/include/domain/session.hpp
@@ -13,47 +13,30 @@
 
 namespace tt::domain {
 
-/**
- * Lifecycle state of a Session.
- *
- * Transitions:
- *   IDLE            --(markInFlight)-------> IN_FLIGHT
- *   IN_FLIGHT       --(clearInFlight)------> IDLE
- *   IN_FLIGHT       --(markCloseRequested)-> CLOSE_REQUESTED
- *   CLOSE_REQUESTED --(clearInFlight)------> CLOSING
- */
+// Lifecycle state of a Session.  IDLE <--(clearInFlight)--> IN_FLIGHT.
 enum class SessionState {
-  IDLE,             // no active request
-  IN_FLIGHT,        // request actively being processed
-  CLOSE_REQUESTED,  // close requested while in-flight; waiting for request to
-                    // finish
-  CLOSING,          // request finished; slot deallocation pending
+  IDLE,       // no active request
+  IN_FLIGHT,  // request actively being processed
 };
 
 class Session {
  public:
   explicit Session(uint32_t slotId = INVALID_SLOT_ID);
 
-  std::string getSessionId() const { return session_id_; }
+  const std::string& getSessionId() const { return session_id_; }
   uint32_t getSlotId() const { return slot_id_; }
   void setSlotId(uint32_t slotId) { slot_id_ = slotId; }
   bool hasSlot() const { return slot_id_ != INVALID_SLOT_ID; }
 
   bool isIdle() const { return state_ == SessionState::IDLE; }
   bool isInFlight() const { return state_ == SessionState::IN_FLIGHT; }
-  bool isCloseRequested() const {
-    return state_ == SessionState::CLOSE_REQUESTED;
-  }
-  bool isClosing() const { return state_ == SessionState::CLOSING; }
 
   SessionState getState() const { return state_; }
 
   // Transition methods return false (without changing state) if the
   // precondition is not met.
-  bool markInFlight();  // IDLE            -> IN_FLIGHT
-  bool
-  clearInFlight();  // IN_FLIGHT        -> IDLE  |  CLOSE_REQUESTED -> CLOSING
-  bool markCloseRequested();  // IN_FLIGHT        -> CLOSE_REQUESTED
+  bool markInFlight();   // IDLE      -> IN_FLIGHT
+  bool clearInFlight();  // IN_FLIGHT -> IDLE
 
   std::chrono::system_clock::time_point getLastActivityTime() const {
     return last_activity_time_;

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -84,19 +84,6 @@ class SessionManager {
     trantor::EventLoop* eventLoop = nullptr;
     int attemptsRemaining = 0;
     std::chrono::steady_clock::time_point retryAt{};
-
-    PendingAllocation() = default;
-
-    PendingAllocation(
-        const tt::domain::Session& session,
-        std::function<void(const tt::domain::Session&)> onCompletion,
-        std::function<void(std::string_view errorMessage)> onError,
-        trantor::EventLoop* eventLoop, int attemptsRemaining)
-        : session(session),
-          onCompletion(onCompletion),
-          onError(onError),
-          eventLoop(eventLoop),
-          attemptsRemaining(attemptsRemaining) {}
   };
 
   struct DeferredDealloc {

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -58,19 +58,29 @@ class SessionManager {
   CloseSessionResult closeSession(const std::string& sessionId);
   bool assignSlotId(const std::string& sessionId, uint32_t slotId);
   uint32_t getSlotIdBySessionId(const std::string& sessionId) const;
-  uint32_t acquireSessionSlot(const std::string& sessionId);
+
+  // Mark the session in-flight and register the cancel function atomically.
+  // The cancel function is invoked immediately if closeSession is called while
+  // the session is in-flight. Pass a null function for non-cancellable requests.
+  // Returns the slot ID assigned to the session (INVALID_SLOT_ID if not set).
+  uint32_t acquireInFlight(const std::string& sessionId,
+                           std::function<void()> cancelFn);
+
   std::optional<domain::Session> getSession(const std::string& sessionId) const;
   size_t getActiveSessionCount() const;
 
   void releaseInFlight(const std::string& sessionId);
 
-  // Register a callback to be invoked immediately if closeSession is called
-  // while the session has an in-flight request. The callback should abort the
-  // active request. It is cleared automatically once the session is released.
-  void setSessionAbortCallback(const std::string& sessionId,
-                               std::function<void()> onAbort);
-
  private:
+  // Bundles a session with the function needed to cancel its active request.
+  // cancelFn is set when the session is in-flight and null when idle. Keeping
+  // both in the same map entry ensures they are always read and written under
+  // the same lock — no risk of the two getting out of sync.
+  struct ManagedSession {
+    domain::Session session;
+    std::function<void()> cancelFn;
+  };
+
   struct PendingAllocation {
     tt::domain::Session session;
     std::function<void(const tt::domain::Session&)> onCompletion;
@@ -109,8 +119,7 @@ class SessionManager {
   void handleMemoryResult(const domain::ManageMemoryResult& result);
   void updateSessionCountMetric();
 
-  mutable utils::ConcurrentMap<std::string, domain::Session> sessions;
-  utils::ConcurrentMap<std::string, std::function<void()>> abortCallbacks_;
+  mutable utils::ConcurrentMap<std::string, ManagedSession> sessions;
 
   std::unique_ptr<ipc::MemoryRequestQueue> memoryRequestQueue;
   std::unique_ptr<ipc::MemoryResultQueue> memoryResultQueue;

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -71,7 +71,8 @@ class SessionManager {
   void releaseInFlight(const std::string& sessionId);
 
  private:
-  // cancelFn is null when idle, set atomically with in-flight state by acquireInFlight.
+  // cancelFn is null when idle, set atomically with in-flight state by
+  // acquireInFlight.
   struct ManagedSession {
     domain::Session session;
     std::function<void()> cancelFn;

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -59,10 +59,9 @@ class SessionManager {
   bool assignSlotId(const std::string& sessionId, uint32_t slotId);
   uint32_t getSlotIdBySessionId(const std::string& sessionId) const;
 
-  // Mark the session in-flight and register the cancel function atomically.
-  // The cancel function is invoked immediately if closeSession is called while
-  // the session is in-flight. Pass a null function for non-cancellable requests.
-  // Returns the slot ID assigned to the session (INVALID_SLOT_ID if not set).
+  // Marks the session in-flight and registers the cancel function atomically.
+  // The cancel function is invoked if closeSession is called while in-flight.
+  // Returns the assigned slot ID (INVALID_SLOT_ID if not yet allocated).
   uint32_t acquireInFlight(const std::string& sessionId,
                            std::function<void()> cancelFn);
 
@@ -72,10 +71,7 @@ class SessionManager {
   void releaseInFlight(const std::string& sessionId);
 
  private:
-  // Bundles a session with the function needed to cancel its active request.
-  // cancelFn is set when the session is in-flight and null when idle. Keeping
-  // both in the same map entry ensures they are always read and written under
-  // the same lock — no risk of the two getting out of sync.
+  // cancelFn is null when idle, set atomically with in-flight state by acquireInFlight.
   struct ManagedSession {
     domain::Session session;
     std::function<void()> cancelFn;

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -57,12 +57,14 @@ LLMController::LLMController() {
 void LLMController::resolveSession(
     std::shared_ptr<domain::LLMRequest> req, trantor::EventLoop* loop,
     std::function<void(SessionInfo)> onResolved,
-    std::function<void(const SessionError&)> onError) const {
+    std::function<void(const SessionError&)> onError,
+    std::function<void()> cancelFn) const {
   SessionInfo info;
 
   if (req->sessionId.has_value() && sessionManager) {
     try {
-      auto slotId = sessionManager->acquireSessionSlot(req->sessionId.value());
+      auto slotId = sessionManager->acquireInFlight(req->sessionId.value(),
+                                                    std::move(cancelFn));
       if (slotId != domain::INVALID_SLOT_ID) {
         req->slotId = slotId;
         req->continuation = true;
@@ -83,9 +85,11 @@ void LLMController::resolveSession(
 
   if (!req->sessionId.has_value() && sessionManager) {
     sessionManager->createSession(
-        [req, onResolved](const domain::Session& session) {
+        [req, onResolved, cancelFn = std::move(cancelFn),
+         mgr = sessionManager](const domain::Session& session) mutable {
           req->sessionId = session.getSessionId();
-          req->slotId = session.getSlotId();
+          req->slotId =
+              mgr->acquireInFlight(session.getSessionId(), std::move(cancelFn));
           SessionInfo info;
           onResolved(info);
         },
@@ -228,18 +232,15 @@ void LLMController::handleStreaming(
       std::make_shared<std::function<void(const drogon::HttpResponsePtr&)>>(
           std::move(callback));
 
+  auto cancelFn = [svc = service, taskId = reqPtr->task_id]() {
+    svc->abortRequest(taskId);
+  };
+
   resolveSession(
       reqPtr, loop,
       [this, reqPtr, cb, loop](SessionInfo sessionInfo) {
         try {
           service->preProcess(*reqPtr);
-
-          if (reqPtr->sessionId.has_value() && sessionManager) {
-            auto taskId = reqPtr->task_id;
-            sessionManager->setSessionAbortCallback(
-                reqPtr->sessionId.value(),
-                [svc = service, taskId]() { svc->abortRequest(taskId); });
-          }
 
           StreamParams params;
           params.completionId = "chatcmpl-" + std::to_string(reqPtr->task_id);
@@ -314,7 +315,8 @@ void LLMController::handleStreaming(
                   err.message,
               "service_unavailable"));
         }
-      });
+      },
+      std::move(cancelFn));
 }
 
 bool LLMController::shouldDoPrefillOnDecode(const domain::LLMRequest& request,

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -3,10 +3,9 @@
 
 #include "domain/session.hpp"
 
-#include <iomanip>
+#include <cstdio>
 #include <mutex>
 #include <random>
-#include <sstream>
 
 namespace tt::domain {
 
@@ -22,43 +21,29 @@ bool Session::markInFlight() {
 }
 
 bool Session::clearInFlight() {
-  if (state_ != SessionState::IN_FLIGHT &&
-      state_ != SessionState::CLOSE_REQUESTED) {
-    return false;
-  }
-  state_ = (state_ == SessionState::IN_FLIGHT) ? SessionState::IDLE
-                                               : SessionState::CLOSING;
-  return true;
-}
-
-bool Session::markCloseRequested() {
   if (state_ != SessionState::IN_FLIGHT) return false;
-  state_ = SessionState::CLOSE_REQUESTED;
+  state_ = SessionState::IDLE;
   return true;
 }
 
 std::string Session::generateUuid() {
   static std::mutex genMutex;
-  static std::random_device rd;
-  static std::mt19937_64 gen(rd());
+  static std::mt19937_64 gen(std::random_device{}());
 
   std::lock_guard<std::mutex> lock(genMutex);
+  uint64_t a = gen(), b = gen();
 
-  // Generate two 64-bit random numbers
-  uint64_t part1 = gen();
-  uint64_t part2 = gen();
+  a = (a & ~0xF000ULL) | 0x4000ULL;                        // version 4
+  b = (b & 0x3FFFFFFFFFFFFFFFULL) | 0x8000000000000000ULL;  // variant 10xx
 
-  // Format as UUID v4: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
-  std::ostringstream ss;
-  ss << std::hex << std::setfill('0');
-  ss << std::setw(8) << (part1 & 0xFFFFFFFF) << '-';
-  ss << std::setw(4) << ((part1 >> 32) & 0xFFFF) << '-';
-  ss << "4" << std::setw(3) << ((part1 >> 48) & 0x0FFF) << '-';
-  ss << std::setw(1) << (8 | ((part2 & 0x3))) << std::setw(3)
-     << ((part2 >> 2) & 0xFFF) << '-';
-  ss << std::setw(12) << ((part2 >> 14) & 0xFFFFFFFFFFFF);
-
-  return ss.str();
+  char buf[37];
+  snprintf(buf, sizeof(buf), "%08x-%04x-%04x-%04x-%012llx",
+           static_cast<uint32_t>(a >> 32),
+           static_cast<uint32_t>((a >> 16) & 0xFFFF),
+           static_cast<uint32_t>(a & 0xFFFF),
+           static_cast<uint32_t>(b >> 48),
+           static_cast<unsigned long long>(b & 0x0000FFFFFFFFFFFFULL));
+  return buf;
 }
 
 }  // namespace tt::domain

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -33,15 +33,14 @@ std::string Session::generateUuid() {
   std::lock_guard<std::mutex> lock(genMutex);
   uint64_t a = gen(), b = gen();
 
-  a = (a & ~0xF000ULL) | 0x4000ULL;                        // version 4
+  a = (a & ~0xF000ULL) | 0x4000ULL;                         // version 4
   b = (b & 0x3FFFFFFFFFFFFFFFULL) | 0x8000000000000000ULL;  // variant 10xx
 
   char buf[37];
   snprintf(buf, sizeof(buf), "%08x-%04x-%04x-%04x-%012llx",
            static_cast<uint32_t>(a >> 32),
            static_cast<uint32_t>((a >> 16) & 0xFFFF),
-           static_cast<uint32_t>(a & 0xFFFF),
-           static_cast<uint32_t>(b >> 48),
+           static_cast<uint32_t>(a & 0xFFFF), static_cast<uint32_t>(b >> 48),
            static_cast<unsigned long long>(b & 0x0000FFFFFFFFFFFFULL));
   return buf;
 }

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -95,9 +95,6 @@ CloseSessionResult SessionManager::closeSession(const std::string& sessionId) {
   TT_LOG_DEBUG("[SessionManager] closeSession called for sessionId={}",
                sessionId);
 
-  // Single atomic take: the session and its cancel function are read and
-  // removed together under one lock, so there is no window where a concurrent
-  // acquireInFlight could orphan a cancel callback in a separate map.
   auto ms = sessions.take(sessionId);
   if (!ms.has_value()) {
     TT_LOG_WARN("[SessionManager] Session not found: {}", sessionId);
@@ -149,22 +146,20 @@ uint32_t SessionManager::acquireInFlight(const std::string& sessionId,
   uint32_t result = domain::INVALID_SLOT_ID;
   bool wasInFlight = false;
 
-  // Mark in-flight and store the cancel function in a single lock acquisition
-  // so closeSession can never observe the session as in-flight without a cancel.
-  sessions.modify(sessionId,
-                  [&result, &wasInFlight, &cancelFn](ManagedSession& ms) {
-                    wasInFlight = !ms.session.isIdle();
-                    if (wasInFlight) {
-                      return;
-                    }
-                    ms.session.updateActivityTime();
-                    if (!ms.session.markInFlight()) {
-                      TT_LOG_WARN("[Session] markInFlight: unexpected state {}",
-                                  static_cast<int>(ms.session.getState()));
-                    }
-                    ms.cancelFn = std::move(cancelFn);
-                    result = ms.session.getSlotId();
-                  });
+  sessions.modify(
+      sessionId,
+      [&result, &wasInFlight, cancelFn = std::move(cancelFn)](
+          ManagedSession& ms) mutable {
+        wasInFlight = !ms.session.isIdle();
+        if (wasInFlight) return;
+        ms.session.updateActivityTime();
+        if (!ms.session.markInFlight()) {
+          TT_LOG_WARN("[Session] markInFlight: unexpected state {}",
+                      static_cast<int>(ms.session.getState()));
+        }
+        ms.cancelFn = std::move(cancelFn);
+        result = ms.session.getSlotId();
+      });
 
   if (wasInFlight) {
     TT_LOG_WARN(
@@ -189,10 +184,6 @@ std::optional<domain::Session> SessionManager::getSession(
 size_t SessionManager::getActiveSessionCount() const { return sessions.size(); }
 
 void SessionManager::releaseInFlight(const std::string& sessionId) {
-  // Session may already be gone if closeSession was called concurrently; that
-  // is expected — closeSession removes the session and sends cancel+dealloc
-  // immediately. Clear the cancel function and in-flight state together under
-  // one lock so no stale callback can be observed.
   bool found = sessions.modify(sessionId, [](ManagedSession& ms) {
     ms.cancelFn = nullptr;
     if (!ms.session.clearInFlight()) {
@@ -210,7 +201,6 @@ void SessionManager::releaseInFlight(const std::string& sessionId) {
   }
   TT_LOG_DEBUG("[SessionManager] Released in-flight for session {}", sessionId);
 }
-
 
 void SessionManager::evictOldSessions() {
   bool expected = false;
@@ -302,10 +292,7 @@ void SessionManager::sendDeallocRequest(const std::string& sessionId,
       "taskId={}",
       sessionId, slotId, task.taskId);
 
-  if (memoryRequestQueue->tryPush(task)) {
-    TT_LOG_DEBUG("[SessionManager] Sent dealloc request for session {} slot {}",
-                 sessionId, slotId);
-  } else {
+  if (!memoryRequestQueue->tryPush(task)) {
     TT_LOG_WARN(
         "[SessionManager] Dealloc queue full, deferring session {} slot {}",
         sessionId, slotId);
@@ -325,7 +312,7 @@ void SessionManager::createSession(
 
   if (slotId.has_value()) {
     domain::Session session(slotId.value());
-    sessions.insert(session.getSessionId(), ManagedSession{session, nullptr});
+    sessions.insert(session.getSessionId(), ManagedSession{session, {}});
     TT_LOG_INFO("[SessionManager] Created session with pre-assigned slot: {}",
                 slotId.value());
     updateSessionCountMetric();
@@ -387,11 +374,6 @@ void SessionManager::sendAsyncAllocationRequest(
           IPC_QUEUE_FULL_RETRY_DELAY.count());
       pendingAllocationsRetryQueue.push(std::move(pa));
     }
-  } else {
-    TT_LOG_DEBUG(
-        "[SessionManager] sendAsyncAllocationRequest: pushed taskId={} to "
-        "IPC queue",
-        task.taskId);
   }
 }
 
@@ -438,10 +420,8 @@ void SessionManager::handleMemoryResult(
                  !result.slotIds.empty();
   if (success) {
     pendingAllocation.session.setSlotId(result.slotIds.front());
-    // Insert as IDLE; the controller will call acquireInFlight to transition
-    // the session and register its cancel function atomically.
     sessions.insert(pendingAllocation.session.getSessionId(),
-                    ManagedSession{pendingAllocation.session, nullptr});
+                    ManagedSession{pendingAllocation.session, {}});
     TT_LOG_DEBUG(
         "[SessionManager] handleMemoryResult: SUCCESS sessionId={}, "
         "assigned slotId={}",
@@ -474,17 +454,10 @@ void SessionManager::handleMemoryResult(
 }
 
 void SessionManager::retryFailedDeallocs() {
-  auto deferredDeallocs = deferredDeallocQueue.drain();
-  if (!deferredDeallocs.empty()) {
-    TT_LOG_DEBUG("[SessionManager] retryFailedDeallocs: {} deferred deallocs",
-                 deferredDeallocs.size());
-  }
-  for (auto& deferredDealloc : deferredDeallocs) {
-    TT_LOG_DEBUG(
-        "[SessionManager] retryFailedDeallocs: retrying sessionId={}, "
-        "slotId={}",
-        deferredDealloc.sessionId, deferredDealloc.slotId);
-    sendDeallocRequest(deferredDealloc.sessionId, deferredDealloc.slotId);
+  for (auto& d : deferredDeallocQueue.drain()) {
+    TT_LOG_DEBUG("[SessionManager] retryFailedDeallocs: sessionId={}, slotId={}",
+                 d.sessionId, d.slotId);
+    sendDeallocRequest(d.sessionId, d.slotId);
   }
 }
 

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -144,8 +144,9 @@ bool SessionManager::assignSlotId(const std::string& sessionId,
 uint32_t SessionManager::getSlotIdBySessionId(
     const std::string& sessionId) const {
   uint32_t result = domain::INVALID_SLOT_ID;
-  sessions.modify(sessionId,
-                  [&result](ManagedSession& ms) { result = ms.session.getSlotId(); });
+  sessions.modify(sessionId, [&result](ManagedSession& ms) {
+    result = ms.session.getSlotId();
+  });
   TT_LOG_DEBUG(
       "[SessionManager] getSlotIdBySessionId sessionId={} -> slotId={}",
       sessionId, result);
@@ -157,17 +158,16 @@ uint32_t SessionManager::acquireInFlight(const std::string& sessionId,
   uint32_t result = domain::INVALID_SLOT_ID;
   bool wasInFlight = false;
 
-  sessions.modify(
-      sessionId,
-      [&result, &wasInFlight, cancelFn = std::move(cancelFn)](
-          ManagedSession& ms) mutable {
-        wasInFlight = !ms.session.isIdle();
-        if (wasInFlight) return;
-        ms.session.updateActivityTime();
-        ms.session.markInFlight();
-        ms.cancelFn = std::move(cancelFn);
-        result = ms.session.getSlotId();
-      });
+  sessions.modify(sessionId,
+                  [&result, &wasInFlight,
+                   cancelFn = std::move(cancelFn)](ManagedSession& ms) mutable {
+                    wasInFlight = !ms.session.isIdle();
+                    if (wasInFlight) return;
+                    ms.session.updateActivityTime();
+                    ms.session.markInFlight();
+                    ms.cancelFn = std::move(cancelFn);
+                    result = ms.session.getSlotId();
+                  });
 
   if (wasInFlight) {
     TT_LOG_WARN(
@@ -237,14 +237,16 @@ void SessionManager::evictOldSessions() {
   using Entry = std::pair<std::chrono::system_clock::time_point, std::string>;
   std::vector<Entry> candidates;
 
-  sessions.forEach([&candidates](const std::string& id, const ManagedSession& ms) {
-    if (ms.session.isIdle())
-      candidates.emplace_back(ms.session.getLastActivityTime(), id);
-  });
+  sessions.forEach(
+      [&candidates](const std::string& id, const ManagedSession& ms) {
+        if (ms.session.isIdle())
+          candidates.emplace_back(ms.session.getLastActivityTime(), id);
+      });
 
   size_t n = std::min(evictionCount, candidates.size());
-  std::nth_element(candidates.begin(), candidates.begin() + n, candidates.end(),
-                   [](const Entry& a, const Entry& b) { return a.first < b.first; });
+  std::nth_element(
+      candidates.begin(), candidates.begin() + n, candidates.end(),
+      [](const Entry& a, const Entry& b) { return a.first < b.first; });
   candidates.resize(n);
 
   TT_LOG_DEBUG("[SessionManager] evictOldSessions: {} candidates for eviction",
@@ -253,8 +255,9 @@ void SessionManager::evictOldSessions() {
   for (const auto& [_, sessionId] : candidates) {
     // A concurrent acquireInFlight call may mark the session in-flight
     // between the forEach above and here; takeIf skips it atomically.
-    auto ms = sessions.takeIf(
-        sessionId, [](const ManagedSession& ms) { return ms.session.isIdle(); });
+    auto ms = sessions.takeIf(sessionId, [](const ManagedSession& ms) {
+      return ms.session.isIdle();
+    });
     if (!ms.has_value()) {
       TT_LOG_DEBUG(
           "[SessionManager] evictOldSessions: session {} already removed or "
@@ -329,7 +332,8 @@ void SessionManager::createSession(
       .onCompletion = std::move(onCompletion),
       .onError = std::move(onError),
       .eventLoop = callerEventLoop,
-      .attemptsRemaining = static_cast<int>(tt::config::sessionAllocationMaxRetries()),
+      .attemptsRemaining =
+          static_cast<int>(tt::config::sessionAllocationMaxRetries()),
   };
 
   sendAsyncAllocationRequest(pendingAllocation);
@@ -452,8 +456,9 @@ void SessionManager::handleMemoryResult(
 
 void SessionManager::retryFailedDeallocs() {
   for (auto& d : deferredDeallocQueue.drain()) {
-    TT_LOG_DEBUG("[SessionManager] retryFailedDeallocs: sessionId={}, slotId={}",
-                 d.sessionId, d.slotId);
+    TT_LOG_DEBUG(
+        "[SessionManager] retryFailedDeallocs: sessionId={}, slotId={}",
+        d.sessionId, d.slotId);
     sendDeallocRequest(d.sessionId, d.slotId);
   }
 }

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -131,10 +131,8 @@ bool SessionManager::assignSlotId(const std::string& sessionId,
 uint32_t SessionManager::getSlotIdBySessionId(
     const std::string& sessionId) const {
   uint32_t result = domain::INVALID_SLOT_ID;
-  sessions.modify(sessionId, [&result](ManagedSession& ms) {
-    ms.session.updateActivityTime();
-    result = ms.session.getSlotId();
-  });
+  sessions.modify(sessionId,
+                  [&result](ManagedSession& ms) { result = ms.session.getSlotId(); });
   TT_LOG_DEBUG(
       "[SessionManager] getSlotIdBySessionId sessionId={} -> slotId={}",
       sessionId, result);
@@ -227,29 +225,22 @@ void SessionManager::evictOldSessions() {
   }
 
   using Entry = std::pair<std::chrono::system_clock::time_point, std::string>;
-  auto newer = [](const Entry& a, const Entry& b) { return a.first < b.first; };
-  std::vector<Entry> heap;
-  heap.reserve(evictionCount + 1);
+  std::vector<Entry> candidates;
 
-  sessions.forEach([&heap, &newer, evictionCount](
-                       const std::string& id, const ManagedSession& ms) {
-    if (!ms.session.isIdle()) return;
-
-    auto t = ms.session.getLastActivityTime();
-    if (heap.size() < evictionCount) {
-      heap.emplace_back(t, id);
-      std::push_heap(heap.begin(), heap.end(), newer);
-    } else if (t < heap.front().first) {
-      std::pop_heap(heap.begin(), heap.end(), newer);
-      heap.back() = {t, id};
-      std::push_heap(heap.begin(), heap.end(), newer);
-    }
+  sessions.forEach([&candidates](const std::string& id, const ManagedSession& ms) {
+    if (ms.session.isIdle())
+      candidates.emplace_back(ms.session.getLastActivityTime(), id);
   });
 
+  size_t n = std::min(evictionCount, candidates.size());
+  std::nth_element(candidates.begin(), candidates.begin() + n, candidates.end(),
+                   [](const Entry& a, const Entry& b) { return a.first < b.first; });
+  candidates.resize(n);
+
   TT_LOG_DEBUG("[SessionManager] evictOldSessions: {} candidates for eviction",
-               heap.size());
+               candidates.size());
   size_t evicted = 0;
-  for (const auto& [_, sessionId] : heap) {
+  for (const auto& [_, sessionId] : candidates) {
     // A concurrent acquireInFlight call may mark the session in-flight
     // between the forEach above and here; takeIf skips it atomically.
     auto ms = sessions.takeIf(
@@ -329,9 +320,13 @@ void SessionManager::createSession(
   }
 
   domain::Session session = domain::Session(domain::INVALID_SLOT_ID);
-  auto pendingAllocation = PendingAllocation(
-      std::move(session), std::move(onCompletion), std::move(onError),
-      callerEventLoop, tt::config::sessionAllocationMaxRetries());
+  PendingAllocation pendingAllocation{
+      .session = std::move(session),
+      .onCompletion = std::move(onCompletion),
+      .onError = std::move(onError),
+      .eventLoop = callerEventLoop,
+      .attemptsRemaining = static_cast<int>(tt::config::sessionAllocationMaxRetries()),
+  };
 
   sendAsyncAllocationRequest(pendingAllocation);
 }

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -143,10 +143,9 @@ bool SessionManager::assignSlotId(const std::string& sessionId,
 
 uint32_t SessionManager::getSlotIdBySessionId(
     const std::string& sessionId) const {
-  uint32_t result = domain::INVALID_SLOT_ID;
-  sessions.modify(sessionId, [&result](ManagedSession& ms) {
-    result = ms.session.getSlotId();
-  });
+  auto ms = sessions.get(sessionId);
+  uint32_t result =
+      ms.has_value() ? ms->session.getSlotId() : domain::INVALID_SLOT_ID;
   TT_LOG_DEBUG(
       "[SessionManager] getSlotIdBySessionId sessionId={} -> slotId={}",
       sessionId, result);
@@ -450,7 +449,7 @@ void SessionManager::handleMemoryResult(
         pendingAllocation.session.getSessionId());
     pendingAllocation.eventLoop->queueInLoop(
         [onError = std::move(pendingAllocation.onError)]() {
-          onError("Failed to allocate slot id: All attemps have failed");
+          onError("Failed to allocate slot id: All attempts have failed");
         });
   }
 }

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -329,6 +329,7 @@ void SessionManager::createSession(
   }
 
   PendingAllocation pendingAllocation{
+      .session = tt::domain::Session(),
       .onCompletion = std::move(onCompletion),
       .onError = std::move(onError),
       .eventLoop = callerEventLoop,

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -34,6 +34,19 @@ int computeFailureCount(int attemptsRemaining) {
   return static_cast<int>(tt::config::sessionAllocationMaxRetries()) -
          attemptsRemaining;
 }
+
+domain::ManageMemoryTask makeAllocTask() {
+  return domain::ManageMemoryTask(tt::utils::TaskIDGenerator::generate(),
+                                  domain::MemoryManagementAction::ALLOCATE);
+}
+
+domain::ManageMemoryTask makeDeallocTask(uint32_t slotId) {
+  domain::ManageMemoryTask task(tt::utils::TaskIDGenerator::generate(),
+                                domain::MemoryManagementAction::DEALLOCATE);
+  task.memoryLayout = domain::KvMemoryLayout::Paged;
+  task.slotIds = {slotId};
+  return task;
+}
 }  // namespace
 
 SessionManager::SessionManager() {
@@ -151,10 +164,7 @@ uint32_t SessionManager::acquireInFlight(const std::string& sessionId,
         wasInFlight = !ms.session.isIdle();
         if (wasInFlight) return;
         ms.session.updateActivityTime();
-        if (!ms.session.markInFlight()) {
-          TT_LOG_WARN("[Session] markInFlight: unexpected state {}",
-                      static_cast<int>(ms.session.getState()));
-        }
+        ms.session.markInFlight();
         ms.cancelFn = std::move(cancelFn);
         result = ms.session.getSlotId();
       });
@@ -273,11 +283,7 @@ void SessionManager::sendDeallocRequest(const std::string& sessionId,
     return;
   }
 
-  domain::ManageMemoryTask task;
-  task.taskId = utils::TaskIDGenerator::generate();
-  task.action = domain::MemoryManagementAction::DEALLOCATE;
-  task.memoryLayout = domain::KvMemoryLayout::Paged;
-  task.slotIds = {slotId};
+  auto task = makeDeallocTask(slotId);
   TT_LOG_DEBUG(
       "[SessionManager] sendDeallocRequest: sessionId={}, slotId={}, "
       "taskId={}",
@@ -319,9 +325,7 @@ void SessionManager::createSession(
     return;
   }
 
-  domain::Session session = domain::Session(domain::INVALID_SLOT_ID);
   PendingAllocation pendingAllocation{
-      .session = std::move(session),
       .onCompletion = std::move(onCompletion),
       .onError = std::move(onError),
       .eventLoop = callerEventLoop,
@@ -333,9 +337,7 @@ void SessionManager::createSession(
 
 void SessionManager::sendAsyncAllocationRequest(
     PendingAllocation& pendingAllocation) {
-  auto task =
-      domain::ManageMemoryTask(tt::utils::TaskIDGenerator::generate(),
-                               domain::MemoryManagementAction::ALLOCATE);
+  auto task = makeAllocTask();
   TT_LOG_DEBUG(
       "[SessionManager] sendAsyncAllocationRequest: taskId={}, "
       "sessionId={}, attemptsRemaining={}",

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -84,7 +84,6 @@ void SessionManager::readerLoop() {
 
 void SessionManager::finalizeSessionClose(const std::string& sessionId,
                                           const domain::Session& session) {
-  abortCallbacks_.take(sessionId);
   if (session.getSlotId() != domain::INVALID_SLOT_ID) {
     sendDeallocRequest(sessionId, session.getSlotId());
   }
@@ -96,51 +95,30 @@ CloseSessionResult SessionManager::closeSession(const std::string& sessionId) {
   TT_LOG_DEBUG("[SessionManager] closeSession called for sessionId={}",
                sessionId);
 
-  auto session = sessions.takeIf(
-      sessionId, [](const domain::Session& s) { return s.isIdle(); });
-  if (session.has_value()) {
-    finalizeSessionClose(sessionId, *session);
-    return CloseSessionResult::SUCCESS;
-  }
-
-  bool found = sessions.modify(sessionId, [](domain::Session& s) {
-    if (!s.markCloseRequested()) {
-      TT_LOG_WARN("[Session] markCloseRequested: unexpected state {}",
-                  static_cast<int>(s.getState()));
-    }
-  });
-  if (!found) {
+  // Single atomic take: the session and its cancel function are read and
+  // removed together under one lock, so there is no window where a concurrent
+  // acquireInFlight could orphan a cancel callback in a separate map.
+  auto ms = sessions.take(sessionId);
+  if (!ms.has_value()) {
     TT_LOG_WARN("[SessionManager] Session not found: {}", sessionId);
     return CloseSessionResult::NOT_FOUND;
   }
 
-  auto abortCallback = abortCallbacks_.take(sessionId);
-  if (abortCallback.has_value()) {
-    (*abortCallback)();
-    TT_LOG_INFO("[SessionManager] Aborted in-flight request for session: {}",
+  if (ms->cancelFn) {
+    ms->cancelFn();
+    TT_LOG_INFO("[SessionManager] Cancelled in-flight request for session: {}",
                 sessionId);
-  } else {
-    TT_LOG_WARN(
-        "[SessionManager] closeSession: sessionId={} is in-flight but no abort "
-        "callback registered; will close when request completes",
-        sessionId);
   }
 
-  // The in-flight request may have completed between the takeIf and modify;
-  // resolve the race with one more attempt.
-  auto deferred = sessions.takeIf(
-      sessionId, [](const domain::Session& s) { return s.isClosing(); });
-  if (deferred.has_value()) {
-    finalizeSessionClose(sessionId, *deferred);
-  }
-
+  finalizeSessionClose(sessionId, ms->session);
   return CloseSessionResult::SUCCESS;
 }
 
 bool SessionManager::assignSlotId(const std::string& sessionId,
                                   uint32_t slotId) {
-  bool found = sessions.modify(
-      sessionId, [slotId](domain::Session& s) { s.setSlotId(slotId); });
+  bool found = sessions.modify(sessionId, [slotId](ManagedSession& ms) {
+    ms.session.setSlotId(slotId);
+  });
 
   if (!found) {
     TT_LOG_WARN("[SessionManager] Session not found for slot assignment: {}",
@@ -156,9 +134,9 @@ bool SessionManager::assignSlotId(const std::string& sessionId,
 uint32_t SessionManager::getSlotIdBySessionId(
     const std::string& sessionId) const {
   uint32_t result = domain::INVALID_SLOT_ID;
-  sessions.modify(sessionId, [&result](domain::Session& s) {
-    s.updateActivityTime();
-    result = s.getSlotId();
+  sessions.modify(sessionId, [&result](ManagedSession& ms) {
+    ms.session.updateActivityTime();
+    result = ms.session.getSlotId();
   });
   TT_LOG_DEBUG(
       "[SessionManager] getSlotIdBySessionId sessionId={} -> slotId={}",
@@ -166,72 +144,73 @@ uint32_t SessionManager::getSlotIdBySessionId(
   return result;
 }
 
-uint32_t SessionManager::acquireSessionSlot(const std::string& sessionId) {
+uint32_t SessionManager::acquireInFlight(const std::string& sessionId,
+                                         std::function<void()> cancelFn) {
   uint32_t result = domain::INVALID_SLOT_ID;
   bool wasInFlight = false;
 
-  sessions.modify(sessionId, [&result, &wasInFlight](domain::Session& s) {
-    wasInFlight = !s.isIdle();
-    if (wasInFlight) {
-      return;
-    }
-    s.updateActivityTime();
-    if (!s.markInFlight()) {
-      TT_LOG_WARN("[Session] markInFlight: unexpected state {}",
-                  static_cast<int>(s.getState()));
-    }
-    result = s.getSlotId();
-  });
+  // Mark in-flight and store the cancel function in a single lock acquisition
+  // so closeSession can never observe the session as in-flight without a cancel.
+  sessions.modify(sessionId,
+                  [&result, &wasInFlight, &cancelFn](ManagedSession& ms) {
+                    wasInFlight = !ms.session.isIdle();
+                    if (wasInFlight) {
+                      return;
+                    }
+                    ms.session.updateActivityTime();
+                    if (!ms.session.markInFlight()) {
+                      TT_LOG_WARN("[Session] markInFlight: unexpected state {}",
+                                  static_cast<int>(ms.session.getState()));
+                    }
+                    ms.cancelFn = std::move(cancelFn);
+                    result = ms.session.getSlotId();
+                  });
 
   if (wasInFlight) {
     TT_LOG_WARN(
-        "[SessionManager] acquireSessionSlot: sessionId={} already has a "
+        "[SessionManager] acquireInFlight: sessionId={} already has a "
         "request in flight",
         sessionId);
     throw SessionInFlightException();
   }
 
-  TT_LOG_DEBUG("[SessionManager] acquireSessionSlot sessionId={} -> slotId={}",
+  TT_LOG_DEBUG("[SessionManager] acquireInFlight sessionId={} -> slotId={}",
                sessionId, result);
   return result;
 }
 
 std::optional<domain::Session> SessionManager::getSession(
     const std::string& sessionId) const {
-  return sessions.get(sessionId);
+  auto ms = sessions.get(sessionId);
+  if (!ms.has_value()) return std::nullopt;
+  return ms->session;
 }
 
 size_t SessionManager::getActiveSessionCount() const { return sessions.size(); }
 
 void SessionManager::releaseInFlight(const std::string& sessionId) {
-  bool found = sessions.modify(sessionId, [](domain::Session& s) {
-    if (!s.clearInFlight()) {
+  // Session may already be gone if closeSession was called concurrently; that
+  // is expected — closeSession removes the session and sends cancel+dealloc
+  // immediately. Clear the cancel function and in-flight state together under
+  // one lock so no stale callback can be observed.
+  bool found = sessions.modify(sessionId, [](ManagedSession& ms) {
+    ms.cancelFn = nullptr;
+    if (!ms.session.clearInFlight()) {
       TT_LOG_WARN("[Session] clearInFlight: unexpected state {}",
-                  static_cast<int>(s.getState()));
+                  static_cast<int>(ms.session.getState()));
     }
   });
 
   if (!found) {
-    TT_LOG_WARN("[SessionManager] Session not found for in-flight update: {}",
-                sessionId);
+    TT_LOG_DEBUG(
+        "[SessionManager] releaseInFlight: session {} already removed "
+        "(closed concurrently), ignoring",
+        sessionId);
     return;
   }
   TT_LOG_DEBUG("[SessionManager] Released in-flight for session {}", sessionId);
-
-  auto session = sessions.takeIf(
-      sessionId, [](const domain::Session& s) { return s.isClosing(); });
-  if (session.has_value()) {
-    finalizeSessionClose(sessionId, *session);
-  } else {
-    abortCallbacks_.take(
-        sessionId);  // clear callback on normal (IDLE) completion
-  }
 }
 
-void SessionManager::setSessionAbortCallback(const std::string& sessionId,
-                                             std::function<void()> onAbort) {
-  abortCallbacks_.insert(sessionId, std::move(onAbort));
-}
 
 void SessionManager::evictOldSessions() {
   bool expected = false;
@@ -263,10 +242,10 @@ void SessionManager::evictOldSessions() {
   heap.reserve(evictionCount + 1);
 
   sessions.forEach([&heap, &newer, evictionCount](
-                       const std::string& id, const domain::Session& session) {
-    if (!session.isIdle()) return;
+                       const std::string& id, const ManagedSession& ms) {
+    if (!ms.session.isIdle()) return;
 
-    auto t = session.getLastActivityTime();
+    auto t = ms.session.getLastActivityTime();
     if (heap.size() < evictionCount) {
       heap.emplace_back(t, id);
       std::push_heap(heap.begin(), heap.end(), newer);
@@ -281,24 +260,21 @@ void SessionManager::evictOldSessions() {
                heap.size());
   size_t evicted = 0;
   for (const auto& [_, sessionId] : heap) {
-    // A concurrent acquireSessionSlot call may mark the session in-flight
+    // A concurrent acquireInFlight call may mark the session in-flight
     // between the forEach above and here; takeIf skips it atomically.
-    auto session = sessions.takeIf(
-        sessionId, [](const domain::Session& s) { return s.isIdle(); });
-    if (!session.has_value()) {
+    auto ms = sessions.takeIf(
+        sessionId, [](const ManagedSession& ms) { return ms.session.isIdle(); });
+    if (!ms.has_value()) {
       TT_LOG_DEBUG(
           "[SessionManager] evictOldSessions: session {} already removed or "
           "now in-flight, skipping",
           sessionId);
       continue;
     }
-    uint32_t slotId = session->getSlotId();
     TT_LOG_DEBUG(
         "[SessionManager] evictOldSessions: evicting sessionId={}, slotId={}",
-        sessionId, slotId);
-    if (slotId != domain::INVALID_SLOT_ID) {
-      sendDeallocRequest(sessionId, slotId);
-    }
+        sessionId, ms->session.getSlotId());
+    finalizeSessionClose(sessionId, ms->session);
     ++evicted;
   }
 
@@ -307,7 +283,6 @@ void SessionManager::evictOldSessions() {
         "[SessionManager] Evicted {} oldest session(s) (active: {}/{}, "
         "threshold: {}%)",
         evicted, activeCount, maxSessions, evictionRate);
-    updateSessionCountMetric();
   }
 }
 
@@ -350,7 +325,7 @@ void SessionManager::createSession(
 
   if (slotId.has_value()) {
     domain::Session session(slotId.value());
-    sessions.insert(session.getSessionId(), session);
+    sessions.insert(session.getSessionId(), ManagedSession{session, nullptr});
     TT_LOG_INFO("[SessionManager] Created session with pre-assigned slot: {}",
                 slotId.value());
     updateSessionCountMetric();
@@ -463,13 +438,10 @@ void SessionManager::handleMemoryResult(
                  !result.slotIds.empty();
   if (success) {
     pendingAllocation.session.setSlotId(result.slotIds.front());
-    if (!pendingAllocation.session.markInFlight()) {
-      TT_LOG_WARN("[Session] markInFlight: unexpected state {} for session {}",
-                  static_cast<int>(pendingAllocation.session.getState()),
-                  pendingAllocation.session.getSessionId());
-    }
+    // Insert as IDLE; the controller will call acquireInFlight to transition
+    // the session and register its cancel function atomically.
     sessions.insert(pendingAllocation.session.getSessionId(),
-                    pendingAllocation.session);
+                    ManagedSession{pendingAllocation.session, nullptr});
     TT_LOG_DEBUG(
         "[SessionManager] handleMemoryResult: SUCCESS sessionId={}, "
         "assigned slotId={}",

--- a/tt-media-server/cpp_server/tests/session_manager_test.cpp
+++ b/tt-media-server/cpp_server/tests/session_manager_test.cpp
@@ -60,6 +60,12 @@ std::string createSessionWithSlot(tt::services::SessionManager& manager,
   return future.get();
 }
 
+// Convenience: acquire with no cancel function.
+uint32_t acquireInFlight(tt::services::SessionManager& manager,
+                         const std::string& sessionId) {
+  return manager.acquireInFlight(sessionId, nullptr);
+}
+
 // ---------------------------------------------------------------------------
 // SessionManager lifecycle tests
 // ---------------------------------------------------------------------------
@@ -83,47 +89,47 @@ TEST(SessionManagerLifecycle, CloseNonExistentSession_ReturnsNotFound) {
             tt::services::CloseSessionResult::NOT_FOUND);
 }
 
-TEST(SessionManagerLifecycle, AcquireSlot_ReturnsPreAssignedSlotId) {
+TEST(SessionManagerLifecycle, AcquireInFlight_ReturnsPreAssignedSlotId) {
   tt::services::SessionManager manager;
   LoopFixture lf;
 
   auto sessionId = createSessionWithSlot(manager, lf.loop, 7u);
   ASSERT_FALSE(sessionId.empty());
 
-  EXPECT_EQ(manager.acquireSessionSlot(sessionId), 7u);
+  EXPECT_EQ(acquireInFlight(manager, sessionId), 7u);
   manager.releaseInFlight(sessionId);
 }
 
-TEST(SessionManagerLifecycle, AcquireSlot_InFlightSession_Throws) {
+TEST(SessionManagerLifecycle, AcquireInFlight_AlreadyInFlight_Throws) {
   tt::services::SessionManager manager;
   LoopFixture lf;
 
   auto sessionId = createSessionWithSlot(manager, lf.loop, 8u);
   ASSERT_FALSE(sessionId.empty());
 
-  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
-  EXPECT_THROW(manager.acquireSessionSlot(sessionId),
+  acquireInFlight(manager, sessionId);
+  EXPECT_THROW(acquireInFlight(manager, sessionId),
                tt::services::SessionInFlightException);
   manager.releaseInFlight(sessionId);
 }
 
-TEST(SessionManagerLifecycle, DeferredClose_FinalizedOnReleaseInFlight) {
-  // CLOSE_REQUESTED path: the session must stay in the map until
-  // releaseInFlight completes the CLOSE_REQUESTED -> CLOSING -> finalized
-  // transition.
+TEST(SessionManagerLifecycle, CloseWhileInFlight_RemovesSessionImmediately) {
+  // closeSession must remove the session and trigger dealloc immediately,
+  // even when the session is in-flight. releaseInFlight called afterwards
+  // should be a safe no-op.
   tt::services::SessionManager manager;
   LoopFixture lf;
 
   auto sessionId = createSessionWithSlot(manager, lf.loop, 9u);
   ASSERT_FALSE(sessionId.empty());
 
-  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
-  manager.closeSession(sessionId);        // IN_FLIGHT -> CLOSE_REQUESTED
-  EXPECT_TRUE(manager.getSession(sessionId).has_value());  // still present
+  acquireInFlight(manager, sessionId);
+  manager.closeSession(sessionId);
+  EXPECT_FALSE(manager.getSession(sessionId).has_value());
 
-  manager.releaseInFlight(
-      sessionId);  // CLOSE_REQUESTED -> CLOSING -> finalized
-  EXPECT_FALSE(manager.getSession(sessionId).has_value());  // now gone
+  // releaseInFlight called by the SSE writer after the request drains must
+  // not crash or assert, even though the session is already gone.
+  EXPECT_NO_THROW(manager.releaseInFlight(sessionId));
 }
 
 TEST(SessionManagerLifecycle, GetActiveSessionCount_ReflectsLifecycle) {
@@ -152,10 +158,10 @@ TEST(SessionManagerLifecycle, AcquireAfterRelease_Succeeds) {
   auto sessionId = createSessionWithSlot(manager, lf.loop, 11u);
   ASSERT_FALSE(sessionId.empty());
 
-  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
-  manager.releaseInFlight(sessionId);     // IN_FLIGHT -> IDLE
+  acquireInFlight(manager, sessionId);
+  manager.releaseInFlight(sessionId);
 
-  EXPECT_NO_THROW(manager.acquireSessionSlot(sessionId));
+  EXPECT_NO_THROW(acquireInFlight(manager, sessionId));
   manager.releaseInFlight(sessionId);
 }
 
@@ -205,60 +211,104 @@ TEST(SessionManagerLifecycle,
 }
 
 // ---------------------------------------------------------------------------
-// SessionManager abort callback tests
+// SessionManager close-while-in-flight tests
 // ---------------------------------------------------------------------------
 
-TEST(SessionManagerAbort, AbortCallbackInvokedOnCloseWhileInFlight) {
+TEST(SessionManagerClose, CloseInFlight_RemovesSessionImmediately) {
   tt::services::SessionManager manager;
   LoopFixture lf;
 
   auto sessionId = createSessionWithSlot(manager, lf.loop, 42u);
   ASSERT_FALSE(sessionId.empty());
 
-  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
+  acquireInFlight(manager, sessionId);
 
-  std::atomic<bool> abortCalled{false};
-  manager.setSessionAbortCallback(sessionId,
-                                  [&abortCalled]() { abortCalled = true; });
-
-  auto result = manager.closeSession(sessionId);
-
-  EXPECT_EQ(result, tt::services::CloseSessionResult::SUCCESS);
-  EXPECT_TRUE(abortCalled.load());
+  EXPECT_EQ(manager.closeSession(sessionId),
+            tt::services::CloseSessionResult::SUCCESS);
+  EXPECT_FALSE(manager.getSession(sessionId).has_value());
 }
 
-TEST(SessionManagerAbort, CloseSessionReturnsSuccessRegardlessOfInFlight) {
+TEST(SessionManagerClose, CloseInFlight_FiresCancelFn_AtomicWithAcquire) {
+  // Cancel and in-flight state are set atomically by acquireInFlight.
+  // closeSession must fire the cancel function immediately.
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 45u);
+  ASSERT_FALSE(sessionId.empty());
+
+  std::atomic<bool> cancelCalled{false};
+  manager.acquireInFlight(sessionId, [&cancelCalled]() { cancelCalled = true; });
+
+  manager.closeSession(sessionId);
+
+  EXPECT_TRUE(cancelCalled.load());
+  EXPECT_FALSE(manager.getSession(sessionId).has_value());
+}
+
+TEST(SessionManagerClose, CloseIdle_NoCancelFired) {
+  // Idle sessions have no in-flight request; closeSession must not fire any
+  // cancel (there is none registered).
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 46u);
+  ASSERT_FALSE(sessionId.empty());
+
+  // Close without ever calling acquireInFlight — no cancel should be needed.
+  EXPECT_EQ(manager.closeSession(sessionId),
+            tt::services::CloseSessionResult::SUCCESS);
+  EXPECT_FALSE(manager.getSession(sessionId).has_value());
+}
+
+TEST(SessionManagerClose, ReleaseInFlight_AfterClose_IsNoOp) {
+  // Simulates the SSE writer calling releaseInFlight after the session was
+  // already removed by a concurrent closeSession.
   tt::services::SessionManager manager;
   LoopFixture lf;
 
   auto sessionId = createSessionWithSlot(manager, lf.loop, 43u);
   ASSERT_FALSE(sessionId.empty());
 
-  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
-  // No abort callback registered (e.g. non-streaming request)
+  acquireInFlight(manager, sessionId);
+  manager.closeSession(sessionId);
 
-  auto result = manager.closeSession(sessionId);
-  EXPECT_EQ(result, tt::services::CloseSessionResult::SUCCESS);
+  EXPECT_NO_THROW(manager.releaseInFlight(sessionId));
+  EXPECT_EQ(manager.getActiveSessionCount(), 0u);
 }
 
-TEST(SessionManagerAbort, AbortCallbackClearedAfterRequestCompletesNormally) {
+TEST(SessionManagerClose, CancelFn_ClearedOnNormalCompletion) {
+  // If the request completes normally, releaseInFlight must clear the cancel
+  // function so a subsequent close does not fire stale cancel logic.
   tt::services::SessionManager manager;
   LoopFixture lf;
 
   auto sessionId = createSessionWithSlot(manager, lf.loop, 44u);
   ASSERT_FALSE(sessionId.empty());
 
-  manager.acquireSessionSlot(sessionId);  // IDLE -> IN_FLIGHT
+  std::atomic<bool> cancelCalled{false};
+  manager.acquireInFlight(sessionId, [&cancelCalled]() { cancelCalled = true; });
 
-  std::atomic<bool> abortCalled{false};
-  manager.setSessionAbortCallback(sessionId,
-                                  [&abortCalled]() { abortCalled = true; });
+  manager.releaseInFlight(sessionId);  // normal completion clears cancel fn
+  manager.closeSession(sessionId);     // should not fire cancel
 
-  manager.releaseInFlight(sessionId);  // IN_FLIGHT -> IDLE, clears callback
+  EXPECT_FALSE(cancelCalled.load());
+}
 
-  manager.closeSession(sessionId);
+TEST(SessionManagerClose, ReleaseInFlight_NormalCompletion_SessionStaysIdle) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
 
-  EXPECT_FALSE(abortCalled.load());
+  auto sessionId = createSessionWithSlot(manager, lf.loop, 47u);
+  ASSERT_FALSE(sessionId.empty());
+
+  acquireInFlight(manager, sessionId);
+  manager.releaseInFlight(sessionId);
+
+  // Session still present and acquirable again.
+  EXPECT_TRUE(manager.getSession(sessionId).has_value());
+  EXPECT_NO_THROW(acquireInFlight(manager, sessionId));
+  manager.releaseInFlight(sessionId);
 }
 
 }  // namespace

--- a/tt-media-server/cpp_server/tests/session_manager_test.cpp
+++ b/tt-media-server/cpp_server/tests/session_manager_test.cpp
@@ -322,11 +322,13 @@ template <typename F>
 void runConcurrently(F&& f) {
   std::atomic<bool> ready{false};
   auto t1 = std::thread([&] {
-    while (!ready.load(std::memory_order_acquire)) {}
+    while (!ready.load(std::memory_order_acquire)) {
+    }
     f();
   });
   auto t2 = std::thread([&] {
-    while (!ready.load(std::memory_order_acquire)) {}
+    while (!ready.load(std::memory_order_acquire)) {
+    }
     f();
   });
   ready.store(true, std::memory_order_release);
@@ -379,7 +381,8 @@ TEST(SessionManagerConcurrency, ConcurrentAcquire_OnlyOneSucceeds) {
   }
 }
 
-TEST(SessionManagerConcurrency, ConcurrentAcquireAndClose_CancelFiredAtMostOnce) {
+TEST(SessionManagerConcurrency,
+     ConcurrentAcquireAndClose_CancelFiredAtMostOnce) {
   // One thread acquires in-flight while another closes. The cancel function
   // must fire at most once regardless of which wins the race. The session
   // must be absent and the count zero after both threads finish.
@@ -393,17 +396,19 @@ TEST(SessionManagerConcurrency, ConcurrentAcquireAndClose_CancelFiredAtMostOnce)
     std::atomic<bool> ready{false};
 
     std::thread acquirer([&] {
-      while (!ready.load(std::memory_order_acquire)) {}
+      while (!ready.load(std::memory_order_acquire)) {
+      }
       try {
-        manager.acquireInFlight(
-            sessionId, [&cancelCount] { cancelCount.fetch_add(1); });
+        manager.acquireInFlight(sessionId,
+                                [&cancelCount] { cancelCount.fetch_add(1); });
         manager.releaseInFlight(sessionId);
       } catch (const tt::services::SessionRateLimitException&) {
       }
     });
 
     std::thread closer([&] {
-      while (!ready.load(std::memory_order_acquire)) {}
+      while (!ready.load(std::memory_order_acquire)) {
+      }
       manager.closeSession(sessionId);
     });
 

--- a/tt-media-server/cpp_server/tests/session_manager_test.cpp
+++ b/tt-media-server/cpp_server/tests/session_manager_test.cpp
@@ -339,8 +339,8 @@ void runConcurrently(F&& f) {
 TEST(SessionManagerConcurrency, ConcurrentClose_OnlyOneSucceeds) {
   // Two threads race to close the same session. Exactly one must get SUCCESS;
   // the other must get NOT_FOUND. The session must be gone afterwards.
-  constexpr int ITERATIONS = 200;
-  for (int i = 0; i < ITERATIONS; ++i) {
+  constexpr int iterations = 200;
+  for (int i = 0; i < iterations; ++i) {
     tt::services::SessionManager manager;
     LoopFixture lf;
     auto sessionId = createSessionWithSlot(manager, lf.loop, 100u);
@@ -361,8 +361,8 @@ TEST(SessionManagerConcurrency, ConcurrentClose_OnlyOneSucceeds) {
 TEST(SessionManagerConcurrency, ConcurrentAcquire_OnlyOneSucceeds) {
   // Two threads race to acquireInFlight the same session. Exactly one must
   // succeed; the other must throw SessionInFlightException.
-  constexpr int ITERATIONS = 200;
-  for (int i = 0; i < ITERATIONS; ++i) {
+  constexpr int iterations = 200;
+  for (int i = 0; i < iterations; ++i) {
     tt::services::SessionManager manager;
     LoopFixture lf;
     auto sessionId = createSessionWithSlot(manager, lf.loop, 101u);
@@ -386,8 +386,8 @@ TEST(SessionManagerConcurrency,
   // One thread acquires in-flight while another closes. The cancel function
   // must fire at most once regardless of which wins the race. The session
   // must be absent and the count zero after both threads finish.
-  constexpr int ITERATIONS = 200;
-  for (int i = 0; i < ITERATIONS; ++i) {
+  constexpr int iterations = 200;
+  for (int i = 0; i < iterations; ++i) {
     tt::services::SessionManager manager;
     LoopFixture lf;
     auto sessionId = createSessionWithSlot(manager, lf.loop, 102u);

--- a/tt-media-server/cpp_server/tests/session_manager_test.cpp
+++ b/tt-media-server/cpp_server/tests/session_manager_test.cpp
@@ -313,4 +313,107 @@ TEST(SessionManagerClose, ReleaseInFlight_NormalCompletion_SessionStaysIdle) {
   manager.releaseInFlight(sessionId);
 }
 
+// ---------------------------------------------------------------------------
+// Concurrency tests
+// ---------------------------------------------------------------------------
+
+// Runs a function from two threads simultaneously using a shared latch.
+template <typename F>
+void runConcurrently(F&& f) {
+  std::atomic<bool> ready{false};
+  auto t1 = std::thread([&] {
+    while (!ready.load(std::memory_order_acquire)) {}
+    f();
+  });
+  auto t2 = std::thread([&] {
+    while (!ready.load(std::memory_order_acquire)) {}
+    f();
+  });
+  ready.store(true, std::memory_order_release);
+  t1.join();
+  t2.join();
+}
+
+TEST(SessionManagerConcurrency, ConcurrentClose_OnlyOneSucceeds) {
+  // Two threads race to close the same session. Exactly one must get SUCCESS;
+  // the other must get NOT_FOUND. The session must be gone afterwards.
+  constexpr int ITERATIONS = 200;
+  for (int i = 0; i < ITERATIONS; ++i) {
+    tt::services::SessionManager manager;
+    LoopFixture lf;
+    auto sessionId = createSessionWithSlot(manager, lf.loop, 100u);
+
+    std::atomic<int> successCount{0};
+    runConcurrently([&] {
+      auto result = manager.closeSession(sessionId);
+      if (result == tt::services::CloseSessionResult::SUCCESS) {
+        successCount.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+
+    EXPECT_EQ(successCount.load(), 1) << "iteration " << i;
+    EXPECT_EQ(manager.getActiveSessionCount(), 0u) << "iteration " << i;
+  }
+}
+
+TEST(SessionManagerConcurrency, ConcurrentAcquire_OnlyOneSucceeds) {
+  // Two threads race to acquireInFlight the same session. Exactly one must
+  // succeed; the other must throw SessionInFlightException.
+  constexpr int ITERATIONS = 200;
+  for (int i = 0; i < ITERATIONS; ++i) {
+    tt::services::SessionManager manager;
+    LoopFixture lf;
+    auto sessionId = createSessionWithSlot(manager, lf.loop, 101u);
+
+    std::atomic<int> acquireCount{0};
+    runConcurrently([&] {
+      try {
+        manager.acquireInFlight(sessionId, nullptr);
+        acquireCount.fetch_add(1, std::memory_order_relaxed);
+      } catch (const tt::services::SessionInFlightException&) {
+      }
+    });
+
+    EXPECT_EQ(acquireCount.load(), 1) << "iteration " << i;
+    manager.releaseInFlight(sessionId);
+  }
+}
+
+TEST(SessionManagerConcurrency, ConcurrentAcquireAndClose_CancelFiredAtMostOnce) {
+  // One thread acquires in-flight while another closes. The cancel function
+  // must fire at most once regardless of which wins the race. The session
+  // must be absent and the count zero after both threads finish.
+  constexpr int ITERATIONS = 200;
+  for (int i = 0; i < ITERATIONS; ++i) {
+    tt::services::SessionManager manager;
+    LoopFixture lf;
+    auto sessionId = createSessionWithSlot(manager, lf.loop, 102u);
+
+    std::atomic<int> cancelCount{0};
+    std::atomic<bool> ready{false};
+
+    std::thread acquirer([&] {
+      while (!ready.load(std::memory_order_acquire)) {}
+      try {
+        manager.acquireInFlight(
+            sessionId, [&cancelCount] { cancelCount.fetch_add(1); });
+        manager.releaseInFlight(sessionId);
+      } catch (const tt::services::SessionRateLimitException&) {
+      }
+    });
+
+    std::thread closer([&] {
+      while (!ready.load(std::memory_order_acquire)) {}
+      manager.closeSession(sessionId);
+    });
+
+    ready.store(true, std::memory_order_release);
+    acquirer.join();
+    closer.join();
+
+    EXPECT_LE(cancelCount.load(), 1) << "iteration " << i;
+    EXPECT_EQ(manager.getActiveSessionCount(), 0u) << "iteration " << i;
+  }
+}
+
 }  // namespace

--- a/tt-media-server/cpp_server/tests/session_manager_test.cpp
+++ b/tt-media-server/cpp_server/tests/session_manager_test.cpp
@@ -238,7 +238,8 @@ TEST(SessionManagerClose, CloseInFlight_FiresCancelFn_AtomicWithAcquire) {
   ASSERT_FALSE(sessionId.empty());
 
   std::atomic<bool> cancelCalled{false};
-  manager.acquireInFlight(sessionId, [&cancelCalled]() { cancelCalled = true; });
+  manager.acquireInFlight(sessionId,
+                          [&cancelCalled]() { cancelCalled = true; });
 
   manager.closeSession(sessionId);
 
@@ -287,7 +288,8 @@ TEST(SessionManagerClose, CancelFn_ClearedOnNormalCompletion) {
   ASSERT_FALSE(sessionId.empty());
 
   std::atomic<bool> cancelCalled{false};
-  manager.acquireInFlight(sessionId, [&cancelCalled]() { cancelCalled = true; });
+  manager.acquireInFlight(sessionId,
+                          [&cancelCalled]() { cancelCalled = true; });
 
   manager.releaseInFlight(sessionId);  // normal completion clears cancel fn
   manager.closeSession(sessionId);     // should not fire cancel

--- a/tt-media-server/cpp_server/tests/session_test.cpp
+++ b/tt-media-server/cpp_server/tests/session_test.cpp
@@ -15,8 +15,6 @@ TEST(SessionState, InitialStateIsIdle) {
   tt::domain::Session s;
   EXPECT_TRUE(s.isIdle());
   EXPECT_FALSE(s.isInFlight());
-  EXPECT_FALSE(s.isCloseRequested());
-  EXPECT_FALSE(s.isClosing());
 }
 
 TEST(SessionState, MarkInFlightFromIdle) {
@@ -40,39 +38,10 @@ TEST(SessionState, ClearInFlightFromInFlightTransitionsToIdle) {
   EXPECT_TRUE(s.isIdle());
 }
 
-TEST(SessionState, ClearInFlightFromCloseRequestedTransitionsToClosing) {
-  tt::domain::Session s;
-  s.markInFlight();
-  s.markCloseRequested();
-  EXPECT_TRUE(s.clearInFlight());
-  EXPECT_TRUE(s.isClosing());
-}
-
 TEST(SessionState, ClearInFlightFromIdleReturnsFalse) {
   tt::domain::Session s;
   EXPECT_FALSE(s.clearInFlight());
   EXPECT_TRUE(s.isIdle());  // state unchanged
-}
-
-TEST(SessionState, MarkCloseRequestedFromInFlight) {
-  tt::domain::Session s;
-  s.markInFlight();
-  EXPECT_TRUE(s.markCloseRequested());
-  EXPECT_TRUE(s.isCloseRequested());
-}
-
-TEST(SessionState, MarkCloseRequestedFromIdleReturnsFalse) {
-  tt::domain::Session s;
-  EXPECT_FALSE(s.markCloseRequested());
-  EXPECT_TRUE(s.isIdle());  // state unchanged
-}
-
-TEST(SessionState, MarkCloseRequestedFromCloseRequestedReturnsFalse) {
-  tt::domain::Session s;
-  s.markInFlight();
-  s.markCloseRequested();
-  EXPECT_FALSE(s.markCloseRequested());
-  EXPECT_TRUE(s.isCloseRequested());  // state unchanged
 }
 
 }  // namespace


### PR DESCRIPTION
Addresses correctness issues in how sessions are closed and cancelled, and simplifies the domain model.

Close is now immediate and atomic. Previously, closing an in-flight session transitioned it to CLOSE_REQUESTED and waited for the request to drain before deallocating the slot. Now closeSession immediately removes the session from the map, fires the cancel function (stopping decode), and sends the dealloc request — all in one call, no waiting.

CLOSE_REQUESTED / CLOSING states removed. These two states existed solely to model the "wait for drain before deallocating" behavior. Since that behavior is gone, the state machine is IDLE ↔ IN_FLIGHT.