### PR TITLE
Add CODEOWNERS for dynamo_frontend and fix tt-inference-server-v2 path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,5 +50,8 @@ scripts/release/* @vmaksimovicTT @tstescoTT @bgoelTT
 docs/ @tenstorrent/tt-inference-server-codeowners
 README.md @tstescoTT @bgoelTT @idjuricTT
 
-# tt-infenrece-server-v2
-tt-infenrece-server-v2/ @idjuricTT @fivanovicTT @vpetrovicTT @ddjukicTT
+# dynamo_frontend
+dynamo_frontend/ @idjuricTT @ljovanovicTT @lmuravljovTT @vpetrovicTT @ztorlakTT
+
+# tt-inference-server-v2
+tt-inference-server-v2/ @idjuricTT @fivanovicTT @vpetrovicTT @ddjukicTT


### PR DESCRIPTION
Corrected spelling of 'inference' and added 'dynamo_frontend' section.