### PR TITLE
Set realistic EfficientNet perf targets

### DIFF
--- a/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/benchmarking/benchmark_targets/model_performance_reference.json
@@ -6516,8 +6516,8 @@
                 "task_type": "cnn",
                 "targets": {
                     "theoretical": {
-                        "ttft_ms": 50,
-                        "tput_user": 20
+                        "ttft_ms": 100,
+                        "tput_user": 12
                     }
                 }
             }
@@ -6529,8 +6529,8 @@
                 "task_type": "cnn",
                 "targets": {
                     "theoretical": {
-                        "ttft_ms": 50,
-                        "tput_user": 20
+                        "ttft_ms": 100,
+                        "tput_user": 12
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Updates the `theoretical` perf targets for EfficientNet on n150 and n300 in `benchmarking/benchmark_targets/model_performance_reference.json` from the unmeasured placeholder `ttft_ms=50` / `tput_user=20` to realistic `ttft_ms=100` / `tput_user=12`.

### Why

CI run [25022507118](https://github.com/tenstorrent/tt-shield/actions/runs/25022507118) shows all working CNN models on n150 cluster at **65–75 ms TTFT (~14 fps)** — the network/Flask round-trip dominates over per-model inference. The `ttft_ms=50` placeholder added in #1136 was never measured and is unreachable on this hardware. MobileNetV2 happens to pass only because its placeholder is the much-more-lenient `ttft_ms=600`; everything else, including EfficientNet, fails the unreachable 50 ms target.

| Model (n150) | Measured TTFT | `ttft_ms` target | `target.ttft_check` |
|---|---|---|---|
| mobilenetv2 | 70.8 ms | 600 | ✅ |
| resnet-50 | 72.1 ms | 50 | ⛔ |
| vit | 68.3 ms | 50 | ⛔ |
| vovnet | 70.6 ms | 50 | ⛔ |
| **efficientnet** | **69.8 ms** | **50** | **⛔** |
| unet | 68.0 ms | 50 | ⛔ |
| segformer | 325.1 ms | 50 | ⛔ |

### Change

- `efficientnet.n150[0].targets.theoretical.ttft_ms`: 50 → 100
- `efficientnet.n150[0].targets.theoretical.tput_user`: 20 → 12
- Same for `n300`

The new values give comfortable headroom (~30%) above measured TTFT and below measured throughput. Functional/complete tiers derive automatically (ttft *10/*2, tput /10/2) and remain green.

### Scope

Limited to EfficientNet to keep the change reviewable. Other CNN rows (resnet-50, vit, vovnet, unet) likely need the same treatment but are out of scope here.

### Dependencies

This change is most effective when paired with the cnn_client.py fixes in #3258 (XLA warmup excludes cold-start, `tput_user` actually written to the eval JSON for the VisionEvalsTest path). Without those, `tput_user` reads as 0 and `target.tput_check` fails regardless of the target value.

## Test plan

- [ ] CI release-efficientnet-n150 measures TTFT < 100 ms and `tput_user` > 12 fps
- [ ] Dashboard EfficientNet `target.ttft_check` and `target.tput_check` go green
- [ ] No regression on other CNN rows