### PR TITLE
suppress stb warnings

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -268,7 +268,7 @@ if(NOT stb_POPULATED)
     FetchContent_Populate(stb)
 endif()
 add_library(stb_image_write INTERFACE)
-target_include_directories(stb_image_write INTERFACE ${stb_SOURCE_DIR})
+target_include_directories(stb_image_write SYSTEM INTERFACE ${stb_SOURCE_DIR})
 
 # Tokenizer (mlc-ai/tokenizers-cpp). Requires Rust.
 set(MLC_ENABLE_SENTENCEPIECE_TOKENIZER ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
`INTERFACE` means the include path is passed to any target that links against _stb_image_write_ (since it's a header-only library with no compiled code of its own).                                                                                           

  `SYSTEM` is an additional modifier that tells the compiler to use **-isystem** instead of **-I**. This marks the headers as "system headers"

  What that means in practice:
  - Compiler suppresses warnings originating from those headers
  - Code that uses STB still gets full warnings
  - Only warnings inside STB's implementation are silenced
  
  
###  outcome
  Suppressing these warnings: 

> In file included from /localdev/lmuravljov/tt-inference-server/tt-media-server/cpp_server/src/utils/image_codec.cpp:8:                    
>   /localdev/lmuravljov/tt-inference-server/tt-media-server/cpp_server/build/_deps/stb-src/stb_image_write.h: In function 'int               
>   stbi_write_bmp_to_func(void (*)(void*, void*, int), void*, int, int, int, const void*)':                                                  
>   /localdev/lmuravljov/tt-inference-server/tt-media-server/cpp_server/build/_deps/stb-src/stb_image_write.h:514:32: warning: missing        
>   initializer for member 'stbi__write_context::context' [-Wmissing-field-initializers]                                                      
>     514 |    stbi__write_context s = { 0 };                                                                                                 
>         |                                ^                                                                                                  
>   /localdev/lmuravljov/tt-inference-server/tt-media-server/cpp_server/build/_deps/stb-src/stb_image_write.h:514:32: warning: missing        
>   initializer for member 'stbi__write_context::buffer' [-Wmissing-field-initializers]                                                       
>   /localdev/lmuravljov/tt-inference-server/tt-media-server/cpp_server/build/_deps/stb-src/stb_image_write.h:514:32: warning: missing        
>   initializer for member 'stbi__write_context::buf_used' [-Wmissing-field-initializers]                                                     
>   /localdev/lmuravljov/tt-inference-server/tt-media-server/cpp_server/build/_deps/stb-src/stb_image_write.h: In function 'int               
>   stbi_write_tga_to_func(void (*)(void*, void*, int), void*, int, int, int, const void*)':                                                  
>   /localdev/lmuravljov/tt-inference-server/tt-media-server/cpp_server/build/_deps/stb-src/stb_image_write.h:613:32: warning: missing        
>   initializer for member 'stbi__write_context::context' [-Wmissing-field-initializers]                                                      
>     613 |    stbi__write_context s = { 0 };                                                                                                 
>         |                                ^                                                                                                  
>   /localdev/lmuravljov/tt-inference-server/tt-media-server/cpp_server/build/_deps/stb-src/stb_image_write.h:613:32: warning: missing        
>   initializer for member 'stbi__write_context::buffer' [-Wmissing-field-initializers]                                                       
>   /localdev/lmuravljov/tt-inference-server/tt-media-server/cpp_server/build/_deps/stb-src/stb_image_write.h:613:32: warning: missing        
>   initializer for member 'stbi__write_context::buf_used' [-Wmissing-field-initializers]                                                     
>   /localdev/lmuravljov/tt-inference-server/tt-media-server/cpp_server/build/_deps/stb-src/stb_image_write.h: In function 'int               
>   stbi_write_jpg_to_func(void (*)(void*, void*, int), void*, int, int, int, const void*, int)':                                             
>   /localdev/lmuravljov/tt-inference-server/tt-media-server/cpp_server/build/_deps/stb-src/stb_image_write.h:1609:32: warning: missing       
>   initializer for member 'stbi__write_context::context' [-Wmissing-field-initializers]                                                      
>    1609 |    stbi__write_context s = { 0 };                                                                                                 
>         |                                ^                                                                                                  
>   /localdev/lmuravljov/tt-inference-server/tt-media-server/cpp_server/build/_deps/stb-src/stb_image_write.h:1609:32: warning: missing       
>   initializer for member 'stbi__write_context::buffer' [-Wmissing-field-initializers]                                                       
>   /localdev/lmuravljov/tt-inference-server/tt-media-server/cpp_server/build/_deps/stb-src/stb_image_write.h:1609:32: warning: missing       
>   initializer for member 'stbi__write_context::buf_used' [-Wmissing-field-initializers]