### PR TITLE
Default inter-server transport to ZMQ

### DIFF
--- a/tt-media-server/cpp_server/src/sockets/socket_transport_factory.cpp
+++ b/tt-media-server/cpp_server/src/sockets/socket_transport_factory.cpp
@@ -11,18 +11,18 @@ namespace tt::sockets {
 
 std::unique_ptr<ISocketTransport> createSocketTransport() {
   const std::string type = tt::config::socketTransport();
-  if (type == transport_names::ZMQ) {
-    TT_LOG_INFO("[SocketTransport] Using ZMQ transport");
-    return std::make_unique<ZmqSocketTransport>();
+  if (type == transport_names::TCP) {
+    TT_LOG_INFO("[SocketTransport] Using TCP transport");
+    return std::make_unique<TcpSocketTransport>();
   }
-  if (type != transport_names::TCP) {
+  if (type != transport_names::ZMQ) {
     TT_LOG_WARN(
         "[SocketTransport] Unknown SOCKET_TRANSPORT='{}'; expected '{}' or "
-        "'{}'. Falling back to TCP.",
+        "'{}'. Falling back to ZMQ.",
         type, transport_names::TCP, transport_names::ZMQ);
   }
-  TT_LOG_INFO("[SocketTransport] Using TCP transport");
-  return std::make_unique<TcpSocketTransport>();
+  TT_LOG_INFO("[SocketTransport] Using ZMQ transport");
+  return std::make_unique<ZmqSocketTransport>();
 }
 
 }  // namespace tt::sockets

--- a/tt-media-server/prefill_gateway/README.md
+++ b/tt-media-server/prefill_gateway/README.md
@@ -28,13 +28,13 @@ This produces:
 Run them all with:
 
 ```bash
-SOCKET_TRANSPORT=tcp ctest --test-dir build --output-on-failure
+ctest --test-dir build --output-on-failure
 ```
 
-To run against the ZMQ transport instead of TCP:
+ZMQ is the default transport. To run against the TCP transport instead:
 
 ```bash
-SOCKET_TRANSPORT=zmq ctest --test-dir build --output-on-failure
+SOCKET_TRANSPORT=tcp ctest --test-dir build --output-on-failure
 ```
 
 ## Run the gateway
@@ -44,15 +44,15 @@ SOCKET_TRANSPORT=zmq ctest --test-dir build --output-on-failure
   --decode-port=7100 \
   --metrics-port=9091 \
   --health-port=9092 \
-  --prefill=127.0.0.1:7200 \
-  --prefill=127.0.0.1:7201
+  --prefill-bind=127.0.0.1:7200
 ```
 
 - `--decode-port` is the port the gateway *listens on* for the decode server.
-- `--prefill=HOST:PORT` is a TCP prefill the gateway *dials out to*. Repeat the
-  flag for each prefill.
 - `--prefill-bind=HOST:PORT` is the ZMQ prefill-side ROUTER bind endpoint.
-  ZMQ prefills dial this single endpoint and register themselves.
+  ZMQ prefills dial this single endpoint and register themselves. This is the
+  default transport mode.
+- `--prefill=HOST:PORT` is a TCP prefill the gateway *dials out to* when
+  `SOCKET_TRANSPORT=tcp`. Repeat the flag for each prefill.
 - `--prefill-stale-timeout-ms=MS` controls how long the ZMQ gateway waits
   without a prefill registration before marking that prefill down. Default:
   `3000`.
@@ -111,7 +111,7 @@ flip the inter-server socket roles to talk through the gateway:
 | Env var                         | Set on  | Effect                                                                                         |
 | ------------------------------- | ------- | ---------------------------------------------------------------------------------------------- |
 | `USE_PREFILL_GATEWAY=1`         | both    | Decode dials gateway as CLIENT. TCP prefills listen for the gateway; ZMQ prefills dial the gateway's prefill ROUTER. |
-| `SOCKET_TRANSPORT`              | all     | `tcp` (default) or `zmq`. Must be the same on all three processes.                             |
+| `SOCKET_TRANSPORT`              | all     | `zmq` (default) or `tcp`. Must be the same on all three processes.                             |
 | `PREFILL_SERVER_ID=...`         | prefill | Identity advertised in `PrefillRegistrationMessage`. Default: `<hostname>:<port>`.             |
 | `PREFILL_MAX_IN_FLIGHT=N`       | prefill | Capacity hint sent to the gateway (0 = unlimited).                                             |
 | `MAX_TOKENS_TO_PREFILL_ON_DECODE=0` | decode  | Set to 0 to force all requests through the gateway. Default 1000 keeps short prompts local. |
@@ -132,8 +132,8 @@ The default (`USE_PREFILL_GATEWAY=0`) keeps the existing direct 1:1 wiring.
                                                                   └───────────┘
 ```
 
-The commands below use TCP (default), where the gateway dials each prefill.
-For ZMQ, use the separate ZMQ commands below: the gateway binds one prefill
+The first commands below use explicit TCP, where the gateway dials each prefill.
+For the default ZMQ mode, use the separate ZMQ commands below: the gateway binds one prefill
 ROUTER endpoint and every prefill connects to it.
 
 ### Terminal A — gateway
@@ -350,8 +350,8 @@ TT_LOG_LEVEL=info \
 ./build/tt_media_server_cpp -p 8002
 ```
 
-For ZMQ — just swap `SOCKET_TRANSPORT=tcp` → `SOCKET_TRANSPORT=zmq` on
-**both** processes.
+For the default ZMQ transport, omit `SOCKET_TRANSPORT` or set
+`SOCKET_TRANSPORT=zmq` on **both** processes.
 
 #### Terminal C — drive a request
 

--- a/tt-media-server/prefill_gateway/README.md
+++ b/tt-media-server/prefill_gateway/README.md
@@ -322,14 +322,13 @@ temporarily make that prefill ineligible for new tasks according to
 Without the gateway the decode server is the socket **server** and the prefill
 is the socket **client** that dials into it. Two terminals suffice.
 
-### TCP
+### ZMQ
 
 #### Terminal A — decode (listens on :9000)
 
 ```bash
 cd tt-media-server/cpp_server
 LLM_MODE=decode \
-SOCKET_TRANSPORT=tcp \
 MAX_TOKENS_TO_PREFILL_ON_DECODE=0 \
 SOCKET_HOST=0.0.0.0 \
 SOCKET_PORT=9000 \
@@ -342,7 +341,6 @@ TT_LOG_LEVEL=info \
 ```bash
 cd tt-media-server/cpp_server
 LLM_MODE=prefill \
-SOCKET_TRANSPORT=tcp \
 SOCKET_HOST=127.0.0.1 \
 SOCKET_PORT=9000 \
 LLM_DEVICE_BACKEND=mock \
@@ -350,8 +348,7 @@ TT_LOG_LEVEL=info \
 ./build/tt_media_server_cpp -p 8002
 ```
 
-For the default ZMQ transport, omit `SOCKET_TRANSPORT` or set
-`SOCKET_TRANSPORT=zmq` on **both** processes.
+For TCP, set `SOCKET_TRANSPORT=tcp` on **both** processes.
 
 #### Terminal C — drive a request
 

--- a/tt-media-server/prefill_gateway/src/main.cpp
+++ b/tt-media-server/prefill_gateway/src/main.cpp
@@ -50,13 +50,17 @@ struct GatewayConfig {
 
 void printUsage(const char* prog) {
   std::cerr
-      << "Usage: " << prog << " --decode-port=<PORT> --prefill=<HOST>:<PORT> "
-      << "[--prefill=<HOST>:<PORT> ...]\n\n"
+      << "Usage: " << prog
+      << " --decode-port=<PORT> --prefill-bind=<HOST>:<PORT>\n"
+      << "       " << prog
+      << " --decode-port=<PORT> --prefill=<HOST>:<PORT> "
+      << "[--prefill=<HOST>:<PORT> ...]  # SOCKET_TRANSPORT=tcp\n\n"
       << "  --decode-port=PORT   Port the gateway listens on for decode.\n"
       << "  --prefill=HOST:PORT  TCP prefill server to connect to "
          "(repeatable).\n"
       << "  --prefill-bind=HOST:PORT\n"
-      << "                        ZMQ ROUTER bind endpoint for prefills.\n"
+      << "                        ZMQ ROUTER bind endpoint for prefills "
+      << "(default transport).\n"
       << "  --prefill-stale-timeout-ms=MS\n"
       << "                        ZMQ prefill registration timeout. Default: "
          "3000.\n"
@@ -81,8 +85,7 @@ void printUsage(const char* prog) {
       << "  --help               Print this message.\n\n"
       << "Example:\n"
       << "  " << prog
-      << " --decode-port=7100 --prefill=192.168.1.1:7200 "
-         "--prefill=192.168.1.2:7200\n";
+      << " --decode-port=7100 --prefill-bind=0.0.0.0:7200\n";
 }
 
 std::optional<PrefillEndpoint> parsePrefillArg(std::string_view value) {
@@ -244,7 +247,20 @@ std::optional<GatewayConfig> parseArgs(int argc, char** argv) {
 
 std::string_view socketTransportFromEnv() {
   const char* value = std::getenv("SOCKET_TRANSPORT");
-  return value ? std::string_view(value) : tt::sockets::transport_names::TCP;
+  if (value == nullptr || value[0] == '\0') {
+    return tt::sockets::transport_names::ZMQ;
+  }
+  const std::string_view transport(value);
+  if (transport == tt::sockets::transport_names::TCP ||
+      transport == tt::sockets::transport_names::ZMQ) {
+    return transport;
+  }
+  TT_LOG_WARN(
+      "[Gateway] Unknown SOCKET_TRANSPORT='{}'; expected '{}' or '{}'. "
+      "Falling back to ZMQ.",
+      transport, tt::sockets::transport_names::TCP,
+      tt::sockets::transport_names::ZMQ);
+  return tt::sockets::transport_names::ZMQ;
 }
 
 volatile sig_atomic_t gStop = 0;

--- a/tt-media-server/prefill_gateway/src/main.cpp
+++ b/tt-media-server/prefill_gateway/src/main.cpp
@@ -52,8 +52,7 @@ void printUsage(const char* prog) {
   std::cerr
       << "Usage: " << prog
       << " --decode-port=<PORT> --prefill-bind=<HOST>:<PORT>\n"
-      << "       " << prog
-      << " --decode-port=<PORT> --prefill=<HOST>:<PORT> "
+      << "       " << prog << " --decode-port=<PORT> --prefill=<HOST>:<PORT> "
       << "[--prefill=<HOST>:<PORT> ...]  # SOCKET_TRANSPORT=tcp\n\n"
       << "  --decode-port=PORT   Port the gateway listens on for decode.\n"
       << "  --prefill=HOST:PORT  TCP prefill server to connect to "
@@ -84,8 +83,7 @@ void printUsage(const char* prog) {
          "0 to disable. Default: 0.\n"
       << "  --help               Print this message.\n\n"
       << "Example:\n"
-      << "  " << prog
-      << " --decode-port=7100 --prefill-bind=0.0.0.0:7200\n";
+      << "  " << prog << " --decode-port=7100 --prefill-bind=0.0.0.0:7200\n";
 }
 
 std::optional<PrefillEndpoint> parsePrefillArg(std::string_view value) {

--- a/tt-media-server/prefill_gateway/src/socket_transport_factory.cpp
+++ b/tt-media-server/prefill_gateway/src/socket_transport_factory.cpp
@@ -14,24 +14,24 @@ namespace tt::sockets {
 namespace {
 std::string socketTransportFromEnv() {
   const char* v = std::getenv("SOCKET_TRANSPORT");
-  return v ? std::string(v) : std::string(transport_names::TCP);
+  return v ? std::string(v) : std::string(transport_names::ZMQ);
 }
 }  // namespace
 
 std::unique_ptr<ISocketTransport> createSocketTransport() {
   const std::string type = socketTransportFromEnv();
-  if (type == transport_names::ZMQ) {
-    TT_LOG_INFO("[Gateway] Using ZMQ transport");
-    return std::make_unique<ZmqSocketTransport>();
+  if (type == transport_names::TCP) {
+    TT_LOG_INFO("[Gateway] Using TCP transport");
+    return std::make_unique<TcpSocketTransport>();
   }
-  if (type != transport_names::TCP) {
+  if (type != transport_names::ZMQ) {
     TT_LOG_WARN(
         "[Gateway] Unknown SOCKET_TRANSPORT='{}'; expected '{}' or '{}'. "
-        "Falling back to TCP.",
+        "Falling back to ZMQ.",
         type, transport_names::TCP, transport_names::ZMQ);
   }
-  TT_LOG_INFO("[Gateway] Using TCP transport");
-  return std::make_unique<TcpSocketTransport>();
+  TT_LOG_INFO("[Gateway] Using ZMQ transport");
+  return std::make_unique<ZmqSocketTransport>();
 }
 
 }  // namespace tt::sockets


### PR DESCRIPTION
Make ZMQ the default socket transport for both `cpp_server` and `prefill_gateway`.
Keep TCP available via explicit `SOCKET_TRANSPORT=tcp`.
