### PR TITLE
Add dispatch subsystem: non-registered model support (runner seam + HF-config introspection floor)

### DIFF
--- a/tests/dispatch/__init__.py
+++ b/tests/dispatch/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/dispatch/conftest.py
+++ b/tests/dispatch/conftest.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared fixtures for the no-device dispatch tests (issue #46).
+
+These tests must NEVER touch a Tenstorrent device. The dispatch package only
+imports ttnn function-locally, so importing dispatcher/runner is safe — but a
+buggy test could still call into a code path that opens the device. To make that
+impossible, we replace `ttnn` in sys.modules with a stub whose open_device (and
+every other attribute) raises. Any test that accidentally tries to open the
+device fails loudly instead of hanging on missing hardware.
+
+This conftest's effect is scoped to the tests/dispatch/ directory — and the CI
+workflow runs only this directory — so the stub never leaks into device-bound
+runs of the wider suite.
+"""
+
+import sys
+import types
+
+
+class _ForbiddenTtnn(types.ModuleType):
+    """A fake ttnn module: any attribute access raises (no device in CI)."""
+
+    def __getattr__(self, name):  # noqa: D401 - simple guard
+        # Let dunders (__file__, __spec__, __path__, ...) behave as ABSENT so the
+        # interpreter's own introspection (inspect/import machinery, which torch's
+        # lazy op registration walks during `import torch`) doesn't trip over a
+        # callable where it expects a path/None.
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+
+        def _hard_fail(*args, **kwargs):
+            raise RuntimeError(
+                f"ttnn.{name} was called in a no-device CI test — forbidden. "
+                "These tests must run with no Tenstorrent card. If you need the "
+                "device, write the test in the device-bound harness under ~/dispatch/tests/."
+            )
+
+        # open_device specifically must hard-fail; return a raiser for everything else too.
+        return _hard_fail
+
+
+# Install the stub unconditionally so it shadows any real ttnn install too — these
+# tests are device-free by contract.
+sys.modules["ttnn"] = _ForbiddenTtnn("ttnn")

--- a/tests/dispatch/test_hardware.py
+++ b/tests/dispatch/test_hardware.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the dispatch-side hardware capability module (WS4).
+
+Covers the budget/grid policy math and the detection fallback ladder. No hardware:
+the tt-kernel and ttnn detectors are monkeypatched.
+"""
+import pytest
+
+from tt_inference_server.dispatch import hardware
+from tt_inference_server.dispatch.hardware import (
+    DEFAULT_CONFIG,
+    KNOWN_CONFIGS,
+    HardwareConfig,
+    detect_hardware,
+)
+
+
+def test_p150_budget_matches_legacy_compat_default():
+    # The whole behavior-preserving argument: detected p150 budget == compat fallback.
+    from tt_inference_server.dispatch.compat import _DEFAULT_L1_BUDGET_BYTES
+    assert KNOWN_CONFIGS["bh_p150_1card"].l1_budget() == _DEFAULT_L1_BUDGET_BYTES
+
+
+def test_budgets_apply_margins():
+    cfg = KNOWN_CONFIGS["bh_p150_1card"]
+    assert cfg.l1_budget() == int(1_572_864 * 0.915)
+    assert cfg.dram_budget() == int(32 * 1024**3 * 0.90)
+
+
+def test_grid_shape_factors_and_returns_python_ints():
+    cfg = KNOWN_CONFIGS["bh_p150_1card"]
+    cols, rows = cfg.grid_shape(32)
+    assert cols * rows == 32 and cols <= cfg.grid_x and rows <= cfg.grid_y
+    assert type(cols) is int and type(rows) is int
+
+
+def test_grid_shape_unmappable_raises():
+    with pytest.raises(ValueError, match="Cannot map 131 heads"):
+        KNOWN_CONFIGS["bh_p150_1card"].grid_shape(131)
+
+
+def test_detect_prefers_tt_kernel(monkeypatch):
+    class _Info:
+        arch = "blackhole"
+        device_count = 2
+    monkeypatch.setattr(hardware, "_detect_via_tt_kernel",
+                        lambda: hardware._config_for(_Info.arch, _Info.device_count))
+    assert detect_hardware().name == "bh_p150_2card"
+
+
+def test_detect_falls_back_to_ttnn(monkeypatch):
+    monkeypatch.setattr(hardware, "_detect_via_tt_kernel", lambda: None)
+    monkeypatch.setattr(hardware, "_detect_via_ttnn",
+                        lambda device=None: KNOWN_CONFIGS["gs_e150_1card"])
+    assert detect_hardware().name == "gs_e150_1card"
+
+
+def test_detect_defaults_when_all_fail(monkeypatch, capsys):
+    monkeypatch.setattr(hardware, "_detect_via_tt_kernel", lambda: None)
+    monkeypatch.setattr(hardware, "_detect_via_ttnn", lambda device=None: None)
+    cfg = detect_hardware()
+    assert cfg is DEFAULT_CONFIG
+    assert "hardware detection failed" in capsys.readouterr().err
+
+
+def test_config_for_mapping():
+    assert hardware._config_for("blackhole", 1).name == "bh_p150_1card"
+    assert hardware._config_for("blackhole", 2).name == "bh_p150_2card"
+    assert hardware._config_for("grayskull", 1).name == "gs_e150_1card"
+    assert hardware._config_for("unknown", 1) is None
+
+
+def test_frozen():
+    cfg = HardwareConfig("x", 1, 1, 100, 100)
+    with pytest.raises(Exception):
+        cfg.grid_x = 2

--- a/tests/dispatch/test_hardware.py
+++ b/tests/dispatch/test_hardware.py
@@ -6,6 +6,7 @@
 Covers the budget/grid policy math and the detection fallback ladder. No hardware:
 the tt-kernel and ttnn detectors are monkeypatched.
 """
+
 import pytest
 
 from tt_inference_server.dispatch import hardware
@@ -20,6 +21,7 @@ from tt_inference_server.dispatch.hardware import (
 def test_p150_budget_matches_legacy_compat_default():
     # The whole behavior-preserving argument: detected p150 budget == compat fallback.
     from tt_inference_server.dispatch.compat import _DEFAULT_L1_BUDGET_BYTES
+
     assert KNOWN_CONFIGS["bh_p150_1card"].l1_budget() == _DEFAULT_L1_BUDGET_BYTES
 
 
@@ -45,15 +47,20 @@ def test_detect_prefers_tt_kernel(monkeypatch):
     class _Info:
         arch = "blackhole"
         device_count = 2
-    monkeypatch.setattr(hardware, "_detect_via_tt_kernel",
-                        lambda: hardware._config_for(_Info.arch, _Info.device_count))
+
+    monkeypatch.setattr(
+        hardware,
+        "_detect_via_tt_kernel",
+        lambda: hardware._config_for(_Info.arch, _Info.device_count),
+    )
     assert detect_hardware().name == "bh_p150_2card"
 
 
 def test_detect_falls_back_to_ttnn(monkeypatch):
     monkeypatch.setattr(hardware, "_detect_via_tt_kernel", lambda: None)
-    monkeypatch.setattr(hardware, "_detect_via_ttnn",
-                        lambda device=None: KNOWN_CONFIGS["gs_e150_1card"])
+    monkeypatch.setattr(
+        hardware, "_detect_via_ttnn", lambda device=None: KNOWN_CONFIGS["gs_e150_1card"]
+    )
     assert detect_hardware().name == "gs_e150_1card"
 
 

--- a/tests/dispatch/test_import_smoke.py
+++ b/tests/dispatch/test_import_smoke.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""No-device import smoke test (issue #46).
+
+The dispatch package imports ttnn only function-locally, so importing the modules
+and referencing the top-level classes must succeed with NO device present. conftest
+installs a hard-failing ttnn stub, so if any of these imports tried to touch the
+device the test would error loudly rather than pass by accident.
+"""
+
+
+def test_import_dispatcher():
+    from tt_inference_server.dispatch.dispatcher import (  # noqa: F401
+        Capabilities,
+        KernelDispatcher,
+        ModelMatrixEntry,
+        derive_capabilities,
+    )
+
+    assert KernelDispatcher is not None
+    assert callable(derive_capabilities)
+
+
+def test_import_runner():
+    from tt_inference_server.dispatch.runner import TTModelRunner  # noqa: F401
+
+    assert TTModelRunner is not None
+
+
+def test_import_validator_and_public_api():
+    from tt_inference_server.dispatch import load_model, ModelHandle  # noqa: F401
+    from tt_inference_server.dispatch.output_validator import validate_output
+
+    assert callable(load_model)
+    assert callable(validate_output)
+
+
+def test_ttnn_is_the_forbidden_stub():
+    """Belt-and-suspenders: confirm conftest's guard is active for this dir."""
+    import ttnn
+    import pytest
+
+    with pytest.raises(RuntimeError):
+        ttnn.open_device(device_id=0)

--- a/tests/dispatch/test_matrix_capabilities.py
+++ b/tests/dispatch/test_matrix_capabilities.py
@@ -27,14 +27,77 @@ from tt_inference_server.dispatch.dispatcher import (
 # name -> (norm_type, activation, rotary_pct, attn_bias, parallel_residual,
 #          embed_scale, expected_fast_path, expected_lm_head_ondevice)
 EXPECTED = {
-    "meta-llama/Llama-3-8B-Instruct":            ("rmsnorm",   "silu",      1.0,  False, False, "none",        True,  True),
-    "deepseek-ai/DeepSeek-R1-Distill-Llama-8B":  ("rmsnorm",   "silu",      1.0,  False, False, "none",        True,  True),
-    "Qwen/Qwen2.5-7B-Instruct":                  ("rmsnorm",   "silu",      1.0,  True,  False, "none",        True,  True),
-    "mistralai/Mistral-7B-v0.3":                 ("rmsnorm",   "silu",      1.0,  False, False, "none",        True,  True),
-    "google/gemma-2-2b-it":                      ("gemma_rms", "gelu_tanh", 1.0,  False, False, "sqrt_hidden", False, True),
-    "microsoft/Phi-3.5-mini-instruct":           ("rmsnorm",   "silu",      1.0,  False, False, "none",        True,  True),
-    "allenai/OLMo-1B-hf":                        ("rmsnorm",   "silu",      1.0,  False, False, "none",        True,  True),
-    "EleutherAI/pythia-2.8b":                    ("layernorm", "gelu",      0.25, True,  True,  "none",        False, True),
+    "meta-llama/Llama-3-8B-Instruct": (
+        "rmsnorm",
+        "silu",
+        1.0,
+        False,
+        False,
+        "none",
+        True,
+        True,
+    ),
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-8B": (
+        "rmsnorm",
+        "silu",
+        1.0,
+        False,
+        False,
+        "none",
+        True,
+        True,
+    ),
+    "Qwen/Qwen2.5-7B-Instruct": (
+        "rmsnorm",
+        "silu",
+        1.0,
+        True,
+        False,
+        "none",
+        True,
+        True,
+    ),
+    "mistralai/Mistral-7B-v0.3": (
+        "rmsnorm",
+        "silu",
+        1.0,
+        False,
+        False,
+        "none",
+        True,
+        True,
+    ),
+    "google/gemma-2-2b-it": (
+        "gemma_rms",
+        "gelu_tanh",
+        1.0,
+        False,
+        False,
+        "sqrt_hidden",
+        False,
+        True,
+    ),
+    "microsoft/Phi-3.5-mini-instruct": (
+        "rmsnorm",
+        "silu",
+        1.0,
+        False,
+        False,
+        "none",
+        True,
+        True,
+    ),
+    "allenai/OLMo-1B-hf": ("rmsnorm", "silu", 1.0, False, False, "none", True, True),
+    "EleutherAI/pythia-2.8b": (
+        "layernorm",
+        "gelu",
+        0.25,
+        True,
+        True,
+        "none",
+        False,
+        True,
+    ),
 }
 
 
@@ -57,7 +120,8 @@ def test_gqa_divisibility_holds_for_all_listed(matrix):
     for e in entries:
         assert e.n_kv_heads >= 1 and e.n_heads >= 1, e.name
         assert e.n_heads % e.n_kv_heads == 0, (
-            f"{e.name}: n_heads={e.n_heads} not divisible by n_kv_heads={e.n_kv_heads}")
+            f"{e.name}: n_heads={e.n_heads} not divisible by n_kv_heads={e.n_kv_heads}"
+        )
 
 
 @pytest.mark.parametrize("name,expected", EXPECTED.items(), ids=list(EXPECTED))
@@ -66,8 +130,16 @@ def test_capabilities_match_expected(matrix, name, expected):
     assert name in index, f"{name} MISSING from matrix"
     e = index[name]
     cap = e.capabilities()
-    got = (e.norm_type, e.activation, e.rotary_pct, e.attn_bias,
-           e.parallel_residual, e.embed_scale, cap.fast_path, cap.lm_head_ondevice)
+    got = (
+        e.norm_type,
+        e.activation,
+        e.rotary_pct,
+        e.attn_bias,
+        e.parallel_residual,
+        e.embed_scale,
+        cap.fast_path,
+        cap.lm_head_ondevice,
+    )
     assert got == expected, f"{name}: expected {expected}, got {got}"
 
 

--- a/tests/dispatch/test_matrix_capabilities.py
+++ b/tests/dispatch/test_matrix_capabilities.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""No-device schema/capability tests for model_matrix.toml (issues #3, #46).
+
+Loads the matrix via the dispatcher's loader and asserts:
+  - schema_version matches the dispatcher,
+  - every listed entry's GQA divisibility holds,
+  - behavioral fields + DERIVED capabilities (fast_path / lm_head_ondevice) match the
+    expected per-model table,
+  - Granite resolves its four architectural scaling multipliers (#43).
+
+NOTE (novel-safety): every assertion is POSITIVE — "Granite resolves X",
+"GQA holds for listed entries". Nothing here asserts a model must be listed to run;
+the novel auto-derive path is the universal floor and is exercised on-card by the
+#47 novel gate, not here.
+"""
+
+import pytest
+
+from tt_inference_server.dispatch.dispatcher import (
+    DISPATCHER_SCHEMA_VERSION,
+    _DEFAULT_MATRIX_PATH,
+    _load_and_validate_matrix,
+)
+
+# name -> (norm_type, activation, rotary_pct, attn_bias, parallel_residual,
+#          embed_scale, expected_fast_path, expected_lm_head_ondevice)
+EXPECTED = {
+    "meta-llama/Llama-3-8B-Instruct":            ("rmsnorm",   "silu",      1.0,  False, False, "none",        True,  True),
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-8B":  ("rmsnorm",   "silu",      1.0,  False, False, "none",        True,  True),
+    "Qwen/Qwen2.5-7B-Instruct":                  ("rmsnorm",   "silu",      1.0,  True,  False, "none",        True,  True),
+    "mistralai/Mistral-7B-v0.3":                 ("rmsnorm",   "silu",      1.0,  False, False, "none",        True,  True),
+    "google/gemma-2-2b-it":                      ("gemma_rms", "gelu_tanh", 1.0,  False, False, "sqrt_hidden", False, True),
+    "microsoft/Phi-3.5-mini-instruct":           ("rmsnorm",   "silu",      1.0,  False, False, "none",        True,  True),
+    "allenai/OLMo-1B-hf":                        ("rmsnorm",   "silu",      1.0,  False, False, "none",        True,  True),
+    "EleutherAI/pythia-2.8b":                    ("layernorm", "gelu",      0.25, True,  True,  "none",        False, True),
+}
+
+
+@pytest.fixture(scope="module")
+def matrix():
+    entries, index = _load_and_validate_matrix(_DEFAULT_MATRIX_PATH)
+    return entries, index
+
+
+def test_schema_version_loads(matrix):
+    entries, _index = matrix
+    assert entries, "matrix loaded zero entries"
+    # _load_and_validate_matrix raises SchemaVersionError on mismatch, so reaching here
+    # means the file's schema_version equals DISPATCHER_SCHEMA_VERSION.
+    assert DISPATCHER_SCHEMA_VERSION >= 1
+
+
+def test_gqa_divisibility_holds_for_all_listed(matrix):
+    entries, _index = matrix
+    for e in entries:
+        assert e.n_kv_heads >= 1 and e.n_heads >= 1, e.name
+        assert e.n_heads % e.n_kv_heads == 0, (
+            f"{e.name}: n_heads={e.n_heads} not divisible by n_kv_heads={e.n_kv_heads}")
+
+
+@pytest.mark.parametrize("name,expected", EXPECTED.items(), ids=list(EXPECTED))
+def test_capabilities_match_expected(matrix, name, expected):
+    _entries, index = matrix
+    assert name in index, f"{name} MISSING from matrix"
+    e = index[name]
+    cap = e.capabilities()
+    got = (e.norm_type, e.activation, e.rotary_pct, e.attn_bias,
+           e.parallel_residual, e.embed_scale, cap.fast_path, cap.lm_head_ondevice)
+    assert got == expected, f"{name}: expected {expected}, got {got}"
+
+
+def test_granite_multipliers(matrix):
+    """Granite (#43) needs four architectural scaling factors plain Llama lacks; the
+    matrix must resolve them (12.0 / 0.22 / 0.015625 / 8.0)."""
+    _entries, index = matrix
+    name = "ibm-granite/granite-3.1-2b-instruct"
+    assert name in index, f"{name} MISSING from matrix"
+    e = index[name]
+    assert e.embedding_multiplier == 12.0
+    assert e.residual_multiplier == 0.22
+    assert e.attention_multiplier == 0.015625
+    assert e.logits_scaling == 8.0

--- a/tests/dispatch/test_release.py
+++ b/tests/dispatch/test_release.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the WS5 producer's push-command assembly (no hardware, no network)."""
+import argparse
+import sys
+
+from tt_inference_server.dispatch import release
+
+
+def _args(**kw):
+    base = dict(repo="ns/m", build_key=None, weights=None, runner_spec=None,
+                python_package=None, entry_point=None, runner_source=None,
+                private=False, public=False)
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_push_argv_kernels_only_public():
+    argv = release._push_argv(_args(), "/cache")
+    assert argv == [sys.executable, "-m", "tt_kernel.cli", "push", "ns/m",
+                    "--cache-dir", "/cache", "--public"]
+
+
+def test_push_argv_private_with_weights_and_build_key():
+    argv = release._push_argv(_args(private=True, weights="org/w", build_key=42), "/c")
+    assert "--private" in argv and "--public" not in argv
+    assert argv[argv.index("--weights") + 1] == "org/w"
+    assert argv[argv.index("--build-key") + 1] == "42"
+
+
+def test_push_argv_packaged_runner():
+    argv = release._push_argv(
+        _args(runner_spec="pkg.mod:R", python_package=["/a.whl", "/b.whl"], entry_point="r"),
+        "/c",
+    )
+    assert argv[argv.index("--runner-spec") + 1] == "pkg.mod:R"
+    assert argv.count("--python-package") == 2
+    assert argv[argv.index("--entry-point") + 1] == "r"
+
+
+def test_push_argv_reference_runner_source():
+    argv = release._push_argv(_args(runner_spec="pkg:R", runner_source="git+https://x"), "/c")
+    assert argv[argv.index("--runner-source") + 1] == "git+https://x"
+    assert "--python-package" not in argv  # reference runner ships no wheel

--- a/tests/dispatch/test_release.py
+++ b/tests/dispatch/test_release.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Unit tests for the WS5 producer's push-command assembly (no hardware, no network)."""
+
 import argparse
 import sys
 
@@ -9,17 +10,33 @@ from tt_inference_server.dispatch import release
 
 
 def _args(**kw):
-    base = dict(repo="ns/m", build_key=None, weights=None, runner_spec=None,
-                python_package=None, entry_point=None, runner_source=None,
-                private=False, public=False)
+    base = dict(
+        repo="ns/m",
+        build_key=None,
+        weights=None,
+        runner_spec=None,
+        python_package=None,
+        entry_point=None,
+        runner_source=None,
+        private=False,
+        public=False,
+    )
     base.update(kw)
     return argparse.Namespace(**base)
 
 
 def test_push_argv_kernels_only_public():
     argv = release._push_argv(_args(), "/cache")
-    assert argv == [sys.executable, "-m", "tt_kernel.cli", "push", "ns/m",
-                    "--cache-dir", "/cache", "--public"]
+    assert argv == [
+        sys.executable,
+        "-m",
+        "tt_kernel.cli",
+        "push",
+        "ns/m",
+        "--cache-dir",
+        "/cache",
+        "--public",
+    ]
 
 
 def test_push_argv_private_with_weights_and_build_key():
@@ -31,7 +48,11 @@ def test_push_argv_private_with_weights_and_build_key():
 
 def test_push_argv_packaged_runner():
     argv = release._push_argv(
-        _args(runner_spec="pkg.mod:R", python_package=["/a.whl", "/b.whl"], entry_point="r"),
+        _args(
+            runner_spec="pkg.mod:R",
+            python_package=["/a.whl", "/b.whl"],
+            entry_point="r",
+        ),
         "/c",
     )
     assert argv[argv.index("--runner-spec") + 1] == "pkg.mod:R"
@@ -40,6 +61,8 @@ def test_push_argv_packaged_runner():
 
 
 def test_push_argv_reference_runner_source():
-    argv = release._push_argv(_args(runner_spec="pkg:R", runner_source="git+https://x"), "/c")
+    argv = release._push_argv(
+        _args(runner_spec="pkg:R", runner_source="git+https://x"), "/c"
+    )
     assert argv[argv.index("--runner-source") + 1] == "git+https://x"
     assert "--python-package" not in argv  # reference runner ships no wheel

--- a/tests/dispatch/test_runner_seam.py
+++ b/tests/dispatch/test_runner_seam.py
@@ -26,8 +26,10 @@ from tt_inference_server.dispatch import load_model
 # Fakes
 # --------------------------------------------------------------------------- #
 
+
 class FakeRunner:
     """A minimal runner that satisfies the BaseRunner contract."""
+
     MANAGES_OWN_DEVICE = False
 
     def __init__(self, model_path, device, **kwargs):
@@ -56,6 +58,7 @@ class OwnDeviceRunner(FakeRunner):
         super().__init__(model_path, device, **kwargs)
         # A real mesh runner would open its own device here.
         import ttnn  # the stubbed fake injected by the test
+
         self.own_device = ttnn.open_mesh_device()
 
 
@@ -88,6 +91,7 @@ def inject_module():
 def fake_ttnn():
     """Inject a fake ttnn module; yield it so tests can assert on its calls."""
     import unittest.mock as mock
+
     fake = types.ModuleType("ttnn")
     fake.open_device = mock.MagicMock(return_value="DEVICE")
     fake.open_mesh_device = mock.MagicMock(return_value="MESH")
@@ -104,6 +108,7 @@ def fake_ttnn():
 # --------------------------------------------------------------------------- #
 # validate_runner
 # --------------------------------------------------------------------------- #
+
 
 def test_validate_runner_accepts_complete():
     base.validate_runner(FakeRunner("m", None))
@@ -127,6 +132,7 @@ def test_validate_runner_rejects_missing_attr():
 # --------------------------------------------------------------------------- #
 # _load_dotted
 # --------------------------------------------------------------------------- #
+
 
 def test_load_dotted_colon(inject_module):
     inject_module("fake_pkg_a", Thing=FakeRunner)
@@ -152,12 +158,16 @@ def test_load_dotted_missing_module():
 # resolution precedence
 # --------------------------------------------------------------------------- #
 
+
 def test_explicit_arg_wins(inject_module, monkeypatch):
     inject_module("fake_explicit", Runner=FakeRunner)
     # Even if an entry point would also match, the explicit arg short-circuits first.
-    monkeypatch.setattr(base, "iter_entry_point_runners",
-                        lambda: [_make_ep("ep", OwnDeviceRunner)])
-    cls, source = base.resolve_runner_class("some/model", "fake_explicit:Runner", unsafe=True)
+    monkeypatch.setattr(
+        base, "iter_entry_point_runners", lambda: [_make_ep("ep", OwnDeviceRunner)]
+    )
+    cls, source = base.resolve_runner_class(
+        "some/model", "fake_explicit:Runner", unsafe=True
+    )
     assert cls is FakeRunner
     assert source.startswith("explicit:")
 
@@ -173,12 +183,18 @@ def test_entry_point_match_by_model_type(monkeypatch):
     class EPRunner(FakeRunner):
         supported_model_types = {"qwen3_5_moe"}
 
-    monkeypatch.setattr(base, "iter_entry_point_runners",
-                        lambda: [_make_ep("qwen", EPRunner)])
+    monkeypatch.setattr(
+        base, "iter_entry_point_runners", lambda: [_make_ep("qwen", EPRunner)]
+    )
     monkeypatch.setattr(base, "load_hf_config", lambda p: None)
-    monkeypatch.setattr(base, "_raw_config_json",
-                        lambda p: {"model_type": "qwen3_5_moe",
-                                   "architectures": ["Qwen3_5MoeForCausalLM"]})
+    monkeypatch.setattr(
+        base,
+        "_raw_config_json",
+        lambda p: {
+            "model_type": "qwen3_5_moe",
+            "architectures": ["Qwen3_5MoeForCausalLM"],
+        },
+    )
     cls, source = base.resolve_runner_class("some/model", None, unsafe=False)
     assert cls is EPRunner
     assert source.startswith("entry_point:")
@@ -188,11 +204,15 @@ def test_entry_point_no_match_falls_through(monkeypatch):
     class EPRunner(FakeRunner):
         supported_model_types = {"qwen3_5_moe"}
 
-    monkeypatch.setattr(base, "iter_entry_point_runners",
-                        lambda: [_make_ep("qwen", EPRunner)])
+    monkeypatch.setattr(
+        base, "iter_entry_point_runners", lambda: [_make_ep("qwen", EPRunner)]
+    )
     monkeypatch.setattr(base, "load_hf_config", lambda p: None)
-    monkeypatch.setattr(base, "_raw_config_json",
-                        lambda p: {"model_type": "llama", "architectures": ["LlamaForCausalLM"]})
+    monkeypatch.setattr(
+        base,
+        "_raw_config_json",
+        lambda p: {"model_type": "llama", "architectures": ["LlamaForCausalLM"]},
+    )
     cls, source = base.resolve_runner_class("some/model", None, unsafe=False)
     assert cls is None
     assert source == "generic"
@@ -207,11 +227,17 @@ def test_entry_point_specificity_breaks_tie(monkeypatch):
         def claims(cls, hf_config):
             return True
 
-    monkeypatch.setattr(base, "iter_entry_point_runners",
-                        lambda: [_make_ep("a", ByType), _make_ep("b", ByClaim)])
+    monkeypatch.setattr(
+        base,
+        "iter_entry_point_runners",
+        lambda: [_make_ep("a", ByType), _make_ep("b", ByClaim)],
+    )
     monkeypatch.setattr(base, "load_hf_config", lambda p: None)
-    monkeypatch.setattr(base, "_raw_config_json",
-                        lambda p: {"model_type": "qwen3_5_moe", "architectures": ["X"]})
+    monkeypatch.setattr(
+        base,
+        "_raw_config_json",
+        lambda p: {"model_type": "qwen3_5_moe", "architectures": ["X"]},
+    )
     cls, _ = base.resolve_runner_class("some/model", None, unsafe=False)
     assert cls is ByClaim  # claims() (rank 3) beats model_type (rank 1)
 
@@ -223,11 +249,15 @@ def test_entry_point_ambiguous_raises(monkeypatch):
     class B(FakeRunner):
         supported_model_types = {"qwen3_5_moe"}
 
-    monkeypatch.setattr(base, "iter_entry_point_runners",
-                        lambda: [_make_ep("a", A), _make_ep("b", B)])
+    monkeypatch.setattr(
+        base, "iter_entry_point_runners", lambda: [_make_ep("a", A), _make_ep("b", B)]
+    )
     monkeypatch.setattr(base, "load_hf_config", lambda p: None)
-    monkeypatch.setattr(base, "_raw_config_json",
-                        lambda p: {"model_type": "qwen3_5_moe", "architectures": ["X"]})
+    monkeypatch.setattr(
+        base,
+        "_raw_config_json",
+        lambda p: {"model_type": "qwen3_5_moe", "architectures": ["X"]},
+    )
     with pytest.raises(RuntimeError, match="[Aa]mbiguous"):
         base.resolve_runner_class("some/model", None, unsafe=False)
 
@@ -235,6 +265,7 @@ def test_entry_point_ambiguous_raises(monkeypatch):
 # --------------------------------------------------------------------------- #
 # self-declaration (trust-gated)
 # --------------------------------------------------------------------------- #
+
 
 def _write_model_dir(tmp_path, **config):
     (tmp_path / "config.json").write_text(json.dumps(config))
@@ -253,7 +284,9 @@ def test_self_declared_ignored_without_unsafe(inject_module, tmp_path, monkeypat
 def test_self_declared_honored_with_unsafe(inject_module, tmp_path, monkeypatch):
     inject_module("fake_self2", Runner=FakeRunner)
     monkeypatch.setattr(base, "iter_entry_point_runners", lambda: [])
-    model_dir = _write_model_dir(tmp_path, model_type="x", tt_runner="fake_self2:Runner")
+    model_dir = _write_model_dir(
+        tmp_path, model_type="x", tt_runner="fake_self2:Runner"
+    )
     cls, source = base.resolve_runner_class(model_dir, None, unsafe=True)
     assert cls is FakeRunner
     assert source.startswith("self_declared:")
@@ -263,7 +296,9 @@ def test_self_declared_sidecar(inject_module, tmp_path, monkeypatch):
     inject_module("fake_self3", Runner=FakeRunner)
     monkeypatch.setattr(base, "iter_entry_point_runners", lambda: [])
     (tmp_path / "config.json").write_text(json.dumps({"model_type": "x"}))
-    (tmp_path / "tt_dispatch.json").write_text(json.dumps({"runner": "fake_self3:Runner"}))
+    (tmp_path / "tt_dispatch.json").write_text(
+        json.dumps({"runner": "fake_self3:Runner"})
+    )
     cls, source = base.resolve_runner_class(str(tmp_path), None, unsafe=True)
     assert cls is FakeRunner
 
@@ -272,7 +307,9 @@ def test_self_declared_allowlist_blocks(inject_module, tmp_path, monkeypatch):
     inject_module("fake_self4", Runner=FakeRunner)
     monkeypatch.setattr(base, "iter_entry_point_runners", lambda: [])
     monkeypatch.setenv(base.ENV_ALLOW, "some_other_pkg")
-    model_dir = _write_model_dir(tmp_path, model_type="x", tt_runner="fake_self4:Runner")
+    model_dir = _write_model_dir(
+        tmp_path, model_type="x", tt_runner="fake_self4:Runner"
+    )
     with pytest.raises(RuntimeError, match="allow"):
         base.resolve_runner_class(model_dir, None, unsafe=True)
 
@@ -281,7 +318,9 @@ def test_self_declared_allowlist_permits(inject_module, tmp_path, monkeypatch):
     inject_module("fake_self5", Runner=FakeRunner)
     monkeypatch.setattr(base, "iter_entry_point_runners", lambda: [])
     monkeypatch.setenv(base.ENV_ALLOW, "fake_self5")  # module-prefix whitelist
-    model_dir = _write_model_dir(tmp_path, model_type="x", tt_runner="fake_self5:Runner")
+    model_dir = _write_model_dir(
+        tmp_path, model_type="x", tt_runner="fake_self5:Runner"
+    )
     cls, _ = base.resolve_runner_class(model_dir, None, unsafe=True)
     assert cls is FakeRunner
 
@@ -289,6 +328,7 @@ def test_self_declared_allowlist_permits(inject_module, tmp_path, monkeypatch):
 # --------------------------------------------------------------------------- #
 # load_model: device ownership
 # --------------------------------------------------------------------------- #
+
 
 def test_load_model_generic_when_nothing_claims(monkeypatch):
     # No explicit, no entry points, not unsafe -> generic fallback path is selected.
@@ -307,7 +347,9 @@ def test_load_model_custom_runner_owns_device(inject_module, fake_ttnn):
     assert handle.community is True  # FakeRunner._community
 
 
-def test_load_model_simple_custom_runner_uses_load_model_device(inject_module, fake_ttnn):
+def test_load_model_simple_custom_runner_uses_load_model_device(
+    inject_module, fake_ttnn
+):
     inject_module("fake_simple", Runner=FakeRunner)  # MANAGES_OWN_DEVICE = False
     handle = load_model("some/model", unsafe=False, runner="fake_simple:Runner")
     fake_ttnn.open_device.assert_called_once()

--- a/tests/dispatch/test_runner_seam.py
+++ b/tests/dispatch/test_runner_seam.py
@@ -1,0 +1,328 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the custom-runner selection seam (dispatch/base.py + load_model).
+
+Pure-Python: no device, no ttnn, no running server. ttnn and the generic
+TTModelRunner are stubbed via sys.modules so the resolution/precedence/device-
+ownership logic can be exercised in isolation.
+
+Run:  python -m pytest tests/dispatch/test_runner_seam.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+
+import pytest
+
+from tt_inference_server.dispatch import base
+from tt_inference_server.dispatch import load_model
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+
+class FakeRunner:
+    """A minimal runner that satisfies the BaseRunner contract."""
+    MANAGES_OWN_DEVICE = False
+
+    def __init__(self, model_path, device, **kwargs):
+        self.model_path = model_path
+        self.device = device
+        self.kwargs = kwargs
+        self._tokenizer = object()
+        self._listed = False
+        self._community = True
+
+    def generate(self, prompt, max_new_tokens=50, temperature=1.0, chat=True):
+        return "ok"
+
+    def generate_stream(self, prompt, max_new_tokens=50, temperature=1.0, chat=True):
+        yield "ok"
+        yield {"finish_reason": "stop", "prompt_tokens": 1, "completion_tokens": 1}
+
+    def benchmark(self, prompt, n_tokens=50):
+        return (1.0, "ok")
+
+
+class OwnDeviceRunner(FakeRunner):
+    MANAGES_OWN_DEVICE = True
+
+    def __init__(self, model_path, device, **kwargs):
+        super().__init__(model_path, device, **kwargs)
+        # A real mesh runner would open its own device here.
+        import ttnn  # the stubbed fake injected by the test
+        self.own_device = ttnn.open_mesh_device()
+
+
+def _make_ep(name, cls):
+    """Build a fake (name, EntryPoint) pair as iter_entry_point_runners() yields."""
+    ep = types.SimpleNamespace(name=name)
+    ep.load = lambda: cls
+    return (name, ep)
+
+
+@pytest.fixture
+def inject_module():
+    """Register fake importable modules in sys.modules; clean up afterwards."""
+    added = []
+
+    def _add(module_name, **attrs):
+        mod = types.ModuleType(module_name)
+        for k, v in attrs.items():
+            setattr(mod, k, v)
+        sys.modules[module_name] = mod
+        added.append(module_name)
+        return mod
+
+    yield _add
+    for m in added:
+        sys.modules.pop(m, None)
+
+
+@pytest.fixture
+def fake_ttnn():
+    """Inject a fake ttnn module; yield it so tests can assert on its calls."""
+    import unittest.mock as mock
+    fake = types.ModuleType("ttnn")
+    fake.open_device = mock.MagicMock(return_value="DEVICE")
+    fake.open_mesh_device = mock.MagicMock(return_value="MESH")
+    fake.close_device = mock.MagicMock()
+    prev = sys.modules.get("ttnn")
+    sys.modules["ttnn"] = fake
+    yield fake
+    if prev is not None:
+        sys.modules["ttnn"] = prev
+    else:
+        sys.modules.pop("ttnn", None)
+
+
+# --------------------------------------------------------------------------- #
+# validate_runner
+# --------------------------------------------------------------------------- #
+
+def test_validate_runner_accepts_complete():
+    base.validate_runner(FakeRunner("m", None))
+
+
+def test_validate_runner_rejects_missing_method():
+    class Bad(FakeRunner):
+        benchmark = None  # not callable
+
+    with pytest.raises(TypeError, match="benchmark"):
+        base.validate_runner(Bad("m", None))
+
+
+def test_validate_runner_rejects_missing_attr():
+    r = FakeRunner("m", None)
+    del r._community
+    with pytest.raises(TypeError, match="_community"):
+        base.validate_runner(r)
+
+
+# --------------------------------------------------------------------------- #
+# _load_dotted
+# --------------------------------------------------------------------------- #
+
+def test_load_dotted_colon(inject_module):
+    inject_module("fake_pkg_a", Thing=FakeRunner)
+    assert base._load_dotted("fake_pkg_a:Thing") is FakeRunner
+
+
+def test_load_dotted_dot(inject_module):
+    inject_module("fake_pkg_b", Thing=FakeRunner)
+    assert base._load_dotted("fake_pkg_b.Thing") is FakeRunner
+
+
+def test_load_dotted_bad_spec():
+    with pytest.raises(ValueError):
+        base._load_dotted("nocolonnodot")
+
+
+def test_load_dotted_missing_module():
+    with pytest.raises(ImportError):
+        base._load_dotted("definitely_not_a_module_xyz:Thing")
+
+
+# --------------------------------------------------------------------------- #
+# resolution precedence
+# --------------------------------------------------------------------------- #
+
+def test_explicit_arg_wins(inject_module, monkeypatch):
+    inject_module("fake_explicit", Runner=FakeRunner)
+    # Even if an entry point would also match, the explicit arg short-circuits first.
+    monkeypatch.setattr(base, "iter_entry_point_runners",
+                        lambda: [_make_ep("ep", OwnDeviceRunner)])
+    cls, source = base.resolve_runner_class("some/model", "fake_explicit:Runner", unsafe=True)
+    assert cls is FakeRunner
+    assert source.startswith("explicit:")
+
+
+def test_explicit_env_wins(inject_module, monkeypatch):
+    inject_module("fake_env", Runner=FakeRunner)
+    monkeypatch.setenv(base.ENV_RUNNER, "fake_env:Runner")
+    cls, source = base.resolve_runner_class("some/model", None, unsafe=False)
+    assert cls is FakeRunner
+
+
+def test_entry_point_match_by_model_type(monkeypatch):
+    class EPRunner(FakeRunner):
+        supported_model_types = {"qwen3_5_moe"}
+
+    monkeypatch.setattr(base, "iter_entry_point_runners",
+                        lambda: [_make_ep("qwen", EPRunner)])
+    monkeypatch.setattr(base, "load_hf_config", lambda p: None)
+    monkeypatch.setattr(base, "_raw_config_json",
+                        lambda p: {"model_type": "qwen3_5_moe",
+                                   "architectures": ["Qwen3_5MoeForCausalLM"]})
+    cls, source = base.resolve_runner_class("some/model", None, unsafe=False)
+    assert cls is EPRunner
+    assert source.startswith("entry_point:")
+
+
+def test_entry_point_no_match_falls_through(monkeypatch):
+    class EPRunner(FakeRunner):
+        supported_model_types = {"qwen3_5_moe"}
+
+    monkeypatch.setattr(base, "iter_entry_point_runners",
+                        lambda: [_make_ep("qwen", EPRunner)])
+    monkeypatch.setattr(base, "load_hf_config", lambda p: None)
+    monkeypatch.setattr(base, "_raw_config_json",
+                        lambda p: {"model_type": "llama", "architectures": ["LlamaForCausalLM"]})
+    cls, source = base.resolve_runner_class("some/model", None, unsafe=False)
+    assert cls is None
+    assert source == "generic"
+
+
+def test_entry_point_specificity_breaks_tie(monkeypatch):
+    class ByType(FakeRunner):
+        supported_model_types = {"qwen3_5_moe"}
+
+    class ByClaim(FakeRunner):
+        @classmethod
+        def claims(cls, hf_config):
+            return True
+
+    monkeypatch.setattr(base, "iter_entry_point_runners",
+                        lambda: [_make_ep("a", ByType), _make_ep("b", ByClaim)])
+    monkeypatch.setattr(base, "load_hf_config", lambda p: None)
+    monkeypatch.setattr(base, "_raw_config_json",
+                        lambda p: {"model_type": "qwen3_5_moe", "architectures": ["X"]})
+    cls, _ = base.resolve_runner_class("some/model", None, unsafe=False)
+    assert cls is ByClaim  # claims() (rank 3) beats model_type (rank 1)
+
+
+def test_entry_point_ambiguous_raises(monkeypatch):
+    class A(FakeRunner):
+        supported_model_types = {"qwen3_5_moe"}
+
+    class B(FakeRunner):
+        supported_model_types = {"qwen3_5_moe"}
+
+    monkeypatch.setattr(base, "iter_entry_point_runners",
+                        lambda: [_make_ep("a", A), _make_ep("b", B)])
+    monkeypatch.setattr(base, "load_hf_config", lambda p: None)
+    monkeypatch.setattr(base, "_raw_config_json",
+                        lambda p: {"model_type": "qwen3_5_moe", "architectures": ["X"]})
+    with pytest.raises(RuntimeError, match="[Aa]mbiguous"):
+        base.resolve_runner_class("some/model", None, unsafe=False)
+
+
+# --------------------------------------------------------------------------- #
+# self-declaration (trust-gated)
+# --------------------------------------------------------------------------- #
+
+def _write_model_dir(tmp_path, **config):
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    return str(tmp_path)
+
+
+def test_self_declared_ignored_without_unsafe(inject_module, tmp_path, monkeypatch):
+    inject_module("fake_self", Runner=FakeRunner)
+    monkeypatch.setattr(base, "iter_entry_point_runners", lambda: [])
+    model_dir = _write_model_dir(tmp_path, model_type="x", tt_runner="fake_self:Runner")
+    cls, source = base.resolve_runner_class(model_dir, None, unsafe=False)
+    assert cls is None
+    assert source == "generic"
+
+
+def test_self_declared_honored_with_unsafe(inject_module, tmp_path, monkeypatch):
+    inject_module("fake_self2", Runner=FakeRunner)
+    monkeypatch.setattr(base, "iter_entry_point_runners", lambda: [])
+    model_dir = _write_model_dir(tmp_path, model_type="x", tt_runner="fake_self2:Runner")
+    cls, source = base.resolve_runner_class(model_dir, None, unsafe=True)
+    assert cls is FakeRunner
+    assert source.startswith("self_declared:")
+
+
+def test_self_declared_sidecar(inject_module, tmp_path, monkeypatch):
+    inject_module("fake_self3", Runner=FakeRunner)
+    monkeypatch.setattr(base, "iter_entry_point_runners", lambda: [])
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "x"}))
+    (tmp_path / "tt_dispatch.json").write_text(json.dumps({"runner": "fake_self3:Runner"}))
+    cls, source = base.resolve_runner_class(str(tmp_path), None, unsafe=True)
+    assert cls is FakeRunner
+
+
+def test_self_declared_allowlist_blocks(inject_module, tmp_path, monkeypatch):
+    inject_module("fake_self4", Runner=FakeRunner)
+    monkeypatch.setattr(base, "iter_entry_point_runners", lambda: [])
+    monkeypatch.setenv(base.ENV_ALLOW, "some_other_pkg")
+    model_dir = _write_model_dir(tmp_path, model_type="x", tt_runner="fake_self4:Runner")
+    with pytest.raises(RuntimeError, match="allow"):
+        base.resolve_runner_class(model_dir, None, unsafe=True)
+
+
+def test_self_declared_allowlist_permits(inject_module, tmp_path, monkeypatch):
+    inject_module("fake_self5", Runner=FakeRunner)
+    monkeypatch.setattr(base, "iter_entry_point_runners", lambda: [])
+    monkeypatch.setenv(base.ENV_ALLOW, "fake_self5")  # module-prefix whitelist
+    model_dir = _write_model_dir(tmp_path, model_type="x", tt_runner="fake_self5:Runner")
+    cls, _ = base.resolve_runner_class(model_dir, None, unsafe=True)
+    assert cls is FakeRunner
+
+
+# --------------------------------------------------------------------------- #
+# load_model: device ownership
+# --------------------------------------------------------------------------- #
+
+def test_load_model_generic_when_nothing_claims(monkeypatch):
+    # No explicit, no entry points, not unsafe -> generic fallback path is selected.
+    monkeypatch.setattr(base, "iter_entry_point_runners", lambda: [])
+    cls, source = base.resolve_runner_class("some/model", None, unsafe=False)
+    assert cls is None and source == "generic"
+
+
+def test_load_model_custom_runner_owns_device(inject_module, fake_ttnn):
+    inject_module("fake_own", Runner=OwnDeviceRunner)
+    handle = load_model("some/model", unsafe=False, runner="fake_own:Runner")
+    # MANAGES_OWN_DEVICE -> load_model must NOT open the device itself.
+    fake_ttnn.open_device.assert_not_called()
+    # The runner opened its own (mesh) device.
+    assert handle._runner.own_device == "MESH"
+    assert handle.community is True  # FakeRunner._community
+
+
+def test_load_model_simple_custom_runner_uses_load_model_device(inject_module, fake_ttnn):
+    inject_module("fake_simple", Runner=FakeRunner)  # MANAGES_OWN_DEVICE = False
+    handle = load_model("some/model", unsafe=False, runner="fake_simple:Runner")
+    fake_ttnn.open_device.assert_called_once()
+    assert handle._runner.device == "DEVICE"
+    # trace_region_size is filtered out (FakeRunner takes **kwargs so it is kept here);
+    # the generic-signature filtering is covered by the regression test.
+    assert handle._runner.kwargs["max_seq"] == 2048
+
+
+def test_load_model_validates_runner(inject_module, fake_ttnn):
+    class BadRunner(FakeRunner):
+        def __init__(self, model_path, device, **kwargs):
+            # Never sets the required contract attributes.
+            pass
+
+    inject_module("fake_bad", Runner=BadRunner)
+    with pytest.raises(TypeError, match="BaseRunner contract"):
+        load_model("some/model", unsafe=False, runner="fake_bad:Runner")

--- a/tests/dispatch/test_serve_scrub.py
+++ b/tests/dispatch/test_serve_scrub.py
@@ -9,17 +9,17 @@ from tt_inference_server.dispatch.serve import _scrub_stale_tt_paths
 
 def test_keeps_cache_var_even_when_missing():
     env = {
-        "TT_METAL_CACHE": "/nonexistent/fresh-cache",        # output dir, not yet created
+        "TT_METAL_CACHE": "/nonexistent/fresh-cache",  # output dir, not yet created
         "TT_MESH_GRAPH_DESC_PATH": "/old/checkout/mesh.yaml",  # stale input path
-        "TT_GOOD_INPUT": "/",                                  # existing path
-        "PATH": "/nonexistent/but-not-TT",                     # non-TT, untouched
+        "TT_GOOD_INPUT": "/",  # existing path
+        "PATH": "/nonexistent/but-not-TT",  # non-TT, untouched
     }
     removed = _scrub_stale_tt_paths(env)
 
-    assert "TT_METAL_CACHE" in env                       # exempt output dir preserved
-    assert "TT_MESH_GRAPH_DESC_PATH" not in env          # stale input scrubbed
-    assert "TT_GOOD_INPUT" in env                        # existing path kept
-    assert "PATH" in env                                 # non-TT untouched
+    assert "TT_METAL_CACHE" in env  # exempt output dir preserved
+    assert "TT_MESH_GRAPH_DESC_PATH" not in env  # stale input scrubbed
+    assert "TT_GOOD_INPUT" in env  # existing path kept
+    assert "PATH" in env  # non-TT untouched
     assert any("TT_MESH_GRAPH_DESC_PATH" in s for s in removed)
     assert all("TT_METAL_CACHE" not in s for s in removed)
 

--- a/tests/dispatch/test_serve_scrub.py
+++ b/tests/dispatch/test_serve_scrub.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""_scrub_stale_tt_paths must drop stale TT_* input paths but keep output dirs like
+TT_METAL_CACHE (which are created lazily and may not exist yet)."""
+
+from tt_inference_server.dispatch.serve import _scrub_stale_tt_paths
+
+
+def test_keeps_cache_var_even_when_missing():
+    env = {
+        "TT_METAL_CACHE": "/nonexistent/fresh-cache",        # output dir, not yet created
+        "TT_MESH_GRAPH_DESC_PATH": "/old/checkout/mesh.yaml",  # stale input path
+        "TT_GOOD_INPUT": "/",                                  # existing path
+        "PATH": "/nonexistent/but-not-TT",                     # non-TT, untouched
+    }
+    removed = _scrub_stale_tt_paths(env)
+
+    assert "TT_METAL_CACHE" in env                       # exempt output dir preserved
+    assert "TT_MESH_GRAPH_DESC_PATH" not in env          # stale input scrubbed
+    assert "TT_GOOD_INPUT" in env                        # existing path kept
+    assert "PATH" in env                                 # non-TT untouched
+    assert any("TT_MESH_GRAPH_DESC_PATH" in s for s in removed)
+    assert all("TT_METAL_CACHE" not in s for s in removed)
+
+
+def test_no_scrub_when_all_paths_exist():
+    env = {"TT_METAL_CACHE": "/", "TT_FOO": "/"}
+    assert _scrub_stale_tt_paths(env) == []
+    assert env == {"TT_METAL_CACHE": "/", "TT_FOO": "/"}

--- a/tests/dispatch/test_validator_fixtures.py
+++ b/tests/dispatch/test_validator_fixtures.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""No-device unit test for the shared output validator (issue #46).
+
+Asserts the tuned cascade classifies all 12 labeled samples (captured on card
+2026-06-11; see ~/dispatch/tests/diagnostic/tune_validator.py) correctly, and that
+each garbage sample fails for the EXPECTED reason category. Frozen reason prefixes
+are a contract for the sweep/diff tooling, so we assert on them here too.
+"""
+
+import pytest
+
+from tt_inference_server.dispatch.output_validator import (
+    ValidatorThresholds,
+    validate_output,
+)
+
+# (name, expect_good, text, reason_category_when_garbage)
+# reason_category is one of: "repetition", "exotic", "punct", or None for good samples.
+SAMPLES = [
+    ("llama3-8b", True, " Paris, which is located in the north-central part of the country. Paris is the most populous city in France and", None),
+    ("deepseek", True, " its official language is French. The currency is the Euro, and the country is part of the European Union.", None),
+    ("qwen2.5-7b", True, " The theory of relativity, developeded by Albert Einstein, consists of two parts: Special Relativity and General Relativity.\n\n1. **Special Relativity (1905)**: This part deals with objects moving at constant speeds, espe", None),
+    ("olmo-1b", True, " the city of Paris. It is the largest city in France and the second largest in Europe.", None),
+    ("stablelm-2", True, " \n\nThe theory of relativity, proposed by Albert Einstein in 1905, is a fundamental principle in physics that describes the relationship between space and time. It is based on two key postulates:\n\n1. The laws of physics are the same for all ", None),
+    ("phi-3.5", True, " Paris. It is the most populous city in France and serves as the country's political, economic, and cultural center.", None),
+    ("gemma2-2b", True, "\n\n**Special Relativity**\n\n* **The speed of light is constant:** No matter how fast you're moving, light always travels at the same speed (approximately 299,792,458 meters per second).\n* **Time and space are relative:** Time and space are no", None),
+    ("qwen3-4b", True, " The theory of relativity is a fundamental concept in physics that describes how gravity and space-time are interconnected. It was developed by Albert Einstein in the early 20th century and consists of two main parts: special relativity and", None),
+    ("bloom-3b", False, "\n plume todo br R retr錄》Berَحَ principal all开展的活动 exbras zel 70 At bel de banyakmansगानिस्तान a general aوفيما开展的活动并注意到并注意到helgraf whole ar hamee ris pr 1 total aterior de》一卷 or;plhar b la le;;dos note des specificr cheg", "exotic"),
+    ("pythia-2.8b", False, " **less** (neTkl. DISTH-\n.P. P. THEILOG==========================) L. IDRIG-j I. HARDERAR) P. 1care' '\n\n                                                                        .equal- _rof_ ) + B _cons** - >_.\n.aken.er_ ", "punct"),
+    ("mistral-7b", False, "Albert Einstein developed the theory of of relativity in simple terms:\n\n1 bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan be", "repetition"),
+    ("starcoder2-3b", False, "_ CELLSPACING SizedBoxGf_ LGPL_ Franc_ Franc_ Franc_ Franc_ Franc_ Franc_ eros segurança_ Franc_ eros ÷luş_ eros armazenamento_ eros ÷Hh_ Chen_ Franc_ eros segurança_ Franc_ eros segurança_ Franc_ eros segurança_ eros armazenamento_ eros se", "repetition"),
+]
+
+# Token ids of plausible length with no single-token loop, so the TEXT checks decide
+# (the captured samples are 80-token continuations).
+_NO_LOOP_IDS = list(range(80))
+
+
+def _category(reason: str) -> str:
+    if reason.startswith("repetition loop"):
+        return "repetition"
+    if "non-Latin" in reason:
+        return "exotic"
+    if "punctuation/symbols" in reason:
+        return "punct"
+    return "other"
+
+
+@pytest.mark.parametrize("name,expect_good,text,category", SAMPLES,
+                         ids=[s[0] for s in SAMPLES])
+def test_validator_classifies_sample(name, expect_good, text, category):
+    is_valid, reason = validate_output(text, _NO_LOOP_IDS)
+    assert is_valid == expect_good, f"{name}: expected good={expect_good}, got {reason!r}"
+    if not expect_good:
+        assert _category(reason) == category, (
+            f"{name}: expected {category} reason, got {reason!r}")
+
+
+def test_all_twelve_classified():
+    """The headline guarantee: 12/12 correct."""
+    wrong = [s[0] for s in SAMPLES
+             if validate_output(s[2], _NO_LOOP_IDS)[0] != s[1]]
+    assert not wrong, f"misclassified: {wrong}"
+
+
+def test_empty_and_too_short_reasons():
+    assert validate_output("", _NO_LOOP_IDS) == (False, "empty output")
+    assert validate_output("   ", _NO_LOOP_IDS)[0] is False
+    ok, reason = validate_output("hello world", [1, 2, 3])
+    assert ok is False and reason.startswith("too short:")
+
+
+def test_single_token_repetition_caught_via_ids():
+    """The check tune_validator dropped: a token-level loop the text n-gram check could
+    miss (diverse-looking text but one token id dominating)."""
+    ids = [42] * 60 + list(range(20))  # 60/80 = 75% one id
+    ok, reason = validate_output("varied looking words here " * 5, ids)
+    assert ok is False and reason == "repetition loop (token)"
+
+
+def test_text_only_mode_skips_length_checks():
+    """token_ids=None => length + token-rep checks skipped (legacy bench.py path)."""
+    ok, reason = validate_output("Paris is the capital of France.", None)
+    assert ok is True and reason == "ok"
+
+
+def test_thresholds_override_relaxes_exotic():
+    """A multilingual/code novel model can relax the English-smoke heuristics."""
+    text = "Paris 東京 北京 ソウル"  # several non-Latin letters
+    assert validate_output(text, None)[0] is False
+    relaxed = ValidatorThresholds(exotic_char_limit=100, punct_fraction=0.9)
+    assert validate_output(text, None, thresholds=relaxed)[0] is True

--- a/tests/dispatch/test_validator_fixtures.py
+++ b/tests/dispatch/test_validator_fixtures.py
@@ -19,18 +19,78 @@ from tt_inference_server.dispatch.output_validator import (
 # (name, expect_good, text, reason_category_when_garbage)
 # reason_category is one of: "repetition", "exotic", "punct", or None for good samples.
 SAMPLES = [
-    ("llama3-8b", True, " Paris, which is located in the north-central part of the country. Paris is the most populous city in France and", None),
-    ("deepseek", True, " its official language is French. The currency is the Euro, and the country is part of the European Union.", None),
-    ("qwen2.5-7b", True, " The theory of relativity, developeded by Albert Einstein, consists of two parts: Special Relativity and General Relativity.\n\n1. **Special Relativity (1905)**: This part deals with objects moving at constant speeds, espe", None),
-    ("olmo-1b", True, " the city of Paris. It is the largest city in France and the second largest in Europe.", None),
-    ("stablelm-2", True, " \n\nThe theory of relativity, proposed by Albert Einstein in 1905, is a fundamental principle in physics that describes the relationship between space and time. It is based on two key postulates:\n\n1. The laws of physics are the same for all ", None),
-    ("phi-3.5", True, " Paris. It is the most populous city in France and serves as the country's political, economic, and cultural center.", None),
-    ("gemma2-2b", True, "\n\n**Special Relativity**\n\n* **The speed of light is constant:** No matter how fast you're moving, light always travels at the same speed (approximately 299,792,458 meters per second).\n* **Time and space are relative:** Time and space are no", None),
-    ("qwen3-4b", True, " The theory of relativity is a fundamental concept in physics that describes how gravity and space-time are interconnected. It was developed by Albert Einstein in the early 20th century and consists of two main parts: special relativity and", None),
-    ("bloom-3b", False, "\n plume todo br R retr錄》Berَحَ principal all开展的活动 exbras zel 70 At bel de banyakmansगानिस्तान a general aوفيما开展的活动并注意到并注意到helgraf whole ar hamee ris pr 1 total aterior de》一卷 or;plhar b la le;;dos note des specificr cheg", "exotic"),
-    ("pythia-2.8b", False, " **less** (neTkl. DISTH-\n.P. P. THEILOG==========================) L. IDRIG-j I. HARDERAR) P. 1care' '\n\n                                                                        .equal- _rof_ ) + B _cons** - >_.\n.aken.er_ ", "punct"),
-    ("mistral-7b", False, "Albert Einstein developed the theory of of relativity in simple terms:\n\n1 bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan be", "repetition"),
-    ("starcoder2-3b", False, "_ CELLSPACING SizedBoxGf_ LGPL_ Franc_ Franc_ Franc_ Franc_ Franc_ Franc_ eros segurança_ Franc_ eros ÷luş_ eros armazenamento_ eros ÷Hh_ Chen_ Franc_ eros segurança_ Franc_ eros segurança_ Franc_ eros segurança_ eros armazenamento_ eros se", "repetition"),
+    (
+        "llama3-8b",
+        True,
+        " Paris, which is located in the north-central part of the country. Paris is the most populous city in France and",
+        None,
+    ),
+    (
+        "deepseek",
+        True,
+        " its official language is French. The currency is the Euro, and the country is part of the European Union.",
+        None,
+    ),
+    (
+        "qwen2.5-7b",
+        True,
+        " The theory of relativity, developeded by Albert Einstein, consists of two parts: Special Relativity and General Relativity.\n\n1. **Special Relativity (1905)**: This part deals with objects moving at constant speeds, espe",
+        None,
+    ),
+    (
+        "olmo-1b",
+        True,
+        " the city of Paris. It is the largest city in France and the second largest in Europe.",
+        None,
+    ),
+    (
+        "stablelm-2",
+        True,
+        " \n\nThe theory of relativity, proposed by Albert Einstein in 1905, is a fundamental principle in physics that describes the relationship between space and time. It is based on two key postulates:\n\n1. The laws of physics are the same for all ",
+        None,
+    ),
+    (
+        "phi-3.5",
+        True,
+        " Paris. It is the most populous city in France and serves as the country's political, economic, and cultural center.",
+        None,
+    ),
+    (
+        "gemma2-2b",
+        True,
+        "\n\n**Special Relativity**\n\n* **The speed of light is constant:** No matter how fast you're moving, light always travels at the same speed (approximately 299,792,458 meters per second).\n* **Time and space are relative:** Time and space are no",
+        None,
+    ),
+    (
+        "qwen3-4b",
+        True,
+        " The theory of relativity is a fundamental concept in physics that describes how gravity and space-time are interconnected. It was developed by Albert Einstein in the early 20th century and consists of two main parts: special relativity and",
+        None,
+    ),
+    (
+        "bloom-3b",
+        False,
+        "\n plume todo br R retr錄》Berَحَ principal all开展的活动 exbras zel 70 At bel de banyakmansगानिस्तान a general aوفيما开展的活动并注意到并注意到helgraf whole ar hamee ris pr 1 total aterior de》一卷 or;plhar b la le;;dos note des specificr cheg",
+        "exotic",
+    ),
+    (
+        "pythia-2.8b",
+        False,
+        " **less** (neTkl. DISTH-\n.P. P. THEILOG==========================) L. IDRIG-j I. HARDERAR) P. 1care' '\n\n                                                                        .equal- _rof_ ) + B _cons** - >_.\n.aken.er_ ",
+        "punct",
+    ),
+    (
+        "mistral-7b",
+        False,
+        "Albert Einstein developed the theory of of relativity in simple terms:\n\n1 bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan bekan be",
+        "repetition",
+    ),
+    (
+        "starcoder2-3b",
+        False,
+        "_ CELLSPACING SizedBoxGf_ LGPL_ Franc_ Franc_ Franc_ Franc_ Franc_ Franc_ eros segurança_ Franc_ eros ÷luş_ eros armazenamento_ eros ÷Hh_ Chen_ Franc_ eros segurança_ Franc_ eros segurança_ Franc_ eros segurança_ eros armazenamento_ eros se",
+        "repetition",
+    ),
 ]
 
 # Token ids of plausible length with no single-token loop, so the TEXT checks decide
@@ -48,20 +108,23 @@ def _category(reason: str) -> str:
     return "other"
 
 
-@pytest.mark.parametrize("name,expect_good,text,category", SAMPLES,
-                         ids=[s[0] for s in SAMPLES])
+@pytest.mark.parametrize(
+    "name,expect_good,text,category", SAMPLES, ids=[s[0] for s in SAMPLES]
+)
 def test_validator_classifies_sample(name, expect_good, text, category):
     is_valid, reason = validate_output(text, _NO_LOOP_IDS)
-    assert is_valid == expect_good, f"{name}: expected good={expect_good}, got {reason!r}"
+    assert is_valid == expect_good, (
+        f"{name}: expected good={expect_good}, got {reason!r}"
+    )
     if not expect_good:
         assert _category(reason) == category, (
-            f"{name}: expected {category} reason, got {reason!r}")
+            f"{name}: expected {category} reason, got {reason!r}"
+        )
 
 
 def test_all_twelve_classified():
     """The headline guarantee: 12/12 correct."""
-    wrong = [s[0] for s in SAMPLES
-             if validate_output(s[2], _NO_LOOP_IDS)[0] != s[1]]
+    wrong = [s[0] for s in SAMPLES if validate_output(s[2], _NO_LOOP_IDS)[0] != s[1]]
     assert not wrong, f"misclassified: {wrong}"
 
 

--- a/tt_inference_server/dispatch/__init__.py
+++ b/tt_inference_server/dispatch/__init__.py
@@ -3,7 +3,7 @@
 
 """Public API for the dispatch layer.
 
-    from tt_inference_server.dispatch import load_model, ModelHandle
+from tt_inference_server.dispatch import load_model, ModelHandle
 """
 
 from __future__ import annotations
@@ -15,6 +15,7 @@ from typing import Optional
 @dataclass
 class ModelHandle:
     """Returned by load_model(). Wraps a TTModelRunner with the public interface."""
+
     _runner: object
     model_path: str
     listed: bool = True
@@ -25,7 +26,9 @@ class ModelHandle:
 
     def generate_stream(self, prompt: str, max_new_tokens: int = 50, **kwargs):
         """Yield decoded text deltas one decode step at a time (for streaming serve)."""
-        return self._runner.generate_stream(prompt, max_new_tokens=max_new_tokens, **kwargs)
+        return self._runner.generate_stream(
+            prompt, max_new_tokens=max_new_tokens, **kwargs
+        )
 
     def benchmark(self, prompt: str, n_tokens: int = 50):
         return self._runner.benchmark(prompt, n_tokens=n_tokens)
@@ -44,9 +47,11 @@ def _construct_runner(runner_cls, model_path, device, **candidate_kwargs):
     (trace_region_size is simply dropped for TTModelRunner).
     """
     import inspect
+
     sig = inspect.signature(runner_cls.__init__)
-    accepts_var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD
-                         for p in sig.parameters.values())
+    accepts_var_kw = any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+    )
     if accepts_var_kw:
         kwargs = dict(candidate_kwargs)
     else:
@@ -69,19 +74,29 @@ def _notice_tuned_bundle_available(model_path: str) -> None:
         return
     try:
         import pathlib
+
         local = pathlib.Path(model_path).is_dir()
         res = tt_kernel.resolve_bundle(model_path, local_only=local)
         if not res.exists:
             return
-        where = "installed" if res.installed else f"published — `tt-kernel pull {model_path}`"
+        where = (
+            "installed"
+            if res.installed
+            else f"published — `tt-kernel pull {model_path}`"
+        )
         if res.has_runner:
-            print(f"[dispatch] a tuned tt-kernel bundle exists for {model_path} "
-                  f"(runner {res.runner_spec}, {where}); running the generic dynamic path "
-                  f"instead. Use `tt-kernel run {model_path}` for the author's tuned path.",
-                  flush=True)
+            print(
+                f"[dispatch] a tuned tt-kernel bundle exists for {model_path} "
+                f"(runner {res.runner_spec}, {where}); running the generic dynamic path "
+                f"instead. Use `tt-kernel run {model_path}` for the author's tuned path.",
+                flush=True,
+            )
         else:
-            print(f"[dispatch] a tt-kernel kernel-cache bundle is {where} for {model_path}; "
-                  f"precompiled kernels will be used from the on-disk cache.", flush=True)
+            print(
+                f"[dispatch] a tt-kernel kernel-cache bundle is {where} for {model_path}; "
+                f"precompiled kernels will be used from the on-disk cache.",
+                flush=True,
+            )
     except Exception:  # noqa: BLE001 — a courtesy notice must never break a load
         return
 
@@ -118,19 +133,22 @@ def load_model(
             (explicit env DISPATCH_RUNNER -> entry-point match -> --unsafe self-declared
             -> generic TTModelRunner). See dispatch/base.py and docs/custom_runners.md.
     """
-    from tt_inference_server.dispatch.base import (
-        resolve_runner_class, validate_runner)
+    from tt_inference_server.dispatch.base import resolve_runner_class, validate_runner
 
     # Resolve which runner backs this model. None -> generic TTModelRunner fallback.
     runner_cls, source = resolve_runner_class(model_path, runner, unsafe)
     if runner_cls is None:
         from tt_inference_server.dispatch.runner import TTModelRunner
+
         runner_cls = TTModelRunner
         # Generic dynamic path selected — surface a curated bundle if one exists.
         _notice_tuned_bundle_available(model_path)
     else:
-        print(f"[dispatch] runner: {runner_cls.__module__}:{runner_cls.__name__} "
-              f"(source={source})", flush=True)
+        print(
+            f"[dispatch] runner: {runner_cls.__module__}:{runner_cls.__name__} "
+            f"(source={source})",
+            flush=True,
+        )
 
     # Device ownership: a runner with MANAGES_OWN_DEVICE opens/owns/closes its own
     # device (e.g. a 1x1 mesh) — load_model must not open one or it would conflict.
@@ -138,13 +156,19 @@ def load_model(
     _owns_device = device is None and not manages_own_device
     if _owns_device:
         import ttnn
+
         ids = device_ids or [0]
         device = ttnn.open_device(device_id=ids[0], trace_region_size=trace_region_size)
 
     runner_obj = _construct_runner(
-        runner_cls, model_path, device,
-        max_seq=max_seq, unsafe=unsafe, force_novel=force_novel,
-        trace_region_size=trace_region_size, device_ids=device_ids,
+        runner_cls,
+        model_path,
+        device,
+        max_seq=max_seq,
+        unsafe=unsafe,
+        force_novel=force_novel,
+        trace_region_size=trace_region_size,
+        device_ids=device_ids,
     )
     validate_runner(runner_obj)
 
@@ -158,6 +182,7 @@ def load_model(
     if _owns_device:
         import atexit
         import ttnn
+
         atexit.register(ttnn.close_device, device)
 
     return handle

--- a/tt_inference_server/dispatch/__init__.py
+++ b/tt_inference_server/dispatch/__init__.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public API for the dispatch layer.
+
+    from tt_inference_server.dispatch import load_model, ModelHandle
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ModelHandle:
+    """Returned by load_model(). Wraps a TTModelRunner with the public interface."""
+    _runner: object
+    model_path: str
+    listed: bool = True
+    community: bool = False
+
+    def generate(self, prompt: str, max_new_tokens: int = 50, **kwargs) -> str:
+        return self._runner.generate(prompt, max_new_tokens=max_new_tokens, **kwargs)
+
+    def generate_stream(self, prompt: str, max_new_tokens: int = 50, **kwargs):
+        """Yield decoded text deltas one decode step at a time (for streaming serve)."""
+        return self._runner.generate_stream(prompt, max_new_tokens=max_new_tokens, **kwargs)
+
+    def benchmark(self, prompt: str, n_tokens: int = 50):
+        return self._runner.benchmark(prompt, n_tokens=n_tokens)
+
+    @property
+    def tokenizer(self):
+        return self._runner._tokenizer
+
+
+def _construct_runner(runner_cls, model_path, device, **candidate_kwargs):
+    """Construct a runner, passing only the keyword args its __init__ accepts.
+
+    The generic TTModelRunner takes (max_seq, unsafe, force_novel); custom runners
+    may additionally take trace_region_size and/or **kwargs. Filtering by signature
+    lets one call site serve both — and keeps the generic path byte-identical
+    (trace_region_size is simply dropped for TTModelRunner).
+    """
+    import inspect
+    sig = inspect.signature(runner_cls.__init__)
+    accepts_var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD
+                         for p in sig.parameters.values())
+    if accepts_var_kw:
+        kwargs = dict(candidate_kwargs)
+    else:
+        kwargs = {k: v for k, v in candidate_kwargs.items() if k in sig.parameters}
+    return runner_cls(model_path, device, **kwargs)
+
+
+def _notice_tuned_bundle_available(model_path: str) -> None:
+    """Best-effort courtesy notice: if a curated tt-kernel bundle exists for this id but
+    we're about to run the generic dynamic path, tell the user the tuned path is there.
+
+    Never blocks, never imports the bundle's runner, and swallows every failure (tt_kernel
+    not installed, offline, not a hub id). For a local model directory the Hub is
+    irrelevant, so the probe stays local-only; for a hub id it also checks published
+    bundles (load_model runs once at startup, so a single manifest fetch is acceptable).
+    """
+    try:
+        import tt_kernel
+    except Exception:  # noqa: BLE001 — tt_kernel is an optional integration, not a dep
+        return
+    try:
+        import pathlib
+        local = pathlib.Path(model_path).is_dir()
+        res = tt_kernel.resolve_bundle(model_path, local_only=local)
+        if not res.exists:
+            return
+        where = "installed" if res.installed else f"published — `tt-kernel pull {model_path}`"
+        if res.has_runner:
+            print(f"[dispatch] a tuned tt-kernel bundle exists for {model_path} "
+                  f"(runner {res.runner_spec}, {where}); running the generic dynamic path "
+                  f"instead. Use `tt-kernel run {model_path}` for the author's tuned path.",
+                  flush=True)
+        else:
+            print(f"[dispatch] a tt-kernel kernel-cache bundle is {where} for {model_path}; "
+                  f"precompiled kernels will be used from the on-disk cache.", flush=True)
+    except Exception:  # noqa: BLE001 — a courtesy notice must never break a load
+        return
+
+
+def load_model(
+    model_path: str,
+    device=None,
+    device_ids: Optional[list] = None,
+    max_seq: int = 2048,
+    unsafe: bool = False,
+    trace_region_size: int = 134217728,
+    force_novel: bool = False,
+    runner: Optional[str] = None,
+) -> ModelHandle:
+    """Load a model and return a ModelHandle ready for inference.
+
+    Args:
+        model_path: HuggingFace hub id (e.g. "meta-llama/Llama-3-8B-Instruct") or a
+            local weight directory. Hub ids are downloaded via transformers.
+        device: An open ttnn device. If None, opens device_ids[0] (default: 0) —
+            unless the selected runner manages its own device (see runner=).
+        device_ids: List of device IDs for multi-card configurations.
+        max_seq: Maximum sequence length supported by the KV cache.
+        unsafe: Acknowledge that this model carries no correctness/SLA guarantee.
+            Required for any model not listed as 'validated' in model_matrix.toml.
+            Also gates honoring a runner self-declared by the model repo (see runner=).
+        trace_region_size: Trace region reserved on the device so the traced fast-path
+            decode (#30) is available when the model is fast-path eligible. Set 0 to skip.
+        force_novel: Skip the model_matrix.toml lookup and resolve via the HF-config
+            auto-derive path even for a listed model (#47). For the regression gate that
+            proves the novel path stays byte-identical to the matrix path; not for normal use.
+        runner: Explicit custom runner as "module:Class" (or "module.Class"). Overrides
+            all auto-discovery. If None, dispatch resolves a runner by precedence
+            (explicit env DISPATCH_RUNNER -> entry-point match -> --unsafe self-declared
+            -> generic TTModelRunner). See dispatch/base.py and docs/custom_runners.md.
+    """
+    from tt_inference_server.dispatch.base import (
+        resolve_runner_class, validate_runner)
+
+    # Resolve which runner backs this model. None -> generic TTModelRunner fallback.
+    runner_cls, source = resolve_runner_class(model_path, runner, unsafe)
+    if runner_cls is None:
+        from tt_inference_server.dispatch.runner import TTModelRunner
+        runner_cls = TTModelRunner
+        # Generic dynamic path selected — surface a curated bundle if one exists.
+        _notice_tuned_bundle_available(model_path)
+    else:
+        print(f"[dispatch] runner: {runner_cls.__module__}:{runner_cls.__name__} "
+              f"(source={source})", flush=True)
+
+    # Device ownership: a runner with MANAGES_OWN_DEVICE opens/owns/closes its own
+    # device (e.g. a 1x1 mesh) — load_model must not open one or it would conflict.
+    manages_own_device = bool(getattr(runner_cls, "MANAGES_OWN_DEVICE", False))
+    _owns_device = device is None and not manages_own_device
+    if _owns_device:
+        import ttnn
+        ids = device_ids or [0]
+        device = ttnn.open_device(device_id=ids[0], trace_region_size=trace_region_size)
+
+    runner_obj = _construct_runner(
+        runner_cls, model_path, device,
+        max_seq=max_seq, unsafe=unsafe, force_novel=force_novel,
+        trace_region_size=trace_region_size, device_ids=device_ids,
+    )
+    validate_runner(runner_obj)
+
+    handle = ModelHandle(
+        _runner=runner_obj,
+        model_path=model_path,
+        listed=getattr(runner_obj, "_listed", True),
+        community=getattr(runner_obj, "_community", False),
+    )
+
+    if _owns_device:
+        import atexit
+        import ttnn
+        atexit.register(ttnn.close_device, device)
+
+    return handle
+
+
+__all__ = ["load_model", "ModelHandle"]

--- a/tt_inference_server/dispatch/base.py
+++ b/tt_inference_server/dispatch/base.py
@@ -38,8 +38,10 @@ ENTRY_POINT_GROUP = "tt_inference_server.runners"
 
 # Env overrides (parallel to the CLI flags) — useful for `python -m ... serve`
 # wrappers and tests.
-ENV_RUNNER = "DISPATCH_RUNNER"          # "module:Class" explicit override
-ENV_ALLOW = "DISPATCH_RUNNER_ALLOW"     # comma-separated allowlist for self-declared runners
+ENV_RUNNER = "DISPATCH_RUNNER"  # "module:Class" explicit override
+ENV_ALLOW = (
+    "DISPATCH_RUNNER_ALLOW"  # comma-separated allowlist for self-declared runners
+)
 
 
 @runtime_checkable
@@ -76,12 +78,21 @@ class BaseRunner(Protocol):
     _listed: bool
     _community: bool
 
-    def generate(self, prompt: str, max_new_tokens: int = 50,
-                 temperature: float = 1.0, chat: bool = True) -> str: ...
+    def generate(
+        self,
+        prompt: str,
+        max_new_tokens: int = 50,
+        temperature: float = 1.0,
+        chat: bool = True,
+    ) -> str: ...
 
-    def generate_stream(self, prompt: str, max_new_tokens: int = 50,
-                        temperature: float = 1.0,
-                        chat: bool = True) -> Iterator[Union[str, dict]]: ...
+    def generate_stream(
+        self,
+        prompt: str,
+        max_new_tokens: int = 50,
+        temperature: float = 1.0,
+        chat: bool = True,
+    ) -> Iterator[Union[str, dict]]: ...
 
     def benchmark(self, prompt: str, n_tokens: int = 50) -> "tuple[float, str]": ...
 
@@ -97,7 +108,9 @@ def validate_runner(obj) -> None:
     attributes set in ``__init__`` (a Protocol ``isinstance`` check alone would
     not, since the attrs are annotations, not class defaults).
     """
-    missing_methods = [m for m in _REQUIRED_METHODS if not callable(getattr(obj, m, None))]
+    missing_methods = [
+        m for m in _REQUIRED_METHODS if not callable(getattr(obj, m, None))
+    ]
     missing_attrs = [a for a in _REQUIRED_ATTRS if not hasattr(obj, a)]
     if missing_methods or missing_attrs:
         cls = type(obj).__name__
@@ -105,8 +118,10 @@ def validate_runner(obj) -> None:
         if missing_methods:
             parts.append(f"missing method(s): {', '.join(missing_methods)}")
         if missing_attrs:
-            parts.append(f"missing attribute(s): {', '.join(missing_attrs)} "
-                         "(set them in __init__)")
+            parts.append(
+                f"missing attribute(s): {', '.join(missing_attrs)} "
+                "(set them in __init__)"
+            )
         raise TypeError(
             f"Runner {cls!r} does not satisfy the BaseRunner contract: "
             + "; ".join(parts)
@@ -149,6 +164,7 @@ def _load_dotted(spec: str):
 # HF config loading (for discovery / matching — does NOT execute remote code)
 # --------------------------------------------------------------------------- #
 
+
 def load_hf_config(model_path: str):
     """Best-effort load of a model's HF config for runner discovery.
 
@@ -158,6 +174,7 @@ def load_hf_config(model_path: str):
     """
     try:
         from transformers import AutoConfig
+
         return AutoConfig.from_pretrained(model_path, trust_remote_code=False)
     except Exception:  # noqa: BLE001 — custom arch may need trust_remote_code; fall back
         return None
@@ -181,6 +198,7 @@ def _raw_config_json(model_path: str) -> dict:
     # Hub id: download just config.json (no model code execution).
     try:
         from huggingface_hub import hf_hub_download
+
         path = hf_hub_download(model_path, "config.json")
         return json.loads(pathlib.Path(path).read_text())
     except Exception:  # noqa: BLE001
@@ -205,12 +223,14 @@ def _config_model_type(hf_config, raw: Optional[dict] = None) -> str:
 # Entry-point discovery (precedence step 2)
 # --------------------------------------------------------------------------- #
 
+
 def iter_entry_point_runners():
     """Yield (name, EntryPoint) for every registered ``tt_inference_server.runners``.
 
     Tolerant of the importlib.metadata API differences across Python versions.
     """
     from importlib import metadata
+
     try:
         eps = metadata.entry_points(group=ENTRY_POINT_GROUP)  # py3.10+
     except TypeError:  # pragma: no cover — py3.9 returns a dict
@@ -259,6 +279,7 @@ def match_runner(hf_config, raw: Optional[dict] = None):
             runner_cls = ep.load()
         except Exception as exc:  # noqa: BLE001 — skip a broken package, keep going
             import sys
+
             sys.stderr.write(
                 f"[dispatch] WARNING: runner entry point {name!r} failed to load: "
                 f"{type(exc).__name__}: {exc}\n"
@@ -287,8 +308,10 @@ def match_runner(hf_config, raw: Optional[dict] = None):
 # HF repo self-declaration (precedence step 3 — trust-gated)
 # --------------------------------------------------------------------------- #
 
-def parse_self_declared_runner(model_path: str, hf_config=None,
-                               raw: Optional[dict] = None) -> Optional[str]:
+
+def parse_self_declared_runner(
+    model_path: str, hf_config=None, raw: Optional[dict] = None
+) -> Optional[str]:
     """Return a ``"module:Class"`` runner spec self-declared by the model repo, or None.
 
     Sources, in order:
@@ -338,6 +361,7 @@ def runner_allowed(spec: str) -> bool:
 # Top-level resolver (used by load_model)
 # --------------------------------------------------------------------------- #
 
+
 def resolve_runner_class(model_path: str, explicit: Optional[str], unsafe: bool):
     """Resolve the runner class for ``model_path`` by precedence.
 
@@ -372,6 +396,7 @@ def resolve_runner_class(model_path: str, explicit: Optional[str], unsafe: bool)
                     "refusing to load it. Add it to the allowlist or pass --runner."
                 )
             import sys
+
             sys.stderr.write(
                 f"[dispatch] WARNING: honoring self-declared runner {spec!r} from the "
                 "model repo (trust_remote_code-class: this imports and executes "

--- a/tt_inference_server/dispatch/base.py
+++ b/tt_inference_server/dispatch/base.py
@@ -1,0 +1,396 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runner contract + selection seam for the dispatch serving runtime.
+
+`load_model()` resolves *which* runner serves a model. The generic
+``TTModelRunner`` (a standard decoder-only transformer) is the fallback. A
+**custom runner** — for a model whose tt-nn graph is not a standard transformer
+(MoE, Gated-DeltaNet/Mamba-state, multimodal) — is selected, in order of
+precedence (most-explicit wins):
+
+  1. Explicit override   — ``runner="module:Class"`` arg / ``DISPATCH_RUNNER`` env.
+  2. Entry-point match   — an installed package declaring the
+     ``tt_inference_server.runners`` entry-point group whose claim matches the
+     model's HF config.
+  3. HF self-declaration — ``config.json`` ``tt_runner`` field or a
+     ``tt_dispatch.json`` sidecar in the model repo. Trust-gated (``--unsafe``).
+  4. Fallback            — the generic ``TTModelRunner`` (unchanged behavior).
+
+Third-party runners live in their OWN package and satisfy `BaseRunner`; no model
+code is vendored here, and dispatch hard-codes no model names — it matches on the
+HF config alone.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import pathlib
+from typing import Iterator, Optional, Protocol, Union, runtime_checkable
+
+# The entry-point group external runner packages register under, e.g. in their
+# pyproject.toml:
+#   [project.entry-points."tt_inference_server.runners"]
+#   qwen3_5_moe = "some_pkg.dispatch_runner:Qwen36Runner"
+ENTRY_POINT_GROUP = "tt_inference_server.runners"
+
+# Env overrides (parallel to the CLI flags) — useful for `python -m ... serve`
+# wrappers and tests.
+ENV_RUNNER = "DISPATCH_RUNNER"          # "module:Class" explicit override
+ENV_ALLOW = "DISPATCH_RUNNER_ALLOW"     # comma-separated allowlist for self-declared runners
+
+
+@runtime_checkable
+class BaseRunner(Protocol):
+    """The complete contract a runner must satisfy to back a ``ModelHandle``.
+
+    `ModelHandle` only ever calls three methods and reads three attributes — this
+    Protocol is exactly that surface. Custom runners implement it directly; they
+    do NOT need to subclass anything (it is structural / duck-typed).
+
+    Optional class-level discovery hooks (any subset; checked in this priority):
+        ``claims(cls, hf_config) -> bool``     classmethod, most flexible matcher
+        ``supported_architectures: set[str]``  matched against config.architectures[0]
+        ``supported_model_types: set[str]``    matched against config.model_type
+
+    Optional lifecycle hook:
+        ``MANAGES_OWN_DEVICE: bool = False``   if True, `load_model` does NOT open a
+            ttnn device; the runner opens/owns/closes its own (e.g. a 1x1 mesh) and
+            registers its own cleanup. The runner is then constructed with
+            ``device=None``.
+            OBLIGATION: such a runner MUST close its device cleanly on shutdown
+            (e.g. ``atexit``-registered ``ttnn.close_mesh_device`` / ``close_device``).
+            This is required for reliable model hot-swap: a serve process exiting must
+            leave the card pristine for the next model. An ungraceful teardown can leave
+            a locked device mutex that wedges the card until a manual ``tt-smi -r``.
+
+    Constructor contract `load_model` calls (keyword args filtered to what the
+    constructor actually accepts — a runner may take ``**kwargs`` and ignore the rest):
+        ``__init__(self, model_path, device, *, max_seq, unsafe,
+                   force_novel=False, trace_region_size=..., **kwargs)``
+    """
+
+    _tokenizer: object
+    _listed: bool
+    _community: bool
+
+    def generate(self, prompt: str, max_new_tokens: int = 50,
+                 temperature: float = 1.0, chat: bool = True) -> str: ...
+
+    def generate_stream(self, prompt: str, max_new_tokens: int = 50,
+                        temperature: float = 1.0,
+                        chat: bool = True) -> Iterator[Union[str, dict]]: ...
+
+    def benchmark(self, prompt: str, n_tokens: int = 50) -> "tuple[float, str]": ...
+
+
+_REQUIRED_METHODS = ("generate", "generate_stream", "benchmark")
+_REQUIRED_ATTRS = ("_tokenizer", "_listed", "_community")
+
+
+def validate_runner(obj) -> None:
+    """Fail fast with a clear message if ``obj`` does not satisfy `BaseRunner`.
+
+    Called on a constructed runner instance, so attribute checks see instance
+    attributes set in ``__init__`` (a Protocol ``isinstance`` check alone would
+    not, since the attrs are annotations, not class defaults).
+    """
+    missing_methods = [m for m in _REQUIRED_METHODS if not callable(getattr(obj, m, None))]
+    missing_attrs = [a for a in _REQUIRED_ATTRS if not hasattr(obj, a)]
+    if missing_methods or missing_attrs:
+        cls = type(obj).__name__
+        parts = []
+        if missing_methods:
+            parts.append(f"missing method(s): {', '.join(missing_methods)}")
+        if missing_attrs:
+            parts.append(f"missing attribute(s): {', '.join(missing_attrs)} "
+                         "(set them in __init__)")
+        raise TypeError(
+            f"Runner {cls!r} does not satisfy the BaseRunner contract: "
+            + "; ".join(parts)
+        )
+
+
+def _load_dotted(spec: str):
+    """Import and return the object named by ``"module:Class"`` or ``"module.Class"``.
+
+    The colon form is preferred (unambiguous when the attribute is nested). Raises
+    a clear error rather than a bare ImportError/AttributeError.
+    """
+    spec = spec.strip()
+    if ":" in spec:
+        module_name, _, attr = spec.partition(":")
+    elif "." in spec:
+        module_name, _, attr = spec.rpartition(".")
+    else:
+        raise ValueError(
+            f"Invalid runner spec {spec!r}: expected 'module:Class' (or 'module.Class')."
+        )
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as exc:  # noqa: BLE001 — surface the original cause clearly
+        raise ImportError(
+            f"Could not import module {module_name!r} for runner {spec!r}: "
+            f"{type(exc).__name__}: {exc}. Is the runner package installed in the "
+            "serving environment?"
+        ) from exc
+    try:
+        obj = getattr(module, attr)
+    except AttributeError as exc:
+        raise ImportError(
+            f"Module {module_name!r} has no attribute {attr!r} for runner {spec!r}."
+        ) from exc
+    return obj
+
+
+# --------------------------------------------------------------------------- #
+# HF config loading (for discovery / matching — does NOT execute remote code)
+# --------------------------------------------------------------------------- #
+
+def load_hf_config(model_path: str):
+    """Best-effort load of a model's HF config for runner discovery.
+
+    Returns a transformers config object, or ``None`` if it cannot be loaded
+    without ``trust_remote_code`` (discovery then proceeds on whatever raw
+    config.json fields it can read). Never executes model repo code.
+    """
+    try:
+        from transformers import AutoConfig
+        return AutoConfig.from_pretrained(model_path, trust_remote_code=False)
+    except Exception:  # noqa: BLE001 — custom arch may need trust_remote_code; fall back
+        return None
+
+
+def _raw_config_json(model_path: str) -> dict:
+    """Read the raw config.json as a dict (local path or hub download). {} on failure.
+
+    Used to read non-standard fields (``model_type``, ``tt_runner``) without
+    needing transformers to fully parse a possibly-custom config.
+    """
+    p = pathlib.Path(model_path)
+    if p.is_dir():
+        cfg = p / "config.json"
+        if cfg.is_file():
+            try:
+                return json.loads(cfg.read_text())
+            except Exception:  # noqa: BLE001
+                return {}
+        return {}
+    # Hub id: download just config.json (no model code execution).
+    try:
+        from huggingface_hub import hf_hub_download
+        path = hf_hub_download(model_path, "config.json")
+        return json.loads(pathlib.Path(path).read_text())
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _config_arch(hf_config, raw: Optional[dict] = None) -> str:
+    archs = getattr(hf_config, "architectures", None) if hf_config is not None else None
+    if not archs and raw:
+        archs = raw.get("architectures")
+    return (archs[0] if archs else "") or ""
+
+
+def _config_model_type(hf_config, raw: Optional[dict] = None) -> str:
+    mt = getattr(hf_config, "model_type", "") if hf_config is not None else ""
+    if not mt and raw:
+        mt = raw.get("model_type", "")
+    return str(mt or "")
+
+
+# --------------------------------------------------------------------------- #
+# Entry-point discovery (precedence step 2)
+# --------------------------------------------------------------------------- #
+
+def iter_entry_point_runners():
+    """Yield (name, EntryPoint) for every registered ``tt_inference_server.runners``.
+
+    Tolerant of the importlib.metadata API differences across Python versions.
+    """
+    from importlib import metadata
+    try:
+        eps = metadata.entry_points(group=ENTRY_POINT_GROUP)  # py3.10+
+    except TypeError:  # pragma: no cover — py3.9 returns a dict
+        eps = metadata.entry_points().get(ENTRY_POINT_GROUP, [])
+    for ep in eps:
+        yield ep.name, ep
+
+
+# Specificity ranks for tie-breaking: a more-specific claim wins.
+_RANK_CLAIMS = 3
+_RANK_ARCH = 2
+_RANK_MODEL_TYPE = 1
+
+
+def _match_rank(runner_cls, hf_config, arch: str, model_type: str) -> int:
+    """Return how specifically ``runner_cls`` claims this model (0 = no match)."""
+    claims = getattr(runner_cls, "claims", None)
+    if callable(claims):
+        try:
+            if claims(hf_config):
+                return _RANK_CLAIMS
+        except Exception:  # noqa: BLE001 — a broken claim() must not break discovery
+            pass
+    archs = getattr(runner_cls, "supported_architectures", None)
+    if archs and arch and arch in archs:
+        return _RANK_ARCH
+    mtypes = getattr(runner_cls, "supported_model_types", None)
+    if mtypes and model_type and model_type in mtypes:
+        return _RANK_MODEL_TYPE
+    return 0
+
+
+def match_runner(hf_config, raw: Optional[dict] = None):
+    """Select the entry-point runner class claiming this model, or None.
+
+    Precedence within entry points: ``claims()`` > ``supported_architectures`` >
+    ``supported_model_types``. Most-specific match wins; a tie at the top rank is
+    ambiguous and raises (caller should ask for an explicit ``--runner``).
+    """
+    arch = _config_arch(hf_config, raw)
+    model_type = _config_model_type(hf_config, raw)
+
+    candidates = []  # (rank, name, runner_cls)
+    for name, ep in iter_entry_point_runners():
+        try:
+            runner_cls = ep.load()
+        except Exception as exc:  # noqa: BLE001 — skip a broken package, keep going
+            import sys
+            sys.stderr.write(
+                f"[dispatch] WARNING: runner entry point {name!r} failed to load: "
+                f"{type(exc).__name__}: {exc}\n"
+            )
+            continue
+        rank = _match_rank(runner_cls, hf_config, arch, model_type)
+        if rank > 0:
+            candidates.append((rank, name, runner_cls))
+
+    if not candidates:
+        return None
+
+    top = max(c[0] for c in candidates)
+    winners = [c for c in candidates if c[0] == top]
+    if len(winners) > 1:
+        names = ", ".join(sorted(n for _, n, _ in winners))
+        raise RuntimeError(
+            f"Ambiguous runner selection: entry points [{names}] all claim this model "
+            f"(arch={arch!r}, model_type={model_type!r}) at the same specificity. "
+            "Disambiguate with an explicit --runner module:Class."
+        )
+    return winners[0][2]
+
+
+# --------------------------------------------------------------------------- #
+# HF repo self-declaration (precedence step 3 — trust-gated)
+# --------------------------------------------------------------------------- #
+
+def parse_self_declared_runner(model_path: str, hf_config=None,
+                               raw: Optional[dict] = None) -> Optional[str]:
+    """Return a ``"module:Class"`` runner spec self-declared by the model repo, or None.
+
+    Sources, in order:
+      1. ``tt_dispatch.json`` sidecar in a local model dir: ``{"runner": "module:Class"}``.
+      2. ``tt_runner`` field in the model's ``config.json``.
+
+    This points at code that will be IMPORTED AND EXECUTED — treat exactly like
+    ``trust_remote_code``. The caller gates honoring it behind ``--unsafe`` and an
+    optional allowlist (see ``runner_allowed``).
+    """
+    p = pathlib.Path(model_path)
+    if p.is_dir():
+        sidecar = p / "tt_dispatch.json"
+        if sidecar.is_file():
+            try:
+                data = json.loads(sidecar.read_text())
+                spec = data.get("runner")
+                if spec:
+                    return str(spec)
+            except Exception:  # noqa: BLE001
+                pass
+    if raw is None:
+        raw = _raw_config_json(model_path)
+    spec = raw.get("tt_runner") if raw else None
+    return str(spec) if spec else None
+
+
+def runner_allowed(spec: str) -> bool:
+    """Whether ``spec`` passes the optional ``DISPATCH_RUNNER_ALLOW`` allowlist.
+
+    If the env var is unset/empty, all specs are allowed (the ``--unsafe`` gate is
+    the only barrier). If set, only listed ``module:Class`` (or module-prefix)
+    entries are honored.
+    """
+    allow = os.environ.get(ENV_ALLOW, "").strip()
+    if not allow:
+        return True
+    entries = {e.strip() for e in allow.split(",") if e.strip()}
+    if spec in entries:
+        return True
+    # Allow a bare module prefix to whitelist a whole package.
+    module = spec.partition(":")[0].partition(".")[0]
+    return module in entries or spec.partition(":")[0] in entries
+
+
+# --------------------------------------------------------------------------- #
+# Top-level resolver (used by load_model)
+# --------------------------------------------------------------------------- #
+
+def resolve_runner_class(model_path: str, explicit: Optional[str], unsafe: bool):
+    """Resolve the runner class for ``model_path`` by precedence.
+
+    Returns ``(runner_cls_or_None, source)``. ``None`` means "use the generic
+    TTModelRunner fallback". ``source`` is a short human-readable tag for logging.
+    """
+    # 1. Explicit override (arg or env). User-supplied -> trusted.
+    explicit = explicit or os.environ.get(ENV_RUNNER) or None
+    if explicit:
+        return _load_dotted(explicit), f"explicit:{explicit}"
+
+    # Lazily load config only if there is any chance of a non-generic match.
+    eps = list(iter_entry_point_runners())
+    hf_config = None
+    raw = None
+    if eps:
+        hf_config = load_hf_config(model_path)
+        raw = _raw_config_json(model_path)
+        matched = match_runner(hf_config, raw)
+        if matched is not None:
+            return matched, f"entry_point:{matched.__module__}:{matched.__name__}"
+
+    # 3. HF repo self-declaration — trust-gated behind --unsafe (+ allowlist).
+    if unsafe:
+        if raw is None:
+            raw = _raw_config_json(model_path)
+        spec = parse_self_declared_runner(model_path, hf_config, raw)
+        if spec:
+            if not runner_allowed(spec):
+                raise RuntimeError(
+                    f"Self-declared runner {spec!r} is not in DISPATCH_RUNNER_ALLOW; "
+                    "refusing to load it. Add it to the allowlist or pass --runner."
+                )
+            import sys
+            sys.stderr.write(
+                f"[dispatch] WARNING: honoring self-declared runner {spec!r} from the "
+                "model repo (trust_remote_code-class: this imports and executes "
+                "repo-referenced code).\n"
+            )
+            return _load_dotted(spec), f"self_declared:{spec}"
+
+    # 4. Generic fallback.
+    return None, "generic"
+
+
+__all__ = [
+    "BaseRunner",
+    "ENTRY_POINT_GROUP",
+    "validate_runner",
+    "load_hf_config",
+    "iter_entry_point_runners",
+    "match_runner",
+    "parse_self_declared_runner",
+    "runner_allowed",
+    "resolve_runner_class",
+]

--- a/tt_inference_server/dispatch/compat.py
+++ b/tt_inference_server/dispatch/compat.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shape validation, padding, and L1 budget checking.
+
+Primary job: given a tensor shape, determine whether a kernel config is
+valid and if not, find the nearest valid config. Prioritizes correctness
+over throughput — any working config is better than a compiler error.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+TILE = 32
+BF16_TILE_BYTES = 32 * 32 * 2  # 2048 bytes per bf16 tile
+# Last-resort fallback for direct callers that pass hw_config=None. The dispatcher now
+# always supplies a detected HardwareConfig (see hardware.detect_hardware), so this is
+# rarely hit; it mirrors bh_p150_1card's budget: int(1_572_864 * 0.915).
+_DEFAULT_L1_BUDGET_BYTES = 1_439_170
+
+
+class ShapeNotSupportedError(ValueError):
+    """Raised when no valid kernel config can be found for a given shape."""
+
+
+@dataclass
+class PaddedShape:
+    original: Tuple[int, ...]
+    padded: Tuple[int, ...]
+    tiles: Tuple[int, ...]
+
+    @property
+    def needed_padding(self) -> bool:
+        return self.original != self.padded
+
+
+def tile_align(dim: int) -> int:
+    """Round dim up to the nearest multiple of TILE."""
+    return math.ceil(dim / TILE) * TILE
+
+
+def to_tiles(dim: int) -> int:
+    return tile_align(dim) // TILE
+
+
+def pad_shape(shape: Tuple[int, ...]) -> PaddedShape:
+    """Return a PaddedShape that is tile-aligned in every dimension."""
+    padded = tuple(tile_align(d) for d in shape)
+    tiles = tuple(d // TILE for d in padded)
+    return PaddedShape(original=shape, padded=padded, tiles=tiles)
+
+
+def l1_bytes_for_attn(
+    head_dim_tiles: int,
+    kv_chunk_tiles: int,
+    n_intermediate_dfbs: int = 17,
+    block_count: int = 2,
+) -> int:
+    """Estimate L1 CB footprint for a flash attention config."""
+    tiles_per_head = head_dim_tiles * block_count
+    tiles_per_chunk = kv_chunk_tiles * block_count
+    # Rough budget: head-sized buffers + chunk-sized buffers + scalar buffers
+    head_bufs = 8  # q, k, v, kt, out, o_corr, pv, l_bcast
+    chunk_bufs = 5  # qk, scaled, exp, m_bcast, mask
+    scalar_bufs = 7  # m, l, alpha, m_new, chunk_max, chunk_sum, scale/ninf/zero
+    total_tiles = (
+        head_bufs * tiles_per_head
+        + chunk_bufs * tiles_per_chunk
+        + scalar_bufs * block_count
+    )
+    return total_tiles * BF16_TILE_BYTES
+
+
+def l1_bytes_for_swiglu(
+    M_tiles: int,
+    K_tiles: int,
+    N_tiles: int,
+    block_count: int = 2,
+) -> int:
+    """Estimate L1 CB footprint for a SwiGLU config."""
+    # 8 DFBs: gate, w_gate, bias_gate, up, w_up, bias_up, act, out
+    mk = M_tiles * K_tiles
+    kn = K_tiles * N_tiles
+    mn = M_tiles * N_tiles
+    total_tiles = (2 * mk + 2 * kn + 4 * mn) * block_count
+    return total_tiles * BF16_TILE_BYTES
+
+
+def resolve_attn_config(
+    N_heads: int,
+    N_kv_heads: int,
+    head_dim: int,
+    max_seq_len: int,
+    hw_config=None,
+) -> Dict:
+    """Find a valid flash attention config for the given model dimensions.
+
+    Returns a dict of kwargs for make_flash_attn_kernel.
+    Raises ShapeNotSupportedError if no valid config exists.
+    """
+    l1_budget = hw_config.l1_budget() if hw_config is not None else _DEFAULT_L1_BUDGET_BYTES
+    head_dim_padded = tile_align(head_dim)
+    head_dim_tiles = head_dim_padded // TILE
+
+    # Try kv_chunk_tiles from 1 up to 4 — larger chunks use more L1
+    for kv_chunk_tiles in (1, 2, 4):
+        l1 = l1_bytes_for_attn(head_dim_tiles, kv_chunk_tiles)
+        if l1 <= l1_budget:
+            return {
+                "N_heads": N_heads,
+                "N_kv_heads": N_kv_heads,
+                "head_dim_tiles": head_dim_tiles,
+                "kv_chunk_tiles": kv_chunk_tiles,
+            }
+
+    raise ShapeNotSupportedError(
+        f"Flash attention config not feasible: head_dim={head_dim} requires "
+        f"{l1_bytes_for_attn(head_dim_tiles, 1) // 1024} KiB L1 but budget is "
+        f"{l1_budget // 1024} KiB ({hw_config.name if hw_config else 'default'}). "
+        f"Consider reducing head_dim or L1 budget."
+    )
+
+
+def resolve_swiglu_config(
+    M: int,
+    K: int,
+    N: int,
+    activation: str = "silu",
+    hw_config=None,
+) -> Dict:
+    """Find a valid SwiGLU config for the given dimensions.
+
+    Returns a dict of kwargs for make_swiglu_kernel.
+    Raises ShapeNotSupportedError if no valid config exists.
+    """
+    l1_budget = hw_config.l1_budget() if hw_config is not None else _DEFAULT_L1_BUDGET_BYTES
+    M_tiles = to_tiles(M)
+    K_tiles = to_tiles(K)
+    N_tiles = to_tiles(N)
+
+    l1 = l1_bytes_for_swiglu(M_tiles, K_tiles, N_tiles)
+    if l1 > l1_budget:
+        raise ShapeNotSupportedError(
+            f"SwiGLU config not feasible: M={M} K={K} N={N} requires "
+            f"{l1 // 1024} KiB L1 but budget is {l1_budget // 1024} KiB. "
+            f"Consider reducing batch/sequence dimension."
+        )
+
+    return {
+        "M_tiles": M_tiles,
+        "K_tiles": K_tiles,
+        "N_tiles": N_tiles,
+        "activation": activation,
+    }
+
+
+def resolve_norm_config(seq_len: int, hidden_dim: int) -> Dict:
+    """Return tile dims for a norm kernel (RMSNorm or LayerNorm)."""
+    return {
+        "seq_tiles": to_tiles(seq_len),
+        "hidden_tiles": to_tiles(hidden_dim),
+    }

--- a/tt_inference_server/dispatch/compat.py
+++ b/tt_inference_server/dispatch/compat.py
@@ -101,7 +101,9 @@ def resolve_attn_config(
     Returns a dict of kwargs for make_flash_attn_kernel.
     Raises ShapeNotSupportedError if no valid config exists.
     """
-    l1_budget = hw_config.l1_budget() if hw_config is not None else _DEFAULT_L1_BUDGET_BYTES
+    l1_budget = (
+        hw_config.l1_budget() if hw_config is not None else _DEFAULT_L1_BUDGET_BYTES
+    )
     head_dim_padded = tile_align(head_dim)
     head_dim_tiles = head_dim_padded // TILE
 
@@ -136,7 +138,9 @@ def resolve_swiglu_config(
     Returns a dict of kwargs for make_swiglu_kernel.
     Raises ShapeNotSupportedError if no valid config exists.
     """
-    l1_budget = hw_config.l1_budget() if hw_config is not None else _DEFAULT_L1_BUDGET_BYTES
+    l1_budget = (
+        hw_config.l1_budget() if hw_config is not None else _DEFAULT_L1_BUDGET_BYTES
+    )
     M_tiles = to_tiles(M)
     K_tiles = to_tiles(K)
     N_tiles = to_tiles(N)

--- a/tt_inference_server/dispatch/config_gemma3.py
+++ b/tt_inference_server/dispatch/config_gemma3.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gemma 3 model family config (Google)."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Gemma3Config:
+    num_heads: int
+    num_kv_heads: int
+    head_dim: int
+    hidden_size: int
+    intermediate_size: int
+    activation: str = "gelu"
+    norm_type: str = "rmsnorm"
+    norm_eps: float = 1e-6
+
+    @classmethod
+    def from_hf_config(cls, hf_config):
+        # Multimodal variant (ForConditionalGeneration) nests text params under text_config
+        cfg = getattr(hf_config, "text_config", hf_config)
+        hidden = cfg.hidden_size
+        n_heads = cfg.num_attention_heads
+        # Read actual activation (gelu_pytorch_tanh is Gemma's default)
+        hf_act = getattr(cfg, "hidden_activation", getattr(cfg, "hidden_act", "gelu_pytorch_tanh"))
+        return cls(
+            num_heads=n_heads,
+            num_kv_heads=cfg.num_key_value_heads,
+            head_dim=getattr(cfg, "head_dim", hidden // n_heads),
+            hidden_size=hidden,
+            intermediate_size=cfg.intermediate_size,
+            activation=hf_act,
+            norm_eps=getattr(cfg, "rms_norm_eps",
+                     getattr(cfg, "layer_norm_eps", 1e-6)),
+        )
+
+
+# Alias so the registry's generic ModelConfig lookup finds this class
+ModelConfig = Gemma3Config

--- a/tt_inference_server/dispatch/config_gemma3.py
+++ b/tt_inference_server/dispatch/config_gemma3.py
@@ -24,7 +24,9 @@ class Gemma3Config:
         hidden = cfg.hidden_size
         n_heads = cfg.num_attention_heads
         # Read actual activation (gelu_pytorch_tanh is Gemma's default)
-        hf_act = getattr(cfg, "hidden_activation", getattr(cfg, "hidden_act", "gelu_pytorch_tanh"))
+        hf_act = getattr(
+            cfg, "hidden_activation", getattr(cfg, "hidden_act", "gelu_pytorch_tanh")
+        )
         return cls(
             num_heads=n_heads,
             num_kv_heads=cfg.num_key_value_heads,
@@ -32,8 +34,7 @@ class Gemma3Config:
             hidden_size=hidden,
             intermediate_size=cfg.intermediate_size,
             activation=hf_act,
-            norm_eps=getattr(cfg, "rms_norm_eps",
-                     getattr(cfg, "layer_norm_eps", 1e-6)),
+            norm_eps=getattr(cfg, "rms_norm_eps", getattr(cfg, "layer_norm_eps", 1e-6)),
         )
 
 

--- a/tt_inference_server/dispatch/config_llama3.py
+++ b/tt_inference_server/dispatch/config_llama3.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shape constants for the Llama 3 model family (Meta)."""
+
+try:
+    from .config_qwen2_5 import ModelConfig
+except ImportError:
+    from .config_qwen2_5 import ModelConfig  # script mode
+
+# Per-size dim tables (CONFIGS) were retired in #3 Phase D — dims for listed models now
+# live in model_matrix.toml; novel models derive via ModelConfig.from_hf_config. This
+# module is kept so registry._FAMILY_MAP can resolve LlamaForCausalLM to ModelConfig.
+__all__ = ["ModelConfig"]

--- a/tt_inference_server/dispatch/config_mistral.py
+++ b/tt_inference_server/dispatch/config_mistral.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shape constants for Mistral and Mixtral model families."""
+
+from dataclasses import dataclass
+
+try:
+    from .config_qwen2_5 import ModelConfig
+except ImportError:
+    from .config_qwen2_5 import ModelConfig  # script mode
+
+
+@dataclass
+class MoEModelConfig(ModelConfig):
+    num_experts: int = 8
+    num_experts_per_tok: int = 2
+
+
+# Per-size dim tables (CONFIGS) were retired in #3 Phase D — dims for listed models now
+# live in model_matrix.toml; novel models derive via ModelConfig.from_hf_config.
+# MoEModelConfig is retained: detect_model_family builds it for MoE archs from hf_config.

--- a/tt_inference_server/dispatch/config_qwen2_5.py
+++ b/tt_inference_server/dispatch/config_qwen2_5.py
@@ -32,5 +32,6 @@ class ModelConfig:
             intermediate_size=intermediate,
         )
 
+
 # Per-size dim tables (CONFIGS) were retired in #3 Phase D — dims for listed models now
 # live in model_matrix.toml (authoritative); novel models derive via from_hf_config above.

--- a/tt_inference_server/dispatch/config_qwen2_5.py
+++ b/tt_inference_server/dispatch/config_qwen2_5.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shape constants for the Qwen 2.5 model family."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ModelConfig:
+    hidden_size: int
+    num_heads: int
+    num_kv_heads: int
+    head_dim: int
+    intermediate_size: int
+    norm_type: str = "rmsnorm"
+    activation: str = "silu"
+    norm_eps: float = 1e-6
+
+    @classmethod
+    def from_hf_config(cls, hf_config) -> "ModelConfig":
+        hidden = hf_config.hidden_size
+        n_heads = hf_config.num_attention_heads
+        n_kv = getattr(hf_config, "num_key_value_heads", n_heads)
+        head_dim = getattr(hf_config, "head_dim", None) or (hidden // n_heads)
+        intermediate = hf_config.intermediate_size
+        return cls(
+            hidden_size=hidden,
+            num_heads=n_heads,
+            num_kv_heads=n_kv,
+            head_dim=head_dim,
+            intermediate_size=intermediate,
+        )
+
+# Per-size dim tables (CONFIGS) were retired in #3 Phase D — dims for listed models now
+# live in model_matrix.toml (authoritative); novel models derive via from_hf_config above.

--- a/tt_inference_server/dispatch/config_qwen3.py
+++ b/tt_inference_server/dispatch/config_qwen3.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shape constants for the Qwen 3 model family."""
+
+try:
+    from .config_qwen2_5 import ModelConfig
+except ImportError:
+    from .config_qwen2_5 import ModelConfig  # script mode
+
+# Per-size dim tables (CONFIGS) were retired in #3 Phase D — dims for listed models now
+# live in model_matrix.toml; novel models derive via ModelConfig.from_hf_config. This
+# module is kept so registry._FAMILY_MAP can resolve Qwen3ForCausalLM to ModelConfig.
+__all__ = ["ModelConfig"]

--- a/tt_inference_server/dispatch/dispatcher.py
+++ b/tt_inference_server/dispatch/dispatcher.py
@@ -1,0 +1,729 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""KernelDispatcher — shape-keyed kernel instance cache with model matrix support.
+
+At init:
+  1. Loads model_matrix.toml and validates schema_version.
+  2. Acquires a file lock at ~/.dispatch.lock to prevent concurrent device use.
+  3. Validates every model entry (GQA constraint).
+  4. Warms the tt-metal kernel cache from pre-compiled binaries in kernels/manifest.json
+     (if present); falls back to JIT with a warning when binaries are missing.
+
+At inference:
+  - dispatch_* methods cache compiled kernel instances keyed by shape.
+  - resolve(model_name_or_path) returns the ModelMatrixEntry for a model.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import pathlib
+import tarfile
+import tomllib
+import warnings
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from .compat import (
+    resolve_attn_config,
+    resolve_norm_config,
+    resolve_swiglu_config,
+    to_tiles,
+)
+
+# Must match schema_version in model_matrix.toml.  Bump both together.
+DISPATCHER_SCHEMA_VERSION = 3
+
+_DEFAULT_MATRIX_PATH = pathlib.Path(__file__).parent / "model_matrix.toml"
+_DEVICE_LOCK_PATH = pathlib.Path.home() / ".dispatch.lock"
+_KERNELS_DIR = pathlib.Path(__file__).parent / "kernels"
+_MANIFEST_PATH = _KERNELS_DIR / "manifest.json"
+_TT_METAL_CACHE = pathlib.Path.home() / ".cache" / "tt-metal-cache"
+
+
+@dataclass
+class Capabilities:
+    """Derived (not stored) decode-path capabilities for a resolved model.
+
+    Computed from a ModelMatrixEntry's behavioral fields + dims (+ HardwareConfig).
+    These replace the runner's inline eligibility computations:
+      fast_path        <- _ondevice_attn_eligible + _setup_paged_decode ok_shape
+      lm_head_ondevice <- _setup_ondevice_lmhead eligibility
+    """
+    fast_path: bool
+    lm_head_ondevice: bool
+    attn_backend: str
+
+
+@dataclass
+class ResolvedConfig:
+    """Model dims view exposing the ModelConfig attribute names the runner reads.
+
+    Built from a matrix entry so the matrix is authoritative for dims (#3 Phase D),
+    replacing the per-arch dim modules / hardcoded CONFIGS dicts in registry.py for
+    listed models. Novel models keep detect_model_family()'s HF-config introspection.
+    """
+    hidden_size: int
+    num_heads: int
+    num_kv_heads: int
+    head_dim: int
+    intermediate_size: int
+    activation: str
+    norm_type: str
+
+
+def _compute_capabilities(
+    *,
+    norm_type: str,
+    rotary_pct: float,
+    attn_bias: bool,
+    head_norm: bool,
+    head_dim: int,
+    n_heads: int,
+    n_kv_heads: int,
+    attn_backend: str = "ttnn",
+) -> Capabilities:
+    """Shared capability formula used by both the matrix entry and the unlisted
+    auto-derive path, so listed and novel models compute eligibility identically.
+
+    fast_path (traced-ttnn decode) is eligible iff the model is a plain RMSNorm
+    full-RoPE attention with no bias / head-norm, a tile-aligned head_dim, and a GQA
+    group the decode SDPA's pad-to-32 can represent (group | 32, nh <= 32). This merges
+    the runner's `_ondevice_attn_eligible` flag with the `_setup_paged_decode` ok_shape
+    gate (and the nh<=32 / group|32 check).
+
+    lm_head_ondevice (on-device final-norm + matmul + argmax): always True. The
+    _lm_head_graph handles RMSNorm, gemma_rms (rmsnorm with (1+w) baked in), and (CP-3)
+    LayerNorm (mean-sub + bias via ttnn.layer_norm) final norms on-device. Unaligned
+    vocab is handled by the runner's pad-mask, so no vocab alignment constraint applies.
+    """
+    group = (n_heads // n_kv_heads) if n_kv_heads else 0
+    fast_path = (
+        norm_type in ("rmsnorm", "layernorm")   # CP-3: LayerNorm runs on-device (ttnn.layer_norm)
+        and rotary_pct == 1.0
+        # CP-1: qkv/o bias now applied on-device (ttnn.add) in the attention paths,
+        # so attn_bias no longer forces the slow CPU-readback route.
+        # CP-4: per-head Q/K RMSNorm now runs on-device (ttnn.rms_norm), so head_norm
+        # no longer blocks the fast path.
+        and head_dim % 32 == 0
+        and group >= 1
+        # CP-5: decode SDPA accepts arbitrary GQA groups (probe PCC 0.9997 for g=7,12),
+        # so 32 % group == 0 is no longer required — _nh_pad = group * (32//group).
+        and n_heads <= 32
+        # CP-3/CP-6: ALiBi (cpu backend) can't fold into the SDPA decode kernel.
+        and attn_backend != "cpu"
+    )
+    # CP-3: _lm_head_graph handles RMSNorm and LayerNorm final norms on device.
+    lm_head_ondevice = True
+    return Capabilities(
+        fast_path=fast_path,
+        lm_head_ondevice=lm_head_ondevice,
+        attn_backend=attn_backend,
+    )
+
+
+def derive_capabilities(hf_config) -> Capabilities:
+    """Auto-derive decode-path capabilities for an UNLISTED (novel) model from its
+    HuggingFace config alone — the universal floor of the two-tier resolution (#3).
+
+    This is intentionally config-only and conservative; the matrix overrides it for
+    listed models. A novel model still runs (flagged community/unverified); the output
+    validator catches breakage. NOTE: some signals the runner sniffs from loaded module
+    structure (e.g. Qwen2's always-on qkv bias) are not visible here — those are exactly
+    the cases the matrix is meant to record an override for.
+    """
+    text_cfg = getattr(hf_config, "text_config", hf_config)
+    archs = getattr(hf_config, "architectures", None) or []
+    arch = archs[0] if archs else ""
+    model_type = str(getattr(text_cfg, "model_type", "")).lower()
+
+    n_heads = getattr(text_cfg, "num_attention_heads", 32)
+    n_kv = getattr(text_cfg, "num_key_value_heads", n_heads) or n_heads
+    hidden = getattr(text_cfg, "hidden_size", 4096)
+    head_dim = getattr(text_cfg, "head_dim", None) or (hidden // n_heads)
+
+    if "gemma" in model_type or arch.startswith("Gemma"):
+        norm_type = "gemma_rms"
+    elif hasattr(text_cfg, "rms_norm_eps"):
+        norm_type = "rmsnorm"
+    elif hasattr(text_cfg, "layer_norm_eps") or hasattr(text_cfg, "layer_norm_epsilon"):
+        norm_type = "layernorm"
+    else:
+        norm_type = "rmsnorm"
+
+    rotary_pct = float(getattr(text_cfg, "partial_rotary_factor",
+                               getattr(text_cfg, "rotary_pct", 1.0)) or 1.0)
+    # LayerNorm-family archs (GPTNeoX/Pythia) carry qkv bias; otherwise read the flag.
+    attn_bias = bool(getattr(text_cfg, "attention_bias", False)) or (norm_type == "layernorm")
+    head_norm = arch.startswith("Qwen3") or "gemma3" in model_type
+    attn_backend = "ttnn" if (n_kv and n_heads % n_kv == 0 and 32 % (n_heads // n_kv) == 0) else "custom"
+
+    return _compute_capabilities(
+        norm_type=norm_type,
+        rotary_pct=rotary_pct,
+        attn_bias=attn_bias,
+        head_norm=head_norm,
+        head_dim=head_dim,
+        n_heads=n_heads,
+        n_kv_heads=n_kv,
+        attn_backend=attn_backend,
+    )
+
+
+@dataclass
+class ModelMatrixEntry:
+    name: str
+    arch: str
+    local_path: str
+    hidden_size: int
+    intermediate_size: int
+    n_layers: int
+    vocab_size: int
+    n_heads: int
+    n_kv_heads: int
+    head_dim: int
+    max_seq: int
+    rope_theta: float
+    swa_window: int
+    tie_embeddings: bool
+    kernels: List[str]
+    min_hw: str
+    status: str
+    # --- behavioral fields (schema v2, issue #3). Defaults reproduce today's
+    #     HF-derived behavior so an entry that omits them is a no-op. ---
+    norm_type: str = "rmsnorm"          # rmsnorm | layernorm | gemma_rms
+    activation: str = "silu"            # silu | gelu | gelu_tanh | relu2
+    rotary_pct: float = 1.0             # 1.0 full; 0.25 partial (GPTNeoX/StableLM)
+    attn_bias: bool = False             # qkv + o-proj bias present
+    head_norm: bool = False             # per-head q/k RMSNorm (Qwen3/Gemma3)
+    parallel_residual: bool = False     # attn + MLP branch the same pre-norm (GPTNeoX)
+    embed_scale: str = "none"           # none | sqrt_hidden (Gemma scales embeds)
+    attn_backend: str = "ttnn"          # ttnn | custom | cpu (#34 backend-per-op)
+    # Granite (#43) architectural scaling factors. None = fall through to the HF config
+    # value (so an omitted field is a no-op); a set value OVERRIDES it, same as the other
+    # behavioral fields. Read by the runner's _scaling_factor().
+    embedding_multiplier: Optional[float] = None   # scales input embeddings
+    residual_multiplier: Optional[float] = None    # scales each sublayer output pre-residual-add
+    attention_multiplier: Optional[float] = None   # overrides the 1/sqrt(head_dim) softmax scale
+    logits_scaling: Optional[float] = None          # divides final logits (no-op for greedy argmax)
+    issue: Optional[int] = None
+    notes: str = ""
+
+    def model_config(self) -> ResolvedConfig:
+        """Return the matrix-authoritative dims view consumed by the runner as self._cfg."""
+        return ResolvedConfig(
+            hidden_size=self.hidden_size,
+            num_heads=self.n_heads,
+            num_kv_heads=self.n_kv_heads,
+            head_dim=self.head_dim,
+            intermediate_size=self.intermediate_size,
+            activation=self.activation,
+            norm_type=self.norm_type,
+        )
+
+    def capabilities(self, hw_config=None) -> Capabilities:
+        """Compute the DERIVED decode-path gates from fields + dims.
+
+        See _compute_capabilities for the eligibility rules.
+        """
+        return _compute_capabilities(
+            norm_type=self.norm_type,
+            rotary_pct=self.rotary_pct,
+            attn_bias=self.attn_bias,
+            head_norm=self.head_norm,
+            head_dim=self.head_dim,
+            n_heads=self.n_heads,
+            n_kv_heads=self.n_kv_heads,
+            attn_backend=self.attn_backend,
+        )
+
+
+class SchemaVersionError(RuntimeError):
+    """Raised when model_matrix.toml schema_version doesn't match dispatcher."""
+
+
+class ModelNotFoundError(ValueError):
+    """Raised when a requested model is not in the matrix."""
+
+
+class UnsafeModelError(ValueError):
+    """Raised when a 'community' model is requested without --unsafe."""
+
+
+class DeviceLockError(RuntimeError):
+    """Raised when the device lock is already held by another process."""
+
+
+class KernelDispatcher:
+    """Dispatches tensor shapes to cached kernel instances.
+
+    Parameters
+    ----------
+    device:
+        An open ttnn device.
+    model_config:
+        Optional pre-loaded ModelMatrixEntry.
+    matrix_path:
+        Path to model_matrix.toml.  Defaults to the file in this package.
+    unsafe:
+        If True, allow loading 'community' status models with a warning.
+    """
+
+    def __init__(
+        self,
+        device,
+        model_config=None,
+        matrix_path: Optional[pathlib.Path] = None,
+        unsafe: bool = False,
+        hw_config=None,
+    ):
+        self._device = device
+        self._model_config = model_config
+        # Resolve the hardware capability config once (tt-smi via tt-kernel, ttnn
+        # fallback, deployment default). Flows to compat's L1/DRAM budgets and to
+        # capabilities(). On the p150 the detected L1 budget equals the legacy default,
+        # so this is behavior-preserving there.
+        if hw_config is None:
+            from tt_inference_server.dispatch.hardware import detect_hardware
+            hw_config = detect_hardware(device)
+        self._hw_config = hw_config
+        self._cache: Dict[Tuple, Any] = {}
+        self._unsafe = unsafe
+        self._lock_fh = None
+
+        self._acquire_device_lock()
+        _warm_kernel_cache(device)
+        _install_kernel_patch_overlay()
+
+        matrix_path = matrix_path or _DEFAULT_MATRIX_PATH
+        self._matrix, self._index = _load_and_validate_matrix(matrix_path)
+
+    # ------------------------------------------------------------------
+    # Device lock
+    # ------------------------------------------------------------------
+
+    def _acquire_device_lock(self) -> None:
+        """Acquire an exclusive file lock so only one dispatcher runs at a time."""
+        try:
+            fh = open(_DEVICE_LOCK_PATH, "w")
+            fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fh.write(str(os.getpid()))
+            fh.flush()
+            self._lock_fh = fh
+        except BlockingIOError:
+            raise DeviceLockError(
+                f"Device lock {_DEVICE_LOCK_PATH} is held by another process. "
+                "Stop the other bench/dispatch process before starting a new one."
+            )
+
+    def release(self) -> None:
+        """Release the device lock. Best-effort and shutdown-safe: __del__ can run during
+        interpreter finalization, when module globals (fcntl) may already be None — so
+        re-import locally and swallow any error rather than raise from a destructor."""
+        fh = self._lock_fh
+        if fh is None:
+            return
+        self._lock_fh = None
+        try:
+            import fcntl as _fcntl
+            _fcntl.flock(fh, _fcntl.LOCK_UN)
+            fh.close()
+        except Exception:
+            pass
+
+    def __del__(self):
+        self.release()
+
+    # ------------------------------------------------------------------
+    # Model matrix
+    # ------------------------------------------------------------------
+
+    def resolve(self, model_name_or_path: str) -> ModelMatrixEntry:
+        """Return the ModelMatrixEntry for a model name or local path.
+
+        Raises ModelNotFoundError if not found.
+        Raises UnsafeModelError if status='community' and unsafe=False.
+        """
+        entry = self._index.get(model_name_or_path)
+
+        # Also match by local_path basename (e.g. "llama3-8b")
+        if entry is None:
+            basename = pathlib.Path(model_name_or_path).name
+            for e in self._matrix:
+                if pathlib.Path(e.local_path).name == basename:
+                    entry = e
+                    break
+
+        if entry is None:
+            known = ", ".join(sorted(self._index.keys()))
+            raise ModelNotFoundError(
+                f"Model '{model_name_or_path}' not found in model matrix. "
+                f"Known models: {known}. "
+                "To attempt an unsupported model, pass unsafe=True to load_model()."
+            )
+
+        if entry.status == "community" and not self._unsafe:
+            raise UnsafeModelError(
+                f"Model '{entry.name}' has status='community' (unverified). "
+                "Pass unsafe=True to load_model() to proceed with a visible warning."
+            )
+
+        if entry.status == "community":
+            warnings.warn(
+                f"Loading community model '{entry.name}': correctness unverified on this hardware.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        return entry
+
+    def lookup(self, model_name_or_path: str) -> Optional[ModelMatrixEntry]:
+        """Return the ModelMatrixEntry for a name/path, or None if unlisted.
+
+        Unlike resolve(), this applies no trust (unsafe) gate and never raises — it
+        answers only "is there a matrix entry?". The runner uses it to prefer the matrix
+        for listed models and fall back to derive_capabilities() for novel ones. The
+        --unsafe / community gating is enforced at the load_model() layer (#25) via
+        resolve().
+        """
+        entry = self._index.get(model_name_or_path)
+        if entry is None:
+            basename = pathlib.Path(model_name_or_path).name
+            for e in self._matrix:
+                if pathlib.Path(e.local_path).name == basename:
+                    entry = e
+                    break
+        return entry
+
+    def models(self) -> List[ModelMatrixEntry]:
+        """Return all entries in the model matrix."""
+        return list(self._matrix)
+
+    # ------------------------------------------------------------------
+    # Kernel dispatch (shape-keyed cache)
+    # ------------------------------------------------------------------
+
+    def swiglu(self, gate, w_gate, bias_gate, up, w_up, bias_up, out, activation="silu"):
+        from tt_inference_server.dispatch.kernels.swiglu import make_swiglu_kernel
+        M, K, N = gate.shape[0], gate.shape[1], w_gate.shape[1]
+        key = ("swiglu", M, K, N, activation)
+        if key not in self._cache:
+            cfg = resolve_swiglu_config(M, K, N, activation, hw_config=self._hw_config)
+            self._cache[key] = make_swiglu_kernel(**cfg)
+        return self._cache[key](gate, w_gate, bias_gate, up, w_up, bias_up, out)
+
+    def flash_attn(self, Q, K, V, scale, neg_inf, zero, zero_head, ones, mask, out,
+                   N_heads: int = None, N_kv_heads: int = None):
+        head_dim = Q.shape[-1]
+        n_heads = N_heads or Q.shape[0]
+        n_kv = N_kv_heads or K.shape[0]
+        kv_seq = K.shape[0] // n_kv if n_kv else K.shape[0]
+        key = ("flash_attn", n_heads, n_kv, head_dim)
+        if key not in self._cache:
+            from tt_inference_server.dispatch.kernels.flash_attn import make_flash_attn_kernel
+            cfg = resolve_attn_config(n_heads, n_kv, head_dim, kv_seq, hw_config=self._hw_config)
+            self._cache[key] = make_flash_attn_kernel(**cfg)
+        return self._cache[key](Q, K, V, scale, neg_inf, zero, zero_head, ones, mask, out)
+
+    def kv_decode(self, Q, K_cache, V_cache, scale, neg_inf, zero, zero_head, out, ones=None):
+        from tt_inference_server.dispatch.kernels.kv_decode import make_kv_decode_kernel
+        N_kv_heads, head_dim = Q.shape[0], Q.shape[1]
+        max_seq = K_cache.shape[0] // N_kv_heads
+        key = ("kv_decode", N_kv_heads, head_dim, max_seq)
+        if key not in self._cache:
+            self._cache[key] = make_kv_decode_kernel(
+                N_kv_heads=N_kv_heads,
+                head_dim_tiles=to_tiles(head_dim),
+                max_seq_tiles=to_tiles(max_seq),
+            )
+        return self._cache[key](Q, K_cache, V_cache, scale, neg_inf, zero, zero_head, out)
+
+    def rmsnorm(self, x, weight, scaler, out):
+        from tt_inference_server.dispatch.kernels.rmsnorm import make_rmsnorm_kernel
+        seq, hidden = x.shape[0], x.shape[1]
+        key = ("rmsnorm", seq, hidden)
+        if key not in self._cache:
+            cfg = resolve_norm_config(seq, hidden)
+            self._cache[key] = make_rmsnorm_kernel(**cfg)
+        return self._cache[key](x, weight, scaler, out)
+
+    def layernorm(self, x, weight, bias, scaler, out):
+        from tt_inference_server.dispatch.kernels.layernorm import make_layernorm_kernel
+        seq, hidden = x.shape[0], x.shape[1]
+        key = ("layernorm", seq, hidden)
+        if key not in self._cache:
+            cfg = resolve_norm_config(seq, hidden)
+            self._cache[key] = make_layernorm_kernel(**cfg)
+        return self._cache[key](x, weight, bias, scaler, out)
+
+    def moe_route(self, hidden, w_router, probs_out, N_experts: int, top_k: int, ones=None):
+        """Run router projection + softmax on device, then top-k on host."""
+        import torch
+        import ttnn
+        hidden_dim = hidden.shape[1]
+        expert_tiles = max(1, (N_experts + 31) // 32)
+        key = ("moe_router", hidden_dim, N_experts)
+        if key not in self._cache:
+            from tt_inference_server.dispatch.kernels.moe_router import make_moe_router_kernel
+            self._cache[key] = make_moe_router_kernel(
+                hidden_tiles=to_tiles(hidden_dim),
+                expert_tiles=expert_tiles,
+            )
+        self._cache[key](hidden, w_router, probs_out)
+        probs = ttnn.to_torch(probs_out).float()[:, :N_experts]
+        weights, indices = torch.topk(probs, k=top_k, dim=-1)
+        return indices, weights
+
+    def cache_size(self) -> int:
+        return len(self._cache)
+
+
+# ------------------------------------------------------------------
+# Pre-compiled kernel cache warming
+# ------------------------------------------------------------------
+
+def _sha256(path: pathlib.Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _device_build_key(device) -> Optional[str]:
+    """Return the tt-metal build key dir name for the current device.
+
+    The build key is the numeric directory under ~/.cache/tt-metal-cache/ that
+    tt-metal creates for this hardware/toolchain combination.  We identify it as
+    the directory that contains a 'kernels/' subdirectory (vs. 'firmware/').
+    Returns None if nothing is found (cache empty or not yet populated).
+    """
+    if not _TT_METAL_CACHE.is_dir():
+        return None
+    candidates = [
+        d for d in _TT_METAL_CACHE.iterdir()
+        if d.is_dir() and (d / "kernels").is_dir()
+    ]
+    if not candidates:
+        return None
+    # Pick the most recently modified — matches the current running device.
+    return max(candidates, key=lambda p: p.stat().st_mtime).name
+
+
+def _warm_kernel_cache(device) -> None:
+    """Extract pre-compiled kernel ELFs into the tt-metal disk cache.
+
+    Reads manifest.json from the kernels/ package directory.  For each variant
+    whose bundle (.tar.gz) is present and whose sha256 matches, extracts the
+    bundle into ~/.cache/tt-metal-cache/<build_key>/.  This makes the tt-metal
+    JIT cache warm so the first kernel call skips the 30–120 s Clang compilation.
+
+    Falls back silently (with a one-time warning) when:
+      - manifest.json is absent (no pre-compiled binaries shipped)
+      - a bundle file is missing
+      - sha256 mismatch (corrupted download)
+    """
+    if not _MANIFEST_PATH.is_file():
+        return
+
+    try:
+        with open(_MANIFEST_PATH) as f:
+            manifest = json.load(f)
+    except Exception as exc:
+        warnings.warn(f"Could not read kernel manifest ({exc}); using JIT compilation.", UserWarning)
+        return
+
+    build_key = _device_build_key(device)
+    if build_key is None:
+        # Cache dir not yet populated — tt-metal hasn't compiled anything yet.
+        # We can't extract to the right location, so let JIT run on first call.
+        return
+
+    cache_dest = _TT_METAL_CACHE / build_key
+    warmed = 0
+    missing = 0
+
+    for variant_key, entry in manifest.get("variants", {}).items():
+        bundle_path = _KERNELS_DIR / entry["path"]
+        if not bundle_path.is_file():
+            missing += 1
+            continue
+
+        expected_sha = entry.get("sha256", "")
+        if expected_sha and _sha256(bundle_path) != expected_sha:
+            warnings.warn(
+                f"Kernel bundle sha256 mismatch for '{variant_key}' — skipping pre-compiled binary.",
+                UserWarning,
+            )
+            missing += 1
+            continue
+
+        # Extract only entries whose paths don't already exist (avoid re-extracting on every init).
+        with tarfile.open(bundle_path, "r:gz") as tar:
+            for member in tar.getmembers():
+                dest = cache_dest / member.name
+                if not dest.exists():
+                    tar.extract(member, path=cache_dest, set_attrs=False)
+        warmed += 1
+
+    if missing > 0 and warmed == 0:
+        warnings.warn(
+            f"{missing} kernel variant(s) have no pre-compiled binary in {_KERNELS_DIR}. "
+            "First inference will trigger JIT compilation (30–120 s per variant). "
+            "Run `make release-kernels` in tt-lang to build the binaries.",
+            UserWarning,
+        )
+
+
+# ------------------------------------------------------------------
+# JIT kernel-patch overlay (#50)
+# ------------------------------------------------------------------
+
+_KERNEL_PATCH_ENV = "DISPATCH_KERNEL_PATCH_DIR"
+
+
+def _install_kernel_patch_overlay() -> None:
+    """A/B kernel-variant dev loop without a tt-metal/tt-lang rebuild (issue #50).
+
+    When DISPATCH_KERNEL_PATCH_DIR is set, overlay patched kernel .cpp files over the
+    tt-lang-generated source at the JIT boundary. Unset => no monkeypatch, exact current
+    behavior (this is a pure no-op then).
+
+    How it works: tt-lang generates each kernel's C++ via ttkernel_to_cpp_by_name() and
+    writes it through ttl.ttl_api._write_kernel_to_tmp(name, source) to
+    /tmp/$USER/ttlang_kernel_<name>_<md5(source)[:8]>.cpp before tt-metal JIT-compiles it.
+    Crucially, `name` is GENERIC ("compute"/"dm_read"/"dm_write") — every compute kernel
+    shares name="compute", so a kernel variant is identified by the CONTENT HASH, not the
+    name. We therefore wrap the writer and match a patch file named exactly like the
+    baseline file tt-lang would write — `ttlang_kernel_<name>_<hash>.cpp`, where <hash> is
+    md5 of the freshly GENERATED (baseline) source. If that patch file exists, its contents
+    REPLACE the generated source; the substituted source is then re-hashed and compiled as
+    usual. So:
+      - a no-op patch (a verbatim copy of the /tmp file) reproduces baseline bit-for-bit;
+      - an edited patch keeps the SAME filename (baseline hash, so it still matches) but
+        new contents -> a fresh compile of the variant, targeting only that one kernel.
+    The .riscv pre-compiled artifact system (#1/#26) stays the release path; this is the
+    iterate-fast dev path that feeds kernel-variant A/B arms (tests/experiments/matrix.toml).
+
+    To create a patch: run a model once, copy the /tmp/$USER/ttlang_kernel_<name>_<hash>.cpp
+    for the kernel you want into <patch_dir>/ (same basename), then edit it.
+    """
+    import hashlib
+    patch_dir = os.environ.get(_KERNEL_PATCH_ENV)
+    if not patch_dir:
+        return
+    patch_path = pathlib.Path(patch_dir).expanduser().resolve()
+    if not patch_path.is_dir():
+        warnings.warn(
+            f"{_KERNEL_PATCH_ENV}={patch_dir} is not a directory; no kernel patches applied.",
+            UserWarning)
+        return
+    try:
+        from ttl import ttl_api
+    except Exception as exc:  # ttl not importable (e.g. no-device CI) — nothing to patch
+        warnings.warn(
+            f"Could not import ttl.ttl_api for kernel patching ({exc}); no patches applied.",
+            UserWarning)
+        return
+    if getattr(ttl_api, "_dispatch_patch_installed", False):
+        return  # idempotent — only wrap once per process
+
+    _orig_write = ttl_api._write_kernel_to_tmp
+
+    def _patched_write(name, source):
+        # Identify the baseline kernel by the same hash tt-lang uses for its filename.
+        h = hashlib.md5(source.encode()).hexdigest()[:8]
+        cand = patch_path / f"ttlang_kernel_{name}_{h}.cpp"
+        if cand.is_file():
+            print(f"  [kernel-patch] overlaying {cand.name} ({cand.stat().st_size} B)")
+            return _orig_write(name, cand.read_text())
+        return _orig_write(name, source)
+
+    ttl_api._write_kernel_to_tmp = _patched_write
+    ttl_api._dispatch_patch_installed = True
+    available = sorted(p.name for p in patch_path.glob("ttlang_kernel_*.cpp"))
+    print(f"  Kernel-patch overlay ACTIVE ({_KERNEL_PATCH_ENV}={patch_path}); "
+          f"patches: {available or '(none found)'}")
+
+
+# ------------------------------------------------------------------
+# Matrix loading helpers
+# ------------------------------------------------------------------
+
+def _opt_float(v):
+    """Coerce an optional numeric matrix field to float, preserving None (= unset)."""
+    return None if v is None else float(v)
+
+
+def _load_and_validate_matrix(
+    path: pathlib.Path,
+) -> Tuple[List[ModelMatrixEntry], Dict[str, ModelMatrixEntry]]:
+    """Load model_matrix.toml, validate schema, return (list, name→entry index)."""
+    with open(path, "rb") as f:
+        raw = tomllib.load(f)
+
+    version = raw.get("schema_version")
+    if version != DISPATCHER_SCHEMA_VERSION:
+        raise SchemaVersionError(
+            f"model_matrix.toml schema_version={version} but dispatcher expects "
+            f"{DISPATCHER_SCHEMA_VERSION}. Redeploy model_matrix.toml or update "
+            "DISPATCHER_SCHEMA_VERSION in dispatcher.py."
+        )
+
+    entries: List[ModelMatrixEntry] = []
+    index: Dict[str, ModelMatrixEntry] = {}
+
+    for raw_entry in raw.get("model", []):
+        entry = ModelMatrixEntry(
+            name=raw_entry["name"],
+            arch=raw_entry["arch"],
+            local_path=raw_entry["local_path"],
+            hidden_size=raw_entry["hidden_size"],
+            intermediate_size=raw_entry["intermediate_size"],
+            n_layers=raw_entry["n_layers"],
+            vocab_size=raw_entry["vocab_size"],
+            n_heads=raw_entry["n_heads"],
+            n_kv_heads=raw_entry["n_kv_heads"],
+            head_dim=raw_entry["head_dim"],
+            max_seq=raw_entry["max_seq"],
+            rope_theta=float(raw_entry["rope_theta"]),
+            swa_window=raw_entry["swa_window"],
+            tie_embeddings=raw_entry["tie_embeddings"],
+            kernels=list(raw_entry["kernels"]),
+            min_hw=raw_entry["min_hw"],
+            status=raw_entry["status"],
+            norm_type=raw_entry.get("norm_type", "rmsnorm"),
+            activation=raw_entry.get("activation", "silu"),
+            rotary_pct=float(raw_entry.get("rotary_pct", 1.0)),
+            attn_bias=raw_entry.get("attn_bias", False),
+            head_norm=raw_entry.get("head_norm", False),
+            parallel_residual=raw_entry.get("parallel_residual", False),
+            embed_scale=raw_entry.get("embed_scale", "none"),
+            attn_backend=raw_entry.get("attn_backend", "ttnn"),
+            embedding_multiplier=_opt_float(raw_entry.get("embedding_multiplier")),
+            residual_multiplier=_opt_float(raw_entry.get("residual_multiplier")),
+            attention_multiplier=_opt_float(raw_entry.get("attention_multiplier")),
+            logits_scaling=_opt_float(raw_entry.get("logits_scaling")),
+            issue=raw_entry.get("issue"),
+            notes=raw_entry.get("notes", ""),
+        )
+
+        if entry.n_heads % entry.n_kv_heads != 0:
+            raise ValueError(
+                f"Model '{entry.name}': n_heads={entry.n_heads} not divisible by "
+                f"n_kv_heads={entry.n_kv_heads}. Fix model_matrix.toml."
+            )
+
+        if entry.n_heads < 1 or entry.n_kv_heads < 1:
+            raise ValueError(
+                f"Model '{entry.name}': n_heads and n_kv_heads must be >= 1."
+            )
+
+        entries.append(entry)
+        index[entry.name] = entry
+
+    return entries, index

--- a/tt_inference_server/dispatch/dispatcher.py
+++ b/tt_inference_server/dispatch/dispatcher.py
@@ -54,6 +54,7 @@ class Capabilities:
       fast_path        <- _ondevice_attn_eligible + _setup_paged_decode ok_shape
       lm_head_ondevice <- _setup_ondevice_lmhead eligibility
     """
+
     fast_path: bool
     lm_head_ondevice: bool
     attn_backend: str
@@ -67,6 +68,7 @@ class ResolvedConfig:
     replacing the per-arch dim modules / hardcoded CONFIGS dicts in registry.py for
     listed models. Novel models keep detect_model_family()'s HF-config introspection.
     """
+
     hidden_size: int
     num_heads: int
     num_kv_heads: int
@@ -103,7 +105,8 @@ def _compute_capabilities(
     """
     group = (n_heads // n_kv_heads) if n_kv_heads else 0
     fast_path = (
-        norm_type in ("rmsnorm", "layernorm")   # CP-3: LayerNorm runs on-device (ttnn.layer_norm)
+        norm_type
+        in ("rmsnorm", "layernorm")  # CP-3: LayerNorm runs on-device (ttnn.layer_norm)
         and rotary_pct == 1.0
         # CP-1: qkv/o bias now applied on-device (ttnn.add) in the attention paths,
         # so attn_bias no longer forces the slow CPU-readback route.
@@ -155,12 +158,20 @@ def derive_capabilities(hf_config) -> Capabilities:
     else:
         norm_type = "rmsnorm"
 
-    rotary_pct = float(getattr(text_cfg, "partial_rotary_factor",
-                               getattr(text_cfg, "rotary_pct", 1.0)) or 1.0)
+    rotary_pct = float(
+        getattr(text_cfg, "partial_rotary_factor", getattr(text_cfg, "rotary_pct", 1.0))
+        or 1.0
+    )
     # LayerNorm-family archs (GPTNeoX/Pythia) carry qkv bias; otherwise read the flag.
-    attn_bias = bool(getattr(text_cfg, "attention_bias", False)) or (norm_type == "layernorm")
+    attn_bias = bool(getattr(text_cfg, "attention_bias", False)) or (
+        norm_type == "layernorm"
+    )
     head_norm = arch.startswith("Qwen3") or "gemma3" in model_type
-    attn_backend = "ttnn" if (n_kv and n_heads % n_kv == 0 and 32 % (n_heads // n_kv) == 0) else "custom"
+    attn_backend = (
+        "ttnn"
+        if (n_kv and n_heads % n_kv == 0 and 32 % (n_heads // n_kv) == 0)
+        else "custom"
+    )
 
     return _compute_capabilities(
         norm_type=norm_type,
@@ -195,21 +206,27 @@ class ModelMatrixEntry:
     status: str
     # --- behavioral fields (schema v2, issue #3). Defaults reproduce today's
     #     HF-derived behavior so an entry that omits them is a no-op. ---
-    norm_type: str = "rmsnorm"          # rmsnorm | layernorm | gemma_rms
-    activation: str = "silu"            # silu | gelu | gelu_tanh | relu2
-    rotary_pct: float = 1.0             # 1.0 full; 0.25 partial (GPTNeoX/StableLM)
-    attn_bias: bool = False             # qkv + o-proj bias present
-    head_norm: bool = False             # per-head q/k RMSNorm (Qwen3/Gemma3)
-    parallel_residual: bool = False     # attn + MLP branch the same pre-norm (GPTNeoX)
-    embed_scale: str = "none"           # none | sqrt_hidden (Gemma scales embeds)
-    attn_backend: str = "ttnn"          # ttnn | custom | cpu (#34 backend-per-op)
+    norm_type: str = "rmsnorm"  # rmsnorm | layernorm | gemma_rms
+    activation: str = "silu"  # silu | gelu | gelu_tanh | relu2
+    rotary_pct: float = 1.0  # 1.0 full; 0.25 partial (GPTNeoX/StableLM)
+    attn_bias: bool = False  # qkv + o-proj bias present
+    head_norm: bool = False  # per-head q/k RMSNorm (Qwen3/Gemma3)
+    parallel_residual: bool = False  # attn + MLP branch the same pre-norm (GPTNeoX)
+    embed_scale: str = "none"  # none | sqrt_hidden (Gemma scales embeds)
+    attn_backend: str = "ttnn"  # ttnn | custom | cpu (#34 backend-per-op)
     # Granite (#43) architectural scaling factors. None = fall through to the HF config
     # value (so an omitted field is a no-op); a set value OVERRIDES it, same as the other
     # behavioral fields. Read by the runner's _scaling_factor().
-    embedding_multiplier: Optional[float] = None   # scales input embeddings
-    residual_multiplier: Optional[float] = None    # scales each sublayer output pre-residual-add
-    attention_multiplier: Optional[float] = None   # overrides the 1/sqrt(head_dim) softmax scale
-    logits_scaling: Optional[float] = None          # divides final logits (no-op for greedy argmax)
+    embedding_multiplier: Optional[float] = None  # scales input embeddings
+    residual_multiplier: Optional[float] = (
+        None  # scales each sublayer output pre-residual-add
+    )
+    attention_multiplier: Optional[float] = (
+        None  # overrides the 1/sqrt(head_dim) softmax scale
+    )
+    logits_scaling: Optional[float] = (
+        None  # divides final logits (no-op for greedy argmax)
+    )
     issue: Optional[int] = None
     notes: str = ""
 
@@ -289,6 +306,7 @@ class KernelDispatcher:
         # so this is behavior-preserving there.
         if hw_config is None:
             from tt_inference_server.dispatch.hardware import detect_hardware
+
             hw_config = detect_hardware(device)
         self._hw_config = hw_config
         self._cache: Dict[Tuple, Any] = {}
@@ -330,6 +348,7 @@ class KernelDispatcher:
         self._lock_fh = None
         try:
             import fcntl as _fcntl
+
             _fcntl.flock(fh, _fcntl.LOCK_UN)
             fh.close()
         except Exception:
@@ -407,8 +426,11 @@ class KernelDispatcher:
     # Kernel dispatch (shape-keyed cache)
     # ------------------------------------------------------------------
 
-    def swiglu(self, gate, w_gate, bias_gate, up, w_up, bias_up, out, activation="silu"):
+    def swiglu(
+        self, gate, w_gate, bias_gate, up, w_up, bias_up, out, activation="silu"
+    ):
         from tt_inference_server.dispatch.kernels.swiglu import make_swiglu_kernel
+
         M, K, N = gate.shape[0], gate.shape[1], w_gate.shape[1]
         key = ("swiglu", M, K, N, activation)
         if key not in self._cache:
@@ -416,21 +438,44 @@ class KernelDispatcher:
             self._cache[key] = make_swiglu_kernel(**cfg)
         return self._cache[key](gate, w_gate, bias_gate, up, w_up, bias_up, out)
 
-    def flash_attn(self, Q, K, V, scale, neg_inf, zero, zero_head, ones, mask, out,
-                   N_heads: int = None, N_kv_heads: int = None):
+    def flash_attn(
+        self,
+        Q,
+        K,
+        V,
+        scale,
+        neg_inf,
+        zero,
+        zero_head,
+        ones,
+        mask,
+        out,
+        N_heads: int = None,
+        N_kv_heads: int = None,
+    ):
         head_dim = Q.shape[-1]
         n_heads = N_heads or Q.shape[0]
         n_kv = N_kv_heads or K.shape[0]
         kv_seq = K.shape[0] // n_kv if n_kv else K.shape[0]
         key = ("flash_attn", n_heads, n_kv, head_dim)
         if key not in self._cache:
-            from tt_inference_server.dispatch.kernels.flash_attn import make_flash_attn_kernel
-            cfg = resolve_attn_config(n_heads, n_kv, head_dim, kv_seq, hw_config=self._hw_config)
-            self._cache[key] = make_flash_attn_kernel(**cfg)
-        return self._cache[key](Q, K, V, scale, neg_inf, zero, zero_head, ones, mask, out)
+            from tt_inference_server.dispatch.kernels.flash_attn import (
+                make_flash_attn_kernel,
+            )
 
-    def kv_decode(self, Q, K_cache, V_cache, scale, neg_inf, zero, zero_head, out, ones=None):
+            cfg = resolve_attn_config(
+                n_heads, n_kv, head_dim, kv_seq, hw_config=self._hw_config
+            )
+            self._cache[key] = make_flash_attn_kernel(**cfg)
+        return self._cache[key](
+            Q, K, V, scale, neg_inf, zero, zero_head, ones, mask, out
+        )
+
+    def kv_decode(
+        self, Q, K_cache, V_cache, scale, neg_inf, zero, zero_head, out, ones=None
+    ):
         from tt_inference_server.dispatch.kernels.kv_decode import make_kv_decode_kernel
+
         N_kv_heads, head_dim = Q.shape[0], Q.shape[1]
         max_seq = K_cache.shape[0] // N_kv_heads
         key = ("kv_decode", N_kv_heads, head_dim, max_seq)
@@ -440,10 +485,13 @@ class KernelDispatcher:
                 head_dim_tiles=to_tiles(head_dim),
                 max_seq_tiles=to_tiles(max_seq),
             )
-        return self._cache[key](Q, K_cache, V_cache, scale, neg_inf, zero, zero_head, out)
+        return self._cache[key](
+            Q, K_cache, V_cache, scale, neg_inf, zero, zero_head, out
+        )
 
     def rmsnorm(self, x, weight, scaler, out):
         from tt_inference_server.dispatch.kernels.rmsnorm import make_rmsnorm_kernel
+
         seq, hidden = x.shape[0], x.shape[1]
         key = ("rmsnorm", seq, hidden)
         if key not in self._cache:
@@ -453,6 +501,7 @@ class KernelDispatcher:
 
     def layernorm(self, x, weight, bias, scaler, out):
         from tt_inference_server.dispatch.kernels.layernorm import make_layernorm_kernel
+
         seq, hidden = x.shape[0], x.shape[1]
         key = ("layernorm", seq, hidden)
         if key not in self._cache:
@@ -460,15 +509,21 @@ class KernelDispatcher:
             self._cache[key] = make_layernorm_kernel(**cfg)
         return self._cache[key](x, weight, bias, scaler, out)
 
-    def moe_route(self, hidden, w_router, probs_out, N_experts: int, top_k: int, ones=None):
+    def moe_route(
+        self, hidden, w_router, probs_out, N_experts: int, top_k: int, ones=None
+    ):
         """Run router projection + softmax on device, then top-k on host."""
         import torch
         import ttnn
+
         hidden_dim = hidden.shape[1]
         expert_tiles = max(1, (N_experts + 31) // 32)
         key = ("moe_router", hidden_dim, N_experts)
         if key not in self._cache:
-            from tt_inference_server.dispatch.kernels.moe_router import make_moe_router_kernel
+            from tt_inference_server.dispatch.kernels.moe_router import (
+                make_moe_router_kernel,
+            )
+
             self._cache[key] = make_moe_router_kernel(
                 hidden_tiles=to_tiles(hidden_dim),
                 expert_tiles=expert_tiles,
@@ -485,6 +540,7 @@ class KernelDispatcher:
 # ------------------------------------------------------------------
 # Pre-compiled kernel cache warming
 # ------------------------------------------------------------------
+
 
 def _sha256(path: pathlib.Path) -> str:
     h = hashlib.sha256()
@@ -505,8 +561,7 @@ def _device_build_key(device) -> Optional[str]:
     if not _TT_METAL_CACHE.is_dir():
         return None
     candidates = [
-        d for d in _TT_METAL_CACHE.iterdir()
-        if d.is_dir() and (d / "kernels").is_dir()
+        d for d in _TT_METAL_CACHE.iterdir() if d.is_dir() and (d / "kernels").is_dir()
     ]
     if not candidates:
         return None
@@ -534,7 +589,10 @@ def _warm_kernel_cache(device) -> None:
         with open(_MANIFEST_PATH) as f:
             manifest = json.load(f)
     except Exception as exc:
-        warnings.warn(f"Could not read kernel manifest ({exc}); using JIT compilation.", UserWarning)
+        warnings.warn(
+            f"Could not read kernel manifest ({exc}); using JIT compilation.",
+            UserWarning,
+        )
         return
 
     build_key = _device_build_key(device)
@@ -613,6 +671,7 @@ def _install_kernel_patch_overlay() -> None:
     for the kernel you want into <patch_dir>/ (same basename), then edit it.
     """
     import hashlib
+
     patch_dir = os.environ.get(_KERNEL_PATCH_ENV)
     if not patch_dir:
         return
@@ -620,14 +679,18 @@ def _install_kernel_patch_overlay() -> None:
     if not patch_path.is_dir():
         warnings.warn(
             f"{_KERNEL_PATCH_ENV}={patch_dir} is not a directory; no kernel patches applied.",
-            UserWarning)
+            UserWarning,
+        )
         return
     try:
         from ttl import ttl_api
-    except Exception as exc:  # ttl not importable (e.g. no-device CI) — nothing to patch
+    except (
+        Exception
+    ) as exc:  # ttl not importable (e.g. no-device CI) — nothing to patch
         warnings.warn(
             f"Could not import ttl.ttl_api for kernel patching ({exc}); no patches applied.",
-            UserWarning)
+            UserWarning,
+        )
         return
     if getattr(ttl_api, "_dispatch_patch_installed", False):
         return  # idempotent — only wrap once per process
@@ -646,13 +709,16 @@ def _install_kernel_patch_overlay() -> None:
     ttl_api._write_kernel_to_tmp = _patched_write
     ttl_api._dispatch_patch_installed = True
     available = sorted(p.name for p in patch_path.glob("ttlang_kernel_*.cpp"))
-    print(f"  Kernel-patch overlay ACTIVE ({_KERNEL_PATCH_ENV}={patch_path}); "
-          f"patches: {available or '(none found)'}")
+    print(
+        f"  Kernel-patch overlay ACTIVE ({_KERNEL_PATCH_ENV}={patch_path}); "
+        f"patches: {available or '(none found)'}"
+    )
 
 
 # ------------------------------------------------------------------
 # Matrix loading helpers
 # ------------------------------------------------------------------
+
 
 def _opt_float(v):
     """Coerce an optional numeric matrix field to float, preserving None (= unset)."""

--- a/tt_inference_server/dispatch/docs/custom_runners.md
+++ b/tt_inference_server/dispatch/docs/custom_runners.md
@@ -1,0 +1,185 @@
+# Custom runners for the dispatch serving runtime
+
+The dispatch runtime serves standard decoder-only transformers with a generic
+runner (`TTModelRunner`) that introspects a HuggingFace module for "the
+attention," "the MLP," embeddings, and per-layer norms. Models whose tt-nn graph
+is **not** a standard transformer — MoE, Gated-DeltaNet/Mamba-state, multimodal —
+cannot be expressed that way.
+
+A **custom runner** lets you serve such a model through the same
+`load_model()` / `serve` entry points. Your runner lives in **your own package**
+— no model code goes into this repo, and no dispatch code goes into yours. The
+only shared surface is the contract below.
+
+> Custom runners run arbitrary code you point dispatch at. The runtime carries no
+> correctness or SLA guarantee for them — that is what `--unsafe` acknowledges.
+
+## 1. The contract — `BaseRunner`
+
+A runner must provide three methods and three attributes. That is the entire
+surface `ModelHandle` uses. You do **not** need to subclass anything; the contract
+is structural (duck-typed), checked by `validate_runner()` right after construction.
+
+```python
+class MyRunner:
+    # --- required attributes (set in __init__) ---
+    _tokenizer: object   # a transformers-like tokenizer (ModelHandle.tokenizer reads this)
+    _listed: bool        # True if this is a known/validated model; else False
+    _community: bool     # True if unverified/community (drives the serve "community" tag)
+
+    # --- required methods ---
+    def generate(self, prompt: str, max_new_tokens: int = 50,
+                 temperature: float = 1.0, chat: bool = True) -> str: ...
+
+    def generate_stream(self, prompt: str, max_new_tokens: int = 50,
+                        temperature: float = 1.0, chat: bool = True):
+        # yield decoded text deltas (str), one per decode step;
+        # the FINAL yielded item MUST be a dict:
+        #   {"finish_reason": str, "prompt_tokens": int, "completion_tokens": int}
+        ...
+
+    def benchmark(self, prompt: str, n_tokens: int = 50) -> tuple[float, str]:
+        # returns (tokens_per_second, output_text)
+        ...
+```
+
+`generate_stream` is the one the OpenAI server actually drives (both streaming and
+non-streaming responses), so make sure the final-dict usage record is correct.
+
+### Constructor
+
+`load_model()` constructs your runner as:
+
+```python
+Runner(model_path, device, max_seq=..., unsafe=..., force_novel=...,
+       trace_region_size=..., device_ids=...)
+```
+
+It passes only the keyword arguments your `__init__` actually declares (accept
+`**kwargs` to future-proof, or declare just the ones you use). `device` is an open
+ttnn device unless you manage your own (see §4).
+
+## 2. Selecting a runner
+
+In precedence order (most-explicit wins):
+
+| # | Mechanism | Trust |
+|---|---|---|
+| 1 | Explicit: `serve --runner module:Class` or env `DISPATCH_RUNNER=module:Class` | user-supplied |
+| 2 | Entry-point match (installed package, see §3) | installed package |
+| 3 | HF-repo self-declaration (`tt_runner` / `tt_dispatch.json`) | **`--unsafe` only** |
+| 4 | Generic `TTModelRunner` fallback | default |
+
+```bash
+# Explicit (works for a source checkout — no install needed):
+python -m tt_inference_server.dispatch.serve serve --unsafe \
+    --runner my_pkg.dispatch_runner:Qwen36Runner /path/to/checkpoint
+
+# Auto-discovery (your package is installed and claims the model):
+python -m tt_inference_server.dispatch.serve serve --unsafe /path/to/checkpoint
+```
+
+If two installed runners claim the same model at the same specificity, dispatch
+errors and asks for an explicit `--runner`.
+
+## 3. Entry-point auto-discovery
+
+Declare the `tt_inference_server.runners` entry-point group in **your** package's
+`pyproject.toml`, then `pip install` it into the serving environment:
+
+```toml
+[project.entry-points."tt_inference_server.runners"]
+qwen3_5_moe = "my_pkg.dispatch_runner:Qwen36Runner"
+```
+
+Dispatch scans this group and matches against the model's HF config, by priority:
+
+1. `@classmethod claims(cls, hf_config) -> bool` — most flexible; overrides the sets.
+2. `supported_architectures: set[str]` — matched against `config.architectures[0]`.
+3. `supported_model_types: set[str]` — matched against `config.model_type`.
+
+```python
+class Qwen36Runner:
+    supported_model_types = {"qwen3_5_moe"}
+    # or, for finer control:
+    # @classmethod
+    # def claims(cls, hf_config): return hf_config.model_type == "qwen3_5_moe"
+```
+
+> Entry points only resolve for **installed** packages (`pip install` /
+> `pip install -e .`). For a plain source checkout that isn't installed, use the
+> `--runner module:Class` path instead.
+
+## 4. Device / mesh ownership
+
+By default `load_model()` opens a single ttnn device and passes it to the runner,
+and closes it at exit. If your runner needs a different device topology — e.g. a
+1×1 **mesh** via `open_mesh_device` — set:
+
+```python
+class Qwen36Runner:
+    MANAGES_OWN_DEVICE = True
+    def __init__(self, model_path, device, **kwargs):
+        # device is None here. Open, own, and register cleanup for your own device:
+        import ttnn
+        self.mesh = ttnn.open_mesh_device(...)
+        import atexit; atexit.register(ttnn.close_mesh_device, self.mesh)
+```
+
+When `MANAGES_OWN_DEVICE = True`, dispatch does **not** open a device and passes
+`device=None`. You are responsible for opening, owning, and closing it (and for
+reserving any trace region you need — `trace_region_size` is passed to your
+constructor if you accept it). This avoids the double-open/double-close that would
+otherwise conflict with a mesh runner.
+
+**Clean teardown is an obligation, not an option.** A `MANAGES_OWN_DEVICE` runner
+**must** close its device on shutdown (register `ttnn.close_mesh_device` / `close_device`
+via `atexit`, or close it in your own lifecycle). This is what makes Ollama-style model
+hot-swap reliable: serving runs one model per process, and when that process exits the
+next model must find a pristine card. An ungraceful teardown can leave a locked device
+mutex (`/dev/shm/tt_device_*`) that wedges the card until a manual `tt-smi -r` — so the
+clean-close path must be the common one.
+
+## 5. HF-repo self-declaration (trust-gated)
+
+A model repo can point at its runner so plain `serve --unsafe <repo>` finds it
+without an installed entry point. Either:
+
+- a `tt_runner` field in the model's `config.json`:
+  ```json
+  { "model_type": "qwen3_5_moe", "tt_runner": "my_pkg.dispatch_runner:Qwen36Runner" }
+  ```
+- or a `tt_dispatch.json` sidecar in the model directory:
+  ```json
+  { "runner": "my_pkg.dispatch_runner:Qwen36Runner", "max_seq": 4096 }
+  ```
+
+This is honored **only under `--unsafe`** because it imports and executes
+repo-referenced code — treat it exactly like `trust_remote_code`. Optionally
+constrain it with an allowlist:
+
+```bash
+export DISPATCH_RUNNER_ALLOW="my_pkg"          # module-prefix, or full module:Class
+```
+
+The referenced module must still be importable in the serving environment.
+
+## 6. Environment coupling
+
+A custom runner pins to whatever tt-metal / ttnn build its model code was written
+against; the serving environment must satisfy the runner package's imports
+(declare them as the package's dependencies). Firmware is environment-wide, not
+per-runner — match it to what the model needs before serving.
+
+## 7. Warm starts (optional)
+
+Cold JIT-compiling kernels on first serve can be slow for large models. The
+orthogonal `tt-kernel-manager` tool can pull a precompiled tt-metal kernel cache
+matching the serving environment before `serve`, so the first request is a cache
+hit:
+
+```bash
+tt-kernel pull <bundle-matching-your-env>   # then serve as usual
+```
+
+This is independent of the runner seam — it only removes compile latency.

--- a/tt_inference_server/dispatch/hardware.py
+++ b/tt_inference_server/dispatch/hardware.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hardware capability data + dispatch policy (Layer 2/3).
+
+This is the dispatch-side home for what used to live as a fork in
+``tt-metal/ttnn/ttnn/hardware.py``. The split, per the migration plan:
+
+  - **Capability data** (grid, L1, DRAM per board) lives here — pure facts about the
+    silicon, keyed by the arch/board the detector reports.
+  - **Policy** (the 0.915 L1 / 0.90 DRAM admission margins, ``grid_shape``) lives here
+    too — it is dispatcher policy, not a ttnn concern, so it does not belong upstream.
+  - **Detection** comes from the tt-kernel package manager (``tt_kernel.device.detect``,
+    which reads tt-smi ``board_type`` and so distinguishes board variants a grid-only
+    match cannot), with a ttnn fallback when tt-smi is unavailable.
+
+On the current single-card p150 deployment, ``bh_p150_1card.l1_budget()`` ==
+``int(1_572_864 * 0.915)`` == 1_439_170 — exactly the legacy hardcoded default in
+``compat.py`` — so wiring detection in is behavior-preserving there.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HardwareConfig:
+    name: str  # e.g. "bh_p150_1card"
+    grid_x: int  # usable Tensix columns
+    grid_y: int  # usable Tensix rows
+    l1_bytes: int  # full L1 SRAM per core in bytes (1_572_864 for p150)
+    dram_bytes: int  # total on-card DRAM in bytes (nominal board capacity)
+    tile_size: int = 32  # element tile dimension (32 for all current TT hardware)
+
+    def l1_budget(self) -> int:
+        """Usable L1 per core after a margin for runtime/firmware reservation."""
+        return int(self.l1_bytes * 0.915)
+
+    def dram_budget(self) -> int:
+        """Usable DRAM for weights + KV cache + activations after a reservation margin.
+        Admission checks must use THIS, not dram_bytes — overstating risks OOM."""
+        return int(self.dram_bytes * 0.90)
+
+    def grid_shape(self, n_heads: int) -> "tuple[int, int]":
+        """Map ``n_heads`` onto the Tensix grid. Returns plain Python ints (required for
+        ttl kernel closure capture)."""
+        for cols in range(min(n_heads, self.grid_x), 0, -1):
+            if n_heads % cols == 0:
+                rows = n_heads // cols
+                if rows <= self.grid_y:
+                    return int(cols), int(rows)
+        raise ValueError(
+            f"Cannot map {n_heads} heads onto {self.name} "
+            f"({self.grid_x}x{self.grid_y} grid)."
+        )
+
+
+# Capability matrix, keyed by config name. Board DRAM is a per-board constant (the
+# MeshDevice API exposes no total-DRAM call), kept correct by hand against the board.
+KNOWN_CONFIGS = {
+    # Blackhole p150a: 32 GB GDDR6 (8 channels), 13x10 usable Tensix grid.
+    "bh_p150_1card": HardwareConfig("bh_p150_1card", 13, 10, 1_572_864, 32 * 1024**3),
+    "bh_p150_2card": HardwareConfig("bh_p150_2card", 13, 10, 1_572_864, 64 * 1024**3),
+    "gs_e150_1card": HardwareConfig("gs_e150_1card", 9, 12, 1_048_576, 8 * 1024**3),
+}
+
+# The config assumed when detection fails entirely — the current deployment target.
+DEFAULT_CONFIG = KNOWN_CONFIGS["bh_p150_1card"]
+
+
+def _config_for(arch: "str | None", device_count: int) -> "HardwareConfig | None":
+    """Map a detected (arch, device_count) onto a known capability config."""
+    if arch == "blackhole":
+        return KNOWN_CONFIGS["bh_p150_2card" if device_count >= 2 else "bh_p150_1card"]
+    if arch == "grayskull":
+        return KNOWN_CONFIGS["gs_e150_1card"]
+    return None
+
+
+def _detect_via_tt_kernel() -> "HardwareConfig | None":
+    """Detect via the tt-kernel package manager (tt-smi board_type). None if tt-kernel
+    is absent or no device is found."""
+    try:
+        from tt_kernel import device as ttk_device
+    except Exception:  # noqa: BLE001 — tt_kernel is an optional integration
+        return None
+    try:
+        info = ttk_device.detect()
+    except Exception:  # noqa: BLE001 — detection must never raise into the runtime
+        return None
+    return _config_for(info.arch, info.device_count or 1)
+
+
+def _detect_via_ttnn(device=None) -> "HardwareConfig | None":
+    """Fallback detection through ttnn when tt-smi is unavailable. Uses the open device's
+    arch (and grid, to disambiguate Grayskull from Blackhole). Cannot tell 1- vs 2-card
+    apart, so it assumes a single card."""
+    try:
+        import ttnn
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        arch_name = (ttnn._ttnn.device.get_arch_name() or "").lower()
+    except Exception:  # noqa: BLE001
+        arch_name = ""
+    if "blackhole" in arch_name:
+        return KNOWN_CONFIGS["bh_p150_1card"]
+    if "grayskull" in arch_name:
+        return KNOWN_CONFIGS["gs_e150_1card"]
+    # Last resort: identify by compute grid if arch string was unhelpful.
+    if device is not None:
+        try:
+            g = device.compute_with_storage_grid_size()
+            for cfg in KNOWN_CONFIGS.values():
+                if cfg.grid_x == g.x and cfg.grid_y == g.y:
+                    return cfg
+        except Exception:  # noqa: BLE001
+            pass
+    return None
+
+
+def detect_hardware(device=None) -> HardwareConfig:
+    """Resolve the active HardwareConfig: tt-kernel (tt-smi) first, then a ttnn fallback,
+    then the deployment default. Never raises — a wrong-but-sane budget is preferable to
+    crashing the runtime, and on the p150 the default is correct anyway."""
+    cfg = _detect_via_tt_kernel() or _detect_via_ttnn(device)
+    if cfg is not None:
+        return cfg
+    sys.stderr.write(
+        f"[dispatch] hardware detection failed; assuming {DEFAULT_CONFIG.name} "
+        f"(L1 budget {DEFAULT_CONFIG.l1_budget()} B). Set up tt-smi or pass an explicit "
+        "config if this host is not a Blackhole p150.\n"
+    )
+    return DEFAULT_CONFIG
+
+
+__all__ = ["HardwareConfig", "KNOWN_CONFIGS", "DEFAULT_CONFIG", "detect_hardware"]

--- a/tt_inference_server/dispatch/kernels/__init__.py
+++ b/tt_inference_server/dispatch/kernels/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0

--- a/tt_inference_server/dispatch/kernels/flash_attn.py
+++ b/tt_inference_server/dispatch/kernels/flash_attn.py
@@ -1,0 +1,258 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Flash attention kernel supporting MHA, GQA, and MQA.
+
+Implements the online softmax (flash attention) algorithm with:
+  - Multi-head attention (MHA): N_kv_heads == N_heads
+  - Grouped-query attention (GQA): N_kv_heads < N_heads  (Llama 3, Qwen 3, Mistral)
+  - Multi-query attention (MQA): N_kv_heads == 1         (Falcon)
+
+Grid: one core per query head. KV heads are broadcast across the GQA group.
+
+Tensor layout conventions (all in tile units):
+  Q:    [N_heads,    head_dim_tiles]  — one row per head
+  K, V: [N_kv_heads * kv_seq_tiles, head_dim_tiles]
+  out:  [1,          N_heads * head_dim_tiles]  — all heads concatenated in one tile row
+
+ttl 1.1.3 API:
+  - ttl.math.transpose(x)                              — not ttl.transpose
+  - ttl.math.reduce_max(x, dims=[-1])                  — no scaler arg
+  - ttl.math.reduce_sum(x, dims=[-1])                  — no scaler arg
+  - ttl.math.broadcast(x, dims=[-1], shape=(rows, cols)) — shape is static tuple
+"""
+
+import ttl  # must be a global for the DSL tracer
+
+TILE = 32   # module-level constant so it's a global, not a closure capture
+# FW 19.6.0 reports an 11-wide compute grid (device.compute_with_storage_grid_size() ==
+# (11, 10)); earlier firmware exposed 13. A 24-head model factors to 12 cols and overflowed
+# ("Kernel grid (12,2) exceeds device compute grid (11,10)" — the starcoder2 error), so the
+# cap is 11. TODO: source from device / HardwareConfig (#18/#19) instead of hardcoding.
+_MAX_GRID_X = 11
+_MAX_GRID_Y = 10
+
+
+def _grid_shape(n_heads: int):
+    """Factor n_heads into (cols, rows) fitting the 13×10 Blackhole p150 grid.
+
+    Prefers larger cols (fewer rows) to minimise row-bank pressure.
+    Raises ValueError if no valid factorization exists.
+    """
+    for cols in range(min(n_heads, _MAX_GRID_X), 0, -1):
+        if n_heads % cols == 0:
+            rows = n_heads // cols
+            if rows <= _MAX_GRID_Y:
+                return cols, rows
+    raise ValueError(
+        f"Cannot map {n_heads} heads onto a {_MAX_GRID_X}×{_MAX_GRID_Y} grid. "
+        f"Choose N_heads with a factor ≤ {_MAX_GRID_X} whose paired factor is ≤ {_MAX_GRID_Y}."
+    )
+
+
+def make_flash_attn_kernel(
+    N_heads: int,
+    N_kv_heads: int,
+    head_dim_tiles: int,
+    kv_chunk_tiles: int = 1,
+):
+    """Return a compiled flash attention kernel.
+
+    Args:
+        N_heads: number of query heads
+        N_kv_heads: number of key/value heads (≤ N_heads)
+        head_dim_tiles: head dimension in tiles (head_dim / 32)
+        kv_chunk_tiles: KV tiles processed per loop iteration (default 1)
+    """
+    if N_heads % N_kv_heads != 0:
+        raise ValueError(
+            f"N_heads ({N_heads}) must be divisible by N_kv_heads ({N_kv_heads})"
+        )
+    GQA = N_heads // N_kv_heads
+    grid_cols, grid_rows = _grid_shape(N_heads)
+
+    @ttl.operation(grid=(grid_cols, grid_rows))
+    def flash_attn_kernel(
+        Q_all,
+        K_all,
+        V_all,
+        scale_tile,
+        neg_inf_tile,
+        zero_tile,
+        zero_head,
+        ones_tile,
+        mask,
+        out,
+    ):
+        kv_seq_tiles = K_all.shape[0] // N_kv_heads // TILE
+        n_chunks = kv_seq_tiles // kv_chunk_tiles
+
+        # Input DFBs
+        q_dfb         = ttl.make_dataflow_buffer_like(Q_all,       shape=(1, head_dim_tiles),   block_count=1)
+        k_dfb         = ttl.make_dataflow_buffer_like(K_all,       shape=(kv_chunk_tiles, head_dim_tiles), block_count=2)
+        v_dfb         = ttl.make_dataflow_buffer_like(V_all,       shape=(kv_chunk_tiles, head_dim_tiles), block_count=2)
+        sc_dfb        = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=1)
+        ninf_dfb      = ttl.make_dataflow_buffer_like(neg_inf_tile,shape=(1, 1), block_count=1)
+        zero_dfb      = ttl.make_dataflow_buffer_like(zero_tile,   shape=(1, 1), block_count=1)
+        zero_head_dfb = ttl.make_dataflow_buffer_like(zero_head,   shape=(1, head_dim_tiles), block_count=1)
+        ones_dfb      = ttl.make_dataflow_buffer_like(ones_tile,   shape=(1, 1), block_count=1)
+        mask_dfb      = ttl.make_dataflow_buffer_like(mask,        shape=(1, kv_chunk_tiles), block_count=2)
+
+        # Intermediate DFBs
+        kt_dfb        = ttl.make_dataflow_buffer_like(K_all,       shape=(head_dim_tiles, kv_chunk_tiles), block_count=2)
+        qk_dfb        = ttl.make_dataflow_buffer_like(mask,        shape=(1, kv_chunk_tiles), block_count=2)
+        scaled_dfb    = ttl.make_dataflow_buffer_like(mask,        shape=(1, kv_chunk_tiles), block_count=2)
+        chunk_max_dfb = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=2)
+        m_dfb         = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=2)
+        alpha_dfb     = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=2)
+        m_new_dfb     = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=2)
+        m_bcast_dfb   = ttl.make_dataflow_buffer_like(mask,        shape=(1, kv_chunk_tiles), block_count=2)
+        alpha_bcast_dfb = ttl.make_dataflow_buffer_like(Q_all,     shape=(1, head_dim_tiles), block_count=2)
+        exp_dfb       = ttl.make_dataflow_buffer_like(mask,        shape=(1, kv_chunk_tiles), block_count=2)
+        chunk_sum_dfb = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=2)
+        l_dfb         = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=2)
+        o_dfb         = ttl.make_dataflow_buffer_like(Q_all,       shape=(1, head_dim_tiles), block_count=2)
+        o_corr_dfb    = ttl.make_dataflow_buffer_like(Q_all,       shape=(1, head_dim_tiles), block_count=2)
+        pv_dfb        = ttl.make_dataflow_buffer_like(Q_all,       shape=(1, head_dim_tiles), block_count=2)
+        l_bcast_dfb   = ttl.make_dataflow_buffer_like(Q_all,       shape=(1, head_dim_tiles), block_count=2)
+        out_dfb       = ttl.make_dataflow_buffer_like(out,         shape=(1, head_dim_tiles), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            nx, ny = ttl.node(dims=2)
+            h = ny * grid_cols + nx
+
+            with (
+                q_dfb.wait() as q,
+                sc_dfb.wait() as scale,
+                ninf_dfb.wait() as ninf,
+                zero_dfb.wait() as zero,
+                zero_head_dfb.wait() as zh,
+                ones_dfb.wait() as ones,
+            ):
+                with m_dfb.reserve() as m_init:
+                    m_init.store(ninf)
+                with l_dfb.reserve() as l_init:
+                    l_init.store(zero)
+                with o_dfb.reserve() as o_init:
+                    o_init.store(zh)
+
+                for c in range(n_chunks):
+                    with k_dfb.wait() as kc, kt_dfb.reserve() as kt:
+                        kt.store(ttl.math.transpose(kc))
+                    with kt_dfb.wait() as kt, qk_dfb.reserve() as qk:
+                        qk.store(q @ kt)
+                    with (
+                        qk_dfb.wait() as qk,
+                        mask_dfb.wait() as msk,
+                        scaled_dfb.reserve() as sc_out,
+                    ):
+                        sc_out.store(scale * qk + msk)
+
+                    with scaled_dfb.wait() as sv:
+                        with chunk_max_dfb.reserve() as cm:
+                            cm.store(ttl.math.reduce_max(sv, dims=[-1]))
+                        with scaled_dfb.reserve() as sv_copy:
+                            sv_copy.store(sv)
+
+                    with m_dfb.wait() as m_old:
+                        with chunk_max_dfb.wait() as cm:
+                            with m_new_dfb.reserve() as mn:
+                                mn.store(ttl.math.max(m_old, cm))
+                        with m_new_dfb.wait() as mn:
+                            with alpha_dfb.reserve() as alpha:
+                                alpha.store(ttl.math.exp(m_old - mn))
+                            with m_bcast_dfb.reserve() as mn_bc:
+                                mn_bc.store(
+                                    ttl.math.broadcast(mn, dims=[-1], shape=(1, kv_chunk_tiles))
+                                )
+                            with m_dfb.reserve() as m_next:
+                                m_next.store(mn)
+
+                    with (
+                        scaled_dfb.wait() as sv2,
+                        m_bcast_dfb.wait() as mn_bc,
+                        exp_dfb.reserve() as ex,
+                    ):
+                        ex.store(ttl.math.exp(sv2 - mn_bc))
+
+                    with exp_dfb.wait() as ex:
+                        with chunk_sum_dfb.reserve() as cs:
+                            cs.store(ttl.math.reduce_sum(ex, dims=[-1]))
+                        with exp_dfb.reserve() as ex_copy:
+                            ex_copy.store(ex)
+
+                    with (
+                        alpha_dfb.wait() as alph,
+                        l_dfb.wait() as l_old,
+                        chunk_sum_dfb.wait() as cs,
+                    ):
+                        with l_dfb.reserve() as l_new:
+                            l_new.store(alph * l_old + cs)
+                        with alpha_bcast_dfb.reserve() as ab:
+                            ab.store(
+                                ttl.math.broadcast(alph, dims=[-1], shape=(1, head_dim_tiles))
+                            )
+                    with (
+                        alpha_bcast_dfb.wait() as ab,
+                        o_dfb.wait() as o_old,
+                        o_corr_dfb.reserve() as oc,
+                    ):
+                        oc.store(ab * o_old)
+
+                    with exp_dfb.wait() as ex2, v_dfb.wait() as vc, pv_dfb.reserve() as pv:
+                        pv.store(ex2 @ vc)
+
+                    with (
+                        o_corr_dfb.wait() as oc,
+                        pv_dfb.wait() as pv,
+                        o_dfb.reserve() as o_new,
+                    ):
+                        o_new.store(oc + pv)
+
+                with l_dfb.wait() as l_final, l_bcast_dfb.reserve() as lb:
+                    lb.store(ttl.math.broadcast(l_final, dims=[-1], shape=(1, head_dim_tiles)))
+                with (
+                    o_dfb.wait() as o_final,
+                    l_bcast_dfb.wait() as lb,
+                    out_dfb.reserve() as final_out,
+                ):
+                    final_out.store(o_final * ttl.math.recip(lb))
+
+        @ttl.datamovement()
+        def dm_read():
+            nx, ny = ttl.node(dims=2)
+            h = ny * grid_cols + nx
+
+            with q_dfb.reserve() as blk:
+                ttl.copy(Q_all[h, 0:head_dim_tiles], blk).wait()
+            with sc_dfb.reserve() as blk:
+                ttl.copy(scale_tile[0, 0], blk).wait()
+            with ninf_dfb.reserve() as blk:
+                ttl.copy(neg_inf_tile[0, 0], blk).wait()
+            with zero_dfb.reserve() as blk:
+                ttl.copy(zero_tile[0, 0], blk).wait()
+            with zero_head_dfb.reserve() as blk:
+                ttl.copy(zero_head[0, 0:head_dim_tiles], blk).wait()
+            with ones_dfb.reserve() as blk:
+                ttl.copy(ones_tile[0, 0], blk).wait()
+
+            # GQA: each KV head serves GQA query heads
+            kv_base = (h // GQA) * kv_seq_tiles
+            for c in range(n_chunks):
+                kv_off = kv_base + c * kv_chunk_tiles
+                with k_dfb.reserve() as blk:
+                    ttl.copy(K_all[kv_off : kv_off + kv_chunk_tiles, 0:head_dim_tiles], blk).wait()
+                with mask_dfb.reserve() as blk:
+                    ttl.copy(mask[0, c * kv_chunk_tiles : (c + 1) * kv_chunk_tiles], blk).wait()
+                with v_dfb.reserve() as blk:
+                    ttl.copy(V_all[kv_off : kv_off + kv_chunk_tiles, 0:head_dim_tiles], blk).wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            nx, ny = ttl.node(dims=2)
+            h = ny * grid_cols + nx
+            with out_dfb.wait() as blk:
+                ttl.copy(blk, out[0, h * head_dim_tiles : (h + 1) * head_dim_tiles]).wait()
+
+    return flash_attn_kernel

--- a/tt_inference_server/dispatch/kernels/flash_attn.py
+++ b/tt_inference_server/dispatch/kernels/flash_attn.py
@@ -24,7 +24,7 @@ ttl 1.1.3 API:
 
 import ttl  # must be a global for the DSL tracer
 
-TILE = 32   # module-level constant so it's a global, not a closure capture
+TILE = 32  # module-level constant so it's a global, not a closure capture
 # FW 19.6.0 reports an 11-wide compute grid (device.compute_with_storage_grid_size() ==
 # (11, 10)); earlier firmware exposed 13. A 24-head model factors to 12 cols and overflowed
 # ("Kernel grid (12,2) exceeds device compute grid (11,10)" — the starcoder2 error), so the
@@ -88,48 +88,82 @@ def make_flash_attn_kernel(
         n_chunks = kv_seq_tiles // kv_chunk_tiles
 
         # Input DFBs
-        q_dfb         = ttl.make_dataflow_buffer_like(Q_all,       shape=(1, head_dim_tiles),   block_count=1)
-        k_dfb         = ttl.make_dataflow_buffer_like(K_all,       shape=(kv_chunk_tiles, head_dim_tiles), block_count=2)
-        v_dfb         = ttl.make_dataflow_buffer_like(V_all,       shape=(kv_chunk_tiles, head_dim_tiles), block_count=2)
-        sc_dfb        = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=1)
-        ninf_dfb      = ttl.make_dataflow_buffer_like(neg_inf_tile,shape=(1, 1), block_count=1)
-        zero_dfb      = ttl.make_dataflow_buffer_like(zero_tile,   shape=(1, 1), block_count=1)
-        zero_head_dfb = ttl.make_dataflow_buffer_like(zero_head,   shape=(1, head_dim_tiles), block_count=1)
-        ones_dfb      = ttl.make_dataflow_buffer_like(ones_tile,   shape=(1, 1), block_count=1)
-        mask_dfb      = ttl.make_dataflow_buffer_like(mask,        shape=(1, kv_chunk_tiles), block_count=2)
+        q_dfb = ttl.make_dataflow_buffer_like(
+            Q_all, shape=(1, head_dim_tiles), block_count=1
+        )
+        k_dfb = ttl.make_dataflow_buffer_like(
+            K_all, shape=(kv_chunk_tiles, head_dim_tiles), block_count=2
+        )
+        v_dfb = ttl.make_dataflow_buffer_like(
+            V_all, shape=(kv_chunk_tiles, head_dim_tiles), block_count=2
+        )
+        sc_dfb = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=1)
+        ninf_dfb = ttl.make_dataflow_buffer_like(
+            neg_inf_tile, shape=(1, 1), block_count=1
+        )
+        zero_dfb = ttl.make_dataflow_buffer_like(zero_tile, shape=(1, 1), block_count=1)
+        zero_head_dfb = ttl.make_dataflow_buffer_like(
+            zero_head, shape=(1, head_dim_tiles), block_count=1
+        )
+        ones_dfb = ttl.make_dataflow_buffer_like(ones_tile, shape=(1, 1), block_count=1)
+        mask_dfb = ttl.make_dataflow_buffer_like(
+            mask, shape=(1, kv_chunk_tiles), block_count=2
+        )
 
         # Intermediate DFBs
-        kt_dfb        = ttl.make_dataflow_buffer_like(K_all,       shape=(head_dim_tiles, kv_chunk_tiles), block_count=2)
-        qk_dfb        = ttl.make_dataflow_buffer_like(mask,        shape=(1, kv_chunk_tiles), block_count=2)
-        scaled_dfb    = ttl.make_dataflow_buffer_like(mask,        shape=(1, kv_chunk_tiles), block_count=2)
-        chunk_max_dfb = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=2)
-        m_dfb         = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=2)
-        alpha_dfb     = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=2)
-        m_new_dfb     = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=2)
-        m_bcast_dfb   = ttl.make_dataflow_buffer_like(mask,        shape=(1, kv_chunk_tiles), block_count=2)
-        alpha_bcast_dfb = ttl.make_dataflow_buffer_like(Q_all,     shape=(1, head_dim_tiles), block_count=2)
-        exp_dfb       = ttl.make_dataflow_buffer_like(mask,        shape=(1, kv_chunk_tiles), block_count=2)
-        chunk_sum_dfb = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=2)
-        l_dfb         = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=2)
-        o_dfb         = ttl.make_dataflow_buffer_like(Q_all,       shape=(1, head_dim_tiles), block_count=2)
-        o_corr_dfb    = ttl.make_dataflow_buffer_like(Q_all,       shape=(1, head_dim_tiles), block_count=2)
-        pv_dfb        = ttl.make_dataflow_buffer_like(Q_all,       shape=(1, head_dim_tiles), block_count=2)
-        l_bcast_dfb   = ttl.make_dataflow_buffer_like(Q_all,       shape=(1, head_dim_tiles), block_count=2)
-        out_dfb       = ttl.make_dataflow_buffer_like(out,         shape=(1, head_dim_tiles), block_count=2)
+        kt_dfb = ttl.make_dataflow_buffer_like(
+            K_all, shape=(head_dim_tiles, kv_chunk_tiles), block_count=2
+        )
+        qk_dfb = ttl.make_dataflow_buffer_like(
+            mask, shape=(1, kv_chunk_tiles), block_count=2
+        )
+        scaled_dfb = ttl.make_dataflow_buffer_like(
+            mask, shape=(1, kv_chunk_tiles), block_count=2
+        )
+        chunk_max_dfb = ttl.make_dataflow_buffer_like(
+            scale_tile, shape=(1, 1), block_count=2
+        )
+        m_dfb = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
+        alpha_dfb = ttl.make_dataflow_buffer_like(
+            scale_tile, shape=(1, 1), block_count=2
+        )
+        m_new_dfb = ttl.make_dataflow_buffer_like(
+            scale_tile, shape=(1, 1), block_count=2
+        )
+        m_bcast_dfb = ttl.make_dataflow_buffer_like(
+            mask, shape=(1, kv_chunk_tiles), block_count=2
+        )
+        alpha_bcast_dfb = ttl.make_dataflow_buffer_like(
+            Q_all, shape=(1, head_dim_tiles), block_count=2
+        )
+        exp_dfb = ttl.make_dataflow_buffer_like(
+            mask, shape=(1, kv_chunk_tiles), block_count=2
+        )
+        chunk_sum_dfb = ttl.make_dataflow_buffer_like(
+            scale_tile, shape=(1, 1), block_count=2
+        )
+        l_dfb = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
+        o_dfb = ttl.make_dataflow_buffer_like(
+            Q_all, shape=(1, head_dim_tiles), block_count=2
+        )
+        o_corr_dfb = ttl.make_dataflow_buffer_like(
+            Q_all, shape=(1, head_dim_tiles), block_count=2
+        )
+        pv_dfb = ttl.make_dataflow_buffer_like(
+            Q_all, shape=(1, head_dim_tiles), block_count=2
+        )
+        l_bcast_dfb = ttl.make_dataflow_buffer_like(
+            Q_all, shape=(1, head_dim_tiles), block_count=2
+        )
+        out_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(1, head_dim_tiles), block_count=2
+        )
 
         @ttl.compute()
         def compute():
             nx, ny = ttl.node(dims=2)
-            h = ny * grid_cols + nx
 
-            with (
-                q_dfb.wait() as q,
-                sc_dfb.wait() as scale,
-                ninf_dfb.wait() as ninf,
-                zero_dfb.wait() as zero,
-                zero_head_dfb.wait() as zh,
-                ones_dfb.wait() as ones,
-            ):
+            with q_dfb.wait() as q, sc_dfb.wait() as scale, ninf_dfb.wait() as ninf, zero_dfb.wait() as zero, zero_head_dfb.wait() as zh, ones_dfb.wait():
                 with m_dfb.reserve() as m_init:
                     m_init.store(ninf)
                 with l_dfb.reserve() as l_init:
@@ -142,11 +176,7 @@ def make_flash_attn_kernel(
                         kt.store(ttl.math.transpose(kc))
                     with kt_dfb.wait() as kt, qk_dfb.reserve() as qk:
                         qk.store(q @ kt)
-                    with (
-                        qk_dfb.wait() as qk,
-                        mask_dfb.wait() as msk,
-                        scaled_dfb.reserve() as sc_out,
-                    ):
+                    with qk_dfb.wait() as qk, mask_dfb.wait() as msk, scaled_dfb.reserve() as sc_out:
                         sc_out.store(scale * qk + msk)
 
                     with scaled_dfb.wait() as sv:
@@ -164,16 +194,14 @@ def make_flash_attn_kernel(
                                 alpha.store(ttl.math.exp(m_old - mn))
                             with m_bcast_dfb.reserve() as mn_bc:
                                 mn_bc.store(
-                                    ttl.math.broadcast(mn, dims=[-1], shape=(1, kv_chunk_tiles))
+                                    ttl.math.broadcast(
+                                        mn, dims=[-1], shape=(1, kv_chunk_tiles)
+                                    )
                                 )
                             with m_dfb.reserve() as m_next:
                                 m_next.store(mn)
 
-                    with (
-                        scaled_dfb.wait() as sv2,
-                        m_bcast_dfb.wait() as mn_bc,
-                        exp_dfb.reserve() as ex,
-                    ):
+                    with scaled_dfb.wait() as sv2, m_bcast_dfb.wait() as mn_bc, exp_dfb.reserve() as ex:
                         ex.store(ttl.math.exp(sv2 - mn_bc))
 
                     with exp_dfb.wait() as ex:
@@ -182,41 +210,31 @@ def make_flash_attn_kernel(
                         with exp_dfb.reserve() as ex_copy:
                             ex_copy.store(ex)
 
-                    with (
-                        alpha_dfb.wait() as alph,
-                        l_dfb.wait() as l_old,
-                        chunk_sum_dfb.wait() as cs,
-                    ):
+                    with alpha_dfb.wait() as alph, l_dfb.wait() as l_old, chunk_sum_dfb.wait() as cs:
                         with l_dfb.reserve() as l_new:
                             l_new.store(alph * l_old + cs)
                         with alpha_bcast_dfb.reserve() as ab:
                             ab.store(
-                                ttl.math.broadcast(alph, dims=[-1], shape=(1, head_dim_tiles))
+                                ttl.math.broadcast(
+                                    alph, dims=[-1], shape=(1, head_dim_tiles)
+                                )
                             )
-                    with (
-                        alpha_bcast_dfb.wait() as ab,
-                        o_dfb.wait() as o_old,
-                        o_corr_dfb.reserve() as oc,
-                    ):
+                    with alpha_bcast_dfb.wait() as ab, o_dfb.wait() as o_old, o_corr_dfb.reserve() as oc:
                         oc.store(ab * o_old)
 
                     with exp_dfb.wait() as ex2, v_dfb.wait() as vc, pv_dfb.reserve() as pv:
                         pv.store(ex2 @ vc)
 
-                    with (
-                        o_corr_dfb.wait() as oc,
-                        pv_dfb.wait() as pv,
-                        o_dfb.reserve() as o_new,
-                    ):
+                    with o_corr_dfb.wait() as oc, pv_dfb.wait() as pv, o_dfb.reserve() as o_new:
                         o_new.store(oc + pv)
 
                 with l_dfb.wait() as l_final, l_bcast_dfb.reserve() as lb:
-                    lb.store(ttl.math.broadcast(l_final, dims=[-1], shape=(1, head_dim_tiles)))
-                with (
-                    o_dfb.wait() as o_final,
-                    l_bcast_dfb.wait() as lb,
-                    out_dfb.reserve() as final_out,
-                ):
+                    lb.store(
+                        ttl.math.broadcast(
+                            l_final, dims=[-1], shape=(1, head_dim_tiles)
+                        )
+                    )
+                with o_dfb.wait() as o_final, l_bcast_dfb.wait() as lb, out_dfb.reserve() as final_out:
                     final_out.store(o_final * ttl.math.recip(lb))
 
         @ttl.datamovement()
@@ -242,17 +260,25 @@ def make_flash_attn_kernel(
             for c in range(n_chunks):
                 kv_off = kv_base + c * kv_chunk_tiles
                 with k_dfb.reserve() as blk:
-                    ttl.copy(K_all[kv_off : kv_off + kv_chunk_tiles, 0:head_dim_tiles], blk).wait()
+                    ttl.copy(
+                        K_all[kv_off : kv_off + kv_chunk_tiles, 0:head_dim_tiles], blk
+                    ).wait()
                 with mask_dfb.reserve() as blk:
-                    ttl.copy(mask[0, c * kv_chunk_tiles : (c + 1) * kv_chunk_tiles], blk).wait()
+                    ttl.copy(
+                        mask[0, c * kv_chunk_tiles : (c + 1) * kv_chunk_tiles], blk
+                    ).wait()
                 with v_dfb.reserve() as blk:
-                    ttl.copy(V_all[kv_off : kv_off + kv_chunk_tiles, 0:head_dim_tiles], blk).wait()
+                    ttl.copy(
+                        V_all[kv_off : kv_off + kv_chunk_tiles, 0:head_dim_tiles], blk
+                    ).wait()
 
         @ttl.datamovement()
         def dm_write():
             nx, ny = ttl.node(dims=2)
             h = ny * grid_cols + nx
             with out_dfb.wait() as blk:
-                ttl.copy(blk, out[0, h * head_dim_tiles : (h + 1) * head_dim_tiles]).wait()
+                ttl.copy(
+                    blk, out[0, h * head_dim_tiles : (h + 1) * head_dim_tiles]
+                ).wait()
 
     return flash_attn_kernel

--- a/tt_inference_server/dispatch/kernels/kv_decode.py
+++ b/tt_inference_server/dispatch/kernels/kv_decode.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""KV cache decode-phase read kernel.
+
+STATUS (2026-06-11): SUPERSEDED / NOT WIRED — the decode path uses either ttnn paged
+SDPA (#30) or the custom `flash_attn` kernel. This standalone decode-read kernel is
+unused; candidate for removal. See issue #34 (kernel strategy).
+
+During autoregressive decode, each new token attends to the full KV cache
+(one row per past token). This kernel reads a single query row and the
+accumulated KV cache and produces a single output row — the dominant
+memory-bandwidth operation in decode.
+
+Double-buffered DFBs overlap DRAM prefetch with compute for each KV chunk.
+
+ttl 1.1.3 API:
+  - reduce_max(input, *, dims)       — no scaler arg
+  - reduce_sum(input, *, dims)       — no scaler arg
+  - broadcast(input, *, dims, shape) — shape is static tuple of ints
+"""
+
+import ttl  # must be a global for the DSL tracer
+
+
+def make_kv_decode_kernel(
+    N_kv_heads: int,
+    head_dim_tiles: int,
+    max_seq_tiles: int,
+    kv_chunk_tiles: int = 2,
+):
+    """Return a compiled KV decode kernel.
+
+    Args:
+        N_kv_heads: number of KV heads
+        head_dim_tiles: head dimension in tiles
+        max_seq_tiles: maximum sequence length in tiles (KV cache capacity)
+        kv_chunk_tiles: tiles prefetched per double-buffer iteration
+    """
+
+    @ttl.operation(grid=(N_kv_heads, 1))
+    def kv_decode_kernel(Q, K_cache, V_cache, scale_tile, neg_inf_tile, zero_tile, zero_head, out):
+        n_chunks = max_seq_tiles // kv_chunk_tiles
+
+        q_dfb         = ttl.make_dataflow_buffer_like(Q,          shape=(1, head_dim_tiles),          block_count=1)
+        k_dfb         = ttl.make_dataflow_buffer_like(K_cache,    shape=(kv_chunk_tiles, head_dim_tiles), block_count=2)
+        v_dfb         = ttl.make_dataflow_buffer_like(V_cache,    shape=(kv_chunk_tiles, head_dim_tiles), block_count=2)
+        sc_dfb        = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=1)
+        ninf_dfb      = ttl.make_dataflow_buffer_like(neg_inf_tile,shape=(1, 1), block_count=1)
+        zero_dfb      = ttl.make_dataflow_buffer_like(zero_tile,   shape=(1, 1), block_count=1)
+        zero_head_dfb = ttl.make_dataflow_buffer_like(zero_head,   shape=(1, head_dim_tiles), block_count=1)
+
+        kt_dfb        = ttl.make_dataflow_buffer_like(K_cache,    shape=(head_dim_tiles, kv_chunk_tiles), block_count=2)
+        qk_dfb        = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, kv_chunk_tiles), block_count=2)
+        exp_dfb       = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, kv_chunk_tiles), block_count=2)
+        pv_dfb        = ttl.make_dataflow_buffer_like(Q,          shape=(1, head_dim_tiles), block_count=2)
+        m_dfb         = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
+        l_dfb         = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
+        o_dfb         = ttl.make_dataflow_buffer_like(Q,          shape=(1, head_dim_tiles), block_count=2)
+        m_new_dfb     = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
+        alpha_dfb     = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
+        alpha_bcast_dfb = ttl.make_dataflow_buffer_like(Q,        shape=(1, head_dim_tiles), block_count=2)
+        chunk_max_dfb = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
+        chunk_sum_dfb = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
+        m_bcast_dfb   = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, kv_chunk_tiles), block_count=2)
+        o_corr_dfb    = ttl.make_dataflow_buffer_like(Q,          shape=(1, head_dim_tiles), block_count=2)
+        l_bcast_dfb   = ttl.make_dataflow_buffer_like(Q,          shape=(1, head_dim_tiles), block_count=2)
+        out_dfb       = ttl.make_dataflow_buffer_like(out,        shape=(1, head_dim_tiles), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            nx, ny = ttl.node(dims=2)
+
+            with (
+                q_dfb.wait() as q,
+                sc_dfb.wait() as scale,
+                ninf_dfb.wait() as ninf,
+                zero_dfb.wait() as zero,
+                zero_head_dfb.wait() as zh,
+            ):
+                with m_dfb.reserve() as m_init:
+                    m_init.store(ninf)
+                with l_dfb.reserve() as l_init:
+                    l_init.store(zero)
+                with o_dfb.reserve() as o_init:
+                    o_init.store(zh)
+
+                for c in range(n_chunks):
+                    with k_dfb.wait() as kc, kt_dfb.reserve() as kt:
+                        kt.store(ttl.math.transpose(kc))
+                    with kt_dfb.wait() as kt, qk_dfb.reserve() as qk:
+                        qk.store(scale * (q @ kt))
+
+                    with qk_dfb.wait() as qkv:
+                        with chunk_max_dfb.reserve() as cm:
+                            cm.store(ttl.math.reduce_max(qkv, dims=[-1]))
+                        with qk_dfb.reserve() as qk_copy:
+                            qk_copy.store(qkv)
+
+                    with m_dfb.wait() as m_old, chunk_max_dfb.wait() as cm:
+                        with m_new_dfb.reserve() as mn:
+                            mn.store(ttl.math.max(m_old, cm))
+                        with m_new_dfb.wait() as mn:
+                            with alpha_dfb.reserve() as alpha:
+                                alpha.store(ttl.math.exp(m_old - mn))
+                            with m_bcast_dfb.reserve() as mn_bc:
+                                mn_bc.store(ttl.math.broadcast(mn, dims=[-1], shape=(1, kv_chunk_tiles)))
+                            with m_dfb.reserve() as m_next:
+                                m_next.store(mn)
+
+                    with qk_dfb.wait() as qkv2, m_bcast_dfb.wait() as mn_bc, exp_dfb.reserve() as ex:
+                        ex.store(ttl.math.exp(qkv2 - mn_bc))
+
+                    with exp_dfb.wait() as ex:
+                        with chunk_sum_dfb.reserve() as cs:
+                            cs.store(ttl.math.reduce_sum(ex, dims=[-1]))
+                        with exp_dfb.reserve() as ex_copy:
+                            ex_copy.store(ex)
+
+                    with alpha_dfb.wait() as alph, l_dfb.wait() as l_old, chunk_sum_dfb.wait() as cs:
+                        with l_dfb.reserve() as l_new:
+                            l_new.store(alph * l_old + cs)
+                        with alpha_bcast_dfb.reserve() as ab:
+                            ab.store(ttl.math.broadcast(alph, dims=[-1], shape=(1, head_dim_tiles)))
+
+                    with alpha_bcast_dfb.wait() as ab, o_dfb.wait() as o_old, o_corr_dfb.reserve() as oc:
+                        oc.store(ab * o_old)
+
+                    with exp_dfb.wait() as ex2, v_dfb.wait() as vc, pv_dfb.reserve() as pv:
+                        pv.store(ex2 @ vc)
+
+                    with o_corr_dfb.wait() as oc, pv_dfb.wait() as pv, o_dfb.reserve() as o_new:
+                        o_new.store(oc + pv)
+
+                with l_dfb.wait() as l_final, l_bcast_dfb.reserve() as lb:
+                    lb.store(ttl.math.broadcast(l_final, dims=[-1], shape=(1, head_dim_tiles)))
+                with o_dfb.wait() as o_final, l_bcast_dfb.wait() as lb, out_dfb.reserve() as final_out:
+                    final_out.store(o_final * ttl.math.recip(lb))
+
+        @ttl.datamovement()
+        def dm_read():
+            nx, ny = ttl.node(dims=2)
+            h = nx  # one core per KV head
+
+            with q_dfb.reserve() as blk:
+                ttl.copy(Q[h, 0:head_dim_tiles], blk).wait()
+            with sc_dfb.reserve() as blk:
+                ttl.copy(scale_tile[0, 0], blk).wait()
+            with ninf_dfb.reserve() as blk:
+                ttl.copy(neg_inf_tile[0, 0], blk).wait()
+            with zero_dfb.reserve() as blk:
+                ttl.copy(zero_tile[0, 0], blk).wait()
+            with zero_head_dfb.reserve() as blk:
+                ttl.copy(zero_head[0, 0:head_dim_tiles], blk).wait()
+
+            kv_base = h * max_seq_tiles
+            for c in range(n_chunks):
+                kv_off = kv_base + c * kv_chunk_tiles
+                with k_dfb.reserve() as blk:
+                    ttl.copy(K_cache[kv_off : kv_off + kv_chunk_tiles, 0:head_dim_tiles], blk).wait()
+                with v_dfb.reserve() as blk:
+                    ttl.copy(V_cache[kv_off : kv_off + kv_chunk_tiles, 0:head_dim_tiles], blk).wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            nx, ny = ttl.node(dims=2)
+            h = nx
+            with out_dfb.wait() as blk:
+                ttl.copy(blk, out[h, 0:head_dim_tiles]).wait()
+
+    return kv_decode_kernel

--- a/tt_inference_server/dispatch/kernels/kv_decode.py
+++ b/tt_inference_server/dispatch/kernels/kv_decode.py
@@ -39,45 +39,79 @@ def make_kv_decode_kernel(
     """
 
     @ttl.operation(grid=(N_kv_heads, 1))
-    def kv_decode_kernel(Q, K_cache, V_cache, scale_tile, neg_inf_tile, zero_tile, zero_head, out):
+    def kv_decode_kernel(
+        Q, K_cache, V_cache, scale_tile, neg_inf_tile, zero_tile, zero_head, out
+    ):
         n_chunks = max_seq_tiles // kv_chunk_tiles
 
-        q_dfb         = ttl.make_dataflow_buffer_like(Q,          shape=(1, head_dim_tiles),          block_count=1)
-        k_dfb         = ttl.make_dataflow_buffer_like(K_cache,    shape=(kv_chunk_tiles, head_dim_tiles), block_count=2)
-        v_dfb         = ttl.make_dataflow_buffer_like(V_cache,    shape=(kv_chunk_tiles, head_dim_tiles), block_count=2)
-        sc_dfb        = ttl.make_dataflow_buffer_like(scale_tile,  shape=(1, 1), block_count=1)
-        ninf_dfb      = ttl.make_dataflow_buffer_like(neg_inf_tile,shape=(1, 1), block_count=1)
-        zero_dfb      = ttl.make_dataflow_buffer_like(zero_tile,   shape=(1, 1), block_count=1)
-        zero_head_dfb = ttl.make_dataflow_buffer_like(zero_head,   shape=(1, head_dim_tiles), block_count=1)
+        q_dfb = ttl.make_dataflow_buffer_like(
+            Q, shape=(1, head_dim_tiles), block_count=1
+        )
+        k_dfb = ttl.make_dataflow_buffer_like(
+            K_cache, shape=(kv_chunk_tiles, head_dim_tiles), block_count=2
+        )
+        v_dfb = ttl.make_dataflow_buffer_like(
+            V_cache, shape=(kv_chunk_tiles, head_dim_tiles), block_count=2
+        )
+        sc_dfb = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=1)
+        ninf_dfb = ttl.make_dataflow_buffer_like(
+            neg_inf_tile, shape=(1, 1), block_count=1
+        )
+        zero_dfb = ttl.make_dataflow_buffer_like(zero_tile, shape=(1, 1), block_count=1)
+        zero_head_dfb = ttl.make_dataflow_buffer_like(
+            zero_head, shape=(1, head_dim_tiles), block_count=1
+        )
 
-        kt_dfb        = ttl.make_dataflow_buffer_like(K_cache,    shape=(head_dim_tiles, kv_chunk_tiles), block_count=2)
-        qk_dfb        = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, kv_chunk_tiles), block_count=2)
-        exp_dfb       = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, kv_chunk_tiles), block_count=2)
-        pv_dfb        = ttl.make_dataflow_buffer_like(Q,          shape=(1, head_dim_tiles), block_count=2)
-        m_dfb         = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
-        l_dfb         = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
-        o_dfb         = ttl.make_dataflow_buffer_like(Q,          shape=(1, head_dim_tiles), block_count=2)
-        m_new_dfb     = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
-        alpha_dfb     = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
-        alpha_bcast_dfb = ttl.make_dataflow_buffer_like(Q,        shape=(1, head_dim_tiles), block_count=2)
-        chunk_max_dfb = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
-        chunk_sum_dfb = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
-        m_bcast_dfb   = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, kv_chunk_tiles), block_count=2)
-        o_corr_dfb    = ttl.make_dataflow_buffer_like(Q,          shape=(1, head_dim_tiles), block_count=2)
-        l_bcast_dfb   = ttl.make_dataflow_buffer_like(Q,          shape=(1, head_dim_tiles), block_count=2)
-        out_dfb       = ttl.make_dataflow_buffer_like(out,        shape=(1, head_dim_tiles), block_count=2)
+        kt_dfb = ttl.make_dataflow_buffer_like(
+            K_cache, shape=(head_dim_tiles, kv_chunk_tiles), block_count=2
+        )
+        qk_dfb = ttl.make_dataflow_buffer_like(
+            scale_tile, shape=(1, kv_chunk_tiles), block_count=2
+        )
+        exp_dfb = ttl.make_dataflow_buffer_like(
+            scale_tile, shape=(1, kv_chunk_tiles), block_count=2
+        )
+        pv_dfb = ttl.make_dataflow_buffer_like(
+            Q, shape=(1, head_dim_tiles), block_count=2
+        )
+        m_dfb = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
+        l_dfb = ttl.make_dataflow_buffer_like(scale_tile, shape=(1, 1), block_count=2)
+        o_dfb = ttl.make_dataflow_buffer_like(
+            Q, shape=(1, head_dim_tiles), block_count=2
+        )
+        m_new_dfb = ttl.make_dataflow_buffer_like(
+            scale_tile, shape=(1, 1), block_count=2
+        )
+        alpha_dfb = ttl.make_dataflow_buffer_like(
+            scale_tile, shape=(1, 1), block_count=2
+        )
+        alpha_bcast_dfb = ttl.make_dataflow_buffer_like(
+            Q, shape=(1, head_dim_tiles), block_count=2
+        )
+        chunk_max_dfb = ttl.make_dataflow_buffer_like(
+            scale_tile, shape=(1, 1), block_count=2
+        )
+        chunk_sum_dfb = ttl.make_dataflow_buffer_like(
+            scale_tile, shape=(1, 1), block_count=2
+        )
+        m_bcast_dfb = ttl.make_dataflow_buffer_like(
+            scale_tile, shape=(1, kv_chunk_tiles), block_count=2
+        )
+        o_corr_dfb = ttl.make_dataflow_buffer_like(
+            Q, shape=(1, head_dim_tiles), block_count=2
+        )
+        l_bcast_dfb = ttl.make_dataflow_buffer_like(
+            Q, shape=(1, head_dim_tiles), block_count=2
+        )
+        out_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(1, head_dim_tiles), block_count=2
+        )
 
         @ttl.compute()
         def compute():
             nx, ny = ttl.node(dims=2)
 
-            with (
-                q_dfb.wait() as q,
-                sc_dfb.wait() as scale,
-                ninf_dfb.wait() as ninf,
-                zero_dfb.wait() as zero,
-                zero_head_dfb.wait() as zh,
-            ):
+            with q_dfb.wait() as q, sc_dfb.wait() as scale, ninf_dfb.wait() as ninf, zero_dfb.wait() as zero, zero_head_dfb.wait() as zh:
                 with m_dfb.reserve() as m_init:
                     m_init.store(ninf)
                 with l_dfb.reserve() as l_init:
@@ -104,7 +138,11 @@ def make_kv_decode_kernel(
                             with alpha_dfb.reserve() as alpha:
                                 alpha.store(ttl.math.exp(m_old - mn))
                             with m_bcast_dfb.reserve() as mn_bc:
-                                mn_bc.store(ttl.math.broadcast(mn, dims=[-1], shape=(1, kv_chunk_tiles)))
+                                mn_bc.store(
+                                    ttl.math.broadcast(
+                                        mn, dims=[-1], shape=(1, kv_chunk_tiles)
+                                    )
+                                )
                             with m_dfb.reserve() as m_next:
                                 m_next.store(mn)
 
@@ -121,7 +159,11 @@ def make_kv_decode_kernel(
                         with l_dfb.reserve() as l_new:
                             l_new.store(alph * l_old + cs)
                         with alpha_bcast_dfb.reserve() as ab:
-                            ab.store(ttl.math.broadcast(alph, dims=[-1], shape=(1, head_dim_tiles)))
+                            ab.store(
+                                ttl.math.broadcast(
+                                    alph, dims=[-1], shape=(1, head_dim_tiles)
+                                )
+                            )
 
                     with alpha_bcast_dfb.wait() as ab, o_dfb.wait() as o_old, o_corr_dfb.reserve() as oc:
                         oc.store(ab * o_old)
@@ -133,7 +175,11 @@ def make_kv_decode_kernel(
                         o_new.store(oc + pv)
 
                 with l_dfb.wait() as l_final, l_bcast_dfb.reserve() as lb:
-                    lb.store(ttl.math.broadcast(l_final, dims=[-1], shape=(1, head_dim_tiles)))
+                    lb.store(
+                        ttl.math.broadcast(
+                            l_final, dims=[-1], shape=(1, head_dim_tiles)
+                        )
+                    )
                 with o_dfb.wait() as o_final, l_bcast_dfb.wait() as lb, out_dfb.reserve() as final_out:
                     final_out.store(o_final * ttl.math.recip(lb))
 
@@ -157,9 +203,13 @@ def make_kv_decode_kernel(
             for c in range(n_chunks):
                 kv_off = kv_base + c * kv_chunk_tiles
                 with k_dfb.reserve() as blk:
-                    ttl.copy(K_cache[kv_off : kv_off + kv_chunk_tiles, 0:head_dim_tiles], blk).wait()
+                    ttl.copy(
+                        K_cache[kv_off : kv_off + kv_chunk_tiles, 0:head_dim_tiles], blk
+                    ).wait()
                 with v_dfb.reserve() as blk:
-                    ttl.copy(V_cache[kv_off : kv_off + kv_chunk_tiles, 0:head_dim_tiles], blk).wait()
+                    ttl.copy(
+                        V_cache[kv_off : kv_off + kv_chunk_tiles, 0:head_dim_tiles], blk
+                    ).wait()
 
         @ttl.datamovement()
         def dm_write():

--- a/tt_inference_server/dispatch/kernels/layernorm.py
+++ b/tt_inference_server/dispatch/kernels/layernorm.py
@@ -33,17 +33,31 @@ def make_layernorm_kernel(seq_tiles: int, hidden_tiles: int, eps: float = 1e-5):
     def layernorm_kernel(x, weight, bias, scaler, out):
         # Single-pass kernel: block_count=1 for all large DFBs.
         # var_dfb stays at 2 because it is read and written in the same step.
-        x_dfb        = ttl.make_dataflow_buffer_like(x,      shape=(seq_tiles, hidden_tiles), block_count=1)
-        w_dfb        = ttl.make_dataflow_buffer_like(weight,  shape=(seq_tiles, hidden_tiles), block_count=1)
-        b_dfb        = ttl.make_dataflow_buffer_like(bias,    shape=(seq_tiles, hidden_tiles), block_count=1)
-        sc_dfb       = ttl.make_dataflow_buffer_like(scaler,  shape=(1, 1),                   block_count=1)
-        mean_dfb     = ttl.make_dataflow_buffer_like(scaler,  shape=(1, 1),                   block_count=2)
-        mean_bc_dfb  = ttl.make_dataflow_buffer_like(x,       shape=(seq_tiles, hidden_tiles), block_count=1)
-        centered_dfb = ttl.make_dataflow_buffer_like(x,       shape=(seq_tiles, hidden_tiles), block_count=2)
-        var_dfb      = ttl.make_dataflow_buffer_like(scaler,  shape=(1, 1),                   block_count=2)
-        rstd_dfb     = ttl.make_dataflow_buffer_like(scaler,  shape=(1, 1),                   block_count=2)
-        rstd_bc_dfb  = ttl.make_dataflow_buffer_like(x,       shape=(seq_tiles, hidden_tiles), block_count=1)
-        out_dfb      = ttl.make_dataflow_buffer_like(out,     shape=(seq_tiles, hidden_tiles), block_count=1)
+        x_dfb = ttl.make_dataflow_buffer_like(
+            x, shape=(seq_tiles, hidden_tiles), block_count=1
+        )
+        w_dfb = ttl.make_dataflow_buffer_like(
+            weight, shape=(seq_tiles, hidden_tiles), block_count=1
+        )
+        b_dfb = ttl.make_dataflow_buffer_like(
+            bias, shape=(seq_tiles, hidden_tiles), block_count=1
+        )
+        sc_dfb = ttl.make_dataflow_buffer_like(scaler, shape=(1, 1), block_count=1)
+        mean_dfb = ttl.make_dataflow_buffer_like(scaler, shape=(1, 1), block_count=2)
+        mean_bc_dfb = ttl.make_dataflow_buffer_like(
+            x, shape=(seq_tiles, hidden_tiles), block_count=1
+        )
+        centered_dfb = ttl.make_dataflow_buffer_like(
+            x, shape=(seq_tiles, hidden_tiles), block_count=2
+        )
+        var_dfb = ttl.make_dataflow_buffer_like(scaler, shape=(1, 1), block_count=2)
+        rstd_dfb = ttl.make_dataflow_buffer_like(scaler, shape=(1, 1), block_count=2)
+        rstd_bc_dfb = ttl.make_dataflow_buffer_like(
+            x, shape=(seq_tiles, hidden_tiles), block_count=1
+        )
+        out_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(seq_tiles, hidden_tiles), block_count=1
+        )
 
         @ttl.compute()
         def compute():
@@ -52,7 +66,11 @@ def make_layernorm_kernel(seq_tiles: int, hidden_tiles: int, eps: float = 1e-5):
                 with mean_dfb.reserve() as mn:
                     mn.store(ttl.math.reduce_sum(xv, dims=[-1]) * sc)
                 with mean_dfb.wait() as mnv, mean_bc_dfb.reserve() as mn_bc:
-                    mn_bc.store(ttl.math.broadcast(mnv, dims=[-1], shape=(seq_tiles, hidden_tiles)))
+                    mn_bc.store(
+                        ttl.math.broadcast(
+                            mnv, dims=[-1], shape=(seq_tiles, hidden_tiles)
+                        )
+                    )
 
                 # x - mean
                 with mean_bc_dfb.wait() as mn_bc, centered_dfb.reserve() as ctr:
@@ -70,7 +88,11 @@ def make_layernorm_kernel(seq_tiles: int, hidden_tiles: int, eps: float = 1e-5):
                 with var_dfb.wait() as varv, rstd_dfb.reserve() as rs:
                     rs.store(ttl.math.rsqrt(varv))
                 with rstd_dfb.wait() as rsv, rstd_bc_dfb.reserve() as rs_bc:
-                    rs_bc.store(ttl.math.broadcast(rsv, dims=[-1], shape=(seq_tiles, hidden_tiles)))
+                    rs_bc.store(
+                        ttl.math.broadcast(
+                            rsv, dims=[-1], shape=(seq_tiles, hidden_tiles)
+                        )
+                    )
 
                 # normalize, scale, shift
                 with centered_dfb.wait() as ctrv2, rstd_bc_dfb.wait() as rs_bc, out_dfb.reserve() as o:

--- a/tt_inference_server/dispatch/kernels/layernorm.py
+++ b/tt_inference_server/dispatch/kernels/layernorm.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""LayerNorm kernel.
+
+STATUS (2026-06-11): NOT YET WIRED — the runner uses a CPU LayerNorm fallback
+(`_layernorm_cpu` in runner.py). This kernel is the planned on-device LayerNorm path
+for pythia / stablelm / bloom. See issues #29 and #34 (kernel strategy).
+
+Computes: out = (x - mean(x)) / sqrt(var(x) + eps) * weight + bias
+
+Used by BERT, Falcon, GPT-NeoX, and other pre-2023 transformers that
+normalize with full mean subtraction rather than RMS-only normalization.
+
+ttl 1.1.3 API:
+  - reduce_sum(input, *, dims)                — no scaler arg; multiply result separately
+  - broadcast(input, *, dims, shape)          — shape is static tuple of ints
+"""
+
+import ttl  # must be a global for the DSL tracer
+
+
+def make_layernorm_kernel(seq_tiles: int, hidden_tiles: int, eps: float = 1e-5):
+    """Return a compiled LayerNorm kernel.
+
+    Args:
+        seq_tiles: sequence length in tiles
+        hidden_tiles: hidden dimension in tiles
+        eps: stability epsilon added to variance
+    """
+
+    @ttl.operation(grid=(1, 1))
+    def layernorm_kernel(x, weight, bias, scaler, out):
+        # Single-pass kernel: block_count=1 for all large DFBs.
+        # var_dfb stays at 2 because it is read and written in the same step.
+        x_dfb        = ttl.make_dataflow_buffer_like(x,      shape=(seq_tiles, hidden_tiles), block_count=1)
+        w_dfb        = ttl.make_dataflow_buffer_like(weight,  shape=(seq_tiles, hidden_tiles), block_count=1)
+        b_dfb        = ttl.make_dataflow_buffer_like(bias,    shape=(seq_tiles, hidden_tiles), block_count=1)
+        sc_dfb       = ttl.make_dataflow_buffer_like(scaler,  shape=(1, 1),                   block_count=1)
+        mean_dfb     = ttl.make_dataflow_buffer_like(scaler,  shape=(1, 1),                   block_count=2)
+        mean_bc_dfb  = ttl.make_dataflow_buffer_like(x,       shape=(seq_tiles, hidden_tiles), block_count=1)
+        centered_dfb = ttl.make_dataflow_buffer_like(x,       shape=(seq_tiles, hidden_tiles), block_count=2)
+        var_dfb      = ttl.make_dataflow_buffer_like(scaler,  shape=(1, 1),                   block_count=2)
+        rstd_dfb     = ttl.make_dataflow_buffer_like(scaler,  shape=(1, 1),                   block_count=2)
+        rstd_bc_dfb  = ttl.make_dataflow_buffer_like(x,       shape=(seq_tiles, hidden_tiles), block_count=1)
+        out_dfb      = ttl.make_dataflow_buffer_like(out,     shape=(seq_tiles, hidden_tiles), block_count=1)
+
+        @ttl.compute()
+        def compute():
+            with x_dfb.wait() as xv, sc_dfb.wait() as sc, w_dfb.wait() as wv, b_dfb.wait() as bv:
+                # mean(x) = reduce_sum(x, dims=[-1]) * (1/hidden_dim)
+                with mean_dfb.reserve() as mn:
+                    mn.store(ttl.math.reduce_sum(xv, dims=[-1]) * sc)
+                with mean_dfb.wait() as mnv, mean_bc_dfb.reserve() as mn_bc:
+                    mn_bc.store(ttl.math.broadcast(mnv, dims=[-1], shape=(seq_tiles, hidden_tiles)))
+
+                # x - mean
+                with mean_bc_dfb.wait() as mn_bc, centered_dfb.reserve() as ctr:
+                    ctr.store(xv - mn_bc)
+
+                # var = mean((x - mean)^2) = reduce_sum(ctr^2, dims=[-1]) * (1/hidden_dim)
+                with centered_dfb.wait() as ctrv:
+                    with var_dfb.reserve() as var:
+                        sq = ctrv * ctrv
+                        var.store(ttl.math.reduce_sum(sq, dims=[-1]) * sc)
+                    with centered_dfb.reserve() as ctr2:
+                        ctr2.store(ctrv)
+
+                # rstd = 1/sqrt(var)
+                with var_dfb.wait() as varv, rstd_dfb.reserve() as rs:
+                    rs.store(ttl.math.rsqrt(varv))
+                with rstd_dfb.wait() as rsv, rstd_bc_dfb.reserve() as rs_bc:
+                    rs_bc.store(ttl.math.broadcast(rsv, dims=[-1], shape=(seq_tiles, hidden_tiles)))
+
+                # normalize, scale, shift
+                with centered_dfb.wait() as ctrv2, rstd_bc_dfb.wait() as rs_bc, out_dfb.reserve() as o:
+                    o.store(ctrv2 * rs_bc * wv + bv)
+
+        @ttl.datamovement()
+        def dm_read():
+            with x_dfb.reserve() as blk:
+                ttl.copy(x[0:seq_tiles, 0:hidden_tiles], blk).wait()
+            with w_dfb.reserve() as blk:
+                ttl.copy(weight[0:seq_tiles, 0:hidden_tiles], blk).wait()
+            with b_dfb.reserve() as blk:
+                ttl.copy(bias[0:seq_tiles, 0:hidden_tiles], blk).wait()
+            with sc_dfb.reserve() as blk:
+                ttl.copy(scaler[0, 0], blk).wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            with out_dfb.wait() as blk:
+                ttl.copy(blk, out[0:seq_tiles, 0:hidden_tiles]).wait()
+
+    return layernorm_kernel

--- a/tt_inference_server/dispatch/kernels/moe_router.py
+++ b/tt_inference_server/dispatch/kernels/moe_router.py
@@ -36,16 +36,32 @@ def make_moe_router_kernel(hidden_tiles: int, expert_tiles: int):
 
     @ttl.operation(grid=(1, 1))
     def moe_router_kernel(hidden, w_router, probs_out):
-        h_dfb      = ttl.make_dataflow_buffer_like(hidden,    shape=(1, hidden_tiles),  block_count=1)
-        wr_dfb     = ttl.make_dataflow_buffer_like(w_router,  shape=(hidden_tiles, expert_tiles), block_count=1)
-        logit_dfb  = ttl.make_dataflow_buffer_like(probs_out, shape=(1, expert_tiles),  block_count=2)
-        max_dfb    = ttl.make_dataflow_buffer_like(probs_out, shape=(1, 1),             block_count=2)
-        max_bc_dfb = ttl.make_dataflow_buffer_like(probs_out, shape=(1, expert_tiles),  block_count=2)
-        shift_dfb  = ttl.make_dataflow_buffer_like(probs_out, shape=(1, expert_tiles),  block_count=2)
-        exp_dfb    = ttl.make_dataflow_buffer_like(probs_out, shape=(1, expert_tiles),  block_count=2)
-        sum_dfb    = ttl.make_dataflow_buffer_like(probs_out, shape=(1, 1),             block_count=2)
-        sum_bc_dfb = ttl.make_dataflow_buffer_like(probs_out, shape=(1, expert_tiles),  block_count=2)
-        out_dfb    = ttl.make_dataflow_buffer_like(probs_out, shape=(1, expert_tiles),  block_count=2)
+        h_dfb = ttl.make_dataflow_buffer_like(
+            hidden, shape=(1, hidden_tiles), block_count=1
+        )
+        wr_dfb = ttl.make_dataflow_buffer_like(
+            w_router, shape=(hidden_tiles, expert_tiles), block_count=1
+        )
+        logit_dfb = ttl.make_dataflow_buffer_like(
+            probs_out, shape=(1, expert_tiles), block_count=2
+        )
+        max_dfb = ttl.make_dataflow_buffer_like(probs_out, shape=(1, 1), block_count=2)
+        max_bc_dfb = ttl.make_dataflow_buffer_like(
+            probs_out, shape=(1, expert_tiles), block_count=2
+        )
+        shift_dfb = ttl.make_dataflow_buffer_like(
+            probs_out, shape=(1, expert_tiles), block_count=2
+        )
+        exp_dfb = ttl.make_dataflow_buffer_like(
+            probs_out, shape=(1, expert_tiles), block_count=2
+        )
+        sum_dfb = ttl.make_dataflow_buffer_like(probs_out, shape=(1, 1), block_count=2)
+        sum_bc_dfb = ttl.make_dataflow_buffer_like(
+            probs_out, shape=(1, expert_tiles), block_count=2
+        )
+        out_dfb = ttl.make_dataflow_buffer_like(
+            probs_out, shape=(1, expert_tiles), block_count=2
+        )
 
         @ttl.compute()
         def compute():
@@ -62,7 +78,9 @@ def make_moe_router_kernel(hidden_tiles: int, expert_tiles: int):
                         lv_copy.store(lv)
 
                 with max_dfb.wait() as mx, max_bc_dfb.reserve() as mx_bc:
-                    mx_bc.store(ttl.math.broadcast(mx, dims=[-1], shape=(1, expert_tiles)))
+                    mx_bc.store(
+                        ttl.math.broadcast(mx, dims=[-1], shape=(1, expert_tiles))
+                    )
 
                 with logit_dfb.wait() as lv2, max_bc_dfb.wait() as mx_bc:
                     with shift_dfb.reserve() as sh:
@@ -78,7 +96,11 @@ def make_moe_router_kernel(hidden_tiles: int, expert_tiles: int):
                         ex_copy.store(ex)
 
                 with sum_dfb.wait() as sm, sum_bc_dfb.reserve() as sm_bc:
-                    sm_bc.store(ttl.math.broadcast(ttl.math.recip(sm), dims=[-1], shape=(1, expert_tiles)))
+                    sm_bc.store(
+                        ttl.math.broadcast(
+                            ttl.math.recip(sm), dims=[-1], shape=(1, expert_tiles)
+                        )
+                    )
 
                 with exp_dfb.wait() as ex2, sum_bc_dfb.wait() as sm_bc:
                     with out_dfb.reserve() as o:
@@ -86,8 +108,10 @@ def make_moe_router_kernel(hidden_tiles: int, expert_tiles: int):
 
         @ttl.datamovement()
         def dm_read():
-            with h_dfb.reserve()  as blk: ttl.copy(hidden[0, 0:hidden_tiles], blk).wait()
-            with wr_dfb.reserve() as blk: ttl.copy(w_router[0:hidden_tiles, 0:expert_tiles], blk).wait()
+            with h_dfb.reserve() as blk:
+                ttl.copy(hidden[0, 0:hidden_tiles], blk).wait()
+            with wr_dfb.reserve() as blk:
+                ttl.copy(w_router[0:hidden_tiles, 0:expert_tiles], blk).wait()
 
         @ttl.datamovement()
         def dm_write():

--- a/tt_inference_server/dispatch/kernels/moe_router.py
+++ b/tt_inference_server/dispatch/kernels/moe_router.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mixture-of-Experts router projection + softmax kernel.
+
+STATUS (2026-06-11): NOT WIRED into the runner — no MoE model in the registry yet.
+Kept for future MoE support. See issue #34 (kernel strategy).
+
+Computes: probs = softmax(hidden @ w_router)
+
+Top-k selection is intentionally left to the dispatch layer (torch.topk on
+the returned prob tensor) because ttl 1.1.3 has no topk primitive.
+
+Layout:
+  hidden:   [1, hidden_tiles]      — one token (decode phase; seq_tiles=1)
+  w_router: [hidden_tiles, expert_tiles]
+  probs_out:[1, expert_tiles]      — full softmax prob distribution
+
+ttl 1.1.3 API:
+  - reduce_max(input, *, dims)     — no scaler arg
+  - reduce_sum(input, *, dims)     — no scaler arg
+  - broadcast(input, *, dims, shape) — shape is static tuple of ints
+  - No ttl.math.topk — handled in dispatch via torch.topk
+"""
+
+import ttl  # must be a global for the DSL tracer
+
+
+def make_moe_router_kernel(hidden_tiles: int, expert_tiles: int):
+    """Return a compiled MoE router kernel (projection + softmax, single token).
+
+    Args:
+        hidden_tiles: hidden dimension in tiles
+        expert_tiles: number of expert logit tiles (ceil(N_experts / 32))
+    """
+
+    @ttl.operation(grid=(1, 1))
+    def moe_router_kernel(hidden, w_router, probs_out):
+        h_dfb      = ttl.make_dataflow_buffer_like(hidden,    shape=(1, hidden_tiles),  block_count=1)
+        wr_dfb     = ttl.make_dataflow_buffer_like(w_router,  shape=(hidden_tiles, expert_tiles), block_count=1)
+        logit_dfb  = ttl.make_dataflow_buffer_like(probs_out, shape=(1, expert_tiles),  block_count=2)
+        max_dfb    = ttl.make_dataflow_buffer_like(probs_out, shape=(1, 1),             block_count=2)
+        max_bc_dfb = ttl.make_dataflow_buffer_like(probs_out, shape=(1, expert_tiles),  block_count=2)
+        shift_dfb  = ttl.make_dataflow_buffer_like(probs_out, shape=(1, expert_tiles),  block_count=2)
+        exp_dfb    = ttl.make_dataflow_buffer_like(probs_out, shape=(1, expert_tiles),  block_count=2)
+        sum_dfb    = ttl.make_dataflow_buffer_like(probs_out, shape=(1, 1),             block_count=2)
+        sum_bc_dfb = ttl.make_dataflow_buffer_like(probs_out, shape=(1, expert_tiles),  block_count=2)
+        out_dfb    = ttl.make_dataflow_buffer_like(probs_out, shape=(1, expert_tiles),  block_count=2)
+
+        @ttl.compute()
+        def compute():
+            with h_dfb.wait() as hv, wr_dfb.wait() as wr:
+                # Router projection
+                with logit_dfb.reserve() as logits:
+                    logits.store(hv @ wr)
+
+                # Softmax: max for numerical stability
+                with logit_dfb.wait() as lv:
+                    with max_dfb.reserve() as mx:
+                        mx.store(ttl.math.reduce_max(lv, dims=[-1]))
+                    with logit_dfb.reserve() as lv_copy:
+                        lv_copy.store(lv)
+
+                with max_dfb.wait() as mx, max_bc_dfb.reserve() as mx_bc:
+                    mx_bc.store(ttl.math.broadcast(mx, dims=[-1], shape=(1, expert_tiles)))
+
+                with logit_dfb.wait() as lv2, max_bc_dfb.wait() as mx_bc:
+                    with shift_dfb.reserve() as sh:
+                        sh.store(lv2 - mx_bc)
+
+                with shift_dfb.wait() as sh, exp_dfb.reserve() as ex:
+                    ex.store(ttl.math.exp(sh))
+
+                with exp_dfb.wait() as ex:
+                    with sum_dfb.reserve() as sm:
+                        sm.store(ttl.math.reduce_sum(ex, dims=[-1]))
+                    with exp_dfb.reserve() as ex_copy:
+                        ex_copy.store(ex)
+
+                with sum_dfb.wait() as sm, sum_bc_dfb.reserve() as sm_bc:
+                    sm_bc.store(ttl.math.broadcast(ttl.math.recip(sm), dims=[-1], shape=(1, expert_tiles)))
+
+                with exp_dfb.wait() as ex2, sum_bc_dfb.wait() as sm_bc:
+                    with out_dfb.reserve() as o:
+                        o.store(ex2 * sm_bc)
+
+        @ttl.datamovement()
+        def dm_read():
+            with h_dfb.reserve()  as blk: ttl.copy(hidden[0, 0:hidden_tiles], blk).wait()
+            with wr_dfb.reserve() as blk: ttl.copy(w_router[0:hidden_tiles, 0:expert_tiles], blk).wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            with out_dfb.wait() as blk:
+                ttl.copy(blk, probs_out[0, 0:expert_tiles]).wait()
+
+    return moe_router_kernel

--- a/tt_inference_server/dispatch/kernels/rmsnorm.py
+++ b/tt_inference_server/dispatch/kernels/rmsnorm.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""RMSNorm kernel.
+
+Computes: out = x / rms(x) * weight
+where rms(x) = sqrt(mean(x^2) + eps).
+
+Used by Llama, Qwen, Mistral, DeepSeek and most post-2022 transformers.
+
+ttl 1.1.3 API:
+  - reduce_sum(input, *, dims)                — no scaler arg; multiply result separately
+  - broadcast(input, *, dims, shape)          — shape is static tuple of ints
+"""
+
+import ttl  # must be a global for the DSL tracer
+
+
+def make_rmsnorm_kernel(seq_tiles: int, hidden_tiles: int, eps: float = 1e-6):
+    """Return a compiled RMSNorm kernel.
+
+    Args:
+        seq_tiles: sequence length in tiles
+        hidden_tiles: hidden dimension in tiles
+        eps: ignored (folded into caller's scaler); kept for API compatibility
+    """
+
+    @ttl.operation(grid=(1, 1))
+    def rmsnorm_kernel(x, weight, scaler, out):
+        # scaler tensor: 1×1 tile filled with 1/hidden_dim (for scaled reduce)
+        # Single-pass kernel: no pipeline loop so block_count=1 for all large DFBs.
+        # sum_dfb stays at 2 because it is read and written in the same compute
+        # step (rsqrt reads sum then writes back into sum).
+        x_dfb     = ttl.make_dataflow_buffer_like(x,       shape=(seq_tiles, hidden_tiles), block_count=1)
+        w_dfb     = ttl.make_dataflow_buffer_like(weight,   shape=(seq_tiles, hidden_tiles), block_count=1)
+        sc_dfb    = ttl.make_dataflow_buffer_like(scaler,   shape=(1, 1),                   block_count=1)
+        sq_dfb    = ttl.make_dataflow_buffer_like(x,        shape=(seq_tiles, hidden_tiles), block_count=1)
+        sum_dfb   = ttl.make_dataflow_buffer_like(scaler,   shape=(1, 1),                   block_count=2)
+        bcast_dfb = ttl.make_dataflow_buffer_like(x,        shape=(seq_tiles, hidden_tiles), block_count=1)
+        out_dfb   = ttl.make_dataflow_buffer_like(out,      shape=(seq_tiles, hidden_tiles), block_count=1)
+
+        @ttl.compute()
+        def compute():
+            with x_dfb.wait() as xv, sc_dfb.wait() as sc, w_dfb.wait() as wv:
+                # x^2
+                with sq_dfb.reserve() as sq:
+                    sq.store(xv * xv)
+                # sum(x^2), then scale by 1/hidden_dim to get mean(x^2)
+                with sq_dfb.wait() as sqv, sum_dfb.reserve() as sm:
+                    sm.store(ttl.math.reduce_sum(sqv, dims=[-1]) * sc)
+                # 1 / sqrt(mean(x^2))
+                with sum_dfb.wait() as smv, sum_dfb.reserve() as rsq:
+                    rsq.store(ttl.math.rsqrt(smv))
+                # broadcast scalar (1,1) → (seq_tiles, hidden_tiles) along columns
+                with sum_dfb.wait() as rsqv, bcast_dfb.reserve() as bc:
+                    bc.store(ttl.math.broadcast(rsqv, dims=[-1], shape=(seq_tiles, hidden_tiles)))
+                # normalize and apply learnable weight
+                with bcast_dfb.wait() as bcv, out_dfb.reserve() as o:
+                    o.store(xv * bcv * wv)
+
+        @ttl.datamovement()
+        def dm_read():
+            with x_dfb.reserve()  as blk: ttl.copy(x[0:seq_tiles, 0:hidden_tiles], blk).wait()
+            with w_dfb.reserve()  as blk: ttl.copy(weight[0:seq_tiles, 0:hidden_tiles], blk).wait()
+            with sc_dfb.reserve() as blk: ttl.copy(scaler[0, 0], blk).wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            with out_dfb.wait() as blk: ttl.copy(blk, out[0:seq_tiles, 0:hidden_tiles]).wait()
+
+    return rmsnorm_kernel

--- a/tt_inference_server/dispatch/kernels/rmsnorm.py
+++ b/tt_inference_server/dispatch/kernels/rmsnorm.py
@@ -31,13 +31,23 @@ def make_rmsnorm_kernel(seq_tiles: int, hidden_tiles: int, eps: float = 1e-6):
         # Single-pass kernel: no pipeline loop so block_count=1 for all large DFBs.
         # sum_dfb stays at 2 because it is read and written in the same compute
         # step (rsqrt reads sum then writes back into sum).
-        x_dfb     = ttl.make_dataflow_buffer_like(x,       shape=(seq_tiles, hidden_tiles), block_count=1)
-        w_dfb     = ttl.make_dataflow_buffer_like(weight,   shape=(seq_tiles, hidden_tiles), block_count=1)
-        sc_dfb    = ttl.make_dataflow_buffer_like(scaler,   shape=(1, 1),                   block_count=1)
-        sq_dfb    = ttl.make_dataflow_buffer_like(x,        shape=(seq_tiles, hidden_tiles), block_count=1)
-        sum_dfb   = ttl.make_dataflow_buffer_like(scaler,   shape=(1, 1),                   block_count=2)
-        bcast_dfb = ttl.make_dataflow_buffer_like(x,        shape=(seq_tiles, hidden_tiles), block_count=1)
-        out_dfb   = ttl.make_dataflow_buffer_like(out,      shape=(seq_tiles, hidden_tiles), block_count=1)
+        x_dfb = ttl.make_dataflow_buffer_like(
+            x, shape=(seq_tiles, hidden_tiles), block_count=1
+        )
+        w_dfb = ttl.make_dataflow_buffer_like(
+            weight, shape=(seq_tiles, hidden_tiles), block_count=1
+        )
+        sc_dfb = ttl.make_dataflow_buffer_like(scaler, shape=(1, 1), block_count=1)
+        sq_dfb = ttl.make_dataflow_buffer_like(
+            x, shape=(seq_tiles, hidden_tiles), block_count=1
+        )
+        sum_dfb = ttl.make_dataflow_buffer_like(scaler, shape=(1, 1), block_count=2)
+        bcast_dfb = ttl.make_dataflow_buffer_like(
+            x, shape=(seq_tiles, hidden_tiles), block_count=1
+        )
+        out_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(seq_tiles, hidden_tiles), block_count=1
+        )
 
         @ttl.compute()
         def compute():
@@ -53,19 +63,27 @@ def make_rmsnorm_kernel(seq_tiles: int, hidden_tiles: int, eps: float = 1e-6):
                     rsq.store(ttl.math.rsqrt(smv))
                 # broadcast scalar (1,1) → (seq_tiles, hidden_tiles) along columns
                 with sum_dfb.wait() as rsqv, bcast_dfb.reserve() as bc:
-                    bc.store(ttl.math.broadcast(rsqv, dims=[-1], shape=(seq_tiles, hidden_tiles)))
+                    bc.store(
+                        ttl.math.broadcast(
+                            rsqv, dims=[-1], shape=(seq_tiles, hidden_tiles)
+                        )
+                    )
                 # normalize and apply learnable weight
                 with bcast_dfb.wait() as bcv, out_dfb.reserve() as o:
                     o.store(xv * bcv * wv)
 
         @ttl.datamovement()
         def dm_read():
-            with x_dfb.reserve()  as blk: ttl.copy(x[0:seq_tiles, 0:hidden_tiles], blk).wait()
-            with w_dfb.reserve()  as blk: ttl.copy(weight[0:seq_tiles, 0:hidden_tiles], blk).wait()
-            with sc_dfb.reserve() as blk: ttl.copy(scaler[0, 0], blk).wait()
+            with x_dfb.reserve() as blk:
+                ttl.copy(x[0:seq_tiles, 0:hidden_tiles], blk).wait()
+            with w_dfb.reserve() as blk:
+                ttl.copy(weight[0:seq_tiles, 0:hidden_tiles], blk).wait()
+            with sc_dfb.reserve() as blk:
+                ttl.copy(scaler[0, 0], blk).wait()
 
         @ttl.datamovement()
         def dm_write():
-            with out_dfb.wait() as blk: ttl.copy(blk, out[0:seq_tiles, 0:hidden_tiles]).wait()
+            with out_dfb.wait() as blk:
+                ttl.copy(blk, out[0:seq_tiles, 0:hidden_tiles]).wait()
 
     return rmsnorm_kernel

--- a/tt_inference_server/dispatch/kernels/swiglu.py
+++ b/tt_inference_server/dispatch/kernels/swiglu.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fused SwiGLU / GeGLU / ReGLU MLP gate kernel.
+
+STATUS (2026-06-11): NOT WIRED into the runner — `_mlp()` uses `ttnn.matmul` +
+`ttnn.silu`/`ttnn.gelu` directly. Available if we decide to move the MLP off ttnn
+primitives onto the custom kernel. See issue #34 (kernel strategy).
+
+Computes: out = activation(gate @ w_gate + bias_gate) * (up @ w_up + bias_up)
+where activation is one of silu (SwiGLU), gelu (GeGLU), or relu2 (ReGLU).
+
+Three-stage compute pattern (required for correctness):
+  1. Gate projection + activation → act_dfb
+  2. Up projection → up_proj_dfb
+  3. Elementwise multiply act_dfb * up_proj_dfb → out_dfb
+
+Fusing stages 2 and 3 (i.e. act * (u @ wu + bu)) fails when the
+intermediate up_proj tiles exceed DST register capacity — the DSL cannot
+hold both a matmul result and the gate activation simultaneously in DST
+registers for the elementwise multiply. The explicit 3-stage pattern keeps
+each intermediate in a DFB, giving the compiler clear register boundaries.
+
+The activation variant is resolved at factory time — three separate kernel
+bodies prevent Python conditionals in the traced compute body (the ttl DSL
+requires 'ttl' to be a global name, not a closure variable).
+"""
+
+import ttl  # must be a global for the DSL tracer
+
+_ACTIVATIONS = {"silu", "gelu", "relu2"}
+
+
+def _make_kernel_silu(M_tiles, K_tiles, N_tiles):
+    @ttl.operation(grid=(1, 1))
+    def kernel(gate, w_gate, bias_gate, up, w_up, bias_up, out):
+        gate_dfb    = ttl.make_dataflow_buffer_like(gate,      shape=(M_tiles, K_tiles), block_count=1)
+        wg_dfb      = ttl.make_dataflow_buffer_like(w_gate,    shape=(K_tiles, N_tiles), block_count=1)
+        bg_dfb      = ttl.make_dataflow_buffer_like(bias_gate, shape=(M_tiles, N_tiles), block_count=1)
+        up_dfb      = ttl.make_dataflow_buffer_like(up,        shape=(M_tiles, K_tiles), block_count=1)
+        wu_dfb      = ttl.make_dataflow_buffer_like(w_up,      shape=(K_tiles, N_tiles), block_count=1)
+        bu_dfb      = ttl.make_dataflow_buffer_like(bias_up,   shape=(M_tiles, N_tiles), block_count=1)
+        act_dfb     = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
+        up_proj_dfb = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
+        out_dfb     = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
+
+        @ttl.compute()
+        def compute():
+            with gate_dfb.wait() as g, wg_dfb.wait() as wg, bg_dfb.wait() as bg:
+                with act_dfb.reserve() as act:
+                    act.store(ttl.silu(g @ wg + bg))
+            with up_dfb.wait() as u, wu_dfb.wait() as wu, bu_dfb.wait() as bu:
+                with up_proj_dfb.reserve() as up_proj:
+                    up_proj.store(u @ wu + bu)
+            with act_dfb.wait() as act, up_proj_dfb.wait() as up_proj:
+                with out_dfb.reserve() as o:
+                    o.store(act * up_proj)
+
+        @ttl.datamovement()
+        def dm_read():
+            with gate_dfb.reserve() as blk: ttl.copy(gate[0:M_tiles, 0:K_tiles], blk).wait()
+            with wg_dfb.reserve()   as blk: ttl.copy(w_gate[0:K_tiles, 0:N_tiles], blk).wait()
+            with bg_dfb.reserve()   as blk: ttl.copy(bias_gate[0:M_tiles, 0:N_tiles], blk).wait()
+            with up_dfb.reserve()   as blk: ttl.copy(up[0:M_tiles, 0:K_tiles], blk).wait()
+            with wu_dfb.reserve()   as blk: ttl.copy(w_up[0:K_tiles, 0:N_tiles], blk).wait()
+            with bu_dfb.reserve()   as blk: ttl.copy(bias_up[0:M_tiles, 0:N_tiles], blk).wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            with out_dfb.wait() as blk: ttl.copy(blk, out[0:M_tiles, 0:N_tiles]).wait()
+
+    return kernel
+
+
+def _make_kernel_gelu(M_tiles, K_tiles, N_tiles):
+    @ttl.operation(grid=(1, 1))
+    def kernel(gate, w_gate, bias_gate, up, w_up, bias_up, out):
+        gate_dfb    = ttl.make_dataflow_buffer_like(gate,      shape=(M_tiles, K_tiles), block_count=1)
+        wg_dfb      = ttl.make_dataflow_buffer_like(w_gate,    shape=(K_tiles, N_tiles), block_count=1)
+        bg_dfb      = ttl.make_dataflow_buffer_like(bias_gate, shape=(M_tiles, N_tiles), block_count=1)
+        up_dfb      = ttl.make_dataflow_buffer_like(up,        shape=(M_tiles, K_tiles), block_count=1)
+        wu_dfb      = ttl.make_dataflow_buffer_like(w_up,      shape=(K_tiles, N_tiles), block_count=1)
+        bu_dfb      = ttl.make_dataflow_buffer_like(bias_up,   shape=(M_tiles, N_tiles), block_count=1)
+        act_dfb     = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
+        up_proj_dfb = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
+        out_dfb     = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
+
+        @ttl.compute()
+        def compute():
+            with gate_dfb.wait() as g, wg_dfb.wait() as wg, bg_dfb.wait() as bg:
+                with act_dfb.reserve() as act:
+                    act.store(ttl.gelu(g @ wg + bg))
+            with up_dfb.wait() as u, wu_dfb.wait() as wu, bu_dfb.wait() as bu:
+                with up_proj_dfb.reserve() as up_proj:
+                    up_proj.store(u @ wu + bu)
+            with act_dfb.wait() as act, up_proj_dfb.wait() as up_proj:
+                with out_dfb.reserve() as o:
+                    o.store(act * up_proj)
+
+        @ttl.datamovement()
+        def dm_read():
+            with gate_dfb.reserve() as blk: ttl.copy(gate[0:M_tiles, 0:K_tiles], blk).wait()
+            with wg_dfb.reserve()   as blk: ttl.copy(w_gate[0:K_tiles, 0:N_tiles], blk).wait()
+            with bg_dfb.reserve()   as blk: ttl.copy(bias_gate[0:M_tiles, 0:N_tiles], blk).wait()
+            with up_dfb.reserve()   as blk: ttl.copy(up[0:M_tiles, 0:K_tiles], blk).wait()
+            with wu_dfb.reserve()   as blk: ttl.copy(w_up[0:K_tiles, 0:N_tiles], blk).wait()
+            with bu_dfb.reserve()   as blk: ttl.copy(bias_up[0:M_tiles, 0:N_tiles], blk).wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            with out_dfb.wait() as blk: ttl.copy(blk, out[0:M_tiles, 0:N_tiles]).wait()
+
+    return kernel
+
+
+def _make_kernel_relu2(M_tiles, K_tiles, N_tiles):
+    @ttl.operation(grid=(1, 1))
+    def kernel(gate, w_gate, bias_gate, up, w_up, bias_up, out):
+        gate_dfb    = ttl.make_dataflow_buffer_like(gate,      shape=(M_tiles, K_tiles), block_count=1)
+        wg_dfb      = ttl.make_dataflow_buffer_like(w_gate,    shape=(K_tiles, N_tiles), block_count=1)
+        bg_dfb      = ttl.make_dataflow_buffer_like(bias_gate, shape=(M_tiles, N_tiles), block_count=1)
+        up_dfb      = ttl.make_dataflow_buffer_like(up,        shape=(M_tiles, K_tiles), block_count=1)
+        wu_dfb      = ttl.make_dataflow_buffer_like(w_up,      shape=(K_tiles, N_tiles), block_count=1)
+        bu_dfb      = ttl.make_dataflow_buffer_like(bias_up,   shape=(M_tiles, N_tiles), block_count=1)
+        act_dfb     = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
+        up_proj_dfb = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
+        out_dfb     = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
+
+        @ttl.compute()
+        def compute():
+            with gate_dfb.wait() as g, wg_dfb.wait() as wg, bg_dfb.wait() as bg:
+                r = ttl.relu(g @ wg + bg)
+                with act_dfb.reserve() as act:
+                    act.store(r * r)
+            with up_dfb.wait() as u, wu_dfb.wait() as wu, bu_dfb.wait() as bu:
+                with up_proj_dfb.reserve() as up_proj:
+                    up_proj.store(u @ wu + bu)
+            with act_dfb.wait() as act, up_proj_dfb.wait() as up_proj:
+                with out_dfb.reserve() as o:
+                    o.store(act * up_proj)
+
+        @ttl.datamovement()
+        def dm_read():
+            with gate_dfb.reserve() as blk: ttl.copy(gate[0:M_tiles, 0:K_tiles], blk).wait()
+            with wg_dfb.reserve()   as blk: ttl.copy(w_gate[0:K_tiles, 0:N_tiles], blk).wait()
+            with bg_dfb.reserve()   as blk: ttl.copy(bias_gate[0:M_tiles, 0:N_tiles], blk).wait()
+            with up_dfb.reserve()   as blk: ttl.copy(up[0:M_tiles, 0:K_tiles], blk).wait()
+            with wu_dfb.reserve()   as blk: ttl.copy(w_up[0:K_tiles, 0:N_tiles], blk).wait()
+            with bu_dfb.reserve()   as blk: ttl.copy(bias_up[0:M_tiles, 0:N_tiles], blk).wait()
+
+        @ttl.datamovement()
+        def dm_write():
+            with out_dfb.wait() as blk: ttl.copy(blk, out[0:M_tiles, 0:N_tiles]).wait()
+
+    return kernel
+
+
+_BUILDERS = {"silu": _make_kernel_silu, "gelu": _make_kernel_gelu, "relu2": _make_kernel_relu2}
+
+
+def make_swiglu_kernel(M_tiles: int, K_tiles: int, N_tiles: int, activation: str = "silu"):
+    """Return a compiled SwiGLU/GLU kernel for the given tile dimensions."""
+    if activation not in _ACTIVATIONS:
+        raise ValueError(f"activation must be one of {set(_ACTIVATIONS)}, got {activation!r}")
+    return _BUILDERS[activation](M_tiles, K_tiles, N_tiles)

--- a/tt_inference_server/dispatch/kernels/swiglu.py
+++ b/tt_inference_server/dispatch/kernels/swiglu.py
@@ -34,15 +34,33 @@ _ACTIVATIONS = {"silu", "gelu", "relu2"}
 def _make_kernel_silu(M_tiles, K_tiles, N_tiles):
     @ttl.operation(grid=(1, 1))
     def kernel(gate, w_gate, bias_gate, up, w_up, bias_up, out):
-        gate_dfb    = ttl.make_dataflow_buffer_like(gate,      shape=(M_tiles, K_tiles), block_count=1)
-        wg_dfb      = ttl.make_dataflow_buffer_like(w_gate,    shape=(K_tiles, N_tiles), block_count=1)
-        bg_dfb      = ttl.make_dataflow_buffer_like(bias_gate, shape=(M_tiles, N_tiles), block_count=1)
-        up_dfb      = ttl.make_dataflow_buffer_like(up,        shape=(M_tiles, K_tiles), block_count=1)
-        wu_dfb      = ttl.make_dataflow_buffer_like(w_up,      shape=(K_tiles, N_tiles), block_count=1)
-        bu_dfb      = ttl.make_dataflow_buffer_like(bias_up,   shape=(M_tiles, N_tiles), block_count=1)
-        act_dfb     = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
-        up_proj_dfb = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
-        out_dfb     = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
+        gate_dfb = ttl.make_dataflow_buffer_like(
+            gate, shape=(M_tiles, K_tiles), block_count=1
+        )
+        wg_dfb = ttl.make_dataflow_buffer_like(
+            w_gate, shape=(K_tiles, N_tiles), block_count=1
+        )
+        bg_dfb = ttl.make_dataflow_buffer_like(
+            bias_gate, shape=(M_tiles, N_tiles), block_count=1
+        )
+        up_dfb = ttl.make_dataflow_buffer_like(
+            up, shape=(M_tiles, K_tiles), block_count=1
+        )
+        wu_dfb = ttl.make_dataflow_buffer_like(
+            w_up, shape=(K_tiles, N_tiles), block_count=1
+        )
+        bu_dfb = ttl.make_dataflow_buffer_like(
+            bias_up, shape=(M_tiles, N_tiles), block_count=1
+        )
+        act_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(M_tiles, N_tiles), block_count=1
+        )
+        up_proj_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(M_tiles, N_tiles), block_count=1
+        )
+        out_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(M_tiles, N_tiles), block_count=1
+        )
 
         @ttl.compute()
         def compute():
@@ -58,16 +76,23 @@ def _make_kernel_silu(M_tiles, K_tiles, N_tiles):
 
         @ttl.datamovement()
         def dm_read():
-            with gate_dfb.reserve() as blk: ttl.copy(gate[0:M_tiles, 0:K_tiles], blk).wait()
-            with wg_dfb.reserve()   as blk: ttl.copy(w_gate[0:K_tiles, 0:N_tiles], blk).wait()
-            with bg_dfb.reserve()   as blk: ttl.copy(bias_gate[0:M_tiles, 0:N_tiles], blk).wait()
-            with up_dfb.reserve()   as blk: ttl.copy(up[0:M_tiles, 0:K_tiles], blk).wait()
-            with wu_dfb.reserve()   as blk: ttl.copy(w_up[0:K_tiles, 0:N_tiles], blk).wait()
-            with bu_dfb.reserve()   as blk: ttl.copy(bias_up[0:M_tiles, 0:N_tiles], blk).wait()
+            with gate_dfb.reserve() as blk:
+                ttl.copy(gate[0:M_tiles, 0:K_tiles], blk).wait()
+            with wg_dfb.reserve() as blk:
+                ttl.copy(w_gate[0:K_tiles, 0:N_tiles], blk).wait()
+            with bg_dfb.reserve() as blk:
+                ttl.copy(bias_gate[0:M_tiles, 0:N_tiles], blk).wait()
+            with up_dfb.reserve() as blk:
+                ttl.copy(up[0:M_tiles, 0:K_tiles], blk).wait()
+            with wu_dfb.reserve() as blk:
+                ttl.copy(w_up[0:K_tiles, 0:N_tiles], blk).wait()
+            with bu_dfb.reserve() as blk:
+                ttl.copy(bias_up[0:M_tiles, 0:N_tiles], blk).wait()
 
         @ttl.datamovement()
         def dm_write():
-            with out_dfb.wait() as blk: ttl.copy(blk, out[0:M_tiles, 0:N_tiles]).wait()
+            with out_dfb.wait() as blk:
+                ttl.copy(blk, out[0:M_tiles, 0:N_tiles]).wait()
 
     return kernel
 
@@ -75,15 +100,33 @@ def _make_kernel_silu(M_tiles, K_tiles, N_tiles):
 def _make_kernel_gelu(M_tiles, K_tiles, N_tiles):
     @ttl.operation(grid=(1, 1))
     def kernel(gate, w_gate, bias_gate, up, w_up, bias_up, out):
-        gate_dfb    = ttl.make_dataflow_buffer_like(gate,      shape=(M_tiles, K_tiles), block_count=1)
-        wg_dfb      = ttl.make_dataflow_buffer_like(w_gate,    shape=(K_tiles, N_tiles), block_count=1)
-        bg_dfb      = ttl.make_dataflow_buffer_like(bias_gate, shape=(M_tiles, N_tiles), block_count=1)
-        up_dfb      = ttl.make_dataflow_buffer_like(up,        shape=(M_tiles, K_tiles), block_count=1)
-        wu_dfb      = ttl.make_dataflow_buffer_like(w_up,      shape=(K_tiles, N_tiles), block_count=1)
-        bu_dfb      = ttl.make_dataflow_buffer_like(bias_up,   shape=(M_tiles, N_tiles), block_count=1)
-        act_dfb     = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
-        up_proj_dfb = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
-        out_dfb     = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
+        gate_dfb = ttl.make_dataflow_buffer_like(
+            gate, shape=(M_tiles, K_tiles), block_count=1
+        )
+        wg_dfb = ttl.make_dataflow_buffer_like(
+            w_gate, shape=(K_tiles, N_tiles), block_count=1
+        )
+        bg_dfb = ttl.make_dataflow_buffer_like(
+            bias_gate, shape=(M_tiles, N_tiles), block_count=1
+        )
+        up_dfb = ttl.make_dataflow_buffer_like(
+            up, shape=(M_tiles, K_tiles), block_count=1
+        )
+        wu_dfb = ttl.make_dataflow_buffer_like(
+            w_up, shape=(K_tiles, N_tiles), block_count=1
+        )
+        bu_dfb = ttl.make_dataflow_buffer_like(
+            bias_up, shape=(M_tiles, N_tiles), block_count=1
+        )
+        act_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(M_tiles, N_tiles), block_count=1
+        )
+        up_proj_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(M_tiles, N_tiles), block_count=1
+        )
+        out_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(M_tiles, N_tiles), block_count=1
+        )
 
         @ttl.compute()
         def compute():
@@ -99,16 +142,23 @@ def _make_kernel_gelu(M_tiles, K_tiles, N_tiles):
 
         @ttl.datamovement()
         def dm_read():
-            with gate_dfb.reserve() as blk: ttl.copy(gate[0:M_tiles, 0:K_tiles], blk).wait()
-            with wg_dfb.reserve()   as blk: ttl.copy(w_gate[0:K_tiles, 0:N_tiles], blk).wait()
-            with bg_dfb.reserve()   as blk: ttl.copy(bias_gate[0:M_tiles, 0:N_tiles], blk).wait()
-            with up_dfb.reserve()   as blk: ttl.copy(up[0:M_tiles, 0:K_tiles], blk).wait()
-            with wu_dfb.reserve()   as blk: ttl.copy(w_up[0:K_tiles, 0:N_tiles], blk).wait()
-            with bu_dfb.reserve()   as blk: ttl.copy(bias_up[0:M_tiles, 0:N_tiles], blk).wait()
+            with gate_dfb.reserve() as blk:
+                ttl.copy(gate[0:M_tiles, 0:K_tiles], blk).wait()
+            with wg_dfb.reserve() as blk:
+                ttl.copy(w_gate[0:K_tiles, 0:N_tiles], blk).wait()
+            with bg_dfb.reserve() as blk:
+                ttl.copy(bias_gate[0:M_tiles, 0:N_tiles], blk).wait()
+            with up_dfb.reserve() as blk:
+                ttl.copy(up[0:M_tiles, 0:K_tiles], blk).wait()
+            with wu_dfb.reserve() as blk:
+                ttl.copy(w_up[0:K_tiles, 0:N_tiles], blk).wait()
+            with bu_dfb.reserve() as blk:
+                ttl.copy(bias_up[0:M_tiles, 0:N_tiles], blk).wait()
 
         @ttl.datamovement()
         def dm_write():
-            with out_dfb.wait() as blk: ttl.copy(blk, out[0:M_tiles, 0:N_tiles]).wait()
+            with out_dfb.wait() as blk:
+                ttl.copy(blk, out[0:M_tiles, 0:N_tiles]).wait()
 
     return kernel
 
@@ -116,15 +166,33 @@ def _make_kernel_gelu(M_tiles, K_tiles, N_tiles):
 def _make_kernel_relu2(M_tiles, K_tiles, N_tiles):
     @ttl.operation(grid=(1, 1))
     def kernel(gate, w_gate, bias_gate, up, w_up, bias_up, out):
-        gate_dfb    = ttl.make_dataflow_buffer_like(gate,      shape=(M_tiles, K_tiles), block_count=1)
-        wg_dfb      = ttl.make_dataflow_buffer_like(w_gate,    shape=(K_tiles, N_tiles), block_count=1)
-        bg_dfb      = ttl.make_dataflow_buffer_like(bias_gate, shape=(M_tiles, N_tiles), block_count=1)
-        up_dfb      = ttl.make_dataflow_buffer_like(up,        shape=(M_tiles, K_tiles), block_count=1)
-        wu_dfb      = ttl.make_dataflow_buffer_like(w_up,      shape=(K_tiles, N_tiles), block_count=1)
-        bu_dfb      = ttl.make_dataflow_buffer_like(bias_up,   shape=(M_tiles, N_tiles), block_count=1)
-        act_dfb     = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
-        up_proj_dfb = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
-        out_dfb     = ttl.make_dataflow_buffer_like(out,       shape=(M_tiles, N_tiles), block_count=1)
+        gate_dfb = ttl.make_dataflow_buffer_like(
+            gate, shape=(M_tiles, K_tiles), block_count=1
+        )
+        wg_dfb = ttl.make_dataflow_buffer_like(
+            w_gate, shape=(K_tiles, N_tiles), block_count=1
+        )
+        bg_dfb = ttl.make_dataflow_buffer_like(
+            bias_gate, shape=(M_tiles, N_tiles), block_count=1
+        )
+        up_dfb = ttl.make_dataflow_buffer_like(
+            up, shape=(M_tiles, K_tiles), block_count=1
+        )
+        wu_dfb = ttl.make_dataflow_buffer_like(
+            w_up, shape=(K_tiles, N_tiles), block_count=1
+        )
+        bu_dfb = ttl.make_dataflow_buffer_like(
+            bias_up, shape=(M_tiles, N_tiles), block_count=1
+        )
+        act_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(M_tiles, N_tiles), block_count=1
+        )
+        up_proj_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(M_tiles, N_tiles), block_count=1
+        )
+        out_dfb = ttl.make_dataflow_buffer_like(
+            out, shape=(M_tiles, N_tiles), block_count=1
+        )
 
         @ttl.compute()
         def compute():
@@ -141,25 +209,40 @@ def _make_kernel_relu2(M_tiles, K_tiles, N_tiles):
 
         @ttl.datamovement()
         def dm_read():
-            with gate_dfb.reserve() as blk: ttl.copy(gate[0:M_tiles, 0:K_tiles], blk).wait()
-            with wg_dfb.reserve()   as blk: ttl.copy(w_gate[0:K_tiles, 0:N_tiles], blk).wait()
-            with bg_dfb.reserve()   as blk: ttl.copy(bias_gate[0:M_tiles, 0:N_tiles], blk).wait()
-            with up_dfb.reserve()   as blk: ttl.copy(up[0:M_tiles, 0:K_tiles], blk).wait()
-            with wu_dfb.reserve()   as blk: ttl.copy(w_up[0:K_tiles, 0:N_tiles], blk).wait()
-            with bu_dfb.reserve()   as blk: ttl.copy(bias_up[0:M_tiles, 0:N_tiles], blk).wait()
+            with gate_dfb.reserve() as blk:
+                ttl.copy(gate[0:M_tiles, 0:K_tiles], blk).wait()
+            with wg_dfb.reserve() as blk:
+                ttl.copy(w_gate[0:K_tiles, 0:N_tiles], blk).wait()
+            with bg_dfb.reserve() as blk:
+                ttl.copy(bias_gate[0:M_tiles, 0:N_tiles], blk).wait()
+            with up_dfb.reserve() as blk:
+                ttl.copy(up[0:M_tiles, 0:K_tiles], blk).wait()
+            with wu_dfb.reserve() as blk:
+                ttl.copy(w_up[0:K_tiles, 0:N_tiles], blk).wait()
+            with bu_dfb.reserve() as blk:
+                ttl.copy(bias_up[0:M_tiles, 0:N_tiles], blk).wait()
 
         @ttl.datamovement()
         def dm_write():
-            with out_dfb.wait() as blk: ttl.copy(blk, out[0:M_tiles, 0:N_tiles]).wait()
+            with out_dfb.wait() as blk:
+                ttl.copy(blk, out[0:M_tiles, 0:N_tiles]).wait()
 
     return kernel
 
 
-_BUILDERS = {"silu": _make_kernel_silu, "gelu": _make_kernel_gelu, "relu2": _make_kernel_relu2}
+_BUILDERS = {
+    "silu": _make_kernel_silu,
+    "gelu": _make_kernel_gelu,
+    "relu2": _make_kernel_relu2,
+}
 
 
-def make_swiglu_kernel(M_tiles: int, K_tiles: int, N_tiles: int, activation: str = "silu"):
+def make_swiglu_kernel(
+    M_tiles: int, K_tiles: int, N_tiles: int, activation: str = "silu"
+):
     """Return a compiled SwiGLU/GLU kernel for the given tile dimensions."""
     if activation not in _ACTIVATIONS:
-        raise ValueError(f"activation must be one of {set(_ACTIVATIONS)}, got {activation!r}")
+        raise ValueError(
+            f"activation must be one of {set(_ACTIVATIONS)}, got {activation!r}"
+        )
     return _BUILDERS[activation](M_tiles, K_tiles, N_tiles)

--- a/tt_inference_server/dispatch/model_matrix.toml
+++ b/tt_inference_server/dispatch/model_matrix.toml
@@ -1,0 +1,453 @@
+# model_matrix.toml — Runtime dispatch config
+# Authoritative for the models it LISTS; not a gate on what can run (two-tier resolution, #3):
+#   1. Matrix entry present -> resolve config + capabilities from it (trusted, hw-tuned).
+#   2. No entry (novel model) -> auto-derive from the HF config (the runner's introspection),
+#      gated --unsafe and labeled community. The matrix OVERRIDES auto-detection; it never
+#      removes the ability to run an unlisted model whose weights are introspectable.
+# Resolved once at load_model() time by KernelDispatcher.
+#
+# status field:
+#   "validated"  — tested end-to-end on hardware, PCC verified. Served without warnings.
+#   "community"  — architecture known but correctness unverified. Requires --unsafe to load.
+#
+# Dispatcher validates at load:
+#   1. schema_version matches DISPATCHER_SCHEMA_VERSION
+#   2. n_heads % n_kv_heads == 0 for every entry
+#   3. Every validated entry has n_heads >= 1
+#
+# Behavioral fields (schema v2, #3) — override the runner's HF-config introspection.
+# Each defaults to today's HF-derived value, so an omitted field is a no-op:
+#   norm_type         rmsnorm | layernorm | gemma_rms        (default rmsnorm)
+#   activation        silu | gelu | gelu_tanh | relu2        (default silu)
+#   rotary_pct        1.0 full | 0.25 partial rope           (default 1.0)
+#   attn_bias         qkv + o-proj bias present              (default false)
+#   head_norm         per-head q/k RMSNorm (Qwen3/Gemma3)    (default false)
+#   parallel_residual attn+MLP share pre-norm (GPTNeoX)      (default false)
+#   embed_scale       none | sqrt_hidden (Gemma)             (default none)
+#   attn_backend      ttnn | custom | cpu (#34)              (default ttnn)
+# fast_path / lm_head_ondevice are DERIVED from these by ModelMatrixEntry.capabilities().
+#
+# Granite architectural scaling factors (schema v3, #43). Omit = fall through to the HF
+# config value (no-op for non-Granite); set = OVERRIDES it. Read by runner._scaling_factor():
+#   embedding_multiplier   scales input embeddings
+#   residual_multiplier    scales each sublayer output before its residual add
+#   attention_multiplier   overrides the 1/sqrt(head_dim) attention softmax scale
+#   logits_scaling         divides final logits (no-op for greedy argmax)
+#
+# Do not edit ttl_kernels/configs/ — that is the legacy POC reference only.
+
+schema_version = 3
+
+# ---------------------------------------------------------------------------
+# Llama 3 family (Meta)
+# ---------------------------------------------------------------------------
+
+[[model]]
+name              = "meta-llama/Llama-3-8B-Instruct"
+arch              = "LlamaForCausalLM"
+local_path        = "models/llama3-8b"
+hidden_size       = 4096
+intermediate_size = 14336
+n_layers          = 32
+vocab_size        = 128256
+n_heads           = 32
+n_kv_heads        = 8
+head_dim          = 128
+max_seq           = 2048
+rope_theta        = 500000.0
+swa_window        = -1
+tie_embeddings    = false
+kernels           = ["flash_attn", "rmsnorm"]
+min_hw            = "bh_p150_1card"
+status            = "validated"
+norm_type         = "rmsnorm"
+activation        = "silu"
+rotary_pct        = 1.0
+attn_bias         = false
+head_norm         = false
+parallel_residual = false
+embed_scale       = "none"
+attn_backend      = "ttnn"
+notes             = "Baseline reference model. GQA 8 KV heads. fast_path eligible."
+
+[[model]]
+name              = "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+arch              = "LlamaForCausalLM"
+local_path        = "models/deepseek-ai--DeepSeek-R1-Distill-Llama-8B"
+hidden_size       = 4096
+intermediate_size = 14336
+n_layers          = 32
+vocab_size        = 128256
+n_heads           = 32
+n_kv_heads        = 8
+head_dim          = 128
+max_seq           = 2048
+rope_theta        = 500000.0
+swa_window        = -1
+tie_embeddings    = false
+kernels           = ["flash_attn", "rmsnorm"]
+min_hw            = "bh_p150_1card"
+status            = "validated"
+norm_type         = "rmsnorm"
+activation        = "silu"
+rotary_pct        = 1.0
+attn_bias         = false
+head_norm         = false
+parallel_residual = false
+embed_scale       = "none"
+attn_backend      = "ttnn"
+notes             = "Llama 3 8B fine-tune. Identical kernel config to llama3-8b. fast_path eligible."
+
+# ---------------------------------------------------------------------------
+# Qwen 2.5 family (Alibaba)
+# ---------------------------------------------------------------------------
+
+[[model]]
+name              = "Qwen/Qwen2.5-7B-Instruct"
+arch              = "Qwen2ForCausalLM"
+local_path        = "models/qwen2.5-7b"
+hidden_size       = 3584
+intermediate_size = 18944
+n_layers          = 28
+vocab_size        = 152064
+n_heads           = 28
+n_kv_heads        = 4
+head_dim          = 128
+max_seq           = 2048
+rope_theta        = 1000000.0
+swa_window        = 131072
+tie_embeddings    = false
+kernels           = ["flash_attn", "rmsnorm"]
+min_hw            = "bh_p150_1card"
+status            = "validated"
+issue             = 22
+norm_type         = "rmsnorm"
+activation        = "silu"
+rotary_pct        = 1.0
+attn_bias         = true
+head_norm         = false
+parallel_residual = false
+embed_scale       = "none"
+attn_backend      = "custom"
+notes             = "BUG-MISTRAL-01: degenerate output, tracked in #22. swa_window=131072 is effectively full attention at max_seq=2048. Qwen2 has qkv bias (attn_bias=true); GQA group=7 does not divide 32 -> attn_backend=custom, fast_path NOT eligible."
+
+# ---------------------------------------------------------------------------
+# Mistral family (Mistral AI)
+# ---------------------------------------------------------------------------
+
+[[model]]
+name              = "mistralai/Mistral-7B-v0.3"
+arch              = "MistralForCausalLM"
+local_path        = "models/mistral-7b"
+hidden_size       = 4096
+intermediate_size = 14336
+n_layers          = 32
+vocab_size        = 32768
+n_heads           = 32
+n_kv_heads        = 8
+head_dim          = 128
+max_seq           = 2048
+rope_theta        = 1000000.0
+swa_window        = -1
+tie_embeddings    = false
+kernels           = ["flash_attn", "rmsnorm"]
+min_hw            = "bh_p150_1card"
+status            = "validated"
+issue             = 22
+norm_type         = "rmsnorm"
+activation        = "silu"
+rotary_pct        = 1.0
+attn_bias         = false
+head_norm         = false
+parallel_residual = false
+embed_scale       = "none"
+attn_backend      = "ttnn"
+notes             = "BUG-MISTRAL-01: hidden-state divergence produces degenerate output. v0.3 has no SWA (removed from v0.1) and rope_theta=1e6. fast_path eligible (the #22 bug is numeric, not a path-eligibility issue)."
+
+# ---------------------------------------------------------------------------
+# Gemma 2 family (Google)
+# ---------------------------------------------------------------------------
+
+[[model]]
+name              = "google/gemma-2-2b-it"
+arch              = "Gemma2ForCausalLM"
+local_path        = "models/google-gemma-2-2b-it"
+hidden_size       = 2304
+intermediate_size = 9216
+n_layers          = 26
+vocab_size        = 256000
+n_heads           = 8
+n_kv_heads        = 4
+head_dim          = 256
+max_seq           = 2048
+rope_theta        = 10000.0
+swa_window        = 4096
+tie_embeddings    = true
+kernels           = ["flash_attn", "rmsnorm"]
+min_hw            = "bh_p150_1card"
+status            = "validated"
+issue             = 10
+norm_type         = "gemma_rms"
+activation        = "gelu_tanh"
+rotary_pct        = 1.0
+attn_bias         = false
+head_norm         = false
+parallel_residual = false
+embed_scale       = "sqrt_hidden"
+attn_backend      = "ttnn"
+notes             = "L1 budget borderline due to head_dim=256 (8 tiles). CPU fallback active via #10. 2B variant on disk (not 9B). gemma_rms (4-norm (1+w)) + gelu_tanh + sqrt(hidden) embed scaling -> fast_path NOT eligible (CPU-RoPE + flash_attn path)."
+
+# ---------------------------------------------------------------------------
+# Phi-3.5 family (Microsoft)
+# ---------------------------------------------------------------------------
+
+[[model]]
+name              = "microsoft/Phi-3.5-mini-instruct"
+arch              = "Phi3ForCausalLM"
+local_path        = "models/microsoft-Phi-3.5-mini-instruct"
+hidden_size       = 3072
+intermediate_size = 8192
+n_layers          = 32
+vocab_size        = 32064
+n_heads           = 32
+n_kv_heads        = 32
+head_dim          = 96
+max_seq           = 2048
+rope_theta        = 10000.0
+swa_window        = 262144
+tie_embeddings    = false
+kernels           = ["flash_attn", "rmsnorm"]
+min_hw            = "bh_p150_1card"
+status            = "validated"
+norm_type         = "rmsnorm"
+activation        = "silu"
+rotary_pct        = 1.0
+attn_bias         = false
+head_norm         = false
+parallel_residual = false
+embed_scale       = "none"
+attn_backend      = "ttnn"
+notes             = "MHA (no GQA, n_kv_heads=n_heads=32). swa_window=262144 is effectively full attention at max_seq=2048. head_dim=96 (3 tiles). fast_path eligible."
+
+# ---------------------------------------------------------------------------
+# OLMo family (AllenAI)
+# ---------------------------------------------------------------------------
+
+[[model]]
+name              = "allenai/OLMo-1B-hf"
+arch              = "OlmoForCausalLM"
+local_path        = "models/allenai-OLMo-1B-hf"
+hidden_size       = 2048
+intermediate_size = 8192
+n_layers          = 16
+vocab_size        = 50304
+n_heads           = 16
+n_kv_heads        = 16
+head_dim          = 128
+max_seq           = 2048
+rope_theta        = 10000.0
+swa_window        = -1
+tie_embeddings    = true
+kernels           = ["flash_attn", "rmsnorm"]
+min_hw            = "bh_p150_1card"
+status            = "validated"
+norm_type         = "rmsnorm"
+activation        = "silu"
+rotary_pct        = 1.0
+attn_bias         = false
+head_norm         = false
+parallel_residual = false
+embed_scale       = "none"
+attn_backend      = "ttnn"
+notes             = "MHA nh=nkv=16 (group=1), non-parametric LayerNorm runs on the RMSNorm path today (no learned weight/bias) so norm_type=rmsnorm reproduces current behavior. vocab 50304 is tile-aligned. fast_path eligible (nh<32 proportional-pad path)."
+
+# ---------------------------------------------------------------------------
+# NOTE: Falcon-7b absent by design
+# Falcon-7b uses N_heads=71 (prime). _grid_shape(71) has only factorization
+# (1, 71) but y-axis limit is 10, so it cannot map to the 13×10 Tensix grid
+# using 1 core per head. Requires a multi-head-per-core loop kernel or a
+# different dispatch strategy. Track in a dedicated issue before claiming
+# Falcon-7b support.
+# Falcon-rw-1b (N_heads=16, MQA N_kv=1) is a separate model and may be
+# supportable — open a port issue before adding it here.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# GPTNeoX family (EleutherAI)
+# ---------------------------------------------------------------------------
+
+[[model]]
+name              = "EleutherAI/pythia-2.8b"
+arch              = "GPTNeoXForCausalLM"
+local_path        = "models/EleutherAI-pythia-2.8b"
+hidden_size       = 2560
+intermediate_size = 10240
+n_layers          = 32
+vocab_size        = 50304
+n_heads           = 32
+n_kv_heads        = 32
+head_dim          = 80
+max_seq           = 2048
+rope_theta        = 10000.0
+swa_window        = -1
+tie_embeddings    = false
+kernels           = ["flash_attn", "layernorm"]
+min_hw            = "bh_p150_1card"
+status            = "validated"
+issue             = 11
+norm_type         = "layernorm"
+activation        = "gelu"
+rotary_pct        = 0.25
+attn_bias         = true
+head_norm         = false
+parallel_residual = true
+embed_scale       = "none"
+attn_backend      = "custom"
+notes             = "VALIDATED 2026-06-12 (#27). LayerNorm (mean-sub+bias), partial rotary (0.25), parallel residual, and qkv+o-proj+MLP bias all handled correctly. The fix was generic presence-driven bias support (the runner had dropped o-proj/MLP biases). activation='gelu' is exact-erf (GPTNeoX), not the tanh approx. Verified vs HF fp32: 14 exact greedy tokens then a benign near-tie; 80-tok coherent @ 7.79 tok/s, cpu_fallbacks=0. head_dim=80 padded to 96 tiles; layernorm+partial-rope+bias+parallel-residual -> fast_path NOT eligible (CPU-readback baseline)."
+
+# ---------------------------------------------------------------------------
+# BLOOM family (BigScience) — ALiBi (no RoPE), LayerNorm, fused interleaved QKV
+# ---------------------------------------------------------------------------
+
+[[model]]
+name              = "bigscience/bloom-3b"
+arch              = "BloomForCausalLM"
+local_path        = "models/bigscience-bloom-3b"
+hidden_size       = 2560
+intermediate_size = 10240
+n_layers          = 30
+vocab_size        = 250880
+n_heads           = 32
+n_kv_heads        = 32
+head_dim          = 80
+max_seq           = 2048
+rope_theta        = 10000.0
+swa_window        = -1
+tie_embeddings    = true
+kernels           = ["flash_attn", "layernorm"]
+min_hw            = "bh_p150_1card"
+status            = "validated"
+issue             = 9
+norm_type         = "layernorm"
+activation        = "gelu_tanh"
+rotary_pct        = 1.0
+attn_bias         = true
+head_norm         = false
+parallel_residual = false
+embed_scale       = "none"
+attn_backend      = "cpu"
+notes             = "VALIDATED 2026-06-12 (#9 correctness, #27/#29). BLOOM has NO RoPE — it uses per-head ALiBi positional bias, which the shared-mask flash_attn kernel can't express, so attention runs on a CPU softmax+ALiBi path from the K/V history mirrors (attn_backend=cpu). Also: word_embeddings_layernorm applied after embed, sequential LayerNorm (mean-sub+bias), qkv+o-proj+MLP bias, and tanh-approx BloomGelu (activation=gelu_tanh; BLOOM carries no hidden_act and was mis-derived as silu). Verified vs HF fp32: per-layer cos 0.999+ across all 30 layers; 8 exact greedy tokens; 'capital of France' -> coherent factual completion @ 4.55 tok/s, cpu_fallbacks=0. Hardware-native per-head-mask ALiBi (flash_attn kernel extension) is a perf follow-on. NOT fast-path eligible."
+
+# ---------------------------------------------------------------------------
+# Falcon family (TII) — ALiBi (no RoPE), LayerNorm, fused interleaved QKV.
+# Like BLOOM but ALiBi bias is scaled by 1/sqrt(head_dim) (beta=inv_norm_factor).
+# ---------------------------------------------------------------------------
+
+[[model]]
+name              = "tiiuae/falcon-rw-1b"
+arch              = "FalconForCausalLM"
+local_path        = "models/tiiuae-falcon-rw-1b"
+hidden_size       = 2048
+intermediate_size = 8192
+n_layers          = 24
+vocab_size        = 50304
+n_heads           = 32
+n_kv_heads        = 32
+head_dim          = 64
+max_seq           = 2048
+rope_theta        = 10000.0
+swa_window        = -1
+tie_embeddings    = true
+kernels           = ["flash_attn", "layernorm"]
+min_hw            = "bh_p150_1card"
+status            = "validated"
+issue             = 41
+norm_type         = "layernorm"
+activation        = "gelu"
+rotary_pct        = 1.0
+attn_bias         = true
+head_norm         = false
+parallel_residual = false
+embed_scale       = "none"
+attn_backend      = "cpu"
+notes             = "VALIDATED 2026-06-12 (#41). Falcon-rw-1b has NO RoPE — per-head ALiBi positional bias on a CPU softmax+ALiBi path (attn_backend=cpu), same as BLOOM. Two bugs fixed: (1) activation mis-derived as silu — Falcon carries no hidden_act and uses exact-erf GELU (FalconMLP nn.GELU); deriver special-cases model_type=='falcon'->'gelu'. (2) ALiBi bias magnitude — unlike BLOOM (beta=1.0), Falcon's HF attention uses beta=inv_norm_factor=1/sqrt(head_dim)=0.125, so the per-head slope bias was ~8x too strong and degenerated output; _attention_cpu_alibi now scales by _alibi_beta. Sequential LayerNorm (mean-sub+bias, parallel_attn=false), fused interleaved query_key_value, qkv+o-proj+MLP bias. NO word_embeddings_layernorm (unlike BLOOM). Verified vs HF fp32: 20/25 exact greedy tokens then a benign bf16 near-tie; 80-tok coherent ('The theory of relativity is a theory of the motion of bodies in the universe...') @ 13.1 tok/s, cpu_fallbacks=0. Base (non-instruct) model so greedy phrase-loops — model behavior, HF loops identically. Hardware-native per-head-mask ALiBi = #40. NOT fast-path eligible."
+
+# ---------------------------------------------------------------------------
+# StarCoder2 family (BigCode)
+# ---------------------------------------------------------------------------
+
+[[model]]
+name              = "bigcode/starcoder2-3b"
+arch              = "Starcoder2ForCausalLM"
+local_path        = "models/bigcode-starcoder2-3b"
+hidden_size       = 3072
+intermediate_size = 12288
+n_layers          = 30
+vocab_size        = 49152
+n_heads           = 24
+n_kv_heads        = 2
+head_dim          = 128
+max_seq           = 2048
+rope_theta        = 1000000.0
+swa_window        = -1
+tie_embeddings    = true
+kernels           = ["flash_attn", "layernorm"]
+min_hw            = "bh_p150_1card"
+status            = "validated"
+norm_type         = "layernorm"
+activation        = "gelu_tanh"
+rotary_pct        = 1.0
+attn_bias         = true
+head_norm         = false
+parallel_residual = false
+embed_scale       = "none"
+attn_backend      = "custom"
+notes             = "VALIDATED 2026-06-12 (#27/#29), fixed alongside GPTNeoX/BLOOM. StarCoder2 has qkv+o-proj+MLP bias, sequential LayerNorm, and gelu_pytorch_tanh — all three were wrong (dropped o-proj/MLP biases, RMSNorm-instead-of-LayerNorm on the sequential branch, exact-erf instead of tanh GELU). Verified COHERENT 2026-06-12: 'def fibonacci(n):' -> correct recursive impl @ 7.11 tok/s, cpu_fallbacks=0. GQA group=12 does not divide 32 -> attn_backend=custom, NOT fast-path eligible."
+
+# ---------------------------------------------------------------------------
+# Granite family (IBM) — Llama-like + architectural scaling factors
+# ---------------------------------------------------------------------------
+
+[[model]]
+name                 = "ibm-granite/granite-3.1-2b-instruct"
+arch                 = "GraniteForCausalLM"
+local_path           = "models/ibm-granite-granite-3.1-2b-instruct"
+hidden_size          = 2048
+intermediate_size    = 8192
+n_layers             = 40
+vocab_size           = 49155
+n_heads              = 32
+n_kv_heads           = 8
+head_dim             = 64
+max_seq              = 2048
+rope_theta           = 5000000.0
+swa_window           = -1
+tie_embeddings       = true
+kernels              = ["flash_attn", "rmsnorm"]
+min_hw               = "bh_p150_1card"
+status               = "validated"
+norm_type            = "rmsnorm"
+activation           = "silu"
+rotary_pct           = 1.0
+attn_bias            = false
+head_norm            = false
+parallel_residual    = false
+embed_scale          = "none"
+attn_backend         = "ttnn"
+embedding_multiplier = 12.0
+residual_multiplier  = 0.22
+attention_multiplier = 0.015625
+logits_scaling       = 8.0
+notes                = "VALIDATED 2026-06-12 (#43). Granite needs four architectural scaling factors plain Llama lacks; the runner applied none, producing garbage. attention_multiplier=0.015625 (=1/64) replaces the default 1/sqrt(64)=0.125 (scores were 8x too large); embedding_multiplier scales embeds 12x; residual_multiplier scales each sublayer output 0.22 before its residual add; logits_scaling divides logits (no-op for greedy argmax). Verified vs HF fp32 greedy: 20/20 exact tokens on BOTH baseline and traced fast path ('The theory of relativity, proposed by Albert Einstein, consists of two parts'), cpu_fallbacks=0. fast_path eligible (rmsnorm, full rope, no head-norm, nh=32 MHA, GQA group=4 | 32)."
+
+# ---------------------------------------------------------------------------
+# Hardware target
+# ---------------------------------------------------------------------------
+
+[hardware]
+card            = "bh_p150"
+tensix_cores    = 120
+l1_budget_bytes = 1_440_000
+pcie_gen        = 5
+device_ids      = [0]
+notes           = "Single Blackhole p150. Multi-card support tracked in #17."

--- a/tt_inference_server/dispatch/output_validator.py
+++ b/tt_inference_server/dispatch/output_validator.py
@@ -40,18 +40,19 @@ from dataclasses import dataclass
 from typing import Optional, Sequence, Tuple
 
 # --- Named thresholds (promoted from the inline magic numbers) -------------
-VALIDATION_MIN_TOKENS = 10          # reject runs shorter than this many tokens
-TOKEN_REPETITION_FRACTION = 0.5     # >50% of token ids being one id => loop
-PHRASE_LOOP_MIN_WORDS = 12          # only run the n-gram check on enough words
-PHRASE_LOOP_NGRAMS = (1, 2, 3)      # n-gram sizes scanned for phrase loops
-PHRASE_LOOP_FRACTION = 0.30         # one n-gram covering >30% of grams => loop
-EXOTIC_CHAR_LIMIT = 3               # >this many non-Latin letters => garbage
-PUNCT_FRACTION = 0.40               # >40% non-alphanumeric (non-space) => soup
+VALIDATION_MIN_TOKENS = 10  # reject runs shorter than this many tokens
+TOKEN_REPETITION_FRACTION = 0.5  # >50% of token ids being one id => loop
+PHRASE_LOOP_MIN_WORDS = 12  # only run the n-gram check on enough words
+PHRASE_LOOP_NGRAMS = (1, 2, 3)  # n-gram sizes scanned for phrase loops
+PHRASE_LOOP_FRACTION = 0.30  # one n-gram covering >30% of grams => loop
+EXOTIC_CHAR_LIMIT = 3  # >this many non-Latin letters => garbage
+PUNCT_FRACTION = 0.40  # >40% non-alphanumeric (non-space) => soup
 
 
 @dataclass(frozen=True)
 class ValidatorThresholds:
     """Tunable thresholds for validate_output. Defaults reproduce the tuned cascade."""
+
     min_tokens: int = VALIDATION_MIN_TOKENS
     token_repetition_fraction: float = TOKEN_REPETITION_FRACTION
     phrase_loop_min_words: int = PHRASE_LOOP_MIN_WORDS
@@ -101,7 +102,7 @@ def validate_output(
     # 2. phrase-loop: a short n-gram repeated heavily (period > 1 loops)
     if len(words) >= t.phrase_loop_min_words:
         for ngram in t.phrase_loop_ngrams:
-            grams = [tuple(words[i:i + ngram]) for i in range(len(words) - ngram + 1)]
+            grams = [tuple(words[i : i + ngram]) for i in range(len(words) - ngram + 1)]
             if not grams:
                 continue
             _top, cnt = Counter(grams).most_common(1)[0]

--- a/tt_inference_server/dispatch/output_validator.py
+++ b/tt_inference_server/dispatch/output_validator.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared output validator for the dispatch benchmark/test harness (issue #46).
+
+Single source of truth for "did this model emit plausible English-prompt output,
+or degenerate garbage?". Import-only and dependency-free: NO ttnn, NO torch — so it
+can be unit-tested in CI with no Tenstorrent card and no model weights.
+
+The cascade is the one tuned offline against labeled good/garbage 80-tok samples
+(see tests/diagnostic/tune_validator.py, 12/12) PLUS the single-token-repetition
+check that tune_validator dropped — a documented true-positive that catches
+tokenizer-level loops the n-gram check can miss. Both bench harnesses
+(tests/_run_model.py and tt-inference-server/bench.py) delegate here.
+
+Signature:  validate_output(text, token_ids) -> (is_valid: bool, reason: str)
+
+The reason-string PREFIXES are a frozen contract — sweep/diff tooling parses them.
+Do not change the wording of an existing reason without updating that tooling:
+    "empty output"
+    "too short: <n> tokens"
+    "repetition loop (token)"
+    "repetition loop (<n>-gram x<count>)"
+    "garbage: <n> non-Latin (CJK/Arabic/etc) chars"
+    "garbage: <pct>% punctuation/symbols"
+    "ok"
+
+NOTE: the exotic-script / punctuation checks assume an ENGLISH-prompt smoke test.
+They gate the *bench verdict* only, never model admission — a deliberately
+multilingual or code-heavy novel model may need relaxed thresholds (pass a custom
+ValidatorThresholds), and a passing verdict is necessary-not-sufficient for
+degeneration-prone models (spot-check actual text; see BUG-MISTRAL-01).
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass
+from typing import Optional, Sequence, Tuple
+
+# --- Named thresholds (promoted from the inline magic numbers) -------------
+VALIDATION_MIN_TOKENS = 10          # reject runs shorter than this many tokens
+TOKEN_REPETITION_FRACTION = 0.5     # >50% of token ids being one id => loop
+PHRASE_LOOP_MIN_WORDS = 12          # only run the n-gram check on enough words
+PHRASE_LOOP_NGRAMS = (1, 2, 3)      # n-gram sizes scanned for phrase loops
+PHRASE_LOOP_FRACTION = 0.30         # one n-gram covering >30% of grams => loop
+EXOTIC_CHAR_LIMIT = 3               # >this many non-Latin letters => garbage
+PUNCT_FRACTION = 0.40               # >40% non-alphanumeric (non-space) => soup
+
+
+@dataclass(frozen=True)
+class ValidatorThresholds:
+    """Tunable thresholds for validate_output. Defaults reproduce the tuned cascade."""
+    min_tokens: int = VALIDATION_MIN_TOKENS
+    token_repetition_fraction: float = TOKEN_REPETITION_FRACTION
+    phrase_loop_min_words: int = PHRASE_LOOP_MIN_WORDS
+    phrase_loop_ngrams: Tuple[int, ...] = PHRASE_LOOP_NGRAMS
+    phrase_loop_fraction: float = PHRASE_LOOP_FRACTION
+    exotic_char_limit: int = EXOTIC_CHAR_LIMIT
+    punct_fraction: float = PUNCT_FRACTION
+
+
+DEFAULT_THRESHOLDS = ValidatorThresholds()
+
+
+def validate_output(
+    text: str,
+    token_ids: Optional[Sequence[int]],
+    thresholds: Optional[ValidatorThresholds] = None,
+) -> Tuple[bool, str]:
+    """Return (is_valid, reason). Conservative: only fail on strong garbage signals.
+
+    Args:
+        text: the decoded model continuation.
+        token_ids: the generated token id sequence. When None, the length and
+            single-token-repetition checks are SKIPPED (text-only mode, for callers
+            that don't have token ids, e.g. the legacy tt-inference-server/bench.py);
+            the caller is then responsible for asserting a minimum token count.
+        thresholds: optional override of the tuned defaults.
+    """
+    t = thresholds or DEFAULT_THRESHOLDS
+
+    if not text or not text.strip():
+        return False, "empty output"
+
+    # Length + single-token repetition only when token ids are supplied.
+    if token_ids is not None:
+        n = len(token_ids)
+        if n < t.min_tokens:
+            return False, f"too short: {n} tokens"
+        # 1. single-token repetition (cheap; catches tokenizer-level loops)
+        if n:
+            most_common_count = Counter(token_ids).most_common(1)[0][1]
+            if most_common_count / n > t.token_repetition_fraction:
+                return False, "repetition loop (token)"
+
+    s = text.strip()
+    words = s.split()
+
+    # 2. phrase-loop: a short n-gram repeated heavily (period > 1 loops)
+    if len(words) >= t.phrase_loop_min_words:
+        for ngram in t.phrase_loop_ngrams:
+            grams = [tuple(words[i:i + ngram]) for i in range(len(words) - ngram + 1)]
+            if not grams:
+                continue
+            _top, cnt = Counter(grams).most_common(1)[0]
+            if cnt / len(grams) > t.phrase_loop_fraction:
+                return False, f"repetition loop ({ngram}-gram x{cnt})"
+
+    # 3. exotic-script chars: correct English output has 0 CJK/Arabic/Devanagari/etc
+    exotic = sum(1 for c in s if c.isalpha() and "LATIN" not in unicodedata.name(c, ""))
+    if exotic > t.exotic_char_limit:
+        return False, f"garbage: {exotic} non-Latin (CJK/Arabic/etc) chars"
+
+    # 4. punctuation/symbol soup (real prose is mostly letters/digits/spaces)
+    nonspace = [c for c in s if not c.isspace()]
+    if nonspace:
+        punct = sum(1 for c in nonspace if not c.isalnum())
+        if punct / len(nonspace) > t.punct_fraction:
+            return False, f"garbage: {punct / len(nonspace):.0%} punctuation/symbols"
+
+    return True, "ok"
+
+
+__all__ = [
+    "validate_output",
+    "ValidatorThresholds",
+    "DEFAULT_THRESHOLDS",
+    "VALIDATION_MIN_TOKENS",
+    "TOKEN_REPETITION_FRACTION",
+    "PHRASE_LOOP_MIN_WORDS",
+    "PHRASE_LOOP_NGRAMS",
+    "PHRASE_LOOP_FRACTION",
+    "EXOTIC_CHAR_LIMIT",
+    "PUNCT_FRACTION",
+]

--- a/tt_inference_server/dispatch/registry.py
+++ b/tt_inference_server/dispatch/registry.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model family registry — auto-detect config from HuggingFace model config."""
+
+from __future__ import annotations
+
+from . import config_gemma3 as gemma3, config_llama3 as llama3, config_mistral as mistral, config_qwen2_5 as qwen2_5, config_qwen3 as qwen3
+from .config_qwen2_5 import ModelConfig
+from .config_mistral import MoEModelConfig
+
+# Maps HuggingFace architecture name → config module
+_FAMILY_MAP = {
+    "Qwen2ForCausalLM":   qwen2_5,
+    "Qwen3ForCausalLM":   qwen3,
+    "LlamaForCausalLM":   llama3,
+    "MistralForCausalLM": mistral,
+    "MixtralForCausalLM": mistral,
+    "Gemma3ForCausalLM":              gemma3,
+    "Gemma3ForConditionalGeneration": gemma3,
+    # Gemma 1 and 2 use same 4-norm pattern — reuse gemma3 config
+    "GemmaForCausalLM":  gemma3,
+    "Gemma2ForCausalLM": gemma3,
+}
+
+
+def detect_model_family(hf_config) -> ModelConfig:
+    """Detect model family and return a ModelConfig from a HuggingFace config.
+
+    Falls back to generic derivation from hf_config fields for unknown
+    architectures, so models we haven't seen before still get reasonable
+    defaults rather than failing outright.
+    """
+    archs = getattr(hf_config, "architectures", None) or []
+    arch = archs[0] if archs else ""
+
+    if arch in _FAMILY_MAP:
+        mod = _FAMILY_MAP[arch]
+        # Each config module exposes either ModelConfig or a family-named class
+        cfg_class = getattr(mod, "ModelConfig",
+                    getattr(mod, arch.replace("ForCausalLM", "Config"), None))
+        if cfg_class is not None:
+            return cfg_class.from_hf_config(hf_config)
+        return _from_hf_config_generic(hf_config)
+
+    # Unknown architecture: derive directly from standard HF config fields.
+    return _from_hf_config_generic(hf_config)
+
+
+def _from_hf_config_generic(hf_config) -> ModelConfig:
+    """Derive ModelConfig from standard HuggingFace config fields.
+
+    Reads the subset of fields that are present across nearly all transformer
+    configs. Missing fields fall back to safe defaults.
+    """
+    hidden = getattr(hf_config, "hidden_size", 4096)
+    n_heads = getattr(hf_config, "num_attention_heads", 32)
+    n_kv = getattr(hf_config, "num_key_value_heads", n_heads)
+    head_dim = getattr(hf_config, "head_dim", hidden // n_heads)
+    intermediate = getattr(hf_config, "intermediate_size", hidden * 4)
+
+    # Determine norm type from config fields. LayerNorm models carry a layer-norm
+    # epsilon under one of several field names (Falcon uses `layer_norm_epsilon`)
+    # and no `rms_norm_eps`.
+    norm_type = "rmsnorm"
+    has_ln_eps = (hasattr(hf_config, "layer_norm_eps")
+                  or hasattr(hf_config, "layer_norm_epsilon"))
+    if has_ln_eps and not hasattr(hf_config, "rms_norm_eps"):
+        norm_type = "layernorm"
+
+    # Determine activation. "gelu" is exact-erf (GPTNeoX); the *_new/_fast/_pytorch_tanh
+    # variants are the tanh approximation (distinguished from "gelu" so the runner can
+    # pick the matching ttnn.gelu mode).
+    act_map = {
+        "silu": "silu", "swish": "silu",
+        "gelu": "gelu",
+        "gelu_tanh": "gelu_tanh",
+        "gelu_new": "gelu_tanh", "gelu_fast": "gelu_tanh",
+        "gelu_pytorch_tanh": "gelu_tanh",
+        "relu": "relu2",
+    }
+    model_type = getattr(getattr(hf_config, "text_config", hf_config), "model_type", "")
+    hf_act = getattr(hf_config, "hidden_act", None)
+    if hf_act is None:
+        # Some arches carry no hidden_act and hardcode their MLP activation:
+        #   BLOOM  -> tanh-approx GELU (BloomGelu)
+        #   Falcon -> exact-erf GELU (nn.GELU in FalconMLP)
+        hf_act = {"bloom": "gelu_tanh", "falcon": "gelu"}.get(model_type, "silu")
+    activation = act_map.get(hf_act, "silu")
+
+    eps = getattr(hf_config, "rms_norm_eps",
+          getattr(hf_config, "layer_norm_eps",
+          getattr(hf_config, "layer_norm_epsilon", 1e-6)))
+
+    # MoE fields
+    num_experts = getattr(hf_config, "num_local_experts",
+                  getattr(hf_config, "num_experts", 0))
+    top_k = getattr(hf_config, "num_experts_per_tok",
+            getattr(hf_config, "top_k_experts", 2))
+
+    if num_experts > 0:
+        return MoEModelConfig(
+            hidden_size=hidden,
+            num_heads=n_heads,
+            num_kv_heads=n_kv,
+            head_dim=head_dim,
+            intermediate_size=intermediate,
+            norm_type=norm_type,
+            activation=activation,
+            norm_eps=eps,
+            num_experts=num_experts,
+            num_experts_per_tok=top_k,
+        )
+
+    return ModelConfig(
+        hidden_size=hidden,
+        num_heads=n_heads,
+        num_kv_heads=n_kv,
+        head_dim=head_dim,
+        intermediate_size=intermediate,
+        norm_type=norm_type,
+        activation=activation,
+        norm_eps=eps,
+    )

--- a/tt_inference_server/dispatch/registry.py
+++ b/tt_inference_server/dispatch/registry.py
@@ -5,21 +5,27 @@
 
 from __future__ import annotations
 
-from . import config_gemma3 as gemma3, config_llama3 as llama3, config_mistral as mistral, config_qwen2_5 as qwen2_5, config_qwen3 as qwen3
+from . import (
+    config_gemma3 as gemma3,
+    config_llama3 as llama3,
+    config_mistral as mistral,
+    config_qwen2_5 as qwen2_5,
+    config_qwen3 as qwen3,
+)
 from .config_qwen2_5 import ModelConfig
 from .config_mistral import MoEModelConfig
 
 # Maps HuggingFace architecture name → config module
 _FAMILY_MAP = {
-    "Qwen2ForCausalLM":   qwen2_5,
-    "Qwen3ForCausalLM":   qwen3,
-    "LlamaForCausalLM":   llama3,
+    "Qwen2ForCausalLM": qwen2_5,
+    "Qwen3ForCausalLM": qwen3,
+    "LlamaForCausalLM": llama3,
     "MistralForCausalLM": mistral,
     "MixtralForCausalLM": mistral,
-    "Gemma3ForCausalLM":              gemma3,
+    "Gemma3ForCausalLM": gemma3,
     "Gemma3ForConditionalGeneration": gemma3,
     # Gemma 1 and 2 use same 4-norm pattern — reuse gemma3 config
-    "GemmaForCausalLM":  gemma3,
+    "GemmaForCausalLM": gemma3,
     "Gemma2ForCausalLM": gemma3,
 }
 
@@ -37,8 +43,11 @@ def detect_model_family(hf_config) -> ModelConfig:
     if arch in _FAMILY_MAP:
         mod = _FAMILY_MAP[arch]
         # Each config module exposes either ModelConfig or a family-named class
-        cfg_class = getattr(mod, "ModelConfig",
-                    getattr(mod, arch.replace("ForCausalLM", "Config"), None))
+        cfg_class = getattr(
+            mod,
+            "ModelConfig",
+            getattr(mod, arch.replace("ForCausalLM", "Config"), None),
+        )
         if cfg_class is not None:
             return cfg_class.from_hf_config(hf_config)
         return _from_hf_config_generic(hf_config)
@@ -63,8 +72,9 @@ def _from_hf_config_generic(hf_config) -> ModelConfig:
     # epsilon under one of several field names (Falcon uses `layer_norm_epsilon`)
     # and no `rms_norm_eps`.
     norm_type = "rmsnorm"
-    has_ln_eps = (hasattr(hf_config, "layer_norm_eps")
-                  or hasattr(hf_config, "layer_norm_epsilon"))
+    has_ln_eps = hasattr(hf_config, "layer_norm_eps") or hasattr(
+        hf_config, "layer_norm_epsilon"
+    )
     if has_ln_eps and not hasattr(hf_config, "rms_norm_eps"):
         norm_type = "layernorm"
 
@@ -72,10 +82,12 @@ def _from_hf_config_generic(hf_config) -> ModelConfig:
     # variants are the tanh approximation (distinguished from "gelu" so the runner can
     # pick the matching ttnn.gelu mode).
     act_map = {
-        "silu": "silu", "swish": "silu",
+        "silu": "silu",
+        "swish": "silu",
         "gelu": "gelu",
         "gelu_tanh": "gelu_tanh",
-        "gelu_new": "gelu_tanh", "gelu_fast": "gelu_tanh",
+        "gelu_new": "gelu_tanh",
+        "gelu_fast": "gelu_tanh",
         "gelu_pytorch_tanh": "gelu_tanh",
         "relu": "relu2",
     }
@@ -88,15 +100,21 @@ def _from_hf_config_generic(hf_config) -> ModelConfig:
         hf_act = {"bloom": "gelu_tanh", "falcon": "gelu"}.get(model_type, "silu")
     activation = act_map.get(hf_act, "silu")
 
-    eps = getattr(hf_config, "rms_norm_eps",
-          getattr(hf_config, "layer_norm_eps",
-          getattr(hf_config, "layer_norm_epsilon", 1e-6)))
+    eps = getattr(
+        hf_config,
+        "rms_norm_eps",
+        getattr(
+            hf_config, "layer_norm_eps", getattr(hf_config, "layer_norm_epsilon", 1e-6)
+        ),
+    )
 
     # MoE fields
-    num_experts = getattr(hf_config, "num_local_experts",
-                  getattr(hf_config, "num_experts", 0))
-    top_k = getattr(hf_config, "num_experts_per_tok",
-            getattr(hf_config, "top_k_experts", 2))
+    num_experts = getattr(
+        hf_config, "num_local_experts", getattr(hf_config, "num_experts", 0)
+    )
+    top_k = getattr(
+        hf_config, "num_experts_per_tok", getattr(hf_config, "top_k_experts", 2)
+    )
 
     if num_experts > 0:
         return MoEModelConfig(

--- a/tt_inference_server/dispatch/release.py
+++ b/tt_inference_server/dispatch/release.py
@@ -48,8 +48,16 @@ def _warmup(model: str, tokens: int, max_seq: int) -> int:
 def _push_argv(args, cache_dir: str) -> "list[str]":
     # Invoke tt-kernel as a module via the current interpreter so it works whether or not
     # the venv's bin/ (with the `tt-kernel` console script) is on PATH.
-    argv = [sys.executable, "-m", "tt_kernel.cli", "push", args.repo, "--cache-dir", cache_dir,
-            "--private" if args.private else "--public"]
+    argv = [
+        sys.executable,
+        "-m",
+        "tt_kernel.cli",
+        "push",
+        args.repo,
+        "--cache-dir",
+        cache_dir,
+        "--private" if args.private else "--public",
+    ]
     if args.build_key is not None:
         argv += ["--build-key", str(args.build_key)]
     if args.weights:
@@ -66,24 +74,75 @@ def _push_argv(args, cache_dir: str) -> "list[str]":
 
 
 def main(argv=None) -> int:
-    ap = argparse.ArgumentParser(prog="release", description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--model", required=True, help="HF id or local weights dir to warm up.")
-    ap.add_argument("--repo", help="Target bundle repo as namespace/name (required unless --warmup-only).")
-    ap.add_argument("--weights", help="HF model repo id this bundle targets (recorded in the manifest).")
-    ap.add_argument("--runner-spec", help="Runner as module:Class (packaged with --python-package, else reference).")
-    ap.add_argument("--python-package", action="append", help="Runner wheel/sdist to ship (repeatable).")
-    ap.add_argument("--entry-point", help="Entry-point name the wheel registers under tt_inference_server.runners.")
-    ap.add_argument("--runner-source", help="For a reference runner: pip name / git URL.")
-    ap.add_argument("--tokens", type=int, default=8, help="Warmup tokens to generate (default 8).")
-    ap.add_argument("--max-seq", type=int, default=512, help="Warmup max_seq (default 512).")
-    ap.add_argument("--cache-dir", help="Cache root to compile into (default: a fresh temp dir).")
-    ap.add_argument("--build-key", type=int, help="Explicit build_key to publish (only needed if ambiguous).")
-    ap.add_argument("--private", action="store_true", help="Publish the repo private (default public).")
-    ap.add_argument("--public", action="store_true", help="Publish public (the default; accepted for explicitness).")
-    ap.add_argument("--skip-warmup", action="store_true", help="Assume the cache-dir is already populated.")
-    ap.add_argument("--dry-run", action="store_true", help="Warm up but print the push command instead of running it.")
-    ap.add_argument("--warmup-only", action="store_true", help=argparse.SUPPRESS)  # internal subprocess mode
+    ap = argparse.ArgumentParser(
+        prog="release",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "--model", required=True, help="HF id or local weights dir to warm up."
+    )
+    ap.add_argument(
+        "--repo",
+        help="Target bundle repo as namespace/name (required unless --warmup-only).",
+    )
+    ap.add_argument(
+        "--weights",
+        help="HF model repo id this bundle targets (recorded in the manifest).",
+    )
+    ap.add_argument(
+        "--runner-spec",
+        help="Runner as module:Class (packaged with --python-package, else reference).",
+    )
+    ap.add_argument(
+        "--python-package",
+        action="append",
+        help="Runner wheel/sdist to ship (repeatable).",
+    )
+    ap.add_argument(
+        "--entry-point",
+        help="Entry-point name the wheel registers under tt_inference_server.runners.",
+    )
+    ap.add_argument(
+        "--runner-source", help="For a reference runner: pip name / git URL."
+    )
+    ap.add_argument(
+        "--tokens", type=int, default=8, help="Warmup tokens to generate (default 8)."
+    )
+    ap.add_argument(
+        "--max-seq", type=int, default=512, help="Warmup max_seq (default 512)."
+    )
+    ap.add_argument(
+        "--cache-dir", help="Cache root to compile into (default: a fresh temp dir)."
+    )
+    ap.add_argument(
+        "--build-key",
+        type=int,
+        help="Explicit build_key to publish (only needed if ambiguous).",
+    )
+    ap.add_argument(
+        "--private",
+        action="store_true",
+        help="Publish the repo private (default public).",
+    )
+    ap.add_argument(
+        "--public",
+        action="store_true",
+        help="Publish public (the default; accepted for explicitness).",
+    )
+    ap.add_argument(
+        "--skip-warmup",
+        action="store_true",
+        help="Assume the cache-dir is already populated.",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Warm up but print the push command instead of running it.",
+    )
+    ap.add_argument(
+        "--warmup-only", action="store_true", help=argparse.SUPPRESS
+    )  # internal subprocess mode
     args = ap.parse_args(argv)
 
     if args.warmup_only:
@@ -96,18 +155,36 @@ def main(argv=None) -> int:
 
     if not args.skip_warmup:
         env = {**os.environ, "TT_METAL_CACHE": cache_dir}
-        print(f"[release] warming up {args.model} ({args.tokens} tokens) ...", flush=True)
+        print(
+            f"[release] warming up {args.model} ({args.tokens} tokens) ...", flush=True
+        )
         subprocess.run(
-            [sys.executable, "-m", "tt_inference_server.dispatch.release", "--warmup-only",
-             "--model", args.model, "--tokens", str(args.tokens), "--max-seq", str(args.max_seq)],
-            env=env, check=True,
+            [
+                sys.executable,
+                "-m",
+                "tt_inference_server.dispatch.release",
+                "--warmup-only",
+                "--model",
+                args.model,
+                "--tokens",
+                str(args.tokens),
+                "--max-seq",
+                str(args.max_seq),
+            ],
+            env=env,
+            check=True,
         )
 
     push = _push_argv(args, cache_dir)
     if args.dry_run:
         from tt_kernel import cache
+
         out_root = cache.resolve_out_root(cache_dir)
-        print("[release] DRY RUN — populated build_keys:", cache.list_build_keys(out_root), flush=True)
+        print(
+            "[release] DRY RUN — populated build_keys:",
+            cache.list_build_keys(out_root),
+            flush=True,
+        )
         print("[release] would run:\n  " + " ".join(push), flush=True)
         return 0
 

--- a/tt_inference_server/dispatch/release.py
+++ b/tt_inference_server/dispatch/release.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Producer path: populate the tt-metal JIT cache for a model, then publish it as a
+tt-kernel bundle (closes #1 / #26).
+
+    python -m tt_inference_server.dispatch.release \\
+        --model ~/dispatch/models/allenai-OLMo-1B-hf \\
+        --repo  mando2222/olmo-1b-blackhole \\
+        --weights allenai/OLMo-1B-hf --public
+
+Flow:
+  1. **Warmup** — run the model for a few tokens in a *subprocess* with a fresh
+     ``TT_METAL_CACHE`` so exactly one (unambiguous, attributable) build_key subtree is
+     produced, and the device is released when the subprocess exits.
+  2. **Publish** — shell out to ``tt-kernel push --cache-dir <fresh>`` to package and
+     upload that build_key subtree, optionally with a runner (packaged wheel or
+     reference spec) and a ``--weights`` model reference.
+
+This is glue over tt-kernel's native artifact system — it adds no new bundle format.
+Pre-compiled kernels published this way are a cache *hit* on a matching consumer
+(``install_subtree`` lands them in the consumer's tt-metal cache dir), so first run skips
+JIT recompilation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+
+_WARMUP_PROMPT = "The quick brown fox jumps over the lazy dog."
+
+
+def _warmup(model: str, tokens: int, max_seq: int) -> int:
+    """Run the model briefly to JIT-compile its kernels into TT_METAL_CACHE, then exit.
+    Invoked as a subprocess (see main) so the device lock is released before the push."""
+    from tt_inference_server.dispatch import load_model
+
+    handle = load_model(model, max_seq=max_seq, unsafe=True, trace_region_size=0)
+    out = handle.generate(_WARMUP_PROMPT, max_new_tokens=tokens, chat=False)
+    print(f"[release] warmup ok: generated {len(out)} chars", flush=True)
+    return 0
+
+
+def _push_argv(args, cache_dir: str) -> "list[str]":
+    # Invoke tt-kernel as a module via the current interpreter so it works whether or not
+    # the venv's bin/ (with the `tt-kernel` console script) is on PATH.
+    argv = [sys.executable, "-m", "tt_kernel.cli", "push", args.repo, "--cache-dir", cache_dir,
+            "--private" if args.private else "--public"]
+    if args.build_key is not None:
+        argv += ["--build-key", str(args.build_key)]
+    if args.weights:
+        argv += ["--weights", args.weights]
+    if args.runner_spec:
+        argv += ["--runner-spec", args.runner_spec]
+    for whl in args.python_package or []:
+        argv += ["--python-package", whl]
+    if args.entry_point:
+        argv += ["--entry-point", args.entry_point]
+    if args.runner_source:
+        argv += ["--runner-source", args.runner_source]
+    return argv
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(prog="release", description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--model", required=True, help="HF id or local weights dir to warm up.")
+    ap.add_argument("--repo", help="Target bundle repo as namespace/name (required unless --warmup-only).")
+    ap.add_argument("--weights", help="HF model repo id this bundle targets (recorded in the manifest).")
+    ap.add_argument("--runner-spec", help="Runner as module:Class (packaged with --python-package, else reference).")
+    ap.add_argument("--python-package", action="append", help="Runner wheel/sdist to ship (repeatable).")
+    ap.add_argument("--entry-point", help="Entry-point name the wheel registers under tt_inference_server.runners.")
+    ap.add_argument("--runner-source", help="For a reference runner: pip name / git URL.")
+    ap.add_argument("--tokens", type=int, default=8, help="Warmup tokens to generate (default 8).")
+    ap.add_argument("--max-seq", type=int, default=512, help="Warmup max_seq (default 512).")
+    ap.add_argument("--cache-dir", help="Cache root to compile into (default: a fresh temp dir).")
+    ap.add_argument("--build-key", type=int, help="Explicit build_key to publish (only needed if ambiguous).")
+    ap.add_argument("--private", action="store_true", help="Publish the repo private (default public).")
+    ap.add_argument("--public", action="store_true", help="Publish public (the default; accepted for explicitness).")
+    ap.add_argument("--skip-warmup", action="store_true", help="Assume the cache-dir is already populated.")
+    ap.add_argument("--dry-run", action="store_true", help="Warm up but print the push command instead of running it.")
+    ap.add_argument("--warmup-only", action="store_true", help=argparse.SUPPRESS)  # internal subprocess mode
+    args = ap.parse_args(argv)
+
+    if args.warmup_only:
+        return _warmup(args.model, args.tokens, args.max_seq)
+    if not args.repo:
+        ap.error("--repo is required (the target namespace/name to publish to).")
+
+    cache_dir = args.cache_dir or tempfile.mkdtemp(prefix="ttk-release-")
+    print(f"[release] cache dir: {cache_dir}", flush=True)
+
+    if not args.skip_warmup:
+        env = {**os.environ, "TT_METAL_CACHE": cache_dir}
+        print(f"[release] warming up {args.model} ({args.tokens} tokens) ...", flush=True)
+        subprocess.run(
+            [sys.executable, "-m", "tt_inference_server.dispatch.release", "--warmup-only",
+             "--model", args.model, "--tokens", str(args.tokens), "--max-seq", str(args.max_seq)],
+            env=env, check=True,
+        )
+
+    push = _push_argv(args, cache_dir)
+    if args.dry_run:
+        from tt_kernel import cache
+        out_root = cache.resolve_out_root(cache_dir)
+        print("[release] DRY RUN — populated build_keys:", cache.list_build_keys(out_root), flush=True)
+        print("[release] would run:\n  " + " ".join(push), flush=True)
+        return 0
+
+    print("[release] publishing: " + " ".join(push), flush=True)
+    return subprocess.run(push, check=True).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tt_inference_server/dispatch/runner.py
+++ b/tt_inference_server/dispatch/runner.py
@@ -66,13 +66,19 @@ def _pad_to_tiles(t: torch.Tensor) -> torch.Tensor:
 
 def _to_tt(t: torch.Tensor, device, dtype=None):
     import ttnn
+
     # dtype defaults to bf16; weight call sites may pass ttnn.bfloat8_b (block-float8,
     # tile-only) to halve DRAM footprint/bandwidth. Activations/masks/KV keep bf16.
     if dtype is None:
         dtype = ttnn.bfloat16
     t = _pad_to_tiles(t.bfloat16().contiguous())
-    return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT,
-                           device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    return ttnn.from_torch(
+        t,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
 
 
 def _pad_qkv_per_head(w: torch.Tensor, n_heads: int, head_dim: int) -> torch.Tensor:
@@ -87,16 +93,20 @@ def _pad_qkv_per_head(w: torch.Tensor, n_heads: int, head_dim: int) -> torch.Ten
     """
     hd_p = _tile_align(head_dim)
     if hd_p == head_dim:
-        return w                               # already aligned — no-op
+        return w  # already aligned — no-op
     in_dim = w.shape[0]
     # (in_dim, n_heads*head_dim) → (n_heads, head_dim, in_dim) → pad → back
-    w_heads = w.T.reshape(n_heads, head_dim, in_dim)          # (n_heads, hd, in)
+    w_heads = w.T.reshape(n_heads, head_dim, in_dim)  # (n_heads, hd, in)
     pad_amt = hd_p - head_dim
-    w_padded = torch.nn.functional.pad(w_heads, (0, 0, 0, pad_amt))   # (n_heads, hd_p, in)
-    return w_padded.reshape(n_heads * hd_p, in_dim).T.contiguous()    # (in, n_heads*hd_p)
+    w_padded = torch.nn.functional.pad(
+        w_heads, (0, 0, 0, pad_amt)
+    )  # (n_heads, hd_p, in)
+    return w_padded.reshape(n_heads * hd_p, in_dim).T.contiguous()  # (in, n_heads*hd_p)
 
 
-def _pad_o_proj_per_head(w_raw: torch.Tensor, n_heads: int, head_dim: int) -> torch.Tensor:
+def _pad_o_proj_per_head(
+    w_raw: torch.Tensor, n_heads: int, head_dim: int
+) -> torch.Tensor:
     """Pad the per-head input dimension of the O projection weight for tile alignment.
 
     The flash-attn output is (TILE, n_heads * hd_p) where hd_p = tile_align(head_dim).
@@ -142,6 +152,7 @@ def _matmul_safe(a, b, device, output_tensor=None):
     Ignored in the CPU fallback path and when ttnn doesn't support the parameter.
     """
     import ttnn
+
     try:
         if output_tensor is not None:
             # ttnn >= 0.71 uses optional_output_tensor; older builds use output_tensor
@@ -177,8 +188,14 @@ def _find_text_backbone(hf_model):
 
     layers_attr is either 'layers' (most models) or 'h' (BLOOM, Falcon).
     """
-    for path in ["model", "language_model.model", "language_model",
-                 "transformer", "gpt_neox", "decoder"]:
+    for path in [
+        "model",
+        "language_model.model",
+        "language_model",
+        "transformer",
+        "gpt_neox",
+        "decoder",
+    ]:
         obj = _getattr_nested(hf_model, path)
         if obj is None:
             continue
@@ -231,19 +248,24 @@ def _find_layer_norms(layer):
     norm1 = pre-attention, norm2 = post-attention (pre-MLP),
     norm3/norm4 = Gemma3 extra norms (None otherwise).
     """
-    n1 = (getattr(layer, "input_layernorm", None) or
-          getattr(layer, "attn_norm", None) or
-          getattr(layer, "ln_1", None) or
-          getattr(layer, "norm_1", None))
-    n2 = (getattr(layer, "post_attention_layernorm", None) or
-          getattr(layer, "ffn_norm", None) or
-          getattr(layer, "ln_2", None) or
-          getattr(layer, "norm_2", None))
+    n1 = (
+        getattr(layer, "input_layernorm", None)
+        or getattr(layer, "attn_norm", None)
+        or getattr(layer, "ln_1", None)
+        or getattr(layer, "norm_1", None)
+    )
+    n2 = (
+        getattr(layer, "post_attention_layernorm", None)
+        or getattr(layer, "ffn_norm", None)
+        or getattr(layer, "ln_2", None)
+        or getattr(layer, "norm_2", None)
+    )
     n3 = getattr(layer, "pre_feedforward_layernorm", None)
     n4 = getattr(layer, "post_feedforward_layernorm", None)
     if n1 is None or n2 is None:
         raise RuntimeError(
-            f"Cannot find layer norms in {type(layer).__name__}: {dir(layer)}")
+            f"Cannot find layer norms in {type(layer).__name__}: {dir(layer)}"
+        )
     return n1, n2, n3, n4
 
 
@@ -260,23 +282,25 @@ def _split_qkv_weights(attn, cfg):
     if qkv_interleaved is not None:
         # GPTNeoX / BLOOM: rows interleaved per head [Q_0,K_0,V_0, Q_1,K_1,V_1, ...]
         w = qkv_interleaved.weight.detach().bfloat16()  # (n_heads*3*head_dim, in)
-        n_h  = cfg.num_heads
+        n_h = cfg.num_heads
         n_kv = cfg.num_kv_heads
-        hd   = cfg.head_dim
+        hd = cfg.head_dim
         # Reshape to (n_heads, 3, head_dim, in), then extract Q/K/V per head
         w_r = w.view(n_h, 3, hd, w.shape[1])
-        q = w_r[:, 0, :, :].reshape(n_h  * hd, w.shape[1]).T.contiguous()
+        q = w_r[:, 0, :, :].reshape(n_h * hd, w.shape[1]).T.contiguous()
         k = w_r[:n_kv, 1, :, :].reshape(n_kv * hd, w.shape[1]).T.contiguous()
         v = w_r[:n_kv, 2, :, :].reshape(n_kv * hd, w.shape[1]).T.contiguous()
         return q, k, v
 
     # Block-layout fused QKV — [Q_all; K_all; V_all]
-    fused = (getattr(attn, "qkv_proj", None) or
-             getattr(attn, "wqkv", None) or
-             getattr(attn, "c_attn", None))
+    fused = (
+        getattr(attn, "qkv_proj", None)
+        or getattr(attn, "wqkv", None)
+        or getattr(attn, "c_attn", None)
+    )
     if fused is not None:
-        w = fused.weight.detach().bfloat16()   # (q_out+k_out+v_out, in)
-        q_out = cfg.num_heads    * cfg.head_dim
+        w = fused.weight.detach().bfloat16()  # (q_out+k_out+v_out, in)
+        q_out = cfg.num_heads * cfg.head_dim
         k_out = cfg.num_kv_heads * cfg.head_dim
         v_out = cfg.num_kv_heads * cfg.head_dim
         total = q_out + k_out + v_out
@@ -284,8 +308,8 @@ def _split_qkv_weights(attn, cfg):
             # Some models pad — take the first total rows
             w = w[:total]
         q = w[:q_out].T.contiguous()
-        k = w[q_out:q_out + k_out].T.contiguous()
-        v = w[q_out + k_out:].T.contiguous()
+        k = w[q_out : q_out + k_out].T.contiguous()
+        v = w[q_out + k_out :].T.contiguous()
         return q, k, v
 
     # Standard separate projections
@@ -303,9 +327,9 @@ def _get_qkv_bias(attn, cfg) -> "torch.Tensor | None":
     produced by _split_qkv_weights / _pad_qkv_per_head: each head's slice is
     zero-padded from head_dim to tile_align(head_dim).
     """
-    hd   = cfg.head_dim
+    hd = cfg.head_dim
     hd_p = _tile_align(hd)
-    n_h  = cfg.num_heads
+    n_h = cfg.num_heads
     n_kv = cfg.num_kv_heads
 
     def _pad_bias_heads(b_raw, n_heads):
@@ -323,23 +347,26 @@ def _get_qkv_bias(attn, cfg) -> "torch.Tensor | None":
         b = b.detach()
         # Interleaved: [Q_0,K_0,V_0, Q_1,K_1,V_1, ...]
         b_r = b.view(n_h, 3, hd)
-        q_b = _pad_bias_heads(b_r[:, 0, :].reshape(n_h  * hd), n_h)
+        q_b = _pad_bias_heads(b_r[:, 0, :].reshape(n_h * hd), n_h)
         k_b = _pad_bias_heads(b_r[:n_kv, 1, :].reshape(n_kv * hd), n_kv)
         v_b = _pad_bias_heads(b_r[:n_kv, 2, :].reshape(n_kv * hd), n_kv)
         return torch.cat([q_b, k_b, v_b])
 
-    fused = (getattr(attn, "qkv_proj", None) or getattr(attn, "wqkv", None) or
-             getattr(attn, "c_attn", None))
+    fused = (
+        getattr(attn, "qkv_proj", None)
+        or getattr(attn, "wqkv", None)
+        or getattr(attn, "c_attn", None)
+    )
     if fused is not None:
         b = getattr(fused, "bias", None)
         if b is None:
             return None
         b = b.detach()
-        q_out = n_h  * hd
+        q_out = n_h * hd
         k_out = n_kv * hd
         q_b = _pad_bias_heads(b[:q_out], n_h)
-        k_b = _pad_bias_heads(b[q_out:q_out + k_out], n_kv)
-        v_b = _pad_bias_heads(b[q_out + k_out:q_out + k_out + k_out], n_kv)
+        k_b = _pad_bias_heads(b[q_out : q_out + k_out], n_kv)
+        v_b = _pad_bias_heads(b[q_out + k_out : q_out + k_out + k_out], n_kv)
         return torch.cat([q_b, k_b, v_b])
 
     # Separate q/k/v — each may have its own bias
@@ -347,12 +374,13 @@ def _get_qkv_bias(attn, cfg) -> "torch.Tensor | None":
         m = getattr(attn, mod_name, None)
         b = getattr(m, "bias", None) if m else None
         return b.detach().float() if b is not None else None
+
     q_b = _get_sep_bias("q_proj")
     k_b = _get_sep_bias("k_proj")
     v_b = _get_sep_bias("v_proj")
     if q_b is None and k_b is None and v_b is None:
         return None
-    q_b2 = _pad_bias_heads(q_b, n_h)  if q_b is not None else torch.zeros(n_h  * hd_p)
+    q_b2 = _pad_bias_heads(q_b, n_h) if q_b is not None else torch.zeros(n_h * hd_p)
     k_b2 = _pad_bias_heads(k_b, n_kv) if k_b is not None else torch.zeros(n_kv * hd_p)
     v_b2 = _pad_bias_heads(v_b, n_kv) if v_b is not None else torch.zeros(n_kv * hd_p)
     return torch.cat([q_b2, k_b2, v_b2])
@@ -381,24 +409,28 @@ def _find_mlp_modules(mlp):
     in practice.
     """
     gate = getattr(mlp, "gate_proj", None) or getattr(mlp, "w1", None)
-    up   = getattr(mlp, "up_proj", None) or getattr(mlp, "w3", None)
+    up = getattr(mlp, "up_proj", None) or getattr(mlp, "w3", None)
     down = getattr(mlp, "down_proj", None) or getattr(mlp, "w2", None)
     if gate is not None and up is not None and down is not None:
         return gate, up, down
 
     gate_up = getattr(mlp, "gate_up_proj", None)
-    down2   = getattr(mlp, "down_proj", None)
+    down2 = getattr(mlp, "down_proj", None)
     if gate_up is not None and down2 is not None:
         return None, gate_up, down2
 
-    up_2 = (getattr(mlp, "dense_h_to_4h", None) or   # GPTNeoX, BLOOM
-            getattr(mlp, "c_fc", None) or              # Starcoder2
-            getattr(mlp, "ff_proj", None) or           # OLMo
-            getattr(mlp, "fc_in", None))
-    dn_2 = (getattr(mlp, "dense_4h_to_h", None) or   # GPTNeoX, BLOOM
-            getattr(mlp, "c_proj", None) or            # Starcoder2
-            getattr(mlp, "ff_out", None) or            # OLMo
-            getattr(mlp, "fc_out", None))
+    up_2 = (
+        getattr(mlp, "dense_h_to_4h", None)  # GPTNeoX, BLOOM
+        or getattr(mlp, "c_fc", None)  # Starcoder2
+        or getattr(mlp, "ff_proj", None)  # OLMo
+        or getattr(mlp, "fc_in", None)
+    )
+    dn_2 = (
+        getattr(mlp, "dense_4h_to_h", None)  # GPTNeoX, BLOOM
+        or getattr(mlp, "c_proj", None)  # Starcoder2
+        or getattr(mlp, "ff_out", None)  # OLMo
+        or getattr(mlp, "fc_out", None)
+    )
     return None, up_2, dn_2
 
 
@@ -410,33 +442,34 @@ def _find_mlp_weights(mlp, cfg):
     2-proj variants (GPTNeoX dense_h_to_4h, Starcoder2 c_fc, OLMo ff_proj).
     """
     # SwiGLU with standard names
-    gate = (getattr(mlp, "gate_proj", None) or
-            getattr(mlp, "w1", None))     # InternLM2
-    up   = (getattr(mlp, "up_proj", None) or
-            getattr(mlp, "w3", None))     # InternLM2
-    down = (getattr(mlp, "down_proj", None) or
-            getattr(mlp, "w2", None))     # InternLM2
+    gate = getattr(mlp, "gate_proj", None) or getattr(mlp, "w1", None)  # InternLM2
+    up = getattr(mlp, "up_proj", None) or getattr(mlp, "w3", None)  # InternLM2
+    down = getattr(mlp, "down_proj", None) or getattr(mlp, "w2", None)  # InternLM2
 
     if gate is not None and up is not None and down is not None:
         return gate.weight, up.weight, down.weight
 
     # Fused gate+up (Phi-3: gate_up_proj contains [gate; up] concatenated)
     gate_up = getattr(mlp, "gate_up_proj", None)
-    down2   = getattr(mlp, "down_proj", None)
+    down2 = getattr(mlp, "down_proj", None)
     if gate_up is not None and down2 is not None:
-        w   = gate_up.weight.detach().bfloat16()  # (gate_out+up_out, in)
+        w = gate_up.weight.detach().bfloat16()  # (gate_out+up_out, in)
         mid = w.shape[0] // 2
         return w[:mid], w[mid:], down2.weight
 
     # 2-proj MLP (no gate) — return gate=None
-    up_2 = (getattr(mlp, "dense_h_to_4h", None) or   # GPTNeoX, BLOOM
-            getattr(mlp, "c_fc", None) or              # Starcoder2
-            getattr(mlp, "ff_proj", None) or           # OLMo
-            getattr(mlp, "fc_in", None))
-    dn_2 = (getattr(mlp, "dense_4h_to_h", None) or   # GPTNeoX, BLOOM
-            getattr(mlp, "c_proj", None) or            # Starcoder2
-            getattr(mlp, "ff_out", None) or            # OLMo
-            getattr(mlp, "fc_out", None))
+    up_2 = (
+        getattr(mlp, "dense_h_to_4h", None)  # GPTNeoX, BLOOM
+        or getattr(mlp, "c_fc", None)  # Starcoder2
+        or getattr(mlp, "ff_proj", None)  # OLMo
+        or getattr(mlp, "fc_in", None)
+    )
+    dn_2 = (
+        getattr(mlp, "dense_4h_to_h", None)  # GPTNeoX, BLOOM
+        or getattr(mlp, "c_proj", None)  # Starcoder2
+        or getattr(mlp, "ff_out", None)  # OLMo
+        or getattr(mlp, "fc_out", None)
+    )
     if up_2 is not None and dn_2 is not None:
         return None, up_2.weight, dn_2.weight
 
@@ -450,33 +483,36 @@ def _find_mlp_weights(mlp, cfg):
 # Per-layer weight container
 # ------------------------------------------------------------------
 
+
 @dataclass
 class _LayerWeights:
-    norm1_w:  object   # ttnn.Tensor (TILE, hidden_p) -- input_layernorm
-    norm1_sc: object   # ttnn.Tensor (TILE, TILE) -- 1/hidden scaler
-    norm2_w:  object   # post_attention_layernorm
+    norm1_w: object  # ttnn.Tensor (TILE, hidden_p) -- input_layernorm
+    norm1_sc: object  # ttnn.Tensor (TILE, TILE) -- 1/hidden scaler
+    norm2_w: object  # post_attention_layernorm
     norm2_sc: object
-    qkv_w:    object   # ttnn.Tensor (hidden_p, q_out_p+k_out_p+v_out_p) -- fused
-    q_end:    int      # slice boundary: qkv[:q_end] = Q
-    k_end:    int      # slice boundary: qkv[q_end:k_end] = K, qkv[k_end:] = V
-    o_w:      object   # ttnn.Tensor (n_heads*head_dim_p, hidden_p)
-    gate_w:   object   # ttnn.Tensor (hidden_p, intermediate_p)
-    up_w:     object
-    down_w:   object   # ttnn.Tensor (intermediate_p, hidden_p)
-    qkv_b:    object   # torch.Tensor (total_qkv_p,) CPU float -- None if no bias
-    gate_b:   object   # ttnn.Tensor (TILE, intermediate_p) -- None if no bias
-    up_b:     object   # ttnn.Tensor (TILE, intermediate_p) -- None if no bias
-    o_b:      object = None  # ttnn.Tensor (TILE, hidden_p) o-proj bias -- None if absent
-    down_b:   object = None  # ttnn.Tensor (TILE, hidden_p) MLP down bias -- None if absent
+    qkv_w: object  # ttnn.Tensor (hidden_p, q_out_p+k_out_p+v_out_p) -- fused
+    q_end: int  # slice boundary: qkv[:q_end] = Q
+    k_end: int  # slice boundary: qkv[q_end:k_end] = K, qkv[k_end:] = V
+    o_w: object  # ttnn.Tensor (n_heads*head_dim_p, hidden_p)
+    gate_w: object  # ttnn.Tensor (hidden_p, intermediate_p)
+    up_w: object
+    down_w: object  # ttnn.Tensor (intermediate_p, hidden_p)
+    qkv_b: object  # torch.Tensor (total_qkv_p,) CPU float -- None if no bias
+    gate_b: object  # ttnn.Tensor (TILE, intermediate_p) -- None if no bias
+    up_b: object  # ttnn.Tensor (TILE, intermediate_p) -- None if no bias
+    o_b: object = None  # ttnn.Tensor (TILE, hidden_p) o-proj bias -- None if absent
+    down_b: object = (
+        None  # ttnn.Tensor (TILE, hidden_p) MLP down bias -- None if absent
+    )
     # Optional extra norms (Gemma 3 style: norm applied to sub-layer OUTPUT)
-    norm3_w:  object = None  # pre_feedforward_layernorm
+    norm3_w: object = None  # pre_feedforward_layernorm
     norm3_sc: object = None
-    norm4_w:  object = None  # post_feedforward_layernorm
+    norm4_w: object = None  # post_feedforward_layernorm
     norm4_sc: object = None
     # Residual pattern: "llama" (norm before sublayer) or "gemma" (norm wraps sublayer output)
     norm_style: str = "llama"
     # Optional per-head Q/K norms (Gemma 3, Qwen 3) -- stored as (head_dim,) CPU tensors
-    q_norm_w: object = None   # torch.Tensor or None
+    q_norm_w: object = None  # torch.Tensor or None
     k_norm_w: object = None
     # LayerNorm weight+bias (CPU float tensors; None for RMSNorm models)
     norm1_w_cpu: object = None
@@ -501,7 +537,7 @@ class _LayerWeights:
 
 def _layernorm_cpu(x: torch.Tensor, weight, bias, eps: float) -> torch.Tensor:
     mean = x.mean(-1, keepdim=True)
-    var  = ((x - mean).pow(2)).mean(-1, keepdim=True)
+    var = ((x - mean).pow(2)).mean(-1, keepdim=True)
     x_norm = (x - mean) / (var + eps).sqrt()
     if weight is not None:
         x_norm = x_norm * weight
@@ -513,6 +549,7 @@ def _layernorm_cpu(x: torch.Tensor, weight, bias, eps: float) -> torch.Tensor:
 # ------------------------------------------------------------------
 # Main runner class
 # ------------------------------------------------------------------
+
 
 class TTModelRunner:
     """Runs a HuggingFace transformer model fully on a TT device.
@@ -539,7 +576,9 @@ class TTModelRunner:
         from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
         from tt_inference_server.dispatch.registry import detect_model_family
         from tt_inference_server.dispatch.dispatcher import (
-            KernelDispatcher, derive_capabilities)
+            KernelDispatcher,
+            derive_capabilities,
+        )
 
         self._device = device
         self._max_seq = max_seq
@@ -560,7 +599,9 @@ class TTModelRunner:
         self._cfg = detect_model_family(hf_config)
         self._hf_cfg = hf_config
 
-        self._tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            model_path, trust_remote_code=True
+        )
 
         print("  Loading weights ...")
         hf_model = AutoModelForCausalLM.from_pretrained(
@@ -582,35 +623,46 @@ class TTModelRunner:
         self._entry = None if force_novel else self._dispatcher.lookup(model_path)
         self._listed = self._entry is not None
         if force_novel:
-            print("  force_novel=True: matrix lookup SKIPPED -> auto-derive path (#47).")
+            print(
+                "  force_novel=True: matrix lookup SKIPPED -> auto-derive path (#47)."
+            )
         if self._entry is not None:
             # Matrix is authoritative for dims for listed models (#3 Phase D); novel
             # models keep detect_model_family()'s HF-config introspection above.
             self._cfg = self._entry.model_config()
             self._caps = self._entry.capabilities(self._dispatcher._hw_config)
-            self._community = (self._entry.status == "community")
-            print(f"  Matrix: '{self._entry.name}' (status={self._entry.status}, "
-                  f"backend={self._caps.attn_backend}, fast_path={self._caps.fast_path}, "
-                  f"lm_head_ondevice={self._caps.lm_head_ondevice})")
+            self._community = self._entry.status == "community"
+            print(
+                f"  Matrix: '{self._entry.name}' (status={self._entry.status}, "
+                f"backend={self._caps.attn_backend}, fast_path={self._caps.fast_path}, "
+                f"lm_head_ondevice={self._caps.lm_head_ondevice})"
+            )
             if self._community and not unsafe:
-                print(f"  WARNING: '{self._entry.name}' is status=community (unverified); "
-                      "correctness is not guaranteed. Pass --unsafe to silence (#25).")
+                print(
+                    f"  WARNING: '{self._entry.name}' is status=community (unverified); "
+                    "correctness is not guaranteed. Pass --unsafe to silence (#25)."
+                )
         else:
             self._caps = derive_capabilities(hf_config)
             self._community = True
-            print(f"  Matrix: no entry for arch '{arch}' -> auto-derived (community, "
-                  f"unverified). fast_path={self._caps.fast_path}, "
-                  f"lm_head_ondevice={self._caps.lm_head_ondevice}. "
-                  "Output validity unverified on this hardware.")
+            print(
+                f"  Matrix: no entry for arch '{arch}' -> auto-derived (community, "
+                f"unverified). fast_path={self._caps.fast_path}, "
+                f"lm_head_ondevice={self._caps.lm_head_ondevice}. "
+                "Output validity unverified on this hardware."
+            )
 
         # bf8 weights (perf spike): upload the large linear weights (qkv/o/gate/up/down/
         # lm_head) as block-float8 to halve their DRAM footprint + per-token read bandwidth.
         # Reversible A/B arm — default OFF keeps the bf16 path byte-identical. Embedding
         # (ROW_MAJOR lookup), norms, biases, KV and activations stay bf16.
         import os as _os
+
         self._bf8_weights = _os.environ.get("DISPATCH_BF8_WEIGHTS", "0") == "1"
         if self._bf8_weights:
-            print("  Weight dtype: bfloat8_b (DISPATCH_BF8_WEIGHTS=1) — linear weights only")
+            print(
+                "  Weight dtype: bfloat8_b (DISPATCH_BF8_WEIGHTS=1) — linear weights only"
+            )
 
         print("  Uploading to device ...")
         try:
@@ -661,7 +713,9 @@ class TTModelRunner:
                     messages, add_generation_prompt=True, return_tensors="pt"
                 )[0].tolist()
             except Exception:
-                input_ids = self._tokenizer.encode(prompt, return_tensors="pt")[0].tolist()
+                input_ids = self._tokenizer.encode(prompt, return_tensors="pt")[
+                    0
+                ].tolist()
         else:
             input_ids = self._tokenizer.encode(prompt, return_tensors="pt")[0].tolist()
         self.reset_cache()
@@ -682,7 +736,7 @@ class TTModelRunner:
         elapsed = time.perf_counter() - t0
         n_new = len(output_ids)
         if n_new:
-            print(f"  {n_new} tokens in {elapsed:.1f}s = {n_new/elapsed:.1f} tok/s")
+            print(f"  {n_new} tokens in {elapsed:.1f}s = {n_new / elapsed:.1f} tok/s")
 
         return self._tokenizer.decode(output_ids, skip_special_tokens=True)
 
@@ -707,7 +761,9 @@ class TTModelRunner:
                     messages, add_generation_prompt=True, return_tensors="pt"
                 )[0].tolist()
             except Exception:
-                input_ids = self._tokenizer.encode(prompt, return_tensors="pt")[0].tolist()
+                input_ids = self._tokenizer.encode(prompt, return_tensors="pt")[
+                    0
+                ].tolist()
         else:
             input_ids = self._tokenizer.encode(prompt, return_tensors="pt")[0].tolist()
         self.reset_cache()
@@ -726,7 +782,7 @@ class TTModelRunner:
             output_ids.append(next_id)
             text = self._tokenizer.decode(output_ids, skip_special_tokens=True)
             if len(text) > len(emitted):
-                yield text[len(emitted):]
+                yield text[len(emitted) :]
                 emitted = text
             next_id = self._decode_step(next_id, len(input_ids) + len(output_ids) - 1)
 
@@ -783,17 +839,21 @@ class TTModelRunner:
     def _decode_step(self, token_id: int, kv_pos: int) -> int:
         """Single-token forward pass. Returns next token id (int)."""
         import ttnn
+
         if self._paged_attn:
             # Write the position into the pinned device tensor once; all layers' paged
             # KV-write + SDPA read it (trace-safe — device-tensor index, not a Python int).
             self._cur_pos_cpu[0] = kv_pos
             ttnn.copy_host_to_device_tensor(
-                ttnn.from_torch(self._cur_pos_cpu, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT),
-                self._cur_pos_dev)
+                ttnn.from_torch(
+                    self._cur_pos_cpu, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT
+                ),
+                self._cur_pos_dev,
+            )
         if self._traced:
             return self._decode_step_traced(token_id)
         hidden_tt = self._embed(token_id)
-        if self._embed_ln_w_cpu is not None:        # BLOOM word_embeddings_layernorm
+        if self._embed_ln_w_cpu is not None:  # BLOOM word_embeddings_layernorm
             hidden_tt = self._apply_embed_ln(hidden_tt)
         self._ladder_capture("post_embed", hidden_tt)
         for i in range(len(self._layers)):
@@ -813,26 +873,35 @@ class TTModelRunner:
         if self._ladder is None:
             return
         import ttnn
+
         hidden = self._cfg.hidden_size
         self._ladder[tag] = ttnn.to_torch(hidden_tt)[0, :hidden].float().clone()
 
     def _apply_embed_ln(self, hidden_tt):
         """Apply the embedding LayerNorm (BLOOM) on CPU, returning (TILE, hidden_p)."""
         import ttnn
-        eps = getattr(self._hf_cfg, "layer_norm_eps",
-                      getattr(self._hf_cfg, "rms_norm_eps", 1e-5))
+
+        eps = getattr(
+            self._hf_cfg, "layer_norm_eps", getattr(self._hf_cfg, "rms_norm_eps", 1e-5)
+        )
         hsz = self._cfg.hidden_size
-        hp  = _tile_align(hsz)
+        hp = _tile_align(hsz)
         hcpu = ttnn.to_torch(hidden_tt)[0, :hsz].float()
         ncpu = _layernorm_cpu(hcpu, self._embed_ln_w_cpu, self._embed_ln_b_cpu, eps)
         v_row = torch.nn.functional.pad(ncpu.bfloat16(), (0, hp - hsz)).unsqueeze(0)
-        v_2d  = v_row.expand(TILE, -1).contiguous()
-        return ttnn.from_torch(v_2d, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
-                               device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        v_2d = v_row.expand(TILE, -1).contiguous()
+        return ttnn.from_torch(
+            v_2d,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self._device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
 
     def _embed_traced(self):
         """Host-free embed: reads the pinned token-id device tensor (no from_torch)."""
         import ttnn
+
         emb = ttnn.embedding(self._tok_dev, self._embed_tt)
         emb = ttnn.reshape(emb, [1, _tile_align(self._cfg.hidden_size)])
         h = ttnn.to_layout(emb, ttnn.TILE_LAYOUT)
@@ -843,7 +912,9 @@ class TTModelRunner:
     def _run_embed_layers(self):
         hidden_tt = self._embed_traced()
         for i in range(len(self._layers)):
-            hidden_tt = self._layer_forward(hidden_tt, i, 0)   # kv_pos unused on paged path
+            hidden_tt = self._layer_forward(
+                hidden_tt, i, 0
+            )  # kv_pos unused on paged path
         return hidden_tt
 
     def _run_decode_graph(self):
@@ -866,19 +937,25 @@ class TTModelRunner:
         sampled id; otherwise the final hidden state is read back for an eager CPU lm_head.
         """
         import ttnn
+
         dev = self._device
         self._tok_cpu[0, 0] = token_id
         ttnn.copy_host_to_device_tensor(
-            ttnn.from_torch(self._tok_cpu, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT),
-            self._tok_dev)
+            ttnn.from_torch(
+                self._tok_cpu, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT
+            ),
+            self._tok_dev,
+        )
         if self._trace_id is None:
             # warmup (compiles kernels) then capture the decode graph as a replayable trace
             self._run_decode_graph()
             self._trace_id = ttnn.begin_trace_capture(dev, cq_id=0)
             self._traced_out = self._run_decode_graph()
             ttnn.end_trace_capture(dev, self._trace_id, cq_id=0)
-            print(f"  Decode trace captured (id={self._trace_id}"
-                  f"{', lm_head folded in' if self._ondevice_lmhead else ''})")
+            print(
+                f"  Decode trace captured (id={self._trace_id}"
+                f"{', lm_head folded in' if self._ondevice_lmhead else ''})"
+            )
         ttnn.execute_trace(dev, self._trace_id, cq_id=0, blocking=True)
         if self._ondevice_lmhead:
             return int(ttnn.to_torch(self._traced_out).flatten()[0])
@@ -887,9 +964,13 @@ class TTModelRunner:
     def _embed(self, token_id: int):
         """Lookup embedding on-device, apply optional scale. Returns (TILE, hidden_p)."""
         import ttnn
+
         self._token_id_cpu[0, 0] = token_id
-        token_tt = ttnn.from_torch(self._token_id_cpu, device=self._device,
-                                   memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        token_tt = ttnn.from_torch(
+            self._token_id_cpu,
+            device=self._device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
         # ttnn.embedding returns ROW_MAJOR [1, 1, hidden_size]; reshape to [1, hidden_p]
         # then convert to TILE_LAYOUT which pads the first dim to TILE automatically.
         emb_tt = ttnn.embedding(token_tt, self._embed_tt)
@@ -905,11 +986,16 @@ class TTModelRunner:
         """Build a (1, hidden) bf16 TILE device tensor from a (hidden,) CPU vector for
         ttnn.layer_norm gamma/beta (CP-3). Returns None if vec is None."""
         import ttnn
+
         if vec is None:
             return None
-        return ttnn.from_torch(vec.detach().float().bfloat16().unsqueeze(0),
-                               dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
-                               device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        return ttnn.from_torch(
+            vec.detach().float().bfloat16().unsqueeze(0),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self._device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
 
     def _layernorm_dev(self, h_tt, w_row_tt, b_row_tt, eps):
         """On-device LayerNorm via ttnn.layer_norm (multi-core, trace-safe). w_row_tt/
@@ -922,6 +1008,7 @@ class TTModelRunner:
         normalized row to TILE rows; otherwise the downstream matmul output_tensor= scratch
         (TILE, *) volume mismatches (the pythia gpt_neox crash)."""
         import ttnn
+
         out = ttnn.layer_norm(h_tt, epsilon=eps, weight=w_row_tt, bias=b_row_tt)
         # Decode-only convention: pad a bare (1,H) embed row up to (TILE,H) to match the
         # rmsnorm scratch volume. In prefill the input is logical (N,H) and must stay (N,H)
@@ -935,6 +1022,7 @@ class TTModelRunner:
         w_row_tt: (1, head_dim) broadcast across heads. Replaces CPU _apply_head_norm
         (Qwen3/Gemma3). PCC 0.99999 vs torch (tests/diagnostic/probe_head_rmsnorm.py)."""
         import ttnn
+
         return ttnn.rms_norm(x4, epsilon=eps, weight=w_row_tt)
 
     def _rmsnorm_dev(self, h_tt, w_2d_tt, eps):
@@ -948,6 +1036,7 @@ class TTModelRunner:
         result must be broadcast back to TILE rows (same fix as _layernorm_dev / the pythia
         gpt_neox crash). In prefill the input is logical (N, H) and must stay (N, H)."""
         import ttnn
+
         hp = _tile_align(self._cfg.hidden_size)
         w_row = ttnn.slice(w_2d_tt, [0, 0], [1, hp])
         out = ttnn.rms_norm(h_tt, epsilon=eps, weight=w_row)
@@ -961,6 +1050,7 @@ class TTModelRunner:
         free the temp). Decode (N=1, not prefilling) takes the plain broadcast add —
         byte-identical to before."""
         import ttnn
+
         if getattr(self, "_prefilling", False):
             # The stored bias is a TILE-padded [32, W] (data in row 0, rows 1..31 zero);
             # decode adds it to a 32-padded single row. Prefill x is [N, W], so slice the
@@ -977,14 +1067,21 @@ class TTModelRunner:
 
     def _layer_forward(self, hidden_tt, layer_idx: int, kv_pos: int):
         import ttnn
+
         lw = self._layers[layer_idx]
 
         def rmsnorm_buf():
-            if getattr(self, "_prefilling", False):        # prefill: fresh [N, hidden_p] out
-                hp = _tile_align(self._cfg.hidden_size)     # logical N rows (match the input!)
-                return ttnn.zeros([self._prefill_N, hp], dtype=ttnn.bfloat16,
-                                  layout=ttnn.TILE_LAYOUT, device=self._device,
-                                  memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            if getattr(self, "_prefilling", False):  # prefill: fresh [N, hidden_p] out
+                hp = _tile_align(
+                    self._cfg.hidden_size
+                )  # logical N rows (match the input!)
+                return ttnn.zeros(
+                    [self._prefill_N, hp],
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.TILE_LAYOUT,
+                    device=self._device,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                )
             return self._rmsnorm_buf_tt
 
         def rms(h_tt, w_tt, sc_tt):
@@ -1003,14 +1100,20 @@ class TTModelRunner:
             on-device RMSNorm otherwise. CP-3: trace-safe, no CPU readback."""
             if not self._uses_layernorm:
                 return rms(h_tt, w_tt, sc_tt)
-            eps = getattr(self._hf_cfg, "layer_norm_eps",
-                          getattr(self._hf_cfg, "rms_norm_eps", 1e-5))
+            eps = getattr(
+                self._hf_cfg,
+                "layer_norm_eps",
+                getattr(self._hf_cfg, "rms_norm_eps", 1e-5),
+            )
             return self._layernorm_dev(h_tt, w_ln_tt, b_ln_tt, eps)
 
         # output_tensor= for residual adds writes into pre-allocated hidden scratch,
         # eliminating 2 device tensor allocations per layer per token.
-        aot = ({} if getattr(self, "_prefilling", False)
-               else ({"output_tensor": self._hidden_scratch_tt} if self._add_ot else {}))
+        aot = (
+            {}
+            if getattr(self, "_prefilling", False)
+            else ({"output_tensor": self._hidden_scratch_tt} if self._add_ot else {})
+        )
 
         def add_resid(h_tt, sub_tt):
             """Residual add, scaling the sublayer output by residual_multiplier first
@@ -1027,25 +1130,32 @@ class TTModelRunner:
             #   normed2 = norm3(hidden)
             #   mlp_raw = mlp(normed2)
             #   hidden  += norm4(mlp_raw)        ← norm wraps mlp OUTPUT
-            normed1_tt  = rms(hidden_tt, lw.norm1_w, lw.norm1_sc)
+            normed1_tt = rms(hidden_tt, lw.norm1_w, lw.norm1_sc)
             attn_raw_tt = self._attention(normed1_tt, layer_idx, kv_pos)
             attn_normed = rms(attn_raw_tt, lw.norm2_w, lw.norm2_sc)
-            hidden_tt   = ttnn.add(hidden_tt, attn_normed, **aot)
+            hidden_tt = ttnn.add(hidden_tt, attn_normed, **aot)
 
-            normed2_tt  = rms(hidden_tt, lw.norm3_w, lw.norm3_sc)
-            mlp_raw_tt  = self._mlp(normed2_tt, layer_idx)
-            mlp_normed  = rms(mlp_raw_tt, lw.norm4_w, lw.norm4_sc)
-            hidden_tt   = ttnn.add(hidden_tt, mlp_normed, **aot)
+            normed2_tt = rms(hidden_tt, lw.norm3_w, lw.norm3_sc)
+            mlp_raw_tt = self._mlp(normed2_tt, layer_idx)
+            mlp_normed = rms(mlp_raw_tt, lw.norm4_w, lw.norm4_sc)
+            hidden_tt = ttnn.add(hidden_tt, mlp_normed, **aot)
         elif lw.norm_style == "gpt_neox":
             # GPTNeoX parallel residual pattern:
             #   attn and MLP both branch from the same pre-norm hidden state
             #   hidden += attn(norm1(hidden)) + mlp(norm2(hidden))
             if self._uses_layernorm:
                 # CP-3: on-device ttnn.layer_norm — no CPU readback (trace-safe).
-                eps = getattr(self._hf_cfg, "layer_norm_eps",
-                              getattr(self._hf_cfg, "rms_norm_eps", 1e-5))
-                normed1_tt = self._layernorm_dev(hidden_tt, lw.norm1_w_ln_tt, lw.norm1_b_ln_tt, eps)
-                normed2_tt = self._layernorm_dev(hidden_tt, lw.norm2_w_ln_tt, lw.norm2_b_ln_tt, eps)
+                eps = getattr(
+                    self._hf_cfg,
+                    "layer_norm_eps",
+                    getattr(self._hf_cfg, "rms_norm_eps", 1e-5),
+                )
+                normed1_tt = self._layernorm_dev(
+                    hidden_tt, lw.norm1_w_ln_tt, lw.norm1_b_ln_tt, eps
+                )
+                normed2_tt = self._layernorm_dev(
+                    hidden_tt, lw.norm2_w_ln_tt, lw.norm2_b_ln_tt, eps
+                )
             else:
                 normed1_tt = rms(hidden_tt, lw.norm1_w, lw.norm1_sc)
                 normed2_tt = rms(hidden_tt, lw.norm2_w, lw.norm2_sc)
@@ -1057,13 +1167,17 @@ class TTModelRunner:
             # Llama / Qwen / Mistral / (LayerNorm: BLOOM, StableLM, Falcon) pattern:
             #   hidden += attn(norm1(hidden))
             #   hidden += mlp(norm2(hidden))
-            normed1_tt = seq_norm(hidden_tt, lw.norm1_w, lw.norm1_sc, lw.norm1_w_ln_tt, lw.norm1_b_ln_tt)
+            normed1_tt = seq_norm(
+                hidden_tt, lw.norm1_w, lw.norm1_sc, lw.norm1_w_ln_tt, lw.norm1_b_ln_tt
+            )
             attn_out_tt = self._attention(normed1_tt, layer_idx, kv_pos)
             hidden_tt = add_resid(hidden_tt, attn_out_tt)
-            if self._ladder_subop:                  # intra-layer rung (#49, DISPATCH_LADDER_SUBOP=1)
+            if self._ladder_subop:  # intra-layer rung (#49, DISPATCH_LADDER_SUBOP=1)
                 self._ladder_capture(f"layer{layer_idx}.post_attn", hidden_tt)
 
-            normed2_tt = seq_norm(hidden_tt, lw.norm2_w, lw.norm2_sc, lw.norm2_w_ln_tt, lw.norm2_b_ln_tt)
+            normed2_tt = seq_norm(
+                hidden_tt, lw.norm2_w, lw.norm2_sc, lw.norm2_w_ln_tt, lw.norm2_b_ln_tt
+            )
             mlp_out_tt = self._mlp(normed2_tt, layer_idx)
             hidden_tt = add_resid(hidden_tt, mlp_out_tt)
 
@@ -1076,20 +1190,29 @@ class TTModelRunner:
         Uses pre-allocated CPU staging buffers to avoid torch.zeros() each call.
         """
         import ttnn
-        cfg  = self._cfg
-        hd   = cfg.head_dim
+
+        cfg = self._cfg
+        hd = cfg.head_dim
 
         self._k_in_cpu.zero_()
         self._v_in_cpu.zero_()
         self._k_in_cpu[0, :, 0, :hd] = k_cpu.bfloat16()
         self._v_in_cpu[0, :, 0, :hd] = v_cpu.bfloat16()
 
-        k_tt = ttnn.from_torch(self._k_in_cpu, dtype=ttnn.bfloat16,
-                               layout=ttnn.TILE_LAYOUT, device=self._device,
-                               memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        v_tt = ttnn.from_torch(self._v_in_cpu, dtype=ttnn.bfloat16,
-                               layout=ttnn.TILE_LAYOUT, device=self._device,
-                               memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        k_tt = ttnn.from_torch(
+            self._k_in_cpu,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self._device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        v_tt = ttnn.from_torch(
+            self._v_in_cpu,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self._device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
         ttnn.kv_cache.update_cache_for_token_(self._k_dev[layer_idx], k_tt, kv_pos, 0)
         ttnn.kv_cache.update_cache_for_token_(self._v_dev[layer_idx], v_tt, kv_pos, 0)
         ttnn.deallocate(k_tt)
@@ -1105,15 +1228,16 @@ class TTModelRunner:
         sequentially, sharing the KV read for heads in the same GQA group.
         """
         import ttnn
-        cfg  = self._cfg
-        lw   = self._layers[layer_idx]
-        hd   = cfg.head_dim
+
+        cfg = self._cfg
+        lw = self._layers[layer_idx]
+        hd = cfg.head_dim
         hd_p = _tile_align(hd)
 
         # Fused QKV projection — write into pre-allocated scratch (no mmap; not in prefill)
         _pf = getattr(self, "_prefilling", False)
-        qkv_ot  = self._qkv_scratch_tt if (self._matmul_ot and not _pf) else None
-        qkv_tt  = _matmul_safe(normed_tt, lw.qkv_w, self._device, output_tensor=qkv_ot)
+        qkv_ot = self._qkv_scratch_tt if (self._matmul_ot and not _pf) else None
+        qkv_tt = _matmul_safe(normed_tt, lw.qkv_w, self._device, output_tensor=qkv_ot)
 
         # Batched prefill (eager, [N,hidden]): causal SDPA + paged_fill_cache.
         if _pf:
@@ -1128,15 +1252,19 @@ class TTModelRunner:
         if self._ondevice_attn:
             return self._attention_ondevice(qkv_tt, layer_idx, kv_pos, lw)
 
-        qkv_cpu = ttnn.to_torch(qkv_tt)[0].float()   # (total_qkv_p,)
+        qkv_cpu = ttnn.to_torch(qkv_tt)[0].float()  # (total_qkv_p,)
         if qkv_ot is None:
             ttnn.deallocate(qkv_tt)
         if lw.qkv_b is not None:
             qkv_cpu += lw.qkv_b
 
-        q_cpu = qkv_cpu[:lw.q_end].view(cfg.num_heads,    hd_p)[:, :hd].contiguous()
-        k_cpu = qkv_cpu[lw.q_end:lw.k_end].view(cfg.num_kv_heads, hd_p)[:, :hd].contiguous()
-        v_cpu = qkv_cpu[lw.k_end:].view(cfg.num_kv_heads, hd_p)[:, :hd].contiguous()
+        q_cpu = qkv_cpu[: lw.q_end].view(cfg.num_heads, hd_p)[:, :hd].contiguous()
+        k_cpu = (
+            qkv_cpu[lw.q_end : lw.k_end]
+            .view(cfg.num_kv_heads, hd_p)[:, :hd]
+            .contiguous()
+        )
+        v_cpu = qkv_cpu[lw.k_end :].view(cfg.num_kv_heads, hd_p)[:, :hd].contiguous()
 
         # Optional per-head Q/K norm (Gemma 3, Qwen 3)
         if lw.q_norm_w is not None:
@@ -1170,24 +1298,31 @@ class TTModelRunner:
 
         # Reshape device KV cache [1, N_kv, max_seq_p, hd_p] →
         # [N_kv * max_seq_p, hd_p] as expected by flash_attn_kernel
-        nkv      = cfg.num_kv_heads
-        ms_p     = _tile_align(self._max_seq)
+        nkv = cfg.num_kv_heads
+        ms_p = _tile_align(self._max_seq)
         K_2d = ttnn.reshape(self._k_dev[layer_idx], [nkv * ms_p, hd_p])
         V_2d = ttnn.reshape(self._v_dev[layer_idx], [nkv * ms_p, hd_p])
 
         # Build causal mask: [TILE, max_seq_p] — 0 for valid positions, -inf for future
         # Reuse pre-allocated CPU buffer; only the boundary tile changes each step
         self._mask_cpu.fill_(float("-inf"))
-        self._mask_cpu[0, :kv_pos + 1] = 0.0
+        self._mask_cpu[0, : kv_pos + 1] = 0.0
         mask_tt = _to_tt(self._mask_cpu, self._device)
 
         # Run flash attention on Tensix cores
         self._dispatcher.flash_attn(
-            q_tt, K_2d, V_2d,
-            self._fa_scale_tt, self._fa_ninf_tt, self._fa_zero_tt,
-            self._fa_zero_head_tt, self._fa_ones_tt,
-            mask_tt, self._fa_out_tt,
-            N_heads=cfg.num_heads, N_kv_heads=cfg.num_kv_heads,
+            q_tt,
+            K_2d,
+            V_2d,
+            self._fa_scale_tt,
+            self._fa_ninf_tt,
+            self._fa_zero_tt,
+            self._fa_zero_head_tt,
+            self._fa_ones_tt,
+            mask_tt,
+            self._fa_out_tt,
+            N_heads=cfg.num_heads,
+            N_kv_heads=cfg.num_kv_heads,
         )
 
         # O projection — _fa_out_tt is [TILE, N_heads*hd_p], already O-proj compatible
@@ -1200,11 +1335,12 @@ class TTModelRunner:
         rotary_ndims == head_dim (gated by self._ondevice_attn).
         """
         import ttnn
-        hd   = self._cfg.head_dim
+
+        hd = self._cfg.head_dim
         half = hd // 2
-        H    = x4.shape[2]
-        a  = ttnn.slice(x4, [0, 0, 0, 0],    [1, 1, H, half])
-        b  = ttnn.slice(x4, [0, 0, 0, half], [1, 1, H, hd])
+        H = x4.shape[2]
+        a = ttnn.slice(x4, [0, 0, 0, 0], [1, 1, H, half])
+        b = ttnn.slice(x4, [0, 0, 0, half], [1, 1, H, hd])
         rh = ttnn.concat([ttnn.neg(b), a], dim=-1)
         return ttnn.add(ttnn.multiply(x4, c4), ttnn.multiply(rh, s4))
 
@@ -1217,32 +1353,41 @@ class TTModelRunner:
         tests/diagnostic/probe_split_rope_layout.py.
         """
         import ttnn
-        cfg  = self._cfg
-        hd   = cfg.head_dim
-        hd_p = _tile_align(hd)                 # == hd here (gated)
-        nh   = cfg.num_heads
-        nkv  = cfg.num_kv_heads
-        qp   = nh * hd_p
-        kp   = nkv * hd_p
+
+        cfg = self._cfg
+        hd = cfg.head_dim
+        hd_p = _tile_align(hd)  # == hd here (gated)
+        nh = cfg.num_heads
+        nkv = cfg.num_kv_heads
+        qp = nh * hd_p
+        kp = nkv * hd_p
         qend, kend, qkvp = qp, qp + kp, qp + 2 * kp
         ms_p = _tile_align(self._max_seq)
 
         # cos/sin for this position, gathered on-device from the resident tables
         self._pos_idx_cpu[0, 0] = kv_pos
-        pidx = ttnn.from_torch(self._pos_idx_cpu, dtype=ttnn.uint32,
-                               layout=ttnn.ROW_MAJOR_LAYOUT, device=self._device,
-                               memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        c4 = ttnn.unsqueeze_to_4D(ttnn.embedding(pidx, self._rope_cos_dev, layout=ttnn.TILE_LAYOUT))
-        s4 = ttnn.unsqueeze_to_4D(ttnn.embedding(pidx, self._rope_sin_dev, layout=ttnn.TILE_LAYOUT))
+        pidx = ttnn.from_torch(
+            self._pos_idx_cpu,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=self._device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        c4 = ttnn.unsqueeze_to_4D(
+            ttnn.embedding(pidx, self._rope_cos_dev, layout=ttnn.TILE_LAYOUT)
+        )
+        s4 = ttnn.unsqueeze_to_4D(
+            ttnn.embedding(pidx, self._rope_sin_dev, layout=ttnn.TILE_LAYOUT)
+        )
 
         # split row 0 of qkv into per-head Q/K/V, then RoPE Q and K
         row = ttnn.slice(qkv_tt, [0, 0], [1, qkvp])
-        if lw.qkv_b_tt is not None:                      # CP-1: fused QKV bias on device
+        if lw.qkv_b_tt is not None:  # CP-1: fused QKV bias on device
             row = ttnn.add(row, lw.qkv_b_tt)
-        q4  = ttnn.reshape(ttnn.slice(row, [0, 0],    [1, qend]), [1, 1, nh,  hd_p])
-        k4  = ttnn.reshape(ttnn.slice(row, [0, qend], [1, kend]), [1, 1, nkv, hd_p])
-        v4  = ttnn.reshape(ttnn.slice(row, [0, kend], [1, qkvp]), [1, 1, nkv, hd_p])
-        if lw.q_norm_w_tt is not None:                   # CP-4: per-head Q/K RMSNorm on device
+        q4 = ttnn.reshape(ttnn.slice(row, [0, 0], [1, qend]), [1, 1, nh, hd_p])
+        k4 = ttnn.reshape(ttnn.slice(row, [0, qend], [1, kend]), [1, 1, nkv, hd_p])
+        v4 = ttnn.reshape(ttnn.slice(row, [0, kend], [1, qkvp]), [1, 1, nkv, hd_p])
+        if lw.q_norm_w_tt is not None:  # CP-4: per-head Q/K RMSNorm on device
             q4 = self._head_rmsnorm_dev(q4, lw.q_norm_w_tt)
         if lw.k_norm_w_tt is not None:
             k4 = self._head_rmsnorm_dev(k4, lw.k_norm_w_tt)
@@ -1254,8 +1399,12 @@ class TTModelRunner:
         q_tt = ttnn.to_layout(q_tt, ttnn.TILE_LAYOUT)
 
         # write post-RoPE K and V into the on-device KV cache at kv_pos
-        k_in = ttnn.pad(ttnn.transpose(k_rot, 1, 2), [(0, 0), (0, 0), (0, TILE - 1), (0, 0)], 0.0)
-        v_in = ttnn.pad(ttnn.transpose(v4,    1, 2), [(0, 0), (0, 0), (0, TILE - 1), (0, 0)], 0.0)
+        k_in = ttnn.pad(
+            ttnn.transpose(k_rot, 1, 2), [(0, 0), (0, 0), (0, TILE - 1), (0, 0)], 0.0
+        )
+        v_in = ttnn.pad(
+            ttnn.transpose(v4, 1, 2), [(0, 0), (0, 0), (0, TILE - 1), (0, 0)], 0.0
+        )
         ttnn.kv_cache.update_cache_for_token_(self._k_dev[layer_idx], k_in, kv_pos, 0)
         ttnn.kv_cache.update_cache_for_token_(self._v_dev[layer_idx], v_in, kv_pos, 0)
 
@@ -1263,14 +1412,21 @@ class TTModelRunner:
         K_2d = ttnn.reshape(self._k_dev[layer_idx], [nkv * ms_p, hd_p])
         V_2d = ttnn.reshape(self._v_dev[layer_idx], [nkv * ms_p, hd_p])
         self._mask_cpu.fill_(float("-inf"))
-        self._mask_cpu[0, :kv_pos + 1] = 0.0
+        self._mask_cpu[0, : kv_pos + 1] = 0.0
         mask_tt = _to_tt(self._mask_cpu, self._device)
         self._dispatcher.flash_attn(
-            q_tt, K_2d, V_2d,
-            self._fa_scale_tt, self._fa_ninf_tt, self._fa_zero_tt,
-            self._fa_zero_head_tt, self._fa_ones_tt,
-            mask_tt, self._fa_out_tt,
-            N_heads=nh, N_kv_heads=nkv,
+            q_tt,
+            K_2d,
+            V_2d,
+            self._fa_scale_tt,
+            self._fa_ninf_tt,
+            self._fa_zero_tt,
+            self._fa_zero_head_tt,
+            self._fa_ones_tt,
+            mask_tt,
+            self._fa_out_tt,
+            N_heads=nh,
+            N_kv_heads=nkv,
         )
         return self._o_proj(self._fa_out_tt, lw)
 
@@ -1284,9 +1440,13 @@ class TTModelRunner:
         """
         import os
         import ttnn
+
         self._paged_attn = False
         self._traced = False
-        want = os.environ.get("DISPATCH_PAGED_ATTN", "0") == "1" or os.environ.get("DISPATCH_TRACE", "0") == "1"
+        want = (
+            os.environ.get("DISPATCH_PAGED_ATTN", "0") == "1"
+            or os.environ.get("DISPATCH_TRACE", "0") == "1"
+        )
         if not want:
             return
         cfg = self._cfg
@@ -1302,52 +1462,89 @@ class TTModelRunner:
         # group-does-not-divide-32 models (starcoder g=12, qwen2.5 g=7) take the custom route.
         # CP-5: the decode SDPA accepts arbitrary GQA groups (probe_gqa_sdpa_group.py,
         # PCC 0.9997 for group 7/12), so group | 32 is no longer required.
-        ok_shape = (nkv > 0 and nh % nkv == 0 and group > 0 and nh <= 32)
+        ok_shape = nkv > 0 and nh % nkv == 0 and group > 0 and nh <= 32
         if not (self._ondevice_attn_eligible and hd_p == hd and ok_shape):
-            print(f"  Paged decode: NOT eligible (need eligible on-device attn + tile head_dim "
-                  f"+ nh<=32; nh={nh}, nkv={nkv}, group={group}, hd_p==hd={hd_p == hd})")
+            print(
+                f"  Paged decode: NOT eligible (need eligible on-device attn + tile head_dim "
+                f"+ nh<=32; nh={nh}, nkv={nkv}, group={group}, hd_p==hd={hd_p == hd})"
+            )
             return
-        self._nh, self._nkv = nh, nkv          # real head counts
+        self._nh, self._nkv = nh, nkv  # real head counts
         # CP-5: pad q to group*nkv_pad — that is 32 for group|32 (validated path, unchanged)
         # and exactly nh for group∤32 (starcoder2 g=12 -> 24, qwen2.5 g=7 -> 28). The padded
         # grouping nh_pad/nkv_pad always equals the real group, so q-heads map to real kv-heads.
-        self._nkv_pad = 32 // group             # == nkv when nh==32 (no-op)
-        self._nh_pad = group * self._nkv_pad    # 32 for group|32; nh for group∤32
+        self._nkv_pad = 32 // group  # == nkv when nh==32 (no-op)
+        self._nh_pad = group * self._nkv_pad  # 32 for group|32; nh for group∤32
         self._block = 32
         self._nblocks = math.ceil(_tile_align(self._max_seq) / self._block)
         n = len(self._layers)
 
         def zc():
-            return ttnn.zeros([self._nblocks, self._nkv_pad, self._block, hd], dtype=ttnn.bfloat16,
-                              layout=ttnn.TILE_LAYOUT, device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            return ttnn.zeros(
+                [self._nblocks, self._nkv_pad, self._block, hd],
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self._device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
         self._kp = [zc() for _ in range(n)]
         self._vp = [zc() for _ in range(n)]
         pt = torch.arange(self._nblocks, dtype=torch.int32).reshape(1, self._nblocks)
-        self._page_table = ttnn.from_torch(pt, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT,
-                                           device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        grid = ttnn.num_cores_to_corerangeset(1, self._device.compute_with_storage_grid_size(), True)
+        self._page_table = ttnn.from_torch(
+            pt,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=self._device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        grid = ttnn.num_cores_to_corerangeset(
+            1, self._device.compute_with_storage_grid_size(), True
+        )
         self._kv_shard = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1,
-            ttnn.ShardSpec(grid, [32, hd], ttnn.ShardOrientation.ROW_MAJOR))
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(grid, [32, hd], ttnn.ShardOrientation.ROW_MAJOR),
+        )
         self._sdpa_pcfg = ttnn.SDPAProgramConfig(
-            compute_with_storage_grid_size=(8, 1), q_chunk_size=32, k_chunk_size=self._block)
+            compute_with_storage_grid_size=(8, 1),
+            q_chunk_size=32,
+            k_chunk_size=self._block,
+        )
         self._cur_pos_cpu = torch.zeros(1, dtype=torch.int32)
-        self._cur_pos_dev = ttnn.from_torch(self._cur_pos_cpu, dtype=ttnn.int32,
-                                            layout=ttnn.ROW_MAJOR_LAYOUT, device=self._device,
-                                            memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        assert hasattr(self, "_rope_cos_dev"), "rope device tables missing (should be uploaded in _build_rope_table)"
+        self._cur_pos_dev = ttnn.from_torch(
+            self._cur_pos_cpu,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=self._device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        assert hasattr(self, "_rope_cos_dev"), (
+            "rope device tables missing (should be uploaded in _build_rope_table)"
+        )
         # Pinned token-id buffer for host-free embed inside the trace (#30)
         self._tok_cpu = torch.zeros(1, 1, dtype=torch.int32)
-        self._tok_dev = ttnn.from_torch(self._tok_cpu, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT,
-                                        device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        self._tok_dev = ttnn.from_torch(
+            self._tok_cpu,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=self._device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
         self._traced = os.environ.get("DISPATCH_TRACE", "0") == "1"
         self._trace_id = None
         self._traced_hidden = None
         self._paged_attn = True
-        pad_note = "" if self._nh_pad == nh else f", q {nh}->32 / kv {nkv}->{self._nkv_pad} (group {group})"
-        print(f"  Paged decode: ENABLED ({self._nblocks} blocks × {self._block}, {n} layers, "
-              f"nkv={nkv}{pad_note})"
-              f"{' + TRACE' if self._traced else ''}")
+        pad_note = (
+            ""
+            if self._nh_pad == nh
+            else f", q {nh}->32 / kv {nkv}->{self._nkv_pad} (group {group})"
+        )
+        print(
+            f"  Paged decode: ENABLED ({self._nblocks} blocks × {self._block}, {n} layers, "
+            f"nkv={nkv}{pad_note})"
+            f"{' + TRACE' if self._traced else ''}"
+        )
 
     def _paged_attention(self, qkv_tt, layer_idx: int, lw):
         """Trace-safe paged attention (issue #30): device-indexed KV write + paged SDPA.
@@ -1357,6 +1554,7 @@ class TTModelRunner:
         it is fully trace-capturable. Validated core: probe_traced_decode.py.
         """
         import ttnn
+
         cfg = self._cfg
         hd = cfg.head_dim
         hd_p = _tile_align(hd)
@@ -1366,17 +1564,21 @@ class TTModelRunner:
 
         # cos/sin for the current position, gathered on-device from the pinned pos tensor
         pidx = ttnn.reshape(ttnn.typecast(self._cur_pos_dev, ttnn.uint32), [1, 1])
-        c4 = ttnn.unsqueeze_to_4D(ttnn.embedding(pidx, self._rope_cos_dev, layout=ttnn.TILE_LAYOUT))
-        s4 = ttnn.unsqueeze_to_4D(ttnn.embedding(pidx, self._rope_sin_dev, layout=ttnn.TILE_LAYOUT))
+        c4 = ttnn.unsqueeze_to_4D(
+            ttnn.embedding(pidx, self._rope_cos_dev, layout=ttnn.TILE_LAYOUT)
+        )
+        s4 = ttnn.unsqueeze_to_4D(
+            ttnn.embedding(pidx, self._rope_sin_dev, layout=ttnn.TILE_LAYOUT)
+        )
 
         # split row 0 -> per-head Q/K/V, RoPE Q and K
         row = ttnn.slice(qkv_tt, [0, 0], [1, qkvp])
-        if lw.qkv_b_tt is not None:                      # CP-1: fused QKV bias on device
+        if lw.qkv_b_tt is not None:  # CP-1: fused QKV bias on device
             row = ttnn.add(row, lw.qkv_b_tt)
-        q4 = ttnn.reshape(ttnn.slice(row, [0, 0],    [1, qend]), [1, 1, nh,  hd_p])
+        q4 = ttnn.reshape(ttnn.slice(row, [0, 0], [1, qend]), [1, 1, nh, hd_p])
         k4 = ttnn.reshape(ttnn.slice(row, [0, qend], [1, kend]), [1, 1, nkv, hd_p])
         v4 = ttnn.reshape(ttnn.slice(row, [0, kend], [1, qkvp]), [1, 1, nkv, hd_p])
-        if lw.q_norm_w_tt is not None:                   # CP-4: per-head Q/K RMSNorm on device
+        if lw.q_norm_w_tt is not None:  # CP-4: per-head Q/K RMSNorm on device
             q4 = self._head_rmsnorm_dev(q4, lw.q_norm_w_tt)
         if lw.k_norm_w_tt is not None:
             k4 = self._head_rmsnorm_dev(k4, lw.k_norm_w_tt)
@@ -1388,27 +1590,43 @@ class TTModelRunner:
         # from the 32-padded input (real kv in 0..nkv-1, pad heads nkv..nkv_pad-1 stay zero).
         pad = [(0, 0), (0, 0), (0, TILE - nkv), (0, 0)]
         k_sh = ttnn.interleaved_to_sharded(ttnn.pad(k_rot, pad, 0.0), self._kv_shard)
-        v_sh = ttnn.interleaved_to_sharded(ttnn.pad(v4,    pad, 0.0), self._kv_shard)
-        ttnn.experimental.paged_update_cache(self._kp[layer_idx], k_sh,
-                                             update_idxs_tensor=self._cur_pos_dev, page_table=self._page_table)
-        ttnn.experimental.paged_update_cache(self._vp[layer_idx], v_sh,
-                                             update_idxs_tensor=self._cur_pos_dev, page_table=self._page_table)
+        v_sh = ttnn.interleaved_to_sharded(ttnn.pad(v4, pad, 0.0), self._kv_shard)
+        ttnn.experimental.paged_update_cache(
+            self._kp[layer_idx],
+            k_sh,
+            update_idxs_tensor=self._cur_pos_dev,
+            page_table=self._page_table,
+        )
+        ttnn.experimental.paged_update_cache(
+            self._vp[layer_idx],
+            v_sh,
+            update_idxs_tensor=self._cur_pos_dev,
+            page_table=self._page_table,
+        )
 
         # Proportional kv-pad (#35): pad Q to 32 heads so padded grouping (32/nkv_pad) == real
         # group; no-op when nh==32. SDPA returns [1,1,32,hd]; keep only the real heads.
         if self._nh_pad != nh:
-            q_rot = ttnn.pad(q_rot, [(0, 0), (0, 0), (0, self._nh_pad - nh), (0, 0)], 0.0)
+            q_rot = ttnn.pad(
+                q_rot, [(0, 0), (0, 0), (0, self._nh_pad - nh), (0, 0)], 0.0
+            )
 
         # SWA (gemma3): clip sliding layers to their window; global layers pass 0 (full attn).
         swa_kw = {"sliding_window_size": lw.swa_window} if lw.swa_window else {}
         attn = ttnn.transformer.paged_scaled_dot_product_attention_decode(
-            q_rot, self._kp[layer_idx], self._vp[layer_idx],
-            cur_pos_tensor=self._cur_pos_dev, page_table_tensor=self._page_table,
-            scale=self._attn_scale_value(), program_config=self._sdpa_pcfg,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG, **swa_kw)   # [1,1,nh_pad,hd]
+            q_rot,
+            self._kp[layer_idx],
+            self._vp[layer_idx],
+            cur_pos_tensor=self._cur_pos_dev,
+            page_table_tensor=self._page_table,
+            scale=self._attn_scale_value(),
+            program_config=self._sdpa_pcfg,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            **swa_kw,
+        )  # [1,1,nh_pad,hd]
 
         if self._nh_pad != nh:
-            attn = ttnn.slice(attn, [0, 0, 0, 0], [1, 1, nh, hd_p])   # real heads only
+            attn = ttnn.slice(attn, [0, 0, 0, 0], [1, 1, nh, hd_p])  # real heads only
 
         # flatten heads -> [1, nh*hd_p] (head-major matches O-proj weight), broadcast to TILE rows
         attn_flat = ttnn.reshape(attn, [1, nh * hd_p])
@@ -1420,10 +1638,11 @@ class TTModelRunner:
         """RoPE over a sequence. x4: [1,H,N,hd]; c4/s4: [1,1,N,hd] (per-position, broadcast
         over heads). Same rotate-half convention as _dev_rope (probe PCC 0.999997)."""
         import ttnn
+
         hd = self._cfg.head_dim
         half = hd // 2
         H, N = x4.shape[1], x4.shape[2]
-        a = ttnn.slice(x4, [0, 0, 0, 0],    [1, H, N, half])
+        a = ttnn.slice(x4, [0, 0, 0, 0], [1, H, N, half])
         b = ttnn.slice(x4, [0, 0, 0, half], [1, H, N, hd])
         rh = ttnn.concat([ttnn.neg(b), a], dim=-1)
         return ttnn.add(ttnn.multiply(x4, c4), ttnn.multiply(rh, s4))
@@ -1431,11 +1650,18 @@ class TTModelRunner:
     def _rope_tables_prefill(self, N: int):
         """Gather cos/sin for positions 0..N-1 from the resident rope tables -> [1,1,N,hd]."""
         import ttnn
+
         hd = self._cfg.head_dim
-        pidx = ttnn.from_torch(torch.arange(N, dtype=torch.int32).reshape(1, N), dtype=ttnn.uint32,
-                               layout=ttnn.ROW_MAJOR_LAYOUT, device=self._device,
-                               memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        c = ttnn.embedding(pidx, self._rope_cos_dev, layout=ttnn.TILE_LAYOUT)   # [1,N,rotary_ndims]
+        pidx = ttnn.from_torch(
+            torch.arange(N, dtype=torch.int32).reshape(1, N),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=self._device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        c = ttnn.embedding(
+            pidx, self._rope_cos_dev, layout=ttnn.TILE_LAYOUT
+        )  # [1,N,rotary_ndims]
         s = ttnn.embedding(pidx, self._rope_sin_dev, layout=ttnn.TILE_LAYOUT)
         return ttnn.reshape(c, [1, 1, N, hd]), ttnn.reshape(s, [1, 1, N, hd])
 
@@ -1444,21 +1670,23 @@ class TTModelRunner:
         Reuses CP-1 bias, CP-4 per-head norm, the rope convention, and _o_proj. Fills the SAME
         paged cache decode reads (paged_fill_cache offset == paged_update_cache, probe-verified)."""
         import ttnn
+
         cfg = self._cfg
-        hd, hd_p = cfg.head_dim, _tile_align(cfg.head_dim)
+        hd_p = _tile_align(cfg.head_dim)
         nh, nkv = cfg.num_heads, cfg.num_kv_heads
         N = self._prefill_N
         qend, kend, qkvp = nh * hd_p, nh * hd_p + nkv * hd_p, nh * hd_p + 2 * nkv * hd_p
-        if lw.qkv_b_tt is not None:                                    # CP-1
+        if lw.qkv_b_tt is not None:  # CP-1
             qkv_tt = self._bias_add(qkv_tt, lw.qkv_b_tt)
 
-        def to_heads(c0, c1, H):                                       # [N, H*hd_p] -> [1,H,N,hd_p]
+        def to_heads(c0, c1, H):  # [N, H*hd_p] -> [1,H,N,hd_p]
             t = ttnn.reshape(ttnn.slice(qkv_tt, [0, c0], [N, c1]), [1, N, H, hd_p])
             return ttnn.permute(t, (0, 2, 1, 3))
+
         q4 = to_heads(0, qend, nh)
         k4 = to_heads(qend, kend, nkv)
         v4 = to_heads(kend, qkvp, nkv)
-        if lw.q_norm_w_tt is not None:                                # CP-4
+        if lw.q_norm_w_tt is not None:  # CP-4
             q4 = self._head_rmsnorm_dev(q4, lw.q_norm_w_tt)
         if lw.k_norm_w_tt is not None:
             k4 = self._head_rmsnorm_dev(k4, lw.k_norm_w_tt)
@@ -1472,14 +1700,24 @@ class TTModelRunner:
             hpad = [(0, 0), (0, self._nkv_pad - nkv), (0, 0), (0, 0)]
             kfill = ttnn.pad(k_rot, hpad, 0.0)
             vfill = ttnn.pad(v4, hpad, 0.0)
-        ttnn.experimental.paged_fill_cache(self._kp[layer_idx], kfill, self._page_table, batch_idx=0)
-        ttnn.experimental.paged_fill_cache(self._vp[layer_idx], vfill, self._page_table, batch_idx=0)
+        ttnn.experimental.paged_fill_cache(
+            self._kp[layer_idx], kfill, self._page_table, batch_idx=0
+        )
+        ttnn.experimental.paged_fill_cache(
+            self._vp[layer_idx], vfill, self._page_table, batch_idx=0
+        )
 
         # causal SDPA on contiguous q/k/v (real nh/nkv — no decode 32-pad)
         swa_kw = {"sliding_window_size": lw.swa_window} if lw.swa_window else {}
         attn = ttnn.transformer.scaled_dot_product_attention(
-            q_rot, k_rot, v4, is_causal=True, scale=self._attn_scale_value(),
-            program_config=self._sdpa_pcfg, **swa_kw)                 # [1,nh,N,hd_p]
+            q_rot,
+            k_rot,
+            v4,
+            is_causal=True,
+            scale=self._attn_scale_value(),
+            program_config=self._sdpa_pcfg,
+            **swa_kw,
+        )  # [1,nh,N,hd_p]
         attn_t = ttnn.reshape(ttnn.permute(attn, (0, 2, 1, 3)), [N, nh * hd_p])
         return self._o_proj(attn_t, lw)
 
@@ -1488,9 +1726,12 @@ class TTModelRunner:
         Batched on-device prefill for paged-eligible models behind DISPATCH_BATCHED_PREFILL;
         otherwise the token-by-token loop (correct for every model)."""
         import os
-        if (getattr(self, "_paged_attn", False)
-                and os.environ.get("DISPATCH_BATCHED_PREFILL", "0") == "1"
-                and 0 < len(input_ids) <= self._max_seq):
+
+        if (
+            getattr(self, "_paged_attn", False)
+            and os.environ.get("DISPATCH_BATCHED_PREFILL", "0") == "1"
+            and 0 < len(input_ids) <= self._max_seq
+        ):
             return self._prefill_batched(input_ids)
         next_id = None
         for pos, tok in enumerate(input_ids):
@@ -1501,21 +1742,26 @@ class TTModelRunner:
         """Eager batched prefill: embed N tokens, run all layers on [N,hidden], fill the paged
         cache for 0..N-1, return lm_head(position N-1). Decode then continues from cur_pos=N."""
         import ttnn
+
         N = len(input_ids)
         hp = _tile_align(self._cfg.hidden_size)
         self._prefilling = True
         self._prefill_N = N
         try:
-            ids = ttnn.from_torch(torch.tensor(input_ids, dtype=torch.int32).reshape(1, N),
-                                  dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT,
-                                  device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-            emb = ttnn.embedding(ids, self._embed_tt)                 # [1, N, hidden]
+            ids = ttnn.from_torch(
+                torch.tensor(input_ids, dtype=torch.int32).reshape(1, N),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=self._device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            emb = ttnn.embedding(ids, self._embed_tt)  # [1, N, hidden]
             hidden = ttnn.to_layout(ttnn.reshape(emb, [N, hp]), ttnn.TILE_LAYOUT)
             if self._embed_scale != 1.0:
                 hidden = ttnn.multiply(hidden, self._embed_scale)
             for i in range(len(self._layers)):
-                hidden = self._layer_forward(hidden, i, 0)            # kv_pos unused in prefill
-            last = ttnn.slice(hidden, [N - 1, 0], [N, hp])           # [1, hp] = position N-1
+                hidden = self._layer_forward(hidden, i, 0)  # kv_pos unused in prefill
+            last = ttnn.slice(hidden, [N - 1, 0], [N, hp])  # [1, hp] = position N-1
         finally:
             self._prefilling = False
         return self._lm_head(last)
@@ -1531,27 +1777,32 @@ class TTModelRunner:
         to avoid mmap/munmap cycling on intermediate tensors.
         """
         import ttnn
-        lw   = self._layers[layer_idx]
+
+        lw = self._layers[layer_idx]
         # (#3 Phase C) listed -> matrix activation (canonical silu/gelu/gelu_tanh/relu2);
         # novel -> _cfg.activation (raw HF act string). Both are matched below.
-        act  = self._entry.activation if self._listed else self._cfg.activation
-        _pf  = getattr(self, "_prefilling", False)   # prefill: fresh alloc, no TILE scratch
-        mot  = self._matmul_ot and not _pf
+        act = self._entry.activation if self._listed else self._cfg.activation
+        _pf = getattr(
+            self, "_prefilling", False
+        )  # prefill: fresh alloc, no TILE scratch
+        mot = self._matmul_ot and not _pf
         muot = self._mul_ot and not _pf
 
         if lw.gate_w is None:
             # 2-proj MLP: act(up(x)+up_b) → down(·)+down_b  (GPTNeoX, BLOOM, Starcoder2, OLMo)
             up_ot = self._up_scratch_tt if mot else None
             up_tt = _matmul_safe(normed_tt, lw.up_w, self._device, output_tensor=up_ot)
-            if lw.up_b is not None:                 # bias before activation
+            if lw.up_b is not None:  # bias before activation
                 up_biased = self._bias_add(up_tt, lw.up_b)
                 if up_ot is None:
                     ttnn.deallocate(up_tt)
-                up_tt, up_ot = up_biased, None      # own the fresh tensor now
+                up_tt, up_ot = up_biased, None  # own the fresh tensor now
             if act == "silu":
                 act_tt = ttnn.silu(up_tt)
             elif act in _GELU_ACTS:
-                act_tt = ttnn.gelu(up_tt, fast_and_approximate_mode=(act in _GELU_TANH_ACTS))
+                act_tt = ttnn.gelu(
+                    up_tt, fast_and_approximate_mode=(act in _GELU_TANH_ACTS)
+                )
             else:
                 act_tt = ttnn.relu(up_tt)
             if up_ot is None:
@@ -1566,11 +1817,13 @@ class TTModelRunner:
 
         # SwiGLU: act(gate(x)) * up(x) → down
         gate_ot = self._gate_scratch_tt if mot else None
-        up_ot   = self._up_scratch_tt   if mot else None
-        gate_tt = _matmul_safe(normed_tt, lw.gate_w, self._device, output_tensor=gate_ot)
-        up_tt   = _matmul_safe(normed_tt, lw.up_w,   self._device, output_tensor=up_ot)
+        up_ot = self._up_scratch_tt if mot else None
+        gate_tt = _matmul_safe(
+            normed_tt, lw.gate_w, self._device, output_tensor=gate_ot
+        )
+        up_tt = _matmul_safe(normed_tt, lw.up_w, self._device, output_tensor=up_ot)
 
-        if lw.gate_b is not None:                   # presence-driven; no-op for Llama-style
+        if lw.gate_b is not None:  # presence-driven; no-op for Llama-style
             t = self._bias_add(gate_tt, lw.gate_b)
             if gate_ot is None:
                 ttnn.deallocate(gate_tt)
@@ -1583,16 +1836,24 @@ class TTModelRunner:
 
         act_ot = self._activated_scratch_tt if muot else None
         if act == "silu":
-            activated_tt = ttnn.multiply(ttnn.silu(gate_tt), up_tt,
-                                         **({"output_tensor": act_ot} if act_ot else {}))
+            activated_tt = ttnn.multiply(
+                ttnn.silu(gate_tt),
+                up_tt,
+                **({"output_tensor": act_ot} if act_ot else {}),
+            )
         elif act in _GELU_ACTS:
             activated_tt = ttnn.multiply(
-                ttnn.gelu(gate_tt, fast_and_approximate_mode=(act in _GELU_TANH_ACTS)), up_tt,
-                **({"output_tensor": act_ot} if act_ot else {}))
+                ttnn.gelu(gate_tt, fast_and_approximate_mode=(act in _GELU_TANH_ACTS)),
+                up_tt,
+                **({"output_tensor": act_ot} if act_ot else {}),
+            )
         else:  # relu2
             r = ttnn.relu(gate_tt)
-            activated_tt = ttnn.multiply(ttnn.multiply(r, r), up_tt,
-                                         **({"output_tensor": act_ot} if act_ot else {}))
+            activated_tt = ttnn.multiply(
+                ttnn.multiply(r, r),
+                up_tt,
+                **({"output_tensor": act_ot} if act_ot else {}),
+            )
             ttnn.deallocate(r)
         if gate_ot is None:
             ttnn.deallocate(gate_tt)
@@ -1627,12 +1888,13 @@ class TTModelRunner:
         """
         import os
         import ttnn
+
         self._ondevice_lmhead = False
         self._lmhead_pad_mask = None
         if os.environ.get("DISPATCH_ONDEVICE_LMHEAD", "0") != "1":
             return
-        vocab   = int(self._lm_head_w_cpu.shape[0])          # [vocab, hidden]
-        vocab_p = int(self._lm_head_w_tt.shape[-1])          # uploaded [hidden_p, vocab_p]
+        vocab = int(self._lm_head_w_cpu.shape[0])  # [vocab, hidden]
+        vocab_p = int(self._lm_head_w_tt.shape[-1])  # uploaded [hidden_p, vocab_p]
         # CP-3: _lm_head_graph now handles both RMSNorm and LayerNorm final norms on
         # device, so lm_head_ondevice is no longer norm-gated.
         # On-device lm_head only PAYS OFF folded into the decode trace (#31). Run
@@ -1642,26 +1904,38 @@ class TTModelRunner:
         # the fast path: apply it only when this model is actually tracing, so each
         # optimization reaches only the models that benefit from it.
         if not getattr(self, "_traced", False):
-            print("  On-device lm_head: skipped (only beneficial folded into the decode "
-                  "trace; model not on fast path) -> CPU lm_head")
+            print(
+                "  On-device lm_head: skipped (only beneficial folded into the decode "
+                "trace; model not on fast path) -> CPU lm_head"
+            )
             return
         # HiFi4 + fp32 dest accumulation: maximize precision of the wide bf16 dot
         # products over a large vocab so greedy argmax matches the CPU fp32 reference.
         self._lmhead_ckc = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi4, math_approx_mode=False,
-            fp32_dest_acc_en=True, packer_l1_acc=True)
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
         # Unaligned vocab: mask the zero-weight padding columns so argmax can't pick them.
         if vocab_p != vocab:
             m = torch.zeros(TILE, vocab_p, dtype=torch.bfloat16)
             m[:, vocab:] = float("-inf")
             self._lmhead_pad_mask = ttnn.from_torch(
-                m, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
-                device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+                m,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self._device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
         self._ondevice_lmhead = True
-        print(f"  On-device lm_head: ENABLED (DISPATCH_ONDEVICE_LMHEAD=1; "
-              f"norm+matmul+argmax on device, vocab={vocab}"
-              + (f", {vocab_p - vocab} padding cols masked" if vocab_p != vocab else "") + ")"
-              + (" + folded into decode trace" if getattr(self, "_traced", False) else ""))
+        print(
+            f"  On-device lm_head: ENABLED (DISPATCH_ONDEVICE_LMHEAD=1; "
+            f"norm+matmul+argmax on device, vocab={vocab}"
+            + (f", {vocab_p - vocab} padding cols masked" if vocab_p != vocab else "")
+            + ")"
+            + (" + folded into decode trace" if getattr(self, "_traced", False) else "")
+        )
 
     def _lm_head_graph(self, hidden_tt):
         """On-device final norm + lm_head matmul + argmax. Returns the argmax index tensor
@@ -1669,16 +1943,22 @@ class TTModelRunner:
         and argmax allocate fixed-address buffers captured by the trace (no host roundtrip).
         """
         import ttnn
-        if self._uses_layernorm:                            # CP-3: LayerNorm-aware final norm
-            eps = getattr(self._hf_cfg, "layer_norm_eps",
-                          getattr(self._hf_cfg, "rms_norm_eps", 1e-5))
-            normed_tt = self._layernorm_dev(hidden_tt, self._final_norm_w_ln_tt,
-                                            self._final_norm_b_ln_tt, eps)
-        else:                                               # RMSNorm final norm (#22 fix)
+
+        if self._uses_layernorm:  # CP-3: LayerNorm-aware final norm
+            eps = getattr(
+                self._hf_cfg,
+                "layer_norm_eps",
+                getattr(self._hf_cfg, "rms_norm_eps", 1e-5),
+            )
+            normed_tt = self._layernorm_dev(
+                hidden_tt, self._final_norm_w_ln_tt, self._final_norm_b_ln_tt, eps
+            )
+        else:  # RMSNorm final norm (#22 fix)
             eps = getattr(self._hf_cfg, "rms_norm_eps", 1e-5)
             normed_tt = self._rmsnorm_dev(hidden_tt, self._final_norm_w_tt, eps)
-        logits_tt = ttnn.matmul(normed_tt, self._lm_head_w_tt,
-                                compute_kernel_config=self._lmhead_ckc)
+        logits_tt = ttnn.matmul(
+            normed_tt, self._lm_head_w_tt, compute_kernel_config=self._lmhead_ckc
+        )
         if self._lmhead_pad_mask is not None:
             logits_tt = ttnn.add(logits_tt, self._lmhead_pad_mask)
         return ttnn.argmax(logits_tt, dim=-1)
@@ -1693,22 +1973,29 @@ class TTModelRunner:
         """
         import os
         import ttnn
+
         out_tt = self._lm_head_graph(hidden_tt)
         dev_idx = int(ttnn.to_torch(out_tt).flatten()[0])
         if os.environ.get("DISPATCH_LMHEAD_DEBUG", "0") == "1":
             hidden = self._cfg.hidden_size
             h_cpu = ttnn.to_torch(hidden_tt)[0, :hidden].float()
-            rms = h_cpu.pow(2).mean().add(
-                getattr(self._hf_cfg, "rms_norm_eps", 1e-5)).sqrt()
+            rms = (
+                h_cpu.pow(2)
+                .mean()
+                .add(getattr(self._hf_cfg, "rms_norm_eps", 1e-5))
+                .sqrt()
+            )
             normed = (h_cpu / rms) * self._final_norm_w_cpu
             ref_logits = normed @ self._lm_head_w_cpu.T
             ref_idx = int(ref_logits.argmax())
             if dev_idx != ref_idx:
                 gap = float(ref_logits[ref_idx] - ref_logits[dev_idx])
                 rng = float(ref_logits.max() - ref_logits.min())
-                print(f"  [lmhead-debug] divergence: dev={dev_idx} cpu={ref_idx} "
-                      f"fp32_gap={gap:.5f} (logit_range={rng:.2f}, rel={gap/rng:.2e})",
-                      flush=True)
+                print(
+                    f"  [lmhead-debug] divergence: dev={dev_idx} cpu={ref_idx} "
+                    f"fp32_gap={gap:.5f} (logit_range={rng:.2f}, rel={gap / rng:.2e})",
+                    flush=True,
+                )
         return dev_idx
 
     def _lm_head(self, hidden_tt) -> int:
@@ -1720,26 +2007,31 @@ class TTModelRunner:
         bf16 matmul + ttnn.argmax instead; see _setup_ondevice_lmhead.
         """
         import ttnn
+
         if self._ondevice_lmhead:
             return self._lm_head_ondevice(hidden_tt)
         hidden = self._cfg.hidden_size
         if self._uses_layernorm:
-            eps = getattr(self._hf_cfg, "layer_norm_eps",
-                          getattr(self._hf_cfg, "rms_norm_eps", 1e-5))
+            eps = getattr(
+                self._hf_cfg,
+                "layer_norm_eps",
+                getattr(self._hf_cfg, "rms_norm_eps", 1e-5),
+            )
             hidden_cpu = ttnn.to_torch(hidden_tt)[0, :hidden].float()
-            normed_cpu = _layernorm_cpu(hidden_cpu, self._final_norm_w_cpu,
-                                        self._final_norm_b_cpu, eps)
-        else:                                               # RMSNorm final norm (#22 fix)
+            normed_cpu = _layernorm_cpu(
+                hidden_cpu, self._final_norm_w_cpu, self._final_norm_b_cpu, eps
+            )
+        else:  # RMSNorm final norm (#22 fix)
             eps = getattr(self._hf_cfg, "rms_norm_eps", 1e-5)
-            normed_tt  = self._rmsnorm_dev(hidden_tt, self._final_norm_w_tt, eps)
-            normed_cpu = ttnn.to_torch(normed_tt)[0, :hidden].float()   # (hidden,)
-        logits = normed_cpu @ self._lm_head_w_cpu.T                 # (vocab,)
+            normed_tt = self._rmsnorm_dev(hidden_tt, self._final_norm_w_tt, eps)
+            normed_cpu = ttnn.to_torch(normed_tt)[0, :hidden].float()  # (hidden,)
+        logits = normed_cpu @ self._lm_head_w_cpu.T  # (vocab,)
         # Granite divides logits by logits_scaling (#43). No effect on greedy argmax
         # (positive divisor), applied for correctness / future temperature sampling.
         logits_scaling = self._scaling_factor("logits_scaling", 1.0)
         if logits_scaling != 1.0:
             logits = logits / logits_scaling
-        if self._ladder is not None:                # logits rung for the HF ladder (#49)
+        if self._ladder is not None:  # logits rung for the HF ladder (#49)
             self._ladder["logits"] = logits.detach().float().clone()
         return int(logits.argmax())
 
@@ -1757,11 +2049,14 @@ class TTModelRunner:
         # the two device tensors need different layouts (ROW_MAJOR vs TILE+transposed),
         # so they are uploaded separately.
         import ttnn as _ttnn
+
         embed_module = _find_embed_tokens(backbone)
-        embed_cpu = embed_module.weight.detach().bfloat16()       # [vocab, hidden]
-        hidden_p  = _tile_align(cfg.hidden_size)
+        embed_cpu = embed_module.weight.detach().bfloat16()  # [vocab, hidden]
+        hidden_p = _tile_align(cfg.hidden_size)
         if hidden_p != cfg.hidden_size:
-            embed_cpu = torch.nn.functional.pad(embed_cpu, (0, hidden_p - cfg.hidden_size))
+            embed_cpu = torch.nn.functional.pad(
+                embed_cpu, (0, hidden_p - cfg.hidden_size)
+            )
         self._embed_tt = _ttnn.from_torch(
             embed_cpu,
             dtype=_ttnn.bfloat16,
@@ -1775,12 +2070,17 @@ class TTModelRunner:
 
         # Embedding LayerNorm (BLOOM: word_embeddings_layernorm, applied to the embedding
         # before layer 0). CPU LayerNorm — None for every other arch (no-op).
-        embed_ln = (getattr(backbone, "word_embeddings_layernorm", None)
-                    or getattr(backbone, "embeddings_layernorm", None))
-        self._embed_ln_w_cpu = embed_ln.weight.detach().float() if embed_ln is not None else None
-        self._embed_ln_b_cpu = (embed_ln.bias.detach().float()
-                                if embed_ln is not None and getattr(embed_ln, "bias", None) is not None
-                                else None)
+        embed_ln = getattr(backbone, "word_embeddings_layernorm", None) or getattr(
+            backbone, "embeddings_layernorm", None
+        )
+        self._embed_ln_w_cpu = (
+            embed_ln.weight.detach().float() if embed_ln is not None else None
+        )
+        self._embed_ln_b_cpu = (
+            embed_ln.bias.detach().float()
+            if embed_ln is not None and getattr(embed_ln, "bias", None) is not None
+            else None
+        )
 
         # Behavioral flags (#3 Phase C). For a LISTED model these come from the matrix
         # entry (trusted, hardware-tuned); for a novel/unlisted model they fall back to the
@@ -1788,24 +2088,34 @@ class TTModelRunner:
         # match introspection, so listed models are byte-identical to the pre-#3 behavior.
         first_layer = layers_list[0]
         if self._listed:
-            self._gemma_norm        = (self._entry.norm_type == "gemma_rms")
-            self._uses_layernorm    = (self._entry.norm_type == "layernorm")
+            self._gemma_norm = self._entry.norm_type == "gemma_rms"
+            self._uses_layernorm = self._entry.norm_type == "layernorm"
             self._parallel_residual = self._entry.parallel_residual
-            self._embed_scale       = (math.sqrt(cfg.hidden_size)
-                                       if self._entry.embed_scale == "sqrt_hidden" else 1.0)
+            self._embed_scale = (
+                math.sqrt(cfg.hidden_size)
+                if self._entry.embed_scale == "sqrt_hidden"
+                else 1.0
+            )
         else:
             # Gemma-style (1+w) 4-norm pattern
-            self._gemma_norm = (hasattr(first_layer, "pre_feedforward_layernorm") and
-                                hasattr(first_layer, "post_feedforward_layernorm"))
+            self._gemma_norm = hasattr(
+                first_layer, "pre_feedforward_layernorm"
+            ) and hasattr(first_layer, "post_feedforward_layernorm")
             # GPTNeoX parallel residual: attn and MLP branch the same pre-norm hidden
-            self._parallel_residual = getattr(self._hf_cfg, "use_parallel_residual", False)
+            self._parallel_residual = getattr(
+                self._hf_cfg, "use_parallel_residual", False
+            )
             # LayerNorm (mean-sub + bias) vs RMSNorm: GPTNeoX/Pythia carry a norm bias
             first_norm = _find_layer_norms(first_layer)[0]
-            self._uses_layernorm = (hasattr(first_norm, "bias") and first_norm.bias is not None)
+            self._uses_layernorm = (
+                hasattr(first_norm, "bias") and first_norm.bias is not None
+            )
             # Gemma family scales input embeddings by sqrt(hidden_size)
-            text_cfg   = getattr(self._hf_cfg, "text_config", self._hf_cfg)
+            text_cfg = getattr(self._hf_cfg, "text_config", self._hf_cfg)
             model_type = getattr(text_cfg, "model_type", "")
-            self._embed_scale = math.sqrt(cfg.hidden_size) if "gemma" in model_type.lower() else 1.0
+            self._embed_scale = (
+                math.sqrt(cfg.hidden_size) if "gemma" in model_type.lower() else 1.0
+            )
 
         # Granite architectural scaling factors (#43). No-op (1.0) for every other arch.
         # embedding_multiplier folds into the existing embed-scale multiply; residual_multiplier
@@ -1815,28 +2125,42 @@ class TTModelRunner:
         # Sourced from the raw HF config (not self._cfg): a listed model rebuilds self._cfg from
         # the matrix entry, which does not carry these fields — reading _hf_cfg keeps the fix
         # correct whether or not Granite is ever promoted to a matrix entry.
-        self._embed_scale   *= self._scaling_factor("embedding_multiplier", 1.0)
-        self._residual_mult  = self._scaling_factor("residual_multiplier", 1.0)
+        self._embed_scale *= self._scaling_factor("embedding_multiplier", 1.0)
+        self._residual_mult = self._scaling_factor("residual_multiplier", 1.0)
 
         # Final norm
         final_norm = _find_final_norm(backbone)
         _fnw = getattr(final_norm, "weight", None)
         final_w = _fnw.detach().float() if _fnw is not None else None
-        self._final_norm_w_cpu = ((1.0 + final_w) if self._gemma_norm else final_w) if final_w is not None else None
-        self._final_norm_w_tt  = self._upload_norm_w(final_w, gemma_style=self._gemma_norm)
+        self._final_norm_w_cpu = (
+            ((1.0 + final_w) if self._gemma_norm else final_w)
+            if final_w is not None
+            else None
+        )
+        self._final_norm_w_tt = self._upload_norm_w(
+            final_w, gemma_style=self._gemma_norm
+        )
         self._final_norm_sc_tt = self._make_scaler_tt(cfg.hidden_size)
         _fnb = getattr(final_norm, "bias", None)
         self._final_norm_b_cpu = _fnb.detach().float() if _fnb is not None else None
         # CP-3: device row tensors for on-device LayerNorm final norm (lm_head trace path)
-        self._final_norm_w_ln_tt = self._ln_row_tt(final_w) if self._uses_layernorm else None
-        self._final_norm_b_ln_tt = self._ln_row_tt(_fnb) if self._uses_layernorm else None
+        self._final_norm_w_ln_tt = (
+            self._ln_row_tt(final_w) if self._uses_layernorm else None
+        )
+        self._final_norm_b_ln_tt = (
+            self._ln_row_tt(_fnb) if self._uses_layernorm else None
+        )
 
         # lm_head (GPTNeoX names it embed_out)
-        lm_head_mod = getattr(hf_model, "lm_head", None) or getattr(hf_model, "embed_out", None)
+        lm_head_mod = getattr(hf_model, "lm_head", None) or getattr(
+            hf_model, "embed_out", None
+        )
         if lm_head_mod is None:
-            raise RuntimeError(f"Cannot find lm_head / embed_out on {type(hf_model).__name__}")
+            raise RuntimeError(
+                f"Cannot find lm_head / embed_out on {type(hf_model).__name__}"
+            )
         self._lm_head_w_cpu = lm_head_mod.weight.detach().float()
-        self._lm_head_w_tt  = self._upload_linear_w(self._lm_head_w_cpu)
+        self._lm_head_w_tt = self._upload_linear_w(self._lm_head_w_cpu)
 
         # Per-layer weights
         self._layers: List[_LayerWeights] = []
@@ -1846,21 +2170,25 @@ class TTModelRunner:
         _swa_cfg = getattr(_hfc, "sliding_window", None)
         _swa_pat = getattr(_hfc, "sliding_window_pattern", 6) or 6
         for i, layer in enumerate(layers_list):
-            print(f"    layer {i+1}/{n}", end="\r")
+            print(f"    layer {i + 1}/{n}", end="\r")
             attn = _find_layer_attn(layer)
             # Per-layer SWA window for the decode SDPA (0 = full attention / global layer).
             # Prefer the HF layer's own is_sliding flag; fall back to the gemma global pattern.
             if _swa_cfg and os.environ.get("DISPATCH_DISABLE_SWA", "0") != "1":
-                _is_sliding = getattr(attn, "is_sliding", getattr(layer, "is_sliding", None))
+                _is_sliding = getattr(
+                    attn, "is_sliding", getattr(layer, "is_sliding", None)
+                )
                 if _is_sliding is None:
-                    _is_sliding = ((i + 1) % _swa_pat != 0)
+                    _is_sliding = (i + 1) % _swa_pat != 0
                 swa_window = int(_swa_cfg) if _is_sliding else 0
             else:
-                swa_window = 0   # DISPATCH_DISABLE_SWA=1 -> full attention (SWA A/B control)
-            mlp  = _find_layer_mlp(layer)
+                swa_window = (
+                    0  # DISPATCH_DISABLE_SWA=1 -> full attention (SWA A/B control)
+                )
+            mlp = _find_layer_mlp(layer)
             n1, n2, n3, n4 = _find_layer_norms(layer)
 
-            has_pre_ff  = n3 is not None
+            has_pre_ff = n3 is not None
             has_post_ff = n4 is not None
             if has_pre_ff and has_post_ff:
                 norm_style = "gemma"
@@ -1868,22 +2196,25 @@ class TTModelRunner:
                 norm_style = "gpt_neox"
             else:
                 norm_style = "llama"
-            gemma_norm  = (norm_style == "gemma")
+            gemma_norm = norm_style == "gemma"
 
             # QKV — handle fused and separate projections.
             # Per-head padding is required when head_dim is not a multiple of 32
             # (e.g. BLOOM head_dim=80) so the view in _attention stays valid.
             q_cpu, k_cpu, v_cpu = _split_qkv_weights(attn, cfg)
-            q_cpu = _pad_qkv_per_head(q_cpu, cfg.num_heads,    cfg.head_dim)
+            q_cpu = _pad_qkv_per_head(q_cpu, cfg.num_heads, cfg.head_dim)
             k_cpu = _pad_qkv_per_head(k_cpu, cfg.num_kv_heads, cfg.head_dim)
             v_cpu = _pad_qkv_per_head(v_cpu, cfg.num_kv_heads, cfg.head_dim)
-            q_out_p = q_cpu.shape[1]   # num_heads    * hd_p (already aligned)
-            k_out_p = k_cpu.shape[1]   # num_kv_heads * hd_p
-            qkv_cat = torch.cat([
-                _pad_to_tiles(q_cpu),
-                _pad_to_tiles(k_cpu),
-                _pad_to_tiles(v_cpu),
-            ], dim=1)
+            q_out_p = q_cpu.shape[1]  # num_heads    * hd_p (already aligned)
+            k_out_p = k_cpu.shape[1]  # num_kv_heads * hd_p
+            qkv_cat = torch.cat(
+                [
+                    _pad_to_tiles(q_cpu),
+                    _pad_to_tiles(k_cpu),
+                    _pad_to_tiles(v_cpu),
+                ],
+                dim=1,
+            )
 
             # MLP — handle SwiGLU, 2-proj, fused gate+up
             gate_raw, up_raw, down_raw = _find_mlp_weights(mlp, cfg)
@@ -1895,74 +2226,106 @@ class TTModelRunner:
             gate_mod, up_mod, down_mod = _find_mlp_modules(mlp)
             gate_b_tt = self._upload_bias(
                 getattr(gate_mod, "bias", None) if gate_mod is not None else None,
-                cfg.intermediate_size)
+                cfg.intermediate_size,
+            )
             up_b_tt = self._upload_bias(
                 getattr(up_mod, "bias", None) if up_mod is not None else None,
-                cfg.intermediate_size)
+                cfg.intermediate_size,
+            )
             down_b_tt = self._upload_bias(
                 getattr(down_mod, "bias", None) if down_mod is not None else None,
-                cfg.hidden_size)
+                cfg.hidden_size,
+            )
 
             # O-projection bias (GPTNeoX/BLOOM attention.dense.bias; None for Llama-style)
-            o_mod  = _find_o_proj(attn)
+            o_mod = _find_o_proj(attn)
             o_b_tt = self._upload_bias(getattr(o_mod, "bias", None), cfg.hidden_size)
 
             qkv_b_cpu = _get_qkv_bias(attn, cfg)
             # CP-1: device twin of the qkv bias (1, total_qkv_p) for on-device/paged attn.
-            qkv_b_tt = (_to_tt(qkv_b_cpu.unsqueeze(0), self._device)
-                        if qkv_b_cpu is not None else None)
+            qkv_b_tt = (
+                _to_tt(qkv_b_cpu.unsqueeze(0), self._device)
+                if qkv_b_cpu is not None
+                else None
+            )
             # CP-4: per-head Q/K norm weights (CPU + device twins for on-device attn).
             q_norm_cpu = self._load_head_norm_w(attn, "q_norm", gemma_norm)
             k_norm_cpu = self._load_head_norm_w(attn, "k_norm", gemma_norm)
 
             lw = _LayerWeights(
-                norm1_w  = self._upload_norm_w(getattr(n1, "weight", None), gemma_norm),
-                norm1_sc = self._make_scaler_tt(cfg.hidden_size),
-                norm2_w  = self._upload_norm_w(getattr(n2, "weight", None), gemma_norm),
-                norm2_sc = self._make_scaler_tt(cfg.hidden_size),
-                qkv_w = _to_tt(qkv_cat, self._device, dtype=self._weight_dtype()),
-                qkv_b = qkv_b_cpu,
-                qkv_b_tt = qkv_b_tt,
-                q_end = q_out_p,
-                k_end = q_out_p + k_out_p,
-                o_w   = self._upload_linear_w(
-                            _pad_o_proj_per_head(
-                                _find_o_proj_weight(attn).detach().bfloat16(),
-                                cfg.num_heads, cfg.head_dim)),
-                gate_w = gate_w_tt,
-                up_w   = self._upload_linear_w(up_raw),
-                down_w = self._upload_linear_w(down_raw),
-                gate_b = gate_b_tt,
-                up_b   = up_b_tt,
-                down_b = down_b_tt,
-                o_b    = o_b_tt,
-                norm3_w  = self._upload_norm_w(getattr(n3, "weight", None), gemma_norm) if has_pre_ff else None,
-                norm3_sc = self._make_scaler_tt(cfg.hidden_size) if has_pre_ff else None,
-                norm4_w  = self._upload_norm_w(getattr(n4, "weight", None), gemma_norm) if has_post_ff else None,
-                norm4_sc = self._make_scaler_tt(cfg.hidden_size) if has_post_ff else None,
-                norm_style = norm_style,
-                q_norm_w = q_norm_cpu,
-                k_norm_w = k_norm_cpu,
-                q_norm_w_tt = self._ln_row_tt(q_norm_cpu),   # CP-4: per-head norm on device
-                k_norm_w_tt = self._ln_row_tt(k_norm_cpu),
-                swa_window = swa_window,                      # SWA: per-layer sliding window
-
-                norm1_w_cpu = n1.weight.detach().float() if self._uses_layernorm else None,
-                norm1_b     = n1.bias.detach().float()   if (self._uses_layernorm and getattr(n1, "bias", None) is not None) else None,
-                norm2_w_cpu = n2.weight.detach().float() if self._uses_layernorm else None,
-                norm2_b     = n2.bias.detach().float()   if (self._uses_layernorm and getattr(n2, "bias", None) is not None) else None,
+                norm1_w=self._upload_norm_w(getattr(n1, "weight", None), gemma_norm),
+                norm1_sc=self._make_scaler_tt(cfg.hidden_size),
+                norm2_w=self._upload_norm_w(getattr(n2, "weight", None), gemma_norm),
+                norm2_sc=self._make_scaler_tt(cfg.hidden_size),
+                qkv_w=_to_tt(qkv_cat, self._device, dtype=self._weight_dtype()),
+                qkv_b=qkv_b_cpu,
+                qkv_b_tt=qkv_b_tt,
+                q_end=q_out_p,
+                k_end=q_out_p + k_out_p,
+                o_w=self._upload_linear_w(
+                    _pad_o_proj_per_head(
+                        _find_o_proj_weight(attn).detach().bfloat16(),
+                        cfg.num_heads,
+                        cfg.head_dim,
+                    )
+                ),
+                gate_w=gate_w_tt,
+                up_w=self._upload_linear_w(up_raw),
+                down_w=self._upload_linear_w(down_raw),
+                gate_b=gate_b_tt,
+                up_b=up_b_tt,
+                down_b=down_b_tt,
+                o_b=o_b_tt,
+                norm3_w=self._upload_norm_w(getattr(n3, "weight", None), gemma_norm)
+                if has_pre_ff
+                else None,
+                norm3_sc=self._make_scaler_tt(cfg.hidden_size) if has_pre_ff else None,
+                norm4_w=self._upload_norm_w(getattr(n4, "weight", None), gemma_norm)
+                if has_post_ff
+                else None,
+                norm4_sc=self._make_scaler_tt(cfg.hidden_size) if has_post_ff else None,
+                norm_style=norm_style,
+                q_norm_w=q_norm_cpu,
+                k_norm_w=k_norm_cpu,
+                q_norm_w_tt=self._ln_row_tt(
+                    q_norm_cpu
+                ),  # CP-4: per-head norm on device
+                k_norm_w_tt=self._ln_row_tt(k_norm_cpu),
+                swa_window=swa_window,  # SWA: per-layer sliding window
+                norm1_w_cpu=n1.weight.detach().float()
+                if self._uses_layernorm
+                else None,
+                norm1_b=n1.bias.detach().float()
+                if (self._uses_layernorm and getattr(n1, "bias", None) is not None)
+                else None,
+                norm2_w_cpu=n2.weight.detach().float()
+                if self._uses_layernorm
+                else None,
+                norm2_b=n2.bias.detach().float()
+                if (self._uses_layernorm and getattr(n2, "bias", None) is not None)
+                else None,
                 # CP-3: device row tensors for on-device ttnn.layer_norm
-                norm1_w_ln_tt = self._ln_row_tt(getattr(n1, "weight", None)) if self._uses_layernorm else None,
-                norm1_b_ln_tt = self._ln_row_tt(getattr(n1, "bias", None))   if self._uses_layernorm else None,
-                norm2_w_ln_tt = self._ln_row_tt(getattr(n2, "weight", None)) if self._uses_layernorm else None,
-                norm2_b_ln_tt = self._ln_row_tt(getattr(n2, "bias", None))   if self._uses_layernorm else None,
+                norm1_w_ln_tt=self._ln_row_tt(getattr(n1, "weight", None))
+                if self._uses_layernorm
+                else None,
+                norm1_b_ln_tt=self._ln_row_tt(getattr(n1, "bias", None))
+                if self._uses_layernorm
+                else None,
+                norm2_w_ln_tt=self._ln_row_tt(getattr(n2, "weight", None))
+                if self._uses_layernorm
+                else None,
+                norm2_b_ln_tt=self._ln_row_tt(getattr(n2, "bias", None))
+                if self._uses_layernorm
+                else None,
             )
             self._layers.append(lw)
         print()
         if _swa_cfg:
             _nsl = sum(1 for lw in self._layers if lw.swa_window)
-            print(f"  Sliding-window attention: {_nsl}/{n} sliding layers "
-                  f"(window={_swa_cfg}), {n - _nsl} global (full attn)")
+            print(
+                f"  Sliding-window attention: {_nsl}/{n} sliding layers "
+                f"(window={_swa_cfg}), {n - _nsl} global (full attn)"
+            )
 
     def _load_head_norm_w(self, attn, attr: str, gemma_style: bool):
         """Load per-head Q/K norm weight as a CPU float tensor, or None."""
@@ -1995,12 +2358,16 @@ class TTModelRunner:
     def _weight_dtype(self):
         """ttnn dtype for large linear weights: bfloat8_b when the bf8 spike is on, else bf16."""
         import ttnn
+
         return ttnn.bfloat8_b if self._bf8_weights else ttnn.bfloat16
 
     def _upload_linear_w(self, w: torch.Tensor):
         """Upload weight (out, in) transposed to (in_p, out_p) on device."""
-        return _to_tt(w.detach().bfloat16().T.contiguous(), self._device,
-                      dtype=self._weight_dtype())
+        return _to_tt(
+            w.detach().bfloat16().T.contiguous(),
+            self._device,
+            dtype=self._weight_dtype(),
+        )
 
     def _upload_bias(self, b: Optional[torch.Tensor], out_dim: int):
         """Upload bias as (TILE, out_p), or None when the module has no bias.
@@ -2022,6 +2389,7 @@ class TTModelRunner:
         no-op for bias-free models on every attention path (CPU-readback/ondevice/paged).
         """
         import ttnn
+
         out = _matmul_safe(inp, lw.o_w, self._device)
         if lw.o_b is not None:
             biased = self._bias_add(out, lw.o_b)
@@ -2034,6 +2402,7 @@ class TTModelRunner:
         """ALiBi per-head slopes (HF BLOOM scheme). slope_h = 2^(-8h/n) for h=1..n
         when n is a power of two; otherwise the nearest-lower-power-of-two set plus
         the interleaved extra slopes. Returns a (n_heads,) float tensor."""
+
         def pow2_slopes(n):
             start = 2.0 ** (-8.0 / n)
             return [start ** (i + 1) for i in range(n)]
@@ -2058,30 +2427,30 @@ class TTModelRunner:
         Projections (qkv/o-proj) stay on device.
         """
         cfg = self._cfg
-        hd  = cfg.head_dim
-        nh  = cfg.num_heads
+        hd = cfg.head_dim
+        nh = cfg.num_heads
         nkv = cfg.num_kv_heads
-        L   = kv_pos + 1
+        L = kv_pos + 1
 
-        K = self._k_hist_cpu[layer_idx][:, :L, :].float()   # (nkv, L, hd)
+        K = self._k_hist_cpu[layer_idx][:, :L, :].float()  # (nkv, L, hd)
         V = self._v_hist_cpu[layer_idx][:, :L, :].float()
-        if nh != nkv:                                       # GQA expand (BLOOM is MHA)
+        if nh != nkv:  # GQA expand (BLOOM is MHA)
             rep = nh // nkv
             K = K.repeat_interleave(rep, dim=0)
             V = V.repeat_interleave(rep, dim=0)
-        q = q_cpu.float()                                   # (nh, hd)
+        q = q_cpu.float()  # (nh, hd)
 
-        scale  = 1.0 / math.sqrt(hd)
-        scores = torch.einsum("hd,hld->hl", q, K) * scale   # (nh, L)
+        scale = 1.0 / math.sqrt(hd)
+        scores = torch.einsum("hd,hld->hl", q, K) * scale  # (nh, L)
         key_pos = torch.arange(L, dtype=torch.float32)
         beta = getattr(self, "_alibi_beta", 1.0)
         scores = scores + beta * self._alibi_slopes.view(nh, 1) * key_pos.view(1, L)
-        attn = torch.softmax(scores, dim=-1)                # (nh, L)
-        out  = torch.einsum("hl,hld->hd", attn, V)          # (nh, hd)
+        attn = torch.softmax(scores, dim=-1)  # (nh, L)
+        out = torch.einsum("hl,hld->hd", attn, V)  # (nh, hd)
 
         # Pack into the _fa_out_tt layout [TILE, nh*hd_p]: row 0 = per-head outputs,
         # each head padded hd -> hd_p, matching the o-proj weight layout.
-        hd_p  = _tile_align(hd)
+        hd_p = _tile_align(hd)
         out_p = torch.zeros(nh, hd_p, dtype=torch.float32)
         out_p[:, :hd] = out
         fa = torch.zeros(TILE, nh * hd_p, dtype=torch.bfloat16)
@@ -2120,15 +2489,21 @@ class TTModelRunner:
         cfg = self._cfg
         scale = self._attn_scale_value()
         self._attn_scale_tt = _to_tt(
-            torch.full((TILE, TILE), scale, dtype=torch.bfloat16), self._device)
+            torch.full((TILE, TILE), scale, dtype=torch.bfloat16), self._device
+        )
         self._neg_inf_tt = _to_tt(
-            torch.full((TILE, TILE), float("-inf"), dtype=torch.bfloat16), self._device)
+            torch.full((TILE, TILE), float("-inf"), dtype=torch.bfloat16), self._device
+        )
         self._zero_tt = _to_tt(
-            torch.zeros(TILE, TILE, dtype=torch.bfloat16), self._device)
+            torch.zeros(TILE, TILE, dtype=torch.bfloat16), self._device
+        )
         self._zero_head_tt = _to_tt(
-            torch.zeros(TILE, _tile_align(cfg.head_dim), dtype=torch.bfloat16), self._device)
+            torch.zeros(TILE, _tile_align(cfg.head_dim), dtype=torch.bfloat16),
+            self._device,
+        )
         self._ones_tt = _to_tt(
-            torch.ones(TILE, TILE, dtype=torch.bfloat16), self._device)
+            torch.ones(TILE, TILE, dtype=torch.bfloat16), self._device
+        )
 
     # ------------------------------------------------------------------
     # KV cache
@@ -2136,27 +2511,36 @@ class TTModelRunner:
 
     def _init_kv_cache(self):
         import ttnn
-        cfg  = self._cfg
-        n    = len(self._layers)
-        nkv  = cfg.num_kv_heads
+
+        cfg = self._cfg
+        n = len(self._layers)
+        nkv = cfg.num_kv_heads
         hd_p = _tile_align(cfg.head_dim)
         ms_p = _tile_align(self._max_seq)
 
         # 4D device KV cache: [1, n_kv_heads, max_seq_p, head_dim_p]
         # Matches update_cache_for_token_ validation: input[1] == cache[1] == nkv
         self._k_dev = [
-            ttnn.zeros([1, nkv, ms_p, hd_p], dtype=ttnn.bfloat16,
-                       layout=ttnn.TILE_LAYOUT, device=self._device,
-                       memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            ttnn.zeros(
+                [1, nkv, ms_p, hd_p],
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self._device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
             for _ in range(n)
         ]
         self._v_dev = [
-            ttnn.zeros([1, nkv, ms_p, hd_p], dtype=ttnn.bfloat16,
-                       layout=ttnn.TILE_LAYOUT, device=self._device,
-                       memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            ttnn.zeros(
+                [1, nkv, ms_p, hd_p],
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self._device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
             for _ in range(n)
         ]
-        print(f"  KV cache: on-device DRAM [1×{nkv}×{ms_p}×{hd_p}] × {n*2} buffers")
+        print(f"  KV cache: on-device DRAM [1×{nkv}×{ms_p}×{hd_p}] × {n * 2} buffers")
 
         # CPU-side KV history mirrors the device cache.
         # CPU attention reads from these directly, eliminating the device→CPU
@@ -2183,62 +2567,77 @@ class TTModelRunner:
         hot-path matmuls can write directly into pre-allocated device buffers.
         """
         import ttnn
-        cfg  = self._cfg
-        hid_p    = _tile_align(cfg.hidden_size)
-        hd_p     = _tile_align(cfg.head_dim)
-        q_out_p  = cfg.num_heads    * hd_p   # use tile-padded hd_p, not raw head_dim
+
+        cfg = self._cfg
+        hid_p = _tile_align(cfg.hidden_size)
+        hd_p = _tile_align(cfg.head_dim)
+        q_out_p = cfg.num_heads * hd_p  # use tile-padded hd_p, not raw head_dim
         kv_out_p = cfg.num_kv_heads * hd_p
-        qkv_p    = q_out_p + 2 * kv_out_p
-        int_p    = _tile_align(cfg.intermediate_size)
-        nkv      = cfg.num_kv_heads
+        qkv_p = q_out_p + 2 * kv_out_p
+        int_p = _tile_align(cfg.intermediate_size)
+        nkv = cfg.num_kv_heads
 
         def z(*shape):
-            return ttnn.zeros(list(shape), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
-                              device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            return ttnn.zeros(
+                list(shape),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self._device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
 
         ms_p = _tile_align(self._max_seq)
         scale_val = self._attn_scale_value()
 
         # Existing rmsnorm output scratch
-        self._rmsnorm_buf_tt        = z(TILE, hid_p)
+        self._rmsnorm_buf_tt = z(TILE, hid_p)
         # QKV projection output
-        self._qkv_scratch_tt        = z(TILE, qkv_p)
+        self._qkv_scratch_tt = z(TILE, qkv_p)
         # MLP gate, up, and activated intermediate (gate×up result)
-        self._gate_scratch_tt       = z(TILE, int_p)
-        self._up_scratch_tt         = z(TILE, int_p)
-        self._activated_scratch_tt  = z(TILE, int_p)
+        self._gate_scratch_tt = z(TILE, int_p)
+        self._up_scratch_tt = z(TILE, int_p)
+        self._activated_scratch_tt = z(TILE, int_p)
         # Residual add output (hidden state accumulator across layers)
-        self._hidden_scratch_tt     = z(TILE, hid_p)
+        self._hidden_scratch_tt = z(TILE, hid_p)
 
         # Flash-attn constant tiles (allocated once, reused every layer/token)
-        self._fa_scale_tt     = ttnn.from_torch(
+        self._fa_scale_tt = ttnn.from_torch(
             torch.full((TILE, TILE), scale_val, dtype=torch.bfloat16),
-            dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
-            device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        self._fa_ninf_tt      = ttnn.from_torch(
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self._device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        self._fa_ninf_tt = ttnn.from_torch(
             torch.full((TILE, TILE), float("-inf"), dtype=torch.bfloat16),
-            dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
-            device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        self._fa_zero_tt      = z(TILE, TILE)
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self._device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        self._fa_zero_tt = z(TILE, TILE)
         self._fa_zero_head_tt = z(TILE, hd_p)
-        self._fa_ones_tt      = ttnn.from_torch(
+        self._fa_ones_tt = ttnn.from_torch(
             torch.ones(TILE, TILE, dtype=torch.bfloat16),
-            dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
-            device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self._device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
         # Flash-attn output scratch: [TILE, N_heads * head_dim_p] — row-major, O-proj ready
-        self._fa_out_tt       = z(TILE, cfg.num_heads * hd_p)
+        self._fa_out_tt = z(TILE, cfg.num_heads * hd_p)
 
         # Pre-allocated CPU tensors reused each token (avoids torch.zeros() in hot loop)
         # Single-token embedding ID staging buffer — filled in _embed() each step
         self._token_id_cpu = torch.zeros(1, 1, dtype=torch.int64)
         # Position index staging for on-device RoPE cos/sin gather (issue #8)
         self._pos_idx_cpu = torch.zeros(1, 1, dtype=torch.int32)
-        self._k_in_cpu  = torch.zeros(1, nkv, TILE, hd_p, dtype=torch.bfloat16)
-        self._v_in_cpu  = torch.zeros(1, nkv, TILE, hd_p, dtype=torch.bfloat16)
+        self._k_in_cpu = torch.zeros(1, nkv, TILE, hd_p, dtype=torch.bfloat16)
+        self._v_in_cpu = torch.zeros(1, nkv, TILE, hd_p, dtype=torch.bfloat16)
         # Q for flash-attn: [N_heads*TILE, head_dim_p] (one TILE-block per head)
-        self._q_cpu     = torch.zeros(cfg.num_heads * TILE, hd_p, dtype=torch.bfloat16)
+        self._q_cpu = torch.zeros(cfg.num_heads * TILE, hd_p, dtype=torch.bfloat16)
         # Causal mask: [TILE, max_seq_p] — rebuilt cheaply each token
-        self._mask_cpu  = torch.full((TILE, ms_p), float("-inf"), dtype=torch.bfloat16)
+        self._mask_cpu = torch.full((TILE, ms_p), float("-inf"), dtype=torch.bfloat16)
 
         # Probe whether ttnn ops accept output_tensor= / optional_output_tensor=.
         # inspect.signature doesn't see through nanobind wrappers, so use docstrings.
@@ -2256,16 +2655,18 @@ class TTModelRunner:
             self._mul_ot = "output_tensor" in (ttnn.multiply.__doc__ or "")
         except Exception:
             self._mul_ot = False
-        print(f"  Scratch bufs: matmul_ot={self._matmul_ot} add_ot={self._add_ot} mul_ot={self._mul_ot}")
+        print(
+            f"  Scratch bufs: matmul_ot={self._matmul_ot} add_ot={self._add_ot} mul_ot={self._mul_ot}"
+        )
 
     # ------------------------------------------------------------------
     # RoPE
     # ------------------------------------------------------------------
 
     def _build_rope_table(self):
-        cfg     = self._hf_cfg
-        dim     = self._cfg.head_dim
-        theta   = getattr(cfg, "rope_theta", 10000.0)
+        cfg = self._hf_cfg
+        dim = self._cfg.head_dim
+        theta = getattr(cfg, "rope_theta", 10000.0)
         max_pos = self._max_seq
 
         # Partial RoPE (GPTNeoX/Pythia): only rotary_pct of head dims are rotated.
@@ -2274,23 +2675,26 @@ class TTModelRunner:
         if self._listed:
             rotary_pct = self._entry.rotary_pct
         else:
-            rotary_pct = getattr(cfg, "partial_rotary_factor",
-                                 getattr(cfg, "rotary_pct", 1.0))
-        rotary_ndims  = round(dim * rotary_pct)
+            rotary_pct = getattr(
+                cfg, "partial_rotary_factor", getattr(cfg, "rotary_pct", 1.0)
+            )
+        rotary_ndims = round(dim * rotary_pct)
         if rotary_ndims % 2 != 0:
             rotary_ndims -= 1
-        self._rotary_ndims = rotary_ndims   # used in _apply_rope
+        self._rotary_ndims = rotary_ndims  # used in _apply_rope
 
         # ALiBi models (BLOOM, Falcon) have NO RoPE — they add a per-head linear
         # positional bias to the attention scores instead. Detect and disable rope; the
         # per-head slopes can't fold into the shared-mask flash_attn kernel, so these run
         # a CPU softmax+ALiBi attention path (see _attention_cpu_alibi).
-        text_cfg   = getattr(cfg, "text_config", cfg)
+        text_cfg = getattr(cfg, "text_config", cfg)
         model_type = getattr(text_cfg, "model_type", "")
-        archs      = getattr(cfg, "architectures", None) or []
-        self._uses_alibi = (model_type == "bloom"
-                            or any("Bloom" in a for a in archs)
-                            or bool(getattr(cfg, "alibi", False)))
+        archs = getattr(cfg, "architectures", None) or []
+        self._uses_alibi = (
+            model_type == "bloom"
+            or any("Bloom" in a for a in archs)
+            or bool(getattr(cfg, "alibi", False))
+        )
         self._no_rope = self._uses_alibi
         if self._uses_alibi:
             self._rotary_ndims = 0
@@ -2299,8 +2703,10 @@ class TTModelRunner:
             # BLOOM adds the bias unscaled (beta=1.0); Falcon scales it by the same
             # 1/sqrt(head_dim) as the QK scores (beta=inv_norm_factor). Getting this
             # wrong leaves a recency bias that's ~8x too strong and degenerates output.
-            is_falcon = (model_type == "falcon" or any("Falcon" in a for a in archs))
-            self._alibi_beta = (1.0 / math.sqrt(self._cfg.head_dim)) if is_falcon else 1.0
+            is_falcon = model_type == "falcon" or any("Falcon" in a for a in archs)
+            self._alibi_beta = (
+                (1.0 / math.sqrt(self._cfg.head_dim)) if is_falcon else 1.0
+            )
 
         # Linear RoPE scaling: compress positions by dividing by scale factor.
         # Do NOT change theta -- scale the position indices instead.
@@ -2311,14 +2717,18 @@ class TTModelRunner:
                 scale_factor = rope_cfg.get("factor", 1.0)
 
         positions = torch.arange(max_pos, dtype=torch.float32) / scale_factor
-        freqs     = 1.0 / (theta ** (torch.arange(0, rotary_ndims, 2).float() / rotary_ndims))
-        angles    = torch.outer(positions, freqs)      # (max_pos, rotary_ndims/2)
-        cos_half  = torch.cos(angles)                  # (max_pos, rotary_ndims/2)
-        sin_half  = torch.sin(angles)
+        freqs = 1.0 / (
+            theta ** (torch.arange(0, rotary_ndims, 2).float() / rotary_ndims)
+        )
+        angles = torch.outer(positions, freqs)  # (max_pos, rotary_ndims/2)
+        cos_half = torch.cos(angles)  # (max_pos, rotary_ndims/2)
+        sin_half = torch.sin(angles)
 
         # HuggingFace convention: expand to rotary_ndims by tiling [half, half].
         # Rotation uses grouped halves (i, i+rotary_ndims//2) not interleaved pairs.
-        self._rope_cos = torch.cat([cos_half, cos_half], dim=-1)  # (max_pos, rotary_ndims)
+        self._rope_cos = torch.cat(
+            [cos_half, cos_half], dim=-1
+        )  # (max_pos, rotary_ndims)
         self._rope_sin = torch.cat([sin_half, sin_half], dim=-1)
 
         # On-device RoPE (issue #8): decide applicability and upload cos/sin tables.
@@ -2326,11 +2736,14 @@ class TTModelRunner:
         # eliminating the per-token QKV->CPU readback. Gated to the families it cleanly
         # covers; everything else keeps the CPU path unchanged.
         import ttnn as _ttnn
-        hd   = self._cfg.head_dim
+
+        hd = self._cfg.head_dim
         hd_p = _tile_align(hd)
-        no_bias     = all(lw.qkv_b is None for lw in self._layers)
-        no_headnorm = all(lw.q_norm_w is None and lw.k_norm_w is None for lw in self._layers)
-        full_rope   = (self._rotary_ndims == hd)
+        no_bias = all(lw.qkv_b is None for lw in self._layers)
+        no_headnorm = all(
+            lw.q_norm_w is None and lw.k_norm_w is None for lw in self._layers
+        )
+        full_rope = self._rotary_ndims == hd
         # CP-1: qkv bias now applied on-device. CP-3: LayerNorm now runs on-device
         # (ttnn.layer_norm). CP-4: per-head Q/K norm runs on-device (ttnn.rms_norm).
         # So neither bias, LayerNorm, nor head_norm blocks eligibility — but ALiBi still
@@ -2339,38 +2752,58 @@ class TTModelRunner:
         # (#3 Phase C) listed -> derived fast_path capability (which also folds in the
         # group|32 / nh<=32 SDPA-pad constraint from _setup_paged_decode); novel -> the
         # introspection floor. They agree for every listed fast-path model.
-        eligible    = self._caps.fast_path if self._listed else introspect_eligible
+        eligible = self._caps.fast_path if self._listed else introspect_eligible
         self._ondevice_attn_eligible = eligible
         # Opt-in (default OFF): the eager on-device path is CORRECT but slower than the
         # CPU-RoPE path because it trades one PCIe readback for ~25 host-dispatched device
         # ops/layer. The perf win lands once the decode step is trace-captured (#30), which
         # removes per-op host dispatch. Until then, keep it opt-in so baseline tok/s holds.
         import os
-        self._ondevice_attn = eligible and os.environ.get("DISPATCH_ONDEVICE_ATTN", "0") == "1"
+
+        self._ondevice_attn = (
+            eligible and os.environ.get("DISPATCH_ONDEVICE_ATTN", "0") == "1"
+        )
         # The paged trace-safe path (#30) also needs the on-device rope tables.
-        _paged_want = os.environ.get("DISPATCH_PAGED_ATTN", "0") == "1" or os.environ.get("DISPATCH_TRACE", "0") == "1"
+        _paged_want = (
+            os.environ.get("DISPATCH_PAGED_ATTN", "0") == "1"
+            or os.environ.get("DISPATCH_TRACE", "0") == "1"
+        )
         if eligible and (self._ondevice_attn or _paged_want):
             self._rope_cos_dev = _ttnn.from_torch(
-                self._rope_cos.bfloat16(), dtype=_ttnn.bfloat16, layout=_ttnn.ROW_MAJOR_LAYOUT,
-                device=self._device, memory_config=_ttnn.DRAM_MEMORY_CONFIG)
+                self._rope_cos.bfloat16(),
+                dtype=_ttnn.bfloat16,
+                layout=_ttnn.ROW_MAJOR_LAYOUT,
+                device=self._device,
+                memory_config=_ttnn.DRAM_MEMORY_CONFIG,
+            )
             self._rope_sin_dev = _ttnn.from_torch(
-                self._rope_sin.bfloat16(), dtype=_ttnn.bfloat16, layout=_ttnn.ROW_MAJOR_LAYOUT,
-                device=self._device, memory_config=_ttnn.DRAM_MEMORY_CONFIG)
+                self._rope_sin.bfloat16(),
+                dtype=_ttnn.bfloat16,
+                layout=_ttnn.ROW_MAJOR_LAYOUT,
+                device=self._device,
+                memory_config=_ttnn.DRAM_MEMORY_CONFIG,
+            )
         if self._ondevice_attn:
             print("  On-device RoPE/attention: ENABLED (DISPATCH_ONDEVICE_ATTN=1)")
         elif eligible:
-            print("  On-device RoPE/attention: eligible but OFF "
-                  "(set DISPATCH_ONDEVICE_ATTN=1 to enable; faster once trace-captured, see #30)")
+            print(
+                "  On-device RoPE/attention: eligible but OFF "
+                "(set DISPATCH_ONDEVICE_ATTN=1 to enable; faster once trace-captured, see #30)"
+            )
         elif self._listed and introspect_eligible:
             # Introspection alone would have marked this eligible, but the matrix entry
             # overrides it (e.g. gemma_rms norm / group∤32) -> stay on the CPU RoPE path.
-            print(f"  On-device RoPE/attention: not eligible "
-                  f"(matrix override: norm_type={self._entry.norm_type}, "
-                  f"backend={self._caps.attn_backend}) -> CPU RoPE path")
+            print(
+                f"  On-device RoPE/attention: not eligible "
+                f"(matrix override: norm_type={self._entry.norm_type}, "
+                f"backend={self._caps.attn_backend}) -> CPU RoPE path"
+            )
         else:
-            print(f"  On-device RoPE/attention: not eligible "
-                  f"(full_rope={full_rope} hd_p==hd={hd_p == hd} no_bias={no_bias} "
-                  f"no_headnorm={no_headnorm} rmsnorm={not self._uses_layernorm}) -> CPU RoPE path")
+            print(
+                f"  On-device RoPE/attention: not eligible "
+                f"(full_rope={full_rope} hd_p==hd={hd_p == hd} no_bias={no_bias} "
+                f"no_headnorm={no_headnorm} rmsnorm={not self._uses_layernorm}) -> CPU RoPE path"
+            )
 
     def _apply_head_norm(self, x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
         """Apply per-head RMSNorm. x: (n_heads, head_dim), w: (head_dim,) already (1+w) or w."""
@@ -2385,12 +2818,12 @@ class TTModelRunner:
         """
         if position >= self._rope_cos.shape[0]:
             return x
-        cos = self._rope_cos[position]   # (rotary_ndims,)
+        cos = self._rope_cos[position]  # (rotary_ndims,)
         sin = self._rope_sin[position]
-        nd  = self._rotary_ndims
+        nd = self._rotary_ndims
         x_rot_in = x[..., :nd]
         # Rotate: x_rot = [-x_rot_in[nd//2:], x_rot_in[:nd//2]]
-        x_rot = torch.cat([-x_rot_in[..., nd // 2:], x_rot_in[..., :nd // 2]], dim=-1)
+        x_rot = torch.cat([-x_rot_in[..., nd // 2 :], x_rot_in[..., : nd // 2]], dim=-1)
         rotated = x_rot_in * cos + x_rot * sin
         if nd == x.shape[-1]:
             return rotated
@@ -2402,30 +2835,43 @@ class TTModelRunner:
 # CLI
 # ------------------------------------------------------------------
 
+
 def main():
     parser = argparse.ArgumentParser(description="TTModelRunner inference")
-    parser.add_argument("--model",      required=True, help="Local model path or HF repo")
-    parser.add_argument("--prompt",     default="The capital of France is",
-                        help="Prompt string")
+    parser.add_argument("--model", required=True, help="Local model path or HF repo")
+    parser.add_argument(
+        "--prompt", default="The capital of France is", help="Prompt string"
+    )
     parser.add_argument("--max-tokens", type=int, default=50)
-    parser.add_argument("--max-seq",    type=int, default=2048,
-                        help="Max KV cache sequence length")
-    parser.add_argument("--no-chat",    action="store_true",
-                        help="Skip chat template (raw completion mode)")
-    parser.add_argument("--unsafe",     action="store_true",
-                        help="Allow community/unlisted (unverified) models without warning (#25)")
+    parser.add_argument(
+        "--max-seq", type=int, default=2048, help="Max KV cache sequence length"
+    )
+    parser.add_argument(
+        "--no-chat",
+        action="store_true",
+        help="Skip chat template (raw completion mode)",
+    )
+    parser.add_argument(
+        "--unsafe",
+        action="store_true",
+        help="Allow community/unlisted (unverified) models without warning (#25)",
+    )
     args = parser.parse_args()
 
     import ttnn
     import os
+
     # Reserve a trace region when the trace-replay decode path (#30) is enabled.
     _tr = 134217728 if os.environ.get("DISPATCH_TRACE", "0") == "1" else 0
     device = ttnn.open_device(device_id=0, trace_region_size=_tr)
     try:
-        runner = TTModelRunner(args.model, device, max_seq=args.max_seq, unsafe=args.unsafe)
+        runner = TTModelRunner(
+            args.model, device, max_seq=args.max_seq, unsafe=args.unsafe
+        )
         print(f"\nPROMPT: {args.prompt}")
-        output = runner.generate(args.prompt, max_new_tokens=args.max_tokens,
-                                 chat=not args.no_chat)
+        output = runner.generate(
+            args.prompt, max_new_tokens=args.max_tokens, chat=not args.no_chat
+        )
         print(f"OUTPUT: {output}")
     finally:
         ttnn.close_device(device)

--- a/tt_inference_server/dispatch/runner.py
+++ b/tt_inference_server/dispatch/runner.py
@@ -1,0 +1,2435 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""TTModelRunner — full on-device inference for HuggingFace transformer models.
+
+Keeps model weights and activations on the TT device throughout the forward
+pass. Only crosses PCIe at model boundaries: one embedding lookup per token in,
+one logit row per token out.
+
+Usage::
+
+    import ttnn
+    from tt_inference_server.dispatch.runner import TTModelRunner
+
+    device = ttnn.open_device(device_id=0)
+    runner = TTModelRunner("models/llama3-8b", device)
+    print(runner.generate("The capital of France is", max_new_tokens=40))
+    ttnn.close_device(device)
+
+CLI::
+
+    python -m tt_inference_server.dispatch.runner --model models/gemma3-4b --prompt "Hello world"
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import time
+from dataclasses import dataclass
+from typing import List, Optional
+
+import torch
+
+
+TILE = 32
+
+
+# ------------------------------------------------------------------
+# Utility helpers
+# ------------------------------------------------------------------
+
+# Activation strings mapped to ttnn.gelu — both the matrix's canonical "gelu_tanh"/"gelu"
+# and the raw HuggingFace act names that the auto-derive (unlisted) path passes through.
+_GELU_ACTS = ("gelu_tanh", "gelu", "gelu_pytorch_tanh", "gelu_new", "gelu_fast")
+# Tanh-approximation GELU family -> ttnn.gelu(fast_and_approximate_mode=True).
+# Plain "gelu" is exact-erf (GPTNeoX) and uses fast_and_approximate_mode=False.
+_GELU_TANH_ACTS = ("gelu_tanh", "gelu_pytorch_tanh", "gelu_new", "gelu_fast")
+
+
+def _tile_align(n: int) -> int:
+    return math.ceil(n / TILE) * TILE
+
+
+def _pad_to_tiles(t: torch.Tensor) -> torch.Tensor:
+    if t.ndim == 1:
+        pc = _tile_align(t.shape[0]) - t.shape[0]
+        return torch.nn.functional.pad(t, (0, pc)) if pc else t
+    pr = _tile_align(t.shape[-2]) - t.shape[-2]
+    pc = _tile_align(t.shape[-1]) - t.shape[-1]
+    if pr or pc:
+        return torch.nn.functional.pad(t, (0, pc, 0, pr))
+    return t
+
+
+def _to_tt(t: torch.Tensor, device, dtype=None):
+    import ttnn
+    # dtype defaults to bf16; weight call sites may pass ttnn.bfloat8_b (block-float8,
+    # tile-only) to halve DRAM footprint/bandwidth. Activations/masks/KV keep bf16.
+    if dtype is None:
+        dtype = ttnn.bfloat16
+    t = _pad_to_tiles(t.bfloat16().contiguous())
+    return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT,
+                           device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+
+def _pad_qkv_per_head(w: torch.Tensor, n_heads: int, head_dim: int) -> torch.Tensor:
+    """Pad each head's output slice to a tile boundary independently.
+
+    w shape: (in_dim, n_heads * head_dim) — weight already transposed.
+    Returns: (in_dim, n_heads * hd_p) where hd_p = tile_align(head_dim).
+
+    Required when head_dim is not a multiple of 32 (e.g. BLOOM head_dim=80).
+    Without this the view in _attention that reshapes to (n_heads, hd_p) fails
+    because n_heads * head_dim ≠ n_heads * hd_p.
+    """
+    hd_p = _tile_align(head_dim)
+    if hd_p == head_dim:
+        return w                               # already aligned — no-op
+    in_dim = w.shape[0]
+    # (in_dim, n_heads*head_dim) → (n_heads, head_dim, in_dim) → pad → back
+    w_heads = w.T.reshape(n_heads, head_dim, in_dim)          # (n_heads, hd, in)
+    pad_amt = hd_p - head_dim
+    w_padded = torch.nn.functional.pad(w_heads, (0, 0, 0, pad_amt))   # (n_heads, hd_p, in)
+    return w_padded.reshape(n_heads * hd_p, in_dim).T.contiguous()    # (in, n_heads*hd_p)
+
+
+def _pad_o_proj_per_head(w_raw: torch.Tensor, n_heads: int, head_dim: int) -> torch.Tensor:
+    """Pad the per-head input dimension of the O projection weight for tile alignment.
+
+    The flash-attn output is (TILE, n_heads * hd_p) where hd_p = tile_align(head_dim).
+    When head_dim is not tile-aligned (e.g. 80 → 96), the O-proj weight must accept
+    n_heads * hd_p inputs instead of n_heads * head_dim.
+
+    w_raw: (out_dim, n_heads * head_dim) — raw HF weight, pre-transpose
+    Returns: (out_dim, n_heads * hd_p)
+    """
+    hd_p = _tile_align(head_dim)
+    if hd_p == head_dim:
+        return w_raw
+    out_dim = w_raw.shape[0]
+    w = w_raw.reshape(out_dim, n_heads, head_dim)
+    w_padded = torch.nn.functional.pad(w, (0, hd_p - head_dim))
+    return w_padded.reshape(out_dim, n_heads * hd_p).contiguous()
+
+
+# CPU-fallback tracking. _matmul_safe falls back to torch.matmul on L1 overflow —
+# correct, but it defeats the "hardware-native" goal, so the test harness treats any
+# fallback as a FAILURE (a model that only "works" on CPU isn't running on the card).
+# Counter is module-level because _matmul_safe is a free function.
+_CPU_FALLBACK_COUNT = 0
+
+
+def reset_cpu_fallback_count():
+    global _CPU_FALLBACK_COUNT
+    _CPU_FALLBACK_COUNT = 0
+
+
+def get_cpu_fallback_count() -> int:
+    return _CPU_FALLBACK_COUNT
+
+
+def _matmul_safe(a, b, device, output_tensor=None):
+    """ttnn.matmul with CPU fallback on L1 overflow.
+
+    Some hidden sizes (e.g. 2560) exceed the 1.5 MB per-core Tensix SRAM limit
+    for static circular buffers. When that happens we fall back to torch.matmul
+    on CPU and re-upload the result. This is slower but correct.
+
+    output_tensor: pre-allocated device tensor to write result into (avoids mmap).
+    Ignored in the CPU fallback path and when ttnn doesn't support the parameter.
+    """
+    import ttnn
+    try:
+        if output_tensor is not None:
+            # ttnn >= 0.71 uses optional_output_tensor; older builds use output_tensor
+            try:
+                return ttnn.matmul(a, b, optional_output_tensor=output_tensor)
+            except TypeError:
+                return ttnn.matmul(a, b, output_tensor=output_tensor)
+        return ttnn.matmul(a, b)
+    except Exception as e:
+        msg = str(e)
+        if "1572864" not in msg and "Statically allocated circular buffers" not in msg:
+            raise
+        # L1 overflow — fall back to CPU matmul (output_tensor not used on CPU path).
+        # Count it: the harness treats any CPU fallback as a failure (not hardware-native).
+        global _CPU_FALLBACK_COUNT
+        _CPU_FALLBACK_COUNT += 1
+        a_cpu = ttnn.to_torch(a).float()
+        b_cpu = ttnn.to_torch(b).float()
+        result = torch.matmul(a_cpu, b_cpu).bfloat16()
+        return _to_tt(result, device)
+
+
+def _getattr_nested(obj, path: str):
+    for part in path.split("."):
+        obj = getattr(obj, part, None)
+        if obj is None:
+            return None
+    return obj
+
+
+def _find_text_backbone(hf_model):
+    """Return (backbone, layers_attr) for the text decoder layers.
+
+    layers_attr is either 'layers' (most models) or 'h' (BLOOM, Falcon).
+    """
+    for path in ["model", "language_model.model", "language_model",
+                 "transformer", "gpt_neox", "decoder"]:
+        obj = _getattr_nested(hf_model, path)
+        if obj is None:
+            continue
+        if hasattr(obj, "layers"):
+            return obj, "layers"
+        if hasattr(obj, "h"):
+            return obj, "h"
+    raise RuntimeError(f"Cannot find text backbone in {type(hf_model).__name__}")
+
+
+def _find_embed_tokens(backbone):
+    """Find embedding table on the backbone regardless of attribute name."""
+    for attr in ("embed_tokens", "embed_in", "word_embeddings", "wte"):
+        m = getattr(backbone, attr, None)
+        if m is not None:
+            return m
+    raise RuntimeError(f"Cannot find embedding table in {type(backbone).__name__}")
+
+
+def _find_final_norm(backbone):
+    """Find final layer norm regardless of attribute name."""
+    for attr in ("norm", "final_layer_norm", "ln_f", "model_norm"):
+        m = getattr(backbone, attr, None)
+        if m is not None:
+            return m
+    raise RuntimeError(f"Cannot find final norm in {type(backbone).__name__}")
+
+
+def _find_layer_attn(layer):
+    """Find the attention sub-module for a decoder layer."""
+    for attr in ("self_attn", "attention", "self_attention"):
+        m = getattr(layer, attr, None)
+        if m is not None:
+            return m
+    raise RuntimeError(f"Cannot find attention in {type(layer).__name__}")
+
+
+def _find_layer_mlp(layer):
+    """Find the MLP sub-module for a decoder layer."""
+    for attr in ("mlp", "feed_forward", "ff"):
+        m = getattr(layer, attr, None)
+        if m is not None:
+            return m
+    raise RuntimeError(f"Cannot find MLP in {type(layer).__name__}")
+
+
+def _find_layer_norms(layer):
+    """Return (norm1, norm2, norm3, norm4) weight modules for a decoder layer.
+
+    norm1 = pre-attention, norm2 = post-attention (pre-MLP),
+    norm3/norm4 = Gemma3 extra norms (None otherwise).
+    """
+    n1 = (getattr(layer, "input_layernorm", None) or
+          getattr(layer, "attn_norm", None) or
+          getattr(layer, "ln_1", None) or
+          getattr(layer, "norm_1", None))
+    n2 = (getattr(layer, "post_attention_layernorm", None) or
+          getattr(layer, "ffn_norm", None) or
+          getattr(layer, "ln_2", None) or
+          getattr(layer, "norm_2", None))
+    n3 = getattr(layer, "pre_feedforward_layernorm", None)
+    n4 = getattr(layer, "post_feedforward_layernorm", None)
+    if n1 is None or n2 is None:
+        raise RuntimeError(
+            f"Cannot find layer norms in {type(layer).__name__}: {dir(layer)}")
+    return n1, n2, n3, n4
+
+
+def _split_qkv_weights(attn, cfg):
+    """Return (q_cpu, k_cpu, v_cpu) bfloat16 weight tensors shaped (in, out).
+
+    Handles separate q/k/v projections and all common fused-QKV variants:
+    - query_key_value (GPTNeoX, BLOOM): interleaved per head [Q_0,K_0,V_0, Q_1,K_1,V_1, ...]
+    - qkv_proj (Phi-3):                block layout [Q_all; K_all; V_all]
+    - wqkv (InternLM2):                block layout [Q_all; K_all; V_all]
+    - c_attn (GPT-2 style):            block layout [Q_all; K_all; V_all]
+    """
+    qkv_interleaved = getattr(attn, "query_key_value", None)
+    if qkv_interleaved is not None:
+        # GPTNeoX / BLOOM: rows interleaved per head [Q_0,K_0,V_0, Q_1,K_1,V_1, ...]
+        w = qkv_interleaved.weight.detach().bfloat16()  # (n_heads*3*head_dim, in)
+        n_h  = cfg.num_heads
+        n_kv = cfg.num_kv_heads
+        hd   = cfg.head_dim
+        # Reshape to (n_heads, 3, head_dim, in), then extract Q/K/V per head
+        w_r = w.view(n_h, 3, hd, w.shape[1])
+        q = w_r[:, 0, :, :].reshape(n_h  * hd, w.shape[1]).T.contiguous()
+        k = w_r[:n_kv, 1, :, :].reshape(n_kv * hd, w.shape[1]).T.contiguous()
+        v = w_r[:n_kv, 2, :, :].reshape(n_kv * hd, w.shape[1]).T.contiguous()
+        return q, k, v
+
+    # Block-layout fused QKV — [Q_all; K_all; V_all]
+    fused = (getattr(attn, "qkv_proj", None) or
+             getattr(attn, "wqkv", None) or
+             getattr(attn, "c_attn", None))
+    if fused is not None:
+        w = fused.weight.detach().bfloat16()   # (q_out+k_out+v_out, in)
+        q_out = cfg.num_heads    * cfg.head_dim
+        k_out = cfg.num_kv_heads * cfg.head_dim
+        v_out = cfg.num_kv_heads * cfg.head_dim
+        total = q_out + k_out + v_out
+        if w.shape[0] != total:
+            # Some models pad — take the first total rows
+            w = w[:total]
+        q = w[:q_out].T.contiguous()
+        k = w[q_out:q_out + k_out].T.contiguous()
+        v = w[q_out + k_out:].T.contiguous()
+        return q, k, v
+
+    # Standard separate projections
+    q = attn.q_proj.weight.detach().bfloat16().T.contiguous()
+    k = attn.k_proj.weight.detach().bfloat16().T.contiguous()
+    v = attn.v_proj.weight.detach().bfloat16().T.contiguous()
+    return q, k, v
+
+
+def _get_qkv_bias(attn, cfg) -> "torch.Tensor | None":
+    """Return concatenated (q_b, k_b, v_b) CPU float bias, or None.
+
+    Handles interleaved (query_key_value) and block (qkv_proj etc.) layouts.
+    The returned tensor has the same head-dim padding as the weight matrices
+    produced by _split_qkv_weights / _pad_qkv_per_head: each head's slice is
+    zero-padded from head_dim to tile_align(head_dim).
+    """
+    hd   = cfg.head_dim
+    hd_p = _tile_align(hd)
+    n_h  = cfg.num_heads
+    n_kv = cfg.num_kv_heads
+
+    def _pad_bias_heads(b_raw, n_heads):
+        """Pad (n_heads * head_dim,) → (n_heads * hd_p,)."""
+        if hd_p == hd:
+            return b_raw.float()
+        bh = b_raw.float().view(n_heads, hd)
+        return torch.nn.functional.pad(bh, (0, hd_p - hd)).view(n_heads * hd_p)
+
+    qkv_interleaved = getattr(attn, "query_key_value", None)
+    if qkv_interleaved is not None:
+        b = getattr(qkv_interleaved, "bias", None)
+        if b is None:
+            return None
+        b = b.detach()
+        # Interleaved: [Q_0,K_0,V_0, Q_1,K_1,V_1, ...]
+        b_r = b.view(n_h, 3, hd)
+        q_b = _pad_bias_heads(b_r[:, 0, :].reshape(n_h  * hd), n_h)
+        k_b = _pad_bias_heads(b_r[:n_kv, 1, :].reshape(n_kv * hd), n_kv)
+        v_b = _pad_bias_heads(b_r[:n_kv, 2, :].reshape(n_kv * hd), n_kv)
+        return torch.cat([q_b, k_b, v_b])
+
+    fused = (getattr(attn, "qkv_proj", None) or getattr(attn, "wqkv", None) or
+             getattr(attn, "c_attn", None))
+    if fused is not None:
+        b = getattr(fused, "bias", None)
+        if b is None:
+            return None
+        b = b.detach()
+        q_out = n_h  * hd
+        k_out = n_kv * hd
+        q_b = _pad_bias_heads(b[:q_out], n_h)
+        k_b = _pad_bias_heads(b[q_out:q_out + k_out], n_kv)
+        v_b = _pad_bias_heads(b[q_out + k_out:q_out + k_out + k_out], n_kv)
+        return torch.cat([q_b, k_b, v_b])
+
+    # Separate q/k/v — each may have its own bias
+    def _get_sep_bias(mod_name):
+        m = getattr(attn, mod_name, None)
+        b = getattr(m, "bias", None) if m else None
+        return b.detach().float() if b is not None else None
+    q_b = _get_sep_bias("q_proj")
+    k_b = _get_sep_bias("k_proj")
+    v_b = _get_sep_bias("v_proj")
+    if q_b is None and k_b is None and v_b is None:
+        return None
+    q_b2 = _pad_bias_heads(q_b, n_h)  if q_b is not None else torch.zeros(n_h  * hd_p)
+    k_b2 = _pad_bias_heads(k_b, n_kv) if k_b is not None else torch.zeros(n_kv * hd_p)
+    v_b2 = _pad_bias_heads(v_b, n_kv) if v_b is not None else torch.zeros(n_kv * hd_p)
+    return torch.cat([q_b2, k_b2, v_b2])
+
+
+def _find_o_proj(attn):
+    """Find the output-projection module regardless of attribute name."""
+    for attr in ("o_proj", "out_proj", "dense", "wo", "c_proj"):
+        m = getattr(attn, attr, None)
+        if m is not None and hasattr(m, "weight"):
+            return m
+    raise RuntimeError(f"Cannot find output projection in {type(attn).__name__}")
+
+
+def _find_o_proj_weight(attn):
+    """Find output projection weight regardless of attribute name."""
+    return _find_o_proj(attn).weight
+
+
+def _find_mlp_modules(mlp):
+    """Return (gate_mod, up_mod, down_mod) MLP modules so callers can read .bias.
+
+    Mirrors _find_mlp_weights' resolution order. gate_mod is None for 2-proj and
+    fused gate+up MLPs. For fused gate+up (Phi-3) up_mod is the fused module —
+    its bias (if any) spans [gate;up]; Phi-3 has no MLP bias so this stays None
+    in practice.
+    """
+    gate = getattr(mlp, "gate_proj", None) or getattr(mlp, "w1", None)
+    up   = getattr(mlp, "up_proj", None) or getattr(mlp, "w3", None)
+    down = getattr(mlp, "down_proj", None) or getattr(mlp, "w2", None)
+    if gate is not None and up is not None and down is not None:
+        return gate, up, down
+
+    gate_up = getattr(mlp, "gate_up_proj", None)
+    down2   = getattr(mlp, "down_proj", None)
+    if gate_up is not None and down2 is not None:
+        return None, gate_up, down2
+
+    up_2 = (getattr(mlp, "dense_h_to_4h", None) or   # GPTNeoX, BLOOM
+            getattr(mlp, "c_fc", None) or              # Starcoder2
+            getattr(mlp, "ff_proj", None) or           # OLMo
+            getattr(mlp, "fc_in", None))
+    dn_2 = (getattr(mlp, "dense_4h_to_h", None) or   # GPTNeoX, BLOOM
+            getattr(mlp, "c_proj", None) or            # Starcoder2
+            getattr(mlp, "ff_out", None) or            # OLMo
+            getattr(mlp, "fc_out", None))
+    return None, up_2, dn_2
+
+
+def _find_mlp_weights(mlp, cfg):
+    """Return (gate_w, up_w, down_w) raw weight tensors.
+
+    gate_w is None for 2-projection MLPs (no gating).
+    Handles SwiGLU (gate+up+down), fused gate_up (Phi-3), and
+    2-proj variants (GPTNeoX dense_h_to_4h, Starcoder2 c_fc, OLMo ff_proj).
+    """
+    # SwiGLU with standard names
+    gate = (getattr(mlp, "gate_proj", None) or
+            getattr(mlp, "w1", None))     # InternLM2
+    up   = (getattr(mlp, "up_proj", None) or
+            getattr(mlp, "w3", None))     # InternLM2
+    down = (getattr(mlp, "down_proj", None) or
+            getattr(mlp, "w2", None))     # InternLM2
+
+    if gate is not None and up is not None and down is not None:
+        return gate.weight, up.weight, down.weight
+
+    # Fused gate+up (Phi-3: gate_up_proj contains [gate; up] concatenated)
+    gate_up = getattr(mlp, "gate_up_proj", None)
+    down2   = getattr(mlp, "down_proj", None)
+    if gate_up is not None and down2 is not None:
+        w   = gate_up.weight.detach().bfloat16()  # (gate_out+up_out, in)
+        mid = w.shape[0] // 2
+        return w[:mid], w[mid:], down2.weight
+
+    # 2-proj MLP (no gate) — return gate=None
+    up_2 = (getattr(mlp, "dense_h_to_4h", None) or   # GPTNeoX, BLOOM
+            getattr(mlp, "c_fc", None) or              # Starcoder2
+            getattr(mlp, "ff_proj", None) or           # OLMo
+            getattr(mlp, "fc_in", None))
+    dn_2 = (getattr(mlp, "dense_4h_to_h", None) or   # GPTNeoX, BLOOM
+            getattr(mlp, "c_proj", None) or            # Starcoder2
+            getattr(mlp, "ff_out", None) or            # OLMo
+            getattr(mlp, "fc_out", None))
+    if up_2 is not None and dn_2 is not None:
+        return None, up_2.weight, dn_2.weight
+
+    raise RuntimeError(
+        f"Cannot find MLP weights in {type(mlp).__name__}. "
+        f"Attributes: {[a for a in dir(mlp) if not a.startswith('_')]}"
+    )
+
+
+# ------------------------------------------------------------------
+# Per-layer weight container
+# ------------------------------------------------------------------
+
+@dataclass
+class _LayerWeights:
+    norm1_w:  object   # ttnn.Tensor (TILE, hidden_p) -- input_layernorm
+    norm1_sc: object   # ttnn.Tensor (TILE, TILE) -- 1/hidden scaler
+    norm2_w:  object   # post_attention_layernorm
+    norm2_sc: object
+    qkv_w:    object   # ttnn.Tensor (hidden_p, q_out_p+k_out_p+v_out_p) -- fused
+    q_end:    int      # slice boundary: qkv[:q_end] = Q
+    k_end:    int      # slice boundary: qkv[q_end:k_end] = K, qkv[k_end:] = V
+    o_w:      object   # ttnn.Tensor (n_heads*head_dim_p, hidden_p)
+    gate_w:   object   # ttnn.Tensor (hidden_p, intermediate_p)
+    up_w:     object
+    down_w:   object   # ttnn.Tensor (intermediate_p, hidden_p)
+    qkv_b:    object   # torch.Tensor (total_qkv_p,) CPU float -- None if no bias
+    gate_b:   object   # ttnn.Tensor (TILE, intermediate_p) -- None if no bias
+    up_b:     object   # ttnn.Tensor (TILE, intermediate_p) -- None if no bias
+    o_b:      object = None  # ttnn.Tensor (TILE, hidden_p) o-proj bias -- None if absent
+    down_b:   object = None  # ttnn.Tensor (TILE, hidden_p) MLP down bias -- None if absent
+    # Optional extra norms (Gemma 3 style: norm applied to sub-layer OUTPUT)
+    norm3_w:  object = None  # pre_feedforward_layernorm
+    norm3_sc: object = None
+    norm4_w:  object = None  # post_feedforward_layernorm
+    norm4_sc: object = None
+    # Residual pattern: "llama" (norm before sublayer) or "gemma" (norm wraps sublayer output)
+    norm_style: str = "llama"
+    # Optional per-head Q/K norms (Gemma 3, Qwen 3) -- stored as (head_dim,) CPU tensors
+    q_norm_w: object = None   # torch.Tensor or None
+    k_norm_w: object = None
+    # LayerNorm weight+bias (CPU float tensors; None for RMSNorm models)
+    norm1_w_cpu: object = None
+    norm1_b: object = None
+    norm2_w_cpu: object = None
+    norm2_b: object = None
+    # CP-1: fused QKV bias as a device tensor (1, total_qkv_p) for the on-device/paged
+    # attention paths — twin of the CPU `qkv_b`. None when the model has no qkv bias.
+    qkv_b_tt: object = None
+    # CP-3: per-layer LayerNorm weight+bias as device row tensors (1, hidden) for
+    # on-device ttnn.layer_norm. None for RMSNorm models.
+    norm1_w_ln_tt: object = None
+    norm1_b_ln_tt: object = None
+    norm2_w_ln_tt: object = None
+    norm2_b_ln_tt: object = None
+    # CP-4: per-head Q/K RMSNorm weight as device row tensors (1, head_dim).
+    q_norm_w_tt: object = None
+    k_norm_w_tt: object = None
+    # SWA: gemma3 per-layer sliding-window size for the decode SDPA (0 = full attention).
+    swa_window: int = 0
+
+
+def _layernorm_cpu(x: torch.Tensor, weight, bias, eps: float) -> torch.Tensor:
+    mean = x.mean(-1, keepdim=True)
+    var  = ((x - mean).pow(2)).mean(-1, keepdim=True)
+    x_norm = (x - mean) / (var + eps).sqrt()
+    if weight is not None:
+        x_norm = x_norm * weight
+    if bias is not None:
+        x_norm = x_norm + bias
+    return x_norm
+
+
+# ------------------------------------------------------------------
+# Main runner class
+# ------------------------------------------------------------------
+
+class TTModelRunner:
+    """Runs a HuggingFace transformer model fully on a TT device.
+
+    Weights are uploaded to device once at init. Each token generation step
+    runs all layers on device and only reads back the final hidden state for
+    lm_head projection.
+
+    This is the generic fallback runner and satisfies the ``BaseRunner`` contract
+    (``dispatch/base.py``): generate / generate_stream / benchmark plus the
+    _tokenizer / _listed / _community attributes. Custom runners for non-standard
+    architectures implement the same contract — see ``docs/custom_runners.md``.
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        device,
+        max_seq: int = 2048,
+        lm_head_on_device: bool = False,
+        unsafe: bool = False,
+        force_novel: bool = False,
+    ):
+        from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
+        from tt_inference_server.dispatch.registry import detect_model_family
+        from tt_inference_server.dispatch.dispatcher import (
+            KernelDispatcher, derive_capabilities)
+
+        self._device = device
+        self._max_seq = max_seq
+        self._lm_head_on_device = lm_head_on_device
+        self._unsafe = unsafe
+        self._force_novel = force_novel
+        # Per-layer HF ladder capture sink (#49). None in production (one branch in the
+        # hot path, same pattern as DISPATCH_LMHEAD_DEBUG); a dict only when DISPATCH_LADDER=1.
+        # EAGER decode only — the traced path never calls _ladder_capture (readbacks would
+        # corrupt the trace). DISPATCH_LADDER_SUBOP=1 adds the intra-layer post_attn rung.
+        self._ladder = {} if os.environ.get("DISPATCH_LADDER") == "1" else None
+        self._ladder_subop = os.environ.get("DISPATCH_LADDER_SUBOP") == "1"
+
+        print(f"Loading {model_path} ...")
+        hf_config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+        archs = getattr(hf_config, "architectures", None) or []
+        arch = archs[0] if archs else "<unknown>"
+        self._cfg = detect_model_family(hf_config)
+        self._hf_cfg = hf_config
+
+        self._tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+
+        print("  Loading weights ...")
+        hf_model = AutoModelForCausalLM.from_pretrained(
+            model_path, torch_dtype=torch.bfloat16, trust_remote_code=True
+        )
+        hf_model.eval()
+
+        self._dispatcher = KernelDispatcher(device, unsafe=unsafe)
+
+        # Two-tier resolution (#3): prefer the matrix entry for listed models; fall back
+        # to HF-config auto-derivation for novel/unlisted ones (the universal floor). The
+        # resolved entry + capabilities are wired here; the inline gates that consume them
+        # are migrated one at a time in Phase C, so behavior is unchanged at this step.
+        # force_novel (#47): skip the matrix lookup so a listed, validated model is
+        # resolved exactly as a truly-unlisted one would be — derive_capabilities() +
+        # detect_model_family() dims + the introspect_eligible recompute. Exercises the
+        # real lookup-miss branch (not a temp matrix / env var), so the regression gate
+        # proves the novel path reproduces the matrix path token-for-token.
+        self._entry = None if force_novel else self._dispatcher.lookup(model_path)
+        self._listed = self._entry is not None
+        if force_novel:
+            print("  force_novel=True: matrix lookup SKIPPED -> auto-derive path (#47).")
+        if self._entry is not None:
+            # Matrix is authoritative for dims for listed models (#3 Phase D); novel
+            # models keep detect_model_family()'s HF-config introspection above.
+            self._cfg = self._entry.model_config()
+            self._caps = self._entry.capabilities(self._dispatcher._hw_config)
+            self._community = (self._entry.status == "community")
+            print(f"  Matrix: '{self._entry.name}' (status={self._entry.status}, "
+                  f"backend={self._caps.attn_backend}, fast_path={self._caps.fast_path}, "
+                  f"lm_head_ondevice={self._caps.lm_head_ondevice})")
+            if self._community and not unsafe:
+                print(f"  WARNING: '{self._entry.name}' is status=community (unverified); "
+                      "correctness is not guaranteed. Pass --unsafe to silence (#25).")
+        else:
+            self._caps = derive_capabilities(hf_config)
+            self._community = True
+            print(f"  Matrix: no entry for arch '{arch}' -> auto-derived (community, "
+                  f"unverified). fast_path={self._caps.fast_path}, "
+                  f"lm_head_ondevice={self._caps.lm_head_ondevice}. "
+                  "Output validity unverified on this hardware.")
+
+        # bf8 weights (perf spike): upload the large linear weights (qkv/o/gate/up/down/
+        # lm_head) as block-float8 to halve their DRAM footprint + per-token read bandwidth.
+        # Reversible A/B arm — default OFF keeps the bf16 path byte-identical. Embedding
+        # (ROW_MAJOR lookup), norms, biases, KV and activations stay bf16.
+        import os as _os
+        self._bf8_weights = _os.environ.get("DISPATCH_BF8_WEIGHTS", "0") == "1"
+        if self._bf8_weights:
+            print("  Weight dtype: bfloat8_b (DISPATCH_BF8_WEIGHTS=1) — linear weights only")
+
+        print("  Uploading to device ...")
+        try:
+            self._load_weights(hf_model)
+        except (AttributeError, KeyError, RuntimeError) as e:
+            raise RuntimeError(
+                f"Weight loading failed for architecture '{arch}'.\n"
+                f"  Model: {model_path}\n"
+                f"  Error: {e}\n"
+                f"  Fix: add '{arch}' support to configs/registry.py and a "
+                f"matching config module, or check that the HF model structure "
+                f"matches the expected layer attribute names."
+            ) from None
+        self._build_rope_table()
+        self._build_attn_scalars()
+        self._init_kv_cache()
+        self._init_scratch_bufs()
+        self._setup_paged_decode()
+        self._setup_ondevice_lmhead()
+
+        del hf_model  # free CPU memory
+        print(f"  Ready. {len(self._layers)} layers on device.")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def generate(
+        self,
+        prompt: str,
+        max_new_tokens: int = 50,
+        temperature: float = 1.0,
+        chat: bool = True,
+    ) -> str:
+        """Generate a response to the given prompt.
+
+        Args:
+            prompt: Input text.
+            max_new_tokens: Maximum tokens to generate.
+            temperature: Sampling temperature (1.0 = greedy).
+            chat: If True and the tokenizer has a chat template, apply it.
+                  Set to False for raw completion prompts.
+        """
+        if chat and hasattr(self._tokenizer, "apply_chat_template"):
+            try:
+                messages = [{"role": "user", "content": prompt}]
+                input_ids = self._tokenizer.apply_chat_template(
+                    messages, add_generation_prompt=True, return_tensors="pt"
+                )[0].tolist()
+            except Exception:
+                input_ids = self._tokenizer.encode(prompt, return_tensors="pt")[0].tolist()
+        else:
+            input_ids = self._tokenizer.encode(prompt, return_tensors="pt")[0].tolist()
+        self.reset_cache()
+
+        t0 = time.perf_counter()
+
+        # Prefill: populate the KV cache for the whole prompt (batched if eligible + flag).
+        next_id = self._prefill(input_ids)
+
+        output_ids = []
+        # Decode: generate new tokens
+        for _ in range(max_new_tokens):
+            if next_id == self._tokenizer.eos_token_id:
+                break
+            output_ids.append(next_id)
+            next_id = self._decode_step(next_id, len(input_ids) + len(output_ids) - 1)
+
+        elapsed = time.perf_counter() - t0
+        n_new = len(output_ids)
+        if n_new:
+            print(f"  {n_new} tokens in {elapsed:.1f}s = {n_new/elapsed:.1f} tok/s")
+
+        return self._tokenizer.decode(output_ids, skip_special_tokens=True)
+
+    def generate_stream(
+        self,
+        prompt: str,
+        max_new_tokens: int = 50,
+        temperature: float = 1.0,
+        chat: bool = True,
+    ):
+        """Generator yielding decoded text deltas one token at a time.
+
+        Same decode loop as generate(), but re-decodes the running id list each step and
+        yields the newly-appended substring — correct across BPE merges/multi-byte chars.
+        The final yielded item is a dict {"finish_reason", "prompt_tokens",
+        "completion_tokens"} so callers can build an OpenAI-style usage block.
+        """
+        if chat and hasattr(self._tokenizer, "apply_chat_template"):
+            try:
+                messages = [{"role": "user", "content": prompt}]
+                input_ids = self._tokenizer.apply_chat_template(
+                    messages, add_generation_prompt=True, return_tensors="pt"
+                )[0].tolist()
+            except Exception:
+                input_ids = self._tokenizer.encode(prompt, return_tensors="pt")[0].tolist()
+        else:
+            input_ids = self._tokenizer.encode(prompt, return_tensors="pt")[0].tolist()
+        self.reset_cache()
+
+        next_id = None
+        for pos, tok_id in enumerate(input_ids):
+            next_id = self._decode_step(tok_id, pos)
+
+        output_ids = []
+        emitted = ""
+        finish_reason = "length"
+        for _ in range(max_new_tokens):
+            if next_id == self._tokenizer.eos_token_id:
+                finish_reason = "stop"
+                break
+            output_ids.append(next_id)
+            text = self._tokenizer.decode(output_ids, skip_special_tokens=True)
+            if len(text) > len(emitted):
+                yield text[len(emitted):]
+                emitted = text
+            next_id = self._decode_step(next_id, len(input_ids) + len(output_ids) - 1)
+
+        yield {
+            "finish_reason": finish_reason,
+            "prompt_tokens": len(input_ids),
+            "completion_tokens": len(output_ids),
+        }
+
+    def benchmark(self, prompt: str, n_tokens: int = 50, warmup: int = 3) -> tuple:
+        """Measure steady-state decode throughput. Returns (tok_s, output_text).
+
+        Prefill and warmup steps are untimed so kernel compilation and pipeline
+        startup don't inflate elapsed. Only the n_tokens timed decode steps count.
+        """
+        input_ids = self._tokenizer.encode(prompt, return_tensors="pt")[0].tolist()
+        self.reset_cache()
+
+        # Prefill — untimed (kernel compilation happens here on first call)
+        next_id = None
+        for pos, tok_id in enumerate(input_ids):
+            next_id = self._decode_step(tok_id, pos)
+
+        # Warmup decode steps — untimed, ensures device pipeline is fully active
+        for i in range(warmup):
+            if next_id == self._tokenizer.eos_token_id:
+                break
+            next_id = self._decode_step(next_id, len(input_ids) + i)
+
+        # Timed decode
+        output_ids = []
+        t0 = time.perf_counter()
+        for i in range(n_tokens):
+            if next_id == self._tokenizer.eos_token_id:
+                break
+            output_ids.append(next_id)
+            next_id = self._decode_step(next_id, len(input_ids) + warmup + i)
+        elapsed = time.perf_counter() - t0
+
+        n = len(output_ids)
+        tok_s = n / elapsed if elapsed > 0 and n > 0 else 0.0
+        print(f"  {n} tokens in {elapsed:.1f}s = {tok_s:.1f} tok/s  (warmup={warmup})")
+        return tok_s, self._tokenizer.decode(output_ids, skip_special_tokens=True)
+
+    def reset_cache(self):
+        """Clear the KV cache for a new conversation."""
+        for buf in self._k_hist_cpu + self._v_hist_cpu:
+            buf.zero_()
+
+    # ------------------------------------------------------------------
+    # Forward pass
+    # ------------------------------------------------------------------
+
+    def _decode_step(self, token_id: int, kv_pos: int) -> int:
+        """Single-token forward pass. Returns next token id (int)."""
+        import ttnn
+        if self._paged_attn:
+            # Write the position into the pinned device tensor once; all layers' paged
+            # KV-write + SDPA read it (trace-safe — device-tensor index, not a Python int).
+            self._cur_pos_cpu[0] = kv_pos
+            ttnn.copy_host_to_device_tensor(
+                ttnn.from_torch(self._cur_pos_cpu, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT),
+                self._cur_pos_dev)
+        if self._traced:
+            return self._decode_step_traced(token_id)
+        hidden_tt = self._embed(token_id)
+        if self._embed_ln_w_cpu is not None:        # BLOOM word_embeddings_layernorm
+            hidden_tt = self._apply_embed_ln(hidden_tt)
+        self._ladder_capture("post_embed", hidden_tt)
+        for i in range(len(self._layers)):
+            hidden_tt = self._layer_forward(hidden_tt, i, kv_pos)
+            self._ladder_capture(f"layer{i}", hidden_tt)
+        self._ladder_capture("final_hidden", hidden_tt)
+        return self._lm_head(hidden_tt)
+
+    def _ladder_capture(self, tag: str, hidden_tt) -> None:
+        """Record a hidden-state rung for the HF ladder diagnostic (#49).
+
+        No-op unless DISPATCH_LADDER=1 (the first line is the production branch). Stores a
+        CPU fp32 (hidden,) vector keyed by `tag`, overwritten each decode step so after a
+        prompt-prefill loop the dict holds the rungs for the LAST position (the step that
+        predicts the next token) — which is what diff_hf_ladder.py aligns against HF.
+        Called from the EAGER path only; the traced decode never reaches here."""
+        if self._ladder is None:
+            return
+        import ttnn
+        hidden = self._cfg.hidden_size
+        self._ladder[tag] = ttnn.to_torch(hidden_tt)[0, :hidden].float().clone()
+
+    def _apply_embed_ln(self, hidden_tt):
+        """Apply the embedding LayerNorm (BLOOM) on CPU, returning (TILE, hidden_p)."""
+        import ttnn
+        eps = getattr(self._hf_cfg, "layer_norm_eps",
+                      getattr(self._hf_cfg, "rms_norm_eps", 1e-5))
+        hsz = self._cfg.hidden_size
+        hp  = _tile_align(hsz)
+        hcpu = ttnn.to_torch(hidden_tt)[0, :hsz].float()
+        ncpu = _layernorm_cpu(hcpu, self._embed_ln_w_cpu, self._embed_ln_b_cpu, eps)
+        v_row = torch.nn.functional.pad(ncpu.bfloat16(), (0, hp - hsz)).unsqueeze(0)
+        v_2d  = v_row.expand(TILE, -1).contiguous()
+        return ttnn.from_torch(v_2d, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
+                               device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    def _embed_traced(self):
+        """Host-free embed: reads the pinned token-id device tensor (no from_torch)."""
+        import ttnn
+        emb = ttnn.embedding(self._tok_dev, self._embed_tt)
+        emb = ttnn.reshape(emb, [1, _tile_align(self._cfg.hidden_size)])
+        h = ttnn.to_layout(emb, ttnn.TILE_LAYOUT)
+        if self._embed_scale != 1.0:
+            h = ttnn.multiply(h, self._embed_scale)
+        return h
+
+    def _run_embed_layers(self):
+        hidden_tt = self._embed_traced()
+        for i in range(len(self._layers)):
+            hidden_tt = self._layer_forward(hidden_tt, i, 0)   # kv_pos unused on paged path
+        return hidden_tt
+
+    def _run_decode_graph(self):
+        """The captured decode graph: embed + layers, plus on-device lm_head when enabled.
+
+        Returns the argmax-index tensor when lm_head is folded in (#31), otherwise the
+        final hidden state (lm_head then runs eagerly off the trace).
+        """
+        hidden_tt = self._run_embed_layers()
+        if self._ondevice_lmhead:
+            return self._lm_head_graph(hidden_tt)
+        return hidden_tt
+
+    def _decode_step_traced(self, token_id: int) -> int:
+        """Trace-replayed decode (#30): host-free embed+layers run from a captured trace.
+
+        Per-token PCIe: write token id + position into pinned buffers, execute the trace,
+        read back the result. With DISPATCH_ONDEVICE_LMHEAD=1 (#31) the final norm +
+        lm_head + argmax are folded into the trace, so the read-back is just the 4-byte
+        sampled id; otherwise the final hidden state is read back for an eager CPU lm_head.
+        """
+        import ttnn
+        dev = self._device
+        self._tok_cpu[0, 0] = token_id
+        ttnn.copy_host_to_device_tensor(
+            ttnn.from_torch(self._tok_cpu, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT),
+            self._tok_dev)
+        if self._trace_id is None:
+            # warmup (compiles kernels) then capture the decode graph as a replayable trace
+            self._run_decode_graph()
+            self._trace_id = ttnn.begin_trace_capture(dev, cq_id=0)
+            self._traced_out = self._run_decode_graph()
+            ttnn.end_trace_capture(dev, self._trace_id, cq_id=0)
+            print(f"  Decode trace captured (id={self._trace_id}"
+                  f"{', lm_head folded in' if self._ondevice_lmhead else ''})")
+        ttnn.execute_trace(dev, self._trace_id, cq_id=0, blocking=True)
+        if self._ondevice_lmhead:
+            return int(ttnn.to_torch(self._traced_out).flatten()[0])
+        return self._lm_head(self._traced_out)
+
+    def _embed(self, token_id: int):
+        """Lookup embedding on-device, apply optional scale. Returns (TILE, hidden_p)."""
+        import ttnn
+        self._token_id_cpu[0, 0] = token_id
+        token_tt = ttnn.from_torch(self._token_id_cpu, device=self._device,
+                                   memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        # ttnn.embedding returns ROW_MAJOR [1, 1, hidden_size]; reshape to [1, hidden_p]
+        # then convert to TILE_LAYOUT which pads the first dim to TILE automatically.
+        emb_tt = ttnn.embedding(token_tt, self._embed_tt)
+        ttnn.deallocate(token_tt)
+        hidden_p = _tile_align(self._cfg.hidden_size)
+        emb_tt = ttnn.reshape(emb_tt, [1, hidden_p])
+        hidden_tt = ttnn.to_layout(emb_tt, ttnn.TILE_LAYOUT)
+        if self._embed_scale != 1.0:
+            hidden_tt = ttnn.multiply(hidden_tt, self._embed_scale)
+        return hidden_tt
+
+    def _ln_row_tt(self, vec):
+        """Build a (1, hidden) bf16 TILE device tensor from a (hidden,) CPU vector for
+        ttnn.layer_norm gamma/beta (CP-3). Returns None if vec is None."""
+        import ttnn
+        if vec is None:
+            return None
+        return ttnn.from_torch(vec.detach().float().bfloat16().unsqueeze(0),
+                               dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
+                               device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    def _layernorm_dev(self, h_tt, w_row_tt, b_row_tt, eps):
+        """On-device LayerNorm via ttnn.layer_norm (multi-core, trace-safe). w_row_tt/
+        b_row_tt are (1, hidden). Replaces the CPU _layernorm_cpu readback. PCC 0.99999
+        vs torch verified in CP-0 (tests/diagnostic/probe_layernorm_pcc.py).
+
+        ttnn.layer_norm preserves the input's logical row count, but the decode-path
+        convention (matching rmsnorm's output buffer) is (TILE, hidden_p) — only row 0
+        carries the token. A bare embed output is logical (1, hidden_p), so broadcast the
+        normalized row to TILE rows; otherwise the downstream matmul output_tensor= scratch
+        (TILE, *) volume mismatches (the pythia gpt_neox crash)."""
+        import ttnn
+        out = ttnn.layer_norm(h_tt, epsilon=eps, weight=w_row_tt, bias=b_row_tt)
+        # Decode-only convention: pad a bare (1,H) embed row up to (TILE,H) to match the
+        # rmsnorm scratch volume. In prefill the input is logical (N,H) and must stay (N,H)
+        # — repeating to TILE would explode it to (N*TILE, H).
+        if not getattr(self, "_prefilling", False) and out.shape[0] != TILE:
+            out = ttnn.repeat(out, ttnn.Shape([TILE, 1]))
+        return out
+
+    def _head_rmsnorm_dev(self, x4, w_row_tt, eps=1e-6):
+        """Per-head RMSNorm over head_dim via ttnn.rms_norm (CP-4). x4: [1,1,nh,hd];
+        w_row_tt: (1, head_dim) broadcast across heads. Replaces CPU _apply_head_norm
+        (Qwen3/Gemma3). PCC 0.99999 vs torch (tests/diagnostic/probe_head_rmsnorm.py)."""
+        import ttnn
+        return ttnn.rms_norm(x4, epsilon=eps, weight=w_row_tt)
+
+    def _rmsnorm_dev(self, h_tt, w_2d_tt, eps):
+        """RMSNorm via native ttnn.rms_norm (fp32-internal variance) — the permanent fix for
+        BUG-MISTRAL-01 (#22), replacing the custom single-core kernel's bf16 variance that
+        under-normalized high-dynamic-range inputs. w_2d_tt is the (TILE, hidden_p) weight;
+        row 0 is the per-feature weight (gemma (1+w) baked in).
+
+        Decode convention: ttnn.rms_norm preserves the input's logical row count, but the
+        decode matmul's pre-allocated output_tensor scratch is (TILE, *) — so a bare 1-row
+        result must be broadcast back to TILE rows (same fix as _layernorm_dev / the pythia
+        gpt_neox crash). In prefill the input is logical (N, H) and must stay (N, H)."""
+        import ttnn
+        hp = _tile_align(self._cfg.hidden_size)
+        w_row = ttnn.slice(w_2d_tt, [0, 0], [1, hp])
+        out = ttnn.rms_norm(h_tt, epsilon=eps, weight=w_row)
+        if not getattr(self, "_prefilling", False) and out.shape[0] != TILE:
+            out = ttnn.repeat(out, ttnn.Shape([TILE, 1]))
+        return out
+
+    def _bias_add(self, x_tt, bias_tt):
+        """Add a [1,W] bias row to x. In prefill x is [N,W] and binary_ng rejects the
+        subtile height-broadcast of a 1-row bias, so materialize it to [N,W] first (and
+        free the temp). Decode (N=1, not prefilling) takes the plain broadcast add —
+        byte-identical to before."""
+        import ttnn
+        if getattr(self, "_prefilling", False):
+            # The stored bias is a TILE-padded [32, W] (data in row 0, rows 1..31 zero);
+            # decode adds it to a 32-padded single row. Prefill x is [N, W], so slice the
+            # canonical bias row and materialize it to N rows (binary_ng rejects the
+            # subtile height-broadcast of a 1-row operand).
+            w = x_tt.shape[-1]
+            b1 = ttnn.slice(bias_tt, [0, 0], [1, w])
+            bias_n = ttnn.repeat(b1, ttnn.Shape([self._prefill_N, 1]))
+            out = ttnn.add(x_tt, bias_n)
+            ttnn.deallocate(b1)
+            ttnn.deallocate(bias_n)
+            return out
+        return ttnn.add(x_tt, bias_tt)
+
+    def _layer_forward(self, hidden_tt, layer_idx: int, kv_pos: int):
+        import ttnn
+        lw = self._layers[layer_idx]
+
+        def rmsnorm_buf():
+            if getattr(self, "_prefilling", False):        # prefill: fresh [N, hidden_p] out
+                hp = _tile_align(self._cfg.hidden_size)     # logical N rows (match the input!)
+                return ttnn.zeros([self._prefill_N, hp], dtype=ttnn.bfloat16,
+                                  layout=ttnn.TILE_LAYOUT, device=self._device,
+                                  memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            return self._rmsnorm_buf_tt
+
+        def rms(h_tt, w_tt, sc_tt):
+            """RMSNorm via native ttnn.rms_norm (fp32-internal variance), for BOTH decode and
+            prefill. Replaces the custom single-core ttl kernel, whose bf16 sum-of-squares
+            accumulation under-normalized high-dynamic-range inputs (magnitude inflated 1.5-3x,
+            correct direction) — the root cause of BUG-MISTRAL-01 (#22). ttnn.rms_norm computes
+            the variance in fp32 and is correct by construction; a 128-tile fp32 reduce cannot
+            fit the custom single-core kernel's L1/DST budget, so the native op is the fix."""
+            eps = getattr(self._hf_cfg, "rms_norm_eps", 1e-6)
+            return self._rmsnorm_dev(h_tt, w_tt, eps)
+
+        def seq_norm(h_tt, w_tt, sc_tt, w_ln_tt, b_ln_tt):
+            """Pre-sublayer norm for the sequential (llama-style) residual path.
+            On-device ttnn.layer_norm for LayerNorm models (StableLM, Falcon, BLOOM);
+            on-device RMSNorm otherwise. CP-3: trace-safe, no CPU readback."""
+            if not self._uses_layernorm:
+                return rms(h_tt, w_tt, sc_tt)
+            eps = getattr(self._hf_cfg, "layer_norm_eps",
+                          getattr(self._hf_cfg, "rms_norm_eps", 1e-5))
+            return self._layernorm_dev(h_tt, w_ln_tt, b_ln_tt, eps)
+
+        # output_tensor= for residual adds writes into pre-allocated hidden scratch,
+        # eliminating 2 device tensor allocations per layer per token.
+        aot = ({} if getattr(self, "_prefilling", False)
+               else ({"output_tensor": self._hidden_scratch_tt} if self._add_ot else {}))
+
+        def add_resid(h_tt, sub_tt):
+            """Residual add, scaling the sublayer output by residual_multiplier first
+            (Granite, #43). No-op multiply skipped when residual_mult == 1.0 (all other arches)."""
+            if self._residual_mult != 1.0:
+                sub_tt = ttnn.multiply(sub_tt, self._residual_mult)
+            return ttnn.add(h_tt, sub_tt, **aot)
+
+        if lw.norm_style == "gemma":
+            # Gemma pattern:
+            #   normed  = norm1(hidden)
+            #   attn_raw = attn(normed)
+            #   hidden  += norm2(attn_raw)      ← norm wraps attn OUTPUT
+            #   normed2 = norm3(hidden)
+            #   mlp_raw = mlp(normed2)
+            #   hidden  += norm4(mlp_raw)        ← norm wraps mlp OUTPUT
+            normed1_tt  = rms(hidden_tt, lw.norm1_w, lw.norm1_sc)
+            attn_raw_tt = self._attention(normed1_tt, layer_idx, kv_pos)
+            attn_normed = rms(attn_raw_tt, lw.norm2_w, lw.norm2_sc)
+            hidden_tt   = ttnn.add(hidden_tt, attn_normed, **aot)
+
+            normed2_tt  = rms(hidden_tt, lw.norm3_w, lw.norm3_sc)
+            mlp_raw_tt  = self._mlp(normed2_tt, layer_idx)
+            mlp_normed  = rms(mlp_raw_tt, lw.norm4_w, lw.norm4_sc)
+            hidden_tt   = ttnn.add(hidden_tt, mlp_normed, **aot)
+        elif lw.norm_style == "gpt_neox":
+            # GPTNeoX parallel residual pattern:
+            #   attn and MLP both branch from the same pre-norm hidden state
+            #   hidden += attn(norm1(hidden)) + mlp(norm2(hidden))
+            if self._uses_layernorm:
+                # CP-3: on-device ttnn.layer_norm — no CPU readback (trace-safe).
+                eps = getattr(self._hf_cfg, "layer_norm_eps",
+                              getattr(self._hf_cfg, "rms_norm_eps", 1e-5))
+                normed1_tt = self._layernorm_dev(hidden_tt, lw.norm1_w_ln_tt, lw.norm1_b_ln_tt, eps)
+                normed2_tt = self._layernorm_dev(hidden_tt, lw.norm2_w_ln_tt, lw.norm2_b_ln_tt, eps)
+            else:
+                normed1_tt = rms(hidden_tt, lw.norm1_w, lw.norm1_sc)
+                normed2_tt = rms(hidden_tt, lw.norm2_w, lw.norm2_sc)
+            attn_out_tt = self._attention(normed1_tt, layer_idx, kv_pos)
+            mlp_out_tt = self._mlp(normed2_tt, layer_idx)
+            hidden_tt = add_resid(hidden_tt, attn_out_tt)
+            hidden_tt = add_resid(hidden_tt, mlp_out_tt)
+        else:
+            # Llama / Qwen / Mistral / (LayerNorm: BLOOM, StableLM, Falcon) pattern:
+            #   hidden += attn(norm1(hidden))
+            #   hidden += mlp(norm2(hidden))
+            normed1_tt = seq_norm(hidden_tt, lw.norm1_w, lw.norm1_sc, lw.norm1_w_ln_tt, lw.norm1_b_ln_tt)
+            attn_out_tt = self._attention(normed1_tt, layer_idx, kv_pos)
+            hidden_tt = add_resid(hidden_tt, attn_out_tt)
+            if self._ladder_subop:                  # intra-layer rung (#49, DISPATCH_LADDER_SUBOP=1)
+                self._ladder_capture(f"layer{layer_idx}.post_attn", hidden_tt)
+
+            normed2_tt = seq_norm(hidden_tt, lw.norm2_w, lw.norm2_sc, lw.norm2_w_ln_tt, lw.norm2_b_ln_tt)
+            mlp_out_tt = self._mlp(normed2_tt, layer_idx)
+            hidden_tt = add_resid(hidden_tt, mlp_out_tt)
+
+        return hidden_tt
+
+    def _write_kv_to_device(self, layer_idx: int, kv_pos: int, k_cpu, v_cpu):
+        """Write one token's post-RoPE K/V into the on-device KV cache.
+
+        k_cpu / v_cpu: float32 tensors shaped (N_kv_heads, head_dim).
+        Uses pre-allocated CPU staging buffers to avoid torch.zeros() each call.
+        """
+        import ttnn
+        cfg  = self._cfg
+        hd   = cfg.head_dim
+
+        self._k_in_cpu.zero_()
+        self._v_in_cpu.zero_()
+        self._k_in_cpu[0, :, 0, :hd] = k_cpu.bfloat16()
+        self._v_in_cpu[0, :, 0, :hd] = v_cpu.bfloat16()
+
+        k_tt = ttnn.from_torch(self._k_in_cpu, dtype=ttnn.bfloat16,
+                               layout=ttnn.TILE_LAYOUT, device=self._device,
+                               memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        v_tt = ttnn.from_torch(self._v_in_cpu, dtype=ttnn.bfloat16,
+                               layout=ttnn.TILE_LAYOUT, device=self._device,
+                               memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        ttnn.kv_cache.update_cache_for_token_(self._k_dev[layer_idx], k_tt, kv_pos, 0)
+        ttnn.kv_cache.update_cache_for_token_(self._v_dev[layer_idx], v_tt, kv_pos, 0)
+        ttnn.deallocate(k_tt)
+        ttnn.deallocate(v_tt)
+
+    def _attention(self, normed_tt, layer_idx: int, kv_pos: int):
+        """Attention: QKV on device, flash-attn on Tensix, O projection on device.
+
+        The flash_attn kernel uses grid=(N_heads // heads_per_core, 1) so it
+        fits within the hardware grid limit (13 cores x-axis on p150).  For
+        models with N_heads > 13 (e.g. Llama 3 8B: 32 heads) heads_per_core is
+        set by resolve_attn_config so each core handles multiple Q-heads
+        sequentially, sharing the KV read for heads in the same GQA group.
+        """
+        import ttnn
+        cfg  = self._cfg
+        lw   = self._layers[layer_idx]
+        hd   = cfg.head_dim
+        hd_p = _tile_align(hd)
+
+        # Fused QKV projection — write into pre-allocated scratch (no mmap; not in prefill)
+        _pf = getattr(self, "_prefilling", False)
+        qkv_ot  = self._qkv_scratch_tt if (self._matmul_ot and not _pf) else None
+        qkv_tt  = _matmul_safe(normed_tt, lw.qkv_w, self._device, output_tensor=qkv_ot)
+
+        # Batched prefill (eager, [N,hidden]): causal SDPA + paged_fill_cache.
+        if _pf:
+            return self._attention_prefill(qkv_tt, layer_idx, lw)
+
+        # Paged path (issue #30): trace-safe device-indexed KV write + paged SDPA decode.
+        if self._paged_attn:
+            return self._paged_attention(qkv_tt, layer_idx, lw)
+
+        # On-device path (issue #8): split + RoPE + KV-write + flash_attn entirely on
+        # device — no QKV readback. Gated at load time by self._ondevice_attn.
+        if self._ondevice_attn:
+            return self._attention_ondevice(qkv_tt, layer_idx, kv_pos, lw)
+
+        qkv_cpu = ttnn.to_torch(qkv_tt)[0].float()   # (total_qkv_p,)
+        if qkv_ot is None:
+            ttnn.deallocate(qkv_tt)
+        if lw.qkv_b is not None:
+            qkv_cpu += lw.qkv_b
+
+        q_cpu = qkv_cpu[:lw.q_end].view(cfg.num_heads,    hd_p)[:, :hd].contiguous()
+        k_cpu = qkv_cpu[lw.q_end:lw.k_end].view(cfg.num_kv_heads, hd_p)[:, :hd].contiguous()
+        v_cpu = qkv_cpu[lw.k_end:].view(cfg.num_kv_heads, hd_p)[:, :hd].contiguous()
+
+        # Optional per-head Q/K norm (Gemma 3, Qwen 3)
+        if lw.q_norm_w is not None:
+            q_cpu = self._apply_head_norm(q_cpu, lw.q_norm_w)
+        if lw.k_norm_w is not None:
+            k_cpu = self._apply_head_norm(k_cpu, lw.k_norm_w)
+
+        # RoPE — skipped for ALiBi models (BLOOM), which carry no rotary embedding
+        if not getattr(self, "_no_rope", False):
+            q_cpu = self._apply_rope(q_cpu, kv_pos)
+            k_cpu = self._apply_rope(k_cpu, kv_pos)
+
+        # Update CPU history mirrors (kept for debugging / fallback)
+        self._k_hist_cpu[layer_idx][:, kv_pos, :] = k_cpu.float()
+        self._v_hist_cpu[layer_idx][:, kv_pos, :] = v_cpu.float()
+
+        # ALiBi (BLOOM): per-head positional bias can't fold into the shared-mask
+        # flash_attn kernel — run CPU softmax+ALiBi attention from the history mirrors.
+        if getattr(self, "_uses_alibi", False):
+            return self._attention_cpu_alibi(q_cpu, layer_idx, kv_pos, lw)
+
+        # Write post-RoPE K/V into the on-device KV cache
+        self._write_kv_to_device(layer_idx, kv_pos, k_cpu, v_cpu)
+
+        # Upload Q to device: [N_heads*TILE, head_dim_p]
+        # Kernel reads tile-row h = element rows [h*TILE:(h+1)*TILE], so each head needs
+        # its full TILE block filled. repeat_interleave(TILE) replicates each head row.
+        self._q_cpu.zero_()
+        self._q_cpu[:, :hd] = q_cpu.bfloat16().repeat_interleave(TILE, dim=0)
+        q_tt = _to_tt(self._q_cpu, self._device)
+
+        # Reshape device KV cache [1, N_kv, max_seq_p, hd_p] →
+        # [N_kv * max_seq_p, hd_p] as expected by flash_attn_kernel
+        nkv      = cfg.num_kv_heads
+        ms_p     = _tile_align(self._max_seq)
+        K_2d = ttnn.reshape(self._k_dev[layer_idx], [nkv * ms_p, hd_p])
+        V_2d = ttnn.reshape(self._v_dev[layer_idx], [nkv * ms_p, hd_p])
+
+        # Build causal mask: [TILE, max_seq_p] — 0 for valid positions, -inf for future
+        # Reuse pre-allocated CPU buffer; only the boundary tile changes each step
+        self._mask_cpu.fill_(float("-inf"))
+        self._mask_cpu[0, :kv_pos + 1] = 0.0
+        mask_tt = _to_tt(self._mask_cpu, self._device)
+
+        # Run flash attention on Tensix cores
+        self._dispatcher.flash_attn(
+            q_tt, K_2d, V_2d,
+            self._fa_scale_tt, self._fa_ninf_tt, self._fa_zero_tt,
+            self._fa_zero_head_tt, self._fa_ones_tt,
+            mask_tt, self._fa_out_tt,
+            N_heads=cfg.num_heads, N_kv_heads=cfg.num_kv_heads,
+        )
+
+        # O projection — _fa_out_tt is [TILE, N_heads*hd_p], already O-proj compatible
+        return self._o_proj(self._fa_out_tt, lw)
+
+    def _dev_rope(self, x4, c4, s4):
+        """Elementwise RoPE on device. x4: [1,1,H,head_dim]; c4/s4: [1,1,1,head_dim].
+
+        Validated 1:1 vs CPU _apply_rope for full rope. Only valid when
+        rotary_ndims == head_dim (gated by self._ondevice_attn).
+        """
+        import ttnn
+        hd   = self._cfg.head_dim
+        half = hd // 2
+        H    = x4.shape[2]
+        a  = ttnn.slice(x4, [0, 0, 0, 0],    [1, 1, H, half])
+        b  = ttnn.slice(x4, [0, 0, 0, half], [1, 1, H, hd])
+        rh = ttnn.concat([ttnn.neg(b), a], dim=-1)
+        return ttnn.add(ttnn.multiply(x4, c4), ttnn.multiply(rh, s4))
+
+    def _attention_ondevice(self, qkv_tt, layer_idx: int, kv_pos: int, lw):
+        """On-device attention: split QKV + RoPE + KV-cache write + flash_attn, no readback.
+
+        Feeds the same proven flash_attn + O-proj path as the CPU route; only the
+        split/RoPE/KV-staging move on-device. Eliminates the per-token QKV->CPU
+        readback (issue #8). All reshapes validated on-card in
+        tests/diagnostic/probe_split_rope_layout.py.
+        """
+        import ttnn
+        cfg  = self._cfg
+        hd   = cfg.head_dim
+        hd_p = _tile_align(hd)                 # == hd here (gated)
+        nh   = cfg.num_heads
+        nkv  = cfg.num_kv_heads
+        qp   = nh * hd_p
+        kp   = nkv * hd_p
+        qend, kend, qkvp = qp, qp + kp, qp + 2 * kp
+        ms_p = _tile_align(self._max_seq)
+
+        # cos/sin for this position, gathered on-device from the resident tables
+        self._pos_idx_cpu[0, 0] = kv_pos
+        pidx = ttnn.from_torch(self._pos_idx_cpu, dtype=ttnn.uint32,
+                               layout=ttnn.ROW_MAJOR_LAYOUT, device=self._device,
+                               memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        c4 = ttnn.unsqueeze_to_4D(ttnn.embedding(pidx, self._rope_cos_dev, layout=ttnn.TILE_LAYOUT))
+        s4 = ttnn.unsqueeze_to_4D(ttnn.embedding(pidx, self._rope_sin_dev, layout=ttnn.TILE_LAYOUT))
+
+        # split row 0 of qkv into per-head Q/K/V, then RoPE Q and K
+        row = ttnn.slice(qkv_tt, [0, 0], [1, qkvp])
+        if lw.qkv_b_tt is not None:                      # CP-1: fused QKV bias on device
+            row = ttnn.add(row, lw.qkv_b_tt)
+        q4  = ttnn.reshape(ttnn.slice(row, [0, 0],    [1, qend]), [1, 1, nh,  hd_p])
+        k4  = ttnn.reshape(ttnn.slice(row, [0, qend], [1, kend]), [1, 1, nkv, hd_p])
+        v4  = ttnn.reshape(ttnn.slice(row, [0, kend], [1, qkvp]), [1, 1, nkv, hd_p])
+        if lw.q_norm_w_tt is not None:                   # CP-4: per-head Q/K RMSNorm on device
+            q4 = self._head_rmsnorm_dev(q4, lw.q_norm_w_tt)
+        if lw.k_norm_w_tt is not None:
+            k4 = self._head_rmsnorm_dev(k4, lw.k_norm_w_tt)
+        q_rot = self._dev_rope(q4, c4, s4)
+        k_rot = self._dev_rope(k4, c4, s4)
+
+        # flash_attn Q layout: [N_heads*TILE, hd_p] (each head row replicated across a tile)
+        q_tt = ttnn.repeat_interleave(ttnn.reshape(q_rot, [nh, hd_p]), TILE, dim=0)
+        q_tt = ttnn.to_layout(q_tt, ttnn.TILE_LAYOUT)
+
+        # write post-RoPE K and V into the on-device KV cache at kv_pos
+        k_in = ttnn.pad(ttnn.transpose(k_rot, 1, 2), [(0, 0), (0, 0), (0, TILE - 1), (0, 0)], 0.0)
+        v_in = ttnn.pad(ttnn.transpose(v4,    1, 2), [(0, 0), (0, 0), (0, TILE - 1), (0, 0)], 0.0)
+        ttnn.kv_cache.update_cache_for_token_(self._k_dev[layer_idx], k_in, kv_pos, 0)
+        ttnn.kv_cache.update_cache_for_token_(self._v_dev[layer_idx], v_in, kv_pos, 0)
+
+        # reshape device KV cache for flash_attn, build causal mask, run kernel
+        K_2d = ttnn.reshape(self._k_dev[layer_idx], [nkv * ms_p, hd_p])
+        V_2d = ttnn.reshape(self._v_dev[layer_idx], [nkv * ms_p, hd_p])
+        self._mask_cpu.fill_(float("-inf"))
+        self._mask_cpu[0, :kv_pos + 1] = 0.0
+        mask_tt = _to_tt(self._mask_cpu, self._device)
+        self._dispatcher.flash_attn(
+            q_tt, K_2d, V_2d,
+            self._fa_scale_tt, self._fa_ninf_tt, self._fa_zero_tt,
+            self._fa_zero_head_tt, self._fa_ones_tt,
+            mask_tt, self._fa_out_tt,
+            N_heads=nh, N_kv_heads=nkv,
+        )
+        return self._o_proj(self._fa_out_tt, lw)
+
+    def _setup_paged_decode(self):
+        """Set up the paged trace-safe decode path (issue #30), gated by env.
+
+        DISPATCH_PAGED_ATTN=1 enables eager paged attention; DISPATCH_TRACE=1 also
+        captures the decode step as a replayable trace. Only the clean GQA case is
+        supported (nh==32 so the decode SDPA's pad-to-32 is a no-op and grouping stays
+        nh/nkv); other shapes fall back to the existing path.
+        """
+        import os
+        import ttnn
+        self._paged_attn = False
+        self._traced = False
+        want = os.environ.get("DISPATCH_PAGED_ATTN", "0") == "1" or os.environ.get("DISPATCH_TRACE", "0") == "1"
+        if not want:
+            return
+        cfg = self._cfg
+        hd, nh, nkv = cfg.head_dim, cfg.num_heads, cfg.num_kv_heads
+        hd_p = _tile_align(hd)
+        group = (nh // nkv) if nkv else 0
+        # Proportional kv-head padding (#35): the decode SDPA pads Q to 32 heads and groups
+        # GQA as padded_nh/nkv. Pad q->32 AND kv->32/group so the padded grouping equals the
+        # real group; real q-heads then map to real kv-heads (probe_nh_lt32_padkv.py, 1.0
+        # cos-sim). For nh==32 this is a no-op (nkv_pad==nkv) — preserves the validated path.
+        # Requires group | 32 (else padded grouping can't match the real group). NOTE: padding
+        # nh<32 up to 32 wastes attention compute (32/nh x query heads) — benchmark the tax;
+        # group-does-not-divide-32 models (starcoder g=12, qwen2.5 g=7) take the custom route.
+        # CP-5: the decode SDPA accepts arbitrary GQA groups (probe_gqa_sdpa_group.py,
+        # PCC 0.9997 for group 7/12), so group | 32 is no longer required.
+        ok_shape = (nkv > 0 and nh % nkv == 0 and group > 0 and nh <= 32)
+        if not (self._ondevice_attn_eligible and hd_p == hd and ok_shape):
+            print(f"  Paged decode: NOT eligible (need eligible on-device attn + tile head_dim "
+                  f"+ nh<=32; nh={nh}, nkv={nkv}, group={group}, hd_p==hd={hd_p == hd})")
+            return
+        self._nh, self._nkv = nh, nkv          # real head counts
+        # CP-5: pad q to group*nkv_pad — that is 32 for group|32 (validated path, unchanged)
+        # and exactly nh for group∤32 (starcoder2 g=12 -> 24, qwen2.5 g=7 -> 28). The padded
+        # grouping nh_pad/nkv_pad always equals the real group, so q-heads map to real kv-heads.
+        self._nkv_pad = 32 // group             # == nkv when nh==32 (no-op)
+        self._nh_pad = group * self._nkv_pad    # 32 for group|32; nh for group∤32
+        self._block = 32
+        self._nblocks = math.ceil(_tile_align(self._max_seq) / self._block)
+        n = len(self._layers)
+
+        def zc():
+            return ttnn.zeros([self._nblocks, self._nkv_pad, self._block, hd], dtype=ttnn.bfloat16,
+                              layout=ttnn.TILE_LAYOUT, device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        self._kp = [zc() for _ in range(n)]
+        self._vp = [zc() for _ in range(n)]
+        pt = torch.arange(self._nblocks, dtype=torch.int32).reshape(1, self._nblocks)
+        self._page_table = ttnn.from_torch(pt, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT,
+                                           device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        grid = ttnn.num_cores_to_corerangeset(1, self._device.compute_with_storage_grid_size(), True)
+        self._kv_shard = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1,
+            ttnn.ShardSpec(grid, [32, hd], ttnn.ShardOrientation.ROW_MAJOR))
+        self._sdpa_pcfg = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=(8, 1), q_chunk_size=32, k_chunk_size=self._block)
+        self._cur_pos_cpu = torch.zeros(1, dtype=torch.int32)
+        self._cur_pos_dev = ttnn.from_torch(self._cur_pos_cpu, dtype=ttnn.int32,
+                                            layout=ttnn.ROW_MAJOR_LAYOUT, device=self._device,
+                                            memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        assert hasattr(self, "_rope_cos_dev"), "rope device tables missing (should be uploaded in _build_rope_table)"
+        # Pinned token-id buffer for host-free embed inside the trace (#30)
+        self._tok_cpu = torch.zeros(1, 1, dtype=torch.int32)
+        self._tok_dev = ttnn.from_torch(self._tok_cpu, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT,
+                                        device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        self._traced = os.environ.get("DISPATCH_TRACE", "0") == "1"
+        self._trace_id = None
+        self._traced_hidden = None
+        self._paged_attn = True
+        pad_note = "" if self._nh_pad == nh else f", q {nh}->32 / kv {nkv}->{self._nkv_pad} (group {group})"
+        print(f"  Paged decode: ENABLED ({self._nblocks} blocks × {self._block}, {n} layers, "
+              f"nkv={nkv}{pad_note})"
+              f"{' + TRACE' if self._traced else ''}")
+
+    def _paged_attention(self, qkv_tt, layer_idx: int, lw):
+        """Trace-safe paged attention (issue #30): device-indexed KV write + paged SDPA.
+
+        Position is read from the pinned self._cur_pos_dev (written once per token in
+        _decode_step), so this contains no Python-int args and no host round-trips —
+        it is fully trace-capturable. Validated core: probe_traced_decode.py.
+        """
+        import ttnn
+        cfg = self._cfg
+        hd = cfg.head_dim
+        hd_p = _tile_align(hd)
+        nh, nkv = cfg.num_heads, cfg.num_kv_heads
+        qp, kp = nh * hd_p, nkv * hd_p
+        qend, kend, qkvp = qp, qp + kp, qp + 2 * kp
+
+        # cos/sin for the current position, gathered on-device from the pinned pos tensor
+        pidx = ttnn.reshape(ttnn.typecast(self._cur_pos_dev, ttnn.uint32), [1, 1])
+        c4 = ttnn.unsqueeze_to_4D(ttnn.embedding(pidx, self._rope_cos_dev, layout=ttnn.TILE_LAYOUT))
+        s4 = ttnn.unsqueeze_to_4D(ttnn.embedding(pidx, self._rope_sin_dev, layout=ttnn.TILE_LAYOUT))
+
+        # split row 0 -> per-head Q/K/V, RoPE Q and K
+        row = ttnn.slice(qkv_tt, [0, 0], [1, qkvp])
+        if lw.qkv_b_tt is not None:                      # CP-1: fused QKV bias on device
+            row = ttnn.add(row, lw.qkv_b_tt)
+        q4 = ttnn.reshape(ttnn.slice(row, [0, 0],    [1, qend]), [1, 1, nh,  hd_p])
+        k4 = ttnn.reshape(ttnn.slice(row, [0, qend], [1, kend]), [1, 1, nkv, hd_p])
+        v4 = ttnn.reshape(ttnn.slice(row, [0, kend], [1, qkvp]), [1, 1, nkv, hd_p])
+        if lw.q_norm_w_tt is not None:                   # CP-4: per-head Q/K RMSNorm on device
+            q4 = self._head_rmsnorm_dev(q4, lw.q_norm_w_tt)
+        if lw.k_norm_w_tt is not None:
+            k4 = self._head_rmsnorm_dev(k4, lw.k_norm_w_tt)
+        q_rot = self._dev_rope(q4, c4, s4)
+        k_rot = self._dev_rope(k4, c4, s4)
+
+        # pad kv heads to TILE, shard, write to paged cache at the device position.
+        # The cache has self._nkv_pad heads; paged_update_cache writes its first nkv_pad heads
+        # from the 32-padded input (real kv in 0..nkv-1, pad heads nkv..nkv_pad-1 stay zero).
+        pad = [(0, 0), (0, 0), (0, TILE - nkv), (0, 0)]
+        k_sh = ttnn.interleaved_to_sharded(ttnn.pad(k_rot, pad, 0.0), self._kv_shard)
+        v_sh = ttnn.interleaved_to_sharded(ttnn.pad(v4,    pad, 0.0), self._kv_shard)
+        ttnn.experimental.paged_update_cache(self._kp[layer_idx], k_sh,
+                                             update_idxs_tensor=self._cur_pos_dev, page_table=self._page_table)
+        ttnn.experimental.paged_update_cache(self._vp[layer_idx], v_sh,
+                                             update_idxs_tensor=self._cur_pos_dev, page_table=self._page_table)
+
+        # Proportional kv-pad (#35): pad Q to 32 heads so padded grouping (32/nkv_pad) == real
+        # group; no-op when nh==32. SDPA returns [1,1,32,hd]; keep only the real heads.
+        if self._nh_pad != nh:
+            q_rot = ttnn.pad(q_rot, [(0, 0), (0, 0), (0, self._nh_pad - nh), (0, 0)], 0.0)
+
+        # SWA (gemma3): clip sliding layers to their window; global layers pass 0 (full attn).
+        swa_kw = {"sliding_window_size": lw.swa_window} if lw.swa_window else {}
+        attn = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+            q_rot, self._kp[layer_idx], self._vp[layer_idx],
+            cur_pos_tensor=self._cur_pos_dev, page_table_tensor=self._page_table,
+            scale=self._attn_scale_value(), program_config=self._sdpa_pcfg,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG, **swa_kw)   # [1,1,nh_pad,hd]
+
+        if self._nh_pad != nh:
+            attn = ttnn.slice(attn, [0, 0, 0, 0], [1, 1, nh, hd_p])   # real heads only
+
+        # flatten heads -> [1, nh*hd_p] (head-major matches O-proj weight), broadcast to TILE rows
+        attn_flat = ttnn.reshape(attn, [1, nh * hd_p])
+        attn_t = ttnn.repeat(attn_flat, ttnn.Shape([TILE, 1]))
+        return self._o_proj(attn_t, lw)
+
+    # ---- Batched prefill (Phase 2) -------------------------------------------------
+    def _dev_rope_prefill(self, x4, c4, s4):
+        """RoPE over a sequence. x4: [1,H,N,hd]; c4/s4: [1,1,N,hd] (per-position, broadcast
+        over heads). Same rotate-half convention as _dev_rope (probe PCC 0.999997)."""
+        import ttnn
+        hd = self._cfg.head_dim
+        half = hd // 2
+        H, N = x4.shape[1], x4.shape[2]
+        a = ttnn.slice(x4, [0, 0, 0, 0],    [1, H, N, half])
+        b = ttnn.slice(x4, [0, 0, 0, half], [1, H, N, hd])
+        rh = ttnn.concat([ttnn.neg(b), a], dim=-1)
+        return ttnn.add(ttnn.multiply(x4, c4), ttnn.multiply(rh, s4))
+
+    def _rope_tables_prefill(self, N: int):
+        """Gather cos/sin for positions 0..N-1 from the resident rope tables -> [1,1,N,hd]."""
+        import ttnn
+        hd = self._cfg.head_dim
+        pidx = ttnn.from_torch(torch.arange(N, dtype=torch.int32).reshape(1, N), dtype=ttnn.uint32,
+                               layout=ttnn.ROW_MAJOR_LAYOUT, device=self._device,
+                               memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        c = ttnn.embedding(pidx, self._rope_cos_dev, layout=ttnn.TILE_LAYOUT)   # [1,N,rotary_ndims]
+        s = ttnn.embedding(pidx, self._rope_sin_dev, layout=ttnn.TILE_LAYOUT)
+        return ttnn.reshape(c, [1, 1, N, hd]), ttnn.reshape(s, [1, 1, N, hd])
+
+    def _attention_prefill(self, qkv_tt, layer_idx: int, lw):
+        """Batched prefill attention over N tokens: contiguous causal SDPA + paged_fill_cache.
+        Reuses CP-1 bias, CP-4 per-head norm, the rope convention, and _o_proj. Fills the SAME
+        paged cache decode reads (paged_fill_cache offset == paged_update_cache, probe-verified)."""
+        import ttnn
+        cfg = self._cfg
+        hd, hd_p = cfg.head_dim, _tile_align(cfg.head_dim)
+        nh, nkv = cfg.num_heads, cfg.num_kv_heads
+        N = self._prefill_N
+        qend, kend, qkvp = nh * hd_p, nh * hd_p + nkv * hd_p, nh * hd_p + 2 * nkv * hd_p
+        if lw.qkv_b_tt is not None:                                    # CP-1
+            qkv_tt = self._bias_add(qkv_tt, lw.qkv_b_tt)
+
+        def to_heads(c0, c1, H):                                       # [N, H*hd_p] -> [1,H,N,hd_p]
+            t = ttnn.reshape(ttnn.slice(qkv_tt, [0, c0], [N, c1]), [1, N, H, hd_p])
+            return ttnn.permute(t, (0, 2, 1, 3))
+        q4 = to_heads(0, qend, nh)
+        k4 = to_heads(qend, kend, nkv)
+        v4 = to_heads(kend, qkvp, nkv)
+        if lw.q_norm_w_tt is not None:                                # CP-4
+            q4 = self._head_rmsnorm_dev(q4, lw.q_norm_w_tt)
+        if lw.k_norm_w_tt is not None:
+            k4 = self._head_rmsnorm_dev(k4, lw.k_norm_w_tt)
+        c4, s4 = self._rope_tables_prefill(N)
+        q_rot = self._dev_rope_prefill(q4, c4, s4)
+        k_rot = self._dev_rope_prefill(k4, c4, s4)
+
+        # write positions 0..N-1 into the paged cache (pad kv heads to nkv_pad)
+        kfill, vfill = k_rot, v4
+        if self._nkv_pad != nkv:
+            hpad = [(0, 0), (0, self._nkv_pad - nkv), (0, 0), (0, 0)]
+            kfill = ttnn.pad(k_rot, hpad, 0.0)
+            vfill = ttnn.pad(v4, hpad, 0.0)
+        ttnn.experimental.paged_fill_cache(self._kp[layer_idx], kfill, self._page_table, batch_idx=0)
+        ttnn.experimental.paged_fill_cache(self._vp[layer_idx], vfill, self._page_table, batch_idx=0)
+
+        # causal SDPA on contiguous q/k/v (real nh/nkv — no decode 32-pad)
+        swa_kw = {"sliding_window_size": lw.swa_window} if lw.swa_window else {}
+        attn = ttnn.transformer.scaled_dot_product_attention(
+            q_rot, k_rot, v4, is_causal=True, scale=self._attn_scale_value(),
+            program_config=self._sdpa_pcfg, **swa_kw)                 # [1,nh,N,hd_p]
+        attn_t = ttnn.reshape(ttnn.permute(attn, (0, 2, 1, 3)), [N, nh * hd_p])
+        return self._o_proj(attn_t, lw)
+
+    def _prefill(self, input_ids):
+        """Populate the KV cache for the whole prompt; return the first next-token id.
+        Batched on-device prefill for paged-eligible models behind DISPATCH_BATCHED_PREFILL;
+        otherwise the token-by-token loop (correct for every model)."""
+        import os
+        if (getattr(self, "_paged_attn", False)
+                and os.environ.get("DISPATCH_BATCHED_PREFILL", "0") == "1"
+                and 0 < len(input_ids) <= self._max_seq):
+            return self._prefill_batched(input_ids)
+        next_id = None
+        for pos, tok in enumerate(input_ids):
+            next_id = self._decode_step(tok, pos)
+        return next_id
+
+    def _prefill_batched(self, input_ids):
+        """Eager batched prefill: embed N tokens, run all layers on [N,hidden], fill the paged
+        cache for 0..N-1, return lm_head(position N-1). Decode then continues from cur_pos=N."""
+        import ttnn
+        N = len(input_ids)
+        hp = _tile_align(self._cfg.hidden_size)
+        self._prefilling = True
+        self._prefill_N = N
+        try:
+            ids = ttnn.from_torch(torch.tensor(input_ids, dtype=torch.int32).reshape(1, N),
+                                  dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT,
+                                  device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            emb = ttnn.embedding(ids, self._embed_tt)                 # [1, N, hidden]
+            hidden = ttnn.to_layout(ttnn.reshape(emb, [N, hp]), ttnn.TILE_LAYOUT)
+            if self._embed_scale != 1.0:
+                hidden = ttnn.multiply(hidden, self._embed_scale)
+            for i in range(len(self._layers)):
+                hidden = self._layer_forward(hidden, i, 0)            # kv_pos unused in prefill
+            last = ttnn.slice(hidden, [N - 1, 0], [N, hp])           # [1, hp] = position N-1
+        finally:
+            self._prefilling = False
+        return self._lm_head(last)
+
+    def _mlp(self, normed_tt, layer_idx: int):
+        """MLP using ttnn.matmul for large weight matrices.
+
+        Handles both SwiGLU (gate+up+down) and 2-proj (up+down, gate_w=None).
+        Gate and up projections run on device. Activation + elementwise multiply
+        also run on device — no PCIe round-trip.
+
+        Uses pre-allocated scratch buffers via output_tensor= when supported by ttnn
+        to avoid mmap/munmap cycling on intermediate tensors.
+        """
+        import ttnn
+        lw   = self._layers[layer_idx]
+        # (#3 Phase C) listed -> matrix activation (canonical silu/gelu/gelu_tanh/relu2);
+        # novel -> _cfg.activation (raw HF act string). Both are matched below.
+        act  = self._entry.activation if self._listed else self._cfg.activation
+        _pf  = getattr(self, "_prefilling", False)   # prefill: fresh alloc, no TILE scratch
+        mot  = self._matmul_ot and not _pf
+        muot = self._mul_ot and not _pf
+
+        if lw.gate_w is None:
+            # 2-proj MLP: act(up(x)+up_b) → down(·)+down_b  (GPTNeoX, BLOOM, Starcoder2, OLMo)
+            up_ot = self._up_scratch_tt if mot else None
+            up_tt = _matmul_safe(normed_tt, lw.up_w, self._device, output_tensor=up_ot)
+            if lw.up_b is not None:                 # bias before activation
+                up_biased = self._bias_add(up_tt, lw.up_b)
+                if up_ot is None:
+                    ttnn.deallocate(up_tt)
+                up_tt, up_ot = up_biased, None      # own the fresh tensor now
+            if act == "silu":
+                act_tt = ttnn.silu(up_tt)
+            elif act in _GELU_ACTS:
+                act_tt = ttnn.gelu(up_tt, fast_and_approximate_mode=(act in _GELU_TANH_ACTS))
+            else:
+                act_tt = ttnn.relu(up_tt)
+            if up_ot is None:
+                ttnn.deallocate(up_tt)
+            result = _matmul_safe(act_tt, lw.down_w, self._device)
+            ttnn.deallocate(act_tt)
+            if lw.down_b is not None:
+                res_biased = self._bias_add(result, lw.down_b)
+                ttnn.deallocate(result)
+                result = res_biased
+            return result
+
+        # SwiGLU: act(gate(x)) * up(x) → down
+        gate_ot = self._gate_scratch_tt if mot else None
+        up_ot   = self._up_scratch_tt   if mot else None
+        gate_tt = _matmul_safe(normed_tt, lw.gate_w, self._device, output_tensor=gate_ot)
+        up_tt   = _matmul_safe(normed_tt, lw.up_w,   self._device, output_tensor=up_ot)
+
+        if lw.gate_b is not None:                   # presence-driven; no-op for Llama-style
+            t = self._bias_add(gate_tt, lw.gate_b)
+            if gate_ot is None:
+                ttnn.deallocate(gate_tt)
+            gate_tt, gate_ot = t, None
+        if lw.up_b is not None:
+            t = self._bias_add(up_tt, lw.up_b)
+            if up_ot is None:
+                ttnn.deallocate(up_tt)
+            up_tt, up_ot = t, None
+
+        act_ot = self._activated_scratch_tt if muot else None
+        if act == "silu":
+            activated_tt = ttnn.multiply(ttnn.silu(gate_tt), up_tt,
+                                         **({"output_tensor": act_ot} if act_ot else {}))
+        elif act in _GELU_ACTS:
+            activated_tt = ttnn.multiply(
+                ttnn.gelu(gate_tt, fast_and_approximate_mode=(act in _GELU_TANH_ACTS)), up_tt,
+                **({"output_tensor": act_ot} if act_ot else {}))
+        else:  # relu2
+            r = ttnn.relu(gate_tt)
+            activated_tt = ttnn.multiply(ttnn.multiply(r, r), up_tt,
+                                         **({"output_tensor": act_ot} if act_ot else {}))
+            ttnn.deallocate(r)
+        if gate_ot is None:
+            ttnn.deallocate(gate_tt)
+        if up_ot is None:
+            ttnn.deallocate(up_tt)
+
+        result = _matmul_safe(activated_tt, lw.down_w, self._device)
+        if act_ot is None:
+            ttnn.deallocate(activated_tt)
+        if lw.down_b is not None:
+            res_biased = self._bias_add(result, lw.down_b)
+            ttnn.deallocate(result)
+            result = res_biased
+        return result
+
+    def _setup_ondevice_lmhead(self):
+        """Set up the on-device final-norm + lm_head + argmax path (issue #31), gated by env.
+
+        DISPATCH_ONDEVICE_LMHEAD=1 keeps the whole final stage on the card: rms_norm →
+        ttnn.matmul(normed, lm_head_w) → ttnn.argmax. Eliminates the per-token logits
+        readback (the last big device→host transfer besides the 4-byte sampled id) and,
+        when combined with DISPATCH_TRACE=1, folds into the captured decode trace so the
+        full step is host-free.
+
+        Eligibility (the nh==32 GQA/MHA validated targets — llama3, DeepSeek-Llama, Phi-3.5):
+          - RMSNorm final norm (LayerNorm final-norm bias not yet uploaded to device).
+        Non-tile-aligned vocab (e.g. granite 49155) IS supported: the uploaded weight's
+        padding columns are zero (logit 0), which could win argmax if all real logits are
+        negative, so a constant [vocab:vocab_p] = -inf mask is added before argmax. Validated
+        on card (probe_ondevice_lmhead.py): bf16 matmul + fp32-acc gives logit cos-sim ~1.0
+        vs CPU fp32; greedy picks differ only on genuine near-ties.
+        """
+        import os
+        import ttnn
+        self._ondevice_lmhead = False
+        self._lmhead_pad_mask = None
+        if os.environ.get("DISPATCH_ONDEVICE_LMHEAD", "0") != "1":
+            return
+        vocab   = int(self._lm_head_w_cpu.shape[0])          # [vocab, hidden]
+        vocab_p = int(self._lm_head_w_tt.shape[-1])          # uploaded [hidden_p, vocab_p]
+        # CP-3: _lm_head_graph now handles both RMSNorm and LayerNorm final norms on
+        # device, so lm_head_ondevice is no longer norm-gated.
+        # On-device lm_head only PAYS OFF folded into the decode trace (#31). Run
+        # standalone (model not on the traced fast path) it adds a per-token device
+        # matmul+argmax that is slower than the CPU lm_head — measured -14..-18% on
+        # gemma2/gemma3/qwen3 (fast_path=False but norm_type!=layernorm). Bundle it with
+        # the fast path: apply it only when this model is actually tracing, so each
+        # optimization reaches only the models that benefit from it.
+        if not getattr(self, "_traced", False):
+            print("  On-device lm_head: skipped (only beneficial folded into the decode "
+                  "trace; model not on fast path) -> CPU lm_head")
+            return
+        # HiFi4 + fp32 dest accumulation: maximize precision of the wide bf16 dot
+        # products over a large vocab so greedy argmax matches the CPU fp32 reference.
+        self._lmhead_ckc = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4, math_approx_mode=False,
+            fp32_dest_acc_en=True, packer_l1_acc=True)
+        # Unaligned vocab: mask the zero-weight padding columns so argmax can't pick them.
+        if vocab_p != vocab:
+            m = torch.zeros(TILE, vocab_p, dtype=torch.bfloat16)
+            m[:, vocab:] = float("-inf")
+            self._lmhead_pad_mask = ttnn.from_torch(
+                m, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
+                device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        self._ondevice_lmhead = True
+        print(f"  On-device lm_head: ENABLED (DISPATCH_ONDEVICE_LMHEAD=1; "
+              f"norm+matmul+argmax on device, vocab={vocab}"
+              + (f", {vocab_p - vocab} padding cols masked" if vocab_p != vocab else "") + ")"
+              + (" + folded into decode trace" if getattr(self, "_traced", False) else ""))
+
+    def _lm_head_graph(self, hidden_tt):
+        """On-device final norm + lm_head matmul + argmax. Returns the argmax index tensor
+        (device-resident). Trace-safe: rms_norm writes the reused _rmsnorm_buf_tt, matmul
+        and argmax allocate fixed-address buffers captured by the trace (no host roundtrip).
+        """
+        import ttnn
+        if self._uses_layernorm:                            # CP-3: LayerNorm-aware final norm
+            eps = getattr(self._hf_cfg, "layer_norm_eps",
+                          getattr(self._hf_cfg, "rms_norm_eps", 1e-5))
+            normed_tt = self._layernorm_dev(hidden_tt, self._final_norm_w_ln_tt,
+                                            self._final_norm_b_ln_tt, eps)
+        else:                                               # RMSNorm final norm (#22 fix)
+            eps = getattr(self._hf_cfg, "rms_norm_eps", 1e-5)
+            normed_tt = self._rmsnorm_dev(hidden_tt, self._final_norm_w_tt, eps)
+        logits_tt = ttnn.matmul(normed_tt, self._lm_head_w_tt,
+                                compute_kernel_config=self._lmhead_ckc)
+        if self._lmhead_pad_mask is not None:
+            logits_tt = ttnn.add(logits_tt, self._lmhead_pad_mask)
+        return ttnn.argmax(logits_tt, dim=-1)
+
+    def _lm_head_ondevice(self, hidden_tt) -> int:
+        """Eager (non-traced) on-device lm_head — reads back only the 4-byte argmax id.
+
+        DISPATCH_LMHEAD_DEBUG=1 additionally computes the CPU fp32 reference argmax from
+        the same hidden state and logs any divergence with the fp32 logit gap between the
+        two picks — a tiny gap means a benign bf16 near-tie, a large gap means a real
+        ranking bug. Diagnostic only (the readback defeats the host-free goal).
+        """
+        import os
+        import ttnn
+        out_tt = self._lm_head_graph(hidden_tt)
+        dev_idx = int(ttnn.to_torch(out_tt).flatten()[0])
+        if os.environ.get("DISPATCH_LMHEAD_DEBUG", "0") == "1":
+            hidden = self._cfg.hidden_size
+            h_cpu = ttnn.to_torch(hidden_tt)[0, :hidden].float()
+            rms = h_cpu.pow(2).mean().add(
+                getattr(self._hf_cfg, "rms_norm_eps", 1e-5)).sqrt()
+            normed = (h_cpu / rms) * self._final_norm_w_cpu
+            ref_logits = normed @ self._lm_head_w_cpu.T
+            ref_idx = int(ref_logits.argmax())
+            if dev_idx != ref_idx:
+                gap = float(ref_logits[ref_idx] - ref_logits[dev_idx])
+                rng = float(ref_logits.max() - ref_logits.min())
+                print(f"  [lmhead-debug] divergence: dev={dev_idx} cpu={ref_idx} "
+                      f"fp32_gap={gap:.5f} (logit_range={rng:.2f}, rel={gap/rng:.2e})",
+                      flush=True)
+        return dev_idx
+
+    def _lm_head(self, hidden_tt) -> int:
+        """Final norm (device) + lm_head matmul + argmax (CPU). Returns next token id.
+
+        lm_head runs on CPU in float32 for accuracy — bfloat16 argmax on device
+        can mis-rank logits for large vocabularies due to precision loss. The
+        on-device path (issue #31, DISPATCH_ONDEVICE_LMHEAD=1) uses fp32-accumulated
+        bf16 matmul + ttnn.argmax instead; see _setup_ondevice_lmhead.
+        """
+        import ttnn
+        if self._ondevice_lmhead:
+            return self._lm_head_ondevice(hidden_tt)
+        hidden = self._cfg.hidden_size
+        if self._uses_layernorm:
+            eps = getattr(self._hf_cfg, "layer_norm_eps",
+                          getattr(self._hf_cfg, "rms_norm_eps", 1e-5))
+            hidden_cpu = ttnn.to_torch(hidden_tt)[0, :hidden].float()
+            normed_cpu = _layernorm_cpu(hidden_cpu, self._final_norm_w_cpu,
+                                        self._final_norm_b_cpu, eps)
+        else:                                               # RMSNorm final norm (#22 fix)
+            eps = getattr(self._hf_cfg, "rms_norm_eps", 1e-5)
+            normed_tt  = self._rmsnorm_dev(hidden_tt, self._final_norm_w_tt, eps)
+            normed_cpu = ttnn.to_torch(normed_tt)[0, :hidden].float()   # (hidden,)
+        logits = normed_cpu @ self._lm_head_w_cpu.T                 # (vocab,)
+        # Granite divides logits by logits_scaling (#43). No effect on greedy argmax
+        # (positive divisor), applied for correctness / future temperature sampling.
+        logits_scaling = self._scaling_factor("logits_scaling", 1.0)
+        if logits_scaling != 1.0:
+            logits = logits / logits_scaling
+        if self._ladder is not None:                # logits rung for the HF ladder (#49)
+            self._ladder["logits"] = logits.detach().float().clone()
+        return int(logits.argmax())
+
+    # ------------------------------------------------------------------
+    # Weight loading
+    # ------------------------------------------------------------------
+
+    def _load_weights(self, hf_model):
+        backbone, layers_attr = _find_text_backbone(hf_model)
+        cfg = self._cfg
+        layers_list = getattr(backbone, layers_attr)
+
+        # Embedding — upload to device DRAM once; free CPU copy to save ~1-2 GB RAM.
+        # For tied embeddings (Llama), lm_head.weight is the same CPU tensor but
+        # the two device tensors need different layouts (ROW_MAJOR vs TILE+transposed),
+        # so they are uploaded separately.
+        import ttnn as _ttnn
+        embed_module = _find_embed_tokens(backbone)
+        embed_cpu = embed_module.weight.detach().bfloat16()       # [vocab, hidden]
+        hidden_p  = _tile_align(cfg.hidden_size)
+        if hidden_p != cfg.hidden_size:
+            embed_cpu = torch.nn.functional.pad(embed_cpu, (0, hidden_p - cfg.hidden_size))
+        self._embed_tt = _ttnn.from_torch(
+            embed_cpu,
+            dtype=_ttnn.bfloat16,
+            layout=_ttnn.ROW_MAJOR_LAYOUT,
+            device=self._device,
+            memory_config=_ttnn.DRAM_MEMORY_CONFIG,
+        )
+        del embed_cpu
+        # Keep a null reference so any stale access fails fast instead of silently using CPU
+        self._embed_w_cpu = None
+
+        # Embedding LayerNorm (BLOOM: word_embeddings_layernorm, applied to the embedding
+        # before layer 0). CPU LayerNorm — None for every other arch (no-op).
+        embed_ln = (getattr(backbone, "word_embeddings_layernorm", None)
+                    or getattr(backbone, "embeddings_layernorm", None))
+        self._embed_ln_w_cpu = embed_ln.weight.detach().float() if embed_ln is not None else None
+        self._embed_ln_b_cpu = (embed_ln.bias.detach().float()
+                                if embed_ln is not None and getattr(embed_ln, "bias", None) is not None
+                                else None)
+
+        # Behavioral flags (#3 Phase C). For a LISTED model these come from the matrix
+        # entry (trusted, hardware-tuned); for a novel/unlisted model they fall back to the
+        # HF/module introspection that is the universal floor. The matrix was populated to
+        # match introspection, so listed models are byte-identical to the pre-#3 behavior.
+        first_layer = layers_list[0]
+        if self._listed:
+            self._gemma_norm        = (self._entry.norm_type == "gemma_rms")
+            self._uses_layernorm    = (self._entry.norm_type == "layernorm")
+            self._parallel_residual = self._entry.parallel_residual
+            self._embed_scale       = (math.sqrt(cfg.hidden_size)
+                                       if self._entry.embed_scale == "sqrt_hidden" else 1.0)
+        else:
+            # Gemma-style (1+w) 4-norm pattern
+            self._gemma_norm = (hasattr(first_layer, "pre_feedforward_layernorm") and
+                                hasattr(first_layer, "post_feedforward_layernorm"))
+            # GPTNeoX parallel residual: attn and MLP branch the same pre-norm hidden
+            self._parallel_residual = getattr(self._hf_cfg, "use_parallel_residual", False)
+            # LayerNorm (mean-sub + bias) vs RMSNorm: GPTNeoX/Pythia carry a norm bias
+            first_norm = _find_layer_norms(first_layer)[0]
+            self._uses_layernorm = (hasattr(first_norm, "bias") and first_norm.bias is not None)
+            # Gemma family scales input embeddings by sqrt(hidden_size)
+            text_cfg   = getattr(self._hf_cfg, "text_config", self._hf_cfg)
+            model_type = getattr(text_cfg, "model_type", "")
+            self._embed_scale = math.sqrt(cfg.hidden_size) if "gemma" in model_type.lower() else 1.0
+
+        # Granite architectural scaling factors (#43). No-op (1.0) for every other arch.
+        # embedding_multiplier folds into the existing embed-scale multiply; residual_multiplier
+        # scales each sublayer output before its residual add (applied in _layer_forward); the
+        # attention scale override is read via _attn_scale_value(); logits_scaling divides the
+        # final logits (no effect on greedy argmax, applied in _lm_head for completeness).
+        # Sourced from the raw HF config (not self._cfg): a listed model rebuilds self._cfg from
+        # the matrix entry, which does not carry these fields — reading _hf_cfg keeps the fix
+        # correct whether or not Granite is ever promoted to a matrix entry.
+        self._embed_scale   *= self._scaling_factor("embedding_multiplier", 1.0)
+        self._residual_mult  = self._scaling_factor("residual_multiplier", 1.0)
+
+        # Final norm
+        final_norm = _find_final_norm(backbone)
+        _fnw = getattr(final_norm, "weight", None)
+        final_w = _fnw.detach().float() if _fnw is not None else None
+        self._final_norm_w_cpu = ((1.0 + final_w) if self._gemma_norm else final_w) if final_w is not None else None
+        self._final_norm_w_tt  = self._upload_norm_w(final_w, gemma_style=self._gemma_norm)
+        self._final_norm_sc_tt = self._make_scaler_tt(cfg.hidden_size)
+        _fnb = getattr(final_norm, "bias", None)
+        self._final_norm_b_cpu = _fnb.detach().float() if _fnb is not None else None
+        # CP-3: device row tensors for on-device LayerNorm final norm (lm_head trace path)
+        self._final_norm_w_ln_tt = self._ln_row_tt(final_w) if self._uses_layernorm else None
+        self._final_norm_b_ln_tt = self._ln_row_tt(_fnb) if self._uses_layernorm else None
+
+        # lm_head (GPTNeoX names it embed_out)
+        lm_head_mod = getattr(hf_model, "lm_head", None) or getattr(hf_model, "embed_out", None)
+        if lm_head_mod is None:
+            raise RuntimeError(f"Cannot find lm_head / embed_out on {type(hf_model).__name__}")
+        self._lm_head_w_cpu = lm_head_mod.weight.detach().float()
+        self._lm_head_w_tt  = self._upload_linear_w(self._lm_head_w_cpu)
+
+        # Per-layer weights
+        self._layers: List[_LayerWeights] = []
+        n = len(layers_list)
+        # Sliding-window attention (gemma3): model-level window + global-layer pattern.
+        _hfc = getattr(self._hf_cfg, "text_config", self._hf_cfg)
+        _swa_cfg = getattr(_hfc, "sliding_window", None)
+        _swa_pat = getattr(_hfc, "sliding_window_pattern", 6) or 6
+        for i, layer in enumerate(layers_list):
+            print(f"    layer {i+1}/{n}", end="\r")
+            attn = _find_layer_attn(layer)
+            # Per-layer SWA window for the decode SDPA (0 = full attention / global layer).
+            # Prefer the HF layer's own is_sliding flag; fall back to the gemma global pattern.
+            if _swa_cfg and os.environ.get("DISPATCH_DISABLE_SWA", "0") != "1":
+                _is_sliding = getattr(attn, "is_sliding", getattr(layer, "is_sliding", None))
+                if _is_sliding is None:
+                    _is_sliding = ((i + 1) % _swa_pat != 0)
+                swa_window = int(_swa_cfg) if _is_sliding else 0
+            else:
+                swa_window = 0   # DISPATCH_DISABLE_SWA=1 -> full attention (SWA A/B control)
+            mlp  = _find_layer_mlp(layer)
+            n1, n2, n3, n4 = _find_layer_norms(layer)
+
+            has_pre_ff  = n3 is not None
+            has_post_ff = n4 is not None
+            if has_pre_ff and has_post_ff:
+                norm_style = "gemma"
+            elif self._parallel_residual:
+                norm_style = "gpt_neox"
+            else:
+                norm_style = "llama"
+            gemma_norm  = (norm_style == "gemma")
+
+            # QKV — handle fused and separate projections.
+            # Per-head padding is required when head_dim is not a multiple of 32
+            # (e.g. BLOOM head_dim=80) so the view in _attention stays valid.
+            q_cpu, k_cpu, v_cpu = _split_qkv_weights(attn, cfg)
+            q_cpu = _pad_qkv_per_head(q_cpu, cfg.num_heads,    cfg.head_dim)
+            k_cpu = _pad_qkv_per_head(k_cpu, cfg.num_kv_heads, cfg.head_dim)
+            v_cpu = _pad_qkv_per_head(v_cpu, cfg.num_kv_heads, cfg.head_dim)
+            q_out_p = q_cpu.shape[1]   # num_heads    * hd_p (already aligned)
+            k_out_p = k_cpu.shape[1]   # num_kv_heads * hd_p
+            qkv_cat = torch.cat([
+                _pad_to_tiles(q_cpu),
+                _pad_to_tiles(k_cpu),
+                _pad_to_tiles(v_cpu),
+            ], dim=1)
+
+            # MLP — handle SwiGLU, 2-proj, fused gate+up
+            gate_raw, up_raw, down_raw = _find_mlp_weights(mlp, cfg)
+            gate_w_tt = None if gate_raw is None else self._upload_linear_w(gate_raw)
+
+            # Biases are presence-driven: loaded from the actual resolved modules
+            # (dense_h_to_4h / dense_4h_to_h for GPTNeoX/BLOOM, not the hardcoded
+            # up_proj name) and applied only when present. None for bias-free MLPs.
+            gate_mod, up_mod, down_mod = _find_mlp_modules(mlp)
+            gate_b_tt = self._upload_bias(
+                getattr(gate_mod, "bias", None) if gate_mod is not None else None,
+                cfg.intermediate_size)
+            up_b_tt = self._upload_bias(
+                getattr(up_mod, "bias", None) if up_mod is not None else None,
+                cfg.intermediate_size)
+            down_b_tt = self._upload_bias(
+                getattr(down_mod, "bias", None) if down_mod is not None else None,
+                cfg.hidden_size)
+
+            # O-projection bias (GPTNeoX/BLOOM attention.dense.bias; None for Llama-style)
+            o_mod  = _find_o_proj(attn)
+            o_b_tt = self._upload_bias(getattr(o_mod, "bias", None), cfg.hidden_size)
+
+            qkv_b_cpu = _get_qkv_bias(attn, cfg)
+            # CP-1: device twin of the qkv bias (1, total_qkv_p) for on-device/paged attn.
+            qkv_b_tt = (_to_tt(qkv_b_cpu.unsqueeze(0), self._device)
+                        if qkv_b_cpu is not None else None)
+            # CP-4: per-head Q/K norm weights (CPU + device twins for on-device attn).
+            q_norm_cpu = self._load_head_norm_w(attn, "q_norm", gemma_norm)
+            k_norm_cpu = self._load_head_norm_w(attn, "k_norm", gemma_norm)
+
+            lw = _LayerWeights(
+                norm1_w  = self._upload_norm_w(getattr(n1, "weight", None), gemma_norm),
+                norm1_sc = self._make_scaler_tt(cfg.hidden_size),
+                norm2_w  = self._upload_norm_w(getattr(n2, "weight", None), gemma_norm),
+                norm2_sc = self._make_scaler_tt(cfg.hidden_size),
+                qkv_w = _to_tt(qkv_cat, self._device, dtype=self._weight_dtype()),
+                qkv_b = qkv_b_cpu,
+                qkv_b_tt = qkv_b_tt,
+                q_end = q_out_p,
+                k_end = q_out_p + k_out_p,
+                o_w   = self._upload_linear_w(
+                            _pad_o_proj_per_head(
+                                _find_o_proj_weight(attn).detach().bfloat16(),
+                                cfg.num_heads, cfg.head_dim)),
+                gate_w = gate_w_tt,
+                up_w   = self._upload_linear_w(up_raw),
+                down_w = self._upload_linear_w(down_raw),
+                gate_b = gate_b_tt,
+                up_b   = up_b_tt,
+                down_b = down_b_tt,
+                o_b    = o_b_tt,
+                norm3_w  = self._upload_norm_w(getattr(n3, "weight", None), gemma_norm) if has_pre_ff else None,
+                norm3_sc = self._make_scaler_tt(cfg.hidden_size) if has_pre_ff else None,
+                norm4_w  = self._upload_norm_w(getattr(n4, "weight", None), gemma_norm) if has_post_ff else None,
+                norm4_sc = self._make_scaler_tt(cfg.hidden_size) if has_post_ff else None,
+                norm_style = norm_style,
+                q_norm_w = q_norm_cpu,
+                k_norm_w = k_norm_cpu,
+                q_norm_w_tt = self._ln_row_tt(q_norm_cpu),   # CP-4: per-head norm on device
+                k_norm_w_tt = self._ln_row_tt(k_norm_cpu),
+                swa_window = swa_window,                      # SWA: per-layer sliding window
+
+                norm1_w_cpu = n1.weight.detach().float() if self._uses_layernorm else None,
+                norm1_b     = n1.bias.detach().float()   if (self._uses_layernorm and getattr(n1, "bias", None) is not None) else None,
+                norm2_w_cpu = n2.weight.detach().float() if self._uses_layernorm else None,
+                norm2_b     = n2.bias.detach().float()   if (self._uses_layernorm and getattr(n2, "bias", None) is not None) else None,
+                # CP-3: device row tensors for on-device ttnn.layer_norm
+                norm1_w_ln_tt = self._ln_row_tt(getattr(n1, "weight", None)) if self._uses_layernorm else None,
+                norm1_b_ln_tt = self._ln_row_tt(getattr(n1, "bias", None))   if self._uses_layernorm else None,
+                norm2_w_ln_tt = self._ln_row_tt(getattr(n2, "weight", None)) if self._uses_layernorm else None,
+                norm2_b_ln_tt = self._ln_row_tt(getattr(n2, "bias", None))   if self._uses_layernorm else None,
+            )
+            self._layers.append(lw)
+        print()
+        if _swa_cfg:
+            _nsl = sum(1 for lw in self._layers if lw.swa_window)
+            print(f"  Sliding-window attention: {_nsl}/{n} sliding layers "
+                  f"(window={_swa_cfg}), {n - _nsl} global (full attn)")
+
+    def _load_head_norm_w(self, attn, attr: str, gemma_style: bool):
+        """Load per-head Q/K norm weight as a CPU float tensor, or None."""
+        norm = getattr(attn, attr, None)
+        if norm is None or not hasattr(norm, "weight"):
+            return None
+        w = norm.weight.detach().float()
+        return (1.0 + w) if gemma_style else w
+
+    def _upload_norm_w(self, w, gemma_style: bool = False):
+        """Upload norm weight (hidden,) as (TILE, hidden_p) on device.
+
+        w may be None for norms without learned parameters (e.g. OLMo
+        uses elementwise_affine=False). In that case we upload ones so the
+        kernel multiplies by 1 (no effect on the normalized output).
+
+        Gemma-style norms use (1 + weight) instead of weight — bake the +1
+        at load time so the kernel path stays the same.
+        """
+        if w is None:
+            w_f = torch.ones(self._cfg.hidden_size, dtype=torch.float32)
+        else:
+            w_f = w.detach().float()
+        if gemma_style:
+            w_f = 1.0 + w_f
+        w_1d = _pad_to_tiles(w_f.bfloat16())
+        w_2d = w_1d.unsqueeze(0).expand(TILE, -1).contiguous()
+        return _to_tt(w_2d, self._device)
+
+    def _weight_dtype(self):
+        """ttnn dtype for large linear weights: bfloat8_b when the bf8 spike is on, else bf16."""
+        import ttnn
+        return ttnn.bfloat8_b if self._bf8_weights else ttnn.bfloat16
+
+    def _upload_linear_w(self, w: torch.Tensor):
+        """Upload weight (out, in) transposed to (in_p, out_p) on device."""
+        return _to_tt(w.detach().bfloat16().T.contiguous(), self._device,
+                      dtype=self._weight_dtype())
+
+    def _upload_bias(self, b: Optional[torch.Tensor], out_dim: int):
+        """Upload bias as (TILE, out_p), or None when the module has no bias.
+
+        Returning None (not a zero tensor) lets the forward pass skip the add
+        entirely for bias-free models (Llama/Qwen/StableLM/OLMo/Phi-3) — keeping
+        the generic bias support a true no-op for them.
+        """
+        if b is None:
+            return None
+        b_1d = _pad_to_tiles(b.detach().bfloat16())
+        b_2d = b_1d.unsqueeze(0).expand(TILE, -1).contiguous()
+        return _to_tt(b_2d, self._device)
+
+    def _o_proj(self, inp, lw):
+        """O-projection matmul + optional bias (GPTNeoX/BLOOM attention.dense.bias).
+
+        Bias is presence-driven (lw.o_b is None for Llama-style attn) so this is a
+        no-op for bias-free models on every attention path (CPU-readback/ondevice/paged).
+        """
+        import ttnn
+        out = _matmul_safe(inp, lw.o_w, self._device)
+        if lw.o_b is not None:
+            biased = self._bias_add(out, lw.o_b)
+            ttnn.deallocate(out)
+            out = biased
+        return out
+
+    @staticmethod
+    def _build_alibi_slopes(n_heads: int) -> torch.Tensor:
+        """ALiBi per-head slopes (HF BLOOM scheme). slope_h = 2^(-8h/n) for h=1..n
+        when n is a power of two; otherwise the nearest-lower-power-of-two set plus
+        the interleaved extra slopes. Returns a (n_heads,) float tensor."""
+        def pow2_slopes(n):
+            start = 2.0 ** (-8.0 / n)
+            return [start ** (i + 1) for i in range(n)]
+
+        if math.log2(n_heads).is_integer():
+            slopes = pow2_slopes(n_heads)
+        else:
+            closest = 2 ** int(math.floor(math.log2(n_heads)))
+            slopes = pow2_slopes(closest)
+            extra = pow2_slopes(2 * closest)[0::2][: n_heads - closest]
+            slopes = slopes + extra
+        return torch.tensor(slopes, dtype=torch.float32)
+
+    def _attention_cpu_alibi(self, q_cpu, layer_idx: int, kv_pos: int, lw):
+        """CPU softmax attention with ALiBi positional bias (BLOOM).
+
+        BLOOM has no RoPE and uses per-head ALiBi slopes that the shared-mask
+        flash_attn kernel can't express; it's already off the device fast path
+        (head_dim=80, LayerNorm), so attention runs on CPU from the K/V history
+        mirrors. Softmax is shift-invariant per query row, so the absolute-key-pos
+        bias (slope_h * key_pos) is equivalent to the relative ALiBi form.
+        Projections (qkv/o-proj) stay on device.
+        """
+        cfg = self._cfg
+        hd  = cfg.head_dim
+        nh  = cfg.num_heads
+        nkv = cfg.num_kv_heads
+        L   = kv_pos + 1
+
+        K = self._k_hist_cpu[layer_idx][:, :L, :].float()   # (nkv, L, hd)
+        V = self._v_hist_cpu[layer_idx][:, :L, :].float()
+        if nh != nkv:                                       # GQA expand (BLOOM is MHA)
+            rep = nh // nkv
+            K = K.repeat_interleave(rep, dim=0)
+            V = V.repeat_interleave(rep, dim=0)
+        q = q_cpu.float()                                   # (nh, hd)
+
+        scale  = 1.0 / math.sqrt(hd)
+        scores = torch.einsum("hd,hld->hl", q, K) * scale   # (nh, L)
+        key_pos = torch.arange(L, dtype=torch.float32)
+        beta = getattr(self, "_alibi_beta", 1.0)
+        scores = scores + beta * self._alibi_slopes.view(nh, 1) * key_pos.view(1, L)
+        attn = torch.softmax(scores, dim=-1)                # (nh, L)
+        out  = torch.einsum("hl,hld->hd", attn, V)          # (nh, hd)
+
+        # Pack into the _fa_out_tt layout [TILE, nh*hd_p]: row 0 = per-head outputs,
+        # each head padded hd -> hd_p, matching the o-proj weight layout.
+        hd_p  = _tile_align(hd)
+        out_p = torch.zeros(nh, hd_p, dtype=torch.float32)
+        out_p[:, :hd] = out
+        fa = torch.zeros(TILE, nh * hd_p, dtype=torch.bfloat16)
+        fa[0] = out_p.reshape(nh * hd_p).bfloat16()
+        return self._o_proj(_to_tt(fa, self._device), lw)
+
+    def _make_scaler_tt(self, dim: int):
+        """Return (TILE, TILE) tile filled with 1/dim on device."""
+        sc = torch.full((TILE, TILE), 1.0 / dim, dtype=torch.bfloat16)
+        return _to_tt(sc, self._device)
+
+    # ------------------------------------------------------------------
+    # Attention scalars
+    # ------------------------------------------------------------------
+
+    def _scaling_factor(self, name: str, default: float):
+        """Read a Granite-style architectural scaling factor (#43). Two-tier, matching the
+        matrix's other behavioral fields: a listed entry that sets the field OVERRIDES; an
+        unset entry (or novel model) falls through to the raw HF config (text_config-aware).
+        Sourced from _hf_cfg, not _cfg, since _cfg is rebuilt from the matrix entry for a
+        listed model and does not carry these fields."""
+        if self._listed:
+            v = getattr(self._entry, name, None)
+            if v is not None:
+                return v
+        tc = getattr(self._hf_cfg, "text_config", self._hf_cfg)
+        return getattr(tc, name, default)
+
+    def _attn_scale_value(self) -> float:
+        """Attention softmax scale. Granite (#43) overrides the standard 1/sqrt(head_dim)
+        with its config attention_multiplier; every other arch returns 1/sqrt(head_dim)."""
+        am = self._scaling_factor("attention_multiplier", None)
+        return am if am is not None else (1.0 / math.sqrt(self._cfg.head_dim))
+
+    def _build_attn_scalars(self):
+        cfg = self._cfg
+        scale = self._attn_scale_value()
+        self._attn_scale_tt = _to_tt(
+            torch.full((TILE, TILE), scale, dtype=torch.bfloat16), self._device)
+        self._neg_inf_tt = _to_tt(
+            torch.full((TILE, TILE), float("-inf"), dtype=torch.bfloat16), self._device)
+        self._zero_tt = _to_tt(
+            torch.zeros(TILE, TILE, dtype=torch.bfloat16), self._device)
+        self._zero_head_tt = _to_tt(
+            torch.zeros(TILE, _tile_align(cfg.head_dim), dtype=torch.bfloat16), self._device)
+        self._ones_tt = _to_tt(
+            torch.ones(TILE, TILE, dtype=torch.bfloat16), self._device)
+
+    # ------------------------------------------------------------------
+    # KV cache
+    # ------------------------------------------------------------------
+
+    def _init_kv_cache(self):
+        import ttnn
+        cfg  = self._cfg
+        n    = len(self._layers)
+        nkv  = cfg.num_kv_heads
+        hd_p = _tile_align(cfg.head_dim)
+        ms_p = _tile_align(self._max_seq)
+
+        # 4D device KV cache: [1, n_kv_heads, max_seq_p, head_dim_p]
+        # Matches update_cache_for_token_ validation: input[1] == cache[1] == nkv
+        self._k_dev = [
+            ttnn.zeros([1, nkv, ms_p, hd_p], dtype=ttnn.bfloat16,
+                       layout=ttnn.TILE_LAYOUT, device=self._device,
+                       memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            for _ in range(n)
+        ]
+        self._v_dev = [
+            ttnn.zeros([1, nkv, ms_p, hd_p], dtype=ttnn.bfloat16,
+                       layout=ttnn.TILE_LAYOUT, device=self._device,
+                       memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            for _ in range(n)
+        ]
+        print(f"  KV cache: on-device DRAM [1×{nkv}×{ms_p}×{hd_p}] × {n*2} buffers")
+
+        # CPU-side KV history mirrors the device cache.
+        # CPU attention reads from these directly, eliminating the device→CPU
+        # slice+to_torch that caused 2×n_layers mmap/munmap calls per token.
+        # Shape: (n_kv_heads, max_seq, head_dim) — matches the attention loop's
+        # access pattern (K_hist[kv_head_idx]) so slices are contiguous.
+        self._k_hist_cpu = [
+            torch.zeros(nkv, self._max_seq, cfg.head_dim, dtype=torch.float32)
+            for _ in range(n)
+        ]
+        self._v_hist_cpu = [
+            torch.zeros(nkv, self._max_seq, cfg.head_dim, dtype=torch.float32)
+            for _ in range(n)
+        ]
+
+    def _init_scratch_bufs(self):
+        """Pre-allocate all fixed-shape device scratch tensors used in the hot path.
+
+        Reusing these across tokens eliminates the mmap/munmap cycle that was
+        measured at ~300-500 syscalls/token. All shapes are deterministic from
+        the model config, so one set of buffers covers every layer and every token.
+
+        Also probes whether ttnn.matmul / ttnn.add accept output_tensor= so the
+        hot-path matmuls can write directly into pre-allocated device buffers.
+        """
+        import ttnn
+        cfg  = self._cfg
+        hid_p    = _tile_align(cfg.hidden_size)
+        hd_p     = _tile_align(cfg.head_dim)
+        q_out_p  = cfg.num_heads    * hd_p   # use tile-padded hd_p, not raw head_dim
+        kv_out_p = cfg.num_kv_heads * hd_p
+        qkv_p    = q_out_p + 2 * kv_out_p
+        int_p    = _tile_align(cfg.intermediate_size)
+        nkv      = cfg.num_kv_heads
+
+        def z(*shape):
+            return ttnn.zeros(list(shape), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
+                              device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        ms_p = _tile_align(self._max_seq)
+        scale_val = self._attn_scale_value()
+
+        # Existing rmsnorm output scratch
+        self._rmsnorm_buf_tt        = z(TILE, hid_p)
+        # QKV projection output
+        self._qkv_scratch_tt        = z(TILE, qkv_p)
+        # MLP gate, up, and activated intermediate (gate×up result)
+        self._gate_scratch_tt       = z(TILE, int_p)
+        self._up_scratch_tt         = z(TILE, int_p)
+        self._activated_scratch_tt  = z(TILE, int_p)
+        # Residual add output (hidden state accumulator across layers)
+        self._hidden_scratch_tt     = z(TILE, hid_p)
+
+        # Flash-attn constant tiles (allocated once, reused every layer/token)
+        self._fa_scale_tt     = ttnn.from_torch(
+            torch.full((TILE, TILE), scale_val, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
+            device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        self._fa_ninf_tt      = ttnn.from_torch(
+            torch.full((TILE, TILE), float("-inf"), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
+            device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        self._fa_zero_tt      = z(TILE, TILE)
+        self._fa_zero_head_tt = z(TILE, hd_p)
+        self._fa_ones_tt      = ttnn.from_torch(
+            torch.ones(TILE, TILE, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
+            device=self._device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        # Flash-attn output scratch: [TILE, N_heads * head_dim_p] — row-major, O-proj ready
+        self._fa_out_tt       = z(TILE, cfg.num_heads * hd_p)
+
+        # Pre-allocated CPU tensors reused each token (avoids torch.zeros() in hot loop)
+        # Single-token embedding ID staging buffer — filled in _embed() each step
+        self._token_id_cpu = torch.zeros(1, 1, dtype=torch.int64)
+        # Position index staging for on-device RoPE cos/sin gather (issue #8)
+        self._pos_idx_cpu = torch.zeros(1, 1, dtype=torch.int32)
+        self._k_in_cpu  = torch.zeros(1, nkv, TILE, hd_p, dtype=torch.bfloat16)
+        self._v_in_cpu  = torch.zeros(1, nkv, TILE, hd_p, dtype=torch.bfloat16)
+        # Q for flash-attn: [N_heads*TILE, head_dim_p] (one TILE-block per head)
+        self._q_cpu     = torch.zeros(cfg.num_heads * TILE, hd_p, dtype=torch.bfloat16)
+        # Causal mask: [TILE, max_seq_p] — rebuilt cheaply each token
+        self._mask_cpu  = torch.full((TILE, ms_p), float("-inf"), dtype=torch.bfloat16)
+
+        # Probe whether ttnn ops accept output_tensor= / optional_output_tensor=.
+        # inspect.signature doesn't see through nanobind wrappers, so use docstrings.
+        # ttnn >= 0.71 uses optional_output_tensor for matmul; add/multiply use output_tensor.
+        try:
+            doc = ttnn.matmul.__doc__ or ""
+            self._matmul_ot = "optional_output_tensor" in doc or "output_tensor" in doc
+        except Exception:
+            self._matmul_ot = False
+        try:
+            self._add_ot = "output_tensor" in (ttnn.add.__doc__ or "")
+        except Exception:
+            self._add_ot = False
+        try:
+            self._mul_ot = "output_tensor" in (ttnn.multiply.__doc__ or "")
+        except Exception:
+            self._mul_ot = False
+        print(f"  Scratch bufs: matmul_ot={self._matmul_ot} add_ot={self._add_ot} mul_ot={self._mul_ot}")
+
+    # ------------------------------------------------------------------
+    # RoPE
+    # ------------------------------------------------------------------
+
+    def _build_rope_table(self):
+        cfg     = self._hf_cfg
+        dim     = self._cfg.head_dim
+        theta   = getattr(cfg, "rope_theta", 10000.0)
+        max_pos = self._max_seq
+
+        # Partial RoPE (GPTNeoX/Pythia): only rotary_pct of head dims are rotated.
+        # rotary_ndims = round(head_dim * rotary_pct) — must be even.
+        # (#3 Phase C) listed -> matrix rotary_pct; novel -> HF-config introspection.
+        if self._listed:
+            rotary_pct = self._entry.rotary_pct
+        else:
+            rotary_pct = getattr(cfg, "partial_rotary_factor",
+                                 getattr(cfg, "rotary_pct", 1.0))
+        rotary_ndims  = round(dim * rotary_pct)
+        if rotary_ndims % 2 != 0:
+            rotary_ndims -= 1
+        self._rotary_ndims = rotary_ndims   # used in _apply_rope
+
+        # ALiBi models (BLOOM, Falcon) have NO RoPE — they add a per-head linear
+        # positional bias to the attention scores instead. Detect and disable rope; the
+        # per-head slopes can't fold into the shared-mask flash_attn kernel, so these run
+        # a CPU softmax+ALiBi attention path (see _attention_cpu_alibi).
+        text_cfg   = getattr(cfg, "text_config", cfg)
+        model_type = getattr(text_cfg, "model_type", "")
+        archs      = getattr(cfg, "architectures", None) or []
+        self._uses_alibi = (model_type == "bloom"
+                            or any("Bloom" in a for a in archs)
+                            or bool(getattr(cfg, "alibi", False)))
+        self._no_rope = self._uses_alibi
+        if self._uses_alibi:
+            self._rotary_ndims = 0
+            self._alibi_slopes = self._build_alibi_slopes(self._cfg.num_heads)
+            # ALiBi bias weight (HF attention `beta`) relative to the score scale.
+            # BLOOM adds the bias unscaled (beta=1.0); Falcon scales it by the same
+            # 1/sqrt(head_dim) as the QK scores (beta=inv_norm_factor). Getting this
+            # wrong leaves a recency bias that's ~8x too strong and degenerates output.
+            is_falcon = (model_type == "falcon" or any("Falcon" in a for a in archs))
+            self._alibi_beta = (1.0 / math.sqrt(self._cfg.head_dim)) if is_falcon else 1.0
+
+        # Linear RoPE scaling: compress positions by dividing by scale factor.
+        # Do NOT change theta -- scale the position indices instead.
+        scale_factor = 1.0
+        rope_cfg = getattr(cfg, "rope_scaling", None)
+        if rope_cfg:
+            if rope_cfg.get("rope_type") == "linear":
+                scale_factor = rope_cfg.get("factor", 1.0)
+
+        positions = torch.arange(max_pos, dtype=torch.float32) / scale_factor
+        freqs     = 1.0 / (theta ** (torch.arange(0, rotary_ndims, 2).float() / rotary_ndims))
+        angles    = torch.outer(positions, freqs)      # (max_pos, rotary_ndims/2)
+        cos_half  = torch.cos(angles)                  # (max_pos, rotary_ndims/2)
+        sin_half  = torch.sin(angles)
+
+        # HuggingFace convention: expand to rotary_ndims by tiling [half, half].
+        # Rotation uses grouped halves (i, i+rotary_ndims//2) not interleaved pairs.
+        self._rope_cos = torch.cat([cos_half, cos_half], dim=-1)  # (max_pos, rotary_ndims)
+        self._rope_sin = torch.cat([sin_half, sin_half], dim=-1)
+
+        # On-device RoPE (issue #8): decide applicability and upload cos/sin tables.
+        # Approach A — elementwise RoPE on DRAM tensors feeding the existing flash_attn,
+        # eliminating the per-token QKV->CPU readback. Gated to the families it cleanly
+        # covers; everything else keeps the CPU path unchanged.
+        import ttnn as _ttnn
+        hd   = self._cfg.head_dim
+        hd_p = _tile_align(hd)
+        no_bias     = all(lw.qkv_b is None for lw in self._layers)
+        no_headnorm = all(lw.q_norm_w is None and lw.k_norm_w is None for lw in self._layers)
+        full_rope   = (self._rotary_ndims == hd)
+        # CP-1: qkv bias now applied on-device. CP-3: LayerNorm now runs on-device
+        # (ttnn.layer_norm). CP-4: per-head Q/K norm runs on-device (ttnn.rms_norm).
+        # So neither bias, LayerNorm, nor head_norm blocks eligibility — but ALiBi still
+        # does (per-head bias can't fold into the shared-mask SDPA decode; CP-6 deferred).
+        introspect_eligible = bool(full_rope and hd_p == hd and not self._uses_alibi)
+        # (#3 Phase C) listed -> derived fast_path capability (which also folds in the
+        # group|32 / nh<=32 SDPA-pad constraint from _setup_paged_decode); novel -> the
+        # introspection floor. They agree for every listed fast-path model.
+        eligible    = self._caps.fast_path if self._listed else introspect_eligible
+        self._ondevice_attn_eligible = eligible
+        # Opt-in (default OFF): the eager on-device path is CORRECT but slower than the
+        # CPU-RoPE path because it trades one PCIe readback for ~25 host-dispatched device
+        # ops/layer. The perf win lands once the decode step is trace-captured (#30), which
+        # removes per-op host dispatch. Until then, keep it opt-in so baseline tok/s holds.
+        import os
+        self._ondevice_attn = eligible and os.environ.get("DISPATCH_ONDEVICE_ATTN", "0") == "1"
+        # The paged trace-safe path (#30) also needs the on-device rope tables.
+        _paged_want = os.environ.get("DISPATCH_PAGED_ATTN", "0") == "1" or os.environ.get("DISPATCH_TRACE", "0") == "1"
+        if eligible and (self._ondevice_attn or _paged_want):
+            self._rope_cos_dev = _ttnn.from_torch(
+                self._rope_cos.bfloat16(), dtype=_ttnn.bfloat16, layout=_ttnn.ROW_MAJOR_LAYOUT,
+                device=self._device, memory_config=_ttnn.DRAM_MEMORY_CONFIG)
+            self._rope_sin_dev = _ttnn.from_torch(
+                self._rope_sin.bfloat16(), dtype=_ttnn.bfloat16, layout=_ttnn.ROW_MAJOR_LAYOUT,
+                device=self._device, memory_config=_ttnn.DRAM_MEMORY_CONFIG)
+        if self._ondevice_attn:
+            print("  On-device RoPE/attention: ENABLED (DISPATCH_ONDEVICE_ATTN=1)")
+        elif eligible:
+            print("  On-device RoPE/attention: eligible but OFF "
+                  "(set DISPATCH_ONDEVICE_ATTN=1 to enable; faster once trace-captured, see #30)")
+        elif self._listed and introspect_eligible:
+            # Introspection alone would have marked this eligible, but the matrix entry
+            # overrides it (e.g. gemma_rms norm / group∤32) -> stay on the CPU RoPE path.
+            print(f"  On-device RoPE/attention: not eligible "
+                  f"(matrix override: norm_type={self._entry.norm_type}, "
+                  f"backend={self._caps.attn_backend}) -> CPU RoPE path")
+        else:
+            print(f"  On-device RoPE/attention: not eligible "
+                  f"(full_rope={full_rope} hd_p==hd={hd_p == hd} no_bias={no_bias} "
+                  f"no_headnorm={no_headnorm} rmsnorm={not self._uses_layernorm}) -> CPU RoPE path")
+
+    def _apply_head_norm(self, x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+        """Apply per-head RMSNorm. x: (n_heads, head_dim), w: (head_dim,) already (1+w) or w."""
+        rms = x.pow(2).mean(-1, keepdim=True).add(1e-6).sqrt()
+        return (x / rms) * w
+
+    def _apply_rope(self, x: torch.Tensor, position: int) -> torch.Tensor:
+        """Apply RoPE to x (n_heads, head_dim) using HuggingFace convention.
+
+        Supports partial RoPE (GPTNeoX/Pythia): only the first rotary_ndims dimensions
+        are rotated; the remaining pass-through dimensions are left unchanged.
+        """
+        if position >= self._rope_cos.shape[0]:
+            return x
+        cos = self._rope_cos[position]   # (rotary_ndims,)
+        sin = self._rope_sin[position]
+        nd  = self._rotary_ndims
+        x_rot_in = x[..., :nd]
+        # Rotate: x_rot = [-x_rot_in[nd//2:], x_rot_in[:nd//2]]
+        x_rot = torch.cat([-x_rot_in[..., nd // 2:], x_rot_in[..., :nd // 2]], dim=-1)
+        rotated = x_rot_in * cos + x_rot * sin
+        if nd == x.shape[-1]:
+            return rotated
+        # Concat rotated prefix with unrotated suffix
+        return torch.cat([rotated, x[..., nd:]], dim=-1)
+
+
+# ------------------------------------------------------------------
+# CLI
+# ------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="TTModelRunner inference")
+    parser.add_argument("--model",      required=True, help="Local model path or HF repo")
+    parser.add_argument("--prompt",     default="The capital of France is",
+                        help="Prompt string")
+    parser.add_argument("--max-tokens", type=int, default=50)
+    parser.add_argument("--max-seq",    type=int, default=2048,
+                        help="Max KV cache sequence length")
+    parser.add_argument("--no-chat",    action="store_true",
+                        help="Skip chat template (raw completion mode)")
+    parser.add_argument("--unsafe",     action="store_true",
+                        help="Allow community/unlisted (unverified) models without warning (#25)")
+    args = parser.parse_args()
+
+    import ttnn
+    import os
+    # Reserve a trace region when the trace-replay decode path (#30) is enabled.
+    _tr = 134217728 if os.environ.get("DISPATCH_TRACE", "0") == "1" else 0
+    device = ttnn.open_device(device_id=0, trace_region_size=_tr)
+    try:
+        runner = TTModelRunner(args.model, device, max_seq=args.max_seq, unsafe=args.unsafe)
+        print(f"\nPROMPT: {args.prompt}")
+        output = runner.generate(args.prompt, max_new_tokens=args.max_tokens,
+                                 chat=not args.no_chat)
+        print(f"OUTPUT: {output}")
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/tt_inference_server/dispatch/serve.py
+++ b/tt_inference_server/dispatch/serve.py
@@ -40,8 +40,8 @@ import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 # Module-global serving state (set in main()).
-_HANDLE = None            # ModelHandle
-_MODEL_ID = None          # str shown in the API
+_HANDLE = None  # ModelHandle
+_MODEL_ID = None  # str shown in the API
 _INFER_LOCK = threading.Lock()
 
 
@@ -49,15 +49,21 @@ _INFER_LOCK = threading.Lock()
 # Prompt rendering
 # ----------------------------------------------------------------------------
 
+
 def _render_chat(messages) -> str:
     """Render OpenAI chat messages to a single prompt string via the tokenizer's chat
     template (preserving multi-turn structure). Falls back to a simple role-tagged join
     when the tokenizer has no chat template."""
     tok = _HANDLE.tokenizer
-    msgs = [{"role": m.get("role", "user"), "content": m.get("content", "")} for m in messages]
+    msgs = [
+        {"role": m.get("role", "user"), "content": m.get("content", "")}
+        for m in messages
+    ]
     if hasattr(tok, "apply_chat_template") and getattr(tok, "chat_template", None):
         try:
-            return tok.apply_chat_template(msgs, tokenize=False, add_generation_prompt=True)
+            return tok.apply_chat_template(
+                msgs, tokenize=False, add_generation_prompt=True
+            )
         except Exception:
             pass
     parts = [f"{m['role']}: {m['content']}" for m in msgs]
@@ -69,13 +75,15 @@ def _render_chat(messages) -> str:
 # Inference (serialized) — returns (text, usage_dict) or yields stream deltas
 # ----------------------------------------------------------------------------
 
+
 def _run(prompt: str, max_tokens: int, temperature: float):
     """Run a full (non-streaming) generation. Returns (text, finish_reason, usage)."""
     with _INFER_LOCK:
         text_parts = []
         meta = {"finish_reason": "length", "prompt_tokens": 0, "completion_tokens": 0}
-        for piece in _HANDLE.generate_stream(prompt, max_new_tokens=max_tokens,
-                                              temperature=temperature, chat=False):
+        for piece in _HANDLE.generate_stream(
+            prompt, max_new_tokens=max_tokens, temperature=temperature, chat=False
+        ):
             if isinstance(piece, dict):
                 meta = piece
             else:
@@ -91,8 +99,9 @@ def _run(prompt: str, max_tokens: int, temperature: float):
 def _run_stream(prompt: str, max_tokens: int, temperature: float):
     """Yield (delta_text_or_None, meta_or_None). Holds the infer lock for the whole stream."""
     with _INFER_LOCK:
-        for piece in _HANDLE.generate_stream(prompt, max_new_tokens=max_tokens,
-                                             temperature=temperature, chat=False):
+        for piece in _HANDLE.generate_stream(
+            prompt, max_new_tokens=max_tokens, temperature=temperature, chat=False
+        ):
             if isinstance(piece, dict):
                 yield None, piece
             else:
@@ -102,6 +111,7 @@ def _run_stream(prompt: str, max_tokens: int, temperature: float):
 # ----------------------------------------------------------------------------
 # HTTP handler
 # ----------------------------------------------------------------------------
+
 
 class _Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
@@ -132,14 +142,24 @@ class _Handler(BaseHTTPRequestHandler):
         if self.path == "/health":
             return self._send_json(200, {"status": "ok", "model": _MODEL_ID})
         if self.path == "/v1/models":
-            return self._send_json(200, {
-                "object": "list",
-                "data": [{
-                    "id": _MODEL_ID, "object": "model", "created": int(time.time()),
-                    "owned_by": "dispatch",
-                    "dispatch": {"listed": _HANDLE.listed, "community": _HANDLE.community},
-                }],
-            })
+            return self._send_json(
+                200,
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": _MODEL_ID,
+                            "object": "model",
+                            "created": int(time.time()),
+                            "owned_by": "dispatch",
+                            "dispatch": {
+                                "listed": _HANDLE.listed,
+                                "community": _HANDLE.community,
+                            },
+                        }
+                    ],
+                },
+            )
         return self._error(404, f"unknown path {self.path}", "not_found")
 
     def do_POST(self):
@@ -171,7 +191,9 @@ class _Handler(BaseHTTPRequestHandler):
                 if isinstance(prompt, list):
                     prompt = prompt[0]
         except Exception as exc:
-            return self._error(422, f"prompt construction failed: {exc}", "unsafe_model_failure")
+            return self._error(
+                422, f"prompt construction failed: {exc}", "unsafe_model_failure"
+            )
 
         if stream:
             return self._stream_completion(prompt, max_tokens, temperature, chat)
@@ -190,16 +212,26 @@ class _Handler(BaseHTTPRequestHandler):
         cid = ("chatcmpl-" if chat else "cmpl-") + uuid.uuid4().hex[:24]
         created = int(time.time())
         if chat:
-            choice = {"index": 0, "message": {"role": "assistant", "content": text},
-                      "finish_reason": finish_reason}
+            choice = {
+                "index": 0,
+                "message": {"role": "assistant", "content": text},
+                "finish_reason": finish_reason,
+            }
             obj = "chat.completion"
         else:
             choice = {"index": 0, "text": text, "finish_reason": finish_reason}
             obj = "text_completion"
-        self._send_json(200, {
-            "id": cid, "object": obj, "created": created, "model": _MODEL_ID,
-            "choices": [choice], "usage": usage,
-        })
+        self._send_json(
+            200,
+            {
+                "id": cid,
+                "object": obj,
+                "created": created,
+                "model": _MODEL_ID,
+                "choices": [choice],
+                "usage": usage,
+            },
+        )
 
     def _stream_completion(self, prompt, max_tokens, temperature, chat):
         cid = ("chatcmpl-" if chat else "cmpl-") + uuid.uuid4().hex[:24]
@@ -216,15 +248,28 @@ class _Handler(BaseHTTPRequestHandler):
             self.wfile.flush()
 
         def chunk(delta, finish=None):
-            ch = ({"index": 0, "delta": ({"content": delta} if delta is not None else {}),
-                   "finish_reason": finish} if chat
-                  else {"index": 0, "text": delta or "", "finish_reason": finish})
-            return {"id": cid, "object": obj, "created": created, "model": _MODEL_ID,
-                    "choices": [ch]}
+            ch = (
+                {
+                    "index": 0,
+                    "delta": ({"content": delta} if delta is not None else {}),
+                    "finish_reason": finish,
+                }
+                if chat
+                else {"index": 0, "text": delta or "", "finish_reason": finish}
+            )
+            return {
+                "id": cid,
+                "object": obj,
+                "created": created,
+                "model": _MODEL_ID,
+                "choices": [ch],
+            }
 
         try:
             if chat:
-                sse(chunk(None))  # role-priming delta (OpenAI sends an empty assistant delta first)
+                sse(
+                    chunk(None)
+                )  # role-priming delta (OpenAI sends an empty assistant delta first)
             finish_reason = "length"
             for delta, meta in _run_stream(prompt, max_tokens, temperature):
                 if meta is not None:
@@ -237,8 +282,14 @@ class _Handler(BaseHTTPRequestHandler):
         except Exception as exc:
             # Best-effort error frame; the stream may already be partially sent.
             try:
-                sse({"error": {"message": f"{type(exc).__name__}: {exc}",
-                               "type": "unsafe_model_failure"}})
+                sse(
+                    {
+                        "error": {
+                            "message": f"{type(exc).__name__}: {exc}",
+                            "type": "unsafe_model_failure",
+                        }
+                    }
+                )
                 self.wfile.write(b"data: [DONE]\n\n")
                 self.wfile.flush()
             except Exception:
@@ -269,11 +320,17 @@ def _scrub_stale_tt_paths(environ) -> "list[str]":
     overrides from an old checkout). Output dirs in ``_OUTPUT_PATH_VARS`` are exempt —
     they're allowed to not exist yet. Mutates ``environ``; returns the removed entries."""
     from pathlib import Path
+
     scrubbed = []
     for k, v in list(environ.items()):
         if k in _OUTPUT_PATH_VARS:
             continue
-        if k.startswith("TT_") and isinstance(v, str) and v.startswith("/") and not Path(v).exists():
+        if (
+            k.startswith("TT_")
+            and isinstance(v, str)
+            and v.startswith("/")
+            and not Path(v).exists()
+        ):
             del environ[k]
             scrubbed.append(f"{k}={v}")
     return scrubbed
@@ -295,11 +352,15 @@ def _ensure_tt_metal_root():
     Must run before ttnn is imported (i.e. before load_model)."""
     import os
     from pathlib import Path
+
     candidate = Path(sys.prefix).parent  # <tt-metal>/python_env -> <tt-metal>
     if not (candidate / "tt_metal" / "soc_descriptors").is_dir():
         cur = os.environ.get("TT_METAL_RUNTIME_ROOT") or os.environ.get("TT_METAL_HOME")
-        print(f"[serve] WARNING: {candidate} has no tt_metal/soc_descriptors; relying on "
-              f"current root ({cur!r}) — ttnn may fail", flush=True)
+        print(
+            f"[serve] WARNING: {candidate} has no tt_metal/soc_descriptors; relying on "
+            f"current root ({cur!r}) — ttnn may fail",
+            flush=True,
+        )
         return
     # (1) Scrub stale TT_* path overrides (absolute paths that no longer exist), but
     #     never the output dirs (TT_METAL_CACHE) — those are created lazily.
@@ -308,30 +369,47 @@ def _ensure_tt_metal_root():
     for var in ("TT_METAL_RUNTIME_ROOT", "TT_METAL_HOME"):
         os.environ[var] = str(candidate)
     if scrubbed:
-        print(f"[serve] scrubbed {len(scrubbed)} stale TT_* path var(s): "
-              + "; ".join(scrubbed), flush=True)
+        print(
+            f"[serve] scrubbed {len(scrubbed)} stale TT_* path var(s): "
+            + "; ".join(scrubbed),
+            flush=True,
+        )
     print(f"[serve] tt-metal root = {candidate}", flush=True)
 
 
 def main(argv=None):
     _ensure_tt_metal_root()
-    parser = argparse.ArgumentParser(prog="tt-inference-server",
-                                     description="Dispatch OpenAI-compatible serving prototype")
+    parser = argparse.ArgumentParser(
+        prog="tt-inference-server",
+        description="Dispatch OpenAI-compatible serving prototype",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
-    sp = sub.add_parser("serve", help="Load a model and serve it over an OpenAI-compatible API")
+    sp = sub.add_parser(
+        "serve", help="Load a model and serve it over an OpenAI-compatible API"
+    )
     sp.add_argument("model", help="HuggingFace model id or local path")
-    sp.add_argument("--unsafe", action="store_true",
-                    help="Acknowledge no correctness/SLA guarantee (required)")
+    sp.add_argument(
+        "--unsafe",
+        action="store_true",
+        help="Acknowledge no correctness/SLA guarantee (required)",
+    )
     sp.add_argument("--host", default="127.0.0.1")
     sp.add_argument("--port", type=int, default=8000)
     sp.add_argument("--max-seq", type=int, default=2048)
-    sp.add_argument("--no-trace", action="store_true",
-                    help="Don't reserve a device trace region (disables the traced fast path)")
-    sp.add_argument("--runner", default=None, metavar="MODULE:CLASS",
-                    help="Use a custom runner (e.g. 'pkg.mod:MyRunner') instead of the generic "
-                         "TTModelRunner. Overrides auto-discovery. A runner self-declared by the "
-                         "model repo is honored only with --unsafe.")
+    sp.add_argument(
+        "--no-trace",
+        action="store_true",
+        help="Don't reserve a device trace region (disables the traced fast path)",
+    )
+    sp.add_argument(
+        "--runner",
+        default=None,
+        metavar="MODULE:CLASS",
+        help="Use a custom runner (e.g. 'pkg.mod:MyRunner') instead of the generic "
+        "TTModelRunner. Overrides auto-discovery. A runner self-declared by the "
+        "model repo is honored only with --unsafe.",
+    )
 
     args = parser.parse_args(argv)
     if args.command != "serve":
@@ -345,6 +423,7 @@ def main(argv=None):
     _MODEL_ID = args.model
 
     from tt_inference_server.dispatch import load_model
+
     print(f"[serve] loading {args.model} (unsafe acknowledged) ...", flush=True)
     try:
         _HANDLE = load_model(

--- a/tt_inference_server/dispatch/serve.py
+++ b/tt_inference_server/dispatch/serve.py
@@ -1,0 +1,383 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenAI-compatible serving prototype for the dispatch runtime (#16/#25).
+
+Loads ANY HuggingFace model id (or local path) once onto the Tenstorrent device and
+serves it over an OpenAI-compatible HTTP API, so any OpenAI client / curl can drive it:
+
+    python -m tt_inference_server.dispatch.serve serve --unsafe \\
+        mistral-community/Mistral-7B-v0.3 --port 8000
+
+    curl localhost:8000/v1/chat/completions -H 'content-type: application/json' -d '{
+      "model": "mistral-community/Mistral-7B-v0.3",
+      "messages": [{"role":"user","content":"The capital of France is"}]
+    }'
+
+Design notes
+------------
+* Built on the stdlib http.server (zero extra deps; runs in the tt-metal venv as-is).
+* --unsafe is REQUIRED. It is an acknowledgement, not a per-model gate: anything served
+  this way carries no correctness/SLA guarantee (validated or not). Without it, serve
+  refuses with an explanation. This removes the "I didn't know it might not work"
+  objection while we bring models up to snuff.
+* The two-tier resolver (#3) decides config + capabilities: validated models resolve from
+  model_matrix.toml; novel models auto-derive from the HF config and are flagged community.
+* One device, one inference at a time: requests are serialized behind a lock. A failed
+  request returns an OpenAI-style error (HTTP 422) and the server stays up for the next one.
+
+Endpoints: GET /health, GET /v1/models, POST /v1/chat/completions, POST /v1/completions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import threading
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+# Module-global serving state (set in main()).
+_HANDLE = None            # ModelHandle
+_MODEL_ID = None          # str shown in the API
+_INFER_LOCK = threading.Lock()
+
+
+# ----------------------------------------------------------------------------
+# Prompt rendering
+# ----------------------------------------------------------------------------
+
+def _render_chat(messages) -> str:
+    """Render OpenAI chat messages to a single prompt string via the tokenizer's chat
+    template (preserving multi-turn structure). Falls back to a simple role-tagged join
+    when the tokenizer has no chat template."""
+    tok = _HANDLE.tokenizer
+    msgs = [{"role": m.get("role", "user"), "content": m.get("content", "")} for m in messages]
+    if hasattr(tok, "apply_chat_template") and getattr(tok, "chat_template", None):
+        try:
+            return tok.apply_chat_template(msgs, tokenize=False, add_generation_prompt=True)
+        except Exception:
+            pass
+    parts = [f"{m['role']}: {m['content']}" for m in msgs]
+    parts.append("assistant:")
+    return "\n".join(parts)
+
+
+# ----------------------------------------------------------------------------
+# Inference (serialized) — returns (text, usage_dict) or yields stream deltas
+# ----------------------------------------------------------------------------
+
+def _run(prompt: str, max_tokens: int, temperature: float):
+    """Run a full (non-streaming) generation. Returns (text, finish_reason, usage)."""
+    with _INFER_LOCK:
+        text_parts = []
+        meta = {"finish_reason": "length", "prompt_tokens": 0, "completion_tokens": 0}
+        for piece in _HANDLE.generate_stream(prompt, max_new_tokens=max_tokens,
+                                              temperature=temperature, chat=False):
+            if isinstance(piece, dict):
+                meta = piece
+            else:
+                text_parts.append(piece)
+        usage = {
+            "prompt_tokens": meta["prompt_tokens"],
+            "completion_tokens": meta["completion_tokens"],
+            "total_tokens": meta["prompt_tokens"] + meta["completion_tokens"],
+        }
+        return "".join(text_parts), meta["finish_reason"], usage
+
+
+def _run_stream(prompt: str, max_tokens: int, temperature: float):
+    """Yield (delta_text_or_None, meta_or_None). Holds the infer lock for the whole stream."""
+    with _INFER_LOCK:
+        for piece in _HANDLE.generate_stream(prompt, max_new_tokens=max_tokens,
+                                             temperature=temperature, chat=False):
+            if isinstance(piece, dict):
+                yield None, piece
+            else:
+                yield piece, None
+
+
+# ----------------------------------------------------------------------------
+# HTTP handler
+# ----------------------------------------------------------------------------
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):  # quieter logs
+        sys.stderr.write("  [serve] %s - %s\n" % (self.address_string(), fmt % args))
+
+    # -- response helpers --
+    def _send_json(self, code, obj):
+        body = json.dumps(obj).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _error(self, code, message, etype="invalid_request_error"):
+        self._send_json(code, {"error": {"message": message, "type": etype}})
+
+    def _read_body(self):
+        length = int(self.headers.get("Content-Length", 0))
+        if not length:
+            return {}
+        return json.loads(self.rfile.read(length).decode("utf-8"))
+
+    # -- routes --
+    def do_GET(self):
+        if self.path == "/health":
+            return self._send_json(200, {"status": "ok", "model": _MODEL_ID})
+        if self.path == "/v1/models":
+            return self._send_json(200, {
+                "object": "list",
+                "data": [{
+                    "id": _MODEL_ID, "object": "model", "created": int(time.time()),
+                    "owned_by": "dispatch",
+                    "dispatch": {"listed": _HANDLE.listed, "community": _HANDLE.community},
+                }],
+            })
+        return self._error(404, f"unknown path {self.path}", "not_found")
+
+    def do_POST(self):
+        try:
+            body = self._read_body()
+        except Exception as exc:
+            return self._error(400, f"invalid JSON body: {exc}")
+
+        if self.path == "/v1/chat/completions":
+            return self._handle_completion(body, chat=True)
+        if self.path == "/v1/completions":
+            return self._handle_completion(body, chat=False)
+        return self._error(404, f"unknown path {self.path}", "not_found")
+
+    def _handle_completion(self, body, chat: bool):
+        max_tokens = int(body.get("max_tokens", 128))
+        temperature = float(body.get("temperature", 1.0))
+        stream = bool(body.get("stream", False))
+        try:
+            if chat:
+                messages = body.get("messages")
+                if not messages:
+                    return self._error(400, "'messages' is required")
+                prompt = _render_chat(messages)
+            else:
+                prompt = body.get("prompt")
+                if prompt is None:
+                    return self._error(400, "'prompt' is required")
+                if isinstance(prompt, list):
+                    prompt = prompt[0]
+        except Exception as exc:
+            return self._error(422, f"prompt construction failed: {exc}", "unsafe_model_failure")
+
+        if stream:
+            return self._stream_completion(prompt, max_tokens, temperature, chat)
+        return self._full_completion(prompt, max_tokens, temperature, chat)
+
+    def _full_completion(self, prompt, max_tokens, temperature, chat):
+        try:
+            text, finish_reason, usage = _run(prompt, max_tokens, temperature)
+        except Exception as exc:
+            # Graceful failure (#25): the model blew up mid-inference; report and stay up.
+            return self._error(
+                422,
+                f"{type(exc).__name__}: {exc}",
+                "unsafe_model_failure",
+            )
+        cid = ("chatcmpl-" if chat else "cmpl-") + uuid.uuid4().hex[:24]
+        created = int(time.time())
+        if chat:
+            choice = {"index": 0, "message": {"role": "assistant", "content": text},
+                      "finish_reason": finish_reason}
+            obj = "chat.completion"
+        else:
+            choice = {"index": 0, "text": text, "finish_reason": finish_reason}
+            obj = "text_completion"
+        self._send_json(200, {
+            "id": cid, "object": obj, "created": created, "model": _MODEL_ID,
+            "choices": [choice], "usage": usage,
+        })
+
+    def _stream_completion(self, prompt, max_tokens, temperature, chat):
+        cid = ("chatcmpl-" if chat else "cmpl-") + uuid.uuid4().hex[:24]
+        created = int(time.time())
+        obj = "chat.completion.chunk" if chat else "text_completion"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "close")
+        self.end_headers()
+
+        def sse(payload):
+            self.wfile.write(b"data: " + json.dumps(payload).encode("utf-8") + b"\n\n")
+            self.wfile.flush()
+
+        def chunk(delta, finish=None):
+            ch = ({"index": 0, "delta": ({"content": delta} if delta is not None else {}),
+                   "finish_reason": finish} if chat
+                  else {"index": 0, "text": delta or "", "finish_reason": finish})
+            return {"id": cid, "object": obj, "created": created, "model": _MODEL_ID,
+                    "choices": [ch]}
+
+        try:
+            if chat:
+                sse(chunk(None))  # role-priming delta (OpenAI sends an empty assistant delta first)
+            finish_reason = "length"
+            for delta, meta in _run_stream(prompt, max_tokens, temperature):
+                if meta is not None:
+                    finish_reason = meta["finish_reason"]
+                    continue
+                sse(chunk(delta))
+            sse(chunk(None, finish=finish_reason))
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+        except Exception as exc:
+            # Best-effort error frame; the stream may already be partially sent.
+            try:
+                sse({"error": {"message": f"{type(exc).__name__}: {exc}",
+                               "type": "unsafe_model_failure"}})
+                self.wfile.write(b"data: [DONE]\n\n")
+                self.wfile.flush()
+            except Exception:
+                pass
+
+
+# ----------------------------------------------------------------------------
+# CLI
+# ----------------------------------------------------------------------------
+
+_UNSAFE_NOTICE = (
+    "Refusing to serve without --unsafe.\n"
+    "  Models served by the dispatch prototype carry NO correctness or SLA guarantee\n"
+    "  (validated or not). Pass --unsafe to acknowledge this and proceed:\n"
+    "      python -m tt_inference_server.dispatch.serve serve --unsafe <model-id>\n"
+)
+
+
+# TT_* env vars that legitimately point at a not-yet-created OUTPUT dir (tt-metal makes
+# them lazily). These must NOT be scrubbed for non-existence — e.g. a producer pointing
+# TT_METAL_CACHE at a fresh cache dir would otherwise have it deleted, silently sending
+# kernels back to the default cache.
+_OUTPUT_PATH_VARS = frozenset({"TT_METAL_CACHE"})
+
+
+def _scrub_stale_tt_paths(environ) -> "list[str]":
+    """Remove TT_* env vars whose value is an absolute path that no longer exists (stale
+    overrides from an old checkout). Output dirs in ``_OUTPUT_PATH_VARS`` are exempt —
+    they're allowed to not exist yet. Mutates ``environ``; returns the removed entries."""
+    from pathlib import Path
+    scrubbed = []
+    for k, v in list(environ.items()):
+        if k in _OUTPUT_PATH_VARS:
+            continue
+        if k.startswith("TT_") and isinstance(v, str) and v.startswith("/") and not Path(v).exists():
+            del environ[k]
+            scrubbed.append(f"{k}={v}")
+    return scrubbed
+
+
+def _ensure_tt_metal_root():
+    """Point tt-metal at the correct source tree before ttnn is imported.
+
+    tt-metal/ttnn locate their data (soc_descriptors, kernels, fabric mesh-graph descriptors,
+    …) via a family of env vars — TT_METAL_RUNTIME_ROOT for the root, plus per-asset overrides
+    like TT_MESH_GRAPH_DESC_PATH and TT_METAL_KERNEL_PATH. (Note: it does NOT read
+    TT_METAL_HOME.) A shell carrying stale values from a previous checkout (e.g. ~/tt-metal)
+    makes ttnn die with 'bad file: …' or 'mesh graph descriptor not found: …'.
+
+    This venv lives at <tt-metal>/python_env, so sys.prefix.parent is the authoritative root.
+    We (1) scrub every TT_* env var whose value is an absolute path that doesn't exist (the
+    stale overrides — once unset, tt-metal recomputes the right default from the root), and
+    (2) force TT_METAL_RUNTIME_ROOT (+ TT_METAL_HOME for other tooling) to the real root.
+    Must run before ttnn is imported (i.e. before load_model)."""
+    import os
+    from pathlib import Path
+    candidate = Path(sys.prefix).parent  # <tt-metal>/python_env -> <tt-metal>
+    if not (candidate / "tt_metal" / "soc_descriptors").is_dir():
+        cur = os.environ.get("TT_METAL_RUNTIME_ROOT") or os.environ.get("TT_METAL_HOME")
+        print(f"[serve] WARNING: {candidate} has no tt_metal/soc_descriptors; relying on "
+              f"current root ({cur!r}) — ttnn may fail", flush=True)
+        return
+    # (1) Scrub stale TT_* path overrides (absolute paths that no longer exist), but
+    #     never the output dirs (TT_METAL_CACHE) — those are created lazily.
+    scrubbed = _scrub_stale_tt_paths(os.environ)
+    # (2) Force the authoritative root.
+    for var in ("TT_METAL_RUNTIME_ROOT", "TT_METAL_HOME"):
+        os.environ[var] = str(candidate)
+    if scrubbed:
+        print(f"[serve] scrubbed {len(scrubbed)} stale TT_* path var(s): "
+              + "; ".join(scrubbed), flush=True)
+    print(f"[serve] tt-metal root = {candidate}", flush=True)
+
+
+def main(argv=None):
+    _ensure_tt_metal_root()
+    parser = argparse.ArgumentParser(prog="tt-inference-server",
+                                     description="Dispatch OpenAI-compatible serving prototype")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sp = sub.add_parser("serve", help="Load a model and serve it over an OpenAI-compatible API")
+    sp.add_argument("model", help="HuggingFace model id or local path")
+    sp.add_argument("--unsafe", action="store_true",
+                    help="Acknowledge no correctness/SLA guarantee (required)")
+    sp.add_argument("--host", default="127.0.0.1")
+    sp.add_argument("--port", type=int, default=8000)
+    sp.add_argument("--max-seq", type=int, default=2048)
+    sp.add_argument("--no-trace", action="store_true",
+                    help="Don't reserve a device trace region (disables the traced fast path)")
+    sp.add_argument("--runner", default=None, metavar="MODULE:CLASS",
+                    help="Use a custom runner (e.g. 'pkg.mod:MyRunner') instead of the generic "
+                         "TTModelRunner. Overrides auto-discovery. A runner self-declared by the "
+                         "model repo is honored only with --unsafe.")
+
+    args = parser.parse_args(argv)
+    if args.command != "serve":
+        parser.error("only 'serve' is supported")
+
+    if not args.unsafe:
+        sys.stderr.write(_UNSAFE_NOTICE)
+        return 2
+
+    global _HANDLE, _MODEL_ID
+    _MODEL_ID = args.model
+
+    from tt_inference_server.dispatch import load_model
+    print(f"[serve] loading {args.model} (unsafe acknowledged) ...", flush=True)
+    try:
+        _HANDLE = load_model(
+            args.model,
+            max_seq=args.max_seq,
+            unsafe=True,
+            trace_region_size=0 if args.no_trace else 134217728,
+            runner=args.runner,
+        )
+    except Exception as exc:
+        # Clean load-time failure (unknown arch / weight mapping / download error).
+        sys.stderr.write(
+            f"[serve] FAILED to load '{args.model}': {type(exc).__name__}: {exc}\n"
+            "  The architecture may be unsupported (introspection/weight mapping failed).\n"
+        )
+        return 1
+
+    tag = "community/unverified" if _HANDLE.community else "validated"
+    print(f"[serve] ready: {args.model} ({tag})", flush=True)
+
+    httpd = ThreadingHTTPServer((args.host, args.port), _Handler)
+    url = f"http://{args.host}:{args.port}"
+    print(f"[serve] OpenAI-compatible API on {url}", flush=True)
+    print(f"[serve]   GET  {url}/v1/models", flush=True)
+    print(f"[serve]   POST {url}/v1/chat/completions", flush=True)
+    print(f"[serve]   POST {url}/v1/completions", flush=True)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\n[serve] shutting down ...", flush=True)
+        httpd.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this PR does

Adds **`tt_inference_server/dispatch/`** — a self-contained runtime that lets
tt-inference-server load and serve models that are **not predefined in a registry**. It is
**purely additive** (the subsystem doesn't exist on `main` today; no existing files change).

An unregistered model can load two ways:

1. **Bring-your-own runner** — selected through a runner-selection seam (`--runner
   module:Class`, an installed package's `tt_inference_server.runners` entry point, or a
   runner the model repo self-declares under `--unsafe`). For architectures whose tt-nn
   graph isn't a standard transformer (MoE, state-space, multimodal).
2. **Generic introspection floor** — with no runner and no matrix entry, the generic
   `TTModelRunner` derives the model's capabilities from its HF config (norm type, RoPE,
   biases, head-norm, activation, …) and JIT-compiles kernels dynamically.

So a never-before-seen Hugging Face model still loads and serves; **a `model_matrix.toml`
entry records trust + hardware-tuned choices but is not a prerequisite to run.**

The subsystem is also designed to be fronted by the kernel/package manager (`tt-kernel`)
without this runtime depending on it: the runner is an opaque `"module:Class"` spec, and
`tt-kernel` is *detected, never imported*.

## How a model is loaded — and where non-registered models fit

`load_model()` resolves down a tiered ladder; higher tiers are opt-in trust, the bottom is a
universal floor:

1. **Custom runner** — explicit `--runner`, entry-point match, or self-declared (`--unsafe`).
2. **Registered model** — present in `model_matrix.toml` (trusted dims + behavioral fields +
   tuned kernel/grid).
3. **Non-registered / unseen (the floor)** — generic `TTModelRunner` introspects the HF
   config and JIT-compiles dynamically. Gated behind `--unsafe`, labeled community, but it
   **runs**.

Custom wins when present; everything else falls through to the dynamic path.

## High-level architecture

The dividing line is "does it touch the card?":

- **`tt-kernel`** (separate, pure-Python, no `ttnn`) — package manager + front door:
  resolves whether a curated bundle exists, distributes precompiled kernel caches, and routes
  — by subprocess — to this runtime. Never imports this package.
- **`tt_inference_server/dispatch/` (this PR)** — the engine: loads weights, builds the ttnn
  graph, JIT-compiles kernels via tt-metal, and generates.

Curated model → `serve --runner <spec> <weights>`; bare HF id → `serve <id>` (floor path).
Hardware capability (grid / L1 / DRAM per board) is detected at load and feeds the kernel
dispatcher's budget checks.

## What's in this PR (all under `dispatch/`, self-contained)

- **Runner seam** — `base.py` (`BaseRunner` Protocol, `resolve_runner_class()` precedence:
  explicit → entry-point → self-declared(`--unsafe`) → generic), `serve.py` (`--runner`),
  `runner.py` (the generic `TTModelRunner` + HF-config introspection).
- **Dispatcher & config** — `dispatcher.py`, `model_matrix.toml`, `registry.py`,
  `config_*.py`, `compat.py` (shape/L1-budget validation).
- **Hardware layer** — `hardware.py` (capability data + detection) feeding the dispatcher.
- **Kernels** — `dispatch/kernels/*` (the `ttl` kernel factories: flash-attn, rmsnorm,
  swiglu, layernorm, kv-decode, moe-router), vendored inside the subsystem.
- **Producer** — `release.py` (warm a model into a fresh cache, publish via `tt-kernel`).
- **Tests** — `tests/dispatch/*` (69 tests; runner-seam, hardware, capabilities, validator,
  serve, release), following the existing `tests/<component>/` convention.
- **Docs** — `dispatch/docs/custom_runners.md` (the runner-authoring contract).

## Compatibility & testing

- **Self-contained:** the subtree imports only stdlib, external libs (`ttnn`/`ttl`/`torch`/
  `transformers`/`huggingface_hub`), the optional `tt_kernel`, and itself — no fork-internal
  dependencies.
- **Clean overlay on `main`:** with only this subtree added to pristine `main`, all imports
  resolve and `tests/dispatch` passes (69 tests).
- **On device (Blackhole p150):** `load_model` + `generate` produces coherent output; the
  kernel dispatch + JIT run. A full OFF/ON benchmark sweep shows correctness preserved across
  models and two prior fast-path crashes (Qwen2.5, StarCoder2) no longer reproduce.

## Known issues (pre-existing / out of scope)

- **BLOOM-3B** crashes `exit -9` (host OOM-killer) on a memory-constrained host (host-side
  CPU-ALiBi path, unrelated to the hardware-budget logic).
- **InternLM2.5** (fused-QKV weight mapping) and **EXAONE** (its `trust_remote_code` config
  needs a newer `transformers` for `RopeParameters`) fail to load — arch/env gaps.
- **GLM-4-9B** emits garbage output.

## Attribution

The **runner seam** (`base.py`, the `load_model` runner-selection wiring, the `runner.py`/
`serve.py` seam changes, the seam tests, and `docs/custom_runners.md`) was authored by the
repository owner together with another AI coding agent. The remaining additions — the
hardware-capability layer, the producer path, the courtesy notice, and the test/serve fixes —
were authored with Claude (Anthropic).
