### PR TITLE
fix(model_spec): add max_num_batched_tokens field to DeviceModelSpec

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -289,6 +289,7 @@ class DeviceModelSpec:
     device: DeviceTypes
     max_concurrency: int
     max_context: int
+    max_num_batched_tokens: Optional[int] = None
     perf_targets_map: Dict[str, float] = field(default_factory=dict)
     default_impl: bool = False
     perf_reference: List[BenchmarkTaskParams] = field(default_factory=list)
@@ -308,23 +309,23 @@ class DeviceModelSpec:
 
     def _infer_data(self):
         """Infer missing data fields from other specification values."""
-        max_tokens_all_users = self.max_context
+        effective_max_num_batched_tokens = (
+            self.max_num_batched_tokens
+            if self.max_num_batched_tokens is not None
+            else self.max_context
+        )
+        max_tokens_all_users = effective_max_num_batched_tokens
         max_concurrency = self.max_concurrency
         if data_parallel_size := self.vllm_args.get("data_parallel_size"):
             assert isinstance(data_parallel_size, int)
-            # vllm args need to be set per engine instance, the number of which is
-            # the data_parallel_size (# of DP ranks). The variables must be computed
-            # and passed to client consumers however that will make requests to the
-            # DP engines without needing to know about DP rank.
             max_concurrency = max_concurrency // data_parallel_size
             max_tokens_all_users = max_tokens_all_users * data_parallel_size
         object.__setattr__(self, "max_tokens_all_users", max_tokens_all_users)
-        # TODO: we should get max_num_batched_tokens from DeviceModelSpec in the future
         default_vllm_args = {
             "block_size": "64",
             "max_model_len": str(self.max_context),
             "max_num_seqs": str(max_concurrency),
-            "max_num_batched_tokens": str(self.max_context),
+            "max_num_batched_tokens": str(effective_max_num_batched_tokens),
             "max-log-len": "32",
             "seed": "9472",
             "override_tt_config": json.dumps(self.override_tt_config),


### PR DESCRIPTION
## Summary

Adds an optional `max_num_batched_tokens` field to `DeviceModelSpec` so
that models with a hardware memory budget different from their context
window can express that independently, without corrupting the semantics
of `max_context`.

Closes #2491

## Problem

`max_num_batched_tokens` was hardcoded to `str(self.max_context)` in
`DeviceModelSpec._infer_data()`. A TODO comment acknowledged this was
wrong. As a workaround, at least one model spec (Qwen3-32B on Galaxy)
inflates `max_context` just to get the right `max_num_batched_tokens`
value, with a NOTE comment explaining the hack. This also incorrectly
sets `--max-model-len` in the vllm args to a value the hardware does not
actually support.

## Fix

- Added `max_num_batched_tokens: Optional[int] = None` to `DeviceModelSpec`.
- When set, `_infer_data` uses it for `--max-num-batched-tokens` and as
  the base for `max_tokens_all_users` (used by client-side benchmark
  concurrency math).
- When `None` (all existing specs), falls back to `max_context` —
  identical to current behavior. No existing spec is changed.
- Removes the TODO comment.

## Testing

All 19 existing model spec unit tests pass unchanged.

## Notes

The Qwen3-32B Galaxy spec NOTE comment is left in place intentionally.
The new field unblocks cleaning that up correctly, but the right values
require hardware-side verification by the model owner.