### PR TITLE
Fix forge-TP benchmark 6h cap: force max_tokens=osl in bench-serve requests

### DIFF
--- a/benchmarking/run_benchmarks.py
+++ b/benchmarking/run_benchmarks.py
@@ -209,8 +209,15 @@ def build_benchmark_command(
     # only truncate prompts for text-only tasks; VLMs interleave vision tokens
     # in the prompt and truncation can drop them, causing 400s at the preprocessor
     if params.task_type == "text":
+        # Pin output length via max_tokens in the request body. --random-output-len
+        # isn't always enforced as a hard cap server-side (the forge OpenAI-compat
+        # server ignores it), so requests can run unbounded -- Qwen3-32B then emits
+        # ~1000+ reasoning tokens for osl=128 and blows the 6h CI cap. max_tokens in
+        # the body is honored.
         cmd.extend([
-            "--extra-body", json.dumps({"truncate_prompt_tokens": str(isl)}),
+            "--extra-body", json.dumps(
+                {"truncate_prompt_tokens": str(isl), "max_tokens": int(osl)}
+            ),
         ])
 
     if params.task_type == "vlm":


### PR DESCRIPTION
Closes #4039. Part of #4038 (forge-TP LLMs on p300x2).

## What
`benchmarking/run_benchmarks.py`: add `"max_tokens": osl` to the text-task `--extra-body` (next to the existing `truncate_prompt_tokens`). Single hunk, text-task path only — no server/image/weights changes.

## Why
`vllm bench serve --random-output-len N` is **not** honored as a `max_tokens` cap by the forge OpenAI-compat server, so text benchmark requests run **unbounded**. Qwen3-32B emits ~1000–1500 reasoning tokens for an `osl=128` request, so the release sweep blows the **6h CI job cap** ([Qwen release run 5204](https://github.com/tenstorrent/tt-shield/actions/runs/27054514200) was cancelled at 6h). The server **does** honor `max_tokens` when it's in the request body.

This is a general correctness fix: output now caps at the requested `osl` for all text benchmarks. It only changes behavior for models that were over-generating — gemma already stopped at the requested length and is unaffected.

## Verification

**CI (tt-shield, QB2 / bh-qb-ge):** [Qwen3-32B benchmarks run 5206](https://github.com/tenstorrent/tt-shield/actions/runs/27116532375) exercises this fix end-to-end on a branch combining it with the gemma/Qwen forge-TP model add (`kmabee/issue_4038_forge-tp-ci-validation`) — same model/runner as the cancelled [release run 5204](https://github.com/tenstorrent/tt-shield/actions/runs/27054514200), where uncapped benchmark output was the cause of the 6h timeout. *(Passed Benchmark in 2hr 45 min)*

**Local (live Qwen3-32B server, p300x2 batch-16/4K):**
- Full `run.py --workflow benchmarks` sweep (**14 configs**: 8 text + 6 structured-output) completes in **~2h11m** end-to-end with the fix — comfortably under the 6h cap.
- **Per-request output is capped:** `max` output tokens == the requested `osl` in every config (`osl=128` → mean ~127–128; `osl=1024` → ≤1024). Before the fix, the `osl=128` conc-1 config ran ~1500 tok/req and timed out (>600 s); after, 127.5 tok/req in ~49 s.
- Structured-output (a separate `--output-len` path, *not* touched by this change, including the unguided `ratio=0.0` variants) stays bounded on its own (~18–21 tok/s, output ≤128), so the text-path cap is sufficient — no change needed there.

## Note
Likely mechanism: the openai-chat backend sends `max_completion_tokens`, which this forge server doesn't enforce, rather than `max_tokens`. The `--extra-body` `max_tokens` sidesteps it; a cleaner long-term fix is server-side honoring of `max_completion_tokens`.
