### PR TITLE
Forge LLMs (P150): enable b32 / high-seq-len / chunked-prefill / b1-prefill serving + eval tuning

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -1259,16 +1259,11 @@ _eval_config_list = [
                     "max_length": 65536,
                 },
                 # gen_kwargs chosen according to https://huggingface.co/Qwen/Qwen3-8B#best-practices
-                # max_gen_toks lowered from 32768 to 12288 so `prompt + max_gen_toks`
-                # fits the forge_vllm_plugin P150 max_model_len=16384 envelope.
-                # Observed r1_gpqa_diamond prompts run up to ~2.4k tokens, so a
-                # 12288 output cap leaves ~3700-token headroom. The original 32K
-                # output budget is intended for ≥64K-context devices; clamping
-                # here is safe at 16K but caps reasoning depth on long-context
-                # devices too — revisit if a >16K-context Qwen3-8B impl lands.
+                # max_gen_toks restored 12288 -> 32768: fits the P150 max_model_len
+                # 40960 (was 16384 when clamped); the clamp truncated reasoning.
                 gen_kwargs={
                     "stream": "true",
-                    "max_gen_toks": 12288,
+                    "max_gen_toks": 32768,
                     "until": [],
                     "do_sample": "true",
                     "temperature": 0.6,
@@ -1302,15 +1297,11 @@ _eval_config_list = [
                     "timeout": "3600",
                 },
                 # gen_kwargs chosen according to https://huggingface.co/Qwen/Qwen3-8B#best-practices
-                # max_gen_toks lowered 32768 -> 12288 for forge P150 (max_model_len=16384).
-                # Earlier value 14336 assumed prompts ≤ ~1.1k tokens; observed CI
-                # prompts run up to 2477, so 14336 + 2477 = 16813 > 16384 → 4xx
-                # rejection on every long-prompt sample, cascading into a 6h
-                # workflow timeout. 12288 matches r1_gpqa_diamond and leaves
-                # ~3700 tokens of prompt headroom. Tracked in #4000.
+                # max_gen_toks restored 12288 -> 32768: fits the P150 max_model_len
+                # 40960 (was 16384 when clamped). Tracked in #4000.
                 gen_kwargs={
                     "stream": "true",
-                    "max_gen_toks": 12288,
+                    "max_gen_toks": 32768,
                     "until": [],
                     "do_sample": "true",
                     "temperature": 0.6,
@@ -1346,12 +1337,10 @@ _eval_config_list = [
                 model_kwargs={
                     "max_length": 65536,
                 },
-                # max_gen_toks lowered 32768 -> 12288 so `prompt + max_gen_toks`
-                # fits forge_vllm_plugin P150 max_model_len=16384. See the same
-                # note on the Qwen3-8B r1_gpqa_diamond entry above.
+                # max_gen_toks restored 12288 -> 32768 (see Qwen3-8B gpqa above).
                 gen_kwargs={
                     "stream": "true",
-                    "max_gen_toks": 12288,
+                    "max_gen_toks": 32768,
                     "until": [],
                     "do_sample": "true",
                     "temperature": 0.6,
@@ -1384,12 +1373,10 @@ _eval_config_list = [
                     "max_length": 65536,
                     "timeout": "3600",
                 },
-                # max_gen_toks lowered 32768 -> 12288 so `prompt + max_gen_toks`
-                # fits forge P150 max_model_len=16384. See the same note on the
-                # Qwen3-8B mmlu_pro entry above. Tracked in #4000.
+                # max_gen_toks restored 12288 -> 32768 (see Qwen3-8B above). #4000.
                 gen_kwargs={
                     "stream": "true",
-                    "max_gen_toks": 12288,
+                    "max_gen_toks": 32768,
                     "until": [],
                     "do_sample": "true",
                     "temperature": 0.6,

--- a/tt-media-server/config/vllm_settings.py
+++ b/tt-media-server/config/vllm_settings.py
@@ -13,15 +13,16 @@ class VLLMSettings(BaseModel):
     min_context_length: int = 128
     max_model_length: int = int(os.environ.get("MAX_MODEL_LENGTH", 4096))
     max_num_seqs: int = int(os.environ.get("MAX_NUM_SEQS", 1))
-    # With chunked prefill (PREFILL_CHUNK_SIZE set), the batched-token budget only
-    # needs batch * chunk rather than batch * full-context, freeing device memory
-    # for KV cache. Falls back to batch * full-context when unset.
+    # Chunked prefill (PREFILL_CHUNK_SIZE set): budget is batch * chunk, floored at
+    # max_model_length so it clears vLLM's max_num_batched_tokens >= max_model_len
+    # check (we pass enable_chunked_prefill=False). The tt-xla plugin re-derives
+    # batch*chunk after, preserving the KV saving. Else: batch * full-context.
     _prefill_chunk_size_env = os.environ.get("PREFILL_CHUNK_SIZE", "").strip()
     prefill_chunk_size: int = (
         int(_prefill_chunk_size_env) if _prefill_chunk_size_env else 0
     )
     max_num_batched_tokens: int = (
-        max_num_seqs * prefill_chunk_size
+        max(max_num_seqs * prefill_chunk_size, max_model_length)
         if prefill_chunk_size
         else max_model_length * max_num_seqs
     )

--- a/tt-media-server/config/vllm_settings.py
+++ b/tt-media-server/config/vllm_settings.py
@@ -10,10 +10,21 @@ from pydantic import BaseModel
 
 class VLLMSettings(BaseModel):
     model: str = SupportedModels.QWEN_3_4B.value
-    min_context_length: int = 32
+    min_context_length: int = 128
     max_model_length: int = int(os.environ.get("MAX_MODEL_LENGTH", 4096))
     max_num_seqs: int = int(os.environ.get("MAX_NUM_SEQS", 1))
-    max_num_batched_tokens: int = max_model_length * max_num_seqs
+    # With chunked prefill (PREFILL_CHUNK_SIZE set), the batched-token budget only
+    # needs batch * chunk rather than batch * full-context, freeing device memory
+    # for KV cache. Falls back to batch * full-context when unset.
+    _prefill_chunk_size_env = os.environ.get("PREFILL_CHUNK_SIZE", "").strip()
+    prefill_chunk_size: int = (
+        int(_prefill_chunk_size_env) if _prefill_chunk_size_env else 0
+    )
+    max_num_batched_tokens: int = (
+        max_num_seqs * prefill_chunk_size
+        if prefill_chunk_size
+        else max_model_length * max_num_seqs
+    )
     # Fraction of TT-device memory allocated for model weights + KV cache.
     # Env-driven so it can be flipped per-run without rebuilding the image.
     # README documents the GPU_MEMORY_UTILIZATION knob (bare, not VLLM__-

--- a/tt-media-server/tt_model_runners/vllm_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_runner.py
@@ -57,6 +57,36 @@ class VLLMForgeRunner(BaseDeviceRunner):
         optimization_level = int(os.getenv("OPTIMIZATION_LEVEL", "1"))
         cpu_sampling = os.getenv("CPU_SAMPLING", "true").lower() == "true"
         enable_trace = os.getenv("ENABLE_TRACE", "true").lower() == "true"
+        # BFP8 KV cache ("bfp_bf8" halves the KV footprint vs bf16; "" -> bf16).
+        kv_cache_dtype = os.getenv("KV_CACHE_DTYPE", "")
+        # On-device chunked-SDPA prefill chunk size: without it the full-context
+        # prefill SDPA buffer OOMs the DRAM banks at 32K/64K. Only passed when set.
+        prefill_chunk_size = os.getenv("PREFILL_CHUNK_SIZE")
+        # "false" -> bf16 matmul dest accumulation (smaller buffers). Only passed
+        # when set, so other models keep the plugin default.
+        fp32_dest_acc_en = os.getenv("FP32_DEST_ACC_EN")
+        # b1-prefill (tt-xla #5281): compile a small [min_num_seqs, n] prefill graph
+        # alongside b32 and route <= prefill_batch_threshold pending prefills to it
+        # (lower TTFT) while decode stays at max_num_seqs. Only passed when set.
+        min_num_seqs = os.getenv("MIN_NUM_SEQS")
+        prefill_batch_threshold = os.getenv("PREFILL_BATCH_THRESHOLD")
+        additional_config = {
+            "enable_const_eval": True,
+            "min_context_len": self.settings.vllm.min_context_length,
+            "experimental_weight_dtype": "bfp_bf8",
+            "experimental_kv_cache_dtype": kv_cache_dtype,
+            "cpu_sampling": cpu_sampling,
+            "optimization_level": optimization_level,
+            "enable_trace": enable_trace,
+        }
+        if prefill_chunk_size:
+            additional_config["prefill_chunk_size"] = int(prefill_chunk_size)
+        if fp32_dest_acc_en is not None:
+            additional_config["fp32_dest_acc_en"] = fp32_dest_acc_en.lower() == "true"
+        if min_num_seqs:
+            additional_config["min_num_seqs"] = int(min_num_seqs)
+        if prefill_batch_threshold:
+            additional_config["prefill_batch_threshold"] = int(prefill_batch_threshold)
         engine_args = AsyncEngineArgs(
             model=self.settings.vllm.model,
             max_model_len=self.settings.vllm.max_model_length,
@@ -64,14 +94,7 @@ class VLLMForgeRunner(BaseDeviceRunner):
             max_num_seqs=self.settings.vllm.max_num_seqs,
             enable_chunked_prefill=False,
             gpu_memory_utilization=self.settings.vllm.gpu_memory_utilization,
-            additional_config={
-                "enable_const_eval": True,
-                "min_context_len": self.settings.vllm.min_context_length,
-                "experimental_weight_dtype": "bfp_bf8",
-                "cpu_sampling": cpu_sampling,
-                "optimization_level": optimization_level,
-                "enable_trace": enable_trace,
-            },
+            additional_config=additional_config,
         )
         self.logger.info(
             f"Device {self.device_id}: additional_config={engine_args.additional_config}"

--- a/workflows/model_specs/dev/cnn.yaml
+++ b/workflows/model_specs/dev/cnn.yaml
@@ -15,17 +15,22 @@ templates:
   uses_tensor_model_cache: false
   device_model_specs:
     - device: P150
-      max_concurrency: 4
-      max_context: 16384
+      max_concurrency: 32
+      max_context: 40960  # Qwen3 native max_position_embeddings
       default_impl: true
       eval_max_retries: 1
       env_vars:
-        MAX_MODEL_LENGTH: "16384"
-        MAX_NUM_SEQS: "4"
-        GPU_MEMORY_UTILIZATION: "0.35"
+        MAX_MODEL_LENGTH: "40960"
+        MAX_NUM_SEQS: "32"
+        GPU_MEMORY_UTILIZATION: "0.30"
         TT_KV_POOL_GB: "32"
         OPTIMIZATION_LEVEL: "1"
+        CPU_SAMPLING: "false"
         ENABLE_TRACE: "true"
+        KV_CACHE_DTYPE: "bfp_bf8"
+        PREFILL_CHUNK_SIZE: "2048"
+        MIN_NUM_SEQS: "1"  # b1-prefill: compile [1,n] graph alongside [32,n] (tt-xla #5281)
+        PREFILL_BATCH_THRESHOLD: "16"  # route <=16 pending prefills to b1, serially
 
 - weights:
     - meta-llama/Llama-3.2-3B
@@ -38,17 +43,22 @@ templates:
   uses_tensor_model_cache: false
   device_model_specs:
     - device: P150
-      max_concurrency: 4
-      max_context: 16384
-      default_impl: false
+      max_concurrency: 32
+      max_context: 65536  # 64 * 1024
+      default_impl: true
       eval_max_retries: 1
       env_vars:
-        MAX_MODEL_LENGTH: "16384"
-        MAX_NUM_SEQS: "4"
-        GPU_MEMORY_UTILIZATION: "0.35"
+        MAX_MODEL_LENGTH: "65536"
+        MAX_NUM_SEQS: "32"
+        GPU_MEMORY_UTILIZATION: "0.30"
         TT_KV_POOL_GB: "32"
         OPTIMIZATION_LEVEL: "1"
+        CPU_SAMPLING: "false"
         ENABLE_TRACE: "true"
+        KV_CACHE_DTYPE: "bfp_bf8"
+        PREFILL_CHUNK_SIZE: "2048"
+        MIN_NUM_SEQS: "1"  # b1-prefill: compile [1,n] graph alongside [32,n] (tt-xla #5281)
+        PREFILL_BATCH_THRESHOLD: "16"  # route <=16 pending prefills to b1, serially
 
 - weights:
     - meta-llama/Llama-3.1-8B-Instruct
@@ -60,17 +70,22 @@ templates:
   uses_tensor_model_cache: false
   device_model_specs:
     - device: P150
-      max_concurrency: 4
-      max_context: 16384
-      default_impl: false
+      max_concurrency: 32
+      max_context: 65536  # 64 * 1024
+      default_impl: true
       eval_max_retries: 1
       env_vars:
-        MAX_MODEL_LENGTH: "16384"
-        MAX_NUM_SEQS: "4"
+        MAX_MODEL_LENGTH: "65536"
+        MAX_NUM_SEQS: "32"
         GPU_MEMORY_UTILIZATION: "0.30"
         TT_KV_POOL_GB: "32"
         OPTIMIZATION_LEVEL: "1"
+        CPU_SAMPLING: "false"
         ENABLE_TRACE: "true"
+        KV_CACHE_DTYPE: "bfp_bf8"
+        PREFILL_CHUNK_SIZE: "2048"
+        MIN_NUM_SEQS: "1"  # b1-prefill: compile [1,n] graph alongside [32,n] (tt-xla #5281)
+        PREFILL_BATCH_THRESHOLD: "16"  # route <=16 pending prefills to b1, serially
 
 - weights:
     - Qwen/Qwen3-8B
@@ -82,17 +97,22 @@ templates:
   uses_tensor_model_cache: false
   device_model_specs:
     - device: P150
-      max_concurrency: 4
-      max_context: 16384
-      default_impl: false
+      max_concurrency: 32
+      max_context: 40960  # Qwen3 native max_position_embeddings
+      default_impl: true
       eval_max_retries: 1
       env_vars:
-        MAX_MODEL_LENGTH: "16384"
-        MAX_NUM_SEQS: "4"
+        MAX_MODEL_LENGTH: "40960"
+        MAX_NUM_SEQS: "32"
         GPU_MEMORY_UTILIZATION: "0.30"
         TT_KV_POOL_GB: "32"
         OPTIMIZATION_LEVEL: "1"
+        CPU_SAMPLING: "false"
         ENABLE_TRACE: "true"
+        KV_CACHE_DTYPE: "bfp_bf8"
+        PREFILL_CHUNK_SIZE: "2048"
+        MIN_NUM_SEQS: "1"  # b1-prefill: compile [1,n] graph alongside [32,n] (tt-xla #5281)
+        PREFILL_BATCH_THRESHOLD: "16"  # route <=16 pending prefills to b1, serially
 
 - weights:
     - tiiuae/Falcon3-7B-Instruct
@@ -104,17 +124,24 @@ templates:
   uses_tensor_model_cache: false
   device_model_specs:
     - device: P150
-      max_concurrency: 4
-      max_context: 16384
+      max_concurrency: 32
+      max_context: 32768  # Falcon3 native max_position_embeddings
       default_impl: true
       eval_max_retries: 1
       env_vars:
-        MAX_MODEL_LENGTH: "16384"
-        MAX_NUM_SEQS: "4"
-        GPU_MEMORY_UTILIZATION: "0.225"
+        MAX_MODEL_LENGTH: "32768"
+        MAX_NUM_SEQS: "32"
+        GPU_MEMORY_UTILIZATION: "0.30"
         TT_KV_POOL_GB: "32"
         OPTIMIZATION_LEVEL: "1"
+        CPU_SAMPLING: "false"
         ENABLE_TRACE: "true"
+        KV_CACHE_DTYPE: "bfp_bf8"
+        # 1024 (not 2048): Falcon3 head_dim=256 makes the b32 prefill SDPA buffer
+        # DRAM-OOM at chunk 2048 during trace-capture.
+        PREFILL_CHUNK_SIZE: "1024"
+        MIN_NUM_SEQS: "1"  # b1-prefill: compile [1,n] graph alongside [32,n] (tt-xla #5281)
+        PREFILL_BATCH_THRESHOLD: "16"  # route <=16 pending prefills to b1, serially
 
 - weights:
     # gemma-4-31b-it Forge LLM (tensor-parallel) on p300x2/QB2. Lowercase

--- a/workflows/model_specs/dev/cnn.yaml
+++ b/workflows/model_specs/dev/cnn.yaml
@@ -22,13 +22,13 @@ templates:
       env_vars:
         MAX_MODEL_LENGTH: "40960"
         MAX_NUM_SEQS: "32"
-        GPU_MEMORY_UTILIZATION: "0.30"
+        GPU_MEMORY_UTILIZATION: "0.5"
         TT_KV_POOL_GB: "32"
         OPTIMIZATION_LEVEL: "1"
         CPU_SAMPLING: "false"
         ENABLE_TRACE: "true"
         KV_CACHE_DTYPE: "bfp_bf8"
-        PREFILL_CHUNK_SIZE: "2048"
+        PREFILL_CHUNK_SIZE: "1024"
         MIN_NUM_SEQS: "1"  # b1-prefill: compile [1,n] graph alongside [32,n] (tt-xla #5281)
         PREFILL_BATCH_THRESHOLD: "16"  # route <=16 pending prefills to b1, serially
 
@@ -50,13 +50,13 @@ templates:
       env_vars:
         MAX_MODEL_LENGTH: "65536"
         MAX_NUM_SEQS: "32"
-        GPU_MEMORY_UTILIZATION: "0.30"
+        GPU_MEMORY_UTILIZATION: "0.5"
         TT_KV_POOL_GB: "32"
         OPTIMIZATION_LEVEL: "1"
         CPU_SAMPLING: "false"
         ENABLE_TRACE: "true"
         KV_CACHE_DTYPE: "bfp_bf8"
-        PREFILL_CHUNK_SIZE: "2048"
+        PREFILL_CHUNK_SIZE: "1024"
         MIN_NUM_SEQS: "1"  # b1-prefill: compile [1,n] graph alongside [32,n] (tt-xla #5281)
         PREFILL_BATCH_THRESHOLD: "16"  # route <=16 pending prefills to b1, serially
 
@@ -77,13 +77,13 @@ templates:
       env_vars:
         MAX_MODEL_LENGTH: "65536"
         MAX_NUM_SEQS: "32"
-        GPU_MEMORY_UTILIZATION: "0.30"
+        GPU_MEMORY_UTILIZATION: "0.35"
         TT_KV_POOL_GB: "32"
         OPTIMIZATION_LEVEL: "1"
         CPU_SAMPLING: "false"
         ENABLE_TRACE: "true"
         KV_CACHE_DTYPE: "bfp_bf8"
-        PREFILL_CHUNK_SIZE: "2048"
+        PREFILL_CHUNK_SIZE: "1024"
         MIN_NUM_SEQS: "1"  # b1-prefill: compile [1,n] graph alongside [32,n] (tt-xla #5281)
         PREFILL_BATCH_THRESHOLD: "16"  # route <=16 pending prefills to b1, serially
 
@@ -104,13 +104,13 @@ templates:
       env_vars:
         MAX_MODEL_LENGTH: "40960"
         MAX_NUM_SEQS: "32"
-        GPU_MEMORY_UTILIZATION: "0.30"
+        GPU_MEMORY_UTILIZATION: "0.35"
         TT_KV_POOL_GB: "32"
         OPTIMIZATION_LEVEL: "1"
         CPU_SAMPLING: "false"
         ENABLE_TRACE: "true"
         KV_CACHE_DTYPE: "bfp_bf8"
-        PREFILL_CHUNK_SIZE: "2048"
+        PREFILL_CHUNK_SIZE: "1024"
         MIN_NUM_SEQS: "1"  # b1-prefill: compile [1,n] graph alongside [32,n] (tt-xla #5281)
         PREFILL_BATCH_THRESHOLD: "16"  # route <=16 pending prefills to b1, serially
 
@@ -131,7 +131,7 @@ templates:
       env_vars:
         MAX_MODEL_LENGTH: "32768"
         MAX_NUM_SEQS: "32"
-        GPU_MEMORY_UTILIZATION: "0.30"
+        GPU_MEMORY_UTILIZATION: "0.35"
         TT_KV_POOL_GB: "32"
         OPTIMIZATION_LEVEL: "1"
         CPU_SAMPLING: "false"


### PR DESCRIPTION
## Ticket

Closes https://github.com/tenstorrent/tt-inference-server/issues/4496

## Summary

Enables the production serving configuration for the 5 single-chip P150 Forge LLMs — **Qwen3-4B, Qwen3-8B, Llama-3.2-3B-Instruct, Llama-3.1-8B-Instruct, Falcon3-7B-Instruct** — and tunes their evals to match. Brings them from the old b4 / 16K / opt0 config up to **batch-32, native max context, opt_level=1, on-device sampling, BFP8 weights + KV, on-device chunked prefill (chunk 1024), per-model GPU memory utilization, and b1-prefill scheduling**.

Depends on the tt-xla chunked-prefill + b1-prefill plugin support (uplifted to tt-inference-server via https://github.com/tenstorrent/tt-inference-server/pull/4514)

## Changes

Four commits are proposed for this PR:

### 1. `forge LLM serving: b32 / high-seq-len / chunked-prefill / b1-prefill support`

- **`tt-media-server/tt_model_runners/vllm_runner.py`** — plumb env-driven `additional_config` knobs into the tt-xla vLLM plugin, each passed only when set so other models keep the plugin defaults:
  - `KV_CACHE_DTYPE` → `experimental_kv_cache_dtype` (BFP8 KV, halves KV footprint)
  - `PREFILL_CHUNK_SIZE` → `prefill_chunk_size` (on-device chunked-SDPA prefill; avoids the full-context DRAM-OOM at 32K/64K)
  - `FP32_DEST_ACC_EN` → `fp32_dest_acc_en` (bf16 matmul dest accum; kept as a lever, not set by any spec)
  - `MIN_NUM_SEQS` + `PREFILL_BATCH_THRESHOLD` → `min_num_seqs` / `prefill_batch_threshold` (b1-prefill: compile a small prefill graph alongside b32 and route low-concurrency prefills to it; tt-xla #5281)
- **`tt-media-server/config/vllm_settings.py`** — size `max_num_batched_tokens` as `batch * prefill_chunk_size` when chunked prefill is engaged (frees device memory for KV cache), else `batch * full-context`; raise `min_context_length` 32 → 128 to match tt-xla and cut warmup graph count. (Refined in commit 4 below.)
- **`workflows/model_specs/dev/cnn.yaml`** — bump the 5 single-chip P150 Forge LLM specs to b32 / native max context / opt=1 / device sampling / BFP8 KV / chunked prefill / b1-prefill; set `default_impl: true` (single-impl models — so `run.py` resolves the forge impl for these specs without an explicit `--impl`). TP entries (gemma-4-31b, Qwen3-32B) untouched. (Per-model chunk size + gmu finalized in commit 3 below.)

### 2. `evals: restore Qwen3-8B/4B forge max_gen_toks 12288 -> 32768`

- **`evals/eval_config.py`** — `max_gen_toks` restored 12288 → 32768 on Qwen3-8B and Qwen3-4B `r1_gpqa_diamond` + `mmlu_pro`. The 12288 clamp was for the old max_model_len=16384; the specs now run 40960, so prompt + 32768 fits with headroom and no longer truncates long Qwen3 reasoning.

### 3. `forge LLMs: prefill_chunk_size 1024 + per-model GPU_MEMORY_UTILIZATION`

- **`workflows/model_specs/dev/cnn.yaml`** — set **all 5** single-chip P150 forge LLMs to `PREFILL_CHUNK_SIZE=1024` (not just Falcon). At chunk 2048 the b32 SwiGLU MLP-intermediate activation `[32, 2048, intermediate]` (Llama-3.1-8B 1.75 GiB, Qwen3-8B 1.50 GiB, Falcon3-7B 2.81 GiB) can't get a contiguous DRAM slot alongside weights + KV at max context → trace-capture OOM; lowering gmu doesn't help (contiguity-limited). chunk 1024 halves that buffer, fixing it at ~0 TTFT cost and freeing headroom to raise gmu instead.
- Per-model `GPU_MEMORY_UTILIZATION`, qualified at each model's max context (b32, trace, BFP8 weights+KV): Llama-3.1-8B / Qwen3-8B / Falcon3-7B (8B-class) = **0.35**; Llama-3.2-3B / Qwen3-4B (small) = **0.5**.

### 4. `fix: floor chunked-prefill max_num_batched_tokens at max_model_len`

- **`tt-media-server/config/vllm_settings.py`** — with chunk 1024, `batch * chunk` (32×1024 = 32768) is below `max_model_len` for the models above 32768, and vLLM rejects `max_num_batched_tokens < max_model_len` (we pass `enable_chunked_prefill=False`). Floor at `max_model_length` so it validates; the tt-xla plugin re-derives `batch * chunk` afterward, preserving the KV saving. (Masked at chunk 2048, where 65536 ≥ all max contexts.)

## Testing

This configuration has been in use for a while: these settings drove serving, evals, and benchmarks for all 5 forge LLMs both locally and on development branches (against an earlier tt-inference-server commit), so they're well exercised — this PR consolidates them onto current main.

Validation on the current config (single P150, tt-media-server on the tt-xla editable venv):

- **Chunked-prefill qualification sweep**: all 5 forge LLMs launch and serve at the production config (b32, native max context, chunk 1024, per-model gmu) with **no DRAM OOM**; compiles 7–12 min.
- Qwen3-8B full ci-nightly e2e release: gpqa **PASS** (score 65 vs published 62 / gpu-ref 64.14 — beats reference) and the full benchmark sweep runs.
- Qwen3-4B and Falcon3-7B-Instruct smoke release: **Acceptance PASS** (0 blockers).

This moves the 5 P150 forge LLMs from a non-passing nightly baseline toward the intended production config.

## Not included / follow-ups

- Bump the forge wheel pin to the official chunked-prefill + b1-prefill build. Edit: Done July 4 via https://github.com/tenstorrent/tt-inference-server/pull/4514
- **Known issue (upstream, not a config regression):** under concurrent load the served model intermittently hangs (0 tokens, streaming timeout) — a tt-metal fast-dispatch completion-queue read that never completes. Tracked in #4521. Reproduces on the shipping chunk-1024 config; independent of chunk size / gmu.
- Revisit chunk 2048 now that tt-xla #5523 (largest-first precompile reorder) has landed — see the chunk-2048 revisit task.
