### PR TITLE
Fix Token Adjustoment on Prefill Node

### DIFF
--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -288,42 +288,27 @@ void DisaggregationService::applyDeltaPrompt(LLMRequest& req,
     return;
   }
 
-  // The remaining (unmatched) prompt tokens that will be prefilled must be
-  // aligned to 32 so the prefill kernel can operate on full tiles.  If the
-  // remainder isn't divisible by 32, we pull back some matched tokens into
-  // the delta to pad the remainder up to the next multiple of 32.
-  constexpr uint32_t kAlignment = 32;
-  const uint32_t totalTokens = static_cast<uint32_t>(tokens.size());
-  const uint32_t remainder = totalTokens - matchedTokens;
-  const uint32_t alignedRemainder =
-      ((remainder + kAlignment - 1) / kAlignment) * kAlignment;
-
-  // How many extra tokens we need to pull back from the matched prefix.
-  const uint32_t pullBack = alignedRemainder - remainder;
-  const uint32_t effectiveSkip =
-      (pullBack <= matchedTokens) ? (matchedTokens - pullBack) : 0;
-
-  if (effectiveSkip == 0) {
-    TT_LOG_DEBUG(
-        "[DisaggregationService] applyDeltaPrompt: matchedTokens={} "
-        "remainder={} — cannot align, full prefill will run",
-        matchedTokens, remainder);
-    return;
-  }
-
+  // `matchedTokens` is always a multiple of 32 because prefix-cache blocks are
+  // 32 tokens wide, so trimming exactly `matchedTokens` leaves the resumed
+  // prefill starting on a tile boundary — it never writes into an existing
+  // partial tile. We send the whole remaining suffix as-is; any *trailing*
+  // partial tile is fine for prefill (only writing into a partial tile at the
+  // start would corrupt previously-written KV, which the tile alignment of
+  // `matchedTokens` guarantees against). No 32-rounding / pull-back of matched
+  // tokens is needed.
   TT_LOG_DEBUG(
       "[DisaggregationService] applyDeltaPrompt: matchedTokens={} "
-      "effectiveSkip={} pullBack={} alignedRemainder={}",
-      matchedTokens, effectiveSkip, pullBack, alignedRemainder);
+      "remainder={}",
+      matchedTokens, static_cast<uint32_t>(tokens.size()) - matchedTokens);
 
-  // Remove the first `effectiveSkip` tokens — they are already in KV cache.
+  // Remove the first `matchedTokens` tokens — they are already in KV cache.
   tokens.erase(tokens.begin(),
-               tokens.begin() + static_cast<ptrdiff_t>(effectiveSkip));
+               tokens.begin() + static_cast<ptrdiff_t>(matchedTokens));
   req.prompt_tokens_count = static_cast<int>(tokens.size());
 
   // kv_position_id points to the last valid KV cache position (0-indexed),
   // which is one less than the number of tokens we're reusing.
