### PR TITLE
Limit IO threads when using Dynamo

### DIFF
--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -97,6 +97,9 @@ constexpr size_t CALLBACK_POOL_THREADS_MIN = 16;
 constexpr size_t CALLBACK_POOL_THREADS_MAX = 32;
 constexpr unsigned WORKER_STOP_TIMEOUT_MS = 500;
 constexpr unsigned SHUTDOWN_POLL_MS = 50;
+// Number of Drogon HTTP IO threads. 0 = auto (hardware_concurrency, or 4 when
+// Dynamo is the primary traffic path). Set explicitly to reduce idle threads.
+constexpr size_t DROGON_IO_THREADS = 0;
 
 // IPC queue capacities
 constexpr size_t RESULT_QUEUE_CAPACITY = 65536;

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -288,6 +288,15 @@ int prefillMaxTokenIds();
 int decodeMaxTokenIds();
 
 // ---------------------------------------------------------------------------
+// Drogon HTTP server
+// ---------------------------------------------------------------------------
+
+/** Number of Drogon IO threads. From DROGON_IO_THREADS. 0 means auto-detect
+ * (hardware_concurrency; reduced to 4 when DYNAMO_ENDPOINT_ENABLED=1 since
+ * Drogon only serves health/metrics in that mode). */
+size_t drogonIoThreads();
+
+// ---------------------------------------------------------------------------
 // Dynamo TCP backend (NVIDIA Dynamo frontend integration)
 // ---------------------------------------------------------------------------
 

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -672,6 +672,11 @@ unsigned prefillTimeoutMs() {
       envUlong("PREFILL_TIMEOUT_MS", defaults::PREFILL_TIMEOUT_MS));
 }
 
+size_t drogonIoThreads() {
+  return static_cast<size_t>(
+      envUlong("DROGON_IO_THREADS", defaults::DROGON_IO_THREADS));
+}
+
 bool dynamoEndpointEnabled() {
   return envBool("DYNAMO_ENDPOINT_ENABLED", defaults::DYNAMO_ENDPOINT_ENABLED);
 }

--- a/tt-media-server/cpp_server/src/main.cpp
+++ b/tt-media-server/cpp_server/src/main.cpp
@@ -121,7 +121,8 @@ int main(int argc, char* argv[]) {
 
   std::string host = defs::SERVER_HOST;
   uint16_t port = defs::SERVER_PORT;
-  int threads = std::thread::hardware_concurrency();
+  int threads = 0;  // 0 = auto (resolved after CLI parsing)
+  bool threadsExplicit = false;
 
   for (int i = 1; i < argc; ++i) {
     std::string arg = argv[i];
@@ -131,6 +132,7 @@ int main(int argc, char* argv[]) {
       port = static_cast<uint16_t>(std::stoi(argv[++i]));
     } else if ((arg == "-t" || arg == "--threads") && i + 1 < argc) {
       threads = std::stoi(argv[++i]);
+      threadsExplicit = true;
     } else if (arg == "--help") {
       // Use cout for help message (before logger is initialized)
       std::cout
@@ -143,6 +145,20 @@ int main(int argc, char* argv[]) {
           << "  --help              Show this help message\n"
           << "\nEnvironment Variables:\n";
       return 0;
+    }
+  }
+
+  // Resolve Drogon IO thread count: CLI > env DROGON_IO_THREADS > auto.
+  // Auto = hardware_concurrency, reduced to 4 when Dynamo is the primary
+  // traffic path (Drogon only serves health/metrics in that mode).
+  if (!threadsExplicit) {
+    const size_t fromConfig = tt::config::drogonIoThreads();
+    if (fromConfig > 0) {
+      threads = static_cast<int>(fromConfig);
+    } else if (tt::config::dynamoEndpointEnabled()) {
+      threads = 4;  // minimal — HTTP only serves health/metrics
+    } else {
+      threads = static_cast<int>(std::thread::hardware_concurrency());
     }
   }
 


### PR DESCRIPTION
With Dynamo on:

<img width="747" height="156" alt="image" src="https://github.com/user-attachments/assets/3dcd240b-42a4-4c01-8de3-4bd55a51d4d6" />


Without Dynamo:

<img width="747" height="156" alt="image" src="https://github.com/user-attachments/assets/7f55f198-6202-4bf8-89ac-373b1c8f6da1" />
