### PR TITLE
Add reusable test-gate helper scripts

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -710,14 +710,8 @@ jobs:
           name: cpp-server-build
           path: tt-media-server/cpp_server
 
-      - name: Extract C++ build
-        run: |
-          cd cpp_server
-          tar -xzf cpp-server-build.tar.gz
-          rm cpp-server-build.tar.gz
-
-      - name: Make binaries executable
-        run: chmod +x cpp_server/build/tt_media_server_cpp
+      - name: Set up C++ build artifact
+        run: bash cpp_server/scripts/ci/setup_cpp_artifact.sh --skip-deps
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
@@ -726,15 +720,7 @@ jobs:
           enable-cache: true
 
       - name: Install Python test dependencies
-        run: |
-          uv venv
-          # Pin transformers<5.6 — bench is bisect-confirmed to regress on
-          # transformers 5.6.x (mock_pipeline mean_ttft_ms 377ms -> 1834ms,
-          # mean_tpot_ms 2.93ms -> 3.57ms with all other deps held identical).
-          # Track upstream and remove pin once 5.6.x is fixed or bench is
-          # made resilient to client tokenizer cost.
-          uv pip install vllm 'transformers<5.6'
-          echo "PATH=${{ github.workspace }}/tt-media-server/.venv/bin:$PATH" >> $GITHUB_ENV
+        run: bash cpp_server/scripts/ci/install_bench_client.sh
 
       # ── Mock backend benchmarks ──────────────────────────────────────
       - name: Start C++ server (mock backend)
@@ -743,19 +729,7 @@ jobs:
           LLM_DEVICE_BACKEND=mock ./tt_media_server_cpp -p 8000 -t 4 > ../../cpp_server_mock.log 2>&1 &
           echo $! > ../../cpp_server.pid
           cd ../..
-          for i in $(seq 1 30); do
-            LIVENESS=$(curl -sf "http://127.0.0.1:8000/tt-liveness" 2>/dev/null || true)
-            if echo "$LIVENESS" | grep -q '"model_ready":true'; then
-              echo "Server ready."
-              break
-            fi
-            sleep 1
-          done
-          LIVENESS=$(curl -sf "http://127.0.0.1:8000/tt-liveness" 2>/dev/null || true)
-          if ! echo "$LIVENESS" | grep -q '"model_ready":true'; then
-            echo "ERROR: Server did not become ready within 30 seconds"
-            exit 1
-          fi
+          bash cpp_server/scripts/ci/wait_for_liveness.sh --port 8000 --pid-file cpp_server.pid --label "mock backend"
 
       # Pre-warm the Drogon IO thread pool so each thread pays its per-thread
       # tokenizer init cost (#3179) before the measured bench starts. Without
@@ -851,19 +825,7 @@ jobs:
           LLM_DEVICE_BACKEND=mock_pipeline ./tt_media_server_cpp -p 8000 -t 4 > ../../cpp_server_mock_pipeline.log 2>&1 &
           echo $! > ../../cpp_server.pid
           cd ../..
-          for i in $(seq 1 30); do
-            LIVENESS=$(curl -sf "http://127.0.0.1:8000/tt-liveness" 2>/dev/null || true)
-            if echo "$LIVENESS" | grep -q '"model_ready":true'; then
-              echo "Server ready."
-              break
-            fi
-            sleep 1
-          done
-          LIVENESS=$(curl -sf "http://127.0.0.1:8000/tt-liveness" 2>/dev/null || true)
-          if ! echo "$LIVENESS" | grep -q '"model_ready":true'; then
-            echo "ERROR: Server did not become ready within 30 seconds"
-            exit 1
-          fi
+          bash cpp_server/scripts/ci/wait_for_liveness.sh --port 8000 --pid-file cpp_server.pid --label "mock_pipeline backend"
 
       - name: Warm up mock_pipeline backend
         env:
@@ -905,77 +867,18 @@ jobs:
       # ── Check thresholds ─────────────────────────────────────────────
       - name: Check all benchmark thresholds
         run: |
+          CONFIG=cpp_server/scripts/ci/vllm_thresholds.json
+          CHECK=cpp_server/scripts/ci/check_vllm_result.py
           FAIL=0
