### PR TITLE
fix(distill): hardcode 4 inference steps for LightX2V distill model

### DIFF
--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -771,15 +771,13 @@ class TTWan22I2VDistillRunner(TTDiTRunner):
         seed = int(request.seed) if request.seed is not None else 0
         pipeline_args = {
             "prompts": [request.prompt],
-            "num_inference_steps": request.num_inference_steps or 4,
+            "num_inference_steps": 4,
             "guidance_scale": 1.0,
             "guidance_scale_2": 1.0,
             "seed": seed,
             "traced": True,
             "image_prompt": self._build_image_prompt(request),
         }
-        if bool(request.negative_prompt):
-            pipeline_args["negative_prompts"] = [request.negative_prompt]
         frames = self.pipeline(**pipeline_args)
         self.logger.debug(f"Device {self.device_id}: Distill inference completed")
         return frames


### PR DESCRIPTION
The LightX2V distill model is trained exclusively for 4 denoising steps with CFG baked in (guidance_scale=1.0). Previously the runner used `request.num_inference_steps or 4`, but since the API default is 20 (with ge=12 validation), the fallback to 4 never triggered.

Running at 20 steps produces degraded quality (noise schedule mismatch) and is 5x slower than intended — defeating the purpose of distillation.

This change only affects TTWan22I2VDistillRunner; all other Wan2.2 models (base I2V, AniSora, LoRA) continue to use the user-supplied num_inference_steps.

Also removed negative_prompt pass-through since CFG is baked in.


request.num_inference_steps or 4 only falls back to 4 when request.num_inference_steps is None or 0 (falsy values).

the API schema sets a default:

`num_inference_steps: Optional[int] = Field(default=20, ge=12, le=50)`
So when the user doesn't send num_inference_steps in their request, Pydantic fills in 20 automatically. By the time the runner sees request.num_inference_steps, it's already 20 — which is truthy — so 20 or 4 evaluates to 20, never 4.

The or 4 fallback would only work if the API allowed None to pass through, but it never does because of the default=20.