### PR TITLE
Add Engine Fields to Dynamo Protocol

### DIFF
--- a/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
+++ b/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
@@ -175,6 +175,10 @@ struct TokenChunk {
   std::optional<uint16_t> error_code;
   /// Populated on the final chunk only; serialized as `completion_usage`.
   std::optional<DynamoUsage> completion_usage;
+  /// When non-null, serialized as `engine_data`; the frontend surfaces it on
+  /// the response `nvext.engine_data` when the client requests it via
+  /// `nvext.extra_fields: ["engine_data"]`.
+  Json::Value engine_data;
 };
 
 /// Encode a TokenChunk as a NetworkStreamWrapper<Annotated<T>> JSON body.
@@ -208,6 +212,9 @@ struct GenerateRequest {
   std::optional<float> frequency_penalty;
   std::optional<float> presence_penalty;
   std::optional<float> repetition_penalty;
+
+  // Opaque passthrough from the request's top-level `mm_processor_kwargs`.
+  Json::Value mm_processor_kwargs;
 
   Json::Value raw;  // Full parsed JSON body, for any field we don't yet map.
 };

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
@@ -204,6 +204,12 @@ GenerateRequest parse_generate_request(const std::vector<uint8_t>& bodyBytes) {
     req.repetition_penalty = getOptFloat("repetition_penalty");
   }
 
+  if (j.isMember("mm_processor_kwargs") && !j["mm_processor_kwargs"].isNull()) {
+    req.mm_processor_kwargs = j["mm_processor_kwargs"];
+    TT_LOG_INFO("[DynamoRx] mm_processor_kwargs received: {}",
+                dumpJsonCompact(req.mm_processor_kwargs));
+  }
+
   return req;
 }
 
@@ -265,6 +271,10 @@ std::vector<uint8_t> encode_stream_chunk(const TokenChunk& chunk) {
       cu["completion_tokens_details"] = std::move(ctd);
     }
     tokenData["completion_usage"] = std::move(cu);
+  }
+
+  if (!chunk.engine_data.isNull()) {
+    tokenData["engine_data"] = chunk.engine_data;
   }
 
   // Annotated<T>: {"data": <token_data>}


### PR DESCRIPTION
## Problem
Since we receive tokenized prompts from Dynamo, it avoids sending unnecessary fields and we are constrained to keep request and response formats aligned with the Dynamo structures.
If there is ever a need to pass additional metadata between user and cpp_server but through Dynamo, we can use the newly added `mm_processor_kwargs` and `engine_data` fields as an extension mechanism.

Note that to include `engine_data` in the response, the request must explicitly set:
```
extra_fields:["engine_data"],
```