### PR TITLE
Support external runtime specs in release workflows

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -45,7 +45,7 @@ For detailed comparison, TTFT measurement differences, and usage guide, see [Ben
 
 ### `run_benchmarks.py`
 
-Purpose: Main script for vLLM benchmarks defined in `BENCHMARK_CONFIGS`, called by `run.py` via `run_workflows.py`.
+Purpose: Main script for benchmarks built from the resolved runtime model spec, called by `run.py` via `run_workflows.py`.
 
 ### `run_genai_benchmarks.py`
 
@@ -78,7 +78,7 @@ Purpose: defines all static information known ahead of run time for benchmarks t
 - **`BenchmarkConfig`**: a set of tasks for a specific model implementation.
 - **`BenchmarkTask`**: defines python environment to use and mapping of tasks to parameters for each device.
 - **`BenchmarkTaskParams`**: Defines how a benchmark should be run.
-- **`BENCHMARK_CONFIGS`**: Final dictionary mapping all internal model names to their BenchmarkConfig.
+- **`get_benchmark_config`**: Builds a `BenchmarkConfig` from the resolved runtime model spec.
 
 ## Benchmark Targets
 

--- a/benchmarking/benchmark_config.py
+++ b/benchmarking/benchmark_config.py
@@ -6,7 +6,6 @@ import os
 from dataclasses import dataclass, replace
 from typing import Dict, Iterable, List, Tuple
 
-from workflows.model_spec import MODEL_SPECS
 from workflows.utils_report import BenchmarkTaskParams, BenchmarkTaskParamsCNN
 from workflows.workflow_types import (
     BenchmarkTaskType,
@@ -539,13 +538,14 @@ def cap_benchmark_params(
     return params
 
 
-# define benchmark configs for each model and each device configuration
-# uses:
-# 1. BENCHMARK_ISL_OSL_PAIRS
-# 2. ISL_OSL_IMAGE_RESOLUTION_PAIRS
-# num_prompts is set dynamically based on OSL because that mostly sets how long the benchmark takes
-BENCHMARK_CONFIGS = {}
-for model_id, model_spec in MODEL_SPECS.items():
+def build_benchmark_config(model_spec) -> BenchmarkConfig:
+    """Build benchmark tasks directly from a resolved model spec.
+
+    Runtime model specs supplied through ``--runtime-model-spec-json`` may not be
+    present in import-time ``MODEL_SPECS``. They still carry the same
+    ``device_model_spec`` fields needed to generate benchmark tasks.
+    """
+
     # Since each ModelConfig now represents a single device, use that device and its max_concurrency
     device = model_spec.device_type
     model_max_concurrency = model_spec.device_model_spec.max_concurrency
@@ -693,4 +693,15 @@ for model_id, model_spec in MODEL_SPECS.items():
             )
         )
 
-    BENCHMARK_CONFIGS[model_id] = BenchmarkConfig(model_id=model_id, tasks=tasks)
+    return BenchmarkConfig(model_id=model_spec.model_id, tasks=tasks)
+
+
+def get_benchmark_config(model_spec) -> BenchmarkConfig:
+    """Build benchmark tasks from the resolved model spec.
+
+    ``--runtime-model-spec-json`` is already resolved into ``model_spec`` before
+    this helper runs. Do not consult the import-time catalog here: the runtime
+    JSON must override even when its ``model_id`` collides with a built-in spec.
+    """
+
+    return build_benchmark_config(model_spec)

--- a/benchmarking/run_benchmarks.py
+++ b/benchmarking/run_benchmarks.py
@@ -23,9 +23,9 @@ if project_root not in sys.path:
     sys.path.insert(0, str(project_root))
 
 from benchmarking.benchmark_config import (
-    BENCHMARK_CONFIGS,
     BenchmarkConfig,
     expand_concurrency_sweep_params,
+    get_benchmark_config,
     powers_of_two_up_to,
     select_smoke_test_benchmark_config,
 )
@@ -156,11 +156,7 @@ def main():
         os.environ["VLLM_API_KEY"] = "your-secret-key"
         logger.info("VLLM_API_KEY environment variable set to your-secret-key.")
 
-    # Look up the evaluation configuration for the model using BENCHMARK_CONFIGS.
-    if model_spec.model_id not in BENCHMARK_CONFIGS:
-        message = f"No benchmark tasks defined for model: {model_spec.model_name}"
-        raise ValueError(message)
-    benchmark_config = BENCHMARK_CONFIGS[model_spec.model_id]
+    benchmark_config = get_benchmark_config(model_spec)
     smoke_test_mode = _is_smoke_test_mode(runtime_config)
     if smoke_test_mode:
         benchmark_config = select_smoke_test_benchmark_config(benchmark_config, device)

--- a/tests/test_benchmark_config.py
+++ b/tests/test_benchmark_config.py
@@ -5,6 +5,7 @@
 
 import importlib
 import sys
+from dataclasses import replace
 from typing import Iterable, List, Optional, Set, Tuple
 
 import pytest
@@ -31,8 +32,8 @@ def _find_model_id(
 
 
 def _import_benchmark_config(monkeypatch):
-    # benchmark_config builds BENCHMARK_CONFIGS at import-time and optionally
-    # skips sweeps based on ONLY_BENCHMARK_TARGETS. We want sweeps enabled here.
+    # benchmark_config optionally skips sweeps based on ONLY_BENCHMARK_TARGETS.
+    # We want sweeps enabled here.
     #
     # NOTE: bool(os.getenv("ONLY_BENCHMARK_TARGETS")) treats any non-empty string
     # as True (including "0"), so we must *unset* the env var.
@@ -82,9 +83,7 @@ def test_benchmark_configs_selected_models_print_sweeps(
     model_id = _find_model_id(
         model_name=model_name, device=device, impl_name="tt-transformers"
     )
-    assert model_id in benchmark_config.BENCHMARK_CONFIGS
-
-    config = benchmark_config.BENCHMARK_CONFIGS[model_id]
+    config = benchmark_config.get_benchmark_config(MODEL_SPECS[model_id])
     assert config.model_id == model_id
     assert len(config.tasks) == 3  # perf_reference + sweeps + structured_output
 
@@ -175,7 +174,7 @@ def test_select_smoke_test_benchmark_config(
         model_name=model_name, device=device, impl_name="tt-transformers"
     )
 
-    config = benchmark_config.BENCHMARK_CONFIGS[model_id]
+    config = benchmark_config.get_benchmark_config(MODEL_SPECS[model_id])
     smoke_config = benchmark_config.select_smoke_test_benchmark_config(config, device)
 
     assert smoke_config.model_id == config.model_id
@@ -222,6 +221,45 @@ def test_select_smoke_test_benchmark_config_adds_smoke_pair_without_targets(
         *benchmark_config.SMOKE_TEST_BENCHMARK_PAIR, 1
     )
     assert getattr(smoke_sweep_params[0], "task_type", "text") == "text"
+
+
+def test_get_benchmark_config_uses_runtime_spec_even_when_model_id_collides(
+    monkeypatch,
+):
+    benchmark_config = _import_benchmark_config(monkeypatch)
+
+    source_id = _find_model_id(
+        model_name="Qwen3-8B", device=DeviceTypes.N150, impl_name="tt-transformers"
+    )
+    source_spec = MODEL_SPECS[source_id]
+    runtime_spec = replace(
+        source_spec,
+        device_model_spec=replace(
+            source_spec.device_model_spec,
+            max_context=256,
+            max_concurrency=32,
+        ),
+    )
+
+    config = benchmark_config.get_benchmark_config(runtime_spec)
+
+    assert config.model_id == source_id
+    assert len(config.tasks) == 3
+    assert runtime_spec.device_type in config.tasks[0].param_map
+    assert config.tasks[0].param_map[runtime_spec.device_type]
+
+    sweep_task = config.tasks[1]
+    sweep_params = sweep_task.param_map[runtime_spec.device_type]
+    assert [
+        p.max_concurrency
+        for p in sweep_params
+        if p.isl == 128 and p.osl == 128 and getattr(p, "task_type", "text") == "text"
+    ] == [1]
+    assert not [
+        p
+        for p in sweep_params
+        if p.isl == 128 and p.osl == 1024 and getattr(p, "task_type", "text") == "text"
+    ]
 
 
 def test_select_smoke_test_benchmark_config_skips_non_text_sweeps(monkeypatch):

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -660,20 +660,21 @@ class TestRuntimeValidation:
             ("stress_tests", True),
         ],
     )
-    def test_workflow_validation(
-        self, mock_model_spec, mock_runtime_config, workflow, should_pass
-    ):
+    def test_workflow_validation(self, mock_runtime_config, workflow, should_pass):
         """Test validation for different workflows."""
         mock_runtime_config.workflow = workflow
+        model_spec, _, _ = get_runtime_model_spec(
+            model="Mistral-7B-Instruct-v0.3", device="n150"
+        )
         with patch.dict(
             "workflows.validate_setup.MODEL_SPECS",
-            {mock_model_spec.model_id: mock_model_spec},
+            {model_spec.model_id: model_spec},
         ):
             if should_pass:
-                validate_runtime_args(mock_model_spec, mock_runtime_config)
+                validate_runtime_args(model_spec, mock_runtime_config)
             else:
                 with pytest.raises(AssertionError):
-                    validate_runtime_args(mock_model_spec, mock_runtime_config)
+                    validate_runtime_args(model_spec, mock_runtime_config)
 
     def test_server_workflow_validation(self, mock_model_spec, mock_runtime_config):
         """Test server workflow specific validation."""
@@ -711,6 +712,17 @@ class TestRuntimeValidation:
                 AssertionError, match="Cannot run --docker-server and --local-server"
             ):
                 validate_runtime_args(mock_model_spec, mock_runtime_config)
