### PR TITLE
Set per-request migration start position

### DIFF
--- a/tt-media-server/cpp_server/include/domain/llm/llm_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/llm_request.hpp
@@ -127,6 +127,11 @@ struct LLMRequest : BaseRequest {
   // transfer / result. Generated on the prefill server and echoed back.
   std::optional<uint64_t> migrationId;
 
+  // Per-request KV migration start position for disaggregated prefill. Set by
+  // the prefill server after comparing prefill-side and decode-side matched
+  // prefix lengths.
+  std::optional<uint32_t> migrationStartPosition;
+
   // First free index in the per-user KV cache: the absolute KV position where
   // the worker writes the next token's KV, equal to the position of the first
   // token handed to the worker. The runner forwards it verbatim as

--- a/tt-media-server/cpp_server/include/domain/llm/sequence.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/sequence.hpp
@@ -46,7 +46,7 @@ class Sequence {
            int decodePositionId = 0, int decodeSkipTokens = 0,
            std::optional<uint64_t> migrationId = std::nullopt,
            bool startsInThinking = false,
-           std::optional<uint64_t> migrationStartPosition = std::nullopt);
+           std::optional<uint32_t> migrationStartPosition = std::nullopt);
 
   void serialize(std::ostream& os) const;
   static Sequence deserialize(std::istream& is);
