### PR TITLE
Use XXH64 Stable Hash Method

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -72,6 +72,17 @@ FetchContent_Declare(googletest
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
+# xxHash for stable, cross-platform hashing (conversation prefix caching)
+FetchContent_Declare(
+    xxhash
+    GIT_REPOSITORY https://github.com/Cyan4973/xxHash.git
+    GIT_TAG        v0.8.2
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(xxhash)
+add_library(xxhash_lib INTERFACE)
+target_include_directories(xxhash_lib INTERFACE ${xxhash_SOURCE_DIR})
+
 # xgrammar for structured output / guided decoding (JSON schema constrained generation)
 FetchContent_Declare(xgrammar
     GIT_REPOSITORY https://github.com/mlc-ai/xgrammar.git
@@ -303,8 +314,8 @@ target_include_directories(llm_runner_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${TT_METAL_INCLUDE_DIRS}
 )
-# Link tokenizers_cpp, JsonCpp, and xgrammar (guided decoding for structured outputs)
-target_link_libraries(llm_runner_lib PUBLIC tokenizers_cpp JsonCpp::JsonCpp xgrammar)
+# Link tokenizers_cpp, JsonCpp, xgrammar (guided decoding), and xxhash (stable hashing)
+target_link_libraries(llm_runner_lib PUBLIC tokenizers_cpp JsonCpp::JsonCpp xgrammar xxhash_lib)
 
 # Link PipelineManager when ENABLE_BLAZE is ON: prefer Full (SocketPipeline + TT::Metalium),
 # fall back to Core (mock pipeline only).

--- a/tt-media-server/cpp_server/src/utils/conversation_hasher.cpp
+++ b/tt-media-server/cpp_server/src/utils/conversation_hasher.cpp
@@ -4,9 +4,10 @@
 #include "utils/conversation_hasher.hpp"
 
 #include <algorithm>
-#include <functional>
 
+#define XXH_INLINE_ALL
 #include "utils/tokenizers/tokenizer.hpp"
+#include "xxhash.h"
 
 namespace tt::utils {
 
@@ -73,8 +74,9 @@ uint64_t hashConversationPrefix(
   const auto& tokenizer = tokenizers::activeTokenizer();
   std::string rendered = tokenizer.applyChatTemplate(prefix, false);
 
-  // Compute stable 64-bit hash
-  return std::hash<std::string>()(rendered);
+  // Compute stable 64-bit hash using xxHash64 (deterministic across
+  // platforms/restarts)
+  return XXH64(rendered.data(), rendered.size(), 0);
 }
 
 std::string renderLastUserTurn(


### PR DESCRIPTION
## Issue
[#3108 [Prefix Caching] Use Stable Hashing Alghoritm](https://github.com/tenstorrent/tt-inference-server/issues/3108)

## Problem
`std::hash` does not guarantee deterministic outputs across application restarts as it is inherently non-stable ([ref](https://en.cppreference.com/cpp/utility/hash) `Hash functions are only required to produce the same result for the same input within a single execution of a program.`). 
Since the plan for Inference Server in the future is to be able to persist state in Redis (or a similar storage) across restarts - on a lifecycle that follows in-memory KV cache life, we must ensure that identical inputs always produce identical hashes, which requires adopting a stable hashing mechanism.