-  req.kv_position_id = effectiveSkip - 1;
+  req.kv_position_id = matchedTokens - 1;
 }
 
 void DisaggregationService::resolvePrefillSession(

--- a/tt-media-server/cpp_server/tests/test_apply_delta_prompt.cpp
+++ b/tt-media-server/cpp_server/tests/test_apply_delta_prompt.cpp
@@ -12,6 +12,11 @@ using namespace tt::domain::llm;
 
 // Reimplementation of DisaggregationService::applyDeltaPrompt for unit testing.
 // Must be kept in sync with the production implementation.
+//
+// `matchedTokens` is always a multiple of 32 (prefix-cache blocks are 32 tokens
+// wide), so we trim exactly `matchedTokens` and the resumed prefill starts on a
+// tile boundary. No 32-rounding / pull-back of matched tokens is performed; the
+// trailing partial tile of the remaining suffix is handled by prefill.
 namespace {
 
 void applyDeltaPrompt(LLMRequest& req, uint32_t matchedTokens) {
@@ -20,24 +25,10 @@ void applyDeltaPrompt(LLMRequest& req, uint32_t matchedTokens) {
     return;
   }
 
-  constexpr uint32_t kAlignment = 32;
-  const uint32_t totalTokens = static_cast<uint32_t>(tokens.size());
-  const uint32_t remainder = totalTokens - matchedTokens;
-  const uint32_t alignedRemainder =
-      ((remainder + kAlignment - 1) / kAlignment) * kAlignment;
-
-  const uint32_t pullBack = alignedRemainder - remainder;
-  const uint32_t effectiveSkip =
-      (pullBack <= matchedTokens) ? (matchedTokens - pullBack) : 0;
-
-  if (effectiveSkip == 0) {
-    return;
-  }
-
   tokens.erase(tokens.begin(),
-               tokens.begin() + static_cast<ptrdiff_t>(effectiveSkip));
+               tokens.begin() + static_cast<ptrdiff_t>(matchedTokens));
   req.prompt_tokens_count = static_cast<int>(tokens.size());
-  req.kv_position_id = effectiveSkip - 1;
+  req.kv_position_id = matchedTokens - 1;
 }
 
 // Helper to create a request with N sequential tokens [0, 1, 2, ..., N-1].
@@ -51,9 +42,9 @@ LLMRequest makeRequest(uint32_t numTokens) {
 
 }  // namespace
 
-// When the remainder is already aligned to 32, no pull-back is needed.
+// Matched tokens are trimmed exactly; an already-aligned remainder is untouched.
 TEST(ApplyDeltaPrompt, RemainderAlreadyAligned) {
-  // 128 total tokens, 96 matched → remainder = 32 (aligned)
+  // 128 total tokens, 96 matched → remainder = 32
   auto req = makeRequest(128);
   applyDeltaPrompt(req, 96);
 
@@ -64,62 +55,32 @@ TEST(ApplyDeltaPrompt, RemainderAlreadyAligned) {
   EXPECT_EQ(req.prompt_tokens_count, 32);
 }
 
-// When remainder is not aligned, tokens are pulled back to make it aligned.
-TEST(ApplyDeltaPrompt, RemainderNotAligned_PullBack) {
-  // 100 total tokens, 90 matched → remainder = 10
-  // alignedRemainder = ceil(10/32)*32 = 32
-  // pullBack = 32 - 10 = 22
-  // effectiveSkip = 90 - 22 = 68
-  // remaining tokens = 100 - 68 = 32 (aligned!)
-  auto req = makeRequest(100);
-  applyDeltaPrompt(req, 90);
+// A non-32-aligned remainder is sent as-is (no pull-back): the resumed prefill
+// still starts on a tile boundary because `matchedTokens` is 32-aligned, and
+// the trailing partial tile is fine for prefill.
+TEST(ApplyDeltaPrompt, RemainderNotAligned_SentAsIs) {
+  // 657 total tokens, 640 matched → remainder = 17 (partial tile)
+  auto req = makeRequest(657);
+  applyDeltaPrompt(req, 640);
 
   auto& tokens = std::get<std::vector<int>>(req.prompt);
-  EXPECT_EQ(tokens.size(), 32u);
-  EXPECT_EQ(tokens.front(), 68);
-  EXPECT_EQ(req.kv_position_id, 67u);
-  EXPECT_EQ(req.prompt_tokens_count, 32);
+  EXPECT_EQ(tokens.size(), 17u);
+  EXPECT_EQ(tokens.front(), 640);
+  EXPECT_EQ(req.kv_position_id, 639u);
+  EXPECT_EQ(req.prompt_tokens_count, 17);
 }
 
-// When remainder needs only a small pull-back.
-TEST(ApplyDeltaPrompt, RemainderSlightlyMisaligned) {
-  // 100 total, 68 matched → remainder = 32 (already aligned, pullBack = 0)
-  auto req = makeRequest(100);
-  applyDeltaPrompt(req, 68);
+// The whole remaining suffix (including the prior partial tile) is sent.
+TEST(ApplyDeltaPrompt, MultiTurnSuffix) {
+  // Scenario: 640 cached (32-aligned) of a (17 + 640 + 1280) = 1937 prompt.
+  auto req = makeRequest(1937);
+  applyDeltaPrompt(req, 640);
 
   auto& tokens = std::get<std::vector<int>>(req.prompt);
-  EXPECT_EQ(tokens.size(), 32u);
-  EXPECT_EQ(tokens.front(), 68);
-  EXPECT_EQ(req.kv_position_id, 67u);
-}
-
-// When matched tokens are too few to satisfy pull-back, effectiveSkip = 0.
-TEST(ApplyDeltaPrompt, InsufficientMatchedTokens_NoDelta) {
-  // 100 total, 5 matched → remainder = 95
-  // alignedRemainder = ceil(95/32)*32 = 96
-  // pullBack = 96 - 95 = 1
-  // effectiveSkip = 5 - 1 = 4
-  // This works, remainder = 96
-  auto req = makeRequest(100);
-  applyDeltaPrompt(req, 5);
-
-  auto& tokens = std::get<std::vector<int>>(req.prompt);
-  EXPECT_EQ(tokens.size(), 96u);
-  EXPECT_EQ(tokens.front(), 4);
-  EXPECT_EQ(req.kv_position_id, 3u);
-}
-
-// When pullBack exceeds matchedTokens, nothing happens.
-TEST(ApplyDeltaPrompt, PullBackExceedsMatched_NoDelta) {
-  // 64 total, 1 matched → remainder = 63
-  // alignedRemainder = ceil(63/32)*32 = 64
-  // pullBack = 64 - 63 = 1
-  // effectiveSkip = 1 - 1 = 0 → no-op
-  auto req = makeRequest(64);
-  applyDeltaPrompt(req, 1);
-
-  auto& tokens = std::get<std::vector<int>>(req.prompt);
-  EXPECT_EQ(tokens.size(), 64u);  // unchanged
+  EXPECT_EQ(tokens.size(), 1297u);  // 17 + 1280
+  EXPECT_EQ(tokens.front(), 640);
+  EXPECT_EQ(req.kv_position_id, 639u);
+  EXPECT_EQ(req.prompt_tokens_count, 1297);
 }
 
 // Zero matched tokens is a no-op.
@@ -129,6 +90,7 @@ TEST(ApplyDeltaPrompt, ZeroMatchedTokens_NoOp) {
 
   auto& tokens = std::get<std::vector<int>>(req.prompt);
   EXPECT_EQ(tokens.size(), 100u);
+  EXPECT_FALSE(req.kv_position_id.has_value());
 }
 
 // matchedTokens >= total is a no-op.
@@ -138,33 +100,28 @@ TEST(ApplyDeltaPrompt, MatchedExceedsTotal_NoOp) {
 
   auto& tokens = std::get<std::vector<int>>(req.prompt);
   EXPECT_EQ(tokens.size(), 50u);
+  EXPECT_FALSE(req.kv_position_id.has_value());
 }
 
-// Large prompt, verify alignment holds.
-TEST(ApplyDeltaPrompt, LargePrompt_AlignmentHolds) {
-  // 2048 total, 1500 matched → remainder = 548
-  // alignedRemainder = ceil(548/32)*32 = 576 (18*32)
-  // pullBack = 576 - 548 = 28
-  // effectiveSkip = 1500 - 28 = 1472
-  // remaining = 2048 - 1472 = 576
+// Large prompt: trims exactly the matched prefix, suffix kept verbatim.
+TEST(ApplyDeltaPrompt, LargePrompt) {
+  // 2048 total, 1504 matched (47 * 32) → remainder = 544
   auto req = makeRequest(2048);
-  applyDeltaPrompt(req, 1500);
+  applyDeltaPrompt(req, 1504);
 
   auto& tokens = std::get<std::vector<int>>(req.prompt);
-  EXPECT_EQ(tokens.size(), 576u);
-  EXPECT_EQ(tokens.size() % 32, 0u);
-  EXPECT_EQ(tokens.front(), 1472);
-  EXPECT_EQ(req.kv_position_id, 1471u);
+  EXPECT_EQ(tokens.size(), 544u);
+  EXPECT_EQ(tokens.front(), 1504);
+  EXPECT_EQ(req.kv_position_id, 1503u);
 }
 
 // Exact 32-boundary matched tokens with exact remainder.
 TEST(ApplyDeltaPrompt, ExactBoundaries) {
-  // 256 total, 192 matched → remainder = 64 (aligned)
+  // 256 total, 192 matched → remainder = 64
   auto req = makeRequest(256);
   applyDeltaPrompt(req, 192);
 
   auto& tokens = std::get<std::vector<int>>(req.prompt);
   EXPECT_EQ(tokens.size(), 64u);
-  EXPECT_EQ(tokens.size() % 32, 0u);
   EXPECT_EQ(req.kv_position_id, 191u);
 }

--- a/tt-media-server/cpp_server/tests/test_apply_delta_prompt.cpp
+++ b/tt-media-server/cpp_server/tests/test_apply_delta_prompt.cpp
@@ -42,7 +42,8 @@ LLMRequest makeRequest(uint32_t numTokens) {
 
 }  // namespace
 
-// Matched tokens are trimmed exactly; an already-aligned remainder is untouched.
+// Matched tokens are trimmed exactly; an already-aligned remainder is
+// untouched.
 TEST(ApplyDeltaPrompt, RemainderAlreadyAligned) {
   // 128 total tokens, 96 matched → remainder = 32
   auto req = makeRequest(128);


### PR DESCRIPTION
## Issue
[#3775 Token adjustment on sending](https://github.com/tenstorrent/tt-inference-server/issues/3775)

## Problem
The additional adjustment to make the new delta prompt 32-token aligned is not necessary. New requests are already padded to 5K tokens in the Prefill Scheduler, and matchedTokens is inherently 32-token aligned because prefix caching operates on blocks of 32 tokens. As a result, the required alignment is already guaranteed by the existing mechanisms.

<img width="1652" height="736" alt="Screenshot 2026-06-05 at 13 35 41 (1)" src="https://github.com/user-attachments/assets/8e1fe49b-f005-4f9e-8390-1ed96a662742" />
