### PR TITLE
v0.16.0

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -41,13 +41,6 @@
               "devices": [
                 "GALAXY"
               ]
-            },
-            "release": {
-              "devices": [
-                "GALAXY",
-                "P150",
-                "P300X2"
-              ]
             }
           }
         },
@@ -277,11 +270,6 @@
               "devices": [
                 "GALAXY"
               ]
-            },
-            "release": {
-              "devices": [
-                "P300X2"
-              ]
             }
           }
         },
@@ -357,11 +345,6 @@
             "GALAXY",
             "N150"
           ]
-        },
-        "release": {
-          "devices": [
-            "GALAXY"
-          ]
         }
       }
     },
@@ -402,22 +385,6 @@
             "P150X4",
             "P300X2",
             "T3K"
-          ]
-        }
-      }
-    },
-    "bge-large-en-v1.5": {
-      "inference_engine": "MEDIA",
-      "ci": {
-        "nightly": {
-          "devices": [
-            "GALAXY",
-            "N150"
-          ]
-        },
-        "release": {
-          "devices": [
-            "GALAXY"
           ]
         }
       }
@@ -531,8 +498,7 @@
         },
         "release": {
           "devices": [
-            "GALAXY",
-            "P300X2"
+            "GALAXY"
           ]
         }
       }
@@ -569,28 +535,6 @@
             "P300X2",
             "T3K"
           ]
-        },
-        "release": {
-          "devices": [
-            "GALAXY"
-          ]
-        }
-      }
-    },
-    "distil-large-v3": {
-      "inference_engine": "MEDIA",
-      "ci": {
-        "nightly": {
-          "devices": [
-            "P150",
-            "P300X2"
-          ]
-        },
-        "release": {
-          "devices": [
-            "P150",
-            "P300X2"
-          ]
         }
       }
     },
@@ -610,25 +554,6 @@
         "nightly": {
           "devices": [
             "N150"
-          ]
-        }
-      }
-    },
-    "speecht5_tts": {
-      "inference_engine": "MEDIA",
-      "ci": {
-        "nightly": {
-          "devices": [
-            "N150",
-            "N300",
-            "P150",
-            "P300X2"
-          ]
-        },
-        "release": {
-          "devices": [
-            "P150",
-            "P300X2"
           ]
         }
       }
@@ -674,11 +599,6 @@
                   "throttle-perf": "5"
                 }
               }
-            },
-            "release": {
-              "devices": [
-                "GALAXY"
-              ]
             }
           }
         },
@@ -739,12 +659,6 @@
         "weekly": {
           "devices": [
             "GALAXY"
-          ]
-        },
-        "release": {
-          "devices": [
-            "P150",
-            "P300X2"
           ]
         }
       }

--- a/charts/tt-inference-server/README.md
+++ b/charts/tt-inference-server/README.md
@@ -309,6 +309,7 @@ All fields under `defaults` apply to every model/engine/device/impl unless overr
 | `Wan2.2-T2V-A14B-Diffusers` | p150x8 |
 | `Wan2.2-T2V-A14B-Diffusers` | p300x2 |
 | `Wan2.2-T2V-A14B-Diffusers` | t3k |
+| `Z-Image-Turbo` | p300x2 |
 | `bge-large-en-v1.5` | galaxy |
 | `bge-large-en-v1.5` | n150 |
 | `bge-large-en-v1.5` | n300 |
@@ -398,12 +399,16 @@ All fields under `defaults` apply to every model/engine/device/impl unless overr
 | `resnet-50` | n300 |
 | `segformer` | n150 |
 | `segformer` | n300 |
+| `stable-diffusion-xl-base-1.0` | p150x8 |
+| `stable-diffusion-xl-base-1.0` | p300x2 |
 | `unet` | n150 |
 | `unet` | n300 |
 | `vit` | n150 |
 | `vit` | n300 |
 | `vovnet` | n150 |
 | `vovnet` | n300 |
