### PR TITLE
Vm/change dev model yaml

### DIFF
--- a/run.py
+++ b/run.py
@@ -532,6 +532,16 @@ def parse_arguments():
             f"(got --workflow {args.workflow})."
         )
 
+    # Dev specs don't pin a docker image (they're built/published out of band),
+    # so dev-mode has no image to run in a container — require an explicit one.
+    if args.dev_mode and args.docker_server and not args.override_docker_image:
+        parser.error(
+            "--dev-mode with --docker-server requires --override-docker-image: "
+            "dev specs do not pin a docker image. Pass the prebuilt image to run "
+            "the dev spec in, e.g. --override-docker-image "
+            "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:<tag>"
+        )
+
     return args
 
 

--- a/scripts/release/promote_dev_spec_to_prod.py
+++ b/scripts/release/promote_dev_spec_to_prod.py
@@ -12,6 +12,12 @@ the matching template in workflows/model_specs/dev/ is copied into the same-name
 file in workflows/model_specs/prod/, upserting by
 (impl, inference_engine, weights, devices) identity.
 
+Dev templates intentionally omit the release pins (``version``,
+``tt_metal_commit`` and ``vllm_commit``); promotion injects them from CLI flags
+into each promoted prod block. ``--version`` and ``--tt-metal-commit`` are
+required; ``--vllm-commit`` is required only when one or more promoted templates
+use the VLLM inference engine and is injected only into those templates.
+
 The catalogue YAML files are hand-authored with inconsistent block-sequence
 indentation (top-level list items at column 0, nested lists indented to column 4),
 which no single ruamel.yaml indent setting can reproduce. Round-tripping a whole
@@ -234,12 +240,49 @@ def _ensure_trailing_newline(lines):
     return lines
 
 
+# Release-pin keys, matched at the template's top-level (2-space) indent.
+_PIN_LINE_RE = re.compile(r"^  (version|tt_metal_commit|vllm_commit):")
+
+
+def inject_pin_fields(lines, *, version, tt_metal_commit, vllm_commit=None):
+    """Return the block's lines with the release pins injected.
+
+    Any pre-existing pin line is dropped first, so the result is deterministic and
+    idempotent. The new lines are inserted right after the ``weights`` block (before
+    the first other top-level key), at the template's 2-space indent. Values are
+    quoted so commit-like strings (e.g. ``1e23``) are never parsed as numbers.
+
+    ``vllm_commit`` is injected only when provided (the caller passes it solely for
+    VLLM templates).
+    """
+    body = [ln for ln in lines if not _PIN_LINE_RE.match(ln)]
+    pins = [
+        f'  version: "{version}"\n',
+        f'  tt_metal_commit: "{tt_metal_commit}"\n',
+    ]
+    if vllm_commit is not None:
+        pins.append(f'  vllm_commit: "{vllm_commit}"\n')
+
+    insert_at = len(body)
+    for idx in range(1, len(body)):
+        if re.match(r"^  \S", body[idx]):
+            insert_at = idx
+            break
+    return body[:insert_at] + pins + body[insert_at:]
+
+
 def _render(segments) -> str:
     return "".join(line for _, seg_lines in segments for line in seg_lines)
 
 
-def promote(ci_config_path, dev_dir, prod_dir, dry_run=False) -> dict:
+def promote(
+    ci_config_path, dev_dir, prod_dir, *, tt_metal_commit, version, vllm_commit=None
+) -> dict:
     """Promote release-marked dev templates into prod.
+
+    ``version`` and ``tt_metal_commit`` are injected into every promoted block.
+    ``vllm_commit`` is injected only into VLLM-engine templates and is required
+    when any promoted template uses the VLLM engine (raises ValueError otherwise).
 
     Returns a report dict:
       - combos: set of all release combos
@@ -252,6 +295,16 @@ def promote(ci_config_path, dev_dir, prod_dir, dry_run=False) -> dict:
     combos = collect_release_combos(ci_config)
     matches_by_file, unmatched = find_matches(Path(dev_dir), combos)
 
+    needs_vllm = any(
+        template_engine(block.template) == InferenceEngine.VLLM
+        for matched in matches_by_file.values()
+        for block in matched
+    )
+    if needs_vllm and vllm_commit is None:
+        raise ValueError(
+            "--vllm-commit is required: one or more promoted templates use the VLLM inference engine."
+        )
+
     actions = {}
     changed_files = []
     for filename, matched in matches_by_file.items():
@@ -261,16 +314,22 @@ def promote(ci_config_path, dev_dir, prod_dir, dry_run=False) -> dict:
 
         file_actions = []
         for block in matched:
-            action = upsert_block(segments, block.identity, block.lines)
+            is_vllm = template_engine(block.template) == InferenceEngine.VLLM
+            lines = inject_pin_fields(
+                block.lines,
+                version=version,
+                tt_metal_commit=tt_metal_commit,
+                vllm_commit=vllm_commit if is_vllm else None,
+            )
+            action = upsert_block(segments, block.identity, lines)
             file_actions.append((block.identity, action))
         actions[filename] = file_actions
 
         new_text = _render(segments)
         if new_text != original:
             changed_files.append(filename)
-            if not dry_run:
-                prod_file.parent.mkdir(parents=True, exist_ok=True)
-                prod_file.write_text(new_text)
+            prod_file.parent.mkdir(parents=True, exist_ok=True)
+            prod_file.write_text(new_text)
 
     return {
         "combos": combos,
@@ -292,26 +351,33 @@ def main(argv=None) -> int:
     parser.add_argument("--ci-config", type=Path, default=DEFAULT_CI_CONFIG)
     parser.add_argument("--dev-dir", type=Path, default=DEFAULT_DEV_DIR)
     parser.add_argument("--prod-dir", type=Path, default=DEFAULT_PROD_DIR)
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Report intended changes without writing any files.",
-    )
+    parser.add_argument("--tt-metal-commit", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--vllm-commit", default=None)
     args = parser.parse_args(argv)
 
-    report = promote(args.ci_config, args.dev_dir, args.prod_dir, dry_run=args.dry_run)
+    try:
+        report = promote(
+            args.ci_config,
+            args.dev_dir,
+            args.prod_dir,
+            tt_metal_commit=args.tt_metal_commit,
+            version=args.version,
+            vllm_commit=args.vllm_commit,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
 
-    prefix = "[dry-run] " if args.dry_run else ""
     for filename, file_actions in sorted(report["actions"].items()):
         for identity, action in file_actions:
             impl, engine, weights, devices = identity
             print(
-                f"{prefix}{action.upper():8} {filename}: "
+                f"{action.upper():8} {filename}: "
                 f"{impl} [{engine.name}] {sorted(weights)} "
                 f"on {sorted(d.name for d in devices)}"
             )
     changed = report["changed_files"]
-    print(f"{prefix}{len(changed)} prod file(s) changed: {sorted(changed)}")
+    print(f"{len(changed)} prod file(s) changed: {sorted(changed)}")
 
     for combo in sorted(
         report["unmatched"],

--- a/tests/test_helm_generator/conftest.py
+++ b/tests/test_helm_generator/conftest.py
@@ -10,7 +10,7 @@ from workflows.model_spec import (
     DeviceModelSpec,
     ImplSpec,
     ModelSpec,
-    ModelSpecTemplate,
+    ProdModelSpecTemplate,
 )
 from workflows.workflow_types import DeviceTypes, InferenceEngine
 
@@ -43,10 +43,11 @@ def _make_template(
     template_env_vars=None,
     device_env_vars=None,
     min_ram_gb=None,
-) -> ModelSpecTemplate:
-    return ModelSpecTemplate(
+) -> ProdModelSpecTemplate:
+    return ProdModelSpecTemplate(
         weights=list(weights),
         impl=impl,
+        version="0.12.0",
         tt_metal_commit="abc1234",
         vllm_commit="def5678"
         if inference_engine == InferenceEngine.VLLM.value

--- a/tests/test_helm_generator/test_cli_integration.py
+++ b/tests/test_helm_generator/test_cli_integration.py
@@ -33,7 +33,7 @@ def test_inserts_new_model_and_idempotent_rerun(tmp_path, fixtures_dir, vllm_spe
 
 def test_multi_impl_same_device(tmp_path, fixtures_dir, sample_impl):
     """Two impls under one (model, engine, device) -> one defaultImpl chosen."""
-    from workflows.model_spec import DeviceModelSpec, ImplSpec, ModelSpecTemplate
+    from workflows.model_spec import DeviceModelSpec, ImplSpec, ProdModelSpecTemplate
     from workflows.workflow_types import DeviceTypes, InferenceEngine
 
     work = tmp_path / "values.yaml"
@@ -47,9 +47,10 @@ def test_multi_impl_same_device(tmp_path, fixtures_dir, sample_impl):
     )
 
     def make(impl, default_impl: bool):
-        return ModelSpecTemplate(
+        return ProdModelSpecTemplate(
             weights=["acme/MultiImpl-7B"],
             impl=impl,
+            version="0.12.0",
             tt_metal_commit="aaa",
             vllm_commit="bbb",
             inference_engine=InferenceEngine.VLLM.value,
@@ -77,16 +78,17 @@ def test_multi_impl_same_device(tmp_path, fixtures_dir, sample_impl):
 
 def test_multi_engine_same_model(tmp_path, fixtures_dir, sample_impl):
     """Two engines on the same model -> defaultEngine picked by precedence."""
-    from workflows.model_spec import DeviceModelSpec, ModelSpecTemplate
+    from workflows.model_spec import DeviceModelSpec, ProdModelSpecTemplate
     from workflows.workflow_types import DeviceTypes, InferenceEngine
 
     work = tmp_path / "values.yaml"
     work.write_text((fixtures_dir / "test_values.yaml").read_text())
 
     def make(engine):
-        return ModelSpecTemplate(
+        return ProdModelSpecTemplate(
             weights=["acme/MultiEngine-7B"],
             impl=sample_impl,
+            version="0.12.0",
             tt_metal_commit="aaa",
             vllm_commit="bbb" if engine == InferenceEngine.VLLM.value else None,
             inference_engine=engine,

--- a/tests/test_helm_generator/test_uniqueness.py
+++ b/tests/test_helm_generator/test_uniqueness.py
@@ -23,7 +23,7 @@ def test_assert_single_default_impl_passes_for_single_default(vllm_spec):
 
 
 def test_assert_single_default_impl_raises_on_collision(sample_impl):
-    from workflows.model_spec import DeviceModelSpec, ImplSpec, ModelSpecTemplate
+    from workflows.model_spec import DeviceModelSpec, ImplSpec, ProdModelSpecTemplate
     from workflows.workflow_types import DeviceTypes, InferenceEngine
 
     other_impl = ImplSpec(
@@ -34,9 +34,10 @@ def test_assert_single_default_impl_raises_on_collision(sample_impl):
     )
 
     def make(impl):
-        return ModelSpecTemplate(
+        return ProdModelSpecTemplate(
             weights=["acme/Collide-7B"],
             impl=impl,
+            version="0.12.0",
             tt_metal_commit="aaa",
             vllm_commit="bbb",
             inference_engine=InferenceEngine.VLLM.value,

--- a/tests/test_model_catalog_yaml.py
+++ b/tests/test_model_catalog_yaml.py
@@ -126,7 +126,10 @@ def test_build_template_resolves_all_enum_and_impl_references():
 
 
 def test_load_templates_from_yaml_roundtrip(tmp_path):
-    yaml_path = tmp_path / "tiny.yaml"
+    # prod/ dir so the pins below are accepted (env selects ProdModelSpecTemplate)
+    prod_dir = tmp_path / "prod"
+    prod_dir.mkdir()
+    yaml_path = prod_dir / "tiny.yaml"
     yaml_path.write_text(
         """
 templates:
