### PR TITLE
evals: parallel-safe EVALS_META setup (per-invocation staging dir)

### DIFF
--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -3,10 +3,13 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 import argparse
+import atexit
 import json
 import logging
 import os
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 from typing import List, Optional
 
@@ -605,8 +608,32 @@ def build_eval_command(
 
     if task.include_path:
         cmd.append("--include_path")
-        cmd.append(task_venv_config.venv_path / task.include_path)
-        os.chdir(task_venv_config.venv_path)
+        if task.workflow_venv_type == WorkflowVenvType.EVALS_META:
+            # lm-eval meta_* task YAMLs hardcode `./work_dir/joined_*.parquet`
+            # relative to cwd. The model-specific data lives at
+            # `<venv>/llama-cookbook/.../meta_eval/work_dir_<model>/`. To
+            # support parallel invocations against different models without
+            # racing on a single shared work_dir/, give each invocation its
+            # own staging dir containing a symlink that masquerades as it.
+            meta_data_dir = (
+                task_venv_config.venv_path
+                / "llama-cookbook/end-to-end-use-cases/benchmarks/llm_eval_harness/meta_eval"
+                / f"work_dir_{model_spec.model_name}"
+            )
+            staging_dir = Path(
+                tempfile.mkdtemp(
+                    prefix=f"meta_eval_{model_spec.model_name}_",
+                    dir=task_venv_config.venv_path,
+                )
+            )
+            atexit.register(shutil.rmtree, staging_dir, ignore_errors=True)
+            staging_work_dir = staging_dir / "work_dir"
+            os.symlink(meta_data_dir, staging_work_dir)
+            cmd.append(staging_work_dir)
+            os.chdir(staging_dir)
+        else:
+            cmd.append(task_venv_config.venv_path / task.include_path)
+            os.chdir(task_venv_config.venv_path)
     if task.apply_chat_template:
         cmd.append("--apply_chat_template")  # Flag argument (no value)
 

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import logging
 import os
-import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional, Tuple
@@ -259,12 +258,13 @@ def setup_evals_meta(
             logger.warning(
                 f"Failed to prepare meta eval datasets for: {meta_eval_data_dir}, continuing..."
             )
-    # IFEval (and likely others) hard-code ./work_dir; hot-swap so downstream finds it.
-    work_dir = venv_config.venv_path / "work_dir"
-    logger.info(f"moving {str(meta_eval_data_dir)} to {str(work_dir)}")
-    if os.path.exists(work_dir):
-        shutil.rmtree(work_dir)
-    shutil.copytree(meta_eval_data_dir, work_dir)
+    # The model-specific data lives at meta_eval_data_dir (work_dir_<model_name>/).
+    # IFEval (and likely others) hard-code ./work_dir relative to lm-eval's cwd,
+    # so run_evals.py creates a per-PID staging dir with a 'work_dir' symlink
+    # pointing here at command-build time. We do NOT write to a shared
+    # .venv_evals_meta/work_dir/ here — that previously raced across parallel
+    # model invocations and produced spurious FileNotFoundError for tasks (e.g.
+    # meta_ifeval) when a sibling model's data overwrote the shared dir.
     os.chdir(original_dir)
     return setup_succeeded
 
@@ -423,10 +423,11 @@ _venv_config_list = [
         extra_dirs=("artifacts",),
         setup_function=check_docker_available,
     ),
-    # Custom Python work; pip handled inside the hook (model-type dependent)
+    # Custom Python work; pip handled inside the hook (model-type dependent).
+    # No extra_dirs — `run_evals.py` materializes a per-invocation staging
+    # dir at command-build time (see EVALS_META branch in build_eval_command).
     VenvConfig(
         venv_type=WorkflowVenvType.EVALS_META,
-        extra_dirs=("work_dir",),
         setup_function=setup_evals_meta,
     ),
 ]


### PR DESCRIPTION
Closes https://github.com/tenstorrent/tt-inference-server/issues/3788

## Summary

`setup_evals_meta` used to `rmtree + copytree` a shared `.venv_evals_meta/work_dir/` on every call, racing across parallel invocations and producing spurious `FileNotFoundError` on `meta_ifeval` for one of the models. Fix: stop using a shared `work_dir/`. The model-specific data already lives at `<venv>/llama-cookbook/.../meta_eval/work_dir_<model_name>/`. `run_evals.py` now materializes a per-invocation staging dir via `tempfile.mkdtemp`, symlinks `staging_dir/work_dir → model-specific dir`, chdirs in, and passes the symlink as `--include_path`. `atexit` cleans up.

CI is unaffected (each model runs in its own runner). The race only surfaces during multi-model qualification on a single host (e.g. QB2, useful during local testing). With this fix, all 4 forge LLM smoke evals can run in parallel and cut local wall-clock by ~4×.

## Changes

| File | Δ |
|---|---|
| `workflows/workflow_venvs.py` | Drop `rmtree + copytree` from `setup_evals_meta` and the now-unused `import shutil`. Drop the stale `extra_dirs=("work_dir",)` from the EVALS_META VenvConfig (the dir is now created per-invocation). |
| `evals/run_evals.py` | New EVALS_META branch in `build_eval_command`: `tempfile.mkdtemp` staging dir, `os.symlink` to model-specific data, `atexit.register(shutil.rmtree, ...)` cleanup. Adds `atexit` / `shutil` / `tempfile` imports. |

## Verification on QB2 P150

4-parallel smoke evals — all pass:

```
Falcon3-7B-Instruct:     ✅ Completed run.py
Llama-3.1-8B-Instruct:   ✅ Completed run.py    ← was the race victim
Llama-3.2-3B-Instruct:   ✅ Completed run.py
Qwen3-8B:                ✅ Completed run.py
```

Per-invocation staging dirs visible during the runs (cleaned by `atexit` on exit):

```
$ ls -la .workflow_venvs/.venv_evals_meta/ | grep meta_eval_
drwx------  meta_eval_Falcon3-7B-Instruct_zq7scxm4/
drwx------  meta_eval_Llama-3.1-8B-Instruct_h7jxe9q9/
drwx------  meta_eval_Llama-3.2-3B-Instruct_cyxf50dr/
drwx------  meta_eval_Qwen3-8B_l40z95rf/

$ ls -la .workflow_venvs/.venv_evals_meta/meta_eval_Llama-3.1-8B-Instruct_h7jxe9q9/
lrwxrwxrwx  work_dir -> .../llama-cookbook/.../meta_eval/work_dir_Llama-3.1-8B-Instruct
```

## Test plan

- [x] 4-parallel smoke evals on QB2 P150 — all complete cleanly
- [x] Single-model EVALS_META eval still passes
- [x] Staging dirs cleaned up on process exit (no `meta_eval_*` residue)
