### PR TITLE
Wire canary monitor to real device health checks

### DIFF
--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -89,7 +89,8 @@ class Settings(BaseSettings):
     # Canary monitor settings (see health_monitoring/).
     canary_enabled: bool = True
     # When False, monitor observes only (logs/metrics); set True to gate /health with 503.
-    canary_gate_readiness: bool = False
+    # Kill-switch: set CANARY_GATE_READINESS=false in container env to disable without code change.
+    canary_gate_readiness: bool = True
     # Seconds of idle before a probe fires.
     canary_wait_seconds: float = 5.0
     # Per-probe round-trip deadline; a timeout counts as one miss.
@@ -102,8 +103,8 @@ class Settings(BaseSettings):
     # For multihost pipelines set this >= sp_warmup_timeout_seconds.
     canary_startup_grace_seconds: float = 30.0
     # When True, every Nth probe replays the compiled warmup forward to certify device liveness.
-    # Off by default: consumes device cycles and requires the warmup shape to avoid recompiles.
-    canary_deep_probe_enabled: bool = False
+    # Kill-switch: set CANARY_DEEP_PROBE_ENABLED=false in container env to disable without code change.
+    canary_deep_probe_enabled: bool = True
     # Run a deep probe every Nth idle probe; the rest are cheap host collectives.
     canary_deep_every_n: int = 3
     # Deadline for deep probes; must be much larger than canary_probe_timeout_seconds.

--- a/tt-media-server/model_services/scheduler.py
+++ b/tt-media-server/model_services/scheduler.py
@@ -124,7 +124,7 @@ class Scheduler:
 
     def check_is_model_ready(self) -> bool:
         if self.is_ready is not True:
