### PR TITLE
Eval report not generated when accuracy fail

### DIFF
--- a/server_tests/utils/media_client/test_image_client.py
+++ b/server_tests/utils/media_client/test_image_client.py
@@ -372,9 +372,7 @@ class TestImageClientStrategyRunEval(unittest.TestCase):
             },
         }
 
-        with patch.object(
-            strategy, "get_health", return_value=(True, "tt-flux.1-dev")
-        ):
+        with patch.object(strategy, "get_health", return_value=(True, "tt-flux.1-dev")):
             with patch("asyncio.run", return_value=eval_result):
                 with pytest.raises(RuntimeError, match="ACCURACY_CHECK"):
                     strategy.run_eval()

--- a/server_tests/utils/media_client/test_image_client.py
+++ b/server_tests/utils/media_client/test_image_client.py
@@ -318,6 +318,81 @@ class TestImageClientStrategyRunEval(unittest.TestCase):
             with pytest.raises(RuntimeError, match="FID score too high"):
                 asyncio.run(strategy._run_image_generation_eval_test())
 
+    @patch(
+        "utils.media_clients.image_client.is_sdxl_num_prompts_enabled", return_value=5
+    )
+    def test_run_image_generation_eval_test_accuracy_failure_returns_result(
+        self, mock_num_prompts
+    ):
+        """Accuracy failure with populated eval_results should return the result
+        (not raise) so the caller can persist a report before failing."""
+        import asyncio
+
+        strategy = self._create_strategy()
+
+        mock_result = {
+            "success": False,
+            "eval_results": {
+                "fid_score": 245.8392,
+                "average_clip": 26.5805,
+                "deviation_clip_score": 3.6637,
+                "accuracy_check": 3,
+            },
+        }
+
+        with patch(
+            "utils.media_clients.image_client.ImageGenerationEvalsTest"
+        ) as MockTest:
+            mock_instance = MagicMock()
+            mock_instance._run_specific_test_async = AsyncMock(return_value=mock_result)
+            MockTest.return_value = mock_instance
+
+            result = asyncio.run(strategy._run_image_generation_eval_test())
+
+        assert result["success"] is False
+        assert result["eval_results"]["fid_score"] == 245.8392
+        assert result["eval_results"]["accuracy_check"] == 3
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("pathlib.Path.mkdir")
+    def test_run_eval_accuracy_failure_writes_report_then_raises(
+        self, mock_mkdir, mock_file
+    ):
+        """When the eval returns success=False with populated eval_results, the
+        report must be written to disk and then a RuntimeError should be raised."""
+        strategy = self._create_strategy()
+
+        eval_result = {
+            "success": False,
+            "eval_results": {
+                "fid_score": 245.8392,
+                "average_clip": 26.5805,
+                "deviation_clip_score": 3.6637,
+                "accuracy_check": 3,
+            },
+        }
+
+        with patch.object(
+            strategy, "get_health", return_value=(True, "tt-flux.1-dev")
+        ):
+            with patch("asyncio.run", return_value=eval_result):
+                with pytest.raises(RuntimeError, match="ACCURACY_CHECK"):
+                    strategy.run_eval()
+
+        mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+
+        write_calls = mock_file().write.call_args_list
+        written_content = "".join(call[0][0] for call in write_calls)
+        report_data = json.loads(written_content)
+
+        assert isinstance(report_data, list)
+        assert len(report_data) == 1
+        persisted = report_data[0]
+        assert persisted["fid_score"] == 245.8392
+        assert persisted["average_clip"] == 26.5805
+        assert persisted["deviation_clip_score"] == 3.6637
+        assert persisted["accuracy_check"] == 3
+
 
 class TestImageClientStrategyRunBenchmark(unittest.TestCase):
     """Tests for run_benchmark method."""

--- a/utils/media_clients/image_client.py
+++ b/utils/media_clients/image_client.py
@@ -198,6 +198,16 @@ class ImageClientStrategy(BaseMediaStrategy):
             json.dump(benchmark_data, f, indent=4)
         logger.info(f"Evaluation data written to: {eval_filename}")
 
+        # If the eval produced metrics but the accuracy check failed, we still
+        # want to persist the report above. Only now do we surface the failure
+        # so upstream callers can treat it as an error.
+        if isinstance(eval_result, dict) and not eval_result.get("success", True):
+            error = eval_result.get(
+                "error", "ImageGenerationEvalsTest ACCURACY_CHECK failed"
+            )
+            logger.error(f"Eval report written despite failure; raising: {error}")
+            raise RuntimeError(error)
+
     def run_benchmark(self, attempt=0) -> list[ImageGenerationTestStatus]:
         """Run benchmarks for the model."""
         logger.info(
@@ -687,10 +697,16 @@ class ImageClientStrategy(BaseMediaStrategy):
         result = await eval_test._run_specific_test_async()
 
         if not result.get("success"):
-            logger.error(
-                f"ImageGenerationEvalsTest ACCURACY_CHECK failed: error={result.get('error')}"
-            )
+            # If eval_results were computed (i.e. accuracy check failed with real
+            # FID/CLIP numbers), return the result so the caller can persist a
+            # report before signaling failure. Only raise when there are no
+            # metrics to report (a genuine execution error).
+            if result.get("eval_results"):
+                logger.error("ImageGenerationEvalsTest ACCURACY_CHECK failed.")
+                return result
+
             error = result.get("error", "ImageGenerationEvalsTest failed")
+            logger.error(f"ImageGenerationEvalsTest failed: error={error}")
             raise RuntimeError(error)
 
         logger.info(f"ImageGenerationEvalsTest completed: {result.get('eval_results')}")


### PR DESCRIPTION
### Github Issue
[Eval report not generated when accuracy fail](https://github.com/tenstorrent/tt-inference-server/issues/3166)

### Summary
Currently, when eval accuracy fail, no eval report is being generated.

Link to the example run: https://github.com/tenstorrent/tt-shield/actions/runs/24861560997/job/72794714890#step:11:4176