### PR TITLE
Fix DeepSeek R1 tool calling: json prefix leak, tool_choice=none, and max_tokens floor

### DIFF
--- a/tt-media-server/cpp_server/include/domain/llm/chat_completion_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/chat_completion_request.hpp
@@ -272,8 +272,13 @@ struct ChatCompletionRequest : BaseRequest {
     out.messages = messages;
     out.skip_apply_chat_template = skip_apply_chat_template;
     const auto& tokenizer = tt::utils::tokenizers::activeTokenizer();
+    std::optional<std::vector<tool_calls::Tool>> effectiveTools =
+        (tool_choice.has_value() && tool_choice->type == "none")
+            ? std::nullopt
+            : tools;
     auto promptStr = tokenizer.applyChatTemplate(
-        messages, true, tools, enable_reasoning, skip_apply_chat_template);
+        messages, true, effectiveTools, enable_reasoning,
+        skip_apply_chat_template);
     out.full_prompt_tokens_count =
         static_cast<int>(tokenizer.encode(promptStr).size());
     out.prompt_tokens_count = out.full_prompt_tokens_count;

--- a/tt-media-server/cpp_server/src/services/deepseek_tool_call_parser.cpp
+++ b/tt-media-server/cpp_server/src/services/deepseek_tool_call_parser.cpp
@@ -85,6 +85,8 @@ struct ToolCallTaskState {
   Json::Value tool_calls;         // Array of completed tool calls
   int call_index = 0;             // Tool call counter
   bool in_json_block = false;     // Inside ```json...``` block
+  bool json_header_stripped =
+      false;  // Whether "json" header after ``` has been checked/stripped
   bool sent_tool_call_start =
       false;  // Whether we've sent TOOL_CALL_START for current call
   std::string current_tool_call_id;  // ID for current tool call being parsed
@@ -115,6 +117,7 @@ class DeepSeekToolCallParser : public IToolCallParser {
     state.tool_calls = Json::Value(Json::arrayValue);
     state.call_index = 0;
     state.in_json_block = false;
+    state.json_header_stripped = false;
     state.sent_tool_call_start = false;
     state.current_tool_call_id.clear();
     state.arguments_buffer.clear();
@@ -159,6 +162,7 @@ class DeepSeekToolCallParser : public IToolCallParser {
       state.current_arguments.clear();
       state.arguments_buffer.clear();
       state.in_json_block = false;
+      state.json_header_stripped = false;
       state.sent_tool_call_start = false;
       state.current_tool_call_id = tt::utils::ToolCallIDGenerator::generate();
       TT_LOG_DEBUG("[ToolCallParser] Task {} started new tool call, id={}",
@@ -240,9 +244,11 @@ class DeepSeekToolCallParser : public IToolCallParser {
           size_t backtickPos = state.buffer.find("```");
           if (backtickPos != std::string::npos) {
             state.in_json_block = true;
+            state.json_header_stripped = false;
             size_t jsonStart = backtickPos + 3;
             if (state.buffer.substr(jsonStart, 4) == "json") {
               jsonStart += 4;
+              state.json_header_stripped = true;
             }
             while (jsonStart < state.buffer.size() &&
                    (state.buffer[jsonStart] == ' ' ||
@@ -264,6 +270,35 @@ class DeepSeekToolCallParser : public IToolCallParser {
           return std::nullopt;
 
         } else {
+          // Strip "json" header if ``` and "json" arrived in separate tokens
+          if (!state.json_header_stripped) {
+            if (state.buffer.size() >= 4) {
+              size_t start = 0;
+              while (start < state.buffer.size() &&
+                     (state.buffer[start] == ' ' ||
+                      state.buffer[start] == '\t')) {
+                start++;
+              }
+              if (state.buffer.substr(start, 4) == "json") {
+                size_t afterJson = start + 4;
+                while (afterJson < state.buffer.size() &&
+                       (state.buffer[afterJson] == ' ' ||
+                        state.buffer[afterJson] == '\n' ||
+                        state.buffer[afterJson] == '\t' ||
+                        state.buffer[afterJson] == '\r')) {
+                  afterJson++;
+                }
+                state.buffer = state.buffer.substr(afterJson);
+                state.arguments_buffer.clear();
+                state.current_arguments.clear();
+              }
+              state.json_header_stripped = true;
+            } else if (state.buffer.find('{') != std::string::npos) {
+              state.json_header_stripped = true;
+            } else {
+              return std::nullopt;
+            }
+          }
           size_t backtickPos = state.buffer.find("```");
           if (backtickPos != std::string::npos) {
             std::string finalContent = state.buffer.substr(0, backtickPos);
@@ -363,9 +398,13 @@ class DeepSeekToolCallParser : public IToolCallParser {
       return;
     }
 
-    // Trim whitespace from arguments
+    // Trim whitespace and any residual "json" prefix from arguments
     std::string argsStr = state.current_arguments;
     argsStr.erase(0, argsStr.find_first_not_of(" \t\n\r"));
+    if (argsStr.substr(0, 4) == "json") {
+      argsStr.erase(0, 4);
+      argsStr.erase(0, argsStr.find_first_not_of(" \t\n\r"));
+    }
     argsStr.erase(argsStr.find_last_not_of(" \t\n\r") + 1);
 
     // Parse JSON arguments

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -524,6 +524,23 @@ void LLMService::processStreamingRequest(
 
   // Initialize tool call parser only if tools are provided
   bool hasTools = request.tools.has_value() && !request.tools->empty();
+
+  // DeepSeek R1 reasoning tokens consume the max_tokens budget.  Clients
+  // often send low values (e.g. 8192) which get exhausted on reasoning before
+  // the model emits tool calls.  Apply a floor when tools are present so
+  // there is enough headroom for both reasoning and tool call output.
+  if (tt::config::modelType() == tt::config::ModelType::DEEPSEEK_R1_0528) {
+    constexpr int MIN_MAX_TOKENS_WITH_TOOLS = 16384;
+    if (hasTools && request.max_tokens.has_value() &&
+        request.max_tokens.value() < MIN_MAX_TOKENS_WITH_TOOLS) {
+      TT_LOG_INFO(
+          "Task {}: bumping max_tokens from {} to {} (DeepSeek R1 with tools, "
+          "need headroom for reasoning)",
+          taskId, request.max_tokens.value(), MIN_MAX_TOKENS_WITH_TOOLS);
+      request.max_tokens = MIN_MAX_TOKENS_WITH_TOOLS;
+    }
+  }
+
   if (hasTools) {
     // Determine effective tool_choice (default to "auto" if not specified)
     tt::domain::tool_calls::ToolChoice effectiveToolChoice;

--- a/tt-media-server/cpp_server/tests/test_tool_call_parser.cpp
+++ b/tt-media-server/cpp_server/tests/test_tool_call_parser.cpp
@@ -431,6 +431,137 @@ void testMalformedSequences() {
   std::cout << "✅ All malformed sequence tests passed!\n";
 }
 
+void testSplitTokenJsonHeader() {
+  std::cout << "\n=== Testing Split-Token JSON Header ===\n";
+
+  constexpr int64_t kToolCallsBeginToken = 128806;
+  constexpr int64_t kToolCallsEndToken = 128807;
+  constexpr int64_t kToolCallBeginToken = 128808;
+  constexpr int64_t kToolCallEndToken = 128809;
+  constexpr int64_t kToolSepToken = 128814;
+
+  // Test 1: ``` and json arrive as separate tokens
+  {
+    auto parser = createToolCallParser(tt::config::ModelType::DEEPSEEK_R1_0528);
+    uint32_t taskId = 300;
+    parser->initializeTask(taskId);
+
+    parser->processToken(taskId, kToolCallsBeginToken, "");
+    parser->processToken(taskId, kToolCallBeginToken, "");
+    parser->processToken(taskId, 12345, "function");
+    parser->processToken(taskId, kToolSepToken, "");
+
+    auto r1 = parser->processToken(taskId, 12346, "get_weather\n");
+    assert(r1.has_value());
+    assert(r1->delta_type == ToolCallDeltaType::TOOL_CALL_START);
+    assert(r1->function_name == "get_weather");
+
+    // ``` arrives alone, then "json\n" as next token
+    parser->processToken(taskId, 12347, "```");
+    parser->processToken(taskId, 12348, "json\n");
+
+    // Actual JSON arguments
+    auto r2 = parser->processToken(taskId, 12349,
+                                   "{\"location\":\"San Francisco, CA\"}\n");
+    assert(r2.has_value());
+    assert(r2->delta_type == ToolCallDeltaType::ARGUMENTS_DELTA);
+    // Arguments must NOT contain "json\n" prefix
+    assert(r2->delta.find("json") == std::string::npos);
+
+    parser->processToken(taskId, 12350, "```\n");
+    parser->processToken(taskId, kToolCallEndToken, "");
+    parser->processToken(taskId, kToolCallsEndToken, "");
+
+    auto toolCalls = parser->finalizeTask(taskId);
+    assert(toolCalls.has_value());
+    assert(toolCalls->size() == 1);
+    assert((*toolCalls)[0]["function"]["name"].asString() == "get_weather");
+
+    // Verify arguments are clean JSON
+    std::string args =
+        (*toolCalls)[0]["function"]["arguments"].asString();
+    assert(args.find("json") == std::string::npos);
+    assert(args.find("San Francisco") != std::string::npos);
+
+    std::cout
+        << "✓ Test 1 passed: ``` and json as separate tokens handled\n";
+  }
+
+  // Test 2: ```, json, \n all as separate tokens
+  {
+    auto parser = createToolCallParser(tt::config::ModelType::DEEPSEEK_R1_0528);
+    uint32_t taskId = 301;
+    parser->initializeTask(taskId);
+
+    parser->processToken(taskId, kToolCallsBeginToken, "");
+    parser->processToken(taskId, kToolCallBeginToken, "");
+    parser->processToken(taskId, 12345, "function");
+    parser->processToken(taskId, kToolSepToken, "");
+    parser->processToken(taskId, 12346, "get_time\n");
+
+    parser->processToken(taskId, 12347, "```");
+    parser->processToken(taskId, 12348, "json");
+    parser->processToken(taskId, 12349, "\n");
+
+    auto r = parser->processToken(taskId, 12350, "{\"tz\":\"PST\"}\n");
+    assert(r.has_value());
+    assert(r->delta_type == ToolCallDeltaType::ARGUMENTS_DELTA);
+    assert(r->delta.find("json") == std::string::npos);
+
+    parser->processToken(taskId, 12351, "```\n");
+    parser->processToken(taskId, kToolCallEndToken, "");
+    parser->processToken(taskId, kToolCallsEndToken, "");
+
+    auto toolCalls = parser->finalizeTask(taskId);
+    assert(toolCalls.has_value());
+    assert(toolCalls->size() == 1);
+
+    std::string args =
+        (*toolCalls)[0]["function"]["arguments"].asString();
+    assert(args.find("json") == std::string::npos);
+    assert(args.find("PST") != std::string::npos);
+
+    std::cout
+        << "✓ Test 2 passed: ```, json, \\n as three separate tokens\n";
+  }
+
+  // Test 3: ``` without json header (just ```\n)
+  {
+    auto parser = createToolCallParser(tt::config::ModelType::DEEPSEEK_R1_0528);
+    uint32_t taskId = 302;
+    parser->initializeTask(taskId);
+
+    parser->processToken(taskId, kToolCallsBeginToken, "");
+    parser->processToken(taskId, kToolCallBeginToken, "");
+    parser->processToken(taskId, 12345, "function");
+    parser->processToken(taskId, kToolSepToken, "");
+    parser->processToken(taskId, 12346, "my_func\n");
+
+    // No "json" after backticks
+    parser->processToken(taskId, 12347, "```\n");
+
+    auto r = parser->processToken(taskId, 12348, "{\"key\":\"val\"}\n");
+    assert(r.has_value());
+    assert(r->delta_type == ToolCallDeltaType::ARGUMENTS_DELTA);
+
+    parser->processToken(taskId, 12349, "```\n");
+    parser->processToken(taskId, kToolCallEndToken, "");
+    parser->processToken(taskId, kToolCallsEndToken, "");
+
+    auto toolCalls = parser->finalizeTask(taskId);
+    assert(toolCalls.has_value());
+    assert(toolCalls->size() == 1);
+
+    std::string args =
+        (*toolCalls)[0]["function"]["arguments"].asString();
+    assert(args.find("val") != std::string::npos);
+
+    std::cout << "✓ Test 3 passed: ``` without json header works\n";
+  }
+
+  std::cout << "✅ All split-token JSON header tests passed!\n";
+}
+
 void testStreamingMultipleToolCalls() {
   std::cout << "\n=== Testing Streaming Multiple Tool Calls ===\n";
 
@@ -494,6 +625,7 @@ int main() {
     testMultipleStreamingTasks();
     testStreamingEdgeCases();
     testMalformedSequences();
+    testSplitTokenJsonHeader();
     testStreamingMultipleToolCalls();
 
     std::cout << "\n";


### PR DESCRIPTION
## Summary

Fixes three issues that prevent DeepSeek R1 tool calling from working reliably on the C++ server, discovered via live testing against `console.tenstorrent.com`:

- **`json\n` prefix leaks into `function.arguments`**: When ` ``` ` and `json` arrive as separate tokens during streaming, the DeepSeek tool call parser enters the json block without stripping the "json" header. Adds a `json_header_stripped` flag to handle split-token scenarios, plus a safety strip in `finalizeSingleToolCall`.
- **`tool_choice=none` leaks raw special tokens into content**: Tools were still injected into the prompt via `applyChatTemplate` even when `tool_choice=none`, causing the model to generate `<|tool_calls_begin|>` etc. that appeared verbatim in the response content. Fix: pass `std::nullopt` for tools when `tool_choice` is `"none"`.
- **R1 exhausts token budget on reasoning before emitting tool calls**: DeepSeek R1 reasoning tokens consume the `max_tokens` budget. Clients often send low values (e.g. 8192) that get fully consumed by reasoning. Adds a DeepSeek-specific `max_tokens` floor of 16384 when tools are present.

## Test plan

- [x] Added `testSplitTokenJsonHeader()` with 3 test cases covering split-token scenarios
- [ ] Existing `test_tool_call_parser` tests still pass
- [ ] Verify `tool_choice=none` no longer leaks special tokens in response content
- [ ] Verify tool calls with `tool_choice=auto` return clean JSON arguments (no `json\n` prefix)
- [ ] Verify low `max_tokens` requests with tools get bumped to 16384 on DeepSeek R1
