### PR TITLE
fix(forge): cancel in-flight worker tasks when result queue is torn down

### DIFF
--- a/tt-media-server/device_workers/device_worker.py
+++ b/tt-media-server/device_workers/device_worker.py
@@ -18,6 +18,7 @@ def device_worker(
     warmup_signals_queue: Queue,
     error_queue: Queue,
     result_queue_name: None | str = None,
+    cancel_queue: Queue = None,  # accepted for signature parity with dynamic-batch worker; unused here (legacy batched-sync path has no async tasks to cancel mid-flight).
 ):
     logger = TTLogger()
 

--- a/tt-media-server/device_workers/device_worker_dynamic_batch.py
+++ b/tt-media-server/device_workers/device_worker_dynamic_batch.py
@@ -20,8 +20,13 @@ def device_worker(
     warmup_signals_queue: Queue,
     error_queue: Queue,
     result_queue_name: str = None,
+    cancel_queue: Queue = None,
 ):
     logger = TTLogger()
+    # Map of in-flight asyncio tasks keyed by request._task_id. Populated when
+    # request_feeder schedules a handler; cleared by a done-callback. Used by
+    # cancel_listener to abort orphaned tasks (#3533 Problem 1).
+    in_flight: dict[str, asyncio.Task] = {}
 
     # attach to queue if it's provided
     if result_queue_name is not None:
