### PR TITLE
Extend Dynamo deploy script with monitoring and PrefillGateway

### DIFF
--- a/dynamo_frontend/DEPLOY.md
+++ b/dynamo_frontend/DEPLOY.md
@@ -1,9 +1,12 @@
 # Deploying Dynamo Frontend + cpp_server Worker
 
-`deploy.sh` brings up a three-container, etcd-backed stack on the `dynamo-net`
-Docker network — **etcd** (discovery), **cpp_server** (worker), and
-**dynamo-frontend** (HTTP gateway) — then tails the worker's logs. Ctrl+C tears
-all three down.
+`deploy.sh` brings up an etcd-backed Dynamo stack on the `dynamo-net` Docker
+network — **etcd** (discovery), **cpp_server** (worker), and
+**dynamo-frontend** (HTTP gateway) — plus **Prometheus** and **Grafana** from
+`tt-media-server/monitoring/`. With `--prefill-gateway`, it also starts a
+C++ **PrefillGateway**, a managed prefill cpp_server worker, and configures the
+Dynamo-registered cpp_server as decode so requests go through the gateway. It
+then tails the decode worker's logs. Ctrl+C tears the managed containers down.
 
 ## Quick start
 
@@ -21,11 +24,15 @@ build made without `TT_METAL_HOME` runs the mock backend):
 
 ```bash
 cd ../tt-media-server/cpp_server && ./build.sh        # produces build/tt_media_server_cpp
-cd ../../dynamo_frontend && ./deploy.sh --deepseek --local-build
+cd ../../dynamo_frontend
+PROMETHEUS_HOST_PORT=9091 GRAFANA_HOST_PORT=3001 \
+  ./deploy.sh --deepseek --local-build --llm-device-backend mock_pipeline
 ```
 
 `--local-build` bind-mounts `<repo>/tt-media-server/cpp_server/build` over the
 worker image and runs that binary — no `--cpp-server-dir` and no image rebuild.
+`mock_pipeline` avoids the Blaze socket descriptor files that
+`pipeline_manager` expects from a live Blaze runtime.
 
 ## Options
 
@@ -39,15 +46,38 @@ worker image and runs that binary — no `--cpp-server-dir` and no image rebuild
 | `--worker-image <img>`   | `…/tt-media-inference-server-blaze:<tag>` | cpp_server image                                                                |
 | `--frontend-image <img>` | `…/tt-dynamo-frontend:<tag>`              | Dynamo frontend image                                                           |
 | `--device-ids <ids>`     | `10,11,14,15,18,19,22,23`                 | `DEVICE_IDS` env on the worker                                                  |
+| `--llm-device-backend <name>` | `pipeline_manager`                   | `LLM_DEVICE_BACKEND` env on the worker                                          |
+| `--prefill-gateway`      | off                                       | Start PrefillGateway and route decode prefill requests through it               |
+| `--prefill-gateway-image <img>` | `tt-prefill-gateway:dev`          | PrefillGateway image; the default local image is built automatically if missing |
+| `--prefill-gateway-prefill <host:port>` | none                       | External TCP prefill endpoint; repeatable and implies TCP transport             |
+| `--prefill-gateway-prefill-bind <host:port>` | `0.0.0.0:7200`        | ZMQ prefill ROUTER bind endpoint                                                |
+| `--no-monitoring`        | off                                       | Skip Prometheus + Grafana                                                       |
 
 
 Fixed (not flags): network `dynamo-net`, container names `etcd` / `tt-cpp-worker`
-/ `dynamo-frontend`, frontend host port `8080`, `LLM_DEVICE_BACKEND=pipeline_manager`,
-`MODEL_NAME=tt-cpp-server`.
+/ `dynamo-frontend`, monitoring container names `dynamo-prometheus` /
+`dynamo-grafana` / `dynamo-process-exporter`, optional gateway container name
+`prefill-gateway`, optional managed prefill worker container name
+`tt-cpp-prefill-worker`, frontend host port `8080`,
+`LLM_DEVICE_BACKEND=pipeline_manager`, `MODEL_NAME=tt-cpp-server`.
 
