### PR TITLE
Add AiPerf prefix caching benchmarking ability to Kimi 2.6

### DIFF
--- a/run.py
+++ b/run.py
@@ -472,6 +472,17 @@ def parse_arguments():
         help="Path to a mooncake-format JSONL trace file for mooncake_trace scenarios.",
     )
     prefix_cache_group.add_argument(
+        "--prefix-cache-metrics-url",
+        type=str,
+        action="append",
+        default=None,
+        metavar="URL",
+        help="Worker /metrics endpoint with the tt_prefix_cache_* counters, forwarded to "
+        "AIPerf as --server-metrics (load stays on the frontend). Accepts a full URL, "
+        "host:port, or host:port/metrics. Repeatable for multi-worker deployments. "
+        "Without it the scrape hits the prefix-unaware frontend and hit-rate is null.",
+    )
+    prefix_cache_group.add_argument(
         "--jwt-secret",
         type=str,
         default=None,

--- a/run.py
+++ b/run.py
@@ -435,9 +435,12 @@ def parse_arguments():
     prefix_cache_group.add_argument(
         "--prefix-cache-preset",
         type=str,
-        choices=["ci", "full"],
+        choices=["ci", "full", "highcache_50k"],
         default="full",
-        help="Preset for --prefix-cache (default: full). 'ci' is a short regression sweep.",
+        help="Preset for --prefix-cache (default: full). 'ci' is a short regression sweep; "
+        "'highcache_50k' simulates the customer trillion-scale shape (50K shared/cacheable "
+        "prefix + 5K new ISL + 500 OSL at concurrency 32, ~90.9%% steady-state hit-rate) "
+        "with a matched zero-prefix baseline for TTFT-uplift comparison.",
     )
     prefix_cache_group.add_argument(
         "--prefix-cache-scenarios",

--- a/tt-inference-server-v2/README.md
+++ b/tt-inference-server-v2/README.md
@@ -253,11 +253,30 @@ Scenarios (`shared_system`, `prefix_pool`, `multi_turn`, `baseline`,
 [`llm_module/prefix_cache/sample_traces/ci_mooncake.jsonl`](llm_module/prefix_cache/sample_traces/ci_mooncake.jsonl)
 ships with the repo for reproducible CI runs.
 
+By default AIPerf auto-derives the `/metrics` scrape from the load target
+(`--service-port`). In a Dynamo deployment that target is the prefix-unaware
+frontend, which does not aggregate the worker prefix-cache counters, so the
+hit-rate column would render `null`. Point the scrape at the cpp_server
+worker(s) with `--prefix-cache-metrics-url` (forwarded to AIPerf's
+`--server-metrics`), keeping load on the frontend. It accepts a full URL,
+`host:port`, or `host:port/metrics`, and is repeatable for multi-worker
+(KV-routed) deployments — the parser sums hit/query deltas across the
+`endpoint_url`-tagged series:
+
+```bash
+python tt-inference-server-v2/run_prefix_cache.py \
+    --model Llama-3.1-8B-Instruct --workflow benchmarks --device gpu \
+    --service-port 8000 --prefix-cache --prefix-cache-preset ci \
+    --prefix-cache-metrics-url bh-glx-120-a03u08.exabox.tenstorrent.com:9000 \
+    --jwt-secret "$JWT_SECRET"
+```
+
 Each AIPerf run emits a `Block(kind="aiperf_prefix_cache")`, which the report
 generator collapses into three Markdown tables (Synthetic, Trace-Driven, Uplift
 vs zero-prefix baseline) via the renderer registered in
 [`report_module/prefix_cache_renderer.py`](report_module/prefix_cache_renderer.py).
-vLLM prefix-cache hit-rate is derived from the Prometheus counters AIPerf
+Prefix-cache hit-rate is derived from the worker Prometheus counters
+(`tt_prefix_cache_*` on cpp_server, or `vllm:prefix_cache_*` on vLLM) AIPerf
 scrapes into `server_metrics_export.jsonl`; on Tenstorrent hardware the
 `tt-vllm-plugin` currently disables prefix caching, so the hit-rate column
 renders as `null` until that's lifted (validation work was done against a

--- a/tt-inference-server-v2/README.md
+++ b/tt-inference-server-v2/README.md
@@ -247,11 +247,39 @@ selects the per-workflow venv externally for image-model runs, keeping venv
 selection out of `run.py`.
 
 Scenarios (`shared_system`, `prefix_pool`, `multi_turn`, `baseline`,
-`mooncake_trace`) and per-preset grids are JSON-defined and overridable with
-`--prefix-cache-scenarios-json`. Override the mooncake trace input with
-`--prefix-cache-trace`; the in-tree fixture at
+`mooncake_trace`) and per-preset grids (`ci`, `full`, `highcache_50k`) are
+JSON-defined and overridable with `--prefix-cache-scenarios-json`. Override the
+mooncake trace input with `--prefix-cache-trace`; the in-tree fixture at
 [`llm_module/prefix_cache/sample_traces/ci_mooncake.jsonl`](llm_module/prefix_cache/sample_traces/ci_mooncake.jsonl)
 ships with the repo for reproducible CI runs.
+
+### `highcache_50k` preset (trillion-scale customer shape)
+
+`--prefix-cache-preset highcache_50k` encodes a high-reuse, large-context
+serving shape: a **50K shared (cacheable) system prefix + 5K new ISL + 500 OSL
+at concurrency 32** (one SC16 decode unit). The shared prefix is sent as an
+identical system message across every session, so once warm the per-session KV
+cache hit-rate is `50000 / (50000 + 5000) = ~90.9%` — meeting the ≥ 90% target —
+and total input is ~55K tokens/request. It expands to two runs:
+
+- `shared_system` (`shared_system_prompt_length=50000`, 100% prefix reuse), and
+- a matched zero-prefix `baseline` (same 5K ISL / 500 OSL / c32) so the report's
+  *Uplift vs baseline* table isolates the TTFT P50/P90/P99 improvement
+  attributable to prefix caching.
+
+`request_count=256` (8 waves of 32) gives usable TTFT percentiles including a
+rough P99; bump it in
+[`llm_module/prefix_cache/manifest.json`](llm_module/prefix_cache/manifest.json)
+for a tighter P99. Pair it with `--prefix-cache-metrics-url` (below) so the
+worker `tt_prefix_cache_*` counters populate the hit-rate column:
+
+```bash
+python tt-inference-server-v2/run_prefix_cache.py \
+    --model <trillion-class-model> --workflow benchmarks --device tt \
+    --service-port 8000 --prefix-cache --prefix-cache-preset highcache_50k \
+    --prefix-cache-metrics-url <cpp_server-worker-host:port> \
+    --jwt-secret "$JWT_SECRET"
+```
 
 By default AIPerf auto-derives the `/metrics` scrape from the load target
 (`--service-port`). In a Dynamo deployment that target is the prefix-unaware

--- a/tt-inference-server-v2/llm_module/config.py
+++ b/tt-inference-server-v2/llm_module/config.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 from urllib.parse import urlparse
 
 
@@ -48,6 +48,13 @@ class ServerConnection:
     # repo (e.g. moonshotai/Kimi-* ships a custom tokenizer). Driven per
     # model from the spec metadata; off by default for safety.
     tokenizer_trust_remote_code: bool = False
+    # Extra Prometheus ``/metrics`` endpoints (cpp_server workers) scraped
+    # by AIPerf via ``--server-metrics``, independent of the load target
+    # in ``base_url``. Used by the prefix-cache benchmark to read the
+    # worker-side ``tt_prefix_cache_*`` counters in a Dynamo deployment
+    # where the frontend (load target) does not aggregate them. A tuple
+    # keeps this frozen dataclass hashable.
+    prefix_cache_metrics_urls: Tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if not self.tokenizer:

--- a/tt-inference-server-v2/llm_module/drivers/aiperf_prefix_cache.py
+++ b/tt-inference-server-v2/llm_module/drivers/aiperf_prefix_cache.py
@@ -34,7 +34,8 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+from urllib.parse import urlparse
 
 from ..config import DriverContext, ServerConnection
 from ..prefix_cache import PrefixCacheRun
@@ -42,14 +43,23 @@ from ._subprocess import load_json, run_command
 
 logger = logging.getLogger(__name__)
 
-# AIPerf 0.5 strips the canonical Prometheus ``_total`` suffix when it
-# writes ``server_metrics_export.jsonl``. Older AIPerf builds and raw
-# scrapes keep it. Accept both spellings.
+# Prefix-cache counter names vary by backend and AIPerf version:
+#   * cpp_server (Tenstorrent worker) exposes ``tt_prefix_cache_*_total``.
+#   * vLLM exposes ``vllm:prefix_cache_*_total``.
+#   * AIPerf 0.5 strips the canonical Prometheus ``_total`` suffix when it
+#     writes ``server_metrics_export.jsonl``; older builds / raw scrapes
+#     keep it.
+# We accept every spelling; ``_first_populated`` picks whichever series is
+# actually present in the scrape.
 PREFIX_CACHE_HITS_METRIC_ALIASES: Tuple[str, ...] = (
+    "tt_prefix_cache_hits_total",
+    "tt_prefix_cache_hits",
     "vllm:prefix_cache_hits_total",
     "vllm:prefix_cache_hits",
 )
 PREFIX_CACHE_QUERIES_METRIC_ALIASES: Tuple[str, ...] = (
+    "tt_prefix_cache_queries_total",
+    "tt_prefix_cache_queries",
     "vllm:prefix_cache_queries_total",
     "vllm:prefix_cache_queries",
 )
@@ -211,6 +221,7 @@ class AIPerfPrefixCacheDriver:
             artifact_dir=str(artifact_dir),
             auth_token=server.auth_token,
             tokenizer_trust_remote_code=server.tokenizer_trust_remote_code,
+            metrics_urls=server.prefix_cache_metrics_urls,
         )
         _log_run_header(prefix_run)
         logger.info("Executing: %s", " ".join(cmd))
@@ -292,6 +303,25 @@ class AIPerfPrefixCacheDriver:
 # ---------------------------------------------------------------------
 
 
+def _normalize_metrics_url(value: str) -> str:
+    """Normalize a worker metrics endpoint for AIPerf ``--server-metrics``.
+
+    Accepts a full URL, ``host:port``, or ``host:port/metrics`` and
+    returns a fully-qualified URL: prepends ``http://`` when no scheme is
+    present and appends ``/metrics`` when the URL has no path. A bare
+    hostname (no port) is passed through with a scheme but will only work
+    if the caller actually included a port -- there is no sane default
+    worker metrics port to assume in a Dynamo deployment.
+    """
+    candidate = value.strip()
+    if "://" not in candidate:
+        candidate = f"http://{candidate}"
+    parsed = urlparse(candidate)
+    if parsed.path in ("", "/"):
+        candidate = f"{candidate.rstrip('/')}/metrics"
+    return candidate
+
+
 def _build_aiperf_cmd(
     *,
     run: PrefixCacheRun,
@@ -302,8 +332,17 @@ def _build_aiperf_cmd(
     artifact_dir: str,
     auth_token: str,
     tokenizer_trust_remote_code: bool = False,
+    metrics_urls: Sequence[str] = (),
 ) -> List[str]:
     """Construct the AIPerf CLI command for one prefix-cache run.
+
+    ``metrics_urls`` are extra Prometheus ``/metrics`` endpoints
+    (cpp_server workers) forwarded to AIPerf via ``--server-metrics``.
+    AIPerf scrapes them independently of ``--url`` (the load target /
+    Dynamo frontend) and tags each exported series with ``endpoint_url``.
+    When empty, AIPerf falls back to auto-deriving ``/metrics`` from
+    ``--url`` (the prefix-unaware frontend), which is why the hit-rate
+    column is ``null`` without this flag in a Dynamo deployment.
 
     Two modes:
 
@@ -352,6 +391,15 @@ def _build_aiperf_cmd(
         "--server-metrics-formats",
         "jsonl",
     ]
+    # Point the scrape at the worker /metrics endpoint(s) holding the
+    # prefix-cache counters. Without this AIPerf auto-derives /metrics
+    # from --url (the frontend), which does not expose them. Repeatable
+    # for multi-worker (KV-routed) deployments; the parser sums across the
+    # endpoint_url-tagged series.
+    normalized_metrics_urls = [_normalize_metrics_url(u) for u in metrics_urls if u]
+    if normalized_metrics_urls:
+        cmd.append("--server-metrics")
+        cmd.extend(normalized_metrics_urls)
     # Required for tokenizers with custom Hub code (e.g. Kimi). Bare
     # store-true flag (aiperf defines it with negative=False).
     if tokenizer_trust_remote_code:
@@ -557,25 +605,36 @@ def _parse_aiperf_output(artifact_dir: Path) -> Dict[str, Any]:
     }
 
 
-def _collect_metric_samples(
-    server_metrics_path: Path,
-) -> Dict[str, List[float]]:
-    """Collect series of ``vllm:prefix_cache_*`` samples from JSONL scrape.
-
-    AIPerf writes one JSONL line per Prometheus scrape snapshot. AIPerf
-    0.5 nests the scrape under a top-level ``"metrics"`` key; older
-    shapes put metrics at the top level. We tolerate both, and we
-    tolerate both ``_total`` and stripped metric-name spellings.
-    """
-    series: Dict[str, List[float]] = {
+def _new_series_dict() -> Dict[str, List[float]]:
+    return {
         alias: []
         for alias in (
             *PREFIX_CACHE_HITS_METRIC_ALIASES,
             *PREFIX_CACHE_QUERIES_METRIC_ALIASES,
         )
     }
+
+
+def _collect_metric_samples(
+    server_metrics_path: Path,
+) -> Dict[str, Dict[str, List[float]]]:
+    """Collect prefix-cache sample series from a JSONL scrape, per endpoint.
+
+    AIPerf writes one JSONL line per Prometheus scrape snapshot, and one
+    snapshot per endpoint when several endpoints are configured via
+    ``--server-metrics``. Each line carries a top-level ``endpoint_url``
+    plus a ``metrics`` dict (AIPerf 0.5; older shapes put metrics at the
+    top level). We bucket samples by ``endpoint_url`` so multi-worker
+    (KV-routed) deltas can be computed per worker and summed -- a single
+    flat series would interleave workers and corrupt ``last - first``.
+
+    Returns ``{endpoint_url: {metric_alias: [samples...]}}``. A missing
+    ``endpoint_url`` (older single-endpoint exports) buckets under ``""``.
+    Both ``_total`` and stripped metric-name spellings are tolerated.
+    """
+    by_endpoint: Dict[str, Dict[str, List[float]]] = {}
     if not server_metrics_path.exists():
-        return series
+        return by_endpoint
 
     def _extract_numeric(payload: Any) -> Optional[float]:
         if isinstance(payload, (int, float)):
@@ -608,12 +667,18 @@ def _collect_metric_samples(
                     snapshot = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                endpoint = ""
+                if isinstance(snapshot, dict):
+                    endpoint = str(snapshot.get("endpoint_url", "") or "")
                 payload = (
                     snapshot["metrics"]
                     if isinstance(snapshot, dict)
                     and isinstance(snapshot.get("metrics"), dict)
                     else snapshot
                 )
+                if not isinstance(payload, dict):
+                    continue
+                series = by_endpoint.setdefault(endpoint, _new_series_dict())
                 for metric_name in series.keys():
                     if metric_name in payload:
                         value = _extract_numeric(payload[metric_name])
@@ -623,7 +688,7 @@ def _collect_metric_samples(
         logger.warning(
             "Could not read server-metrics file %s: %s", server_metrics_path, e
         )
-    return series
+    return by_endpoint
 
 
 def _parse_server_metrics_for_prefix_cache(
@@ -656,31 +721,50 @@ def _parse_server_metrics_for_prefix_cache(
         )
         return out
 
-    samples = _collect_metric_samples(server_metrics_path)
+    by_endpoint = _collect_metric_samples(server_metrics_path)
 
-    def _first_populated(aliases: Tuple[str, ...]) -> List[float]:
+    def _first_populated(
+        series: Mapping[str, List[float]], aliases: Tuple[str, ...]
+    ) -> List[float]:
         for alias in aliases:
-            series = samples.get(alias) or []
-            if series:
-                return series
+            values = series.get(alias) or []
+            if values:
+                return values
         return []
 
-    hits = _first_populated(PREFIX_CACHE_HITS_METRIC_ALIASES)
-    queries = _first_populated(PREFIX_CACHE_QUERIES_METRIC_ALIASES)
-    if not hits or not queries:
+    # Per worker (endpoint_url) compute last - first, then sum across
+    # workers so KV-routed multi-worker deployments aggregate correctly.
+    hits_delta = 0.0
+    queries_delta = 0.0
+    hits_final = 0.0
+    queries_final = 0.0
+    saw_hits = False
+    saw_queries = False
+    for series in by_endpoint.values():
+        hits = _first_populated(series, PREFIX_CACHE_HITS_METRIC_ALIASES)
+        queries = _first_populated(series, PREFIX_CACHE_QUERIES_METRIC_ALIASES)
+        if hits:
+            hits_delta += max(hits[-1] - hits[0], 0.0)
+            hits_final += hits[-1]
+            saw_hits = True
+        if queries:
+            queries_delta += max(queries[-1] - queries[0], 0.0)
+            queries_final += queries[-1]
+            saw_queries = True
+
+    if not saw_hits or not saw_queries:
         logger.warning(
-            "vLLM prefix-cache counters not present in %s. Hit rate "
-            "unavailable for this run.",
+            "Prefix-cache counters (tt_prefix_cache_* / vllm:prefix_cache_*) "
+            "not present in %s. Hit rate unavailable for this run. Verify "
+            "AIPerf --server-metrics points at the worker /metrics endpoint.",
             server_metrics_path,
         )
         return out
 
-    hits_delta = max(hits[-1] - hits[0], 0.0)
-    queries_delta = max(queries[-1] - queries[0], 0.0)
     out["prefix_cache_hits_delta"] = hits_delta
     out["prefix_cache_queries_delta"] = queries_delta
-    out["prefix_cache_hits_final"] = hits[-1]
-    out["prefix_cache_queries_final"] = queries[-1]
+    out["prefix_cache_hits_final"] = hits_final
+    out["prefix_cache_queries_final"] = queries_final
     out["prefix_cache_hit_rate"] = (
         (hits_delta / queries_delta) if queries_delta > 0 else 0.0
     )

--- a/tt-inference-server-v2/llm_module/prefix_cache/manifest.json
+++ b/tt-inference-server-v2/llm_module/prefix_cache/manifest.json
@@ -2,6 +2,14 @@
   "_comment": [
     "Opinionated prefix-caching benchmark scenarios run by --tools aiperf --prefix-cache.",
     "Each scenario produces multiple runs (cartesian product of concurrencies x arrivals x isl_profiles).",
+    "Presets:",
+    "  - ci            : tiny regression sweep.",
+    "  - full          : comprehensive serving-validation sweep.",
+    "  - highcache_50k : customer trillion-scale shape -- 50K shared (cacheable) prefix",
+    "                    + 5K new ISL + 500 OSL at concurrency 32. Steady-state KV-cache",
+    "                    hit-rate target ~90.9% = 50000/(50000+5000). Pairs shared_system",
+    "                    (100% reuse) with a matched zero-prefix baseline so the report",
+    "                    isolates the TTFT (P50/P90/P99) uplift from prefix caching.",
     "Scenarios:",
     "  - shared_system  : single shared system prompt (100% prefix reuse).",
     "  - prefix_pool    : pool of N distinct prefixes; reuse_ratio = request_count / N.",
@@ -122,6 +130,37 @@
             {"pattern": "poisson"},
             {"pattern": "gamma", "smoothness": 0.5}
           ]
+        },
+        "baseline": {
+          "arrival_patterns": [{"pattern": "constant"}]
+        }
+      }
+    },
+    "highcache_50k": {
+      "_comment": [
+        "Customer specific shape: 50K shared (cacheable) prefix +",
+        "5K new ISL + 500 OSL at concurrency 32 (one SC16 decode unit).",
+        "shared_system_prompt_length=50000 is sent as an identical system message",
+        "across every session (100% prefix reuse), so once warm the per-session KV",
+        "cache hit-rate is 50000/(50000+5000) = ~90.9% (>= the customer's 90% target).",
+        "isl_mean=5000 is the *new* per-request input; total ISL/request ~= 55000.",
+        "The matched zero-prefix baseline (same 5K ISL / 500 OSL / c32) isolates the",
+        "TTFT P50/P90/P99 uplift attributable to prefix caching.",
+        "request_count=256 (8 waves of 32) gives usable TTFT percentiles incl. a rough",
+        "P99; bump it for a tighter P99. Scrape the worker tt_prefix_cache_* counters",
+        "with --prefix-cache-metrics-url to populate the hit-rate column."
+      ],
+      "request_count": 256,
+      "concurrencies": [32],
+      "isl_profiles": [
+        {"name": "new5k", "isl_mean": 5000, "isl_stddev": 0}
+      ],
+      "osl_mean": 500,
+      "osl_stddev": 0,
+      "scenarios": {
+        "shared_system": {
+          "shared_system_prompt_length": 50000,
+          "arrival_patterns": [{"pattern": "constant"}]
         },
         "baseline": {
           "arrival_patterns": [{"pattern": "constant"}]

--- a/tt-inference-server-v2/report_module/prefix_cache_renderer.py
+++ b/tt-inference-server-v2/report_module/prefix_cache_renderer.py
@@ -247,9 +247,13 @@ def render_aiperf_prefix_cache(block: Block, metadata: Mapping[str, Any]) -> str
         "**Benchmarking Tool:** "
         "[AIPerf](https://github.com/ai-dynamo/aiperf) with the "
         "`--prefix-cache` scenario set. Cache hit-rate is derived from the "
-        "vLLM Prometheus counters `vllm:prefix_cache_hits_total` / "
-        "`vllm:prefix_cache_queries_total` scraped during each run via "
-        "AIPerf's `--server-metrics`."
+        "worker Prometheus counters `tt_prefix_cache_hits_total` / "
+        "`tt_prefix_cache_queries_total` (or the vLLM "
+        "`vllm:prefix_cache_*` equivalents) scraped during each run via "
+        "AIPerf's `--server-metrics`. In a Dynamo deployment point "
+        "`--prefix-cache-metrics-url` at the cpp_server worker(s); the "
+        "prefix-unaware frontend does not aggregate these counters. "
+        "Multi-worker deltas are summed across endpoints."
     )
 
     if synthetic_rows:

--- a/tt-inference-server-v2/run.py
+++ b/tt-inference-server-v2/run.py
@@ -205,12 +205,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--prefix-cache-preset",
         type=str,
-        choices=["ci", "full"],
+        choices=["ci", "full", "highcache_50k"],
         default="full",
         help=(
             "Preset for --prefix-cache (default: full). 'ci' is a short "
             "regression-friendly sweep, 'full' is the comprehensive serving "
-            "validation sweep."
+            "validation sweep, 'highcache_50k' simulates the customer "
+            "trillion-scale shape (50K shared/cacheable prefix + 5K new ISL + "
+            "500 OSL at concurrency 32; ~90.9%% steady-state hit-rate) with a "
+            "matched zero-prefix baseline for TTFT-uplift comparison."
         ),
     )
     parser.add_argument(

--- a/tt-inference-server-v2/run.py
+++ b/tt-inference-server-v2/run.py
@@ -262,6 +262,25 @@ def parse_args() -> argparse.Namespace:
             "https://github.com/ai-dynamo/aiperf/blob/main/docs/tutorials/prefix-synthesis.md"
         ),
     )
+    parser.add_argument(
+        "--prefix-cache-metrics-url",
+        type=str,
+        action="append",
+        default=None,
+        metavar="URL",
+        help=(
+            "Worker Prometheus /metrics endpoint holding the "
+            "tt_prefix_cache_* counters, forwarded to AIPerf as "
+            "--server-metrics. Load still targets --service-port (the "
+            "Dynamo frontend); this only redirects the metrics scrape to "
+            "the cpp_server worker, which the prefix-unaware frontend does "
+            "not aggregate. Accepts a full URL, host:port, or "
+            "host:port/metrics (http:// and /metrics are added if missing). "
+            "Repeat for multi-worker (KV-routed) deployments; the parser "
+            "sums hit/query deltas across endpoints. Without it the scrape "
+            "hits the frontend and the hit-rate column is null."
+        ),
+    )
     # ----- Speculative-decoding benchmark (LLM-only) ------------------
     # When --spec-decode is set, BenchmarksWorkflow swaps its default
     # media-task dispatch for the AIPerf SPEED-Bench spec-decode sweep (wired

--- a/tt-inference-server-v2/test_module/llm_tests/prefix_cache_tests.py
+++ b/tt-inference-server-v2/test_module/llm_tests/prefix_cache_tests.py
@@ -69,6 +69,7 @@ def run_prefix_cache(
     scenarios_json: Optional[str] = None,
     trace_path: Optional[str] = None,
     auth_token: str = "",
+    metrics_urls: Sequence[str] = (),
     venv_python: Optional[Path] = None,
     server_controller: Optional[ServerController] = None,
     output_subdir: str = "prefix_cache",
@@ -88,6 +89,13 @@ def run_prefix_cache(
     auth_token:
         Bearer token sent to the inference server (JWT, OPENAI_API_KEY).
         Empty string disables auth.
+    metrics_urls:
+        Extra Prometheus ``/metrics`` endpoints (cpp_server workers)
+        scraped by AIPerf via ``--server-metrics`` for the
+        ``tt_prefix_cache_*`` counters, independent of the load target.
+        Repeatable for multi-worker (KV-routed) deployments. Empty keeps
+        AIPerf's auto-derived ``/metrics`` from ``ctx.server_host`` (the
+        Dynamo frontend), which does not expose the counters.
     venv_python:
         Python interpreter that has ``aiperf`` installed. Falls back to
         ``sys.executable``.
@@ -164,6 +172,7 @@ def run_prefix_cache(
         tokenizer=model_repo,
         auth_token=auth_token,
         tokenizer_trust_remote_code=tokenizer_trust_remote_code,
+        prefix_cache_metrics_urls=tuple(metrics_urls or ()),
     )
     context = DriverContext(output_dir=output_root, device=device_label)
 

--- a/tt-inference-server-v2/tests/llm_module/test_aiperf_prefix_cache_driver.py
+++ b/tt-inference-server-v2/tests/llm_module/test_aiperf_prefix_cache_driver.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for the prefix-cache AIPerf driver's worker-metrics wiring.
+
+Covers the benchmark-side fix for scraping ``tt_prefix_cache_*`` counters
+off the cpp_server worker (not the prefix-unaware Dynamo frontend):
+
+* ``_normalize_metrics_url`` URL handling.
+* ``_build_aiperf_cmd`` emitting ``--server-metrics`` while keeping load
+  on the frontend ``--url``.
+* ``_parse_server_metrics_for_prefix_cache`` recognizing the ``tt_`` names
+  and summing hit/query deltas across ``endpoint_url``-tagged series.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from llm_module.drivers.aiperf_prefix_cache import (
+    _build_aiperf_cmd,
+    _normalize_metrics_url,
+    _parse_server_metrics_for_prefix_cache,
+)
+from llm_module.prefix_cache import PrefixCacheRun
+
+
+def _synthetic_run() -> PrefixCacheRun:
+    return PrefixCacheRun(
+        scenario="baseline",
+        label="baseline_isl128_c1_constant",
+        isl_mean=128,
+        isl_stddev=0,
+        osl_mean=128,
+        osl_stddev=0,
+        concurrency=1,
+        request_count=8,
+        arrival_pattern="constant",
+    )
+
+
+class TestNormalizeMetricsUrl:
+    def test_bare_host_port_gets_scheme_and_metrics_path(self):
+        assert (
+            _normalize_metrics_url("worker-a:9000")
+            == "http://worker-a:9000/metrics"
+        )
+
+    def test_existing_path_is_preserved(self):
+        assert (
+            _normalize_metrics_url("worker-a:9000/metrics")
+            == "http://worker-a:9000/metrics"
+        )
+
+    def test_full_url_passed_through(self):
+        assert (
+            _normalize_metrics_url("https://host.example.com:8443/metrics")
+            == "https://host.example.com:8443/metrics"
+        )
+
+    def test_root_path_is_replaced_with_metrics(self):
+        assert _normalize_metrics_url("http://h:9000/") == "http://h:9000/metrics"
+
+    def test_whitespace_is_trimmed(self):
+        assert _normalize_metrics_url("  h:9000 ") == "http://h:9000/metrics"
+
+
+class TestBuildAiperfCmd:
+    def test_server_metrics_emitted_for_each_worker(self):
+        cmd = _build_aiperf_cmd(
+            run=_synthetic_run(),
+            venv_python=Path("/tmp/venv/bin/python"),
+            model_name="m",
+            tokenizer="m",
+            url="http://dynamo-frontend:8000",
+            artifact_dir="/tmp/art",
+            auth_token="",
+            metrics_urls=("worker-a:9000", "worker-b:9000/metrics"),
+        )
+        # Load target (frontend) is untouched.
+        assert cmd[cmd.index("--url") + 1] == "http://dynamo-frontend:8000"
+        # --server-metrics carries both normalized worker endpoints, in order.
+        idx = cmd.index("--server-metrics")
+        assert cmd[idx + 1] == "http://worker-a:9000/metrics"
+        assert cmd[idx + 2] == "http://worker-b:9000/metrics"
+        # JSONL export stays pinned so the parser can read it.
+        assert cmd[cmd.index("--server-metrics-formats") + 1] == "jsonl"
+
+    def test_server_metrics_omitted_when_no_workers(self):
+        cmd = _build_aiperf_cmd(
+            run=_synthetic_run(),
+            venv_python=Path("/tmp/venv/bin/python"),
+            model_name="m",
+            tokenizer="m",
+            url="http://dynamo-frontend:8000",
+            artifact_dir="/tmp/art",
+            auth_token="",
+        )
+        assert "--server-metrics" not in cmd
+
+    def test_blank_worker_urls_are_skipped(self):
+        cmd = _build_aiperf_cmd(
+            run=_synthetic_run(),
+            venv_python=Path("/tmp/venv/bin/python"),
+            model_name="m",
+            tokenizer="m",
+            url="http://dynamo-frontend:8000",
+            artifact_dir="/tmp/art",
+            auth_token="",
+            metrics_urls=("", "worker-a:9000"),
+        )
+        idx = cmd.index("--server-metrics")
+        assert cmd[idx + 1] == "http://worker-a:9000/metrics"
+        # Only the one real endpoint follows the flag (next token is a flag).
+        assert cmd[idx + 2].startswith("--")
+
+
+def _write_jsonl(path: Path, lines: list) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for obj in lines:
+            f.write(json.dumps(obj) + "\n")
+
+
+class TestParseServerMetrics:
+    def test_tt_counters_single_worker(self, tmp_path):
+        jsonl = tmp_path / "server_metrics_export.jsonl"
+        url = "http://worker-a:9000/metrics"
+        _write_jsonl(
+            jsonl,
+            [
+                {
+                    "endpoint_url": url,
+                    "metrics": {
+                        "tt_prefix_cache_hits_total": [{"value": 10.0}],
+                        "tt_prefix_cache_queries_total": [{"value": 20.0}],
+                    },
+                },
+                {
+                    "endpoint_url": url,
+                    "metrics": {
+                        "tt_prefix_cache_hits_total": [{"value": 40.0}],
+                        "tt_prefix_cache_queries_total": [{"value": 60.0}],
+                    },
+                },
+            ],
+        )
+        out = _parse_server_metrics_for_prefix_cache(tmp_path)
+        # delta = last - first: hits 30, queries 40 -> 0.75
+        assert out["prefix_cache_hits_delta"] == 30.0
+        assert out["prefix_cache_queries_delta"] == 40.0
+        assert out["prefix_cache_hit_rate"] == 0.75
+        assert out["prefix_cache_hits_final"] == 40.0
+        assert out["prefix_cache_queries_final"] == 60.0
+
+    def test_sums_deltas_across_endpoints(self, tmp_path):
+        jsonl = tmp_path / "server_metrics_export.jsonl"
+        a = "http://worker-a:9000/metrics"
+        b = "http://worker-b:9000/metrics"
+        # Lines interleave the two workers, as AIPerf writes one line per
+        # endpoint per scrape. A flat last-first would be nonsensical;
+        # per-endpoint deltas must be summed.
+        _write_jsonl(
+            jsonl,
+            [
+                {
+                    "endpoint_url": a,
+                    "metrics": {
+                        "tt_prefix_cache_hits_total": [{"value": 0.0}],
+                        "tt_prefix_cache_queries_total": [{"value": 0.0}],
+                    },
+                },
+                {
+                    "endpoint_url": b,
+                    "metrics": {
+                        "tt_prefix_cache_hits_total": [{"value": 100.0}],
+                        "tt_prefix_cache_queries_total": [{"value": 100.0}],
+                    },
+                },
+                {
+                    "endpoint_url": a,
+                    "metrics": {
+                        "tt_prefix_cache_hits_total": [{"value": 30.0}],
+                        "tt_prefix_cache_queries_total": [{"value": 50.0}],
+                    },
+                },
+                {
+                    "endpoint_url": b,
+                    "metrics": {
+                        "tt_prefix_cache_hits_total": [{"value": 170.0}],
+                        "tt_prefix_cache_queries_total": [{"value": 150.0}],
+                    },
+                },
+            ],
+        )
+        out = _parse_server_metrics_for_prefix_cache(tmp_path)
+        # worker A delta: hits 30, queries 50; worker B delta: hits 70,
+        # queries 50. Summed: hits 100, queries 100 -> 1.0.
+        assert out["prefix_cache_hits_delta"] == 100.0
+        assert out["prefix_cache_queries_delta"] == 100.0
+        assert out["prefix_cache_hit_rate"] == 1.0
+
+    def test_missing_counters_returns_nulls(self, tmp_path):
+        jsonl = tmp_path / "server_metrics_export.jsonl"
+        _write_jsonl(
+            jsonl,
+            [
+                {
+                    "endpoint_url": "http://frontend:8000/metrics",
+                    "metrics": {"vllm:num_requests_running": [{"value": 1.0}]},
+                }
+            ],
+        )
+        out = _parse_server_metrics_for_prefix_cache(tmp_path)
+        assert out["prefix_cache_hit_rate"] is None
+        assert out["prefix_cache_hits_delta"] is None

--- a/tt-inference-server-v2/tests/llm_module/test_prefix_cache_scenarios.py
+++ b/tt-inference-server-v2/tests/llm_module/test_prefix_cache_scenarios.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for prefix-cache scenario/preset expansion.
+
+Focuses on the ``highcache_50k`` preset, which encodes the customer
+trillion-scale traffic shape: a 50K shared (cacheable) system prefix plus a
+5K new ISL and 500 OSL at concurrency 32. The cacheable fraction of each
+warm request is ``50000 / (50000 + 5000) = ~90.9%``, matching the customer's
+>= 90% per-session KV-cache hit-rate requirement.
+"""
+
+from __future__ import annotations
+
+from llm_module.prefix_cache import build_runs
+
+
+def _run_by_scenario(preset: str):
+    return {r.scenario: r for r in build_runs(preset=preset)}
+
+
+def test_highcache_50k_shared_system_shape():
+    runs = build_runs(preset="highcache_50k")
+    by_scenario = {r.scenario: r for r in runs}
+
+    assert set(by_scenario) == {"shared_system", "baseline"}
+
+    shared = by_scenario["shared_system"]
+    assert shared.shared_system_prompt_length == 50000
+    assert shared.isl_mean == 5000
+    assert shared.osl_mean == 500
+    assert shared.concurrency == 32
+    assert shared.arrival_pattern == "constant"
+    assert shared.request_count == 256
+
+
+def test_highcache_50k_hit_rate_is_at_least_90_percent():
+    shared = _run_by_scenario("highcache_50k")["shared_system"]
+    cacheable = shared.shared_system_prompt_length
+    total = shared.shared_system_prompt_length + shared.isl_mean
+    steady_state_hit_rate = cacheable / total
+    assert steady_state_hit_rate >= 0.90
+
+
+def test_highcache_50k_baseline_matches_load_minus_prefix():
+    by_scenario = _run_by_scenario("highcache_50k")
+    shared = by_scenario["shared_system"]
+    baseline = by_scenario["baseline"]
+
+    # The baseline isolates the TTFT uplift from caching: same new ISL / OSL /
+    # concurrency, but no shared (cacheable) prefix.
+    assert baseline.shared_system_prompt_length is None
+    assert baseline.isl_mean == shared.isl_mean
+    assert baseline.osl_mean == shared.osl_mean
+    assert baseline.concurrency == shared.concurrency

--- a/tt-inference-server-v2/tests/workflow_module/test_command_factory.py
+++ b/tt-inference-server-v2/tests/workflow_module/test_command_factory.py
@@ -86,6 +86,7 @@ class TestPrefixCacheOptions:
             prefix_cache_request_rate=4.0,
             prefix_cache_scenarios_json=None,
             prefix_cache_trace=None,
+            prefix_cache_metrics_url=["worker-a:9000", "worker-b:9000/metrics"],
             jwt_secret=None,
         )
         opts = cf._build_prefix_cache_options(args)
@@ -95,6 +96,28 @@ class TestPrefixCacheOptions:
         assert opts.arrival_pattern == "poisson"
         assert opts.request_rate == 4.0
         assert opts.auth_token == ""  # no secret -> auth disabled
+        # Repeatable --prefix-cache-metrics-url -> tuple, forwarded verbatim
+        # (normalization happens later in the driver).
+        assert opts.metrics_urls == ("worker-a:9000", "worker-b:9000/metrics")
+
+    def test_metrics_urls_default_empty_when_flag_absent(self, monkeypatch):
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        # No prefix_cache_metrics_url attr at all (image-model entry path).
+        args = Namespace(
+            prefix_cache=True,
+            prefix_cache_preset="ci",
+            prefix_cache_scenarios=None,
+            prefix_cache_arrival=None,
+            prefix_cache_request_rate=None,
+            prefix_cache_scenarios_json=None,
+            prefix_cache_trace=None,
+            jwt_secret=None,
+        )
+        opts = cf._build_prefix_cache_options(args)
+        assert opts is not None
+        assert opts.metrics_urls == ()
 
 
 class TestLLMEvalOptions:

--- a/tt-inference-server-v2/workflow_module/command_factory.py
+++ b/tt-inference-server-v2/workflow_module/command_factory.py
@@ -256,6 +256,7 @@ def _build_prefix_cache_options(
         scenarios_json=args.prefix_cache_scenarios_json,
         trace_path=args.prefix_cache_trace,
         auth_token=_mint_jwt_if_secret(args.jwt_secret),
+        metrics_urls=tuple(getattr(args, "prefix_cache_metrics_url", None) or ()),
     )
 
 

--- a/tt-inference-server-v2/workflow_module/execution.py
+++ b/tt-inference-server-v2/workflow_module/execution.py
@@ -81,6 +81,11 @@ class PrefixCacheOptions:
     scenarios_json: Optional[str] = None
     trace_path: Optional[str] = None
     auth_token: str = ""
+    # Worker /metrics endpoints scraped by AIPerf (--server-metrics) for
+    # the prefix-cache counters, independent of the load target. Repeatable
+    # for multi-worker deployments. Empty keeps AIPerf's auto-derived
+    # /metrics from --url (the frontend), which lacks the counters.
+    metrics_urls: Tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/tt-inference-server-v2/workflow_module/workflows.py
+++ b/tt-inference-server-v2/workflow_module/workflows.py
@@ -244,6 +244,7 @@ class BenchmarksWorkflow(WorkflowExecution):
                 scenarios_json=opts.scenarios_json,
                 trace_path=opts.trace_path,
                 auth_token=opts.auth_token,
+                metrics_urls=opts.metrics_urls,
             ),
         )
 

