### PR TITLE
Auto-enable ccache for Faster Rebuilds

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -640,7 +640,7 @@ jobs:
       - name: C++ lint check (build with clang-tidy)
         run: |
           cd cpp_server
-          ./build.sh --clang-tidy --blaze --no-fresh
+          ./build.sh --clang-tidy --blaze
 
   prefill-gateway-format-check:
     needs: detect-changes
@@ -724,7 +724,7 @@ jobs:
       - name: Build C++ server
         run: |
           cd cpp_server
-          ./build.sh --blaze --no-fresh
+          ./build.sh --blaze
           cd ..
 
       - name: Run C++ unit tests
@@ -2241,7 +2241,7 @@ jobs:
       - name: Build C++ server with ThreadSanitizer
         run: |
           cd cpp_server
-          ./build.sh --tsan --no-fresh
+          ./build.sh --tsan
 
       - name: Set up uv (for guidellm)
         uses: astral-sh/setup-uv@v7

--- a/tt-media-server/cpp_server/build.sh
+++ b/tt-media-server/cpp_server/build.sh
@@ -369,7 +369,8 @@ CMAKE_ARGS=(
 )
 [ -n "${TT_METAL_HOME}" ] && CMAKE_ARGS+=(-DTT_METAL_HOME="${TT_METAL_HOME}")
 [ -n "${FETCHCONTENT_BASE_DIR:-}" ] && CMAKE_ARGS+=(-DFETCHCONTENT_BASE_DIR="${FETCHCONTENT_BASE_DIR}")
-if [ "${CI_CCACHE:-0}" = "1" ] && command -v ccache >/dev/null 2>&1; then
+# Use ccache if available for faster rebuilds
+if command -v ccache >/dev/null 2>&1; then
     CMAKE_ARGS+=(-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache)
 fi
 

--- a/tt-media-server/cpp_server/build.sh
+++ b/tt-media-server/cpp_server/build.sh
@@ -17,7 +17,7 @@ CLANG_TIDY="OFF"
 TOOLCHAIN_PATH_ARG=""
 CXX_COMPILER_PATH=""
 KAFKA_ENABLED="OFF"
-FRESH_CONFIGURE="ON"
+FRESH_CONFIGURE="OFF"
 while [[ $# -gt 0 ]]; do
     case $1 in
         --debug)
@@ -51,8 +51,8 @@ while [[ $# -gt 0 ]]; do
             KAFKA_ENABLED="ON"
             shift
             ;;
-        --no-fresh)
-            FRESH_CONFIGURE="OFF"
+        --fresh)
+            FRESH_CONFIGURE="ON"
             shift
             ;;
         --toolchain-path)
@@ -74,7 +74,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --blaze              Build with tt-blaze pipeline_manager support"
             echo "  --clang-tidy          Run clang-tidy during build (lint = build, same as tt-metal)"
             echo "  --kafka              Enable Kafka (CMake KAFKA_ENABLED=ON; needs librdkafka-dev)"
-            echo "  --no-fresh           Reuse existing CMake configure state"
+            echo "  --fresh              Wipe CMake cache and reconfigure from scratch"
             echo "  --toolchain-path P   Use CMake toolchain file (overrides TT_METAL_HOME toolchain)"
             echo "  --cxx-compiler-path P  Set C++ compiler (overrides toolchain)"
             echo "  --help               Show this help message"


### PR DESCRIPTION
## Problem
With this PR, we enable ccache to speed up clean rebuilds and branch switching, and disable the fresh-build behavior that was previously enabled by default. As a result, subsequent builds are much faster since only the changed files need to be rebuilt.