### PR TITLE
cpp server - make ContiguousMemoryManager allocate from a slot pool

### DIFF
--- a/tt-media-server/cpp_server/include/services/memory_services/contiguous_memory_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/memory_services/contiguous_memory_manager.hpp
@@ -3,15 +3,28 @@
 
 #pragma once
 
+#include <cstdint>
+#include <set>
+
 #include "services/memory_services/memory_manager.hpp"
 
 namespace tt::services {
 
 class ContiguousMemoryManager : public MemoryManager {
  public:
-  ContiguousMemoryManager() = default;
+  explicit ContiguousMemoryManager(uint32_t poolSize);
 
   void handleRequest(const domain::ManageMemoryTask& request) override;
+
+  uint32_t getPoolSize() const { return slotPoolSize; }
+  uint32_t getFreeCount() const {
+    return static_cast<uint32_t>(freeSlots.size());
+  }
+
+ private:
+  uint32_t slotPoolSize;
+  std::set<uint32_t> freeSlots;
+  std::set<uint32_t> allocatedSlots;
 };
 
 }  // namespace tt::services

--- a/tt-media-server/cpp_server/src/runners/blaze_runner/sp_pipeline_runner_demo.cpp
+++ b/tt-media-server/cpp_server/src/runners/blaze_runner/sp_pipeline_runner_demo.cpp
@@ -32,7 +32,7 @@ SpPipelineRunnerDemo::SpPipelineRunnerDemo(const config::LLMConfig& config,
       outputHangTimeout(tt::config::outputHangTimeoutMs()) {
   if (tt::config::llmMode() == config::LLMMode::DECODE_ONLY ||
       tt::config::llmMode() == config::LLMMode::REGULAR) {
-    memoryManager = std::make_unique<services::ContiguousMemoryManager>();
+    memoryManager = std::make_unique<services::ContiguousMemoryManager>(64);
     memoryThread = std::thread([this] { memoryLoop(); });
   }
 

--- a/tt-media-server/cpp_server/src/services/memory_services/contiguous_memory_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/memory_services/contiguous_memory_manager.cpp
@@ -4,22 +4,84 @@
 #include "services/memory_services/contiguous_memory_manager.hpp"
 
 #include "domain/manage_memory.hpp"
+#include "utils/logger.hpp"
 
 namespace tt::services {
 
 using tt::domain::ManageMemoryResult;
 using tt::domain::ManageMemoryStatus;
 using tt::domain::ManageMemoryTask;
+using tt::domain::MemoryManagementAction;
+
+ContiguousMemoryManager::ContiguousMemoryManager(uint32_t poolSize)
+    : slotPoolSize(poolSize) {
+  for (uint32_t i = 0; i < poolSize; ++i) {
+    freeSlots.insert(i);
+  }
+  TT_LOG_INFO("[ContiguousMemoryManager] Initialized with {} slots", poolSize);
+}
 
 void ContiguousMemoryManager::handleRequest(const ManageMemoryTask& task) {
-  ManageMemoryResult result{};
-  result.taskId = task.taskId;
-  // TODO return a proper slot id here
-  result.slotIds = {static_cast<std::uint32_t>(123)};
-  if (task.action != domain::MemoryManagementAction::DEALLOCATE) {
-    result.status = domain::ManageMemoryStatus::SUCCESS;
+  switch (task.action) {
+    case MemoryManagementAction::ALLOCATE: {
+      if (freeSlots.empty()) {
+        TT_LOG_DEBUG(
+            "[ContiguousMemoryManager] ALLOCATE taskId={}: pool exhausted "
+            "(allocated={})",
+            task.taskId, allocatedSlots.size());
+
+        ManageMemoryResult result{};
+        result.taskId = task.taskId;
+        result.status = ManageMemoryStatus::FAILURE;
+        resultQueue->push(result);
+        return;
+      }
+
+      uint32_t slotId = *freeSlots.begin();
+      freeSlots.erase(freeSlots.begin());
+      allocatedSlots.insert(slotId);
+
+      TT_LOG_DEBUG(
+          "[ContiguousMemoryManager] ALLOCATE taskId={}: assigned slot={}, "
+          "free={}, allocated={}",
+          task.taskId, slotId, freeSlots.size(), allocatedSlots.size());
+
+      ManageMemoryResult result{};
+      result.taskId = task.taskId;
+      result.status = ManageMemoryStatus::SUCCESS;
+      result.slotIds = {slotId};
+      resultQueue->push(result);
+      return;
+    }
+
+    case MemoryManagementAction::DEALLOCATE: {
+      for (uint32_t slotId : task.slotIds) {
+        if (allocatedSlots.erase(slotId) > 0) {
+          freeSlots.insert(slotId);
+          TT_LOG_DEBUG(
+              "[ContiguousMemoryManager] DEALLOCATE taskId={}: freed slot={}, "
+              "free={}, allocated={}",
+              task.taskId, slotId, freeSlots.size(), allocatedSlots.size());
+        } else {
+          TT_LOG_WARN(
+              "[ContiguousMemoryManager] DEALLOCATE taskId={}: slot={} was "
+              "not allocated",
+              task.taskId, slotId);
+        }
+      }
+      return;
+    }
+
+    default: {
+      TT_LOG_WARN(
+          "[ContiguousMemoryManager] Unsupported action {} for taskId={}",
+          static_cast<int>(task.action), task.taskId);
+      ManageMemoryResult result{};
+      result.taskId = task.taskId;
+      result.status = ManageMemoryStatus::FAILURE;
+      resultQueue->push(result);
+    }
   }
-  resultQueue->push(result);
 }
 
 }  // namespace tt::services


### PR DESCRIPTION
Adapts ContiguousMemoryManager to own a pool of N slot IDs instead of returning slot ID 123 for all requests.
This enables testing of upcoming prefix caching.
