### PR TITLE
Fix slot copy selecting threshold-rejected prefix candidates

### DIFF
--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -628,6 +628,7 @@ SessionManager::tryAcquireByPrefixHash(
 
   const float threshold = tt::config::prefixCacheHitThreshold();
   bool anyBusy = false;
+  std::vector<Candidate> copyCandidates;
   for (const auto& candidate : candidates) {
     // Check if match percentage meets threshold (skip if below).
     if (threshold > 0.0f) {
@@ -685,7 +686,10 @@ SessionManager::tryAcquireByPrefixHash(
       return acquired;
     }
 
-    anyBusy |= busy;
+    if (busy) {
+      anyBusy = true;
+      copyCandidates.push_back(candidate);
+    }
   }
 
   if (anyBusy) {
@@ -698,9 +702,8 @@ SessionManager::tryAcquireByPrefixHash(
       "[SessionManager] tryAcquireByPrefixHash: no acquirable session for "
       "keyHash={}",
       keyHash);
-  // Return candidates sorted by matched tokens descending even though no
-  // session was acquired
-  return AcquiredSession{false, {}, 0, 0, 0, std::move(candidates)};
+  // Return only threshold-accepted busy candidates for slot-copy planning.
+  return AcquiredSession{false, {}, 0, 0, 0, std::move(copyCandidates)};
 }
 
 namespace {

--- a/tt-media-server/cpp_server/tests/integration/sessions/session_manager_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/sessions/session_manager_test.cpp
@@ -7,6 +7,7 @@
 #include <trantor/net/EventLoop.h>
 
 #include <atomic>
+#include <cstdlib>
 #include <string>
 #include <thread>
 #include <vector>
@@ -391,6 +392,78 @@ TEST(SessionManagerConcurrency,
     EXPECT_LE(cancelCount.load(), 1) << "iteration " << i;
     EXPECT_EQ(manager.getActiveSessionCount(), 0u) << "iteration " << i;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Prefix-cache slot-copy tests
+// ---------------------------------------------------------------------------
+
+TEST(SessionManagerPrefixCache,
+     SlotCopySkipsThresholdRejectedBusyCandidate) {
+  tt::services::SessionManager manager;
+  LoopFixture lf;
+
+  auto makeBlocks = [](size_t count) {
+    std::vector<tt::utils::BlockHashInfo> blocks;
+    blocks.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+      blocks.push_back({static_cast<uint64_t>(1000 + i), 0});
+    }
+    return blocks;
+  };
+
+  // Mirrors the issue #4401 log shape: a short request fully matches the first
+  // 35 blocks of a much longer busy session (35/1283 = 2.7%, below threshold),
+  // while a second busy source is a qualifying copy candidate.
+  auto rejectedBlocks = makeBlocks(1283);
+  std::vector<tt::utils::BlockHashInfo> requestBlocks(
+      rejectedBlocks.begin(), rejectedBlocks.begin() + 35);
+  std::vector<tt::utils::BlockHashInfo> qualifyingBlocks(
+      rejectedBlocks.begin(), rejectedBlocks.begin() + 34);
+
+  auto rejectedSessionId =
+      createSessionWithSlot(manager, lf.loop, 2u, rejectedBlocks);
+  auto qualifyingSessionId =
+      createSessionWithSlot(manager, lf.loop, 3u, qualifyingBlocks);
+  ASSERT_FALSE(rejectedSessionId.empty());
+  ASSERT_FALSE(qualifyingSessionId.empty());
+
+  manager.setResidentPrefixBlocks(rejectedSessionId, rejectedBlocks.size());
+  manager.setResidentPrefixBlocks(qualifyingSessionId,
+                                  qualifyingBlocks.size());
+  acquireInFlight(manager, rejectedSessionId);
+  acquireInFlight(manager, qualifyingSessionId);
+
+  const char* previousThreshold = std::getenv("PREFIX_CACHE_HIT_THRESHOLD");
+  const std::string previousValue =
+      previousThreshold == nullptr ? "" : previousThreshold;
+  setenv("PREFIX_CACHE_HIT_THRESHOLD", "40", 1);
+
+  auto acquired = manager.tryAcquireByPrefixHash(requestBlocks, nullptr);
+  if (!acquired.has_value()) {
+    ADD_FAILURE() << "busy prefix candidates should be returned for slot-copy "
+                     "evaluation";
+  } else {
+    EXPECT_FALSE(acquired->sessionFound);
+    auto copyCandidate = manager.findASlotToCopyFrom(acquired->candidatesList);
+    if (!copyCandidate.has_value()) {
+      ADD_FAILURE()
+          << "the qualifying busy session should still be eligible for slot "
+             "copy";
+    } else {
+      EXPECT_EQ(copyCandidate->sessionId, qualifyingSessionId)
+          << "slot copy must not use a prefix candidate rejected by "
+             "PREFIX_CACHE_HIT_THRESHOLD";
+    }
+  }
+
+  if (previousThreshold == nullptr) {
+    unsetenv("PREFIX_CACHE_HIT_THRESHOLD");
+  } else {
+    setenv("PREFIX_CACHE_HIT_THRESHOLD", previousValue.c_str(), 1);
+  }
+  manager.getSession(rejectedSessionId)->release();
+  manager.getSession(qualifyingSessionId)->release();
 }
 
 // ---------------------------------------------------------------------------

--- a/tt-media-server/cpp_server/tests/integration/sessions/session_manager_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/sessions/session_manager_test.cpp
@@ -412,9 +412,7 @@ TEST(SessionManagerPrefixCache,
     return blocks;
   };
 
-  // Mirrors the issue #4401 log shape: a short request fully matches the first
-  // 35 blocks of a much longer busy session (35/1283 = 2.7%, below threshold),
-  // while a second busy source is a qualifying copy candidate.
+  // Issue #4401 shape: 35/1283 blocks is below the 40% hit threshold.
   auto rejectedBlocks = makeBlocks(1283);
   std::vector<tt::utils::BlockHashInfo> requestBlocks(
       rejectedBlocks.begin(), rejectedBlocks.begin() + 35);
@@ -423,16 +421,10 @@ TEST(SessionManagerPrefixCache,
 
   auto rejectedSessionId =
       createSessionWithSlot(manager, lf.loop, 2u, rejectedBlocks);
-  auto qualifyingSessionId =
-      createSessionWithSlot(manager, lf.loop, 3u, qualifyingBlocks);
   ASSERT_FALSE(rejectedSessionId.empty());
-  ASSERT_FALSE(qualifyingSessionId.empty());
 
   manager.setResidentPrefixBlocks(rejectedSessionId, rejectedBlocks.size());
-  manager.setResidentPrefixBlocks(qualifyingSessionId,
-                                  qualifyingBlocks.size());
   acquireInFlight(manager, rejectedSessionId);
-  acquireInFlight(manager, qualifyingSessionId);
 
   const char* previousThreshold = std::getenv("PREFIX_CACHE_HIT_THRESHOLD");
   const std::string previousValue =
@@ -441,19 +433,32 @@ TEST(SessionManagerPrefixCache,
 
   auto acquired = manager.tryAcquireByPrefixHash(requestBlocks, nullptr);
   if (!acquired.has_value()) {
-    ADD_FAILURE() << "busy prefix candidates should be returned for slot-copy "
-                     "evaluation";
+    ADD_FAILURE() << "busy prefix candidates should be returned";
+  } else {
+    EXPECT_FALSE(acquired->sessionFound);
+    EXPECT_FALSE(manager.findASlotToCopyFrom(acquired->candidatesList))
+        << "threshold-rejected candidates must not be copy sources";
+  }
+
+  auto qualifyingSessionId =
+      createSessionWithSlot(manager, lf.loop, 3u, qualifyingBlocks);
+  ASSERT_FALSE(qualifyingSessionId.empty());
+  manager.setResidentPrefixBlocks(qualifyingSessionId,
+                                  qualifyingBlocks.size());
+  acquireInFlight(manager, qualifyingSessionId);
+
+  acquired = manager.tryAcquireByPrefixHash(requestBlocks, nullptr);
+  if (!acquired.has_value()) {
+    ADD_FAILURE() << "valid busy candidates should be returned";
   } else {
     EXPECT_FALSE(acquired->sessionFound);
     auto copyCandidate = manager.findASlotToCopyFrom(acquired->candidatesList);
     if (!copyCandidate.has_value()) {
       ADD_FAILURE()
-          << "the qualifying busy session should still be eligible for slot "
-             "copy";
+          << "the threshold-valid busy session should remain copy-eligible";
     } else {
       EXPECT_EQ(copyCandidate->sessionId, qualifyingSessionId)
-          << "slot copy must not use a prefix candidate rejected by "
-             "PREFIX_CACHE_HIT_THRESHOLD";
+          << "slot copy must skip the threshold-rejected session";
     }
   }
 

--- a/tt-media-server/cpp_server/tests/integration/sessions/session_manager_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/sessions/session_manager_test.cpp
@@ -398,8 +398,7 @@ TEST(SessionManagerConcurrency,
 // Prefix-cache slot-copy tests
 // ---------------------------------------------------------------------------
 
-TEST(SessionManagerPrefixCache,
-     SlotCopySkipsThresholdRejectedBusyCandidate) {
+TEST(SessionManagerPrefixCache, SlotCopySkipsThresholdRejectedBusyCandidate) {
   tt::services::SessionManager manager;
   LoopFixture lf;
 
@@ -443,8 +442,7 @@ TEST(SessionManagerPrefixCache,
   auto qualifyingSessionId =
       createSessionWithSlot(manager, lf.loop, 3u, qualifyingBlocks);
   ASSERT_FALSE(qualifyingSessionId.empty());
-  manager.setResidentPrefixBlocks(qualifyingSessionId,
-                                  qualifyingBlocks.size());
+  manager.setResidentPrefixBlocks(qualifyingSessionId, qualifyingBlocks.size());
   acquireInFlight(manager, qualifyingSessionId);
 
   acquired = manager.tryAcquireByPrefixHash(requestBlocks, nullptr);


### PR DESCRIPTION
Fixes a slot-copy bug where prefix-cache candidates rejected by PREFIX_CACHE_HIT_THRESHOLD could still be used as copy sources when all matching sessions were in flight.

Adds a regression test reproducing the issue shape from #4401 and verifies slot-copy planning only considers threshold-accepted busy candidates.
