### PR TITLE
Cancel in progress runs on new CI runs

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -6,9 +6,9 @@ on:
     types: [opened, synchronize, reopened]
   merge_group:
 
-# Cancel superseded PR runs so a series of force-pushes doesn't keep three
-# xlarge bench jobs alive per stale commit. merge_group and push-to-main runs
-# are never cancelled — those gate merges and main-branch history.
+# Cancel in-flight runs on a PR when its head advances, so we don't keep three
+# xlarge bench jobs alive per stale commit; merge_group and workflow_dispatch
+# runs are never cancelled.
 concurrency:
   group: test-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -6,6 +6,13 @@ on:
     types: [opened, synchronize, reopened]
   merge_group:
 
+# Cancel superseded PR runs so a series of force-pushes doesn't keep three
+# xlarge bench jobs alive per stale commit. merge_group and push-to-main runs
+# are never cancelled — those gate merges and main-branch history.
+concurrency:
+  group: test-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   detect-changes:
     name: Detect Code Changes


### PR DESCRIPTION
This PR reduces the load on the shared GitHub runner.

Most of our long-running jobs run on shared internal GitHub runner.
If we push a lot of commits, especially if we push them one by one, it will run a lot of jobs.
We are interested in the outcome of the CI job related to the last push, but the previous ones will just keep running and waste the compute.

