### PR TITLE
fix(v2-bench): force transformers 5.x on V2_LLM_VLLM so gemma-4 tokenizer loads

### DIFF
--- a/requirements/v2-llm-vllm-overrides.txt
+++ b/requirements/v2-llm-vllm-overrides.txt
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# uv --override file for the V2_LLM_VLLM venv (see requirements/v2-llm-vllm.txt
+# and the overrides_file hook in workflows/workflow_venvs.py).
+#
+# vllm==0.13.0 declares `transformers>=4.56.0,<5`, so the venv otherwise
+# resolves transformers 4.x. gemma-4's tokenizer_config.json stores
+# `extra_special_tokens` as a list that only transformers 5.x parses; under 4.x
+# `_set_model_specific_special_tokens` calls `.keys()` on the list and raises
+#   AttributeError: 'list' object has no attribute 'keys'
+# during `vllm bench serve` prompt tokenization, failing every sweep point
+# before it reaches the server.
+#
+# uv treats overrides as authoritative over a package's declared constraints,
+# so this forces transformers 5.x past vllm's cap. transformers 5.x needs
+# torch>=2.5 (torch.distributed.tensor.device_mesh); the venv's torch already
+# satisfies that. `vllm bench serve` is a pure client (tokenizer + HTTP) and
+# was verified to install and run under vllm 0.13.0 + transformers 5.12.1, so
+# the client tolerates the newer library while its CLI/behavior stay unchanged.
+transformers>=5.5.0,<6

--- a/requirements/v2-llm-vllm.txt
+++ b/requirements/v2-llm-vllm.txt
@@ -11,6 +11,13 @@
 # sync with VLLM_PIN_VERSION in workflow_venvs.py. `aiohttp` covers the v2
 # orchestrator's eager import chain (workflow_module -> test_module.context ->
 # health_tests); `requests`/`pyjwt` back the health checks + JWT minting.
+#
+# transformers is NOT pinned here: vllm==0.13.0 transitively caps it at <5, but
+# gemma-4's tokenizer needs 5.x (see v2-llm-vllm-overrides.txt). It is forced
+# past that cap via uv --override, wired onto this venv in workflow_venvs.py.
+# Keeping vllm at 0.13.0 means the `vllm bench serve` client (CLI flags, result
+# schema, tokenization path) is unchanged for every other model — only the
+# tokenizer library moves, and 5.x still loads legacy tokenizers.
 
 -c constraints.txt
 

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -33,12 +33,18 @@ REQUIREMENTS_DIR = get_repo_root_path() / "requirements"
 def install_requirements(
     venv_config: "VenvConfig",  # noqa: F821
     requirements_file: str,
+    overrides_file: Optional[str] = None,
 ) -> bool:
     """Install pip deps from requirements/<requirements_file> into the venv.
 
     Always passes ``--index-strategy unsafe-best-match`` so per-file
     ``--extra-index-url`` directives resolve against all configured indexes
     (e.g. PyPI + the PyTorch CPU index).
+
+    If ``overrides_file`` is given, it is passed to uv as ``--override`` so we
+    can force a dependency version that conflicts with a package's declared
+    pin (e.g. bumping transformers past vllm's ``transformers<5`` cap so the
+    Gemma-4 tokenizer loads). See https://docs.astral.sh/uv/pip/compile/#overrides.
     """
     requirements_path = REQUIREMENTS_DIR / requirements_file
     if not requirements_path.is_file():
@@ -46,10 +52,20 @@ def install_requirements(
             f"Requirements file not found: {requirements_path}. "
             f"Expected one of the per-venv files under {REQUIREMENTS_DIR}."
         )
+    override_arg = ""
+    if overrides_file is not None:
+        overrides_path = REQUIREMENTS_DIR / overrides_file
+        if not overrides_path.is_file():
+            raise FileNotFoundError(
+                f"Overrides file not found: {overrides_path}. "
+                f"Expected one of the per-venv files under {REQUIREMENTS_DIR}."
+            )
+        override_arg = f"--override {overrides_path} "
     return_code = run_command(
         f"{UV_EXEC} pip install --managed-python "
         f"--python {venv_config.venv_python} "
         f"--index-strategy unsafe-best-match "
+        f"{override_arg}"
         f"-r {requirements_path}",
         logger=logger,
     )
@@ -66,6 +82,7 @@ class VenvConfig:
 
     venv_type: WorkflowVenvType
     requirements_file: Optional[str] = None
