### PR TITLE
forge LLMs P150: enable trace on 5 specs (tt-forge 1.2.0 decode workaround, +16-89% tok/s)

### DIFF
--- a/tt-media-server/tests/test_vllm_runner.py
+++ b/tt-media-server/tests/test_vllm_runner.py
@@ -2,6 +2,7 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
+import os
 from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
@@ -135,3 +136,60 @@ async def test_run_async_streaming_yields_each_token(mock_get_settings):
     assert final_chunk["type"] == "final_result"
     expected_full_text = ""
     assert final_chunk["data"].text == expected_full_text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "env, expected",
+    [
+        # Defaults — no env set
+        (
+            {},
+            {"optimization_level": 0, "cpu_sampling": True, "enable_trace": False},
+        ),
+        # All env vars set
+        (
+            {
+                "OPTIMIZATION_LEVEL": "2",
+                "CPU_SAMPLING": "false",
+                "ENABLE_TRACE": "true",
+            },
+            {"optimization_level": 2, "cpu_sampling": False, "enable_trace": True},
+        ),
+    ],
+)
+@patch("tt_model_runners.vllm_runner.AsyncLLMEngine")
+@patch("tt_model_runners.vllm_runner.AsyncEngineArgs")
+@patch("tt_model_runners.base_device_runner.get_settings")
+async def test_warmup_reads_env_into_additional_config(
+    mock_get_settings, mock_engine_args, mock_llm_engine, env, expected
+):
+    """warmup() must thread OPTIMIZATION_LEVEL/CPU_SAMPLING/ENABLE_TRACE env vars
+    into AsyncEngineArgs(additional_config=...) so the forge runtime sees them."""
+    mock_settings = MagicMock()
+    mock_settings.device_mesh_shape = (1, 8)
+    mock_get_settings.return_value = mock_settings
+
+    # warmup() iterates the engine.generate() async-generator until exhausted; an
+    # empty async generator is enough to let it complete.
+    async def empty_gen(*_args, **_kwargs):
+        if False:
+            yield  # pragma: no cover
+
+    mock_engine_instance = MagicMock()
+    mock_engine_instance.generate = empty_gen
+    mock_llm_engine.from_engine_args = MagicMock(return_value=mock_engine_instance)
+
+    runner = VLLMForgeRunner(device_id="test-device")
+    with patch.dict(os.environ, env, clear=False):
+        # Strip any inherited env keys so defaults assert correctly
+        for k in ("OPTIMIZATION_LEVEL", "CPU_SAMPLING", "ENABLE_TRACE"):
+            if k not in env:
+                os.environ.pop(k, None)
+        result = await runner.warmup()
+
+    assert result is True
+    add_cfg = mock_engine_args.call_args.kwargs["additional_config"]
+    assert add_cfg["optimization_level"] == expected["optimization_level"]
+    assert add_cfg["cpu_sampling"] is expected["cpu_sampling"]
+    assert add_cfg["enable_trace"] is expected["enable_trace"]

--- a/tt-media-server/tt_model_runners/vllm_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_runner.py
@@ -36,6 +36,23 @@ class VLLMForgeRunner(BaseDeviceRunner):
     async def warmup(self) -> bool:
         self.logger.info(f"Device {self.device_id}: Loading VLLM model...")
         prompt = "Hello, it's me"
