### PR TITLE
Display Prefix Caching Metrics in Grafana

### DIFF
--- a/tt-media-server/cpp_server/include/metrics/metrics.hpp
+++ b/tt-media-server/cpp_server/include/metrics/metrics.hpp
@@ -88,6 +88,20 @@ class ServerMetrics {
    */
   void onHttpResponse(const std::string& method, int statusCode);
 
+  /**
+   * Record one prefix-cache lookup attempt. Called once per request that
+   * enters the hash-based prefix cache routing path (i.e. has a prior
+   * [assistant, user] turn pair).
+   *
+   * `hit` is true if an existing session matching the lookup hash was
+   * acquired and its KV cache reused; false if the lookup missed and a new
+   * session had to be allocated.
+   *
+   * Writes directly to the counter; lookup rate is request-level, not
+   * token-level, so queueing would be unnecessary overhead.
+   */
+  void onPrefixCacheLookup(bool hit);
+
   /** Render the full registry in Prometheus text exposition format. */
   std::string renderText() const;
 
@@ -159,6 +173,8 @@ class ServerMetrics {
   prometheus::Counter* generation_tokens_total_{nullptr};
   prometheus::Family<prometheus::Counter>* request_success_family_{nullptr};
   prometheus::Family<prometheus::Counter>* http_requests_family_{nullptr};
+  prometheus::Counter* prefix_cache_queries_total_{nullptr};
+  prometheus::Counter* prefix_cache_hits_total_{nullptr};
 
   // --- gauges ---
   prometheus::Gauge* queue_depth_{nullptr};

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -16,6 +16,7 @@
 #include "domain/chat_completion_request.hpp"
 #include "domain/chat_completion_response.hpp"
 #include "domain/models_response.hpp"
+#include "metrics/metrics.hpp"
 #include "profiling/tracy.hpp"
 #include "utils/conversation_hasher.hpp"
 #include "utils/id_generator.hpp"
@@ -126,6 +127,7 @@ void LLMController::resolveSession(
 
       if (acquired.has_value()) {
         // HIT: found matching session, send delta only
+        tt::metrics::ServerMetrics::instance().onPrefixCacheLookup(true);
         TT_LOG_DEBUG(
             "[LLMController] Prefix cache HIT: hash={}, sessionId={}, "
             "slotId={}",
@@ -141,6 +143,7 @@ void LLMController::resolveSession(
         return;
       }
 
+      tt::metrics::ServerMetrics::instance().onPrefixCacheLookup(false);
       TT_LOG_DEBUG(
           "[LLMController] Prefix cache MISS: hash={}, allocating new session",
           *routingInfo.lookupHash);

--- a/tt-media-server/cpp_server/src/metrics/metrics.cpp
+++ b/tt-media-server/cpp_server/src/metrics/metrics.cpp
@@ -68,6 +68,28 @@ ServerMetrics::ServerMetrics() {
                "are failures.")
            .Register(*registry_);
 
+  prefix_cache_queries_total_ =
+      &prometheus::BuildCounter()
+           .Name("tt_prefix_cache_queries_total")
+           .Help(
+               "Number of requests that attempted a prefix-cache lookup "
+               "(i.e. had a prior [assistant, user] turn pair). Denominator "
+               "for the prefix cache hit rate: "
+               "rate(tt_prefix_cache_hits_total[5m]) / "
+               "rate(tt_prefix_cache_queries_total[5m]).")
+           .Register(*registry_)
+           .Add(modelLabel);
+
+  prefix_cache_hits_total_ =
+      &prometheus::BuildCounter()
+           .Name("tt_prefix_cache_hits_total")
+           .Help(
+               "Number of prefix-cache lookups that found an existing "
+               "session and reused its KV cache (continuation path, delta "
+               "prompt only).")
+           .Register(*registry_)
+           .Add(modelLabel);
+
   // ----- gauges ----------------------------------------------------------
   queue_depth_ =
       &prometheus::BuildGauge()
@@ -192,6 +214,11 @@ void ServerMetrics::onHttpResponse(const std::string& method, int statusCode) {
              {"method", method},
              {"status_code", std::to_string(statusCode)}})
       .Increment();
+}
+
+void ServerMetrics::onPrefixCacheLookup(bool hit) {
+  prefix_cache_queries_total_->Increment();
+  if (hit) prefix_cache_hits_total_->Increment();
 }
 
 // -----------------------------------------------------------------------------

--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_cpp.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_cpp.json
@@ -1194,6 +1194,95 @@
       ],
       "title": "HTTP Requests (successful / failed)",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 85 },
+      "id": 120,
+      "title": "Prefix Cache",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Rate at which incoming /v1/chat/completions requests attempted a session-level prefix-cache lookup (requests per second). A lookup is attempted whenever the request has a prior [assistant, user] turn pair and therefore *could* match an existing session's KV cache. Fresh first-turn conversations and legacy-sessionId requests are excluded, so this is the denominator of the hit-rate calculation.\n\nSource counter: tt_prefix_cache_queries_total (monotonic, resets on server restart). Computed here as rate(tt_prefix_cache_queries_total[$__rate_interval]).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "reqps",
+          "decimals": 2
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "queries/s" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "blue" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 86 },
+      "id": 121,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true, "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(tt_prefix_cache_queries_total[$__rate_interval])",
+          "legendFormat": "queries/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Prefix Cache Queries",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Rate at which prefix-cache lookups actually succeeded and reused an existing session's KV cache (requests per second). On a hit the server sends only the delta prompt (last user turn) to the model instead of re-prefilling the full conversation, saving a prefill pass.\n\nThis is the numerator of the hit-rate calculation. The instantaneous hit rate over the dashboard window is therefore: rate(tt_prefix_cache_hits_total[$__rate_interval]) / rate(tt_prefix_cache_queries_total[$__rate_interval]).\n\nSource counter: tt_prefix_cache_hits_total (monotonic, resets on server restart). Computed here as rate(tt_prefix_cache_hits_total[$__rate_interval]).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "reqps",
+          "decimals": 2
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "hits/s" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 86 },
+      "id": 122,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true, "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(tt_prefix_cache_hits_total[$__rate_interval])",
+          "legendFormat": "hits/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Prefix Cache Hits",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_cpp.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_cpp.json
@@ -247,7 +247,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "Session-level prefix-cache counters (monotonic since server start; reset on restart).\n\n• Queries: lifetime count of /v1/chat/completions requests that attempted a prefix-cache lookup — i.e. carried a prior [assistant, user] turn pair and therefore *could* match an existing session's KV cache. Fresh first-turn conversations and legacy-sessionId requests are excluded.\n• Hits: subset of queries that actually matched an existing session and reused its KV cache, sending only the delta prompt to the model.\n\nLifetime hit rate = tt_prefix_cache_hits_total / tt_prefix_cache_queries_total. For an instantaneous rate, wrap both in rate(...[5m]).",
+      "description": "Queries: returning-user requests (multiple 'user' messages) checked against the prefix cache. Hits: subset that reused an existing KV cache.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },

