### PR TITLE
v2 reports: Add missing metadata 

### DIFF
--- a/tt-inference-server-v2/run.py
+++ b/tt-inference-server-v2/run.py
@@ -162,6 +162,7 @@ def build_context(args: argparse.Namespace) -> MediaContext:
         device=device,
         output_path=str(output_path),
         service_port=args.service_port,
+        spec_tests_num_prompts_cap=args.num_prompts,
     )
 
 
@@ -222,7 +223,6 @@ def main() -> int:
 
         _ibt.SDXL_BENCHMARK_NUM_PROMPTS = args.num_prompts
         _ibt.SDXL_SD35_BENCHMARK_NUM_PROMPTS = args.num_prompts
-        ctx.spec_tests_num_prompts_cap = args.num_prompts
         logger.info(
             "Overriding image benchmark + spec_tests prompt count to %d",
             args.num_prompts,

--- a/tt-inference-server-v2/run.py
+++ b/tt-inference-server-v2/run.py
@@ -18,11 +18,13 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import logging
+import shlex
 import sys
 import time
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Sequence
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _V2_ROOT = Path(__file__).resolve().parent
@@ -31,6 +33,7 @@ for _p in (_REPO_ROOT, _V2_ROOT):
         sys.path.insert(0, str(_p))
 
 from workflows.model_spec import MODEL_SPECS, get_runtime_model_spec  # noqa: E402
+from workflows.runtime_config import RuntimeConfig  # noqa: E402
 from workflows.workflow_types import DeviceTypes  # noqa: E402
 
 from report_module import (  # noqa: E402
@@ -97,6 +100,20 @@ def parse_args() -> argparse.Namespace:
         help="Where to write the rendered report (markdown + json).",
     )
     parser.add_argument(
+        "--docker-server",
+        action="store_true",
+        help=(
+            "Record server_mode=docker in the report metadata. Fallback "
+            "when --runtime-model-spec-json is not supplied."
+        ),
+    )
+    parser.add_argument(
+        "--runtime-model-spec-json",
+        type=str,
+        default=None,
+        help="Path to the runtime model spec JSON written by the server launcher.",
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=("DEBUG", "INFO", "WARNING", "ERROR"),
@@ -146,6 +163,48 @@ def build_context(args: argparse.Namespace) -> MediaContext:
         output_path=str(output_path),
         service_port=args.service_port,
     )
+
+
+def _load_runtime_config(path: Optional[str]) -> Optional[RuntimeConfig]:
+    """Best-effort load; returns ``None`` on missing/malformed input."""
+    if not path:
+        return None
+    try:
+        return RuntimeConfig.from_json(path)
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as e:
+        logger.warning(
+            "Could not load runtime_model_spec_json=%r (%s); "
+            "falling back to CLI flags for server_mode.",
+            path,
+            e,
+        )
+        return None
+
+
+def _resolve_server_mode(
+    args: argparse.Namespace, runtime_config: Optional[RuntimeConfig]
+) -> str:
+    """Spec JSON wins over ``--docker-server`` when present."""
+    if runtime_config is not None:
+        return "docker" if runtime_config.docker_server else "API"
+    return "docker" if args.docker_server else "API"
+
+
+def _capture_run_command(argv: Optional[Sequence[str]] = None) -> str:
+    """Paste-runnable reproduction of the orchestrator invocation."""
+    parts = list(sys.argv if argv is None else argv)
+    return "python " + shlex.join(parts)
+
+
+def _inject_orchestrator_metadata(
+    meta: dict, ctx: MediaContext, args: argparse.Namespace
+) -> None:
+    """Populate metadata fields the per-task runners can't see."""
+    del ctx  # reserved for future per-run fields derivable from context
+    runtime_config = _load_runtime_config(args.runtime_model_spec_json)
+    meta["server_mode"] = _resolve_server_mode(args, runtime_config)
+    meta["run_command"] = _capture_run_command()
+    meta["runtime_model_spec_json"] = args.runtime_model_spec_json
 
 
 def main() -> int:
@@ -203,6 +262,7 @@ def main() -> int:
         return 1
 
     schema = accumulator.build_schema()
+    _inject_orchestrator_metadata(schema.metadata, ctx, args)
     accepted, blockers = acceptance_criteria_check(schema)
     schema.metadata["acceptance_summary_markdown"] = format_acceptance_summary_markdown(
         accepted, blockers

--- a/tt-inference-server-v2/test_module/_test_common/blockify.py
+++ b/tt-inference-server-v2/test_module/_test_common/blockify.py
@@ -31,12 +31,9 @@ def block_targets(
     """Per-block envelope attached to ``Block.targets`` by a runner.
 
     ``ctx`` is unused today but kept in the signature so future
-    per-block envelope fields (e.g. a model variant id) have a place to
-    plug in without churning every call site. ``task_type`` is the v1
-    record-level label (``"image"``, ``"audio"``, …); ``kind``
-    (``"image_benchmark"``) on the Block is the canonical renderer key.
-    ``extra`` lets a caller fold in additional envelope-style fields
-    without polluting ``Block.data``.
+    per-block envelope fields have a place to plug in without churning
+    every call site. ``extra`` lets a caller fold in additional
+    envelope-style fields without polluting ``Block.data``.
     """
     del ctx  # reserved for future per-block envelope fields
     targets: Dict[str, Any] = {"task_type": task_type}
@@ -45,18 +42,26 @@ def block_targets(
 
 
 def sweep_envelope(ctx: "MediaContext") -> Dict[str, Any]:
-    """Sweep-level envelope handed to the workflow accumulator.
-
-    These three fields are recorded once for the whole sweep and become
-    the report's top-level ``metadata`` — they're identical across every
-    block a sweep emits, so duplicating them per-block in
-    ``Block.targets`` would be pure noise in the resulting JSON.
-    """
-    return {
-        "model_name": ctx.model_spec.model_name,
+    """Sweep-level metadata recorded once for the whole report."""
+    spec = ctx.model_spec
+    impl = getattr(spec, "impl", None)
+    model_id = getattr(spec, "model_id", None)
+    generated_at = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+    envelope: Dict[str, Any] = {
+        "model_name": getattr(spec, "model_name", ""),
+        "model_id": model_id,
+        "model_repo": getattr(spec, "hf_model_repo", None),
+        "model_impl": getattr(impl, "impl_name", None) if impl else None,
+        "inference_engine": getattr(spec, "inference_engine", None),
         "device": ctx.device.name,
-        "generated_at": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime()),
+        "tt_metal_commit": getattr(spec, "tt_metal_commit", None),
+        "vllm_commit": getattr(spec, "vllm_commit", None),
+        "generated_at": generated_at,
     }
+    if model_id:
+        ts = time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime())
+        envelope["report_id"] = f"{model_id}_{ts}"
+    return envelope
 
 
 def block_id(ctx: "MediaContext") -> str:


### PR DESCRIPTION
Adding missing metadata to reports. 
`### Metadata: stable-diffusion-xl-base-1.0 on n150
```json
{
    "report_id": "id_tt-transformers_stable-diffusion-xl-base-1.0_n150_2026-05-08_22-07-24",
    "model_name": "stable-diffusion-xl-base-1.0",
    "model_id": "id_tt-transformers_stable-diffusion-xl-base-1.0_n150",
    "runtime_model_spec_json": "/opt/github/actions-runner/_work/tt-shield/tt-shield/tt-inference-server/workflow_logs/runtime_model_specs/runtime_model_spec_2026-05-08_21-26-30_id_tt-transformers_stable-diffusion-xl-base-1.0_n150_rFEMMFu0.json",
    "model_repo": "stabilityai/stable-diffusion-xl-base-1.0",
    "model_impl": "tt-transformers",
    "inference_engine": "media",
    "device": "n150",
    "server_mode": "docker",
    "tt_metal_commit": "4dfa5170076148d1b3d1b49c5ff322e8bb868fa8",
    "vllm_commit": null,
    "run_command": "python run.py --model stable-diffusion-xl-base-1.0 --tt-device n150 --workflow release --docker-server"
}`