### PR TITLE
SDXL add Lora to img2img and inpainting

### DIFF
--- a/tt-media-server/tt_model_runners/sdxl_edit_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_edit_runner_trace.py
@@ -121,8 +121,10 @@ class TTSDXLEditRunner(TTSDXLImageToImageRunner):
         prompts, negative_prompts, prompts_2, negative_prompt_2, needed_padding = (
             self._process_prompts(requests)
         )
+        prompts = self._inject_lora_triggers(prompts, requests[0].lora_path)
 
         self._apply_request_settings(requests[0])
+        self._ensure_lora_state(requests[0])
         self._apply_image_to_image_request_settings(requests[0])
 
         self.logger.debug(f"Device {self.device_id}: Starting text encoding...")

--- a/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
@@ -118,8 +118,10 @@ class TTSDXLImageToImageRunner(BaseSDXLRunner):
         prompts, negative_prompts, prompts_2, negative_prompt_2, needed_padding = (
             self._process_prompts(requests)
         )
+        prompts = self._inject_lora_triggers(prompts, requests[0].lora_path)
 
         self._apply_request_settings(requests[0])
+        self._ensure_lora_state(requests[0])
         self._apply_image_to_image_request_settings(requests[0])
 
         self.logger.debug(f"Device {self.device_id}: Starting text encoding...")


### PR DESCRIPTION
## Problem description
Lora is required for sdxl img2img and sdxl inpainting on tt-console for tt-deploy

## Checklist
- [stable-diffusion-xl-base-1.0-img-2-img | llmbox | release | main | jmitrovic/lora_img2img_inpainting](https://github.com/tenstorrent/tt-shield/actions/runs/25011561650) passed✅ (except evals - failing on main), perf: 5.583s
- [stable-diffusion-xl-base-1.0-img-2-img | n150 | release | main | jmitrovic/lora_img2img_inpainting](https://github.com/tenstorrent/tt-shield/actions/runs/25011573699) passed✅ (except evals - failing on main), perf: 8.928s
- [stable-diffusion-xl-1.0-inpainting-0.1 | n150 | release | main | jmitrovic/lora_img2img_inpainting](https://github.com/tenstorrent/tt-shield/actions/runs/25011604386) passed✅ (except evals - failing on main), perf: 9.759s
- [stable-diffusion-xl-1.0-inpainting-0.1 | llmbox | release | main | jmitrovic/lora_img2img_inpainting](https://github.com/tenstorrent/tt-shield/actions/runs/25011614700) passed✅ (except evals - failing on main), perf: 6.434s

## Notes: Local Testing:
- **img2img**

Request with LoRA has:
```json
{
  "prompt": "red hair",
  "lora_path": "ostris/crayon_style_lora_sdxl",
  "lora_scale": 0.5,
  "num_inference_steps": 20,
  "seed": 0,
  "lora_scale": 0.5,
  "strength": 0.7,
  "image": ...
}
```
| Img2img request without LoRA | Img2img request with LoRA |
|---|---|
| <img width="256" height="256" alt="download_no_lora_img2img" src="https://github.com/user-attachments/assets/39ef616e-bcdd-4da5-b221-55708d93d881" /> | <img width="256" height="256" alt="download_img2img_lora" src="https://github.com/user-attachments/assets/5c7f9c42-33fa-412f-a9f3-b4e45d667f11" /> |

**inpainting**

Request with LoRA has:
```json
{
  "prompt": "a tiger",
  "num_inference_steps": 20,
  "seed": 0,
  "lora_path": "ostris/crayon_style_lora_sdxl"
  "lora_scale": 2,
  "strength": 1,
  "image": ...,
  "mask": ...
}
```

| Inpainting request without LoRA | Inpainting request with LoRA |
|---|---|
| <img width="256" height="256" alt="inpaint_no_lora" src="https://github.com/user-attachments/assets/3fa720c3-ba21-4482-aa8c-fba8298ea701" /> | <img width="256" height="256" alt="inpaint_lora" src="https://github.com/user-attachments/assets/b4cdc440-5146-4eda-a303-33a4170a72e6" /> |

