### PR TITLE
Fix Qwen3-32B P300X2 memory crash via trace_region_size

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1359,6 +1359,9 @@ llm_templates = [
                 max_concurrency=32,
                 max_context=128 * 1024,
                 default_impl=True,
+                override_tt_config={
+                    "trace_region_size": 53000000,
+                },
             ),
         ],
         status=ModelStatusTypes.FUNCTIONAL,


### PR DESCRIPTION
## Summary

- Adds `trace_region_size: 53000000` to the `Qwen3-32B` `P300X2` `DeviceModelSpec` to prevent an OOM/memory crash at model init

## References

- Issue: https://github.com/tenstorrent/tt-inference-server/issues/3144
- Shield run: https://github.com/tenstorrent/tt-shield/actions/runs/24865278713