### PR TITLE
Onboard `openai/gpt-oss-120b` and `MiniMaxAI/MiniMax-M2.7`

### DIFF
--- a/tt-media-server/cpp_server/include/config/types.hpp
+++ b/tt-media-server/cpp_server/include/config/types.hpp
@@ -46,17 +46,25 @@ enum class ModelType {
   DEEPSEEK_R1_0528,
   LLAMA_3_1_8B_INSTRUCT,
   KIMI_K2_6,
+  GPT_OSS_120B,
+  MINIMAX_M2_7,
 };
 
 /** Map lowercase `LLM_DEVICE_BACKEND` values to `ModelType`:
  * "llama" -> `LLAMA_3_1_8B_INSTRUCT`,
  * "kimi" -> `KIMI_K2_6`,
+ * "gpt-oss" -> `GPT_OSS_120B`,
+ * "minimax" -> `MINIMAX_M2_7`,
  * otherwise -> `DEEPSEEK_R1_0528`. */
 inline ModelType modelTypeFromDeviceBackend(const std::string& v) {
   if (v == "llama")
     return ModelType::LLAMA_3_1_8B_INSTRUCT;
   else if (v == "kimi")
     return ModelType::KIMI_K2_6;
+  else if (v == "gpt-oss")
+    return ModelType::GPT_OSS_120B;
+  else if (v == "minimax")
+    return ModelType::MINIMAX_M2_7;
   return ModelType::DEEPSEEK_R1_0528;
 }
 
