### PR TITLE
cpp server - fix tt_warmup_signals shm collision between co-located servers

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1018,7 +1018,15 @@ jobs:
       - name: Start Decode server (receives HTTP, listens for prefill)
         run: |
           cd cpp_server/build
+          NS=r1_decode
           LLM_MODE=decode SOCKET_HOST=0.0.0.0 SOCKET_PORT=9000 \
+          TT_WARMUP_SIGNALS_QUEUE=tt_warmup_signals_$NS \
+          TT_TASK_QUEUE=tt_tasks_$NS \
+          TT_RESULT_QUEUE=tt_results_$NS \
+          TT_CANCEL_QUEUE=tt_cancels_$NS \
+          TT_MEMORY_REQUEST_QUEUE=tt_mem_requests_$NS \
+          TT_MEMORY_RESULT_QUEUE=tt_mem_results_$NS \
+          TT_WORKER_METRICS_SHM=/tt_worker_metrics_$NS \
             ./tt_media_server_cpp -p 8001 -t 4 > ../../decode_server.log 2>&1 &
           echo $! > ../../decode_server.pid
           cd ../..
@@ -1039,7 +1047,15 @@ jobs:
       - name: Start Prefill server (connects to decode server)
         run: |
           cd cpp_server/build
+          NS=r1_prefill
           LLM_MODE=prefill SOCKET_HOST=127.0.0.1 SOCKET_PORT=9000 \
+          TT_WARMUP_SIGNALS_QUEUE=tt_warmup_signals_$NS \
+          TT_TASK_QUEUE=tt_tasks_$NS \
+          TT_RESULT_QUEUE=tt_results_$NS \
+          TT_CANCEL_QUEUE=tt_cancels_$NS \
+          TT_MEMORY_REQUEST_QUEUE=tt_mem_requests_$NS \
+          TT_MEMORY_RESULT_QUEUE=tt_mem_results_$NS \
+          TT_WORKER_METRICS_SHM=/tt_worker_metrics_$NS \
             ./tt_media_server_cpp -p 8002 -t 4 > ../../prefill_server.log 2>&1 &
           echo $! > ../../prefill_server.pid
           cd ../..
@@ -1108,10 +1124,18 @@ jobs:
       - name: Start Prefill server (mock_prefill_runner round)
         run: |
           cd cpp_server
+          NS=r2_prefill
           TT_IPC_SHM_C2P=tt_ipc_c2p TT_IPC_SHM_P2C=tt_ipc_p2c \
           TT_LOG_LEVEL=debug \
           LLM_MODE=prefill LLM_DEVICE_BACKEND=prefill \
           SOCKET_HOST=127.0.0.1 SOCKET_PORT=9000 \
+          TT_WARMUP_SIGNALS_QUEUE=tt_warmup_signals_$NS \
+          TT_TASK_QUEUE=tt_tasks_$NS \
+          TT_RESULT_QUEUE=tt_results_$NS \
+          TT_CANCEL_QUEUE=tt_cancels_$NS \
+          TT_MEMORY_REQUEST_QUEUE=tt_mem_requests_$NS \
+          TT_MEMORY_RESULT_QUEUE=tt_mem_results_$NS \
+          TT_WORKER_METRICS_SHM=/tt_worker_metrics_$NS \
             ./build/tt_media_server_cpp -p 8001 -t 4 \
             > ../prefill_server_runner.log 2>&1 &
           echo $! > ../prefill_server_runner.pid
@@ -1134,8 +1158,16 @@ jobs:
       - name: Start Decode server (mock_prefill_runner round)
         run: |
           cd cpp_server
+          NS=r2_decode
           LLM_MODE=decode SOCKET_HOST=0.0.0.0 SOCKET_PORT=9000 \
           TT_LOG_LEVEL=debug \
+          TT_WARMUP_SIGNALS_QUEUE=tt_warmup_signals_$NS \
+          TT_TASK_QUEUE=tt_tasks_$NS \
+          TT_RESULT_QUEUE=tt_results_$NS \
+          TT_CANCEL_QUEUE=tt_cancels_$NS \
+          TT_MEMORY_REQUEST_QUEUE=tt_mem_requests_$NS \
+          TT_MEMORY_RESULT_QUEUE=tt_mem_results_$NS \
+          TT_WORKER_METRICS_SHM=/tt_worker_metrics_$NS \
             ./build/tt_media_server_cpp -p 8000 -t 4 \
             > ../decode_server_runner.log 2>&1 &
           echo $! > ../decode_server_runner.pid