--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_cpp.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_cpp.json
@@ -46,7 +46,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "gridPos": { "h": 3, "w": 6, "x": 0, "y": 1 },
       "id": 2,
       "options": { "colorMode": "background_solid", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
@@ -77,7 +77,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 3, "w": 6, "x": 6, "y": 1 },
+      "gridPos": { "h": 3, "w": 6, "x": 0, "y": 4 },
       "id": 1,
       "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
@@ -169,7 +169,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 3, "w": 6, "x": 6, "y": 4 },
+      "gridPos": { "h": 3, "w": 6, "x": 6, "y": 1 },
       "id": 6,
       "options": { "colorMode": "background_solid", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
@@ -199,7 +199,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 3, "w": 6, "x": 12, "y": 4 },
+      "gridPos": { "h": 3, "w": 6, "x": 6, "y": 4 },
       "id": 7,
       "options": { "colorMode": "background_solid", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
@@ -232,7 +232,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 3, "w": 6, "x": 18, "y": 4 },
+      "gridPos": { "h": 3, "w": 6, "x": 12, "y": 4 },
       "id": 4,
       "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
@@ -243,6 +243,44 @@
         }
       ],
       "title": "Request Queue Utilisation",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Session-level prefix-cache counters (monotonic since server start; reset on restart).\n\n• Queries: lifetime count of /v1/chat/completions requests that attempted a prefix-cache lookup — i.e. carried a prior [assistant, user] turn pair and therefore *could* match an existing session's KV cache. Fresh first-turn conversations and legacy-sessionId requests are excluded.\n• Hits: subset of queries that actually matched an existing session and reused its KV cache, sending only the delta prompt to the model.\n\nLifetime hit rate = tt_prefix_cache_hits_total / tt_prefix_cache_queries_total. For an instantaneous rate, wrap both in rate(...[5m]).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 40 },
