### PR TITLE
SDXL: perf benchmark script + methodology for Blackhole comparison

### DIFF
--- a/tt-media-server/scripts/sdxl_perf_benchmark.py
+++ b/tt-media-server/scripts/sdxl_perf_benchmark.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+"""SDXL inference-server perf benchmark.
+
+Sends a fixed sequence of requests against a running media server and prints
+client-side timing stats (min / median / p90 / max / mean). Intended for
+side-by-side comparison of:
+  - trace runner (full-on-device)
+  - Forge runner with TTXLA_SDXL_FULL_ON_DEVICE=false (UNet-only)
+  - Forge runner with TTXLA_SDXL_FULL_ON_DEVICE=true  (full-on-device)
+
+Per-stage timings (text encoding, UNet diffusion, VAE decode) are emitted by
+the runners to the server log; grep hints are printed at the end.
+
+Usage:
+    python sdxl_perf_benchmark.py --host localhost --port 8000 \
+        --config-label forge-full-on-device --runs 5
+"""
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from dataclasses import dataclass, asdict
+
+import requests
+
+DEFAULT_PROMPT = (
+    "A beautiful sunset over a mountain landscape with vibrant colors"
+)
+DEFAULT_NEGATIVE = "blurry, low quality, distorted"
+DEFAULT_SEED = 42
+DEFAULT_GUIDANCE = 7.5
+DEFAULT_TOKEN = "your-secret-key"
+ENDPOINT = "/v1/images/generations"
+
+
+@dataclass
+class RunStats:
+    config_label: str
+    num_inference_steps: int
+    warmup_runs: int
+    measured_runs: int
+    min_s: float
+    median_s: float
+    p90_s: float
+    max_s: float
+    mean_s: float
+    per_run_s: list[float]
+
+
+def _percentile(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    if len(s) == 1:
+        return s[0]
+    pos = (len(s) - 1) * q
+    lo = int(pos)
+    hi = min(lo + 1, len(s) - 1)
+    frac = pos - lo
+    return s[lo] + (s[hi] - s[lo]) * frac
+
+
+def send_request(
+    session: requests.Session,
+    url: str,
+    headers: dict,
+    payload: dict,
+    timeout: int,
+) -> float:
+    start = time.perf_counter()
+    response = session.post(url, json=payload, headers=headers, timeout=timeout)
+    duration = time.perf_counter() - start
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"HTTP {response.status_code}: {response.text[:500]}"
+        )
+    return duration
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument(
+        "--config-label",
+        required=True,
+        help="Free-form label identifying the runner config "
+        "(e.g. trace-full-on-device, forge-unet-only, forge-full-on-device)",
+    )
+    parser.add_argument("--steps", type=int, default=20)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--runs", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--negative-prompt", default=DEFAULT_NEGATIVE)
+    parser.add_argument("--token", default=DEFAULT_TOKEN)
+    parser.add_argument(
+        "--timeout", type=int, default=600, help="Per-request timeout in seconds"
+    )
+    parser.add_argument(
+        "--output",
+        choices=("text", "json"),
+        default="text",
+        help="Output format",
+    )
+    args = parser.parse_args()
+
+    url = f"http://{args.host}:{args.port}{ENDPOINT}"
+    headers = {
+        "accept": "application/json",
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {args.token}",
+    }
+    payload = {
+        "prompt": args.prompt,
+        "negative_prompt": args.negative_prompt,
+        "num_inference_steps": args.steps,
+        "seed": args.seed,
+        "guidance_scale": DEFAULT_GUIDANCE,
+        "number_of_images": 1,
+    }
+
+    print(
+        f"[{args.config_label}] Benchmarking {url} "
+        f"(steps={args.steps}, warmup={args.warmup}, runs={args.runs})",
+        file=sys.stderr,
+    )
+
+    with requests.Session() as session:
+        for i in range(args.warmup):
+            d = send_request(session, url, headers, payload, args.timeout)
+            print(f"  warmup {i + 1}/{args.warmup}: {d:.3f}s", file=sys.stderr)
+
+        per_run: list[float] = []
+        for i in range(args.runs):
+            d = send_request(session, url, headers, payload, args.timeout)
+            per_run.append(d)
+            print(f"  run {i + 1}/{args.runs}: {d:.3f}s", file=sys.stderr)
+
+    stats = RunStats(
+        config_label=args.config_label,
+        num_inference_steps=args.steps,
+        warmup_runs=args.warmup,
+        measured_runs=args.runs,
+        min_s=min(per_run),
+        median_s=statistics.median(per_run),
+        p90_s=_percentile(per_run, 0.9),
+        max_s=max(per_run),
+        mean_s=statistics.fmean(per_run),
+        per_run_s=[round(v, 3) for v in per_run],
+    )
+
+    if args.output == "json":
+        print(json.dumps(asdict(stats), indent=2))
+    else:
+        print(f"\n=== {stats.config_label} (steps={stats.num_inference_steps}) ===")
+        print(f"  runs:    {stats.per_run_s}")
+        print(f"  min:     {stats.min_s:.3f}s")
+        print(f"  median:  {stats.median_s:.3f}s")
+        print(f"  p90:     {stats.p90_s:.3f}s")
+        print(f"  max:     {stats.max_s:.3f}s")
+        print(f"  mean:    {stats.mean_s:.3f}s")
+        print(
+            "\nFor per-stage breakdown, grep the server log for "
+            "'Text encoding took', 'UNet', and 'VAE' lines."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tt-media-server/scripts/sdxl_perf_benchmark_README.md
+++ b/tt-media-server/scripts/sdxl_perf_benchmark_README.md
@@ -1,0 +1,74 @@
+# SDXL Perf Benchmark — methodology for issue #3479
+
+Captures Blackhole perf numbers for the three SDXL configs Nikola asked about
+(2026-05-12): trace runner, Forge UNet-only, Forge full-on-device.
+
+## Prerequisites
+
+- A running media server with SDXL loaded for the config under test.
+- Per-stage logging in place (issue #3478 / branch `feat/sdxl-perf-logging`).
+- Full-on-device path available (issue #3477 / branch `feat/sdxl-forge-full-on-device`).
+
+## Configs to capture
+
+| Label                  | Runner | Env                                 | Device      |
+| ---------------------- | ------ | ----------------------------------- | ----------- |
+| `trace`                | Metal pipeline (trace runner)       | (defaults)                          | N300 / T3K (reference upper bound) |
+| `forge-unet-only`      | Forge runner | `TTXLA_SDXL_FULL_ON_DEVICE=false` (or unset) | p150x4 / p150x8 / p300x2 |
+| `forge-full-on-device` | Forge runner | `TTXLA_SDXL_FULL_ON_DEVICE=true`              | p150x4 / p150x8 / p300x2 |
+
+## Procedure (per config)
+
+1. Start the server with the target runner + env vars. Capture the server log
+   to a file (e.g. `tee /tmp/sdxl-<label>.log`).
+2. Wait for warmup to complete (look for `Warmup completed` in the log).
+3. Run the benchmark:
+
+   ```bash
+   python tt-media-server/scripts/sdxl_perf_benchmark.py \
+       --host localhost --port 8000 \
+       --config-label <label> \
+       --steps 20 --warmup 1 --runs 5 \
+       --output json > /tmp/sdxl-<label>.json
+   ```
+
+4. Capture per-stage timings from the server log:
+
+   ```bash
+   grep -E "Text encoding took|UNet diffusion|UNet\+VAE|VAE decode" \
+       /tmp/sdxl-<label>.log \
+       | tail -n +N   # skip warmup, take the last 5 runs' worth of lines
+   ```
+
+   For Forge, per-stage log lines are: `Text encoding`, `UNet diffusion (N steps)`,
+   `VAE decode (full_on_device=…)`. For trace, after #3478 lands: `Text encoding`,
+   `UNet+VAE inference`.
+
+## Report format
+
+Paste in issue #3479 as a Markdown table:
+
+```
+| Config | Device | n | Total mean (s) | TE (s) | UNet (s) | VAE (s) | Compile/warmup (s) |
+|---|---|---|---|---|---|---|---|
+| trace | t3k | 5 | … | … | … | … | … |
+| forge-unet-only | p150x8 | 5 | … | … | … | … | … |
+| forge-full-on-device | p150x8 | 5 | … | … | … | … | … |
+```
+
+Include a one-sentence recommendation: should `TTXLA_SDXL_FULL_ON_DEVICE` default
+to `true` based on the numbers? Note any compile/warmup time regressions for the
+full-on-device config — that hits cold-start, not steady-state inference.
+
+## Fixed run parameters
+
+- `prompt`: "A beautiful sunset over a mountain landscape with vibrant colors"
+- `negative_prompt`: "blurry, low quality, distorted"
+- `seed`: 42
+- `num_inference_steps`: 20
+- `guidance_scale`: 7.5
+- `number_of_images`: 1
+- Resolution: 1024 (default). Run a separate 512 sweep only if explicitly asked.
+
+Keeping these fixed across all configs lets us compare like-for-like; the only
+variable is the runner config / env.


### PR DESCRIPTION
## Summary
- Adds `tt-media-server/scripts/sdxl_perf_benchmark.py`: standalone client-side benchmark. Posts a fixed sequence of image-generation requests against a running media server and reports min/median/p90/max/mean wall-clock per run.
- Adds `tt-media-server/scripts/sdxl_perf_benchmark_README.md`: methodology for capturing all three configs (trace / Forge UNet-only / Forge full-on-device) and what to paste back into #3479.
- Per-stage breakdowns come from the runners' own log lines (see #3478).

## Test plan
- [ ] Run against an idle media server, verify it reports expected stats.
- [ ] Run all three configs on Blackhole, paste numbers into #3479.

Refs #3479