### PR TITLE
Remove obsolete prefill timeout plumbing

### DIFF
--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -55,7 +55,6 @@ constexpr const char* KAFKA_OFFLOAD_TOPIC_NAME = "session-offload";
 constexpr const char* KAFKA_GROUP_ID = "migration-workers";
 
 constexpr unsigned SESSION_ALLOCATION_MAX_RETRIES = 15;
-constexpr unsigned PREFILL_TIMEOUT_MS = 20000;
 
 constexpr const char* BLAZE_SOCKET_DESCRIPTOR_PREFIX = "deepseek";
 constexpr const char* TT_TASK_QUEUE = "tt_tasks";

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -201,10 +201,6 @@ std::string kafkaGroupId();
  * defaults::SESSION_ALLOCATION_MAX_RETRIES. */
 unsigned sessionAllocationMaxRetries();
 
-/** Prefill timeout in milliseconds from PREFILL_TIMEOUT_MS. Default:
- * defaults::PREFILL_TIMEOUT_MS. */
-unsigned prefillTimeoutMs();
-
 /** Blaze socket descriptor prefix from BLAZE_SOCKET_DESCRIPTOR_PREFIX. Default:
  * defaults::BLAZE_SOCKET_DESCRIPTOR_PREFIX. */
 std::string blazeSocketDescriptorPrefix();

--- a/tt-media-server/cpp_server/include/domain/llm/llm_error_reason.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/llm_error_reason.hpp
@@ -34,8 +34,4 @@ inline LLMErrorReason errorReasonFromFinishReason(
                                                      : LLMErrorReason::GENERIC;
 }
 
-inline bool isTimeoutError(LLMErrorReason reason) {
-  return reason == LLMErrorReason::TIMEOUT;
-}
-
 }  // namespace tt::domain::llm

--- a/tt-media-server/cpp_server/include/domain/llm/sequence.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/sequence.hpp
@@ -23,17 +23,14 @@ struct TokenResult {
   uint64_t tokenId = 0;
   std::optional<bool> finished;
   bool isError = false;
-  bool isTimeoutError = false;
 
   TokenResult() = default;
   TokenResult(uint32_t taskId, uint64_t tokenId,
-              std::optional<bool> finished = {}, bool isError = false,
-              bool isTimeoutError = false)
+              std::optional<bool> finished = {}, bool isError = false)
       : taskId(taskId),
         tokenId(tokenId),
         finished(std::move(finished)),
