### PR TITLE
Propagate Both decodePositionId and decodeSkipTokens to Prefill Node

### DIFF
--- a/tt-media-server/cpp_server/include/domain/llm/llm_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/llm_request.hpp
@@ -133,7 +133,7 @@ struct LLMRequest : BaseRequest {
 
   // Number of tokens already in the decode-side KV cache that the prefill
   // prefill should not send this part of KV.
-  int number_of_decode_skip_tokens = 0;
+  int decode_position_id = 0;
 
   std::optional<bool> disaggregation_override;
 

--- a/tt-media-server/cpp_server/include/domain/llm/llm_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/llm_request.hpp
@@ -135,6 +135,16 @@ struct LLMRequest : BaseRequest {
   // prefill should not send this part of KV.
   int decode_position_id = 0;
 
+  // Accumulated think (reasoning) tokens in the matched prefix, folded into
+  // kv_position_id during decode-side session resolution. Used to derive
+  // decode_skip_tokens. Set on a prefix-cache hit.
+  int accumulated_think_tokens = 0;
+
+  // Same leading reused prefix as decode_position_id but excluding the
+  // accumulated think tokens. Computed on the decode side and forwarded to the
+  // prefill server, which stores it on the Sequence.
+  int decode_skip_tokens = 0;
+
   std::optional<bool> disaggregation_override;
 
   bool parallel_tool_calls = true;

--- a/tt-media-server/cpp_server/include/domain/llm/sequence.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/sequence.hpp
@@ -43,7 +43,7 @@ class Sequence {
            std::optional<uint32_t> prefillSlotId, bool continuation,
            bool disaggregated, std::unique_ptr<SamplingParams> samplingParams,
            std::optional<uint32_t> kvPositionId = std::nullopt,
-           int numberOfDecodeSkipTokens = 0);
+           int decodePositionId = 0);
 
   void serialize(std::ostream& os) const;
   static Sequence deserialize(std::istream& is);
@@ -109,8 +109,8 @@ class Sequence {
   std::optional<uint32_t> getKVPositionId() const { return kvPositionId; }
   void setKVPositionId(uint32_t positionId) { kvPositionId = positionId; }
 
-  int getNumberOfDecodeSkipTokens() const { return numberOfDecodeSkipTokens; }
-  void setNumberOfDecodeSkipTokens(int n) { numberOfDecodeSkipTokens = n; }
+  int getDecodePositionId() const { return decodePositionId; }
+  void setDecodePositionId(int n) { decodePositionId = n; }
 
  private:
   SequenceStatus status = SequenceStatus::WAITING;
@@ -126,7 +126,7 @@ class Sequence {
   uint32_t prefillKvCacheSlot = tt::domain::INVALID_SLOT_ID;
   bool continuation = false;   // True if this continues an existing session
   bool disaggregated = false;  // True if this is a disaggregated request
-  int numberOfDecodeSkipTokens = 0;
+  int decodePositionId = 0;
 };
 
 }  // namespace tt::domain::llm

--- a/tt-media-server/cpp_server/include/domain/llm/sequence.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/sequence.hpp
@@ -43,7 +43,7 @@ class Sequence {
            std::optional<uint32_t> prefillSlotId, bool continuation,
            bool disaggregated, std::unique_ptr<SamplingParams> samplingParams,
            std::optional<uint32_t> kvPositionId = std::nullopt,
-           int decodePositionId = 0);
+           int decodePositionId = 0, int decodeSkipTokens = 0);
 
   void serialize(std::ostream& os) const;
   static Sequence deserialize(std::istream& is);
@@ -112,6 +112,9 @@ class Sequence {
   int getDecodePositionId() const { return decodePositionId; }
   void setDecodePositionId(int n) { decodePositionId = n; }
 
+  int getDecodeSkipTokens() const { return decodeSkipTokens; }
+  void setDecodeSkipTokens(int n) { decodeSkipTokens = n; }
+
  private:
   SequenceStatus status = SequenceStatus::WAITING;
   std::vector<int64_t> tokenIds;
@@ -127,6 +130,9 @@ class Sequence {
   bool continuation = false;   // True if this continues an existing session
   bool disaggregated = false;  // True if this is a disaggregated request
   int decodePositionId = 0;
+  // Reused prefix length excluding accumulated think tokens, forwarded from the
+  // decode server. Stored only; not yet consumed by the runner.
+  int decodeSkipTokens = 0;
 };
 
 }  // namespace tt::domain::llm

