### PR TITLE
fix(forge): accept batched prompts on /v1/completions to fix 422 Errors

### DIFF
--- a/tt-media-server/domain/completion_request.py
+++ b/tt-media-server/domain/completion_request.py
@@ -27,8 +27,9 @@ class CompletionRequest(BaseRequest):
     # Model identifier
     model: str | None = None
 
-    # prompt can be a string or a list of token ids
-    prompt: str | list[int]
+    # Per OpenAI /v1/completions spec, prompt can be a string, list of strings,
+    # flat list of token ids, or list of token-id lists (batched).
+    prompt: str | list[str] | list[int] | list[list[int]]
 
     # Response configuration
     echo: bool | None = False

--- a/tt-media-server/open_ai_api/llm.py
+++ b/tt-media-server/open_ai_api/llm.py
@@ -2,6 +2,7 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
+import asyncio
 import json
 import time
 import uuid
@@ -19,6 +20,19 @@ from open_ai_api.chat import _count_tokens
 
 logger = TTLogger()
 router = APIRouter()
+
+
+def _split_batched_prompts(req: CompletionRequest) -> list[CompletionRequest]:
+    """Split a batched-prompt request into N single-prompt requests.
+
+    OpenAI /v1/completions accepts prompt as List[str] or List[List[int]] for
+    batched submission. The downstream runner accepts only a single prompt
+    per request, so split here and aggregate results into N choices.
+    """
+    p = req.prompt
+    if isinstance(p, list) and p and isinstance(p[0], (list, str)):
+        return [req.model_copy(update={"prompt": item}) for item in p]
+    return [req]
 
 
 @router.post("/completions")
@@ -40,23 +54,27 @@ async def complete_text(
     created = int(time.time())
     model = completion_request.model or "default"
 
+    sub_requests = _split_batched_prompts(completion_request)
+
     # Reject prompts that exceed the model's context window
     try:
-        if isinstance(completion_request.prompt, str):
-            prompt_tokens = _count_tokens(completion_request.prompt)
-        elif isinstance(completion_request.prompt, list):
-            prompt_tokens = len(completion_request.prompt)
-        else:
-            prompt_tokens = 0
         max_model_len = settings.vllm.max_model_length
-        if prompt_tokens > max_model_len:
-            logger.warning(
-                f"Rejected prompt: length ({prompt_tokens}) exceeds max model length ({max_model_len})"
-            )
-            raise HTTPException(
-                status_code=400,
-                detail=f"Prompt length ({prompt_tokens}) exceeds max model length ({max_model_len})",
-            )
+        for r in sub_requests:
+            p = r.prompt
+            if isinstance(p, str):
+                prompt_tokens = _count_tokens(p)
+            elif isinstance(p, list):
+                prompt_tokens = len(p)
+            else:
+                prompt_tokens = 0
+            if prompt_tokens > max_model_len:
+                logger.warning(
+                    f"Rejected prompt: length ({prompt_tokens}) exceeds max model length ({max_model_len})"
+                )
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Prompt length ({prompt_tokens}) exceeds max model length ({max_model_len})",
+                )
     except HTTPException:
         raise
     except Exception:
@@ -64,7 +82,9 @@ async def complete_text(
 
     try:
         if not completion_request.stream:
-            result = await service.process_request(completion_request)
+            results = await asyncio.gather(
+                *(service.process_request(r) for r in sub_requests)
+            )
             response = {
                 "id": completion_id,
                 "object": "text_completion",
@@ -72,11 +92,12 @@ async def complete_text(
                 "model": model,
                 "choices": [
                     {
-                        "text": result.text,
-                        "index": 0,
+                        "text": r.text,
+                        "index": i,
                         "logprobs": None,
-                        "finish_reason": result.finish_reason or "stop",
+                        "finish_reason": r.finish_reason or "stop",
                     }
+                    for i, r in enumerate(results)
                 ],
                 "usage": {
                     "prompt_tokens": 0,
@@ -86,13 +107,22 @@ async def complete_text(
             }
             return JSONResponse(content=response)
 
+        # Streaming + batched prompts: not implemented. Multiplexing N async
+        # generators into one SSE stream is significant work and no current
+        # client (lm-eval-harness, vllm bench) sends batched + streaming.
+        if len(sub_requests) > 1:
+            raise HTTPException(
+                status_code=501,
+                detail="Streaming responses are not supported for batched prompts.",
+            )
+
         try:
             service.scheduler.check_is_model_ready()
         except Exception:
             raise HTTPException(status_code=405, detail="Model is not ready")
 
         async def result_stream():
-            async for partial in service.process_streaming_request(completion_request):
+            async for partial in service.process_streaming_request(sub_requests[0]):
                 chunk = {
                     "id": completion_id,
                     "object": "text_completion",


### PR DESCRIPTION
### Issue

Closes #3531 

### Problem

`tt-media-server/domain/completion_request.py` types `prompt` as `str | list[int]`, but the OpenAI `/v1/completions` spec accepts the full union `str | list[str] | list[int] | list[list[int]]`. lm-evaluation-harness always wraps prompts in a list (even at `batch_size=1`), so every forge-LLM eval request fails with HTTP 422 before the model is invoked.

### What's changed

- `tt-media-server/domain/completion_request.py`: expand `prompt` union to match the OpenAI spec.
- `tt-media-server/open_ai_api/llm.py`:
  - Add `_split_batched_prompts(req)` helper. For `list[str]` / `list[list[int]]`, it produces N single-prompt sub-requests via `req.model_copy(update={"prompt": item})`; for `str` / `list[int]` it returns `[req]` unchanged.
  - Non-streaming path fans out via `asyncio.gather(*(service.process_request(r) for r in sub_requests))` and aggregates results into N indexed `choices`. Order-preserving gather keeps the choice index stable.
  - Token-length validation now loops over all sub-prompts (not just the first), so an oversized batch entry fails fast at the API layer instead of wasting a runner slot.
  - Streaming + batched returns HTTP `501 Not Implemented`. No current client (lm-eval-harness, vllm bench) sends that combination; multiplexing N async generators into one SSE stream is significant work for zero current benefit.

### Testing

Depends on, and was tested with fix for #3529 in place otherwise can't see these errors.

Stock forge container running Llama-3.2-3B-Instruct, `--workflow evals` (lm-eval-harness via the `EVALS_META` venv, `tokenizer_backend=huggingface` so prompts arrive as `list[list[int]]`):

- **Baseline (no fix):** every request 422s; `samples_*.jsonl` is all `__INFERENCE_ERROR__`; lm-eval reports failure-noise scores.
- **With fix:** 0 × 422, 0 × 401 across the run; `meta_ifeval` generated real completions end-to-end, `meta_gpqa` in progress. lm-eval-harness's batched payload is now accepted and fanned out into N choices that map back to its expected response shape.