### PR TITLE
Reduce SPDX Header Checker run frequency

### DIFF
--- a/.github/workflows/spdx-checker.yml
+++ b/.github/workflows/spdx-checker.yml
@@ -10,8 +10,11 @@ on:
       - opened
       - reopened
       - synchronize
-      - assigned
-      - review_requested
+      - ready_for_review
+
+concurrency:
+  group: spdx-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-spdx-header-script:


### PR DESCRIPTION
## Summary

The SPDX Header Checker workflow runs many redundant times per PR. For example, PR #3372 produced **8 identical runs on the same head SHA** within seconds — one for `ready_for_review` and one for each of the 7 reviewers added.

Root cause: the `pull_request` trigger lists action types `assigned` and `review_requested`, which fire a separate webhook for **each individual reviewer/assignee added**, even though the code under test hasn't changed.

## Changes

- Drop `assigned` and `review_requested` from `pull_request.types` — these don't change file contents.
- Add `ready_for_review` so draft-to-ready transitions still trigger a run (otherwise that single transition could be missed).
- Add a `concurrency` group keyed on PR number with `cancel-in-progress: true` so rapid pushes cancel still-running checks instead of stacking duplicates.