### PR TITLE
Route additional media models  (7 CNN + 3 embedding)  to v2 engine 

### DIFF
--- a/workflows/v2_bridge.py
+++ b/workflows/v2_bridge.py
@@ -58,6 +58,16 @@ _V2_ROUTED_MODELS = frozenset(
         "whisper-large-v3",
         "distil-large-v3",
         "Z-Image-Turbo",
+        "resnet-50",
+        "vovnet",
+        "mobilenetv2",
+        "efficientnet",
+        "segformer",
+        "vit",
+        "unet",
+        "bge-large-en-v1.5",
+        "Qwen3-Embedding-8B",
+        "Qwen3-Embedding-4B",
     }
 )
 


### PR DESCRIPTION
Route additional media models — 7 CNN + 3 embedding — to the tt-inference-server-v2 engine by adding them to the _V2_ROUTED_MODELS allowlist in workflows/v2_bridge.py.

Each model was verified to have both prerequisites already in place, so routing is the only change needed:

- A resolvable workflow catalog spec in workflows/model_specs/prod/{cnn,embedding}.yaml.

- A v2 spec-test suite in tt-inference-server-v2/test_module/test_suites/{cnn,embedding}.json, with CNN/EMBEDDING runners already registered in the v2 dispatch (test_module/dispatch.py).