### PR TITLE
Parallel tool call validation

### DIFF
--- a/tt-media-server/cpp_server/include/domain/chat_completion_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/chat_completion_request.hpp
@@ -5,12 +5,12 @@
 
 #include <json/json.h>
 
+#include <algorithm>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 #include "domain/base_request.hpp"
 #include "domain/chat_message.hpp"
@@ -396,7 +396,7 @@ struct ChatCompletionRequest : BaseRequest {
     }
     for (const auto& expectedId : expectedToolCallIds) {
       size_t count = std::count(actualToolCallIds.begin(),
-                                 actualToolCallIds.end(), expectedId);
+                                actualToolCallIds.end(), expectedId);
 
       if (count == 0) {
         throw std::invalid_argument("Missing tool response for tool_call_id '" +

--- a/tt-media-server/cpp_server/include/domain/chat_completion_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/chat_completion_request.hpp
@@ -408,21 +408,6 @@ struct ChatCompletionRequest : BaseRequest {
             "Duplicate tool response for tool_call_id '" + expectedId +
             "': found " + std::to_string(count) + " responses");
       }
-
-      if (std::find(expectedToolCallIds.begin(), expectedToolCallIds.end(),
-                    expectedId) == expectedToolCallIds.end()) {
-        throw std::invalid_argument("Unknown tool_call_id '" + expectedId +
-                                    "' not found in assistant's tool_calls");
-      }
-    }
-
-    for (const auto& actualId : actualToolCallIds) {
-      if (std::find(expectedToolCallIds.begin(), expectedToolCallIds.end(),
-                    actualId) == expectedToolCallIds.end()) {
-        throw std::invalid_argument("Unknown tool_call_id '" + actualId +
-                                    "' does not match any tool_call in the "
-                                    "assistant's previous message");
-      }
     }
   }
 };

--- a/tt-media-server/cpp_server/include/domain/chat_completion_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/chat_completion_request.hpp
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #include "domain/base_request.hpp"
 #include "domain/chat_message.hpp"
@@ -327,32 +328,101 @@ struct ChatCompletionRequest : BaseRequest {
       return;
     }
 
-    const std::string& expectedCallId = lastAssistant.tool_calls->at(0).id;
-
     if (lastAssistantIdx + 1 >= req.messages.size()) {
       throw std::invalid_argument(
           "Expected message with role='tool' after assistant message with "
           "tool_calls, but didn't get any new messages");
     }
 
-    const auto& nextMessage = req.messages[lastAssistantIdx + 1];
+    const auto& toolCalls = *lastAssistant.tool_calls;
 
