### PR TITLE
Post sticky reminder to run tt-shield docker build on PRs touching docker files

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -93,6 +93,81 @@ jobs:
           chmod +x fix_dependencies.sh
           ./fix_dependencies.sh
 
+  manage-docker-build-reminder:
+    needs: detect-changes
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Manage docker build reminder comment
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      # Reminds PR authors to run tt-shield's docker build before merge when
+      # docker-related files change. Posts at most once per PR; removes itself
+      # if all docker changes are later reverted.
+      - name: Create or remove sticky reminder
+        uses: actions/github-script@v7
+        env:
+          SHOULD_HAVE_COMMENT: ${{ needs.detect-changes.outputs.media-server-deps }}
+        with:
+          script: |
+            const shouldHave = process.env.SHOULD_HAVE_COMMENT === 'true';
+            const pr = context.payload.pull_request;
+            const isFromFork = pr.head.repo.full_name !== pr.base.repo.full_name;
+            const ref = isFromFork ? pr.head.sha : pr.head.ref;
+            const refLabel = isFromFork ? 'commit SHA' : 'branch name';
+            const marker = '<!-- docker-build-reminder -->';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (shouldHave) {
+              if (existing) {
+                core.info('Reminder already present; leaving it untouched.');
+                return;
+              }
+              const body = [
+                marker,
+                '## Docker build sanity check needed',
+                '',
+                'This PR touches docker-related files (`Dockerfile*`, `requirements.txt`,',
+                '`uv-overrides.txt`, or `fix_dependencies.sh`). The pre-merge',
+                '`Verify Media Server Dep Install` job catches install-resolution',
+                'regressions but does **not** build the actual docker image.',
+                '',
+                "Before merging, please run [tt-shield's Build Inference Server workflow]",
+                '(https://github.com/tenstorrent/tt-shield/actions/workflows/on-dispatch-build-media-server.yml)',
+                'with these inputs:',
+                '',
+                '| Input | Value |',
+                '|---|---|',
+                '| `inference-server-type` | `media-inference-server` |',
+                `| \`inference-server-git-ref\` | \`${ref}\` (${refLabel}) |`,
+                '| `tt-metal-git-ref` | leave default (`main`) |',
+                '',
+                'Confirm the run succeeds and post the run link as a comment for reviewers.',
+              ].join('\n');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              core.info('Reminder created.');
+            } else if (existing) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+              });
+              core.info('Docker changes reverted; reminder deleted.');
+            } else {
+              core.info('No docker changes and no reminder; nothing to do.');
+            }
+
   unit-tests:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.should-test == 'true' }}

--- a/tt-media-server/uv-overrides.txt
+++ b/tt-media-server/uv-overrides.txt
@@ -23,7 +23,6 @@
 #    in the venv when this override file is consumed). whisperx==3.4.3
 #    declares numpy>=2.0.2, which would force a venv-wide numpy upgrade and
 #    break tt-metal's pin. whisperx is observed to run fine on numpy<2;
-
 #    overriding here keeps the venv consistent with tt-metal.
 numpy>=1.24.4,<2
 lightning @ https://files.pythonhosted.org/packages/0f/dd/86bb3bebadcdbc6e6e5a63657f0a03f74cd065b5ea965896679f76fec0b4/lightning-2.5.5.tar.gz

--- a/tt-media-server/uv-overrides.txt
+++ b/tt-media-server/uv-overrides.txt
@@ -23,6 +23,7 @@
 #    in the venv when this override file is consumed). whisperx==3.4.3
 #    declares numpy>=2.0.2, which would force a venv-wide numpy upgrade and
 #    break tt-metal's pin. whisperx is observed to run fine on numpy<2;
+
 #    overriding here keeps the venv consistent with tt-metal.
 numpy>=1.24.4,<2
 lightning @ https://files.pythonhosted.org/packages/0f/dd/86bb3bebadcdbc6e6e5a63657f0a03f74cd065b5ea965896679f76fec0b4/lightning-2.5.5.tar.gz


### PR DESCRIPTION
This PR adds a sticky PR comment that reminds the author to manually trigger tt-shield's `Build Inference Server` workflow before merge whenever they touch docker files.

| Scenario | Behavior |
|---|---|
| PR adds a docker-related change | Comment created |
| PR pushes more commits, docker changes still present | Comment left untouched (at most one per PR) |
| PR reverts all docker changes | Comment deleted |
| PR has no docker changes | No-op |
| Fork PR | Falls back to commit SHA instead of branch name (tt-shield's `find-latest-sha` only resolves refs in the canonical repo) |

<img width="905" height="545" alt="Screenshot 2026-05-07 at 13 25 42" src="https://github.com/user-attachments/assets/3cd59660-d926-417d-91e7-cf590e90af29" />
