### PR TITLE
v2 command_factory creates JWT token with 'exp' field → API server returns 401 on every request

### DIFF
--- a/tt-inference-server-v2/workflow_module/command_factory.py
+++ b/tt-inference-server-v2/workflow_module/command_factory.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import argparse
-import datetime as _dt
 import json
 import logging
 import os
@@ -289,7 +288,6 @@ def _mint_jwt_if_secret(jwt_secret_arg: Optional[str]) -> str:
     payload = {
         "team_id": "tenstorrent",
         "token_id": "debug-test",
-        "exp": int(_dt.datetime.now(_dt.timezone.utc).timestamp()) + 24 * 3600,
     }
     encoded = _jwt.encode(payload, secret, algorithm="HS256")
     os.environ["OPENAI_API_KEY"] = encoded


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-inference-server/issues/4444