### PR TITLE
Add FLUX.2-dev on WH Galaxy in tt-media-server

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -15,6 +15,7 @@ class SupportedModels(Enum):
     STABLE_DIFFUSION_3_5_LARGE = "stabilityai/stable-diffusion-3.5-large"
     FLUX_1_DEV = "black-forest-labs/FLUX.1-dev"
     FLUX_1_SCHNELL = "black-forest-labs/FLUX.1-schnell"
+    FLUX_2_DEV = "black-forest-labs/FLUX.2-dev"
     MOTIF_IMAGE_6B_PREVIEW = "Motif-Technologies/Motif-Image-6B-Preview"
     QWEN_IMAGE = "Qwen/Qwen-Image"
     QWEN_IMAGE_2512 = "Qwen/Qwen-Image-2512"
@@ -58,6 +59,7 @@ class ModelNames(Enum):
     STABLE_DIFFUSION_3_5_LARGE = "stable-diffusion-3.5-large"
     FLUX_1_DEV = "FLUX.1-dev"
     FLUX_1_SCHNELL = "FLUX.1-schnell"
+    FLUX_2_DEV = "FLUX.2-dev"
     MOTIF_IMAGE_6B_PREVIEW = "Motif-Image-6B-Preview"
     QWEN_IMAGE = "Qwen-Image"
     QWEN_IMAGE_2512 = "Qwen-Image-2512"
@@ -105,6 +107,7 @@ class ModelRunners(Enum):
     TT_SD3_5 = "tt-sd3.5"
     TT_FLUX_1_DEV = "tt-flux.1-dev"
     TT_FLUX_1_SCHNELL = "tt-flux.1-schnell"
+    TT_FLUX_2_DEV = "tt-flux.2-dev"
     TT_MOTIF_IMAGE_6B_PREVIEW = "tt-motif-image-6b-preview"
     TT_QWEN_IMAGE = "tt-qwen-image"
     TT_QWEN_IMAGE_2512 = "tt-qwen-image-2512"
