### PR TITLE
Increase PREFILL_TIMEOUT_MS

### DIFF
--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -37,7 +37,7 @@ constexpr const char* KAFKA_OFFLOAD_TOPIC_NAME = "session-offload";
 constexpr const char* KAFKA_GROUP_ID = "migration-workers";
 
 constexpr unsigned SESSION_ALLOCATION_MAX_RETRIES = 15;
-constexpr unsigned PREFILL_TIMEOUT_MS = 10000;
+constexpr unsigned PREFILL_TIMEOUT_MS = 20000;
 
 constexpr const char* BLAZE_SOCKET_DESCRIPTOR_PREFIX = "deepseek";
 constexpr const char* TT_TASK_QUEUE = "tt_tasks";


### PR DESCRIPTION
## Problem
Prefill warmup often timed out on `PREFILL_TIMEOUT_MS=10s`, so with these changes the default value increased to 20s