### PR TITLE
Fix seed propagation for GPT-OSS-120B AIME25 evaluation

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -3360,6 +3360,7 @@ _eval_config_list = [
                     # values leave zero headroom, the Harmony path schedules
                     # a 1-token prefill, and every response comes back empty.
                     "max_gen_toks": 120 * 1024,
+                    "seed": "42",  # Fix non-deterministic outputs: ensure seed propagates to vLLM SamplingParams
                 },
             ),
             EvalTask(
@@ -3392,6 +3393,7 @@ _eval_config_list = [
                     "do_sample": "true",
                     "temperature": 1.0,
                     "max_gen_toks": 120 * 1024,
+                    "seed": "42",  # Fix non-deterministic outputs: ensure seed propagates to vLLM SamplingParams
                 },
             ),
             EvalTask(


### PR DESCRIPTION
## Problem
The seed parameter was not being propagated from lm-eval to vLLM's SamplingParams, causing non-deterministic outputs even though `--seed 42` was passed to lm-eval.

This caused AIME25 scores to vary between runs (e.g., 85-92%) even with identical test sets.

## Root Cause Analysis

### Current Flow
1. **lm-eval command**: `--seed 42` is passed at CLI level
   ```bash
   lm_eval --seed 42 --gen_kwargs stream=false,reasoning_effort=high,do_sample=true,temperature=1.0,max_gen_toks=122880
   ```

2. **Problem**: The `--seed 42` flag only controls dataset shuffling/ordering in lm-eval, but does NOT automatically propagate to API requests

3. **Missing in gen_kwargs**: The AIME25 task configuration had:
   ```python
   gen_kwargs={
       "stream": "false",
       "reasoning_effort": "high",
       "do_sample": "true",
       "temperature": 1.0,
       "max_gen_toks": 120 * 1024,
       # ❌ NO "seed": "42" here!
   }
   ```

4. **Result**: API requests arrive with `seed=None` → vLLM uses random seed → non-deterministic outputs

### Code Path
```
lm-eval --seed 42 
  → gen_kwargs (without seed)
    → CompletionRequest (seed=None)
      → build_sampling_params (falls back to default seed=None)
        → SamplingParams(seed=None)
          → vLLM generates with random seed
```

## Solution
Add `"seed": "42"` to gen_kwargs for GPT-OSS-120B tasks that use sampling:
- ✅ `aime25` task
- ✅ `gpqa_diamond_cot_zeroshot` task

This ensures the seed propagates correctly:
```
lm-eval --seed 42
  → gen_kwargs WITH seed="42"
    → CompletionRequest(seed=42)
      → build_sampling_params(seed=42)
        → SamplingParams(seed=42)
          → vLLM generates deterministically
```

## Testing
**Before fix**: Same prompt produces different outputs across runs  
**After fix**: Same prompt produces identical outputs (deterministic)

## Files Changed
- `evals/eval_config.py`: Added `"seed": "42"` to gen_kwargs for AIME25 and GPQA tasks

## References
- CI job showing non-determinism: https://github.com/tenstorrent/tt-shield/actions/runs/27737158390/job/82056362699
- Related models (DeepSeek-R1, etc.) already have `seed=42` configured correctly