### PR TITLE
fix(evals): drop hardcoded model/base_url/tokenizer_backend from eval_config.py model_kwargs

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -944,9 +944,6 @@ _eval_config_list = [
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "Qwen/Qwen3-8B",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                 },
                 # gen_kwargs chosen according to https://huggingface.co/Qwen/Qwen3-8B#best-practices
@@ -982,9 +979,6 @@ _eval_config_list = [
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "Qwen/Qwen3-8B",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                     "timeout": "3600",
                 },
@@ -1025,9 +1019,6 @@ _eval_config_list = [
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "Qwen/Qwen3-4B",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                 },
                 gen_kwargs={
@@ -1062,9 +1053,6 @@ _eval_config_list = [
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "Qwen/Qwen3-4B",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                     "timeout": "3600",
                 },
@@ -1104,9 +1092,6 @@ _eval_config_list = [
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "Qwen/Qwen3-32B",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                     "timeout": "3600",
                 },
@@ -1142,9 +1127,6 @@ _eval_config_list = [
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "Qwen/Qwen3-32B",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                     "timeout": "3600",
                 },
@@ -1181,9 +1163,6 @@ _eval_config_list = [
                 max_concurrent=16,
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "Qwen/Qwen3-32B",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                 },
                 # gen_kwargs chosen according to https://huggingface.co/Qwen/Qwen3-32B#best-practices
@@ -1356,9 +1335,6 @@ _eval_config_list = [
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "Qwen/QwQ-32B",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                     "timeout": "3600",
                 },
@@ -1387,9 +1363,6 @@ _eval_config_list = [
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "Qwen/QwQ-32B",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                     "timeout": "3600",
                 },
@@ -1418,9 +1391,6 @@ _eval_config_list = [
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "Qwen/QwQ-32B",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                 },
                 gen_kwargs={
@@ -1453,9 +1423,6 @@ _eval_config_list = [
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                 },
                 gen_kwargs={"stream": "false", "max_gen_toks": "32768"},
@@ -1482,9 +1449,6 @@ _eval_config_list = [
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 65536,
                 },
                 gen_kwargs={"stream": "false", "max_gen_toks": "32768"},
@@ -1512,9 +1476,6 @@ _eval_config_list = [
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "deepseek-ai/DeepSeek-R1-0528",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 32768,
                 },
                 gen_kwargs={
@@ -1544,9 +1505,6 @@ _eval_config_list = [
                 ),
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 model_kwargs={
-                    "model": "deepseek-ai/DeepSeek-R1-0528",
-                    "base_url": "http://127.0.0.1:8000/v1/completions",
-                    "tokenizer_backend": "huggingface",
                     "max_length": 32768,
                 },
                 gen_kwargs={


### PR DESCRIPTION
## PR description

### Issue

Addresses **Problem 5** of #3533 (uncovered while validating forge LLM eval flow end-to-end after PRs for Problems 1/2/3/4).

### Problem

`evals/run_evals.py` builds the lm-eval `--model_args` string with the dynamic context-aware values, then appends the task's `model_kwargs` as comma-separated `key=value` pairs:

```python
"--model_args", (
    f"model={model_spec.hf_model_repo},"
    f"base_url={_base_url},"
    f"tokenizer_backend={task.tokenizer_backend},"
    f"{model_kwargs_str}"
)
```

`lm-eval`'s arg parser takes the **last** occurrence of each key, so anything in `model_kwargs` that collides with the dynamic block silently overrides it.

14 `EvalTask` entries in `evals/eval_config.py` (Qwen3-4B, Qwen3-8B, Qwen3-32B, etc.) pin:
```python
model_kwargs={
    "model": "Qwen/Qwen3-4B",
    "base_url": "http://127.0.0.1:8000/v1/completions",
    "tokenizer_backend": "huggingface",
    "max_length": 65536,
    ...
}
```

This has worked fine for any single-model setup defaulting to port 8000, which is why CI hasn't caught it. Surfaced during **local multi-model validation on quietbox 2** — bringing up several forge LLMs in parallel (one per device, on ports 8101 / 8102 / 8103 to avoid collision) and running evals against each `--service-port`. Every eval target then connects to 127.0.0.1:8000 regardless of the port `run.py` was launched with:

```
ERROR [models.api_models:552] Exception:ClientConnectorError(ConnectionKey(host='127.0.0.1', port=8000, ...), ConnectionRefusedError(111, "Connect call failed ('127.0.0.1', 8000)"))
...
ERROR [_cli.run:482] 3 prompt(s) failed during inference. Sample logs have been saved for debugging.
RuntimeError: Evaluation completed with 3 failed prompt(s).
```

### What changed

`evals/eval_config.py` — remove the redundant `model`, `base_url`, `tokenizer_backend` keys from each `model_kwargs` block. `run_evals.py` already injects all three with the right values. The per-task tunings (`max_length`, `timeout`) are preserved.

42 lines deleted across 14 `EvalTask` entries (3 keys × 14 blocks). No functional change for any path that was previously working — the dynamic block already supplied the correct values; we're just no longer clobbering them.

Lines affected (`base_url` markers, before fix): 948, 986, 1029, 1066, 1108, 1146, 1185, 1360, 1391, 1422, 1457, 1486, 1516, 1548.

### Testing

Verified on Qwen3-4B forge (`max_num_seqs=2`, port 8101, P150 host). Before the fix, the lm-eval command's `--model_args` included two `base_url=` entries, the second hardcoded to `http://127.0.0.1:8000/v1/completions`:

```
lm_eval ... --model_args model=Qwen/Qwen3-4B,base_url=http://127.0.0.1:8101/v1/completions,tokenizer_backend=huggingface,model=Qwen/Qwen3-4B,base_url=http://127.0.0.1:8000/v1/completions,tokenizer_backend=huggingface,max_length=65536,num_concurrent=2 ...
```

After the fix, only the dynamic block remains:

```
lm_eval ... --model_args model=Qwen/Qwen3-4B,base_url=http://127.0.0.1:8101/v1/completions,tokenizer_backend=huggingface,max_length=65536,num_concurrent=2 ...
```

Eval client now reaches the actual server (verified — pre-fix had `ConnectionRefusedError`, post-fix HTTP requests land on 8101 and get 400/200 responses from the running server).

(Note: a separate config-vs-device-context-window mismatch on Qwen3-4B's `max_gen_toks=32768` is the next blocker for that model's eval; tracked separately as Problem 6 of #3533.)

### Scope

Eval-config cleanup only. No behavior change for any model where the eval was already working. The fix removes a foot-gun that has been quietly waiting for someone to run on a non-default port.

### Related PRs

- **PR for Problem 2 (clamp)** — same file (`evals/run_evals.py`). Independent.
- **PR for Problem 1, Problem 3, Problem 4** — `tt-media-server/` server-side changes. Independent.
- **Problem 6** (max_gen_toks vs max_context mismatch) — next layer on Qwen eval tasks; needs its own fix once we agree on the shape.

### Files changed

- `evals/eval_config.py` — 42 lines deleted across 14 model_kwargs blocks.
