### PR TITLE
Dynamo Integration - Enable etcd for Backend Discovery

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -803,6 +803,7 @@ set(SOURCES
     src/runtime/worker/blaze_worker_metrics_renderer.cpp
     src/dynamo/dynamo_protocol.cpp
     src/dynamo/discovery.cpp
+    src/dynamo/etcd_client.cpp
     src/dynamo/dynamo_endpoint.cpp
 )
 

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -106,9 +106,19 @@ constexpr int DECODE_MAX_TOKEN_IDS = 1;
 // off unless DYNAMO_ENDPOINT_ENABLED=1.
 constexpr bool DYNAMO_ENDPOINT_ENABLED = false;
 constexpr const char* DYNAMO_BIND_HOST = "0.0.0.0";
-constexpr const char* DYNAMO_DISCOVERY_PATH = "/tmp/dynamo_store_kv";
 constexpr const char* DYNAMO_NAMESPACE = "default";
 constexpr const char* DYNAMO_COMPONENT = "backend";
 constexpr const char* DYNAMO_ENDPOINT_NAME = "generate";
+
+// Discovery backend: "file" (default) writes JSON to DYNAMO_DISCOVERY_PATH,
+// "etcd" PUTs to a Dynamo-shared etcd cluster (matching the frontend's
+// DYN_DISCOVERY_BACKEND=etcd mode). Frontend and backend must agree.
+constexpr const char* DYNAMO_DISCOVERY_BACKEND = "file";
+constexpr const char* DYNAMO_DISCOVERY_PATH = "/tmp/dynamo_store_kv";
+constexpr const char* DYNAMO_ETCD_ENDPOINTS = "http://localhost:2379";
+// Lease TTL for instance + MDC entries in etcd. The keep-alive thread
+// refreshes the lease at half this interval so a missed tick doesn't trip
+// the reaper.
+constexpr int64_t DYNAMO_ETCD_LEASE_TTL_SECS = 10;
 
 }  // namespace tt::config::defaults

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -246,9 +246,24 @@ bool dynamoEndpointEnabled();
  * defaults::DYNAMO_BIND_HOST. */
 std::string dynamoBindHost();
 
+/** Discovery backend selection ("file" or "etcd"). From
+ * DYNAMO_DISCOVERY_BACKEND. Default: defaults::DYNAMO_DISCOVERY_BACKEND.
+ * Must match the Dynamo frontend's DYN_DISCOVERY_BACKEND. */
+std::string dynamoDiscoveryBackend();
+
 /** Path to the file-based discovery store the Dynamo frontend watches. From
- * DYNAMO_DISCOVERY_PATH. Default: defaults::DYNAMO_DISCOVERY_PATH. */
+ * DYNAMO_DISCOVERY_PATH. Default: defaults::DYNAMO_DISCOVERY_PATH. Only
+ * consulted when the discovery backend is "file". */
 std::string dynamoDiscoveryPath();
+
+/** Etcd endpoint(s) the discovery client dials. From DYNAMO_ETCD_ENDPOINTS,
+ * falling back to ETCD_ENDPOINTS (the env var Dynamo's own runtime reads).
+ * Default: defaults::DYNAMO_ETCD_ENDPOINTS. */
+std::string dynamoEtcdEndpoints();
+
+/** Lease TTL (seconds) for etcd-backed discovery. From
+ * DYNAMO_ETCD_LEASE_TTL_SECS. Default: defaults::DYNAMO_ETCD_LEASE_TTL_SECS. */
+int64_t dynamoEtcdLeaseTtlSecs();
 
 /** Discovery namespace key. From DYNAMO_NAMESPACE. Default:
  * defaults::DYNAMO_NAMESPACE. */

