### PR TITLE
Add pre-merge install verification for tt-media-server deps

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -60,9 +60,6 @@ jobs:
     if: ${{ needs.detect-changes.outputs.media-server-deps == 'true' }}
     name: Verify Media Server Dep Install
     runs-on: ubuntu-latest
-    # Hard cap: install resolves + downloads in ~4–7 min on a cold cache. The
-    # 15 min ceiling exists so a hung/looping resolver fails CI fast.
-    timeout-minutes: 15
     defaults:
       run:
         working-directory: tt-media-server

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -73,12 +73,11 @@ jobs:
           enable-cache: true
 
       - name: Create venv and seed tt-metal-equivalent pins
-        # tt-metal's python_env carries numpy<2; seed it via uv-overrides.txt
-        # (single source of truth) so the resolver in the next step sees the
-        # same constraints it would in the Dockerfile install layer.
+        # Simulates tt-metal's pre-existing numpy<2 pin so this gate fails
+        # if uv-overrides.txt's numpy override is removed.
         run: |
           uv venv
-          uv pip install --overrides uv-overrides.txt numpy
+          uv pip install 'numpy>=1.24.4,<2'
 
       - name: Install media-server requirements (strict, no fallback)
         # Mirrors tt-media-server/Dockerfile, but drops its `|| (grep -v

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -72,19 +72,17 @@ jobs:
           python-version: "3.10"
           enable-cache: true
 
-      - name: Create venv and seed tt-metal-equivalent pins
-        # Simulates tt-metal's pre-existing numpy<2 pin so this gate fails
-        # if uv-overrides.txt's numpy override is removed.
+      - name: Install media-server requirements (strict, no fallback)
+        # Mirrors tt-media-server/Dockerfile, minus its `|| (grep -v pyluwen ...)`
+        # fallback — that fallback masks resolver failures this gate must catch.
+        # The numpy<2 constraint mimics tt-metal's pin so removing uv-overrides.txt's
+        # numpy line fails CI here, before tt-metal's C extensions would crash on
+        # numpy 2 at runtime in docker.
         run: |
           uv venv
-          uv pip install 'numpy>=1.24.4,<2'
-
-      - name: Install media-server requirements (strict, no fallback)
-        # Mirrors tt-media-server/Dockerfile, but drops its `|| (grep -v
-        # pyluwen ...)` fallback — that fallback silently masks resolver
-        # failures, which is the class of bug this gate exists to catch.
-        run: |
+          echo 'numpy>=1.24.4,<2' > tt-metal-pins.txt
           uv pip install \
+            --constraint tt-metal-pins.txt \
             --index-strategy unsafe-best-match \
             --overrides uv-overrides.txt \
             -r requirements.txt

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -73,27 +73,17 @@ jobs:
           enable-cache: true
 
       - name: Create venv and seed tt-metal-equivalent pins
-        # The runtime install runs inside tt-metal's python_env, which already
-        # carries numpy<2 (tt-metal/requirements-dev.txt). Seed an equivalent
-        # numpy here so this gate behaves close to the Dockerfile install layer
-        # without pulling the heavyweight tt-metal base image.
-        #
-        # The exact constraint lives in uv-overrides.txt — we install through
-        # the same overrides file so there is a single source of truth. If
-        # tt-metal moves the numpy pin and uv-overrides.txt follows, this step
-        # picks the new constraint up automatically with no workflow edit.
+        # tt-metal's python_env carries numpy<2; seed it via uv-overrides.txt
+        # (single source of truth) so the resolver in the next step sees the
+        # same constraints it would in the Dockerfile install layer.
         run: |
           uv venv
           uv pip install --overrides uv-overrides.txt numpy
 
       - name: Install media-server requirements (strict, no fallback)