@@ -175,9 +178,9 @@ def _write_catalog(tmp_path, env, extra_fields):
 
 
 def test_prod_catalog_requires_tt_metal_commit_and_version(tmp_path):
-    # Missing both -> raises listing both.
+    # Missing both -> ProdModelSpecTemplate construction fails for both.
     p = _write_catalog(tmp_path, "prod", {})
-    with pytest.raises(ValueError, match=r"must define.*tt_metal_commit.*version"):
+    with pytest.raises(ValueError, match=r"tt_metal_commit.*version"):
         load_templates_from_yaml(p)
     # Both present -> loads.
     p2 = _write_catalog(
@@ -196,8 +199,9 @@ def test_prod_catalog_requires_tt_metal_commit_and_version(tmp_path):
     ],
 )
 def test_dev_catalog_forbids_pinning_fields(tmp_path, field, value):
+    # The dev base template has no pin fields, so setting one is an unexpected kwarg.
     p = _write_catalog(tmp_path, "dev", {field: value})
-    with pytest.raises(ValueError, match=rf"must not define.*{field}"):
+    with pytest.raises(ValueError, match=rf"unexpected keyword argument '{field}'"):
         load_templates_from_yaml(p)
 
 
@@ -205,10 +209,13 @@ def test_dev_catalog_without_pinning_fields_loads(tmp_path):
     p = _write_catalog(tmp_path, "dev", {})
     templates = load_templates_from_yaml(p)
     assert len(templates) == 1
-    assert templates[0].tt_metal_commit is None
-    assert templates[0].version is None
-    # dev specs skip docker/code-link synthesis instead of raising.
+    # dev (base) template carries no pin fields at all.
+    assert not hasattr(templates[0], "tt_metal_commit")
+    assert not hasattr(templates[0], "version")
+    # expanded spec has them as None and skips docker/code-link synthesis.
     spec = templates[0].expand_to_specs()[0]
+    assert spec.tt_metal_commit is None
+    assert spec.version is None
     assert spec.docker_image is None
     assert spec.code_link is None
 

--- a/tests/test_model_catalog_yaml.py
+++ b/tests/test_model_catalog_yaml.py
@@ -152,6 +152,67 @@ templates:
 
 import pytest
 
+
+def _write_catalog(tmp_path, env, extra_fields):
+    """Write a one-template catalog under tmp_path/<env>/x.yaml.
+
+    extra_fields is rendered as additional 4-space-indented template keys.
+    """
+    d = tmp_path / env
+    d.mkdir(parents=True)
+    p = d / "x.yaml"
+    lines = "".join(f"    {k}: {v}\n" for k, v in extra_fields.items())
+    p.write_text(
+        "templates:\n"
+        "  - weights: [Qwen/Qwen3-8B]\n"
+        "    impl: tt_transformers\n"
+        "    inference_engine: VLLM\n"
+        f"{lines}"
+        "    device_model_specs:\n"
+        "      - {device: N150, max_concurrency: 1, max_context: 1024, default_impl: true}\n"
+    )
+    return p
+
+
+def test_prod_catalog_requires_tt_metal_commit_and_version(tmp_path):
+    # Missing both -> raises listing both.
+    p = _write_catalog(tmp_path, "prod", {})
+    with pytest.raises(ValueError, match=r"must define.*tt_metal_commit.*version"):
+        load_templates_from_yaml(p)
+    # Both present -> loads.
+    p2 = _write_catalog(
+        tmp_path / "ok", "prod", {"tt_metal_commit": "abc1234", "version": '"0.10.0"'}
+    )
+    assert len(load_templates_from_yaml(p2)) == 1
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("tt_metal_commit", "abc1234"),
+        ("vllm_commit", "def5678"),
+        ("version", '"0.10.0"'),
+        ("docker_image", '"ghcr.io/x/y:1.0"'),
+    ],
+)
+def test_dev_catalog_forbids_pinning_fields(tmp_path, field, value):
+    p = _write_catalog(tmp_path, "dev", {field: value})
+    with pytest.raises(ValueError, match=rf"must not define.*{field}"):
+        load_templates_from_yaml(p)
+
+
+def test_dev_catalog_without_pinning_fields_loads(tmp_path):
+    p = _write_catalog(tmp_path, "dev", {})
+    templates = load_templates_from_yaml(p)
+    assert len(templates) == 1
+    assert templates[0].tt_metal_commit is None
+    assert templates[0].version is None
+    # dev specs skip docker/code-link synthesis instead of raising.
+    spec = templates[0].expand_to_specs()[0]
+    assert spec.docker_image is None
+    assert spec.code_link is None
+
+
 MODEL_SPECS_DIR = Path(__file__).resolve().parent.parent / "workflows" / "model_specs"
 EXPECTED_CATALOG_ENVS = ("prod", "dev")
 EXPECTED_CATALOG_FILES = (

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -163,7 +163,9 @@ class TestModelSpecTemplateSystem:
             weights=["test/model"],
         )
         assert template.repacked == 0
-        assert template.version == VERSION
+        # version is no longer defaulted to VERSION; it is None unless the spec
+        # (prod catalog) pins it explicitly.
+        assert template.version is None
         assert template.status == ModelStatusTypes.EXPERIMENTAL
         assert template.docker_image is None
         # Directly-constructed templates default to pinned so they are never
@@ -421,6 +423,7 @@ class TestModelSpecSystem:
             model_name="TestModel-7B",
             tt_metal_commit="v1.0.0",
             vllm_commit="abc123",
+            version="0.10.0",
             inference_engine=InferenceEngine.VLLM.value,
             device_model_spec=sample_device_model_spec,
         )
@@ -429,6 +432,7 @@ class TestModelSpecSystem:
         assert spec.device_type == DeviceTypes.N150
         assert spec.model_name == "TestModel-7B"
         assert spec.param_count == 7  # Inferred from model name
