### PR TITLE
Gateway and socket code cleanup

### DIFF
--- a/tt-media-server/cpp_server/include/sockets/i_socket_transport.hpp
+++ b/tt-media-server/cpp_server/include/sockets/i_socket_transport.hpp
@@ -3,10 +3,13 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <span>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace tt::sockets {
@@ -15,8 +18,8 @@ namespace tt::sockets {
  * @brief Wire-format names for SOCKET_TRANSPORT.
  */
 namespace transport_names {
-constexpr const char* TCP = "tcp";
-constexpr const char* ZMQ = "zmq";
+constexpr std::string_view TCP = "tcp";
+constexpr std::string_view ZMQ = "zmq";
 }  // namespace transport_names
 
 /**
@@ -41,15 +44,15 @@ class ISocketTransport {
   virtual bool isConnected() const = 0;
   virtual std::string getStatus() const = 0;
 
-  virtual bool sendRawData(const std::vector<uint8_t>& data) = 0;
+  virtual bool sendRawData(std::span<const uint8_t> data) = 0;
   virtual std::vector<uint8_t> receiveRawData() = 0;
 
   virtual void setConnectionLostCallback(std::function<void()> callback) = 0;
   virtual void setConnectionEstablishedCallback(
       std::function<void()> callback) = 0;
 
-  virtual void setReconnectBackoff(uint32_t /*initialDelayMs*/,
-                                   uint32_t /*maxDelayMs*/) {}
+  virtual void setReconnectBackoff(std::chrono::milliseconds /*initialDelay*/,
+                                   std::chrono::milliseconds /*maxDelay*/) {}
 };
 
 /**

--- a/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
@@ -5,11 +5,13 @@
 
 #include <cereal/types/string.hpp>
 #include <cereal/types/vector.hpp>
+#include <chrono>
 #include <functional>
 #include <map>
 #include <mutex>
 #include <stop_token>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -56,7 +58,7 @@ class SocketManager {
    * @return true if successful
    */
   template <typename T>
-  bool sendObject(const std::string& messageType, const T& obj);
+  bool sendObject(std::string_view messageType, const T& obj);
 
   /**
    * @brief Register handler for incoming messages of specific type
@@ -64,7 +66,7 @@ class SocketManager {
    * @param handler Function to call when message is received
    */
   template <typename T>
-  void registerHandler(const std::string& messageType,
+  void registerHandler(std::string_view messageType,
                        std::function<void(const T&)> handler);
 
   /**
@@ -101,13 +103,14 @@ class SocketManager {
    * @brief Configure client-mode reconnect backoff (defaults: 100ms/5000ms).
    * Must be called before start().
    */
-  void setReconnectBackoff(uint32_t initialDelayMs, uint32_t maxDelayMs);
+  void setReconnectBackoff(std::chrono::milliseconds initialDelay,
+                           std::chrono::milliseconds maxDelay);
 
  private:
   void messageLoop(std::stop_token stopToken);
   void handleIncomingMessage(const std::vector<uint8_t>& data);
   std::function<void(const std::vector<uint8_t>&)> getHandler(
-      const std::string& messageType) const;
+      std::string_view messageType) const;
 
   std::unique_ptr<ISocketTransport> transport_;
 
@@ -115,14 +118,15 @@ class SocketManager {
   std::jthread messageThread_;
 
   mutable std::mutex handlersMutex_;
-  std::map<std::string, std::function<void(const std::vector<uint8_t>&)>>
+  std::map<std::string, std::function<void(const std::vector<uint8_t>&)>,
+           std::less<>>
       handlers_;
 
   std::function<void()> pendingConnectionLostCallback_;
   std::function<void()> pendingConnectionEstablishedCallback_;
   bool reconnectBackoffSet_{false};
-  uint32_t reconnectInitialDelayMs_{0};
-  uint32_t reconnectMaxDelayMs_{0};
+  std::chrono::milliseconds reconnectInitialDelay_{0};
+  std::chrono::milliseconds reconnectMaxDelay_{0};
 
   void applyPendingSettings();
 };
