### PR TITLE
build: vendor Drogon via FetchContent

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -20,8 +20,35 @@ endif()
 # Set only after FetchContent so _deps (tokenizers_cpp, sentencepiece, protobuf, etc.) are excluded.
 option(CLANG_TIDY "Run clang-tidy during build" OFF)
 
-# Find Drogon and JsonCpp (tokenizer_config parsing)
-find_package(Drogon REQUIRED)
+# Drogon HTTP framework. Vendored via FetchContent so the build is
+# self-contained (no sudo required). BUILD_POSTGRESQL/MYSQL/SQLITE/REDIS=OFF
+# prevent Drogon from auto-detecting those client libs at configure time and
+# transitively linking them into our binary via Drogon::Drogon based on
+# whatever happens to be installed on the build machine.
+include(FetchContent)
+set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(BUILD_CTL OFF CACHE BOOL "" FORCE)
+set(BUILD_YAML_CONFIG OFF CACHE BOOL "" FORCE)
+set(BUILD_POSTGRESQL OFF CACHE BOOL "" FORCE)
+set(BUILD_MYSQL OFF CACHE BOOL "" FORCE)
+set(BUILD_SQLITE OFF CACHE BOOL "" FORCE)
+set(BUILD_REDIS OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    drogon
+    GIT_REPOSITORY https://github.com/drogonframework/drogon.git
+    GIT_TAG        v1.9.12
+    GIT_SHALLOW    TRUE
+    GIT_SUBMODULES_RECURSE TRUE
+)
+FetchContent_MakeAvailable(drogon)
+# Drogon's DrogonConfig.cmake (used by find_package) creates the Drogon::Drogon
+# alias; the add_subdirectory path doesn't, so define it ourselves to keep the
+# target_link_libraries(... Drogon::Drogon) call sites unchanged.
+if(NOT TARGET Drogon::Drogon)
+    add_library(Drogon::Drogon ALIAS drogon)
+endif()
+
+# JsonCpp (tokenizer_config parsing)
 find_package(jsoncpp REQUIRED)
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 

--- a/tt-media-server/cpp_server/README.md
+++ b/tt-media-server/cpp_server/README.md
@@ -873,27 +873,11 @@ With `LLM_DEVICE_BACKEND=mock`, the stub runner can be used to benchmark server 
 ### Prerequisites
 
 1. **CMake** >= 3.19
-2. **Drogon Framework** >= 1.8
-3. **C++20 compatible compiler** (GCC 10+, Clang 12+)
-4. **Boost** (headers; used for Boost.Interprocess in the LLM engine IPC queue).
-5. **JsonCpp** (used for tokenizer_config parsing).
+2. **C++20 compatible compiler** (GCC 10+, Clang 12+)
+3. **Boost** (headers; used for Boost.Interprocess in the LLM engine IPC queue).
+4. **JsonCpp** (used for tokenizer_config parsing).
 
-### Install Drogon (Ubuntu/Debian)
-
-```bash
-# Install dependencies
-sudo apt install git gcc g++ cmake libjsoncpp-dev uuid-dev \
-     openssl libssl-dev zlib1g-dev libbrotli-dev libboost-dev
-
-# Clone and build Drogon
-git clone https://github.com/drogonframework/drogon
-cd drogon
-git submodule update --init
-mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
-make -j$(nproc)
-sudo make install
-```
+Drogon and its trantor dependency are vendored via CMake `FetchContent` and built as part of the project — no system install required. Other system dependencies (jsoncpp, libuuid, openssl, zlib, boost headers, plus Rust for tokenizers-cpp) can be installed with `./install_dependencies.sh`.
 
 ### Build the Server
 
@@ -1012,14 +996,7 @@ To compare with the Python server:
 
 ### Build fails
 
-1. **Drogon not found:**
-  ```bash
-   # Install Drogon system-wide
-   cd /path/to/drogon/build
-   sudo make install
-   sudo ldconfig
-  ```
-2. **CMake too old:**
+1. **CMake too old:**
   ```bash
    cmake --version  # Need 3.19+
   ```

--- a/tt-media-server/cpp_server/build.sh
+++ b/tt-media-server/cpp_server/build.sh
@@ -118,49 +118,6 @@ if ! command -v cargo >/dev/null 2>&1; then
     fi
 fi
 
