### PR TITLE
Return Think Block in Mock Runner

### DIFF
--- a/tt-media-server/cpp_server/src/runtime/runners/llm_runner/mock_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/llm_runner/mock_model_runner.cpp
@@ -3,7 +3,9 @@
 
 #include <chrono>
 #include <cstdlib>
+#include <mutex>
 #include <thread>
+#include <unordered_map>
 
 #include "profiling/tracy.hpp"
 #include "runtime/runners/llm_runner/model_runner.hpp"
@@ -19,6 +21,11 @@ using Config = tt::config::LLMConfig;
 namespace {
 
 constexpr int64_t K_WHITESPACE_TOKEN_ID = 223;
+constexpr int64_t K_THINK_START_TOKEN_ID = 128798;
+constexpr int64_t K_THINK_END_TOKEN_ID = 128799;
+constexpr int64_t K_THINK_CONTENT_TOKEN_ID = 77291;  // "thinking"
+constexpr int64_t K_VISIBLE_CONTENT_TOKEN_ID = 15329;  // "response"
+constexpr size_t K_THINK_TOKENS_COUNT = 10;
 
 std::chrono::milliseconds mockPrefillDelay() {
   const char* value = std::getenv("MOCK_PREFILL_SLEEP_MS");
@@ -99,16 +106,45 @@ class MockModelRunner : public IModelRunner {
         std::this_thread::sleep_for(delay);
       }
       for (Sequence* seq : seqs) {
+        // Reset counter on prefill (new request)
+        {
+          std::lock_guard<std::mutex> lock(tokenCountMutex_);
+          tokenCounts_[seq->taskId] = 0;
+        }
         decodeCallback(
             TokenResult(seq->taskId, pickToken(seq, K_WHITESPACE_TOKEN_ID)));
       }
     } else {
       ZoneScopedN("MockModelRunner::decode");
       for (Sequence* seq : seqs) {
-        uint64_t defaultToken = static_cast<uint64_t>(seq->getLastToken() + 1);
-        decodeCallback(TokenResult(seq->taskId, pickToken(seq, defaultToken)));
+        uint64_t token = pickThinkingToken(seq);
+        decodeCallback(TokenResult(seq->taskId, pickToken(seq, token)));
       }
     }
+  }
+
+  // Generates a sequence: <think> + 10 tokens + </think> + visible tokens
+  // Position 0: think start, 1-10: think content, 11: think end, 12+: visible
+  // Visible tokens alternate: "response" + space + "response" + space + ...
+  uint64_t pickThinkingToken(Sequence* seq) {
+    size_t generated = 0;
+    {
+      std::lock_guard<std::mutex> lock(tokenCountMutex_);
+      generated = tokenCounts_[seq->taskId]++;
+    }
+    if (generated == 0) {
+      return K_THINK_START_TOKEN_ID;
+    }
+    if (generated <= K_THINK_TOKENS_COUNT) {
+      return K_THINK_CONTENT_TOKEN_ID;
+    }
+    if (generated == K_THINK_TOKENS_COUNT + 1) {
+      return K_THINK_END_TOKEN_ID;
+    }
+    // Alternate between "response" and space
+    size_t visiblePos = generated - K_THINK_TOKENS_COUNT - 2;
+    return (visiblePos % 2 == 0) ? K_VISIBLE_CONTENT_TOKEN_ID
+                                 : K_WHITESPACE_TOKEN_ID;
   }
 
   void exit() override { TT_LOG_DEBUG("[model_runner:mock] exit"); }
@@ -189,6 +225,8 @@ class MockModelRunner : public IModelRunner {
   Config config;
   DecodeCallback decodeCallback;
   GrammarTokenIds tokenIds;
+  std::mutex tokenCountMutex_;
+  std::unordered_map<uint32_t, size_t> tokenCounts_;
 };
 
 }  // namespace

