### PR TITLE
fix: update benchmark_configs.py to use build_benchmark_config

### DIFF
--- a/tt-inference-server-v2/llm_module/benchmark_configs.py
+++ b/tt-inference-server-v2/llm_module/benchmark_configs.py
@@ -2,7 +2,7 @@
 #
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-"""Build the LLM benchmark sweep from ``BENCHMARK_CONFIGS``."""
+"""Build the LLM benchmark sweep from the model spec."""
 
 from __future__ import annotations
 
@@ -28,18 +28,13 @@ def get_llm_configs(
     ``limit_samples_mode`` honours v1's smoke-test selection when set.
     """
     from benchmarking.benchmark_config import (
-        BENCHMARK_CONFIGS,
+        build_benchmark_config,
         select_smoke_test_benchmark_config,
     )
     from workflows.workflow_types import EvalLimitMode
 
     model_id = model_spec.model_id
-    benchmark_config = BENCHMARK_CONFIGS.get(model_id)
-    if benchmark_config is None:
-        raise ValueError(
-            f"No benchmark sweep defined for model_id={model_id!r} in "
-            "BENCHMARK_CONFIGS. The model must have a v1 benchmark config."
-        )
+    benchmark_config = build_benchmark_config(model_spec)
 
     if (
         limit_samples_mode
@@ -54,7 +49,7 @@ def get_llm_configs(
         available = sorted(getattr(dev, "name", str(dev)) for dev in configured_devices)
         raise ValueError(
             f"No benchmark params for device={getattr(device, 'name', device)!r} "
-            f"in BENCHMARK_CONFIGS[{model_id!r}]. Configured devices: {available}."
+            f"in benchmark config for model_id={model_id!r}. Configured devices: {available}."
         )
 
     configs: List[LLMRunConfig] = []


### PR DESCRIPTION
PR #4345 replaced `BENCHMARK_CONFIGS` (a module-level dict) with `build_benchmark_config(model_spec)` in `benchmarking/benchmark_config.py`, but `tt-inference-server-v2/llm_module/benchmark_configs.py` was not updated, leaving a broken import that caused `ImportError` in the benchmark phase of release workflows (8 acceptance check failures).