### PR TITLE
Improve first-run error messages and add --debug flag

### DIFF
--- a/run.py
+++ b/run.py
@@ -351,6 +351,12 @@ def parse_arguments():
         default=os.getenv("SERVER_TESTS", "false"),
         help="Run server tests using server_tests/run.py (true/false). Default is false.",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Show full Python tracebacks on error instead of plain-English messages (for developers).",
+    )
 
     # SPEC_TESTS workflow arguments (server tests filtering)
     spec_tests_group = parser.add_argument_group(
@@ -693,7 +699,20 @@ def main():
     logger.info(f"Runtime model spec saved to: {json_fpath}")
 
     # validate setup after run logger has been initialized
-    validate_setup(model_spec, runtime_config, json_fpath)
+    try:
+        validate_setup(model_spec, runtime_config, json_fpath)
+    except SystemExit:
+        raise
+    except Exception as exc:
+        if args.debug:
+            raise
+        print(
+            f"\nERROR: Setup validation failed: {exc}\n"
+            "\nRun with --debug to see the full traceback.\n"
+            "If this looks like a bug, please open a GitHub issue.\n",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     setup_config = None
     if runtime_config.docker_server or runtime_config.local_server:
@@ -701,19 +720,32 @@ def main():
             logger.info("Running inference server in Docker container ...")
         else:
             logger.info("Resolving local-server host storage ...")
-        setup_config = setup_host(
-            model_spec=model_spec,
-            jwt_secret=os.getenv("JWT_SECRET"),
-            hf_token=os.getenv("HF_TOKEN"),
-            automatic_setup=os.getenv("AUTOMATIC_HOST_SETUP"),
-            host_volume=runtime_config.host_volume,
-            host_hf_cache=runtime_config.host_hf_cache,
-            host_weights_dir=runtime_config.host_weights_dir,
-            image_user=(
-                runtime_config.image_user if runtime_config.docker_server else None
-            ),
-            local_server=runtime_config.local_server,
-        )
+        try:
+            setup_config = setup_host(
+                model_spec=model_spec,
+                jwt_secret=os.getenv("JWT_SECRET"),
+                hf_token=os.getenv("HF_TOKEN"),
+                automatic_setup=os.getenv("AUTOMATIC_HOST_SETUP"),
+                host_volume=runtime_config.host_volume,
+                host_hf_cache=runtime_config.host_hf_cache,
+                host_weights_dir=runtime_config.host_weights_dir,
+                image_user=(
+                    runtime_config.image_user if runtime_config.docker_server else None
+                ),
+                local_server=runtime_config.local_server,
+            )
+        except SystemExit:
+            raise
+        except Exception as exc:
+            if args.debug:
+                raise
+            print(
+                f"\nERROR: Host setup failed: {exc}\n"
+                "\nRun with --debug to see the full traceback.\n"
+                "If this looks like a bug, please open a GitHub issue.\n",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     # step 4: optionally run inference server
     if runtime_config.docker_server:
@@ -768,7 +800,20 @@ def main():
         run_docker_server(model_spec, runtime_config, setup_config, docker_json_fpath)
     elif runtime_config.local_server:
         logger.info("Running inference server on localhost ...")
-        run_local_server(model_spec, runtime_config, json_fpath, setup_config)
+        try:
+            run_local_server(model_spec, runtime_config, json_fpath, setup_config)
+        except SystemExit:
+            raise
+        except Exception as exc:
+            if args.debug:
+                raise
+            print(
+                f"\nERROR: Local server launch failed: {exc}\n"
+                "\nRun with --debug to see the full traceback.\n"
+                "If this looks like a bug, please open a GitHub issue.\n",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     main_return_code = 0
 

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -684,9 +684,7 @@ class TestRuntimeValidation:
             {mock_model_spec.model_id: mock_model_spec},
         ):
             # Should fail without docker or local server
-            with pytest.raises(
-                ValueError, match="requires --docker-server or --local-server"
-            ):
+            with pytest.raises(SystemExit):
                 validate_runtime_args(mock_model_spec, mock_runtime_config)
 
             # Should pass with docker server
@@ -707,9 +705,7 @@ class TestRuntimeValidation:
             "workflows.validate_setup.MODEL_SPECS",
             {mock_model_spec.model_id: mock_model_spec},
         ):
-            with pytest.raises(
-                AssertionError, match="Cannot run --docker-server and --local-server"
-            ):
+            with pytest.raises(SystemExit):
                 validate_runtime_args(mock_model_spec, mock_runtime_config)
 
 

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -684,7 +684,7 @@ class TestRuntimeValidation:
             {mock_model_spec.model_id: mock_model_spec},
         ):
             # Should fail without docker or local server
-            with pytest.raises(SystemExit):
+            with pytest.raises(ValueError, match="--docker-server"):
                 validate_runtime_args(mock_model_spec, mock_runtime_config)
 
             # Should pass with docker server
@@ -705,7 +705,7 @@ class TestRuntimeValidation:
             "workflows.validate_setup.MODEL_SPECS",
             {mock_model_spec.model_id: mock_model_spec},
         ):
-            with pytest.raises(SystemExit):
+            with pytest.raises(ValueError, match="cannot be used at the same time"):
                 validate_runtime_args(mock_model_spec, mock_runtime_config)
 
 

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -389,8 +389,8 @@ class TestSystemSoftwareValidationCheckFalse:
             mock_run.assert_called_once()
             assert mock_run.call_args[1].get("check", False) is False
 
-    def test_system_validation_raises_on_failure(self):
-        """Test system software validation failure raises SystemExit."""
+    def test_system_validation_raises_valueerror_on_failure(self):
+        """Test system software validation failure raises ValueError."""
         from workflows.validate_setup import validate_local_setup
 
         mock_model_spec = MagicMock()
@@ -417,7 +417,7 @@ class TestSystemSoftwareValidationCheckFalse:
             mock_venv_config.setup.return_value = True
             mock_venv_configs.__getitem__.return_value = mock_venv_config
 
-            with pytest.raises(SystemExit):
+            with pytest.raises(ValueError, match="software validation failed"):
                 validate_local_setup(
                     mock_model_spec, mock_runtime_config, "/fake/json/path"
                 )

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -389,8 +389,8 @@ class TestSystemSoftwareValidationCheckFalse:
             mock_run.assert_called_once()
             assert mock_run.call_args[1].get("check", False) is False
 
-    def test_system_validation_raises_valueerror_on_failure(self):
-        """Test system software validation failure raises ValueError."""
+    def test_system_validation_raises_on_failure(self):
+        """Test system software validation failure raises SystemExit."""
         from workflows.validate_setup import validate_local_setup
 
         mock_model_spec = MagicMock()
@@ -417,9 +417,7 @@ class TestSystemSoftwareValidationCheckFalse:
             mock_venv_config.setup.return_value = True
             mock_venv_configs.__getitem__.return_value = mock_venv_config
 
-            with pytest.raises(
-                ValueError, match="validating system software dependencies failed"
-            ):
+            with pytest.raises(SystemExit):
                 validate_local_setup(
                     mock_model_spec, mock_runtime_config, "/fake/json/path"
                 )

--- a/tests/test_run_local_server.py
+++ b/tests/test_run_local_server.py
@@ -439,7 +439,7 @@ class TestRunLocalServer:
         assert env["MODEL_WEIGHTS_DIR"] == str(weights_dir.resolve())
 
     def test_build_local_server_env_reports_host_user_permission_mismatch(
-        self, tmp_path, capsys
+        self, tmp_path
     ):
         repo_root = tmp_path / "repo"
         entrypoint = repo_root / "vllm-tt-metal" / "src" / "run_vllm_api_server.py"
@@ -469,7 +469,10 @@ class TestRunLocalServer:
             "workflows.run_local_server.ensure_readwriteable_dir",
             side_effect=fail_on_logs,
         ):
-            with pytest.raises(SystemExit):
+            with pytest.raises(
+                PermissionError,
+                match="current host user",
+            ) as exc_info:
                 build_local_server_env(
                     self._make_model_spec(),
                     runtime_config,
@@ -478,9 +481,8 @@ class TestRunLocalServer:
                     repo_root=repo_root,
                 )
 
-        err = capsys.readouterr().err
-        assert "owned by a different user" in err
-        assert "sudo chown -R $(id -u):$(id -g)" in err
+        assert "owned by a different user" in str(exc_info.value)
+        assert "sudo chown -R $(id -u):$(id -g)" in str(exc_info.value)
 
     def test_format_env_exports_only_logs_overrides(self):
         env = {

--- a/tests/test_run_local_server.py
+++ b/tests/test_run_local_server.py
@@ -439,7 +439,7 @@ class TestRunLocalServer:
         assert env["MODEL_WEIGHTS_DIR"] == str(weights_dir.resolve())
 
     def test_build_local_server_env_reports_host_user_permission_mismatch(
-        self, tmp_path
+        self, tmp_path, capsys
     ):
         repo_root = tmp_path / "repo"
         entrypoint = repo_root / "vllm-tt-metal" / "src" / "run_vllm_api_server.py"
@@ -469,10 +469,7 @@ class TestRunLocalServer:
             "workflows.run_local_server.ensure_readwriteable_dir",
             side_effect=fail_on_logs,
         ):
-            with pytest.raises(
-                PermissionError,
-                match="invoking host user.*ignores --image-user",
-            ) as exc_info:
+            with pytest.raises(SystemExit):
                 build_local_server_env(
                     self._make_model_spec(),
                     runtime_config,
@@ -481,10 +478,9 @@ class TestRunLocalServer:
                     repo_root=repo_root,
                 )
 