--- a/tt-media-server/cpp_server/include/sockets/inter_server_service.hpp
+++ b/tt-media-server/cpp_server/include/sockets/inter_server_service.hpp
@@ -94,7 +94,7 @@ class InterServerService {
                           std::optional<int> maxTokens = std::nullopt,
                           std::optional<uint32_t> slotId = std::nullopt,
                           const tt::domain::llm::SamplingParams& sampling = {},
-                          int decodePositionId = 0);
+                          int decodePositionId = 0, int decodeSkipTokens = 0);
 
   /**
    * @brief Send prefill result back to the decode server

--- a/tt-media-server/cpp_server/include/sockets/inter_server_service.hpp
+++ b/tt-media-server/cpp_server/include/sockets/inter_server_service.hpp
@@ -94,7 +94,7 @@ class InterServerService {
                           std::optional<int> maxTokens = std::nullopt,
                           std::optional<uint32_t> slotId = std::nullopt,
                           const tt::domain::llm::SamplingParams& sampling = {},
-                          int numberOfDecodeSkipTokens = 0);
+                          int decodePositionId = 0);
 
   /**
    * @brief Send prefill result back to the decode server

--- a/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
@@ -44,7 +44,7 @@ struct PrefillRequestMessage {
   std::optional<float> top_p;
   std::optional<int> top_k;
   bool fast_mode = false;
-  int number_of_decode_skip_tokens = 0;
+  int decode_position_id = 0;
 
   explicit PrefillRequestMessage(uint32_t taskId) : task_id(taskId) {}
 
@@ -59,8 +59,7 @@ struct PrefillRequestMessage {
     bool hasTopK = top_k.has_value();
     int topKVal = top_k.value_or(0);
     ar(task_id, registration_hashes, token_ids, mt, sid, hasTemp, tempVal,
-       hasTopP, topPVal, hasTopK, topKVal, fast_mode,
-       number_of_decode_skip_tokens);
+       hasTopP, topPVal, hasTopK, topKVal, fast_mode, decode_position_id);
   }
 
   template <class Archive>
@@ -77,9 +76,9 @@ struct PrefillRequestMessage {
     bool hasTopK;
     int topKVal;
     bool fastMode;
-    int decodeSkipTokens;
+    int decodePositionId;
     ar(tid, hashes, tids, mt, sid, hasTemp, tempVal, hasTopP, topPVal, hasTopK,
-       topKVal, fastMode, decodeSkipTokens);
+       topKVal, fastMode, decodePositionId);
     PrefillRequestMessage msg(tid);
     msg.registration_hashes = std::move(hashes);
     msg.token_ids = std::move(tids);
@@ -91,7 +90,7 @@ struct PrefillRequestMessage {
     if (hasTopP) msg.top_p = topPVal;
     if (hasTopK) msg.top_k = topKVal;
     msg.fast_mode = fastMode;
-    msg.number_of_decode_skip_tokens = decodeSkipTokens;
+    msg.decode_position_id = decodePositionId;
     return msg;
   }
 };

--- a/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
@@ -45,6 +45,7 @@ struct PrefillRequestMessage {
   std::optional<int> top_k;
   bool fast_mode = false;
   int decode_position_id = 0;
+  int decode_skip_tokens = 0;
 
   explicit PrefillRequestMessage(uint32_t taskId) : task_id(taskId) {}
 
@@ -59,7 +60,8 @@ struct PrefillRequestMessage {
     bool hasTopK = top_k.has_value();
     int topKVal = top_k.value_or(0);
     ar(task_id, registration_hashes, token_ids, mt, sid, hasTemp, tempVal,
-       hasTopP, topPVal, hasTopK, topKVal, fast_mode, decode_position_id);
+       hasTopP, topPVal, hasTopK, topKVal, fast_mode, decode_position_id,
+       decode_skip_tokens);
   }
 
   template <class Archive>
@@ -77,8 +79,9 @@ struct PrefillRequestMessage {
     int topKVal;
     bool fastMode;
     int decodePositionId;
+    int decodeSkipTokens;
     ar(tid, hashes, tids, mt, sid, hasTemp, tempVal, hasTopP, topPVal, hasTopK,
-       topKVal, fastMode, decodePositionId);
+       topKVal, fastMode, decodePositionId, decodeSkipTokens);
     PrefillRequestMessage msg(tid);
     msg.registration_hashes = std::move(hashes);
     msg.token_ids = std::move(tids);
@@ -91,6 +94,7 @@ struct PrefillRequestMessage {
     if (hasTopK) msg.top_k = topKVal;
     msg.fast_mode = fastMode;
     msg.decode_position_id = decodePositionId;
+    msg.decode_skip_tokens = decodeSkipTokens;
     return msg;
   }
 };

--- a/tt-media-server/cpp_server/src/domain/llm/sequence.cpp
+++ b/tt-media-server/cpp_server/src/domain/llm/sequence.cpp
@@ -35,7 +35,8 @@ Sequence::Sequence(uint32_t taskId, int blockSize,
                    std::optional<uint32_t> prefillSlotId, bool continuation,
                    bool disaggregated,
                    std::unique_ptr<SamplingParams> inputSamplingParams,
-                   std::optional<uint32_t> kvPositionId, int decodePositionId)
+                   std::optional<uint32_t> kvPositionId, int decodePositionId,
+                   int decodeSkipTokens)
     : taskId(taskId),
       status(SequenceStatus::WAITING),
       tokenIds(std::move(inputTokenIds)),
@@ -47,7 +48,8 @@ Sequence::Sequence(uint32_t taskId, int blockSize,
       prefillKvCacheSlot(prefillSlotId.value_or(tt::domain::INVALID_SLOT_ID)),
       continuation(continuation),
       disaggregated(disaggregated),
-      decodePositionId(decodePositionId) {
+      decodePositionId(decodePositionId),
+      decodeSkipTokens(decodeSkipTokens) {
   if (!tokenIds.empty()) {
     lastToken = tokenIds.back();
   }
@@ -113,6 +115,8 @@ void Sequence::serialize(std::ostream& os) const {
   }
   os.write(reinterpret_cast<const char*>(&decodePositionId),
            sizeof(decodePositionId));
+  os.write(reinterpret_cast<const char*>(&decodeSkipTokens),
+           sizeof(decodeSkipTokens));
 }
 
 Sequence Sequence::deserialize(std::istream& is) {
@@ -165,6 +169,8 @@ Sequence Sequence::deserialize(std::istream& is) {
   }
   is.read(reinterpret_cast<char*>(&seq.decodePositionId),
           sizeof(seq.decodePositionId));
+  is.read(reinterpret_cast<char*>(&seq.decodeSkipTokens),
+          sizeof(seq.decodeSkipTokens));
   return seq;
 }
 

--- a/tt-media-server/cpp_server/src/domain/llm/sequence.cpp
+++ b/tt-media-server/cpp_server/src/domain/llm/sequence.cpp
@@ -35,8 +35,7 @@ Sequence::Sequence(uint32_t taskId, int blockSize,
                    std::optional<uint32_t> prefillSlotId, bool continuation,
                    bool disaggregated,
                    std::unique_ptr<SamplingParams> inputSamplingParams,
-                   std::optional<uint32_t> kvPositionId,
-                   int numberOfDecodeSkipTokens)
+                   std::optional<uint32_t> kvPositionId, int decodePositionId)
     : taskId(taskId),
       status(SequenceStatus::WAITING),
       tokenIds(std::move(inputTokenIds)),
@@ -48,7 +47,7 @@ Sequence::Sequence(uint32_t taskId, int blockSize,
       prefillKvCacheSlot(prefillSlotId.value_or(tt::domain::INVALID_SLOT_ID)),
       continuation(continuation),
       disaggregated(disaggregated),
-      numberOfDecodeSkipTokens(numberOfDecodeSkipTokens) {
+      decodePositionId(decodePositionId) {
   if (!tokenIds.empty()) {
     lastToken = tokenIds.back();
   }
@@ -112,8 +111,8 @@ void Sequence::serialize(std::ostream& os) const {
     os.write(reinterpret_cast<const char*>(&kvPositionIdValue),
              sizeof(uint32_t));
   }
-  os.write(reinterpret_cast<const char*>(&numberOfDecodeSkipTokens),
-           sizeof(numberOfDecodeSkipTokens));
+  os.write(reinterpret_cast<const char*>(&decodePositionId),
+           sizeof(decodePositionId));
 }
 
 Sequence Sequence::deserialize(std::istream& is) {
@@ -164,8 +163,8 @@ Sequence Sequence::deserialize(std::istream& is) {
   } else {
     seq.kvPositionId = std::nullopt;
   }
-  is.read(reinterpret_cast<char*>(&seq.numberOfDecodeSkipTokens),
-          sizeof(seq.numberOfDecodeSkipTokens));
+  is.read(reinterpret_cast<char*>(&seq.decodePositionId),
+          sizeof(seq.decodePositionId));
   return seq;
 }
 

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_prefill_runner/blaze_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_prefill_runner/blaze_prefill_runner.cpp
@@ -42,10 +42,9 @@ void BlazePrefillRunner::run() {
     TT_LOG_DEBUG("[BlazePrefillRunner] Starting prefill for task {}",
                  sequence->taskId);
 
-    if (sequence->getNumberOfDecodeSkipTokens() > 0) {
-      TT_LOG_INFO(
-          "[BlazePrefillRunner] task {} has numberOfDecodeSkipTokens={}",
-          sequence->taskId, sequence->getNumberOfDecodeSkipTokens());
+    if (sequence->getDecodePositionId() > 0) {
+      TT_LOG_INFO("[BlazePrefillRunner] task {} has decodePositionId={}",
+                  sequence->taskId, sequence->getDecodePositionId());
     }
 
     auto result = modelRunner->forward(

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -170,12 +170,16 @@ void DisaggregationService::setupSocketHandlers() {
                 // Cached (reused) prompt tokens = the leading prefix that did
                 // NOT need a fresh prefill. Two sources describe that same
                 // prefix; take the larger:
-                //   - decode_position_id: the prefix the decode node already
-                //     holds in its KV from earlier turns. The decode node does
-                //     the multi-turn prefix match and ships the full prompt
-                //     plus this skip count (it does not trim itself); the
-                //     prefill runner honors it. This is the dominant source in
-                //     chat.
+                //   - decode_skip_tokens: the prompt prefix the decode node
+                //     already holds in its KV from earlier turns. The decode
+                //     node does the multi-turn prefix match and ships the full
+                //     prompt plus this skip count (it does not trim itself);
+                //     the prefill runner honors it. This is the dominant source
+                //     in chat. We use decode_skip_tokens (not
+                //     decode_position_id) because it excludes the accumulated
+                //     think tokens folded into kv_position_id — those occupy KV
+                //     slots but are not prompt tokens, so counting them would
+                //     inflate cached_tokens beyond prompt_tokens.
                 //   - prefill-side trim (fullPrompt - delta): when the prefill
                 //     server independently hits its own prefix cache.
                 const int prefillTrim = static_cast<int>(
@@ -183,7 +187,7 @@ void DisaggregationService::setupSocketHandlers() {
                         ? fullPromptTokens - trimmedPromptTokens
                         : 0);
                 const int cachedTokens =
-                    std::max(prefillTrim, message.decode_position_id);
+                    std::max(prefillTrim, message.decode_skip_tokens);
                 // Capture the resolved sessionId by value:
                 // submitStreamingRequest hands the request to the pipeline, so
                 // request->sessionId is no longer reliable by the time this

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -167,27 +167,22 @@ void DisaggregationService::setupSocketHandlers() {
                 const size_t fullPromptTokens = message.token_ids.size();
                 const size_t trimmedPromptTokens =
                     std::get<std::vector<int>>(request->prompt).size();
-                // Cached (reused) prompt tokens = the leading prefix that did
-                // NOT need a fresh prefill. Two sources describe that same
-                // prefix; take the larger:
-                //   - decode_skip_tokens: the prompt prefix the decode node
-                //     already holds in its KV from earlier turns. The decode
-                //     node does the multi-turn prefix match and ships the full
-                //     prompt plus this skip count (it does not trim itself);
-                //     the prefill runner honors it. This is the dominant source
-                //     in chat. We use decode_skip_tokens (not
-                //     decode_position_id) because it excludes the accumulated
-                //     think tokens folded into kv_position_id — those occupy KV
-                //     slots but are not prompt tokens, so counting them would
-                //     inflate cached_tokens beyond prompt_tokens.
-                //   - prefill-side trim (fullPrompt - delta): when the prefill
-                //     server independently hits its own prefix cache.
-                const int prefillTrim = static_cast<int>(
+                // Cached (reused) prompt tokens = the leading prefix this
+                // prefill did NOT recompute = what resolvePrefillSession
+                // trimmed off its own prefix-cache hit (fullPrompt - remaining
+                // delta).
+                //
+                // Only the prefill-side trim counts: the prefill runner trims
+                // and recomputes purely by its own prefix match, so any prefix
+                // the decode node reports (decode_skip_tokens) but that prefill
+                // does not have gets recomputed here — it is not cached.
+                // Folding decode_skip_tokens in (e.g. via max) would
+                // over-report cached_tokens by exactly the tokens prefill
+                // re-prefilled.
+                const int cachedTokens = static_cast<int>(
                     fullPromptTokens >= trimmedPromptTokens
                         ? fullPromptTokens - trimmedPromptTokens
                         : 0);
-                const int cachedTokens =
-                    std::max(prefillTrim, message.decode_skip_tokens);
                 // Capture the resolved sessionId by value:
                 // submitStreamingRequest hands the request to the pipeline, so
                 // request->sessionId is no longer reliable by the time this

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -153,8 +153,7 @@ void DisaggregationService::setupSocketHandlers() {
                                                     message.token_ids.end());
           auto slotId = message.slot_id;
           request->slotId = slotId;
-          request->number_of_decode_skip_tokens =
-              message.number_of_decode_skip_tokens;
+          request->decode_position_id = message.decode_position_id;
 
           // Resolve prefix cache asynchronously: on HIT sets prefillSlotId
           // and trims prompt, on MISS allocates a new session first.
@@ -170,7 +169,7 @@ void DisaggregationService::setupSocketHandlers() {
                 // Cached (reused) prompt tokens = the leading prefix that did
                 // NOT need a fresh prefill. Two sources describe that same
                 // prefix; take the larger:
-                //   - decode_skip_tokens: the prefix the decode node already
+                //   - decode_position_id: the prefix the decode node already
                 //     holds in its KV from earlier turns. The decode node does
                 //     the multi-turn prefix match and ships the full prompt
                 //     plus this skip count (it does not trim itself); the
@@ -183,7 +182,7 @@ void DisaggregationService::setupSocketHandlers() {
                         ? fullPromptTokens - trimmedPromptTokens
                         : 0);
                 const int cachedTokens =
-                    std::max(prefillTrim, message.number_of_decode_skip_tokens);
+                    std::max(prefillTrim, message.decode_position_id);
                 // Capture the resolved sessionId by value:
                 // submitStreamingRequest hands the request to the pipeline, so
                 // request->sessionId is no longer reliable by the time this
@@ -439,7 +438,7 @@ void DisaggregationService::handleStreamingRequest(
     auto maxTokens = request.max_tokens;
     auto slotId = request.slotId;
     auto tokenIds = std::get<std::vector<int>>(request.prompt);
-    int decodeSkipTokens = request.kv_position_id.has_value()
+    int decodePositionId = request.kv_position_id.has_value()
                                ? static_cast<int>(*request.kv_position_id + 1)
                                : 0;
 
@@ -447,7 +446,7 @@ void DisaggregationService::handleStreamingRequest(
         request.task_id, registrationHashes,
         std::vector<int64_t>(tokenIds.begin(), tokenIds.end()), maxTokens,
         slotId, tt::utils::mapper::mapSamplingParams(request),
-        decodeSkipTokens);
+        decodePositionId);
 
     if (!sent) {
       streamCallbacks.erase(request.task_id);

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -154,6 +154,7 @@ void DisaggregationService::setupSocketHandlers() {
           auto slotId = message.slot_id;
           request->slotId = slotId;
           request->decode_position_id = message.decode_position_id;
+          request->decode_skip_tokens = message.decode_skip_tokens;
 
           // Resolve prefix cache asynchronously: on HIT sets prefillSlotId
           // and trims prompt, on MISS allocates a new session first.
@@ -441,12 +442,16 @@ void DisaggregationService::handleStreamingRequest(
     int decodePositionId = request.kv_position_id.has_value()
                                ? static_cast<int>(*request.kv_position_id + 1)
                                : 0;
+    // Same reused prefix as decodePositionId but excluding the accumulated
+    // think tokens that were folded into kv_position_id during session
+    // resolution.
+    int decodeSkipTokens = decodePositionId - request.accumulated_think_tokens;
 
     auto sent = socketService->sendPrefillRequest(
         request.task_id, registrationHashes,
         std::vector<int64_t>(tokenIds.begin(), tokenIds.end()), maxTokens,
-        slotId, tt::utils::mapper::mapSamplingParams(request),
-        decodePositionId);
+        slotId, tt::utils::mapper::mapSamplingParams(request), decodePositionId,
+        decodeSkipTokens);
 
     if (!sent) {
       streamCallbacks.erase(request.task_id);

--- a/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
@@ -172,6 +172,8 @@ void LLMPipeline::resolveSession(
         // thinking tokens (accumulated in cache but not in hash)
         req->kv_position_id = --acquired->numberOfMatchedTokens +
                               acquired->accumulatedThinkTokens;
+        req->accumulated_think_tokens =
+            static_cast<int>(acquired->accumulatedThinkTokens);
 
         std::vector<int> fullPrompt;
         if (auto* p = std::get_if<std::vector<int>>(&req->prompt)) {

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -626,7 +626,7 @@ void LLMService::produceStream(
       request.continuation, request.disaggregated,
       std::make_unique<tt::domain::llm::SamplingParams>(
           tt::utils::mapper::mapSamplingParams(request)),
-      request.kv_position_id, request.number_of_decode_skip_tokens);
+      request.kv_position_id, request.decode_position_id);
   taskQueue->push(*std::move(sequence));
 }
 

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -626,7 +626,8 @@ void LLMService::produceStream(
       request.continuation, request.disaggregated,
       std::make_unique<tt::domain::llm::SamplingParams>(
           tt::utils::mapper::mapSamplingParams(request)),
-      request.kv_position_id, request.decode_position_id);
+      request.kv_position_id, request.decode_position_id,
+      request.decode_skip_tokens);
   taskQueue->push(*std::move(sequence));
 }
 

--- a/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
+++ b/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
@@ -144,7 +144,8 @@ bool InterServerService::sendPrefillRequest(
     uint32_t taskId, const std::vector<uint64_t>& registrationHashes,
     const std::vector<int64_t>& tokenIds, std::optional<int> maxTokens,
     std::optional<uint32_t> slotId,
-    const tt::domain::llm::SamplingParams& sampling, int decodePositionId) {
+    const tt::domain::llm::SamplingParams& sampling, int decodePositionId,
+    int decodeSkipTokens) {
   if (!enabled_) {
     return false;
   }
@@ -159,6 +160,7 @@ bool InterServerService::sendPrefillRequest(
   message.top_k = sampling.top_k;
   message.fast_mode = sampling.fast_mode;
   message.decode_position_id = decodePositionId;
+  message.decode_skip_tokens = decodeSkipTokens;
 
   return socket_manager_.sendObject("prefill_request", message);
 }

--- a/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
+++ b/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
@@ -144,8 +144,7 @@ bool InterServerService::sendPrefillRequest(
     uint32_t taskId, const std::vector<uint64_t>& registrationHashes,
     const std::vector<int64_t>& tokenIds, std::optional<int> maxTokens,
     std::optional<uint32_t> slotId,
-    const tt::domain::llm::SamplingParams& sampling,
-    int numberOfDecodeSkipTokens) {
+    const tt::domain::llm::SamplingParams& sampling, int decodePositionId) {
   if (!enabled_) {
     return false;
   }
@@ -159,7 +158,7 @@ bool InterServerService::sendPrefillRequest(
   message.top_p = sampling.top_p;
   message.top_k = sampling.top_k;
   message.fast_mode = sampling.fast_mode;
-  message.number_of_decode_skip_tokens = numberOfDecodeSkipTokens;
+  message.decode_position_id = decodePositionId;
 
   return socket_manager_.sendObject("prefill_request", message);
 }

--- a/tt-media-server/cpp_server/tests/integration/prefill_integration_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/prefill_integration_test.cpp
@@ -306,7 +306,7 @@ TEST_F(PrefillIntegrationTest, PrefillRequest_TriggersSessionAllocation) {
   prefillReq.temperature = 0.7f;
   prefillReq.top_p = 0.9f;
   prefillReq.registration_hashes = {111, 222};
-  prefillReq.number_of_decode_skip_tokens = 5;
+  prefillReq.decode_position_id = 5;
 
   // Send the prefill request from mock decode to our prefill server
   bool sent = mockDecode->send("prefill_request", prefillReq);
@@ -343,9 +343,9 @@ TEST_F(PrefillIntegrationTest, PrefillRequest_TriggersSessionAllocation) {
   ASSERT_NE(seq, nullptr);
   EXPECT_GT(seq->getNumPromptTokens(), 0u);
 
-  // Verify number_of_decode_skip_tokens propagated to the Sequence.
-  EXPECT_EQ(seq->getNumberOfDecodeSkipTokens(), 5)
-      << "number_of_decode_skip_tokens must propagate from "
+  // Verify decode_position_id propagated to the Sequence.
+  EXPECT_EQ(seq->getDecodePositionId(), 5)
+      << "decode_position_id must propagate from "
          "PrefillRequestMessage";
 
   // Verify slot_id from decode (7) is the KV cache slot (the worker's output

--- a/tt-media-server/cpp_server/tests/integration/prefill_integration_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/prefill_integration_test.cpp
@@ -307,6 +307,8 @@ TEST_F(PrefillIntegrationTest, PrefillRequest_TriggersSessionAllocation) {
   prefillReq.top_p = 0.9f;
   prefillReq.registration_hashes = {111, 222};
   prefillReq.decode_position_id = 5;
+  // Distinct from decode_position_id to confirm both propagate independently.
+  prefillReq.decode_skip_tokens = 3;
 
   // Send the prefill request from mock decode to our prefill server
   bool sent = mockDecode->send("prefill_request", prefillReq);
@@ -346,6 +348,11 @@ TEST_F(PrefillIntegrationTest, PrefillRequest_TriggersSessionAllocation) {
   // Verify decode_position_id propagated to the Sequence.
   EXPECT_EQ(seq->getDecodePositionId(), 5)
       << "decode_position_id must propagate from "
+         "PrefillRequestMessage";
+
+  // Verify decode_skip_tokens propagated to the Sequence.
+  EXPECT_EQ(seq->getDecodeSkipTokens(), 3)
+      << "decode_skip_tokens must propagate from "
          "PrefillRequestMessage";
 
   // Verify slot_id from decode (7) is the KV cache slot (the worker's output

--- a/tt-media-server/cpp_server/tests/sequence_test.cpp
+++ b/tt-media-server/cpp_server/tests/sequence_test.cpp
@@ -136,6 +136,8 @@ TEST(SequenceTest, SerializeDeserialize_RoundTrip_PreservesAllFields) {
   orig.setContinuation(true);
   orig.setDisaggregated(true);
   orig.setKVPositionId(17);
+  orig.setDecodePositionId(18);
+  orig.setDecodeSkipTokens(11);
 
   std::ostringstream os;
   orig.serialize(os);
@@ -155,6 +157,8 @@ TEST(SequenceTest, SerializeDeserialize_RoundTrip_PreservesAllFields) {
   EXPECT_EQ(restored.isDisaggregated(), orig.isDisaggregated());
   ASSERT_TRUE(restored.getKVPositionId().has_value());
   EXPECT_EQ(*restored.getKVPositionId(), *orig.getKVPositionId());
+  EXPECT_EQ(restored.getDecodePositionId(), orig.getDecodePositionId());
+  EXPECT_EQ(restored.getDecodeSkipTokens(), orig.getDecodeSkipTokens());
   EXPECT_EQ(restored.numCachedBlocks(), orig.numCachedBlocks());
 
   const auto& sp = restored.getSamplingParams();


### PR DESCRIPTION
## Issue
[#4074 Decode should send to prefill skip tokens and start_position](https://github.com/tenstorrent/tt-inference-server/issues/4074)

## Problem
Since reasoning blocks may exist in the Decode node's KV cache but not in the Prefill node's KV cache (as we currently do not support D->P migration), it is not sufficient to know only how many tokens need to be transferred from Prefill to Decode, we also need to know the exact location where those tokens should be transferred.

To support this, we introduce two variables:
- `decodeSkipTokens` - the number of tokens for which KV cache has already been computed on the Decode node and therefore does not need to be transferred or recomputed
- `decodePositionId` - the target position in the Decode KV cache where transferred KV entries should be written, ensuring that already computed state is preserved
