### PR TITLE
v0.13.0 Post Release

### DIFF
--- a/docs/model_support/cnn/README.md
+++ b/docs/model_support/cnn/README.md
@@ -4,6 +4,18 @@ This page lists all supported convolutional neural network models and their devi
 
 [Search other models by model type](../../../README.md#models-by-model-type)
 
+## Supported Models
+
+Models with status: TOP_PERF, COMPLETE, or FUNCTIONAL.
+
+| Model Name | [N150/N300](https://tenstorrent.com/hardware/wormhole) |
+| --- | --- |
+| [mobilenetv2](mobilenetv2_n150.md) | [🟢 Complete](mobilenetv2_n150.md) |
+| [vit](vit_n150.md) | [🟢 Complete](vit_n150.md) |
+| [vovnet](vovnet_n150.md) | [🟢 Complete](vovnet_n150.md) |
+| [resnet-50](resnet-50_n150.md) | [🟡 Functional](resnet-50_n150.md) |
+| [segformer](segformer_n150.md) | [🟡 Functional](segformer_n150.md) |
+
 ## Experimental Models
 
 Models with EXPERIMENTAL status are under active development and may have stability or performance issues.
@@ -11,9 +23,4 @@ Models with EXPERIMENTAL status are under active development and may have stabil
 | Model Name | [N150/N300](https://tenstorrent.com/hardware/wormhole) |
 | --- | --- |
 | [efficientnet](efficientnet_n150.md) | [🛠️ Experimental](efficientnet_n150.md) |
-| [mobilenetv2](mobilenetv2_n150.md) | [🛠️ Experimental](mobilenetv2_n150.md) |
-| [resnet-50](resnet-50_n150.md) | [🛠️ Experimental](resnet-50_n150.md) |
-| [segformer](segformer_n150.md) | [🛠️ Experimental](segformer_n150.md) |
 | [unet](unet_n150.md) | [🛠️ Experimental](unet_n150.md) |
-| [vit](vit_n150.md) | [🛠️ Experimental](vit_n150.md) |
-| [vovnet](vovnet_n150.md) | [🛠️ Experimental](vovnet_n150.md) |

--- a/docs/model_support/cnn/mobilenetv2_n150.md
+++ b/docs/model_support/cnn/mobilenetv2_n150.md
@@ -24,11 +24,11 @@ For details on the run.py command, see the [run.py CLI Options](../../workflows_
 | Parameter | Value |
 |-----------|-------|
 | Weights | [mobilenetv2](https://huggingface.co/mobilenetv2) |
-| Model Status | 🛠️ Experimental |
+| Model Status | 🟢 Complete |
 | Max Batch Size | 1 |
-| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers) |
-| tt-metal Commit | `2496be4` |
-| Docker Image | `ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673` |
+| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers) |
+| tt-metal Commit | `079a2c2` |
+| Docker Image | `ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2` |
 
 ---
 
@@ -47,8 +47,8 @@ python3 run.py --model mobilenetv2 --device n300 --workflow server --docker-serv
 | Parameter | Value |
 |-----------|-------|
 | Weights | [mobilenetv2](https://huggingface.co/mobilenetv2) |
-| Model Status | 🛠️ Experimental |
+| Model Status | 🟢 Complete |
 | Max Batch Size | 1 |
-| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers) |
-| tt-metal Commit | `2496be4` |
-| Docker Image | `ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673` |
+| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers) |
+| tt-metal Commit | `079a2c2` |
+| Docker Image | `ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2` |

--- a/docs/model_support/cnn/resnet-50_n150.md
+++ b/docs/model_support/cnn/resnet-50_n150.md
@@ -24,11 +24,11 @@ For details on the run.py command, see the [run.py CLI Options](../../workflows_
 | Parameter | Value |
 |-----------|-------|
 | Weights | [resnet-50](https://huggingface.co/resnet-50) |
-| Model Status | 🛠️ Experimental |
+| Model Status | 🟡 Functional |
 | Max Batch Size | 1 |
-| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers) |
-| tt-metal Commit | `2496be4` |
-| Docker Image | `ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673` |
+| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers) |
+| tt-metal Commit | `079a2c2` |
+| Docker Image | `ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2` |
 
 ---
 
@@ -47,8 +47,8 @@ python3 run.py --model resnet-50 --device n300 --workflow server --docker-server
 | Parameter | Value |
 |-----------|-------|
 | Weights | [resnet-50](https://huggingface.co/resnet-50) |
-| Model Status | 🛠️ Experimental |
+| Model Status | 🟡 Functional |
 | Max Batch Size | 1 |
-| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers) |
-| tt-metal Commit | `2496be4` |
-| Docker Image | `ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673` |
+| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers) |
+| tt-metal Commit | `079a2c2` |
+| Docker Image | `ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2` |

--- a/docs/model_support/cnn/segformer_n150.md
+++ b/docs/model_support/cnn/segformer_n150.md
@@ -24,11 +24,11 @@ For details on the run.py command, see the [run.py CLI Options](../../workflows_
 | Parameter | Value |
 |-----------|-------|
 | Weights | [segformer](https://huggingface.co/segformer) |
-| Model Status | 🛠️ Experimental |
+| Model Status | 🟡 Functional |
 | Max Batch Size | 1 |
-| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers) |
-| tt-metal Commit | `2496be4` |
-| Docker Image | `ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673` |
+| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers) |
+| tt-metal Commit | `079a2c2` |
+| Docker Image | `ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2` |
 
 ---
 
@@ -47,8 +47,8 @@ python3 run.py --model segformer --device n300 --workflow server --docker-server
 | Parameter | Value |
 |-----------|-------|
 | Weights | [segformer](https://huggingface.co/segformer) |
-| Model Status | 🛠️ Experimental |
+| Model Status | 🟡 Functional |
 | Max Batch Size | 1 |
-| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers) |
-| tt-metal Commit | `2496be4` |
-| Docker Image | `ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673` |
+| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers) |
+| tt-metal Commit | `079a2c2` |
+| Docker Image | `ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2` |

