### PR TITLE
Make missing spec tests for model not mandatory

### DIFF
--- a/tt-inference-server-v2/test_module/dispatch.py
+++ b/tt-inference-server-v2/test_module/dispatch.py
@@ -188,6 +188,11 @@ def run_spec_tests(ctx: MediaContext) -> Tuple[int, Optional[Block]]:
     is non-zero if any test class raised or any Block did not explicitly
     report ``success=True`` (missing key, non-dict data, or any non-True
     value all count as failures).
+
+    An empty filter result (no suite in ``test_module/test_suites/*.json``
+    matches this model+device pair) is treated as a clean no-op: a warning
+    is logged and ``(0, None)`` is returned, so a model that has not yet
+    been wired into the spec-test config does not fail the whole workflow.
     """
     logger.info(
         "Running spec_tests for model=%s, device=%s",
@@ -196,12 +201,12 @@ def run_spec_tests(ctx: MediaContext) -> Tuple[int, Optional[Block]]:
     )
     suites = _resolve_spec_test_suites(ctx)
     if not suites:
-        logger.error(
-            "No spec test suites match model=%r device=%r — nothing to do.",
+        logger.warning(
+            "No spec test suites match model=%r device=%r — skipping spec_tests.",
             ctx.model_spec.model_name,
             ctx.device.name.lower(),
         )
-        return 1, None
+        return 0, None
 
     cap = ctx.spec_tests_num_prompts_cap
     blocks: List[Block] = []

--- a/tt-inference-server-v2/workflow_module/execution.py
+++ b/tt-inference-server-v2/workflow_module/execution.py
@@ -277,7 +277,7 @@ class WorkflowExecution(ABC):
 
         elapsed = time.time() - started
         block_kind = block.kind if block is not None else None
-        if exit_code != 0 or block is None:
+        if exit_code != 0:
             self.logger.error(
                 "❌ task=%s rc=%d block=%s (%.1fs)",
                 task_type.value,
@@ -285,6 +285,10 @@ class WorkflowExecution(ABC):
                 block_kind,
                 elapsed,
             )
+        elif block is None:
+            # Runner intentionally produced no block (e.g. spec_tests found
+            # no matching suites for this model+device)
+            self.logger.info("⏭  task=%s no-op rc=0 (%.1fs)", task_type.value, elapsed)
         else:
             self.logger.info(
                 "✅ task=%s block=%s (%.1fs)", task_type.value, block_kind, elapsed


### PR DESCRIPTION
### Summary

Make missing spec tests for model not mandatory - it will not fail whole workflow, it will just print a warning.