### PR TITLE
Expose per-worker and per-LLM-slot Prometheus metrics

### DIFF
--- a/tt-media-server/cpp_server/include/runtime/worker/blaze_metrics_layout.hpp
+++ b/tt-media-server/cpp_server/include/runtime/worker/blaze_metrics_layout.hpp
@@ -26,12 +26,48 @@ namespace tt::worker::sp_pipeline {
 constexpr size_t SCRATCH_STEP_EPOCH_MS = 0;
 constexpr size_t SCRATCH_LAST_OUTPUT_EPOCH_MS = 1;
 constexpr size_t SCRATCH_ACTIVE_REQUESTS = 2;
-// reserved for future sp_pipeline metrics:
-// constexpr size_t SCRATCH_KV_CACHE_BPS    = 3;  // basis points 0-10000
-// constexpr size_t SCRATCH_NUM_DECODING    = 4;
-// ... up to index 31
+// Cumulative aggregates across all turns / slots in this worker.
+constexpr size_t SCRATCH_TOTAL_PROMPT_TOKENS = 3;
+constexpr size_t SCRATCH_TOTAL_GENERATION_TOKENS = 4;
+constexpr size_t SCRATCH_TOTAL_SPEC_ACCEPTS = 5;
+constexpr size_t SCRATCH_TOTAL_SPEC_REJECTS = 6;
+// Indices 7..31 reserved for future aggregates.
 
-static_assert(SCRATCH_ACTIVE_REQUESTS < WORKER_SCRATCH_U64_COUNT,
-              "sp_pipeline scratch indices exceed scratch capacity");
+// ---------------------------------------------------------------------------
+//  Per-LLM-slot region (starts at index LLM_SLOT_BASE).
+//
+//  Layout:  scratch[LLM_SLOT_BASE + slot_id * LLM_SLOT_FIELDS + field]
+//
+//  Fields are written by the runner on its step thread (single writer per
+//  worker) and read by the main process at scrape time. All accesses use
+//  relaxed atomics — visibility across the scrape-to-step boundary is
+//  acceptable to be a few ms stale.
+// ---------------------------------------------------------------------------
+constexpr size_t LLM_SLOT_BASE = 32;
+constexpr size_t MAX_LLM_SLOTS = 128;  // matches defaults::PM_MAX_USERS
+constexpr size_t LLM_SLOT_FIELDS = 7;
+
+constexpr size_t LLM_FIELD_LAST_INPUT_TOKENS = 0;  // ISL of last submitted turn
+constexpr size_t LLM_FIELD_CURRENT_OUTPUT_TOKENS =
+    1;  // tokens emitted so far in current turn
+constexpr size_t LLM_FIELD_LAST_OUTPUT_TOKENS =
+    2;  // OSL of last completed turn
+constexpr size_t LLM_FIELD_TURN_START_EPOCH_MS = 3;
+constexpr size_t LLM_FIELD_FIRST_TOKEN_EPOCH_MS =
+    4;  // 0 until first decode token of current turn
+constexpr size_t LLM_FIELD_LAST_TPOT_US =
+    5;  // (last_token_ms - first_token_ms) * 1000 / (osl - 1)
+constexpr size_t LLM_FIELD_LAST_ACCEPTANCE_RATE_BPS =
+    6;  // basis points 0-10000
+
+inline size_t llmSlotIdx(uint32_t slotId, size_t field) {
+  return LLM_SLOT_BASE + static_cast<size_t>(slotId) * LLM_SLOT_FIELDS + field;
+}
+
+static_assert(SCRATCH_TOTAL_SPEC_REJECTS < LLM_SLOT_BASE,
+              "sp_pipeline aggregate indices overlap per-slot region");
+static_assert(LLM_SLOT_BASE + MAX_LLM_SLOTS * LLM_SLOT_FIELDS <=
+                  WORKER_SCRATCH_U64_COUNT,
+              "sp_pipeline per-slot region exceeds scratch capacity");
 
 }  // namespace tt::worker::sp_pipeline

--- a/tt-media-server/cpp_server/include/runtime/worker/blaze_worker_metrics_renderer.hpp
+++ b/tt-media-server/cpp_server/include/runtime/worker/blaze_worker_metrics_renderer.hpp
@@ -7,6 +7,7 @@
 #include <prometheus/registry.h>
 
 #include <unordered_map>