-        # Mirrors tt-media-server/Dockerfile RUN ... uv pip install ... -r
-        # requirements.txt, with two deliberate differences:
-        #   - no --no-cache-dir: irrelevant in CI, slows reruns.
-        #   - no `|| (grep -v pyluwen ...)` fallback: that fallback in the
-        #     Dockerfile silently masks resolver failures, which is exactly
-        #     the failure mode this gate exists to catch (e.g. the 2026-04
-        #     `lightning` PyPI quarantine that broke the base image build).
+        # Mirrors tt-media-server/Dockerfile, but drops its `|| (grep -v
+        # pyluwen ...)` fallback — that fallback silently masks resolver
+        # failures, which is the class of bug this gate exists to catch.
         run: |
           uv pip install \
             --index-strategy unsafe-best-match \

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       should-test: ${{ steps.filter.outputs.code }}
       cpp-server: ${{ steps.filter.outputs.cpp_server }}
+      media-server-deps: ${{ steps.filter.outputs.media_server_deps }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -26,6 +27,11 @@ jobs:
               - '.github/workflows/*.yml'
             cpp_server:
               - 'tt-media-server/cpp_server/**'
+            media_server_deps:
+              - 'tt-media-server/requirements.txt'
+              - 'tt-media-server/uv-overrides.txt'
+              - 'tt-media-server/fix_dependencies.sh'
+              - 'tt-media-server/Dockerfile*'
 
   lint:
     needs: detect-changes
@@ -48,6 +54,60 @@ jobs:
 
       - name: Run ruff format check
         run: ruff format --check .
+
+  verify-media-server-install:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.media-server-deps == 'true' }}
+    name: Verify Media Server Dep Install
+    runs-on: ubuntu-latest
+    # Hard cap: install resolves + downloads in ~4–7 min on a cold cache. The
+    # 15 min ceiling exists so a hung/looping resolver fails CI fast.
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: tt-media-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.10"
+          enable-cache: true
+
+      - name: Create venv and seed tt-metal-equivalent pins
+        # The runtime install runs inside tt-metal's python_env, which already
+        # carries numpy<2 (tt-metal/requirements-dev.txt). Seed an equivalent
+        # numpy here so this gate behaves close to the Dockerfile install layer
+        # without pulling the heavyweight tt-metal base image.
+        #
+        # The exact constraint lives in uv-overrides.txt — we install through
+        # the same overrides file so there is a single source of truth. If
+        # tt-metal moves the numpy pin and uv-overrides.txt follows, this step
+        # picks the new constraint up automatically with no workflow edit.
+        run: |
+          uv venv
+          uv pip install --overrides uv-overrides.txt numpy
+
+      - name: Install media-server requirements (strict, no fallback)
+        # Mirrors tt-media-server/Dockerfile RUN ... uv pip install ... -r
+        # requirements.txt, with two deliberate differences:
+        #   - no --no-cache-dir: irrelevant in CI, slows reruns.
+        #   - no `|| (grep -v pyluwen ...)` fallback: that fallback in the
+        #     Dockerfile silently masks resolver failures, which is exactly
+        #     the failure mode this gate exists to catch (e.g. the 2026-04
+        #     `lightning` PyPI quarantine that broke the base image build).
+        run: |
+          uv pip install \
+            --index-strategy unsafe-best-match \
+            --overrides uv-overrides.txt \
+            -r requirements.txt
+
+      - name: Run fix_dependencies.sh
+        # Validates the post-install CPU-torch swap-in still resolves.
+        run: |
+          chmod +x fix_dependencies.sh
+          ./fix_dependencies.sh
 
   unit-tests:
     needs: detect-changes
@@ -1622,6 +1682,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - lint
+      - verify-media-server-install
       - unit-tests
       - forge-runner-cpu-tests
       - llm-streaming-performance
