### PR TITLE
fix(evals): clamp client max_gen_toks to fit within device_model_spec.max_context

### DIFF
--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -47,6 +47,39 @@ from workflows.workflow_venvs import VENV_CONFIGS
 logger = logging.getLogger(__name__)
 SMOKE_TEST_EVAL_LIMIT = 3
 
+# Per-request budget reserved for the prompt when clamping max_gen_toks against
+# device_model_spec.max_context. A floor prevents pathological clamps on
+# devices with very small max_context.
+_MAX_GEN_TOKS_PROMPT_RESERVE = 1024
+_MIN_OUTPUT_TOKENS = 256
+
+
+def _clamp_max_gen_toks(
+    gen_kwargs: dict, device_max_context: Optional[int], task_name: str
+) -> dict:
+    """Return a copy of gen_kwargs with max_gen_toks clamped to fit within
+    device_max_context after reserving room for the prompt. Returns the
+    original dict (no copy) when there is nothing to clamp."""
+    if not device_max_context or gen_kwargs.get("max_gen_toks") is None:
+        return gen_kwargs
+    try:
+        requested = int(gen_kwargs["max_gen_toks"])
+    except (TypeError, ValueError):
+        return gen_kwargs
+    ceiling = max(_MIN_OUTPUT_TOKENS, device_max_context - _MAX_GEN_TOKS_PROMPT_RESERVE)
+    if requested <= ceiling:
+        return gen_kwargs
+    out = dict(gen_kwargs)
+    out["max_gen_toks"] = ceiling
+    logger.info(
+        f"Clamping {task_name} max_gen_toks: "
+        f"{requested} -> {ceiling} "
+        f"(device_model_spec.max_context={device_max_context}, "
+        f"reserving {_MAX_GEN_TOKS_PROMPT_RESERVE} tokens for the prompt)"
+    )
+    return out
+
+
 # fmt: off
 IMAGE_RESOLUTIONS = [
     (512, 512),
@@ -462,6 +495,18 @@ def build_eval_command(
                 f"(device_model_spec.max_concurrency={device_max_concurrency})"
             )
 
+    # Clamp gen_kwargs.max_gen_toks so prompt + max_tokens fits within the
+    # server's max_context. lm-eval tasks tuned for the model's full context
+    # (e.g. Qwen3 with max_gen_toks=32768 assuming 65K) otherwise over-subscribe
+    # a forge entry in bring-up with a smaller max_context and trigger 100%
+    # server-side rejection (`prompt + max_tokens > max_model_len`).
+    device_max_context = getattr(
+        getattr(model_spec, "device_model_spec", None), "max_context", None
+    )
+    effective_gen_kwargs = _clamp_max_gen_toks(
+        task.gen_kwargs, device_max_context, task.task_name
+    )
+
     optional_model_args = []
     if effective_max_concurrent:
         optional_model_args.append(f"num_concurrent={effective_max_concurrent}")
@@ -496,7 +541,7 @@ def build_eval_command(
     model_kwargs_str = ",".join(model_kwargs_list)
 
     # build gen_kwargs string
-    gen_kwargs_list = [f"{k}={v}" for k, v in task.gen_kwargs.items()]
+    gen_kwargs_list = [f"{k}={v}" for k, v in effective_gen_kwargs.items()]
     gen_kwargs_str = ",".join(gen_kwargs_list)
 
     # set output_dir

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -275,3 +275,56 @@ def test_build_swebench_eval_command_uses_wrapper_and_task_limit(monkeypatch, tm
         cmd[cmd.index("--completion-kwargs-json") + 1]
         == '{"extra_body": {"top_k": 20}}'
     )
+
+
+class TestClampMaxGenToks:
+    """#3533 Problem 6: clamp eval-client max_gen_toks to fit within the
+    server's max_context. Tasks tuned for a model's full context (e.g. Qwen3
+    with max_gen_toks=32768 assuming 65K) otherwise over-subscribe a forge
+    entry with smaller max_context and trigger 100% server-side rejection."""
+
+    def test_clamps_when_max_gen_toks_exceeds_ceiling(self, monkeypatch):
+        run_evals = _import_run_evals(monkeypatch)
+        # max_context=4096 -> ceiling = max(256, 4096 - 1024) = 3072.
+        out = run_evals._clamp_max_gen_toks(
+            {"max_gen_toks": 32768, "stream": "true"}, 4096, "task_x"
+        )
+        assert out["max_gen_toks"] == 3072
+        assert out["stream"] == "true"
+
+    def test_pass_through_when_within_ceiling(self, monkeypatch):
+        run_evals = _import_run_evals(monkeypatch)
+        gen_kwargs = {"max_gen_toks": 256, "stream": "False"}
+        out = run_evals._clamp_max_gen_toks(gen_kwargs, 4096, "task_x")
+        # Returns original dict unchanged (no copy needed).
+        assert out is gen_kwargs
+
+    def test_floor_protects_tiny_max_context(self, monkeypatch):
+        run_evals = _import_run_evals(monkeypatch)
+        # max_context=512 -> 512 - 1024 < 0, floor of 256 kicks in.
+        out = run_evals._clamp_max_gen_toks({"max_gen_toks": 32768}, 512, "task_x")
+        assert out["max_gen_toks"] == 256
+
+    def test_no_clamp_when_max_context_unset(self, monkeypatch):
+        run_evals = _import_run_evals(monkeypatch)
+        gen_kwargs = {"max_gen_toks": 32768}
+        out = run_evals._clamp_max_gen_toks(gen_kwargs, None, "task_x")
+        assert out is gen_kwargs
+
+    def test_no_clamp_when_max_gen_toks_absent(self, monkeypatch):
+        run_evals = _import_run_evals(monkeypatch)
+        gen_kwargs = {"stream": "False"}
+        out = run_evals._clamp_max_gen_toks(gen_kwargs, 4096, "task_x")
+        assert out is gen_kwargs
+
+    def test_non_numeric_max_gen_toks_passes_through(self, monkeypatch):
+        run_evals = _import_run_evals(monkeypatch)
+        gen_kwargs = {"max_gen_toks": "not-a-number"}
+        out = run_evals._clamp_max_gen_toks(gen_kwargs, 4096, "task_x")
+        assert out is gen_kwargs
+
+    def test_string_numeric_max_gen_toks_clamps(self, monkeypatch):
+        run_evals = _import_run_evals(monkeypatch)
+        # lm-eval task defs sometimes serialize max_gen_toks as a string.
+        out = run_evals._clamp_max_gen_toks({"max_gen_toks": "32768"}, 4096, "task_x")
+        assert out["max_gen_toks"] == 3072


### PR DESCRIPTION
### Issue

Addresses **Problem 6** of #3533.

### Problem

`evals/eval_config.py` sets `gen_kwargs={"max_gen_toks": 32768, ...}` for several Qwen3 reasoning tasks (`r1_gpqa_diamond`, `mmlu_pro`, `r1_aime24`, …) — the intended output budget for Qwen3's full 65K-token context window. When those tasks run against a `DeviceModelSpec` entry with a smaller `max_context` (e.g. the forge LLM entries currently in bring-up at `max_context=4096`), every request asks for more output room than the engine can satisfy:

```
WARNING - Rejected prompt: length (175) + max_tokens (32768) exceeds max model length (4096)
INFO:     "POST /v1/completions HTTP/1.1" 400 Bad Request
...
ERROR [_cli.run:482] 3 prompt(s) failed during inference.
RuntimeError: Evaluation completed with 3 failed prompt(s).
```

100% rejection on every request the eval makes. The prompt-length validation (PR for Problem 3 of the same issue) is correctly catching the impossibility upfront — but the eval can't proceed at all.

Surfaced while validating the full forge LLM eval flow end-to-end on quietbox 2 (local multi-model run on Qwen3-4B and Qwen3-8B forge servers with `max_context=4096`).

### What changed

`evals/run_evals.py` — `build_eval_command()` now reads `model_spec.device_model_spec.max_context` and clamps `gen_kwargs["max_gen_toks"]` so that `prompt + max_tokens` has a chance of fitting within the engine's context window.

Logic is factored into a small helper, `_clamp_max_gen_toks(gen_kwargs, device_max_context, task_name)`, that:

- Returns the original `gen_kwargs` (no copy, no log) when there is nothing to clamp — i.e. `device_max_context` is unset, `max_gen_toks` is absent, or the requested value already fits.
- Coerces `max_gen_toks` via `int(...)`, returning the original `gen_kwargs` unchanged on non-numeric values (lm-eval task definitions occasionally pass strings).
- Clamps the requested value to `max(_MIN_OUTPUT_TOKENS, device_max_context - _MAX_GEN_TOKS_PROMPT_RESERVE)` where the reserve is 1024 tokens (room for a typical eval prompt) and the floor is 256 tokens (sanity for very small `max_context` entries).
- Logs a single info-level line when it actually clamps, naming both numbers and the device cap.

Net effect (forge `max_context=4096`):
- Entries with `max_gen_toks <= 3072`: no change.
- Entries with `max_gen_toks > 3072` (e.g. Qwen3 reasoning tasks at 32768): clamped to 3072 so `prompt (~1K) + max_tokens (3072) ≤ 4096`. Eval completes; the engine accepts requests.

ttnn / vllm-tt entries are unaffected — their `max_context` (typically 128K) already comfortably covers any task's `max_gen_toks`.

~50 lines (helper + 2 module-level constants + 7 unit tests + call-site).

### Testing

**Unit tests** (`tests/test_run_evals.py::TestClampMaxGenToks`, 7 cases):

| Case | Input | Expected |
|---|---|---|
| Exceeds ceiling | `max_gen_toks=32768, max_context=4096` | clamped to 3072 |
| Within ceiling | `max_gen_toks=256, max_context=4096` | unchanged (same dict, no copy) |
| Tiny `max_context` | `max_gen_toks=32768, max_context=512` | clamped to floor `256` |
| `max_context` unset | `max_gen_toks=32768, max_context=None` | unchanged |
| `max_gen_toks` absent | `{"stream": "False"}, max_context=4096` | unchanged |
| Non-numeric `max_gen_toks` | `{"max_gen_toks": "not-a-number"}` | unchanged |
| String-form numeric | `{"max_gen_toks": "32768"}` | clamped to 3072 |

All pass via `pytest tests/test_run_evals.py -v`.

**Live end-to-end** on Qwen3-4B (dev 1 / port 8101) and Qwen3-8B (dev 2 / port 8102) forge LLM containers, `max_num_seqs=2`, `max_context=4096`, P150 host:

| Model | Before fix | After fix |
|---|---|---|
| Qwen3-4B | 30 s — all 3 prompts × 2 retries rejected upfront with `RuntimeError: Evaluation completed with 3 failed prompt(s)` | **5 m 49 s — `Completed run.py`, Acceptance criteria `PASS`, 0 of-32768 rejects** |
| Qwen3-8B | 33 s — same failure shape | **6 m 25 s — `Completed run.py`, 0 of-32768 rejects** |

The remaining score of 0% on the smoke runs of these specific tasks is a separate consideration: `r1_gpqa_diamond` is a reasoning task where the model needs to emit its full chain-of-thought before reaching a parseable answer; with 3072 tokens of headroom the chain truncates before the answer extractor matches. That's a task-vs-device-context-window mismatch, not a fix gap — the clamp is doing exactly what it should, the device just doesn't have the room these reasoning tasks were tuned for. Other tasks with shorter expected outputs (e.g. `ifeval`, `meta_gpqa`, `meta_math` on Llama models) continue to score normally.

### Scope

Eval-client clamp only. No behavior change for any (model, device) pair where `max_gen_toks` already fits within `device_max_context - 1024`. Mirrors the shape of the concurrency-clamp PR (same file, same `getattr(getattr(model_spec, "device_model_spec", None), <attr>, None)` pattern) but is independent — neither PR depends on the other landing first.

### Related PRs (same issue, #3533)

- **Problem 1** (orphan-task cancel) — `kmabee/forge_orphan_task_cancel_issue_3533`.
- **Problem 2** (concurrency clamp) — `kmabee/evals_concurrency_clamp_issue_3533`.
- **Problem 3** (prompt + max_tokens validation) — `kmabee/forge_prompt_length_validation_issue_3533`.
- **Problem 4** (fan-out `_task_id` collision) — `kmabee/forge_batched_prompts_task_id_collision_issue_3533`.
- **Problem 5** (eval_config port-8000 cleanup) — `kmabee/evals_remove_hardcoded_base_url`.
- **Problem 6 — this PR** — `kmabee/evals_clamp_max_gen_toks_issue_3533`.

### Files changed

- `evals/run_evals.py` — `_clamp_max_gen_toks` helper + 2 constants + call from `build_eval_command()`.
- `tests/test_run_evals.py` — `TestClampMaxGenToks` covering 7 cases.
