### PR TITLE
Fix shouldDoPrefillOnDecode

### DIFF
--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -173,7 +173,6 @@ void LLMController::resolveSession(
             routingInfo.registrationHash);
 
         SessionInfo info;
-        info.validSessionFound = true;
         onResolved(info);
       },
       [onError](std::string_view err) {


### PR DESCRIPTION
## Issue
With recent changes disaggregated setup did not work since new session was always created and `shouldDoPrefillOnDecode` always returned false