### PR TITLE
Adding test categorization& suite-config  to v2

### DIFF
--- a/tt-inference-server-v2/test_module/server_tests_config.json
+++ b/tt-inference-server-v2/test_module/server_tests_config.json
@@ -1,0 +1,741 @@
+{
+    "_version": "1.0.0",
+    "_description": "Server tests schema configuration. Test suites are in test_suites/*.json",
+    "model_categories": {
+        "IMAGE": [
+            "stable-diffusion-xl-base-1.0",
+            "stable-diffusion-xl-base-1.0-img-2-img",
+            "stable-diffusion-xl-1.0-inpainting-0.1",
+            "stable-diffusion-3.5-large",
+            "FLUX.1-dev",
+            "FLUX.1-schnell",
+            "Motif-Image-6B-Preview"
+        ],
+        "AUDIO": [
+            "distil-large-v3",
+            "whisper-large-v3"
+        ],
+        "CNN": [
+            "resnet-50",
+            "vovnet",
+            "mobilenetv2",
+            "efficientnet",
+            "segformer",
+            "unet",
+            "vit"
+        ],
+        "EMBEDDING": [
+            "bge-large-en-v1.5",
+            "Qwen3-Embedding-4B",
+            "Qwen3-Embedding-8B",
+            "bge-m3"
+        ],
+        "TTS": [
+            "speecht5_tts"
+        ],
+        "VIDEO": [
+            "Wan2.2-T2V-A14B-Diffusers",
+            "Wan2.2-I2V-A14B-Diffusers",
+            "mochi-1-preview"
+        ]
+    },
+    "available_markers": {
+        "test_types": {
+            "load": "Load testing with concurrent requests",
+            "param": "Parameter validation tests",
+            "e2e": "Full system tests covering complete workflows",
+            "eval": "Model evaluation tests"
+        },
+        "performance_characteristics": {
+            "slow": "Tests taking >30 seconds to complete",
+            "heavy": "Resource-intensive tests (large models, high memory)",
+            "fast": "Tests completing in <10 seconds"
+        },
+        "hardware_targets": {
+            "n150": "Tests for N150 device (1 chip)",
+            "n300": "Tests for N300 device (2 chips)",
+            "t3k": "Tests for T3K device (4 chips)",
+            "galaxy": "Tests for Galaxy device (32 chips)",
+            "p150": "Tests for P150 device (1 chip)",
+            "p150x4": "Tests for P150x4 device (4 chips)",
+            "p150x8": "Tests for P150x8 device (8 chips)",
+            "p300": "Tests for P300 device (2 chips)",
+            "p300x2": "Tests for P300x2 device (4 chips)"
+        },
+        "model_categories": {
+            "image": "Image generation/processing model tests",
+            "audio": "Audio transcription model tests",
+            "cnn": "CNN model tests",
+            "llm": "Large Language Model tests",
+            "embedding": "Embedding model tests",
+            "tts": "Text-to-speech model tests",
+            "video": "Video generation model tests"
+        },
+        "specific_models": {
+            "sdxl": "Stable Diffusion XL tests",
+            "sdxl_img2img": "Stable Diffusion XL img2img tests",
+            "sdxl_inpaint": "Stable Diffusion XL inpainting tests",
+            "sd35": "Stable Diffusion 3.5 tests",
+            "whisper": "Whisper model tests",
+            "distil_whisper": "Distil Whisper model tests",
+            "flux_dev": "FLUX.1-dev model tests",
+            "flux_schnell": "FLUX.1-schnell model tests",
+            "motif": "Motif image generation model tests",
+            "bge": "BGE embedding model tests",
+            "qwen3_emb": "Qwen3 embedding model tests",
+            "speecht5": "SpeechT5 TTS model tests",
+            "wan": "Wan video generation model tests",
+            "wan_i2v": "Wan image-to-video generation model tests",
+            "mochi": "Mochi video generation model tests",
+            "mobilenetv2": "MobileNetV2 CNN model tests",
+            "bge_m3": "BGE-M3 embedding model tests"
+        }
+    },
+    "model_configs": {
+        "mobilenetv2": {
+            "weights": [
+                "mobilenetv2"
+            ],
+            "category": "CNN",
+            "compatible_devices": [
+                "n150",
+                "n300"
+            ]
+        },
+        "resnet": {
+            "id_name": "resnet-50",
+            "weights": [
+                "resnet-50"
+            ],
+            "category": "CNN",
+            "compatible_devices": [
+                "n150",
+                "n300"
+            ]
+        },
+        "efficientnet": {
+            "weights": [
+                "efficientnet"
+            ],
+            "category": "CNN",
+            "compatible_devices": [
+                "n150"
+            ]
+        },
+        "segformer": {
+            "weights": [
+                "segformer"
+            ],
+            "category": "CNN",
+            "compatible_devices": [
+                "n150"
+            ]
+        },
+        "unet": {
+            "weights": [
+                "unet"
+            ],
+            "category": "CNN",
+            "compatible_devices": [
+                "n150"
+            ]
+        },
+        "vit": {
+            "weights": [
+                "vit"
+            ],
+            "category": "CNN",
+            "compatible_devices": [
+                "n150"
+            ]
+        },
+        "vovnet": {
+            "weights": [
+                "vovnet"
+            ],
+            "category": "CNN",
+            "compatible_devices": [
+                "n150"
+            ]
+        },
+        "distil_whisper": {
+            "id_name": "distil-whisper",
+            "weights": [
+                "distil-large-v3"
+            ],
+            "category": "AUDIO",
+            "compatible_devices": [
+                "n150",
+                "t3k",
+                "galaxy"
+            ]
+        },
+        "whisper": {
+            "weights": [
+                "whisper-large-v3"
+            ],
+            "category": "AUDIO",
+            "compatible_devices": [
+                "n150",
+                "t3k",
+                "galaxy"
+            ]
+        },
+        "wan": {
+            "weights": [
+                "Wan2.2-T2V-A14B-Diffusers"
+            ],
+            "category": "VIDEO",
+            "compatible_devices": [
+                "t3k",
+                "galaxy",
+                "p150x4",
+                "p150x8",
+                "p300x2"
+            ]
+        },
+        "wan_i2v": {
+            "id_name": "wan-i2v",
+            "weights": [
+                "Wan2.2-I2V-A14B-Diffusers"
+            ],
+            "category": "VIDEO",
+            "compatible_devices": [
+                "t3k",
+                "galaxy",
+                "p150x4",
+                "p150x8",
+                "p300x2"
+            ]
+        },
+        "mochi": {
+            "weights": [
+                "mochi-1-preview"
+            ],
+            "category": "VIDEO",
+            "compatible_devices": [
+                "t3k",
+                "galaxy",
+                "p150x4",
+                "p150x8",
+                "p300x2"
+            ]
+        },
+        "sdxl": {
+            "weights": [
+                "stable-diffusion-xl-base-1.0"
+            ],
+            "category": "IMAGE",
+            "compatible_devices": [
+                "n150",
+                "t3k",
+                "galaxy",
+                "n300",
+                "p150x8",
+                "p300x2"
+            ]
+        },
+        "sdxl_img2img": {
+            "id_name": "sdxl-img2img",
+            "weights": [
+                "stable-diffusion-xl-base-1.0-img-2-img"
+            ],
+            "category": "IMAGE",
+            "compatible_devices": [
+                "n150",
+                "t3k",
+                "galaxy"
+            ]
+        },
+        "sdxl_inpaint": {
+            "id_name": "sdxl-inpaint",
+            "weights": [
+                "stable-diffusion-xl-1.0-inpainting-0.1"
+            ],
+            "category": "IMAGE",
+            "compatible_devices": [
+                "n150",
+                "t3k",
+                "galaxy"
+            ]
+        },
+        "sd35": {
+            "weights": [
+                "stable-diffusion-3.5-large"
+            ],
+            "category": "IMAGE",
+            "compatible_devices": [
+                "t3k",
+                "galaxy"
+            ]
+        },
+        "flux_dev": {
+            "id_name": "flux-dev",
+            "weights": [
+                "FLUX.1-dev"
+            ],
+            "category": "IMAGE",
+            "compatible_devices": [
+                "t3k",
+                "galaxy",
+                "p150x4",
+                "p150x8",
+                "p300",
+                "p300x2"
+            ]
+        },
+        "flux_schnell": {
+            "id_name": "flux-schnell",
+            "weights": [
+                "FLUX.1-schnell"
+            ],
+            "category": "IMAGE",
+            "compatible_devices": [
+                "t3k",
+                "galaxy",
+                "p150x4",
+                "p150x8",
+                "p300",
+                "p300x2"
+            ]
+        },
+        "motif": {
+            "weights": [
+                "Motif-Image-6B-Preview"
+            ],
+            "category": "IMAGE",
+            "compatible_devices": [
+                "t3k",
+                "galaxy",
+                "p150x4",
+                "p150x8",
+                "p300x2"
+            ]
+        },
+        "bge": {
+            "weights": [
+                "bge-large-en-v1.5"
+            ],
+            "category": "EMBEDDING",
+            "compatible_devices": [
+                "n150",
+                "t3k",
+                "galaxy"
+            ]
+        },
+        "qwen3_emb": {
+            "id_name": "qwen3-emb-8b",
+            "weights": [
+                "Qwen3-Embedding-8B",
+                "Qwen3-Embedding-4B"
+            ],
+            "category": "EMBEDDING",
+            "compatible_devices": [
+                "n150",
+                "t3k",
+                "galaxy"
+            ]
+        },
+        "speecht5": {
+            "weights": [
+                "speecht5_tts"
+            ],
+            "category": "TTS",
+            "compatible_devices": [
+                "n150",
+                "p150"
+            ]
+        }
+    },
+    "hardware_defaults": {
+        "n150": {
+            "num_of_devices": 1,
+            "liveness_retry_attempts": 80
+        },
+        "n300": {
+            "num_of_devices": 2,
+            "liveness_retry_attempts": 100
+        },
+        "t3k": {
+            "num_of_devices": 4,
+            "liveness_retry_attempts": 120
+        },
+        "galaxy": {
+            "num_of_devices": 32,
+            "liveness_retry_attempts": 220
+        },
+        "p150": {
+            "num_of_devices": 1,
+            "liveness_retry_attempts": 80
+        },
+        "p150x4": {
+            "num_of_devices": 4,
+            "liveness_retry_attempts": 120
+        },
+        "p150x8": {
+            "num_of_devices": 8,
+            "liveness_retry_attempts": 140
+        },
+        "p300": {
+            "num_of_devices": 2,
+            "liveness_retry_attempts": 100
+        },
+        "p300x2": {
+            "num_of_devices": 4,
+            "liveness_retry_attempts": 120
+        }
+    },
+    "prerequisite_tests": [
+        {
+            "name": "DeviceLivenessTest",
+            "module": "test_module.health_tests.device_liveness_test",
+            "description": "Test for device liveness checks - runs before all other tests",
+            "markers": [
+                "fast",
+                "prerequisite"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_delay": 10,
+                "break_on_failure": true,
+                "mock_mode": false
+            },
+            "_comment": "retry_attempts and num_of_devices derived from hardware_defaults"
+        },
+        {
+            "name": "LoggerForkSafetyTest",
+            "module": "test_module.unit_tests.logger_fork_safety_test",
+            "description": "Test for logging fork safety to prevent deadlocks",
+            "markers": [
+                "fast",
+                "prerequisite"
+            ],
+            "test_config": {
+                "test_timeout": 60,
+                "retry_attempts": 1,
+                "retry_delay": 5,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        }
+    ],
+    "test_templates": {
+        "ImageGenerationLoadTest": {
+            "module": "test_module.load_param_tests.image_generation_load_test",
+            "markers": [
+                "load",
+                "e2e",
+                "slow",
+                "heavy"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "ImageGenerationParamTest": {
+            "module": "test_module.load_param_tests.image_generation_param_test",
+            "markers": [
+                "param",
+                "e2e",
+                "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "Img2ImgGenerationParamTest": {
+            "module": "test_module.load_param_tests.img2img_generation_param_test",
+            "markers": [
+                "param",
+                "e2e",
+                "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "InpaintingGenerationParamTest": {
+            "module": "test_module.load_param_tests.inpainting_generation_param_test",
+            "markers": [
+                "param",
+                "e2e",
+                "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "ImageGenerationEvalsTest": {
+            "module": "test_module.eval_tests.image_generation_eval_test",
+            "markers": [
+                "eval",
+                "e2e",
+                "slow",
+                "heavy"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "ImageGenerationLoraLoadTest": {
+            "module": "test_module.load_param_tests.image_generation_lora_load_test",
+            "markers": [
+                "load",
+                "e2e",
+                "slow",
+                "heavy"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "AudioTranscriptionLoadTest": {
+            "module": "test_module.load_param_tests.audio_transcription_load_test",
+            "markers": [
+                "load",
+                "e2e",
+                "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "AudioTranscriptionParamTest": {
+            "module": "test_module.load_param_tests.audio_transcription_param_test",
+            "markers": [
+                "param",
+                "e2e",
+                "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "AudioTranscriptionLoadDp2Chunk5Test": {
+            "module": "test_module.load_param_tests.audio_transcription_load_dp2_chunk5_test",
+            "markers": [
+                "load",
+                "e2e",
+                "slow",
+                "heavy"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "AudioTranscriptionLoadDp2Chunk30Test": {
+            "module": "test_module.load_param_tests.audio_transcription_load_dp2_chunk30_test",
+            "markers": [
+                "load",
+                "e2e",
+                "slow",
+                "heavy"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "DeviceStabilityTest": {
+            "module": "test_module.stability_tests.device_stability_test",
+            "markers": [
+                "stability",
+                "e2e",
+                "slow",
+                "heavy"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "CnnLoadTest": {
+            "module": "test_module.load_param_tests.cnn_load_test",
+            "markers": [
+                "load",
+                "e2e"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "CnnParamTest": {
+            "module": "test_module.load_param_tests.cnn_param_test",
+            "markers": [
+                "param",
+                "e2e"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "EmbeddingLoadTest": {
+            "module": "test_module.load_param_tests.embedding_load_test",
+            "markers": [
+                "load",
+                "e2e"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "SpeechT5TTSTest": {
+            "module": "test_module.integration_tests.speecht5_tts_test",
+            "markers": [
+                "e2e",
+                "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "TestTTSServerHealth": {
+            "module": "test_module.load_param_tests.tts_load_test",
+            "markers": [
+                "load",
+                "e2e"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "TTSParamTest": {
+            "module": "test_module.load_param_tests.tts_param_test",
+            "markers": [
+                "param",
+                "e2e"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "TTSIntegrationTest": {
+            "module": "test_module.integration_tests.tts_integration_test",
+            "markers": [
+                "e2e",
+                "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "VideoGenerationLoadTest": {
+            "module": "test_module.load_param_tests.video_generation_load_test",
+            "markers": [
+                "load",
+                "e2e",
+                "slow",
+                "heavy"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "VideoGenerationParamTest": {
+            "module": "test_module.load_param_tests.video_generation_param_test",
+            "markers": [
+                "param",
+                "e2e",
+                "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "VideoGenerationI2VTest": {
+            "module": "test_module.load_param_tests.video_generation_i2v_test",
+            "markers": [
+                "e2e",
+                "slow",
+                "heavy"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 1,
+                "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        }
+    },
+    "_comment": "test_suites are loaded from test_suites/*.json files",
+    "test_suites": []
+}

--- a/tt-inference-server-v2/test_module/test_categorization_system/TEST_MARKING_SYSTEM.md
+++ b/tt-inference-server-v2/test_module/test_categorization_system/TEST_MARKING_SYSTEM.md
@@ -1,0 +1,429 @@
+# Test Categorization and Marking System
+
+## Overview
+
+This document describes the test marking system implemented for the TT Inference Server test suite. The system enables selective test execution based on test characteristics, hardware requirements, and model categories.
+
+## Architecture
+
+The marking system is implemented through:
+
+1. **Configuration v2.0** in `server_tests_config.json` with:
+   - `test_templates`: Reusable test definitions with default markers
+   - `test_suites`: Model/device specific configurations
+   - `prerequisite_tests`: Tests that run before all others (DeviceLivenessTest)
+   - `hardware_defaults`: Device-specific defaults (num_devices, retry_attempts)
+   - `model_categories`: Category to model mappings
+
+2. **TestFilter** in `test_categorization_system/test_filter.py` for programmatic test selection with:
+   - Auto-derivation of markers from context (model, device, category)
+   - Prerequisite test injection
+   - Method chaining for filter composition
+
+3. **CLI Support** in `run.py` with marker-based filtering arguments
+
+## Key Features
+
+### Auto-Derived Markers
+
+Markers are automatically derived from context, reducing manual configuration:
+
+- **Model category** → `image`, `audio`, `cnn`, `llm`
+- **Specific model** → `sdxl`, `whisper`, `distil_whisper`, etc.
+- **Hardware target** → `n150`, `n300`, `t3k`, `galaxy`
+- **Template markers** → `load`, `param`, `smoke`, etc.
+
+### Prerequisite Tests
+
+DeviceLivenessTest automatically runs before all other tests for each model/device combination. This ensures hardware is ready before running actual tests.
+
+To skip prerequisites:
+```bash
+python run.py --model sdxl --device n150 --skip-prerequisites
+```
+
+### Test Templates
+
+Common test configurations are defined once in `test_templates` and referenced in test suites:
+
+```json
+"test_templates": {
+    "ImageGenerationLoadTest": {
+        "module": "tests.server_tests.test_cases.image_generation_load_test",
+        "markers": ["load", "e2e", "slow", "heavy"],
+        "test_config": {
+            "test_timeout": 3600,
+            "retry_attempts": 1
+        }
+    }
+}
+```
+
+Test suites reference templates with overrides:
+```json
+{
+    "template": "ImageGenerationLoadTest",
+    "description": "Test image generation time for 20 iterations",
+    "targets": {
+        "num_inference_steps": 20,
+        "image_generation_time": 10
+    }
+}
+```
+
+## Marker Categories
+
+### Test Types
+| Marker | Description | Use Case |
+|--------|-------------|----------|
+| `unit` | Fast, isolated tests | Development feedback loops |
+| `integration` | Medium-speed tests with local dependencies | Pre-commit validation |
+| `load` | Load testing with concurrent requests | Performance validation |
+| `param` | Parameter validation tests | API contract testing |
+| `functional` | Functional correctness tests | Feature verification |
+| `smoke` | Quick sanity checks | Basic functionality |
+| `e2e` | Full system tests | Complete workflows |
+| `stability` | Long-running stability tests | Reliability validation |
+| `eval` | Model evaluation tests | Quality metrics |
+
+### Performance Characteristics
+| Marker | Description |
+|--------|-------------|
+| `slow` | Tests taking >30 seconds |
+| `heavy` | Resource-intensive tests |
+| `fast` | Tests completing in <10 seconds |
+
+### Hardware Targets
+| Marker | Description |
+|--------|-------------|
+| `n150` | N150 device (1 chip) |
+| `n300` | N300 device (2 chips) |
+| `t3k` | T3K device (4 chips) |
+| `galaxy` | Galaxy device (32 chips) |
+
+### Model Categories
+| Marker | Description |
+|--------|-------------|
+| `image` | Image generation/processing |
+| `audio` | Audio transcription |
+| `cnn` | CNN models |
+| `llm` | Large Language Models |
+
+### Specific Models
+| Marker | Description |
+|--------|-------------|
+| `sdxl` | Stable Diffusion XL |
+| `sdxl_img2img` | SDXL img2img |
+| `sdxl_inpaint` | SDXL inpainting |
+| `sd35` | Stable Diffusion 3.5 |
+| `whisper` | Whisper model |
+| `distil_whisper` | Distil Whisper |
+
+## Usage Examples
+
+### Use Case 1: Run All IMAGE/AUDIO Tests on Specific Hardware
+
+```bash
+# All IMAGE tests on N150
+python run.py --model-category IMAGE --device n150
+
+# All IMAGE and AUDIO tests on all hardware
+python run.py --model-category IMAGE AUDIO
+
+# Programmatically
+from tests.server_tests.test_categorization_system import TestFilter
+
+filter = TestFilter()
+tests = filter.filter_by_model_category(["IMAGE", "AUDIO"]) \
+              .filter_by_device("n150") \
+              .get_tests()
+```
+
+### Use Case 2: Run Specific Model on Specific Hardware with Category
+
+```bash
+# SDXL load tests on N150
+python run.py --model stable-diffusion-xl-base-1.0 --device n150 --markers load
+
+# Programmatically
+filter = TestFilter()
+tests = filter.filter_by_model("stable-diffusion-xl-base-1.0") \
+              .filter_by_device("n150") \
+              .filter_by_markers(["load"]) \
+              .get_tests()
+```
+
+### Use Case 3: Run Specific Tests with Full Filtering
+
+```bash
+# Specific test class for SDXL on N150
+python run.py --model stable-diffusion-xl-base-1.0 --device n150 --markers load --test-name ImageGenerationLoadTest
+
+# Programmatically
+filter = TestFilter()
+tests = filter.filter_by_model("stable-diffusion-xl-base-1.0") \
+              .filter_by_device("n150") \
+              .filter_by_markers(["load"]) \
+              .filter_by_test_name("ImageGenerationLoadTest") \
+              .get_tests()
+```
+
+### Use Case 4: Run All Performance/Load Tests
+
+```bash
+# All load tests across all models
+python run.py --markers load
+
+# All load and eval tests
+python run.py --markers load eval
+
+# Programmatically
+filter = TestFilter()
+tests = filter.filter_by_markers(["load"]).get_tests()
+```
+
+### Additional Examples
+
+```bash
+# Fast smoke tests only
+python run.py --markers smoke fast --match-all-markers
+
+# Exclude slow/heavy tests (for CI)
+python run.py --device n150 --exclude-markers slow heavy
+
+# List all available markers
+python run.py --list-markers
+
+# Preview which tests would run (dry-run)
+python run.py --model-category IMAGE --device n150 --list-tests
+```
+
+## CLI Reference
+
+```
+usage: run.py [-h] [--model MODEL] [--device DEVICE]
+              [--model-category CATEGORY [CATEGORY ...]]
+              [--markers MARKER [MARKER ...]] [--match-all-markers]
+              [--exclude-markers MARKER [MARKER ...]]
+              [--test-name TEST_NAME] [--skip-prerequisites]
+              [--list-markers] [--list-tests] [--dry-run]
+
+Arguments:
+  --model MODEL           Filter by model name
+  --device DEVICE         Filter by device (n150, n300, t3k, galaxy)
+  --model-category        Filter by model category (IMAGE, AUDIO, CNN)
+  --markers               Filter by test markers
+  --match-all-markers     Require ALL markers to match
+  --exclude-markers       Exclude tests with these markers
+  --test-name             Filter by specific test class name
+  --skip-prerequisites    Skip prerequisite tests (DeviceLivenessTest)
+  --list-markers          List available markers and exit
+  --list-tests            List matching tests without running
+```
+
+## Adding New Tests
+
+### Step 1: Define Template (if needed)
+
+If your test type doesn't exist, add a template to `test_templates`:
+
+```json
+"NewTestType": {
+    "module": "tests.server_tests.test_cases.new_test_type",
+    "markers": ["e2e", "slow"],
+    "test_config": {
+        "test_timeout": 3600,
+        "retry_attempts": 1,
+        "retry_delay": 60
+    }
+}
+```
+
+### Step 2: Add to Test Suite
+
+Add your test case to the appropriate suite in `test_suites`:
+
+```json
+{
+    "template": "NewTestType",
+    "enabled": true,
+    "description": "Description of what this test does",
+    "targets": {
+        "custom_param": "value"
+    }
+}
+```
+
+Markers are **automatically derived**:
+- From the template (`e2e`, `slow`)
+- From model category (`image`, `audio`, etc.)
+- From model marker (`sdxl`, `whisper`, etc.)
+- From device (`n150`, `t3k`, etc.)
+
+### Step 3: Add Custom Markers (Optional)
+
+If you need additional markers beyond auto-derived ones, add them in the template:
+
+```json
+"test_config": {
+    ...
+},
+"markers": ["e2e", "slow", "regression"]  // "regression" is custom
+```
+
+## Configuration Reference
+
+### Hardware Defaults
+
+Located in `hardware_defaults`, defines device-specific values:
+
+```json
+"hardware_defaults": {
+    "n150": {
+        "num_of_devices": 1,
+        "liveness_retry_attempts": 80
+    },
+    "t3k": {
+        "num_of_devices": 4,
+        "liveness_retry_attempts": 120
+    }
+}
+```
+
+These are automatically applied to:
+- DeviceLivenessTest `retry_attempts`
+- Test `targets.num_of_devices` — physical chip count, read by
+  `DeviceLivenessTest` and `DeviceStabilityTest`
+- Test `targets.num_concurrent_requests` — default client-side concurrency
+  for `*LoadTest` cases
+
+Per-test overrides inside a suite's `targets:` block should use:
+- `num_concurrent_requests` for load tests (e.g. to send a single request on
+  a multi-chip board like Galaxy)
+- `num_of_devices` only for liveness/stability tests that genuinely probe
+  the physical chip count
+
+For back-compat, `num_of_devices` is still accepted inside a load-test
+`targets:` block, but it is **deprecated** there — the canonical key is
+`num_concurrent_requests`. At expansion time, any per-test-case
+`num_of_devices` override is mirrored into `num_concurrent_requests` and a
+deprecation warning is logged. Please migrate to `num_concurrent_requests`.
+
+### Test Suite Structure
+
+```json
+{
+    "id": "sdxl-n150",           // Unique identifier
+    "weights": ["model-name"],   // Model(s) this suite tests
+    "device": "n150",            // Target hardware
+    "model_marker": "sdxl",      // Specific model marker
+    "test_cases": [...]          // List of test case configs
+}
+```
+
+## Programmatic API
+
+### TestFilter Methods
+
+```python
+from tests.server_tests.test_categorization_system import TestFilter
+
+filter = TestFilter()
+
+# Filtering methods (chainable)
+filter.filter_by_model_category(["IMAGE", "AUDIO"])
+filter.filter_by_model("stable-diffusion-xl-base-1.0")
+filter.filter_by_device("n150")
+filter.filter_by_markers(["load", "smoke"], match_all=False)
+filter.filter_by_test_name("ImageGenerationLoadTest")
+filter.exclude_markers(["slow", "heavy"])
+filter.include_prerequisites(True)
+
+# Get results
+tests = filter.get_tests()           # List of suite dicts
+flat = filter.get_flat_tests()       # Flat list of test dicts
+count = filter.get_test_count()      # Total test count
+
+# Utilities
+filter.print_summary()               # Print filtered test summary
+filter.reset()                       # Reset all filters
+filter.get_available_markers()       # Get marker definitions
+filter.get_all_devices()             # List all devices
+filter.get_all_models()              # List all models
+```
+
+## CI/CD Integration
+
+### GitHub Actions Example
+
+```yaml
+jobs:
+  smoke-tests:
+    runs-on: self-hosted
+    steps:
+      - name: Run smoke tests
+        run: python tests/server_tests/run.py --markers smoke --device n150
+
+  load-tests:
+    runs-on: self-hosted
+    needs: smoke-tests
+    steps:
+      - name: Run load tests
+        run: python tests/server_tests/run.py --markers load --device n150
+
+  full-suite:
+    runs-on: self-hosted
+    needs: load-tests
+    steps:
+      - name: Run all tests
+        run: python tests/server_tests/run.py --device n150
+```
+
+### Environment Variables
+
+```bash
+SERVICE_PORT=8000      # Service port for tests
+TEST_TIMEOUT=60        # Default test timeout
+TEST_RETRIES=2         # Default retry count
+MODEL=sdxl             # Default model filter
+DEVICE=n150            # Default device filter
+```
+
+## Best Practices
+
+1. **Use templates**: Define common test configurations once
+2. **Let markers auto-derive**: Don't manually add model/device markers
+3. **Keep descriptions clear**: Help others understand test purpose
+4. **Group by model/device**: One suite per model/device combination
+5. **Use meaningful targets**: Document expected values
+6. **Run smoke tests first**: Use `--markers smoke` in CI for quick feedback
+7. **Exclude heavy tests in dev**: Use `--exclude-markers slow heavy`
+
+## Troubleshooting
+
+### No tests match filters
+
+```bash
+# List available options
+python run.py --list-markers
+python run.py --list-tests
+
+# Check filter results
+python run.py --model-category IMAGE --list-tests
+```
+
+### Test not loading
+
+Check that:
+1. Module path is correct in template
+2. Class name matches template name
+3. Test file has no syntax errors
+4. Required dependencies are installed
+
+### Markers not applied
+
+Verify:
+1. Template has `markers` array
+2. Suite has `model_marker` field
+3. Suite has `device` field
+4. Test case references correct template

--- a/tt-inference-server-v2/test_module/test_categorization_system/TEST_SUITE_CONFIG_GUIDE.md
+++ b/tt-inference-server-v2/test_module/test_categorization_system/TEST_SUITE_CONFIG_GUIDE.md
@@ -1,0 +1,256 @@
+# Test Suite Configuration Guide
+
+This guide shows how to add models, devices, and tests using the test matrix system.
+All changes are JSON-only — no Python code required.
+
+Two files are involved:
+- `server_tests/server_tests_config.json` — model definitions (`model_configs` section)
+- `server_tests/test_suites/<category>.json` — test suite definitions per category
+
+## How it works
+
+Each suite file defines `test_matrices` (compact) and/or `test_suites` (explicit).
+A matrix expands `models × devices` into individual suites automatically:
+
+```
+models: ["wan", "mochi"]  ×  devices: ["t3k", "galaxy"]
+    → wan-t3k, wan-galaxy, mochi-t3k, mochi-galaxy
+```
+
+Model properties (weights, compatible devices) come from `model_configs`.
+Per-model or per-model+device target overrides use `model_targets` inside each test case.
+
+---
+
+## Case 1: Add a completely new model on multiple devices
+
+**Scenario:** You have a new video model `hunyuan` running on t3k, galaxy, and p300x2.
+
+**Step 1** — Add model config in `server_tests_config.json`:
+
+```json
+"model_configs": {
+    ...existing models...
+    "hunyuan": {
+        "weights": ["HunyuanVideo"],
+        "category": "VIDEO",
+        "compatible_devices": ["t3k", "galaxy", "p300x2"]
+    }
+}
+```
+
+**Step 2** — Add model to an existing matrix in `test_suites/video.json` (if it shares the same test pattern), or add a new matrix:
+
+```json
+"test_matrices": [
+    ...existing matrices...
+    {
+        "models": ["hunyuan"],
+        "devices": ["t3k", "galaxy", "p300x2"],
+        "num_of_devices": 1,
+        "test_cases": [
+            {
+                "template": "VideoGenerationLoadTest",
+                "enabled": true,
+                "description": "Video generation load test",
+                "targets": {"video_generation_target_time": 300}
+            },
+            {
+                "template": "VideoGenerationParamTest",
+                "enabled": true,
+                "description": "Video generation param test"
+            }
+        ]
+    }
+]
+```
+
+This produces 3 suites: `hunyuan-t3k`, `hunyuan-galaxy`, `hunyuan-p300x2`.
+
+**If timing differs per device**, use `model_targets`:
+
+```json
+"targets": {"video_generation_target_time": 300},
+"model_targets": {
+    "hunyuan+galaxy": {"video_generation_target_time": 350}
+}
+```
+
+Galaxy gets 350, all other devices get the base value of 300.
+
+---
+
+## Case 2: Add a new device to an existing model
+
+**Scenario:** Whisper now runs on n300. It needs the same tests as t3k but with different timing.
+
+**Step 1** — Add `"n300"` to compatible_devices in `server_tests_config.json`:
+
+```json
+"whisper": {
+    "weights": ["whisper-large-v3"],
+    "category": "AUDIO",
+    "compatible_devices": ["n150", "t3k", "galaxy", "n300"]
+}
+```
+
+**Step 2** — Add `"n300"` to the relevant matrix's `devices` list in `test_suites/audio.json`:
+
+```json
+"devices": ["t3k", "n300"],
+```
+
+**Step 3** — Add timing targets for the new device in each test case's `model_targets`:
+
+```json
+"model_targets": {
+    "whisper": {"audio_transcription_time": 5},
+    "whisper+n300": {"audio_transcription_time": 8},
+    ...
+}
+```
+
+If n300 uses the same timing as the model-level default, skip step 3.
+
+**Alternative: If n300 needs a unique test list** (different templates than other devices), add it as an explicit suite in `test_suites` instead of adding it to a matrix. See `audio.json` for an example — n150 suites are explicit because they have unique test lists.
+
+---
+
+## Case 3: Add a new test to existing model/device configurations
+
+**Scenario:** Add a new `ImageGenerationEvalsTest` for FLUX.1-dev on all its devices.
+
+Find the relevant matrix in `test_suites/image.json` and add the test case:
+
+```json
+"test_cases": [
+    ...existing test cases...
+    {
+        "template": "ImageGenerationEvalsTest",
+        "enabled": true,
+        "description": "LoRA eval: new-style",
+        "targets": {
+            "request": {
+                "model_name": "FLUX.1-dev-lora",
+                "num_prompts": 50,
+                "num_inference_steps": 20,
+                "lora_path": "example/new-lora",
+                "lora_scale": 0.7
+            }
+        }
+    }
+]
+```
+
+Since flux_dev shares a matrix with flux_schnell and motif, this test is added to all three models. If the test should only apply to flux_dev, either:
+
+- Move flux_dev to its own matrix, or
+- Add it as an explicit `test_suites` entry for specific flux_dev+device combinations
+
+---
+
+## Case 4: Add a model that joins an existing multi-model matrix
+
+**Scenario:** A new image model `sana` uses the same test pattern as FLUX and Motif.
+
+**Step 1** — Add model config:
+
+```json
+"sana": {
+    "weights": ["Sana-1.6B"],
+    "category": "IMAGE",
+    "compatible_devices": ["t3k", "galaxy", "p150x4"]
+}
+```
+
+**Step 2** — Add `"sana"` to the existing combined matrix in `image.json`:
+
+```json
+"models": ["flux_dev", "flux_schnell", "motif", "sana"],
+```
+
+**Step 3** — Add timing overrides if needed:
+
+```json
+"model_targets": {
+    ...existing overrides...
+    "sana+galaxy": {"image_generation_time": 12}
+}
+```
+
+Devices not in `compatible_devices` (e.g. p300) are automatically skipped.
+
+---
+
+## Case 5: Change timing targets for an existing model/device
+
+**Scenario:** Motif on galaxy got faster — update from 11s to 8s for 20-iteration test.
+
+Find the test case in the matrix and update the `model_targets` value:
+
+```json
+"model_targets": {
+    ...
+    "motif+galaxy": {"image_generation_time": 8}
+}
+```
+
+If the model has no `model_targets` entry (uses the base `targets`), add one.
+
+---
+
+## Case 6: Add a model with hyphens in the suite ID
+
+**Scenario:** Model key is `distil_whisper` but IDs should be `distil-whisper-t3k`.
+
+Use `id_name` in the model config:
+
+```json
+"distil_whisper": {
+    "id_name": "distil-whisper",
+    "weights": ["distil-large-v3"],
+    "category": "AUDIO",
+    "compatible_devices": ["n150", "t3k", "galaxy"]
+}
+```
+
+The `id_name` is used in suite IDs (`distil-whisper-t3k`), while `model_marker` stays as the key (`distil_whisper`).
+
+---
+
+## Quick reference
+
+| What | Where | Key |
+|------|-------|-----|
+| Model weights, category, devices | `server_tests_config.json` → `model_configs` | model key |
+| Which tests run for a model | `test_suites/<category>.json` → `test_matrices` | `test_cases` |
+| Timing that's the same across devices | `test_cases[].targets` | base targets |
+| Timing that differs per model | `test_cases[].model_targets.<model>` | model-level override |
+| Timing that differs per model+device | `test_cases[].model_targets.<model>+<device>` | most specific override |
+| Suites with unique test lists | `test_suites/<category>.json` → `test_suites` | explicit definition |
+| Client-side concurrency for a load test | `test_cases[].targets.num_concurrent_requests` | overrides matrix/suite default |
+| Physical chip count probed by liveness | `hardware_defaults.<device>.num_of_devices` | inherited by `DeviceLivenessTest` |
+
+### `num_concurrent_requests` vs `num_of_devices`
+
+Inside a load-test `targets:` block, use `num_concurrent_requests` — it
+controls how many concurrent HTTP requests the test fires. Example (single
+request on a 32-chip Galaxy board):
+
+```json
+{
+    "template": "AudioTranscriptionLoadTest",
+    "description": "Test single audio 60s transcription and expect chunking",
+    "targets": {
+        "num_concurrent_requests": 1,
+        "dataset": "60s"
+    }
+}
+```
+
+`num_of_devices` is reserved for the physical chip count consumed by
+`DeviceLivenessTest` / `DeviceStabilityTest`. Inside a load-test `targets:`
+block it is **deprecated** (the canonical key is `num_concurrent_requests`)
+but still accepted: at expansion time any per-test-case `num_of_devices`
+override is mirrored into `num_concurrent_requests` and a deprecation
+warning is logged. Please migrate to `num_concurrent_requests`.

--- a/tt-inference-server-v2/test_module/test_categorization_system/__init__.py
+++ b/tt-inference-server-v2/test_module/test_categorization_system/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+"""Test categorization system for server tests."""
+
+from .test_filter import TestFilter
+
+__all__ = ["TestFilter"]

--- a/tt-inference-server-v2/test_module/test_categorization_system/suite_loader.py
+++ b/tt-inference-server-v2/test_module/test_categorization_system/suite_loader.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+"""
+This module provides utilities to load suite files from /test_suites/*.json.
+
+Supports two suite definition formats:
+- "test_suites": Explicit suite definitions (original format)
+- "test_matrices": Compact model × device matrix definitions that are
+  automatically expanded into the same format as test_suites
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from copy import deepcopy
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Constants
+SERVER_TESTS_CONFIG_FILE = "server_tests_config.json"
+TEST_SUITES_DIR = "test_suites"
+TEST_SUITES_KEY = "test_suites"
+TEST_MATRICES_KEY = "test_matrices"
+TEST_SUITE_CATEGORY_KEY = "_category"
+CONFIG_DIR = Path(__file__).parent.parent
+SUITES_DIR = CONFIG_DIR / TEST_SUITES_DIR
+CONFIG_PATH = CONFIG_DIR / SERVER_TESTS_CONFIG_FILE
+
+
+def load_server_tests_config():
+    """
+    Load server tests configuration from server_tests_config.json.
+    """
+    logger.info(f"Loading server tests configuration from {SERVER_TESTS_CONFIG_FILE}")
+    with open(CONFIG_PATH, "r") as f:
+        return json.load(f)
+
+
+def expand_test_matrices(matrices: list[dict], model_configs: dict) -> list[dict]:
+    """
+    Expand compact test matrix definitions into individual test suites.
+
+    Each matrix entry defines a cross product of models × devices, producing
+    one suite per (model, device) pair. Model properties (weights, compatibility)
+    are resolved from model_configs in server_tests_config.json.
+
+    Per-model (and optionally per-model+device) targets are specified via
+    ``model_targets`` within each test_case, keeping the override co-located
+    with the test it applies to.
+
+    Args:
+        matrices: List of matrix definitions from a suite file's "test_matrices" key.
+        model_configs: The "model_configs" section from server_tests_config.json.
+
+    Returns:
+        List of suite dicts in the same format as manually-defined "test_suites" entries.
+
+    Raises:
+        ValueError: If a referenced model is not found in model_configs.
+    """
+    suites = []
+
+    for matrix in matrices:
+        id_pattern = matrix.get("id_pattern", "{model}-{device}")
+        models = matrix.get("models", [])
+        devices = matrix.get("devices", [])
+        matrix_num_devices = matrix.get("num_of_devices")
+        base_test_cases = matrix.get("test_cases", [])
+
+        for model_key in models:
+            model_cfg = model_configs.get(model_key)
+            if not model_cfg:
+                raise ValueError(
+                    f"Model '{model_key}' referenced in test_matrix "
+                    f"but not found in model_configs"
+                )
+
+            compatible = model_cfg.get("compatible_devices", [])
+
+            for device in devices:
+                if compatible and device not in compatible:
+                    logger.warning(
+                        f"Skipping {model_key} on {device}: "
+                        f"not in compatible_devices {compatible}"
+                    )
+                    continue
+
+                id_name = model_cfg.get("id_name", model_key)
+                suite_id = id_pattern.format(model=id_name, device=device)
+                test_cases = deepcopy(base_test_cases)
+
+                _resolve_model_targets(test_cases, model_key, device)
+
+                suite = {
+                    "id": suite_id,
+                    "weights": list(model_cfg["weights"]),
+                    "device": device,
+                    "model_marker": model_key,
+                    "test_cases": test_cases,
+                }
+
+                num_devices = _resolve_num_devices(matrix_num_devices, model_cfg)
+                if num_devices is not None:
+                    suite["num_of_devices"] = num_devices
+
+                suites.append(suite)
+
+    logger.info(f"Expanded {len(matrices)} test matrices into {len(suites)} suites")
+    return suites
+
+
+def _resolve_model_targets(test_cases: list[dict], model_key: str, device: str) -> None:
+    """
+    Resolve ``model_targets`` within each test case in-place.
+
+    Each test_case may carry an optional ``model_targets`` dict with
+    per-model (or per-model+device) target values. These are merged on
+    top of the test_case's base ``targets``, then ``model_targets`` is
+    removed from the output.
+
+    Lookup priority (highest wins):
+        1. ``model_targets["{model}+{device}"]``
+        2. ``model_targets["{model}"]``
+        3. Base ``targets`` on the test_case
+    """
+    for tc in test_cases:
+        model_targets = tc.pop("model_targets", None)
+        if not model_targets:
+            continue
+
+        resolved = dict(tc.get("targets", {}))
+
+        if model_key in model_targets:
+            resolved.update(model_targets[model_key])
+
+        specific_key = f"{model_key}+{device}"
+        if specific_key in model_targets:
+            resolved.update(model_targets[specific_key])
+
+        if resolved:
+            tc["targets"] = resolved
+        elif "targets" in tc and not tc["targets"]:
+            del tc["targets"]
+
+
+def _resolve_num_devices(matrix_value: Optional[int], model_cfg: dict) -> Optional[int]:
+    """Resolve num_of_devices: matrix-level takes priority over model config."""
+    if matrix_value is not None:
+        return matrix_value
+    return model_cfg.get("num_of_devices")
+
+
+def _load_suites_from_file(
+    suite_file: Path, model_configs: dict
+) -> tuple[list[dict], dict]:
+    """
+    Load suites from a single JSON file, expanding any test_matrices.
+
+    Returns (suites, raw_suite_data) tuple: expanded suites list and the
+    original parsed JSON for metadata access (e.g. _category).
+    """
+    with open(suite_file, "r") as f:
+        suite_data = json.load(f)
+
+    suites = list(suite_data.get(TEST_SUITES_KEY, []))
+
+    matrices = suite_data.get(TEST_MATRICES_KEY, [])
+    if matrices:
+        expanded = expand_test_matrices(matrices, model_configs)
+        suites.extend(expanded)
+
+    return suites, suite_data
+
+
+def load_suite_files() -> list[dict]:
+    """
+    Load and merge test suite files from test_suites/ directory.
+
+    Supports both explicit "test_suites" and compact "test_matrices" definitions.
+    Matrices are expanded using model_configs from server_tests_config.json.
+    """
+    logger.info(f"Loading suite files from {SUITES_DIR}")
+    if not SUITES_DIR.exists():
+        raise FileNotFoundError(f"test_suites directory not found: {SUITES_DIR}")
+
+    config = load_server_tests_config()
+    model_configs = config.get("model_configs", {})
+    suite_files = list(SUITES_DIR.glob("*.json"))
+
+    test_suites = []
+    for suite_file in sorted(suite_files):
+        try:
+            suites, suite_data = _load_suites_from_file(suite_file, model_configs)
+            if suites:
+                category = suite_data.get(TEST_SUITE_CATEGORY_KEY, suite_file.stem)
+                logger.info(
+                    f"Loaded {len(suites)} suites from {suite_file.name} ({category})"
+                )
+                test_suites.extend(suites)
+
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON in suite file {suite_file}: {e}")
+            raise ValueError(f"Invalid JSON in suite file {suite_file}: {e}") from e
+        except Exception as e:
+            logger.error(f"Error loading suite file {suite_file}: {e}")
+            raise RuntimeError(f"Error loading suite file {suite_file}: {e}") from e
+
+    return test_suites
+
+
+def load_suite_files_by_category(category: str) -> list[dict]:
+    """
+    Load suites from a specific category file (e.g., 'image' -> image.json).
+
+    Supports both explicit "test_suites" and compact "test_matrices" definitions.
+
+    Args:
+        category: Category name (e.g., "image", "audio", "video").
+
+    Returns:
+        List of test suite dictionaries from that category file.
+
+    Raises:
+        FileNotFoundError: If the category file doesn't exist.
+    """
+    logger.info(f"Loading suite file for category: {category}")
+    suite_file = SUITES_DIR / f"{category.lower()}.json"
+
+    if not suite_file.exists():
+        available = [f.stem for f in SUITES_DIR.glob("*.json")]
+        raise FileNotFoundError(
+            f"Suite file not found: {suite_file}. Available categories: {available}"
+        )
+
+    config = load_server_tests_config()
+    model_configs = config.get("model_configs", {})
+    suites, _ = _load_suites_from_file(suite_file, model_configs)
+
+    logger.info(f"Loaded {len(suites)} suites from {suite_file.name}")
+    return suites

--- a/tt-inference-server-v2/test_module/test_categorization_system/test_filter.py
+++ b/tt-inference-server-v2/test_module/test_categorization_system/test_filter.py
@@ -1,0 +1,572 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+"""
+Test filtering utilities for server tests configuration.
+
+This module provides utilities to filter and select tests from /test_suites/*.json
+based on markers, models, devices, and other criteria.
+
+It handles the following:
+- Auto-derivation of markers from model category and hardware
+- Prerequisite test injection (DeviceLivenessTest)
+- Hardware defaults for num_of_devices and retry_attempts
+- Auto-discovery and merging of suite files from test_suites/*.json
+"""
+
+from __future__ import annotations
+
+import logging
+from copy import deepcopy
+from typing import Dict, List, Optional
+
+from .suite_loader import (
+    load_server_tests_config,
+    load_suite_files,
+    load_suite_files_by_category,
+)
+
+logger = logging.getLogger(__name__)
+
+# Constants
+TEST_CONFIG = "test_config"
+NUM_OF_DEVICES = "num_of_devices"
+NUM_CONCURRENT_REQUESTS = "num_concurrent_requests"
+TARGETS = "targets"
+
+
+class TestFilter:
+    """
+    Filter tests from /test_suites/*.json based on various criteria.
+
+    The filter handles config format with:
+    - test_suites: Model/device specific test configurations
+    - prerequisite_tests: Tests that run before all others (e.g., DeviceLivenessTest)
+    - hardware_defaults: Device-specific defaults
+    - model_categories: Category to model mappings
+
+    Markers are automatically derived from:
+    - Template markers (from test_templates)
+    - Model category (IMAGE -> "image", AUDIO -> "audio", etc.)
+    - Specific model marker (from suite's model_marker field)
+    - Hardware target (device field -> "n150", "t3k", etc.)
+    """
+
+    def __init__(self, suites: list[dict] = None):
+        """
+        Initialize TestFilter with server test configuration from /test_suites/*.json.
+        """
+        logger.info("Loading server tests configuration")
+        self.config = load_server_tests_config()
+
+        self.model_categories = self.config.get("model_categories", {})
+        self.hardware_defaults = self.config.get("hardware_defaults", {})
+        self.test_templates = self.config.get("test_templates", {})
+        self.prerequisite_tests = self.config.get("prerequisite_tests", [])
+
+        if suites is None:
+            logger.info("Loading test suites from discovery")
+            self.test_suites = load_suite_files()
+        else:
+            logger.info(f"Using {len(suites)} pre-loaded test suites")
+            self.test_suites = suites
+
+        logger.info("Building reverse mapping: model -> category")
+        self._model_to_category = {}
+        for category, models in self.model_categories.items():
+            for model in models:
+                self._model_to_category[model] = category
+
+        logger.info(f"Expanding {len(self.test_suites)} test suites")
+        self.expanded_suites = self._expand_all_suites()
+        self.filtered_suites = list(self.expanded_suites)
+
+        logger.info("Including prerequisites by default")
+        self._include_prerequisites = True
+
+    @classmethod
+    def from_category(cls, category: str) -> TestFilter:
+        """
+        Create a TestFilter loading only suites from a specific category file.
+
+        This is useful for running tests for a single category (IMAGE, AUDIO, FORGE, etc.)
+        without loading other category suites.
+
+        Args:
+            category: Category name (e.g., "image", "audio", "forge")
+
+        Returns:
+            TestFilter instance with only the specified category's suites
+
+        Example:
+            filter = TestFilter.from_category("image")
+            filter.filter_by_device("n150")
+            tests = filter.get_tests()
+        """
+        suites = load_suite_files_by_category(category)
+        return cls(suites=suites)
+
+    def _get_category_marker(self, model: str) -> Optional[str]:
+        """Get the category marker for a model.
+
+        Args:
+            model: Model name (e.g., "stable-diffusion-xl-base-1.0")
+
+        Returns:
+            Category marker in lowercase (e.g., "image", "audio") or None if not found.
+        """
+        category = self._model_to_category.get(model)
+        if category:
+            return category.lower()
+        return None
+
+    def _get_num_of_devices(self, suite: Dict) -> Optional[int]:
+        """Get num_of_devices for a suite, preferring suite-level override over hardware default."""
+        suite_override = suite.get(NUM_OF_DEVICES)
+        if suite_override is not None:
+            return suite_override
+        device = suite.get("device", "")
+        hw_defaults = self.hardware_defaults.get(device, {})
+        return hw_defaults.get(NUM_OF_DEVICES)
+
+    def _expand_test_case(self, test_case: Dict, suite: Dict) -> Dict:
+        """Expand a test case by merging template defaults with overrides.
+
+        Applies template config, hardware defaults, and auto-derives markers
+        from model category, model marker, and device.
+
+        Args:
+            test_case: Raw test case dict with template reference
+            suite: Parent suite containing device and weights info
+
+        Returns:
+            Expanded test case dict with all fields populated.
+        """
+        template_name = test_case.get("template")
+        if not template_name:
+            logger.info(
+                f"Direct test case (no template): {test_case.get('name', 'unknown')}"
+            )
+            return test_case
+
+        template = self.test_templates.get(template_name, {})
+        if not template:
+            raise ValueError(f"Template '{template_name}' not found in test_templates")
+
+        # Start with template defaults
+        expanded = {
+            "name": template_name,
+            "module": template.get("module"),
+            "enabled": test_case.get("enabled", True),
+            "description": test_case.get("description", ""),
+            "test_config": deepcopy(template.get("test_config", {})),
+            "targets": {},
+        }
+
+        # Merge test_config overrides
+        if TEST_CONFIG in test_case:
+            expanded["test_config"].update(test_case["test_config"])
+
+        # Populate both keys from the suite/hardware default so that:
+        #   - DeviceStabilityTest reads num_of_devices (chip count).
+        #   - *LoadTest read num_concurrent_requests (client-side fan-out).
+        # Per-test-case targets below may override either independently.
+        num_devices = self._get_num_of_devices(suite)
+        if num_devices is not None:
+            expanded["targets"][NUM_OF_DEVICES] = num_devices
+            expanded["targets"][NUM_CONCURRENT_REQUESTS] = num_devices
+
+        case_targets = test_case.get(TARGETS) or {}
+        case_overrides_devices = NUM_OF_DEVICES in case_targets
+        case_overrides_concurrent = NUM_CONCURRENT_REQUESTS in case_targets
+        expanded["targets"].update(case_targets)
+
+        if case_overrides_devices and not case_overrides_concurrent:
+            expanded["targets"][NUM_CONCURRENT_REQUESTS] = case_targets[NUM_OF_DEVICES]
+            logger.warning(
+                "Suite '%s' test case '%s' uses targets.%s; this is a "
+                "deprecated alias for targets.%s in load tests. Please "
+                "update the suite config.",
+                suite.get("id", "unknown"),
+                template_name,
+                NUM_OF_DEVICES,
+                NUM_CONCURRENT_REQUESTS,
+            )
+
+        # Build markers: template + category + model_marker + hardware
+        markers = set(template.get("markers", []))
+
+        # Add category marker (e.g., "image", "audio")
+        for model in suite.get("weights", []):
+            category_marker = self._get_category_marker(model)
+            if category_marker:
+                markers.add(category_marker)
+
+        # Add model-specific marker (e.g., "sdxl", "whisper")
+        model_marker = suite.get("model_marker")
+        if model_marker:
+            markers.add(model_marker)
+
+        # Add hardware marker
+        device = suite.get("device", "")
+        if device:
+            markers.add(device.lower())
+
+        expanded["markers"] = list(markers)
+
+        return expanded
+
+    def _expand_prerequisite_test(self, prereq: Dict, suite: Dict) -> Dict:
+        """Expand a prerequisite test with hardware-specific values."""
+        logger.info(f"Expanding prerequisite test: {prereq.get('name', 'unknown')}")
+        expanded = deepcopy(prereq)
+        device = suite.get("device", "")
+        hw_defaults = self.hardware_defaults.get(device, {})
+
+        # Set hardware-specific retry_attempts for liveness test
+        if "liveness_retry_attempts" in hw_defaults:
+            if "test_config" not in expanded:
+                expanded["test_config"] = {}
+            expanded["test_config"]["retry_attempts"] = hw_defaults[
+                "liveness_retry_attempts"
+            ]
+
+        # Set num_of_devices: suite-level override > hardware default
+        if "targets" not in expanded:
+            expanded["targets"] = {}
+        num_devices = self._get_num_of_devices(suite)
+        if num_devices is not None:
+            expanded["targets"]["num_of_devices"] = num_devices
+
+        # Add markers for model category, model marker, and hardware
+        markers = set(expanded.get("markers", []))
+
+        for model in suite.get("weights", []):
+            category_marker = self._get_category_marker(model)
+            if category_marker:
+                markers.add(category_marker)
+
+        model_marker = suite.get("model_marker")
+        if model_marker:
+            markers.add(model_marker)
+
+        if device:
+            markers.add(device.lower())
+
+        expanded["markers"] = list(markers)
+
+        return expanded
+
+    def _expand_all_suites(self) -> List[Dict]:
+        """Expand all test suites by applying templates to each test case.
+
+        Returns:
+            List of expanded suite dicts with fully populated test cases.
+        """
+        expanded_suites = []
+
+        for suite in self.test_suites:
+            expanded_suite = {
+                "id": suite.get("id", ""),
+                "weights": suite.get("weights", []),
+                "device": suite.get("device", ""),
+                "model_marker": suite.get("model_marker", ""),
+                "test_cases": [],
+            }
+            if NUM_OF_DEVICES in suite:
+                expanded_suite[NUM_OF_DEVICES] = suite[NUM_OF_DEVICES]
+
+            # Expand each test case
+            for test_case in suite.get("test_cases", []):
+                expanded = self._expand_test_case(test_case, suite)
+                expanded_suite["test_cases"].append(expanded)
+
+            expanded_suites.append(expanded_suite)
+
+        return expanded_suites
+
+    def _get_prerequisite_for_suite(self, suite: Dict) -> List[Dict]:
+        """Get expanded prerequisite tests for a specific suite.
+
+        Args:
+            suite: Suite dict for hardware context
+
+        Returns:
+            List of expanded prerequisite test dicts.
+        """
+        logger.info(
+            f"Getting prerequisite tests for suite: {suite.get('id', 'unknown')}"
+        )
+        prereqs = []
+        for prereq in self.prerequisite_tests:
+            expanded = self._expand_prerequisite_test(prereq, suite)
+            prereqs.append(expanded)
+        return prereqs
+
+    def include_prerequisites(self, include: bool = True) -> TestFilter:
+        """
+        Control whether prerequisite tests (DeviceLivenessTest) are included.
+
+        Args:
+            include: If True, prerequisite tests are prepended to results.
+
+        Returns:
+            Self for method chaining
+        """
+        self._include_prerequisites = include
+        return self
+
+    def filter_by_model_category(self, categories: List[str]) -> TestFilter:
+        """
+        Filter tests by model category (IMAGE, AUDIO, CNN, etc.).
+
+        Args:
+            categories: List of category names (e.g., ["IMAGE", "AUDIO"])
+
+        Returns:
+            Self for method chaining
+        """
+        if not categories:
+            return self
+
+        # Get all models in the specified categories
+        target_models = set()
+        for category in categories:
+            target_models.update(self.model_categories.get(category, []))
+
+        # Filter suites that match these models
+        self.filtered_suites = [
+            suite
+            for suite in self.filtered_suites
+            if any(model in target_models for model in suite.get("weights", []))
+        ]
+
+        return self
+
+    def filter_by_model(self, model_name: str) -> TestFilter:
+        """
+        Filter tests by specific model name.
+
+        Args:
+            model_name: Model name (e.g., "stable-diffusion-xl-base-1.0")
+
+        Returns:
+            Self for method chaining
+        """
+        self.filtered_suites = [
+            suite
+            for suite in self.filtered_suites
+            if model_name in suite.get("weights", [])
+        ]
+
+        return self
+
+    def filter_by_device(self, device: str) -> TestFilter:
+        """
+        Filter tests by device type.
+
+        Args:
+            device: Device name (e.g., "n150", "t3k", "galaxy")
+
+        Returns:
+            Self for method chaining
+        """
+        self.filtered_suites = [
+            suite
+            for suite in self.filtered_suites
+            if suite.get("device", "").lower() == device.lower()
+        ]
+
+        return self
+
+    def filter_by_markers(
+        self, markers: List[str], match_all: bool = False
+    ) -> TestFilter:
+        """
+        Filter tests by markers (tags).
+
+        Args:
+            markers: List of marker names (e.g., ["load", "slow"])
+            match_all: If True, test must have ALL markers. If False, ANY marker matches.
+
+        Returns:
+            Self for method chaining
+        """
+        if not markers:
+            return self
+
+        marker_set = set(m.lower() for m in markers)
+        filtered_suites = []
+
+        for suite in self.filtered_suites:
+            filtered_suite = deepcopy(suite)
+            filtered_suite["test_cases"] = []
+
+            for test in suite.get("test_cases", []):
+                test_markers = set(m.lower() for m in test.get("markers", []))
+
+                if match_all:
+                    if marker_set.issubset(test_markers):
+                        filtered_suite["test_cases"].append(test)
+                else:
+                    if marker_set.intersection(test_markers):
+                        filtered_suite["test_cases"].append(test)
+
+            if filtered_suite["test_cases"]:
+                filtered_suites.append(filtered_suite)
+
+        self.filtered_suites = filtered_suites
+        return self
+
+    def filter_by_test_name(self, test_name: str) -> TestFilter:
+        """
+        Filter tests by test class name.
+
+        Args:
+            test_name: Test class name (e.g., "ImageGenerationLoadTest")
+
+        Returns:
+            Self for method chaining
+        """
+        filtered_suites = []
+
+        for suite in self.filtered_suites:
+            filtered_suite = deepcopy(suite)
+            filtered_suite["test_cases"] = [
+                test
+                for test in suite.get("test_cases", [])
+                if test.get("name") == test_name
+            ]
+
+            if filtered_suite["test_cases"]:
+                filtered_suites.append(filtered_suite)
+
+        self.filtered_suites = filtered_suites
+        return self
+
+    def exclude_markers(self, markers: List[str]) -> TestFilter:
+        """
+        Exclude tests that have any of the specified markers.
+
+        Args:
+            markers: List of marker names to exclude (e.g., ["slow", "heavy"])
+
+        Returns:
+            Self for method chaining
+        """
+        if not markers:
+            return self
+
+        exclude_set = set(m.lower() for m in markers)
+        filtered_suites = []
+
+        for suite in self.filtered_suites:
+            filtered_suite = deepcopy(suite)
+            filtered_suite["test_cases"] = []
+
+            for test in suite.get("test_cases", []):
+                test_markers = set(m.lower() for m in test.get("markers", []))
+
+                if not exclude_set.intersection(test_markers):
+                    filtered_suite["test_cases"].append(test)
+
+            if filtered_suite["test_cases"]:
+                filtered_suites.append(filtered_suite)
+
+        self.filtered_suites = filtered_suites
+        return self
+
+    def get_tests(self) -> List[Dict]:
+        """
+        Get the filtered test suites with prerequisite tests prepended.
+
+        Returns:
+            List of test suites with expanded test cases.
+            Each suite has prerequisite tests (e.g., DeviceLivenessTest) prepended
+            if include_prerequisites is True.
+        """
+        logger.info("Getting filtered tests")
+        result = []
+
+        for suite in self.filtered_suites:
+            result_suite = deepcopy(suite)
+
+            if self._include_prerequisites:
+                prereqs = self._get_prerequisite_for_suite(suite)
+                result_suite["test_cases"] = prereqs + result_suite["test_cases"]
+
+            result.append(result_suite)
+
+        return result
+
+    def get_flat_tests(self) -> List[Dict]:
+        """
+        Get a flat list of all test cases (without suite grouping).
+        Useful for counting or iterating over all tests.
+
+        Returns:
+            List of individual test case dictionaries
+        """
+        tests = []
+        for suite in self.get_tests():
+            for test in suite.get("test_cases", []):
+                test_copy = deepcopy(test)
+                test_copy["_suite_id"] = suite.get("id", "")
+                test_copy["_weights"] = suite.get("weights", [])
+                test_copy["_device"] = suite.get("device", "")
+                tests.append(test_copy)
+        return tests
+
+    def print_summary(self, suites: List[Dict] = None):
+        """Print a summary of filtered tests."""
+        if suites is None:
+            suites = self.get_tests()
+        total_tests = sum(len(s.get("test_cases", [])) for s in suites)
+
+        logger.info("Filtered Test Summary:")
+        logger.info(f"Total test suites: {len(suites)}")
+        logger.info(f"Total individual tests: {total_tests}")
+        logger.info("Test breakdown:")
+
+        for suite in suites:
+            models = ", ".join(suite.get("weights", []))
+            device = suite.get("device", "unknown")
+            test_count = len(suite.get("test_cases", []))
+            logger.info(
+                f"  [{suite.get('id', 'unknown')}] {models} on {device}: {test_count} tests"
+            )
+
+            for test in suite.get("test_cases", []):
+                markers = ", ".join(sorted(test.get("markers", [])))
+                enabled = "✅" if test.get("enabled", True) else "❌"
+                logger.info(f"    {enabled} {test.get('name')}: [{markers}]")
+                if test.get("description"):
+                    logger.info(f"      └─ {test.get('description')}")
+
+    def get_available_markers(self) -> Dict:
+        """Get all available markers defined in server_tests_config.json.
+
+        Returns:
+            Dict of marker categories and their descriptions.
+        """
+        return self.config.get("available_markers", {})
+
+    def get_all_devices(self) -> List[str]:
+        """Get list of all unique devices across all test suites.
+
+        Returns:
+            List of device names (e.g., ["n150", "t3k", "galaxy"]).
+        """
+        return list(set(suite.get("device", "") for suite in self.test_suites))
+
+    def get_all_models(self) -> List[str]:
+        """Get list of all unique models across all test suites.
+
+        Returns:
+            List of model names from suite weights.
+        """
+        models = set()
+        for suite in self.test_suites:
+            models.update(suite.get("weights", []))
+        return list(models)

--- a/tt-inference-server-v2/test_module/test_suites/audio.json
+++ b/tt-inference-server-v2/test_module/test_suites/audio.json
@@ -1,0 +1,228 @@
+{
+    "_description": "Test suites for AUDIO model category (Whisper, Distil-Whisper)",
+    "_category": "AUDIO",
+    "test_matrices": [
+        {
+            "_comment": "t3k: both models share the same test templates, timing differs per model",
+            "models": [
+                "distil_whisper",
+                "whisper"
+            ],
+            "devices": [
+                "t3k"
+            ],
+            "test_cases": [
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test audio 30s load",
+                    "model_targets": {
+                        "distil_whisper": {
+                            "audio_transcription_time": 4
+                        },
+                        "whisper": {
+                            "audio_transcription_time": 5
+                        }
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test audio 60s load",
+                    "targets": {
+                        "dataset": "60s"
+                    },
+                    "model_targets": {
+                        "distil_whisper": {
+                            "audio_transcription_time": 5
+                        },
+                        "whisper": {
+                            "audio_transcription_time": 10
+                        }
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test single audio 60s transcription and expect chunking",
+                    "targets": {
+                        "num_concurrent_requests": 1,
+                        "dataset": "60s"
+                    },
+                    "model_targets": {
+                        "distil_whisper": {
+                            "audio_transcription_time": 2
+                        },
+                        "whisper": {
+                            "audio_transcription_time": 6
+                        }
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionParamTest",
+                    "enabled": true,
+                    "description": "Test audio transcription params"
+                }
+            ]
+        },
+        {
+            "_comment": "galaxy: both models share the same test templates, timing differs per model",
+            "models": [
+                "distil_whisper",
+                "whisper"
+            ],
+            "devices": [
+                "galaxy"
+            ],
+            "test_cases": [
+                {
+                    "template": "AudioTranscriptionLoadDp2Chunk5Test",
+                    "enabled": true,
+                    "description": "DP2 burst with 60s audio, chunk_duration_seconds=5",
+                    "targets": {
+                        "num_concurrent": 64,
+                        "dataset": "60s"
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionLoadDp2Chunk30Test",
+                    "enabled": true,
+                    "description": "DP2 burst with 60s audio, chunk_duration_seconds=30",
+                    "targets": {
+                        "num_concurrent": 64,
+                        "dataset": "60s"
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test audio 30s load",
+                    "model_targets": {
+                        "distil_whisper": {
+                            "audio_transcription_time": 2
+                        },
+                        "whisper": {
+                            "audio_transcription_time": 4
+                        }
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test audio 60s load",
+                    "targets": {
+                        "dataset": "60s"
+                    },
+                    "model_targets": {
+                        "distil_whisper": {
+                            "audio_transcription_time": 2
+                        },
+                        "whisper": {
+                            "audio_transcription_time": 7
+                        }
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test single audio 60s transcription and expect chunking",
+                    "targets": {
+                        "num_concurrent_requests": 1,
+                        "dataset": "60s"
+                    },
+                    "model_targets": {
+                        "distil_whisper": {
+                            "audio_transcription_time": 2
+                        },
+                        "whisper": {
+                            "audio_transcription_time": 4
+                        }
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionParamTest",
+                    "enabled": true,
+                    "description": "Test audio transcription params"
+                }
+            ]
+        }
+    ],
+    "test_suites": [
+        {
+            "_comment": "n150 distil-whisper: unique test list (includes StabilityTest)",
+            "id": "distil-whisper-n150",
+            "weights": [
+                "distil-large-v3"
+            ],
+            "device": "n150",
+            "model_marker": "distil_whisper",
+            "test_cases": [
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test audio 30s load",
+                    "targets": {
+                        "audio_transcription_time": 0.7
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test audio 60s load",
+                    "targets": {
+                        "audio_transcription_time": 4,
+                        "dataset": "60s"
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionParamTest",
+                    "enabled": true,
+                    "description": "Test audio transcription params"
+                },
+                {
+                    "template": "DeviceStabilityTest",
+                    "enabled": true,
+                    "description": "Device stability test"
+                }
+            ]
+        },
+        {
+            "_comment": "n150 whisper: unique test list (no ParamTest, has single-device test)",
+            "id": "whisper-n150",
+            "weights": [
+                "whisper-large-v3"
+            ],
+            "device": "n150",
+            "model_marker": "whisper",
+            "test_cases": [
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test audio 30s load",
+                    "targets": {
+                        "audio_transcription_time": 6
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test audio 60s load",
+                    "targets": {
+                        "audio_transcription_time": 12,
+                        "dataset": "60s"
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test single audio 60s transcription and expect chunking",
+                    "targets": {
+                        "audio_transcription_time": 12,
+                        "num_concurrent_requests": 1,
+                        "dataset": "60s"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tt-inference-server-v2/test_module/test_suites/cnn.json
+++ b/tt-inference-server-v2/test_module/test_suites/cnn.json
@@ -1,0 +1,40 @@
+{
+    "_description": "Test suites for CNN model category",
+    "_category": "CNN",
+    "test_matrices": [
+        {
+            "models": [
+                "mobilenetv2",
+                "resnet",
+                "efficientnet",
+                "segformer",
+                "unet",
+                "vit",
+                "vovnet"
+            ],
+            "devices": [
+                "n150",
+                "n300"
+            ],
+            "num_of_devices": 1,
+            "test_cases": [
+                {
+                    "template": "CnnLoadTest",
+                    "enabled": true,
+                    "description": "CNN image classification load test",
+                    "targets": {
+                        "cnn_time": 5,
+                        "response_format": "json",
+                        "top_k": 3,
+                        "min_confidence": 70.0
+                    }
+                },
+                {
+                    "template": "CnnParamTest",
+                    "enabled": true,
+                    "description": "CNN parameter variations test"
+                }
+            ]
+        }
+    ]
+}

--- a/tt-inference-server-v2/test_module/test_suites/embedding.json
+++ b/tt-inference-server-v2/test_module/test_suites/embedding.json
@@ -1,0 +1,35 @@
+{
+    "_description": "Test suites for EMBEDDING model category",
+    "_category": "EMBEDDING",
+    "test_matrices": [
+        {
+            "models": [
+                "bge",
+                "qwen3_emb"
+            ],
+            "devices": [
+                "n150",
+                "t3k",
+                "galaxy"
+            ],
+            "test_cases": [
+                {
+                    "template": "EmbeddingLoadTest",
+                    "enabled": true,
+                    "description": "Embedding load test",
+                    "targets": {
+                        "embedding_time": 1
+                    },
+                    "model_targets": {
+                        "bge+n150": {
+                            "embedding_time": 0.1
+                        },
+                        "qwen3_emb+n150": {
+                            "embedding_time": 0.1
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tt-inference-server-v2/test_module/test_suites/image.json
+++ b/tt-inference-server-v2/test_module/test_suites/image.json
@@ -1,0 +1,448 @@
+{
+    "_description": "Test suites for IMAGE model category",
+    "_category": "IMAGE",
+    "test_matrices": [
+        {
+            "_comment": "SDXL with full LoRA test set; galaxy has slightly different timing",
+            "models": [
+                "sdxl"
+            ],
+            "devices": [
+                "n150",
+                "t3k",
+                "galaxy"
+            ],
+            "test_cases": [
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "20 iterations",
+                    "targets": {
+                        "num_inference_steps": 20,
+                        "image_generation_time": 10
+                    },
+                    "model_targets": {
+                        "sdxl+galaxy": {
+                            "image_generation_time": 11
+                        }
+                    }
+                },
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "30 iterations",
+                    "targets": {
+                        "num_inference_steps": 30,
+                        "image_generation_time": 14
+                    },
+                    "model_targets": {
+                        "sdxl+galaxy": {
+                            "image_generation_time": 15
+                        }
+                    }
+                },
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "50 iterations",
+                    "targets": {
+                        "num_inference_steps": 50,
+                        "image_generation_time": 23
+                    },
+                    "model_targets": {
+                        "sdxl+galaxy": {
+                            "image_generation_time": 25
+                        }
+                    }
+                },
+                {
+                    "template": "ImageGenerationParamTest",
+                    "enabled": true,
+                    "description": "Param validation"
+                },
+                {
+                    "template": "ImageGenerationEvalsTest",
+                    "enabled": true,
+                    "description": "LoRA eval: pixel-art-xl",
+                    "targets": {
+                        "request": {
+                            "model_name": "stable-diffusion-xl-base-1.0-lora",
+                            "num_prompts": 100,
+                            "num_inference_steps": 20,
+                            "lora_path": "nerijs/pixel-art-xl",
+                            "lora_scale": 0.8
+                        }
+                    }
+                },
+                {
+                    "template": "ImageGenerationEvalsTest",
+                    "enabled": true,
+                    "description": "LoRA eval: ColoringBookRedmond-V2",
+                    "targets": {
+                        "request": {
+                            "model_name": "stable-diffusion-xl-base-1.0-lora",
+                            "num_prompts": 100,
+                            "num_inference_steps": 20,
+                            "lora_path": "artificialguybr/ColoringBookRedmond-V2",
+                            "lora_scale": 0.6
+                        }
+                    }
+                },
+                {
+                    "template": "ImageGenerationLoraLoadTest",
+                    "enabled": true,
+                    "description": "Mixed LoRA load test",
+                    "targets": {
+                        "batch_size": 10,
+                        "num_inference_steps": 20,
+                        "target_time": 120,
+                        "lora_configs": [
+                            {
+                                "lora_path": "nerijs/pixel-art-xl",
+                                "lora_scale": 0.8
+                            },
+                            {
+                                "lora_path": "artificialguybr/ColoringBookRedmond-V2",
+                                "lora_scale": 0.6
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "models": [
+                "sdxl_img2img"
+            ],
+            "devices": [
+                "n150",
+                "t3k",
+                "galaxy"
+            ],
+            "test_cases": [
+                {
+                    "template": "Img2ImgGenerationParamTest",
+                    "enabled": true,
+                    "description": "Param validation"
+                }
+            ]
+        },
+        {
+            "models": [
+                "sdxl_inpaint"
+            ],
+            "devices": [
+                "n150",
+                "t3k",
+                "galaxy"
+            ],
+            "test_cases": [
+                {
+                    "template": "InpaintingGenerationParamTest",
+                    "enabled": true,
+                    "description": "Param validation"
+                }
+            ]
+        },
+        {
+            "models": [
+                "sd35"
+            ],
+            "devices": [
+                "t3k",
+                "galaxy"
+            ],
+            "num_of_devices": 1,
+            "test_cases": [
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "20 iterations",
+                    "targets": {
+                        "num_inference_steps": 20
+                    },
+                    "model_targets": {
+                        "sd35+t3k": {
+                            "image_generation_time": 15
+                        },
+                        "sd35+galaxy": {
+                            "image_generation_time": 16
+                        }
+                    }
+                },
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "30 iterations",
+                    "targets": {
+                        "num_inference_steps": 30
+                    },
+                    "model_targets": {
+                        "sd35+t3k": {
+                            "image_generation_time": 20
+                        },
+                        "sd35+galaxy": {
+                            "image_generation_time": 22
+                        }
+                    }
+                },
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "50 iterations",
+                    "targets": {
+                        "num_inference_steps": 50
+                    },
+                    "model_targets": {
+                        "sd35+t3k": {
+                            "image_generation_time": 25
+                        },
+                        "sd35+galaxy": {
+                            "image_generation_time": 28
+                        }
+                    }
+                },
+                {
+                    "template": "ImageGenerationParamTest",
+                    "enabled": true,
+                    "description": "Param validation"
+                }
+            ]
+        },
+        {
+            "_comment": "FLUX.1-dev, FLUX.1-schnell, Motif share same test pattern; motif skips p300 via compatible_devices",
+            "models": [
+                "flux_dev",
+                "flux_schnell",
+                "motif"
+            ],
+            "devices": [
+                "t3k",
+                "galaxy",
+                "p150x4",
+                "p150x8",
+                "p300",
+                "p300x2"
+            ],
+            "num_of_devices": 1,
+            "test_cases": [
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "20 iterations",
+                    "targets": {
+                        "num_inference_steps": 20,
+                        "image_generation_time": 10
+                    },
+                    "model_targets": {
+                        "flux_dev+t3k": {
+                            "image_generation_time": 16
+                        },
+                        "flux_dev+galaxy": {
+                            "image_generation_time": 11
+                        },
+                        "flux_schnell+galaxy": {
+                            "image_generation_time": 11
+                        },
+                        "motif+galaxy": {
+                            "image_generation_time": 11
+                        }
+                    }
+                },
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "30 iterations",
+                    "targets": {
+                        "num_inference_steps": 30,
+                        "image_generation_time": 14
+                    },
+                    "model_targets": {
+                        "flux_dev+t3k": {
+                            "image_generation_time": 23
+                        },
+                        "flux_dev+galaxy": {
+                            "image_generation_time": 15
+                        },
+                        "flux_schnell+galaxy": {
+                            "image_generation_time": 15
+                        },
+                        "motif+galaxy": {
+                            "image_generation_time": 15
+                        }
+                    }
+                },
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "50 iterations",
+                    "targets": {
+                        "num_inference_steps": 50,
+                        "image_generation_time": 23
+                    },
+                    "model_targets": {
+                        "flux_dev+t3k": {
+                            "image_generation_time": 36
+                        },
+                        "flux_dev+galaxy": {
+                            "image_generation_time": 25
+                        },
+                        "flux_schnell+galaxy": {
+                            "image_generation_time": 25
+                        },
+                        "motif+galaxy": {
+                            "image_generation_time": 25
+                        }
+                    }
+                },
+                {
+                    "template": "ImageGenerationParamTest",
+                    "enabled": true,
+                    "description": "Param validation",
+                    "model_targets": {
+                        "flux_dev": {
+                            "model": "FLUX.1-dev"
+                        },
+                        "flux_schnell": {
+                            "model": "FLUX.1-schnell"
+                        },
+                        "motif": {
+                            "model": "Motif-Image-6B-Preview"
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "test_suites": [
+        {
+            "id": "sdxl-n300",
+            "weights": [
+                "stable-diffusion-xl-base-1.0"
+            ],
+            "device": "n300",
+            "num_of_devices": 1,
+            "model_marker": "sdxl",
+            "test_cases": [
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "20 iterations",
+                    "targets": {
+                        "num_inference_steps": 20,
+                        "image_generation_time": 10
+                    }
+                },
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "30 iterations",
+                    "targets": {
+                        "num_inference_steps": 30,
+                        "image_generation_time": 14
+                    }
+                },
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "50 iterations",
+                    "targets": {
+                        "num_inference_steps": 50,
+                        "image_generation_time": 23
+                    }
+                },
+                {
+                    "template": "ImageGenerationParamTest",
+                    "enabled": true,
+                    "description": "Param validation"
+                }
+            ]
+        },
+        {
+            "id": "sdxl-p150x8",
+            "weights": [
+                "stable-diffusion-xl-base-1.0"
+            ],
+            "device": "p150x8",
+            "num_of_devices": 4,
+            "model_marker": "sdxl",
+            "test_cases": [
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "20 iterations",
+                    "targets": {
+                        "num_inference_steps": 20,
+                        "image_generation_time": 10
+                    }
+                },
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "30 iterations",
+                    "targets": {
+                        "num_inference_steps": 30,
+                        "image_generation_time": 14
+                    }
+                },
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "50 iterations",
+                    "targets": {
+                        "num_inference_steps": 50,
+                        "image_generation_time": 23
+                    }
+                },
+                {
+                    "template": "ImageGenerationParamTest",
+                    "enabled": true,
+                    "description": "Param validation"
+                }
+            ]
+        },
+        {
+            "id": "sdxl-p300x2",
+            "weights": [
+                "stable-diffusion-xl-base-1.0"
+            ],
+            "device": "p300x2",
+            "num_of_devices": 2,
+            "model_marker": "sdxl",
+            "test_cases": [
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "20 iterations",
+                    "targets": {
+                        "num_inference_steps": 20,
+                        "image_generation_time": 10
+                    }
+                },
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "30 iterations",
+                    "targets": {
+                        "num_inference_steps": 30,
+                        "image_generation_time": 14
+                    }
+                },
+                {
+                    "template": "ImageGenerationLoadTest",
+                    "enabled": true,
+                    "description": "50 iterations",
+                    "targets": {
+                        "num_inference_steps": 50,
+                        "image_generation_time": 23
+                    }
+                },
+                {
+                    "template": "ImageGenerationParamTest",
+                    "enabled": true,
+                    "description": "Param validation"
+                }
+            ]
+        }
+    ]
+}

--- a/tt-inference-server-v2/test_module/test_suites/tts.json
+++ b/tt-inference-server-v2/test_module/test_suites/tts.json
@@ -1,0 +1,42 @@
+{
+    "_description": "Test suites for TTS model category (SpeechT5)",
+    "_category": "TTS",
+    "test_matrices": [
+        {
+            "models": [
+                "speecht5"
+            ],
+            "devices": [
+                "n150",
+                "p150"
+            ],
+            "test_cases": [
+                {
+                    "template": "SpeechT5TTSTest",
+                    "enabled": true,
+                    "description": "SpeechT5 TTS functionality test"
+                },
+                {
+                    "template": "TestTTSServerHealth",
+                    "enabled": true,
+                    "description": "TTS server health test",
+                    "targets": {
+                        "tts_generation_time": 10,
+                        "sample_count": 10,
+                        "compare_audio": true
+                    }
+                },
+                {
+                    "template": "TTSParamTest",
+                    "enabled": true,
+                    "description": "TTS parameter variations test"
+                },
+                {
+                    "template": "TTSIntegrationTest",
+                    "enabled": true,
+                    "description": "TTS error handling and validation test"
+                }
+            ]
+        }
+    ]
+}

--- a/tt-inference-server-v2/test_module/test_suites/video.json
+++ b/tt-inference-server-v2/test_module/test_suites/video.json
@@ -1,0 +1,138 @@
+{
+    "_description": "Test suites for VIDEO model category (Wan2.2, Mochi)",
+    "_category": "VIDEO",
+    "test_matrices": [
+        {
+            "models": [
+                "wan"
+            ],
+            "devices": [
+                "t3k",
+                "galaxy",
+                "p150x4",
+                "p150x8",
+                "p300x2"
+            ],
+            "num_of_devices": 1,
+            "test_cases": [
+                {
+                    "template": "VideoGenerationLoadTest",
+                    "enabled": true,
+                    "description": "Video generation load test",
+                    "targets": {
+                        "video_generation_target_time": 370
+                    },
+                    "model_targets": {
+                        "wan+t3k": {
+                            "video_generation_target_time": 1200,
+                            "poll_timeout": 1500
+                        },
+                        "wan+galaxy": {
+                            "video_generation_target_time": 250,
+                            "poll_timeout": 550
+                        },
+                        "wan+p150x8": {
+                            "video_generation_target_time": 600,
+                            "poll_timeout": 900
+                        },
+                        "wan+p300x2": {
+                            "video_generation_target_time": 500,
+                            "poll_timeout": 800
+                        }
+                    }
+                },
+                {
+                    "template": "VideoGenerationParamTest",
+                    "enabled": true,
+                    "description": "Video generation param test"
+                }
+            ]
+        },
+        {
+            "models": [
+                "wan_i2v"
+            ],
+            "devices": [
+                "t3k",
+                "galaxy",
+                "p150x4",
+                "p150x8",
+                "p300x2"
+            ],
+            "num_of_devices": 1,
+            "test_cases": [
+                {
+                    "template": "VideoGenerationI2VTest",
+                    "enabled": true,
+                    "description": "Wan2.2 I2V end-to-end happy path",
+                    "targets": {
+                        "num_inference_steps": 40,
+                        "poll_timeout": 1200,
+                        "poll_interval": 5
+                    },
+                    "model_targets": {
+                        "wan_i2v+t3k": {
+                            "poll_timeout": 1500
+                        },
+                        "wan_i2v+galaxy": {
+                            "poll_timeout": 550
+                        },
+                        "wan_i2v+p150x8": {
+                            "poll_timeout": 900
+                        },
+                        "wan_i2v+p300x2": {
+                            "poll_timeout": 800
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "models": [
+                "mochi"
+            ],
+            "devices": [
+                "p150x4",
+                "p300x2",
+                "t3k",
+                "galaxy",
+                "p150x8"
+            ],
+            "num_of_devices": 1,
+            "test_cases": [
+                {
+                    "template": "VideoGenerationLoadTest",
+                    "enabled": true,
+                    "description": "Video generation load test",
+                    "targets": {
+                        "video_generation_target_time": 480,
+                        "num_inference_steps": 50
+                    },
+                    "model_targets": {
+                        "mochi+p300x2": {
+                            "video_generation_target_time": 900,
+                            "poll_timeout": 1100
+                        },
+                        "mochi+t3k": {
+                            "video_generation_target_time": 600,
+                            "poll_timeout": 900
+                        },
+                        "mochi+galaxy": {
+                            "video_generation_target_time": 650,
+                            "poll_timeout": 800
+                        },
+                        "mochi+p150x8": {
+                            "video_generation_target_time": 900,
+                            "poll_timeout": 1000
+                        }
+                    }
+                },
+                {
+                    "template": "VideoGenerationParamTest",
+                    "enabled": true,
+                    "description": "Video generation param test"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adds a test categorization + suite-config system to v2, enabling marker-based test selection and JSON-driven model/device coverag