### PR TITLE
cpp_server: populate prompt_tokens_count so usage.cached_tokens is correct

### DIFF
--- a/tt-media-server/cpp_server/include/domain/llm/chat_completion_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/chat_completion_request.hpp
@@ -276,6 +276,7 @@ struct ChatCompletionRequest : BaseRequest {
         messages, true, tools, enable_reasoning, skip_apply_chat_template);
     out.full_prompt_tokens_count =
         static_cast<int>(tokenizer.encode(promptStr).size());
+    out.prompt_tokens_count = out.full_prompt_tokens_count;
     TT_LOG_INFO("Prompt: {}",
                 detail::truncate(promptStr, detail::MAX_PROMPT_LOG_LENGTH));
     out.prompt = std::move(promptStr);

--- a/tt-media-server/cpp_server/include/domain/responses_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/responses_request.hpp
@@ -384,6 +384,7 @@ struct ResponsesRequest : BaseRequest {
                                                  std::nullopt, true, false);
     out.full_prompt_tokens_count =
         static_cast<int>(tokenizer.encode(promptStr).size());
+    out.prompt_tokens_count = out.full_prompt_tokens_count;
     out.prompt = std::move(promptStr);
 
     out.max_tokens = max_output_tokens;

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -29,6 +29,7 @@
 #include "utils/id_generator.hpp"
 #include "utils/logger.hpp"
 #include "utils/mapper.hpp"
+#include "utils/tokenizers/tokenizer.hpp"
 
 namespace tt::api {
 
@@ -97,6 +98,10 @@ void LLMController::resolveSession(
         req->session = sessionManager->getSession(acquired->sessionId);
         req->continuation = true;
         req->prompt = routingInfo.deltaPrompt;
+        req->prompt_tokens_count =
+            static_cast<int>(tt::utils::tokenizers::activeTokenizer()
+                                 .encode(routingInfo.deltaPrompt)
+                                 .size());
         sessionManager->registerPrefixHash(acquired->sessionId,
                                            routingInfo.registrationHash);
         info.validSessionFound = true;
@@ -186,7 +191,7 @@ void LLMController::chatCompletions(
   auto reqPtr = std::make_shared<LLMRequest>(chatReq.toLLMRequest());
   const size_t maxContextLength = tt::config::maxContextLength();
   const size_t promptTokens =
-      static_cast<size_t>(std::max(0, reqPtr->prompt_tokens_count));
+      static_cast<size_t>(std::max(0, reqPtr->full_prompt_tokens_count));
 
   const size_t requested =
       promptTokens +
@@ -197,7 +202,7 @@ void LLMController::chatCompletions(
 
   if (exceedsContext) {
     std::string detail =
-        "prompt_tokens=" + std::to_string(reqPtr->prompt_tokens_count);
+        "prompt_tokens=" + std::to_string(reqPtr->full_prompt_tokens_count);
     if (reqPtr->max_tokens.has_value()) {
       detail += ", max_tokens=" + std::to_string(*reqPtr->max_tokens);
     }


### PR DESCRIPTION
## Summary

The C++ server's `usage.prompt_tokens_details.cached_tokens` is reported incorrectly on multi-turn continuations: it always equals `prompt_tokens`, even when the new user message clearly required prefilling. Root cause traces back to #3360: it introduced the new field `full_prompt_tokens_count` and the formula

```cpp
params.cachedTokenCount = request.continuation
    ? request.full_prompt_tokens_count - request.prompt_tokens_count
    : 0;
```

but the same PR removed the only assignment to `prompt_tokens_count` from `ChatCompletionRequest::toLLMRequest()`. The field is left at its default `0` on every code path, so `cached = full − 0 = full` whenever `continuation == true`.

The same uninitialized field is read by the context-length check added in #3372 (`requested = prompt_tokens_count + max_tokens`), so a large prompt with a small `max_tokens` is silently accepted regardless of `MAX_CONTEXT_LENGTH`.

## Changes

- Restore `out.prompt_tokens_count = out.full_prompt_tokens_count` in `ChatCompletionRequest::toLLMRequest()` and `ResponsesRequest::toLLMRequest()` so the fresh-request path has a sensible value.
- In `LLMController::resolveSession`'s prefix-cache-hit branch, override `prompt_tokens_count` with the delta-prompt encoded length — matching the semantic the cached-tokens formula already assumes.
- Migrate the context-length check to `full_prompt_tokens_count`, the right field for an attention-window limit (the model attends to the full conversation, not just the delta).

The disagg routing site at `llm_controller.cpp:548` keeps using `prompt_tokens_count`, which is now correct for both fresh (= full) and continuation (= delta) requests.

## Tests

Probed against `./build.sh --blaze` + `LLM_DEVICE_BACKEND=mock_pipeline`. Three-turn conversation, `max_tokens=10` each, replaying the prior assistant reply on each new turn.

### A. cached_tokens (3-turn)

| Turn | `prompt_tokens` | `cached_tokens` before | `cached_tokens` after |
|---|---|---|---|
| 1 (cold) | 10 | 0 | 0 |
| 2 (continuation) | 28 | **28** | **19** |
| 3 (continuation) | 46 | **46** | **37** |

Cold turn unchanged. After fix, only the part of the prompt already in the KV cache from prior turns is reported as cached; the new user delta is correctly excluded. Streaming and non-streaming usage chunks match.

### B. context-length check (`MAX_CONTEXT_LENGTH=1024`)

Send a ~1404-token prompt with `max_tokens=10`:

| Behavior | Before | After |
|---|---|---|
| Big prompt (1404 tok) | **accepted** (200 OK) | **rejected** (HTTP 400: `Request exceeds maximum context length (1024 tokens): prompt_tokens=1404, max_tokens=10`) |
| Small prompt (4 tok) | accepted | accepted |

### C. Unit tests

All 182 ctest cases pass on both before- and after-fix builds.

## Test plan

- [x] `./build.sh --blaze` builds clean
- [x] `ctest --output-on-failure` — 182/182 pass
- [x] Multi-turn `cached_tokens` reports the cached portion correctly (non-streaming + streaming, both via mock_pipeline backend)
- [x] Single-turn requests still report `cached_tokens=0`
- [x] Oversize prompt is now correctly rejected with a 400 when `MAX_CONTEXT_LENGTH` is exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)