### PR TITLE
ci(bench): pin transformers<5.6 in cpp-server bench install

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -502,7 +502,12 @@ jobs:
       - name: Install Python test dependencies
         run: |
           uv venv
-          uv pip install vllm
+          # Pin transformers<5.6 — bench is bisect-confirmed to regress on
+          # transformers 5.6.x (mock_pipeline mean_ttft_ms 377ms -> 1834ms,
+          # mean_tpot_ms 2.93ms -> 3.57ms with all other deps held identical).
+          # Track upstream and remove pin once 5.6.x is fixed or bench is
+          # made resilient to client tokenizer cost.
+          uv pip install vllm 'transformers<5.6'
           echo "PATH=${{ github.workspace }}/tt-media-server/.venv/bin:$PATH" >> $GITHUB_ENV
 
       # ── Mock backend benchmarks ──────────────────────────────────────
@@ -826,7 +831,12 @@ jobs:
       - name: Install Python test dependencies
         run: |
           uv venv
-          uv pip install vllm
+          # Pin transformers<5.6 — bench is bisect-confirmed to regress on
+          # transformers 5.6.x (mock_pipeline mean_ttft_ms 377ms -> 1834ms,
+          # mean_tpot_ms 2.93ms -> 3.57ms with all other deps held identical).
+          # Track upstream and remove pin once 5.6.x is fixed or bench is
+          # made resilient to client tokenizer cost.
+          uv pip install vllm 'transformers<5.6'
           echo "PATH=${{ github.workspace }}/tt-media-server/.venv/bin:$PATH" >> $GITHUB_ENV
 
       - name: Run vLLM bench serve against split servers


### PR DESCRIPTION
## Summary
The `cpp-server-benchmarks` job started failing on every PR / merge-group run from 2026-04-22 onwards. Bisect-isolated to a **single Python dep**: `transformers` 5.6.0 hit PyPI on Apr 22 and made the unpinned `vllm bench serve` client resolve to 5.6.1, which then halves the streaming throughput of our mock C++ server in CI.

This PR pins `transformers<5.6` in both bench install steps and **nothing else**. Every other dep stays free to receive patches.

## Bisect evidence
Two same-day same-runner-pool runs of this branch with everything else held identical — only `transformers` differs in the resolved set.

| Bench | Metric | Threshold | A: `transformers==5.5.4` | B: `transformers==5.6.1` | Δ B vs A |
|---|---|---|---|---|---|
| `mock_pipeline` | `mean_tpot_ms` | ≤ 3 | **2.93 ✅** | **3.57 ❌** | +22 % |
| `mock_pipeline` | `mean_ttft_ms` | ≤ 395 | **377 ✅** | **1834 ❌** | +387 % |
| `mock_pipeline` | `p99_ttft_ms` | — | 799 | 2 923 | +266 % |
| `mock_pipeline` | `output_throughput` | — | 10 487 | 2 879 | −73 % |
| `prefill/decode split` | `mean_tpot_ms` | (no gate) | 6.10 | 18.30 | +200 % |
| `prefill/decode split` | `mean_ttft_ms` | (no gate) | 155 | 695 | +349 % |
| `prefill/decode split` | `output_throughput` | — | 8 560 | 2 516 | −71 % |
| `mock` | `mean_ttft_ms` | ≤ 150 | 116 | 118 | ≈ 0 % |
| `mock` | `mean_tpot_ms` | ≤ 1 | 0.041 | 0.045 | ≈ 0 % |
| `structured-output-json-object` | `mean_tpot_ms` | ≤ 5 | 2.36 | 2.18 | ≈ 0 % |
| `structured-output-json-schema` | `mean_tpot_ms` | ≤ 3 | 0.81 | 0.63 | ≈ 0 % |

Linked CI runs (probes were on a sibling branch with one extra TT_LOG_DEBUG tweak so the `cpp_server` paths-filter would fire; the workflow change matches what's in this PR exactly):
- A — pinned, all green: https://github.com/tenstorrent/tt-inference-server/actions/runs/24836574737
- B — unpinned, red mock_pipeline: https://github.com/tenstorrent/tt-inference-server/actions/runs/24836574520

Resolved package diff between A and B (everything else identical):
```
A: + transformers==5.5.4
B: + transformers==5.6.1
```

Pattern: only the **streaming** benches regress (`mock_pipeline`, `prefill/decode split`). Both stream tokens and tokenize on the client side per chunk. Non-streaming benches (`mock`, `structured-output-*`) are flat. That's exactly where a slower per-token client tokenizer would bite.

## Why workflow-only diff (no `cpp_server/**` change in this PR)
The `cpp-server-benchmarks` job is gated on `tt-media-server/cpp_server/**` paths and therefore won't fire on this PR's own commit. Validation lives in the linked bisect runs above — same workflow content, plus a one-line TT_LOG_DEBUG tweak to clear the paths filter. Trade-off chosen for the cleanest possible permanent diff.

## Out of scope (follow-ups worth filing separately)
- **Bench fragility**: even with the pin, `mean_tpot_ms` at 2.93 vs threshold 3.00 leaves ~3 % headroom. We are one transformers patch release / one noisy GitHub runner away from the next surprise. Worth either widening the thresholds (~3.3 / ~500) or replacing the busy-wait spin loop in `MockDevicePipeline::pipelineLoop()` with `sleep_until` so server CPU isn't pegged at 100 % while benchmarking.
- **Upstream**: file a minimal-repro issue against `transformers` 5.6.x — a 4× TTFT / 73 % throughput hit on the streaming-tokenizer path is almost certainly an unintended regression, not a feature.

## Test plan
- [x] Bisect run A (pinned, this exact workflow change): all bench thresholds pass — see linked run
- [x] Bisect run B (no pin, same commit): mock_pipeline fails identically to recent main runs — see linked run
- [ ] After merge: first cpp_server-touching PR on main re-validates the fix on real merge-queue traffic