### PR TITLE
Move tool-calling validation to API layer

### DIFF
--- a/tt-media-server/cpp_server/include/domain/llm/chat_completion_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/chat_completion_request.hpp
@@ -319,6 +319,26 @@ struct ChatCompletionRequest : BaseRequest {
       throw std::invalid_argument("tool_choice='" + type +
                                   "' requires non-empty 'tools'");
     }
+
+    if (type == "function") {
+      if (!toolChoice.function.has_value()) {
+        throw std::invalid_argument(
+            "tool_choice.function.name is required when type is 'function'. "
+            "Expected format: {\"type\": \"function\", \"function\": "
+            "{\"name\": \"function_name\"}}");
+      }
+
+      const auto& functionName = toolChoice.function.value();
+      const auto& tools = req.tools.value();
+      const bool found = std::any_of(
+          tools.begin(), tools.end(), [&](const tool_calls::Tool& tool) {
+            return tool.functionDefinition.name == functionName;
+          });
+      if (!found) {
+        throw std::invalid_argument("tool_choice.function.name '" +
+                                    functionName + "' not found in tools");
+      }
+    }
   }
 
   static void validateToolMessages(const ChatCompletionRequest& req) {

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -114,57 +114,6 @@ std::vector<tt::worker::WorkerInfo> LLMService::getWorkerInfo() const {
 void LLMService::preProcess(LLMRequest& request) const {
   BaseService::preProcess(request);
 
-  if (request.tool_choice.has_value()) {
-    const auto& type = request.tool_choice->type;
-    if (type != "auto" && type != "none" && type != "function" &&
-        type != "required") {
-      throw std::invalid_argument("tool_choice='" + type +
-                                  "' is not yet supported by this server; only "
-                                  "'auto', 'none', 'required', and "
-                                  "'function' are currently implemented");
-    }
-
-    // Validate named function call
-    if (type == "function") {
-      if (!request.tool_choice->function.has_value() ||
-          request.tool_choice->function.value().empty()) {
-        throw std::invalid_argument(
-            "tool_choice.function.name is required when type is 'function'. "
-            "Expected format: {\"type\": \"function\", \"function\": "
-            "{\"name\": \"function_name\"}}");
-      }
-
-      if (!request.tools.has_value()) {
-        throw std::invalid_argument(
-            "tools array is required when tool_choice type is 'function'");
-      }
-
-      // Validate function name exists in tools
-      const auto& functionName = request.tool_choice->function.value();
-      bool found = false;
-      for (const auto& tool : request.tools.value()) {
-        if (tool.functionDefinition.name == functionName) {
-          found = true;
-          break;
-        }
-      }
-
-      if (!found) {
-        throw std::invalid_argument("tool_choice.function.name '" +
-                                    functionName + "' not found in tools");
-      }
-    }
-
-    // Validate required tool choice
-    if (type == "required") {
-      if (!request.tools.has_value() || request.tools->empty()) {
-        throw std::invalid_argument(
-            "tools array is required and must not be empty when tool_choice "
-            "type is 'required'");
-      }
-    }
-  }
-
   if (std::holds_alternative<std::string>(request.prompt)) {
     auto text = std::get<std::string>(request.prompt);
     static auto cfg = tt::utils::tokenizers::getTokenizerConfig();

--- a/tt-media-server/cpp_server/tests/test_chat_completion_request.cpp
+++ b/tt-media-server/cpp_server/tests/test_chat_completion_request.cpp
@@ -253,6 +253,64 @@ void testToolChoiceFunction() {
   std::cout << "✅ Test passed!\n";
 }
 
+void testToolChoiceFunctionMissingNameRejected() {
+  std::cout << "\n=== Testing tool_choice=function Without function.name "
+               "(Should Reject) ===\n";
+
+  Json::Value json = createBasicRequestJson();
+  json["tools"].append(createToolJson("get_weather", "Get weather"));
+
+  Json::Value toolChoice;
+  toolChoice["type"] = "function";
+  // No "function" field
+  json["tool_choice"] = toolChoice;
+
+  bool exceptionThrown = false;
+  try {
+    ChatCompletionRequest::fromJson(json, 1);
+  } catch (const std::invalid_argument& e) {
+    exceptionThrown = true;
+    std::string errorMsg = e.what();
+    assert(errorMsg.find("tool_choice.function.name is required") !=
+           std::string::npos);
+  }
+
+  assert(exceptionThrown &&
+         "Should throw when tool_choice=function has no function.name");
+
+  std::cout << "✓ tool_choice=function without name correctly rejected\n";
+  std::cout << "✅ Test passed!\n";
+}
+
+void testToolChoiceFunctionUnknownNameRejected() {
+  std::cout << "\n=== Testing tool_choice=function With Unknown function.name "
+               "(Should Reject) ===\n";
+
+  Json::Value json = createBasicRequestJson();
+  json["tools"].append(createToolJson("get_weather", "Get weather"));
+
+  Json::Value toolChoice;
+  toolChoice["type"] = "function";
+  toolChoice["function"]["name"] = "missing_tool";
+  json["tool_choice"] = toolChoice;
+
+  bool exceptionThrown = false;
+  try {
+    ChatCompletionRequest::fromJson(json, 1);
+  } catch (const std::invalid_argument& e) {
+    exceptionThrown = true;
+    std::string errorMsg = e.what();
+    assert(errorMsg.find("not found in tools") != std::string::npos);
+    assert(errorMsg.find("missing_tool") != std::string::npos);
+  }
+
+  assert(exceptionThrown &&
+         "Should throw when tool_choice.function.name not in tools");
+
+  std::cout << "✓ tool_choice=function with unknown name correctly rejected\n";
+  std::cout << "✅ Test passed!\n";
+}
+
 void testToolChoiceRequired() {
   std::cout << "\n=== Testing tool_choice=required ===\n";
 
@@ -729,6 +787,8 @@ int main() {
     testToolChoiceNone();
     testToolChoiceAuto();
     testToolChoiceFunction();
+    testToolChoiceFunctionMissingNameRejected();
+    testToolChoiceFunctionUnknownNameRejected();
     testToolChoiceRequired();
     testToolChoiceNoneWithoutTools();
     testToolChoiceNoneWithEmptyToolsArray();


### PR DESCRIPTION
Moves the tool_choice validation block out of LLMService::preProcess into ChatCompletionRequest::fromJson (via validateToolFields), so malformed requests are rejected at JSON parse time before any session or slot is acquired.