### PR TITLE
prefix cache lookup optimization

### DIFF
--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -242,9 +242,10 @@ class SessionManager {
   // contiguously for cache-friendly linear scanning.
   struct SessionBlockSequence {
     std::string sessionId;
-    std::vector<uint64_t> blockHashes;             // all blocks, contiguous
-    std::vector<uint32_t> accumulatedThinkTokens;  // parallel array, same length
-    uint32_t keyBlockThinkTokens = 0;              // think tokens at first block
+    std::vector<uint64_t> blockHashes;  // all blocks, contiguous
+    std::vector<uint32_t>
+        accumulatedThinkTokens;        // parallel array, same length
+    uint32_t keyBlockThinkTokens = 0;  // think tokens at first block
   };
 
   // Flat array of all session block sequences. Linear scan with early-break

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -238,24 +238,19 @@ class SessionManager {
   mutable utils::ConcurrentMap<std::string, std::shared_ptr<domain::Session>>
       sessions;
 
-  // An entry in the prefix index: a group of sessions sharing the same prefix
-  // path, together with the remaining block info that follows (used for deeper
-  // prefix matching / numberOfMatchedTokens calculation).
-  struct RemainingBlockInfo {
-    uint64_t hash;
-    uint32_t accumulatedThinkTokens;
+  // A session's block sequence for prefix matching. All blocks stored
+  // contiguously for cache-friendly linear scanning.
+  struct SessionBlockSequence {
+    std::string sessionId;
+    std::vector<uint64_t> blockHashes;             // all blocks, contiguous
+    std::vector<uint32_t> accumulatedThinkTokens;  // parallel array, same length
+    uint32_t keyBlockThinkTokens = 0;              // think tokens at first block
   };
 
-  struct PrefixIndexEntry {
-    std::list<std::string> sessionIds;              // sessions registered here
-    std::list<RemainingBlockInfo> remainingBlocks;  // subsequent block info
-    uint32_t keyBlockThinkTokens = 0;  // think tokens at key hash block
-  };
-
-  // Secondary index: block hash -> entries (each with different remaining
-  // hashes pointing to different sessions/slots).
-  // Used by tryAcquireByPrefixHash / registerPrefixHash for prefix caching.
-  utils::ConcurrentMap<uint64_t, std::vector<PrefixIndexEntry>> prefixIndex;
+  // Flat array of all session block sequences. Linear scan with early-break
+  // is faster than hash lookup for ≤128 sessions due to cache locality.
+  mutable std::mutex prefixIndexMutex_;
+  std::vector<SessionBlockSequence> sessionSequences_;
 
   // Secondary index: previous_response_id -> the session registered under it.
   // Unlike prefixIndex (where many sessions can share a content hash), response

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -770,11 +770,10 @@ void SessionManager::registerPrefixHash(
     std::lock_guard<std::mutex> lock(prefixIndexMutex_);
 
     // Find existing entry by sessionId, or add new one
-    auto it = std::find_if(
-        sessionSequences_.begin(), sessionSequences_.end(),
-        [&sessionId](const SessionBlockSequence& s) {
-          return s.sessionId == sessionId;
-        });
+    auto it = std::find_if(sessionSequences_.begin(), sessionSequences_.end(),
+                           [&sessionId](const SessionBlockSequence& s) {
+                             return s.sessionId == sessionId;
+                           });
 
     if (it != sessionSequences_.end()) {
       *it = std::move(newSeq);  // Replace in-place
@@ -943,11 +942,10 @@ std::pair<uint32_t, uint32_t> SessionManager::computeMatchedTokens(
   {
     std::lock_guard<std::mutex> lock(prefixIndexMutex_);
 
-    auto it = std::find_if(
-        sessionSequences_.begin(), sessionSequences_.end(),
-        [&sessionId](const SessionBlockSequence& s) {
-          return s.sessionId == sessionId;
-        });
+    auto it = std::find_if(sessionSequences_.begin(), sessionSequences_.end(),
+                           [&sessionId](const SessionBlockSequence& s) {
+                             return s.sessionId == sessionId;
+                           });
 
     if (it != sessionSequences_.end()) {
       // Count matching blocks with early break
@@ -984,11 +982,10 @@ void SessionManager::clearSessionBlockThinkTokens(
   {
     std::lock_guard<std::mutex> lock(prefixIndexMutex_);
 
-    auto it = std::find_if(
-        sessionSequences_.begin(), sessionSequences_.end(),
-        [&sessionId](const SessionBlockSequence& s) {
-          return s.sessionId == sessionId;
-        });
+    auto it = std::find_if(sessionSequences_.begin(), sessionSequences_.end(),
+                           [&sessionId](const SessionBlockSequence& s) {
+                             return s.sessionId == sessionId;
+                           });
 
     if (it == sessionSequences_.end()) {
       TT_LOG_WARN(
@@ -1018,11 +1015,10 @@ void SessionManager::removeFromPrefixIndex(const std::string& sessionId,
                                            uint64_t /* prefixHash */) {
   std::lock_guard<std::mutex> lock(prefixIndexMutex_);
 
-  auto it = std::find_if(
-      sessionSequences_.begin(), sessionSequences_.end(),
-      [&sessionId](const SessionBlockSequence& s) {
-        return s.sessionId == sessionId;
-      });
+  auto it = std::find_if(sessionSequences_.begin(), sessionSequences_.end(),
+                         [&sessionId](const SessionBlockSequence& s) {
+                           return s.sessionId == sessionId;
+                         });
 
   if (it != sessionSequences_.end()) {
     // Swap-and-pop for O(1) removal from vector

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -572,42 +572,36 @@ SessionManager::tryAcquireByPrefixHash(
   const size_t firstBlockTokens = tt::config::kvCacheFirstBlockSize();
   const size_t blockTokens = tt::config::kvCacheBlockSize();
 
-  // Build the caller's remaining block info for comparison (blockInfos[1:]).
-  std::list<RemainingBlockInfo> callerRemaining;
-  for (size_t i = 1; i < blockInfos.size(); ++i) {
-    callerRemaining.push_back(
-        {blockInfos[i].hash, blockInfos[i].accumulatedThinkTokens});
-  }
-
-  // Snapshot candidates: for each entry under keyHash, count how many
-  // consecutive remaining hashes match the caller's remaining hashes.
-  // Pick the entry with the longest match.
+  // Snapshot candidates via linear scan with early-break on mismatch.
   std::vector<Candidate> candidates;
 
-  prefixIndex.modify(keyHash, [&](std::vector<PrefixIndexEntry>& entries) {
-    for (const auto& entry : entries) {
-      // Count consecutive matching remaining hashes.
-      size_t matched = 0;
-      uint32_t lastMatchedThinkCount = entry.keyBlockThinkTokens;
-      auto callerIt = callerRemaining.begin();
-      auto entryIt = entry.remainingBlocks.begin();
-      while (callerIt != callerRemaining.end() &&
-             entryIt != entry.remainingBlocks.end() &&
-             callerIt->hash == entryIt->hash) {
-        lastMatchedThinkCount = entryIt->accumulatedThinkTokens;
+  {
+    std::lock_guard<std::mutex> lock(prefixIndexMutex_);
+
+    for (const auto& seq : sessionSequences_) {
+      // Early exit if first block doesn't match
+      if (seq.blockHashes.empty() || seq.blockHashes[0] != keyHash) {
+        continue;
+      }
+
+      // Count consecutive matching blocks with early break
+      size_t matched = 1;  // key block matched
+      uint32_t lastMatchedThinkCount = seq.keyBlockThinkTokens;
+
+      const size_t maxCompare =
+          std::min(seq.blockHashes.size(), blockInfos.size());
+      for (size_t i = 1; i < maxCompare; ++i) {
+        if (seq.blockHashes[i] != blockInfos[i].hash) {
+          break;  // Early exit on mismatch
+        }
+        lastMatchedThinkCount = seq.accumulatedThinkTokens[i];
         ++matched;
-        ++callerIt;
-        ++entryIt;
       }
-      // key hash itself counts as 1 block match.
-      size_t totalMatched = 1 + matched;
-      size_t sessionTotal = 1 + entry.remainingBlocks.size();
-      for (const auto& sid : entry.sessionIds) {
-        candidates.push_back(
-            {sid, totalMatched, sessionTotal, lastMatchedThinkCount});
-      }
+
+      candidates.push_back({seq.sessionId, matched, seq.blockHashes.size(),
+                            lastMatchedThinkCount});
     }
-  });
+  }
 
   if (candidates.empty()) {
     TT_LOG_DEBUG("[SessionManager] tryAcquireByPrefixHash: keyHash={} miss",
@@ -747,12 +741,9 @@ void SessionManager::registerPrefixHash(
       sessionId, keyHash, blockInfos.size(), keyThinkCount);
 
   // Update session's hash field (stores the key for staleness checks).
-  uint64_t oldHash = 0;
   uint32_t slotId = tt::domain::INVALID_SLOT_ID;
   bool sessionFound = sessions.modify(
-      sessionId,
-      [&oldHash, &slotId, keyHash](std::shared_ptr<domain::Session>& s) {
-        oldHash = s->getHash();
+      sessionId, [&slotId, keyHash](std::shared_ptr<domain::Session>& s) {
         slotId = s->getSlotId();
         s->setHash(keyHash);
       });
@@ -763,66 +754,39 @@ void SessionManager::registerPrefixHash(
     return;
   }
 
-  if (oldHash != 0 && oldHash != keyHash) {
-    removeFromPrefixIndex(sessionId, oldHash);
+  // Build the new sequence
+  SessionBlockSequence newSeq;
+  newSeq.sessionId = sessionId;
+  newSeq.keyBlockThinkTokens = keyThinkCount;
+  newSeq.blockHashes.reserve(blockInfos.size());
+  newSeq.accumulatedThinkTokens.reserve(blockInfos.size());
+
+  for (const auto& info : blockInfos) {
+    newSeq.blockHashes.push_back(info.hash);
+    newSeq.accumulatedThinkTokens.push_back(info.accumulatedThinkTokens);
   }
 
-  // Build remaining blocks (blockInfos[1:]).
-  std::list<RemainingBlockInfo> remaining;
-  for (size_t i = 1; i < blockInfos.size(); ++i) {
-    remaining.push_back(
-        {blockInfos[i].hash, blockInfos[i].accumulatedThinkTokens});
-  }
+  {
+    std::lock_guard<std::mutex> lock(prefixIndexMutex_);
 
-  // Helper to compare remaining block lists by hash only (for dedup).
-  auto remainingHashesMatch = [](const std::list<RemainingBlockInfo>& a,
-                                 const std::list<RemainingBlockInfo>& b) {
-    if (a.size() != b.size()) return false;
-    auto itA = a.begin();
-    auto itB = b.begin();
-    while (itA != a.end()) {
-      if (itA->hash != itB->hash) return false;
-      ++itA;
-      ++itB;
+    // Find existing entry by sessionId, or add new one
+    auto it = std::find_if(
+        sessionSequences_.begin(), sessionSequences_.end(),
+        [&sessionId](const SessionBlockSequence& s) {
+          return s.sessionId == sessionId;
+        });
+
+    if (it != sessionSequences_.end()) {
+      *it = std::move(newSeq);  // Replace in-place
+    } else {
+      sessionSequences_.push_back(std::move(newSeq));
     }
-    return true;
-  };
-
-  // Insert into prefixIndex: key=keyHash, entry has remaining + sessionId.
-  // First, remove sessionId from any existing entry under this key (a session
-  // should only appear once — always at its latest registration).
-  bool exists = prefixIndex.modify(
-      keyHash, [&sessionId, &remaining, &remainingHashesMatch,
-                keyThinkCount](std::vector<PrefixIndexEntry>& entries) {
-        // Remove sessionId from all entries (it may be in a stale one).
-        for (auto it = entries.begin(); it != entries.end();) {
-          it->sessionIds.remove(sessionId);
-          if (it->sessionIds.empty()) {
-            it = entries.erase(it);
-          } else {
-            ++it;
-          }
-        }
-        // Now add to the matching entry or create a new one.
-        for (auto& entry : entries) {
-          if (remainingHashesMatch(entry.remainingBlocks, remaining)) {
-            entry.sessionIds.push_back(sessionId);
-            return;
-          }
-        }
-        entries.push_back(
-            PrefixIndexEntry{{sessionId}, remaining, keyThinkCount});
-      });
-  if (!exists) {
-    std::vector<PrefixIndexEntry> entries;
-    entries.push_back(PrefixIndexEntry{{sessionId}, remaining, keyThinkCount});
-    prefixIndex.insert(keyHash, std::move(entries));
   }
 
   TT_LOG_INFO(
       "[SessionManager] registerPrefixHash: registered sessionId={} under "
       "keyHash={} with {} remaining blocks",
-      sessionId, keyHash, remaining.size());
+      sessionId, keyHash, blockInfos.size() - 1);
 
   // Publish the slot's committed block count (1 key block + remaining).
   if (slotId != tt::domain::INVALID_SLOT_ID) {
@@ -970,45 +934,42 @@ std::pair<uint32_t, uint32_t> SessionManager::computeMatchedTokens(
     return {0, 0};
   }
 
-  const uint64_t keyHash = blockInfos.front().hash;
   const size_t firstBlockTokens = tt::config::kvCacheFirstBlockSize();
   const size_t blockTokens = tt::config::kvCacheBlockSize();
-
-  std::list<RemainingBlockInfo> callerRemaining;
-  for (size_t i = 1; i < blockInfos.size(); ++i) {
-    callerRemaining.push_back(
-        {blockInfos[i].hash, blockInfos[i].accumulatedThinkTokens});
-  }
 
   size_t matchedBlocks = 0;
   uint32_t thinkTokens = 0;
 
-  prefixIndex.modify(keyHash, [&](std::vector<PrefixIndexEntry>& entries) {
-    for (const auto& entry : entries) {
-      bool hasSession =
-          std::find(entry.sessionIds.begin(), entry.sessionIds.end(),
-                    sessionId) != entry.sessionIds.end();
-      if (!hasSession) continue;
+  {
+    std::lock_guard<std::mutex> lock(prefixIndexMutex_);
 
-      size_t matched = 0;
-      uint32_t lastThink = entry.keyBlockThinkTokens;
-      auto callerIt = callerRemaining.begin();
-      auto entryIt = entry.remainingBlocks.begin();
-      while (callerIt != callerRemaining.end() &&
-             entryIt != entry.remainingBlocks.end() &&
-             callerIt->hash == entryIt->hash) {
-        lastThink = entryIt->accumulatedThinkTokens;
-        ++matched;
-        ++callerIt;
-        ++entryIt;
+    auto it = std::find_if(
+        sessionSequences_.begin(), sessionSequences_.end(),
+        [&sessionId](const SessionBlockSequence& s) {
+          return s.sessionId == sessionId;
+        });
+
+    if (it != sessionSequences_.end()) {
+      // Count matching blocks with early break
+      uint32_t lastThink = it->keyBlockThinkTokens;
+      const size_t maxCompare =
+          std::min(it->blockHashes.size(), blockInfos.size());
+
+      for (size_t i = 0; i < maxCompare; ++i) {
+        if (it->blockHashes[i] != blockInfos[i].hash) {
+          break;
+        }
+        if (i > 0) {
+          lastThink = it->accumulatedThinkTokens[i];
+        }
+        ++matchedBlocks;
       }
-      size_t total = 1 + matched;
-      if (total > matchedBlocks) {
-        matchedBlocks = total;
+
+      if (matchedBlocks > 0) {
         thinkTokens = lastThink;
       }
     }
-  });
+  }
 
   if (matchedBlocks == 0) {
     return {0, 0};
@@ -1020,37 +981,27 @@ std::pair<uint32_t, uint32_t> SessionManager::computeMatchedTokens(
 
 void SessionManager::clearSessionBlockThinkTokens(
     const std::string& sessionId) {
-  uint64_t keyHash = 0;
-  bool found = sessions.modify(sessionId,
-                               [&keyHash](std::shared_ptr<domain::Session>& s) {
-                                 keyHash = s->getHash();
-                               });
+  {
+    std::lock_guard<std::mutex> lock(prefixIndexMutex_);
 
-  if (!found) {
-    TT_LOG_WARN(
-        "[SessionManager] clearSessionBlockThinkTokens: sessionId={} not "
-        "found",
-        sessionId);
-    return;
+    auto it = std::find_if(
+        sessionSequences_.begin(), sessionSequences_.end(),
+        [&sessionId](const SessionBlockSequence& s) {
+          return s.sessionId == sessionId;
+        });
+
+    if (it == sessionSequences_.end()) {
+      TT_LOG_WARN(
+          "[SessionManager] clearSessionBlockThinkTokens: sessionId={} not "
+          "found in prefix index",
+          sessionId);
+      return;
+    }
+
+    it->keyBlockThinkTokens = 0;
+    std::fill(it->accumulatedThinkTokens.begin(),
+              it->accumulatedThinkTokens.end(), 0);
   }
-
-  if (keyHash == 0) {
-    return;
-  }
-
-  prefixIndex.modify(
-      keyHash, [&sessionId](std::vector<PrefixIndexEntry>& entries) {
-        for (auto& entry : entries) {
-          bool hasSession =
-              std::find(entry.sessionIds.begin(), entry.sessionIds.end(),
-                        sessionId) != entry.sessionIds.end();
-          if (!hasSession) continue;
-          entry.keyBlockThinkTokens = 0;
-          for (auto& block : entry.remainingBlocks) {
-            block.accumulatedThinkTokens = 0;
-          }
-        }
-      });
 
   TT_LOG_INFO(
       "[SessionManager] clearSessionBlockThinkTokens: reset think tokens for "
@@ -1064,25 +1015,19 @@ void SessionManager::updateSessionCountMetric() {
 }
 
 void SessionManager::removeFromPrefixIndex(const std::string& sessionId,
-                                           uint64_t prefixHash) {
-  if (prefixHash == 0) return;
-  bool becameEmpty = false;
-  prefixIndex.modify(prefixHash, [&sessionId, &becameEmpty](
-                                     std::vector<PrefixIndexEntry>& entries) {
-    for (auto& entry : entries) {
-      auto& ids = entry.sessionIds;
-      ids.erase(std::remove(ids.begin(), ids.end(), sessionId), ids.end());
-    }
-    // Remove entries with no sessions left
-    entries.erase(std::remove_if(entries.begin(), entries.end(),
-                                 [](const PrefixIndexEntry& e) {
-                                   return e.sessionIds.empty();
-                                 }),
-                  entries.end());
-    becameEmpty = entries.empty();
-  });
-  if (becameEmpty) {
-    prefixIndex.erase(prefixHash);
+                                           uint64_t /* prefixHash */) {
+  std::lock_guard<std::mutex> lock(prefixIndexMutex_);
+
+  auto it = std::find_if(
+      sessionSequences_.begin(), sessionSequences_.end(),
+      [&sessionId](const SessionBlockSequence& s) {
+        return s.sessionId == sessionId;
+      });
+
+  if (it != sessionSequences_.end()) {
+    // Swap-and-pop for O(1) removal from vector
+    *it = std::move(sessionSequences_.back());
+    sessionSequences_.pop_back();
   }
 }
 


### PR DESCRIPTION
## Replace prefix index hash map with flat vector scan

### Summary

Replaces the `ConcurrentMap<uint64_t, vector<PrefixIndexEntry>>` prefix index with a flat `vector<SessionBlockSequence>` protected by a mutex. All block hashes for each session are stored contiguously, enabling cache-friendly linear scanning with early-break on mismatch.

### Motivation

Worst-case working set: **64 sessions x ~3300 blocks x 8 bytes = ~1.6MB**, which fits entirely in L2/L3 cache. At this scale, a linear scan with early-exit on the first mismatched block outperforms hash-map lookup due to:

- No pointer chasing (old approach used `std::list` for remaining blocks and session IDs)
- No hash collisions or bucket probing
- Sequential memory access pattern enables hardware prefetching
- Early break means most non-matching sessions exit after comparing a single `uint64_t`

### Changes

- **`SessionBlockSequence`** replaces `PrefixIndexEntry` + `RemainingBlockInfo`: stores `sessionId`, a contiguous `vector<uint64_t>` of all block hashes, and a parallel `vector<uint32_t>` for accumulated think tokens.
- **`tryAcquireByPrefixHash`**: linear scan over `sessionSequences_` with early-break on first block mismatch.
- **`registerPrefixHash`**: find-or-append by session ID, replace in-place.
- **`removeFromPrefixIndex`**: O(1) swap-and-pop removal.
- **`computeMatchedTokens`**: direct lookup by session ID, sequential block comparison.
- **`clearSessionBlockThinkTokens`**: lookup by session ID, `std::fill` on the think-tokens vector.
- **Integration test**: new `Eviction_RemovesSessionFromPrefixCache` test validates that evicted sessions are properly cleaned from the prefix index.


<img width="1100" height="870" alt="image" src="https://github.com/user-attachments/assets/b2f280b8-87bc-479c-a02b-627e67db41a3" />

session_manager_benchmark results BEFORE:
<img width="1536" height="140" alt="image" src="https://github.com/user-attachments/assets/2bdd2590-ba17-482c-801a-73e221cd0252" />


session_manager_benchmark results AFTER:
<img width="1488" height="148" alt="image" src="https://github.com/user-attachments/assets/ae199579-5758-44b2-bc8f-1f2883511a94" />





