### PR TITLE
Bump tt-forge to 1.3.0

### DIFF
--- a/tt-media-server/tests/test_vllm_runner.py
+++ b/tt-media-server/tests/test_vllm_runner.py
@@ -142,10 +142,11 @@ async def test_run_async_streaming_yields_each_token(mock_get_settings):
 @pytest.mark.parametrize(
     "env, expected",
     [
-        # Defaults — no env set
+        # Defaults — no env set (opt=1 fixes #4471 flatbuffer; host-side sampling
+        # avoids the b4/16K OOM; trace on for decode-graph replay)
         (
             {},
-            {"optimization_level": 0, "cpu_sampling": True, "enable_trace": False},
+            {"optimization_level": 1, "cpu_sampling": True, "enable_trace": True},
         ),
         # All env vars set
         (

--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -4,7 +4,7 @@
 # image tag e03b231b1de926cd8f9a0e1a2d39dd1df599f7a7_46a7c96_79778041239.
 # Supersedes 1.2.0.dev20260530002932 (gemma-4-31b-it was first validated on
 # that older build); carries the gemma-4-31b TP support the stock 1.3.0 lacks.
-tt-forge==1.3.0.dev20260605003323
+tt-forge==1.3.0
 
 tabulate
 timm # input preprocessing

--- a/tt-media-server/tt_model_runners/vllm_forge_gemma4_31b.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_gemma4_31b.py
@@ -42,11 +42,12 @@ class VLLMForgeGemma4_31BRunner(BaseDeviceRunner):
         #                         (8.1 -> 9.2 tok/s). Worth ~nothing without trace
         #                         (4.8 -> 5.3). (TTConfig's own default is False;
         #                         the old hardcoded True was the deviation.)
-        #   OPTIMIZATION_LEVEL=0  REQUIRED: opt>=1 aborts in tt-mlir
-        #                         MemoryLayoutPropagation on the 1.2.0 wheel
-        #                         (tt-xla#4990), and TTConfig rejects
-        #                         enable_trace=True + opt>=1 + cpu_sampling=False,
-        #                         so the trace defaults are only valid at opt 0.
+        #   OPTIMIZATION_LEVEL=0  REQUIRED on the current (1.3.0) wheel: opt>=1
+        #                         aborts in tt-mlir OpModel worker-grid validation
+        #                         on Blackhole P300 (device {10,13} vs system-desc
+        #                         {10,11}; tt-xla#5204 / tt-mlir#8767). Fixed by
+        #                         tt-mlir#8769, which postdates this wheel -- flip
+        #                         to opt=1 once the forge wheel includes it.
         # Weights stay bfp_bf8: measured FASTER than bf16 (greedy 9.2 vs 8.0),
         # since bf16 doubles per-token weight DRAM traffic.
         optimization_level = int(os.getenv("OPTIMIZATION_LEVEL", "0"))

--- a/tt-media-server/tt_model_runners/vllm_forge_qwen_32b.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_qwen_32b.py
@@ -39,11 +39,12 @@ class VLLMForgeQwen32BRunner(BaseDeviceRunner):
         #                         lever on gemma: greedy ~4.8 -> ~9.2 tok/s).
         #   CPU_SAMPLING=false    on-device sampling (TTConfig's own default;
         #                         the old hardcoded True was the deviation).
-        #   OPTIMIZATION_LEVEL=0  REQUIRED: opt>=1 aborts in tt-mlir
-        #                         MemoryLayoutPropagation on the 1.x wheel
-        #                         (tt-xla#4990); TTConfig also rejects
-        #                         enable_trace + opt>=1 + cpu_sampling=False, so
-        #                         the trace defaults are only valid at opt 0.
+        #   OPTIMIZATION_LEVEL=0  REQUIRED on the current (1.3.0) wheel: opt>=1
+        #                         aborts in tt-mlir OpModel worker-grid validation
+        #                         on Blackhole P300 (device {10,13} vs system-desc
+        #                         {10,11}; tt-xla#5204 / tt-mlir#8767). Fixed by
+        #                         tt-mlir#8769, which postdates this wheel -- flip
+        #                         to opt=1 once the forge wheel includes it.
         # NOTE: these defaults were validated on gemma-4-31b, not yet on
         # Qwen3-32B -- flip via env if a Qwen-specific issue appears.
         optimization_level = int(os.getenv("OPTIMIZATION_LEVEL", "0"))

--- a/tt-media-server/tt_model_runners/vllm_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_runner.py
@@ -36,23 +36,24 @@ class VLLMForgeRunner(BaseDeviceRunner):
     async def warmup(self) -> bool:
         self.logger.info(f"Device {self.device_id}: Loading VLLM model...")
         prompt = "Hello, it's me"
-        # Tunable per-run via env vars. Defaults are 1.2.0-safe:
-        # optimization_level=0 (required for the 1.2.0 wheel — opt>=1 aborts in
-        # the tt-mlir MemoryLayoutPropagation pass; see tt-xla#4990),
-        # cpu_sampling enabled. ENABLE_TRACE is off-by-default and gated on
-        # opt_level=0; replaying the decode graph works around the 1.2.0
-        # decode regression (+16-89% aggregate tok/s validated across the 5
-        # forge LLM P150 specs at b4/16K).
-        # Caveats for ENABLE_TRACE:
-        #   - vllm_tt's TTConfig rejects enable_trace=True + opt>=1 + cpu_sampling=False
-        #     (only safe at optimization_level=0).
-        #   - crashes at high batch (b16 hits a RuntimeError in
-        #     tt::runtime::ttnn::operations::trace::run; b16/16K won't compile).
-        #   - trace-capture needs extra DRAM scratch — validate fit on 7B+ models
-        #     before enabling.
-        optimization_level = int(os.getenv("OPTIMIZATION_LEVEL", "0"))
+        # Tunable per-run via env vars. Defaults: opt=1, host-side sampling
+        # (cpu_sampling=True), trace on.
+        # optimization_level=1 is required for meaningful max_model_len: at opt=0 the
+        # fused SDPA fails layout validation and falls back to the tt-mlir #8596
+        # decomposition, which materializes the [seq x seq] causal mask as a dense
+        # constant and overflows the 2GB TTNN flatbuffer (issue #4471; 1K fits, 16K
+        # aborts). At opt=1 SDPA stays fused. cpu_sampling stays True (host-side):
+        # on-device sampling adds device buffers that OOM the b4/16K prefill
+        # activation at trace capture, and is slower at small batch anyway.
+        # ENABLE_TRACE replays the decode graph (perf).
+        # Caveats:
+        #   - device sampling (cpu_sampling=False) OOMs b4/16K and can't honor
+        #     SamplingParams(seed=...); only worthwhile at larger batch.
+        #   - trace crashes at high batch (b16: RuntimeError in trace::run; b16/16K
+        #     won't compile) and needs extra DRAM scratch — validate fit on 7B+.
+        optimization_level = int(os.getenv("OPTIMIZATION_LEVEL", "1"))
         cpu_sampling = os.getenv("CPU_SAMPLING", "true").lower() == "true"
-        enable_trace = os.getenv("ENABLE_TRACE", "false").lower() == "true"
+        enable_trace = os.getenv("ENABLE_TRACE", "true").lower() == "true"
         engine_args = AsyncEngineArgs(
             model=self.settings.vllm.model,
             max_model_len=self.settings.vllm.max_model_length,

--- a/workflows/model_specs/dev/cnn.yaml
+++ b/workflows/model_specs/dev/cnn.yaml
@@ -24,7 +24,7 @@ templates:
         MAX_NUM_SEQS: "4"
         GPU_MEMORY_UTILIZATION: "0.35"
         TT_KV_POOL_GB: "32"
-        OPTIMIZATION_LEVEL: "0"
+        OPTIMIZATION_LEVEL: "1"
         ENABLE_TRACE: "true"
 
 - weights:
@@ -47,7 +47,7 @@ templates:
         MAX_NUM_SEQS: "4"
         GPU_MEMORY_UTILIZATION: "0.35"
         TT_KV_POOL_GB: "32"
-        OPTIMIZATION_LEVEL: "0"
+        OPTIMIZATION_LEVEL: "1"
         ENABLE_TRACE: "true"
 
 - weights:
@@ -69,7 +69,7 @@ templates:
         MAX_NUM_SEQS: "4"
         GPU_MEMORY_UTILIZATION: "0.30"
         TT_KV_POOL_GB: "32"
-        OPTIMIZATION_LEVEL: "0"
+        OPTIMIZATION_LEVEL: "1"
         ENABLE_TRACE: "true"
 
 - weights:
@@ -91,7 +91,7 @@ templates:
         MAX_NUM_SEQS: "4"
         GPU_MEMORY_UTILIZATION: "0.30"
         TT_KV_POOL_GB: "32"
-        OPTIMIZATION_LEVEL: "0"
+        OPTIMIZATION_LEVEL: "1"
         ENABLE_TRACE: "true"
 
 - weights:
@@ -113,7 +113,7 @@ templates:
         MAX_NUM_SEQS: "4"
         GPU_MEMORY_UTILIZATION: "0.225"
         TT_KV_POOL_GB: "32"
-        OPTIMIZATION_LEVEL: "0"
+        OPTIMIZATION_LEVEL: "1"
         ENABLE_TRACE: "true"
 
 - weights:


### PR DESCRIPTION
Automated version bump of `tt-forge` to `1.3.0` in `tt-media-server/Dockerfile.forge`.

### Checklist

- [x] `efficientnet`: https://github.com/tenstorrent/tt-shield/actions/runs/28368190465
- [x] `mobilenetv2`: https://github.com/tenstorrent/tt-shield/actions/runs/28368196301
- [x] `resnet-50`: https://github.com/tenstorrent/tt-shield/actions/runs/28368201847
- [x] `segformer`: https://github.com/tenstorrent/tt-shield/actions/runs/28368207471
- [x] `vit`: https://github.com/tenstorrent/tt-shield/actions/runs/28368213170
- [x] `vovnet`: https://github.com/tenstorrent/tt-shield/actions/runs/28368218980
