### PR TITLE
Bump CMake Version

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.24)
 project(tt_media_server_cpp CXX)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/tt-media-server/cpp_server/README.md
+++ b/tt-media-server/cpp_server/README.md
@@ -872,7 +872,7 @@ With `LLM_DEVICE_BACKEND=mock`, the stub runner can be used to benchmark server 
 
 ### Prerequisites
 
-1. **CMake** >= 3.19
+1. **CMake** >= 3.24
 2. **Drogon Framework** >= 1.8
 3. **C++20 compatible compiler** (GCC 10+, Clang 12+)
 4. **Boost** (headers; used for Boost.Interprocess in the LLM engine IPC queue).
@@ -1021,7 +1021,7 @@ To compare with the Python server:
   ```
 2. **CMake too old:**
   ```bash
-   cmake --version  # Need 3.19+
+  cmake --version  # Need 3.24+
   ```
 
 ### Server crashes

--- a/tt-media-server/cpp_server/install_dependencies.sh
+++ b/tt-media-server/cpp_server/install_dependencies.sh
@@ -32,7 +32,7 @@ SUDO=""
 [ "$(id -u)" -ne 0 ] && SUDO="sudo"
 
 APT_PKGS=(
-    build-essential cmake g++ pkg-config curl git wget
+    build-essential g++ pkg-config curl git wget
     libjsoncpp-dev uuid-dev zlib1g-dev libssl-dev libboost-all-dev
 )
 if [ "${INSTALL_KAFKA}" = 1 ]; then
@@ -42,6 +42,8 @@ fi
 
 $SUDO apt-get update -qq
 $SUDO apt-get install -y --no-install-recommends "${APT_PKGS[@]}"
+# CMakeLists.txt requires >= 3.24; Ubuntu 22.04 apt ships 3.22, so always pull Kitware's binary.
+curl -fsSL "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-linux-$(uname -m).sh" -o /tmp/cmake.sh && $SUDO sh /tmp/cmake.sh --prefix=/usr/local --skip-license --exclude-subdir && rm -f /tmp/cmake.sh
 if ! command -v clang-format-20 >/dev/null 2>&1; then
     LLVM_SH="/tmp/llvm.sh"
     curl -sSL -o "${LLVM_SH}" https://apt.llvm.org/llvm.sh


### PR DESCRIPTION
## Issue 
A dependency project used by the inference server required a newer CMake version due to its recursive dependencies, which resulted in the following CI issues:
```
CMake Error at tt-llm-engine/CMakeLists.txt:1 (cmake_minimum_required):
  CMake 3.24 or higher is required.  You are running version 3.22.1
```

## Implementation 
Bump CMake version to 3.24.