+              { "color": "red", "value": 60 }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 6, "x": 18, "y": 4 },
+      "id": 8,
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "tt_prefix_cache_queries_total",
+          "legendFormat": "Queries",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "tt_prefix_cache_hits_total",
+          "legendFormat": "Hits",
+          "refId": "B"
+        }
+      ],
+      "title": "Prefix Cache",
       "type": "stat"
     },
     {
@@ -1194,75 +1232,6 @@
       ],
       "title": "HTTP Requests (successful / failed)",
       "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 85 },
-      "id": 120,
-      "title": "Prefix Cache",
-      "type": "row"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "Cumulative number of /v1/chat/completions requests that attempted a session-level prefix-cache lookup since server start. A lookup is attempted whenever the request carries a prior [assistant, user] turn pair and therefore *could* match an existing session's KV cache. Fresh first-turn conversations and legacy-sessionId requests are excluded, so this is the denominator of the hit-rate calculation (hits / queries).\n\nSource counter: tt_prefix_cache_queries_total — monotonic, only resets on server restart.",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "blue", "value": null }
-            ]
-          },
-          "unit": "short",
-          "decimals": 0
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 86 },
-      "id": 121,
-      "options": { "colorMode": "background_solid", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "tt_prefix_cache_queries_total",
-          "legendFormat": "Queries",
-          "refId": "A"
-        }
-      ],
-      "title": "Prefix Cache Queries",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "Cumulative number of prefix-cache lookups that successfully reused an existing session's KV cache since server start. On a hit the server sends only the delta prompt (last user turn) to the model instead of re-prefilling the whole conversation, saving a prefill pass.\n\nThis is the numerator of the hit-rate calculation: tt_prefix_cache_hits_total / tt_prefix_cache_queries_total gives the lifetime hit rate; wrap both in rate(...[5m]) for an instantaneous rate.\n\nSource counter: tt_prefix_cache_hits_total — monotonic, only resets on server restart.",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null }
-            ]
-          },
-          "unit": "short",
-          "decimals": 0
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 86 },
-      "id": 122,
-      "options": { "colorMode": "background_solid", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "tt_prefix_cache_hits_total",
-          "legendFormat": "Hits",
-          "refId": "A"
-        }
-      ],
-      "title": "Prefix Cache Hits",
-      "type": "stat"
     }
   ],
   "refresh": "5s",

--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_cpp.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_cpp.json
@@ -1204,85 +1204,65 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "Rate at which incoming /v1/chat/completions requests attempted a session-level prefix-cache lookup (requests per second). A lookup is attempted whenever the request has a prior [assistant, user] turn pair and therefore *could* match an existing session's KV cache. Fresh first-turn conversations and legacy-sessionId requests are excluded, so this is the denominator of the hit-rate calculation.\n\nSource counter: tt_prefix_cache_queries_total (monotonic, resets on server restart). Computed here as rate(tt_prefix_cache_queries_total[$__rate_interval]).",
+      "description": "Cumulative number of /v1/chat/completions requests that attempted a session-level prefix-cache lookup since server start. A lookup is attempted whenever the request carries a prior [assistant, user] turn pair and therefore *could* match an existing session's KV cache. Fresh first-turn conversations and legacy-sessionId requests are excluded, so this is the denominator of the hit-rate calculation (hits / queries).\n\nSource counter: tt_prefix_cache_queries_total — monotonic, only resets on server restart.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "lineWidth": 2,
-            "showPoints": "never"
-          },
-          "unit": "reqps",
-          "decimals": 2
-        },
-        "overrides": [
-          {
-            "matcher": { "id": "byName", "options": "queries/s" },
-            "properties": [
-              { "id": "color", "value": { "mode": "fixed", "fixedColor": "blue" } }
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null }
             ]
-          }
-        ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 86 },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 86 },
       "id": 121,
