### PR TITLE
Use Model Agnostic Dynamo Frontend Image 

### DIFF
--- a/dynamo_frontend/Dockerfile.frontend
+++ b/dynamo_frontend/Dockerfile.frontend
@@ -38,9 +38,6 @@ RUN uv venv .venv --python 3.12 \
 COPY dynamo_frontend/patch_owned_by.sh /app/patch_owned_by.sh
 RUN chmod +x /app/patch_owned_by.sh && /app/patch_owned_by.sh
 
-# Install huggingface_hub for model downloads
-RUN . .venv/bin/activate && uv pip install huggingface_hub
-
 # Environment for Dynamo (all overridable at runtime via -e).
 # Defaults to etcd-backed discovery; ETCD_ENDPOINTS is the var Dynamo's
 # Python frontend reads (see cpp_server/scripts/start_dynamo.sh).
@@ -49,19 +46,15 @@ ENV DYN_DISCOVERY_BACKEND=etcd \
     DYN_REQUEST_PLANE=tcp \
     DYN_EVENT_PLANE=zmq \
     MODEL_NAME=mock-model \
-    MODEL_PATH=/app/model \
-    HF_MODEL_ID=deepseek-ai/DeepSeek-R1-0528 \
     HTTP_PORT=8000 \
     VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"
 
 EXPOSE 8000
 
-# Pre-fetch the tokenizer tree at the absolute path the worker advertises in its
-# MDC, using the SAME script the worker's build.sh runs (single source of truth).
-# With this baked in, no tokenizer bind-mount is needed at deploy time: just set
-# MODEL_PATH to the model subdir (e.g. .../tokenizers/moonshotai/Kimi-K2.6). The
-# dir is writable so entrypoint.sh's mkdir/optional-download still work.
+# Pre-fetch the tokenizer tree at the absolute path each worker advertises in its
+# MDC, using the SAME script the worker's build.sh runs (single source of truth),
+# so the frontend resolves every model's tokenizer locally with no bind-mount.
 # Pass HF_TOKEN as a build secret (--secret id=hf_token,...) to also fetch gated
 # tokenizers; public ones (DeepSeek, Kimi) need no token.
 COPY tt-media-server/cpp_server/scripts/fetch_tokenizers.sh /usr/local/bin/fetch_tokenizers.sh
@@ -71,7 +64,7 @@ RUN --mount=type=secret,id=hf_token \
        /usr/local/bin/fetch_tokenizers.sh \
        /home/container_app_user/app/server/cpp_server/tokenizers
 
-# Startup script: download model config/tokenizer if not present, then launch frontend
+# Startup script: launch the frontend.
 COPY dynamo_frontend/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 

--- a/dynamo_frontend/deploy.sh
+++ b/dynamo_frontend/deploy.sh
@@ -15,7 +15,6 @@ PROMETHEUS_HOST_PORT="${PROMETHEUS_HOST_PORT:-9090}"
 GRAFANA_HOST_PORT="${GRAFANA_HOST_PORT:-3000}"
 MODEL_NAME="tt-cpp-server"
 LLM_DEVICE_BACKEND="${LLM_DEVICE_BACKEND:-pipeline_manager}"
-WORKER_TOKENIZER_DIR="/home/container_app_user/app/server/cpp_server/tokenizers"
 MONITORING_COMPOSE="${REPO_ROOT}/tt-media-server/monitoring/docker-compose.yml"
 MONITORING_PROJECT_NAME="dynamo-monitoring"
 MONITORING_PROMETHEUS_NAME="dynamo-prometheus"
@@ -343,16 +342,14 @@ log "worker registered:"
 docker exec "$ETCD_NAME" etcdctl get --prefix --keys-only v1/ | grep -v '^$' | sed 's/^/[deploy]   /'
 
 # ── frontend ────────────────────────────────────────────────────────────────
-# The frontend image bakes the tokenizer tree at WORKER_TOKENIZER_DIR (same
-# fetch_tokenizers.sh the worker uses), so MODEL_PATH just points the entrypoint
-# at the baked dir — no tokenizer extraction or bind-mount needed.
+# The frontend image bakes the tokenizer tree at the path each worker advertises
+# in its MDC, so the run is model-agnostic: it resolves every discovered model's
+# tokenizer locally and serves whatever workers register in etcd.
 log "starting frontend ($FRONTEND_IMAGE)"
 docker run -d --name "$FRONTEND_NAME" --network "$NETWORK_NAME" -p "${FRONTEND_HOST_PORT}:8000" \
