### PR TITLE
tt-media-server: bump request_processing_timeout_seconds to 3000s for (VLLMForge, P150) 

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -1304,6 +1304,7 @@ ModelConfigs = {
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_1.value,
         "max_batch_size": 1,
+        "request_processing_timeout_seconds": 3000,
     },
     (ModelRunners.VLLMForge, DeviceTypes.P300): {
         "device_mesh_shape": (1, 1),


### PR DESCRIPTION
Fixes #3950

## Summary

The `(ModelRunners.VLLMForge, DeviceTypes.P150)` entry in `tt-media-server/config/constants.py:ModelConfigs` had no per-runner override for `request_processing_timeout_seconds`, so requests fell back to the 1000s global default. The current forge wheel's per-tok rate is slow enough that long-output eval requests (Qwen3 `r1_gpqa_diamond` with `max_gen_toks=12288`, Llama-3.1-8B `meta_ifeval`) regularly cross that budget — `APITimeoutError` propagates to lm-eval, which retry-storms and compounds into multi-hour wall-clock burn (confirmed in [tt-shield run 26800608401](https://github.com/tenstorrent/tt-shield/actions/runs/26800608401), Llama-3.2-3B `meta_gpqa`).

3000s matches several existing slow forge configs in the same file (`(VLLMForge, P300)`, `(TT_SDXL_TRACE, N300)`, etc.).

## Changes

- `tt-media-server/config/constants.py`: add `"request_processing_timeout_seconds": 3000` to the `(VLLMForge, P150)` entry in `ModelConfigs`.

## Test plan

- [x] 4 forge servers on P150 stand up under this config without regressions (Falcon3-7B, Llama-3.1-8B, Qwen3-4B, Qwen3-8B at 16K).
- [ ] Targeted tt-shield nightly on the phase1 branch (which bundles this fix) to verify no more `APITimeoutError` on slow-request paths: [run 26936556577](https://github.com/tenstorrent/tt-shield/actions/runs/26936556577).

## Out of scope

- Bumping per-tok throughput (the root cause that makes 1000s tight) — tracked in #3954 + [tt-xla#5034](https://github.com/tenstorrent/tt-xla/issues/5034).
- Per-engine eval downsampling as an alternative — rejected (would fork the eval config tree).

Part of the #3787 Phase 1 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
