### PR TITLE
Expand docker_image name generation to include forge image

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -46,15 +46,19 @@ def generate_default_docker_link(
     version: str,
     tt_metal_commit: str,
     vllm_commit: Optional[str],
+    inference_engine: str = "",
     multihost: bool = False,
 ) -> str:
     _default_docker_tag = generate_docker_tag(version, tt_metal_commit, vllm_commit)
-    if vllm_commit is None:
-        _default_docker_repo = "ghcr.io/tenstorrent/tt-media-inference-server"
-    elif multihost:
-        _default_docker_repo = "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-multihost-ubuntu-22.04-amd64"
+    if vllm_commit is not None:
+        if multihost:
+            _default_docker_repo = "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-multihost-ubuntu-22.04-amd64"
+        else:
+            _default_docker_repo = "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64"
+    elif inference_engine == "forge":
+        _default_docker_repo = "ghcr.io/tenstorrent/tt-media-inference-server-forge"
     else:
-        _default_docker_repo = "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64"
+        _default_docker_repo = "ghcr.io/tenstorrent/tt-media-inference-server"
     return f"{_default_docker_repo}:{_default_docker_tag}"
 
 
@@ -472,6 +476,7 @@ class ModelSpec:
                 self.version,
                 self.tt_metal_commit,
                 self.vllm_commit,
+                inference_engine=self.inference_engine,
                 multihost=self.device_type.is_multihost(),
             )
             object.__setattr__(self, "docker_image", _default_docker_link)
@@ -3506,11 +3511,11 @@ cnn_templates = [
     ),
     ModelSpecTemplate(
         weights=["resnet-50"],
-        tt_metal_commit="2496be4",
+        version="0.13.0",
+        tt_metal_commit="079a2c2",
         impl=tt_transformers_impl,
         min_disk_gb=15,
         min_ram_gb=6,
-        docker_image="ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
         model_type=ModelType.CNN,
         inference_engine=InferenceEngine.FORGE.value,
         status=ModelStatusTypes.FUNCTIONAL,
@@ -3531,11 +3536,11 @@ cnn_templates = [
     ),
     ModelSpecTemplate(
         weights=["vovnet"],
-        tt_metal_commit="2496be4",
+        version="0.13.0",
+        tt_metal_commit="079a2c2",
         impl=tt_transformers_impl,
         min_disk_gb=15,
         min_ram_gb=6,
-        docker_image="ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
         model_type=ModelType.CNN,
         inference_engine=InferenceEngine.FORGE.value,
         status=ModelStatusTypes.COMPLETE,
@@ -3556,11 +3561,11 @@ cnn_templates = [
     ),
     ModelSpecTemplate(
         weights=["mobilenetv2"],
-        tt_metal_commit="2496be4",
+        version="0.13.0",
+        tt_metal_commit="079a2c2",
         impl=tt_transformers_impl,
         min_disk_gb=15,
         min_ram_gb=6,
-        docker_image="ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
         model_type=ModelType.CNN,
         inference_engine=InferenceEngine.FORGE.value,
         status=ModelStatusTypes.COMPLETE,
@@ -3605,11 +3610,11 @@ cnn_templates = [
     ),
     ModelSpecTemplate(
         weights=["segformer"],
-        tt_metal_commit="2496be4",
+        version="0.13.0",
+        tt_metal_commit="079a2c2",
         impl=tt_transformers_impl,
         min_disk_gb=15,
         min_ram_gb=6,
-        docker_image="ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
         model_type=ModelType.CNN,
         inference_engine=InferenceEngine.FORGE.value,
         status=ModelStatusTypes.FUNCTIONAL,
@@ -3630,11 +3635,11 @@ cnn_templates = [
     ),
     ModelSpecTemplate(
         weights=["vit"],
-        tt_metal_commit="2496be4",
+        version="0.13.0",
+        tt_metal_commit="079a2c2",
         impl=tt_transformers_impl,
         min_disk_gb=15,
         min_ram_gb=6,
-        docker_image="ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
         model_type=ModelType.CNN,
         inference_engine=InferenceEngine.FORGE.value,
         status=ModelStatusTypes.COMPLETE,


### PR DESCRIPTION
- This is needed for the release of tt-media-forge server
- Also, remove pinned private docker images for the 5 models we are releasing
- Update version