### PR TITLE
v2: fix forge/media LLM eval/benchmark 401s — send literal API key, not a JWT 

### DIFF
--- a/tt-inference-server-v2/tests/workflow_module/test_command_factory.py
+++ b/tt-inference-server-v2/tests/workflow_module/test_command_factory.py
@@ -12,8 +12,11 @@ out of scope here.
 from __future__ import annotations
 
 from argparse import Namespace
+from types import SimpleNamespace
 
 import pytest
+
+from workflows.workflow_types import InferenceEngine
 
 from workflow_module import command_factory as cf
 from workflow_module.execution import (
@@ -172,3 +175,72 @@ class TestMintJwt:
         monkeypatch.setenv("JWT_SECRET", "env-secret-key-of-sufficient-length-12345")
         monkeypatch.setenv("OPENAI_API_KEY", "")
         assert cf._mint_jwt_if_secret(None)
+
+
+class TestResolveAuthToken:
+    """Engine-aware bearer-token selection.
+
+    Forge/media servers (tt-media-server) validate a *literal* ``Bearer
+    $API_KEY``; only the vLLM (tt-metal) server decodes a JWT. Sending a
+    minted JWT to a forge/media server is what caused the 401 storm this
+    fix addresses.
+    """
+
+    def _args(self, **kw):
+        base = dict(model="m", device="p150", jwt_secret=None)
+        base.update(kw)
+        return Namespace(**base)
+
+    def _patch_engine(self, monkeypatch, engine):
+        monkeypatch.setattr(
+            cf,
+            "get_runtime_model_spec",
+            lambda model, device: (
+                SimpleNamespace(inference_engine=engine),
+                None,
+                None,
+            ),
+        )
+
+    def test_forge_uses_literal_default_not_jwt(self, monkeypatch):
+        # Even with JWT_SECRET set, a forge server must get the literal key.
+        monkeypatch.setenv("JWT_SECRET", "secret-of-sufficient-length-123456")
+        for var in ("VLLM_API_KEY", "API_KEY", "OPENAI_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        self._patch_engine(monkeypatch, InferenceEngine.FORGE)
+        assert cf._resolve_auth_token(self._args()) == "your-secret-key"
+
+    def test_forge_accepts_raw_string_engine(self, monkeypatch):
+        # model_spec may carry the enum's str value rather than the enum.
+        for var in ("VLLM_API_KEY", "API_KEY", "OPENAI_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        self._patch_engine(monkeypatch, InferenceEngine.FORGE.value)
+        assert cf._resolve_auth_token(self._args()) == "your-secret-key"
+
+    def test_media_prefers_explicit_vllm_api_key(self, monkeypatch):
+        monkeypatch.setenv("JWT_SECRET", "secret-of-sufficient-length-123456")
+        monkeypatch.setenv("VLLM_API_KEY", "explicit-key")
+        self._patch_engine(monkeypatch, InferenceEngine.MEDIA)
+        assert cf._resolve_auth_token(self._args()) == "explicit-key"
+
+    def test_vllm_engine_mints_jwt(self, monkeypatch):
+        pytest.importorskip("jwt")
+        monkeypatch.setenv("JWT_SECRET", "secret-of-sufficient-length-123456")
+        self._patch_engine(monkeypatch, InferenceEngine.VLLM)
+        token = cf._resolve_auth_token(self._args())
+        assert token != "your-secret-key"
+        assert token.count(".") == 2  # header.payload.signature
+
+    def test_vllm_engine_without_secret_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        self._patch_engine(monkeypatch, InferenceEngine.VLLM)
+        assert cf._resolve_auth_token(self._args()) == ""
+
+    def test_unresolvable_spec_falls_back_to_jwt_path(self, monkeypatch):
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+
+        def boom(model, device):
+            raise RuntimeError("no spec")
+
+        monkeypatch.setattr(cf, "get_runtime_model_spec", boom)
+        assert cf._resolve_auth_token(self._args()) == ""

--- a/tt-inference-server-v2/workflow_module/command_factory.py
+++ b/tt-inference-server-v2/workflow_module/command_factory.py
@@ -16,7 +16,7 @@ from typing import List, Optional
 
 from workflows.model_spec import get_runtime_model_spec
 from workflows.runtime_config import RuntimeConfig
-from workflows.workflow_types import DeviceTypes
+from workflows.workflow_types import DeviceTypes, InferenceEngine
 
 from utils.url_helpers import resolve_deploy_url
 
@@ -188,7 +188,7 @@ def _build_llm_bench_options(args: argparse.Namespace) -> Optional[LLMBenchOptio
         return None
     return LLMBenchOptions(
         tools=getattr(args, "tools", None) or "vllm",
-        auth_token=_mint_jwt_if_secret(getattr(args, "jwt_secret", None)),
+        auth_token=_resolve_auth_token(args),
         venv_python=_release_bench_venv_python(args),
     )
 
@@ -214,7 +214,7 @@ def _build_llm_eval_options(args: argparse.Namespace) -> Optional[LLMEvalOptions
     if getattr(args, "workflow", None) not in _LLM_EVAL_WORKFLOWS:
         return None
     return LLMEvalOptions(
-        auth_token=_mint_jwt_if_secret(getattr(args, "jwt_secret", None)),
+        auth_token=_resolve_auth_token(args),
     )
 
 
@@ -245,7 +245,7 @@ def _build_prefix_cache_options(
         request_rate=args.prefix_cache_request_rate,
         scenarios_json=args.prefix_cache_scenarios_json,
         trace_path=args.prefix_cache_trace,
-        auth_token=_mint_jwt_if_secret(args.jwt_secret),
+        auth_token=_resolve_auth_token(args),
     )
 
 
@@ -264,8 +264,27 @@ def _build_spec_decode_options(
     return SpecDecodeOptions(
         preset=args.spec_decode_preset,
         warmup_requests=args.spec_decode_warmup_requests,
-        auth_token=_mint_jwt_if_secret(args.jwt_secret),
+        auth_token=_resolve_auth_token(args),
     )
+
+
+def _resolve_auth_token(args: argparse.Namespace) -> str:
+    """Resolve the bearer token the eval/benchmark clients send.
+
+    Forge/media servers (tt-media-server) check a *literal* ``Bearer $API_KEY``
+    (default ``your-secret-key``, see ``security/api_key_checker.py``) and do
+    NOT decode JWTs; only the vLLM/tt-metal server validates a JWT. Mirrors the
+    engine branch in v1 ``evals/run_evals.py`` — a JWT sent to a forge/media
+    server 401s. Falls back to the JWT path when the spec can't be resolved.
+    """
+    try:
+        spec, _, _ = get_runtime_model_spec(model=args.model, device=args.device)
+        engine = getattr(spec.inference_engine, "value", spec.inference_engine)
+    except Exception:  # pragma: no cover - defensive
+        engine = None
+    if engine in (InferenceEngine.FORGE.value, InferenceEngine.MEDIA.value):
+        return os.getenv("VLLM_API_KEY") or os.getenv("API_KEY") or "your-secret-key"
+    return _mint_jwt_if_secret(getattr(args, "jwt_secret", None))
 
 
 def _mint_jwt_if_secret(jwt_secret_arg: Optional[str]) -> str:
@@ -273,7 +292,9 @@ def _mint_jwt_if_secret(jwt_secret_arg: Optional[str]) -> str:
 
     Looks at the ``--jwt-secret`` arg first, then ``$JWT_SECRET``. When no
     secret is supplied, returns the empty string (auth disabled). Matches the
-    inference server's expected debug token for JWT auth.
+    inference server's expected debug token for JWT auth. Used for the vLLM
+    (tt-metal) server; forge/media servers go through the literal-key branch
+    in :func:`_resolve_auth_token`.
     """
     secret = jwt_secret_arg or os.getenv("JWT_SECRET", "")
     if not secret:


### PR DESCRIPTION
## Ticket

Fixes #4467. Complementary to #4444 / PR #4462 (that fixes the vLLM/tt-metal *with-`exp`* JWT variant; this fixes the forge/media literal-key variant — both needed).

## Problem
- Forge/media servers (tt-media-server `security/api_key_checker.py`) authenticate with a literal `Bearer $API_KEY` check (default `your-secret-key`) and never decode JWTs.
- v2's `command_factory` mints a JWT for every LLM run, so since #4348 routed forge/media LLM release/evals/benchmarks through v2, the client sent `Bearer <jwt>` → HTTP 401 on every eval request and every benchmark sweep point (first hit by the 2026-07-01 Falcon3-7B p150 nightly).
- v1 `evals/run_evals.py` branched on `inference_engine` and used the literal key for MEDIA/FORGE; v2 lost that branch.

## Change
`_resolve_auth_token(args)` branches on `inference_engine`: FORGE/MEDIA → literal key (`VLLM_API_KEY` / `API_KEY`, default `your-secret-key`), else the existing JWT mint (unchanged). Applied to all four auth call sites (`llm_bench`, `llm_eval`, `prefix_cache`, `spec_decode`). A literal-env-var-only fix isn't enough — the forge CI host sets no `VLLM_API_KEY`/`API_KEY` and relies on the server's `your-secret-key` default, so the client must key off server type.

## Tests
`test_command_factory.py::TestResolveAuthToken` — forge → literal default, media → explicit `VLLM_API_KEY`, forge raw-string engine, vLLM → JWT, vLLM no-secret → empty, unresolvable spec → JWT fallback.

## Validation
`Falcon3-7B-Instruct | p150 | release`, reusing the failing run's server image so this fix is the only variable:
- **Auth fixed** ([run 28541433780](https://github.com/tenstorrent/tt-shield/actions/runs/28541433780)): success, Acceptance PASS; zero `HTTP 401` (failing run had dozens), all `/v1/completions` 200, eval + benchmark each produced a block.
- **Full-scale nightly** ([run 28543805366](https://github.com/tenstorrent/tt-shield/actions/runs/28543805366)) — full eval set + 11-point sweep - also passing.
