### PR TITLE
Isolate heavy C++ ccache keys

### DIFF
--- a/.github/workflows/cpp-heavy-checks.yml
+++ b/.github/workflows/cpp-heavy-checks.yml
@@ -50,7 +50,7 @@ jobs:
         uses: ./.github/actions/setup-cpp-ci
         with:
           token: ${{ secrets.TT_LLM_ENGINE }}
-          ccache-key-suffix: server-heavy-build
+          ccache-key-suffix: server
 
       - name: Restore cached tokenizer files
         uses: actions/cache@v5
@@ -111,7 +111,7 @@ jobs:
         uses: ./.github/actions/setup-cpp-ci
         with:
           token: ${{ secrets.TT_LLM_ENGINE }}
-          ccache-key-suffix: server-heavy-mock-pipeline
+          ccache-key-suffix: server
 
       - name: Build C++ server
         run: |
@@ -254,7 +254,7 @@ jobs:
         uses: ./.github/actions/setup-cpp-ci
         with:
           token: ${{ secrets.TT_LLM_ENGINE }}
-          ccache-key-suffix: server-heavy-prefill-decode
+          ccache-key-suffix: server
 
       - name: Build C++ server
         run: |
@@ -657,7 +657,7 @@ jobs:
         uses: ./.github/actions/setup-cpp-ci
         with:
           token: ${{ secrets.TT_LLM_ENGINE }}
-          ccache-key-suffix: server-heavy-gateway-split
+          ccache-key-suffix: server
 
       - name: Build C++ server
         run: |
@@ -1382,7 +1382,7 @@ jobs:
         uses: ./.github/actions/setup-cpp-ci
         with:
           token: ${{ secrets.TT_LLM_ENGINE }}
-          ccache-key-suffix: server-heavy-tsan
+          ccache-key-suffix: server
 
       - name: Restore cached tokenizer files
         uses: actions/cache@v5
@@ -1536,7 +1536,7 @@ jobs:
         uses: ./.github/actions/setup-cpp-ci
         with:
           init-private-submodule: "false"
-          ccache-key-suffix: gateway-heavy-tsan
+          ccache-key-suffix: gateway
 
       - name: Configure prefill_gateway with ThreadSanitizer
         run: |

--- a/.github/workflows/cpp-heavy-checks.yml
+++ b/.github/workflows/cpp-heavy-checks.yml
@@ -50,6 +50,7 @@ jobs:
         uses: ./.github/actions/setup-cpp-ci
         with:
           token: ${{ secrets.TT_LLM_ENGINE }}
+          ccache-key-suffix: server-heavy-build
 
       - name: Restore cached tokenizer files
         uses: actions/cache@v5
@@ -110,6 +111,7 @@ jobs:
         uses: ./.github/actions/setup-cpp-ci
         with:
           token: ${{ secrets.TT_LLM_ENGINE }}
+          ccache-key-suffix: server-heavy-mock-pipeline
 
       - name: Build C++ server
         run: |
@@ -252,6 +254,7 @@ jobs:
         uses: ./.github/actions/setup-cpp-ci
         with:
           token: ${{ secrets.TT_LLM_ENGINE }}
+          ccache-key-suffix: server-heavy-prefill-decode
 
       - name: Build C++ server
         run: |
@@ -654,6 +657,7 @@ jobs:
         uses: ./.github/actions/setup-cpp-ci
         with:
           token: ${{ secrets.TT_LLM_ENGINE }}
+          ccache-key-suffix: server-heavy-gateway-split
 
       - name: Build C++ server
         run: |
@@ -1378,6 +1382,7 @@ jobs:
         uses: ./.github/actions/setup-cpp-ci
         with:
           token: ${{ secrets.TT_LLM_ENGINE }}
+          ccache-key-suffix: server-heavy-tsan
 
       - name: Restore cached tokenizer files
         uses: actions/cache@v5
@@ -1531,6 +1536,7 @@ jobs:
         uses: ./.github/actions/setup-cpp-ci
         with:
           init-private-submodule: "false"
+          ccache-key-suffix: gateway-heavy-tsan
 
       - name: Configure prefill_gateway with ThreadSanitizer
         run: |


### PR DESCRIPTION
- Add explicit `ccache-key-suffix` values for all `cpp-heavy-checks.yml` callers of `setup-cpp-ci`.
- Prevent scheduled heavy C++ jobs from sharing the default cache key and racing to persist incomplete Cargo/ccache state.

https://github.com/tenstorrent/tt-inference-server/actions/runs/27020325359
