### PR TITLE
Use a single ZMQ ROUTER socket for gateway prefills

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1934,7 +1934,8 @@ jobs:
         run: |
           cd cpp_server/build
           NS=gw_zmq_prefill1
-          SOCKET_TRANSPORT=zmq USE_PREFILL_GATEWAY=1 LLM_MODE=prefill SOCKET_PORT=9201 \
+          SOCKET_TRANSPORT=zmq USE_PREFILL_GATEWAY=1 LLM_MODE=prefill \
+          SOCKET_HOST=127.0.0.1 SOCKET_PORT=9201 \
           PREFILL_SERVER_ID=prefill-1 PREFILL_MAX_IN_FLIGHT=4 \
           TT_WARMUP_SIGNALS_QUEUE=tt_warmup_signals_$NS \
           TT_TASK_QUEUE=tt_tasks_$NS \
@@ -1964,7 +1965,8 @@ jobs:
         run: |
           cd cpp_server/build
           NS=gw_zmq_prefill2
-          SOCKET_TRANSPORT=zmq USE_PREFILL_GATEWAY=1 LLM_MODE=prefill SOCKET_PORT=9202 \
+          SOCKET_TRANSPORT=zmq USE_PREFILL_GATEWAY=1 LLM_MODE=prefill \
+          SOCKET_HOST=127.0.0.1 SOCKET_PORT=9201 \
           PREFILL_SERVER_ID=prefill-2 PREFILL_MAX_IN_FLIGHT=4 \
           TT_WARMUP_SIGNALS_QUEUE=tt_warmup_signals_$NS \
           TT_TASK_QUEUE=tt_tasks_$NS \
@@ -1995,8 +1997,7 @@ jobs:
           SOCKET_TRANSPORT=zmq TT_LOG_LEVEL=debug \
             ./prefill_gateway/build/prefill_gateway \
             --decode-port=9200 \
-            --prefill=127.0.0.1:9201 \
-            --prefill=127.0.0.1:9202 \
+            --prefill-bind=127.0.0.1:9201 \
             > gw_zmq.log 2>&1 &
           echo $! > gw_zmq.pid
           for i in $(seq 1 30); do
@@ -2054,10 +2055,10 @@ jobs:
             P1=$(curl -sf "http://127.0.0.1:8201/tt-liveness" 2>/dev/null || true)
             P2=$(curl -sf "http://127.0.0.1:8202/tt-liveness" 2>/dev/null || true)
             DEC=$(curl -sf "http://127.0.0.1:8200/tt-liveness" 2>/dev/null || true)
-            if echo "$P1"  | grep -q '"socket_status":"server:connected"' \
-               && echo "$P2"  | grep -q '"socket_status":"server:connected"' \
+            if echo "$P1"  | grep -q '"socket_status":"client:connected"' \
+               && echo "$P2"  | grep -q '"socket_status":"client:connected"' \
                && echo "$DEC" | grep -q '"socket_status":"client:connected"'; then
-              echo "✅ Prefill-1, Prefill-2 (server:connected) and Decode (client:connected) all verified"
+              echo "✅ Prefill-1, Prefill-2 and Decode (client:connected) all verified"
               break
             fi
             sleep 1
@@ -2072,8 +2073,8 @@ jobs:
           for VAR_NAME in "Prefill-1:$P1" "Prefill-2:$P2"; do
             NAME="${VAR_NAME%%:*}"
             VAL="${VAR_NAME#*:}"
-            if ! echo "$VAL" | grep -q '"socket_status":"server:connected"'; then
-              echo "ERROR: $NAME socket_status is not 'server:connected'"
+            if ! echo "$VAL" | grep -q '"socket_status":"client:connected"'; then
+              echo "ERROR: $NAME socket_status is not 'client:connected'"
               FAIL=1
             fi
           done

