### PR TITLE
Report run_command fix

### DIFF
--- a/tt-inference-server-v2/workflow_module/command_factory.py
+++ b/tt-inference-server-v2/workflow_module/command_factory.py
@@ -9,10 +9,8 @@ import datetime as _dt
 import json
 import logging
 import os
-import shlex
-import sys
 from pathlib import Path
-from typing import List, Optional, Sequence
+from typing import List, Optional
 
 from workflows.model_spec import get_runtime_model_spec
 from workflows.runtime_config import RuntimeConfig
@@ -149,9 +147,10 @@ def _resolve_eval_config(model_name: str):
 
 def _build_orchestrator_metadata(args: argparse.Namespace) -> OrchestratorMetadata:
     runtime_config = _load_runtime_config(args.runtime_model_spec_json)
+    server_mode = _resolve_server_mode(args, runtime_config)
     return OrchestratorMetadata(
-        server_mode=_resolve_server_mode(args, runtime_config),
-        run_command=_capture_run_command(),
+        server_mode=server_mode,
+        run_command=_resolve_run_command(args, server_mode),
         runtime_model_spec_json=args.runtime_model_spec_json,
         prefix_cache=_build_prefix_cache_options(args),
         serving_bench=_build_serving_bench_options(args),
@@ -241,9 +240,45 @@ def _resolve_server_mode(
     return "docker" if args.docker_server else "API"
 
 
-def _capture_run_command(argv: Optional[Sequence[str]] = None) -> str:
-    parts = list(sys.argv if argv is None else argv)
-    return "python " + shlex.join(parts)
+_V1_RUN_COMMAND_ENV = "TT_V1_RUN_COMMAND"
+
+
+def _resolve_run_command(args: argparse.Namespace, server_mode: str) -> str:
+    """Resolve the ``run_command`` recorded in the report metadata."""
+    propagated = os.environ.get(_V1_RUN_COMMAND_ENV)
+    if propagated:
+        return propagated
+    return _reconstruct_run_command(args, server_mode)
+
+
+def _reconstruct_run_command(args: argparse.Namespace, server_mode: str) -> str:
+    """Rebuild a minimal, human-reproducible ``run.py`` invocation."""
+    parts = [
+        "python run.py",
+        f"--model {args.model}",
+        f"--tt-device {args.device}",
+        f"--workflow {args.workflow}",
+    ]
+    impl_flag = _impl_flag(args.model, args.device)
+    if impl_flag:
+        parts.append(impl_flag)
+    if server_mode == "docker":
+        parts.append("--docker-server")
+    return " ".join(parts)
+
+
+def _impl_flag(model: str, device: str) -> str:
+    """Return ``--impl <name>`` only when a non-default impl is selected."""
+    try:
+        model_spec, _, _ = get_runtime_model_spec(model=model, device=device)
+    except Exception as e:
+        logger.warning(
+            "Could not resolve model spec for run_command impl flag (%s).", e
+        )
+        return ""
+    if model_spec.device_model_spec.default_impl:
+        return ""
+    return f"--impl {model_spec.impl.impl_name}"
 
 
 __all__ = ["CommandFactory"]

--- a/tt-inference-server-v2/workflow_module/command_factory.py
+++ b/tt-inference-server-v2/workflow_module/command_factory.py
@@ -9,6 +9,8 @@ import datetime as _dt
 import json
 import logging
 import os
+import shlex
+import sys
 from pathlib import Path
 from typing import List, Optional
 
@@ -150,7 +152,7 @@ def _build_orchestrator_metadata(args: argparse.Namespace) -> OrchestratorMetada
     server_mode = _resolve_server_mode(args, runtime_config)
     return OrchestratorMetadata(
         server_mode=server_mode,
-        run_command=_resolve_run_command(args, server_mode),
+        run_command=_resolve_run_command(),
         runtime_model_spec_json=args.runtime_model_spec_json,
         prefix_cache=_build_prefix_cache_options(args),
         serving_bench=_build_serving_bench_options(args),
@@ -243,42 +245,12 @@ def _resolve_server_mode(
 _V1_RUN_COMMAND_ENV = "TT_V1_RUN_COMMAND"
 
 
-def _resolve_run_command(args: argparse.Namespace, server_mode: str) -> str:
+def _resolve_run_command() -> str:
     """Resolve the ``run_command`` recorded in the report metadata."""
     propagated = os.environ.get(_V1_RUN_COMMAND_ENV)
     if propagated:
         return propagated
-    return _reconstruct_run_command(args, server_mode)
-
-
-def _reconstruct_run_command(args: argparse.Namespace, server_mode: str) -> str:
-    """Rebuild a minimal, human-reproducible ``run.py`` invocation."""
-    parts = [
-        "python run.py",
-        f"--model {args.model}",
-        f"--tt-device {args.device}",
-        f"--workflow {args.workflow}",
-    ]
-    impl_flag = _impl_flag(args.model, args.device)
-    if impl_flag:
-        parts.append(impl_flag)
-    if server_mode == "docker":
-        parts.append("--docker-server")
-    return " ".join(parts)
-
-
-def _impl_flag(model: str, device: str) -> str:
-    """Return ``--impl <name>`` only when a non-default impl is selected."""
-    try:
-        model_spec, _, _ = get_runtime_model_spec(model=model, device=device)
-    except Exception as e:
-        logger.warning(
-            "Could not resolve model spec for run_command impl flag (%s).", e
-        )
-        return ""
-    if model_spec.device_model_spec.default_impl:
-        return ""
-    return f"--impl {model_spec.impl.impl_name}"
+    return "python " + shlex.join(sys.argv)
 
 
 __all__ = ["CommandFactory"]

--- a/workflows/utils.py
+++ b/workflows/utils.py
@@ -280,6 +280,7 @@ def run_command(
             stderr=subprocess.PIPE,
             bufsize=1,
             text=True,
+            env=env,
         )
 
         stdout_thread = threading.Thread(


### PR DESCRIPTION
When a model routes through the v1 entry point into v2, the bridge synthesizes a full argv with absolute paths and the runtime spec JSON._capture_run_command()faithfully echoes all of it.

So, for a running this command:  
` python run.py --model whisper-large-v3 --workflow benchmarks --device n150 --service-port 8000 
`
we would get:
`"run_command": "python /localdev/ddjukic/tt-inference-server/tt-inference-server-v2/run.py --model whisper-large-v3 --workflow benchmarks --device n150 --service-port 8000 --runtime-model-spec-json /localdev/ddjukic/tt-inference-server/workflow_logs/runtime_model_specs/runtime_model_spec_2026-06-16_14-34-40_id_whisper_whisper-large-v3_n150_fr8kYKPO.json --output-dir /localdev/ddjukic/tt-inference-server/workflow_logs/reports_output/benchmarks --num-prompts 100"`