-    -e MODEL_PATH="${WORKER_TOKENIZER_DIR}/${HF_MODEL_ID}" \
     -e DYN_DISCOVERY_BACKEND=etcd \
     -e ETCD_ENDPOINTS="http://${ETCD_NAME}:2379" \
     -e MODEL_NAME="$MODEL_NAME" \
-    -e HF_MODEL_ID="$HF_MODEL_ID" \
     -e HF_TOKEN="${HF_TOKEN:-}" \
     -e DYN_CHAT_PROCESSOR="${DYN_CHAT_PROCESSOR:-dynamo}" \
     -e DYN_RUNTIME_NUM_WORKER_THREADS="${DYN_RUNTIME_NUM_WORKER_THREADS:-}" \

--- a/dynamo_frontend/entrypoint.sh
+++ b/dynamo_frontend/entrypoint.sh
@@ -1,40 +1,9 @@
 #!/bin/bash
 set -e
 
-MODEL_PATH="${MODEL_PATH:-/app/model}"
-HF_MODEL_ID="${HF_MODEL_ID:-deepseek-ai/DeepSeek-R1-0528}"
-
-mkdir -p "$MODEL_PATH"
-
-# Ensure config.json exists (required by frontend)
-if [ ! -f "$MODEL_PATH/config.json" ]; then
-    echo "[entrypoint] No config.json found, creating minimal config..."
-    cat > "$MODEL_PATH/config.json" << 'CONF'
-{"model_type":"llama","architectures":["LlamaForCausalLM"],"vocab_size":128256,"eos_token_id":[128001,128008,128009],"bos_token_id":128000}
-CONF
-fi
-
-# Download tokenizer if not already present
-if [ ! -f "$MODEL_PATH/tokenizer.json" ]; then
-    echo "[entrypoint] Downloading model files from $HF_MODEL_ID..."
-    python3 -c "
-from huggingface_hub import hf_hub_download
-import shutil, os
-model_id = os.environ.get('HF_MODEL_ID', '$HF_MODEL_ID')
-token = os.environ.get('HF_TOKEN', None)
-dest = '$MODEL_PATH'
-for f in ['config.json', 'tokenizer.json', 'tokenizer_config.json']:
-    try:
-        path = hf_hub_download(model_id, f, token=token)
-        shutil.copy(path, os.path.join(dest, f))
-        print(f'  Downloaded {f}')
-    except Exception as e:
-        print(f'  Skipped {f}: {e}')
-" || echo "[entrypoint] WARNING: HF download failed (gated model?). Frontend will start without tokenizer."
-    echo "[entrypoint] Model files ready."
-else
-    echo "[entrypoint] Model files already present at $MODEL_PATH"
-fi
+# Tokenizers are baked into the image at the path each worker advertises in its
+# MDC, so the frontend resolves every discovered model locally and serves
+# whatever registers in etcd — no --model-path overlay or runtime download.
 
 # Default to Dynamo's Rust-native chat processor. The HTTP server, router,
 # and preprocessing all live in Rust (driven by Tokio); Python is just the
@@ -103,7 +72,6 @@ fi
 echo "  DYN_REQUEST_PLANE=$DYN_REQUEST_PLANE"
 echo "  DYN_EVENT_PLANE=$DYN_EVENT_PLANE"
 echo "  MODEL_NAME=$MODEL_NAME"
-echo "  MODEL_PATH=$MODEL_PATH"
 echo "  DYN_CHAT_PROCESSOR=$DYN_CHAT_PROCESSOR"
 echo "  DYN_RUNTIME_NUM_WORKER_THREADS=$DYN_RUNTIME_NUM_WORKER_THREADS"
 echo "  DYN_RUNTIME_MAX_BLOCKING_THREADS=$DYN_RUNTIME_MAX_BLOCKING_THREADS"
@@ -117,7 +85,6 @@ echo "  ROUTER_MODE=${ROUTER_MODE:-<default>}"
 exec python -m dynamo.frontend \
     --http-port "$HTTP_PORT" \
     --model-name "$MODEL_NAME" \
-    --model-path "$MODEL_PATH" \
     --dyn-chat-processor "$DYN_CHAT_PROCESSOR" \
     --tokenizer "$DYN_TOKENIZER" \
     $ROUTER_MODE_FLAG \


### PR DESCRIPTION
## Issue
[#4302 Dynamo should not be restarted when deploying different models](https://github.com/tenstorrent/tt-inference-server/issues/4302)

## Problem 
We want to be able to reuse the same Dynamo Frontend Image across running different model deployments. What was holding us back were the `MODEL_PATH` and `HF_MODEL_ID` variables passed on starting of this image.

With this PR, a legacy path of downloading tokenizers at runtime is deleted - this is no longer needed since these files are baked into the Dynamo Frontend image, and with that the variables were no longer needed.