### PR TITLE
Bump tt-forge to 1.2.0

### DIFF
--- a/tt-media-server/requirements.txt
+++ b/tt-media-server/requirements.txt
@@ -18,8 +18,8 @@ silero_vad
 tqdm
 uvicorn
 whisperx==3.4.3
-torch==2.7.1+cpu
-torchaudio==2.7.1+cpu
+torch==2.10.0+cpu
+torchaudio
 requests
 num2words
 

--- a/tt-media-server/requirements.txt
+++ b/tt-media-server/requirements.txt
@@ -18,8 +18,8 @@ silero_vad
 tqdm
 uvicorn
 whisperx==3.4.3
-torch==2.10.0+cpu
-torchaudio
+torch==2.7.1+cpu
+torchaudio==2.7.1+cpu
 requests
 num2words
 

--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,6 +1,12 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
 --extra-index-url https://download.pytorch.org/whl/cpu
 tt-forge==1.2.0
+# tt-forge 1.2.0 needs torch 2.10.0; pin the matching torch/vision/audio here
+# (forge image only) so the shared requirements.txt — and the media/blaze
+# images that install only it — stay on torch 2.7.1. forge_runners is installed
+# after requirements.txt, so these override the shared pins for the forge image.
+torch==2.10.0+cpu
+torchaudio==2.10.0+cpu
 torchvision==0.25.0+cpu
 
 tabulate

--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,6 +1,7 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
+--extra-index-url https://download.pytorch.org/whl/cpu
 tt-forge==1.2.0
-torchvision
+torchvision==0.25.0+cpu
 
 tabulate
 timm # input preprocessing

--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
-tt-forge==1.1.0
+tt-forge==1.2.0
 torchvision
 
 tabulate

--- a/tt-media-server/tt_model_runners/vllm_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_runner.py
@@ -48,7 +48,9 @@ class VLLMForgeRunner(BaseDeviceRunner):
                 "min_context_len": self.settings.vllm.min_context_length,
                 "experimental_weight_dtype": "bfp_bf8",
                 "cpu_sampling": True,
-                "optimization_level": 1,
+                # opt_level>=1 crashes the tt-mlir optimizer during warmup on
+                # the 1.2.0 wheel; keep 0 until tenstorrent/tt-xla#4990 lands.
+                "optimization_level": 0,
             },
         )
         self.logger.info(


### PR DESCRIPTION
Automated version bump of `tt-forge` to `1.2.0` in `tt-media-server/Dockerfile.forge`.

Requirements change, qualified against these models and more, see follow up discussions below.

### Checklist

- [x] `efficientnet`: https://github.com/tenstorrent/tt-shield/actions/runs/26567995302
- [x] `mobilenetv2`: https://github.com/tenstorrent/tt-shield/actions/runs/26568002108
- [x] `resnet-50`: https://github.com/tenstorrent/tt-shield/actions/runs/26568008830
- [x] `segformer`: https://github.com/tenstorrent/tt-shield/actions/runs/26568015158
- [x] `vit`: https://github.com/tenstorrent/tt-shield/actions/runs/26568021156
- [x] `vovnet`: https://github.com/tenstorrent/tt-shield/actions/runs/26568027166
