### PR TITLE
Refactor shared socket transport state

### DIFF
--- a/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
@@ -101,6 +101,8 @@ class SocketManager {
  private:
   void messageLoop();
   void handleIncomingMessage(const std::vector<uint8_t>& data);
+  std::function<void(const std::vector<uint8_t>&)> getHandler(
+      const std::string& messageType) const;
 
   std::unique_ptr<ISocketTransport> transport_;
 

--- a/tt-media-server/cpp_server/include/sockets/socket_transport_state.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_transport_state.hpp
@@ -14,10 +14,6 @@ namespace tt::sockets {
 
 /**
  * @brief Shared state for concrete socket transports.
- *
- * The byte-level transport logic stays in
- * TcpSocketTransport/ZmqSocketTransport; this helper only owns common
- * lifecycle/status/callback state.
  */
 class SocketTransportState {
  protected:

--- a/tt-media-server/cpp_server/include/sockets/socket_transport_state.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_transport_state.hpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <utility>
+
+namespace tt::sockets {
+
+/**
+ * @brief Shared state for concrete socket transports.
+ *
+ * The byte-level transport logic stays in
+ * TcpSocketTransport/ZmqSocketTransport; this helper only owns common
+ * lifecycle/status/callback state.
+ */
+class SocketTransportState {
+ protected:
+  enum class Mode { SERVER, CLIENT };
+
+  SocketTransportState(uint32_t reconnectInitialDelayMs = 100,
+                       uint32_t reconnectMaxDelayMs = 5000)
+      : reconnectInitialDelayMs_(reconnectInitialDelayMs),
+        reconnectMaxDelayMs_(reconnectMaxDelayMs) {}
+
+  bool isConnectedState() const { return connected_; }
+
+  std::string getStatusString() const {
+    if (!running_) {
+      return "stopped";
+    }
+    if (connected_) {
+      return mode_ == Mode::SERVER ? "server:connected" : "client:connected";
+    }
+    return mode_ == Mode::SERVER ? "server:waiting" : "client:connecting";
+  }
+
+  const char* modeName() const {
+    return mode_ == Mode::SERVER ? "server" : "client";
+  }
+
+  void markDisconnected() { connected_ = false; }
+
+  void setConnectionLostCallbackCommon(std::function<void()> callback) {
+    std::lock_guard<std::mutex> lock(callbackMutex_);
+    connectionLostCallback_ = std::move(callback);
+  }
+
+  void notifyConnectionLost() {
+    std::function<void()> callback;
+    {
+      std::lock_guard<std::mutex> lock(callbackMutex_);
+      callback = connectionLostCallback_;
+    }
+    if (callback) {
+      callback();
+    }
+  }
+
+  void setReconnectBackoffCommon(uint32_t initialDelayMs, uint32_t maxDelayMs) {
+    reconnectInitialDelayMs_ = initialDelayMs;
+    reconnectMaxDelayMs_ = maxDelayMs;
+  }
+
+  Mode mode_{Mode::CLIENT};
+  std::atomic<bool> running_{false};
+  std::atomic<bool> connected_{false};
+  uint32_t reconnectInitialDelayMs_;
+  uint32_t reconnectMaxDelayMs_;
+
+ private:
+  mutable std::mutex callbackMutex_;
+  std::function<void()> connectionLostCallback_;
+};
+
+}  // namespace tt::sockets

--- a/tt-media-server/cpp_server/include/sockets/tcp_socket_transport.hpp
+++ b/tt-media-server/cpp_server/include/sockets/tcp_socket_transport.hpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "sockets/i_socket_transport.hpp"
+#include "sockets/socket_transport_state.hpp"
 #include "utils/scoped_fd.hpp"
 
 namespace tt::sockets {
@@ -26,7 +27,8 @@ namespace tt::sockets {
  * Original transport implementation — length-prefixed framing over a single
  * TCP connection with keepalive and automatic reconnect.
  */
-class TcpSocketTransport : public ISocketTransport {
+class TcpSocketTransport : public ISocketTransport,
+                           protected SocketTransportState {
  public:
   TcpSocketTransport() = default;
   TcpSocketTransport(const TcpSocketTransport&) = delete;
@@ -52,12 +54,14 @@ class TcpSocketTransport : public ISocketTransport {
                            uint32_t maxDelayMs) override;
 
  private:
-  enum class Mode { SERVER, CLIENT };
+  enum class ReceiveResult { COMPLETE, NO_DATA, DISCONNECTED };
 
   void serverLoop();
   void clientLoop();
+  bool sendAll(int fd, const void* buffer, size_t size);
+  ReceiveResult receiveExact(int fd, uint8_t* buffer, size_t size,
+                             int maxRetries, bool returnIfNoInitialData);
 
-  Mode mode_;
   std::string host_;
   uint16_t port_;
 
@@ -65,17 +69,9 @@ class TcpSocketTransport : public ISocketTransport {
   tt::utils::ScopedFd clientSocket_;
   std::atomic<int> peerSocket_{-1};
 
-  std::atomic<bool> running_{false};
-  std::atomic<bool> connected_{false};
-
   std::thread connectionThread_;
 
   mutable std::mutex socketMutex_;
-
-  std::function<void()> connectionLostCallback_;
-
-  uint32_t reconnectInitialDelayMs_{100};
-  uint32_t reconnectMaxDelayMs_{5000};
 };
 
 }  // namespace tt::sockets

--- a/tt-media-server/cpp_server/include/sockets/zmq_socket_transport.hpp
+++ b/tt-media-server/cpp_server/include/sockets/zmq_socket_transport.hpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "sockets/i_socket_transport.hpp"
+#include "sockets/socket_transport_state.hpp"
 
 // Forward-declare ZMQ types to avoid leaking zmq.hpp into every TU.
 namespace zmq {
@@ -31,7 +32,8 @@ namespace tt::sockets {
  * messaging over tcp://. ZMQ handles framing, reconnection, and keepalive
  * internally — no manual length-prefix or retry logic needed.
  */
-class ZmqSocketTransport : public ISocketTransport {
+class ZmqSocketTransport : public ISocketTransport,
+                           protected SocketTransportState {
  public:
   ZmqSocketTransport();
   ZmqSocketTransport(const ZmqSocketTransport&) = delete;
@@ -55,8 +57,6 @@ class ZmqSocketTransport : public ISocketTransport {
                            uint32_t maxDelayMs) override;
 
  private:
-  enum class Mode { SERVER, CLIENT };
-
   struct SendRequest {
     std::vector<uint8_t> data;
     std::promise<bool> result;
@@ -64,9 +64,12 @@ class ZmqSocketTransport : public ISocketTransport {
 
   bool startIoThread();
   void ioLoop(std::promise<bool> initialized);
+  bool initializeSocket();
   void setupMonitor();
   void monitorLoop(std::promise<void> ready);
   bool processPendingSends();
+  bool receiveAvailableMessages();
+  void waitForIoWork();
   void failPendingSends();
   void enqueueReceivedMessage(std::vector<uint8_t> data);
 
@@ -77,15 +80,12 @@ class ZmqSocketTransport : public ISocketTransport {
   std::vector<uint8_t> receiveAsRouter();
   std::vector<uint8_t> receiveAsDealer();
 
-  Mode mode_ = Mode::CLIENT;
   std::string endpoint_;
 
   std::unique_ptr<zmq::context_t> context_;
   std::unique_ptr<zmq::socket_t> socket_;
 
-  std::atomic<bool> running_{false};
   std::atomic<bool> ioActive_{false};
-  std::atomic<bool> connected_{false};
   std::atomic<bool> monitorActive_{false};
 
   std::thread ioThread_;
@@ -100,13 +100,6 @@ class ZmqSocketTransport : public ISocketTransport {
 
   std::mutex receiveMutex_;
   std::deque<std::vector<uint8_t>> receivedMessages_;
-
-  mutable std::mutex callbackMutex_;
-  std::function<void()> connectionLostCallback_;
-
-  // ZMQ_RECONNECT_IVL / ZMQ_RECONNECT_IVL_MAX, applied at initializeAsClient.
-  uint32_t reconnectInitialDelayMs_{1000};
-  uint32_t reconnectMaxDelayMs_{5000};
 };
 
 }  // namespace tt::sockets

--- a/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
+++ b/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
@@ -9,6 +9,10 @@
 
 namespace tt::sockets {
 
+namespace {
+constexpr auto MESSAGE_LOOP_SLEEP = std::chrono::milliseconds(10);
+}
+
 SocketManager::~SocketManager() { stop(); }
 
 void SocketManager::applyPendingSettings() {
@@ -74,7 +78,7 @@ void SocketManager::messageLoop() {
       TT_LOG_ERROR("[SocketManager] Message loop error: {}", e.what());
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(MESSAGE_LOOP_SLEEP);
   }
 }
 
@@ -87,17 +91,27 @@ void SocketManager::handleIncomingMessage(const std::vector<uint8_t>& data) {
     std::string messageType;
     archive(messageType);
 
-    std::lock_guard<std::mutex> lock(handlersMutex_);
-    auto it = handlers_.find(messageType);
-    if (it != handlers_.end()) {
-      it->second(data);
-    } else {
+    auto handler = getHandler(messageType);
+    if (!handler) {
       TT_LOG_DEBUG("[SocketManager] No handler for message type: {}",
                    messageType);
+      return;
     }
+
+    handler(data);
   } catch (const std::exception& e) {
     TT_LOG_ERROR("[SocketManager] Message handling error: {}", e.what());
   }
+}
+
+std::function<void(const std::vector<uint8_t>&)> SocketManager::getHandler(
+    const std::string& messageType) const {
+  std::lock_guard<std::mutex> lock(handlersMutex_);
+  auto it = handlers_.find(messageType);
+  if (it == handlers_.end()) {
+    return {};
+  }
+  return it->second;
 }
 
 bool SocketManager::isConnected() const {

--- a/tt-media-server/cpp_server/src/sockets/tcp_socket_transport.cpp
+++ b/tt-media-server/cpp_server/src/sockets/tcp_socket_transport.cpp
@@ -15,6 +15,18 @@
 namespace tt::sockets {
 
 namespace {
+constexpr int KEEPALIVE_IDLE_SECONDS = 10;
+constexpr int KEEPALIVE_INTERVAL_SECONDS = 5;
+constexpr int KEEPALIVE_MAX_PROBES = 3;
+constexpr int MAX_SEND_RETRIES = 100;
+constexpr int MAX_HEADER_RETRIES = 100;
+constexpr int MAX_PAYLOAD_RETRIES = 1000;
+constexpr uint32_t MAX_MESSAGE_SIZE_BYTES = 1024 * 1024;
+constexpr auto RETRY_SLEEP = std::chrono::milliseconds(1);
+constexpr auto CONNECTION_POLL_INTERVAL = std::chrono::milliseconds(100);
+
+bool wouldBlock() { return errno == EAGAIN || errno == EWOULDBLOCK; }
+
 void setSocketKeepAlive(int socketFd) {
   int enable = 1;
   if (setsockopt(socketFd, SOL_SOCKET, SO_KEEPALIVE, &enable, sizeof(enable)) <
@@ -23,21 +35,21 @@ void setSocketKeepAlive(int socketFd) {
                 strerror(errno));
   }
 
-  int idle = 10;
+  int idle = KEEPALIVE_IDLE_SECONDS;
   if (setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle)) <
       0) {
     TT_LOG_WARN("[TcpSocketTransport] Failed to set TCP_KEEPIDLE: {}",
                 strerror(errno));
   }
 
-  int interval = 5;
+  int interval = KEEPALIVE_INTERVAL_SECONDS;
   if (setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPINTVL, &interval,
                  sizeof(interval)) < 0) {
     TT_LOG_WARN("[TcpSocketTransport] Failed to set TCP_KEEPINTVL: {}",
                 strerror(errno));
   }
 
-  int maxProbes = 3;
+  int maxProbes = KEEPALIVE_MAX_PROBES;
   if (setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPCNT, &maxProbes,
                  sizeof(maxProbes)) < 0) {
     TT_LOG_WARN("[TcpSocketTransport] Failed to set TCP_KEEPCNT: {}",
@@ -137,11 +149,14 @@ void TcpSocketTransport::stop() {
   running_ = false;
   connected_ = false;
 
-  int fd = peerSocket_.load(std::memory_order_acquire);
-  if (fd >= 0) {
-    ::shutdown(fd, SHUT_RDWR);
+  {
+    std::lock_guard<std::mutex> lock(socketMutex_);
+    int fd = peerSocket_.load(std::memory_order_acquire);
+    if (fd >= 0) {
+      ::shutdown(fd, SHUT_RDWR);
+    }
+    peerSocket_.store(-1, std::memory_order_release);
   }
-  peerSocket_.store(-1, std::memory_order_release);
 
   if (serverSocket_) {
     ::shutdown(serverSocket_.get(), SHUT_RDWR);
@@ -151,8 +166,11 @@ void TcpSocketTransport::stop() {
     connectionThread_.join();
   }
 
-  clientSocket_.reset();
-  serverSocket_.reset();
+  {
+    std::lock_guard<std::mutex> lock(socketMutex_);
+    clientSocket_.reset();
+    serverSocket_.reset();
+  }
 
   TT_LOG_INFO("[TcpSocketTransport] Stopped");
 }
@@ -182,7 +200,7 @@ void TcpSocketTransport::serverLoop() {
                 inet_ntoa(clientAddr.sin_addr), ntohs(clientAddr.sin_port));
 
     while (running_ && connected_) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      std::this_thread::sleep_for(CONNECTION_POLL_INTERVAL);
     }
 
     {
@@ -190,10 +208,8 @@ void TcpSocketTransport::serverLoop() {
       peerSocket_.store(-1, std::memory_order_release);
       accepted.reset();
     }
-    connected_ = false;
-    if (connectionLostCallback_) {
-      connectionLostCallback_();
-    }
+    markDisconnected();
+    notifyConnectionLost();
 
     TT_LOG_INFO("[TcpSocketTransport] Client disconnected");
   }
@@ -248,7 +264,7 @@ void TcpSocketTransport::clientLoop() {
     TT_LOG_INFO("[TcpSocketTransport] Connected to server");
 
     while (running_ && connected_) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      std::this_thread::sleep_for(CONNECTION_POLL_INTERVAL);
     }
 
     {
@@ -256,10 +272,8 @@ void TcpSocketTransport::clientLoop() {
       peerSocket_.store(-1, std::memory_order_release);
       clientSocket_.reset();
     }
-    connected_ = false;
-    if (connectionLostCallback_) {
-      connectionLostCallback_();
-    }
+    markDisconnected();
+    notifyConnectionLost();
 
     TT_LOG_INFO("[TcpSocketTransport] Disconnected from server");
   }
@@ -275,39 +289,36 @@ bool TcpSocketTransport::sendRawData(const std::vector<uint8_t>& data) {
   uint32_t size = static_cast<uint32_t>(data.size());
   uint32_t netSize = htonl(size);
 
-  // Send with retry on EAGAIN — the socket is non-blocking, so a transient
-  // "would block" on the header should not disconnect the peer.
-  auto sendAll = [&](const void* buf, size_t len) -> bool {
-    size_t sent = 0;
-    int retries = 0;
-    const int maxRetries = 100;
-    while (sent < len) {
-      ssize_t n = send(fd, static_cast<const uint8_t*>(buf) + sent, len - sent,
-                       MSG_NOSIGNAL);
-      if (n > 0) {
-        sent += static_cast<size_t>(n);
-        retries = 0;
-      } else if (n == 0) {
-        connected_ = false;
-        return false;
-      } else {
-        if (errno == EAGAIN || errno == EWOULDBLOCK) {
-          if (++retries > maxRetries) {
-            connected_ = false;
-            return false;
-          }
-          std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        } else {
-          connected_ = false;
-          return false;
-        }
-      }
-    }
-    return true;
-  };
+  if (!sendAll(fd, &netSize, sizeof(netSize))) return false;
+  if (!sendAll(fd, data.data(), data.size())) return false;
 
-  if (!sendAll(&netSize, sizeof(netSize))) return false;
-  if (!sendAll(data.data(), data.size())) return false;
+  return true;
+}
+
+bool TcpSocketTransport::sendAll(int fd, const void* buffer, size_t size) {
+  size_t sent = 0;
+  int retries = 0;
+  const auto* data = static_cast<const uint8_t*>(buffer);
+
+  while (sent < size) {
+    ssize_t n = send(fd, data + sent, size - sent, MSG_NOSIGNAL);
+    if (n > 0) {
+      sent += static_cast<size_t>(n);
+      retries = 0;
+      continue;
+    }
+
+    if (n == 0 || !wouldBlock()) {
+      markDisconnected();
+      return false;
+    }
+
+    if (++retries > MAX_SEND_RETRIES) {
+      markDisconnected();
+      return false;
+    }
+    std::this_thread::sleep_for(RETRY_SLEEP);
+  }
 
   return true;
 }
@@ -319,105 +330,83 @@ std::vector<uint8_t> TcpSocketTransport::receiveRawData() {
   int fd = peerSocket_.load(std::memory_order_acquire);
   if (fd < 0) return {};
 
-  // Read the 4-byte length header. The first recv uses MSG_DONTWAIT so the
-  // call returns immediately when no data is available (EAGAIN). If a partial
-  // header arrives, retry with a short timeout rather than treating it as a
-  // disconnect — partial reads are possible on non-blocking sockets.
   uint32_t netSize = 0;
-  size_t headerReceived = 0;
-  int headerRetries = 0;
-  const int maxHeaderRetries = 100;  // 100ms timeout (100 * 1ms)
-
-  while (headerReceived < sizeof(netSize)) {
-    ssize_t n = recv(fd, reinterpret_cast<uint8_t*>(&netSize) + headerReceived,
-                     sizeof(netSize) - headerReceived,
-                     headerReceived == 0 ? MSG_DONTWAIT : 0);
-    if (n > 0) {
-      headerReceived += static_cast<size_t>(n);
-      headerRetries = 0;
-    } else if (n == 0) {
-      connected_ = false;
-      return {};
-    } else {
-      if (errno == EAGAIN || errno == EWOULDBLOCK) {
-        if (headerReceived == 0) {
-          // No data available yet — normal, just return empty.
-          return {};
-        }
-        // Partial header: wait briefly for the rest.
-        if (++headerRetries > maxHeaderRetries) {
-          connected_ = false;
-          return {};
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      } else {
-        connected_ = false;
-        return {};
-      }
-    }
+  auto headerStatus =
+      receiveExact(fd, reinterpret_cast<uint8_t*>(&netSize), sizeof(netSize),
+                   MAX_HEADER_RETRIES, /*returnIfNoInitialData=*/true);
+  if (headerStatus == ReceiveResult::NO_DATA) {
+    return {};
+  }
+  if (headerStatus == ReceiveResult::DISCONNECTED) {
+    markDisconnected();
+    return {};
   }
 
   uint32_t size = ntohl(netSize);
-  if (size == 0 || size > 1024 * 1024) {  // Max 1MB per message
-    connected_ = false;
+  if (size == 0 || size > MAX_MESSAGE_SIZE_BYTES) {
+    markDisconnected();
     return {};
   }
 
   std::vector<uint8_t> data(size);
-  size_t totalReceived = 0;
-  int retryCount = 0;
-  const int maxRetries = 1000;  // 1 second timeout (1000 * 1ms)
-
-  while (totalReceived < size) {
-    ssize_t received =
-        recv(fd, data.data() + totalReceived, size - totalReceived, 0);
-    if (received > 0) {
-      totalReceived += static_cast<size_t>(received);
-      retryCount = 0;
-    } else if (received == 0) {
-      connected_ = false;
-      return {};
-    } else {
-      if (errno == EAGAIN || errno == EWOULDBLOCK) {
-        if (++retryCount > maxRetries) {
-          TT_LOG_ERROR("[TcpSocketTransport] Timeout waiting for message data");
-          connected_ = false;
-          return {};
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        continue;
-      }
-      connected_ = false;
-      return {};
-    }
+  auto payloadStatus =
+      receiveExact(fd, data.data(), data.size(), MAX_PAYLOAD_RETRIES,
+                   /*returnIfNoInitialData=*/false);
+  if (payloadStatus != ReceiveResult::COMPLETE) {
+    markDisconnected();
+    return {};
   }
 
   return data;
 }
 
-bool TcpSocketTransport::isConnected() const { return connected_; }
+TcpSocketTransport::ReceiveResult TcpSocketTransport::receiveExact(
+    int fd, uint8_t* buffer, size_t size, int maxRetries,
+    bool returnIfNoInitialData) {
+  size_t receivedTotal = 0;
+  int retries = 0;
 
-std::string TcpSocketTransport::getStatus() const {
-  if (!running_) {
-    return "stopped";
+  while (receivedTotal < size) {
+    const int flags =
+        receivedTotal == 0 && returnIfNoInitialData ? MSG_DONTWAIT : 0;
+    ssize_t received =
+        recv(fd, buffer + receivedTotal, size - receivedTotal, flags);
+
+    if (received > 0) {
+      receivedTotal += static_cast<size_t>(received);
+      retries = 0;
+      continue;
+    }
+
+    if (received == 0 || !wouldBlock()) {
+      return ReceiveResult::DISCONNECTED;
+    }
+
+    if (receivedTotal == 0 && returnIfNoInitialData) {
+      return ReceiveResult::NO_DATA;
+    }
+
+    if (++retries > maxRetries) {
+      return ReceiveResult::DISCONNECTED;
+    }
+    std::this_thread::sleep_for(RETRY_SLEEP);
   }
 
-  if (connected_) {
-    return mode_ == Mode::SERVER ? "server:connected" : "client:connected";
-  }
-
-  return mode_ == Mode::SERVER ? "server:waiting" : "client:connecting";
+  return ReceiveResult::COMPLETE;
 }
+
+bool TcpSocketTransport::isConnected() const { return isConnectedState(); }
+
+std::string TcpSocketTransport::getStatus() const { return getStatusString(); }
 
 void TcpSocketTransport::setConnectionLostCallback(
     std::function<void()> callback) {
-  connectionLostCallback_ = std::move(callback);
+  setConnectionLostCallbackCommon(std::move(callback));
 }
 
 void TcpSocketTransport::setReconnectBackoff(uint32_t initialDelayMs,
                                              uint32_t maxDelayMs) {
-  reconnectInitialDelayMs_ = initialDelayMs;
-  reconnectMaxDelayMs_ = maxDelayMs;
+  setReconnectBackoffCommon(initialDelayMs, maxDelayMs);
 }
 
 }  // namespace tt::sockets

--- a/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
+++ b/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
@@ -15,6 +15,11 @@
 namespace tt::sockets {
 
 namespace {
+constexpr int ZMQ_CONTEXT_IO_THREADS = 1;
+constexpr int ZMQ_RECEIVE_TIMEOUT_MS = 100;
+constexpr int ZMQ_MONITOR_TIMEOUT_MS = 200;
+constexpr auto IO_IDLE_WAIT = std::chrono::milliseconds(1);
+
 std::string makeMonitorEndpoint(const void* self) {
   return "inproc://zmq-monitor-" +
          std::to_string(reinterpret_cast<uintptr_t>(self));
@@ -22,7 +27,9 @@ std::string makeMonitorEndpoint(const void* self) {
 }  // namespace
 
 ZmqSocketTransport::ZmqSocketTransport()
-    : context_(std::make_unique<zmq::context_t>(1)) {}
+    : SocketTransportState(/*reconnectInitialDelayMs=*/1000,
+                           /*reconnectMaxDelayMs=*/5000),
+      context_(std::make_unique<zmq::context_t>(ZMQ_CONTEXT_IO_THREADS)) {}
 
 ZmqSocketTransport::~ZmqSocketTransport() { stop(); }
 
@@ -56,12 +63,36 @@ bool ZmqSocketTransport::startIoThread() {
 }
 
 void ZmqSocketTransport::ioLoop(std::promise<bool> initialized) {
+  if (!initializeSocket()) {
+    initialized.set_value(false);
+    return;
+  }
+
+  initialized.set_value(true);
+
+  while (ioActive_) {
+    const bool sent = processPendingSends();
+    const bool received = receiveAvailableMessages();
+
+    if (!sent && !received) {
+      waitForIoWork();
+    }
+  }
+
+  failPendingSends();
+  if (socket_) {
+    socket_->close();
+    socket_.reset();
+  }
+}
+
+bool ZmqSocketTransport::initializeSocket() {
   try {
     socket_ = std::make_unique<zmq::socket_t>(
         *context_, mode_ == Mode::SERVER ? zmq::socket_type::router
                                          : zmq::socket_type::dealer);
     socket_->set(zmq::sockopt::linger, 0);
-    socket_->set(zmq::sockopt::rcvtimeo, 100);  // 100ms poll timeout
+    socket_->set(zmq::sockopt::rcvtimeo, ZMQ_RECEIVE_TIMEOUT_MS);
     if (mode_ == Mode::CLIENT) {
       socket_->set(zmq::sockopt::reconnect_ivl,
                    static_cast<int>(reconnectInitialDelayMs_));
@@ -76,7 +107,7 @@ void ZmqSocketTransport::ioLoop(std::promise<bool> initialized) {
       socket_->connect(endpoint_);
       TT_LOG_INFO("[ZmqSocketTransport] Client connecting to {}", endpoint_);
     }
-    initialized.set_value(true);
+    return true;
   } catch (const zmq::error_t& e) {
     TT_LOG_ERROR("[ZmqSocketTransport] Failed to initialize {}: {}", endpoint_,
                  e.what());
@@ -86,39 +117,7 @@ void ZmqSocketTransport::ioLoop(std::promise<bool> initialized) {
     if (monitorThread_.joinable()) {
       monitorThread_.join();
     }
-    initialized.set_value(false);
-    return;
-  }
-
-  while (ioActive_) {
-    const bool sent = processPendingSends();
-
-    bool received = false;
-    try {
-      while (true) {
-        auto data =
-            mode_ == Mode::SERVER ? receiveAsRouter() : receiveAsDealer();
-        if (data.empty()) break;
-        enqueueReceivedMessage(std::move(data));
-        received = true;
-      }
-    } catch (const zmq::error_t& e) {
-      if (e.num() != EAGAIN) {
-        TT_LOG_ERROR("[ZmqSocketTransport] Recv failed: {}", e.what());
-      }
-    }
-
-    if (!sent && !received) {
-      std::unique_lock<std::mutex> lock(sendMutex_);
-      sendCv_.wait_for(lock, std::chrono::milliseconds(1),
-                       [this] { return !pendingSends_.empty() || !ioActive_; });
-    }
-  }
-
-  failPendingSends();
-  if (socket_) {
-    socket_->close();
-    socket_.reset();
+    return false;
   }
 }
 
@@ -151,8 +150,7 @@ void ZmqSocketTransport::start() {
   // initializeAsClient/Server) may already have observed and recorded a
   // CONNECTED/ACCEPTED event that fired between connect()/bind() and start().
 
-  TT_LOG_INFO("[ZmqSocketTransport] Started ({})",
-              mode_ == Mode::SERVER ? "server" : "client");
+  TT_LOG_INFO("[ZmqSocketTransport] Started ({})", modeName());
 }
 
 void ZmqSocketTransport::stop() {
@@ -182,7 +180,7 @@ void ZmqSocketTransport::monitorLoop(std::promise<void> ready) {
   zmq::socket_t monitorSocket(*context_, zmq::socket_type::pair);
   try {
     monitorSocket.set(zmq::sockopt::linger, 0);
-    monitorSocket.set(zmq::sockopt::rcvtimeo, 200);
+    monitorSocket.set(zmq::sockopt::rcvtimeo, ZMQ_MONITOR_TIMEOUT_MS);
     monitorSocket.connect(makeMonitorEndpoint(this));
   } catch (const zmq::error_t& e) {
     ready.set_value();
@@ -210,22 +208,14 @@ void ZmqSocketTransport::monitorLoop(std::promise<void> ready) {
       if (eventId == ZMQ_EVENT_CONNECTED || eventId == ZMQ_EVENT_ACCEPTED) {
         bool wasConnected = connected_.exchange(true);
         if (!wasConnected) {
-          TT_LOG_DEBUG("[ZmqSocketTransport] Peer connected ({})",
-                       mode_ == Mode::SERVER ? "server" : "client");
+          TT_LOG_DEBUG("[ZmqSocketTransport] Peer connected ({})", modeName());
         }
       } else if (eventId == ZMQ_EVENT_DISCONNECTED) {
         bool wasConnected = connected_.exchange(false);
         if (wasConnected) {
           TT_LOG_DEBUG("[ZmqSocketTransport] Peer disconnected ({})",
-                       mode_ == Mode::SERVER ? "server" : "client");
-          std::function<void()> callback;
-          {
-            std::lock_guard<std::mutex> callbackLock(callbackMutex_);
-            callback = connectionLostCallback_;
-          }
-          if (callback) {
-            callback();
-          }
+                       modeName());
+          notifyConnectionLost();
         }
       }
     } catch (const zmq::error_t& e) {
@@ -235,15 +225,9 @@ void ZmqSocketTransport::monitorLoop(std::promise<void> ready) {
   }
 }
 
-bool ZmqSocketTransport::isConnected() const { return connected_; }
+bool ZmqSocketTransport::isConnected() const { return isConnectedState(); }
 
-std::string ZmqSocketTransport::getStatus() const {
-  if (!running_) return "stopped";
-  if (connected_) {
-    return mode_ == Mode::SERVER ? "server:connected" : "client:connected";
-  }
-  return mode_ == Mode::SERVER ? "server:waiting" : "client:connecting";
-}
+std::string ZmqSocketTransport::getStatus() const { return getStatusString(); }
 
 bool ZmqSocketTransport::sendRawData(const std::vector<uint8_t>& data) {
   if (!running_ || !ioActive_) return false;
@@ -289,6 +273,29 @@ bool ZmqSocketTransport::processPendingSends() {
     request->result.set_value(ok);
     processed = true;
   }
+}
+
+bool ZmqSocketTransport::receiveAvailableMessages() {
+  bool received = false;
+  try {
+    while (true) {
+      auto data = mode_ == Mode::SERVER ? receiveAsRouter() : receiveAsDealer();
+      if (data.empty()) break;
+      enqueueReceivedMessage(std::move(data));
+      received = true;
+    }
+  } catch (const zmq::error_t& e) {
+    if (e.num() != EAGAIN) {
+      TT_LOG_ERROR("[ZmqSocketTransport] Recv failed: {}", e.what());
+    }
+  }
+  return received;
+}
+
+void ZmqSocketTransport::waitForIoWork() {
+  std::unique_lock<std::mutex> lock(sendMutex_);
+  sendCv_.wait_for(lock, IO_IDLE_WAIT,
+                   [this] { return !pendingSends_.empty() || !ioActive_; });
 }
 
 void ZmqSocketTransport::failPendingSends() {
@@ -372,14 +379,12 @@ std::vector<uint8_t> ZmqSocketTransport::receiveAsDealer() {
 
 void ZmqSocketTransport::setConnectionLostCallback(
     std::function<void()> callback) {
-  std::lock_guard<std::mutex> lock(callbackMutex_);
-  connectionLostCallback_ = std::move(callback);
+  setConnectionLostCallbackCommon(std::move(callback));
 }
 
 void ZmqSocketTransport::setReconnectBackoff(uint32_t initialDelayMs,
                                              uint32_t maxDelayMs) {
-  reconnectInitialDelayMs_ = initialDelayMs;
-  reconnectMaxDelayMs_ = maxDelayMs;
+  setReconnectBackoffCommon(initialDelayMs, maxDelayMs);
 }
 
 }  // namespace tt::sockets


### PR DESCRIPTION
- Extract common TCP/ZMQ transport state into `SocketTransportState`
- Share connection status, reconnect backoff, and connection-lost callback handling
- Keep TCP framing and ZMQ owner-thread send/receive logic transport-specific