### PR TITLE
Acvejic/refuse pre 0.11 images

### DIFF
--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -536,6 +536,39 @@ class TestModelSpecSystem:
         assert spec.tt_metal_commit == new_tt_metal_commit
         assert spec.vllm_commit == new_vllm_commit
         assert spec.docker_image == docker_image_with_commits
+        # version is also re-parsed from the override tag — see comment in
+        # apply_overrides. Drives the pre-0.11 support check in
+        # validate_setup._check_image_version_supported.
+        assert spec.version == "0.4.0"
+
+    def test_apply_overrides_unparseable_tag_keeps_template_version(
+        self, sample_impl, sample_device_model_spec
+    ):
+        """Override tags like ':dev' / ':latest' have no parseable version;
+        the template's declared version must be left alone."""
+        from workflows.runtime_config import RuntimeConfig
+
+        spec = ModelSpec(
+            device_type=DeviceTypes.N150,
+            impl=sample_impl,
+            hf_model_repo="test/TestModel-7B",
+            model_id="id_test-impl_TestModel-7B_n150",
+            model_name="TestModel-7B",
+            tt_metal_commit="x",
+            vllm_commit="y",
+            inference_engine=InferenceEngine.VLLM.value,
+            device_model_spec=sample_device_model_spec,
+            version="0.13.0",
+        )
+        rc = RuntimeConfig(
+            model="TestModel-7B",
+            workflow="benchmarks",
+            device="n150",
+            override_docker_image="ghcr.io/foo/bar:dev",
+        )
+
+        spec.apply_overrides(rc)
+        assert spec.version == "0.13.0"
 
 
 class TestSystemIntegration:

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -558,8 +558,16 @@ class TestCheckImageVersionSupported:
 
     def test_pre_0_11_versions_raise(self):
         for v in ("0.10.9", "0.10.1", "0.10.0", "0.9.0", "0.2.0"):
-            with pytest.raises(RuntimeError, match="predates the v0.11.0"):
+            with pytest.raises(RuntimeError, match="too old"):
                 _check_image_version_supported(self._spec(v))
