### PR TITLE
Add USE_FAST_MODE as Environment Variable

### DIFF
--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -32,6 +32,7 @@ constexpr size_t MAX_SESSIONS_COUNT = 128;
 constexpr unsigned SESSION_EVICTION_RATE = 90;
 constexpr size_t SESSION_EVICTION_COUNT = 10;
 constexpr size_t MAX_TOKENS_TO_PREFILL_ON_DECODE = 1000;
+constexpr bool USE_FAST_MODE = false;
 constexpr const char* KAFKA_BROKERS = "localhost:9092";
 constexpr const char* KAFKA_OFFLOAD_TOPIC_NAME = "session-offload";
 constexpr const char* KAFKA_GROUP_ID = "migration-workers";

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -109,6 +109,9 @@ size_t sessionEvictionCount();
  * Default: defaults::MAX_TOKENS_TO_PREFILL_ON_DECODE. */
 size_t maxTokensToPrefillOnDecode();
 
+/** Use fast mode from USE_FAST_MODE. Default: defaults::USE_FAST_MODE. */
+bool useFastMode();
+
 /** Kafka broker addresses from KAFKA_BROKERS. Default:
  * defaults::KAFKA_BROKERS. */
 std::string kafkaBrokers();

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -326,6 +326,10 @@ size_t maxTokensToPrefillOnDecode() {
                defaults::MAX_TOKENS_TO_PREFILL_ON_DECODE));
 }
 
+bool useFastMode() {
+  return envUlong("USE_FAST_MODE", defaults::USE_FAST_MODE);
+}
+
 std::string kafkaBrokers() {
   return envString("KAFKA_BROKERS", defaults::KAFKA_BROKERS);
 }

--- a/tt-media-server/cpp_server/src/utils/mapper.cpp
+++ b/tt-media-server/cpp_server/src/utils/mapper.cpp
@@ -1,5 +1,7 @@
 #include "utils/mapper.hpp"
 
+#include "config/settings.hpp"
+
 namespace tt::utils::mapper {
 
 tt::domain::SamplingParams mapSamplingParams(
@@ -25,7 +27,7 @@ tt::domain::SamplingParams mapSamplingParams(
   params.allowed_token_ids = request.allowed_token_ids;
   params.prompt_logprobs = request.prompt_logprobs;
   params.truncate_prompt_tokens = request.truncate_prompt_tokens;
-  params.fast_mode = request.fast_mode;
+  params.fast_mode = config::useFastMode() || request.fast_mode;
 
   if (request.response_format.has_value()) {
     params.response_format_type = request.response_format->type;


### PR DESCRIPTION
## Issue
We need the ability to override `fast_mode=true` for all requests in runtime, without the need to rebuild the Docker Image, in order to support testing