### PR TITLE
Fix LLM release reports

### DIFF
--- a/tt-inference-server-v2/llm_module/conftest.py
+++ b/tt-inference-server-v2/llm_module/conftest.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Pytest fixtures for the vLLM parameter-conformance suites.
+
+These suites (``test_vllm_chat_completions.py`` / ``test_vllm_responses.py``)
+are run as a child pytest process by
+``test_module.llm_tests.vllm_param_conformance_test``.
+"""
+
+from server_tests.conftest import (  # noqa: F401
+    api_client,
+    endpoint_url,
+    max_context,
+    output_path,
+    pytest_addoption,
+    pytest_runtest_makereport,
+    report_test,
+    results_report,
+)

--- a/tt-inference-server-v2/report_module/acceptance_criteria.py
+++ b/tt-inference-server-v2/report_module/acceptance_criteria.py
@@ -223,7 +223,7 @@ def _check_evals(schema: ReportSchema) -> CategoryResult:
 
         state = _check_state(check_value)
         if state == STATUS_FAIL:
-            blockers[block_key] = f"Accuracy check failed (value={check_value!r})"
+            blockers[block_key] = "Accuracy check failed."
             failed += 1
         elif state == STATUS_NA:
             na += 1

--- a/tt-inference-server-v2/report_module/acceptance_criteria.py
+++ b/tt-inference-server-v2/report_module/acceptance_criteria.py
@@ -120,9 +120,24 @@ def format_acceptance_summary_markdown(
     lines.append("")
     lines.append("#### Blockers")
     lines.append("")
-    for key, message in blockers.items():
-        lines.append(f"- `{key}`: {message}")
+    lines.extend(_format_blocker_lines(blockers))
     return "\n".join(lines)
+
+
+def _format_blocker_lines(blockers: Mapping[str, str]) -> List[str]:
+    """Render blockers, collapsing entries that share the same message."""
+    grouped: Dict[str, List[str]] = {}
+    for key, message in blockers.items():
+        grouped.setdefault(message, []).append(key)
+
+    lines: List[str] = []
+    for message, keys in grouped.items():
+        if len(keys) == 1:
+            lines.append(f"- `{keys[0]}`: {message}")
+            continue
+        lines.append(f"- {message} ({len(keys)} blocks)")
+        lines.extend(f"  - `{key}`" for key in keys)
+    return lines
 
 
 def _detail(category: CategoryResult) -> str:

--- a/tt-inference-server-v2/report_module/display.py
+++ b/tt-inference-server-v2/report_module/display.py
@@ -112,6 +112,12 @@ DISPLAY_NAMES: Dict[str, str] = {
     "model_ready": "Model Ready",
     "runner_in_use": "Runner",
     "child_result": "Child Result",
+    # vLLM parameter-conformance tables
+    "test_case": "Test Case",
+    "parametrization": "Parametrization",
+    "summary": "Summary",
+    "message": "Message",
+    "endpoint_url": "Endpoint URL",
     # Common envelope
     "name": "Name",
     "success": "Success",

--- a/tt-inference-server-v2/report_module/generator.py
+++ b/tt-inference-server-v2/report_module/generator.py
@@ -28,6 +28,9 @@ logger = logging.getLogger(__name__)
 
 _METADATA_RENDERING_KEYS = frozenset(ACCEPTANCE_EXPORT_KEYS)
 
+_EVALS_KIND = "evals"
+_CONSOLIDATED_EVALS_TITLE = "Accuracy Evaluations"
+
 
 @dataclass(frozen=True)
 class GenerateResult:
@@ -52,6 +55,7 @@ class ReportGenerator:
         out_dir.mkdir(parents=True, exist_ok=True)
 
         render_sections = _collapse_same_heading_blocks(normalized.sections)
+        render_sections = _consolidate_eval_blocks(render_sections)
         section_markdowns = [
             self._render_block(block, normalized.metadata) for block in render_sections
         ]
@@ -260,6 +264,35 @@ def generate_report(
 ) -> GenerateResult:
     """Convenience functional wrapper around :class:`ReportGenerator`."""
     return ReportGenerator(file_saver=file_saver).generate(schema, output_dir)
+
+
+def _consolidate_eval_blocks(sections: List[Block]) -> List[Block]:
+    """Merge every ``evals`` block into one consolidated table block."""
+    eval_blocks = [block for block in sections if block.kind == _EVALS_KIND]
+    if len(eval_blocks) <= 1:
+        return sections
+
+    records: List[Dict[str, Any]] = []
+    for block in eval_blocks:
+        records.extend(renderers._extract_records(block))
+    merged = Block(
+        kind=_EVALS_KIND,
+        title=_CONSOLIDATED_EVALS_TITLE,
+        task_type=None,
+        id=eval_blocks[0].id,
+        targets={},
+        data={"records": records},
+    )
+
+    out: List[Block] = []
+    inserted = False
+    for block in sections:
+        if block.kind != _EVALS_KIND:
+            out.append(block)
+        elif not inserted:
+            out.append(merged)
+            inserted = True
+    return out
 
 
 def _collapse_same_heading_blocks(sections: List[Block]) -> List[Block]:

--- a/tt-inference-server-v2/report_module/renderers.py
+++ b/tt-inference-server-v2/report_module/renderers.py
@@ -38,9 +38,19 @@ HIDDEN_COLUMNS = frozenset(
 
 GENERIC_KINDS: tuple[str, ...] = (
     "benchmarks",
-    "evals",
     "spec_tests",
     "stress_tests",
+)
+
+EVALS_KIND = "evals"
+
+EVALS_METHODOLOGY_NOTE = (
+    "Note: The ratio to published scores defines if eval ran roughly correctly, "
+    "as the exact methodology of the model publisher cannot always be reproduced. "
+    "For this reason the accuracy check is based first on being equivalent to the "
+    "GPU reference within a +/- tolerance. If a value GPU reference is not "
+    "available, the accuracy check is based on the direct ratio to the published "
+    "score."
 )
 
 _REGISTRY: Dict[str, RendererFn] = {}
@@ -292,6 +302,22 @@ def render_generic_table(block: Block, metadata: Mapping[str, Any]) -> str:
         parts.append(f"#### {_humanize_key(key)}\n\n{sub_table}")
 
     return "\n\n".join(parts) if len(parts) > 1 else ""
+
+
+@register(EVALS_KIND)
+def render_evals(block: Block, metadata: Mapping[str, Any]) -> str:
+    """Render eval results as one table followed by the methodology note."""
+    records = _extract_records(block)
+    if not records:
+        return ""
+    model, device = _resolve_model_device(block, metadata, records)
+    heading = _heading(
+        block.kind, model, device, block.title or "", block.task_type or ""
+    )
+    table = _build_table(records)
+    if not table:
+        return ""
+    return f"{heading}\n\n{table}\n\n{EVALS_METHODOLOGY_NOTE}"
 
 
 for _kind in GENERIC_KINDS:

--- a/tt-inference-server-v2/test_module/_test_common/blockify.py
+++ b/tt-inference-server-v2/test_module/_test_common/blockify.py
@@ -26,20 +26,22 @@ if TYPE_CHECKING:
 
 
 def sweep_envelope(ctx: "MediaContext") -> Dict[str, Any]:
-    """Sweep-level metadata recorded once for the whole report."""
+    """Sweep-level metadata recorded once for the whole report.
+
+    Identity / provenance fields (``model_id``, ``model_repo``,
+    ``model_impl``, ``inference_engine``, ``tt_metal_commit``,
+    ``vllm_commit``) are injected centrally from the runtime model spec by
+    :meth:`workflow_module.execution.WorkflowExecution.inject_metadata`, so
+    they are not duplicated here. This envelope only carries what the
+    accumulator needs before that step: model name, device, timestamp, and a
+    synthesized ``report_id``.
+    """
     spec = ctx.model_spec
-    impl = getattr(spec, "impl", None)
     model_id = getattr(spec, "model_id", None)
     generated_at = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
     envelope: Dict[str, Any] = {
         "model_name": getattr(spec, "model_name", ""),
-        "model_id": model_id,
-        "model_repo": getattr(spec, "hf_model_repo", None),
-        "model_impl": getattr(impl, "impl_name", None) if impl else None,
-        "inference_engine": getattr(spec, "inference_engine", None),
         "device": ctx.device.name,
-        "tt_metal_commit": getattr(spec, "tt_metal_commit", None),
-        "vllm_commit": getattr(spec, "vllm_commit", None),
         "generated_at": generated_at,
     }
     if model_id:

--- a/tt-inference-server-v2/test_module/llm_tests/vllm_param_conformance_test.py
+++ b/tt-inference-server-v2/test_module/llm_tests/vllm_param_conformance_test.py
@@ -128,7 +128,9 @@ class VLLMParamConformanceTest(BaseTest):
         # A nonzero return code is expected when conformance tests fail — those
         # failures are captured in the report. Only a missing report means the
         # run itself broke (e.g. missing fixtures / server unreachable).
-        report_path = Path(output_dir) / f"parameter_report_{self.REPORT_TASK_NAME}.json"
+        report_path = (
+            Path(output_dir) / f"parameter_report_{self.REPORT_TASK_NAME}.json"
+        )
         if not report_path.exists():
             tail = (stdout or b"").decode(errors="replace")[-2000:]
             raise RuntimeError(

--- a/tt-inference-server-v2/test_module/llm_tests/vllm_param_conformance_test.py
+++ b/tt-inference-server-v2/test_module/llm_tests/vllm_param_conformance_test.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Spec-test wrappers around the vLLM parameter-conformance suites.
+
+Each wrapper runs its pytest suite (``test_vllm_chat_completions.py`` or
+``test_vllm_responses.py``) in a child pytest process — the suites contain a
+``@pytest.mark.asyncio`` test that needs its own loop, which would collide
+with ``BaseTest.run_tests``' ``asyncio.run`` — then reshapes the report into
+the ``parameter_conformance_summary`` / ``detailed_test_results`` list fields
+on ``Block.data`` so the generic renderer draws them as sub-tables with no
+dedicated renderer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional
+
+from report_module.schema import Block
+
+from .._test_common import BaseTest, TestConfig
+
+if TYPE_CHECKING:
+    from ..context import MediaContext
+
+logger = logging.getLogger(__name__)
+
+PASSED_STATUS = "passed"
+FAILED_STATUS = "failed"
+DEFAULT_MODEL_NAME = "unknown-model"
+MESSAGE_MAX_LEN = 250
+
+# test_module/llm_tests/<this file> -> parents[2] is the v2 package root.
+_V2_ROOT = Path(__file__).resolve().parents[2]
+_LLM_MODULE_DIR = _V2_ROOT / "llm_module"
+
+
+def _truncate_message(message: Any) -> str:
+    """Collapse a failure message to a single, table-safe, bounded string.
+
+    Pipe/newline escaping is handled by the markdown table builder; here we
+    only cap length so a long traceback doesn't dominate the report.
+    """
+    text = str(message)
+    if len(text) > MESSAGE_MAX_LEN:
+        return text[:MESSAGE_MAX_LEN] + "..."
+    return text
+
+
+class VLLMParamConformanceTest(BaseTest):
+    """Run the vLLM chat-completions parameter suite and wrap its report.
+
+    Subclasses point at a different suite/endpoint by overriding the three
+    ``PYTEST_*`` / ``ENDPOINT_PATH`` / ``REPORT_TASK_NAME`` attributes.
+    """
+
+    KIND = "vllm_chat_completions"
+    # "functional" (not the inherited "infra") so acceptance_criteria counts
+    # this block: infra task types are skipped by _check_spec_tests.
+    TASK_TYPE = "functional"
+
+    PYTEST_FILENAME = "test_vllm_chat_completions.py"
+    ENDPOINT_PATH = "/v1/chat/completions"
+    REPORT_TASK_NAME = "vllm_chat_completions"
+
+    async def _run_specific_test_async(self) -> Dict[str, Any]:
+        endpoint_url = f"{self.base_url}{self.ENDPOINT_PATH}"
+        model_name = self._resolve_model_name()
+
+        with tempfile.TemporaryDirectory(prefix="vllm_param_") as tmp_dir:
+            report_data = await self._run_pytest_suite(
+                tmp_dir, endpoint_url, model_name
+            )
+
+        results = report_data.get("results", {})
+        return {
+            "endpoint_url": report_data.get("endpoint_url", endpoint_url),
+            "model_name": report_data.get("model_name", model_name),
+            "task_name": report_data.get("task_name", self.REPORT_TASK_NAME),
+            "parameter_conformance_summary": self._build_conformance_summary(results),
+            "detailed_test_results": self._build_detailed_results(results),
+            "success": self._all_passed(results),
+        }
+
+    async def _run_pytest_suite(
+        self, output_dir: str, endpoint_url: str, model_name: str
+    ) -> Dict[str, Any]:
+        pytest_file = _LLM_MODULE_DIR / self.PYTEST_FILENAME
+        command = [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(pytest_file),
+            "--output-path",
+            output_dir,
+            "--task-name",
+            self.REPORT_TASK_NAME,
+            "--endpoint-url",
+            endpoint_url,
+            "--model-name",
+            model_name,
+            "-q",
+        ]
+        logger.info("Running vLLM parameter suite: %s", " ".join(command))
+
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=str(_V2_ROOT),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        try:
+            stdout, _ = await process.communicate()
+        finally:
+            if process.returncode is None:
+                process.kill()
+                await process.wait()
+
+        self._record_pytest_output(process.returncode, stdout)
+
+        # A nonzero return code is expected when conformance tests fail — those
+        # failures are captured in the report. Only a missing report means the
+        # run itself broke (e.g. missing fixtures / server unreachable).
+        report_path = Path(output_dir) / f"parameter_report_{self.REPORT_TASK_NAME}.json"
+        if not report_path.exists():
+            tail = (stdout or b"").decode(errors="replace")[-2000:]
+            raise RuntimeError(
+                f"pytest produced no report (return code {process.returncode}). "
+                f"Output tail:\n{tail}"
+            )
+
+        return json.loads(report_path.read_text())
+
+    def _record_pytest_output(
+        self, return_code: Optional[int], stdout: Optional[bytes]
+    ) -> None:
+        text = (stdout or b"").decode(errors="replace")
+        for line in text.splitlines():
+            self.logs.append(line)
+        logger.info("vLLM parameter suite exited with code %s", return_code)
+
+    def _resolve_model_name(self) -> str:
+        if self.ctx is not None:
+            model_name = getattr(self.ctx.model_spec, "model_name", None)
+            if model_name:
+                return str(model_name)
+        return str(self.config.get("model") or DEFAULT_MODEL_NAME)
+
+    @staticmethod
+    def _all_passed(results: Mapping[str, List[Mapping[str, Any]]]) -> bool:
+        return all(
+            test.get("status") == PASSED_STATUS
+            for tests in results.values()
+            for test in tests
+        )
+
+    @staticmethod
+    def _build_conformance_summary(
+        results: Mapping[str, List[Mapping[str, Any]]],
+    ) -> List[Dict[str, str]]:
+        """One row per test case: pass/fail status and a "P/N passed" count."""
+        rows: List[Dict[str, str]] = []
+        for test_case in sorted(results):
+            tests = results[test_case]
+            total = len(tests)
+            if not total:
+                rows.append(
+                    {
+                        "test_case": test_case,
+                        "status": "⚠️ SKIP",
+                        "summary": "No tests run",
+                    }
+                )
+                continue
+            passed = sum(1 for t in tests if t.get("status") == PASSED_STATUS)
+            failed = sum(1 for t in tests if t.get("status") == FAILED_STATUS)
+            status = "✅ PASS" if failed == 0 else "❌ FAIL"
+            rows.append(
+                {
+                    "test_case": test_case,
+                    "status": status,
+                    "summary": f"{passed}/{total} passed",
+                }
+            )
+        return rows
+
+    @staticmethod
+    def _build_detailed_results(
+        results: Mapping[str, List[Mapping[str, Any]]],
+    ) -> List[Dict[str, str]]:
+        """One row per parametrization; failures first, message only on failure."""
+        rows: List[Dict[str, str]] = []
+        for test_case in sorted(results):
+            ordered = sorted(
+                results[test_case],
+                key=lambda t: (
+                    t.get("status") == PASSED_STATUS,
+                    t.get("test_node_name", ""),
+                ),
+            )
+            for test in ordered:
+                passed = test.get("status") == PASSED_STATUS
+                rows.append(
+                    {
+                        "test_case": test_case,
+                        "parametrization": str(test.get("test_node_name", "")),
+                        "status": "✅ PASSED" if passed else "❌ FAILED",
+                        "message": ""
+                        if passed
+                        else _truncate_message(test.get("message", "")),
+                    }
+                )
+        return rows
+
+
+class VLLMResponsesParamConformanceTest(VLLMParamConformanceTest):
+    """Run the vLLM responses (``/v1/responses``) parameter suite."""
+
+    KIND = "vllm_responses"
+    PYTEST_FILENAME = "test_vllm_responses.py"
+    ENDPOINT_PATH = "/v1/responses"
+    REPORT_TASK_NAME = "vllm_responses"
+
+
+def run_vllm_param_conformance(
+    ctx: "MediaContext",
+    targets: Optional[dict] = None,
+    test_cls: type[VLLMParamConformanceTest] = VLLMParamConformanceTest,
+) -> Block:
+    """Run a vLLM parameter-conformance test under ``ctx`` and return its Block."""
+    test_config = TestConfig(
+        {
+            "timeout": 3600,
+            "retry_attempts": 0,
+            "retry_delay": 10,
+            "break_on_failure": False,
+        }
+    )
+    return test_cls(test_config, targets or {}, ctx=ctx).run_tests()

--- a/tt-inference-server-v2/test_module/server_tests_config.json
+++ b/tt-inference-server-v2/test_module/server_tests_config.json
@@ -37,6 +37,12 @@
             "Wan2.2-T2V-A14B-Diffusers",
             "Wan2.2-I2V-A14B-Diffusers",
             "mochi-1-preview"
+        ],
+        "LLM": [
+            "Qwen3-32B",
+            "Llama-3.1-8B-Instruct",
+            "Llama-3.3-70B-Instruct",
+            "gpt-oss-20b"
         ]
     },
     "available_markers": {
@@ -356,6 +362,68 @@
             "compatible_devices": [
                 "n150",
                 "p150"
+            ]
+        },
+        "gpt_oss_20b": {
+            "id_name": "gpt-oss-20b",
+            "weights": [
+                "gpt-oss-20b"
+            ],
+            "category": "LLM",
+            "compatible_devices": [
+                "t3k",
+                "galaxy_t3k",
+                "galaxy"
+            ]
+        },
+        "qwen3_32b": {
+            "id_name": "qwen3-32b",
+            "weights": [
+                "Qwen3-32B"
+            ],
+            "category": "LLM",
+            "compatible_devices": [
+                "galaxy",
+                "t3k",
+                "galaxy_t3k",
+                "p150x8",
+                "p300x2"
+            ]
+        },
+        "llama_70b_family": {
+            "id_name": "llama-70b",
+            "weights": [
+                "Llama-3.3-70B-Instruct"
+            ],
+            "category": "LLM",
+            "compatible_devices": [
+                "galaxy",
+                "t3k",
+                "galaxy_t3k",
+                "p150x4",
+                "p150x8",
+                "p300x2"
+            ]
+        },
+        "llama_3_1_8b": {
+            "id_name": "llama-3.1-8b",
+            "weights": [
+                "Llama-3.1-8B-Instruct"
+            ],
+            "category": "LLM",
+            "compatible_devices": [
+                "n150",
+                "n300",
+                "t3k",
+                "gpu",
+                "p100",
+                "p150",
+                "p150x4",
+                "p150x8",
+                "p300",
+                "p300x2",
+                "galaxy",
+                "galaxy_t3k"
             ]
         }
     },
@@ -747,6 +815,36 @@
                 "test_timeout": 3600,
                 "retry_attempts": 1,
                 "retry_delay": 60,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "VLLMParamConformanceTest": {
+            "module": "test_module.llm_tests.vllm_param_conformance_test",
+            "markers": [
+                "param",
+                "e2e",
+                "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 0,
+                "retry_delay": 10,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "VLLMResponsesParamConformanceTest": {
+            "module": "test_module.llm_tests.vllm_param_conformance_test",
+            "markers": [
+                "param",
+                "e2e",
+                "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 0,
+                "retry_delay": 10,
                 "break_on_failure": false,
                 "mock_mode": false
             }

--- a/tt-inference-server-v2/test_module/test_suites/llm.json
+++ b/tt-inference-server-v2/test_module/test_suites/llm.json
@@ -1,0 +1,52 @@
+{
+    "_description": "Test suites for LLM model category",
+    "_category": "LLM",
+    "test_matrices": [
+        {
+            "models": [
+                "qwen3_32b",
+                "llama_3_1_8b",
+                "llama_70b_family",
+                "gpt_oss_20b"
+            ],
+            "devices": [
+                "n150",
+                "n300",
+                "t3k",
+                "galaxy",
+                "galaxy_t3k",
+                "gpu",
+                "p100",
+                "p150",
+                "p150x4",
+                "p150x8",
+                "p300",
+                "p300x2"
+            ],
+            "test_cases": [
+                {
+                    "template": "VLLMParamConformanceTest",
+                    "enabled": true,
+                    "description": "vLLM chat/completions parameter conformance"
+                }
+            ]
+        },
+        {
+            "models": [
+                "gpt_oss_20b"
+            ],
+            "devices": [
+                "t3k",
+                "galaxy",
+                "galaxy_t3k"
+            ],
+            "test_cases": [
+                {
+                    "template": "VLLMResponsesParamConformanceTest",
+                    "enabled": true,
+                    "description": "vLLM responses parameter conformance"
+                }
+            ]
+        }
+    ]
+}

--- a/tt-inference-server-v2/tests/report_module/test_generator.py
+++ b/tt-inference-server-v2/tests/report_module/test_generator.py
@@ -15,9 +15,17 @@ from report_module.generator import (
     ReportGenerator,
     _coerce_schema,
     _collapse_same_heading_blocks,
+    _consolidate_eval_blocks,
     generate_report,
 )
 from report_module.schema import Block, ReportSchema
+
+
+def _eval_block(task: str, **data) -> Block:
+    payload = {"task_name": task, "tolerance": 0.05, **data}
+    return Block(
+        kind="evals", task_type="llm", title=f"LLM Eval — {task}", data=payload
+    )
 
 
 def _schema(*blocks: Block) -> ReportSchema:
@@ -59,6 +67,30 @@ class TestCollapseSameHeadingBlocks:
         assert len(_collapse_same_heading_blocks([a, b])) == 2
 
 
+class TestConsolidateEvalBlocks:
+    def test_multiple_evals_merge_into_one_block(self):
+        sections = [_eval_block("a", score=1.0), _eval_block("b", score=2.0)]
+        merged = _consolidate_eval_blocks(sections)
+        assert len(merged) == 1
+        assert merged[0].title == "Accuracy Evaluations"
+        assert merged[0].task_type is None
+        records = merged[0].data["records"]
+        assert [r["task_name"] for r in records] == ["a", "b"]
+
+    def test_single_eval_block_is_left_unchanged(self):
+        sections = [_eval_block("a", score=1.0)]
+        assert _consolidate_eval_blocks(sections) is sections
+
+    def test_non_eval_blocks_are_preserved_in_order(self):
+        head = Block(kind="benchmarks", title="B", data={"records": [{"x": 1}]})
+        tail = Block(kind="spec_tests", title="S", data={"records": [{"y": 2}]})
+        merged = _consolidate_eval_blocks(
+            [head, _eval_block("a"), _eval_block("b"), tail]
+        )
+        assert [b.kind for b in merged] == ["benchmarks", "evals", "spec_tests"]
+        assert merged[1].title == "Accuracy Evaluations"
+
+
 class TestGenerate:
     def test_writes_markdown_and_json(self, tmp_path: Path):
         result = generate_report(
@@ -74,6 +106,21 @@ class TestGenerate:
     def test_release_header_carries_model_and_device(self, tmp_path: Path):
         result = ReportGenerator().generate(_schema(), tmp_path)
         assert "Tenstorrent Model Release Summary: m on n300" in result.markdown
+
+    def test_evals_render_as_single_table_with_note(self, tmp_path: Path):
+        result = ReportGenerator().generate(
+            _schema(
+                _eval_block("meta_ifeval", gpu_reference_score=81.38, accuracy_check=2),
+                _eval_block("longbench_code_e", score=0.0, accuracy_check=3),
+            ),
+            tmp_path,
+        )
+        md = result.markdown
+        assert md.count("### Accuracy Evaluations for m on n300") == 1
+        assert "LLM Eval — meta_ifeval" not in md
+        assert "Note: The ratio to published scores" in md
+        # Both tasks live in the one consolidated table.
+        assert "meta_ifeval" in md and "longbench_code_e" in md
 
     def test_acceptance_criteria_promoted_to_top_level_json(self, tmp_path: Path):
         schema = ReportSchema(

--- a/tt-inference-server-v2/tests/workflow_module/test_execution.py
+++ b/tt-inference-server-v2/tests/workflow_module/test_execution.py
@@ -6,10 +6,17 @@
 
 from __future__ import annotations
 
+import json
+
+from unittest.mock import MagicMock
+
+from report_module import ReportSchema
 from workflow_module.execution import (
+    OrchestratorMetadata,
     TaskOutcome,
     WorkflowResult,
 )
+from workflow_module.workflows import ReleaseWorkflow
 
 
 class TestTaskOutcome:
@@ -33,3 +40,96 @@ class TestWorkflowResult:
     def test_succeeded_reflects_return_code(self):
         assert WorkflowResult("w", return_code=0).succeeded is True
         assert WorkflowResult("w", return_code=1, error="boom").succeeded is False
+
+
+def _write_spec(tmp_path, spec: dict) -> str:
+    path = tmp_path / "runtime_model_spec.json"
+    path.write_text(json.dumps({"runtime_model_spec": spec}), encoding="utf-8")
+    return str(path)
+
+
+def _make_workflow(orchestrator_metadata):
+    ctx = MagicMock()
+    return ReleaseWorkflow(ctx, orchestrator_metadata=orchestrator_metadata)
+
+
+class TestInjectMetadata:
+    """Central metadata injection — the single source of truth for the six
+    identity/provenance fields on both media and LLM reports."""
+
+    def test_copies_spec_identity_and_provenance_fields(self, tmp_path):
+        spec_path = _write_spec(
+            tmp_path,
+            {
+                "model_id": "id_tt-transformers_Llama-3.1-8B-Instruct_galaxy",
+                "hf_model_repo": "meta-llama/Llama-3.1-8B-Instruct",
+                "inference_engine": "vLLM",
+                "tt_metal_commit": "6593e60",
+                "vllm_commit": "9a72cb9",
+                "impl": {"impl_id": "tt_transformers", "impl_name": "tt-transformers"},
+                "status": "READY",
+            },
+        )
+        meta = OrchestratorMetadata(
+            server_mode="docker", runtime_model_spec_json=spec_path
+        )
+        schema = ReportSchema(
+            metadata={"model_name": "m", "device": "GALAXY"}, sections=[]
+        )
+
+        _make_workflow(meta).inject_metadata(schema)
+
+        assert schema.metadata["workflow"] == "release"
+        assert schema.metadata["server_mode"] == "docker"
+        assert schema.metadata["model_id"] == (
+            "id_tt-transformers_Llama-3.1-8B-Instruct_galaxy"
+        )
+        assert schema.metadata["model_repo"] == "meta-llama/Llama-3.1-8B-Instruct"
+        assert schema.metadata["inference_engine"] == "vLLM"
+        assert schema.metadata["tt_metal_commit"] == "6593e60"
+        assert schema.metadata["vllm_commit"] == "9a72cb9"
+        assert schema.metadata["model_impl"] == "tt-transformers"
+
+    def test_media_spec_missing_commits_are_written_as_none(self, tmp_path):
+        # A media image has no tt-metal / vLLM commits; the keys must still be
+        # present (as None) so media and LLM reports share one schema.
+        spec_path = _write_spec(
+            tmp_path,
+            {
+                "model_id": "id_tt-transformers_FLUX.1-schnell_p300x2",
+                "hf_model_repo": "black-forest-labs/FLUX.1-schnell",
+                "inference_engine": "media",
+                "impl": {"impl_name": "tt-transformers"},
+            },
+        )
+        meta = OrchestratorMetadata(runtime_model_spec_json=spec_path)
+        schema = ReportSchema(
+            metadata={"model_name": "FLUX.1-schnell", "device": "P300X2"}, sections=[]
+        )
+
+        _make_workflow(meta).inject_metadata(schema)
+
+        assert schema.metadata["model_repo"] == "black-forest-labs/FLUX.1-schnell"
+        assert schema.metadata["inference_engine"] == "media"
+        assert schema.metadata["model_impl"] == "tt-transformers"
+        assert schema.metadata["tt_metal_commit"] is None
+        assert schema.metadata["vllm_commit"] is None
+
+    def test_no_spec_leaves_fields_absent(self):
+        meta = OrchestratorMetadata(server_mode="API")
+        schema = ReportSchema(
+            metadata={"model_name": "m", "device": "N150"}, sections=[]
+        )
+
+        _make_workflow(meta).inject_metadata(schema)
+
+        assert schema.metadata["workflow"] == "release"
+        for absent in (
+            "model_id",
+            "model_repo",
+            "inference_engine",
+            "tt_metal_commit",
+            "vllm_commit",
+            "model_impl",
+        ):
+            assert absent not in schema.metadata

--- a/tt-inference-server-v2/tests/workflow_module/test_release_workflow.py
+++ b/tt-inference-server-v2/tests/workflow_module/test_release_workflow.py
@@ -60,18 +60,22 @@ class TestReleaseWorkflowRegistry:
     def test_registered(self):
         assert get_workflow_class("release") is ReleaseWorkflow
 
-    def test_llm_children_drops_spec_tests(self):
-        assert ReleaseWorkflow.llm_children == ("evals", "benchmarks")
+    def test_llm_children_include_spec_tests(self):
+        assert ReleaseWorkflow.llm_children == ("evals", "benchmarks", "spec_tests")
         assert ReleaseWorkflow.children == ("evals", "benchmarks", "spec_tests")
 
 
 class TestReleaseWorkflowChildSelection:
-    def test_llm_runs_evals_and_benchmarks_only(self):
+    def test_llm_runs_full_suite(self):
         outcomes, classes, _acc, _meta = _run_release(_make_ctx(ModelType.LLM))
         classes["evals"].assert_called_once()
         classes["benchmarks"].assert_called_once()
-        classes["spec_tests"].assert_not_called()
-        assert [o.task_type for o in outcomes] == ["evals", "benchmarks"]
+        classes["spec_tests"].assert_called_once()
+        assert [o.task_type for o in outcomes] == [
+            "evals",
+            "benchmarks",
+            "spec_tests",
+        ]
 
     def test_media_runs_full_suite(self):
         outcomes, classes, _acc, _meta = _run_release(_make_ctx(ModelType.IMAGE))
@@ -96,10 +100,16 @@ class TestReleaseWorkflowChildSelection:
         ctx = _make_ctx(ModelType.LLM)
         evals_cls, evals_inst = _fake_child("evals")
         bench_cls, bench_inst = _fake_child("benchmarks")
-        registry = {"evals": evals_cls, "benchmarks": bench_cls}
+        spec_cls, spec_inst = _fake_child("spec_tests")
+        registry = {
+            "evals": evals_cls,
+            "benchmarks": bench_cls,
+            "spec_tests": spec_cls,
+        }
         with patch.dict(
             "workflow_module.workflows.WORKFLOW_REGISTRY", registry, clear=False
         ):
             ReleaseWorkflow(ctx, accumulator=MagicMock()).run_tasks()
         evals_inst.run_tasks.assert_called_once()
         bench_inst.run_tasks.assert_called_once()
+        spec_inst.run_tasks.assert_called_once()

--- a/tt-inference-server-v2/workflow_module/execution.py
+++ b/tt-inference-server-v2/workflow_module/execution.py
@@ -37,6 +37,15 @@ from .blocks_sink import BlockAccumulator, get_default_accumulator
 logger = logging.getLogger(__name__)
 
 
+_SPEC_METADATA_FIELDS: Tuple[Tuple[str, str], ...] = (
+    ("model_id", "model_id"),
+    ("model_repo", "hf_model_repo"),
+    ("inference_engine", "inference_engine"),
+    ("tt_metal_commit", "tt_metal_commit"),
+    ("vllm_commit", "vllm_commit"),
+)
+
+
 @dataclass(frozen=True)
 class TaskOutcome:
     """Result of a single ``run_media_task`` invocation inside a workflow."""
@@ -301,7 +310,8 @@ class WorkflowExecution(ABC):
         )
         return accepted, blockers
 
-    def _model_status(self) -> Optional[str]:
+    def _load_runtime_model_spec(self) -> Optional[dict]:
+        """Return the ``runtime_model_spec`` sub-dict from the spec JSON, if any."""
         path = self.orchestrator_metadata.runtime_model_spec_json
         if not path:
             return None
@@ -311,9 +321,11 @@ class WorkflowExecution(ABC):
         except (OSError, ValueError):
             return None
         spec = data.get("runtime_model_spec") if isinstance(data, dict) else None
-        if isinstance(spec, dict):
-            return spec.get("status")
-        return None
+        return spec if isinstance(spec, dict) else None
+
+    def _model_status(self) -> Optional[str]:
+        spec = self._load_runtime_model_spec()
+        return spec.get("status") if spec else None
 
     def inject_metadata(self, schema: ReportSchema) -> None:
         meta = schema.metadata
@@ -325,6 +337,26 @@ class WorkflowExecution(ABC):
             meta["run_command"] = m.run_command
         if m.runtime_model_spec_json is not None:
             meta["runtime_model_spec_json"] = m.runtime_model_spec_json
+        self._inject_model_spec_metadata(meta)
+
+    def _inject_model_spec_metadata(self, meta: dict) -> None:
+        """Populate identity/provenance fields from the runtime model spec.
+
+        Single source of truth for both media and LLM reports: every field is
+        written whenever the spec is available (``None`` when the spec omits
+        it, e.g. ``tt_metal_commit`` for a media image) so the report metadata
+        schema is stable across workflows. ``model_impl`` comes from the
+        nested ``impl.impl_name`` (the hyphenated display name, e.g.
+        ``tt-transformers``); the rest map verbatim per
+        :data:`_SPEC_METADATA_FIELDS`.
+        """
+        spec = self._load_runtime_model_spec()
+        if not spec:
+            return
+        for meta_key, spec_key in _SPEC_METADATA_FIELDS:
+            meta[meta_key] = spec.get(spec_key)
+        impl = spec.get("impl")
+        meta["model_impl"] = impl.get("impl_name") if isinstance(impl, dict) else None
 
     def generate_report(self, schema: ReportSchema) -> GenerateResult:
         report_dir = Path(self.ctx.output_path).parent

--- a/tt-inference-server-v2/workflow_module/workflows.py
+++ b/tt-inference-server-v2/workflow_module/workflows.py
@@ -355,7 +355,7 @@ class SpecTestsWorkflow(WorkflowExecution):
 class ReleaseWorkflow(WorkflowExecution):
     name = "release"
     children: ClassVar[Sequence[str]] = ("evals", "benchmarks", "spec_tests")
-    llm_children: ClassVar[Sequence[str]] = ("evals", "benchmarks")
+    llm_children: ClassVar[Sequence[str]] = ("evals", "benchmarks", "spec_tests")
 
     def run_tasks(self) -> List[TaskOutcome]:
         children = (


### PR DESCRIPTION
Brings the `tt-inference-server-v2` release report to parity with the v1 report, wires the vLLM parameter-conformance suites into LLM release runs, and fixes a cosmetic acceptance bug.

## Report parity

- **Restored the six metadata fields** that v2 dropped (`model_id`, `model_repo`, `model_impl`, `inference_engine`, `tt_metal_commit`, `vllm_commit`)
- 
- **Consolidated eval tables + methodology note.**  A dedicated `evals` renderer now emits the table followed by the methodology note, and the generator merges every `evals` block into one consolidated table.

## Acceptance fix

- **Clean failed-eval blockers.** Failed accuracy checks printed `<ReportCheckTypes.FAIL: 3>` instead of a message

## vLLM parameter-conformance spec tests in LLM release reports

- `ReleaseWorkflow.llm_children` now includes `spec_tests`

## Tests

- `test_generator.py`: eval-block consolidation and single-table-with-note rendering.
- `test_execution.py`: central metadata injection (identity/provenance copied, missing commits written as `None`, absent-when-no-spec).
- `test_release_workflow.py`: updated to assert LLM release now runs `spec_tests`.

## CI gate
- https://github.com/tenstorrent/tt-shield/actions/runs/28530465727
- https://github.com/tenstorrent/tt-shield/actions/runs/28530666470