-        assert "persistent_volume tree was created by Docker or another UID" in str(
-            exc_info.value
-        )
-        assert "sudo chown -R $(id -u):$(id -g)" in str(exc_info.value)
+        err = capsys.readouterr().err
+        assert "owned by a different user" in err
+        assert "sudo chown -R $(id -u):$(id -g)" in err
 
     def test_format_env_exports_only_logs_overrides(self):
         env = {

--- a/tests/test_setup_host.py
+++ b/tests/test_setup_host.py
@@ -699,10 +699,7 @@ class TestSetupHostValidation:
         with patch.dict(
             "workflows.validate_setup.MODEL_SPECS", {mock_spec.model_id: mock_spec}
         ):
-            with pytest.raises(
-                ValueError,
-                match="Only one of --host-volume, --host-hf-cache, --host-weights-dir",
-            ):
+            with pytest.raises(SystemExit):
                 validate_runtime_args(mock_spec, runtime_config)
 
     def test_mutual_exclusivity_host_volume_and_weights_dir(self):
@@ -714,10 +711,7 @@ class TestSetupHostValidation:
         with patch.dict(
             "workflows.validate_setup.MODEL_SPECS", {mock_spec.model_id: mock_spec}
         ):
-            with pytest.raises(
-                ValueError,
-                match="Only one of --host-volume, --host-hf-cache, --host-weights-dir",
-            ):
+            with pytest.raises(SystemExit):
                 validate_runtime_args(mock_spec, runtime_config)
 
     def test_mutual_exclusivity_hf_cache_and_weights_dir(self):
@@ -729,10 +723,7 @@ class TestSetupHostValidation:
         with patch.dict(
             "workflows.validate_setup.MODEL_SPECS", {mock_spec.model_id: mock_spec}
         ):
-            with pytest.raises(
-                ValueError,
-                match="Only one of --host-volume, --host-hf-cache, --host-weights-dir",
-            ):
+            with pytest.raises(SystemExit):
                 validate_runtime_args(mock_spec, runtime_config)
 
     def test_all_three_set_raises(self):
@@ -745,10 +736,7 @@ class TestSetupHostValidation:
         with patch.dict(
             "workflows.validate_setup.MODEL_SPECS", {mock_spec.model_id: mock_spec}
         ):
-            with pytest.raises(
-                ValueError,
-                match="Only one of --host-volume, --host-hf-cache, --host-weights-dir",
-            ):
+            with pytest.raises(SystemExit):
                 validate_runtime_args(mock_spec, runtime_config)
 
     def test_single_option_passes_validation(self):

--- a/tests/test_setup_host.py
+++ b/tests/test_setup_host.py
@@ -699,7 +699,7 @@ class TestSetupHostValidation:
         with patch.dict(
             "workflows.validate_setup.MODEL_SPECS", {mock_spec.model_id: mock_spec}
         ):
-            with pytest.raises(SystemExit):
+            with pytest.raises(ValueError, match="Only one of --host-volume"):
                 validate_runtime_args(mock_spec, runtime_config)
 
     def test_mutual_exclusivity_host_volume_and_weights_dir(self):
@@ -711,7 +711,7 @@ class TestSetupHostValidation:
         with patch.dict(
             "workflows.validate_setup.MODEL_SPECS", {mock_spec.model_id: mock_spec}
         ):
-            with pytest.raises(SystemExit):
+            with pytest.raises(ValueError, match="Only one of --host-volume"):
                 validate_runtime_args(mock_spec, runtime_config)
 
     def test_mutual_exclusivity_hf_cache_and_weights_dir(self):
@@ -723,7 +723,7 @@ class TestSetupHostValidation:
         with patch.dict(
             "workflows.validate_setup.MODEL_SPECS", {mock_spec.model_id: mock_spec}
         ):
-            with pytest.raises(SystemExit):
+            with pytest.raises(ValueError, match="Only one of --host-volume"):
                 validate_runtime_args(mock_spec, runtime_config)
 
     def test_all_three_set_raises(self):
@@ -736,7 +736,7 @@ class TestSetupHostValidation:
         with patch.dict(
             "workflows.validate_setup.MODEL_SPECS", {mock_spec.model_id: mock_spec}
         ):
-            with pytest.raises(SystemExit):
+            with pytest.raises(ValueError, match="Only one of --host-volume"):
                 validate_runtime_args(mock_spec, runtime_config)
 
     def test_single_option_passes_validation(self):

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -203,9 +203,7 @@ class TestValidateBindMountPermissions:
                 "workflows.validate_setup._try_fix_path_permissions_for_uid",
                 return_value=False,
             ):
-                with pytest.raises(
-                    ValueError, match="Bind mount permission check failed"
-                ):
+                with pytest.raises(SystemExit):
                     validate_bind_mount_permissions(args)
         finally:
             os.chmod(d, 0o700)
@@ -238,9 +236,7 @@ class TestValidateBindMountPermissions:
                 "workflows.validate_setup._try_fix_path_permissions_for_uid",
                 return_value=False,
             ):
-                with pytest.raises(
-                    ValueError, match="Bind mount permission check failed"
-                ):
+                with pytest.raises(SystemExit):
                     validate_bind_mount_permissions(args)
         finally:
             os.chmod(d, 0o700)
@@ -261,9 +257,7 @@ class TestValidateBindMountPermissions:
                 "workflows.validate_setup._try_fix_path_permissions_for_uid",
                 return_value=False,
             ):
-                with pytest.raises(
-                    ValueError, match="Bind mount permission check failed"
-                ):
+                with pytest.raises(SystemExit):
                     validate_bind_mount_permissions(args)
         finally:
             os.chmod(d, 0o700)
@@ -292,7 +286,7 @@ class TestValidateBindMountPermissions:
         mode = os.stat(d).st_mode
         assert mode & 0o007 == 0o007
 
-    def test_error_message_includes_fix_guidance(self, tmp_path):
+    def test_error_message_includes_fix_guidance(self, tmp_path, capsys):
         d = tmp_path / "noperm"
         d.mkdir()
         os.chmod(d, 0o500)
@@ -302,8 +296,11 @@ class TestValidateBindMountPermissions:
                 "workflows.validate_setup._try_fix_path_permissions_for_uid",
                 return_value=False,
             ):
-                with pytest.raises(ValueError, match="chmod/chown"):
+                with pytest.raises(SystemExit):
                     validate_bind_mount_permissions(args)
+            err = capsys.readouterr().err
+            assert "chown" in err
+            assert "chmod" in err
         finally:
             os.chmod(d, 0o700)
 
@@ -336,9 +333,7 @@ class TestLocalServerValidation:
             "workflows.validate_setup.MODEL_SPECS",
             {model_spec.model_id: model_spec},
         ):
-            with pytest.raises(
-                ValueError, match="requires --tt-metal-home or TT_METAL_HOME"
-            ):
+            with pytest.raises(SystemExit):
                 validate_runtime_args(model_spec, runtime_config)
 
     def test_runtime_args_allow_tt_metal_home_from_env(self):
@@ -393,7 +388,7 @@ class TestLocalServerValidation:
             },
         )
 
-        with pytest.raises(ValueError, match="python venv interpreter"):
+        with pytest.raises(SystemExit):
             validate_local_server_paths(args)
 
     def test_validate_local_server_paths_requires_cached_hf_snapshot(self, tmp_path):
@@ -420,7 +415,7 @@ class TestLocalServerValidation:
             },
         )
 
-        with pytest.raises(ValueError, match="did not contain a cached snapshot"):
+        with pytest.raises(SystemExit):
             validate_local_server_paths(args)
 
     def test_validate_local_server_paths_accepts_cached_hf_snapshot(self, tmp_path):
@@ -536,7 +531,7 @@ class TestLocalServerValidation:
 
         mock_get_log_dir.return_value = tmp_path / "logs"
 
-        with pytest.raises(ValueError, match="requires the `vllm` Python package"):
+        with pytest.raises(SystemExit):
             validate_local_setup(model_spec, runtime_config, tmp_path / "runtime.json")
 
         mock_ensure_dir.assert_called_once_with(tmp_path / "logs")
@@ -643,10 +638,7 @@ class TestLocalServerValidation:
         with patch(
             "workflows.validate_setup.run_command", side_effect=[0, 1]
         ) as mock_validate_run_command:
-            with pytest.raises(
-                ValueError,
-                match=r"`vllm_tt_plugin` Python package",
-            ):
+            with pytest.raises(SystemExit):
                 validate_local_setup(
                     model_spec, runtime_config, tmp_path / "runtime.json"
                 )
@@ -681,16 +673,16 @@ class TestCheckImageVersionSupported:
 
     def test_pre_0_11_vllm_versions_raise(self):
         for v in ("0.10.9", "0.10.1", "0.10.0", "0.9.0", "0.2.0"):
-            with pytest.raises(RuntimeError, match="not supported"):
+            with pytest.raises(SystemExit):
                 _check_image_version_supported(self._spec(v))
 
-    def test_error_names_exact_tag_to_checkout(self):
+    def test_error_names_exact_tag_to_checkout(self, capsys):
         # The matching tt-inference-server release tag is `v<spec.version>`.
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(SystemExit):
             _check_image_version_supported(self._spec("0.10.1"))
-        msg = str(exc.value)
-        assert "v0.10.1" in msg
-        assert "git checkout v0.10.1" in msg
+        err = capsys.readouterr().err
+        assert "v0.10.1" in err
+        assert "git checkout v0.10.1" in err
 
     def test_unparseable_versions_pass(self):
         # `dev`, `latest`, empty — let the runtime decide, matches main.

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -203,7 +203,7 @@ class TestValidateBindMountPermissions:
                 "workflows.validate_setup._try_fix_path_permissions_for_uid",
                 return_value=False,
             ):
-                with pytest.raises(SystemExit):
+                with pytest.raises(ValueError, match="bind-mounted"):
                     validate_bind_mount_permissions(args)
         finally:
             os.chmod(d, 0o700)
@@ -236,7 +236,7 @@ class TestValidateBindMountPermissions:
                 "workflows.validate_setup._try_fix_path_permissions_for_uid",
                 return_value=False,
             ):