+        # Tunable per-run via env vars. Defaults are 1.2.0-safe:
+        # optimization_level=0 (required for the 1.2.0 wheel — opt>=1 aborts in
+        # the tt-mlir MemoryLayoutPropagation pass; see tt-xla#4990),
+        # cpu_sampling enabled. ENABLE_TRACE is off-by-default and gated on
+        # opt_level=0; replaying the decode graph works around the 1.2.0
+        # decode regression (+16-89% aggregate tok/s validated across the 5
+        # forge LLM P150 specs at b4/16K).
+        # Caveats for ENABLE_TRACE:
+        #   - vllm_tt's TTConfig rejects enable_trace=True + opt>=1 + cpu_sampling=False
+        #     (only safe at optimization_level=0).
+        #   - crashes at high batch (b16 hits a RuntimeError in
+        #     tt::runtime::ttnn::operations::trace::run; b16/16K won't compile).
+        #   - trace-capture needs extra DRAM scratch — validate fit on 7B+ models
+        #     before enabling.
+        optimization_level = int(os.getenv("OPTIMIZATION_LEVEL", "0"))
+        cpu_sampling = os.getenv("CPU_SAMPLING", "true").lower() == "true"
+        enable_trace = os.getenv("ENABLE_TRACE", "false").lower() == "true"
         engine_args = AsyncEngineArgs(
             model=self.settings.vllm.model,
             max_model_len=self.settings.vllm.max_model_length,
@@ -47,10 +64,9 @@ class VLLMForgeRunner(BaseDeviceRunner):
                 "enable_const_eval": True,
                 "min_context_len": self.settings.vllm.min_context_length,
                 "experimental_weight_dtype": "bfp_bf8",
-                "cpu_sampling": True,
-                # opt_level>=1 crashes the tt-mlir optimizer during warmup on
-                # the 1.2.0 wheel; keep 0 until tenstorrent/tt-xla#4990 lands.
-                "optimization_level": 0,
+                "cpu_sampling": cpu_sampling,
+                "optimization_level": optimization_level,
+                "enable_trace": enable_trace,
             },
         )
         self.logger.info(

--- a/workflows/model_specs/dev/cnn.yaml
+++ b/workflows/model_specs/dev/cnn.yaml
@@ -26,6 +26,8 @@ templates:
         MAX_NUM_SEQS: "4"
         GPU_MEMORY_UTILIZATION: "0.35"
         TT_KV_POOL_GB: "32"
+        OPTIMIZATION_LEVEL: "0"
+        ENABLE_TRACE: "true"
 
 - weights:
     - meta-llama/Llama-3.2-3B
@@ -49,6 +51,8 @@ templates:
         MAX_NUM_SEQS: "4"
         GPU_MEMORY_UTILIZATION: "0.35"
         TT_KV_POOL_GB: "32"
+        OPTIMIZATION_LEVEL: "0"
+        ENABLE_TRACE: "true"
 
 - weights:
     - meta-llama/Llama-3.1-8B-Instruct
@@ -71,6 +75,8 @@ templates:
         MAX_NUM_SEQS: "4"
         GPU_MEMORY_UTILIZATION: "0.30"
         TT_KV_POOL_GB: "32"
+        OPTIMIZATION_LEVEL: "0"
+        ENABLE_TRACE: "true"
 
 - weights:
     - Qwen/Qwen3-8B
@@ -93,6 +99,8 @@ templates:
         MAX_NUM_SEQS: "4"
         GPU_MEMORY_UTILIZATION: "0.30"
         TT_KV_POOL_GB: "32"
+        OPTIMIZATION_LEVEL: "0"
+        ENABLE_TRACE: "true"
 
 - weights:
     - tiiuae/Falcon3-7B-Instruct
@@ -115,6 +123,8 @@ templates:
         MAX_NUM_SEQS: "4"
         GPU_MEMORY_UTILIZATION: "0.225"
         TT_KV_POOL_GB: "32"
+        OPTIMIZATION_LEVEL: "0"
+        ENABLE_TRACE: "true"
 
 - weights:
     - resnet-50


### PR DESCRIPTION
## Ticket: 

Related to https://github.com/tenstorrent/tt-xla/issues/5034

## Summary

Motivated by the [~40% per-tok decode throughput regression](https://github.com/tenstorrent/tt-xla/issues/5034) introduced in the tt-forge 1.2.0 wheel. Replaying the decode graph via `enable_trace` skips per-step host dispatch and works around the regression. Validated locally on QB2 P150 at batch=4 / 16K context across all 5 forge LLM specs (no trace-capture OOM on any).

| Model | N=4 non-grd | N=4 greedy | Δ aggregate tok/s |
|---|---|---|---|
| Llama-3.2-3B-Instruct | 57.4 → **95.7** | 60.3 → **108.2** | **+67-79%** |
| Falcon3-7B-Instruct | 55.4 → **64.2** | 58.1 → **68.5** | +16-18% |
| Llama-3.1-8B-Instruct | 49.6 → **63.5** | 50.9 → **67.0** | +28-32% |
| Qwen/Qwen3-4B | 44.4 → **79.0** | 45.8 → **86.8** | **+78-89%** |
| Qwen/Qwen3-8B | 43.8 → **60.4** | 45.3 → **63.6** | +38-40% |

## Changes

- `tt-media-server/tt_model_runners/vllm_runner.py`: read `OPTIMIZATION_LEVEL` / `CPU_SAMPLING` / `ENABLE_TRACE` from env (mirroring `sdxl_forge_runner`'s convention). Defaults are 1.2.0-safe: `optimization_level=0` (forge 1.2.0 requires it — `opt>=1` aborts in tt-mlir `MemoryLayoutPropagation`, see [tt-xla#4990](https://github.com/tenstorrent/tt-xla/issues/4990)), `cpu_sampling=true`, `enable_trace=false`.
- `workflows/model_specs/dev/cnn.yaml`: set `OPTIMIZATION_LEVEL: "0"` + `ENABLE_TRACE: "true"` on all 5 forge LLM P150 specs.

## `ENABLE_TRACE` caveats (encoded as inline comment in vllm_runner.py)

- vllm_tt's `TTConfig` rejects `enable_trace=True + opt>=1 + cpu_sampling=False`. Only safe at `optimization_level=0` (which is also where we have to be for 1.2.0).
- `b16` hits a `RuntimeError` in `tt::runtime::ttnn::operations::trace::run`; `b16/16K` won't compile. Trace must stay at batch ≤ 4.
- Trace-capture needs extra DRAM scratch — Falcon3-7B previously OOMed at `TT_KV_POOL_GB=16`. We're fine at `TT_KV_POOL_GB=32` with the per-model `GPU_MEMORY_UTILIZATION` calibration from #3948 (Falcon at gmu=0.225 leaves ~25 GB free for trace scratch + weights), validated locally.

## Test plan

- [x] Local validation on QB2 P150, all 5 specs at batch=4 / 16K: stood up cleanly with trace-capture, no OOM.
- [x] Aggregate tok/s improvements measured per the table above using `cbench.py` — N concurrent streaming `/v1/completions`, 128 tok each, both greedy + non-greedy.
- [ ] Targeted tt-shield nightly on this branch + #3955 stacked: [run 26941582252](https://github.com/tenstorrent/tt-shield/actions/runs/26941582252) (dispatched against the pre-rebase branch, which represents the post-merge state: this PR's `OPTIMIZATION_LEVEL` + `ENABLE_TRACE` changes on top of #3955's calibration).

## Depends on

Merge after https://github.com/tenstorrent/tt-inference-server/pull/3955 lands in main.

## Out of scope

- Restoring `optimization_level=1` once `tt-mlir` `MemoryLayoutPropagation` is fixed ([tt-xla#4990](https://github.com/tenstorrent/tt-xla/issues/4990)) — flip the default in `vllm_runner.py` later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
