### PR TITLE
Increase default runner timeouts

### DIFF
--- a/tt-media-server/cpp_server/DEPLOYMENT.md
+++ b/tt-media-server/cpp_server/DEPLOYMENT.md
@@ -344,8 +344,8 @@ roughly an hour.
 
 | Variable                 | Default | Description                                                                                              |
 | ------------------------ | ------- | -------------------------------------------------------------------------------------------------------- |
-| `WARMUP_TIMEOUT_MS`      | `3600000` | Max wait for the first token during runner warmup.                                                     |
-| `OUTPUT_HANG_TIMEOUT_MS` | `3600000` | Max gap with no model output (while a request is in flight) before the worker self-terminates.          |
+| `WARMUP_TIMEOUT_MS`      | `120000` | Max wait for the first token during runner warmup.                                                     |
+| `OUTPUT_HANG_TIMEOUT_MS` | `120000` | Max gap with no model output (while a request is in flight) before the worker self-terminates.          |
 | `PM_CONNECT_TIMEOUT_MS`  | `30000` | Pipeline manager connect timeout. Must be large enough to ride out runner startup.                       |
 
 ### Shared memory and IPC

--- a/tt-media-server/cpp_server/DEPLOYMENT.md
+++ b/tt-media-server/cpp_server/DEPLOYMENT.md
@@ -345,7 +345,7 @@ roughly an hour.
 | Variable                 | Default | Description                                                                                              |
 | ------------------------ | ------- | -------------------------------------------------------------------------------------------------------- |
 | `WARMUP_TIMEOUT_MS`      | `10000` | Max wait for the first token during runner warmup.                                                       |
-| `OUTPUT_HANG_TIMEOUT_MS` | `60000` | Max gap with no model output (while a request is in flight) before the worker self-terminates.           |
+| `OUTPUT_HANG_TIMEOUT_MS` | `120000` | Max gap with no model output (while a request is in flight) before the worker self-terminates.          |
 | `PM_CONNECT_TIMEOUT_MS`  | `30000` | Pipeline manager connect timeout. Must be large enough to ride out runner startup.                       |
 
 ### Shared memory and IPC

--- a/tt-media-server/cpp_server/DEPLOYMENT.md
+++ b/tt-media-server/cpp_server/DEPLOYMENT.md
@@ -344,8 +344,8 @@ roughly an hour.
 
 | Variable                 | Default | Description                                                                                              |
 | ------------------------ | ------- | -------------------------------------------------------------------------------------------------------- |
-| `WARMUP_TIMEOUT_MS`      | `10000` | Max wait for the first token during runner warmup.                                                       |
-| `OUTPUT_HANG_TIMEOUT_MS` | `120000` | Max gap with no model output (while a request is in flight) before the worker self-terminates.          |
+| `WARMUP_TIMEOUT_MS`      | `3600000` | Max wait for the first token during runner warmup.                                                     |
+| `OUTPUT_HANG_TIMEOUT_MS` | `3600000` | Max gap with no model output (while a request is in flight) before the worker self-terminates.          |
 | `PM_CONNECT_TIMEOUT_MS`  | `30000` | Pipeline manager connect timeout. Must be large enough to ride out runner startup.                       |
 
 ### Shared memory and IPC

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -87,7 +87,7 @@ constexpr unsigned WARMUP_TIMEOUT_MS = 10000;
  * process. Self-terminating lets the infrastructure monitoring stack notice
  * the crash and restart the server instead of hanging silently.
  */
-constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 60000;
+constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 120000;
 
 constexpr const char* MODEL = "deepseek-ai/DeepSeek-R1-0528";
 constexpr const char* WIRE_FORMAT = "blaze";

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -80,14 +80,14 @@ constexpr uint32_t MODEL_NUM_LAYERS = 61;
 constexpr uint32_t PREFILL_CHUNK_SIZE = 5120;
 constexpr unsigned PM_CONNECT_TIMEOUT_MS = 30000;
 constexpr size_t PM_MAX_USERS = 128;
-constexpr unsigned WARMUP_TIMEOUT_MS = 10000;
+constexpr unsigned WARMUP_TIMEOUT_MS = 3600000;
 /**
  * Max time (ms) the runner may go without producing a model output while at
  * least one request is in flight before it self-terminates the worker
  * process. Self-terminating lets the infrastructure monitoring stack notice
  * the crash and restart the server instead of hanging silently.
  */
-constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 120000;
+constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 3600000;
 
 constexpr const char* MODEL = "deepseek-ai/DeepSeek-R1-0528";
 constexpr const char* WIRE_FORMAT = "blaze";

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -80,14 +80,14 @@ constexpr uint32_t MODEL_NUM_LAYERS = 61;
 constexpr uint32_t PREFILL_CHUNK_SIZE = 5120;
 constexpr unsigned PM_CONNECT_TIMEOUT_MS = 30000;
 constexpr size_t PM_MAX_USERS = 128;
-constexpr unsigned WARMUP_TIMEOUT_MS = 3600000;
+constexpr unsigned WARMUP_TIMEOUT_MS = 120000;
 /**
  * Max time (ms) the runner may go without producing a model output while at
  * least one request is in flight before it self-terminates the worker
  * process. Self-terminating lets the infrastructure monitoring stack notice
  * the crash and restart the server instead of hanging silently.
  */
-constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 3600000;
+constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 120000;
 
 constexpr const char* MODEL = "deepseek-ai/DeepSeek-R1-0528";
 constexpr const char* WIRE_FORMAT = "blaze";


### PR DESCRIPTION
Raises the default WARMUP_TIMEOUT_MS and OUTPUT_HANG_TIMEOUT_MS to 120000 ms so slower or long-context models have enough time for warmup and TTFT/decode progress before the worker is considered stalled.
