### PR TITLE
Bump tt-forge to 1.2.0.dev20260524002812

### DIFF
--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
-tt-forge==1.1.0
+tt-forge==1.2.0.dev20260524002812
 torchvision
 
 tabulate


### PR DESCRIPTION
Automated version bump of `tt-forge` to `1.2.0.dev20260524002812` in `tt-media-server/tt_model_runners/forge_runners/requirements.txt`, triggered by the tt-xla `Stable version release` workflow.

### Checklist

- [ ] `resnet-50`: https://github.com/tenstorrent/tt-shield/actions/runs/26454495933