+#include <vector>
 
 #include "runtime/worker/worker_metrics_renderer.hpp"
 #include "runtime/worker/worker_metrics_shm.hpp"
@@ -17,10 +18,25 @@ namespace tt::worker {
  * Renderer for slots tagged MetricsLayout::SP_PIPELINE_RUNNER (currently
  * produced by SpPipelineRunner / SpPipelineRunnerDemo). Translates the
  * sp_pipeline scratch indices into the externally-visible Prometheus series:
- *   - tt_worker_alive
- *   - tt_worker_heartbeat_age_seconds
- *   - tt_worker_last_output_age_seconds
- *   - tt_worker_active_requests
+ *
+ *   Worker-level (label: worker_id):
+ *     - tt_worker_alive
+ *     - tt_worker_heartbeat_age_seconds
+ *     - tt_worker_last_output_age_seconds
+ *     - tt_worker_active_requests
+ *     - tt_worker_prompt_tokens_total
+ *     - tt_worker_generation_tokens_total
+ *     - tt_worker_spec_accepts_total
+ *     - tt_worker_spec_rejects_total
+ *     - tt_worker_total_acceptance_rate
+ *
+ *   Per-LLM-slot (labels: worker_id, slot_id) — wired so that
+ *   "TPOT vs ISL/OSL" correlation can be plotted in Grafana:
+ *     - tt_worker_slot_input_tokens          (last submitted turn's ISL)
+ *     - tt_worker_slot_output_tokens         (last completed turn's OSL)
+ *     - tt_worker_slot_current_output_tokens (in-flight turn's emitted tokens)
+ *     - tt_worker_slot_tpot_seconds          (last completed turn's TPOT)
+ *     - tt_worker_slot_acceptance_rate       (last completed turn, 0..1)
  *
  * Class is named after the layout it reads (sp_pipeline), not after the
  * runner that writes it, so a future second runner producing the same
@@ -32,17 +48,42 @@ class SpPipelineWorkerMetricsRenderer : public IWorkerMetricsRenderer {
   void render(const WorkerMetricsShm& shm, int workerId, bool isAlive) override;
 
  private:
+  struct SlotGauges {
+    prometheus::Gauge* input_tokens{nullptr};
+    prometheus::Gauge* output_tokens{nullptr};
+    prometheus::Gauge* current_output_tokens{nullptr};
+    prometheus::Gauge* tpot_seconds{nullptr};
+    prometheus::Gauge* acceptance_rate{nullptr};
+  };
+
   struct WorkerGauges {
     prometheus::Gauge* alive{nullptr};
     prometheus::Gauge* step_age{nullptr};
     prometheus::Gauge* output_age{nullptr};
     prometheus::Gauge* active_requests{nullptr};
+    prometheus::Gauge* prompt_tokens_total{nullptr};
+    prometheus::Gauge* generation_tokens_total{nullptr};
+    prometheus::Gauge* spec_accepts_total{nullptr};
+    prometheus::Gauge* spec_rejects_total{nullptr};
+    prometheus::Gauge* total_acceptance_rate{nullptr};
+    std::vector<SlotGauges> slots;
   };
 
   prometheus::Family<prometheus::Gauge>* alive_family_{nullptr};
   prometheus::Family<prometheus::Gauge>* step_age_family_{nullptr};
   prometheus::Family<prometheus::Gauge>* output_age_family_{nullptr};
   prometheus::Family<prometheus::Gauge>* active_family_{nullptr};
+  prometheus::Family<prometheus::Gauge>* prompt_tokens_family_{nullptr};
+  prometheus::Family<prometheus::Gauge>* generation_tokens_family_{nullptr};
+  prometheus::Family<prometheus::Gauge>* spec_accepts_family_{nullptr};
+  prometheus::Family<prometheus::Gauge>* spec_rejects_family_{nullptr};
+  prometheus::Family<prometheus::Gauge>* total_acceptance_rate_family_{nullptr};
+  prometheus::Family<prometheus::Gauge>* slot_input_tokens_family_{nullptr};
+  prometheus::Family<prometheus::Gauge>* slot_output_tokens_family_{nullptr};
+  prometheus::Family<prometheus::Gauge>* slot_current_output_tokens_family_{
+      nullptr};
+  prometheus::Family<prometheus::Gauge>* slot_tpot_seconds_family_{nullptr};
+  prometheus::Family<prometheus::Gauge>* slot_acceptance_rate_family_{nullptr};
 
   std::unordered_map<int, WorkerGauges> gauges_;
 };

--- a/tt-media-server/cpp_server/include/runtime/worker/single_process_worker_metrics.hpp
+++ b/tt-media-server/cpp_server/include/runtime/worker/single_process_worker_metrics.hpp
@@ -45,6 +45,26 @@ class SingleProcessWorkerMetrics {
   void incrementActiveRequests();
   void decrementActiveRequests();
 
+  // Per-LLM-slot lifecycle hooks. All hot-path safe: relaxed atomic stores
+  // only, no syscalls or allocations. Writes are silently dropped if the
+  // slotId is out of range or the worker has no shm attached.
+  //
+  // onTurnStart      — called when a new request enters the slot. Records ISL,
+  //                    turn-start timestamp, resets the in-flight output
+  //                    counter. Also bumps the worker's cumulative
+  //                    prompt-tokens aggregate.
+  // onOutputToken    — called per emitted decode token. Increments OSL counter
+  //                    and on the first token stamps FIRST_TOKEN_EPOCH_MS for
+  //                    later TPOT computation. Also bumps the worker's
+  //                    cumulative generation-tokens aggregate.
+  // onTurnComplete   — called when the slot's turn finishes. Computes per-turn
+  //                    TPOT (from FIRST_TOKEN to now over OSL-1 steps) and
+  //                    acceptance rate, stores them as gauges, and adds the
+  //                    accepts/rejects to the worker aggregates.
+  void onTurnStart(uint32_t slotId, uint32_t inputTokens);
+  void onOutputToken(uint32_t slotId);
+  void onTurnComplete(uint32_t slotId, uint32_t accepts, uint32_t rejects);
+
   // ----- low-level layout-agnostic writers ----------------------------------
   void scratchStoreU64(size_t idx, uint64_t value);
   void scratchAddU64(size_t idx, uint64_t delta);

--- a/tt-media-server/cpp_server/include/runtime/worker/worker_metrics_shm.hpp
+++ b/tt-media-server/cpp_server/include/runtime/worker/worker_metrics_shm.hpp
@@ -26,7 +26,10 @@ namespace tt::worker {
  */
 
 constexpr size_t MAX_WORKER_SLOTS = 32;
-constexpr size_t WORKER_SCRATCH_U64_COUNT = 32;
+// 32 reserved for layout-level aggregates + 128 LLM-slots * 7 fields = 928,
+// rounded up to 1024 to give per-layout headroom. Sized once for all layouts;
+// non-LLM layouts (SDXL, EMBEDDING) just use the lower indices.
+constexpr size_t WORKER_SCRATCH_U64_COUNT = 1024;
 
 /**
  * Names what a slot's scratch area means. Each worker writes its own value
@@ -138,7 +141,7 @@ class WorkerMetricsShm {
     uint32_t reserved;
     std::atomic<uint64_t> scratch[WORKER_SCRATCH_U64_COUNT];
   };
-  static_assert(sizeof(Slot) == 320, "Slot layout drift");
+  static_assert(sizeof(Slot) == 8256, "Slot layout drift");
 
   struct Region {
     std::atomic<uint32_t> magic;

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_runner.cpp
@@ -523,7 +523,8 @@ inline void BlazeRunner::handleStopRequest(uint32_t taskId) {
 }
 
 void BlazeRunner::handleOutput(const ds::OutputMessage& output) {
-  tt::worker::SingleProcessWorkerMetrics::instance().updateOutputHeartbeat();
+  auto& metrics = tt::worker::SingleProcessWorkerMetrics::instance();
+  metrics.updateOutputHeartbeat();
   lastOutputTime = std::chrono::steady_clock::now();
   auto& slotContext = slotManager.getSlotContext(output.slot_id);
   if (slotContext.state != SlotState::RUNNING) {
@@ -554,13 +555,14 @@ void BlazeRunner::handleOutput(const ds::OutputMessage& output) {
   auto taskId = slotContext.taskId.value();
 
   slotContext.tokensGenerated++;
+  metrics.onOutputToken(output.slot_id);
   utils::SpecDelta spec{};
   if (finished) {
     spec = utils::computeAndLogSpecDelta(*decodeScheduler, slotContext, output,
                                          taskId, hitStop);
+    metrics.onTurnComplete(output.slot_id, spec.accepts, spec.rejects);
     slotManager.setSlotAsIdle(output.slot_id);
-    tt::worker::SingleProcessWorkerMetrics::instance()
-        .decrementActiveRequests();
+    metrics.decrementActiveRequests();
   }
   uint32_t flag = finished ? ipc::SharedToken::FLAG_FINAL : 0;
   ipc::helpers::pushToken(*resultQueue, taskId, output.token_id, flag,
@@ -627,8 +629,14 @@ void BlazeRunner::handleRequest(
       utils::initSlotForRun(slotContext, *request, *decodeScheduler);
       slotManager.bindTaskToSlot(request->taskId, slotId);
       slotManager.setSlotState(slotId, SlotState::RUNNING);
-      tt::worker::SingleProcessWorkerMetrics::instance()
-          .incrementActiveRequests();
+      auto& metrics = tt::worker::SingleProcessWorkerMetrics::instance();
+      metrics.incrementActiveRequests();
+      // Reset the slot's per-turn counters every time a request is bound to it
+      // (fresh, continuation, or disaggregated). Skipping continuations would
+      // leave the previous turn's OSL counter and first-token timestamp in
+      // place, breaking TPOT/OSL exposure for any multi-turn slot.
+      metrics.onTurnStart(slotId,
+                          static_cast<uint32_t>(request->getTokenIds().size()));
       break;
     }
     case SlotState::AWAITING_STOP_ACK: {

--- a/tt-media-server/cpp_server/src/runtime/worker/blaze_worker_metrics_renderer.cpp
+++ b/tt-media-server/cpp_server/src/runtime/worker/blaze_worker_metrics_renderer.cpp
@@ -47,6 +47,58 @@ void SpPipelineWorkerMetricsRenderer::prebuildGauges(
              .Name("tt_worker_active_requests")
              .Help("Number of requests currently in the worker pipeline")
              .Register(registry);
+    prompt_tokens_family_ =
+        &prometheus::BuildGauge()
+             .Name("tt_worker_prompt_tokens_total")
+             .Help("Cumulative prompt tokens submitted to this worker")
+             .Register(registry);
+    generation_tokens_family_ =
+        &prometheus::BuildGauge()
+             .Name("tt_worker_generation_tokens_total")
+             .Help("Cumulative generation tokens emitted by this worker")
+             .Register(registry);
+    spec_accepts_family_ =
+        &prometheus::BuildGauge()
+             .Name("tt_worker_spec_accepts_total")
+             .Help("Cumulative speculative-decode accepts on this worker")
+             .Register(registry);
+    spec_rejects_family_ =
+        &prometheus::BuildGauge()
+             .Name("tt_worker_spec_rejects_total")
+             .Help("Cumulative speculative-decode rejects on this worker")
+             .Register(registry);
+    total_acceptance_rate_family_ =
+        &prometheus::BuildGauge()
+             .Name("tt_worker_total_acceptance_rate")
+             .Help("Cumulative speculative-decode acceptance rate (0..1)")
+             .Register(registry);
+    slot_input_tokens_family_ =
+        &prometheus::BuildGauge()
+             .Name("tt_worker_slot_input_tokens")
+             .Help("ISL of the last turn submitted to this LLM slot")
+             .Register(registry);
+    slot_output_tokens_family_ =
+        &prometheus::BuildGauge()
+             .Name("tt_worker_slot_output_tokens")
+             .Help("OSL of the last completed turn on this LLM slot")
+             .Register(registry);
+    slot_current_output_tokens_family_ =
+        &prometheus::BuildGauge()
+             .Name("tt_worker_slot_current_output_tokens")
+             .Help("Tokens emitted so far in the in-flight turn on this slot")
+             .Register(registry);
+    slot_tpot_seconds_family_ =
+        &prometheus::BuildGauge()
+             .Name("tt_worker_slot_tpot_seconds")
+             .Help("Time-per-output-token of the last completed turn (seconds)")
+             .Register(registry);
+    slot_acceptance_rate_family_ =
+        &prometheus::BuildGauge()
+             .Name("tt_worker_slot_acceptance_rate")
+             .Help(
+                 "Speculative-decode acceptance rate of the last completed "
+                 "turn (0..1)")
+             .Register(registry);
   }
 
   const std::string idStr = std::to_string(workerId);
@@ -55,7 +107,32 @@ void SpPipelineWorkerMetricsRenderer::prebuildGauges(
   g.step_age = &step_age_family_->Add({{"worker_id", idStr}});
   g.output_age = &output_age_family_->Add({{"worker_id", idStr}});
   g.active_requests = &active_family_->Add({{"worker_id", idStr}});
-  gauges_[workerId] = g;
+  g.prompt_tokens_total = &prompt_tokens_family_->Add({{"worker_id", idStr}});
+  g.generation_tokens_total =
+      &generation_tokens_family_->Add({{"worker_id", idStr}});
+  g.spec_accepts_total = &spec_accepts_family_->Add({{"worker_id", idStr}});
+  g.spec_rejects_total = &spec_rejects_family_->Add({{"worker_id", idStr}});
+  g.total_acceptance_rate =
+      &total_acceptance_rate_family_->Add({{"worker_id", idStr}});
+
+  g.slots.resize(sp_pipeline::MAX_LLM_SLOTS);
+  for (size_t s = 0; s < sp_pipeline::MAX_LLM_SLOTS; ++s) {
+    const std::string slotStr = std::to_string(s);
+    SlotGauges sg;
+    sg.input_tokens = &slot_input_tokens_family_->Add(
+        {{"worker_id", idStr}, {"slot_id", slotStr}});
+    sg.output_tokens = &slot_output_tokens_family_->Add(
+        {{"worker_id", idStr}, {"slot_id", slotStr}});
+    sg.current_output_tokens = &slot_current_output_tokens_family_->Add(
+        {{"worker_id", idStr}, {"slot_id", slotStr}});
+    sg.tpot_seconds = &slot_tpot_seconds_family_->Add(
+        {{"worker_id", idStr}, {"slot_id", slotStr}});
+    sg.acceptance_rate = &slot_acceptance_rate_family_->Add(
+        {{"worker_id", idStr}, {"slot_id", slotStr}});
+    g.slots[s] = sg;
+  }
+
+  gauges_[workerId] = std::move(g);
 }
 
 void SpPipelineWorkerMetricsRenderer::render(const WorkerMetricsShm& shm,
@@ -70,11 +147,55 @@ void SpPipelineWorkerMetricsRenderer::render(const WorkerMetricsShm& shm,
   uint64_t outputMs =
       shm.loadScratch(slot, sp_pipeline::SCRATCH_LAST_OUTPUT_EPOCH_MS);
   uint64_t active = shm.loadScratch(slot, sp_pipeline::SCRATCH_ACTIVE_REQUESTS);
+  uint64_t promptTotal =
+      shm.loadScratch(slot, sp_pipeline::SCRATCH_TOTAL_PROMPT_TOKENS);
+  uint64_t genTotal =
+      shm.loadScratch(slot, sp_pipeline::SCRATCH_TOTAL_GENERATION_TOKENS);
+  uint64_t accTotal =
+      shm.loadScratch(slot, sp_pipeline::SCRATCH_TOTAL_SPEC_ACCEPTS);
+  uint64_t rejTotal =
+      shm.loadScratch(slot, sp_pipeline::SCRATCH_TOTAL_SPEC_REJECTS);
 
   g.alive->Set(isAlive ? 1.0 : 0.0);
   g.step_age->Set(ageSeconds(stepMs, now));
   g.output_age->Set(ageSeconds(outputMs, now));
   g.active_requests->Set(static_cast<double>(active));
+  g.prompt_tokens_total->Set(static_cast<double>(promptTotal));
+  g.generation_tokens_total->Set(static_cast<double>(genTotal));
+  g.spec_accepts_total->Set(static_cast<double>(accTotal));
+  g.spec_rejects_total->Set(static_cast<double>(rejTotal));
+  const uint64_t specTotal = accTotal + rejTotal;
+  g.total_acceptance_rate->Set(
+      specTotal > 0 ? static_cast<double>(accTotal) / specTotal : 0.0);
+
+  for (size_t s = 0; s < g.slots.size(); ++s) {
+    const uint64_t isl = shm.loadScratch(
+        slot,
+        sp_pipeline::llmSlotIdx(static_cast<uint32_t>(s),
+                                sp_pipeline::LLM_FIELD_LAST_INPUT_TOKENS));
+    const uint64_t osl = shm.loadScratch(
+        slot,
+        sp_pipeline::llmSlotIdx(static_cast<uint32_t>(s),
+                                sp_pipeline::LLM_FIELD_LAST_OUTPUT_TOKENS));
+    const uint64_t curOsl = shm.loadScratch(
+        slot,
+        sp_pipeline::llmSlotIdx(static_cast<uint32_t>(s),
+                                sp_pipeline::LLM_FIELD_CURRENT_OUTPUT_TOKENS));
+    const uint64_t tpotUs = shm.loadScratch(
+        slot, sp_pipeline::llmSlotIdx(static_cast<uint32_t>(s),
+                                      sp_pipeline::LLM_FIELD_LAST_TPOT_US));
+    const uint64_t bps = shm.loadScratch(
+        slot, sp_pipeline::llmSlotIdx(
+                  static_cast<uint32_t>(s),
+                  sp_pipeline::LLM_FIELD_LAST_ACCEPTANCE_RATE_BPS));
+
+    SlotGauges& sg = g.slots[s];
+    sg.input_tokens->Set(static_cast<double>(isl));
+    sg.output_tokens->Set(static_cast<double>(osl));
+    sg.current_output_tokens->Set(static_cast<double>(curOsl));
+    sg.tpot_seconds->Set(static_cast<double>(tpotUs) / 1.0e6);
+    sg.acceptance_rate->Set(static_cast<double>(bps) / 10000.0);
+  }
 }
 
 }  // namespace tt::worker

--- a/tt-media-server/cpp_server/src/runtime/worker/single_process_worker_metrics.cpp
+++ b/tt-media-server/cpp_server/src/runtime/worker/single_process_worker_metrics.cpp
@@ -106,4 +106,92 @@ void SingleProcessWorkerMetrics::scratchAddU64(size_t idx, uint64_t delta) {
   shm_->fetchAddScratch(workerId_, idx, delta);
 }
 
+void SingleProcessWorkerMetrics::onTurnStart(uint32_t slotId,
+                                             uint32_t inputTokens) {
+  if (shm_ == nullptr) return;
+  if (slotId >= sp_pipeline::MAX_LLM_SLOTS) return;
+  const uint64_t now = nowMs();
+  shm_->storeScratch(
+      workerId_,
+      sp_pipeline::llmSlotIdx(slotId, sp_pipeline::LLM_FIELD_LAST_INPUT_TOKENS),
+      inputTokens);
+  shm_->storeScratch(workerId_,
+                     sp_pipeline::llmSlotIdx(
+                         slotId, sp_pipeline::LLM_FIELD_CURRENT_OUTPUT_TOKENS),
+                     0);
+  shm_->storeScratch(workerId_,
+                     sp_pipeline::llmSlotIdx(
+                         slotId, sp_pipeline::LLM_FIELD_TURN_START_EPOCH_MS),
+                     now);
+  shm_->storeScratch(workerId_,
+                     sp_pipeline::llmSlotIdx(
+                         slotId, sp_pipeline::LLM_FIELD_FIRST_TOKEN_EPOCH_MS),
+                     0);
+  shm_->fetchAddScratch(workerId_, sp_pipeline::SCRATCH_TOTAL_PROMPT_TOKENS,
+                        inputTokens);
+}
+
+void SingleProcessWorkerMetrics::onOutputToken(uint32_t slotId) {
+  if (shm_ == nullptr) return;
+  if (slotId >= sp_pipeline::MAX_LLM_SLOTS) return;
+  const size_t curIdx = sp_pipeline::llmSlotIdx(
+      slotId, sp_pipeline::LLM_FIELD_CURRENT_OUTPUT_TOKENS);
+  const uint64_t prev = shm_->fetchAddScratch(workerId_, curIdx, 1);
+  if (prev == 0) {
+    shm_->storeScratch(workerId_,
+                       sp_pipeline::llmSlotIdx(
+                           slotId, sp_pipeline::LLM_FIELD_FIRST_TOKEN_EPOCH_MS),
+                       nowMs());
+  }
+  shm_->fetchAddScratch(workerId_, sp_pipeline::SCRATCH_TOTAL_GENERATION_TOKENS,
+                        1);
+}
+
+void SingleProcessWorkerMetrics::onTurnComplete(uint32_t slotId,
+                                                uint32_t accepts,
+                                                uint32_t rejects) {
+  if (shm_ == nullptr) return;
+  if (slotId >= sp_pipeline::MAX_LLM_SLOTS) return;
+  const uint64_t now = nowMs();
+  const uint64_t osl = shm_->loadScratch(
+      workerId_, sp_pipeline::llmSlotIdx(
+                     slotId, sp_pipeline::LLM_FIELD_CURRENT_OUTPUT_TOKENS));
+  const uint64_t firstTokenMs = shm_->loadScratch(
+      workerId_, sp_pipeline::llmSlotIdx(
+                     slotId, sp_pipeline::LLM_FIELD_FIRST_TOKEN_EPOCH_MS));
+
+  // TPOT excludes prefill: numerator is (now - first_token_ms) and
+  // denominator is (osl - 1). Skip the gauge update if we don't have at
+  // least two decode tokens — the previous turn's value remains visible.
+  if (osl >= 2 && firstTokenMs > 0 && now > firstTokenMs) {
+    const uint64_t decodeMs = now - firstTokenMs;
+    const uint64_t tpotUs = (decodeMs * 1000ULL) / (osl - 1);
+    shm_->storeScratch(
+        workerId_,
+        sp_pipeline::llmSlotIdx(slotId, sp_pipeline::LLM_FIELD_LAST_TPOT_US),
+        tpotUs);
+  }
+
+  // Acceptance rate as basis points so it stays a single u64 cell.
+  // 10000 bps = 100.00 %. If neither path fired, leave the previous value.
+  const uint32_t total = accepts + rejects;
+  if (total > 0) {
+    const uint64_t bps = (static_cast<uint64_t>(accepts) * 10000ULL) / total;
+    shm_->storeScratch(
+        workerId_,
+        sp_pipeline::llmSlotIdx(
+            slotId, sp_pipeline::LLM_FIELD_LAST_ACCEPTANCE_RATE_BPS),
+        bps);
+  }
+
+  shm_->storeScratch(workerId_,
+                     sp_pipeline::llmSlotIdx(
+                         slotId, sp_pipeline::LLM_FIELD_LAST_OUTPUT_TOKENS),
+                     osl);
+  shm_->fetchAddScratch(workerId_, sp_pipeline::SCRATCH_TOTAL_SPEC_ACCEPTS,
+                        accepts);
+  shm_->fetchAddScratch(workerId_, sp_pipeline::SCRATCH_TOTAL_SPEC_REJECTS,
+                        rejects);
+}
+
 }  // namespace tt::worker

--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_cpp.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_cpp.json
@@ -2049,6 +2049,685 @@
       "id": 300,
       "title": "System Throughput",
       "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 94
+      },
+      "id": 400,
+      "title": "Per-Slot Performance (TPOT / ISL / OSL / Acceptance)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Cumulative speculative-decode acceptance rate across all slots and turns since worker startup.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.4
+              },
+              {
+                "color": "green",
+                "value": 0.7
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 95
+      },
+      "id": 401,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "tt_worker_total_acceptance_rate",
+          "legendFormat": "Worker {{worker_id}}"
+        }
+      ],
+      "title": "Total Acceptance Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Cumulative prompt tokens submitted to this worker since startup.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 95
+      },
+      "id": 402,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "tt_worker_prompt_tokens_total",
+          "legendFormat": "Worker {{worker_id}}"
+        }
+      ],
+      "title": "Worker Prompt Tokens",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Cumulative generation tokens emitted by this worker since startup.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 95
+      },
+      "id": 403,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "tt_worker_generation_tokens_total",
+          "legendFormat": "Worker {{worker_id}}"
+        }
+      ],
+      "title": "Worker Generation Tokens",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Cumulative speculative-decode accepts vs rejects on this worker. Rate of growth indicates how often the draft model's tokens are being kept.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accepts"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Rejects"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 95
+      },
+      "id": 404,
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(tt_worker_spec_accepts_total)",
+          "legendFormat": "Accepts"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(tt_worker_spec_rejects_total)",
+          "legendFormat": "Rejects"
+        }
+      ],
+      "title": "Spec Accepts vs Rejects (cumulative)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "TPOT (time per output token) of the most recently completed turn on each LLM slot. Each line is one slot. Filter slots by clicking legend entries; correlate with the OSL panel to the right to see how TPOT scales with output length.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 99
+      },
+      "id": 405,
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "tt_worker_slot_tpot_seconds > 0",
+          "legendFormat": "slot {{slot_id}}"
+        }
+      ],
+      "title": "TPOT per Slot (last completed turn)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Per-turn speculative-decode acceptance rate for the most recently completed turn on each slot. Useful for spotting slots where the draft model is consistently rejected.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 99
+      },
+      "id": 406,
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "tt_worker_slot_acceptance_rate > 0",
+          "legendFormat": "slot {{slot_id}}"
+        }
+      ],
+      "title": "Acceptance Rate per Slot",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Input sequence length (prompt tokens) of the last turn submitted to each slot. Compare against TPOT to see how prefill cost shifts with prompt size.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 107
+      },
+      "id": 407,
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "tt_worker_slot_input_tokens > 0",
+          "legendFormat": "slot {{slot_id}}"
+        }
+      ],
+      "title": "ISL per Slot",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Output sequence length of the most recently completed turn on each slot. Together with TPOT this is the primary signal for 'how does decode cost scale with output length?'.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 107
+      },
+      "id": 408,
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "tt_worker_slot_output_tokens > 0",
+          "legendFormat": "slot {{slot_id}}"
+        }
+      ],
+      "title": "OSL per Slot (last completed turn)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Heatmap of TPOT values across all slots over time. Darker bands at higher y indicate slower decode; widening bands suggest workload-dependent spread.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 115
+      },
+      "id": 409,
+      "options": {
+        "calculate": true,
+        "calculation": {
+          "yBuckets": {
+            "mode": "count",
+            "value": "30"
+          }
+        },
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "tt_worker_slot_tpot_seconds > 0",
+          "format": "time_series",
+          "legendFormat": "slot {{slot_id}}"
+        }
+      ],
+      "title": "TPOT Distribution (all slots)",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "TPOT plotted against output sequence length, one point per slot per scrape. Hover to see which slot a point belongs to. This is the primary view for the question 'does TPOT scale with sequence length?'.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "lineWidth": 0,
+            "pointSize": 5,
+            "showPoints": "always"
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "OSL"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 115
+      },
+      "id": 410,
+      "options": {
+        "dims": {
+          "frame": 0
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "series": [
+          {
+            "x": {
+              "field": "OSL"
+            },
+            "y": {
+              "field": "TPOT"
+            },
+            "name": "TPOT vs OSL",
+            "pointColor": {
+              "mode": "fixed",
+              "fixedColor": "blue"
+            }
+          }
+        ],
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "tt_worker_slot_output_tokens > 0",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "OSL",
+          "refId": "OSL"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "tt_worker_slot_tpot_seconds > 0",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "TPOT",
+          "refId": "TPOT"
+        }
+      ],
+      "title": "TPOT vs OSL (scatter)",
+      "type": "xychart",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "slot_id",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #OSL": "OSL",
+              "Value #TPOT": "TPOT"
+            }
+          }
+        }
+      ]
     }
   ],
   "refresh": "5s",
@@ -2069,5 +2748,5 @@
   "timezone": "browser",
   "title": "TT Inference Server",
   "uid": "tt-inference-server",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
Port of #3189 onto the current cpp_server tree (paths moved to include/runtime/worker, sp_pipeline_* renamed to blaze_*, runner state machine evolved). Wires three hot-path-safe lifecycle hooks (onTurnStart / onOutputToken / onTurnComplete) into BlazeRunner so the renderer can publish:

  worker-level: prompt_tokens_total, generation_tokens_total,
                spec_accepts_total, spec_rejects_total,
                total_acceptance_rate
  per-slot:     input_tokens, output_tokens, current_output_tokens,
                tpot_seconds, acceptance_rate

Scratch region grows from 32 -> 1024 u64 cells (32 aggregates + 128 LLM slots * 7 fields) so a non-LLM layout still fits without negotiating size. Grafana dashboard panels for TPOT/ISL/OSL/ acceptance correlations included.