### PR TITLE
Use jthread for gateway and socket background loops

### DIFF
--- a/tt-media-server/cpp_server/include/sockets/inter_server_service.hpp
+++ b/tt-media-server/cpp_server/include/sockets/inter_server_service.hpp
@@ -176,10 +176,9 @@ class InterServerService {
   bool enabled_ = false;
   bool gateway_mode_ = false;
   bool periodic_registration_mode_ = false;
-  bool registration_stop_ = false;
   std::mutex registration_mutex_;
   std::condition_variable registration_cv_;
-  std::thread registration_thread_;
+  std::jthread registration_thread_;
 };
 
 }  // namespace tt::sockets

--- a/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <map>
 #include <mutex>
+#include <stop_token>
 #include <string>
 #include <thread>
 #include <vector>
@@ -103,7 +104,7 @@ class SocketManager {
   void setReconnectBackoff(uint32_t initialDelayMs, uint32_t maxDelayMs);
 
  private:
-  void messageLoop();
+  void messageLoop(std::stop_token stopToken);
   void handleIncomingMessage(const std::vector<uint8_t>& data);
   std::function<void(const std::vector<uint8_t>&)> getHandler(
       const std::string& messageType) const;
@@ -111,7 +112,7 @@ class SocketManager {
   std::unique_ptr<ISocketTransport> transport_;
 
   std::atomic<bool> running_{false};
-  std::thread messageThread_;
+  std::jthread messageThread_;
 
   mutable std::mutex handlersMutex_;
   std::map<std::string, std::function<void(const std::vector<uint8_t>&)>>

--- a/tt-media-server/cpp_server/include/sockets/tcp_socket_transport.hpp
+++ b/tt-media-server/cpp_server/include/sockets/tcp_socket_transport.hpp
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <functional>
 #include <mutex>
+#include <stop_token>
 #include <string>
 #include <thread>
 #include <vector>
@@ -58,8 +59,8 @@ class TcpSocketTransport : public ISocketTransport,
  private:
   enum class ReceiveResult { COMPLETE, NO_DATA, DISCONNECTED };
 
-  void serverLoop();
-  void clientLoop();
+  void serverLoop(std::stop_token stopToken);
+  void clientLoop(std::stop_token stopToken);
   bool sendAll(int fd, const void* buffer, size_t size);
   ReceiveResult receiveExact(int fd, uint8_t* buffer, size_t size,
                              int maxRetries, bool returnIfNoInitialData);
@@ -71,7 +72,7 @@ class TcpSocketTransport : public ISocketTransport,
   tt::utils::ScopedFd clientSocket_;
   std::atomic<int> peerSocket_{-1};
 
-  std::thread connectionThread_;
+  std::jthread connectionThread_;
 
   mutable std::mutex socketMutex_;
 };

--- a/tt-media-server/cpp_server/include/sockets/zmq_socket_transport.hpp
+++ b/tt-media-server/cpp_server/include/sockets/zmq_socket_transport.hpp
@@ -10,6 +10,7 @@
 #include <future>
 #include <memory>
 #include <mutex>
+#include <stop_token>
 #include <string>
 #include <thread>
 #include <vector>
@@ -65,10 +66,10 @@ class ZmqSocketTransport : public ISocketTransport,
   };
 
   bool startIoThread();
-  void ioLoop(std::promise<bool> initialized);
+  void ioLoop(std::stop_token stopToken, std::promise<bool> initialized);
   bool initializeSocket();
   void setupMonitor();
-  void monitorLoop(std::promise<void> ready);
+  void monitorLoop(std::stop_token stopToken, std::promise<void> ready);
   bool processPendingSends();
   bool receiveAvailableMessages();
   void waitForIoWork();
@@ -90,8 +91,8 @@ class ZmqSocketTransport : public ISocketTransport,
   std::atomic<bool> ioActive_{false};
   std::atomic<bool> monitorActive_{false};
 