-`HF_TOKEN` (for gated models) and perf knobs (`DYN_TOKENIZER`, `RAYON_NUM_THREADS`,
-`DYN_RUNTIME_*`, `RUST_LOG`, `DYN_TX_TRACE`, `DYN_ENABLE_ANTHROPIC_API`) are read
-from the calling shell's environment if set.
+`HF_TOKEN` (for gated models) and perf knobs (`ROUTER_MODE`, `DYN_TOKENIZER`,
+`RAYON_NUM_THREADS`, `DYN_RUNTIME_*`, `RUST_LOG`, `DYN_TX_TRACE`,
+`DYN_ENABLE_ANTHROPIC_API`) are read from the calling shell's environment if
+set. `ROUTER_MODE` defaults to `kv` in this deployment so Dynamo frontend
+timing metrics are emitted; override it if you need a different router.
+`LLM_DEVICE_BACKEND` is also read from the environment and can be overridden
+with `--llm-device-backend`.
+
+Monitoring uses `tt-media-server/monitoring/docker-compose.yml`, attached to
+`dynamo-net` via `TT_NET=dynamo-net`. By default Prometheus scrapes
+`dynamo-frontend:8000` so Dynamo frontend metrics are available immediately.
+Override `SERVER_TARGET`, `SERVER_SERVICE`, `GATEWAY_TARGET`, or
+`GF_HOME_DASHBOARD` in the calling shell if you want a different scrape target
+or dashboard. If another monitoring stack already uses the default ports, set
+`PROMETHEUS_HOST_PORT` or `GRAFANA_HOST_PORT` before running `deploy.sh`.
+When `--prefill-gateway` is enabled and `GATEWAY_TARGET` is not set,
+Prometheus scrapes `prefill-gateway:9091`.
 
 ## What it does, step by step
 
@@ -65,9 +95,20 @@ from the calling shell's environment if set.
   `MODEL_PATH` points at the tokenizer tree **baked into the frontend image**
    (same `fetch_tokenizers.sh` the worker uses), so no tokenizer bind-mount is
    needed.
-5. **Logs** — `docker logs -f tt-cpp-worker`, blocking until you Ctrl+C.
-6. **Teardown** — `trap cleanup EXIT INT TERM` removes the three containers
-  (the `dynamo-net` network is left in place).
+5. **PrefillGateway (optional)** — with `--prefill-gateway`, starts the
+   gateway on `dynamo-net`. The default ZMQ mode binds `0.0.0.0:7200` for
+   prefills and exposes metrics on container port `9091`; the script also
+   starts one managed `LLM_MODE=prefill` cpp_server worker that connects to
+   that bind endpoint. The Dynamo-registered worker runs as `LLM_MODE=decode`
+   with `USE_PREFILL_GATEWAY=1` and
+   `MAX_TOKENS_TO_PREFILL_ON_DECODE=0`, so decode requests route prefill work
+   through the gateway.
+6. **Monitoring** — starts Prometheus + Grafana, with Prometheus attached to
+   `dynamo-net` and scraping the frontend's `/metrics`.
+7. **Logs** — `docker logs -f tt-cpp-worker`, blocking until you Ctrl+C.
+8. **Teardown** — `trap cleanup EXIT INT TERM` stops the monitoring compose
+   stack and removes the Dynamo containers plus the optional PrefillGateway and
+   managed prefill worker (the `dynamo-net` network is left in place).
 
 ## Verify (from a second shell)
 
@@ -77,6 +118,14 @@ curl -s http://localhost:8080/v1/models | jq          # owned_by: "TT Inc"
 curl -sS http://localhost:8080/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{"model":"deepseek-ai/DeepSeek-R1-0528","messages":[{"role":"user","content":"Hello"}],"max_tokens":16}' | jq