--- a/tt-media-server/cpp_server/include/dynamo/discovery.hpp
+++ b/tt-media-server/cpp_server/include/dynamo/discovery.hpp
@@ -4,22 +4,49 @@
 #pragma once
 
 /**
- * File-based discovery registration for Dynamo.
+ * Discovery registration for Dynamo backends.
  *
- * Writes the instance JSON and Model Descriptor Card (MDC) JSON files that
- * the Dynamo frontend watches at `${DYN_FILE_STORE}/v1/instances` and
- * `${DYN_FILE_STORE}/v1/mdc`, respectively. The frontend uses the MDC's
- * tokenizer paths to tokenize incoming requests before routing to this
- * worker, so the paths must match the tokenizer the worker actually uses.
+ * Two backends are supported:
+ *
+ *   - File: writes the instance + Model Descriptor Card JSON under
+ *     `${DYNAMO_DISCOVERY_PATH}/v1/{instances,mdc}/<url-encoded-key>`. The
+ *     keep-alive simply rewrites the file (refreshes mtime).
+ *
+ *   - Etcd: PUTs the same JSON bodies under keys `v1/instances/<key>` and
+ *     `v1/mdc/<key>` attached to a lease. Keep-alive refreshes that lease;
+ *     unregister revokes it (atomically deleting both keys).
+ *
+ * Both are wire-compatible with NVIDIA Dynamo's KVStoreDiscovery; the
+ * frontend reads the same JSON payloads regardless of backend.
  */
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 namespace tt::dynamo {
 
+enum class DiscoveryBackendKind {
+  File,
+  Etcd,
+};
+
 struct DiscoveryConfig {
+  DiscoveryBackendKind backend = DiscoveryBackendKind::File;
+
+  // ---- File backend ------------------------------------------------------
   std::string store_path = "/tmp/dynamo_store_kv";
+
+  // ---- Etcd backend ------------------------------------------------------
+  /// Single etcd HTTP endpoint or comma-separated list (only the first is
+  /// dialed today). Use `http://<host>:2379`; HTTPS is unsupported.
+  std::string etcd_endpoints = "http://localhost:2379";
+  /// Lease TTL the backend grants for its instance + MDC keys. Keep-alive
+  /// is performed at half this interval so brief frontend hiccups don't
+  /// cause an etcd reap.
+  int64_t etcd_lease_ttl_secs = 10;
+
+  // ---- Identity (both backends) ------------------------------------------
   std::string namespace_name = "default";
   std::string component = "backend";
   std::string endpoint = "generate";
@@ -28,7 +55,7 @@ struct DiscoveryConfig {
   /// "host:port/instance_id_hex/endpoint" — the address Dynamo dials to send
   /// us a request.
   std::string tcp_address;
-  /// Slug shown in /v1/models (e.g. "deepseek-ai/DeepSeek-R1-0528").
+  /// Display name in /v1/models (e.g. "deepseek-ai/DeepSeek-R1-0528").
   std::string model_name;
   /// Filesystem directory containing config.json + tokenizer.json +
   /// tokenizer_config.json.
@@ -36,13 +63,40 @@ struct DiscoveryConfig {
 };
 
 /**
- * Register this backend instance in the file-based discovery store. Must be
- * called after the Dynamo TCP listener binds (so the port is known). When
- * `quiet` is true, skip log output (used by keepalive re-registrations).
+ * Lifecycle handle for a discovery registration. Construct via
+ * `DiscoveryRegistration::create`, call `registerSelf()` once after binding,
+ * `keepAlive()` periodically, and `unregisterSelf()` on shutdown.
+ *
+ * Implementations are NOT thread-safe; callers must serialize access (the
+ * existing keep-alive thread does).
  */
-void register_discovery(const DiscoveryConfig& config, bool quiet = false);
+class DiscoveryRegistration {
+ public:
+  static std::unique_ptr<DiscoveryRegistration> create(
+      const DiscoveryConfig& config);
 
-/// Remove the instance + MDC files this backend wrote.
-void unregister_discovery(const DiscoveryConfig& config);
+  virtual ~DiscoveryRegistration() = default;
+
+  /// Publish the instance + MDC documents. Throws on transport failure.
+  virtual void registerSelf() = 0;
+
+  /// Refresh the registration so it doesn't expire. For the file backend
+  /// this is a re-write; for etcd it's a lease keep-alive that falls back
+  /// to a full re-register if the lease has been reaped. Errors are
+  /// swallowed (logged) so a transient outage doesn't kill the worker.
+  virtual void keepAlive() = 0;
+
+  /// Remove the registration. Errors are swallowed (best effort on
+  /// shutdown).
+  virtual void unregisterSelf() = 0;
+
+  /// Suggested keep-alive period. The endpoint thread sleeps for this many
+  /// seconds between `keepAlive()` calls.
+  virtual int keepAliveIntervalSecs() const = 0;
+};
+
+/// Map a string form ("file" / "etcd", case-insensitive) to the enum. Used
+/// by settings.cpp.
+DiscoveryBackendKind parseDiscoveryBackend(const std::string& s);
 
 }  // namespace tt::dynamo

--- a/tt-media-server/cpp_server/include/dynamo/dynamo_endpoint.hpp
+++ b/tt-media-server/cpp_server/include/dynamo/dynamo_endpoint.hpp
@@ -43,7 +43,17 @@ class DynamoEndpoint {
     std::string namespace_name = "default";
     std::string component = "backend";
     std::string endpoint = "generate";
+
+    /// Discovery backend ("file" or "etcd"). Must match the frontend's
+    /// DYN_DISCOVERY_BACKEND.
+    DiscoveryBackendKind discovery_backend = DiscoveryBackendKind::File;
+    /// File backend: store directory.
     std::string discovery_path = "/tmp/dynamo_store_kv";
+    /// Etcd backend: endpoint URL (or comma-separated list).
+    std::string etcd_endpoints = "http://localhost:2379";
+    /// Etcd backend: lease TTL in seconds (keep-alive runs at half this).
+    int64_t etcd_lease_ttl_secs = 10;
+
     /// Slug shown in /v1/models. When empty, the active tokenizer's
     /// modelName() is used.
     std::string model_name;
@@ -79,7 +89,7 @@ class DynamoEndpoint {
   std::thread keepalive_thread_;
   std::unique_ptr<trantor::EventLoopThread> loop_thread_;
   std::atomic<bool> running_{false};
-  DiscoveryConfig discovery_;
+  std::unique_ptr<DiscoveryRegistration> discovery_;
 };
 
 }  // namespace tt::dynamo

--- a/tt-media-server/cpp_server/include/dynamo/etcd_client.hpp
+++ b/tt-media-server/cpp_server/include/dynamo/etcd_client.hpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#pragma once
+
+/**
+ * Minimal etcd v3 client over the JSON HTTP gateway.
+ *
+ * etcd's gRPC-gateway exposes the v3 KV/Lease API as JSON HTTP endpoints on
+ * the same port as gRPC (default 2379). This client speaks HTTP/1.1 directly
+ * over a POSIX socket so we don't pull in libcurl or grpc.
+ *
+ * Only the surface used by Dynamo discovery is implemented:
+ *   - LeaseGrant: create a lease the backend will associate with its keys.
+ *   - LeaseKeepAlive: refresh the lease so etcd doesn't reap our entries.
+ *   - LeaseRevoke: explicit deregistration on shutdown.
+ *   - Put / DeleteRange: write / remove the instance + MDC documents.
+ *
+ * HTTPS endpoints are NOT supported (frontends in the same trust domain
+ * typically use plain HTTP; production deployments should terminate TLS at a
+ * sidecar proxy).
+ */
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+namespace tt::dynamo {
+
+/// Throws when the etcd HTTP gateway responds with anything other than 200,
+/// or when the JSON body cannot be parsed. Callers translate this into a
+/// retry / re-register on the next keep-alive tick.
+class EtcdError : public std::runtime_error {
+ public:
+  using std::runtime_error::runtime_error;
+};
+
+class EtcdClient {
+ public:
+  /**
+   * `endpoint` may be a single `http://host:port` URL or a comma-separated
+   * list (only the first is used; multi-endpoint failover is not
+   * implemented). `timeout_ms` bounds connect + read for every call.
+   */
+  explicit EtcdClient(const std::string& endpoint, int timeout_ms = 5000);
+
+  /// Grant a new lease with the given TTL (seconds). Returns the lease id.
+  int64_t leaseGrant(int64_t ttl_secs);
+
+  /// Refresh `lease_id`. Returns the TTL etcd reports remaining (in
+  /// seconds); zero means etcd considers the lease already expired.
+  int64_t leaseKeepAlive(int64_t lease_id);
+
+  /// Revoke `lease_id`. All keys attached to it are deleted atomically.
+  void leaseRevoke(int64_t lease_id);
+
+  /// Put a single key-value pair, optionally attached to a lease (0 = none).
+  void put(const std::string& key, const std::string& value,
+           int64_t lease_id = 0);
+
+  /// Delete a single key (range_end is left unset).
+  void deleteRange(const std::string& key);
+
+ private:
+  std::string host_;
+  int port_ = 2379;
+  int timeout_ms_;
+};
+
+}  // namespace tt::dynamo

--- a/tt-media-server/cpp_server/scripts/start_dynamo.sh
+++ b/tt-media-server/cpp_server/scripts/start_dynamo.sh
@@ -9,7 +9,8 @@
 #   sibling dynamo-mock-backend `setup.sh` or any Dynamo install).
 #
 # Usage:
-#   ./scripts/start_dynamo.sh                 # build (if needed) + run
+#   ./scripts/start_dynamo.sh                              # default file store
+#   DYN_DISCOVERY_BACKEND=etcd ./scripts/start_dynamo.sh   # use etcd
 #   DYNAMO_DISCOVERY_PATH=/tmp/dyn HTTP_PORT=9000 ./scripts/start_dynamo.sh
 
 set -euo pipefail
@@ -30,15 +31,38 @@ if [[ ! -d "${DYN_VENV}" ]]; then
 fi
 
 # --- discovery + endpoint ---------------------------------------------------
+# DYN_DISCOVERY_BACKEND: "file" (default) or "etcd".
+#   - file: writes JSON under DYN_FILE_STORE; both processes mount the same path.
+#   - etcd: requires a reachable etcd at ETCD_ENDPOINTS (default
+#           http://localhost:2379). The frontend reads the same env var.
 export DYN_DISCOVERY_BACKEND="${DYN_DISCOVERY_BACKEND:-file}"
 export DYN_REQUEST_PLANE="${DYN_REQUEST_PLANE:-tcp}"
 export DYN_EVENT_PLANE="${DYN_EVENT_PLANE:-zmq}"
 export DYN_FILE_STORE="${DYN_FILE_STORE:-/tmp/dynamo_store_kv}"
+export ETCD_ENDPOINTS="${ETCD_ENDPOINTS:-http://localhost:2379}"
 export DYNAMO_ENDPOINT_ENABLED=1
+# Mirror the Dynamo-side env into cpp_server's namespace so the C++ accessors
+# (which key off DYNAMO_*) see the same values without duplicating exports.
+export DYNAMO_DISCOVERY_BACKEND="${DYN_DISCOVERY_BACKEND}"
 export DYNAMO_DISCOVERY_PATH="${DYNAMO_DISCOVERY_PATH:-${DYN_FILE_STORE}}"
+export DYNAMO_ETCD_ENDPOINTS="${DYNAMO_ETCD_ENDPOINTS:-${ETCD_ENDPOINTS}}"
 export DYNAMO_NAMESPACE="${DYNAMO_NAMESPACE:-default}"
 export DYNAMO_COMPONENT="${DYNAMO_COMPONENT:-backend}"
 export DYNAMO_ENDPOINT_NAME="${DYNAMO_ENDPOINT_NAME:-generate}"
+
+# Quick sanity check: when running with etcd, fail fast if the gateway isn't
+# reachable so we don't waste a minute booting cpp_server only to crash on
+# first lease grant.
+if [[ "${DYN_DISCOVERY_BACKEND}" == "etcd" ]]; then
+    ETCD_HOST_PORT="${ETCD_ENDPOINTS#http://}"
+    ETCD_HOST_PORT="${ETCD_HOST_PORT%%/*}"
+    if ! (echo > "/dev/tcp/${ETCD_HOST_PORT/:/\/}") 2>/dev/null; then
+        echo "etcd not reachable at ${ETCD_ENDPOINTS}." >&2
+        echo "Start one with:  docker run --rm -d -p 2379:2379 --name etcd quay.io/coreos/etcd:v3.5.13 \\" >&2
+        echo "    /usr/local/bin/etcd --advertise-client-urls=http://0.0.0.0:2379 --listen-client-urls=http://0.0.0.0:2379" >&2
+        exit 1
+    fi
+fi
 
 # Resolve the model path the cpp_server's tokenizers/ tree exposes for the
 # active backend so the frontend ends up tokenizing against the same files
@@ -64,7 +88,12 @@ SERVER_PORT="${SERVER_PORT:-8000}"
 MODEL_NAME="${MODEL_NAME:-tt-cpp-server}"
 export OPENAI_API_KEY="${OPENAI_API_KEY:-dynamo-bypass}"
 
-rm -rf "${DYN_FILE_STORE}"
+if [[ "${DYN_DISCOVERY_BACKEND}" == "file" ]]; then
+    rm -rf "${DYN_FILE_STORE}"
+    DISCOVERY_LABEL="file://${DYN_FILE_STORE}"
+else
+    DISCOVERY_LABEL="${DYN_DISCOVERY_BACKEND}://${ETCD_ENDPOINTS}"
+fi
 
 cleanup() {
     echo "" >&2
@@ -78,7 +107,7 @@ trap cleanup EXIT INT TERM
 echo "=== Dynamo + cpp_server ==="
 echo "  Frontend HTTP : ${HTTP_PORT}"
 echo "  cpp_server    : http://0.0.0.0:${SERVER_PORT}"
-echo "  Discovery     : ${DYN_FILE_STORE}"
+echo "  Discovery     : ${DISCOVERY_LABEL}"
 echo "  Model name    : ${MODEL_NAME}"
 echo "  Model path    : ${MODEL_PATH}"
 echo "  LLM backend   : ${LLM_BACKEND}"

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -557,8 +557,37 @@ std::string dynamoBindHost() {
   return envString("DYNAMO_BIND_HOST", defaults::DYNAMO_BIND_HOST);
 }
 
+std::string dynamoDiscoveryBackend() {
+  return envString("DYNAMO_DISCOVERY_BACKEND",
+                   defaults::DYNAMO_DISCOVERY_BACKEND);
+}
+
 std::string dynamoDiscoveryPath() {
   return envString("DYNAMO_DISCOVERY_PATH", defaults::DYNAMO_DISCOVERY_PATH);
+}
+
+std::string dynamoEtcdEndpoints() {
+  // Prefer DYNAMO_ETCD_ENDPOINTS (cpp_server-specific). Fall back to
+  // ETCD_ENDPOINTS — Dynamo's Rust runtime reads the same name, so a single
+  // export propagates to both processes when start_dynamo.sh wires them
+  // together.
+  if (const char* v = std::getenv("DYNAMO_ETCD_ENDPOINTS"); v && *v) {
+    return v;
+  }
+  if (const char* v = std::getenv("ETCD_ENDPOINTS"); v && *v) {
+    return v;
+  }
+  return defaults::DYNAMO_ETCD_ENDPOINTS;
+}
+
+int64_t dynamoEtcdLeaseTtlSecs() {
+  const char* v = std::getenv("DYNAMO_ETCD_LEASE_TTL_SECS");
+  if (!v || !*v) return defaults::DYNAMO_ETCD_LEASE_TTL_SECS;
+  try {
+    return std::stoll(v);
+  } catch (const std::exception&) {
+    return defaults::DYNAMO_ETCD_LEASE_TTL_SECS;
+  }
 }
 
 std::string dynamoNamespace() {

--- a/tt-media-server/cpp_server/src/dynamo/discovery.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/discovery.cpp
@@ -290,7 +290,7 @@ class EtcdDiscoveryRegistration : public DiscoveryRegistration {
   void publishKeys() {
     const std::string key = instanceKey(cfg);
     client->put("v1/instances/" + key, serializeJson(buildInstanceJson(cfg)),
-                 leaseId);
+                leaseId);
     client->put("v1/mdc/" + key, serializeJson(buildMdcJson(cfg)), leaseId);
   }
 

--- a/tt-media-server/cpp_server/src/dynamo/discovery.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/discovery.cpp
@@ -5,10 +5,14 @@
 
 #include <json/json.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <memory>
+#include <stdexcept>
 #include <string>
 
+#include "dynamo/etcd_client.hpp"
 #include "utils/logger.hpp"
 
 namespace tt::dynamo {
@@ -20,8 +24,15 @@ namespace {
 constexpr int K_CONTEXT_LENGTH = 131072;
 constexpr int K_KV_CACHE_BLOCK_SIZE = 16;
 
+/// Frontend reads the checksum but doesn't validate it for routing — it's
+/// used only for cache invalidation.
+constexpr const char* K_BLAKE3_PLACEHOLDER =
+    "blake3:0000000000000000000000000000000000000000000000000000000000000000";
+
 /// URL-encode a path component (only `/` needs to be escaped for our keys).
-std::string urlEncodePath(const std::string& s) {
+/// Used by the file backend so a slash inside namespace/component doesn't
+/// create unintended subdirectories.
+std::string urlEncodeSlash(const std::string& s) {
   std::string out;
   out.reserve(s.size());
   for (char c : s) {
@@ -32,13 +43,6 @@ std::string urlEncodePath(const std::string& s) {
     }
   }
   return out;
-}
-
-/// Frontend reads the checksum but doesn't validate it for routing — it's
-/// used only for cache invalidation.
-std::string blake3Placeholder() {
-  return "blake3:0000000000000000000000000000000000000000000000000000000000"
-         "000000";
 }
 
 /// Dynamo's slug validator rejects anything outside [a-z0-9_-]. HuggingFace
@@ -59,135 +63,263 @@ std::string sanitizeSlug(const std::string& s) {
   return out;
 }
 
-std::string writeJson(const Json::Value& v) {
+std::string serializeJson(const Json::Value& v) {
   Json::StreamWriterBuilder b;
   b["indentation"] = "";
   b["emitUTF8"] = true;
   return Json::writeString(b, v);
 }
 
-}  // namespace
-
-void register_discovery(const DiscoveryConfig& config, bool quiet) {
-  // Key = "namespace/component/endpoint/instance_id_hex" (URL-encoded).
-  const std::string key = config.namespace_name + "/" + config.component + "/" +
-                          config.endpoint + "/" + config.instance_id_hex;
-  const std::string encodedKey = urlEncodePath(key);
-
-  // ---- instance JSON ----
-  {
-    const std::string dir = config.store_path + "/v1/instances";
-    fs::create_directories(dir);
-
-    Json::Value instance(Json::objectValue);
-    instance["type"] = "Endpoint";
-    instance["component"] = config.component;
-    instance["endpoint"] = config.endpoint;
-    instance["namespace"] = config.namespace_name;
-    instance["instance_id"] = static_cast<Json::UInt64>(config.instance_id);
-
-    Json::Value transport(Json::objectValue);
-    transport["tcp"] = config.tcp_address;
-    instance["transport"] = std::move(transport);
-    instance["device_type"] = "cuda";
-
-    const std::string filePath = dir + "/" + encodedKey;
-    std::ofstream f(filePath);
-    f << writeJson(instance);
-    f.close();
-
-    if (!quiet) {
-      TT_LOG_INFO("[DynamoDiscovery] Registered instance at {}", filePath);
-    }
-  }
-
-  // ---- Model Descriptor Card (MDC) ----
-  {
-    const std::string dir = config.store_path + "/v1/mdc";
-    fs::create_directories(dir);
-
-    const std::string configPath = config.model_path + "/config.json";
-    const std::string tokenizerPath = config.model_path + "/tokenizer.json";
-    const std::string tokenizerConfigPath =
-        config.model_path + "/tokenizer_config.json";
-
-    Json::Value mdc(Json::objectValue);
-    mdc["type"] = "Model";
-    mdc["namespace"] = config.namespace_name;
-    mdc["component"] = config.component;
-    mdc["endpoint"] = config.endpoint;
-    mdc["instance_id"] = static_cast<Json::UInt64>(config.instance_id);
-
-    Json::Value card(Json::objectValue);
-    card["display_name"] = config.model_name;
-    card["slug"] = sanitizeSlug(config.model_name);
-    card["source_path"] = config.model_path;
-
-    Json::Value modelInfo(Json::objectValue);
-    Json::Value hfConfig(Json::objectValue);
-    hfConfig["path"] = configPath;
-    hfConfig["checksum"] = blake3Placeholder();
-    modelInfo["hf_config_json"] = std::move(hfConfig);
-    card["model_info"] = std::move(modelInfo);
-
-    Json::Value tokenizer(Json::objectValue);
-    Json::Value hfTok(Json::objectValue);
-    hfTok["path"] = tokenizerPath;
-    hfTok["checksum"] = blake3Placeholder();
-    tokenizer["hf_tokenizer_json"] = std::move(hfTok);
-    card["tokenizer"] = std::move(tokenizer);
-
-    Json::Value promptFormatter(Json::objectValue);
-    Json::Value hfTokCfg(Json::objectValue);
-    hfTokCfg["path"] = tokenizerConfigPath;
-    hfTokCfg["checksum"] = blake3Placeholder();
-    promptFormatter["hf_tokenizer_config_json"] = std::move(hfTokCfg);
-    card["prompt_formatter"] = std::move(promptFormatter);
-
-    card["context_length"] = K_CONTEXT_LENGTH;
-    card["kv_cache_block_size"] = K_KV_CACHE_BLOCK_SIZE;
-    card["migration_limit"] = 0;
-    card["model_type"] = "Chat";
-    card["model_input"] = "Tokens";
-
-    Json::Value runtime(Json::objectValue);
-    runtime["total_kv_blocks"] = Json::Value::null;
-    runtime["max_num_seqs"] = Json::Value::null;
-    runtime["max_num_batched_tokens"] = Json::Value::null;
-    runtime["tool_call_parser"] = Json::Value::null;
-    runtime["reasoning_parser"] = Json::Value::null;
-    runtime["exclude_tools_when_tool_choice_none"] = true;
-    runtime["data_parallel_start_rank"] = 0;
-    runtime["data_parallel_size"] = 1;
-    runtime["enable_local_indexer"] = true;
-    runtime["enable_eagle"] = false;
-    card["runtime_config"] = std::move(runtime);
-
-    card["media_decoder"] = Json::Value::null;
-    card["media_fetcher"] = Json::Value::null;
-
-    mdc["card_json"] = std::move(card);
-
-    const std::string filePath = dir + "/" + encodedKey;
-    std::ofstream f(filePath);
-    f << writeJson(mdc);
-    f.close();
-
-    if (!quiet) {
-      TT_LOG_INFO("[DynamoDiscovery] Registered MDC at {} (model={})", filePath,
-                  config.model_name);
-    }
-  }
+/// Hierarchical key that Dynamo's KVStoreDiscovery uses for both file and
+/// etcd backends: <namespace>/<component>/<endpoint>/<instance_id_hex>.
+std::string instanceKey(const DiscoveryConfig& c) {
+  return c.namespace_name + "/" + c.component + "/" + c.endpoint + "/" +
+         c.instance_id_hex;
 }
 
-void unregister_discovery(const DiscoveryConfig& config) {
-  const std::string key = config.namespace_name + "/" + config.component + "/" +
-                          config.endpoint + "/" + config.instance_id_hex;
-  const std::string encodedKey = urlEncodePath(key);
+/// Build the instance JSON document the frontend dials over (transport.tcp).
+Json::Value buildInstanceJson(const DiscoveryConfig& c) {
+  Json::Value instance(Json::objectValue);
+  instance["type"] = "Endpoint";
+  instance["component"] = c.component;
+  instance["endpoint"] = c.endpoint;
+  instance["namespace"] = c.namespace_name;
+  instance["instance_id"] = static_cast<Json::UInt64>(c.instance_id);
 
-  fs::remove(config.store_path + "/v1/instances/" + encodedKey);
-  fs::remove(config.store_path + "/v1/mdc/" + encodedKey);
-  TT_LOG_INFO("[DynamoDiscovery] Unregistered {}", key);
+  Json::Value transport(Json::objectValue);
+  transport["tcp"] = c.tcp_address;
+  instance["transport"] = std::move(transport);
+  instance["device_type"] = "cuda";
+  return instance;
+}
+
+/// Build the Model Descriptor Card JSON the frontend uses to tokenize and
+/// list the model. Paths point at the same files cpp_server itself loads so
+/// the frontend tokenization matches exactly.
+Json::Value buildMdcJson(const DiscoveryConfig& c) {
+  Json::Value mdc(Json::objectValue);
+  mdc["type"] = "Model";
+  mdc["namespace"] = c.namespace_name;
+  mdc["component"] = c.component;
+  mdc["endpoint"] = c.endpoint;
+  mdc["instance_id"] = static_cast<Json::UInt64>(c.instance_id);
+
+  Json::Value card(Json::objectValue);
+  card["display_name"] = c.model_name;
+  card["slug"] = sanitizeSlug(c.model_name);
+  card["source_path"] = c.model_path;
+
+  const std::string configPath = c.model_path + "/config.json";
+  const std::string tokenizerPath = c.model_path + "/tokenizer.json";
+  const std::string tokenizerConfigPath =
+      c.model_path + "/tokenizer_config.json";
+
+  Json::Value modelInfo(Json::objectValue);
+  Json::Value hfConfig(Json::objectValue);
+  hfConfig["path"] = configPath;
+  hfConfig["checksum"] = K_BLAKE3_PLACEHOLDER;
+  modelInfo["hf_config_json"] = std::move(hfConfig);
+  card["model_info"] = std::move(modelInfo);
+
+  Json::Value tokenizer(Json::objectValue);
+  Json::Value hfTok(Json::objectValue);
+  hfTok["path"] = tokenizerPath;
+  hfTok["checksum"] = K_BLAKE3_PLACEHOLDER;
+  tokenizer["hf_tokenizer_json"] = std::move(hfTok);
+  card["tokenizer"] = std::move(tokenizer);
+
+  Json::Value promptFormatter(Json::objectValue);
+  Json::Value hfTokCfg(Json::objectValue);
+  hfTokCfg["path"] = tokenizerConfigPath;
+  hfTokCfg["checksum"] = K_BLAKE3_PLACEHOLDER;
+  promptFormatter["hf_tokenizer_config_json"] = std::move(hfTokCfg);
+  card["prompt_formatter"] = std::move(promptFormatter);
+
+  card["context_length"] = K_CONTEXT_LENGTH;
+  card["kv_cache_block_size"] = K_KV_CACHE_BLOCK_SIZE;
+  card["migration_limit"] = 0;
+  card["model_type"] = "Chat";
+  card["model_input"] = "Tokens";
+
+  Json::Value runtime(Json::objectValue);
+  runtime["total_kv_blocks"] = Json::Value::null;
+  runtime["max_num_seqs"] = Json::Value::null;
+  runtime["max_num_batched_tokens"] = Json::Value::null;
+  runtime["tool_call_parser"] = Json::Value::null;
+  runtime["reasoning_parser"] = Json::Value::null;
+  runtime["exclude_tools_when_tool_choice_none"] = true;
+  runtime["data_parallel_start_rank"] = 0;
+  runtime["data_parallel_size"] = 1;
+  runtime["enable_local_indexer"] = true;
+  runtime["enable_eagle"] = false;
+  card["runtime_config"] = std::move(runtime);
+
+  card["media_decoder"] = Json::Value::null;
+  card["media_fetcher"] = Json::Value::null;
+
+  mdc["card_json"] = std::move(card);
+  return mdc;
+}
+
+// ---------------------------------------------------------------------------
+// File backend
+// ---------------------------------------------------------------------------
+
+class FileDiscoveryRegistration : public DiscoveryRegistration {
+ public:
+  explicit FileDiscoveryRegistration(DiscoveryConfig cfg)
+      : cfg(std::move(cfg)) {}
+
+  void registerSelf() override { writeAll(/*quiet=*/false); }
+  void keepAlive() override { writeAll(/*quiet=*/true); }
+
+  void unregisterSelf() override {
+    const std::string encoded = urlEncodeSlash(instanceKey(cfg));
+    std::error_code ec;
+    fs::remove(cfg.store_path + "/v1/instances/" + encoded, ec);
+    fs::remove(cfg.store_path + "/v1/mdc/" + encoded, ec);
+    TT_LOG_INFO("[DynamoDiscovery/file] Unregistered {}", instanceKey(cfg));
+  }
+
+  int keepAliveIntervalSecs() const override { return 5; }
+
+ private:
+  void writeAll(bool quiet) {
+    const std::string encoded = urlEncodeSlash(instanceKey(cfg));
+    {
+      const std::string dir = cfg.store_path + "/v1/instances";
+      fs::create_directories(dir);
+      const std::string path = dir + "/" + encoded;
+      std::ofstream f(path);
+      f << serializeJson(buildInstanceJson(cfg));
+      if (!quiet) {
+        TT_LOG_INFO("[DynamoDiscovery/file] Registered instance at {}", path);
+      }
+    }
+    {
+      const std::string dir = cfg.store_path + "/v1/mdc";
+      fs::create_directories(dir);
+      const std::string path = dir + "/" + encoded;
+      std::ofstream f(path);
+      f << serializeJson(buildMdcJson(cfg));
+      if (!quiet) {
+        TT_LOG_INFO("[DynamoDiscovery/file] Registered MDC at {} (model={})",
+                    path, cfg.model_name);
+      }
+    }
+  }
+
+  DiscoveryConfig cfg;
+};
+
+// ---------------------------------------------------------------------------
+// Etcd backend
+// ---------------------------------------------------------------------------
+
+class EtcdDiscoveryRegistration : public DiscoveryRegistration {
+ public:
+  explicit EtcdDiscoveryRegistration(DiscoveryConfig cfg)
+      : cfg(std::move(cfg)),
+        client(std::make_unique<EtcdClient>(cfg.etcd_endpoints)) {}
+
+  void registerSelf() override {
+    if (leaseId == 0) {
+      leaseId = client->leaseGrant(cfg.etcd_lease_ttl_secs);
+      TT_LOG_INFO(
+          "[DynamoDiscovery/etcd] Lease granted id={} ttl={}s endpoints={}",
+          leaseId, cfg.etcd_lease_ttl_secs, cfg.etcd_endpoints);
+    }
+    publishKeys();
+    TT_LOG_INFO(
+        "[DynamoDiscovery/etcd] Registered key={} model={} endpoints={}",
+        instanceKey(cfg), cfg.model_name, cfg.etcd_endpoints);
+  }
+
+  void keepAlive() override {
+    if (leaseId == 0) {
+      // Lost the lease (or never granted). Re-create from scratch.
+      try {
+        registerSelf();
+      } catch (const std::exception& e) {
+        TT_LOG_WARN("[DynamoDiscovery/etcd] re-register failed: {}", e.what());
+      }
+      return;
+    }
+    try {
+      int64_t remaining = client->leaseKeepAlive(leaseId);
+      if (remaining <= 0) {
+        // etcd considered the lease expired; force a fresh register.
+        TT_LOG_WARN(
+            "[DynamoDiscovery/etcd] lease {} reported expired by etcd; "
+            "re-registering",
+            leaseId);
+        leaseId = 0;
+        registerSelf();
+      }
+    } catch (const std::exception& e) {
+      // Likely transient (etcd hiccup, frontend restart). Drop the lease so
+      // the next tick performs a clean re-register; do not crash.
+      TT_LOG_WARN(
+          "[DynamoDiscovery/etcd] keep-alive failed (lease {}): {} — will "
+          "re-register",
+          leaseId, e.what());
+      leaseId = 0;
+    }
+  }
+
+  void unregisterSelf() override {
+    if (leaseId == 0) return;
+    try {
+      client->leaseRevoke(leaseId);
+      TT_LOG_INFO("[DynamoDiscovery/etcd] Revoked lease {} (key={})", leaseId,
+                  instanceKey(cfg));
+    } catch (const std::exception& e) {
+      TT_LOG_WARN("[DynamoDiscovery/etcd] revoke failed: {}", e.what());
+    }
+    leaseId = 0;
+  }
+
+  /// Keep-alive at half the lease TTL so a single missed tick doesn't expire
+  /// the registration. Floor at 1s so misconfigured very-short TTLs don't
+  /// busy-loop the keep-alive thread.
+  int keepAliveIntervalSecs() const override {
+    return std::max<int>(1, static_cast<int>(cfg.etcd_lease_ttl_secs / 2));
+  }
+
+ private:
+  void publishKeys() {
+    const std::string key = instanceKey(cfg);
+    client->put("v1/instances/" + key, serializeJson(buildInstanceJson(cfg)),
+                 leaseId);
+    client->put("v1/mdc/" + key, serializeJson(buildMdcJson(cfg)), leaseId);
+  }
+
+  DiscoveryConfig cfg;
+  std::unique_ptr<EtcdClient> client;
+  int64_t leaseId = 0;
+};
+
+}  // namespace
+
+std::unique_ptr<DiscoveryRegistration> DiscoveryRegistration::create(
+    const DiscoveryConfig& config) {
+  switch (config.backend) {
+    case DiscoveryBackendKind::File:
+      return std::make_unique<FileDiscoveryRegistration>(config);
+    case DiscoveryBackendKind::Etcd:
+      return std::make_unique<EtcdDiscoveryRegistration>(config);
+  }
+  throw std::invalid_argument("DiscoveryRegistration: unknown backend");
+}
+
+DiscoveryBackendKind parseDiscoveryBackend(const std::string& s) {
+  std::string lower;
+  lower.reserve(s.size());
+  for (char c : s) lower += static_cast<char>(std::tolower(c));
+  if (lower == "etcd") return DiscoveryBackendKind::Etcd;
+  if (lower == "file" || lower.empty()) return DiscoveryBackendKind::File;
+  throw std::invalid_argument("Unknown DYNAMO_DISCOVERY_BACKEND value: '" + s +
+                              "' (expected 'file' or 'etcd')");
 }
 
 }  // namespace tt::dynamo

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
@@ -36,8 +36,6 @@ namespace tt::dynamo {
 
 namespace {
 
-constexpr int K_KEEP_ALIVE_INTERVAL_SEC = 5;
-
 /// Shape an LLMRequest from a Dynamo PreprocessedRequest. The frontend has
 /// already applied the chat template, so we forward token ids directly and
 /// leave `messages` empty — the pipeline picks up that signal and routes
@@ -276,34 +274,45 @@ void DynamoEndpoint::start() {
         "DynamoEndpoint: server failed to bind within timeout");
   }
 
-  discovery_.store_path = options_.discovery_path;
-  discovery_.namespace_name = options_.namespace_name;
-  discovery_.component = options_.component;
-  discovery_.endpoint = options_.endpoint;
-  discovery_.instance_id = server_->config().instance_id;
-  discovery_.instance_id_hex = server_->config().instance_id_hex;
-  discovery_.tcp_address = options_.advertise_host + ":" +
-                           std::to_string(server_->port()) + "/" +
-                           discovery_.instance_id_hex + "/" + options_.endpoint;
-  discovery_.model_name = options_.model_name;
-  discovery_.model_path = options_.model_path;
+  DiscoveryConfig dc;
+  dc.backend = options_.discovery_backend;
+  dc.store_path = options_.discovery_path;
+  dc.etcd_endpoints = options_.etcd_endpoints;
+  dc.etcd_lease_ttl_secs = options_.etcd_lease_ttl_secs;
+  dc.namespace_name = options_.namespace_name;
+  dc.component = options_.component;
+  dc.endpoint = options_.endpoint;
+  dc.instance_id = server_->config().instance_id;
+  dc.instance_id_hex = server_->config().instance_id_hex;
+  dc.tcp_address = options_.advertise_host + ":" +
+                   std::to_string(server_->port()) + "/" + dc.instance_id_hex +
+                   "/" + options_.endpoint;
+  dc.model_name = options_.model_name;
+  dc.model_path = options_.model_path;
 
-  register_discovery(discovery_);
+  discovery_ = DiscoveryRegistration::create(dc);
+  discovery_->registerSelf();
 
+  const char* backendStr =
+      (dc.backend == DiscoveryBackendKind::Etcd) ? "etcd" : "file";
+  const std::string& backendTarget = (dc.backend == DiscoveryBackendKind::Etcd)
+                                         ? dc.etcd_endpoints
+                                         : dc.store_path;
   TT_LOG_INFO(
       "[DynamoEndpoint] Ready: bind={}:{} advertise={} model={} "
-      "discovery={}",
-      options_.bind_host, server_->port(), discovery_.tcp_address,
-      discovery_.model_name, discovery_.store_path);
+      "discovery={}({})",
+      options_.bind_host, server_->port(), dc.tcp_address, dc.model_name,
+      backendStr, backendTarget);
 
-  // Refresh discovery files periodically so a frontend that prunes stale
-  // entries keeps seeing this worker.
-  keepalive_thread_ = std::thread([this]() {
+  // Refresh the registration periodically so a frontend that prunes stale
+  // entries (file mtime) or expires unleased keys (etcd) keeps seeing us.
+  const int interval = discovery_->keepAliveIntervalSecs();
+  keepalive_thread_ = std::thread([this, interval]() {
     while (running_) {
-      for (int i = 0; i < K_KEEP_ALIVE_INTERVAL_SEC * 10 && running_; ++i) {
+      for (int i = 0; i < interval * 10 && running_; ++i) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
       }
-      if (running_) register_discovery(discovery_, /*quiet=*/true);
+      if (running_) discovery_->keepAlive();
     }
   });
 }
@@ -317,7 +326,9 @@ void DynamoEndpoint::stop() {
   if (server_) {
     server_->shutdown();
   }
-  unregister_discovery(discovery_);
+  if (discovery_) {
+    discovery_->unregisterSelf();
+  }
 
   if (keepalive_thread_.joinable()) keepalive_thread_.join();
   if (server_thread_.joinable()) server_thread_.join();
@@ -325,6 +336,7 @@ void DynamoEndpoint::stop() {
     loop_thread_.reset();
   }
   server_.reset();
+  discovery_.reset();
 }
 
 }  // namespace tt::dynamo

--- a/tt-media-server/cpp_server/src/dynamo/etcd_client.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/etcd_client.cpp
@@ -1,0 +1,478 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#include "dynamo/etcd_client.hpp"
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <json/json.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <sstream>
+#include <string>
+
+namespace tt::dynamo {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Base64 (RFC 4648, standard alphabet, padding). etcd's JSON gateway expects
+// keys/values to be base64-encoded strings.
+// ---------------------------------------------------------------------------
+
+constexpr char K_BASE64_ALPHABET[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+std::string base64Encode(const std::string& in) {
+  std::string out;
+  out.reserve(((in.size() + 2) / 3) * 4);
+  size_t i = 0;
+  while (i + 3 <= in.size()) {
+    uint32_t v = (static_cast<uint8_t>(in[i]) << 16) |
+                 (static_cast<uint8_t>(in[i + 1]) << 8) |
+                 static_cast<uint8_t>(in[i + 2]);
+    out += K_BASE64_ALPHABET[(v >> 18) & 0x3F];
+    out += K_BASE64_ALPHABET[(v >> 12) & 0x3F];
+    out += K_BASE64_ALPHABET[(v >> 6) & 0x3F];
+    out += K_BASE64_ALPHABET[v & 0x3F];
+    i += 3;
+  }
+  const size_t rem = in.size() - i;
+  if (rem == 1) {
+    uint32_t v = static_cast<uint8_t>(in[i]) << 16;
+    out += K_BASE64_ALPHABET[(v >> 18) & 0x3F];
+    out += K_BASE64_ALPHABET[(v >> 12) & 0x3F];
+    out += "==";
+  } else if (rem == 2) {
+    uint32_t v = (static_cast<uint8_t>(in[i]) << 16) |
+                 (static_cast<uint8_t>(in[i + 1]) << 8);
+    out += K_BASE64_ALPHABET[(v >> 18) & 0x3F];
+    out += K_BASE64_ALPHABET[(v >> 12) & 0x3F];
+    out += K_BASE64_ALPHABET[(v >> 6) & 0x3F];
+    out += "=";
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// URL parsing: accept "http://host:port" optionally with trailing "/" and
+// optionally a comma-separated list (we keep the first endpoint).
+// ---------------------------------------------------------------------------
+
+struct ParsedUrl {
+  std::string host;
+  int port;
+};
+
+ParsedUrl parseEtcdUrl(const std::string& urlList) {
+  std::string url = urlList;
+  if (auto comma = url.find(','); comma != std::string::npos) {
+    url = url.substr(0, comma);
+  }
+  // strip leading whitespace
+  while (!url.empty() &&
+         std::isspace(static_cast<unsigned char>(url.front()))) {
+    url.erase(url.begin());
+  }
+  if (url.rfind("https://", 0) == 0) {
+    throw EtcdError(
+        "EtcdClient: HTTPS endpoints are not supported (use a TLS-terminating "
+        "sidecar)");
+  }
+  if (url.rfind("http://", 0) == 0) {
+    url.erase(0, 7);
+  }
+  if (auto slash = url.find('/'); slash != std::string::npos) {
+    url.resize(slash);
+  }
+  ParsedUrl out;
+  if (auto colon = url.find(':'); colon != std::string::npos) {
+    out.host = url.substr(0, colon);
+    try {
+      out.port = std::stoi(url.substr(colon + 1));
+    } catch (...) {
+      throw EtcdError("EtcdClient: invalid port in endpoint '" + urlList + "'");
+    }
+  } else {
+    out.host = url;
+    out.port = 2379;
+  }
+  if (out.host.empty()) {
+    throw EtcdError("EtcdClient: empty host in endpoint '" + urlList + "'");
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tiny blocking HTTP/1.1 client. Connect with a deadline (so etcd-not-running
+// fails fast), POST a JSON body, parse Content-Length-bounded response.
+// ---------------------------------------------------------------------------
+
+class Socket {
+ public:
+  Socket() = default;
+  ~Socket() {
+    if (fd >= 0) ::close(fd);
+  }
+  Socket(const Socket&) = delete;
+  Socket& operator=(const Socket&) = delete;
+
+  int getFd() const { return fd; }
+  void reset(int newFd) {
+    if (fd >= 0) ::close(fd);
+    fd = newFd;
+  }
+
+ private:
+  int fd = -1;
+};
+
+void connectWithTimeout(int fd, const sockaddr* addr, socklen_t len,
+                        int timeoutMs) {
+  int flags = ::fcntl(fd, F_GETFL, 0);
+  ::fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+  int rc = ::connect(fd, addr, len);
+  if (rc == 0) {
+    ::fcntl(fd, F_SETFL, flags);
+    return;
+  }
+  if (errno != EINPROGRESS) {
+    throw EtcdError(std::string("EtcdClient: connect failed: ") +
+                    std::strerror(errno));
+  }
+  pollfd pfd{fd, POLLOUT, 0};
+  int pr = ::poll(&pfd, 1, timeoutMs);
+  if (pr <= 0) {
+    throw EtcdError("EtcdClient: connect timeout");
+  }
+  int err = 0;
+  socklen_t errlen = sizeof(err);
+  if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &errlen) < 0 || err != 0) {
+    throw EtcdError(std::string("EtcdClient: connect error: ") +
+                    std::strerror(err));
+  }
+  ::fcntl(fd, F_SETFL, flags);
+}
+
+void writeAll(int fd, const std::string& data, int timeoutMs) {
+  size_t sent = 0;
+  while (sent < data.size()) {
+    pollfd pfd{fd, POLLOUT, 0};
+    int pr = ::poll(&pfd, 1, timeoutMs);
+    if (pr <= 0) throw EtcdError("EtcdClient: send timeout");
+    ssize_t n =
+        ::send(fd, data.data() + sent, data.size() - sent, MSG_NOSIGNAL);
+    if (n <= 0) {
+      if (n < 0 && (errno == EINTR || errno == EAGAIN)) continue;
+      throw EtcdError(std::string("EtcdClient: send failed: ") +
+                      std::strerror(errno));
+    }
+    sent += static_cast<size_t>(n);
+  }
+}
+
+/// Read bytes until either `until` appears in the buffer or `maxBytes` is
+/// hit. Used to find the end of HTTP headers ("\r\n\r\n").
+std::string readUntil(int fd, const std::string& until, size_t maxBytes,
+                      int timeoutMs) {
+  std::string buf;
+  buf.reserve(1024);
+  while (buf.find(until) == std::string::npos) {
+    if (buf.size() >= maxBytes) {
+      throw EtcdError("EtcdClient: response headers too large");
+    }
+    pollfd pfd{fd, POLLIN, 0};
+    int pr = ::poll(&pfd, 1, timeoutMs);
+    if (pr <= 0) throw EtcdError("EtcdClient: read timeout (headers)");
+    char tmp[1024];
+    ssize_t n = ::recv(fd, tmp, sizeof(tmp), 0);
+    if (n == 0) throw EtcdError("EtcdClient: connection closed in headers");
+    if (n < 0) {
+      if (errno == EINTR || errno == EAGAIN) continue;
+      throw EtcdError(std::string("EtcdClient: recv failed: ") +
+                      std::strerror(errno));
+    }
+    buf.append(tmp, static_cast<size_t>(n));
+  }
+  return buf;
+}
+
+std::string readExact(int fd, size_t n, int timeoutMs,
+                      const std::string& alreadyRead) {
+  std::string buf = alreadyRead;
+  buf.reserve(n);
+  while (buf.size() < n) {
+    pollfd pfd{fd, POLLIN, 0};
+    int pr = ::poll(&pfd, 1, timeoutMs);
+    if (pr <= 0) throw EtcdError("EtcdClient: read timeout (body)");
+    char tmp[4096];
+    size_t want = std::min(sizeof(tmp), n - buf.size());
+    ssize_t r = ::recv(fd, tmp, want, 0);
+    if (r == 0) throw EtcdError("EtcdClient: connection closed in body");
+    if (r < 0) {
+      if (errno == EINTR || errno == EAGAIN) continue;
+      throw EtcdError(std::string("EtcdClient: recv failed: ") +
+                      std::strerror(errno));
+    }
+    buf.append(tmp, static_cast<size_t>(r));
+  }
+  return buf;
+}
+
+/// Case-insensitive header lookup.
+bool findHeader(const std::string& headers, const char* name,
+                std::string* value) {
+  std::string lower = headers;
+  for (auto& c : lower) c = static_cast<char>(std::tolower(c));
+  std::string key = std::string("\r\n") + name + ":";
+  for (auto& c : key) c = static_cast<char>(std::tolower(c));
+  auto pos = lower.find(key);
+  if (pos == std::string::npos) return false;
+  pos += key.size();
+  auto end = lower.find("\r\n", pos);
+  if (end == std::string::npos) return false;
+  std::string raw = headers.substr(pos, end - pos);
+  while (!raw.empty() && std::isspace(static_cast<unsigned char>(raw.front())))
+    raw.erase(raw.begin());
+  while (!raw.empty() && std::isspace(static_cast<unsigned char>(raw.back())))
+    raw.pop_back();
+  *value = raw;
+  return true;
+}
+
+/// POST `body` (assumed JSON) to `path` and return the response body. Raises
+/// EtcdError on transport failure or a non-2xx status.
+std::string httpPostJson(const std::string& host, int port,
+                         const std::string& path, const std::string& body,
+                         int timeoutMs) {
+  addrinfo hints{};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  addrinfo* res = nullptr;
+  std::string portStr = std::to_string(port);
+  int gai = ::getaddrinfo(host.c_str(), portStr.c_str(), &hints, &res);
+  if (gai != 0 || res == nullptr) {
+    throw EtcdError(std::string("EtcdClient: getaddrinfo(") + host +
+                    ") failed: " + ::gai_strerror(gai));
+  }
+  Socket sock;
+  EtcdError lastErr("EtcdClient: no addresses tried");
+  bool connected = false;
+  for (auto* p = res; p != nullptr; p = p->ai_next) {
+    int fd = ::socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+    if (fd < 0) continue;
+    try {
+      connectWithTimeout(fd, p->ai_addr, p->ai_addrlen, timeoutMs);
+      sock.reset(fd);
+      connected = true;
+      break;
+    } catch (const EtcdError& e) {
+      ::close(fd);
+      lastErr = e;
+    }
+  }
+  ::freeaddrinfo(res);
+  if (!connected) throw lastErr;
+
+  std::ostringstream req;
+  req << "POST " << path << " HTTP/1.1\r\n"
+      << "Host: " << host << ":" << port << "\r\n"
+      << "Content-Type: application/json\r\n"
+      << "Content-Length: " << body.size() << "\r\n"
+      << "Connection: close\r\n"
+      << "\r\n"
+      << body;
+  writeAll(sock.getFd(), req.str(), timeoutMs);
+
+  // Read headers up to "\r\n\r\n", then determine body length.
+  std::string head = readUntil(sock.getFd(), "\r\n\r\n", 32 * 1024, timeoutMs);
+  auto headerEnd = head.find("\r\n\r\n");
+  std::string headers = head.substr(0, headerEnd + 2);
+  std::string already = head.substr(headerEnd + 4);
+
+  // status line: HTTP/1.1 <code> <reason>
+  int status = 0;
+  {
+    auto firstSpace = headers.find(' ');
+    if (firstSpace == std::string::npos) {
+      throw EtcdError("EtcdClient: malformed response status line");
+    }
+    auto secondSpace = headers.find(' ', firstSpace + 1);
+    if (secondSpace == std::string::npos) {
+      throw EtcdError("EtcdClient: malformed response status line");
+    }
+    try {
+      status = std::stoi(
+          headers.substr(firstSpace + 1, secondSpace - firstSpace - 1));
+    } catch (...) {
+      throw EtcdError("EtcdClient: malformed response status code");
+    }
+  }
+
+  std::string bodyOut;
+  std::string contentLength;
+  std::string transferEncoding;
+  bool chunked = false;
+  if (findHeader(headers, "Transfer-Encoding", &transferEncoding)) {
+    chunked = (transferEncoding.find("chunked") != std::string::npos);
+  }
+  if (chunked) {
+    // Minimal chunked decoder: read chunk-size lines and the bytes that
+    // follow until a zero-sized chunk arrives.
+    std::string buf = std::move(already);
+    auto readMore = [&]() {
+      pollfd pfd{sock.getFd(), POLLIN, 0};
+      int pr = ::poll(&pfd, 1, timeoutMs);
+      if (pr <= 0) throw EtcdError("EtcdClient: read timeout (chunked)");
+      char tmp[4096];
+      ssize_t r = ::recv(sock.getFd(), tmp, sizeof(tmp), 0);
+      if (r == 0) throw EtcdError("EtcdClient: closed mid chunk");
+      if (r < 0) throw EtcdError("EtcdClient: recv chunked failed");
+      buf.append(tmp, static_cast<size_t>(r));
+    };
+    while (true) {
+      while (buf.find("\r\n") == std::string::npos) readMore();
+      auto crlf = buf.find("\r\n");
+      std::string sizeLine = buf.substr(0, crlf);
+      buf.erase(0, crlf + 2);
+      if (auto semi = sizeLine.find(';'); semi != std::string::npos) {
+        sizeLine.resize(semi);
+      }
+      size_t sz = 0;
+      try {
+        sz = std::stoul(sizeLine, nullptr, 16);
+      } catch (...) {
+        throw EtcdError("EtcdClient: bad chunk size");
+      }
+      if (sz == 0) break;
+      while (buf.size() < sz + 2) readMore();
+      bodyOut.append(buf, 0, sz);
+      buf.erase(0, sz + 2);  // consume CRLF after chunk
+    }
+  } else if (findHeader(headers, "Content-Length", &contentLength)) {
+    size_t want = 0;
+    try {
+      want = std::stoul(contentLength);
+    } catch (...) {
+      throw EtcdError("EtcdClient: bad Content-Length");
+    }
+    bodyOut = readExact(sock.getFd(), want, timeoutMs, already);
+  } else {
+    // Server-closes: read until EOF.
+    bodyOut = std::move(already);
+    while (true) {
+      pollfd pfd{sock.getFd(), POLLIN, 0};
+      int pr = ::poll(&pfd, 1, timeoutMs);
+      if (pr <= 0) break;
+      char tmp[4096];
+      ssize_t r = ::recv(sock.getFd(), tmp, sizeof(tmp), 0);
+      if (r <= 0) break;
+      bodyOut.append(tmp, static_cast<size_t>(r));
+    }
+  }
+
+  if (status / 100 != 2) {
+    throw EtcdError(std::string("EtcdClient: HTTP ") + std::to_string(status) +
+                    " from " + path + ": " + bodyOut);
+  }
+  return bodyOut;
+}
+
+Json::Value parseJson(const std::string& body) {
+  Json::CharReaderBuilder b;
+  Json::Value v;
+  std::string errs;
+  std::istringstream is(body);
+  if (!Json::parseFromStream(b, is, &v, &errs)) {
+    throw EtcdError("EtcdClient: response is not valid JSON: " + errs +
+                    " body=" + body);
+  }
+  return v;
+}
+
+/// etcd JSON gateway returns numeric ids as strings ("ID":"123456"); accept
+/// both for resilience.
+int64_t toInt64(const Json::Value& v) {
+  if (v.isInt64()) return v.asInt64();
+  if (v.isUInt64()) return static_cast<int64_t>(v.asUInt64());
+  if (v.isString()) {
+    try {
+      return std::stoll(v.asString());
+    } catch (...) {
+      throw EtcdError("EtcdClient: integer string not parseable: " +
+                      v.asString());
+    }
+  }
+  throw EtcdError("EtcdClient: expected integer, got " + v.toStyledString());
+}
+
+std::string serialize(const Json::Value& v) {
+  Json::StreamWriterBuilder b;
+  b["indentation"] = "";
+  b["emitUTF8"] = true;
+  return Json::writeString(b, v);
+}
+
+}  // namespace
+
+EtcdClient::EtcdClient(const std::string& endpoint, int timeoutMs)
+    : timeout_ms_(timeoutMs) {
+  auto parsed = parseEtcdUrl(endpoint);
+  host_ = parsed.host;
+  port_ = parsed.port;
+}
+
+int64_t EtcdClient::leaseGrant(int64_t ttlSecs) {
+  Json::Value body(Json::objectValue);
+  body["TTL"] = static_cast<Json::Int64>(ttlSecs);
+  body["ID"] = 0;
+  auto resp = parseJson(httpPostJson(host_, port_, "/v3/lease/grant",
+                                     serialize(body), timeout_ms_));
+  if (!resp.isMember("ID")) {
+    throw EtcdError("EtcdClient: lease/grant response missing ID: " +
+                    resp.toStyledString());
+  }
+  return toInt64(resp["ID"]);
+}
+
+int64_t EtcdClient::leaseKeepAlive(int64_t leaseId) {
+  Json::Value body(Json::objectValue);
+  body["ID"] = static_cast<Json::Int64>(leaseId);
+  auto resp = parseJson(httpPostJson(host_, port_, "/v3/lease/keepalive",
+                                     serialize(body), timeout_ms_));
+  // Streaming endpoint returns {"result": {"ID": "...", "TTL": "..."}}
+  const auto& r = resp.isMember("result") ? resp["result"] : resp;
+  if (!r.isMember("TTL")) return 0;
+  return toInt64(r["TTL"]);
+}
+
+void EtcdClient::leaseRevoke(int64_t leaseId) {
+  Json::Value body(Json::objectValue);
+  body["ID"] = static_cast<Json::Int64>(leaseId);
+  httpPostJson(host_, port_, "/v3/lease/revoke", serialize(body), timeout_ms_);
+}
+
+void EtcdClient::put(const std::string& key, const std::string& value,
+                     int64_t leaseId) {
+  Json::Value body(Json::objectValue);
+  body["key"] = base64Encode(key);
+  body["value"] = base64Encode(value);
+  if (leaseId != 0) body["lease"] = static_cast<Json::Int64>(leaseId);
+  httpPostJson(host_, port_, "/v3/kv/put", serialize(body), timeout_ms_);
+}
+
+void EtcdClient::deleteRange(const std::string& key) {
+  Json::Value body(Json::objectValue);
+  body["key"] = base64Encode(key);
+  httpPostJson(host_, port_, "/v3/kv/deleterange", serialize(body),
+               timeout_ms_);
+}
+
+}  // namespace tt::dynamo

--- a/tt-media-server/cpp_server/src/main.cpp
+++ b/tt-media-server/cpp_server/src/main.cpp
@@ -360,7 +360,16 @@ int main(int argc, char* argv[]) {
       opts.namespace_name = tt::config::dynamoNamespace();
       opts.component = tt::config::dynamoComponent();
       opts.endpoint = tt::config::dynamoEndpointName();
+      try {
+        opts.discovery_backend = tt::dynamo::parseDiscoveryBackend(
+            tt::config::dynamoDiscoveryBackend());
+      } catch (const std::exception& e) {
+        TT_LOG_ERROR("[Main] {}; falling back to file backend", e.what());
+        opts.discovery_backend = tt::dynamo::DiscoveryBackendKind::File;
+      }
       opts.discovery_path = tt::config::dynamoDiscoveryPath();
+      opts.etcd_endpoints = tt::config::dynamoEtcdEndpoints();
+      opts.etcd_lease_ttl_secs = tt::config::dynamoEtcdLeaseTtlSecs();
 
       try {
         dynamoEndpoint =


### PR DESCRIPTION
## Problem
In order for the Dynamo Frontend to operate in a fully distributed system and act as a gateway to multiple distributed LLM nodes deployed across different machines, we need to enable distributed service discovery. In this case, `etcd` was chosen due to its simplicity, reliability, and proven support for production-scale workloads.