### PR TITLE
Bump lm-eval from 0.4.3 to 0.4.4

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -2587,96 +2587,96 @@ _eval_config_list = [
                     },
                 ),
             ),
-            EvalTask(
-                task_name="longbench_code_e",
-                min_context_required=16384,
-                score=EvalTaskScore(
-                    published_score=None,
-                    published_score_ref=None,
-                    gpu_reference_score=48.12,
-                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
-                    score_func=score_task_single_key,
-                    score_func_kwargs={
-                        "result_keys": ["score,none"],
-                        "unit": "percent",
-                    },
-                ),
-            ),
-            EvalTask(
-                task_name="longbench_fewshot_e",
-                min_context_required=16384,
-                score=EvalTaskScore(
-                    published_score=None,
-                    published_score_ref=None,
-                    gpu_reference_score=63.34,
-                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
-                    score_func=score_task_single_key,
-                    score_func_kwargs={
-                        "result_keys": ["score,none"],
-                        "unit": "percent",
-                    },
-                ),
-            ),
-            EvalTask(
-                task_name="longbench_multi_e",
-                min_context_required=16384,
-                score=EvalTaskScore(
-                    published_score=None,
-                    published_score_ref=None,
-                    gpu_reference_score=20.84,
-                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
-                    score_func=score_task_single_key,
-                    score_func_kwargs={
-                        "result_keys": ["score,none"],
-                        "unit": "percent",
-                    },
-                ),
-            ),
-            EvalTask(
-                task_name="longbench_single_e",
-                min_context_required=16384,
-                score=EvalTaskScore(
-                    published_score=None,
-                    published_score_ref=None,
-                    gpu_reference_score=22.22,
-                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
-                    score_func=score_task_single_key,
-                    score_func_kwargs={
-                        "result_keys": ["score,none"],
-                        "unit": "percent",
-                    },
-                ),
-            ),
-            EvalTask(
-                task_name="longbench_summarization_e",
-                min_context_required=16384,
-                score=EvalTaskScore(
-                    published_score=None,
-                    published_score_ref=None,
-                    gpu_reference_score=26.09,
-                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
-                    score_func=score_task_single_key,
-                    score_func_kwargs={
-                        "result_keys": ["score,none"],
-                        "unit": "percent",
-                    },
-                ),
-            ),
-            EvalTask(
-                task_name="longbench_synthetic_e",
-                min_context_required=16384,
-                score=EvalTaskScore(
-                    published_score=None,
-                    published_score_ref=None,
-                    gpu_reference_score=14.86,
-                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
-                    score_func=score_task_single_key,
-                    score_func_kwargs={
-                        "result_keys": ["score,none"],
-                        "unit": "percent",
-                    },
-                ),
-            ),
+            # EvalTask(
+            #     task_name="longbench_code_e",
+            #     min_context_required=16384,
+            #     score=EvalTaskScore(
+            #         published_score=None,
+            #         published_score_ref=None,
+            #         gpu_reference_score=48.12,
+            #         gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+            #         score_func=score_task_single_key,
+            #         score_func_kwargs={
+            #             "result_keys": ["score,none"],
+            #             "unit": "percent",
+            #         },
+            #     ),
+            # ),
+            # EvalTask(
+            #     task_name="longbench_fewshot_e",
+            #     min_context_required=16384,
+            #     score=EvalTaskScore(
+            #         published_score=None,
+            #         published_score_ref=None,
+            #         gpu_reference_score=63.34,
+            #         gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+            #         score_func=score_task_single_key,
+            #         score_func_kwargs={
+            #             "result_keys": ["score,none"],
+            #             "unit": "percent",
+            #         },
+            #     ),
+            # ),
+            # EvalTask(
+            #     task_name="longbench_multi_e",
+            #     min_context_required=16384,
+            #     score=EvalTaskScore(
+            #         published_score=None,
+            #         published_score_ref=None,
+            #         gpu_reference_score=20.84,
+            #         gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+            #         score_func=score_task_single_key,
+            #         score_func_kwargs={
+            #             "result_keys": ["score,none"],
+            #             "unit": "percent",
+            #         },
+            #     ),
+            # ),
+            # EvalTask(
+            #     task_name="longbench_single_e",
+            #     min_context_required=16384,
+            #     score=EvalTaskScore(
+            #         published_score=None,
+            #         published_score_ref=None,
+            #         gpu_reference_score=22.22,
+            #         gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+            #         score_func=score_task_single_key,
+            #         score_func_kwargs={
+            #             "result_keys": ["score,none"],
+            #             "unit": "percent",
+            #         },
+            #     ),
+            # ),
+            # EvalTask(
+            #     task_name="longbench_summarization_e",
+            #     min_context_required=16384,
+            #     score=EvalTaskScore(
+            #         published_score=None,
+            #         published_score_ref=None,
+            #         gpu_reference_score=26.09,
+            #         gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+            #         score_func=score_task_single_key,
+            #         score_func_kwargs={
+            #             "result_keys": ["score,none"],
+            #             "unit": "percent",
+            #         },
+            #     ),
+            # ),
+            # EvalTask(
+            #     task_name="longbench_synthetic_e",
+            #     min_context_required=16384,
+            #     score=EvalTaskScore(
+            #         published_score=None,
+            #         published_score_ref=None,
+            #         gpu_reference_score=14.86,
+            #         gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+            #         score_func=score_task_single_key,
+            #         score_func_kwargs={
+            #             "result_keys": ["score,none"],
+            #             "unit": "percent",
+            #         },
+            #     ),
+            # ),
         ],
     ),
     EvalConfig(

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -2587,96 +2587,96 @@ _eval_config_list = [
                     },
                 ),
             ),