-# Check for Drogon
-DROGON_FOUND=0
-if pkg-config --exists drogon 2>/dev/null; then
-    DROGON_FOUND=1
-elif [ -f "/usr/local/lib/cmake/Drogon/DrogonConfig.cmake" ]; then
-    DROGON_FOUND=1
-elif [ -f "/usr/lib/cmake/Drogon/DrogonConfig.cmake" ]; then
-    DROGON_FOUND=1
-elif [ -f "/opt/homebrew/lib/cmake/Drogon/DrogonConfig.cmake" ]; then
-    DROGON_FOUND=1
-fi
-
-if [ "${DROGON_FOUND}" -eq 0 ]; then
-    echo ""
-    echo "Drogon not found. Installing dependencies..."
-    echo ""
-
-    # Check if we need to build Drogon from deps
-    DROGON_DIR="${SCRIPT_DIR}/deps/drogon"
-    if [ -d "${DROGON_DIR}" ]; then
-        echo "Building Drogon from ${DROGON_DIR}..."
-        mkdir -p "${DROGON_DIR}/build"
-        cd "${DROGON_DIR}/build"
-        cmake -DCMAKE_BUILD_TYPE=Release \
-              -DBUILD_EXAMPLES=OFF \
-              -DBUILD_CTL=OFF \
-              -DBUILD_YAML_CONFIG=OFF \
-              ..
-        NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
-        make -j"${NPROC}"
-        sudo make install
-        if [ "$(uname -s)" = "Linux" ]; then
-            sudo ldconfig
-        fi
-        cd "${SCRIPT_DIR}"
-    else
-        echo "Please install Drogon framework first:"
-        echo "  Ubuntu/Debian: sudo apt install libdrogon-dev"
-        echo "  Or build from source: https://github.com/drogonframework/drogon"
-        exit 1
-    fi
-fi
-
 # ---------------------------------------------------------------------------
 # Pre-fetch tokenizer files for all supported models
 # ---------------------------------------------------------------------------

--- a/tt-media-server/cpp_server/build_exabox.sh
+++ b/tt-media-server/cpp_server/build_exabox.sh
@@ -4,13 +4,15 @@
 #
 # Build cpp_server on exabox (no sudo, ephemeral /home).
 #
-# All local installs (jsoncpp, libuuid, Drogon, Rust) go to
+# All local installs (jsoncpp, libuuid, Rust) go to
 # /data/$USER/.local so they persist across compute nodes.
 # Only libboost-dev is expected to be a system package.
+# Drogon is vendored via CMake FetchContent (see CMakeLists.txt) — no local
+# install required.
 #
 # Usage:
 #   ./build_exabox.sh [OPTIONS]        # same flags as build.sh
-#   ./build_exabox.sh --install-deps   # one-time: build jsoncpp, libuuid, Drogon + install Rust
+#   ./build_exabox.sh --install-deps   # one-time: build jsoncpp, libuuid + install Rust
 #
 # After building, run the binary with:
 #   LD_LIBRARY_PATH=/data/$USER/.local/lib:$LD_LIBRARY_PATH \
