### PR TITLE
Add missing p150/p300x2 perf targets for distil-large-v3 and whisper-large-v3

### DIFF
--- a/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/benchmarking/benchmark_targets/model_performance_reference.json
@@ -5928,6 +5928,22 @@
                     }
                 }
             }
+        ],
+        "p300x2": [
+            {
+                "max_concurrency": 1,
+                "num_eval_runs": 2,
+                "task_type": "asr",
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 400.0,
+                        "ttft_streaming_ms": null,
+                        "tput_user": 65.0,
+                        "rtr": 17.0,
+                        "tolerance": 0.05
+                    }
+                }
+            }
         ]
     },
     "distil-large-v3": {
@@ -5974,6 +5990,38 @@
                         "ttft_streaming_ms": 450,
                         "tput_user": 131.10,
                         "rtr": 21.81,
+                        "tolerance": 0.05
+                    }
+                }
+            }
+        ],
+        "p150": [
+            {
+                "max_concurrency": 1,
+                "num_eval_runs": 2,
+                "task_type": "asr",
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 200.0,
+                        "ttft_streaming_ms": null,
+                        "tput_user": 130.0,
+                        "rtr": 34.0,
+                        "tolerance": 0.05
+                    }
+                }
+            }
+        ],
+        "p300x2": [
+            {
+                "max_concurrency": 1,
+                "num_eval_runs": 2,
+                "task_type": "asr",
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 200.0,
+                        "ttft_streaming_ms": null,
+                        "tput_user": 130.0,
+                        "rtr": 34.0,
                         "tolerance": 0.05
                     }
                 }


### PR DESCRIPTION
## Summary

Adds the missing performance target entries to `benchmarking/benchmark_targets/model_performance_reference.json` for model/device combinations that were causing a P0 crash in `run_reports.py`.

When no targets exist for a model/device pair, `calculate_target_metrics()` skips populating the `functional_latency`/`complete_latency`/`target_latency` keys, and the subsequent hard dict lookup in `add_target_checks_audio()` crashes with `KeyError: 'functional_latency'`.

**Entries added:**

| Model | Device | Source |
|---|---|---|
| `whisper-large-v3` | `p300x2` | Copied from `whisper-large-v3/p150` |
| `distil-large-v3` | `p150` | Derived from `whisper-large-v3/p150` at confirmed 2× ratio |
| `distil-large-v3` | `p300x2` | Copied from `distil-large-v3/p150` |

Fixes: #3684

## Validation runs

- [distil-large-v3 | p150 | release](https://github.com/tenstorrent/tt-shield/actions/runs/26380466259)
- [distil-large-v3 | bh-qb-ge (p300x2) | release](https://github.com/tenstorrent/tt-shield/actions/runs/26380468657)
- [whisper-large-v3 | bh-qb-ge (p300x2) | release](https://github.com/tenstorrent/tt-shield/actions/runs/26380469294)