### PR TITLE
Remove [BORDER] logging, keep position-ID signal in existing DEBUG logs

### DIFF
--- a/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_utils.hpp
+++ b/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_utils.hpp
@@ -4,12 +4,9 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 
 #include "config/settings.hpp"
 #include "domain/llm/sequence.hpp"
-#include "domain/manage_memory.hpp"
-#include "ipc/interface/result_queue.hpp"
 #include "runtime/runners/blaze_runner/blaze_types.hpp"
 #include "tt_llm_engine/pipeline/channel_configs.hpp"
 #include "tt_llm_engine/pipeline/prefill_pipeline_config.hpp"
@@ -97,114 +94,6 @@ inline sch::ISRequest makeContinueRequest(
     req.position_id = *seq.getKVPositionId();
   }
   return req;
-}
-
-// ---------------------------------------------------------------------------
-// Interface-border logging.
-//
-// Every line carries the greppable "[BORDER]" tag so a single
-// `grep '\[BORDER\]'` surfaces all traffic crossing a runner boundary.
-// Direction is encoded in the arrow: ">>" = runner sent to the scheduler,
-// "<<" = runner received (from the scheduler, a queue, or dynamo). `role`
-// is "prefill" or "decode" so prefill/decode lines can be told apart in a
-// shared log. All emit at INFO.
-// ---------------------------------------------------------------------------
-
-inline const char* requestTypeName(sch::RequestType t) {
-  switch (t) {
-    case sch::RequestType::ALLOCATE:
-      return "ALLOCATE";
-    case sch::RequestType::SUBMIT:
-      return "SUBMIT";
-    case sch::RequestType::CONTINUE:
-      return "CONTINUE";
-    case sch::RequestType::EVICT:
-      return "EVICT";
-    case sch::RequestType::STOP:
-      return "STOP";
-  }
-  return "UNKNOWN";
-}
-
-inline std::string optU32(const std::optional<uint32_t>& v) {
-  return v.has_value() ? std::to_string(*v) : "-";
-}
-
-// Runner -> scheduler. One line per ISRequest the runner pushes.
-inline void logSchedTx(const char* role, const sch::ISRequest& req) {
-  TT_LOG_INFO(
-      "[BORDER] {}>>sched {} req={} slot={} destSlot={} tok={} posId={} "
-      "maxNew={} temp={:.3f} topP={:.3f} topK={} ignoreEos={} spec={} "
-      "disagg={} stopTok={}",
-      role, requestTypeName(req.type), req.request_id, req.slot_id,
-      optU32(req.dest_slot_id), req.tokens.size(), optU32(req.position_id),
-      req.gen.max_new_tokens, req.gen.temperature, req.gen.top_p, req.gen.top_k,
-      req.gen.ignore_eos, req.gen.spec_decode, req.gen.disaggregated_decode,
-      req.gen.stop_tokens.size());
-}
-
-// Scheduler -> runner. Ack for an ALLOCATE / SUBMIT / EVICT / STOP.
-inline void logSchedRxAck(const char* role,
-                          const sch::SchedulerResponse& resp) {
-  TT_LOG_INFO(
-      "[BORDER] {}<<sched ACK {} req={} slot={} err={} status={} startPos={}",
-      role, requestTypeName(resp.request_type), resp.request_id, resp.slot_id,
-      resp.error_code, static_cast<int>(resp.status), resp.start_position);
-}
-
-// Scheduler -> runner. A generated/prefill OutputMessage. `level` lets the
-// per-token decode path drop to DEBUG while low-volume callers stay at INFO.
-inline void logSchedRxOutput(const char* role, const sch::OutputMessage& out,
-                             tt::utils::ZeroOverheadLogger::Level level =
-                                 tt::utils::ZeroOverheadLogger::INFO) {
-  tt::utils::ZeroOverheadLogger::log(
-      level,
-      "[BORDER] {}<<sched OUT slot={} tok={} isComplete={} prefillComplete={} "
-      "ctxExhausted={} posId={} realPos={} tokensGen={} req={}",
-      role, out.slot_id, out.token_id, out.is_complete, out.prefill_complete,
-      out.ctx_exhausted, out.position_id, out.real_pos, out.tokens_generated,
-      out.request_id);
-}
-
-// Runner -> result/response queue. One line per token (or final/abort/error
-// sentinel) the runner publishes back toward the client. Pair with the
-// matching logSchedRxOutput line (same taskId) to see what the runner forwarded
-// vs. what the scheduler produced.
-inline void logResultTx(const char* role, uint32_t taskId, uint64_t tokenId,
-                        uint32_t flag,
-                        tt::utils::ZeroOverheadLogger::Level level =
-                            tt::utils::ZeroOverheadLogger::INFO) {
-  tt::utils::ZeroOverheadLogger::log(
-      level, "[BORDER] {}>>resultq taskId={} tok={} final={} abort={} error={}",
-      role, taskId, tokenId,
-      static_cast<bool>(flag & tt::ipc::SharedToken::FLAG_FINAL),
-      static_cast<bool>(flag & tt::ipc::SharedToken::FLAG_ABORT),
-      static_cast<bool>(flag & tt::ipc::SharedToken::FLAG_ERROR));
-}
-
-// Memory queue -> runner. A ManageMemoryTask read from the MemoryManager.
-inline void logMemQueueRx(const char* role,
-                          const tt::domain::ManageMemoryTask& task) {
-  TT_LOG_INFO("[BORDER] {}<<memq taskId={} action={} slot={} copyFrom={}", role,
-              task.taskId,
-              task.action == tt::domain::MemoryManagementAction::ALLOCATE
-                  ? "ALLOCATE"
-              : task.action == tt::domain::MemoryManagementAction::DEALLOCATE
-                  ? "DEALLOCATE"
-                  : "MOVE",
-              task.slotId, optU32(task.slotIdToCopyFrom));
-}
-
-// Task queue -> runner. A Sequence read from the task queue. `slotId` is the
-// caller-resolved KV slot (prefill vs decode accessor differs).
-inline void logTaskQueueRx(const char* role,
-                           const tt::domain::llm::Sequence& seq,
-                           uint32_t slotId) {
-  TT_LOG_INFO(
-      "[BORDER] {}<<taskq taskId={} slot={} promptTok={} totalTok={} "
-      "continuation={} disagg={}",
-      role, seq.taskId, slotId, seq.getNumPromptTokens(),
-      seq.getTokenIds().size(), seq.isContinuation(), seq.isDisaggregated());
 }
 
 // Populates per-run fields on `slot` from `seq`. Snapshots the slot's spec

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
@@ -179,20 +179,6 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
 
     trantor::EventLoop* loop = pool->getNextLoop();
     auto req = buildLLMRequest(dynReq);
