### PR TITLE
Fix Slot Reuse Registering Prefix Cache

### DIFF
--- a/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
@@ -272,6 +272,11 @@ void LLMPipeline::resolveSession(
 
         req->session = mgr->getSession(session.getSessionId());
 
+        std::vector<int> fullPrompt;
+        if (auto* p = std::get_if<std::vector<int>>(&req->prompt)) {
+          fullPrompt = *p;
+        }
+
         // If we copied from a slot, mark as continuation with kv_position_id.
         if (slotToCopyFrom.has_value() && copyMatchedTokens > 0) {
           req->continuation = true;
@@ -282,9 +287,9 @@ void LLMPipeline::resolveSession(
         }
 
         mgr->registerPrefixHash(session.getSessionId(), routingInfo.blocks);
-        if (auto* promptTokens = std::get_if<std::vector<int>>(&req->prompt)) {
+        if (!fullPrompt.empty()) {
           req->session->initTokenAccumulator(
-              *promptTokens, /*initialBlocks=*/{},
+              std::move(fullPrompt), /*initialBlocks=*/{},
               [mgr](const std::string& sessionId,
                     const std::vector<tt::utils::BlockHashInfo>& blocks) {
                 mgr->registerPrefixHash(sessionId, blocks);


### PR DESCRIPTION
## Problem
Since we added a new `applyDeltaPrompt` call with recent changes before `registerPrefixHash` - we were running into issues where prefix was generated on delta prompt, and not on full prompt, making it impossible to match on the next turn. With this fix, we are reenabling the prefix cache HIT path in slot copy scenario