+```
+
+Open Prometheus at `http://localhost:${PROMETHEUS_HOST_PORT:-9090}` and Grafana
+at `http://localhost:${GRAFANA_HOST_PORT:-3000}` (`admin` / `admin`).
+Prometheus target health is also available directly:
+
+```bash
+curl -s "http://localhost:${PROMETHEUS_HOST_PORT:-9090}/api/v1/targets" | jq
 ```
 
 Use the `id` returned by `/v1/models` as the `model` (it's the HF id, e.g.
@@ -91,11 +140,33 @@ docker exec etcd etcdctl get --prefix --keys-only v1/
 # v1/mdc/default/backend/generate/<hex>
 ```
 
+If you enabled `--prefill-gateway`, verify that Prometheus sees it:
+
+```bash
+docker exec dynamo-prometheus wget -qO- http://prefill-gateway:9091/metrics | head
+docker exec dynamo-prometheus wget -qO- http://127.0.0.1:9090/api/v1/targets
+```
+
+You can also inspect the gateway health endpoint inside the Docker network:
+
+```bash
+docker exec dynamo-prometheus wget -qO- http://prefill-gateway:9092/health
+```
+
 ## Troubleshooting
 
 - **Worker never registers** — usually a device or model-env problem; the worker
 log dump on timeout shows the cause. On a box without the card, use
-`--local-build` with a mock build to exercise the discovery + frontend wiring.
+`--local-build --llm-device-backend mock_pipeline` with a mock build to
+exercise the discovery + frontend wiring.
+- **Prometheus/Grafana port already allocated** — keep the existing monitoring
+stack running and publish this deployment on alternate ports:
+`PROMETHEUS_HOST_PORT=9091 GRAFANA_HOST_PORT=3001 ./deploy.sh --deepseek`.
+- **PrefillGateway is up but unhealthy** — inspect
+`docker logs prefill-gateway`, `docker logs tt-cpp-prefill-worker`, and
+`docker exec dynamo-prometheus wget -qO- http://prefill-gateway:9092/health`.
+Healthy gateway routing requires one decode connection and at least one
+registered prefill worker.
 - `**/v1/models` is empty** — frontend and worker aren't talking to the same etcd.
 Check `docker exec dynamo-frontend curl -s http://etcd:2379/version` and that
 both use namespace `default` / component `backend` / endpoint `generate`.

--- a/dynamo_frontend/deploy.sh
+++ b/dynamo_frontend/deploy.sh
@@ -2,16 +2,34 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # Fixed names/ports (not CLI-configurable).
 NETWORK_NAME="dynamo-net"
 ETCD_NAME="etcd"
 WORKER_NAME="tt-cpp-worker"
+PREFILL_WORKER_NAME="tt-cpp-prefill-worker"
 FRONTEND_NAME="dynamo-frontend"
 FRONTEND_HOST_PORT="8080"
+PROMETHEUS_HOST_PORT="${PROMETHEUS_HOST_PORT:-9090}"
+GRAFANA_HOST_PORT="${GRAFANA_HOST_PORT:-3000}"
 MODEL_NAME="tt-cpp-server"
-LLM_DEVICE_BACKEND="pipeline_manager"
+LLM_DEVICE_BACKEND="${LLM_DEVICE_BACKEND:-pipeline_manager}"
 WORKER_TOKENIZER_DIR="/home/container_app_user/app/server/cpp_server/tokenizers"
+MONITORING_COMPOSE="${REPO_ROOT}/tt-media-server/monitoring/docker-compose.yml"
+MONITORING_PROJECT_NAME="dynamo-monitoring"
+MONITORING_PROMETHEUS_NAME="dynamo-prometheus"
+MONITORING_GRAFANA_NAME="dynamo-grafana"
+MONITORING_PROCESS_EXPORTER_NAME="dynamo-process-exporter"
+PREFILL_GATEWAY_NAME="prefill-gateway"
+DEFAULT_PREFILL_GATEWAY_IMAGE="tt-prefill-gateway:dev"
+PREFILL_GATEWAY_IMAGE="${PREFILL_GATEWAY_IMAGE:-$DEFAULT_PREFILL_GATEWAY_IMAGE}"
+PREFILL_GATEWAY_DECODE_PORT="${PREFILL_GATEWAY_DECODE_PORT:-7100}"
+PREFILL_GATEWAY_METRICS_PORT="${PREFILL_GATEWAY_METRICS_PORT:-9091}"
+PREFILL_GATEWAY_HEALTH_PORT="${PREFILL_GATEWAY_HEALTH_PORT:-9092}"
+PREFILL_GATEWAY_PREFILL_BIND="${PREFILL_GATEWAY_PREFILL_BIND:-0.0.0.0:7200}"
+PREFILL_GATEWAY_SOCKET_TRANSPORT="${PREFILL_GATEWAY_SOCKET_TRANSPORT:-zmq}"
+PREFILL_WORKER_PORT="${PREFILL_WORKER_PORT:-8001}"
 
 # Image defaults (override with the matching flag if needed).
 ETCD_IMAGE="quay.io/coreos/etcd:v3.5.13"
@@ -27,9 +45,56 @@ DEVICE_IDS="10,11,14,15,18,19,22,23"
 # runs the local binary; defaults to the in-repo cpp_server so no path is needed.
 LOCAL_BUILD=""
 CPP_SERVER_DIR="${SCRIPT_DIR}/../tt-media-server/cpp_server"
+MONITORING_ENABLED=1
+MONITORING_STARTED=0
+PREFILL_GATEWAY_ENABLED=0
+PREFILL_GATEWAY_STARTED=0
+PREFILL_WORKER_STARTED=0
+PREFILL_GATEWAY_PREFILLS=()
 
 log() { printf '[deploy] %s\n' "$*"; }
 die() { printf '[deploy] %s\n' "$*" >&2; exit 1; }
+
+port_in_use() {
+    local port="$1"
+    if command -v ss >/dev/null 2>&1; then
+        [[ -n "$(ss -ltnH "sport = :${port}" 2>/dev/null)" ]] && return 0
+    fi
+    (echo >"/dev/tcp/127.0.0.1/${port}") >/dev/null 2>&1
+}
+
+require_host_port_free() {
+    local port="$1"
+    local label="$2"
+    local override_env="${3:-}"
+    if port_in_use "$port"; then
+        if [[ -n "$override_env" ]]; then
+            die "${label} host port ${port} is already in use. Set ${override_env}=<free-port> and rerun, or use --no-monitoring."
+        fi
+        die "${label} host port ${port} is already in use."
+    fi
+}
+
+ensure_prefill_gateway_image() {
+    if docker image inspect "$PREFILL_GATEWAY_IMAGE" >/dev/null 2>&1; then
+        return
+    fi
+
+    if [[ "$PREFILL_GATEWAY_IMAGE" != "$DEFAULT_PREFILL_GATEWAY_IMAGE" ]]; then
+        die "prefill gateway image not found: $PREFILL_GATEWAY_IMAGE"
+    fi
+
+    log "building prefill gateway image ($PREFILL_GATEWAY_IMAGE)"
+    docker build \
+        -f "${REPO_ROOT}/tt-media-server/Dockerfile.gateway" \
+        -t "$PREFILL_GATEWAY_IMAGE" \
+        "$REPO_ROOT" >/dev/null
+}
+
+endpoint_port() {
+    local endpoint="$1"
+    printf '%s' "${endpoint##*:}"
+}
 
 usage() {
     cat >&2 <<EOF
@@ -41,9 +106,24 @@ Usage: $0 [options]
   --worker-image <img>         (default: ${WORKER_IMAGE})
   --frontend-image <img>       (default: ${FRONTEND_IMAGE})
   --device-ids <ids>           cpp_server DEVICE_IDS (default: ${DEVICE_IDS})
+  --llm-device-backend <name>   cpp_server LLM_DEVICE_BACKEND (default: ${LLM_DEVICE_BACKEND})
+  --prefill-gateway            start PrefillGateway and route decode prefill requests through it
+  --prefill-gateway-image <img> (default: ${PREFILL_GATEWAY_IMAGE}; auto-builds default if missing)
+  --prefill-gateway-prefill <host:port>
+                               TCP prefill endpoint; repeatable, implies tcp transport
+  --prefill-gateway-prefill-bind <host:port>
+                               ZMQ prefill bind endpoint (default: ${PREFILL_GATEWAY_PREFILL_BIND})
+  --no-monitoring              skip Prometheus + Grafana deployment
 
-HF_TOKEN and perf knobs (DYN_TOKENIZER, RAYON_NUM_THREADS, DYN_RUNTIME_*,
-RUST_LOG, DYN_TX_TRACE, DYN_ENABLE_ANTHROPIC_API) are read from the environment.
+LLM_DEVICE_BACKEND, HF_TOKEN, and perf knobs (ROUTER_MODE, DYN_TOKENIZER,
+RAYON_NUM_THREADS, DYN_RUNTIME_*, RUST_LOG, DYN_TX_TRACE,
+DYN_ENABLE_ANTHROPIC_API) are read from the environment.
+
+Monitoring is enabled by default and uses tt-media-server/monitoring/docker-compose.yml.
+Override SERVER_TARGET/SERVER_SERVICE/GATEWAY_TARGET/GF_HOME_DASHBOARD in the
+environment if you want Prometheus to scrape a different container or dashboard.
+Set PROMETHEUS_HOST_PORT/GRAFANA_HOST_PORT if 9090/3000 are already in use.
+Prefill gateway knobs can also be set through PREFILL_GATEWAY_* environment variables.
 EOF
     exit 1
 }
@@ -58,6 +138,21 @@ while [[ $# -gt 0 ]]; do
         --worker-image)   WORKER_IMAGE="$2";                shift 2 ;;
         --frontend-image) FRONTEND_IMAGE="$2";              shift 2 ;;
         --device-ids)     DEVICE_IDS="$2";                  shift 2 ;;
