### PR TITLE
persist tt-triage logs to cache_root volume in --ci-mode

### DIFF
--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -495,7 +495,12 @@ def set_metal_timeout_env_vars():
     triage_old = Path(tt_metal_home) / "scripts" / "debugging_scripts" / "triage.py"
     triage_script = str(triage_new if triage_new.exists() else triage_old)
 
+    # mkdir -p so the redirect below succeeds even when log_dir does not exist
+    # yet. In CI, TT_METAL_LOGS_PATH points at {cache_root}/logs on a mounted
+    # volume that has no pre-existing logs/ subdir (see run_docker_server.py and
+    # issue #2670); without this the redirect fails and the triage report is lost.
     timeout_cmd = (
+        f"mkdir -p {log_dir} && "
         f"{python_env_dir}/bin/python {triage_script} "
         f"--disable-progress > {log_dir}/tt-triage-$(date +%Y%m%d-%H%M%S).log 2>&1"
     )

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -495,10 +495,8 @@ def set_metal_timeout_env_vars():
     triage_old = Path(tt_metal_home) / "scripts" / "debugging_scripts" / "triage.py"
     triage_script = str(triage_new if triage_new.exists() else triage_old)
 
-    # mkdir -p so the redirect below succeeds even when log_dir does not exist
-    # yet. In CI, TT_METAL_LOGS_PATH points at {cache_root}/logs on a mounted
-    # volume that has no pre-existing logs/ subdir (see run_docker_server.py and
-    # issue #2670); without this the redirect fails and the triage report is lost.
+    # mkdir -p so the redirect succeeds when log_dir doesn't exist yet (in CI it
+    # points at the cache_root volume, which has no pre-created logs/ dir). See #2670.
     timeout_cmd = (
         f"mkdir -p {log_dir} && "
         f"{python_env_dir}/bin/python {triage_script} "

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -320,13 +320,8 @@ def generate_docker_run_command(
             docker_env_vars["TT_CACHE_PATH"] = (
                 setup_config.container_tt_metal_cache_dir / device_cache_dir
             )
-        # In CI, redirect automatic tt-triage hang logs to the persistent
-        # cache_root volume. The default /home/container_app_user/logs (see
-        # run_vllm_api_server.py set_metal_timeout_env_vars) lives on ephemeral
-        # docker overlay storage and is lost on container teardown, so triage
-        # reports generated in Models CI are not recoverable. cache_root is a
-        # mounted volume, so logs written there survive.
-        # See https://github.com/tenstorrent/tt-inference-server/issues/2670.
+        # In CI, persist tt-triage hang logs on the cache_root volume; the default
+        # /home/container_app_user/logs is ephemeral and lost on teardown. See #2670.
         if runtime_config.ci_mode:
             docker_env_vars["TT_METAL_LOGS_PATH"] = f"{setup_config.cache_root}/logs"
 

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -320,6 +320,15 @@ def generate_docker_run_command(
             docker_env_vars["TT_CACHE_PATH"] = (
                 setup_config.container_tt_metal_cache_dir / device_cache_dir
             )
+        # In CI, redirect automatic tt-triage hang logs to the persistent
+        # cache_root volume. The default /home/container_app_user/logs (see
+        # run_vllm_api_server.py set_metal_timeout_env_vars) lives on ephemeral
+        # docker overlay storage and is lost on container teardown, so triage
+        # reports generated in Models CI are not recoverable. cache_root is a
+        # mounted volume, so logs written there survive.
+        # See https://github.com/tenstorrent/tt-inference-server/issues/2670.
+        if runtime_config.ci_mode:
+            docker_env_vars["TT_METAL_LOGS_PATH"] = f"{setup_config.cache_root}/logs"
 
     if (
         model_spec.inference_engine == InferenceEngine.FORGE.value

--- a/workflows/runtime_config.py
+++ b/workflows/runtime_config.py
@@ -80,6 +80,10 @@ class RuntimeConfig:
     # Validation
     skip_system_sw_validation: bool = False
 
+    # CI mode (set from --ci-mode): triggers CI-friendly behavior such as
+    # persisting tt-triage logs to the mounted cache_root volume.
+    ci_mode: bool = False
+
     # Misc
     tt_metal_python_venv_dir: Optional[str] = None
     tt_metal_home: Optional[str] = None
@@ -139,6 +143,7 @@ class RuntimeConfig:
             host_weights_dir=args.host_weights_dir,
             image_user=args.image_user,
             skip_system_sw_validation=args.skip_system_sw_validation,
+            ci_mode=args.ci_mode,
             tt_metal_python_venv_dir=args.tt_metal_python_venv_dir,
             tt_metal_home=args.tt_metal_home,
             vllm_dir=args.vllm_dir,


### PR DESCRIPTION
Closes https://github.com/tenstorrent/tt-inference-server/issues/2670

automatic tt-triage (enabled in #2297) writes its hang report to `TT_METAL_LOGS_PATH`, which defaults to `/home/container_app_user/logs`. for the docker server that path is ephemeral docker overlay storage, so triage reports generated in Models CI are lost on container teardown. this redirects them to the persistent `cache_root` volume when `--ci-mode` is set.

**Context:**
- `run_local_server.py` already sets `TT_METAL_LOGS_PATH` to `cache_root/logs`; only the docker-server path was missing it.
- the triage command (`set_metal_timeout_env_vars` in `run_vllm_api_server.py`) redirects with `> {log_dir}/...log`, which also fails if `{log_dir}` doesn't exist yet — and `cache_root/logs` is not pre-created by the image or entrypoint.

**Changes:**
- `runtime_config.py`: thread `ci_mode` through `RuntimeConfig` (from `--ci-mode`).
- `run_docker_server.py`: when `ci_mode`, set `TT_METAL_LOGS_PATH={cache_root}/logs` on the docker server (mounted volume, survives teardown).
- `run_vllm_api_server.py`: prepend `mkdir -p {log_dir}` to the triage command so the redirect succeeds when the dir doesn't exist yet.

Tests:
- unit-level: `generate_docker_run_command` emits `-e TT_METAL_LOGS_PATH={cache_root}/logs` only when `ci_mode=True`, and nothing when `False`.
