### PR TITLE
SDXL: per-stage perf logging in trace and Forge runners

### DIFF
--- a/tt-media-server/tt_model_runners/base_sdxl_runner.py
+++ b/tt-media-server/tt_model_runners/base_sdxl_runner.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import os
+import time
 from abc import abstractmethod
 
 import ttnn
@@ -249,7 +250,11 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
         self.logger.info(f"Device {self.device_id}: Starting ttnn inference...")
         self._prepare_input_tensors_for_iteration(tensors)
 
+        t0 = time.time()
         imgs = self.tt_sdxl.generate_images()
+        self.logger.info(
+            f"Device {self.device_id}: UNet+VAE inference took {time.time() - t0:.4f}s"
+        )
 
         for idx, img in enumerate(imgs):
             if idx >= self.batch_size - needed_padding:

--- a/tt-media-server/tt_model_runners/sdxl_edit_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_edit_runner_trace.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 import os
+import time
 
 import torch
 from config.constants import SupportedModels
@@ -130,8 +131,12 @@ class TTSDXLEditRunner(TTSDXLImageToImageRunner):
         self.logger.debug(f"Device {self.device_id}: Starting text encoding...")
         self.tt_sdxl.compile_text_encoding()
 
+        t0 = time.time()
         all_prompt_embeds_torch, torch_add_text_embeds = self.tt_sdxl.encode_prompts(
             prompts, negative_prompts, prompts_2, negative_prompt_2
+        )
+        self.logger.info(
+            f"Device {self.device_id}: Text encoding took {time.time() - t0:.4f}s"
         )
 
         images, masks, masked_images = self._process_image_and_mask(requests)

--- a/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 import os
+import time
 
 import torch
 from config.constants import SupportedModels
@@ -87,11 +88,15 @@ class TTSDXLGenerateRunnerTrace(BaseSDXLRunner):
         self._ensure_lora_state(requests[0])
         self.tt_sdxl.compile_text_encoding()
 
+        t0 = time.time()
         (
             all_prompt_embeds_torch,
             torch_add_text_embeds,
         ) = self.tt_sdxl.encode_prompts(
             prompts, negative_prompts, prompts_2, negative_prompt_2
+        )
+        self.logger.info(
+            f"Device {self.device_id}: Text encoding took {time.time() - t0:.4f}s"
         )
 
         tt_latents, tt_prompt_embeds, tt_add_text_embeds = (

--- a/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 import os
+import time
 
 import torch
 from config.constants import SupportedModels
@@ -127,11 +128,15 @@ class TTSDXLImageToImageRunner(BaseSDXLRunner):
         self.logger.debug(f"Device {self.device_id}: Starting text encoding...")
         self.tt_sdxl.compile_text_encoding()
 
+        t0 = time.time()
         (
             all_prompt_embeds_torch,
             torch_add_text_embeds,
         ) = self.tt_sdxl.encode_prompts(
             prompts, negative_prompts, prompts_2, negative_prompt_2
+        )
+        self.logger.info(
+            f"Device {self.device_id}: Text encoding took {time.time() - t0:.4f}s"
         )
 
         images = [self._preprocess_image(request.image) for request in requests]


### PR DESCRIPTION
## Summary
- `base_sdxl_runner`: time the UNet + VAE on-device pass.
- `sdxl_{generate,edit,image_to_image}_runner_trace`: time text encoding.
- Format matches the existing Forge runner: `Device {id}: <stage> took X.YYYYs`.
- Logs only; no metrics surface.

## Test plan
- [ ] Stand up trace SDXL, send a request, confirm both `Text encoding took ...` and `UNet+VAE inference took ...` lines appear.
- [ ] Stand up Forge SDXL, confirm the matching log lines (existing).
- [ ] Use these logs as input to the perf-comparison deliverable (#3479).

Refs #3478