### PR TITLE
fix(forge): regenerate _task_id for each /v1/completions fan-out sub-request

### DIFF
--- a/tt-media-server/open_ai_api/llm.py
+++ b/tt-media-server/open_ai_api/llm.py
@@ -31,7 +31,16 @@ def _split_batched_prompts(req: CompletionRequest) -> list[CompletionRequest]:
     """
     p = req.prompt
     if isinstance(p, list) and p and isinstance(p[0], (list, str)):
-        return [req.model_copy(update={"prompt": item}) for item in p]
+        sub_reqs = [req.model_copy(update={"prompt": item}) for item in p]
+        # Pydantic's model_copy(update=...) preserves PrivateAttr values, so
+        # every sub-request would otherwise share the original request's
+        # _task_id. That collides in the scheduler's per-task result_queues
+        # map — only one sub-request's await sees its result, the rest hang
+        # until request_processing_timeout_seconds. Re-key each sub-request
+        # with a fresh UUID so the per-task queues stay distinct.
+        for sr in sub_reqs:
+            sr._task_id = str(uuid.uuid4())
+        return sub_reqs
     return [req]
 
 

--- a/tt-media-server/tests/test_split_batched_prompts.py
+++ b/tt-media-server/tests/test_split_batched_prompts.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+from domain.completion_request import CompletionRequest
+from open_ai_api.llm import _split_batched_prompts
+
+
+class TestSplitBatchedPrompts:
+    """Per #3533 Problem 4: fan-out must regenerate _task_id for each sub-request,
+    otherwise the scheduler's per-task result_queues collide and only one
+    sub-request's await unblocks."""
+
+    def test_string_list_yields_unique_task_ids(self):
+        req = CompletionRequest(model="m", prompt=["hello", "world"], max_tokens=5)
+        subs = _split_batched_prompts(req)
+        assert len(subs) == 2
+        assert [s.prompt for s in subs] == ["hello", "world"]
+        task_ids = {s._task_id for s in subs}
+        assert len(task_ids) == 2
+        assert req._task_id not in task_ids
+
+    def test_token_list_list_yields_unique_task_ids(self):
+        req = CompletionRequest(
+            model="m",
+            prompt=[[1, 2, 3], [4, 5, 6], [7, 8]],
+            max_tokens=5,
+        )
+        subs = _split_batched_prompts(req)
+        assert len(subs) == 3
+        assert [s.prompt for s in subs] == [[1, 2, 3], [4, 5, 6], [7, 8]]
+        task_ids = {s._task_id for s in subs}
+        assert len(task_ids) == 3
+        assert req._task_id not in task_ids
+
+    def test_single_string_prompt_passes_through_unchanged(self):
+        req = CompletionRequest(model="m", prompt="single", max_tokens=5)
+        subs = _split_batched_prompts(req)
+        assert len(subs) == 1
+        assert subs[0] is req
+        assert subs[0]._task_id == req._task_id
+
+    def test_flat_token_list_passes_through_unchanged(self):
+        # Flat list of ints is a single tokenized prompt, not a batch.
+        req = CompletionRequest(model="m", prompt=[1, 2, 3], max_tokens=5)
+        subs = _split_batched_prompts(req)
+        assert len(subs) == 1
+        assert subs[0] is req
+        assert subs[0]._task_id == req._task_id
+
+    def test_empty_list_passes_through_unchanged(self):
+        req = CompletionRequest(model="m", prompt=[], max_tokens=5)
+        subs = _split_batched_prompts(req)
+        assert len(subs) == 1
+        assert subs[0] is req


### PR DESCRIPTION
### Issue

Addresses **Problem 4** of #3533. (Uncovered while validating the eval flow end-to-end after PRs for Problems 1/2/3.)

### Problem

