### PR TITLE
 Fix conc=1 `tput` targets: set `tput = tput_user` for forge LLMs

### DIFF
--- a/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/benchmarking/benchmark_targets/model_performance_reference.json
@@ -364,7 +364,7 @@
                     "theoretical": {
                         "ttft_ms": 29.0,
                         "tput_user": 73.0,
-                        "tput": 4483.0
+                        "tput": 73.0
                     }
                 }
             }
@@ -383,7 +383,7 @@
                     "theoretical": {
                         "ttft_ms": 40.0,
                         "tput_user": 41.0,
-                        "tput": 1307.0
+                        "tput": 41.0
                     }
                 }
             }
@@ -402,7 +402,7 @@
                     "theoretical": {
                         "ttft_ms": 51.0,
                         "tput_user": 21.0,
-                        "tput": 654.0
+                        "tput": 21.0
                     }
                 }
             }
@@ -421,7 +421,7 @@
                     "theoretical": {
                         "ttft_ms": 34.0,
                         "tput_user": 33.0,
-                        "tput": 1017.0
+                        "tput": 33.0
                     }
                 }
             }
@@ -440,7 +440,7 @@
                     "theoretical": {
                         "ttft_ms": 29.0,
                         "tput_user": 73.0,
-                        "tput": 17932.0
+                        "tput": 73.0
                     }
                 }
             }
@@ -459,7 +459,7 @@
                     "theoretical": {
                         "ttft_ms": 30.0,
                         "tput_user": 37.0,
-                        "tput": 1162.0
+                        "tput": 37.0
                     }
                 }
             }
@@ -820,7 +820,7 @@
                     "theoretical": {
                         "ttft_ms": 22.0,
                         "tput_user": 81.0,
-                        "tput": 5212.0
+                        "tput": 81.0
                     }
                 }
             }
@@ -839,7 +839,7 @@
                     "theoretical": {
                         "ttft_ms": 51.0,
                         "tput_user": 21.0,
-                        "tput": 652.0
+                        "tput": 21.0
                     }
                 }
             }
@@ -858,7 +858,7 @@
                     "theoretical": {
                         "ttft_ms": 42.0,
                         "tput_user": 41.0,
-                        "tput": 1303.0
+                        "tput": 41.0
                     }
                 }
             }
@@ -877,7 +877,7 @@
                     "theoretical": {
                         "ttft_ms": 34.0,
                         "tput_user": 33.0,
-                        "tput": 1013.0
+                        "tput": 33.0
                     }
                 }
             }
@@ -896,7 +896,7 @@
                     "theoretical": {
                         "ttft_ms": 12.0,
                         "tput_user": 600.0,
-                        "tput": 20848.0
+                        "tput": 600.0
                     }
                 }
             }
@@ -915,7 +915,7 @@
                     "theoretical": {
                         "ttft_ms": 30.0,
                         "tput_user": 37.0,
-                        "tput": 1158.0
+                        "tput": 37.0
                     }
                 }
             }
@@ -1307,7 +1307,7 @@
                     "theoretical": {
                         "ttft_ms": 21.0,
                         "tput_user": 56.0,
-                        "tput": 1682.0
+                        "tput": 56.0
                     }
                 }
             }
@@ -1326,7 +1326,7 @@
                     "theoretical": {
                         "ttft_ms": 12.0,
                         "tput_user": 167.0,
-                        "tput": 13458.0
+                        "tput": 167.0
                     }
                 }
             }
@@ -1345,7 +1345,7 @@
                     "theoretical": {
                         "ttft_ms": 20.0,
                         "tput_user": 109.0,
-                        "tput": 3364.0
+                        "tput": 109.0
                     }
                 }
             }
@@ -1364,7 +1364,7 @@
                     "theoretical": {
                         "ttft_ms": 13.0,
                         "tput_user": 99.0,
-                        "tput": 2991.0
+                        "tput": 99.0
                     }
                 }
             }