--- a/tt-media-server/cpp_server/src/runtime/runners/llm_runner/mock_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/llm_runner/mock_model_runner.cpp
@@ -46,14 +46,14 @@ std::chrono::milliseconds mockPrefillDelay() {
 // from the active tokenizer at construction time so the mock works with any
 // vocabulary (DeepSeek, Llama, etc.).
 struct GrammarTokenIds {
-  int quote;    // '"'
-  int letterA;  // 'A' — valid in bitmask only inside free-form string values
-  int minus;    // '-'
-  int comma;    // ','
-  int closeBracket;                 // ']'
-  int closeBrace;                   // '}'
-  std::array<int, 10> digits;       // '0'–'9' (not assumed consecutive)
-  std::array<int, 5> mockStrChars;  // T I S R V — varied content per task
+  int quote;         // '"'
+  int letterA;       // 'A' — valid in bitmask only inside free-form string values
+  int minus;         // '-'
+  int comma;         // ','
+  int closeBracket;  // ']'
+  int closeBrace;    // '}'
+  std::array<int, 10> digits;        // '0'–'9' (not assumed consecutive)
+  std::array<int, 5> mockStrChars;   // T I S R V — varied content per task
 
   static GrammarTokenIds fromTokenizer(
       const tt::utils::tokenizers::Tokenizer& tok) {
@@ -106,13 +106,8 @@ class MockModelRunner : public IModelRunner {
         std::this_thread::sleep_for(delay);
       }
       for (Sequence* seq : seqs) {
-        // Reset counter on prefill (new request), start at 0 so first decode
-        // emits think start
-        {
-          std::lock_guard<std::mutex> lock(tokenCountMutex_);
-          tokenCounts_[seq->taskId] = 0;
-        }
-        // Prefill emits think start token
+        std::lock_guard<std::mutex> lock(tokenCountMutex);
+        tokenCounts[seq->taskId] = 0;
         decodeCallback(
             TokenResult(seq->taskId, pickToken(seq, K_THINK_START_TOKEN_ID)));
       }
@@ -125,29 +120,20 @@ class MockModelRunner : public IModelRunner {
     }
   }
 
-  // Generates a sequence: <think> + 10 tokens + </think> + visible tokens
-  // Prefill emits think start (position 0 already used).
-  // Decode positions: 0-9: think content, 10: think end, 11+: visible
-  // Both think and visible tokens alternate with spaces.
   uint64_t pickThinkingToken(Sequence* seq) {
     size_t generated = 0;
     {
-      std::lock_guard<std::mutex> lock(tokenCountMutex_);
-      generated = tokenCounts_[seq->taskId]++;
+      std::lock_guard<std::mutex> lock(tokenCountMutex);
+      generated = tokenCounts[seq->taskId]++;
     }
-    // Positions 0-9: think content with spaces
     if (generated < K_THINK_TOKENS_COUNT) {
-      return (generated % 2 == 0) ? K_THINK_CONTENT_TOKEN_ID
-                                  : K_WHITESPACE_TOKEN_ID;
+      return (generated % 2 == 0) ? K_THINK_CONTENT_TOKEN_ID : K_WHITESPACE_TOKEN_ID;
     }
-    // Position 10: think end
     if (generated == K_THINK_TOKENS_COUNT) {
       return K_THINK_END_TOKEN_ID;
     }
-    // Position 11+: visible content with spaces
     size_t visiblePos = generated - K_THINK_TOKENS_COUNT - 1;
-    return (visiblePos % 2 == 0) ? K_VISIBLE_CONTENT_TOKEN_ID
-                                 : K_WHITESPACE_TOKEN_ID;
+    return (visiblePos % 2 == 0) ? K_VISIBLE_CONTENT_TOKEN_ID : K_WHITESPACE_TOKEN_ID;
   }
 
   void exit() override { TT_LOG_DEBUG("[model_runner:mock] exit"); }
@@ -228,8 +214,8 @@ class MockModelRunner : public IModelRunner {
   Config config;
   DecodeCallback decodeCallback;
   GrammarTokenIds tokenIds;
-  std::mutex tokenCountMutex_;
-  std::unordered_map<uint32_t, size_t> tokenCounts_;
+  std::mutex tokenCountMutex;
+  std::unordered_map<uint32_t, size_t> tokenCounts;
 };
 
 }  // namespace

--- a/tt-media-server/cpp_server/src/runtime/runners/llm_runner/mock_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/llm_runner/mock_model_runner.cpp
@@ -46,14 +46,14 @@ std::chrono::milliseconds mockPrefillDelay() {
 // from the active tokenizer at construction time so the mock works with any
 // vocabulary (DeepSeek, Llama, etc.).
 struct GrammarTokenIds {
-  int quote;         // '"'
-  int letterA;       // 'A' — valid in bitmask only inside free-form string values
-  int minus;         // '-'
-  int comma;         // ','
-  int closeBracket;  // ']'
-  int closeBrace;    // '}'
-  std::array<int, 10> digits;        // '0'–'9' (not assumed consecutive)
-  std::array<int, 5> mockStrChars;   // T I S R V — varied content per task
+  int quote;    // '"'
+  int letterA;  // 'A' — valid in bitmask only inside free-form string values
+  int minus;    // '-'
+  int comma;    // ','
+  int closeBracket;                 // ']'
+  int closeBrace;                   // '}'
+  std::array<int, 10> digits;       // '0'–'9' (not assumed consecutive)
+  std::array<int, 5> mockStrChars;  // T I S R V — varied content per task
 
   static GrammarTokenIds fromTokenizer(
       const tt::utils::tokenizers::Tokenizer& tok) {
@@ -127,13 +127,15 @@ class MockModelRunner : public IModelRunner {
       generated = tokenCounts[seq->taskId]++;
     }
     if (generated < K_THINK_TOKENS_COUNT) {
-      return (generated % 2 == 0) ? K_THINK_CONTENT_TOKEN_ID : K_WHITESPACE_TOKEN_ID;
+      return (generated % 2 == 0) ? K_THINK_CONTENT_TOKEN_ID
+                                  : K_WHITESPACE_TOKEN_ID;
     }
     if (generated == K_THINK_TOKENS_COUNT) {
       return K_THINK_END_TOKEN_ID;
     }
     size_t visiblePos = generated - K_THINK_TOKENS_COUNT - 1;
-    return (visiblePos % 2 == 0) ? K_VISIBLE_CONTENT_TOKEN_ID : K_WHITESPACE_TOKEN_ID;
+    return (visiblePos % 2 == 0) ? K_VISIBLE_CONTENT_TOKEN_ID
+                                 : K_WHITESPACE_TOKEN_ID;
   }
 
   void exit() override { TT_LOG_DEBUG("[model_runner:mock] exit"); }

--- a/tt-media-server/cpp_server/src/runtime/runners/llm_runner/mock_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/llm_runner/mock_model_runner.cpp
@@ -23,7 +23,7 @@ namespace {
 constexpr int64_t K_WHITESPACE_TOKEN_ID = 223;
 constexpr int64_t K_THINK_START_TOKEN_ID = 128798;
 constexpr int64_t K_THINK_END_TOKEN_ID = 128799;
-constexpr int64_t K_THINK_CONTENT_TOKEN_ID = 77291;  // "thinking"
+constexpr int64_t K_THINK_CONTENT_TOKEN_ID = 77291;    // "thinking"
 constexpr int64_t K_VISIBLE_CONTENT_TOKEN_ID = 15329;  // "response"
 constexpr size_t K_THINK_TOKENS_COUNT = 10;
 
@@ -106,13 +106,15 @@ class MockModelRunner : public IModelRunner {
         std::this_thread::sleep_for(delay);
       }
       for (Sequence* seq : seqs) {
-        // Reset counter on prefill (new request)
+        // Reset counter on prefill (new request), start at 0 so first decode
+        // emits think start
         {
           std::lock_guard<std::mutex> lock(tokenCountMutex_);
           tokenCounts_[seq->taskId] = 0;
         }
+        // Prefill emits think start token
         decodeCallback(
-            TokenResult(seq->taskId, pickToken(seq, K_WHITESPACE_TOKEN_ID)));
+            TokenResult(seq->taskId, pickToken(seq, K_THINK_START_TOKEN_ID)));
       }
     } else {
       ZoneScopedN("MockModelRunner::decode");
@@ -124,25 +126,26 @@ class MockModelRunner : public IModelRunner {
   }
 
   // Generates a sequence: <think> + 10 tokens + </think> + visible tokens
-  // Position 0: think start, 1-10: think content, 11: think end, 12+: visible
-  // Visible tokens alternate: "response" + space + "response" + space + ...
+  // Prefill emits think start (position 0 already used).
+  // Decode positions: 0-9: think content, 10: think end, 11+: visible
+  // Both think and visible tokens alternate with spaces.
   uint64_t pickThinkingToken(Sequence* seq) {
     size_t generated = 0;
     {
       std::lock_guard<std::mutex> lock(tokenCountMutex_);
       generated = tokenCounts_[seq->taskId]++;
     }
-    if (generated == 0) {
-      return K_THINK_START_TOKEN_ID;
+    // Positions 0-9: think content with spaces
+    if (generated < K_THINK_TOKENS_COUNT) {
+      return (generated % 2 == 0) ? K_THINK_CONTENT_TOKEN_ID
+                                  : K_WHITESPACE_TOKEN_ID;
     }
-    if (generated <= K_THINK_TOKENS_COUNT) {
-      return K_THINK_CONTENT_TOKEN_ID;
-    }
-    if (generated == K_THINK_TOKENS_COUNT + 1) {
+    // Position 10: think end
+    if (generated == K_THINK_TOKENS_COUNT) {
       return K_THINK_END_TOKEN_ID;
     }
-    // Alternate between "response" and space
-    size_t visiblePos = generated - K_THINK_TOKENS_COUNT - 2;
+    // Position 11+: visible content with spaces
+    size_t visiblePos = generated - K_THINK_TOKENS_COUNT - 1;
     return (visiblePos % 2 == 0) ? K_VISIBLE_CONTENT_TOKEN_ID
                                  : K_WHITESPACE_TOKEN_ID;
   }

--- a/tt-media-server/cpp_server/tests/llm_runner_test.cpp
+++ b/tt-media-server/cpp_server/tests/llm_runner_test.cpp
@@ -94,18 +94,41 @@ TEST(LLMRunnerTest, AllTokensPublishedInOrder) {
 
   ASSERT_EQ(finishedCount.load(), totalRequests);
 
-  // 1st published token in the mocked prefill is always whitespace token id=223
-  // The followed tokens using the mocked runner are increments of 223
+  // Mock runner generates: <think_start> + 10 think tokens + <think_end> +
+  // visible tokens. Think/visible tokens alternate with whitespace (223).
+  // Think content = 77291, visible content = 15329.
+  constexpr int64_t kThinkStart = 128798;
+  constexpr int64_t kThinkEnd = 128799;
+  constexpr int64_t kThinkContent = 77291;
+  constexpr int64_t kVisibleContent = 15329;
+  constexpr int64_t kWhitespace = 223;
+
+  // 30 tokens: think_start + 10 think + think_end + 18 visible
   const std::vector<int64_t> expectedSeq0 = {
-      223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237,
-      238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252,
+      kThinkStart,
+      kThinkContent, kWhitespace, kThinkContent, kWhitespace, kThinkContent,
+      kWhitespace, kThinkContent, kWhitespace, kThinkContent, kWhitespace,
+      kThinkEnd,
+      kVisibleContent, kWhitespace, kVisibleContent, kWhitespace,
+      kVisibleContent, kWhitespace, kVisibleContent, kWhitespace,
+      kVisibleContent, kWhitespace, kVisibleContent, kWhitespace,
+      kVisibleContent, kWhitespace, kVisibleContent, kWhitespace,
+      kVisibleContent, kWhitespace,
   };
+  // 10 tokens: think_start + 9 think
   const std::vector<int64_t> expectedSeq1 = {
-      223, 224, 225, 226, 227, 228, 229, 230, 231, 232,
+      kThinkStart,
+      kThinkContent, kWhitespace, kThinkContent, kWhitespace, kThinkContent,
+      kWhitespace, kThinkContent, kWhitespace, kThinkContent,
   };
+  // 20 tokens: think_start + 10 think + think_end + 8 visible
   const std::vector<int64_t> expectedSeq2 = {
-      223, 224, 225, 226, 227, 228, 229, 230, 231, 232,
-      233, 234, 235, 236, 237, 238, 239, 240, 241, 242,
+      kThinkStart,
+      kThinkContent, kWhitespace, kThinkContent, kWhitespace, kThinkContent,
+      kWhitespace, kThinkContent, kWhitespace, kThinkContent, kWhitespace,
+      kThinkEnd,
+      kVisibleContent, kWhitespace, kVisibleContent, kWhitespace,
+      kVisibleContent, kWhitespace, kVisibleContent, kWhitespace,
   };
 
   EXPECT_EQ(receivedTokens[taskIds[0]], expectedSeq0);

--- a/tt-media-server/cpp_server/tests/llm_runner_test.cpp
+++ b/tt-media-server/cpp_server/tests/llm_runner_test.cpp
@@ -105,30 +105,27 @@ TEST(LLMRunnerTest, AllTokensPublishedInOrder) {
 
   // 30 tokens: think_start + 10 think + think_end + 18 visible
   const std::vector<int64_t> expectedSeq0 = {
-      kThinkStart,
-      kThinkContent, kWhitespace, kThinkContent, kWhitespace, kThinkContent,
-      kWhitespace, kThinkContent, kWhitespace, kThinkContent, kWhitespace,
-      kThinkEnd,
-      kVisibleContent, kWhitespace, kVisibleContent, kWhitespace,
-      kVisibleContent, kWhitespace, kVisibleContent, kWhitespace,
-      kVisibleContent, kWhitespace, kVisibleContent, kWhitespace,
-      kVisibleContent, kWhitespace, kVisibleContent, kWhitespace,
+      kThinkStart,     kThinkContent, kWhitespace,     kThinkContent,
+      kWhitespace,     kThinkContent, kWhitespace,     kThinkContent,
+      kWhitespace,     kThinkContent, kWhitespace,     kThinkEnd,
+      kVisibleContent, kWhitespace,   kVisibleContent, kWhitespace,
+      kVisibleContent, kWhitespace,   kVisibleContent, kWhitespace,
+      kVisibleContent, kWhitespace,   kVisibleContent, kWhitespace,
+      kVisibleContent, kWhitespace,   kVisibleContent, kWhitespace,
       kVisibleContent, kWhitespace,
   };
   // 10 tokens: think_start + 9 think
   const std::vector<int64_t> expectedSeq1 = {
-      kThinkStart,
-      kThinkContent, kWhitespace, kThinkContent, kWhitespace, kThinkContent,
-      kWhitespace, kThinkContent, kWhitespace, kThinkContent,
+      kThinkStart,   kThinkContent, kWhitespace,   kThinkContent, kWhitespace,
+      kThinkContent, kWhitespace,   kThinkContent, kWhitespace,   kThinkContent,
   };
   // 20 tokens: think_start + 10 think + think_end + 8 visible
   const std::vector<int64_t> expectedSeq2 = {
-      kThinkStart,
-      kThinkContent, kWhitespace, kThinkContent, kWhitespace, kThinkContent,
-      kWhitespace, kThinkContent, kWhitespace, kThinkContent, kWhitespace,
-      kThinkEnd,
-      kVisibleContent, kWhitespace, kVisibleContent, kWhitespace,
-      kVisibleContent, kWhitespace, kVisibleContent, kWhitespace,
+      kThinkStart,     kThinkContent, kWhitespace,     kThinkContent,
+      kWhitespace,     kThinkContent, kWhitespace,     kThinkContent,
+      kWhitespace,     kThinkContent, kWhitespace,     kThinkEnd,
+      kVisibleContent, kWhitespace,   kVisibleContent, kWhitespace,
+      kVisibleContent, kWhitespace,   kVisibleContent, kWhitespace,
   };
 
   EXPECT_EQ(receivedTokens[taskIds[0]], expectedSeq0);


### PR DESCRIPTION
## Problem
In order to provide better testing environment, mock model runner now returns a thinking block.

## Testing
Example request:
```
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer your-secret-key" \
  -d '{
    "messages": [{"role": "user", "content": "Hello!"}],
    "stream": false,
    "max_tokens": 20
  }'
```

Example response:
```
{
  "id": "chatcmpl-1",
  "object": "chat.completion",
  "created": 1780061733,
  "model": "default",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "reasoning": "thinking thinking thinking thinking thinking ",
        "content": "response response response response "
      },
      "logprobs": null,
      "finish_reason": "length"
    }
  ],
  "usage": {
    "prompt_tokens": 5,
    "prompt_tokens_details": {
      "audio_tokens": 0,
      "cached_tokens": 0
    },
    "completion_tokens": 18,
    "completion_tokens_details": {
      "accepted_prediction_tokens": 0,
      "audio_tokens": 0,
      "reasoning_tokens": 10,
      "rejected_prediction_tokens": 0
    },
    "total_tokens": 23,
    "tps": 1214285.714,
    "ttft_ms": 421.98
  }
}
```