### PR TITLE
Fix Test Gate - Reuse Tokenizer Files

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -2266,10 +2266,35 @@ jobs:
         with:
           token: ${{ secrets.TT_LLM_ENGINE }}
 
+      # Reuse tokenizer files across runs: fetch_tokenizers.sh (invoked by
+      # build.sh) skips any model whose files already exist, so restoring this
+      # directory turns the fetch into a no-op and avoids hitting HuggingFace.
+      # Keyed on the fetch script so a change to the model list / download logic
+      # invalidates the cache.
+      - name: Restore cached tokenizer files
+        uses: actions/cache@v4
+        with:
+          path: tt-media-server/cpp_server/tokenizers
+          key: cpp-server-tokenizers-${{ hashFiles('tt-media-server/cpp_server/scripts/fetch_tokenizers.sh') }}
+          restore-keys: |
+            cpp-server-tokenizers-
+
       - name: Build C++ server with ThreadSanitizer
         run: |
           cd cpp_server
           ./build.sh --tsan
+
+      - name: Archive C++ tokenizer bundle
+        run: |
+          cd cpp_server
+          tar -czf cpp-server-tokenizers.tar.gz tokenizers
+
+      - name: Upload C++ tokenizer bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpp-server-tokenizers
+          path: tt-media-server/cpp_server/cpp-server-tokenizers.tar.gz
+          retention-days: 1
 
       - name: Set up uv (for guidellm)
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -2266,11 +2266,6 @@ jobs:
         with:
           token: ${{ secrets.TT_LLM_ENGINE }}
 
-      # Reuse tokenizer files across runs: fetch_tokenizers.sh (invoked by
-      # build.sh) skips any model whose files already exist, so restoring this
-      # directory turns the fetch into a no-op and avoids hitting HuggingFace.
-      # Keyed on the fetch script so a change to the model list / download logic
-      # invalidates the cache.
       - name: Restore cached tokenizer files
         uses: actions/cache@v4
         with:

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -548,6 +548,7 @@ SessionManager::tryAcquireByPrefixHash(
         {blockInfos[i].hash, blockInfos[i].accumulatedThinkTokens});
   }
 
+  
   // Snapshot candidates: for each entry under keyHash, count how many
   // consecutive remaining hashes match the caller's remaining hashes.
   // Pick the entry with the longest match.

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -548,7 +548,6 @@ SessionManager::tryAcquireByPrefixHash(
         {blockInfos[i].hash, blockInfos[i].accumulatedThinkTokens});
   }
 
-  
   // Snapshot candidates: for each entry under keyHash, count how many
   // consecutive remaining hashes match the caller's remaining hashes.
   // Pick the entry with the longest match.


### PR DESCRIPTION
## Problem 
Due to recent instability of the self-hosted runners, the following error has been observed on multiple occasions:
```
Downloading deepseek-ai/DeepSeek-R1-0528 tokenizer... 
ERROR: Failed to download deepseek-ai/DeepSeek-R1-0528/tokenizer_config.json. 
URL: https://huggingface.co/deepseek-ai/DeepSeek-R1-0528/raw/main/tokenizer_config.json
```

The changes introduced in this PR reduce the likelihood of this issue occurring again

## Testing
```
Received 3298272 of 3298272 (100.0%), 11.8 MBs/sec
Cache Size: ~3 MB (3298272 B)
/usr/bin/tar -xf /home/runner/work/_temp/ff39c012-7f26-4639-aa26-77ed3da41920/cache.tzst -P -C /home/runner/work/tt-inference-server/tt-inference-server --use-compress-program unzstd
Cache restored successfully
Cache restored from key: cpp-server-tokenizers-b2d27b6679c29442172fabe7332fc654980faf966dc1714a038aad81ed6b420c
```