### PR TITLE
Minor tweaks

### DIFF
--- a/tt-media-server/cpp_server/src/runners/blaze_prefill_runner/blaze_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runners/blaze_prefill_runner/blaze_prefill_runner.cpp
@@ -54,7 +54,7 @@ void BlazePrefillRunner::run() {
       TT_LOG_DEBUG(
           "[BlazePrefillRunner] pushToken task_id={} token_id={} finished={}",
           result->taskId, result->tokenId, true);
-      ipc::pushToken(*resultQueue, result->taskId, result->tokenId, true);
+      ipc::pushToken(*resultQueue, sequence->taskId, result->tokenId, true);
     }
 
     // sequence automatically cleaned up at end of scope

--- a/tt-media-server/cpp_server/src/runners/mock_prefill_runner.py
+++ b/tt-media-server/cpp_server/src/runners/mock_prefill_runner.py
@@ -175,7 +175,7 @@ def run_rank0_coordinator() -> None:
                         )
 
                 # Return exactly one token (first token from reasoning sequence)
-                prefill_token = 128798  # <think> token
+                prefill_token = "12345" + str(task_id)
 
                 p2c.write_token(task_id, prefill_token)
 


### PR DESCRIPTION
- Use task_id from request, not from shared memory for return
- Return 12345 since <think> token gets hidden