### PR TITLE
fix(forge): reject /v1/{,chat/}completions when prompt + max_tokens > max_model_len

### DIFF
--- a/tt-media-server/open_ai_api/chat.py
+++ b/tt-media-server/open_ai_api/chat.py
@@ -106,15 +106,26 @@ async def chat_completions(
     prompt = _apply_chat_template(messages)
     prompt_tokens = _count_tokens(prompt)
 
-    # Reject prompts that exceed the model's context window
+    # Reject prompts that won't leave room for the requested output. vLLM requires
+    # `prompt + max_tokens <= max_model_len`; an exact-fit prompt (== max_model_len)
+    # would otherwise fail deeper in the engine as an HTTP 500.
     max_model_len = settings.vllm.max_model_length
-    if prompt_tokens > max_model_len:
+    # Default to 1 when max_tokens is unset; vLLM needs >= 1 output token. Pass
+    # explicit values through (incl. 0) so the check matches what the engine sees.
+    output_tokens_needed = (
+        chat_request.max_tokens if chat_request.max_tokens is not None else 1
+    )
+    if prompt_tokens + output_tokens_needed > max_model_len:
         logger.warning(
-            f"Rejected prompt: length ({prompt_tokens}) exceeds max model length ({max_model_len})"
+            f"Rejected prompt: length ({prompt_tokens}) + max_tokens "
+            f"({output_tokens_needed}) exceeds max model length ({max_model_len})"
         )
         raise HTTPException(
             status_code=400,
-            detail=f"Prompt length ({prompt_tokens}) exceeds max model length ({max_model_len})",
+            detail=(
+                f"Prompt length ({prompt_tokens}) + max_tokens "
+                f"({output_tokens_needed}) exceeds max model length ({max_model_len})"
+            ),
         )
 
     # Build an internal CompletionRequest to reuse the existing inference pipeline

--- a/tt-media-server/open_ai_api/llm.py
+++ b/tt-media-server/open_ai_api/llm.py
@@ -57,6 +57,10 @@ async def complete_text(
     sub_requests = _split_batched_prompts(completion_request)
 
     # Compute prompt token counts (for context-window validation and usage stats).
+    # vLLM requires `prompt + max_tokens <= max_model_len`; a prompt that fits
+    # the context window exactly (prompt == max_model_len) leaves zero room for
+    # output and fails deep in the engine as an HTTP 500. Validate the combined
+    # length up front so the failure mode is a clean 400 from the handler.
     prompt_tokens_total = 0
     try:
         max_model_len = settings.vllm.max_model_length
@@ -69,13 +73,21 @@ async def complete_text(
             else:
                 prompt_tokens = 0
             prompt_tokens_total += prompt_tokens
-            if prompt_tokens > max_model_len:
+            # Default to 1 when max_tokens is unset; vLLM needs >= 1 output token.
+            # Pass explicit values through (incl. 0) so the check matches what the
+            # engine will actually try to allocate.
+            output_tokens_needed = r.max_tokens if r.max_tokens is not None else 1
+            if prompt_tokens + output_tokens_needed > max_model_len:
                 logger.warning(
-                    f"Rejected prompt: length ({prompt_tokens}) exceeds max model length ({max_model_len})"
+                    f"Rejected prompt: length ({prompt_tokens}) + max_tokens "
+                    f"({output_tokens_needed}) exceeds max model length ({max_model_len})"
                 )
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Prompt length ({prompt_tokens}) exceeds max model length ({max_model_len})",
+                    detail=(
+                        f"Prompt length ({prompt_tokens}) + max_tokens "
+                        f"({output_tokens_needed}) exceeds max model length ({max_model_len})"
+                    ),
                 )
     except HTTPException:
         raise

--- a/tt-media-server/tests/test_prompt_length_validation.py
+++ b/tt-media-server/tests/test_prompt_length_validation.py
@@ -70,10 +70,34 @@ class TestChatPromptLengthValidation:
 
         response = test_client.post(
             "/v1/chat/completions",
-            json={"messages": [{"role": "user", "content": "hello"}]},
+            json={"messages": [{"role": "user", "content": "hello"}], "max_tokens": 10},
         )
 
         assert response.status_code == 200
+
+    @patch("open_ai_api.chat._apply_chat_template", return_value="hello")
+    @patch("open_ai_api.chat._count_tokens", return_value=50)
+    @patch("open_ai_api.chat.settings")
+    def test_returns_400_when_prompt_plus_max_tokens_exceeds_limit(
+        self, mock_settings, mock_count, mock_template, test_client
+    ):
+        """Prompt fits within max_model_len on its own, but prompt + max_tokens does not."""
+        mock_settings.vllm.max_model_length = 100
+        mock_settings.vllm.model = "test-model"
+        mock_settings.model_weights_path = "test-model"
+
+        response = test_client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 200,
+            },
+        )
+
+        assert response.status_code == 400
+        assert "exceeds max model length" in response.json()["detail"]
+        assert "50" in response.json()["detail"]
+        assert "200" in response.json()["detail"]
 
 
 class TestCompletionsPromptLengthValidation:
@@ -124,3 +148,20 @@ class TestCompletionsPromptLengthValidation:
 
         # Won't be 400 — prompt is short enough
         assert response.status_code != 400
+
+    @patch("open_ai_api.llm.settings")
+    def test_returns_400_when_prompt_plus_max_tokens_exceeds_limit(
+        self, mock_settings, test_client
+    ):
+        """Prompt fits within max_model_len on its own, but prompt + max_tokens does not."""
+        mock_settings.vllm.max_model_length = 100
+
+        response = test_client.post(
+            "/v1/completions",
+            json={"prompt": list(range(50)), "max_tokens": 60},
+        )
+
+        assert response.status_code == 400
+        assert "exceeds max model length" in response.json()["detail"]
+        assert "50" in response.json()["detail"]
+        assert "60" in response.json()["detail"]


### PR DESCRIPTION
### Issue

Addresses Problem 3 of #3533

### Problem

Both `/v1/completions` (`tt-media-server/open_ai_api/llm.py`) and `/v1/chat/completions` (`tt-media-server/open_ai_api/chat.py`) pre-validate that prompt tokens fit within `max_model_len`, but each uses `prompt_tokens > max_model_len` — strictly greater than, no accounting for the requested output. A prompt that fits the context window exactly (e.g. 4096 of 4096 tokens) passes the check, then vLLM rejects it deeper with `decoder prompt (length 4096) plus the number of requested output tokens (at least 1) is longer than the maximum model length`. The handler's outer try/except wraps that as HTTP 500.

