### PR TITLE
Separate Streaming Request Process and Preprocess

### DIFF
--- a/tt-media-server/cpp_server/include/api/response_writer/non_stream_response_writer.hpp
+++ b/tt-media-server/cpp_server/include/api/response_writer/non_stream_response_writer.hpp
@@ -18,7 +18,7 @@ namespace tt::api {
  * Response writer that accumulates chunks into a single ChatCompletionResponse.
  *
  * The non-streaming counterpart to StreamingResponseWriter: the controller
- * drives the same Streamable producer (LLMService::submitStreamingRequest or
+ * drives the same Streamable producer (LLMService::processStreamingRequest or
  * the disaggregation service) and forwards every chunk here instead of out to
  * SSE. On the final chunk we build the full ChatCompletionResponse, run the
  * service's postProcess (reasoning strip + tool-call parsing — non-streaming

--- a/tt-media-server/cpp_server/include/services/llm_service.hpp
+++ b/tt-media-server/cpp_server/include/services/llm_service.hpp
@@ -65,17 +65,16 @@ class LLMService
     return workerManager.get();
   }
 
+  void processStreamingRequest(
+      domain::LLMRequest request,
+      std::function<void(const domain::LLMStreamChunk&, bool isFinal)> callback)
+      override;
+
  protected:
   size_t currentQueueSize() const override;
   domain::LLMResponse processRequest(domain::LLMRequest request) override;
 
   std::vector<tt::worker::WorkerInfo> getWorkerInfo() const override;
-
-  void streamingPostProcess(domain::LLMStreamChunk&) const override {}
-  void processStreamingRequest(
-      domain::LLMRequest request,
-      std::function<void(domain::LLMStreamChunk&, bool isFinal)> callback)
-      override;
 
  private:
   struct StreamCallbackEntry {

--- a/tt-media-server/cpp_server/include/services/streamable.hpp
+++ b/tt-media-server/cpp_server/include/services/streamable.hpp
@@ -17,28 +17,9 @@ class Streamable {
  public:
   virtual ~Streamable() = default;
 
-  void submitStreamingRequest(
-      RequestType& request,
-      std::function<void(const ResponseType&, bool isFinal)> callback,
-      bool skipPreProcess = false) {
-    if (!skipPreProcess) {
-      preProcess(request);
-    }
-    processStreamingRequest(
-        std::move(request),
-        [this, cb = std::move(callback)](ResponseType& response, bool isFinal) {
-          streamingPostProcess(response);
-          cb(response, isFinal);
-        });
-  }
-
- protected:
   virtual void processStreamingRequest(
       RequestType request,
-      std::function<void(ResponseType&, bool isFinal)> callback) = 0;
-
-  virtual void preProcess(RequestType& request) const = 0;
-  virtual void streamingPostProcess(ResponseType& response) const = 0;
+      std::function<void(const ResponseType&, bool isFinal)> callback) = 0;
 };
 
 }  // namespace tt::services

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -399,7 +399,7 @@ void LLMController::dispatchGeneration(
     const std::function<void(const domain::LLMStreamChunk&, bool)>& cb) const {
   const auto mode = tt::config::llmMode();
   if (mode == tt::config::LLMMode::REGULAR) {
-    service->submitStreamingRequest(request, cb, /*skipPreProcess=*/true);
+    service->processStreamingRequest(std::move(request), cb);
     return;
   }
 
@@ -407,7 +407,7 @@ void LLMController::dispatchGeneration(
     if (shouldDoPrefillOnDecode(request, validSessionFound)) {
       TT_LOG_DEBUG("[LLMController] Using prefill on decode for sessionId: {}",
                    request.sessionId.value_or("none"));
-      service->submitStreamingRequest(request, cb, /*skipPreProcess=*/true);
+      service->processStreamingRequest(std::move(request), cb);
     } else {
       TT_LOG_DEBUG(
           "[LLMController] Using disaggregated prefill for request with "

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -66,10 +66,13 @@ void DisaggregationService::setupSocketHandlers() {
             request.disaggregated = true;
             request.prompt = std::vector<int>(message.token_ids.begin(),
                                               message.token_ids.end());
+            request.prompt_tokens_count =
+                static_cast<int>(message.token_ids.size());
             request.max_tokens = message.remaining_tokens;
             auto slotId = message.slot_id;
             request.slotId = slotId;
-            llmService->submitStreamingRequest(request, callback.value());
+            llmService->processStreamingRequest(std::move(request),
+                                                callback.value());
           } else {
             auto finalResponse = domain::LLMStreamChunk(message.task_id);
             domain::LLMChoice finalChoice;
@@ -122,8 +125,9 @@ void DisaggregationService::setupSocketHandlers() {
                                                    message.token_ids.end()));
           auto slotId = message.slot_id;
 
-          llmService->submitStreamingRequest(
-              request,
+          llmService->preProcess(request);
+          llmService->processStreamingRequest(
+              std::move(request),
               [this, message, maxTokens, slotId](
                   const domain::LLMStreamChunk& response, bool /*isFinal*/) {
                 auto prefillResult =

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -367,7 +367,8 @@ domain::LLMResponse LLMService::processRequest(domain::LLMRequest request) {
   const std::string model = request.model.value_or("default");
 
   processStreamingRequest(
-      std::move(request), [&](domain::LLMStreamChunk& chunk, bool isFinal) {
+      std::move(request),
+      [&](const domain::LLMStreamChunk& chunk, bool isFinal) {
         if (!chunk.choices.empty()) {
           if (chunk.choices[0].reasoning.has_value()) {
             accumulatedReasoning.append(chunk.choices[0].reasoning.value());
@@ -414,7 +415,7 @@ domain::LLMResponse LLMService::processRequest(domain::LLMRequest request) {
 
 void LLMService::processStreamingRequest(
     domain::LLMRequest request,
-    std::function<void(domain::LLMStreamChunk&, bool isFinal)> callback) {
+    std::function<void(const domain::LLMStreamChunk&, bool isFinal)> callback) {
   if (!callback) {
     throw std::invalid_argument("streaming callback must not be null");
   }


### PR DESCRIPTION
## Problem
Preprocess was called multiple times for DS setup. 
Also, we do not need to preprocess the request again if we are in Decode server.