### PR TITLE
Fix(workflows): auto-install vllm-tt-plugin for --local-server

### DIFF
--- a/tests/test_run_local_server.py
+++ b/tests/test_run_local_server.py
@@ -159,9 +159,13 @@ class TestRunLocalServer:
         vllm_dir = tmp_path / "vllm"
         plugin_dir = vllm_tt_plugin_source_path(vllm_dir)
         plugin_dir.mkdir(parents=True)
-        (plugin_dir / "pyproject.toml").write_text("[project]\nname = 'vllm-tt-plugin'\n")
+        (plugin_dir / "pyproject.toml").write_text(
+            "[project]\nname = 'vllm-tt-plugin'\n"
+        )
 
-        runtime_config = self._make_runtime_config(tt_metal_home, vllm_dir=str(vllm_dir))
+        runtime_config = self._make_runtime_config(
+            tt_metal_home, vllm_dir=str(vllm_dir)
+        )
 
         with patch("workflows.run_local_server.run_command") as run_command_mock, patch(
             "workflows.run_local_server.UV_EXEC", Path("/tmp/uv")
@@ -188,7 +192,9 @@ class TestRunLocalServer:
 
         vllm_dir = tmp_path / "vllm"
         vllm_dir.mkdir()
-        runtime_config = self._make_runtime_config(tt_metal_home, vllm_dir=str(vllm_dir))
+        runtime_config = self._make_runtime_config(
+            tt_metal_home, vllm_dir=str(vllm_dir)
+        )
 
         with patch("workflows.run_local_server.run_command") as run_command_mock:
             result = install_vllm_tt_plugin_if_present(
@@ -213,9 +219,13 @@ class TestRunLocalServer:
         vllm_dir = tmp_path / "vllm"
         plugin_dir = vllm_tt_plugin_source_path(vllm_dir)
         plugin_dir.mkdir(parents=True)
-        (plugin_dir / "pyproject.toml").write_text("[project]\nname = 'vllm-tt-plugin'\n")
+        (plugin_dir / "pyproject.toml").write_text(
+            "[project]\nname = 'vllm-tt-plugin'\n"
+        )
 
-        runtime_config = self._make_runtime_config(tt_metal_home, vllm_dir=str(vllm_dir))
+        runtime_config = self._make_runtime_config(
+            tt_metal_home, vllm_dir=str(vllm_dir)
+        )
 
         with patch("workflows.run_local_server.run_command") as run_command_mock, patch(
             "workflows.run_local_server.UV_EXEC", Path("/tmp/uv")

--- a/tests/test_run_local_server.py
+++ b/tests/test_run_local_server.py
@@ -15,8 +15,10 @@ from workflows.run_local_server import (
     build_local_server_env,
     generate_local_run_command,
     install_local_server_requirements,
+    install_vllm_tt_plugin_if_present,
     run_local_command,
     run_local_server,
+    vllm_tt_plugin_source_path,
 )
 from workflows.runtime_config import RuntimeConfig
 
@@ -121,6 +123,8 @@ class TestRunLocalServer:
         python_bin_dir.mkdir(parents=True)
         (python_bin_dir / "python").write_text("")
 
+        # No vllm checkout exists, so the follow-up plugin install must skip
+        # without invoking run_command for that step.
         runtime_config = self._make_runtime_config(tt_metal_home)
 
         with patch("workflows.run_local_server.run_command") as run_command_mock, patch(
@@ -128,10 +132,110 @@ class TestRunLocalServer:
         ):
             install_local_server_requirements(runtime_config, repo_root=repo_root)
 
-        install_command = run_command_mock.call_args.args[0]
+        # The first call must be the requirements.txt install. The plugin
+        # helper is invoked unconditionally but no-ops (no command) when the
+        # plugin source dir is absent, so this remains a single run_command call.
+        assert run_command_mock.call_count == 1
+        install_command = run_command_mock.call_args_list[0].args[0]
         assert str(Path("/tmp/uv")) in install_command
         assert str(python_bin_dir / "python") in install_command
         assert str(requirements_path) in install_command
+        assert run_command_mock.call_args_list[0].kwargs["check"] is True
+
+    def test_install_local_server_requirements_also_installs_plugin_when_present(
+        self, tmp_path
+    ):
+        repo_root = tmp_path / "repo"
+        requirements_path = repo_root / "vllm-tt-metal" / "requirements.txt"
+        requirements_path.parent.mkdir(parents=True)
+        requirements_path.write_text("requests==2.32.3\n")
+
+        tt_metal_home = tmp_path / "tt-metal"
+        python_bin_dir = tt_metal_home / "python_env" / "bin"
+        python_bin_dir.mkdir(parents=True)
+        (python_bin_dir / "python").write_text("")
+
+        # Stage a vllm checkout that ships the plugin source.
+        vllm_dir = tmp_path / "vllm"
+        plugin_dir = vllm_tt_plugin_source_path(vllm_dir)
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "pyproject.toml").write_text("[project]\nname = 'vllm-tt-plugin'\n")
+
+        runtime_config = self._make_runtime_config(tt_metal_home, vllm_dir=str(vllm_dir))
+
+        with patch("workflows.run_local_server.run_command") as run_command_mock, patch(
+            "workflows.run_local_server.UV_EXEC", Path("/tmp/uv")
+        ):
+            install_local_server_requirements(runtime_config, repo_root=repo_root)
+
+        # Two calls: requirements.txt then plugin editable install.
+        assert run_command_mock.call_count == 2
+        plugin_command = run_command_mock.call_args_list[1].args[0]
+        assert "pip install" in plugin_command
+        assert "--no-deps" in plugin_command
+        assert " -e " in plugin_command
+        assert str(plugin_dir) in plugin_command
+        assert run_command_mock.call_args_list[1].kwargs["check"] is True
+
+    def test_install_vllm_tt_plugin_if_present_skips_when_dir_missing(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        (repo_root / "vllm-tt-metal").mkdir(parents=True)
+
+        tt_metal_home = tmp_path / "tt-metal"
+        python_bin_dir = tt_metal_home / "python_env" / "bin"
+        python_bin_dir.mkdir(parents=True)
+        (python_bin_dir / "python").write_text("")
+
+        vllm_dir = tmp_path / "vllm"
+        vllm_dir.mkdir()
+        runtime_config = self._make_runtime_config(tt_metal_home, vllm_dir=str(vllm_dir))
+
+        with patch("workflows.run_local_server.run_command") as run_command_mock:
+            result = install_vllm_tt_plugin_if_present(
+                runtime_config, repo_root=repo_root
+            )
+
+        assert result is False
+        run_command_mock.assert_not_called()
+
+    def test_install_vllm_tt_plugin_if_present_invokes_uv_pip_when_dir_exists(
+        self, tmp_path
+    ):
+        repo_root = tmp_path / "repo"
+        (repo_root / "vllm-tt-metal").mkdir(parents=True)
+
+        tt_metal_home = tmp_path / "tt-metal"
+        python_bin_dir = tt_metal_home / "python_env" / "bin"
+        python_bin_dir.mkdir(parents=True)
+        venv_python = python_bin_dir / "python"
+        venv_python.write_text("")
+
+        vllm_dir = tmp_path / "vllm"
+        plugin_dir = vllm_tt_plugin_source_path(vllm_dir)
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "pyproject.toml").write_text("[project]\nname = 'vllm-tt-plugin'\n")
+
+        runtime_config = self._make_runtime_config(tt_metal_home, vllm_dir=str(vllm_dir))
+
+        with patch("workflows.run_local_server.run_command") as run_command_mock, patch(
+            "workflows.run_local_server.UV_EXEC", Path("/tmp/uv")
+        ):
+            result = install_vllm_tt_plugin_if_present(
+                runtime_config, repo_root=repo_root
+            )
+
+        assert result is True
+        run_command_mock.assert_called_once()
+        install_command = run_command_mock.call_args.args[0]
+        assert str(Path("/tmp/uv")) in install_command
+        assert "pip install" in install_command
+        assert f"--python {venv_python}" in install_command
+        assert "--no-deps" in install_command
+        assert " -e " in install_command
+        # The plugin source path appears as an absolute path ending with the
+        # canonical plugins/vllm-tt-plugin suffix.
+        assert str(plugin_dir) in install_command
+        assert "plugins/vllm-tt-plugin" in install_command
         assert run_command_mock.call_args.kwargs["check"] is True
 
     def test_build_local_server_env_sets_expected_overrides(self, tmp_path):

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -10,6 +10,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+from workflows.run_local_server import vllm_tt_plugin_source_path
 from workflows.runtime_config import RuntimeConfig
 from workflows.utils import check_path_permissions_for_uid
 from workflows.validate_setup import (
@@ -503,12 +504,15 @@ class TestLocalServerValidation:
 
         mock_get_log_dir.return_value = tmp_path / "logs"
 
+        # No vllm checkout, so plugin install + check are skipped and the only
+        # run_command call is the existing `import vllm` probe.
         validate_local_setup(model_spec, runtime_config, tmp_path / "runtime.json")
 
         mock_ensure_dir.assert_called_once_with(tmp_path / "logs")
-        mock_run_command.assert_called_once_with(
+        mock_run_command.assert_any_call(
             [str(venv_python), "-c", "import vllm"], logger=ANY
         )
+        assert mock_run_command.call_count == 1
 
     @patch("workflows.validate_setup.run_command", return_value=1)
     @patch("workflows.validate_setup.ensure_readwriteable_dir")
@@ -537,6 +541,119 @@ class TestLocalServerValidation:
 
         mock_ensure_dir.assert_called_once_with(tmp_path / "logs")
         mock_run_command.assert_called_once()
+
+    @patch("workflows.run_local_server.run_command", return_value=0)
+    @patch("workflows.validate_setup.run_command", return_value=0)
+    @patch("workflows.validate_setup.ensure_readwriteable_dir")
+    @patch("workflows.validate_setup.get_default_workflow_root_log_dir")
+    def test_validate_local_setup_installs_and_verifies_tt_plugin_when_present(
+        self,
+        mock_get_log_dir,
+        mock_ensure_dir,
+        mock_validate_run_command,
+        mock_runlocal_run_command,
+        tmp_path,
+    ):
+        """When the vLLM checkout ships plugins/vllm-tt-plugin, local-server
+        validation must (a) editable-install the plugin via run_local_server's
+        install helper and (b) probe that the `tt` entry-point is registered.
+        """
+        tt_metal_home = tmp_path / "tt-metal"
+        python_bin_dir = tt_metal_home / "python_env" / "bin"
+        python_bin_dir.mkdir(parents=True)
+        venv_python = python_bin_dir / "python"
+        venv_python.write_text("")
+
+        # Stage the plugin source so the validator detects it.
+        vllm_dir = tmp_path / "vllm"
+        plugin_dir = vllm_tt_plugin_source_path(vllm_dir)
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "pyproject.toml").write_text(
+            "[project]\nname = 'vllm-tt-plugin'\n"
+        )
+
+        model_spec = self._make_model_spec()
+        runtime_config = self._make_runtime_config()
+        runtime_config.tt_metal_home = str(tt_metal_home)
+        runtime_config.vllm_dir = str(vllm_dir)
+        runtime_config.skip_system_sw_validation = True
+
+        mock_get_log_dir.return_value = tmp_path / "logs"
+
+        validate_local_setup(model_spec, runtime_config, tmp_path / "runtime.json")
+
+        # The plugin install happens through workflows.run_local_server.run_command
+        # because install_vllm_tt_plugin_if_present is defined in that module.
+        mock_runlocal_run_command.assert_called_once()
+        plugin_install_cmd = mock_runlocal_run_command.call_args.args[0]
+        assert "pip install" in plugin_install_cmd
+        assert "--no-deps" in plugin_install_cmd
+        assert "plugins/vllm-tt-plugin" in plugin_install_cmd
+        assert mock_runlocal_run_command.call_args.kwargs["check"] is True
+
+        # The validator side does two calls: `import vllm` and the entry-point check.
+        validate_calls = mock_validate_run_command.call_args_list
+        assert len(validate_calls) == 2
+        assert validate_calls[0].args[0] == [str(venv_python), "-c", "import vllm"]
+        entry_point_cmd = validate_calls[1].args[0]
+        assert entry_point_cmd[0] == str(venv_python)
+        assert entry_point_cmd[1] == "-c"
+        script = entry_point_cmd[2]
+        assert "import vllm_tt_plugin" in script
+        assert "vllm.platform_plugins" in script
+        assert "'tt' in eps" in script
+
+    @patch("workflows.run_local_server.run_command", return_value=0)
+    @patch("workflows.validate_setup.ensure_readwriteable_dir")
+    @patch("workflows.validate_setup.get_default_workflow_root_log_dir")
+    def test_validate_local_setup_raises_when_tt_plugin_entry_point_missing(
+        self,
+        mock_get_log_dir,
+        mock_ensure_dir,
+        mock_runlocal_run_command,
+        tmp_path,
+    ):
+        """If the plugin install succeeds but the entry-point check fails
+        (e.g. wheel staleness, missing pip --editable refresh), validation
+        must raise an actionable error rather than letting `vllm serve`
+        crash later.
+        """
+        tt_metal_home = tmp_path / "tt-metal"
+        python_bin_dir = tt_metal_home / "python_env" / "bin"
+        python_bin_dir.mkdir(parents=True)
+        (python_bin_dir / "python").write_text("")
+
+        vllm_dir = tmp_path / "vllm"
+        plugin_dir = vllm_tt_plugin_source_path(vllm_dir)
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "pyproject.toml").write_text(
+            "[project]\nname = 'vllm-tt-plugin'\n"
+        )
+
+        model_spec = self._make_model_spec()
+        runtime_config = self._make_runtime_config()
+        runtime_config.tt_metal_home = str(tt_metal_home)
+        runtime_config.vllm_dir = str(vllm_dir)
+        runtime_config.skip_system_sw_validation = True
+
+        mock_get_log_dir.return_value = tmp_path / "logs"
+
+        # `import vllm` (call 1) succeeds with rc=0; the plugin entry-point
+        # probe (call 2) fails with rc=1.
+        with patch(
+            "workflows.validate_setup.run_command", side_effect=[0, 1]
+        ) as mock_validate_run_command:
+            with pytest.raises(
+                ValueError,
+                match=r"`vllm_tt_plugin` Python package",
+            ):
+                validate_local_setup(
+                    model_spec, runtime_config, tmp_path / "runtime.json"
+                )
+
+            assert mock_validate_run_command.call_count == 2
+
+        mock_runlocal_run_command.assert_called_once()
 
 
 class TestCheckImageVersionSupported:

--- a/workflows/run_local_server.py
+++ b/workflows/run_local_server.py
@@ -240,6 +240,51 @@ def generate_local_run_command(
     return command, env, process_name
 
 
+def vllm_tt_plugin_source_path(vllm_dir: Path) -> Path:
+    """Return the on-disk location of the vllm-tt-plugin source tree inside a vLLM checkout.
+
+    The plugin package was introduced by tenstorrent/vllm commit a072e40a6
+    ("Extract TT backend into plugin package (Phase 1)", 2026-05-04). Older
+    vLLM checkouts do not contain this directory and continue to ship the TT
+    platform inside vllm core.
+    """
+    return Path(vllm_dir) / "plugins" / "vllm-tt-plugin"
+
+
+def install_vllm_tt_plugin_if_present(runtime_config, repo_root=None) -> bool:
+    """Editable-install the vllm-tt-plugin package into the tt-metal venv if it
+    exists in the user's vLLM checkout.
+
+    Mirrors the conditional install added to
+    vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile by PR #3370. The plugin owns
+    the ``tt`` entry in ``vllm.platform_plugins`` since tenstorrent/vllm
+    commit a072e40a6 ("Extract TT backend into plugin package (Phase 1)").
+
+    Returns True when the plugin source was found and an install command was
+    invoked, False when the plugin directory does not exist (older vLLM
+    checkouts that still bundle the TT platform inside vllm core).
+    """
+    paths = get_local_server_paths(runtime_config, repo_root=repo_root)
+    vllm_dir = paths["vllm_dir"]
+    plugin_path = vllm_tt_plugin_source_path(vllm_dir)
+    if not (plugin_path / "pyproject.toml").exists():
+        logger.info(
+            f"Skipping vllm-tt-plugin install: source not present at {plugin_path}"
+        )
+        return False
+
+    install_command = (
+        f"{shlex.quote(str(UV_EXEC))} pip install "
+        f"--python {shlex.quote(str(paths['venv_python']))} "
+        f"--no-deps -e {shlex.quote(str(plugin_path))}"
+    )
+    logger.info(
+        f"Installing vllm-tt-plugin into tt-metal venv from: {plugin_path}"
+    )
+    run_command(install_command, logger=logger, check=True)
+    return True
+
+
 def install_local_server_requirements(runtime_config, repo_root=None):
     paths = get_local_server_paths(runtime_config, repo_root=repo_root)
     requirements_path = paths["requirements_path"]
@@ -257,6 +302,8 @@ def install_local_server_requirements(runtime_config, repo_root=None):
         f"Installing local server requirements into tt-metal venv from: {requirements_path}"
     )
     run_command(install_command, logger=logger, check=True)
+
+    install_vllm_tt_plugin_if_present(runtime_config, repo_root=repo_root)
 
 
 def _terminate_process_group(process: subprocess.Popen, process_name: str):

--- a/workflows/run_local_server.py
+++ b/workflows/run_local_server.py
@@ -278,9 +278,7 @@ def install_vllm_tt_plugin_if_present(runtime_config, repo_root=None) -> bool:
         f"--python {shlex.quote(str(paths['venv_python']))} "
         f"--no-deps -e {shlex.quote(str(plugin_path))}"
     )
-    logger.info(
-        f"Installing vllm-tt-plugin into tt-metal venv from: {plugin_path}"
-    )
+    logger.info(f"Installing vllm-tt-plugin into tt-metal venv from: {plugin_path}")
     run_command(install_command, logger=logger, check=True)
     return True
 

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -241,9 +241,7 @@ def _validate_local_vllm_tt_plugin(runtime_config, venv_python: Path):
         "assert 'tt' in eps, "
         "f'tt platform plugin not registered in vllm.platform_plugins entry points, got: {eps}'"
     )
