### PR TITLE
Set correct vLLM logging config env var

### DIFF
--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -396,7 +396,7 @@ def model_setup(model_spec_json):
     hf_dir = create_model_symlink(symlinks_dir, model_dir_name, weights_dir)
 
     dynamic_env_vars = {
-        "VLLM_LOGGING_CONFIG": str(config_path),
+        "VLLM_LOGGING_CONFIG_PATH": str(config_path),
         "HF_MODEL": hf_dir,
     }
 


### PR DESCRIPTION
The environment variable used to register a custom logger is `VLLM_LOGGING_CONFIG_PATH` not `VLLM_LOGGING_CONFIG_PATH`.

This fixes the problem where server logs were not printing the periodic engine telemetry:
```shell
(APIServer pid=962) INFO 04-28 04:15:05 [loggers.py:259] Engine 000: Avg prompt throughput: 10.0 tokens/s, Avg generation throughput: 0.1 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.1%, Prefix cache hit rate: 0.0%, MM cache hit rate: 0.0%
```