### PR TITLE
Git ignore C++ tokenizers

### DIFF
--- a/tt-media-server/cpp_server/.gitignore
+++ b/tt-media-server/cpp_server/.gitignore
@@ -24,6 +24,9 @@ logs/
 
 deps/
 
+# Downloaded Hugging Face tokenizer assets
+tokenizers/
+
 # Profiling output (flamegraph-capture[-offcpu].sh writes here)
 bench_results/
 


### PR DESCRIPTION
Add `cpp_server/tokenizers/` to git ignore.