### PR TITLE
model_spec: set gpt-oss-120b trace_region_size to 128MB

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1005,6 +1005,9 @@ llm_templates = [
                 max_context=16 * 1024,
                 default_impl=True,
                 tensor_cache_timeout=5400.0,
+                override_tt_config={
+                    "trace_region_size": 134217728,  # 128 MB; vLLM default 50 MB is too small for long prefill
+                },
             ),
             DeviceModelSpec(
                 device=DeviceTypes.GALAXY,
@@ -1023,6 +1026,7 @@ llm_templates = [
                 },
                 override_tt_config={
                     "sample_on_device_mode": "all",
+                    "trace_region_size": 134217728,  # 128 MB; vLLM default 50 MB is too small for long prefill
                 },
             ),
         ],


### PR DESCRIPTION
## Why

`gpt-oss-120b` does not set `trace_region_size` and falls back to vLLM's default 50 MB, which is too small for prefill traces (~85 MB observed at SL=131072 in tt-shield runs). Without this, the server crashes during trace capture on long-context cells:

```
Creating trace buffers of size 84877312B on MeshDevice 0,
but only 50000000B is allocated for trace region.
```

The benchmark JSONs come back with `output_lens=[0,0,...]`, and the downstream report-gen step crashes with `ZeroDivisionError: float division by zero` while computing throughput. (Seen in tt-shield run [#621](https://github.com/tenstorrent/tt-shield/actions/runs/24960859686/job/73089333672) and [later](https://github.com/tenstorrent/tt-shield/actions/runs/24983710463/job/73157371874).)

Other 120B-class models in this file already set explicit `trace_region_size` for the same reason — e.g. Llama-3.1-70B Galaxy uses 184 MB.

## What

Set `trace_region_size = 134217728` (128 MB) in the GALAXY and T3K device specs for `openai/gpt-oss-120b` in `workflows/model_spec.py` (the source of truth). `release_model_spec.json` will be regenerated by the release tooling.

Per [@bgoelTT review](https://github.com/tenstorrent/tt-inference-server/pull/3188#pullrequestreview-4184569088): change goes in `workflows/model_spec.py`, not `release_model_spec.json`.

128 MB picked over the previous 100 MB because it was empirically validated against the full benchmarks workflow on Galaxy 4x8 — all 19 cells passed including the previously-failing `isl=65536 conc=1` (was DRAM OOM in attention all-reduce) and `isl=16384 conc=31 n=62` (was hung at near-OOM KV cache state). Headroom over Ben's observed 85 MB high-water mark.

## Test plan
- [x] Full `--workflow benchmarks` on gpt-oss-120b galaxy: all 19 cells PASS
- [ ] Re-run tt-shield gpt-oss-120b release-galaxy benchmark; verify no trace OOM and `output_lens > 0`