### PR TITLE
Fix SpeechT5 MGD for P300/P300X2 to single-chip descriptor

### DIFF
--- a/tt-media-server/utils/runner_utils.py
+++ b/tt-media-server/utils/runner_utils.py
@@ -14,8 +14,8 @@ _BH_DEVICE_MESH_DESCRIPTORS = {
     "p150": "p150_mesh_graph_descriptor.textproto",
     "p150x4": "p150x4_mesh_graph_descriptor.textproto",
     "p150x8": "p150x8_mesh_graph_descriptor.textproto",
-    "p300": "p300_mesh_graph_descriptor.textproto",
-    "p300x2": "p300_x2_mesh_graph_descriptor.textproto",
+    "p300": "p150_mesh_graph_descriptor.textproto",
+    "p300x2": "p150_mesh_graph_descriptor.textproto",
     "p100": "p100_mesh_graph_descriptor.textproto",
 }
 
@@ -68,17 +68,11 @@ def setup_cpu_threading_limits(cpu_threads: str, num_torch_threads: int = 1):
 def _setup_blackhole_mesh_config(tt_metal_home: str):
     """Configure mesh graph descriptors for Blackhole hardware"""
     device = (settings.device or "").lower()
-    if device not in _BH_DEVICE_MESH_DESCRIPTORS:
-        return
-    # Single-chip-per-worker workloads always use the 1x1 descriptor regardless
-    # of the host board type (P300 / P300X2 expose individual BH chips).
-    if settings.device_mesh_shape == (1, 1):
-        descriptor = "p150_mesh_graph_descriptor.textproto"
-    else:
-        descriptor = _BH_DEVICE_MESH_DESCRIPTORS[device]
-    os.environ["TT_MESH_GRAPH_DESC_PATH"] = (
-        f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/{descriptor}"
-    )
+    descriptor = _BH_DEVICE_MESH_DESCRIPTORS.get(device)
+    if descriptor:
+        os.environ["TT_MESH_GRAPH_DESC_PATH"] = (
+            f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/{descriptor}"
+        )
 
 
 def _setup_galaxy_mesh_config(tt_metal_home: str):

--- a/tt-media-server/utils/runner_utils.py
+++ b/tt-media-server/utils/runner_utils.py
@@ -68,11 +68,17 @@ def setup_cpu_threading_limits(cpu_threads: str, num_torch_threads: int = 1):
 def _setup_blackhole_mesh_config(tt_metal_home: str):
     """Configure mesh graph descriptors for Blackhole hardware"""
     device = (settings.device or "").lower()
-    descriptor = _BH_DEVICE_MESH_DESCRIPTORS.get(device)
-    if descriptor:
-        os.environ["TT_MESH_GRAPH_DESC_PATH"] = (
-            f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/{descriptor}"
-        )
+    if device not in _BH_DEVICE_MESH_DESCRIPTORS:
+        return
+    # Single-chip-per-worker workloads always use the 1x1 descriptor regardless
+    # of the host board type (P300 / P300X2 expose individual BH chips).
+    if settings.device_mesh_shape == (1, 1):
+        descriptor = "p150_mesh_graph_descriptor.textproto"
+    else:
+        descriptor = _BH_DEVICE_MESH_DESCRIPTORS[device]
+    os.environ["TT_MESH_GRAPH_DESC_PATH"] = (
+        f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/{descriptor}"
+    )
 
 
 def _setup_galaxy_mesh_config(tt_metal_home: str):

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -2795,7 +2795,7 @@ audio_tts_templates = [
                 max_context=64 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto",
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
                 },
             ),
             DeviceModelSpec(
@@ -2804,7 +2804,7 @@ audio_tts_templates = [
                 max_context=64 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto",
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
                 },
             ),
         ],

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -2795,7 +2795,7 @@ audio_tts_templates = [
                 max_context=64 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto",
                 },
             ),
             DeviceModelSpec(
@@ -2804,7 +2804,7 @@ audio_tts_templates = [
                 max_context=64 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto",
                 },
             ),
         ],


### PR DESCRIPTION
## Summary

`tt-media-server`'s `_setup_blackhole_mesh_config` was forcing a multi-chip MGD (`p300_mesh_graph_descriptor.textproto` / `p300_x2_mesh_graph_descriptor.textproto`) onto every BH worker keyed only on board type, ignoring `device_mesh_shape`. Single-chip workloads like SpeechT5 (whose `ModelConfigs` declare `device_mesh_shape=(1, 1)` on P300/P300X2) hit `TT_FATAL @ topology_mapper.cpp:527` because a single-chip physical slice cannot satisfy a multi-chip target graph.

Mirror the galaxy path: when `device_mesh_shape == (1, 1)`, use the 1×1 `p150_mesh_graph_descriptor.textproto` regardless of board; otherwise keep the existing per-device map. Multi-chip media models (FLUX P300/P300X2 etc.) are unaffected.

The first commit on this branch tried to set this via `DeviceModelSpec.env_vars` in `workflows/model_spec.py`, but that value never reached the container and would have been overwritten anyway. Reverted.

Refs: DEVSTACK-74

## Validation

`tt-shield` `on-dispatch.yml` runs against this branch on `bh-qb-ge`, `tt-metal-git-ref=6900b0c2457d1d7c7092d585a540a527a9397749`:

- P300 (initial, failed before fix): https://github.com/tenstorrent/tt-shield/actions/runs/25132767962
- P300X2 (initial, failed before fix): https://github.com/tenstorrent/tt-shield/actions/runs/25132777592
- P300 (after fix): https://github.com/tenstorrent/tt-shield/actions/runs/25171504194
- P300X2 (after fix): https://github.com/tenstorrent/tt-shield/actions/runs/25171505746
