### PR TITLE
Use tt-llm-engine commit instead of tt-blaze in info endpoint

### DIFF
--- a/tt-media-server/cpp_server/DEPLOYMENT.md
+++ b/tt-media-server/cpp_server/DEPLOYMENT.md
@@ -205,11 +205,11 @@ bug or correlating an incident with a release.
 
 Response fields:
 
-| Field                          | Meaning                                                                |
-| ------------------------------ | ---------------------------------------------------------------------- |
-| `tt_inference_server.version`  | Semver of this server build (from `VERSION` file).                     |
-| `tt_inference_server.commit`   | Git commit of the `tt-inference-server` repo at build time.            |
-| `tt_llm_engine.commit`         | Git commit of the `tt-llm-engine` submodule used at build time.        |
+| Field                          | Meaning                                                                      |
+| ------------------------------ | -----------------------------------------------------------------------------|
+| `tt_inference_server.version`  | Semver of this server build (from `VERSION` file).                           |
+| `tt_inference_server.commit`   | Git commit of the `tt-inference-server` repo at build time.                  |
+| `tt_llm_engine.commit`         | Git commit of the `tt-llm-engine` submodule used at build time.              |
 | `tt_metal.commit`              | Git commit of the `tt-metal` submodule (inside tt-llm-engine) at build time. |
 
 **Example:**

--- a/tt-media-server/cpp_server/DEPLOYMENT.md
+++ b/tt-media-server/cpp_server/DEPLOYMENT.md
@@ -209,8 +209,8 @@ Response fields:
 | ------------------------------ | ---------------------------------------------------------------------- |
 | `tt_inference_server.version`  | Semver of this server build (from `VERSION` file).                     |
 | `tt_inference_server.commit`   | Git commit of the `tt-inference-server` repo at build time.            |
-| `tt_blaze.commit`              | Git commit of the `tt-blaze` submodule used at build time.             |
-| `tt_metal.commit`              | Git commit of the `tt-metal` submodule (inside tt-blaze) at build time. |
+| `tt_llm_engine.commit`         | Git commit of the `tt-llm-engine` submodule used at build time.        |
+| `tt_metal.commit`              | Git commit of the `tt-metal` submodule (inside tt-llm-engine) at build time. |
 
 **Example:**
 
@@ -220,7 +220,7 @@ Response fields:
     "version": "0.5.0",
     "commit": "56741604fa1e1d2cb8a..."
   },
-  "tt_blaze": {
+  "tt_llm_engine": {
     "commit": "8df8a38675123db7b56..."
   },
   "tt_metal": {

--- a/tt-media-server/cpp_server/cmake/GenerateBuildInfo.cmake
+++ b/tt-media-server/cpp_server/cmake/GenerateBuildInfo.cmake
@@ -58,13 +58,7 @@ if(TT_INFERENCE_SERVER_COMMIT STREQUAL "")
     set(TT_INFERENCE_SERVER_COMMIT "unknown")
 endif()
 
-# tt-llm-engine commit (exposed in /info as `tt_blaze.commit` for backwards
-# compatibility — keep the C++ var name TT_BLAZE_COMMIT in sync with
-# build_info.hpp.in / kTtBlazeCommit). git rev-parse on the cloned
-# tt-llm-engine working tree. Present at this path inside Dockerfile.blaze
-# (cloned at build time); absent in standalone cpp_server builds — falls
-# through to "unknown".
-_resolve_git_commit("${CPP_SERVER_DIR}/tt-llm-engine" TT_BLAZE_COMMIT)
+_resolve_git_commit("${CPP_SERVER_DIR}/tt-llm-engine" TT_LLM_ENGINE_COMMIT)
 
 # tt-metal commit: git rev-parse on tt-llm-engine's tt-metal submodule working tree.
 # Intentionally NOT reading $ENV{TT_METAL_COMMIT_SHA_OR_TAG} — that ARG in
@@ -80,5 +74,5 @@ configure_file("${TEMPLATE}" "${OUTPUT}" @ONLY)
 message(STATUS "build_info.hpp generated:")
 message(STATUS "  tt_inference_server.version = ${TT_INFERENCE_SERVER_VERSION}")
 message(STATUS "  tt_inference_server.commit  = ${TT_INFERENCE_SERVER_COMMIT}")
-message(STATUS "  tt_blaze.commit             = ${TT_BLAZE_COMMIT}")
+message(STATUS "  tt_llm_engine.commit        = ${TT_LLM_ENGINE_COMMIT}")
 message(STATUS "  tt_metal.commit             = ${TT_METAL_COMMIT}")

--- a/tt-media-server/cpp_server/include/api/info_controller.hpp
+++ b/tt-media-server/cpp_server/include/api/info_controller.hpp
@@ -11,7 +11,7 @@ namespace tt::api {
  * GET /info
  *
  * Returns the build identity of the running server: tt-inference-server
- * version + commit, tt-blaze commit, and tt-metal commit.
+ * version + commit, tt-llm-engine commit, and tt-metal commit.
  * No authentication required (listed in the security filter bypass list).
  */
 class InfoController : public drogon::HttpController<InfoController> {

--- a/tt-media-server/cpp_server/include/config/build_info.hpp.in
+++ b/tt-media-server/cpp_server/include/config/build_info.hpp.in
@@ -13,7 +13,7 @@ namespace tt::config {
 
 inline constexpr std::string_view kInferenceServerVersion = "@TT_INFERENCE_SERVER_VERSION@";
 inline constexpr std::string_view kInferenceServerCommit  = "@TT_INFERENCE_SERVER_COMMIT@";
-inline constexpr std::string_view kTtBlazeCommit          = "@TT_BLAZE_COMMIT@";
+inline constexpr std::string_view kTtLlmEngineCommit      = "@TT_LLM_ENGINE_COMMIT@";
 inline constexpr std::string_view kTtMetalCommit          = "@TT_METAL_COMMIT@";
 
 }  // namespace tt::config

--- a/tt-media-server/cpp_server/src/api/info_controller.cpp
+++ b/tt-media-server/cpp_server/src/api/info_controller.cpp
@@ -19,7 +19,8 @@ void InfoController::info(
       std::string{tt::config::kInferenceServerVersion};
   response["tt_inference_server"]["commit"] =
       std::string{tt::config::kInferenceServerCommit};
-  response["tt_blaze"]["commit"] = std::string{tt::config::kTtBlazeCommit};
+  response["tt_llm_engine"]["commit"] =
+      std::string{tt::config::kTtLlmEngineCommit};
   response["tt_metal"]["commit"] = std::string{tt::config::kTtMetalCommit};
 
   callback(drogon::HttpResponse::newHttpJsonResponse(response));


### PR DESCRIPTION
Breaking change for /info consumers: any out-of-tree dashboard or monitoring script reading `tt_blaze.commit` from the JSON response will need to switch to `tt_llm_engine.commit`