### PR TITLE
Fix runner selection when MODEL and MODEL_RUNNER env vars are both set

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -179,51 +179,52 @@ MODEL_SERVICE_RUNNER_MAP = {
 }
 
 
-MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
-    ModelRunners.TT_SDXL_EDIT: {ModelNames.STABLE_DIFFUSION_XL_INPAINTING},
-    ModelRunners.TT_SDXL_IMAGE_TO_IMAGE: {ModelNames.STABLE_DIFFUSION_XL_IMG2IMG},
-    ModelRunners.TT_SDXL_TRACE: {ModelNames.STABLE_DIFFUSION_XL_BASE},
-    ModelRunners.TT_SD3_5: {ModelNames.STABLE_DIFFUSION_3_5_LARGE},
-    ModelRunners.TT_FLUX_1_DEV: {ModelNames.FLUX_1_DEV},
-    ModelRunners.TT_FLUX_1_SCHNELL: {ModelNames.FLUX_1_SCHNELL},
-    ModelRunners.TT_MOTIF_IMAGE_6B_PREVIEW: {ModelNames.MOTIF_IMAGE_6B_PREVIEW},
-    ModelRunners.TT_QWEN_IMAGE: {ModelNames.QWEN_IMAGE},
-    ModelRunners.TT_QWEN_IMAGE_2512: {ModelNames.QWEN_IMAGE_2512},
-    ModelRunners.TT_MOCHI_1: {ModelNames.MOCHI_1},
-    ModelRunners.TT_WAN_2_2: {ModelNames.WAN_2_2},
-    ModelRunners.SP_RUNNER: {ModelNames.WAN_2_2, ModelNames.MOCHI_1},
-    ModelRunners.TT_WHISPER: {
-        ModelNames.OPENAI_WHISPER_LARGE_V3,
-        ModelNames.DISTIL_WHISPER_LARGE_V3,
-    },
-    ModelRunners.TT_XLA_RESNET: {ModelNames.MICROSOFT_RESNET_50},
-    ModelRunners.TT_XLA_VOVNET: {ModelNames.VOVNET},
-    ModelRunners.TT_XLA_MOBILENETV2: {ModelNames.MOBILENETV2},
-    ModelRunners.TT_XLA_EFFICIENTNET: {ModelNames.EFFICIENTNET},
-    ModelRunners.TT_XLA_SEGFORMER: {ModelNames.SEGFORMER},
-    ModelRunners.TT_XLA_UNET: {ModelNames.UNET},
-    ModelRunners.TT_XLA_VIT: {ModelNames.VIT},
-    ModelRunners.VLLMForge_QWEN_EMBEDDING: {ModelNames.QWEN_3_EMBEDDING_4B},
-    ModelRunners.VLLMForge_LLAMA_70B: {ModelNames.LLAMA_3_1_70B},
-    ModelRunners.QWEN_EMBEDDING_8B: {ModelNames.QWEN_3_EMBEDDING_8B},
-    ModelRunners.BGELargeEN_V1_5: {ModelNames.BGE_LARGE_EN_V1_5},
-    ModelRunners.BGEM3: {ModelNames.BGE_M3},
-    ModelRunners.VLLMForge: {
-        ModelNames.LLAMA_3_2_3B,
-        ModelNames.LLAMA_3_2_3B_INSTRUCT,
-        ModelNames.LLAMA_3_1_8B_INSTRUCT,
-        ModelNames.QWEN_3_4B,
-        ModelNames.QWEN_3_8B,
-    },
-    ModelRunners.TT_SPEECHT5_TTS: {ModelNames.SPEECHT5_TTS},
-    ModelRunners.TRAINING_GEMMA_LORA: {ModelNames.GEMMA_1_1_2B_IT},
-    ModelRunners.TRAINING_LLAMA_LORA: {ModelNames.LLAMA_3_1_8B},
-    ModelRunners.LORA_SINGLE_CHIP: {ModelNames.GEMMA_1_1_2B_IT},
-    ModelRunners.TT_XLA_SDXL: {
-        ModelNames.STABLE_DIFFUSION_XL_BASE,
-        ModelNames.STABLE_DIFFUSION_XL_512,
-    },
+# Canonical runner per model. Set MODEL_RUNNER env var to override (e.g. for training runners).
+MODEL_NAME_TO_RUNNER_MAP: dict = {
+    ModelNames.STABLE_DIFFUSION_XL_INPAINTING: ModelRunners.TT_SDXL_EDIT,
+    ModelNames.STABLE_DIFFUSION_XL_IMG2IMG: ModelRunners.TT_SDXL_IMAGE_TO_IMAGE,
+    ModelNames.STABLE_DIFFUSION_XL_BASE: ModelRunners.TT_SDXL_TRACE,
+    ModelNames.STABLE_DIFFUSION_XL_512: ModelRunners.TT_XLA_SDXL,
+    ModelNames.STABLE_DIFFUSION_3_5_LARGE: ModelRunners.TT_SD3_5,
+    ModelNames.FLUX_1_DEV: ModelRunners.TT_FLUX_1_DEV,
+    ModelNames.FLUX_1_SCHNELL: ModelRunners.TT_FLUX_1_SCHNELL,
+    ModelNames.MOTIF_IMAGE_6B_PREVIEW: ModelRunners.TT_MOTIF_IMAGE_6B_PREVIEW,
+    ModelNames.QWEN_IMAGE: ModelRunners.TT_QWEN_IMAGE,
+    ModelNames.QWEN_IMAGE_2512: ModelRunners.TT_QWEN_IMAGE_2512,
+    ModelNames.MOCHI_1: ModelRunners.TT_MOCHI_1,
+    ModelNames.WAN_2_2: ModelRunners.TT_WAN_2_2,
+    ModelNames.OPENAI_WHISPER_LARGE_V3: ModelRunners.TT_WHISPER,
+    ModelNames.DISTIL_WHISPER_LARGE_V3: ModelRunners.TT_WHISPER,
+    ModelNames.MICROSOFT_RESNET_50: ModelRunners.TT_XLA_RESNET,
+    ModelNames.VOVNET: ModelRunners.TT_XLA_VOVNET,
+    ModelNames.MOBILENETV2: ModelRunners.TT_XLA_MOBILENETV2,
+    ModelNames.EFFICIENTNET: ModelRunners.TT_XLA_EFFICIENTNET,
+    ModelNames.SEGFORMER: ModelRunners.TT_XLA_SEGFORMER,
+    ModelNames.UNET: ModelRunners.TT_XLA_UNET,
+    ModelNames.VIT: ModelRunners.TT_XLA_VIT,
+    ModelNames.QWEN_3_EMBEDDING_4B: ModelRunners.VLLMForge_QWEN_EMBEDDING,
+    ModelNames.QWEN_3_EMBEDDING_8B: ModelRunners.QWEN_EMBEDDING_8B,
+    ModelNames.LLAMA_3_1_70B: ModelRunners.VLLMForge_LLAMA_70B,
+    ModelNames.BGE_LARGE_EN_V1_5: ModelRunners.BGELargeEN_V1_5,
+    ModelNames.BGE_M3: ModelRunners.BGEM3,
+    ModelNames.LLAMA_3_2_3B: ModelRunners.VLLMForge,
+    ModelNames.LLAMA_3_2_3B_INSTRUCT: ModelRunners.VLLMForge,
+    ModelNames.LLAMA_3_1_8B_INSTRUCT: ModelRunners.VLLMForge,
+    ModelNames.QWEN_3_4B: ModelRunners.VLLMForge,
+    ModelNames.QWEN_3_8B: ModelRunners.VLLMForge,
+    ModelNames.SPEECHT5_TTS: ModelRunners.TT_SPEECHT5_TTS,
+    ModelNames.GEMMA_1_1_2B_IT: ModelRunners.TRAINING_GEMMA_LORA,
+    ModelNames.LLAMA_3_1_8B: ModelRunners.TRAINING_LLAMA_LORA,
 }
