### PR TITLE
fix: waive longbench_code_e on p150 (matches p300x2 known issue)

### DIFF
--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -907,6 +907,9 @@ templates:
         - workflow_type: EVALS
           task_name: longbench_summarization_e
           reason: "longbench_summarization_e measured score is ~94% which does not satisfy the >=95% threshold  https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121. Masked due to other longbench subtasks passing."
+        - workflow_type: EVALS
+          task_name: longbench_code_e
+          reason: "longbench_code_e known issue with longbench code sub-task where the chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121. Masked due to other longbench subtasks passing."
   status: EXPERIMENTAL
   metadata:
     meta-llama/Llama-3.1-8B:


### PR DESCRIPTION
## Summary

- Adds `longbench_code_e` to p150's `known_issues` in `workflows/model_specs/dev/llm.yaml`, matching the identical waiver already present for p300x2
- The root cause (chat-template/prompt-template interference) is hardware-agnostic and tracked in #4002 — the p300x2 waiver was never mirrored to p150 when its block was created
- p150 is `status: EXPERIMENTAL`; holding it to a stricter eval gate than p300x2 (`FUNCTIONAL`) is unintentional

Closes #4360

## Test plan

- [ ] Next tt-shield release run for `Llama-3.1-8B-Instruct p150` should no longer block on `longbench_code_e`, matching the p300x2 run that passed on 2026-06-26