+        # version + tt_metal_commit are set, so docker_image is synthesized.
         assert spec.docker_image is not None
 
     def test_model_spec_validation(self, sample_impl, sample_device_model_spec):

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -17,6 +17,7 @@ from workflows.model_spec import (
     KnownIssue,
     ModelSpec,
     ModelSpecTemplate,
+    ProdModelSpecTemplate,
     VersionRequirement,
     export_model_specs_json,
     get_model_spec_map,
@@ -65,8 +66,9 @@ class TestModelSpecTemplateSystem:
 
     def test_template_creation_and_expansion(self, sample_impl):
         """Test template creation and expansion."""
-        template = ModelSpecTemplate(
+        template = ProdModelSpecTemplate(
             impl=sample_impl,
+            version="0.0.0",
             tt_metal_commit="v1.0.0",
             vllm_commit="abc123",
             inference_engine=InferenceEngine.VLLM.value,
@@ -122,8 +124,9 @@ class TestModelSpecTemplateSystem:
                 reason="GH#2550 - eval harness crash",
             ),
         ]
-        template = ModelSpecTemplate(
+        template = ProdModelSpecTemplate(
             impl=sample_impl,
+            version="0.0.0",
             tt_metal_commit="v1.0.0",
             vllm_commit="abc123",
             inference_engine=InferenceEngine.VLLM.value,
@@ -147,11 +150,9 @@ class TestModelSpecTemplateSystem:
         assert expanded_issues[1].task_name is None
 
     def test_template_defaults(self, sample_impl):
-        """Test template creation with defaults."""
+        """The dev base template carries no release pins at all."""
         template = ModelSpecTemplate(
             impl=sample_impl,
-            tt_metal_commit="v1.0.0",
-            vllm_commit="abc123",
             inference_engine=InferenceEngine.VLLM.value,
             device_model_specs=[
                 DeviceModelSpec(
@@ -163,40 +164,66 @@ class TestModelSpecTemplateSystem:
             weights=["test/model"],
         )
         assert template.repacked == 0
-        assert template.version is None
         assert template.status == ModelStatusTypes.EXPERIMENTAL
-        assert template.docker_image is None
+        # The base (dev) template has no pin fields; they live on
+        # ProdModelSpecTemplate only.
+        assert not hasattr(template, "version")
+        assert not hasattr(template, "tt_metal_commit")
+        assert not hasattr(template, "docker_image")
         # Directly-constructed templates default to pinned so they are never
         # dropped from IMAGE_PINNED_MODEL_SPECS.
         assert template.image_pinned is True
 
+    def test_prod_template_requires_version_and_tt_metal_commit(self, sample_impl):
+        """ProdModelSpecTemplate enforces the release pins at construction."""
+        kwargs = dict(
+            impl=sample_impl,
+            inference_engine=InferenceEngine.VLLM.value,
+            device_model_specs=[
+                DeviceModelSpec(
+                    device=DeviceTypes.N150, max_concurrency=1, max_context=1024
+                )
+            ],
+            weights=["test/model"],
+        )
+        with pytest.raises(TypeError):
+            ProdModelSpecTemplate(**kwargs)  # missing version + tt_metal_commit
+        prod = ProdModelSpecTemplate(version="0.1.0", tt_metal_commit="abc", **kwargs)
+        assert prod.version == "0.1.0"
+        assert prod.tt_metal_commit == "abc"
+        assert prod.vllm_commit is None  # optional
+
     def test_build_template_sets_image_pinned_from_yaml_keys(self):
-        """A catalog entry "pins" its image only when it sets `version` or
-        `docker_image`; with neither, image_pinned is False so the spec is
-        excluded from IMAGE_PINNED_MODEL_SPECS."""
+        """image_pinned reflects whether the entry sets `version` or `docker_image`:
+        prod templates (which require version) are pinned; dev templates are not."""
         from workflows.model_spec import _IMPL_REGISTRY, _build_template
 
         base = {
             "weights": ["acme/Foo-7B"],
             "impl": next(iter(_IMPL_REGISTRY)),
-            "tt_metal_commit": "abc1234",
             "inference_engine": "VLLM",
             "device_model_specs": [
                 {"device": "N150", "max_concurrency": 16, "max_context": 8192}
             ],
         }
 
-        assert _build_template(dict(base)).image_pinned is False
-        assert _build_template({**base, "version": "0.10.0"}).image_pinned is True
+        # dev: no pins → not image-pinned
+        assert _build_template(dict(base), env="dev").image_pinned is False
+        # prod: version is required and present → image-pinned
+        prod = {**base, "version": "0.10.0", "tt_metal_commit": "abc1234"}
+        assert _build_template(prod, env="prod").image_pinned is True
         assert (
-            _build_template({**base, "docker_image": "ghcr.io/x/y:1.0"}).image_pinned
+            _build_template(
+                {**prod, "docker_image": "ghcr.io/x/y:1.0"}, env="prod"
+            ).image_pinned
             is True
         )
 
     def test_system_requirement_template_level(self, sample_impl):
         """Test that SystemRequirements propagate correctly from templates and device specs."""
-        template1 = ModelSpecTemplate(
+        template1 = ProdModelSpecTemplate(
             impl=sample_impl,
+            version="0.0.0",
             tt_metal_commit="v1.0.0",
             vllm_commit="abc123",
             inference_engine=InferenceEngine.VLLM.value,
@@ -229,8 +256,9 @@ class TestModelSpecTemplateSystem:
         assert specs1[0].system_requirements.kmd.mode == VersionMode.STRICT
 
     def test_system_requirements_device_model_spec_level(self, sample_impl):
-        template2 = ModelSpecTemplate(
+        template2 = ProdModelSpecTemplate(
             impl=sample_impl,
+            version="0.0.0",
             tt_metal_commit="v1.1.0",
             vllm_commit="abc123",
             inference_engine=InferenceEngine.VLLM.value,
@@ -263,8 +291,9 @@ class TestModelSpecTemplateSystem:
         assert specs2[0].system_requirements.kmd.mode == VersionMode.SUGGESTED
 
     def test_system_requirements_both_levels(self, sample_impl):
-        template3 = ModelSpecTemplate(
+        template3 = ProdModelSpecTemplate(
             impl=sample_impl,
+            version="0.0.0",
             tt_metal_commit="v1.2.0",
             vllm_commit="abc123",
             inference_engine=InferenceEngine.VLLM.value,
@@ -308,8 +337,9 @@ class TestModelSpecTemplateSystem:
 
     def test_metadata_per_weight(self, sample_impl):
         """Test that metadata is correctly assigned per weight during expansion."""
-        template = ModelSpecTemplate(
+        template = ProdModelSpecTemplate(
             impl=sample_impl,
+            version="0.0.0",
             tt_metal_commit="v1.0.0",
             vllm_commit="abc123",
             inference_engine=InferenceEngine.VLLM.value,
@@ -339,8 +369,9 @@ class TestModelSpecTemplateSystem:
 
     def test_metadata_defaults_empty(self, sample_impl):
         """Test that metadata defaults to empty dict when not provided."""
-        template = ModelSpecTemplate(
+        template = ProdModelSpecTemplate(
             impl=sample_impl,
+            version="0.0.0",
             tt_metal_commit="v1.0.0",
             vllm_commit="abc123",
             inference_engine=InferenceEngine.VLLM.value,
@@ -360,8 +391,9 @@ class TestModelSpecTemplateSystem:
 
     def test_metadata_partial_weights(self, sample_impl):
         """Test that weights without metadata entries get empty dict."""
-        template = ModelSpecTemplate(
+        template = ProdModelSpecTemplate(
             impl=sample_impl,
+            version="0.0.0",
             tt_metal_commit="v1.0.0",
             vllm_commit="abc123",
             inference_engine=InferenceEngine.VLLM.value,
@@ -388,8 +420,9 @@ class TestModelSpecTemplateSystem:
     def test_metadata_invalid_key_raises(self, sample_impl):
         """Test that metadata with keys not in weights raises an error."""
         with pytest.raises(AssertionError, match="These keys do not exist as weights"):
-            ModelSpecTemplate(
+            ProdModelSpecTemplate(
                 impl=sample_impl,
+                version="0.0.0",
                 tt_metal_commit="v1.0.0",
                 vllm_commit="abc123",
                 inference_engine=InferenceEngine.VLLM.value,
@@ -604,8 +637,9 @@ class TestSystemIntegration:
     def test_model_spec_map_generation(self, sample_impl):
         """Test spec map generation from templates."""
         templates = [
-            ModelSpecTemplate(
+            ProdModelSpecTemplate(
                 impl=sample_impl,
+                version="0.0.0",
                 tt_metal_commit="v1.0.0",
                 vllm_commit="abc123",
                 inference_engine=InferenceEngine.VLLM.value,

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -163,8 +163,6 @@ class TestModelSpecTemplateSystem:
             weights=["test/model"],
         )
         assert template.repacked == 0
-        # version is no longer defaulted to VERSION; it is None unless the spec
-        # (prod catalog) pins it explicitly.
         assert template.version is None
         assert template.status == ModelStatusTypes.EXPERIMENTAL
         assert template.docker_image is None
@@ -432,7 +430,6 @@ class TestModelSpecSystem:
         assert spec.device_type == DeviceTypes.N150
         assert spec.model_name == "TestModel-7B"
         assert spec.param_count == 7  # Inferred from model name
-        # version + tt_metal_commit are set, so docker_image is synthesized.
         assert spec.docker_image is not None
 
     def test_model_spec_validation(self, sample_impl, sample_device_model_spec):

--- a/tests/test_promote_dev_spec_to_prod.py
+++ b/tests/test_promote_dev_spec_to_prod.py
@@ -5,6 +5,8 @@
 import json
 import textwrap
 
+import pytest
+
 from scripts.release.promote_dev_spec_to_prod import (
     DEFAULT_CI_CONFIG,
     DEFAULT_DEV_DIR,
@@ -22,6 +24,19 @@ from scripts.release.promote_dev_spec_to_prod import (
     upsert_block,
 )
 from workflows.workflow_types import DeviceTypes, InferenceEngine
+
+# Release pins injected by promotion. version="0.2.0" lets the existing
+# "version bumped from dev" assertions keep working now that the source is the
+# CLI flag rather than the dev template.
+PINS = {"tt_metal_commit": "abc1234", "version": "0.2.0", "vllm_commit": "def5678"}
+PIN_ARGS = [
+    "--tt-metal-commit",
+    "abc1234",
+    "--version",
+    "0.2.0",
+    "--vllm-commit",
+    "def5678",
+]
 
 
 def test_model_name_from_weight_strips_org_prefix():
@@ -339,7 +354,6 @@ def _build_tree(tmp_path):
             - meta-llama/Llama-3.1-8B-Instruct
           impl: tt_transformers
           inference_engine: VLLM
-          version: "0.2.0"
           device_model_specs:
             - device: GALAXY
               max_context: 16384  # 16 * 1024
@@ -381,7 +395,7 @@ def _build_tree(tmp_path):
 
 def test_promote_updates_prod_preserving_comment_and_whole_template(tmp_path):
     ci, dev, prod = _build_tree(tmp_path)
-    report = promote(ci, dev, prod, dry_run=False)
+    report = promote(ci, dev, prod, **PINS)
 
     text = (prod / "llm.yaml").read_text()
     assert "0.2.0" in text  # version bumped from dev
@@ -390,6 +404,150 @@ def test_promote_updates_prod_preserving_comment_and_whole_template(tmp_path):
     assert "device: N150" in text  # whole template copied (non-release device)
     assert report["unmatched"] == set()
     assert "llm.yaml" in report["changed_files"]
+
+
+def test_promote_injects_pins_and_result_passes_prod_enforcement(tmp_path):
+    """A stripped dev block is promoted with the pins injected, and the resulting
+    prod file loads under the prod required-fields enforcement."""
+    from workflows.model_spec import load_templates_from_yaml
+
+    dev = tmp_path / "dev"
+    prod = tmp_path / "prod"  # parent dir name "prod" => enforcement is active
+    _write(
+        dev / "llm.yaml",
+        """
+        templates:
+        - weights:
+            - meta-llama/Llama-3.1-8B-Instruct
+          impl: tt_transformers
+          inference_engine: VLLM
+          device_model_specs:
+            - device: GALAXY
+              max_concurrency: 32
+              max_context: 4096
+              default_impl: true
+        """,
+    )
+    # prod already has this template pinned at an older release (update path).
+    _write(
+        prod / "llm.yaml",
+        """
+        templates:
+        - weights:
+            - meta-llama/Llama-3.1-8B-Instruct
+          impl: tt_transformers
+          inference_engine: VLLM
+          version: "0.0.1"
+          tt_metal_commit: "old"
+          vllm_commit: "old"
+          device_model_specs:
+            - device: GALAXY
+              max_concurrency: 32
+              max_context: 4096
+              default_impl: true
+        """,
+    )
+    ci = tmp_path / "ci.json"
+    ci.write_text(
+        json.dumps(
+            {
+                "models": {
+                    "Llama-3.1-8B-Instruct": {
+                        "inference_engine": "vLLM",
+                        "ci": {"release": {"devices": ["GALAXY"]}},
+                    }
+                }
+            }
+        )
+    )
+
+    promote(
+        ci,
+        dev,
+        prod,
+        tt_metal_commit="deadbeef",
+        version="1.2.3",
+        vllm_commit="cafef00d",
+    )
+
+    text = (prod / "llm.yaml").read_text()
+    assert 'version: "1.2.3"' in text
+    assert 'tt_metal_commit: "deadbeef"' in text
+    assert 'vllm_commit: "cafef00d"' in text
+
+    templates = load_templates_from_yaml(prod / "llm.yaml")
+    assert templates[0].version == "1.2.3"
+    assert templates[0].tt_metal_commit == "deadbeef"
+    assert templates[0].vllm_commit == "cafef00d"
+
+
+def test_promote_requires_vllm_commit_for_vllm_template(tmp_path):
+    """Omitting vllm_commit raises when a promoted template is VLLM-engine."""
+    ci, dev, prod = _build_tree(tmp_path)  # _build_tree uses inference_engine VLLM
+    with pytest.raises(ValueError, match="vllm-commit"):
+        promote(ci, dev, prod, tt_metal_commit="abc1234", version="1.0.0")
+
+
+def test_promote_non_vllm_template_omits_vllm_commit(tmp_path):
+    """FORGE/MEDIA templates need no vllm_commit and get none injected."""
+    dev = tmp_path / "dev"
+    prod = tmp_path / "prod"
+    _write(
+        dev / "cnn.yaml",
+        """
+        templates:
+        - weights:
+            - resnet-50
+          impl: tt_transformers
+          inference_engine: FORGE
+          device_model_specs:
+            - device: N150
+              max_concurrency: 1
+              max_context: 4096
+              default_impl: true
+        """,
+    )
+    ci = tmp_path / "ci.json"
+    ci.write_text(
+        json.dumps(
+            {
+                "models": {
+                    "resnet-50": {
+                        "inference_engine": "FORGE",
+                        "ci": {"release": {"devices": ["N150"]}},
+                    }
+                }
+            }
+        )
+    )
+    # No vllm_commit passed, and none required.
+    report = promote(ci, dev, prod, tt_metal_commit="abc1234", version="1.0.0")
+    text = (prod / "cnn.yaml").read_text()
+    assert 'version: "1.0.0"' in text
+    assert 'tt_metal_commit: "abc1234"' in text
+    assert "vllm_commit" not in text
+    assert report["unmatched"] == set()
+
+
+def test_main_errors_when_vllm_commit_missing(tmp_path):
+    """main() exits non-zero (argparse error) when vllm_commit is needed but absent."""
+    ci, dev, prod = _build_tree(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                "--ci-config",
+                str(ci),
+                "--dev-dir",
+                str(dev),
+                "--prod-dir",
+                str(prod),
+                "--tt-metal-commit",
+                "abc1234",
+                "--version",
+                "1.0.0",
+            ]
+        )
+    assert exc.value.code == 2  # argparse usage error
 
 
 def test_promote_appends_new_release_template_and_stays_valid_yaml(tmp_path):
@@ -438,7 +596,7 @@ def test_promote_appends_new_release_template_and_stays_valid_yaml(tmp_path):
         )
     )
 
-    report = promote(ci, dev, prod, dry_run=False)
+    report = promote(ci, dev, prod, **PINS)
 
     assert report["actions"]["llm.yaml"] == [
         (
@@ -463,20 +621,11 @@ def test_promote_appends_new_release_template_and_stays_valid_yaml(tmp_path):
     assert ("meta-llama/Llama-3.1-8B-Instruct",) in weights
 
 
-def test_promote_dry_run_writes_nothing(tmp_path):
-    ci, dev, prod = _build_tree(tmp_path)
-    before = (prod / "llm.yaml").read_text()
-    report = promote(ci, dev, prod, dry_run=True)
-    # Disk is untouched, but the intended change is still reported.
-    assert (prod / "llm.yaml").read_text() == before
-    assert "llm.yaml" in report["changed_files"]
-
-
 def test_promote_is_idempotent(tmp_path):
     ci, dev, prod = _build_tree(tmp_path)
-    promote(ci, dev, prod, dry_run=False)
+    promote(ci, dev, prod, **PINS)
     after_first = (prod / "llm.yaml").read_text()
-    report = promote(ci, dev, prod, dry_run=False)
+    report = promote(ci, dev, prod, **PINS)
     assert (prod / "llm.yaml").read_text() == after_first
     assert report["changed_files"] == []
 
@@ -495,7 +644,7 @@ def test_promote_reports_unmatched_combo(tmp_path):
             }
         )
     )
-    report = promote(ci, dev, prod, dry_run=False)
+    report = promote(ci, dev, prod, **PINS)
     assert (
         ReleaseCombo("ghost-model", InferenceEngine.VLLM, DeviceTypes.GALAXY)
         in report["unmatched"]
@@ -504,14 +653,6 @@ def test_promote_reports_unmatched_combo(tmp_path):
 
 def test_main_returns_zero_and_writes(tmp_path, capsys):
     ci, dev, prod = _build_tree(tmp_path)
-    rc = main(["--ci-config", str(ci), "--dev-dir", str(dev), "--prod-dir", str(prod)])
-    assert rc == 0
-    assert "0.2.0" in (prod / "llm.yaml").read_text()
-
-
-def test_main_dry_run_writes_nothing(tmp_path):
-    ci, dev, prod = _build_tree(tmp_path)
-    before = (prod / "llm.yaml").read_text()
     rc = main(
         [
             "--ci-config",
@@ -520,11 +661,11 @@ def test_main_dry_run_writes_nothing(tmp_path):
             str(dev),
             "--prod-dir",
             str(prod),
-            "--dry-run",
+            *PIN_ARGS,
         ]
     )
     assert rc == 0
-    assert (prod / "llm.yaml").read_text() == before
+    assert "0.2.0" in (prod / "llm.yaml").read_text()
 
 
 def test_main_returns_nonzero_on_unmatched(tmp_path, capsys):
@@ -541,7 +682,17 @@ def test_main_returns_nonzero_on_unmatched(tmp_path, capsys):
             }
         )
     )
-    rc = main(["--ci-config", str(ci), "--dev-dir", str(dev), "--prod-dir", str(prod)])
+    rc = main(
+        [
+            "--ci-config",
+            str(ci),
+            "--dev-dir",
+            str(dev),
+            "--prod-dir",
+            str(prod),
+            *PIN_ARGS,
+        ]
+    )
     assert rc == 1
     assert "ghost-model" in capsys.readouterr().out
 
@@ -555,9 +706,16 @@ def test_real_repo_release_combos_all_match_dev():
     assert unmatched == set(), f"release combos missing from dev: {unmatched}"
 
 
-def test_real_repo_dry_run_against_prod_succeeds(tmp_path):
-    """Dry-run against the real catalogues runs cleanly and writes nothing to repo."""
-    report = promote(DEFAULT_CI_CONFIG, DEFAULT_DEV_DIR, DEFAULT_PROD_DIR, dry_run=True)
+def test_real_repo_promote_against_prod_succeeds(tmp_path):
+    """Promoting against the real catalogues runs cleanly with no unmatched combos.
+
+    Writes to a temp copy so the repo's prod/ is never touched.
+    """
+    import shutil
+
+    prod_copy = tmp_path / "prod"
+    shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
+    report = promote(DEFAULT_CI_CONFIG, DEFAULT_DEV_DIR, prod_copy, **PINS)
     assert report["unmatched"] == set()
 
 
@@ -576,7 +734,7 @@ def test_real_repo_promote_only_touches_release_blocks(tmp_path):
     shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
     combos = collect_release_combos(json.loads(DEFAULT_CI_CONFIG.read_text()))
     matches_by_file, _ = find_matches(DEFAULT_DEV_DIR, combos)
-    report = promote(DEFAULT_CI_CONFIG, DEFAULT_DEV_DIR, prod_copy, dry_run=False)
+    report = promote(DEFAULT_CI_CONFIG, DEFAULT_DEV_DIR, prod_copy, **PINS)
 
     def blocks(text):
         return {
@@ -605,8 +763,8 @@ def test_real_repo_promote_is_idempotent(tmp_path):
 
     prod_copy = tmp_path / "prod"
     shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
-    promote(DEFAULT_CI_CONFIG, DEFAULT_DEV_DIR, prod_copy, dry_run=False)
+    promote(DEFAULT_CI_CONFIG, DEFAULT_DEV_DIR, prod_copy, **PINS)
     snapshot = {p.name: p.read_text() for p in prod_copy.glob("*.yaml")}
-    report = promote(DEFAULT_CI_CONFIG, DEFAULT_DEV_DIR, prod_copy, dry_run=False)
+    report = promote(DEFAULT_CI_CONFIG, DEFAULT_DEV_DIR, prod_copy, **PINS)
     assert report["changed_files"] == []
     assert {p.name: p.read_text() for p in prod_copy.glob("*.yaml")} == snapshot

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -36,8 +36,18 @@ MODEL_SPECS_SCHEMA_VERSION = "0.1.0"
 
 
 def generate_docker_tag(
-    version: str, tt_metal_commit: str, vllm_commit: Optional[str]
+    version: Optional[str],
+    tt_metal_commit: Optional[str],
+    vllm_commit: Optional[str],
 ) -> str:
+    # version and tt_metal_commit are required to build a tag. They are
+    # optional on the spec (dev catalog omits them), so guard here: callers
+    # that synthesize an image from a dev spec are a bug, fail loudly rather
+    # than emit a "None-None" tag.
+    if version is None:
+        raise ValueError("Cannot generate docker tag: version is None")
+    if tt_metal_commit is None:
+        raise ValueError("Cannot generate docker tag: tt_metal_commit is None")
     max_tag_len = 12
     if vllm_commit:
         return f"{version}-{tt_metal_commit[:max_tag_len]}-{vllm_commit[:max_tag_len]}"
@@ -45,9 +55,20 @@ def generate_docker_tag(
         return f"{version}-{tt_metal_commit[:max_tag_len]}"
 
 
+def generate_code_link(
+    repo_url: str, tt_metal_commit: Optional[str], code_path: str
+) -> str:
+    # tt_metal_commit is required to pin the source tree. Optional on the spec
+    # (dev catalog omits it), so fail loudly if a caller tries to build a link
+    # without it rather than produce a `/tree/None/` URL.
+    if tt_metal_commit is None:
+        raise ValueError("Cannot generate code link: tt_metal_commit is None")
+    return f"{repo_url}/tree/{tt_metal_commit}/{code_path}"
+
+
 def generate_default_docker_link(
-    version: str,
-    tt_metal_commit: str,
+    version: Optional[str],
+    tt_metal_commit: Optional[str],
     vllm_commit: Optional[str],
     inference_engine: str = "",
     multihost: bool = False,
@@ -423,12 +444,14 @@ class ModelSpec:
     model_name: str
     inference_engine: InferenceEngine
     device_type: DeviceTypes  # Single device, not a set
-    tt_metal_commit: str
     device_model_spec: DeviceModelSpec
 
     # Optional specification fields (WITH DEFAULTS)
     system_requirements: Optional[SystemRequirements] = None
     env_vars: Dict[str, str] = field(default_factory=dict)
+    # tt_metal_commit/version are required for prod specs (enforced when loading
+    # the prod catalog) but omitted by dev specs, so they are optional here.
+    tt_metal_commit: Optional[str] = None
     vllm_commit: Optional[str] = None
     hf_weights_repo: Optional[str] = (
         None  # HF repo to download weights from (defaults to hf_model_repo)
@@ -438,7 +461,7 @@ class ModelSpec:
     min_ram_gb: Optional[int] = None
     model_type: Optional[ModelType] = ModelType.LLM
     repacked: int = 0
-    version: str = VERSION
+    version: Optional[str] = None
     docker_image: Optional[str] = None
     status: str = ModelStatusTypes.EXPERIMENTAL
     code_link: Optional[str] = None
@@ -530,8 +553,14 @@ class ModelSpec:
             # assume fp16 equivalent weights, add 0.5x overhead buffer
             object.__setattr__(self, "min_ram_gb", self.param_count * 2.5)
 
-        # Generate default docker image if not provided
-        if not self.docker_image:
+        # Generate default docker image if not provided. Synthesis needs
+        # version + tt_metal_commit; dev specs omit both, so skip and leave
+        # docker_image=None (dev images are pinned at runtime, not synthesized).
+        if (
+            not self.docker_image
+            and self.version is not None
+            and self.tt_metal_commit is not None
+        ):
             # TODO: Use ubuntu version to interpolate this string
             _default_docker_link = generate_default_docker_link(
                 self.version,
@@ -542,12 +571,14 @@ class ModelSpec:
             )
             object.__setattr__(self, "docker_image", _default_docker_link)
 
-        # Generate code link
-        if not self.code_link:
+        # Generate code link. Needs tt_metal_commit; skip when absent (dev specs).
+        if not self.code_link and self.tt_metal_commit is not None:
             object.__setattr__(
                 self,
                 "code_link",
-                f"{self.impl.repo_url}/tree/{self.tt_metal_commit}/{self.impl.code_path}",
+                generate_code_link(
+                    self.impl.repo_url, self.tt_metal_commit, self.impl.code_path
+                ),
             )
 
         data_parallel = self.device_model_spec.vllm_args.get("data_parallel_size")
@@ -879,26 +910,29 @@ class ModelSpecTemplate:
     # Required fields (NO DEFAULTS) - must come first
     weights: List[str]  # List of HF model repos to create specs for
     impl: ImplSpec
-    tt_metal_commit: str
     inference_engine: InferenceEngine
     device_model_specs: List[DeviceModelSpec]
 
     # Optional template fields (WITH DEFAULTS) - must come after required fields
     system_requirements: Optional[SystemRequirements] = None
+    # tt_metal_commit/version/vllm_commit are required for prod templates and
+    # forbidden for dev templates; both rules are enforced in
+    # load_templates_from_yaml based on the catalog directory (prod/ vs dev/).
+    tt_metal_commit: Optional[str] = None
     vllm_commit: Optional[str] = None
     status: str = ModelStatusTypes.EXPERIMENTAL
     env_vars: Dict[str, str] = field(default_factory=dict)
     supported_modalities: List[str] = field(default_factory=lambda: ["text"])
     repacked: int = 0
-    version: str = VERSION
+    version: Optional[str] = None
     perf_targets_map: Dict[str, float] = field(default_factory=dict)
     docker_image: Optional[str] = None
     # True when the catalog explicitly pinned the image via `version` or
-    # `docker_image`. When neither is set, the docker tag is synthesized from the
-    # repo-wide VERSION + commits rather than a real published image, so these
-    # specs are excluded from IMAGE_PINNED_MODEL_SPECS (the list the helm chart
-    # generator consumes). Set by _build_template from YAML key presence;
-    # defaults True for directly constructed templates so they are never dropped.
+    # `docker_image`. When neither is set (e.g. dev specs), no docker tag is
+    # synthesized at all, so these specs are excluded from
+    # IMAGE_PINNED_MODEL_SPECS (the list the helm chart generator consumes).
+    # Set by _build_template from YAML key presence; defaults True for directly
+    # constructed templates so they are never dropped.
     image_pinned: bool = True
     model_type: Optional[ModelType] = ModelType.LLM
     min_disk_gb: Optional[int] = None
@@ -1084,11 +1118,45 @@ def _build_template(data: Dict) -> "ModelSpecTemplate":
     return ModelSpecTemplate(**kwargs)
 
 
+# prod templates must pin these; dev templates must omit all of _DEV_FORBIDDEN.
+# Enforced per-catalog-directory in load_templates_from_yaml. vllm_commit is not
+# prod-required (CNN/FORGE specs legitimately have none) but is dev-forbidden.
+_PROD_REQUIRED_FIELDS = ("tt_metal_commit", "version")
+_DEV_FORBIDDEN_FIELDS = ("tt_metal_commit", "vllm_commit", "version", "docker_image")
+
+
+def _validate_template_env_fields(template: Dict, env: str, path: Path) -> None:
+    """Enforce the prod/dev field contract on a raw template dict.
+
+    prod templates must define every field in _PROD_REQUIRED_FIELDS; dev
+    templates must define none of _DEV_FORBIDDEN_FIELDS (dev images are pinned
+    at runtime via --override-docker-image, never synthesized from the catalog).
+    Checked on the raw YAML dict so absence is distinguishable from a default.
+    """
+    weights = template.get("weights", ["<unknown>"])
+    if env == "prod":
+        missing = [f for f in _PROD_REQUIRED_FIELDS if template.get(f) is None]
+        if missing:
+            raise ValueError(f"{path}: prod template {weights} must define {missing}")
+    elif env == "dev":
+        present = [f for f in _DEV_FORBIDDEN_FIELDS if f in template]
+        if present:
+            raise ValueError(
+                f"{path}: dev template {weights} must not define {present} "
+                "(dev specs are pinned at runtime, not from the catalog)"
+            )
+
+
 def load_templates_from_yaml(path: Path) -> List["ModelSpecTemplate"]:
     with open(path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
     if not data or "templates" not in data:
         raise ValueError(f"YAML file {path} is empty or missing 'templates' key")
+    # The catalog environment is the parent directory name (prod/ or dev/).
+    # Other callers (tests, ad-hoc paths) get no field enforcement.
+    env = path.parent.name
+    for template in data["templates"]:
+        _validate_template_env_fields(template, env, path)
     return [_build_template(t) for t in data["templates"]]
 
 

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -40,14 +40,10 @@ def generate_docker_tag(
     tt_metal_commit: Optional[str],
     vllm_commit: Optional[str],
 ) -> str:
-    # version and tt_metal_commit are required to build a tag. They are
-    # optional on the spec (dev catalog omits them), so guard here: callers
-    # that synthesize an image from a dev spec are a bug, fail loudly rather
-    # than emit a "None-None" tag.
-    if version is None:
-        raise ValueError("Cannot generate docker tag: version is None")
-    if tt_metal_commit is None:
-        raise ValueError("Cannot generate docker tag: tt_metal_commit is None")
+    if version is None or tt_metal_commit is None:
+        raise ValueError(
+            "Cannot generate docker tag: version and tt_metal_commit are required"
+        )
     max_tag_len = 12
     if vllm_commit:
         return f"{version}-{tt_metal_commit[:max_tag_len]}-{vllm_commit[:max_tag_len]}"
@@ -58,9 +54,6 @@ def generate_docker_tag(
 def generate_code_link(
     repo_url: str, tt_metal_commit: Optional[str], code_path: str
 ) -> str:
-    # tt_metal_commit is required to pin the source tree. Optional on the spec
-    # (dev catalog omits it), so fail loudly if a caller tries to build a link
-    # without it rather than produce a `/tree/None/` URL.
     if tt_metal_commit is None:
         raise ValueError("Cannot generate code link: tt_metal_commit is None")
     return f"{repo_url}/tree/{tt_metal_commit}/{code_path}"
@@ -449,8 +442,6 @@ class ModelSpec:
     # Optional specification fields (WITH DEFAULTS)
     system_requirements: Optional[SystemRequirements] = None
     env_vars: Dict[str, str] = field(default_factory=dict)
-    # tt_metal_commit/version are required for prod specs (enforced when loading
-    # the prod catalog) but omitted by dev specs, so they are optional here.
     tt_metal_commit: Optional[str] = None
     vllm_commit: Optional[str] = None
     hf_weights_repo: Optional[str] = (
@@ -554,8 +545,7 @@ class ModelSpec:
             object.__setattr__(self, "min_ram_gb", self.param_count * 2.5)
 
         # Generate default docker image if not provided. Synthesis needs
-        # version + tt_metal_commit; dev specs omit both, so skip and leave
-        # docker_image=None (dev images are pinned at runtime, not synthesized).
+        # version + tt_metal_commit; dev specs omit both, so skip and leave docker_image=None
         if (
             not self.docker_image
             and self.version is not None
@@ -915,9 +905,6 @@ class ModelSpecTemplate:
 
     # Optional template fields (WITH DEFAULTS) - must come after required fields
     system_requirements: Optional[SystemRequirements] = None
-    # tt_metal_commit/version/vllm_commit are required for prod templates and
-    # forbidden for dev templates; both rules are enforced in
-    # load_templates_from_yaml based on the catalog directory (prod/ vs dev/).
     tt_metal_commit: Optional[str] = None
     vllm_commit: Optional[str] = None
     status: str = ModelStatusTypes.EXPERIMENTAL
@@ -1152,8 +1139,6 @@ def load_templates_from_yaml(path: Path) -> List["ModelSpecTemplate"]:
         data = yaml.safe_load(f)
     if not data or "templates" not in data:
         raise ValueError(f"YAML file {path} is empty or missing 'templates' key")
-    # The catalog environment is the parent directory name (prod/ or dev/).
-    # Other callers (tests, ad-hoc paths) get no field enforcement.
     env = path.parent.name
     for template in data["templates"]:
         _validate_template_env_fields(template, env, path)

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -905,18 +905,14 @@ class ModelSpecTemplate:
 
     # Optional template fields (WITH DEFAULTS) - must come after required fields
     system_requirements: Optional[SystemRequirements] = None
-    tt_metal_commit: Optional[str] = None
-    vllm_commit: Optional[str] = None
     status: str = ModelStatusTypes.EXPERIMENTAL
     env_vars: Dict[str, str] = field(default_factory=dict)
     supported_modalities: List[str] = field(default_factory=lambda: ["text"])
     repacked: int = 0
-    version: Optional[str] = None
     perf_targets_map: Dict[str, float] = field(default_factory=dict)
-    docker_image: Optional[str] = None
     # True when the catalog explicitly pinned the image via `version` or
-    # `docker_image`. When neither is set (e.g. dev specs), no docker tag is
-    # synthesized at all, so these specs are excluded from
+    # `docker_image` (prod templates always do; dev never does). When neither is
+    # set, no docker tag is synthesized, so these specs are excluded from
     # IMAGE_PINNED_MODEL_SPECS (the list the helm chart generator consumes).
     # Set by _build_template from YAML key presence; defaults True for directly
     # constructed templates so they are never dropped.
@@ -1017,14 +1013,16 @@ class ModelSpecTemplate:
                     system_requirements=device_model_spec.system_requirements
                     if device_model_spec.system_requirements
                     else self.system_requirements,
-                    tt_metal_commit=self.tt_metal_commit,
-                    vllm_commit=self.vllm_commit,
+                    # Release pins live only on ProdModelSpecTemplate; dev (base)
+                    # templates omit them, so read via getattr (None for dev).
+                    tt_metal_commit=getattr(self, "tt_metal_commit", None),
+                    vllm_commit=getattr(self, "vllm_commit", None),
                     hf_weights_repo=self.hf_weights_repo,
                     # Template fields
                     env_vars=self.env_vars,
                     repacked=self.repacked,
-                    version=self.version,
-                    docker_image=self.docker_image,
+                    version=getattr(self, "version", None),
+                    docker_image=getattr(self, "docker_image", None),
                     status=self.status,
                     override_tt_config=device_model_spec.override_tt_config,
                     supported_modalities=self.supported_modalities,
@@ -1038,6 +1036,22 @@ class ModelSpecTemplate:
 
                 specs.append(spec)
         return specs
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProdModelSpecTemplate(ModelSpecTemplate):
+    """Prod catalog template: carries the release pins the dev base omits.
+
+    ``version`` and ``tt_metal_commit`` are required (a prod YAML missing either
+    fails to construct); ``vllm_commit`` and ``docker_image`` are optional
+    (FORGE/MEDIA specs have no vllm_commit; most specs synthesize their image).
+    Construction enforces the prod contract directly — no separate field check.
+    """
+
+    tt_metal_commit: str
+    version: str
+    vllm_commit: Optional[str] = None
+    docker_image: Optional[str] = None
 
 
 # Catalog data lives in workflows/model_specs/catalog.yaml.
@@ -1076,7 +1090,15 @@ def _build_device_model_spec(data: Dict) -> "DeviceModelSpec":
     return DeviceModelSpec(**kwargs)
 
 
-def _build_template(data: Dict) -> "ModelSpecTemplate":
+def _build_template(data: Dict, env: str = "prod") -> "ModelSpecTemplate":
+    """Build a template from a raw catalog dict.
+
+    ``env`` selects the dataclass and thus the field contract: "prod" builds a
+    ProdModelSpecTemplate (version + tt_metal_commit required), anything else
+    builds the dev base ModelSpecTemplate (which has no pin fields, so a dev
+    entry that sets one fails to construct). Construction errors are re-raised
+    with the offending weights for a readable, catalog-scoped message.
+    """
     kwargs = dict(data)
     impl_id = kwargs["impl"]
     if impl_id not in _IMPL_REGISTRY:
@@ -1102,36 +1124,12 @@ def _build_template(data: Dict) -> "ModelSpecTemplate":
     kwargs["image_pinned"] = (
         data.get("version") is not None or data.get("docker_image") is not None
     )
-    return ModelSpecTemplate(**kwargs)
-
-
-# prod templates must pin these; dev templates must omit all of _DEV_FORBIDDEN.
-# Enforced per-catalog-directory in load_templates_from_yaml. vllm_commit is not
-# prod-required (CNN/FORGE specs legitimately have none) but is dev-forbidden.
-_PROD_REQUIRED_FIELDS = ("tt_metal_commit", "version")
-_DEV_FORBIDDEN_FIELDS = ("tt_metal_commit", "vllm_commit", "version", "docker_image")
-
-
-def _validate_template_env_fields(template: Dict, env: str, path: Path) -> None:
-    """Enforce the prod/dev field contract on a raw template dict.
-
-    prod templates must define every field in _PROD_REQUIRED_FIELDS; dev
-    templates must define none of _DEV_FORBIDDEN_FIELDS (dev images are pinned
-    at runtime via --override-docker-image, never synthesized from the catalog).
-    Checked on the raw YAML dict so absence is distinguishable from a default.
-    """
-    weights = template.get("weights", ["<unknown>"])
-    if env == "prod":
-        missing = [f for f in _PROD_REQUIRED_FIELDS if template.get(f) is None]
-        if missing:
-            raise ValueError(f"{path}: prod template {weights} must define {missing}")
-    elif env == "dev":
-        present = [f for f in _DEV_FORBIDDEN_FIELDS if f in template]
-        if present:
-            raise ValueError(
-                f"{path}: dev template {weights} must not define {present} "
-                "(dev specs are pinned at runtime, not from the catalog)"
-            )
+    cls = ProdModelSpecTemplate if env == "prod" else ModelSpecTemplate
+    try:
+        return cls(**kwargs)
+    except TypeError as exc:
+        weights = data.get("weights", ["<unknown>"])
+        raise ValueError(f"{env} template {weights}: {exc}") from exc
 
 
 def load_templates_from_yaml(path: Path) -> List["ModelSpecTemplate"]:
@@ -1140,9 +1138,7 @@ def load_templates_from_yaml(path: Path) -> List["ModelSpecTemplate"]:
     if not data or "templates" not in data:
         raise ValueError(f"YAML file {path} is empty or missing 'templates' key")
     env = path.parent.name
-    for template in data["templates"]:
-        _validate_template_env_fields(template, env, path)
-    return [_build_template(t) for t in data["templates"]]
+    return [_build_template(t, env) for t in data["templates"]]
 
 
 _MODEL_SPECS_DIR = get_repo_root_path() / "workflows" / "model_specs"

--- a/workflows/model_specs/dev/audio_tts.yaml
+++ b/workflows/model_specs/dev/audio_tts.yaml
@@ -8,8 +8,6 @@ templates:
 - weights:
     - openai/whisper-large-v3
     - distil-whisper/distil-large-v3
-  version: "0.11.1"
-  tt_metal_commit: "2508216"
   impl: whisper
   min_disk_gb: 15
   min_ram_gb: 6
@@ -47,8 +45,6 @@ templates:
 - weights:
     - openai/whisper-large-v3
     - distil-whisper/distil-large-v3
-  version: "0.15.0"
-  tt_metal_commit: "25891d3"
   impl: whisper
   min_disk_gb: 15
   min_ram_gb: 6
@@ -71,8 +67,6 @@ templates:
 
 - weights:
     - microsoft/speecht5_tts
-  version: "0.10.0"
-  tt_metal_commit: "2508216"
   impl: speecht5_tts
   min_disk_gb: 15
   min_ram_gb: 6
@@ -91,8 +85,6 @@ templates:
 
 - weights:
     - microsoft/speecht5_tts
-  version: "0.15.0"
-  tt_metal_commit: "25891d3"
   impl: speecht5_tts
   min_disk_gb: 15
   min_ram_gb: 6
@@ -115,8 +107,6 @@ templates:
 
 - weights:
     - microsoft/speecht5_tts
-  version: "0.10.0"
-  tt_metal_commit: "2508216"
   impl: speecht5_tts
   min_disk_gb: 15
   min_ram_gb: 6

--- a/workflows/model_specs/dev/cnn.yaml
+++ b/workflows/model_specs/dev/cnn.yaml
@@ -7,11 +7,9 @@ templates:
 # =============================================================================
 - weights:
     - Qwen/Qwen3-4B
-  tt_metal_commit: "2496be4"
   impl: forge_vllm_plugin
   min_disk_gb: 15
   min_ram_gb: 8
-  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349"
   model_type: LLM
   inference_engine: FORGE
   uses_tensor_model_cache: false
@@ -32,11 +30,9 @@ templates:
 - weights:
     - meta-llama/Llama-3.2-3B
     - meta-llama/Llama-3.2-3B-Instruct
-  tt_metal_commit: "2496be4"
   impl: forge_vllm_plugin
   min_disk_gb: 15
   min_ram_gb: 8
-  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349"
   model_type: LLM
   inference_engine: FORGE
   uses_tensor_model_cache: false
@@ -56,11 +52,9 @@ templates:
 
 - weights:
     - meta-llama/Llama-3.1-8B-Instruct
-  tt_metal_commit: "2496be4"
   impl: forge_vllm_plugin
   min_disk_gb: 20
   min_ram_gb: 12
-  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349"
   model_type: LLM
   inference_engine: FORGE
   uses_tensor_model_cache: false
@@ -80,11 +74,9 @@ templates:
 
 - weights:
     - Qwen/Qwen3-8B
-  tt_metal_commit: "2496be4"
   impl: forge_vllm_plugin
   min_disk_gb: 20
   min_ram_gb: 12
-  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349"
   model_type: LLM
   inference_engine: FORGE
   uses_tensor_model_cache: false
@@ -104,11 +96,9 @@ templates:
 
 - weights:
     - tiiuae/Falcon3-7B-Instruct
-  tt_metal_commit: "2496be4"
   impl: forge_vllm_plugin
   min_disk_gb: 20
   min_ram_gb: 12
-  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349"
   model_type: LLM
   inference_engine: FORGE
   uses_tensor_model_cache: false
@@ -133,12 +123,9 @@ templates:
     # (constants.py only carries the TP mesh topology), mirroring the single-chip
     # forge LLMs above.
     - google/gemma-4-31b-it
-  tt_metal_commit: "e03b231b1de926cd8f9a0e1a2d39dd1df599f7a7"
-  vllm_commit: "46a7c96"
   impl: forge_vllm_plugin
   min_disk_gb: 80
   min_ram_gb: 32
-  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:aed6177ab424aa93f447118aac5a7b8ab1cafdbc_f752cce_79853177306"
   model_type: LLM
   inference_engine: FORGE
   uses_tensor_model_cache: false
@@ -166,12 +153,9 @@ templates:
     # basename "Qwen3-32B" matches ModelNames.QWEN_3_32B. batch-16 / 4K (same as
     # gemma; not yet independently swept on Qwen -- local verify is the check).
     - Qwen/Qwen3-32B
-  tt_metal_commit: "e03b231b1de926cd8f9a0e1a2d39dd1df599f7a7"
-  vllm_commit: "46a7c96"
   impl: forge_vllm_plugin
   min_disk_gb: 80
   min_ram_gb: 32
-  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:aed6177ab424aa93f447118aac5a7b8ab1cafdbc_f752cce_79853177306"
   model_type: LLM
   inference_engine: FORGE
   uses_tensor_model_cache: false
@@ -193,8 +177,6 @@ templates:
 
 - weights:
     - resnet-50
-  version: "0.13.0"
-  tt_metal_commit: "079a2c2"
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -213,8 +195,6 @@ templates:
 
 - weights:
     - vovnet
-  version: "0.13.0"
-  tt_metal_commit: "079a2c2"
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -233,8 +213,6 @@ templates:
 
 - weights:
     - mobilenetv2
-  version: "0.13.0"
-  tt_metal_commit: "079a2c2"
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -253,11 +231,9 @@ templates:
 
 - weights:
     - efficientnet
-  tt_metal_commit: "2496be4"
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
-  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673"
   model_type: CNN
   inference_engine: FORGE
   device_model_specs:
@@ -272,8 +248,6 @@ templates:
 
 - weights:
     - segformer
-  version: "0.13.0"
-  tt_metal_commit: "079a2c2"
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -292,8 +266,6 @@ templates:
 
 - weights:
     - vit
-  version: "0.13.0"
-  tt_metal_commit: "079a2c2"
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -312,8 +284,6 @@ templates:
 
 - weights:
     - yolox_nano
-  version: "0.13.0"
-  tt_metal_commit: "079a2c2"
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -332,11 +302,9 @@ templates:
 
 - weights:
     - unet
-  tt_metal_commit: "2496be4"
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
-  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673"
   model_type: CNN
   inference_engine: FORGE
   device_model_specs:
@@ -351,8 +319,6 @@ templates:
 
 - weights:
     - meta-llama/Llama-3.1-70B
-  version: "0.11.1"
-  tt_metal_commit: "2496be4"
   impl: forge_vllm_plugin
   min_disk_gb: 150
   min_ram_gb: 80

--- a/workflows/model_specs/dev/embedding.yaml
+++ b/workflows/model_specs/dev/embedding.yaml
@@ -7,11 +7,9 @@ templates:
 # =============================================================================
 - weights:
     - BAAI/bge-large-en-v1.5
-  tt_metal_commit: "65718bb"
   impl: tt_vllm_plugin
   min_disk_gb: 15
   min_ram_gb: 6
-  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756"
   model_type: EMBEDDING
   inference_engine: MEDIA
   device_model_specs:
@@ -65,7 +63,6 @@ templates:
 
 - weights:
     - BAAI/bge-m3
-  tt_metal_commit: "ec28d12"
   impl: tt_vllm_plugin
   min_disk_gb: 15
   min_ram_gb: 6
@@ -121,11 +118,9 @@ templates:
 
 - weights:
     - Qwen/Qwen3-Embedding-8B
-  tt_metal_commit: "555f240"
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
-  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756"
   model_type: EMBEDDING
   inference_engine: MEDIA
   device_model_specs:
@@ -168,11 +163,9 @@ templates:
 
 - weights:
     - Qwen/Qwen3-Embedding-4B
-  tt_metal_commit: "2496be4"
   impl: forge_vllm_plugin
   min_disk_gb: 15
   min_ram_gb: 6
-  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673"
   model_type: EMBEDDING
   inference_engine: FORGE
   device_model_specs:

--- a/workflows/model_specs/dev/image.yaml
+++ b/workflows/model_specs/dev/image.yaml
@@ -9,8 +9,6 @@ templates:
 - weights:
     - stabilityai/stable-diffusion-xl-base-1.0
     - stabilityai/stable-diffusion-xl-base-1.0-img-2-img
-  version: "0.11.1"
-  tt_metal_commit: bac8b34
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -66,8 +64,6 @@ templates:
 # at PR time.
 - weights:
     - stabilityai/stable-diffusion-xl-base-1.0
-  version: "0.13.0"
-  tt_metal_commit: 079a2c2
   impl: sdxl_forge
   min_disk_gb: 15
   min_ram_gb: 6
@@ -85,8 +81,6 @@ templates:
 
 - weights:
     - stabilityai/stable-diffusion-3.5-large
-  version: "0.9.0"
-  tt_metal_commit: c180ef7
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -105,12 +99,9 @@ templates:
 
 - weights:
     - diffusers/stable-diffusion-xl-1.0-inpainting-0.1
-  version: "0.12.0"
-  tt_metal_commit: fbbbd2d
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
-  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd"
   model_type: IMAGE
   inference_engine: MEDIA
   device_model_specs:
@@ -151,8 +142,6 @@ templates:
 - weights:
     - black-forest-labs/FLUX.1-dev
     - black-forest-labs/FLUX.1-schnell
-  version: "0.14.0"
-  tt_metal_commit: 80180b9
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -187,8 +176,6 @@ templates:
 
 - weights:
     - Motif-Technologies/Motif-Image-6B-Preview
-  version: "0.9.0"
-  tt_metal_commit: c180ef7
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -216,8 +203,6 @@ templates:
 - weights:
     - Qwen/Qwen-Image
     - Qwen/Qwen-Image-2512
-  version: "0.9.0"
-  tt_metal_commit: be88351
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -238,8 +223,6 @@ templates:
 
 - weights:
     - Tongyi-MAI/Z-Image-Turbo
-  version: "0.15.0"
-  tt_metal_commit: d0393dc
   impl: tt_transformers
   min_disk_gb: 30
   min_ram_gb: 16

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -8,9 +8,6 @@ templates:
 - weights:
     - openai/gpt-oss-20b
   impl: gpt_oss
-  version: "0.10.0"
-  tt_metal_commit: e867533
-  vllm_commit: 8f36910
   inference_engine: VLLM
   device_model_specs:
     - device: T3K
@@ -46,9 +43,6 @@ templates:
 - weights:
     - openai/gpt-oss-120b
   impl: gpt_oss
-  version: "0.12.0"
-  tt_metal_commit: 805f43d
-  vllm_commit: a45c614
   inference_engine: VLLM
   device_model_specs:
     - device: T3K
@@ -85,8 +79,6 @@ templates:
 - weights:
     - openai/gpt-oss-120b
   impl: gpt_oss
-  tt_metal_commit: 747215b  # handrew/gpt-oss-p150 branch
-  vllm_commit: 7678b70  # stable branch
   inference_engine: VLLM
   device_model_specs:
     - device: P300X2
@@ -112,9 +104,6 @@ templates:
 - weights:
     - arcee-ai/AFM-4.5B
   impl: tt_transformers
-  version: "0.3.0"
-  tt_metal_commit: ae65ee5
-  vllm_commit: 35f023f
   inference_engine: VLLM
   # need to add default sampling params here because they're
   # not in generation_config.json
@@ -137,9 +126,6 @@ templates:
 - weights:
     - google/gemma-3-1b-it
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: c254ee3
-  vllm_commit: c4f2327
   inference_engine: VLLM
   device_model_specs:
     - device: N150
@@ -155,9 +141,6 @@ templates:
 - weights:
     - Qwen/Qwen3-8B
   impl: tt_transformers
-  version: "0.10.0"
-  tt_metal_commit: e0e0500
-  vllm_commit: 409b1cd
   inference_engine: VLLM
   device_model_specs:
     - device: N150
@@ -209,9 +192,6 @@ templates:
     kmd:
       specifier: ">=2.5.0"
       mode: STRICT
-  version: "0.10.0"
-  tt_metal_commit: e867533
-  vllm_commit: 22be241
   inference_engine: VLLM
   device_model_specs:
     - device: P300
@@ -227,9 +207,6 @@ templates:
 - weights:
     - Qwen/Qwen3-32B
   impl: qwen3_32b_galaxy
-  version: "0.11.1"
-  tt_metal_commit: bac8b34
-  vllm_commit: 7c6685a
   inference_engine: VLLM
   device_model_specs:
     - device: GALAXY
@@ -279,9 +256,6 @@ templates:
 - weights:
     - Qwen/Qwen3-32B
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: e95ffa5
-  vllm_commit: 48eba14
   inference_engine: VLLM
   device_model_specs:
     - device: T3K
@@ -339,9 +313,6 @@ templates:
     kmd:
       specifier: ">=2.4.1"
       mode: STRICT
-  version: "0.10.0"
-  tt_metal_commit: 555f240
-  vllm_commit: 22be241
   inference_engine: VLLM
   device_model_specs:
     - device: P150X8
@@ -368,9 +339,6 @@ templates:
     kmd:
       specifier: ">=2.5.0"
       mode: STRICT
-  version: "0.14.0"
-  tt_metal_commit: 80180b9
-  vllm_commit: 7678b70
   inference_engine: VLLM
   device_model_specs:
     - device: P300X2
@@ -391,9 +359,6 @@ templates:
 - weights:
     - mistralai/Mistral-7B-Instruct-v0.3
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: 9b67e09
-  vllm_commit: a91b644
   inference_engine: VLLM
   device_model_specs:
     - device: N150
@@ -415,8 +380,6 @@ templates:
 - weights:
     - mistralai/Mistral-Small-3.1-24B-Instruct-2503
   impl: tt_transformers
-  tt_metal_commit: 9e3b1b3
-  vllm_commit: 1d0aa18
   inference_engine: VLLM
   device_model_specs:
     - device: T3K
@@ -440,9 +403,6 @@ templates:
 - weights:
     - Qwen/QwQ-32B
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: e95ffa5
-  vllm_commit: 48eba14
   inference_engine: VLLM
   device_model_specs:
     - device: T3K
@@ -480,9 +440,6 @@ templates:
     - Qwen/Qwen2.5-72B
     - Qwen/Qwen2.5-72B-Instruct
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: 13f44c5
-  vllm_commit: 0edd242
   inference_engine: VLLM
   device_model_specs:
     - device: T3K
@@ -528,9 +485,6 @@ templates:
     - Qwen/Qwen2.5-7B
     - Qwen/Qwen2.5-7B-Instruct
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: 5b5db8a
-  vllm_commit: e771fff
   inference_engine: VLLM
   device_model_specs:
     - device: N300
@@ -558,9 +512,6 @@ templates:
     - meta-llama/Llama-3.1-70B-Instruct
     - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
   impl: llama3_70b_galaxy
-  version: "0.10.0"
-  tt_metal_commit: e867533
-  vllm_commit: 8f36910
   inference_engine: VLLM
   device_model_specs:
     - device: GALAXY
@@ -612,9 +563,6 @@ templates:
 - weights:
     - deepseek-ai/DeepSeek-R1-0528
   impl: deepseek_r1_galaxy
-  version: "0.12.0"
-  tt_metal_commit: 805f43d
-  vllm_commit: a45c614
   inference_engine: VLLM
   device_model_specs:
     - device: GALAXY
@@ -674,9 +622,6 @@ templates:
     kmd:
       specifier: ">=2.2.0"
       mode: SUGGESTED
-  version: "0.11.1"
-  tt_metal_commit: 750ca54
-  vllm_commit: 38dee8c
   inference_engine: VLLM
   device_model_specs:
     - device: T3K
@@ -707,9 +652,6 @@ templates:
     - meta-llama/Llama-3.1-70B-Instruct
     - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
   impl: tt_transformers
-  version: "0.10.0"
-  tt_metal_commit: 555f240
-  vllm_commit: 22be241
   inference_engine: VLLM
   device_model_specs:
     - device: P150X4
@@ -765,9 +707,6 @@ templates:
     kmd:
       specifier: ">=2.5.0"
       mode: STRICT
-  version: "0.16.0"
-  tt_metal_commit: 669d59e
-  vllm_commit: "3334377"
   inference_engine: VLLM
   device_model_specs:
     - device: P300X2
@@ -807,9 +746,6 @@ templates:
     kmd:
       specifier: ">=2.1.0"
       mode: STRICT
-  version: "0.2.0"
-  tt_metal_commit: v0.62.0-rc33
-  vllm_commit: e7c329b
   inference_engine: VLLM
   device_model_specs:
     - device: GALAXY_T3K
@@ -840,9 +776,6 @@ templates:
     - meta-llama/Llama-3.2-1B
     - meta-llama/Llama-3.2-1B-Instruct
   impl: tt_transformers
-  version: "0.11.1"
-  tt_metal_commit: 84b4c53
-  vllm_commit: 222ee06
   inference_engine: VLLM
   device_model_specs:
     - device: N150
@@ -871,9 +804,6 @@ templates:
     - meta-llama/Llama-3.2-3B
     - meta-llama/Llama-3.2-3B-Instruct
   impl: tt_transformers
-  version: "0.3.0"
-  tt_metal_commit: 20edc39
-  vllm_commit: 03cb300
   inference_engine: VLLM
   device_model_specs:
     - device: N150
@@ -901,9 +831,6 @@ templates:
     - meta-llama/Llama-3.1-8B
     - meta-llama/Llama-3.1-8B-Instruct
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: 25305db
-  vllm_commit: 6e67d2d
   inference_engine: VLLM
   device_model_specs:
     - device: N150
@@ -939,9 +866,6 @@ templates:
     - meta-llama/Llama-3.1-8B
     - meta-llama/Llama-3.1-8B-Instruct
   impl: tt_transformers
-  version: "0.10.0"
-  tt_metal_commit: 55fd115
-  vllm_commit: aa4ae1e
   inference_engine: VLLM
   device_model_specs:
     - device: P100
@@ -967,9 +891,6 @@ templates:
     - meta-llama/Llama-3.1-8B
     - meta-llama/Llama-3.1-8B-Instruct
   impl: tt_transformers
-  version: "0.10.0"
-  tt_metal_commit: 555f240
-  vllm_commit: 22be241
   inference_engine: VLLM
   device_model_specs:
     - device: P150X4
@@ -999,9 +920,6 @@ templates:
     kmd:
       specifier: ">=2.4.1"
       mode: STRICT
-  version: "0.10.0"
-  tt_metal_commit: 555f240
-  vllm_commit: 22be241
   inference_engine: VLLM
   device_model_specs:
     - device: P150X8
@@ -1030,9 +948,6 @@ templates:
     kmd:
       specifier: ">=2.5.0"
       mode: STRICT
-  version: "0.14.0"
-  tt_metal_commit: 80180b9
-  vllm_commit: 7678b70
   inference_engine: VLLM
   device_model_specs:
     - device: P300X2
@@ -1060,9 +975,6 @@ templates:
     - meta-llama/Llama-3.1-8B
     - meta-llama/Llama-3.1-8B-Instruct
   impl: tt_transformers
-  version: "0.11.1"
-  tt_metal_commit: bac8b34
-  vllm_commit: 7c6685a
   inference_engine: VLLM
   device_model_specs:
     - device: GALAXY
@@ -1104,9 +1016,6 @@ templates:
 - weights:
     - Qwen/Qwen2.5-Coder-32B-Instruct
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: 17a5973
-  vllm_commit: aa4ae1e
   inference_engine: VLLM
   device_model_specs:
     - device: T3K

--- a/workflows/model_specs/dev/video.yaml
+++ b/workflows/model_specs/dev/video.yaml
@@ -7,8 +7,6 @@ templates:
 # =============================================================================
 - weights:
     - genmo/mochi-1-preview
-  version: "0.10.0"
-  tt_metal_commit: 555f240
   impl: tt_transformers
   min_disk_gb: 60
   min_ram_gb: 32
@@ -51,8 +49,6 @@ templates:
 
 - weights:
     - Wan-AI/Wan2.2-T2V-A14B-Diffusers
-  version: "0.14.0"
-  tt_metal_commit: 80180b9
   impl: tt_transformers
   min_disk_gb: 60
   min_ram_gb: 32
@@ -95,8 +91,6 @@ templates:
 
 - weights:
     - Wan-AI/Wan2.2-I2V-A14B-Diffusers
-  version: "0.10.0"
-  tt_metal_commit: 555f240
   impl: tt_transformers
   min_disk_gb: 60
   min_ram_gb: 32

--- a/workflows/model_specs/dev/vlm.yaml
+++ b/workflows/model_specs/dev/vlm.yaml
@@ -9,9 +9,6 @@ templates:
     - google/gemma-3-4b-it
     - google/medgemma-4b-it
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: aecd1d7
-  vllm_commit: 0da90eb
   inference_engine: VLLM
   device_model_specs:
     - device: N150
@@ -66,9 +63,6 @@ templates:
     - google/gemma-3-27b-it
     - google/medgemma-27b-it
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: aecd1d7
-  vllm_commit: 0da90eb
   inference_engine: VLLM
   device_model_specs:
     - device: T3K
@@ -141,9 +135,6 @@ templates:
   impl: tt_transformers
   inference_engine: VLLM
   model_type: VLM
-  version: "0.14.0"
-  tt_metal_commit: 80180b9
-  vllm_commit: 7678b70
   device_model_specs:
     - device: T3K
       max_concurrency: 32
@@ -161,9 +152,6 @@ templates:
 - weights:
     - Qwen/Qwen2.5-VL-3B-Instruct
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: c18569e
-  vllm_commit: b2894d3
   inference_engine: VLLM
   model_type: VLM
   device_model_specs:
@@ -188,9 +176,6 @@ templates:
 - weights:
     - Qwen/Qwen2.5-VL-7B-Instruct
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: c18569e
-  vllm_commit: b2894d3
   inference_engine: VLLM
   model_type: VLM
   device_model_specs:
@@ -215,9 +200,6 @@ templates:
 - weights:
     - Qwen/Qwen2.5-VL-32B-Instruct
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: c18569e
-  vllm_commit: b2894d3
   inference_engine: VLLM
   model_type: VLM
   device_model_specs:
@@ -240,9 +222,6 @@ templates:
 - weights:
     - Qwen/Qwen2.5-VL-72B-Instruct
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: c18569e
-  vllm_commit: b2894d3
   inference_engine: VLLM
   model_type: VLM
   device_model_specs:
@@ -272,9 +251,6 @@ templates:
     - meta-llama/Llama-3.2-11B-Vision
     - meta-llama/Llama-3.2-11B-Vision-Instruct
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: v0.61.1-rc1
-  vllm_commit: 5cbc982
   inference_engine: VLLM
   device_model_specs:
     - device: N300
@@ -295,9 +271,6 @@ templates:
     - meta-llama/Llama-3.2-90B-Vision
     - meta-llama/Llama-3.2-90B-Vision-Instruct
   impl: tt_transformers
-  version: "0.9.0"
-  tt_metal_commit: v0.61.1-rc1
-  vllm_commit: 5cbc982
   inference_engine: VLLM
   device_model_specs:
     - device: T3K


### PR DESCRIPTION
This PR mainly removes `tt_metal_commit`, `vllm_commit`, `version` and `docker_image` fields from the ModelSepc templates in the `dev` catalogue.

These 4 fields are used mainly for generating helm chart values and docs, which are note being generated from the `dev` catalogue, but rather `prod`. The dev catalogue is mainly used for running model specs in Models CI, and there, version of tt_metal, inference server and vllm are taken from GH Action input parameters, not `dev` model spec.

Why we want to remove these fields?

Well, these are the last files which cause conflicts at the ned of every release cycle (Post Release PR), which in turn prevent us from fully automating it.