### PR TITLE
Use Trantor Thread Pool in Dynamo Protocol

### DIFF
--- a/tt-media-server/cpp_server/include/dynamo/dynamo_endpoint.hpp
+++ b/tt-media-server/cpp_server/include/dynamo/dynamo_endpoint.hpp
@@ -87,7 +87,6 @@ class DynamoEndpoint {
   Options options_;
 
   std::unique_ptr<DynamoServer> server_;
-  std::thread server_thread_;
   std::thread keepalive_thread_;
   std::unique_ptr<trantor::EventLoopThreadPool> loop_pool_;
   std::atomic<bool> running_{false};

--- a/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
+++ b/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
@@ -23,10 +23,18 @@
 #include <atomic>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+namespace trantor {
+class EventLoop;
+class TcpServer;
+class TcpConnection;
+class MsgBuffer;
+}  // namespace trantor
 
 namespace tt::dynamo {
 
@@ -232,21 +240,22 @@ struct ServerConfig {
 
 class DynamoServer {
  public:
-  DynamoServer(ServerConfig config, GenerateHandler handler);
+  DynamoServer(ServerConfig config, GenerateHandler handler,
+               std::vector<trantor::EventLoop*> io_loops);
   ~DynamoServer();
 
   DynamoServer(const DynamoServer&) = delete;
   DynamoServer& operator=(const DynamoServer&) = delete;
 
-  /// Start listening. Blocks the calling thread; intended to run in its own
-  /// thread.
-  void run();
+  /// Bind the listener on the supplied io loops and start serving.
+  /// Non-blocking: the loops are driven by their own threads.
+  void start();
 
-  /// Stop the accept loop and close the listen socket. Safe to call from any
-  /// thread.
+  /// Stop the listener and force-close live connections. Safe to call from
+  /// any thread.
   void shutdown();
 
-  /// Bound port (valid after `run()` has bound, or 0 when not bound yet).
+  /// Bound port (valid after `start()`).
   uint16_t port() const { return actual_port_; }
 
   const ServerConfig& config() const { return config_; }
@@ -254,14 +263,15 @@ class DynamoServer {
  private:
   ServerConfig config_;
   GenerateHandler handler_;
-  int listen_fd_ = -1;
+  std::vector<trantor::EventLoop*> io_loops_;
+  std::unique_ptr<trantor::TcpServer> tcp_server_;
   uint16_t actual_port_ = 0;
   std::atomic<bool> running_{false};
 
-  void handle_connection(int client_fd);
-  bool read_exact(int fd, std::vector<uint8_t>& buf, size_t n);
-  bool read_request(int fd, TcpRequestMessage& msg);
-  void process_request(int fd, const TcpRequestMessage& msg);
+  void onMessage(const std::shared_ptr<trantor::TcpConnection>& conn,
+                 trantor::MsgBuffer* buf);
+  void process_request(const std::shared_ptr<trantor::TcpConnection>& conn,
+                       const TcpRequestMessage& msg);
   void stream_response(const TcpStreamConnectionInfo& conn_info,
                        const std::string& request_id,
                        const GenerateRequest& gen_req);

--- a/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
+++ b/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
@@ -32,6 +32,7 @@
 namespace trantor {
 class EventLoop;
 class TcpServer;
+class TcpClient;
 class TcpConnection;
 class MsgBuffer;
 }  // namespace trantor
@@ -218,13 +219,66 @@ GenerateRequest parse_generate_request(const std::vector<uint8_t>& body_bytes);
 // ---------------------------------------------------------------------------
 
 /**
- * Generate handler: invoked once per inbound request. Push tokens via
- * `send_chunk`; the server framework calls the call-home response stream and
- * the trailing sentinels for you.
+ * Generate handler: invoked once per inbound request on the io loop. The
+ * handler owns the call-home response stream (a DynamoStreamWriter) for the
+ * supplied connection info and returns without blocking.
  */
-using GenerateHandler =
-    std::function<void(const GenerateRequest& request,
-                       std::function<bool(const TokenChunk&)> send_chunk)>;
+using GenerateHandler = std::function<void(
+    const GenerateRequest& request, const TcpStreamConnectionInfo& conn_info)>;
+
+/**
+ * Owns the outbound call-home connection for a single request and streams
+ * framed response chunks to the frontend without blocking the caller.
+ *
+ * Mirrors the HTTP StreamingResponseWriter: token callbacks (on the LLMService
+ * consumer thread) only `queueInLoop` onto the loop that owns the connection;
+ * every socket write happens on that loop. A self-reference taken once the
+ * connection is established keeps the writer (and its buffered sentinels) alive
+ * until the peer closes, so a graceful shutdown is never truncated by the
+ * TcpClient's abortive destructor.
+ */
+class DynamoStreamWriter
+    : public std::enable_shared_from_this<DynamoStreamWriter> {
+ public:
+  static std::shared_ptr<DynamoStreamWriter> create(
+      trantor::EventLoop* loop, TcpStreamConnectionInfo conn_info,
+      std::string request_id, std::function<void()> on_disconnect);
+
+  /// Dial the frontend's call-home address. Non-blocking.
+  void connect();
+
+  /// Queue a chunk for delivery. Returns false once the stream is terminal
+  /// (error frame sent or peer gone), signalling the caller to stop.
+  bool sendChunk(const TokenChunk& chunk);
+
+  /// Queue the trailing sentinels and close. No-op once terminal.
+  void finalize();
+
+ private:
+  DynamoStreamWriter(trantor::EventLoop* loop,
+                     TcpStreamConnectionInfo conn_info, std::string request_id,
+                     std::function<void()> on_disconnect);
+
+  void onConnState(const std::shared_ptr<trantor::TcpConnection>& conn);
+  void ensurePrologue();
+  void writeOrBuffer(std::string bytes);
+  void closeStream();
+
+  trantor::EventLoop* loop_;
+  TcpStreamConnectionInfo conn_info_;
+  std::string request_id_;
+  std::function<void()> on_disconnect_;
+
+  std::shared_ptr<trantor::TcpClient> client_;
+  // The members below are touched only on `loop_`.
+  std::shared_ptr<trantor::TcpConnection> conn_;
+  std::shared_ptr<DynamoStreamWriter> self_guard_;
+  std::vector<std::string> early_buffer_;
+  bool connected_ = false;
+  bool prologue_sent_ = false;
+  bool closed_ = false;
+  std::atomic<bool> done_{false};
+};
 
 struct ServerConfig {
   std::string bind_host = "0.0.0.0";
@@ -272,9 +326,6 @@ class DynamoServer {
                  trantor::MsgBuffer* buf);
   void process_request(const std::shared_ptr<trantor::TcpConnection>& conn,
                        const TcpRequestMessage& msg);
-  void stream_response(const TcpStreamConnectionInfo& conn_info,
-                       const std::string& request_id,
-                       const GenerateRequest& gen_req);
 };
 
 }  // namespace tt::dynamo

--- a/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
+++ b/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
@@ -224,7 +224,7 @@ GenerateRequest parse_generate_request(const std::vector<uint8_t>& body_bytes);
  * supplied connection info and returns without blocking.
  */
 using GenerateHandler = std::function<void(
-    const GenerateRequest& request, const TcpStreamConnectionInfo& conn_info)>;
+    const GenerateRequest& request, const TcpStreamConnectionInfo& connInfo)>;
 
 /**
  * Owns the outbound call-home connection for a single request and streams
@@ -241,8 +241,8 @@ class DynamoStreamWriter
     : public std::enable_shared_from_this<DynamoStreamWriter> {
  public:
   static std::shared_ptr<DynamoStreamWriter> create(
-      trantor::EventLoop* loop, TcpStreamConnectionInfo conn_info,
-      std::string request_id, std::function<void()> on_disconnect);
+      trantor::EventLoop* loop, TcpStreamConnectionInfo connInfo,
+      std::string requestId, std::function<void()> onDisconnect);
 
   /// Dial the frontend's call-home address. Non-blocking.
   void connect();
@@ -255,9 +255,8 @@ class DynamoStreamWriter
   void finalize();
 
  private:
-  DynamoStreamWriter(trantor::EventLoop* loop,
-                     TcpStreamConnectionInfo conn_info, std::string request_id,
-                     std::function<void()> on_disconnect);
+  DynamoStreamWriter(trantor::EventLoop* loop, TcpStreamConnectionInfo connInfo,
+                     std::string requestId, std::function<void()> onDisconnect);
 
   void onConnState(const std::shared_ptr<trantor::TcpConnection>& conn);
   void ensurePrologue();
@@ -295,7 +294,7 @@ struct ServerConfig {
 class DynamoServer {
  public:
   DynamoServer(ServerConfig config, GenerateHandler handler,
-               std::vector<trantor::EventLoop*> io_loops);
+               std::vector<trantor::EventLoop*> ioLoops);
   ~DynamoServer();
 
   DynamoServer(const DynamoServer&) = delete;

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
@@ -455,27 +455,14 @@ void DynamoEndpoint::start() {
   sc.model_name = options_.model_name;
   sc.model_path = options_.model_path;
 
-  server_ = std::make_unique<DynamoServer>(sc, makeGenerateHandler());
-
-  // Spawn the accept loop in its own thread so we can fall through to
-  // discovery registration once the port is bound.
-  server_thread_ = std::thread([this]() {
-    try {
-      server_->run();
-    } catch (const std::exception& e) {
-      TT_LOG_ERROR("[DynamoEndpoint] server thread terminated: {}", e.what());
-    }
-  });
-
-  // Wait for the listener to bind (port becomes non-zero). Bounded poll —
-  // bind is synchronous in run() right after socket creation.
-  for (int i = 0; i < 50 && server_->port() == 0 && running_; ++i) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  }
+  // start() binds and listens on the pool loops synchronously; the resolved
+  // port is available immediately afterwards.
+  server_ = std::make_unique<DynamoServer>(sc, makeGenerateHandler(),
+                                           loop_pool_->getLoops());
+  server_->start();
   if (server_->port() == 0) {
     running_ = false;
-    throw std::runtime_error(
-        "DynamoEndpoint: server failed to bind within timeout");
+    throw std::runtime_error("DynamoEndpoint: server failed to bind");
   }
 
   DiscoveryConfig dc;
@@ -531,7 +518,6 @@ void DynamoEndpoint::stop() {
   }
 
   if (keepalive_thread_.joinable()) keepalive_thread_.join();
-  if (server_thread_.joinable()) server_thread_.join();
   if (loop_pool_) {
     // EventLoopThreadPool has no explicit stop(); destruction joins all
     // threads.

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
@@ -171,7 +171,7 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
   trantor::EventLoopThreadPool* pool = loop_pool_.get();
 
   return [pipeline, pool](const GenerateRequest& dynReq,
-                          std::function<bool(const TokenChunk&)> sendChunk) {
+                          const TcpStreamConnectionInfo& connInfo) {
     using SteadyClock = std::chrono::steady_clock;
     const auto recvT = SteadyClock::now();
     const std::string probeId = dynReq.raw.get("request_id", "").asString();
@@ -215,19 +215,19 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
     TT_LOG_INFO("[DynamoLatency] id={} stage=dispatched loop_tid={}",
                 probeId.empty() ? "?" : probeId, loopTid);
 
-    // Block the dynamo per-request worker thread until the streaming
-    // callback signals completion. Using a shared_ptr + future lets the
-    // pipeline callbacks (which run on the LLMService consumer thread)
-    // complete the future safely even if this lambda is being torn down.
-    auto done = std::make_shared<std::promise<void>>();
-    auto future = done->get_future();
-    auto signalDone = [done]() {
-      try {
-        done->set_value();
-      } catch (...) {
-        // future already satisfied (e.g. multiple final chunks); ignore.
-      }
+    // The call-home writer owns the outbound connection and streams chunks
+    // asynchronously on the loop — no blocking, no per-request thread. The
+    // pipeline callbacks below are unchanged: sendChunk/signalDone forward to
+    // it.
+    auto writer = DynamoStreamWriter::create(
+        loop, connInfo, probeId,
+        [svc, taskId = req->task_id]() { svc->abortRequest(taskId); });
+    writer->connect();
+
+    auto sendChunk = [writer](const TokenChunk& chunk) {
+      return writer->sendChunk(chunk);
     };
+    auto signalDone = [writer]() { writer->finalize(); };
 
     auto cancelFn = [svc, taskId = req->task_id]() {
       svc->abortRequest(taskId);
@@ -247,8 +247,6 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
                   " tokens): prompt_tokens=" + std::to_string(promptTokens);
       err.error_code = 400;
       sendChunk(err);
-      signalDone();
-      future.wait();
       return;
     }
 
@@ -423,8 +421,6 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
           signalDone();
         },
         std::move(cancelFn));
-
-    future.wait();
   };
 }
 

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
@@ -7,8 +7,14 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
+#include <trantor/net/EventLoop.h>
+#include <trantor/net/InetAddress.h>
+#include <trantor/net/TcpConnection.h>
+#include <trantor/net/TcpServer.h>
+#include <trantor/utils/MsgBuffer.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
@@ -322,8 +328,11 @@ std::vector<uint8_t> encode_stream_final() {
 // DynamoServer implementation
 // ---------------------------------------------------------------------------
 
-DynamoServer::DynamoServer(ServerConfig config, GenerateHandler handler)
-    : config_(std::move(config)), handler_(std::move(handler)) {
+DynamoServer::DynamoServer(ServerConfig config, GenerateHandler handler,
+                           std::vector<trantor::EventLoop*> io_loops)
+    : config_(std::move(config)),
+      handler_(std::move(handler)),
+      io_loops_(std::move(io_loops)) {
   if (config_.instance_id == 0) {
     std::srand(static_cast<unsigned>(std::time(nullptr) ^ ::getpid()));
     config_.instance_id = (static_cast<uint64_t>(std::rand()) << 32) |
@@ -339,57 +348,51 @@ DynamoServer::DynamoServer(ServerConfig config, GenerateHandler handler)
 DynamoServer::~DynamoServer() { shutdown(); }
 
 void DynamoServer::shutdown() {
-  bool wasRunning = running_.exchange(false);
-  if (listen_fd_ >= 0) {
-    int fd = listen_fd_;
-    listen_fd_ = -1;
-    ::shutdown(fd, SHUT_RDWR);
-    ::close(fd);
-  }
-  (void)wasRunning;
+  running_.store(false);
+  if (tcp_server_) tcp_server_->stop();
 }
 
-bool DynamoServer::read_exact(int fd, std::vector<uint8_t>& buf, size_t n) {
-  buf.resize(n);
-  size_t total = 0;
-  while (total < n) {
-    ssize_t r = ::read(fd, buf.data() + total, n - total);
-    if (r <= 0) return false;
-    total += static_cast<size_t>(r);
-  }
-  return true;
-}
+void DynamoServer::onMessage(const trantor::TcpConnectionPtr& conn,
+                             trantor::MsgBuffer* buf) {
+  // Frame: [path_len:u16][path][headers_len:u16][headers][payload_len:u32]
+  //        [payload]. Extract every complete frame the buffer holds; leave a
+  // partial frame for the next callback.
+  while (running_.load()) {
+    const size_t avail = buf->readableBytes();
+    if (avail < 2) return;
+    const uint8_t* p = reinterpret_cast<const uint8_t*>(buf->peek());
 
-bool DynamoServer::read_request(int fd, TcpRequestMessage& msg) {
-  std::vector<uint8_t> tmp;
-  if (!read_exact(fd, tmp, 2)) return false;
-  uint16_t pathLen = get_u16_be(tmp.data());
+    const uint16_t pathLen = get_u16_be(p);
+    const size_t afterPath = 2u + pathLen + 2u;
+    if (avail < afterPath) return;
 
-  if (!read_exact(fd, tmp, pathLen)) return false;
-  msg.endpoint_path.assign(tmp.begin(), tmp.end());
+    const uint16_t headersLen = get_u16_be(p + 2 + pathLen);
+    const size_t afterHeaders = afterPath + headersLen + 4u;
+    if (avail < afterHeaders) return;
 
-  if (!read_exact(fd, tmp, 2)) return false;
-  uint16_t headersLen = get_u16_be(tmp.data());
+    const uint32_t payloadLen = get_u32_be(p + afterPath + headersLen);
+    const size_t total = afterHeaders + payloadLen;
+    if (avail < total) return;
 
-  if (headersLen > 0) {
-    if (!read_exact(fd, tmp, headersLen)) return false;
-    Json::Value j = parseJsonBytes(tmp.data(), tmp.size());
-    if (j.isObject()) {
-      for (auto it = j.begin(); it != j.end(); ++it) {
-        msg.headers[it.name()] = (*it).asString();
+    TcpRequestMessage msg;
+    msg.endpoint_path.assign(p + 2, p + 2 + pathLen);
+    if (headersLen > 0) {
+      Json::Value j = parseJsonBytes(p + afterPath, headersLen);
+      if (j.isObject()) {
+        for (auto it = j.begin(); it != j.end(); ++it) {
+          msg.headers[it.name()] = (*it).asString();
+        }
       }
     }
+    msg.payload.assign(p + afterHeaders, p + total);
+    buf->retrieve(total);
+
+    process_request(conn, msg);
   }
-
-  if (!read_exact(fd, tmp, 4)) return false;
-  uint32_t payloadLen = get_u32_be(tmp.data());
-
-  if (!read_exact(fd, tmp, payloadLen)) return false;
-  msg.payload = std::move(tmp);
-  return true;
 }
 
-void DynamoServer::process_request(int fd, const TcpRequestMessage& msg) {
+void DynamoServer::process_request(const trantor::TcpConnectionPtr& conn,
+                                   const TcpRequestMessage& msg) {
   TwoPartMessage twoPart = decode_two_part(msg.payload);
   auto ctrl = parse_control_message(twoPart.header);
   auto genReq = parse_generate_request(twoPart.body);
@@ -399,20 +402,14 @@ void DynamoServer::process_request(int fd, const TcpRequestMessage& msg) {
       "[DynamoServer] Request id={} input_tokens={} max_tokens={} address={}",
       ctrl.id, genReq.token_ids.size(), genReq.max_tokens, connInfo.address);
 
-  // ACK on the inbound connection (caller is still in the read loop on
-  // `fd`, so ACKs stay in the same order the frontend pipelined the
-  // requests in — Dynamo's reader task on the frontend matches ACKs to
-  // pending requests in FIFO order on a per-connection basis).
+  // ACK on the inbound connection. onMessage runs on the connection's io
+  // loop, so sends stay in the FIFO order the frontend pipelined requests in.
   auto ack = encode_tcp_response();
-  if (!writeAll(fd, ack)) {
-    TT_LOG_WARN("[DynamoServer] Failed to send ACK for id={}", ctrl.id);
-    return;
-  }
+  conn->send(reinterpret_cast<const char*>(ack.data()), ack.size());
 
-  // Off-thread the slow path (LLMService dispatch + call-home streaming)
-  // so the read loop on `fd` can immediately consume the next pipelined
-  // request. `stream_response` opens its own outbound socket and never
-  // touches `fd`, so concurrent streams don't share state.
+  // Off-thread the slow path (LLMService dispatch + call-home streaming) so
+  // the io loop can keep reading the next pipelined request. `stream_response`
+  // opens its own outbound socket and never touches the inbound connection.
   std::thread([this, connInfo = std::move(connInfo), requestId = ctrl.id,
                genReq = std::move(genReq)]() {
     stream_response(connInfo, requestId, genReq);
@@ -631,60 +628,36 @@ void DynamoServer::stream_response(const TcpStreamConnectionInfo& connInfo,
   ::close(sock);
 }
 
-void DynamoServer::handle_connection(int clientFd) {
-  int flag = 1;
-  ::setsockopt(clientFd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
-
-  while (running_) {
-    TcpRequestMessage msg;
-    if (!read_request(clientFd, msg)) break;
-    process_request(clientFd, msg);
+void DynamoServer::start() {
+  if (io_loops_.empty()) {
+    throw std::runtime_error("DynamoServer: no io loops provided");
   }
 
-  ::close(clientFd);
-}
+  running_.store(true);
+  trantor::InetAddress addr(config_.bind_host, config_.bind_port);
+  tcp_server_ = std::make_unique<trantor::TcpServer>(io_loops_.front(), addr,
+                                                     "DynamoServer");
+  tcp_server_->setIoLoops(io_loops_);
+  // Port 0 is resolved during the acceptor's bind, which happens in the
+  // TcpServer constructor — so the assigned port is available synchronously.
+  actual_port_ = tcp_server_->address().toPort();
 
-void DynamoServer::run() {
-  listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
-  if (listen_fd_ < 0) {
-    throw std::runtime_error("DynamoServer: failed to create listen socket");
-  }
+  tcp_server_->setAfterAcceptSockOptCallback([](int fd) {
+    int one = 1;
+    if (::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one)) < 0) {
+      TT_LOG_WARN("[DynamoServer] Failed to set TCP_NODELAY: {}",
+                  strerror(errno));
+    }
+  });
+  tcp_server_->setRecvMessageCallback(
+      [this](const trantor::TcpConnectionPtr& conn, trantor::MsgBuffer* buf) {
+        onMessage(conn, buf);
+      });
+  tcp_server_->start();
 
-  int opt = 1;
-  ::setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-
-  struct sockaddr_in bindAddr{};
-  bindAddr.sin_family = AF_INET;
-  bindAddr.sin_port = htons(config_.bind_port);
-  ::inet_pton(AF_INET, config_.bind_host.c_str(), &bindAddr.sin_addr);
-
-  if (::bind(listen_fd_, reinterpret_cast<struct sockaddr*>(&bindAddr),
-             sizeof(bindAddr)) < 0) {
-    throw std::runtime_error("DynamoServer: failed to bind");
-  }
-
-  struct sockaddr_in actual{};
-  socklen_t len = sizeof(actual);
-  ::getsockname(listen_fd_, reinterpret_cast<struct sockaddr*>(&actual), &len);
-  actual_port_ = ntohs(actual.sin_port);
-
-  if (::listen(listen_fd_, 128) < 0) {
-    throw std::runtime_error("DynamoServer: failed to listen");
-  }
-
-  running_ = true;
   TT_LOG_INFO("[DynamoServer] Listening on {}:{}  ({}.{}.{}, instance={})",
               config_.bind_host, actual_port_, config_.namespace_name,
               config_.component, config_.endpoint, config_.instance_id_hex);
-
-  while (running_) {
-    int clientFd = ::accept(listen_fd_, nullptr, nullptr);
-    if (clientFd < 0) {
-      if (!running_) break;
-      continue;
-    }
-    std::thread([this, clientFd]() { handle_connection(clientFd); }).detach();
-  }
 }
 
 }  // namespace tt::dynamo

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
@@ -293,10 +293,10 @@ std::vector<uint8_t> encode_stream_final() {
 // ---------------------------------------------------------------------------
 
 DynamoServer::DynamoServer(ServerConfig config, GenerateHandler handler,
-                           std::vector<trantor::EventLoop*> io_loops)
+                           std::vector<trantor::EventLoop*> ioLoops)
     : config_(std::move(config)),
       handler_(std::move(handler)),
-      io_loops_(std::move(io_loops)) {
+      io_loops_(std::move(ioLoops)) {
   if (config_.instance_id == 0) {
     std::srand(static_cast<unsigned>(std::time(nullptr) ^ ::getpid()));
     config_.instance_id = (static_cast<uint64_t>(std::rand()) << 32) |
@@ -381,21 +381,21 @@ void DynamoServer::process_request(const trantor::TcpConnectionPtr& conn,
 // ---------------------------------------------------------------------------
 
 std::shared_ptr<DynamoStreamWriter> DynamoStreamWriter::create(
-    trantor::EventLoop* loop, TcpStreamConnectionInfo conn_info,
-    std::string request_id, std::function<void()> on_disconnect) {
+    trantor::EventLoop* loop, TcpStreamConnectionInfo connInfo,
+    std::string requestId, std::function<void()> onDisconnect) {
   return std::shared_ptr<DynamoStreamWriter>(
-      new DynamoStreamWriter(loop, std::move(conn_info), std::move(request_id),
-                             std::move(on_disconnect)));
+      new DynamoStreamWriter(loop, std::move(connInfo), std::move(requestId),
+                             std::move(onDisconnect)));
 }
 
 DynamoStreamWriter::DynamoStreamWriter(trantor::EventLoop* loop,
-                                       TcpStreamConnectionInfo conn_info,
-                                       std::string request_id,
-                                       std::function<void()> on_disconnect)
+                                       TcpStreamConnectionInfo connInfo,
+                                       std::string requestId,
+                                       std::function<void()> onDisconnect)
     : loop_(loop),
-      conn_info_(std::move(conn_info)),
-      request_id_(std::move(request_id)),
-      on_disconnect_(std::move(on_disconnect)) {}
+      conn_info_(std::move(connInfo)),
+      request_id_(std::move(requestId)),
+      on_disconnect_(std::move(onDisconnect)) {}
 
 void DynamoStreamWriter::connect() {
   const auto colon = conn_info_.address.rfind(':');

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
@@ -9,6 +9,7 @@
 #include <sys/socket.h>
 #include <trantor/net/EventLoop.h>
 #include <trantor/net/InetAddress.h>
+#include <trantor/net/TcpClient.h>
 #include <trantor/net/TcpConnection.h>
 #include <trantor/net/TcpServer.h>
 #include <trantor/utils/MsgBuffer.h>
@@ -27,34 +28,6 @@
 namespace tt::dynamo {
 
 namespace {
-
-/// Enables verbose per-chunk send tracing. Set DYN_TX_TRACE=1 (or any
-/// non-zero/non-"false" value) to log a [DynamoTx] line for every
-/// TokenChunk written to the call-home socket. Useful for verifying
-/// whether inter-token latency is incurred on the wire (here) or in the
-/// frontend's SSE delivery path.
-///
-/// Read once on first call; result is cached for the lifetime of the
-/// process so we don't pay getenv() per token.
-bool txTraceEnabled() {
-  static const bool kEnabled = [] {
-    const char* v = std::getenv("DYN_TX_TRACE");
-    if (v == nullptr) return false;
-    std::string s(v);
-    if (s.empty() || s == "0" || s == "false" || s == "FALSE" || s == "False" ||
-        s == "off" || s == "OFF") {
-      return false;
-    }
-    return true;
-  }();
-  return kEnabled;
-}
-
-using SteadyClock = std::chrono::steady_clock;
-
-int64_t microsBetween(SteadyClock::time_point a, SteadyClock::time_point b) {
-  return std::chrono::duration_cast<std::chrono::microseconds>(b - a).count();
-}
 
 /// Parse JSON bytes into a Json::Value. Returns an empty value on parse error
 /// (callers treat that as "skip").
@@ -80,18 +53,9 @@ std::string dumpJsonCompact(const Json::Value& v) {
   return Json::writeString(writer, v);
 }
 
-bool writeAll(int fd, const uint8_t* data, size_t len) {
-  size_t written = 0;
-  while (written < len) {
-    ssize_t w = ::write(fd, data + written, len - written);
-    if (w <= 0) return false;
-    written += static_cast<size_t>(w);
-  }
-  return true;
-}
-
-bool writeAll(int fd, const std::vector<uint8_t>& data) {
-  return writeAll(fd, data.data(), data.size());
+std::string framedString(const TwoPartMessage& tp) {
+  auto framed = encode_two_part(tp);
+  return std::string(framed.begin(), framed.end());
 }
 
 }  // namespace
@@ -407,225 +371,159 @@ void DynamoServer::process_request(const trantor::TcpConnectionPtr& conn,
   auto ack = encode_tcp_response();
   conn->send(reinterpret_cast<const char*>(ack.data()), ack.size());
 
-  // Off-thread the slow path (LLMService dispatch + call-home streaming) so
-  // the io loop can keep reading the next pipelined request. `stream_response`
-  // opens its own outbound socket and never touches the inbound connection.
-  std::thread([this, connInfo = std::move(connInfo), requestId = ctrl.id,
-               genReq = std::move(genReq)]() {
-    stream_response(connInfo, requestId, genReq);
-  }).detach();
+  // The handler creates the async call-home writer and returns without
+  // blocking, so dispatch runs inline on the io loop — no per-request thread.
+  handler_(genReq, connInfo);
 }
 
-void DynamoServer::stream_response(const TcpStreamConnectionInfo& connInfo,
-                                   const std::string& requestId,
-                                   const GenerateRequest& genReq) {
-  auto colonPos = connInfo.address.rfind(':');
-  if (colonPos == std::string::npos) {
-    TT_LOG_ERROR("[DynamoServer] Invalid response address: {}",
-                 connInfo.address);
+// ---------------------------------------------------------------------------
+// DynamoStreamWriter
+// ---------------------------------------------------------------------------
+
+std::shared_ptr<DynamoStreamWriter> DynamoStreamWriter::create(
+    trantor::EventLoop* loop, TcpStreamConnectionInfo conn_info,
+    std::string request_id, std::function<void()> on_disconnect) {
+  return std::shared_ptr<DynamoStreamWriter>(
+      new DynamoStreamWriter(loop, std::move(conn_info), std::move(request_id),
+                             std::move(on_disconnect)));
+}
+
+DynamoStreamWriter::DynamoStreamWriter(trantor::EventLoop* loop,
+                                       TcpStreamConnectionInfo conn_info,
+                                       std::string request_id,
+                                       std::function<void()> on_disconnect)
+    : loop_(loop),
+      conn_info_(std::move(conn_info)),
+      request_id_(std::move(request_id)),
+      on_disconnect_(std::move(on_disconnect)) {}
+
+void DynamoStreamWriter::connect() {
+  const auto colon = conn_info_.address.rfind(':');
+  uint16_t port = 0;
+  bool ok = colon != std::string::npos;
+  std::string host;
+  if (ok) {
+    host = conn_info_.address.substr(0, colon);
+    try {
+      port = static_cast<uint16_t>(
+          std::stoi(conn_info_.address.substr(colon + 1)));
+    } catch (const std::exception&) {
+      ok = false;
+    }
+  }
+  if (!ok) {
+    TT_LOG_ERROR("[DynamoTx] id={} invalid response address: {}", request_id_,
+                 conn_info_.address);
+    if (!done_.exchange(true) && on_disconnect_) on_disconnect_();
     return;
   }
-  std::string host = connInfo.address.substr(0, colonPos);
-  uint16_t port =
-      static_cast<uint16_t>(std::stoi(connInfo.address.substr(colonPos + 1)));
 
-  const bool txTrace = txTraceEnabled();
+  client_ = std::make_shared<trantor::TcpClient>(
+      loop_, trantor::InetAddress(host, port), "DynamoCallHome");
+  std::weak_ptr<DynamoStreamWriter> weak = shared_from_this();
+  client_->setConnectionCallback([weak](const trantor::TcpConnectionPtr& c) {
+    if (auto self = weak.lock()) self->onConnState(c);
+  });
+  client_->setConnectionErrorCallback([weak]() {
+    if (auto self = weak.lock()) {
+      TT_LOG_WARN("[DynamoTx] id={} call-home connect failed",
+                  self->request_id_);
+      if (!self->done_.exchange(true) && self->on_disconnect_)
+        self->on_disconnect_();
+    }
+  });
+  client_->connect();
+}
 
-  // Timing reference for the whole call-home leg. Stage timings are deltas
-  // from this point so we can correlate against the frontend's
-  // worker_recv_to_first_chunk_ms / dispatch_to_first_chunk_ms logs and
-  // against client-side TTFT/ITL measurements.
-  const auto tStart = SteadyClock::now();
+void DynamoStreamWriter::onConnState(const trantor::TcpConnectionPtr& conn) {
+  if (conn->connected()) {
+    conn->setTcpNoDelay(true);
+    conn_ = conn;
+    connected_ = true;
+    // Stay alive until the peer closes so a graceful shutdown is not truncated
+    // by ~TcpClient's forceClose once the pipeline callbacks are released.
+    self_guard_ = shared_from_this();
 
-  int sock = ::socket(AF_INET, SOCK_STREAM, 0);
-  if (sock < 0) {
-    TT_LOG_ERROR("[DynamoServer] Failed to create socket for response stream");
-    return;
-  }
-  int flag = 1;
-  ::setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
-
-  struct sockaddr_in addr{};
-  addr.sin_family = AF_INET;
-  addr.sin_port = htons(port);
-  ::inet_pton(AF_INET, host.c_str(), &addr.sin_addr);
-
-  const auto tConnectStart = SteadyClock::now();
-  if (::connect(sock, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) <
-      0) {
-    TT_LOG_ERROR("[DynamoServer] Failed to connect to response stream at {}",
-                 connInfo.address);
-    ::close(sock);
-    return;
-  }
-  const auto tConnected = SteadyClock::now();
-  TT_LOG_INFO("[DynamoTx] id={} stage=connected connect_us={}", requestId,
-              microsBetween(tConnectStart, tConnected));
-
-  // 1. CallHomeHandshake (header-only TwoPartMessage).
-  {
     Json::Value handshake(Json::objectValue);
-    handshake["subject"] = connInfo.subject;
+    handshake["subject"] = conn_info_.subject;
     handshake["stream_type"] = "response";
     std::string hs = dumpJsonCompact(handshake);
-
     TwoPartMessage tp;
     tp.header.assign(hs.begin(), hs.end());
-    const auto tBefore = SteadyClock::now();
-    if (!writeAll(sock, encode_two_part(tp))) {
-      TT_LOG_WARN("[DynamoServer] Failed to send handshake (id={})", requestId);
-      ::close(sock);
-      return;
-    }
-    const auto tAfter = SteadyClock::now();
-    TT_LOG_INFO(
-        "[DynamoTx] id={} stage=handshake_sent write_us={} since_start_us={}",
-        requestId, microsBetween(tBefore, tAfter),
-        microsBetween(tStart, tAfter));
+    conn_->send(framedString(tp));
+
+    for (const auto& b : early_buffer_) conn_->send(b);
+    early_buffer_.clear();
+    if (closed_) conn_->shutdown();
+  } else {
+    connected_ = false;
+    conn_.reset();
+    if (!done_.exchange(true) && on_disconnect_) on_disconnect_();
+    // Release the self-reference on a fresh tick so we never destroy the
+    // TcpClient from inside its own callback.
+    if (self_guard_) loop_->queueInLoop([g = std::move(self_guard_)]() {});
   }
+}
 
-  // 2. ResponseStreamPrologue + streaming.
-  //    The prologue carries either error=null (success) or error="<msg>"
-  //    (pre-stream rejection). We defer sending the prologue until the first
-  //    chunk arrives so the handler can signal an error via TokenChunk::error.
-  size_t chunkSeq = 0;
-  size_t totalTokens = 0;
-  size_t totalBytes = 0;
-  SteadyClock::time_point tFirstChunk{};
-  SteadyClock::time_point tPrevChunk{};
-  bool sawFirstChunk = false;
-  bool prologueSent = false;
-  bool hadError = false;
+void DynamoStreamWriter::ensurePrologue() {
+  if (prologue_sent_) return;
+  prologue_sent_ = true;
+  Json::Value prologue(Json::objectValue);
+  prologue["error"] = Json::Value::null;
+  std::string ps = dumpJsonCompact(prologue);
+  TwoPartMessage tp;
+  tp.header.assign(ps.begin(), ps.end());
+  writeOrBuffer(framedString(tp));
+}
 
-  auto sendPrologue = [&](const Json::Value& errorVal) -> bool {
-    Json::Value prologue(Json::objectValue);
-    prologue["error"] = errorVal;
-    std::string ps = dumpJsonCompact(prologue);
+void DynamoStreamWriter::writeOrBuffer(std::string bytes) {
+  if (connected_ && conn_)
+    conn_->send(bytes);
+  else
+    early_buffer_.push_back(std::move(bytes));
+}
 
-    TwoPartMessage tp;
-    tp.header.assign(ps.begin(), ps.end());
-    const auto tBefore = SteadyClock::now();
-    if (!writeAll(sock, encode_two_part(tp))) {
-      TT_LOG_WARN("[DynamoServer] Failed to send prologue (id={})", requestId);
-      return false;
-    }
-    const auto tAfter = SteadyClock::now();
-    TT_LOG_INFO(
-        "[DynamoTx] id={} stage=prologue_sent write_us={} since_start_us={}",
-        requestId, microsBetween(tBefore, tAfter),
-        microsBetween(tStart, tAfter));
-    prologueSent = true;
-    return true;
-  };
+void DynamoStreamWriter::closeStream() {
+  if (closed_) return;
+  closed_ = true;
+  if (connected_ && conn_) conn_->shutdown();
+}
 
-  handler_(genReq, [&](const TokenChunk& chunk) -> bool {
-    // Always send a success prologue first (even for error chunks).
-    if (!prologueSent) {
-      if (!sendPrologue(Json::Value::null)) {
-        return false;
-      }
-    }
+bool DynamoStreamWriter::sendChunk(const TokenChunk& chunk) {
+  if (done_.load()) return false;
+  const bool isError = chunk.error.has_value();
 
-    // If the chunk carries an error, send it as an Annotated::error frame and
-    // abort. The Dynamo frontend's check_for_backend_error() will intercept
-    // this and map it to an HTTP 4xx/5xx response.
-    if (chunk.error.has_value()) {
-      hadError = true;
-      // Send the error as an Annotated::error frame, then stop.
-      auto chunkBytes = encode_stream_chunk(chunk);
-      TwoPartMessage errTp;
-      errTp.body = std::move(chunkBytes);
-      writeAll(sock, encode_two_part(errTp));
-      return false;
-    }
+  TwoPartMessage tp;
+  auto body = encode_stream_chunk(chunk);
+  tp.body.assign(body.begin(), body.end());
+  std::string bytes = framedString(tp);
 
-    auto chunkBytes = encode_stream_chunk(chunk);
-    const size_t bytesOut = chunkBytes.size() + sizeof(uint64_t) * 3;
-    TwoPartMessage tp;
-    tp.body = std::move(chunkBytes);
-    auto framed = encode_two_part(tp);
-
-    const auto tBefore = SteadyClock::now();
-    const bool ok = writeAll(sock, framed);
-    const auto tAfter = SteadyClock::now();
-
-    if (!ok) {
-      TT_LOG_WARN(
-          "[DynamoTx] id={} stage=chunk_failed seq={} tokens={} bytes={}",
-          requestId, chunkSeq, chunk.token_ids.size(), bytesOut);
-      return false;
-    }
-
-    if (!sawFirstChunk) {
-      tFirstChunk = tBefore;
-      tPrevChunk = tBefore;
-      sawFirstChunk = true;
-    }
-
-    if (txTrace) {
-      // Per-chunk INFO line. High volume (~one per generated token) — only
-      // emitted when DYN_TX_TRACE is set. Format is intentionally compact
-      // and easy to grep/awk for offline analysis.
-      //   seq            — chunk index within this request
-      //   tokens         — token ids packed into this chunk (usually 1)
-      //   bytes          — framed wire bytes (TwoPartMessage envelope incl.)
-      //   write_us       — time spent inside writeAll() (kernel buffer copy)
-      //   since_prev_us  — gap since the previous chunk's write(); this is
-      //                    the per-token inter-arrival the wire sees
-      //   since_first_us — offset from the first chunk; matches client TTFT
-      //                    + cumulative ITL
-      TT_LOG_INFO(
-          "[DynamoTx] id={} stage=chunk seq={} tokens={} bytes={} "
-          "write_us={} since_prev_us={} since_first_us={}",
-          requestId, chunkSeq, chunk.token_ids.size(), bytesOut,
-          microsBetween(tBefore, tAfter), microsBetween(tPrevChunk, tBefore),
-          microsBetween(tFirstChunk, tBefore));
-    }
-
-    tPrevChunk = tBefore;
-    chunkSeq++;
-    totalTokens += chunk.token_ids.size();
-    totalBytes += bytesOut;
-    return true;
+  if (isError) done_.store(true);
+  auto self = shared_from_this();
+  loop_->queueInLoop([self, bytes = std::move(bytes), isError]() mutable {
+    if (self->closed_) return;
+    self->ensurePrologue();
+    self->writeOrBuffer(std::move(bytes));
+    if (isError) self->closeStream();  // error frames carry no sentinels
   });
+  return !isError;
+}
 
-  // If an error was sent in the prologue, skip the stream sentinels.
-  if (hadError) {
-    ::close(sock);
-    return;
-  }
-
-  // Send prologue now if the handler produced no chunks at all.
-  if (!prologueSent) {
-    if (!sendPrologue(Json::Value::null)) {
-      ::close(sock);
-      return;
+void DynamoStreamWriter::finalize() {
+  done_.store(true);
+  auto self = shared_from_this();
+  loop_->queueInLoop([self]() {
+    if (self->closed_) return;
+    self->ensurePrologue();
+    {
+      TwoPartMessage tp;
+      auto f = encode_stream_final();
+      tp.body.assign(f.begin(), f.end());
+      self->writeOrBuffer(framedString(tp));
     }
-  }
-
-  // 3. complete_final sentinel.
-  {
-    auto finalBytes = encode_stream_final();
-    TwoPartMessage tp;
-    tp.body = std::move(finalBytes);
-    const auto tBefore = SteadyClock::now();
-    writeAll(sock, encode_two_part(tp));
-    const auto tAfter = SteadyClock::now();
-    TT_LOG_INFO(
-        "[DynamoTx] id={} stage=complete_final chunks={} tokens={} bytes={} "
-        "stream_us={} write_us={}",
-        requestId, chunkSeq, totalTokens, totalBytes,
-        sawFirstChunk ? microsBetween(tFirstChunk, tBefore) : 0,
-        microsBetween(tBefore, tAfter));
-  }
-
-  // 4. End-of-stream sentinel (empty TwoPartMessage).
-  {
-    TwoPartMessage tp;
-    writeAll(sock, encode_two_part(tp));
-  }
-
-  ::close(sock);
+    self->writeOrBuffer(framedString(TwoPartMessage{}));  // end-of-stream
+    self->closeStream();
+  });
 }
 
 void DynamoServer::start() {


### PR DESCRIPTION
## Issue
[#4066 Fix number of threads](https://github.com/tenstorrent/tt-inference-server/issues/4066)

## Problem
### Before
The Dynamo path in the inference server had grown a fairly complex threading model. A single request would end up traversing five different thread types:

- Accept thread — waits for inbound Dynamo connections.
- Per-connection thread — handles a TCP connection, reads requests, sends ACKs, and spawns per-request threads.
- Per-request thread — handles an individual request, opens the call-home connection, drives request processing, and then waits until streaming completes.
- Trantor loop pool (4–64 threads) — performs session resolution, preprocessing, and dispatches work to the task queue.
- Consumer thread — one per worker; receives generated tokens and streams them back to the client.

```
frontend       accept thread   per-conn thread   per-req thread   trantor loop(4–64)   consumer thread
   │                │                │                │                  │                  │
   │── connect ────▶│ accept()       │                │                  │                  │
   │                │ spawn ─────────▶│                │                  │                  │
   │── request ─────┼────────────────▶│ read + ACK     │                  │                  │
   │                │                │ spawn ─────────▶│ connect to       │                  │
   │                │                │ (read next)     │ frontend addr    │                  │
   │                │                │                 │ getNextLoop() ──▶ │ resolveSession   │
   │                │                │                 │                  │ preProcess       │
   │                │                │                 │                  │ dispatch ────────▶ task queue
   │                │                │                 │ future.wait() ◀──┤ stream cb ◀───────┤ tokens
   │◀── chunk ──────┼────────────────┼─ writeAll() ◀───┤ (BLOCKS)         │                  │
   │◀── sentinel ───┼────────────────┼─ writeAll() ◀───┤ done             │                  │
```

The main issue was the amount of blocking involved. Every in-flight request required a dedicated thread waiting for completion. Even worse, response streaming performed blocking socket writes on the shared consumer thread. This meant that a single slow client could block token delivery for every other request handled by the same worker, creating significant head-of-line blocking.

### After
The Dynamo path now follows the same architecture as the legacy HTTP path.

- A Trantor EventLoop thread pool accepts incoming connections, parses requests, and dispatches work to the task queue without blocking
- The existing consumer thread continues to receive tokens from workers, but instead of writing them directly to the socket, it schedules the send operation on the EventLoop using queueInLoop
- The EventLoop is responsible for opening the call-home connection and streaming responses back to Dynamo asynchronously

```
frontend            trantor loop pool (inbound + call-home)        consumer thread (per worker)
   │                          │                                          │
   │── connect/request ──────▶│ parse + ACK                              │
   │                          │ resolveSession → dispatch ──────────────▶ task queue → worker
   │                          │                                          │
   │                          │ queueInLoop(send) ◀── token chunks ◀─────┤ (no blocking)
   │◀── chunk / sentinel ─────┤ async write on the loop                  │
```

As a result, we no longer create a dedicated thread for every request, and there are no threads sitting idle waiting for streaming to finish. Consumer threads are no longer blocked by slow clients, which means one slow connection can no longer impact unrelated requests on the same worker. Response streaming is now fully asynchronous, making the system simpler, more efficient, and much better suited to handling higher loads.

One thing that has not changed is the two-way connection model (inbound request + outbound call-home response), as this behavior is required by Dynamo's TCP protocol (`transport: "tcp_server"`).

## Testing
For higher server loads there is a small perf improvement, but this change has more architectural benefits:
```
┌─────────────┬─────────┬─────────┬────────────┬────────────┐
│ Concurrency │ req/s Δ │ tok/s Δ │ TTFT p99 Δ │ TTFT med Δ │
├─────────────┼─────────┼─────────┼────────────┼────────────┤
│ 32          │ +6.2%   │ +6.2%   │ +0.5%      │ −2.2%      │
├─────────────┼─────────┼─────────┼────────────┼────────────┤
│ 64          │ −0.2%   │ −0.2%   │ −6.9%      │ +0.7%      │
├─────────────┼─────────┼─────────┼────────────┼────────────┤
│ 128         │ +6.5%   │ +6.5%   │ −14.3%     │ −4.5%      |
├─────────────┼─────────┼─────────┼────────────┼────────────┤
│ 512         │ +2.8%   │ +5.0%   │ −5.3%      │ +7.3%      │ 
├─────────────┼─────────┼─────────┼────────────┼────────────┤
│ 1000        │ +9.2%   │ +20.6%  │ −4.3%      │ +5.8%      │
└─────────────┴─────────┴─────────┴────────────┴────────────┘
```

Heavy checks: https://github.com/tenstorrent/tt-inference-server/actions/runs/27616598257/job/81653981833