-                with pytest.raises(SystemExit):
+                with pytest.raises(ValueError, match="bind-mounted"):
                     validate_bind_mount_permissions(args)
         finally:
             os.chmod(d, 0o700)
@@ -257,7 +257,7 @@ class TestValidateBindMountPermissions:
                 "workflows.validate_setup._try_fix_path_permissions_for_uid",
                 return_value=False,
             ):
-                with pytest.raises(SystemExit):
+                with pytest.raises(ValueError, match="bind-mounted"):
                     validate_bind_mount_permissions(args)
         finally:
             os.chmod(d, 0o700)
@@ -286,7 +286,7 @@ class TestValidateBindMountPermissions:
         mode = os.stat(d).st_mode
         assert mode & 0o007 == 0o007
 
-    def test_error_message_includes_fix_guidance(self, tmp_path, capsys):
+    def test_error_message_includes_fix_guidance(self, tmp_path):
         d = tmp_path / "noperm"
         d.mkdir()
         os.chmod(d, 0o500)
@@ -296,11 +296,11 @@ class TestValidateBindMountPermissions:
                 "workflows.validate_setup._try_fix_path_permissions_for_uid",
                 return_value=False,
             ):
-                with pytest.raises(SystemExit):
+                with pytest.raises(ValueError) as exc_info:
                     validate_bind_mount_permissions(args)
-            err = capsys.readouterr().err
-            assert "chown" in err
-            assert "chmod" in err
+            msg = str(exc_info.value)
+            assert "chown" in msg
+            assert "chmod" in msg
         finally:
             os.chmod(d, 0o700)
 
@@ -333,7 +333,7 @@ class TestLocalServerValidation:
             "workflows.validate_setup.MODEL_SPECS",
             {model_spec.model_id: model_spec},
         ):
-            with pytest.raises(SystemExit):
+            with pytest.raises(ValueError, match="TT_METAL_HOME"):
                 validate_runtime_args(model_spec, runtime_config)
 
     def test_runtime_args_allow_tt_metal_home_from_env(self):
@@ -388,7 +388,7 @@ class TestLocalServerValidation:
             },
         )
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(ValueError, match="python venv interpreter"):
             validate_local_server_paths(args)
 
     def test_validate_local_server_paths_requires_cached_hf_snapshot(self, tmp_path):
@@ -415,7 +415,7 @@ class TestLocalServerValidation:
             },
         )
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(ValueError, match="cached snapshot"):
             validate_local_server_paths(args)
 
     def test_validate_local_server_paths_accepts_cached_hf_snapshot(self, tmp_path):
@@ -531,7 +531,7 @@ class TestLocalServerValidation:
 
         mock_get_log_dir.return_value = tmp_path / "logs"
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(ValueError, match="vllm Python package"):
             validate_local_setup(model_spec, runtime_config, tmp_path / "runtime.json")
 
         mock_ensure_dir.assert_called_once_with(tmp_path / "logs")
@@ -638,7 +638,7 @@ class TestLocalServerValidation:
         with patch(
             "workflows.validate_setup.run_command", side_effect=[0, 1]
         ) as mock_validate_run_command:
-            with pytest.raises(SystemExit):
+            with pytest.raises(ValueError, match="vllm-tt-plugin"):
                 validate_local_setup(
                     model_spec, runtime_config, tmp_path / "runtime.json"
                 )
@@ -673,16 +673,16 @@ class TestCheckImageVersionSupported:
 
     def test_pre_0_11_vllm_versions_raise(self):
         for v in ("0.10.9", "0.10.1", "0.10.0", "0.9.0", "0.2.0"):
-            with pytest.raises(SystemExit):
+            with pytest.raises(RuntimeError, match="not supported"):
                 _check_image_version_supported(self._spec(v))
 
-    def test_error_names_exact_tag_to_checkout(self, capsys):
+    def test_error_names_exact_tag_to_checkout(self):
         # The matching tt-inference-server release tag is `v<spec.version>`.
-        with pytest.raises(SystemExit):
+        with pytest.raises(RuntimeError) as exc:
             _check_image_version_supported(self._spec("0.10.1"))
-        err = capsys.readouterr().err
-        assert "v0.10.1" in err
-        assert "git checkout v0.10.1" in err
+        msg = str(exc.value)
+        assert "v0.10.1" in msg
+        assert "git checkout v0.10.1" in msg
 
     def test_unparseable_versions_pass(self):
         # `dev`, `latest`, empty — let the runtime decide, matches main.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -494,8 +494,8 @@ class TestHostSetupIntegration:
             host_volume=host_volume,
         )
 
-        # Should raise assertion error due to insufficient disk space
-        with pytest.raises(AssertionError, match="Insufficient disk space"):
+        # Should raise due to insufficient disk space
+        with pytest.raises(ValueError, match="disk space"):
             manager.setup_model_environment()
 
     def test_hf_token_validation_failure(
@@ -519,8 +519,8 @@ class TestHostSetupIntegration:
             hf_token="invalid_token",
         )
 
-        # Should raise assertion error due to invalid token
-        with pytest.raises(AssertionError, match="HF_TOKEN validation failed"):
+        # Should raise due to invalid token
+        with pytest.raises(ValueError, match="HF_TOKEN validation"):
             manager.setup_model_environment()
 
 
@@ -635,8 +635,9 @@ class TestMainWorkflowIntegration:
         ), patch("run.run_workflows") as mock_run_workflows, patch(
             "workflows.utils.get_default_workflow_root_log_dir", return_value=temp_dir
         ), patch("workflows.log_setup.setup_run_logger"):
-            with pytest.raises(RuntimeError, match="validation failed"):
+            with pytest.raises(SystemExit) as exc_info:
                 main()
+            assert exc_info.value.code == 1
 
         assert not mock_run_workflows.called
 
@@ -661,8 +662,9 @@ class TestMainWorkflowIntegration:
         ), patch("run.run_workflows") as mock_run_workflows, patch(
             "workflows.utils.get_default_workflow_root_log_dir", return_value=temp_dir
         ), patch("workflows.log_setup.setup_run_logger"):
-            with pytest.raises(RuntimeError, match="host setup failed"):
+            with pytest.raises(SystemExit) as exc_info:
                 main()
+            assert exc_info.value.code == 1
 
         assert not mock_run_workflows.called
 

--- a/workflows/run_local_server.py
+++ b/workflows/run_local_server.py
@@ -22,6 +22,7 @@ from workflows.utils import (
     get_default_workflow_root_log_dir,
     get_repo_root_path,
     run_command,
+    user_error,
 )
 from workflows.workflow_types import DeviceTypes, InferenceEngine, WorkflowType
 
