### PR TITLE
Whisper: propagate language, task and prompt to generator

### DIFF
--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -157,6 +157,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                     request._audio_array,
                     request.stream,
                     self._create_generation_params(request),
+                    prompt=request.prompt,
                 )
 
                 if request.stream:
@@ -184,12 +185,6 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
             generation_params.no_speech_threshold = request.no_speech_threshold
         if request.return_timestamps is not None:
             generation_params.return_timestamps = request.return_timestamps
-        if request.prompt is not None:
-            generation_params.prompt = request.prompt
-        if self.settings.audio_language is not None:
-            generation_params.language = self.settings.audio_language
-        if self.settings.audio_task is not None:
-            generation_params.task = self.settings.audio_task
 
         return generation_params
 
@@ -227,16 +222,20 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
 
         return request
 
-    async def _execute_pipeline(self, audio_data, stream, generation_params):
+    async def _execute_pipeline(
+        self, audio_data, stream, generation_params, prompt=None
+    ):
         """Main pipeline execution method"""
         try:
             if stream:
                 # Return the async generator
-                return self._execute_pipeline_streaming(audio_data, generation_params)
+                return self._execute_pipeline_streaming(
+                    audio_data, generation_params, prompt
+                )
             else:
                 # Return the single result
                 return await self._execute_pipeline_non_streaming(
-                    audio_data, generation_params
+                    audio_data, generation_params, prompt
                 )
 
         except Exception as e:
@@ -268,10 +267,20 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
             else:
                 audio_data = audio_arrays
 
+            # prompt is batch-homogeneous in tt-metal's WhisperGenerator: take the
+            # first request's prompt and warn if requests disagree.
+            prompts = {req.prompt for req in requests if req.prompt is not None}
+            if len(prompts) > 1:
+                self.logger.warning(
+                    f"Device {self.device_id}: Batch contains differing prompts; using only the first request's prompt."
+                )
+            prompt = requests[0].prompt if requests else None
+
             result = await self.pipeline(
                 audio_data,
                 stream=False,
                 generation_params=generation_params,
+                prompt=prompt,
             )
 
             responses = []
@@ -296,23 +305,29 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
             )
             raise RuntimeError(f"Audio processing failed: {str(e)}") from e
 
-    async def _execute_pipeline_streaming(self, audio_data, generation_params):
+    async def _execute_pipeline_streaming(
+        self, audio_data, generation_params, prompt=None
+    ):
         """Async generator for streaming results"""
         generator = await self.pipeline(
             audio_data,
             stream=True,
             generation_params=generation_params,
+            prompt=prompt,
         )
 
         for item in generator:
             yield item
 
-    async def _execute_pipeline_non_streaming(self, audio_data, generation_params):
+    async def _execute_pipeline_non_streaming(
+        self, audio_data, generation_params, prompt=None
+    ):
         """Non-streaming pipeline execution"""
         result = await self.pipeline(
             audio_data,
             stream=False,
             generation_params=generation_params,
+            prompt=prompt,
         )
 
         if result is None:
@@ -351,6 +366,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                 segment_audio,
                 request.stream,
                 self._create_generation_params(request),
+                prompt=request.prompt,
             )
 
             segment_prefix = f"[{speaker}] "
@@ -452,6 +468,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                 segment_audio,
                 request.stream,
                 self._create_generation_params(request),
+                prompt=request.prompt,
             )
 
             cleaned_text, start, end = TextUtils.extract_text(segment_result)
@@ -719,6 +736,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                 generation_params: Optional[
                     Union[GenerationParams, List[GenerationParams]]
                 ] = None,
+                prompt: Optional[str] = None,
             ):
                 try:
                     # Validate pipeline inputs
@@ -760,6 +778,9 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                         return generator.generate(
                             current_batch=current_batch,
                             generation_params=generation_params,
+                            language=self.settings.audio_language,
+                            task=self.settings.audio_task,
+                            prompt=prompt,
                             stream_generation=stream,
                             return_perf_metrics=False,
                         )

--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -780,7 +780,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                             generation_params=generation_params,
                             language=self.settings.audio_language,
                             task=self.settings.audio_task,
-                            prompt=prompt,
+                            prompt=prompt or None,
                             stream_generation=stream,
                             return_perf_metrics=False,
                         )


### PR DESCRIPTION
### Propagate language, task, prompt
`TTWhisperRunner._create_generation_params()` was setting `language`, `task`, and `prompt` as dynamic attributes on `GenerationParams`, but tt-metal's `GenerationParams` does not declare those fields — its docstring says they "must be passed as separate parameters to `generate()`". They were silently dropped, so the defaults (`language="en"`, `task="transcribe"`, `prompt=None`) were always used and non-English `AUDIO_LANGUAGE` had no effect.

Fix: pass `language` / `task` / `prompt` as explicit kwargs to `generator.generate()`. `language` / `task` come from `self.settings`; `prompt` is per-request and plumbed through `_execute_pipeline*`.

### Batch handling for prompt
tt-metal's `WhisperGenerator` treats `prompt` as batch-homogeneous (one value per batch), but the API accepts a per-request `prompt`. When multiple requests are batched, the first request's `prompt` is used and a warning is logged if requests disagree — matching the existing first-request-wins behavior in this runner.

### Test plan
- [x] `AUDIO_LANGUAGE=Japanese AUDIO_TASK=transcribe` on t3k: Japanese audio now transcribes in Japanese (non-streaming + streaming).