### PR TITLE
fix: pin tt-llm-engine to submodule SHA instead of main

### DIFF
--- a/tt-media-server/Dockerfile.blaze
+++ b/tt-media-server/Dockerfile.blaze
@@ -24,10 +24,16 @@ ARG DEBIAN_FRONTEND=noninteractive
 # submodule's .git tree at build time.
 ARG TT_METAL_COMMIT_SHA_OR_TAG=unknown
 ARG TT_INFERENCE_SERVER_COMMIT_SHA_OR_TAG=unknown
+# tt-llm-engine submodule commit, pinned to the superproject gitlink. Required;
+# pass at build time, e.g.:
+#   docker build --build-arg TT_LLM_ENGINE_COMMIT="$(git rev-parse \
+#     :tt-media-server/cpp_server/tt-llm-engine)" ...
+ARG TT_LLM_ENGINE_COMMIT
 
 # make build commit SHA available in the image for reference and debugging
 ENV TT_METAL_COMMIT_SHA_OR_TAG=${TT_METAL_COMMIT_SHA_OR_TAG}
 ENV TT_INFERENCE_SERVER_COMMIT_SHA_OR_TAG=${TT_INFERENCE_SERVER_COMMIT_SHA_OR_TAG}
+ENV TT_LLM_ENGINE_COMMIT=${TT_LLM_ENGINE_COMMIT}
 
 ENV ENVIRONMENT=development
 ENV TT_MM_THROTTLE_PERF=5
@@ -133,13 +139,19 @@ RUN export CARGO_HOME=${HOME_DIR}/.cargo \
     && . ${HOME_DIR}/.cargo/env \
     && rustup default stable
 
-# add tt-llm-engine (clone using GitHub token from secret)
+# add tt-llm-engine — shallow-clone, then fetch + check out the pinned
+# TT_LLM_ENGINE_COMMIT (same pattern as tt-metal in tt-media-server/Dockerfile),
+# keeping the image in lockstep with the superproject's submodule gitlink. The
+# nested tt-metal submodule is pinned transitively to whatever that commit references.
 RUN --mount=type=secret,id=github_token \
-    rm -rf ${APP_DIR}/server/cpp_server/tt-llm-engine \
+    : "${TT_LLM_ENGINE_COMMIT:?must be set to the pinned tt-llm-engine submodule SHA, e.g. --build-arg TT_LLM_ENGINE_COMMIT=\$(git rev-parse :tt-media-server/cpp_server/tt-llm-engine)}" \
+    && rm -rf ${APP_DIR}/server/cpp_server/tt-llm-engine \
     && GITHUB_TOKEN=$(cat /run/secrets/github_token) \
     && git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:" \
-    && git clone --depth 1 --branch main https://x-access-token:${GITHUB_TOKEN}@github.com/tenstorrent/tt-llm-engine.git ${APP_DIR}/server/cpp_server/tt-llm-engine \
+    && git clone --depth 1 https://x-access-token:${GITHUB_TOKEN}@github.com/tenstorrent/tt-llm-engine.git ${APP_DIR}/server/cpp_server/tt-llm-engine \
     && cd ${APP_DIR}/server/cpp_server/tt-llm-engine \
+    && git fetch --depth 1 origin ${TT_LLM_ENGINE_COMMIT} \
+    && git checkout ${TT_LLM_ENGINE_COMMIT} \
     && git submodule update --init --recursive --depth 1 || echo "Some submodules failed, continuing..." \
     && (cd tt-metal && ./build_metal.sh --disable-profiler && ./create_venv.sh) \
     && ./setup.sh --ds-full \


### PR DESCRIPTION
Dockerfile.blaze cloned tt-llm-engine's main tip at build time, so the tt-llm-engine and its nested tt-metal drifted between builds. Updated to shallow-clone and check out a pinned TT_LLM_ENGINE_COMMIT instead.

Builds must now pass --build-arg TT_LLM_ENGINE_COMMIT.

Before (tt-llm-engine came from live main, nothing to pass):
  DOCKER_BUILDKIT=1 docker build \
    -f tt-media-server/Dockerfile.blaze \
    --secret id=github_token,src=./gh_token.txt \
    -t <your-tag> .

  After (tt-llm-engine pinned to the submodule SHA):
  DOCKER_BUILDKIT=1 docker build \
    -f tt-media-server/Dockerfile.blaze \
    --secret id=github_token,src=./gh_token.txt \
    --build-arg TT_LLM_ENGINE_COMMIT="$(git rev-parse :tt-media-server/cpp_server/tt-llm-engine)" \
    -t <your-tag> .