@@ -101,6 +109,8 @@ enum class Model {
   DEEPSEEK_R1_0528,
   LLAMA_3_1_8B_INSTRUCT,
   KIMI_K2_6,
+  GPT_OSS_120B,
+  MINIMAX_M2_7,
 };
 
 struct ModelMapping {
@@ -112,6 +122,8 @@ static constexpr ModelMapping MODEL_MAPPINGS[] = {
     {Model::DEEPSEEK_R1_0528, "deepseek-ai/DeepSeek-R1-0528"},
     {Model::LLAMA_3_1_8B_INSTRUCT, "meta-llama/Llama-3.1-8B-Instruct"},
     {Model::KIMI_K2_6, "moonshotai/Kimi-K2.6"},
+    {Model::GPT_OSS_120B, "openai/gpt-oss-120b"},
+    {Model::MINIMAX_M2_7, "MiniMaxAI/MiniMax-M2.7"},
 };
 
 inline std::string toString(Model m) {

--- a/tt-media-server/cpp_server/scripts/fetch_tokenizers.sh
+++ b/tt-media-server/cpp_server/scripts/fetch_tokenizers.sh
@@ -193,8 +193,6 @@ download_tokenizer \
     "tiktoken"
 
 # GPT-OSS 120B (public, no auth)
-# tokenizer.json is an LFS file, so use /resolve/main (which redirects to the
-# real bytes); /raw/main would return the LFS pointer text and fail to parse.
 download_tokenizer \
     "openai/gpt-oss-120b" \
     "https://huggingface.co/openai/gpt-oss-120b/resolve/main" \

--- a/tt-media-server/cpp_server/scripts/fetch_tokenizers.sh
+++ b/tt-media-server/cpp_server/scripts/fetch_tokenizers.sh
@@ -91,6 +91,12 @@ download_hf_file() {
 #                         tokenizer_config.json). Required by the Dynamo
 #                         frontend's PromptFormatter. (tiktoken always fetches
 #                         it regardless of this flag.)
+#
+# generation_config.json (eos_token_id / sampling defaults) is fetched
+# best-effort for EVERY model — it's optional (a 404 is non-fatal) since not
+# all models ship it and config.json may already carry eos_token_id. When
+# present, discovery.cpp publishes it in the MDC so the frontend gets the full
+# eos set (e.g. gpt-oss's <|call|>, MiniMax's only eos).
 download_tokenizer() {
     local model_name="$1"
     local hf_repo="$2"
@@ -98,10 +104,10 @@ download_tokenizer() {
     local placeholder_config="${4:-}"
     local tokenizer_type="${5:-json}"
     local needs_chat_template="${6:-false}"
-    local needs_gen_config="${7:-false}"
 
     local model_dir="${TOKENIZER_DIR}/${model_name}"
     local model_config="${model_dir}/config.json"
+    local gen_config="${model_dir}/generation_config.json"
 
     # Determine required files based on tokenizer type
     local required_files=("tokenizer_config.json")
@@ -113,14 +119,27 @@ download_tokenizer() {
             required_files+=("chat_template.jinja")
         fi
     fi
-    # generation_config.json carries eos_token_id / sampling defaults. Some
-    # models (e.g. MiniMax) omit eos_token_id from config.json, and the Dynamo
-    # frontend hard-fails to load them without it.
-    if [ "${needs_gen_config}" = "true" ]; then
-        required_files+=("generation_config.json")
+
+    # Skip gated models without auth token (covers all downloads below).
+    if [ "${requires_auth}" = "true" ] && [ -z "${HF_TOKEN_RESOLVED}" ]; then
+        echo "  Skipping ${model_name} (gated model — set HF_TOKEN to download)."
+        return 0
     fi
 
-    # Check if all required files exist
+    mkdir -p "${model_dir}"
+
+    # Best-effort generation_config.json (optional, every model).
+    if [ ! -f "${gen_config}" ]; then
+        if download_hf_file "${gen_config}" "${hf_repo}/generation_config.json" \
+                "${requires_auth}" "${model_name}" >/dev/null 2>&1; then
+            echo "  ${model_name}/generation_config.json downloaded"
+        else
+            rm -f "${gen_config}"
+            echo "  note: no generation_config.json for ${model_name} (optional; skipped)"
+        fi
+    fi
+
+    # Fast path: tokenizer essentials + config already present.
     local all_exist=true
     for f in "${required_files[@]}"; do
         if [ ! -f "${model_dir}/${f}" ]; then
@@ -133,13 +152,6 @@ download_tokenizer() {
         return 0
     fi
 
-    # Skip gated models without auth token
-    if [ "${requires_auth}" = "true" ] && [ -z "${HF_TOKEN_RESOLVED}" ]; then
-        echo "  Skipping ${model_name} (gated model — set HF_TOKEN to download)."
-        return 0
-    fi
-
-    mkdir -p "${model_dir}"
     echo "Downloading ${model_name} tokenizer..."
 
     # Download required tokenizer files
@@ -193,6 +205,11 @@ download_tokenizer \
     "tiktoken"
 
 # GPT-OSS 120B (public, no auth)
+# generation_config.json (fetched best-effort for all models) is important here:
+# config.json declares only eos_token_id=200002, but the full stop set lives in
+# generation_config.json's eos_token_id array [200002, 199999, 200012]
+# (<|return|>, <|endoftext|>, <|call|>) — without it the frontend never stops on
+# a tool call (<|call|>).
 download_tokenizer \
     "openai/gpt-oss-120b" \
     "https://huggingface.co/openai/gpt-oss-120b/resolve/main" \
@@ -208,7 +225,6 @@ download_tokenizer \
     "false" \
     '{"model_type":"minimax_m2","architectures":["MiniMaxM2ForCausalLM"]}' \
     "json" \
-    "true" \
     "true"
 
 echo ""

--- a/tt-media-server/cpp_server/scripts/fetch_tokenizers.sh
+++ b/tt-media-server/cpp_server/scripts/fetch_tokenizers.sh
@@ -176,4 +176,18 @@ download_tokenizer \
     '{"model_type":"kimi_k25","architectures":["KimiK25ForConditionalGeneration"]}' \
     "tiktoken"
 
+# GPT-OSS 120B (public, no auth)
+download_tokenizer \
+    "openai/gpt-oss-120b" \
+    "https://huggingface.co/openai/gpt-oss-120b/raw/main" \
+    "false" \
+    '{"model_type":"gpt_oss","architectures":["GptOssForCausalLM"]}'
+
+# MiniMax M2 (public, no auth)
+download_tokenizer \
+    "MiniMaxAI/MiniMax-M2.7" \
+    "https://huggingface.co/MiniMaxAI/MiniMax-M2.7/raw/main" \
+    "false" \
+    '{"model_type":"minimax_m2","architectures":["MiniMaxM2ForCausalLM"]}'
+
 echo ""

--- a/tt-media-server/cpp_server/scripts/fetch_tokenizers.sh
+++ b/tt-media-server/cpp_server/scripts/fetch_tokenizers.sh
@@ -86,12 +86,19 @@ download_hf_file() {
 #   requires_auth       - "true" if gated model requiring HF_TOKEN
 #   placeholder_config  - Fallback config.json content if HF fetch fails
 #   tokenizer_type      - "json" (default) for tokenizer.json, "tiktoken" for tiktoken.model
+#   needs_chat_template - "true" if the model ships its chat template as a
+#                         separate chat_template.jinja (rather than inline in
+#                         tokenizer_config.json). Required by the Dynamo
+#                         frontend's PromptFormatter. (tiktoken always fetches
+#                         it regardless of this flag.)
 download_tokenizer() {
     local model_name="$1"
     local hf_repo="$2"
     local requires_auth="$3"
     local placeholder_config="${4:-}"
     local tokenizer_type="${5:-json}"
+    local needs_chat_template="${6:-false}"
+    local needs_gen_config="${7:-false}"
 
     local model_dir="${TOKENIZER_DIR}/${model_name}"
     local model_config="${model_dir}/config.json"
@@ -102,6 +109,15 @@ download_tokenizer() {
         required_files+=("tiktoken.model" "chat_template.jinja")
     else
         required_files+=("tokenizer.json")
+        if [ "${needs_chat_template}" = "true" ]; then
+            required_files+=("chat_template.jinja")
+        fi
+    fi
+    # generation_config.json carries eos_token_id / sampling defaults. Some
+    # models (e.g. MiniMax) omit eos_token_id from config.json, and the Dynamo
+    # frontend hard-fails to load them without it.
+    if [ "${needs_gen_config}" = "true" ]; then
+        required_files+=("generation_config.json")
     fi
 
     # Check if all required files exist
@@ -177,17 +193,24 @@ download_tokenizer \
     "tiktoken"
 
 # GPT-OSS 120B (public, no auth)
+# tokenizer.json is an LFS file, so use /resolve/main (which redirects to the
+# real bytes); /raw/main would return the LFS pointer text and fail to parse.
 download_tokenizer \
     "openai/gpt-oss-120b" \
-    "https://huggingface.co/openai/gpt-oss-120b/raw/main" \
+    "https://huggingface.co/openai/gpt-oss-120b/resolve/main" \
     "false" \
-    '{"model_type":"gpt_oss","architectures":["GptOssForCausalLM"]}'
+    '{"model_type":"gpt_oss","architectures":["GptOssForCausalLM"]}' \
+    "json" \
+    "true"
 
 # MiniMax M2 (public, no auth)
 download_tokenizer \
     "MiniMaxAI/MiniMax-M2.7" \
-    "https://huggingface.co/MiniMaxAI/MiniMax-M2.7/raw/main" \
+    "https://huggingface.co/MiniMaxAI/MiniMax-M2.7/resolve/main" \
     "false" \
-    '{"model_type":"minimax_m2","architectures":["MiniMaxM2ForCausalLM"]}'
+    '{"model_type":"minimax_m2","architectures":["MiniMaxM2ForCausalLM"]}' \
+    "json" \
+    "true" \
+    "true"
 
 echo ""

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -468,6 +468,8 @@ ModelType modelType() {
     if (m == "moonshotai/Kimi-K2.6") return ModelType::KIMI_K2_6;
     if (m == "meta-llama/Llama-3.1-8B-Instruct")
       return ModelType::LLAMA_3_1_8B_INSTRUCT;
+    if (m == "openai/gpt-oss-120b") return ModelType::GPT_OSS_120B;
+    if (m == "MiniMaxAI/MiniMax-M2.7") return ModelType::MINIMAX_M2_7;
     return ModelType::DEEPSEEK_R1_0528;
   }();
   return cached;

--- a/tt-media-server/cpp_server/src/dynamo/discovery.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/discovery.cpp
@@ -148,6 +148,12 @@ RuntimeParsers runtimeParsersForModelType(const std::string& modelType) {
   if (modelType == "llama") {
     return {nullptr, nullptr};
   }
+  if (modelType == "gpt_oss") {
+    return {"gpt_oss", "harmony"};
+  }
+  if (modelType == "minimax_m2") {
+    return {"deepseek_r1", nullptr};
+  }
   // deepseek_v3 and unknown types default to DeepSeek R1 reasoning.
   return {"deepseek_r1", nullptr};
 }

--- a/tt-media-server/cpp_server/src/dynamo/discovery.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/discovery.cpp
@@ -152,7 +152,7 @@ RuntimeParsers runtimeParsersForModelType(const std::string& modelType) {
     return {"gpt_oss", "harmony"};
   }
   if (modelType == "minimax_m2") {
-    return {"deepseek_r1", nullptr};
+    return {"minimax_append_think", "minimax_m2"};
   }
   // deepseek_v3 and unknown types default to DeepSeek R1 reasoning.
   return {"deepseek_r1", nullptr};
@@ -193,6 +193,7 @@ Json::Value buildMdcJson(const DiscoveryConfig& c) {
   const std::string tokenizerConfigPath =
       c.model_path + "/tokenizer_config.json";
   const std::string chatTemplatePath = c.model_path + "/chat_template.jinja";
+  const std::string genConfigPath = c.model_path + "/generation_config.json";
 
   Json::Value modelInfo(Json::objectValue);
   Json::Value hfConfig(Json::objectValue);
@@ -200,6 +201,19 @@ Json::Value buildMdcJson(const DiscoveryConfig& c) {
   hfConfig["checksum"] = fileChecksum(configPath);
   modelInfo["hf_config_json"] = std::move(hfConfig);
   card["model_info"] = std::move(modelInfo);
+
+  // generation_config.json carries eos_token_id / sampling defaults. Models
+  // like MiniMax omit eos_token_id from config.json, and the frontend hard-
+  // fails to load them without it. Publish it only when present so models that
+  // carry eos_token_id in config.json (DeepSeek, gpt-oss) are unaffected.
+  if (std::filesystem::exists(genConfigPath)) {
+    Json::Value genConfig(Json::objectValue);
+    Json::Value hfGenConfig(Json::objectValue);
+    hfGenConfig["path"] = genConfigPath;
+    hfGenConfig["checksum"] = fileChecksum(genConfigPath);
+    genConfig["hf_generation_config_json"] = std::move(hfGenConfig);
+    card["gen_config"] = std::move(genConfig);
+  }
 
   Json::Value tokenizer(Json::objectValue);
   Json::Value tokFile(Json::objectValue);

--- a/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
+++ b/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
@@ -202,6 +202,10 @@ std::string tokenizerDirForModel(config::ModelType model) {
       return "moonshotai/Kimi-K2.6";
     case config::ModelType::LLAMA_3_1_8B_INSTRUCT:
       return "meta-llama/Llama-3.1-8B-Instruct";
+    case config::ModelType::GPT_OSS_120B:
+      return "openai/gpt-oss-120b";
+    case config::ModelType::MINIMAX_M2_7:
+      return "MiniMaxAI/MiniMax-M2.7";
     case config::ModelType::DEEPSEEK_R1_0528:
     default:
       return "deepseek-ai/DeepSeek-R1-0528";
@@ -217,6 +221,12 @@ std::unique_ptr<Tokenizer> createTokenizer(config::ModelType model,
       // Kimi K2.6 uses model-specific files, but currently shares the same
       // chat-template/tool-call behavior as DeepSeek until a dedicated
       // Kimi tokenizer implementation is added.
+      return std::make_unique<DeepseekTokenizer>(path);
+    case config::ModelType::GPT_OSS_120B:
+    case config::ModelType::MINIMAX_M2_7:
+      // These load their own model-specific files but currently reuse the
+      // DeepSeek chat-template/tool-call behavior until a dedicated tokenizer
+      // implementation is added.
       return std::make_unique<DeepseekTokenizer>(path);
     case config::ModelType::DEEPSEEK_R1_0528:
     default:
@@ -273,6 +283,34 @@ const StaticTokenizerInfo& kimiK26Info() {
   return kInfo;
 }
 
+// IDs verified against the fetched o200k_harmony tokenizer. gpt-oss uses the
+// Harmony channel format rather than <think> tags, so no think tokens; the
+// assistant turn ends on <|return|> (200002) and a tool call on <|call|>
+// (200012). assistantHeaderSequence is left empty (the Harmony header is
+// multi-token and handled by the chat template, not a fixed prefix here).
+const StaticTokenizerInfo& gptOss120bInfo() {
+  static const StaticTokenizerInfo kInfo{
+      /*modelName=*/"openai/gpt-oss-120b",
+      /*stopTokenIds=*/{200002, 200012},  // <|return|>, <|call|>
+      /*eosTokenId=*/200002,              // <|return|>
+      /*assistantHeaderSequence=*/{},
+  };
+  return kInfo;
+}
+
+// IDs verified against the fetched MiniMax-M2.7 tokenizer.
+const StaticTokenizerInfo& minimaxM27Info() {
+  static const StaticTokenizerInfo kInfo{
+      /*modelName=*/"MiniMaxAI/MiniMax-M2.7",
+      /*stopTokenIds=*/{200020},  // [e~[
+      /*eosTokenId=*/200020,      // [e~[
+      /*assistantHeaderSequence=*/{},
+      /*thinkStartTokenId=*/200050,  // <think>
+      /*thinkEndTokenId=*/200051,    // </think>
+  };
+  return kInfo;
+}
+
 }  // namespace
 
 const StaticTokenizerInfo& staticInfoFor(config::ModelType model) {
@@ -283,6 +321,10 @@ const StaticTokenizerInfo& staticInfoFor(config::ModelType model) {
       return llama31Info();
     case config::ModelType::KIMI_K2_6:
       return kimiK26Info();
+    case config::ModelType::GPT_OSS_120B:
+      return gptOss120bInfo();
+    case config::ModelType::MINIMAX_M2_7:
+      return minimaxM27Info();
   }
   throw std::invalid_argument(
       "tokenizers::staticInfoFor: no static info registered for ModelType " +

--- a/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
+++ b/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
@@ -291,8 +291,10 @@ const StaticTokenizerInfo& kimiK26Info() {
 const StaticTokenizerInfo& gptOss120bInfo() {
   static const StaticTokenizerInfo kInfo{
       /*modelName=*/"openai/gpt-oss-120b",
-      /*stopTokenIds=*/{200002, 200012},  // <|return|>, <|call|>
-      /*eosTokenId=*/200002,              // <|return|>
+      // generation_config.json eos_token_id: [200002, 199999, 200012] =
+      // <|return|> (final turn), <|endoftext|>, <|call|> (tool call).
+      /*stopTokenIds=*/{199999, 200012},
+      /*eosTokenId=*/200002,  // <|return|> (primary, per config.json)
       /*assistantHeaderSequence=*/{},
   };
   return kInfo;
@@ -302,8 +304,8 @@ const StaticTokenizerInfo& gptOss120bInfo() {
 const StaticTokenizerInfo& minimaxM27Info() {
   static const StaticTokenizerInfo kInfo{
       /*modelName=*/"MiniMaxAI/MiniMax-M2.7",
-      /*stopTokenIds=*/{200020},  // [e~[
-      /*eosTokenId=*/200020,      // [e~[
+      /*stopTokenIds=*/{},
+      /*eosTokenId=*/200020,  // [e~[
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/200050,  // <think>
       /*thinkEndTokenId=*/200051,    // </think>


### PR DESCRIPTION
## Issue
[#4136 Add a way to start IS in Gpt-OSS and Minimax mode](https://github.com/tenstorrent/tt-inference-server/issues/4136)

## Problem
We need to onboard the following models to work with Dynamo+cpp_server:
- openai/gpt-oss-120b
- MiniMaxAI/MiniMax-M2.7

### Example of applyChatTemplate for gpt oss:
```
<|start|>system<|message|>You are ChatGPT, a large language model trained by OpenAI.<|end|><|start|>user<|message|>Hello, my name is Lana<|end|><|start|>assistant<|channel|>final<|message|>Nice to meet you, Lana! How can I help you today?<|end|><|start|>user<|message|>Write a Python function for the nth Fibonacci number.<|end|><|start|>assistant
```
Note that there is no <think> tag beeing applied, since gpt oss uses channeling method:
```
<|channel|>analysis<|message|> …chain-of-thought… <|end|>      ← reasoning
<|start|>assistant<|channel|>final<|message|> …answer… <|return|>  ← user-visible answer
```
There are three valid channels declared right in the system prompt: analysis, commentary, final.

### Example of applyChatTemplate for MiniMaxAi:
```
]~!b[]~b]system
You are a helpful assistant. Your name is MiniMax-M2.7 and is built by MiniMax.[e~[
]~b]user
Hello, my name is Lana[e~[
]~b]ai
Nice to meet you, Lana! How can I help you today?[e~[
]~b]user
Write a Python function for the nth Fibonacci number.[e~[
]~b]ai
<think>
```

## Next steps
After these changes are merged, a new Docker Image for Dynamo Frontend will be published