### PR TITLE
Fix Blaze slot manager missing sstream include

### DIFF
--- a/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_slot_manager.hpp
+++ b/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_slot_manager.hpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <cstdint>
 #include <optional>
+#include <sstream>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
CI run before fix: https://github.com/tenstorrent/tt-inference-server/actions/runs/27583506695
CI run after fix: https://github.com/tenstorrent/tt-inference-server/actions/runs/27601275800