+    overrides_file: Optional[str] = None
     extra_dirs: Tuple[str, ...] = field(default_factory=tuple)
     setup_function: Optional[Callable[["VenvConfig", "ModelSpec"], bool]] = None
     name: Optional[str] = None
@@ -118,7 +135,9 @@ class VenvConfig:
                 target.mkdir(parents=True, exist_ok=True)
 
         if self.requirements_file is not None:
-            if not install_requirements(self, self.requirements_file):
+            if not install_requirements(
+                self, self.requirements_file, self.overrides_file
+            ):
                 raise RuntimeError(
                     f"Failed to install requirements for venv {self.venv_type.name} "
                     f"from {self.requirements_file}"
@@ -408,6 +427,10 @@ _venv_config_list = [
     VenvConfig(
         venv_type=WorkflowVenvType.V2_LLM_VLLM,
         requirements_file="v2-llm-vllm.txt",
+        # Force transformers 5.x past vllm==0.13.0's `transformers<5` cap so the
+        # gemma-4 tokenizer loads; keeps vllm (and the bench-serve client) at
+        # 0.13.0 for every other model. See v2-llm-vllm-overrides.txt.
+        overrides_file="v2-llm-vllm-overrides.txt",
         extra_dirs=("artifacts",),
         python_version="3.11",
     ),


### PR DESCRIPTION
## Problem

The gemma-4 vLLM nightly (tt-shield) fails every `vllm bench serve` sweep point during prompt tokenization:

```
AttributeError: 'list' object has no attribute 'keys'
  transformers/tokenization_utils_base.py, _set_model_specific_special_tokens
```

**Root cause:** gemma-4's `tokenizer_config.json` stores `extra_special_tokens` as a v5-style *list*, which only `transformers` 5.x parses. Under `transformers <5`, `_set_model_specific_special_tokens` calls `.keys()` on the list and crashes. The `V2_LLM_VLLM` benchmark-client venv runs `vllm==0.13.0`, whose transitive `transformers>=4.56,<5` cap forces 4.x — so the client can't load the tokenizer, and every benchmark fails before reaching the server.

## Fix

Keep `vllm==0.13.0` and force **only** `transformers` to 5.x via a uv `--override` file.

Deliberately **not** bumping vllm (e.g. to 0.19.1): `V2_LLM_VLLM` is the shared benchmark client for *every* v2 vllm model. Pinning vllm leaves the `vllm bench serve` CLI flags, result-JSON schema, and tokenization path **byte-identical to main** for all other models — the only thing that changes is the tokenizer library (4.57 → 5.x), and transformers 5.x still loads legacy tokenizers.

A plain `transformers==5.x` requirement line can't work here — uv's resolver honors vllm's `<5` cap and fails; `--override` is the supported escape hatch.

### Changes
- **`requirements/v2-llm-vllm-overrides.txt`** (new) — uv `--override` pinning `transformers>=5.5.0,<6`.
- **`requirements/v2-llm-vllm.txt`** — deps unchanged (`vllm==0.13.0` kept); added a comment explaining the override.
- **`workflows/workflow_venvs.py`** — re-added the small generic `overrides_file` field on `VenvConfig`, threaded into `install_requirements()` as uv `--override`, and wired it onto the `V2_LLM_VLLM` config.

## Verification

Built the venv end-to-end with the committed repo files:

```
uv pip install --override requirements/v2-llm-vllm-overrides.txt -r requirements/v2-llm-vllm.txt
# → exit 0; resolves transformers 5.12.1 · vllm 0.13.0 · torch 2.9.0
vllm bench serve --help    # → runs cleanly under that combo
```

`py_compile` and `ruff format --check` / `ruff check` pass.

## Scope / regression risk

Only models shipping the v5 list-format tokenizer config are affected (gemma-4). **Qwen3.6-27B** ships dict-format `extra_special_tokens` (`Qwen2Tokenizer`) and already benchmarks fine on main; transformers 5.x still loads it, so no regression. `datasets==5.0.0` / `pyarrow==24.0.0` (from #4428) are unchanged.

## CI Runs:

Benchmarks workflow now starts for both Qewn and Gemma, green for Qwen as expected, fabric hang for Gemma as expected.

Qwen3.6-27B : https://github.com/tenstorrent/tt-shield/actions/runs/28669286229/job/85028603648 
gemma-4-31B-it: https://github.com/tenstorrent/tt-shield/actions/runs/28669052193/job/85027847311
