### PR TITLE
fix(evals): clamp client concurrency to device_model_spec.max_concurrency

### DIFF
--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -334,9 +334,39 @@ def build_eval_command(
     else:
         api_url = f"{base_url}/completions"
 
+    # Clamp client concurrency/batch_size to the server's device_model_spec.max_concurrency.
+    # lm-eval / lmms-eval default to num_concurrent=32, which can exceed the server's
+    # max_num_seqs when the (model, device, engine) tuple supports a smaller batch —
+    # e.g. some forge LLMs currently in bring-up run with a smaller max_num_seqs. When
+    # that happens, the client over-subscribes the server, the queue serializes, and
+    # the client's read timeout fires. Source the correct ceiling from ModelSpec.
+    device_max_concurrency = getattr(
+        getattr(model_spec, "device_model_spec", None), "max_concurrency", None
+    )
+
+    effective_max_concurrent = task.max_concurrent
+    if effective_max_concurrent and device_max_concurrency:
+        effective_max_concurrent = min(effective_max_concurrent, device_max_concurrency)
+        if effective_max_concurrent != task.max_concurrent:
+            logger.info(
+                f"Clamping {task.task_name} num_concurrent: "
+                f"{task.max_concurrent} -> {effective_max_concurrent} "
+                f"(device_model_spec.max_concurrency={device_max_concurrency})"
+            )
+
+    effective_batch_size = task.batch_size
+    if effective_batch_size and device_max_concurrency:
+        effective_batch_size = min(effective_batch_size, device_max_concurrency)
+        if effective_batch_size != task.batch_size:
+            logger.info(
+                f"Clamping {task.task_name} batch_size: "
+                f"{task.batch_size} -> {effective_batch_size} "
+                f"(device_model_spec.max_concurrency={device_max_concurrency})"
+            )
+
     optional_model_args = []
-    if task.max_concurrent:
-        optional_model_args.append(f"num_concurrent={task.max_concurrent}")
+    if effective_max_concurrent:
+        optional_model_args.append(f"num_concurrent={effective_max_concurrent}")
 
     # lm-eval (text) expects full completions api route in base_url
     # lmms-eval (vision) expects base_url WITHOUT the endpoint path
@@ -391,7 +421,7 @@ def build_eval_command(
             "--output_path", output_dir_path,
             "--seed", task.seed,
             "--num_fewshot", task.num_fewshot,
-            "--batch_size", task.batch_size,
+            "--batch_size", effective_batch_size,
             "--log_samples",
             "--show_config",
         ]
@@ -405,7 +435,7 @@ def build_eval_command(
                 f"{model_kwargs_str}"
             ),
             "--tasks", task.task_name,
-            "--batch_size", str(task.batch_size),
+            "--batch_size", str(effective_batch_size),
             "--output_path", str(output_dir_path),
             "--log_samples",
         ]
@@ -424,7 +454,7 @@ def build_eval_command(
             "--output_path", output_dir_path,
             "--seed", task.seed,
             "--num_fewshot", task.num_fewshot,
-            "--batch_size", task.batch_size,
+            "--batch_size", effective_batch_size,
             "--log_samples",
             "--show_config",
         ]


### PR DESCRIPTION
### Issue

Addresses Problem 2 of #3533

### Problem

`evals/run_evals.py` builds lm-eval / lmms-eval commands with `num_concurrent=32` (from `EvalTask.max_concurrent=32` default) and `batch_size=32` on the EVALS_META path (post_init reassigns `batch_size = max_concurrent`). This works for engines/models that support a 32-wide batch (typical ttnn / vllm-tt) but over-subscribes engines that don't — e.g. some forge LLMs currently in bring-up run with a smaller `max_num_seqs` (Llama-3.2-3B-Instruct on N150 is at 2 today). When that happens the eval client queues 32 requests onto a smaller-than-32-slot server, the queue serializes, the client's read timeout fires, and requests cancel mid-flight.

The data needed to do the right thing already exists: `DeviceModelSpec.max_concurrency` is set per (model, device, engine) in `workflows/model_spec.py`. The eval command builder just wasn't consulting it.

This is also the fix shape the team had in mind. From prior discussion on #3533:

> "We've seen this issue a couple of times ourselves and the solution we want to implement but have not gotten around to, is to source the correct concurrency factor from the ModelSpec object." — @bgoelTT

### What changed

