### PR TITLE
Add ModelSpecs with BH_GALAXY device

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,8 @@ run.py @tstescoTT @bgoelTT @stisiTT @tenstorrent/tt-inference-server-codeowners
 workflows/ @tstescoTT @tenstorrent/tt-inference-server-codeowners
 workflows/model_spec.py @tstescoTT @bgoelTT @idjuricTT @tenstorrent/tt-inference-server-codeowners
 workflows/run_reports.py @acvejicTT @mjeremicTT @mdobrosavljevicTT @vmaksimovicTT @vcankovicTT @tenstorrent/tt-inference-server-codeowners
+workflows/model_specs/dev/ @tenstorrent/tt-inference-server-codeowners
+workflows/model_specs/prod/ @acvejicTT @mjeremicTT @mdobrosavljevicTT @vmaksimovicTT @vcankovicTT @tstescoTT @bgoelTT
 
 # helm charts
 charts/tt-inference-server/ @acvejicTT @vcankovicTT @mjeremicTT @mdobrosavljevicTT @vmaksimovicTT @tenstorrent/tt-inference-server-codeowners

--- a/.github/workflows/models-ci-config-schema.json
+++ b/.github/workflows/models-ci-config-schema.json
@@ -6,7 +6,7 @@
   "$defs": {
     "device_names": {
       "type": "string",
-      "enum": ["N150", "N300", "T3K", "GALAXY", "GALAXY_BH", "P100", "P150", "P150X4", "P150X8", "P300X2", "DUAL_GALAXY", "QUAD_GALAXY"]
+      "enum": ["N150", "N300", "T3K", "GALAXY", "BH_GALAXY", "P100", "P150", "P150X4", "P150X8", "P300X2", "DUAL_GALAXY", "QUAD_GALAXY"]
     },
     "device_arg_entry": {
       "type": "object",
@@ -51,7 +51,7 @@
             "N300":    { "$ref": "#/$defs/device_arg_entry" },
             "T3K":     { "$ref": "#/$defs/device_arg_entry" },
             "GALAXY":  { "$ref": "#/$defs/device_arg_entry" },
-            "GALAXY_BH": { "$ref": "#/$defs/device_arg_entry" },
+            "BH_GALAXY": { "$ref": "#/$defs/device_arg_entry" },
             "P100":    { "$ref": "#/$defs/device_arg_entry" },
             "P150":    { "$ref": "#/$defs/device_arg_entry" },
             "P150X4":  { "$ref": "#/$defs/device_arg_entry" },

--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -126,7 +126,7 @@
         "nightly": {
           "devices": [
             "GALAXY",
-            "GALAXY_BH",
+            "BH_GALAXY",
             "P150X4",
             "P300X2",
             "T3K"
@@ -264,7 +264,7 @@
         "nightly": {
           "devices": [
             "GALAXY",
-            "GALAXY_BH",
+            "BH_GALAXY",
             "P300X2",
             "T3K"
           ]
@@ -363,7 +363,7 @@
         "nightly": {
           "devices": [
             "GALAXY",
-            "GALAXY_BH",
+            "BH_GALAXY",
             "P150X4",
             "P300X2",
             "T3K"
@@ -377,7 +377,7 @@
         "nightly": {
           "devices": [
             "GALAXY",
-            "GALAXY_BH",
+            "BH_GALAXY",
             "P150X4",
             "P300X2",
             "T3K"
@@ -532,7 +532,7 @@
         "nightly": {
           "devices": [
             "GALAXY",
-            "GALAXY_BH",
+            "BH_GALAXY",
             "P150X4",
             "P300X2",
             "T3K"
@@ -625,7 +625,7 @@
             "nightly": {
               "devices": [
                 "GALAXY",
-                "GALAXY_BH",
+                "BH_GALAXY",
                 "N150",
                 "N300",
                 "P300X2"
@@ -698,7 +698,7 @@
         "nightly": {
           "devices": [
             "GALAXY",
-            "GALAXY_BH",
+            "BH_GALAXY",
             "N150",
             "P150",
             "P300X2"

--- a/workflows/model_specs/dev/audio_tts.yaml
+++ b/workflows/model_specs/dev/audio_tts.yaml
@@ -28,6 +28,10 @@ templates:
       max_concurrency: 32
       max_context: 65536  # 64 * 1024
       default_impl: true
+    - device: BLACKHOLE_GALAXY
+      max_concurrency: 32
+      max_context: 65536  # 64 * 1024
+      default_impl: true
     - device: T3K
       max_concurrency: 4
       max_context: 65536  # 64 * 1024

--- a/workflows/model_specs/dev/image.yaml
+++ b/workflows/model_specs/dev/image.yaml
@@ -35,6 +35,10 @@ templates:
       max_concurrency: 32
       max_context: 65536  # 64 * 1024
       default_impl: true
+    - device: BLACKHOLE_GALAXY
+      max_concurrency: 32
+      max_context: 65536  # 64 * 1024
+      default_impl: true
     - device: P150
       max_concurrency: 1
       max_context: 65536  # 64 * 1024

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -247,6 +247,21 @@ templates:
         fabric_config: FABRIC_1D_RING
         worker_l1_size: 1344544
         trace_region_size: 184915840
+    - device: BLACKHOLE_GALAXY
+      max_concurrency: 32  # 8 * 4
+      # NOTE: model natively supports 40K but use this to override max_num_batched_tokens
+      max_context: 131072  # 128 * 1024
+      default_impl: true
+      env_vars:
+        VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+      vllm_args:
+        data_parallel_size: 4
+      override_tt_config:
+        dispatch_core_axis: col
+        sample_on_device_mode: all
+        fabric_config: FABRIC_1D_RING
+        worker_l1_size: 1344544
+        trace_region_size: 184915840
   system_requirements:
     firmware:
       specifier: ">=18.6.0"
@@ -285,6 +300,17 @@ templates:
       override_tt_config:
         fabric_config: FABRIC_1D
     - device: GALAXY
+      max_concurrency: 128  # 32 * 4
+      max_context: 131072  # 128 * 1024
+      default_impl: false
+      override_tt_config:
+        trace_region_size: 66147328
+        sample_on_device_mode: decode_only
+      vllm_args:
+        data_parallel_size: 4
+      env_vars:
+        TT_MM_THROTTLE_PERF: 5
+    - device: BLACKHOLE_GALAXY
       max_concurrency: 128  # 32 * 4
       max_context: 131072  # 128 * 1024
       default_impl: false
@@ -538,6 +564,19 @@ templates:
   inference_engine: VLLM
   device_model_specs:
     - device: GALAXY
+      max_concurrency: 32  # 8 * 4
+      max_context: 131072  # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      vllm_args:
+        data_parallel_size: 4
+      override_tt_config:
+        dispatch_core_axis: col
+        sample_on_device_mode: all
+        fabric_config: FABRIC_1D_RING
+        worker_l1_size: 1344544
+        trace_region_size: 215000000
+    - device: BLACKHOLE_GALAXY
       max_concurrency: 32  # 8 * 4
       max_context: 131072  # 128 * 1024
       default_impl: true

--- a/workflows/model_specs/dev/video.yaml
+++ b/workflows/model_specs/dev/video.yaml
@@ -23,6 +23,10 @@ templates:
       max_concurrency: 1
       max_context: 65536  # 64 * 1024
       default_impl: true
+    - device: BLACKHOLE_GALAXY
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: true
     - device: P150X4
       max_concurrency: 1
       max_context: 65536  # 64 * 1024
@@ -61,6 +65,10 @@ templates:
       max_concurrency: 1
       max_context: 65536  # 64 * 1024
       default_impl: true
+    - device: BLACKHOLE_GALAXY
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: true
     - device: P150X4
       max_concurrency: 1
       max_context: 65536  # 64 * 1024
@@ -96,6 +104,10 @@ templates:
       max_context: 65536  # 64 * 1024
       default_impl: true
     - device: GALAXY
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+    - device: BLACKHOLE_GALAXY
       max_concurrency: 1
       max_context: 65536  # 64 * 1024
       default_impl: true


### PR DESCRIPTION
We already have specific BLACHOLE_GALAXY device type, as well as bh gallaxy runners in CI. This PR just updates model_spec to pair several models that already run on our bh_galaxy runners with this BLACKHOLE_GALAXY device

https://github.com/tenstorrent/tt-inference-server/issues/2131