-  std::thread ioThread_;
-  std::thread monitorThread_;
+  std::jthread ioThread_;
+  std::jthread monitorThread_;
 
   std::vector<uint8_t>
       peerId_;  // ROUTER stores the connected DEALER's identity.

--- a/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
+++ b/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
@@ -319,30 +319,23 @@ void InterServerService::sendRegistrationIfGatewayModeIsEnabled() {
 
 void InterServerService::startRegistrationThread() {
   stopRegistrationThread();
-  {
-    std::lock_guard<std::mutex> lock(registration_mutex_);
-    registration_stop_ = false;
-  }
 
-  registration_thread_ = std::thread([this] {
-    std::unique_lock<std::mutex> lock(registration_mutex_);
-    while (!registration_stop_) {
-      lock.unlock();
+  registration_thread_ = std::jthread([this](std::stop_token stopToken) {
+    while (!stopToken.stop_requested()) {
       if (socket_manager_.isConnected()) {
         sendRegistration();
       }
-      lock.lock();
-      registration_cv_.wait_for(lock, REGISTRATION_INTERVAL,
-                                [this] { return registration_stop_; });
+
+      std::unique_lock<std::mutex> lock(registration_mutex_);
+      registration_cv_.wait_for(lock, REGISTRATION_INTERVAL, [&stopToken] {
+        return stopToken.stop_requested();
+      });
     }
   });
 }
 
 void InterServerService::stopRegistrationThread() {
-  {
-    std::lock_guard<std::mutex> lock(registration_mutex_);
-    registration_stop_ = true;
-  }
+  registration_thread_.request_stop();
   registration_cv_.notify_all();
   if (registration_thread_.joinable()) {
     registration_thread_.join();

--- a/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
+++ b/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
@@ -50,7 +50,8 @@ void SocketManager::start() {
 
   running_ = true;
   transport_->start();
-  messageThread_ = std::thread(&SocketManager::messageLoop, this);
+  messageThread_ = std::jthread(
+      [this](std::stop_token stopToken) { messageLoop(stopToken); });
 }
 
 void SocketManager::stop() {
@@ -61,6 +62,7 @@ void SocketManager::stop() {
   running_ = false;
 
   if (messageThread_.joinable()) {
+    messageThread_.request_stop();
     messageThread_.join();
   }
 
@@ -71,8 +73,8 @@ void SocketManager::stop() {
   TT_LOG_INFO("[SocketManager] Stopped");
 }
 
-void SocketManager::messageLoop() {
-  while (running_) {
+void SocketManager::messageLoop(std::stop_token stopToken) {
+  while (running_ && !stopToken.stop_requested()) {
     try {
       auto data = transport_->receiveRawData();
       if (!data.empty()) {

--- a/tt-media-server/cpp_server/src/sockets/tcp_socket_transport.cpp
+++ b/tt-media-server/cpp_server/src/sockets/tcp_socket_transport.cpp
@@ -171,9 +171,11 @@ void TcpSocketTransport::start() {
   running_ = true;
 
   if (mode_ == Mode::SERVER) {
-    connectionThread_ = std::thread(&TcpSocketTransport::serverLoop, this);
+    connectionThread_ = std::jthread(
+        [this](std::stop_token stopToken) { serverLoop(stopToken); });
   } else {
-    connectionThread_ = std::thread(&TcpSocketTransport::clientLoop, this);
+    connectionThread_ = std::jthread(
+        [this](std::stop_token stopToken) { clientLoop(stopToken); });
   }
 }
 
@@ -199,6 +201,7 @@ void TcpSocketTransport::stop() {
   }
 
   if (connectionThread_.joinable()) {
+    connectionThread_.request_stop();
     connectionThread_.join();
   }
 
@@ -211,8 +214,8 @@ void TcpSocketTransport::stop() {
   TT_LOG_INFO("[TcpSocketTransport] Stopped");
 }
 
-void TcpSocketTransport::serverLoop() {
-  while (running_) {
+void TcpSocketTransport::serverLoop(std::stop_token stopToken) {
+  while (running_ && !stopToken.stop_requested()) {
     TT_LOG_INFO("[TcpSocketTransport] Waiting for client connection...");
 
     struct sockaddr_in clientAddr;
@@ -221,7 +224,7 @@ void TcpSocketTransport::serverLoop() {
     tt::utils::ScopedFd accepted =
         acceptClient(serverSocket_.get(), &clientAddr, &clientLen);
     if (!accepted) {
-      if (running_) {
+      if (running_ && !stopToken.stop_requested()) {
         TT_LOG_ERROR("[TcpSocketTransport] Accept failed: {}", strerror(errno));
       }
       break;
@@ -236,7 +239,7 @@ void TcpSocketTransport::serverLoop() {
                 inet_ntoa(clientAddr.sin_addr), ntohs(clientAddr.sin_port));
     notifyConnectionEstablished();
 
-    while (running_ && connected_) {
+    while (running_ && connected_ && !stopToken.stop_requested()) {
       std::this_thread::sleep_for(CONNECTION_POLL_INTERVAL);
     }
 
@@ -252,14 +255,14 @@ void TcpSocketTransport::serverLoop() {
   }
 }
 
-void TcpSocketTransport::clientLoop() {
+void TcpSocketTransport::clientLoop(std::stop_token stopToken) {
   uint32_t delayMs = reconnectInitialDelayMs_;
   auto backoff = [&]() {
     std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
     delayMs = std::min(delayMs * 2, reconnectMaxDelayMs_);
   };
 
-  while (running_) {
+  while (running_ && !stopToken.stop_requested()) {
     clientSocket_ = createTcpSocket();
     if (!clientSocket_) {
       TT_LOG_ERROR("[TcpSocketTransport] Failed to create client socket: {}",
@@ -301,7 +304,7 @@ void TcpSocketTransport::clientLoop() {
     TT_LOG_INFO("[TcpSocketTransport] Connected to server");
     notifyConnectionEstablished();
 
-    while (running_ && connected_) {
+    while (running_ && connected_ && !stopToken.stop_requested()) {
       std::this_thread::sleep_for(CONNECTION_POLL_INTERVAL);
     }
 

--- a/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
+++ b/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
@@ -52,17 +52,21 @@ bool ZmqSocketTransport::startIoThread() {
 
   std::promise<bool> initialized;
   auto fut = initialized.get_future();
-  ioThread_ =
-      std::thread(&ZmqSocketTransport::ioLoop, this, std::move(initialized));
+  ioThread_ = std::jthread([this, initialized = std::move(initialized)](
+                               std::stop_token stopToken) mutable {
+    ioLoop(stopToken, std::move(initialized));
+  });
 
   bool initializedOk = fut.get();
   if (!initializedOk && ioThread_.joinable()) {
+    ioThread_.request_stop();
     ioThread_.join();
   }
   return initializedOk;
 }
 
-void ZmqSocketTransport::ioLoop(std::promise<bool> initialized) {
+void ZmqSocketTransport::ioLoop(std::stop_token stopToken,
+                                std::promise<bool> initialized) {
   if (!initializeSocket()) {
     initialized.set_value(false);
     return;
@@ -70,7 +74,7 @@ void ZmqSocketTransport::ioLoop(std::promise<bool> initialized) {
 
   initialized.set_value(true);
 
-  while (ioActive_) {
+  while (ioActive_ && !stopToken.stop_requested()) {
     const bool sent = processPendingSends();
     const bool received = receiveAvailableMessages();
 
@@ -114,6 +118,7 @@ bool ZmqSocketTransport::initializeSocket() {
     ioActive_ = false;
     monitorActive_ = false;
     if (monitorThread_.joinable()) {
+      monitorThread_.request_stop();
       monitorThread_.join();
     }
     return false;
@@ -137,8 +142,10 @@ void ZmqSocketTransport::setupMonitor() {
   monitorActive_ = true;
   std::promise<void> ready;
   auto fut = ready.get_future();
-  monitorThread_ =
-      std::thread(&ZmqSocketTransport::monitorLoop, this, std::move(ready));
+  monitorThread_ = std::jthread(
+      [this, ready = std::move(ready)](std::stop_token stopToken) mutable {
+        monitorLoop(stopToken, std::move(ready));
+      });
   fut.wait();
 }
 
@@ -161,10 +168,12 @@ void ZmqSocketTransport::stop() {
   sendCv_.notify_all();
 
   if (ioThread_.joinable()) {
+    ioThread_.request_stop();
     ioThread_.join();
   }
 
   if (monitorThread_.joinable()) {
+    monitorThread_.request_stop();
     monitorThread_.join();
   }
 
@@ -175,7 +184,8 @@ void ZmqSocketTransport::stop() {
   TT_LOG_INFO("[ZmqSocketTransport] Stopped");
 }
 
-void ZmqSocketTransport::monitorLoop(std::promise<void> ready) {
+void ZmqSocketTransport::monitorLoop(std::stop_token stopToken,
+                                     std::promise<void> ready) {
   zmq::socket_t monitorSocket(*context_, zmq::socket_type::pair);
   try {
     monitorSocket.set(zmq::sockopt::linger, 0);
@@ -188,7 +198,7 @@ void ZmqSocketTransport::monitorLoop(std::promise<void> ready) {
   }
   ready.set_value();
 
-  while (monitorActive_) {
+  while (monitorActive_ && !stopToken.stop_requested()) {
     try {
       zmq::message_t eventMsg;
       auto eventResult = monitorSocket.recv(eventMsg, zmq::recv_flags::none);

--- a/tt-media-server/prefill_gateway/include/gateway/zmq_prefill_router.hpp
+++ b/tt-media-server/prefill_gateway/include/gateway/zmq_prefill_router.hpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <stop_token>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -61,7 +62,7 @@ class ZmqPrefillRouter {
   static std::string peerKey(const PeerIdentity& peerId);
 
   bool startIoThread();
-  void ioLoop(std::promise<bool> initialized);
+  void ioLoop(std::stop_token stopToken, std::promise<bool> initialized);
   bool initializeSocket();
   bool processPendingSends();
   bool receiveAvailableMessages();
@@ -78,7 +79,7 @@ class ZmqPrefillRouter {
   std::unique_ptr<Impl> impl_;
 
   std::atomic<bool> running_{false};
-  std::thread io_thread_;
+  std::jthread io_thread_;
 
   mutable std::mutex peer_mutex_;
   std::unordered_map<std::string, PeerIdentity> server_to_peer_;

--- a/tt-media-server/prefill_gateway/src/main.cpp
+++ b/tt-media-server/prefill_gateway/src/main.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
-#include <atomic>
 #include <chrono>
 #include <csignal>
 #include <cstdint>
@@ -9,6 +8,7 @@
 #include <iostream>
 #include <memory>
 #include <optional>
+#include <stop_token>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -296,26 +296,26 @@ int main(int argc, char** argv) {
   for (auto& sm : prefillSms) sm->start();
   decodeSm.start();
 
-  std::atomic<bool> proberStop{false};
   constexpr auto probeIntervalMs = std::chrono::milliseconds(1000);
-  std::thread proberThread([&prefillSms, &proberStop, probeIntervalMs]() {
-    while (!proberStop.load()) {
-      for (auto& sm : prefillSms) {
-        sm->sendObject(tt::sockets::tags::REGISTRATION_PROBE,
-                       tt::sockets::RegistrationProbeMessage{});
-      }
-      std::this_thread::sleep_for(probeIntervalMs);
-    }
-  });
+  std::jthread proberThread(
+      [&prefillSms, probeIntervalMs](std::stop_token stopToken) {
+        while (!stopToken.stop_requested()) {
+          for (auto& sm : prefillSms) {
+            sm->sendObject(tt::sockets::tags::REGISTRATION_PROBE,
+                           tt::sockets::RegistrationProbeMessage{});
+          }
+          std::this_thread::sleep_for(probeIntervalMs);
+        }
+      });
 
-  std::atomic<bool> watchdogStop{false};
   const auto prefillStaleTimeout =
       std::chrono::milliseconds(cfg.prefillStaleTimeoutMs);
-  std::thread watchdogThread;
+  std::jthread watchdogThread;
   if (useZmqPrefillRouter) {
-    watchdogThread = std::thread(
-        [&registry, &zmqPrefillRouter, &watchdogStop, prefillStaleTimeout] {
-          while (!watchdogStop.load()) {
+    watchdogThread =
+        std::jthread([&registry, &zmqPrefillRouter,
+                      prefillStaleTimeout](std::stop_token stopToken) {
+          while (!stopToken.stop_requested()) {
             for (const auto& serverId :
                  zmqPrefillRouter.takeStaleServers(prefillStaleTimeout)) {
               TT_LOG_WARN("[Gateway] Prefill '{}' registration timed out",
@@ -337,9 +337,9 @@ int main(int argc, char** argv) {
   }
 
   TT_LOG_INFO("[Gateway] Shutting down…");
-  proberStop = true;
+  proberThread.request_stop();
   if (proberThread.joinable()) proberThread.join();
-  watchdogStop = true;
+  watchdogThread.request_stop();
   if (watchdogThread.joinable()) watchdogThread.join();
   decodeSm.stop();
   for (auto& sm : prefillSms) sm->stop();

--- a/tt-media-server/prefill_gateway/src/zmq_prefill_router.cpp
+++ b/tt-media-server/prefill_gateway/src/zmq_prefill_router.cpp
@@ -56,6 +56,7 @@ void ZmqPrefillRouter::stop() {
   send_cv_.notify_all();
 
   if (io_thread_.joinable()) {
+    io_thread_.request_stop();
     io_thread_.join();
   }
 
@@ -130,16 +131,20 @@ std::optional<ZmqPrefillRouter::PeerIdentity> ZmqPrefillRouter::peerIdForServer(
 bool ZmqPrefillRouter::startIoThread() {
   std::promise<bool> initialized;
   auto fut = initialized.get_future();
-  io_thread_ =
-      std::thread(&ZmqPrefillRouter::ioLoop, this, std::move(initialized));
+  io_thread_ = std::jthread([this, initialized = std::move(initialized)](
+                                std::stop_token stopToken) mutable {
+    ioLoop(stopToken, std::move(initialized));
+  });
   bool initializedOk = fut.get();
   if (!initializedOk && io_thread_.joinable()) {
+    io_thread_.request_stop();
     io_thread_.join();
   }
   return initializedOk;
 }
 
-void ZmqPrefillRouter::ioLoop(std::promise<bool> initialized) {
+void ZmqPrefillRouter::ioLoop(std::stop_token stopToken,
+                              std::promise<bool> initialized) {
   if (!initializeSocket()) {
     initialized.set_value(false);
     return;
@@ -147,7 +152,7 @@ void ZmqPrefillRouter::ioLoop(std::promise<bool> initialized) {
 
   initialized.set_value(true);
 
-  while (running_) {
+  while (running_ && !stopToken.stop_requested()) {
     const bool sent = processPendingSends();
     const bool received = receiveAvailableMessages();
     if (!sent && !received) {


### PR DESCRIPTION
- Replace manually managed `std::thread` lifecycle loops with `std::jthread` and `std::stop_token` in gateway/socket components.
- Simplify shutdown for ZMQ/TCP transports, socket manager, registration loop, and gateway prober/watchdog loops.
