### PR TITLE
[P0] Fix SpeechT5 startup crash on P300/P300X2 (MGD mismatch)

### DIFF
--- a/tt-media-server/tests/test_worker_utils.py
+++ b/tt-media-server/tests/test_worker_utils.py
@@ -467,7 +467,7 @@ class TestSetupBlackholeMeshConfig:
                 assert os.environ["TT_MESH_GRAPH_DESC_PATH"] == expected_path
 
     def test_sets_p300_mesh_descriptor(self):
-        """Test mesh descriptor is set for p300 device"""
+        """Test mesh descriptor is set for p300 device (maps to p150 descriptor)"""
         mock_settings_bh = Mock()
         mock_settings_bh.device = "p300"
 
@@ -477,7 +477,7 @@ class TestSetupBlackholeMeshConfig:
 
                 expected_path = (
                     "/opt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/"
-                    "p300_mesh_graph_descriptor.textproto"
+                    "p150_mesh_graph_descriptor.textproto"
                 )
                 assert os.environ["TT_MESH_GRAPH_DESC_PATH"] == expected_path
 

--- a/tt-media-server/utils/runner_utils.py
+++ b/tt-media-server/utils/runner_utils.py
@@ -15,8 +15,8 @@ _BH_DEVICE_MESH_DESCRIPTORS = {
     "p150": "p150_mesh_graph_descriptor.textproto",
     "p150x4": "p150x4_mesh_graph_descriptor.textproto",
     "p150x8": "p150x8_mesh_graph_descriptor.textproto",
-    "p300": "p300_mesh_graph_descriptor.textproto",
-    "p300x2": "p300_x2_mesh_graph_descriptor.textproto",
+    "p300": "p150_mesh_graph_descriptor.textproto",
+    "p300x2": "p150_mesh_graph_descriptor.textproto",
     "p100": "p100_mesh_graph_descriptor.textproto",
 }
 
@@ -85,17 +85,11 @@ def setup_cpu_threading_limits(cpu_threads: str, num_torch_threads: int = 1):
 def _setup_blackhole_mesh_config(tt_metal_home: str):
     """Configure mesh graph descriptors for Blackhole hardware"""
     device = (settings.device or "").lower()
-    if device not in _BH_DEVICE_MESH_DESCRIPTORS:
-        return
-    # Single-chip-per-worker workloads always use the 1x1 descriptor regardless
-    # of the host board type (P300 / P300X2 expose individual BH chips).
-    if settings.device_mesh_shape == (1, 1):
-        descriptor = "p150_mesh_graph_descriptor.textproto"
-    else:
-        descriptor = _BH_DEVICE_MESH_DESCRIPTORS[device]
-    os.environ["TT_MESH_GRAPH_DESC_PATH"] = (
-        f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/{descriptor}"
-    )
+    descriptor = _BH_DEVICE_MESH_DESCRIPTORS.get(device)
+    if descriptor:
+        os.environ["TT_MESH_GRAPH_DESC_PATH"] = (
+            f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/{descriptor}"
+        )
 
 
 def _setup_galaxy_mesh_config(tt_metal_home: str):

--- a/tt-media-server/utils/runner_utils.py
+++ b/tt-media-server/utils/runner_utils.py
@@ -85,11 +85,17 @@ def setup_cpu_threading_limits(cpu_threads: str, num_torch_threads: int = 1):
 def _setup_blackhole_mesh_config(tt_metal_home: str):
     """Configure mesh graph descriptors for Blackhole hardware"""
     device = (settings.device or "").lower()
-    descriptor = _BH_DEVICE_MESH_DESCRIPTORS.get(device)
-    if descriptor:
-        os.environ["TT_MESH_GRAPH_DESC_PATH"] = (
-            f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/{descriptor}"
-        )
+    if device not in _BH_DEVICE_MESH_DESCRIPTORS:
+        return
+    # Single-chip-per-worker workloads always use the 1x1 descriptor regardless
+    # of the host board type (P300 / P300X2 expose individual BH chips).
+    if settings.device_mesh_shape == (1, 1):
+        descriptor = "p150_mesh_graph_descriptor.textproto"
+    else:
+        descriptor = _BH_DEVICE_MESH_DESCRIPTORS[device]
+    os.environ["TT_MESH_GRAPH_DESC_PATH"] = (
+        f"{tt_metal_home}/tt_metal/fabric/mesh_graph_descriptors/{descriptor}"
+    )
 
 
 def _setup_galaxy_mesh_config(tt_metal_home: str):

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -3336,7 +3336,7 @@ audio_tts_templates = [
                 max_context=64 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto",
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
                 },
             ),
             DeviceModelSpec(
@@ -3345,7 +3345,7 @@ audio_tts_templates = [
                 max_context=64 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto",
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
                 },
             ),
         ],

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -3336,7 +3336,7 @@ audio_tts_templates = [
                 max_context=64 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto",
                 },
             ),
             DeviceModelSpec(
@@ -3345,7 +3345,7 @@ audio_tts_templates = [
                 max_context=64 * 1024,
                 default_impl=True,
                 env_vars={
-                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
+                    "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto",
                 },
             ),
         ],


### PR DESCRIPTION
## Summary

SpeechT5 on P300/P300X2 crashes at startup with `TT_FATAL` from `topology_mapper.cpp:518`. Each worker is pinned to a single chip via `TT_VISIBLE_DEVICES=N`, but was being assigned a multi-chip Mesh Graph Descriptor — a 1-chip worker cannot satisfy a 4-chip target graph.

## Fix

Map `p300` and `p300x2` to the single-chip `p150_mesh_graph_descriptor.textproto` in `_BH_DEVICE_MESH_DESCRIPTORS`, matching the `(1,1)` mesh shape already configured per worker.

\`\`\`diff
-    "p300":   "p300_mesh_graph_descriptor.textproto",
-    "p300x2": "p300_x2_mesh_graph_descriptor.textproto",
+    "p300":   "p150_mesh_graph_descriptor.textproto",
+    "p300x2": "p150_mesh_graph_descriptor.textproto",
\`\`\`

Supersedes #3256.

## Test Plan

- [ ] SpeechT5 starts cleanly on P300 and P300X2 (no `TT_FATAL`)
- [ ] TTS inference produces audio output
- [ ] No regression on P150 / P100 SpeechT5

Closes #3681