### PR TITLE
Update device in models-ci-config.json for DeepSeek-R1 #3091

### DIFF
--- a/.github/workflows/models-ci-config-schema.json
+++ b/.github/workflows/models-ci-config-schema.json
@@ -6,7 +6,7 @@
   "$defs": {
     "device_names": {
       "type": "string",
-      "enum": ["N150", "N300", "T3K", "GALAXY", "GALAXY_BH", "P100", "P150X4", "P150X8", "P300X2", "DUAL_GALAXY"]
+      "enum": ["N150", "N300", "T3K", "GALAXY", "GALAXY_BH", "P100", "P150X4", "P150X8", "P300X2", "DUAL_GALAXY", "QUAD_GALAXY"]
     },
     "device_arg_entry": {
       "type": "object",

--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -5,7 +5,7 @@
       "ci": {
         "nightly": {
           "devices": [
-            "DUAL_GALAXY"
+            "QUAD_GALAXY"
           ]
         }
       }


### PR DESCRIPTION
closes #3091 
as DUAL_GALAXY is not available as a runner, we must switch to QUAD_GALAXY