### PR TITLE
Save slot candidates and add slot lock

### DIFF
--- a/tt-media-server/.vscode/settings.json
+++ b/tt-media-server/.vscode/settings.json
@@ -32,7 +32,7 @@
     "python.languageServer": "None",
     "python-envs.pythonProjects": [],
     "python.envFile": "${workspaceFolder}/.env.test",
-    "cmake.sourceDirectory": "/localdev/idjuric/tt-inference-server/tt-media-server/cpp_server/build/_deps/prometheus-cpp-subbuild",
+    "cmake.sourceDirectory": "${workspaceFolder}/tt-media-server/cpp_server",
     "cmake.useCMakePresets": "always",
     "cmake.allowCommentsInPresetsFile": true,
     "cmake.configureOnOpen": true,

--- a/tt-media-server/.vscode/settings.json
+++ b/tt-media-server/.vscode/settings.json
@@ -32,7 +32,7 @@
     "python.languageServer": "None",
     "python-envs.pythonProjects": [],
     "python.envFile": "${workspaceFolder}/.env.test",
-    "cmake.sourceDirectory": "${workspaceFolder}/tt-media-server/cpp_server",
+    "cmake.sourceDirectory": "/localdev/idjuric/tt-inference-server/tt-media-server/cpp_server/build/_deps/prometheus-cpp-subbuild",
     "cmake.useCMakePresets": "always",
     "cmake.allowCommentsInPresetsFile": true,
     "cmake.configureOnOpen": true,

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -11,10 +11,12 @@
 #include <functional>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 #include "domain/session.hpp"