+
+
+_RUNNER_TO_MODELS_MAP: dict = {}
+for _name, _runner in MODEL_NAME_TO_RUNNER_MAP.items():
+    _RUNNER_TO_MODELS_MAP.setdefault(_runner, []).append(_name)
+
+
+def models_for_runner(runner: ModelRunners) -> list:
+    return _RUNNER_TO_MODELS_MAP.get(runner, [])
 
 
 # DEVICE environment variable

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -8,8 +8,9 @@ from typing import Optional
 
 from config.constants import (
     MODEL_NAME_OVERRIDES,
-    MODEL_RUNNER_TO_MODEL_NAMES_MAP,
+    MODEL_NAME_TO_RUNNER_MAP,
     MODEL_SERVICE_RUNNER_MAP,
+    models_for_runner,
     SDXL_VALID_IMAGE_RESOLUTIONS,
     AudioTasks,
     DeviceTypes,
@@ -151,19 +152,17 @@ class Settings(BaseSettings):
 
         # set model weights path using model name
         if self.model_weights_path is None or self.model_weights_path == "":
-            # Convert string to enum first
             model_runner_enum = ModelRunners(self.model_runner)
-
-            # Use dictionary key access
-            model_names_set = MODEL_RUNNER_TO_MODEL_NAMES_MAP.get(model_runner_enum)
-
-            if model_names_set:
-                # Get first model name from the set
-                model_name = list(model_names_set)[0]
-                if model_name:
-                    supported_model = getattr(SupportedModels, model_name.name, None)
-                    if supported_model:
-                        self.model_weights_path = supported_model.value
+            runner_models = models_for_runner(model_runner_enum)
+            if len(runner_models) > 1:
+                logger.warning(
+                    f"MODEL_RUNNER={self.model_runner!r} supports multiple models "
+                    f"{[m.value for m in runner_models]}. Set MODEL env var to select explicitly."
+                )
+            elif runner_models:
+                supported_model = getattr(SupportedModels, runner_models[0].name, None)
+                if supported_model:
+                    self.model_weights_path = supported_model.value
 
         # use throttling overrides until we confirm is no-throttling a stable approach
         self._set_throttling_overrides()
@@ -281,46 +280,50 @@ class Settings(BaseSettings):
     def _set_config_overrides(self, model_to_run: str, device: str):
         model_name_enum = ModelNames(model_to_run)
 
-        # Find the appropriate model runner for this model name
-        model_runner_enum = None
-        for runner, model_names in MODEL_RUNNER_TO_MODEL_NAMES_MAP.items():
-            if model_name_enum in model_names:
-                model_runner_enum = runner
-                break
-
-        if model_runner_enum:
-            device_type_enum = DeviceTypes(device)
-            config_key = (model_runner_enum, device_type_enum)
-            matching_config = ModelConfigs.get(config_key)
-            logger.info(
-                f"Config lookup: runner={model_runner_enum}, device_type={device_type_enum}, "
-                f"key_exists={config_key in ModelConfigs}, "
-                f"matching_config={matching_config}"
-            )
-        else:
+        canonical_runner = MODEL_NAME_TO_RUNNER_MAP.get(model_name_enum)
+        if not canonical_runner:
             raise ValueError(f"No model runner found for model {model_to_run}.")
 
-        if matching_config:
-            self.model_runner = model_runner_enum.value
+        # MODEL_RUNNER env var overrides the canonical runner for both config lookup
+        # and runner assignment (e.g. to select a training runner over an inference runner)
+        model_runner_str = os.environ.get("MODEL_RUNNER")
+        model_runner_enum = (
+            ModelRunners(model_runner_str) if model_runner_str else canonical_runner
+        )
 
-            supported_model = getattr(SupportedModels, model_name_enum.name, None)
-            if supported_model:
-                self.model_weights_path = supported_model.value
+        device_type_enum = DeviceTypes(device)
+        config_key = (model_runner_enum, device_type_enum)
+        matching_config = ModelConfigs.get(config_key)
+        logger.info(
+            f"Config lookup: runner={model_runner_enum}, device_type={device_type_enum}, "
+            f"key_exists={config_key in ModelConfigs}, "
+            f"matching_config={matching_config}"
+        )
 
-            # Apply all configuration values (env vars take precedence)
-            for key, value in matching_config.items():
-                if hasattr(self, key):
-                    if key.upper() in os.environ:
-                        continue
-                    if key == "vllm" and isinstance(value, dict):
-                        value = VLLMSettings(**value)
-                    setattr(self, key, value)
+        if not matching_config:
+            return
 
-            # Apply per-model overrides (e.g. chat_template_kwargs for Qwen3)
-            model_overrides = MODEL_NAME_OVERRIDES.get(model_name_enum, {})
-            for key, value in model_overrides.items():
-                if hasattr(self, key):
-                    setattr(self, key, value)
+        self.model_runner = model_runner_enum.value
+
+        supported_model = getattr(SupportedModels, model_name_enum.name, None)
+        if supported_model:
+            self.model_weights_path = supported_model.value
+
+        # Apply all configuration values (env vars take precedence)
+        for key, value in matching_config.items():
+            if hasattr(self, key):
+                if key.upper() in os.environ:
+                    continue
+                if key == "vllm" and isinstance(value, dict):
+                    value = VLLMSettings(**value)
+                setattr(self, key, value)
+
+        # Apply per-model overrides (e.g. chat_template_kwargs for Qwen3)
+        model_overrides = MODEL_NAME_OVERRIDES.get(model_name_enum, {})
+        for key, value in model_overrides.items():
+            if hasattr(self, key):
+                setattr(self, key, value)
+
         if any(
             self.model_runner == r.value
             for r in MODEL_SERVICE_RUNNER_MAP[ModelServices.LLM]

--- a/tt-media-server/model_services/training_service.py
+++ b/tt-media-server/model_services/training_service.py
@@ -6,7 +6,7 @@ from multiprocessing import Manager
 
 from model_services.base_job_service import BaseJobService
 from config.constants import (
-    MODEL_RUNNER_TO_MODEL_NAMES_MAP,
+    models_for_runner,
     TRAINING_STORE_ADAPTERS_DIR,
     JobTypes,
     ModelRunners,
@@ -21,8 +21,10 @@ class TrainingService(BaseJobService):
         self.settings = get_settings()
         self._manager = Manager()
         runner_enum = ModelRunners(self.settings.model_runner)
-        model_names = MODEL_RUNNER_TO_MODEL_NAMES_MAP.get(runner_enum, set())
-        self._model_name = next(iter(model_names)).value
+        runner_models = models_for_runner(runner_enum)
+        if not runner_models:
+            raise ValueError(f"No model found for runner {runner_enum}.")
+        self._model_name = runner_models[0].value
         super().__init__()
 
     async def create_job(

--- a/tt-media-server/tests/test_build_training_catalog.py
+++ b/tt-media-server/tests/test_build_training_catalog.py
@@ -53,8 +53,10 @@ class TestBuildModelsCatalog:
 
     def test_raises_when_model_missing_from_enums(self):
         fake_model = enum.Enum("FakeModel", {"FAKE_MODEL": "fake-model"}).FAKE_MODEL
-        fake_map = {ModelRunners.TRAINING_GEMMA_LORA: {fake_model}}
-        with patch("utils.build_catalog.MODEL_RUNNER_TO_MODEL_NAMES_MAP", fake_map):
+        with patch(
+            "utils.build_catalog.models_for_runner",
+            return_value=[ModelNames.GEMMA_1_1_2B_IT, fake_model],
+        ):
             with pytest.raises(
                 ValueError, match="SupportedModels and ModelDisplayNames"
             ):

--- a/tt-media-server/utils/build_catalog.py
+++ b/tt-media-server/utils/build_catalog.py
@@ -4,7 +4,7 @@
 import math
 
 from config.constants import (
-    MODEL_RUNNER_TO_MODEL_NAMES_MAP,
+    models_for_runner,
     DeviceTypes,
     ModelDisplayNames,
     ModelRunners,
@@ -31,7 +31,7 @@ def _build_models_catalog(model_runner: str):
     except ValueError:
         return []
     models = []
-    for model_name in MODEL_RUNNER_TO_MODEL_NAMES_MAP.get(runner_enum, set()):
+    for model_name in models_for_runner(runner_enum):
         try:
             model_config = SupportedModels[model_name.name].value
             display_name = ModelDisplayNames[model_name.name].value


### PR DESCRIPTION
Fixes the runner selection logic when MODEL env var is used for config overrides.

Changes:
- Add MODEL_NAME_TO_RUNNER_MAP as the single source of truth for model→runner mapping, replacing MODEL_RUNNER_TO_MODEL_NAMES_MAP
- MODEL_RUNNER env var now correctly takes precedence over the canonical runner, enabling use of training runners for models that also have inference runners
- Add models_for_runner() helper (O(1) lookup, precomputed at import time) to derive runner→models direction
- Fix non-deterministic set iteration in model_weights_path fallback and TrainingService — multi-model runners now log a warning and require MODEL to be set explicitly