-          ERRORS=""
-
-          check_thresholds() {
-            local LABEL="$1" FILE="$2" TPOT_LIMIT="$3" TTFT_LIMIT="$4"
-            if [ ! -f "$FILE" ]; then
-              echo "❌ [$LABEL] Result file not found: $FILE"
-              ERRORS="${ERRORS:+$ERRORS$'\n'}[$LABEL] Result file not found: $FILE"
-              FAIL=1
-              return
-            fi
-
-            local COMPLETED FAILED_REQ MEAN_TPOT_MS MEAN_TTFT_MS
-            COMPLETED=$(jq -r '.completed // 0' "$FILE")
-            FAILED_REQ=$(jq -r '.failed // 0' "$FILE")
-            MEAN_TPOT_MS=$(jq -r '.mean_tpot_ms // 0' "$FILE")
-            MEAN_TTFT_MS=$(jq -r '.mean_ttft_ms // 0' "$FILE")
-
-            if [ "$FAILED_REQ" -gt 0 ]; then
-              echo "❌ [$LABEL] $FAILED_REQ request(s) failed (completed=$COMPLETED, failed=$FAILED_REQ)"
-              ERRORS="${ERRORS:+$ERRORS$'\n'}[$LABEL] $FAILED_REQ request(s) failed (completed=$COMPLETED, failed=$FAILED_REQ)"
-              FAIL=1
-            fi
-
-            if [ -n "$MEAN_TPOT_MS" ] && [ "$MEAN_TPOT_MS" != "null" ]; then
-              if ! python3 -c "exit(0 if float('$MEAN_TPOT_MS') <= $TPOT_LIMIT else 1)"; then
-                echo "❌ [$LABEL] mean_tpot_ms $MEAN_TPOT_MS exceeds threshold ${TPOT_LIMIT}ms"
-                ERRORS="${ERRORS:+$ERRORS$'\n'}[$LABEL] mean_tpot_ms $MEAN_TPOT_MS exceeds threshold ${TPOT_LIMIT}ms"
-                FAIL=1
-              fi
-            fi
-            if [ -n "$MEAN_TTFT_MS" ] && [ "$MEAN_TTFT_MS" != "null" ]; then
-              if ! python3 -c "exit(0 if float('$MEAN_TTFT_MS') <= $TTFT_LIMIT else 1)"; then
-                echo "❌ [$LABEL] mean_ttft_ms $MEAN_TTFT_MS exceeds threshold ${TTFT_LIMIT}ms"
-                ERRORS="${ERRORS:+$ERRORS$'\n'}[$LABEL] mean_ttft_ms $MEAN_TTFT_MS exceeds threshold ${TTFT_LIMIT}ms"
-                FAIL=1
-              fi
-            fi
-
-            {
-              echo "## $LABEL"
-              echo ""
-              echo "| Metric | Value | Threshold |"
-              echo "|--------|-------|-----------|"
-              echo "| **mean_tpot_ms** | $MEAN_TPOT_MS | ≤ ${TPOT_LIMIT}ms |"
-              echo "| **mean_ttft_ms** | $MEAN_TTFT_MS | ≤ ${TTFT_LIMIT}ms |"
-              echo "| **completed** | $COMPLETED | - |"
-              echo "| **failed** | $FAILED_REQ | 0 |"
-              echo ""
-            } >> $GITHUB_STEP_SUMMARY
-          }
-
-          check_thresholds "C++ Server vLLM Bench (mock)" \
-            "vllm-bench-mock.json" 1 150
-
-          check_thresholds "C++ Server vLLM Bench (structured output - json_object)" \
-            "vllm-bench-structured-output-json-object.json" 5 150
-
-          check_thresholds "C++ Server vLLM Bench (structured output - json_schema)" \
-            "vllm-bench-structured-output-json-schema.json" 3 250
-
-          check_thresholds "C++ Server vLLM Bench (mock_pipeline)" \
-            "vllm-bench-mock-pipeline.json" 3 395
-
-          echo "BENCH_FAIL=$FAIL" >> $GITHUB_ENV
-          {
-            echo "BENCH_ERRORS<<BENCHERRORSEOF"
-            printf '%s\n' "$ERRORS"
-            echo "BENCHERRORSEOF"
-          } >> $GITHUB_ENV
-
+          python3 "$CHECK" --config "$CONFIG" --scenario cpp_mock \
+            --result vllm-bench-mock.json || FAIL=1
+          python3 "$CHECK" --config "$CONFIG" --scenario cpp_structured_json_object \
+            --result vllm-bench-structured-output-json-object.json || FAIL=1
+          python3 "$CHECK" --config "$CONFIG" --scenario cpp_structured_json_schema \
+            --result vllm-bench-structured-output-json-schema.json || FAIL=1
+          python3 "$CHECK" --config "$CONFIG" --scenario cpp_mock_pipeline \
+            --result vllm-bench-mock-pipeline.json || FAIL=1
+          echo "BENCH_FAIL=$FAIL" >> "$GITHUB_ENV"
       # ── Artifacts & logs ─────────────────────────────────────────────
       - name: Show server logs
         if: always()
@@ -1012,12 +915,7 @@ jobs:
 
       - name: Check benchmark result
         if: always()
-        run: |
-          if [ "${BENCH_FAIL:-0}" != "1" ]; then
-            exit 0
-          fi
-          printf '%s\n' "$BENCH_ERRORS"
-          exit 1
+        run: exit "${BENCH_FAIL:-0}"
 
   cpp-server-prefill-decode-split:
     needs: [detect-changes, cpp-build]
@@ -1047,14 +945,8 @@ jobs:
           name: cpp-server-build
           path: tt-media-server/cpp_server
 