@@ -46,12 +48,22 @@ enum class CloseSessionResult {
 
 class SessionManager {
  public:
+  struct Candidate {
+    std::string sessionId;
+    size_t
+        matchedBlocks;  // total matched blocks (1 for key + matched remaining)
+    size_t sessionBlocks;  // total blocks in the cached session
+    uint32_t thinkTokens;  // accumulated think tokens at matched block
+  };
+
   // Result of tryAcquireByPrefixHash: the session's UUID and pre-assigned slot.
   struct AcquiredSession {
+    bool sessionFound;
     std::string sessionId;
     uint32_t slotId;
     uint32_t numberOfMatchedTokens = 0;
     uint32_t accumulatedThinkTokens = 0;  // Think tokens at matched block
+    std::vector<Candidate> candidatesList;
   };
 
   SessionManager();
@@ -79,6 +91,10 @@ class SessionManager {
 
   domain::Session* getSession(const std::string& sessionId);
   size_t getActiveSessionCount() const;
+
+  // Lock/unlock a slot to prevent eviction.
+  void lockSlot(uint32_t slotId);
+  void unlockSlot(uint32_t slotId);
 
   /**
    * Try to find a session whose registered prefix hash matches one of the
@@ -178,6 +194,10 @@ class SessionManager {
   std::atomic<bool> stopped{false};
   std::atomic<bool> evictionInProgress{false};
   std::thread drainThread;
+
+  // Slots locked from eviction (O(1) lookup).
+  mutable std::mutex lockedSlotsMutex;
+  std::unordered_set<uint32_t> lockedSlots;
 };
 
 }  // namespace tt::services

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -267,7 +267,7 @@ void DisaggregationService::resolvePrefillSession(
 
   auto acquired = sessionManager->tryAcquireByPrefixHash(blockInfos, nullptr);
 
-  if (acquired.has_value()) {
+  if (acquired.has_value() && acquired->sessionFound) {
     TT_LOG_INFO(
         "[DisaggregationService] Prefill prefix cache HIT taskId={} "
         "sessionId={} slotId={} matchedTokens={}",

--- a/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
@@ -154,7 +154,7 @@ void LLMPipeline::resolveSession(
           "[SessionTimer] taskId={} tryAcquireByPrefixHash_us={} hit={}",
           req->task_id, acquireUs, acquired.has_value());
 
-      if (acquired.has_value()) {
+      if (acquired.has_value() && acquired->sessionFound) {
         tt::metrics::ServerMetrics::instance().onPrefixCacheLookup(true);
         TT_LOG_INFO(
             "[LLMPipeline] Prefix cache HIT taskId={} sessionId={} "

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -199,6 +199,18 @@ domain::Session* SessionManager::getSession(const std::string& sessionId) {
 
 size_t SessionManager::getActiveSessionCount() const { return sessions.size(); }
 
+void SessionManager::lockSlot(uint32_t slotId) {
+  std::lock_guard<std::mutex> lock(lockedSlotsMutex);
+  lockedSlots.insert(slotId);
+  TT_LOG_DEBUG("[SessionManager] lockSlot: slotId={}", slotId);
+}
+
+void SessionManager::unlockSlot(uint32_t slotId) {
+  std::lock_guard<std::mutex> lock(lockedSlotsMutex);
+  lockedSlots.erase(slotId);
+  TT_LOG_DEBUG("[SessionManager] unlockSlot: slotId={}", slotId);
+}
+
 void SessionManager::evictOldSessions() {
   bool expected = false;
   if (!evictionInProgress.compare_exchange_strong(expected, true)) {
@@ -226,10 +238,19 @@ void SessionManager::evictOldSessions() {
   using Entry = std::pair<std::chrono::system_clock::time_point, std::string>;
   std::vector<Entry> candidates;
 
-  sessions.forEach(
-      [&candidates](const std::string& id, const domain::Session& s) {
-        if (s.isIdle()) candidates.emplace_back(s.getLastActivityTime(), id);
-      });
+  // Snapshot locked slots for the duration of candidate selection.
+  std::unordered_set<uint32_t> lockedSnapshot;
+  {
+    std::lock_guard<std::mutex> lock(lockedSlotsMutex);
+    lockedSnapshot = lockedSlots;
+  }
+
+  sessions.forEach([&candidates, &lockedSnapshot](const std::string& id,
+                                                  const domain::Session& s) {
+    if (s.isIdle() &&
+        lockedSnapshot.find(s.getSlotId()) == lockedSnapshot.end())
+      candidates.emplace_back(s.getLastActivityTime(), id);
+  });
 
   size_t n = std::min(evictionCount, candidates.size());
   std::nth_element(
@@ -241,10 +262,14 @@ void SessionManager::evictOldSessions() {
                candidates.size());
   size_t evicted = 0;
   for (const auto& [_, sessionId] : candidates) {
-    // A concurrent acquireInFlight call may mark the session in-flight
-    // between the forEach above and here; takeIf skips it atomically.
-    auto ms = sessions.takeIf(
-        sessionId, [](const domain::Session& s) { return s.isIdle(); });
+    // A concurrent acquireInFlight or lockSlot call may mark the session
+    // busy/locked between the forEach above and here; takeIf checks
+    // atomically under the map's entry lock.
+    auto ms = sessions.takeIf(sessionId, [&](const domain::Session& s) {
+      if (!s.isIdle()) return false;
+      std::lock_guard<std::mutex> lk(lockedSlotsMutex);
+      return lockedSlots.find(s.getSlotId()) == lockedSlots.end();
+    });
     if (!ms.has_value()) {
       TT_LOG_DEBUG(
           "[SessionManager] evictOldSessions: sessionId={} no longer idle, "
@@ -522,13 +547,6 @@ SessionManager::tryAcquireByPrefixHash(
   // Snapshot candidates: for each entry under keyHash, count how many
   // consecutive remaining hashes match the caller's remaining hashes.
   // Pick the entry with the longest match.
-  struct Candidate {
-    std::string sessionId;
-    size_t
-        matchedBlocks;  // total matched blocks (1 for key + matched remaining)
-    size_t sessionBlocks;  // total blocks in the cached session
-    uint32_t thinkTokens;  // accumulated think tokens at matched block
-  };
   std::vector<Candidate> candidates;
 
   prefixIndex.modify(keyHash, [&](std::vector<PrefixIndexEntry>& entries) {
@@ -611,8 +629,9 @@ SessionManager::tryAcquireByPrefixHash(
       s.updateActivityTime();
       s.markInFlight();
       s.setCancelFn(cancelFn);
-      acquired = AcquiredSession{candidate.sessionId, s.getSlotId(),
-                                 matchedTokens, candidate.thinkTokens};
+      acquired =
+          AcquiredSession{true,          candidate.sessionId,   s.getSlotId(),
+                          matchedTokens, candidate.thinkTokens, {}};
     });
 
     if (!found || stale) {
@@ -643,7 +662,9 @@ SessionManager::tryAcquireByPrefixHash(
       "[SessionManager] tryAcquireByPrefixHash: no acquirable session for "
       "keyHash={}",
       keyHash);
-  return std::nullopt;
+  // Return candidates sorted by matched tokens descending even though no
+  // session was acquired
+  return AcquiredSession{false, {}, 0, 0, 0, std::move(candidates)};
 }
 
 void SessionManager::registerPrefixHash(


### PR DESCRIPTION
Added:

- From tryAcquireSession return list of candidates that were not acquired
- Allow locking a slot from eviction (in case we copy from it later)
- Add slot lock/unlock methods