### PR TITLE
forge LLMs P150: lift max_context 4K → 16K + Qwen3 max_gen_toks clamp 

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1106,9 +1106,16 @@ _eval_config_list = [
                     "max_length": 65536,
                 },
                 # gen_kwargs chosen according to https://huggingface.co/Qwen/Qwen3-8B#best-practices
+                # max_gen_toks lowered from 32768 to 12288 so `prompt + max_gen_toks`
+                # fits the forge_vllm_plugin P150 max_model_len=16384 envelope.
+                # Observed r1_gpqa_diamond prompts run up to ~2.4k tokens, so a
+                # 12288 output cap leaves ~3700-token headroom. The original 32K
+                # output budget is intended for ≥64K-context devices; clamping
+                # here is safe at 16K but caps reasoning depth on long-context
+                # devices too — revisit if a >16K-context Qwen3-8B impl lands.
                 gen_kwargs={
                     "stream": "true",
-                    "max_gen_toks": 32768,
+                    "max_gen_toks": 12288,
                     "until": [],
                     "do_sample": "true",
                     "temperature": 0.6,
@@ -1142,9 +1149,14 @@ _eval_config_list = [
                     "timeout": "3600",
                 },
                 # gen_kwargs chosen according to https://huggingface.co/Qwen/Qwen3-8B#best-practices
+                # max_gen_toks lowered 32768 -> 14336 for forge P150 (max_model_len=16384).
+                # Observed mmlu_pro prompts are ~1.1k tokens, so 14336 output cap
+                # leaves ~950-token headroom. Even with the runtime clamp at
+                # 16384-PROMPT_RESERVE=15360, prompts >1024 would 4xx-reject;
+                # explicit cap is the safe value.
                 gen_kwargs={
                     "stream": "true",
-                    "max_gen_toks": 32768,
+                    "max_gen_toks": 14336,
                     "until": [],
                     "do_sample": "true",
                     "temperature": 0.6,
@@ -1180,9 +1192,12 @@ _eval_config_list = [
                 model_kwargs={
                     "max_length": 65536,
                 },
+                # max_gen_toks lowered 32768 -> 12288 so `prompt + max_gen_toks`
+                # fits forge_vllm_plugin P150 max_model_len=16384. See the same
+                # note on the Qwen3-8B r1_gpqa_diamond entry above.
                 gen_kwargs={
                     "stream": "true",
-                    "max_gen_toks": 32768,
+                    "max_gen_toks": 12288,
                     "until": [],
                     "do_sample": "true",
                     "temperature": 0.6,
@@ -1215,9 +1230,12 @@ _eval_config_list = [
                     "max_length": 65536,
                     "timeout": "3600",
                 },
+                # max_gen_toks lowered 32768 -> 14336 so `prompt + max_gen_toks`
+                # fits forge P150 max_model_len=16384. See the same note on the
+                # Qwen3-8B mmlu_pro entry above.
                 gen_kwargs={
                     "stream": "true",
-                    "max_gen_toks": 32768,
+                    "max_gen_toks": 14336,
                     "until": [],
                     "do_sample": "true",
                     "temperature": 0.6,

--- a/tt-media-server/run_uvicorn.sh
+++ b/tt-media-server/run_uvicorn.sh
@@ -9,4 +9,24 @@ if [ "$1" != "--skip-venv" ]; then
     source "${TT_METAL_HOME}/python_env/bin/activate"
 fi
 
+# Short-term workaround: forge wheel's vllm_tt/worker.py hardcodes the device
+# memory cap at 12 GB (vllm_tt/worker.py:236) — well below P150's 32 GB HBM —
+# which artificially limits the KV-cache pool and blocks 16K seq len on 7B/8B
+# models. When TT_KV_POOL_GB is set, swap the hardcode for an env-driven value
+# at startup. No-op if the env var is unset or the expected pattern isn't
+# found (e.g. after the upstream tt-xla fix lands and replaces the hardcode
+# with the real device DRAM value, at which point this block self-deactivates
+# and can be removed in a one-line revert).
+if [ -n "${TT_KV_POOL_GB:-}" ]; then
+    WORKER_PY=$(python3 -c "from importlib.util import find_spec; s=find_spec('vllm_tt'); print((s.submodule_search_locations[0] if s else '') + '/worker.py')" 2>/dev/null || true)
+    if [ -f "$WORKER_PY" ] && grep -q "total_memory_size = 12 \* 1024\*\*3" "$WORKER_PY"; then
+        sed -i 's|total_memory_size = 12 \* 1024\*\*3|total_memory_size = int(os.environ.get("TT_KV_POOL_GB", "12")) * 1024**3|' "$WORKER_PY"
+        echo "[run_uvicorn] patched vllm_tt/worker.py: KV pool size now driven by TT_KV_POOL_GB=$TT_KV_POOL_GB"
+    elif [ -f "$WORKER_PY" ]; then
+        echo "[run_uvicorn] vllm_tt/worker.py at $WORKER_PY does not contain expected hardcode pattern; TT_KV_POOL_GB ignored"
+    else
+        echo "[run_uvicorn] could not locate vllm_tt/worker.py; TT_KV_POOL_GB ignored"
+    fi
+fi
+
 uvicorn --host 0.0.0.0 main:app --lifespan on --port "${SERVICE_PORT:-8000}"

--- a/workflows/model_specs/dev/cnn.yaml
+++ b/workflows/model_specs/dev/cnn.yaml
@@ -17,14 +17,15 @@ templates:
   uses_tensor_model_cache: false
   device_model_specs:
     - device: P150
-      max_concurrency: 16
-      max_context: 4096
+      max_concurrency: 4
+      max_context: 16384
       default_impl: true
       eval_max_retries: 1
       env_vars:
-        MAX_MODEL_LENGTH: "4096"
-        MAX_NUM_SEQS: "16"
-        GPU_MEMORY_UTILIZATION: "0.7"
+        MAX_MODEL_LENGTH: "16384"
+        MAX_NUM_SEQS: "4"
+        GPU_MEMORY_UTILIZATION: "0.35"
+        TT_KV_POOL_GB: "32"
 
 - weights:
     - meta-llama/Llama-3.2-3B
@@ -39,14 +40,15 @@ templates:
   uses_tensor_model_cache: false
   device_model_specs:
     - device: P150
-      max_concurrency: 16
-      max_context: 8192
+      max_concurrency: 4
+      max_context: 16384
       default_impl: false
       eval_max_retries: 1
       env_vars:
-        MAX_MODEL_LENGTH: "8192"
-        MAX_NUM_SEQS: "16"
-        GPU_MEMORY_UTILIZATION: "0.7"
+        MAX_MODEL_LENGTH: "16384"
+        MAX_NUM_SEQS: "4"
+        GPU_MEMORY_UTILIZATION: "0.35"
+        TT_KV_POOL_GB: "32"
 
 - weights:
     - meta-llama/Llama-3.1-8B-Instruct
@@ -60,14 +62,15 @@ templates:
   uses_tensor_model_cache: false
   device_model_specs:
     - device: P150
-      max_concurrency: 16
-      max_context: 4096
+      max_concurrency: 4
+      max_context: 16384
       default_impl: false
       eval_max_retries: 1
       env_vars:
-        MAX_MODEL_LENGTH: "4096"
-        MAX_NUM_SEQS: "16"
-        GPU_MEMORY_UTILIZATION: "0.6"
+        MAX_MODEL_LENGTH: "16384"
+        MAX_NUM_SEQS: "4"
+        GPU_MEMORY_UTILIZATION: "0.30"
+        TT_KV_POOL_GB: "32"
 
 - weights:
     - Qwen/Qwen3-8B
@@ -81,14 +84,15 @@ templates:
   uses_tensor_model_cache: false
   device_model_specs:
     - device: P150
-      max_concurrency: 16
-      max_context: 4096
+      max_concurrency: 4
+      max_context: 16384
       default_impl: false
       eval_max_retries: 1
       env_vars:
-        MAX_MODEL_LENGTH: "4096"
-        MAX_NUM_SEQS: "16"
-        GPU_MEMORY_UTILIZATION: "0.6"
+        MAX_MODEL_LENGTH: "16384"
+        MAX_NUM_SEQS: "4"
+        GPU_MEMORY_UTILIZATION: "0.30"
+        TT_KV_POOL_GB: "32"
 
 - weights:
     - tiiuae/Falcon3-7B-Instruct
@@ -102,14 +106,15 @@ templates:
   uses_tensor_model_cache: false
   device_model_specs:
     - device: P150
-      max_concurrency: 16
-      max_context: 4096
+      max_concurrency: 4
+      max_context: 16384
       default_impl: true
       eval_max_retries: 1
       env_vars:
-        MAX_MODEL_LENGTH: "4096"
-        MAX_NUM_SEQS: "16"
-        GPU_MEMORY_UTILIZATION: "0.6"
+        MAX_MODEL_LENGTH: "16384"
+        MAX_NUM_SEQS: "4"
+        GPU_MEMORY_UTILIZATION: "0.225"
+        TT_KV_POOL_GB: "32"
 
 - weights:
     - resnet-50


### PR DESCRIPTION
Fixes #3948
Fixes #3949

## Summary

Two coupled fixes that together unblock forge LLM evals from CI's prompt-overflow failure mode. They only make sense together — landing either alone leaves the workload broken — so bundled into one PR.

- **#3948 — `max_context` 4K → 16K via `TT_KV_POOL_GB` workaround.** All 5 forge LLM P150 specs were at `max_context=4096` (Llama-3.2-3B at 8192), forcing **41 `exceeds max model length` 4xx rejections** across the 5 models in the latest forge nightly ([tt-shield run 26800608401](https://github.com/tenstorrent/tt-shield/actions/runs/26800608401)). The forge wheel hardcodes a 12 GB DRAM cap in `vllm_tt/worker.py:236`, blocking KV-pool > ~12 GB.
- **#3949 — Qwen3-4B/8B `max_gen_toks` clamp.** Qwen3 EvalConfigs bake `max_gen_toks=32768` (Qwen upstream best-practice for ≥64K-context devices) on `r1_gpqa_diamond` and `mmlu_pro`. At 16K `max_model_len`, every request 4xx-rejects on `prompt + max_tokens > max_model_len` because 32768 alone exceeds 16384.

> **`TT_KV_POOL_GB` is a temporary workaround.** It self-deactivates once a newer tt-forge wheel ships with the `worker.py:236` hardcode replaced by the actual device DRAM value (tracked in #3954). At that point the env var has no effect and the `run_uvicorn.sh` block can be removed in a one-line revert.

## Changes

- `tt-media-server/run_uvicorn.sh`: sed-patch the `worker.py:236` 12 GB hardcode at container startup when `TT_KV_POOL_GB` env var is set. Gated on env-set + pattern-present.
- `workflows/model_specs/{prod,dev}/cnn.yaml`: on all 5 forge LLM P150 specs — `max_context=16384`, `max_concurrency=4`, `MAX_NUM_SEQS="4"`, `TT_KV_POOL_GB="32"` (P150's actual HBM), and per-model `GPU_MEMORY_UTILIZATION`:
  - Llama-3.2-3B-Instruct / Qwen3-4B → `0.35` (~11.2 GB pool)
  - Llama-3.1-8B-Instruct / Qwen3-8B → `0.30` (~9.6 GB pool)
  - Falcon3-7B-Instruct → `0.225` (~7.2 GB pool; lower — observed trace-capture fragmentation OOM at higher gmu)
- `charts/tt-inference-server/values.yaml`: helm-regen output reflecting the above.
- `evals/eval_config.py`: per-task `gen_kwargs.max_gen_toks` overrides on Qwen3-4B + Qwen3-8B EvalConfigs:
  - `r1_gpqa_diamond`: 32768 → **12288** (fits prompts up to ~4K; observed 1.1k–2.4k)
  - `mmlu_pro`: 32768 → **14336** (fits prompts up to ~2K; observed ~1.1k)
  - Both stay below the runtime clamp ceiling (`16384 − PROMPT_RESERVE=1024 = 15360`) so `_clamp_max_gen_toks` is a no-op and the explicit value flows through unchanged. Trade-off documented inline: reasoning depth below Qwen's published 32K — revisit when a >16K-context forge Qwen impl lands.

## Test plan

- [x] Local validation on QB2 P150 (4 servers in parallel at batch=4 / 16K): Falcon3-7B, Llama-3.1-8B, Qwen3-4B, Qwen3-8B stood up cleanly with new gmu values — no trace-capture OOM, no KV-cache-too-small errors.
- [x] Llama-3.1-8B `meta_ifeval` smoke: **33% (FAIL, 0.41× GPU ref) at 4K → 100% (PASS, 1.23× GPU ref) at 16K**.
- [x] Qwen3-4B `r1_gpqa_diamond` smoke: every request returns HTTP 200 with the new `max_gen_toks=12288`; pre-fix the same request 4xx-rejected and lm-eval got `JSONDecodeError`.
- [ ] Targeted tt-shield nightly on this branch to confirm CI acceptance under EXPERIMENTAL: [run 26936556577](https://github.com/tenstorrent/tt-shield/actions/runs/26936556577) (forge-only dispatch).

## Out of scope

- Upstream fix that lifts the `worker.py:236` 12 GB hardcode (the real removal of the `TT_KV_POOL_GB` workaround) — tracked in #3954.
- Per-model context tuning beyond 16K — gated on bfp8 KV cache support in tt-xla ([tt-xla#5006](https://github.com/tenstorrent/tt-xla/issues/5006), waiting on tt-mlir uplift), which roughly doubles the per-sequence KV-pool headroom.
- Restoring full 32K `max_gen_toks` on Qwen3 — needs >16K-context forge impl, infeasible today (Qwen3-8B trace-capture OOMs already at 8K).
- Eval-quality gaps below GPU reference at 16K — tracked separately in #3954.

Part of the #3787 Phase 1 plan (3 of 4 child issues; #3950 lands in a separate PR; #3951 has no PR in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