-            raise HTTPException(405, "Model is not ready")
+            raise HTTPException(503, "Model is not ready: warming up")
 
         # Check if at least one worker is ready
         ready_workers = [

--- a/tt-media-server/open_ai_api/audio.py
+++ b/tt-media-server/open_ai_api/audio.py
@@ -123,7 +123,7 @@ async def handle_audio_request(audio_request, service):
             try:
                 service.scheduler.check_is_model_ready()
             except Exception:
-                raise HTTPException(status_code=405, detail="Model is not ready")
+                raise HTTPException(status_code=503, detail="Model is not ready")
 
             async def result_stream():
                 async for partial in service.process_streaming_request(audio_request):

--- a/tt-media-server/open_ai_api/chat.py
+++ b/tt-media-server/open_ai_api/chat.py
@@ -159,7 +159,7 @@ async def chat_completions(
         try:
             service.scheduler.check_is_model_ready()
         except Exception:
-            raise HTTPException(status_code=405, detail="Model is not ready")
+            raise HTTPException(status_code=503, detail="Model is not ready")
 
         async def result_stream():
             accumulated_text = ""

--- a/tt-media-server/open_ai_api/fine_tuning.py
+++ b/tt-media-server/open_ai_api/fine_tuning.py
@@ -57,7 +57,7 @@ async def submit_fine_tuning_request(
     try:
         service.scheduler.check_is_model_ready()
     except Exception:
-        raise HTTPException(status_code=405, detail="Model is not ready")
+        raise HTTPException(status_code=503, detail="Model is not ready")
 
     settings = get_settings()
     if request.device_type != settings.device:

--- a/tt-media-server/open_ai_api/llm.py
+++ b/tt-media-server/open_ai_api/llm.py
@@ -143,7 +143,7 @@ async def complete_text(
         try:
             service.scheduler.check_is_model_ready()
         except Exception:
-            raise HTTPException(status_code=405, detail="Model is not ready")
+            raise HTTPException(status_code=503, detail="Model is not ready")
 
         async def result_stream():
             async for partial in service.process_streaming_request(sub_requests[0]):

--- a/tt-media-server/open_ai_api/tt_maintenance_api.py
+++ b/tt-media-server/open_ai_api/tt_maintenance_api.py
@@ -21,9 +21,10 @@ def liveness(service: BaseService = Depends(service_resolver)) -> dict[str, Any]
 
     Raises:
         HTTPException: If service is unavailable or model check fails.
-            HTTPExceptions raised by the service (e.g. 405 "model not ready",
-            503 "no workers available") are propagated unchanged so callers
-            can distinguish "still warming up" from "actually broken".
+            HTTPExceptions raised by the service are propagated unchanged:
+            503 "Model is not ready: warming up" while the model is still
+            initializing, and 503 "no workers available" when no worker is
+            ready. Returns 200 only once the model is serving.
     """
     try:
         return {"status": "alive", **service.check_is_model_ready()}

--- a/tt-media-server/open_ai_api/video.py
+++ b/tt-media-server/open_ai_api/video.py
@@ -138,7 +138,7 @@ async def _submit_video_request(
     try:
         service.scheduler.check_is_model_ready()
     except Exception:
-        raise HTTPException(status_code=405, detail="Model is not ready")
+        raise HTTPException(status_code=503, detail="Model is not ready")
 
     try:
         # Synchronous mode: process and return video directly

--- a/tt-media-server/tests/test_scheduler.py
+++ b/tt-media-server/tests/test_scheduler.py
@@ -151,7 +151,7 @@ class TestScheduler:
         with pytest.raises(Exception) as exc_info:
             scheduler.check_is_model_ready()
 
-        assert "405" in str(exc_info.value) or "Model is not ready" in str(
+        assert "503" in str(exc_info.value) or "Model is not ready" in str(
             exc_info.value
         )
 
@@ -201,7 +201,7 @@ class TestScheduler:
         with pytest.raises(Exception) as exc_info:
             scheduler.process_request(mock_request)
 
-        assert "405" in str(exc_info.value) or "Model is not ready" in str(
+        assert "503" in str(exc_info.value) or "Model is not ready" in str(
             exc_info.value
         )
 

--- a/tt-media-server/tt_model_runners/base_metal_device_runner.py
+++ b/tt-media-server/tt_model_runners/base_metal_device_runner.py
@@ -21,6 +21,21 @@ class BaseMetalDeviceRunner(BaseDeviceRunner):
         self.max_batch_size = self.settings.max_batch_size
         return self.ttnn_device
 
+    def health_check(self, deep: bool = False) -> bool:
+        if self.ttnn_device is None:
+            self.logger.warning(
+                f"Device {self.device_id}: health_check called before set_device()"
+            )
+            return False
+        try:
+            self.ttnn_device.get_num_devices()
+            return True
+        except Exception as e:
+            self.logger.warning(
+                f"Device {self.device_id}: health_check device ping failed: {e}"
+            )
+            return False
+
     def close_device(self):
         try:
             self.logger.info(f"Device {self.device_id}: Closing mesh device...")

--- a/tt-media-server/tt_model_runners/base_sdxl_runner.py
+++ b/tt-media-server/tt_model_runners/base_sdxl_runner.py
@@ -142,6 +142,20 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
 
         return True
 
+    def health_check(self, deep: bool = False) -> bool:
+        if not super().health_check():
+            return False
+        if not deep or self.tt_sdxl is None:
+            return True
+        try:
+            self._warmup_inference_block()
+            return True
+        except Exception as e:
+            self.logger.warning(
+                f"Device {self.device_id}: deep health_check failed: {e}"
+            )
+            return False
+
     @abstractmethod
     def run(self, requests: list[ImageGenerateRequest]):
         pass

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -177,6 +177,31 @@ class TTDiTRunner(BaseMetalDeviceRunner):
             num_inference_steps=2,
         )
 
+    def health_check(self, deep: bool = False) -> bool:
+        if not super().health_check():
+            return False
+        if not deep or self.pipeline is None:
+            return True
+        try:
+            if self.settings.model_service == ModelServices.IMAGE.value:
+                self.run(
+                    [
+                        ImageGenerateRequest.model_construct(
+                            prompt="health",
+                            negative_prompt="",
+                            num_inference_steps=2,
+                        )
+                    ]
+                )
+            elif self.settings.model_service == ModelServices.VIDEO.value:
+                self.run([self._build_warmup_video_request()])
+            return True
+        except Exception as e:
+            self.logger.warning(
+                f"Device {self.device_id}: deep health_check failed: {e}"
+            )
+            return False
+
     @log_execution_time(
         f"{dit_runner_log_map[get_settings().model_runner]} inference",
         TelemetryEvent.MODEL_INFERENCE,


### PR DESCRIPTION
## Summary

The media server had a silent gap: a worker that hangs mid-inference keeps reporting healthy because the canary monitor's device probes were no-ops. This PR closes that gap.

**What was broken:** \`BaseMetalDeviceRunner.health_check()\` always returned \`True\`. The canary monitor called it dutifully, declared the device alive, and \`/health\` + \`/tt-liveness\` stayed at 200 — even while the worker was wedged.

**What this fixes:**
- Adds a real shallow probe to \`BaseMetalDeviceRunner\` (pings the TTNN mesh device handle)
- Adds deep-probe overrides to \`TTDiTRunner\` (FLUX, Wan, etc.) and \`BaseSDXLRunner\` — both replay the 2-step compiled warmup forward, reusing the existing trace
- Flips \`canary_gate_readiness=True\` and \`canary_deep_probe_enabled=True\` so a DEAD canary surfaces as \`503\` on both endpoints instead of silently absorbing requests

**Kill-switch:** set \`CANARY_GATE_READINESS=false\` or \`CANARY_DEEP_PROBE_ENABLED=false\` in the container env to revert without a code change.

This PR also includes the 405→503 fix from #4274 (cherry-picked), so #4274 can be closed.

Closes #4275

## Validation runs

| Model | Device | Run |
|---|---|---|
| whisper-large-v3 | p150 | [27720892450](https://github.com/tenstorrent/tt-shield/actions/runs/27720892450) |
| speecht5_tts | p150 | [27720895691](https://github.com/tenstorrent/tt-shield/actions/runs/27720895691) |
| Wan2.2-T2V-A14B-Diffusers | bh-qb-ge | [27720899389](https://github.com/tenstorrent/tt-shield/actions/runs/27720899389) |
| whisper-large-v3 | bh-galaxy | [27720902581](https://github.com/tenstorrent/tt-shield/actions/runs/27720902581) |
| Wan2.2-T2V-A14B-Diffusers | bh-galaxy | [27720905720](https://github.com/tenstorrent/tt-shield/actions/runs/27720905720) |
| Wan2.2-I2V-A14B-Diffusers | bh-galaxy | [27720909813](https://github.com/tenstorrent/tt-shield/actions/runs/27720909813) |
| stable-diffusion-xl-base-1.0 | bh-galaxy | [27720912861](https://github.com/tenstorrent/tt-shield/actions/runs/27720912861) |
| mochi-1-preview | bh-galaxy | [27720916194](https://github.com/tenstorrent/tt-shield/actions/runs/27720916194) |
| whisper-large-v3 | 6u | [27720919662](https://github.com/tenstorrent/tt-shield/actions/runs/27720919662) |
| FLUX.1-dev | 6u | [27720923396](https://github.com/tenstorrent/tt-shield/actions/runs/27720923396) |
| Wan2.2-T2V-A14B-Diffusers | 6u | [27720926831](https://github.com/tenstorrent/tt-shield/actions/runs/27720926831) |
| stable-diffusion-xl-base-1.0 | 6u | [27720930555](https://github.com/tenstorrent/tt-shield/actions/runs/27720930555) |
| mochi-1-preview | 6u | [27720933870](https://github.com/tenstorrent/tt-shield/actions/runs/27720933870) |