### PR TITLE
vLLD Dockerfile change and new plugin-config vLLM wrapper for "override-tt-config"

### DIFF
--- a/tt-vllm-plugin/tt_vllm_plugin/platform.py
+++ b/tt-vllm-plugin/tt_vllm_plugin/platform.py
@@ -100,9 +100,9 @@ class TTPlatform(Platform):
         # TODO move this to tt_model_runner when request validation
         # stops depending on vllm_config
 
-        override_tt_config = getattr(
-            vllm_config.model_config, "plugin_config", {}
-        ).get("tt", {})
+        override_tt_config = getattr(vllm_config.model_config, "plugin_config", {}).get(
+            "tt", {}
+        )
         if (
             override_tt_config is not None
             and "sample_on_device_mode" in override_tt_config

--- a/tt-vllm-plugin/tt_vllm_plugin/platform.py
+++ b/tt-vllm-plugin/tt_vllm_plugin/platform.py
@@ -100,7 +100,9 @@ class TTPlatform(Platform):
         # TODO move this to tt_model_runner when request validation
         # stops depending on vllm_config
 
-        override_tt_config = {}
+        override_tt_config = getattr(
+            vllm_config.model_config, "plugin_config", {}
+        ).get("tt", {})
         if (
             override_tt_config is not None
             and "sample_on_device_mode" in override_tt_config

--- a/tt-vllm-plugin/tt_vllm_plugin/v1/worker/tt_worker.py
+++ b/tt-vllm-plugin/tt_vllm_plugin/v1/worker/tt_worker.py
@@ -51,7 +51,9 @@ class TTWorker(WorkerBase):
 
         # Initialized by init_device
         self.mesh_device = None
-        self.model_config.override_tt_config = {}
+        self.model_config.override_tt_config = getattr(
+            self.model_config, "plugin_config", {}
+        ).get("tt", {})
 
         # Whether to use ttnn tracing for model execution
         override_tt_config = self.model_config.override_tt_config

--- a/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
+++ b/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
@@ -95,8 +95,8 @@ RUN /bin/bash -c "git clone https://github.com/tenstorrent/vllm.git ${vllm_dir} 
     && git checkout ${TT_VLLM_COMMIT_SHA_OR_TAG} \
     && source ${PYTHON_ENV_DIR}/bin/activate \
     && uv pip install --upgrade pip \
-    && uv pip install --index-strategy unsafe-best-match -e . --extra-index-url https://download.pytorch.org/whl/cpu \
-    && if [ -d plugins/vllm-tt-plugin ]; then uv pip install --no-deps -e plugins/vllm-tt-plugin; fi \  
+    && VLLM_TARGET_DEVICE=empty uv pip install --index-strategy unsafe-best-match -e . --extra-index-url https://download.pytorch.org/whl/cpu \
+    && if [ -d plugins/vllm-tt-plugin ]; then uv pip install --index-strategy unsafe-best-match -e 'plugins/vllm-tt-plugin[runtime]' --extra-index-url https://download.pytorch.org/whl/cpu; fi \
     && rm -rf ${vllm_dir}/.git"
 
 # Build tt-smi in separate venv to avoid conflicts with tt-metal venv

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -348,7 +348,7 @@ class DeviceModelSpec:
             "max_num_batched_tokens": str(self.max_context),
             "max-log-len": "32",
             "seed": "9472",
-            "override_tt_config": json.dumps(self.override_tt_config),
+            "plugin_config": json.dumps({"tt": self.override_tt_config}),
         }
         merged_vllm_args = {**default_vllm_args, **self.vllm_args}
         object.__setattr__(self, "vllm_args", merged_vllm_args)
@@ -776,7 +776,7 @@ class ModelSpec:
             )
             merged_vllm_args = {
                 **self.device_model_spec.vllm_args,
-                "override_tt_config": json.dumps(merged_override_config),
+                "plugin_config": json.dumps({"tt": merged_override_config}),
             }
             object.__setattr__(self.device_model_spec, "vllm_args", merged_vllm_args)
 