@@ -114,14 +115,16 @@ def _raise_local_server_storage_permission_error(path: Path, error: PermissionEr
     host_uid = os.getuid() if hasattr(os, "getuid") else "unknown"
     uid_suffix = f" (uid={host_uid})" if isinstance(host_uid, int) else ""
     chown_command = f"sudo chown -R $(id -u):$(id -g) {shlex.quote(str(path.parent))}"
-    raise PermissionError(
-        f"Local server storage path is not writable: {path}. "
-        f"--local-server runs as the invoking host user{uid_suffix} and ignores "
-        "--image-user. This usually means the existing persistent_volume tree was "
-        "created by Docker or another UID. Try "
-        f"`{chown_command}` or adjust the path with chmod, or remove the stale "
-        "directory and rerun."
-    ) from error
+    user_error(
+        f"ERROR: The local server cannot write to its storage directory.\n"
+        f"  Path: {path}\n"
+        f"  This script runs as the current host user{uid_suffix}, but the directory\n"
+        f"  appears to be owned by a different user (e.g. created by Docker).\n"
+        "\nTo fix this:\n"
+        f"  Option A — fix ownership:  {chown_command}\n"
+        f"  Option B — remove the stale directory and rerun: rm -rf {path.parent}\n"
+        "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+    )
 
 
 def ensure_local_server_storage_paths(
@@ -180,9 +183,15 @@ def build_local_server_env(
         )
     elif setup_config.host_hf_cache:
         if not setup_config.host_model_weights_snapshot_dir:
-            raise ValueError(
-                f"Could not resolve a Hugging Face snapshot for {model_spec.hf_weights_repo} "
-                f"under {setup_config.host_hf_cache}"
+            user_error(
+                f"ERROR: Could not find a downloaded snapshot for '{model_spec.hf_weights_repo}' in the HuggingFace cache.\n"
+                f"Cache directory: {setup_config.host_hf_cache}\n"
+                "\nTo fix this:\n"
+                f"  1. Download the model weights: huggingface-cli download {model_spec.hf_weights_repo}\n"
+                f"     (ensure HF_HOME or HF_CACHE_DIR points to {setup_config.host_hf_cache})\n"
+                "  2. Or remove --host-hf-cache to let the server handle weights automatically\n"
+                "  3. Re-run this script\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
             )
         hf_home = Path(setup_config.host_hf_cache).resolve()
         snapshot_dir = Path(setup_config.host_model_weights_snapshot_dir).resolve()
@@ -208,8 +217,13 @@ def generate_local_run_command(
     model_spec, runtime_config, json_fpath, setup_config: SetupConfig, repo_root=None
 ):
     if model_spec.inference_engine != InferenceEngine.VLLM.value:
-        raise NotImplementedError(
-            "--local-server currently supports only vLLM-backed model specs."
+        user_error(
+            f"ERROR: --local-server only supports vLLM-backed models, but '{model_spec.model_name}' uses engine '{model_spec.inference_engine}'.\n"
+            "Local server mode is not yet implemented for other inference engines.\n"
+            "\nTo fix this:\n"
+            "  1. Use --docker-server instead, OR\n"
+            "  2. Choose a vLLM-backed model\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
         )
 
     paths = get_local_server_paths(runtime_config, repo_root=repo_root)
@@ -287,8 +301,13 @@ def install_local_server_requirements(runtime_config, repo_root=None):
     paths = get_local_server_paths(runtime_config, repo_root=repo_root)
     requirements_path = paths["requirements_path"]
     if not requirements_path.exists():
-        raise FileNotFoundError(
-            f"Missing local server requirements file: {requirements_path}"
+        user_error(
+            f"ERROR: The local server requirements file is missing: {requirements_path}\n"
+            "This file is part of the tt-inference-server repository and should exist after cloning.\n"
+            "\nTo fix this:\n"
+            "  1. Verify you are running from the correct tt-inference-server directory\n"
+            "  2. Re-clone or restore the repository if the file was accidentally deleted\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
         )
 
     install_command = (
@@ -359,7 +378,16 @@ def run_local_command(
         if process.poll() is not None:
             logger.error(f"Local server process {process_name} exited before startup.")
             logger.error(f"Local server logs are streamed to: {local_log_file_path}")
-            raise RuntimeError("Local server process failed to start.")
+            user_error(
+                "ERROR: The local inference server process exited immediately after starting.\n"
+                "This usually means a configuration error, missing library, or driver issue.\n"
+                f"\nTo diagnose:\n"
+                f"  1. Check the server log for the error:\n"
+                f"     cat {local_log_file_path}\n"
+                "  2. Make sure TT_METAL_HOME is built correctly and the device is accessible\n"
+                "  3. Re-run this script with --debug for the full Python traceback\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
         time.sleep(0.1)
 
     skip_workflows = {WorkflowType.SERVER, WorkflowType.REPORTS}

--- a/workflows/run_local_server.py
+++ b/workflows/run_local_server.py
@@ -115,7 +115,7 @@ def _raise_local_server_storage_permission_error(path: Path, error: PermissionEr
     host_uid = os.getuid() if hasattr(os, "getuid") else "unknown"
     uid_suffix = f" (uid={host_uid})" if isinstance(host_uid, int) else ""
     chown_command = f"sudo chown -R $(id -u):$(id -g) {shlex.quote(str(path.parent))}"
-    user_error(
+    raise PermissionError(
         f"ERROR: The local server cannot write to its storage directory.\n"
         f"  Path: {path}\n"
         f"  This script runs as the current host user{uid_suffix}, but the directory\n"
@@ -124,7 +124,7 @@ def _raise_local_server_storage_permission_error(path: Path, error: PermissionEr
         f"  Option A — fix ownership:  {chown_command}\n"
         f"  Option B — remove the stale directory and rerun: rm -rf {path.parent}\n"
         "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
-    )
+    ) from error
 
 
 def ensure_local_server_storage_paths(

--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -221,7 +221,7 @@ def http_request(
     except urllib.error.HTTPError as e:
         return e.read(), e.getcode(), dict(e.headers)
     except Exception as e:
-        user_error(
+        raise RuntimeError(
             f"ERROR: Could not reach {url} ({type(e).__name__}: {e})\n"
             "A network request to HuggingFace failed before a response was received.\n"
             "\nTo fix this:\n"
@@ -229,7 +229,7 @@ def http_request(
             "  2. Check that https://huggingface.co is reachable from this host\n"
             "  3. If you are behind a proxy, set HTTPS_PROXY and re-run this script\n"
             "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
-        )
+        ) from e
 
 
 class HostSetupManager:

--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -27,6 +27,7 @@ from workflows.model_spec import ModelSpec
 from workflows.utils import (
     get_default_persistent_volume_root,
     resolve_hf_snapshot_dir,
+    user_error,
 )
 from workflows.validate_setup import _try_fix_path_permissions_for_uid
 from workflows.workflow_types import ModelSource, WorkflowVenvType
@@ -155,7 +156,15 @@ class SetupConfig:
         try:
             ModelSource(self.model_source)
         except ValueError:
-            raise ValueError("⛔ Invalid model source.")
+            valid = ", ".join(s.value for s in ModelSource)
+            user_error(
+                f"ERROR: '{self.model_source}' is not a valid model source.\n"
+                f"Valid choices are: {valid}\n"
+                "\nTo fix this:\n"
+                f"  1. Set MODEL_SOURCE to one of: {valid}\n"
+                "  2. Re-run this script\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
 
     def update_host_model_weights_snapshot_dir(
         self, host_model_weights_snapshot_dir, repo_path_filter=None
@@ -212,8 +221,15 @@ def http_request(
     except urllib.error.HTTPError as e:
         return e.read(), e.getcode(), dict(e.headers)
     except Exception as e:
-        logger.error(f"⛔ Error making {method} request to {url}: {e}")
-        raise Exception from e
+        user_error(
+            f"ERROR: Could not reach {url} ({type(e).__name__}: {e})\n"
+            "A network request to HuggingFace failed before a response was received.\n"
+            "\nTo fix this:\n"
+            "  1. Check your internet connection\n"
+            "  2. Check that https://huggingface.co is reachable from this host\n"
+            "  3. If you are behind a proxy, set HTTPS_PROXY and re-run this script\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+        )
 
 
 class HostSetupManager:
@@ -325,7 +341,15 @@ class HostSetupManager:
             logger.info("Assuming that server self-provides the weights.")
             return True
         else:
-            raise ValueError("⛔ Invalid model source.")
+            valid = ", ".join(s.value for s in ModelSource)
+            user_error(
+                f"ERROR: '{self.setup_config.model_source}' is not a valid model source.\n"
+                f"Valid choices are: {valid}\n"
+                "\nTo fix this:\n"
+                f"  1. Set MODEL_SOURCE to one of: {valid}\n"
+                "  2. Re-run this script\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
 
     def check_disk_space(self) -> bool:
         if self.setup_config.model_source != ModelSource.HUGGINGFACE.value:
@@ -378,7 +402,16 @@ class HostSetupManager:
         self.hf_token = self.hf_token or os.getenv("HF_TOKEN", "")
         if not self.hf_token and not self.automatic:
             self.hf_token = getpass.getpass("Enter your HF_TOKEN: ").strip()
-        assert self.check_hf_access(self.hf_token), "⛔ HF_TOKEN validation failed."
+        if not self.check_hf_access(self.hf_token):
+            user_error(
+                "ERROR: HF_TOKEN validation failed.\n"
+                "The token was either missing, invalid, or rejected by HuggingFace.\n"
+                "\nTo fix this:\n"
+                "  1. Go to https://huggingface.co/settings/tokens and create or copy a token\n"
+                "  2. Run: export HF_TOKEN=your_token_here\n"
+                "  3. Re-run this script\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
 
         if self.setup_config.host_hf_cache:
             hf_home = Path(self.setup_config.host_hf_cache)
@@ -389,14 +422,19 @@ class HostSetupManager:
 
     def check_hf_access(self, token: str) -> int:
         if not token or not token.startswith("hf_"):
-            logger.error("⛔ Invalid HF_TOKEN.")
+            logger.debug(
+                "HF_TOKEN is missing or has an unexpected format (expected it to start with 'hf_')."
+            )
             return False
         data, status, _ = http_request(
             "https://huggingface.co/api/whoami-v2",
             headers={"Authorization": f"Bearer {token}"},
         )
         if status != 200:
-            logger.error("⛔ HF_TOKEN rejected by Hugging Face.")
+            logger.debug(
+                "HuggingFace rejected the HF_TOKEN (HTTP %d).",
+                status,
+            )
             return False
         model_url = (
             f"https://huggingface.co/api/models/{self.model_spec.hf_weights_repo}"
@@ -407,28 +445,47 @@ class HostSetupManager:
         try:
             json_data = json.loads(data.decode("utf-8"))
         except json.JSONDecodeError:
-            logger.error("⛔ Invalid JSON response from Hugging Face.")
+            logger.debug(
+                "Received an unexpected response from the HuggingFace API (not valid JSON)."
+            )
             return False
         siblings = json_data.get("siblings", [])
         if not siblings:
-            logger.error("⛔ No files found in repository.")
+            logger.debug(
+                "The HuggingFace repository '%s' appears to have no files.",
+                self.model_spec.hf_weights_repo,
+            )
             return False
         first_file = siblings[0].get("rfilename")
         if not first_file:
-            logger.error("⛔ Unexpected repository structure.")
+            logger.debug(
+                "Unexpected structure in the HuggingFace repository response for '%s'.",
+                self.model_spec.hf_weights_repo,
+            )
             return False
         head_url = f"https://huggingface.co/{self.model_spec.hf_weights_repo}/resolve/main/{first_file}"
         _, _, head_headers = http_request(
             head_url, method="HEAD", headers={"Authorization": f"Bearer {token}"}
         )
         if head_headers.get("x-error-code"):
-            logger.error("⛔ The model is gated and you don't have access.")
+            logger.debug(
+                "Access to model '%s' was denied — this model is gated.",
+                self.model_spec.hf_weights_repo,
+            )
             return False
         logger.info("✅ HF_TOKEN is valid.")
         return True
 
     def setup_model_environment(self):
-        assert self.check_ram(), "⛔ Insufficient host RAM."
+        if not self.check_ram():
+            user_error(
+                f"ERROR: This host does not have enough RAM to run the model '{self.model_spec.model_name}'.\n"
+                f"Required: {self.model_spec.min_ram_gb} GB  —  see log above for the amount detected.\n"
+                "\nTo fix this:\n"
+                "  1. Free up RAM by stopping other processes, or\n"
+                "  2. Use a smaller model that fits in the available memory\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
 
         if not self.automatic and os.getenv("MODEL_SOURCE") is None:
             print("\nHow do you want to provide a model?")
@@ -441,16 +498,28 @@ class HostSetupManager:
             elif choice == "2":
                 self.setup_config.model_source = ModelSource.LOCAL.value
             else:
-                raise ValueError("⛔ Invalid model source choice.")
+                user_error(
+                    f"ERROR: '{choice}' is not a valid choice for the model source.\n"
+                    "Please enter '1' for HuggingFace or '2' for a local folder.\n"
+                    "\nTo fix this:\n"
+                    "  1. Re-run this script and enter 1 or 2 when prompted\n"
+                    "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+                )
 
         if self.setup_config.model_source == ModelSource.HUGGINGFACE.value:
             self.get_hf_env_vars()
         elif self.setup_config.model_source == ModelSource.LOCAL.value:
             if self.automatic:
                 _host_model_weights_mount_dir = os.getenv("MODEL_WEIGHTS_DIR")
-                assert _host_model_weights_mount_dir, (
-                    "⛔ MODEL_WEIGHTS_DIR environment variable is required for local model source in automatic mode."
-                )
+                if not _host_model_weights_mount_dir:
+                    user_error(
+                        "ERROR: MODEL_WEIGHTS_DIR is not set but is required when using a local model source in automatic mode.\n"
+                        "In automatic mode the script cannot prompt for the weights directory interactively.\n"
+                        "\nTo fix this:\n"
+                        "  1. Run: export MODEL_WEIGHTS_DIR=/path/to/your/weights\n"
+                        "  2. Re-run this script\n"
+                        "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+                    )
             else:
                 _host_model_weights_mount_dir = (
                     os.getenv("MODEL_WEIGHTS_DIR")
@@ -459,14 +528,31 @@ class HostSetupManager:
             self.setup_config.update_host_model_weights_mount_dir(
                 Path(_host_model_weights_mount_dir)
             )
-        assert self.check_disk_space(), "⛔ Insufficient disk space."
+        if not self.check_disk_space():
+            user_error(
+                f"ERROR: Not enough disk space to download weights for '{self.model_spec.model_name}'.\n"
+                f"Required: {self.model_spec.min_disk_gb} GB free  —  see log above for the amount detected.\n"
+                "\nTo fix this:\n"
+                "  1. Free up disk space on the target volume, or\n"
+                "  2. Point to a volume with more free space using --host-volume or --host-hf-cache\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
 
         if not self.jwt_secret:
             self.jwt_secret = os.getenv("JWT_SECRET", "")
         if not self.jwt_secret and not self.automatic:
             self.jwt_secret = getpass.getpass("Enter your JWT_SECRET: ").strip()
 
-        assert self.jwt_secret, "⛔ JWT_SECRET cannot be empty."
+        if not self.jwt_secret:
+            user_error(
+                "ERROR: JWT_SECRET is empty.\n"
+                "A non-empty secret is required to sign API authentication tokens.\n"
+                "\nTo fix this:\n"
+                "  1. Generate a secret: python3 -c \"import secrets; print(secrets.token_hex(32))\"\n"
+                "  2. Run: export JWT_SECRET=<the generated secret>\n"
+                "  3. Re-run this script\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
 
     def repack_weights(self, source_dir: Path, target_dir: Path):
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -504,7 +590,15 @@ class HostSetupManager:
         )
         repack_url = "https://github.com/tenstorrent/tt-metal/raw/refs/tags/v0.56.0-rc47/models/demos/t3000/llama2_70b/scripts/repack_weights.py"
         data, status, _ = http_request(repack_url)
-        assert status == 200, "⛔ Failed to download repack_weights.py"
+        if status != 200:
+            user_error(
+                f"ERROR: Failed to download the weight repacking script (HTTP {status}).\n"
+                "The script is needed to convert weights to the tt-metal format.\n"
+                "\nTo fix this:\n"
+                "  1. Check your internet connection\n"
+                "  2. Re-run this script\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
         repack_script = Path("repack_weights.py")
         with repack_script.open("wb") as f:
             f.write(data)
@@ -539,16 +633,31 @@ class HostSetupManager:
 
         assert self.hf_token, "⛔ HF_TOKEN not set."
         if self.model_spec.repacked == 1:
-            raise ValueError("⛔ Repacked models are not supported for Hugging Face.")
+            user_error(
+                f"ERROR: Model '{self.model_spec.model_name}' uses repacked weights, which cannot be downloaded directly from HuggingFace.\n"
+                "Repacked weight formats must be prepared locally before use.\n"
+                "\nTo fix this:\n"
+                "  1. Download the raw weights manually: huggingface-cli download " + self.model_spec.hf_weights_repo + "\n"
+                "  2. Repack them following the instructions in vllm-tt-metal/README.md\n"
+                "  3. Use --host-weights-dir to point at the repacked directory\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
         # setup venv using uv
         venv_config = VENV_CONFIGS[WorkflowVenvType.HF_SETUP]
         venv_config.setup(model_spec=self.model_spec)
         os.environ["HF_HUB_DOWNLOAD_TIMEOUT"] = "60"
         os.environ["HF_TOKEN"] = self.hf_token
         hf_exec = venv_config.venv_path / "bin" / "hf"
-        assert hf_exec.exists(), (
-            f"⛔ 'hf' CLI not found at: {hf_exec}. Check HF_SETUP venv installation."
-        )
+        if not hf_exec.exists():
+            user_error(
+                f"ERROR: The 'hf' CLI tool was not found after setting up the HF venv.\n"
+                f"Expected at: {hf_exec}\n"
+                "\nTo fix this:\n"
+                "  1. Delete the HF venv and let it be recreated: rm -rf .workflow_venvs/hf_setup\n"
+                "  2. Re-run this script\n"
+                "  3. If the problem persists, run with --debug for the full traceback\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
         hf_repo = self.model_spec.hf_weights_repo
         if self.setup_config.host_hf_cache:
             os.environ["HOST_HF_HOME"] = self.setup_config.host_hf_cache
@@ -563,7 +672,16 @@ class HostSetupManager:
             logger.info(f"Downloading model to host HF cache: {hf_repo}")
             logger.info(f"Command: {shlex.join(cmd)}")
             result = subprocess.run(cmd)
-            assert result.returncode == 0, f"⛔ Error during: {' '.join(cmd)}"
+            if result.returncode != 0:
+                user_error(
+                    f"ERROR: Downloading model weights from HuggingFace failed.\n"
+                    f"Repository: {hf_repo}\n"
+                    "\nTo fix this:\n"
+                    "  1. Check your HF_TOKEN is valid: huggingface-cli whoami\n"
+                    "  2. Check your internet connection\n"
+                    "  3. Retry: the download may have been interrupted\n"
+                    "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+                )
             snapshot_dir = resolve_hf_snapshot_dir(
                 self.model_spec.hf_weights_repo, Path(self.setup_config.host_hf_cache)
             )
@@ -594,7 +712,18 @@ class HostSetupManager:
         logger.info(f"Downloading model to host volume: {hf_repo}")
         logger.info(f"Command: {shlex.join(cmd)}")
         result = subprocess.run(cmd)
-        assert result.returncode == 0, f"⛔ Error during: {' '.join(cmd)}"
+        if result.returncode != 0:
+            user_error(
+                f"ERROR: Downloading model weights from HuggingFace to the host volume failed.\n"
+                f"Repository: {hf_repo}\n"
+                f"Target directory: {host_weights_dir}\n"
+                "\nTo fix this:\n"
+                "  1. Check your HF_TOKEN is valid: huggingface-cli whoami\n"
+                "  2. Check your internet connection\n"
+                "  3. Check that the target directory is writable\n"
+                "  4. Retry: the download may have been interrupted\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
         logger.info(f"✅ Using weights directory: {host_weights_dir}")
 
     def setup_weights_local(self):
@@ -604,7 +733,15 @@ class HostSetupManager:
             )
             self.check_model_weights_dir(self.setup_config.host_model_weights_mount_dir)
         else:
-            raise ValueError("⛔ Weights directory does not exist.")
+            user_error(
+                f"ERROR: The local weights directory does not exist: {self.setup_config.host_model_weights_mount_dir}\n"
+                "The MODEL_WEIGHTS_DIR path must point to a directory containing model weights.\n"
+                "\nTo fix this:\n"
+                "  1. Check that the path is correct: ls " + str(self.setup_config.host_model_weights_mount_dir) + "\n"
+                "  2. Update MODEL_WEIGHTS_DIR or --host-weights-dir to the correct path\n"
+                "  3. Re-run this script\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
 
     def make_host_dirs(self):
         dirs_to_create = [
@@ -744,6 +881,12 @@ def main():
         help="Model implementation to use",
         default=os.getenv("MODEL_IMPL", "tt-transformers"),
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Show full Python tracebacks on error instead of plain-English messages (for developers).",
+    )
 
     args = parser.parse_args()
 
@@ -805,4 +948,17 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as exc:
+        if "--debug" in sys.argv:
+            raise
+        print(
+            f"\nERROR: An unexpected error occurred: {exc}\n"
+            "\nRun with --debug to see the full traceback.\n"
+            "If this looks like a bug, please open a GitHub issue.\n",
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -548,7 +548,7 @@ class HostSetupManager:
                 "ERROR: JWT_SECRET is empty.\n"
                 "A non-empty secret is required to sign API authentication tokens.\n"
                 "\nTo fix this:\n"
-                "  1. Generate a secret: python3 -c \"import secrets; print(secrets.token_hex(32))\"\n"
+                '  1. Generate a secret: python3 -c "import secrets; print(secrets.token_hex(32))"\n'
                 "  2. Run: export JWT_SECRET=<the generated secret>\n"
                 "  3. Re-run this script\n"
                 "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
@@ -637,7 +637,9 @@ class HostSetupManager:
                 f"ERROR: Model '{self.model_spec.model_name}' uses repacked weights, which cannot be downloaded directly from HuggingFace.\n"
                 "Repacked weight formats must be prepared locally before use.\n"
                 "\nTo fix this:\n"
-                "  1. Download the raw weights manually: huggingface-cli download " + self.model_spec.hf_weights_repo + "\n"
+                "  1. Download the raw weights manually: huggingface-cli download "
+                + self.model_spec.hf_weights_repo
+                + "\n"
                 "  2. Repack them following the instructions in vllm-tt-metal/README.md\n"
                 "  3. Use --host-weights-dir to point at the repacked directory\n"
                 "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
@@ -737,7 +739,9 @@ class HostSetupManager:
                 f"ERROR: The local weights directory does not exist: {self.setup_config.host_model_weights_mount_dir}\n"
                 "The MODEL_WEIGHTS_DIR path must point to a directory containing model weights.\n"
                 "\nTo fix this:\n"
-                "  1. Check that the path is correct: ls " + str(self.setup_config.host_model_weights_mount_dir) + "\n"
+                "  1. Check that the path is correct: ls "
+                + str(self.setup_config.host_model_weights_mount_dir)
+                + "\n"
                 "  2. Update MODEL_WEIGHTS_DIR or --host-weights-dir to the correct path\n"
                 "  3. Re-run this script\n"
                 "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"

--- a/workflows/utils.py
+++ b/workflows/utils.py
@@ -10,6 +10,7 @@ import os
 import re
 import shlex
 import subprocess
+import sys
 import tempfile
 import threading
 import uuid
@@ -17,6 +18,12 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
+
+
+def user_error(message: str) -> None:
+    """Print a plain-English error block and exit with code 1."""
+    print(f"\n{message}\n", file=sys.stderr)
+    raise SystemExit(1)
 
 # SDXL num prompts limits
 SDXL_DEFAULT_NUM_PROMPTS = 100

--- a/workflows/utils.py
+++ b/workflows/utils.py
@@ -25,6 +25,7 @@ def user_error(message: str) -> None:
     print(f"\n{message}\n", file=sys.stderr)
     raise SystemExit(1)
 
+
 # SDXL num prompts limits
 SDXL_DEFAULT_NUM_PROMPTS = 100
 SDXL_LOWER_BOUND_NUM_PROMPTS = 2

--- a/workflows/utils.py
+++ b/workflows/utils.py
@@ -10,7 +10,6 @@ import os
 import re
 import shlex
 import subprocess
-import sys
 import tempfile
 import threading
 import uuid
@@ -21,9 +20,14 @@ logger = logging.getLogger(__name__)
 
 
 def user_error(message: str) -> None:
-    """Print a plain-English error block and exit with code 1."""
-    print(f"\n{message}\n", file=sys.stderr)
-    raise SystemExit(1)
+    """Raise a plain-English ValueError for user-fixable errors.
+
+    Library functions call this to signal a misconfiguration.  The
+    top-level entry-point (run.py / setup_host.py main()) catches
+    ValueError and either prints it cleanly (default) or re-raises with
+    a full traceback when --debug is set.
+    """
+    raise ValueError(message)
 
 
 # SDXL num prompts limits

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -21,6 +21,7 @@ from workflows.utils import (
     parse_version_tuple,
     resolve_hf_snapshot_dir,
     run_command,
+    user_error,
 )
 from workflows.workflow_types import (
     DeviceTypes,
@@ -60,11 +61,13 @@ def _check_image_version_supported(model_spec):
     if parsed < MIN_SUPPORTED_IMAGE_VERSION:
         min_str = ".".join(str(p) for p in MIN_SUPPORTED_IMAGE_VERSION)
         tag = f"v{model_spec.version}"
-        raise RuntimeError(
-            f"⛔ Image v{model_spec.version} is not supported in this "
-            f"version of run.py (need v{min_str}+). Check out the matching "
-            f"release tag {tag} and re-run:\n"
-            f"    git checkout {tag}"
+        user_error(
+            f"ERROR: Docker image v{model_spec.version} is not supported by this version of run.py.\n"
+            f"This run.py requires vLLM image v{min_str} or newer (the Docker interface changed in v{min_str}).\n"
+            f"\nTo fix this:\n"
+            f"  1. Check out the matching release tag: git checkout {tag}\n"
+            f"  2. Re-run this script\n"
+            f"\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
         )
 
 
@@ -74,60 +77,114 @@ def validate_runtime_args(model_spec, runtime_config):
 
     if not args.device:
         # TODO: detect phy device
-        raise NotImplementedError("Device detection not implemented yet")
+        user_error(
+            "ERROR: No device specified and automatic device detection is not yet implemented.\n"
+            "You must tell run.py which Tenstorrent device to target.\n"
+            "\nTo fix this:\n"
+            "  1. Add --tt-device <device> to your command (e.g. --tt-device n150)\n"
+            "  2. Re-run this script\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+        )
 
     model_id = model_spec.model_id
 
     # Check if the model_id exists in MODEL_SPECS (this validates device support)
     if model_id not in MODEL_SPECS:
-        raise ValueError(
-            f"model:={runtime_config.model} does not support device:={runtime_config.device}"
+        user_error(
+            f"ERROR: Model '{runtime_config.model}' does not support device '{runtime_config.device}'.\n"
+            "This combination is not listed in the supported model specs.\n"
+            "\nTo fix this:\n"
+            "  1. Run: python run.py --help  to see the list of supported --model / --tt-device pairs\n"
+            "  2. Choose a supported combination and re-run this script\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
         )
 
     _check_image_version_supported(model_spec)
 
-    assert not (args.docker_server and args.local_server), (
-        "Cannot run --docker-server and --local-server"
-    )
+    if args.docker_server and args.local_server:
+        user_error(
+            "ERROR: --docker-server and --local-server cannot be used at the same time.\n"
+            "These flags are mutually exclusive — pick one mode.\n"
+            "\nTo fix this:\n"
+            "  1. Use --docker-server to run inside a Docker container, OR\n"
+            "  2. Use --local-server to run directly on the host\n"
+            "  3. Re-run this script with only one of those flags\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+        )
 
     if workflow_type == WorkflowType.EVALS:
-        assert model_spec.model_name in EVAL_CONFIGS, (
-            f"Model:={model_spec.model_name} not found in EVAL_CONFIGS"
-        )
+        if model_spec.model_name not in EVAL_CONFIGS:
+            user_error(
+                f"ERROR: Model '{model_spec.model_name}' does not have an eval configuration.\n"
+                "The --workflow evals mode requires a config entry in EVAL_CONFIGS.\n"
+                "\nTo fix this:\n"
+                "  1. Choose a model that supports evals (run python run.py --help for the list)\n"
+                "  2. Or use a different --workflow\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
     if workflow_type == WorkflowType.BENCHMARKS:
         if os.getenv("OVERRIDE_BENCHMARKS"):
             logger.warning("OVERRIDE_BENCHMARKS is active, using override benchmarks")
-        assert model_spec.model_id in BENCHMARK_CONFIGS, (
-            f"Model:={model_spec.model_name} not found in BENCHMARKS_CONFIGS"
-        )
+        if model_spec.model_id not in BENCHMARK_CONFIGS:
+            user_error(
+                f"ERROR: Model '{model_spec.model_name}' does not have a benchmark configuration.\n"
+                "The --workflow benchmarks mode requires a config entry in BENCHMARK_CONFIGS.\n"
+                "\nTo fix this:\n"
+                "  1. Choose a model that supports benchmarks (run python run.py --help for the list)\n"
+                "  2. Or use a different --workflow\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
     if workflow_type == WorkflowType.STRESS_TESTS:
         pass  # Model support already validated via MODEL_SPECS check
 
     if workflow_type == WorkflowType.TESTS:
-        assert model_spec.model_name in TEST_CONFIGS, (
-            f"Model:={model_spec.model_name} not found in TEST_CONFIGS"
-        )
+        if model_spec.model_name not in TEST_CONFIGS:
+            user_error(
+                f"ERROR: Model '{model_spec.model_name}' does not have a test configuration.\n"
+                "The --workflow tests mode requires a config entry in TEST_CONFIGS.\n"
+                "\nTo fix this:\n"
+                "  1. Choose a model that supports tests (run python run.py --help for the list)\n"
+                "  2. Or use a different --workflow\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
     if workflow_type == WorkflowType.REPORTS:
         pass
     if workflow_type == WorkflowType.SERVER:
         if not (args.docker_server or args.local_server):
-            raise ValueError(
-                f"Workflow {args.workflow} requires --docker-server or --local-server"
+            user_error(
+                f"ERROR: The '{args.workflow}' workflow requires a server mode flag.\n"
+                "You must tell run.py where to run the inference server.\n"
+                "\nTo fix this:\n"
+                "  1. Add --docker-server to run inside a Docker container, OR\n"
+                "  2. Add --local-server to run directly on the host\n"
+                "  3. Re-run this script\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
             )
         if (
             args.local_server
             and model_spec.inference_engine != InferenceEngine.VLLM.value
         ):
-            raise NotImplementedError(
-                "--local-server currently supports only vLLM-backed model specs"
+            user_error(
+                f"ERROR: --local-server only supports vLLM-backed models, but '{model_spec.model_name}' uses engine '{model_spec.inference_engine}'.\n"
+                "Local server mode is not yet implemented for other inference engines.\n"
+                "\nTo fix this:\n"
+                "  1. Use --docker-server instead, OR\n"
+                "  2. Choose a vLLM-backed model\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
             )
 
         # For partitioning Galaxy per tray as T3K
         # TODO: Add a check to verify whether these devices belong to the same tray
         if DeviceTypes.from_string(args.device) == DeviceTypes.GALAXY_T3K:
             if not args.device_id or len(args.device_id) != 8:
-                raise ValueError(
-                    "Galaxy T3K requires exactly 8 device IDs specified with --device-id (e.g. '0,1,2,3,4,5,6,7'). These must be devices within the same tray."
+                user_error(
+                    "ERROR: Galaxy T3K requires exactly 8 device IDs but the wrong number was specified.\n"
+                    "Each T3K tray contains 8 Tenstorrent devices that must all be listed.\n"
+                    "\nTo fix this:\n"
+                    "  1. Run: tt-smi  to list the PCI device indices available on this host\n"
+                    "  2. Add --device-id 0,1,2,3,4,5,6,7  (using the 8 indices from the same tray)\n"
+                    "  3. Re-run this script\n"
+                    "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
                 )
 
     if workflow_type == WorkflowType.RELEASE:
@@ -135,22 +192,45 @@ def validate_runtime_args(model_spec, runtime_config):
         # today this will stop models defined in MODEL_SPECS
         # but not in EVAL_CONFIGS or BENCHMARK_CONFIGS, e.g. non-instruct models
         # a run_*.log fill will be made for the failed combination indicating this
-        assert model_spec.model_name in EVAL_CONFIGS, (
-            f"Model:={model_spec.model_name} not found in EVAL_CONFIGS"
-        )
-        assert model_spec.model_id in BENCHMARK_CONFIGS, (
-            f"Model:={model_spec.model_name} not found in BENCHMARKS_CONFIGS"
-        )
+        if model_spec.model_name not in EVAL_CONFIGS:
+            user_error(
+                f"ERROR: Model '{model_spec.model_name}' is missing an eval configuration required by the release workflow.\n"
+                "The release workflow requires both EVAL_CONFIGS and BENCHMARK_CONFIGS entries.\n"
+                "\nTo fix this:\n"
+                "  1. Use a model that has a complete release configuration\n"
+                "  2. Or use a different --workflow (e.g. --workflow server)\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
+        if model_spec.model_id not in BENCHMARK_CONFIGS:
+            user_error(
+                f"ERROR: Model '{model_spec.model_name}' is missing a benchmark configuration required by the release workflow.\n"
+                "The release workflow requires both EVAL_CONFIGS and BENCHMARK_CONFIGS entries.\n"
+                "\nTo fix this:\n"
+                "  1. Use a model that has a complete release configuration\n"
+                "  2. Or use a different --workflow (e.g. --workflow server)\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
 
     if DeviceTypes.from_string(args.device) == DeviceTypes.GPU:
         if args.docker_server or args.local_server:
-            raise NotImplementedError(
-                "GPU support for running inference server not implemented yet"
+            user_error(
+                "ERROR: Running the inference server on GPU is not yet implemented.\n"
+                "GPU device support for --docker-server and --local-server is a planned feature.\n"
+                "\nTo fix this:\n"
+                "  1. Use a Tenstorrent device (e.g. --tt-device n150) instead of GPU\n"
+                "  2. Or remove --docker-server / --local-server to run workflows without a server\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
             )
 
     if args.local_server and not args.tt_metal_home:
-        raise ValueError(
-            "--local-server requires --tt-metal-home or TT_METAL_HOME to be set"
+        user_error(
+            "ERROR: --local-server requires a tt-metal build directory but none was specified.\n"
+            "The local server needs the compiled tt-metal libraries to run.\n"
+            "\nTo fix this:\n"
+            "  1. Set the environment variable: export TT_METAL_HOME=/path/to/tt-metal\n"
+            "  2. Or pass the flag: --tt-metal-home /path/to/tt-metal\n"
+            "  3. Re-run this script\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
         )
 
     # Validate mutual exclusivity of weight source options
@@ -160,14 +240,28 @@ def validate_runtime_args(model_spec, runtime_config):
         getattr(args, "host_weights_dir", None),
     ]
     if sum(1 for a in weight_source_args if a) > 1:
-        raise ValueError(
-            "Only one of --host-volume, --host-hf-cache, --host-weights-dir can be specified."
+        user_error(
+            "ERROR: More than one weight source flag was specified.\n"
+            "Only one of --host-volume, --host-hf-cache, or --host-weights-dir may be used at a time.\n"
+            "\nTo fix this:\n"
+            "  1. Choose one weight source:\n"
+            "     --host-volume       for a Docker named volume\n"
+            "     --host-hf-cache     to reuse an existing HuggingFace cache directory\n"
+            "     --host-weights-dir  to point at a pre-downloaded weights directory\n"
+            "  2. Remove the other flags and re-run this script\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
         )
 
     if "ENABLE_AUTO_TOOL_CHOICE" in os.environ:
-        raise AssertionError(
-            "Setting ENABLE_AUTO_TOOL_CHOICE has been deprecated, use the VLLM_OVERRIDE_ARGS env var directly or via --vllm-override-args in run.py CLI.\n"
-            'Enable auto tool choice by adding --vllm-override-args \'{"enable-auto-tool-choice": true, "tool-call-parser": <parser-name>}\' when calling run.py'
+        user_error(
+            "ERROR: The ENABLE_AUTO_TOOL_CHOICE environment variable is no longer supported.\n"
+            "This setting was deprecated and has been replaced by --vllm-override-args.\n"
+            "\nTo fix this:\n"
+            "  1. Unset the variable: unset ENABLE_AUTO_TOOL_CHOICE\n"
+            '  2. Pass the setting via the CLI flag instead:\n'
+            '     --vllm-override-args \'{"enable-auto-tool-choice": true, "tool-call-parser": <parser-name>}\'\n'
+            "  3. Re-run this script\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
         )
 
 
@@ -181,14 +275,28 @@ def _get_local_server_python_env_dir(runtime_config) -> Path:
 def _validate_local_vllm_installation(runtime_config):
     venv_python = _get_local_server_python_env_dir(runtime_config) / "bin" / "python"
     if not venv_python.exists():
-        raise ValueError(f"⛔ Missing required python venv interpreter: {venv_python}")
+        user_error(
+            f"ERROR: The Python virtual environment for tt-metal was not found.\n"
+            f"Expected interpreter at: {venv_python}\n"
+            "\nTo fix this:\n"
+            "  1. Build the tt-metal Python environment by following:\n"
+            "     https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md\n"
+            "  2. Verify the path is correct with --tt-metal-home or TT_METAL_HOME\n"
+            "  3. Re-run this script\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+        )
 
     return_code = run_command([str(venv_python), "-c", "import vllm"], logger=logger)
     if return_code != 0:
-        raise ValueError(
-            "⛔ --local-server with inference engine vLLM requires the `vllm` Python "
-            f"package to be installed in the tt-metal python environment. Could not "
-            f"import `vllm` with: {venv_python}"
+        user_error(
+            "ERROR: The vllm Python package is not installed in the tt-metal virtual environment.\n"
+            f"Tried to import vllm using: {venv_python}\n"
+            "\nTo fix this:\n"
+            "  1. Activate the tt-metal venv and install vLLM:\n"
+            f"     {venv_python} -m pip install vllm\n"
+            "  2. Or follow the full local install guide: vllm-tt-metal/README.md\n"
+            "  3. Re-run this script\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
         )
     logger.info(f"✅ validated vLLM Python package import with: {venv_python}")
 
@@ -243,17 +351,17 @@ def _validate_local_vllm_tt_plugin(runtime_config, venv_python: Path):
     )
     return_code = run_command([str(venv_python), "-c", check_script], logger=logger)
     if return_code != 0:
-        raise ValueError(
-            "⛔ --local-server with inference engine vLLM requires the "
-            "`vllm_tt_plugin` Python package (the TT platform plugin) "
-            "to be installed in the tt-metal python environment and to register "
-            "the `tt` entry under the `vllm.platform_plugins` entry-point group.\n"
+        vllm_dir = _get_local_vllm_dir(runtime_config)
+        user_error(
+            "ERROR: The vllm-tt-plugin package is not installed or not registered in the tt-metal venv.\n"
+            "This plugin is required for the TT platform backend since vLLM extracted it into a separate package.\n"
             f"Plugin source detected at: {plugin_path}\n"
-            "Auto-install via this validator failed or the entry point did not "
-            "register. Re-install the plugin by running the canonical script "
-            f"from the vLLM repo: `cd {_get_local_vllm_dir(runtime_config)} && "
-            "bash tt_metal/install-vllm-tt.sh`\n"
-            "See vllm-tt-metal/README.md for the full local installation steps."
+            "\nTo fix this:\n"
+            f"  1. Run the install script from the vLLM repo:\n"
+            f"     cd {vllm_dir} && bash tt_metal/install-vllm-tt.sh\n"
+            "  2. Or see the full local install guide: vllm-tt-metal/README.md\n"
+            "  3. Re-run this script\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
         )
     logger.info(
         f"✅ validated vllm-tt-plugin install and `tt` platform_plugins entry "
@@ -294,10 +402,16 @@ def validate_local_setup(model_spec, runtime_config, json_fpath):
         return_code = run_command(cmd, logger=logger)
 
         if return_code != 0:
-            raise ValueError(
-                "⛔ validating system software dependencies failed. See errors above for "
-                "required version, and System Info section above for current system versions."
-                "\nTo skip system software validation, use the flag: --skip-system-sw-validation"
+            user_error(
+                "ERROR: System software validation failed.\n"
+                "One or more required software versions (drivers, firmware, tt-smi) did not meet the minimum requirements.\n"
+                "\nTo fix this:\n"
+                "  1. Check the errors above for the specific version that failed\n"
+                "  2. Install or upgrade the flagged software to the required version\n"
+                "  3. Re-run this script\n"
+                "\nIf you are debugging and want to skip this check temporarily, add:\n"
+                "  --skip-system-sw-validation\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
             )
         logger.info("✅ validating system software dependencies completed")
 
@@ -359,9 +473,16 @@ def run_multihost_validation_subprocess(
     return_code = run_command(cmd, logger=logger)
 
     if return_code != 0:
-        raise ValueError(
-            "⛔ Multi-host validation failed. See errors above.\n"
-            "To skip system software validation, use the flag: --skip-system-sw-validation"
+        user_error(
+            "ERROR: Multi-host validation failed.\n"
+            "One or more remote hosts failed software or connectivity checks.\n"
+            "\nTo fix this:\n"
+            "  1. Check the errors above for the specific host and check that failed\n"
+            "  2. Ensure all hosts are reachable over SSH and meet the software requirements\n"
+            "  3. Re-run this script\n"
+            "\nIf you are debugging and want to skip this check temporarily, add:\n"
+            "  --skip-system-sw-validation\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
         )
 
     logger.info("✅ Multi-host validation completed")
@@ -452,12 +573,16 @@ def validate_bind_mount_permissions(args):
             )
         if not ok:
             access_type = "read+write" if need_write else "read"
-            raise ValueError(
-                f"⛔ Bind mount permission check failed for {flag}={host_path}\n"
-                f"  Container user (--image-user={uid}) needs {access_type} access.\n"
-                f"  {reason}\n"
-                f"  Fix: set --image-user to match the path owner UID, or adjust "
-                f"permissions with chmod/chown on the host path."
+            user_error(
+                f"ERROR: The Docker container user cannot access a bind-mounted host path.\n"
+                f"  Path: {host_path}  (flag: {flag})\n"
+                f"  Container user UID {uid} needs {access_type} access but was denied.\n"
+                f"  Reason: {reason}\n"
+                f"\nTo fix this:\n"
+                f"  Option A — match the UID: add --image-user $(id -u) to your run.py command\n"
+                f"  Option B — fix the path permissions: sudo chown -R {uid}:{uid} {host_path}\n"
+                f"  Option C — use chmod: chmod o+{'rw' if need_write else 'r'} {host_path}\n"
+                f"\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
             )
         logger.info(
             f"✅ Bind mount permission check passed for {flag}={host_path} "
@@ -470,15 +595,36 @@ def validate_local_server_paths(args):
     if not args.local_server:
         return
     if not args.tt_metal_home:
-        raise ValueError(
-            "--local-server requires --tt-metal-home or TT_METAL_HOME to be set"
+        user_error(
+            "ERROR: --local-server requires a tt-metal build directory but none was specified.\n"
+            "The local server needs the compiled tt-metal libraries to run.\n"
+            "\nTo fix this:\n"
+            "  1. Set the environment variable: export TT_METAL_HOME=/path/to/tt-metal\n"
+            "  2. Or pass the flag: --tt-metal-home /path/to/tt-metal\n"
+            "  3. Re-run this script\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
         )
 
     tt_metal_home = Path(args.tt_metal_home).expanduser().resolve()
     if not tt_metal_home.exists():
-        raise ValueError(f"⛔ --tt-metal-home path does not exist: {tt_metal_home}")
+        user_error(
+            f"ERROR: The --tt-metal-home path does not exist: {tt_metal_home}\n"
+            "This path must point to a built tt-metal repository.\n"
+            "\nTo fix this:\n"
+            "  1. Build tt-metal following: https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md\n"
+            "  2. Update TT_METAL_HOME or --tt-metal-home to the correct path\n"
+            "  3. Re-run this script\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+        )
     if not tt_metal_home.is_dir():
-        raise ValueError(f"⛔ --tt-metal-home is not a directory: {tt_metal_home}")
+        user_error(
+            f"ERROR: The --tt-metal-home path exists but is not a directory: {tt_metal_home}\n"
+            "This path must point to the root directory of a built tt-metal repository.\n"
+            "\nTo fix this:\n"
+            "  1. Check that TT_METAL_HOME or --tt-metal-home is set to a directory path, not a file\n"
+            "  2. Re-run this script\n"
+            "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+        )
 
     python_env_dir = _get_local_server_python_env_dir(args)
     vllm_dir = (
@@ -500,26 +646,55 @@ def validate_local_server_paths(args):
     ]
     for label, path in required_paths:
         if not path.exists():
-            raise ValueError(f"⛔ Missing required {label}: {path}")
+            user_error(
+                f"ERROR: A required path for --local-server is missing.\n"
+                f"  Missing: {label}\n"
+                f"  Expected at: {path}\n"
+                "\nTo fix this:\n"
+                "  1. Ensure tt-metal is fully built and --tt-metal-home points to the right directory\n"
+                "  2. If using a custom vLLM directory, check --vllm-dir is correct\n"
+                "  3. Re-run this script\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
 
     if args.host_hf_cache:
         host_hf_cache = Path(args.host_hf_cache).expanduser().resolve()
         if not host_hf_cache.exists():
-            raise ValueError(f"⛔ --host-hf-cache path does not exist: {host_hf_cache}")
+            user_error(
+                f"ERROR: The --host-hf-cache directory does not exist: {host_hf_cache}\n"
+                "This path must point to an existing HuggingFace cache directory.\n"
+                "\nTo fix this:\n"
+                f"  1. Create the directory: mkdir -p {host_hf_cache}\n"
+                "  2. Or point to your existing HuggingFace cache (usually ~/.cache/huggingface)\n"
+                "  3. Re-run this script\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
+            )
         snapshot_dir = resolve_hf_snapshot_dir(
             args.runtime_model_spec["hf_weights_repo"], host_hf_cache
         )
         if snapshot_dir is None:
-            raise ValueError(
-                f"⛔ --host-hf-cache did not contain a cached snapshot for "
-                f"{args.runtime_model_spec['hf_weights_repo']}: {host_hf_cache}"
+            hf_repo = args.runtime_model_spec["hf_weights_repo"]
+            user_error(
+                f"ERROR: No cached snapshot found for '{hf_repo}' in the HuggingFace cache.\n"
+                f"Cache directory: {host_hf_cache}\n"
+                "\nTo fix this:\n"
+                f"  1. Download the model weights first: huggingface-cli download {hf_repo}\n"
+                "  2. Or remove --host-hf-cache to let the server download weights on first start\n"
+                "  3. Re-run this script\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
             )
 
     if args.host_weights_dir:
         host_weights_dir = Path(args.host_weights_dir).expanduser().resolve()
         if not host_weights_dir.exists():
-            raise ValueError(
-                f"⛔ --host-weights-dir path does not exist: {host_weights_dir}"
+            user_error(
+                f"ERROR: The --host-weights-dir directory does not exist: {host_weights_dir}\n"
+                "This path must point to a directory containing pre-downloaded model weights.\n"
+                "\nTo fix this:\n"
+                f"  1. Download the model weights to that directory, or\n"
+                "  2. Update --host-weights-dir to point to where your weights are stored\n"
+                "  3. Re-run this script\n"
+                "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"
             )
 
 

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -258,7 +258,7 @@ def validate_runtime_args(model_spec, runtime_config):
             "This setting was deprecated and has been replaced by --vllm-override-args.\n"
             "\nTo fix this:\n"
             "  1. Unset the variable: unset ENABLE_AUTO_TOOL_CHOICE\n"
-            '  2. Pass the setting via the CLI flag instead:\n'
+            "  2. Pass the setting via the CLI flag instead:\n"
             '     --vllm-override-args \'{"enable-auto-tool-choice": true, "tool-call-parser": <parser-name>}\'\n'
             "  3. Re-run this script\n"
             "\nIf you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin"

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -61,7 +61,7 @@ def _check_image_version_supported(model_spec):
     if parsed < MIN_SUPPORTED_IMAGE_VERSION:
         min_str = ".".join(str(p) for p in MIN_SUPPORTED_IMAGE_VERSION)
         tag = f"v{model_spec.version}"
-        user_error(
+        raise RuntimeError(
             f"ERROR: Docker image v{model_spec.version} is not supported by this version of run.py.\n"
             f"This run.py requires vLLM image v{min_str} or newer (the Docker interface changed in v{min_str}).\n"
             f"\nTo fix this:\n"


### PR DESCRIPTION
## Summary

- Replace every raw Python traceback in `validate_setup.py`, `setup_host.py`, and `run_local_server.py` with a plain-English `ERROR:` block that names the problem, explains why it matters, and gives numbered fix steps with exact commands
- Add `user_error()` helper to `workflows/utils.py` — prints to stderr, exits 1, used at all ~55 call sites
- Add `--debug` flag to `run.py` and `setup_host.py` — re-enables full tracebacks for developers; default behaviour is clean messages only
- Wrap `validate_setup`, `setup_host`, and `run_local_server` call sites in `run.py` in top-level try/except with the same debug gate
- All \"If you need help\" pointers link to https://docs.tenstorrent.com/getting-started/README.html#before-you-begin
- No logic changes — only error message copy and exception handling

## Error message format

Every failure now follows this template:
```
ERROR: <one sentence naming the problem>
<one sentence explaining why it matters>

To fix this:
  1. <exact command or action>
  2. <follow-up if needed>
  3. Re-run this script

If you need help, see https://docs.tenstorrent.com/getting-started/README.html#before-you-begin
```

## Test plan

- [x] Syntax-checked all five modified files locally (`ast.parse`)
- [x] Deployed to node1 (Blackhole p150a, Ubuntu 24.04, `192.168.50.208`)
- [x] 27/27 failure modes verified on hardware: each exits 1, prints `ERROR:`, includes `To fix this:` steps, no raw tracebacks
- [x] `--debug` flag appears in `--help` for both `run.py` and `setup_host.py`
- [x] Without `--debug`: clean one-liner error on unexpected exceptions
- [x] With `--debug`: full traceback shown
- [x] Message content audited for all 24 in-process cases — copy matches the actual failure condition

Failure modes covered (27 total):
`no --tt-device` · `unsupported model+device` · `--docker-server + --local-server` · `SERVER workflow without mode flag` · `--local-server without TT_METAL_HOME` (×2 code paths) · `multiple weight source flags` · `deprecated ENABLE_AUTO_TOOL_CHOICE` · `TT_METAL_HOME missing/not-a-dir` · `--host-hf-cache missing` · `--host-weights-dir missing` · `bind-mount permission denied` · `invalid model source` · `insufficient RAM` · `insufficient disk` · `empty JWT_SECRET` · `HF_TOKEN missing/wrong-format/rejected` · `MODEL_WEIGHTS_DIR not set in auto mode` · `local weights dir missing` · `non-vLLM local server engine` · `missing requirements.txt` · `http_request network failure` · `setup_host --debug flag + traceback gate` (×3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)