### PR TITLE
Extract URL resolution into utils/url_helpers

### DIFF
--- a/benchmarking/run_aiperf_benchmarks.py
+++ b/benchmarking/run_aiperf_benchmarks.py
@@ -24,7 +24,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
-from urllib.parse import urlparse
 
 import jwt
 import requests
@@ -36,6 +35,7 @@ sys.path.insert(0, str(project_root))
 from benchmarking.benchmark_config import BENCHMARK_CONFIGS
 from utils.prompt_client import PromptClient
 from utils.prompt_configs import EnvironmentConfig
+from utils.url_helpers import build_base_url, resolve_deploy_url, resolve_host_port
 from workflows.log_setup import setup_workflow_script_logger
 from workflows.model_spec import ModelSpec
 from workflows.runtime_config import RuntimeConfig
@@ -472,14 +472,10 @@ def send_warmup_requests(
         try:
             logger.info(f"Sending warm-up request {i + 1}/{num_requests}...")
 
-            # Use the prompt client's URL and auth. Honor an explicit port on
-            # env_config.deploy_url to avoid double-port URLs when --server-url
-            # already carries one.
-            _parsed = urlparse(prompt_client.env_config.deploy_url.rstrip("/"))
-            _base = (
-                prompt_client.env_config.deploy_url.rstrip("/")
-                if _parsed.port is not None
-                else f"{prompt_client.env_config.deploy_url.rstrip('/')}:{prompt_client.env_config.service_port}"
+            # Use the prompt client's URL and auth.
+            _base = build_base_url(
+                prompt_client.env_config.deploy_url,
+                prompt_client.env_config.service_port,
             )
             url = f"{_base}/v1/chat/completions"
             headers = {"Content-Type": "application/json"}
@@ -570,14 +566,8 @@ def main():
     # runtime config loaded from JSON
     device_str = runtime_config.device
     service_port = runtime_config.service_port
-    deploy_url = getattr(runtime_config, "server_url", None) or os.environ.get(
-        "DEPLOY_URL", "http://127.0.0.1"
-    )
-    # An explicit port on deploy_url wins over service_port so AIPerf doesn't
-    # connect to host:service_port when --server-url already carries a port.
-    _parsed = urlparse(deploy_url.rstrip("/"))
-    aiperf_host = _parsed.hostname or "localhost"
-    aiperf_port = str(_parsed.port) if _parsed.port is not None else str(service_port)
+    deploy_url = resolve_deploy_url(runtime_config)
+    aiperf_host, aiperf_port = resolve_host_port(deploy_url, service_port)
     aiperf_url = f"{aiperf_host}:{aiperf_port}"
 
     device = DeviceTypes.from_string(device_str)

--- a/benchmarking/run_benchmarks.py
+++ b/benchmarking/run_benchmarks.py
@@ -10,7 +10,6 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from urllib.parse import urlparse
 
 import jwt
 import requests
@@ -20,6 +19,7 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 from utils.media_clients.media_client_factory import MediaClientFactory, MediaTaskType
+from utils.url_helpers import resolve_deploy_url, resolve_host_port
 
 # Add the script's directory to the Python path
 # this for 0 setup python setup script
@@ -136,20 +136,6 @@ def parse_args():
     return ret_args
 
 
-def _resolve_host_port(deploy_url: str, service_port) -> tuple[str, str]:
-    """Split a deploy URL into ``(host, port)`` for ``--host``/``--port`` args.
-
-    When ``deploy_url`` carries an explicit port (e.g. ``http://host:9000``) that
-    port wins over ``service_port`` so callers can't end up with mismatched
-    ``--host host --port <service_port>`` against a server that's actually
-    listening on a different port.
-    """
-    parsed = urlparse(deploy_url.rstrip("/"))
-    host = parsed.hostname or "localhost"
-    port = str(parsed.port) if parsed.port is not None else str(service_port)
-    return host, port
-
-
 def build_benchmark_command(
     task,
     benchmark_script,
@@ -183,7 +169,7 @@ def build_benchmark_command(
     dataset_name = "random-mm" if params.task_type == "vlm" else "random"
     backend = "openai-chat"
 
-    host, port = _resolve_host_port(deploy_url, service_port)
+    host, port = resolve_host_port(deploy_url, service_port)
 
     # fmt: off
     cmd = [
@@ -246,7 +232,7 @@ def build_structured_output_command(
         f"_osl-{params.osl}_maxcon-{params.max_concurrency}_n-{params.num_prompts}.json"
     )
 
-    host, port = _resolve_host_port(deploy_url, service_port)
+    host, port = resolve_host_port(deploy_url, service_port)
 
     # fmt: off
     cmd = [
@@ -305,12 +291,9 @@ def main():
     device_str = runtime_config.device
     service_port = runtime_config.service_port
     disable_trace_capture = runtime_config.disable_trace_capture
-    # Mirror EnvironmentConfig's default (os.environ.get("DEPLOY_URL",
-    # "http://127.0.0.1")) so the genai-perf path (which runs before
+    # Resolved once here so the genai-perf branch (which returns before
     # env_config is constructed) sees the same value used later.
-    deploy_url = getattr(runtime_config, "server_url", None) or os.environ.get(
-        "DEPLOY_URL", "http://127.0.0.1"
-    )
+    deploy_url = resolve_deploy_url(runtime_config)
 
     # Automatically control trace capture based on has_builtin_warmup
     # Only apply automatic logic if user hasn't explicitly set --disable-trace-capture

--- a/benchmarking/run_genai_benchmarks.py
+++ b/benchmarking/run_genai_benchmarks.py
@@ -13,7 +13,6 @@ import os
 import sys
 import uuid
 from pathlib import Path
-from urllib.parse import urlparse
 
 import jwt
 
@@ -21,6 +20,7 @@ import jwt
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from utils.url_helpers import resolve_deploy_url, resolve_host_port
 from workflows.log_setup import setup_workflow_script_logger
 from workflows.model_spec import ModelSpec
 from workflows.runtime_config import RuntimeConfig
@@ -109,12 +109,8 @@ def run_genai_benchmarks(
     """
     logger.info("Starting genai-perf benchmarks...")
 
-    # genai-perf consumes URL as host[:port] without the scheme, so strip it
-    # here. An explicit port on the deploy URL wins over service_port to
-    # match the resolver used by the vLLM-bench path.
-    parsed = urlparse(deploy_url.rstrip("/"))
-    genai_host = parsed.hostname or "localhost"
-    genai_port = str(parsed.port) if parsed.port is not None else str(service_port)
+    # genai-perf consumes URL as host[:port] without the scheme, so strip it.
+    genai_host, genai_port = resolve_host_port(deploy_url, service_port)
     genai_url = f"{genai_host}:{genai_port}"
 
     # Get venv config for artifacts directory
@@ -240,9 +236,7 @@ def main():
 
     # runtime config loaded from JSON
     service_port = runtime_config.service_port
-    deploy_url = getattr(runtime_config, "server_url", None) or os.environ.get(
-        "DEPLOY_URL", "http://127.0.0.1"
-    )
+    deploy_url = resolve_deploy_url(runtime_config)
 
     logger.info(f"Model: {model_spec.model_name}")
     logger.info(f"Device: {model_spec.device_type}")

--- a/benchmarking/run_guidellm_benchmarks.py
+++ b/benchmarking/run_guidellm_benchmarks.py
@@ -21,7 +21,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import urlparse
 
 import jwt
 
@@ -31,6 +30,7 @@ sys.path.insert(0, str(project_root))
 
 from utils.prompt_client import PromptClient
 from utils.prompt_configs import EnvironmentConfig
+from utils.url_helpers import build_base_url, resolve_deploy_url
 from workflows.log_setup import setup_workflow_script_logger
 from workflows.model_spec import ModelSpec
 from workflows.runtime_config import RuntimeConfig
@@ -657,9 +657,7 @@ def main():
     model_spec = ModelSpec.from_json(args.runtime_model_spec_json)
     runtime_config = RuntimeConfig.from_json(args.runtime_model_spec_json)
 
-    deploy_url = getattr(runtime_config, "server_url", None) or os.environ.get(
-        "DEPLOY_URL", "http://127.0.0.1"
-    )
+    deploy_url = resolve_deploy_url(runtime_config)
 
     if model_spec.inference_engine in (
         InferenceEngine.MEDIA.value,
@@ -682,13 +680,7 @@ def main():
     output_root.mkdir(parents=True, exist_ok=True)
 
     workflow_params = parse_workflow_args(runtime_config.workflow_args)
-    # Honor an explicit port on deploy_url to avoid double-port targets.
-    _parsed = urlparse(deploy_url.rstrip("/"))
-    _base = (
-        deploy_url.rstrip("/")
-        if _parsed.port is not None
-        else f"{deploy_url.rstrip('/')}:{runtime_config.service_port}"
-    )
+    _base = build_base_url(deploy_url, runtime_config.service_port)
     target = workflow_params.get("target", f"{_base}/v1")
 
     runs = build_scenario_runs(

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -12,7 +12,6 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import List, Optional
-from urllib.parse import urlparse
 
 import jwt
 
@@ -22,6 +21,7 @@ sys.path.insert(0, str(project_root))
 
 from utils.media_clients.base_strategy_interface import BaseMediaStrategy
 from utils.media_clients.media_client_factory import MediaClientFactory, MediaTaskType
+from utils.url_helpers import build_base_url, resolve_deploy_url
 
 # Add the script's directory to the Python path
 # this for 0 setup python setup script
@@ -435,22 +435,6 @@ def parse_args():
     return ret_args
 
 
-def _build_base_url(deploy_url: str, service_port: str) -> str:
-    """Construct a base URL from a deploy URL and service port.
-
-    Normalizes the deploy URL by stripping trailing slashes.  When the URL
-    already contains an explicit port (e.g. ``http://host:9000``) that port is
-    used and *service_port* is ignored so that the resulting URL is never of
-    the form ``http://host:9000:8000``.
-    """
-    normalized = deploy_url.rstrip("/")
-    parsed = urlparse(normalized)
-    if parsed.port is not None:
-        # URL already includes a port; use as-is
-        return normalized
-    return f"{normalized}:{service_port}"
-
-
 def build_eval_command(
     task: EvalTask,
     model_spec,
@@ -475,7 +459,7 @@ def build_eval_command(
 
     # Audio models use tt-media-server which has endpoints at /audio (not /v1/audio)
     # Other models use vLLM which has endpoints at /v1
-    host_with_port = _build_base_url(deploy_url, service_port)
+    host_with_port = build_base_url(deploy_url, service_port)
     if task.workflow_venv_type == WorkflowVenvType.EVALS_AUDIO:
         base_url = host_with_port
     else:
@@ -912,8 +896,7 @@ def main():
     # explicitly re-read so in-process PromptClient sees later env updates
     # (mirrors run_benchmarks.py:439).
     env_config.vllm_api_key = os.getenv("VLLM_API_KEY")
-    if getattr(runtime_config, "server_url", None):
-        env_config.deploy_url = runtime_config.server_url
+    env_config.deploy_url = resolve_deploy_url(runtime_config)
 
     if (
         model_spec.model_type in EVAL_TASK_TYPES

--- a/server_tests/base_test.py
+++ b/server_tests/base_test.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional
 import requests
 
 from server_tests.test_classes import TestConfig
+from utils.url_helpers import DEFAULT_DEPLOY_URL, build_base_url
 
 logger = logging.getLogger(__name__)
 
@@ -44,20 +45,10 @@ class BaseTest(ABC):
         self.targets = targets
         self.description = description
         self.service_port = os.getenv("SERVICE_PORT", "8000")
-        # DEPLOY_URL is set by the workflow runner from --server-url; keep the
-        # localhost default for direct/manual test invocations.
-        self.deploy_url = os.getenv("DEPLOY_URL", "http://localhost")
-        # Pre-computed base URL (scheme://host[:port]) for test_cases to build
-        # endpoint URLs against. An explicit port on DEPLOY_URL wins over
-        # SERVICE_PORT so test_cases can't end up with a double-port URL.
-        from urllib.parse import urlparse as _urlparse
-
-        _parsed = _urlparse(self.deploy_url.rstrip("/"))
-        self.base_url = (
-            self.deploy_url.rstrip("/")
-            if _parsed.port is not None
-            else f"{self.deploy_url.rstrip('/')}:{self.service_port}"
-        )
+        # DEPLOY_URL is set by the workflow runner from --server-url.
+        self.deploy_url = os.getenv("DEPLOY_URL", DEFAULT_DEPLOY_URL)
+        # Pre-computed base URL (scheme://host[:port]) for test_cases.
+        self.base_url = build_base_url(self.deploy_url, self.service_port)
         self.timeout = config.get("timeout")
         self.retry_attempts = config.get("retry_attempts")
         self.break_on_failure = config.get("break_on_failure")
@@ -218,18 +209,7 @@ class BaseTest(ABC):
         retry_delay = (
             retry_delay if retry_delay is not None else HEALTH_CHECK_CONFIG.RETRY_DELAY
         )
-        # If DEPLOY_URL already carries a port, honor it; otherwise append
-        # service_port. Mirrors the urlparse-port-wins rule used by the
-        # benchmark/eval runners.
-        from urllib.parse import urlparse
-
-        parsed = urlparse(self.deploy_url.rstrip("/"))
-        host_with_port = (
-            self.deploy_url.rstrip("/")
-            if parsed.port is not None
-            else f"{self.deploy_url.rstrip('/')}:{service_port}"
-        )
-        health_url = f"{host_with_port}/tt-liveness"
+        health_url = f"{build_base_url(self.deploy_url, service_port)}/tt-liveness"
         logger.info("Waiting for server at %s ...", health_url)
 
         for attempt in range(1, max_attempts + 1):

--- a/server_tests/conftest.py
+++ b/server_tests/conftest.py
@@ -4,7 +4,6 @@
 
 import os
 from pathlib import Path
-from urllib.parse import urlparse
 
 import pytest
 import requests
@@ -12,6 +11,7 @@ import json
 from datetime import datetime
 from utils.prompt_client import PromptClient
 from utils.prompt_configs import EnvironmentConfig
+from utils.url_helpers import DEFAULT_DEPLOY_URL, build_base_url
 
 
 def _default_endpoint_url() -> str:
@@ -19,14 +19,9 @@ def _default_endpoint_url() -> str:
     vars (set by the workflow runner from --server-url), falling back to the
     localhost dev default for direct pytest invocations.
     """
-    deploy_url = os.environ.get("DEPLOY_URL", "http://127.0.0.1").rstrip("/")
-    parsed = urlparse(deploy_url)
-    if parsed.port is not None:
-        base = deploy_url
-    else:
-        port = os.environ.get("SERVICE_PORT", "8000")
-        base = f"{deploy_url}:{port}"
-    return f"{base}/v1/chat/completions"
+    deploy_url = os.environ.get("DEPLOY_URL", DEFAULT_DEPLOY_URL)
+    service_port = os.environ.get("SERVICE_PORT", "8000")
+    return f"{build_base_url(deploy_url, service_port)}/v1/chat/completions"
 
 
 # 1. Add command-line options for endpoint and metadata

--- a/server_tests/run_tests.py
+++ b/server_tests/run_tests.py
@@ -18,6 +18,7 @@ if project_root not in sys.path:
 
 from server_tests.test_config import TEST_CONFIGS, TestTask
 from utils.prompt_configs import EnvironmentConfig
+from utils.url_helpers import build_base_url, resolve_deploy_url
 from workflows.log_setup import setup_workflow_script_logger
 from workflows.model_spec import ModelSpec
 from workflows.runtime_config import RuntimeConfig
@@ -53,16 +54,7 @@ def build_test_command(
 
     if task.task_name == "vllm_responses":
         # vLLM responses test needs the service port to connect to the server.
-        # An explicit port on deploy_url wins over service_port to avoid
-        # double-port URLs when --server-url already carries a port.
-        from urllib.parse import urlparse
-
-        parsed = urlparse(deploy_url.rstrip("/"))
-        base = (
-            deploy_url.rstrip("/")
-            if parsed.port is not None
-            else (f"{deploy_url.rstrip('/')}:{service_port}")
-        )
+        base = build_base_url(deploy_url, service_port)
         test_kwargs_list.extend(["--endpoint-url", f"{base}/v1/responses"])
     cmd = [
         str(test_exec),
@@ -145,9 +137,7 @@ def main():
     # runtime config loaded from JSON
     device_str = runtime_config.device
     service_port = runtime_config.service_port
-    deploy_url = getattr(runtime_config, "server_url", None) or os.environ.get(
-        "DEPLOY_URL", "http://127.0.0.1"
-    )
+    deploy_url = resolve_deploy_url(runtime_config)
     # Propagate to subprocesses (pytest, etc.) that read DEPLOY_URL /
     # SERVICE_PORT (conftest --endpoint-url default, BaseTest). Without
     # exporting SERVICE_PORT, a non-default --service-port wouldn't reach

--- a/server_tests/test_cases/image_generation_lora_load_test.py
+++ b/server_tests/test_cases/image_generation_lora_load_test.py
@@ -124,8 +124,7 @@ class ImageGenerationLoraLoadTest(BaseTest):
     async def _fire_batch(
         self, specs: list[RequestSpec], num_inference_steps: int
     ) -> list[RequestResult]:
-        base_url = f"{self.base_url}"
-        url = f"{base_url}/{ENDPOINT}"
+        url = f"{self.base_url}/{ENDPOINT}"
         headers = {
             "accept": "application/json",
             "Authorization": f"Bearer {DEFAULT_AUTHORIZATION}",

--- a/server_tests/test_cases/server_helper.py
+++ b/server_tests/test_cases/server_helper.py
@@ -7,27 +7,16 @@ import os
 import subprocess
 from pathlib import Path
 
+from utils.url_helpers import DEFAULT_DEPLOY_URL, build_base_url
+
 SERVER_STARTUP_TIMEOUT = 5 * 60  # wait up to 5 minutes for server to start
 SERVER_SHUTDOWN_TIMEOUT = 20
 
-
-def _build_server_base_url() -> str:
-    """Resolve the server base URL from DEPLOY_URL / SERVICE_PORT (set by
-    the workflow runner from --server-url), defaulting to localhost for
-    direct script invocations.
-    """
-    from urllib.parse import urlparse
-
-    deploy_url = os.environ.get("DEPLOY_URL", "http://127.0.0.1").rstrip("/")
-    parsed = urlparse(deploy_url)
-    if parsed.port is not None:
-        return deploy_url
-    port = os.environ.get("SERVICE_PORT", "8000")
-    return f"{deploy_url}:{port}"
-
-
 # Base URL (host:port only) for building v1 API paths in eval tests
-SERVER_BASE_URL = _build_server_base_url()
+SERVER_BASE_URL = build_base_url(
+    os.environ.get("DEPLOY_URL", DEFAULT_DEPLOY_URL),
+    os.environ.get("SERVICE_PORT", "8000"),
+)
 # Full URL to CNN search-image endpoint
 SERVER_DEFAULT_URL = f"{SERVER_BASE_URL}/v1/cnn/search-image"
 DEFAULT_AUTHORIZATION = "your-secret-key"

--- a/stress_tests/stress_tests_args.py
+++ b/stress_tests/stress_tests_args.py
@@ -11,10 +11,11 @@ into a single well-typed dataclass with explicit precedence rules.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
+
+from utils.url_helpers import resolve_deploy_url
 
 if TYPE_CHECKING:
     from workflows.runtime_config import RuntimeConfig
@@ -90,10 +91,7 @@ class StressTestsArgs:
             model=runtime_config.model,
             device=runtime_config.device,
             service_port=runtime_config.service_port,
-            deploy_url=(
-                getattr(runtime_config, "server_url", None)
-                or os.environ.get("DEPLOY_URL", "http://127.0.0.1")
-            ),
+            deploy_url=resolve_deploy_url(runtime_config),
             # From RuntimeConfig (stress tests configuration)
             # Auto-disable trace capture if model has builtin warmup and user hasn't explicitly overridden
             disable_trace_capture=runtime_config.disable_trace_capture

--- a/stress_tests/stress_tests_core.py
+++ b/stress_tests/stress_tests_core.py
@@ -29,12 +29,12 @@ and automatically applies context limit constraints with adjustment when needed.
 import os
 import logging
 import subprocess
-from urllib.parse import urlparse
 import time
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+from utils.url_helpers import resolve_host_port
 from workflows.workflow_types import DeviceTypes
 from .stress_tests_config import StressTestParamSpace, enforce_context_limit
 from .stress_tests_args import StressTestsArgs
@@ -716,15 +716,8 @@ class StressTests:
             str(self.test_args.project_root)
             + "/stress_tests/stress_tests_benchmarking_script.py"
         )
-        # An explicit port on deploy_url wins over service_port to avoid
-        # --host h --port <service_port> against a server actually on a
-        # different port (mirrors run_benchmarks._resolve_host_port).
-        parsed = urlparse(self.test_args.deploy_url.rstrip("/"))
-        sub_host = parsed.hostname or "127.0.0.1"
-        sub_port = (
-            str(parsed.port)
-            if parsed.port is not None
-            else str(self.env_config.service_port)
+        sub_host, sub_port = resolve_host_port(
+            self.test_args.deploy_url, self.env_config.service_port
         )
         cmd = [
             str(self.test_args.project_root)

--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -133,9 +133,7 @@ class PromptClient:
         """
         from utils.url_helpers import build_base_url
 
-        base = build_base_url(
-            self.env_config.deploy_url, self.env_config.service_port
-        )
+        base = build_base_url(self.env_config.deploy_url, self.env_config.service_port)
         return f"{base}/v1" if include_v1 else base
 
     def _get_api_completions_url(self) -> str:

--- a/utils/prompt_client.py
+++ b/utils/prompt_client.py
@@ -131,17 +131,10 @@ class PromptClient:
             include_v1: If True, append /v1 for OpenAI-compatible endpoints.
                        If False, return root URL for vLLM-specific endpoints.
         """
-        # An explicit port on deploy_url wins over service_port to avoid
-        # malformed double-port URLs like http://host:9000:8000 when
-        # --server-url already carries a port (e.g. via kubectl port-forward).
-        from urllib.parse import urlparse
+        from utils.url_helpers import build_base_url
 
-        deploy_url = self.env_config.deploy_url.rstrip("/")
-        parsed = urlparse(deploy_url)
-        base = (
-            deploy_url
-            if parsed.port is not None
-            else f"{deploy_url}:{self.env_config.service_port}"
+        base = build_base_url(
+            self.env_config.deploy_url, self.env_config.service_port
         )
         return f"{base}/v1" if include_v1 else base
 

--- a/utils/url_helpers.py
+++ b/utils/url_helpers.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Shared helpers for resolving the inference-server URL across workflows.
+
+Every workflow (benchmarks, evals, stress_tests, tests, spec_tests) needs the
+same answer to "where is the server?" with the same ``urlparse``-port-wins
+rule. Previously each runner re-derived this inline; this module is the
+single source of truth so a fix applied here propagates everywhere.
+
+Resolution precedence (used by :func:`resolve_deploy_url`):
+
+1. ``runtime_config.server_url`` — set from ``--server-url`` on ``run.py``
+2. ``DEPLOY_URL`` env var — for direct script invocations
+3. ``http://127.0.0.1`` — default
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Tuple
+from urllib.parse import urlparse
+
+DEFAULT_DEPLOY_URL = "http://127.0.0.1"
+
+
+def resolve_deploy_url(runtime_config=None) -> str:
+    """Resolve the deploy URL using the standard precedence.
+
+    Pass ``runtime_config`` when available; otherwise the function falls back
+    to ``DEPLOY_URL`` env var, then the localhost default.
+    """
+    if runtime_config is not None:
+        server_url = getattr(runtime_config, "server_url", None)
+        if server_url:
+            return server_url
+    return os.environ.get("DEPLOY_URL", DEFAULT_DEPLOY_URL)
+
+
+def build_base_url(deploy_url: str, service_port) -> str:
+    """Return ``scheme://host[:port]`` for building endpoint URLs.
+
+    An explicit port on ``deploy_url`` wins over ``service_port`` so callers
+    can't end up with malformed double-port URLs like ``http://host:9000:8000``
+    when the user passes ``--server-url http://host:9000``.
+    """
+    deploy_url = deploy_url.rstrip("/")
+    parsed = urlparse(deploy_url)
+    if parsed.port is not None:
+        return deploy_url
+    return f"{deploy_url}:{service_port}"
+
+
+def resolve_host_port(deploy_url: str, service_port) -> Tuple[str, str]:
+    """Split into ``(host, port)`` for ``--host``/``--port`` style CLI args.
+
+    Same port-wins rule as :func:`build_base_url`: an explicit port on
+    ``deploy_url`` overrides ``service_port``.
+    """
+    parsed = urlparse(deploy_url.rstrip("/"))
+    host = parsed.hostname or "localhost"
+    port = str(parsed.port) if parsed.port is not None else str(service_port)
+    return host, port


### PR DESCRIPTION
Consolidate the duplicated --server-url / deploy_url resolution logic from 12+ call sites into a single utils/url_helpers.py module.