### PR TITLE
Fix ZMQ server readiness before ROUTER peer identity

### DIFF
--- a/tt-media-server/cpp_server/include/sockets/socket_transport_state.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_transport_state.hpp
@@ -28,11 +28,11 @@ class SocketTransportState {
 
   bool isConnectedState() const { return connected_; }
 
-  std::string getStatusString() const {
+  std::string getStatusString(bool connected) const {
     if (!running_) {
       return "stopped";
     }
-    if (connected_) {
+    if (connected) {
       return mode_ == Mode::SERVER ? "server:connected" : "client:connected";
     }
     return mode_ == Mode::SERVER ? "server:waiting" : "client:connecting";

--- a/tt-media-server/cpp_server/include/sockets/zmq_socket_transport.hpp
+++ b/tt-media-server/cpp_server/include/sockets/zmq_socket_transport.hpp
@@ -97,6 +97,7 @@ class ZmqSocketTransport : public ISocketTransport,
 
   std::vector<uint8_t>
       peerId_;  // ROUTER stores the connected DEALER's identity.
+  std::atomic<bool> routerPeerReady{false};
 
   ZmqSendQueue<SendRequest> sendQueue;
 

--- a/tt-media-server/cpp_server/src/sockets/tcp_socket_transport.cpp
+++ b/tt-media-server/cpp_server/src/sockets/tcp_socket_transport.cpp
@@ -438,7 +438,9 @@ TcpSocketTransport::ReceiveResult TcpSocketTransport::receiveExact(
 
 bool TcpSocketTransport::isConnected() const { return isConnectedState(); }
 
-std::string TcpSocketTransport::getStatus() const { return getStatusString(); }
+std::string TcpSocketTransport::getStatus() const {
+  return getStatusString(isConnectedState());
+}
 
 void TcpSocketTransport::setConnectionLostCallback(
     std::function<void()> callback) {

--- a/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
+++ b/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
@@ -164,6 +164,7 @@ void ZmqSocketTransport::stop() {
   ioActive_ = false;
   monitorActive_ = false;
   connected_ = false;
+  routerPeerReady = false;
   sendQueue.notifyStopped();
 
   if (ioThread_.joinable()) {
@@ -221,6 +222,9 @@ void ZmqSocketTransport::monitorLoop(std::stop_token stopToken,
         }
       } else if (eventId == ZMQ_EVENT_DISCONNECTED) {
         bool wasConnected = connected_.exchange(false);
+        if (mode_ == Mode::SERVER) {
+          routerPeerReady = false;
+        }
         if (wasConnected) {
           TT_LOG_DEBUG("[ZmqSocketTransport] Peer disconnected ({})",
                        modeName());
@@ -234,9 +238,22 @@ void ZmqSocketTransport::monitorLoop(std::stop_token stopToken,
   }
 }
 
-bool ZmqSocketTransport::isConnected() const { return isConnectedState(); }
+bool ZmqSocketTransport::isConnected() const {
+  if (mode_ == Mode::SERVER) {
+    return isConnectedState() && routerPeerReady.load();
+  }
+  return isConnectedState();
+}
 
-std::string ZmqSocketTransport::getStatus() const { return getStatusString(); }
+std::string ZmqSocketTransport::getStatus() const {
+  if (mode_ == Mode::SERVER) {
+    if (!running_) {
+      return "stopped";
+    }
+    return isConnected() ? "server:connected" : "server:waiting";
+  }
+  return getStatusString();
+}
 
 bool ZmqSocketTransport::sendRawData(std::span<const uint8_t> data) {
   if (!running_ || !ioActive_) return false;
@@ -313,8 +330,8 @@ void ZmqSocketTransport::failPendingSends() {
 
 bool ZmqSocketTransport::sendAsRouter(const std::vector<uint8_t>& data) {
   // ROUTER must prefix every outgoing message with the peer's identity.
-  if (peerId_.empty()) {
-    TT_LOG_ERROR(
+  if (!routerPeerReady.load()) {
+    TT_LOG_DEBUG(
         "[ZmqSocketTransport] Cannot send — no peer identity known yet");
     return false;
   }
@@ -357,6 +374,7 @@ std::vector<uint8_t> ZmqSocketTransport::receiveAsRouter() {
 
   peerId_.assign(static_cast<uint8_t*>(identity.data()),
                  static_cast<uint8_t*>(identity.data()) + identity.size());
+  routerPeerReady = true;
 
   if (!identity.more()) return {};
 

--- a/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
+++ b/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
@@ -246,13 +246,7 @@ bool ZmqSocketTransport::isConnected() const {
 }
 
 std::string ZmqSocketTransport::getStatus() const {
-  if (mode_ == Mode::SERVER) {
-    if (!running_) {
-      return "stopped";
-    }
-    return isConnected() ? "server:connected" : "server:waiting";
-  }
-  return getStatusString();
+  return getStatusString(isConnected());
 }
 
 bool ZmqSocketTransport::sendRawData(std::span<const uint8_t> data) {

--- a/tt-media-server/prefill_gateway/tests/gateway_e2e_test.cpp
+++ b/tt-media-server/prefill_gateway/tests/gateway_e2e_test.cpp
@@ -1104,6 +1104,33 @@ TEST(ZmqSocketOptionsTest, AppliesHeartbeatsAndMandatoryRouterSends) {
   context.close();
 }
 
+TEST(ZmqSocketTransportTest, ServerIsConnectedOnlyAfterPeerIdentityIsKnown) {
+  const uint16_t port = ephemeralPort();
+
+  tt::sockets::ZmqSocketTransport server;
+  ASSERT_TRUE(server.initializeAsServer(port));
+  server.start();
+
+  tt::sockets::ZmqSocketTransport client;
+  ASSERT_TRUE(client.initializeAsClient("127.0.0.1", port));
+  client.start();
+
+  EXPECT_EQ(server.getStatus(), "server:waiting");
+  EXPECT_FALSE(server.isConnected());
+
+  tt::sockets::PrefillRegistrationMessage registration;
+  registration.server_id = "prefill-A";
+  registration.max_in_flight = 4;
+  ASSERT_TRUE(client.sendRawData(tt::sockets::wire::serializeMessage(
+      tt::sockets::tags::PREFILL_REGISTRATION, registration)));
+
+  ASSERT_TRUE(waitFor([&] { return server.isConnected(); }));
+  EXPECT_EQ(server.getStatus(), "server:connected");
+
+  client.stop();
+  server.stop();
+}
+
 TEST(ZmqPrefillRouterTest, SendFailsWhenRegisteredPeerIsNoLongerRoutable) {
   const uint16_t port = ephemeralPort();
 


### PR DESCRIPTION
Updates ZMQ server-side connection readiness so isConnected() only reports true once the ROUTER has learned a peer identity. This avoids misleading startup errors from health probes sending before the socket is routable