`evals/run_evals.py` — `build_eval_command()` now reads `model_spec.device_model_spec.max_concurrency` and clamps both `task.max_concurrent` and `task.batch_size` to that ceiling before they go into the lm-eval / lmms-eval command line. Logs each clamp. Falls back to the task's value if ModelSpec doesn't expose the field (defensive — keeps behavior unchanged for older specs).

Net effect:
- Entries with `max_concurrency >= 32` (typical ttnn / vllm-tt): no change, clamp is a no-op.
- Entries with `max_concurrency < 32` (some forge LLMs currently in bring-up): `num_concurrent` and `batch_size` are clamped down to the declared ceiling.

Note: the clamp applies universally — no `engine == "forge"` branch. It's a no-op when `device_model_spec.max_concurrency >= task.max_concurrent`, which is the case for most ttnn / vllm-tt entries today. The functional effect lands on entries that declare smaller capacity, which today is mainly forge LLMs in bring-up but may apply to any future entry. The spec stays the source of truth; the eval runner just honors it.

~30 lines including comments.

### Relationship to other recent PRs

- **#3558 (forge concurrency)** — set the smaller `max_concurrency` values on currently-in-bring-up forge LLM `DeviceModelSpec` entries (Llama-3.2-3B-Instruct N150/N300 went to 2). That made the model spec *truthful* about each entry's current capacity. This PR makes the eval client *honor* it. Without #3558, those entries would have still reported the legacy `max_concurrency=32` and the clamp would be a no-op. The two PRs are complementary.
- **#3532 (`/v1/completions` batched-prompt schema + fan-out)** — also a precondition for evals: lm-eval with `batch_size=N` packs N prompts into one HTTP request as `prompt: [str1, ..., strN]`, which #3532's schema + fan-out accept. Required for evals to reach the server at all.

### Testing

Llama-3.2-3B-Instruct on forge (`max_num_seqs=2`, P150 host, fresh tt-shield-built image), smoke eval (`--limit-samples-mode smoke-test`).

**Clamp log fires correctly:**
```
INFO Clamping meta_gpqa batch_size: 32 -> 2 (device_model_spec.max_concurrency=2)
```

**Resulting lm-eval command uses the clamped value:**
```
lm_eval --tasks meta_gpqa --model local-completions ... --batch_size 2 ...
```

**Server processes the now-properly-sized batch with full parallelism (server log, single-millisecond resolution):**
```
02:34:39,671 - Device 0: Starting non-streaming batch generation for 1 requests  <- sub-req A
02:34:39,671 - Device 0: Starting non-streaming batch generation for 1 requests  <- sub-req B  (same ms)
02:34:39,671 - Device 0: Starting non-streaming generation
02:34:39,671 - Device 0: Starting non-streaming generation
02:34:40,022 - Device 0: Non-streaming generation completed                       <- both done
02:34:40,022 - Device 0: Non-streaming generation completed
02:34:40,022 - Device 0: Non-streaming batch generation completed for 1 requests
02:34:40,022 - Device 0: Non-streaming batch generation completed for 1 requests
02:34:40,023 - [process_request] async executed in 0.3525 seconds. Base processing request
```

Both sub-requests started in the *same millisecond* (02:34:39.671) and finished in the *same millisecond* (02:34:40.022). They ran concurrently — that's `max_num_seqs=2` doing its job. Total `process_request` time: 0.35s, well under any read-timeout.

Before the fix, with `batch_size=32` against this 2-slot configuration, the queue would have been ~16-deep, taking ~70s per HTTP request — over the openai-python default 60s read-timeout, causing requests to cancel mid-flight (the original failure mode of #3533). The same dynamic applies to any other entry whose `max_concurrency` is below 32 — current or future.

**Validation on ttnn entries (no-op path):** `DeviceModelSpec.max_concurrency=32` on Llama-3.2-3B-Instruct ttnn entries (`workflows/model_spec.py:2089`) → clamp condition `min(32, 32) == 32` → no-op, command unchanged. Behavior preserved.

### Out of scope (intentional)

- **Problem 1 of #3533 (server-side worker orphan-task drain):** even after the clamp, evals can still hang because cancelled tasks remain on the worker queue and get re-processed (`No result queue found for task ...` warnings in the server log). The clamp drastically reduces the *amplification factor* (32× → 2×) and makes the bug far less reachable on real workloads, but doesn't fix the underlying server-side issue. A separate PR will address the worker-side drain in `tt-media-server/model_services/`. Both PRs together resolve the forge LLM eval timeout end-to-end.

### Files changed

- `evals/run_evals.py` — clamp + logging in `build_eval_command()`.
