### PR TITLE
cpp server - add EventRecorder for ContiguousMemoryManager slot events

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -266,6 +266,7 @@ set(LLM_RUNNER_LIB_SOURCES
     src/services/memory_services/memory_manager.cpp
     src/services/memory_services/paged_memory_manager.cpp
     src/services/memory_services/contiguous_memory_manager.cpp
+    src/utils/event_recorder.cpp
     src/runners/blaze_runner/sp_pipeline_runner_demo.cpp
     src/runners/blaze_runner/i_sp_pipeline_model_runner.cpp
     src/runners/blaze_runner/sp_pipeline_model_runner.cpp

--- a/tt-media-server/cpp_server/include/utils/event_recorder.hpp
+++ b/tt-media-server/cpp_server/include/utils/event_recorder.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#pragma once
+
+#include <chrono>
+#include <fstream>
+#include <mutex>
+#include <string_view>
+
+namespace tt::utils {
+
+class EventRecorder {
+ public:
+  static EventRecorder& instance();
+
+  void record(std::string_view source, std::string_view event,
+              std::string_view payload = "");
+
+  bool isEnabled() const { return enabled; }
+
+  EventRecorder(const EventRecorder&) = delete;
+  EventRecorder& operator=(const EventRecorder&) = delete;
+
+ private:
+  EventRecorder();
+  ~EventRecorder();
+
+  bool enabled{false};
+  std::ofstream file;
+  std::mutex mutex;
+  std::chrono::steady_clock::time_point epoch;
+};
+
+}  // namespace tt::utils

--- a/tt-media-server/cpp_server/src/services/memory_services/contiguous_memory_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/memory_services/contiguous_memory_manager.cpp
@@ -3,7 +3,10 @@
 
 #include "services/memory_services/contiguous_memory_manager.hpp"
 
+#include <string>
+
 #include "domain/manage_memory.hpp"
+#include "utils/event_recorder.hpp"
 #include "utils/logger.hpp"
 
 namespace tt::services {
@@ -19,9 +22,15 @@ ContiguousMemoryManager::ContiguousMemoryManager(uint32_t poolSize)
     freeSlots.insert(i);
   }
   TT_LOG_INFO("[ContiguousMemoryManager] Initialized with {} slots", poolSize);
+
+  auto& recorder = tt::utils::EventRecorder::instance();
+  recorder.record("MM", "POOL_INITIALIZED",
+                  "\"pool_size\":" + std::to_string(poolSize));
 }
 
 void ContiguousMemoryManager::handleRequest(const ManageMemoryTask& task) {
+  auto& recorder = tt::utils::EventRecorder::instance();
+
   switch (task.action) {
     case MemoryManagementAction::ALLOCATE: {
       if (freeSlots.empty()) {
@@ -29,6 +38,11 @@ void ContiguousMemoryManager::handleRequest(const ManageMemoryTask& task) {
             "[ContiguousMemoryManager] ALLOCATE taskId={}: pool exhausted "
             "(allocated={})",
             task.taskId, allocatedSlots.size());
+
+        recorder.record(
+            "MM", "ALLOC_EXHAUSTED",
+            "\"task_id\":" + std::to_string(task.taskId) +
+                ",\"allocated\":" + std::to_string(allocatedSlots.size()));
 
         ManageMemoryResult result{};
         result.taskId = task.taskId;
@@ -46,6 +60,13 @@ void ContiguousMemoryManager::handleRequest(const ManageMemoryTask& task) {
           "free={}, allocated={}",
           task.taskId, slotId, freeSlots.size(), allocatedSlots.size());
 
+      recorder.record(
+          "MM", "SLOT_ALLOCATED",
+          "\"task_id\":" + std::to_string(task.taskId) +
+              ",\"slot_id\":" + std::to_string(slotId) +
+              ",\"free\":" + std::to_string(freeSlots.size()) +
+              ",\"allocated\":" + std::to_string(allocatedSlots.size()));
+
       ManageMemoryResult result{};
       result.taskId = task.taskId;
       result.status = ManageMemoryStatus::SUCCESS;
@@ -62,11 +83,23 @@ void ContiguousMemoryManager::handleRequest(const ManageMemoryTask& task) {
               "[ContiguousMemoryManager] DEALLOCATE taskId={}: freed slot={}, "
               "free={}, allocated={}",
               task.taskId, slotId, freeSlots.size(), allocatedSlots.size());
+
+          recorder.record(
+              "MM", "SLOT_DEALLOCATED",
+              "\"task_id\":" + std::to_string(task.taskId) +
+                  ",\"slot_id\":" + std::to_string(slotId) +
+                  ",\"free\":" + std::to_string(freeSlots.size()) +
+                  ",\"allocated\":" + std::to_string(allocatedSlots.size()));
         } else {
           TT_LOG_WARN(
               "[ContiguousMemoryManager] DEALLOCATE taskId={}: slot={} was "
               "not allocated",
               task.taskId, slotId);
+
+          recorder.record(
+              "MM", "DEALLOC_UNKNOWN_SLOT",
+              "\"task_id\":" + std::to_string(task.taskId) +
+                  ",\"slot_id\":" + std::to_string(slotId));
         }
       }
       return;

--- a/tt-media-server/cpp_server/src/utils/event_recorder.cpp
+++ b/tt-media-server/cpp_server/src/utils/event_recorder.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#include "utils/event_recorder.hpp"
+
+#include <cstdlib>
+
+namespace tt::utils {
+
+EventRecorder& EventRecorder::instance() {
+  static EventRecorder recorder;
+  return recorder;
+}
+
+EventRecorder::EventRecorder() {
+  const char* path = std::getenv("SLOT_EVENT_LOG");
+  if (!path || path[0] == '\0') {
+    path = std::getenv("TT_SLOT_EVENT_LOG");
+  }
+  if (!path || path[0] == '\0') {
+    return;
+  }
+
+  file.open(path, std::ios::out | std::ios::trunc);
+  if (!file.is_open()) {
+    return;
+  }
+
+  enabled = true;
+  epoch = std::chrono::steady_clock::now();
+}
+
+EventRecorder::~EventRecorder() {
+  if (file.is_open()) {
+    file.close();
+  }
+}
+
+void EventRecorder::record(std::string_view source, std::string_view event,
+                           std::string_view payload) {
+  if (!enabled) return;
+
+  auto now = std::chrono::steady_clock::now();
+  auto elapsedUs =
+      std::chrono::duration_cast<std::chrono::microseconds>(now - epoch)
+          .count();
+
+  std::lock_guard lock(mutex);
+  file << R"({"t_us":)" << elapsedUs << R"(,"src":")" << source
+       << R"(","event":")" << event << '"';
+  if (!payload.empty()) {
+    file << ',' << payload;
+  }
+  file << "}\n";
+  file.flush();
+}
+
+}  // namespace tt::utils


### PR DESCRIPTION
Adds the EventRecorder utility (opt-in via SLOT_EVENT_LOG / TT_SLOT_EVENT_LOG env vars) and wires ContiguousMemoryManager to emit pool-init, allocate, deallocate and exhaustion events under the "MM" source for offline slot visualization, on top of the slot-pool changes from #3097.

Made with [Cursor](https://cursor.com)