### PR TITLE
Scale output hang timeout for long prompts

### DIFF
--- a/tt-media-server/cpp_server/DEPLOYMENT.md
+++ b/tt-media-server/cpp_server/DEPLOYMENT.md
@@ -344,8 +344,8 @@ roughly an hour.
 
 | Variable                 | Default | Description                                                                                              |
 | ------------------------ | ------- | -------------------------------------------------------------------------------------------------------- |
-| `WARMUP_TIMEOUT_MS`      | `3600000` | Max wait for the first token during runner warmup.                                                     |
-| `OUTPUT_HANG_TIMEOUT_MS` | `3600000` | Max gap with no model output (while a request is in flight) before the worker self-terminates.          |
+| `WARMUP_TIMEOUT_MS`      | `120000` | Max wait for the first token during runner warmup.                                                     |
+| `OUTPUT_HANG_TIMEOUT_MS` | `120000` | Max gap with no model output (while a request is in flight) before the worker self-terminates.          |
 | `PM_CONNECT_TIMEOUT_MS`  | `30000` | Pipeline manager connect timeout. Must be large enough to ride out runner startup.                       |
 
 ### Shared memory and IPC

--- a/tt-media-server/cpp_server/DEPLOYMENT.md
+++ b/tt-media-server/cpp_server/DEPLOYMENT.md
@@ -345,7 +345,7 @@ roughly an hour.
 | Variable                 | Default | Description                                                                                              |
 | ------------------------ | ------- | -------------------------------------------------------------------------------------------------------- |
 | `WARMUP_TIMEOUT_MS`      | `10000` | Max wait for the first token during runner warmup.                                                       |
-| `OUTPUT_HANG_TIMEOUT_MS` | `60000` | Max gap with no model output (while a request is in flight) before the worker self-terminates.           |
+| `OUTPUT_HANG_TIMEOUT_MS` | `120000` | Max gap with no model output (while a request is in flight) before the worker self-terminates.          |
 | `PM_CONNECT_TIMEOUT_MS`  | `30000` | Pipeline manager connect timeout. Must be large enough to ride out runner startup.                       |
 
 ### Shared memory and IPC

--- a/tt-media-server/cpp_server/DEPLOYMENT.md
+++ b/tt-media-server/cpp_server/DEPLOYMENT.md
@@ -344,8 +344,8 @@ roughly an hour.
 
 | Variable                 | Default | Description                                                                                              |
 | ------------------------ | ------- | -------------------------------------------------------------------------------------------------------- |
-| `WARMUP_TIMEOUT_MS`      | `10000` | Max wait for the first token during runner warmup.                                                       |
-| `OUTPUT_HANG_TIMEOUT_MS` | `120000` | Max gap with no model output (while a request is in flight) before the worker self-terminates.          |
+| `WARMUP_TIMEOUT_MS`      | `3600000` | Max wait for the first token during runner warmup.                                                     |
+| `OUTPUT_HANG_TIMEOUT_MS` | `3600000` | Max gap with no model output (while a request is in flight) before the worker self-terminates.          |
 | `PM_CONNECT_TIMEOUT_MS`  | `30000` | Pipeline manager connect timeout. Must be large enough to ride out runner startup.                       |
 
 ### Shared memory and IPC

--- a/tt-media-server/cpp_server/DEPLOYMENT.md
+++ b/tt-media-server/cpp_server/DEPLOYMENT.md
@@ -342,11 +342,13 @@ hardware takes a long time, so production deployments typically set
 `PM_CONNECT_TIMEOUT_MS` to several hours and `WARMUP_TIMEOUT_MS` to
 roughly an hour.
 