@@ -72,6 +77,12 @@ def device_worker(
             logger.info(
                 f"Worker {worker_id} finished streaming chunks for task {request._task_id}"
             )
+        except asyncio.CancelledError:
+            # Orphaned by client cancel / timeout; vLLM will release the slot
+            # once the iterator closes. Don't push to error_queue — the caller
+            # already abandoned the result_queue.
+            logger.info(f"Streaming task {request._task_id} cancelled")
+            raise
         except Exception as e:
             logger.error(f"Streaming failed for task {request._task_id}: {e}")
             error_queue.put((worker_id, request._task_id, str(e)))
@@ -84,9 +95,48 @@ def device_worker(
                 result_queue.put((worker_id, request._task_id, response[0]))
             else:
                 error_queue.put((worker_id, request._task_id, "No response generated"))
+        except asyncio.CancelledError:
+            # See handle_streaming — caller has gone away, don't report error.
+            logger.info(f"Non-streaming task {request._task_id} cancelled")
+            raise
         except Exception as e:
             logger.error(f"Execution failed for task {request._task_id}: {e}")
             error_queue.put((worker_id, request._task_id, str(e)))
+
+    async def cancel_listener():
+        """Watch cancel_queue and cancel any matching in-flight asyncio task.
+
+        Cancellation propagates into `device_runner._run_async`, which is an
+        async iterator over `llm_engine.generate(...)` — vLLM observes the
+        consumer closing and aborts its internal request, freeing the slot.
+        """
+        if cancel_queue is None:
+            return
+        while True:
+            try:
+                task_id = await loop.run_in_executor(None, cancel_queue.get)
+            except Exception as e:
+                logger.warning(f"cancel_listener queue read failed: {e}")
+                return
+            if task_id is None:
+                logger.info(f"Worker {worker_id} cancel_listener exiting")
+                return
+            target = in_flight.get(task_id)
+            if target is None or target.done():
+                # Already finished — common when client polite-disconnects right
+                # at the end. Nothing to do.
+                continue
+            logger.info(f"Worker {worker_id} aborting in-flight task {task_id}")
+            target.cancel()
+
+    def _track(request, task):
+        """Register a fire-and-forget handler so cancel_listener can find it.
+
+        Calling .cancel() on a not-yet-started asyncio task is safe — the
+        cancellation surfaces as CancelledError on its first run-step.
+        """
+        in_flight[request._task_id] = task
+        task.add_done_callback(lambda _t: in_flight.pop(request._task_id, None))
 
     # Async task that pulls from queue and feeds requests to handlers
     async def request_feeder():
@@ -95,6 +145,7 @@ def device_worker(
         settings = get_settings()
         """Continuously pull requests from queue and submit to async handlers"""
         batch_size = settings.vllm.max_num_seqs
+        cancel_task = asyncio.create_task(cancel_listener())
         while True:
             # Run blocking queue.get() in thread pool to not block event loop
             requests = await loop.run_in_executor(
@@ -105,15 +156,17 @@ def device_worker(
             for request in requests:
                 if request == SHUTDOWN_SIGNAL:
                     logger.info(f"Worker {worker_id} received shutdown signal")
+                    if not cancel_task.done():
+                        cancel_task.cancel()
                     return
                 if request is None:
                     continue
                 if hasattr(request, "stream") and request.stream:
                     # Fire and forget streaming task - runs concurrently
-                    asyncio.create_task(handle_streaming(request))
+                    _track(request, asyncio.create_task(handle_streaming(request)))
                 else:
                     # Fire and forget non-streaming task - runs concurrently in event loop
-                    asyncio.create_task(handle_non_streaming(request))
+                    _track(request, asyncio.create_task(handle_non_streaming(request)))
 
     try:
         loop.run_until_complete(request_feeder())

--- a/tt-media-server/model_services/base_service.py
+++ b/tt-media-server/model_services/base_service.py
@@ -133,6 +133,14 @@ class BaseService(ABC):
     async def pre_process(self, request):
         return request
 
+    def _teardown_task(self, task_id: str) -> None:
+        """Drop the per-task result queue and signal the worker to abort any
+        in-flight asyncio task for this id. Idempotent — on the success path
+        the worker has already finished and the cancel signal is a no-op.
+        See #3533 (Problem 1)."""
+        self.scheduler.result_queues.pop(task_id, None)
+        self.scheduler.cancel_task(task_id)
+
     async def process(self, request):
         queue = asyncio.Queue()
         self.scheduler.result_queues[request._task_id] = queue
@@ -160,7 +168,7 @@ class BaseService(ABC):
             self.logger.error(f"Error processing request: {e}")
             raise e
         finally:
-            self.scheduler.result_queues.pop(request._task_id, None)
+            self._teardown_task(request._task_id)
 
     def handle_streaming_chunk(self, chunk):
         formatted_chunk = chunk["chunk"]
@@ -226,4 +234,4 @@ class BaseService(ABC):
             )
             raise
         finally:
-            self.scheduler.result_queues.pop(request._task_id, None)
+            self._teardown_task(request._task_id)

--- a/tt-media-server/model_services/scheduler.py
+++ b/tt-media-server/model_services/scheduler.py
@@ -51,6 +51,14 @@ class Scheduler:
             )
 
         self.error_queue = Queue()
+        # Cancellation channel: when a FastAPI handler is cancelled or errored
+        # out mid-flight (client read-timeout, asyncio.CancelledError, etc.),
+        # base_service.process() pushes the request's task_id here so the worker
+        # can abort the in-flight asyncio task in vLLM and free the slot it was
+        # holding. Without this, the engine continues generating until natural
+        # completion, starving sibling sub-requests waiting on max_num_seqs.
+        # See #3533 (Problem 1).
+        self.cancel_queue = Queue()
 
     def get_worker_count(self):
         if not hasattr(self, "worker_count"):
@@ -70,6 +78,20 @@ class Scheduler:
         self.listener_task_ref = None
         self.device_warmup_listener_ref = None
         self.error_queue_listener_ref = None
+
+    def cancel_task(self, task_id: str) -> None:
+        """Signal the worker that the given task_id should be aborted.
+
+        Best-effort and non-blocking: the worker may already have finished the
+        task (in which case the signal is a no-op), or the cancel_queue may be
+        unavailable during shutdown. Either way we don't raise.
+        """
+        if not task_id:
+            return
+        try:
+            self.cancel_queue.put(task_id, block=False)
+        except Exception:
+            pass
 
     def process_request(self, request):
         try:
@@ -188,6 +210,7 @@ class Scheduler:
                 if self.settings.queue_for_multiprocessing
                 == QueueType.MemoryQueue.value
                 else None,
+                self.cancel_queue,
             ),
             name=f"DeviceWorker-{worker_id}",
         )
@@ -410,12 +433,19 @@ class Scheduler:
 
                 self.error_queue.put((None, None, None), timeout=1.0)
                 self.warmup_signals_queue.put(None, timeout=1.0)
+                # Wake the worker's cancel_listener so it can exit cleanly.
+                self.cancel_queue.put(None, timeout=1.0)
             except Exception:
                 self.logger.warning("Timeout sending shutdown signals to listeners")
 
             # Close all worker queues
             self._close_queues(
-                [self.task_queue, self.warmup_signals_queue, self.error_queue]
+                [
+                    self.task_queue,
+                    self.warmup_signals_queue,
+                    self.error_queue,
+                    self.cancel_queue,
+                ]
                 + list(self.result_queues_by_worker.values())
             )
 


### PR DESCRIPTION
### Issue

Addresses Problem 1 of #3533

### Problem

When a `/v1/{,chat/}completions` handler is cancelled or errored out mid-flight — server-side `request_processing_timeout_seconds` firing on a slow request, `asyncio.CancelledError` propagating, or an HTTP error after the request was already submitted to the worker — `base_service.py`'s `finally` clause popped the per-task `result_queue` but left the request running in vLLM. The engine continued generating until natural completion, holding one of `max_num_seqs` slots and starving sibling sub-requests behind it.

A telltale warning fires when the orphaned worker eventually writes its result back to a `result_queue` that no longer exists:
```
ERROR - [process_request] async failed after 1000.0009 seconds.
WARNING - No result queue found for task 82b3fbc4-... Current queues: [<sibling>]
INFO  - Worker 0 processing tasks: 1
INFO  - Device 0: Starting non-streaming batch generation for 1 requests
INFO  - [run] executed in 71.3360 seconds. Run VLLM inference
WARNING - No result queue found for task 82b3fbc4-...   (sibling now also gone)
```

The compound effect is that long-running evals on a low-concurrency model (e.g. forge LLMs with `max_num_seqs=2`) can stall: one orphan holds a slot for tens of seconds, sibling sub-requests fan-out behind it, and `lm-eval`'s `httpx` read-timeout fires, cancelling more requests and feeding more orphans into the queue.

### What changed

Plumb a cancellation channel between the FastAPI handler (main process) and the worker (subprocess) so the worker can abort the in-flight asyncio task — which propagates into vLLM's internal request abort and frees the slot.

**`tt-media-server/model_services/scheduler.py`** (+32 lines)
- New `self.cancel_queue = multiprocessing.Queue()` in `_start_queues`.
- New `cancel_task(task_id)` API: non-blocking put on `cancel_queue`. Swallows exceptions so callers don't have to (best-effort during shutdown).
- `cancel_queue` passed as a new positional Process arg in `_start_worker`.
- Shutdown sentinel sent + queue closed in `stop_workers`.

**`tt-media-server/model_services/base_service.py`** (+12 lines)
- New `_teardown_task(task_id)` helper that pops `result_queues[task_id]` and calls `scheduler.cancel_task(task_id)`.
- Both `process()` and `process_streaming()` `finally` blocks call `_teardown_task` so the contract is consistent across paths. Idempotent — on the success path the worker has already finished and the cancel signal is a no-op (the worker's `in_flight` dict no longer contains the task).

**`tt-media-server/device_workers/device_worker_dynamic_batch.py`** (+59 lines)
- New `cancel_queue: Queue = None` arg.
- New `in_flight: dict[str, asyncio.Task]` mapping `task_id` → asyncio task for the handler, populated by a tiny `_track` helper that also sets a done-callback to pop on completion.
- New `cancel_listener()` coroutine that blocks on `cancel_queue.get` via `loop.run_in_executor`, looks up the task in `in_flight`, and calls `target.cancel()` when present. Honors `None` shutdown sentinel.
- `handle_streaming` and `handle_non_streaming` gain an `except asyncio.CancelledError` block that logs and re-raises (no push to `error_queue` — the caller has already abandoned the result_queue).
- `request_feeder` spawns the `cancel_listener` at startup and registers each handler via `_track`.

**`tt-media-server/device_workers/device_worker.py`** (+1 line)
- Accepts `cancel_queue` for signature parity with the dynamic-batch worker; doesn't use it (the legacy batched-sync path has no in-flight asyncio tasks to cancel mid-flight).

Net: ~99 lines effective change across 4 files; ~50 of those are comments.

### Mechanism walkthrough

1. Client sends `/v1/completions`. FastAPI handler enters `base_service.process()`.
2. Handler creates `result_queues[task_id] = asyncio.Queue()`, submits to `scheduler.task_queue`, awaits `result_queue.get(timeout=request_processing_timeout_seconds)`.
3. Worker pulls task, dispatches `asyncio.create_task(handle_non_streaming(request))`, `_track` records it in `in_flight`.
4. *Either*: the handler's `await` completes normally → result returned → finally fires `_teardown_task` → cancel signal arrives at worker → `in_flight.get(task_id)` returns None (handler already removed via done-callback) → no-op. Cheap.
5. *Or*: the handler's `await` raises (timeout, CancelledError, worker-pushed exception) → finally fires `_teardown_task` → cancel signal arrives at worker → `in_flight.get(task_id)` returns the still-running asyncio task → `target.cancel()` → CancelledError raised inside `async for request_output in llm_engine.generate(...)` → vLLM observes the consumer closing and aborts its internal request → slot freed.

### Scope

Forge-only:
- The dynamic-batch worker (`device_worker_dynamic_batch.py`) is the path used by forge LLMs (vLLM AsyncLLMEngine async-iterator generation).
- The legacy batched-sync worker (`device_worker.py`) has no concept of mid-flight async cancellation — its `device_runner.run([requests])` call is synchronous from the worker's perspective.
- ttnn / vllm-tt LLMs run in a different container with vLLM's native OpenAI-compatible server; this change does not affect them.

### Testing

- Unit-test path: `tt-media-server/tests/` still passes (pre-commit pytest green on every push).
- Live wiring verified on Llama-3.2-3B-Instruct forge container (P150 host, `max_num_seqs=2`, bind-mounted patched files plus the prompt-validation and clamp fixes from sister branches):
  - `T1` baseline `/v1/completions`: 200 OK, no log spam.
  - `T3` request after a client-side TCP drop on `T2`: 200 OK (slot was available — this is the headline behavior the fix delivers in the documented timeout path).
- End-to-end validation of the smoke eval flow on Llama-3.2-3B-Instruct (which previously hung at 10 min due to compound effect of the bug) is in progress; results will be added once available.

Note on testing the cancel path itself: client-side TCP-disconnect (curl `--max-time`) does *not* trigger FastAPI's `CancelledError` in the handler by default — Starlette holds the connection. The cancel path is exercised by the server-side `request_processing_timeout_seconds` path documented in the issue (the `async failed after 1000.0009 seconds` evidence). The fix is wired correctly for that trigger and for any future Starlette-side disconnect propagation work.

### Related PRs (same issue, #3533)

- **PR #1 — eval client concurrency clamp (already opened)**: addresses Problem 2 (eval client over-subscribes). Makes the orphan-task scenario much harder to trigger in the first place.
- **PR #2 — prompt + max_tokens validation (already opened)**: addresses Problem 3 (server-side 500 on exact-fit prompts). Fails requests upfront so they never enter the worker pipeline, sidestepping one Problem 1 trigger path.
- **This PR — orphan-task cancel (Problem 1)**: directly addresses the worker-side bug. The three together complete the #3533 fix set.

### Files changed

- `tt-media-server/model_services/scheduler.py`
- `tt-media-server/model_services/base_service.py`
- `tt-media-server/device_workers/device_worker_dynamic_batch.py`
- `tt-media-server/device_workers/device_worker.py`
