### PR TITLE
Remove Unused Migrate Full KV Env Var

### DIFF
--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -48,7 +48,6 @@ constexpr size_t KV_CACHE_BLOCK_SIZE = 32;
 constexpr size_t KV_CACHE_FIRST_BLOCK_SIZE = 128;
 constexpr unsigned PREFIX_CACHE_HIT_THRESHOLD = 40;
 constexpr bool USE_FAST_MODE = false;
-constexpr bool MIGRATE_FULL_KV = false;
 constexpr bool ENABLE_MIGRATION = false;
 constexpr const char* MIGRATION_CMD_QUEUE_NAME = "mig_ep0_cmd";
 constexpr const char* MIGRATION_TABLE_QUEUE_NAME = "mig_ep0_table";

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -228,10 +228,6 @@ uint32_t modelNumLayers();
  * defaults::PREFILL_CHUNK_SIZE. */
 uint32_t prefillChunkSize();
 
-/** Migrate full KV from MIGRATE_FULL_KV. Default:
- * defaults::MIGRATE_FULL_KV. */
-bool migrateFullKV();
-
 /** Enable migration from ENABLE_MIGRATION. Default:
  * defaults::ENABLE_MIGRATION. */
 bool enableMigration();

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -238,10 +238,6 @@ std::string blazeSocketDescriptorPrefix() {
   return cached;
 }
 
-bool migrateFullKV() {
-  return envBool("MIGRATE_FULL_KV", defaults::MIGRATE_FULL_KV);
-}
-
 unsigned pmConnectTimeoutMs() {
   return static_cast<unsigned>(
       envUlong("PM_CONNECT_TIMEOUT_MS", defaults::PM_CONNECT_TIMEOUT_MS));


### PR DESCRIPTION
## Problem
We had an unused `MIGRATE_FULL_KV` env variable