### PR TITLE
Improve ZMQ gateway send and liveness handling

### DIFF
--- a/tt-media-server/cpp_server/include/sockets/zmq_socket_options.hpp
+++ b/tt-media-server/cpp_server/include/sockets/zmq_socket_options.hpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#pragma once
+
+#include <zmq.hpp>
+
+namespace tt::sockets::zmq_options {
+
+constexpr int RECEIVE_TIMEOUT_MS = 100;
+constexpr int HEARTBEAT_INTERVAL_MS = 1000;
+constexpr int HEARTBEAT_TIMEOUT_MS = 3000;
+constexpr int HEARTBEAT_TTL_MS = 3000;
+
+inline void applyCommonOptions(zmq::socket_t& socket) {
+  socket.set(zmq::sockopt::linger, 0);
+  socket.set(zmq::sockopt::rcvtimeo, RECEIVE_TIMEOUT_MS);
+  socket.set(zmq::sockopt::heartbeat_ivl, HEARTBEAT_INTERVAL_MS);
+  socket.set(zmq::sockopt::heartbeat_timeout, HEARTBEAT_TIMEOUT_MS);
+  socket.set(zmq::sockopt::heartbeat_ttl, HEARTBEAT_TTL_MS);
+}
+
+inline void applyRouterOptions(zmq::socket_t& socket) {
+  applyCommonOptions(socket);
+  socket.set(zmq::sockopt::router_mandatory, 1);
+}
+
+}  // namespace tt::sockets::zmq_options