+
+    def test_error_names_exact_tag_to_checkout(self):
+        # The matching tt-inference-server release tag is `v<spec.version>`.
+        with pytest.raises(RuntimeError) as exc:
+            _check_image_version_supported(self._spec("0.10.1"))
+        msg = str(exc.value)
+        assert "v0.10.1" in msg
+        assert "git checkout v0.10.1" in msg
 
     def test_unparseable_versions_pass(self):
         # `dev`, `latest`, empty — let the runtime decide, matches main.

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -13,6 +13,7 @@ import pytest
 from workflows.runtime_config import RuntimeConfig
 from workflows.utils import check_path_permissions_for_uid
 from workflows.validate_setup import (
+    _check_image_version_supported,
     _try_fix_path_permissions_for_uid,  # noqa: F401
     validate_bind_mount_permissions,
     validate_local_setup,
@@ -536,3 +537,68 @@ class TestLocalServerValidation:
 
         mock_ensure_dir.assert_called_once_with(tmp_path / "logs")
         mock_run_command.assert_called_once()
+
+
+class TestCheckImageVersionSupported:
+    """run.py only emits the post-0.11 vLLM docker contract; pre-0.11 specs
+    (or pre-0.11 override images) must be refused with a clear migration
+    message rather than silently producing a broken docker run."""
+
+    def _spec(self, version):
+        s = MagicMock()
+        s.version = version
+        return s
+
+    def test_post_0_11_versions_pass(self):
+        # Boundary and above must not raise.
+        _check_image_version_supported(self._spec("0.11.0"))
+        _check_image_version_supported(self._spec("0.11.1"))
+        _check_image_version_supported(self._spec("0.13.0"))
+        _check_image_version_supported(self._spec("1.0.0"))
+
+    def test_pre_0_11_versions_raise(self):
+        for v in ("0.10.9", "0.10.1", "0.10.0", "0.9.0", "0.2.0"):
+            with pytest.raises(RuntimeError, match="predates the v0.11.0"):
+                _check_image_version_supported(self._spec(v))
+
+    def test_unparseable_versions_pass(self):
+        # `dev`, `latest`, empty — let the runtime decide, matches main.
+        _check_image_version_supported(self._spec("dev"))
+        _check_image_version_supported(self._spec("latest"))
+        _check_image_version_supported(self._spec(""))
+
+    def test_error_message_points_to_checkout_workaround(self):
+        with pytest.raises(RuntimeError) as exc:
+            _check_image_version_supported(self._spec("0.10.0"))
+        msg = str(exc.value)
+        assert "git checkout" in msg
+        assert "0.10.0" in msg
+        assert "release" in msg.lower()
+
+
+class TestVersionParsers:
+    """workflows.utils version helpers, used by _check_image_version_supported."""
+
+    def test_parse_version_tuple(self):
+        from workflows.utils import parse_version_tuple
+
+        assert parse_version_tuple("0.10.0") == (0, 10, 0)
+        assert parse_version_tuple("0.11.0") == (0, 11, 0)
+        assert parse_version_tuple("0.9") == (0, 9, 0)
+        assert parse_version_tuple("0.13.0-suffix") == (0, 13, 0)
+        # Non-version / empty / non-string inputs return None.
+        assert parse_version_tuple("dev") is None
+        assert parse_version_tuple("") is None
+        assert parse_version_tuple(None) is None  # type: ignore[arg-type]
+
+    def test_parse_image_version(self):
+        from workflows.utils import parse_image_version
+
+        assert parse_image_version("ghcr.io/foo/bar:0.10.0-abc") == (0, 10, 0)
+        assert parse_image_version("ghcr.io/foo/bar:0.11.0") == (0, 11, 0)
+        assert parse_image_version("ghcr.io/foo/bar:0.9-abc") == (0, 9, 0)
+        # Unparseable tags / no tag / no version-prefix / None.
+        assert parse_image_version("ghcr.io/foo/bar:dev") is None
+        assert parse_image_version("ghcr.io/foo/bar:latest") is None
+        assert parse_image_version("ghcr.io/foo/bar") is None
+        assert parse_image_version(None) is None  # type: ignore[arg-type]

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -558,7 +558,7 @@ class TestCheckImageVersionSupported:
 
     def test_pre_0_11_versions_raise(self):
         for v in ("0.10.9", "0.10.1", "0.10.0", "0.9.0", "0.2.0"):
-            with pytest.raises(RuntimeError, match="too old"):
+            with pytest.raises(RuntimeError, match="not supported"):
                 _check_image_version_supported(self._spec(v))
 
     def test_error_names_exact_tag_to_checkout(self):

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -540,23 +540,29 @@ class TestLocalServerValidation:
 
 
 class TestCheckImageVersionSupported:
-    """run.py only emits the post-0.11 vLLM docker contract; pre-0.11 specs
-    (or pre-0.11 override images) must be refused with a clear migration
-    message rather than silently producing a broken docker run."""
+    """run.py only emits the post-0.11 vLLM docker contract; pre-0.11 vLLM
+    specs (or pre-0.11 override images) must be refused with a clear migration
+    message rather than silently producing a broken docker run.
 
-    def _spec(self, version):
+    Media-inference-server and forge images use a different Dockerfile that
+    isn't affected by the 0.11.0 vLLM interface refactor, so the check must
+    NOT fire for them.
+    """
+
+    def _spec(self, version, engine="vLLM"):
         s = MagicMock()
         s.version = version
+        s.inference_engine = engine
         return s
 
-    def test_post_0_11_versions_pass(self):
+    def test_post_0_11_vllm_versions_pass(self):
         # Boundary and above must not raise.
         _check_image_version_supported(self._spec("0.11.0"))
         _check_image_version_supported(self._spec("0.11.1"))
         _check_image_version_supported(self._spec("0.13.0"))
         _check_image_version_supported(self._spec("1.0.0"))
 
-    def test_pre_0_11_versions_raise(self):
+    def test_pre_0_11_vllm_versions_raise(self):
         for v in ("0.10.9", "0.10.1", "0.10.0", "0.9.0", "0.2.0"):
             with pytest.raises(RuntimeError, match="not supported"):
                 _check_image_version_supported(self._spec(v))
@@ -575,13 +581,16 @@ class TestCheckImageVersionSupported:
         _check_image_version_supported(self._spec("latest"))
         _check_image_version_supported(self._spec(""))
 
-    def test_error_message_points_to_checkout_workaround(self):
-        with pytest.raises(RuntimeError) as exc:
-            _check_image_version_supported(self._spec("0.10.0"))
-        msg = str(exc.value)
-        assert "git checkout" in msg
-        assert "0.10.0" in msg
-        assert "release" in msg.lower()
+    def test_media_engine_not_blocked_by_pre_0_11(self):
+        # tt-media-inference-server images aren't affected by the vLLM
+        # 0.11.0 interface change. Pre-0.11 media specs must still run.
+        for v in ("0.2.0", "0.5.0", "0.9.0", "0.10.0", "0.10.1"):
+            _check_image_version_supported(self._spec(v, engine="media"))
+
+    def test_forge_engine_not_blocked_by_pre_0_11(self):
+        # forge images are also outside the vLLM image-interface refactor.
+        for v in ("0.2.0", "0.9.0", "0.10.1"):
+            _check_image_version_supported(self._spec(v, engine="forge"))
 
 
 class TestVersionParsers:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -555,11 +555,15 @@ class TestMainWorkflowIntegration:
     def test_main_workflow_benchmarks_no_docker(
         self, temp_dir, mock_env_vars, mock_version_file
     ):
-        """Test main run.py workflow for benchmarks without docker server."""
+        """Test main run.py workflow for benchmarks without docker server.
+
+        Uses a post-0.11 model — pre-0.11 specs are refused by
+        validate_runtime_args (_check_image_version_supported).
+        """
         test_args = [
             "run.py",
             "--model",
-            "Llama-3.1-8B-Instruct",
+            "Llama-3.2-1B-Instruct",
             "--device",
             "n150",
             "--workflow",
@@ -582,11 +586,15 @@ class TestMainWorkflowIntegration:
     def test_main_returns_one_when_any_workflow_fails(
         self, temp_dir, mock_env_vars, mock_version_file
     ):
-        """Test main run.py returns failure when any workflow result is non-zero."""
+        """Test main run.py returns failure when any workflow result is non-zero.
+
+        Uses a post-0.11 model — pre-0.11 specs are refused by
+        validate_runtime_args (_check_image_version_supported).
+        """
         test_args = [
             "run.py",
             "--model",
-            "Llama-3.1-8B-Instruct",
+            "Llama-3.2-1B-Instruct",
             "--device",
             "n150",
             "--workflow",

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -15,6 +15,7 @@ from workflows.utils import (
     get_repo_root_path,
     get_version,
     parse_commits_from_docker_image,
+    parse_image_version,
 )
 from workflows.utils_report import BenchmarkTaskParams, PerformanceTarget
 from workflows.workflow_types import (
@@ -814,6 +815,15 @@ class ModelSpec:
             )
             object.__setattr__(self, "tt_metal_commit", tt_metal_commit)
             object.__setattr__(self, "vllm_commit", vllm_commit)
+            # Re-parse `version` from the override tag so the pre-0.11
+            # support check (validate_runtime_args) sees the actual image
+            # being run, not the template default. Unparseable override
+            # tags (`:dev`, `:latest`) leave version untouched.
+            parsed_version = parse_image_version(runtime_config.override_docker_image)
+            if parsed_version is not None:
+                object.__setattr__(
+                    self, "version", ".".join(str(p) for p in parsed_version)
+                )
 
 
 @dataclass(frozen=True)

--- a/workflows/utils.py
+++ b/workflows/utils.py
@@ -24,6 +24,44 @@ SDXL_LOWER_BOUND_NUM_PROMPTS = 2
 SDXL_UPPER_BOUND_NUM_PROMPTS = 5000
 
 
+# Minimum image version supported by this run.py. The vLLM docker image
+# interface was reshaped in v0.11.0 (commit 50db8ac7 "Simplify and improve
+# vLLM Docker image interface"); main only emits the post-0.11 contract.
+# Older images must be run against an older tt-inference-server release.
+MIN_SUPPORTED_IMAGE_VERSION: Tuple[int, int, int] = (0, 11, 0)
+
+
+_VERSION_PREFIX_RE = re.compile(r"^(\d+(?:\.\d+){1,2})")
+
+
+def parse_version_tuple(s: str) -> Optional[Tuple[int, int, int]]:
+    """Parse a leading semver-style version into a (major, minor, patch) tuple.
+
+    Short forms are padded to three components ("0.9" -> (0, 9, 0)). Returns
+    None if the input is empty, not a string, or doesn't start with a
+    parseable version (e.g. "dev", "latest").
+    """
+    if not isinstance(s, str) or not s:
+        return None
+    match = _VERSION_PREFIX_RE.match(s)
+    if not match:
+        return None
+    parts = [int(p) for p in match.group(1).split(".")]
+    while len(parts) < 3:
+        parts.append(0)
+    return (parts[0], parts[1], parts[2])
+
+
+def parse_image_version(image: str) -> Optional[Tuple[int, int, int]]:
+    """Parse the version prefix from a docker image tag (everything after ':').
+
+    Returns None for unparseable tags (`:dev`, `:latest`, no tag).
+    """
+    if not isinstance(image, str) or ":" not in image:
+        return None
+    return parse_version_tuple(image.rsplit(":", 1)[1])
+
+
 def get_repo_root_path(marker: str = ".git") -> Path:
     """Return the root directory of the repository by searching for a marker file or directory."""
     current_path = Path(__file__).resolve().parent  # Start from the script's directory

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -53,14 +53,11 @@ def _check_image_version_supported(model_spec):
         return
     if parsed < MIN_SUPPORTED_IMAGE_VERSION:
         min_str = ".".join(str(p) for p in MIN_SUPPORTED_IMAGE_VERSION)
+        tag = f"v{model_spec.version}"
         raise RuntimeError(
-            f"⛔ ModelSpec version {model_spec.version!r} predates the "
-            f"v{min_str} docker image interface change. This run.py only "
-            f"supports v{min_str} and newer images.\n"
-            f"   To run this image, check out the matching tt-inference-server "
-            f"release (e.g. `git checkout v{model_spec.version}`) and use that "
-            f"version's run.py.\n"
-            f"   See https://github.com/tenstorrent/tt-inference-server/releases."
+            f"Image v{model_spec.version} is too old (need v{min_str}+). "
+            f"Check out the matching release tag {tag} and re-run:\n"
+            f"    git checkout {tag}"
         )
 
 

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -55,8 +55,9 @@ def _check_image_version_supported(model_spec):
         min_str = ".".join(str(p) for p in MIN_SUPPORTED_IMAGE_VERSION)
         tag = f"v{model_spec.version}"
         raise RuntimeError(
-            f"⛔ Image v{model_spec.version} is too old (need v{min_str}+). "
-            f"Check out the matching release tag {tag} and re-run:\n"
+            f"⛔ Image v{model_spec.version} is not supported in this "
+            f"version of run.py (need v{min_str}+). Check out the matching "
+            f"release tag {tag} and re-run:\n"
             f"    git checkout {tag}"
         )
 

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -40,12 +40,18 @@ def _check_image_version_supported(model_spec):
     "Simplify and improve vLLM Docker image interface"): ENTRYPOINT changed
     from docker-entrypoint.sh + gosu to bash -c, the script's CLI argument
     contract changed, and shared-memory + env-var conventions changed. main
-    only emits the new contract, so an older image won't start.
+    only emits the new contract, so an older vLLM image won't start.
+
+    Scoped to vLLM only — media-inference-server and forge images have
+    different Dockerfiles and aren't affected by this interface change
+    (the docker command for them is also simpler and stable across versions).
 
     apply_overrides re-parses model_spec.version from --override-docker-image
     when present, so this check covers both template-pinned versions and
     override paths.
     """
+    if model_spec.inference_engine != InferenceEngine.VLLM.value:
+        return
     parsed = parse_version_tuple(model_spec.version)
     if parsed is None:
         # Unparseable versions (`dev`, `latest`, etc.) default to "newest

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -12,11 +12,13 @@ from evals.eval_config import EVAL_CONFIGS
 from server_tests.test_config import TEST_CONFIGS
 from workflows.model_spec import MODEL_SPECS
 from workflows.utils import (
+    MIN_SUPPORTED_IMAGE_VERSION,
     check_path_permissions_for_uid,
     ensure_readwriteable_dir,
     get_default_workflow_root_log_dir,
     get_groups_for_uid,
     get_repo_root_path,
+    parse_version_tuple,
     resolve_hf_snapshot_dir,
     run_command,
 )
@@ -29,6 +31,37 @@ from workflows.workflow_types import (
 from workflows.workflow_venvs import VENV_CONFIGS
 
 logger = logging.getLogger("run_log")
+
+
+def _check_image_version_supported(model_spec):
+    """Refuse to run a pre-0.11 vLLM image with this run.py.
+
+    The vLLM docker image interface was reshaped in v0.11.0 (commit 50db8ac7
+    "Simplify and improve vLLM Docker image interface"): ENTRYPOINT changed
+    from docker-entrypoint.sh + gosu to bash -c, the script's CLI argument
+    contract changed, and shared-memory + env-var conventions changed. main
+    only emits the new contract, so an older image won't start.
+
+    apply_overrides re-parses model_spec.version from --override-docker-image
+    when present, so this check covers both template-pinned versions and
+    override paths.
+    """
+    parsed = parse_version_tuple(model_spec.version)
+    if parsed is None:
+        # Unparseable versions (`dev`, `latest`, etc.) default to "newest
+        # contract" — let the runtime decide, matches main's behaviour.
+        return
+    if parsed < MIN_SUPPORTED_IMAGE_VERSION:
+        min_str = ".".join(str(p) for p in MIN_SUPPORTED_IMAGE_VERSION)
+        raise RuntimeError(
+            f"⛔ ModelSpec version {model_spec.version!r} predates the "
+            f"v{min_str} docker image interface change. This run.py only "
+            f"supports v{min_str} and newer images.\n"
+            f"   To run this image, check out the matching tt-inference-server "
+            f"release (e.g. `git checkout v{model_spec.version}`) and use that "
+            f"version's run.py.\n"
+            f"   See https://github.com/tenstorrent/tt-inference-server/releases."
+        )
 
 
 def validate_runtime_args(model_spec, runtime_config):
@@ -46,6 +79,8 @@ def validate_runtime_args(model_spec, runtime_config):
         raise ValueError(
             f"model:={runtime_config.model} does not support device:={runtime_config.device}"
         )
+
+    _check_image_version_supported(model_spec)
 
     assert not (args.docker_server and args.local_server), (
         "Cannot run --docker-server and --local-server"

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -55,7 +55,7 @@ def _check_image_version_supported(model_spec):
         min_str = ".".join(str(p) for p in MIN_SUPPORTED_IMAGE_VERSION)
         tag = f"v{model_spec.version}"
         raise RuntimeError(
-            f"Image v{model_spec.version} is too old (need v{min_str}+). "
+            f"⛔ Image v{model_spec.version} is too old (need v{min_str}+). "
             f"Check out the matching release tag {tag} and re-run:\n"
             f"    git checkout {tag}"
         )


### PR DESCRIPTION
## Summary
Refuse to run with a pre-0.11.0 vLLM docker image. main's run.py only emits the post-0.11 docker contract; running an older image would silently produce a  broken `docker run`. Now we exit early with a clear migration message instead.

  ## How

  `validate_runtime_args` calls `_check_image_version_supported`, which compares `model_spec.version` against `MIN_SUPPORTED_IMAGE_VERSION = (0, 11, 0)`:

  - `version >= 0.11.0` → passes through, unchanged behavior
  - `version < 0.11.0` and `inference_engine == vLLM` → raises with checkout hint
  - `version < 0.11.0` and `inference_engine in (media, forge)` → passes through (media/forge images use a different Dockerfile not affected by the 0.11.0 vLLM  interface refactor)
  - unparseable version (`dev`, `latest`) → passes through (let runtime decide, matches main)

  `apply_overrides` re-parses `version` from `--override-docker-image` tag so the check sees the actual image being run, not just the template default.
  
## Local runs
  
### 1:
```
ubuntu@UF-EV-A11-GWH02:~/tt/tt-inference-server$ python3 run.py --model QwQ-32B --workflow release --device galaxy     --impl tt-transformers --docker-server --print-docker-cmd
2026-05-14 13:20:51,560 - run.py:611 - INFO: TT-Inference version: 0.13.0
2026-05-14 13:20:51,560 - run.py:612 - INFO: TT-Inference SHA: e605f04b2086
2026-05-14 13:20:51,560 - run.py:613 - INFO:
============================================================
tt-inference-server run.py CLI args summary
============================================================

Model Options:
  model:                      QwQ-32B
  device:                     galaxy
  impl:                       tt-transformers
  engine:                     vLLM
  workflow:                   release
  tools:                      vllm

Optional args:
  dev_mode:                   False
  docker_server:              True
  local_server:               False
  no_auth:                    False
  tt_metal_python_venv_dir:   None
  tt_metal_home:              None
  vllm_dir:                   None
  service_port:               8000
  bind_host:                  0.0.0.0
  docker_override_image:      None
  docker_interactive:         False
  device_id:                  None
  disable_trace_capture:      False
  override_tt_config:         None
  vllm_override_args:         None
  workflow_args:              None
  limit_samples_mode:         None
  skip_system_sw_validation:  False

Host Storage Options:
  host_volume:                None
  host_hf_cache:              None
  host_weights_dir:           None
  image_user:                 1000

============================================================
2026-05-14 13:20:51,561 - run.py:619 - INFO: Runtime model spec saved to: /home/ubuntu/tt/tt-inference-server/workflow_logs/runtime_model_specs/runtime_model_spec_2026-05-14_13-20-51_id_tt-transformers_QwQ-32B_galaxy_OUDhlE6A.json
Traceback (most recent call last):
  File "/home/ubuntu/tt/tt-inference-server/run.py", line 736, in <module>
    sys.exit(main())
  File "/home/ubuntu/tt/tt-inference-server/run.py", line 622, in main
    validate_setup(model_spec, runtime_config, json_fpath)
  File "/home/ubuntu/tt/tt-inference-server/workflows/validate_setup.py", line 457, in validate_setup
    validate_runtime_args(model_spec, runtime_config)
  File "/home/ubuntu/tt/tt-inference-server/workflows/validate_setup.py", line 87, in validate_runtime_args
    _check_image_version_supported(model_spec)
  File "/home/ubuntu/tt/tt-inference-server/workflows/validate_setup.py", line 63, in _check_image_version_supported
    raise RuntimeError(
RuntimeError: ⛔ Image v0.9.0 is not supported in this version of run.py (need v0.11.0+). Check out the matching release tag v0.9.0 and re-run:
    git checkout v0.9.0
```
    
 ### 2:
 ```
    ubuntu@UF-EV-A11-GWH02:~/tt/tt-inference-server$ python3 run.py --model QwQ-32B --workflow release --device galaxy     --impl tt-transformers --docker-server
2026-05-14 13:21:40,176 - run.py:611 - INFO: TT-Inference version: 0.13.0
2026-05-14 13:21:40,176 - run.py:612 - INFO: TT-Inference SHA: e605f04b2086
2026-05-14 13:21:40,176 - run.py:613 - INFO:
============================================================
tt-inference-server run.py CLI args summary
============================================================

Model Options:
  model:                      QwQ-32B
  device:                     galaxy
  impl:                       tt-transformers
  engine:                     vLLM
  workflow:                   release
  tools:                      vllm

Optional args:
  dev_mode:                   False
  docker_server:              True
  local_server:               False
  no_auth:                    False
  tt_metal_python_venv_dir:   None
  tt_metal_home:              None
  vllm_dir:                   None
  service_port:               8000
  bind_host:                  0.0.0.0
  docker_override_image:      None
  docker_interactive:         False
  device_id:                  None
  disable_trace_capture:      False
  override_tt_config:         None
  vllm_override_args:         None
  workflow_args:              None
  limit_samples_mode:         None
  skip_system_sw_validation:  False

Host Storage Options:
  host_volume:                None
  host_hf_cache:              None
  host_weights_dir:           None
  image_user:                 1000

============================================================
2026-05-14 13:21:40,177 - run.py:619 - INFO: Runtime model spec saved to: /home/ubuntu/tt/tt-inference-server/workflow_logs/runtime_model_specs/runtime_model_spec_2026-05-14_13-21-40_id_tt-transformers_QwQ-32B_galaxy_znWaZlCc.json
Traceback (most recent call last):
  File "/home/ubuntu/tt/tt-inference-server/run.py", line 736, in <module>
    sys.exit(main())
  File "/home/ubuntu/tt/tt-inference-server/run.py", line 622, in main
    validate_setup(model_spec, runtime_config, json_fpath)
  File "/home/ubuntu/tt/tt-inference-server/workflows/validate_setup.py", line 457, in validate_setup
    validate_runtime_args(model_spec, runtime_config)
  File "/home/ubuntu/tt/tt-inference-server/workflows/validate_setup.py", line 87, in validate_runtime_args
    _check_image_version_supported(model_spec)
  File "/home/ubuntu/tt/tt-inference-server/workflows/validate_setup.py", line 63, in _check_image_version_supported
    raise RuntimeError(
RuntimeError: ⛔ Image v0.9.0 is not supported in this version of run.py (need v0.11.0+). Check out the matching release tag v0.9.0 and re-run:
    git checkout v0.9.0
```

### 3:

```
ubuntu@UF-EV-A11-GWH02:~/tt/tt-inference-server$ python3 run.py --model FLUX.1-schnell --workflow release --device galaxy     --impl tt-transformers --docker-server --print-docker-cmd
2026-05-14 13:21:54,995 - run.py:611 - INFO: TT-Inference version: 0.13.0
2026-05-14 13:21:54,995 - run.py:612 - INFO: TT-Inference SHA: e605f04b2086
2026-05-14 13:21:54,995 - run.py:613 - INFO:
============================================================
tt-inference-server run.py CLI args summary
============================================================

Model Options:
  model:                      FLUX.1-schnell
  device:                     galaxy
  impl:                       tt-transformers
  engine:                     media
  workflow:                   release
  tools:                      vllm

Optional args:
  dev_mode:                   False
  docker_server:              True
  local_server:               False
  no_auth:                    False
  tt_metal_python_venv_dir:   None
  tt_metal_home:              None
  vllm_dir:                   None
  service_port:               8000
  bind_host:                  0.0.0.0
  docker_override_image:      None
  docker_interactive:         False
  device_id:                  None
  disable_trace_capture:      False
  override_tt_config:         None
  vllm_override_args:         None
  workflow_args:              None
  limit_samples_mode:         None
  skip_system_sw_validation:  False

Host Storage Options:
  host_volume:                None
  host_hf_cache:              None
  host_weights_dir:           None
  image_user:                 1000

============================================================
2026-05-14 13:21:54,996 - run.py:619 - INFO: Runtime model spec saved to: /home/ubuntu/tt/tt-inference-server/workflow_logs/runtime_model_specs/runtime_model_spec_2026-05-14_13-21-54_id_tt-transformers_FLUX.1-schnell_galaxy_ASvh_X5R.json
2026-05-14 13:21:54,996 - validate_setup.py:197 - INFO: Starting local setup validation
2026-05-14 13:21:54,996 - utils.py:272 - INFO: Running command: /home/ubuntu/tt/tt-inference-server/.workflow_venvs/.venv_bootstrap_uv/bin/uv pip install --managed-python --python /home/ubuntu/tt/tt-inference-server/.workflow_venvs/.venv_system_software_validation/bin/python --index-strategy unsafe-best-match -r /home/ubuntu/tt/tt-inference-server/requirements/system-software-validation.txt
Using Python 3.11.14 environment at: .workflow_venvs/.venv_system_software_validation
Checked 2 packages in 1ms
2026-05-14 13:21:55,006 - utils.py:272 - INFO: Running command: /home/ubuntu/tt/tt-inference-server/.workflow_venvs/.venv_system_software_validation/bin/python /home/ubuntu/tt/tt-inference-server/workflows/run_system_software_validation.py --runtime-model-spec-json /home/ubuntu/tt/tt-inference-server/workflow_logs/runtime_model_specs/runtime_model_spec_2026-05-14_13-21-54_id_tt-transformers_FLUX.1-schnell_galaxy_ASvh_X5R.json
2026-05-14 13:21:55,087 - run_system_software_validation.py:245 - INFO: Running /home/ubuntu/tt/tt-inference-server/workflows/run_system_software_validation.py ...
2026-05-14 13:21:55,088 - utils.py:272 - INFO: Running command: /home/ubuntu/tt/tt-inference-server/.workflow_venvs/.venv_bootstrap_uv/bin/uv pip install --managed-python --python /home/ubuntu/tt/tt-inference-server/.workflow_venvs/.venv_tt_smi/bin/python --index-strategy unsafe-best-match -r /home/ubuntu/tt/tt-inference-server/requirements/tt-smi.txt
2026-05-14 13:21:55,095 - utils.py:223 - INFO: Using Python 3.10.19 environment at: .workflow_venvs/.venv_tt_smi
2026-05-14 13:21:55,098 - utils.py:223 - INFO: Checked 1 package in 3ms
2026-05-14 13:21:55,100 - run_system_software_validation.py:41 - INFO: Running tt-smi -s to get device telemetry
2026-05-14 13:21:55,484 - run_system_software_validation.py:65 - INFO: Successfully parsed tt-smi data
2026-05-14 13:21:55,485 - run_system_software_validation.py:308 - INFO: System info:
================================================================================
FW bundle versions (across all devices): ['19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0', '19.2.0.0']
KMD version (on host): 2.5.0
Board types: ['tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L', 'tt-galaxy-wh L']
Topology: SystemTopology.ISOLATED
================================================================================
2026-05-14 13:21:55,498 - validate_setup.py:225 - INFO: ✅ validating system software dependencies completed
2026-05-14 13:21:55,498 - validate_setup.py:233 - INFO: ✅ validating local setup completed
2026-05-14 13:21:55,498 - run.py:627 - INFO: Running inference server in Docker container ...
2026-05-14 13:21:55,499 - run_docker_server.py:54 - INFO: Media server environment variables: MODEL=FLUX.1-schnell, DEVICE=galaxy
Docker run command:

docker run \
  --rm \
  --name tt-inference-server-329e8f8e \
  --env-file /home/ubuntu/tt/tt-inference-server/.env \
  --ipc host \
  --device /dev/tenstorrent:/dev/tenstorrent \
  --mount type=bind,src=/dev/hugepages-1G,dst=/dev/hugepages-1G \
  --publish 0.0.0.0:8000:8000 \
  --volume volume_id_tt_transformers-FLUX.1-schnell:/home/container_app_user/cache_root \
  -e CACHE_ROOT=/home/container_app_user/cache_root \
  -e MODEL=FLUX.1-schnell \
  -e DEVICE=galaxy \
  ghcr.io/tenstorrent/tt-media-inference-server:0.10.0-555f240
```
  
## CI runs:
  https://github.com/tenstorrent/tt-shield/actions/runs/25861300620/job/75991659742
  https://github.com/tenstorrent/tt-shield/actions/runs/25862578217/job/75996111022
  https://github.com/tenstorrent/tt-shield/actions/runs/25863299069/job/75998621435
  https://github.com/tenstorrent/tt-shield/actions/runs/25861287799/job/75991597970