-      "options": {
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true, "calcs": ["mean", "max"] },
-        "tooltip": { "mode": "multi", "sort": "none" }
-      },
+      "options": { "colorMode": "background_solid", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "rate(tt_prefix_cache_queries_total[$__rate_interval])",
-          "legendFormat": "queries/s",
+          "expr": "tt_prefix_cache_queries_total",
+          "legendFormat": "Queries",
           "refId": "A"
         }
       ],
       "title": "Prefix Cache Queries",
-      "type": "timeseries"
+      "type": "stat"
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "Rate at which prefix-cache lookups actually succeeded and reused an existing session's KV cache (requests per second). On a hit the server sends only the delta prompt (last user turn) to the model instead of re-prefilling the full conversation, saving a prefill pass.\n\nThis is the numerator of the hit-rate calculation. The instantaneous hit rate over the dashboard window is therefore: rate(tt_prefix_cache_hits_total[$__rate_interval]) / rate(tt_prefix_cache_queries_total[$__rate_interval]).\n\nSource counter: tt_prefix_cache_hits_total (monotonic, resets on server restart). Computed here as rate(tt_prefix_cache_hits_total[$__rate_interval]).",
+      "description": "Cumulative number of prefix-cache lookups that successfully reused an existing session's KV cache since server start. On a hit the server sends only the delta prompt (last user turn) to the model instead of re-prefilling the whole conversation, saving a prefill pass.\n\nThis is the numerator of the hit-rate calculation: tt_prefix_cache_hits_total / tt_prefix_cache_queries_total gives the lifetime hit rate; wrap both in rate(...[5m]) for an instantaneous rate.\n\nSource counter: tt_prefix_cache_hits_total — monotonic, only resets on server restart.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "lineWidth": 2,
-            "showPoints": "never"
-          },
-          "unit": "reqps",
-          "decimals": 2
-        },
-        "overrides": [
-          {
-            "matcher": { "id": "byName", "options": "hits/s" },
-            "properties": [
-              { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
             ]
-          }
-        ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 86 },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 86 },
       "id": 122,
-      "options": {
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true, "calcs": ["mean", "max"] },
-        "tooltip": { "mode": "multi", "sort": "none" }
-      },
+      "options": { "colorMode": "background_solid", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "rate(tt_prefix_cache_hits_total[$__rate_interval])",
-          "legendFormat": "hits/s",
+          "expr": "tt_prefix_cache_hits_total",
+          "legendFormat": "Hits",
           "refId": "A"
         }
       ],
       "title": "Prefix Cache Hits",
-      "type": "timeseries"
+      "type": "stat"
     }
   ],
   "refresh": "5s",


### PR DESCRIPTION
## Issue
[#3099 [Prefix Caching] Add Metric to Grafana](https://github.com/tenstorrent/tt-inference-server/issues/3099)


## Problem
Add two new metrics to Prometheus and their visualization to Grafana:
- `tt_prefix_cache_queries_total` - Number of requests that we checked prefix cache for - these are returning users with multiple "user" role in "messages" field
-`tt_prefix_cache_hits_total` - Number of requests that had prefix cache hit - requests that were able to reuse their already calculated KV Cache

## Implementation
### Prometheus
<img width="1447" height="107" alt="Screenshot 2026-04-23 at 11 59 48" src="https://github.com/user-attachments/assets/7f428052-607a-42bd-b58d-02ddbb5cabe8" />

### Grafana
<img width="345" height="118" alt="Screenshot 2026-04-23 at 12 44 54" src="https://github.com/user-attachments/assets/f9f01620-e916-40c9-9c32-c1d849118df9" />

Single user multi-turn benchmark:
https://github.com/user-attachments/assets/970bae15-4fb3-4053-bf19-88bffc5ad192