-    if (nextMessage.role != "tool") {
-      throw std::invalid_argument(
-          "Expected message with role='tool' after assistant message with "
-          "tool_calls, but got role='" +
-          nextMessage.role + "'");
+    std::vector<std::string> expectedToolCallIds;
+    for (const auto& toolCall : toolCalls) {
+      expectedToolCallIds.push_back(toolCall.id);
     }
 
-    if (!nextMessage.tool_call_id.has_value()) {
-      throw std::invalid_argument(
-          "Message with role='tool' must include 'tool_call_id' field");
+    std::vector<std::string> actualToolCallIds;
+    for (size_t i = lastAssistantIdx + 1; i < req.messages.size(); ++i) {
+      const auto& msg = req.messages[i];
+
+      if (msg.role != "tool") {
+        break;
+      }
+
+      if (!msg.tool_call_id.has_value()) {
+        throw std::invalid_argument(
+            "Message with role='tool' must include 'tool_call_id' field");
+      }
+
+      actualToolCallIds.push_back(*msg.tool_call_id);
     }
 
-    if (*nextMessage.tool_call_id != expectedCallId) {
-      throw std::invalid_argument("tool_call_id '" + *nextMessage.tool_call_id +
-                                  "' does not match expected call_id '" +
-                                  expectedCallId + "'");
+    if (actualToolCallIds.size() < expectedToolCallIds.size()) {
+      std::ostringstream err;
+      err << "Incomplete tool call conversation: assistant requested "
+          << expectedToolCallIds.size() << " tool call(s) but only received "
+          << actualToolCallIds.size() << " tool response(s). "
+          << "Missing tool_call_id(s): ";
+
+      bool first = true;
+      for (const auto& expectedId : expectedToolCallIds) {
+        if (std::find(actualToolCallIds.begin(), actualToolCallIds.end(),
+                      expectedId) == actualToolCallIds.end()) {
+          if (!first) err << ", ";
+          err << "'" << expectedId << "'";
+          first = false;
+        }
+      }
+      throw std::invalid_argument(err.str());
+    }
+
+    if (actualToolCallIds.size() > expectedToolCallIds.size()) {
+      std::ostringstream err;
+      err << "Too many tool call responses: assistant requested "
+          << expectedToolCallIds.size() << " tool call(s) but received "
+          << actualToolCallIds.size() << " tool response(s). "
+          << "Unexpected tool_call_id(s): ";
+
+      bool first = true;
+      for (const auto& actualId : actualToolCallIds) {
+        if (std::find(expectedToolCallIds.begin(), expectedToolCallIds.end(),
+                      actualId) == expectedToolCallIds.end()) {
+          if (!first) err << ", ";
+          err << "'" << actualId << "'";
+          first = false;
+        }
+      }
+      throw std::invalid_argument(err.str());
+    }
+    for (const auto& expectedId : expectedToolCallIds) {
+      size_t count = std::count(actualToolCallIds.begin(),
+                                 actualToolCallIds.end(), expectedId);
+
+      if (count == 0) {
+        throw std::invalid_argument("Missing tool response for tool_call_id '" +
+                                    expectedId + "'");
+      }
+
+      if (count > 1) {
+        throw std::invalid_argument(
+            "Duplicate tool response for tool_call_id '" + expectedId +
+            "': found " + std::to_string(count) + " responses");
+      }
+
+      if (std::find(expectedToolCallIds.begin(), expectedToolCallIds.end(),
+                    expectedId) == expectedToolCallIds.end()) {
+        throw std::invalid_argument("Unknown tool_call_id '" + expectedId +
+                                    "' not found in assistant's tool_calls");
+      }
+    }
+
+    for (const auto& actualId : actualToolCallIds) {
+      if (std::find(expectedToolCallIds.begin(), expectedToolCallIds.end(),
+                    actualId) == expectedToolCallIds.end()) {
+        throw std::invalid_argument("Unknown tool_call_id '" + actualId +
+                                    "' does not match any tool_call in the "
+                                    "assistant's previous message");
+      }
     }
   }
 };

--- a/tt-media-server/cpp_server/tests/test_chat_completion_request.cpp
+++ b/tt-media-server/cpp_server/tests/test_chat_completion_request.cpp
@@ -41,7 +41,6 @@ Json::Value createToolJson(const std::string& name,
   return tool;
 }
 
-// Helper to create a user message
 Json::Value createUserMessage(const std::string& content) {
   Json::Value msg;
   msg["role"] = "user";
@@ -49,7 +48,6 @@ Json::Value createUserMessage(const std::string& content) {
   return msg;
 }
 
-// Helper to create an assistant message
 Json::Value createAssistantMessage(const std::string& content) {
   Json::Value msg;
   msg["role"] = "assistant";
@@ -57,7 +55,6 @@ Json::Value createAssistantMessage(const std::string& content) {
   return msg;
 }
 
-// Helper to create an assistant message with a tool call
 Json::Value createAssistantWithToolCall(const std::string& callId,
                                         const std::string& functionName,
                                         const std::string& arguments) {
@@ -269,8 +266,10 @@ void testToolMessageMissingAfterToolCalls() {
   } catch (const std::invalid_argument& e) {
     exceptionThrown = true;
     std::string errorMsg = e.what();
-    assert(errorMsg.find("Expected message with role='tool'") !=
-           std::string::npos);
+    assert(errorMsg.find("Incomplete tool call conversation") !=
+               std::string::npos ||
+           errorMsg.find("Expected message with role='tool'") !=
+               std::string::npos);
   }
 
   assert(exceptionThrown &&
@@ -336,13 +335,332 @@ void testToolMessageMismatchedCallId() {
   } catch (const std::invalid_argument& e) {
     exceptionThrown = true;
     std::string errorMsg = e.what();
-    assert(errorMsg.find("does not match expected call_id") !=
-           std::string::npos);
+    assert(errorMsg.find("Missing tool response") != std::string::npos ||
+           errorMsg.find("Unknown tool_call_id") != std::string::npos ||
+           errorMsg.find("does not match") != std::string::npos);
   }
 
   assert(exceptionThrown && "Should throw when tool_call_id doesn't match");
 
   std::cout << "✓ Mismatched tool_call_id correctly rejected\n";
+  std::cout << "✅ Test passed!\n";
+}
+
+void testToolCallFewerOutputsThanExpected() {
+  std::cout << "\n=== Testing Scenario 1: Fewer Outputs Than Tool Calls "
+               "(Should Reject) ===\n";
+
+  Json::Value json = createBasicRequestJson();
+  json["messages"].clear();
+
+  json["messages"].append(createUserMessage("What's the weather and time?"));
+
+  // Assistant requests 3 tool calls
+  Json::Value assistantMsg;
+  assistantMsg["role"] = "assistant";
+  assistantMsg["content"] = "";
+
+  Json::Value toolCall1, toolCall2, toolCall3;
+  toolCall1["id"] = "call_abc123";
+  toolCall1["type"] = "function";
+  toolCall1["function"]["name"] = "get_weather";
+  toolCall1["function"]["arguments"] = "{\"location\":\"NYC\"}";
+
+  toolCall2["id"] = "call_def456";
+  toolCall2["type"] = "function";
+  toolCall2["function"]["name"] = "get_time";
+  toolCall2["function"]["arguments"] = "{}";
+
+  toolCall3["id"] = "call_ghi789";
+  toolCall3["type"] = "function";
+  toolCall3["function"]["name"] = "get_date";
+  toolCall3["function"]["arguments"] = "{}";
+
+  assistantMsg["tool_calls"].append(toolCall1);
+  assistantMsg["tool_calls"].append(toolCall2);
+  assistantMsg["tool_calls"].append(toolCall3);
+  json["messages"].append(assistantMsg);
+
+  // Client only provides 2 outputs (missing call_ghi789)
+  json["messages"].append(createToolMessage("call_abc123", "Sunny, 72°F"));
+  json["messages"].append(createToolMessage("call_def456", "3:45 PM"));
+
+  bool exceptionThrown = false;
+  try {
+    ChatCompletionRequest::fromJson(json, 1);
+  } catch (const std::invalid_argument& e) {
+    exceptionThrown = true;
+    std::string errorMsg = e.what();
+    assert(errorMsg.find("Incomplete tool call conversation") !=
+               std::string::npos ||
+           errorMsg.find("requested 3") != std::string::npos);
+    assert(errorMsg.find("call_ghi789") != std::string::npos);
+    std::cout << "  Error message: " << errorMsg << "\n";
+  }
+
+  assert(exceptionThrown &&
+         "Should throw when fewer outputs than tool calls");
+
+  std::cout << "✓ Fewer outputs correctly rejected\n";
+  std::cout << "✅ Test passed!\n";
+}
+
+void testToolCallMoreOutputsThanExpected() {
+  std::cout << "\n=== Testing Scenario 2: More Outputs Than Tool Calls (Should "
+               "Reject) ===\n";
+
+  Json::Value json = createBasicRequestJson();
+  json["messages"].clear();
+
+  json["messages"].append(createUserMessage("What's the weather?"));
+
+  // Assistant requests 2 tool calls
+  Json::Value assistantMsg;
+  assistantMsg["role"] = "assistant";
+  assistantMsg["content"] = "";
+
+  Json::Value toolCall1, toolCall2;
+  toolCall1["id"] = "call_abc123";
+  toolCall1["type"] = "function";
+  toolCall1["function"]["name"] = "get_weather";
+  toolCall1["function"]["arguments"] = "{\"location\":\"NYC\"}";
+
+  toolCall2["id"] = "call_def456";
+  toolCall2["type"] = "function";
+  toolCall2["function"]["name"] = "get_time";
+  toolCall2["function"]["arguments"] = "{}";
+
+  assistantMsg["tool_calls"].append(toolCall1);
+  assistantMsg["tool_calls"].append(toolCall2);
+  json["messages"].append(assistantMsg);
+
+  // Client provides 3 outputs (extra call_ghi789)
+  json["messages"].append(createToolMessage("call_abc123", "Sunny, 72°F"));
+  json["messages"].append(createToolMessage("call_def456", "3:45 PM"));
+  json["messages"].append(
+      createToolMessage("call_ghi789", "Extra output"));  // Extra!
+
+  bool exceptionThrown = false;
+  try {
+    ChatCompletionRequest::fromJson(json, 1);
+  } catch (const std::invalid_argument& e) {
+    exceptionThrown = true;
+    std::string errorMsg = e.what();
+    assert(errorMsg.find("Too many tool call responses") != std::string::npos ||
+           errorMsg.find("requested 2") != std::string::npos);
+    assert(errorMsg.find("call_ghi789") != std::string::npos);
+    std::cout << "  Error message: " << errorMsg << "\n";
+  }
+
+  assert(exceptionThrown && "Should throw when more outputs than tool calls");
+
+  std::cout << "✓ Extra outputs correctly rejected\n";
+  std::cout << "✅ Test passed!\n";
+}
+
+void testToolCallOneRequestMultipleOutputs() {
+  std::cout << "\n=== Testing Scenario 3: 1 Tool Call → Multiple Outputs "
+               "(Should Reject) ===\n";
+
+  Json::Value json = createBasicRequestJson();
+  json["messages"].clear();
+
+  json["messages"].append(createUserMessage("What's the weather?"));
+  json["messages"].append(
+      createAssistantWithToolCall("call_abc123", "get_weather", "{}"));
+
+  // Client provides 2 outputs when only 1 was requested
+  json["messages"].append(createToolMessage("call_abc123", "Sunny, 72°F"));
+  json["messages"].append(createToolMessage("call_def456", "Extra output"));
+
+  bool exceptionThrown = false;
+  try {
+    ChatCompletionRequest::fromJson(json, 1);
+  } catch (const std::invalid_argument& e) {
+    exceptionThrown = true;
+    std::string errorMsg = e.what();
+    assert(errorMsg.find("Too many tool call responses") != std::string::npos);
+    std::cout << "  Error message: " << errorMsg << "\n";
+  }
+
+  assert(exceptionThrown &&
+         "Should throw when multiple outputs for single tool call");
+
+  std::cout << "✓ Multiple outputs for single tool call correctly rejected\n";
+  std::cout << "✅ Test passed!\n";
+}
+
+void testToolCallZeroOutputs() {
+  std::cout
+      << "\n=== Testing Scenario 4: Tool Calls → 0 Outputs (Should Reject) "
+         "===\n";
+
+  Json::Value json = createBasicRequestJson();
+  json["messages"].clear();
+
+  json["messages"].append(createUserMessage("What's the weather?"));
+  json["messages"].append(
+      createAssistantWithToolCall("call_abc123", "get_weather", "{}"));
+  // No tool message follows
+
+  bool exceptionThrown = false;
+  try {
+    ChatCompletionRequest::fromJson(json, 1);
+  } catch (const std::invalid_argument& e) {
+    exceptionThrown = true;
+    std::string errorMsg = e.what();
+    assert(errorMsg.find("Expected message with role='tool'") !=
+           std::string::npos);
+    std::cout << "  Error message: " << errorMsg << "\n";
+  }
+
+  assert(exceptionThrown && "Should throw when no outputs after tool calls");
+
+  std::cout << "✓ Zero outputs correctly rejected\n";
+  std::cout << "✅ Test passed!\n";
+}
+
+void testToolCallDuplicateToolCallIds() {
+  std::cout << "\n=== Testing Duplicate tool_call_id in Responses (Should "
+               "Reject) ===\n";
+
+  Json::Value json = createBasicRequestJson();
+  json["messages"].clear();
+
+  json["messages"].append(createUserMessage("What's the weather?"));
+
+  // Assistant requests 2 different tool calls
+  Json::Value assistantMsg;
+  assistantMsg["role"] = "assistant";
+  assistantMsg["content"] = "";
+
+  Json::Value toolCall1, toolCall2;
+  toolCall1["id"] = "call_abc123";
+  toolCall1["type"] = "function";
+  toolCall1["function"]["name"] = "get_weather";
+  toolCall1["function"]["arguments"] = "{}";
+
+  toolCall2["id"] = "call_def456";
+  toolCall2["type"] = "function";
+  toolCall2["function"]["name"] = "get_time";
+  toolCall2["function"]["arguments"] = "{}";
+
+  assistantMsg["tool_calls"].append(toolCall1);
+  assistantMsg["tool_calls"].append(toolCall2);
+  json["messages"].append(assistantMsg);
+
+  // Client provides duplicate response for call_abc123
+  json["messages"].append(createToolMessage("call_abc123", "Sunny"));
+  json["messages"].append(
+      createToolMessage("call_abc123", "Duplicate!"));  // Duplicate!
+
+  bool exceptionThrown = false;
+  try {
+    ChatCompletionRequest::fromJson(json, 1);
+  } catch (const std::invalid_argument& e) {
+    exceptionThrown = true;
+    std::string errorMsg = e.what();
+    assert(errorMsg.find("Duplicate tool response") != std::string::npos ||
+           errorMsg.find("call_abc123") != std::string::npos);
+    std::cout << "  Error message: " << errorMsg << "\n";
+  }
+
+  assert(exceptionThrown && "Should throw when duplicate tool_call_ids exist");
+
+  std::cout << "✓ Duplicate tool_call_ids correctly rejected\n";
+  std::cout << "✅ Test passed!\n";
+}
+
+void testToolCallMultipleValidSequence() {
+  std::cout << "\n=== Testing Multiple Valid Tool Calls Sequence ===\n";
+
+  Json::Value json = createBasicRequestJson();
+  json["messages"].clear();
+
+  json["messages"].append(createUserMessage("What's the weather and time?"));
+
+  // Assistant requests 3 tool calls
+  Json::Value assistantMsg;
+  assistantMsg["role"] = "assistant";
+  assistantMsg["content"] = "";
+
+  Json::Value toolCall1, toolCall2, toolCall3;
+  toolCall1["id"] = "call_abc123";
+  toolCall1["type"] = "function";
+  toolCall1["function"]["name"] = "get_weather";
+  toolCall1["function"]["arguments"] = "{\"location\":\"NYC\"}";
+
+  toolCall2["id"] = "call_def456";
+  toolCall2["type"] = "function";
+  toolCall2["function"]["name"] = "get_time";
+  toolCall2["function"]["arguments"] = "{}";
+
+  toolCall3["id"] = "call_ghi789";
+  toolCall3["type"] = "function";
+  toolCall3["function"]["name"] = "get_date";
+  toolCall3["function"]["arguments"] = "{}";
+
+  assistantMsg["tool_calls"].append(toolCall1);
+  assistantMsg["tool_calls"].append(toolCall2);
+  assistantMsg["tool_calls"].append(toolCall3);
+  json["messages"].append(assistantMsg);
+
+  // Client provides all 3 outputs in correct order
+  json["messages"].append(createToolMessage("call_abc123", "Sunny, 72°F"));
+  json["messages"].append(createToolMessage("call_def456", "3:45 PM"));
+  json["messages"].append(createToolMessage("call_ghi789", "April 29, 2026"));
+
+  auto request = ChatCompletionRequest::fromJson(json, 1);
+
+  assert(request.messages.size() == 5);
+  assert(request.messages[1].tool_calls.has_value());
+  assert(request.messages[1].tool_calls->size() == 3);
+
+  std::cout << "✓ Multiple valid tool calls sequence accepted\n";
+  std::cout << "✅ Test passed!\n";
+}
+
+void testToolCallValidSequenceWithSubsequentMessage() {
+  std::cout << "\n=== Testing Valid Tool Calls Followed by User Message ===\n";
+
+  Json::Value json = createBasicRequestJson();
+  json["messages"].clear();
+
+  json["messages"].append(createUserMessage("What's the weather?"));
+
+  // Assistant requests 2 tool calls
+  Json::Value assistantMsg;
+  assistantMsg["role"] = "assistant";
+  assistantMsg["content"] = "";
+
+  Json::Value toolCall1, toolCall2;
+  toolCall1["id"] = "call_abc123";
+  toolCall1["type"] = "function";
+  toolCall1["function"]["name"] = "get_weather";
+  toolCall1["function"]["arguments"] = "{}";
+
+  toolCall2["id"] = "call_def456";
+  toolCall2["type"] = "function";
+  toolCall2["function"]["name"] = "get_time";
+  toolCall2["function"]["arguments"] = "{}";
+
+  assistantMsg["tool_calls"].append(toolCall1);
+  assistantMsg["tool_calls"].append(toolCall2);
+  json["messages"].append(assistantMsg);
+
+  json["messages"].append(createToolMessage("call_abc123", "Sunny"));
+  json["messages"].append(createToolMessage("call_def456", "3:45 PM"));
+
+  json["messages"].append(createUserMessage("Thanks!"));
+
+  auto request = ChatCompletionRequest::fromJson(json, 1);
+
+  assert(request.messages.size() == 5);
+  assert(request.messages[1].tool_calls->size() == 2);
+  assert(request.messages[4].role == "user");
+
+  std::cout
+      << "✓ Tool calls followed by user message correctly accepted\n";
   std::cout << "✅ Test passed!\n";
 }
 
@@ -367,6 +685,15 @@ int main() {
     testToolMessageMissingAfterToolCalls();
     testToolMessageMissingToolCallId();
     testToolMessageMismatchedCallId();
+
+    // New tool call ID validation tests (OpenAI compatibility)
+    testToolCallFewerOutputsThanExpected();
+    testToolCallMoreOutputsThanExpected();
+    testToolCallOneRequestMultipleOutputs();
+    testToolCallZeroOutputs();
+    testToolCallDuplicateToolCallIds();
+    testToolCallMultipleValidSequence();
+    testToolCallValidSequenceWithSubsequentMessage();
 
     std::cout << "\n";
     std::cout

--- a/tt-media-server/cpp_server/tests/test_chat_completion_request.cpp
+++ b/tt-media-server/cpp_server/tests/test_chat_completion_request.cpp
@@ -398,8 +398,7 @@ void testToolCallFewerOutputsThanExpected() {
     std::cout << "  Error message: " << errorMsg << "\n";
   }
 
-  assert(exceptionThrown &&
-         "Should throw when fewer outputs than tool calls");
+  assert(exceptionThrown && "Should throw when fewer outputs than tool calls");
 
   std::cout << "✓ Fewer outputs correctly rejected\n";
   std::cout << "✅ Test passed!\n";
@@ -659,8 +658,7 @@ void testToolCallValidSequenceWithSubsequentMessage() {
   assert(request.messages[1].tool_calls->size() == 2);
   assert(request.messages[4].role == "user");
 
-  std::cout
-      << "✓ Tool calls followed by user message correctly accepted\n";
+  std::cout << "✓ Tool calls followed by user message correctly accepted\n";
   std::cout << "✅ Test passed!\n";
 }
 


### PR DESCRIPTION
## Parallel Tool Call Support                                                                                                                                 

  This PR adds support for parallel tool calls in the C++ server, matching OpenAI's API specification.                                                          
   
When an assistant message contains multiple `tool_calls`, the server now validates that the conversation includes corresponding tool responses before processing continues. This validation ensures the integrity of multi-turn tool call conversations, which is essential for parallel tool calling where the model can request multiple tool invocations simultaneously. 