--- a/workflows/multihost_orchestrator.py
+++ b/workflows/multihost_orchestrator.py
@@ -602,10 +602,10 @@ class MultiHostOrchestrator:
         # Get serialized model spec dict
         spec_dict = self.model_spec.get_serialized_dict()
 
-        # Get the existing override_tt_config from vllm_args (it's a JSON string)
+        # Get the existing TT config from vllm_args plugin_config (it's a JSON string)
         vllm_args = spec_dict.get("device_model_spec", {}).get("vllm_args", {})
-        existing_override_str = vllm_args.get("override_tt_config", "{}")
-        existing_override = json.loads(existing_override_str)
+        existing_plugin_str = vllm_args.get("plugin_config", '{"tt": {}}')
+        existing_override = json.loads(existing_plugin_str).get("tt", {})
 
         # Merge with MPI override_tt_config from multihost setup
         # Lists (e.g., env_passthrough) are concatenated, others are overwritten
@@ -620,9 +620,9 @@ class MultiHostOrchestrator:
                 merged_override, runtime_override
             )
 
-        # Update the spec dict with merged override_tt_config
-        spec_dict["device_model_spec"]["vllm_args"]["override_tt_config"] = json.dumps(
-            merged_override
+        # Update the spec dict with merged plugin_config under the "tt" namespace
+        spec_dict["device_model_spec"]["vllm_args"]["plugin_config"] = json.dumps(
+            {"tt": merged_override}
         )
 
         # Write to JSON file in config_dir


### PR DESCRIPTION
closes #3535 

## Description

  This PR introduces a `plugin_config` wrapping around TT-specific overrides under "tt", replacing the TT-fork-specific
  `--override-tt-config` vLLM argument with the vLLM `--plugin-config` interface.

  The internal representation of TT overrides (`override_tt_config` fields in all `ModelSpecTemplate` declarations) is unchanged. Only the plugin reading layer are adapted to the new vLLM interface.

## Error
  
  CI job: Llama-3.1-8B-Instruct (n150) https://github.com/tenstorrent/tt-shield/actions/runs/25848363779/job/75953950781
  `run_vllm_api_server.py: error: unrecognized arguments: --override-tt-config`

## Root cause: 

`model_spec.py` reads the TT override config into `vllm_args` under the key `override_tt_config`. This argument existed only in the `tenstorrent/vllm fork`. The new plugin mode does not recognize `--override-tt-config`, causing the server to fail immediately on startup.

## Introduced Changes

The following scripts/files are changed.

### Dockerfile "vllm.tt-metal.src.dev.Dockerfile" 

changes  confirmed by Viktor Pus. All code changes are separating all TT-specific code to a plugin.

```
&& VLLM_TARGET_DEVICE=empty uv pip install --index-strategy unsafe-best-match -e . --extra-index-url https://download.pytorch.org/whl/cpu \
    && if [ -d plugins/vllm-tt-plugin ]; then uv pip install --index-strategy unsafe-best-match -e 'plugins/vllm-tt-plugin[runtime]' --extra-index-url https://download.pytorch.org/whl/cpu; fi \
```

### model_spec.py

 Replacing the `--override-tt-config` vLLM argument with the upstream vLLM `--plugin-config` argument, adding a "tt" key within it, so vLLM can identify it as plugin-specific configuration for Tenstorrent.

 We don't do simple rename as the shape of the variables changes: `--override-tt-config` expected a flat dict, `--plugin-config` expects a nested-dict, one level deeper.

  **Change 1 — DeviceModelSpec._infer_data():**
  Before
  `"override_tt_config": json.dumps(self.override_tt_config)`
  
  After
  `"plugin_config": json.dumps({"tt": self.override_tt_config})`
  
  **Change 2 — ModelSpec.apply_overrides():**
   Before
  `"override_tt_config": json.dumps(merged_override_config)`
  
  After
  `"plugin_config": json.dumps({"tt": merged_override_config})`


  ### workflows/multihost_orchestrator.py
 
 We update the read and write paths to use the new plugin_config key and {"tt": ...} instead of the old `override_tt_config` key.

```
  existing_plugin_str = vllm_args.get("plugin_config", '{"tt": {}}')

  existing_override = json.loads(existing_plugin_str).get("tt", {})

  spec_dict["device_model_spec"]["vllm_args"]["plugin_config"] = json.dumps({"tt": merged_override})
```


  ### tt-vllm-plugin/tt_vllm_plugin/platform.py -- to be double checked(?)
  
 This file is used for platform config initialization
  
  Purpose: `TTPlatform.check_and_update_config()` is called by vLLM early in startup before any worker is created. It configures scheduler, cache, worker class, and sampling behavior based on TT-specific settings. It was previously reading
  `override_tt_config` from a hardcoded empty dict.

  We need to check what we want to achieve: to read `model_config.plugin_config` under the "tt" key, so setting like `sample_on_device_mode` is actually applied.

 **Before** — always empty, config was never applied in plugin mode
  `override_tt_config = {}`
  
  **After** — reads actual TT config passed via --plugin-config
```
  override_tt_config = getattr(
      vllm_config.model_config, "plugin_config", {}
  ).get("tt", {})
```
  
  ### tt-vllm-plugin/tt_vllm_plugin/v1/worker/tt_worker.py -- to be double checked(?)
  
  This file is used for worker config initialization.

  Purpose: `TTWorker.__init__()` is called when vLLM creates the TT worker process. It reads TT-specific config to determine device parameters such as `trace region size`. All the device initialization parameters — were never being read from the model spec in this worker. The device was always being opened with defaults. 

  This fix is the first time tt_worker.py in this repo actually reads the config and passes it through to device initialization. Is this what we want to achieve?

  Change:
  **Before** — always empty dict, all device overrides silently ignored
  `self.model_config.override_tt_config = {}`
  
  **After** — populated from --plugin-config {"tt": {...}}
```
  self.model_config.override_tt_config = getattr(
      self.model_config, "plugin_config", {}
  ).get("tt", {})
```
  
  By setting self.model_config.override_tt_config here, all existing downstream code in tt_worker.py (utility functions get_dispatch_core_config, get_fabric_config, device_params_from_override_tt_config, etc.) and in tt_loader.py continues
  to work without modification — they all read from model_config.override_tt_config which is now correctly populated.
  
  
  ## Test
  
  https://github.com/tenstorrent/tt-shield/actions/runs/25983643325/job/76378926361
  
  The arguments were correct. Here's the proof from the log:
     
```
  vllm serve \
    --model meta-llama/Llama-3.1-8B-Instruct \
    --plugin_config '{"tt": {"sample_on_device_mode": "decode_only", "trace_region_size": 105000000}}' \
    --port 8000
```

  The job failed for a completely unrelated reason — the trace_region_size value in the model spec is too small for the actual hardware requirement:

```
  trace_region_size configured: 105,000,000 bytes
  trace_region_size required:   107,331,584 bytes
  shortage: ~2.3 MB
```

### release_model_spec.json - will not be updated manually

`release_model_spec.json` is re-generated using the script `scripts/release/update_model_spec.py` 

The new json file format will have the following structure after it is being regenerated (example for `Llama-3.1-8B-Instruct`):

```
              "vllm_args": {
                "model": "meta-llama/Llama-3.1-8B-Instruct",
                "block_size": "64",
                "max_model_len": "32768",
                "max_num_seqs": "32",
                "max_num_batched_tokens": "32768",
                "max-log-len": "32",
                "seed": "9472",
                "plugin_config": "{\"tt\": {\"trace_region_size\": 52000000}}"
              },
              "override_tt_config": {
                "trace_region_size": 52000000
              },

```