### PR TITLE
added Qwen3-Embedding-4B weights in qwen3_emb mapping

### DIFF
--- a/server_tests/server_tests_config.json
+++ b/server_tests/server_tests_config.json
@@ -310,7 +310,8 @@
         "qwen3_emb": {
             "id_name": "qwen3-emb-8b",
             "weights": [
-                "Qwen3-Embedding-8B"
+                "Qwen3-Embedding-8B",
+                "Qwen3-Embedding-4B"
             ],
             "category": "EMBEDDING",
             "compatible_devices": [


### PR DESCRIPTION
closes #3294 

**spec_tests** has been failing because **Qwen3-Embedding-4B** missing from **qwen3_emb** model config in **server_tests_config.json**

Every On-nightly job is failing for that reason.

Solution: 
Added **"Qwen3-Embedding-4B"** to the weights array of the **qwen3_emb** config.



After that on-dispatch job presents that evals and benchmarks are completed, and spec tests failed with EmbeddingLoadTest. I suppose this might be examined afterwards by inference or forge team.

Pipeline with corrected mapping:
https://github.com/tenstorrent/tt-shield/actions/runs/25163427002/job/73766853382

INFO: ✅ Completed workflow: evals
................
✅ Completed workflow: benchmarks
..................
📊 TEST EXECUTION SUMMARY
================================================================================
INFO -   Total: 3  |  ✅ Passed: 2  |  ❌ Failed: 1  |  ⏱️  Duration: 60.11s  |  Attempts: 4
server_tests.tests_runner ================================================================================

INFO - ✅ PASS   DeviceLivenessTest        0.02s        1  Test for device liveness checks - runs before all
INFO - ✅ PASS   LoggerForkSafetyTest      0.01s        1  Test for logging fork safety to prevent deadlocks
NFO - ❌ FAIL   EmbeddingLoadTest        60.09s        2  Embedding load test


