### PR TITLE
Refactor Driver and Parser into Tightly Coupled Components

### DIFF
--- a/tt-inference-server-v2/llm_module/__init__.py
+++ b/tt-inference-server-v2/llm_module/__init__.py
@@ -12,14 +12,6 @@ from .drivers import (
     LLMDriver,
     VLLMBenchDriver,
 )
-from .parsers import (
-    AIPerfParser,
-    GenAIPerfParser,
-    GuideLLMParser,
-    InferenceMaxParser,
-    LLMResultParser,
-    VLLMBenchParser,
-)
 from .runner import LLMPerformanceRunner, RunnerResult
 from .server_control import ServerController
 
@@ -34,12 +26,6 @@ __all__ = [
     "GuideLLMDriver",
     "InferenceMaxDriver",
     "VLLMBenchDriver",
-    "LLMResultParser",
-    "AIPerfParser",
-    "GenAIPerfParser",
-    "GuideLLMParser",
-    "InferenceMaxParser",
-    "VLLMBenchParser",
     "LLMPerformanceRunner",
     "RunnerResult",
     "ServerController",

--- a/tt-inference-server-v2/llm_module/drivers/aiperf.py
+++ b/tt-inference-server-v2/llm_module/drivers/aiperf.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Optional
 
 from ..config import DriverContext, LLMRunConfig, ServerConnection
+from ..parsers.aiperf import AIPerfParser
 from ._subprocess import find_first, load_json, run_command
 from .base import DriverResult, LLMDriver
 
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 class AIPerfDriver(LLMDriver):
     name = "aiperf"
+    _parser = AIPerfParser()
 
     def __init__(self, venv_python: Optional[Path] = None) -> None:
         self.venv_python = Path(venv_python) if venv_python else Path(sys.executable)

--- a/tt-inference-server-v2/llm_module/drivers/base.py
+++ b/tt-inference-server-v2/llm_module/drivers/base.py
@@ -2,13 +2,14 @@
 #
 # SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
 
-"""Driver interface: launch one perf-tool run and return its raw output.
+"""Driver interface: launch one perf-tool run and parse its output.
 
 A driver is fully self-contained: it knows how to set up its own venv
 or Docker container, build the command line for one ``LLMRunConfig``
-sweep point against a given ``ServerConnection``, run it, and return
-the raw result file as a parsed dict (preferred) plus the path on disk.
-Drivers do **not** call parsers — the runner orchestrates that.
+sweep point against a given ``ServerConnection``, run it, and adapt
+the resulting JSON into a report ``Block``. Each concrete driver binds
+to its matching parser via the ``_parser`` class attribute, so the
+(command-build, execute, parse) trio is selected as one unit.
 """
 
 from __future__ import annotations
@@ -16,16 +17,19 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional
+
+from report_module.schema import Block
 
 from ..config import DriverContext, LLMRunConfig, ServerConnection
+from ..parsers.base import LLMResultParser
 
 
 @dataclass(frozen=True)
 class DriverResult:
     """One driver run's outcome.
 
-    ``raw`` is the parsed result dict (what parsers consume). ``raw_path``
+    ``raw`` is the parsed result dict (what ``parse`` consumes). ``raw_path``
     is the on-disk JSON the driver produced. ``return_code`` is the
     exit status of the underlying tool process; non-zero means the
     runner should skip parsing and surface the failure.
@@ -37,9 +41,10 @@ class DriverResult:
 
 
 class LLMDriver(ABC):
-    """One LLM perf tool's runner half (command-build + execute)."""
+    """One LLM perf tool's full adapter: command-build, execute, parse."""
 
     name: str
+    _parser: LLMResultParser
 
     @abstractmethod
     def run(
@@ -49,3 +54,6 @@ class LLMDriver(ABC):
         context: DriverContext,
     ) -> DriverResult:
         """Run the tool for one sweep point and return the raw result."""
+
+    def parse(self, raw: Mapping[str, Any], *, device: str = "") -> Block:
+        return self._parser.parse(raw, device=device)

--- a/tt-inference-server-v2/llm_module/drivers/genai_perf.py
+++ b/tt-inference-server-v2/llm_module/drivers/genai_perf.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Optional
 
 from ..config import DriverContext, LLMRunConfig, ServerConnection
+from ..parsers.genai_perf import GenAIPerfParser
 from ._subprocess import find_first, load_json, run_command
 from .base import DriverResult, LLMDriver
 
@@ -31,6 +32,7 @@ DEFAULT_RELEASE = "25.11"
 
 class GenAIPerfDriver(LLMDriver):
     name = "genai_perf"
+    _parser = GenAIPerfParser()
 
     def __init__(
         self,

--- a/tt-inference-server-v2/llm_module/drivers/guidellm.py
+++ b/tt-inference-server-v2/llm_module/drivers/guidellm.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Optional
 
 from ..config import DriverContext, LLMRunConfig, ServerConnection
+from ..parsers.guidellm import GuideLLMParser
 from ._subprocess import load_json, run_command, safe_filename_part
 from .base import DriverResult, LLMDriver
 
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 class GuideLLMDriver(LLMDriver):
     name = "guidellm"
+    _parser = GuideLLMParser()
 
     def __init__(
         self,

--- a/tt-inference-server-v2/llm_module/drivers/inferencex.py
+++ b/tt-inference-server-v2/llm_module/drivers/inferencex.py
@@ -2,15 +2,7 @@
 #
 # SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
 
-"""InferenceMax driver.
-
-No v1 reference — fresh runner that invokes
-``benchmark_serving.py`` from an InferenceMax checkout. The script
-path is configurable so callers can point at their local clone.
-The result file matches v1 ``vllm bench serve``'s flat shape (the
-InferenceMax fork is descended from it), parsed by
-:class:`llm_module.parsers.InferenceMaxParser`.
-"""
+"""InferenceMax driver."""
 
 from __future__ import annotations
 
@@ -21,6 +13,7 @@ from pathlib import Path
 from typing import Optional
 
 from ..config import DriverContext, LLMRunConfig, ServerConnection
+from ..parsers.inferencex import InferenceMaxParser
 from ._subprocess import load_json, run_command, safe_filename_part
 from .base import DriverResult, LLMDriver
 
@@ -29,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 class InferenceMaxDriver(LLMDriver):
     name = "inferencex"
+    _parser = InferenceMaxParser()
 
     def __init__(
         self,

--- a/tt-inference-server-v2/llm_module/drivers/vllm.py
+++ b/tt-inference-server-v2/llm_module/drivers/vllm.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from typing import Optional
 
 from ..config import DriverContext, LLMRunConfig, ServerConnection
+from ..parsers.vllm import VLLMBenchParser
 from ._subprocess import load_json, run_command, safe_filename_part
 from .base import DriverResult, LLMDriver
 
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 class VLLMBenchDriver(LLMDriver):
     name = "vllm"
+    _parser = VLLMBenchParser()
 
     def __init__(self, vllm_binary: Optional[str] = None) -> None:
         self.vllm_binary = vllm_binary or shutil.which("vllm") or "vllm"

--- a/tt-inference-server-v2/llm_module/parsers/__init__.py
+++ b/tt-inference-server-v2/llm_module/parsers/__init__.py
@@ -2,18 +2,6 @@
 #
 # SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
 
-from .aiperf import AIPerfParser
 from .base import LLMResultParser
-from .genai_perf import GenAIPerfParser
-from .guidellm import GuideLLMParser
-from .inferencex import InferenceMaxParser
-from .vllm import VLLMBenchParser
 
-__all__ = [
-    "LLMResultParser",
-    "AIPerfParser",
-    "GenAIPerfParser",
-    "GuideLLMParser",
-    "InferenceMaxParser",
-    "VLLMBenchParser",
-]
+__all__ = ["LLMResultParser"]

--- a/tt-inference-server-v2/llm_module/runner.py
+++ b/tt-inference-server-v2/llm_module/runner.py
@@ -9,7 +9,7 @@ Mirrors v1 ``benchmarking/run_benchmarks.py`` orchestration:
 1. ``server.wait_for_healthy()`` — block until the inference server is up.
 2. ``server.capture_traces(unique (isl,osl) pairs)`` — warm trace cache.
 3. For each ``LLMRunConfig`` in the sweep: health-check, sleep 2 s,
-   ``driver.run()``, ``parser.parse(raw)`` → ``Block``.
+   ``driver.run()``, ``driver.parse(raw)`` → ``Block``.
 
 Returns the list of Blocks plus any nonzero driver exit codes the
 caller should surface.
@@ -28,7 +28,6 @@ from report_module.schema import Block
 
 from .config import DriverContext, LLMRunConfig, ServerConnection
 from .drivers.base import LLMDriver
-from .parsers.base import LLMResultParser
 from .server_control import ServerController
 
 logger = logging.getLogger(__name__)
@@ -55,7 +54,6 @@ class LLMPerformanceRunner:
     def __init__(
         self,
         driver: LLMDriver,
-        parser: LLMResultParser,
         server_controller: Optional[ServerController] = None,
         *,
         inter_run_sleep_s: float = 2.0,
@@ -63,7 +61,6 @@ class LLMPerformanceRunner:
         wait_healthy_timeout_s: float = 1200.0,
     ) -> None:
         self.driver = driver
-        self.parser = parser
         self.server_controller = server_controller
         self.inter_run_sleep_s = inter_run_sleep_s
         self.capture_trace_timeout_s = capture_trace_timeout_s
@@ -151,7 +148,7 @@ class LLMPerformanceRunner:
                 result.parse_failures.append(i)
                 continue
 
-            block = self.parser.parse(outcome.raw, device=context.device)
+            block = self.driver.parse(outcome.raw, device=context.device)
             result.blocks.append(block)
 
         return result

--- a/tt-inference-server-v2/test_module/llm_tests/llm_performance_tests.py
+++ b/tt-inference-server-v2/test_module/llm_tests/llm_performance_tests.py
@@ -5,13 +5,14 @@
 """LLM performance test caller.
 
 Bridges ``test_module`` to ``llm_module``: builds an
-``LLMPerformanceRunner`` from a (driver, parser, server_controller)
-triple, executes the sweep defined by ``configs``, and forwards the
-resulting ``list[Block]`` to ``workflow_module`` for downstream
-processing (report rendering, artifact upload, etc.).
+``LLMPerformanceRunner`` from a (driver, server_controller) pair,
+executes the sweep defined by ``configs``, and forwards the resulting
+``list[Block]`` to ``workflow_module`` for downstream processing
+(report rendering, artifact upload, etc.). The driver carries its own
+parser, so command-build, execute, and parse stay selected as one unit.
 
 The caller is the only place in test_module that knows about
-llm_module's internals; everything else (drivers, parsers, runner
+llm_module's internals; everything else (drivers, runner
 orchestration) stays inside llm_module.
 """
 
@@ -26,7 +27,6 @@ from llm_module import (
     DriverContext,
     LLMDriver,
     LLMPerformanceRunner,
-    LLMResultParser,
     LLMRunConfig,
     ServerConnection,
     ServerController,
@@ -43,7 +43,6 @@ def run_llm_performance(
     ctx: MediaContext,
     *,
     driver: LLMDriver,
-    parser: LLMResultParser,
     configs: Sequence[LLMRunConfig],
     server_controller: Optional[ServerController] = None,
     output_subdir: str = "llm",
@@ -66,7 +65,6 @@ def run_llm_performance(
 
     runner = LLMPerformanceRunner(
         driver=driver,
-        parser=parser,
         server_controller=server_controller,
     )
     result = runner.run(configs, server, context)


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-inference-server/issues/3312?issue=tenstorrent%7Ctt-inference-server%7C3489

As noted on [#3352](https://github.com/tenstorrent/tt-inference-server/pull/3352#discussion_r3220524003), parsing is intrinsically linked to driver execution: the parser must match the exact JSON shape the driver produces. With the previous (driver, parser) split, callers had to pick both, and a mismatch (e.g. `VLLMBenchDriver` + `AIPerfParser`) type-checked fine and only failed at parse time — after the run had already consumed device time. Coupling them at the class level (not by file -> Parser modules stay split from driver modules for readability )removes that.

```
  # before
  runner = LLMPerformanceRunner(driver=VLLMBenchDriver(), parser=VLLMBenchParser(), server_controller=...)

  # after
  runner = LLMPerformanceRunner(driver=VLLMBenchDriver(), server_controller=...)
```
.