### PR TITLE
Bug fix: Evals are not producing consistent results for different model types 

### DIFF
--- a/benchmarking/summary_report.py
+++ b/benchmarking/summary_report.py
@@ -418,7 +418,7 @@ def process_benchmark_file(filepath: str) -> Dict[str, Any]:
             }
             return format_metrics(metrics)
 
-    if params.get("task_type") == "text_to_speech" or params.get("task_type") == "tts":
+    if params.get("task_type") == "text_to_speech":
         logger.info(f"Processing TTS benchmark file: {filename}")
         # For TTS benchmarks, extract data from JSON content
         benchmarks_data = data.get("benchmarks", {})
@@ -433,7 +433,7 @@ def process_benchmark_file(filepath: str) -> Dict[str, Any]:
             "mean_ttft_ms": benchmarks_data.get("ttft", 0)
             * 1000,  # ttft is in seconds, convert to ms
             "filename": filename,
-            "task_type": "tts",
+            "task_type": "text_to_speech",
             "rtr": benchmarks_data.get("rtr", 0),
             "p90_ttft": benchmarks_data.get("ttft_p90", 0) * 1000
             if benchmarks_data.get("ttft_p90")
@@ -1082,7 +1082,7 @@ def generate_report(files, output_dir, report_id, metadata={}, model_spec=None):
     vlm_results = [r for r in results if r.get("task_type") == "vlm"]
     image_results = [r for r in results if r.get("task_type") == "image"]
     audio_results = [r for r in results if r.get("task_type") == "audio"]
-    tts_results = [r for r in results if r.get("task_type") == "tts"]
+    tts_results = [r for r in results if r.get("task_type") == "text_to_speech"]
     embedding_results = [r for r in results if r.get("task_type") == "embedding"]
     cnn_results = [r for r in results if r.get("task_type") == "cnn"]
     video_results = [r for r in results if r.get("task_type") == "video"]

--- a/server_tests/utils/media_client/test_tts_client.py
+++ b/server_tests/utils/media_client/test_tts_client.py
@@ -593,7 +593,7 @@ class TestTtsClientStrategyRunBenchmark(unittest.TestCase):
 
         assert report_data["model"] == "test_model"
         assert report_data["device"] == "test_device"
-        assert report_data["task_type"] == "tts"
+        assert report_data["task_type"] == "text_to_speech"
 
     @patch("transformers.AutoTokenizer.from_pretrained")
     def test_run_benchmark_health_check_failed(self, mock_tokenizer):
@@ -662,4 +662,4 @@ class TestTtsClientStrategyGenerateReport(unittest.TestCase):
 
         assert report_data["model"] == "test_model"
         assert report_data["device"] == "test_device"
-        assert report_data["task_type"] == "tts"
+        assert report_data["task_type"] == "text_to_speech"

--- a/tests/test_matrix_expansion.py
+++ b/tests/test_matrix_expansion.py
@@ -801,16 +801,16 @@ class TestTtsMatrixExpansion:
     """Validate that the migrated tts.json produces the same suites as before."""
 
     def test_tts_suite_count(self):
-        suites = load_suite_files_by_category("tts")
+        suites = load_suite_files_by_category("text_to_speech")
         assert len(suites) == 2
 
     def test_tts_suite_ids(self):
-        suites = load_suite_files_by_category("tts")
+        suites = load_suite_files_by_category("text_to_speech")
         ids = {s["id"] for s in suites}
         assert ids == {"speecht5-n150", "speecht5-p150"}
 
     def test_tts_test_cases_match(self):
-        suites = load_suite_files_by_category("tts")
+        suites = load_suite_files_by_category("text_to_speech")
         for suite in suites:
             assert len(suite["test_cases"]) == 4
             templates = [tc["template"] for tc in suite["test_cases"]]
@@ -822,7 +822,7 @@ class TestTtsMatrixExpansion:
             ]
 
     def test_tts_health_test_targets(self):
-        suites = load_suite_files_by_category("tts")
+        suites = load_suite_files_by_category("text_to_speech")
         for suite in suites:
             health_test = suite["test_cases"][1]
             assert health_test["targets"] == {

--- a/tests/test_matrix_expansion.py
+++ b/tests/test_matrix_expansion.py
@@ -801,16 +801,16 @@ class TestTtsMatrixExpansion:
     """Validate that the migrated tts.json produces the same suites as before."""
 
     def test_tts_suite_count(self):
-        suites = load_suite_files_by_category("text_to_speech")
+        suites = load_suite_files_by_category("tts")
         assert len(suites) == 2
 
     def test_tts_suite_ids(self):
-        suites = load_suite_files_by_category("text_to_speech")
+        suites = load_suite_files_by_category("tts")
         ids = {s["id"] for s in suites}
         assert ids == {"speecht5-n150", "speecht5-p150"}
 
     def test_tts_test_cases_match(self):
-        suites = load_suite_files_by_category("text_to_speech")
+        suites = load_suite_files_by_category("tts")
         for suite in suites:
             assert len(suite["test_cases"]) == 4
             templates = [tc["template"] for tc in suite["test_cases"]]
@@ -822,7 +822,7 @@ class TestTtsMatrixExpansion:
             ]
 
     def test_tts_health_test_targets(self):