-| Variable                 | Default | Description                                                                                              |
-| ------------------------ | ------- | -------------------------------------------------------------------------------------------------------- |
-| `WARMUP_TIMEOUT_MS`      | `120000` | Max wait for the first token during runner warmup.                                                     |
-| `OUTPUT_HANG_TIMEOUT_MS` | `120000` | Max gap with no model output (while a request is in flight) before the worker self-terminates.          |
-| `PM_CONNECT_TIMEOUT_MS`  | `30000` | Pipeline manager connect timeout. Must be large enough to ride out runner startup.                       |
+| Variable                                      | Default   | Description                                                                                                  |
+| --------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------ |
+| `WARMUP_TIMEOUT_MS`                           | `120000`  | Max wait for the first token during runner warmup.                                                           |
+| `OUTPUT_HANG_TIMEOUT_MS`                      | `120000`  | Minimum max gap with no model output before the worker self-terminates. Long prompts can extend this value. |
+| `OUTPUT_HANG_TIMEOUT_MAX_MS`                  | `3600000` | Cap for the dynamic no-output timeout.                                                                       |
+| `OUTPUT_HANG_MIN_PREFILL_TOKENS_PER_SECOND`   | `100`     | Lower-bound aggregate prefill throughput used to estimate long-prompt no-output timeout.                     |
+| `PM_CONNECT_TIMEOUT_MS`                       | `30000`   | Pipeline manager connect timeout. Must be large enough to ride out runner startup.                           |
 
 ### Shared memory and IPC
 

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -82,12 +82,14 @@ constexpr unsigned PM_CONNECT_TIMEOUT_MS = 30000;
 constexpr size_t PM_MAX_USERS = 128;
 constexpr unsigned WARMUP_TIMEOUT_MS = 120000;
 /**
- * Max time (ms) the runner may go without producing a model output while at
- * least one request is in flight before it self-terminates the worker
- * process. Self-terminating lets the infrastructure monitoring stack notice
- * the crash and restart the server instead of hanging silently.
+ * Minimum time (ms) the runner may go without producing a model output while
+ * at least one request is in flight before it self-terminates the worker
+ * process. Long prompts can extend this dynamically up to
+ * OUTPUT_HANG_TIMEOUT_MAX_MS.
  */
 constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 120000;
+constexpr unsigned OUTPUT_HANG_TIMEOUT_MAX_MS = 3600000;
+constexpr unsigned OUTPUT_HANG_MIN_PREFILL_TOKENS_PER_SECOND = 100;
 
 constexpr const char* MODEL = "deepseek-ai/DeepSeek-R1-0528";
 constexpr const char* WIRE_FORMAT = "blaze";

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -87,7 +87,7 @@ constexpr unsigned WARMUP_TIMEOUT_MS = 10000;
  * process. Self-terminating lets the infrastructure monitoring stack notice
  * the crash and restart the server instead of hanging silently.
  */
-constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 60000;
+constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 120000;
 
 constexpr const char* MODEL = "deepseek-ai/DeepSeek-R1-0528";
 constexpr const char* WIRE_FORMAT = "blaze";

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -80,14 +80,14 @@ constexpr uint32_t MODEL_NUM_LAYERS = 61;
 constexpr uint32_t PREFILL_CHUNK_SIZE = 5120;
 constexpr unsigned PM_CONNECT_TIMEOUT_MS = 30000;
 constexpr size_t PM_MAX_USERS = 128;
-constexpr unsigned WARMUP_TIMEOUT_MS = 10000;
+constexpr unsigned WARMUP_TIMEOUT_MS = 3600000;
 /**
  * Max time (ms) the runner may go without producing a model output while at
  * least one request is in flight before it self-terminates the worker
  * process. Self-terminating lets the infrastructure monitoring stack notice
  * the crash and restart the server instead of hanging silently.
  */
-constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 120000;
+constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 3600000;
 
 constexpr const char* MODEL = "deepseek-ai/DeepSeek-R1-0528";
 constexpr const char* WIRE_FORMAT = "blaze";

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -80,14 +80,14 @@ constexpr uint32_t MODEL_NUM_LAYERS = 61;
 constexpr uint32_t PREFILL_CHUNK_SIZE = 5120;
 constexpr unsigned PM_CONNECT_TIMEOUT_MS = 30000;
 constexpr size_t PM_MAX_USERS = 128;