-      - name: Extract C++ build
-        run: |
-          cd cpp_server
-          tar -xzf cpp-server-build.tar.gz
-          rm cpp-server-build.tar.gz
-
-      - name: Make binaries executable
-        run: chmod +x cpp_server/build/tt_media_server_cpp
+      - name: Set up C++ build artifact
+        run: bash cpp_server/scripts/ci/setup_cpp_artifact.sh --skip-deps
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
@@ -1063,15 +955,7 @@ jobs:
           enable-cache: true
 
       - name: Install Python test dependencies
-        run: |
-          uv venv
-          # Pin transformers<5.6 — bench is bisect-confirmed to regress on
-          # transformers 5.6.x (mock_pipeline mean_ttft_ms 377ms -> 1834ms,
-          # mean_tpot_ms 2.93ms -> 3.57ms with all other deps held identical).
-          # Track upstream and remove pin once 5.6.x is fixed or bench is
-          # made resilient to client tokenizer cost.
-          uv pip install vllm 'transformers<5.6'
-          echo "PATH=${{ github.workspace }}/tt-media-server/.venv/bin:$PATH" >> $GITHUB_ENV
+        run: bash cpp_server/scripts/ci/install_bench_client.sh
 
       # ── Round 1a: TCP Decode + Prefill split ─────────────────────────
       - name: "[TCP] Start Decode server (direct split)"
@@ -1400,74 +1284,16 @@ jobs:
 
       - name: Check benchmark thresholds
         run: |
+          CONFIG=cpp_server/scripts/ci/vllm_thresholds.json
+          CHECK=cpp_server/scripts/ci/check_vllm_result.py
           FAIL=0
-          ERRORS=""
-
-          check_thresholds() {
-            local LABEL="$1" FILE="$2" TPOT_LIMIT="$3" TTFT_LIMIT="$4"
-            if [ ! -f "$FILE" ]; then
-              echo "❌ [$LABEL] Result file not found: $FILE"
-              ERRORS="${ERRORS:+$ERRORS$'\n'}[$LABEL] Result file not found: $FILE"
-              FAIL=1
-              return
-            fi
-
-            local COMPLETED FAILED_REQ MEAN_TPOT_MS MEAN_TTFT_MS
-            COMPLETED=$(jq -r '.completed // 0' "$FILE")
-            FAILED_REQ=$(jq -r '.failed // 0' "$FILE")
-            MEAN_TPOT_MS=$(jq -r '.mean_tpot_ms // 0' "$FILE")
-            MEAN_TTFT_MS=$(jq -r '.mean_ttft_ms // 0' "$FILE")
-
-            if [ "$FAILED_REQ" -gt 0 ]; then
-              echo "❌ [$LABEL] $FAILED_REQ request(s) failed (completed=$COMPLETED, failed=$FAILED_REQ)"
-              ERRORS="${ERRORS:+$ERRORS$'\n'}[$LABEL] $FAILED_REQ request(s) failed (completed=$COMPLETED, failed=$FAILED_REQ)"
-              FAIL=1
-            fi
-
-            if [ -n "$MEAN_TPOT_MS" ] && [ "$MEAN_TPOT_MS" != "null" ]; then
-              if ! python3 -c "exit(0 if float('$MEAN_TPOT_MS') <= $TPOT_LIMIT else 1)"; then
-                echo "❌ [$LABEL] mean_tpot_ms $MEAN_TPOT_MS exceeds threshold ${TPOT_LIMIT}ms"
-                ERRORS="${ERRORS:+$ERRORS$'\n'}[$LABEL] mean_tpot_ms $MEAN_TPOT_MS exceeds threshold ${TPOT_LIMIT}ms"
-                FAIL=1
-              fi
-            fi
-            if [ -n "$MEAN_TTFT_MS" ] && [ "$MEAN_TTFT_MS" != "null" ]; then
-              if ! python3 -c "exit(0 if float('$MEAN_TTFT_MS') <= $TTFT_LIMIT else 1)"; then
-                echo "❌ [$LABEL] mean_ttft_ms $MEAN_TTFT_MS exceeds threshold ${TTFT_LIMIT}ms"
-                ERRORS="${ERRORS:+$ERRORS$'\n'}[$LABEL] mean_ttft_ms $MEAN_TTFT_MS exceeds threshold ${TTFT_LIMIT}ms"
-                FAIL=1
-              fi
-            fi
-
-            {
-              echo "## $LABEL"
-              echo ""
-              echo "| Metric | Value | Threshold |"
-              echo "|--------|-------|-----------|"
-              echo "| **mean_tpot_ms** | $MEAN_TPOT_MS | ≤ ${TPOT_LIMIT}ms |"
-              echo "| **mean_ttft_ms** | $MEAN_TTFT_MS | ≤ ${TTFT_LIMIT}ms |"
-              echo "| **completed** | $COMPLETED | - |"
-              echo "| **failed** | $FAILED_REQ | 0 |"
-              echo ""
-            } >> $GITHUB_STEP_SUMMARY
-          }
-
-          check_thresholds "C++ Server Prefill/Decode Split (TCP)" \
-            "vllm-bench-split-tcp-result.json" 10 650
-
-          check_thresholds "C++ Server Prefill/Decode Split (ZMQ)" \
-            "vllm-bench-split-zmq-result.json" 10 650
-
-          check_thresholds "C++ Server Prefill/Decode Split (mock_prefill_runner)" \
-            "vllm-bench-split-runner-result.json" 10 650
-
-          echo "BENCH_FAIL=$FAIL" >> $GITHUB_ENV
-          {
-            echo "BENCH_ERRORS<<BENCHERRORSEOF"
-            printf '%s\n' "$ERRORS"
-            echo "BENCHERRORSEOF"
-          } >> $GITHUB_ENV
-
+          python3 "$CHECK" --config "$CONFIG" --scenario prefill_decode_split_tcp \
+            --result vllm-bench-split-tcp-result.json || FAIL=1
+          python3 "$CHECK" --config "$CONFIG" --scenario prefill_decode_split_zmq \
+            --result vllm-bench-split-zmq-result.json || FAIL=1
+          python3 "$CHECK" --config "$CONFIG" --scenario prefill_decode_split_runner \
+            --result vllm-bench-split-runner-result.json || FAIL=1
+          echo "BENCH_FAIL=$FAIL" >> "$GITHUB_ENV"
       - name: Show server logs
         if: always()
         run: |