-        suites = load_suite_files_by_category("text_to_speech")
+        suites = load_suite_files_by_category("tts")
         for suite in suites:
             health_test = suite["test_cases"][1]
             assert health_test["targets"] == {

--- a/utils/media_clients/tts_client.py
+++ b/utils/media_clients/tts_client.py
@@ -214,7 +214,7 @@ class TtsClientStrategy(BaseMediaStrategy):
             "model": self.model_spec.model_name,
             "device": self.device.name,
             "timestamp": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime()),
-            "task_type": "tts",
+            "task_type": "text_to_speech",
         }
 
         with open(result_filename, "w") as f:

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -1622,7 +1622,9 @@ def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata
         vllm_text = [r for r in vllm_release_raw if r.get("task_type") == "text"]
         vllm_vlm = [r for r in vllm_release_raw if r.get("task_type") == "vlm"]
         vllm_audio = [r for r in vllm_release_raw if r.get("task_type") == "audio"]
-        vllm_tts = [r for r in vllm_release_raw if r.get("task_type") == "text_to_speech"]
+        vllm_tts = [
+            r for r in vllm_release_raw if r.get("task_type") == "text_to_speech"
+        ]
         vllm_embedding = [
             r for r in vllm_release_raw if r.get("task_type") == "embedding"
         ]

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -1622,7 +1622,7 @@ def benchmark_generate_report(args, server_mode, model_spec, report_id, metadata
         vllm_text = [r for r in vllm_release_raw if r.get("task_type") == "text"]
         vllm_vlm = [r for r in vllm_release_raw if r.get("task_type") == "vlm"]
         vllm_audio = [r for r in vllm_release_raw if r.get("task_type") == "audio"]
-        vllm_tts = [r for r in vllm_release_raw if r.get("task_type") == "tts"]
+        vllm_tts = [r for r in vllm_release_raw if r.get("task_type") == "text_to_speech"]
         vllm_embedding = [
             r for r in vllm_release_raw if r.get("task_type") == "embedding"
         ]

--- a/workflows/run_reports.py
+++ b/workflows/run_reports.py
@@ -2190,6 +2190,7 @@ def extract_eval_results(files):
 def evals_release_report_data(args, results, meta_data, model_spec):
     eval_config = EVAL_CONFIGS[model_spec.model_name]
 
+    task_type = model_spec.model_type.task_type
     report_rows = []
 
     for task in eval_config.tasks:
@@ -2282,6 +2283,7 @@ def evals_release_report_data(args, results, meta_data, model_spec):
                         "model": model_spec.model_name,
                         "device": args.device,
                         "task_name": t_key,
+                        "task_type": task_type,
                         "accuracy_check": accuracy_check,
                         "score": score,
                         "ratio_to_reference": ratio_to_reference,
@@ -2304,6 +2306,7 @@ def evals_release_report_data(args, results, meta_data, model_spec):
                     "model": model_spec.model_name,
                     "device": args.device,
                     "task_name": task.task_name,
+                    "task_type": task_type,
                     "accuracy_check": accuracy_check,
                     "score": score,
                     "ratio_to_reference": ratio_to_reference,
@@ -3127,7 +3130,7 @@ def benchmarks_release_data_format(
             "inference_steps_per_second", 0
         ),
         "filename": benchmark_summary_data.get("filename", ""),
-        "task_type": model_spec.model_type.name.lower(),
+        "task_type": model_spec.model_type.task_type,
     }
 
     if (
@@ -3184,7 +3187,7 @@ def benchmarks_release_data_format_embedding(
             "tput_prefill": benchmark_summary_data.get("tps_prefill_throughput", 0),
             "e2el_ms": benchmark_summary_data.get("mean_e2el_ms", 0),
             "filename": benchmark_summary_data.get("filename", ""),
-            "task_type": model_spec.model_type.name.lower(),
+            "task_type": model_spec.model_type.task_type,
         }
     ]
 

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -380,3 +380,17 @@ class ModelType(IntEnum):
             ModelType.VIDEO: "Video",
         }
         return short_names[self]
+
+    @property
+    def task_type(self) -> str:
+        task_types = {
+            ModelType.LLM: "text",
+            ModelType.VLM: "vlm",
+            ModelType.AUDIO: "audio",
+            ModelType.IMAGE: "image",
+            ModelType.CNN: "cnn",
+            ModelType.EMBEDDING: "embedding",
+            ModelType.TEXT_TO_SPEECH: "text_to_speech",
+            ModelType.VIDEO: "video",
+        }
+        return task_types[self]


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-inference-server/issues/3184

In addition, there were inconsistent `task_type` values returned for text-to-speech models ("tts" vs "text_to_speech"). I updated them all to "text_to_speech".