### PR TITLE
Unique test for health check in spec_tests

### DIFF
--- a/server_tests/base_test.py
+++ b/server_tests/base_test.py
@@ -8,12 +8,27 @@ import os
 import time
 import traceback
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
 
 from server_tests.test_classes import TestConfig
 
 # Set up logging
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class HealthCheckConfig:
+    """Health check configuration."""
+
+    MAX_ATTEMPTS: int = 230
+    RETRY_DELAY: int = 10
+    TIMEOUT: int = 10
+
+
+HEALTH_CHECK_CONFIG = HealthCheckConfig()
 
 
 class BaseTest(ABC):
@@ -132,6 +147,67 @@ class BaseTest(ABC):
     def get_logs(self):
         """Get all logs collected during test execution"""
         return self.logs
+
+    def wait_for_server_ready(
+        self,
+        service_port: Optional[int] = None,
+        max_attempts: Optional[int] = None,
+        retry_delay: Optional[int] = None,
+    ) -> bool:
+        """Wait for server to be ready using simple HTTP health check.
+
+        Args:
+            service_port: Port where the server is running.
+            max_attempts: Maximum number of retry attempts.
+            retry_delay: Seconds to wait between retries.
+
+        Returns:
+            bool: True if server is ready, False otherwise.
+        """
+        logger.info("Waiting for server to be ready...")
+        service_port = int(
+            service_port if service_port is not None else self.service_port
+        )
+        max_attempts = (
+            max_attempts
+            if max_attempts is not None
+            else HEALTH_CHECK_CONFIG.MAX_ATTEMPTS
+        )
+        retry_delay = (
+            retry_delay if retry_delay is not None else HEALTH_CHECK_CONFIG.RETRY_DELAY
+        )
+        health_url = f"http://localhost:{service_port}/tt-liveness"
+        logger.info("Waiting for server at %s ...", health_url)
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                response = requests.get(health_url, timeout=HEALTH_CHECK_CONFIG.TIMEOUT)
+                if response.status_code == 200:
+                    data = response.json()
+                    if data.get("status") == "alive" and data.get("model_ready"):
+                        logger.info(
+                            "Server is ready after %s attempt(s)",
+                            attempt,
+                        )
+                        return True
+                logger.info(
+                    "Server not ready (attempt %s/%s), retrying in %ss...",
+                    attempt,
+                    max_attempts,
+                    retry_delay,
+                )
+            except requests.exceptions.RequestException as e:
+                logger.info(
+                    "Health check failed (attempt %s/%s): %s, retrying in %ss...",
+                    attempt,
+                    max_attempts,
+                    e,
+                    retry_delay,
+                )
+            time.sleep(retry_delay)
+
+        logger.error("Server health check failed after %s attempts", max_attempts)
+        return False
 
     @abstractmethod
     async def _run_specific_test_async(self):

--- a/server_tests/test_cases/image_generation_eval_test.py
+++ b/server_tests/test_cases/image_generation_eval_test.py
@@ -11,7 +11,6 @@ from enum import IntEnum
 from typing import Optional, Union
 
 import aiohttp
-import requests
 
 from server_tests.base_test import BaseTest
 from server_tests.test_cases.server_helper import DEFAULT_AUTHORIZATION
@@ -52,17 +51,7 @@ class ImageGenConfig:
     REQUEST_TIMEOUT: int = 5000
 
 
-@dataclass(frozen=True)
-class HealthCheckConfig:
-    """Health check configuration."""
-
-    MAX_ATTEMPTS: int = 230
-    RETRY_DELAY: int = 10
-    TIMEOUT: int = 10
-
-
 CONFIG = ImageGenConfig()
