### PR TITLE
fix(evals): set API key for FORGE/MEDIA LLMs, don't overwrite with JWT

### DIFF
--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -38,6 +38,7 @@ from workflows.workflow_config import (
 from workflows.workflow_types import (
     DeviceTypes,
     EvalLimitMode,
+    InferenceEngine,
     ModelType,
     WorkflowVenvType,
 )
@@ -380,8 +381,15 @@ def main():
     # Setup authentication based on model type
     if model_spec.model_type in EVAL_TASK_TYPES:
         _setup_openai_api_key(args, logger)
+    elif model_spec.inference_engine in (
+        InferenceEngine.MEDIA.value,
+        InferenceEngine.FORGE.value,
+    ):
+        # Forge/media servers validate the literal API key, not JWTs.
+        _setup_openai_api_key(args, logger)
+        os.environ["VLLM_API_KEY"] = os.environ["OPENAI_API_KEY"]
     elif args.jwt_secret:
-        # For LLM models, generate JWT token from jwt_secret
+        # For tt-transformers / vllm-tt LLMs, generate JWT token from jwt_secret
         json_payload = json.loads(
             '{"team_id": "tenstorrent", "token_id": "debug-test"}'
         )
@@ -415,6 +423,10 @@ def main():
     env_config.jwt_secret = args.jwt_secret
     env_config.service_port = runtime_config.service_port
     env_config.vllm_model = model_spec.hf_model_repo
+    # EnvironmentConfig.vllm_api_key default is captured at module-load time;
+    # explicitly re-read so in-process PromptClient sees later env updates
+    # (mirrors run_benchmarks.py:439).
+    env_config.vllm_api_key = os.getenv("VLLM_API_KEY")
 
     if (
         model_spec.model_type in EVAL_TASK_TYPES


### PR DESCRIPTION
### Issue

Closes #3529

### Problem

- `evals/run_evals.py:380-392` picks the JWT auth path for any LLM model_type, overwriting `OPENAI_API_KEY=your-secret-key` that CI writes to `.env` for forge/media servers. Forge/media servers validate the literal API key, not JWTs, so every eval request 401s.
- `benchmarking/run_benchmarks.py:345-351` has the engine-aware branch but hardcodes `"your-secret-key"`, so an explicit `API_KEY` env override isn't honored (the rest of the codebase, including the `_setup_openai_api_key` helper, does honor it).

### What's changed

- Low risk, reuses existing helpers and aligns both client paths:
  - `evals/run_evals.py`: new FORGE/MEDIA branch before the JWT branch. Calls the existing `_setup_openai_api_key()` helper (already used by the `EVAL_TASK_TYPES` branch above) and additionally sets `VLLM_API_KEY` to match for the in-process `PromptClient`.
  - `evals/run_evals.py`: explicitly re-read `VLLM_API_KEY` into `env_config` after construction (mirrors `run_benchmarks.py:439`) so the in-process trace capture picks up env updates the dataclass default missed.
  - `benchmarking/run_benchmarks.py`: align the existing FORGE/MEDIA branch to use `os.getenv("API_KEY", "your-secret-key")` so an explicit `API_KEY` env override is honored, matching the helper's behavior.

### Testing

- Tested locally with a stock forge container running Llama-3.2-3B-Instruct. Baseline (no fix): 3165 `status=401` errors; trace capture logged `tokens_generated=0, TPOT=<unix timestamp>`. With fix: 0 `status=401` errors; trace capture returns real numbers (`tokens_generated=4, TTFT=42.990ms, TPOT=32.003ms`); eval reaches the next layer of forge-server issues (HTTP 422 schema — tracked separately).