--- a/tt-media-server/cpp_server/include/ipc/boost_ipc_warmup_signal_queue.hpp
+++ b/tt-media-server/cpp_server/include/ipc/boost_ipc_warmup_signal_queue.hpp
@@ -11,8 +11,6 @@
 
 namespace tt::ipc {
 
-constexpr const char* WARMUP_SIGNALS_QUEUE_NAME = "tt_warmup_signals";
-
 /**
  * IWarmupSignalQueue implementation backed by the generic BoostIpcMemoryQueue.
  */

--- a/tt-media-server/cpp_server/src/worker/single_process_worker.cpp
+++ b/tt-media-server/cpp_server/src/worker/single_process_worker.cpp
@@ -105,7 +105,7 @@ void SingleProcessWorker::start() {
     runner_->start([this]() {
       try {
         tt::ipc::BoostIpcWarmupSignalQueue warmupQueue(
-            tt::ipc::WARMUP_SIGNALS_QUEUE_NAME);
+            tt::config::ttWarmupSignalsQueueName());
         warmupQueue.sendReady(worker_id);
         TT_LOG_INFO("[SingleProcessWorker] Worker {} signaled warmup complete",
                     worker_id);

--- a/tt-media-server/cpp_server/src/worker/worker_manager.cpp
+++ b/tt-media-server/cpp_server/src/worker/worker_manager.cpp
@@ -205,7 +205,7 @@ void WorkerManager::startWorkers() {
 
 void WorkerManager::startWarmupListener() {
   warmupQueue = std::make_unique<tt::ipc::BoostIpcWarmupSignalQueue>(
-      tt::ipc::WARMUP_SIGNALS_QUEUE_NAME, workerCount);
+      tt::config::ttWarmupSignalsQueueName(), workerCount);
   warmupReceived = false;
   warmupListenerThread = std::thread([this]() {
     try {


### PR DESCRIPTION
Stacked on top of #3372 (dmadicTT/max-64k).

## Summary

- Wire `tt::config::ttWarmupSignalsQueueName()` through `worker_manager.cpp` and `single_process_worker.cpp` so `TT_WARMUP_SIGNALS_QUEUE` actually takes effect (the getter existed but was dead code). Drop the duplicate `WARMUP_SIGNALS_QUEUE_NAME` constant in `boost_ipc_warmup_signal_queue.hpp`.
- In `cpp-server-prefill-decode-split` give each cpp_server launch a unique namespace (`r{1,2}_{decode,prefill}`) for every shared IPC name (warmup signals, task/result/cancel queues, memory queues, worker metrics shm).

## Why

`WARMUP_SIGNALS_QUEUE_NAME = \"tt_warmup_signals\"` is a host-wide identifier. When one cpp_server shuts down, its `stopWarmupListener()` calls `warmupQueue->remove(\"tt_warmup_signals\")`, which unlinks the shm for **every** cpp_server on the host. The split CI test runs two servers concurrently, so a slow shutdown on one trampled the freshly created shm of the other.

### Observed failure ([run 25655689065](https://github.com/tenstorrent/tt-inference-server/actions/runs/25655689065/job/75304456677?pr=3372))

Round-1 decode (SIGTERM'd at 07:24:05) keeps the InterServer socket draining for ~4.6s — its `WorkerManager::stop()` doesn't reach `stopWarmupListener()` until 07:24:09.77. Round-2 prefill starts at 07:24:09.15, its parent creates a fresh \`tt_warmup_signals\` queue, and its worker tries to open the queue at 07:24:10.12 — round-1 decode removed it ~350 ms earlier. ENOENT → \"Worker 0 failed to signal warmup\" → \`model_ready\` stays false → 30s liveness timeout.

```
[round-1 decode]      07:24:09.768  Liveness checker thread stopped
                      07:24:09.7??  warmupQueue->remove(\"tt_warmup_signals\")  ← deletes shm
[round-2 prefill worker]
                      07:24:10.117  Failed to open existing queue: tt_warmup_signals (errno 2)
```

The other IPC names (`tt_tasks`/`tt_results`/`tt_cancels`/`tt_mem_*`/`/tt_worker_metrics`) were already env-overridable but were never namespaced per launch — they have the same collision potential and are now namespaced here.

## Test plan

- [x] `./build.sh` green on this branch
- [x] `ctest --output-on-failure` — 182/182 passed locally
- [ ] CI `cpp-server-prefill-decode-split` job passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)