### PR TITLE
Fix Forge LLM models so local launches work without --override-docker-image

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -206,6 +206,7 @@ class ImplSpec:
     impl_name: str
     repo_url: str
     code_path: str
+    default_model_runner: Optional[str] = None
 
 
 tt_transformers_impl = ImplSpec(
@@ -255,6 +256,7 @@ forge_vllm_plugin_impl = ImplSpec(
     impl_name="forge-vllm-plugin",
     repo_url="https://github.com/tenstorrent/tt-xla/tree/main",
     code_path="integrations/vllm_plugin",
+    default_model_runner="vllm_forge",
 )
 tt_vllm_plugin_impl = ImplSpec(
     impl_id="tt_vllm_plugin",
@@ -406,9 +408,15 @@ class ModelSpec:
             "VLLM_TARGET_DEVICE": "tt",
             "TORCHDYNAMO_DISABLE": "1",
         }
-        # order of precedence: default, env_vars, device_model_spec
+        impl_env_vars = (
+            {"MODEL_RUNNER": self.impl.default_model_runner}
+            if self.impl.default_model_runner
+            else {}
+        )
+        # order of precedence: default, impl, env_vars, device_model_spec
         merged_env_vars = {
             **default_env_vars,
+            **impl_env_vars,
             **self.env_vars,
             **self.device_model_spec.env_vars,
         }

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -3554,11 +3554,11 @@ embedding_templates = [
 cnn_templates = [
     ModelSpecTemplate(
         weights=["Qwen/Qwen3-4B"],
-        tt_metal_commit="2496be4",
+        version="0.13.0",
+        tt_metal_commit="079a2c2",
         impl=forge_vllm_plugin_impl,
         min_disk_gb=15,
         min_ram_gb=8,
-        docker_image="ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
         model_type=ModelType.LLM,
         inference_engine=InferenceEngine.FORGE.value,
         uses_tensor_model_cache=False,
@@ -3589,11 +3589,11 @@ cnn_templates = [
     ),
     ModelSpecTemplate(
         weights=["meta-llama/Llama-3.2-3B", "meta-llama/Llama-3.2-3B-Instruct"],
-        tt_metal_commit="2496be4",
+        version="0.13.0",
+        tt_metal_commit="079a2c2",
         impl=forge_vllm_plugin_impl,
         min_disk_gb=15,
         min_ram_gb=8,
-        docker_image="ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
         model_type=ModelType.LLM,
         inference_engine=InferenceEngine.FORGE.value,
         uses_tensor_model_cache=False,

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -231,6 +231,8 @@ def generate_docker_run_command(
         model_spec.inference_engine == InferenceEngine.FORGE.value
         or model_spec.inference_engine == InferenceEngine.MEDIA.value
     ):
+        if model_spec.env_vars:
+            docker_env_vars.update(model_spec.env_vars)
         docker_env_vars.update(get_media_server_docker_env_vars(model_spec))
         api_key = os.getenv("API_KEY")
         if api_key:


### PR DESCRIPTION
### Problem

Local launches of the Forge LLM templates (`Qwen3-4B`, `Llama-3.2-3B[-Instruct]`) fail at startup with `'<model>' is not a valid ModelNames`:

1. Both templates hardcode a stale `docker_image=tt-media-inference-server:0.2.0-2496be4...` that predates LLM support and lacks them in its `ModelNames` enum.
2. Also, the template doesn't declaratively pin which container runner the model uses, so resolution falls back to the image's baked `ENV MODEL_RUNNER` default (`tt-xla-resnet`), which silently misroutes non-resnet models. (#3200 already removed that directive from `Dockerfile.forge`, but the only published public Forge image predates that fix.)

CI doesn't trip on either — tt-shield always passes `--override-docker-image` and sets `MODEL_RUNNER` per-job.

### Changes

`workflows/model_spec.py`:
- Drop hardcoded `docker_image=` from Qwen3-4B and Llama-3.2-3B templates; add `version="0.13.0"`, `tt_metal_commit="079a2c2"` so they auto-derive to the current Forge image (same one resnet-50 uses).
- Add `default_model_runner` to `ImplSpec`; set `"vllm_forge"` on `forge_vllm_plugin_impl`.
- `ModelSpec.__post_init__` surfaces the impl default as `MODEL_RUNNER` in `env_vars`. Per-template / per-device `env_vars` still override (escape hatch for embedding templates that share the impl but use a different runner).

`workflows/run_docker_server.py`:
- Propagate `model_spec.env_vars` into `docker run -e` flags for forge/media engines so the impl-derived `MODEL_RUNNER` reaches the container.

### Testing

Verified spec-side blockers are gone: Qwen3-4B now boots without `--override-docker-image` or `MODEL_RUNNER` env tweaks; runner resolves to `vllm_forge`, LLM routes register, weights download and warmup begins.

End-to-end inference not yet verified — model compile crashes during warmup `loc("custom-call.825"): error: failed to legalize operation 'ttir.paged_fill_cache'` on the only hardware I had local access to (Blackhole QB2 using single chip P150, which is outside this spec's declared `N150`/`N300` targets). That's a separate upstream issue, unaffected by this PR. 

### Compatibility

CI is unaffected — tt-shield continues to pass `--override-docker-image`, and the auto-derived image matches the resnet-50 entry's image (already exercised by CI).