### PR TITLE
Suppress Drogon Race

### DIFF
--- a/tt-media-server/cpp_server/tsan_suppressions.txt
+++ b/tt-media-server/cpp_server/tsan_suppressions.txt
@@ -35,6 +35,18 @@ signal:trantor::Date::toFormattedString
 race:trantor::TcpServer::stop
 race:TcpServer.cc
 
+# ── drogon/trantor listener teardown at process exit ───────────────────────
+# At static-deinit the HttpAppFramework singleton destroys ListenerManager ->
+# trantor::TcpServer, freeing its per-EventLoop timing-wheel map, while a
+# not-yet-joined "DrogonIoLoop" thread is still lazily inserting a TimingWheel
+# for a late connection. Drogon (1.9.12) exposes no API to join its IO-loop
+# pool before the singleton is destroyed, so this ordering cannot be fixed from
+# application code; it is benign (the process is exiting). The destructor frame
+# symbolizes as `trantor::TcpServer::~TcpServer() <null>` (symbol only, no
+# file), so `race:TcpServer.cc` above does not match it — match by symbol.
+race:trantor::TcpServer::~TcpServer
+race:drogon::ListenerManager::~ListenerManager
+
 # ── trantor::EventLoop test-fixture lifecycle ──────────────────────────────
 # session_manager_test's LoopFixture posts loop->quit() from the main thread
 # while the loop-thread lambda is destructing trantor::EventLoop. The


### PR DESCRIPTION
## Problem
TSan reports a race condition during application shutdown that appears to originate from Drogon's internal code rather than our implementation. Since this issue was not introduced by our changes, this PR adds the race to the list of TSan suppressions to prevent it from affecting test results.

Analysis:
```
At static-deinit, Drogon's HttpAppFramework singleton destroys ListenerManager → trantor::TcpServer (freeing its per-EventLoop timingWheelMap_) while a not-yet-joined IO-loop thread lazily inserts a TimingWheel for a connection that arrived during shutdown. It's a framework member-destruction-ordering / IO-loop-join gap in Drogon 1.9.12, triggered whenever an idle-timeout is set (Drogon's default is 60s, so this is the out-of-the-box behavior) and a connection lands during teardown.
```