+
+    def test_external_runtime_model_spec_skips_catalog_membership(
+        self, mock_model_spec, mock_runtime_config
+    ):
+        """A supplied runtime spec is the source of truth for model/device support."""
+        mock_model_spec.model_id = "id_autoport_Mistral-7B-Instruct-v0.3_n150"
+        mock_runtime_config.workflow = "reports"
+        mock_runtime_config.runtime_model_spec_json = "/tmp/custom-runtime-spec.json"
+
+        with patch.dict("workflows.validate_setup.MODEL_SPECS", {}):
+            validate_runtime_args(mock_model_spec, mock_runtime_config)
 
 
 class TestOverrideArgsIntegration:

--- a/tests/test_setup_host.py
+++ b/tests/test_setup_host.py
@@ -783,7 +783,7 @@ class TestSetupHostValidation:
         mock_spec.model_name = "Llama-3.1-8B-Instruct"
 
         cli_defaults = {
-            "workflow": "benchmarks",
+            "workflow": "reports",
             "device": "n150",
             "model": "Llama-3.1-8B-Instruct",
             "docker_server": False,

--- a/workflows/run_workflows.py
+++ b/workflows/run_workflows.py
@@ -5,7 +5,7 @@
 import logging
 from dataclasses import dataclass
 
-from benchmarking.benchmark_config import BENCHMARK_CONFIGS
+from benchmarking.benchmark_config import get_benchmark_config
 from evals.eval_config import EVAL_CONFIGS
 from server_tests.test_categorization_system import TestFilter
 from server_tests.test_config import TEST_CONFIGS
@@ -56,14 +56,16 @@ class WorkflowSetup:
         ]
 
         self.config = None
