### PR TITLE
v2 reports display changes

### DIFF
--- a/tt-inference-server-v2/report_module/acceptance_criteria.py
+++ b/tt-inference-server-v2/report_module/acceptance_criteria.py
@@ -26,7 +26,6 @@ EVAL_KINDS = frozenset(
         "tts_eval",
         "video_eval",
         "embedding_eval",
-        "image_generation_evals",
     }
 )
 HEALTH_INFRA_KINDS = frozenset(

--- a/tt-inference-server-v2/report_module/acceptance_criteria.py
+++ b/tt-inference-server-v2/report_module/acceptance_criteria.py
@@ -4,139 +4,238 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping, Tuple
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Tuple
 
 from .schema import Block, ReportSchema
 
-BENCHMARK_KINDS = frozenset(
-    {
-        "image_benchmark",
-        "cnn_benchmark",
-        "audio_benchmark",
-        "tts_benchmark",
-        "video_benchmark",
-        "embedding_benchmark",
-    }
-)
-EVAL_KINDS = frozenset(
-    {
-        "image_eval",
-        "cnn_eval",
-        "audio_eval",
-        "tts_eval",
-        "video_eval",
-        "embedding_eval",
-    }
-)
-HEALTH_INFRA_KINDS = frozenset(
-    {
-        "device_liveness",
-        "media_server_liveness",
-        "logger_fork_safety",
-    }
-)
+# Three canonical kinds emitted by every runner. Acceptance routes by
+# this field alone — no substring matching, no frozensets, no regex.
+KIND_BENCHMARKS = "benchmarks"
+KIND_EVALS = "evals"
+KIND_SERVER_TESTS = "server_tests"
+
 TARGET_LEVELS = ("functional", "complete", "target")
 CHECK_SUFFIX = "_check"
 FAIL_CHECK_INT = 3
 
+STATUS_PASS = "PASS"
+STATUS_FAIL = "FAIL"
+STATUS_NA = "NA"
+
+CATEGORY_BENCHMARKS = "Benchmarks"
+CATEGORY_EVALS = "Evals"
+CATEGORY_SERVER_TESTS = "Server Tests"
+
+INFRA_TASK_TYPES = frozenset({"health", "infra", "unit", "stability", "integration"})
+
+
+@dataclass(frozen=True)
+class CategoryResult:
+    name: str
+    status: str
+    total: int
+    failed: int
+    na: int = 0
+    blockers: Dict[str, str] = field(default_factory=dict)
+
+    @property
+    def passed(self) -> int:
+        return self.total - self.failed - self.na
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "total": self.total,
+            "passed": self.passed,
+            "failed": self.failed,
+            "na": self.na,
+            "blockers": dict(self.blockers),
+        }
+
 
 def acceptance_criteria_check(
     schema: ReportSchema,
-) -> Tuple[bool, Dict[str, str]]:
+) -> Tuple[bool, Dict[str, str], List[CategoryResult]]:
+    categories = [
+        _check_benchmarks(schema),
+        _check_evals(schema),
+        _check_spec_tests(schema),
+    ]
     blockers: Dict[str, str] = {}
-
-    _check_benchmarks(schema, blockers)
-    _check_evals(schema, blockers)
-    _check_spec_tests(schema, blockers)
-
-    return len(blockers) == 0, blockers
+    for category in categories:
+        blockers.update(category.blockers)
+    return len(blockers) == 0, blockers, categories
 
 
 def format_acceptance_summary_markdown(
-    accepted: bool, blockers: Mapping[str, str]
+    accepted: bool,
+    blockers: Mapping[str, str],
+    categories: List[CategoryResult],
 ) -> str:
     lines = [
         "### Acceptance Criteria",
         "",
-        f"- Acceptance status: `{'PASS' if accepted else 'FAIL'}`",
+        f"- Overall status: `{STATUS_PASS if accepted else STATUS_FAIL}`",
     ]
-    if accepted:
+    for category in categories:
+        lines.append(f"- {category.name}: `{category.status}` ({_detail(category)})")
+
+    if not blockers:
         lines.append("- All acceptance criteria passed.")
         return "\n".join(lines)
+
+    lines.append("")
+    lines.append("#### Blockers")
+    lines.append("")
     for key, message in blockers.items():
         lines.append(f"- `{key}`: {message}")
     return "\n".join(lines)
 
 
-def _check_benchmarks(schema: ReportSchema, blockers: Dict[str, str]) -> None:
-    benchmark_blocks = [b for b in schema.sections if b.kind in BENCHMARK_KINDS]
-    if not benchmark_blocks:
-        return
+def _detail(category: CategoryResult) -> str:
+    if category.status == STATUS_NA:
+        return "no blocks present"
+    parts = [f"{category.passed}/{category.total} passed"]
+    if category.failed:
+        parts.append(f"{category.failed} failed")
+    if category.na:
+        parts.append(f"{category.na} NA")
+    return ", ".join(parts)
 
+
+def _check_benchmarks(schema: ReportSchema) -> CategoryResult:
+    benchmark_blocks = [b for b in schema.sections if b.kind == KIND_BENCHMARKS]
+    if not benchmark_blocks:
+        return CategoryResult(CATEGORY_BENCHMARKS, STATUS_NA, 0, 0)
+
+    blockers: Dict[str, str] = {}
+    failed = 0
     for block in benchmark_blocks:
         block_key = _block_key(block)
+        block_blockers: Dict[str, str] = {}
         target_checks = _resolve_nested(block.data, "target_checks")
         if not isinstance(target_checks, Mapping):