+        --llm-device-backend) LLM_DEVICE_BACKEND="$2";      shift 2 ;;
+        --prefill-gateway) PREFILL_GATEWAY_ENABLED=1;       shift ;;
+        --prefill-gateway-image) PREFILL_GATEWAY_IMAGE="$2"; shift 2 ;;
+        --prefill-gateway-prefill)
+            PREFILL_GATEWAY_ENABLED=1
+            PREFILL_GATEWAY_SOCKET_TRANSPORT=tcp
+            PREFILL_GATEWAY_PREFILLS+=(--prefill="$2")
+            shift 2
+            ;;
+        --prefill-gateway-prefill-bind)
+            PREFILL_GATEWAY_ENABLED=1
+            PREFILL_GATEWAY_PREFILL_BIND="$2"
+            shift 2
+            ;;
+        --no-monitoring)  MONITORING_ENABLED=0;             shift ;;
         *) echo "Unknown argument: $1" >&2; usage ;;
     esac
 done
@@ -75,8 +170,41 @@ if [[ -n "$LOCAL_BUILD" ]]; then
     WORKER_ENTRYPOINT+=(--entrypoint /bin/bash)
 fi
 
+if [[ "$MONITORING_ENABLED" == "1" ]]; then
+    [[ -f "$MONITORING_COMPOSE" ]] || die "monitoring compose file not found: $MONITORING_COMPOSE"
+    docker compose version >/dev/null 2>&1 || die "docker compose is required for monitoring"
+fi
+if [[ "$PREFILL_GATEWAY_ENABLED" == "1" ]]; then
+    ensure_prefill_gateway_image
+    if [[ "$PREFILL_GATEWAY_SOCKET_TRANSPORT" == "tcp" && "${#PREFILL_GATEWAY_PREFILLS[@]}" -eq 0 ]]; then
+        die "--prefill-gateway-prefill is required when PREFILL_GATEWAY_SOCKET_TRANSPORT=tcp"
+    fi
+fi
+
+require_host_port_free 2379 "etcd"
+require_host_port_free "$FRONTEND_HOST_PORT" "Dynamo frontend"
+if [[ "$MONITORING_ENABLED" == "1" ]]; then
+    require_host_port_free "$PROMETHEUS_HOST_PORT" "Prometheus" "PROMETHEUS_HOST_PORT"
+    require_host_port_free "$GRAFANA_HOST_PORT" "Grafana" "GRAFANA_HOST_PORT"
+fi
+
 cleanup() {
     log "tearing down"
+    if [[ "${MONITORING_STARTED:-0}" == "1" ]]; then
+        TT_NET="$NETWORK_NAME" \
+            PROMETHEUS_CONTAINER_NAME="$MONITORING_PROMETHEUS_NAME" \
+            GRAFANA_CONTAINER_NAME="$MONITORING_GRAFANA_NAME" \
+            PROCESS_EXPORTER_CONTAINER_NAME="$MONITORING_PROCESS_EXPORTER_NAME" \
+            PROMETHEUS_HOST_PORT="$PROMETHEUS_HOST_PORT" \
+            GRAFANA_HOST_PORT="$GRAFANA_HOST_PORT" \
+            docker compose -p "$MONITORING_PROJECT_NAME" -f "$MONITORING_COMPOSE" down >/dev/null 2>&1 || true
+    fi
+    if [[ "${PREFILL_GATEWAY_STARTED:-0}" == "1" ]]; then
+        docker rm -f "$PREFILL_GATEWAY_NAME" >/dev/null 2>&1 || true
+    fi
+    if [[ "${PREFILL_WORKER_STARTED:-0}" == "1" ]]; then
+        docker rm -f "$PREFILL_WORKER_NAME" >/dev/null 2>&1 || true
+    fi
     docker rm -f "$FRONTEND_NAME" "$WORKER_NAME" "$ETCD_NAME" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT INT TERM
@@ -99,6 +227,33 @@ done
 [[ -n "${ETCD_OK:-}" ]] || { docker logs --tail 50 "$ETCD_NAME" >&2 || true; die "etcd never became healthy"; }
 log "etcd healthy"
 
+if [[ "$PREFILL_GATEWAY_ENABLED" == "1" ]]; then
+    docker ps -a --format '{{.Names}}' | grep -q "^${PREFILL_GATEWAY_NAME}\$" \
+        && die "container already exists: ${PREFILL_GATEWAY_NAME}"
+
+    PREFILL_GATEWAY_ARGS=(
+        --decode-port="$PREFILL_GATEWAY_DECODE_PORT"
+        --metrics-port="$PREFILL_GATEWAY_METRICS_PORT"
+        --health-port="$PREFILL_GATEWAY_HEALTH_PORT"
+    )
+    if [[ "$PREFILL_GATEWAY_SOCKET_TRANSPORT" == "tcp" ]]; then
+        PREFILL_GATEWAY_ARGS+=("${PREFILL_GATEWAY_PREFILLS[@]}")
+    else
+        PREFILL_GATEWAY_ARGS+=(--prefill-bind="$PREFILL_GATEWAY_PREFILL_BIND")
+    fi
+
+    log "starting PrefillGateway ($PREFILL_GATEWAY_IMAGE)"
+    docker run -d --name "$PREFILL_GATEWAY_NAME" --network "$NETWORK_NAME" \
+        -e SOCKET_TRANSPORT="$PREFILL_GATEWAY_SOCKET_TRANSPORT" \
+        "$PREFILL_GATEWAY_IMAGE" \
+        "${PREFILL_GATEWAY_ARGS[@]}" >/dev/null
+    PREFILL_GATEWAY_STARTED=1
+
+    sleep 2
+    docker ps --format '{{.Names}}' | grep -q "^${PREFILL_GATEWAY_NAME}\$" \
+        || { docker logs --tail 80 "$PREFILL_GATEWAY_NAME" >&2 || true; die "PrefillGateway exited during startup"; }
+fi
+
 # ── worker ────────────────────────────────────────────────────────────────
 DEVICE_ARGS=()
 [[ -e /dev/tenstorrent ]] && DEVICE_ARGS+=(--device /dev/tenstorrent --cap-add=SYS_NICE)
@@ -111,6 +266,51 @@ case "$HF_MODEL_ID" in
     *)         WORKER_MODEL_ENV+=(-e USE_DEEPSEEK_MD_FORMAT=1 -e BLAZE_SOCKET_DESCRIPTOR_PREFIX=deepseek) ;;
 esac
 