-        _config = {
-            WorkflowType.EVALS: EVAL_CONFIGS.get(self.model_spec.model_name, {}),
-            WorkflowType.BENCHMARKS: BENCHMARK_CONFIGS.get(
-                self.model_spec.model_id, {}
-            ),
-            WorkflowType.TESTS: TEST_CONFIGS.get(self.model_spec.model_name, {}),
-            WorkflowType.STRESS_TESTS: {},
-        }.get(_workflow_type)
+        if _workflow_type == WorkflowType.EVALS:
+            _config = EVAL_CONFIGS.get(self.model_spec.model_name, {})
+        elif _workflow_type == WorkflowType.BENCHMARKS:
+            _config = get_benchmark_config(self.model_spec)
+        elif _workflow_type == WorkflowType.TESTS:
+            _config = TEST_CONFIGS.get(self.model_spec.model_name, {})
+        elif _workflow_type == WorkflowType.STRESS_TESTS:
+            _config = {}
+        else:
+            _config = None
         if _config:
             self.config = _config
 

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -7,7 +7,7 @@ import os
 import stat
 from pathlib import Path
 
-from benchmarking.benchmark_config import BENCHMARK_CONFIGS
+from benchmarking.benchmark_config import get_benchmark_config
 from evals.eval_config import EVAL_CONFIGS
 from server_tests.test_config import TEST_CONFIGS
 from workflows.model_spec import MODEL_SPECS
