### PR TITLE
Adjust warmup settings in test-gate workflow

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -795,8 +795,8 @@ jobs:
       # Pre-warm the Drogon IO thread pool so each thread pays its per-thread
       # tokenizer init cost (#3179) before the measured bench starts. Without
       # this, mean_ttft_ms on the first bench is dominated by the cold-start
-      # P99 tail. Concurrency of 16 across 4 IO threads reliably touches every
-      # thread.
+      # P99 tail. Match the measured bench concurrency so warmup exercises the
+      # same client/server scheduling shape before thresholded measurements.
       - name: Warm up mock backend
         env:
           OPENAI_API_KEY: 'your-secret-key'
@@ -808,8 +808,8 @@ jobs:
             --dataset-name random \
             --random-input-len 128 \
             --random-output-len 128 \
-            --num-prompts 32 \
-            --max-concurrency 16 \
+            --num-prompts 128 \
+            --max-concurrency 64 \
             > /dev/null
 
       - name: Bench mock backend

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -79,7 +79,7 @@ void DisaggregationService::setupSocketHandlers() {
             auto request = LLMRequest(message.task_id);
             request.disaggregated = true;
             // -2 because last token doesnt count, and we need current pos in kv
-            // cache.
+            // cache
             request.kv_position_id =
                 static_cast<uint32_t>(message.token_ids.size() - 2);
             request.prompt.emplace<std::vector<int>>(


### PR DESCRIPTION
Updated warmup parameters for mock backend to improve concurrency and prompt count.