@@ -130,7 +134,7 @@ class SocketManager {
 // Template implementations
 
 template <typename T>
-bool SocketManager::sendObject(const std::string& messageType, const T& obj) {
+bool SocketManager::sendObject(std::string_view messageType, const T& obj) {
   if (!transport_) {
     return false;
   }
@@ -145,18 +149,19 @@ bool SocketManager::sendObject(const std::string& messageType, const T& obj) {
 }
 
 template <typename T>
-void SocketManager::registerHandler(const std::string& messageType,
+void SocketManager::registerHandler(std::string_view messageType,
                                     std::function<void(const T&)> handler) {
   std::lock_guard<std::mutex> lock(handlersMutex_);
 
-  handlers_[messageType] = [handler](const std::vector<uint8_t>& data) {
-    try {
-      T payload = wire::deserializePayload<T>(data);
-      handler(payload);
-    } catch (const std::exception& e) {
-      TT_LOG_ERROR("[SocketManager] Deserialization error: {}", e.what());
-    }
-  };
+  handlers_[std::string(messageType)] =
+      [handler](const std::vector<uint8_t>& data) {
+        try {
+          T payload = wire::deserializePayload<T>(data);
+          handler(payload);
+        } catch (const std::exception& e) {
+          TT_LOG_ERROR("[SocketManager] Deserialization error: {}", e.what());
+        }
+      };
 }
 
 }  // namespace tt::sockets

--- a/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "domain/slot_types.hpp"
@@ -309,12 +310,13 @@ struct PrefillCacheBlocksEvictedMessage
 // Wire-protocol tags for the new gateway messages. Existing tags
 // ("prefill_request", etc.) remain string literals at their call sites.
 namespace tags {
-constexpr const char* PREFILL_REGISTRATION = "prefill_registration";
-constexpr const char* PREFILL_ASSIGNMENT = "prefill_assignment";
-constexpr const char* PREFILL_CACHE_BLOCKS_ADDED = "prefill_cache_added";
-constexpr const char* PREFILL_CACHE_BLOCKS_EVICTED = "prefill_cache_evicted";
-constexpr const char* REGISTRATION_PROBE = "registration_probe";
-constexpr const char* CANCEL_PREFILL = "cancel_prefill";
+constexpr std::string_view PREFILL_REGISTRATION = "prefill_registration";
+constexpr std::string_view PREFILL_ASSIGNMENT = "prefill_assignment";
+constexpr std::string_view PREFILL_CACHE_BLOCKS_ADDED = "prefill_cache_added";
+constexpr std::string_view PREFILL_CACHE_BLOCKS_EVICTED =
+    "prefill_cache_evicted";
+constexpr std::string_view REGISTRATION_PROBE = "registration_probe";
+constexpr std::string_view CANCEL_PREFILL = "cancel_prefill";
 }  // namespace tags
 
 }  // namespace tt::sockets

--- a/tt-media-server/cpp_server/include/sockets/socket_serialization.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_serialization.hpp
@@ -6,19 +6,22 @@
 #include <cereal/archives/binary.hpp>
 #include <cereal/types/string.hpp>
 #include <cstdint>
+#include <span>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace tt::sockets::wire {
 
 template <typename T>
-std::vector<uint8_t> serializeMessage(const std::string& messageType,
+std::vector<uint8_t> serializeMessage(std::string_view messageType,
                                       const T& obj) {
   std::ostringstream oss;
   {
     cereal::BinaryOutputArchive archive(oss);
-    archive(messageType);
+    std::string messageTypeString(messageType);
+    archive(messageTypeString);
     obj.write(archive);
   }
 
@@ -26,8 +29,16 @@ std::vector<uint8_t> serializeMessage(const std::string& messageType,
   return {serialized.begin(), serialized.end()};
 }
 
-inline std::string readMessageType(const std::vector<uint8_t>& data) {
-  std::string serialized(data.begin(), data.end());
+inline std::string toSerializedString(std::span<const uint8_t> data) {
+  if (data.empty()) {
+    return {};
+  }
+  const auto* bytes = reinterpret_cast<const char*>(data.data());
+  return {bytes, data.size()};
+}
+
+inline std::string readMessageType(std::span<const uint8_t> data) {
+  std::string serialized = toSerializedString(data);
   std::istringstream iss(serialized);
 
   cereal::BinaryInputArchive archive(iss);
@@ -37,8 +48,8 @@ inline std::string readMessageType(const std::vector<uint8_t>& data) {
 }
 
 template <typename T>
-T deserializePayload(const std::vector<uint8_t>& data) {
-  std::string serialized(data.begin(), data.end());
+T deserializePayload(std::span<const uint8_t> data) {
+  std::string serialized = toSerializedString(data);
   std::istringstream iss(serialized);
 
   cereal::BinaryInputArchive archive(iss);

--- a/tt-media-server/cpp_server/include/sockets/socket_transport_state.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_transport_state.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <atomic>
-#include <cstdint>
+#include <chrono>
 #include <functional>
 #include <mutex>
 #include <string>
@@ -19,10 +19,12 @@ class SocketTransportState {
  protected:
   enum class Mode { SERVER, CLIENT };
 
-  SocketTransportState(uint32_t reconnectInitialDelayMs = 100,
-                       uint32_t reconnectMaxDelayMs = 5000)
-      : reconnectInitialDelayMs_(reconnectInitialDelayMs),
-        reconnectMaxDelayMs_(reconnectMaxDelayMs) {}
+  SocketTransportState(std::chrono::milliseconds reconnectInitialDelay =
+                           std::chrono::milliseconds(100),
+                       std::chrono::milliseconds reconnectMaxDelay =
+                           std::chrono::milliseconds(5000))
+      : reconnectInitialDelay_(reconnectInitialDelay),
+        reconnectMaxDelay_(reconnectMaxDelay) {}
 
   bool isConnectedState() const { return connected_; }
 
@@ -74,16 +76,17 @@ class SocketTransportState {
     }
   }
 
-  void setReconnectBackoffCommon(uint32_t initialDelayMs, uint32_t maxDelayMs) {
-    reconnectInitialDelayMs_ = initialDelayMs;
-    reconnectMaxDelayMs_ = maxDelayMs;
+  void setReconnectBackoffCommon(std::chrono::milliseconds initialDelay,
+                                 std::chrono::milliseconds maxDelay) {
+    reconnectInitialDelay_ = initialDelay;
+    reconnectMaxDelay_ = maxDelay;
   }
 
   Mode mode_{Mode::CLIENT};
   std::atomic<bool> running_{false};
   std::atomic<bool> connected_{false};
-  uint32_t reconnectInitialDelayMs_;
-  uint32_t reconnectMaxDelayMs_;
+  std::chrono::milliseconds reconnectInitialDelay_;
+  std::chrono::milliseconds reconnectMaxDelay_;
 
  private:
   mutable std::mutex callbackMutex_;

--- a/tt-media-server/cpp_server/include/sockets/tcp_socket_transport.hpp
+++ b/tt-media-server/cpp_server/include/sockets/tcp_socket_transport.hpp
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <functional>
 #include <mutex>
+#include <span>
 #include <stop_token>
 #include <string>
 #include <thread>
@@ -47,14 +48,14 @@ class TcpSocketTransport : public ISocketTransport,
   bool isConnected() const override;
   std::string getStatus() const override;
 
-  bool sendRawData(const std::vector<uint8_t>& data) override;
+  bool sendRawData(std::span<const uint8_t> data) override;
   std::vector<uint8_t> receiveRawData() override;
 
   void setConnectionLostCallback(std::function<void()> callback) override;
   void setConnectionEstablishedCallback(
       std::function<void()> callback) override;
-  void setReconnectBackoff(uint32_t initialDelayMs,
-                           uint32_t maxDelayMs) override;
+  void setReconnectBackoff(std::chrono::milliseconds initialDelay,
+                           std::chrono::milliseconds maxDelay) override;
 
  private:
   enum class ReceiveResult { COMPLETE, NO_DATA, DISCONNECTED };

--- a/tt-media-server/cpp_server/include/sockets/zmq_socket_transport.hpp
+++ b/tt-media-server/cpp_server/include/sockets/zmq_socket_transport.hpp
@@ -10,6 +10,7 @@
 #include <future>
 #include <memory>
 #include <mutex>
+#include <span>
 #include <stop_token>
 #include <string>
 #include <thread>
@@ -50,14 +51,14 @@ class ZmqSocketTransport : public ISocketTransport,
   bool isConnected() const override;
   std::string getStatus() const override;
 
-  bool sendRawData(const std::vector<uint8_t>& data) override;
+  bool sendRawData(std::span<const uint8_t> data) override;
   std::vector<uint8_t> receiveRawData() override;
 
   void setConnectionLostCallback(std::function<void()> callback) override;
   void setConnectionEstablishedCallback(
       std::function<void()> callback) override;
-  void setReconnectBackoff(uint32_t initialDelayMs,
-                           uint32_t maxDelayMs) override;
+  void setReconnectBackoff(std::chrono::milliseconds initialDelay,
+                           std::chrono::milliseconds maxDelay) override;
 
  private:
   struct SendRequest {

--- a/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
+++ b/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
@@ -26,8 +26,7 @@ void SocketManager::applyPendingSettings() {
         std::move(pendingConnectionEstablishedCallback_));
   }
   if (reconnectBackoffSet_) {
-    transport_->setReconnectBackoff(reconnectInitialDelayMs_,
-                                    reconnectMaxDelayMs_);
+    transport_->setReconnectBackoff(reconnectInitialDelay_, reconnectMaxDelay_);
   }
 }
 
@@ -105,7 +104,7 @@ void SocketManager::handleIncomingMessage(const std::vector<uint8_t>& data) {
 }
 
 std::function<void(const std::vector<uint8_t>&)> SocketManager::getHandler(
-    const std::string& messageType) const {
+    std::string_view messageType) const {
   std::lock_guard<std::mutex> lock(handlersMutex_);
   auto it = handlers_.find(messageType);
   if (it == handlers_.end()) {
@@ -139,14 +138,14 @@ void SocketManager::setConnectionEstablishedCallback(
   }
 }
 
-void SocketManager::setReconnectBackoff(uint32_t initialDelayMs,
-                                        uint32_t maxDelayMs) {
+void SocketManager::setReconnectBackoff(std::chrono::milliseconds initialDelay,
+                                        std::chrono::milliseconds maxDelay) {
   if (transport_) {
-    transport_->setReconnectBackoff(initialDelayMs, maxDelayMs);
+    transport_->setReconnectBackoff(initialDelay, maxDelay);
   } else {
     reconnectBackoffSet_ = true;
-    reconnectInitialDelayMs_ = initialDelayMs;
-    reconnectMaxDelayMs_ = maxDelayMs;
+    reconnectInitialDelay_ = initialDelay;
+    reconnectMaxDelay_ = maxDelay;
   }
 }
 

--- a/tt-media-server/cpp_server/src/sockets/tcp_socket_transport.cpp
+++ b/tt-media-server/cpp_server/src/sockets/tcp_socket_transport.cpp
@@ -256,10 +256,10 @@ void TcpSocketTransport::serverLoop(std::stop_token stopToken) {
 }
 
 void TcpSocketTransport::clientLoop(std::stop_token stopToken) {
-  uint32_t delayMs = reconnectInitialDelayMs_;
+  auto delay = reconnectInitialDelay_;
   auto backoff = [&]() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
-    delayMs = std::min(delayMs * 2, reconnectMaxDelayMs_);
+    std::this_thread::sleep_for(delay);
+    delay = std::min(delay * 2, reconnectMaxDelay_);
   };
 
   while (running_ && !stopToken.stop_requested()) {
@@ -284,7 +284,7 @@ void TcpSocketTransport::clientLoop(std::stop_token stopToken) {
 
     TT_LOG_INFO(
         "[TcpSocketTransport] Attempting to connect to {}:{} (backoff {}ms)",
-        host_, port_, delayMs);
+        host_, port_, delay.count());
 
     if (connect(clientSocket_.get(), (struct sockaddr*)&serverAddr,
                 sizeof(serverAddr)) < 0) {
@@ -299,7 +299,7 @@ void TcpSocketTransport::clientLoop(std::stop_token stopToken) {
 
     peerSocket_.store(clientSocket_.get(), std::memory_order_release);
     connected_ = true;
-    delayMs = reconnectInitialDelayMs_;  // reset on success
+    delay = reconnectInitialDelay_;  // reset on success
 
     TT_LOG_INFO("[TcpSocketTransport] Connected to server");
     notifyConnectionEstablished();
@@ -320,7 +320,7 @@ void TcpSocketTransport::clientLoop(std::stop_token stopToken) {
   }
 }
 
-bool TcpSocketTransport::sendRawData(const std::vector<uint8_t>& data) {
+bool TcpSocketTransport::sendRawData(std::span<const uint8_t> data) {
   std::lock_guard<std::mutex> lock(socketMutex_);
   if (!connected_) return false;
 
@@ -450,9 +450,10 @@ void TcpSocketTransport::setConnectionEstablishedCallback(
   setConnectionEstablishedCallbackCommon(std::move(callback));
 }
 
-void TcpSocketTransport::setReconnectBackoff(uint32_t initialDelayMs,
-                                             uint32_t maxDelayMs) {
-  setReconnectBackoffCommon(initialDelayMs, maxDelayMs);
+void TcpSocketTransport::setReconnectBackoff(
+    std::chrono::milliseconds initialDelay,
+    std::chrono::milliseconds maxDelay) {
+  setReconnectBackoffCommon(initialDelay, maxDelay);
 }
 
 }  // namespace tt::sockets

--- a/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
+++ b/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
@@ -26,8 +26,7 @@ std::string makeMonitorEndpoint(const void* self) {
 }  // namespace
 
 ZmqSocketTransport::ZmqSocketTransport()
-    : SocketTransportState(/*reconnectInitialDelayMs=*/1000,
-                           /*reconnectMaxDelayMs=*/5000),
+    : SocketTransportState(std::chrono::seconds(1), std::chrono::seconds(5)),
       context_(
           std::make_unique<zmq::context_t>(zmq_options::CONTEXT_IO_THREADS)) {}
 
@@ -98,9 +97,9 @@ bool ZmqSocketTransport::initializeSocket() {
     zmq_options::applyCommonOptions(*socket_);
     if (mode_ == Mode::CLIENT) {
       socket_->set(zmq::sockopt::reconnect_ivl,
-                   static_cast<int>(reconnectInitialDelayMs_));
+                   static_cast<int>(reconnectInitialDelay_.count()));
       socket_->set(zmq::sockopt::reconnect_ivl_max,
-                   static_cast<int>(reconnectMaxDelayMs_));
+                   static_cast<int>(reconnectMaxDelay_.count()));
     }
     setupMonitor();
     if (mode_ == Mode::SERVER) {
@@ -239,11 +238,11 @@ bool ZmqSocketTransport::isConnected() const { return isConnectedState(); }
 
 std::string ZmqSocketTransport::getStatus() const { return getStatusString(); }
 
-bool ZmqSocketTransport::sendRawData(const std::vector<uint8_t>& data) {
+bool ZmqSocketTransport::sendRawData(std::span<const uint8_t> data) {
   if (!running_ || !ioActive_) return false;
 
   auto request = std::make_shared<SendRequest>();
-  request->data = data;
+  request->data.assign(data.begin(), data.end());
   auto result = request->result.get_future();
 
   {
@@ -397,9 +396,10 @@ void ZmqSocketTransport::setConnectionEstablishedCallback(
   setConnectionEstablishedCallbackCommon(std::move(callback));
 }
 
-void ZmqSocketTransport::setReconnectBackoff(uint32_t initialDelayMs,
-                                             uint32_t maxDelayMs) {
-  setReconnectBackoffCommon(initialDelayMs, maxDelayMs);
+void ZmqSocketTransport::setReconnectBackoff(
+    std::chrono::milliseconds initialDelay,
+    std::chrono::milliseconds maxDelay) {
+  setReconnectBackoffCommon(initialDelay, maxDelay);
 }
 
 }  // namespace tt::sockets

--- a/tt-media-server/prefill_gateway/include/gateway/zmq_prefill_router.hpp
+++ b/tt-media-server/prefill_gateway/include/gateway/zmq_prefill_router.hpp
@@ -15,6 +15,7 @@
 #include <optional>
 #include <stop_token>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -36,12 +37,12 @@ class ZmqPrefillRouter {
   void stop();
 
   template <typename T>
-  bool sendObject(const std::string& serverId, const std::string& messageType,
+  bool sendObject(const std::string& serverId, std::string_view messageType,
                   const T& obj);
 
   template <typename T>
   void registerHandler(
-      const std::string& messageType,
+      std::string_view messageType,
       std::function<void(const PeerIdentity&, const T&)> handler);
 
   void rememberRegistration(const std::string& serverId,
@@ -97,8 +98,7 @@ class ZmqPrefillRouter {
 
 template <typename T>
 bool ZmqPrefillRouter::sendObject(const std::string& serverId,
-                                  const std::string& messageType,
-                                  const T& obj) {
+                                  std::string_view messageType, const T& obj) {
   auto peerId = peerIdForServer(serverId);
   if (!peerId.has_value()) {
     return false;
@@ -126,14 +126,14 @@ bool ZmqPrefillRouter::sendObject(const std::string& serverId,
 
 template <typename T>
 void ZmqPrefillRouter::registerHandler(
-    const std::string& messageType,
+    std::string_view messageType,
     std::function<void(const PeerIdentity&, const T&)> handler) {
   std::lock_guard<std::mutex> lock(handlers_mutex_);
-  handlers_[messageType] = [handler](const PeerIdentity& peerId,
-                                     const std::vector<uint8_t>& data) {
-    T payload = tt::sockets::wire::deserializePayload<T>(data);
-    handler(peerId, payload);
-  };
+  handlers_[std::string(messageType)] =
+      [handler](const PeerIdentity& peerId, const std::vector<uint8_t>& data) {
+        T payload = tt::sockets::wire::deserializePayload<T>(data);
+        handler(peerId, payload);
+      };
 }
 
 }  // namespace tt::gateway

--- a/tt-media-server/prefill_gateway/src/main.cpp
+++ b/tt-media-server/prefill_gateway/src/main.cpp
@@ -35,10 +35,10 @@ struct GatewayConfig {
   std::vector<PrefillEndpoint> prefills;
   std::string prefillBindHost = "*";
   uint16_t prefillBindPort = 0;
-  uint32_t prefillStaleTimeoutMs = 3000;
-  uint32_t requestTimeoutMs = 300000;
-  uint32_t timeoutWindowMs = 60000;
-  uint32_t timeoutCooldownMs = 30000;
+  std::chrono::milliseconds prefillStaleTimeout{3000};
+  std::chrono::milliseconds requestTimeout{300000};
+  std::chrono::milliseconds timeoutWindow{60000};
+  std::chrono::milliseconds timeoutCooldown{30000};
   uint32_t timeoutThreshold = 3;
 };
 
@@ -75,13 +75,13 @@ void printUsage(const char* prog) {
          "--prefill=192.168.1.2:7200\n";
 }
 
-std::optional<PrefillEndpoint> parsePrefillArg(const std::string& value) {
+std::optional<PrefillEndpoint> parsePrefillArg(std::string_view value) {
   auto colon = value.rfind(':');
   if (colon == std::string::npos || colon == 0 || colon == value.size() - 1) {
     return std::nullopt;
   }
-  std::string host = value.substr(0, colon);
-  int portInt = std::stoi(value.substr(colon + 1));
+  std::string host(value.substr(0, colon));
+  int portInt = std::stoi(std::string(value.substr(colon + 1)));
   if (portInt <= 0 || portInt > 65535) return std::nullopt;
   return PrefillEndpoint{std::move(host), static_cast<uint16_t>(portInt)};
 }
@@ -92,6 +92,18 @@ std::optional<std::string_view> flagValue(std::string_view arg,
     return arg.substr(prefix.size());
   }
   return std::nullopt;
+}
+
+std::optional<std::chrono::milliseconds> parseMilliseconds(
+    std::string_view value, std::string_view flagName, bool allowZero) {
+  const int timeoutMs = std::stoi(std::string(value));
+  if (timeoutMs < 0 || (!allowZero && timeoutMs == 0)) {
+    std::cerr << "Invalid " << flagName << " value: " << value << " (expected "
+              << (allowZero ? "non-negative" : "positive")
+              << " milliseconds)\n";
+    return std::nullopt;
+  }
+  return std::chrono::milliseconds(timeoutMs);
 }
 
 std::optional<GatewayConfig> parseArgs(int argc, char** argv) {
@@ -111,46 +123,42 @@ std::optional<GatewayConfig> parseArgs(int argc, char** argv) {
     }
 
     if (auto v = flagValue(arg, "--prefill-stale-timeout-ms=")) {
-      int timeoutMs = std::stoi(std::string(*v));
-      if (timeoutMs <= 0) {
-        std::cerr << "Invalid --prefill-stale-timeout-ms value: " << *v
-                  << " (expected positive milliseconds)\n";
+      auto timeout = parseMilliseconds(*v, "--prefill-stale-timeout-ms",
+                                       /*allowZero=*/false);
+      if (!timeout) {
         return std::nullopt;
       }
-      cfg.prefillStaleTimeoutMs = static_cast<uint32_t>(timeoutMs);
+      cfg.prefillStaleTimeout = *timeout;
       continue;
     }
 
     if (auto v = flagValue(arg, "--request-timeout-ms=")) {
-      int timeoutMs = std::stoi(std::string(*v));
-      if (timeoutMs < 0) {
-        std::cerr << "Invalid --request-timeout-ms value: " << *v
-                  << " (expected non-negative milliseconds)\n";
+      auto timeout =
+          parseMilliseconds(*v, "--request-timeout-ms", /*allowZero=*/true);
+      if (!timeout) {
         return std::nullopt;
       }
-      cfg.requestTimeoutMs = static_cast<uint32_t>(timeoutMs);
+      cfg.requestTimeout = *timeout;
       continue;
     }
 
     if (auto v = flagValue(arg, "--timeout-window-ms=")) {
-      int timeoutMs = std::stoi(std::string(*v));
-      if (timeoutMs < 0) {
-        std::cerr << "Invalid --timeout-window-ms value: " << *v
-                  << " (expected non-negative milliseconds)\n";
+      auto timeout =
+          parseMilliseconds(*v, "--timeout-window-ms", /*allowZero=*/true);
+      if (!timeout) {
         return std::nullopt;
       }
-      cfg.timeoutWindowMs = static_cast<uint32_t>(timeoutMs);
+      cfg.timeoutWindow = *timeout;
       continue;
     }
 
     if (auto v = flagValue(arg, "--timeout-cooldown-ms=")) {
-      int timeoutMs = std::stoi(std::string(*v));
-      if (timeoutMs < 0) {
-        std::cerr << "Invalid --timeout-cooldown-ms value: " << *v
-                  << " (expected non-negative milliseconds)\n";
+      auto timeout =
+          parseMilliseconds(*v, "--timeout-cooldown-ms", /*allowZero=*/true);
+      if (!timeout) {
         return std::nullopt;
       }
-      cfg.timeoutCooldownMs = static_cast<uint32_t>(timeoutMs);
+      cfg.timeoutCooldown = *timeout;
       continue;
     }
 
@@ -166,7 +174,7 @@ std::optional<GatewayConfig> parseArgs(int argc, char** argv) {
     }
 
     if (auto v = flagValue(arg, "--prefill=")) {
-      auto ep = parsePrefillArg(std::string(*v));
+      auto ep = parsePrefillArg(*v);
       if (!ep) {
         std::cerr << "Invalid --prefill value: " << *v
                   << " (expected HOST:PORT)\n";
@@ -177,7 +185,7 @@ std::optional<GatewayConfig> parseArgs(int argc, char** argv) {
     }
 
     if (auto v = flagValue(arg, "--prefill-bind=")) {
-      auto ep = parsePrefillArg(std::string(*v));
+      auto ep = parsePrefillArg(*v);
       if (!ep) {
         std::cerr << "Invalid --prefill-bind value: " << *v
                   << " (expected HOST:PORT)\n";
@@ -202,9 +210,9 @@ std::optional<GatewayConfig> parseArgs(int argc, char** argv) {
   return cfg;
 }
 
-std::string socketTransportFromEnv() {
+std::string_view socketTransportFromEnv() {
   const char* value = std::getenv("SOCKET_TRANSPORT");
-  return value ? std::string(value) : tt::sockets::transport_names::TCP;
+  return value ? std::string_view(value) : tt::sockets::transport_names::TCP;
 }
 
 volatile sig_atomic_t gStop = 0;
@@ -263,7 +271,7 @@ int main(int argc, char** argv) {
   if (!useZmqPrefillRouter) {
     for (const auto& ep : cfg.prefills) {
       auto sm = std::make_unique<tt::sockets::SocketManager>();
-      sm->setReconnectBackoff(/*initial_ms=*/1000, /*max_ms=*/5000);
+      sm->setReconnectBackoff(std::chrono::seconds(1), std::chrono::seconds(5));
       if (!sm->initializeAsClient(ep.host, ep.port)) {
         TT_LOG_ERROR("[Gateway] Failed to init client socket to {}:{}", ep.host,
                      ep.port);
@@ -325,9 +333,8 @@ int main(int argc, char** argv) {
   };
 
   tt::gateway::Dispatcher::Options dispatcherOptions{
-      std::chrono::milliseconds(cfg.requestTimeoutMs),
-      std::chrono::milliseconds(cfg.timeoutWindowMs),
-      std::chrono::milliseconds(cfg.timeoutCooldownMs), cfg.timeoutThreshold};
+      cfg.requestTimeout, cfg.timeoutWindow, cfg.timeoutCooldown,
+      cfg.timeoutThreshold};
   dispatcherPtr = std::make_unique<tt::gateway::Dispatcher>(
       registry, affinity, std::move(senders), dispatcherOptions);
 
@@ -374,8 +381,7 @@ int main(int argc, char** argv) {
         }
       });
 
-  const auto prefillStaleTimeout =
-      std::chrono::milliseconds(cfg.prefillStaleTimeoutMs);
+  const auto prefillStaleTimeout = cfg.prefillStaleTimeout;
   std::jthread watchdogThread;
   if (useZmqPrefillRouter) {
     watchdogThread =
@@ -394,7 +400,7 @@ int main(int argc, char** argv) {
   }
 
   std::jthread requestTimeoutThread;
-  if (cfg.requestTimeoutMs > 0) {
+  if (cfg.requestTimeout.count() > 0) {
     requestTimeoutThread =
         std::jthread([&dispatcherPtr](std::stop_token stopToken) {
           while (!stopToken.stop_requested()) {

--- a/tt-media-server/prefill_gateway/src/prefill_selector.cpp
+++ b/tt-media-server/prefill_gateway/src/prefill_selector.cpp
@@ -4,7 +4,6 @@
 #include "gateway/prefill_selector.hpp"
 
 #include <algorithm>
-#include <limits>
 
 namespace tt::gateway {
 
@@ -19,9 +18,9 @@ bool isEligible(const PrefillSnapshot& p) {
 
 const PrefillSnapshot* findById(const std::vector<PrefillSnapshot>& prefills,
                                 const std::string& serverId) {
-  auto it = std::find_if(
-      prefills.begin(), prefills.end(),
-      [&](const PrefillSnapshot& p) { return p.server_id == serverId; });
+  auto it = std::ranges::find_if(prefills, [&](const PrefillSnapshot& p) {
+    return p.server_id == serverId;
+  });
   return it == prefills.end() ? nullptr : &*it;
 }
 
@@ -29,22 +28,22 @@ const PrefillSnapshot* findById(const std::vector<PrefillSnapshot>& prefills,
 
 PrefillEligibilitySummary summarizePrefillEligibility(
     const std::vector<PrefillSnapshot>& prefills) {
+  auto healthy = [](const PrefillSnapshot& prefill) { return prefill.healthy; };
+  auto accepting = [](const PrefillSnapshot& prefill) {
+    return prefill.healthy && prefill.accepting_tasks;
+  };
+  auto capacityAvailable = [](const PrefillSnapshot& prefill) {
+    return prefill.healthy && prefill.accepting_tasks &&
+           (prefill.max_in_flight == 0 ||
+            prefill.in_flight < prefill.max_in_flight);
+  };
+
   PrefillEligibilitySummary summary;
   summary.total = prefills.size();
-  for (const auto& prefill : prefills) {
-    if (!prefill.healthy) {
-      continue;
-    }
-    ++summary.healthy;
-    if (!prefill.accepting_tasks) {
-      continue;
-    }
-    ++summary.accepting;
-    if (prefill.max_in_flight == 0 ||
-        prefill.in_flight < prefill.max_in_flight) {
-      ++summary.capacity_available;
-    }
-  }
+  summary.healthy = std::ranges::count_if(prefills, healthy);
+  summary.accepting = std::ranges::count_if(prefills, accepting);
+  summary.capacity_available =
+      std::ranges::count_if(prefills, capacityAvailable);
   return summary;
 }
 
@@ -68,10 +67,10 @@ std::optional<std::string> selectPrefill(
     return std::nullopt;
   }
 
-  uint32_t minInFlight = std::numeric_limits<uint32_t>::max();
-  for (const auto* p : eligible) {
-    minInFlight = std::min(minInFlight, p->in_flight);
-  }
+  const auto minInFlight =
+      (*std::ranges::min_element(eligible, {}, [](const PrefillSnapshot* p) {
+        return p->in_flight;
+      }))->in_flight;
 
   std::vector<const PrefillSnapshot*> leastLoaded;
   leastLoaded.reserve(eligible.size());

--- a/tt-media-server/prefill_gateway/src/socket_transport_factory.cpp
+++ b/tt-media-server/prefill_gateway/src/socket_transport_factory.cpp
@@ -14,7 +14,7 @@ namespace tt::sockets {
 namespace {
 std::string socketTransportFromEnv() {
   const char* v = std::getenv("SOCKET_TRANSPORT");
-  return v ? std::string(v) : transport_names::TCP;
+  return v ? std::string(v) : std::string(transport_names::TCP);
 }
 }  // namespace
 

--- a/tt-media-server/prefill_gateway/src/zmq_prefill_router.cpp
+++ b/tt-media-server/prefill_gateway/src/zmq_prefill_router.cpp
@@ -99,21 +99,19 @@ std::vector<std::string> ZmqPrefillRouter::takeStaleServers(
   std::vector<std::string> staleServers;
 
   std::lock_guard<std::mutex> lock(peer_mutex_);
-  for (auto it = last_seen_by_server_.begin();
-       it != last_seen_by_server_.end();) {
-    if (now - it->second <= timeout) {
-      ++it;
-      continue;
+  std::erase_if(last_seen_by_server_, [&](const auto& lastSeen) {
+    if (now - lastSeen.second <= timeout) {
+      return false;
     }
 
-    staleServers.push_back(it->first);
-    auto peerIt = server_to_peer_.find(it->first);
+    staleServers.push_back(lastSeen.first);
+    auto peerIt = server_to_peer_.find(lastSeen.first);
     if (peerIt != server_to_peer_.end()) {
       peer_to_server_.erase(peerKey(peerIt->second));
       server_to_peer_.erase(peerIt);
     }
-    it = last_seen_by_server_.erase(it);
-  }
+    return true;
+  });
 
   return staleServers;
 }

--- a/tt-media-server/prefill_gateway/tests/gateway_e2e_test.cpp
+++ b/tt-media-server/prefill_gateway/tests/gateway_e2e_test.cpp
@@ -157,7 +157,8 @@ class FakeDecode {
  public:
   FakeDecode(const std::string& gatewayHost, uint16_t gatewayPort) {
     sm_.initializeAsClient(gatewayHost, gatewayPort);
-    sm_.setReconnectBackoff(50, 500);
+    sm_.setReconnectBackoff(std::chrono::milliseconds(50),
+                            std::chrono::milliseconds(500));
 
     sm_.registerHandler<tt::sockets::PrefillResultMessage>(
         "prefill_result", [this](const tt::sockets::PrefillResultMessage& msg) {
@@ -228,7 +229,8 @@ class GatewayHarness {
 
     for (const auto& [host, port] : prefills) {
       auto sm = std::make_unique<tt::sockets::SocketManager>();
-      sm->setReconnectBackoff(50, 500);
+      sm->setReconnectBackoff(std::chrono::milliseconds(50),
+                              std::chrono::milliseconds(500));
       sm->initializeAsClient(host, port);
       prefillSms_.push_back(std::move(sm));
     }
@@ -346,7 +348,8 @@ class FakeZmqPrefill {
         routerPort_(routerPort),
         maxInFlight_(maxInFlight) {
     sm_.initializeAsClient(routerHost_, routerPort_);
-    sm_.setReconnectBackoff(50, 500);
+    sm_.setReconnectBackoff(std::chrono::milliseconds(50),
+                            std::chrono::milliseconds(500));
   }
 
   ~FakeZmqPrefill() { stop(); }


### PR DESCRIPTION
- Use C++20 helpers to simplify gateway and socket code.
- Replace raw millisecond values with chrono durations.
- Use string/span views and standard algorithms where they make the code clearer.