-    return_code = run_command(
-        [str(venv_python), "-c", check_script], logger=logger
-    )
+    return_code = run_command([str(venv_python), "-c", check_script], logger=logger)
     if return_code != 0:
         raise ValueError(
             "⛔ --local-server with inference engine vLLM requires the "

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -192,6 +192,85 @@ def _validate_local_vllm_installation(runtime_config):
         )
     logger.info(f"✅ validated vLLM Python package import with: {venv_python}")
 
+    _validate_local_vllm_tt_plugin(runtime_config, venv_python)
+
+
+def _validate_local_vllm_tt_plugin(runtime_config, venv_python: Path):
+    """Ensure the vllm-tt-plugin package is installed and registered when the
+    user's vLLM checkout requires it.
+
+    Since tenstorrent/vllm commit a072e40a6 (2026-05-04, "Extract TT backend
+    into plugin package (Phase 1)") the TT platform lives in a separate
+    editable package at ``$VLLM_DIR/plugins/vllm-tt-plugin``. Without that
+    package installed, ``vllm/platforms/tt.py`` raises
+    ``ModuleNotFoundError: No module named 'vllm_tt_plugin'`` when
+    ``vllm serve`` starts up.
+
+    When the plugin source directory exists in the vLLM checkout this helper
+    will:
+
+    1. Editable-install it into the tt-metal venv (idempotent, mirrors the
+       dev Dockerfile behaviour added by tt-inference-server PR #3370).
+    2. Run a strict in-process check that ``import vllm_tt_plugin`` works AND
+       that the ``tt`` entry is registered under the ``vllm.platform_plugins``
+       entry-point group.
+
+    When the plugin source is absent (older vLLM checkouts that still ship
+    TT support inside vllm core) both steps are skipped.
+    """
+    # Local import to avoid a module-level circular dependency:
+    # workflows.run_local_server -> workflows.setup_host -> workflows.validate_setup
+    from workflows.run_local_server import (  # noqa: PLC0415
+        install_vllm_tt_plugin_if_present,
+        vllm_tt_plugin_source_path,
+    )
+
+    plugin_path = vllm_tt_plugin_source_path(_get_local_vllm_dir(runtime_config))
+    if not (plugin_path / "pyproject.toml").exists():
+        logger.info(
+            f"Skipping vllm-tt-plugin validation: source not present at {plugin_path}"
+        )
+        return
+
+    install_vllm_tt_plugin_if_present(runtime_config)
+
+    check_script = (
+        "import vllm_tt_plugin; "
+        "from importlib.metadata import entry_points; "
+        "eps = {ep.name for ep in entry_points(group='vllm.platform_plugins')}; "
+        "assert 'tt' in eps, "
+        "f'tt platform plugin not registered in vllm.platform_plugins entry points, got: {eps}'"
+    )
+    return_code = run_command(
+        [str(venv_python), "-c", check_script], logger=logger
+    )
+    if return_code != 0:
+        raise ValueError(
+            "⛔ --local-server with inference engine vLLM requires the "
+            "`vllm_tt_plugin` Python package (the TT platform plugin) "
+            "to be installed in the tt-metal python environment and to register "
+            "the `tt` entry under the `vllm.platform_plugins` entry-point group.\n"
+            f"Plugin source detected at: {plugin_path}\n"
+            "Auto-install via this validator failed or the entry point did not "
+            "register. Re-install the plugin by running the canonical script "
+            f"from the vLLM repo: `cd {_get_local_vllm_dir(runtime_config)} && "
+            "bash tt_metal/install-vllm-tt.sh`\n"
+            "See vllm-tt-metal/README.md for the full local installation steps."
+        )
+    logger.info(
+        f"✅ validated vllm-tt-plugin install and `tt` platform_plugins entry "
+        f"point registration with: {venv_python}"
+    )
+
+
+def _get_local_vllm_dir(runtime_config) -> Path:
+    """Resolve $VLLM_DIR the same way workflows.run_local_server does."""
+    tt_metal_home = Path(runtime_config.tt_metal_home).expanduser().resolve()
+    vllm_dir = getattr(runtime_config, "vllm_dir", None)
+    if vllm_dir:
+        return Path(vllm_dir).expanduser().resolve()
+    return (tt_metal_home / "vllm").resolve()
+
 
 def validate_local_setup(model_spec, runtime_config, json_fpath):
     logger.info("Starting local setup validation")


