### PR TITLE
Mask longbench evals for Llama-3.1-8B-Instruct on p300x2

### DIFF
--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -957,6 +957,16 @@ templates:
       override_tt_config:
         sample_on_device_mode: decode_only
         trace_region_size: 155000000
+      known_issues:
+        - workflow_type: EVALS
+          task_name: longbench_code_e
+          reason: "LongBench code scores degraded on p300x2; masking pending investigation. Tracked in #4002."
+        - workflow_type: EVALS
+          task_name: longbench_fewshot_e
+          reason: "LongBench fewshot scores degraded on p300x2; masking pending investigation. Tracked in #4002."
+        - workflow_type: EVALS
+          task_name: longbench_summarization_e
+          reason: "LongBench summarization marginally below threshold on p300x2; masking to unblock release. Tracked in #4002."
     - device: P300
       max_concurrency: 32
       max_context: 131072  # 128 * 1024

--- a/workflows/model_specs/prod/llm.yaml
+++ b/workflows/model_specs/prod/llm.yaml
@@ -941,6 +941,16 @@ templates:
       override_tt_config:
         sample_on_device_mode: decode_only
         trace_region_size: 155000000
+      known_issues:
+        - workflow_type: EVALS
+          task_name: longbench_code_e
+          reason: "LongBench code scores degraded on p300x2; masking pending investigation. Tracked in #4002."
+        - workflow_type: EVALS
+          task_name: longbench_fewshot_e
+          reason: "LongBench fewshot scores degraded on p300x2; masking pending investigation. Tracked in #4002."
+        - workflow_type: EVALS
+          task_name: longbench_summarization_e
+          reason: "LongBench summarization marginally below threshold on p300x2; masking to unblock release. Tracked in #4002."
     - device: P300
       max_concurrency: 32
       max_context: 131072  # 128 * 1024


### PR DESCRIPTION
Three LongBench evals (code_e, fewshot_e, summarization_e) are blocking acceptance criteria for Llama-3.1-8B-Instruct on p300x2. Code and fewshot are known failures on this device; summarization is marginally below threshold and unlikely to be a real accuracy regression given all other evals pass. Masking all three in prod and dev specs to unblock the release workflow while tracked in #4002.