### PR TITLE
Fix gemma-4 benchmark tokenizer crash with a forge-only client venv

### DIFF
--- a/benchmarking/benchmark_config.py
+++ b/benchmarking/benchmark_config.py
@@ -11,9 +11,24 @@ from workflows.utils_report import BenchmarkTaskParams, BenchmarkTaskParamsCNN
 from workflows.workflow_types import (
     BenchmarkTaskType,
     DeviceTypes,
+    InferenceEngine,
     ModelType,
     WorkflowVenvType,
 )
+
+
+# Forge models need a newer vllm client that can load their tokenizers; other
+# engines use the shared client.
+_VLLM_BENCHMARK_VENV_BY_ENGINE = {
+    InferenceEngine.FORGE.value: WorkflowVenvType.BENCHMARKS_VLLM_FORGE,
+}
+
+
+def select_vllm_benchmark_venv(model_spec) -> WorkflowVenvType:
+    """Pick the vllm benchmark client venv for ``model_spec``."""
+    return _VLLM_BENCHMARK_VENV_BY_ENGINE.get(
+        model_spec.inference_engine, WorkflowVenvType.BENCHMARKS_VLLM
+    )
 
 
 @dataclass(frozen=True)
@@ -538,6 +553,8 @@ for model_id, model_spec in MODEL_SPECS.items():
     max_tokens_all_users = model_spec.device_model_spec.max_tokens_all_users
     perf_reference = model_spec.device_model_spec.perf_reference
 
+    vllm_benchmark_venv = select_vllm_benchmark_venv(model_spec)
+
     # Apply capping to each perf reference entry (including vision tokens for VLM models)
     capped_perf_reference = [
         cap_benchmark_params(
@@ -555,7 +572,8 @@ for model_id, model_spec in MODEL_SPECS.items():
         perf_ref_task = BenchmarkTaskCNN(param_map={device: capped_perf_reference})
     elif model_spec.model_type == ModelType.EMBEDDING:
         perf_ref_task = BenchmarkTaskEmbedding(
-            param_map={device: capped_perf_reference}
+            param_map={device: capped_perf_reference},
+            workflow_venv_type=vllm_benchmark_venv,
         )
     elif model_spec.model_type == ModelType.VIDEO:
         perf_ref_task = BenchmarkTaskVideo(param_map={device: capped_perf_reference})
@@ -566,7 +584,10 @@ for model_id, model_spec in MODEL_SPECS.items():
     elif model_spec.model_type == ModelType.AUDIO:
         perf_ref_task = BenchmarkTaskAudio(param_map={device: capped_perf_reference})
     else:
-        perf_ref_task = BenchmarkTask(param_map={device: capped_perf_reference})
+        perf_ref_task = BenchmarkTask(
+            param_map={device: capped_perf_reference},
+            workflow_venv_type=vllm_benchmark_venv,
+        )
 
     tasks = [perf_ref_task]
     # optionally skip the benchmark sweeps and only run the perf reference targets
@@ -582,7 +603,8 @@ for model_id, model_spec in MODEL_SPECS.items():
             )
         elif model_spec.model_type == ModelType.EMBEDDING:
             benchmark_task_runs = BenchmarkTaskEmbedding(
-                param_map={device: [BenchmarkTaskParams()]}
+                param_map={device: [BenchmarkTaskParams()]},
+                workflow_venv_type=vllm_benchmark_venv,
             )
         elif model_spec.model_type == ModelType.VIDEO:
             benchmark_task_runs = BenchmarkTaskVideo(
@@ -643,7 +665,8 @@ for model_id, model_spec in MODEL_SPECS.items():
                         if "image" in model_spec.supported_modalities
                         else []
                     )
-                }
+                },
+                workflow_venv_type=vllm_benchmark_venv,
             )
 
         tasks.append(benchmark_task_runs)
@@ -665,7 +688,8 @@ for model_id, model_spec in MODEL_SPECS.items():
                         )
                         for dataset, ratio in STRUCTURED_OUTPUT_PAIRS
                     ]
-                }
+                },
+                workflow_venv_type=vllm_benchmark_venv,
             )
         )
 

