### PR TITLE
Initial Forge-TP support: gemma-4-31b-it + Qwen3-32B on p300x2 (serving + evals)

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -261,27 +261,41 @@
       }
     },
     "Qwen3-32B": {
-      "inference_engine": "vLLM",
-      "ci": {
-        "nightly": {
-          "devices": [
-            "GALAXY",
-            "BH_GALAXY",
-            "P300X2",
-            "T3K"
-          ]
+      "implementations": [
+        {
+          "inference_engine": "vLLM",
+          "ci": {
+            "nightly": {
+              "devices": [
+                "GALAXY",
+                "BH_GALAXY",
+                "P300X2",
+                "T3K"
+              ]
+            },
+            "weekly": {
+              "devices": [
+                "GALAXY"
+              ]
+            },
+            "release": {
+              "devices": [
+                "P300X2"
+              ]
+            }
+          }
         },
-        "weekly": {
-          "devices": [
-            "GALAXY"
-          ]
-        },
-        "release": {
-          "devices": [
-            "P300X2"
-          ]
+        {
+          "inference_engine": "FORGE",
+          "ci": {
+            "nightly": {
+              "devices": [
+                "P300X2"
+              ]
+            }
+          }
         }
-      }
+      ]
     },
     "Qwen3-8B": {
       "implementations": [
@@ -491,6 +505,16 @@
             "N300",
             "T3K",
             "P150"
+          ]
+        }
+      }
+    },
+    "gemma-4-31b-it": {
+      "inference_engine": "FORGE",
+      "ci": {
+        "nightly": {
+          "devices": [
+            "P300X2"
           ]
         }
       }

--- a/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/benchmarking/benchmark_targets/model_performance_reference.json
@@ -1,4 +1,25 @@
 {
+    "gemma-4-31b-it": {
+        "p300x2": [
+            {
+                "isl": 128,
+                "osl": 128,
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "task_type": "text",
+                "image_height": null,
+                "image_width": null,
+                "images_per_prompt": null,
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 46,
+                        "tput_user": 37,
+                        "tput": 37
+                    }
+                }
+            }
+        ]
+    },
     "Qwen3-VL-32B-Instruct": {
         "t3k": [
             {

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -3290,6 +3290,34 @@ _eval_config_list = [
             ),
         ],
     ),
+    EvalConfig(
+        hf_model_repo="google/gemma-4-31b-it",
+        tasks=[
+            EvalTask(
+                task_name="ifeval",
+                score=EvalTaskScore(
+                    # First TT user of gemma-4-31b-it (no prior TTNN entry) and
+                    # no published gemma-4 reference yet -- fill published_score /
+                    # gpu_reference_score from the first CI_NIGHTLY run.
+                    published_score=None,
+                    published_score_ref=None,
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": [
+                            "prompt_level_strict_acc,none",
+                            "inst_level_strict_acc,none",
+                        ],
+                        "unit": "percent",
+                    },
+                ),
+                # Downsampled: first user of the model, trim nightly runtime.
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.1,
+                    EvalLimitMode.SMOKE_TEST: 0.01,
+                },
+            ),
+        ],
+    ),
 ]
 
 

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -38,6 +38,7 @@ class SupportedModels(Enum):
     LLAMA_3_1_70B = "meta-llama/Llama-3.1-70B"
     QWEN_3_4B = "Qwen/Qwen3-4B"
     QWEN_3_8B = "Qwen/Qwen3-8B"
+    QWEN_3_32B = "Qwen/Qwen3-32B"
     SPEECHT5_TTS = "microsoft/speecht5_tts"
     GEMMA_1_1_2B_IT = "google/gemma-1.1-2b-it"
     GEMMA_4_31B_IT = "google/gemma-4-31B-it"
@@ -86,6 +87,7 @@ class ModelNames(Enum):
     LLAMA_3_1_70B = "Llama-3.1-70B"
     QWEN_3_4B = "Qwen3-4B"
     QWEN_3_8B = "Qwen3-8B"