Surfaced by `meta_gpqa` evals on Llama-3.2-3B-Instruct (forge, `max_model_len=4096`): some samples produce prompts that exactly fill the context window after chat-template overhead. The resulting 500 also trips the orphan-task drain (Problem 1 of #3533), making the failure mode much worse than just a single 500. The chat endpoint has the same shape on the same forge stack and the same trigger paths (e.g. `vllm bench serve --backend openai-chat`, lm-eval tasks with `use_chat_api=True`, any OpenAI-compatible chat client).

### What changed

Both handlers — `complete_text()` in `llm.py` and `chat_completions()` in `chat.py` — now read `max_tokens` from the request (defaulting to 1 when `None`, matching vLLM's minimum-1-output-token requirement) and check `prompt_tokens + output_tokens_needed > max_model_len`. Failures continue to land as a 400 with a clearer detail string that includes both numbers. Same try/except structure preserved; the tokenizer-unavailable fallthrough path in `llm.py` is unchanged. ~25 lines effective change across both files, mechanically identical pattern.

### Testing

Llama-3.2-3B-Instruct on forge (`max_model_len=4096`, P150 host, bind-mounted patched `llm.py` + `chat.py`):

**`/v1/completions`:**

| Case | Prompt | max_tokens | Before fix | After fix | Outcome |
|---|---|---|---|---|---|
| A | ~4000-token string | 5 | 200 | 200 | unchanged success |
| B' | token-id list len=4097 | 5 | 400 | 400 | pre-existing `> max_model_len` rejection preserved |
| C | token-id list len=4096 | 5 | **500** | **400** | **fix:** prompt fills context window exactly — the meta_gpqa edge case |
| D | token-id list len=4090 | 10 (4090+10>4096) | **500** | **400** | **fix:** prompt + max_tokens crosses the line |
| E | token-id list len=4090 | 5 (4090+5≤4096) | 200 | 200 | unchanged success at edge |

**`/v1/chat/completions`:**

| Case | Prompt | max_tokens | Before fix | After fix | Outcome |
|---|---|---|---|---|---|
| F | short message | 5 | 200 | 200 | baseline |
| G | short message (37 tok after template) | 10000 | **500** | **400** | **fix:** caller asks for more output than fits |
| H' | very long message (~6000 tok) | 5 | 400 | 400 | pre-existing strict-greater-than rejection preserved |

Live response examples after the fix:

```
$ curl ... /v1/completions '{"prompt":[<4096 tokens>],"max_tokens":5}'
HTTP 400
{"detail":"Prompt length (4096) + max_tokens (5) exceeds max model length (4096)"}

$ curl ... /v1/chat/completions '{"messages":[...short msg...],"max_tokens":10000}'
HTTP 400
{"detail":"Prompt length (37) + max_tokens (10000) exceeds max model length (4096)"}
```

Server log on rejection (new format includes both numbers, making the cause explicit):
```
WARNING - Rejected prompt: length (4096) + max_tokens (5) exceeds max model length (4096)
WARNING - Rejected prompt: length (37)   + max_tokens (10000) exceeds max model length (4096)
WARNING - Rejected prompt: length (6036) + max_tokens (5) exceeds max model length (4096)
```

### Test updates:

The existing `tt-media-server/tests/test_prompt_length_validation.py` had one chat-side case that depended on the old "prompt-only" semantics. Under the new check, it failed on CI ([run](https://github.com/tenstorrent/tt-inference-server/actions/runs/26142645589/job/76891189727?pr=3628#step:6:1116)):

```
FAILED tt-media-server/tests/test_prompt_length_validation.py::TestChatPromptLengthValidation::test_returns_200_when_prompt_within_limit
  assert 400 == 200
```

Root cause: the test sent a chat request without specifying `max_tokens`, which defaults to `ChatCompletionRequest.max_tokens=2048`. Under the mocked `max_model_length=100`, the new `prompt + max_tokens > max_model_len` check correctly rejects it. The completions sibling test already passed `max_tokens=10` explicitly; the chat test now mirrors that.

Additionally, one new test per endpoint exercises the new edge case (prompt fits on its own, but `prompt + max_tokens` does not), so the behavioral change has dedicated coverage. All 7 tests in the file pass locally.

### Side-effect: avoids one Problem 1 trigger path

Failing in the FastAPI handler upfront — before `scheduler.process_request` runs — means no task is queued, no per-task `result_queue` is created, and the orphan-task drain bug in Problem 1 of #3533 cannot fire on this code path. Problem 1 still needs its own fix for the other trigger paths (client timeouts, mid-flight cancellations, etc.) and is tracked separately.

### Scope

Forge-only: these files (`tt-media-server/open_ai_api/{llm,chat}.py`) are the FastAPI handlers used by forge LLM containers (`ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:*`). ttnn / vllm-tt LLMs run in a separate stack (`vllm-tt-metal` images) with vLLM's native OpenAI-compatible server and are not affected by this change. Naming reflects this (`fix(forge): ...`).

### Files changed

- `tt-media-server/open_ai_api/llm.py` — tightened pre-validation in `complete_text()`.
- `tt-media-server/open_ai_api/chat.py` — tightened pre-validation in `chat_completions()` (same shape).
