### PR TITLE
Remove Non-Stream Specific Method from Reasoning Parser

### DIFF
--- a/tt-media-server/cpp_server/include/services/reasoning_parser.hpp
+++ b/tt-media-server/cpp_server/include/services/reasoning_parser.hpp
@@ -5,7 +5,6 @@
 
 #include <cstdint>
 #include <mutex>
-#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -15,15 +14,6 @@ namespace tt::services {
 enum class ContentType {
   REASONING,  // Inside <think>...</think> block
   ANSWER      // Outside reasoning block (normal content)
-};
-
-// Result of parsing complete text for reasoning blocks
-struct ReasoningParseResult {
-  std::optional<std::string> reasoning;  // Reasoning content (inside <think>)
-  std::string answer;                    // Answer content (outside <think>)
-  bool has_reasoning;                    // Whether reasoning was found
-  bool
-      is_malformed;  // Whether reasoning block is incomplete (missing </think>)
 };
 
 // Result of processing a single token
@@ -54,11 +44,6 @@ class ReasoningParser {
   // Token IDs for DeepSeek R1 reasoning markers
   static constexpr int64_t THINK_START_TOKEN = 128798;  // <think>
   static constexpr int64_t THINK_END_TOKEN = 128799;    // </think>
-  static constexpr int64_t NEWLINE_TOKEN = 201;         // \n
-
-  // String markers for text-based parsing
-  static constexpr const char* THINK_START_TAG = "<think>";
-  static constexpr const char* THINK_END_TAG = "</think>";
 
   ReasoningParser() = default;
   ~ReasoningParser() = default;
@@ -66,12 +51,6 @@ class ReasoningParser {
   // Non-copyable
   ReasoningParser(const ReasoningParser&) = delete;
   ReasoningParser& operator=(const ReasoningParser&) = delete;
-
-  /**
-   * Parse complete text to extract reasoning and answer.
-   * Used for non-streaming requests.
-   */
-  ReasoningParseResult parseComplete(const std::string& text) const;
 
   /**
    * Initialize streaming state for a task.

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -449,16 +449,6 @@ void LLMService::processStreamingRequest(
 }
 
 void LLMService::postProcess(LLMResponse& response) const {
-  // Parse and strip reasoning blocks from all choices
-  if (reasoningParser) {
-    for (auto& choice : response.choices) {
-      auto result = reasoningParser->parseComplete(choice.text);
-
-      // Replace text with answer only (reasoning stripped)
-      choice.text = std::move(result.answer);
-    }
-  }
-
   auto toolChoiceOpt = toolChoiceMap.take(response.task_id);
   tt::domain::tool_calls::ToolChoice toolChoice;
   if (toolChoiceOpt.has_value()) {

--- a/tt-media-server/cpp_server/src/services/reasoning_parser.cpp
+++ b/tt-media-server/cpp_server/src/services/reasoning_parser.cpp
@@ -3,89 +3,9 @@
 
 #include "services/reasoning_parser.hpp"
 
-#include <algorithm>
-#include <cassert>
-#include <cstring>
-
 #include "utils/logger.hpp"
 
 namespace tt::services {
-
-ReasoningParseResult ReasoningParser::parseComplete(
-    const std::string& text) const {
-  ReasoningParseResult result;
-
-  // Check if text starts with <think>
-  size_t startLen = std::strlen(THINK_START_TAG);
-  size_t endLen = std::strlen(THINK_END_TAG);
-
-  if (text.size() < startLen ||
-      text.compare(0, startLen, THINK_START_TAG) != 0) {
-    // No <think> tag at start - treat entire text as answer
-    result.reasoning = std::nullopt;
-    result.answer = text;
-    result.has_reasoning = false;
-    result.is_malformed = false;
-    return result;
-  }
-
-  // Has <think> tag at start
-  result.has_reasoning = true;
-
-  // Find </think> delimiter
-  size_t endPos = text.find(THINK_END_TAG, startLen);
-
-  if (endPos == std::string::npos) {
-    // Malformed: has <think> but no </think>
-    // Treat everything after <think> as reasoning, no answer
-    std::string reasoningContent = text.substr(startLen);
-
-    // Trim leading/trailing whitespace from reasoning
-    size_t first = reasoningContent.find_first_not_of("\n\r\t ");
-    size_t last = reasoningContent.find_last_not_of("\n\r\t ");
-
-    if (first != std::string::npos && last != std::string::npos) {
-      result.reasoning = reasoningContent.substr(first, last - first + 1);
-    } else {
-      result.reasoning = reasoningContent;
-    }
-
-    result.answer = "";
-    result.is_malformed = true;
-
-    TT_LOG_WARN(
-        "[ReasoningParser] Malformed output: found <think> but no </think>");
-    return result;
-  }
-
-  // Extract reasoning (between <think> and </think>)
-  std::string reasoningContent = text.substr(startLen, endPos - startLen);
-
-  // Trim leading/trailing whitespace from reasoning
-  size_t first = reasoningContent.find_first_not_of("\n\r\t ");
-  size_t last = reasoningContent.find_last_not_of("\n\r\t ");
-
-  if (first != std::string::npos && last != std::string::npos) {
-    result.reasoning = reasoningContent.substr(first, last - first + 1);
-  } else {
-    result.reasoning = reasoningContent;
-  }
-
-  // Extract answer (after </think>)
-  size_t answerStart = endPos + endLen;
-  std::string answerContent = text.substr(answerStart);
-
-  // Trim leading whitespace from answer
-  first = answerContent.find_first_not_of("\n\r\t ");
-  if (first != std::string::npos) {
-    result.answer = answerContent.substr(first);
-  } else {
-    result.answer = answerContent;
-  }
-
-  result.is_malformed = false;
-  return result;
-}
 
 void ReasoningParser::initializeTask(uint32_t taskId) {
   std::lock_guard<std::mutex> lock(mutex_);

--- a/tt-media-server/cpp_server/tests/test_reasoning_parser.cpp
+++ b/tt-media-server/cpp_server/tests/test_reasoning_parser.cpp
@@ -11,83 +11,6 @@
 
 using namespace tt::services;
 
-void testParseComplete() {
-  std::cout << "\n=== Testing parseComplete ===\n";
-
-  ReasoningParser parser;
-
-  // Test 1: Complete reasoning block
-  {
-    std::string input =
-        "<think>\nOkay, the user is asking about math.\n</think>\nThe answer "
-        "is 42.";
-    auto result = parser.parseComplete(input);
-
-    assert(result.has_reasoning);
-    assert(!result.is_malformed);
-    assert(result.reasoning.has_value());
-    assert(result.reasoning.value() == "Okay, the user is asking about math.");
-    assert(result.answer == "The answer is 42.");
-    std::cout << "✓ Test 1 passed: Complete reasoning block\n";
-  }
-
-  // Test 2: No reasoning block
-  {
-    std::string input = "The answer is 42.";
-    auto result = parser.parseComplete(input);
-
-    assert(!result.has_reasoning);
-    assert(!result.is_malformed);
-    assert(!result.reasoning.has_value());
-    assert(result.answer == "The answer is 42.");
-    std::cout << "✓ Test 2 passed: No reasoning block\n";
-  }
-
-  // Test 3: Malformed (missing </think>)
-  {
-    std::string input = "<think>\nOkay, the user is asking about math.";
-    auto result = parser.parseComplete(input);
-
-    assert(result.has_reasoning);
-    assert(result.is_malformed);
-    assert(result.reasoning.has_value());
-    assert(result.reasoning.value() == "Okay, the user is asking about math.");
-    assert(result.answer == "");
-    std::cout << "✓ Test 3 passed: Malformed (missing </think>)\n";
-  }
-
-  // Test 4: Empty reasoning
-  {
-    std::string input = "<think>\n\n</think>\nThe answer is 42.";
-    auto result = parser.parseComplete(input);
-
-    assert(result.has_reasoning);
-    assert(!result.is_malformed);
-    // Empty reasoning after trimming should be empty string
-    assert(result.answer == "The answer is 42.");
-    std::cout << "✓ Test 4 passed: Empty reasoning\n";
-  }
-
-  // Test 5: Multi-line reasoning
-  {
-    std::string input =
-        "<think>\nFirst, I need to understand the question.\nThen I'll "
-        "calculate.\nFinally, I'll provide the answer.\n</think>\nThe answer "
-        "is 42.";
-    auto result = parser.parseComplete(input);
-
-    assert(result.has_reasoning);
-    assert(!result.is_malformed);
-    assert(result.reasoning.has_value());
-    assert(result.reasoning.value().find("First") != std::string::npos);
-    assert(result.reasoning.value().find("Finally") != std::string::npos);
-    assert(result.answer == "The answer is 42.");
-    std::cout << "✓ Test 5 passed: Multi-line reasoning\n";
-  }
-
-  std::cout << "✅ All parseComplete tests passed!\n";
-}
-
 void testStreamingTokens() {
   std::cout << "\n=== Testing Streaming Tokens ===\n";
 
@@ -468,7 +391,6 @@ int main() {
   std::cout << "╚══════════════════════════════════════════════════════════╝\n";
 
   try {
-    testParseComplete();
     testStreamingTokens();
     testMultipleTasks();
     testEdgeCases();


### PR DESCRIPTION
## Issue
### [#3382 Cleanup Legacy NonStreaming Code Paths](https://github.com/tenstorrent/tt-inference-server/issues/3382)

## Problem 
In the non-streaming flow, we accumulate chunks received from streaming model responses. As a result, each generated token passes through`LLMService`’s `consumerLoopForWorker`, where `ReasoningParser::processToken` is invoked.

With this setup, the legacy `parseComplete` method was only introducing unnecessary overhead, so it is removed with this PR.

## Testing
[reasoning_parser_test.txt](https://github.com/user-attachments/files/27476981/reasoning_parser_test.txt)