### PR TITLE
Set max session count through an API

### DIFF
--- a/tt-media-server/cpp_server/include/api/health_controller.hpp
+++ b/tt-media-server/cpp_server/include/api/health_controller.hpp
@@ -20,6 +20,8 @@ class HealthController : public drogon::HttpController<HealthController> {
   METHOD_LIST_BEGIN
   ADD_METHOD_TO(HealthController::health, "/health", drogon::Get);
   ADD_METHOD_TO(HealthController::ready, "/tt-liveness", drogon::Get);
+  ADD_METHOD_TO(HealthController::getMaxSessionCount, "/max-session-count", drogon::Get);
+  ADD_METHOD_TO(HealthController::setMaxSessionCount, "/max-session-count", drogon::Post);
   METHOD_LIST_END
 
   HealthController();
@@ -31,6 +33,14 @@ class HealthController : public drogon::HttpController<HealthController> {
   void ready(
       const drogon::HttpRequestPtr& req,
       std::function<void(const drogon::HttpResponsePtr&)>&& callback) const;
+
+  void getMaxSessionCount(
+      const drogon::HttpRequestPtr& req,
+      std::function<void(const drogon::HttpResponsePtr&)>&& callback) const;
+
+  void setMaxSessionCount(
+      const drogon::HttpRequestPtr& req,
+      std::function<void(const drogon::HttpResponsePtr&)>&& callback);
 
  private:
   std::shared_ptr<services::IService> service_;

--- a/tt-media-server/cpp_server/include/api/health_controller.hpp
+++ b/tt-media-server/cpp_server/include/api/health_controller.hpp
@@ -20,8 +20,10 @@ class HealthController : public drogon::HttpController<HealthController> {
   METHOD_LIST_BEGIN
   ADD_METHOD_TO(HealthController::health, "/health", drogon::Get);
   ADD_METHOD_TO(HealthController::ready, "/tt-liveness", drogon::Get);
-  ADD_METHOD_TO(HealthController::getMaxSessionCount, "/max-session-count", drogon::Get);
-  ADD_METHOD_TO(HealthController::setMaxSessionCount, "/max-session-count", drogon::Post);
+  ADD_METHOD_TO(HealthController::getMaxSessionCount, "/max-session-count",
+                drogon::Get);
+  ADD_METHOD_TO(HealthController::setMaxSessionCount, "/max-session-count",
+                drogon::Post);
   METHOD_LIST_END
 
   HealthController();

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -94,8 +94,13 @@ SchedulingPolicy schedulingPolicy();
 size_t maxInFlightCount();
 
 /** Max sessions count from MAX_SESSIONS_COUNT. Default:
- * defaults::MAX_SESSIONS_COUNT. */
+ * defaults::MAX_SESSIONS_COUNT. Can be overridden at runtime via
+ * setMaxSessionsCount(). */
 size_t maxSessionsCount();
+
+/** Set max sessions count override. Pass 0 to clear the override and use the
+ * environment variable value. */
+void setMaxSessionsCount(size_t count);
 
 /** Session eviction rate percentage from SESSION_EVICTION_RATE. Default:
  * defaults::SESSION_EVICTION_RATE. */

--- a/tt-media-server/cpp_server/resources/openapi.json
+++ b/tt-media-server/cpp_server/resources/openapi.json
@@ -336,6 +336,7 @@
         "summary": "Health check",
         "description": "Returns server health status.",
         "operationId": "healthCheck",
+        "security": [],
         "responses": {
           "200": {
             "description": "Server is healthy",
@@ -354,6 +355,7 @@
         "summary": "Liveness check",
         "description": "Liveness probe (same as Python tt-liveness). Returns 200 with {\"status\": \"alive\", ...system status} when the process can respond. model_ready in the body reflects whether any worker has warmed up. Does not return 503 for model not ready; 500 only on unrecoverable failure.",
         "operationId": "livenessCheck",
+        "security": [],
         "responses": {
           "200": {
             "description": "Process is alive; body includes status alive and system status (model_ready, workers, queue)",
@@ -374,12 +376,73 @@
         }
       }
     },
+    "/max-session-count": {
+      "get": {
+        "tags": ["Health"],
+        "summary": "Get maximum session count",
+        "description": "Returns the current maximum session count. This may be either the value set via the POST endpoint or the default from the MAX_SESSIONS_COUNT environment variable.",
+        "operationId": "getMaxSessionCount",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved max session count",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MaxSessionCountResponse" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Health"],
+        "summary": "Set maximum session count",
+        "description": "Sets the maximum session count at runtime. This overrides the MAX_SESSIONS_COUNT environment variable. Set to 0 to clear the override and revert to the environment variable value. Changes take effect immediately for new session allocation attempts.",
+        "operationId": "setMaxSessionCount",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MaxSessionCountRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully set max session count",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MaxSessionCountSetResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request (e.g. missing field or invalid value)",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/metrics": {
       "get": {
         "tags": ["Monitoring"],
         "summary": "Prometheus metrics",
         "description": "Exposes all server metrics in Prometheus text exposition format (version 0.0.4). No authentication required. Intended to be scraped by a Prometheus server every few seconds.",
         "operationId": "getMetrics",
+        "security": [],
         "responses": {
           "200": {
             "description": "Prometheus text format metrics",
@@ -634,6 +697,50 @@
           "is_ready": {
             "type": "boolean",
             "description": "Whether worker is ready"
+          }
+        }
+      },
+      "MaxSessionCountResponse": {
+        "type": "object",
+        "required": ["max_session_count"],
+        "properties": {
+          "max_session_count": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "description": "Current maximum session count",
+            "example": 128
+          }
+        }
+      },
+      "MaxSessionCountRequest": {
+        "type": "object",
+        "required": ["max_session_count"],
+        "properties": {
+          "max_session_count": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "description": "New maximum session count. Set to 0 to clear override and use environment variable value.",
+            "example": 256
+          }
+        }
+      },
+      "MaxSessionCountSetResponse": {
+        "type": "object",
+        "required": ["max_session_count", "status"],
+        "properties": {
+          "max_session_count": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "description": "The new maximum session count that was set",
+            "example": 256
+          },
+          "status": {
+            "type": "string",
+            "enum": ["success"],
+            "description": "Operation status"
           }
         }
       },

--- a/tt-media-server/cpp_server/src/api/health_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/health_controller.cpp
@@ -136,7 +136,8 @@ void HealthController::getMaxSessionCount(
     const drogon::HttpRequestPtr&,
     std::function<void(const drogon::HttpResponsePtr&)>&& callback) const {
   Json::Value response;
-  response["max_session_count"] = static_cast<Json::UInt64>(tt::config::maxSessionsCount());
+  response["max_session_count"] =
+      static_cast<Json::UInt64>(tt::config::maxSessionsCount());
   callback(drogon::HttpResponse::newHttpJsonResponse(response));
 }
 
@@ -174,18 +175,20 @@ void HealthController::setMaxSessionCount(
     }
 
     size_t newCount = static_cast<size_t>(countValue.asUInt64());
-    
+
     TT_LOG_INFO("[HealthController] Setting max session count to {}", newCount);
     tt::config::setMaxSessionsCount(newCount);
-    
+
     Json::Value response;
     response["max_session_count"] = static_cast<Json::UInt64>(newCount);
     response["status"] = "success";
     callback(drogon::HttpResponse::newHttpJsonResponse(response));
   } catch (const std::exception& e) {
-    TT_LOG_ERROR("[HealthController] Failed to set max session count: {}", e.what());
+    TT_LOG_ERROR("[HealthController] Failed to set max session count: {}",
+                 e.what());
     Json::Value response;
-    response["error"] = std::string("Failed to set max session count: ") + e.what();
+    response["error"] =
+        std::string("Failed to set max session count: ") + e.what();
     auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
     resp->setStatusCode(drogon::k500InternalServerError);
     callback(resp);

--- a/tt-media-server/cpp_server/src/api/health_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/health_controller.cpp
@@ -132,4 +132,64 @@ void HealthController::ready(
   }
 }
 
+void HealthController::getMaxSessionCount(
+    const drogon::HttpRequestPtr&,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback) const {
+  Json::Value response;
+  response["max_session_count"] = static_cast<Json::UInt64>(tt::config::maxSessionsCount());
+  callback(drogon::HttpResponse::newHttpJsonResponse(response));
+}
+
+void HealthController::setMaxSessionCount(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
+  try {
+    auto json = req->getJsonObject();
+    if (!json) {
+      Json::Value response;
+      response["error"] = "Request body must be JSON";
+      auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
+      resp->setStatusCode(drogon::k400BadRequest);
+      callback(resp);
+      return;
+    }
+
+    if (!json->isMember("max_session_count")) {
+      Json::Value response;
+      response["error"] = "Missing required field: max_session_count";
+      auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
+      resp->setStatusCode(drogon::k400BadRequest);
+      callback(resp);
+      return;
+    }
+
+    const auto& countValue = (*json)["max_session_count"];
+    if (!countValue.isUInt64() && !countValue.isInt64()) {
+      Json::Value response;
+      response["error"] = "max_session_count must be a non-negative integer";
+      auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
+      resp->setStatusCode(drogon::k400BadRequest);
+      callback(resp);
+      return;
+    }
+
+    size_t newCount = static_cast<size_t>(countValue.asUInt64());
+    
+    TT_LOG_INFO("[HealthController] Setting max session count to {}", newCount);
+    tt::config::setMaxSessionsCount(newCount);
+    
+    Json::Value response;
+    response["max_session_count"] = static_cast<Json::UInt64>(newCount);
+    response["status"] = "success";
+    callback(drogon::HttpResponse::newHttpJsonResponse(response));
+  } catch (const std::exception& e) {
+    TT_LOG_ERROR("[HealthController] Failed to set max session count: {}", e.what());
+    Json::Value response;
+    response["error"] = std::string("Failed to set max session count: ") + e.what();
+    auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
+    resp->setStatusCode(drogon::k500InternalServerError);
+    callback(resp);
+  }
+}
+
 }  // namespace tt::api

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -311,7 +311,8 @@ std::atomic<size_t> maxSessionsCountOverride{0};
 }
 
 size_t maxSessionsCount() {
-  size_t override_val = maxSessionsCountOverride.load(std::memory_order_relaxed);
+  size_t override_val =
+      maxSessionsCountOverride.load(std::memory_order_relaxed);
   if (override_val > 0) {
     return override_val;
   }

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -311,10 +311,9 @@ std::atomic<size_t> maxSessionsCountOverride{0};
 }
 
 size_t maxSessionsCount() {
-  size_t override_val =
-      maxSessionsCountOverride.load(std::memory_order_relaxed);
-  if (override_val > 0) {
-    return override_val;
+  size_t overrideVal = maxSessionsCountOverride.load(std::memory_order_relaxed);
+  if (overrideVal > 0) {
+    return overrideVal;
   }
   return static_cast<size_t>(
       envUlong("MAX_SESSIONS_COUNT", defaults::MAX_SESSIONS_COUNT));

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -4,6 +4,7 @@
 #include "config/settings.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 #include <cstddef>
 #include <cstdlib>
@@ -305,9 +306,21 @@ size_t maxQueueSize() {
   return cached;
 }
 
+namespace {
+std::atomic<size_t> maxSessionsCountOverride{0};
+}
+
 size_t maxSessionsCount() {
+  size_t override_val = maxSessionsCountOverride.load(std::memory_order_relaxed);
+  if (override_val > 0) {
+    return override_val;
+  }
   return static_cast<size_t>(
       envUlong("MAX_SESSIONS_COUNT", defaults::MAX_SESSIONS_COUNT));
+}
+
+void setMaxSessionsCount(size_t count) {
+  maxSessionsCountOverride.store(count, std::memory_order_relaxed);
 }
 
 unsigned sessionEvictionRate() {

--- a/tt-media-server/cpp_server/src/main.cpp
+++ b/tt-media-server/cpp_server/src/main.cpp
@@ -184,7 +184,7 @@ int main(int argc, char* argv[]) {
 
         if (path == "/health" || path == "/tt-liveness" || path == "/docs" ||
             path == "/swagger" || path == "/openapi.json" ||
-            path == "/metrics") {
+            path == "/metrics" || path == "/max-session-count") {
           chainCallback();
           return;
         }

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -360,6 +360,38 @@ void SessionManager::createSession(
 
 void SessionManager::sendAsyncAllocationRequest(
     PendingAllocation& pendingAllocation) {
+  // Check if max session count is reached
+  size_t maxSessions = tt::config::maxSessionsCount();
+  size_t activeCount = getActiveSessionCount();
+  
+  if (activeCount >= maxSessions) {
+    TT_LOG_DEBUG(
+        "[SessionManager] sendAsyncAllocationRequest: max sessions reached "
+        "({}/{}), deferring sessionId={}",
+        activeCount, maxSessions, pendingAllocation.session.getSessionId());
+    
+    if (pendingAllocation.attemptsRemaining == 0) {
+      TT_LOG_ERROR(
+          "[SessionManager] sendAsyncAllocationRequest: no attempts left, "
+          "failing sessionId={}",
+          pendingAllocation.session.getSessionId());
+      pendingAllocation.eventLoop->queueInLoop([onError = std::move(pendingAllocation.onError)]() {
+        onError("Failed to allocate: max session count reached after all attempts");
+      });
+    } else {
+      pendingAllocation.attemptsRemaining--;
+      pendingAllocation.retryAt =
+          std::chrono::steady_clock::now() + IPC_QUEUE_FULL_RETRY_DELAY;
+      TT_LOG_DEBUG(
+          "[SessionManager] sendAsyncAllocationRequest: queuing retry for "
+          "sessionId={}, attemptsRemaining={}, delayMs={}",
+          pendingAllocation.session.getSessionId(), pendingAllocation.attemptsRemaining,
+          IPC_QUEUE_FULL_RETRY_DELAY.count());
+      pendingAllocationsRetryQueue.push(std::move(pendingAllocation));
+    }
+    return;
+  }
+
   auto task = makeAllocTask();
   TT_LOG_DEBUG(
       "[SessionManager] sendAsyncAllocationRequest: taskId={}, "

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -363,20 +363,23 @@ void SessionManager::sendAsyncAllocationRequest(
   // Check if max session count is reached
   size_t maxSessions = tt::config::maxSessionsCount();
   size_t activeCount = getActiveSessionCount();
-  
+
   if (activeCount >= maxSessions) {
     TT_LOG_DEBUG(
         "[SessionManager] sendAsyncAllocationRequest: max sessions reached "
         "({}/{}), deferring sessionId={}",
         activeCount, maxSessions, pendingAllocation.session.getSessionId());
-    
+
     if (pendingAllocation.attemptsRemaining == 0) {
       TT_LOG_ERROR(
           "[SessionManager] sendAsyncAllocationRequest: no attempts left, "
           "failing sessionId={}",
           pendingAllocation.session.getSessionId());
-      pendingAllocation.eventLoop->queueInLoop([onError = std::move(pendingAllocation.onError)]() {
-        onError("Failed to allocate: max session count reached after all attempts");
+      pendingAllocation.eventLoop->queueInLoop([onError =
+                                                    std::move(pendingAllocation
+                                                                  .onError)]() {
+        onError(
+            "Failed to allocate: max session count reached after all attempts");
       });
     } else {
       pendingAllocation.attemptsRemaining--;
@@ -385,7 +388,8 @@ void SessionManager::sendAsyncAllocationRequest(
       TT_LOG_DEBUG(
           "[SessionManager] sendAsyncAllocationRequest: queuing retry for "
           "sessionId={}, attemptsRemaining={}, delayMs={}",
-          pendingAllocation.session.getSessionId(), pendingAllocation.attemptsRemaining,
+          pendingAllocation.session.getSessionId(),
+          pendingAllocation.attemptsRemaining,
           IPC_QUEUE_FULL_RETRY_DELAY.count());
       pendingAllocationsRetryQueue.push(std::move(pendingAllocation));
     }


### PR DESCRIPTION
API:

<img width="441" height="386" alt="image" src="https://github.com/user-attachments/assets/bcb7888c-c630-4c94-a014-a0491be924e1" />


<img width="434" height="350" alt="image" src="https://github.com/user-attachments/assets/69873c35-d6d5-41ee-a601-2211f08b745d" />



Max 5 sessions, vllm bench serve 32 concurrency:

<img width="842" height="688" alt="image" src="https://github.com/user-attachments/assets/f23b1daa-4ff8-46f2-bc71-fb11939f61b1" />


Max 15 sessions:

<img width="842" height="688" alt="image" src="https://github.com/user-attachments/assets/d5baeea3-94fd-4863-b1b0-b65fcaad377b" />


Max 32 sessions:

![Uploading image.png…]()
