### PR TITLE
Fix gateway split ZMQ metrics port collision

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1735,6 +1735,7 @@ jobs:
             ./prefill_gateway/build/prefill_gateway \
             --decode-port=9200 \
             --prefill-bind=127.0.0.1:9201 \
+            --metrics-port=9092 \
             > gw_zmq.log 2>&1 &
           echo $! > gw_zmq.pid
           bash cpp_server/scripts/ci/wait_for_command.sh \

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -118,7 +118,7 @@ void DisaggregationService::setupSocketHandlers() {
     // side's connection-lost handler can fail in-flight streams instead of
     // hanging on requests nobody can answer.  Assumes WorkerManager does not
     // auto-restart workers; if that changes, the callback will fire again on
-    // the replacement worker's first crash and stop a possibly-rearmed socket.
+    // the replacement worker's first crash and stop a possibly-rearmed socket
     if (auto* workerManager = llmService->getWorkerManager()) {
       workerManager->setWorkerDeathCallback(
           [socket = socketService](size_t workerIdx, pid_t pid) {


### PR DESCRIPTION
- Assign a dedicated metrics port to the ZMQ prefill gateway in `test-gate.yml`
- Prevent CI failures caused by the TCP and ZMQ gateway split tests competing for the default metrics port