+if [[ "$PREFILL_GATEWAY_ENABLED" == "1" && "$PREFILL_GATEWAY_SOCKET_TRANSPORT" != "tcp" ]]; then
+    PREFILL_CONNECT_PORT="$(endpoint_port "$PREFILL_GATEWAY_PREFILL_BIND")"
+    PREFILL_WORKER_COMMAND=()
+    if [[ -n "$LOCAL_BUILD" ]]; then
+        PREFILL_WORKER_COMMAND=(-c "cd cpp_server && ./build/tt_media_server_cpp -p ${PREFILL_WORKER_PORT}")
+    fi
+
+    log "starting managed prefill worker ($WORKER_IMAGE)"
+    docker run -d --name "$PREFILL_WORKER_NAME" --network "$NETWORK_NAME" --shm-size=2g \
+        "${DEVICE_ARGS[@]}" "${LOCAL_BUILD_MOUNT[@]}" "${WORKER_ENTRYPOINT[@]}" \
+        -e DYNAMO_ENDPOINT_ENABLED=0 \
+        -e SERVER_MODE=cpp \
+        -e MODEL="$HF_MODEL_ID" \
+        -e LLM_DEVICE_BACKEND="$LLM_DEVICE_BACKEND" \
+        -e LLM_MODE=prefill \
+        -e USE_PREFILL_GATEWAY=1 \
+        -e SOCKET_TRANSPORT="$PREFILL_GATEWAY_SOCKET_TRANSPORT" \
+        -e SOCKET_HOST="$PREFILL_GATEWAY_NAME" \
+        -e SOCKET_PORT="$PREFILL_CONNECT_PORT" \
+        -e PREFILL_SERVER_ID=managed-prefill-0 \
+        -e DEVICE_IDS="$DEVICE_IDS" \
+        "${WORKER_MODEL_ENV[@]}" \
+        -e MAX_SESSIONS_COUNT=128 -e TT_LOG_LEVEL=debug -e USE_FAST_MODE=1 \
+        "$WORKER_IMAGE" \
+        "${PREFILL_WORKER_COMMAND[@]}" \
+        >/dev/null
+    PREFILL_WORKER_STARTED=1
+
+    sleep 2
+    docker ps --format '{{.Names}}' | grep -q "^${PREFILL_WORKER_NAME}\$" \
+        || { docker logs --tail 80 "$PREFILL_WORKER_NAME" >&2 || true; die "managed prefill worker exited during startup"; }
+fi
+
+WORKER_GATEWAY_ENV=()
+if [[ "$PREFILL_GATEWAY_ENABLED" == "1" ]]; then
+    WORKER_GATEWAY_ENV+=(
+        -e LLM_MODE=decode
+        -e USE_PREFILL_GATEWAY=1
+        -e MAX_TOKENS_TO_PREFILL_ON_DECODE="${MAX_TOKENS_TO_PREFILL_ON_DECODE:-0}"
+        -e SOCKET_TRANSPORT="$PREFILL_GATEWAY_SOCKET_TRANSPORT"
+        -e SOCKET_HOST="$PREFILL_GATEWAY_NAME"
+        -e SOCKET_PORT="$PREFILL_GATEWAY_DECODE_PORT"
+    )
+fi
+
 log "starting worker ($WORKER_IMAGE)"
 docker run -d --name "$WORKER_NAME" --network "$NETWORK_NAME" --shm-size=2g \
     "${DEVICE_ARGS[@]}" "${LOCAL_BUILD_MOUNT[@]}" "${WORKER_ENTRYPOINT[@]}" \
