### PR TITLE
Fix whisper and distil-large-v3 CI model names

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -584,29 +584,13 @@
         }
       }
     },
-    "distil-whisper-distil-large-v3": {
+    "distil-large-v3": {
       "inference_engine": "MEDIA",
       "ci": {
         "nightly": {
           "devices": [
             "P150",
             "P300X2"
-          ]
-        }
-      }
-    },
-    "openai-whisper-large-v3": {
-      "inference_engine": "MEDIA",
-      "ci": {
-        "nightly": {
-          "devices": [
-            "P150",
-            "P300X2"
-          ]
-        },
-        "weekly": {
-          "devices": [
-            "GALAXY"
           ]
         }
       }
@@ -729,7 +713,14 @@
           "devices": [
             "GALAXY",
             "GALAXY_BH",
-            "N150"
+            "N150",
+            "P150",
+            "P300X2"
+          ]
+        },
+        "weekly": {
+          "devices": [
+            "GALAXY"
           ]
         },
         "release": {


### PR DESCRIPTION
Fixes invalid model names introduced in the previous CI nightly PR.

- Renames `distil-whisper-distil-large-v3` → `distil-large-v3` to match the name derived from the HF repo path in `model_spec.py`
- Removes duplicate `openai-whisper-large-v3` entry and merges its devices (P150, P300X2 nightly; GALAXY weekly) into the existing `whisper-large-v3` entry