### PR TITLE
Adding cursor rule to use new C++20 syntax wherever possible 

### DIFF
--- a/tt-media-server/cpp_server/.cursor/rules/cpp-use-contains.mdc
+++ b/tt-media-server/cpp_server/.cursor/rules/cpp-use-contains.mdc
@@ -1,0 +1,25 @@
+---
+description: Prefer C++20 contains() over find/end checks in C++ code
+globs: **/*.{cpp,hpp,cc,cxx,h,hxx}
+alwaysApply: false
+---
+
+# Prefer `contains` for membership checks
+
+When code only needs to test key membership, prefer C++20 `contains` instead of `find(...) != end()`.
+
+Use this for associative containers that support `contains`, such as `std::set`, `std::map`, `std::unordered_set`, and `std::unordered_map`.
+
+```cpp
+// ❌ BAD
+if (active_ids.find(request_id) != active_ids.end()) {
+    handle_request(request_id);
+}
+
+// ✅ GOOD
+if (active_ids.contains(request_id)) {
+    handle_request(request_id);
+}
+```
+
+Keep `find` when an iterator is needed (for erase by iterator, value access from iterator, or in pre-C++20 code).


### PR DESCRIPTION
when vibe-coding in cursor

https://tenstorrent.slack.com/archives/C09FGPL1E3U/p1779285104910609?thread_ts=1779283882.692559&cid=C09FGPL1E3U