@@ -164,6 +167,7 @@ MODEL_SERVICE_RUNNER_MAP = {
         ModelRunners.TT_SD3_5,
         ModelRunners.TT_FLUX_1_DEV,
         ModelRunners.TT_FLUX_1_SCHNELL,
+        ModelRunners.TT_FLUX_2_DEV,
         ModelRunners.TT_MOTIF_IMAGE_6B_PREVIEW,
         ModelRunners.TT_QWEN_IMAGE,
         ModelRunners.TT_QWEN_IMAGE_2512,
@@ -226,6 +230,7 @@ INFERENCE_MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.TT_SD3_5: {ModelNames.STABLE_DIFFUSION_3_5_LARGE},
     ModelRunners.TT_FLUX_1_DEV: {ModelNames.FLUX_1_DEV},
     ModelRunners.TT_FLUX_1_SCHNELL: {ModelNames.FLUX_1_SCHNELL},
+    ModelRunners.TT_FLUX_2_DEV: {ModelNames.FLUX_2_DEV},
     ModelRunners.TT_MOTIF_IMAGE_6B_PREVIEW: {ModelNames.MOTIF_IMAGE_6B_PREVIEW},
     ModelRunners.TT_QWEN_IMAGE: {ModelNames.QWEN_IMAGE},
     ModelRunners.TT_QWEN_IMAGE_2512: {ModelNames.QWEN_IMAGE_2512},
@@ -687,6 +692,13 @@ ModelConfigs = {
         "request_processing_timeout_seconds": 3000,
     },
     (ModelRunners.TT_FLUX_1_SCHNELL, DeviceTypes.GALAXY): {
+        "device_mesh_shape": (4, 8),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_32_GROUP.value,
+        "max_batch_size": 1,
+        "request_processing_timeout_seconds": 5000,
+    },
+    (ModelRunners.TT_FLUX_2_DEV, DeviceTypes.GALAXY): {
         "device_mesh_shape": (4, 8),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_32_GROUP.value,

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -304,6 +304,7 @@ class Settings(BaseSettings):
             ModelRunners.TT_SD3_5.value,
             ModelRunners.TT_FLUX_1_SCHNELL.value,
             ModelRunners.TT_FLUX_1_DEV.value,
+            ModelRunners.TT_FLUX_2_DEV.value,
             ModelRunners.TT_QWEN_IMAGE.value,
             ModelRunners.TT_MOCHI_1.value,
             ModelRunners.TT_WAN_2_2.value,

--- a/tt-media-server/open_ai_api/models.py
+++ b/tt-media-server/open_ai_api/models.py
@@ -19,6 +19,7 @@ MODEL_RUNNER_TO_REQUEST_MAP = {
     ModelRunners.TT_SD3_5.value: BaseImageRequest,
     ModelRunners.TT_FLUX_1_DEV.value: BaseImageRequest,
     ModelRunners.TT_FLUX_1_SCHNELL.value: BaseImageRequest,
+    ModelRunners.TT_FLUX_2_DEV.value: BaseImageRequest,
     ModelRunners.TT_MOTIF_IMAGE_6B_PREVIEW.value: BaseImageRequest,
     ModelRunners.TT_QWEN_IMAGE.value: BaseImageRequest,
     ModelRunners.TT_QWEN_IMAGE_2512.value: BaseImageRequest,

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -23,6 +23,11 @@ from domain.video_generate_request import VideoGenerateRequest
 from domain.video_i2v_generate_request import ImagePromptEntry, VideoI2VGenerateRequest
 from models.common.utility_functions import is_blackhole
 from models.tt_dit.pipelines.flux1.pipeline_flux1 import Flux1Pipeline
+
+# WH Galaxy-optimized Flux2 pipeline (Ring topology, FSDP, prompt sharding,
+# swept matmul configs). The plain pipelines.flux2.pipeline_flux2 is the
+# functional/reference variant and is intentionally NOT used here.
+from models.tt_dit.pipelines.flux2.pipeline_flux2_opt_hybrid import Flux2Pipeline
 from models.tt_dit.pipelines.mochi.pipeline_mochi import MochiPipeline
 from models.tt_dit.pipelines.motif.pipeline_motif import MotifPipeline
 from models.tt_dit.pipelines.qwenimage.pipeline_qwenimage import (
@@ -47,6 +52,7 @@ dit_runner_log_map = {
     ModelRunners.TT_SD3_5.value: "SD35",
     ModelRunners.TT_FLUX_1_DEV.value: "FLUX.1-dev",
     ModelRunners.TT_FLUX_1_SCHNELL.value: "FLUX.1-schnell",
+    ModelRunners.TT_FLUX_2_DEV.value: "FLUX.2-dev",
     ModelRunners.TT_MOTIF_IMAGE_6B_PREVIEW.value: "Motif-Image-6B-Preview",
     ModelRunners.TT_MOCHI_1.value: "Mochi1",
     ModelRunners.TT_WAN_2_2.value: "Wan22",
@@ -240,6 +246,91 @@ class TTFlux1Runner(TTDiTRunner):
 
     def get_pipeline_device_params(self):
         return {"l1_small_size": 32768, "trace_region_size": 50000000}
+
+
+# Flux2 (FLUX.2-dev) trace region for the full traced image pipeline on a
+# Galaxy (4, 8) mesh. The transformer reference uses 31MB; the full pipeline
+# (encoder + transformer + VAE) needs headroom. Validate / tune on real WH
+# Galaxy hardware if warmup OOMs or rejects the trace binary.
+FLUX2_TRACE_REGION_SIZE = 90_000_000
+
+
+# Runner for FLUX.2-dev on WH Galaxy, using the WH-optimized hybrid pipeline.
+# Config mirrors tt-metal's perf test id "wh_glx_ring_sp0tp1_fsdp": Ring
+# topology over FABRIC_1D_RING, 4 links, FSDP, prompt sharding, with the VAE
+# tensor-parallel on the row (sp) axis. Inference is via __call__ returning a
+# list of PIL images (not run_single_prompt), so create_pipeline and run are
+# both overridden.
+class TTFlux2Runner(TTDiTRunner):
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+
+    def _parallel_params(self) -> dict:
+        """Resolve Flux2 parallel config for the active mesh + arch.
+
+        Mirrors tt-metal's flux2 perf test (id ``wh_glx_ring_sp0tp1_fsdp``):
+        sp on axis 0, tp on axis 1, encoder TP on the column axis, VAE TP on
+        the row axis. WH Galaxy uses 4 links; BH Galaxy uses 2.
+        """
+        num_links = 2 if is_blackhole() else 4
+        return {
+            "sp_axis": 0,
+            "tp_axis": 1,
+            "encoder_tp_axis": 1,
+            "vae_tp_axis": 0,
+            "vae_h_axis": 1,
+            "vae_w_axis": None,
+            "num_links": num_links,
+            "is_fsdp": True,
+            "shard_prompt": True,
+        }
+
+    def create_pipeline(self):
+        try:
+            return Flux2Pipeline.create_pipeline(
+                mesh_device=self.ttnn_device,
+                checkpoint_name=self.settings.model_weights_path,
+                topology=ttnn.Topology.Ring,
+                width=1024,
+                height=1024,
+                trace_warmup=True,
+                **self._parallel_params(),
+            )
+        except Exception as e:
+            log_exception_chain(
+                self.logger,
+                self.device_id,
+                "Flux2 pipeline creation failed",
+                e,
+            )
+            raise
+
+    @log_execution_time(
+        f"{dit_runner_log_map.get(get_settings().model_runner, 'FLUX.2-dev')} inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    def run(self, requests: list[ImageGenerateRequest]):
+        self.logger.debug(f"Device {self.device_id}: Running inference")
+        request = requests[0]
+        images = self.pipeline(
+            prompts=[request.prompt],
+            num_inference_steps=request.num_inference_steps,
+            seed=int(request.seed or 0),
+            traced=True,
+        )
+        self.logger.debug(f"Device {self.device_id}: Inference completed")
+        return images[0]
+
+    def get_pipeline_device_params(self):
+        # WH Galaxy ring config validated with ring_params_flux2:
+        # FABRIC_1D_RING + l1_small_size 32768 (no 8k router config needed at
+        # 4 links on WH).
+        return {
+            "l1_small_size": 32768,
+            "trace_region_size": FLUX2_TRACE_REGION_SIZE,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+        }
 
 
 class TTMotifImage6BPreviewRunner(TTDiTRunner):

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -28,6 +28,9 @@ AVAILABLE_RUNNERS = {
     ModelRunners.TT_FLUX_1_SCHNELL: lambda wid: __import__(
         "tt_model_runners.dit_runners", fromlist=["TTFlux1Runner"]
     ).TTFlux1Runner(wid),
+    ModelRunners.TT_FLUX_2_DEV: lambda wid: __import__(
+        "tt_model_runners.dit_runners", fromlist=["TTFlux2Runner"]
+    ).TTFlux2Runner(wid),
     ModelRunners.TT_MOTIF_IMAGE_6B_PREVIEW: lambda wid: __import__(
         "tt_model_runners.dit_runners", fromlist=["TTMotifImage6BPreviewRunner"]
     ).TTMotifImage6BPreviewRunner(wid),

--- a/workflows/model_specs/dev/image.yaml
+++ b/workflows/model_specs/dev/image.yaml
@@ -185,6 +185,24 @@ templates:
       default_impl: true
   status: COMPLETE
 
+# FLUX.2-dev on WH Galaxy (4, 8). tt_metal_commit points at the flux2 branch
+# until it merges to tt-metal main; update once merged.
+- weights:
+    - black-forest-labs/FLUX.2-dev
+  version: "0.1.0"
+  tt_metal_commit: e56a7ce
+  impl: tt_transformers
+  min_disk_gb: 80
+  min_ram_gb: 64
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+  status: EXPERIMENTAL
+
 - weights:
     - Motif-Technologies/Motif-Image-6B-Preview
   version: "0.9.0"

--- a/workflows/model_specs/prod/image.yaml
+++ b/workflows/model_specs/prod/image.yaml
@@ -164,6 +164,25 @@ templates:
       default_impl: true
   status: COMPLETE
 
+# FLUX.2-dev on WH Galaxy (4, 8). tt_metal_commit points at the flux2 branch
+# until it merges to tt-metal main; update once merged. Status EXPERIMENTAL
+# until validated end-to-end on real WH Galaxy hardware.
+- weights:
+    - black-forest-labs/FLUX.2-dev
+  version: "0.1.0"
+  tt_metal_commit: e56a7ce
+  impl: tt_transformers
+  min_disk_gb: 80
+  min_ram_gb: 64
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+  status: EXPERIMENTAL
+
 - weights:
     - Motif-Technologies/Motif-Image-6B-Preview
   version: "0.9.0"

--- a/workflows/v2_bridge.py
+++ b/workflows/v2_bridge.py
@@ -53,6 +53,7 @@ _V2_ROUTED_MODELS = frozenset(
         "stable-diffusion-3.5-large",
         "FLUX.1-dev",
         "FLUX.1-schnell",
+        "FLUX.2-dev",
         "Motif-Image-6B-Preview",
         "whisper-large-v3",
         "distil-large-v3",


### PR DESCRIPTION
Integrate FLUX.2-dev into the media server end-to-end: new TTFlux2Runner (Flux2Pipeline with explicit parallel config and __call__ inference), runner/model registration, GALAXY (4,8) device config, request schema, shared model catalog entries (prod + dev), and v2 routing.

tt-metal branch : [tvardhineni/flux2_wh-glx ](https://github.com/tenstorrent/tt-metal/tree/tvardhineni/flux2_wh-glx)