-
-    // Interface border: what dynamo handed us off the wire. "[BORDER]" tags
-    // every cross-boundary log so `grep '\[BORDER\]'` traces a request end to
-    // end. Optionals render as -1 when unset.
-    TT_LOG_INFO(
-        "[BORDER] dynamo<<recv taskId={} reqId={} model={} promptTok={} "
-        "maxTok={} minTok={} temp={:.3f} topP={:.3f} topK={} ignoreEos={} "
-        "stopTokIds={} stopStr={}",
-        req->task_id, probeId.empty() ? "?" : probeId, dynReq.model,
-        dynReq.token_ids.size(), dynReq.max_tokens,
-        dynReq.min_tokens.value_or(-1), dynReq.temperature.value_or(-1.0f),
-        dynReq.top_p.value_or(-1.0f), dynReq.top_k.value_or(-1),
-        dynReq.ignore_eos, dynReq.stop_token_ids.size(), dynReq.stop.size());
-
     auto svc = pipeline->service();
 
     // Reasoning/usage accounting for the Dynamo path. The worker doesn't decode
@@ -393,15 +379,6 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
               }
               out.completion_usage = du;
             }
-            // Interface border: what we stream back to the dynamo frontend.
-            // "emitted" is the running completion-token count (incremented
-            // above before this send).
-            TT_LOG_INFO(
-                "[BORDER] dynamo>>resp taskId={} reqId={} tok={} final={} "
-                "finishReason={} emitted={}",
-                req->task_id, probeId.empty() ? "?" : probeId,
-                out.token_ids.empty() ? -1 : out.token_ids.front(), isFinal,
-                out.finish_reason.value_or("-"), usage->completion);
             const bool sent = sendChunk(out);
             if (isFinal) {
               signalDone();

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_decode_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_decode_runner.cpp
@@ -687,21 +687,19 @@ void BlazeDecodeRunner::handleRequest(
     case SlotState::IDLE: {
       ds::ISRequest req = isNew ? utils::makeSubmitRequest(slotId, *request)
                                 : utils::makeContinueRequest(slotId, *request);
-      // kvPositionId is what came in on the Sequence; schedPositionId is what
-      // we hand the scheduler (CONTINUE overrides it from the Sequence's KV
-      // position, SUBMIT leaves it unset).
+      // kvPositionId is the KV-cache offset that came in on the Sequence. On
+      // CONTINUE it is forwarded verbatim as the scheduler's position_id; on a
+      // fresh SUBMIT it is absent ("none") and the scheduler starts from 0.
       TT_LOG_DEBUG(
           "[BlazeDecodeRunner] handleRequest: {} taskId={}, slotId={}, "
           "isNew={}, isContinuation={}, numPromptTokens={}, totalTokens={}, "
-          "runningSlots={}, kvPositionId={}, schedPositionId={}",
+          "runningSlots={}, kvPositionId={}",
           isNew ? "SUBMIT" : "CONTINUE", request->taskId, slotId, isNew,
           request->isContinuation(), request->getNumPromptTokens(),
           request->getTokenIds().size(), slotManager.activeRunningCount(),
           request->getKVPositionId().has_value()
               ? std::to_string(*request->getKVPositionId())
-              : "none",
-          req.position_id.has_value() ? std::to_string(*req.position_id)
-                                      : "none");
+              : "none");
       if (!decodeScheduler->push_request(req)) {
         TT_LOG_DEBUG(
             "[BlazeDecodeRunner] handleRequest: failed to push request, "

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_decode_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_decode_runner.cpp
@@ -687,9 +687,6 @@ void BlazeDecodeRunner::handleRequest(
     case SlotState::IDLE: {
       ds::ISRequest req = isNew ? utils::makeSubmitRequest(slotId, *request)
                                 : utils::makeContinueRequest(slotId, *request);
-      // kvPositionId is the KV-cache offset that came in on the Sequence. On
-      // CONTINUE it is forwarded verbatim as the scheduler's position_id; on a
-      // fresh SUBMIT it is absent ("none") and the scheduler starts from 0.
       TT_LOG_DEBUG(
           "[BlazeDecodeRunner] handleRequest: {} taskId={}, slotId={}, "
           "isNew={}, isContinuation={}, numPromptTokens={}, totalTokens={}, "

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_decode_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_decode_runner.cpp
@@ -215,7 +215,6 @@ std::unique_ptr<tt::domain::llm::Sequence> BlazeDecodeRunner::getRequest() {
   }
   auto req = taskQueue->tryPop();
   if (!req) return nullptr;
-  utils::logTaskQueueRx("decode", *req, req->getKVCacheSlot());
   return req;
 }
 
@@ -265,7 +264,6 @@ inline void BlazeDecodeRunner::handleEvictRequest(
         pendingRequests.pendingMemoryTask = request;
         return;
       }
-      utils::logSchedTx("decode", evictRequest);
       if (pendingRequests.pendingTask &&
           pendingRequests.pendingTask->getKVCacheSlot() == request.slotId) {
         auto droppedTaskId = pendingRequests.pendingTask->taskId;
@@ -274,9 +272,6 @@ inline void BlazeDecodeRunner::handleEvictRequest(
             "[BlazeDecodeRunner] handleEvictRequest: dropping pending task for "
             "taskId={} on slotId={} (EVICT wins)",
             droppedTaskId, request.slotId);
-        utils::logResultTx(
-            "decode", droppedTaskId, 0,
-            ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT);
         ipc::helpers::pushToken(
             *resultQueue, droppedTaskId, 0,
             ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT, 0, 0);
@@ -313,9 +308,6 @@ inline void BlazeDecodeRunner::handleEvictRequest(
             "for "
             "taskId={} on slotId={} (DEALLOCATE wins)",
             droppedTaskId, request.slotId);
-        utils::logResultTx(
-            "decode", droppedTaskId, 0,
-            ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT);
         ipc::helpers::pushToken(
             *resultQueue, droppedTaskId, 0,
             ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT, 0, 0);
@@ -364,7 +356,6 @@ inline void BlazeDecodeRunner::handleAllocateRequest(
     pendingRequests.pendingMemoryTask = request;
     return;
   }
-  utils::logSchedTx("decode", allocateRequest);
   TT_LOG_DEBUG(
       "[BlazeDecodeRunner] handleAllocateRequest: pushed ALLOCATE taskId={}",
       request.taskId);
@@ -372,7 +363,6 @@ inline void BlazeDecodeRunner::handleAllocateRequest(
 
 inline void BlazeDecodeRunner::handleMemoryResponse(
     const ds::SchedulerResponse& response) {
-  utils::logSchedRxAck("decode", response);
   auto taskId = response.request_id;
   auto slotId = response.slot_id;
   auto action = response.request_type;
@@ -479,9 +469,6 @@ inline void BlazeDecodeRunner::handleDeferred(SlotContext& slot) {
           "slotId={} (deferredEvict wins)",
           droppedTaskId, slot.slotId);
       // FINAL|ERROR (not ABORT) — see handleEvictRequest's comment.
-      utils::logResultTx(
-          "decode", droppedTaskId, 0,
-          ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT);
       ipc::helpers::pushToken(
           *resultQueue, droppedTaskId, 0,
           ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT, 0, 0);
@@ -514,11 +501,7 @@ BlazeDecodeRunner::getMemoryRequest() {
     pendingRequests.pendingMemoryTask = std::nullopt;
     return task;
   }
-  auto task = memoryManager->getRequest();
-  if (task.has_value()) {
-    utils::logMemQueueRx("decode", *task);
-  }
-  return task;
+  return memoryManager->getRequest();
 }
 
 void BlazeDecodeRunner::drainAndHandleStopRequests() {
@@ -570,8 +553,8 @@ inline void BlazeDecodeRunner::handleStopRequest(uint32_t taskId) {
         taskId, slot->slotId, toString(slot->state));
     return;
   }
-  auto stopRequest = utils::makeStopRequest(taskId, slot->slotId);
-  if (!decodeScheduler->push_request(stopRequest)) {
+  if (!decodeScheduler->push_request(
+          utils::makeStopRequest(taskId, slot->slotId))) {
     TT_LOG_WARN(
         "[BlazeDecodeRunner] handleCancelRequest: scheduler queue full, "
         "deferring "
@@ -580,7 +563,6 @@ inline void BlazeDecodeRunner::handleStopRequest(uint32_t taskId) {
     pendingRequests.pendingCancelTaskId = taskId;
     return;
   }
-  utils::logSchedTx("decode", stopRequest);
   TT_LOG_DEBUG(
       "[BlazeDecodeRunner] handleCancelRequest: pushed STOP taskId={}, "
       "slotId={}",
@@ -588,7 +570,6 @@ inline void BlazeDecodeRunner::handleStopRequest(uint32_t taskId) {
   slot->pendingAckRequestId = taskId;
   slotManager.setSlotState(slot->slotId, SlotState::AWAITING_STOP_ACK);
   slotManager.unbindTaskFromSlot(taskId);
-  utils::logResultTx("decode", taskId, 0, ipc::SharedToken::FLAG_ABORT);
   ipc::helpers::pushToken(*resultQueue, taskId, 0, ipc::SharedToken::FLAG_ABORT,
                           0, 0);
   tt::worker::SingleProcessWorkerMetrics::instance().decrementActiveRequests();
@@ -597,9 +578,6 @@ inline void BlazeDecodeRunner::handleStopRequest(uint32_t taskId) {
 }
 
 void BlazeDecodeRunner::handleOutput(const ds::OutputMessage& output) {
-  // Per-token border: DEBUG so a busy decode loop doesn't flood INFO.
-  utils::logSchedRxOutput("decode", output,
-                          tt::utils::ZeroOverheadLogger::DEBUG);
   auto& metrics = tt::worker::SingleProcessWorkerMetrics::instance();
   metrics.updateOutputHeartbeat();
   auto& slotContext = slotManager.getSlotContext(output.slot_id);
@@ -642,9 +620,6 @@ void BlazeDecodeRunner::handleOutput(const ds::OutputMessage& output) {
     metrics.decrementActiveRequests();
   }
   uint32_t flag = finished ? ipc::SharedToken::FLAG_FINAL : 0;
-  // Per-token border: DEBUG so a busy decode loop doesn't flood INFO.
-  utils::logResultTx("decode", taskId, output.token_id, flag,
-                     tt::utils::ZeroOverheadLogger::DEBUG);
   ipc::helpers::pushToken(*resultQueue, taskId, output.token_id, flag,
                           spec.accepts, spec.rejects);
 }
@@ -710,15 +685,23 @@ void BlazeDecodeRunner::handleRequest(
   auto& slotContext = slotManager.getSlotContext(slotId);
   switch (slotContext.state) {
     case SlotState::IDLE: {
-      TT_LOG_DEBUG(
-          "[BlazeDecodeRunner] handleRequest: taskId={}, slotId={}, isNew={}, "
-          "isContinuation={}, numPromptTokens={}, totalTokens={}, "
-          "runningSlots={}",
-          request->taskId, slotId, isNew, request->isContinuation(),
-          request->getNumPromptTokens(), request->getTokenIds().size(),
-          slotManager.activeRunningCount());
       ds::ISRequest req = isNew ? utils::makeSubmitRequest(slotId, *request)
                                 : utils::makeContinueRequest(slotId, *request);
+      // kvPositionId is what came in on the Sequence; schedPositionId is what
+      // we hand the scheduler (CONTINUE overrides it from the Sequence's KV
+      // position, SUBMIT leaves it unset).
+      TT_LOG_DEBUG(
+          "[BlazeDecodeRunner] handleRequest: {} taskId={}, slotId={}, "
+          "isNew={}, isContinuation={}, numPromptTokens={}, totalTokens={}, "
+          "runningSlots={}, kvPositionId={}, schedPositionId={}",
+          isNew ? "SUBMIT" : "CONTINUE", request->taskId, slotId, isNew,
+          request->isContinuation(), request->getNumPromptTokens(),
+          request->getTokenIds().size(), slotManager.activeRunningCount(),
+          request->getKVPositionId().has_value()
+              ? std::to_string(*request->getKVPositionId())
+              : "none",
+          req.position_id.has_value() ? std::to_string(*req.position_id)
+                                      : "none");
       if (!decodeScheduler->push_request(req)) {
         TT_LOG_DEBUG(
             "[BlazeDecodeRunner] handleRequest: failed to push request, "
@@ -728,7 +711,6 @@ void BlazeDecodeRunner::handleRequest(
         pendingRequests.pendingTask = std::move(request);
         return;
       }
-      utils::logSchedTx("decode", req);
       utils::initSlotForRun(slotContext, *request, *decodeScheduler);
       slotManager.bindTaskToSlot(request->taskId, slotId);
       slotManager.setSlotState(slotId, SlotState::RUNNING);
@@ -766,9 +748,6 @@ void BlazeDecodeRunner::handleRequest(
           "[BlazeDecodeRunner] handleRequest: dropping SUBMIT for taskId={} on "
           "slotId={} (slot is AWAITING_EVICT_ACK)",
           request->taskId, slotId);
-      utils::logResultTx(
-          "decode", request->taskId, 0,
-          ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT);
       ipc::helpers::pushToken(
           *resultQueue, request->taskId, 0,
           ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT, 0, 0);

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_prefill_runner.cpp
@@ -656,10 +656,6 @@ void BlazePrefillRunner::handleRequest(
     case SlotState::IDLE: {
       ps::ISRequest req = utils::makeSubmitRequest(
           slotId, *request, std::make_optional(request->getKVCacheSlot()));
-      // destSlot is the decode KV slot we tell the scheduler to copy the
-      // prefilled KV into. Positions received (decodePositionId/
-      // decodeSkipTokens) are logged one line up; prefill never sends a
-      // position_id to the scheduler — only decode CONTINUE does.
       TT_LOG_DEBUG(
           "[BlazePrefillRunner] handleRequest: SUBMIT taskId={}, slotId={}, "
           "isContinuation={}, numPromptTokens={}, totalTokens={}, "

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_prefill_runner.cpp
@@ -656,19 +656,19 @@ void BlazePrefillRunner::handleRequest(
     case SlotState::IDLE: {
       ps::ISRequest req = utils::makeSubmitRequest(
           slotId, *request, std::make_optional(request->getKVCacheSlot()));
-      // schedPositionId/destSlot are what we hand the scheduler on SUBMIT;
-      // decodePositionId/decodeSkipTokens (logged above) are what came in.
+      // destSlot is the decode KV slot we tell the scheduler to copy the
+      // prefilled KV into. Positions received (decodePositionId/
+      // decodeSkipTokens) are logged one line up; prefill never sends a
+      // position_id to the scheduler — only decode CONTINUE does.
       TT_LOG_DEBUG(
           "[BlazePrefillRunner] handleRequest: SUBMIT taskId={}, slotId={}, "
           "isContinuation={}, numPromptTokens={}, totalTokens={}, "
-          "runningSlots={}, destSlot={}, schedPositionId={}",
+          "runningSlots={}, destSlot={}",
           request->taskId, slotId, request->isContinuation(),
           request->getNumPromptTokens(), request->getTokenIds().size(),
           slotManager.activeRunningCount(),
           req.dest_slot_id.has_value() ? std::to_string(*req.dest_slot_id)
-                                       : "none",
-          req.position_id.has_value() ? std::to_string(*req.position_id)
-                                      : "none");
+                                       : "none");
       if (!prefillScheduler->push_request(req)) {
         TT_LOG_DEBUG(
             "[BlazePrefillRunner] handleRequest: failed to push request, "

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_prefill_runner.cpp
@@ -217,7 +217,6 @@ std::unique_ptr<tt::domain::llm::Sequence> BlazePrefillRunner::getRequest() {
   }
   auto req = taskQueue->tryPop();
   if (!req) return nullptr;
-  utils::logTaskQueueRx("prefill", *req, req->getPrefillKVCacheSlot());
   return req;
 }
 
@@ -267,7 +266,6 @@ inline void BlazePrefillRunner::handleEvictRequest(
         pendingRequests.pendingMemoryTask = request;
         return;
       }
-      utils::logSchedTx("prefill", evictRequest);
       if (pendingRequests.pendingTask &&
           pendingRequests.pendingTask->getPrefillKVCacheSlot() ==
               request.slotId) {
@@ -278,9 +276,6 @@ inline void BlazePrefillRunner::handleEvictRequest(
             "for "
             "taskId={} on slotId={} (EVICT wins)",
             droppedTaskId, request.slotId);
-        utils::logResultTx(
-            "prefill", droppedTaskId, 0,
-            ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT);
         ipc::helpers::pushToken(
             *resultQueue, droppedTaskId, 0,
             ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT, 0, 0);
@@ -317,9 +312,6 @@ inline void BlazePrefillRunner::handleEvictRequest(
             "for "
             "taskId={} on slotId={} (DEALLOCATE wins)",
             droppedTaskId, request.slotId);
-        utils::logResultTx(
-            "prefill", droppedTaskId, 0,
-            ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT);
         ipc::helpers::pushToken(
             *resultQueue, droppedTaskId, 0,
             ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT, 0, 0);
@@ -362,7 +354,6 @@ inline void BlazePrefillRunner::handleAllocateRequest(
     pendingRequests.pendingMemoryTask = request;
     return;
   }
-  utils::logSchedTx("prefill", allocateRequest);
   TT_LOG_DEBUG(
       "[BlazePrefillRunner] handleAllocateRequest: pushed ALLOCATE taskId={}",
       request.taskId);
@@ -370,7 +361,6 @@ inline void BlazePrefillRunner::handleAllocateRequest(
 
 inline void BlazePrefillRunner::handleMemoryResponse(
     const ps::SchedulerResponse& response) {
-  utils::logSchedRxAck("prefill", response);
   auto taskId = response.request_id;
   auto slotId = response.slot_id;
   auto action = response.request_type;
@@ -479,9 +469,6 @@ inline void BlazePrefillRunner::handleDeferred(SlotContext& slot) {
           "slotId={} (deferredEvict wins)",
           droppedTaskId, slot.slotId);
       // FINAL|ERROR (not ABORT) — see handleEvictRequest's comment.
-      utils::logResultTx(
-          "prefill", droppedTaskId, 0,
-          ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT);
       ipc::helpers::pushToken(
           *resultQueue, droppedTaskId, 0,
           ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT, 0, 0);
@@ -507,11 +494,7 @@ BlazePrefillRunner::getMemoryRequest() {
     pendingRequests.pendingMemoryTask = std::nullopt;
     return task;
   }
-  auto task = memoryManager->getRequest();
-  if (task.has_value()) {
-    utils::logMemQueueRx("prefill", *task);
-  }
-  return task;
+  return memoryManager->getRequest();
 }
 
 void BlazePrefillRunner::drainAndHandleStopRequests() {
@@ -563,8 +546,8 @@ inline void BlazePrefillRunner::handleStopRequest(uint32_t taskId) {
         taskId, slot->slotId, toString(slot->state));
     return;
   }
-  auto stopRequest = utils::makeStopRequest(taskId, slot->slotId);
-  if (!prefillScheduler->push_request(stopRequest)) {
+  if (!prefillScheduler->push_request(
+          utils::makeStopRequest(taskId, slot->slotId))) {
     TT_LOG_WARN(
         "[BlazePrefillRunner] handleCancelRequest: scheduler queue full, "
         "deferring "
@@ -573,7 +556,6 @@ inline void BlazePrefillRunner::handleStopRequest(uint32_t taskId) {
     pendingRequests.pendingCancelTaskId = taskId;
     return;
   }
-  utils::logSchedTx("prefill", stopRequest);
   TT_LOG_DEBUG(
       "[BlazePrefillRunner] handleCancelRequest: pushed STOP taskId={}, "
       "slotId={}",
@@ -581,14 +563,12 @@ inline void BlazePrefillRunner::handleStopRequest(uint32_t taskId) {
   slot->pendingAckRequestId = taskId;
   slotManager.setSlotState(slot->slotId, SlotState::AWAITING_STOP_ACK);
   slotManager.unbindTaskFromSlot(taskId);
-  utils::logResultTx("prefill", taskId, 0, ipc::SharedToken::FLAG_ABORT);
   ipc::helpers::pushToken(*resultQueue, taskId, 0, ipc::SharedToken::FLAG_ABORT,
                           0, 0);
   tt::worker::SingleProcessWorkerMetrics::instance().decrementActiveRequests();
 }
 
 void BlazePrefillRunner::handleOutput(const ps::OutputMessage& output) {
-  utils::logSchedRxOutput("prefill", output);
   tt::worker::SingleProcessWorkerMetrics::instance().updateOutputHeartbeat();
   lastOutputTime = std::chrono::steady_clock::now();
   auto& slotContext = slotManager.getSlotContext(output.slot_id);
@@ -621,9 +601,6 @@ void BlazePrefillRunner::handleOutput(const ps::OutputMessage& output) {
     slotManager.setSlotAsIdle(output.slot_id);
     tt::worker::SingleProcessWorkerMetrics::instance()
         .decrementActiveRequests();
-    utils::logResultTx(
-        "prefill", taskId, output.token_id,
-        ipc::SharedToken::FLAG_ERROR | ipc::SharedToken::FLAG_FINAL);
     ipc::helpers::pushToken(
         *resultQueue, taskId, output.token_id,
         ipc::SharedToken::FLAG_ERROR | ipc::SharedToken::FLAG_FINAL, 0, 0);
@@ -638,7 +615,6 @@ void BlazePrefillRunner::handleOutput(const ps::OutputMessage& output) {
         .decrementActiveRequests();
   }
   uint32_t flag = finished ? ipc::SharedToken::FLAG_FINAL : 0;
-  utils::logResultTx("prefill", taskId, output.token_id, flag);
   ipc::helpers::pushToken(*resultQueue, taskId, output.token_id, flag, 0, 0);
 }
 
@@ -678,15 +654,21 @@ void BlazePrefillRunner::handleRequest(
   auto& slotContext = slotManager.getSlotContext(slotId);
   switch (slotContext.state) {
     case SlotState::IDLE: {
-      TT_LOG_DEBUG(
-          "[BlazePrefillRunner] handleRequest: taskId={}, slotId={}, "
-          "isContinuation={}, numPromptTokens={}, totalTokens={}, "
-          "runningSlots={}",
-          request->taskId, slotId, request->isContinuation(),
-          request->getNumPromptTokens(), request->getTokenIds().size(),
-          slotManager.activeRunningCount());
       ps::ISRequest req = utils::makeSubmitRequest(
           slotId, *request, std::make_optional(request->getKVCacheSlot()));
+      // schedPositionId/destSlot are what we hand the scheduler on SUBMIT;
+      // decodePositionId/decodeSkipTokens (logged above) are what came in.
+      TT_LOG_DEBUG(
+          "[BlazePrefillRunner] handleRequest: SUBMIT taskId={}, slotId={}, "
+          "isContinuation={}, numPromptTokens={}, totalTokens={}, "
+          "runningSlots={}, destSlot={}, schedPositionId={}",
+          request->taskId, slotId, request->isContinuation(),
+          request->getNumPromptTokens(), request->getTokenIds().size(),
+          slotManager.activeRunningCount(),
+          req.dest_slot_id.has_value() ? std::to_string(*req.dest_slot_id)
+                                       : "none",
+          req.position_id.has_value() ? std::to_string(*req.position_id)
+                                      : "none");
       if (!prefillScheduler->push_request(req)) {
         TT_LOG_DEBUG(
             "[BlazePrefillRunner] handleRequest: failed to push request, "
@@ -696,7 +678,6 @@ void BlazePrefillRunner::handleRequest(
         pendingRequests.pendingTask = std::move(request);
         return;
       }
-      utils::logSchedTx("prefill", req);
       if (slotManager.activeRunningCount() == 0) {
         lastOutputTime = std::chrono::steady_clock::now();
       }
@@ -731,9 +712,6 @@ void BlazePrefillRunner::handleRequest(
           "on "
           "slotId={} (slot is AWAITING_EVICT_ACK)",
           request->taskId, slotId);
-      utils::logResultTx(
-          "prefill", request->taskId, 0,
-          ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT);
       ipc::helpers::pushToken(
           *resultQueue, request->taskId, 0,
           ipc::SharedToken::FLAG_FINAL | ipc::SharedToken::FLAG_ABORT, 0, 0);


### PR DESCRIPTION
Reverts the parallel [BORDER] logging layer from #4132 (helpers in blaze_utils.hpp, all runner call sites, and the two dynamo blocks). 
Folds the high-value bits back into the existing handleRequest DEBUG lines instead: prefill/decode IDLE now log the request type (SUBMIT/ CONTINUE), the position ID received on the Sequence (kvPositionId), and the position ID handed to the scheduler (schedPositionId / destSlot).