### PR TITLE
Testing performance after sdxl migration to cpp

### DIFF
--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -4885,7 +4885,7 @@ models:
             progressDeadlineSeconds: 5400
             image:
               repository: ghcr.io/tenstorrent/tt-media-inference-server
-              tag: 0.11.1-bac8b34
+              tag: 0.11.1-7463e586f3b5
             probes:
               liveness:
                 initialDelaySeconds: 2400
@@ -4907,7 +4907,7 @@ models:
             progressDeadlineSeconds: 5400
             image:
               repository: ghcr.io/tenstorrent/tt-media-inference-server
-              tag: 0.11.1-bac8b34
+              tag: 0.11.1-7463e586f3b5
             probes:
               liveness:
                 initialDelaySeconds: 2400
@@ -4931,7 +4931,7 @@ models:
             progressDeadlineSeconds: 5400
             image:
               repository: ghcr.io/tenstorrent/tt-media-inference-server
-              tag: 0.11.1-bac8b34
+              tag: 0.11.1-7463e586f3b5
             probes:
               liveness:
                 initialDelaySeconds: 2400
@@ -4955,7 +4955,7 @@ models:
             progressDeadlineSeconds: 5400
             image:
               repository: ghcr.io/tenstorrent/tt-media-inference-server
-              tag: 0.11.1-bac8b34
+              tag: 0.11.1-7463e586f3b5
             probes:
               liveness:
                 initialDelaySeconds: 2400
@@ -5117,7 +5117,7 @@ models:
             progressDeadlineSeconds: 5400
             image:
               repository: ghcr.io/tenstorrent/tt-media-inference-server
-              tag: 0.11.1-bac8b34
+              tag: 0.11.1-7463e586f3b5
             probes:
               liveness:
                 initialDelaySeconds: 2400
@@ -5139,7 +5139,7 @@ models:
             progressDeadlineSeconds: 5400
             image:
               repository: ghcr.io/tenstorrent/tt-media-inference-server
-              tag: 0.11.1-bac8b34
+              tag: 0.11.1-7463e586f3b5
             probes:
               liveness:
                 initialDelaySeconds: 2400
@@ -5163,7 +5163,7 @@ models:
             progressDeadlineSeconds: 5400
             image:
               repository: ghcr.io/tenstorrent/tt-media-inference-server
-              tag: 0.11.1-bac8b34
+              tag: 0.11.1-7463e586f3b5
             probes:
               liveness:
                 initialDelaySeconds: 2400
@@ -5187,7 +5187,7 @@ models:
             progressDeadlineSeconds: 5400
             image:
               repository: ghcr.io/tenstorrent/tt-media-inference-server
-              tag: 0.11.1-bac8b34
+              tag: 0.11.1-7463e586f3b5
             probes:
               liveness:
                 initialDelaySeconds: 2400

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -1034,7 +1034,10 @@ class TestOverrideArgsIntegration:
 
 
 class TestMediaServerDockerEnvVars:
-    def test_single_runner_sdxl_uses_cpp_server(self):
+    # REGRESSION TEST branch: _is_cpp_media_spec() is forced False, so SDXL
+    # routes to the old python uvicorn media-server (MODEL+DEVICE env, no
+    # SERVER_MODE=cpp) instead of cpp_server.
+    def test_single_runner_sdxl_uses_python_server(self):
         model_spec, _, _ = get_runtime_model_spec(
             model="stable-diffusion-xl-base-1.0",
             device="n150",
@@ -1042,13 +1045,12 @@ class TestMediaServerDockerEnvVars:
 
         env_vars = get_media_server_docker_env_vars(model_spec)
 
-        assert env_vars["SERVER_MODE"] == "cpp"
-        assert env_vars["MODEL_SERVICE"] == "image"
-        assert env_vars["MODEL_RUNNER_TYPE"] == "tt_sdxl_generate"
-        assert env_vars["DEVICE_IDS"] == "(0)"
+        assert "SERVER_MODE" not in env_vars
+        assert env_vars["MODEL"] == "stable-diffusion-xl-base-1.0"
+        assert env_vars["DEVICE"] == "n150"
 
     @pytest.mark.parametrize("device", ["galaxy"])
-    def test_multi_runner_sdxl_uses_cpp_server(self, device):
+    def test_multi_runner_sdxl_uses_python_server(self, device):
         model_spec, _, _ = get_runtime_model_spec(
             model="stable-diffusion-xl-base-1.0",
             device=device,
@@ -1056,10 +1058,9 @@ class TestMediaServerDockerEnvVars:
 
         env_vars = get_media_server_docker_env_vars(model_spec)
 
-        assert env_vars["SERVER_MODE"] == "cpp"
-        assert env_vars["MODEL_SERVICE"] == "image"
-        assert env_vars["MODEL_RUNNER_TYPE"] == "tt_sdxl_generate"
-        assert env_vars["DEVICE_IDS"].replace(" ", "").count("(") > 1
+        assert "SERVER_MODE" not in env_vars
+        assert env_vars["MODEL"] == "stable-diffusion-xl-base-1.0"
+        assert env_vars["DEVICE"] == device
 
 
 class TestSecretsHandling:

--- a/workflows/model_specs/dev/image.yaml
+++ b/workflows/model_specs/dev/image.yaml
@@ -10,7 +10,7 @@ templates:
     - stabilityai/stable-diffusion-xl-base-1.0
     - stabilityai/stable-diffusion-xl-base-1.0-img-2-img
   version: "0.11.1"
-  tt_metal_commit: bac8b34
+  tt_metal_commit: 7463e586f3b5
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6

--- a/workflows/model_specs/prod/image.yaml
+++ b/workflows/model_specs/prod/image.yaml
@@ -10,7 +10,7 @@ templates:
     - stabilityai/stable-diffusion-xl-base-1.0
     - stabilityai/stable-diffusion-xl-base-1.0-img-2-img
   version: "0.11.1"
-  tt_metal_commit: bac8b34
+  tt_metal_commit: 7463e586f3b5
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -78,12 +78,19 @@ _CPP_SDXL_DEVICE_DEFAULTS = {
 
 def _is_cpp_media_spec(model_spec) -> bool:
     """True if this MEDIA spec should run on the cpp_server backend."""
-    defaults = _CPP_SDXL_DEVICE_DEFAULTS.get(model_spec.device_type.name.lower())
-    return (
-        model_spec.inference_engine == InferenceEngine.MEDIA.value
-        and model_spec.model_name in _CPP_SDXL_RUNNER_BY_MODEL_NAME
-        and defaults is not None
-    )
+    # REGRESSION TEST: force SDXL back onto the old python uvicorn media-server
+    # (pre-#3391, cpp_server migration 2026-05-15) to A/B the regression seen
+    # between the May 7 and June 2 runs. tt_metal_commit is pinned to
+    # 7463e586f3b5 in image.yaml to match the June 2 run, so only the server
+    # backend differs.
+    # Original body:
+    #   defaults = _CPP_SDXL_DEVICE_DEFAULTS.get(model_spec.device_type.name.lower())
+    #   return (
+    #       model_spec.inference_engine == InferenceEngine.MEDIA.value
+    #       and model_spec.model_name in _CPP_SDXL_RUNNER_BY_MODEL_NAME
+    #       and defaults is not None
+    #   )
+    return False
 
 
 def _get_cpp_media_server_docker_env_vars(model_spec):


### PR DESCRIPTION
## `main`:

p300x2 -> https://github.com/tenstorrent/tt-shield/actions/runs/29617320728/job/88025312524

## `ztorlak/remove-sdxl-code-from-media-server`:

p300x2 -> https://github.com/tenstorrent/tt-shield/actions/runs/29824145793