### PR TITLE
Forge LLM sampling defaults: repetition_penalty 1.1 -> 1.0 and drop per-request seed

### DIFF
--- a/tt-media-server/tests/test_sampling_params_builder.py
+++ b/tt-media-server/tests/test_sampling_params_builder.py
@@ -96,7 +96,11 @@ class TestBuildSamplingParamsRequestValues:
             kwargs = mock_sp.call_args.kwargs
             assert kwargs["max_tokens"] == 100
 
-    def test_seed_from_request(self):
+    def test_seed_is_dropped(self):
+        # The Forge sampling-params builder intentionally drops the per-request
+        # seed (forces seed=None): the Forge device sampler ignores it
+        # (tenstorrent/tt-xla#4539) and a non-None seed forces the ~5x-slower
+        # seeded sampling path (#4338). So even an explicit request seed is dropped.
         with patch("utils.sampling_params_builder.SamplingParams") as mock_sp:
             from utils.sampling_params_builder import build_sampling_params
 
@@ -104,7 +108,7 @@ class TestBuildSamplingParamsRequestValues:
             build_sampling_params(request)
 
             kwargs = mock_sp.call_args.kwargs
-            assert kwargs["seed"] == 42
+            assert kwargs["seed"] is None
 
     def test_presence_penalty_from_request(self):
         with patch("utils.sampling_params_builder.SamplingParams") as mock_sp:

--- a/tt-media-server/tt_model_runners/vllm_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_runner.py
@@ -22,7 +22,10 @@ class VLLMForgeRunner(BaseDeviceRunner):
     # Sampling defaults for Forge LLM inference (overrides global greedy defaults)
     SAMPLING_DEFAULTS = {
         "temperature": 0.6,
-        "repetition_penalty": 1.1,
+        # 1.0 (off) matches every sibling runner (Forge TP, metal) and the repo-wide
+        # _DEFAULT_SAMPLING_PARAMS; the old 1.1 was the lone outlier and drove the
+        # O(N^2) decode regression (#4278). Callers can still opt into 1.1 per request.
+        "repetition_penalty": 1.0,
     }
 
     def __init__(self, device_id: str):

--- a/tt-media-server/utils/sampling_params_builder.py
+++ b/tt-media-server/utils/sampling_params_builder.py
@@ -39,7 +39,13 @@ def build_sampling_params(
     # We check falsey here because that is what we used to do, if user passes 0, he will get 65536(default) tokens back
     max_tokens = request.max_tokens if request.max_tokens else defaults["max_tokens"]
     n = request.n if request.n is not None else defaults["n"]
-    seed = request.seed if request.seed is not None else defaults["seed"]
+    # Force seed=None: the Forge device sampler ignores per-request seeds
+    # (tt-xla#4539), but a non-None seed still forces the ~5x-slower seeded path
+    # (per-step CPU noise draw + H2D copy). lm-eval always sends seed=1234, so drop
+    # it. Scoped to Forge LLMs: every caller of this builder is a Forge runner
+    # (VLLMForgeRunner + the TP Llama-70B/Qwen-32B/Gemma runners); the metal runner
+    # has its own builder and still honors seed. See #4338.
+    seed = None
     logprobs = (
         request.logprobs if request.logprobs is not None else defaults["logprobs"]
     )


### PR DESCRIPTION
## Problem

Two Forge-LLM sampling defaults were silently taxing the device-sampling hot path, both surfaced during the Qwen3-8B CI-runtime effort (#4131):

- **`repetition_penalty=1.1`** was the default in `VLLMForgeRunner` — the lone outlier (every other runner and the repo-wide `_DEFAULT_SAMPLING_PARAMS` use 1.0). It drove the O(N^2) decode regression on the penalty path: per-request decode falls with output length (single-layer ~48 -> ~16 tok/s as OSL grows).
- **Per-request `seed`** (lm-eval sends `seed=1234`, so **every eval request** hit it) switches the forge sampler to a host-side slow path: a fixed ~69 ms/step host tax (~19 MB CPU noise + H2D copy per step). The seed isn't even honored on the device sampler properly (tt-xla + tt-metal issues exist), so the cost buys nothing. Will add back once supported.

## What's Changed

- **`vllm_runner.py`** — `VLLMForgeRunner` default `repetition_penalty` **1.1 -> 1.0**. Callers can still opt into 1.1 per request.
- **`sampling_params_builder.py`** — **drop the per-request `seed`** (force `seed=None`). Scoped to Forge LLMs: this builder is used only by the Forge runners (single-chip `VLLMForgeRunner` + the TP Llama-70B / Qwen-32B / Gemma runners); the metal runner has its own builder and still honors `seed`.
  - **Why drop it rather than rely on validation:** the Forge path is *supposed* to reject seeded requests with an exception (directing users to `cpu_sampling=True`), but a bug means that validation isn't firing — so seeds silently fall through to the slow path. Dropping the seed sidesteps that.
  - **Temporary:** removed once seeded sampling is properly supported on the Forge path — a tt-metal kernel fix to thread per-row seed entropy into `tt::sampling`, then tt-xla wires it back up.
- **`tests/test_sampling_params_builder.py`** — `test_seed_from_request` (asserted old passthrough) -> **`test_seed_is_dropped`** (asserts `seed is None`). The `repetition_penalty` override tests are unaffected (they pass `1.1` in explicitly to test the merge mechanism, not the runner default).

## Scope + Testing

- **Defaults only**, scoped to Forge LLMs — no change for non-Forge runners.
- **Tested locally** (Qwen3-8B, P150); measured gains:
  - **Seed drop:** **5.4x faster** single-layer decode (**14.5 -> 78 tok/s**, TPOT 69 -> 13 ms); on the full model, removes a ~69 ms/step host tax worth ~6-11% at short context (and resurfaces as the ceiling as decode gets faster).
  - **repetition_penalty 1.0:** avoids the O(N^2) penalty-path regression that degrades decode with output length (single-layer ~48 -> ~16 tok/s across the OSL sweep).

## Related issues

- repetition_penalty: #4278
- seed drop: #4338, tenstorrent/tt-xla#4539 (device sampler ignores `seed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