@@ -122,6 +322,7 @@ docker run -d --name "$WORKER_NAME" --network "$NETWORK_NAME" --shm-size=2g \
     -e MODEL="$HF_MODEL_ID" \
     -e LLM_DEVICE_BACKEND="$LLM_DEVICE_BACKEND" \
     -e DEVICE_IDS="$DEVICE_IDS" \
+    "${WORKER_GATEWAY_ENV[@]}" \
     "${WORKER_MODEL_ENV[@]}" \
     -e MAX_SESSIONS_COUNT=128 -e TT_LOG_LEVEL=debug -e USE_FAST_MODE=1 \
     -e DYN_TX_TRACE="${DYN_TX_TRACE:-}" \
@@ -161,8 +362,40 @@ docker run -d --name "$FRONTEND_NAME" --network "$NETWORK_NAME" -p "${FRONTEND_H
     -e DYN_TOKENIZER="${DYN_TOKENIZER:-fastokens}" \
     -e DYN_DEBUG_PERF="${DYN_DEBUG_PERF:-0}" \
     -e DYN_ENABLE_ANTHROPIC_API="${DYN_ENABLE_ANTHROPIC_API:-true}" \
+    -e ROUTER_MODE="${ROUTER_MODE:-kv}" \
     -e RUST_LOG="${RUST_LOG:-}" \
     "$FRONTEND_IMAGE" >/dev/null
 
