### PR TITLE
fix(forge): honor --no-auth by treating missing API_KEY as auth-disabled

### DIFF
--- a/tt-media-server/security/api_key_checker.py
+++ b/tt-media-server/security/api_key_checker.py
@@ -8,14 +8,14 @@ from fastapi import HTTPException, Security
 from fastapi.security import APIKeyHeader
 from starlette.status import HTTP_401_UNAUTHORIZED
 
-# No API_KEY → no auth required, matching vllm-tt-metal's handle_secrets() convention.
-API_KEY = os.getenv("API_KEY")
-# auto_error=False so missing header is None (handled below), not 403.
-api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
+API_KEY = os.getenv("API_KEY", "your-secret-key")
+NO_AUTH = os.getenv("NO_AUTH", "").lower() in ("1", "true", "yes")
+# auto_error=False when NO_AUTH so missing header is None, not 403.
+api_key_header = APIKeyHeader(name="Authorization", auto_error=not NO_AUTH)
 
 
 def get_api_key(api_key: str | None = Security(api_key_header)):
-    if not API_KEY:
+    if NO_AUTH:
         return None
     if api_key != f"Bearer {API_KEY}":
         raise HTTPException(

--- a/tt-media-server/security/api_key_checker.py
+++ b/tt-media-server/security/api_key_checker.py
@@ -8,11 +8,15 @@ from fastapi import HTTPException, Security
 from fastapi.security import APIKeyHeader
 from starlette.status import HTTP_401_UNAUTHORIZED
 
-API_KEY = os.getenv("API_KEY", "your-secret-key")  # Or use os.getenv("API_KEY")
-api_key_header = APIKeyHeader(name="Authorization")
+# No API_KEY → no auth required, matching vllm-tt-metal's handle_secrets() convention.
+API_KEY = os.getenv("API_KEY")
+# auto_error=False so missing header is None (handled below), not 403.
+api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
 
 
-def get_api_key(api_key: str = Security(api_key_header)):
+def get_api_key(api_key: str | None = Security(api_key_header)):
+    if not API_KEY:
+        return None
     if api_key != f"Bearer {API_KEY}":
         raise HTTPException(
             status_code=HTTP_401_UNAUTHORIZED,

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -328,7 +328,8 @@ def generate_docker_run_command(
     ):
         docker_env_vars.update(get_media_server_docker_env_vars(model_spec))
         api_key = os.getenv("API_KEY")
-        if api_key:
+        # Skip API_KEY when --no-auth: container sees no key → auth disabled.
+        if api_key and not runtime_config.no_auth:
             docker_env_vars["API_KEY"] = api_key
         if _is_cpp_media_spec(model_spec):
             openai_api_key = os.getenv("OPENAI_API_KEY") or api_key

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -328,8 +328,9 @@ def generate_docker_run_command(
     ):
         docker_env_vars.update(get_media_server_docker_env_vars(model_spec))
         api_key = os.getenv("API_KEY")
-        # Skip API_KEY when --no-auth: container sees no key → auth disabled.
-        if api_key and not runtime_config.no_auth:
+        if runtime_config.no_auth:
+            docker_env_vars["NO_AUTH"] = "1"
+        elif api_key:
             docker_env_vars["API_KEY"] = api_key
         if _is_cpp_media_spec(model_spec):
             openai_api_key = os.getenv("OPENAI_API_KEY") or api_key


### PR DESCRIPTION
### Issue

Closes #3527

### Problem

- `--no-auth` was silently dropped by the forge container entrypoint, and `api_key_checker.py`'s hardcoded `"your-secret-key"` default kept auth enforced regardless. Inference endpoints (`/v1/completions`, `/v1/chat/completions`) always required `Authorization: Bearer your-secret-key`.

### What's changed

- Low risk, aligns with the existing convention used by `vllm-tt-metal/src/run_vllm_api_server.py:handle_secrets()`: no `API_KEY` configured → no auth required.
  - `tt-media-server/security/api_key_checker.py` — drop the `"your-secret-key"` default; short-circuit `get_api_key()` when `API_KEY` is unset; `auto_error=False` on the header so missing-header surfaces as None.
  - `workflows/run_docker_server.py` — omit `API_KEY` from container env when `runtime_config.no_auth` is set.

### Testing

- Tested locally on a forge container via `docker cp` + `docker restart`. With no `API_KEY` in env and no `Authorization` header, `/v1/completions` and `/v1/chat/completions` now return 200 (were 401). `/health` and `/v1/models` unaffected.