### PR TITLE
test(ci): bisect probe — no dep pin (re-confirm red baseline)

### DIFF
--- a/tt-media-server/cpp_server/src/runners/blaze_runner/mock_device_pipeline.cpp
+++ b/tt-media-server/cpp_server/src/runners/blaze_runner/mock_device_pipeline.cpp
@@ -57,7 +57,7 @@ void MockDevicePipeline::exit() {
   inputNotFull.notify_all();
   outputNotEmpty.notify_all();
   if (pipelineThread.joinable()) pipelineThread.join();
-  TT_LOG_DEBUG("[mock_device_pipeline] exit");
+  TT_LOG_DEBUG("[mock_device_pipeline] exit (bisect: no-pin baseline)");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Test branch — **do not merge**. Bisect baseline (Run B) for the cpp-server bench regression that started ~2026-04-22.

Workflow `Install Python test dependencies` step is **unchanged from main** — `uv pip install vllm` with no pins. Only a `TT_LOG_DEBUG` line in `mock_device_pipeline.cpp` is tweaked so the `cpp_server` paths-filter triggers the bench job.

Paired with sister branch `dmadic/test-bench-transformers-pin-only` (Run A). The two run on the same day against the same runner pool, so the only meaningful difference between them is whether `transformers` is pinned.

## Why this exists
Without re-running an unpinned baseline at the same moment as the pinned probe, we can't cleanly attribute a result. Runner CPU contention varies hour-to-hour, so we want both data points side by side.

## Test plan
- [ ] CI `cpp-server-benchmarks (mock_pipeline)` — expected to **fail** the same way recent main runs have (mean_tpot_ms ≈ 3.5, mean_ttft_ms ≈ 1800)
- [ ] If this run accidentally passes, the regression is intermittent rather than purely dep-driven — different fix path needed

Made with [Cursor](https://cursor.com)