### PR TITLE
Add Wan2.2 I2V experimental model runners: AniSora, Distill, LoRA

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -21,6 +21,9 @@ class SupportedModels(Enum):
     WAN_2_2 = "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
     WAN_2_2_I2V = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
     WAN_2_2_I2V_PRODIA = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+    WAN_2_2_I2V_ANISORA = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+    WAN_2_2_I2V_DISTILL = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+    WAN_2_2_I2V_LORA = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
     DISTIL_WHISPER_LARGE_V3 = "distil-whisper/distil-large-v3"
     OPENAI_WHISPER_LARGE_V3 = "openai/whisper-large-v3"
     PYANNOTE_SPEAKER_DIARIZATION = "pyannote/speaker-diarization-3.0"
@@ -59,6 +62,9 @@ class ModelNames(Enum):
     WAN_2_2 = "Wan2.2-T2V-A14B-Diffusers"
     WAN_2_2_I2V = "Wan2.2-I2V-A14B-Diffusers"
     WAN_2_2_I2V_PRODIA = "Wan2.2-I2V-A14B-Prodia"
+    WAN_2_2_I2V_ANISORA = "Wan2.2-I2V-AniSora-V3.2"
+    WAN_2_2_I2V_DISTILL = "Wan2.2-I2V-Distill-LightX2V"
+    WAN_2_2_I2V_LORA = "Wan2.2-I2V-LoRA"
     DISTIL_WHISPER_LARGE_V3 = "distil-large-v3"
     OPENAI_WHISPER_LARGE_V3 = "whisper-large-v3"
     MICROSOFT_RESNET_50 = "resnet-50"
@@ -101,6 +107,9 @@ class ModelRunners(Enum):
     TT_WAN_2_2 = "tt-wan2.2"
     TT_WAN_2_2_I2V = "tt-wan2.2-i2v"
     TT_WAN_2_2_I2V_PRODIA = "tt-wan2.2-i2v-prodia"
+    TT_WAN_2_2_I2V_ANISORA = "tt-wan2.2-i2v-anisora"
+    TT_WAN_2_2_I2V_DISTILL = "tt-wan2.2-i2v-distill"
+    TT_WAN_2_2_I2V_LORA = "tt-wan2.2-i2v-lora"
     TT_WHISPER = "tt-whisper"
     VLLMForge = "vllm_forge"
     TT_YOLOV4 = "tt-yolov4"