-        isError(isError),
-        isTimeoutError(isTimeoutError) {}
+        isError(isError) {}
 };
 
 class Sequence {

--- a/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
@@ -196,7 +196,7 @@ inline tt::domain::llm::LLMErrorReason errorReasonFromPrefillResult(
 
 inline std::string prefillErrorTextForReason(
     tt::domain::llm::LLMErrorReason reason, std::string genericError) {
-  if (tt::domain::llm::isTimeoutError(reason)) {
+  if (reason == tt::domain::llm::LLMErrorReason::TIMEOUT) {
     return std::string(PREFILL_TIMEOUT_ERROR_TEXT);
   }
   return genericError.empty() ? "error" : std::move(genericError);

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -676,11 +676,6 @@ unsigned sessionAllocationMaxRetries() {
                defaults::SESSION_ALLOCATION_MAX_RETRIES));
 }
 
-unsigned prefillTimeoutMs() {
-  return static_cast<unsigned>(
-      envUlong("PREFILL_TIMEOUT_MS", defaults::PREFILL_TIMEOUT_MS));
-}
-
 bool dynamoEndpointEnabled() {
   return envBool("DYNAMO_ENDPOINT_ENABLED", defaults::DYNAMO_ENDPOINT_ENABLED);
 }

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -55,13 +55,12 @@ void DisaggregationService::setupSocketHandlers() {
                 message.task_id);
             const auto reason =
                 tt::sockets::errorReasonFromPrefillResult(message);
-            callback.value()(
-                makeErrorChunk(message.task_id,
-                               reason == LLMErrorReason::TIMEOUT
-                                   ? "prefill timeout"
-                                   : "prefill error",
-                               reason),
-                /*isFinal=*/true);
+            callback.value()(makeErrorChunk(message.task_id,
+                                            reason == LLMErrorReason::TIMEOUT
+                                                ? "prefill timeout"
+                                                : "prefill error",
+                                            reason),
+                             /*isFinal=*/true);
             return;
           }
 

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -57,8 +57,9 @@ void DisaggregationService::setupSocketHandlers() {
                 tt::sockets::errorReasonFromPrefillResult(message);
             callback.value()(
                 makeErrorChunk(message.task_id,
-                               isTimeoutError(reason) ? "prefill timeout"
-                                                      : "prefill error",
+                               reason == LLMErrorReason::TIMEOUT
+                                   ? "prefill timeout"
+                                   : "prefill error",
                                reason),
                 /*isFinal=*/true);
             return;

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -380,7 +380,7 @@ void LLMService::consumerLoopForWorker(size_t workerIdx) {
         }
         toolChoiceMap.take(taskId);  // Clean up
         auto errorChunk = makeErrorChunk(taskId,
-                                         isTimeoutError(errorReason)
+                                         errorReason == LLMErrorReason::TIMEOUT
                                              ? "runner timeout"
                                              : "runner reported error",
                                          errorReason);

--- a/tt-media-server/cpp_server/tests/sequence_test.cpp
+++ b/tt-media-server/cpp_server/tests/sequence_test.cpp
@@ -80,11 +80,6 @@ TEST(LLMResponseTest, ErrorReasonMapsToFinishReason) {
 }
 
 TEST(LLMResponseTest, TimeoutTokenFlagMapsToTimeoutErrorReason) {
-  TokenResult result(/*taskId=*/123, /*tokenId=*/0, std::nullopt,
-                     /*isError=*/true, /*isTimeoutError=*/true);
-  EXPECT_TRUE(result.isError);
-  EXPECT_TRUE(result.isTimeoutError);
-
   tt::ipc::SharedToken token;
   token.flags = tt::ipc::SharedToken::FLAG_FINAL |
                 tt::ipc::SharedToken::FLAG_ERROR |

--- a/tt-media-server/prefill_gateway/README.md
+++ b/tt-media-server/prefill_gateway/README.md
@@ -172,7 +172,6 @@ TT_LOG_LEVEL=info \
 cd tt-media-server/cpp_server
 TT_IPC_SHM_C2P=tt_ipc_c2p_8002 \
 TT_IPC_SHM_P2C=tt_ipc_p2c_8002 \
-PREFILL_TIMEOUT_MS=15000 \
 TT_LOG_LEVEL=info \
 LLM_MODE=prefill \
 LLM_DEVICE_BACKEND=mock \
@@ -191,7 +190,6 @@ PREFILL_SERVER_ID=prefill-0 \
 cd tt-media-server/cpp_server
 TT_IPC_SHM_C2P=tt_ipc_c2p_8003 \
 TT_IPC_SHM_P2C=tt_ipc_p2c_8003 \
-PREFILL_TIMEOUT_MS=15000 \
 TT_LOG_LEVEL=info \
 LLM_MODE=prefill \
 LLM_DEVICE_BACKEND=mock \
@@ -243,7 +241,6 @@ TT_LOG_LEVEL=info \
 cd tt-media-server/cpp_server
 TT_IPC_SHM_C2P=tt_ipc_c2p_8002 \
 TT_IPC_SHM_P2C=tt_ipc_p2c_8002 \
-PREFILL_TIMEOUT_MS=15000 \
 TT_LOG_LEVEL=info \
 LLM_MODE=prefill \
 LLM_DEVICE_BACKEND=mock \
@@ -262,7 +259,6 @@ PREFILL_SERVER_ID=prefill-0 \
 cd tt-media-server/cpp_server
 TT_IPC_SHM_C2P=tt_ipc_c2p_8003 \
 TT_IPC_SHM_P2C=tt_ipc_p2c_8003 \
-PREFILL_TIMEOUT_MS=15000 \
 TT_LOG_LEVEL=info \
 LLM_MODE=prefill \
 LLM_DEVICE_BACKEND=mock \


### PR DESCRIPTION
 Remove unused `PREFILL_TIMEOUT_MS` config after the legacy prefill runner was replaced.