### PR TITLE
Onboard forge SDXL to nightly CI / models-status dashboard

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -618,35 +618,49 @@
       }
     },
     "stable-diffusion-xl-base-1.0": {
-      "inference_engine": "MEDIA",
-      "ci": {
-        "nightly": {
-          "devices": [
-            "GALAXY",
-            "GALAXY_BH",
-            "N150",
-            "N300",
-            "P300X2"
-          ]
-        },
-        "weekly": {
-          "devices": [
-            "GALAXY",
-            "T3K"
-          ],
-          "device-args": {
-            "T3K": {
-              "additional-args": "--sdxl_num_prompts 5000",
-              "throttle-perf": "5"
+      "implementations": [
+        {
+          "inference_engine": "MEDIA",
+          "ci": {
+            "nightly": {
+              "devices": [
+                "GALAXY",
+                "GALAXY_BH",
+                "N150",
+                "N300",
+                "P300X2"
+              ]
+            },
+            "weekly": {
+              "devices": [
+                "GALAXY",
+                "T3K"
+              ],
+              "device-args": {
+                "T3K": {
+                  "additional-args": "--sdxl_num_prompts 5000",
+                  "throttle-perf": "5"
+                }
+              }
+            },
+            "release": {
+              "devices": [
+                "GALAXY"
+              ]
             }
           }
         },
-        "release": {
-          "devices": [
-            "GALAXY"
-          ]
+        {
+          "inference_engine": "FORGE",
+          "ci": {
+            "nightly": {
+              "devices": [
+                "P150X8"
+              ]
+            }
+          }
         }
-      }
+      ]
     },
     "unet": {
       "inference_engine": "FORGE",

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -5063,6 +5063,55 @@ models:
               - name: MESH_DEVICE
                 value: P150
     defaultEngine: media
+    forge:
+      p150x8:
+        defaultImpl: sdxl_forge
+        impls:
+          sdxl_forge:
+            progressDeadlineSeconds: 5400
+            image:
+              repository: ghcr.io/tenstorrent/tt-media-inference-server-forge
+              tag: 0.13.0-079a2c2
+            probes:
+              liveness:
+                initialDelaySeconds: 2400
+                path: /tt-liveness
+              readiness:
+                initialDelaySeconds: 2400
+            resources:
+              requests:
+                memory: 6Gi
+            env:
+              - name: ARCH_NAME
+                value: blackhole
+              - name: MESH_DEVICE
+                value: P150x8
+              - name: TTXLA_SDXL_FULL_ON_DEVICE
+                value: 'true'
+      p300x2:
+        defaultImpl: sdxl_forge
+        impls:
+          sdxl_forge:
+            progressDeadlineSeconds: 5400
+            image:
+              repository: ghcr.io/tenstorrent/tt-media-inference-server-forge
+              tag: 0.13.0-079a2c2
+            probes:
+              liveness:
+                initialDelaySeconds: 2400
+                path: /tt-liveness
+              readiness:
+                initialDelaySeconds: 2400
+            resources:
+              requests:
+                memory: 6Gi
+            env:
+              - name: ARCH_NAME
+                value: blackhole
+              - name: MESH_DEVICE
+                value: P300x2
+              - name: TTXLA_SDXL_FULL_ON_DEVICE
+                value: 'true'
   stable-diffusion-xl-base-1.0-img-2-img:
     media:
       n150:

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -265,6 +265,14 @@ tt_vllm_plugin_impl = ImplSpec(
     repo_url="https://github.com/tenstorrent/tt-inference-server/tree/dev/tt-vllm-plugin",
     code_path="tt_vllm_plugin",
 )
+# Distinct impl for forge SDXL so its model_id does not collide with the media
+# SDXL spec (which uses tt_transformers_impl) on shared Blackhole devices.
+sdxl_forge_impl = ImplSpec(
+    impl_id="sdxl_forge",
+    impl_name="sdxl-forge",
+    repo_url="https://github.com/tenstorrent/tt-inference-server",
+    code_path="tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py",
+)
 
 _IMPL_REGISTRY: Dict[str, ImplSpec] = {
     "tt_transformers": tt_transformers_impl,
@@ -276,6 +284,7 @@ _IMPL_REGISTRY: Dict[str, ImplSpec] = {
     "speecht5_tts": speecht5_impl,
     "forge_vllm_plugin": forge_vllm_plugin_impl,
     "tt_vllm_plugin": tt_vllm_plugin_impl,
+    "sdxl_forge": sdxl_forge_impl,
 }
 
 

--- a/workflows/model_specs/dev/image.yaml
+++ b/workflows/model_specs/dev/image.yaml
@@ -53,6 +53,36 @@ templates:
       default_impl: true
   status: COMPLETE
 
+# Forge full-on-device SDXL (PR #3485) — UNet (+ text encoders/VAE via
+# TTXLA_SDXL_FULL_ON_DEVICE) on Blackhole. Distinct sdxl_forge impl avoids a
+# model_id collision with the media SDXL spec above on shared devices.
+# NOTE: version/tt_metal_commit must point to the tt-media-inference-server-forge
+# image that ships sdxl_forge_runner.py + #3485 (+ Forge LoRA) for this to pass;
+# the values below mirror the current forge image family and should be confirmed
+# at PR time.
+- weights:
+    - stabilityai/stable-diffusion-xl-base-1.0
+  version: "0.13.0"
+  tt_metal_commit: 079a2c2
+  impl: sdxl_forge
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: FORGE
+  status: EXPERIMENTAL
+  env_vars:
+    TTXLA_SDXL_FULL_ON_DEVICE: "true"
+  hf_weights_repo: stabilityai/stable-diffusion-xl-base-1.0
+  device_model_specs:
+    - device: P150X8
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: false
+    - device: P300X2
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: false
+
 - weights:
     - stabilityai/stable-diffusion-3.5-large
   version: "0.9.0"

--- a/workflows/model_specs/prod/image.yaml
+++ b/workflows/model_specs/prod/image.yaml
@@ -53,6 +53,36 @@ templates:
       default_impl: true
   status: COMPLETE
 
+# Forge full-on-device SDXL (PR #3485) — UNet (+ text encoders/VAE via
+# TTXLA_SDXL_FULL_ON_DEVICE) on Blackhole. Distinct sdxl_forge impl avoids a
+# model_id collision with the media SDXL spec above on shared devices.
+# NOTE: version/tt_metal_commit must point to the tt-media-inference-server-forge
+# image that ships sdxl_forge_runner.py + #3485 (+ Forge LoRA) for this to pass;
+# the values below mirror the current forge image family and should be confirmed
+# at PR time.
+- weights:
+    - stabilityai/stable-diffusion-xl-base-1.0
+  version: "0.13.0"
+  tt_metal_commit: 079a2c2
+  impl: sdxl_forge
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: FORGE
+  status: EXPERIMENTAL
+  env_vars:
+    TTXLA_SDXL_FULL_ON_DEVICE: "true"
+  hf_weights_repo: stabilityai/stable-diffusion-xl-base-1.0
+  device_model_specs:
+    - device: P150X8
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: false
+    - device: P300X2
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: false
+
 - weights:
     - stabilityai/stable-diffusion-3.5-large
   version: "0.9.0"


### PR DESCRIPTION
## Problem
`stable-diffusion-xl-base-1.0` runs in nightly CI only under the **MEDIA** engine, so it shows on the models-status dashboard under engine=media but is **absent from engine=forge + "With inference server"**. The forge matrix (`server-type=forge-media-inference-server`) skips it because its config entry is MEDIA-only.

This re-targets #3874 directly at `main`. That PR was authored against the old inline-Python `MODEL_SPECS` and merged into `feat/sdxl-forge-lora` (gated behind the still-open LoRA PR #3488), so it never reached `main`. `main` has since moved to the YAML catalog layout (#3782, *"Dev and prod spec"*), so the spec change is reapplied there instead of in `model_spec.py`'s now-removed `image_templates` list.

## Change (mirrors the Falcon3-7B forge onboarding #3525)
1. **`.github/workflows/models-ci-config.json`** — convert SDXL to the multi-engine `"implementations"` format (MEDIA block unchanged) + add a **FORGE** impl dispatched nightly on `P150X8`.
2. **`workflows/model_spec.py`** — add a distinct **`sdxl_forge`** `ImplSpec` and register it in `_IMPL_REGISTRY`, so the forge `model_id` doesn't collide with the media `tt_transformers` impl on shared Blackhole devices.
3. **`workflows/model_specs/{prod,dev}/image.yaml`** — add a forge SDXL template (`P150X8`/`P300X2`, `model_type=IMAGE`, `inference_engine=FORGE`, `status=EXPERIMENTAL`, `env TTXLA_SDXL_FULL_ON_DEVICE=true` for #3485's full-on-device path).

No `eval_config.py` change needed — `EVAL_CONFIGS` is keyed by `model_name`, so the existing SDXL eval config is reused.

## Verification
- Catalog loads: **251 specs, no duplicate `model_id`s**.
- `get_runtime_model_spec("stable-diffusion-xl-base-1.0", "P150X8", engine="forge")` → `id_sdxl-forge_…_p150x8`, docker auto-derived `ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2`, env carries `TTXLA_SDXL_FULL_ON_DEVICE=true`; media resolves independently on the same device with a distinct `id_tt-transformers_…` id.
- `tests/test_model_specification.py` + `tests/test_matrix_expansion.py`: **118 passed**.

## Note before green
`version`/`tt_metal_commit` (`0.13.0`/`079a2c2`) mirror the current forge image family and must be confirmed against the `tt-media-inference-server-forge` image that ships `sdxl_forge_runner.py` + #3485. Until then SDXL appears as a row (may be red), like `unet`/`Falcon3` do today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)