### PR TITLE
fix(forge): use --engine to resolve multi-impl model spec

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -4092,13 +4092,13 @@ def get_runtime_model_spec(
         (spec for spec in candidate_specs if spec.device_model_spec.default_impl),
         None,
     )
-    selected_spec = default_spec or (candidate_specs[0] if impl else None)
+    selected_spec = default_spec or (candidate_specs[0] if (impl or engine) else None)
 
     if selected_spec is None:
         raise ValueError(
             f"Model:={model} does not have a default impl for "
             f"device:={device}, engine:={engine}; "
-            f"you must pass --impl"
+            f"you must pass --impl or --engine"
         )
 
     resolved_impl = selected_spec.impl.impl_name


### PR DESCRIPTION
closes Issue in tt-shield https://github.com/tenstorrent/tt-shield/issues/736

FORGE-impl models share a model name with vLLM , so the CI matrix needed an explicit `engine` field passed all the way from the matrix generator through to the `run.py` to ensure the right impl is selected.

| model | device | engine | impl | default_impl |
  |---|---|---|---|---|
  | `Llama-3.2-3B-Instruct` | `n150` | `vLLM` | `tt-transformers` | **True** |
  | `Llama-3.2-3B-Instruct` | `n150` | `forge` | `forge-vllm-plugin` | **False** |

##  Bug

CI was not passing `--engine` when launching the FORGE job. Because the engine filter in `get_runtime_model_spec` is a wildcard when `engine` is not passed, `candidate_specs` contained both rows and `default_spec` resolved to the `tt-transformers` entry (the only one with `default_impl=True`). The FORGE CI job was silently running with the wrong impl.

## The fix 

The tt-shield CI change adds `--engine forge` to the FORGE job invocation, which correctly narrows `candidate_specs` to only the FORGE entry. However, that entry has `default_impl=False`, so `default_spec=None`. The existing script:

  `selected_spec = default_spec or (candidate_specs[0] if impl else None)`

only reduced candidate list when `--impl` was explicitly provided, which is not the case as `tt-shield` cannot know `impl` value in advance. Therefore, with `impl=None`, it would have value `None` — even though the correct spec is the only element in `candidate_specs`. 
`impl` is defined in `tt-inference-server/workflows/model_spec.py` but `tt-shield's` matrix generator only has inference_engine value from `models-ci-config.json`. Setting the matrix's `impl` would require `tt-shield` to know the `engine→impl_name` mapping and that mapping isn't 1:1 for MEDIA and VLLM.

The following change has to be introduced in order to select the proper row in models spec.

  `selected_spec = default_spec or (candidate_specs[0] if (impl or engine) else None)`
  
  The error message is extended that we must pass `--impl` or `--engine` to reflect both valid options

## Depends on

tt-shield fix that passes `--engine` to `run.py`
https://github.com/tenstorrent/tt-shield/pull/739

## Test

Tested on reduced `nightly` job where the same model is run properly for vLLM and FORGE engines.
https://github.com/tenstorrent/tt-shield/actions/runs/25913894911/job/76168966839#step:11:203

```
Model Options:
  model:                      Llama-3.2-3B-Instruct
  device:                     n150
  impl:                       forge-vllm-plugin
  engine:                     forge
  workflow:                   release
  tools:                      vllm 
```