### PR TITLE
Add ConversationStore for per-session conversation export

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -514,6 +514,16 @@ target_include_directories(session_manager_test PRIVATE
     ${prometheus-cpp_SOURCE_DIR}/core/include
 )
 
+add_executable(conversation_store_test
+    tests/conversation_store_test.cpp
+    src/services/conversation_store.cpp
+)
+target_link_libraries(conversation_store_test PRIVATE
+    llm_runner_lib JsonCpp::JsonCpp GTest::gtest_main)
+target_include_directories(conversation_store_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
 include(GoogleTest)
 gtest_discover_tests(scheduler_test)
 gtest_discover_tests(llm_runner_test)
@@ -528,6 +538,7 @@ gtest_discover_tests(worker_metrics_shm_test)
 gtest_discover_tests(concurrent_map_test)
 gtest_discover_tests(session_test)
 gtest_discover_tests(session_manager_test)
+gtest_discover_tests(conversation_store_test)
 
 # Register tool call tests
 add_test(NAME ChatCompletionRequest COMMAND test_chat_completion_request)

--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -608,6 +608,7 @@ set(SOURCES
     src/services/reasoning_parser.cpp
     src/services/deepseek_tool_call_parser.cpp
     src/services/session_manager.cpp
+    src/services/conversation_store.cpp
     src/domain/session.cpp
     src/worker/single_process_worker.cpp
     src/worker/worker_manager.cpp

--- a/tt-media-server/cpp_server/include/api/llm_controller.hpp
+++ b/tt-media-server/cpp_server/include/api/llm_controller.hpp
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "services/conversation_store.hpp"
 #include "services/disaggregation_service.hpp"
 #include "services/llm_service.hpp"
 #include "services/session_manager.hpp"
@@ -28,6 +29,8 @@ class LLMController : public drogon::HttpController<LLMController> {
                 drogon::Delete);
   ADD_METHOD_TO(LLMController::getSlotId, "/v1/sessions/{session_id}/slot",
                 drogon::Get);
+  ADD_METHOD_TO(LLMController::exportConversation,
+                "/v1/sessions/{session_id}/export", drogon::Get);
   ADD_METHOD_TO(LLMController::models, "/v1/models", drogon::Get);
   METHOD_LIST_END
 
@@ -70,10 +73,21 @@ class LLMController : public drogon::HttpController<LLMController> {
                  std::function<void(const drogon::HttpResponsePtr&)>&& callback,
                  const std::string& sessionId) const;
 
+  /**
+   * GET /v1/sessions/{session_id}/export
+   * Download the raw conversation log (input messages, output text, TTFT, TPS)
+   * for a session as a JSON array.
+   */
+  void exportConversation(
+      const drogon::HttpRequestPtr& req,
+      std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+      const std::string& sessionId) const;
+
  private:
   std::shared_ptr<services::LLMService> service;
   std::shared_ptr<services::DisaggregationService> disaggregationService;
   std::shared_ptr<services::SessionManager> sessionManager;
+  std::shared_ptr<services::ConversationStore> conversationStore;
 
   /**
    * Handle streaming chat completion (SSE). Emits ChatCompletionStreamChunk

--- a/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
+++ b/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
@@ -35,7 +35,7 @@ struct StreamParams {
   std::shared_ptr<services::SessionManager> sessionManager;
   // Conversation logging (optional; null disables logging)
   std::shared_ptr<services::ConversationStore> conversationStore;
-  Json::Value inputMessages;  // JSON array of {role, content} objects
+  Json::Value inputMessages;
 };
 
 class SseStreamWriter : public std::enable_shared_from_this<SseStreamWriter> {
@@ -81,8 +81,8 @@ class SseStreamWriter : public std::enable_shared_from_this<SseStreamWriter> {
   // Accumulated output for conversation logging; written only from the
   // consumer thread before finalizeStream is called, then read once by the
   // event-loop lambda — no additional synchronization needed.
-  std::string accumulated_output_;
-  std::string finish_reason_;
+  std::string accumulatedOutput_;
+  std::string finishReason_;
 
   StreamParams params_;
 };

--- a/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
+++ b/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
@@ -13,7 +13,10 @@
 #include <optional>
 #include <string>
 
+#include <json/json.h>
+
 #include "domain/llm_response.hpp"
+#include "services/conversation_store.hpp"
 #include "services/llm_service.hpp"
 #include "services/session_manager.hpp"
 #include "utils/concurrent_queue.hpp"
@@ -31,6 +34,9 @@ struct StreamParams {
   uint32_t taskId;
   std::shared_ptr<services::LLMService> service;
   std::shared_ptr<services::SessionManager> sessionManager;
+  // Conversation logging (optional; null disables logging)
+  std::shared_ptr<services::ConversationStore> conversationStore;
+  Json::Value inputMessages;  // JSON array of {role, content} objects
 };
 
 class SseStreamWriter : public std::enable_shared_from_this<SseStreamWriter> {
@@ -72,6 +78,12 @@ class SseStreamWriter : public std::enable_shared_from_this<SseStreamWriter> {
   std::optional<std::chrono::high_resolution_clock::time_point>
       second_token_time_;
   std::atomic<bool> first_content_chunk_{true};
+
+  // Accumulated output for conversation logging; written only from the
+  // consumer thread before finalizeStream is called, then read once by the
+  // event-loop lambda — no additional synchronization needed.
+  std::string accumulated_output_;
+  std::string finish_reason_;
 
   StreamParams params_;
 };

--- a/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
+++ b/tt-media-server/cpp_server/include/api/sse_stream_writer.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <drogon/drogon.h>
+#include <json/json.h>
 #include <trantor/net/EventLoop.h>
 
 #include <atomic>
@@ -12,8 +13,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-
-#include <json/json.h>
 
 #include "domain/llm_response.hpp"
 #include "services/conversation_store.hpp"

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -60,6 +60,8 @@ constexpr unsigned WARMUP_TIMEOUT_MS = 10000;
  */
 constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 10000;
 
+constexpr const char* CONVERSATION_LOG_DIR = "/tmp/tt_conversation_logs";
+
 constexpr const char* MODEL = "deepseek-ai/DeepSeek-R1-0528";
 
 constexpr const char* SERVER_HOST = "0.0.0.0";

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -198,4 +198,8 @@ LLMConfig llmEngineConfig();
 /** Model from MODEL. Default: defaults::MODEL. */
 Model model();
 
+/** Directory for conversation log files from CONVERSATION_LOG_DIR.
+ *  Default: defaults::CONVERSATION_LOG_DIR. */
+std::string conversationLogDir();
+
 }  // namespace tt::config

--- a/tt-media-server/cpp_server/include/services/conversation_store.hpp
+++ b/tt-media-server/cpp_server/include/services/conversation_store.hpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#pragma once
+
+#include <json/json.h>
+
+#include <atomic>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <thread>
+
+#include "utils/concurrent_queue.hpp"
+
+namespace tt::services {
+
+struct TurnRecord {
+  Json::Value input_messages;  // JSON array of {role, content} objects
+  std::string output_text;
+  std::optional<double> ttft_ms;
+  std::optional<double> tps;
+  int prompt_tokens = 0;
+  int completion_tokens = 0;
+  int64_t timestamp_ms = 0;
+  std::string finish_reason;
+};
+
+/**
+ * Stores per-session conversation turns (input + output + timing) to disk for
+ * later download. Each session's turns are appended as newline-delimited JSON
+ * to {logDir}/{sessionId}.jsonl by a background writer thread so the hot
+ * request path is never blocked on I/O.
+ *
+ * Removal: delete this file, remove it from ServiceContainer, and remove the
+ * two recordTurn call-sites in LLMController / SseStreamWriter.
+ */
+class ConversationStore {
+ public:
+  explicit ConversationStore(std::string logDir);
+  ~ConversationStore();
+
+  ConversationStore(const ConversationStore&) = delete;
+  ConversationStore& operator=(const ConversationStore&) = delete;
+
+  // Thread-safe: enqueue a completed turn for async file write.
+  void recordTurn(const std::string& sessionId, TurnRecord record);
+
+  // Return all recorded turns for the session as a JSON array string.
+  // Reads from the .jsonl file on disk.
+  // Note: turns enqueued but not yet flushed by the background thread may not
+  // appear immediately; in practice the writer thread drains within ~5 ms.
+  std::optional<std::string> exportSession(const std::string& sessionId) const;
+
+ private:
+  struct WriteTask {
+    std::string sessionId;
+    TurnRecord record;
+  };
+
+  void writerLoop();
+  void writeTurnToFile(const std::string& sessionId,
+                       const TurnRecord& record) const;
+  static std::string serializeTurn(const TurnRecord& record);
+  std::string logFilePath(const std::string& sessionId) const;
+
+  std::string logDir_;
+  utils::ConcurrentQueue<WriteTask> writeQueue_;
+  std::atomic<bool> stopped_{false};
+  std::thread writerThread_;
+};
+
+}  // namespace tt::services

--- a/tt-media-server/cpp_server/include/services/conversation_store.hpp
+++ b/tt-media-server/cpp_server/include/services/conversation_store.hpp
@@ -44,9 +44,8 @@ class ConversationStore {
   void recordTurn(const std::string& sessionId, TurnRecord record);
 
   // Return all recorded turns for the session as a JSON array string.
-  // Reads from the .jsonl file on disk.
-  // Note: turns enqueued but not yet flushed by the background thread may not
-  // appear immediately; in practice the writer thread drains within ~5 ms.
+  // Reads from the .jsonl file on disk. Turns enqueued but not yet
+  // flushed by the background thread may not appear immediately
   std::optional<std::string> exportSession(const std::string& sessionId) const;
 
  private:

--- a/tt-media-server/cpp_server/include/services/conversation_store.hpp
+++ b/tt-media-server/cpp_server/include/services/conversation_store.hpp
@@ -16,14 +16,14 @@
 namespace tt::services {
 
 struct TurnRecord {
-  Json::Value input_messages;  // JSON array of {role, content} objects
-  std::string output_text;
-  std::optional<double> ttft_ms;
+  Json::Value inputMessages;
+  std::string outputText;
+  std::optional<double> ttftMs;
   std::optional<double> tps;
-  int prompt_tokens = 0;
-  int completion_tokens = 0;
-  int64_t timestamp_ms = 0;
-  std::string finish_reason;
+  int promptTokens = 0;
+  int completionTokens = 0;
+  int64_t timestampMs = 0;
+  std::string finishReason;
 };
 
 /**
@@ -31,9 +31,6 @@ struct TurnRecord {
  * later download. Each session's turns are appended as newline-delimited JSON
  * to {logDir}/{sessionId}.jsonl by a background writer thread so the hot
  * request path is never blocked on I/O.
- *
- * Removal: delete this file, remove it from ServiceContainer, and remove the
- * two recordTurn call-sites in LLMController / SseStreamWriter.
  */
 class ConversationStore {
  public:

--- a/tt-media-server/cpp_server/include/services/conversation_store.hpp
+++ b/tt-media-server/cpp_server/include/services/conversation_store.hpp
@@ -60,10 +60,10 @@ class ConversationStore {
   static std::string serializeTurn(const TurnRecord& record);
   std::string logFilePath(const std::string& sessionId) const;
 
-  std::string logDir_;
-  utils::ConcurrentQueue<WriteTask> writeQueue_;
-  std::atomic<bool> stopped_{false};
-  std::thread writerThread_;
+  std::string logDir;
+  utils::ConcurrentQueue<WriteTask> writeQueue;
+  std::atomic<bool> stopped{false};
+  std::thread writerThread;
 };
 
 }  // namespace tt::services

--- a/tt-media-server/cpp_server/include/utils/service_container.hpp
+++ b/tt-media-server/cpp_server/include/utils/service_container.hpp
@@ -11,6 +11,7 @@ class LLMService;
 class EmbeddingService;
 class DisaggregationService;
 class SessionManager;
+class ConversationStore;
 class IService;
 }  // namespace tt::services
 
@@ -37,7 +38,8 @@ class ServiceContainer {
       std::shared_ptr<services::EmbeddingService> embedding,
       std::shared_ptr<sockets::InterServerService> socket,
       std::shared_ptr<services::DisaggregationService> disaggregation,
-      std::shared_ptr<services::SessionManager> sessionMgr);
+      std::shared_ptr<services::SessionManager> sessionMgr,
+      std::shared_ptr<services::ConversationStore> conversationStore);
 
   std::shared_ptr<services::IService> configuredService() const;
 
@@ -54,6 +56,9 @@ class ServiceContainer {
   std::shared_ptr<services::SessionManager> sessionManager() const {
     return sessionManager_;
   }
+  std::shared_ptr<services::ConversationStore> conversationStore() const {
+    return conversationStore_;
+  }
 
  private:
   ServiceContainer() = default;
@@ -63,6 +68,7 @@ class ServiceContainer {
   std::shared_ptr<sockets::InterServerService> socket_;
   std::shared_ptr<services::DisaggregationService> disaggregation_;
   std::shared_ptr<services::SessionManager> sessionManager_;
+  std::shared_ptr<services::ConversationStore> conversationStore_;
 };
 
 }  // namespace tt::utils

--- a/tt-media-server/cpp_server/resources/openapi.json
+++ b/tt-media-server/cpp_server/resources/openapi.json
@@ -282,6 +282,96 @@
         }
       }
     },