@@ -1638,6 +1699,7 @@ jobs:
           STATUS=0
           declare -A JOBS=(
             [lint]="${{ needs.lint.result }}"
+            [verify-media-server-install]="${{ needs.verify-media-server-install.result }}"
             [unit-tests]="${{ needs.unit-tests.result }}"
             [forge-runner-cpu-tests]="${{ needs.forge-runner-cpu-tests.result }}"
             [llm-streaming-performance]="${{ needs.llm-streaming-performance.result }}"

--- a/tt-media-server/fix_dependencies.sh
+++ b/tt-media-server/fix_dependencies.sh
@@ -8,7 +8,8 @@ uv pip uninstall xformers diffusers torch torchvision torchaudio
 # Install CPU-only versions
 uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
 
-# Install xformers withouth and CUDA sub-depts
+# Install xformers without its CUDA sub-deps (--no-deps avoids re-pulling
+# the CUDA torch wheels we just replaced with CPU-only ones above).
 uv pip install xformers --no-deps
 
 uv pip install diffusers

--- a/tt-media-server/uv-overrides.txt
+++ b/tt-media-server/uv-overrides.txt
@@ -24,3 +24,5 @@
 #    declares numpy>=2.0.2, which would force a venv-wide numpy upgrade and
 #    break tt-metal's pin. whisperx is observed to run fine on numpy<2;
 #    overriding here keeps the venv consistent with tt-metal.
+numpy>=1.24.4,<2
+lightning @ https://files.pythonhosted.org/packages/0f/dd/86bb3bebadcdbc6e6e5a63657f0a03f74cd065b5ea965896679f76fec0b4/lightning-2.5.5.tar.gz

--- a/tt-media-server/uv-overrides.txt
+++ b/tt-media-server/uv-overrides.txt
@@ -24,5 +24,3 @@
 #    declares numpy>=2.0.2, which would force a venv-wide numpy upgrade and
 #    break tt-metal's pin. whisperx is observed to run fine on numpy<2;
 #    overriding here keeps the venv consistent with tt-metal.
-numpy>=1.24.4,<2
-lightning @ https://files.pythonhosted.org/packages/0f/dd/86bb3bebadcdbc6e6e5a63657f0a03f74cd065b5ea965896679f76fec0b4/lightning-2.5.5.tar.gz


### PR DESCRIPTION
## Why
[PR #3262](https://github.com/tenstorrent/tt-inference-server/pull/3262) merged with a clean test-gate but immediately broke the base docker image build downstream in tt-shield ([PR #3275](https://github.com/tenstorrent/tt-inference-server/pull/3275) was the forced-merge fix). The root cause was PyPI quarantining the `lightning` project, making `pyannote-audio` (a transitive dep of `whisperx==3.4.3`) unresolvable. The break was invisible to test-gate because no job in test-gate ever runs `uv pip install -r tt-media-server/requirements.txt` — the Dockerfile install only runs in tt-shield's post-merge image build.

## What
Adds a new `verify-media-server-install` job that runs the exact install
command from `tt-media-server/Dockerfile` whenever a PR touches:
- `tt-media-server/requirements.txt`
- `tt-media-server/uv-overrides.txt`
- `tt-media-server/fix_dependencies.sh`
- `tt-media-server/Dockerfile*`

The job:
- runs on `ubuntu-latest` in parallel with the rest of test-gate (only `needs: detect-changes`),
- seeds `numpy<2` into a fresh venv to mimic tt-metal's pre-installed venv state (which `uv-overrides.txt` assumes as a precondition),
- runs `uv pip install --index-strategy unsafe-best-match --overrides uv-overrides.txt -r requirements.txt` strictly (no `pyluwen` fallback — that fallback masks the exact failure class this gate catches),
- runs `fix_dependencies.sh` to validate the CPU-torch post-install swap,
- is wired into `ci-gate` so it can block merge.

Note:
This gate runs against a stock ubuntu-latest venv with a numpy seed, not the full tt-metal `python_env`. Conflicts that depend on other tt-metal pins beyond numpy could still slip through. Closing that residual gap would mean pulling the tt-metal base image and running inside it.