### PR TITLE
Bump Claude review max-turns to 40

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -112,5 +112,5 @@ jobs:
 
           claude_args: |
             --model claude-opus-4-7
-            --max-turns 15
+            --max-turns 40
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"


### PR DESCRIPTION
The 15-turn cap was too tight: each tool call (gh pr view/diff, file reads, inline comments) consumes one turn, so medium PRs were hitting error_max_turns before Claude finished posting comments (e.g. PR #3316 exited with subtype "error_max_turns" at turn 16).

Also bumps actions/checkout to v6 to silence the Node.js 20 deprecation annotation (matches Anthropic's official examples).