--- a/workflows/runtime_config.py
+++ b/workflows/runtime_config.py
@@ -76,6 +76,7 @@ class RuntimeConfig:
     prefix_cache_request_rate: Optional[float] = None
     prefix_cache_scenarios_json: Optional[str] = None
     prefix_cache_trace: Optional[str] = None
+    prefix_cache_metrics_url: Optional[List[str]] = None
     jwt_secret: Optional[str] = None
     serving_bench_suites: Optional[str] = None
 
@@ -162,6 +163,7 @@ class RuntimeConfig:
                 args, "prefix_cache_scenarios_json", None
             ),
             prefix_cache_trace=getattr(args, "prefix_cache_trace", None),
+            prefix_cache_metrics_url=getattr(args, "prefix_cache_metrics_url", None),
             jwt_secret=getattr(args, "jwt_secret", None),
             serving_bench_suites=getattr(args, "serving_bench_suites", None),
             spec_decode=getattr(args, "spec_decode", False),

--- a/workflows/v2_bridge.py
+++ b/workflows/v2_bridge.py
@@ -379,6 +379,8 @@ def _build_prefix_cache_cmd(v2_dir, model_spec, runtime_config, json_fpath, outp
         cmd, "--prefix-cache-scenarios-json", runtime_config.prefix_cache_scenarios_json
     )
     _extend_if_set(cmd, "--prefix-cache-trace", runtime_config.prefix_cache_trace)
