### PR TITLE
fix: add runtime_config parameter to get_media_server_docker_env_vars…

### DIFF
--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -43,12 +43,13 @@ def short_uuid():
     return str(uuid.uuid4())[:8]
 
 
-def get_media_server_docker_env_vars(model_spec):
+def get_media_server_docker_env_vars(model_spec, runtime_config):
     """Get media server environment variables for Docker container."""
     env_vars = {
         "CACHE_ROOT": "/home/container_app_user/cache_root",  # TODO: remove this
         "MODEL": model_spec.model_name,
         "DEVICE": model_spec.device_type.name.lower(),
+        "SERVICE_PORT": runtime_config.service_port,
     }
 
     logger.info(
@@ -216,7 +217,7 @@ def generate_docker_run_command(
         model_spec.inference_engine == InferenceEngine.FORGE.value
         or model_spec.inference_engine == InferenceEngine.MEDIA.value
     ):
-        docker_env_vars.update(get_media_server_docker_env_vars(model_spec))
+        docker_env_vars.update(get_media_server_docker_env_vars(model_spec, runtime_config))
         api_key = os.getenv("API_KEY")
         if api_key:
             docker_env_vars["API_KEY"] = api_key


### PR DESCRIPTION
### fix: pass SERVICE_PORT env var to media/forge containers

  Description:

  Summary

  - Media and forge server containers were launched with --publish host_port:host_port but uvicorn inside the container always defaulted to port 8000 (via ${SERVICE_PORT:-8000}), causing connection
   resets when hitting the host port from outside
  - Fix: inject SERVICE_PORT into the container via get_media_server_docker_env_vars() so uvicorn binds to the correct port and the publish mapping lines up


Addresses issues cited [here](https://github.com/tenstorrent/tt-inference-server/pull/3284#pullrequestreview-4211600139) 