+| `yolox_nano` | n150 |
+| `yolox_nano` | p150 |
 
 To add a new model, add an entry under `models.<name>.<engine>.<device>` in `values.yaml`, where `<engine>` is one of `vllm`, `media`, or `forge`, and the device block contains an `impls.<impl-id>` entry with `image.repository` and `image.tag`.
 

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -196,7 +196,7 @@ models:
             progressDeadlineSeconds: 7200
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
-              tag: 0.12.0-805f43d-a45c614
+              tag: 0.16.0-669d59e-3334377
             probes:
               liveness:
                 initialDelaySeconds: 3600
@@ -229,7 +229,7 @@ models:
             progressDeadlineSeconds: 7200
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
-              tag: 0.12.0-805f43d-a45c614
+              tag: 0.16.0-669d59e-3334377
             probes:
               liveness:
                 initialDelaySeconds: 3600
@@ -1520,7 +1520,7 @@ models:
             progressDeadlineSeconds: 7200
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
-              tag: 0.10.1-555f240-22be241
+              tag: 0.16.0-669d59e-3334377
             probes:
               liveness:
                 initialDelaySeconds: 3600
@@ -1713,7 +1713,7 @@ models:
             progressDeadlineSeconds: 7200
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
-              tag: 0.10.1-555f240-22be241
+              tag: 0.16.0-669d59e-3334377
             probes:
               liveness:
                 initialDelaySeconds: 3600
@@ -1939,7 +1939,7 @@ models:
             progressDeadlineSeconds: 7200
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
-              tag: 0.10.1-555f240-22be241
+              tag: 0.16.0-669d59e-3334377
             probes:
               liveness:
                 initialDelaySeconds: 3600
@@ -2132,7 +2132,7 @@ models:
             progressDeadlineSeconds: 7200
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
-              tag: 0.10.1-555f240-22be241
+              tag: 0.16.0-669d59e-3334377
             probes:
               liveness:
                 initialDelaySeconds: 3600

--- a/docs/model_support/llm/Llama-3.3-70B-Instruct_p300x2.md
+++ b/docs/model_support/llm/Llama-3.3-70B-Instruct_p300x2.md
@@ -38,7 +38,7 @@ docker run \
   --device /dev/tenstorrent \
   --mount type=bind,src=/dev/hugepages-1G,dst=/dev/hugepages-1G \
   --volume volume_id_Llama-3.3-70B-Instruct:/home/container_app_user/cache_root \
-  ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.1-555f240-22be241 \
+  ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377 \
   --model Llama-3.3-70B-Instruct \
   --tt-device p300x2
 ```
@@ -58,7 +58,7 @@ For details on the run.py command, see the [run.py CLI Options](../../workflows_
 | Model Status | 🟡 Functional |
 | Max Batch Size | 32 |
 | Max Context Length | 131072 |
-| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/555f240/models/tt_transformers) |
-| tt-metal Commit | `555f240` |
-| vLLM Commit | `22be241` |
-| Docker Image | `ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.1-555f240-22be241` |
+| Implementation Code | [tt-transformers](https://github.com/tenstorrent/tt-metal/tree/669d59e/models/tt_transformers) |
+| tt-metal Commit | `669d59e` |
+| vLLM Commit | `3334377` |
+| Docker Image | `ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377` |

--- a/docs/model_support/llm/gpt-oss-120b_galaxy.md
+++ b/docs/model_support/llm/gpt-oss-120b_galaxy.md
@@ -26,7 +26,7 @@ docker run \
   --device /dev/tenstorrent \
   --mount type=bind,src=/dev/hugepages-1G,dst=/dev/hugepages-1G \
   --volume volume_id_gpt-oss-120b:/home/container_app_user/cache_root \
-  ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.12.0-805f43d-a45c614 \
+  ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377 \
   --model gpt-oss-120b \
   --tt-device galaxy
 ```