+    for metrics_url in getattr(runtime_config, "prefix_cache_metrics_url", None) or []:
+        _extend_if_set(cmd, "--prefix-cache-metrics-url", metrics_url)
     _forward_jwt(cmd, runtime_config)
     return cmd
 


### PR DESCRIPTION
## Problem
The v2 prefix-cache benchmark's **hit-rate column was always `null`**. Root cause: in a Dynamo deployment, AIPerf was scraping Prometheus metrics off the **frontend** (the load target), but the frontend is prefix-unaware and doesn't aggregate the prefix-cache counters. Those counters (`tt_prefix_cache_hits_total` / `tt_prefix_cache_queries_total`) live only on the **`cpp_server` workers**.

## What we changed

**1. New repeatable `--prefix-cache-metrics-url` flag**
- Lets you point the metrics scrape at the actual worker `/metrics` endpoint(s), independent of where load is sent (load still targets `--service-port` / the frontend).
- Forwarded to AIPerf as `--server-metrics`.
- A normalizer (`_normalize_metrics_url`) accepts a full URL, `host:port`, or `host:port/metrics`, adding `http://` and `/metrics` if missing, and preserving HTTPS.
- Repeatable for multi-worker (KV-routed) deployments.
- Wired end-to-end through the same v1→v2 bridge path the goodput flag later used: v1 `run.py` → `runtime_config` → `v2_bridge` → v2 `run.py` → `command_factory`/`PrefixCacheOptions` → `run_prefix_cache` → driver.

**2. Parser update for the worker counters**
- Taught the prefix-cache parser to recognize the `tt_prefix_cache_*` metric names (alongside the vLLM `vllm:prefix_cache_*` names).
- AIPerf tags each exported series with `endpoint_url`, so the parser **sums hit/query deltas across all worker endpoints** before computing the hit-rate — correct for multi-worker setups.

**3. Tests + docs**
- Driver tests for URL normalization, `--server-metrics` emission (load stays on the frontend), and summing `tt_` counters across one and multiple `endpoint_url`-tagged series.
- README updated to explain the frontend-vs-worker scrape distinction and the `--prefix-cache-metrics-url` usage.