-log "frontend on http://localhost:${FRONTEND_HOST_PORT} — tailing worker logs (Ctrl+C to tear down)"
+if [[ "$MONITORING_ENABLED" == "1" ]]; then
+    MONITORING_SERVER_TARGET="${SERVER_TARGET:-${FRONTEND_NAME}:8000}"
+    MONITORING_SERVER_SERVICE="${SERVER_SERVICE:-dynamo_frontend}"
+    if [[ "$PREFILL_GATEWAY_ENABLED" == "1" ]]; then
+        MONITORING_GATEWAY_TARGET="${GATEWAY_TARGET:-${PREFILL_GATEWAY_NAME}:${PREFILL_GATEWAY_METRICS_PORT}}"
+    else
+        MONITORING_GATEWAY_TARGET="${GATEWAY_TARGET:-prefill-gateway:9091}"
+    fi
+
+    log "starting Prometheus + Grafana (scraping ${MONITORING_SERVER_TARGET})"
+    TT_NET="$NETWORK_NAME" \
+        PROMETHEUS_CONTAINER_NAME="$MONITORING_PROMETHEUS_NAME" \
+        GRAFANA_CONTAINER_NAME="$MONITORING_GRAFANA_NAME" \
+        PROCESS_EXPORTER_CONTAINER_NAME="$MONITORING_PROCESS_EXPORTER_NAME" \
+        PROMETHEUS_HOST_PORT="$PROMETHEUS_HOST_PORT" \
+        GRAFANA_HOST_PORT="$GRAFANA_HOST_PORT" \
+        SERVER_TARGET="$MONITORING_SERVER_TARGET" \
+        SERVER_SERVICE="$MONITORING_SERVER_SERVICE" \
+        GATEWAY_TARGET="$MONITORING_GATEWAY_TARGET" \
+        GF_HOME_DASHBOARD="${GF_HOME_DASHBOARD:-}" \
+        docker compose -p "$MONITORING_PROJECT_NAME" -f "$MONITORING_COMPOSE" up -d >/dev/null
+    MONITORING_STARTED=1
+fi
+
+log "frontend on http://localhost:${FRONTEND_HOST_PORT}"
+if [[ "$MONITORING_ENABLED" == "1" ]]; then
+    log "Prometheus on http://localhost:${PROMETHEUS_HOST_PORT}; Grafana on http://localhost:${GRAFANA_HOST_PORT} (admin/admin)"
+fi
+if [[ "$PREFILL_GATEWAY_ENABLED" == "1" ]]; then
+    log "PrefillGateway metrics on ${PREFILL_GATEWAY_NAME}:${PREFILL_GATEWAY_METRICS_PORT} inside ${NETWORK_NAME}"
+fi
+log "tailing worker logs (Ctrl+C to tear down)"
 docker logs -f "$WORKER_NAME"

