### PR TITLE
Skip DeviceLivenessTest prerequisite for vLLM suites

### DIFF
--- a/tt-inference-server-v2/test_module/dispatch.py
+++ b/tt-inference-server-v2/test_module/dispatch.py
@@ -121,13 +121,15 @@ def run_media_task(
 
 
 def _resolve_spec_test_suites(ctx: MediaContext) -> List[dict]:
-    """Return matching expanded suites for ``ctx.model_spec.model_name`` + device."""
+    """Return matching expanded suites for ``ctx.model_spec.model_name`` + device.
+    Prerequisite injection is engine-aware."""
     from .test_categorization_system import TestFilter
 
     return (
         TestFilter()
         .filter_by_model(ctx.model_spec.model_name)
         .filter_by_device(ctx.device.name.lower())
+        .filter_prerequisites_by_engine(ctx.model_spec.inference_engine)
         .get_tests()
     )
 

--- a/tt-inference-server-v2/test_module/server_tests_config.json
+++ b/tt-inference-server-v2/test_module/server_tests_config.json
@@ -474,6 +474,10 @@
             "name": "DeviceLivenessTest",
             "module": "test_module.health_tests.device_liveness_test",
             "description": "Test for device liveness checks - runs before all other tests",
+            "engines": [
+                "media",
+                "forge"
+            ],
             "markers": [
                 "fast",
                 "prerequisite"

--- a/tt-inference-server-v2/test_module/test_categorization_system/TEST_SUITE_CONFIG_GUIDE.md
+++ b/tt-inference-server-v2/test_module/test_categorization_system/TEST_SUITE_CONFIG_GUIDE.md
@@ -230,6 +230,17 @@ The `id_name` is used in suite IDs (`distil-whisper-t3k`), while `model_marker` 
 | Suites with unique test lists | `test_suites/<category>.json` → `test_suites` | explicit definition |
 | Client-side concurrency for a load test | `test_cases[].targets.num_concurrent_requests` | overrides matrix/suite default |
 | Physical chip count probed by liveness | `hardware_defaults.<device>.num_of_devices` | inherited by `DeviceLivenessTest` |
+| Restrict a prerequisite to certain engines | `prerequisite_tests[].engines` | e.g. `["media", "forge"]`; omit for engine-agnostic |
+
+### Prerequisite `engines` allow-list
+
+Each entry in `prerequisite_tests` may declare an `engines` allow-list whose
+values match `workflows.workflow_types.InferenceEngine` (`"vLLM"`, `"media"`,
+`"forge"`). A prerequisite with an allow-list is injected only for suites whose
+model runs on one of those engines; a prerequisite that omits the key is
+engine-agnostic and runs everywhere. `DeviceLivenessTest` uses
+`["media", "forge"]` because it probes the tt-media-server `/tt-liveness`
+endpoint, which vLLM does not expose (vLLM serves `/health` instead).
 
 ### `num_concurrent_requests` vs `num_of_devices`
 

--- a/tt-inference-server-v2/test_module/test_categorization_system/test_filter.py
+++ b/tt-inference-server-v2/test_module/test_categorization_system/test_filter.py
@@ -34,6 +34,7 @@ TEST_CONFIG = "test_config"
 NUM_OF_DEVICES = "num_of_devices"
 NUM_CONCURRENT_REQUESTS = "num_concurrent_requests"
 TARGETS = "targets"
+ENGINES = "engines"
 
 
 class TestFilter:
@@ -84,6 +85,7 @@ class TestFilter:
 
         logger.info("Including prerequisites by default")
         self._include_prerequisites = True
+        self._prerequisite_engine: Optional[str] = None
 
     @classmethod
     def from_category(cls, category: str) -> TestFilter:
@@ -286,8 +288,22 @@ class TestFilter:
 
         return expanded_suites
 
+    def _prerequisite_applies_to_engine(self, prereq: Dict) -> bool:
+        """Whether ``prereq`` should run under the configured inference engine.
+
+        A prerequisite without an ``engines`` allow-list is engine-agnostic and
+        always applies. One that declares engines applies only when the active
+        engine is in that list."""
+        allowed_engines = prereq.get(ENGINES)
+        if not allowed_engines or self._prerequisite_engine is None:
+            return True
+        return self._prerequisite_engine in allowed_engines
+
     def _get_prerequisite_for_suite(self, suite: Dict) -> List[Dict]:
         """Get expanded prerequisite tests for a specific suite.
+
+        Prerequisites whose ``engines`` allow-list excludes the configured
+        inference engine are skipped.
 
         Args:
             suite: Suite dict for hardware context
@@ -300,6 +316,14 @@ class TestFilter:
         )
         prereqs = []
         for prereq in self.prerequisite_tests:
+            if not self._prerequisite_applies_to_engine(prereq):
+                logger.info(
+                    "Skipping prerequisite %s for engine %s (allowed: %s)",
+                    prereq.get("name", "unknown"),
+                    self._prerequisite_engine,
+                    prereq.get(ENGINES),
+                )
+                continue
             expanded = self._expand_prerequisite_test(prereq, suite)
             prereqs.append(expanded)
         return prereqs
@@ -315,6 +339,10 @@ class TestFilter:
             Self for method chaining
         """
         self._include_prerequisites = include
+        return self
+
+    def filter_prerequisites_by_engine(self, engine: Optional[str]) -> TestFilter:
+        self._prerequisite_engine = engine
         return self
 
     def filter_by_model_category(self, categories: List[str]) -> TestFilter:


### PR DESCRIPTION
DeviceLivenessTest probes the tt-media-server /tt-liveness endpoint, which vLLM's server does not expose (it serves /health instead). Since PR #4348 routed LLM evals/release through tt-inference-server-v2, the global prerequisite got prepended to vLLM suites too, so every liveness attempt failed with HTTP 404 and the Run tests step failed after all retries

Make prerequisite injection engine-aware: prerequisites may declare an `engines` allow-list  and are skipped for any other engine(entries without the key stay engine-agnostic)

CI run: https://github.com/tenstorrent/tt-shield/actions/runs/28672144088