--- a/requirements/benchmarks-vllm-forge.txt
+++ b/requirements/benchmarks-vllm-forge.txt
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# Dependencies for the BENCHMARKS_VLLM_FORGE workflow venv (Python 3.11).
+#
+# Forge-only benchmark client. The shared benchmarks-vllm.txt stays on its
+# older pins so qualified TTNN models are untouched; forge models need newer
+# vllm/transformers to load their tokenizers. Keep the vllm pin in sync with
+# FORGE_VLLM_PIN_VERSION in workflow_venvs.py.
+
+-c constraints.txt
+
+vllm==0.19.1
+transformers==5.5.1
+torch
+# Extra deps required by benchmark_serving_structured_output.py; the
+# `vllm bench serve` CLI does not pull these in transitively.
+datasets
+pandas
+xgrammar

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -46,6 +46,7 @@ class WorkflowVenvType(IntEnum):
     BENCHMARKS_EMBEDDING = auto()
     BENCHMARKS_VIDEO = auto()
     BENCHMARKS_VLLM = auto()
+    BENCHMARKS_VLLM_FORGE = auto()
     BENCHMARKS_GENAI_PERF = auto()
     BENCHMARKS_AIPERF = auto()
     BENCHMARKS_GUIDELLM = auto()

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -271,11 +271,20 @@ def setup_evals_meta(
     return setup_succeeded
 
 
-# Pinned vLLM tag used both by `requirements/benchmarks-vllm.txt` (where
-# vllm==<VLLM_PIN_VERSION>) and as the source for the structured-output
-# benchmark scripts fetched at venv setup time. Keep these in sync.
+# Pinned vLLM tags for the benchmark client venvs. Each must match the vllm==
+# pin in its requirements file (structured-output scripts are fetched from
+# vllm-project/vllm@v<pin>/benchmarks at setup time):
+#   VLLM_PIN_VERSION       <-> requirements/benchmarks-vllm.txt
+#   FORGE_VLLM_PIN_VERSION <-> requirements/benchmarks-vllm-forge.txt
 VLLM_PIN_VERSION = "0.13.0"
-VLLM_BENCHMARKS_RAW_BASE = f"https://raw.githubusercontent.com/vllm-project/vllm/v{VLLM_PIN_VERSION}/benchmarks"
+FORGE_VLLM_PIN_VERSION = "0.19.1"
+
+
+def _vllm_benchmarks_raw_base(pin_version: str) -> str:
+    return (
+        f"https://raw.githubusercontent.com/vllm-project/vllm/v{pin_version}/benchmarks"
+    )
+
 
 # (relative_path_in_vllm_repo, relative_path_in_work_dir)
 STRUCTURED_OUTPUT_FETCH_FILES = (
@@ -296,23 +305,21 @@ STRUCTURED_OUTPUT_FETCH_FILES = (
 STRUCTURED_OUTPUT_SCRIPT_NAME = "benchmark_serving_structured_output.py"
 
 
-def fetch_structured_output_scripts(
+def _fetch_structured_output_scripts(
     venv_config: "VenvConfig",
-    model_spec: "ModelSpec",
+    pin_version: str,
 ) -> bool:
-    """Hook for BENCHMARKS_VLLM: download structured-output benchmark scripts.
+    """Fetch the structured-output benchmark driver scripts for ``pin_version``.
 
-    Pip-installable deps (vllm/torch/datasets/pandas/xgrammar) come from
-    requirements/benchmarks-vllm.txt. The benchmark driver scripts are not
-    published on PyPI, so they're fetched at venv setup time from the pinned
-    vLLM source tag rather than vendored into this repo.
+    They aren't published on PyPI, so they're pulled from the matching vLLM
+    source tag at venv setup time rather than vendored into this repo.
     """
-    logger.info("running fetch_structured_output_scripts() ...")
     work_dir = venv_config.venv_path / "work_dir"
+    raw_base = _vllm_benchmarks_raw_base(pin_version)
     for src_rel, dst_rel in STRUCTURED_OUTPUT_FETCH_FILES:
         dst = work_dir / dst_rel
         dst.parent.mkdir(parents=True, exist_ok=True)
-        url = f"{VLLM_BENCHMARKS_RAW_BASE}/{src_rel}"
+        url = f"{raw_base}/{src_rel}"
         return_code = run_command(
             f"curl -fSL --retry 3 --retry-delay 5 --retry-connrefused {url} -o {dst}",
             logger=logger,
@@ -320,6 +327,24 @@ def fetch_structured_output_scripts(
         if return_code != 0:
             return False
     return True
+
+
+def fetch_structured_output_scripts(
+    venv_config: "VenvConfig",
+    model_spec: "ModelSpec",
+) -> bool:
+    """Hook for BENCHMARKS_VLLM: fetch scripts pinned to VLLM_PIN_VERSION."""
+    logger.info("running fetch_structured_output_scripts() ...")
+    return _fetch_structured_output_scripts(venv_config, VLLM_PIN_VERSION)
+
+
+def fetch_structured_output_scripts_forge(
+    venv_config: "VenvConfig",
+    model_spec: "ModelSpec",
+) -> bool:
+    """Hook for BENCHMARKS_VLLM_FORGE: fetch scripts pinned to FORGE_VLLM_PIN_VERSION."""
+    logger.info("running fetch_structured_output_scripts_forge() ...")
+    return _fetch_structured_output_scripts(venv_config, FORGE_VLLM_PIN_VERSION)
 
 
 _venv_config_list = [
@@ -409,6 +434,15 @@ _venv_config_list = [
         extra_dirs=("work_dir",),
         python_version="3.11",
         setup_function=fetch_structured_output_scripts,
+    ),
+    # Forge-only benchmark client on newer vllm/transformers so forge tokenizers
+    # load. benchmark_config.py routes forge-engine models here.
+    VenvConfig(
+        venv_type=WorkflowVenvType.BENCHMARKS_VLLM_FORGE,
+        requirements_file="benchmarks-vllm-forge.txt",
+        extra_dirs=("work_dir",),
+        python_version="3.11",
+        setup_function=fetch_structured_output_scripts_forge,
     ),
     VenvConfig(
         venv_type=WorkflowVenvType.BENCHMARKS_AIPERF,


### PR DESCRIPTION
## Ticket

Closes #4043 

## Problem

The shared `BENCHMARKS_VLLM` benchmark client venv pins `vllm==0.13.0`, which drags in `transformers<5`. That transformers can't load the gemma-4 tokenizer and crashes the benchmark client before any request is sent:

```
AttributeError: 'list' object has no attribute 'keys'
```

(gemma-4's `extra_special_tokens` is a list, not a dict.) Forge LLMs/VLMs ship a newer transformers in their serving image, so this blocks benchmarking every forge model whose tokenizer the old transformers can't parse.

Bumping the shared venv would fix it but force re-qualifying every already-validated TTNN model against the newer vllm/transformers.

## Change

Add a separate **forge-only** benchmark client venv and route only forge-engine models to it; the shared venv (and every TTNN model) is left untouched.

- **`requirements/benchmarks-vllm-forge.txt`** — new `BENCHMARKS_VLLM_FORGE` venv at `vllm==0.19.1` / `transformers==5.5.1` (the pairing forge models are qualified with).
- **`workflow_types.py`** — new `WorkflowVenvType.BENCHMARKS_VLLM_FORGE`.
- **`workflow_venvs.py`** — forge `VenvConfig`; the structured-output script fetch is parametrized by vllm pin (`FORGE_VLLM_PIN_VERSION`) so each venv pulls its driver scripts from the matching `vllm-project/vllm@v<pin>` tag.
- **`benchmark_config.py`** — `select_vllm_benchmark_venv()` routes `inference_engine == forge` models to the forge venv (via a small engine→venv map); all other engines stay on the shared `BENCHMARKS_VLLM` venv.

This is client-side only — no change to model serving or accuracy eval.

## Scope / risk

- Shared `BENCHMARKS_VLLM` venv is unchanged (`vllm==0.13.0`); no TTNN model needs re-qualification.
- Only forge-engine models (e.g. gemma-4-31b-it, the forge Qwen3-32B on p300x2) pick up the new venv.

## Verification

Confirmed the fix end-to-end; full output in the follow-up comment. Summary:

- Shared venv (`vllm 0.13.0` / `transformers 4.57.6`) reproduces the `AttributeError`; forge venv (`vllm 0.19.1` / `transformers 5.5.1`) loads the gemma-4 tokenizer cleanly — same tokenizer, same host.
- `benchmark_config` routes the forge gemma-4-31b-it / Qwen3-32B specs to `BENCHMARKS_VLLM_FORGE` and TTNN specs to `BENCHMARKS_VLLM`.
- Smoke benchmark of gemma-4-31b-it on p300x2 runs end-to-end through the forge venv: 8/8 requests, 0 failed.
- `tests/test_benchmark_config.py` + `tests/test_benchmark_concurrency_sweeps.py` pass.

Bonus — tt-shield `benchmarks` dispatched against this branch (`inference-server-git-ref=kmabee/issue_4043_forge-benchmark-venv`) as extra confirmation on real CI; the verification above stands on its own locally:

- Forge / fix path — gemma-4-31b-it on p300x2: https://github.com/tenstorrent/tt-shield/actions/runs/27323440640
- Non-forge / regression check — Llama-3.2-1B-Instruct on t3k (shared venv untouched): https://github.com/tenstorrent/tt-shield/actions/runs/27323439714