@@ -1383,7 +1383,7 @@
                     "theoretical": {
                         "ttft_ms": 14.0,
                         "tput_user": 87.0,
-                        "tput": 2617.0
+                        "tput": 87.0
                     }
                 }
             }
@@ -1402,7 +1402,7 @@
                     "theoretical": {
                         "ttft_ms": 8.0,
                         "tput_user": 1506.0,
-                        "tput": 53832.0
+                        "tput": 1506.0
                     }
                 }
             }
@@ -1520,7 +1520,7 @@
                     "theoretical": {
                         "ttft_ms": 9.0,
                         "tput_user": 1144.0,
-                        "tput": 41381.0
+                        "tput": 1144.0
                     }
                 }
             }
@@ -1539,7 +1539,7 @@
                     "theoretical": {
                         "ttft_ms": 26.0,
                         "tput_user": 82.0,
-                        "tput": 2586.0
+                        "tput": 82.0
                     }
                 }
             }
@@ -1558,7 +1558,7 @@
                     "theoretical": {
                         "ttft_ms": 16.0,
                         "tput_user": 132.0,
-                        "tput": 10345.0
+                        "tput": 132.0
                     }
                 }
             }
@@ -1577,7 +1577,7 @@
                     "theoretical": {
                         "ttft_ms": 27.0,
                         "tput_user": 42.0,
-                        "tput": 1293.0
+                        "tput": 42.0
                     }
                 }
             }
@@ -1596,7 +1596,7 @@
                     "theoretical": {
                         "ttft_ms": 17.0,
                         "tput_user": 75.0,
-                        "tput": 2299.0
+                        "tput": 75.0
                     }
                 }
             }
@@ -1615,7 +1615,7 @@
                     "theoretical": {
                         "ttft_ms": 19.0,
                         "tput_user": 65.0,
-                        "tput": 2012.0
+                        "tput": 65.0
                     }
                 }
             }
@@ -4405,7 +4405,7 @@
                     "theoretical": {
                         "ttft_ms": 26.0,
                         "tput_user": 43.0,
-                        "tput": 1328.0
+                        "tput": 43.0
                     }
                 }
             }


### PR DESCRIPTION
## Ticket

Related: #3995 #3954 

## Problem

- At `max_concurrency=1` the bench runs `aiperf --concurrency 1` (single-file), so aggregate `tput` is physically equal to per-stream `tput_user`. But `model_performance_reference.json` stored `theoretical.tput` on these conc=1 rows as a ~30× saturation projection (e.g. Falcon3-7B P150: `tput_user=43`, `tput=1328`). The tier derivation in `model_spec.py` (`theoretical.tput × 0.10`) then produced a `functional.tput_check` threshold ~30× unreachable at conc=1 (Falcon3-7B: `actual=11.4` vs `threshold=132.8`). The gap is mathematical, not a perf deficit. Confirmed by @fivanovicTT on #3995, referencing `gpt-oss-120b` as the correct pattern (conc=1 → `tput == tput_user`).

- Without this fix, would see the following for Falcon3-7B-Instruct for example:

```
- `benchmarks.functional.tput_check`: actual tput=11.4000; threshold tput=132.8000; ratio=0.0858.
```

## Fix

- Option B from #3995 (data fix): set `theoretical.tput = theoretical.tput_user` on every `max_concurrency=1` row for the 5 forge single-chip P150 promotion targets (Falcon3-7B-Instruct, Llama-3.1-8B-Instruct, Llama-3.2-3B-Instruct, Qwen3-4B, Qwen3-8B), across all their conc=1 device rows — 25 rows total. `conc>1` aggregate rows are left as saturation targets. 

## Out of scope (follow-up)

The same bug exists on ~220 other (non-forge) rows; this PR fixes only the forge promotion targets. The global hardening (guard `model_spec.py` to derive a `tput` target only when `max_concurrency > 1`) is tracked separately.
