### PR TITLE
patch curl request for structured output benchmarks

### DIFF
--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -287,7 +287,7 @@ def fetch_structured_output_scripts(
         dst.parent.mkdir(parents=True, exist_ok=True)
         url = f"{VLLM_BENCHMARKS_RAW_BASE}/{src_rel}"
         return_code = run_command(
-            f"curl -fSL --retry 3 --retry-delay 5 --retry-all-errors {url} -o {dst}",
+            f"curl -fSL {url} -o {dst}",
             logger=logger,
         )
         if return_code != 0:

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -287,7 +287,7 @@ def fetch_structured_output_scripts(
         dst.parent.mkdir(parents=True, exist_ok=True)
         url = f"{VLLM_BENCHMARKS_RAW_BASE}/{src_rel}"
         return_code = run_command(
-            f"curl -fSL {url} -o {dst}",
+            f"curl -fSL --retry 3 --retry-delay 5 {url} -o {dst}",
             logger=logger,
         )
         if return_code != 0:


### PR DESCRIPTION
--retry-all-errors is added in curl 7.71.0, but on a given OS release you get one curl version:  on Ubuntu 20.04 -> retry == 7.68  on Ubuntu 22.04  -> retry == 7.81

this patch is temporary because we have some devices on on Ubuntu 20.04 (https://github.com/tenstorrent/tt-shield/issues/715). we will be able to add --retry-all-errors once OS drivers are all up to Ubuntu 22.04