### PR TITLE
separate tt-llm-engine "blaze" image from  "Dockerfile.blaze"

### DIFF
--- a/tt-media-server/Dockerfile.blaze
+++ b/tt-media-server/Dockerfile.blaze
@@ -47,7 +47,8 @@ FROM ${TT_LLM_ENGINE_IMAGE} AS engine
 # ==============================================================================
 # BUILDER STAGE - compile cpp_server against the prebuilt engine.
 # ==============================================================================
-FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest AS builder
+# FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest AS builder
+FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-light-amd64:latest AS builder
 
 LABEL maintainer="Igor Djuric <idjuric@tenstorrent.com>"
 LABEL org.opencontainers.image.source=https://github.com/tenstorrent/tt-inference-server
@@ -308,7 +309,8 @@ RUN set -eux; \
 # Same shape as before; path expectations changed (TT_METAL_HOME under /opt,
 # LD_LIBRARY_PATH points at the engine artifact dirs).
 # ==============================================================================
-FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest AS runtime
+# FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest AS runtime
+FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-light-amd64:latest AS runtime
 
 LABEL maintainer="Igor Djuric <idjuric@tenstorrent.com>"
 LABEL org.opencontainers.image.source=https://github.com/tenstorrent/tt-inference-server

--- a/tt-media-server/Dockerfile.blaze
+++ b/tt-media-server/Dockerfile.blaze
@@ -3,23 +3,18 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 # ==============================================================================
-# Slim Dockerfile.blaze (v2 split)
+# Slim Dockerfile.blaze
 # ------------------------------------------------------------------------------
 # Consumes a prebuilt tt-llm-engine image and compiles cpp_server on top.
 #
 # Required build args:
-#   TT_LLM_ENGINE_IMAGE                   — full image reference, e.g.
-#                                           ghcr.io/tenstorrent/tt-llm-engine/blaze:<sha>
-#                                           (sentinel default triggers a clear
-#                                           "manifest unknown" if the caller forgets)
+#   TT_LLM_ENGINE_IMAGE  — full image reference, e.g. ghcr.io/tenstorrent/tt-llm-engine/blaze:<sha>
 #   TT_INFERENCE_SERVER_COMMIT_SHA_OR_TAG — stamped into /info for debugging
 #
 # Runtime auth: docker login to ghcr.io with read access on tt-llm-engine/blaze.
 # ==============================================================================
 
-# IMPORTANT: TT_LLM_ENGINE_IMAGE MUST be passed via --build-arg. The
-# sentinel default below produces a clear "manifest unknown" error if the
-# caller forgets — better than a cryptic "invalid reference format".
+# IMPORTANT: TT_LLM_ENGINE_IMAGE MUST be passed via --build-arg
 ARG TT_LLM_ENGINE_IMAGE=ghcr.io/tenstorrent/tt-llm-engine/blaze:MUST_PASS_TT_LLM_ENGINE_IMAGE_AT_BUILD_TIME
 
 # ==============================================================================

--- a/tt-media-server/Dockerfile.blaze
+++ b/tt-media-server/Dockerfile.blaze
@@ -12,18 +12,20 @@
 # rebuilt tt-metal and tt-llm-engine on every blaze build even when nothing
 # upstream had changed.
 #
-# Pinning (mirrors PR #3917):
-#   The tt-llm-engine SHA is sourced from the superproject's submodule
-#   gitlink: `git rev-parse :tt-media-server/cpp_server/tt-llm-engine`.
-#   That SHA is passed via --build-arg TT_LLM_ENGINE_COMMIT and used as
-#   the engine image tag. Single source of truth = the submodule pointer;
-#   no chance of consumer/engine drift.
+# Pinning model:
+#   The caller passes the FULL engine image reference as a build-arg, e.g.
+#     --build-arg TT_LLM_ENGINE_IMAGE=ghcr.io/tenstorrent/tt-llm-engine/blaze:a018a2d6b270
+#   This Dockerfile does not derive or compute the tag — the operator
+#   picks the exact image (by sha, short-sha, or :latest) at dispatch
+#   time. Source of truth = whatever the caller passes.
 #
 # Required build args:
-#   TT_LLM_ENGINE_COMMIT              — full SHA of the tt-llm-engine
-#                                       submodule pointer (required;
-#                                       FROM fails with "manifest unknown"
-#                                       if not set)
+#   TT_LLM_ENGINE_IMAGE                   — full image reference for the
+#                                           prebuilt engine image
+#                                           (required; FROM fails with
+#                                           "manifest unknown" if not set
+#                                           because the sentinel default
+#                                           below isn't a valid tag)
 #   TT_INFERENCE_SERVER_COMMIT_SHA_OR_TAG — stamped into /info for debugging
 #
 # Required runtime auth (on the docker build host):
@@ -31,11 +33,10 @@
 #   ghcr.io/tenstorrent/tt-llm-engine/blaze.
 # ==============================================================================
 
-# IMPORTANT: TT_LLM_ENGINE_COMMIT MUST be passed via --build-arg. The
+# IMPORTANT: TT_LLM_ENGINE_IMAGE MUST be passed via --build-arg. The
 # sentinel default below produces a clear "manifest unknown" error if the
 # caller forgets — better than a cryptic "invalid reference format".
-ARG TT_LLM_ENGINE_COMMIT=MUST_PASS_TT_LLM_ENGINE_COMMIT_FROM_SUBMODULE_POINTER
-ARG TT_LLM_ENGINE_IMAGE=ghcr.io/tenstorrent/tt-llm-engine/blaze:${TT_LLM_ENGINE_COMMIT}
+ARG TT_LLM_ENGINE_IMAGE=ghcr.io/tenstorrent/tt-llm-engine/blaze:MUST_PASS_TT_LLM_ENGINE_IMAGE_AT_BUILD_TIME
 
 # ==============================================================================
 # ENGINE STAGE - prebuilt tt-llm-engine + tt-metal artifacts.
@@ -53,9 +54,11 @@ LABEL org.opencontainers.image.source=https://github.com/tenstorrent/tt-inferenc
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TT_INFERENCE_SERVER_COMMIT_SHA_OR_TAG=unknown
-ARG TT_LLM_ENGINE_COMMIT=MUST_PASS_TT_LLM_ENGINE_COMMIT_FROM_SUBMODULE_POINTER
+# Surface the engine image reference inside the runtime image for
+# debugging — `cat /etc/tt-llm-engine-image` to see what was pulled.
+ARG TT_LLM_ENGINE_IMAGE
 ENV TT_INFERENCE_SERVER_COMMIT_SHA_OR_TAG=${TT_INFERENCE_SERVER_COMMIT_SHA_OR_TAG}
-ENV TT_LLM_ENGINE_COMMIT=${TT_LLM_ENGINE_COMMIT}
+ENV TT_LLM_ENGINE_IMAGE=${TT_LLM_ENGINE_IMAGE}
 
 ENV ENVIRONMENT=development
 ENV TT_MM_THROTTLE_PERF=5

