### PR TITLE
Fix Dynamo Excessive Logging on Client Disconnection

### DIFF
--- a/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
@@ -279,8 +279,8 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
               probeId.empty() ? "?" : probeId, preProcessMs);
 
           const auto tDispatch = SteadyClock::now();
-          auto cb = [req, sendChunk, signalDone, recvT, firstChunkSeen, probeId,
-                     tDispatch,
+          auto cb = [req, svc, sendChunk, signalDone, recvT, firstChunkSeen,
+                     probeId, tDispatch,
                      usage](const tt::domain::llm::LLMStreamChunk& chunk,
                             bool isFinal) {
             // Log worker-side TTFT exactly once per request: total since recv
@@ -354,9 +354,18 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
               }
               out.completion_usage = du;
             }
-            sendChunk(out);
+            const bool sent = sendChunk(out);
             if (isFinal) {
               signalDone();
+              return;
+            }
+            if (!sent) {
+              TT_LOG_WARN(
+                  "[DynamoEndpoint] downstream send failed for task {}; "
+                  "aborting generation",
+                  req->task_id);
+              svc->abortRequest(req->task_id);
+              return;
             }
           };
 


### PR DESCRIPTION
## Problem
Client disconnects during streaming could generate an excessive number of error logs, significantly reducing log readability.
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/900fbd57-96a5-4ea4-b4af-31bba16c6ad3" />

This PR detects client disconnects early and stops streaming to Dynamo Frontend once the connection is closed, reducing the noise to a single error log entry.


## Testing
Docker image: https://github.com/tenstorrent/tt-shield/actions/runs/27028753259