### PR TITLE
forge: stop hand-pinning torch/torchvision/torchaudio; let the CPU index drive them

### DIFF
--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,13 +1,6 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
 --extra-index-url https://download.pytorch.org/whl/cpu
 tt-forge==1.2.0
-# tt-forge 1.2.0 needs torch 2.10.0; pin the matching torch/vision/audio here
-# (forge image only) so the shared requirements.txt — and the media/blaze
-# images that install only it — stay on torch 2.7.1. forge_runners is installed
-# after requirements.txt, so these override the shared pins for the forge image.
-torch==2.10.0+cpu
-torchaudio==2.10.0+cpu
-torchvision==0.25.0+cpu
 
 tabulate
 timm # input preprocessing


### PR DESCRIPTION
## Ticket

Closes https://github.com/tenstorrent/tt-inference-server/issues/3946

## What

Remove the explicit `torch==2.10.0+cpu` / `torchaudio==2.10.0+cpu` / `torchvision==0.25.0+cpu` pins from `tt-media-server/tt_model_runners/forge_runners/requirements.txt`added in uplift yesterday, which turned out to be not needed. Keep both `--extra-index-url` lines. The `tt-forge` closure (`pjrt-plugin-tt` pins torch via direct URL; `vllm` pins torchvision/torchaudio) already selects these exact versions, and the PyTorch CPU index ensures the `+cpu` builds are chosen.

Result: the next tt-forge uplift is a one-line `tt-forge==X.Y.Z` bump instead of a four-line edit that silently breaks if the torch/vision/audio versions drift.

## Why

The three pins added in #3801 are redundant with what the wheel already resolves to. The change that actually fixed the `operator torchvision::nms does not exist` warmup crash was adding the CPU index (`--extra-index-url https://download.pytorch.org/whl/cpu`) — without it, torchvision/torchaudio resolve to generic (CUDA-ABI) PyPI builds that mismatch the `+cpu` torch. With the CPU index present, the `+cpu` builds win automatically, so the pins add maintenance burden without protection. See the issue for full root-cause analysis.

## Verification

CI: tt-shield run [#26913493728](https://github.com/tenstorrent/tt-shield/actions/runs/26913493728) (built from this branch).

- **Dependency resolution** — build job [build-inference-server](https://github.com/tenstorrent/tt-shield/actions/runs/26913493728/job/79397506829), step *"Build image for forge-media-inference-server"*. With the pins removed, `tt-forge==1.2.0` resolves to `torch-2.10.0+cpu`, `torchvision-0.25.0+cpu`, `torchaudio-2.10.0+cpu` — all fetched from `download.pytorch.org/whl/cpu` (torch via `pjrt-plugin-tt`'s direct URL, vision/audio via `vllm`), with no manual pins.
- **End-to-end (the model class that hit the bug)** — the original #3801 `torchvision::nms` crash was on forge **LLMs**, not CNNs, so the meaningful proof is a forge LLM warming up and serving on the image from this branch: forge job [run-release-Falcon3-7B-Instruct-p150](https://github.com/tenstorrent/tt-shield/actions/runs/26913493728/job/79402920869). 
- **Supporting** — forge CNN job [run-release-efficientnet-n150](https://github.com/tenstorrent/tt-shield/actions/runs/26913493728/job/79402920877) passed end-to-end (warms up and serves, no `torchvision::nms` error). Useful as a second data point, though CNNs weren't the models that originally failed.

Local (pre-CI):

- `pip install --dry-run --report` of `tt-forge==1.2.0` (both index URLs, no torch pins) resolves to the same `+cpu` stack listed above.
- The matching `+cpu` set imports `torchvision.ops.nms` cleanly; the generic set (what you get without the CPU index) reproduces `RuntimeError: operator torchvision::nms does not exist`.

## Risk / scope

- Forge image only. Shared `requirements.txt` (torch 2.7.1 for media/blaze) is untouched.
- Forge-image build + CNN warmup are confirmed in CI (above). Note: any segformer/unet reds in the run trimmed Nightly CI above are unrelated to this change (a flaky eval-teardown SIGABRT and a pre-existing unet `top_k` runner bug that also fails on `main` nightly, respectively).
