### PR TITLE
Mirror Motif x t3k target fixes into v2 test module

### DIFF
--- a/tt-inference-server-v2/test_module/load_param_tests/image_generation_param_test.py
+++ b/tt-inference-server-v2/test_module/load_param_tests/image_generation_param_test.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 _MODEL_DIFF_PARAM_OVERRIDES = {
     "FLUX.1-dev": {"seed": 0},
     "FLUX.1-schnell": {"seed": 0},
+    "Motif-Image-6B-Preview": {"seed": 0},
 }
 default_payload = {
     "prompt": "A beautiful sunset over a mountain landscape with vibrant colors",

--- a/tt-inference-server-v2/test_module/test_suites/image.json
+++ b/tt-inference-server-v2/test_module/test_suites/image.json
@@ -237,6 +237,9 @@
                         },
                         "motif+galaxy": {
                             "image_generation_time": 11
+                        },
+                        "motif+t3k": {
+                            "image_generation_time": 22
                         }
                     }
                 },
@@ -260,6 +263,9 @@
                         },
                         "motif+galaxy": {
                             "image_generation_time": 15
+                        },
+                        "motif+t3k": {
+                            "image_generation_time": 32
                         }
                     }
                 },
@@ -283,6 +289,9 @@
                         },
                         "motif+galaxy": {
                             "image_generation_time": 25
+                        },
+                        "motif+t3k": {
+                            "image_generation_time": 52
                         }
                     }
                 },


### PR DESCRIPTION
PR [#4300](https://github.com/tenstorrent/tt-inference-server/pull/4300) added motif+t3k load-test targets and the Motif SSIM seed override only to the v1 server_tests/ tree. Nightly CI runs the v2 test_module/ copy, so motif on t3k kept falling back to the base image_generation_time targets (10/14/23) and the diff-param test kept
using seed 42 for Motif, leaving the test red with stale targets.