### PR TITLE
Improve cpp build output

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -72,6 +72,16 @@ FetchContent_Declare(googletest
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
+# GCC 12's libstdc++ still uses the C++17-deprecated std::get_temporary_buffer
+# inside std::stable_sort, which gtest.cc triggers when sorting TestInfo*.
+# Silence on the googletest targets only — keep -Wdeprecated-declarations active
+# for our own code.
+foreach(_gt_target gtest gtest_main gmock gmock_main)
+    if(TARGET ${_gt_target})
+        target_compile_options(${_gt_target} PRIVATE -Wno-deprecated-declarations)
+    endif()
+endforeach()
+
 # xxHash for stable, cross-platform hashing (conversation prefix caching)
 FetchContent_Declare(
     xxhash

--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -112,7 +112,7 @@ if(NOT xgrammar_POPULATED)
         "set(XGRAMMAR_ENABLE_INTERNAL_CHECK OFF)\n"
     )
     add_subdirectory(${xgrammar_SOURCE_DIR} ${xgrammar_BINARY_DIR})
-    target_compile_options(xgrammar PRIVATE -Wno-error=deprecated-declarations -fno-lto)
+    target_compile_options(xgrammar PRIVATE -Wno-deprecated-declarations -fno-lto)
 endif()
 
 # Import fmt from tt-metal for spdlog

--- a/tt-media-server/cpp_server/build.sh
+++ b/tt-media-server/cpp_server/build.sh
@@ -87,6 +87,31 @@ if [ "${SANITIZE_THREAD}" = "ON" ] && [ "${SANITIZE_ADDRESS}" = "ON" ]; then
     exit 1
 fi
 
+# --blaze requires tt-blaze/pipeline_manager (cloned out-of-band; not a submodule
+# with a tracked URL). Fail early with a clear setup hint instead of letting
+# CMake bail out on a missing add_subdirectory().
+if [ "${ENABLE_BLAZE}" = "ON" ] && [ ! -f "${SCRIPT_DIR}/tt-blaze/pipeline_manager/CMakeLists.txt" ]; then
+    echo ""
+    echo "ERROR: --blaze requires tt-blaze/pipeline_manager but ${SCRIPT_DIR}/tt-blaze is missing or empty."
+    echo ""
+    echo "  Clone tt-blaze (private repo — needs a GitHub token with read access):"
+    echo "    rm -rf ${SCRIPT_DIR}/tt-blaze"
+    echo "    git clone --depth 1 --branch asaigal/relaxed_acceptance \\"
+    echo "        https://x-access-token:\${GITHUB_TOKEN}@github.com/tenstorrent/tt-blaze.git \\"
+    echo "        ${SCRIPT_DIR}/tt-blaze"
+    echo "    cd ${SCRIPT_DIR}/tt-blaze && git submodule update --init --recursive --depth 1"
+    echo "    ./install.sh && . ./env.sh"
+    echo "    (cd tt-metal && ./build_metal.sh --disable-profiler)"
+    echo "    ./pipeline_manager/setup.sh --pm-full"
+    echo ""
+    echo "  Then point TT_METAL_HOME at the bundled tt-metal and re-run this script:"
+    echo "    export TT_METAL_HOME=${SCRIPT_DIR}/tt-blaze/tt-metal"
+    echo "    ./build.sh --blaze"
+    echo ""
+    echo "  See Dockerfile.blaze in the repo root for the canonical setup."
+    exit 1
+fi
+
 echo "=============================================="
 echo "  Building TT Media Server (C++ Drogon)"
 echo "  Build type: ${BUILD_TYPE}"
@@ -95,9 +120,6 @@ echo "  AddressSanitizer: ${SANITIZE_ADDRESS}"
 echo "  Tracy: ${ENABLE_TRACY}"
 echo "  Blaze: ${ENABLE_BLAZE}"
 echo "  Clang-Tidy: ${CLANG_TIDY}"
-echo "  AddressSanitizer: ${SANITIZE_ADDRESS}"
-echo "  Tracy profiling: ${ENABLE_TRACY}"
-echo "  Clang-tidy: ${CLANG_TIDY}"
 echo "  Kafka (KAFKA_ENABLED): ${KAFKA_ENABLED}"
 echo "=============================================="
 

--- a/tt-media-server/cpp_server/build.sh
+++ b/tt-media-server/cpp_server/build.sh
@@ -87,31 +87,6 @@ if [ "${SANITIZE_THREAD}" = "ON" ] && [ "${SANITIZE_ADDRESS}" = "ON" ]; then
     exit 1
 fi
 
-# --blaze requires tt-blaze/pipeline_manager (cloned out-of-band; not a submodule
-# with a tracked URL). Fail early with a clear setup hint instead of letting
-# CMake bail out on a missing add_subdirectory().
-if [ "${ENABLE_BLAZE}" = "ON" ] && [ ! -f "${SCRIPT_DIR}/tt-blaze/pipeline_manager/CMakeLists.txt" ]; then
-    echo ""
-    echo "ERROR: --blaze requires tt-blaze/pipeline_manager but ${SCRIPT_DIR}/tt-blaze is missing or empty."
-    echo ""
-    echo "  Clone tt-blaze (private repo — needs a GitHub token with read access):"
-    echo "    rm -rf ${SCRIPT_DIR}/tt-blaze"
-    echo "    git clone --depth 1 --branch asaigal/relaxed_acceptance \\"
-    echo "        https://x-access-token:\${GITHUB_TOKEN}@github.com/tenstorrent/tt-blaze.git \\"
-    echo "        ${SCRIPT_DIR}/tt-blaze"
-    echo "    cd ${SCRIPT_DIR}/tt-blaze && git submodule update --init --recursive --depth 1"
-    echo "    ./install.sh && . ./env.sh"
-    echo "    (cd tt-metal && ./build_metal.sh --disable-profiler)"
-    echo "    ./pipeline_manager/setup.sh --pm-full"
-    echo ""
-    echo "  Then point TT_METAL_HOME at the bundled tt-metal and re-run this script:"
-    echo "    export TT_METAL_HOME=${SCRIPT_DIR}/tt-blaze/tt-metal"
-    echo "    ./build.sh --blaze"
-    echo ""
-    echo "  See Dockerfile.blaze in the repo root for the canonical setup."
-    exit 1
-fi
-
 echo "=============================================="
 echo "  Building TT Media Server (C++ Drogon)"
 echo "  Build type: ${BUILD_TYPE}"

--- a/tt-media-server/cpp_server/include/domain/manage_memory.hpp
+++ b/tt-media-server/cpp_server/include/domain/manage_memory.hpp
@@ -25,7 +25,7 @@ struct ManageMemoryTask {
   uint32_t taskId;
   MemoryManagementAction action{MemoryManagementAction::ALLOCATE};
   KvMemoryLayout memoryLayout{KvMemoryLayout::PAGED};
-  uint32_t slotId;
+  uint32_t slotId{};
 
   void serialize(std::ostream& os) const {
     os.write(reinterpret_cast<const char*>(&taskId), sizeof(taskId));

--- a/tt-media-server/cpp_server/include/runners/embedding_runner.hpp
+++ b/tt-media-server/cpp_server/include/runners/embedding_runner.hpp
@@ -50,7 +50,7 @@ class EmbeddingRunner : public IRunner {
   // IRunner interface implementation
   void run() override;
   void stop() override;
-  const char* runnerType() const { return "EmbeddingRunner"; }
+  const char* runnerType() const override { return "EmbeddingRunner"; }
 
   /**
    * Get the device ID.

--- a/tt-media-server/cpp_server/include/services/embedding_service.hpp
+++ b/tt-media-server/cpp_server/include/services/embedding_service.hpp
@@ -34,7 +34,8 @@ class EmbeddingService
   size_t currentQueueSize() const override;
   void postProcess(domain::EmbeddingResponse& response) const override;
 
-  domain::EmbeddingResponse processRequest(domain::EmbeddingRequest request) override;
+  domain::EmbeddingResponse processRequest(
+      domain::EmbeddingRequest request) override;
 
  private:
   struct Impl;

--- a/tt-media-server/cpp_server/include/services/embedding_service.hpp
+++ b/tt-media-server/cpp_server/include/services/embedding_service.hpp
@@ -28,13 +28,13 @@ class EmbeddingService
 
   void start() override;
   void stop() override;
-  bool isModelReady() const;
+  bool isModelReady() const override;
 
  protected:
-  size_t currentQueueSize() const;
-  void postProcess(domain::EmbeddingResponse& response) const;
+  size_t currentQueueSize() const override;
+  void postProcess(domain::EmbeddingResponse& response) const override;
 
-  domain::EmbeddingResponse processRequest(domain::EmbeddingRequest request);
+  domain::EmbeddingResponse processRequest(domain::EmbeddingRequest request) override;
 
  private:
   struct Impl;

--- a/tt-media-server/cpp_server/src/main.cpp
+++ b/tt-media-server/cpp_server/src/main.cpp
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 #include <drogon/drogon.h>
+#include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 
 #include <atomic>
@@ -16,9 +18,6 @@
 #include <thread>
 #include <utility>
 #include <vector>
-
-#include <netinet/in.h>
-#include <sys/socket.h>
 
 #include "api/error_response.hpp"
 #include "api/route_registry.hpp"
@@ -56,7 +55,8 @@ bool probePort(const std::string& host, uint16_t port) {
   addr.sin_port = htons(port);
   if (::inet_pton(AF_INET, host.c_str(), &addr.sin_addr) <= 0)
     addr.sin_addr.s_addr = INADDR_ANY;
-  bool available = (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0);
+  bool available =
+      (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0);
   ::close(sock);
   return available;
 }
@@ -172,8 +172,10 @@ int main(int argc, char* argv[]) {
   // If we skip this and Drogon fails to bind later, workers are already running
   // and the warmup signal queue gets removed mid-lifecycle — causing a crash.
   if (!probePort(host, port)) {
-    TT_LOG_CRITICAL("[Main] Port {} is already in use. "
-                    "Stop the existing server before starting a new one.", port);
+    TT_LOG_CRITICAL(
+        "[Main] Port {} is already in use. "
+        "Stop the existing server before starting a new one.",
+        port);
     return 1;
   }
   TT_LOG_INFO("[Main] Port {} is available", port);

--- a/tt-media-server/cpp_server/src/main.cpp
+++ b/tt-media-server/cpp_server/src/main.cpp
@@ -17,6 +17,9 @@
 #include <utility>
 #include <vector>
 
+#include <netinet/in.h>
+#include <sys/socket.h>
+
 #include "api/error_response.hpp"
 #include "api/route_registry.hpp"
 #include "config/defaults.hpp"
@@ -38,6 +41,25 @@
 namespace {
 
 volatile std::sig_atomic_t gShutdownRequested = 0;
+
+// Returns true if the port is available, false if already in use.
+bool probePort(const std::string& host, uint16_t port) {
+  int sock = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (sock < 0) {
+    TT_LOG_ERROR("[Main] Failed to create probe socket: {}", strerror(errno));
+    return false;
+  }
+  int reuse = 1;
+  ::setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+  struct sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  if (::inet_pton(AF_INET, host.c_str(), &addr.sin_addr) <= 0)
+    addr.sin_addr.s_addr = INADDR_ANY;
+  bool available = (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0);
+  ::close(sock);
+  return available;
+}
 
 void signalHandler(int signal) {
   TT_LOG_WARN("\n[Main] Received signal {}, initiating shutdown...", signal);
@@ -146,6 +168,16 @@ int main(int argc, char* argv[]) {
   // (initializeServices() starts the WorkerManager which fork+execv's
   // workers). The unique_ptr below owns the lifecycle: its destructor
   // munmaps and shm_unlinks on scope exit, so there is no explicit teardown.
+  // Pre-flight port probe: verify the port is available before forking workers.
+  // If we skip this and Drogon fails to bind later, workers are already running
+  // and the warmup signal queue gets removed mid-lifecycle — causing a crash.
+  if (!probePort(host, port)) {
+    TT_LOG_CRITICAL("[Main] Port {} is already in use. "
+                    "Stop the existing server before starting a new one.", port);
+    return 1;
+  }
+  TT_LOG_INFO("[Main] Port {} is available", port);
+
   const std::string shmName = tt::config::workerMetricsShmName();
   const size_t numWorkers = tt::config::numWorkers();
   auto shm = tt::worker::WorkerMetricsShm::create(shmName, numWorkers);

--- a/tt-media-server/cpp_server/src/worker/single_process_worker.cpp
+++ b/tt-media-server/cpp_server/src/worker/single_process_worker.cpp
@@ -46,11 +46,16 @@ void fatalSignalHandler(int sig) {
   const char* sigName = strsignal(sig);
   if (!sigName) sigName = "unknown";
 
-  if (write(STDERR_FILENO, prefix, sizeof(prefix) - 1) < 0) {}
-  if (write(STDERR_FILENO, idBuf, len) < 0) {}
-  if (write(STDERR_FILENO, mid, sizeof(mid) - 1) < 0) {}
-  if (write(STDERR_FILENO, sigName, strlen(sigName)) < 0) {}
-  if (write(STDERR_FILENO, suffix, sizeof(suffix) - 1) < 0) {}
+  if (write(STDERR_FILENO, prefix, sizeof(prefix) - 1) < 0) {
+  }
+  if (write(STDERR_FILENO, idBuf, len) < 0) {
+  }
+  if (write(STDERR_FILENO, mid, sizeof(mid) - 1) < 0) {
+  }
+  if (write(STDERR_FILENO, sigName, strlen(sigName)) < 0) {
+  }
+  if (write(STDERR_FILENO, suffix, sizeof(suffix) - 1) < 0) {
+  }
 
   signal(sig, SIG_DFL);
   raise(sig);

--- a/tt-media-server/cpp_server/src/worker/single_process_worker.cpp
+++ b/tt-media-server/cpp_server/src/worker/single_process_worker.cpp
@@ -46,11 +46,11 @@ void fatalSignalHandler(int sig) {
   const char* sigName = strsignal(sig);
   if (!sigName) sigName = "unknown";
 
-  write(STDERR_FILENO, prefix, sizeof(prefix) - 1);
-  write(STDERR_FILENO, idBuf, len);
-  write(STDERR_FILENO, mid, sizeof(mid) - 1);
-  write(STDERR_FILENO, sigName, strlen(sigName));
-  write(STDERR_FILENO, suffix, sizeof(suffix) - 1);
+  if (write(STDERR_FILENO, prefix, sizeof(prefix) - 1) < 0) {}
+  if (write(STDERR_FILENO, idBuf, len) < 0) {}
+  if (write(STDERR_FILENO, mid, sizeof(mid) - 1) < 0) {}
+  if (write(STDERR_FILENO, sigName, strlen(sigName)) < 0) {}
+  if (write(STDERR_FILENO, suffix, sizeof(suffix) - 1) < 0) {}
 
   signal(sig, SIG_DFL);
   raise(sig);


### PR DESCRIPTION
Working with Aditya I noticed two things that confuse new people working with our code

- Many build warnings
- Misleading error when port is already in use (below)

```
[2026-05-06 00:08:48.617104] [tt-media-server] [error] [BoostIpcQueue] Failed to open existing queue: tt_warmup_signals
[2026-05-06 00:08:48.617122] [tt-media-server] [error] [SingleProcessWorker] Worker 0 failed to signal warmup: Failed to open existing queue: tt_warmup_signals 2 No such file or directory
```

This fixes both