@@ -1550,12 +1376,7 @@ jobs:
 
       - name: Check benchmark result
         if: always()
-        run: |
-          if [ "${BENCH_FAIL:-0}" != "1" ]; then
-            exit 0
-          fi
-          printf '%s\n' "$BENCH_ERRORS"
-          exit 1
+        run: exit "${BENCH_FAIL:-0}"
 
   prefill-gateway-build:
     needs: detect-changes
@@ -1721,11 +1542,8 @@ jobs:
           name: cpp-server-build
           path: tt-media-server/cpp_server
 
-      - name: Extract C++ server build
-        run: |
-          cd cpp_server
-          tar -xzf cpp-server-build.tar.gz
-          rm cpp-server-build.tar.gz
+      - name: Set up C++ server build artifact
+        run: bash cpp_server/scripts/ci/setup_cpp_artifact.sh --skip-deps
 
       - name: Download prefill_gateway binary
         uses: actions/download-artifact@v4
@@ -1733,10 +1551,8 @@ jobs:
           name: prefill-gateway-build
           path: tt-media-server/prefill_gateway/build
 
-      - name: Make binaries executable
-        run: |
-          chmod +x cpp_server/build/tt_media_server_cpp
-          chmod +x prefill_gateway/build/prefill_gateway
+      - name: Make prefill_gateway executable
+        run: chmod +x prefill_gateway/build/prefill_gateway
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
@@ -1745,10 +1561,7 @@ jobs:
           enable-cache: true
 
       - name: Install Python test dependencies
-        run: |
-          uv venv
-          uv pip install vllm 'transformers<5.6'
-          echo "PATH=${{ github.workspace }}/tt-media-server/.venv/bin:$PATH" >> $GITHUB_ENV
+        run: bash cpp_server/scripts/ci/install_bench_client.sh
 
       # ── Round 1: TCP transport ────────────────────────────────────────────
       # Startup order: prefill-1 → prefill-2 → gateway → decode.
@@ -2121,47 +1934,14 @@ jobs:
 
       - name: Check benchmark thresholds
         run: |
+          CONFIG=cpp_server/scripts/ci/vllm_thresholds.json
+          CHECK=cpp_server/scripts/ci/check_vllm_result.py
           FAIL=0