`_split_batched_prompts()` (introduced in PR #3532 to handle OpenAI's `prompt: List[str]`/`List[List[int]]` batched form) fans out a single batched request into N single-prompt sub-requests via `req.model_copy(update={"prompt": item})`. Pydantic preserves `PrivateAttr` values across `model_copy`, so every sub-request shared the original request's `_task_id`.

That UUID is the key for `scheduler.result_queues`. When `complete_text()` ran `asyncio.gather(*(service.process_request(r) for r in sub_reqs))`, each `process()` call did `result_queues[T] = asyncio.Queue()` with the **same** `T`. The later writes overwrote the queues used by the earlier `process()` calls. Only one sub-request's await ever resolved; the rest hung until `request_processing_timeout_seconds` (1000 s) fired.

Client-visible symptom: `lm-eval` and `vllm bench` saw `httpx.ReadTimeout` at the default 10-minute mark on every batched-prompt request, even with the rest of the #3533 fixes (clamp, prompt-validation, orphan-cancel) applied. Server-side, the giveaway was many `WARNING - No result queue found for task X. Current queues: []` log lines.

Pydantic reproducer (verified before fix):
```python
from domain.completion_request import CompletionRequest
req = CompletionRequest(model="m", prompt=["hello", "world"], max_tokens=5)
copies = [req.model_copy(update={"prompt": p}) for p in req.prompt]
assert copies[0]._task_id == req._task_id  # True — collision
assert copies[1]._task_id == req._task_id  # True — collision
```

### What changed

**`tt-media-server/open_ai_api/llm.py`** — in `_split_batched_prompts`, after `model_copy`, re-key each sub-request with a fresh UUID:

```python
sub_reqs = [req.model_copy(update={"prompt": item}) for item in p]
for sr in sub_reqs:
    sr._task_id = str(uuid.uuid4())
return sub_reqs
```

**`tt-media-server/tests/test_split_batched_prompts.py`** (new) — 5 unit tests covering:
- `prompt: List[str]` → distinct task_ids, neither equal to original
- `prompt: List[List[int]]` → distinct task_ids, neither equal to original
- `prompt: str` → pass-through, original task_id preserved
- `prompt: List[int]` (flat token list, not a batch) → pass-through
- `prompt: []` (empty) → pass-through

~6 lines effective change in `llm.py`, ~50 lines of test coverage.

### Testing

**Pre-fix repro** of the collision (verified locally on Llama-3.2-3B-Instruct forge):

```
06:18:09,839 - Device 0: Starting non-streaming batch generation for 1 requests (×2 in lockstep)
06:18:09,959 - Device 0: Non-streaming generation completed
06:18:09,960 - [process_request] async executed in 0.1216 seconds.    <- only 1 process_request log fires
06:18:09,995 - Device 0: Non-streaming generation completed              (2nd sub-request)
06:18:09,996 - WARNING - No result queue found for task b3916f01-...    Current queues: []
```

Two worker handlers completed back-to-back, only one `process_request async executed` log fired, the orphaned task_id matched the only result_queues key — both sub-requests were mapped to the same key.

**Post-fix** (same model, same workload, smoke-eval end-to-end):

```
2026-05-20 07:01:54 - run_workflows.py - INFO: ✅ Completed workflow: evals
2026-05-20 07:01:54 - run_reports.py   - INFO: Acceptance criteria enforcement: PASS
2026-05-20 07:01:54 - run.py           - INFO: Completed run.py.
```

- Eval ran end-to-end in 32 s (was hanging at 10 min before).
- 0 "No result queue found" warnings (was many before).
- 10 `process_request async executed` log entries — both sub-requests of each fan-out complete cleanly (was 1 of 2 before).
- `meta_gpqa` acceptance check **PASS** with score 66.67% (ratio_to_reference 2.05).

### Scope

Forge-only:
- The bug lives in `tt-media-server/open_ai_api/llm.py:_split_batched_prompts`, which is the FastAPI handler running inside forge LLM containers.
- ttnn / vllm-tt LLMs use a separate stack (`vllm-tt-metal` images with vLLM's native OpenAI-compatible server) and are not affected.
- `chat.py` does not fan out (chat is single-message → single-completion), so it doesn't have this bug.

### Related PRs (same issue, #3533)

- **PR #1 — concurrency clamp** (Problem 2): prevents the eval client from over-subscribing the server.
- **PR #2 — prompt + max_tokens validation** (Problem 3): rejects requests upfront when context would overflow.
- **PR #3 — orphan-task cancel** (Problem 1): signals the worker to abort orphaned in-flight tasks.
- **PR #4 — this PR** (Problem 4): completes the eval-e2e unblocker chain. With all four applied, smoke eval on Llama-3.2-3B-Instruct goes from "hangs at 10 min" → "completes in 32 s, scores recorded, acceptance PASS".

### Files changed

- `tt-media-server/open_ai_api/llm.py` — 6-line fix in `_split_batched_prompts`.
- `tt-media-server/tests/test_split_batched_prompts.py` — new file, 5 unit tests.