--- a/docs/model_support/cnn/vit_n150.md
+++ b/docs/model_support/cnn/vit_n150.md
@@ -24,11 +24,11 @@ For details on the run.py command, see the [run.py CLI Options](../../workflows_
 | Parameter | Value |
 |-----------|-------|
 | Weights | [vit](https://huggingface.co/vit) |
-| Model Status | 🛠️ Experimental |
+| Model Status | 🟢 Complete |
 | Max Batch Size | 1 |
-| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers) |
-| tt-metal Commit | `2496be4` |
-| Docker Image | `ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673` |
+| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers) |
+| tt-metal Commit | `079a2c2` |
+| Docker Image | `ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2` |
 
 ---
 
@@ -47,8 +47,8 @@ python3 run.py --model vit --device n300 --workflow server --docker-server
 | Parameter | Value |
 |-----------|-------|
 | Weights | [vit](https://huggingface.co/vit) |
-| Model Status | 🛠️ Experimental |
+| Model Status | 🟢 Complete |
 | Max Batch Size | 1 |
-| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers) |
-| tt-metal Commit | `2496be4` |
-| Docker Image | `ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673` |
+| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers) |
+| tt-metal Commit | `079a2c2` |
+| Docker Image | `ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2` |

--- a/docs/model_support/cnn/vovnet_n150.md
+++ b/docs/model_support/cnn/vovnet_n150.md
@@ -24,11 +24,11 @@ For details on the run.py command, see the [run.py CLI Options](../../workflows_
 | Parameter | Value |
 |-----------|-------|
 | Weights | [vovnet](https://huggingface.co/vovnet) |
-| Model Status | 🛠️ Experimental |
+| Model Status | 🟢 Complete |
 | Max Batch Size | 1 |
-| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers) |
-| tt-metal Commit | `2496be4` |
-| Docker Image | `ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673` |
+| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers) |
+| tt-metal Commit | `079a2c2` |
+| Docker Image | `ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2` |
 
 ---
 
@@ -47,8 +47,8 @@ python3 run.py --model vovnet --device n300 --workflow server --docker-server
 | Parameter | Value |
 |-----------|-------|
 | Weights | [vovnet](https://huggingface.co/vovnet) |
-| Model Status | 🛠️ Experimental |
+| Model Status | 🟢 Complete |
 | Max Batch Size | 1 |
-| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers) |
-| tt-metal Commit | `2496be4` |
-| Docker Image | `ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673` |
+| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers) |
+| tt-metal Commit | `079a2c2` |
+| Docker Image | `ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2` |

--- a/release_model_spec.json
+++ b/release_model_spec.json
@@ -21667,7 +21667,7 @@
             "model_name": "resnet-50",
             "inference_engine": "forge",
             "device_type": "N150",