@@ -46,7 +46,7 @@ For details on the run.py command, see the [run.py CLI Options](../../workflows_
 | Model Status | 🛠️ Experimental |
 | Max Batch Size | 32 |
 | Max Context Length | 131072 |
-| Implementation Code | [gpt-oss](https://github.com/tenstorrent/tt-metal/tree/805f43d/models/demos/gpt_oss) |
-| tt-metal Commit | `805f43d` |
-| vLLM Commit | `a45c614` |
-| Docker Image | `ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.12.0-805f43d-a45c614` |
+| Implementation Code | [gpt-oss](https://github.com/tenstorrent/tt-metal/tree/669d59e/models/demos/gpt_oss) |
+| tt-metal Commit | `669d59e` |
+| vLLM Commit | `3334377` |
+| Docker Image | `ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377` |

--- a/docs/model_support/llm/gpt-oss-120b_t3k.md
+++ b/docs/model_support/llm/gpt-oss-120b_t3k.md
@@ -26,7 +26,7 @@ docker run \
   --device /dev/tenstorrent \
   --mount type=bind,src=/dev/hugepages-1G,dst=/dev/hugepages-1G \
   --volume volume_id_gpt-oss-120b:/home/container_app_user/cache_root \
-  ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.12.0-805f43d-a45c614 \
+  ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377 \
   --model gpt-oss-120b \
   --tt-device t3k
 ```
@@ -46,7 +46,7 @@ For details on the run.py command, see the [run.py CLI Options](../../workflows_
 | Model Status | 🛠️ Experimental |
 | Max Batch Size | 1 |
 | Max Context Length | 16384 |
-| Implementation Code | [gpt-oss](https://github.com/tenstorrent/tt-metal/tree/805f43d/models/demos/gpt_oss) |
-| tt-metal Commit | `805f43d` |
-| vLLM Commit | `a45c614` |
-| Docker Image | `ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.12.0-805f43d-a45c614` |
+| Implementation Code | [gpt-oss](https://github.com/tenstorrent/tt-metal/tree/669d59e/models/demos/gpt_oss) |
+| tt-metal Commit | `669d59e` |
+| vLLM Commit | `3334377` |
+| Docker Image | `ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377` |

--- a/release_model_spec.json
+++ b/release_model_spec.json
@@ -346,7 +346,7 @@
             "model_name": "gpt-oss-120b",
             "inference_engine": "vLLM",
             "device_type": "T3K",
-            "tt_metal_commit": "805f43d",
+            "tt_metal_commit": "669d59e",
             "device_model_spec": {
               "device": "T3K",
               "max_concurrency": 1,
@@ -429,17 +429,17 @@
               "MESH_DEVICE": "T3K",
               "ARCH_NAME": "wormhole_b0"
             },
-            "vllm_commit": "a45c614",
+            "vllm_commit": "3334377",
             "hf_weights_repo": "openai/gpt-oss-120b",
             "param_count": 120,
             "min_disk_gb": 260,
             "min_ram_gb": 300.0,
             "model_type": "LLM",
             "repacked": 0,
-            "version": "0.12.0",
-            "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.12.0-805f43d-a45c614",
+            "version": "0.16.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
             "status": "EXPERIMENTAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/805f43d/models/demos/gpt_oss",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/669d59e/models/demos/gpt_oss",
             "override_tt_config": {
               "trace_region_size": 134217728
             },
@@ -471,7 +471,7 @@
             "model_name": "gpt-oss-120b",
             "inference_engine": "vLLM",
             "device_type": "GALAXY",
-            "tt_metal_commit": "805f43d",
+            "tt_metal_commit": "669d59e",
             "device_model_spec": {
               "device": "GALAXY",
               "max_concurrency": 32,
@@ -556,17 +556,17 @@
               "ARCH_NAME": "wormhole_b0",
               "TT_MM_THROTTLE_PERF": 2
             },
-            "vllm_commit": "a45c614",
+            "vllm_commit": "3334377",
             "hf_weights_repo": "openai/gpt-oss-120b",
             "param_count": 120,
             "min_disk_gb": 260,
             "min_ram_gb": 300.0,
             "model_type": "LLM",
             "repacked": 0,
-            "version": "0.12.0",
-            "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.12.0-805f43d-a45c614",
+            "version": "0.16.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
             "status": "EXPERIMENTAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/805f43d/models/demos/gpt_oss",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/669d59e/models/demos/gpt_oss",
             "override_tt_config": {
               "sample_on_device_mode": "all",
               "trace_region_size": 134217728
@@ -862,19 +862,19 @@
                     "functional": {
                       "ttft_ms": 510.0,
                       "tput_user": 2.1,
-                      "tput": 65.2,
+                      "tput": 2.1,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 102.0,
                       "tput_user": 10.5,
-                      "tput": 326.0,
+                      "tput": 10.5,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 51.0,
                       "tput_user": 21.0,
-                      "tput": 652.0,
+                      "tput": 21.0,
                       "tolerance": 0.0
                     }
                   },
@@ -984,19 +984,19 @@
                     "functional": {
                       "ttft_ms": 420.0,
                       "tput_user": 4.1000000000000005,
-                      "tput": 130.3,
+                      "tput": 4.1000000000000005,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 84.0,
                       "tput_user": 20.5,
-                      "tput": 651.5,
+                      "tput": 20.5,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 42.0,
                       "tput_user": 41.0,
-                      "tput": 1303.0,
+                      "tput": 41.0,
                       "tolerance": 0.0
                     }
                   },
@@ -1108,19 +1108,19 @@
                     "functional": {
                       "ttft_ms": 220.0,
                       "tput_user": 8.1,
-                      "tput": 521.2,
+                      "tput": 8.1,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 44.0,
                       "tput_user": 40.5,
-                      "tput": 2606.0,
+                      "tput": 40.5,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 22.0,
                       "tput_user": 81.0,
-                      "tput": 5212.0,
+                      "tput": 81.0,
                       "tolerance": 0.0
                     }
                   },
@@ -1315,19 +1315,19 @@
                     "functional": {
                       "ttft_ms": 120.0,
                       "tput_user": 60.0,
-                      "tput": 2084.8,
+                      "tput": 60.0,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 24.0,
                       "tput_user": 300.0,
-                      "tput": 10424.0,
+                      "tput": 300.0,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 12.0,
                       "tput_user": 600.0,
-                      "tput": 20848.0,
+                      "tput": 600.0,
                       "tolerance": 0.0
                     }
                   },
@@ -4615,7 +4615,7 @@
             "model_name": "Llama-3.3-70B-Instruct",
             "inference_engine": "vLLM",
             "device_type": "P300X2",
-            "tt_metal_commit": "555f240",
+            "tt_metal_commit": "669d59e",
             "device_model_spec": {
               "device": "P300X2",
               "max_concurrency": 32,
@@ -4683,7 +4683,13 @@
               },
               "tensor_cache_timeout": 5400.0,
               "system_requirements": null,
-              "known_issues": [],
+              "known_issues": [
+                {
+                  "workflow_type": "TESTS",
+                  "reason": "test_penalties length-change assertion (server_tests/test_cases/test_vllm_chat_completions.py:289) is over-strict for short, low-repetition prompts decoded near-greedily; presence_penalty=1.2 legitimately produced identical output. Model meets FUNCTIONAL expectations. Tracked in #3888.",
+                  "task_name": "test_penalties"
+                }
+              ],
               "eval_max_retries": null
             },
             "system_requirements": {
@@ -4704,17 +4710,17 @@
               "MESH_DEVICE": "P300x2",
               "ARCH_NAME": "blackhole"
             },
-            "vllm_commit": "22be241",
+            "vllm_commit": "3334377",
             "hf_weights_repo": "meta-llama/Llama-3.3-70B-Instruct",
             "param_count": 70,
             "min_disk_gb": 160,
             "min_ram_gb": 175.0,
             "model_type": "LLM",
             "repacked": 0,
-            "version": "0.10.1",
-            "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.1-555f240-22be241",
+            "version": "0.16.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
             "status": "FUNCTIONAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/555f240/models/tt_transformers",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/669d59e/models/tt_transformers",
             "override_tt_config": {
               "trace_region_size": 402653184
             },
@@ -4723,7 +4729,7 @@
             ],
             "subdevice_type": null,
             "uses_tensor_model_cache": true,
-            "has_builtin_warmup": false,
+            "has_builtin_warmup": true,
             "metadata": {
               "tool_call_parser_name": "llama3_json"
             },
@@ -5399,7 +5405,7 @@
             "model_name": "Llama-3.1-70B",
             "inference_engine": "vLLM",
             "device_type": "P300X2",
-            "tt_metal_commit": "555f240",
+            "tt_metal_commit": "669d59e",
             "device_model_spec": {
               "device": "P300X2",
               "max_concurrency": 32,
@@ -5467,7 +5473,13 @@
               },
               "tensor_cache_timeout": 5400.0,
               "system_requirements": null,
-              "known_issues": [],
+              "known_issues": [
+                {
+                  "workflow_type": "TESTS",
+                  "reason": "test_penalties length-change assertion (server_tests/test_cases/test_vllm_chat_completions.py:289) is over-strict for short, low-repetition prompts decoded near-greedily; presence_penalty=1.2 legitimately produced identical output. Model meets FUNCTIONAL expectations. Tracked in #3888.",
+                  "task_name": "test_penalties"
+                }
+              ],
               "eval_max_retries": null
             },
             "system_requirements": {
@@ -5488,17 +5500,17 @@
               "MESH_DEVICE": "P300x2",
               "ARCH_NAME": "blackhole"
             },
-            "vllm_commit": "22be241",
+            "vllm_commit": "3334377",
             "hf_weights_repo": "meta-llama/Llama-3.1-70B",
             "param_count": 70,
             "min_disk_gb": 160,
             "min_ram_gb": 175.0,
             "model_type": "LLM",
             "repacked": 0,
-            "version": "0.10.1",
-            "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.1-555f240-22be241",
+            "version": "0.16.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
             "status": "FUNCTIONAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/555f240/models/tt_transformers",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/669d59e/models/tt_transformers",
             "override_tt_config": {
               "trace_region_size": 402653184
             },
@@ -5507,7 +5519,7 @@
             ],
             "subdevice_type": null,
             "uses_tensor_model_cache": true,
-            "has_builtin_warmup": false,
+            "has_builtin_warmup": true,
             "metadata": {
               "tool_call_parser_name": "llama3_json"
             },
@@ -6183,7 +6195,7 @@
             "model_name": "Llama-3.1-70B-Instruct",
             "inference_engine": "vLLM",
             "device_type": "P300X2",
-            "tt_metal_commit": "555f240",
+            "tt_metal_commit": "669d59e",
             "device_model_spec": {
               "device": "P300X2",
               "max_concurrency": 32,
@@ -6251,7 +6263,13 @@
               },
               "tensor_cache_timeout": 5400.0,
               "system_requirements": null,
-              "known_issues": [],
+              "known_issues": [
+                {
+                  "workflow_type": "TESTS",
+                  "reason": "test_penalties length-change assertion (server_tests/test_cases/test_vllm_chat_completions.py:289) is over-strict for short, low-repetition prompts decoded near-greedily; presence_penalty=1.2 legitimately produced identical output. Model meets FUNCTIONAL expectations. Tracked in #3888.",
+                  "task_name": "test_penalties"
+                }
+              ],
               "eval_max_retries": null
             },
             "system_requirements": {
@@ -6272,17 +6290,17 @@
               "MESH_DEVICE": "P300x2",
               "ARCH_NAME": "blackhole"
             },
-            "vllm_commit": "22be241",
+            "vllm_commit": "3334377",
             "hf_weights_repo": "meta-llama/Llama-3.1-70B-Instruct",
             "param_count": 70,
             "min_disk_gb": 160,
             "min_ram_gb": 175.0,
             "model_type": "LLM",
             "repacked": 0,
-            "version": "0.10.1",
-            "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.1-555f240-22be241",
+            "version": "0.16.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
             "status": "FUNCTIONAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/555f240/models/tt_transformers",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/669d59e/models/tt_transformers",
             "override_tt_config": {
               "trace_region_size": 402653184
             },
@@ -6291,7 +6309,7 @@
             ],
             "subdevice_type": null,
             "uses_tensor_model_cache": true,
-            "has_builtin_warmup": false,
+            "has_builtin_warmup": true,
             "metadata": {
               "tool_call_parser_name": "llama3_json"
             },
@@ -6971,7 +6989,7 @@
             "model_name": "DeepSeek-R1-Distill-Llama-70B",
             "inference_engine": "vLLM",
             "device_type": "P300X2",
-            "tt_metal_commit": "555f240",
+            "tt_metal_commit": "669d59e",
             "device_model_spec": {
               "device": "P300X2",
               "max_concurrency": 32,
@@ -7039,7 +7057,13 @@
               },
               "tensor_cache_timeout": 5400.0,
               "system_requirements": null,
-              "known_issues": [],
+              "known_issues": [
+                {
+                  "workflow_type": "TESTS",
+                  "reason": "test_penalties length-change assertion (server_tests/test_cases/test_vllm_chat_completions.py:289) is over-strict for short, low-repetition prompts decoded near-greedily; presence_penalty=1.2 legitimately produced identical output. Model meets FUNCTIONAL expectations. Tracked in #3888.",
+                  "task_name": "test_penalties"
+                }
+              ],
               "eval_max_retries": null
             },
             "system_requirements": {
@@ -7060,17 +7084,17 @@
               "MESH_DEVICE": "P300x2",
               "ARCH_NAME": "blackhole"
             },
-            "vllm_commit": "22be241",
+            "vllm_commit": "3334377",
             "hf_weights_repo": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
             "param_count": 70,
             "min_disk_gb": 160,
             "min_ram_gb": 175.0,
             "model_type": "LLM",
             "repacked": 0,
-            "version": "0.10.1",
-            "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.1-555f240-22be241",
+            "version": "0.16.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
             "status": "FUNCTIONAL",
-            "code_link": "https://github.com/tenstorrent/tt-metal/tree/555f240/models/tt_transformers",
+            "code_link": "https://github.com/tenstorrent/tt-metal/tree/669d59e/models/tt_transformers",
             "override_tt_config": {
               "trace_region_size": 402653184
             },
@@ -7079,7 +7103,7 @@
             ],
             "subdevice_type": null,
             "uses_tensor_model_cache": true,
-            "has_builtin_warmup": false,
+            "has_builtin_warmup": true,
             "metadata": {
               "reasoning_parser_name": "deepseek_r1",
               "tool_call_parser_name": "deepseek_v3"
@@ -22981,19 +23005,19 @@
                     "functional": {
                       "ttft_ms": 270.0,
                       "tput_user": 4.2,
-                      "tput": 129.3,
+                      "tput": 4.2,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 54.0,
                       "tput_user": 21.0,
-                      "tput": 646.5,
+                      "tput": 21.0,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 27.0,
                       "tput_user": 42.0,
-                      "tput": 1293.0,
+                      "tput": 42.0,
                       "tolerance": 0.0
                     }
                   },
@@ -23098,19 +23122,19 @@
                     "functional": {
                       "ttft_ms": 260.0,
                       "tput_user": 8.200000000000001,
-                      "tput": 258.6,
+                      "tput": 8.200000000000001,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 52.0,
                       "tput_user": 41.0,
-                      "tput": 1293.0,
+                      "tput": 41.0,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 26.0,
                       "tput_user": 82.0,
-                      "tput": 2586.0,
+                      "tput": 82.0,
                       "tolerance": 0.0
                     }
                   },

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -46,9 +46,9 @@ templates:
 - weights:
     - openai/gpt-oss-120b
   impl: gpt_oss
-  version: "0.12.0"
-  tt_metal_commit: 805f43d
-  vllm_commit: a45c614
+  version: "0.16.0"
+  tt_metal_commit: 669d59e
+  vllm_commit: "3334377"
   inference_engine: VLLM
   device_model_specs:
     - device: T3K
@@ -765,9 +765,9 @@ templates:
     kmd:
       specifier: ">=2.5.0"
       mode: STRICT
-  version: "0.10.0"
-  tt_metal_commit: 555f240
-  vllm_commit: 22be241
+  version: "0.16.0"
+  tt_metal_commit: 669d59e
+  vllm_commit: "3334377"
   inference_engine: VLLM
   device_model_specs:
     - device: P300X2

--- a/workflows/model_specs/prod/llm.yaml
+++ b/workflows/model_specs/prod/llm.yaml
@@ -46,9 +46,9 @@ templates:
 - weights:
     - openai/gpt-oss-120b
   impl: gpt_oss
-  version: "0.12.0"
-  tt_metal_commit: 805f43d
-  vllm_commit: a45c614
+  version: "0.16.0"
+  tt_metal_commit: 669d59e
+  vllm_commit: "3334377"
   inference_engine: VLLM
   device_model_specs:
     - device: T3K
@@ -668,9 +668,9 @@ templates:
     kmd:
       specifier: ">=2.5.0"
       mode: STRICT
-  version: "0.10.1"
-  tt_metal_commit: 555f240
-  vllm_commit: 22be241
+  version: "0.16.0"
+  tt_metal_commit: 669d59e
+  vllm_commit: "3334377"
   inference_engine: VLLM
   device_model_specs:
     - device: P300X2
@@ -680,7 +680,12 @@ templates:
       tensor_cache_timeout: 5400.0
       override_tt_config:
         trace_region_size: 402653184  # 384 * 1024 * 1024
+      known_issues:
+        - workflow_type: TESTS
+          task_name: test_penalties
+          reason: "test_penalties length-change assertion (server_tests/test_cases/test_vllm_chat_completions.py:289) is over-strict for short, low-repetition prompts decoded near-greedily; presence_penalty=1.2 legitimately produced identical output. Model meets FUNCTIONAL expectations. Tracked in #3888."
   status: FUNCTIONAL
+  has_builtin_warmup: true
   metadata:
     meta-llama/Llama-3.3-70B-Instruct:
       tool_call_parser_name: llama3_json


### PR DESCRIPTION
# Summary of Changes

* Uplifted Llama-3.3-70B-Instruct on Blackhole QuietBox 2
* Uplifted gpt-oss-120b on Wormhole Galaxy

# SW versions recommended for Wormhole Galaxy:

- tt-smi: 4.0.0
- Firmware: 19.2.0
- tt-kmd: 2.5.0

# Model Spec Release Updates

This document shows model specification updates.

| Impl | Model Arch | Weights | Devices | TT-Metal Commit Change | Status Change | CI Job Link |
|------|------------|---------|---------|------------------------|---------------|-------------|
| `tt_transformers` | `Llama-3.3-70B-Instruct` | `meta-llama/Llama-3.3-70B-Instruct` | P300X2 | `555f240` → `669d59e` | No change [FUNCTIONAL] | [CI Link](https://github.com/tenstorrent/tt-shield/actions/runs/27369620710/job/81021768673) |
| `gpt_oss` | `gpt-oss-120b ` | `openai/gpt-oss-120b` | GALAXY | `747215b ` → `669d59e` | No change [EXPERIMENTAL] | [CI Link](https://github.com/tenstorrent/tt-shield/actions/runs/27369620710/job/81021768256) |

# Release Artifacts Summary

## Images Promoted from Models CI

- http://ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377

**Total:** 1