+    QWEN_3_32B = "Qwen3-32B"
     SPEECHT5_TTS = "speecht5_tts"
     GEMMA_1_1_2B_IT = "gemma-1.1-2b-it"
     GEMMA_4_31B_IT = "gemma-4-31b-it"
@@ -116,6 +118,7 @@ class ModelRunners(Enum):
     VLLMForge_QWEN_EMBEDDING = "vllmforge_qwen_embedding"
     VLLMForge_LLAMA_70B = "vllm_forge_llama_70b"
     VLLMForge_GEMMA4_31B = "vllm_forge_gemma4_31b"
+    VLLMForge_QWEN_32B = "vllm_forge_qwen_32b"
     QWEN_EMBEDDING_8B = "qwen_embedding_8b"
     BGELargeEN_V1_5 = "bge_large_en_v1_5"
     BGEM3 = "bge-m3"
@@ -167,6 +170,7 @@ MODEL_SERVICE_RUNNER_MAP = {
         ModelRunners.VLLMForge,
         ModelRunners.VLLMForge_LLAMA_70B,
         ModelRunners.VLLMForge_GEMMA4_31B,
+        ModelRunners.VLLMForge_QWEN_32B,
         ModelRunners.LLM_TEST,
         ModelRunners.LLAMA_RUNNER,
         ModelRunners.LORA_SINGLE_CHIP,
@@ -247,6 +251,7 @@ INFERENCE_MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.VLLMForge_QWEN_EMBEDDING: {ModelNames.QWEN_3_EMBEDDING_4B},
     ModelRunners.VLLMForge_LLAMA_70B: {ModelNames.LLAMA_3_1_70B},
     ModelRunners.VLLMForge_GEMMA4_31B: {ModelNames.GEMMA_4_31B_IT},
+    ModelRunners.VLLMForge_QWEN_32B: {ModelNames.QWEN_3_32B},
     ModelRunners.QWEN_EMBEDDING_8B: {ModelNames.QWEN_3_EMBEDDING_8B},
     ModelRunners.BGELargeEN_V1_5: {ModelNames.BGE_LARGE_EN_V1_5},
     ModelRunners.BGEM3: {ModelNames.BGE_M3},
@@ -1072,16 +1077,21 @@ ModelConfigs = {
         "device_mesh_shape": (1, 4),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_4_GROUP.value,
+        # Dims are env-driven via dev/cnn.yaml env_vars (mimics the single-chip
+        # forge LLMs): VLLMSettings reads MAX_MODEL_LENGTH / MAX_NUM_SEQS /
+        # GPU_MEMORY_UTILIZATION from env and auto-computes max_num_batched_tokens
+        # = max_model_length * max_num_seqs. model is set from the MODEL env
+        # (settings.py); max_batch_size auto-raises to max_num_seqs. This entry
+        # only carries the TP mesh topology (batch-16/4K lives in cnn.yaml).
         "max_batch_size": 1,
-        "vllm": {
-            "model": SupportedModels.GEMMA_4_31B_IT.value,
-            "max_model_length": 512,
-            # Gemma-4 multimodal requires max_num_batched_tokens >= 2560
-            # (video: _VIDEO_MAX_FRAMES=32 * 78 tokens = 2496).
-            "max_num_batched_tokens": 2560,
-            "min_context_length": 32,
-            "max_num_seqs": 1,
-        },
+        "queue_for_multiprocessing": QueueType.FasterFifo.value,
+    },
+    (ModelRunners.VLLMForge_QWEN_32B, DeviceTypes.P300X2): {
+        "device_mesh_shape": (1, 4),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_4_GROUP.value,
+        # Dims env-driven via dev/cnn.yaml env_vars (see gemma entry above).
+        "max_batch_size": 1,
         "queue_for_multiprocessing": QueueType.FasterFifo.value,
     },
     (ModelRunners.QWEN_EMBEDDING_8B, DeviceTypes.N150): {

--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,6 +1,10 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
 --extra-index-url https://download.pytorch.org/whl/cpu
-tt-forge==1.2.0
+# Custom 1.3.0 dev/nightly built 2026-06-05, as baked into the tt-shield forge
+# image tag e03b231b1de926cd8f9a0e1a2d39dd1df599f7a7_46a7c96_79778041239.
+# Supersedes 1.2.0.dev20260530002932 (gemma-4-31b-it was first validated on
+# that older build); carries the gemma-4-31b TP support the stock 1.3.0 lacks.
+tt-forge==1.3.0.dev20260605003323
 
 tabulate
 timm # input preprocessing

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -92,6 +92,10 @@ AVAILABLE_RUNNERS = {
         "tt_model_runners.vllm_forge_gemma4_31b",
         fromlist=["VLLMForgeGemma4_31BRunner"],
     ).VLLMForgeGemma4_31BRunner(wid),
+    ModelRunners.VLLMForge_QWEN_32B: lambda wid: __import__(
+        "tt_model_runners.vllm_forge_qwen_32b",
+        fromlist=["VLLMForgeQwen32BRunner"],
+    ).VLLMForgeQwen32BRunner(wid),
     ModelRunners.TT_XLA_RESNET: lambda wid: __import__(
         "tt_model_runners.forge_runners.runners", fromlist=["ForgeResnetRunner"]
     ).ForgeResnetRunner(wid),

--- a/tt-media-server/tt_model_runners/vllm_forge_qwen_32b.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_qwen_32b.py
@@ -18,37 +18,34 @@ CHUNK_TYPE = "streaming_chunk"
 FINAL_TYPE = "final_result"
 
 
-class VLLMForgeGemma4_31BRunner(BaseDeviceRunner):
+class VLLMForgeQwen32BRunner(BaseDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
 
     @log_execution_time(
-        "VLLM Forge Gemma-4 31B model load",
+        "VLLM Forge Qwen3-32B model load",
         TelemetryEvent.DEVICE_WARMUP,
         os.environ.get("TT_VISIBLE_DEVICES"),
     )
     async def warmup(self) -> bool:
         self.logger.info(
-            f"Device {self.device_id}: Loading VLLM Forge Gemma-4 31B model..."
+            f"Device {self.device_id}: Loading VLLM Forge Qwen3-32B model..."
         )
         prompt = "Hello, it's me"
-        # Tunable per-run via env vars (mirrors vllm_runner.py). Defaults are the
-        # measured-best for the gemma-4-31b TP config on p300x2 (4-chip (1,4)
-        # mesh, 512 seq len, bs1):
-        #   ENABLE_TRACE=true     decode-graph replay; the dominant lever
-        #                         (greedy 4.8 -> 8.1 tok/s, +71%). Trace-capture
-        #                         fits in DRAM at 512 seq len on the 4-chip mesh.
-        #   CPU_SAMPLING=false    on-device sampling; +13% greedy ON TOP of trace
-        #                         (8.1 -> 9.2 tok/s). Worth ~nothing without trace
-        #                         (4.8 -> 5.3). (TTConfig's own default is False;
-        #                         the old hardcoded True was the deviation.)
+        # Tunable per-run via env vars (mirrors vllm_runner.py /
+        # vllm_forge_gemma4_31b.py). Defaults follow the gemma-4-31b TP
+        # measured-best:
+        #   ENABLE_TRACE=true     decode-graph replay (the dominant decode-speed
+        #                         lever on gemma: greedy ~4.8 -> ~9.2 tok/s).
+        #   CPU_SAMPLING=false    on-device sampling (TTConfig's own default;
+        #                         the old hardcoded True was the deviation).
         #   OPTIMIZATION_LEVEL=0  REQUIRED: opt>=1 aborts in tt-mlir
-        #                         MemoryLayoutPropagation on the 1.2.0 wheel
-        #                         (tt-xla#4990), and TTConfig rejects
-        #                         enable_trace=True + opt>=1 + cpu_sampling=False,
-        #                         so the trace defaults are only valid at opt 0.
-        # Weights stay bfp_bf8: measured FASTER than bf16 (greedy 9.2 vs 8.0),
-        # since bf16 doubles per-token weight DRAM traffic.
+        #                         MemoryLayoutPropagation on the 1.x wheel
+        #                         (tt-xla#4990); TTConfig also rejects
+        #                         enable_trace + opt>=1 + cpu_sampling=False, so
+        #                         the trace defaults are only valid at opt 0.
+        # NOTE: these defaults were validated on gemma-4-31b, not yet on
+        # Qwen3-32B -- flip via env if a Qwen-specific issue appears.
         optimization_level = int(os.getenv("OPTIMIZATION_LEVEL", "0"))
         cpu_sampling = os.getenv("CPU_SAMPLING", "false").lower() == "true"
         enable_trace = os.getenv("ENABLE_TRACE", "true").lower() == "true"
@@ -93,7 +90,7 @@ class VLLMForgeGemma4_31BRunner(BaseDeviceRunner):
         raise ValueError(f"Invalid prompt type: {type(request.prompt)}")
 
     @log_execution_time(
-        "Run VLLM Forge Gemma-4 31B inference",
+        "Run VLLM Forge Qwen3-32B inference",
         TelemetryEvent.MODEL_INFERENCE,
         os.environ.get("TT_VISIBLE_DEVICES"),
     )
@@ -104,7 +101,7 @@ class VLLMForgeGemma4_31BRunner(BaseDeviceRunner):
 
     async def _run_async(self, requests: list[CompletionRequest]):
         try:
-            self.logger.debug(f"Device {self.device_id}: Running Gemma-4 31B inference")
+            self.logger.debug(f"Device {self.device_id}: Running Qwen3-32B inference")
 
             request = requests[0]
             if request.stream:
@@ -113,12 +110,12 @@ class VLLMForgeGemma4_31BRunner(BaseDeviceRunner):
                 return await self._generate_non_streaming(requests)
         except Exception as e:
             self.logger.error(
-                f"Device {self.device_id}: Gemma-4 31B inference failed: {type(e).__name__}: {e}"
+                f"Device {self.device_id}: Qwen3-32B inference failed: {type(e).__name__}: {e}"
             )
             self.logger.error(
                 f"Device {self.device_id}: Full traceback: {traceback.format_exc()}"
             )
-            raise RuntimeError(f"Gemma-4 31B inference failed: {str(e)}") from e
+            raise RuntimeError(f"Qwen3-32B inference failed: {str(e)}") from e
 
     async def _generate_streaming(self, request: CompletionRequest):
         """Yields CompletionOutput dicts for streaming generation."""
@@ -154,7 +151,7 @@ class VLLMForgeGemma4_31BRunner(BaseDeviceRunner):
                 )
 
         self.logger.info(
-            f"Device {self.device_id}: Gemma-4 31B streaming generation completed"
+            f"Device {self.device_id}: Qwen3-32B streaming generation completed"
         )
 
         yield CompletionOutput(
@@ -166,7 +163,7 @@ class VLLMForgeGemma4_31BRunner(BaseDeviceRunner):
         self, request: CompletionRequest
     ) -> CompletionOutput:
         self.logger.info(
-            f"Device {self.device_id}: Starting Gemma-4 31B non-streaming generation"
+            f"Device {self.device_id}: Starting Qwen3-32B non-streaming generation"
         )
 
         sampling_params = build_sampling_params(request)
@@ -181,7 +178,7 @@ class VLLMForgeGemma4_31BRunner(BaseDeviceRunner):
         generated_text = "".join(generated_text)
 
         self.logger.info(
-            f"Device {self.device_id}: Gemma-4 31B non-streaming generation completed"
+            f"Device {self.device_id}: Qwen3-32B non-streaming generation completed"
         )
 
         return CompletionOutput(

--- a/workflows/model_specs/dev/cnn.yaml
+++ b/workflows/model_specs/dev/cnn.yaml
@@ -127,6 +127,71 @@ templates:
         ENABLE_TRACE: "true"
 
 - weights:
+    # gemma-4-31b-it Forge LLM (tensor-parallel) on p300x2/QB2. Lowercase
+    # basename matches tt-media-server ModelNames.GEMMA_4_31B_IT. batch-16 / 4K
+    # is the best fitting balance (~76 tok/s aggregate). Dims are env-driven here
+    # (constants.py only carries the TP mesh topology), mirroring the single-chip
+    # forge LLMs above.
+    - google/gemma-4-31b-it
+  tt_metal_commit: "e03b231b1de926cd8f9a0e1a2d39dd1df599f7a7"
+  vllm_commit: "46a7c96"
+  impl: forge_vllm_plugin
+  min_disk_gb: 80
+  min_ram_gb: 32
+  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:aed6177ab424aa93f447118aac5a7b8ab1cafdbc_f752cce_79853177306"
+  model_type: LLM
+  inference_engine: FORGE
+  uses_tensor_model_cache: false
+  status: EXPERIMENTAL
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 16
+      max_context: 4096
+      default_impl: true
+      eval_max_retries: 1
+      env_vars:
+        MAX_MODEL_LENGTH: "4096"
+        MAX_NUM_SEQS: "16"
+        GPU_MEMORY_UTILIZATION: "0.9"
+        OPTIMIZATION_LEVEL: "0"
+        ENABLE_TRACE: "true"
+        CPU_SAMPLING: "false"
+        # 4-chip (1,4) TP mesh: the runner doesn't auto-set this and the image
+        # maps p300x2->p150, so pin the p300_x2 descriptor (else stablehlo
+        # "unknown mesh: @mesh" at compile). -e overrides --env-file here.
+        TT_MESH_GRAPH_DESC_PATH: "/home/container_app_user/app/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto"
+
+- weights:
+    # Qwen3-32B Forge LLM (tensor-parallel) on p300x2/QB2, mirroring gemma-4-31b.
+    # basename "Qwen3-32B" matches ModelNames.QWEN_3_32B. batch-16 / 4K (same as
+    # gemma; not yet independently swept on Qwen -- local verify is the check).
+    - Qwen/Qwen3-32B
+  tt_metal_commit: "e03b231b1de926cd8f9a0e1a2d39dd1df599f7a7"
+  vllm_commit: "46a7c96"
+  impl: forge_vllm_plugin
+  min_disk_gb: 80
+  min_ram_gb: 32
+  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:aed6177ab424aa93f447118aac5a7b8ab1cafdbc_f752cce_79853177306"
+  model_type: LLM
+  inference_engine: FORGE
+  uses_tensor_model_cache: false
+  status: EXPERIMENTAL
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 16
+      max_context: 4096
+      default_impl: true
+      eval_max_retries: 1
+      env_vars:
+        MAX_MODEL_LENGTH: "4096"
+        MAX_NUM_SEQS: "16"
+        GPU_MEMORY_UTILIZATION: "0.9"
+        OPTIMIZATION_LEVEL: "0"
+        ENABLE_TRACE: "true"
+        CPU_SAMPLING: "false"
+        TT_MESH_GRAPH_DESC_PATH: "/home/container_app_user/app/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto"
+
+- weights:
     - resnet-50
   version: "0.13.0"
   tt_metal_commit: "079a2c2"


### PR DESCRIPTION
Closes #4041. Part of #4038 (forge-TP LLMs on p300x2).

## What's changed
  Adds both 4-chip tensor-parallel Forge LLMs — **gemma-4-31b-it** and **Qwen3-32B** — on p300x2/QB2 as **servable + eval-able** at `EXPERIMENTAL`. Batch-16 / 4K, dims env-driven; image `…forge:aed6177…_f752cce_79853177306` (built from this branch).

  - **New model specs** in the dev catalog (CI reads dev) — both models, p300x2, env-driven dims — `workflows/model_specs/dev/cnn.yaml`
  - **Two env-var-tunable forge runners** (`ENABLE_TRACE` / `CPU_SAMPLING` / `OPTIMIZATION_LEVEL`, perf-tuned defaults) + fabric registration — `vllm_forge_{gemma4_31b,qwen_32b}.py`, `runner_fabric.py`
  - **Forge wheel** bumped to `1.3.0.dev20260605003323` — `forge_runners/requirements.txt`
  - **Server config** trimmed to TP mesh topology only (dims now env-driven) — `config/constants.py`
  - **Evals**: `ifeval`, downsampled (CI_NIGHTLY 0.1 / SMOKE 0.01) — `evals/eval_config.py`
  - **Perf-ref placeholder** copied from Qwen3-32B p300x2 — `model_performance_reference.json`
  - **Nightly CI matrix** entries (FORGE / P300X2) — `.github/workflows/models-ci-config.json`

## Scope
Additive — new models only; no changes to existing models. **Benchmarks are out of scope here:** the benchmark step stays known-red until the output-cap fix (#4039 : Merged) and the benchmark-client vllm/transformers uplift (#4043) land. Serving + evals run, which unblocks perf work.

## Validation
- **Local** (p01t05, build image): both serve at 4K/16; gemma `ifeval` prompt_level_strict_acc **0.89**; Qwen eval functional.
- **CI** (tt-shield, QB2 / bh-qb-ge): full **release** (serve + evals + benchmark) for both models, on a branch combining this add with the output-cap fix (#4039) and the benchmark-client uplift (#4043) 
  - [gemma-4-31b-it run 5214](https://github.com/tenstorrent/tt-shield/actions/runs/27119820484) **Passing e2e**
  - [Qwen3-32B run 5215](https://github.com/tenstorrent/tt-shield/actions/runs/27119821324). **Passing e2e**
 
- Eval reference scores are TBD (first TT user of these models) — fill from the first clean nightly.
- Perf-reference targets for `gemma-4-31b-it` (`ttft_ms=46, tput_user=37, tput=37`) are **placeholders copied from Qwen3-32B's existing p300x2 targets** (same-class 32B forge model, same device) — gemma-4-31b-it is the first TT user, so there's no measured baseline yet.

## Forge wheel re-qualification (`tt-forge 1.3.0.dev20260605003323`)
This PR bumps `forge_runners/requirements.txt`, which affects every forge-image model — so the existing forge models were re-qualified by **building a fresh forge image from this branch** (no prebuilt image override; `release` workflow), mirroring the prior wheel-bump re-qual.

Vision (`n150`, `release`, `impl=default`):
- [x] `efficientnet`: https://github.com/tenstorrent/tt-shield/actions/runs/27117635910
- [x] `mobilenetv2`: https://github.com/tenstorrent/tt-shield/actions/runs/27117636525
- [x] `resnet-50`: https://github.com/tenstorrent/tt-shield/actions/runs/27117637159
- [x] `segformer`: https://github.com/tenstorrent/tt-shield/actions/runs/27117637799
- [x] `vit`: https://github.com/tenstorrent/tt-shield/actions/runs/27117638393
- [x] `vovnet`: https://github.com/tenstorrent/tt-shield/actions/runs/27117638960

Forge LLM (`p150`, `release`, `impl=forge-vllm-plugin`):
- [x] `Falcon3-7B-Instruct`: https://github.com/tenstorrent/tt-shield/actions/runs/27117648384 (runs, model WIP)

