### PR TITLE
evals: drop Qwen3 `mmlu_pro` `max_gen_toks` 14336 → 12288 to fit 16K context

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1149,14 +1149,15 @@ _eval_config_list = [
                     "timeout": "3600",
                 },
                 # gen_kwargs chosen according to https://huggingface.co/Qwen/Qwen3-8B#best-practices
-                # max_gen_toks lowered 32768 -> 14336 for forge P150 (max_model_len=16384).
-                # Observed mmlu_pro prompts are ~1.1k tokens, so 14336 output cap
-                # leaves ~950-token headroom. Even with the runtime clamp at
-                # 16384-PROMPT_RESERVE=15360, prompts >1024 would 4xx-reject;
-                # explicit cap is the safe value.
+                # max_gen_toks lowered 32768 -> 12288 for forge P150 (max_model_len=16384).
+                # Earlier value 14336 assumed prompts ≤ ~1.1k tokens; observed CI
+                # prompts run up to 2477, so 14336 + 2477 = 16813 > 16384 → 4xx
+                # rejection on every long-prompt sample, cascading into a 6h
+                # workflow timeout. 12288 matches r1_gpqa_diamond and leaves
+                # ~3700 tokens of prompt headroom. Tracked in #4000.
                 gen_kwargs={
                     "stream": "true",
-                    "max_gen_toks": 14336,
+                    "max_gen_toks": 12288,
                     "until": [],
                     "do_sample": "true",
                     "temperature": 0.6,
@@ -1230,12 +1231,12 @@ _eval_config_list = [
                     "max_length": 65536,
                     "timeout": "3600",
                 },
-                # max_gen_toks lowered 32768 -> 14336 so `prompt + max_gen_toks`
+                # max_gen_toks lowered 32768 -> 12288 so `prompt + max_gen_toks`
                 # fits forge P150 max_model_len=16384. See the same note on the
-                # Qwen3-8B mmlu_pro entry above.
+                # Qwen3-8B mmlu_pro entry above. Tracked in #4000.
                 gen_kwargs={
                     "stream": "true",
-                    "max_gen_toks": 14336,
+                    "max_gen_toks": 12288,
                     "until": [],
                     "do_sample": "true",
                     "temperature": 0.6,


### PR DESCRIPTION
## Summary

Short-term workaround for #4000: the existing `mmlu_pro` clamp (14336, set by #3949) overshoots `max_model_len=16384` once prompts exceed ~1.1K tokens. Observed CI prompts run up to **2477 tokens**, so `2477 + 14336 = 16813 > 16384` 4xx-rejects every long-prompt sample. `lm-eval` then retry-burns through ~600 prompts and the workflow trips the 6h timeout. Both Qwen3-4B and Qwen3-8B hit this on the most recent nightly.

Drop to **12288** (matches `r1_gpqa_diamond` on the same models). Leaves ~3700 tokens of prompt headroom — comfortably above the observed 2477-token tail.

## Test plan

**Verified locally on QB2 P150** against live Qwen3-4B (port 8012) and Qwen3-8B (port 8013) forge_vllm_plugin servers. A ~2500-token prompt (close to the observed CI tail of 2477) was sent at both the OLD clamp value (14336, expected to fail) and the NEW value (12288, expected to succeed):

```
[OLD-q3_4b] max_tokens=14336 → HTTP 400 "Prompt length (2520) + max_tokens (14336) exceeds max model length (16384)"
[NEW-q3_4b] max_tokens=12288 → 200 OK, first_chunk=0.11s
[OLD-q3_8b] max_tokens=14336 → HTTP 400 (same error)
[NEW-q3_8b] max_tokens=12288 → 200 OK, first_chunk=23.67s
```

OLD reproduces the exact CI error verbatim; NEW accepts the request and begins streaming on both models.

tt-shield on-dispatch CI runs against this branch:
- Qwen3-4B P150: [tt-shield run 26994938115](https://github.com/tenstorrent/tt-shield/actions/runs/26994938115)
- Qwen3-8B P150: [tt-shield run 26994937009](https://github.com/tenstorrent/tt-shield/actions/runs/26994937009)

## Notes

Workaround, not a fix — **#4000 stays open** until forge P150 `max_model_len` rises enough to drop the clamp. 1-line follow-up to #3949 / #3955.