-constexpr unsigned WARMUP_TIMEOUT_MS = 3600000;
+constexpr unsigned WARMUP_TIMEOUT_MS = 120000;
 /**
  * Max time (ms) the runner may go without producing a model output while at
  * least one request is in flight before it self-terminates the worker
  * process. Self-terminating lets the infrastructure monitoring stack notice
  * the crash and restart the server instead of hanging silently.
  */
-constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 3600000;
+constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 120000;
 
 constexpr const char* MODEL = "deepseek-ai/DeepSeek-R1-0528";
 constexpr const char* WIRE_FORMAT = "blaze";

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -264,10 +264,20 @@ std::string prefillAckChannelName();
  * From WARMUP_TIMEOUT_MS. Default: defaults::WARMUP_TIMEOUT_MS. */
 unsigned warmupTimeoutMs();
 
-/** Max time (ms) without any model output while at least one request is in
- * flight before the runner self-terminates the worker process. From
- * OUTPUT_HANG_TIMEOUT_MS. Default: defaults::OUTPUT_HANG_TIMEOUT_MS. */
+/** Minimum time (ms) without any model output while at least one request is in
+ * flight before the runner self-terminates the worker process. Long prompts
+ * can extend this dynamically. From OUTPUT_HANG_TIMEOUT_MS. Default:
+ * defaults::OUTPUT_HANG_TIMEOUT_MS. */
 unsigned outputHangTimeoutMs();
+
+/** Max dynamic output hang timeout (ms). From OUTPUT_HANG_TIMEOUT_MAX_MS.
+ * Default: defaults::OUTPUT_HANG_TIMEOUT_MAX_MS. */
+unsigned outputHangTimeoutMaxMs();
+
+/** Assumed lower-bound aggregate prefill throughput used to estimate dynamic
+ * output hang timeouts. From OUTPUT_HANG_MIN_PREFILL_TOKENS_PER_SECOND.
+ * Default: defaults::OUTPUT_HANG_MIN_PREFILL_TOKENS_PER_SECOND. */
+unsigned outputHangMinPrefillTokensPerSecond();
 
 /** Task queue name from TT_TASK_QUEUE. Default: defaults::TT_TASK_QUEUE. */
 std::string ttTaskQueueName();

--- a/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_slot_manager.hpp
+++ b/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_slot_manager.hpp
@@ -41,6 +41,7 @@ class SlotManager {
       ss << " specAcceptsAtStart=" << slots[i].specAcceptsAtStart << "\n";
       ss << " specRejectsAtStart=" << slots[i].specRejectsAtStart << "\n";
       ss << " tokensGenerated=" << slots[i].tokensGenerated << "\n";
+      ss << " promptTokens=" << slots[i].promptTokens << "\n";
       ss << "----------------------------------------\n";
     }
     return ss.str();
