### PR TITLE
fix: use float timestamps for sub-second generation time precision

### DIFF
--- a/tt-media-server/utils/job_database.py
+++ b/tt-media-server/utils/job_database.py
@@ -50,8 +50,8 @@ class JobDatabase:
                     model TEXT NOT NULL,
                     request_parameters TEXT,
                     status TEXT NOT NULL,
-                    created_at INTEGER NOT NULL,
-                    completed_at INTEGER,
+                    created_at REAL NOT NULL,
+                    completed_at REAL,
                     error_message TEXT,
                     result_path TEXT,
                     org_id TEXT
@@ -105,7 +105,7 @@ class JobDatabase:
         model: str,
         request_parameters: dict,
         status: str,
-        created_at: int,
+        created_at: float,
         org_id: Optional[str] = None,
     ) -> None:
         """Insert a new job into the database."""
@@ -129,7 +129,7 @@ class JobDatabase:
         self,
         job_id: str,
         status: str,
-        completed_at: Optional[int] = None,
+        completed_at: Optional[float] = None,
         result_path: Optional[str] = None,
         error_message: Optional[dict[str, str]] = None,
     ) -> None:

--- a/tt-media-server/utils/job_manager.py
+++ b/tt-media-server/utils/job_manager.py
@@ -36,8 +36,8 @@ class Job:
     request_parameters: dict = field(default_factory=dict)
     org_id: Optional[str] = None
     status: JobStatus = JobStatus.QUEUED
-    created_at: int = None
-    completed_at: Optional[int] = None
+    created_at: float = None
+    completed_at: Optional[float] = None
     result_path: Optional[str] = None
     error: Optional[dict] = None
     _task: Callable = None
@@ -49,13 +49,13 @@ class Job:
 
     def __post_init__(self):
         if self.created_at is None:
-            self.created_at = int(time.time())
+            self.created_at = time.time()
 
     def mark_in_progress(self):
         self.status = JobStatus.IN_PROGRESS
 
     def mark_completed(self, result_path: str):
-        self.completed_at = int(time.time())
+        self.completed_at = time.time()
         self.status = JobStatus.COMPLETED
         self.result_path = result_path
 
@@ -64,10 +64,10 @@ class Job:
 
     def mark_cancelled(self):
         self.status = JobStatus.CANCELLED
-        self.completed_at = int(time.time())
+        self.completed_at = time.time()
 
     def mark_failed(self, error_code: str, error_message: str):
-        self.completed_at = int(time.time())
+        self.completed_at = time.time()
         self.status = JobStatus.FAILED
         self.error = {"code": error_code, "message": error_message}
 


### PR DESCRIPTION
## Summary

`created_at` and `completed_at` were stored as `int`, using `int(time.time())` which truncates to whole seconds. This caused generation times to display as `2.0s` instead of the actual `2.3s`.

## Changes

**`tt-media-server/utils/job_manager.py`**
- `created_at: int` → `float`
- `completed_at: Optional[int]` → `Optional[float]`
- `int(time.time())` → `time.time()` in `__post_init__`, `mark_completed`, `mark_cancelled`, `mark_failed`

**`tt-media-server/utils/job_database.py`**
- `created_at INTEGER` → `REAL` in SQLite schema
- `completed_at INTEGER` → `REAL` in SQLite schema
- Type annotations `int` → `float` for `created_at`/`completed_at` parameters

## Effect

`completed_at` is now returned as a float (e.g. `1776881712.648`) instead of an integer (`1776881712`). The `flexTime` parser in consumers that handle both Unix integers and floats will preserve the sub-second precision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)