-            # EvalTask(
-            #     task_name="longbench_code_e",
-            #     min_context_required=16384,
-            #     score=EvalTaskScore(
-            #         published_score=None,
-            #         published_score_ref=None,
-            #         gpu_reference_score=48.12,
-            #         gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
-            #         score_func=score_task_single_key,
-            #         score_func_kwargs={
-            #             "result_keys": ["score,none"],
-            #             "unit": "percent",
-            #         },
-            #     ),
-            # ),
-            # EvalTask(
-            #     task_name="longbench_fewshot_e",
-            #     min_context_required=16384,
-            #     score=EvalTaskScore(
-            #         published_score=None,
-            #         published_score_ref=None,
-            #         gpu_reference_score=63.34,
-            #         gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
-            #         score_func=score_task_single_key,
-            #         score_func_kwargs={
-            #             "result_keys": ["score,none"],
-            #             "unit": "percent",
-            #         },
-            #     ),
-            # ),
-            # EvalTask(
-            #     task_name="longbench_multi_e",
-            #     min_context_required=16384,
-            #     score=EvalTaskScore(
-            #         published_score=None,
-            #         published_score_ref=None,
-            #         gpu_reference_score=20.84,
-            #         gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
-            #         score_func=score_task_single_key,
-            #         score_func_kwargs={
-            #             "result_keys": ["score,none"],
-            #             "unit": "percent",
-            #         },
-            #     ),
-            # ),
-            # EvalTask(
-            #     task_name="longbench_single_e",
-            #     min_context_required=16384,
-            #     score=EvalTaskScore(
-            #         published_score=None,
-            #         published_score_ref=None,
-            #         gpu_reference_score=22.22,
-            #         gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
-            #         score_func=score_task_single_key,
-            #         score_func_kwargs={
-            #             "result_keys": ["score,none"],
-            #             "unit": "percent",
-            #         },
-            #     ),
-            # ),
-            # EvalTask(
-            #     task_name="longbench_summarization_e",
-            #     min_context_required=16384,
-            #     score=EvalTaskScore(
-            #         published_score=None,
-            #         published_score_ref=None,
-            #         gpu_reference_score=26.09,
-            #         gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
-            #         score_func=score_task_single_key,
-            #         score_func_kwargs={
-            #             "result_keys": ["score,none"],
-            #             "unit": "percent",
-            #         },
-            #     ),
-            # ),
-            # EvalTask(
-            #     task_name="longbench_synthetic_e",
-            #     min_context_required=16384,
-            #     score=EvalTaskScore(
-            #         published_score=None,
-            #         published_score_ref=None,
-            #         gpu_reference_score=14.86,
-            #         gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
-            #         score_func=score_task_single_key,
-            #         score_func_kwargs={
-            #             "result_keys": ["score,none"],
-            #             "unit": "percent",
-            #         },
-            #     ),
-            # ),
+            EvalTask(
+                task_name="longbench_code_e",
+                min_context_required=16384,
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=48.12,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["score,none"],
+                        "unit": "percent",
+                    },
+                ),
+            ),
+            EvalTask(
+                task_name="longbench_fewshot_e",
+                min_context_required=16384,
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=63.34,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["score,none"],
+                        "unit": "percent",
+                    },
+                ),
+            ),
+            EvalTask(
+                task_name="longbench_multi_e",
+                min_context_required=16384,
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=20.84,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["score,none"],
+                        "unit": "percent",
+                    },
+                ),
+            ),
+            EvalTask(
+                task_name="longbench_single_e",
+                min_context_required=16384,
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=22.22,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["score,none"],
+                        "unit": "percent",
+                    },
+                ),
+            ),
+            EvalTask(
+                task_name="longbench_summarization_e",
+                min_context_required=16384,
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=26.09,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["score,none"],
+                        "unit": "percent",
+                    },
+                ),
+            ),
+            EvalTask(
+                task_name="longbench_synthetic_e",
+                min_context_required=16384,
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=14.86,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["score,none"],
+                        "unit": "percent",
+                    },
+                ),
+            ),
         ],
     ),
     EvalConfig(

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -558,7 +558,6 @@ def build_eval_command(
     # lm-eval (text) expects full completions api route in base_url
     # lmms-eval (vision) expects base_url WITHOUT the endpoint path
     if task.workflow_venv_type in [
-        WorkflowVenvType.EVALS_META,
         WorkflowVenvType.EVALS_VISION,
     ]:
         _base_url = base_url

--- a/requirements/evals-meta.txt
+++ b/requirements/evals-meta.txt
@@ -13,7 +13,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 antlr4_python3_runtime==4.11
-lm-eval[math,ifeval,sentencepiece,vllm]==0.4.4
+lm-eval[api, math,ifeval,sentencepiece,vllm]==0.4.4
 pyjwt
 pillow
 datasets==3.1.0

--- a/requirements/evals-meta.txt
+++ b/requirements/evals-meta.txt
@@ -13,7 +13,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 antlr4_python3_runtime==4.11
-lm-eval[math,ifeval,sentencepiece,vllm]==0.4.3
+lm-eval[math,ifeval,sentencepiece,vllm]==0.4.4
 pyjwt
 pillow
 datasets==3.1.0


### PR DESCRIPTION
Addresses https://github.com/tenstorrent/tt-inference-server/issues/4225#issuecomment-4793232893

Proof of passing in Models CI dispatch https://github.com/tenstorrent/tt-shield/actions/runs/28121683483/job/83319687278. **Also note that we are seeing this in our Nightly https://github.com/tenstorrent/tt-shield/actions/runs/28061268478/job/83084686648#step:11:7277** so this fixes that issue too