-            "tt_metal_commit": "2496be4",
+            "tt_metal_commit": "079a2c2",
             "device_model_spec": {
               "device": "N150",
               "max_concurrency": 1,
@@ -21748,10 +21748,10 @@
             "min_ram_gb": 6,
             "model_type": "CNN",
             "repacked": 0,
-            "version": "0.12.0",
-            "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-            "status": "EXPERIMENTAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers",
+            "version": "0.13.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
+            "status": "FUNCTIONAL",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers",
             "override_tt_config": {},
             "supported_modalities": [
               "text"
@@ -21777,7 +21777,7 @@
             "model_name": "resnet-50",
             "inference_engine": "forge",
             "device_type": "N300",
-            "tt_metal_commit": "2496be4",
+            "tt_metal_commit": "079a2c2",
             "device_model_spec": {
               "device": "N300",
               "max_concurrency": 1,
@@ -21860,10 +21860,10 @@
             "min_ram_gb": 6,
             "model_type": "CNN",
             "repacked": 0,
-            "version": "0.12.0",
-            "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-            "status": "EXPERIMENTAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers",
+            "version": "0.13.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
+            "status": "FUNCTIONAL",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers",
             "override_tt_config": {},
             "supported_modalities": [
               "text"
@@ -21891,7 +21891,7 @@
             "model_name": "vovnet",
             "inference_engine": "forge",
             "device_type": "N150",
-            "tt_metal_commit": "2496be4",
+            "tt_metal_commit": "079a2c2",
             "device_model_spec": {
               "device": "N150",
               "max_concurrency": 1,
@@ -21972,10 +21972,10 @@
             "min_ram_gb": 6,
             "model_type": "CNN",
             "repacked": 0,
-            "version": "0.12.0",
-            "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-            "status": "EXPERIMENTAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers",
+            "version": "0.13.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
+            "status": "COMPLETE",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers",
             "override_tt_config": {},
             "supported_modalities": [
               "text"
@@ -22001,7 +22001,7 @@
             "model_name": "vovnet",
             "inference_engine": "forge",
             "device_type": "N300",
-            "tt_metal_commit": "2496be4",
+            "tt_metal_commit": "079a2c2",
             "device_model_spec": {
               "device": "N300",
               "max_concurrency": 1,
@@ -22084,10 +22084,10 @@
             "min_ram_gb": 6,
             "model_type": "CNN",
             "repacked": 0,
-            "version": "0.12.0",
-            "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-            "status": "EXPERIMENTAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers",
+            "version": "0.13.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
+            "status": "COMPLETE",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers",
             "override_tt_config": {},
             "supported_modalities": [
               "text"
@@ -22115,7 +22115,7 @@
             "model_name": "mobilenetv2",
             "inference_engine": "forge",
             "device_type": "N150",
-            "tt_metal_commit": "2496be4",
+            "tt_metal_commit": "079a2c2",
             "device_model_spec": {
               "device": "N150",
               "max_concurrency": 1,
@@ -22196,10 +22196,10 @@
             "min_ram_gb": 6,
             "model_type": "CNN",
             "repacked": 0,
-            "version": "0.12.0",
-            "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-            "status": "EXPERIMENTAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers",
+            "version": "0.13.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
+            "status": "COMPLETE",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers",
             "override_tt_config": {},
             "supported_modalities": [
               "text"
@@ -22225,7 +22225,7 @@
             "model_name": "mobilenetv2",
             "inference_engine": "forge",
             "device_type": "N300",
-            "tt_metal_commit": "2496be4",
+            "tt_metal_commit": "079a2c2",
             "device_model_spec": {
               "device": "N300",
               "max_concurrency": 1,
@@ -22308,10 +22308,10 @@
             "min_ram_gb": 6,
             "model_type": "CNN",
             "repacked": 0,
-            "version": "0.12.0",
-            "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-            "status": "EXPERIMENTAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers",
+            "version": "0.13.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
+            "status": "COMPLETE",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers",
             "override_tt_config": {},
             "supported_modalities": [
               "text"
@@ -22563,7 +22563,7 @@
             "model_name": "segformer",
             "inference_engine": "forge",
             "device_type": "N150",
-            "tt_metal_commit": "2496be4",
+            "tt_metal_commit": "079a2c2",
             "device_model_spec": {
               "device": "N150",
               "max_concurrency": 1,
@@ -22644,10 +22644,10 @@
             "min_ram_gb": 6,
             "model_type": "CNN",
             "repacked": 0,
-            "version": "0.12.0",
-            "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-            "status": "EXPERIMENTAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers",
+            "version": "0.13.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
+            "status": "FUNCTIONAL",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers",
             "override_tt_config": {},
             "supported_modalities": [
               "text"
@@ -22673,7 +22673,7 @@
             "model_name": "segformer",
             "inference_engine": "forge",
             "device_type": "N300",
-            "tt_metal_commit": "2496be4",
+            "tt_metal_commit": "079a2c2",
             "device_model_spec": {
               "device": "N300",
               "max_concurrency": 1,
@@ -22756,10 +22756,10 @@
             "min_ram_gb": 6,
             "model_type": "CNN",
             "repacked": 0,
-            "version": "0.12.0",
-            "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-            "status": "EXPERIMENTAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers",
+            "version": "0.13.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
+            "status": "FUNCTIONAL",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers",
             "override_tt_config": {},
             "supported_modalities": [
               "text"
@@ -22787,7 +22787,7 @@
             "model_name": "vit",
             "inference_engine": "forge",
             "device_type": "N150",
-            "tt_metal_commit": "2496be4",
+            "tt_metal_commit": "079a2c2",
             "device_model_spec": {
               "device": "N150",
               "max_concurrency": 1,
@@ -22868,10 +22868,10 @@
             "min_ram_gb": 6,
             "model_type": "CNN",
             "repacked": 0,
-            "version": "0.12.0",
-            "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-            "status": "EXPERIMENTAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers",
+            "version": "0.13.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
+            "status": "COMPLETE",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers",
             "override_tt_config": {},
             "supported_modalities": [
               "text"
@@ -22897,7 +22897,7 @@
             "model_name": "vit",
             "inference_engine": "forge",
             "device_type": "N300",
-            "tt_metal_commit": "2496be4",
+            "tt_metal_commit": "079a2c2",
             "device_model_spec": {
               "device": "N300",
               "max_concurrency": 1,
@@ -22980,10 +22980,10 @@
             "min_ram_gb": 6,
             "model_type": "CNN",
             "repacked": 0,
-            "version": "0.12.0",
-            "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-            "status": "EXPERIMENTAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/2496be4/models/tt_transformers",
+            "version": "0.13.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
+            "status": "COMPLETE",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/079a2c2/models/tt_transformers",
             "override_tt_config": {},
             "supported_modalities": [
               "text"

--- a/scripts/release/generate_model_support_docs.py
+++ b/scripts/release/generate_model_support_docs.py
@@ -32,7 +32,6 @@ from typing import Dict, List, Optional, Set, Tuple
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from workflows.model_spec import (
-    VERSION,
     ModelSpecTemplate,
     generate_default_docker_link,
     model_weights_to_model_name,

--- a/scripts/release/generate_model_support_docs.py
+++ b/scripts/release/generate_model_support_docs.py
@@ -575,6 +575,7 @@ def generate_model_page_group_page(
                         target_template.version,
                         target_template.tt_metal_commit,
                         target_template.vllm_commit,
+                        inference_engine=target_template.inference_engine,
                         multihost=is_multihost,
                     )
                 )
@@ -618,9 +619,10 @@ def generate_model_page_group_page(
             docker_image = target_template.docker_image
         else:
             docker_image = generate_default_docker_link(
-                VERSION,
+                target_template.version,
                 target_template.tt_metal_commit,
                 target_template.vllm_commit,
+                inference_engine=target_template.inference_engine,
                 multihost=device.is_multihost(),
             )
 


### PR DESCRIPTION
<!--
metadata:run_id=24842121888
metadata:version=v0.13.0
-->
# Summary of Changes

* Initial release of 5 Forge models, with the newest version of the forge library (1.0.0)

# SW versions recommended for Wormhole Galaxy:

- tt-smi: 3.0.38
- Firmware: 19.3.0
- tt-kmd: 2.5.0

# Model Spec Release Updates


This document shows model specification updates.

| Impl | Model Arch | Weights | Devices | TT-Metal Commit Change | Status Change | CI Job Link |
|------|------------|---------|---------|------------------------|---------------|-------------|
| `tt_transformers` | `resnet-50` | `resnet-50` | N150, N300 | `2496be4` → `079a2c2` | EXPERIMENTAL → FUNCTIONAL | N/A |
| `tt_transformers` | `vovnet` | `vovnet` | N150, N300 | `2496be4` → `079a2c2` | EXPERIMENTAL → COMPLETE | N/A |
| `tt_transformers` | `mobilenetv2` | `mobilenetv2` | N150, N300 | `2496be4` → `079a2c2` | EXPERIMENTAL → COMPLETE | N/A |
| `tt_transformers` | `segformer` | `segformer` | N150, N300 | `2496be4` → `079a2c2` | EXPERIMENTAL → FUNCTIONAL | N/A |
| `tt_transformers` | `vit` | `vit` | N150, N300 | `2496be4` → `079a2c2` | EXPERIMENTAL → COMPLETE | N/A |


# Release Artifacts Summary

## Images Promoted from Models CI

- https://ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2 from  https://ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:079a2c23f4b360dd0c415a43dd2ffc94d0a792de_fbccfcd_72718973516

**Total:** 1