### PR TITLE
reenable gatewat split test

### DIFF
--- a/.github/workflows/cpp-heavy-checks.yml
+++ b/.github/workflows/cpp-heavy-checks.yml
@@ -652,7 +652,6 @@ jobs:
           fi
 
   cpp-server-gateway-split:
-    if: ${{ inputs.run_split_tests }}
     name: C++ Server Gateway Split Test
     # Self-hosted: this job launches a PrefillGateway plus 3-4 cpp_server
     # processes (each -t 4) concurrently. On a 4-core GitHub runner that

--- a/.github/workflows/cpp-heavy-checks.yml
+++ b/.github/workflows/cpp-heavy-checks.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       run_split_tests:
-        description: 'Run the prefill/decode split test)'
+        description: 'Run the prefill/decode split test'
         type: boolean
         default: false
 

--- a/.github/workflows/cpp-heavy-checks.yml
+++ b/.github/workflows/cpp-heavy-checks.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       run_split_tests:
-        description: 'Run the split tests (prefill/decode and gateway)'
+        description: 'Run the prefill/decode split test)'
         type: boolean
         default: false
 


### PR DESCRIPTION
c++ heavy check runs:
https://github.com/tenstorrent/tt-inference-server/actions/runs/28577039607
https://github.com/tenstorrent/tt-inference-server/actions/runs/28580675014