### PR TITLE
Fix Use-After-Free Server Crash in Server Metrics

### DIFF
--- a/tt-media-server/cpp_server/include/metrics/metrics.hpp
+++ b/tt-media-server/cpp_server/include/metrics/metrics.hpp
@@ -204,6 +204,12 @@ class ServerMetrics {
   prometheus::Gauge* decoding_requests_{nullptr};
   prometheus::Gauge* active_sessions_{nullptr};
   prometheus::Family<prometheus::Gauge>* slot_blocks_family_{nullptr};
+  // Serializes Add()/Set()/Remove() on slot_blocks_family_. prometheus-cpp's
+  // Family::Add returns a Gauge& that Family::Remove invalidates (destroys), so
+  // a concurrent setSlotBlocks (Add+Set) and removeSlot (Add+Remove) on the
+  // same slot id is a use-after-free on the Gauge. Mock assigns every session
+  // slotId=0 -> one shared gauge -> this races constantly under load.
+  std::mutex slot_blocks_mutex_;
 
   // --- latency summaries (exact quantiles via CKMS, 60 s sliding window) ---
   prometheus::Summary* e2e_latency_seconds_{nullptr};

--- a/tt-media-server/cpp_server/include/metrics/metrics.hpp
+++ b/tt-media-server/cpp_server/include/metrics/metrics.hpp
@@ -204,11 +204,7 @@ class ServerMetrics {
   prometheus::Gauge* decoding_requests_{nullptr};
   prometheus::Gauge* active_sessions_{nullptr};
   prometheus::Family<prometheus::Gauge>* slot_blocks_family_{nullptr};
-  // Serializes Add()/Set()/Remove() on slot_blocks_family_. prometheus-cpp's
-  // Family::Add returns a Gauge& that Family::Remove invalidates (destroys), so
-  // a concurrent setSlotBlocks (Add+Set) and removeSlot (Add+Remove) on the
-  // same slot id is a use-after-free on the Gauge. Mock assigns every session
-  // slotId=0 -> one shared gauge -> this races constantly under load.
+
   std::mutex slot_blocks_mutex_;
 
   // --- latency summaries (exact quantiles via CKMS, 60 s sliding window) ---

--- a/tt-media-server/cpp_server/src/metrics/metrics.cpp
+++ b/tt-media-server/cpp_server/src/metrics/metrics.cpp
@@ -242,7 +242,10 @@ void ServerMetrics::setActiveSessionsCount(double n) {
 void ServerMetrics::setSlotBlocks(uint32_t slotId, double blocks) {
   // Called at turn-end prefix registration — session-lifecycle frequency.
   // Family::Add is idempotent for identical labels, so this reuses the
-  // existing gauge for the slot.
+  // existing gauge for the slot. Locked against removeSlot: the Gauge& from
+  // Add() must not be Set() while another thread is Remove()-ing (destroying)
+  // it — that is a use-after-free.
+  std::lock_guard<std::mutex> lock(slot_blocks_mutex_);
   slot_blocks_family_
       ->Add({{"model_name", model_name_}, {"slot_id", std::to_string(slotId)}})
       .Set(blocks);
@@ -251,7 +254,10 @@ void ServerMetrics::setSlotBlocks(uint32_t slotId, double blocks) {
 void ServerMetrics::removeSlot(uint32_t slotId) {
   // Drop the series so Prometheus stops reporting a stale value after the
   // slot is deallocated. Add() returns the existing gauge (or creates one),
-  // which Remove() then deletes from the family.
+  // which Remove() then deletes from the family. Locked against setSlotBlocks
+  // (see above): Remove() destroys the Gauge that a concurrent Add().Set()
+  // could still be writing.
+  std::lock_guard<std::mutex> lock(slot_blocks_mutex_);
   auto& gauge = slot_blocks_family_->Add(
       {{"model_name", model_name_}, {"slot_id", std::to_string(slotId)}});
   slot_blocks_family_->Remove(&gauge);

--- a/tt-media-server/cpp_server/src/metrics/metrics.cpp
+++ b/tt-media-server/cpp_server/src/metrics/metrics.cpp
@@ -242,9 +242,7 @@ void ServerMetrics::setActiveSessionsCount(double n) {
 void ServerMetrics::setSlotBlocks(uint32_t slotId, double blocks) {
   // Called at turn-end prefix registration — session-lifecycle frequency.
   // Family::Add is idempotent for identical labels, so this reuses the
-  // existing gauge for the slot. Locked against removeSlot: the Gauge& from
-  // Add() must not be Set() while another thread is Remove()-ing (destroying)
-  // it — that is a use-after-free.
+  // existing gauge for the slot.
   std::lock_guard<std::mutex> lock(slot_blocks_mutex_);
   slot_blocks_family_
       ->Add({{"model_name", model_name_}, {"slot_id", std::to_string(slotId)}})


### PR DESCRIPTION
## Problem
A data race (use-after-free) existed in `ServerMetrics` `setSlotBlocks` and `removeSlot` operate on the same Prometheus gauge but weren't synchronized, so a concurrent `setSlotBlocks` (which writes the gauge) and `removeSlot` (which destroys it) could free the gauge out from under a thread still writing to it.

This resulted in the following error on higher server load:
```
malloc(): unaligned tcache chunk detected
```

Notably, neither TSan/ASan, or several other third-party tools I tried caught this. The root cause lives in prometheus-cpp, a third-party library that isn't built from source with instrumentation, so the sanitizers were blind to it and the timing overhead they add further masked the race. Worth keeping in mind for the future.

## Testing
Testing was done on high server load, witch bench like this (**num-prompts = 10 000**):
```
vllm bench serve \
  --model 'deepseek-ai/DeepSeek-R1-0528' \
  --tokenizer 'cpp_server/tokenizers/deepseek-ai/DeepSeek-R1-0528' \
  --backend openai-chat \
  --endpoint /v1/chat/completions \
  --dataset-name random \
  --random-input-len 128 \
  --random-output-len 128 \
  --num-prompts 10000 \
  --max-concurrency 64 \
  --save-result \
  --result-filename "vllm-bench-mock.json" \
  --host dynamo-frontend 2>&1 | tee bench_mock_output.txt
```