### PR TITLE
Fix vLLM image build

### DIFF
--- a/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
+++ b/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
@@ -96,6 +96,7 @@ RUN /bin/bash -c "git clone https://github.com/tenstorrent/vllm.git ${vllm_dir} 
     && source ${PYTHON_ENV_DIR}/bin/activate \
     && uv pip install --upgrade pip \
     && uv pip install --index-strategy unsafe-best-match -e . --extra-index-url https://download.pytorch.org/whl/cpu \
+    && if [ -d plugins/vllm-tt-plugin ]; then uv pip install --no-deps -e plugins/vllm-tt-plugin; fi \  
     && rm -rf ${vllm_dir}/.git"
 
 # Build tt-smi in separate venv to avoid conflicts with tt-metal venv


### PR DESCRIPTION
After https://github.com/tenstorrent/vllm/pull/379 introduced the first out-of-tree plugin installation method, our vLLM Docker image build has been silently incorrect, resulting in the import errors identified in #3342.

This PR adds the pip installation of the plugin to our Docker image build.

Dispatch run: https://github.com/tenstorrent/tt-shield/actions/runs/25413210659