-HEALTH_CONFIG = HealthCheckConfig()
 
 
 SDXL_RESOLUTION_MODEL_NAME_SUFFIX = {
@@ -268,7 +257,7 @@ class ImageGenerationEvalsTest(BaseTest):
         """Generate images for all prompts concurrently."""
         logger.info("Step 2: Generating %s images concurrently", len(prompts))
 
-        if not self._wait_for_server_ready():
+        if not self.wait_for_server_ready():
             raise RuntimeError("Server health check failed")
 
         ctx = ImageGenContext(
@@ -379,37 +368,6 @@ class ImageGenerationEvalsTest(BaseTest):
             base64image=images[0],
             prompt=prompt,
         )
-
-    def _wait_for_server_ready(self) -> bool:
-        """Wait for server to be ready."""
-        health_url = f"http://localhost:{self.service_port}/tt-liveness"
-        logger.info("Waiting for server: %s", health_url)
-
-        for attempt in range(1, HEALTH_CONFIG.MAX_ATTEMPTS + 1):
-            if self._check_health(health_url):
-                logger.info("Server ready after %s attempt(s)", attempt)
-                return True
-
-            logger.debug(
-                "Not ready (attempt %s/%s)", attempt, HEALTH_CONFIG.MAX_ATTEMPTS
-            )
-            time.sleep(HEALTH_CONFIG.RETRY_DELAY)
-
-        logger.error("Server not ready after %s attempts", HEALTH_CONFIG.MAX_ATTEMPTS)
-        return False
-
-    def _check_health(self, url: str) -> bool:
-        """Single health check attempt."""
-        try:
-            response = requests.get(url, timeout=HEALTH_CONFIG.TIMEOUT)
-        except requests.RequestException:
-            return False
-
-        if response.status_code != 200:
-            return False
-
-        data = response.json()
-        return data.get("status") == "alive" and data.get("model_ready", False)
 
     @staticmethod
     def _build_headers() -> dict:

--- a/server_tests/test_cases/server_helper.py
+++ b/server_tests/test_cases/server_helper.py
@@ -5,9 +5,7 @@
 import logging
 import os
 import subprocess
-import time
 from pathlib import Path
-from typing import Optional
 
 SERVER_STARTUP_TIMEOUT = 5 * 60  # wait up to 5 minutes for server to start
 SERVER_SHUTDOWN_TIMEOUT = 20
@@ -97,48 +95,6 @@ def launch_device_server(model_runner: str) -> tuple[subprocess.Popen, Path]:
     """Start the media server in CPU mode for the given model and capture logs."""
 
     return _launch_server(model_runner=model_runner, port=8000, runs_on_cpu=False)
-
-
-def wait_for_server_ready(
-    process: subprocess.Popen,
-    timeout: float = SERVER_STARTUP_TIMEOUT,
-    interval: float = 1.0,
-    log_path: Optional[Path] = None,
-) -> None:
-    """Stream server logs until the ready marker is observed."""
-
-    ready_path = log_path or getattr(process, "_log_path", None)
-    if ready_path is None:
-        raise ValueError("Missing log path for readiness checks.")
-
-    deadline = time.time() + timeout
-    last_pos = 0
-    buffer = ""
-    max_buffer = max(len(READY_LOG_TEXT) * 2, 2048)
-
-    with ready_path.open("r", encoding="utf-8", errors="replace") as log_file:
-        while time.time() < deadline:
-            if process.poll() is not None:
-                log_file.seek(0)
-                snippet = log_file.read()
-                raise RuntimeError(
-                    "Server process exited before becoming ready. Last log output:\n"
-                    + snippet[-2000:]
-                )
-
-            log_file.seek(last_pos)
-            chunk = log_file.read()
-            if chunk:
-                last_pos = log_file.tell()
-                buffer = (buffer + chunk)[-max_buffer:]
-                if READY_LOG_TEXT in buffer:
-                    return
-
-            time.sleep(interval)
-
-    raise TimeoutError(
-        f"Server did not log '{READY_LOG_TEXT}' within {timeout} seconds."
-    )
 
 
 def stop_server(

--- a/server_tests/test_cases/video_generation_eval_test.py
+++ b/server_tests/test_cases/video_generation_eval_test.py
@@ -121,56 +121,6 @@ class VideoGenerationEvalsTest(BaseTest):
             "eval_results": results,
         }
 
-    def _wait_for_server_ready(
-        self,
-        service_port: int = 8000,
-        max_attempts: int = 230,
-        retry_delay: int = 10,
-    ) -> bool:
-        """Wait for server to be ready using simple HTTP health check.
-
-        Args:
-            service_port: Port where the server is running.
-            max_attempts: Maximum number of retry attempts.
-            retry_delay: Seconds to wait between retries.
-
-        Returns:
-            bool: True if server is ready, False otherwise.
-        """
-        logger.info("Waiting for server to be ready...")
-        health_url = f"http://localhost:{service_port}/tt-liveness"
-        logger.info("Health URL: %s", health_url)
-
-        for attempt in range(1, max_attempts + 1):
-            try:
-                response = requests.get(health_url, timeout=10)
-                if response.status_code == 200:
-                    data = response.json()
-                    if data.get("status") == "alive" and data.get("model_ready"):
-                        logger.info(
-                            "Server is ready after %s attempt(s)",
-                            attempt,
-                        )
-                        return True
-                logger.info(
-                    "Server not ready (attempt %s/%s), retrying in %ss...",
-                    attempt,
-                    max_attempts,
-                    retry_delay,
-                )
-            except requests.exceptions.RequestException as e:
-                logger.info(
-                    "Health check failed (attempt %s/%s): %s, retrying in %ss...",
-                    attempt,
-                    max_attempts,
-                    e,
-                    retry_delay,
-                )
-            time.sleep(retry_delay)
-
-        logger.error("Server health check failed after %s attempts", max_attempts)
-        return False
-
     def _generate_videos(
         self,
         prompts: list[str],
@@ -197,7 +147,7 @@ class VideoGenerationEvalsTest(BaseTest):
             shutil.rmtree(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        if not self._wait_for_server_ready():
+        if not self.wait_for_server_ready():
             raise RuntimeError("Server health check failed - server not ready")
 
         base_url = server_url or SERVER_BASE_URL

--- a/server_tests/test_cases/vision_evals_test.py
+++ b/server_tests/test_cases/vision_evals_test.py
@@ -144,56 +144,6 @@ class VisionEvalsTest(BaseTest):
 
         return metadata
 
-    def _wait_for_server_ready(
-        self,
-        service_port: int = 8000,
-        max_attempts: int = 230,
-        retry_delay: int = 10,
-    ) -> bool:
-        """Wait for server to be ready using simple HTTP health check.
-
-        Args:
-            service_port: Port where the server is running.
-            max_attempts: Maximum number of retry attempts.
-            retry_delay: Seconds to wait between retries.
-
-        Returns:
-            bool: True if server is ready, False otherwise.
-        """
-        logger.info("Waiting for server to be ready...")
-        health_url = f"http://localhost:{service_port}/tt-liveness"
-        logger.info("Health URL: %s", health_url)
-
-        for attempt in range(1, max_attempts + 1):
-            try:
-                response = requests.get(health_url, timeout=10)
-                if response.status_code == 200:
-                    data = response.json()
-                    if data.get("status") == "alive" and data.get("model_ready"):
-                        logger.info(
-                            "Server is ready after %s attempt(s)",
-                            attempt,
-                        )
-                        return True
-                logger.info(
-                    "Server not ready (attempt %s/%s), retrying in %ss...",
-                    attempt,
-                    max_attempts,
-                    retry_delay,
-                )
-            except requests.exceptions.RequestException as e:
-                logger.info(
-                    "Health check failed (attempt %s/%s): %s, retrying in %ss...",
-                    attempt,
-                    max_attempts,
-                    e,
-                    retry_delay,
-                )
-            time.sleep(retry_delay)
-
-        logger.error("Server health check failed after %s attempts", max_attempts)
-        return False
-
     def _replay_samples(
         self,
         metadata: list[dict],
@@ -521,7 +471,7 @@ class VisionEvalsTest(BaseTest):
         accuracy_summary: dict[str, float] = {}
 
         # Wait for server to be ready (assumes server is already running)
-        if not self._wait_for_server_ready():
+        if not self.wait_for_server_ready():
             raise RuntimeError("Server health check failed - server not ready")
 
         for model in models:


### PR DESCRIPTION
### Github Issue
[Unique test for health check in spec_tests](https://github.com/tenstorrent/tt-inference-server/issues/1835)

### Summary

- Currently, every test has it's own implementation of calling DeviceHealthCheck test, we need a unified place for this.
- DeviceLivenessTest is registered once as a prerequisite test in server_tests_config.json and is automatically prepended to every suite by the categorization system. You don't need to add it to each test case — it just runs.
- For specific eval test there is a code duplication for _wait_for_server_ready. It should be centralized in single class - base_test.py. I will add fix in relation to this issue