### PR TITLE
Add spec tests for whisper+bh galaxy

### DIFF
--- a/tt-inference-server-v2/test_module/server_tests_config.json
+++ b/tt-inference-server-v2/test_module/server_tests_config.json
@@ -56,6 +56,7 @@
             "n300": "Tests for N300 device (2 chips)",
             "t3k": "Tests for T3K device (4 chips)",
             "galaxy": "Tests for Galaxy device (32 chips)",
+            "blackhole_galaxy": "Tests for Blackhole Galaxy device (32 P150 chips)",
             "p150": "Tests for P150 device (1 chip)",
             "p150x4": "Tests for P150x4 device (4 chips)",
             "p150x8": "Tests for P150x8 device (8 chips)",
@@ -179,7 +180,8 @@
             "compatible_devices": [
                 "n150",
                 "t3k",
-                "galaxy"
+                "galaxy",
+                "blackhole_galaxy"
             ]
         },
         "wan": {
@@ -371,6 +373,10 @@
             "liveness_retry_attempts": 120
         },
         "galaxy": {
+            "num_of_devices": 32,
+            "liveness_retry_attempts": 220
+        },
+        "blackhole_galaxy": {
             "num_of_devices": 32,
             "liveness_retry_attempts": 220
         },

--- a/tt-inference-server-v2/test_module/test_suites/audio.json
+++ b/tt-inference-server-v2/test_module/test_suites/audio.json
@@ -145,6 +145,67 @@
                     "description": "Test audio transcription params"
                 }
             ]
+        },
+        {
+            "_comment": "blackhole_galaxy whisper: mirrors the galaxy whisper test list/timings",
+            "models": [
+                "whisper"
+            ],
+            "devices": [
+                "blackhole_galaxy"
+            ],
+            "test_cases": [
+                {
+                    "template": "AudioTranscriptionLoadDp2Chunk5Test",
+                    "enabled": true,
+                    "description": "DP2 burst with 60s audio, chunk_duration_seconds=5",
+                    "targets": {
+                        "num_concurrent": 64,
+                        "dataset": "60s"
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionLoadDp2Chunk30Test",
+                    "enabled": true,
+                    "description": "DP2 burst with 60s audio, chunk_duration_seconds=30",
+                    "targets": {
+                        "num_concurrent": 64,
+                        "dataset": "60s"
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test audio 30s load",
+                    "targets": {
+                        "audio_transcription_time": 4
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test audio 60s load",
+                    "targets": {
+                        "audio_transcription_time": 7,
+                        "dataset": "60s"
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionLoadTest",
+                    "enabled": true,
+                    "description": "Test single audio 60s transcription and expect chunking",
+                    "targets": {
+                        "audio_transcription_time": 4,
+                        "num_concurrent_requests": 1,
+                        "dataset": "60s"
+                    }
+                },
+                {
+                    "template": "AudioTranscriptionParamTest",
+                    "enabled": true,
+                    "description": "Test audio transcription params"
+                }
+            ]
         }
     ],
     "test_suites": [


### PR DESCRIPTION
We were missing spec tests for whisper + bh galaxy ([CI run](https://github.com/tenstorrent/tt-shield/actions/runs/27793609626/job/82258260363)).