@@ -186,6 +195,9 @@ MODEL_SERVICE_RUNNER_MAP = {
         ModelRunners.TT_WAN_2_2,
         ModelRunners.TT_WAN_2_2_I2V,
         ModelRunners.TT_WAN_2_2_I2V_PRODIA,
+        ModelRunners.TT_WAN_2_2_I2V_ANISORA,
+        ModelRunners.TT_WAN_2_2_I2V_DISTILL,
+        ModelRunners.TT_WAN_2_2_I2V_LORA,
         ModelRunners.SP_RUNNER,
     },
     ModelServices.TRAINING: {
@@ -212,6 +224,9 @@ INFERENCE_MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.TT_WAN_2_2: {ModelNames.WAN_2_2},
     ModelRunners.TT_WAN_2_2_I2V: {ModelNames.WAN_2_2_I2V},
     ModelRunners.TT_WAN_2_2_I2V_PRODIA: {ModelNames.WAN_2_2_I2V_PRODIA},
+    ModelRunners.TT_WAN_2_2_I2V_ANISORA: {ModelNames.WAN_2_2_I2V_ANISORA},
+    ModelRunners.TT_WAN_2_2_I2V_DISTILL: {ModelNames.WAN_2_2_I2V_DISTILL},
+    ModelRunners.TT_WAN_2_2_I2V_LORA: {ModelNames.WAN_2_2_I2V_LORA},
     ModelRunners.SP_RUNNER: {
         ModelNames.WAN_2_2,
         ModelNames.WAN_2_2_I2V,
@@ -865,6 +880,27 @@ ModelConfigs = {
         "max_batch_size": 1,
         "request_processing_timeout_seconds": 5000,
         "num_inference_steps": 3,
+    },
+    (ModelRunners.TT_WAN_2_2_I2V_ANISORA, DeviceTypes.BLACKHOLE_GALAXY): {
+        "device_mesh_shape": (4, 8),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_32_GROUP.value,
+        "max_batch_size": 1,
+        "request_processing_timeout_seconds": 5000,
+    },
+    (ModelRunners.TT_WAN_2_2_I2V_DISTILL, DeviceTypes.BLACKHOLE_GALAXY): {
+        "device_mesh_shape": (4, 8),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_32_GROUP.value,
+        "max_batch_size": 1,
+        "request_processing_timeout_seconds": 5000,
+    },
+    (ModelRunners.TT_WAN_2_2_I2V_LORA, DeviceTypes.BLACKHOLE_GALAXY): {
+        "device_mesh_shape": (4, 8),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_32_GROUP.value,
+        "max_batch_size": 1,
+        "request_processing_timeout_seconds": 5000,
     },
     (ModelRunners.SP_RUNNER, DeviceTypes.N150): {
         "device_mesh_shape": (1, 1),

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -281,6 +281,9 @@ class Settings(BaseSettings):
             ModelRunners.TT_WAN_2_2.value,
             ModelRunners.TT_WAN_2_2_I2V.value,
             ModelRunners.TT_WAN_2_2_I2V_PRODIA.value,
+            ModelRunners.TT_WAN_2_2_I2V_ANISORA.value,
+            ModelRunners.TT_WAN_2_2_I2V_DISTILL.value,
+            ModelRunners.TT_WAN_2_2_I2V_LORA.value,
         ]:
             self.default_throttle_level = None
 

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -707,7 +707,9 @@ class TTWan22I2VAniSoraRunner(TTDiTRunner):
         self.logger.debug(f"Device {self.device_id}: Running AniSora inference")
         request = requests[0]
         pipeline_args = _wan22_pipeline_args(
-            request, self.resolution, image_prompt=self._build_image_prompt(request),
+            request,
+            self.resolution,
+            image_prompt=self._build_image_prompt(request),
         )
         frames = self.pipeline(**pipeline_args)
         self.logger.debug(f"Device {self.device_id}: AniSora inference completed")
@@ -847,7 +849,9 @@ class TTWan22I2VLoRARunner(TTDiTRunner):
         self.logger.debug(f"Device {self.device_id}: Running LoRA inference")
         request = requests[0]
         pipeline_args = _wan22_pipeline_args(
-            request, self.resolution, image_prompt=self._build_image_prompt(request),
+            request,
+            self.resolution,
+            image_prompt=self._build_image_prompt(request),
         )
         frames = self.pipeline(**pipeline_args)
         self.logger.debug(f"Device {self.device_id}: LoRA inference completed")

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -52,6 +52,9 @@ dit_runner_log_map = {
     ModelRunners.TT_WAN_2_2.value: "Wan22",
     ModelRunners.TT_WAN_2_2_I2V.value: "Wan22-I2V",
     ModelRunners.TT_WAN_2_2_I2V_PRODIA.value: "Wan22-I2V-Prodia",
+    ModelRunners.TT_WAN_2_2_I2V_ANISORA.value: "Wan22-I2V-AniSora",
+    ModelRunners.TT_WAN_2_2_I2V_DISTILL.value: "Wan22-I2V-Distill",
+    ModelRunners.TT_WAN_2_2_I2V_LORA.value: "Wan22-I2V-LoRA",
     ModelRunners.TT_QWEN_IMAGE.value: "Qwen-Image",
     ModelRunners.TT_QWEN_IMAGE_2512.value: "Qwen-Image-2512",
     ModelRunners.SP_RUNNER.value: "SP-Runner",
@@ -636,3 +639,222 @@ class TTWan22I2VRunner(TTDiTRunner):
             num_inference_steps=2,
             image_prompts=[ImagePromptEntry(image=b64, frame_pos=0)],
         )
+
+
+# ---------------------------------------------------------------------------
+# Wan2.2 I2V experimental variants: AniSora, Distill (LightX2V), LoRA
+# ---------------------------------------------------------------------------
+
+
+def _wan22_i2v_warmup_request(prompt: str = "Sunrise on a beach"):
+    """Shared warmup request builder for I2V experimental runners."""
+    dummy = Image.new("RGB", (64, 64), color=0)
+    buf = io.BytesIO()
+    dummy.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    return VideoI2VGenerateRequest.model_construct(
+        prompt=prompt,
+        negative_prompt="",
+        num_inference_steps=2,
+        image_prompts=[ImagePromptEntry(image=b64, frame_pos=0)],
+    )
+
+
+class TTWan22I2VAniSoraRunner(TTDiTRunner):
+    """Wan2.2 I2V with AniSora V3.2 anime fine-tune weights."""
+
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self.resolution = wan22_target_resolution(self.settings.device_mesh_shape)
+        self.image_manager = ImageManager()
+
+    def create_pipeline(self):
+        try:
+            from models.tt_dit.experimental.pipelines.pipeline_anisora import (
+                AniSoraPipeline,
+            )
+
+            return AniSoraPipeline.create_pipeline(
+                mesh_device=self.ttnn_device,
+                height=self.resolution.height,
+                width=self.resolution.width,
+                num_frames=WAN22_NUM_FRAMES,
+            )
+        except Exception as e:
+            log_exception_chain(
+                self.logger, self.device_id, "AniSora I2V pipeline creation failed", e
+            )
+            raise
+
+    def load_weights(self):
+        return False
+
+    def _build_image_prompt(self, request: VideoI2VGenerateRequest) -> list:
+        return [
+            ImagePrompt(
+                image=self.image_manager.base64_to_pil_image(entry.image),
+                frame_pos=entry.frame_pos,
+            )
+            for entry in request.image_prompts
+        ]
+
+    @log_execution_time(
+        f"{dit_runner_log_map.get(get_settings().model_runner, 'AniSora')} inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    def run(self, requests: list[VideoI2VGenerateRequest]):
+        self.logger.debug(f"Device {self.device_id}: Running AniSora inference")
+        request = requests[0]
+        pipeline_args = _wan22_pipeline_args(
+            request, self.resolution, image_prompt=self._build_image_prompt(request),
+        )
+        frames = self.pipeline(**pipeline_args)
+        self.logger.debug(f"Device {self.device_id}: AniSora inference completed")
+        return frames
+
+    def get_pipeline_device_params(self):
+        return _wan22_dit_device_params(self.settings.device_mesh_shape)
+
+    def _build_warmup_video_request(self) -> VideoI2VGenerateRequest:
+        return _wan22_i2v_warmup_request("An anime girl smiling, soft lighting")
+
+
+class TTWan22I2VDistillRunner(TTDiTRunner):
+    """Wan2.2 I2V with LightX2V 4-step distilled weights.
+
+    Distill bakes in classifier-free guidance, so ``guidance_scale`` is forced
+    to 1.0 and ``num_inference_steps`` defaults to 4.
+    """
+
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self.resolution = wan22_target_resolution(self.settings.device_mesh_shape)
+        self.image_manager = ImageManager()
+
+    def create_pipeline(self):
+        try:
+            from models.tt_dit.experimental.pipelines.pipeline_wan_distill import (
+                WanDistillPipelineI2V,
+            )
+
+            return WanDistillPipelineI2V.create_pipeline(
+                mesh_device=self.ttnn_device,
+                height=self.resolution.height,
+                width=self.resolution.width,
+                num_frames=WAN22_NUM_FRAMES,
+            )
+        except Exception as e:
+            log_exception_chain(
+                self.logger, self.device_id, "Distill I2V pipeline creation failed", e
+            )
+            raise
+
+    def load_weights(self):
+        return False
+
+    def _build_image_prompt(self, request: VideoI2VGenerateRequest) -> list:
+        return [
+            ImagePrompt(
+                image=self.image_manager.base64_to_pil_image(entry.image),
+                frame_pos=entry.frame_pos,
+            )
+            for entry in request.image_prompts
+        ]
+
+    @log_execution_time(
+        f"{dit_runner_log_map.get(get_settings().model_runner, 'Distill')} inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    def run(self, requests: list[VideoI2VGenerateRequest]):
+        self.logger.debug(f"Device {self.device_id}: Running Distill inference")
+        request = requests[0]
+        seed = int(request.seed) if request.seed is not None else None
+        pipeline_args = {
+            "prompt": request.prompt,
+            "height": self.resolution.height,
+            "width": self.resolution.width,
+            "num_frames": WAN22_NUM_FRAMES,
+            "num_inference_steps": request.num_inference_steps or 4,
+            "guidance_scale": 1.0,
+            "guidance_scale_2": 1.0,
+            "seed": seed,
+            "traced": True,
+            "image_prompt": self._build_image_prompt(request),
+        }
+        if bool(request.negative_prompt):
+            pipeline_args["negative_prompt"] = request.negative_prompt
+        frames = self.pipeline(**pipeline_args)
+        self.logger.debug(f"Device {self.device_id}: Distill inference completed")
+        return frames
+
+    def get_pipeline_device_params(self):
+        return _wan22_dit_device_params(self.settings.device_mesh_shape)
+
+    def _build_warmup_video_request(self) -> VideoI2VGenerateRequest:
+        return _wan22_i2v_warmup_request()
+
+
+class TTWan22I2VLoRARunner(TTDiTRunner):
+    """Wan2.2 I2V with LoRA adapter fusion (camera control, style, etc.).
+
+    LoRA weights are resolved from ``LORA_HIGH_PATH`` / ``LORA_LOW_PATH``
+    environment variables by the pipeline's ``__init__``.
+    """
+
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self.resolution = wan22_target_resolution(self.settings.device_mesh_shape)
+        self.image_manager = ImageManager()
+
+    def create_pipeline(self):
+        try:
+            from models.tt_dit.experimental.pipelines.pipeline_wan_lora import (
+                WanLoraPipelineI2V,
+            )
+
+            return WanLoraPipelineI2V.create_pipeline(
+                mesh_device=self.ttnn_device,
+                height=self.resolution.height,
+                width=self.resolution.width,
+                num_frames=WAN22_NUM_FRAMES,
+            )
+        except Exception as e:
+            log_exception_chain(
+                self.logger, self.device_id, "LoRA I2V pipeline creation failed", e
+            )
+            raise
+
+    def load_weights(self):
+        return False
+
+    def _build_image_prompt(self, request: VideoI2VGenerateRequest) -> list:
+        return [
+            ImagePrompt(
+                image=self.image_manager.base64_to_pil_image(entry.image),
+                frame_pos=entry.frame_pos,
+            )
+            for entry in request.image_prompts
+        ]
+
+    @log_execution_time(
+        f"{dit_runner_log_map.get(get_settings().model_runner, 'LoRA')} inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    def run(self, requests: list[VideoI2VGenerateRequest]):
+        self.logger.debug(f"Device {self.device_id}: Running LoRA inference")
+        request = requests[0]
+        pipeline_args = _wan22_pipeline_args(
+            request, self.resolution, image_prompt=self._build_image_prompt(request),
+        )
+        frames = self.pipeline(**pipeline_args)
+        self.logger.debug(f"Device {self.device_id}: LoRA inference completed")
+        return frames
+
+    def get_pipeline_device_params(self):
+        return _wan22_dit_device_params(self.settings.device_mesh_shape)
+
+    def _build_warmup_video_request(self) -> VideoI2VGenerateRequest:
+        return _wan22_i2v_warmup_request("A golden retriever running on a sandy beach")

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -49,6 +49,15 @@ AVAILABLE_RUNNERS = {
     ModelRunners.TT_WAN_2_2_I2V_PRODIA: lambda wid: __import__(
         "tt_model_runners.dit_runners", fromlist=["TTWan22I2VProdiaRunner"]
     ).TTWan22I2VProdiaRunner(wid),
+    ModelRunners.TT_WAN_2_2_I2V_ANISORA: lambda wid: __import__(
+        "tt_model_runners.dit_runners", fromlist=["TTWan22I2VAniSoraRunner"]
+    ).TTWan22I2VAniSoraRunner(wid),
+    ModelRunners.TT_WAN_2_2_I2V_DISTILL: lambda wid: __import__(
+        "tt_model_runners.dit_runners", fromlist=["TTWan22I2VDistillRunner"]
+    ).TTWan22I2VDistillRunner(wid),
+    ModelRunners.TT_WAN_2_2_I2V_LORA: lambda wid: __import__(
+        "tt_model_runners.dit_runners", fromlist=["TTWan22I2VLoRARunner"]
+    ).TTWan22I2VLoRARunner(wid),
     ModelRunners.TT_WHISPER: lambda wid: __import__(
         "tt_model_runners.whisper_runner", fromlist=["TTWhisperRunner"]
     ).TTWhisperRunner(wid),

--- a/tt-media-server/tt_model_runners/video_runner.py
+++ b/tt-media-server/tt_model_runners/video_runner.py
@@ -150,6 +150,9 @@ def _create_dit_runner(model_runner: str, rank: int):
     """Create the appropriate DiT runner (lazy import to avoid loading ttnn globally)."""
     from tt_model_runners.dit_runners import (
         TTMochi1Runner,
+        TTWan22I2VAniSoraRunner,
+        TTWan22I2VDistillRunner,
+        TTWan22I2VLoRARunner,
         TTWan22I2VProdiaRunner,
         TTWan22I2VRunner,
         TTWan22Runner,
@@ -160,6 +163,9 @@ def _create_dit_runner(model_runner: str, rank: int):
         ModelRunners.TT_WAN_2_2.value: TTWan22Runner,
         ModelRunners.TT_WAN_2_2_I2V.value: TTWan22I2VRunner,
         ModelRunners.TT_WAN_2_2_I2V_PRODIA.value: TTWan22I2VProdiaRunner,
+        ModelRunners.TT_WAN_2_2_I2V_ANISORA.value: TTWan22I2VAniSoraRunner,
+        ModelRunners.TT_WAN_2_2_I2V_DISTILL.value: TTWan22I2VDistillRunner,
+        ModelRunners.TT_WAN_2_2_I2V_LORA.value: TTWan22I2VLoRARunner,
     }
     runner_class = runner_map.get(model_runner)
     if not runner_class:


### PR DESCRIPTION
Register three new Wan2.2 I2V pipeline variants that import from models.tt_dit.experimental:

- TTWan22I2VAniSoraRunner  (anime fine-tune, AniSora V3.2)
- TTWan22I2VDistillRunner  (4-step LightX2V distill, CFG baked in)
- TTWan22I2VLoRARunner     (LoRA adapter fusion for camera/style)

All three reuse the existing Wan2.2 mesh, fabric, and resolution helpers. Changes are purely additive — no existing code is modified.

Files touched:
  config/constants.py    — enum entries + BH Galaxy ModelConfigs
  config/settings.py     — throttle overrides
  dit_runners.py         — runner classes
  runner_fabric.py       — AVAILABLE_RUNNERS registration
  video_runner.py        — MPI runner_map registration