### PR TITLE
Fix Dynamo backend error streaming

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -666,6 +666,20 @@ target_include_directories(transport_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+add_executable(dynamo_protocol_test
+    tests/unit/dynamo/dynamo_protocol_test.cpp
+    src/dynamo/dynamo_protocol.cpp
+    src/utils/logger.cpp
+)
+target_link_libraries(dynamo_protocol_test PRIVATE
+    Drogon::Drogon
+    JsonCpp::JsonCpp
+    spdlog::spdlog
+    GTest::gtest_main)
+target_include_directories(dynamo_protocol_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
 if(ENABLE_BLAZE)
     add_executable(blaze_decode_runner_test
         tests/integration/runners/blaze_decode_runner_test.cpp
@@ -1001,6 +1015,7 @@ set_tests_properties(MainIntegrationTest PrefillIntegrationTest DisaggregatedE2E
 gtest_discover_tests(scheduler_test)
 gtest_discover_tests(llm_runner_test)
 gtest_discover_tests(transport_test)
+gtest_discover_tests(dynamo_protocol_test)
 if(ENABLE_BLAZE)
     gtest_discover_tests(blaze_decode_runner_test)
     gtest_discover_tests(blaze_prefill_runner_test)

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
@@ -23,6 +23,7 @@
 #include <thread>
 #include <utility>
 
+#include "domain/llm/llm_error_reason.hpp"
 #include "utils/logger.hpp"
 
 namespace tt::dynamo {
@@ -51,6 +52,31 @@ std::string dumpJsonCompact(const Json::Value& v) {
   writer["indentation"] = "";
   writer["emitUTF8"] = true;
   return Json::writeString(writer, v);
+}
+
+std::vector<uint8_t> encodeAnnotatedError(const std::string& message,
+                                          uint16_t code) {
+  // Encode the error message as a JSON payload with a status code so the
+  // Dynamo frontend's extract_backend_error_if_present() can parse it and
+  // return the correct HTTP status (e.g. 400 instead of default 500).
+  Json::Value errorPayload(Json::objectValue);
+  errorPayload["message"] = message;
+  errorPayload["code"] = code;
+  std::string errorJson = dumpJsonCompact(errorPayload);
+
+  Json::Value annotated(Json::objectValue);
+  annotated["data"] = Json::Value::null;
+  annotated["event"] = "error";
+  Json::Value comment(Json::arrayValue);
+  comment.append(errorJson);
+  annotated["comment"] = std::move(comment);
+
+  Json::Value wrapper(Json::objectValue);
+  wrapper["data"] = std::move(annotated);
+  wrapper["complete_final"] = false;
+
+  std::string s = dumpJsonCompact(wrapper);
+  return std::vector<uint8_t>(s.begin(), s.end());
 }
 
 std::string framedString(const TwoPartMessage& tp) {
@@ -217,27 +243,12 @@ std::vector<uint8_t> encode_stream_chunk(const TokenChunk& chunk) {
   // If this chunk carries an error, encode as Annotated::error format
   // so the Dynamo frontend's check_for_backend_error can intercept it.
   if (chunk.error.has_value()) {
-    // Encode the error message as a JSON payload with a status code so the
-    // Dynamo frontend's extract_backend_error_if_present() can parse it and
-    // return the correct HTTP status (e.g. 400 instead of default 500).
-    Json::Value errorPayload(Json::objectValue);
-    errorPayload["message"] = *chunk.error;
-    errorPayload["code"] = chunk.error_code.value_or(500);
-    std::string errorJson = dumpJsonCompact(errorPayload);
+    return encodeAnnotatedError(*chunk.error, chunk.error_code.value_or(500));
+  }
 
-    Json::Value annotated(Json::objectValue);
-    annotated["data"] = Json::Value::null;
-    annotated["event"] = "error";
-    Json::Value comment(Json::arrayValue);
-    comment.append(errorJson);
-    annotated["comment"] = std::move(comment);
-
-    Json::Value wrapper(Json::objectValue);
-    wrapper["data"] = std::move(annotated);
-    wrapper["complete_final"] = false;
-
-    std::string s = dumpJsonCompact(wrapper);
-    return std::vector<uint8_t>(s.begin(), s.end());
+  if (chunk.finish_reason.has_value() &&
+      tt::domain::llm::isErrorFinishReason(*chunk.finish_reason)) {
+    return encodeAnnotatedError(*chunk.finish_reason, 500);
   }
 
   Json::Value tokenData(Json::objectValue);

--- a/tt-media-server/cpp_server/tests/unit/dynamo/dynamo_protocol_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/dynamo/dynamo_protocol_test.cpp
@@ -19,8 +19,8 @@ Json::Value parseJson(const std::vector<uint8_t>& bytes) {
   std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
   std::string errors;
   const std::string body(bytes.begin(), bytes.end());
-  EXPECT_TRUE(reader->parse(body.data(), body.data() + body.size(), &root,
-                            &errors))
+  EXPECT_TRUE(
+      reader->parse(body.data(), body.data() + body.size(), &root, &errors))
       << errors;
   return root;
 }
@@ -31,8 +31,8 @@ Json::Value parseJsonString(const std::string& body) {
   builder["collectComments"] = false;
   std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
   std::string errors;
-  EXPECT_TRUE(reader->parse(body.data(), body.data() + body.size(), &root,
-                            &errors))
+  EXPECT_TRUE(
+      reader->parse(body.data(), body.data() + body.size(), &root, &errors))
       << errors;
   return root;
 }

--- a/tt-media-server/cpp_server/tests/unit/dynamo/dynamo_protocol_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/dynamo/dynamo_protocol_test.cpp
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#include "dynamo/dynamo_protocol.hpp"
+
+#include <gtest/gtest.h>
+#include <json/json.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+Json::Value parseJson(const std::vector<uint8_t>& bytes) {
+  Json::Value root;
+  Json::CharReaderBuilder builder;
+  builder["collectComments"] = false;
+  std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+  std::string errors;
+  const std::string body(bytes.begin(), bytes.end());
+  EXPECT_TRUE(reader->parse(body.data(), body.data() + body.size(), &root,
+                            &errors))
+      << errors;
+  return root;
+}
+
+Json::Value parseJsonString(const std::string& body) {
+  Json::Value root;
+  Json::CharReaderBuilder builder;
+  builder["collectComments"] = false;
+  std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+  std::string errors;
+  EXPECT_TRUE(reader->parse(body.data(), body.data() + body.size(), &root,
+                            &errors))
+      << errors;
+  return root;
+}
+
+}  // namespace
+
+TEST(DynamoProtocolTest, ErrorChunkUsesAnnotatedErrorNotFinishReasonError) {
+  tt::dynamo::TokenChunk chunk;
+  chunk.error = "prefill error";
+  chunk.error_code = 500;
+
+  const Json::Value wrapper = parseJson(tt::dynamo::encode_stream_chunk(chunk));
+
+  ASSERT_TRUE(wrapper.isObject());
+  EXPECT_FALSE(wrapper["complete_final"].asBool());
+  ASSERT_TRUE(wrapper["data"].isObject());
+
+  const Json::Value& annotated = wrapper["data"];
+  EXPECT_TRUE(annotated["data"].isNull());
+  EXPECT_EQ(annotated["event"].asString(), "error");
+  ASSERT_TRUE(annotated["comment"].isArray());
+  ASSERT_EQ(annotated["comment"].size(), 1u);
+
+  const Json::Value errorPayload =
+      parseJsonString(annotated["comment"][0].asString());
+  EXPECT_EQ(errorPayload["message"].asString(), "prefill error");
+  EXPECT_EQ(errorPayload["code"].asInt(), 500);
+  EXPECT_FALSE(annotated.isMember("finish_reason"));
+}
+
+TEST(DynamoProtocolTest, FinishReasonErrorUsesAnnotatedError) {
+  tt::dynamo::TokenChunk chunk;
+  chunk.finish_reason = "error";
+
+  const Json::Value wrapper = parseJson(tt::dynamo::encode_stream_chunk(chunk));
+
+  ASSERT_TRUE(wrapper.isObject());
+  EXPECT_FALSE(wrapper["complete_final"].asBool());
+  ASSERT_TRUE(wrapper["data"].isObject());
+
+  const Json::Value& annotated = wrapper["data"];
+  EXPECT_TRUE(annotated["data"].isNull())
+      << "Dynamo should not receive finish_reason=\"error\" as a normal "
+         "BackendOutput payload";
+  EXPECT_EQ(annotated["event"].asString(), "error");
+  ASSERT_TRUE(annotated["comment"].isArray());
+  ASSERT_EQ(annotated["comment"].size(), 1u);
+
+  const Json::Value errorPayload =
+      parseJsonString(annotated["comment"][0].asString());
+  EXPECT_EQ(errorPayload["message"].asString(), "error");
+  EXPECT_EQ(errorPayload["code"].asInt(), 500);
+}
+
+TEST(DynamoProtocolTest, TimeoutFinishReasonUsesAnnotatedError) {
+  tt::dynamo::TokenChunk chunk;
+  chunk.finish_reason = "timeout_error";
+
+  const Json::Value wrapper = parseJson(tt::dynamo::encode_stream_chunk(chunk));
+
+  ASSERT_TRUE(wrapper.isObject());
+  EXPECT_FALSE(wrapper["complete_final"].asBool());
+  ASSERT_TRUE(wrapper["data"].isObject());
+
+  const Json::Value& annotated = wrapper["data"];
+  EXPECT_TRUE(annotated["data"].isNull())
+      << "Dynamo should receive timeout_error as a backend error event";
+  EXPECT_EQ(annotated["event"].asString(), "error");
+  ASSERT_TRUE(annotated["comment"].isArray());
+  ASSERT_EQ(annotated["comment"].size(), 1u);
+
+  const Json::Value errorPayload =
+      parseJsonString(annotated["comment"][0].asString());
+  EXPECT_EQ(errorPayload["message"].asString(), "timeout_error");
+  EXPECT_EQ(errorPayload["code"].asInt(), 500);
+}
+
+TEST(DynamoProtocolTest, FinalDataChunkCanCarryStopFinishReason) {
+  tt::dynamo::TokenChunk chunk;
+  chunk.token_ids = {123};
+  chunk.finish_reason = "stop";
+
+  const Json::Value wrapper = parseJson(tt::dynamo::encode_stream_chunk(chunk));
+
+  ASSERT_TRUE(wrapper["data"].isObject());
+  ASSERT_TRUE(wrapper["data"]["data"].isObject());
+  EXPECT_EQ(wrapper["data"]["data"]["finish_reason"].asString(), "stop");
+  ASSERT_TRUE(wrapper["data"]["data"]["token_ids"].isArray());
+  EXPECT_EQ(wrapper["data"]["data"]["token_ids"][0].asInt(), 123);
+}


### PR DESCRIPTION
- Encode Dynamo error finish reasons (`error`, `timeout_error`) as annotated backend error events.
- Add protocol tests for generic and timeout error chunks.