--- a/tt-media-server/cpp_server/include/sockets/zmq_socket_options.hpp
+++ b/tt-media-server/cpp_server/include/sockets/zmq_socket_options.hpp
@@ -7,21 +7,24 @@
 
 namespace tt::sockets::zmq_options {
 
+constexpr int CONTEXT_IO_THREADS = 1;
 constexpr int RECEIVE_TIMEOUT_MS = 100;
 constexpr int HEARTBEAT_INTERVAL_MS = 1000;
 constexpr int HEARTBEAT_TIMEOUT_MS = 3000;
 constexpr int HEARTBEAT_TTL_MS = 3000;
 
-inline void applyCommonOptions(zmq::socket_t& socket) {
+inline void applyCommonOptions(zmq::socket_t& socket,
+                               int receiveTimeoutMs = RECEIVE_TIMEOUT_MS) {
   socket.set(zmq::sockopt::linger, 0);
-  socket.set(zmq::sockopt::rcvtimeo, RECEIVE_TIMEOUT_MS);
+  socket.set(zmq::sockopt::rcvtimeo, receiveTimeoutMs);
   socket.set(zmq::sockopt::heartbeat_ivl, HEARTBEAT_INTERVAL_MS);
   socket.set(zmq::sockopt::heartbeat_timeout, HEARTBEAT_TIMEOUT_MS);
   socket.set(zmq::sockopt::heartbeat_ttl, HEARTBEAT_TTL_MS);
 }
 
-inline void applyRouterOptions(zmq::socket_t& socket) {
-  applyCommonOptions(socket);
+inline void applyRouterOptions(zmq::socket_t& socket,
+                               int receiveTimeoutMs = RECEIVE_TIMEOUT_MS) {
+  applyCommonOptions(socket, receiveTimeoutMs);
   socket.set(zmq::sockopt::router_mandatory, 1);
 }
 

--- a/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
+++ b/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
@@ -10,13 +10,13 @@
 #include <utility>
 #include <zmq.hpp>
 
+#include "sockets/zmq_socket_options.hpp"
 #include "utils/logger.hpp"
 
 namespace tt::sockets {
 
 namespace {
 constexpr int ZMQ_CONTEXT_IO_THREADS = 1;
-constexpr int ZMQ_RECEIVE_TIMEOUT_MS = 100;
 constexpr int ZMQ_MONITOR_TIMEOUT_MS = 200;
 constexpr auto IO_IDLE_WAIT = std::chrono::milliseconds(1);
 
@@ -91,8 +91,7 @@ bool ZmqSocketTransport::initializeSocket() {
     socket_ = std::make_unique<zmq::socket_t>(
         *context_, mode_ == Mode::SERVER ? zmq::socket_type::router
                                          : zmq::socket_type::dealer);
-    socket_->set(zmq::sockopt::linger, 0);
-    socket_->set(zmq::sockopt::rcvtimeo, ZMQ_RECEIVE_TIMEOUT_MS);
+    zmq_options::applyCommonOptions(*socket_);
     if (mode_ == Mode::CLIENT) {
       socket_->set(zmq::sockopt::reconnect_ivl,
                    static_cast<int>(reconnectInitialDelayMs_));

--- a/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
+++ b/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
@@ -16,7 +16,6 @@
 namespace tt::sockets {
 
 namespace {
-constexpr int ZMQ_CONTEXT_IO_THREADS = 1;
 constexpr int ZMQ_MONITOR_TIMEOUT_MS = 200;
 constexpr auto IO_IDLE_WAIT = std::chrono::milliseconds(1);
 
@@ -29,7 +28,8 @@ std::string makeMonitorEndpoint(const void* self) {
 ZmqSocketTransport::ZmqSocketTransport()
     : SocketTransportState(/*reconnectInitialDelayMs=*/1000,
                            /*reconnectMaxDelayMs=*/5000),
-      context_(std::make_unique<zmq::context_t>(ZMQ_CONTEXT_IO_THREADS)) {}
+      context_(
+          std::make_unique<zmq::context_t>(zmq_options::CONTEXT_IO_THREADS)) {}
 
 ZmqSocketTransport::~ZmqSocketTransport() { stop(); }
 

--- a/tt-media-server/prefill_gateway/src/zmq_prefill_router.cpp
+++ b/tt-media-server/prefill_gateway/src/zmq_prefill_router.cpp
@@ -11,7 +11,6 @@
 namespace tt::gateway {
 namespace {
 
-constexpr int ZMQ_CONTEXT_IO_THREADS = 1;
 constexpr int ZMQ_RECEIVE_TIMEOUT_MS = 50;
 constexpr auto IO_IDLE_WAIT = std::chrono::milliseconds(1);
 
@@ -24,7 +23,7 @@ std::vector<uint8_t> toBytes(const zmq::message_t& message) {
 
 class ZmqPrefillRouter::Impl {
  public:
-  Impl() : context(ZMQ_CONTEXT_IO_THREADS) {}
+  Impl() : context(tt::sockets::zmq_options::CONTEXT_IO_THREADS) {}
 
   zmq::context_t context;
   std::unique_ptr<zmq::socket_t> socket;
@@ -168,8 +167,8 @@ bool ZmqPrefillRouter::initializeSocket() {
   try {
     impl_->socket = std::make_unique<zmq::socket_t>(impl_->context,
                                                     zmq::socket_type::router);
-    tt::sockets::zmq_options::applyRouterOptions(*impl_->socket);
-    impl_->socket->set(zmq::sockopt::rcvtimeo, ZMQ_RECEIVE_TIMEOUT_MS);
+    tt::sockets::zmq_options::applyRouterOptions(*impl_->socket,
+                                                 ZMQ_RECEIVE_TIMEOUT_MS);
     impl_->socket->bind(endpoint_);
     TT_LOG_INFO("[ZmqPrefillRouter] Bound prefill ROUTER to {}", endpoint_);
     return true;

--- a/tt-media-server/prefill_gateway/src/zmq_prefill_router.cpp
+++ b/tt-media-server/prefill_gateway/src/zmq_prefill_router.cpp
@@ -5,6 +5,7 @@
 
 #include <zmq.hpp>
 
+#include "sockets/zmq_socket_options.hpp"
 #include "utils/logger.hpp"
 
 namespace tt::gateway {
@@ -167,7 +168,7 @@ bool ZmqPrefillRouter::initializeSocket() {
   try {
     impl_->socket = std::make_unique<zmq::socket_t>(impl_->context,
                                                     zmq::socket_type::router);
-    impl_->socket->set(zmq::sockopt::linger, 0);
+    tt::sockets::zmq_options::applyRouterOptions(*impl_->socket);
     impl_->socket->set(zmq::sockopt::rcvtimeo, ZMQ_RECEIVE_TIMEOUT_MS);
     impl_->socket->bind(endpoint_);
     TT_LOG_INFO("[ZmqPrefillRouter] Bound prefill ROUTER to {}", endpoint_);
@@ -197,10 +198,11 @@ bool ZmqPrefillRouter::processPendingSends() {
     bool ok = false;
     try {
       zmq::message_t idFrame(request->peerKey.data(), request->peerKey.size());
-      impl_->socket->send(idFrame, zmq::send_flags::sndmore);
+      auto idResult = impl_->socket->send(idFrame, zmq::send_flags::sndmore);
 
       zmq::message_t msg(request->data.data(), request->data.size());
-      ok = impl_->socket->send(msg, zmq::send_flags::dontwait).has_value();
+      auto msgResult = impl_->socket->send(msg, zmq::send_flags::dontwait);
+      ok = idResult.has_value() && msgResult.has_value();
     } catch (const zmq::error_t& e) {
       TT_LOG_ERROR("[ZmqPrefillRouter] Send failed: {}", e.what());
     }

--- a/tt-media-server/prefill_gateway/tests/gateway_e2e_test.cpp
+++ b/tt-media-server/prefill_gateway/tests/gateway_e2e_test.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <zmq.hpp>
 
 #include "gateway/affinity_cache.hpp"
 #include "gateway/dispatcher.hpp"
@@ -27,6 +28,7 @@
 #include "sockets/socket_manager.hpp"
 #include "sockets/socket_messages.hpp"
 #include "sockets/socket_serialization.hpp"
+#include "sockets/zmq_socket_options.hpp"
 #include "sockets/zmq_socket_transport.hpp"
 
 namespace tt::gateway {
@@ -691,6 +693,75 @@ TEST(ZmqPrefillRouterTest, RoutesRequestToRegisteredPrefill) {
     clientThread.join();
   }
   client.stop();
+  router.stop();
+}
+
+TEST(ZmqSocketOptionsTest, AppliesHeartbeatsAndMandatoryRouterSends) {
+  zmq::context_t context(tt::sockets::zmq_options::CONTEXT_IO_THREADS);
+
+  zmq::socket_t dealer(context, zmq::socket_type::dealer);
+  ASSERT_NO_THROW(tt::sockets::zmq_options::applyCommonOptions(
+      dealer, /*receiveTimeoutMs=*/42));
+  EXPECT_EQ(dealer.get(zmq::sockopt::linger), 0);
+  EXPECT_EQ(dealer.get(zmq::sockopt::rcvtimeo), 42);
+  EXPECT_EQ(dealer.get(zmq::sockopt::heartbeat_ivl),
+            tt::sockets::zmq_options::HEARTBEAT_INTERVAL_MS);
+  EXPECT_EQ(dealer.get(zmq::sockopt::heartbeat_timeout),
+            tt::sockets::zmq_options::HEARTBEAT_TIMEOUT_MS);
+
+  zmq::socket_t router(context, zmq::socket_type::router);
+  ASSERT_NO_THROW(tt::sockets::zmq_options::applyRouterOptions(
+      router, /*receiveTimeoutMs=*/43));
+  EXPECT_EQ(router.get(zmq::sockopt::rcvtimeo), 43);
+
+  dealer.close();
+  router.close();
+  context.close();
+}
+
+TEST(ZmqPrefillRouterTest, SendFailsWhenRegisteredPeerIsNoLongerRoutable) {
+  const uint16_t port = ephemeralPort();
+
+  ZmqPrefillRouter router;
+  std::mutex mutex;
+  bool registered = false;
+
+  router.registerHandler<tt::sockets::PrefillRegistrationMessage>(
+      tt::sockets::tags::PREFILL_REGISTRATION,
+      [&router, &mutex, &registered](
+          const ZmqPrefillRouter::PeerIdentity& peerId,
+          const tt::sockets::PrefillRegistrationMessage& msg) {
+        router.rememberRegistration(msg.server_id, peerId);
+        std::lock_guard<std::mutex> lock(mutex);
+        registered = true;
+      });
+
+  ASSERT_TRUE(router.start("127.0.0.1", port));
+
+  tt::sockets::ZmqSocketTransport client;
+  ASSERT_TRUE(client.initializeAsClient("127.0.0.1", port));
+  client.start();
+
+  tt::sockets::PrefillRegistrationMessage registration;
+  registration.server_id = "prefill-A";
+  registration.max_in_flight = 4;
+  ASSERT_TRUE(client.sendRawData(tt::sockets::wire::serializeMessage(
+      tt::sockets::tags::PREFILL_REGISTRATION, registration)));
+  ASSERT_TRUE(waitFor([&] {
+    std::lock_guard<std::mutex> lock(mutex);
+    return registered;
+  }));
+
+  client.stop();
+
+  tt::sockets::PrefillRequestMessage request(7);
+  ASSERT_TRUE(waitFor(
+      [&] {
+        return !router.sendObject("prefill-A", "prefill_request", request);
+      },
+      /*timeout=*/3s))
+      << "ROUTER_MANDATORY should make sends to unroutable peers fail";
+
   router.stop();
 }
 


### PR DESCRIPTION
- Enables ZMQ heartbeats on ZMQ transport sockets for faster transport-level dead peer detection.
- Enables `ZMQ_ROUTER_MANDATORY` on the prefill gateway ROUTER socket so sends to unroutable peer identities fail instead of being silently dropped.
- Adds shared ZMQ socket option helpers to keep heartbeat/router defaults consistent.
