### PR TITLE
fix(forge): accept list-form content on /v1/chat/completions (fixes benchmark workflow)

### DIFF
--- a/tt-media-server/domain/chat_completion_request.py
+++ b/tt-media-server/domain/chat_completion_request.py
@@ -7,11 +7,22 @@ from typing import Union
 from pydantic import BaseModel
 
 
+class ChatContentPart(BaseModel):
+    """A single content part. Per OpenAI spec chat message content can be a
+    string OR a list of these parts (multi-modal inputs). For text-only LLMs
+    we consume only `type=="text"` parts; other types are accepted but ignored."""
+
+    type: str
+    text: str | None = None
+
+
 class ChatMessage(BaseModel):
     """A single message in a chat conversation."""
 
     role: str
-    content: str
+    # Per OpenAI spec, content can be a string OR a list of content parts.
+    # vllm bench / openai-python / lm-eval all send the list form by default.
+    content: str | list[ChatContentPart]
 
 
 class ChatCompletionRequest(BaseModel):

--- a/tt-media-server/open_ai_api/chat.py
+++ b/tt-media-server/open_ai_api/chat.py
@@ -39,6 +39,18 @@ def _apply_chat_template(messages: list[dict]) -> str:
     )
 
 
+def _normalize_message_content(content) -> str:
+    """Per OpenAI spec, chat message content is `str | list[ChatContentPart]`.
+    For text-only models, flatten the list form by joining text-type parts."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            p.text for p in content if getattr(p, "type", None) == "text" and p.text
+        )
+    return ""
+
+
 def _count_tokens(text: str) -> int:
     tokenizer = _get_tokenizer()
     return len(tokenizer.encode(text))
@@ -87,7 +99,10 @@ async def chat_completions(
     )
 
     # Convert chat messages to a prompt using the model's chat template
-    messages = [{"role": m.role, "content": m.content} for m in chat_request.messages]
+    messages = [
+        {"role": m.role, "content": _normalize_message_content(m.content)}
+        for m in chat_request.messages
+    ]
     prompt = _apply_chat_template(messages)
     prompt_tokens = _count_tokens(prompt)
 


### PR DESCRIPTION
### Issue

Closes #3577

### Problem

`tt-media-server/domain/chat_completion_request.py` types `ChatMessage.content: str`. Per OpenAI spec, content can be a string or a list of content parts. `vllm bench serve --backend openai-chat`, openai-python, and lm-eval-harness all send the list form by default — even for text-only datasets. Forge containers respond with HTTP 422, blocking every forge-LLM benchmark via `--workflow benchmarks`.

Same shape as #3532 (the `/v1/completions` schema fix) — chat endpoint was explicitly out of scope there. This PR is the chat-side companion.

### What's changed

- **`tt-media-server/domain/chat_completion_request.py`** — add `ChatContentPart` model (`type: str`, `text: str | None`). Expand `ChatMessage.content` union to `str | list[ChatContentPart]`.
- **`tt-media-server/open_ai_api/chat.py`** — add `_normalize_message_content()` helper. Convert list-form content to plain string by joining text from `type=="text"` parts. Other part types (image_url etc.) accepted but ignored on text-only LLMs.

~10 lines total. No downstream changes — `_apply_chat_template` already takes string content.

### Testing

- All 4 currently-released forge LLMs (Llama-3.2-3B-Instruct, Qwen3-4B, Qwen3-8B, Falcon3-7B-Instruct) verified locally on a fresh tt-shield-built image with this commit baked in (no bind-mount patches):
  - String-form content (existing behavior): still 200, unchanged.
  - List-form content (the fix): now 200 (was 422 with `string_type` error on `body.messages.0.content`).
- **Smoke benchmark via `python3 run.py --workflow benchmarks --limit-samples-mode smoke-test` runs end-to-end on all 4** (was blocked at the first `vllm bench serve` call before this fix). 7+ vllm-bench benchmarks per model now complete cleanly.

### Smoke benchmark numbers after the fix (P150 host, --tt-device n150)

Each model's smoke run produced ~7 benchmarks across ISL/OSL/concurrency combos. Headline numbers (ISL=128 OSL=128 Conc=1 — the baseline) using a few models had on hand:

| Model | TTFT (ms) | Tput User (TPS) | Tput Decode @ Conc=2 (TPS) | Smoke runtime |
|---|---|---|---|---|
| Llama-3.2-3B-Instruct | 97.3  | 29.29 | **58.5** (~2× scaling) | 106s |
| Qwen3-4B              | 133.6 | 24.10 | **42.1** (~1.7×)        | 77s  |
| Qwen3-8B              | 186.6 | 17.59 | **31.7** (~1.8×)        | 132s |
| Falcon3-7B-Instruct   | 171.5 | 16.04 | **31.9** (~2×)          | 44s  (includes ISL=16/OSL=4 fallback row) |

All four runs completed cleanly. Acceptance criteria reports "FAIL" only at the informational `Complete`/`Target` perf-tier thresholds (P150 host vs N150-target expectations) — model status is EXPERIMENTAL with no enforced tiers, so this is informational not actionable.

Concurrency=2 results (Tput Decode column) show the expected ~1.7–2× scaling vs single-stream, end-to-end validation that the recently-merged concurrency PR works at scale on real benchmark workloads.

