### PR TITLE
update unit-tests and test-coverage jobs

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -198,6 +198,7 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements-dev.txt
           pip install -r tt-media-server/requirements.txt
+          pip install pytest-cov
 
       - name: Run tt-inference-server tests
         run: |
@@ -211,11 +212,17 @@ jobs:
           HF_TOKEN: ""
           MODEL: ""
           JWT_SECRET: ""
-        working-directory: tt-media-server
         run: |
           echo "Running tests from tt-media-server/tests/"
-          pytest tests/ -v --tb=short --continue-on-collection-errors > ../media_test_output.txt 2>&1 || true
-          cat ../media_test_output.txt
+          # Run from repo root so coverage.xml has paths like "tt-media-server/..."
+          # This makes paths match git diff output for diff-cover
+          pytest tt-media-server/tests/ \
+            --ignore=tt-media-server/performance_tests/ \
+            --cov=tt-media-server \
+            --cov-report=xml:coverage.xml \
+            --cov-report=term-missing \
+            -v --tb=short --continue-on-collection-errors > media_test_output.txt 2>&1 || true
+          cat media_test_output.txt
 
       - name: Test Results Summary
         if: always()
@@ -348,6 +355,15 @@ jobs:
             echo "💥 Failing workflow due to test failures"
             exit 1
           fi
+
+      - name: Upload coverage artifact
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data
+          path: coverage.xml
+          retention-days: 1
+          if-no-files-found: warn
 
       - name: Comment on PR
         if: always() && github.event_name == 'pull_request'
@@ -1545,15 +1561,13 @@ jobs:
           pytest tt_model_runners/forge_runners/test_forge_models.py -k "cpu" -v
 
   test-coverage:
-    needs: detect-changes
+    needs: [detect-changes, unit-tests]
     if: ${{ needs.detect-changes.outputs.should-test == 'true' && github.event_name == 'pull_request' }}
     name: Test Coverage Check
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-    env:
-      PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/tt-media-server
 
     steps:
       - name: Checkout repository
@@ -1565,30 +1579,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-          cache: 'pip'
-          cache-dependency-path: 'requirements-dev.txt'
 
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip
-          pip install -r requirements-dev.txt
-          pip install -r tt-media-server/requirements.txt
-          pip install pytest-cov diff-cover
+      - name: Install diff-cover
+        run: pip install diff-cover
 
-      - name: Run tt-media-server tests with coverage
-        env:
-          HF_TOKEN: ""
-          MODEL: ""
-          JWT_SECRET: ""
-        run: |
-          # Run from repo root so coverage.xml has paths like "tt-media-server/..."
-          # This makes paths match git diff output
-          pytest tt-media-server/tests/ \
-            --ignore=tt-media-server/performance_tests/ \
-            --cov=tt-media-server \
-            --cov-report=xml:coverage.xml \
-            --cov-report=term-missing \
-            -v --tb=short --continue-on-collection-errors || true
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: coverage-data
+          path: .
 
       - name: Check coverage of changed lines
         id: diff-cover


### PR DESCRIPTION
#1637

 ## Summary                                                                                                                                                                              
                                         
  Run pytest **once** with coverage instead of twice. Pass `coverage.xml` via artifact from `unit-tests` to `test-coverage`.                                                              
   
  ## Changes                                                                                                                                                                              
                                                            
  - `unit-tests`: Add `--cov` flags, upload `coverage.xml` artifact
  - `test-coverage`: Download artifact instead of re-running tests
                                                                                                                                                                                          
  ## Impact
                                                                                                                                                                                          
  - `test-coverage` job: **2-3 min → 15 seconds**                                                                                                                                         
  - Total pytest runs: 2 → 1