@@ -62,7 +64,7 @@ while [[ $# -gt 0 ]]; do
             echo "Usage: $0 [OPTIONS]"
             echo ""
             echo "Exabox-specific options:"
-            echo "  --install-deps       One-time setup: build jsoncpp, libuuid, Drogon + install Rust to /data/\$USER/.local"
+            echo "  --install-deps       One-time setup: build jsoncpp, libuuid + install Rust to /data/\$USER/.local"
             echo ""
             echo "Build options (same as build.sh):"
             echo "  --debug              Debug build (default: Release)"
@@ -150,48 +152,6 @@ install_uuid() {
     echo "libuuid installed to ${LOCAL_PREFIX}"
 }
 
-install_drogon() {
-    local drogon_cmake="${LOCAL_PREFIX}/lib/cmake/Drogon/DrogonConfig.cmake"
-    if [ -f "${drogon_cmake}" ]; then
-        echo "Drogon already installed at ${LOCAL_PREFIX}"
-        return 0
-    fi
-
-    echo ""
-    echo "Building Drogon → ${LOCAL_PREFIX} ..."
-
-    local drogon_src="${SCRIPT_DIR}/deps/drogon"
-    local drogon_tmp=""
-    if [ -d "${drogon_src}" ]; then
-        echo "  Using bundled source: ${drogon_src}"
-    else
-        drogon_tmp="${_build_tmp}/drogon"
-        echo "  Cloning drogon v1.9.12 → ${drogon_tmp}"
-        git clone --depth 1 --branch v1.9.12 --recurse-submodules \
-            https://github.com/drogonframework/drogon.git "${drogon_tmp}"
-        drogon_src="${drogon_tmp}"
-    fi
-
-    mkdir -p "${drogon_src}/build" && cd "${drogon_src}/build"
-    cmake .. \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX="${LOCAL_PREFIX}" \
-        -DCMAKE_PREFIX_PATH="${LOCAL_PREFIX}" \
-        -DBUILD_EXAMPLES=OFF \
-        -DBUILD_CTL=OFF \
-        -DBUILD_YAML_CONFIG=OFF \
-        -DBUILD_POSTGRESQL=OFF \
-        -DBUILD_MYSQL=OFF \
-        -DBUILD_SQLITE=OFF \
-        -DBUILD_REDIS=OFF
-    make -j"${_nproc}"
-    make install
-    cd "${SCRIPT_DIR}"
-    [ -n "${drogon_tmp}" ] && rm -rf "${drogon_tmp}"
-
-    echo "Drogon installed to ${LOCAL_PREFIX}"
-}
-
 install_rust() {
     local cargo_bin="${CARGO_DIR}/bin/cargo"
     local rustup_cargo="${RUSTUP_DIR}/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo"
@@ -214,7 +174,6 @@ if [ "${INSTALL_DEPS}" -eq 1 ]; then
     trap 'rm -rf "${_build_tmp}"' EXIT
     install_jsoncpp
     install_uuid
-    install_drogon
     install_rust
     echo ""
     echo "=============================================="
@@ -226,7 +185,6 @@ fi
 
 # ── Verify prerequisites ─────────────────────────────────────────────────
 _missing=()
-[ ! -f "${LOCAL_PREFIX}/lib/cmake/Drogon/DrogonConfig.cmake" ] && _missing+=("Drogon")
 have_lib jsoncpp jsoncpp || _missing+=("jsoncpp")
 have_lib uuid uuid       || _missing+=("libuuid")
 if [ ${#_missing[@]} -gt 0 ]; then

--- a/tt-media-server/cpp_server/install_dependencies.sh
+++ b/tt-media-server/cpp_server/install_dependencies.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
-# cpp_server build deps: apt + Rust (if needed) + Drogon (if not found).
+# cpp_server build deps: apt + Rust (if needed). Drogon is vendored via
+# FetchContent in CMakeLists.txt — no system install required.
 # Optional: ./install_dependencies.sh --kafka for librdkafka when using -DKAFKA_ENABLED=ON.
 set -euo pipefail
 
@@ -60,28 +61,3 @@ if ! command -v cargo >/dev/null 2>&1; then
     fi
 fi
 
-drogon_found() {
-    pkg-config --exists drogon 2>/dev/null || [ -f /usr/local/lib/cmake/Drogon/DrogonConfig.cmake ] || [ -f /usr/lib/cmake/Drogon/DrogonConfig.cmake ]
-}
-if ! drogon_found; then
-    DROGON_TMP="/tmp/drogon_build"
-    rm -rf "${DROGON_TMP}"
-    git clone --depth 1 --branch v1.9.12 --recurse-submodules https://github.com/drogonframework/drogon.git "${DROGON_TMP}"
-    mkdir -p "${DROGON_TMP}/build" && cd "${DROGON_TMP}/build"
-    # Disable Drogon's optional ORM/DB modules. We don't use them, and
-    # leaving them on causes Drogon to auto-detect libpq/libmysqlclient/
-    # libsqlite3/libhiredis at configure time and link them transitively
-    # into our binary via Drogon::Drogon. That made the build artifact's
-    # runtime deps a function of whatever happened to be installed on the
-    # build runner — see PR history for the libpq.so.5-on-bench-runner
-    # incident this avoids.
-    cmake .. \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DBUILD_EXAMPLES=OFF -DBUILD_CTL=OFF -DBUILD_YAML_CONFIG=OFF \
-        -DBUILD_POSTGRESQL=OFF -DBUILD_MYSQL=OFF -DBUILD_SQLITE=OFF -DBUILD_REDIS=OFF
-    make -j"$(nproc 2>/dev/null || echo 4)"
-    $SUDO make install
-    [ "$(uname -s)" = "Linux" ] && $SUDO ldconfig
-    cd "${SCRIPT_DIR}" && rm -rf "${DROGON_TMP}"
-fi


### PR DESCRIPTION
Replace find_package(Drogon REQUIRED) with FetchContent_Declare pinned to v1.9.12, mirroring the BUILD_POSTGRESQL/MYSQL/SQLITE/REDIS=OFF flags from install_dependencies.sh so transitive ORM/DB client libs don't leak into the binary. Add add_library(Drogon::Drogon ALIAS drogon) since Drogon only defines that alias inside its install-time DrogonConfig.cmake, not when add_subdirectory'd.

Strip the matching Drogon install/detection blocks from install_dependencies.sh, build.sh, build_exabox.sh, and the README sections that pointed at sudo make install. Build is now self-contained: no sudo required, works on Exabox without the /data/$USER/.local Drogon workaround that build_exabox.sh was carrying.