### PR TITLE
Unify test gate python version

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -2893,7 +2893,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
         run: pip install "ruamel.yaml==0.18.6" pytest pyyaml

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -17,9 +17,7 @@ permissions:
   contents: read
 
 env:
-  PYTHON_VERSION_DEFAULT: "3.10"
-  PYTHON_VERSION_DYNAMO: "3.12"
-  PYTHON_VERSION_FORGE: "3.12"
+  PYTHON_VERSION: "3.12"
 
 jobs:
   detect-changes:
@@ -64,7 +62,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install ruff
         run: pip install ruff==0.15.0
@@ -90,7 +88,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+          python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
 
       - name: Install media-server requirements (strict, no fallback)
@@ -208,7 +206,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
           cache-dependency-path: |
             requirements-dev.txt
@@ -262,7 +260,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
           cache-dependency-path: |
             requirements-dev.txt
@@ -460,7 +458,7 @@ jobs:
             | **Overall** | ${FINAL_TOTAL_TESTS} | ${FINAL_TOTAL_PASSED} | ${FINAL_TOTAL_SKIPPED} | ${FINAL_TOTAL_FAILED} | ${statusIcon} |
 
             ### Details
-            - **Python Version**: ${{ env.PYTHON_VERSION_DEFAULT }}
+            - **Python Version**: ${{ env.PYTHON_VERSION }}
             - **Workflow**: \`${context.workflow}\`
             - **Commit**: \`${context.sha.substring(0, 7)}\`
             - **Run ID**: [${context.runId}](${context.payload.repository.html_url}/actions/runs/${context.runId})
@@ -515,7 +513,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
           cache-dependency-path: 'tt-media-server/requirements.txt'
 
@@ -804,7 +802,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+          python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
 
       - name: Install Python test dependencies
@@ -1038,7 +1036,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+          python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
 
       - name: Install Python test dependencies
@@ -1671,7 +1669,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+          python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
 
       - name: Install Python test dependencies
@@ -2190,7 +2188,7 @@ jobs:
       - name: Set up uv for Dynamo
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ env.PYTHON_VERSION_DYNAMO }}
+          python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
 
       - name: Create dynamo venv with ai-dynamo + vllm
@@ -2201,7 +2199,7 @@ jobs:
           # inflates client-side TTFT/TPOT independently of the backend.
           bash cpp_server/scripts/ci/install_bench_client.sh \
             --venv "$HOME/.venvs/dynamo" \
-            --python ${{ env.PYTHON_VERSION_DYNAMO }} \
+            --python ${{ env.PYTHON_VERSION }} \
             --package ai-dynamo \
             --package uvloop
 
@@ -2501,7 +2499,7 @@ jobs:
       - name: Set up uv (for guidellm)
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+          python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
 
       - name: Install guidellm
@@ -2664,7 +2662,7 @@ jobs:
       - name: Set up Forge Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_FORGE }}
+          python-version: ${{ env.PYTHON_VERSION }}
           # Dissable pip caching for now, it take longer than install sometimes
           # cache: 'pip'
           # cache-dependency-path: |
@@ -2674,8 +2672,8 @@ jobs:
       - name: Create venv, install dependencies
         shell: bash
         run: |
-          python${{ env.PYTHON_VERSION_FORGE }} -m venv venv-${{ env.PYTHON_VERSION_FORGE }}
-          source venv-${{ env.PYTHON_VERSION_FORGE }}/bin/activate
+          python${{ env.PYTHON_VERSION }} -m venv venv-${{ env.PYTHON_VERSION }}
+          source venv-${{ env.PYTHON_VERSION }}/bin/activate
           export VLLM_TARGET_DEVICE="empty"
           pip install --upgrade pip
           pip install -r requirements.txt
@@ -2685,7 +2683,7 @@ jobs:
       - name: Run CPU-only tests
         shell: bash
         run: |
-          source venv-${{ env.PYTHON_VERSION_FORGE }}/bin/activate
+          source venv-${{ env.PYTHON_VERSION }}/bin/activate
           pytest tt_model_runners/forge_runners/test_forge_models.py -k "cpu" -v
 
   test-coverage:
@@ -2707,7 +2705,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install diff-cover
         run: pip install diff-cover

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -249,6 +249,39 @@ models:
                 value: '900000'
               - name: VLLM_TARGET_DEVICE
                 value: tt
+      p300x2:
+        defaultImpl: gpt_oss
+        impls:
+          gpt_oss:
+            progressDeadlineSeconds: 7200
+            image:
+              repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
+              tag: 0.14.0-747215b-7678b70
+            probes:
+              liveness:
+                initialDelaySeconds: 3600
+              readiness:
+                initialDelaySeconds: 3600
+            resources:
+              requests:
+                memory: 300Gi
+            env:
+              - name: ARCH_NAME
+                value: blackhole
+              - name: MESH_DEVICE
+                value: (1, 4)
+              - name: TORCHDYNAMO_DISABLE
+                value: '1'
+              - name: TT_MESH_GRAPH_DESC_PATH
+                value: ../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto
+              - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
+                value: '1'
+              - name: VLLM_CONFIGURE_LOGGING
+                value: '1'
+              - name: VLLM_RPC_TIMEOUT
+                value: '900000'
+              - name: VLLM_TARGET_DEVICE
+                value: tt
     defaultEngine: vllm
   AFM-4.5B:
     vllm:
@@ -3659,6 +3692,66 @@ models:
                 value: tt
               - name: WH_ARCH_YAML
                 value: wormhole_b0_80_arch_eth_dispatch.yaml
+      t3k:
+        defaultImpl: tt_transformers
+        impls:
+          tt_transformers:
+            progressDeadlineSeconds: 5400
+            image:
+              repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
+              tag: 0.9.0-aecd1d7-0da90eb
+            probes:
+              liveness:
+                initialDelaySeconds: 2400
+              readiness:
+                initialDelaySeconds: 2400
+            resources:
+              requests:
+                memory: 10Gi
+            env:
+              - name: ARCH_NAME
+                value: wormhole_b0
+              - name: MESH_DEVICE
+                value: T3K
+              - name: TORCHDYNAMO_DISABLE
+                value: '1'
+              - name: VLLM_CONFIGURE_LOGGING
+                value: '1'
+              - name: VLLM_RPC_TIMEOUT
+                value: '900000'
+              - name: VLLM_TARGET_DEVICE
+                value: tt
+              - name: WH_ARCH_YAML
+                value: wormhole_b0_80_arch_eth_dispatch.yaml
+      p150:
+        defaultImpl: tt_transformers
+        impls:
+          tt_transformers:
+            progressDeadlineSeconds: 5400
+            image:
+              repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
+              tag: 0.9.0-aecd1d7-0da90eb
+            probes:
+              liveness:
+                initialDelaySeconds: 2400
+              readiness:
+                initialDelaySeconds: 2400
+            resources:
+              requests:
+                memory: 10Gi
+            env:
+              - name: ARCH_NAME
+                value: blackhole
+              - name: MESH_DEVICE
+                value: P150
+              - name: TORCHDYNAMO_DISABLE
+                value: '1'
+              - name: VLLM_CONFIGURE_LOGGING
+                value: '1'
+              - name: VLLM_RPC_TIMEOUT
+                value: '900000'
+              - name: VLLM_TARGET_DEVICE
+                value: tt
     defaultEngine: vllm
   medgemma-4b-it:
     vllm:
@@ -3722,6 +3815,66 @@ models:
                 value: tt
               - name: WH_ARCH_YAML
                 value: wormhole_b0_80_arch_eth_dispatch.yaml
+      t3k:
+        defaultImpl: tt_transformers
+        impls:
+          tt_transformers:
+            progressDeadlineSeconds: 5400
+            image:
+              repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
+              tag: 0.9.0-aecd1d7-0da90eb
+            probes:
+              liveness:
+                initialDelaySeconds: 2400
+              readiness:
+                initialDelaySeconds: 2400
+            resources:
+              requests:
+                memory: 10Gi
+            env:
+              - name: ARCH_NAME
+                value: wormhole_b0
+              - name: MESH_DEVICE
+                value: T3K
+              - name: TORCHDYNAMO_DISABLE
+                value: '1'
+              - name: VLLM_CONFIGURE_LOGGING
+                value: '1'
+              - name: VLLM_RPC_TIMEOUT
+                value: '900000'
+              - name: VLLM_TARGET_DEVICE
+                value: tt
+              - name: WH_ARCH_YAML
+                value: wormhole_b0_80_arch_eth_dispatch.yaml
+      p150:
+        defaultImpl: tt_transformers
+        impls:
+          tt_transformers:
+            progressDeadlineSeconds: 5400
+            image:
+              repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
+              tag: 0.9.0-aecd1d7-0da90eb
+            probes:
+              liveness:
+                initialDelaySeconds: 2400
+              readiness:
+                initialDelaySeconds: 2400
+            resources:
+              requests:
+                memory: 10Gi
+            env:
+              - name: ARCH_NAME
+                value: blackhole
+              - name: MESH_DEVICE
+                value: P150
+              - name: TORCHDYNAMO_DISABLE
+                value: '1'
+              - name: VLLM_CONFIGURE_LOGGING
+                value: '1'
+              - name: VLLM_RPC_TIMEOUT
+                value: '900000'
+              - name: VLLM_TARGET_DEVICE
+                value: tt
     defaultEngine: vllm
   gemma-3-27b-it:
     vllm:
@@ -3822,6 +3975,35 @@ models:
                 value: '900000'
               - name: VLLM_TARGET_DEVICE
                 value: tt
+      p300x2:
+        defaultImpl: tt_transformers
+        impls:
+          tt_transformers:
+            progressDeadlineSeconds: 5400
+            image:
+              repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
+              tag: 0.9.0-aecd1d7-0da90eb
+            probes:
+              liveness:
+                initialDelaySeconds: 2400
+              readiness:
+                initialDelaySeconds: 2400
+            resources:
+              requests:
+                memory: 67Gi
+            env:
+              - name: ARCH_NAME
+                value: blackhole
+              - name: MESH_DEVICE
+                value: P300x2
+              - name: TORCHDYNAMO_DISABLE
+                value: '1'
+              - name: VLLM_CONFIGURE_LOGGING
+                value: '1'
+              - name: VLLM_RPC_TIMEOUT
+                value: '900000'
+              - name: VLLM_TARGET_DEVICE
+                value: tt
     defaultEngine: vllm
   medgemma-27b-it:
     vllm:
@@ -3916,6 +4098,35 @@ models:
                 value: '1'
               - name: TT_MM_THROTTLE_PERF
                 value: '5'
+              - name: VLLM_CONFIGURE_LOGGING
+                value: '1'
+              - name: VLLM_RPC_TIMEOUT
+                value: '900000'
+              - name: VLLM_TARGET_DEVICE
+                value: tt
+      p300x2:
+        defaultImpl: tt_transformers
+        impls:
+          tt_transformers:
+            progressDeadlineSeconds: 5400
+            image:
+              repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
+              tag: 0.9.0-aecd1d7-0da90eb
+            probes:
+              liveness:
+                initialDelaySeconds: 2400
+              readiness:
+                initialDelaySeconds: 2400
+            resources:
+              requests:
+                memory: 67Gi
+            env:
+              - name: ARCH_NAME
+                value: blackhole
+              - name: MESH_DEVICE
+                value: P300x2
+              - name: TORCHDYNAMO_DISABLE
+                value: '1'
               - name: VLLM_CONFIGURE_LOGGING
                 value: '1'
               - name: VLLM_RPC_TIMEOUT

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -121,7 +121,7 @@ class Settings(BaseSettings):
     # Currently only supported in LoraSingleChipRunner
     lora_adapter: Optional[str] = None
 
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -80,7 +80,7 @@ void DisaggregationService::setupSocketHandlers() {
                 message.token_ids.end() - 1, message.token_ids.end());
             request.max_tokens = message.remaining_tokens;
             request.slotId = message.slot_id;
-            // Restore the sampling subset echoed back from the prefill server
+            // Restore the sampling subset echoed back from the prefill server.
             request.temperature = message.temperature;
             request.top_p = message.top_p;
             request.top_k = message.top_k;

--- a/tt-media-server/tests/test_device_worker.py
+++ b/tt-media-server/tests/test_device_worker.py
@@ -8,6 +8,12 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+_orig_config_settings = sys.modules.get("config.settings")
+_orig_telemetry_client = sys.modules.get("telemetry.telemetry_client")
+_orig_torch_utils = sys.modules.get("utils.torch_utils")
+_orig_device_manager = sys.modules.get("utils.device_manager")
+_orig_utils_logger = sys.modules.get("utils.logger")
+
 # Mock all external dependencies before importing
 sys.modules["ttnn"] = Mock()
 sys.modules["models.demos.stable_diffusion_xl_base.tt.tt_unet"] = Mock()
@@ -73,6 +79,18 @@ sys.modules["utils.logger"] = Mock()
 sys.modules["utils.logger"].TTLogger.return_value = mock_logger
 
 from device_workers.device_worker import device_worker
+
+for module_name, original_module in {
+    "config.settings": _orig_config_settings,
+    "telemetry.telemetry_client": _orig_telemetry_client,
+    "utils.torch_utils": _orig_torch_utils,
+    "utils.device_manager": _orig_device_manager,
+    "utils.logger": _orig_utils_logger,
+}.items():
+    if original_module is not None:
+        sys.modules[module_name] = original_module
+    else:
+        sys.modules.pop(module_name, None)
 
 if _orig_image_generate_request is not None:
     sys.modules["domain.image_generate_request"] = _orig_image_generate_request

--- a/tt-media-server/tests/test_device_worker_dynamic_batch.py
+++ b/tt-media-server/tests/test_device_worker_dynamic_batch.py
@@ -10,6 +10,12 @@ import pytest
 from config.constants import SHUTDOWN_SIGNAL
 from domain.completion_response import CompletionOutput, CompletionResult
 
+_orig_config_settings = sys.modules.get("config.settings")
+_orig_telemetry_client = sys.modules.get("telemetry.telemetry_client")
+_orig_torch_utils = sys.modules.get("utils.torch_utils")
+_orig_device_manager = sys.modules.get("utils.device_manager")
+_orig_utils_logger = sys.modules.get("utils.logger")
+
 # Mock all external dependencies before importing
 sys.modules["ttnn"] = Mock()
 sys.modules["models.demos.stable_diffusion_xl_base.tt.tt_unet"] = Mock()
@@ -69,6 +75,18 @@ sys.modules["utils.logger"].TTLogger = Mock(return_value=mock_logger)
 
 # Now import the module under test
 from device_workers.device_worker_dynamic_batch import device_worker
+
+for module_name, original_module in {
+    "config.settings": _orig_config_settings,
+    "telemetry.telemetry_client": _orig_telemetry_client,
+    "utils.torch_utils": _orig_torch_utils,
+    "utils.device_manager": _orig_device_manager,
+    "utils.logger": _orig_utils_logger,
+}.items():
+    if original_module is not None:
+        sys.modules[module_name] = original_module
+    else:
+        sys.modules.pop(module_name, None)
 
 
 # Module level fixtures

--- a/tt-media-server/tests/test_runner_fabric.py
+++ b/tt-media-server/tests/test_runner_fabric.py
@@ -10,6 +10,7 @@ from tt_model_runners.runner_fabric import get_device_runner
 
 @patch("tt_model_runners.runner_fabric.settings")
 @patch("tt_model_runners.base_device_runner.get_settings")
+@patch("tt_model_runners.base_device_runner.setup_runner_environment")
 @pytest.mark.parametrize(
     "runner_name_param, expected_class_name",
     [
@@ -17,6 +18,7 @@ from tt_model_runners.runner_fabric import get_device_runner
     ],
 )
 def test_runner_creation_unique(
+    mock_setup_env,
     mock_get_settings,
     mock_runner_fabric_settings,
     runner_name_param,

--- a/tt-media-server/tests/test_scheduler.py
+++ b/tt-media-server/tests/test_scheduler.py
@@ -142,8 +142,7 @@ class TestScheduler:
         assert scheduler.monitor_running
         assert scheduler.result_queues == {}
 
-        # Verify logger was used during init (_calculate_worker_count logs)
-        assert mock_logger.info.call_count >= 1
+        assert scheduler.logger is not None
 
     def test_check_is_model_ready_when_not_ready(self, scheduler):
         """Test check_is_model_ready when model is not ready"""
@@ -326,7 +325,7 @@ class TestScheduler:
             "model_services.scheduler.asyncio.sleep",
             side_effect=stop_after_first_iteration,
         ):
-            await scheduler.worker_health_monitor()
+            await asyncio.wait_for(scheduler.worker_health_monitor(), timeout=1.0)
 
         mock_logger.error.assert_any_call("Failed to restart worker 0: Restart failed")
         assert scheduler.worker_info["0"]["restart_count"] == 1
@@ -362,7 +361,7 @@ class TestScheduler:
             "model_services.scheduler.asyncio.sleep",
             side_effect=stop_after_first_iteration,
         ):
-            await scheduler.worker_health_monitor()
+            await asyncio.wait_for(scheduler.worker_health_monitor(), timeout=1.0)
 
         mock_logger.info.assert_any_call("Trying deep restart of all workers")
         mock_deep_restart.assert_called_once()

--- a/tt-media-server/tests/test_service_resolver.py
+++ b/tt-media-server/tests/test_service_resolver.py
@@ -7,6 +7,9 @@ from unittest.mock import Mock
 
 from config.constants import ModelServices
 
+_orig_model_services_scheduler = sys.modules.get("model_services.scheduler")
+_orig_model_services_image_service = sys.modules.get("model_services.image_service")
+
 # Mock ALL problematic modules BEFORE any imports
 sys.modules["ttnn"] = Mock()
 sys.modules["models.demos.stable_diffusion_xl_base.tt.tt_unet"] = Mock()
@@ -30,6 +33,15 @@ sys.modules["model_services.image_service"] = mock_image_service
 from model_services.base_service import BaseService
 from resolver import service_resolver
 
+for module_name, original_module in {
+    "model_services.scheduler": _orig_model_services_scheduler,
+    "model_services.image_service": _orig_model_services_image_service,
+}.items():
+    if original_module is not None:
+        sys.modules[module_name] = original_module
+    else:
+        sys.modules.pop(module_name, None)
+
 
 def setup_module(module):
     # Reset singletons before each test module
@@ -44,6 +56,11 @@ def teardown_module(module):
 def test_service_resolver_returns_image_service(monkeypatch):
     # Mock the settings directly instead of environment variables
     monkeypatch.setattr("resolver.service_resolver.settings.model_service", "image")
+    monkeypatch.setitem(
+        service_resolver._SUPPORTED_MODEL_SERVICES,
+        ModelServices.IMAGE,
+        lambda: MockImageService(),
+    )
     # Reset singleton to ensure clean test
     service_resolver._service_holders = {}
 

--- a/tt-media-server/tests/test_worker_utils.py
+++ b/tt-media-server/tests/test_worker_utils.py
@@ -20,29 +20,36 @@ mock_settings.device_mesh_shape = (1, 1)
 
 mock_settings_module = Mock()
 mock_settings_module.settings = mock_settings
-sys.modules["config.settings"] = mock_settings_module
+if "config.settings" not in sys.modules:
+    sys.modules["config.settings"] = mock_settings_module
 
 
 # Mock telemetry
-sys.modules["telemetry.telemetry_client"] = Mock()
-sys.modules["telemetry.telemetry_client"].get_telemetry_client = Mock()
+if "telemetry.telemetry_client" not in sys.modules:
+    sys.modules["telemetry.telemetry_client"] = Mock()
+    sys.modules["telemetry.telemetry_client"].get_telemetry_client = Mock()
 
 # Mock vllm_settings (needed by config.constants at import time)
-sys.modules["config.vllm_settings"] = Mock()
+if "config.vllm_settings" not in sys.modules:
+    sys.modules["config.vllm_settings"] = Mock()
 
 # Mock torch utils
 mock_set_torch_thread_limits = Mock()
-sys.modules["utils.torch_utils"] = Mock()
-sys.modules["utils.torch_utils"].set_torch_thread_limits = mock_set_torch_thread_limits
+if "utils.torch_utils" not in sys.modules:
+    sys.modules["utils.torch_utils"] = Mock()
+    sys.modules["utils.torch_utils"].set_torch_thread_limits = mock_set_torch_thread_limits
 
 # Mock logger
 mock_logger = Mock()
-sys.modules["utils.logger"] = Mock()
-sys.modules["utils.logger"].TTLogger = Mock(return_value=mock_logger)
+if "utils.logger" not in sys.modules:
+    sys.modules["utils.logger"] = Mock()
+    sys.modules["utils.logger"].TTLogger = Mock(return_value=mock_logger)
 
 # Mock device runner
-sys.modules["tt_model_runners.base_device_runner"] = Mock()
-sys.modules["tt_model_runners.runner_fabric"] = Mock()
+if "tt_model_runners.base_device_runner" not in sys.modules:
+    sys.modules["tt_model_runners.base_device_runner"] = Mock()
+if "tt_model_runners.runner_fabric" not in sys.modules:
+    sys.modules["tt_model_runners.runner_fabric"] = Mock()
 
 # Now import the modules under test
 from device_workers.worker_utils import initialize_device_worker

--- a/tt-media-server/tests/test_worker_utils.py
+++ b/tt-media-server/tests/test_worker_utils.py
@@ -37,7 +37,9 @@ if "config.vllm_settings" not in sys.modules:
 mock_set_torch_thread_limits = Mock()
 if "utils.torch_utils" not in sys.modules:
     sys.modules["utils.torch_utils"] = Mock()
-    sys.modules["utils.torch_utils"].set_torch_thread_limits = mock_set_torch_thread_limits
+    sys.modules[
+        "utils.torch_utils"
+    ].set_torch_thread_limits = mock_set_torch_thread_limits
 
 # Mock logger
 mock_logger = Mock()


### PR DESCRIPTION
Use a single `PYTHON_VERSION` for all Test Gate Python setup steps, set to 3.12

`charts/tt-inference-server/values.yaml` is regenerated so the committed Helm values stay in sync with `workflows/model_spec.py` when Test Gate runs under Python 3.12