### PR TITLE
Stop reporting a not-ready media model as 405 Method Not Allowed

### DIFF
--- a/tt-media-server/model_services/scheduler.py
+++ b/tt-media-server/model_services/scheduler.py
@@ -124,7 +124,7 @@ class Scheduler:
 
     def check_is_model_ready(self) -> bool:
         if self.is_ready is not True:
-            raise HTTPException(405, "Model is not ready")
+            raise HTTPException(503, "Model is not ready: warming up")
 
         # Check if at least one worker is ready
         ready_workers = [

--- a/tt-media-server/open_ai_api/audio.py
+++ b/tt-media-server/open_ai_api/audio.py
@@ -123,7 +123,7 @@ async def handle_audio_request(audio_request, service):
             try:
                 service.scheduler.check_is_model_ready()
             except Exception:
-                raise HTTPException(status_code=405, detail="Model is not ready")
+                raise HTTPException(status_code=503, detail="Model is not ready")
 
             async def result_stream():
                 async for partial in service.process_streaming_request(audio_request):

--- a/tt-media-server/open_ai_api/chat.py
+++ b/tt-media-server/open_ai_api/chat.py
@@ -159,7 +159,7 @@ async def chat_completions(
         try:
             service.scheduler.check_is_model_ready()
         except Exception:
-            raise HTTPException(status_code=405, detail="Model is not ready")
+            raise HTTPException(status_code=503, detail="Model is not ready")
 
         async def result_stream():
             accumulated_text = ""

--- a/tt-media-server/open_ai_api/fine_tuning.py
+++ b/tt-media-server/open_ai_api/fine_tuning.py
@@ -57,7 +57,7 @@ async def submit_fine_tuning_request(
     try:
         service.scheduler.check_is_model_ready()
     except Exception:
-        raise HTTPException(status_code=405, detail="Model is not ready")
+        raise HTTPException(status_code=503, detail="Model is not ready")
 
     settings = get_settings()
     if request.device_type != settings.device:

--- a/tt-media-server/open_ai_api/llm.py
+++ b/tt-media-server/open_ai_api/llm.py
@@ -143,7 +143,7 @@ async def complete_text(
         try:
             service.scheduler.check_is_model_ready()
         except Exception:
-            raise HTTPException(status_code=405, detail="Model is not ready")
+            raise HTTPException(status_code=503, detail="Model is not ready")
 
         async def result_stream():
             async for partial in service.process_streaming_request(sub_requests[0]):

--- a/tt-media-server/open_ai_api/tt_maintenance_api.py
+++ b/tt-media-server/open_ai_api/tt_maintenance_api.py
@@ -21,9 +21,10 @@ def liveness(service: BaseService = Depends(service_resolver)) -> dict[str, Any]
 
     Raises:
         HTTPException: If service is unavailable or model check fails.
-            HTTPExceptions raised by the service (e.g. 405 "model not ready",
-            503 "no workers available") are propagated unchanged so callers
-            can distinguish "still warming up" from "actually broken".
+            HTTPExceptions raised by the service are propagated unchanged:
+            503 "Model is not ready: warming up" while the model is still
+            initializing, and 503 "no workers available" when no worker is
+            ready. Returns 200 only once the model is serving.
     """
     try:
         return {"status": "alive", **service.check_is_model_ready()}

--- a/tt-media-server/open_ai_api/video.py
+++ b/tt-media-server/open_ai_api/video.py
@@ -138,7 +138,7 @@ async def _submit_video_request(
     try:
         service.scheduler.check_is_model_ready()
     except Exception:
-        raise HTTPException(status_code=405, detail="Model is not ready")
+        raise HTTPException(status_code=503, detail="Model is not ready")
 
     try:
         # Synchronous mode: process and return video directly

--- a/tt-media-server/tests/test_scheduler.py
+++ b/tt-media-server/tests/test_scheduler.py
@@ -151,7 +151,7 @@ class TestScheduler:
         with pytest.raises(Exception) as exc_info:
             scheduler.check_is_model_ready()
 
-        assert "405" in str(exc_info.value) or "Model is not ready" in str(
+        assert "503" in str(exc_info.value) or "Model is not ready" in str(
             exc_info.value
         )
 
@@ -201,7 +201,7 @@ class TestScheduler:
         with pytest.raises(Exception) as exc_info:
             scheduler.process_request(mock_request)
 
-        assert "405" in str(exc_info.value) or "Model is not ready" in str(
+        assert "503" in str(exc_info.value) or "Model is not ready" in str(
             exc_info.value
         )
 


### PR DESCRIPTION
## What this fixes

When a media model isn't ready yet (still warming up), the server replied to requests with HTTP **405 Method Not Allowed**. That status is the wrong *kind* of signal: 405 means "you're calling this endpoint the wrong way" — a client/method/contract error. It says nothing about the model, and it points whoever sees it at the wrong problem.

That mislabeling had real consequences. Our CI health probe hit the endpoint, saw 405, and concluded the endpoint itself was broken — so it gave up instead of waiting for warmup. A human reading the same 405 would reasonably go check routing, methods, or the URL — none of which were actually wrong.

The fix makes every not-ready path return **503 Service Unavailable**, which truthfully describes the situation: the endpoint is correct, the service is just temporarily not ready. Callers (CI, the cloud console, Kubernetes) already treat 503 as "retry shortly," so nothing on their side changes.

This is purely about *what the endpoint reports*. It does **not** change which endpoint anything hits, the routes, the methods, or the paths.

## What changed

- The scheduler's readiness check returns 503 ("warming up") instead of 405.
- The same 405 was duplicated in five request endpoints (chat, llm, audio, video, fine-tuning) — all switched to 503.
- Updated the `/tt-liveness` docstring and two tests to match.

## Tested

- `tests/test_scheduler.py` — 23 passed
- `tests/test_tt_maintenance_api.py` — 12 passed
- Validation runs across media models + devices dispatched (see comment below).

## Out of scope (separate follow-up)

Two related-but-distinct items are **not** in this PR: (1) which endpoint consumers should probe (`/health` vs `/tt-liveness`), and (2) making the server actually detect a *hung* (not just not-ready) model and report it unhealthy. Those are tracked separately.