### PR TITLE
Update CI config to modify device lists

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -44,7 +44,6 @@
             },
             "release": {
               "devices": [
-                "GALAXY",
                 "P150",
                 "P300X2"
               ]
@@ -583,7 +582,12 @@
         "nightly": {
           "devices": [
             "P150",
-            "P300X2"
+            "GALAXY"
+          ]
+        },
+        "release": {
+          "devices": [
+            "GALAXY"
           ]
         }
       }
@@ -715,8 +719,12 @@
             "GALAXY",
             "BH_GALAXY",
             "N150",
-            "P150",
-            "P300X2"
+            "P150"
+          ]
+        },
+        "release": {
+          "devices": [
+            "GALAXY"
           ]
         },
         "weekly": {


### PR DESCRIPTION
Removed 'GALAXY' from the release devices and added it to the nightly devices for CI configuration.