### PR TITLE
Escape '+' in produce_data workflow_run filter

### DIFF
--- a/.github/workflows/produce_data.yml
+++ b/.github/workflows/produce_data.yml
@@ -16,7 +16,7 @@ on:
         default: 1
   workflow_run:
     workflows:
-      - "Nightly C++ Server Benchmarks"
+      - 'Nightly C\+\+ Server Benchmarks'
     types:
       - completed
 


### PR DESCRIPTION
GitHub Actions treats workflow_run `workflows:` entries as glob patterns, so the literal `+` in "C++" caused the filter to fail to parse. 

The result was a phantom BuildFailed workflow generating a startup_failure run for every workflow_run lifecycle event in the repo (6,000+ failures since the dev → main migration on Apr 16). 

Escape the plus signs so the filter matches the literal workflow name.

Refs: https://github.com/orgs/community/discussions/128694