### PR TITLE
Offload Json Parsing off the IO Loop

### DIFF
--- a/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
+++ b/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
@@ -29,10 +29,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include "utils/thread_pool.hpp"
-
 namespace trantor {
 class EventLoop;
+class EventLoopThreadPool;
 class TcpServer;
 class TcpClient;
 class TcpConnection;
@@ -298,13 +297,12 @@ struct ServerConfig {
   std::string model_path;
   std::string instance_id_hex;  // Auto-generated when empty.
   uint64_t instance_id = 0;     // Auto-generated when zero.
-  size_t dispatch_pool_threads = 0;
 };
 
 class DynamoServer {
  public:
   DynamoServer(ServerConfig config, GenerateHandler handler,
-               std::vector<trantor::EventLoop*> ioLoops);
+               trantor::EventLoopThreadPool* loopPool);
   ~DynamoServer();
 
   DynamoServer(const DynamoServer&) = delete;
@@ -326,12 +324,10 @@ class DynamoServer {
  private:
   ServerConfig config_;
   GenerateHandler handler_;
-  std::vector<trantor::EventLoop*> io_loops_;
+  trantor::EventLoopThreadPool* loop_pool_;
   std::unique_ptr<trantor::TcpServer> tcp_server_;
   uint16_t actual_port_ = 0;
   std::atomic<bool> running_{false};
-
-  std::unique_ptr<tt::utils::ThreadPool> dispatch_pool_;
 
   void onMessage(const std::shared_ptr<trantor::TcpConnection>& conn,
                  trantor::MsgBuffer* buf);

--- a/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
+++ b/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
@@ -29,6 +29,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "utils/thread_pool.hpp"
+
 namespace trantor {
 class EventLoop;
 class TcpServer;
@@ -296,6 +298,10 @@ struct ServerConfig {
   std::string model_path;
   std::string instance_id_hex;  // Auto-generated when empty.
   uint64_t instance_id = 0;     // Auto-generated when zero.
+  // Threads for the dispatch pool that parses request bodies and invokes the
+  // generate handler off the connection's io loop. 0 = auto (see DynamoServer
+  // ctor).
+  size_t dispatch_pool_threads = 0;
 };
 
 class DynamoServer {
@@ -327,6 +333,14 @@ class DynamoServer {
   std::unique_ptr<trantor::TcpServer> tcp_server_;
   uint16_t actual_port_ = 0;
   std::atomic<bool> running_{false};
+
+  // Parses request bodies (the ~11 ms jsoncpp decode of the 55K-token_ids
+  // array) and runs the generate handler off the connection's io loop, so a
+  // single pipelined connection no longer serializes ingestion on one thread.
+  // Declared last so it is destroyed first — its destructor joins in-flight
+  // tasks (which reference handler_ and the endpoint's loop pool) before those
+  // outlive it. See DynamoEndpoint::stop() for the loop-pool ordering.
+  std::unique_ptr<tt::utils::ThreadPool> dispatch_pool_;
 
   void onMessage(const std::shared_ptr<trantor::TcpConnection>& conn,
                  trantor::MsgBuffer* buf);

--- a/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
+++ b/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
@@ -298,9 +298,6 @@ struct ServerConfig {
   std::string model_path;
   std::string instance_id_hex;  // Auto-generated when empty.
   uint64_t instance_id = 0;     // Auto-generated when zero.
-  // Threads for the dispatch pool that parses request bodies and invokes the
-  // generate handler off the connection's io loop. 0 = auto (see DynamoServer
-  // ctor).
   size_t dispatch_pool_threads = 0;
 };
 
@@ -334,12 +331,6 @@ class DynamoServer {
   uint16_t actual_port_ = 0;
   std::atomic<bool> running_{false};
 
-  // Parses request bodies (the ~11 ms jsoncpp decode of the 55K-token_ids
-  // array) and runs the generate handler off the connection's io loop, so a
-  // single pipelined connection no longer serializes ingestion on one thread.
-  // Declared last so it is destroyed first — its destructor joins in-flight
-  // tasks (which reference handler_ and the endpoint's loop pool) before those
-  // outlive it. See DynamoEndpoint::stop() for the loop-pool ordering.
   std::unique_ptr<tt::utils::ThreadPool> dispatch_pool_;
 
   void onMessage(const std::shared_ptr<trantor::TcpConnection>& conn,

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
@@ -403,9 +403,9 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
     // How long this request occupied the connection's loop thread synchronously
     // (route + acquire + dispatch/forward). Compare against the gap between
     // consecutive stage=dispatched lines with the same loop_tid: busy_ms ~= gap
-    // means the loop is saturated (ingress-bound here); busy_ms << gap means the
-    // loop sat idle between requests (the stagger is upstream — Dynamo egress /
-    // single worker connection), not lost in this loop.
+    // means the loop is saturated (ingress-bound here); busy_ms << gap means
+    // the loop sat idle between requests (the stagger is upstream — Dynamo
+    // egress / single worker connection), not lost in this loop.
     const auto handlerBusyMs =
         std::chrono::duration_cast<std::chrono::microseconds>(
             SteadyClock::now() - recvT)

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
@@ -399,22 +399,6 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
           return cb;
         },
         std::move(handlers), std::move(cancelFn));
-
-    // How long this request occupied the connection's loop thread synchronously
-    // (route + acquire + dispatch/forward). Compare against the gap between
-    // consecutive stage=dispatched lines with the same loop_tid: busy_ms ~= gap
-    // means the loop is saturated (ingress-bound here); busy_ms << gap means
-    // the loop sat idle between requests (the stagger is upstream — Dynamo
-    // egress / single worker connection), not lost in this loop.
-    const auto handlerBusyMs =
-        std::chrono::duration_cast<std::chrono::microseconds>(
-            SteadyClock::now() - recvT)
-            .count() /
-        1000.0;
-    TT_LOG_INFO(
-        "[DynamoLatency] id={} stage=handler_returned busy_ms={:.3f} "
-        "loop_tid={}",
-        probeId.empty() ? "?" : probeId, handlerBusyMs, loopTid);
   };
 }
 
@@ -444,8 +428,6 @@ void DynamoEndpoint::start() {
   sc.endpoint = options_.endpoint;
   sc.model_name = options_.model_name;
   sc.model_path = options_.model_path;
-  // Reuse the callback-pool sizing (auto-scales with workers) for the dispatch
-  // pool that parses request bodies + runs the handler off the io loops.
   sc.dispatch_pool_threads = tt::config::callbackPoolThreads();
 
   // start() binds and listens on the pool loops synchronously; the resolved
@@ -508,14 +490,11 @@ void DynamoEndpoint::stop() {
   if (discovery_) {
     discovery_->unregisterSelf();
   }
-  if (keepalive_thread_.joinable()) keepalive_thread_.join();
+  if (keepalive_thread_.joinable()) {
+    keepalive_thread_.join();
+  }
 
-  // Destroy the server first: its dispatch pool's destructor joins in-flight
-  // parse/handler tasks, which create call-home writers on the loop pool. They
-  // must finish before the loop pool is torn down below, or a late task would
-  // call getNextLoop() on a destroyed pool.
   server_.reset();
-
   discovery_.reset();
   if (loop_pool_) {
     for (auto* loop : loop_pool_->getLoops()) {

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
@@ -428,12 +428,11 @@ void DynamoEndpoint::start() {
   sc.endpoint = options_.endpoint;
   sc.model_name = options_.model_name;
   sc.model_path = options_.model_path;
-  sc.dispatch_pool_threads = tt::config::callbackPoolThreads();
 
   // start() binds and listens on the pool loops synchronously; the resolved
   // port is available immediately afterwards.
   server_ = std::make_unique<DynamoServer>(sc, makeGenerateHandler(),
-                                           loop_pool_->getLoops());
+                                           loop_pool_.get());
   server_->start();
   if (server_->port() == 0) {
     running_ = false;

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
@@ -399,6 +399,22 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
           return cb;
         },
         std::move(handlers), std::move(cancelFn));
+
+    // How long this request occupied the connection's loop thread synchronously
+    // (route + acquire + dispatch/forward). Compare against the gap between
+    // consecutive stage=dispatched lines with the same loop_tid: busy_ms ~= gap
+    // means the loop is saturated (ingress-bound here); busy_ms << gap means the
+    // loop sat idle between requests (the stagger is upstream — Dynamo egress /
+    // single worker connection), not lost in this loop.
+    const auto handlerBusyMs =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            SteadyClock::now() - recvT)
+            .count() /
+        1000.0;
+    TT_LOG_INFO(
+        "[DynamoLatency] id={} stage=handler_returned busy_ms={:.3f} "
+        "loop_tid={}",
+        probeId.empty() ? "?" : probeId, handlerBusyMs, loopTid);
   };
 }
 
@@ -428,6 +444,9 @@ void DynamoEndpoint::start() {
   sc.endpoint = options_.endpoint;
   sc.model_name = options_.model_name;
   sc.model_path = options_.model_path;
+  // Reuse the callback-pool sizing (auto-scales with workers) for the dispatch
+  // pool that parses request bodies + runs the handler off the io loops.
+  sc.dispatch_pool_threads = tt::config::callbackPoolThreads();
 
   // start() binds and listens on the pool loops synchronously; the resolved
   // port is available immediately afterwards.
@@ -489,10 +508,14 @@ void DynamoEndpoint::stop() {
   if (discovery_) {
     discovery_->unregisterSelf();
   }
-  if (keepalive_thread_.joinable()) {
-    keepalive_thread_.join();
-  }
+  if (keepalive_thread_.joinable()) keepalive_thread_.join();
+
+  // Destroy the server first: its dispatch pool's destructor joins in-flight
+  // parse/handler tasks, which create call-home writers on the loop pool. They
+  // must finish before the loop pool is torn down below, or a late task would
+  // call getNextLoop() on a destroyed pool.
   server_.reset();
+
   discovery_.reset();
   if (loop_pool_) {
     for (auto* loop : loop_pool_->getLoops()) {

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
@@ -15,11 +15,13 @@
 #include <trantor/utils/MsgBuffer.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <sstream>
+#include <string_view>
 #include <thread>
 #include <utility>
 
@@ -45,6 +47,146 @@ Json::Value parseJsonBytes(const uint8_t* data, size_t len) {
   }
 
   return outt;
+}
+
+std::string dumpJsonCompact(const Json::Value& v);  // defined below
+
+/// Scan a flat JSON array of integers. `s[start]` must be '['. Appends each
+/// value to `out` and returns the index just past the matching ']'. Returns
+/// std::string_view::npos if the array is not a clean flat int array (nested
+/// arrays, strings, floats, etc.) so the caller can fall back to the full JSON
+/// parser. Tolerates whitespace, negative ints, and a trailing comma.
+size_t scanIntArray(const char* s, size_t start, size_t n,
+                    std::vector<int>& out) {
+  if (start >= n || s[start] != '[') return std::string_view::npos;
+  size_t i = start + 1;
+  auto isWs = [](char c) {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+  };
+  while (i < n) {
+    char c = s[i];
+    if (isWs(c) || c == ',') {
+      ++i;
+      continue;
+    }
+    if (c == ']') return i + 1;
+    bool neg = false;
+    if (c == '-') {
+      neg = true;
+      ++i;
+    }
+    if (i >= n || s[i] < '0' || s[i] > '9') {
+      return std::string_view::npos;  // not a plain integer element
+    }
+    long long v = 0;
+    while (i < n && s[i] >= '0' && s[i] <= '9') {
+      v = v * 10 + (s[i] - '0');
+      ++i;
+    }
+    out.push_back(neg ? -static_cast<int>(v) : static_cast<int>(v));
+  }
+  return std::string_view::npos;  // unterminated array
+}
+
+/// Locate the object value for the top-level `"token_ids"` key and return the
+/// index of its opening '['. Distinguishes the key from look-alikes such as
+/// `"stop_token_ids_hidden"` by requiring the exact quoted key, immediately
+/// preceded by '{' or ',' (an object key, not text inside a string value) and
+/// followed by ':' then '['. Returns false if no such array is found.
+bool findTokenIdsArray(std::string_view body, size_t& arrayStart) {
+  static constexpr std::string_view kKey = "\"token_ids\"";
+  auto isWs = [](char c) {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+  };
+  size_t pos = body.find(kKey);
+  while (pos != std::string_view::npos) {
+    // The char before the key (skipping whitespace) must open an object member.
+    size_t b = pos;
+    while (b > 0 && isWs(body[b - 1])) --b;
+    const bool keyContext = b == 0 || body[b - 1] == '{' || body[b - 1] == ',';
+    if (keyContext) {
+      size_t i = pos + kKey.size();
+      while (i < body.size() && isWs(body[i])) ++i;
+      if (i < body.size() && body[i] == ':') {
+        ++i;
+        while (i < body.size() && isWs(body[i])) ++i;
+        if (i < body.size() && body[i] == '[') {
+          arrayStart = i;
+          return true;
+        }
+      }
+    }
+    pos = body.find(kKey, pos + 1);
+  }
+  return false;
+}
+
+/// Populate every GenerateRequest field except `token_ids` from a parsed body.
+/// Shared by the fast path (which parses a token_ids-elided copy) and the
+/// jsoncpp fallback.
+void populateGenerateFields(GenerateRequest& req, const Json::Value& j) {
+  req.raw = j;
+  req.model = j.get("model", "").asString();
+
+  if (j.isMember("stop_conditions") && j["stop_conditions"].isObject()) {
+    const auto& sc = j["stop_conditions"];
+    if (sc.isMember("max_tokens") && !sc["max_tokens"].isNull()) {
+      req.max_tokens = sc["max_tokens"].asInt();
+    }
+    if (sc.isMember("min_tokens") && !sc["min_tokens"].isNull()) {
+      req.min_tokens = sc["min_tokens"].asInt();
+    }
+    // Dynamo's StopConditions serializes the token-id stop list as
+    // `stop_token_ids_hidden` (see lib/llm/src/protocols/common.rs — the Rust
+    // field has no serde rename). Prefer that key, but also accept the plain
+    // `stop_token_ids` name for forward-compatibility / other senders.
+    const Json::Value* stopIds = nullptr;
+    if (sc.isMember("stop_token_ids_hidden") &&
+        sc["stop_token_ids_hidden"].isArray()) {
+      stopIds = &sc["stop_token_ids_hidden"];
+    } else if (sc.isMember("stop_token_ids") &&
+               sc["stop_token_ids"].isArray()) {
+      stopIds = &sc["stop_token_ids"];
+    }
+    if (stopIds != nullptr) {
+      for (const auto& t : *stopIds) {
+        req.stop_token_ids.push_back(t.asInt());
+      }
+    }
+    if (sc.isMember("stop") && sc["stop"].isArray()) {
+      for (const auto& s : sc["stop"]) {
+        req.stop.push_back(s.asString());
+      }
+    }
+    if (sc.isMember("ignore_eos") && sc["ignore_eos"].isBool()) {
+      req.ignore_eos = sc["ignore_eos"].asBool();
+    }
+  }
+
+  if (j.isMember("sampling_options") && j["sampling_options"].isObject()) {
+    const auto& so = j["sampling_options"];
+    auto getOptFloat = [&](const char* k) -> std::optional<float> {
+      if (so.isMember(k) && !so[k].isNull()) return so[k].asFloat();
+      return std::nullopt;
+    };
+    auto getOptInt = [&](const char* k) -> std::optional<int> {
+      if (so.isMember(k) && !so[k].isNull()) return so[k].asInt();
+      return std::nullopt;
+    };
+    req.temperature = getOptFloat("temperature");
+    req.top_p = getOptFloat("top_p");
+    req.top_k = getOptInt("top_k");
+    req.seed = getOptInt("seed");
+    req.frequency_penalty = getOptFloat("frequency_penalty");
+    req.presence_penalty = getOptFloat("presence_penalty");
+    req.repetition_penalty = getOptFloat("repetition_penalty");
+  }
+
+  if (j.isMember("mm_processor_kwargs") && !j["mm_processor_kwargs"].isNull()) {
+    req.mm_processor_kwargs = j["mm_processor_kwargs"];
+    TT_LOG_INFO("[DynamoRx] mm_processor_kwargs received: {}",
+                dumpJsonCompact(req.mm_processor_kwargs));
+  }
 }
 
 std::string dumpJsonCompact(const Json::Value& v) {
@@ -163,79 +305,52 @@ TcpStreamConnectionInfo parse_connection_info(const ConnectionInfo& info) {
 
 GenerateRequest parse_generate_request(const std::vector<uint8_t>& bodyBytes) {
   GenerateRequest req;
-  Json::Value j = parseJsonBytes(bodyBytes.data(), bodyBytes.size());
+  if (bodyBytes.empty()) return req;
+  const char* data = reinterpret_cast<const char*>(bodyBytes.data());
+  const size_t n = bodyBytes.size();
+  const std::string_view body(data, n);
+
+  // Fast path. The `token_ids` array can hold tens of thousands of ints, and
+  // jsoncpp allocates a Value node per element (~10 ms for a 55K-token prompt,
+  // measured) — the dominant cost of receiving a request. Scan that array
+  // directly, then let jsoncpp parse a copy of the body with the array elided
+  // (`[]`), so it only builds the small remaining fields. Nothing downstream
+  // reads `token_ids` from `req.raw` (only scalar keys like request_id), so an
+  // empty array there is fine. Any deviation from a flat int array falls
+  // through to the jsoncpp path below, which stays correct.
+  size_t arrayStart = 0;
+  if (findTokenIdsArray(body, arrayStart)) {
+    std::vector<int> ids;
+    const size_t arrayEnd = scanIntArray(data, arrayStart, n, ids);
+    if (arrayEnd != std::string_view::npos) {
+      // Rebuild the body with the token_ids array replaced by "[]" for jsoncpp.
+      // Everything except this one array is tiny, so this copy is cheap
+      // regardless of where the array sits in the object.
+      std::string reduced;
+      reduced.reserve(arrayStart + 2 + (n - arrayEnd));
+      reduced.append(data, arrayStart);
+      reduced.append("[]");
+      reduced.append(data + arrayEnd, n - arrayEnd);
+      Json::Value j = parseJsonBytes(
+          reinterpret_cast<const uint8_t*>(reduced.data()), reduced.size());
+      if (j.isObject()) {
+        req.token_ids = std::move(ids);
+        populateGenerateFields(req, j);
+        return req;
+      }
+    }
+  }
+
+  // Fallback: full jsoncpp parse (handles any body the fast path declined).
+  Json::Value j = parseJsonBytes(bodyBytes.data(), n);
   if (!j.isObject()) return req;
-
-  req.raw = j;
-  req.model = j.get("model", "").asString();
-
   if (j.isMember("token_ids") && j["token_ids"].isArray()) {
     req.token_ids.reserve(j["token_ids"].size());
     for (const auto& t : j["token_ids"]) {
       req.token_ids.push_back(t.asInt());
     }
   }
-
-  if (j.isMember("stop_conditions") && j["stop_conditions"].isObject()) {
-    const auto& sc = j["stop_conditions"];
-    if (sc.isMember("max_tokens") && !sc["max_tokens"].isNull()) {
-      req.max_tokens = sc["max_tokens"].asInt();
-    }
-    if (sc.isMember("min_tokens") && !sc["min_tokens"].isNull()) {
-      req.min_tokens = sc["min_tokens"].asInt();
-    }
-    // Dynamo's StopConditions serializes the token-id stop list as
-    // `stop_token_ids_hidden` (see lib/llm/src/protocols/common.rs — the Rust
-    // field has no serde rename). Prefer that key, but also accept the plain
-    // `stop_token_ids` name for forward-compatibility / other senders.
-    const Json::Value* stopIds = nullptr;
-    if (sc.isMember("stop_token_ids_hidden") &&
-        sc["stop_token_ids_hidden"].isArray()) {
-      stopIds = &sc["stop_token_ids_hidden"];
-    } else if (sc.isMember("stop_token_ids") &&
-               sc["stop_token_ids"].isArray()) {
-      stopIds = &sc["stop_token_ids"];
-    }
-    if (stopIds != nullptr) {
-      for (const auto& t : *stopIds) {
-        req.stop_token_ids.push_back(t.asInt());
-      }
-    }
-    if (sc.isMember("stop") && sc["stop"].isArray()) {
-      for (const auto& s : sc["stop"]) {
-        req.stop.push_back(s.asString());
-      }
-    }
-    if (sc.isMember("ignore_eos") && sc["ignore_eos"].isBool()) {
-      req.ignore_eos = sc["ignore_eos"].asBool();
-    }
-  }
-
-  if (j.isMember("sampling_options") && j["sampling_options"].isObject()) {
-    const auto& so = j["sampling_options"];
-    auto getOptFloat = [&](const char* k) -> std::optional<float> {
-      if (so.isMember(k) && !so[k].isNull()) return so[k].asFloat();
-      return std::nullopt;
-    };
-    auto getOptInt = [&](const char* k) -> std::optional<int> {
-      if (so.isMember(k) && !so[k].isNull()) return so[k].asInt();
-      return std::nullopt;
-    };
-    req.temperature = getOptFloat("temperature");
-    req.top_p = getOptFloat("top_p");
-    req.top_k = getOptInt("top_k");
-    req.seed = getOptInt("seed");
-    req.frequency_penalty = getOptFloat("frequency_penalty");
-    req.presence_penalty = getOptFloat("presence_penalty");
-    req.repetition_penalty = getOptFloat("repetition_penalty");
-  }
-
-  if (j.isMember("mm_processor_kwargs") && !j["mm_processor_kwargs"].isNull()) {
-    req.mm_processor_kwargs = j["mm_processor_kwargs"];
-    TT_LOG_INFO("[DynamoRx] mm_processor_kwargs received: {}",
-                dumpJsonCompact(req.mm_processor_kwargs));
-  }
-
+  populateGenerateFields(req, j);
   return req;
 }
 
@@ -328,6 +443,18 @@ DynamoServer::DynamoServer(ServerConfig config, GenerateHandler handler,
     oss << std::hex << config_.instance_id;
     config_.instance_id_hex = oss.str();
   }
+
+  // Dispatch pool: parses request bodies + runs the handler off the io loop.
+  // Auto-size to the hardware concurrency (clamped to [4, 32]) when unset so a
+  // burst of large prompts parses in parallel instead of serializing on one
+  // connection's loop thread.
+  size_t poolThreads = config_.dispatch_pool_threads;
+  if (poolThreads == 0) {
+    const auto hw = std::thread::hardware_concurrency();
+    poolThreads = hw == 0 ? 8u : hw;
+    poolThreads = std::min<size_t>(std::max<size_t>(poolThreads, 4), 32);
+  }
+  dispatch_pool_ = std::make_unique<tt::utils::ThreadPool>(poolThreads);
 }
 
 DynamoServer::~DynamoServer() { shutdown(); }
@@ -378,23 +505,38 @@ void DynamoServer::onMessage(const trantor::TcpConnectionPtr& conn,
 
 void DynamoServer::process_request(const trantor::TcpConnectionPtr& conn,
                                    const TcpRequestMessage& msg) {
+  // Cheap work stays on the io loop: split the frame and parse the small
+  // control header (address + request id), which are needed to ACK and to
+  // route the call-home stream. The expensive part — parsing the request body,
+  // whose `token_ids` array can be tens of thousands of ints (~11 ms of
+  // jsoncpp for a 55K-token prompt) — is deferred to the dispatch pool below.
   TwoPartMessage twoPart = decode_two_part(msg.payload);
   auto ctrl = parse_control_message(twoPart.header);
-  auto genReq = parse_generate_request(twoPart.body);
   auto connInfo = parse_connection_info(ctrl.connection_info);
 
-  TT_LOG_DEBUG(
-      "[DynamoServer] Request id={} input_tokens={} max_tokens={} address={}",
-      ctrl.id, genReq.token_ids.size(), genReq.max_tokens, connInfo.address);
-
-  // ACK on the inbound connection. onMessage runs on the connection's io
-  // loop, so sends stay in the FIFO order the frontend pipelined requests in.
+  // ACK immediately on the inbound connection. onMessage runs on the
+  // connection's io loop, so ACKs stay in the FIFO order the frontend
+  // pipelined requests in. Sending it before the body parse lets the loop
+  // return to reading the next pipelined request right away instead of
+  // blocking ~11 ms per request on a single connection.
   auto ack = encode_tcp_response();
   conn->send(reinterpret_cast<const char*>(ack.data()), ack.size());
 
-  // The handler creates the async call-home writer and returns without
-  // blocking, so dispatch runs inline on the io loop — no per-request thread.
-  handler_(genReq, connInfo);
+  // Offload the body parse + dispatch off the io loop. The handler creates the
+  // async call-home writer (bound to one of the endpoint's loop-pool loops)
+  // and returns without blocking, and the pipeline is already invoked
+  // concurrently across io loops in the multi-connection case, so running it
+  // from a pool thread is safe. This lets a burst of large prompts parse in
+  // parallel instead of serializing on one connection's io loop.
+  dispatch_pool_->submit([this, body = std::move(twoPart.body),
+                          connInfo = std::move(connInfo),
+                          id = ctrl.id]() mutable {
+    GenerateRequest genReq = parse_generate_request(body);
+    TT_LOG_DEBUG(
+        "[DynamoServer] Request id={} input_tokens={} max_tokens={} address={}",
+        id, genReq.token_ids.size(), genReq.max_tokens, connInfo.address);
+    handler_(genReq, connInfo);
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
@@ -8,6 +8,7 @@
 #include <netinet/tcp.h>
 #include <sys/socket.h>
 #include <trantor/net/EventLoop.h>
+#include <trantor/net/EventLoopThreadPool.h>
 #include <trantor/net/InetAddress.h>
 #include <trantor/net/TcpClient.h>
 #include <trantor/net/TcpConnection.h>
@@ -15,14 +16,12 @@
 #include <trantor/utils/MsgBuffer.h>
 #include <unistd.h>
 
-#include <algorithm>
 #include <cerrno>
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <sstream>
 #include <string_view>
-#include <thread>
 #include <utility>
 
 #include "domain/llm/llm_error_reason.hpp"
@@ -418,10 +417,10 @@ std::vector<uint8_t> encode_stream_final() {
 // ---------------------------------------------------------------------------
 
 DynamoServer::DynamoServer(ServerConfig config, GenerateHandler handler,
-                           std::vector<trantor::EventLoop*> ioLoops)
+                           trantor::EventLoopThreadPool* loopPool)
     : config_(std::move(config)),
       handler_(std::move(handler)),
-      io_loops_(std::move(ioLoops)) {
+      loop_pool_(loopPool) {
   if (config_.instance_id == 0) {
     std::srand(static_cast<unsigned>(std::time(nullptr) ^ ::getpid()));
     config_.instance_id = (static_cast<uint64_t>(std::rand()) << 32) |
@@ -432,14 +431,6 @@ DynamoServer::DynamoServer(ServerConfig config, GenerateHandler handler,
     oss << std::hex << config_.instance_id;
     config_.instance_id_hex = oss.str();
   }
-
-  size_t poolThreads = config_.dispatch_pool_threads;
-  if (poolThreads == 0) {
-    const auto hw = std::thread::hardware_concurrency();
-    poolThreads = hw == 0 ? 8u : hw;
-    poolThreads = std::min<size_t>(std::max<size_t>(poolThreads, 4), 32);
-  }
-  dispatch_pool_ = std::make_unique<tt::utils::ThreadPool>(poolThreads);
 }
 
 DynamoServer::~DynamoServer() { shutdown(); }
@@ -497,14 +488,20 @@ void DynamoServer::process_request(const trantor::TcpConnectionPtr& conn,
   auto ack = encode_tcp_response();
   conn->send(reinterpret_cast<const char*>(ack.data()), ack.size());
 
-  dispatch_pool_->submit([this, body = std::move(twoPart.body),
-                          connInfo = std::move(connInfo),
-                          id = ctrl.id]() mutable {
-    GenerateRequest genReq = parse_generate_request(body);
-    TT_LOG_DEBUG(
-        "[DynamoServer] Request id={} input_tokens={} max_tokens={} address={}",
-        id, genReq.token_ids.size(), genReq.max_tokens, connInfo.address);
-    handler_(genReq, connInfo);
+  trantor::EventLoop* loop = loop_pool_->getNextLoop();
+  loop->queueInLoop([this, body = std::move(twoPart.body),
+                     connInfo = std::move(connInfo), id = ctrl.id]() mutable {
+    try {
+      GenerateRequest genReq = parse_generate_request(body);
+      TT_LOG_DEBUG(
+          "[DynamoServer] Request id={} input_tokens={} max_tokens={} "
+          "address={}",
+          id, genReq.token_ids.size(), genReq.max_tokens, connInfo.address);
+      handler_(genReq, connInfo);
+    } catch (const std::exception& e) {
+      TT_LOG_ERROR("[DynamoServer] request dispatch failed id={}: {}", id,
+                   e.what());
+    }
   });
 }
 
@@ -659,15 +656,17 @@ void DynamoStreamWriter::finalize() {
 }
 
 void DynamoServer::start() {
-  if (io_loops_.empty()) {
+  const auto ioLoops =
+      loop_pool_ ? loop_pool_->getLoops() : std::vector<trantor::EventLoop*>{};
+  if (ioLoops.empty()) {
     throw std::runtime_error("DynamoServer: no io loops provided");
   }
 
   running_.store(true);
   trantor::InetAddress addr(config_.bind_host, config_.bind_port);
-  tcp_server_ = std::make_unique<trantor::TcpServer>(io_loops_.front(), addr,
+  tcp_server_ = std::make_unique<trantor::TcpServer>(ioLoops.front(), addr,
                                                      "DynamoServer");
-  tcp_server_->setIoLoops(io_loops_);
+  tcp_server_->setIoLoops(ioLoops);
   // Port 0 is resolved during the acceptor's bind, which happens in the
   // TcpServer constructor — so the assigned port is available synchronously.
   actual_port_ = tcp_server_->address().toPort();

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
@@ -310,22 +310,11 @@ GenerateRequest parse_generate_request(const std::vector<uint8_t>& bodyBytes) {
   const size_t n = bodyBytes.size();
   const std::string_view body(data, n);
 
-  // Fast path. The `token_ids` array can hold tens of thousands of ints, and
-  // jsoncpp allocates a Value node per element (~10 ms for a 55K-token prompt,
-  // measured) — the dominant cost of receiving a request. Scan that array
-  // directly, then let jsoncpp parse a copy of the body with the array elided
-  // (`[]`), so it only builds the small remaining fields. Nothing downstream
-  // reads `token_ids` from `req.raw` (only scalar keys like request_id), so an
-  // empty array there is fine. Any deviation from a flat int array falls
-  // through to the jsoncpp path below, which stays correct.
   size_t arrayStart = 0;
   if (findTokenIdsArray(body, arrayStart)) {
     std::vector<int> ids;
     const size_t arrayEnd = scanIntArray(data, arrayStart, n, ids);
     if (arrayEnd != std::string_view::npos) {
-      // Rebuild the body with the token_ids array replaced by "[]" for jsoncpp.
-      // Everything except this one array is tiny, so this copy is cheap
-      // regardless of where the array sits in the object.
       std::string reduced;
       reduced.reserve(arrayStart + 2 + (n - arrayEnd));
       reduced.append(data, arrayStart);
@@ -444,10 +433,6 @@ DynamoServer::DynamoServer(ServerConfig config, GenerateHandler handler,
     config_.instance_id_hex = oss.str();
   }
 
-  // Dispatch pool: parses request bodies + runs the handler off the io loop.
-  // Auto-size to the hardware concurrency (clamped to [4, 32]) when unset so a
-  // burst of large prompts parses in parallel instead of serializing on one
-  // connection's loop thread.
   size_t poolThreads = config_.dispatch_pool_threads;
   if (poolThreads == 0) {
     const auto hw = std::thread::hardware_concurrency();
@@ -505,29 +490,13 @@ void DynamoServer::onMessage(const trantor::TcpConnectionPtr& conn,
 
 void DynamoServer::process_request(const trantor::TcpConnectionPtr& conn,
                                    const TcpRequestMessage& msg) {
-  // Cheap work stays on the io loop: split the frame and parse the small
-  // control header (address + request id), which are needed to ACK and to
-  // route the call-home stream. The expensive part — parsing the request body,
-  // whose `token_ids` array can be tens of thousands of ints (~11 ms of
-  // jsoncpp for a 55K-token prompt) — is deferred to the dispatch pool below.
   TwoPartMessage twoPart = decode_two_part(msg.payload);
   auto ctrl = parse_control_message(twoPart.header);
   auto connInfo = parse_connection_info(ctrl.connection_info);
 
-  // ACK immediately on the inbound connection. onMessage runs on the
-  // connection's io loop, so ACKs stay in the FIFO order the frontend
-  // pipelined requests in. Sending it before the body parse lets the loop
-  // return to reading the next pipelined request right away instead of
-  // blocking ~11 ms per request on a single connection.
   auto ack = encode_tcp_response();
   conn->send(reinterpret_cast<const char*>(ack.data()), ack.size());
 
-  // Offload the body parse + dispatch off the io loop. The handler creates the
-  // async call-home writer (bound to one of the endpoint's loop-pool loops)
-  // and returns without blocking, and the pipeline is already invoked
-  // concurrently across io loops in the multi-connection case, so running it
-  // from a pool thread is safe. This lets a burst of large prompts parse in
-  // parallel instead of serializing on one connection's io loop.
   dispatch_pool_->submit([this, body = std::move(twoPart.body),
                           connInfo = std::move(connInfo),
                           id = ctrl.id]() mutable {

--- a/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
@@ -3,6 +3,8 @@
 
 #include "services/llm_pipeline.hpp"
 
+#include <trantor/net/EventLoop.h>
+
 #include <chrono>
 #include <functional>
 #include <stdexcept>
@@ -140,6 +142,18 @@ void LLMPipeline::resolveSession(
       "messages={} promptKind={} promptTokens={}",
       req->task_id, req->model.value_or("default"), req->stream,
       req->messages.size(), promptKind, promptTokens);
+
+  // Deliver every resolution/error on `loop`. resolveSession may run on a
+  // non-event-loop thread (e.g. the Dynamo dispatch pool), so all callbacks are
+  // routed onto `loop` here in one place instead of at each call site.
+  // runInLoop runs inline when already on `loop`, so on-loop callers pay no
+  // hop.
+  onResolved = [loop, cb = std::move(onResolved)](SessionInfo resolved) {
+    loop->runInLoop([cb, resolved = std::move(resolved)]() { cb(resolved); });
+  };
+  onError = [loop, cb = std::move(onError)](const SessionError& err) {
+    loop->runInLoop([cb, err]() { cb(err); });
+  };
 
   SessionInfo info;
 


### PR DESCRIPTION
## Issue
[#4499 Investigate 20ms Dynamo <-> IS Overhead](https://github.com/tenstorrent/tt-inference-server/issues/4499)

## Problem
When testing the disaggregated setup with large input sequences (55K ISL) under concurrent load, we observed that the Dynamo <-> Inference Server path introduced approximately 20 ms of overhead per request.

This became noticeable when four requests arrived as a burst at Dynamo (generated by vllm bench with request_rate=inf). Although Dynamo received them simultaneously, the Inference Server processed them roughly 20 ms apart.

We identified two contributing factors:

- Unintentional request serialization. Dynamo and the Inference Server communicate over a single TCP connection. Requests were accepted on a single I/O thread, which also synchronously parsed each request before reading the next one. As a result, requests arriving in a burst were unintentionally serialized.
- Slow JSON parsing. The jsoncpp parser introduced significant overhead for this workload. Replacing it with manual parsing of the token_ids field reduced parsing time from approximately 11 ms to 0.2 ms per request.

To address these issues, two changes were implemented:

- Fix 1: Move request parsing off the I/O thread so incoming requests can continue to be accepted while parsing happens asynchronously.
- Fix 2: Replace jsoncpp parsing of token_ids with a lightweight manual parser optimized for this use case.


## Testing
Testing was done on host, and here are observed performance optimizations:

On a mock benchmark with a burst of 32 concurrent requests, each containing 55K input tokens, these changes improved throughput from 49.7 req/s to 83.1 req/s, reduced P99 TTFT from 615 ms to 352 ms, and eliminated request failures
```
┌──────────────────────────────────────┬───────┬───────────┬──────────┐
│                Config                │ req/s │ TTFT mean │ TTFT P99 │
├──────────────────────────────────────┼───────┼───────────┼──────────┤
│ Original (serial jsoncpp on io loop) │ 49.7  │ 402 ms    │ 615 ms   │
├──────────────────────────────────────┼───────┼───────────┼──────────┤
│ + parse offloaded to pool            │ 80.0  │ 331 ms    │ 386 ms   │
├──────────────────────────────────────┼───────┼───────────┼──────────┤
│ + hand-rolled parser                 │ 83.1  │ 309 ms    │ 352 ms   │
└──────────────────────────────────────┴───────┴───────────┴──────────┘
```