### PR TITLE
forge SDXL: fix CLIPTokenizer call for transformers 5.x

### DIFF
--- a/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/sdxl_forge_runner.py
@@ -250,14 +250,20 @@ class SDXLForgeRunner(BaseDeviceRunner):
             (self.tokenizer_2, self.text_encoder_2),
         ]:
             cond_tokens = torch.tensor(
-                tokenizer.batch_encode_plus(
-                    [prompt], padding="max_length", max_length=77
+                tokenizer(
+                    [prompt],
+                    padding="max_length",
+                    max_length=77,
+                    truncation=True,
                 ).input_ids,
                 dtype=torch.long,
             )
             uncond_tokens = torch.tensor(
-                tokenizer.batch_encode_plus(
-                    [negative_prompt or ""], padding="max_length", max_length=77
+                tokenizer(
+                    [negative_prompt or ""],
+                    padding="max_length",
+                    max_length=77,
+                    truncation=True,
                 ).input_ids,
                 dtype=torch.long,
             )


### PR DESCRIPTION
## Problem

The Forge SDXL runner (`SDXLForgeRunner`) tokenizes prompts with `tokenizer.batch_encode_plus(...)`. That method was deprecated years ago and **removed in transformers 5.0**. On a worker venv built with transformers >= 5 it raises:

```
AttributeError: CLIPTokenizer has no attribute batch_encode_plus. Did you mean: '_encode_plus'?
  File ".../tt_model_runners/forge_runners/sdxl_forge_runner.py", line 253, in _encode_prompts
    tokenizer.batch_encode_plus(...)
  File ".../transformers/tokenization_utils_base.py", line 1301, in __getattr__
    raise AttributeError(f"{self.__class__.__name__} has no attribute {key}")
```

This crashed warmup (`Device 0: Warmup inference failed`) on the N150 Forge SDXL CI, so the run-tests step never came up and the job was cancelled — see tt-shield run [27950079537](https://github.com/tenstorrent/tt-shield/actions/runs/27950079537/job/82704604267#step:21:142). The CI image's worker venv was built with transformers 5.x + huggingface-hub 1.20.1, while older images pinned transformers 4.57.x (which still has `batch_encode_plus`), which is why this surfaced now.

## Fix

Replace the deprecated `batch_encode_plus(...)` calls with the standard callable form `tokenizer(...)`, which works on both transformers 4.x and 5.x and is the pattern used elsewhere in this repo. Also add `truncation=True` so prompts longer than the 77-token CLIP context are truncated instead of overflowing the fixed-size token tensor (a latent bug in the old call, which omitted truncation).

## Verification

Reproduced the exact failure locally in a transformers 5.5.4 / huggingface-hub 1.20.1 env, then confirmed the fixed call produces `(1, 77)` token tensors — including for >77-token prompts — under **both** transformers 4.57.6 and 5.5.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
