### PR TITLE
Enable Kimi K2.6 Tokenization with Dynamo Frontend

### DIFF
--- a/dynamo_frontend/deploy.sh
+++ b/dynamo_frontend/deploy.sh
@@ -33,8 +33,10 @@ Optional:
                               (default: "10,11,14,15,18,19,22,23" — the
                               local 8-device DeepSeek-R1 mesh)
   --tokenizers-host-dir <dir> host directory containing the tokenizers tree
-                              (must hold <hf-model-id>/{config,tokenizer,
-                              tokenizer_config}.json). Bind-mounted into the
+                              (must hold <hf-model-id>/config.json,
+                              tokenizer_config.json, and either tokenizer.json
+                              or tiktoken.model for tiktoken-based models such
+                              as Kimi K2.6). Bind-mounted into the
                               frontend at the path the worker advertises in
                               the MDC. (default: auto — extracts tokenizer
                               assets out of the worker image into a host
@@ -298,19 +300,41 @@ if [[ -z "$SKIP_TOKENIZER_SHARE" ]]; then
             "https://huggingface.co/${HF_MODEL_ID}/raw/main/config.json" \
             -o "$MODEL_SUBDIR/config.json" 2>/dev/null; then
             log "  HF fetch failed; writing a minimal placeholder config.json"
-            cat > "$MODEL_SUBDIR/config.json" <<'CONF'
+            if [[ "$HF_MODEL_ID" == *Kimi* || "$HF_MODEL_ID" == *kimi* ]]; then
+                cat > "$MODEL_SUBDIR/config.json" <<'CONF'
+{"model_type":"kimi_k25","architectures":["KimiK25ForConditionalGeneration"]}
+CONF
+            else
+                cat > "$MODEL_SUBDIR/config.json" <<'CONF'
 {"model_type":"deepseek_v3","architectures":["DeepseekV3ForCausalLM"]}
 CONF
+            fi
         fi
     fi
 
-    for f in config.json tokenizer.json tokenizer_config.json; do
+    for f in config.json tokenizer_config.json; do
         if [[ ! -f "$MODEL_SUBDIR/$f" ]]; then
             log "missing $f under $MODEL_SUBDIR"
             log "  the worker's MDC will advertise a path the frontend can't read"
             exit 1
         fi
     done
+    if [[ ! -f "$MODEL_SUBDIR/tokenizer.json" && ! -f "$MODEL_SUBDIR/tiktoken.model" ]]; then
+        log "missing tokenizer.json or tiktoken.model under $MODEL_SUBDIR"
+        log "  the worker's MDC will advertise a path the frontend can't read"
+        exit 1
+    fi
+    if [[ "$HF_MODEL_ID" == *Kimi* || "$HF_MODEL_ID" == *kimi* ]]; then
+        if [[ ! -f "$MODEL_SUBDIR/chat_template.jinja" ]]; then
+            log "fetching $HF_MODEL_ID/chat_template.jinja from HuggingFace"
+            curl -fsSL --max-time 30 \
+                "https://huggingface.co/${HF_MODEL_ID}/raw/main/chat_template.jinja" \
+                -o "$MODEL_SUBDIR/chat_template.jinja" || {
+                log "missing chat_template.jinja under $MODEL_SUBDIR"
+                exit 1
+            }
+        fi
+    fi
 
     log "mounting tokenizers: $TOKENIZERS_HOST_DIR_ABS -> $WORKER_TOKENIZER_DIR"
     log "  using $HF_MODEL_ID:"

--- a/dynamo_frontend/deploy.sh
+++ b/dynamo_frontend/deploy.sh
@@ -291,48 +291,24 @@ if [[ -z "$SKIP_TOKENIZER_SHARE" ]]; then
     MODEL_SUBDIR="$TOKENIZERS_HOST_DIR_ABS/$HF_MODEL_ID"
     mkdir -p "$MODEL_SUBDIR"
 
-    # Backfill config.json. cpp_server/build.sh's pre-fetch grabs only
-    # tokenizer{.json,_config.json}, so the image ships without the HF
-    # model config. Frontend's model_card loader needs it.
-    if [[ ! -f "$MODEL_SUBDIR/config.json" ]]; then
-        log "fetching $HF_MODEL_ID/config.json from HuggingFace"
-        if ! curl -fsSL --max-time 30 \
-            "https://huggingface.co/${HF_MODEL_ID}/raw/main/config.json" \
-            -o "$MODEL_SUBDIR/config.json" 2>/dev/null; then
-            log "  HF fetch failed; writing a minimal placeholder config.json"
-            if [[ "$HF_MODEL_ID" == *Kimi* || "$HF_MODEL_ID" == *kimi* ]]; then
-                cat > "$MODEL_SUBDIR/config.json" <<'CONF'
-{"model_type":"kimi_k25","architectures":["KimiK25ForConditionalGeneration"]}
-CONF
-            else
-                cat > "$MODEL_SUBDIR/config.json" <<'CONF'
-{"model_type":"deepseek_v3","architectures":["DeepseekV3ForCausalLM"]}
-CONF
-            fi
-        fi
-    fi
-
+    # Validate required tokenizer files exist (expected to be in worker image)
     for f in config.json tokenizer_config.json; do
         if [[ ! -f "$MODEL_SUBDIR/$f" ]]; then
             log "missing $f under $MODEL_SUBDIR"
-            log "  the worker's MDC will advertise a path the frontend can't read"
+            log "  ensure tokenizer files are included in the worker image"
             exit 1
         fi
     done
     if [[ ! -f "$MODEL_SUBDIR/tokenizer.json" && ! -f "$MODEL_SUBDIR/tiktoken.model" ]]; then
         log "missing tokenizer.json or tiktoken.model under $MODEL_SUBDIR"
-        log "  the worker's MDC will advertise a path the frontend can't read"
+        log "  ensure tokenizer files are included in the worker image"
         exit 1
     fi
     if [[ "$HF_MODEL_ID" == *Kimi* || "$HF_MODEL_ID" == *kimi* ]]; then
         if [[ ! -f "$MODEL_SUBDIR/chat_template.jinja" ]]; then
-            log "fetching $HF_MODEL_ID/chat_template.jinja from HuggingFace"
-            curl -fsSL --max-time 30 \
-                "https://huggingface.co/${HF_MODEL_ID}/raw/main/chat_template.jinja" \
-                -o "$MODEL_SUBDIR/chat_template.jinja" || {
-                log "missing chat_template.jinja under $MODEL_SUBDIR"
-                exit 1
-            }
+            log "missing chat_template.jinja under $MODEL_SUBDIR"
+            log "  ensure tokenizer files are included in the worker image"
+            exit 1
         fi
     fi
 

--- a/tt-media-server/cpp_server/build.sh
+++ b/tt-media-server/cpp_server/build.sh
@@ -249,6 +249,54 @@ download_tokenizer() {
     fi
 }
 
+# Kimi K2.x ships a tiktoken BPE vocab (tiktoken.model), not tokenizer.json.
+# Dynamo's model_card loader accepts tiktoken.model; the chat template lives in
+# chat_template.jinja (see dynamo/lib/llm/src/model_card.rs TokenizerKind::from_disk).
+download_kimi_tokenizer() {
+    local model_name="moonshotai/Kimi-K2.6"
+    local hf_repo="https://huggingface.co/moonshotai/Kimi-K2.6/raw/main"
+    local model_dir="${TOKENIZER_DIR}/${model_name}"
+    local tiktoken_model="${model_dir}/tiktoken.model"
+    local tok_config="${model_dir}/tokenizer_config.json"
+    local model_config="${model_dir}/config.json"
+    local chat_template="${model_dir}/chat_template.jinja"
+    local placeholder_config_json='{"model_type":"kimi_k25","architectures":["KimiK25ForConditionalGeneration"]}'
+
+    if [ -f "${tiktoken_model}" ] && [ -f "${tok_config}" ] && [ -f "${model_config}" ] \
+        && [ -f "${chat_template}" ]; then
+        echo "  Using existing ${model_name} tokenizer + config."
+        return 0
+    fi
+
+    mkdir -p "${model_dir}"
+    echo "Downloading ${model_name} tokenizer (tiktoken + chat template)..."
+
+    for f in tiktoken.model tokenizer_config.json chat_template.jinja; do
+        local dest="${model_dir}/${f}"
+        if [ -f "${dest}" ]; then
+            continue
+        fi
+        if wget -q -O "${dest}" "${hf_repo}/${f}" 2>&1; then
+            echo "  ${f} downloaded to ${dest}"
+        else
+            rm -f "${dest}"
+            echo "  ERROR: Failed to download ${model_name}/${f}."
+            echo "  URL: ${hf_repo}/${f}"
+            return 1
+        fi
+    done
+
+    if [ ! -f "${model_config}" ]; then
+        if wget -q -O "${model_config}" "${hf_repo}/config.json" 2>&1; then
+            echo "  config.json downloaded to ${model_config}"
+        else
+            rm -f "${model_config}"
+            echo "  config.json HF fetch failed; writing minimal placeholder."
+            printf '%s\n' "${placeholder_config_json}" > "${model_config}"
+        fi
+    fi
+}
+
 echo ""
 echo "Pre-fetching tokenizer files for supported models..."
 
@@ -268,6 +316,9 @@ download_tokenizer \
     "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/raw/main" \
     "true" \
     '{"model_type":"llama","architectures":["LlamaForCausalLM"]}'
+
+# Kimi K2.6 (public tiktoken tokenizer + jinja chat template; no tokenizer.json on HF)
+download_kimi_tokenizer
 
 echo ""
 

--- a/tt-media-server/cpp_server/build.sh
+++ b/tt-media-server/cpp_server/build.sh
@@ -169,28 +169,18 @@ if [ -z "${HF_TOKEN_RESOLVED}" ] && [ -f "${HOME}/.cache/huggingface/token" ]; t
     HF_TOKEN_RESOLVED=$(cat "${HOME}/.cache/huggingface/token")
 fi
 
-download_tokenizer() {
-    local model_name="$1"
-    local hf_repo="$2"
+# Download a single file from HuggingFace with optional auth.
+# Args: dest_path hf_url requires_auth model_name
+# Returns 0 on success, 1 on failure.
+download_hf_file() {
+    local dest="$1"
+    local url="$2"
     local requires_auth="$3"
-    # Optional 4th arg: minimal placeholder config.json body. Used when HF
-    # is unreachable so the artifact is still self-contained (the cpp_server
-    # itself doesn't need config.json, but Dynamo's frontend loader does —
-    # see dynamo_frontend/deploy.sh for the canonical backfill).
-    local placeholder_config_json="${4:-}"
+    local model_name="$4"
+    local filename
+    filename=$(basename "${dest}")
 
-    local model_dir="${TOKENIZER_DIR}/${model_name}"
-    local tok_json="${model_dir}/tokenizer.json"
-    local tok_config="${model_dir}/tokenizer_config.json"
-    local model_config="${model_dir}/config.json"
-
-    if [ -f "${tok_json}" ] && [ -f "${tok_config}" ] && [ -f "${model_config}" ]; then
-        echo "  Using existing ${model_name} tokenizer + config."
-        return 0
-    fi
-
-    if [ "${requires_auth}" = "true" ] && [ -z "${HF_TOKEN_RESOLVED}" ]; then
-        echo "  Skipping ${model_name} (gated model — set HF_TOKEN to download)."
+    if [ -f "${dest}" ]; then
         return 0
     fi
 
@@ -199,100 +189,87 @@ download_tokenizer() {
         wget_args=(--header "Authorization: Bearer ${HF_TOKEN_RESOLVED}")
     fi
 
-    mkdir -p "${model_dir}"
-
-    echo "Downloading ${model_name} tokenizer..."
-    if [ ! -f "${tok_json}" ]; then
-        if wget -q "${wget_args[@]}" -O "${tok_json}" "${hf_repo}/tokenizer.json" 2>&1; then
-            echo "  tokenizer.json downloaded to ${tok_json}"
-        else
-            rm -f "${tok_json}"
-            echo "  ERROR: Failed to download ${model_name} tokenizer.json."
-            echo "  URL: ${hf_repo}/tokenizer.json"
-            if [ "${requires_auth}" = "true" ]; then
-                echo "  This is a gated model. Make sure you have:"
-                echo "    1. A valid HF_TOKEN set in your environment"
-                echo "    2. Accepted the model license at https://huggingface.co/${model_name}"
-            fi
-            echo "  Debug: wget ${wget_args[*]} -S -O /dev/null ${hf_repo}/tokenizer.json"
-            return 1
-        fi
+    if wget -q "${wget_args[@]}" -O "${dest}" "${url}" 2>&1; then
+        echo "  ${filename} downloaded"
+        return 0
     fi
 
-    if [ ! -f "${tok_config}" ]; then
-        if wget -q "${wget_args[@]}" -O "${tok_config}" "${hf_repo}/tokenizer_config.json" 2>&1; then
-            echo "  tokenizer_config.json downloaded to ${tok_config}"
-        else
-            rm -f "${tok_config}"
-            echo "  ERROR: Failed to download ${model_name} tokenizer_config.json."
-            return 1
-        fi
+    rm -f "${dest}"
+    echo "  ERROR: Failed to download ${model_name}/${filename}."
+    echo "  URL: ${url}"
+    if [ "${requires_auth}" = "true" ]; then
+        echo "  This is a gated model. Make sure you have:"
+        echo "    1. A valid HF_TOKEN set in your environment"
+        echo "    2. Accepted the model license at https://huggingface.co/${model_name}"
     fi
-
-    # config.json (HF model config) is not required by cpp_server itself,
-    # but Dynamo's frontend refuses to start without it. Try HF first; fall
-    # back to the caller-supplied minimal stub so the build artifact always
-    # carries a usable file.
-    if [ ! -f "${model_config}" ]; then
-        if wget -q "${wget_args[@]}" -O "${model_config}" "${hf_repo}/config.json" 2>&1; then
-            echo "  config.json downloaded to ${model_config}"
-        elif [ -n "${placeholder_config_json}" ]; then
-            rm -f "${model_config}"
-            echo "  config.json HF fetch failed; writing minimal placeholder."
-            printf '%s\n' "${placeholder_config_json}" > "${model_config}"
-        else
-            rm -f "${model_config}"
-            echo "  WARN: ${model_name} config.json missing and no placeholder supplied."
-            echo "  Dynamo frontend will fail with 'unable to extract config.json'."
-            return 1
-        fi
-    fi
+    return 1
 }
 
-# Kimi K2.x ships a tiktoken BPE vocab (tiktoken.model), not tokenizer.json.
-# Dynamo's model_card loader accepts tiktoken.model; the chat template lives in
-# chat_template.jinja (see dynamo/lib/llm/src/model_card.rs TokenizerKind::from_disk).
-download_kimi_tokenizer() {
-    local model_name="moonshotai/Kimi-K2.6"
-    local hf_repo="https://huggingface.co/moonshotai/Kimi-K2.6/raw/main"
-    local model_dir="${TOKENIZER_DIR}/${model_name}"
-    local tiktoken_model="${model_dir}/tiktoken.model"
-    local tok_config="${model_dir}/tokenizer_config.json"
-    local model_config="${model_dir}/config.json"
-    local chat_template="${model_dir}/chat_template.jinja"
-    local placeholder_config_json='{"model_type":"kimi_k25","architectures":["KimiK25ForConditionalGeneration"]}'
+# Download tokenizer files for a model.
+# Args:
+#   model_name          - HF model path (e.g., "deepseek-ai/DeepSeek-R1-0528")
+#   hf_repo             - Base URL for raw files
+#   requires_auth       - "true" if gated model requiring HF_TOKEN
+#   placeholder_config  - Fallback config.json content if HF fetch fails
+#   tokenizer_type      - "json" (default) for tokenizer.json, "tiktoken" for tiktoken.model
+download_tokenizer() {
+    local model_name="$1"
+    local hf_repo="$2"
+    local requires_auth="$3"
+    local placeholder_config="${4:-}"
+    local tokenizer_type="${5:-json}"
 
-    if [ -f "${tiktoken_model}" ] && [ -f "${tok_config}" ] && [ -f "${model_config}" ] \
-        && [ -f "${chat_template}" ]; then
+    local model_dir="${TOKENIZER_DIR}/${model_name}"
+    local model_config="${model_dir}/config.json"
+
+    # Determine required files based on tokenizer type
+    local required_files=("tokenizer_config.json")
+    if [ "${tokenizer_type}" = "tiktoken" ]; then
+        required_files+=("tiktoken.model" "chat_template.jinja")
+    else
+        required_files+=("tokenizer.json")
+    fi
+
+    # Check if all required files exist
+    local all_exist=true
+    for f in "${required_files[@]}"; do
+        if [ ! -f "${model_dir}/${f}" ]; then
+            all_exist=false
+            break
+        fi
+    done
+    if [ "${all_exist}" = "true" ] && [ -f "${model_config}" ]; then
         echo "  Using existing ${model_name} tokenizer + config."
         return 0
     fi
 
-    mkdir -p "${model_dir}"
-    echo "Downloading ${model_name} tokenizer (tiktoken + chat template)..."
+    # Skip gated models without auth token
+    if [ "${requires_auth}" = "true" ] && [ -z "${HF_TOKEN_RESOLVED}" ]; then
+        echo "  Skipping ${model_name} (gated model — set HF_TOKEN to download)."
+        return 0
+    fi
 
-    for f in tiktoken.model tokenizer_config.json chat_template.jinja; do
-        local dest="${model_dir}/${f}"
-        if [ -f "${dest}" ]; then
-            continue
-        fi
-        if wget -q -O "${dest}" "${hf_repo}/${f}" 2>&1; then
-            echo "  ${f} downloaded to ${dest}"
-        else
-            rm -f "${dest}"
-            echo "  ERROR: Failed to download ${model_name}/${f}."
-            echo "  URL: ${hf_repo}/${f}"
+    mkdir -p "${model_dir}"
+    echo "Downloading ${model_name} tokenizer..."
+
+    # Download required tokenizer files
+    for f in "${required_files[@]}"; do
+        if ! download_hf_file "${model_dir}/${f}" "${hf_repo}/${f}" "${requires_auth}" "${model_name}"; then
             return 1
         fi
     done
 
+    # Download config.json with placeholder fallback
     if [ ! -f "${model_config}" ]; then
-        if wget -q -O "${model_config}" "${hf_repo}/config.json" 2>&1; then
-            echo "  config.json downloaded to ${model_config}"
-        else
-            rm -f "${model_config}"
+        if download_hf_file "${model_config}" "${hf_repo}/config.json" "${requires_auth}" "${model_name}" 2>/dev/null; then
+            :
+        elif [ -n "${placeholder_config}" ]; then
             echo "  config.json HF fetch failed; writing minimal placeholder."
-            printf '%s\n' "${placeholder_config_json}" > "${model_config}"
+            printf '%s\n' "${placeholder_config}" > "${model_config}"
+        else
+            echo "  WARN: ${model_name} config.json missing and no placeholder supplied."
+            echo "  Dynamo frontend will fail with 'unable to extract config.json'."
+            return 1
         fi
     fi
 }
@@ -318,7 +295,12 @@ download_tokenizer \
     '{"model_type":"llama","architectures":["LlamaForCausalLM"]}'
 
 # Kimi K2.6 (public tiktoken tokenizer + jinja chat template; no tokenizer.json on HF)
-download_kimi_tokenizer
+download_tokenizer \
+    "moonshotai/Kimi-K2.6" \
+    "https://huggingface.co/moonshotai/Kimi-K2.6/raw/main" \
+    "false" \
+    '{"model_type":"kimi_k25","architectures":["KimiK25ForConditionalGeneration"]}' \
+    "tiktoken"
 
 echo ""
 

--- a/tt-media-server/cpp_server/src/dynamo/discovery.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/discovery.cpp
@@ -6,6 +6,7 @@
 #include <json/json.h>
 
 #include <algorithm>
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -90,9 +91,11 @@ Json::Value buildMdcJson(const DiscoveryConfig& c) {
   card["source_path"] = c.model_path;
 
   const std::string configPath = c.model_path + "/config.json";
-  const std::string tokenizerPath = c.model_path + "/tokenizer.json";
+  const std::string tokenizerJsonPath = c.model_path + "/tokenizer.json";
+  const std::string tiktokenModelPath = c.model_path + "/tiktoken.model";
   const std::string tokenizerConfigPath =
       c.model_path + "/tokenizer_config.json";
+  const std::string chatTemplatePath = c.model_path + "/chat_template.jinja";
 
   Json::Value modelInfo(Json::objectValue);
   Json::Value hfConfig(Json::objectValue);
@@ -102,11 +105,31 @@ Json::Value buildMdcJson(const DiscoveryConfig& c) {
   card["model_info"] = std::move(modelInfo);
 
   Json::Value tokenizer(Json::objectValue);
-  Json::Value hfTok(Json::objectValue);
-  hfTok["path"] = tokenizerPath;
-  hfTok["checksum"] = K_BLAKE3_PLACEHOLDER;
-  tokenizer["hf_tokenizer_json"] = std::move(hfTok);
+  Json::Value tokFile(Json::objectValue);
+  const bool hasTiktoken = std::filesystem::exists(tiktokenModelPath) &&
+                           !std::filesystem::exists(tokenizerJsonPath);
+  if (hasTiktoken) {
+    tokFile["path"] = tiktokenModelPath;
+    tokFile["checksum"] = K_BLAKE3_PLACEHOLDER;
+    tokenizer["tik_token_model"] = std::move(tokFile);
+  } else {
+    tokFile["path"] = tokenizerJsonPath;
+    tokFile["checksum"] = K_BLAKE3_PLACEHOLDER;
+    tokenizer["hf_tokenizer_json"] = std::move(tokFile);
+  }
   card["tokenizer"] = std::move(tokenizer);
+
+  if (std::filesystem::exists(chatTemplatePath)) {
+    Json::Value chatTemplateFile(Json::objectValue);
+    Json::Value hfChatTemplate(Json::objectValue);
+    hfChatTemplate["is_custom"] = false;
+    Json::Value jinjaFile(Json::objectValue);
+    jinjaFile["path"] = chatTemplatePath;
+    jinjaFile["checksum"] = K_BLAKE3_PLACEHOLDER;
+    hfChatTemplate["file"] = std::move(jinjaFile);
+    chatTemplateFile["hf_chat_template_jinja"] = std::move(hfChatTemplate);
+    card["chat_template_file"] = std::move(chatTemplateFile);
+  }
 
   Json::Value promptFormatter(Json::objectValue);
   Json::Value hfTokCfg(Json::objectValue);


### PR DESCRIPTION
## Problem
In order to use Dynamo Frontend for tokenization, we need to provide the required tokenizer configuration files in a location where Dynamo can discover them.

With this PR, all tokenizer configuration files are downloaded from Hugging Face into the /tokenizers/<model_name> directory within the cpp_server project.