+    "/v1/sessions/{session_id}/export": {
+      "get": {
+        "tags": ["Sessions"],
+        "summary": "Export raw conversation log",
+        "description": "Download all recorded turns for a session as a JSON array. Each turn contains the input messages, output text, TTFT, TPS, token counts, finish reason, and timestamp. The session must have had at least one completed request.",
+        "operationId": "exportConversation",
+        "security": [{ "BearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session ID",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Conversation log exported successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "timestamp_ms": {
+                        "type": "integer",
+                        "description": "Unix timestamp in milliseconds when the turn completed"
+                      },
+                      "input_messages": {
+                        "type": "array",
+                        "description": "The input messages sent for this turn",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "role": { "type": "string" },
+                            "content": { "type": "string" }
+                          }
+                        }
+                      },
+                      "output_text": {
+                        "type": "string",
+                        "description": "The generated response text"
+                      },
+                      "ttft_ms": {
+                        "type": "number",
+                        "description": "Time to first token in milliseconds"
+                      },
+                      "tps": {
+                        "type": "number",
+                        "description": "Tokens per second (excluding first token)"
+                      },
+                      "prompt_tokens": {
+                        "type": "integer",
+                        "description": "Number of prompt tokens"
+                      },
+                      "completion_tokens": {
+                        "type": "integer",
+                        "description": "Number of completion tokens"
+                      },
+                      "finish_reason": {
+                        "type": "string",
+                        "description": "Reason the generation stopped"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No conversation log found for this session",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "503": {
+            "description": "Conversation store not available",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/models": {
       "get": {
         "tags": ["Models"],

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -25,6 +25,19 @@
 
 namespace tt::api {
 
+namespace {
+
+Json::Value messagesToJson(
+    const std::vector<domain::ChatMessage>& messages) {
+  Json::Value arr(Json::arrayValue);
+  for (const auto& msg : messages) {
+    arr.append(msg.toJson());
+  }
+  return arr;
+}
+
+}  // namespace
+
 void LLMController::models(
     const drogon::HttpRequestPtr& _,
     std::function<void(const drogon::HttpResponsePtr&)>&& callback) const {
@@ -47,6 +60,7 @@ LLMController::LLMController() {
   service = c.llm();
   disaggregationService = c.disaggregation();
   sessionManager = c.sessionManager();
+  conversationStore = c.conversationStore();
 
   if (!service) {
     throw std::runtime_error(
@@ -232,9 +246,12 @@ void LLMController::chatCompletions(
         std::make_shared<std::function<void(const drogon::HttpResponsePtr&)>>(
             std::move(callback));
 
+    auto inputMessages = messagesToJson(chatReq.messages);
+
     resolveSession(
         request, loop,
-        [this, request, cb](SessionInfo) {
+        [this, request, cb,
+         inputMessages = std::move(inputMessages)](SessionInfo) mutable {
           try {
             auto sessionId = request->sessionId;
             auto startTime = std::chrono::high_resolution_clock::now();
@@ -268,6 +285,29 @@ void LLMController::chatCompletions(
 
             if (sessionId.has_value() && sessionManager) {
               sessionManager->releaseInFlight(sessionId.value());
+            }
+
+            if (sessionId.has_value() && conversationStore) {
+              tt::services::TurnRecord record;
+              record.input_messages = std::move(inputMessages);
+              record.output_text = completion.choices.empty()
+                                       ? ""
+                                       : completion.choices[0].text;
+              record.ttft_ms = completion.usage.ttft_ms;
+              record.tps = completion.usage.tps;
+              record.prompt_tokens = completion.usage.prompt_tokens;
+              record.completion_tokens = completion.usage.completion_tokens;
+              record.finish_reason =
+                  (!completion.choices.empty() &&
+                   completion.choices[0].finish_reason.has_value())
+                      ? completion.choices[0].finish_reason.value()
+                      : "unknown";
+              record.timestamp_ms =
+                  std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::system_clock::now().time_since_epoch())
+                      .count();
+              conversationStore->recordTurn(sessionId.value(),
+                                            std::move(record));
             }
 
             (*cb)(resp);
@@ -318,9 +358,12 @@ void LLMController::handleStreaming(
     svc->abortRequest(taskId);
   };
 
+  auto inputMessages = messagesToJson(reqPtr->messages);
+
   resolveSession(
       reqPtr, loop,
-      [this, reqPtr, cb, loop](SessionInfo sessionInfo) {
+      [this, reqPtr, cb, loop,
+       inputMessages = std::move(inputMessages)](SessionInfo sessionInfo) mutable {
         try {
           service->preProcess(*reqPtr);
 
@@ -341,6 +384,8 @@ void LLMController::handleStreaming(
           params.taskId = reqPtr->task_id;
           params.service = service;
           params.sessionManager = sessionManager;
+          params.conversationStore = conversationStore;
+          params.inputMessages = std::move(inputMessages);
 
           auto writer = SseStreamWriter::create(loop, std::move(params));
 
@@ -493,6 +538,32 @@ void LLMController::getSlotId(
   response["session_id"] = sessionId;
   response["slot_id"] = slotId;
   auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
+  callback(resp);
+}
+
+void LLMController::exportConversation(
+    const drogon::HttpRequestPtr& /*req*/,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    const std::string& sessionId) const {
+  if (!conversationStore) {
+    callback(errorResponse(drogon::k503ServiceUnavailable,
+                           "Conversation store not available",
+                           "service_unavailable"));
+    return;
+  }
+
+  auto data = conversationStore->exportSession(sessionId);
+  if (!data.has_value()) {
+    callback(errorResponse(drogon::k404NotFound,
+                           "No conversation log found for session id: " +
+                               sessionId,
+                           "not_found"));
+    return;
+  }
+
+  auto resp = drogon::HttpResponse::newHttpResponse();
+  resp->setContentTypeCode(drogon::CT_APPLICATION_JSON);
+  resp->setBody(std::move(data.value()));
   callback(resp);
 }
 

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -35,6 +35,26 @@ Json::Value messagesToJson(const std::vector<domain::ChatMessage>& messages) {
   return arr;
 }
 
+tt::services::TurnRecord buildTurnRecord(
+    Json::Value inputMessages, const domain::LLMResponse& completion) {
+  tt::services::TurnRecord record;
+  record.inputMessages = std::move(inputMessages);
+  record.outputText =
+      completion.choices.empty() ? "" : completion.choices[0].text;
+  record.ttftMs = completion.usage.ttft_ms;
+  record.tps = completion.usage.tps;
+  record.promptTokens = completion.usage.prompt_tokens;
+  record.completionTokens = completion.usage.completion_tokens;
+  record.finishReason = (!completion.choices.empty() &&
+                         completion.choices[0].finish_reason.has_value())
+                            ? completion.choices[0].finish_reason.value()
+                            : "unknown";
+  record.timestampMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           std::chrono::system_clock::now().time_since_epoch())
+                           .count();
+  return record;
+}
+
 }  // namespace
 
 void LLMController::models(
@@ -287,25 +307,9 @@ void LLMController::chatCompletions(
             }
 
             if (sessionId.has_value() && conversationStore) {
-              tt::services::TurnRecord record;
-              record.input_messages = std::move(inputMessages);
-              record.output_text =
-                  completion.choices.empty() ? "" : completion.choices[0].text;
-              record.ttft_ms = completion.usage.ttft_ms;
-              record.tps = completion.usage.tps;
-              record.prompt_tokens = completion.usage.prompt_tokens;
-              record.completion_tokens = completion.usage.completion_tokens;
-              record.finish_reason =
-                  (!completion.choices.empty() &&
-                   completion.choices[0].finish_reason.has_value())
-                      ? completion.choices[0].finish_reason.value()
-                      : "unknown";
-              record.timestamp_ms =
-                  std::chrono::duration_cast<std::chrono::milliseconds>(
-                      std::chrono::system_clock::now().time_since_epoch())
-                      .count();
-              conversationStore->recordTurn(sessionId.value(),
-                                            std::move(record));
+              conversationStore->recordTurn(
+                  sessionId.value(),
+                  buildTurnRecord(std::move(inputMessages), completion));
             }
 
             (*cb)(resp);

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -27,8 +27,7 @@ namespace tt::api {
 
 namespace {
 
-Json::Value messagesToJson(
-    const std::vector<domain::ChatMessage>& messages) {
+Json::Value messagesToJson(const std::vector<domain::ChatMessage>& messages) {
   Json::Value arr(Json::arrayValue);
   for (const auto& msg : messages) {
     arr.append(msg.toJson());
@@ -290,9 +289,8 @@ void LLMController::chatCompletions(
             if (sessionId.has_value() && conversationStore) {
               tt::services::TurnRecord record;
               record.input_messages = std::move(inputMessages);
-              record.output_text = completion.choices.empty()
-                                       ? ""
-                                       : completion.choices[0].text;
+              record.output_text =
+                  completion.choices.empty() ? "" : completion.choices[0].text;
               record.ttft_ms = completion.usage.ttft_ms;
               record.tps = completion.usage.tps;
               record.prompt_tokens = completion.usage.prompt_tokens;
@@ -362,8 +360,8 @@ void LLMController::handleStreaming(
 
   resolveSession(
       reqPtr, loop,
-      [this, reqPtr, cb, loop,
-       inputMessages = std::move(inputMessages)](SessionInfo sessionInfo) mutable {
+      [this, reqPtr, cb, loop, inputMessages = std::move(inputMessages)](
+          SessionInfo sessionInfo) mutable {
         try {
           service->preProcess(*reqPtr);
 
@@ -554,10 +552,9 @@ void LLMController::exportConversation(
 
   auto data = conversationStore->exportSession(sessionId);
   if (!data.has_value()) {
-    callback(errorResponse(drogon::k404NotFound,
-                           "No conversation log found for session id: " +
-                               sessionId,
-                           "not_found"));
+    callback(errorResponse(
+        drogon::k404NotFound,
+        "No conversation log found for session id: " + sessionId, "not_found"));
     return;
   }
 

--- a/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
+++ b/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
@@ -108,9 +108,9 @@ void SseStreamWriter::handleTokenChunk(const domain::LLMStreamChunk& chunk) {
   const int currentTokens = completion_tokens_.fetch_add(1) + 1;
 
   if (!chunk.choices.empty()) {
-    accumulated_output_ += chunk.choices[0].text;
+    accumulatedOutput_ += chunk.choices[0].text;
     if (chunk.choices[0].finish_reason.has_value()) {
-      finish_reason_ = chunk.choices[0].finish_reason.value();
+      finishReason_ = chunk.choices[0].finish_reason.value();
     }
   }
 
@@ -183,14 +183,14 @@ void SseStreamWriter::finalizeStream() {
       if (self->params_.conversationStore &&
           self->params_.sessionId.has_value()) {
         tt::services::TurnRecord record;
-        record.input_messages = self->params_.inputMessages;
-        record.output_text = self->accumulated_output_;
-        record.ttft_ms = usage.ttft_ms;
+        record.inputMessages = self->params_.inputMessages;
+        record.outputText = self->accumulatedOutput_;
+        record.ttftMs = usage.ttft_ms;
         record.tps = usage.tps;
-        record.prompt_tokens = usage.prompt_tokens;
-        record.completion_tokens = usage.completion_tokens;
-        record.finish_reason = self->finish_reason_;
-        record.timestamp_ms =
+        record.promptTokens = usage.prompt_tokens;
+        record.completionTokens = usage.completion_tokens;
+        record.finishReason = self->finishReason_;
+        record.timestampMs =
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::system_clock::now().time_since_epoch())
                 .count();

--- a/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
+++ b/tt-media-server/cpp_server/src/api/sse_stream_writer.cpp
@@ -107,6 +107,13 @@ void SseStreamWriter::handleTokenChunk(const domain::LLMStreamChunk& chunk) {
 
   const int currentTokens = completion_tokens_.fetch_add(1) + 1;
 
+  if (!chunk.choices.empty()) {
+    accumulated_output_ += chunk.choices[0].text;
+    if (chunk.choices[0].finish_reason.has_value()) {
+      finish_reason_ = chunk.choices[0].finish_reason.value();
+    }
+  }
+
   auto now = std::chrono::high_resolution_clock::now();
   if (!first_token_time_.has_value()) {
     first_token_time_ = now;
@@ -155,8 +162,9 @@ void SseStreamWriter::finalizeStream() {
     if (!self->done_.exchange(true) && *self->stream_ptr_) {
       self->flushAccumulated();
 
+      auto usage = self->buildFinalUsage();
+
       if (self->params_.includeUsage) {
-        auto usage = self->buildFinalUsage();
         (*self->stream_ptr_)
             ->send(domain::ChatCompletionStreamChunk::makeUsageChunk(
                        self->params_.completionId, self->params_.model,
@@ -170,6 +178,24 @@ void SseStreamWriter::finalizeStream() {
       if (self->params_.sessionId.has_value() && self->params_.sessionManager) {
         self->params_.sessionManager->releaseInFlight(
             self->params_.sessionId.value());
+      }
+
+      if (self->params_.conversationStore &&
+          self->params_.sessionId.has_value()) {
+        tt::services::TurnRecord record;
+        record.input_messages = self->params_.inputMessages;
+        record.output_text = self->accumulated_output_;
+        record.ttft_ms = usage.ttft_ms;
+        record.tps = usage.tps;
+        record.prompt_tokens = usage.prompt_tokens;
+        record.completion_tokens = usage.completion_tokens;
+        record.finish_reason = self->finish_reason_;
+        record.timestamp_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch())
+                .count();
+        self->params_.conversationStore->recordTurn(
+            self->params_.sessionId.value(), std::move(record));
       }
     }
   });

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -366,4 +366,8 @@ unsigned prefillTimeoutMs() {
       envUlong("PREFILL_TIMEOUT_MS", defaults::PREFILL_TIMEOUT_MS));
 }
 
+std::string conversationLogDir() {
+  return envString("CONVERSATION_LOG_DIR", defaults::CONVERSATION_LOG_DIR);
+}
+
 }  // namespace tt::config

--- a/tt-media-server/cpp_server/src/services/conversation_store.cpp
+++ b/tt-media-server/cpp_server/src/services/conversation_store.cpp
@@ -16,27 +16,27 @@
 namespace tt::services {
 
 ConversationStore::ConversationStore(std::string logDir)
-    : logDir_(std::move(logDir)) {
+    : logDir(std::move(logDir)) {
   try {
-    std::filesystem::create_directories(logDir_);
-    TT_LOG_INFO("[ConversationStore] Log directory: {}", logDir_);
+    std::filesystem::create_directories(logDir);
+    TT_LOG_INFO("[ConversationStore] Log directory: {}", logDir);
   } catch (const std::exception& e) {
-    TT_LOG_WARN("[ConversationStore] Failed to create log dir {}: {}", logDir_,
+    TT_LOG_WARN("[ConversationStore] Failed to create log dir {}: {}", logDir,
                 e.what());
   }
-  writerThread_ = std::thread([this] { writerLoop(); });
+  writerThread = std::thread([this] { writerLoop(); });
 }
 
 ConversationStore::~ConversationStore() {
-  stopped_.store(true, std::memory_order_relaxed);
-  if (writerThread_.joinable()) {
-    writerThread_.join();
+  stopped.store(true, std::memory_order_relaxed);
+  if (writerThread.joinable()) {
+    writerThread.join();
   }
 }
 
 void ConversationStore::recordTurn(const std::string& sessionId,
                                    TurnRecord record) {
-  writeQueue_.push(WriteTask{sessionId, std::move(record)});
+  writeQueue.push(WriteTask{sessionId, std::move(record)});
 }
 
 std::optional<std::string> ConversationStore::exportSession(
@@ -69,8 +69,8 @@ std::optional<std::string> ConversationStore::exportSession(
 }
 
 void ConversationStore::writerLoop() {
-  while (!stopped_.load(std::memory_order_relaxed)) {
-    auto tasks = writeQueue_.drain();
+  while (!stopped.load(std::memory_order_relaxed)) {
+    auto tasks = writeQueue.drain();
     if (tasks.empty()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(5));
       continue;
@@ -79,7 +79,7 @@ void ConversationStore::writerLoop() {
       writeTurnToFile(task.sessionId, task.record);
     }
   }
-  for (const auto& task : writeQueue_.drain()) {
+  for (const auto& task : writeQueue.drain()) {
     writeTurnToFile(task.sessionId, task.record);
   }
 }
@@ -113,7 +113,7 @@ std::string ConversationStore::serializeTurn(const TurnRecord& record) {
 }
 
 std::string ConversationStore::logFilePath(const std::string& sessionId) const {
-  return logDir_ + "/" + sessionId + ".jsonl";
+  return logDir + "/" + sessionId + ".jsonl";
 }
 
 }  // namespace tt::services

--- a/tt-media-server/cpp_server/src/services/conversation_store.cpp
+++ b/tt-media-server/cpp_server/src/services/conversation_store.cpp
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#include "services/conversation_store.hpp"
+
+#include <json/json.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <thread>
+
+#include "utils/logger.hpp"
+
+namespace tt::services {
+
+ConversationStore::ConversationStore(std::string logDir)
+    : logDir_(std::move(logDir)) {
+  try {
+    std::filesystem::create_directories(logDir_);
+    TT_LOG_INFO("[ConversationStore] Log directory: {}", logDir_);
+  } catch (const std::exception& e) {
+    TT_LOG_WARN("[ConversationStore] Failed to create log dir {}: {}", logDir_,
+                e.what());
+  }
+  writerThread_ = std::thread([this] { writerLoop(); });
+}
+
+ConversationStore::~ConversationStore() {
+  stopped_.store(true, std::memory_order_relaxed);
+  if (writerThread_.joinable()) {
+    writerThread_.join();
+  }
+}
+
+void ConversationStore::recordTurn(const std::string& sessionId,
+                                   TurnRecord record) {
+  writeQueue_.push(WriteTask{sessionId, std::move(record)});
+}
+
+std::optional<std::string> ConversationStore::exportSession(
+    const std::string& sessionId) const {
+  auto path = logFilePath(sessionId);
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    return std::nullopt;
+  }
+
+  Json::Value turns(Json::arrayValue);
+  std::string line;
+  Json::CharReaderBuilder builder;
+  while (std::getline(file, line)) {
+    if (line.empty()) continue;
+    Json::Value turn;
+    std::istringstream ss(line);
+    std::string errs;
+    if (Json::parseFromStream(builder, ss, &turn, &errs)) {
+      turns.append(std::move(turn));
+    } else {
+      TT_LOG_WARN("[ConversationStore] Failed to parse line for session {}: {}",
+                  sessionId, errs);
+    }
+  }
+
+  Json::StreamWriterBuilder writer;
+  writer["indentation"] = "  ";
+  return Json::writeString(writer, turns);
+}
+
+void ConversationStore::writerLoop() {
+  while (!stopped_.load(std::memory_order_relaxed)) {
+    auto tasks = writeQueue_.drain();
+    if (tasks.empty()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      continue;
+    }
+    for (const auto& task : tasks) {
+      writeTurnToFile(task.sessionId, task.record);
+    }
+  }
+  for (const auto& task : writeQueue_.drain()) {
+    writeTurnToFile(task.sessionId, task.record);
+  }
+}
+
+void ConversationStore::writeTurnToFile(const std::string& sessionId,
+                                        const TurnRecord& record) const {
+  auto path = logFilePath(sessionId);
+  std::ofstream file(path, std::ios::app);
+  if (!file.is_open()) {
+    TT_LOG_WARN("[ConversationStore] Failed to open log file: {}", path);
+    return;
+  }
+  file << serializeTurn(record) << "\n";
+  TT_LOG_DEBUG("[ConversationStore] Wrote turn for session {}", sessionId);
+}
+
+std::string ConversationStore::serializeTurn(const TurnRecord& record) {
+  Json::Value json;
+  json["timestamp_ms"] = static_cast<Json::Int64>(record.timestamp_ms);
+  json["input_messages"] = record.input_messages;
+  json["output_text"] = record.output_text;
+  json["prompt_tokens"] = record.prompt_tokens;
+  json["completion_tokens"] = record.completion_tokens;
+  json["finish_reason"] = record.finish_reason;
+  if (record.ttft_ms.has_value()) json["ttft_ms"] = record.ttft_ms.value();
+  if (record.tps.has_value()) json["tps"] = record.tps.value();
+
+  Json::StreamWriterBuilder writer;
+  writer["indentation"] = "";
+  return Json::writeString(writer, json);
+}
+
+std::string ConversationStore::logFilePath(
+    const std::string& sessionId) const {
+  return logDir_ + "/" + sessionId + ".jsonl";
+}
+
+}  // namespace tt::services

--- a/tt-media-server/cpp_server/src/services/conversation_store.cpp
+++ b/tt-media-server/cpp_server/src/services/conversation_store.cpp
@@ -98,13 +98,13 @@ void ConversationStore::writeTurnToFile(const std::string& sessionId,
 
 std::string ConversationStore::serializeTurn(const TurnRecord& record) {
   Json::Value json;
-  json["timestamp_ms"] = static_cast<Json::Int64>(record.timestamp_ms);
-  json["input_messages"] = record.input_messages;
-  json["output_text"] = record.output_text;
-  json["prompt_tokens"] = record.prompt_tokens;
-  json["completion_tokens"] = record.completion_tokens;
-  json["finish_reason"] = record.finish_reason;
-  if (record.ttft_ms.has_value()) json["ttft_ms"] = record.ttft_ms.value();
+  json["timestamp_ms"] = static_cast<Json::Int64>(record.timestampMs);
+  json["input_messages"] = record.inputMessages;
+  json["output_text"] = record.outputText;
+  json["prompt_tokens"] = record.promptTokens;
+  json["completion_tokens"] = record.completionTokens;
+  json["finish_reason"] = record.finishReason;
+  if (record.ttftMs.has_value()) json["ttft_ms"] = record.ttftMs.value();
   if (record.tps.has_value()) json["tps"] = record.tps.value();
 
   Json::StreamWriterBuilder writer;

--- a/tt-media-server/cpp_server/src/services/conversation_store.cpp
+++ b/tt-media-server/cpp_server/src/services/conversation_store.cpp
@@ -112,8 +112,7 @@ std::string ConversationStore::serializeTurn(const TurnRecord& record) {
   return Json::writeString(writer, json);
 }
 
-std::string ConversationStore::logFilePath(
-    const std::string& sessionId) const {
+std::string ConversationStore::logFilePath(const std::string& sessionId) const {
   return logDir_ + "/" + sessionId + ".jsonl";
 }
 

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -360,6 +360,7 @@ void SessionManager::createSession(
 
 void SessionManager::sendAsyncAllocationRequest(
     PendingAllocation& pendingAllocation) {
+  // Check if max session count is reached
   size_t maxSessions = tt::config::maxSessionsCount();
   size_t activeCount = getActiveSessionCount();
 
@@ -374,12 +375,12 @@ void SessionManager::sendAsyncAllocationRequest(
           "[SessionManager] sendAsyncAllocationRequest: no attempts left, "
           "failing sessionId={}",
           pendingAllocation.session.getSessionId());
-      pendingAllocation.eventLoop->queueInLoop(
-          [onError = std::move(pendingAllocation.onError)]() {
-            onError(
-                "Failed to allocate: max session count reached after all "
-                "attempts");
-          });
+      pendingAllocation.eventLoop->queueInLoop([onError =
+                                                    std::move(pendingAllocation
+                                                                  .onError)]() {
+        onError(
+            "Failed to allocate: max session count reached after all attempts");
+      });
     } else {
       pendingAllocation.attemptsRemaining--;
       pendingAllocation.retryAt =

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -360,6 +360,41 @@ void SessionManager::createSession(
 
 void SessionManager::sendAsyncAllocationRequest(
     PendingAllocation& pendingAllocation) {
+  size_t maxSessions = tt::config::maxSessionsCount();
+  size_t activeCount = getActiveSessionCount();
+
+  if (activeCount >= maxSessions) {
+    TT_LOG_DEBUG(
+        "[SessionManager] sendAsyncAllocationRequest: max sessions reached "
+        "({}/{}), deferring sessionId={}",
+        activeCount, maxSessions, pendingAllocation.session.getSessionId());
+
+    if (pendingAllocation.attemptsRemaining == 0) {
+      TT_LOG_ERROR(
+          "[SessionManager] sendAsyncAllocationRequest: no attempts left, "
+          "failing sessionId={}",
+          pendingAllocation.session.getSessionId());
+      pendingAllocation.eventLoop->queueInLoop(
+          [onError = std::move(pendingAllocation.onError)]() {
+            onError(
+                "Failed to allocate: max session count reached after all "
+                "attempts");
+          });
+    } else {
+      pendingAllocation.attemptsRemaining--;
+      pendingAllocation.retryAt =
+          std::chrono::steady_clock::now() + IPC_QUEUE_FULL_RETRY_DELAY;
+      TT_LOG_DEBUG(
+          "[SessionManager] sendAsyncAllocationRequest: queuing retry for "
+          "sessionId={}, attemptsRemaining={}, delayMs={}",
+          pendingAllocation.session.getSessionId(),
+          pendingAllocation.attemptsRemaining,
+          IPC_QUEUE_FULL_RETRY_DELAY.count());
+      pendingAllocationsRetryQueue.push(std::move(pendingAllocation));
+    }
+    return;
+  }
+
   auto task = makeAllocTask();
   TT_LOG_DEBUG(
       "[SessionManager] sendAsyncAllocationRequest: taskId={}, "

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -360,42 +360,6 @@ void SessionManager::createSession(
 
 void SessionManager::sendAsyncAllocationRequest(
     PendingAllocation& pendingAllocation) {
-  // Check if max session count is reached
-  size_t maxSessions = tt::config::maxSessionsCount();
-  size_t activeCount = getActiveSessionCount();
-
-  if (activeCount >= maxSessions) {
-    TT_LOG_DEBUG(
-        "[SessionManager] sendAsyncAllocationRequest: max sessions reached "
-        "({}/{}), deferring sessionId={}",
-        activeCount, maxSessions, pendingAllocation.session.getSessionId());
-
-    if (pendingAllocation.attemptsRemaining == 0) {
-      TT_LOG_ERROR(
-          "[SessionManager] sendAsyncAllocationRequest: no attempts left, "
-          "failing sessionId={}",
-          pendingAllocation.session.getSessionId());
-      pendingAllocation.eventLoop->queueInLoop([onError =
-                                                    std::move(pendingAllocation
-                                                                  .onError)]() {
-        onError(
-            "Failed to allocate: max session count reached after all attempts");
-      });
-    } else {
-      pendingAllocation.attemptsRemaining--;
-      pendingAllocation.retryAt =
-          std::chrono::steady_clock::now() + IPC_QUEUE_FULL_RETRY_DELAY;
-      TT_LOG_DEBUG(
-          "[SessionManager] sendAsyncAllocationRequest: queuing retry for "
-          "sessionId={}, attemptsRemaining={}, delayMs={}",
-          pendingAllocation.session.getSessionId(),
-          pendingAllocation.attemptsRemaining,
-          IPC_QUEUE_FULL_RETRY_DELAY.count());
-      pendingAllocationsRetryQueue.push(std::move(pendingAllocation));
-    }
-    return;
-  }
-
   auto task = makeAllocTask();
   TT_LOG_DEBUG(
       "[SessionManager] sendAsyncAllocationRequest: taskId={}, "

--- a/tt-media-server/cpp_server/src/utils/service_container.cpp
+++ b/tt-media-server/cpp_server/src/utils/service_container.cpp
@@ -4,6 +4,7 @@
 #include "utils/service_container.hpp"
 
 #include "config/settings.hpp"
+#include "services/conversation_store.hpp"
 #include "services/embedding_service.hpp"
 #include "services/llm_service.hpp"
 
@@ -14,12 +15,14 @@ void ServiceContainer::initialize(
     std::shared_ptr<services::EmbeddingService> embedding,
     std::shared_ptr<sockets::InterServerService> socket,
     std::shared_ptr<services::DisaggregationService> disaggregation,
-    std::shared_ptr<services::SessionManager> sessionMgr) {
+    std::shared_ptr<services::SessionManager> sessionMgr,
+    std::shared_ptr<services::ConversationStore> conversationStore) {
   llm_ = std::move(llm);
   embedding_ = std::move(embedding);
   socket_ = std::move(socket);
   disaggregation_ = std::move(disaggregation);
   sessionManager_ = std::move(sessionMgr);
+  conversationStore_ = std::move(conversationStore);
 }
 
 std::shared_ptr<services::IService> ServiceContainer::configuredService()

--- a/tt-media-server/cpp_server/src/utils/service_factory.cpp
+++ b/tt-media-server/cpp_server/src/utils/service_factory.cpp
@@ -7,6 +7,7 @@
 
 #include "config/settings.hpp"
 #include "profiling/tracy.hpp"
+#include "services/conversation_store.hpp"
 #include "services/disaggregation_service.hpp"
 #include "services/embedding_service.hpp"
 #include "services/llm_service.hpp"
@@ -30,6 +31,9 @@ void initializeServices() {
   // Create SessionManager for all modes
   sessionManager = std::make_shared<services::SessionManager>();
 
+  auto conversationStore = std::make_shared<services::ConversationStore>(
+      tt::config::conversationLogDir());
+
   // Only construct services for MODEL_SERVICE (see config::modelService()).
   // Additional modes (e.g. videogen) extend config::ModelService and add cases.
   switch (tt::config::modelService()) {
@@ -50,7 +54,8 @@ void initializeServices() {
   }
 
   c.initialize(std::move(llm), std::move(embedding), std::move(socket),
-               std::move(disaggregation), std::move(sessionManager));
+               std::move(disaggregation), std::move(sessionManager),
+               std::move(conversationStore));
 
   if (c.llm()) {
     c.llm()->start();
@@ -66,6 +71,10 @@ void initializeServices() {
   }
   if (c.sessionManager()) {
     TT_LOG_INFO("[ServiceFactory] Session manager initialized");
+  }
+  if (c.conversationStore()) {
+    TT_LOG_INFO("[ServiceFactory] Conversation store initialized (log dir: {})",
+                tt::config::conversationLogDir());
   }
 }
 

--- a/tt-media-server/cpp_server/tests/conversation_store_test.cpp
+++ b/tt-media-server/cpp_server/tests/conversation_store_test.cpp
@@ -77,7 +77,6 @@ class ConversationStoreTest : public ::testing::Test {
   std::filesystem::path tmpDir;
 };
 
-
 TEST_F(ConversationStoreTest, ExportUnknownSessionReturnsNullopt) {
   tt::services::ConversationStore store(logDir());
   auto result = store.exportSession("nonexistent-session-id");

--- a/tt-media-server/cpp_server/tests/conversation_store_test.cpp
+++ b/tt-media-server/cpp_server/tests/conversation_store_test.cpp
@@ -14,12 +14,8 @@
 
 namespace {
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 tt::services::TurnRecord makeTurn(const std::string& userContent,
-                                  const std::string& outputText, double ttft_ms,
+                                  const std::string& outputText, double ttftMs,
                                   double tps, int promptTokens,
                                   int completionTokens,
                                   const std::string& finishReason = "stop") {
@@ -31,16 +27,16 @@ tt::services::TurnRecord makeTurn(const std::string& userContent,
   msg["content"] = userContent;
   messages.append(msg);
 
-  record.input_messages = messages;
-  record.output_text = outputText;
-  record.ttft_ms = ttft_ms;
+  record.inputMessages = messages;
+  record.outputText = outputText;
+  record.ttftMs = ttftMs;
   record.tps = tps;
-  record.prompt_tokens = promptTokens;
-  record.completion_tokens = completionTokens;
-  record.finish_reason = finishReason;
-  record.timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                            std::chrono::system_clock::now().time_since_epoch())
-                            .count();
+  record.promptTokens = promptTokens;
+  record.completionTokens = completionTokens;
+  record.finishReason = finishReason;
+  record.timestampMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           std::chrono::system_clock::now().time_since_epoch())
+                           .count();
   return record;
 }
 
@@ -64,31 +60,23 @@ bool waitForFile(const std::string& logDir, const std::string& sessionId,
   return false;
 }
 
-// ---------------------------------------------------------------------------
-// Fixture: creates a temp directory and cleans it up after each test.
-// ---------------------------------------------------------------------------
-
 class ConversationStoreTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    tmpDir_ =
-        std::filesystem::temp_directory_path() /
-        ("conversation_store_test_" +
-         std::to_string(
-             std::chrono::steady_clock::now().time_since_epoch().count()));
-    std::filesystem::create_directories(tmpDir_);
+    tmpDir = std::filesystem::temp_directory_path() /
+             ("conversation_store_test_" +
+              std::to_string(
+                  std::chrono::steady_clock::now().time_since_epoch().count()));
+    std::filesystem::create_directories(tmpDir);
   }
 
-  void TearDown() override { std::filesystem::remove_all(tmpDir_); }
+  void TearDown() override { std::filesystem::remove_all(tmpDir); }
 
-  std::string logDir() const { return tmpDir_.string(); }
+  std::string logDir() const { return tmpDir.string(); }
 
-  std::filesystem::path tmpDir_;
+  std::filesystem::path tmpDir;
 };
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 TEST_F(ConversationStoreTest, ExportUnknownSessionReturnsNullopt) {
   tt::services::ConversationStore store(logDir());
@@ -111,7 +99,6 @@ TEST_F(ConversationStoreTest, RecordAndExportSingleTurn) {
   auto exported = store.exportSession(sessionId);
   ASSERT_TRUE(exported.has_value());
 
-  // Parse the returned JSON array
   Json::Value turns;
   Json::CharReaderBuilder builder;
   std::istringstream ss(exported.value());
@@ -211,11 +198,11 @@ TEST_F(ConversationStoreTest, TurnWithOptionalFieldsMissing) {
 
   tt::services::TurnRecord record;
   Json::Value messages(Json::arrayValue);
-  record.input_messages = messages;
-  record.output_text = "some output";
-  // ttft_ms and tps deliberately left as nullopt
-  record.finish_reason = "length";
-  record.timestamp_ms = 1000;
+  record.inputMessages = messages;
+  record.outputText = "some output";
+  // ttftMs and tps deliberately left as nullopt
+  record.finishReason = "length";
+  record.timestampMs = 1000;
 
   store.recordTurn(sessionId, record);
 

--- a/tt-media-server/cpp_server/tests/conversation_store_test.cpp
+++ b/tt-media-server/cpp_server/tests/conversation_store_test.cpp
@@ -19,9 +19,9 @@ namespace {
 // ---------------------------------------------------------------------------
 
 tt::services::TurnRecord makeTurn(const std::string& userContent,
-                                  const std::string& outputText,
-                                  double ttft_ms, double tps,
-                                  int promptTokens, int completionTokens,
+                                  const std::string& outputText, double ttft_ms,
+                                  double tps, int promptTokens,
+                                  int completionTokens,
                                   const std::string& finishReason = "stop") {
   tt::services::TurnRecord record;
 
@@ -71,17 +71,15 @@ bool waitForFile(const std::string& logDir, const std::string& sessionId,
 class ConversationStoreTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    tmpDir_ = std::filesystem::temp_directory_path() /
-              ("conversation_store_test_" +
-               std::to_string(std::chrono::steady_clock::now()
-                                  .time_since_epoch()
-                                  .count()));
+    tmpDir_ =
+        std::filesystem::temp_directory_path() /
+        ("conversation_store_test_" +
+         std::to_string(
+             std::chrono::steady_clock::now().time_since_epoch().count()));
     std::filesystem::create_directories(tmpDir_);
   }
 
-  void TearDown() override {
-    std::filesystem::remove_all(tmpDir_);
-  }
+  void TearDown() override { std::filesystem::remove_all(tmpDir_); }
 
   std::string logDir() const { return tmpDir_.string(); }
 
@@ -102,8 +100,8 @@ TEST_F(ConversationStoreTest, RecordAndExportSingleTurn) {
   tt::services::ConversationStore store(logDir());
 
   const std::string sessionId = "test-session-001";
-  auto turn = makeTurn("Hello, what is 2+2?", "The answer is 4.", 8.3, 120.5,
-                       12, 5);
+  auto turn =
+      makeTurn("Hello, what is 2+2?", "The answer is 4.", 8.3, 120.5, 12, 5);
 
   store.recordTurn(sessionId, turn);
 
@@ -141,9 +139,12 @@ TEST_F(ConversationStoreTest, MultiTurnOrderPreserved) {
   tt::services::ConversationStore store(logDir());
 
   const std::string sessionId = "test-session-002";
-  store.recordTurn(sessionId, makeTurn("Turn 1", "Response 1", 8.0, 100.0, 5, 3));
-  store.recordTurn(sessionId, makeTurn("Turn 2", "Response 2", 9.0, 110.0, 6, 4));
-  store.recordTurn(sessionId, makeTurn("Turn 3", "Response 3", 7.5, 105.0, 4, 2));
+  store.recordTurn(sessionId,
+                   makeTurn("Turn 1", "Response 1", 8.0, 100.0, 5, 3));
+  store.recordTurn(sessionId,
+                   makeTurn("Turn 2", "Response 2", 9.0, 110.0, 6, 4));
+  store.recordTurn(sessionId,
+                   makeTurn("Turn 3", "Response 3", 7.5, 105.0, 4, 2));
 
   ASSERT_TRUE(waitForFile(logDir(), sessionId, 3))
       << "Timed out waiting for 3 turns to be written";
@@ -169,8 +170,10 @@ TEST_F(ConversationStoreTest, MultipleSessionsAreIsolated) {
   const std::string sessionA = "session-aaa";
   const std::string sessionB = "session-bbb";
 
-  store.recordTurn(sessionA, makeTurn("Question A", "Answer A", 8.0, 100.0, 5, 3));
-  store.recordTurn(sessionB, makeTurn("Question B", "Answer B", 9.0, 110.0, 6, 4));
+  store.recordTurn(sessionA,
+                   makeTurn("Question A", "Answer A", 8.0, 100.0, 5, 3));
+  store.recordTurn(sessionB,
+                   makeTurn("Question B", "Answer B", 9.0, 110.0, 6, 4));
 
   ASSERT_TRUE(waitForFile(logDir(), sessionA, 1));
   ASSERT_TRUE(waitForFile(logDir(), sessionB, 1));
@@ -197,10 +200,8 @@ TEST_F(ConversationStoreTest, MultipleSessionsAreIsolated) {
   EXPECT_EQ(turnsB[0]["output_text"].asString(), "Answer B");
 
   // Verify separate files on disk
-  EXPECT_TRUE(
-      std::filesystem::exists(logDir() + "/" + sessionA + ".jsonl"));
-  EXPECT_TRUE(
-      std::filesystem::exists(logDir() + "/" + sessionB + ".jsonl"));
+  EXPECT_TRUE(std::filesystem::exists(logDir() + "/" + sessionA + ".jsonl"));
+  EXPECT_TRUE(std::filesystem::exists(logDir() + "/" + sessionB + ".jsonl"));
 }
 
 TEST_F(ConversationStoreTest, TurnWithOptionalFieldsMissing) {

--- a/tt-media-server/cpp_server/tests/conversation_store_test.cpp
+++ b/tt-media-server/cpp_server/tests/conversation_store_test.cpp
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#include "services/conversation_store.hpp"
+
+#include <gtest/gtest.h>
+#include <json/json.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+tt::services::TurnRecord makeTurn(const std::string& userContent,
+                                  const std::string& outputText,
+                                  double ttft_ms, double tps,
+                                  int promptTokens, int completionTokens,
+                                  const std::string& finishReason = "stop") {
+  tt::services::TurnRecord record;
+
+  Json::Value messages(Json::arrayValue);
+  Json::Value msg;
+  msg["role"] = "user";
+  msg["content"] = userContent;
+  messages.append(msg);
+
+  record.input_messages = messages;
+  record.output_text = outputText;
+  record.ttft_ms = ttft_ms;
+  record.tps = tps;
+  record.prompt_tokens = promptTokens;
+  record.completion_tokens = completionTokens;
+  record.finish_reason = finishReason;
+  record.timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::system_clock::now().time_since_epoch())
+                            .count();
+  return record;
+}
+
+// Waits up to maxWaitMs for the .jsonl file for sessionId to contain at least
+// expectedTurns lines. Returns true if the condition is met in time.
+bool waitForFile(const std::string& logDir, const std::string& sessionId,
+                 int expectedTurns, int maxWaitMs = 500) {
+  auto path = logDir + "/" + sessionId + ".jsonl";
+  for (int waited = 0; waited < maxWaitMs; waited += 10) {
+    std::ifstream f(path);
+    if (f.is_open()) {
+      int lines = 0;
+      std::string line;
+      while (std::getline(f, line)) {
+        if (!line.empty()) ++lines;
+      }
+      if (lines >= expectedTurns) return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: creates a temp directory and cleans it up after each test.
+// ---------------------------------------------------------------------------
+
+class ConversationStoreTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    tmpDir_ = std::filesystem::temp_directory_path() /
+              ("conversation_store_test_" +
+               std::to_string(std::chrono::steady_clock::now()
+                                  .time_since_epoch()
+                                  .count()));
+    std::filesystem::create_directories(tmpDir_);
+  }
+
+  void TearDown() override {
+    std::filesystem::remove_all(tmpDir_);
+  }
+
+  std::string logDir() const { return tmpDir_.string(); }
+
+  std::filesystem::path tmpDir_;
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+TEST_F(ConversationStoreTest, ExportUnknownSessionReturnsNullopt) {
+  tt::services::ConversationStore store(logDir());
+  auto result = store.exportSession("nonexistent-session-id");
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ConversationStoreTest, RecordAndExportSingleTurn) {
+  tt::services::ConversationStore store(logDir());
+
+  const std::string sessionId = "test-session-001";
+  auto turn = makeTurn("Hello, what is 2+2?", "The answer is 4.", 8.3, 120.5,
+                       12, 5);
+
+  store.recordTurn(sessionId, turn);
+
+  ASSERT_TRUE(waitForFile(logDir(), sessionId, 1))
+      << "Timed out waiting for turn to be written";
+
+  auto exported = store.exportSession(sessionId);
+  ASSERT_TRUE(exported.has_value());
+
+  // Parse the returned JSON array
+  Json::Value turns;
+  Json::CharReaderBuilder builder;
+  std::istringstream ss(exported.value());
+  std::string errs;
+  ASSERT_TRUE(Json::parseFromStream(builder, ss, &turns, &errs)) << errs;
+
+  ASSERT_EQ(turns.size(), 1u);
+
+  const Json::Value& t = turns[0];
+  EXPECT_EQ(t["output_text"].asString(), "The answer is 4.");
+  EXPECT_EQ(t["finish_reason"].asString(), "stop");
+  EXPECT_EQ(t["prompt_tokens"].asInt(), 12);
+  EXPECT_EQ(t["completion_tokens"].asInt(), 5);
+  EXPECT_DOUBLE_EQ(t["ttft_ms"].asDouble(), 8.3);
+  EXPECT_DOUBLE_EQ(t["tps"].asDouble(), 120.5);
+
+  ASSERT_TRUE(t["input_messages"].isArray());
+  ASSERT_EQ(t["input_messages"].size(), 1u);
+  EXPECT_EQ(t["input_messages"][0]["role"].asString(), "user");
+  EXPECT_EQ(t["input_messages"][0]["content"].asString(),
+            "Hello, what is 2+2?");
+}
+
+TEST_F(ConversationStoreTest, MultiTurnOrderPreserved) {
+  tt::services::ConversationStore store(logDir());
+
+  const std::string sessionId = "test-session-002";
+  store.recordTurn(sessionId, makeTurn("Turn 1", "Response 1", 8.0, 100.0, 5, 3));
+  store.recordTurn(sessionId, makeTurn("Turn 2", "Response 2", 9.0, 110.0, 6, 4));
+  store.recordTurn(sessionId, makeTurn("Turn 3", "Response 3", 7.5, 105.0, 4, 2));
+
+  ASSERT_TRUE(waitForFile(logDir(), sessionId, 3))
+      << "Timed out waiting for 3 turns to be written";
+
+  auto exported = store.exportSession(sessionId);
+  ASSERT_TRUE(exported.has_value());
+
+  Json::Value turns;
+  Json::CharReaderBuilder builder;
+  std::istringstream ss(exported.value());
+  std::string errs;
+  ASSERT_TRUE(Json::parseFromStream(builder, ss, &turns, &errs)) << errs;
+
+  ASSERT_EQ(turns.size(), 3u);
+  EXPECT_EQ(turns[0]["output_text"].asString(), "Response 1");
+  EXPECT_EQ(turns[1]["output_text"].asString(), "Response 2");
+  EXPECT_EQ(turns[2]["output_text"].asString(), "Response 3");
+}
+
+TEST_F(ConversationStoreTest, MultipleSessionsAreIsolated) {
+  tt::services::ConversationStore store(logDir());
+
+  const std::string sessionA = "session-aaa";
+  const std::string sessionB = "session-bbb";
+
+  store.recordTurn(sessionA, makeTurn("Question A", "Answer A", 8.0, 100.0, 5, 3));
+  store.recordTurn(sessionB, makeTurn("Question B", "Answer B", 9.0, 110.0, 6, 4));
+
+  ASSERT_TRUE(waitForFile(logDir(), sessionA, 1));
+  ASSERT_TRUE(waitForFile(logDir(), sessionB, 1));
+
+  auto exportedA = store.exportSession(sessionA);
+  auto exportedB = store.exportSession(sessionB);
+
+  ASSERT_TRUE(exportedA.has_value());
+  ASSERT_TRUE(exportedB.has_value());
+
+  Json::Value turnsA, turnsB;
+  Json::CharReaderBuilder builder;
+  std::string errs;
+
+  std::istringstream ssA(exportedA.value());
+  ASSERT_TRUE(Json::parseFromStream(builder, ssA, &turnsA, &errs)) << errs;
+
+  std::istringstream ssB(exportedB.value());
+  ASSERT_TRUE(Json::parseFromStream(builder, ssB, &turnsB, &errs)) << errs;
+
+  ASSERT_EQ(turnsA.size(), 1u);
+  ASSERT_EQ(turnsB.size(), 1u);
+  EXPECT_EQ(turnsA[0]["output_text"].asString(), "Answer A");
+  EXPECT_EQ(turnsB[0]["output_text"].asString(), "Answer B");
+
+  // Verify separate files on disk
+  EXPECT_TRUE(
+      std::filesystem::exists(logDir() + "/" + sessionA + ".jsonl"));
+  EXPECT_TRUE(
+      std::filesystem::exists(logDir() + "/" + sessionB + ".jsonl"));
+}
+
+TEST_F(ConversationStoreTest, TurnWithOptionalFieldsMissing) {
+  tt::services::ConversationStore store(logDir());
+
+  const std::string sessionId = "test-session-004";
+
+  tt::services::TurnRecord record;
+  Json::Value messages(Json::arrayValue);
+  record.input_messages = messages;
+  record.output_text = "some output";
+  // ttft_ms and tps deliberately left as nullopt
+  record.finish_reason = "length";
+  record.timestamp_ms = 1000;
+
+  store.recordTurn(sessionId, record);
+
+  ASSERT_TRUE(waitForFile(logDir(), sessionId, 1));
+
+  auto exported = store.exportSession(sessionId);
+  ASSERT_TRUE(exported.has_value());
+
+  Json::Value turns;
+  Json::CharReaderBuilder builder;
+  std::istringstream ss(exported.value());
+  std::string errs;
+  ASSERT_TRUE(Json::parseFromStream(builder, ss, &turns, &errs)) << errs;
+
+  ASSERT_EQ(turns.size(), 1u);
+  EXPECT_EQ(turns[0]["output_text"].asString(), "some output");
+  EXPECT_EQ(turns[0]["finish_reason"].asString(), "length");
+  EXPECT_FALSE(turns[0].isMember("ttft_ms"));
+  EXPECT_FALSE(turns[0].isMember("tps"));
+}
+
+}  // namespace


### PR DESCRIPTION
<img width="682" height="326" alt="Screenshot 2026-04-28 at 15 01 39" src="https://github.com/user-attachments/assets/cc0bc654-8bba-4944-bb62-04b731f02cbf" />

Adds a ConversationStore service that records every completed LLM turn (input messages, output text, TTFT, TPS, token counts, finish reason, timestamp) and persists it to disk as newline-delimited JSON ({sessionId}.jsonl). File writes happen on a background thread so the request path is never blocked on I/O.

- A new GET /v1/sessions/{session_id}/export endpoint returns all recorded turns for a session as a JSON array.
- Log directory is configurable via CONVERSATION_LOG_DIR (default: /tmp/tt_conversation_logs).
- Both streaming (SseStreamWriter::finalizeStream) and non-streaming (chatCompletions) paths record turns.

Example:
```
curl -s http://localhost:8000/v1/sessions/$SESSION_ID/export   -H "Authorization: Bearer your-secret-key" | jq .
[
  {
    "completion_tokens": 19,
    "finish_reason": "length",
    "input_messages": [
      {
        "content": "Hello, what is 2+2?",
        "role": "user"
      }
    ],
    "output_text": "<｜User｜>Hello, what is 2+2?<｜Assistant｜> latter latter latter latter latter latter latter latter",
    "prompt_tokens": 12,
    "timestamp_ms": 1777375877832,
    "tps": 333.3333333333333,
    "ttft_ms": 57
  }
]
```