### PR TITLE
Socket Manager Cleanup

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -614,6 +614,7 @@ add_executable(main_integration_test
     src/services/disaggregation_service.cpp
     src/sockets/inter_server_service.cpp
     src/sockets/socket_manager.cpp
+    src/sockets/socket_transport.cpp
 )
 target_link_libraries(main_integration_test PRIVATE
     llm_runner_lib
@@ -755,6 +756,7 @@ set(SOURCES
     src/services/embedding_service.cpp
     src/services/disaggregation_service.cpp
     src/sockets/socket_manager.cpp
+    src/sockets/socket_transport.cpp
     src/sockets/inter_server_service.cpp
     src/metrics/metrics.cpp
     src/api/metrics_controller.cpp

--- a/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
@@ -20,9 +20,9 @@
 namespace tt::sockets {
 
 /**
- * @brief High-level socket manager for inter-server communication
+ * @brief Singleton socket manager for inter-server communication
  *
- * Provides typed message serialization and dispatch on top of SocketTransport.
+ * Supports both server (listening) and client (connecting) modes.
  * Can serialize and send objects using Cereal library.
  */
 class SocketManager {

--- a/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
@@ -3,42 +3,30 @@
 
 #pragma once
 
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <unistd.h>
-
-#include <atomic>
 #include <cereal/archives/binary.hpp>
 #include <cereal/types/string.hpp>
 #include <cereal/types/vector.hpp>
 #include <functional>
 #include <map>
-#include <memory>
 #include <mutex>
 #include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
 
+#include "sockets/socket_transport.hpp"
 #include "utils/logger.hpp"
-#include "utils/scoped_fd.hpp"
 
 namespace tt::sockets {
 
 /**
- * @brief Singleton socket manager for inter-server communication
+ * @brief High-level socket manager for inter-server communication
  *
- * Supports both server (listening) and client (connecting) modes.
+ * Provides typed message serialization and dispatch on top of SocketTransport.
  * Can serialize and send objects using Cereal library.
  */
 class SocketManager {
  public:
-  enum class Mode {
-    SERVER,  // Listen for incoming connections
-    CLIENT   // Connect to remote server
-  };
-
   SocketManager() = default;
   SocketManager(const SocketManager&) = delete;
   SocketManager& operator=(const SocketManager&) = delete;
@@ -63,7 +51,7 @@ class SocketManager {
 
   /**
    * @brief Send serializable object to connected peer
-   * @param message_type Type identifier for the message
+   * @param messageType Type identifier for the message
    * @param obj Object to send
    * @return true if successful
    */
@@ -72,7 +60,7 @@ class SocketManager {
 
   /**
    * @brief Register handler for incoming messages of specific type
-   * @param message_type Type identifier to handle
+   * @param messageType Type identifier to handle
    * @param handler Function to call when message is received
    */
   template <typename T>
@@ -106,41 +94,24 @@ class SocketManager {
   void setConnectionLostCallback(std::function<void()> callback);
 
  private:
-  void serverLoop();
-  void clientLoop();
   void messageLoop();
   void handleIncomingMessage(const std::vector<uint8_t>& data);
-  bool sendRawData(const std::vector<uint8_t>& data);
-  std::vector<uint8_t> receiveRawData();
 
-  Mode mode_;
-  std::string host_;
-  uint16_t port_;
-
-  tt::utils::ScopedFd serverSocket;
-  tt::utils::ScopedFd clientSocket;
-  int peerSocket = -1;  // Non-owning view of active connection FD
+  SocketTransport transport_;
 
   std::atomic<bool> running_{false};
-  std::atomic<bool> connected_{false};
+  std::thread messageThread_;
 
-  std::thread server_thread_;
-  std::thread message_thread_;
-
-  mutable std::mutex handlers_mutex_;
+  mutable std::mutex handlersMutex_;
   std::map<std::string, std::function<void(const std::vector<uint8_t>&)>>
       handlers_;
-
-  mutable std::mutex send_mutex_;
-
-  std::function<void()> connection_lost_callback_;
 };
 
 // Template implementations
 
 template <typename T>
 bool SocketManager::sendObject(const std::string& messageType, const T& obj) {
-  if (!connected_) {
+  if (!transport_.isConnected()) {
     return false;
   }
 
@@ -155,7 +126,7 @@ bool SocketManager::sendObject(const std::string& messageType, const T& obj) {
     std::string serialized = oss.str();
     std::vector<uint8_t> data(serialized.begin(), serialized.end());
 
-    return sendRawData(data);
+    return transport_.sendRawData(data);
   } catch (const std::exception& e) {
     TT_LOG_ERROR("[SocketManager] Serialization error: {}", e.what());
     return false;
@@ -165,7 +136,7 @@ bool SocketManager::sendObject(const std::string& messageType, const T& obj) {
 template <typename T>
 void SocketManager::registerHandler(const std::string& messageType,
                                     std::function<void(const T&)> handler) {
-  std::lock_guard<std::mutex> lock(handlers_mutex_);
+  std::lock_guard<std::mutex> lock(handlersMutex_);
 
   handlers_[messageType] = [handler](const std::vector<uint8_t>& data) {
     try {

--- a/tt-media-server/cpp_server/include/sockets/socket_transport.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_transport.hpp
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#pragma once
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "utils/scoped_fd.hpp"
+
+namespace tt::sockets {
+
+/**
+ * @brief Low-level socket transport for inter-server communication
+ *
+ * Handles socket lifecycle, connection management, and raw byte I/O.
+ * Supports both server (listening) and client (connecting) modes.
+ * Uses length-prefixed framing for message boundaries.
+ */
+class SocketTransport {
+ public:
+  enum class Mode {
+    SERVER,  // Listen for incoming connections
+    CLIENT   // Connect to remote server
+  };
+
+  SocketTransport() = default;
+  SocketTransport(const SocketTransport&) = delete;
+  SocketTransport& operator=(const SocketTransport&) = delete;
+  SocketTransport(SocketTransport&&) = delete;
+  SocketTransport& operator=(SocketTransport&&) = delete;
+  ~SocketTransport();
+
+  /**
+   * @brief Initialize as server (listening mode)
+   * @param port Port to listen on
+   * @return true if successful
+   */
+  bool initializeAsServer(uint16_t port);
+
+  /**
+   * @brief Initialize as client (connecting mode)
+   * @param host Remote host to connect to
+   * @param port Remote port to connect to
+   * @return true if successful
+   */
+  bool initializeAsClient(const std::string& host, uint16_t port);
+
+  /**
+   * @brief Start the transport (begins listening/connecting)
+   */
+  void start();
+
+  /**
+   * @brief Stop the transport
+   */
+  void stop();
+
+  /**
+   * @brief Check if connected to peer
+   */
+  bool isConnected() const;
+
+  /**
+   * @brief Get connection status string
+   */
+  std::string getStatus() const;
+
+  /**
+   * @brief Send raw data with length-prefix framing
+   * @param data Bytes to send
+   * @return true if successful
+   */
+  bool sendRawData(const std::vector<uint8_t>& data);
+
+  /**
+   * @brief Receive raw data with length-prefix framing
+   * @return Received bytes, empty if no data or error
+   */
+  std::vector<uint8_t> receiveRawData();
+
+  /**
+   * @brief Set callback for connection lost events
+   * @param callback Function to call when connection is lost
+   */
+  void setConnectionLostCallback(std::function<void()> callback);
+
+ private:
+  void serverLoop();
+  void clientLoop();
+
+  Mode mode_;
+  std::string host_;
+  uint16_t port_;
+
+  tt::utils::ScopedFd serverSocket_;
+  tt::utils::ScopedFd clientSocket_;
+  int peerSocket_ = -1;  // Non-owning view of active connection FD
+
+  std::atomic<bool> running_{false};
+  std::atomic<bool> connected_{false};
+
+  std::thread connectionThread_;
+
+  mutable std::mutex sendMutex_;
+
+  std::function<void()> connectionLostCallback_;
+};
+
+}  // namespace tt::sockets

--- a/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
+++ b/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
@@ -43,6 +43,19 @@ void setSocketKeepAlive(int socketFd) {
                 strerror(errno));
   }
 }
+
+void setNonBlocking(int socketFd) {
+  int flags = fcntl(socketFd, F_GETFL, 0);
+  if (flags < 0 || fcntl(socketFd, F_SETFL, flags | O_NONBLOCK) < 0) {
+    TT_LOG_WARN("[SocketManager] Failed to set non-blocking: {}",
+                strerror(errno));
+  }
+}
+
+void configureSocket(int socketFd) {
+  setNonBlocking(socketFd);
+  setSocketKeepAlive(socketFd);
+}
 }  // namespace
 
 SocketManager::~SocketManager() { stop(); }
@@ -158,12 +171,7 @@ void SocketManager::serverLoop() {
       break;
     }
 
-    int flags = fcntl(accepted.get(), F_GETFL, 0);
-    if (flags < 0 || fcntl(accepted.get(), F_SETFL, flags | O_NONBLOCK) < 0) {
-      TT_LOG_WARN("[SocketManager] Failed to set non-blocking: {}",
-                  strerror(errno));
-    }
-    setSocketKeepAlive(accepted.get());
+    configureSocket(accepted.get());
 
     peerSocket = accepted.get();
     connected_ = true;
@@ -217,13 +225,7 @@ void SocketManager::clientLoop() {
       continue;
     }
 
-    int flags = fcntl(clientSocket.get(), F_GETFL, 0);
-    if (flags < 0 ||
-        fcntl(clientSocket.get(), F_SETFL, flags | O_NONBLOCK) < 0) {
-      TT_LOG_WARN("[SocketManager] Failed to set non-blocking: {}",
-                  strerror(errno));
-    }
-    setSocketKeepAlive(clientSocket.get());
+    configureSocket(clientSocket.get());
 
     peerSocket = clientSocket.get();
     connected_ = true;

--- a/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
+++ b/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
@@ -3,114 +3,20 @@
 
 #include "sockets/socket_manager.hpp"
 
-#include <errno.h>
-#include <fcntl.h>
-#include <netinet/tcp.h>
-
 #include <cstring>
 
 #include "utils/logger.hpp"
 
 namespace tt::sockets {
 
-namespace {
-void setSocketKeepAlive(int socketFd) {
-  int enable = 1;
-  if (setsockopt(socketFd, SOL_SOCKET, SO_KEEPALIVE, &enable, sizeof(enable)) <
-      0) {
-    TT_LOG_WARN("[SocketManager] Failed to set SO_KEEPALIVE: {}",
-                strerror(errno));
-  }
-
-  int idle = 10;
-  if (setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle)) <
-      0) {
-    TT_LOG_WARN("[SocketManager] Failed to set TCP_KEEPIDLE: {}",
-                strerror(errno));
-  }
-
-  int interval = 5;
-  if (setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPINTVL, &interval,
-                 sizeof(interval)) < 0) {
-    TT_LOG_WARN("[SocketManager] Failed to set TCP_KEEPINTVL: {}",
-                strerror(errno));
-  }
-
-  int maxProbes = 3;
-  if (setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPCNT, &maxProbes,
-                 sizeof(maxProbes)) < 0) {
-    TT_LOG_WARN("[SocketManager] Failed to set TCP_KEEPCNT: {}",
-                strerror(errno));
-  }
-}
-
-void setNonBlocking(int socketFd) {
-  int flags = fcntl(socketFd, F_GETFL, 0);
-  if (flags < 0 || fcntl(socketFd, F_SETFL, flags | O_NONBLOCK) < 0) {
-    TT_LOG_WARN("[SocketManager] Failed to set non-blocking: {}",
-                strerror(errno));
-  }
-}
-
-void configureSocket(int socketFd) {
-  setNonBlocking(socketFd);
-  setSocketKeepAlive(socketFd);
-}
-}  // namespace
-
 SocketManager::~SocketManager() { stop(); }
 
 bool SocketManager::initializeAsServer(uint16_t port) {
-  mode_ = Mode::SERVER;
-  port_ = port;
-
-  serverSocket.reset(socket(AF_INET, SOCK_STREAM, 0));
-  if (!serverSocket) {
-    TT_LOG_ERROR("[SocketManager] Failed to create server socket: {}",
-                 strerror(errno));
-    return false;
-  }
-
-  int opt = 1;
-  if (setsockopt(serverSocket.get(), SOL_SOCKET, SO_REUSEADDR, &opt,
-                 sizeof(opt)) < 0) {
-    TT_LOG_ERROR("[SocketManager] Failed to set SO_REUSEADDR: {}",
-                 strerror(errno));
-    serverSocket.reset();
-    return false;
-  }
-
-  struct sockaddr_in address;
-  address.sin_family = AF_INET;
-  address.sin_addr.s_addr = INADDR_ANY;
-  address.sin_port = htons(port_);
-
-  if (bind(serverSocket.get(), (struct sockaddr*)&address, sizeof(address)) <
-      0) {
-    TT_LOG_ERROR("[SocketManager] Failed to bind to port {}: {}", port_,
-                 strerror(errno));
-    serverSocket.reset();
-    return false;
-  }
-
-  if (listen(serverSocket.get(), 1) < 0) {
-    TT_LOG_ERROR("[SocketManager] Failed to listen: {}", strerror(errno));
-    serverSocket.reset();
-    return false;
-  }
-
-  TT_LOG_INFO("[SocketManager] Server initialized on port {}", port_);
-  return true;
+  return transport_.initializeAsServer(port);
 }
 
 bool SocketManager::initializeAsClient(const std::string& host, uint16_t port) {
-  mode_ = Mode::CLIENT;
-  host_ = host;
-  port_ = port;
-
-  TT_LOG_INFO("[SocketManager] Client initialized to connect to {}:{}", host_,
-              port_);
-  return true;
+  return transport_.initializeAsClient(host, port);
 }
 
 void SocketManager::start() {
@@ -119,14 +25,8 @@ void SocketManager::start() {
   }
 
   running_ = true;
-
-  if (mode_ == Mode::SERVER) {
-    server_thread_ = std::thread(&SocketManager::serverLoop, this);
-  } else {
-    server_thread_ = std::thread(&SocketManager::clientLoop, this);
-  }
-
-  message_thread_ = std::thread(&SocketManager::messageLoop, this);
+  transport_.start();
+  messageThread_ = std::thread(&SocketManager::messageLoop, this);
 }
 
 void SocketManager::stop() {
@@ -135,250 +35,45 @@ void SocketManager::stop() {
   }
 
   running_ = false;
-  connected_ = false;
+  transport_.stop();
 
-  // peerSocket is non-owning; just clear the reference.
-  // The owning UniqueFd (serverSocket or clientSocket) handles the close.
-  peerSocket = -1;
-
-  clientSocket.reset();
-  serverSocket.reset();
-
-  if (server_thread_.joinable()) {
-    server_thread_.join();
-  }
-
-  if (message_thread_.joinable()) {
-    message_thread_.join();
+  if (messageThread_.joinable()) {
+    messageThread_.join();
   }
 
   TT_LOG_INFO("[SocketManager] Stopped");
 }
 
-void SocketManager::serverLoop() {
-  while (running_) {
-    TT_LOG_INFO("[SocketManager] Waiting for client connection...");
-
-    struct sockaddr_in clientAddr;
-    socklen_t clientLen = sizeof(clientAddr);
-
-    tt::utils::ScopedFd accepted(
-        accept(serverSocket.get(), (struct sockaddr*)&clientAddr, &clientLen));
-    if (!accepted) {
-      if (running_) {
-        TT_LOG_ERROR("[SocketManager] Accept failed: {}", strerror(errno));
-      }
-      break;
-    }
-
-    configureSocket(accepted.get());
-
-    peerSocket = accepted.get();
-    connected_ = true;
-
-    TT_LOG_INFO("[SocketManager] Client connected from {}:{}",
-                inet_ntoa(clientAddr.sin_addr), ntohs(clientAddr.sin_port));
-
-    while (running_ && connected_) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
-    accepted.reset();
-    peerSocket = -1;
-    bool wasConnected = connected_.exchange(false);
-    if (wasConnected && connection_lost_callback_) {
-      connection_lost_callback_();
-    }
-
-    TT_LOG_INFO("[SocketManager] Client disconnected");
-  }
-}
-
-void SocketManager::clientLoop() {
-  while (running_) {
-    clientSocket.reset(socket(AF_INET, SOCK_STREAM, 0));
-    if (!clientSocket) {
-      TT_LOG_ERROR("[SocketManager] Failed to create client socket: {}",
-                   strerror(errno));
-      std::this_thread::sleep_for(std::chrono::seconds(5));
-      continue;
-    }
-
-    struct sockaddr_in serverAddr;
-    serverAddr.sin_family = AF_INET;
-    serverAddr.sin_port = htons(port_);
-
-    if (inet_pton(AF_INET, host_.c_str(), &serverAddr.sin_addr) <= 0) {
-      TT_LOG_ERROR("[SocketManager] Invalid address: {}", host_);
-      clientSocket.reset();
-      std::this_thread::sleep_for(std::chrono::seconds(5));
-      continue;
-    }
-
-    TT_LOG_INFO("[SocketManager] Attempting to connect to {}:{}", host_, port_);
-
-    if (connect(clientSocket.get(), (struct sockaddr*)&serverAddr,
-                sizeof(serverAddr)) < 0) {
-      TT_LOG_ERROR("[SocketManager] Connection failed: {}", strerror(errno));
-      clientSocket.reset();
-      std::this_thread::sleep_for(std::chrono::seconds(5));
-      continue;
-    }
-
-    configureSocket(clientSocket.get());
-
-    peerSocket = clientSocket.get();
-    connected_ = true;
-
-    TT_LOG_INFO("[SocketManager] Connected to server");
-
-    while (running_ && connected_) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
-    peerSocket = -1;
-    clientSocket.reset();
-    bool wasConnected = connected_.exchange(false);
-    if (wasConnected && connection_lost_callback_) {
-      connection_lost_callback_();
-    }
-
-    TT_LOG_INFO("[SocketManager] Disconnected from server");
-
-    if (running_) {
-      std::this_thread::sleep_for(std::chrono::seconds(5));
-    }
-  }
-}
-
 void SocketManager::messageLoop() {
   while (running_) {
-    if (!connected_) {
+    if (!transport_.isConnected()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
       continue;
     }
 
     try {
-      auto data = receiveRawData();
+      auto data = transport_.receiveRawData();
       if (!data.empty()) {
         handleIncomingMessage(data);
       }
     } catch (const std::exception& e) {
       TT_LOG_ERROR("[SocketManager] Message loop error: {}", e.what());
-      connected_ = false;
     }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 }
 
-bool SocketManager::sendRawData(const std::vector<uint8_t>& data) {
-  if (!connected_ || peerSocket < 0) {
-    return false;
-  }
-
-  std::lock_guard<std::mutex> lock(send_mutex_);
-
-  // Send data size first
-  uint32_t size = static_cast<uint32_t>(data.size());
-  uint32_t netSize = htonl(size);
-
-  ssize_t sent = send(peerSocket, &netSize, sizeof(netSize), MSG_NOSIGNAL);
-  if (sent != sizeof(netSize)) {
-    connected_ = false;
-    return false;
-  }
-
-  // Send actual data
-  size_t totalSent = 0;
-  while (totalSent < data.size()) {
-    sent = send(peerSocket, data.data() + totalSent, data.size() - totalSent,
-                MSG_NOSIGNAL);
-    if (sent <= 0) {
-      connected_ = false;
-      return false;
-    }
-    totalSent += sent;
-  }
-
-  return true;
-}
-
-std::vector<uint8_t> SocketManager::receiveRawData() {
-  if (!connected_ || peerSocket < 0) {
-    return {};
-  }
-
-  // Read data size first
-  uint32_t netSize;
-  ssize_t received = recv(peerSocket, &netSize, sizeof(netSize), MSG_DONTWAIT);
-  if (received <= 0) {
-    if (received == 0 || (errno != EAGAIN && errno != EWOULDBLOCK)) {
-      connected_ = false;
-    }
-    return {};
-  }
-
-  if (received != sizeof(netSize)) {
-    connected_ = false;
-    return {};
-  }
-
-  uint32_t size = ntohl(netSize);
-  if (size == 0 || size > 1024 * 1024) {  // Max 1MB per message
-    connected_ = false;
-    return {};
-  }
-
-  // Read actual data
-  std::vector<uint8_t> data(size);
-  size_t totalReceived = 0;
-  int retryCount = 0;
-  const int maxRetries = 1000;  // 1 second timeout (1000 * 1ms)
-
-  while (totalReceived < size) {
-    received =
-        recv(peerSocket, data.data() + totalReceived, size - totalReceived, 0);
-    if (received > 0) {
-      totalReceived += received;
-      retryCount = 0;  // Reset retry count on successful receive
-    } else if (received == 0) {
-      // Connection closed by peer
-      connected_ = false;
-      return {};
-    } else {
-      // received < 0: check if it's a temporary error
-      if (errno == EAGAIN || errno == EWOULDBLOCK) {
-        // Non-blocking socket has no data yet, wait briefly and retry
-        if (++retryCount > maxRetries) {
-          TT_LOG_ERROR("[SocketManager] Timeout waiting for message data");
-          connected_ = false;
-          return {};
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        continue;
-      }
-      // Real error
-      connected_ = false;
-      return {};
-    }
-  }
-
-  return data;
-}
-
 void SocketManager::handleIncomingMessage(const std::vector<uint8_t>& data) {
   try {
-    // First, extract the message type
     std::string serialized(data.begin(), data.end());
     std::istringstream iss(serialized);
 
     cereal::BinaryInputArchive archive(iss);
     std::string messageType;
-    archive(messageType);  // Use operator() instead of loadBinaryValue
+    archive(messageType);
 
-    // Find handler for this message type
-    std::lock_guard<std::mutex> lock(handlers_mutex_);
+    std::lock_guard<std::mutex> lock(handlersMutex_);
     auto it = handlers_.find(messageType);
     if (it != handlers_.end()) {
       it->second(data);
@@ -391,22 +86,12 @@ void SocketManager::handleIncomingMessage(const std::vector<uint8_t>& data) {
   }
 }
 
-bool SocketManager::isConnected() const { return connected_; }
+bool SocketManager::isConnected() const { return transport_.isConnected(); }
 
-std::string SocketManager::getStatus() const {
-  if (!running_) {
-    return "stopped";
-  }
-
-  if (connected_) {
-    return mode_ == Mode::SERVER ? "server:connected" : "client:connected";
-  }
-
-  return mode_ == Mode::SERVER ? "server:waiting" : "client:connecting";
-}
+std::string SocketManager::getStatus() const { return transport_.getStatus(); }
 
 void SocketManager::setConnectionLostCallback(std::function<void()> callback) {
-  connection_lost_callback_ = std::move(callback);
+  transport_.setConnectionLostCallback(std::move(callback));
 }
 
 }  // namespace tt::sockets

--- a/tt-media-server/cpp_server/src/sockets/socket_transport.cpp
+++ b/tt-media-server/cpp_server/src/sockets/socket_transport.cpp
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#include "sockets/socket_transport.hpp"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/tcp.h>
+
+#include <cstring>
+
+#include "utils/logger.hpp"
+
+namespace tt::sockets {
+
+namespace {
+void setSocketKeepAlive(int socketFd) {
+  int enable = 1;
+  if (setsockopt(socketFd, SOL_SOCKET, SO_KEEPALIVE, &enable, sizeof(enable)) <
+      0) {
+    TT_LOG_WARN("[SocketTransport] Failed to set SO_KEEPALIVE: {}",
+                strerror(errno));
+  }
+
+  int idle = 10;
+  if (setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle)) <
+      0) {
+    TT_LOG_WARN("[SocketTransport] Failed to set TCP_KEEPIDLE: {}",
+                strerror(errno));
+  }
+
+  int interval = 5;
+  if (setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPINTVL, &interval,
+                 sizeof(interval)) < 0) {
+    TT_LOG_WARN("[SocketTransport] Failed to set TCP_KEEPINTVL: {}",
+                strerror(errno));
+  }
+
+  int maxProbes = 3;
+  if (setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPCNT, &maxProbes,
+                 sizeof(maxProbes)) < 0) {
+    TT_LOG_WARN("[SocketTransport] Failed to set TCP_KEEPCNT: {}",
+                strerror(errno));
+  }
+}
+
+void setNonBlocking(int socketFd) {
+  int flags = fcntl(socketFd, F_GETFL, 0);
+  if (flags < 0 || fcntl(socketFd, F_SETFL, flags | O_NONBLOCK) < 0) {
+    TT_LOG_WARN("[SocketTransport] Failed to set non-blocking: {}",
+                strerror(errno));
+  }
+}
+
+void configureSocket(int socketFd) {
+  setNonBlocking(socketFd);
+  setSocketKeepAlive(socketFd);
+}
+}  // namespace
+
+SocketTransport::~SocketTransport() { stop(); }
+
+bool SocketTransport::initializeAsServer(uint16_t port) {
+  mode_ = Mode::SERVER;
+  port_ = port;
+
+  serverSocket_.reset(socket(AF_INET, SOCK_STREAM, 0));
+  if (!serverSocket_) {
+    TT_LOG_ERROR("[SocketTransport] Failed to create server socket: {}",
+                 strerror(errno));
+    return false;
+  }
+
+  int opt = 1;
+  if (setsockopt(serverSocket_.get(), SOL_SOCKET, SO_REUSEADDR, &opt,
+                 sizeof(opt)) < 0) {
+    TT_LOG_ERROR("[SocketTransport] Failed to set SO_REUSEADDR: {}",
+                 strerror(errno));
+    serverSocket_.reset();
+    return false;
+  }
+
+  struct sockaddr_in address;
+  address.sin_family = AF_INET;
+  address.sin_addr.s_addr = INADDR_ANY;
+  address.sin_port = htons(port_);
+
+  if (bind(serverSocket_.get(), (struct sockaddr*)&address, sizeof(address)) <
+      0) {
+    TT_LOG_ERROR("[SocketTransport] Failed to bind to port {}: {}", port_,
+                 strerror(errno));
+    serverSocket_.reset();
+    return false;
+  }
+
+  if (listen(serverSocket_.get(), 1) < 0) {
+    TT_LOG_ERROR("[SocketTransport] Failed to listen: {}", strerror(errno));
+    serverSocket_.reset();
+    return false;
+  }
+
+  TT_LOG_INFO("[SocketTransport] Server initialized on port {}", port_);
+  return true;
+}
+
+bool SocketTransport::initializeAsClient(const std::string& host,
+                                         uint16_t port) {
+  mode_ = Mode::CLIENT;
+  host_ = host;
+  port_ = port;
+
+  TT_LOG_INFO("[SocketTransport] Client initialized to connect to {}:{}", host_,
+              port_);
+  return true;
+}
+
+void SocketTransport::start() {
+  if (running_) {
+    return;
+  }
+
+  running_ = true;
+
+  if (mode_ == Mode::SERVER) {
+    connectionThread_ = std::thread(&SocketTransport::serverLoop, this);
+  } else {
+    connectionThread_ = std::thread(&SocketTransport::clientLoop, this);
+  }
+}
+
+void SocketTransport::stop() {
+  if (!running_) {
+    return;
+  }
+
+  running_ = false;
+  connected_ = false;
+
+  peerSocket_ = -1;
+
+  clientSocket_.reset();
+  serverSocket_.reset();
+
+  if (connectionThread_.joinable()) {
+    connectionThread_.join();
+  }
+
+  TT_LOG_INFO("[SocketTransport] Stopped");
+}
+
+void SocketTransport::serverLoop() {
+  while (running_) {
+    TT_LOG_INFO("[SocketTransport] Waiting for client connection...");
+
+    struct sockaddr_in clientAddr;
+    socklen_t clientLen = sizeof(clientAddr);
+
+    tt::utils::ScopedFd accepted(
+        accept(serverSocket_.get(), (struct sockaddr*)&clientAddr, &clientLen));
+    if (!accepted) {
+      if (running_) {
+        TT_LOG_ERROR("[SocketTransport] Accept failed: {}", strerror(errno));
+      }
+      break;
+    }
+
+    configureSocket(accepted.get());
+
+    peerSocket_ = accepted.get();
+    connected_ = true;
+
+    TT_LOG_INFO("[SocketTransport] Client connected from {}:{}",
+                inet_ntoa(clientAddr.sin_addr), ntohs(clientAddr.sin_port));
+
+    while (running_ && connected_) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    accepted.reset();
+    peerSocket_ = -1;
+    bool wasConnected = connected_.exchange(false);
+    if (wasConnected && connectionLostCallback_) {
+      connectionLostCallback_();
+    }
+
+    TT_LOG_INFO("[SocketTransport] Client disconnected");
+  }
+}
+
+void SocketTransport::clientLoop() {
+  while (running_) {
+    clientSocket_.reset(socket(AF_INET, SOCK_STREAM, 0));
+    if (!clientSocket_) {
+      TT_LOG_ERROR("[SocketTransport] Failed to create client socket: {}",
+                   strerror(errno));
+      std::this_thread::sleep_for(std::chrono::seconds(5));
+      continue;
+    }
+
+    struct sockaddr_in serverAddr;
+    serverAddr.sin_family = AF_INET;
+    serverAddr.sin_port = htons(port_);
+
+    if (inet_pton(AF_INET, host_.c_str(), &serverAddr.sin_addr) <= 0) {
+      TT_LOG_ERROR("[SocketTransport] Invalid address: {}", host_);
+      clientSocket_.reset();
+      std::this_thread::sleep_for(std::chrono::seconds(5));
+      continue;
+    }
+
+    TT_LOG_INFO("[SocketTransport] Attempting to connect to {}:{}", host_,
+                port_);
+
+    if (connect(clientSocket_.get(), (struct sockaddr*)&serverAddr,
+                sizeof(serverAddr)) < 0) {
+      TT_LOG_ERROR("[SocketTransport] Connection failed: {}", strerror(errno));
+      clientSocket_.reset();
+      std::this_thread::sleep_for(std::chrono::seconds(5));
+      continue;
+    }
+
+    configureSocket(clientSocket_.get());
+
+    peerSocket_ = clientSocket_.get();
+    connected_ = true;
+
+    TT_LOG_INFO("[SocketTransport] Connected to server");
+
+    while (running_ && connected_) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    peerSocket_ = -1;
+    clientSocket_.reset();
+    bool wasConnected = connected_.exchange(false);
+    if (wasConnected && connectionLostCallback_) {
+      connectionLostCallback_();
+    }
+
+    TT_LOG_INFO("[SocketTransport] Disconnected from server");
+
+    if (running_) {
+      std::this_thread::sleep_for(std::chrono::seconds(5));
+    }
+  }
+}
+
+bool SocketTransport::sendRawData(const std::vector<uint8_t>& data) {
+  if (!connected_ || peerSocket_ < 0) {
+    return false;
+  }
+
+  std::lock_guard<std::mutex> lock(sendMutex_);
+
+  uint32_t size = static_cast<uint32_t>(data.size());
+  uint32_t netSize = htonl(size);
+
+  ssize_t sent = send(peerSocket_, &netSize, sizeof(netSize), MSG_NOSIGNAL);
+  if (sent != sizeof(netSize)) {
+    connected_ = false;
+    return false;
+  }
+
+  size_t totalSent = 0;
+  while (totalSent < data.size()) {
+    sent = send(peerSocket_, data.data() + totalSent, data.size() - totalSent,
+                MSG_NOSIGNAL);
+    if (sent <= 0) {
+      connected_ = false;
+      return false;
+    }
+    totalSent += sent;
+  }
+
+  return true;
+}
+
+std::vector<uint8_t> SocketTransport::receiveRawData() {
+  if (!connected_ || peerSocket_ < 0) {
+    return {};
+  }
+
+  uint32_t netSize;
+  ssize_t received = recv(peerSocket_, &netSize, sizeof(netSize), MSG_DONTWAIT);
+  if (received <= 0) {
+    if (received == 0 || (errno != EAGAIN && errno != EWOULDBLOCK)) {
+      connected_ = false;
+    }
+    return {};
+  }
+
+  if (received != sizeof(netSize)) {
+    connected_ = false;
+    return {};
+  }
+
+  uint32_t size = ntohl(netSize);
+  if (size == 0 || size > 1024 * 1024) {  // Max 1MB per message
+    connected_ = false;
+    return {};
+  }
+
+  std::vector<uint8_t> data(size);
+  size_t totalReceived = 0;
+  int retryCount = 0;
+  const int maxRetries = 1000;  // 1 second timeout (1000 * 1ms)
+
+  while (totalReceived < size) {
+    received =
+        recv(peerSocket_, data.data() + totalReceived, size - totalReceived, 0);
+    if (received > 0) {
+      totalReceived += received;
+      retryCount = 0;
+    } else if (received == 0) {
+      connected_ = false;
+      return {};
+    } else {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        if (++retryCount > maxRetries) {
+          TT_LOG_ERROR("[SocketTransport] Timeout waiting for message data");
+          connected_ = false;
+          return {};
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        continue;
+      }
+      connected_ = false;
+      return {};
+    }
+  }
+
+  return data;
+}
+
+bool SocketTransport::isConnected() const { return connected_; }
+
+std::string SocketTransport::getStatus() const {
+  if (!running_) {
+    return "stopped";
+  }
+
+  if (connected_) {
+    return mode_ == Mode::SERVER ? "server:connected" : "client:connected";
+  }
+
+  return mode_ == Mode::SERVER ? "server:waiting" : "client:connecting";
+}
+
+void SocketTransport::setConnectionLostCallback(
+    std::function<void()> callback) {
+  connectionLostCallback_ = std::move(callback);
+}
+
+}  // namespace tt::sockets


### PR DESCRIPTION
## Summary

Split `SocketManager` into two layers to separate networking from message dispatch.

## Before

`SocketManager` owned everything:
- `Mode`, host/port, `serverSocket`/`clientSocket`/`peerSocket`
- `serverLoop` / `clientLoop`
- `sendRawData` / `receiveRawData`
- `messageLoop`, `handlers_` map + dispatch
- `sendObject<T>` / `registerHandler<T>`
- `connection_lost_callback_`

## After

**`SocketManager`** (high-level) — Cereal-typed API:
- `sendObject<T>` / `registerHandler<T>`
- `messageLoop` + `handlers_` map
- Owns a `SocketTransport transport_`; forwards `initializeAsServer/Client`, `start`, `stop`, `isConnected`, `getStatus`, `setConnectionLostCallback`

**`SocketTransport`** (low-level, new) — OS/networking:
- `Mode`, host/port, `ScopedFd` sockets
- `serverLoop` / `clientLoop` on `connectionThread_`
- Length-prefixed `sendRawData` / `receiveRawData`
- `isConnected` / `getStatus`, lost-connection callback

`SocketManager`'s public surface is unchanged; the transport is now self-contained and independently testable.


<img width="800" height="605" alt="image" src="https://github.com/user-attachments/assets/2cdf9dc5-6118-421f-91ea-cb26a712af82" />