--- a/tt-media-server/monitoring/docker-compose.yml
+++ b/tt-media-server/monitoring/docker-compose.yml
@@ -24,10 +24,10 @@
 services:
   prometheus:
     image: prom/prometheus:v2.51.0
-    container_name: tt_prometheus
+    container_name: ${PROMETHEUS_CONTAINER_NAME:-tt_prometheus}
     restart: unless-stopped
     ports:
-      - "9090:9090"
+      - "${PROMETHEUS_HOST_PORT:-9090}:9090"
     environment:
       - SERVER_TARGET=${SERVER_TARGET:-tt-inference-server:8000}
       - SERVER_SERVICE=${SERVER_SERVICE:-python}
@@ -58,7 +58,7 @@ services:
   # on either server's side.
   process-exporter:
     image: ncabatoff/process-exporter:0.8.7
-    container_name: tt_process_exporter
+    container_name: ${PROCESS_EXPORTER_CONTAINER_NAME:-tt_process_exporter}
     restart: unless-stopped
     pid: host
     privileged: true          # needed to read /proc/<pid> across namespaces
@@ -73,10 +73,10 @@ services:
 
   grafana:
     image: grafana/grafana:10.4.2
-    container_name: tt_grafana
+    container_name: ${GRAFANA_CONTAINER_NAME:-tt_grafana}
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "${GRAFANA_HOST_PORT:-3000}:3000"
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false


### PR DESCRIPTION
- Extend `dynamo_frontend/deploy.sh` to deploy Prometheus and Grafana alongside etcd, cpp_server, and Dynamo frontend.
- Add optional `--prefill-gateway` mode that starts PrefillGateway plus a managed prefill worker and routes decode prefill requests through it.
- Make monitoring container names and host ports configurable so this stack can coexist with existing monitoring deployments.
