### PR TITLE
fix(forge): make concurrency reachable via run.py and --vllm-override-args + set batch2 for Llama-3.2-3B-Instruct

### DIFF
--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -205,6 +205,15 @@ class Settings(BaseSettings):
             )
             self.max_batch_size = self.vllm.max_num_seqs
 
+        # Without this the scheduler picks the serial device_worker even though
+        # max_num_seqs > 1 advertises concurrent capacity; explicit env still wins.
+        if self.vllm.max_num_seqs > 1 and os.getenv("USE_DYNAMIC_BATCHER") is None:
+            logger.info(
+                f"Auto-enabling use_dynamic_batcher because max_num_seqs={self.vllm.max_num_seqs} > 1 "
+                f"(set USE_DYNAMIC_BATCHER=false to override)"
+            )
+            self.use_dynamic_batcher = True
+
     def _set_device_pairs_overrides(self) -> None:
         logger.info(
             f"_set_device_pairs_overrides: is_galaxy={self.is_galaxy}, "

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -3676,6 +3676,7 @@ cnn_templates = [
                     "VLLM__MAX_NUM_BATCHED_TOKENS": "4096",
                     "VLLM__MAX_MODEL_LENGTH": "4096",
                     "VLLM__MIN_MODEL_LENGTH": "32",
+                    "MAX_NUM_SEQS": "2",
                 },
             ),
             DeviceModelSpec(
@@ -3687,6 +3688,7 @@ cnn_templates = [
                     "VLLM__MAX_NUM_BATCHED_TOKENS": "4096",
                     "VLLM__MAX_MODEL_LENGTH": "4096",
                     "VLLM__MIN_MODEL_LENGTH": "32",
+                    "MAX_NUM_SEQS": "2",
                 },
             ),
         ],

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -801,6 +801,22 @@ class ModelSpec:
 
             object.__setattr__(self.device_model_spec, "vllm_args", merged_vllm_args)
 
+            # Mirror overridden vllm_args into env_vars so forge/media containers,
+            # which read bare env vars (not vllm CLI args), pick up the override.
+            VLLM_ARG_TO_ENV = {
+                "max_num_seqs": "MAX_NUM_SEQS",
+                "max_model_len": "MAX_MODEL_LENGTH",
+            }
+            overridden_env = {
+                env_key: str(vllm_override_args_from_cli[vllm_key])
+                for vllm_key, env_key in VLLM_ARG_TO_ENV.items()
+                if vllm_override_args_from_cli.get(vllm_key) is not None
+            }
+            if overridden_env:
+                object.__setattr__(
+                    self, "env_vars", {**self.env_vars, **overridden_env}
+                )
+
         if runtime_config.service_port:
             merged_vllm_args = {
                 **self.device_model_spec.vllm_args,

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -430,12 +430,19 @@ class ModelSpec:
     cli_args: Dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self):
-        default_env_vars = {
-            "VLLM_CONFIGURE_LOGGING": "1",
-            "VLLM_RPC_TIMEOUT": "900000",
-            "VLLM_TARGET_DEVICE": "tt",
-            "TORCHDYNAMO_DISABLE": "1",
-        }
+        # Skipped for forge/media: Forge vLLM relies on torch.compile/dynamo for its compilation pipeline; TORCHDYNAMO_DISABLE=1 breaks warmup.
+        if self.inference_engine in (
+            InferenceEngine.FORGE.value,
+            InferenceEngine.MEDIA.value,
+        ):
+            default_env_vars = {}
+        else:
+            default_env_vars = {
+                "VLLM_CONFIGURE_LOGGING": "1",
+                "VLLM_RPC_TIMEOUT": "900000",
+                "VLLM_TARGET_DEVICE": "tt",
+                "TORCHDYNAMO_DISABLE": "1",
+            }
         # order of precedence: default, env_vars, device_model_spec
         merged_env_vars = {
             **default_env_vars,

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -231,6 +231,10 @@ def generate_docker_run_command(
         model_spec.inference_engine == InferenceEngine.FORGE.value
         or model_spec.inference_engine == InferenceEngine.MEDIA.value
     ):
+        # Propagate ModelSpec.env_vars (defaults + template + device-specific)
+        # to the container so per-model declarations like MAX_NUM_SEQS take
+        # effect. Runtime-derived values below override these.
+        docker_env_vars.update({k: str(v) for k, v in model_spec.env_vars.items()})
         docker_env_vars.update(get_media_server_docker_env_vars(model_spec))
         api_key = os.getenv("API_KEY")
         if api_key:


### PR DESCRIPTION
### Issue

Closes #3556

### Problem

Configuring `max_num_seqs > 1` for a forge LLM is silently a no-op via the standard `run.py` flow. Two parallel requests always serialize. Four gaps stack (per the linked issue):

- `tt-media-server/config/settings.py`: `use_dynamic_batcher` defaults False → scheduler picks serial worker even when `max_num_seqs > 1`.
- `workflows/run_docker_server.py`: `model_spec.env_vars` is never propagated to the container for forge/media engines.
- `workflows/model_spec.py`: vllm-tt-only defaults (`TORCHDYNAMO_DISABLE` etc.) injected unconditionally; leak into forge containers and crash warmup.
- `workflows/model_spec.py`: `--vllm-override-args` updates `vllm_args` but never reaches the container env on forge/media.

### What's changed

Four commits in this PR:

1. `settings.py` — auto-enable `use_dynamic_batcher` when `max_num_seqs > 1`.
2. `run_docker_server.py` + `model_spec.py` — propagate `model_spec.env_vars` to forge/media containers; gate vllm-tt-only `default_env_vars` to non-forge engines.
3. `model_spec.py` — bridge `--vllm-override-args` keys (`max_num_seqs` → `MAX_NUM_SEQS`, `max_model_len` → `MAX_MODEL_LENGTH`) into `env_vars`.
4. `model_spec.py` — set `MAX_NUM_SEQS=2` as the default for Llama-3.2-3B-Instruct (N150, N300).

After: `python3 run.py --model Llama-3.2-3B-Instruct ...` delivers 2-concurrent execution by default. Other forge LLMs (Qwen3-4B, Llama-3.1-8B-Instruct, Qwen3-8B, Falcon3-7B-Instruct) keep their `max_num_seqs=1` default and can opt-in per-invocation via `--vllm-override-args '{"max_num_seqs": N}'` pending per-model validation on real N150/N300.

### Testing

- Two parallel curls against Llama-3.2-3B-Instruct: **1.37s identical wall-clock** (was 2.1s serialized pre-fix).
- Single-request throughput at batch=2: **~28.4 tok/s** vs the batch=1 baseline of ~30 tok/s (~5% regression — acceptable for the 2x aggregate win on batched workloads).
- `--vllm-override-args '{"max_num_seqs": N}'` for N=1/2/4 each reaches the container as `MAX_NUM_SEQS=N`.

Detailed timings, server-log evidence, and bridge verification in the follow-up comment below.