### PR DESCRIPTION
Fixes [--local-server fails with ModuleNotFoundError: No module named 'vllm_tt_plugin' on recent tenstorrent/vllm checkouts](https://github.com/tenstorrent/tt-inference-server/issues/3655)

## Summary

Bring the `--local-server` flow to parity with the dev Dockerfile so it works with `tenstorrent/vllm` checkouts that ship the TT backend as the standalone `vllm_tt_plugin` package (>= commit `a072e40a6`).

- `workflows/run_local_server.py`: when `$VLLM_DIR/plugins/vllm-tt-plugin/pyproject.toml` exists, editable-install the plugin into the `tt-metal` venv (`uv pip install --no-deps -e plugins/vllm-tt-plugin`) right after the existing `requirements.txt` install. Skips silently on older checkouts that still bundle the TT platform in vllm core.
- `workflows/validate_setup.py`: after `import vllm` succeeds, run the same auto-install and then assert that `import vllm_tt_plugin` works **and** that the `tt` platform entry point is registered under `vllm.platform_plugins`. Failure raises an actionable error pointing at `tt_metal/install-vllm-tt.sh`.

## Test plan

- [x] `pytest tests/test_run_local_server.py tests/test_validate_setup.py tests/test_setup_host.py tests/test_run_arguments.py` — 156 passed.
- New unit tests cover:
  - skip-when-plugin-source-absent,
  - install-when-plugin-source-present,
  - validator success path (plugin imports + `tt` entry point registered),
  - validator failure path (raises with install instructions when the entry point is missing).
- [x] Manual: `--local-server` with `gemma-3-27b-it` on P300x2 starts past the previous `ModuleNotFoundError`.
- [ ] Manual: `--local-server` with an older `tenstorrent/vllm` checkout (pre-`a072e40a6`) still works (auto-install no-ops, validator passes).
- [x] CI: `--docker-server` flows unchanged.