### PR TITLE
Add google/gemma-4-31B-it as supported Forge model

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -34,6 +34,7 @@ class SupportedModels(Enum):
     QWEN_3_8B = "Qwen/Qwen3-8B"
     SPEECHT5_TTS = "microsoft/speecht5_tts"
     GEMMA_1_1_2B_IT = "google/gemma-1.1-2b-it"
+    GEMMA_4_31B_IT = "google/gemma-4-31B-it"
     FALCON3_7B_INSTRUCT = "tiiuae/Falcon3-7B-Instruct"
     Z_IMAGE_TURBO = "Tongyi-MAI/Z-Image-Turbo"
 
@@ -76,6 +77,7 @@ class ModelNames(Enum):
     QWEN_3_8B = "Qwen3-8B"
     SPEECHT5_TTS = "speecht5_tts"
     GEMMA_1_1_2B_IT = "gemma-1.1-2b-it"
+    GEMMA_4_31B_IT = "gemma-4-31b-it"
     FALCON3_7B_INSTRUCT = "Falcon3-7B-Instruct"
     Z_IMAGE_TURBO = "Z-Image-Turbo"
 
@@ -97,6 +99,7 @@ class ModelRunners(Enum):
     TT_YOLOV4 = "tt-yolov4"
     VLLMForge_QWEN_EMBEDDING = "vllmforge_qwen_embedding"
     VLLMForge_LLAMA_70B = "vllm_forge_llama_70b"
+    VLLMForge_GEMMA4_31B = "vllm_forge_gemma4_31b"
     QWEN_EMBEDDING_8B = "qwen_embedding_8b"
     BGELargeEN_V1_5 = "bge_large_en_v1_5"
     BGEM3 = "bge-m3"
