### PR TITLE
Onboard zai-org/GLM-5.1 to cpp_server (Dynamo)

### DIFF
--- a/tt-media-server/cpp_server/include/config/types.hpp
+++ b/tt-media-server/cpp_server/include/config/types.hpp
@@ -47,6 +47,7 @@ enum class ModelType {
   KIMI_K2_6,
   GPT_OSS_120B,
   MINIMAX_M2_7,
+  GLM_5_1,
 };
 
 enum class LLMMode {
@@ -91,6 +92,7 @@ enum class Model {
   KIMI_K2_6,
   GPT_OSS_120B,
   MINIMAX_M2_7,
+  GLM_5_1,
 };
 
 struct ModelMapping {
@@ -104,6 +106,7 @@ static constexpr ModelMapping MODEL_MAPPINGS[] = {
     {Model::KIMI_K2_6, "moonshotai/Kimi-K2.6"},
     {Model::GPT_OSS_120B, "openai/gpt-oss-120b"},
     {Model::MINIMAX_M2_7, "MiniMaxAI/MiniMax-M2.7"},
+    {Model::GLM_5_1, "zai-org/GLM-5.1"},
 };
 
 inline std::string toString(Model m) {

--- a/tt-media-server/cpp_server/scripts/fetch_tokenizers.sh
+++ b/tt-media-server/cpp_server/scripts/fetch_tokenizers.sh
@@ -227,4 +227,17 @@ download_tokenizer \
     "json" \
     "true"
 
+# GLM-5.1 (public, no auth). Ships a separate chat_template.jinja (no inline
+# template in tokenizer_config.json), so needs_chat_template=true. config.json
+# and generation_config.json both carry eos_token_id [154820, 154827, 154829]
+# (<|endoftext|>, <|user|>, <|observation|>) — eos 154820, stops on the other
+# two. tokenizer.json is an LFS file, so use /resolve/main.
+download_tokenizer \
+    "zai-org/GLM-5.1" \
+    "https://huggingface.co/zai-org/GLM-5.1/resolve/main" \
+    "false" \
+    '{"model_type":"glm_moe_dsa","architectures":["GlmMoeDsaForCausalLM"]}' \
+    "json" \
+    "true"
+
 echo ""

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -55,6 +55,8 @@ std::string resolveBlazeSocketDescriptorPrefix() {
       return "gpt-oss";
     case ModelType::MINIMAX_M2_7:
       return "minimax";
+    case ModelType::GLM_5_1:
+      return "glm";
   }
 }
 
@@ -467,6 +469,7 @@ ModelType modelType() {
       return ModelType::LLAMA_3_1_8B_INSTRUCT;
     if (m == "openai/gpt-oss-120b") return ModelType::GPT_OSS_120B;
     if (m == "MiniMaxAI/MiniMax-M2.7") return ModelType::MINIMAX_M2_7;
+    if (m == "zai-org/GLM-5.1") return ModelType::GLM_5_1;
     return ModelType::DEEPSEEK_R1_0528;
   }();
   return cached;
@@ -487,6 +490,7 @@ bool sampleOnlyInReasoning() {
     case ModelType::KIMI_K2_6:
     case ModelType::GPT_OSS_120B:
     case ModelType::MINIMAX_M2_7:
+    case ModelType::GLM_5_1:
       return false;
   }
   return false;

--- a/tt-media-server/cpp_server/src/dynamo/discovery.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/discovery.cpp
@@ -154,6 +154,11 @@ RuntimeParsers runtimeParsersForModelType(const std::string& modelType) {
   if (modelType == "minimax_m2") {
     return {"minimax_append_think", "minimax_m2"};
   }
+  // GLM-5.1 (glm_moe_dsa): <think>/</think> reasoning (glm45, no
+  // force_reasoning) + GLM-4.7-style <tool_call><arg_key>/<arg_value> tools.
+  if (modelType == "glm_moe_dsa") {
+    return {"glm45", "glm47"};
+  }
   // deepseek_v3 and unknown types default to DeepSeek R1 reasoning.
   return {"deepseek_r1", nullptr};
 }

--- a/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
+++ b/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
@@ -206,6 +206,8 @@ std::string tokenizerDirForModel(config::ModelType model) {
       return "openai/gpt-oss-120b";
     case config::ModelType::MINIMAX_M2_7:
       return "MiniMaxAI/MiniMax-M2.7";
+    case config::ModelType::GLM_5_1:
+      return "zai-org/GLM-5.1";
     case config::ModelType::DEEPSEEK_R1_0528:
     default:
       return "deepseek-ai/DeepSeek-R1-0528";
@@ -224,6 +226,7 @@ std::unique_ptr<Tokenizer> createTokenizer(config::ModelType model,
       return std::make_unique<DeepseekTokenizer>(path);
     case config::ModelType::GPT_OSS_120B:
     case config::ModelType::MINIMAX_M2_7:
+    case config::ModelType::GLM_5_1:
       // These load their own model-specific files but currently reuse the
       // DeepSeek chat-template/tool-call behavior until a dedicated tokenizer
       // implementation is added.
@@ -313,6 +316,23 @@ const StaticTokenizerInfo& minimaxM27Info() {
   return kInfo;
 }
 
+// IDs verified against the fetched zai-org/GLM-5.1 tokenizer. config.json and
+// generation_config.json both list eos_token_id [154820, 154827, 154829] =
+// <|endoftext|> (primary eos / pad), <|user|>, <|observation|> (chat stops).
+// Reasoning uses <think>/</think>. assistantHeaderSequence left empty (the
+// Dynamo frontend applies the chat template); it is worker-side log-only.
+const StaticTokenizerInfo& glm51Info() {
+  static const StaticTokenizerInfo kInfo{
+      /*modelName=*/"zai-org/GLM-5.1",
+      /*stopTokenIds=*/{154827, 154829},  // <|user|>, <|observation|>
+      /*eosTokenId=*/154820,              // <|endoftext|>
+      /*assistantHeaderSequence=*/{},
+      /*thinkStartTokenId=*/154841,  // <think>
+      /*thinkEndTokenId=*/154842,    // </think>
+  };
+  return kInfo;
+}
+
 }  // namespace
 
 const StaticTokenizerInfo& staticInfoFor(config::ModelType model) {
@@ -327,6 +347,8 @@ const StaticTokenizerInfo& staticInfoFor(config::ModelType model) {
       return gptOss120bInfo();
     case config::ModelType::MINIMAX_M2_7:
       return minimaxM27Info();
+    case config::ModelType::GLM_5_1:
+      return glm51Info();
   }
   throw std::invalid_argument(
       "tokenizers::staticInfoFor: no static info registered for ModelType " +


### PR DESCRIPTION
Register GLM-5.1 (model_type glm_moe_dsa) across the five model touchpoints: enum + HF id mapping, modelType() resolver, tokenizer fetch, static tokenizer info, and Dynamo discovery parsers.

Token ids verified against the HF tokenizer: eos 154820 (<|endoftext|>), stops 154827 (<|user|>) / 154829 (<|observation|>), think 154841/154842. eos_token_id ships in both config.json and generation_config.json (already published in the MDC). Reasoning uses <think>/</think> and tools use the GLM-4.7 format, so the frontend gets {reasoning:"glm45", tool_call:"glm47"}.