### PR TITLE
Mask test_penalties for Llama-3.3-70B on P300X2 (#3888)

### DIFF
--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -738,6 +738,10 @@ templates:
       tensor_cache_timeout: 5400.0
       override_tt_config:
         trace_region_size: 402653184  # 384 * 1024 * 1024
+      known_issues:
+        - workflow_type: TESTS
+          task_name: test_penalties
+          reason: "test_penalties length-change assertion (server_tests/test_cases/test_vllm_chat_completions.py:289) is over-strict for short, low-repetition prompts decoded near-greedily; presence_penalty=1.2 legitimately produced identical output. Model meets FUNCTIONAL expectations. Tracked in #3888."
   status: FUNCTIONAL
   has_builtin_warmup: true
   metadata:

--- a/workflows/model_specs/prod/llm.yaml
+++ b/workflows/model_specs/prod/llm.yaml
@@ -738,10 +738,6 @@ templates:
       tensor_cache_timeout: 5400.0
       override_tt_config:
         trace_region_size: 402653184  # 384 * 1024 * 1024
-      known_issues:
-        - workflow_type: TESTS
-          task_name: test_penalties
-          reason: "test_penalties length-change assertion (server_tests/test_cases/test_vllm_chat_completions.py:289) is over-strict for short, low-repetition prompts decoded near-greedily; presence_penalty=1.2 legitimately produced identical output. Model meets FUNCTIONAL expectations. Tracked in #3888."
   status: FUNCTIONAL
   has_builtin_warmup: true
   metadata:

--- a/workflows/model_specs/prod/llm.yaml
+++ b/workflows/model_specs/prod/llm.yaml
@@ -738,6 +738,10 @@ templates:
       tensor_cache_timeout: 5400.0
       override_tt_config:
         trace_region_size: 402653184  # 384 * 1024 * 1024
+      known_issues:
+        - workflow_type: TESTS
+          task_name: test_penalties
+          reason: "test_penalties length-change assertion (server_tests/test_cases/test_vllm_chat_completions.py:289) is over-strict for short, low-repetition prompts decoded near-greedily; presence_penalty=1.2 legitimately produced identical output. Model meets FUNCTIONAL expectations. Tracked in #3888."
   status: FUNCTIONAL
   has_builtin_warmup: true
   metadata:


### PR DESCRIPTION
Waives the over-strict `test_penalties` subtest for Llama-3.3-70B on P300X2 via a `known_issues` entry in `dev/llm.yaml`, so acceptance passes. The model meets FUNCTIONAL expectations; per Ben's guidance the test is masked rather than blocking.

Refs: #3888