@@ -147,6 +150,7 @@ MODEL_SERVICE_RUNNER_MAP = {
     ModelServices.LLM: {
         ModelRunners.VLLMForge,
         ModelRunners.VLLMForge_LLAMA_70B,
+        ModelRunners.VLLMForge_GEMMA4_31B,
         ModelRunners.LLM_TEST,
         ModelRunners.LLAMA_RUNNER,
         ModelRunners.LORA_SINGLE_CHIP,
@@ -211,6 +215,7 @@ MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.TT_XLA_VIT: {ModelNames.VIT},
     ModelRunners.VLLMForge_QWEN_EMBEDDING: {ModelNames.QWEN_3_EMBEDDING_4B},
     ModelRunners.VLLMForge_LLAMA_70B: {ModelNames.LLAMA_3_1_70B},
+    ModelRunners.VLLMForge_GEMMA4_31B: {ModelNames.GEMMA_4_31B_IT},
     ModelRunners.QWEN_EMBEDDING_8B: {ModelNames.QWEN_3_EMBEDDING_8B},
     ModelRunners.BGELargeEN_V1_5: {ModelNames.BGE_LARGE_EN_V1_5},
     ModelRunners.BGEM3: {ModelNames.BGE_M3},
@@ -848,6 +853,22 @@ ModelConfigs = {
             "model": SupportedModels.LLAMA_3_1_70B.value,
             "max_model_length": 1024,
             "max_num_batched_tokens": 1024,
+            "min_context_length": 32,
+            "max_num_seqs": 1,
+        },
+        "queue_for_multiprocessing": QueueType.FasterFifo.value,
+    },
+    (ModelRunners.VLLMForge_GEMMA4_31B, DeviceTypes.P300X2): {
+        "device_mesh_shape": (1, 4),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_4_GROUP.value,
+        "max_batch_size": 1,
+        "vllm": {
+            "model": SupportedModels.GEMMA_4_31B_IT.value,
+            "max_model_length": 512,
+            # Gemma-4 multimodal requires max_num_batched_tokens >= 2560
+            # (video: _VIDEO_MAX_FRAMES=32 * 78 tokens = 2496).
+            "max_num_batched_tokens": 2560,
             "min_context_length": 32,
             "max_num_seqs": 1,
         },

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -73,6 +73,10 @@ AVAILABLE_RUNNERS = {
         "tt_model_runners.vllm_forge_llama_70b",
         fromlist=["VLLMForgeLlama70BRunner"],
     ).VLLMForgeLlama70BRunner(wid),
+    ModelRunners.VLLMForge_GEMMA4_31B: lambda wid: __import__(
+        "tt_model_runners.vllm_forge_gemma4_31b",
+        fromlist=["VLLMForgeGemma4_31BRunner"],
+    ).VLLMForgeGemma4_31BRunner(wid),
     ModelRunners.TT_XLA_RESNET: lambda wid: __import__(
         "tt_model_runners.forge_runners.runners", fromlist=["ForgeResnetRunner"]
     ).ForgeResnetRunner(wid),

--- a/tt-media-server/tt_model_runners/vllm_forge_gemma4_31b.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_gemma4_31b.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+import asyncio
+import os
+import traceback
+
+from domain.completion_request import CompletionRequest
+from domain.completion_response import CompletionOutput, CompletionResult
+from telemetry.telemetry_client import TelemetryEvent
+from tt_model_runners.base_device_runner import BaseDeviceRunner
+from utils.decorators import log_execution_time
+from utils.sampling_params_builder import build_sampling_params
+from utils.text_utils import TextUtils
+from vllm import AsyncEngineArgs, AsyncLLMEngine, SamplingParams
+
+CHUNK_TYPE = "streaming_chunk"
+FINAL_TYPE = "final_result"
+
+
+class VLLMForgeGemma4_31BRunner(BaseDeviceRunner):
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+
+    @log_execution_time(
+        "VLLM Forge Gemma-4 31B model load",
+        TelemetryEvent.DEVICE_WARMUP,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    async def warmup(self) -> bool:
+        self.logger.info(
+            f"Device {self.device_id}: Loading VLLM Forge Gemma-4 31B model..."
+        )
+        prompt = "Hello, it's me"
+        engine_args = AsyncEngineArgs(
+            model=self.settings.vllm.model,
+            max_model_len=self.settings.vllm.max_model_length,
+            max_num_batched_tokens=self.settings.vllm.max_num_batched_tokens,
+            max_num_seqs=self.settings.vllm.max_num_seqs,
+            enable_chunked_prefill=False,
+            gpu_memory_utilization=self.settings.vllm.gpu_memory_utilization,
+            additional_config={
+                "enable_const_eval": True,
+                "min_context_len": self.settings.vllm.min_context_length,
+                "enable_tensor_parallel": True,
+                "use_2d_mesh": False,
+                "cpu_sampling": True,
+                "optimization_level": 0,
+                "experimental_weight_dtype": "bfp_bf8",
+            },
+        )
+        self.llm_engine = AsyncLLMEngine.from_engine_args(engine_args)
+
+        self.logger.info(f"Device {self.device_id}: Starting model warmup")
+        warmup_sampling_params = SamplingParams(temperature=0.0, max_tokens=10)
+        warmup_generator = self.llm_engine.generate(
+            prompt, warmup_sampling_params, "warmup_task_id"
+        )
+        async for _ in warmup_generator:
+            pass
+        self.logger.info(f"Device {self.device_id}: Model warmup completed")
+        return True
+
+    def _build_vllm_input(self, request: CompletionRequest):
+        if isinstance(request.prompt, str):
+            return request.prompt
+        elif isinstance(request.prompt, list):
+            return {"prompt_token_ids": request.prompt}
+        raise ValueError(f"Invalid prompt type: {type(request.prompt)}")
+
+    @log_execution_time(
+        "Run VLLM Forge Gemma-4 31B inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    def run(self, requests: list[CompletionRequest]):
+        """Synchronous wrapper for async inference"""
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(self._run_async(requests))
+
+    async def _run_async(self, requests: list[CompletionRequest]):
+        try:
+            self.logger.debug(f"Device {self.device_id}: Running Gemma-4 31B inference")
+
+            request = requests[0]
+            if request.stream:
+                return self._generate_streaming(request)
+            else:
+                return await self._generate_non_streaming(requests)
+        except Exception as e:
+            self.logger.error(
+                f"Device {self.device_id}: Gemma-4 31B inference failed: {type(e).__name__}: {e}"
+            )
+            self.logger.error(
+                f"Device {self.device_id}: Full traceback: {traceback.format_exc()}"
+            )
+            raise RuntimeError(f"Gemma-4 31B inference failed: {str(e)}") from e
+
+    async def _generate_streaming(self, request: CompletionRequest):
+        """Yields CompletionOutput dicts for streaming generation."""
+
+        chunks = []
+        strip_eos = TextUtils.strip_eos
+        sampling_params = build_sampling_params(request)
+
+        async for request_output in self.llm_engine.generate(
+            self._build_vllm_input(request), sampling_params, request._task_id
+        ):
+            outputs = request_output.outputs
+            if not outputs:
+                continue
+
+            for output in outputs:
+                chunk_text = output.text
+                if not chunk_text:
+                    continue
+
+                if chunk_text.endswith(
+                    ("</s>", "<|endoftext|>", "<|im_end|>", "<end_of_turn>")
+                ):
+                    chunk_text = strip_eos(chunk_text)
+                    if not chunk_text:
+                        continue
+
+                chunks.append(chunk_text)
+
+                yield CompletionOutput(
+                    type=CHUNK_TYPE,
+                    data=CompletionResult(text=chunk_text),
+                )
+
+        self.logger.info(
+            f"Device {self.device_id}: Gemma-4 31B streaming generation completed"
+        )
+
+        yield CompletionOutput(
+            type=FINAL_TYPE,
+            data=CompletionResult(text=""),
+        )
+
+    async def process_request_non_streaming(
+        self, request: CompletionRequest
+    ) -> CompletionOutput:
+        self.logger.info(
+            f"Device {self.device_id}: Starting Gemma-4 31B non-streaming generation"
+        )
+
+        sampling_params = build_sampling_params(request)
+
+        generated_text = []
+        async for request_output in self.llm_engine.generate(
+            self._build_vllm_input(request), sampling_params, request._task_id
+        ):
+            if request_output.outputs:
+                generated_text.append(request_output.outputs[0].text)
+
+        generated_text = "".join(generated_text)
+
+        self.logger.info(
+            f"Device {self.device_id}: Gemma-4 31B non-streaming generation completed"
+        )
+
+        return CompletionOutput(
+            type=FINAL_TYPE,
+            data=CompletionResult(text=generated_text),
+        )
+
+    async def _generate_non_streaming(self, requests: list[CompletionRequest]):
+        tasks = [self.process_request_non_streaming(request) for request in requests]
+        self.logger.info(
+            f"Device {self.device_id}: Starting non-streaming batch generation for {len(tasks)} requests"
+        )
+        results = await asyncio.gather(*tasks)
+        self.logger.info(
+            f"Device {self.device_id}: Non-streaming batch generation completed for {len(tasks)} requests"
+        )
+        return results

--- a/tt-media-server/utils/sampling_params_builder.py
+++ b/tt-media-server/utils/sampling_params_builder.py
@@ -97,6 +97,11 @@ def build_sampling_params(
         max_tokens=max_tokens,
         skip_special_tokens=request.skip_special_tokens,
         spaces_between_special_tokens=request.spaces_between_special_tokens,
-        truncate_prompt_tokens=request.truncate_prompt_tokens,
+        # truncate_prompt_tokens not supported in vLLM 0.19.x
+        **(
+            {"truncate_prompt_tokens": request.truncate_prompt_tokens}
+            if hasattr(SamplingParams, "truncate_prompt_tokens")
+            else {}
+        ),
         output_kind=RequestOutputKind.DELTA,
     )


### PR DESCRIPTION
## Summary

- Adds `google/gemma-4-31B-it` support on QB2 (2x P300, 4-chip 1x4 mesh) via a new `VLLMForgeGemma4_31BRunner`, and fixes a `SamplingParams.truncate_prompt_tokens` crash on vLLM 0.19.x.
- Similar to llama, qwen, falcon models added previously and served as demos

## Test plan

- [x] Server starts and model loads on QB2 and runs correctly, hosted on tt-cloud-console 
- [x] Chat completions return correct streaming output, screenshot in comment