### PR TITLE
fix: read override_tt_config from vllm_config instead of hardcoded empty dict

### DIFF
--- a/tt-vllm-plugin/tt_vllm_plugin/platform.py
+++ b/tt-vllm-plugin/tt_vllm_plugin/platform.py
@@ -100,7 +100,7 @@ class TTPlatform(Platform):
         # TODO move this to tt_model_runner when request validation
         # stops depending on vllm_config
 
-        override_tt_config = {}
+        override_tt_config = getattr(vllm_config.model_config, "override_tt_config", {})
         if (
             override_tt_config is not None
             and "sample_on_device_mode" in override_tt_config

--- a/tt-vllm-plugin/tt_vllm_plugin/v1/worker/tt_worker.py
+++ b/tt-vllm-plugin/tt_vllm_plugin/v1/worker/tt_worker.py
@@ -49,12 +49,11 @@ class TTWorker(WorkerBase):
             vllm_config, local_rank, rank, distributed_init_method, is_driver_worker
         )
 
-        # Initialized by init_device
+       # Initialized by init_device
         self.mesh_device = None
-        self.model_config.override_tt_config = {}
 
         # Whether to use ttnn tracing for model execution
-        override_tt_config = self.model_config.override_tt_config
+        override_tt_config = getattr(self.model_config, "override_tt_config", {})
         trace_key = "trace_mode"
         self.trace_mode = True
         if override_tt_config and trace_key in override_tt_config:


### PR DESCRIPTION
## Summary

Two related bugs caused `--override-tt-config` values to be silently
discarded at startup, making runtime configuration of
`sample_on_device_mode`, `always_compat_sampling`, and `trace_mode`
completely ineffective.

## Root Cause

**`platform.py`** — `check_and_update_config` assigned
`override_tt_config = {}` unconditionally, so the config read from
`vllm_config.model_config` was never consulted. All downstream
`if ... in override_tt_config` checks were always false.

**`v1/worker/tt_worker.py`** — `TTWorker.__init__` clobbered
`self.model_config.override_tt_config = {}` before reading it,
causing `trace_mode` to always fall back to its default of `True`
regardless of what was passed via `--override-tt-config`.

## Fix

- `platform.py`: replace `override_tt_config = {}` with
  `getattr(vllm_config.model_config, "override_tt_config", {})`.
- `tt_worker.py`: remove the clobber assignment; read the existing
  attribute safely with `getattr(self.model_config, "override_tt_config", {})`.

## Testing

Behavior is unchanged when `--override-tt-config` is not passed
(both `getattr` calls default to `{}`). When a config is passed,
`sample_on_device_mode`, `always_compat_sampling`, and `trace_mode`
are now correctly applied.

## Files Changed

- `tt-vllm-plugin/tt_vllm_plugin/platform.py`
- `tt-vllm-plugin/tt_vllm_plugin/v1/worker/tt_worker.py`