@@ -97,10 +97,10 @@ class Sequence {
   const std::vector<int>& getBlockTable() const { return blockTable; }
   std::vector<int>& getMutableBlockTable() { return blockTable; }
 
-  std::optional<uint64_t> getMigrationStartPosition() const {
+  std::optional<uint32_t> getMigrationStartPosition() const {
     return migrationStartPosition;
   }
-  void setMigrationStartPosition(uint64_t position) {
+  void setMigrationStartPosition(uint32_t position) {
     migrationStartPosition = position;
   }
 
@@ -151,7 +151,7 @@ class Sequence {
   int decodeSkipTokens = 0;
   // Unique 64-bit ID correlating this sequence with a prefill migration.
   std::optional<uint64_t> migrationId;
-  std::optional<uint64_t> migrationStartPosition;
+  std::optional<uint32_t> migrationStartPosition;
   // Upstream-derived: prompt begins inside an unclosed think block.
   bool startsInThinking_ = false;
 };

--- a/tt-media-server/cpp_server/src/domain/llm/sequence.cpp
+++ b/tt-media-server/cpp_server/src/domain/llm/sequence.cpp
@@ -38,7 +38,7 @@ Sequence::Sequence(uint32_t taskId, int blockSize,
                    std::optional<uint32_t> kvPositionId, int decodePositionId,
                    int decodeSkipTokens, std::optional<uint64_t> migrationId,
                    bool startsInThinking,
-                   std::optional<uint64_t> migrationStartPosition)
+                   std::optional<uint32_t> migrationStartPosition)
     : taskId(taskId),
       status(SequenceStatus::WAITING),
       tokenIds(std::move(inputTokenIds)),
@@ -138,7 +138,7 @@ void Sequence::serialize(std::ostream& os) const {
   os.write(reinterpret_cast<const char*>(&hasMigrationStartPosition),
            sizeof(hasMigrationStartPosition));
   if (hasMigrationStartPosition) {
-    uint64_t migrationStartPositionValue = migrationStartPosition.value();
+    uint32_t migrationStartPositionValue = migrationStartPosition.value();
     os.write(reinterpret_cast<const char*>(&migrationStartPositionValue),
              sizeof(migrationStartPositionValue));
   }
@@ -213,7 +213,7 @@ Sequence Sequence::deserialize(std::istream& is) {
   is.read(reinterpret_cast<char*>(&hasMigrationStartPosition),
           sizeof(hasMigrationStartPosition));
   if (hasMigrationStartPosition) {
-    seq.migrationStartPosition = std::make_optional<uint64_t>(0);
+    seq.migrationStartPosition = std::make_optional<uint32_t>(0);
     is.read(reinterpret_cast<char*>(&(*seq.migrationStartPosition)),
             sizeof(*seq.migrationStartPosition));
   } else {

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -201,6 +201,16 @@ void DisaggregationService::setupSocketHandlers() {
                     fullPromptTokens >= trimmedPromptTokens
                         ? fullPromptTokens - trimmedPromptTokens
                         : 0);
+                request->migrationStartPosition =
+                    request->decode_skip_tokens < cachedTokens
+                        ? 0u
+                        : static_cast<uint32_t>(cachedTokens);
+                TT_LOG_DEBUG(
+                    "[DisaggregationService] taskId={} "
+                    "migrationStartPosition={} prefillMatchedTokens={} "
+                    "decodeSkipTokens={}",
+                    message.taskId, *request->migrationStartPosition,
+                    cachedTokens, request->decode_skip_tokens);
                 // Capture the resolved sessionId by value:
                 // submitStreamingRequest hands the request to the pipeline, so
                 // request->sessionId is no longer reliable by the time this

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -375,7 +375,8 @@ void LLMService::produceStream(
       std::make_unique<tt::domain::llm::SamplingParams>(
           tt::utils::mapper::mapSamplingParams(request)),
       request.kv_position_id, request.decode_position_id,
-      request.decode_skip_tokens, request.migrationId, startsInThinking);
+      request.decode_skip_tokens, request.migrationId, startsInThinking,
+      request.migrationStartPosition);
   taskQueue->push(*std::move(sequence));
 }
 

--- a/tt-media-server/cpp_server/tests/integration/server/prefill_integration_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/server/prefill_integration_test.cpp
@@ -496,6 +496,7 @@ TEST_F(PrefillIntegrationTest, MultiTurn_SubsequentRequestsAreContinuations) {
     req.temperature = 0.7f;
     req.topP = 0.9f;
     req.registrationHashes = hashes;
+    req.decodeSkipTokens = turn == 1 ? 0 : 100000;
 
     bool sent = mockDecode->send(tt::sockets::tags::PREFILL_REQUEST, req);
     ASSERT_TRUE(sent) << "Turn " << turn << ": failed to send";
@@ -516,6 +517,18 @@ TEST_F(PrefillIntegrationTest, MultiTurn_SubsequentRequestsAreContinuations) {
     // Delta prompt: only the new tokens should be sent (not the full prompt).
     EXPECT_LT(seq->getNumPromptTokens(), baseTokens.size())
         << "Turn " << turn << ": should send delta, not full prompt";
+    ASSERT_TRUE(seq->getKVPositionId().has_value())
+        << "Turn " << turn << ": continuation must set kv_position_id";
+    ASSERT_TRUE(seq->getMigrationStartPosition().has_value())
+        << "Turn " << turn << ": must set migration_start_position";
+    const uint32_t expectedMigrationStart =
+        req.decodeSkipTokens < static_cast<int>(*seq->getKVPositionId())
+            ? 0u
+            : *seq->getKVPositionId();
+    EXPECT_EQ(*seq->getMigrationStartPosition(), expectedMigrationStart)
+        << "Turn " << turn
+        << ": migration_start_position should full-migrate only when decode "
+           "has fewer matched tokens than prefill";
 
     tt::test::WorkerResponse(seq->taskId)
         .tokenWithFlags(42 + turn, tt::ipc::SharedToken::FLAG_FINAL)

--- a/tt-media-server/cpp_server/tests/integration/sessions/llm_service_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/sessions/llm_service_test.cpp
@@ -118,6 +118,25 @@ TEST(LLMServiceProcessStreamingRequest,
   EXPECT_FALSE(pushed->getStartsInThinking());
 }
 
+TEST(LLMServiceProcessStreamingRequest, PropagatesMigrationStartPosition) {
+  auto taskQueue = std::make_shared<tt::ipc::in_memory::TaskQueue>();
+  auto llmService = makeService(taskQueue);
+  tt::domain::llm::LLMRequest request{/*taskId=*/7};
+  request.prompt = std::vector<int>{10, 20, 30};
+  request.skip_special_tokens = true;
+  request.migrationStartPosition = 64;
+
+  llmService->submitStreamingRequest(
+      request, [](const tt::domain::llm::LLMStreamChunk&, bool) {},
+      /*skipPreProcess=*/true);
+
+  ASSERT_FALSE(taskQueue->empty());
+  auto pushed = taskQueue->tryPop();
+  ASSERT_NE(pushed, nullptr);
+  ASSERT_TRUE(pushed->getMigrationStartPosition().has_value());
+  EXPECT_EQ(*pushed->getMigrationStartPosition(), 64u);
+}
+
 int main(int argc, char** argv) {
   configureEnvForTest();
   ::testing::InitGoogleTest(&argc, argv);

--- a/tt-media-server/cpp_server/tests/unit/model/sequence_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/model/sequence_test.cpp
@@ -192,6 +192,7 @@ TEST(SequenceTest, SerializeDeserialize_RoundTrip_PreservesAllFields) {
   orig.setDecodeSkipTokens(11);
   orig.setMigrationId(0xDEADBEEFCAFE1234ULL);
   orig.setStartsInThinking(true);
+  orig.setMigrationStartPosition(128);
 
   std::ostringstream os;
   orig.serialize(os);
@@ -217,6 +218,9 @@ TEST(SequenceTest, SerializeDeserialize_RoundTrip_PreservesAllFields) {
   ASSERT_TRUE(restored.getMigrationId().has_value());
   EXPECT_EQ(*restored.getMigrationId(), *orig.getMigrationId());
   EXPECT_EQ(restored.getStartsInThinking(), orig.getStartsInThinking());
+  ASSERT_TRUE(restored.getMigrationStartPosition().has_value());
+  EXPECT_EQ(*restored.getMigrationStartPosition(),
+            *orig.getMigrationStartPosition());
 
   const auto& sp = restored.getSamplingParams();
   const auto& spOrig = orig.getSamplingParams();
@@ -276,6 +280,7 @@ TEST(SequenceTest, SerializeDeserialize_AfterAppendToken) {
 TEST(SequenceTest, SerializeDeserialize_MigrationIdUnsetRemainsNullopt) {
   Sequence orig(12345, 256, {10, 20}, SamplingParams{.max_tokens = 5});
   ASSERT_FALSE(orig.getMigrationId().has_value());
+  ASSERT_FALSE(orig.getMigrationStartPosition().has_value());
 
   std::ostringstream os;
   orig.serialize(os);
@@ -284,6 +289,7 @@ TEST(SequenceTest, SerializeDeserialize_MigrationIdUnsetRemainsNullopt) {
   Sequence restored = Sequence::deserialize(is);
 
   EXPECT_FALSE(restored.getMigrationId().has_value());
+  EXPECT_FALSE(restored.getMigrationStartPosition().has_value());
 }
 
 }  // namespace


### PR DESCRIPTION
- Compute `migrationStartPosition` on the prefill server per request.
- Use full-prefix migration when Decode has fewer matched tokens than Prefill.
- Otherwise migrate from the Prefill matched-token position for delta migration.