-            blockers[f"{block_key}.target_checks"] = (
+            block_blockers[f"{block_key}.target_checks"] = (
                 "Missing target_checks in benchmark block."
             )
-            continue
-
-        if any(
+        elif any(
             isinstance(target_checks.get(lvl), Mapping)
             and _level_passes(target_checks[lvl])
             for lvl in TARGET_LEVELS
         ):
-            continue
-
-        any_check_seen = False
-        for lvl in TARGET_LEVELS:
-            level_checks = target_checks.get(lvl)
-            if not isinstance(level_checks, Mapping):
-                continue
-            for check_name, check_value in level_checks.items():
-                if not check_name.endswith(CHECK_SUFFIX):
+            pass
+        else:
+            any_check_seen = False
+            for lvl in TARGET_LEVELS:
+                level_checks = target_checks.get(lvl)
+                if not isinstance(level_checks, Mapping):
                     continue
-                any_check_seen = True
-                if not _passes_check(check_value):
-                    metric = check_name[: -len(CHECK_SUFFIX)]
-                    blockers[f"{block_key}.{lvl}.{check_name}"] = (
-                        f"{lvl} {metric} failed (check={check_value!r})"
-                    )
-        if not any_check_seen:
-            blockers[f"{block_key}.target_checks"] = (
-                "No *_check fields found across any tier."
-            )
+                for check_name, check_value in level_checks.items():
+                    if not check_name.endswith(CHECK_SUFFIX):
+                        continue
+                    any_check_seen = True
+                    if not _passes_check(check_value):
+                        metric = check_name[: -len(CHECK_SUFFIX)]
+                        block_blockers[f"{block_key}.{lvl}.{check_name}"] = (
+                            f"{lvl} {metric} failed (check={check_value!r})"
+                        )
+            if not any_check_seen:
+                block_blockers[f"{block_key}.target_checks"] = (
+                    "No *_check fields found across any tier."
+                )
+
+        if block_blockers:
+            failed += 1
+            blockers.update(block_blockers)
+
+    status = STATUS_FAIL if failed else STATUS_PASS
+    return CategoryResult(
+        CATEGORY_BENCHMARKS,
+        status,
+        len(benchmark_blocks),
+        failed,
+        blockers=blockers,
+    )
 
 
-def _check_evals(schema: ReportSchema, blockers: Dict[str, str]) -> None:
-    eval_blocks = [b for b in schema.sections if b.kind in EVAL_KINDS]
+def _check_evals(schema: ReportSchema) -> CategoryResult:
+    eval_blocks = [b for b in schema.sections if b.kind == KIND_EVALS]
     if not eval_blocks:
-        return
+        return CategoryResult(CATEGORY_EVALS, STATUS_NA, 0, 0)
 
+    blockers: Dict[str, str] = {}
+    failed = 0
+    na = 0
     for block in eval_blocks:
         block_key = _block_key(block)
+        data = block.data if isinstance(block.data, Mapping) else None
+
+        # success=False is decisive — a test that self-reported failure
+        # is a blocker regardless of any accuracy_check value alongside it.
+        if data is not None and data.get("success") is False:
+            blockers[block_key] = (
+                f"{block.title or block.kind} reported success=False "
+                f"(attempts={data.get('attempts', '?')})"
+            )
+            failed += 1
+            continue
+
         check_value = _resolve_nested(block.data, "accuracy_check")
         if check_value is None:
             blockers[block_key] = "Missing accuracy_check on eval block."
+            failed += 1
             continue
-        if not _passes_check(check_value):
+
+        state = _check_state(check_value)
+        if state == STATUS_FAIL:
             blockers[block_key] = f"Accuracy check failed (value={check_value!r})"
+            failed += 1
+        elif state == STATUS_NA:
+            na += 1
+
+    status = STATUS_FAIL if failed else STATUS_PASS
+    return CategoryResult(
+        CATEGORY_EVALS,
+        status,
+        len(eval_blocks),
+        failed,
+        na=na,
+        blockers=blockers,
+    )
 
 
-def _check_spec_tests(schema: ReportSchema, blockers: Dict[str, str]) -> None:
-    excluded = BENCHMARK_KINDS | EVAL_KINDS | HEALTH_INFRA_KINDS
-    for block in schema.sections:
-        if block.kind in excluded:
-            continue
-        if not isinstance(block.data, Mapping):
-            continue
+def _check_spec_tests(schema: ReportSchema) -> CategoryResult:
+    spec_blocks = [
+        b
+        for b in schema.sections
+        if b.kind == KIND_SERVER_TESTS
+        and (b.task_type or "") not in INFRA_TASK_TYPES
+        and isinstance(b.data, Mapping)
+    ]
+    if not spec_blocks:
+        return CategoryResult(CATEGORY_SERVER_TESTS, STATUS_NA, 0, 0)
+
+    blockers: Dict[str, str] = {}
+    failed = 0
+    for block in spec_blocks:
         success = block.data.get("success")
         if success is False:
             blockers[f"spec.{_block_key(block)}"] = (
                 f"{block.title or block.kind} reported success=False "
                 f"(attempts={block.data.get('attempts', '?')})"
             )
+            failed += 1
+
+    status = STATUS_FAIL if failed else STATUS_PASS
+    return CategoryResult(
+        CATEGORY_SERVER_TESTS,
+        status,
+        len(spec_blocks),
+        failed,
+        blockers=blockers,
+    )
 
 
 def _block_key(block: Block) -> str:
@@ -172,9 +271,42 @@ def _passes_check(check_value: Any) -> bool:
         return str(check_value).strip().upper() not in {"FAIL", "FAILED", "NA"}
 
 
+def _check_state(check_value: Any) -> str:
+    """Map a raw accuracy_check value to one of STATUS_PASS / FAIL / NA.
+
+    Honors the ReportCheckTypes IntEnum convention (NA=1, PASS=2, FAIL=3)
+    and the string spellings used in legacy data.
+    """
+    if check_value is None:
+        return STATUS_NA
+    try:
+        as_int = int(check_value)
+    except (TypeError, ValueError):
+        text = str(check_value).strip().upper()
+        if text in {"FAIL", "FAILED"}:
+            return STATUS_FAIL
+        if text in {"NA", "N/A"}:
+            return STATUS_NA
+        return STATUS_PASS
+    if as_int == FAIL_CHECK_INT:
+        return STATUS_FAIL
+    if as_int == 1:
+        return STATUS_NA
+    return STATUS_PASS
+
+
 __all__ = [
     "acceptance_criteria_check",
     "format_acceptance_summary_markdown",
-    "BENCHMARK_KINDS",
-    "EVAL_KINDS",
+    "CategoryResult",
+    "KIND_BENCHMARKS",
+    "KIND_EVALS",
+    "KIND_SERVER_TESTS",
+    "STATUS_PASS",
+    "STATUS_FAIL",
+    "STATUS_NA",
+    "CATEGORY_BENCHMARKS",
+    "CATEGORY_EVALS",
+    "CATEGORY_SERVER_TESTS",
+    "INFRA_TASK_TYPES",
 ]

--- a/tt-inference-server-v2/report_module/acceptance_criteria.py
+++ b/tt-inference-server-v2/report_module/acceptance_criteria.py
@@ -270,6 +270,8 @@ def _resolve_nested(data: Any, key: str) -> Any:
 def _passes_check(check_value: Any) -> bool:
     if check_value is None:
         return False
+    if isinstance(check_value, bool):
+        return check_value
     try:
         return int(check_value) != FAIL_CHECK_INT
     except (TypeError, ValueError):
@@ -284,6 +286,8 @@ def _check_state(check_value: Any) -> str:
     """
     if check_value is None:
         return STATUS_NA
+    if isinstance(check_value, bool):
+        return STATUS_PASS if check_value else STATUS_FAIL
     try:
         as_int = int(check_value)
     except (TypeError, ValueError):

--- a/tt-inference-server-v2/report_module/acceptance_criteria.py
+++ b/tt-inference-server-v2/report_module/acceptance_criteria.py
@@ -195,7 +195,12 @@ def _check_evals(schema: ReportSchema) -> CategoryResult:
         elif state == STATUS_NA:
             na += 1
 
-    status = STATUS_FAIL if failed else STATUS_PASS
+    if failed:
+        status = STATUS_FAIL
+    elif na == len(eval_blocks):
+        status = STATUS_NA
+    else:
+        status = STATUS_PASS
     return CategoryResult(
         CATEGORY_EVALS,
         status,

--- a/tt-inference-server-v2/report_module/display.py
+++ b/tt-inference-server-v2/report_module/display.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+
+from __future__ import annotations
+
+from typing import Dict
+
+# Raw data key → display header. Canonical name per key (no per-task
+# variations — pick one, the renderer applies it everywhere). Names
+# without a unit suffix appear as-is; metrics with units include them in
+# parens so the column header is self-describing.
+DISPLAY_NAMES: Dict[str, str] = {
+    # Sequence / concurrency
+    "input_sequence_length": "ISL",
+    "isl": "ISL",
+    "output_sequence_length": "OSL",
+    "osl": "OSL",
+    "max_con": "Concurrency",
+    "max_concurrency": "Concurrency",
+    "concurrency": "Concurrency",
+    "num_requests": "Num Requests",
+    "num_prompts": "Num Prompts",
+    "num_responses": "Num Responses",
+    "num_concurrent_requests": "Num Concurrent Requests",
+    # Latency
+    "mean_ttft_ms": "TTFT (ms)",
+    "std_ttft_ms": "TTFT Std (ms)",
+    "ttft": "TTFT",
+    "p5_ttft": "P5 TTFT (ms)",
+    "p25_ttft": "P25 TTFT (ms)",
+    "p50_ttft": "P50 TTFT (ms)",
+    "p90_ttft": "P90 TTFT (ms)",
+    "p95_ttft": "P95 TTFT (ms)",
+    "p99_ttft": "P99 TTFT (ms)",
+    "mean_tpot_ms": "TPOT (ms)",
+    "std_tpot_ms": "TPOT Std (ms)",
+    "tpot": "TPOT",
+    "mean_itl_ms": "ITL (ms)",
+    "itl": "ITL",
+    "mean_e2el_ms": "E2EL (ms)",
+    "e2el": "E2EL",
+    # Throughput
+    "mean_tps": "Tput User (TPS)",
+    "std_tps": "Tput User Std (TPS)",
+    "tput_user": "Tput User (TPS)",
+    "tps_decode_throughput": "Tput Decode (TPS)",
+    "tput_decode": "Tput Decode (TPS)",
+    "tput": "Tput Decode (TPS)",
+    "tps_prefill_throughput": "Tput Prefill (TPS)",
+    "tput_prefill": "Tput Prefill (TPS)",
+    "request_throughput": "Req Tput (RPS)",
+    "req_tput": "Req Tput (RPS)",
+    "total_token_throughput": "Total Token Throughput (tokens/s)",
+    "total_input_tokens": "Total Input Tokens",
+    "total_output_tokens": "Total Output Tokens",
+    # Image-generation / CNN / video
+    "num_inference_steps": "Inference Steps",
+    "inference_steps_per_second": "Steps/Sec",
+    "image_height": "Image Height",
+    "image_width": "Image Width",
+    "image_resolution": "Image Resolution",
+    "images_per_prompt": "Images per Prompt",
+    "images": "Images",
+    "requests_duration": "Request Duration (s)",
+    "average_duration": "Avg Duration (s)",
+    "max_duration": "Max Duration (s)",
+    "avg_duration": "Avg Duration (s)",
+    "target_time": "Target (s)",
+    "within_target": "Within Target",
+    "total_requests": "Total Requests",
+    "batch_size": "Batch Size",
+    # Image-eval scores (image_generation_evals + image_eval)
+    "fid_score": "FID",
+    "average_clip": "CLIP Score",
+    "deviation_clip_score": "CLIP Std",
+    "same_seed_ssim": "Same-Seed SSIM",
+    "diff_params_ssim": "Diff-Params SSIM",
+    "same_requests_match": "Same-Request Match",
+    "diff_params_differs": "Diff-Params Differs",
+    "lora_differentiation": "LoRA Differentiation",
+    "lora_configs": "LoRA Configs",
+    # Audio / TTS
+    "wer": "WER",
+    "rtr": "RTR",
+    "t/s/u": "T/S/U",
+    "audio_duration": "Audio Duration (s)",
+    "streaming_enabled": "Streaming Enabled",
+    "preprocessing_enabled": "Preprocessing Enabled",
+    "reference_text": "Reference Text",
+    # Embedding
+    "embedding_dimension": "Embedding Dimension",
+    # Eval (orchestrator)
+    "task_name": "Task",
+    "tolerance": "Tolerance",
+    "published_score": "Published Score",
+    "published_score_ref": "Published Score Ref",
+    "score": "Score",
+    "accuracy_check": "Accuracy Check",
+    # Liveness / infra
+    "status": "Status",
+    "expected_devices": "Expected Devices",
+    "ready_workers": "Ready Workers",
+    "alive_workers": "Alive Workers",
+    "ready_count": "Ready Count",
+    "alive_count": "Alive Count",
+    "model_ready": "Model Ready",
+    "runner_in_use": "Runner",
+    "child_result": "Child Result",
+    # Common envelope
+    "name": "Name",
+    "success": "Success",
+    "attempts": "Attempts",
+    "backend": "Source",
+    "task_type": "Task Type",
+    "dataset": "Dataset",
+    "structured_output_ratio": "SO Ratio",
+    "correct_rate_pct": "Correct Rate (%)",
+}
+
+# Raw key → digits after the decimal point. Missing keys use
+# :data:`report_module.formatting._format_float`'s significant-digits
+# default. Pull these straight from v1's sig_digits_map and
+# decimal_places_map; 
+DECIMAL_PLACES: Dict[str, int] = {
+    "mean_ttft_ms": 1,
+    "std_ttft_ms": 1,
+    "p5_ttft": 1,
+    "p25_ttft": 1,
+    "p50_ttft": 1,
+    "p90_ttft": 1,
+    "p95_ttft": 1,
+    "p99_ttft": 1,
+    "mean_tpot_ms": 1,
+    "std_tpot_ms": 1,
+    "mean_itl_ms": 1,
+    "mean_e2el_ms": 1,
+    "mean_tps": 2,
+    "std_tps": 2,
+    "tput_user": 2,
+    "tps_decode_throughput": 1,
+    "tps_prefill_throughput": 1,
+    "request_throughput": 3,
+    "total_token_throughput": 2,
+    "requests_duration": 2,
+    "average_duration": 2,
+    "max_duration": 2,
+    "avg_duration": 2,
+    "target_time": 2,
+    "inference_steps_per_second": 1,
+    "elapsed_seconds": 2,
+    "fid_score": 2,
+    "average_clip": 4,
+    "deviation_clip_score": 4,
+    "same_seed_ssim": 4,
+    "diff_params_ssim": 4,
+    "tput_decode": 1,
+    "tput_prefill": 1,
+    "rtr": 3,
+    "wer": 4,
+    "audio_duration": 2,
+}
+
+# Footnote glossary. Looked up by raw key. Only add entries for terms
+# that aren't already obvious from the display name itself.
+EXPLANATIONS: Dict[str, str] = {
+    "input_sequence_length": "Input Sequence Length (tokens)",
+    "output_sequence_length": "Output Sequence Length (tokens)",
+    "max_con": "number of concurrent requests (batch size)",
+    "num_requests": "total number of requests (sample size, N)",
+    "mean_ttft_ms": "Time To First Token (ms)",
+    "mean_tpot_ms": "Time Per Output Token (ms)",
+    "mean_tps": "Throughput per user (TPS)",
+    "tps_decode_throughput": "Throughput for decode tokens, across all users (TPS)",
+    "tps_prefill_throughput": "Throughput for prefill tokens (TPS)",
+    "mean_e2el_ms": "End-to-End Latency (ms)",
+    "request_throughput": "Request Throughput (RPS)",
+}
+
+
+def display_name(raw_key: str) -> str:
+    """Translate a raw data key to its display header, or fall back."""
+    return DISPLAY_NAMES.get(raw_key, raw_key)
+
+
+def decimal_places(raw_key: str) -> int | None:
+    """Per-key float precision, or None when the default formatter applies."""
+    return DECIMAL_PLACES.get(raw_key)
+
+
+__all__ = [
+    "DISPLAY_NAMES",
+    "DECIMAL_PLACES",
+    "EXPLANATIONS",
+    "display_name",
+    "decimal_places",
+]

--- a/tt-inference-server-v2/report_module/display.py
+++ b/tt-inference-server-v2/report_module/display.py
@@ -122,7 +122,7 @@ DISPLAY_NAMES: Dict[str, str] = {
 # Raw key → digits after the decimal point. Missing keys use
 # :data:`report_module.formatting._format_float`'s significant-digits
 # default. Pull these straight from v1's sig_digits_map and
-# decimal_places_map; 
+# decimal_places_map;
 DECIMAL_PLACES: Dict[str, int] = {
     "mean_ttft_ms": 1,
     "std_ttft_ms": 1,

--- a/tt-inference-server-v2/report_module/display.py
+++ b/tt-inference-server-v2/report_module/display.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Dict
 
 # Raw data key → display header. Canonical name per key (no per-task
@@ -189,10 +190,30 @@ def decimal_places(raw_key: str) -> int | None:
     return DECIMAL_PLACES.get(raw_key)
 
 
+_UNIT_SUFFIX = re.compile(r"\s*\([^)]*\)\s*$")
+_CHECK_SUFFIX = "_check"
+_RATIO_SUFFIX = "_ratio"
+
+
+def _base_display(raw_key: str) -> str:
+    return _UNIT_SUFFIX.sub("", display_name(raw_key))
+
+
+def target_checks_header(col: str) -> str:
+    if col == "name":
+        return "Tier"
+    if col.endswith(_CHECK_SUFFIX):
+        return f"{_base_display(col[: -len(_CHECK_SUFFIX)])} Check"
+    if col.endswith(_RATIO_SUFFIX):
+        return f"{_base_display(col[: -len(_RATIO_SUFFIX)])} Ratio"
+    return f"{_base_display(col)} Target"
+
+
 __all__ = [
     "DISPLAY_NAMES",
     "DECIMAL_PLACES",
     "EXPLANATIONS",
     "display_name",
     "decimal_places",
+    "target_checks_header",
 ]

--- a/tt-inference-server-v2/report_module/generator.py
+++ b/tt-inference-server-v2/report_module/generator.py
@@ -16,7 +16,7 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 from report_module import renderers
 from report_module.report_file_saver import ReportFileSaver
@@ -56,9 +56,10 @@ class ReportGenerator:
         section_markdowns = [
             self._render_block(block, normalized.metadata) for block in render_sections
         ]
-        rendered = [md for md in section_markdowns if md]
+        rendered_pairs = list(zip(render_sections, section_markdowns))
+        rendered_pairs = [(block, md) for block, md in rendered_pairs if md]
 
-        release_md = _assemble_release_markdown(normalized, rendered)
+        release_md = _assemble_release_markdown(normalized, rendered_pairs)
 
         md_path = out_dir / f"report_{normalized.report_id}.md"
         json_path = out_dir / f"report_{normalized.report_id}.json"
@@ -108,7 +109,9 @@ def _coerce_schema(schema: SchemaLike) -> ReportSchema:
     )
 
 
-def _assemble_release_markdown(schema: ReportSchema, sections: list[str]) -> str:
+def _assemble_release_markdown(
+    schema: ReportSchema, rendered_pairs: list[tuple[Block, str]]
+) -> str:
     header = (
         f"## Tenstorrent Model Release Summary: {schema.model_name} on {schema.device}"
     )
@@ -126,7 +129,115 @@ def _assemble_release_markdown(schema: ReportSchema, sections: list[str]) -> str
     ).strip()
     if acceptance_md:
         preamble.append(acceptance_md)
+
+    sections = _inject_spec_test_summary(rendered_pairs, schema.metadata)
     return "\n\n".join(preamble + sections)
+
+
+def _inject_spec_test_summary(
+    rendered_pairs: list[tuple[Block, str]], metadata: Mapping[str, Any]
+) -> list[str]:
+    runs: List[Mapping[str, Any]] = []
+    first_spec_idx: Optional[int] = None
+    for idx, (block, _md) in enumerate(rendered_pairs):
+        block_runs = _spec_test_runs(block)
+        if block_runs and first_spec_idx is None:
+            first_spec_idx = idx
+        runs.extend(block_runs)
+
+    sections = [md for _block, md in rendered_pairs]
+    if first_spec_idx is None or not runs:
+        return sections
+
+    summary_md = _build_spec_test_summary_markdown(
+        runs, str(metadata.get("generated_at") or "")
+    )
+    if not summary_md:
+        return sections
+    return sections[:first_spec_idx] + [summary_md] + sections[first_spec_idx:]
+
+
+def _spec_test_runs(block: Block) -> List[Mapping[str, Any]]:
+    data = block.data
+    if not isinstance(data, Mapping):
+        return []
+    if "test_name" in data and "attempts" in data:
+        return [data]
+    records = data.get("records") if isinstance(data, Mapping) else None
+    if isinstance(records, list):
+        return [
+            record
+            for record in records
+            if isinstance(record, Mapping)
+            and "test_name" in record
+            and "attempts" in record
+        ]
+    return []
+
+
+def _build_spec_test_summary_markdown(
+    runs: Sequence[Mapping[str, Any]], generated_at: str
+) -> str:
+    """Render the 📋 Summary + 🧪 Test Results section for spec tests."""
+    if not runs:
+        return ""
+
+    total = len(runs)
+    passed = sum(1 for r in runs if r.get("success") is True)
+    failed = sum(1 for r in runs if r.get("success") is False)
+    skipped = 0
+    attempted = passed + failed
+    total_duration = sum(_coerce_float(r.get("elapsed_seconds")) for r in runs)
+    total_attempts = sum(_coerce_int(r.get("attempts")) for r in runs)
+    success_rate = (passed / total * 100.0) if total else 0.0
+
+    summary_rows = [
+        ("Total Tests", str(total)),
+        ("Passed", str(passed)),
+        ("Failed", str(failed)),
+        ("Skipped", str(skipped)),
+        ("Attempted", str(attempted)),
+        ("Success Rate", f"{success_rate:.1f}%"),
+        ("Total Duration", f"{total_duration:.2f}s"),
+        ("Total Attempts", str(total_attempts)),
+        ("Generated", generated_at or "-"),
+    ]
+    summary_table = "\n".join(
+        ["| Metric | Value |", "|:-------|------:|"]
+        + [f"| {metric} | {value} |" for metric, value in summary_rows]
+    )
+
+    result_header = (
+        "| Status | Test Name | Duration | Attempts | Description |\n"
+        "|:------:|:----------|---------:|---------:|:------------|"
+    )
+    result_rows = [
+        "| {status} | {name} | {duration:.2f}s | {attempts} | {description} |".format(
+            status="✅" if run.get("success") is True else "❌",
+            name=str(run.get("test_name") or ""),
+            duration=_coerce_float(run.get("elapsed_seconds")),
+            attempts=_coerce_int(run.get("attempts")),
+            description=str(run.get("description") or ""),
+        )
+        for run in runs
+    ]
+    results_table = "\n".join([result_header] + result_rows)
+
+    return f"## 📋 Summary\n{summary_table}\n\n## 🧪 Test Results\n{results_table}"
+
+
+def _coerce_float(value: Any) -> float:
+    try:
+        return float(value) if value is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _coerce_int(value: Any) -> int:
+    try:
+        return int(value) if value is not None else 0
+    except (TypeError, ValueError):
+        return 0
 
 
 def generate_report(

--- a/tt-inference-server-v2/report_module/generator.py
+++ b/tt-inference-server-v2/report_module/generator.py
@@ -288,7 +288,9 @@ def _records_for_merge(block: Block) -> List[Dict[str, Any]]:
 def _flatten_one_level(record: Mapping[str, Any]) -> Dict[str, Any]:
     out: Dict[str, Any] = {}
     for key, value in record.items():
-        if isinstance(value, Mapping):
+        if isinstance(value, Mapping) and all(
+            not isinstance(v, Mapping) for v in value.values()
+        ):
             for sub_key, sub_value in value.items():
                 out.setdefault(sub_key, sub_value)
         else:

--- a/tt-inference-server-v2/report_module/generator.py
+++ b/tt-inference-server-v2/report_module/generator.py
@@ -16,7 +16,7 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from report_module import renderers
 from report_module.report_file_saver import ReportFileSaver
@@ -52,9 +52,10 @@ class ReportGenerator:
         out_dir = Path(output_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
 
+        render_sections = _collapse_same_heading_blocks(normalized.sections)
         section_markdowns = [
             self._render_block(block, normalized.metadata)
-            for block in normalized.sections
+            for block in render_sections
         ]
         rendered = [md for md in section_markdowns if md]
 
@@ -136,3 +137,50 @@ def generate_report(
 ) -> GenerateResult:
     """Convenience functional wrapper around :class:`ReportGenerator`."""
     return ReportGenerator(file_saver=file_saver).generate(schema, output_dir)
+
+
+def _collapse_same_heading_blocks(sections: List[Block]) -> List[Block]:
+    """Merge consecutive blocks that would render under the same heading.
+    """
+    merged: List[Block] = []
+    for block in sections:
+        if merged and _has_same_heading(merged[-1], block):
+            merged[-1] = _merge_blocks(merged[-1], block)
+        else:
+            merged.append(block)
+    return merged
+
+
+def _has_same_heading(a: Block, b: Block) -> bool:
+    return (
+        a.kind == b.kind
+        and (a.title or "") == (b.title or "")
+        and (a.id or "") == (b.id or "")
+    )
+
+
+def _merge_blocks(a: Block, b: Block) -> Block:
+    records = _records_for_merge(a) + _records_for_merge(b)
+    return Block(
+        kind=a.kind,
+        title=a.title,
+        id=a.id,
+        targets=dict(a.targets),
+        checks=dict(a.checks),
+        data={"records": records},
+    )
+
+
+def _records_for_merge(block: Block) -> List[Dict[str, Any]]:
+    return [_flatten_one_level(record) for record in renderers._extract_records(block)]
+
+
+def _flatten_one_level(record: Mapping[str, Any]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for key, value in record.items():
+        if isinstance(value, Mapping):
+            for sub_key, sub_value in value.items():
+                out.setdefault(sub_key, sub_value)
+        else:
+            out[key] = value
+    return out

--- a/tt-inference-server-v2/report_module/generator.py
+++ b/tt-inference-server-v2/report_module/generator.py
@@ -54,8 +54,7 @@ class ReportGenerator:
 
         render_sections = _collapse_same_heading_blocks(normalized.sections)
         section_markdowns = [
-            self._render_block(block, normalized.metadata)
-            for block in render_sections
+            self._render_block(block, normalized.metadata) for block in render_sections
         ]
         rendered = [md for md in section_markdowns if md]
 
@@ -140,8 +139,7 @@ def generate_report(
 
 
 def _collapse_same_heading_blocks(sections: List[Block]) -> List[Block]:
-    """Merge consecutive blocks that would render under the same heading.
-    """
+    """Merge consecutive blocks that would render under the same heading."""
     merged: List[Block] = []
     for block in sections:
         if merged and _has_same_heading(merged[-1], block):

--- a/tt-inference-server-v2/report_module/generator.py
+++ b/tt-inference-server-v2/report_module/generator.py
@@ -263,6 +263,7 @@ def _collapse_same_heading_blocks(sections: List[Block]) -> List[Block]:
 def _has_same_heading(a: Block, b: Block) -> bool:
     return (
         a.kind == b.kind
+        and (a.task_type or "") == (b.task_type or "")
         and (a.title or "") == (b.title or "")
         and (a.id or "") == (b.id or "")
     )
@@ -273,9 +274,9 @@ def _merge_blocks(a: Block, b: Block) -> Block:
     return Block(
         kind=a.kind,
         title=a.title,
+        task_type=a.task_type,
         id=a.id,
         targets=dict(a.targets),
-        checks=dict(a.checks),
         data={"records": records},
     )
 

--- a/tt-inference-server-v2/report_module/renderers.py
+++ b/tt-inference-server-v2/report_module/renderers.py
@@ -17,7 +17,17 @@ logger = logging.getLogger(__name__)
 
 RendererFn = Callable[[Block, Mapping[str, Any]], str]
 
-HIDDEN_COLUMNS = frozenset({"kind", "model", "device", "timestamp"})
+HIDDEN_COLUMNS = frozenset(
+    {
+        "kind",
+        "model",
+        "device",
+        "timestamp",
+        "test_name",
+        "description",
+        "elapsed_seconds",
+    }
+)
 
 GENERIC_KINDS: tuple[str, ...] = (
     "benchmarks",

--- a/tt-inference-server-v2/report_module/renderers.py
+++ b/tt-inference-server-v2/report_module/renderers.py
@@ -38,13 +38,9 @@ HIDDEN_COLUMNS = frozenset(
 
 GENERIC_KINDS: tuple[str, ...] = (
     "benchmarks",
-    "benchmarks_summary",
     "evals",
-    "percentile_benchmarks",
-    "parameter_support_tests",
+    "server_tests",
     "stress_tests",
-    "server_test_results",
-    "results_details",
 )
 
 _REGISTRY: Dict[str, RendererFn] = {}

--- a/tt-inference-server-v2/report_module/renderers.py
+++ b/tt-inference-server-v2/report_module/renderers.py
@@ -9,7 +9,12 @@ import logging
 import re
 from typing import Any, Callable, Dict, List, Mapping, Sequence
 
-from report_module.display import DISPLAY_NAMES, decimal_places, display_name
+from report_module.display import (
+    DISPLAY_NAMES,
+    decimal_places,
+    display_name,
+    target_checks_header,
+)
 from report_module.formatting import format_value
 from report_module.markdown_table import build_markdown_table
 from report_module.schema import Block
@@ -192,16 +197,21 @@ def _pivot_single_record(
     ]
 
 
-def _build_table(records: Sequence[Mapping[str, Any]]) -> str:
+def _build_table(
+    records: Sequence[Mapping[str, Any]],
+    header_fn: Callable[[str], str] = display_name,
+) -> str:
     columns = _ordered_display_columns(records)
     if not columns:
         return ""
     display_rows = [
-        {display_name(col): _format_cell(col, record.get(col)) for col in columns}
+        {header_fn(col): _format_cell(col, record.get(col)) for col in columns}
         for record in records
     ]
     return build_markdown_table(display_rows)
 
+
+_TARGET_CHECKS_KEY = "target_checks"
 
 _SNAKE_CASE = re.compile(r"^[a-z0-9_]+$")
 
@@ -274,7 +284,8 @@ def render_generic_table(block: Block, metadata: Mapping[str, Any]) -> str:
         sub_records = _extract_records(Block(kind=key, data=value))
         if not sub_records:
             continue
-        sub_table = _build_table(sub_records)
+        header_fn = target_checks_header if key == _TARGET_CHECKS_KEY else display_name
+        sub_table = _build_table(sub_records, header_fn=header_fn)
         if not sub_table:
             continue
         parts.append(f"#### {_humanize_key(key)}\n\n{sub_table}")

--- a/tt-inference-server-v2/report_module/renderers.py
+++ b/tt-inference-server-v2/report_module/renderers.py
@@ -9,6 +9,7 @@ import logging
 import re
 from typing import Any, Callable, Dict, List, Mapping, Sequence
 
+from report_module.display import DISPLAY_NAMES, decimal_places, display_name
 from report_module.formatting import format_value
 from report_module.markdown_table import build_markdown_table
 from report_module.schema import Block
@@ -154,6 +155,9 @@ def _format_cell(column: str, value: Any) -> str:
         and value in _CHECK_INT_TO_LABEL
     ):
         return _CHECK_INT_TO_LABEL[value]
+    places = decimal_places(column)
+    if places is not None and isinstance(value, float) and value == value:
+        return f"{value:.{places}f}"
     return format_value(value)
 
 
@@ -167,8 +171,8 @@ def _pivot_single_record(
     """
     return [
         {
-            PIVOT_FIELD_HEADER: col,
-            PIVOT_VALUE_HEADER: format_value(record.get(col)),
+            PIVOT_FIELD_HEADER: display_name(col),
+            PIVOT_VALUE_HEADER: _format_cell(col, record.get(col)),
         }
         for col in columns
     ]
@@ -179,7 +183,7 @@ def _build_table(records: Sequence[Mapping[str, Any]]) -> str:
     if not columns:
         return ""
     display_rows = [
-        {col: _format_cell(col, record.get(col)) for col in columns}
+        {display_name(col): _format_cell(col, record.get(col)) for col in columns}
         for record in records
     ]
     return build_markdown_table(display_rows)
@@ -190,7 +194,11 @@ _SNAKE_CASE = re.compile(r"^[a-z0-9_]+$")
 
 def _humanize_key(key: str) -> str:
     """Turn ``"summary_stats"`` into ``"Summary Stats"`` while leaving
-    already-formatted keys (``"TTFT vs. Context"``) untouched."""
+    already-formatted keys (``"TTFT vs. Context"``) untouched.
+
+    Prefers an explicit :mod:`display` mapping when one exists"""
+    if key in DISPLAY_NAMES:
+        return display_name(key)
     if _SNAKE_CASE.match(key):
         return key.replace("_", " ").title()
     return key

--- a/tt-inference-server-v2/report_module/renderers.py
+++ b/tt-inference-server-v2/report_module/renderers.py
@@ -27,6 +27,7 @@ HIDDEN_COLUMNS = frozenset(
         "test_name",
         "description",
         "elapsed_seconds",
+        "logs",
     }
 )
 
@@ -106,8 +107,21 @@ def _resolve_model_device(
     return model, device
 
 
-def _heading(kind: str, model: str, device: str, title_override: str = "") -> str:
-    label = title_override or kind.replace("_", " ").title()
+def _heading(
+    kind: str,
+    model: str,
+    device: str,
+    title_override: str = "",
+    task_type: str = "",
+) -> str:
+    if title_override:
+        label = title_override
+    elif task_type and kind:
+        label = (
+            f"{task_type.replace('_', ' ').title()} {kind.replace('_', ' ').title()}"
+        )
+    else:
+        label = kind.replace("_", " ").title()
     suffix_bits = [bit for bit in (model, device) if bit]
     if not suffix_bits:
         return f"### {label}"
@@ -231,7 +245,9 @@ def render_generic_table(block: Block, metadata: Mapping[str, Any]) -> str:
         return ""
 
     model, device = _resolve_model_device(block, metadata, records)
-    heading = _heading(block.kind, model, device, block.title or "")
+    heading = _heading(
+        block.kind, model, device, block.title or "", block.task_type or ""
+    )
 
     if len(records) > 1:
         table = _build_table(records)

--- a/tt-inference-server-v2/report_module/schema.py
+++ b/tt-inference-server-v2/report_module/schema.py
@@ -11,20 +11,14 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 @dataclass(frozen=True)
 class Block:
-    """One section of a report.
-
-    ``kind`` selects the renderer. ``data`` and ``targets`` are free-form
-    and only the registered renderer for ``kind`` is expected to
-    understand their shape. ``id`` disambiguates blocks that share a
-    ``kind`` (e.g. two ``benchmarks`` blocks for different tools).
-    """
+    """One section of a report."""
 
     kind: str
     data: Any
     title: Optional[str] = None
+    task_type: Optional[str] = None
     id: Optional[str] = None
     targets: Dict[str, Any] = field(default_factory=dict)
-    checks: Dict[str, Any] = field(default_factory=dict)
 
     @property
     def slug(self) -> str:
@@ -39,21 +33,21 @@ class Block:
             kind=str(payload["kind"]),
             data=payload.get("data"),
             title=payload.get("title"),
+            task_type=payload.get("task_type"),
             id=payload.get("id"),
             targets=dict(payload.get("targets") or {}),
-            checks=dict(payload.get("checks") or {}),
         )
 
     def to_dict(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {"kind": self.kind, "data": self.data}
         if self.title is not None:
             out["title"] = self.title
+        if self.task_type is not None:
+            out["task_type"] = self.task_type
         if self.id is not None:
             out["id"] = self.id
         if self.targets:
             out["targets"] = dict(self.targets)
-        if self.checks:
-            out["checks"] = dict(self.checks)
         return out
 
 

--- a/tt-inference-server-v2/run.py
+++ b/tt-inference-server-v2/run.py
@@ -263,13 +263,14 @@ def main() -> int:
 
     schema = accumulator.build_schema()
     _inject_orchestrator_metadata(schema.metadata, ctx, args)
-    accepted, blockers = acceptance_criteria_check(schema)
+    accepted, blockers, categories = acceptance_criteria_check(schema)
     schema.metadata["acceptance_summary_markdown"] = format_acceptance_summary_markdown(
-        accepted, blockers
+        accepted, blockers, categories
     )
     schema.metadata["acceptance_criteria"] = {
         "accepted": accepted,
         "blockers": blockers,
+        "categories": [c.to_dict() for c in categories],
     }
     logger.info(
         "Acceptance criteria: %s (%d blocker(s))",

--- a/tt-inference-server-v2/test_module/_test_common/__init__.py
+++ b/tt-inference-server-v2/test_module/_test_common/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 from .base_test import BaseTest
-from .blockify import block_id, block_targets, sweep_envelope
+from .blockify import block_id, sweep_envelope
 from .report_types import ReportCheckTypes
 from .target_check import MetricSpec, PerformanceTargets, run_tiered_check
 from .test_classes import TestCase, TestConfig, TestReport, TestTarget
@@ -18,7 +18,6 @@ __all__ = [
     "TestReport",
     "TestTarget",
     "block_id",
-    "block_targets",
     "run_tiered_check",
     "sweep_envelope",
 ]

--- a/tt-inference-server-v2/test_module/_test_common/base_test.py
+++ b/tt-inference-server-v2/test_module/_test_common/base_test.py
@@ -17,7 +17,7 @@ import requests
 
 from report_module.schema import Block
 
-from .blockify import block_id, block_targets
+from .blockify import block_id
 from .test_classes import TestConfig
 
 if TYPE_CHECKING:
@@ -113,14 +113,19 @@ class BaseTest(ABC):
         return value
 
     def _block(self, data: Dict[str, Any]) -> Block:
-        """Wrap ``data`` in a Block tagged with this test's KIND/TASK_TYPE."""
-        if self.ctx is not None:
-            bid = block_id(self.ctx) or None
-            targets = block_targets(self.ctx, task_type=self.TASK_TYPE)
-        else:
-            bid = None
-            targets = {"task_type": self.TASK_TYPE}
-        return Block(kind=self.KIND, id=bid, targets=targets, data=data)
+        """Wrap ``data`` in a Block tagged with this test's KIND.
+
+        ``Block.targets`` carries the test case's own threshold dict
+        (``self.targets``) so the JSON output preserves what each test
+        was measured against. 
+        """
+        bid = block_id(self.ctx) or None if self.ctx is not None else None
+        return Block(
+            kind=self.KIND,
+            id=bid,
+            targets=dict(self.targets),
+            data=data,
+        )
 
     def run_tests(self) -> Block:
         """Run the test with retry/log accounting and return a Block.

--- a/tt-inference-server-v2/test_module/_test_common/base_test.py
+++ b/tt-inference-server-v2/test_module/_test_common/base_test.py
@@ -126,7 +126,8 @@ class BaseTest(ABC):
         """Run the test with retry/log accounting and return a Block.
 
         On success, ``Block.data`` carries the envelope keys
-        (``success``, ``attempts``, ``logs``) merged with the test's own
+        (``success``, ``attempts``, ``logs``, ``elapsed_seconds``,
+        ``test_name``, ``description``) merged with the test's own
         result dict at the top level — so a result like
         ``{"runner_in_use": "vllm", "ttft": 0.18}`` becomes
         ``{"success": True, "attempts": 1, "logs": [...],
@@ -143,7 +144,8 @@ class BaseTest(ABC):
 
         On failure (all retries exhausted)::
             {"success": False, "attempts": int, "logs": list,
-             "error": {"type": str, "message": str}}
+             "elapsed_seconds": float, "test_name": str,
+             "description": str, "error": {"type": str, "message": str}}
 
         ``break_on_failure=True`` re-raises ``SystemExit`` after building the
         failure Block so callers that opt into hard-fail still get one;
@@ -151,6 +153,7 @@ class BaseTest(ABC):
         """
         last_exception: Optional[BaseException] = None
         attempts_used = 0
+        run_started = time.monotonic()
 
         for attempt in range(self.retry_attempts + 1):
             attempts_used = attempt + 1
@@ -186,6 +189,9 @@ class BaseTest(ABC):
                 data["success"] = success
                 data["attempts"] = attempts_used
                 data["logs"] = list(self.logs)
+                data["elapsed_seconds"] = time.monotonic() - run_started
+                data["test_name"] = type(self).__name__
+                data["description"] = self.description
                 return self._block(data)
 
             except asyncio.TimeoutError as e:
@@ -270,6 +276,9 @@ class BaseTest(ABC):
                 "success": False,
                 "attempts": attempts_used,
                 "logs": list(self.logs),
+                "elapsed_seconds": time.monotonic() - run_started,
+                "test_name": type(self).__name__,
+                "description": self.description,
                 "error": error_payload,
             }
         )

--- a/tt-inference-server-v2/test_module/_test_common/base_test.py
+++ b/tt-inference-server-v2/test_module/_test_common/base_test.py
@@ -113,16 +113,13 @@ class BaseTest(ABC):
         return value
 
     def _block(self, data: Dict[str, Any]) -> Block:
-        """Wrap ``data`` in a Block tagged with this test's KIND.
-
-        ``Block.targets`` carries the test case's own threshold dict
-        (``self.targets``) so the JSON output preserves what each test
-        was measured against. 
-        """
+        """Wrap ``data`` in a Block tagged kind="server_tests"."""
         bid = block_id(self.ctx) or None if self.ctx is not None else None
         return Block(
-            kind=self.KIND,
+            kind="server_tests",
             id=bid,
+            title=self.KIND.replace("_", " ").title(),
+            task_type=self.TASK_TYPE,
             targets=dict(self.targets),
             data=data,
         )

--- a/tt-inference-server-v2/test_module/_test_common/blockify.py
+++ b/tt-inference-server-v2/test_module/_test_common/blockify.py
@@ -5,15 +5,15 @@
 """Helpers for building :class:`report_module.schema.Block` objects from a
 :class:`MediaContext`.
 
-Media benchmark/eval runners construct their own Block directly; these
-helpers cover the boilerplate (envelope targets, Block id slug, and the
-sweep-level envelope dict) so each runner only has to write its own
-``data`` payload.
+Media benchmark/eval runners construct their own Block directly; this
+module covers the boilerplate (Block id slug and the sweep-level
+envelope dict) so each runner only has to write its own ``data``
+payload + a per-runner ``targets`` dict capturing the run config.
 
 Model / device / timestamp are recorded **once** at sweep level by the
 workflow accumulator (see :mod:`workflow_module.blocks_sink`) and become
-the report's top-level metadata; per-block targets only carry fields that
-genuinely vary between blocks (``task_type``).
+the report's top-level metadata; per-block ``targets`` carries the test
+case's own thresholds / run config.
 """
 
 from __future__ import annotations
@@ -23,22 +23,6 @@ from typing import TYPE_CHECKING, Any, Dict
 
 if TYPE_CHECKING:
     from ..context import MediaContext
-
-
-def block_targets(
-    ctx: "MediaContext", *, task_type: str, **extra: Any
-) -> Dict[str, Any]:
-    """Per-block envelope attached to ``Block.targets`` by a runner.
-
-    ``ctx`` is unused today but kept in the signature so future
-    per-block envelope fields have a place to plug in without churning
-    every call site. ``extra`` lets a caller fold in additional
-    envelope-style fields without polluting ``Block.data``.
-    """
-    del ctx  # reserved for future per-block envelope fields
-    targets: Dict[str, Any] = {"task_type": task_type}
-    targets.update(extra)
-    return targets
 
 
 def sweep_envelope(ctx: "MediaContext") -> Dict[str, Any]:
@@ -78,4 +62,4 @@ def block_id(ctx: "MediaContext") -> str:
     return "_".join(parts).replace("/", "__").replace("\\", "__").replace(" ", "_")
 
 
-__all__ = ["block_id", "block_targets", "sweep_envelope"]
+__all__ = ["block_id", "sweep_envelope"]

--- a/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
@@ -31,7 +31,6 @@ from .._test_common import (
     MetricSpec,
     ReportCheckTypes,
     block_id,
-    block_targets,
     run_tiered_check,
 )
 from ..context import MediaContext, count_tokens, require_health
@@ -294,7 +293,11 @@ def run_audio_benchmark(ctx: MediaContext) -> Block:
     return Block(
         kind="audio_benchmark",
         id=block_id(ctx) or None,
-        targets=block_targets(ctx, task_type="audio"),
+        targets={
+            "num_prompts": len(status_list),
+            "streaming_enabled": is_streaming_enabled_for_whisper(ctx),
+            "preprocessing_enabled": is_preprocessing_enabled_for_whisper(ctx),
+        },
         data={
             "Benchmarks": {
                 "num_requests": len(status_list),

--- a/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
@@ -291,7 +291,9 @@ def run_audio_benchmark(ctx: MediaContext) -> Block:
     )
 
     return Block(
-        kind="audio_benchmark",
+        kind="benchmarks",
+        task_type="audio",
+        title="Audio Benchmark",
         id=block_id(ctx) or None,
         targets={
             "num_prompts": len(status_list),

--- a/tt-inference-server-v2/test_module/benchmark_tests/cnn_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/cnn_benchmark_tests.py
@@ -215,7 +215,9 @@ def run_cnn_benchmark(ctx: MediaContext) -> Block:
         ctx, ttft_value, inference_steps_per_second
     )
     return Block(
-        kind="cnn_benchmark",
+        kind="benchmarks",
+        task_type="cnn",
+        title="CNN Benchmark",
         id=block_id(ctx) or None,
         targets={
             "num_prompts": len(status_list),

--- a/tt-inference-server-v2/test_module/benchmark_tests/cnn_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/cnn_benchmark_tests.py
@@ -24,7 +24,6 @@ from .._test_common import (
     MetricSpec,
     ReportCheckTypes,
     block_id,
-    block_targets,
     run_tiered_check,
 )
 from ..context import MediaContext, require_health
@@ -218,7 +217,12 @@ def run_cnn_benchmark(ctx: MediaContext) -> Block:
     return Block(
         kind="cnn_benchmark",
         id=block_id(ctx) or None,
-        targets=block_targets(ctx, task_type="cnn"),
+        targets={
+            "num_prompts": len(status_list),
+            "num_inference_steps": (
+                status_list[0].num_inference_steps if status_list else 0
+            ),
+        },
         data={
             "Benchmarks": {
                 "num_requests": len(status_list),

--- a/tt-inference-server-v2/test_module/benchmark_tests/embedding_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/embedding_benchmark_tests.py
@@ -25,7 +25,6 @@ from .._test_common import (
     MetricSpec,
     ReportCheckTypes,
     block_id,
-    block_targets,
     run_tiered_check,
 )
 from ..context import MediaContext, require_health
@@ -173,7 +172,11 @@ def run_embedding_benchmark(ctx: MediaContext) -> Block:
     return Block(
         kind="embedding_benchmark",
         id=block_id(ctx) or None,
-        targets=block_targets(ctx, task_type="embedding"),
+        targets={
+            "num_prompts": successful_requests + failed_requests,
+            "isl": isl,
+            "concurrency": concurrency,
+        },
         data={
             "Benchmarks": {
                 "isl": isl,

--- a/tt-inference-server-v2/test_module/benchmark_tests/embedding_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/embedding_benchmark_tests.py
@@ -170,7 +170,9 @@ def run_embedding_benchmark(ctx: MediaContext) -> Block:
     )
 
     return Block(
-        kind="embedding_benchmark",
+        kind="benchmarks",
+        task_type="embedding",
+        title="Embedding Benchmark",
         id=block_id(ctx) or None,
         targets={
             "num_prompts": successful_requests + failed_requests,

--- a/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
@@ -361,7 +361,9 @@ def run_image_benchmark(ctx: MediaContext) -> Block:
     )
     num_inference_steps_used = status_list[0].num_inference_steps if status_list else 0
     return Block(
-        kind="image_benchmark",
+        kind="benchmarks",
+        task_type="image",
+        title="Image Benchmark",
         id=block_id(ctx) or None,
         targets={
             "num_prompts": len(status_list),

--- a/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
@@ -26,7 +26,6 @@ from .._test_common import (
     MetricSpec,
     ReportCheckTypes,
     block_id,
-    block_targets,
     run_tiered_check,
 )
 from ..context import MediaContext, require_health
@@ -360,16 +359,18 @@ def run_image_benchmark(ctx: MediaContext) -> Block:
     target_checks, accuracy_check = _image_target_checks(
         ctx, ttft_value, inference_steps_per_second
     )
+    num_inference_steps_used = status_list[0].num_inference_steps if status_list else 0
     return Block(
         kind="image_benchmark",
         id=block_id(ctx) or None,
-        targets=block_targets(ctx, task_type="image"),
+        targets={
+            "num_prompts": len(status_list),
+            "num_inference_steps": num_inference_steps_used,
+        },
         data={
             "Benchmarks": {
                 "num_requests": len(status_list),
-                "num_inference_steps": (
-                    status_list[0].num_inference_steps if status_list else 0
-                ),
+                "num_inference_steps": num_inference_steps_used,
                 "ttft": ttft_value,
                 "inference_steps_per_second": inference_steps_per_second,
                 "tput_user": inference_steps_per_second,

--- a/tt-inference-server-v2/test_module/benchmark_tests/tts_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/tts_benchmark_tests.py
@@ -236,7 +236,9 @@ def run_tts_benchmark(ctx: MediaContext) -> Block:
     target_checks, accuracy_check = _tts_target_checks(ctx, ttft_value, rtr_value)
 
     return Block(
-        kind="tts_benchmark",
+        kind="benchmarks",
+        task_type="text_to_speech",
+        title="Text-to-Speech Benchmark",
         id=block_id(ctx) or None,
         targets={"num_prompts": len(status_list)},
         data={

--- a/tt-inference-server-v2/test_module/benchmark_tests/tts_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/tts_benchmark_tests.py
@@ -27,7 +27,6 @@ from .._test_common import (
     MetricSpec,
     ReportCheckTypes,
     block_id,
-    block_targets,
     run_tiered_check,
 )
 from ..context import MediaContext, require_health
@@ -239,7 +238,7 @@ def run_tts_benchmark(ctx: MediaContext) -> Block:
     return Block(
         kind="tts_benchmark",
         id=block_id(ctx) or None,
-        targets=block_targets(ctx, task_type="tts"),
+        targets={"num_prompts": len(status_list)},
         data={
             "Benchmarks": {
                 "num_requests": len(status_list),

--- a/tt-inference-server-v2/test_module/benchmark_tests/video_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/video_benchmark_tests.py
@@ -24,7 +24,6 @@ from .._test_common import (
     MetricSpec,
     ReportCheckTypes,
     block_id,
-    block_targets,
     run_tiered_check,
 )
 from ..context import MediaContext, require_health
@@ -248,7 +247,12 @@ def run_video_benchmark(ctx: MediaContext) -> Block:
     return Block(
         kind="video_benchmark",
         id=block_id(ctx) or None,
-        targets=block_targets(ctx, task_type="video"),
+        targets={
+            "num_prompts": len(status_list),
+            "num_inference_steps": (
+                status_list[0].num_inference_steps if status_list else 0
+            ),
+        },
         data={
             "Benchmarks": {
                 "num_requests": len(status_list),

--- a/tt-inference-server-v2/test_module/benchmark_tests/video_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/video_benchmark_tests.py
@@ -245,7 +245,9 @@ def run_video_benchmark(ctx: MediaContext) -> Block:
         ctx, ttft_value, inference_steps_per_second
     )
     return Block(
-        kind="video_benchmark",
+        kind="benchmarks",
+        task_type="video",
+        title="Video Benchmark",
         id=block_id(ctx) or None,
         targets={
             "num_prompts": len(status_list),

--- a/tt-inference-server-v2/test_module/dispatch.py
+++ b/tt-inference-server-v2/test_module/dispatch.py
@@ -170,16 +170,20 @@ def _instantiate_spec_test(case: dict, ctx: MediaContext):
     BaseTest accepts ``(config, targets, description="", ctx=None)`` but a
     handful of test classes (e.g. ImageGenerationEvalsTest) override
     ``__init__`` with just ``(config, targets)`` — so we try the rich form
-    first and fall back to the minimal one rather than introspecting.
+    first and fall back to the minimal one, patching ``description`` on
+    afterward so the summary block can still surface it.
     """
     config = TestConfig(case.get("test_config") or {})
     targets = case.get("targets") or {}
+    description = case.get("description") or ""
     module = importlib.import_module(case["module"])
     cls = getattr(module, case["name"])
     try:
-        return cls(config, targets, ctx=ctx)
+        return cls(config, targets, description=description, ctx=ctx)
     except TypeError:
-        return cls(config, targets)
+        instance = cls(config, targets)
+        instance.description = description
+        return instance
 
 
 def run_spec_tests(ctx: MediaContext) -> Tuple[int, Optional[Block]]:

--- a/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
@@ -27,7 +27,7 @@ from workflows.utils import (
 )
 from report_module.schema import Block
 
-from .._test_common import ReportCheckTypes, block_id, block_targets
+from .._test_common import ReportCheckTypes, block_id
 from ..context import MediaContext, count_tokens, require_health
 from ..test_status import AudioTestStatus
 
@@ -273,7 +273,12 @@ def run_audio_eval(ctx: MediaContext) -> Block:
     return Block(
         kind="audio_eval",
         id=block_id(ctx) or None,
-        targets=block_targets(ctx, task_type="audio"),
+        targets={
+            "task_name": task.task_name,
+            "tolerance": task.score.tolerance,
+            "published_score": task.score.published_score,
+            "published_score_ref": task.score.published_score_ref,
+        },
         data={
             "task_name": task.task_name,
             "tolerance": task.score.tolerance,

--- a/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
@@ -271,7 +271,9 @@ def run_audio_eval(ctx: MediaContext) -> Block:
 
     task = ctx.all_params.tasks[0]
     return Block(
-        kind="audio_eval",
+        kind="evals",
+        task_type="audio",
+        title="Audio Eval",
         id=block_id(ctx) or None,
         targets={
             "task_name": task.task_name,

--- a/tt-inference-server-v2/test_module/eval_tests/cnn_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/cnn_eval_tests.py
@@ -20,7 +20,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from report_module.schema import Block
 
-from .._test_common import ReportCheckTypes, block_id, block_targets
+from .._test_common import ReportCheckTypes, block_id
 from ..context import MediaContext, require_health
 from ..test_status import CnnGenerationTestStatus
 
@@ -224,7 +224,12 @@ def run_cnn_eval(ctx: MediaContext) -> Block:
     return Block(
         kind="cnn_eval",
         id=block_id(ctx) or None,
-        targets=block_targets(ctx, task_type="cnn"),
+        targets={
+            "task_name": ctx.all_params.tasks[0].task_name,
+            "tolerance": ctx.all_params.tasks[0].score.tolerance,
+            "published_score": ctx.all_params.tasks[0].score.published_score,
+            "published_score_ref": ctx.all_params.tasks[0].score.published_score_ref,
+        },
         data=data,
     )
 

--- a/tt-inference-server-v2/test_module/eval_tests/cnn_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/cnn_eval_tests.py
@@ -222,7 +222,9 @@ def run_cnn_eval(ctx: MediaContext) -> Block:
         data["published_score_ref"] = task.score.published_score_ref
 
     return Block(
-        kind="cnn_eval",
+        kind="evals",
+        task_type="cnn",
+        title="CNN Eval",
         id=block_id(ctx) or None,
         targets={
             "task_name": ctx.all_params.tasks[0].task_name,

--- a/tt-inference-server-v2/test_module/eval_tests/embedding_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/embedding_eval_tests.py
@@ -149,7 +149,9 @@ def run_embedding_eval(ctx: MediaContext) -> Block:
 
     logger.info("Generating evals report...")
     return Block(
-        kind="embedding_eval",
+        kind="evals",
+        task_type="embedding",
+        title="Embedding Eval",
         id=block_id(ctx) or None,
         targets={"task_name": ctx.all_params.tasks[0].task_name},
         data={

--- a/tt-inference-server-v2/test_module/eval_tests/embedding_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/embedding_eval_tests.py
@@ -16,7 +16,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from report_module.schema import Block
 
-from .._test_common import block_id, block_targets
+from .._test_common import block_id
 from ..context import MediaContext, require_health
 
 logger = logging.getLogger(__name__)
@@ -151,7 +151,7 @@ def run_embedding_eval(ctx: MediaContext) -> Block:
     return Block(
         kind="embedding_eval",
         id=block_id(ctx) or None,
-        targets=block_targets(ctx, task_type="embedding"),
+        targets={"task_name": ctx.all_params.tasks[0].task_name},
         data={
             "task_name": ctx.all_params.tasks[0].task_name,
             **metrics,

--- a/tt-inference-server-v2/test_module/eval_tests/image_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/image_eval_tests.py
@@ -29,7 +29,7 @@ from utils.sdxl_accuracy_utils.sdxl_accuracy_utils import (
 )
 from workflows.utils import is_sdxl_num_prompts_enabled
 
-from .._test_common import block_id, block_targets
+from .._test_common import block_id
 from ..context import MediaContext, require_health
 from ..test_status import ImageGenerationTestStatus
 
@@ -499,7 +499,12 @@ def run_image_eval(ctx: MediaContext) -> Block:
     return Block(
         kind="image_eval",
         id=block_id(ctx) or None,
-        targets=block_targets(ctx, task_type="image"),
+        targets={
+            "task_name": task.task_name,
+            "tolerance": task.score.tolerance,
+            "published_score": task.score.published_score,
+            "published_score_ref": task.score.published_score_ref,
+        },
         data=data,
     )
 

--- a/tt-inference-server-v2/test_module/eval_tests/image_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/image_eval_tests.py
@@ -497,7 +497,9 @@ def run_image_eval(ctx: MediaContext) -> Block:
             logger.warning(f"No device spec found for device: {ctx.device}")
 
     return Block(
-        kind="image_eval",
+        kind="evals",
+        task_type="image",
+        title="Image Eval",
         id=block_id(ctx) or None,
         targets={
             "task_name": task.task_name,

--- a/tt-inference-server-v2/test_module/eval_tests/image_generation_eval_test.py
+++ b/tt-inference-server-v2/test_module/eval_tests/image_generation_eval_test.py
@@ -101,6 +101,9 @@ class ImageGenContext:
 class ImageGenerationEvalsTest(BaseTest):
     """Eval test for image generation models."""
 
+    KIND = "image_generation_evals"
+    TASK_TYPE = "image"
+
     def __init__(self, config: TestConfig, targets: dict):
         super().__init__(config, targets)
         self.eval_results: dict = {}

--- a/tt-inference-server-v2/test_module/eval_tests/tts_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/tts_eval_tests.py
@@ -26,7 +26,6 @@ from .._test_common import (
     MetricSpec,
     ReportCheckTypes,
     block_id,
-    block_targets,
     run_tiered_check,
 )
 from ..context import MediaContext, require_health
@@ -244,7 +243,12 @@ def run_tts_eval(ctx: MediaContext) -> Block:
     return Block(
         kind="tts_eval",
         id=block_id(ctx) or None,
-        targets=block_targets(ctx, task_type="text_to_speech"),
+        targets={
+            "task_name": task.task_name,
+            "tolerance": task.score.tolerance,
+            "published_score": task.score.published_score,
+            "published_score_ref": task.score.published_score_ref,
+        },
         data={
             "task_name": task.task_name,
             "tolerance": task.score.tolerance,

--- a/tt-inference-server-v2/test_module/eval_tests/tts_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/tts_eval_tests.py
@@ -241,7 +241,9 @@ def run_tts_eval(ctx: MediaContext) -> Block:
     task = ctx.all_params.tasks[0]
     target_checks, performance_check = _tts_target_checks(ctx, ttft_value, rtr_value)
     return Block(
-        kind="tts_eval",
+        kind="evals",
+        task_type="text_to_speech",
+        title="Text-to-Speech Eval",
         id=block_id(ctx) or None,
         targets={
             "task_name": task.task_name,

--- a/tt-inference-server-v2/test_module/eval_tests/tts_quality_test.py
+++ b/tt-inference-server-v2/test_module/eval_tests/tts_quality_test.py
@@ -46,6 +46,9 @@ class TTSQualityTest(BaseTest):
     - WER > 20%: Poor
     """
 
+    KIND = "tts_quality_evals"
+    TASK_TYPE = "audio"
+
     def __init__(self, config, targets=None, **kwargs):
         super().__init__(config, targets)
         self._whisper_model = None

--- a/tt-inference-server-v2/test_module/eval_tests/video_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/video_eval_tests.py
@@ -15,7 +15,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from report_module.schema import Block
 
-from .._test_common import ReportCheckTypes, block_id, block_targets
+from .._test_common import ReportCheckTypes, block_id
 from ..context import MediaContext, require_health
 
 logger = logging.getLogger(__name__)
@@ -182,7 +182,12 @@ def run_video_eval(ctx: MediaContext) -> Block:
     return Block(
         kind="video_eval",
         id=block_id(ctx) or None,
-        targets=block_targets(ctx, task_type="video"),
+        targets={
+            "task_name": ctx.all_params.tasks[0].task_name,
+            "tolerance": ctx.all_params.tasks[0].score.tolerance,
+            "published_score": ctx.all_params.tasks[0].score.published_score,
+            "published_score_ref": ctx.all_params.tasks[0].score.published_score_ref,
+        },
         data=data,
     )
 

--- a/tt-inference-server-v2/test_module/eval_tests/video_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/video_eval_tests.py
@@ -180,7 +180,9 @@ def run_video_eval(ctx: MediaContext) -> Block:
         logger.error(f"Error running video FVD and FVMD eval: {e}")
 
     return Block(
-        kind="video_eval",
+        kind="evals",
+        task_type="video",
+        title="Video Eval",
         id=block_id(ctx) or None,
         targets={
             "task_name": ctx.all_params.tasks[0].task_name,

--- a/tt-inference-server-v2/test_module/eval_tests/video_fvd_eval_test.py
+++ b/tt-inference-server-v2/test_module/eval_tests/video_fvd_eval_test.py
@@ -64,6 +64,9 @@ class VideoFVDTest(BaseTest):
     Lower scores indicate better quality (0 = identical distributions).
     """
 
+    KIND = "video_fvd_evals"
+    TASK_TYPE = "video"
+
     def __init__(self, config: TestConfig, targets: dict):
         super().__init__(config, targets)
         self.eval_results: dict = {}

--- a/tt-inference-server-v2/test_module/eval_tests/video_fvmd_eval_test.py
+++ b/tt-inference-server-v2/test_module/eval_tests/video_fvmd_eval_test.py
@@ -62,6 +62,9 @@ class VideoFVMDTest(BaseTest):
     Reference: FVMD metric from video generation evaluation literature.
     """
 
+    KIND = "video_fvmd_evals"
+    TASK_TYPE = "video"
+
     def __init__(self, config: TestConfig, targets: dict):
         super().__init__(config, targets)
         self.eval_results: dict = {}

--- a/tt-inference-server-v2/test_module/eval_tests/video_generation_eval_test.py
+++ b/tt-inference-server-v2/test_module/eval_tests/video_generation_eval_test.py
@@ -47,6 +47,9 @@ class VideoGenerationEvalsTestRequest:
 
 
 class VideoGenerationEvalsTest(BaseTest):
+    KIND = "video_generation_evals"
+    TASK_TYPE = "video"
+
     def __init__(self, config: TestConfig, targets: dict):
         super().__init__(config, targets)
         self.eval_results: dict = {}

--- a/tt-inference-server-v2/test_module/eval_tests/vision_evals_test.py
+++ b/tt-inference-server-v2/test_module/eval_tests/vision_evals_test.py
@@ -55,6 +55,9 @@ class VisionEvalsTestRequest:
 
 
 class VisionEvalsTest(BaseTest):
+    KIND = "vision_evals"
+    TASK_TYPE = "image"
+
     def __init__(self, config: TestConfig, targets: dict):
         super().__init__(config, targets)
         self.eval_results: dict = {}

--- a/tt-inference-server-v2/test_module/eval_tests/whisper_eval_test.py
+++ b/tt-inference-server-v2/test_module/eval_tests/whisper_eval_test.py
@@ -37,6 +37,9 @@ class WhisperEvalTest(BaseTest):
     from workflow virtual environments or common installation locations.
     """
 
+    KIND = "whisper_evals"
+    TASK_TYPE = "audio"
+
     # Class-level configuration - use same settings as run_evals.py
     model_name: str = "whisper_tt"  # eval_class from eval_config.py
     hf_model_repo: str = "distil-whisper/distil-large-v3"

--- a/tt-inference-server-v2/test_module/load_param_tests/image_generation_load_test.py
+++ b/tt-inference-server-v2/test_module/load_param_tests/image_generation_load_test.py
@@ -70,6 +70,7 @@ class ImageGenerationLoadTest(BaseTest):
             "average_duration": average_duration,
             "target_time": image_generation_target_time,
             "num_concurrent_requests": num_concurrent_requests,
+            "num_inference_steps": num_inference_steps,
             "image_resolution": image_resolution,
             "success": success,
         }

--- a/tt-inference-server-v2/tests/test_module/test_blockify.py
+++ b/tt-inference-server-v2/tests/test_module/test_blockify.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from types import SimpleNamespace
 
-from test_module._test_common import block_id, block_targets, sweep_envelope
+from test_module._test_common import block_id, sweep_envelope
 
 
 def _ctx(model: str = "tt-sdxl-1.0", device: str = "n300") -> SimpleNamespace:
@@ -17,22 +17,6 @@ def _ctx(model: str = "tt-sdxl-1.0", device: str = "n300") -> SimpleNamespace:
         model_spec=SimpleNamespace(model_name=model),
         device=SimpleNamespace(name=device),
     )
-
-
-def test_block_targets_only_carries_per_block_fields():
-    targets = block_targets(_ctx(), task_type="image")
-    assert targets == {"task_type": "image"}
-    # model/device/timestamp deliberately absent — they live in the
-    # sweep envelope (schema metadata), not on every block.
-    assert "model" not in targets
-    assert "device" not in targets
-    assert "timestamp" not in targets
-
-
-def test_block_targets_extra_kwargs_get_merged():
-    targets = block_targets(_ctx(), task_type="image", task_name="sdxl-prompts")
-    assert targets["task_name"] == "sdxl-prompts"
-    assert targets["task_type"] == "image"
 
 
 def test_sweep_envelope_carries_model_device_timestamp():

--- a/tt-inference-server-v2/tests/workflow_module/test_blocks_sink.py
+++ b/tt-inference-server-v2/tests/workflow_module/test_blocks_sink.py
@@ -24,7 +24,9 @@ SWEEP_ENVELOPE = {
 
 def _benchmark_block() -> Block:
     return Block(
-        kind="image_benchmark",
+        kind="benchmarks",
+        task_type="image",
+        title="Image Benchmark",
         id="tt-sdxl_n300",
         data={
             "Benchmarks": {
@@ -38,7 +40,9 @@ def _benchmark_block() -> Block:
 
 def _eval_block() -> Block:
     return Block(
-        kind="image_eval",
+        kind="evals",
+        task_type="image",
+        title="Image Eval",
         id="tt-sdxl_n300",
         data={
             "task_name": "sdxl-prompts",
@@ -55,13 +59,13 @@ def test_accumulator_preserves_insertion_order():
     acc.accept([_benchmark_block()], envelope=SWEEP_ENVELOPE)
     acc.accept([_eval_block()])
     kinds = [b.kind for b in acc.blocks]
-    assert kinds == ["image_benchmark", "image_eval"]
+    assert kinds == ["benchmarks", "evals"]
 
 
 def test_accumulator_rejects_non_blocks():
     acc = BlockAccumulator()
     with pytest.raises(TypeError):
-        acc.accept([{"kind": "image_benchmark"}])  # type: ignore[list-item]
+        acc.accept([{"kind": "benchmarks"}])  # type: ignore[list-item]
 
 
 def test_envelope_first_write_wins():
@@ -80,7 +84,7 @@ def test_build_schema_uses_recorded_envelope():
     assert schema.metadata["device"] == "n300"
     assert schema.metadata["generated_at"] == "2026-05-05 12:00:00"
     assert schema.metadata["report_id"]  # synthesised, non-empty
-    assert [b.kind for b in schema.sections] == ["image_benchmark", "image_eval"]
+    assert [b.kind for b in schema.sections] == ["benchmarks", "evals"]
 
 
 def test_build_schema_round_trips_through_report_generator(tmp_path: Path):

--- a/tt-inference-server-v2/tests/workflow_module/test_blocks_sink.py
+++ b/tt-inference-server-v2/tests/workflow_module/test_blocks_sink.py
@@ -26,7 +26,6 @@ def _benchmark_block() -> Block:
     return Block(
         kind="image_benchmark",
         id="tt-sdxl_n300",
-        targets={"task_type": "image"},
         data={
             "Benchmarks": {
                 "num_requests": 5,
@@ -41,7 +40,6 @@ def _eval_block() -> Block:
     return Block(
         kind="image_eval",
         id="tt-sdxl_n300",
-        targets={"task_type": "image"},
         data={
             "task_name": "sdxl-prompts",
             "tolerance": 0.05,
@@ -102,17 +100,15 @@ def test_build_schema_round_trips_through_report_generator(tmp_path: Path):
     assert "### Image Eval" in md
 
 
-def test_block_targets_no_longer_duplicate_metadata(tmp_path: Path):
-    """Per-block targets carry only block-specific fields (task_type), so the
-    serialised JSON does not repeat model/device/timestamp on every section."""
+def test_sweep_metadata_lives_only_at_top_level(tmp_path: Path):
+    """Sweep-level model/device/timestamp live once in top-level metadata —
+    never duplicated onto every block's serialised payload."""
     acc = BlockAccumulator()
     acc.accept([_benchmark_block()], envelope=SWEEP_ENVELOPE)
     schema = acc.build_schema()
     result = ReportGenerator().generate(schema, tmp_path)
 
     payload = result.json_path.read_text()
-    # model/device/timestamp appear once at the top, not in section.targets.
     assert payload.count('"model"') == 0
     assert payload.count('"device"') == 1  # top-level metadata.device
     assert payload.count('"timestamp"') == 0
-    assert '"task_type": "image"' in payload


### PR DESCRIPTION
- Collapse same-heading blocks into one table
- Added _Test Summary_ +  _Test Results_ section 

- `kind` was test-class–specific (`image_generation_load`, `device_liveness`, …) and now every block emits exactly one of three kinds ("benchmarks", "evals", "server_tests")

- Detailed acceptance criteria at the top of the report:
  ```
  - Overall status: `FAIL`
  - Benchmarks: `PASS` (2/2 passed)
  - Evals: `PASS` (0/1 passed, 1 NA)
  - Server Tests: `FAIL` (6/7 passed, 1 failed)

  #### Blockers
  - `spec.server_tests:Image Generation Evals`: reported success=False (attempts=1)
  ````
- `Block.targets` now carries real per-test configuration
- `display.py` — single source of truth for column headers