-          check_file() {
-            local FILE="$1"
-            local LABEL="$2"
-            if [ ! -f "$FILE" ]; then
-              echo "❌ Result file not found: $FILE"
-              FAIL=1
-              return
-            fi
-            COMPLETED=$(jq -r '.completed // 0' "$FILE")
-            FAILED_REQ=$(jq -r '.failed // 0' "$FILE")
-            MEAN_TPOT_MS=$(jq -r '.mean_tpot_ms // 0' "$FILE")
-            MEAN_TTFT_MS=$(jq -r '.mean_ttft_ms // 0' "$FILE")
-            if [ "$FAILED_REQ" -gt 0 ]; then
-              echo "❌ [$LABEL] $FAILED_REQ request(s) failed (completed=$COMPLETED)"
-              FAIL=1
-            fi
-            if ! python3 -c "exit(0 if float('$MEAN_TPOT_MS') <= 10 else 1)"; then
-              echo "❌ [$LABEL] mean_tpot_ms $MEAN_TPOT_MS exceeds 10ms threshold"
-              FAIL=1
-            fi
-            if ! python3 -c "exit(0 if float('$MEAN_TTFT_MS') <= 650 else 1)"; then
-              echo "❌ [$LABEL] mean_ttft_ms $MEAN_TTFT_MS exceeds 650ms threshold"
-              FAIL=1
-            fi
-            {
-              echo "## C++ Server Gateway Split ($LABEL)"
-              echo ""
-              echo "| Metric | Value | Threshold |"
-              echo "|--------|-------|-----------|"
-              echo "| **mean_tpot_ms** | $MEAN_TPOT_MS | ≤ 10ms |"
-              echo "| **mean_ttft_ms** | $MEAN_TTFT_MS | ≤ 650ms |"
-              echo "| **completed** | $COMPLETED | - |"
-              echo "| **failed** | $FAILED_REQ | 0 |"
-              echo ""
-            } >> $GITHUB_STEP_SUMMARY
-          }
-          check_file "vllm-bench-gateway-split-tcp-result.json" "TCP"
-          check_file "vllm-bench-gateway-split-zmq-result.json" "ZMQ"
-          [ "$FAIL" -eq 0 ] || exit 1
-
+          python3 "$CHECK" --config "$CONFIG" --scenario gateway_split_tcp \
+            --result vllm-bench-gateway-split-tcp-result.json || FAIL=1
+          python3 "$CHECK" --config "$CONFIG" --scenario gateway_split_zmq \
+            --result vllm-bench-gateway-split-zmq-result.json || FAIL=1
+          echo "BENCH_FAIL=$FAIL" >> "$GITHUB_ENV"
       - name: Show server logs
         if: always()
         run: |
@@ -2199,6 +1979,10 @@ jobs:
             tt-media-server/gw_zmq_decode.log
           retention-days: 1
           if-no-files-found: warn
+
+      - name: Check benchmark result
+        if: always()
+        run: exit "${BENCH_FAIL:-0}"
 
   dynamo-frontend-integration:
     needs: [detect-changes, cpp-build]
@@ -2247,14 +2031,8 @@ jobs:
           name: cpp-server-build
           path: tt-media-server/cpp_server
 
-      - name: Extract C++ build
-        run: |
-          cd cpp_server
-          tar -xzf cpp-server-build.tar.gz
-          rm cpp-server-build.tar.gz
-
-      - name: Make binary executable
-        run: chmod +x cpp_server/build/tt_media_server_cpp
+      - name: Set up C++ build artifact
+        run: bash cpp_server/scripts/ci/setup_cpp_artifact.sh --skip-deps
 
       # No-docker etcd: grab the upstream signed binary tarball from the
       # etcd-io GitHub release. Two cpp_server backends registering under the
@@ -2305,14 +2083,11 @@ jobs:
       - name: Create dynamo venv with ai-dynamo + vllm
         run: |
           mkdir -p "$HOME/.venvs"
-          uv venv --python 3.12 "$HOME/.venvs/dynamo"
-          # vllm is the bench client. transformers<5.6 mirrors the other
-          # cpp-server bench jobs — 5.6.x regresses tokenizer cost and
-          # inflates client-side TTFT/TPOT independently of the backend.
-          uv pip install --python "$HOME/.venvs/dynamo/bin/python" \
-            ai-dynamo uvloop vllm 'transformers<5.6'
-          # Expose vllm on PATH for subsequent bench step.
-          echo "$HOME/.venvs/dynamo/bin" >> "$GITHUB_PATH"
+          bash cpp_server/scripts/ci/install_bench_client.sh \
+            --venv "$HOME/.venvs/dynamo" \
+            --python 3.12 \
+            --package ai-dynamo \
+            --package uvloop
 
       # Two cpp_server backends + one Dynamo frontend. The frontend
       # discovers both backends through the shared etcd store (one instance
@@ -2514,38 +2289,14 @@ jobs:
 
       - name: Check benchmark result
         run: |
-          FILE="vllm-bench-dynamo.json"
-          if [ ! -f "$FILE" ]; then
-            echo "::error::Result file not found: $FILE"
-            exit 1
-          fi
-          COMPLETED=$(jq -r '.completed // 0' "$FILE")
-          FAILED_REQ=$(jq -r '.failed // 0' "$FILE")
-          MEAN_TPOT_MS=$(jq -r '.mean_tpot_ms // 0' "$FILE")
-          MEAN_TTFT_MS=$(jq -r '.mean_ttft_ms // 0' "$FILE")
-          {
-            echo "## Dynamo Frontend + cpp_server Integration"
-            echo ""
-            echo "| Metric | Value |"
-            echo "|--------|-------|"
-            echo "| **completed** | $COMPLETED |"
-            echo "| **failed** | $FAILED_REQ |"
-            echo "| **mean_tpot_ms** | $MEAN_TPOT_MS |"
-            echo "| **mean_ttft_ms** | $MEAN_TTFT_MS |"
-            echo ""
-          } >> $GITHUB_STEP_SUMMARY
           # Integration gate: every request must succeed. Latency is not
           # asserted here — the backend is a mock and the value of this job
           # is proving the wiring (Dynamo frontend -> etcd discovery ->
           # cpp_server TCP transport) works end-to-end.