--- a/tt-media-server/cpp_server/include/sockets/inter_server_service.hpp
+++ b/tt-media-server/cpp_server/include/sockets/inter_server_service.hpp
@@ -153,9 +153,9 @@ class InterServerService {
   // response to a RegistrationProbeMessage from the gateway. No-op otherwise.
   void sendRegistrationIfGatewayModeIsEnabled();
 
-  // Prefill-side, direct-mode only: background thread that periodically sends
-  // PrefillRegistrationMessage so the decode ROUTER learns the peer identity.
-  void startDirectModeRegistrationThread();
+  // Prefill-side background thread that periodically sends
+  // PrefillRegistrationMessage so a ROUTER peer learns the DEALER identity.
+  void startRegistrationThread();
 
   SocketManager socket_manager_;
   PrefillRequestedCallback prefill_requested_callback_;
@@ -163,7 +163,7 @@ class InterServerService {
   HealthCallback health_check_callback_;
   bool enabled_ = false;
   bool gateway_mode_ = false;
-  bool direct_prefill_mode_ = false;
+  bool periodic_registration_mode_ = false;
 
   // Direct-mode registration loop: condition_variable lets stop() wake the
   // thread immediately instead of waiting for the 1s timer to elapse.

--- a/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
@@ -3,18 +3,17 @@
 
 #pragma once
 
-#include <cereal/archives/binary.hpp>
 #include <cereal/types/string.hpp>
 #include <cereal/types/vector.hpp>
 #include <functional>
 #include <map>
 #include <mutex>
-#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include "sockets/i_socket_transport.hpp"
+#include "sockets/socket_serialization.hpp"
 #include "utils/logger.hpp"
 
 namespace tt::sockets {
@@ -130,16 +129,7 @@ bool SocketManager::sendObject(const std::string& messageType, const T& obj) {
   }
 
   try {
-    std::ostringstream oss;
-    {
-      cereal::BinaryOutputArchive archive(oss);
-      archive(messageType);
-      obj.write(archive);
-    }
-
-    std::string serialized = oss.str();
-    std::vector<uint8_t> data(serialized.begin(), serialized.end());
-
+    std::vector<uint8_t> data = wire::serializeMessage(messageType, obj);
     return transport_->sendRawData(data);
   } catch (const std::exception& e) {
     TT_LOG_ERROR("[SocketManager] Serialization error: {}", e.what());
@@ -154,14 +144,7 @@ void SocketManager::registerHandler(const std::string& messageType,
 
   handlers_[messageType] = [handler](const std::vector<uint8_t>& data) {
     try {
-      std::string serialized(data.begin(), data.end());
-      std::istringstream iss(serialized);
-
-      cereal::BinaryInputArchive archive(iss);
-      std::string msgType;
-      archive(msgType);
-      T payload = T::read(archive);
-
+      T payload = wire::deserializePayload<T>(data);
       handler(payload);
     } catch (const std::exception& e) {
       TT_LOG_ERROR("[SocketManager] Deserialization error: {}", e.what());

--- a/tt-media-server/cpp_server/include/sockets/socket_serialization.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_serialization.hpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#pragma once
+
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/string.hpp>
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace tt::sockets::wire {
+
+template <typename T>
+std::vector<uint8_t> serializeMessage(const std::string& messageType,
+                                      const T& obj) {
+  std::ostringstream oss;
+  {
+    cereal::BinaryOutputArchive archive(oss);
+    archive(messageType);
+    obj.write(archive);
+  }
+
+  const std::string serialized = oss.str();
+  return {serialized.begin(), serialized.end()};
+}
+
+inline std::string readMessageType(const std::vector<uint8_t>& data) {
+  std::string serialized(data.begin(), data.end());
+  std::istringstream iss(serialized);
+
+  cereal::BinaryInputArchive archive(iss);
+  std::string messageType;
+  archive(messageType);
+  return messageType;
+}
+
+template <typename T>
+T deserializePayload(const std::vector<uint8_t>& data) {
+  std::string serialized(data.begin(), data.end());
+  std::istringstream iss(serialized);
+
+  cereal::BinaryInputArchive archive(iss);
+  std::string ignoredMessageType;
+  archive(ignoredMessageType);
+  return T::read(archive);
+}
+
+}  // namespace tt::sockets::wire

--- a/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
+++ b/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
@@ -35,8 +35,8 @@ bool InterServerService::initializeFromConfig() {
 
   bool success = false;
 
-  // Gateway mode inverts roles: decode becomes CLIENT, prefill becomes SERVER,
-  // and the gateway sits between them.
+  // Gateway mode always makes decode dial the gateway. TCP prefills listen for
+  // the gateway, while ZMQ prefills dial the gateway's shared ROUTER socket.
   if (mode == tt::config::LLMMode::DECODE_ONLY) {
     if (gatewayMode) {
       TT_LOG_INFO(

--- a/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
+++ b/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
@@ -30,6 +30,8 @@ bool InterServerService::initializeFromConfig() {
   auto host = tt::config::socketHost();
   auto port = tt::config::socketPort();
   const bool gatewayMode = tt::config::usePrefillGateway();
+  const bool zmqTransport =
+      tt::config::socketTransport() == tt::sockets::transport_names::ZMQ;
 
   bool success = false;
 
@@ -49,18 +51,27 @@ bool InterServerService::initializeFromConfig() {
     }
   } else if (mode == tt::config::LLMMode::PREFILL_ONLY) {
     if (gatewayMode) {
-      TT_LOG_INFO(
-          "[InterServerService] Prefill (gateway mode): listening on port {} "
-          "for gateway",
-          port);
-      success = socket_manager_.initializeAsServer(port);
+      if (zmqTransport) {
+        TT_LOG_INFO(
+            "[InterServerService] Prefill (gateway ZMQ mode): connecting to "
+            "{}:{}",
+            host, port);
+        success = socket_manager_.initializeAsClient(host, port);
+        periodic_registration_mode_ = success;
+      } else {
+        TT_LOG_INFO(
+            "[InterServerService] Prefill (gateway mode): listening on port {} "
+            "for gateway",
+            port);
+        success = socket_manager_.initializeAsServer(port);
+      }
       gateway_mode_ = success;
     } else {
       TT_LOG_INFO(
           "[InterServerService] Prefill (direct mode): connecting to {}:{}",
           host, port);
       success = socket_manager_.initializeAsClient(host, port);
-      direct_prefill_mode_ = success;
+      periodic_registration_mode_ = success;
     }
   }
 
@@ -83,8 +94,8 @@ void InterServerService::start() {
   }
 
   socket_manager_.start();
-  if (direct_prefill_mode_) {
-    startDirectModeRegistrationThread();
+  if (periodic_registration_mode_) {
+    startRegistrationThread();
   }
   TT_LOG_INFO("[InterServerService] Started socket communication");
 }
@@ -276,7 +287,7 @@ void InterServerService::sendRegistrationIfGatewayModeIsEnabled() {
   sendRegistration();
 }
 
-void InterServerService::startDirectModeRegistrationThread() {
+void InterServerService::startRegistrationThread() {
   registration_running_ = true;
   registration_thread_ = std::thread([this] {
     constexpr auto registrationInterval = std::chrono::seconds(1);

--- a/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
+++ b/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
@@ -84,13 +84,7 @@ void SocketManager::messageLoop() {
 
 void SocketManager::handleIncomingMessage(const std::vector<uint8_t>& data) {
   try {
-    std::string serialized(data.begin(), data.end());
-    std::istringstream iss(serialized);
-
-    cereal::BinaryInputArchive archive(iss);
-    std::string messageType;
-    archive(messageType);
-
+    std::string messageType = wire::readMessageType(data);
     auto handler = getHandler(messageType);
     if (!handler) {
       TT_LOG_DEBUG("[SocketManager] No handler for message type: {}",

--- a/tt-media-server/prefill_gateway/CMakeLists.txt
+++ b/tt-media-server/prefill_gateway/CMakeLists.txt
@@ -144,8 +144,10 @@ add_library(prefill_gateway_io STATIC
     ${CPP_SERVER_DIR}/src/sockets/tcp_socket_transport.cpp
     ${CPP_SERVER_DIR}/src/sockets/zmq_socket_transport.cpp
     src/socket_transport_factory.cpp
+    src/zmq_prefill_router.cpp
 )
 target_include_directories(prefill_gateway_io PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CPP_SERVER_DIR}/include
     ${cppzmq_SOURCE_DIR}
 )

--- a/tt-media-server/prefill_gateway/CMakeLists.txt
+++ b/tt-media-server/prefill_gateway/CMakeLists.txt
@@ -143,6 +143,7 @@ add_library(prefill_gateway_io STATIC
     ${CPP_SERVER_DIR}/src/sockets/socket_manager.cpp
     ${CPP_SERVER_DIR}/src/sockets/tcp_socket_transport.cpp
     ${CPP_SERVER_DIR}/src/sockets/zmq_socket_transport.cpp
+    src/prefill_connection_wiring.cpp
     src/socket_transport_factory.cpp
     src/zmq_prefill_router.cpp
 )

--- a/tt-media-server/prefill_gateway/README.md
+++ b/tt-media-server/prefill_gateway/README.md
@@ -51,6 +51,9 @@ SOCKET_TRANSPORT=zmq ctest --test-dir build --output-on-failure
   flag for each prefill.
 - `--prefill-bind=HOST:PORT` is the ZMQ prefill-side ROUTER bind endpoint.
   ZMQ prefills dial this single endpoint and register themselves.
+- `--prefill-stale-timeout-ms=MS` controls how long the ZMQ gateway waits
+  without a prefill registration before marking that prefill down. Default:
+  `3000`.
 
 ## End-to-end curl test (real cpp_server + gateway)
 

--- a/tt-media-server/prefill_gateway/README.md
+++ b/tt-media-server/prefill_gateway/README.md
@@ -47,8 +47,10 @@ SOCKET_TRANSPORT=zmq ctest --test-dir build --output-on-failure
 ```
 
 - `--decode-port` is the port the gateway *listens on* for the decode server.
-- `--prefill=HOST:PORT` is a prefill the gateway *dials out to*. Repeat the
+- `--prefill=HOST:PORT` is a TCP prefill the gateway *dials out to*. Repeat the
   flag for each prefill.
+- `--prefill-bind=HOST:PORT` is the ZMQ prefill-side ROUTER bind endpoint.
+  ZMQ prefills dial this single endpoint and register themselves.
 
 ## End-to-end curl test (real cpp_server + gateway)
 
@@ -58,7 +60,7 @@ flip the inter-server socket roles to talk through the gateway:
 
 | Env var                         | Set on  | Effect                                                                                         |
 | ------------------------------- | ------- | ---------------------------------------------------------------------------------------------- |
-| `USE_PREFILL_GATEWAY=1`         | both    | Decode dials gateway as CLIENT. Prefill listens on `SOCKET_PORT` for the gateway as SERVER.    |
+| `USE_PREFILL_GATEWAY=1`         | both    | Decode dials gateway as CLIENT. TCP prefills listen for the gateway; ZMQ prefills dial the gateway's prefill ROUTER. |
 | `SOCKET_TRANSPORT`              | all     | `tcp` (default) or `zmq`. Must be the same on all three processes.                             |
 | `PREFILL_SERVER_ID=...`         | prefill | Identity advertised in `PrefillRegistrationMessage`. Default: `<hostname>:<port>`.             |
 | `PREFILL_MAX_IN_FLIGHT=N`       | prefill | Capacity hint sent to the gateway (0 = unlimited).                                             |
@@ -80,8 +82,9 @@ The default (`USE_PREFILL_GATEWAY=0`) keeps the existing direct 1:1 wiring.
                                                                   └───────────┘
 ```
 
-The commands below use TCP (default). To switch to ZMQ, add
-`SOCKET_TRANSPORT=zmq` to **all four** processes (gateway + decode + both prefills).
+The commands below use TCP (default), where the gateway dials each prefill.
+For ZMQ, use the separate ZMQ commands below: the gateway binds one prefill
+ROUTER endpoint and every prefill connects to it.
 
 ### Terminal A — gateway
 
@@ -130,6 +133,61 @@ LLM_MODE=prefill LLM_DEVICE_BACKEND=mock \
 SOCKET_TRANSPORT=tcp \
 USE_PREFILL_GATEWAY=1 \
 SOCKET_HOST=0.0.0.0 SOCKET_PORT=7201 \
+PREFILL_SERVER_ID=prefill-1 \
+./build/tt_media_server_cpp -p 8003
+```
+
+### ZMQ variant
+
+For ZMQ, the decode side still connects to the gateway on `:7100`, but prefills
+connect to one gateway ROUTER endpoint on `:7200`.
+
+#### Terminal A — gateway
+
+```bash
+cd tt-media-server/prefill_gateway
+TT_LOG_LEVEL=info SOCKET_TRANSPORT=zmq ./build/prefill_gateway \
+  --decode-port=7100 \
+  --prefill-bind=127.0.0.1:7200
+```
+
+#### Terminal B — decode
+
+```bash
+cd tt-media-server/cpp_server
+LLM_MODE=decode \
+SOCKET_TRANSPORT=zmq \
+USE_PREFILL_GATEWAY=1 \
+MAX_TOKENS_TO_PREFILL_ON_DECODE=0 \
+SOCKET_HOST=127.0.0.1 SOCKET_PORT=7100 \
+TT_LOG_LEVEL=info \
+./build/tt_media_server_cpp -p 8001
+```
+
+#### Terminal C — prefill-0
+
+```bash
+cd tt-media-server/cpp_server
+TT_IPC_SHM_C2P=tt_ipc_c2p_8002 TT_IPC_SHM_P2C=tt_ipc_p2c_8002 \
+PREFILL_TIMEOUT_MS=15000 TT_LOG_LEVEL=info \
+LLM_MODE=prefill LLM_DEVICE_BACKEND=mock \
+SOCKET_TRANSPORT=zmq \
+USE_PREFILL_GATEWAY=1 \
+SOCKET_HOST=127.0.0.1 SOCKET_PORT=7200 \
+PREFILL_SERVER_ID=prefill-0 \
+./build/tt_media_server_cpp -p 8002
+```
+
+#### Terminal D — prefill-1
+
+```bash
+cd tt-media-server/cpp_server
+TT_IPC_SHM_C2P=tt_ipc_c2p_8003 TT_IPC_SHM_P2C=tt_ipc_p2c_8003 \
+PREFILL_TIMEOUT_MS=15000 TT_LOG_LEVEL=info \
+LLM_MODE=prefill LLM_DEVICE_BACKEND=mock \
+SOCKET_TRANSPORT=zmq \
+USE_PREFILL_GATEWAY=1 \
+SOCKET_HOST=127.0.0.1 SOCKET_PORT=7200 \
 PREFILL_SERVER_ID=prefill-1 \
 ./build/tt_media_server_cpp -p 8003
 ```

--- a/tt-media-server/prefill_gateway/include/gateway/prefill_connection_wiring.hpp
+++ b/tt-media-server/prefill_gateway/include/gateway/prefill_connection_wiring.hpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+namespace tt::sockets {
+class SocketManager;
+}  // namespace tt::sockets
+
+namespace tt::gateway {
+
+class Dispatcher;
+class PrefillRegistry;
+class ZmqPrefillRouter;
+
+using PrefillSocketManagers =
+    std::vector<std::unique_ptr<tt::sockets::SocketManager>>;
+
+void registerTcpPrefillHandlers(PrefillSocketManagers& prefillSms,
+                                PrefillRegistry& registry,
+                                Dispatcher& dispatcher);
+
+void registerZmqPrefillHandlers(ZmqPrefillRouter& zmqPrefillRouter,
+                                PrefillRegistry& registry,
+                                Dispatcher& dispatcher);
+
+}  // namespace tt::gateway

--- a/tt-media-server/prefill_gateway/include/gateway/zmq_prefill_router.hpp
+++ b/tt-media-server/prefill_gateway/include/gateway/zmq_prefill_router.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <atomic>
-#include <cereal/archives/binary.hpp>
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
@@ -14,13 +13,12 @@
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <sstream>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <vector>
 
-#include "sockets/socket_messages.hpp"
+#include "sockets/socket_serialization.hpp"
 
 namespace tt::gateway {
 
@@ -106,17 +104,9 @@ bool ZmqPrefillRouter::sendObject(const std::string& serverId,
   }
 
   try {
-    std::ostringstream oss;
-    {
-      cereal::BinaryOutputArchive archive(oss);
-      archive(messageType);
-      obj.write(archive);
-    }
-
-    std::string serialized = oss.str();
     auto request = std::make_shared<SendRequest>();
     request->peerKey = peerKey(*peerId);
-    request->data.assign(serialized.begin(), serialized.end());
+    request->data = tt::sockets::wire::serializeMessage(messageType, obj);
     auto result = request->result.get_future();
 
     {
@@ -140,12 +130,7 @@ void ZmqPrefillRouter::registerHandler(
   std::lock_guard<std::mutex> lock(handlers_mutex_);
   handlers_[messageType] = [handler](const PeerIdentity& peerId,
                                      const std::vector<uint8_t>& data) {
-    std::string serialized(data.begin(), data.end());
-    std::istringstream iss(serialized);
-    cereal::BinaryInputArchive archive(iss);
-    std::string ignoredMessageType;
-    archive(ignoredMessageType);
-    T payload = T::read(archive);
+    T payload = tt::sockets::wire::deserializePayload<T>(data);
     handler(peerId, payload);
   };
 }

--- a/tt-media-server/prefill_gateway/include/gateway/zmq_prefill_router.hpp
+++ b/tt-media-server/prefill_gateway/include/gateway/zmq_prefill_router.hpp
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#pragma once
+
+#include <atomic>
+#include <cereal/archives/binary.hpp>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "sockets/socket_messages.hpp"
+
+namespace tt::gateway {
+
+class ZmqPrefillRouter {
+ public:
+  using PeerIdentity = std::vector<uint8_t>;
+
+  ZmqPrefillRouter();
+  ZmqPrefillRouter(const ZmqPrefillRouter&) = delete;
+  ZmqPrefillRouter& operator=(const ZmqPrefillRouter&) = delete;
+  ~ZmqPrefillRouter();
+
+  bool start(const std::string& bindHost, uint16_t port);
+  void stop();
+
+  template <typename T>
+  bool sendObject(const std::string& serverId, const std::string& messageType,
+                  const T& obj);
+
+  template <typename T>
+  void registerHandler(
+      const std::string& messageType,
+      std::function<void(const PeerIdentity&, const T&)> handler);
+
+  void rememberRegistration(const std::string& serverId,
+                            const PeerIdentity& peerId);
+  std::optional<std::string> serverIdForPeer(const PeerIdentity& peerId) const;
+  std::vector<std::string> takeStaleServers(std::chrono::milliseconds timeout);
+
+ private:
+  struct SendRequest {
+    std::string peerKey;
+    std::vector<uint8_t> data;
+    std::promise<bool> result;
+  };
+
+  using RawHandler =
+      std::function<void(const PeerIdentity&, const std::vector<uint8_t>&)>;
+
+  static std::string peerKey(const PeerIdentity& peerId);
+
+  bool startIoThread();
+  void ioLoop(std::promise<bool> initialized);
+  bool initializeSocket();
+  bool processPendingSends();
+  bool receiveAvailableMessages();
+  void waitForIoWork();
+  void failPendingSends();
+  void handleIncomingMessage(const PeerIdentity& peerId,
+                             const std::vector<uint8_t>& data);
+  std::optional<PeerIdentity> peerIdForServer(
+      const std::string& serverId) const;
+
+  std::string endpoint_;
+
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+
+  std::atomic<bool> running_{false};
+  std::thread io_thread_;
+
+  mutable std::mutex peer_mutex_;
+  std::unordered_map<std::string, PeerIdentity> server_to_peer_;
+  std::unordered_map<std::string, std::string> peer_to_server_;
+  std::unordered_map<std::string, std::chrono::steady_clock::time_point>
+      last_seen_by_server_;
+
+  std::mutex send_mutex_;
+  std::condition_variable send_cv_;
+  std::deque<std::shared_ptr<SendRequest>> pending_sends_;
+
+  mutable std::mutex handlers_mutex_;
+  std::unordered_map<std::string, RawHandler> handlers_;
+};
+
+template <typename T>
+bool ZmqPrefillRouter::sendObject(const std::string& serverId,
+                                  const std::string& messageType,
+                                  const T& obj) {
+  auto peerId = peerIdForServer(serverId);
+  if (!peerId.has_value()) {
+    return false;
+  }
+
+  try {
+    std::ostringstream oss;
+    {
+      cereal::BinaryOutputArchive archive(oss);
+      archive(messageType);
+      obj.write(archive);
+    }
+
+    std::string serialized = oss.str();
+    auto request = std::make_shared<SendRequest>();
+    request->peerKey = peerKey(*peerId);
+    request->data.assign(serialized.begin(), serialized.end());
+    auto result = request->result.get_future();
+
+    {
+      std::lock_guard<std::mutex> lock(send_mutex_);
+      if (!running_) {
+        return false;
+      }
+      pending_sends_.push_back(std::move(request));
+    }
+    send_cv_.notify_one();
+    return result.get();
+  } catch (const std::exception&) {
+    return false;
+  }
+}
+
+template <typename T>
+void ZmqPrefillRouter::registerHandler(
+    const std::string& messageType,
+    std::function<void(const PeerIdentity&, const T&)> handler) {
+  std::lock_guard<std::mutex> lock(handlers_mutex_);
+  handlers_[messageType] = [handler](const PeerIdentity& peerId,
+                                     const std::vector<uint8_t>& data) {
+    std::string serialized(data.begin(), data.end());
+    std::istringstream iss(serialized);
+    cereal::BinaryInputArchive archive(iss);
+    std::string ignoredMessageType;
+    archive(ignoredMessageType);
+    T payload = T::read(archive);
+    handler(peerId, payload);
+  };
+}
+
+}  // namespace tt::gateway

--- a/tt-media-server/prefill_gateway/src/main.cpp
+++ b/tt-media-server/prefill_gateway/src/main.cpp
@@ -8,7 +8,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <memory>
-#include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -16,6 +16,7 @@
 
 #include "gateway/affinity_cache.hpp"
 #include "gateway/dispatcher.hpp"
+#include "gateway/prefill_connection_wiring.hpp"
 #include "gateway/prefill_registry.hpp"
 #include "gateway/zmq_prefill_router.hpp"
 #include "sockets/socket_manager.hpp"
@@ -34,21 +35,7 @@ struct GatewayConfig {
   std::vector<PrefillEndpoint> prefills;
   std::string prefillBindHost = "*";
   uint16_t prefillBindPort = 0;
-};
-
-struct PrefillConnectionState {
-  void setServerId(const std::string& serverId) {
-    std::lock_guard<std::mutex> lock(mutex);
-    this->serverId = serverId;
-  }
-
-  std::string getServerId() const {
-    std::lock_guard<std::mutex> lock(mutex);
-    return serverId;
-  }
-
-  mutable std::mutex mutex;
-  std::string serverId;
+  uint32_t prefillStaleTimeoutMs = 3000;
 };
 
 void printUsage(const char* prog) {
@@ -60,6 +47,9 @@ void printUsage(const char* prog) {
          "(repeatable).\n"
       << "  --prefill-bind=HOST:PORT\n"
       << "                        ZMQ ROUTER bind endpoint for prefills.\n"
+      << "  --prefill-stale-timeout-ms=MS\n"
+      << "                        ZMQ prefill registration timeout. Default: "
+         "3000.\n"
       << "  --help               Print this message.\n\n"
       << "Example:\n"
       << "  " << prog
@@ -99,6 +89,17 @@ std::optional<GatewayConfig> parseArgs(int argc, char** argv) {
 
     if (auto v = flagValue(arg, "--decode-port=")) {
       cfg.decodePort = static_cast<uint16_t>(std::stoi(std::string(*v)));
+      continue;
+    }
+
+    if (auto v = flagValue(arg, "--prefill-stale-timeout-ms=")) {
+      int timeoutMs = std::stoi(std::string(*v));
+      if (timeoutMs <= 0) {
+        std::cerr << "Invalid --prefill-stale-timeout-ms value: " << *v
+                  << " (expected positive milliseconds)\n";
+        return std::nullopt;
+      }
+      cfg.prefillStaleTimeoutMs = static_cast<uint32_t>(timeoutMs);
       continue;
     }
 
@@ -195,7 +196,7 @@ int main(int argc, char** argv) {
   }
 
   // TCP keeps one independent SocketManager (CLIENT) per endpoint.
-  std::vector<std::unique_ptr<tt::sockets::SocketManager>> prefillSms;
+  tt::gateway::PrefillSocketManagers prefillSms;
   prefillSms.reserve(cfg.prefills.size());
   if (!useZmqPrefillRouter) {
     for (const auto& ep : cfg.prefills) {
@@ -250,104 +251,12 @@ int main(int argc, char** argv) {
     dispatcherPtr->onPrefillDown(id);
   });
 
-  for (auto& smPtr : prefillSms) {
-    tt::sockets::SocketManager* sm = smPtr.get();
-
-    // Shared between callbacks that may run on different threads. The id is
-    // unknown until the first registration message.
-    auto state = std::make_shared<PrefillConnectionState>();
-
-    sm->registerHandler<tt::sockets::PrefillRegistrationMessage>(
-        tt::sockets::tags::PREFILL_REGISTRATION,
-        [&registry, sm,
-         state](const tt::sockets::PrefillRegistrationMessage& msg) {
-          TT_LOG_DEBUG("[Gateway] Prefill registered: id='{}' max_in_flight={}",
-                       msg.server_id, msg.max_in_flight);
-          state->setServerId(msg.server_id);
-          registry.preRegister(msg.server_id, sm);
-          bool ok = registry.markRegistered(msg.server_id, msg.max_in_flight);
-          if (!ok) {
-            TT_LOG_ERROR("[Gateway] markRegistered failed for '{}'",
-                         msg.server_id);
-          }
-        });
-
-    sm->registerHandler<tt::sockets::PrefillResultMessage>(
-        "prefill_result",
-        [&dispatcherPtr, state](const tt::sockets::PrefillResultMessage& msg) {
-          dispatcherPtr->onPrefillResult(state->getServerId(), msg);
-        });
-
-    sm->registerHandler<tt::sockets::PrefillCacheBlocksAddedMessage>(
-        tt::sockets::tags::PREFILL_CACHE_BLOCKS_ADDED,
-        [&dispatcherPtr](
-            const tt::sockets::PrefillCacheBlocksAddedMessage& msg) {
-          dispatcherPtr->onCacheBlocksAdded(msg);
-        });
-
-    sm->registerHandler<tt::sockets::PrefillCacheBlocksEvictedMessage>(
-        tt::sockets::tags::PREFILL_CACHE_BLOCKS_EVICTED,
-        [&dispatcherPtr](
-            const tt::sockets::PrefillCacheBlocksEvictedMessage& msg) {
-          dispatcherPtr->onCacheBlocksEvicted(msg);
-        });
-
-    sm->setConnectionLostCallback([&registry, state]() {
-      const std::string sid = state->getServerId();
-      if (!sid.empty()) {
-        TT_LOG_WARN("[Gateway] Prefill '{}' connection lost", sid);
-        registry.markDown(sid);  // fires onPrefillDown -> dispatcher
-      }
-    });
-  }
-
   if (useZmqPrefillRouter) {
-    zmqPrefillRouter.registerHandler<tt::sockets::PrefillRegistrationMessage>(
-        tt::sockets::tags::PREFILL_REGISTRATION,
-        [&registry, &zmqPrefillRouter](
-            const tt::gateway::ZmqPrefillRouter::PeerIdentity& peerId,
-            const tt::sockets::PrefillRegistrationMessage& msg) {
-          TT_LOG_DEBUG("[Gateway] Prefill registered: id='{}' max_in_flight={}",
-                       msg.server_id, msg.max_in_flight);
-          zmqPrefillRouter.rememberRegistration(msg.server_id, peerId);
-          registry.preRegister(msg.server_id, nullptr);
-          bool ok = registry.markRegistered(msg.server_id, msg.max_in_flight);
-          if (!ok) {
-            TT_LOG_ERROR("[Gateway] markRegistered failed for '{}'",
-                         msg.server_id);
-          }
-        });
-
-    zmqPrefillRouter.registerHandler<tt::sockets::PrefillResultMessage>(
-        "prefill_result",
-        [&dispatcherPtr, &zmqPrefillRouter](
-            const tt::gateway::ZmqPrefillRouter::PeerIdentity& peerId,
-            const tt::sockets::PrefillResultMessage& msg) {
-          auto serverId = zmqPrefillRouter.serverIdForPeer(peerId);
-          if (!serverId.has_value()) {
-            TT_LOG_WARN("[Gateway] Ignoring result from unregistered prefill");
-            return;
-          }
-          dispatcherPtr->onPrefillResult(*serverId, msg);
-        });
-
-    zmqPrefillRouter
-        .registerHandler<tt::sockets::PrefillCacheBlocksAddedMessage>(
-            tt::sockets::tags::PREFILL_CACHE_BLOCKS_ADDED,
-            [&dispatcherPtr](
-                const tt::gateway::ZmqPrefillRouter::PeerIdentity&,
-                const tt::sockets::PrefillCacheBlocksAddedMessage& msg) {
-              dispatcherPtr->onCacheBlocksAdded(msg);
-            });
-
-    zmqPrefillRouter
-        .registerHandler<tt::sockets::PrefillCacheBlocksEvictedMessage>(
-            tt::sockets::tags::PREFILL_CACHE_BLOCKS_EVICTED,
-            [&dispatcherPtr](
-                const tt::gateway::ZmqPrefillRouter::PeerIdentity&,
-                const tt::sockets::PrefillCacheBlocksEvictedMessage& msg) {
-              dispatcherPtr->onCacheBlocksEvicted(msg);
-            });
+    tt::gateway::registerZmqPrefillHandlers(zmqPrefillRouter, registry,
+                                            *dispatcherPtr);
+  } else {
+    tt::gateway::registerTcpPrefillHandlers(prefillSms, registry,
+                                            *dispatcherPtr);
   }
 
   decodeSm.registerHandler<tt::sockets::PrefillRequestMessage>(
@@ -376,7 +285,8 @@ int main(int argc, char** argv) {
   });
 
   std::atomic<bool> watchdogStop{false};
-  constexpr auto prefillStaleTimeout = std::chrono::milliseconds(3000);
+  const auto prefillStaleTimeout =
+      std::chrono::milliseconds(cfg.prefillStaleTimeoutMs);
   std::thread watchdogThread;
   if (useZmqPrefillRouter) {
     watchdogThread = std::thread(

--- a/tt-media-server/prefill_gateway/src/main.cpp
+++ b/tt-media-server/prefill_gateway/src/main.cpp
@@ -17,6 +17,7 @@
 #include "gateway/affinity_cache.hpp"
 #include "gateway/dispatcher.hpp"
 #include "gateway/prefill_registry.hpp"
+#include "gateway/zmq_prefill_router.hpp"
 #include "sockets/socket_manager.hpp"
 #include "sockets/socket_messages.hpp"
 #include "utils/logger.hpp"
@@ -31,6 +32,8 @@ struct PrefillEndpoint {
 struct GatewayConfig {
   uint16_t decodePort = 0;
   std::vector<PrefillEndpoint> prefills;
+  std::string prefillBindHost = "*";
+  uint16_t prefillBindPort = 0;
 };
 
 struct PrefillConnectionState {
@@ -53,7 +56,10 @@ void printUsage(const char* prog) {
       << "Usage: " << prog << " --decode-port=<PORT> --prefill=<HOST>:<PORT> "
       << "[--prefill=<HOST>:<PORT> ...]\n\n"
       << "  --decode-port=PORT   Port the gateway listens on for decode.\n"
-      << "  --prefill=HOST:PORT  Prefill server to connect to (repeatable).\n"
+      << "  --prefill=HOST:PORT  TCP prefill server to connect to "
+         "(repeatable).\n"
+      << "  --prefill-bind=HOST:PORT\n"
+      << "                        ZMQ ROUTER bind endpoint for prefills.\n"
       << "  --help               Print this message.\n\n"
       << "Example:\n"
       << "  " << prog
@@ -107,6 +113,18 @@ std::optional<GatewayConfig> parseArgs(int argc, char** argv) {
       continue;
     }
 
+    if (auto v = flagValue(arg, "--prefill-bind=")) {
+      auto ep = parsePrefillArg(std::string(*v));
+      if (!ep) {
+        std::cerr << "Invalid --prefill-bind value: " << *v
+                  << " (expected HOST:PORT)\n";
+        return std::nullopt;
+      }
+      cfg.prefillBindHost = std::move(ep->host);
+      cfg.prefillBindPort = ep->port;
+      continue;
+    }
+
     std::cerr << "Unknown argument: " << arg << "\n";
     printUsage(argv[0]);
     return std::nullopt;
@@ -118,13 +136,12 @@ std::optional<GatewayConfig> parseArgs(int argc, char** argv) {
     return std::nullopt;
   }
 
-  if (cfg.prefills.empty()) {
-    std::cerr << "At least one --prefill is required.\n";
-    printUsage(argv[0]);
-    return std::nullopt;
-  }
-
   return cfg;
+}
+
+std::string socketTransportFromEnv() {
+  const char* value = std::getenv("SOCKET_TRANSPORT");
+  return value ? std::string(value) : tt::sockets::transport_names::TCP;
 }
 
 volatile sig_atomic_t gStop = 0;
@@ -139,9 +156,24 @@ int main(int argc, char** argv) {
   auto cfgOpt = parseArgs(argc, argv);
   if (!cfgOpt) return 1;
   const GatewayConfig& cfg = *cfgOpt;
+  const bool useZmqPrefillRouter =
+      socketTransportFromEnv() == tt::sockets::transport_names::ZMQ;
 
-  TT_LOG_INFO("[Gateway] Starting — decode port={}, prefills={}",
-              cfg.decodePort, cfg.prefills.size());
+  if (useZmqPrefillRouter && cfg.prefillBindPort == 0) {
+    std::cerr
+        << "--prefill-bind=HOST:PORT is required for SOCKET_TRANSPORT=zmq\n";
+    return 1;
+  }
+  if (!useZmqPrefillRouter && cfg.prefills.empty()) {
+    std::cerr << "At least one --prefill is required for TCP mode.\n";
+    return 1;
+  }
+  if (useZmqPrefillRouter && !cfg.prefills.empty()) {
+    TT_LOG_WARN("[Gateway] Ignoring --prefill endpoints in ZMQ ROUTER mode");
+  }
+
+  TT_LOG_INFO("[Gateway] Starting — decode port={}, transport={}",
+              cfg.decodePort, useZmqPrefillRouter ? "zmq" : "tcp");
 
   tt::gateway::PrefillRegistry registry;
   tt::gateway::AffinityCache affinity;
@@ -153,19 +185,29 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  // Per-prefill: one independent SocketManager (CLIENT) per endpoint — the
-  // gateway's 1:N fan-out without modifying the underlying 1:1 transport.
+  tt::gateway::ZmqPrefillRouter zmqPrefillRouter;
+
+  if (useZmqPrefillRouter &&
+      !zmqPrefillRouter.start(cfg.prefillBindHost, cfg.prefillBindPort)) {
+    TT_LOG_ERROR("[Gateway] Failed to bind ZMQ prefill ROUTER on {}:{}",
+                 cfg.prefillBindHost, cfg.prefillBindPort);
+    return 1;
+  }
+
+  // TCP keeps one independent SocketManager (CLIENT) per endpoint.
   std::vector<std::unique_ptr<tt::sockets::SocketManager>> prefillSms;
   prefillSms.reserve(cfg.prefills.size());
-  for (const auto& ep : cfg.prefills) {
-    auto sm = std::make_unique<tt::sockets::SocketManager>();
-    sm->setReconnectBackoff(/*initial_ms=*/1000, /*max_ms=*/5000);
-    if (!sm->initializeAsClient(ep.host, ep.port)) {
-      TT_LOG_ERROR("[Gateway] Failed to init client socket to {}:{}", ep.host,
-                   ep.port);
-      return 1;
+  if (!useZmqPrefillRouter) {
+    for (const auto& ep : cfg.prefills) {
+      auto sm = std::make_unique<tt::sockets::SocketManager>();
+      sm->setReconnectBackoff(/*initial_ms=*/1000, /*max_ms=*/5000);
+      if (!sm->initializeAsClient(ep.host, ep.port)) {
+        TT_LOG_ERROR("[Gateway] Failed to init client socket to {}:{}", ep.host,
+                     ep.port);
+        return 1;
+      }
+      prefillSms.push_back(std::move(sm));
     }
-    prefillSms.push_back(std::move(sm));
   }
 
   // Dispatcher takes Senders by value; lambdas below capture references which
@@ -175,8 +217,13 @@ int main(int argc, char** argv) {
   tt::gateway::Dispatcher::Senders senders;
 
   senders.sendRequestToPrefill =
-      [&registry](const std::string& serverId,
-                  const tt::sockets::PrefillRequestMessage& msg) -> bool {
+      [&registry, &zmqPrefillRouter, useZmqPrefillRouter](
+          const std::string& serverId,
+          const tt::sockets::PrefillRequestMessage& msg) -> bool {
+    if (useZmqPrefillRouter) {
+      return zmqPrefillRouter.sendObject(serverId, "prefill_request", msg);
+    }
+
     auto* sm = registry.getSocketManager(serverId);
     if (!sm) {
       TT_LOG_WARN("[Gateway] sendRequestToPrefill: no socket for '{}'",
@@ -254,6 +301,55 @@ int main(int argc, char** argv) {
     });
   }
 
+  if (useZmqPrefillRouter) {
+    zmqPrefillRouter.registerHandler<tt::sockets::PrefillRegistrationMessage>(
+        tt::sockets::tags::PREFILL_REGISTRATION,
+        [&registry, &zmqPrefillRouter](
+            const tt::gateway::ZmqPrefillRouter::PeerIdentity& peerId,
+            const tt::sockets::PrefillRegistrationMessage& msg) {
+          TT_LOG_DEBUG("[Gateway] Prefill registered: id='{}' max_in_flight={}",
+                       msg.server_id, msg.max_in_flight);
+          zmqPrefillRouter.rememberRegistration(msg.server_id, peerId);
+          registry.preRegister(msg.server_id, nullptr);
+          bool ok = registry.markRegistered(msg.server_id, msg.max_in_flight);
+          if (!ok) {
+            TT_LOG_ERROR("[Gateway] markRegistered failed for '{}'",
+                         msg.server_id);
+          }
+        });
+
+    zmqPrefillRouter.registerHandler<tt::sockets::PrefillResultMessage>(
+        "prefill_result",
+        [&dispatcherPtr, &zmqPrefillRouter](
+            const tt::gateway::ZmqPrefillRouter::PeerIdentity& peerId,
+            const tt::sockets::PrefillResultMessage& msg) {
+          auto serverId = zmqPrefillRouter.serverIdForPeer(peerId);
+          if (!serverId.has_value()) {
+            TT_LOG_WARN("[Gateway] Ignoring result from unregistered prefill");
+            return;
+          }
+          dispatcherPtr->onPrefillResult(*serverId, msg);
+        });
+
+    zmqPrefillRouter
+        .registerHandler<tt::sockets::PrefillCacheBlocksAddedMessage>(
+            tt::sockets::tags::PREFILL_CACHE_BLOCKS_ADDED,
+            [&dispatcherPtr](
+                const tt::gateway::ZmqPrefillRouter::PeerIdentity&,
+                const tt::sockets::PrefillCacheBlocksAddedMessage& msg) {
+              dispatcherPtr->onCacheBlocksAdded(msg);
+            });
+
+    zmqPrefillRouter
+        .registerHandler<tt::sockets::PrefillCacheBlocksEvictedMessage>(
+            tt::sockets::tags::PREFILL_CACHE_BLOCKS_EVICTED,
+            [&dispatcherPtr](
+                const tt::gateway::ZmqPrefillRouter::PeerIdentity&,
+                const tt::sockets::PrefillCacheBlocksEvictedMessage& msg) {
+              dispatcherPtr->onCacheBlocksEvicted(msg);
+            });
+  }
+
   decodeSm.registerHandler<tt::sockets::PrefillRequestMessage>(
       "prefill_request",
       [&dispatcherPtr](const tt::sockets::PrefillRequestMessage& msg) {
@@ -279,6 +375,24 @@ int main(int argc, char** argv) {
     }
   });
 
+  std::atomic<bool> watchdogStop{false};
+  constexpr auto prefillStaleTimeout = std::chrono::milliseconds(3000);
+  std::thread watchdogThread;
+  if (useZmqPrefillRouter) {
+    watchdogThread = std::thread(
+        [&registry, &zmqPrefillRouter, &watchdogStop, prefillStaleTimeout] {
+          while (!watchdogStop.load()) {
+            for (const auto& serverId :
+                 zmqPrefillRouter.takeStaleServers(prefillStaleTimeout)) {
+              TT_LOG_WARN("[Gateway] Prefill '{}' registration timed out",
+                          serverId);
+              registry.markDown(serverId);
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+          }
+        });
+  }
+
   TT_LOG_INFO("[Gateway] Running. Send SIGINT/SIGTERM to stop.");
 
   std::signal(SIGINT, signalHandler);
@@ -291,8 +405,11 @@ int main(int argc, char** argv) {
   TT_LOG_INFO("[Gateway] Shutting down…");
   proberStop = true;
   if (proberThread.joinable()) proberThread.join();
+  watchdogStop = true;
+  if (watchdogThread.joinable()) watchdogThread.join();
   decodeSm.stop();
   for (auto& sm : prefillSms) sm->stop();
+  zmqPrefillRouter.stop();
   TT_LOG_INFO("[Gateway] Stopped.");
 
   return 0;

--- a/tt-media-server/prefill_gateway/src/prefill_connection_wiring.cpp
+++ b/tt-media-server/prefill_gateway/src/prefill_connection_wiring.cpp
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#include "gateway/prefill_connection_wiring.hpp"
+
+#include <mutex>
+#include <string>
+
+#include "gateway/dispatcher.hpp"
+#include "gateway/prefill_registry.hpp"
+#include "gateway/zmq_prefill_router.hpp"
+#include "sockets/socket_manager.hpp"
+#include "sockets/socket_messages.hpp"
+#include "utils/logger.hpp"
+
+namespace tt::gateway {
+namespace {
+
+struct PrefillConnectionState {
+  void setServerId(const std::string& serverId) {
+    std::lock_guard<std::mutex> lock(mutex);
+    this->serverId = serverId;
+  }
+
+  std::string getServerId() const {
+    std::lock_guard<std::mutex> lock(mutex);
+    return serverId;
+  }
+
+  mutable std::mutex mutex;
+  std::string serverId;
+};
+
+}  // namespace
+
+void registerTcpPrefillHandlers(PrefillSocketManagers& prefillSms,
+                                PrefillRegistry& registry,
+                                Dispatcher& dispatcher) {
+  for (auto& smPtr : prefillSms) {
+    tt::sockets::SocketManager* sm = smPtr.get();
+
+    // Shared between callbacks that may run on different threads. The id is
+    // unknown until the first registration message.
+    auto state = std::make_shared<PrefillConnectionState>();
+
+    sm->registerHandler<tt::sockets::PrefillRegistrationMessage>(
+        tt::sockets::tags::PREFILL_REGISTRATION,
+        [&registry, sm,
+         state](const tt::sockets::PrefillRegistrationMessage& msg) {
+          TT_LOG_DEBUG("[Gateway] Prefill registered: id='{}' max_in_flight={}",
+                       msg.server_id, msg.max_in_flight);
+          state->setServerId(msg.server_id);
+          registry.preRegister(msg.server_id, sm);
+          bool ok = registry.markRegistered(msg.server_id, msg.max_in_flight);
+          if (!ok) {
+            TT_LOG_ERROR("[Gateway] markRegistered failed for '{}'",
+                         msg.server_id);
+          }
+        });
+
+    sm->registerHandler<tt::sockets::PrefillResultMessage>(
+        "prefill_result",
+        [&dispatcher, state](const tt::sockets::PrefillResultMessage& msg) {
+          dispatcher.onPrefillResult(state->getServerId(), msg);
+        });
+
+    sm->registerHandler<tt::sockets::PrefillCacheBlocksAddedMessage>(
+        tt::sockets::tags::PREFILL_CACHE_BLOCKS_ADDED,
+        [&dispatcher](const tt::sockets::PrefillCacheBlocksAddedMessage& msg) {
+          dispatcher.onCacheBlocksAdded(msg);
+        });
+
+    sm->registerHandler<tt::sockets::PrefillCacheBlocksEvictedMessage>(
+        tt::sockets::tags::PREFILL_CACHE_BLOCKS_EVICTED,
+        [&dispatcher](
+            const tt::sockets::PrefillCacheBlocksEvictedMessage& msg) {
+          dispatcher.onCacheBlocksEvicted(msg);
+        });
+
+    sm->setConnectionLostCallback([&registry, state]() {
+      const std::string sid = state->getServerId();
+      if (!sid.empty()) {
+        TT_LOG_WARN("[Gateway] Prefill '{}' connection lost", sid);
+        registry.markDown(sid);
+      }
+    });
+  }
+}
+
+void registerZmqPrefillHandlers(ZmqPrefillRouter& zmqPrefillRouter,
+                                PrefillRegistry& registry,
+                                Dispatcher& dispatcher) {
+  zmqPrefillRouter.registerHandler<tt::sockets::PrefillRegistrationMessage>(
+      tt::sockets::tags::PREFILL_REGISTRATION,
+      [&registry, &zmqPrefillRouter](
+          const ZmqPrefillRouter::PeerIdentity& peerId,
+          const tt::sockets::PrefillRegistrationMessage& msg) {
+        TT_LOG_DEBUG("[Gateway] Prefill registered: id='{}' max_in_flight={}",
+                     msg.server_id, msg.max_in_flight);
+        zmqPrefillRouter.rememberRegistration(msg.server_id, peerId);
+        registry.preRegister(msg.server_id, nullptr);
+        bool ok = registry.markRegistered(msg.server_id, msg.max_in_flight);
+        if (!ok) {
+          TT_LOG_ERROR("[Gateway] markRegistered failed for '{}'",
+                       msg.server_id);
+        }
+      });
+
+  zmqPrefillRouter.registerHandler<tt::sockets::PrefillResultMessage>(
+      "prefill_result", [&dispatcher, &zmqPrefillRouter](
+                            const ZmqPrefillRouter::PeerIdentity& peerId,
+                            const tt::sockets::PrefillResultMessage& msg) {
+        auto serverId = zmqPrefillRouter.serverIdForPeer(peerId);
+        if (!serverId.has_value()) {
+          TT_LOG_WARN("[Gateway] Ignoring result from unregistered prefill");
+          return;
+        }
+        dispatcher.onPrefillResult(*serverId, msg);
+      });
+
+  zmqPrefillRouter.registerHandler<tt::sockets::PrefillCacheBlocksAddedMessage>(
+      tt::sockets::tags::PREFILL_CACHE_BLOCKS_ADDED,
+      [&dispatcher](const ZmqPrefillRouter::PeerIdentity&,
+                    const tt::sockets::PrefillCacheBlocksAddedMessage& msg) {
+        dispatcher.onCacheBlocksAdded(msg);
+      });
+
+  zmqPrefillRouter
+      .registerHandler<tt::sockets::PrefillCacheBlocksEvictedMessage>(
+          tt::sockets::tags::PREFILL_CACHE_BLOCKS_EVICTED,
+          [&dispatcher](
+              const ZmqPrefillRouter::PeerIdentity&,
+              const tt::sockets::PrefillCacheBlocksEvictedMessage& msg) {
+            dispatcher.onCacheBlocksEvicted(msg);
+          });
+}
+
+}  // namespace tt::gateway

--- a/tt-media-server/prefill_gateway/src/zmq_prefill_router.cpp
+++ b/tt-media-server/prefill_gateway/src/zmq_prefill_router.cpp
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#include "gateway/zmq_prefill_router.hpp"
+
+#include <zmq.hpp>
+
+#include "utils/logger.hpp"
+
+namespace tt::gateway {
+namespace {
+
+constexpr int ZMQ_CONTEXT_IO_THREADS = 1;
+constexpr int ZMQ_RECEIVE_TIMEOUT_MS = 50;
+constexpr auto IO_IDLE_WAIT = std::chrono::milliseconds(1);
+
+std::vector<uint8_t> toBytes(const zmq::message_t& message) {
+  auto* ptr = static_cast<const uint8_t*>(message.data());
+  return {ptr, ptr + message.size()};
+}
+
+}  // namespace
+
+class ZmqPrefillRouter::Impl {
+ public:
+  Impl() : context(ZMQ_CONTEXT_IO_THREADS) {}
+
+  zmq::context_t context;
+  std::unique_ptr<zmq::socket_t> socket;
+};
+
+ZmqPrefillRouter::ZmqPrefillRouter() : impl_(std::make_unique<Impl>()) {}
+
+ZmqPrefillRouter::~ZmqPrefillRouter() { stop(); }
+
+bool ZmqPrefillRouter::start(const std::string& bindHost, uint16_t port) {
+  if (running_) {
+    return false;
+  }
+
+  endpoint_ = "tcp://" + bindHost + ":" + std::to_string(port);
+  running_ = true;
+  if (!startIoThread()) {
+    running_ = false;
+    return false;
+  }
+  return true;
+}
+
+void ZmqPrefillRouter::stop() {
+  if (!running_) {
+    return;
+  }
+
+  running_ = false;
+  send_cv_.notify_all();
+
+  if (io_thread_.joinable()) {
+    io_thread_.join();
+  }
+
+  TT_LOG_INFO("[ZmqPrefillRouter] Stopped");
+}
+
+std::string ZmqPrefillRouter::peerKey(const PeerIdentity& peerId) {
+  return {reinterpret_cast<const char*>(peerId.data()), peerId.size()};
+}
+
+void ZmqPrefillRouter::rememberRegistration(const std::string& serverId,
+                                            const PeerIdentity& peerId) {
+  const std::string key = peerKey(peerId);
+  std::lock_guard<std::mutex> lock(peer_mutex_);
+
+  auto oldPeer = server_to_peer_.find(serverId);
+  if (oldPeer != server_to_peer_.end()) {
+    peer_to_server_.erase(peerKey(oldPeer->second));
+  }
+
+  server_to_peer_[serverId] = peerId;
+  peer_to_server_[key] = serverId;
+  last_seen_by_server_[serverId] = std::chrono::steady_clock::now();
+}
+
+std::optional<std::string> ZmqPrefillRouter::serverIdForPeer(
+    const PeerIdentity& peerId) const {
+  const std::string key = peerKey(peerId);
+  std::lock_guard<std::mutex> lock(peer_mutex_);
+  auto it = peer_to_server_.find(key);
+  if (it == peer_to_server_.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+std::vector<std::string> ZmqPrefillRouter::takeStaleServers(
+    std::chrono::milliseconds timeout) {
+  const auto now = std::chrono::steady_clock::now();
+  std::vector<std::string> staleServers;
+
+  std::lock_guard<std::mutex> lock(peer_mutex_);
+  for (auto it = last_seen_by_server_.begin();
+       it != last_seen_by_server_.end();) {
+    if (now - it->second <= timeout) {
+      ++it;
+      continue;
+    }
+
+    staleServers.push_back(it->first);
+    auto peerIt = server_to_peer_.find(it->first);
+    if (peerIt != server_to_peer_.end()) {
+      peer_to_server_.erase(peerKey(peerIt->second));
+      server_to_peer_.erase(peerIt);
+    }
+    it = last_seen_by_server_.erase(it);
+  }
+
+  return staleServers;
+}
+
+std::optional<ZmqPrefillRouter::PeerIdentity> ZmqPrefillRouter::peerIdForServer(
+    const std::string& serverId) const {
+  std::lock_guard<std::mutex> lock(peer_mutex_);
+  auto it = server_to_peer_.find(serverId);
+  if (it == server_to_peer_.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+bool ZmqPrefillRouter::startIoThread() {
+  std::promise<bool> initialized;
+  auto fut = initialized.get_future();
+  io_thread_ =
+      std::thread(&ZmqPrefillRouter::ioLoop, this, std::move(initialized));
+  bool initializedOk = fut.get();
+  if (!initializedOk && io_thread_.joinable()) {
+    io_thread_.join();
+  }
+  return initializedOk;
+}
+
+void ZmqPrefillRouter::ioLoop(std::promise<bool> initialized) {
+  if (!initializeSocket()) {
+    initialized.set_value(false);
+    return;
+  }
+
+  initialized.set_value(true);
+
+  while (running_) {
+    const bool sent = processPendingSends();
+    const bool received = receiveAvailableMessages();
+    if (!sent && !received) {
+      waitForIoWork();
+    }
+  }
+
+  failPendingSends();
+  if (impl_->socket) {
+    impl_->socket->close();
+    impl_->socket.reset();
+  }
+  impl_->context.close();
+}
+
+bool ZmqPrefillRouter::initializeSocket() {
+  try {
+    impl_->socket = std::make_unique<zmq::socket_t>(impl_->context,
+                                                    zmq::socket_type::router);
+    impl_->socket->set(zmq::sockopt::linger, 0);
+    impl_->socket->set(zmq::sockopt::rcvtimeo, ZMQ_RECEIVE_TIMEOUT_MS);
+    impl_->socket->bind(endpoint_);
+    TT_LOG_INFO("[ZmqPrefillRouter] Bound prefill ROUTER to {}", endpoint_);
+    return true;
+  } catch (const zmq::error_t& e) {
+    TT_LOG_ERROR("[ZmqPrefillRouter] Failed to bind {}: {}", endpoint_,
+                 e.what());
+    impl_->socket.reset();
+    return false;
+  }
+}
+
+bool ZmqPrefillRouter::processPendingSends() {
+  bool processed = false;
+
+  while (true) {
+    std::shared_ptr<SendRequest> request;
+    {
+      std::lock_guard<std::mutex> lock(send_mutex_);
+      if (pending_sends_.empty()) {
+        return processed;
+      }
+      request = std::move(pending_sends_.front());
+      pending_sends_.pop_front();
+    }
+
+    bool ok = false;
+    try {
+      zmq::message_t idFrame(request->peerKey.data(), request->peerKey.size());
+      impl_->socket->send(idFrame, zmq::send_flags::sndmore);
+
+      zmq::message_t msg(request->data.data(), request->data.size());
+      ok = impl_->socket->send(msg, zmq::send_flags::dontwait).has_value();
+    } catch (const zmq::error_t& e) {
+      TT_LOG_ERROR("[ZmqPrefillRouter] Send failed: {}", e.what());
+    }
+    request->result.set_value(ok);
+    processed = true;
+  }
+}
+
+bool ZmqPrefillRouter::receiveAvailableMessages() {
+  bool received = false;
+  try {
+    while (true) {
+      zmq::message_t identity;
+      auto idResult = impl_->socket->recv(identity, zmq::recv_flags::dontwait);
+      if (!idResult.has_value()) {
+        return received;
+      }
+      if (!identity.more()) {
+        continue;
+      }
+
+      zmq::message_t msg;
+      auto msgResult = impl_->socket->recv(msg, zmq::recv_flags::dontwait);
+      if (!msgResult.has_value() || msg.size() == 0) {
+        continue;
+      }
+
+      handleIncomingMessage(toBytes(identity), toBytes(msg));
+      received = true;
+    }
+  } catch (const zmq::error_t& e) {
+    if (e.num() != EAGAIN) {
+      TT_LOG_ERROR("[ZmqPrefillRouter] Receive failed: {}", e.what());
+    }
+  }
+  return received;
+}
+
+void ZmqPrefillRouter::waitForIoWork() {
+  std::unique_lock<std::mutex> lock(send_mutex_);
+  send_cv_.wait_for(lock, IO_IDLE_WAIT,
+                    [this] { return !pending_sends_.empty() || !running_; });
+}
+
+void ZmqPrefillRouter::failPendingSends() {
+  while (true) {
+    std::shared_ptr<SendRequest> request;
+    {
+      std::lock_guard<std::mutex> lock(send_mutex_);
+      if (pending_sends_.empty()) {
+        return;
+      }
+      request = std::move(pending_sends_.front());
+      pending_sends_.pop_front();
+    }
+    request->result.set_value(false);
+  }
+}
+
+void ZmqPrefillRouter::handleIncomingMessage(const PeerIdentity& peerId,
+                                             const std::vector<uint8_t>& data) {
+  try {
+    std::string serialized(data.begin(), data.end());
+    std::istringstream iss(serialized);
+    cereal::BinaryInputArchive archive(iss);
+    std::string messageType;
+    archive(messageType);
+
+    RawHandler handler;
+    {
+      std::lock_guard<std::mutex> lock(handlers_mutex_);
+      auto it = handlers_.find(messageType);
+      if (it == handlers_.end()) {
+        TT_LOG_DEBUG("[ZmqPrefillRouter] No handler for message type: {}",
+                     messageType);
+        return;
+      }
+      handler = it->second;
+    }
+
+    handler(peerId, data);
+  } catch (const std::exception& e) {
+    TT_LOG_ERROR("[ZmqPrefillRouter] Message handling error: {}", e.what());
+  }
+}
+
+}  // namespace tt::gateway

--- a/tt-media-server/prefill_gateway/src/zmq_prefill_router.cpp
+++ b/tt-media-server/prefill_gateway/src/zmq_prefill_router.cpp
@@ -263,12 +263,7 @@ void ZmqPrefillRouter::failPendingSends() {
 void ZmqPrefillRouter::handleIncomingMessage(const PeerIdentity& peerId,
                                              const std::vector<uint8_t>& data) {
   try {
-    std::string serialized(data.begin(), data.end());
-    std::istringstream iss(serialized);
-    cereal::BinaryInputArchive archive(iss);
-    std::string messageType;
-    archive(messageType);
-
+    std::string messageType = tt::sockets::wire::readMessageType(data);
     RawHandler handler;
     {
       std::lock_guard<std::mutex> lock(handlers_mutex_);

--- a/tt-media-server/prefill_gateway/tests/gateway_e2e_test.cpp
+++ b/tt-media-server/prefill_gateway/tests/gateway_e2e_test.cpp
@@ -23,8 +23,10 @@
 #include "gateway/affinity_cache.hpp"
 #include "gateway/dispatcher.hpp"
 #include "gateway/prefill_registry.hpp"
+#include "gateway/zmq_prefill_router.hpp"
 #include "sockets/socket_manager.hpp"
 #include "sockets/socket_messages.hpp"
+#include "sockets/zmq_socket_transport.hpp"
 
 namespace tt::gateway {
 namespace {
@@ -54,6 +56,38 @@ uint16_t ephemeralPort() {
   uint16_t port = ntohs(addr.sin_port);
   close(s);
   return port;
+}
+
+template <typename T>
+std::vector<uint8_t> serializeMessage(const std::string& messageType,
+                                      const T& message) {
+  std::ostringstream oss;
+  {
+    cereal::BinaryOutputArchive archive(oss);
+    archive(messageType);
+    message.write(archive);
+  }
+  const std::string serialized = oss.str();
+  return {serialized.begin(), serialized.end()};
+}
+
+std::string messageTypeOf(const std::vector<uint8_t>& data) {
+  std::string serialized(data.begin(), data.end());
+  std::istringstream iss(serialized);
+  cereal::BinaryInputArchive archive(iss);
+  std::string messageType;
+  archive(messageType);
+  return messageType;
+}
+
+template <typename T>
+T deserializeMessage(const std::vector<uint8_t>& data) {
+  std::string serialized(data.begin(), data.end());
+  std::istringstream iss(serialized);
+  cereal::BinaryInputArchive archive(iss);
+  std::string messageType;
+  archive(messageType);
+  return T::read(archive);
 }
 
 struct PrefillConnectionState {
@@ -296,6 +330,154 @@ class GatewayHarness {
   std::atomic<bool> proberStop_{false};
 };
 
+class FakeZmqPrefill {
+ public:
+  FakeZmqPrefill(std::string serverId, const std::string& routerHost,
+                 uint16_t routerPort, uint32_t maxInFlight = 4)
+      : serverId_(std::move(serverId)),
+        routerHost_(routerHost),
+        routerPort_(routerPort),
+        maxInFlight_(maxInFlight) {
+    sm_.initializeAsClient(routerHost_, routerPort_);
+    sm_.setReconnectBackoff(50, 500);
+  }
+
+  ~FakeZmqPrefill() { stop(); }
+
+  void start() {
+    sm_.start();
+    running_ = true;
+    registrationThread_ = std::thread([this] {
+      while (running_.load()) {
+        tt::sockets::PrefillRegistrationMessage msg;
+        msg.server_id = serverId_;
+        msg.max_in_flight = maxInFlight_;
+        sm_.sendRawData(
+            serializeMessage(tt::sockets::tags::PREFILL_REGISTRATION, msg));
+        std::this_thread::sleep_for(50ms);
+      }
+    });
+    receiveThread_ = std::thread([this] {
+      while (running_.load()) {
+        auto data = sm_.receiveRawData();
+        if (data.empty()) {
+          std::this_thread::sleep_for(10ms);
+          continue;
+        }
+        if (messageTypeOf(data) != "prefill_request") {
+          continue;
+        }
+
+        auto request =
+            deserializeMessage<tt::sockets::PrefillRequestMessage>(data);
+        receivedTaskIds_.fetch_add(1);
+        tt::sockets::PrefillResultMessage result(request.task_id);
+        result.finished = true;
+        result.generated_text = "ok-from-" + serverId_;
+        sm_.sendRawData(serializeMessage("prefill_result", result));
+      }
+    });
+  }
+
+  void stop() {
+    running_ = false;
+    if (registrationThread_.joinable()) {
+      registrationThread_.join();
+    }
+    if (receiveThread_.joinable()) {
+      receiveThread_.join();
+    }
+    sm_.stop();
+  }
+
+  uint32_t receivedTaskCount() const { return receivedTaskIds_.load(); }
+
+ private:
+  std::string serverId_;
+  std::string routerHost_;
+  uint16_t routerPort_;
+  uint32_t maxInFlight_;
+  std::atomic<bool> running_{false};
+  std::atomic<uint32_t> receivedTaskIds_{0};
+  tt::sockets::ZmqSocketTransport sm_;
+  std::thread registrationThread_;
+  std::thread receiveThread_;
+};
+
+class ZmqRouterGatewayHarness {
+ public:
+  ZmqRouterGatewayHarness(uint16_t decodePort, uint16_t prefillRouterPort)
+      : decodePort_(decodePort), prefillRouterPort_(prefillRouterPort) {
+    decodeSm_.initializeAsServer(decodePort_);
+
+    Dispatcher::Senders senders;
+    senders.sendRequestToPrefill =
+        [this](const std::string& serverId,
+               const tt::sockets::PrefillRequestMessage& msg) -> bool {
+      return prefillRouter_.sendObject(serverId, "prefill_request", msg);
+    };
+    senders.sendAssignmentToDecode =
+        [this](const tt::sockets::PrefillAssignmentMessage& msg) -> bool {
+      return decodeSm_.sendObject(tt::sockets::tags::PREFILL_ASSIGNMENT, msg);
+    };
+    senders.sendResultToDecode =
+        [this](const tt::sockets::PrefillResultMessage& msg) -> bool {
+      return decodeSm_.sendObject("prefill_result", msg);
+    };
+
+    dispatcher_ =
+        std::make_unique<Dispatcher>(registry_, affinity_, std::move(senders));
+
+    registry_.setOnPrefillDown(
+        [this](const std::string& id) { dispatcher_->onPrefillDown(id); });
+
+    prefillRouter_.registerHandler<tt::sockets::PrefillRegistrationMessage>(
+        tt::sockets::tags::PREFILL_REGISTRATION,
+        [this](const ZmqPrefillRouter::PeerIdentity& peerId,
+               const tt::sockets::PrefillRegistrationMessage& msg) {
+          prefillRouter_.rememberRegistration(msg.server_id, peerId);
+          registry_.preRegister(msg.server_id, nullptr);
+          registry_.markRegistered(msg.server_id, msg.max_in_flight);
+        });
+
+    prefillRouter_.registerHandler<tt::sockets::PrefillResultMessage>(
+        "prefill_result", [this](const ZmqPrefillRouter::PeerIdentity& peerId,
+                                 const tt::sockets::PrefillResultMessage& msg) {
+          auto serverId = prefillRouter_.serverIdForPeer(peerId);
+          if (serverId.has_value()) {
+            dispatcher_->onPrefillResult(*serverId, msg);
+          }
+        });
+
+    decodeSm_.registerHandler<tt::sockets::PrefillRequestMessage>(
+        "prefill_request",
+        [this](const tt::sockets::PrefillRequestMessage& msg) {
+          dispatcher_->onPrefillRequest(msg);
+        });
+  }
+
+  ~ZmqRouterGatewayHarness() {
+    decodeSm_.stop();
+    prefillRouter_.stop();
+  }
+
+  void start() {
+    ASSERT_TRUE(prefillRouter_.start("127.0.0.1", prefillRouterPort_));
+    decodeSm_.start();
+  }
+
+  PrefillRegistry& registry() { return registry_; }
+
+ private:
+  uint16_t decodePort_;
+  uint16_t prefillRouterPort_;
+  PrefillRegistry registry_;
+  AffinityCache affinity_;
+  tt::sockets::SocketManager decodeSm_;
+  ZmqPrefillRouter prefillRouter_;
+  std::unique_ptr<Dispatcher> dispatcher_;
+};
+
 class GatewayE2ETest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -407,6 +589,138 @@ TEST_F(GatewayE2ETest, PrefillDownFailsInFlightTaskToDecode) {
   EXPECT_TRUE(results[0].error);
   EXPECT_EQ(results[0].generated_text, "prefill_down");
   EXPECT_FALSE(gateway_->affinity().lookup(77).has_value());
+}
+
+TEST(ZmqRouterGatewayE2ETest, PrefillsCanStartBeforeGateway) {
+  const uint16_t decodePort = ephemeralPort();
+  const uint16_t prefillRouterPort = ephemeralPort();
+
+  FakeZmqPrefill prefillA("prefill-A", "127.0.0.1", prefillRouterPort);
+  FakeZmqPrefill prefillB("prefill-B", "127.0.0.1", prefillRouterPort);
+  prefillA.start();
+  prefillB.start();
+
+  ZmqRouterGatewayHarness gateway(decodePort, prefillRouterPort);
+  gateway.start();
+
+  FakeDecode decode("127.0.0.1", decodePort);
+  decode.start();
+
+  ASSERT_TRUE(waitFor([&] {
+    auto snap = gateway.registry().snapshot();
+    int healthy = 0;
+    for (const auto& s : snap) {
+      if (s.healthy) ++healthy;
+    }
+    return healthy == 2 && decode.isConnected();
+  })) << "Timed out waiting for prefills to register after gateway start";
+
+  decode.sendRequest(/*task_id=*/101, /*hash=*/0);
+  decode.sendRequest(/*task_id=*/102, /*hash=*/0);
+
+  ASSERT_TRUE(waitFor([&] { return decode.resultCount() >= 2; }))
+      << "No results received through ZMQ prefill ROUTER";
+
+  auto assignments = decode.assignments();
+  ASSERT_EQ(assignments.size(), 2u);
+  EXPECT_NE(assignments[0].server_id, assignments[1].server_id);
+
+  EXPECT_EQ(prefillA.receivedTaskCount() + prefillB.receivedTaskCount(), 2u);
+  EXPECT_EQ(prefillA.receivedTaskCount(), 1u);
+  EXPECT_EQ(prefillB.receivedTaskCount(), 1u);
+}
+
+TEST(ZmqPrefillRouterTest, RoutesRequestToRegisteredPrefill) {
+  const uint16_t port = ephemeralPort();
+
+  ZmqPrefillRouter router;
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool registered = false;
+  bool requestReceived = false;
+  bool resultReceived = false;
+
+  router.registerHandler<tt::sockets::PrefillRegistrationMessage>(
+      tt::sockets::tags::PREFILL_REGISTRATION,
+      [&router, &mutex, &cv, &registered](
+          const ZmqPrefillRouter::PeerIdentity& peerId,
+          const tt::sockets::PrefillRegistrationMessage& msg) {
+        router.rememberRegistration(msg.server_id, peerId);
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          registered = true;
+        }
+        cv.notify_all();
+      });
+
+  router.registerHandler<tt::sockets::PrefillResultMessage>(
+      "prefill_result", [&mutex, &cv, &resultReceived](
+                            const ZmqPrefillRouter::PeerIdentity&,
+                            const tt::sockets::PrefillResultMessage& msg) {
+        EXPECT_EQ(msg.task_id, 7u);
+        std::lock_guard<std::mutex> lock(mutex);
+        resultReceived = true;
+        cv.notify_all();
+      });
+
+  ASSERT_TRUE(router.start("127.0.0.1", port));
+
+  tt::sockets::ZmqSocketTransport client;
+  ASSERT_TRUE(client.initializeAsClient("127.0.0.1", port));
+  client.start();
+
+  std::atomic<bool> clientRunning{true};
+  std::thread clientThread([&] {
+    while (clientRunning.load()) {
+      auto data = client.receiveRawData();
+      if (data.empty()) {
+        std::this_thread::sleep_for(10ms);
+        continue;
+      }
+
+      if (messageTypeOf(data) != "prefill_request") {
+        continue;
+      }
+
+      auto request =
+          deserializeMessage<tt::sockets::PrefillRequestMessage>(data);
+      EXPECT_EQ(request.task_id, 7u);
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        requestReceived = true;
+      }
+      cv.notify_all();
+
+      tt::sockets::PrefillResultMessage result(request.task_id);
+      result.finished = true;
+      result.generated_text = "ok";
+      client.sendRawData(serializeMessage("prefill_result", result));
+    }
+  });
+
+  tt::sockets::PrefillRegistrationMessage registration;
+  registration.server_id = "prefill-A";
+  registration.max_in_flight = 4;
+  ASSERT_TRUE(client.sendRawData(
+      serializeMessage(tt::sockets::tags::PREFILL_REGISTRATION, registration)));
+  ASSERT_TRUE(waitFor([&] {
+    std::lock_guard<std::mutex> lock(mutex);
+    return registered;
+  }));
+
+  tt::sockets::PrefillRequestMessage request(7);
+  ASSERT_TRUE(router.sendObject("prefill-A", "prefill_request", request));
+  ASSERT_TRUE(waitFor([&] {
+    std::lock_guard<std::mutex> lock(mutex);
+    return requestReceived && resultReceived;
+  }));
+
+  clientRunning = false;
+  if (clientThread.joinable()) {
+    clientThread.join();
+  }
+  client.stop();
+  router.stop();
 }
 
 }  // namespace

--- a/tt-media-server/prefill_gateway/tests/gateway_e2e_test.cpp
+++ b/tt-media-server/prefill_gateway/tests/gateway_e2e_test.cpp
@@ -26,6 +26,7 @@
 #include "gateway/zmq_prefill_router.hpp"
 #include "sockets/socket_manager.hpp"
 #include "sockets/socket_messages.hpp"
+#include "sockets/socket_serialization.hpp"
 #include "sockets/zmq_socket_transport.hpp"
 
 namespace tt::gateway {
@@ -56,38 +57,6 @@ uint16_t ephemeralPort() {
   uint16_t port = ntohs(addr.sin_port);
   close(s);
   return port;
-}
-
-template <typename T>
-std::vector<uint8_t> serializeMessage(const std::string& messageType,
-                                      const T& message) {
-  std::ostringstream oss;
-  {
-    cereal::BinaryOutputArchive archive(oss);
-    archive(messageType);
-    message.write(archive);
-  }
-  const std::string serialized = oss.str();
-  return {serialized.begin(), serialized.end()};
-}
-
-std::string messageTypeOf(const std::vector<uint8_t>& data) {
-  std::string serialized(data.begin(), data.end());
-  std::istringstream iss(serialized);
-  cereal::BinaryInputArchive archive(iss);
-  std::string messageType;
-  archive(messageType);
-  return messageType;
-}
-
-template <typename T>
-T deserializeMessage(const std::vector<uint8_t>& data) {
-  std::string serialized(data.begin(), data.end());
-  std::istringstream iss(serialized);
-  cereal::BinaryInputArchive archive(iss);
-  std::string messageType;
-  archive(messageType);
-  return T::read(archive);
 }
 
 struct PrefillConnectionState {
@@ -352,8 +321,8 @@ class FakeZmqPrefill {
         tt::sockets::PrefillRegistrationMessage msg;
         msg.server_id = serverId_;
         msg.max_in_flight = maxInFlight_;
-        sm_.sendRawData(
-            serializeMessage(tt::sockets::tags::PREFILL_REGISTRATION, msg));
+        sm_.sendRawData(tt::sockets::wire::serializeMessage(
+            tt::sockets::tags::PREFILL_REGISTRATION, msg));
         std::this_thread::sleep_for(50ms);
       }
     });
@@ -364,17 +333,18 @@ class FakeZmqPrefill {
           std::this_thread::sleep_for(10ms);
           continue;
         }
-        if (messageTypeOf(data) != "prefill_request") {
+        if (tt::sockets::wire::readMessageType(data) != "prefill_request") {
           continue;
         }
 
-        auto request =
-            deserializeMessage<tt::sockets::PrefillRequestMessage>(data);
+        auto request = tt::sockets::wire::deserializePayload<
+            tt::sockets::PrefillRequestMessage>(data);
         receivedTaskIds_.fetch_add(1);
         tt::sockets::PrefillResultMessage result(request.task_id);
         result.finished = true;
         result.generated_text = "ok-from-" + serverId_;
-        sm_.sendRawData(serializeMessage("prefill_result", result));
+        sm_.sendRawData(
+            tt::sockets::wire::serializeMessage("prefill_result", result));
       }
     });
   }
@@ -678,12 +648,12 @@ TEST(ZmqPrefillRouterTest, RoutesRequestToRegisteredPrefill) {
         continue;
       }
 
-      if (messageTypeOf(data) != "prefill_request") {
+      if (tt::sockets::wire::readMessageType(data) != "prefill_request") {
         continue;
       }
 
-      auto request =
-          deserializeMessage<tt::sockets::PrefillRequestMessage>(data);
+      auto request = tt::sockets::wire::deserializePayload<
+          tt::sockets::PrefillRequestMessage>(data);
       EXPECT_EQ(request.task_id, 7u);
       {
         std::lock_guard<std::mutex> lock(mutex);
@@ -694,15 +664,16 @@ TEST(ZmqPrefillRouterTest, RoutesRequestToRegisteredPrefill) {
       tt::sockets::PrefillResultMessage result(request.task_id);
       result.finished = true;
       result.generated_text = "ok";
-      client.sendRawData(serializeMessage("prefill_result", result));
+      client.sendRawData(
+          tt::sockets::wire::serializeMessage("prefill_result", result));
     }
   });
 
   tt::sockets::PrefillRegistrationMessage registration;
   registration.server_id = "prefill-A";
   registration.max_in_flight = 4;
-  ASSERT_TRUE(client.sendRawData(
-      serializeMessage(tt::sockets::tags::PREFILL_REGISTRATION, registration)));
+  ASSERT_TRUE(client.sendRawData(tt::sockets::wire::serializeMessage(
+      tt::sockets::tags::PREFILL_REGISTRATION, registration)));
   ASSERT_TRUE(waitFor([&] {
     std::lock_guard<std::mutex> lock(mutex);
     return registered;


### PR DESCRIPTION
This changes ZMQ gateway mode so the PrefillGateway binds one prefill-side ROUTER socket and all prefill nodes connect to it as ZMQ clients. The gateway now maps PREFILL_SERVER_ID to the ZMQ peer identity from registration messages, while TCP keeps the existing one-socket-per-prefill model.
- Updates gateway mode wiring so TCP keeps the existing gateway-dials-prefill flow, while ZMQ prefills act as clients and periodically register with the gateway ROUTER.
- Adds `ZmqPrefillRouter`, shared socket serialization helpers, and extracted prefill handler wiring to keep `main.cpp`, `SocketManager`, and router serialization logic simpler.
- Adds `--prefill-bind=HOST:PORT` for ZMQ prefill routing and `--prefill-stale-timeout-ms=MS` to configure stale ZMQ registration detection.