### PR TITLE
Add preferred prefill hint routing

### DIFF
--- a/tt-media-server/cpp_server/include/domain/llm/llm_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/llm_request.hpp
@@ -149,6 +149,9 @@ struct LLMRequest : BaseRequest {
   int decode_skip_tokens = 0;
 
   std::optional<bool> disaggregation_override;
+  // Optional routing hint for PrefillGateway. The gateway may use this prefill
+  // only if it is healthy and has capacity; otherwise it falls back normally.
+  std::optional<std::string> preferred_prefill_id;
 
   // Structured output constraint
   std::optional<ResponseFormat> response_format;
@@ -198,7 +201,8 @@ struct LLMRequest : BaseRequest {
         << " stop_count=" << stop.size()
         << " sessionId=" << detail::optStr(sessionId)
         << " slotId=" << detail::optStr(slotId) << " disaggregation_override="
-        << detail::optStr(disaggregation_override);
+        << detail::optStr(disaggregation_override)
+        << " preferred_prefill_id=" << detail::optStr(preferred_prefill_id);
     return out.str();
   }
 };

--- a/tt-media-server/cpp_server/include/sockets/inter_server_service.hpp
+++ b/tt-media-server/cpp_server/include/sockets/inter_server_service.hpp
@@ -88,7 +88,9 @@ class InterServerService {
                           std::optional<int> maxTokens = std::nullopt,
                           std::optional<uint32_t> slotId = std::nullopt,
                           const tt::domain::llm::SamplingParams& sampling = {},
-                          int decodePositionId = 0, int decodeSkipTokens = 0);
+                          int decodePositionId = 0, int decodeSkipTokens = 0,
+                          std::optional<std::string> preferredPrefillId =
+                              std::nullopt);
 
   /**
    * @brief Send prefill result back to the decode server

--- a/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
@@ -48,6 +48,7 @@ struct PrefillRequestMessage {
   bool fastMode = false;
   int decodePositionId = 0;
   int decodeSkipTokens = 0;
+  std::optional<std::string> preferredPrefillId;
 
   explicit PrefillRequestMessage(uint32_t taskId) : taskId(taskId) {}
 
@@ -61,8 +62,11 @@ struct PrefillRequestMessage {
     float topPVal = topP.value_or(0.0f);
     bool hasTopK = topK.has_value();
     int topKVal = topK.value_or(0);
+    bool hasPreferredPrefill = preferredPrefillId.has_value();
+    const std::string preferredPrefillVal = preferredPrefillId.value_or("");
     ar(taskId, registrationHashes, tokenIds, mt, sid, hasTemp, tempVal, hasTopP,
-       topPVal, hasTopK, topKVal, fastMode, decodePositionId, decodeSkipTokens);
+       topPVal, hasTopK, topKVal, fastMode, decodePositionId, decodeSkipTokens,
+       hasPreferredPrefill, preferredPrefillVal);
   }
 
   template <class Archive>
@@ -81,8 +85,11 @@ struct PrefillRequestMessage {
     bool fastMode;
     int decodePositionId;
     int decodeSkipTokens;
+    bool hasPreferredPrefill;
+    std::string preferredPrefillVal;
     ar(tid, hashes, tids, mt, sid, hasTemp, tempVal, hasTopP, topPVal, hasTopK,
-       topKVal, fastMode, decodePositionId, decodeSkipTokens);
+       topKVal, fastMode, decodePositionId, decodeSkipTokens,
+       hasPreferredPrefill, preferredPrefillVal);
     PrefillRequestMessage msg(tid);
     msg.registrationHashes = std::move(hashes);
     msg.tokenIds = std::move(tids);
@@ -96,6 +103,7 @@ struct PrefillRequestMessage {
     msg.fastMode = fastMode;
     msg.decodePositionId = decodePositionId;
     msg.decodeSkipTokens = decodeSkipTokens;
+    if (hasPreferredPrefill) msg.preferredPrefillId = preferredPrefillVal;
     return msg;
   }
 };

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
@@ -79,6 +79,12 @@ std::shared_ptr<tt::domain::llm::LLMRequest> buildLLMRequest(
   if (currentId.empty()) currentId = dyn.raw.get("request_id", "").asString();
   if (!currentId.empty()) req->responseId = currentId;
 
+  const std::string preferredPrefillId =
+      dyn.raw.get("preferred_prefill_id", "").asString();
+  if (!preferredPrefillId.empty()) {
+    req->preferred_prefill_id = preferredPrefillId;
+  }
+
   return req;
 }
 

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -433,7 +433,7 @@ void DisaggregationService::handleStreamingRequest(
         request.task_id, registrationHashes,
         std::vector<int64_t>(tokenIds.begin(), tokenIds.end()), maxTokens,
         slotId, tt::utils::mapper::mapSamplingParams(request), decodePositionId,
-        decodeSkipTokens);
+        decodeSkipTokens, request.preferred_prefill_id);
 
     if (!sent) {
       streamCallbacks.erase(request.task_id);

--- a/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
+++ b/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <string>
+#include <utility>
 
 #include "config/settings.hpp"
 #include "utils/logger.hpp"
@@ -147,7 +148,7 @@ bool InterServerService::sendPrefillRequest(
     const std::vector<int64_t>& tokenIds, std::optional<int> maxTokens,
     std::optional<uint32_t> slotId,
     const tt::domain::llm::SamplingParams& sampling, int decodePositionId,
-    int decodeSkipTokens) {
+    int decodeSkipTokens, std::optional<std::string> preferredPrefillId) {
   if (!enabled) {
     return false;
   }
@@ -163,6 +164,7 @@ bool InterServerService::sendPrefillRequest(
   message.fastMode = sampling.fast_mode;
   message.decodePositionId = decodePositionId;
   message.decodeSkipTokens = decodeSkipTokens;
+  message.preferredPrefillId = std::move(preferredPrefillId);
 
   return socketManager.sendObject(tags::PREFILL_REQUEST, message);
 }

--- a/tt-media-server/prefill_gateway/README.md
+++ b/tt-media-server/prefill_gateway/README.md
@@ -119,6 +119,20 @@ flip the inter-server socket roles to talk through the gateway:
 
 The default (`USE_PREFILL_GATEWAY=0`) keeps the existing direct 1:1 wiring.
 
+### Preferred prefill hint
+
+Decode can attach an optional `preferredPrefillId` to `PrefillRequestMessage`.
+The gateway treats it as a safe hint, not a hard requirement:
+
+- if the named prefill is registered, healthy, accepting tasks, and under
+  `PREFILL_MAX_IN_FLIGHT`, the gateway routes the request there;
+- otherwise the gateway falls back to the normal policy: longest prefix match,
+  then least in-flight, then round-robin.
+
+The Dynamo request path maps the raw request field `preferred_prefill_id` to
+this hint. This lets experiments prove that an externally selected prefill id
+can travel through decode to the gateway without replacing gateway routing.
+
 ### Topology
 
 ```

--- a/tt-media-server/prefill_gateway/include/gateway/prefill_selector.hpp
+++ b/tt-media-server/prefill_gateway/include/gateway/prefill_selector.hpp
@@ -32,6 +32,7 @@ struct PrefillSnapshot {
 };
 
 enum class PrefillRoutingReason {
+  PreferredPrefill,
   PrefixMatch,
   LeastInflight,
   RoundRobin,
@@ -57,6 +58,8 @@ PrefillEligibilitySummary summarizePrefillEligibility(
 std::string_view routingReasonName(PrefillRoutingReason reason);
 
 PrefillSelection selectPrefill(const std::vector<PrefillSnapshot>& prefills,
-                               size_t& roundRobinCursor);
+                               size_t& roundRobinCursor,
+                               const std::optional<std::string>&
+                                   preferredPrefillId = std::nullopt);
 
 }  // namespace tt::gateway

--- a/tt-media-server/prefill_gateway/src/dispatcher.cpp
+++ b/tt-media-server/prefill_gateway/src/dispatcher.cpp
@@ -31,7 +31,8 @@ void Dispatcher::onPrefillRequest(
   const uint64_t firstRegistrationHash =
       msg.registrationHashes.empty() ? 0 : msg.registrationHashes.front();
 
-  auto selection = selectPrefill(prefills, roundRobinCursor);
+  auto selection =
+      selectPrefill(prefills, roundRobinCursor, msg.preferredPrefillId);
   GatewayMetrics::instance().recordRoutingDecision(
       routingReasonName(selection.reason));
   if (!selection.serverId.has_value()) {
@@ -52,9 +53,10 @@ void Dispatcher::onPrefillRequest(
   }
   TT_LOG_INFO(
       "[Dispatcher] taskId={} route prefill='{}' reason={} "
-      "prefix_match_depth={} hash={}",
+      "prefix_match_depth={} hash={} preferred_prefill='{}'",
       msg.taskId, chosen, routingReasonName(selection.reason),
-      selection.prefixMatchDepth, firstRegistrationHash);
+      selection.prefixMatchDepth, firstRegistrationHash,
+      msg.preferredPrefillId.value_or(""));
 
   registry.incrementInflight(chosen);
   {

--- a/tt-media-server/prefill_gateway/src/prefill_selector.cpp
+++ b/tt-media-server/prefill_gateway/src/prefill_selector.cpp
@@ -50,6 +50,8 @@ PrefillEligibilitySummary summarizePrefillEligibility(
 
 std::string_view routingReasonName(PrefillRoutingReason reason) {
   switch (reason) {
+    case PrefillRoutingReason::PreferredPrefill:
+      return "preferred_prefill";
     case PrefillRoutingReason::PrefixMatch:
       return "prefix_match";
     case PrefillRoutingReason::LeastInflight:
@@ -63,7 +65,18 @@ std::string_view routingReasonName(PrefillRoutingReason reason) {
 }
 
 PrefillSelection selectPrefill(const std::vector<PrefillSnapshot>& prefills,
-                               size_t& roundRobinCursor) {
+                               size_t& roundRobinCursor,
+                               const std::optional<std::string>&
+                                   preferredPrefillId) {
+  if (preferredPrefillId.has_value() && !preferredPrefillId->empty()) {
+    for (const auto& p : prefills) {
+      if (p.serverId == *preferredPrefillId && p.isEligible()) {
+        return {p.serverId, PrefillRoutingReason::PreferredPrefill,
+                p.prefixMatchDepth};
+      }
+    }
+  }
+
   std::vector<Candidate> bestCandidates;
   bestCandidates.reserve(prefills.size());
 

--- a/tt-media-server/prefill_gateway/tests/dispatcher_test.cpp
+++ b/tt-media-server/prefill_gateway/tests/dispatcher_test.cpp
@@ -128,6 +128,46 @@ TEST_F(DispatcherTest, CachedBlockHitDrivesPrefixRouting) {
   EXPECT_EQ(requests[0].prefillServerId, "B");
 }
 
+TEST_F(DispatcherTest, PreferredPrefillWinsWhenHealthy) {
+  markAllHealthy();
+  registry.addCachedBlocks("A", {99});
+  auto req = makeRequest(7, /*hash=*/99);
+  req.preferredPrefillId = "B";
+
+  dispatcher->onPrefillRequest(req);
+
+  ASSERT_EQ(requests.size(), 1u);
+  EXPECT_EQ(requests[0].prefillServerId, "B");
+}
+
+TEST_F(DispatcherTest, MissingPreferredPrefillFallsBackToRouting) {
+  markAllHealthy();
+  registry.addCachedBlocks("A", {99});
+  auto req = makeRequest(7, /*hash=*/99);
+  req.preferredPrefillId = "missing";
+
+  dispatcher->onPrefillRequest(req);
+
+  ASSERT_EQ(requests.size(), 1u);
+  EXPECT_EQ(requests[0].prefillServerId, "A");
+}
+
+TEST_F(DispatcherTest, FullPreferredPrefillFallsBackToRouting) {
+  markAllHealthy();
+  registry.addCachedBlocks("A", {99});
+  registry.incrementInflight("B");
+  registry.incrementInflight("B");
+  registry.incrementInflight("B");
+  registry.incrementInflight("B");
+  auto req = makeRequest(7, /*hash=*/99);
+  req.preferredPrefillId = "B";
+
+  dispatcher->onPrefillRequest(req);
+
+  ASSERT_EQ(requests.size(), 1u);
+  EXPECT_EQ(requests[0].prefillServerId, "A");
+}
+
 TEST_F(DispatcherTest, ResultIsForwardedToDecode) {
   markAllHealthy();
   dispatcher->onPrefillRequest(makeRequest(5, /*hash=*/0));

--- a/tt-media-server/prefill_gateway/tests/prefill_selector_test.cpp
+++ b/tt-media-server/prefill_gateway/tests/prefill_selector_test.cpp
@@ -26,8 +26,9 @@ PrefillSnapshot prefixMatchedPrefill(std::string id, size_t prefixMatchDepth,
 }
 
 std::optional<std::string> selectedServer(
-    const std::vector<PrefillSnapshot>& prefills, size_t& roundRobinCursor) {
-  return selectPrefill(prefills, roundRobinCursor).serverId;
+    const std::vector<PrefillSnapshot>& prefills, size_t& roundRobinCursor,
+    std::optional<std::string> preferredPrefillId = std::nullopt) {
+  return selectPrefill(prefills, roundRobinCursor, preferredPrefillId).serverId;
 }
 
 TEST(PrefillSelectorTest, NoPeersAvailableWhenAllDown) {
@@ -86,6 +87,34 @@ TEST(PrefillSelectorTest, LongestPrefixMatchWinsOverLowerLoad) {
 
   ASSERT_TRUE(chosen.has_value());
   EXPECT_EQ(*chosen, "A");
+}
+
+TEST(PrefillSelectorTest, PreferredPrefillWinsWhenEligible) {
+  std::vector<PrefillSnapshot> prefills = {
+      prefixMatchedPrefill("A", /*prefixMatchDepth=*/3, /*inFlight=*/0),
+      prefixMatchedPrefill("B", /*prefixMatchDepth=*/0, /*inFlight=*/3)};
+  size_t cursor = 0;
+
+  const auto selection = selectPrefill(prefills, cursor, std::string("B"));
+
+  ASSERT_TRUE(selection.serverId.has_value());
+  EXPECT_EQ(*selection.serverId, "B");
+  EXPECT_EQ(selection.reason, PrefillRoutingReason::PreferredPrefill);
+  EXPECT_EQ(selection.prefixMatchDepth, 0u);
+}
+
+TEST(PrefillSelectorTest, IneligiblePreferredPrefillFallsBack) {
+  auto preferred = prefixMatchedPrefill("A", /*prefixMatchDepth=*/3);
+  preferred.acceptingTasks = false;
+  std::vector<PrefillSnapshot> prefills = {
+      preferred, prefixMatchedPrefill("B", /*prefixMatchDepth=*/1)};
+  size_t cursor = 0;
+
+  const auto selection = selectPrefill(prefills, cursor, std::string("A"));
+
+  ASSERT_TRUE(selection.serverId.has_value());
+  EXPECT_EQ(*selection.serverId, "B");
+  EXPECT_EQ(selection.reason, PrefillRoutingReason::PrefixMatch);
 }
 
 TEST(PrefillSelectorTest, PrefixMatchIgnoresIneligiblePrefills) {


### PR DESCRIPTION
- Add an optional `preferred_prefill_id` hint that Dynamo/raw requests can pass through decode to `PrefillGateway`.
- Make `PrefillGateway` honor the preferred prefill only when it is healthy, accepting tasks, and under capacity; otherwise it falls back to prefix/load/round-robin routing.
- Add selector and dispatcher coverage for preferred-prefill routing and fallback behavior.
