### PR TITLE
correction of helm README.md file generation (fix Supported Models table generation) for helm values.yaml schema

### DIFF
--- a/charts/tt-inference-server/README.md
+++ b/charts/tt-inference-server/README.md
@@ -10,10 +10,11 @@ Deploys vLLM and media inference backends on Tenstorrent Galaxy hardware.
 
 This chart creates a single `Deployment`, `Service`, `ConfigMap`, and `Secret` for one inference model on one Tenstorrent device. The chart ships with pre-validated configurations for every supported model and device combination. You select a model and device at install time; the chart merges your selection against a layered config system to produce the final Kubernetes resources.
 
-Two server types are supported:
+Three engines are supported:
 
 - **vllm** — large language models served via the vLLM OpenAI-compatible API
 - **media** — image/audio/video/embedding models served via the tt-media-inference-server API
+- **forge** — models served via the tt-forge backend
 
 ---
 
@@ -50,70 +51,76 @@ charts/tt-inference-server/
 
 Contains the core logic for this chart:
 
-- **`tt-inference-server.validateValues`** — fails the render if `model` or `device` is missing, or if the `model`+`device` combination has no entry in the `models` map.
-- **`tt-inference-server.resolvedConfig`** — deep-merges `defaults` with the per-model/device config block and returns the final effective config as YAML (see [Configuration System](#configuration-system)).
+- **`tt-inference-server.validateValues`** — fails the render if `model` or `device` is missing, or if the resolved `model`/`engine`/`device`/`impl` has no entry in the `models` map.
+- **`tt-inference-server.resolvedEngine`** — picks the engine: `.Values.engine` if set, the sole engine offering the device, otherwise `models.<model>.defaultEngine` when more than one engine offers it.
+- **`tt-inference-server.resolvedImpl`** — picks the implementation: `.Values.impl` if set, otherwise `models.<model>.<engine>.<device>.defaultImpl`.
+- **`tt-inference-server.resolvedConfig`** — deep-merges `defaults` with the resolved impl block (`models.<model>.<engine>.<device>.impls.<impl>`) and returns the effective config as YAML (see [Configuration System](#configuration-system)).
 - **`tt-inference-server.image`** — assembles the container image string (`repository:tag`) from the resolved config.
-- **`tt-inference-server.cacheHostPath`** — returns `cache.hostPath` if set, otherwise generates `/opt/cache/<model>-<device>`.
+- **`tt-inference-server.cacheHostPath`** — returns `cache.hostPath` if set, otherwise generates `/opt/cache/<model>-<device>-<impl>`.
 - Standard Helm name helpers: `tt-inference-server.name`, `tt-inference-server.fullname`, `tt-inference-server.labels`, `tt-inference-server.selectorLabels`.
 
 ---
 
 ## Configuration System
 
-Values are resolved through a three-level merge. Later levels win on any conflict.
+A model is addressed by a `model → engine → device → impl` path. `engine` and `impl` are normally inferred, so most installs set only `model` and `device`:
+
+- **engine** — if exactly one engine offers the requested device it is chosen automatically; when more than one does, `models.<model>.defaultEngine` is used unless you pass `--set engine=`.
+- **impl** — defaults to `models.<model>.<engine>.<device>.defaultImpl` unless you pass `--set impl=`.
+
+The effective config is then a two-level merge — the resolved impl block layered on top of `defaults`, where the impl block wins on any conflict:
 
 ```
-defaults                          ← baseline for all models and devices
-  └── models.<name>               ← model-level fields (serverType)
-        └── models.<name>.<device> ← deepest override, wins on all conflicts
+defaults                                              ← baseline for every model
+  └── models.<model>.<engine>.<device>.impls.<impl>   ← resolved leaf, wins on conflict
 ```
 
-**Example:** for `model=Llama-3.1-8B-Instruct` and `device=galaxy`, the effective config is:
+**Example:** for `model=Llama-3.1-8B-Instruct` and `device=n300`:
 
-1. Start with the full `defaults` block.
-2. Apply the `serverType: vllm` field from `models.Llama-3.1-8B-Instruct`.
-3. Deep-merge the `models.Llama-3.1-8B-Instruct.galaxy` block on top — overriding `image.repository`, `image.tag`, `resources`, and probe delays.
+1. Resolve the engine — `n300` is offered by both `vllm` and `forge`, so `models.Llama-3.1-8B-Instruct.defaultEngine` (`vllm`) is used. Pass `--set engine=forge` to pick the other.
+2. Resolve the impl — `models.Llama-3.1-8B-Instruct.vllm.n300.defaultImpl` (`tt_transformers`).
+3. Start from the full `defaults` block, then deep-merge `models.Llama-3.1-8B-Instruct.vllm.n300.impls.tt_transformers` on top — overriding `image.repository`, `image.tag`, `resources`, probe delays, and `env`.
 
-Any field not overridden at the model/device level falls back to `defaults`.
+Any field the resolved impl block does not set falls back to `defaults`.
 
 ---
 
 ## Values Reference
 
+Set per release, typically via `--set`.
+
 | Value | Required | Default | Description |
 |---|---|---|---|
-| `model` | yes | `""` | Model name. Must match a key in `models`. |
-| `device` | yes | `""` | Device name. Must match a key under `models.<model>`. |
-| `hfToken` | yes* | `""` | HuggingFace token. Injected as `HF_TOKEN`. Required unless weights are pre-downloaded. |
-| `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Skips download at startup. |
-| `cache.hostPath` | no | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>`. |
+| `model` | yes | `""` | Model name. Must match a key under `models`. |
+| `device` | yes | `""` | Device name. Must match a key under `models.<model>.<engine>`. |
+| `engine` | no | `""` | Pin the engine (`vllm`, `media`, or `forge`) when a model+device is offered by more than one. Defaults to the only matching engine, or `models.<model>.defaultEngine` when ambiguous. |
+| `impl` | no | `""` | Pin the implementation when a device offers more than one. Defaults to `models.<model>.<engine>.<device>.defaultImpl`. |
+| `hfToken` | yes* | `""` | HuggingFace token. Injected as `HF_TOKEN`. Required unless weights are pre-downloaded via `hfCacheDir`. |
+| `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
+| `cache.hostPath` | no | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>-<impl>`. |
 | `nameOverride` | no | `""` | Overrides the chart name component in resource names. |
 | `fullnameOverride` | no | `""` | Fully overrides the resource name prefix. |
-
----
+| `models` | — | See [Supported Models](#supported-models) | Per-model catalogue keyed by `<model>.<engine>.<device>.impls.<impl>`. Each impl leaf overrides `defaults`. |
 
 ## Defaults Reference
 
-All fields under `defaults` apply to every model/device unless overridden in the `models` map.
+All fields under `defaults` apply to every model/engine/device/impl unless overridden by the resolved impl block.
 
 | Field | Default | Description |
 |---|---|---|
-| `defaults.serverType` | `vllm` | Server backend: `vllm` or `media`. |
 | `defaults.replicaCount` | `1` | Number of Deployment replicas. |
 | `defaults.progressDeadlineSeconds` | `3600` | Deployment progress deadline. Set high due to long model load times. |
-| `defaults.hostIPC` | `true` | Enables host IPC namespace, required for Tenstorrent device communication. |
+| `defaults.podAnnotations` | `{}` | Annotations applied to the pod template. |
+| `defaults.podSecurityContext` | `{}` | Pod-level `securityContext`. |
 | `defaults.image.pullPolicy` | `IfNotPresent` | Image pull policy. |
 | `defaults.image.pullSecrets` | `[]` | Image pull secrets. |
 | `defaults.service.type` | `ClusterIP` | Kubernetes Service type. |
 | `defaults.service.port` | `8000` | Service port. |
 | `defaults.service.targetPort` | `8000` | Container target port. |
-| `defaults.service.protocol` | `TCP` | Service protocol. |
 | `defaults.service.annotations` | `{}` | Annotations applied to the Service. |
-| `defaults.resources.limits.cpu` | `8` | CPU limit. |
-| `defaults.resources.limits.memory` | `128Gi` | Memory limit (overridden per model). |
-| `defaults.resources.limits.hugepages-1Gi` | `32Gi` | Hugepage limit. |
-| `defaults.resources.requests.cpu` | `6` | CPU request. |
-| `defaults.resources.requests.memory` | `64Gi` | Memory request (overridden per model). |
+| `defaults.resources.limits.hugepages-1Gi` | `32Gi` | Hugepage limit. (`cpu` and `memory` limits are unset by default.) |
+| `defaults.resources.requests.cpu` | `"6"` | CPU request. |
+| `defaults.resources.requests.memory` | `64Gi` | Memory request (often overridden per impl). |
 | `defaults.resources.requests.hugepages-1Gi` | `32Gi` | Hugepage request. |
 | `defaults.probes.liveness.enabled` | `true` | Enable liveness probe. |
 | `defaults.probes.liveness.path` | `/v1/models` | Liveness probe HTTP path. |
@@ -121,196 +128,290 @@ All fields under `defaults` apply to every model/device unless overridden in the
 | `defaults.probes.readiness.enabled` | `true` | Enable readiness probe. |
 | `defaults.probes.readiness.path` | `/health` | Readiness probe HTTP path. |
 | `defaults.probes.readiness.initialDelaySeconds` | `2400` | Readiness probe initial delay. |
-| `defaults.securityContext.privileged` | `true` | Required for access to Tenstorrent device files. |
 | `defaults.nodeSelector` | `{}` | Node selector applied to the pod. |
 | `defaults.tolerations` | `[]` | Tolerations applied to the pod. |
 | `defaults.affinity` | `{}` | Affinity rules applied to the pod. |
 | `defaults.extraEnv` | `[]` | Additional environment variables (see [Extra Environment Variables](#extra-environment-variables)). |
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| cache.hostPath | string | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>`. |
-| defaults.affinity | object | `{}` | Affinity rules applied to the pod. |
-| defaults.extraEnv | list | `[]` | Additional environment variables (see [Extra Environment Variables](#extra-environment-variables)). |
-| defaults.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
-| defaults.image.pullSecrets | list | `[]` | Image pull secrets. |
-| defaults.nodeSelector | object | `{}` | Node selector applied to the pod. |
-| defaults.podAnnotations | object | `{}` | Annotations applied to the pod template. |
-| defaults.podSecurityContext | object | `{}` | Pod-level `securityContext`. |
-| defaults.probes.liveness.enabled | bool | `true` | Enable liveness probe. |
-| defaults.probes.liveness.initialDelaySeconds | int | `2400` | Liveness probe initial delay. Set high due to model load times. |
-| defaults.probes.liveness.path | string | `"/v1/models"` | Liveness probe HTTP path. |
-| defaults.probes.readiness.enabled | bool | `true` | Enable readiness probe. |
-| defaults.probes.readiness.initialDelaySeconds | int | `2400` | Readiness probe initial delay. |
-| defaults.probes.readiness.path | string | `"/health"` | Readiness probe HTTP path. |
-| defaults.progressDeadlineSeconds | int | `3600` | Deployment progress deadline. Set high due to long model load times. |
-| defaults.replicaCount | int | `1` | Number of Deployment replicas. |
-| defaults.resources.limits.cpu | string | `"8"` | CPU limit. |
-| defaults.resources.limits.hugepages-1Gi | string | `"32Gi"` | Hugepage limit. |
-| defaults.resources.limits.memory | string | `"128Gi"` | Memory limit (overridden per model). |
-| defaults.resources.requests.cpu | string | `"6"` | CPU request. |
-| defaults.resources.requests.hugepages-1Gi | string | `"32Gi"` | Hugepage request. |
-| defaults.resources.requests.memory | string | `"64Gi"` | Memory request (overridden per model). |
-| defaults.serverType | string | `"vllm"` | Server backend: `vllm` or `media`. |
-| defaults.service.annotations | object | `{}` | Annotations applied to the Service. |
-| defaults.service.port | int | `8000` | Service port. |
-| defaults.service.targetPort | int | `8000` | Container target port. |
-| defaults.service.type | string | `"ClusterIP"` | Kubernetes Service type. |
-| defaults.tolerations | list | `[]` | Tolerations applied to the pod. |
-| device | string | `""` | Device name. Must match a key under `models.<model>`. |
-| fullnameOverride | string | `""` | Fully overrides the resource name prefix. |
-| hfToken | string | `""` | HuggingFace token. Injected as `HF_TOKEN`. Required unless weights are pre-downloaded. |
-| model | string | `""` | Model name. Must match a key in `models`. |
-| models | object | See the Supported Models section below. | Per-model catalogue keyed by `<model-name>.<device-name>`. Each leaf overrides `defaults:` for image, resources, and probes. See the Supported Models section below for the full list. |
-| nameOverride | string | `""` | Overrides the chart name component in resource names. |
-
 ---
 
 ## Supported Models
 
-### Unknown
+### vLLM
 
 | Model | Device |
 |---|---|
-| `AFM-4.5B` | defaultEngine |
-| `AFM-4.5B` | vllm |
-| `DeepSeek-R1-0528` | defaultEngine |
-| `DeepSeek-R1-0528` | vllm |
-| `DeepSeek-R1-Distill-Llama-70B` | defaultEngine |
-| `DeepSeek-R1-Distill-Llama-70B` | vllm |
-| `FLUX.1-dev` | defaultEngine |
-| `FLUX.1-dev` | media |
-| `FLUX.1-schnell` | defaultEngine |
-| `FLUX.1-schnell` | media |
-| `Falcon3-7B-Instruct` | defaultEngine |
-| `Falcon3-7B-Instruct` | forge |
-| `Llama-3.1-70B` | defaultEngine |
-| `Llama-3.1-70B` | media |
-| `Llama-3.1-70B` | vllm |
-| `Llama-3.1-70B-Instruct` | defaultEngine |
-| `Llama-3.1-70B-Instruct` | vllm |
-| `Llama-3.1-8B` | defaultEngine |
-| `Llama-3.1-8B` | vllm |
-| `Llama-3.1-8B-Instruct` | defaultEngine |
-| `Llama-3.1-8B-Instruct` | forge |
-| `Llama-3.1-8B-Instruct` | vllm |
-| `Llama-3.2-11B-Vision` | defaultEngine |
-| `Llama-3.2-11B-Vision` | vllm |
-| `Llama-3.2-11B-Vision-Instruct` | defaultEngine |
-| `Llama-3.2-11B-Vision-Instruct` | vllm |
-| `Llama-3.2-1B` | defaultEngine |
-| `Llama-3.2-1B` | vllm |
-| `Llama-3.2-1B-Instruct` | defaultEngine |
-| `Llama-3.2-1B-Instruct` | vllm |
-| `Llama-3.2-3B` | defaultEngine |
-| `Llama-3.2-3B` | forge |
-| `Llama-3.2-3B` | vllm |
-| `Llama-3.2-3B-Instruct` | defaultEngine |
-| `Llama-3.2-3B-Instruct` | forge |
-| `Llama-3.2-3B-Instruct` | vllm |
-| `Llama-3.2-90B-Vision` | defaultEngine |
-| `Llama-3.2-90B-Vision` | vllm |
-| `Llama-3.2-90B-Vision-Instruct` | defaultEngine |
-| `Llama-3.2-90B-Vision-Instruct` | vllm |
-| `Llama-3.3-70B-Instruct` | defaultEngine |
-| `Llama-3.3-70B-Instruct` | vllm |
-| `Mistral-7B-Instruct-v0.3` | defaultEngine |
-| `Mistral-7B-Instruct-v0.3` | vllm |
-| `Mistral-Small-3.1-24B-Instruct-2503` | defaultEngine |
-| `Mistral-Small-3.1-24B-Instruct-2503` | vllm |
-| `Motif-Image-6B-Preview` | defaultEngine |
-| `Motif-Image-6B-Preview` | media |
-| `QwQ-32B` | defaultEngine |
-| `QwQ-32B` | vllm |
-| `Qwen-Image` | defaultEngine |
-| `Qwen-Image` | media |
-| `Qwen-Image-2512` | defaultEngine |
-| `Qwen-Image-2512` | media |
-| `Qwen2.5-72B` | defaultEngine |
-| `Qwen2.5-72B` | vllm |
-| `Qwen2.5-72B-Instruct` | defaultEngine |
-| `Qwen2.5-72B-Instruct` | vllm |
-| `Qwen2.5-7B` | defaultEngine |
-| `Qwen2.5-7B` | vllm |
-| `Qwen2.5-7B-Instruct` | defaultEngine |
-| `Qwen2.5-7B-Instruct` | vllm |
-| `Qwen2.5-Coder-32B-Instruct` | defaultEngine |
-| `Qwen2.5-Coder-32B-Instruct` | vllm |
-| `Qwen2.5-VL-32B-Instruct` | defaultEngine |
-| `Qwen2.5-VL-32B-Instruct` | vllm |
-| `Qwen2.5-VL-3B-Instruct` | defaultEngine |
-| `Qwen2.5-VL-3B-Instruct` | vllm |
-| `Qwen2.5-VL-72B-Instruct` | defaultEngine |
-| `Qwen2.5-VL-72B-Instruct` | vllm |
-| `Qwen2.5-VL-7B-Instruct` | defaultEngine |
-| `Qwen2.5-VL-7B-Instruct` | vllm |
-| `Qwen3-32B` | defaultEngine |
-| `Qwen3-32B` | vllm |
-| `Qwen3-4B` | defaultEngine |
-| `Qwen3-4B` | forge |
-| `Qwen3-8B` | defaultEngine |
-| `Qwen3-8B` | forge |
-| `Qwen3-8B` | vllm |
-| `Qwen3-Embedding-4B` | defaultEngine |
-| `Qwen3-Embedding-4B` | forge |
-| `Qwen3-Embedding-8B` | defaultEngine |
-| `Qwen3-Embedding-8B` | media |
-| `Qwen3-VL-32B-Instruct` | defaultEngine |
-| `Qwen3-VL-32B-Instruct` | vllm |
-| `Wan2.2-I2V-A14B-Diffusers` | defaultEngine |
-| `Wan2.2-I2V-A14B-Diffusers` | media |
-| `Wan2.2-T2V-A14B-Diffusers` | defaultEngine |
-| `Wan2.2-T2V-A14B-Diffusers` | media |
-| `bge-large-en-v1.5` | defaultEngine |
-| `bge-large-en-v1.5` | media |
-| `bge-m3` | defaultEngine |
-| `bge-m3` | media |
-| `distil-large-v3` | defaultEngine |
-| `distil-large-v3` | media |
-| `efficientnet` | defaultEngine |
-| `efficientnet` | forge |
-| `gemma-3-1b-it` | defaultEngine |
-| `gemma-3-1b-it` | vllm |
-| `gemma-3-27b-it` | defaultEngine |
-| `gemma-3-27b-it` | vllm |
-| `gemma-3-4b-it` | defaultEngine |
-| `gemma-3-4b-it` | vllm |
-| `gpt-oss-120b` | defaultEngine |
-| `gpt-oss-120b` | vllm |
-| `gpt-oss-20b` | defaultEngine |
-| `gpt-oss-20b` | vllm |
-| `medgemma-27b-it` | defaultEngine |
-| `medgemma-27b-it` | vllm |
-| `medgemma-4b-it` | defaultEngine |
-| `medgemma-4b-it` | vllm |
-| `mobilenetv2` | defaultEngine |
-| `mobilenetv2` | forge |
-| `mochi-1-preview` | defaultEngine |
-| `mochi-1-preview` | media |
-| `resnet-50` | defaultEngine |
-| `resnet-50` | forge |
-| `segformer` | defaultEngine |
-| `segformer` | forge |
-| `speecht5_tts` | defaultEngine |
-| `speecht5_tts` | media |
-| `stable-diffusion-3.5-large` | defaultEngine |
-| `stable-diffusion-3.5-large` | media |
-| `stable-diffusion-xl-1.0-inpainting-0.1` | defaultEngine |
-| `stable-diffusion-xl-1.0-inpainting-0.1` | media |
-| `stable-diffusion-xl-base-1.0` | defaultEngine |
-| `stable-diffusion-xl-base-1.0` | media |
-| `stable-diffusion-xl-base-1.0-img-2-img` | defaultEngine |
-| `stable-diffusion-xl-base-1.0-img-2-img` | media |
-| `unet` | defaultEngine |
-| `unet` | forge |
-| `vit` | defaultEngine |
-| `vit` | forge |
-| `vovnet` | defaultEngine |
-| `vovnet` | forge |
-| `whisper-large-v3` | defaultEngine |
-| `whisper-large-v3` | media |
+| `AFM-4.5B` | n300 |
+| `AFM-4.5B` | t3k |
+| `DeepSeek-R1-0528` | galaxy |
+| `DeepSeek-R1-Distill-Llama-70B` | galaxy |
+| `DeepSeek-R1-Distill-Llama-70B` | galaxy_t3k |
+| `DeepSeek-R1-Distill-Llama-70B` | p150x4 |
+| `DeepSeek-R1-Distill-Llama-70B` | p150x8 |
+| `DeepSeek-R1-Distill-Llama-70B` | p300x2 |
+| `DeepSeek-R1-Distill-Llama-70B` | t3k |
+| `Llama-3.1-70B` | galaxy |
+| `Llama-3.1-70B` | galaxy_t3k |
+| `Llama-3.1-70B` | p150x4 |
+| `Llama-3.1-70B` | p150x8 |
+| `Llama-3.1-70B` | p300x2 |
+| `Llama-3.1-70B` | t3k |
+| `Llama-3.1-70B-Instruct` | galaxy |
+| `Llama-3.1-70B-Instruct` | galaxy_t3k |
+| `Llama-3.1-70B-Instruct` | p150x4 |
+| `Llama-3.1-70B-Instruct` | p150x8 |
+| `Llama-3.1-70B-Instruct` | p300x2 |
+| `Llama-3.1-70B-Instruct` | t3k |
+| `Llama-3.1-8B` | galaxy |
+| `Llama-3.1-8B` | galaxy_t3k |
+| `Llama-3.1-8B` | gpu |
+| `Llama-3.1-8B` | n150 |
+| `Llama-3.1-8B` | n300 |
+| `Llama-3.1-8B` | p100 |
+| `Llama-3.1-8B` | p150 |
+| `Llama-3.1-8B` | p150x4 |
+| `Llama-3.1-8B` | p150x8 |
+| `Llama-3.1-8B` | p300 |
+| `Llama-3.1-8B` | p300x2 |
+| `Llama-3.1-8B` | t3k |
+| `Llama-3.1-8B-Instruct` | galaxy |
+| `Llama-3.1-8B-Instruct` | galaxy_t3k |
+| `Llama-3.1-8B-Instruct` | gpu |
+| `Llama-3.1-8B-Instruct` | n150 |
+| `Llama-3.1-8B-Instruct` | n300 |
+| `Llama-3.1-8B-Instruct` | p100 |
+| `Llama-3.1-8B-Instruct` | p150 |
+| `Llama-3.1-8B-Instruct` | p150x4 |
+| `Llama-3.1-8B-Instruct` | p150x8 |
+| `Llama-3.1-8B-Instruct` | p300 |
+| `Llama-3.1-8B-Instruct` | p300x2 |
+| `Llama-3.1-8B-Instruct` | t3k |
+| `Llama-3.2-11B-Vision` | n300 |
+| `Llama-3.2-11B-Vision` | t3k |
+| `Llama-3.2-11B-Vision-Instruct` | n300 |
+| `Llama-3.2-11B-Vision-Instruct` | t3k |
+| `Llama-3.2-1B` | n150 |
+| `Llama-3.2-1B` | n300 |
+| `Llama-3.2-1B` | t3k |
+| `Llama-3.2-1B-Instruct` | n150 |
+| `Llama-3.2-1B-Instruct` | n300 |
+| `Llama-3.2-1B-Instruct` | t3k |
+| `Llama-3.2-3B` | n150 |
+| `Llama-3.2-3B` | n300 |
+| `Llama-3.2-3B` | t3k |
+| `Llama-3.2-3B-Instruct` | n150 |
+| `Llama-3.2-3B-Instruct` | n300 |
+| `Llama-3.2-3B-Instruct` | t3k |
+| `Llama-3.2-90B-Vision` | t3k |
+| `Llama-3.2-90B-Vision-Instruct` | t3k |
+| `Llama-3.3-70B-Instruct` | galaxy |
+| `Llama-3.3-70B-Instruct` | galaxy_t3k |
+| `Llama-3.3-70B-Instruct` | p150x4 |
+| `Llama-3.3-70B-Instruct` | p150x8 |
+| `Llama-3.3-70B-Instruct` | p300x2 |
+| `Llama-3.3-70B-Instruct` | t3k |
+| `Mistral-7B-Instruct-v0.3` | n150 |
+| `Mistral-7B-Instruct-v0.3` | n300 |
+| `Mistral-7B-Instruct-v0.3` | t3k |
+| `Mistral-Small-3.1-24B-Instruct-2503` | t3k |
+| `QwQ-32B` | galaxy |
+| `QwQ-32B` | galaxy_t3k |
+| `QwQ-32B` | t3k |
+| `Qwen2.5-72B` | galaxy |
+| `Qwen2.5-72B` | galaxy_t3k |
+| `Qwen2.5-72B` | t3k |
+| `Qwen2.5-72B-Instruct` | galaxy |
+| `Qwen2.5-72B-Instruct` | galaxy_t3k |
+| `Qwen2.5-72B-Instruct` | t3k |
+| `Qwen2.5-7B` | n150x4 |
+| `Qwen2.5-7B` | n300 |
+| `Qwen2.5-7B-Instruct` | n150x4 |
+| `Qwen2.5-7B-Instruct` | n300 |
+| `Qwen2.5-Coder-32B-Instruct` | galaxy_t3k |
+| `Qwen2.5-Coder-32B-Instruct` | t3k |
+| `Qwen2.5-VL-32B-Instruct` | t3k |
+| `Qwen2.5-VL-3B-Instruct` | n150 |
+| `Qwen2.5-VL-3B-Instruct` | n300 |
+| `Qwen2.5-VL-72B-Instruct` | gpu |
+| `Qwen2.5-VL-72B-Instruct` | t3k |
+| `Qwen2.5-VL-7B-Instruct` | n150 |
+| `Qwen2.5-VL-7B-Instruct` | n300 |
+| `Qwen3-32B` | galaxy |
+| `Qwen3-32B` | galaxy_t3k |
+| `Qwen3-32B` | p150x8 |
+| `Qwen3-32B` | p300x2 |
+| `Qwen3-32B` | t3k |
+| `Qwen3-8B` | galaxy |
+| `Qwen3-8B` | galaxy_t3k |
+| `Qwen3-8B` | n150 |
+| `Qwen3-8B` | n300 |
+| `Qwen3-8B` | p300 |
+| `Qwen3-8B` | t3k |
+| `Qwen3-VL-32B-Instruct` | t3k |
+| `gemma-3-1b-it` | n150 |
+| `gemma-3-27b-it` | galaxy |
+| `gemma-3-27b-it` | galaxy_t3k |
+| `gemma-3-27b-it` | p300x2 |
+| `gemma-3-27b-it` | t3k |
+| `gemma-3-4b-it` | n150 |
+| `gemma-3-4b-it` | n300 |
+| `gemma-3-4b-it` | p150 |
+| `gemma-3-4b-it` | t3k |
+| `gpt-oss-120b` | galaxy |
+| `gpt-oss-120b` | p300x2 |
+| `gpt-oss-120b` | t3k |
+| `gpt-oss-20b` | galaxy |
+| `gpt-oss-20b` | galaxy_t3k |
+| `gpt-oss-20b` | t3k |
+| `medgemma-27b-it` | galaxy |
+| `medgemma-27b-it` | galaxy_t3k |
+| `medgemma-27b-it` | p300x2 |
+| `medgemma-27b-it` | t3k |
+| `medgemma-4b-it` | n150 |
+| `medgemma-4b-it` | n300 |
+| `medgemma-4b-it` | p150 |
+| `medgemma-4b-it` | t3k |
 
-To add a new model, add an entry under `models` in `values.yaml` with at least one device sub-key containing `image.repository` and `image.tag`.
+### Media
+
+| Model | Device |
+|---|---|
+| `FLUX.1-dev` | galaxy |
+| `FLUX.1-dev` | p150x4 |
+| `FLUX.1-dev` | p150x8 |
+| `FLUX.1-dev` | p300 |
+| `FLUX.1-dev` | p300x2 |
+| `FLUX.1-dev` | t3k |
+| `FLUX.1-schnell` | galaxy |
+| `FLUX.1-schnell` | p150x4 |
+| `FLUX.1-schnell` | p150x8 |
+| `FLUX.1-schnell` | p300 |
+| `FLUX.1-schnell` | p300x2 |
+| `FLUX.1-schnell` | t3k |
+| `Llama-3.1-70B` | t3k |
+| `Motif-Image-6B-Preview` | galaxy |
+| `Motif-Image-6B-Preview` | p150x8 |
+| `Motif-Image-6B-Preview` | p300x2 |
+| `Motif-Image-6B-Preview` | t3k |
+| `Qwen-Image` | galaxy |
+| `Qwen-Image` | t3k |
+| `Qwen-Image-2512` | galaxy |
+| `Qwen-Image-2512` | t3k |
+| `Qwen3-Embedding-8B` | galaxy |
+| `Qwen3-Embedding-8B` | n150 |
+| `Qwen3-Embedding-8B` | n300 |
+| `Qwen3-Embedding-8B` | t3k |
+| `Wan2.2-I2V-A14B-Diffusers` | galaxy |
+| `Wan2.2-I2V-A14B-Diffusers` | p150x4 |
+| `Wan2.2-I2V-A14B-Diffusers` | p150x8 |
+| `Wan2.2-I2V-A14B-Diffusers` | p300x2 |
+| `Wan2.2-I2V-A14B-Diffusers` | t3k |
+| `Wan2.2-T2V-A14B-Diffusers` | galaxy |
+| `Wan2.2-T2V-A14B-Diffusers` | p150x4 |
+| `Wan2.2-T2V-A14B-Diffusers` | p150x8 |
+| `Wan2.2-T2V-A14B-Diffusers` | p300x2 |
+| `Wan2.2-T2V-A14B-Diffusers` | t3k |
+| `bge-large-en-v1.5` | galaxy |
+| `bge-large-en-v1.5` | n150 |
+| `bge-large-en-v1.5` | n300 |
+| `bge-large-en-v1.5` | t3k |
+| `bge-m3` | galaxy |
+| `bge-m3` | n150 |
+| `bge-m3` | n300 |
+| `bge-m3` | t3k |
+| `distil-large-v3` | galaxy |
+| `distil-large-v3` | n150 |
+| `distil-large-v3` | n300 |
+| `distil-large-v3` | p150 |
+| `distil-large-v3` | p300 |
+| `distil-large-v3` | p300x2 |
+| `distil-large-v3` | t3k |
+| `mochi-1-preview` | galaxy |
+| `mochi-1-preview` | p150x4 |
+| `mochi-1-preview` | p150x8 |
+| `mochi-1-preview` | p300x2 |
+| `mochi-1-preview` | t3k |
+| `speecht5_tts` | n150 |
+| `speecht5_tts` | n300 |
+| `speecht5_tts` | p150 |
+| `speecht5_tts` | p300 |
+| `speecht5_tts` | p300x2 |
+| `stable-diffusion-3.5-large` | galaxy |
+| `stable-diffusion-3.5-large` | t3k |
+| `stable-diffusion-xl-1.0-inpainting-0.1` | galaxy |
+| `stable-diffusion-xl-1.0-inpainting-0.1` | n150 |
+| `stable-diffusion-xl-1.0-inpainting-0.1` | n300 |
+| `stable-diffusion-xl-1.0-inpainting-0.1` | p150 |
+| `stable-diffusion-xl-1.0-inpainting-0.1` | p150x4 |
+| `stable-diffusion-xl-1.0-inpainting-0.1` | p150x8 |
+| `stable-diffusion-xl-1.0-inpainting-0.1` | p300x2 |
+| `stable-diffusion-xl-1.0-inpainting-0.1` | t3k |
+| `stable-diffusion-xl-base-1.0` | galaxy |
+| `stable-diffusion-xl-base-1.0` | n150 |
+| `stable-diffusion-xl-base-1.0` | n300 |
+| `stable-diffusion-xl-base-1.0` | p150 |
+| `stable-diffusion-xl-base-1.0` | p150x4 |
+| `stable-diffusion-xl-base-1.0` | p150x8 |
+| `stable-diffusion-xl-base-1.0` | p300x2 |
+| `stable-diffusion-xl-base-1.0` | t3k |
+| `stable-diffusion-xl-base-1.0-img-2-img` | galaxy |
+| `stable-diffusion-xl-base-1.0-img-2-img` | n150 |
+| `stable-diffusion-xl-base-1.0-img-2-img` | n300 |
+| `stable-diffusion-xl-base-1.0-img-2-img` | p150 |
+| `stable-diffusion-xl-base-1.0-img-2-img` | p150x4 |
+| `stable-diffusion-xl-base-1.0-img-2-img` | p150x8 |
+| `stable-diffusion-xl-base-1.0-img-2-img` | p300x2 |
+| `stable-diffusion-xl-base-1.0-img-2-img` | t3k |
+| `whisper-large-v3` | galaxy |
+| `whisper-large-v3` | n150 |
+| `whisper-large-v3` | n300 |
+| `whisper-large-v3` | p150 |
+| `whisper-large-v3` | p300 |
+| `whisper-large-v3` | p300x2 |
+| `whisper-large-v3` | t3k |
+
+### Forge
+
+| Model | Device |
+|---|---|
+| `Falcon3-7B-Instruct` | n150 |
+| `Falcon3-7B-Instruct` | n300 |
+| `Falcon3-7B-Instruct` | p150 |
+| `Llama-3.1-8B-Instruct` | n150 |
+| `Llama-3.1-8B-Instruct` | n300 |
+| `Llama-3.1-8B-Instruct` | p150 |
+| `Llama-3.2-3B` | n150 |
+| `Llama-3.2-3B` | n300 |
+| `Llama-3.2-3B` | p150 |
+| `Llama-3.2-3B-Instruct` | n150 |
+| `Llama-3.2-3B-Instruct` | n300 |
+| `Llama-3.2-3B-Instruct` | p150 |
+| `Qwen3-4B` | n150 |
+| `Qwen3-4B` | n300 |
+| `Qwen3-4B` | p150 |
+| `Qwen3-8B` | n150 |
+| `Qwen3-8B` | n300 |
+| `Qwen3-8B` | p150 |
+| `Qwen3-Embedding-4B` | galaxy |
+| `Qwen3-Embedding-4B` | n150 |
+| `Qwen3-Embedding-4B` | n300 |
+| `Qwen3-Embedding-4B` | t3k |
+| `efficientnet` | n150 |
+| `efficientnet` | n300 |
+| `mobilenetv2` | n150 |
+| `mobilenetv2` | n300 |
+| `resnet-50` | n150 |
+| `resnet-50` | n300 |
+| `segformer` | n150 |
+| `segformer` | n300 |
+| `unet` | n150 |
+| `unet` | n300 |
+| `vit` | n150 |
+| `vit` | n300 |
+| `vovnet` | n150 |
+| `vovnet` | n300 |
+
+To add a new model, add an entry under `models.<name>.<engine>.<device>` in `values.yaml`, where `<engine>` is one of `vllm`, `media`, or `forge`, and the device block contains an `impls.<impl-id>` entry with `image.repository` and `image.tag`.
 
 ---
 

--- a/charts/tt-inference-server/README.md.gotmpl
+++ b/charts/tt-inference-server/README.md.gotmpl
@@ -10,10 +10,11 @@ Deploys vLLM and media inference backends on Tenstorrent Galaxy hardware.
 
 This chart creates a single `Deployment`, `Service`, `ConfigMap`, and `Secret` for one inference model on one Tenstorrent device. The chart ships with pre-validated configurations for every supported model and device combination. You select a model and device at install time; the chart merges your selection against a layered config system to produce the final Kubernetes resources.
 
-Two server types are supported:
+Three engines are supported:
 
 - **vllm** — large language models served via the vLLM OpenAI-compatible API
 - **media** — image/audio/video/embedding models served via the tt-media-inference-server API
+- **forge** — models served via the tt-forge backend
 
 ---
 
@@ -50,35 +51,87 @@ charts/tt-inference-server/
 
 Contains the core logic for this chart:
 
-- **`tt-inference-server.validateValues`** — fails the render if `model` or `device` is missing, or if the `model`+`device` combination has no entry in the `models` map.
-- **`tt-inference-server.resolvedConfig`** — deep-merges `defaults` with the per-model/device config block and returns the final effective config as YAML (see [Configuration System](#configuration-system)).
+- **`tt-inference-server.validateValues`** — fails the render if `model` or `device` is missing, or if the resolved `model`/`engine`/`device`/`impl` has no entry in the `models` map.
+- **`tt-inference-server.resolvedEngine`** — picks the engine: `.Values.engine` if set, the sole engine offering the device, otherwise `models.<model>.defaultEngine` when more than one engine offers it.
+- **`tt-inference-server.resolvedImpl`** — picks the implementation: `.Values.impl` if set, otherwise `models.<model>.<engine>.<device>.defaultImpl`.
+- **`tt-inference-server.resolvedConfig`** — deep-merges `defaults` with the resolved impl block (`models.<model>.<engine>.<device>.impls.<impl>`) and returns the effective config as YAML (see [Configuration System](#configuration-system)).
 - **`tt-inference-server.image`** — assembles the container image string (`repository:tag`) from the resolved config.
-- **`tt-inference-server.cacheHostPath`** — returns `cache.hostPath` if set, otherwise generates `/opt/cache/<model>-<device>`.
+- **`tt-inference-server.cacheHostPath`** — returns `cache.hostPath` if set, otherwise generates `/opt/cache/<model>-<device>-<impl>`.
 - Standard Helm name helpers: `tt-inference-server.name`, `tt-inference-server.fullname`, `tt-inference-server.labels`, `tt-inference-server.selectorLabels`.
 
 ---
 
 ## Configuration System
 
-Values are resolved through a three-level merge. Later levels win on any conflict.
+A model is addressed by a `model → engine → device → impl` path. `engine` and `impl` are normally inferred, so most installs set only `model` and `device`:
+
+- **engine** — if exactly one engine offers the requested device it is chosen automatically; when more than one does, `models.<model>.defaultEngine` is used unless you pass `--set engine=`.
+- **impl** — defaults to `models.<model>.<engine>.<device>.defaultImpl` unless you pass `--set impl=`.
+
+The effective config is then a two-level merge — the resolved impl block layered on top of `defaults`, where the impl block wins on any conflict:
 
 ```
-defaults                          ← baseline for all models and devices
-  └── models.<name>               ← model-level fields (serverType)
-        └── models.<name>.<device> ← deepest override, wins on all conflicts
+defaults                                              ← baseline for every model
+  └── models.<model>.<engine>.<device>.impls.<impl>   ← resolved leaf, wins on conflict
 ```
 
-**Example:** for `model=Llama-3.1-8B-Instruct` and `device=galaxy`, the effective config is:
+**Example:** for `model=Llama-3.1-8B-Instruct` and `device=n300`:
 
-1. Start with the full `defaults` block.
-2. Apply the `serverType: vllm` field from `models.Llama-3.1-8B-Instruct`.
-3. Deep-merge the `models.Llama-3.1-8B-Instruct.galaxy` block on top — overriding `image.repository`, `image.tag`, `resources`, and probe delays.
+1. Resolve the engine — `n300` is offered by both `vllm` and `forge`, so `models.Llama-3.1-8B-Instruct.defaultEngine` (`vllm`) is used. Pass `--set engine=forge` to pick the other.
+2. Resolve the impl — `models.Llama-3.1-8B-Instruct.vllm.n300.defaultImpl` (`tt_transformers`).
+3. Start from the full `defaults` block, then deep-merge `models.Llama-3.1-8B-Instruct.vllm.n300.impls.tt_transformers` on top — overriding `image.repository`, `image.tag`, `resources`, probe delays, and `env`.
 
-Any field not overridden at the model/device level falls back to `defaults`.
+Any field the resolved impl block does not set falls back to `defaults`.
 
 ---
 
-{{ template "chart.valuesSection" . }}
+## Values Reference
+
+Set per release, typically via `--set`.
+
+| Value | Required | Default | Description |
+|---|---|---|---|
+| `model` | yes | `""` | Model name. Must match a key under `models`. |
+| `device` | yes | `""` | Device name. Must match a key under `models.<model>.<engine>`. |
+| `engine` | no | `""` | Pin the engine (`vllm`, `media`, or `forge`) when a model+device is offered by more than one. Defaults to the only matching engine, or `models.<model>.defaultEngine` when ambiguous. |
+| `impl` | no | `""` | Pin the implementation when a device offers more than one. Defaults to `models.<model>.<engine>.<device>.defaultImpl`. |
+| `hfToken` | yes* | `""` | HuggingFace token. Injected as `HF_TOKEN`. Required unless weights are pre-downloaded via `hfCacheDir`. |
+| `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
+| `cache.hostPath` | no | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>-<impl>`. |
+| `nameOverride` | no | `""` | Overrides the chart name component in resource names. |
+| `fullnameOverride` | no | `""` | Fully overrides the resource name prefix. |
+| `models` | — | See [Supported Models](#supported-models) | Per-model catalogue keyed by `<model>.<engine>.<device>.impls.<impl>`. Each impl leaf overrides `defaults`. |
+
+## Defaults Reference
+
+All fields under `defaults` apply to every model/engine/device/impl unless overridden by the resolved impl block.
+
+| Field | Default | Description |
+|---|---|---|
+| `defaults.replicaCount` | `1` | Number of Deployment replicas. |
+| `defaults.progressDeadlineSeconds` | `3600` | Deployment progress deadline. Set high due to long model load times. |
+| `defaults.podAnnotations` | `{}` | Annotations applied to the pod template. |
+| `defaults.podSecurityContext` | `{}` | Pod-level `securityContext`. |
+| `defaults.image.pullPolicy` | `IfNotPresent` | Image pull policy. |
+| `defaults.image.pullSecrets` | `[]` | Image pull secrets. |
+| `defaults.service.type` | `ClusterIP` | Kubernetes Service type. |
+| `defaults.service.port` | `8000` | Service port. |
+| `defaults.service.targetPort` | `8000` | Container target port. |
+| `defaults.service.annotations` | `{}` | Annotations applied to the Service. |
+| `defaults.resources.limits.hugepages-1Gi` | `32Gi` | Hugepage limit. (`cpu` and `memory` limits are unset by default.) |
+| `defaults.resources.requests.cpu` | `"6"` | CPU request. |
+| `defaults.resources.requests.memory` | `64Gi` | Memory request (often overridden per impl). |
+| `defaults.resources.requests.hugepages-1Gi` | `32Gi` | Hugepage request. |
+| `defaults.probes.liveness.enabled` | `true` | Enable liveness probe. |
+| `defaults.probes.liveness.path` | `/v1/models` | Liveness probe HTTP path. |
+| `defaults.probes.liveness.initialDelaySeconds` | `2400` | Liveness probe initial delay. Set high due to model load times. |
+| `defaults.probes.readiness.enabled` | `true` | Enable readiness probe. |
+| `defaults.probes.readiness.path` | `/health` | Readiness probe HTTP path. |
+| `defaults.probes.readiness.initialDelaySeconds` | `2400` | Readiness probe initial delay. |
+| `defaults.nodeSelector` | `{}` | Node selector applied to the pod. |
+| `defaults.tolerations` | `[]` | Tolerations applied to the pod. |
+| `defaults.affinity` | `{}` | Affinity rules applied to the pod. |
+| `defaults.extraEnv` | `[]` | Additional environment variables (see [Extra Environment Variables](#extra-environment-variables)). |
 
 ---
 

--- a/charts/tt-inference-server/_supportedModels.gotmpl
+++ b/charts/tt-inference-server/_supportedModels.gotmpl
@@ -1,12 +1,15 @@
 {{- /*
 chart.supportedModelsSection — auto-generated Supported Models tables.
 
-Reads values.yaml via .Files.Get, groups every entry under `models:` by
-its `serverType`, and emits one Markdown table per engine. The label is
-derived from the engine key (vllm → vLLM, media → Media, forge → Forge);
-any unmapped engine falls back to its capitalised key.
+Reads values.yaml via .Files.Get and walks the model catalogue, whose shape is
+`models.<name>.<engine>.<device>` alongside a sibling `defaultEngine` string.
+Models are grouped by engine — the top-level key under each model, excluding
+`defaultEngine` — and one Markdown table is emitted per engine, listing every
+model/device pair. The label is derived from the engine key (vllm → vLLM,
+media → Media, forge → Forge); any unmapped engine falls back to its
+capitalised key.
 
-Adding a new engine or model in values.yaml is reflected here on the
+Adding a new engine, model, or device in values.yaml is reflected here on the
 next helm-docs run — no manual edit to this file or README.md.gotmpl.
 */ -}}
 {{- define "chart.supportedModelsSection" -}}
@@ -15,9 +18,12 @@ next helm-docs run — no manual edit to this file or README.md.gotmpl.
 {{- $engineOrder := list "vllm" "media" "forge" -}}
 {{- $groups := dict -}}
 {{- range $name, $cfg := $values.models -}}
-  {{- $engine := default "unknown" $cfg.serverType -}}
-  {{- $entries := default (list) (index $groups $engine) -}}
-  {{- $_ := set $groups $engine (append $entries (dict "name" $name "cfg" $cfg)) -}}
+  {{- range $engine, $devices := $cfg -}}
+  {{- if ne $engine "defaultEngine" -}}
+    {{- $entries := default (list) (index $groups $engine) -}}
+    {{- $_ := set $groups $engine (append $entries (dict "name" $name "devices" $devices)) -}}
+  {{- end -}}
+  {{- end -}}
 {{- end -}}
 ## Supported Models
 {{- range $engineOrder }}
@@ -30,10 +36,8 @@ next helm-docs run — no manual edit to this file or README.md.gotmpl.
 |---|---|
 {{- range (index $groups $engine) }}
 {{- $name := .name }}
-{{- range $key, $_ := .cfg }}
-{{- if ne $key "serverType" }}
-| `{{ $name }}` | {{ $key }} |
-{{- end }}
+{{- range $device, $_ := .devices }}
+| `{{ $name }}` | {{ $device }} |
 {{- end }}
 {{- end }}
 {{- end }}
@@ -47,14 +51,12 @@ next helm-docs run — no manual edit to this file or README.md.gotmpl.
 |---|---|
 {{- range $entries }}
 {{- $name := .name }}
-{{- range $key, $_ := .cfg }}
-{{- if ne $key "serverType" }}
-| `{{ $name }}` | {{ $key }} |
-{{- end }}
+{{- range $device, $_ := .devices }}
+| `{{ $name }}` | {{ $device }} |
 {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
 
-To add a new model, add an entry under `models` in `values.yaml` with at least one device sub-key containing `image.repository` and `image.tag`.
+To add a new model, add an entry under `models.<name>.<engine>.<device>` in `values.yaml`, where `<engine>` is one of `vllm`, `media`, or `forge`, and the device block contains an `impls.<impl-id>` entry with `image.repository` and `image.tag`.
 {{- end -}}


### PR DESCRIPTION
closes #3834 

## Issue 
The Supported Models table in the chart README  was generated from an obsolete schema assumption (`models.<name>.serverType` + device sub-keys), producing one invalid `defaultEngine` row per model and grouping everything under a invalid `### Unknown` heading.
 
 https://github.com/tenstorrent/tt-inference-server/blob/main/charts/tt-inference-server/README.md

## Solution
Rewrite `_supportedModels.gotmpl` to walk the actual schema (`models.<name>.<engine>.<device>`, with `defaultEngine` as a sibling string), grouping models by engine into per-engine tables (vLLM/Media/ Forge) that list real devices. The table now has 259 verified model/device rows and no `defaultEngine` rows