### PR TITLE
Add GPT OSS 120B forge (tt-xla) model support for Galaxy

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -475,6 +475,16 @@
         }
       }
     },
+    "gpt-oss-120b-forge": {
+      "inference_engine": "FORGE",
+      "ci": {
+        "nightly": {
+          "devices": [
+            "GALAXY"
+          ]
+        }
+      }
+    },
     "gpt-oss-20b": {
       "inference_engine": "vLLM",
       "ci": {

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -34,6 +34,7 @@ class SupportedModels(Enum):
     QWEN_3_8B = "Qwen/Qwen3-8B"
     SPEECHT5_TTS = "microsoft/speecht5_tts"
     GEMMA_1_1_2B_IT = "google/gemma-1.1-2b-it"
+    GPT_OSS_120B = "openai/gpt-oss-120b"
 
 
 # MODEL environment variable
@@ -74,6 +75,7 @@ class ModelNames(Enum):
     QWEN_3_8B = "Qwen3-8B"
     SPEECHT5_TTS = "speecht5_tts"
     GEMMA_1_1_2B_IT = "gemma-1.1-2b-it"
+    GPT_OSS_120B = "gpt-oss-120b"
 
 
 class ModelRunners(Enum):
@@ -112,6 +114,7 @@ class ModelRunners(Enum):
     LLAMA_RUNNER = "llama_runner"
     TT_SPEECHT5_TTS = "tt-speecht5-tts"
     TT_XLA_SDXL = "tt-xla-sdxl"
+    VLLMForge_GPT_OSS_120B = "vllm_forge_gpt_oss_120b"
 
 
 class ModelServices(Enum):
@@ -141,6 +144,7 @@ MODEL_SERVICE_RUNNER_MAP = {
     ModelServices.LLM: {
         ModelRunners.VLLMForge,
         ModelRunners.VLLMForge_LLAMA_70B,
+        ModelRunners.VLLMForge_GPT_OSS_120B,
         ModelRunners.LLM_TEST,
         ModelRunners.LLAMA_RUNNER,
         ModelRunners.LORA_SINGLE_CHIP,
@@ -219,6 +223,7 @@ MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.TRAINING_GEMMA_LORA: {ModelNames.GEMMA_1_1_2B_IT},
     ModelRunners.TRAINING_LLAMA_LORA: {ModelNames.LLAMA_3_1_8B},
     ModelRunners.LORA_SINGLE_CHIP: {ModelNames.GEMMA_1_1_2B_IT},
+    ModelRunners.VLLMForge_GPT_OSS_120B: {ModelNames.GPT_OSS_120B},
     ModelRunners.TT_XLA_SDXL: {
         ModelNames.STABLE_DIFFUSION_XL_BASE,
         ModelNames.STABLE_DIFFUSION_XL_512,
@@ -1077,6 +1082,21 @@ ModelConfigs = {
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_4.value,
         "max_batch_size": 1,
+    },
+    (ModelRunners.VLLMForge_GPT_OSS_120B, DeviceTypes.GALAXY): {
+        "device_mesh_shape": (4, 8),
+        "is_galaxy": True,
+        "device_ids": DeviceIds.DEVICE_IDS_32_GROUP.value,
+        "max_batch_size": 1,
+        "vllm": {
+            "model": SupportedModels.GPT_OSS_120B.value,
+            "max_model_length": 1024,
+            "max_num_batched_tokens": 1024,
+            "min_context_length": 32,
+            "max_num_seqs": 1,
+        },
+        "queue_for_multiprocessing": QueueType.FasterFifo.value,
+        "request_processing_timeout_seconds": 5400,
     },
     (ModelRunners.TT_XLA_SDXL, DeviceTypes.P150X4): {
         "device_mesh_shape": (1, 1),

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -73,6 +73,10 @@ AVAILABLE_RUNNERS = {
         "tt_model_runners.vllm_forge_llama_70b",
         fromlist=["VLLMForgeLlama70BRunner"],
     ).VLLMForgeLlama70BRunner(wid),
+    ModelRunners.VLLMForge_GPT_OSS_120B: lambda wid: __import__(
+        "tt_model_runners.vllm_forge_gpt_oss_120b",
+        fromlist=["VLLMForgeGPTOSS120BRunner"],
+    ).VLLMForgeGPTOSS120BRunner(wid),
     ModelRunners.TT_XLA_RESNET: lambda wid: __import__(
         "tt_model_runners.forge_runners.runners", fromlist=["ForgeResnetRunner"]
     ).ForgeResnetRunner(wid),

--- a/tt-media-server/tt_model_runners/vllm_forge_gpt_oss_120b.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_gpt_oss_120b.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+import asyncio
+import os
+import traceback
+
+from domain.completion_request import CompletionRequest
+from domain.completion_response import CompletionOutput, CompletionResult
+from telemetry.telemetry_client import TelemetryEvent
+from tt_model_runners.base_device_runner import BaseDeviceRunner
+from utils.decorators import log_execution_time
+from utils.sampling_params_builder import build_sampling_params
+from utils.text_utils import TextUtils
+from vllm import AsyncEngineArgs, AsyncLLMEngine, SamplingParams
+
+CHUNK_TYPE = "streaming_chunk"
+FINAL_TYPE = "final_result"
+
+
+class VLLMForgeGPTOSS120BRunner(BaseDeviceRunner):
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+
+    @log_execution_time(
+        "VLLM Forge GPT OSS 120B model load",
+        TelemetryEvent.DEVICE_WARMUP,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    async def warmup(self) -> bool:
+        self.logger.info(
+            f"Device {self.device_id}: Loading VLLM Forge GPT OSS 120B model..."
+        )
+        prompt = "Hello, it's me"
+        engine_args = AsyncEngineArgs(
+            model=self.settings.vllm.model,
+            max_model_len=self.settings.vllm.max_model_length,
+            max_num_batched_tokens=self.settings.vllm.max_num_batched_tokens,
+            max_num_seqs=self.settings.vllm.max_num_seqs,
+            enable_chunked_prefill=False,
+            gpu_memory_utilization=self.settings.vllm.gpu_memory_utilization,
+            additional_config={
+                "enable_const_eval": True,
+                "min_context_len": self.settings.vllm.min_context_length,
+                "enable_tensor_parallel": True,
+                "optimization_level": 1,
+                "cpu_sampling": True,
+                "weight_dtype_overrides": {
+                    "model.layers.*.mlp.router.weight": "bf16",
+                    "model.layers.*.mlp.experts.gate_up_proj": "bfp_bf4",
+                    "model.layers.*.mlp.experts.down_proj": "bfp_bf4",
+                    "default": "bfp_bf8",
+                },
+            },
+        )
+        self.llm_engine = AsyncLLMEngine.from_engine_args(engine_args)
+
+        self.logger.info(f"Device {self.device_id}: Starting model warmup")
+        warmup_sampling_params = SamplingParams(temperature=0.0, max_tokens=10)
+        warmup_generator = self.llm_engine.generate(
+            prompt, warmup_sampling_params, "warmup_task_id"
+        )
+        async for _ in warmup_generator:
+            pass  # Just consume the generator for warmup
+        self.logger.info(f"Device {self.device_id}: Model warmup completed")
+        return True
+
+    def _build_vllm_input(self, request: CompletionRequest):
+        if isinstance(request.prompt, str):
+            return request.prompt
+        elif isinstance(request.prompt, list):
+            return {"prompt_token_ids": request.prompt}
+        raise ValueError(f"Invalid prompt type: {type(request.prompt)}")
+
+    @log_execution_time(
+        "Run VLLM Forge GPT OSS 120B inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    def run(self, requests: list[CompletionRequest]):
+        """Synchronous wrapper for async inference"""
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(self._run_async(requests))
+
+    async def _run_async(self, requests: list[CompletionRequest]):
+        try:
+            self.logger.debug(
+                f"Device {self.device_id}: Running GPT OSS 120B inference"
+            )
+
+            request = requests[0]
+            if request.stream:
+                return self._generate_streaming(request)
+            else:
+                return await self._generate_non_streaming(requests)
+        except Exception as e:
+            self.logger.error(
+                f"Device {self.device_id}: GPT OSS 120B inference failed: {type(e).__name__}: {e}"
+            )
+            self.logger.error(
+                f"Device {self.device_id}: Full traceback: {traceback.format_exc()}"
+            )
+            raise RuntimeError(f"GPT OSS 120B inference failed: {str(e)}") from e
+
+    async def _generate_streaming(self, request: CompletionRequest):
+        """Yields CompletionOutput dicts for streaming generation."""
+
+        chunks = []
+        strip_eos = TextUtils.strip_eos
+        sampling_params = build_sampling_params(request)
+
+        async for request_output in self.llm_engine.generate(
+            self._build_vllm_input(request), sampling_params, request._task_id
+        ):
+            outputs = request_output.outputs
+            if not outputs:
+                continue
+
+            for output in outputs:
+                chunk_text = output.text
+                if not chunk_text:
+                    continue
+
+                if chunk_text.endswith(("</s>", "<|endoftext|>", "<|im_end|>")):
+                    chunk_text = strip_eos(chunk_text)
+                    if not chunk_text:
+                        continue
+
+                chunks.append(chunk_text)
+
+                yield CompletionOutput(
+                    type=CHUNK_TYPE,
+                    data=CompletionResult(text=chunk_text),
+                )
+
+        self.logger.info(
+            f"Device {self.device_id}: GPT OSS 120B streaming generation completed"
+        )
+
+        yield CompletionOutput(
+            type=FINAL_TYPE,
+            data=CompletionResult(text=""),
+        )
+
+    async def process_request_non_streaming(
+        self, request: CompletionRequest
+    ) -> CompletionOutput:
+        self.logger.info(
+            f"Device {self.device_id}: Starting GPT OSS 120B non-streaming generation"
+        )
+
+        sampling_params = build_sampling_params(request)
+
+        generated_text = []
+        async for request_output in self.llm_engine.generate(
+            self._build_vllm_input(request), sampling_params, request._task_id
+        ):
+            if request_output.outputs:
+                generated_text.append(request_output.outputs[0].text)
+
+        generated_text = "".join(generated_text)
+
+        self.logger.info(
+            f"Device {self.device_id}: GPT OSS 120B non-streaming generation completed"
+        )
+
+        return CompletionOutput(
+            type=FINAL_TYPE,
+            data=CompletionResult(text=generated_text),
+        )
+
+    async def _generate_non_streaming(self, requests: list[CompletionRequest]):
+        tasks = [self.process_request_non_streaming(request) for request in requests]
+        self.logger.info(
+            f"Device {self.device_id}: Starting non-streaming batch generation for {len(tasks)} requests"
+        )
+        results = await asyncio.gather(*tasks)
+        self.logger.info(
+            f"Device {self.device_id}: Non-streaming batch generation completed for {len(tasks)} requests"
+        )
+        return results

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -3648,6 +3648,34 @@ cnn_templates = [
             "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
         },
     ),
+    ModelSpecTemplate(
+        weights=["openai/gpt-oss-120b"],
+        tt_metal_commit="2496be4",
+        impl=forge_vllm_plugin_impl,
+        min_disk_gb=260,
+        min_ram_gb=300,
+        model_type=ModelType.LLM,
+        inference_engine=InferenceEngine.FORGE.value,
+        uses_tensor_model_cache=False,
+        device_model_specs=[
+            DeviceModelSpec(
+                device=DeviceTypes.GALAXY,
+                max_concurrency=1,
+                max_context=1024,
+                default_impl=False,
+                env_vars={
+                    "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
+                    "VLLM__MAX_MODEL_LENGTH": "1024",
+                    "VLLM__MIN_CONTEXT_LENGTH": "32",
+                    "MESH_DEVICE": "(4, 8)",
+                },
+            ),
+        ],
+        status=ModelStatusTypes.EXPERIMENTAL,
+        env_vars={
+            "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
+        },
+    ),
 ]
 
 # make spec_templates from the templates in the correct order


### PR DESCRIPTION
Add a forge/tt-xla compiled implementation of GPT OSS 120B alongside the existing tt-metal handwritten version, enabling 1-to-1 accuracy and performance comparison on Galaxy machines.

Changes:
- New VLLMForgeGPTOSS120BRunner with MoE-specific weight_dtype_overrides (router=bf16, experts=bfp_bf4, default=bfp_bf8)
- Constants: SupportedModels, ModelNames, ModelRunners, ModelConfigs for Galaxy (4x8 mesh, 32-chip tensor parallel)
- Model spec with forge_vllm_plugin_impl, default_impl=False so tt-metal remains the default; select via --engine forge
- Nightly CI config entry for Galaxy