-          if [ "$FAILED_REQ" -gt 0 ]; then
-            echo "::error::$FAILED_REQ request(s) failed (completed=$COMPLETED)"
-            exit 1
-          fi
-          if [ "$COMPLETED" -lt 1000 ]; then
-            echo "::error::Only $COMPLETED/1000 requests completed"
-            exit 1
-          fi
+          python3 cpp_server/scripts/ci/check_vllm_result.py \
+            --config cpp_server/scripts/ci/vllm_thresholds.json \
+            --scenario dynamo_frontend \
+            --result vllm-bench-dynamo.json
 
       - name: Show server logs
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ scripts/examples/example_data
 !tt-inference-server-v2/test_module/_test_common/targets/*.json
 !release_model_spec.json
 !tt-media-server/static/demos/images.json
+!tt-media-server/cpp_server/scripts/ci/vllm_thresholds.json
 !tt-media-server/monitoring/grafana/**/*.json
 .github/workflows/*.json
 

--- a/tt-media-server/cpp_server/scripts/ci/check_vllm_result.py
+++ b/tt-media-server/cpp_server/scripts/ci/check_vllm_result.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def as_number(value: Any, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    return number if math.isfinite(number) else default
+
+
+def format_value(value: Any) -> str:
+    if value is None:
+        return "N/A"
+    return str(value)
+
+
+def load_scenario(config_path: Path, scenario: str) -> dict[str, Any]:
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    scenarios = config.get("scenarios", {})
+    if scenario not in scenarios:
+        known = ", ".join(sorted(scenarios))
+        raise SystemExit(f"Unknown scenario {scenario!r}. Known scenarios: {known}")
+    return scenarios[scenario]
+
+
+def github_step_summary_path() -> Path | None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return None
+
+    summary = Path(summary_path).resolve(strict=False)
+    runner_temp = Path(os.environ.get("RUNNER_TEMP", tempfile.gettempdir())).resolve(
+        strict=False
+    )
+    if not summary.is_relative_to(runner_temp):
+        raise SystemExit(f"GITHUB_STEP_SUMMARY must be under RUNNER_TEMP: {summary}")
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a vLLM bench serve result JSON."
+    )
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--scenario", required=True)
+    parser.add_argument("--result", required=True, type=Path)
+    args = parser.parse_args()
+
+    scenario = load_scenario(args.config, args.scenario)
+    label = scenario.get("label", args.scenario)
+    if not args.result.exists():
+        print(f"::error::[{label}] Result file not found: {args.result}")
+        return 1
+
+    result = json.loads(args.result.read_text(encoding="utf-8"))
+    completed = int(as_number(result.get("completed"), 0))
+    failed = int(as_number(result.get("failed"), 0))
+    mean_tpot_ms = result.get("mean_tpot_ms")
+    mean_ttft_ms = result.get("mean_ttft_ms")
+
+    failures: list[str] = []
+    min_completed = int(scenario.get("min_completed", 0))
+    max_failed = int(scenario.get("max_failed", 0))
+    max_mean_tpot_ms = scenario.get("max_mean_tpot_ms")
+    max_mean_ttft_ms = scenario.get("max_mean_ttft_ms")
+
+    if completed < min_completed:
+        failures.append(f"completed {completed} is below minimum {min_completed}")
+    if failed > max_failed:
+        failures.append(f"failed {failed} exceeds maximum {max_failed}")
+    if max_mean_tpot_ms is not None and as_number(mean_tpot_ms, float("inf")) > float(
+        max_mean_tpot_ms
+    ):
+        failures.append(
+            f"mean_tpot_ms {mean_tpot_ms} exceeds threshold {max_mean_tpot_ms}ms"
+        )
+    if max_mean_ttft_ms is not None and as_number(mean_ttft_ms, float("inf")) > float(
+        max_mean_ttft_ms
+    ):
+        failures.append(
+            f"mean_ttft_ms {mean_ttft_ms} exceeds threshold {max_mean_ttft_ms}ms"
+        )
+
+    percentile_thresholds = scenario.get("percentile_thresholds", {})
+    for metric, threshold in percentile_thresholds.items():
+        if metric in result and as_number(result.get(metric), float("inf")) > float(
+            threshold
+        ):
+            failures.append(
+                f"{metric} {result.get(metric)} exceeds threshold {threshold}ms"
+            )
+
+    summary = github_step_summary_path()
+    lines = [
+        f"## {label}",
+        "",
+        "| Metric | Value | Threshold |",
+        "|--------|-------|-----------|",
+        f"| **completed** | {completed} | >= {min_completed} |",
+        f"| **failed** | {failed} | <= {max_failed} |",
+        f"| **mean_tpot_ms** | {format_value(mean_tpot_ms)} | <= {format_value(max_mean_tpot_ms)}ms |",
+        f"| **mean_ttft_ms** | {format_value(mean_ttft_ms)} | <= {format_value(max_mean_ttft_ms)}ms |",
+    ]
+    for metric, threshold in percentile_thresholds.items():
+        lines.append(
+            f"| **{metric}** | {format_value(result.get(metric))} | <= {threshold}ms |"
+        )
+    lines.append("")
+    if summary:
+        with summary.open("a", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+            f.write("\n")
+
+    if failures:
+        for failure in failures:
+            print(f"::error::[{label}] {failure}")
+        return 1
+
+    print(f"[{label}] result passed thresholds")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tt-media-server/cpp_server/scripts/ci/install_bench_client.sh
+++ b/tt-media-server/cpp_server/scripts/ci/install_bench_client.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+set -euo pipefail
+
+VENV_PATH=".venv"
+PYTHON_BIN=""
+PACKAGES=(vllm "transformers<5.6")
+
+usage() {
+    cat <<'EOF'
+Usage: install_bench_client.sh [options]
+
+Options:
+  --venv PATH             Virtualenv path (default: .venv)
+  --python PYTHON         Python interpreter for uv (optional)
+  --package PACKAGE       Extra package to install. Can be repeated.
+  --no-default-packages   Do not install vllm and transformers<5.6.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --venv) VENV_PATH="$2"; shift 2 ;;
+        --python) PYTHON_BIN="$2"; shift 2 ;;
+        --package) PACKAGES+=("$2"); shift 2 ;;
+        --no-default-packages) PACKAGES=(); shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [[ -n "$PYTHON_BIN" ]]; then
+    uv venv --python "$PYTHON_BIN" "$VENV_PATH"
+else
+    uv venv "$VENV_PATH"
+fi
+
+if [[ "${#PACKAGES[@]}" -gt 0 ]]; then
+    uv pip install --python "${VENV_PATH}/bin/python" "${PACKAGES[@]}"
+fi
+
+venv_abs="$(cd "$(dirname "$VENV_PATH")" && pwd)/$(basename "$VENV_PATH")"
+echo "PATH=${venv_abs}/bin:${PATH}" >> "$GITHUB_ENV"

--- a/tt-media-server/cpp_server/scripts/ci/setup_cpp_artifact.sh
+++ b/tt-media-server/cpp_server/scripts/ci/setup_cpp_artifact.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+set -euo pipefail
+
+ARTIFACT="cpp_server/cpp-server-build.tar.gz"
+INSTALL_DEPS=1
+
+usage() {
+    cat <<'EOF'
+Usage: setup_cpp_artifact.sh [options]
+
+Options:
+  --artifact PATH         Build artifact tarball (default: cpp_server/cpp-server-build.tar.gz)
+  --skip-deps            Do not install runtime dependencies first
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --artifact) ARTIFACT="$2"; shift 2 ;;
+        --skip-deps) INSTALL_DEPS=0; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [[ "$INSTALL_DEPS" = 1 ]]; then
+    cpp_server/install_dependencies.sh --runtime
+fi
+
+if [[ ! -f "$ARTIFACT" ]]; then
+    echo "::error::C++ build artifact not found: $ARTIFACT"
+    exit 1
+fi
+
+artifact_dir="$(dirname "$ARTIFACT")"
+tar -xzf "$ARTIFACT" -C "$artifact_dir"
+rm -f "$ARTIFACT"
+chmod +x cpp_server/build/tt_media_server_cpp

--- a/tt-media-server/cpp_server/scripts/ci/vllm_thresholds.json
+++ b/tt-media-server/cpp_server/scripts/ci/vllm_thresholds.json
@@ -1,0 +1,72 @@
+{
+  "scenarios": {
+    "cpp_mock": {
+      "label": "C++ Server vLLM Bench (mock)",
+      "min_completed": 1000,
+      "max_failed": 0,
+      "max_mean_tpot_ms": 1,
+      "max_mean_ttft_ms": 150
+    },
+    "cpp_structured_json_object": {
+      "label": "C++ Server vLLM Bench (structured output - json_object)",
+      "min_completed": 1000,
+      "max_failed": 0,
+      "max_mean_tpot_ms": 5,
+      "max_mean_ttft_ms": 150
+    },
+    "cpp_structured_json_schema": {
+      "label": "C++ Server vLLM Bench (structured output - json_schema)",
+      "min_completed": 1000,
+      "max_failed": 0,
+      "max_mean_tpot_ms": 3,
+      "max_mean_ttft_ms": 250
+    },
+    "cpp_mock_pipeline": {
+      "label": "C++ Server vLLM Bench (mock_pipeline)",
+      "min_completed": 1000,
+      "max_failed": 0,
+      "max_mean_tpot_ms": 3,
+      "max_mean_ttft_ms": 395
+    },
+    "prefill_decode_split_tcp": {
+      "label": "C++ Server Prefill/Decode Split (TCP)",
+      "min_completed": 1000,
+      "max_failed": 0,
+      "max_mean_tpot_ms": 10,
+      "max_mean_ttft_ms": 650
+    },
+    "prefill_decode_split_zmq": {
+      "label": "C++ Server Prefill/Decode Split (ZMQ)",
+      "min_completed": 1000,
+      "max_failed": 0,
+      "max_mean_tpot_ms": 10,
+      "max_mean_ttft_ms": 650
+    },
+    "prefill_decode_split_runner": {
+      "label": "C++ Server Prefill/Decode Split (mock_prefill_runner)",
+      "min_completed": 1000,
+      "max_failed": 0,
+      "max_mean_tpot_ms": 10,
+      "max_mean_ttft_ms": 650
+    },
+    "gateway_split_tcp": {
+      "label": "C++ Server Gateway Split (TCP)",
+      "min_completed": 1000,
+      "max_failed": 0,
+      "max_mean_tpot_ms": 10,
+      "max_mean_ttft_ms": 2000
+    },
+    "gateway_split_zmq": {
+      "label": "C++ Server Gateway Split (ZMQ)",
+      "min_completed": 1000,
+      "max_failed": 0,
+      "max_mean_tpot_ms": 10,
+      "max_mean_ttft_ms": 650
+    },
+    "dynamo_frontend": {
+      "label": "Dynamo Frontend + cpp_server Integration",
+      "min_completed": 1000,
+      "max_failed": 0
+    }
+  }
+}

--- a/tt-media-server/cpp_server/scripts/ci/wait_for_liveness.sh
+++ b/tt-media-server/cpp_server/scripts/ci/wait_for_liveness.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+set -euo pipefail
+
+HOST="127.0.0.1"
+PORT=""
+TIMEOUT_SECONDS=30
+INTERVAL_SECONDS=1
+EXPECT='"model_ready":true'
+PID_FILE=""
+LABEL="server"
+
+usage() {
+    cat <<'EOF'
+Usage: wait_for_liveness.sh --port PORT [options]
+
+Options:
+  --host HOST             Host to poll (default: 127.0.0.1)
+  --port PORT             HTTP port to poll (required)
+  --timeout SECONDS       Total wait time (default: 30)
+  --interval SECONDS      Poll interval (default: 1)
+  --expect STRING         String expected in /tt-liveness response
+                           (default: "model_ready":true)
+  --pid-file PATH         Fail early if this process exits
+  --label LABEL           Friendly name for logs/errors
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host) HOST="$2"; shift 2 ;;
+        --port) PORT="$2"; shift 2 ;;
+        --timeout) TIMEOUT_SECONDS="$2"; shift 2 ;;
+        --interval) INTERVAL_SECONDS="$2"; shift 2 ;;
+        --expect) EXPECT="$2"; shift 2 ;;
+        --pid-file) PID_FILE="$2"; shift 2 ;;
+        --label) LABEL="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$PORT" ]]; then
+    echo "--port is required" >&2
+    usage >&2
+    exit 2
+fi
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+last_response=""
+
+while (( SECONDS < deadline )); do
+    if [[ -n "$PID_FILE" && -f "$PID_FILE" ]]; then
+        pid="$(cat "$PID_FILE")"
+        if [[ -n "$pid" ]] && ! kill -0 "$pid" 2>/dev/null; then
+            echo "::error::${LABEL} process ${pid} exited before becoming ready"
+            exit 1
+        fi
+    fi
+
+    last_response="$(curl -sf "http://${HOST}:${PORT}/tt-liveness" 2>/dev/null || true)"
+    if [[ -n "$last_response" ]] && grep -Fq "$EXPECT" <<<"$last_response"; then
+        echo "${LABEL} ready on ${HOST}:${PORT}."
+        exit 0
+    fi
+    sleep "$INTERVAL_SECONDS"
+done
+
+echo "::error::${LABEL} did not become ready on ${HOST}:${PORT} within ${TIMEOUT_SECONDS}s"
+if [[ -n "$last_response" ]]; then
+    echo "Last /tt-liveness response:"
+    printf '%s\n' "$last_response"
+fi
+exit 1

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -28,7 +28,7 @@ void DisaggregationService::setupSocketHandlers() {
                                            double /*cpu*/, double /*memory*/,
                                            int tasks) {
     TT_LOG_INFO(
-        "[DisaggregationService] Health check from {} (active_tasks={})",
+        "[DisaggregationService]  Health check from {} (active_tasks={})",
         serverId, tasks);
   });
 


### PR DESCRIPTION
Adds reusable helper scripts for C++ CI benchmark jobs and updates `test-gate` to use them for:
- C++ build artifact extraction
- benchmark client venv setup
- server liveness polling
- vLLM benchmark threshold validation
Also adds a tracked `vllm_thresholds.json` config and the `.gitignore` exception needed for it.
