### PR TITLE
SDXL concurrent benchmark request fix

### DIFF
--- a/tt-inference-server-v2/report_module/display.py
+++ b/tt-inference-server-v2/report_module/display.py
@@ -29,6 +29,7 @@ DISPLAY_NAMES: Dict[str, str] = {
     "mean_ttft_ms": "TTFT (ms)",
     "std_ttft_ms": "TTFT Std (ms)",
     "ttft": "TTFT",
+    "ttft_ms": "TTFT (ms)",
     "p5_ttft": "P5 TTFT (ms)",
     "p25_ttft": "P25 TTFT (ms)",
     "p50_ttft": "P50 TTFT (ms)",
@@ -126,6 +127,7 @@ DISPLAY_NAMES: Dict[str, str] = {
 # decimal_places_map;
 DECIMAL_PLACES: Dict[str, int] = {
     "mean_ttft_ms": 1,
+    "ttft_ms": 1,
     "std_ttft_ms": 1,
     "p5_ttft": 1,
     "p25_ttft": 1,

--- a/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
@@ -9,6 +9,7 @@ import json
 import logging
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Callable
 
@@ -34,7 +35,7 @@ from ..test_status import ImageGenerationTestStatus
 logger = logging.getLogger(__name__)
 
 
-SDXL_LOAD_TEST_NUM_BATCHES = 3
+SDXL_BENCHMARK_NUM_BATCHES = 3
 
 SDXL_SD35_BENCHMARK_NUM_PROMPTS = 20
 SDXL_SD35_INFERENCE_STEPS = 20
@@ -195,10 +196,12 @@ def _build_image_status_list(
     inference_steps: int,
     generator: Callable[..., tuple[bool, float]],
     generator_steps_kwarg: bool = False,
+    concurrency: int = 1,
 ) -> list[ImageGenerationTestStatus]:
-    status_list: list[ImageGenerationTestStatus] = []
-    for i in range(num_calls):
-        logger.info(f"Generating image {i + 1}/{num_calls}...")
+    concurrency = max(1, concurrency)
+
+    def _one(call_index: int) -> ImageGenerationTestStatus:
+        logger.info(f"Generating image {call_index + 1}/{num_calls}...")
         if generator_steps_kwarg:
             status, elapsed = generator(ctx, inference_steps)
         else:
@@ -207,46 +210,59 @@ def _build_image_status_list(
         logger.info(
             f"Generated image with {inference_steps} steps in {elapsed:.2f} seconds."
         )
-        status_list.append(
-            ImageGenerationTestStatus(
-                status=status,
-                elapsed=elapsed,
-                num_inference_steps=inference_steps,
-                inference_steps_per_second=inference_steps_per_second,
-            )
+        return ImageGenerationTestStatus(
+            status=status,
+            elapsed=elapsed,
+            num_inference_steps=inference_steps,
+            inference_steps_per_second=inference_steps_per_second,
         )
+
+    status_list: list[ImageGenerationTestStatus] = []
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        for batch_start in range(0, num_calls, concurrency):
+            batch = range(batch_start, min(batch_start + concurrency, num_calls))
+            futures = [pool.submit(_one, i) for i in batch]
+            status_list.extend(f.result() for f in futures)
     return status_list
 
 
 def _run_sdxl_image_generation_benchmark(
-    ctx: MediaContext, num_calls: int
+    ctx: MediaContext, num_calls: int, concurrency: int = 1
 ) -> list[ImageGenerationTestStatus]:
     logger.info("Running image generation benchmark.")
     return _build_image_status_list(
-        ctx, num_calls, SDXL_SD35_INFERENCE_STEPS, _generate_image
+        ctx, num_calls, SDXL_SD35_INFERENCE_STEPS, _generate_image, concurrency=concurrency
     )
 
 
 def _run_img2img_generation_benchmark(
-    ctx: MediaContext, num_calls: int
+    ctx: MediaContext, num_calls: int, concurrency: int = 1
 ) -> list[ImageGenerationTestStatus]:
     logger.info("Running image-to-image generation benchmark.")
     return _build_image_status_list(
-        ctx, num_calls, SDXL_IMG2IMG_INFERENCE_STEPS, _generate_image_img2img
+        ctx,
+        num_calls,
+        SDXL_IMG2IMG_INFERENCE_STEPS,
+        _generate_image_img2img,
+        concurrency=concurrency,
     )
 
 
 def _run_inpainting_generation_benchmark(
-    ctx: MediaContext, num_calls: int
+    ctx: MediaContext, num_calls: int, concurrency: int = 1
 ) -> list[ImageGenerationTestStatus]:
     logger.info("Running inpainting generation benchmark.")
     return _build_image_status_list(
-        ctx, num_calls, SDXL_INPAINTING_INFERENCE_STEPS, _generate_image_inpainting
+        ctx,
+        num_calls,
+        SDXL_INPAINTING_INFERENCE_STEPS,
+        _generate_image_inpainting,
+        concurrency=concurrency,
     )
 
 
 def _run_flux_1_dev_benchmark(
-    ctx: MediaContext, num_calls: int
+    ctx: MediaContext, num_calls: int, concurrency: int = 1
 ) -> list[ImageGenerationTestStatus]:
     logger.info("Running Flux 1 Dev or Schnell benchmark.")
     return _build_image_status_list(
@@ -255,11 +271,12 @@ def _run_flux_1_dev_benchmark(
         FLUX_MOTIF_INFERENCE_STEPS,
         _generate_image,
         generator_steps_kwarg=True,
+        concurrency=concurrency,
     )
 
 
 def _run_flux_1_schnell_benchmark(
-    ctx: MediaContext, num_calls: int
+    ctx: MediaContext, num_calls: int, concurrency: int = 1
 ) -> list[ImageGenerationTestStatus]:
     logger.info("Running Flux 1 Schnell benchmark.")
     return _build_image_status_list(
@@ -268,11 +285,12 @@ def _run_flux_1_schnell_benchmark(
         FLUX_1_SCHNELL_INFERENCE_STEPS,
         _generate_image,
         generator_steps_kwarg=True,
+        concurrency=concurrency,
     )
 
 
 def _run_motif_image_6b_preview_benchmark(
-    ctx: MediaContext, num_calls: int
+    ctx: MediaContext, num_calls: int, concurrency: int = 1
 ) -> list[ImageGenerationTestStatus]:
     logger.info("Running Motif Image 6B Preview benchmark.")
     return _build_image_status_list(
@@ -281,11 +299,12 @@ def _run_motif_image_6b_preview_benchmark(
         FLUX_MOTIF_INFERENCE_STEPS,
         _generate_image,
         generator_steps_kwarg=True,
+        concurrency=concurrency,
     )
 
 
 IMAGE_BENCHMARK_DISPATCH: dict[
-    str, Callable[[MediaContext, int], list[ImageGenerationTestStatus]]
+    str, Callable[[MediaContext, int, int], list[ImageGenerationTestStatus]]
 ] = {
     "tt-sdxl-trace": _run_sdxl_image_generation_benchmark,
     "tt-sdxl-image-to-image": _run_img2img_generation_benchmark,
@@ -297,7 +316,7 @@ IMAGE_BENCHMARK_DISPATCH: dict[
 }
 
 
-_SDXL_LOAD_TEST_RUNNERS = {
+_SDXL_BENCHMARK_RUNNERS = {
     "tt-sdxl-trace",
     "tt-sdxl-image-to-image",
     "tt-sdxl-edit",
@@ -343,13 +362,13 @@ def run_image_benchmark(ctx: MediaContext) -> Block:
     try:
         num_calls = get_num_calls(ctx)
         max_concurrency = None
-        if runner_in_use in _SDXL_LOAD_TEST_RUNNERS:
+        if runner_in_use in _SDXL_BENCHMARK_RUNNERS:
             max_concurrency = ctx.model_spec.device_model_spec.max_concurrency
             if max_concurrency and max_concurrency > 0:
-                num_calls = SDXL_LOAD_TEST_NUM_BATCHES * max_concurrency
+                num_calls = SDXL_BENCHMARK_NUM_BATCHES * max_concurrency
                 logger.info(
                     f"Overriding num_calls for {runner_in_use} to {num_calls} prompts "
-                    f"({SDXL_LOAD_TEST_NUM_BATCHES} batches x {max_concurrency} concurrent requests)"
+                    f"({SDXL_BENCHMARK_NUM_BATCHES} batches x {max_concurrency} concurrent requests)"
                 )
             else:
                 max_concurrency = None
@@ -357,7 +376,7 @@ def run_image_benchmark(ctx: MediaContext) -> Block:
         benchmark_fn = IMAGE_BENCHMARK_DISPATCH.get(
             runner_in_use, _run_sdxl_image_generation_benchmark
         )
-        status_list = benchmark_fn(ctx, num_calls)
+        status_list = benchmark_fn(ctx, num_calls, max_concurrency or 1)
     except Exception as e:
         logger.error(f"Benchmark execution encountered an error: {e}")
         raise

--- a/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
@@ -9,7 +9,6 @@ import json
 import logging
 import sys
 import time
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Callable
 
@@ -219,47 +218,6 @@ def _build_image_status_list(
     return status_list
 
 
-def _build_image_status_list_concurrent(
-    ctx: MediaContext,
-    max_concurrency: int,
-    num_batches: int,
-    inference_steps: int,
-    generator: Callable[..., tuple[bool, float]],
-    generator_steps_kwarg: bool = False,
-) -> tuple[list[ImageGenerationTestStatus], float]:
-    status_list: list[ImageGenerationTestStatus] = []
-    total_start = time.time()
-    for batch in range(num_batches):
-        logger.info(
-            f"Running batch {batch + 1}/{num_batches} with {max_concurrency} concurrent requests..."
-        )
-        with ThreadPoolExecutor(max_workers=max_concurrency) as executor:
-            if generator_steps_kwarg:
-                futures = [
-                    executor.submit(generator, ctx, inference_steps)
-                    for _ in range(max_concurrency)
-                ]
-            else:
-                futures = [
-                    executor.submit(generator, ctx) for _ in range(max_concurrency)
-                ]
-            for future in futures:
-                status, elapsed = future.result()
-                inference_steps_per_second = (
-                    inference_steps / elapsed if elapsed > 0 else 0
-                )
-                status_list.append(
-                    ImageGenerationTestStatus(
-                        status=status,
-                        elapsed=elapsed,
-                        num_inference_steps=inference_steps,
-                        inference_steps_per_second=inference_steps_per_second,
-                    )
-                )
-    total_time = time.time() - total_start
-    return status_list, total_time
-
-
 def _run_sdxl_image_generation_benchmark(
     ctx: MediaContext, num_calls: int
 ) -> list[ImageGenerationTestStatus]:
@@ -339,10 +297,10 @@ IMAGE_BENCHMARK_DISPATCH: dict[
 }
 
 
-_CONCURRENT_IMAGE_RUNNERS: dict[str, tuple[Callable[..., tuple[bool, float]], int]] = {
-    "tt-sdxl-trace": (_generate_image, SDXL_SD35_INFERENCE_STEPS),
-    "tt-sdxl-image-to-image": (_generate_image_img2img, SDXL_IMG2IMG_INFERENCE_STEPS),
-    "tt-sdxl-edit": (_generate_image_inpainting, SDXL_INPAINTING_INFERENCE_STEPS),
+_SDXL_LOAD_TEST_RUNNERS = {
+    "tt-sdxl-trace",
+    "tt-sdxl-image-to-image",
+    "tt-sdxl-edit",
 }
 
 
@@ -361,7 +319,7 @@ def _image_target_checks(
         ctx,
         [
             MetricSpec(
-                "TTFT", ttft_ms, "ttft_ms", lower_is_better=True, field_name="ttft"
+                "TTFT", ttft_ms, "ttft_ms", lower_is_better=True, field_name="ttft_ms"
             ),
             MetricSpec(
                 "tput_user",
@@ -385,31 +343,21 @@ def run_image_benchmark(ctx: MediaContext) -> Block:
     try:
         num_calls = get_num_calls(ctx)
         max_concurrency = None
-        total_time = None
-        concurrent_cfg = _CONCURRENT_IMAGE_RUNNERS.get(runner_in_use)
-        if concurrent_cfg is not None:
+        if runner_in_use in _SDXL_LOAD_TEST_RUNNERS:
             max_concurrency = ctx.model_spec.device_model_spec.max_concurrency
+            if max_concurrency and max_concurrency > 0:
+                num_calls = SDXL_LOAD_TEST_NUM_BATCHES * max_concurrency
+                logger.info(
+                    f"Overriding num_calls for {runner_in_use} to {num_calls} prompts "
+                    f"({SDXL_LOAD_TEST_NUM_BATCHES} batches x {max_concurrency} concurrent requests)"
+                )
+            else:
+                max_concurrency = None
 
-        if concurrent_cfg is not None and max_concurrency and max_concurrency > 0:
-            generator, inference_steps = concurrent_cfg
-            num_calls = SDXL_LOAD_TEST_NUM_BATCHES * max_concurrency
-            logger.info(
-                f"Running {runner_in_use} load test: {SDXL_LOAD_TEST_NUM_BATCHES} batches "
-                f"x {max_concurrency} concurrent requests = {num_calls} prompts"
-            )
-            status_list, total_time = _build_image_status_list_concurrent(
-                ctx,
-                max_concurrency,
-                SDXL_LOAD_TEST_NUM_BATCHES,
-                inference_steps,
-                generator,
-            )
-        else:
-            max_concurrency = None
-            benchmark_fn = IMAGE_BENCHMARK_DISPATCH.get(
-                runner_in_use, _run_sdxl_image_generation_benchmark
-            )
-            status_list = benchmark_fn(ctx, num_calls)
+        benchmark_fn = IMAGE_BENCHMARK_DISPATCH.get(
+            runner_in_use, _run_sdxl_image_generation_benchmark
+        )
+        status_list = benchmark_fn(ctx, num_calls)
     except Exception as e:
         logger.error(f"Benchmark execution encountered an error: {e}")
         raise
@@ -421,18 +369,15 @@ def run_image_benchmark(ctx: MediaContext) -> Block:
         if status_list
         else 0
     )
-    if max_concurrency and total_time and total_time > 0:
-        tput_user = len(status_list) / (total_time * max_concurrency)
-    else:
-        tput_user = inference_steps_per_second
-    target_checks, accuracy_check = _image_target_checks(
-        ctx, ttft_value, tput_user
-    )
+    total_elapsed = sum(s.elapsed for s in status_list)
+    # tput_user is per-user image throughput (images/sec = 1 / avg latency).
+    tput_user = len(status_list) / total_elapsed if total_elapsed > 0 else 0
+    target_checks, accuracy_check = _image_target_checks(ctx, ttft_value, tput_user)
     num_inference_steps_used = status_list[0].num_inference_steps if status_list else 0
     benchmarks_data = {
         "num_requests": len(status_list),
         "num_inference_steps": num_inference_steps_used,
-        "ttft": ttft_value,
+        "ttft_ms": ttft_value * 1000,
         "inference_steps_per_second": inference_steps_per_second,
         "tput_user": tput_user,
         "accuracy_check": accuracy_check,

--- a/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
@@ -9,6 +9,7 @@ import json
 import logging
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Callable
 
@@ -33,6 +34,8 @@ from ..test_status import ImageGenerationTestStatus
 
 logger = logging.getLogger(__name__)
 
+
+SDXL_LOAD_TEST_NUM_BATCHES = 3
 
 SDXL_SD35_BENCHMARK_NUM_PROMPTS = 20
 SDXL_SD35_INFERENCE_STEPS = 20
@@ -216,6 +219,47 @@ def _build_image_status_list(
     return status_list
 
 
+def _build_image_status_list_concurrent(
+    ctx: MediaContext,
+    max_concurrency: int,
+    num_batches: int,
+    inference_steps: int,
+    generator: Callable[..., tuple[bool, float]],
+    generator_steps_kwarg: bool = False,
+) -> tuple[list[ImageGenerationTestStatus], float]:
+    status_list: list[ImageGenerationTestStatus] = []
+    total_start = time.time()
+    for batch in range(num_batches):
+        logger.info(
+            f"Running batch {batch + 1}/{num_batches} with {max_concurrency} concurrent requests..."
+        )
+        with ThreadPoolExecutor(max_workers=max_concurrency) as executor:
+            if generator_steps_kwarg:
+                futures = [
+                    executor.submit(generator, ctx, inference_steps)
+                    for _ in range(max_concurrency)
+                ]
+            else:
+                futures = [
+                    executor.submit(generator, ctx) for _ in range(max_concurrency)
+                ]
+            for future in futures:
+                status, elapsed = future.result()
+                inference_steps_per_second = (
+                    inference_steps / elapsed if elapsed > 0 else 0
+                )
+                status_list.append(
+                    ImageGenerationTestStatus(
+                        status=status,
+                        elapsed=elapsed,
+                        num_inference_steps=inference_steps,
+                        inference_steps_per_second=inference_steps_per_second,
+                    )
+                )
+    total_time = time.time() - total_start
+    return status_list, total_time
+
+
 def _run_sdxl_image_generation_benchmark(
     ctx: MediaContext, num_calls: int
 ) -> list[ImageGenerationTestStatus]:
@@ -295,6 +339,13 @@ IMAGE_BENCHMARK_DISPATCH: dict[
 }
 
 
+_CONCURRENT_IMAGE_RUNNERS: dict[str, tuple[Callable[..., tuple[bool, float]], int]] = {
+    "tt-sdxl-trace": (_generate_image, SDXL_SD35_INFERENCE_STEPS),
+    "tt-sdxl-image-to-image": (_generate_image_img2img, SDXL_IMG2IMG_INFERENCE_STEPS),
+    "tt-sdxl-edit": (_generate_image_inpainting, SDXL_INPAINTING_INFERENCE_STEPS),
+}
+
+
 def _image_ttft(status_list: list[ImageGenerationTestStatus]) -> float:
     logger.info("Calculating TTFT value")
     return sum(s.elapsed for s in status_list) / len(status_list) if status_list else 0
@@ -333,18 +384,32 @@ def run_image_benchmark(ctx: MediaContext) -> Block:
 
     try:
         num_calls = get_num_calls(ctx)
-        if runner_in_use == "tt-sdxl-trace":
-            num_chips = ctx.model_spec.device_model_spec.max_concurrency
-            if num_chips and num_chips > 0:
-                num_calls = num_chips
-            logger.info(
-                f"Overriding num_calls for SDXL trace model to {num_calls} prompts (one per chip)"
-            )
+        max_concurrency = None
+        total_time = None
+        concurrent_cfg = _CONCURRENT_IMAGE_RUNNERS.get(runner_in_use)
+        if concurrent_cfg is not None:
+            max_concurrency = ctx.model_spec.device_model_spec.max_concurrency
 
-        benchmark_fn = IMAGE_BENCHMARK_DISPATCH.get(
-            runner_in_use, _run_sdxl_image_generation_benchmark
-        )
-        status_list = benchmark_fn(ctx, num_calls)
+        if concurrent_cfg is not None and max_concurrency and max_concurrency > 0:
+            generator, inference_steps = concurrent_cfg
+            num_calls = SDXL_LOAD_TEST_NUM_BATCHES * max_concurrency
+            logger.info(
+                f"Running {runner_in_use} load test: {SDXL_LOAD_TEST_NUM_BATCHES} batches "
+                f"x {max_concurrency} concurrent requests = {num_calls} prompts"
+            )
+            status_list, total_time = _build_image_status_list_concurrent(
+                ctx,
+                max_concurrency,
+                SDXL_LOAD_TEST_NUM_BATCHES,
+                inference_steps,
+                generator,
+            )
+        else:
+            max_concurrency = None
+            benchmark_fn = IMAGE_BENCHMARK_DISPATCH.get(
+                runner_in_use, _run_sdxl_image_generation_benchmark
+            )
+            status_list = benchmark_fn(ctx, num_calls)
     except Exception as e:
         logger.error(f"Benchmark execution encountered an error: {e}")
         raise
@@ -356,11 +421,25 @@ def run_image_benchmark(ctx: MediaContext) -> Block:
         if status_list
         else 0
     )
-    # Sequential single-user benchmark, so tput_user = total throughput.
+    if max_concurrency and total_time and total_time > 0:
+        tput_user = len(status_list) / (total_time * max_concurrency)
+    else:
+        tput_user = inference_steps_per_second
     target_checks, accuracy_check = _image_target_checks(
-        ctx, ttft_value, inference_steps_per_second
+        ctx, ttft_value, tput_user
     )
     num_inference_steps_used = status_list[0].num_inference_steps if status_list else 0
+    benchmarks_data = {
+        "num_requests": len(status_list),
+        "num_inference_steps": num_inference_steps_used,
+        "ttft": ttft_value,
+        "inference_steps_per_second": inference_steps_per_second,
+        "tput_user": tput_user,
+        "accuracy_check": accuracy_check,
+        "target_checks": target_checks,
+    }
+    if max_concurrency:
+        benchmarks_data["num_concurrent_requests"] = max_concurrency
     return Block(
         kind="benchmarks",
         task_type="image",
@@ -371,15 +450,7 @@ def run_image_benchmark(ctx: MediaContext) -> Block:
             "num_inference_steps": num_inference_steps_used,
         },
         data={
-            "Benchmarks": {
-                "num_requests": len(status_list),
-                "num_inference_steps": num_inference_steps_used,
-                "ttft": ttft_value,
-                "inference_steps_per_second": inference_steps_per_second,
-                "tput_user": inference_steps_per_second,
-                "accuracy_check": accuracy_check,
-                "target_checks": target_checks,
-            },
+            "Benchmarks": benchmarks_data,
         },
     )
 

--- a/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
@@ -399,15 +399,19 @@ def run_image_benchmark(ctx: MediaContext) -> Block:
     num_inference_steps_used = status_list[0].num_inference_steps if status_list else 0
     benchmarks_data = {
         "num_requests": len(status_list),
-        "num_inference_steps": num_inference_steps_used,
-        "ttft_ms": ttft_value * 1000,
-        "inference_steps_per_second": inference_steps_per_second,
-        "tput_user": tput_user,
-        "accuracy_check": accuracy_check,
-        "target_checks": target_checks,
     }
     if max_concurrency:
         benchmarks_data["num_concurrent_requests"] = max_concurrency
+    benchmarks_data.update(
+        {
+            "num_inference_steps": num_inference_steps_used,
+            "ttft_ms": ttft_value * 1000,
+            "inference_steps_per_second": inference_steps_per_second,
+            "tput_user": tput_user,
+            "accuracy_check": accuracy_check,
+            "target_checks": target_checks,
+        }
+    )
     return Block(
         kind="benchmarks",
         task_type="image",

--- a/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
@@ -231,7 +231,11 @@ def _run_sdxl_image_generation_benchmark(
 ) -> list[ImageGenerationTestStatus]:
     logger.info("Running image generation benchmark.")
     return _build_image_status_list(
-        ctx, num_calls, SDXL_SD35_INFERENCE_STEPS, _generate_image, concurrency=concurrency
+        ctx,
+        num_calls,
+        SDXL_SD35_INFERENCE_STEPS,
+        _generate_image,
+        concurrency=concurrency,
     )
 
 


### PR DESCRIPTION
 0. Fires `max_concurrency` requests concurrently per batch
 1. Benchmark `num_calls` =` num_batches` × `max_concurrency` for the three SDXL runners
  2. Added report fields _num_requests_ + _num_concurrent_requests_
  3. tput_user = images/sec (num_calls / Σ elapsed)
  4. TTFT displayed in ms (ttft_ms) so both image tables share unit

Future feature: [Make `num_batches` configurable per-model](https://github.com/tenstorrent/tt-inference-server/issues/2848?issue=tenstorrent%7Ctt-inference-server%7C3922)