### PR TITLE
fix(forge): populate usage block on /v1/completions

### DIFF
--- a/tt-media-server/open_ai_api/llm.py
+++ b/tt-media-server/open_ai_api/llm.py
@@ -56,7 +56,8 @@ async def complete_text(
 
     sub_requests = _split_batched_prompts(completion_request)
 
-    # Reject prompts that exceed the model's context window
+    # Compute prompt token counts (for context-window validation and usage stats).
+    prompt_tokens_total = 0
     try:
         max_model_len = settings.vllm.max_model_length
         for r in sub_requests:
@@ -67,6 +68,7 @@ async def complete_text(
                 prompt_tokens = len(p)
             else:
                 prompt_tokens = 0
+            prompt_tokens_total += prompt_tokens
             if prompt_tokens > max_model_len:
                 logger.warning(
                     f"Rejected prompt: length ({prompt_tokens}) exceeds max model length ({max_model_len})"
@@ -85,6 +87,7 @@ async def complete_text(
             results = await asyncio.gather(
                 *(service.process_request(r) for r in sub_requests)
             )
+            completion_tokens = sum(_count_tokens(r.text) for r in results if r.text)
             response = {
                 "id": completion_id,
                 "object": "text_completion",
@@ -100,9 +103,9 @@ async def complete_text(
                     for i, r in enumerate(results)
                 ],
                 "usage": {
-                    "prompt_tokens": 0,
-                    "completion_tokens": 0,
-                    "total_tokens": 0,
+                    "prompt_tokens": prompt_tokens_total,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens_total + completion_tokens,
                 },
             }
             return JSONResponse(content=response)


### PR DESCRIPTION
### Issue

Closes #3552 

### Problem

- `tt-media-server/open_ai_api/llm.py:102-106` returned a `usage` block with `prompt_tokens`, `completion_tokens`, and `total_tokens` hardcoded to `0` on non-streaming responses. Regression since commit `2c3186e8` (2025-12-29, "Inline methods") which inlined helper functions but dropped the token-counting variables in the process. Sibling `/v1/chat/completions` computes these correctly using the same `_count_tokens()` helper, which is already imported into `llm.py` for the schema-fix's context-window validation.

### What's changed

`tt-media-server/open_ai_api/llm.py`:

- Accumulate `prompt_tokens_total` during the existing context-window validation loop (one extra line — no second pass over `sub_requests`, no new tokenizer calls).
- After `asyncio.gather`, compute `completion_tokens = sum(_count_tokens(r.text) for r in results if r.text)`. Single line; tokenizer is `lru_cache(maxsize=1)`'d (`chat.py:25`) so per-result calls are cheap.
- Populate `usage` block with real values instead of literal zeros.

Streaming path unchanged (no `usage` block today; not added here — separate scope, would need `stream_options.include_usage` plumbing and a final SSE chunk).

### Testing

Local curl against a forge Llama-3.2-3B-Instruct server with the patched `llm.py` bind-mounted:

```bash
curl -s -X POST http://localhost:8103/v1/completions \
  -H 'Authorization: Bearer your-secret-key' -H 'Content-Type: application/json' \
  -d '{"model":"meta-llama/Llama-3.2-3B-Instruct","prompt":"Explain the theory of relativity briefly.","max_tokens":128}' \
  | python3 -c 'import json,sys; print(json.load(sys.stdin)["usage"])'
  
  {'prompt_tokens': 10, 'completion_tokens': 126, 'total_tokens': 136} // Previously all zero
```