@@ -54,6 +55,7 @@ class SlotManager {
     slot.specAcceptsAtStart = 0;
     slot.specRejectsAtStart = 0;
     slot.tokensGenerated = 0;
+    slot.promptTokens = 0;
     slot.pendingAckRequestId.reset();
     slot.deferredEvict.reset();
     slot.deferredContinue.reset();
@@ -106,6 +108,7 @@ class SlotManager {
     slotContext.specAcceptsAtStart = 0;
     slotContext.specRejectsAtStart = 0;
     slotContext.tokensGenerated = 0;
+    slotContext.promptTokens = 0;
     slotContext.pendingAckRequestId.reset();
     setSlotState(slotId, SlotState::IDLE);
   }

--- a/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_types.hpp
+++ b/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_types.hpp
@@ -5,6 +5,7 @@
 
 #include <cassert>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -49,6 +50,7 @@ struct SlotContext {
   uint32_t specAcceptsAtStart = 0;
   uint32_t specRejectsAtStart = 0;
   uint32_t tokensGenerated = 0;
+  size_t promptTokens = 0;
   std::optional<uint32_t> pendingAckRequestId = std::nullopt;
   std::optional<ds::ISRequest> deferredEvict = std::nullopt;
   std::unique_ptr<tt::domain::llm::Sequence> deferredContinue = nullptr;

--- a/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_utils.hpp
+++ b/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_utils.hpp
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -55,6 +57,29 @@ namespace tt::runners::blaze::utils {
 namespace sch = tt_llm_engine::scheduler;
 namespace ds = sch::decode;
 namespace ps = sch::prefill;
+
+inline std::chrono::milliseconds dynamicOutputHangTimeout(
+    size_t promptTokens, uint32_t activeUsers,
+    std::chrono::milliseconds minTimeout) {
+  const auto configuredMax =
+      std::chrono::milliseconds(tt::config::outputHangTimeoutMaxMs());
+  const auto maxTimeout = std::max(minTimeout, configuredMax);
+  const auto minPrefillTokensPerSecond =
+      tt::config::outputHangMinPrefillTokensPerSecond();
+  if (promptTokens == 0 || activeUsers == 0 ||
+      minPrefillTokensPerSecond == 0) {
+    return minTimeout;
+  }
+
+  const uint64_t tokenWork =
+      static_cast<uint64_t>(promptTokens) * static_cast<uint64_t>(activeUsers);
+  const uint64_t estimatedMs =
+      (tokenWork * 1000 + minPrefillTokensPerSecond - 1) /
+      minPrefillTokensPerSecond;
+  const auto estimatedTimeout =
+      std::chrono::milliseconds(static_cast<int64_t>(estimatedMs));
+  return std::clamp(estimatedTimeout, minTimeout, maxTimeout);
+}
 
 inline void logISRequest(const sch::ISRequest& req) {
   const sch::GenerationParams& gen = req.gen;
@@ -192,6 +217,7 @@ inline void initSlotForRun(SlotContext& slot,
   slot.specRejectsAtStart = sched.get_spec_rejects(slot.slotId);
   slot.taskId = seq.taskId;
   slot.tokensGenerated = 0;
+  slot.promptTokens = seq.getNumPromptTokens();
 }
 
 // Populates per-run fields on `slot` from `seq`. Snapshots the slot's spec
@@ -202,6 +228,7 @@ inline void initSlotForRun(SlotContext& slot,
   slot.ignoreEos = seq.getSamplingParams().ignore_eos;
   slot.taskId = seq.taskId;
   slot.tokensGenerated = 0;
+  slot.promptTokens = seq.getNumPromptTokens();
 }
 
 struct SpecDelta {

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -261,6 +261,17 @@ unsigned outputHangTimeoutMs() {
       envUlong("OUTPUT_HANG_TIMEOUT_MS", defaults::OUTPUT_HANG_TIMEOUT_MS));
 }
 
+unsigned outputHangTimeoutMaxMs() {
+  return static_cast<unsigned>(envUlong("OUTPUT_HANG_TIMEOUT_MAX_MS",
+                                        defaults::OUTPUT_HANG_TIMEOUT_MAX_MS));
+}
+
+unsigned outputHangMinPrefillTokensPerSecond() {
+  return static_cast<unsigned>(envUlong(
+      "OUTPUT_HANG_MIN_PREFILL_TOKENS_PER_SECOND",
+      defaults::OUTPUT_HANG_MIN_PREFILL_TOKENS_PER_SECOND));
+}
+
 std::string ttTaskQueueName() {
   return envString("TT_TASK_QUEUE", defaults::TT_TASK_QUEUE);
 }

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_decode_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_decode_runner.cpp
@@ -684,6 +684,7 @@ void BlazeDecodeRunner::handleSchedulerOutput(const ds::OutputMessage& output) {
 
 void BlazeDecodeRunner::checkOutputHang() {
   auto currentTime = std::chrono::steady_clock::now();
+  auto activeUsers = slotManager.activeRunningCount();
 
   for (const auto& slot : slotManager.getSlots()) {
     const char* hangKind = nullptr;
@@ -704,20 +705,26 @@ void BlazeDecodeRunner::checkOutputHang() {
 
     auto stalledFor = std::chrono::duration_cast<std::chrono::milliseconds>(
         currentTime - slot.lastProgressTime);
-    if (stalledFor <= outputHangTimeout) {
+    auto promptTokensForTimeout =
+        (slot.state == SlotState::RUNNING && slot.tokensGenerated == 0)
+            ? slot.promptTokens
+            : 0;
+    auto threshold = utils::dynamicOutputHangTimeout(
+        promptTokensForTimeout, activeUsers, outputHangTimeout);
+    if (stalledFor <= threshold) {
       continue;
     }
 
     TT_LOG_CRITICAL(
         "[BlazeRunner] Hang detected on Slot {} in state {}: {} for {} ms "
-        "(threshold {} ms). Total in-flight generations: {}. "
+        "(threshold {} ms, timeoutPromptTokens={}, activeUsers={}). "
         "Self-terminating worker for infrastructure restart.",
-        slot.slotId,                        // Which slot broke?
-        toString(slot.state),               // What was it waiting on?
-        hangKind,                           // Human-readable cause
-        stalledFor.count(),                 // How bad is it?
-        outputHangTimeout.count(),          // What was the limit?
-        slotManager.activeRunningCount());  // Global context
+        slot.slotId,           // Which slot broke?
+        toString(slot.state),  // What was it waiting on?
+        hangKind,              // Human-readable cause
+        stalledFor.count(),    // How bad is it?
+        threshold.count(),     // What was the dynamic limit?
+        promptTokensForTimeout, activeUsers);
 
     TT_LOG_CRITICAL("[BlazeRunner] State dump\n{}",
                     slotManager.dumpSlotStates());

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_prefill_runner.cpp
@@ -3,6 +3,7 @@
 
 #include "runtime/runners/blaze_runner/blaze_prefill_runner.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdlib>
@@ -675,17 +676,24 @@ void BlazePrefillRunner::checkOutputHang() {
     lastOutputTime = std::chrono::steady_clock::now();
     return;
   }
+  size_t maxPromptTokens = 0;
+  for (const auto& slot : slotManager.getSlots()) {
+    if (slot.state == SlotState::RUNNING) {
+      maxPromptTokens = std::max(maxPromptTokens, slot.promptTokens);
+    }
+  }
   auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - lastOutputTime);
-  if (elapsed <= outputHangTimeout) {
+  auto threshold = utils::dynamicOutputHangTimeout(
+      maxPromptTokens, runningCount, outputHangTimeout);
+  if (elapsed <= threshold) {
     return;
   }
   TT_LOG_CRITICAL(
       "[BlazePrefillRunner] Output hang detected: no model output for {} ms "
-      "with {} "
-      "in-flight generation(s) (threshold={} ms). Self-terminating worker so "
-      "infrastructure can restart the server.",
-      elapsed.count(), runningCount, outputHangTimeout.count());
+      "with {} in-flight generation(s) (threshold={} ms, maxPromptTokens={}). "
+      "Self-terminating worker so infrastructure can restart the server.",
+      elapsed.count(), runningCount, threshold.count(), maxPromptTokens);
   std::abort();
 }
 


### PR DESCRIPTION
Dynamically scales the output hang timeout based on prompt length and active users, while keeping `OUTPUT_HANG_TIMEOUT_MS` as the minimum threshold.
Adds a configurable max cap and assumed minimum prefill throughput so long-context/high-concurrency requests can avoid false hang detection without disabling fast failure for smaller requests.