--- a/tt-media-server/Dockerfile.blaze
+++ b/tt-media-server/Dockerfile.blaze
@@ -3,35 +3,57 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 # ==============================================================================
-# BUILDER STAGE - build tt-metal and inference server
+# Slim Dockerfile.blaze (v2 split)
+# ------------------------------------------------------------------------------
+# Consumes a prebuilt tt-llm-engine image (built and published by
+# tenstorrent/tt-llm-engine's CI) and only compiles the tt-media-server
+# cpp_server on top. Replaces the previous "clone tt-llm-engine + build
+# tt-metal + build engine + build cpp_server" monolithic flow, which
+# rebuilt tt-metal and tt-llm-engine on every blaze build even when nothing
+# upstream had changed.
+#
+# Pinning (mirrors PR #3917):
+#   The tt-llm-engine SHA is sourced from the superproject's submodule
+#   gitlink: `git rev-parse :tt-media-server/cpp_server/tt-llm-engine`.
+#   That SHA is passed via --build-arg TT_LLM_ENGINE_COMMIT and used as
+#   the engine image tag. Single source of truth = the submodule pointer;
+#   no chance of consumer/engine drift.
+#
+# Required build args:
+#   TT_LLM_ENGINE_COMMIT              — full SHA of the tt-llm-engine
+#                                       submodule pointer (required;
+#                                       FROM fails with "manifest unknown"
+#                                       if not set)
+#   TT_INFERENCE_SERVER_COMMIT_SHA_OR_TAG — stamped into /info for debugging
+#
+# Required runtime auth (on the docker build host):
+#   docker login ghcr.io with a token that has read access on
+#   ghcr.io/tenstorrent/tt-llm-engine/blaze.
 # ==============================================================================
-# Note: Dependencies installed in this stage are NOT included in the final image.
-# Only the built artifacts and files are copied to the runtime stage.
-# Runtime dependencies must be installed separately in the runtime stage.
+
+# IMPORTANT: TT_LLM_ENGINE_COMMIT MUST be passed via --build-arg. The
+# sentinel default below produces a clear "manifest unknown" error if the
+# caller forgets — better than a cryptic "invalid reference format".
+ARG TT_LLM_ENGINE_COMMIT=MUST_PASS_TT_LLM_ENGINE_COMMIT_FROM_SUBMODULE_POINTER
+ARG TT_LLM_ENGINE_IMAGE=ghcr.io/tenstorrent/tt-llm-engine/blaze:${TT_LLM_ENGINE_COMMIT}
+
+# ==============================================================================
+# ENGINE STAGE - prebuilt tt-llm-engine + tt-metal artifacts.
+# Used purely as a file source for COPY --from=engine; never actually run.
+# ==============================================================================
+FROM ${TT_LLM_ENGINE_IMAGE} AS engine
+
+# ==============================================================================
+# BUILDER STAGE - compile cpp_server against the prebuilt engine.
+# ==============================================================================
 FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest AS builder
 
-# Build stage
 LABEL maintainer="Igor Djuric <idjuric@tenstorrent.com>"
-# connect Github repo with package
 LABEL org.opencontainers.image.source=https://github.com/tenstorrent/tt-inference-server
 
 ARG DEBIAN_FRONTEND=noninteractive
-# WARNING: TT_METAL_COMMIT_SHA_OR_TAG is documentation only — it does NOT pin
-# tt-metal. tt-metal is pulled in as a submodule of tt-llm-engine (cloned by
-# branch below), so the SHA actually compiled in is whatever the latest
-# tt-llm-engine branch tip resolves to at build time. Expect this default to
-# drift from reality. /info exposes the real tt-metal SHA from the cloned
-# submodule's .git tree at build time.
-ARG TT_METAL_COMMIT_SHA_OR_TAG=unknown
 ARG TT_INFERENCE_SERVER_COMMIT_SHA_OR_TAG=unknown
-# tt-llm-engine submodule commit, pinned to the superproject gitlink. Required;
-# pass at build time, e.g.:
-#   docker build --build-arg TT_LLM_ENGINE_COMMIT="$(git rev-parse \
-#     :tt-media-server/cpp_server/tt-llm-engine)" ...
-ARG TT_LLM_ENGINE_COMMIT
-
-# make build commit SHA available in the image for reference and debugging
-ENV TT_METAL_COMMIT_SHA_OR_TAG=${TT_METAL_COMMIT_SHA_OR_TAG}
+ARG TT_LLM_ENGINE_COMMIT=MUST_PASS_TT_LLM_ENGINE_COMMIT_FROM_SUBMODULE_POINTER
 ENV TT_INFERENCE_SERVER_COMMIT_SHA_OR_TAG=${TT_INFERENCE_SERVER_COMMIT_SHA_OR_TAG}
 ENV TT_LLM_ENGINE_COMMIT=${TT_LLM_ENGINE_COMMIT}
 
@@ -43,28 +65,34 @@ ENV CONTAINER_APP_USERNAME=container_app_user
 ARG HOME_DIR=/home/${CONTAINER_APP_USERNAME}
 ARG APP_DIR="${HOME_DIR}/app"
 ENV APP_DIR=${APP_DIR}
-# tt-metal build vars — tt-metal is a submodule of tt-llm-engine (cloned
-# further below). Its python_env is created by `./create_venv.sh` in that
-# same RUN step, so paths referenced here only have to exist before they
-# are actually used (cpp_server build, runtime).
-ENV TT_METAL_HOME=${APP_DIR}/server/cpp_server/tt-llm-engine/tt-metal
+
+# tt-metal + tt-llm-engine now live at fixed /opt paths inside the engine
+# image and are COPY --from=engine'd in below. TT_METAL_HOME is read by
+# cpp_server/build.sh (clang-20 toolchain detection, Metal C++ API includes).
+ENV TT_METAL_HOME=/opt/tt-llm-engine-src/tt-metal
 ENV CONFIG=Release
 ENV TT_METAL_ENV=dev
 ENV LOGURU_LEVEL=INFO
-# derived vars
 ENV PYTHONPATH=${TT_METAL_HOME}
-# note: PYTHON_ENV_DIR is used by create_venv.sh
 ENV PYTHON_ENV_DIR=${TT_METAL_HOME}/python_env
-ENV LD_LIBRARY_PATH=${TT_METAL_HOME}/build/lib
+# Cover both build/ and build_Release/ — tt-metal uses build_Release by default
+# but some configs symlink build/ → build_Release/.
+ENV LD_LIBRARY_PATH=${TT_METAL_HOME}/build_Release/lib:${TT_METAL_HOME}/build/lib:/opt/tt-llm-engine/lib
+# CMAKE_PREFIX_PATH composition — mirrors tt-llm-engine's own build.sh
+# --with-metal pattern. Three components, each addressing a specific
+# find_package call in the chain:
+#   1. /opt/tt-llm-engine                                       → find_package(tt-llm-engine)
+#   2. .../tt-metal/build_Release/lib/cmake                     → find_dependency(TT-Metalium) [transitive]
+#       (NOT .../build_Release/ — tt-metal also emits a non-relocatable
+#        build-tree config there which includes a sibling Metalium.cmake
+#        not present in the engine image; CMake hits that broken one first.)
+#   3. .../tt-metal/build_Release/_deps/nlohmann_json-build     → find_dependency(nlohmann_json) [transitive from tt-metalium-config]
+ENV CMAKE_PREFIX_PATH=/opt/tt-llm-engine:${TT_METAL_HOME}/build_Release/lib/cmake:${TT_METAL_HOME}/build_Release/_deps/nlohmann_json-build
 
-# apt-get might have an outdated keyring, preventing it to download packages, so we fetch the latest
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
-    && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-
-
-# extra system deps
+# System deps for the cpp_server build itself (Drogon + tokenizers-cpp + misc).
+# The heavy engine-build deps (protobuf-compiler, libprotobuf-dev) are no
+# longer needed because tt-llm-engine is consumed prebuilt.
 RUN apt-get update && apt-get install -y \
-    # required
     gosu \
     libgl1 \
     libsndfile1 \
@@ -74,13 +102,10 @@ RUN apt-get update && apt-get install -y \
     acl \
     jq \
     vim \
