### PR TITLE
Forge LLM P150 bringup: Falcon3-7B 422 + missing perf reference entries

### DIFF
--- a/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/benchmarking/benchmark_targets/model_performance_reference.json
@@ -4390,6 +4390,27 @@
             }
         ]
     },
+    "Falcon3-7B-Instruct": {
+        "p150": [
+            {
+                "isl": 128,
+                "osl": 128,
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "task_type": "text",
+                "image_height": null,
+                "image_width": null,
+                "images_per_prompt": null,
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 26.0,
+                        "tput_user": 43.0,
+                        "tput": 1328.0
+                    }
+                }
+            }
+        ]
+    },
     "Falcon3-10B-Base": {
         "t3k": [
             {
@@ -5139,6 +5160,25 @@
                     "theoretical": {
                         "ttft_ms": 17,
                         "tput_user": 61
+                    }
+                }
+            }
+        ],
+        "p150": [
+            {
+                "isl": 128,
+                "osl": 128,
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "task_type": "text",
+                "image_height": null,
+                "image_width": null,
+                "images_per_prompt": null,
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 13.0,
+                        "tput_user": 99.0,
+                        "tput": 2991.0
                     }
                 }
             }

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -3211,16 +3211,13 @@ _eval_config_list = [
     EvalConfig(
         hf_model_repo="tiiuae/Falcon3-7B-Instruct",
         tasks=[
-            # NOTE: tokenizer_backend="none" is required for the FORGE LLM server.
-            # The default ("huggingface") makes lm-eval-harness pre-tokenize prompts
-            # and send them as List[List[int]] to /v1/completions, which the forge
-            # server's pydantic schema rejects with HTTP 422 (it only accepts
-            # `prompt: Union[str, List[int]]`). With "none", lm-eval applies the
-            # chat template host-side, sends prompts as strings, and the server
-            # tokenizes them — schema-compatible.
+            # tokenizer_backend defaults to "huggingface" — matches the Qwen3-*
+            # configs below. Don't set "none" here: without a tokenizer loaded
+            # lm-eval can't apply_chat_template host-side and instead sends the
+            # raw chat message list, which the server's CompletionRequest schema
+            # rejects with HTTP 422.
             EvalTask(
                 task_name="ifeval",
-                tokenizer_backend="none",
                 score=EvalTaskScore(
                     published_score=None,
                     published_score_ref="https://huggingface.co/tiiuae/Falcon3-7B-Instruct",
@@ -3236,7 +3233,6 @@ _eval_config_list = [
             ),
             EvalTask(
                 task_name="gpqa_diamond_generative_n_shot",
-                tokenizer_backend="none",
                 num_fewshot=5,
                 score=EvalTaskScore(
                     published_score=None,


### PR DESCRIPTION
Fixes #3786

## Summary

Two small CI-correctness fixes uncovered during forge LLM P150 ci-nightly bringup.

## Changes

### 1. Falcon3-7B-Instruct evals fail with HTTP 422 (commit `630005c1`)

Two Falcon3-7B eval tasks had stale `tokenizer_backend="none"` overrides. Combined with `apply_chat_template=True`, lm-eval sent raw `list[dict]` chat messages — which the server schema (see #3531) rejects with HTTP 422. Removing the overrides falls back to lm-eval's default `huggingface` tokenizer, which sends `List[List[int]]` and matches what the other forge LLMs (Qwen3-4B, Qwen3-8B) already use.

### 2. Missing P150 perf reference entries (commit `797f2c9f`)

`benchmarking/benchmark_targets/model_performance_reference.json` was missing:
- **Falcon3-7B-Instruct** top-level key entirely (only `Falcon3-7B-Base` existed). The forge `ModelSpecTemplate` looks up by `weights[0]="Falcon3-7B-Instruct"` → no match → `target_checks` couldn't run.
- **Llama-3.2-3B** P150 sub-entry (the base key had `n150/n300/t3k` but no `p150`). The Instruct variant's lookup key is the base name `"Llama-3.2-3B"`, so the new P150 sub-entry has to live under the base key.

Added both with values mirrored from the comparable existing entries (no new measurement):
- Falcon3-7B-Instruct.p150 ← copied from Falcon3-7B-Base.p150 (same arch; instruction tuning doesn't change inference cost): `ttft_ms=26.0, tput_user=43.0, tput=1328.0`
- Llama-3.2-3B.p150 ← copied from Llama-3.2-3B-Instruct.p150 already present elsewhere in the file: `ttft_ms=13.0, tput_user=99.0, tput=2991.0`

## Verification on QB2 P150

- Falcon3-7B-Instruct smoke evals: 100% pass, 0 × HTTP 422 in log
- Falcon3-7B-Instruct + Llama-3.2-3B smoke benchmarks: `target_checks` now finds the reference entries (the prior "Missing target_checks" failure no longer fires)

## Test plan

- [x] Falcon3-7B-Instruct smoke eval — completes without HTTP 422
- [x] Falcon3-7B-Instruct + Llama-3.2-3B smoke benchmarks — `target_checks` resolves the (mirrored) reference entries