### PR TITLE
fix: benchmark config missing IMAGE/AUDIO task types and curl compatibility

### DIFF
--- a/benchmarking/benchmark_config.py
+++ b/benchmarking/benchmark_config.py
@@ -56,6 +56,24 @@ class BenchmarkTaskTTS(BenchmarkTask):
 
 
 @dataclass(frozen=True)
+class BenchmarkTaskImage(BenchmarkTask):
+    param_map: Dict[DeviceTypes, List[BenchmarkTaskParams]]
+    task_type: BenchmarkTaskType = BenchmarkTaskType.HTTP_CLIENT_CNN_API
+    workflow_venv_type: WorkflowVenvType = (
+        None  # no workflow venv needed for image generation benchmarks
+    )
+
+
+@dataclass(frozen=True)
+class BenchmarkTaskAudio(BenchmarkTask):
+    param_map: Dict[DeviceTypes, List[BenchmarkTaskParams]]
+    task_type: BenchmarkTaskType = BenchmarkTaskType.HTTP_CLIENT_CNN_API
+    workflow_venv_type: WorkflowVenvType = (
+        None  # no workflow venv needed for audio transcription benchmarks
+    )
+
+
+@dataclass(frozen=True)
 class BenchmarkTaskStructuredOutput(BenchmarkTask):
     param_map: Dict[DeviceTypes, List[BenchmarkTaskParams]]
     task_type: BenchmarkTaskType = (
@@ -543,6 +561,10 @@ for model_id, model_spec in MODEL_SPECS.items():
         perf_ref_task = BenchmarkTaskVideo(param_map={device: capped_perf_reference})
     elif model_spec.model_type == ModelType.TEXT_TO_SPEECH:
         perf_ref_task = BenchmarkTaskTTS(param_map={device: capped_perf_reference})
+    elif model_spec.model_type == ModelType.IMAGE:
+        perf_ref_task = BenchmarkTaskImage(param_map={device: capped_perf_reference})
+    elif model_spec.model_type == ModelType.AUDIO:
+        perf_ref_task = BenchmarkTaskAudio(param_map={device: capped_perf_reference})
     else:
         perf_ref_task = BenchmarkTask(param_map={device: capped_perf_reference})
 
@@ -577,6 +599,14 @@ for model_id, model_spec in MODEL_SPECS.items():
                         )
                     ]
                 }
+            )
+        elif model_spec.model_type == ModelType.IMAGE:
+            benchmark_task_runs = BenchmarkTaskImage(
+                param_map={device: [BenchmarkTaskParams()]}
+            )
+        elif model_spec.model_type == ModelType.AUDIO:
+            benchmark_task_runs = BenchmarkTaskAudio(
+                param_map={device: [BenchmarkTaskParams()]}
             )
         else:
             benchmark_task_runs = BenchmarkTask(

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -287,7 +287,7 @@ def fetch_structured_output_scripts(
         dst.parent.mkdir(parents=True, exist_ok=True)
         url = f"{VLLM_BENCHMARKS_RAW_BASE}/{src_rel}"
         return_code = run_command(
-            f"curl -fSL --retry 3 --retry-delay 5 --retry-all-errors {url} -o {dst}",
+            f"curl -fSL --retry 3 --retry-delay 5 --retry-connrefused {url} -o {dst}",
             logger=logger,
         )
         if return_code != 0:


### PR DESCRIPTION
Fixes two bugs present on main that caused CI failures on image and audio model workflows.
1. curl --retry-all-errors unsupported on self-hosted runner
2. ModelType.IMAGE and ModelType.AUDIO missing from benchmark_config.py

Failing run example: https://github.com/tenstorrent/tt-shield/actions/runs/25723717780/job/75540216676

CI runs:
- SDXL n150: https://github.com/tenstorrent/tt-shield/actions/runs/25812142252
- Whisper 6u: https://github.com/tenstorrent/tt-shield/actions/runs/25820776875