-    # pyluwen build dependencies (Rust package with protobuf)
     build-essential \
     python3-dev \
     libffi-dev \
     libssl-dev \
-    protobuf-compiler \
-    libprotobuf-dev \
     pkg-config \
     htop \
     screen \
@@ -90,16 +115,16 @@ RUN apt-get update && apt-get install -y \
     curl \
     iputils-ping \
     rsync \
-    && rm -rf /var/lib/apt/lists/* \
-    && protoc --version
+    && rm -rf /var/lib/apt/lists/*
 
-# Install CMake 3.26.4 to ensure compatibility with CMP0169
-RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4-linux-x86_64.sh -o cmake.sh \
-    && chmod +x cmake.sh \
-    && ./cmake.sh --skip-license --prefix=/usr/local \
-    && rm cmake.sh \
+# CMake 3.26 — cpp_server's CMakeLists requires >= 3.24; the tt-metalium
+# base ships 3.22. Same CMake the engine image uses, so consumers stay
+# in sync.
+RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4-linux-x86_64.sh -o /tmp/cmake.sh \
+    && chmod +x /tmp/cmake.sh \
+    && /tmp/cmake.sh --skip-license --prefix=/usr/local \
+    && rm /tmp/cmake.sh \
     && /usr/local/bin/cmake --version
-
 
 RUN mkdir -p ${HOME_DIR} \
     && mkdir -p /run/sshd \
@@ -107,164 +132,140 @@ RUN mkdir -p ${HOME_DIR} \
 
 RUN echo "source ${PYTHON_ENV_DIR}/bin/activate" >> ${HOME_DIR}/.bashrc
 
-# install tt-smi
-# RUN /bin/bash -c "source ${PYTHON_ENV_DIR}/bin/activate \
-#     && export CARGO_HOME=${HOME_DIR}/.cargo \
-#     && export RUSTUP_HOME=${HOME_DIR}/.rustup \
-#     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --no-modify-path \
-#     && . ${HOME_DIR}/.cargo/env \
-#     && rustup update \
-#     && uv pip install git+https://github.com/tenstorrent/tt-smi \
-#     && find ${HOME_DIR} -name '.git' -type d -exec rm -rf {} + 2>/dev/null || true"
-
 WORKDIR ${HOME_DIR}
 
-# install inference server requirements
+# ----- tt-media-server source (tt-inference-server's own code) -----
 WORKDIR ${APP_DIR}
-# ENV PYTHONPATH=${TT_METAL_HOME}
 COPY "tt-media-server" "${APP_DIR}/server"
 COPY VERSION ${APP_DIR}/VERSION
 
-# Remove any local build artifacts that were copied
+# Scrub any leftover build artifacts or stale tt-llm-engine submodule clone
+# from the build context (relevant only if a dev built the repo locally
+# before triggering the docker build).
 RUN rm -rf ${APP_DIR}/server/cpp_server/build \
     && rm -rf ${APP_DIR}/server/cpp_server/tt-llm-engine
 
-# cpp_server deps (apt + Rust if needed + Drogon)
+# cpp_server build deps (Drogon, libboost, libjsoncpp, clang-format-20).
+# Idempotent — apt packages it overlaps with above are no-ops.
 RUN cd ${APP_DIR}/server/cpp_server && ./install_dependencies.sh
 
-# Install Rust (needed for tokenizers-cpp)
+# Rust toolchain — needed by cpp_server's CMake which FetchContent's
+# tokenizers-cpp directly (separate from tt-llm-engine's tokenizers).
 RUN export CARGO_HOME=${HOME_DIR}/.cargo \
     && export RUSTUP_HOME=${HOME_DIR}/.rustup \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --no-modify-path \
     && . ${HOME_DIR}/.cargo/env \
     && rustup default stable
 
-# add tt-llm-engine — shallow-clone, then fetch + check out the pinned
-# TT_LLM_ENGINE_COMMIT (same pattern as tt-metal in tt-media-server/Dockerfile),
-# keeping the image in lockstep with the superproject's submodule gitlink. The
-# nested tt-metal submodule is pinned transitively to whatever that commit references.
-RUN --mount=type=secret,id=github_token \
-    : "${TT_LLM_ENGINE_COMMIT:?must be set to the pinned tt-llm-engine submodule SHA, e.g. --build-arg TT_LLM_ENGINE_COMMIT=\$(git rev-parse :tt-media-server/cpp_server/tt-llm-engine)}" \
-    && rm -rf ${APP_DIR}/server/cpp_server/tt-llm-engine \
-    && GITHUB_TOKEN=$(cat /run/secrets/github_token) \
-    && git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:" \
-    && git clone --depth 1 https://x-access-token:${GITHUB_TOKEN}@github.com/tenstorrent/tt-llm-engine.git ${APP_DIR}/server/cpp_server/tt-llm-engine \
-    && cd ${APP_DIR}/server/cpp_server/tt-llm-engine \
-    && git fetch --depth 1 origin ${TT_LLM_ENGINE_COMMIT} \
-    && git checkout ${TT_LLM_ENGINE_COMMIT} \
-    && git submodule update --init --recursive --depth 1 || echo "Some submodules failed, continuing..." \
-    && (cd tt-metal && ./build_metal.sh --disable-profiler && ./create_venv.sh --bundle-python) \
-    && ./setup.sh --ds-full \
-    && git config --global --unset url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf
+# ----- Pull prebuilt tt-llm-engine + tt-metal from the engine image -----
+# Replaces the entire `git clone tt-llm-engine + git submodule update +
+# build_metal.sh + create_venv.sh + setup.sh --ds-full` chunk of the
+# original Dockerfile.blaze. Everything that step used to produce in
+# ~25-30 min is delivered in seconds as image layers.
+#
+# Note: no separate COPY of /root/.local/share/uv needed — the engine
+# image uses `create_venv.sh --bundle-python`, so the Python interpreter
+# is deep-copied into tt-metal/python_env/ rather than symlinked to the
+# uv store. Mirrors PR #4019 ("Fix Docker images").
+COPY --from=engine /opt/tt-llm-engine     /opt/tt-llm-engine
+COPY --from=engine /opt/tt-llm-engine-src /opt/tt-llm-engine-src
 
-# Build C++ server (requires Rust for tokenizers-cpp)
-# Use existing Python venv, temporarily point TT_METAL_HOME to tt-llm-engine's tt-metal for the build
+# ----- Build cpp_server with ENABLE_BLAZE=ON -----
+# cpp_server/CMakeLists.txt uses find_package(tt-llm-engine CONFIG QUIET)
+# (with add_subdirectory fallback for local dev), so this build links
+# against /opt/tt-llm-engine instead of recompiling tt-llm-engine in-tree.
 RUN /bin/bash -c "source ${PYTHON_ENV_DIR}/bin/activate \
     && export CARGO_HOME=${HOME_DIR}/.cargo \
     && export RUSTUP_HOME=${HOME_DIR}/.rustup \
     && export PATH=${HOME_DIR}/.cargo/bin:${PATH} \
-    && export TT_METAL_HOME=${APP_DIR}/server/cpp_server/tt-llm-engine/tt-metal \
     && cd ${APP_DIR}/server/cpp_server \
     && ./build.sh --blaze-with-migration"
 
-# Add script for running C++ server
+# Runtime helper that picks Python vs C++ server mode.
 COPY "tt-media-server/run_cpp.sh" "${APP_DIR}/server/run_cpp.sh"
 RUN chmod +x ${APP_DIR}/server/run_cpp.sh
 
-# Cleanup build-only directories
+# Cleanup build-only directories before COPY to runtime stage.
+# Much smaller scope than the old Dockerfile.blaze since we no longer
+# have a tt-metal/.cpmcache or tt-llm-engine tree under ${APP_DIR}.
 RUN rm -rf ${HOME_DIR}/.rustup \
     && rm -rf ${HOME_DIR}/.cargo \
-    && rm -rf ${HOME_DIR}/.cache \
-    && rm -rf ${APP_DIR}/server/cpp_server/tt-llm-engine/tt-metal/.cpmcache \
-    && rm -rf ${APP_DIR}/server/cpp_server/tt-llm-engine/tt-metal/docs \
-    && rm -rf ${APP_DIR}/server/cpp_server/tt-llm-engine/tt-metal/tests \
-    && rm -rf ${APP_DIR}/server/cpp_server/tt-llm-engine/tt-metal/tech_reports \
-    && rm -rf ${APP_DIR}/server/cpp_server/tt-llm-engine/tt-metal/.github \
-    && rm -rf /usr/local/rustup \
-    && rm -rf /usr/include
+    && rm -rf ${HOME_DIR}/.cache
 
 
 # ==============================================================================
-# STRIP SOURCE - remove first-party C/C++ source from the app tree
+# STRIP SOURCE - drop first-party cpp_server C/C++ source from the app tree
 # ==============================================================================
-# Done in the BUILDER, before the cross-stage COPY, so source bytes never enter
-# any layer of the final image. A copy-then-rm in the runtime stage would only
-# add a whiteout: the source would still live in the COPY layer, fully
-# recoverable via `docker save`.
+# Done in the BUILDER, before the cross-stage COPY, so source bytes never
+# enter any layer of the final image. A copy-then-rm in the runtime stage
+# would only add a whiteout: the source would still live in the COPY
+# layer, fully recoverable via `docker save`.
 #
 # Policy: ship the Python app + compiled artifacts only.
-#   DELETE: our cpp_server source (src/include), the blaze engine source
-#           (tt-llm-engine/{src,include}), prefill_gateway, and the build-only
-#           third_party tree (boost/mooncake/...). Then sweep any remaining
-#           C/C++ source under cpp_server (e.g. CMake _deps, generated headers).
-#   KEEP:   every compiled artifact (tt_media_server_cpp, *.so, build-full libs),
-#           the vendored tt-metal tree in full (its kernels are JIT-compiled
-#           from source at runtime, and it holds python_env + build/lib), the
-#           blaze kernels tree (potential runtime JIT), and the runtime data
-#           dirs (tokenizers/resources/monitoring) plus all *.py.
+#   DELETE: cpp_server source (src/include), prefill_gateway
+#   KEEP:   every compiled artifact (tt_media_server_cpp, *.so),
+#           runtime data dirs (tokenizers/resources/monitoring), all *.py
 #
-# NOTE: `-prune` is incompatible with `-delete` (which forces `-depth`), so the
-# sweep collects with `-print0` and removes via `xargs` to honour the excludes.
+# Engine source is already stripped in the tt-llm-engine image; the
+# COPY --from=engine layers carry no first-party engine C/C++ source.
+#
+# NOTE: `-prune` is incompatible with `-delete` (which forces `-depth`),
+# so the sweep collects with `-print0` and removes via `xargs` to honour
+# the excludes.
 RUN set -eux; \
     SRV="${APP_DIR}/server"; \
-    ENG="${SRV}/cpp_server/tt-llm-engine"; \
     rm -rf "${SRV}/cpp_server/src" "${SRV}/cpp_server/include" \
-           "${SRV}/prefill_gateway" \
-           "${ENG}/src" "${ENG}/include" "${ENG}/third_party"; \
+           "${SRV}/prefill_gateway"; \
     find "${SRV}/cpp_server" \
-        -path "${ENG}/tt-metal" -prune -o \
-        -path "${ENG}/kernels" -prune -o \
         -type f \( \
            -name '*.c'  -o -name '*.cc'  -o -name '*.cpp' -o -name '*.cxx' \
         -o -name '*.h'  -o -name '*.hh'  -o -name '*.hpp' -o -name '*.hxx' \
         -o -name '*.cu' -o -name '*.cuh' \) -print0 \
       | xargs -0 -r rm -f; \
     REMAIN="$(find "${SRV}/cpp_server" \
-        -path "${ENG}/tt-metal" -prune -o \
-        -path "${ENG}/kernels" -prune -o \
         -type f \( \
            -name '*.c'  -o -name '*.cc'  -o -name '*.cpp' -o -name '*.cxx' \
         -o -name '*.h'  -o -name '*.hh'  -o -name '*.hpp' -o -name '*.hxx' \
         -o -name '*.cu' -o -name '*.cuh' \) -print)"; \
     if [ -n "${REMAIN}" ]; then \
-        echo "ERROR: first-party C/C++ source survived the strip:"; echo "${REMAIN}"; exit 1; \
+        echo "ERROR: first-party cpp_server C/C++ source survived the strip:"; echo "${REMAIN}"; exit 1; \
     fi; \
-    echo "OK: first-party C/C++ source stripped (tt-metal + blaze kernels kept for runtime JIT)"
+    echo "OK: first-party cpp_server C/C++ source stripped"
 
 # ==============================================================================
-# STRIP SYMBOLS - remove debug info + symbol tables from first-party artifacts
+# STRIP SYMBOLS - remove debug info + symbol tables from cpp_server artifacts
 # ==============================================================================
-# Deleting .cpp source is not enough: an unstripped binary/.so carries DWARF
-# debug info (.debug_*) and a full local symbol table (.symtab), which let a
-# decompiler (Ghidra/IDA) reconstruct near-source pseudocode with the original
-# names, types and line numbers, and embeds source paths. Strip our compiled
-# artifacts so only opaque machine code ships.
+# Deleting .cpp source is not enough: an unstripped binary/.so carries
+# DWARF debug info (.debug_*) and a full local symbol table (.symtab),
+# which let a decompiler reconstruct near-source pseudocode with names
+# and types. Strip our compiled artifacts so only opaque machine code
+# ships.
 #   * executable  -> --strip-all
-#   * shared libs -> --strip-debug --strip-unneeded (keeps .dynsym, so the
-#     LD_PRELOADed blaze symbols and any dlsym lookups still resolve)
-# tt-metal / ttnn libs are upstream open-source and intentionally left untouched.
+#   * shared libs -> --strip-debug --strip-unneeded (keeps .dynsym, so
+#     dlsym lookups + dynamic linking still resolve)
+# tt-metal / ttnn libs are upstream open-source and intentionally left
+# untouched. Engine libs were already stripped in the tt-llm-engine image.
 RUN set -eux; \
     SRV="${APP_DIR}/server"; \
-    ENG="${SRV}/cpp_server/tt-llm-engine"; \
     BIN="${SRV}/cpp_server/build/tt_media_server_cpp"; \
     if [ -f "${BIN}" ]; then strip --strip-all "${BIN}"; fi; \
-    find "${SRV}/cpp_server/build" "${ENG}/build-full" \
+    find "${SRV}/cpp_server/build" \
         -type f \( -name '*.so' -o -name '*.so.*' \) \
         -exec strip --strip-debug --strip-unneeded {} +; \
-    echo "OK: stripped symbols + debug info from first-party binary and shared libs"
+    echo "OK: stripped symbols + debug info from first-party cpp_server binary and shared libs"
 
 
 # ==============================================================================
 # RUNTIME STAGE - final lightweight image
 # ==============================================================================
-# This is the final image that will be used. Only the built artifacts from the builder stage
-# are copied here. Any runtime dependencies needed by the application must be installed in this stage.
+# Same shape as before; path expectations changed (TT_METAL_HOME under /opt,
+# LD_LIBRARY_PATH points at the engine artifact dirs).
+# ==============================================================================
 FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest AS runtime
 
 LABEL maintainer="Igor Djuric <idjuric@tenstorrent.com>"
 LABEL org.opencontainers.image.source=https://github.com/tenstorrent/tt-inference-server
 
-# Reuse all args and environment variables
 ARG DEBIAN_FRONTEND=noninteractive
 ARG CONTAINER_APP_UID=1000
 ARG CONTAINER_APP_USERNAME=container_app_user
@@ -275,60 +276,66 @@ ENV ENVIRONMENT=development \
     SHELL=/bin/bash \
     CONTAINER_APP_USERNAME=${CONTAINER_APP_USERNAME} \
     APP_DIR=${HOME_DIR}/app \
-    TT_METAL_HOME=${HOME_DIR}/app/server/cpp_server/tt-llm-engine/tt-metal \
-    TT_METAL_RUNTIME_ROOT=${HOME_DIR}/app/server/cpp_server/tt-llm-engine/tt-metal \
+    TT_METAL_HOME=/opt/tt-llm-engine-src/tt-metal \
+    TT_METAL_RUNTIME_ROOT=/opt/tt-llm-engine-src/tt-metal \
     CONFIG=Release \
     TT_METAL_ENV=dev \
     LOGURU_LEVEL=INFO \
-    PYTHONPATH=${HOME_DIR}/app/server/cpp_server/tt-llm-engine/tt-metal \
-    PYTHON_ENV_DIR=${HOME_DIR}/app/server/cpp_server/tt-llm-engine/tt-metal/python_env \
-    LD_LIBRARY_PATH=${HOME_DIR}/app/server/cpp_server/tt-llm-engine/tt-metal/build/lib \
+    PYTHONPATH=/opt/tt-llm-engine-src/tt-metal \
+    PYTHON_ENV_DIR=/opt/tt-llm-engine-src/tt-metal/python_env \
+    LD_LIBRARY_PATH=/opt/tt-llm-engine-src/tt-metal/build_Release/lib:/opt/tt-llm-engine-src/tt-metal/build/lib:/opt/tt-llm-engine/lib \
+    CMAKE_PREFIX_PATH=/opt/tt-llm-engine:/opt/tt-llm-engine-src/tt-metal/build_Release/lib/cmake:/opt/tt-llm-engine-src/tt-metal/build_Release/_deps/nlohmann_json-build \
     TT_METAL_LOGS_PATH=${HOME_DIR}/logs
 
-# Install runtime dependencies
-# These packages are required for the application to run in production
 RUN apt-get update && apt-get install -y \
     ffmpeg \
     gosu \
     libjsoncpp-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Create user
 RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_USERNAME} \
     && mkdir -p ${HOME_DIR} ${HOME_DIR}/logs \
     && chown -R ${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} ${HOME_DIR} \
     && mkdir -p /run/sshd \
     && chmod 755 /run/sshd
 
-# Copy everything from builder
+# cpp_server build outputs + tt-media-server source + .bashrc (cpp_server
+# source already stripped + symbols already stripped in builder).
 COPY --from=builder --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} \
     /home/container_app_user ${HOME_DIR}
 
-# Fix venv permissions (COPY --chown can break symlink permissions)
+# Engine artifacts - COPY straight from the engine image so the runtime
+# image's /opt tree is byte-identical to engine's final stage, no detour
+# through builder. The venv inside tt-metal/python_env/ is self-contained
+# (--bundle-python was used at venv creation), so no separate COPY of
+# /root/.local/share/uv is needed.
+COPY --from=engine /opt/tt-llm-engine     /opt/tt-llm-engine
+COPY --from=engine /opt/tt-llm-engine-src /opt/tt-llm-engine-src
+
+# Fix venv permissions (COPY --chown above can break symlink permissions).
 RUN chmod -R +x ${PYTHON_ENV_DIR}/bin
 
-# ── Verify the final image carries no first-party C/C++ source ──────────────
-# The builder already strips + gates this; re-asserted here so a regression in
-# the wholesale COPY can never ship first-party source to production. The
-# vendored tt-metal tree and the blaze kernels tree are excluded on purpose
-# (their source is JIT-compiled at runtime).
+# ── Verify the final image carries no first-party cpp_server C/C++ source ──
+# The builder already strips + gates this; re-asserted here so a regression
+# in the wholesale COPY can never ship first-party source to production.
+# The vendored tt-metal tree and the engine kernels tree are excluded on
+# purpose (their source is JIT-compiled at runtime or only used inside the
+# engine image).
 RUN SRV="${APP_DIR}/server"; \
-    ENG="${SRV}/cpp_server/tt-llm-engine"; \
     SRC="$(find "${SRV}/cpp_server" \
-        -path "${ENG}/tt-metal" -prune -o \
-        -path "${ENG}/kernels" -prune -o \
         -type f \( \
            -name '*.c'  -o -name '*.cc'  -o -name '*.cpp' -o -name '*.cxx' \
         -o -name '*.h'  -o -name '*.hh'  -o -name '*.hpp' -o -name '*.hxx' \
         -o -name '*.cu' -o -name '*.cuh' \) -print)"; \
     if [ -n "${SRC}" ]; then \
-        echo "ERROR: first-party C/C++ source present in runtime image:"; echo "${SRC}"; exit 1; \
+        echo "ERROR: first-party cpp_server C/C++ source present in runtime image:"; echo "${SRC}"; exit 1; \
     fi; \
-    echo "verified: no first-party C/C++ source under ${SRV}/cpp_server (tt-metal + kernels excluded)"
+    echo "verified: no first-party cpp_server C/C++ source under ${SRV}/cpp_server"
 
 # ── Informational: surface any unresolved shared libs for the C++ binary ────
-# A linking gap (e.g. Drogon, the blaze libtt_llm_engine, or an RPATH into a
-# stripped build tree) shows up here in the build log. Non-fatal by design.
+# A linking gap (e.g. Drogon, the engine libtt_llm_engine, or an RPATH
+# into a stripped build tree) shows up here in the build log. Non-fatal
+# by design.
 RUN BIN="${APP_DIR}/server/cpp_server/build/tt_media_server_cpp"; \
     if [ -x "$BIN" ]; then \
         echo "ldd $BIN:"; ldd "$BIN" || true; \
@@ -342,12 +349,11 @@ RUN BIN="${APP_DIR}/server/cpp_server/build/tt_media_server_cpp"; \
     fi
 
 USER ${CONTAINER_APP_USERNAME}
-WORKDIR ${HOME_DIR}/tt-metal
 
-# Set up bashrc
+# Bashrc venv activation for interactive `docker exec` shells.
 RUN echo "source ${PYTHON_ENV_DIR}/bin/activate" >> ${HOME_DIR}/.bashrc
 
-# Switch back to root for entrypoint (it will drop to non-root user via gosu)
+# Switch back to root so the entrypoint can `gosu` drop to the non-root user.
 USER root
 COPY docker-entrypoint.sh ${HOME_DIR}/app/server/docker-entrypoint.sh
 RUN chmod +x ${HOME_DIR}/app/server/docker-entrypoint.sh

--- a/tt-media-server/Dockerfile.blaze
+++ b/tt-media-server/Dockerfile.blaze
@@ -259,6 +259,50 @@ RUN set -eux; \
 
 
 # ==============================================================================
+# STRIP cpp_server BUILD ARTIFACTS - drop ~2 GB of build-time-only state
+# ==============================================================================
+# Verified by readelf -d + ldd on tt_media_server_cpp:
+#   RUNPATH = $ORIGIN/tt-llm-engine:/opt/tt-llm-engine-src/tt-metal/build_Release/lib:/opt/tt-llm-engine/lib
+#   All NEEDED .so deps resolve from system paths + the two engine prefixes
+#   above. NOTHING inside cpp_server/build/ is on the runtime lookup path.
+# What we delete and why:
+#   - build/CMakeFiles/ (342 MB)     CMake build-graph bookkeeping
+#   - build/_deps/      (795 MB)     FetchContent source/build intermediates
+#                                    incl. Rust proc-macro .so files (compile-time only)
+#   - build/{CMakeCache.txt, build.ninja, *.cmake, compile_commands.json, ...}
+#                                    cmake/ninja generator state
+#   - top-level *_test, test_*, *_benchmark (~810 MB)  CTest binaries, not run in prod
+#   - top-level *.a (libllm_runner_lib.a, 26 MB)       link-time only; already in binary
+#   - dangling cpp_server/compile_commands.json symlink
+# Safety gates at the bottom: binary must still exist + ldd must still resolve.
+RUN set -eux; \
+    BUILD="${APP_DIR}/server/cpp_server/build"; \
+    echo "cpp_server/build/ BEFORE strip:"; du -sh "${BUILD}" || true; \
+    rm -rf "${BUILD}/CMakeFiles" "${BUILD}/_deps" ; \
+    rm -f  "${BUILD}/CMakeCache.txt" \
+           "${BUILD}/build.ninja" \
+           "${BUILD}/.ninja_log" \
+           "${BUILD}/.ninja_deps" \
+           "${BUILD}/compile_commands.json" \
+           "${BUILD}/cmake_install.cmake" ; \
+    find "${BUILD}" -maxdepth 1 -type f \
+        \( -name '*.cmake' -o -name 'CTestTestfile.cmake' \) -delete ; \
+    find "${BUILD}" -maxdepth 1 -type f \
+        \( -name '*_test' -o -name 'test_*' -o -name '*_benchmark' \) -delete ; \
+    find "${BUILD}" -maxdepth 1 -type f \
+        \( -name '*.a' -o -name '*.o' \) -delete ; \
+    rm -f "${APP_DIR}/server/cpp_server/compile_commands.json" ; \
+    echo "cpp_server/build/ AFTER strip:"; du -sh "${BUILD}" || true; \
+    test -x "${BUILD}/tt_media_server_cpp" || { echo "ERROR: tt_media_server_cpp missing after strip"; exit 1; } ; \
+    if ldd "${BUILD}/tt_media_server_cpp" 2>/dev/null | grep -q "not found" ; then \
+        echo "ERROR: unresolved .so deps for tt_media_server_cpp after strip" ; \
+        ldd "${BUILD}/tt_media_server_cpp" ; \
+        exit 1 ; \
+    fi ; \
+    echo "OK: cpp_server build artifacts stripped (~1.97 GB); binary intact + linkable"
+
+
+# ==============================================================================
 # RUNTIME STAGE - final lightweight image
 # ==============================================================================
 # Same shape as before; path expectations changed (TT_METAL_HOME under /opt,

--- a/tt-media-server/Dockerfile.blaze
+++ b/tt-media-server/Dockerfile.blaze
@@ -5,32 +5,16 @@
 # ==============================================================================
 # Slim Dockerfile.blaze (v2 split)
 # ------------------------------------------------------------------------------
-# Consumes a prebuilt tt-llm-engine image (built and published by
-# tenstorrent/tt-llm-engine's CI) and only compiles the tt-media-server
-# cpp_server on top. Replaces the previous "clone tt-llm-engine + build
-# tt-metal + build engine + build cpp_server" monolithic flow, which
-# rebuilt tt-metal and tt-llm-engine on every blaze build even when nothing
-# upstream had changed.
-#
-# Pinning model:
-#   The caller passes the FULL engine image reference as a build-arg, e.g.
-#     --build-arg TT_LLM_ENGINE_IMAGE=ghcr.io/tenstorrent/tt-llm-engine/blaze:a018a2d6b270
-#   This Dockerfile does not derive or compute the tag — the operator
-#   picks the exact image (by sha, short-sha, or :latest) at dispatch
-#   time. Source of truth = whatever the caller passes.
+# Consumes a prebuilt tt-llm-engine image and compiles cpp_server on top.
 #
 # Required build args:
-#   TT_LLM_ENGINE_IMAGE                   — full image reference for the
-#                                           prebuilt engine image
-#                                           (required; FROM fails with
-#                                           "manifest unknown" if not set
-#                                           because the sentinel default
-#                                           below isn't a valid tag)
+#   TT_LLM_ENGINE_IMAGE                   — full image reference, e.g.
+#                                           ghcr.io/tenstorrent/tt-llm-engine/blaze:<sha>
+#                                           (sentinel default triggers a clear
+#                                           "manifest unknown" if the caller forgets)
 #   TT_INFERENCE_SERVER_COMMIT_SHA_OR_TAG — stamped into /info for debugging
 #
-# Required runtime auth (on the docker build host):
-#   docker login ghcr.io with a token that has read access on
-#   ghcr.io/tenstorrent/tt-llm-engine/blaze.
+# Runtime auth: docker login to ghcr.io with read access on tt-llm-engine/blaze.
 # ==============================================================================
 
 # IMPORTANT: TT_LLM_ENGINE_IMAGE MUST be passed via --build-arg. The
@@ -93,9 +77,7 @@ ENV LD_LIBRARY_PATH=${TT_METAL_HOME}/build_Release/lib:${TT_METAL_HOME}/build/li
 #   3. .../tt-metal/build_Release/_deps/nlohmann_json-build     → find_dependency(nlohmann_json) [transitive from tt-metalium-config]
 ENV CMAKE_PREFIX_PATH=/opt/tt-llm-engine:${TT_METAL_HOME}/build_Release/lib/cmake:${TT_METAL_HOME}/build_Release/_deps/nlohmann_json-build
 
-# System deps for the cpp_server build itself (Drogon + tokenizers-cpp + misc).
-# The heavy engine-build deps (protobuf-compiler, libprotobuf-dev) are no
-# longer needed because tt-llm-engine is consumed prebuilt.
+# System deps for the cpp_server build (Drogon + tokenizers-cpp + misc).
 RUN apt-get update && apt-get install -y \
     gosu \
     libgl1 \
@@ -138,7 +120,7 @@ RUN echo "source ${PYTHON_ENV_DIR}/bin/activate" >> ${HOME_DIR}/.bashrc
 
 WORKDIR ${HOME_DIR}
 
-# ----- tt-media-server source (tt-inference-server's own code) -----
+# ----- tt-media-server source -----
 WORKDIR ${APP_DIR}
 COPY "tt-media-server" "${APP_DIR}/server"
 COPY VERSION ${APP_DIR}/VERSION
@@ -162,15 +144,9 @@ RUN export CARGO_HOME=${HOME_DIR}/.cargo \
     && rustup default stable
 
 # ----- Pull prebuilt tt-llm-engine + tt-metal from the engine image -----
-# Replaces the entire `git clone tt-llm-engine + git submodule update +
-# build_metal.sh + create_venv.sh + setup.sh --ds-full` chunk of the
-# original Dockerfile.blaze. Everything that step used to produce in
-# ~25-30 min is delivered in seconds as image layers.
-#
-# Note: no separate COPY of /root/.local/share/uv needed — the engine
-# image uses `create_venv.sh --bundle-python`, so the Python interpreter
-# is deep-copied into tt-metal/python_env/ rather than symlinked to the
-# uv store. Mirrors PR #4019 ("Fix Docker images").
+# No separate uv-store COPY needed: the engine image was built with
+# `create_venv.sh --bundle-python`, so the interpreter is deep-copied into
+# tt-metal/python_env/ rather than symlinked to /root/.local/share/uv.
 COPY --from=engine /opt/tt-llm-engine     /opt/tt-llm-engine
 COPY --from=engine /opt/tt-llm-engine-src /opt/tt-llm-engine-src
 
@@ -189,9 +165,7 @@ RUN /bin/bash -c "source ${PYTHON_ENV_DIR}/bin/activate \
 COPY "tt-media-server/run_cpp.sh" "${APP_DIR}/server/run_cpp.sh"
 RUN chmod +x ${APP_DIR}/server/run_cpp.sh
 
-# Cleanup build-only directories before COPY to runtime stage.
-# Much smaller scope than the old Dockerfile.blaze since we no longer
-# have a tt-metal/.cpmcache or tt-llm-engine tree under ${APP_DIR}.
+# Cleanup build-only directories before the cross-stage COPY.
 RUN rm -rf ${HOME_DIR}/.rustup \
     && rm -rf ${HOME_DIR}/.cargo \
     && rm -rf ${HOME_DIR}/.cache
@@ -262,19 +236,10 @@ RUN set -eux; \
 # ==============================================================================
 # STRIP cpp_server BUILD ARTIFACTS - drop ~2 GB of build-time-only state
 # ==============================================================================
-# Verified by readelf -d + ldd on tt_media_server_cpp:
-#   RUNPATH = $ORIGIN/tt-llm-engine:/opt/tt-llm-engine-src/tt-metal/build_Release/lib:/opt/tt-llm-engine/lib
-#   All NEEDED .so deps resolve from system paths + the two engine prefixes
-#   above. NOTHING inside cpp_server/build/ is on the runtime lookup path.
-# What we delete and why:
-#   - build/CMakeFiles/ (342 MB)     CMake build-graph bookkeeping
-#   - build/_deps/      (795 MB)     FetchContent source/build intermediates
-#                                    incl. Rust proc-macro .so files (compile-time only)
-#   - build/{CMakeCache.txt, build.ninja, *.cmake, compile_commands.json, ...}
-#                                    cmake/ninja generator state
-#   - top-level *_test, test_*, *_benchmark (~810 MB)  CTest binaries, not run in prod
-#   - top-level *.a (libllm_runner_lib.a, 26 MB)       link-time only; already in binary
-#   - dangling cpp_server/compile_commands.json symlink
+# Verified via readelf -d + ldd: nothing inside cpp_server/build/ is on
+# tt_media_server_cpp's RUNPATH — all .so deps resolve from system paths and
+# the two engine prefixes. Delete CMake bookkeeping (CMakeFiles/, _deps/,
+# *.cmake), top-level test/benchmark binaries, and static archives.
 # Safety gates at the bottom: binary must still exist + ldd must still resolve.
 RUN set -eux; \
     BUILD="${APP_DIR}/server/cpp_server/build"; \
@@ -305,9 +270,6 @@ RUN set -eux; \
 
 # ==============================================================================
 # RUNTIME STAGE - final lightweight image
-# ==============================================================================
-# Same shape as before; path expectations changed (TT_METAL_HOME under /opt,
-# LD_LIBRARY_PATH points at the engine artifact dirs).
 # ==============================================================================
 # FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest AS runtime
 FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-light-amd64:latest AS runtime
@@ -353,11 +315,8 @@ RUN useradd -u ${CONTAINER_APP_UID} -s /bin/bash -d ${HOME_DIR} ${CONTAINER_APP_
 COPY --from=builder --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} \
     /home/container_app_user ${HOME_DIR}
 
-# Engine artifacts - COPY straight from the engine image so the runtime
-# image's /opt tree is byte-identical to engine's final stage, no detour
-# through builder. The venv inside tt-metal/python_env/ is self-contained
-# (--bundle-python was used at venv creation), so no separate COPY of
-# /root/.local/share/uv is needed.
+# Engine artifacts — COPY straight from the engine image (not via builder)
+# so the runtime /opt tree is byte-identical to the engine's final stage.
 COPY --from=engine /opt/tt-llm-engine     /opt/tt-llm-engine
 COPY --from=engine /opt/tt-llm-engine-src /opt/tt-llm-engine-src
 

--- a/tt-media-server/Dockerfile.blaze
+++ b/tt-media-server/Dockerfile.blaze
@@ -115,7 +115,7 @@ RUN echo "source ${PYTHON_ENV_DIR}/bin/activate" >> ${HOME_DIR}/.bashrc
 
 WORKDIR ${HOME_DIR}
 
-# ----- tt-media-server source -----
+# ----- tt-inference-server source -----
 WORKDIR ${APP_DIR}
 COPY "tt-media-server" "${APP_DIR}/server"
 COPY VERSION ${APP_DIR}/VERSION

--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -239,17 +239,36 @@ if(ENABLE_BLAZE_MIGRATION AND NOT ENABLE_BLAZE)
 endif()
 
 if(ENABLE_BLAZE)
-    # tt-llm-engine (Core-only at compile time when TT::Metalium is not in scope;
-    # the Full target adds SocketPipeline support when Metalium is available).
-    set(DS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-    # tt-llm-engine has C++11 braced-init narrowing that GCC only warns on, but
-    # the tt-metal clang-20 toolchain rejects as a hard error. Downgrade it to a
-    # warning for the sub-build only; restore our stricter flags afterwards.
-    set(_tt_saved_cxx_flags "${CMAKE_CXX_FLAGS}")
-    string(APPEND CMAKE_CXX_FLAGS " -Wno-c++11-narrowing")
-    add_subdirectory(tt-llm-engine)
-    set(CMAKE_CXX_FLAGS "${_tt_saved_cxx_flags}")
-    message(STATUS "tt-llm-engine: ENABLED")
+    # Prefer a pre-built tt-llm-engine discovered via find_package — this is
+    # the path used by the Docker build, which pulls /opt/tt-llm-engine out
+    # of the tt-llm-engine builder image and sets CMAKE_PREFIX_PATH so the
+    # package is locatable. Fall back to building the in-tree submodule for
+    # local-dev workflows that don't go through Docker.
+    find_package(tt-llm-engine CONFIG QUIET)
+    if(tt-llm-engine_FOUND)
+        message(STATUS "tt-llm-engine: using pre-built package at ${tt-llm-engine_DIR}")
+    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/CMakeLists.txt")
+        # Legacy path — local dev with the submodule checked out under cpp_server/.
+        # The narrowing-warning flag is only needed when we actually compile
+        # tt-llm-engine from source; the find_package path consumes a prebuilt
+        # .so so the warning is irrelevant there.
+        set(DS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+        # tt-llm-engine has C++11 braced-init narrowing that GCC only warns on, but
+        # the tt-metal clang-20 toolchain rejects as a hard error. Downgrade it to a
+        # warning for the sub-build only; restore our stricter flags afterwards.
+        set(_tt_saved_cxx_flags "${CMAKE_CXX_FLAGS}")
+        string(APPEND CMAKE_CXX_FLAGS " -Wno-c++11-narrowing")
+        add_subdirectory(tt-llm-engine)
+        set(CMAKE_CXX_FLAGS "${_tt_saved_cxx_flags}")
+        message(STATUS "tt-llm-engine: building from in-tree submodule (legacy path)")
+    else()
+        message(FATAL_ERROR
+            "ENABLE_BLAZE=ON but tt-llm-engine is neither installed "
+            "(find_package failed) nor present in source tree at "
+            "${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine. "
+            "Either ensure the prebuilt image's /opt/tt-llm-engine is on "
+            "CMAKE_PREFIX_PATH, or initialize the tt-llm-engine submodule.")
+    endif()
 else()
     message(STATUS "tt-llm-engine: DISABLED (use -DENABLE_BLAZE=ON to enable)")
 endif()

--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -504,11 +504,31 @@ if(ENABLE_BLAZE)
         message(STATUS "Linking llm_runner_lib against TtLlmEngine::Core")
     endif()
     target_compile_definitions(llm_runner_lib PUBLIC ENABLE_BLAZE)
+    # Detect where the tt-llm-engine source tree lives. Two layouts are supported:
+    #   1. Monolithic flow (main's Dockerfile.blaze): cpp_server/tt-llm-engine/ —
+    #      cloned in-tree during the Docker build.
+    #   2. Slim flow (v2 Dockerfile.blaze): /opt/tt-llm-engine-src/ — COPY'd from
+    #      the prebuilt tt-llm-engine image's source tree.
+    # Both layouts expose the same subdirectories (src/, disaggregation/, tt-metal/),
+    # so a single root variable lets every consumer-of-engine-source path adapt.
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/CMakeLists.txt")
+        set(_TT_LLM_ENGINE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine")
+        message(STATUS "tt-llm-engine source: in-tree at ${_TT_LLM_ENGINE_ROOT}")
+    elseif(EXISTS "/opt/tt-llm-engine-src/CMakeLists.txt")
+        set(_TT_LLM_ENGINE_ROOT "/opt/tt-llm-engine-src")
+        message(STATUS "tt-llm-engine source: slim engine image at ${_TT_LLM_ENGINE_ROOT}")
+    else()
+        message(FATAL_ERROR
+            "ENABLE_BLAZE=ON but tt-llm-engine source not found. Expected either "
+            "${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/ (in-tree clone, monolithic flow) "
+            "or /opt/tt-llm-engine-src/ (slim engine image flow).")
+    endif()
+
     # Header-only MigrationClientInterface implementations (MigrationLayerClientAdapter,
     # MockMigrationClient) live under the engine's src tree rather than its public
     # include tree; blaze_utils.hpp instantiates them, so expose that path.
     target_include_directories(llm_runner_lib PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/src)
+        ${_TT_LLM_ENGINE_ROOT}/src)
 
     if(ENABLE_BLAZE_MIGRATION)
         target_compile_definitions(llm_runner_lib PUBLIC ENABLE_BLAZE_MIGRATION)
@@ -520,8 +540,8 @@ if(ENABLE_BLAZE)
         # directly into a small static lib and link it in. There is a single concrete
         # implementation (no mock/real .so swap), so static linking is sufficient for
         # both Core and LD_PRELOAD'd Full runs.
-        set(_MIG_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/disaggregation/migration)
-        set(_MIG_TT_STL "${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/tt-metal/tt_stl")
+        set(_MIG_DIR ${_TT_LLM_ENGINE_ROOT}/disaggregation/migration)
+        set(_MIG_TT_STL "${_TT_LLM_ENGINE_ROOT}/tt-metal/tt_stl")
         add_library(migration_client STATIC
             ${_MIG_DIR}/src/migration_client.cpp
             ${_MIG_DIR}/src/file_lock_guard.cpp)
@@ -529,7 +549,7 @@ if(ENABLE_BLAZE)
         target_include_directories(migration_client PUBLIC
             ${_MIG_DIR}/include
             ${_MIG_DIR}/src/worker
-            ${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/src/common
+            ${_TT_LLM_ENGINE_ROOT}/src/common
             ${TT_METAL_INCLUDE_DIRS}
             ${_MIG_TT_STL})
         target_link_libraries(migration_client PUBLIC spdlog::spdlog PRIVATE rt)

--- a/tt-media-server/run_cpp.sh
+++ b/tt-media-server/run_cpp.sh
@@ -2,11 +2,17 @@
 #
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
-# Start the C++ server
-cd cpp_server
+# Start the C++ server.
+#
+# Note on LD_PRELOAD removal (engine-split Phase 3c):
+# The previous version preloaded ./tt-llm-engine/build-full/libtt_llm_engine.so.0
+# when LLM_DEVICE_BACKEND=pipeline_manager. That path no longer exists — the
+# engine .so now lives at /opt/tt-llm-engine/lib/libtt_llm_engine.so.0 (shipped
+# by the prebuilt tt-llm-engine image) and is linked into tt_media_server_cpp
+# via find_package (cpp_server/CMakeLists.txt) plus runtime LD_LIBRARY_PATH
+# (set in Dockerfile.blaze runtime stage). There is now a single canonical
+# copy of the .so, so the preload override that distinguished build-tree from
+# install-tree copies is no longer needed.
 
-if [ "$LLM_DEVICE_BACKEND" = "pipeline_manager" ]; then
-  LD_PRELOAD=$(pwd)/tt-llm-engine/build-full/libtt_llm_engine.so.0 ./build/tt_media_server_cpp -p 8000
-else
-  ./build/tt_media_server_cpp -p 8000
-fi
+cd cpp_server
+./build/tt_media_server_cpp -p 8000


### PR DESCRIPTION
## Latest testing job

https://github.com/tenstorrent/tt-shield/actions/runs/28524471440

## slim Docker image (~9GB) to try the deployment on, prior the merge

ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-blaze:861bfc9_20260701_142158


## Summary

Split the blaze docker build so `Dockerfile.blaze` no longer clones and
rebuilds tt-llm-engine and tt-metal every time. Instead, it pulls a
prebuilt tt-llm-engine image from GHCR and only compiles cpp_server on
top. 

## Why

- Every blaze CI build was rebuilding tt-metal and tt-llm-engine from
  source, even when nothing in those repos had changed. 
- The new flow: tt-llm-engine's own CI publishes a prebuilt image; this
  Dockerfile consumes it and only compiles our own cpp_server. 

## Files changed

- `tt-media-server/Dockerfile.blaze` — rewritten as a slim consumer:
  `FROM ${TT_LLM_ENGINE_IMAGE} AS engine` + `COPY --from=engine
  /opt/tt-llm-engine{,-src}`. 
- `tt-media-server/cpp_server/CMakeLists.txt` — uses
  `find_package(tt-llm-engine CONFIG)` to link against the prebuilt
  engine. Detects both source layouts (in-tree clone or engine-image
  source tree) so local dev and slim Docker builds both work.
- `tt-media-server/run_cpp.sh` — LD_PRELOAD dropped. The engine .so
  lives at the `/opt/tt-llm-engine/lib/` and is discovered
  via `LD_LIBRARY_PATH`.

## New build-arg

`Dockerfile.blaze` now requires:

`--build-arg TT_LLM_ENGINE_IMAGE=ghcr.io/tenstorrent/tt-llm-engine/blaze:<sha>`

## Additional cleanup on the metal image

- Base image changed from `tt-metalium/ubuntu-22.04-dev-amd64` to the
  `-light-amd64` variant, which drops the ~3.3 GB `/opt/venv` that
  tt-metal's dev image ships for model demos. Blaze doesn't touch
  Python at runtime.

## How to trigger a fresh blaze build

Dispatch tt-shield's `on-dispatch-build-media-server` workflow with:
- `inference-server-type`: `blaze-media-inference-server`
- `inference-server-git-ref`: eg. main
- `tt-llm-engine-image`: a real published SHA, e.g.
  `ghcr.io/tenstorrent/tt-llm-engine/blaze:<sha-from-engine-CI>`
  (`:latest` default).