@@ -31,6 +31,10 @@ from workflows.workflow_types import (
 from workflows.workflow_venvs import VENV_CONFIGS
 
 logger = logging.getLogger("run_log")
+
+
+def _uses_external_runtime_model_spec(runtime_config) -> bool:
+    return bool(runtime_config.runtime_model_spec_json)
 
 
 def _check_image_version_supported(model_spec):
@@ -78,8 +82,9 @@ def validate_runtime_args(model_spec, runtime_config):
 
     model_id = model_spec.model_id
 
-    # Check if the model_id exists in MODEL_SPECS (this validates device support)
-    if model_id not in MODEL_SPECS:
+    # Built-in catalog runs must resolve to MODEL_SPECS. Explicit
+    # --runtime-model-spec-json runs use that JSON as the source of truth.
+    if model_id not in MODEL_SPECS and not _uses_external_runtime_model_spec(args):
         raise ValueError(
             f"model:={runtime_config.model} does not support device:={runtime_config.device}"
         )
@@ -107,9 +112,7 @@ def validate_runtime_args(model_spec, runtime_config):
     ):
         if os.getenv("OVERRIDE_BENCHMARKS"):
             logger.warning("OVERRIDE_BENCHMARKS is active, using override benchmarks")
-        assert model_spec.model_id in BENCHMARK_CONFIGS, (
-            f"Model:={model_spec.model_name} not found in BENCHMARKS_CONFIGS"
-        )
+        get_benchmark_config(model_spec)
     if workflow_type == WorkflowType.STRESS_TESTS:
         pass  # Model support already validated via MODEL_SPECS check
 
@@ -141,16 +144,12 @@ def validate_runtime_args(model_spec, runtime_config):
                 )
 
     if workflow_type == WorkflowType.RELEASE:
-        # NOTE: fail fast for models without both defined evals and benchmarks
-        # today this will stop models defined in MODEL_SPECS
-        # but not in EVAL_CONFIGS or BENCHMARK_CONFIGS, e.g. non-instruct models
-        # a run_*.log fill will be made for the failed combination indicating this
+        # NOTE: fail fast for models without both defined evals and generated
+        # benchmark tasks. A run_*.log file will be made for failed combinations.
         assert model_spec.model_name in EVAL_CONFIGS, (
             f"Model:={model_spec.model_name} not found in EVAL_CONFIGS"
         )
-        assert model_spec.model_id in BENCHMARK_CONFIGS, (
-            f"Model:={model_spec.model_name} not found in BENCHMARKS_CONFIGS"
-        )
+        get_benchmark_config(model_spec)
 
     if DeviceTypes.from_string(args.device) == DeviceTypes.GPU:
         if args.docker_server or args.local_server:


### PR DESCRIPTION
Codex: This fixes release workflows for generated/custom runtime model specs.

## Summary
- Treat `--runtime-model-spec-json` as the source of truth during setup validation instead of requiring the resolved `model_id` to exist in import-time `MODEL_SPECS`.
- Build benchmark configs directly from the resolved `ModelSpec` every time, including when the injected spec reuses a catalog `model_id`.
- Remove the import-time `BENCHMARK_CONFIGS` lookup path so benchmark task generation cannot silently fall back to a built-in spec.

## Problem
`run.py` can load a custom runtime model spec, but validation and benchmark setup still assumed the model was present in the built-in catalog. That made valid custom specs fail with errors like `model:=... does not support device:=...` or missing benchmark config. It also meant a custom spec that reused a catalog `model_id` could accidentally use catalog benchmark parameters instead of the JSON's device limits.

## Testing
- `.venv/bin/python -m pytest tests/test_setup_host.py::TestSetupHostValidation tests/test_benchmark_config.py tests/test_run_arguments.py`
- `.venv/bin/python -m ruff check benchmarking/benchmark_config.py benchmarking/run_benchmarks.py workflows/run_workflows.py workflows/validate_setup.py tests/test_benchmark_config.py tests/test_run_arguments.py tests/test_setup_host.py`
- `git diff --check`
