### PR TITLE
Fix Dockerfile.blaze entrypoint and ensure conversation log dir creation

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -41,29 +41,33 @@ set_group_permissions() {
 
 echo "using CACHE_ROOT: ${CACHE_ROOT}"
 
-# Get current ownership of volume
-VOLUME_OWNER=$(stat -c '%u' "$CACHE_ROOT")
-VOLUME_GROUP=$(stat -c '%g' "$CACHE_ROOT")
-echo "Mounted CACHE_ROOT volume is owned by UID:GID - $VOLUME_OWNER:$VOLUME_GROUP"
+if [ -n "${CACHE_ROOT}" ] && [ -d "${CACHE_ROOT}" ]; then
+    # Get current ownership of volume
+    VOLUME_OWNER=$(stat -c '%u' "$CACHE_ROOT")
+    VOLUME_GROUP=$(stat -c '%g' "$CACHE_ROOT")
+    echo "Mounted CACHE_ROOT volume is owned by UID:GID - $VOLUME_OWNER:$VOLUME_GROUP"
 
-# Create shared group with host's GID if it doesn't exist
-if ! getent group "$VOLUME_GROUP" > /dev/null 2>&1; then
-    groupadd -g "$VOLUME_GROUP" sharedgroup
+    # Create shared group with host's GID if it doesn't exist
+    if ! getent group "$VOLUME_GROUP" > /dev/null 2>&1; then
+        groupadd -g "$VOLUME_GROUP" sharedgroup
+    fi
+
+    # Get the created/existing group name
+    SHARED_GROUP_NAME=$(getent group "$VOLUME_GROUP" | cut -d: -f1)
+
+    # Add container user to the shared group
+    usermod -a -G "$SHARED_GROUP_NAME" "${CONTAINER_APP_USERNAME}"
+
+    # Ensure new files get group write permissions (in current shell)
+    umask 0002
+
+    # only set permisssions for cache_root
+    set_group_permissions "$CACHE_ROOT" "$SHARED_GROUP_NAME"
+    # NOTE: running recursive chmod on /home/${CONTAINER_APP_USERNAME} takes long time
+    echo "Mounted volume permissions setup completed."
+else
+    echo "CACHE_ROOT is not set or does not exist, skipping volume permissions setup."
 fi
-
-# Get the created/existing group name
-SHARED_GROUP_NAME=$(getent group "$VOLUME_GROUP" | cut -d: -f1)
-
-# Add container user to the shared group
-usermod -a -G "$SHARED_GROUP_NAME" "${CONTAINER_APP_USERNAME}"
-
-# Ensure new files get group write permissions (in current shell)
-umask 0002
-
-# only set permisssions for cache_root
-set_group_permissions "$CACHE_ROOT" "$SHARED_GROUP_NAME"
-# NOTE: running recursive chmod on /home/${CONTAINER_APP_USERNAME} takes long time
-echo "Mounted volume permissions setup completed."
 
 # Ensure conversation log directory exists and is writable by app user
 CONVERSATION_LOG_DIR="${CONVERSATION_LOG_DIR:-/tmp/tt_conversation_logs}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -65,6 +65,11 @@ set_group_permissions "$CACHE_ROOT" "$SHARED_GROUP_NAME"
 # NOTE: running recursive chmod on /home/${CONTAINER_APP_USERNAME} takes long time
 echo "Mounted volume permissions setup completed."
 
+# Ensure conversation log directory exists and is writable by app user
+CONVERSATION_LOG_DIR="${CONVERSATION_LOG_DIR:-/tmp/tt_conversation_logs}"
+mkdir -p "${CONVERSATION_LOG_DIR}"
+chown "${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME}" "${CONVERSATION_LOG_DIR}"
+
 # Execute server as CONTAINER_APP_USERNAME user
 # Usage: docker run <image> --model <hf_repo> --device <device_type>
 exec gosu "${CONTAINER_APP_USERNAME}" "$@"

--- a/tt-media-server/Dockerfile.blaze
+++ b/tt-media-server/Dockerfile.blaze
@@ -190,7 +190,11 @@ ENV TT_METAL_COMMIT_SHA_OR_TAG=${TT_METAL_COMMIT_SHA_OR_TAG} \
     TT_METAL_RUNTIME_ROOT=${HOME_DIR}/app/server/cpp_server/tt-blaze/tt-metal \
     CONFIG=Release \
     TT_METAL_ENV=dev \
-    LOGURU_LEVEL=INFO
+    LOGURU_LEVEL=INFO \
+    PYTHONPATH=${HOME_DIR}/app/server/cpp_server/tt-blaze/tt-metal \
+    PYTHON_ENV_DIR=${HOME_DIR}/tt-metal/python_env \
+    LD_LIBRARY_PATH=${HOME_DIR}/app/server/cpp_server/tt-blaze/tt-metal/build/lib \
+    TT_METAL_LOGS_PATH=${HOME_DIR}/logs
 
 # Install runtime dependencies
 # These packages are required for the application to run in production
@@ -233,7 +237,6 @@ RUN chmod +x ${HOME_DIR}/app/server/run_uvicorn.sh
 
 EXPOSE 8000
 WORKDIR ${HOME_DIR}/app/server
-# Default to uvicornr-entrypoint.sh"]
+ENTRYPOINT ["./docker-entrypoint.sh"]
 ENV SERVER_MODE=uvicorn
-CMD ["/bin/bash", "-c", "source ${PYTHON_ENV_DIR}/bin/activate && if [ \"$SERVER_MODE\" = \"cpp\" ]; then source ./run_cpp.sh; else source ./run_uvicorn.sh; fi"]
 CMD ["/bin/bash", "-c", "source ${PYTHON_ENV_DIR}/bin/activate && if [ \"$SERVER_MODE\" = \"cpp\" ]; then source ./run_cpp.sh; else source ./run_uvicorn.sh; fi"]

--- a/tt-media-server/cpp_server/src/services/conversation_store.cpp
+++ b/tt-media-server/cpp_server/src/services/conversation_store.cpp
@@ -18,11 +18,11 @@ namespace tt::services {
 ConversationStore::ConversationStore(std::string logDir)
     : logDir(std::move(logDir)) {
   try {
-    std::filesystem::create_directories(logDir);
-    TT_LOG_INFO("[ConversationStore] Log directory: {}", logDir);
+    std::filesystem::create_directories(this->logDir);
+    TT_LOG_INFO("[ConversationStore] Log directory: {}", this->logDir);
   } catch (const std::exception& e) {
-    TT_LOG_WARN("[ConversationStore] Failed to create log dir {}: {}", logDir,
-                e.what());
+    TT_LOG_WARN("[ConversationStore] Failed to create log dir {}: {}",
+                this->logDir, e.what());
   }
   writerThread = std::thread([this] { writerLoop(); });
 }


### PR DESCRIPTION
- Restored the missing `ENTRYPOINT` in `Dockerfile.blaze` — it was garbled into a comment, so `docker-entrypoint.sh` never ran (no permission setup, no gosu drop to non-root user)
- Removed duplicate `CMD` line
- Added missing runtime ENV vars (`PYTHONPATH`, `PYTHON_ENV_DIR`, `LD_LIBRARY_PATH`, `TT_METAL_LOGS_PATH`) to match the main Dockerfile
- Added conversation log directory creation in `docker-entrypoint.sh` so it exists with correct ownership before the app starts
