### PR TITLE
Fix v2 LLM benchmark config lookup

### DIFF
--- a/tt-inference-server-v2/llm_module/benchmark_configs.py
+++ b/tt-inference-server-v2/llm_module/benchmark_configs.py
@@ -2,7 +2,7 @@
 #
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-"""Build the LLM benchmark sweep from ``BENCHMARK_CONFIGS``."""
+"""Build the LLM benchmark sweep from the resolved runtime model spec."""
 
 from __future__ import annotations
 
@@ -28,18 +28,12 @@ def get_llm_configs(
     ``limit_samples_mode`` honours v1's smoke-test selection when set.
     """
     from benchmarking.benchmark_config import (
-        BENCHMARK_CONFIGS,
+        get_benchmark_config,
         select_smoke_test_benchmark_config,
     )
     from workflows.workflow_types import EvalLimitMode
 
-    model_id = model_spec.model_id
-    benchmark_config = BENCHMARK_CONFIGS.get(model_id)
-    if benchmark_config is None:
-        raise ValueError(
-            f"No benchmark sweep defined for model_id={model_id!r} in "
-            "BENCHMARK_CONFIGS. The model must have a v1 benchmark config."
-        )
+    benchmark_config = get_benchmark_config(model_spec)
 
     if (
         limit_samples_mode
@@ -54,7 +48,8 @@ def get_llm_configs(
         available = sorted(getattr(dev, "name", str(dev)) for dev in configured_devices)
         raise ValueError(
             f"No benchmark params for device={getattr(device, 'name', device)!r} "
-            f"in BENCHMARK_CONFIGS[{model_id!r}]. Configured devices: {available}."
+            f"in benchmark config for model_id={model_spec.model_id!r}. "
+            f"Configured devices: {available}."
         )
 
     configs: List[LLMRunConfig] = []
@@ -81,7 +76,7 @@ def get_llm_configs(
     if not configs:
         logger.warning(
             "No text benchmark params for model_id=%s on device=%s",
-            model_id,
+            model_spec.model_id,
             getattr(device, "name", device),
         )
     return configs

--- a/tt-inference-server-v2/test_module/llm_tests/llm_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/llm_tests/llm_benchmark_tests.py
@@ -5,8 +5,8 @@
 """LLM benchmark caller — select a perf-tool driver and run the sweep.
 
 Bridges ``test_module`` to ``llm_module`` for the standard LLM performance
-benchmark. The ``--tools`` value picks one driver; the sweep is
-``BENCHMARK_CONFIGS`` matrix; the run is delegated to the existing
+benchmark. The ``--tools`` value picks one driver; the sweep is built from
+the resolved runtime model spec; the run is delegated to the existing
 ``run_llm_performance`` orchestrator, which forwards the resulting Blocks to
 ``workflow_module`` for the unified report.
 """

--- a/tt-inference-server-v2/tests/test_module/llm_tests/test_llm_benchmark_tests.py
+++ b/tt-inference-server-v2/tests/test_module/llm_tests/test_llm_benchmark_tests.py
@@ -4,12 +4,30 @@
 
 """Tests for the LLM benchmark caller: driver selection + sweep wiring."""
 
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from workflows.model_spec import MODEL_SPECS
+from workflows.workflow_types import DeviceTypes
+
 from test_module.llm_tests import llm_benchmark_tests as lbt
+
+
+def _find_model_spec(*, model_name: str, device: DeviceTypes, impl_name: str):
+    for spec in MODEL_SPECS.values():
+        if (
+            spec.model_name == model_name
+            and spec.device_type == device
+            and spec.impl.impl_name == impl_name
+        ):
+            return spec
+    raise AssertionError(
+        f"Could not find model spec for model={model_name!r}, "
+        f"device={device.name}, impl={impl_name!r}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -55,6 +73,53 @@ def test_run_llm_bench_short_circuits_on_empty_sweep(monkeypatch):
     assert result.blocks == []
     assert result.ok is False
     assert called["run"] is False
+
+
+def test_run_llm_bench_builds_real_runtime_spec_sweep(monkeypatch, tmp_path):
+    """Exercise the real v2 LLM config path without running a benchmark."""
+    source_spec = _find_model_spec(
+        model_name="Qwen3-8B",
+        device=DeviceTypes.N150,
+        impl_name="tt-transformers",
+    )
+    runtime_spec = replace(
+        source_spec,
+        device_model_spec=replace(
+            source_spec.device_model_spec,
+            max_context=256,
+            max_concurrency=32,
+        ),
+    )
+
+    seen = {}
+
+    def _capture(ctx, *, driver, configs, auth_token=""):
+        seen["driver"] = driver.name
+        seen["configs"] = configs
+        from llm_module.runner import RunnerResult
+
+        return RunnerResult(return_codes=[0])
+
+    monkeypatch.setattr(lbt, "run_llm_performance", _capture)
+
+    ctx = SimpleNamespace(
+        model_spec=runtime_spec,
+        device=runtime_spec.device_type,
+        runtime_config=SimpleNamespace(limit_samples_mode=None),
+        output_path=str(tmp_path),
+    )
+    result = lbt.run_llm_bench(
+        ctx,
+        tools="vllm",
+        venv_python=Path("/tmp/venv/bin/python"),
+    )
+
+    assert result.ok is True
+    assert seen["driver"] == "vllm"
+    assert any(
+        cfg.isl == 128 and cfg.osl == 128 and cfg.max_concurrency == 1
+        for cfg in seen["configs"]
+    )
 
 
 def test_guidellm_uses_scenarios_not_sweep(monkeypatch, tmp_path):

--- a/tt-inference-server-v2/workflow_module/workflows.py
+++ b/tt-inference-server-v2/workflow_module/workflows.py
@@ -200,8 +200,8 @@ class BenchmarksWorkflow(WorkflowExecution):
 
         Delegates to :func:`test_module.llm_tests.llm_benchmark_tests.run_llm_bench`,
         which selects the perf-tool driver from ``opts.tools``, builds the
-        ``BENCHMARK_CONFIGS`` sweep, runs it, and forwards the resulting
-        Blocks to the accumulator. Imported from the leaf submodule so the
+        runtime model-spec sweep, runs it, and forwards the resulting Blocks
+        to the accumulator. Imported from the leaf submodule so the
         media runner imports stay untouched.
         """
         from test_module.llm_tests.llm_benchmark_tests import run_llm_bench


### PR DESCRIPTION
Codex: This is a narrow hotfix for the LLM nightly failure introduced after #4345.

## Summary
- Update the v2 LLM benchmark sweep builder to call `get_benchmark_config(model_spec)` instead of importing the removed `BENCHMARK_CONFIGS` global.
- Keep runtime `ModelSpec` as the source of truth, preserving the behavior added in #4345 for external/runtime specs.
- Add a regression test that drives `run_llm_bench` through the real v2 config path while patching out the expensive benchmark runner, so the lazy import failure is caught in unit tests.
- Refresh stale docstrings that still described the old global config lookup.

## Validation
- `./.venv/bin/python -m pytest tt-inference-server-v2/tests/test_module/llm_tests/test_llm_benchmark_tests.py -q`
- `./.venv/bin/python -m pytest tests/test_benchmark_config.py tests/test_run_arguments.py tests/workflows/test_v2_bridge_llm_routing.py -q`
- `./.venv/bin/python -m ruff check tt-inference-server-v2/llm_module/benchmark_configs.py tt-inference-server-v2/test_module/llm_tests/llm_benchmark_tests.py tt-inference-server-v2/workflow_module/workflows.py tt-inference-server-v2/tests/test_module/llm_tests/test_llm_benchmark_tests.py`
- `git diff --check`

Refs #4345
Nightly failure: https://github.com/tenstorrent/tt-shield/actions/runs/28406605440/job/84181133741
