### PR TITLE
fix(v2): drop exp claim from minted JWT so benchmark/eval bearer matches server's static key

### DIFF
--- a/tt-inference-server-v2/tests/workflow_module/test_command_factory.py
+++ b/tt-inference-server-v2/tests/workflow_module/test_command_factory.py
@@ -176,6 +176,22 @@ class TestMintJwt:
         monkeypatch.setenv("OPENAI_API_KEY", "")
         assert cf._mint_jwt_if_secret(None)
 
+    def test_minted_token_byte_matches_server_precomputed_key(self, monkeypatch):
+        """The minted bearer MUST equal the server's precomputed VLLM_API_KEY.
+
+        The tt-metal/vLLM server does not decode the JWT; it precomputes
+        ``get_encoded_api_key(JWT_SECRET)`` and has vLLM compare the bearer by
+        exact byte-equality. Any extra claim (e.g. ``exp``) breaks that match
+        and 401s every request, so keep the two encodings in lockstep.
+        """
+        pytest.importorskip("jwt")
+        vllm_run_utils = pytest.importorskip("utils.vllm_run_utils")
+        secret = "super-secret-key-of-sufficient-length-1234"
+        monkeypatch.setenv("OPENAI_API_KEY", "")
+        assert cf._mint_jwt_if_secret(secret) == vllm_run_utils.get_encoded_api_key(
+            secret
+        )
+
 
 class TestResolveAuthToken:
     """Engine-aware bearer-token selection.

--- a/tt-inference-server-v2/workflow_module/command_factory.py
+++ b/tt-inference-server-v2/workflow_module/command_factory.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import argparse
-import datetime as _dt
 import json
 import logging
 import os
@@ -307,10 +306,18 @@ def _mint_jwt_if_secret(jwt_secret_arg: Optional[str]) -> str:
             "will be minted. Install pyjwt to enable JWT-protected servers."
         )
         return ""
+    # The tt-metal/vLLM server does NOT decode this JWT at request time. In
+    # run_vllm_api_server.py -> handle_secrets() it precomputes a STATIC key
+    # VLLM_API_KEY = get_encoded_api_key(JWT_SECRET), i.e.
+    #   jwt.encode({"team_id": "tenstorrent", "token_id": "debug-test"}, secret,
+    #              algorithm="HS256")
+    # (no exp claim), and vLLM's AuthenticationMiddleware compares the incoming
+    # bearer to that string by exact sha256/compare_digest byte-equality. So the
+    # token minted here MUST be byte-identical to the server's key — any extra
+    # claim (e.g. "exp") changes the encoded string and 401s every request.
     payload = {
         "team_id": "tenstorrent",
         "token_id": "debug-test",
-        "exp": int(_dt.datetime.now(_dt.timezone.utc).timestamp()) + 24 * 3600,
     }
     encoded = _jwt.encode(payload, secret, algorithm="HS256")
     os.environ["OPENAI_API_KEY"] = encoded


### PR DESCRIPTION
**Problem:** vLLM/tt-metal benchmark & eval runs 401'd on every request (all sweep points) — e.g. Qwen/Qwen3.6-27B. The client *was* sending a token; the server rejected it.

**Cause:** The server doesn't decode the JWT — it precomputes `VLLM_API_KEY = get_encoded_api_key(JWT_SECRET)` (payload `{team_id, token_id}`, **no `exp`**) and byte-compares the bearer via `sha256`/`compare_digest`. The client minted the token **with** an `exp` claim, so the encoded strings never matched.

**Fix:** Drop the `exp` claim in `_mint_jwt_if_secret` so the token is byte-identical to the server's key. Adds a regression test pinning `_mint_jwt_if_secret(secret) == get_encoded_api_key(secret)`.

**Verification:** Byte-match + `compare_digest` confirmed locally with the real functions; end-to-end confirmed by a passing P300X2 benchmark run. Complements #4468 (forge/media literal-key path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)