### PR TITLE
 v2: real WhisperEvalTest + multi-size benchmark on release for whisper

### DIFF
--- a/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
@@ -34,6 +34,12 @@ from .._test_common import (
     run_tiered_check,
 )
 from ..context import MediaContext, count_tokens, require_health
+from ..load_param_tests.test_payloads.audio_payload_30s import (
+    dataset as dataset30s,
+)
+from ..load_param_tests.test_payloads.audio_payload_60s import (
+    dataset as dataset60s,
+)
 from ..test_status import AudioTestStatus
 
 logger = logging.getLogger(__name__)
@@ -53,7 +59,9 @@ async def _transcribe_audio_streaming_off(
     if audio_b64 is not None:
         audio_file = {"file": audio_b64}
     else:
-        with open(f"{ctx.test_payloads_path}/image_client_audio_payload", "r") as f:
+        with open(
+            Path(ctx.test_payloads_path) / "image_client_audio_payload", "r"
+        ) as f:
             audio_file = json.load(f)
 
     headers = {
@@ -113,7 +121,7 @@ async def _transcribe_audio_streaming_on(
         audio_file = {"file": audio_b64}
     else:
         with open(
-            f"{ctx.test_payloads_path}/image_client_audio_streaming_payload", "r"
+            Path(ctx.test_payloads_path) / "image_client_audio_streaming_payload", "r"
         ) as f:
             audio_file = json.load(f)
 
@@ -187,11 +195,10 @@ async def _transcribe_audio_streaming_on(
 
                     elapsed = now - start_time
                     tokens_per_sec = total_tokens / elapsed if elapsed > 0 else 0
-                    tokens_per_user_per_sec = tokens_per_sec / 1
                     logger.info(
                         f"[{elapsed:.2f}s] chunk={chunk_id} chunk_tokens={chunk_tokens} "
                         f"total_tokens={total_tokens} tps={tokens_per_sec:.2f} "
-                        f"t/s/u={tokens_per_user_per_sec:.2f} text={text!r}"
+                        f"t/s/u={tokens_per_sec:.2f} text={text!r}"
                     )
 
         end_time = time.monotonic()
@@ -201,7 +208,7 @@ async def _transcribe_audio_streaming_on(
         final_tps = (
             final_tokens / content_streaming_time if content_streaming_time > 0 else 0
         )
-        final_tokens_per_user_per_sec = final_tps / 1
+        final_tokens_per_user_per_sec = final_tps
 
         rtr = None
         if audio_duration is not None:
@@ -234,7 +241,7 @@ async def _transcribe_audio(
 ) -> tuple[bool, float, Optional[float], Optional[float], Optional[float]]:
     logger.info("🔈 Calling whisper")
     is_preprocessing_enabled = is_preprocessing_enabled_for_whisper(ctx)
-    logging.info(f"Preprocessing enabled: {is_preprocessing_enabled}")
+    logger.info(f"Preprocessing enabled: {is_preprocessing_enabled}")
 
     if is_streaming_enabled_for_whisper(ctx):
         return await _transcribe_audio_streaming_on(
@@ -302,15 +309,13 @@ def _run_whisper_benchmark_sweep(ctx: MediaContext, num_calls: int) -> Block:
     Target checks are computed from the 60s (heavier) pass and placed at
     the top level of ``data`` so the acceptance gate keeps working.
     """
-    from ..load_param_tests.test_payloads.audio_payload_30s import (
-        dataset as dataset30s,
-    )
-    from ..load_param_tests.test_payloads.audio_payload_60s import (
-        dataset as dataset60s,
-    )
+    GATE_LABEL = "Benchmarks 60s"
+
+    streaming_enabled = is_streaming_enabled_for_whisper(ctx)
+    preprocessing_enabled = is_preprocessing_enabled_for_whisper(ctx)
 
     records = []
-    last_metrics = None
+    metrics_by_label: dict[str, tuple] = {}
     for label, audio_b64 in (
         ("Benchmarks 30s", dataset30s["file"]),
         ("Benchmarks 60s", dataset60s["file"]),
@@ -322,7 +327,7 @@ def _run_whisper_benchmark_sweep(ctx: MediaContext, num_calls: int) -> Block:
         ttft_value = _audio_avg(status_list, "ttft")
         rtr_value = _audio_avg(status_list, "rtr")
         tsu_value = _audio_avg(status_list, "tsu")
-        last_metrics = (ttft_value, tsu_value, rtr_value)
+        metrics_by_label[label] = (ttft_value, tsu_value, rtr_value)
         records.append(
             {
                 "name": label,
@@ -332,12 +337,16 @@ def _run_whisper_benchmark_sweep(ctx: MediaContext, num_calls: int) -> Block:
                 "inference_steps_per_second": 0,
                 "t/s/u": tsu_value,
                 "rtr": rtr_value,
-                "streaming_enabled": is_streaming_enabled_for_whisper(ctx),
-                "preprocessing_enabled": is_preprocessing_enabled_for_whisper(ctx),
+                "streaming_enabled": streaming_enabled,
+                "preprocessing_enabled": preprocessing_enabled,
             }
         )
 
-    ttft_value, tsu_value, rtr_value = last_metrics
+    if GATE_LABEL not in metrics_by_label:
+        raise RuntimeError(
+            f"Whisper sweep must include {GATE_LABEL!r} (got {list(metrics_by_label)})"
+        )
+    ttft_value, tsu_value, rtr_value = metrics_by_label[GATE_LABEL]
     target_checks, _accuracy_check = _audio_target_checks(
         ctx, ttft_value, tsu_value, rtr_value
     )
@@ -349,8 +358,8 @@ def _run_whisper_benchmark_sweep(ctx: MediaContext, num_calls: int) -> Block:
         id=block_id(ctx) or None,
         targets={
             "num_prompts": num_calls,
-            "streaming_enabled": is_streaming_enabled_for_whisper(ctx),
-            "preprocessing_enabled": is_preprocessing_enabled_for_whisper(ctx),
+            "streaming_enabled": streaming_enabled,
+            "preprocessing_enabled": preprocessing_enabled,
             "sweep_sizes": ["30s", "60s"],
         },
         data={

--- a/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Optional
 
 import aiohttp
-import requests
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 if str(_PROJECT_ROOT) not in sys.path:
@@ -45,7 +44,7 @@ def _audio_avg(status_list: list[AudioTestStatus], attr: str) -> Optional[float]
     return sum(valid) / len(valid) if valid else None
 
 
-def _transcribe_audio_streaming_off(
+async def _transcribe_audio_streaming_off(
     ctx: MediaContext,
     is_preprocessing_enabled: bool,
     audio_b64: Optional[str] = None,
@@ -69,20 +68,25 @@ def _transcribe_audio_streaming_off(
     }
 
     start_time = time.time()
-    response = requests.post(
-        f"{ctx.base_url}/v1/audio/transcriptions",
-        json=payload,
-        headers=headers,
-        timeout=90,
-    )
+    status_ok = False
+    response_data = None
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{ctx.base_url}/v1/audio/transcriptions",
+            json=payload,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=90),
+        ) as response:
+            status_ok = response.status == 200
+            if status_ok:
+                response_data = await response.json()
     elapsed = time.time() - start_time
     ttft = elapsed
     tsu = None
 
     rtr = None
-    if response.status_code == 200:
+    if status_ok and response_data is not None:
         try:
-            response_data = response.json()
             audio_duration = response_data.get("duration")
             if audio_duration is not None:
                 rtr = audio_duration / elapsed
@@ -95,7 +99,7 @@ def _transcribe_audio_streaming_off(
         except Exception as e:
             logger.error(f"Failed to calculate RTR: {e}")
 
-    return (response.status_code == 200), elapsed, ttft, tsu, rtr
+    return status_ok, elapsed, ttft, tsu, rtr
 
 
 async def _transcribe_audio_streaming_on(
@@ -237,7 +241,7 @@ async def _transcribe_audio(
             ctx, is_preprocessing_enabled, audio_b64=audio_b64
         )
 
-    return _transcribe_audio_streaming_off(
+    return await _transcribe_audio_streaming_off(
         ctx, is_preprocessing_enabled, audio_b64=audio_b64
     )
 

--- a/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
@@ -334,7 +334,7 @@ def _run_whisper_benchmark_sweep(ctx: MediaContext, num_calls: int) -> Block:
         )
 
     ttft_value, tsu_value, rtr_value = last_metrics
-    target_checks, accuracy_check = _audio_target_checks(
+    target_checks, _accuracy_check = _audio_target_checks(
         ctx, ttft_value, tsu_value, rtr_value
     )
 
@@ -351,7 +351,6 @@ def _run_whisper_benchmark_sweep(ctx: MediaContext, num_calls: int) -> Block:
         },
         data={
             "records": records,
-            "accuracy_check": accuracy_check,
             "target_checks": target_checks,
         },
     )

--- a/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
@@ -46,11 +46,16 @@ def _audio_avg(status_list: list[AudioTestStatus], attr: str) -> Optional[float]
 
 
 def _transcribe_audio_streaming_off(
-    ctx: MediaContext, is_preprocessing_enabled: bool
+    ctx: MediaContext,
+    is_preprocessing_enabled: bool,
+    audio_b64: Optional[str] = None,
 ) -> tuple[bool, float, Optional[float], Optional[float], Optional[float]]:
     logger.info("Transcribing audio without streaming")
-    with open(f"{ctx.test_payloads_path}/image_client_audio_payload", "r") as f:
-        audio_file = json.load(f)
+    if audio_b64 is not None:
+        audio_file = {"file": audio_b64}
+    else:
+        with open(f"{ctx.test_payloads_path}/image_client_audio_payload", "r") as f:
+            audio_file = json.load(f)
 
     headers = {
         "accept": "application/json",
@@ -94,14 +99,19 @@ def _transcribe_audio_streaming_off(
 
 
 async def _transcribe_audio_streaming_on(
-    ctx: MediaContext, is_preprocessing_enabled: bool
+    ctx: MediaContext,
+    is_preprocessing_enabled: bool,
+    audio_b64: Optional[str] = None,
 ) -> tuple[bool, float, Optional[float], Optional[float], Optional[float]]:
     logger.info("Transcribing audio with streaming enabled")
 
-    with open(
-        f"{ctx.test_payloads_path}/image_client_audio_streaming_payload", "r"
-    ) as f:
-        audio_file = json.load(f)
+    if audio_b64 is not None:
+        audio_file = {"file": audio_b64}
+    else:
+        with open(
+            f"{ctx.test_payloads_path}/image_client_audio_streaming_payload", "r"
+        ) as f:
+            audio_file = json.load(f)
 
     hf_model_repo = ctx.model_spec.hf_model_repo
     headers = {
@@ -216,25 +226,32 @@ async def _transcribe_audio_streaming_on(
 
 async def _transcribe_audio(
     ctx: MediaContext,
+    audio_b64: Optional[str] = None,
 ) -> tuple[bool, float, Optional[float], Optional[float], Optional[float]]:
     logger.info("🔈 Calling whisper")
     is_preprocessing_enabled = is_preprocessing_enabled_for_whisper(ctx)
     logging.info(f"Preprocessing enabled: {is_preprocessing_enabled}")
 
     if is_streaming_enabled_for_whisper(ctx):
-        return await _transcribe_audio_streaming_on(ctx, is_preprocessing_enabled)
+        return await _transcribe_audio_streaming_on(
+            ctx, is_preprocessing_enabled, audio_b64=audio_b64
+        )
 
-    return _transcribe_audio_streaming_off(ctx, is_preprocessing_enabled)
+    return _transcribe_audio_streaming_off(
+        ctx, is_preprocessing_enabled, audio_b64=audio_b64
+    )
 
 
 def _run_audio_transcription_benchmark(
-    ctx: MediaContext, num_calls: int
+    ctx: MediaContext, num_calls: int, audio_b64: Optional[str] = None
 ) -> list[AudioTestStatus]:
     logger.info(f"Running audio transcription benchmark with {num_calls} calls.")
     status_list: list[AudioTestStatus] = []
     for i in range(num_calls):
         logger.info(f"Transcribing audio {i + 1}/{num_calls}...")
-        status, elapsed, ttft, tsu, rtr = asyncio.run(_transcribe_audio(ctx))
+        status, elapsed, ttft, tsu, rtr = asyncio.run(
+            _transcribe_audio(ctx, audio_b64=audio_b64)
+        )
         logger.info(f"Transcribed audio in {elapsed:.2f} seconds.")
         status_list.append(
             AudioTestStatus(status=status, elapsed=elapsed, ttft=ttft, tsu=tsu, rtr=rtr)
@@ -269,6 +286,77 @@ def _audio_target_checks(
     )
 
 
+def _is_whisper(ctx: MediaContext) -> bool:
+    impl = getattr(ctx.model_spec, "impl", None)
+    return getattr(impl, "impl_name", None) == "whisper"
+
+
+def _run_whisper_benchmark_sweep(ctx: MediaContext, num_calls: int) -> Block:
+    """Multi-size audio benchmark for whisper: runs 30s and 60s clips and
+    emits one ``benchmarks`` block with a row per size.
+
+    Target checks are computed from the 60s (heavier) pass and placed at
+    the top level of ``data`` so the acceptance gate keeps working.
+    """
+    from ..load_param_tests.test_payloads.audio_payload_30s import (
+        dataset as dataset30s,
+    )
+    from ..load_param_tests.test_payloads.audio_payload_60s import (
+        dataset as dataset60s,
+    )
+
+    records = []
+    last_metrics = None
+    for label, audio_b64 in (
+        ("Benchmarks 30s", dataset30s["file"]),
+        ("Benchmarks 60s", dataset60s["file"]),
+    ):
+        logger.info("Running whisper benchmark sweep: %s", label)
+        status_list = _run_audio_transcription_benchmark(
+            ctx, num_calls, audio_b64=audio_b64
+        )
+        ttft_value = _audio_avg(status_list, "ttft")
+        rtr_value = _audio_avg(status_list, "rtr")
+        tsu_value = _audio_avg(status_list, "tsu")
+        last_metrics = (ttft_value, tsu_value, rtr_value)
+        records.append(
+            {
+                "name": label,
+                "num_requests": len(status_list),
+                "num_inference_steps": 0,
+                "ttft": ttft_value,
+                "inference_steps_per_second": 0,
+                "t/s/u": tsu_value,
+                "rtr": rtr_value,
+                "streaming_enabled": is_streaming_enabled_for_whisper(ctx),
+                "preprocessing_enabled": is_preprocessing_enabled_for_whisper(ctx),
+            }
+        )
+
+    ttft_value, tsu_value, rtr_value = last_metrics
+    target_checks, accuracy_check = _audio_target_checks(
+        ctx, ttft_value, tsu_value, rtr_value
+    )
+
+    return Block(
+        kind="benchmarks",
+        task_type="audio",
+        title="Audio Benchmark",
+        id=block_id(ctx) or None,
+        targets={
+            "num_prompts": num_calls,
+            "streaming_enabled": is_streaming_enabled_for_whisper(ctx),
+            "preprocessing_enabled": is_preprocessing_enabled_for_whisper(ctx),
+            "sweep_sizes": ["30s", "60s"],
+        },
+        data={
+            "records": records,
+            "accuracy_check": accuracy_check,
+            "target_checks": target_checks,
+        },
+    )
+
+
 def run_audio_benchmark(ctx: MediaContext) -> Block:
     """Run benchmarks for an audio model (Whisper, etc.)."""
     logger.info(
@@ -278,6 +366,8 @@ def run_audio_benchmark(ctx: MediaContext) -> Block:
 
     try:
         num_calls = get_num_calls(ctx)
+        if _is_whisper(ctx):
+            return _run_whisper_benchmark_sweep(ctx, num_calls)
         status_list = _run_audio_transcription_benchmark(ctx, num_calls)
     except Exception as e:
         logger.error(f"Benchmark execution encountered an error: {e}")

--- a/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
@@ -328,15 +328,17 @@ def _run_whisper_lmms_eval(ctx: MediaContext) -> Block:
 
     score = 100.0 - wer
     published = task.score.published_score
-    tolerance = task.score.tolerance or 0.05
-    if published is not None:
-        ratio = score / published if published else 0.0
-        within_tolerance = abs(1.0 - ratio) <= tolerance
+    reference = getattr(task.score, "gpu_reference_score", None) or published
+    tolerance = task.score.tolerance if task.score.tolerance is not None else 0.05
+    if reference:
+        ratio = score / reference
         accuracy_check = (
-            ReportCheckTypes.PASS if within_tolerance else ReportCheckTypes.FAIL
+            ReportCheckTypes.PASS
+            if ratio >= (1.0 - tolerance)
+            else ReportCheckTypes.FAIL
         )
     else:
-        accuracy_check = ReportCheckTypes.PASS
+        accuracy_check = ReportCheckTypes.NA
 
     logger.info(
         "WhisperEvalTest WER=%.4f score=%.4f published=%s tolerance=%s check=%s",

--- a/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
@@ -52,7 +52,7 @@ async def _transcribe_audio_streaming_off(
     ctx: MediaContext, is_preprocessing_enabled: bool
 ) -> tuple[bool, float, Optional[float], Optional[float], Optional[float]]:
     logger.info("Transcribing audio without streaming")
-    with open(f"{ctx.test_payloads_path}/image_client_audio_payload", "r") as f:
+    with open(Path(ctx.test_payloads_path) / "image_client_audio_payload", "r") as f:
         audio_file = json.load(f)
 
     headers = {
@@ -108,7 +108,7 @@ async def _transcribe_audio_streaming_on(
     logger.info("Transcribing audio with streaming enabled")
 
     with open(
-        f"{ctx.test_payloads_path}/image_client_audio_streaming_payload", "r"
+        Path(ctx.test_payloads_path) / "image_client_audio_streaming_payload", "r"
     ) as f:
         audio_file = json.load(f)
 
@@ -182,11 +182,10 @@ async def _transcribe_audio_streaming_on(
 
                     elapsed = now - start_time
                     tokens_per_sec = total_tokens / elapsed if elapsed > 0 else 0
-                    tokens_per_user_per_sec = tokens_per_sec / 1
                     logger.info(
                         f"[{elapsed:.2f}s] chunk={chunk_id} chunk_tokens={chunk_tokens} "
                         f"total_tokens={total_tokens} tps={tokens_per_sec:.2f} "
-                        f"t/s/u={tokens_per_user_per_sec:.2f} text={text!r}"
+                        f"t/s/u={tokens_per_sec:.2f} text={text!r}"
                     )
 
         end_time = time.monotonic()
@@ -196,7 +195,7 @@ async def _transcribe_audio_streaming_on(
         final_tps = (
             final_tokens / content_streaming_time if content_streaming_time > 0 else 0
         )
-        final_tokens_per_user_per_sec = final_tps / 1
+        final_tokens_per_user_per_sec = final_tps
 
         rtr = None
         if audio_duration is not None:
@@ -228,7 +227,7 @@ async def _transcribe_audio(
 ) -> tuple[bool, float, Optional[float], Optional[float], Optional[float]]:
     logger.info("🔈 Calling whisper")
     is_preprocessing_enabled = is_preprocessing_enabled_for_whisper(ctx)
-    logging.info(f"Preprocessing enabled: {is_preprocessing_enabled}")
+    logger.info(f"Preprocessing enabled: {is_preprocessing_enabled}")
 
     if is_streaming_enabled_for_whisper(ctx):
         return await _transcribe_audio_streaming_on(ctx, is_preprocessing_enabled)

--- a/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
@@ -247,12 +247,138 @@ def _run_audio_transcription_benchmark(
     return status_list
 
 
+def _is_whisper(ctx: MediaContext) -> bool:
+    impl = getattr(ctx.model_spec, "impl", None)
+    return getattr(impl, "impl_name", None) == "whisper"
+
+
+def _run_whisper_lmms_eval(ctx: MediaContext) -> Block:
+    """Run the real lmms-eval librispeech_test_other WER eval via WhisperEvalTest."""
+    from .._test_common import TestConfig
+    from .whisper_eval_test import WhisperEvalTest
+
+    task = ctx.all_params.tasks[0]
+    timeout_s = 1800  # full LibriSpeech run on n150 is ~10 min; pad for safety
+
+    test = WhisperEvalTest(
+        config=TestConfig.create_default(timeout=timeout_s),
+        targets={},
+    )
+    test.hf_model_repo = ctx.model_spec.hf_model_repo
+    test.base_url = ctx.base_url
+    test.task_name = task.task_name
+    test.test_limit = None
+    test.debug_mode = False
+    test.mock_mode = False
+
+    logger.info(
+        "Invoking WhisperEvalTest (lmms-eval): task=%s base_url=%s hf_model_repo=%s",
+        test.task_name,
+        test.base_url,
+        test.hf_model_repo,
+    )
+
+    results = asyncio.run(
+        asyncio.wait_for(test._run_specific_test_async(), timeout=timeout_s)
+    )
+
+    wer = None
+    metrics = results.get("metrics") or {}
+    for key in (f"{task.task_name}_wer", "wer"):
+        val = metrics.get(key)
+        if isinstance(val, (int, float)):
+            wer = float(val)
+            break
+
+    if wer is None:
+        detailed = results.get("detailed_results") or {}
+        task_block = detailed.get(task.task_name) or {}
+        raw = task_block.get("wer,none")
+        if isinstance(raw, (int, float)):
+            wer = float(raw)
+
+    if wer is None:
+        logger.error(
+            "Could not parse WER from lmms-eval results; emitting FAIL block. "
+            "results keys=%s",
+            list(results.keys()),
+        )
+        return Block(
+            kind="evals",
+            task_type="audio",
+            title="Audio Eval",
+            id=block_id(ctx) or None,
+            targets={
+                "task_name": task.task_name,
+                "tolerance": task.score.tolerance,
+                "published_score": task.score.published_score,
+                "published_score_ref": task.score.published_score_ref,
+            },
+            data={
+                "task_name": task.task_name,
+                "tolerance": task.score.tolerance,
+                "published_score": task.score.published_score,
+                "score": None,
+                "published_score_ref": task.score.published_score_ref,
+                "accuracy_check": ReportCheckTypes.FAIL,
+                "wer": None,
+                "error": "WER not found in lmms-eval results",
+            },
+        )
+
+    score = 100.0 - wer
+    published = task.score.published_score
+    tolerance = task.score.tolerance or 0.05
+    if published is not None:
+        ratio = score / published if published else 0.0
+        within_tolerance = abs(1.0 - ratio) <= tolerance
+        accuracy_check = (
+            ReportCheckTypes.PASS if within_tolerance else ReportCheckTypes.FAIL
+        )
+    else:
+        accuracy_check = ReportCheckTypes.PASS
+
+    logger.info(
+        "WhisperEvalTest WER=%.4f score=%.4f published=%s tolerance=%s check=%s",
+        wer,
+        score,
+        published,
+        tolerance,
+        accuracy_check,
+    )
+
+    return Block(
+        kind="evals",
+        task_type="audio",
+        title="Audio Eval",
+        id=block_id(ctx) or None,
+        targets={
+            "task_name": task.task_name,
+            "tolerance": tolerance,
+            "published_score": published,
+            "published_score_ref": task.score.published_score_ref,
+        },
+        data={
+            "task_name": task.task_name,
+            "tolerance": tolerance,
+            "published_score": published,
+            "score": score,
+            "wer": wer,
+            "published_score_ref": task.score.published_score_ref,
+            "accuracy_check": accuracy_check,
+        },
+    )
+
+
 def run_audio_eval(ctx: MediaContext) -> Block:
     """Run evaluations for an audio model (Whisper, etc.)."""
     logger.info(
         f"Running evals for model: {ctx.model_spec.model_name} on device: {ctx.device.name}"
     )
     require_health(ctx)
+
+    if _is_whisper(ctx):
+        return _run_whisper_lmms_eval(ctx)
 
     try:
         num_calls = get_num_calls(ctx)

--- a/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Optional
 
 import aiohttp
-import requests
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 if str(_PROJECT_ROOT) not in sys.path:
@@ -49,7 +48,7 @@ def _audio_tsu(status_list: list[AudioTestStatus]) -> float:
     return sum(valid) / len(valid) if valid else 0
 
 
-def _transcribe_audio_streaming_off(
+async def _transcribe_audio_streaming_off(
     ctx: MediaContext, is_preprocessing_enabled: bool
 ) -> tuple[bool, float, Optional[float], Optional[float], Optional[float]]:
     logger.info("Transcribing audio without streaming")
@@ -68,20 +67,25 @@ def _transcribe_audio_streaming_off(
     }
 
     start_time = time.time()
-    response = requests.post(
-        f"{ctx.base_url}/v1/audio/transcriptions",
-        json=payload,
-        headers=headers,
-        timeout=90,
-    )
+    status_ok = False
+    response_data = None
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{ctx.base_url}/v1/audio/transcriptions",
+            json=payload,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=90),
+        ) as response:
+            status_ok = response.status == 200
+            if status_ok:
+                response_data = await response.json()
     elapsed = time.time() - start_time
     ttft = elapsed
     tsu = None
 
     rtr = None
-    if response.status_code == 200:
+    if status_ok and response_data is not None:
         try:
-            response_data = response.json()
             audio_duration = response_data.get("duration")
             if audio_duration is not None:
                 rtr = audio_duration / elapsed
@@ -94,7 +98,7 @@ def _transcribe_audio_streaming_off(
         except Exception as e:
             logger.error(f"Failed to calculate RTR: {e}")
 
-    return (response.status_code == 200), elapsed, ttft, tsu, rtr
+    return status_ok, elapsed, ttft, tsu, rtr
 
 
 async def _transcribe_audio_streaming_on(
@@ -229,7 +233,7 @@ async def _transcribe_audio(
     if is_streaming_enabled_for_whisper(ctx):
         return await _transcribe_audio_streaming_on(ctx, is_preprocessing_enabled)
 
-    return _transcribe_audio_streaming_off(ctx, is_preprocessing_enabled)
+    return await _transcribe_audio_streaming_off(ctx, is_preprocessing_enabled)
 
 
 def _run_audio_transcription_benchmark(


### PR DESCRIPTION
 Eval:
-  Before: placeholder transcribed 2 short clips, dumped ttft into the score field, `accuracy_check` was hardcoded 
-   After: for whisper, `run_audio_eval` now drives the existing `WhisperEvalTest `class -> runs lmms-eval on the full sample LibriSpeech test, parses real WER from results, sets score, and computes `accuracy_check`

  Benchmark:

-   Before: looped a single hardcoded 30s clip `num_calls `times → one row. 
- After: threaded an optional `audio_b64` through the transcription helpers, then for whisper runs the benchmark once with the 30s payload and once with the 60s payload from`  load_param_tests/test_payloads/ ` and emits one benchmarks block with a two-row records list 