### PR TITLE
Onboard forge SDXL to nightly CI / models-status dashboard

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -642,36 +642,50 @@
       }
     },
     "stable-diffusion-xl-base-1.0": {
-      "inference_engine": "MEDIA",
-      "ci": {
-        "nightly": {
-          "devices": [
-            "GALAXY",
-            "GALAXY_BH",
-            "N150",
-            "N300",
-            "P150X8",
-            "P300X2"
-          ]
-        },
-        "weekly": {
-          "devices": [
-            "GALAXY",
-            "T3K"
-          ],
-          "device-args": {
-            "T3K": {
-              "additional-args": "--sdxl_num_prompts 5000",
-              "throttle-perf": "5"
+      "implementations": [
+        {
+          "inference_engine": "MEDIA",
+          "ci": {
+            "nightly": {
+              "devices": [
+                "GALAXY",
+                "GALAXY_BH",
+                "N150",
+                "N300",
+                "P150X8",
+                "P300X2"
+              ]
+            },
+            "weekly": {
+              "devices": [
+                "GALAXY",
+                "T3K"
+              ],
+              "device-args": {
+                "T3K": {
+                  "additional-args": "--sdxl_num_prompts 5000",
+                  "throttle-perf": "5"
+                }
+              }
+            },
+            "release": {
+              "devices": [
+                "GALAXY"
+              ]
             }
           }
         },
-        "release": {
-          "devices": [
-            "GALAXY"
-          ]
+        {
+          "inference_engine": "FORGE",
+          "ci": {
+            "nightly": {
+              "devices": [
+                "P150X8"
+              ]
+            }
+          }
         }
-      }
+      ]
     },
     "unet": {
       "inference_engine": "FORGE",

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -258,6 +258,14 @@ forge_vllm_plugin_impl = ImplSpec(
     repo_url="https://github.com/tenstorrent/tt-xla/tree/main",
     code_path="integrations/vllm_plugin",
 )
+# Distinct impl for forge SDXL so its model_id does not collide with the media
+# SDXL spec (which uses tt_transformers_impl) on shared Blackhole devices.
+sdxl_forge_impl = ImplSpec(
+    impl_id="sdxl_forge",
+    impl_name="sdxl-forge",
+    repo_url="https://github.com/tenstorrent/tt-inference-server",
+    code_path="tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py",
+)
 tt_vllm_plugin_impl = ImplSpec(
     impl_id="tt_vllm_plugin",
     impl_name="tt-vllm-plugin",
@@ -2995,6 +3003,40 @@ image_templates = [
             ),
         ],
         status=ModelStatusTypes.COMPLETE,
+    ),
+    # Forge full-on-device SDXL (PR #3485) — UNet (+ text encoders/VAE via
+    # TTXLA_SDXL_FULL_ON_DEVICE) on Blackhole. Distinct sdxl_forge_impl avoids a
+    # model_id collision with the media SDXL spec above on shared devices.
+    # NOTE: version/tt_metal_commit must point to the tt-media-inference-server-forge
+    # image that ships sdxl_forge_runner.py + #3485 (+ Forge LoRA) for this to pass;
+    # the values below mirror the current forge image family and should be confirmed
+    # at PR time.
+    ModelSpecTemplate(
+        weights=["stabilityai/stable-diffusion-xl-base-1.0"],
+        version="0.13.0",
+        tt_metal_commit="079a2c2",
+        impl=sdxl_forge_impl,
+        min_disk_gb=15,
+        min_ram_gb=6,
+        model_type=ModelType.IMAGE,
+        inference_engine=InferenceEngine.FORGE.value,
+        status=ModelStatusTypes.EXPERIMENTAL,
+        env_vars={"TTXLA_SDXL_FULL_ON_DEVICE": "true"},
+        hf_weights_repo="stabilityai/stable-diffusion-xl-base-1.0",
+        device_model_specs=[
+            DeviceModelSpec(
+                device=DeviceTypes.P150X8,
+                max_concurrency=1,
+                max_context=64 * 1024,
+                default_impl=False,
+            ),
+            DeviceModelSpec(
+                device=DeviceTypes.P300X2,
+                max_concurrency=1,
+                max_context=64 * 1024,
+                default_impl=False,
+            ),
+        ],
     ),
     ModelSpecTemplate(
         weights=["stabilityai/stable-diffusion-3.5-large"],


### PR DESCRIPTION
## Problem
`stable-diffusion-xl-base-1.0` runs in nightly CI only under the **MEDIA** engine, so it shows on the models-status dashboard under engine=media but is **absent from engine=forge + "With inference server"**. The forge matrix (`server-type=forge-media-inference-server`) skips it because its config entry is MEDIA-only.

## Change (mirrors the Falcon3-7B forge onboarding #3525)
Two files — the minimal set to get a forge SDXL row on the dashboard:

1. **`.github/workflows/models-ci-config.json`** — convert SDXL to the multi-engine `"implementations"` format (MEDIA block unchanged) + add a **FORGE** impl dispatched nightly on `P150X8`.
2. **`workflows/model_spec.py`** — add a distinct **`sdxl_forge_impl`** (so the forge `model_id` doesn't collide with the media `tt_transformers` impl on shared Blackhole devices) + a forge SDXL `ModelSpecTemplate` (`P150X8`/`P300X2`, `model_type=IMAGE`, `env TTXLA_SDXL_FULL_ON_DEVICE=true` for #3485's full-on-device path).

No `eval_config.py` change needed — `EVAL_CONFIGS` is keyed by `model_name`, so the existing SDXL eval config is reused. `release_model_spec.json` is intentionally untouched (generated release snapshot; runtime resolves from `MODEL_SPECS`).

## Verification
- `get_runtime_model_spec("stable-diffusion-xl-base-1.0", "P150X8", engine="forge")` → `id_sdxl-forge_…_p150x8`, docker auto-derived `tt-media-inference-server-forge:0.13.0-079a2c2`; media resolves independently on the same device. No duplicate model_ids across 249 specs.
- tt-shield `generate_ci_matrix.py --server-type forge-media-inference-server --schedule nightly` now emits SDXL under `P150X8_bh-lb`; media SDXL still on all 6 of its devices.

## Note before green
`version`/`tt_metal_commit` (`0.13.0`/`079a2c2`) mirror the current forge image family and must be confirmed against the `tt-media-inference-server-forge` image that ships `sdxl_forge_runner.py` + #3485. Until then SDXL appears as a row (may be red), like `unet`/`Falcon3` do today.