### PR TITLE
Pass LORA_HIGH_PATH/LORA_LOW_PATH env vars to LoRA pipeline

### DIFF
--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -816,11 +816,16 @@ class TTWan22I2VLoRARunner(TTDiTRunner):
                 WanPipelineI2VLora,
             )
 
+            lora_high = os.environ.get("LORA_HIGH_PATH")
+            lora_low = os.environ.get("LORA_LOW_PATH")
+
             return WanPipelineI2VLora.create_pipeline(
                 mesh_device=self.ttnn_device,
                 height=self.resolution.height,
                 width=self.resolution.width,
                 num_frames=WAN22_NUM_FRAMES,
+                lora_high=lora_high,
+                lora_low=lora_low,
             )
         except Exception as e:
             log_exception_chain(


### PR DESCRIPTION
The WanPipelineI2VLora.__init__ requires lora_high and/or lora_low arguments pointing to adapter safetensor files, but create_pipeline() was never reading the documented env vars or passing them through.