### PR TITLE
Ben/bump metal evals lm eval main

### DIFF
--- a/requirements/evals-meta.txt
+++ b/requirements/evals-meta.txt
@@ -13,7 +13,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 antlr4_python3_runtime==4.11
-lm-eval[math,ifeval,sentencepiece,vllm]==0.4.3
+lm-eval[math,ifeval,sentencepiece,vllm]==0.4.4
 pyjwt
 pillow
 datasets==3.1.0

--- a/tt-inference-server-v2/llm_module/eval_command.py
+++ b/tt-inference-server-v2/llm_module/eval_command.py
@@ -238,7 +238,6 @@ def build_eval_command(
     # lm-eval (text) expects full completions api route in base_url
     # lmms-eval (vision) expects base_url WITHOUT the endpoint path
     if task.workflow_venv_type in [
-        WorkflowVenvType.EVALS_META,
         WorkflowVenvType.EVALS_VISION,
     ]:
         _base_url = base_url


### PR DESCRIPTION
This is the `main`-targeting equivalent of #4359 

Running Models CI dispatch here https://github.com/tenstorrent/tt-shield/actions/runs/28152359982