### PR TITLE
Use Basic Reasoning Parser for Minimax

### DIFF
--- a/tt-media-server/cpp_server/src/dynamo/discovery.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/discovery.cpp
@@ -152,7 +152,7 @@ RuntimeParsers runtimeParsersForModelType(const std::string& modelType) {
     return {"gpt_oss", "harmony"};
   }
   if (modelType == "minimax_m2") {
-    return {"minimax_append_think", "minimax_m2"};
+    return {"basic", "minimax_m2"};
   }
   // deepseek_v3 and unknown types default to DeepSeek R1 reasoning.
   return {"deepseek_r1", nullptr};


### PR DESCRIPTION
## Problem
Dynamo's `minimax_append_think` does not extract reasoning content, leaving raw `<think>` and `</think>` tokens in response.

## Testing
Tested on TT-Console