### PR TITLE
test(ci): pin bench deps via uv --exclude-newer to isolate bench regression

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -502,7 +502,10 @@ jobs:
       - name: Install Python test dependencies
         run: |
           uv venv
-          uv pip install vllm
+          # Pin the entire resolution to a known-good cutoff to neutralise
+          # client-side dep drift (e.g. transformers 5.5.4 -> 5.6.1) while we
+          # investigate the bench regression that started ~2026-04-22.
+          uv pip install --exclude-newer 2026-04-22T14:00:00Z vllm
           echo "PATH=${{ github.workspace }}/tt-media-server/.venv/bin:$PATH" >> $GITHUB_ENV
 
       # ── Mock backend benchmarks ──────────────────────────────────────
@@ -826,7 +829,10 @@ jobs:
       - name: Install Python test dependencies
         run: |
           uv venv
-          uv pip install vllm
+          # Pin the entire resolution to a known-good cutoff to neutralise
+          # client-side dep drift (e.g. transformers 5.5.4 -> 5.6.1) while we
+          # investigate the bench regression that started ~2026-04-22.
+          uv pip install --exclude-newer 2026-04-22T14:00:00Z vllm
           echo "PATH=${{ github.workspace }}/tt-media-server/.venv/bin:$PATH" >> $GITHUB_ENV
 
       - name: Run vLLM bench serve against split servers

--- a/tt-media-server/cpp_server/src/runners/blaze_runner/mock_device_pipeline.cpp
+++ b/tt-media-server/cpp_server/src/runners/blaze_runner/mock_device_pipeline.cpp
@@ -57,7 +57,7 @@ void MockDevicePipeline::exit() {
   inputNotFull.notify_all();
   outputNotEmpty.notify_all();
   if (pipelineThread.joinable()) pipelineThread.join();
-  TT_LOG_DEBUG("[mock_device_pipeline] exit");
+  TT_LOG_DEBUG("[mock_device_pipeline] exit (bench-pin-test)");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Test branch — **do not merge**. Goal: confirm whether the recent `cpp-server-benchmarks` regression (`mean_tpot_ms` / `mean_ttft_ms` exceeding thresholds since ~2026-04-22) is driven by client-side Python dependency drift on the GitHub `ubuntu-latest` runners.

- Pins the entire `vllm` resolution in both bench install steps (`cpp-server-benchmarks`, `cpp-server-prefill-decode-split`) by passing `uv pip install --exclude-newer 2026-04-22T14:00:00Z` — this snaps everything (including transitive deps like `transformers`, which moved 5.5.4 → 5.6.1) back to a known-good cutoff.
- Tweaks one `TT_LOG_DEBUG` line in `mock_device_pipeline.cpp` so the `cpp_server` paths-filter triggers the bench jobs on this branch.

## Hypothesis under test
Reverting the only suspicious recent C++ change (#3097 → #3132) did **not** restore bench numbers, so the regression isn't in our C++. Two remaining suspects:
1. Client-side dep update on the bench runner (this PR isolates that).
2. Reduced CPU headroom on shared `ubuntu-latest` runners interacting with the busy-wait spin loop in `MockDevicePipeline::pipelineLoop()`.

If this PR's bench numbers come back green, suspect (1) is confirmed and we should land a real pin (probably `vllm==0.19.1` + an `--exclude-newer` floor) on `main`. If still red, suspect (2) is the next thing to address (replace the busy-wait with `sleep_until`, or move bench to a higher-core runner).

## Test plan
- [ ] CI `cpp-server-benchmarks (mock_pipeline)` — check `mean_tpot_ms` and `mean_ttft_ms` vs threshold
- [ ] CI `cpp-server-prefill-decode-split` — same
- [ ] Compare installed `transformers` / `vllm` versions in this run's "Install Python test dependencies" log against the last known-good run from 2026-04-22


Made with [Cursor](https://cursor.com)