### PR TITLE
Increase CI_NIGHTLY downsampling factor to 50% on gpt-oss-120b for AIME25

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -3328,7 +3328,7 @@ _eval_config_list = [
                 task_name="aime25",
                 limit_samples_map={
                     EvalLimitMode.SMOKE_TEST: 0.05,  # 30 samples * 0.05 ~= 1 sample
-                    EvalLimitMode.CI_NIGHTLY: 0.33,  # 30 samples * 0.2 = 6 samples
+                    EvalLimitMode.CI_NIGHTLY: 0.50,  # 30 samples * 0.2 = 6 samples
                 },
                 score=EvalTaskScore(
                     published_score=92.5,  # AIME 2025 score (without tools)


### PR DESCRIPTION
This PR will increase the approximate duration of running AIME25 by the following amounts:
* WH Galaxy = 22m35s -> 33m45s
  * Source https://github.com/tenstorrent/tt-shield/actions/runs/27567919843/job/81507587486#step:11:2893
* QB2 = 3h14m -> 4h53m
  * Source https://github.com/tenstorrent/tt-shield/actions/runs/27567919843/job/81507587515#step:11:856