### PR TITLE
Add Qwen3-32B to release CI on P300X2

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -292,6 +292,11 @@
           "devices": [
             "GALAXY"
           ]
+        },
+        "release": {
+          "devices": [
+            "P300X2"
+          ]
         }
       }
     },


### PR DESCRIPTION
Adds a `release` schedule entry for `Qwen3-32B` targeting `P300X2` in `models-ci-config.json`.