### PR TITLE
Add Claude Rules for Lint and Format and Cursor Skill for Dynamo Deploy

### DIFF
--- a/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/SKILL.md
+++ b/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/SKILL.md
@@ -16,6 +16,7 @@ description: Checklist for onboarding a new LLM to the cpp_server inference back
 | 4 | `src/utils/tokenizers/tokenizer.cpp` | `tokenizerDirForModel`, `createTokenizer` (defaults to `DeepseekTokenizer`), `staticInfoFor` + a `StaticTokenizerInfo` (eos/stop/think token ids) |
 | 5 | `src/dynamo/discovery.cpp` | `runtimeParsersForModelType` (reasoning + tool-call parser ids), `buildMdcJson` (publishes `generation_config.json`) |
 | 6 | deploy + verify | `deploy.sh --hf-model-id <hf-id>`, confirm loads / registers / answers |
+| 7 | **ask the user** | verify the **blaze wire format** works / isn't different for this model (`blaze_runner/blaze_utils.hpp`) |
 
 Reference: [tenstorrent/tt-inference-server#4143](https://github.com/tenstorrent/tt-inference-server/pull/4143) (and the GPT-OSS/MiniMax onboarding commits).
 
@@ -87,3 +88,16 @@ Confirm: `docker logs tt-cpp-worker` shows the new tokenizer loaded and the work
 registered with etcd; a reasoning model reports `reasoning_tokens` in the final-chunk
 usage; tool-call output parses (the `runtimeParsersForModelType` ids are correct);
 and the frontend didn't reject the model for a missing `eos_token_id`.
+
+7. **Verify the blaze wire format.** As a final step, **ask the user to confirm the
+   model's blaze wire format works** — i.e. check whether this model uses a
+   *different* request/response wire format to the blaze engine than the existing
+   models (see `blaze_runner/blaze_utils.hpp`). A new model family can change the
+   tensor/prompt encoding expected by the engine; if so, the model may load and
+   register cleanly yet produce garbage tokens. Don't assume the default works —
+   have the user verify before considering onboarding complete.
+
+## Related skills
+
+For the full deploy + verification flow (bring up the stack, reach the frontend,
+read worker/etcd logs, troubleshoot), see the **`run-dynamo-server`** skill.

--- a/tt-media-server/cpp_server/.claude/skills/run-dynamo-server/SKILL.md
+++ b/tt-media-server/cpp_server/.claude/skills/run-dynamo-server/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: run-dynamo-server
+description: Bring up the cpp_server LLM backend behind the NVIDIA Dynamo frontend (etcd + worker + frontend) for local dev and testing. Use when the user asks to run/start the server with Dynamo, deploy the Dynamo stack, launch the frontend + cpp worker, or reach the OpenAI-compatible endpoint that routes through Dynamo.
+---
+
+# Running cpp_server with Dynamo
+
+## At a glance
+
+| Step | Command (from repo root) |
+|------|--------------------------|
+| Build host binary | `cd tt-media-server/cpp_server && ./build.sh` |
+| Launch stack (mock) | `cd dynamo_frontend && LLM_DEVICE_BACKEND=mock ./deploy.sh --deepseek --local-build --no-monitoring` |
+| Resolve frontend addr | `docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' dynamo-frontend` |
+| Smoke test | `curl -s "http://<FE_IP>:8000/v1/models"` |
+| Tear down | `docker rm -f dynamo-frontend tt-cpp-worker etcd` |
+
+## How the stack connects
+
+```
+client ──HTTP──▶ Dynamo frontend ──(discovers via)──▶ etcd ◀──(registers)── cpp_server worker
+                        └──────── Dynamo TCP call-home protocol ────────────────┘
+```
+
+All three run as Docker containers on the `dynamo-net` network, orchestrated by
+`dynamo_frontend/deploy.sh`. `--local-build` **bind-mounts `cpp_server/build/`**
+into the worker image and runs the local binary — so iterate with `./build.sh`,
+not a Docker image rebuild.
+
+The recurring failure mode: forgetting `LLM_DEVICE_BACKEND=mock` (it defaults to
+`pipeline_manager`, which claims **real** TT devices), or hitting `localhost:8080`
+when the host port-publish is flaky instead of the container bridge IP.
+
+## Quick start (mock backend — no TT hardware)
+
+1. **Build** the host binary (default = Release, mock device backend, blaze OFF):
+   `./build.sh` in `tt-media-server/cpp_server`.
+2. **Launch** (mock!):
+   `LLM_DEVICE_BACKEND=mock ./deploy.sh --deepseek --local-build --no-monitoring`
+   from `dynamo_frontend`.
+   - `--deepseek` (default) | `--kimi` selects the model.
+   - `--no-monitoring` skips Prometheus/Grafana (and their 9090/3000 port checks).
+   - `deploy.sh` stays foreground tailing the worker log; **Ctrl+C tears the whole stack down** (`trap cleanup`). Background it if you need the shell.
+3. **Wait for readiness** — it blocks until the worker registers with etcd (≤60s), then logs `frontend on http://localhost:8080`.
+
+## Reaching the frontend
+
+Normally `http://localhost:8080` (the frontend publishes `-p 8080:8000`). If that
+refuses connections (a docker iptables quirk), use the container bridge IP — it's
+directly routable from the host on Linux:
+
+```bash
+FE=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' dynamo-frontend)
+curl -s "http://${FE}:8000/v1/chat/completions" -H 'Content-Type: application/json' \
+  -d '{"model":"deepseek-ai/DeepSeek-R1-0528","messages":[{"role":"user","content":"hi"}],"max_tokens":16}'
+```
+
+## Real hardware
+
+Direct (no Dynamo): `cpp_server/run_server.sh` (sets `pipeline_manager`,
+`DEVICE_IDS`, `LD_PRELOAD` of the blaze engine). Dynamo on real HW: drop
+`LLM_DEVICE_BACKEND=mock` and make `DEVICE_IDS` in `deploy.sh` match free devices.
+
+## Troubleshooting
+
+- **Worker "did not register within 60s"** → `deploy.sh` dumps worker logs and dies. Usually a stale/missing mounted `build/` binary (rebuild) or `pipeline_manager` claiming busy/absent devices (use `mock`).
+- **Connection refused on :8080** → use the bridge-IP method above.
+- **Logs:** `docker logs -f tt-cpp-worker`, `docker logs dynamo-frontend`.
+- **Discovery:** `docker exec etcd etcdctl get --prefix --keys-only v1/instances/`.
+- **Port in use** → a prior stack didn't tear down: `docker rm -f dynamo-frontend tt-cpp-worker etcd`.
+
+## Related skills
+
+`benchmark-dynamo` (load-test this stack) · `add-model-dynamo` (make `--<model>` work).

--- a/tt-media-server/cpp_server/.cursor/skills/run-dynamo-server
+++ b/tt-media-server/cpp_server/.cursor/skills/run-dynamo-server
@@ -1,0 +1,1 @@
+../../.claude/skills/run-dynamo-server

--- a/tt-media-server/cpp_server/CLAUDE.md
+++ b/tt-media-server/cpp_server/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance when working in `cpp_server/` (TT Media Server C++ / Drogon).
+
+## Project overview
+
+High-performance C++ server with an OpenAI-compatible API, for benchmarking against the Python FastAPI stack. Features include LLM chat completions and embeddings, paged attention, prefix caching, and multiprocess workers with Boost.Interprocess IPC.
+
+## Build and development
+
+```bash
+# Standard release build (tokenizer assets pre-fetched by build.sh)
+./build.sh
+
+./build.sh --debug
+./build.sh --asan
+./build.sh --tsan
+```
+
+Runtime model/backend selection uses `LLM_DEVICE_BACKEND` and related env vars (see `config/settings.hpp`).
+
+## Testing
+
+```bash
+cd build && ctest --output-on-failure
+```
+
+Integration tests also live under `tests/` (Python and C++).
+
+## C++ conventions (naming, format, lint)
+
+Mirrors the Cursor rules in `.cursor/rules/` (`cpp-naming`, `cpp-format-lint`).
+
+- **Naming** (per `.clang-tidy`, Google style): **never snake_case**. camelCase for
+  functions/methods/variables/parameters/locals (incl. local `const`); PascalCase for
+  classes/structs; `UPPER_CASE` for global/static/class constants and macros; private
+  members are camelCase with a trailing `_` (e.g. `sessionManager_`). Don't rename
+  externally visible strings (JSON fields, metric labels, env vars, wire values) for style.
+- **Format:** `./format.sh` (clang-format; authoritative for layout).
+- **Lint:** `./build.sh --clang-tidy` (lint == build; enforces the naming above).
+
+## Dependencies and prerequisites
+
+- **CMake** >= **3.24** (matches `CMakeLists.txt` `cmake_minimum_required`). On Ubuntu 22.04 and similar, distro `cmake` may be older; run `./install_dependencies.sh`, which installs a Kitware CMake under `/usr/local` when needed.
+- **C++20** compiler (GCC 10+, Clang 12+)
+- **Drogon** >= 1.8 (installed by `install_dependencies.sh` if missing)
+- **Boost**, **JsonCpp**, **Rust** (for tokenizers-cpp), **Python 3** (interpreter + dev headers for pybind)
+
+Optional: **Kafka** / `librdkafka-dev` via `./install_dependencies.sh --kafka` when building with `KAFKA_ENABLED=ON`.
+
+## Docker / CI
+
+CI runs `cpp_server/install_dependencies.sh` before C++ jobs; it must keep CMake at or above the `cmake_minimum_required` version in `CMakeLists.txt`.


### PR DESCRIPTION
## Problem
To improve productivity,this PR adds additional Claude/Cursor rules covering linting and formatting, as well as a dedicated Claude/Cursor skill for running Dynamo deployment.

## Testing
### Prompt
<img width="992" height="159" alt="Screenshot 2026-06-17 at 15 34 23" src="https://github.com/user-attachments/assets/926cb603-3170-4448-87f4-0cce2082236a" />

### Output:
<img width="826" height="219" alt="Screenshot 2026-06-17 at 15 44 47" src="https://github.com/user-attachments/assets/0f8442d8-0d80-4a30-862f-d8520757a872" />

