### PR TITLE
Calculate Cached Tokens on Prefill for Disaggregated Setup

### DIFF
--- a/tt-media-server/cpp_server/include/api/response_writer/response_writer.hpp
+++ b/tt-media-server/cpp_server/include/api/response_writer/response_writer.hpp
@@ -62,6 +62,15 @@ class ResponseWriter : public std::enable_shared_from_this<ResponseWriter> {
   /** Signal end-of-stream. Idempotent; releases in-flight slot. */
   virtual void finalize() = 0;
 
+  /**
+   * Disaggregation: the decode server stamps the prefill server's prefix-cache
+   * reuse onto the first stream chunk (LLMStreamChunk::cached_prompt_tokens).
+   * When present it overrides the request-derived cachedTokenCount in usage.
+   * Safe to call on every chunk; no-op for the aggregated path. The controller
+   * calls this before its content filter so a cached-only chunk still counts.
+   */
+  void observeCachedTokens(const LLMStreamChunk& chunk);
+
   bool isDone() const { return done.load(); }
 
  protected:
@@ -80,6 +89,8 @@ class ResponseWriter : public std::enable_shared_from_this<ResponseWriter> {
   CompletionUsage buildUsage() const;
 
   ResponseWriterParams params;
+  // -1 = unset (use params.cachedTokenCount); >=0 = override from prefill.
+  std::atomic<int> cachedTokensOverride{-1};
   std::chrono::high_resolution_clock::time_point startTime =
       std::chrono::high_resolution_clock::now();
   std::optional<std::chrono::high_resolution_clock::time_point> firstTokenTime;

--- a/tt-media-server/cpp_server/include/domain/llm/llm_response.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/llm_response.hpp
@@ -113,6 +113,12 @@ struct LLMStreamChunk : BaseResponse {
   std::vector<LLMChoice> choices;
   std::optional<std::string> error;
   std::optional<CompletionUsage> usage;
+
+  // In disaggregation, the decode server fills this on the first chunk with the
+  // number of prompt tokens the prefill server served from its KV cache
+  // (prefix-cache reuse), so the transport can report
+  // usage.prompt_tokens_details.cached_tokens. Unset in non-disaggregated runs.
+  std::optional<int> cached_prompt_tokens;
 };
 
 /**

--- a/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
@@ -117,6 +117,10 @@ struct PrefillResultMessage {
   std::optional<float> top_p;
   std::optional<int> top_k;
   bool fast_mode = false;
+  // Number of prompt tokens the prefill server served from its KV cache
+  // (prefix-cache reuse). The decode server surfaces this as
+  // usage.prompt_tokens_details.cached_tokens.
+  int cached_tokens = 0;
 
   explicit PrefillResultMessage(uint32_t taskId) : task_id(taskId) {}
 
@@ -132,7 +136,7 @@ struct PrefillResultMessage {
     int topKVal = top_k.value_or(0);
     ar(task_id, generated_text, finished, tokens_generated, processing_time_ms,
        token_ids, rt, sid, error, hasTemp, tempVal, hasTopP, topPVal, hasTopK,
-       topKVal, fast_mode);
+       topKVal, fast_mode, cached_tokens);
   }
 
   template <class Archive>
@@ -153,8 +157,9 @@ struct PrefillResultMessage {
     bool hasTopK;
     int topKVal;
     bool fastMode;
+    int cachedTokens;
     ar(tid, genText, fin, tg, pt, tids, rt, sid, err, hasTemp, tempVal, hasTopP,
-       topPVal, hasTopK, topKVal, fastMode);
+       topPVal, hasTopK, topKVal, fastMode, cachedTokens);
     PrefillResultMessage msg(tid);
     msg.generated_text = std::move(genText);
     msg.finished = fin;
@@ -170,6 +175,7 @@ struct PrefillResultMessage {
     if (hasTopP) msg.top_p = topPVal;
     if (hasTopK) msg.top_k = topKVal;
     msg.fast_mode = fastMode;
+    msg.cached_tokens = cachedTokens;
     return msg;
   }
 };

--- a/tt-media-server/cpp_server/src/api/llm_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/llm_controller.cpp
@@ -280,6 +280,11 @@ LLMController::makeStreamingCallback(std::shared_ptr<ResponseWriter> writer,
 
     if (writer->isDone()) return;
 
+    // Disaggregation: capture the prefill server's cached-token count (stamped
+    // on the first chunk) before the content filter below, so it surfaces in
+    // usage even if that chunk carries no displayable text.
+    writer->observeCachedTokens(chunk);
+
     // Only forward chunks with content to the writer; suppressed tokens (e.g.,
     // think markers with empty text) are tracked above but not sent to client.
     if (!chunk.choices.empty() &&

--- a/tt-media-server/cpp_server/src/api/response_writer/response_writer.cpp
+++ b/tt-media-server/cpp_server/src/api/response_writer/response_writer.cpp
@@ -36,13 +36,21 @@ int ResponseWriter::noteToken(const LLMChoice& choice) {
   return current;
 }
 
+void ResponseWriter::observeCachedTokens(const LLMStreamChunk& chunk) {
+  if (chunk.cached_prompt_tokens.has_value()) {
+    cachedTokensOverride.store(*chunk.cached_prompt_tokens);
+  }
+}
+
 CompletionUsage ResponseWriter::buildUsage() const {
   const int tokens = completionTokens.load();
   const int reasoning = reasoningTokens.load();
   const int totalTokens = params.promptTokenCount + tokens;
 
   PromptTokensDetails promptDetails;
-  promptDetails.cached_tokens = params.cachedTokenCount;
+  const int cachedOverride = cachedTokensOverride.load();
+  promptDetails.cached_tokens =
+      cachedOverride >= 0 ? cachedOverride : params.cachedTokenCount;
 
   CompletionTokensDetails completionDetails;
   completionDetails.reasoning_tokens = reasoning;

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
@@ -184,6 +184,9 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
       bool inReasoning;
       int completion = 0;
       int reasoning = 0;
+      // Prefix-cache reuse reported by the prefill server in disaggregation
+      // (carried on the first stream chunk). 0 in non-disaggregated runs.
+      int cachedTokens = 0;
     };
     auto usage = std::make_shared<UsageAccum>();
     {
@@ -310,6 +313,14 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
                   sinceDispatchMs);
             }
 
+            // Disaggregation: the decode server stamps the prefill server's
+            // prefix-cache reuse count onto the first chunk. Capture it so the
+            // final usage block can report it (the decode-side request is not a
+            // continuation, so the formula below would otherwise yield 0).
+            if (chunk.cached_prompt_tokens.has_value()) {
+              usage->cachedTokens = *chunk.cached_prompt_tokens;
+            }
+
             // Track token for prefix cache hash accumulation
             if (req->session && !chunk.choices.empty() &&
                 chunk.choices[0].token_id) {
@@ -343,9 +354,15 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
               du.prompt_tokens = req->full_prompt_tokens_count;
               du.completion_tokens = usage->completion;
               du.total_tokens = du.prompt_tokens + du.completion_tokens;
-              int cached = req->continuation ? req->full_prompt_tokens_count -
-                                                   req->prompt_tokens_count
-                                             : 0;
+              // Prefer the prefix-cache reuse reported by the prefill server in
+              // disaggregation; fall back to the aggregated-path formula
+              // (continuation delta) when not disaggregated.
+              int cached =
+                  usage->cachedTokens > 0
+                      ? usage->cachedTokens
+                      : (req->continuation ? req->full_prompt_tokens_count -
+                                                 req->prompt_tokens_count
+                                           : 0);
               du.cached_tokens = cached < 0 ? 0 : cached;
               // Only report reasoning_tokens for models that have think tokens.
               const auto kNo = tt::utils::tokenizers::kNoTokenId;

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -142,11 +142,6 @@ void DisaggregationService::setupSocketHandlers() {
           request->top_k = message.top_k;
           request->fast_mode = message.fast_mode;
 
-          TT_LOG_DEBUG(
-              "[DisaggregationService] Prefill request taskId={} "
-              "registration_hashes={}",
-              message.task_id, message.registration_hashes.size());
-
           auto maxTokens = message.max_tokens;
 
           request->prompt.emplace<std::vector<int>>(message.token_ids.begin(),
@@ -167,10 +162,23 @@ void DisaggregationService::setupSocketHandlers() {
                 const size_t fullPromptTokens = message.token_ids.size();
                 const size_t trimmedPromptTokens =
                     std::get<std::vector<int>>(request->prompt).size();
-                const int cachedTokens = static_cast<int>(
+                // Cached (reused) prompt tokens = the leading prefix that did
+                // NOT need a fresh prefill. Two sources describe that same
+                // prefix; take the larger:
+                //   - decode_skip_tokens: the prefix the decode node already
+                //     holds in its KV from earlier turns. The decode node does
+                //     the multi-turn prefix match and ships the full prompt
+                //     plus this skip count (it does not trim itself); the
+                //     prefill runner honors it. This is the dominant source in
+                //     chat.
+                //   - prefill-side trim (fullPrompt - delta): when the prefill
+                //     server independently hits its own prefix cache.
+                const int prefillTrim = static_cast<int>(
                     fullPromptTokens >= trimmedPromptTokens
                         ? fullPromptTokens - trimmedPromptTokens
                         : 0);
+                const int cachedTokens =
+                    std::max(prefillTrim, message.number_of_decode_skip_tokens);
                 llmService->submitStreamingRequest(
                     *request,
                     [this, message, maxTokens, slotId, cachedTokens](
@@ -401,6 +409,7 @@ void DisaggregationService::handleStreamingRequest(
     int decodeSkipTokens = request.kv_position_id.has_value()
                                ? static_cast<int>(*request.kv_position_id + 1)
                                : 0;
+
     auto sent = socketService->sendPrefillRequest(
         request.task_id, registrationHashes,
         std::vector<int64_t>(tokenIds.begin(), tokenIds.end()), maxTokens,

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -63,6 +63,9 @@ void DisaggregationService::setupSocketHandlers() {
           LLMChoice choice;
           choice.text = message.generated_text;
           response.choices.push_back(std::move(choice));
+          // Surface the prefill server's prefix-cache reuse count to the
+          // transport's usage accounting (prompt_tokens_details.cached_tokens).
+          response.cached_prompt_tokens = message.cached_tokens;
 
           callback.value()(response, false);
 
@@ -158,9 +161,19 @@ void DisaggregationService::setupSocketHandlers() {
           resolvePrefillSession(
               request, message.registration_hashes,
               [this, request, message, maxTokens, slotId]() {
+                // Tokens the prefill server served from its KV cache
+                // (prefix-cache reuse) = prompt tokens trimmed off by
+                // resolvePrefillSession (full prompt - remaining delta).
+                const size_t fullPromptTokens = message.token_ids.size();
+                const size_t trimmedPromptTokens =
+                    std::get<std::vector<int>>(request->prompt).size();
+                const int cachedTokens = static_cast<int>(
+                    fullPromptTokens >= trimmedPromptTokens
+                        ? fullPromptTokens - trimmedPromptTokens
+                        : 0);
                 llmService->submitStreamingRequest(
                     *request,
-                    [this, message, maxTokens, slotId](
+                    [this, message, maxTokens, slotId, cachedTokens](
                         const LLMStreamChunk& response, bool /*isFinal*/) {
                       auto prefillResult =
                           tt::sockets::PrefillResultMessage(message.task_id);
@@ -169,6 +182,7 @@ void DisaggregationService::setupSocketHandlers() {
                       prefillResult.top_p = message.top_p;
                       prefillResult.top_k = message.top_k;
                       prefillResult.fast_mode = message.fast_mode;
+                      prefillResult.cached_tokens = cachedTokens;
 
                       bool isError =
                           !response.choices.empty() &&

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -142,6 +142,11 @@ void DisaggregationService::setupSocketHandlers() {
           request->top_k = message.top_k;
           request->fast_mode = message.fast_mode;
 
+          TT_LOG_DEBUG(
+              "[DisaggregationService] Prefill request taskId={} "
+              "registration_hashes={}",
+              message.task_id, message.registration_hashes.size());
+
           auto maxTokens = message.max_tokens;
 
           request->prompt.emplace<std::vector<int>>(message.token_ids.begin(),
@@ -179,10 +184,17 @@ void DisaggregationService::setupSocketHandlers() {
                         : 0);
                 const int cachedTokens =
                     std::max(prefillTrim, message.number_of_decode_skip_tokens);
+                // Capture the resolved sessionId by value:
+                // submitStreamingRequest hands the request to the pipeline, so
+                // request->sessionId is no longer reliable by the time this
+                // async callback fires.
+                const std::string prefillSessionId =
+                    request->sessionId.value_or("");
                 llmService->submitStreamingRequest(
                     *request,
-                    [this, message, maxTokens, slotId, cachedTokens](
-                        const LLMStreamChunk& response, bool /*isFinal*/) {
+                    [this, prefillSessionId, message, maxTokens, slotId,
+                     cachedTokens](const LLMStreamChunk& response,
+                                   bool /*isFinal*/) {
                       auto prefillResult =
                           tt::sockets::PrefillResultMessage(message.task_id);
                       prefillResult.slot_id = slotId;
@@ -220,6 +232,22 @@ void DisaggregationService::setupSocketHandlers() {
                       }
 
                       socketService->sendPrefillResult(prefillResult);
+
+                      // Release the prefill session's in-flight hold now that
+                      // this one-shot prefill (max_tokens=1) is done. Unlike
+                      // the decode/HTTP transports, the prefill path has no
+                      // stream-end release, so without this the session stays
+                      // IN_FLIGHT forever — and evictOldSessions only reclaims
+                      // IDLE sessions, so the prefill pool fills with
+                      // un-evictable sessions and allocation eventually fails.
+                      // Releasing to IDLE-but-cached also lets the next turn's
+                      // prefix cache match it. clearInFlight() is idempotent.
+                      if (!prefillSessionId.empty()) {
+                        if (auto* s =
+                                sessionManager->getSession(prefillSessionId)) {
+                          s->clearInFlight();
+                        }
+                      }
                     });
               },
               [this, message, slotId](std::string_view error) {
@@ -321,6 +349,9 @@ void DisaggregationService::resolvePrefillSession(
         request->task_id, acquired->sessionId, acquired->slotId,
         acquired->numberOfMatchedTokens);
     request->prefillSlotId = acquired->slotId;
+    // Record the acquired session so the prefill completion can release its
+    // in-flight hold (see clearInFlight below).
+    request->sessionId = acquired->sessionId;
     applyDeltaPrompt(*request, acquired->numberOfMatchedTokens);
     sessionManager->registerPrefixHash(acquired->sessionId, blockInfos);
     onResolved();


### PR DESCRIPTION
## Issue
[#3877 Track token usage in case of disaggregation](https://github.com/tenstorrent/tt-inference-server/issues/3877)

## Problem
In case of disaggregated setup, we want to report `cached_tokens` from Prefill node. 
With this PR, this is done for both Dynamo path and legacy HTTP path.