### PR TITLE
Bump tt-forge to 1.2.0.dev20260525002812

### DIFF
--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
-tt-forge==1.1.0
+tt-forge==1.2.0.dev20260525002812
 torchvision
 
 tabulate


### PR DESCRIPTION
Automated version bump of `tt-forge` to `1.2.0.dev20260525002812` in `tt-media-server/Dockerfile.forge`.

### Checklist

- [ ] `resnet-50`: https://github.com/tenstorrent/tt-shield/actions/runs/26495551802
- [ ] `segformer`: https://github.com/tenstorrent/tt-shield/actions/runs/26495555799
