### PR TITLE
Add Llama-3.1-8B and Llama-3.1-8B-Instruct to nightly CI for P150 and P300X2

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -20,6 +20,23 @@
         }
       }
     },
+    "Llama-3.1-8B": {
+      "inference_engine": "vLLM",
+      "ci": {
+        "nightly": {
+          "devices": [
+            "P150",
+            "P300X2"
+          ]
+        },
+        "release": {
+          "devices": [
+            "P150",
+            "P300X2"
+          ]
+        }
+      }
+    },
     "Llama-3.1-8B-Instruct": {
       "implementations": [
         {
@@ -31,6 +48,7 @@
                 "N150",
                 "N300",
                 "P100",
+                "P150",
                 "P150X4",
                 "P300X2",
                 "T3K"
@@ -44,6 +62,7 @@
             "release": {
               "devices": [
                 "GALAXY",
+                "P150",
                 "P300X2"
               ]
             }


### PR DESCRIPTION
Adds Llama-3.1-8B (base) and updates Llama-3.1-8B-Instruct in `models-ci-config.json`:

- New `Llama-3.1-8B` entry: nightly + release on P150 and P300X2
- `Llama-3.1-8B-Instruct` vLLM: adds P150 to nightly and release device lists

Model spec prerequisites are already present in the dev/prod catalog YAML.