### PR TITLE
Complete yolox_nano for release (+ uplift forge models)

### DIFF
--- a/requirements/evals-run-script.txt
+++ b/requirements/evals-run-script.txt
@@ -25,6 +25,7 @@ datasets
 open-clip-torch
 pyjwt
 pillow
+pycocotools
 imageio
 imageio-ffmpeg
 mteb[openai]>=2.6.6

--- a/tt-media-server/tt_model_runners/forge_runners/fetch_models.sh
+++ b/tt-media-server/tt_model_runners/forge_runners/fetch_models.sh
@@ -7,7 +7,7 @@
 
 set -e  # Exit on any error
 
-FORGE_MODELS_SHA="e9f4a7b60775abb6c34dd967a5484234428622c2"
+FORGE_MODELS_SHA="2e59f9b5f72a6bfacace309d4a809300f4ad4eb7"
 
 REPO_URL="https://github.com/tenstorrent/tt-forge-models.git"
 TARGET_DIR="model_loaders"

--- a/tt-media-server/tt_model_runners/forge_runners/forge_runner.py
+++ b/tt-media-server/tt_model_runners/forge_runners/forge_runner.py
@@ -212,17 +212,27 @@ class ForgeRunner(BaseDeviceRunner):
         self.logger.info(f"Top 1 class label: {top1_class_label}")
         self.logger.info(f"Top 1 class probability: {top1_class_probability}")
 
+        # Detection models (e.g. YOLOX) provide boxes + numeric
+        # scores.
+        boxes = raw_predictions.get("boxes")
+        scores = raw_predictions.get("scores")
+
         predictions = []
-        for label, probability, index in zip(
-            raw_predictions["labels"],
-            raw_predictions["probabilities"],
-            raw_predictions["indices"],
+        for i, (label, probability, index) in enumerate(
+            zip(
+                raw_predictions["labels"],
+                raw_predictions["probabilities"],
+                raw_predictions["indices"],
+            )
         ):
             prob = float(probability.rstrip("%"))
             if prob >= min_confidence:
-                predictions.append(
-                    {"label": label, "probability": prob, "index": index}
-                )
+                pred = {"label": label, "probability": prob, "index": index}
+                if boxes is not None and i < len(boxes):
+                    pred["box"] = boxes[i]
+                if scores is not None and i < len(scores):
+                    pred["score"] = scores[i]
+                predictions.append(pred)
 
         return predictions, top1_class_label, top1_class_probability
 
@@ -252,12 +262,17 @@ class ForgeRunner(BaseDeviceRunner):
             return f"{top1_class_label},{top1_class_probability},{','.join(parts)}"
 
         self.logger.info("Formatting response in JSON format")
+        output = {
+            "labels": [p["label"] for p in predictions],
+            "probabilities": [f"{p['probability']:.4f}%" for p in predictions],
+            "indices": [p["index"] for p in predictions],
+        }
+        # Include detection boxes + numeric scores when available (e.g. YOLOX).
+        if any("box" in p for p in predictions):
+            output["boxes"] = [p.get("box") for p in predictions]
+            output["scores"] = [p.get("score") for p in predictions]
         return ImageClassificationResult(
             top1_class_label=top1_class_label,
             top1_class_probability=top1_class_probability,
-            output={
-                "labels": [p["label"] for p in predictions],
-                "probabilities": [f"{p['probability']:.4f}%" for p in predictions],
-                "indices": [p["index"] for p in predictions],
-            },
+            output=output,
         )

--- a/utils/media_clients/cnn_client.py
+++ b/utils/media_clients/cnn_client.py
@@ -57,11 +57,10 @@ class CnnClientStrategy(BaseMediaStrategy):
         try:
             runner_in_use = self.require_health()
             eval_result = None
-            yolox_result = None
             if runner_in_use == CNN_MOBILENETV2_RUNNER:
                 eval_result = self._run_mobilenetv2_eval()
             elif runner_in_use == CNN_YOLOX_NANO_RUNNER:
-                yolox_result = self._run_yolox_coco_eval()
+                eval_result = self._run_yolox_coco_eval()
             else:
                 status_list = self._run_image_analysis_benchmark()
         except Exception as e:
@@ -90,23 +89,28 @@ class CnnClientStrategy(BaseMediaStrategy):
             benchmark_data["correct"] = eval_result["correct"]
             benchmark_data["total"] = eval_result["total"]
             benchmark_data["mismatches_count"] = eval_result["mismatches_count"]
-        elif runner_in_use == CNN_YOLOX_NANO_RUNNER and yolox_result:
+        elif runner_in_use == CNN_YOLOX_NANO_RUNNER and eval_result:
             logger.info("Adding YOLOX COCO mAP eval results")
-            benchmark_data["accuracy_check"] = yolox_result.get(
+            benchmark_data["accuracy_check"] = eval_result.get(
                 "accuracy_status", ReportCheckTypes.NA
             )
             # Report mAP (as a percentage) as the eval score against the
             # published COCO mAP (25.8 for yolox_nano).
-            benchmark_data["score"] = yolox_result["mAP_percent"]
-            benchmark_data["mAP"] = yolox_result["mAP_percent"]
-            benchmark_data["num_images"] = yolox_result["num_images"]
+            benchmark_data["score"] = eval_result["mAP_percent"]
+            benchmark_data["mAP"] = eval_result["mAP_percent"]
+            benchmark_data["num_images"] = eval_result["num_images"]
             benchmark_data["published_score"] = self.all_params.tasks[
                 0
             ].score.published_score
             benchmark_data["published_score_ref"] = self.all_params.tasks[
                 0
             ].score.published_score_ref
-            latency_for_perf_check = yolox_result.get("mean_latency")
+            latency_for_perf_check = eval_result.get("mean_latency")
+
+            # For single-concurrency CNN inference, tput_user (images/sec/user) = 1/latency.
+            if latency_for_perf_check:
+                benchmark_data["tput_user"] = 1.0 / latency_for_perf_check
+
         else:
             logger.info("No eval results from eval spec test to add to benchmark data")
             latency_value = self._calculate_latency(status_list)
@@ -120,10 +124,6 @@ class CnnClientStrategy(BaseMediaStrategy):
             benchmark_data["published_score_ref"] = self.all_params.tasks[
                 0
             ].score.published_score_ref
-
-        # For single-concurrency CNN inference, tput_user (images/sec/user) = 1/latency.
-        if latency_for_perf_check:
-            benchmark_data["tput_user"] = 1.0 / latency_for_perf_check
 
         benchmark_data["performance_check"] = self._calculate_performance_check(
             latency_value=latency_for_perf_check,
@@ -482,7 +482,7 @@ class CnnClientStrategy(BaseMediaStrategy):
         return buf.getvalue()
 
     @staticmethod
-    def _bbox_xyxy_to_xywh(bbox) -> Optional[list]:
+    def _corner_to_height_width_format(bbox) -> Optional[list]:
         """Convert an ``[x1,y1,x2,y2]`` box to ``[x,y,w,h]`` floats.
 
         Returns None for a malformed/None box so the caller can skip it (the
@@ -501,11 +501,9 @@ class CnnClientStrategy(BaseMediaStrategy):
     def _run_yolox_coco_eval(self) -> dict:
         """Evaluate the served YOLOX model with COCO mAP over a val2017 subset.
 
-        Streams ``detection-datasets/coco`` (val; ``objects`` is a dict-of-lists
-        with xyxy ``bbox`` and 0..79 ``category``), builds a COCO ground-truth
-        dict from its per-image boxes/categories, runs the served model on each
-        image, and scores predictions with ``pycocotools`` COCOeval. Category
-        ids 0..79 are shared between GT and predictions (canonical COCO order).
+        Orchestrates the two steps: collect GT + server predictions
+        (:meth:`_collect_yolox_coco_predictions`), then score them
+        (:meth:`_score_yolox_coco_predictions`) and derive an accuracy status.
 
         Robust-but-strict: a bad per-sample response is logged and skipped
         rather than crashing the evals workflow, but if nothing could be scored
@@ -515,17 +513,76 @@ class CnnClientStrategy(BaseMediaStrategy):
         Returns ``accuracy_status`` / ``mAP_percent`` / ``num_images`` /
         ``mean_latency``.
         """
-        # Lazy imports: heavy deps only needed for this eval.
-        from datasets import load_dataset
-        from pycocotools.coco import COCO
-        from pycocotools.cocoeval import COCOeval
-
         task = self.all_params.tasks[0]
         published = task.score.published_score
         tolerance = task.score.tolerance
         num_images = int(
             os.environ.get("YOLOX_COCO_NUM_IMAGES", DEFAULT_COCO_NUM_IMAGES)
         )
+
+        images_meta, annotations, predictions, mean_latency = (
+            self._collect_yolox_coco_predictions(num_images)
+        )
+        mAP, scored = self._score_yolox_coco_predictions(
+            images_meta, annotations, predictions
+        )
+
+        mAP_percent = mAP * 100.0
+        if scored and published:
+            accuracy_status = ReportCheckTypes.from_result(
+                mAP_percent >= published * (1.0 - tolerance)
+            )
+        elif scored and not published:
+            # No reference score configured — cannot judge the mAP.
+            accuracy_status = ReportCheckTypes.NA
+        else:
+            # Could not compute a real mAP: the server returned no detection
+            # boxes, ground truth was empty, or COCOeval errored. For a release
+            # gate this is a FAIL, not NA — a serving/plumbing regression must
+            # not pass silently.
+            logger.error(
+                "YOLOX COCO eval: could not score mAP (preds=%d, anns=%d); "
+                "failing accuracy_check (is the server returning boxes?)",
+                len(predictions),
+                len(annotations),
+            )
+            accuracy_status = ReportCheckTypes.FAIL
+
+        logger.info(
+            "YOLOX COCO eval: mAP=%.4f (%.2f%%) images=%d preds=%d anns=%d "
+            "published=%s -> accuracy_status=%s",
+            mAP,
+            mAP_percent,
+            len(images_meta),
+            len(predictions),
+            len(annotations),
+            published,
+            accuracy_status,
+        )
+        return {
+            "accuracy_status": accuracy_status,
+            "mAP_percent": mAP_percent,
+            "num_images": len(images_meta),
+            "mean_latency": mean_latency,
+        }
+
+    def _collect_yolox_coco_predictions(
+        self, num_images: int
+    ) -> tuple[list, list, list, float]:
+        """Stream a COCO val subset, run inference per image, and collect GT +
+        server predictions in COCO format.
+
+        Streams ``detection-datasets/coco`` (val; ``objects`` is a dict-of-lists
+        with xyxy ``bbox`` and 0..79 ``category``). Category ids 0..79 are shared
+        between GT and predictions (canonical COCO order). A bad sample is logged
+        and skipped rather than aborting the run.
+
+        Returns ``(images_meta, annotations, predictions, mean_latency)`` where
+        the first three are COCO-format lists and ``mean_latency`` is the mean
+        per-image request latency in seconds.
+        """
+        # Lazy import: heavy dep only needed for this eval.
+        from datasets import load_dataset
 
         images_meta: list = []
         annotations: list = []
@@ -561,7 +618,7 @@ class CnnClientStrategy(BaseMediaStrategy):
                     categories = objects.get("category") or []
                     bboxes = objects.get("bbox") or []
                     for cat, bbox in zip(categories, bboxes):
-                        xywh = self._bbox_xyxy_to_xywh(bbox)
+                        xywh = self._corner_to_height_width_format(bbox)
                         if xywh is None or cat is None:
                             continue
                         annotations.append(
@@ -587,7 +644,7 @@ class CnnClientStrategy(BaseMediaStrategy):
                         )
                         logged_pred = True
                     for box, score, cls_ind in dets:
-                        xywh = self._bbox_xyxy_to_xywh(box)
+                        xywh = self._corner_to_height_width_format(box)
                         if xywh is None:
                             continue
                         predictions.append(
@@ -606,72 +663,45 @@ class CnnClientStrategy(BaseMediaStrategy):
             logger.exception("YOLOX COCO eval: dataset/inference loop failed")
 
         mean_latency = sum(latencies) / len(latencies) if latencies else 0.0
-        image_ids = [m["id"] for m in images_meta]
+        return images_meta, annotations, predictions, mean_latency
 
-        mAP = 0.0
-        scored = False
-        try:
-            if predictions and annotations:
-                coco_gt = COCO()
-                coco_gt.dataset = {
-                    "images": images_meta,
-                    "annotations": annotations,
-                    "categories": [{"id": c, "name": str(c)} for c in range(80)],
-                }
-                coco_gt.createIndex()
-                coco_dt = coco_gt.loadRes(predictions)
-                coco_eval = COCOeval(coco_gt, coco_dt, "bbox")
-                coco_eval.params.imgIds = image_ids
-                coco_eval.evaluate()
-                coco_eval.accumulate()
-                coco_eval.summarize()
-                mAP = max(float(coco_eval.stats[0]), 0.0)
-                scored = True
-            else:
-                logger.warning(
-                    "YOLOX COCO eval: nothing to score (predictions=%d, "
-                    "annotations=%d) - is the server returning detection boxes?",
-                    len(predictions),
-                    len(annotations),
-                )
-        except Exception:
-            logger.exception("YOLOX COCO eval: COCOeval failed; mAP=0.0")
+    def _score_yolox_coco_predictions(
+        self, images_meta: list, annotations: list, predictions: list
+    ) -> tuple[float, bool]:
+        """Score predictions against ground truth with ``pycocotools`` COCOeval.
 
-        mAP_percent = mAP * 100.0
-        if scored and published:
-            accuracy_status = ReportCheckTypes.from_result(
-                mAP_percent >= published * (1.0 - tolerance)
-            )
-        elif scored and not published:
-            # No reference score configured — cannot judge the mAP.
-            accuracy_status = ReportCheckTypes.NA
-        else:
-            # Could not compute a real mAP: the server returned no detection
-            # boxes, ground truth was empty, or COCOeval errored. For a release
-            # gate this is a FAIL, not NA — a serving/plumbing regression must
-            # not pass silently.
-            logger.error(
-                "YOLOX COCO eval: could not score mAP (preds=%d, anns=%d); "
-                "failing accuracy_check (is the server returning boxes?)",
+        Returns ``(mAP, scored)`` where ``mAP`` is mAP@[.5:.95] (>= 0) and
+        ``scored`` is False when there was nothing to score (no predictions or
+        no GT) or COCOeval errored.
+        """
+        # Lazy imports: heavy deps only needed for this eval.
+        from pycocotools.coco import COCO
+        from pycocotools.cocoeval import COCOeval
+
+        if not (predictions and annotations):
+            logger.warning(
+                "YOLOX COCO eval: nothing to score (predictions=%d, "
+                "annotations=%d) - is the server returning detection boxes?",
                 len(predictions),
                 len(annotations),
             )
-            accuracy_status = ReportCheckTypes.FAIL
+            return 0.0, False
 
-        logger.info(
-            "YOLOX COCO eval: mAP=%.4f (%.2f%%) images=%d preds=%d anns=%d "
-            "published=%s -> accuracy_status=%s",
-            mAP,
-            mAP_percent,
-            len(image_ids),
-            len(predictions),
-            len(annotations),
-            published,
-            accuracy_status,
-        )
-        return {
-            "accuracy_status": accuracy_status,
-            "mAP_percent": mAP_percent,
-            "num_images": len(image_ids),
-            "mean_latency": mean_latency,
-        }
+        try:
+            coco_gt = COCO()
+            coco_gt.dataset = {
+                "images": images_meta,
+                "annotations": annotations,
+                "categories": [{"id": c, "name": str(c)} for c in range(80)],
+            }
+            coco_gt.createIndex()
+            coco_dt = coco_gt.loadRes(predictions)
+            coco_eval = COCOeval(coco_gt, coco_dt, "bbox")
+            coco_eval.params.imgIds = [m["id"] for m in images_meta]
+            coco_eval.evaluate()
+            coco_eval.accumulate()
+            coco_eval.summarize()
+            return max(float(coco_eval.stats[0]), 0.0), True
+        except Exception:
+            logger.exception("YOLOX COCO eval: COCOeval failed; mAP=0.0")
+            return 0.0, False

--- a/utils/media_clients/cnn_client.py
+++ b/utils/media_clients/cnn_client.py
@@ -42,6 +42,10 @@ DEFAULT_COCO_NUM_IMAGES = 100
 # (standard COCO eval uses ~0.01).
 COCO_EVAL_MIN_CONFIDENCE = 1.0  # percent -> server score_thr ~0.01
 COCO_EVAL_TOP_K = 300
+# Benchmark (latency/throughput timing only) reuses COCO images for YOLOX so it
+# doesn't also pull the ImageNet subset. Materialized once from the same HF
+# dataset the eval streams (parquet already cached).
+COCO_BENCHMARK_DATASET_DIR = "server_tests/datasets/coco_bench"
 
 
 class CnnClientStrategy(BaseMediaStrategy):
@@ -162,8 +166,59 @@ class CnnClientStrategy(BaseMediaStrategy):
             logger.error(f"Benchmark execution encountered an error: {e}")
             raise
 
+    def _is_yolox(self) -> bool:
+        """True for YOLOX detection models (they eval/benchmark on COCO)."""
+        return "yolox" in (self.model_spec.hf_model_repo or "").lower()
+
+    def _ensure_coco_benchmark_images(
+        self, count: int = DEFAULT_DATASET_DOWNLOAD_COUNT
+    ) -> tuple[Path, list[dict]]:
+        """Materialize a small COCO image set for benchmark timing.
+
+        The benchmark only needs images to POST for latency/throughput timing
+        (it ignores labels), so YOLOX reuses COCO here instead of pulling the
+        ImageNet subset. Streamed from the same HF dataset the eval uses (so the
+        parquet is already cached); images are saved once and reused. Returns
+        ``(dataset_path, metadata)`` matching ``_ensure_imagenet_dataset``.
+        """
+        dataset_path = Path(COCO_BENCHMARK_DATASET_DIR)
+        metadata_path = dataset_path / IMAGENET_METADATA_FILE
+        if metadata_path.exists():
+            try:
+                with metadata_path.open("r", encoding="utf-8") as f:
+                    metadata = json.load(f)
+                if metadata:
+                    return dataset_path, metadata
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        logger.info(
+            "COCO benchmark images missing at %s; materializing %d images.",
+            dataset_path,
+            count,
+        )
+        # Lazy import to avoid loading 'datasets' at module import time.
+        from datasets import load_dataset
+
+        ds = load_dataset(COCO_HF_DATASET, split=COCO_HF_SPLIT, streaming=True)
+        dataset_path.mkdir(parents=True, exist_ok=True)
+        metadata: list[dict] = []
+        for i, sample in enumerate(itertools.islice(ds, count)):
+            image = sample["image"]
+            if image.mode != "RGB":
+                image = image.convert("RGB")
+            filename = f"coco_{i:03d}.jpg"
+            image.save(dataset_path / filename)
+            metadata.append({"filename": filename})
+
+        if not metadata:
+            raise RuntimeError("No COCO benchmark images could be materialized.")
+        with metadata_path.open("w", encoding="utf-8") as f:
+            json.dump(metadata, f)
+        return dataset_path, metadata
+
     def _run_image_analysis_benchmark(self) -> list[CnnGenerationTestStatus]:
-        """Run image analysis benchmark using the ImageNet subset dataset.
+        """Run image analysis benchmark using an image subset dataset.
 
         Sends one request per image present in the dataset (so the number of
         requests is determined by the dataset itself, not by a benchmark
@@ -172,11 +227,16 @@ class CnnClientStrategy(BaseMediaStrategy):
         request - no accuracy comparison. Aggregate metrics such as TTFT are
         computed downstream from `len(status_list)`.
         """
-        dataset_path, metadata = self._ensure_imagenet_dataset()
+        # The benchmark only needs images to time inference (accuracy-agnostic).
+        # YOLOX reuses COCO so it doesn't also download the ImageNet subset;
+        # other CNNs keep using the shared ImageNet subset.
+        if self._is_yolox():
+            dataset_path, metadata = self._ensure_coco_benchmark_images()
+        else:
+            dataset_path, metadata = self._ensure_imagenet_dataset()
         total_requests = len(metadata)
         logger.info(
-            "Running image analysis benchmark over ImageNet subset at %s "
-            "(%d images -> %d requests).",
+            "Running image analysis benchmark over %s (%d images -> %d requests).",
             dataset_path,
             total_requests,
             total_requests,

--- a/utils/media_clients/cnn_client.py
+++ b/utils/media_clients/cnn_client.py
@@ -157,6 +157,10 @@ class CnnClientStrategy(BaseMediaStrategy):
         )
         try:
             self.require_health()
+            if self._is_yolox():
+                self._ensure_coco_benchmark_images()
+            else:
+                self._ensure_imagenet_dataset()
             loop_start = time.monotonic()
             status_list = self._run_image_analysis_benchmark()
             wall_clock_seconds = time.monotonic() - loop_start

--- a/utils/media_clients/cnn_client.py
+++ b/utils/media_clients/cnn_client.py
@@ -3,8 +3,11 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 import base64
+import io
+import itertools
 import json
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -20,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 # Constants
 CNN_MOBILENETV2_RUNNER = "tt-xla-mobilenetv2"
+CNN_YOLOX_NANO_RUNNER = "tt-xla-yolox-nano"
 # Reuse the ImageNet subset prepared by VisionEvalsTest so benchmarks and
 # accuracy evals exercise the model with the exact same inputs.
 IMAGENET_DATASET_DIR = "server_tests/datasets/imagenet_subset"
@@ -28,6 +32,16 @@ IMAGENET_METADATA_FILE = "metadata.json"
 # downloaded, the benchmark sends one request per image found in the dataset
 # (so the request count equals len(metadata), not this constant).
 DEFAULT_DATASET_DOWNLOAD_COUNT = 20
+
+# --- YOLOX COCO mAP eval ----------------------------------------------------
+COCO_HF_DATASET = "detection-datasets/coco"
+COCO_HF_SPLIT = "val"
+# Number of COCO val images to evaluate.
+DEFAULT_COCO_NUM_IMAGES = 100
+# Detection thresholds requested from the server for mAP
+# (standard COCO eval uses ~0.01).
+COCO_EVAL_MIN_CONFIDENCE = 1.0  # percent -> server score_thr ~0.01
+COCO_EVAL_TOP_K = 300
 
 
 class CnnClientStrategy(BaseMediaStrategy):
@@ -43,8 +57,11 @@ class CnnClientStrategy(BaseMediaStrategy):
         try:
             runner_in_use = self.require_health()
             eval_result = None
+            yolox_result = None
             if runner_in_use == CNN_MOBILENETV2_RUNNER:
                 eval_result = self._run_mobilenetv2_eval()
+            elif runner_in_use == CNN_YOLOX_NANO_RUNNER:
+                yolox_result = self._run_yolox_coco_eval()
             else:
                 status_list = self._run_image_analysis_benchmark()
         except Exception as e:
@@ -73,6 +90,23 @@ class CnnClientStrategy(BaseMediaStrategy):
             benchmark_data["correct"] = eval_result["correct"]
             benchmark_data["total"] = eval_result["total"]
             benchmark_data["mismatches_count"] = eval_result["mismatches_count"]
+        elif runner_in_use == CNN_YOLOX_NANO_RUNNER and yolox_result:
+            logger.info("Adding YOLOX COCO mAP eval results")
+            benchmark_data["accuracy_check"] = yolox_result.get(
+                "accuracy_status", ReportCheckTypes.NA
+            )
+            # Report mAP (as a percentage) as the eval score against the
+            # published COCO mAP (25.8 for yolox_nano).
+            benchmark_data["score"] = yolox_result["mAP_percent"]
+            benchmark_data["mAP"] = yolox_result["mAP_percent"]
+            benchmark_data["num_images"] = yolox_result["num_images"]
+            benchmark_data["published_score"] = self.all_params.tasks[
+                0
+            ].score.published_score
+            benchmark_data["published_score_ref"] = self.all_params.tasks[
+                0
+            ].score.published_score_ref
+            latency_for_perf_check = yolox_result.get("mean_latency")
         else:
             logger.info("No eval results from eval spec test to add to benchmark data")
             latency_value = self._calculate_latency(status_list)
@@ -86,6 +120,10 @@ class CnnClientStrategy(BaseMediaStrategy):
             benchmark_data["published_score_ref"] = self.all_params.tasks[
                 0
             ].score.published_score_ref
+
+        # For single-concurrency CNN inference, tput_user (images/sec/user) = 1/latency.
+        if latency_for_perf_check:
+            benchmark_data["tput_user"] = 1.0 / latency_for_perf_check
 
         benchmark_data["performance_check"] = self._calculate_performance_check(
             latency_value=latency_for_perf_check,
@@ -378,3 +416,262 @@ class CnnClientStrategy(BaseMediaStrategy):
         logger.info(f"VisionEvalsTest device eval_results: {device_result}")
 
         return device_result
+
+    # --- YOLOX COCO mAP eval ------------------------------------------------
+
+    def _yolox_detect(self, image_jpeg: bytes) -> tuple[list, float]:
+        """POST one JPEG image and return (detections, elapsed_seconds).
+
+        Each detection is ``(box_xyxy, score, cls_ind)``. Requests a low
+        confidence threshold + high top_k so low-confidence detections are
+        retained for mAP.
+        """
+        encoded = base64.b64encode(image_jpeg).decode("ascii")
+        headers = {
+            "accept": "application/json",
+            "Authorization": "Bearer your-secret-key",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "prompt": f"data:image/jpeg;base64,{encoded}",
+            "top_k": COCO_EVAL_TOP_K,
+            "min_confidence": COCO_EVAL_MIN_CONFIDENCE,
+            "response_format": "json",
+        }
+        start_time = time.time()
+        response = requests.post(
+            f"{self.base_url}/v1/cnn/search-image",
+            json=payload,
+            headers=headers,
+            timeout=120,
+        )
+        elapsed = time.time() - start_time
+
+        detections: list = []
+        if response.status_code != 200:
+            logger.warning(
+                "YOLOX COCO eval: server returned HTTP %s", response.status_code
+            )
+            return detections, elapsed
+        try:
+            body = response.json()
+        except ValueError:
+            return detections, elapsed
+
+        image_data = body.get("image_data") if isinstance(body, dict) else None
+        first = (
+            image_data[0] if isinstance(image_data, list) and image_data else image_data
+        )
+        if not isinstance(first, dict):
+            return detections, elapsed
+        output = first.get("output") or {}
+        boxes = output.get("boxes") or []
+        scores = output.get("scores") or []
+        indices = output.get("indices") or []
+        for box, score, cls_ind in zip(boxes, scores, indices):
+            detections.append((box, float(score), int(cls_ind)))
+        return detections, elapsed
+
+    @staticmethod
+    def _pil_to_jpeg_bytes(image) -> bytes:
+        """Encode a PIL image to JPEG bytes (RGB)."""
+        if image.mode != "RGB":
+            image = image.convert("RGB")
+        buf = io.BytesIO()
+        image.save(buf, format="JPEG")
+        return buf.getvalue()
+
+    @staticmethod
+    def _bbox_xyxy_to_xywh(bbox) -> Optional[list]:
+        """Convert an ``[x1,y1,x2,y2]`` box to ``[x,y,w,h]`` floats.
+
+        Returns None for a malformed/None box so the caller can skip it (the
+        source data or server response occasionally has missing coordinates).
+        """
+        if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+            return None
+        if any(c is None for c in bbox):
+            return None
+        try:
+            x1, y1, x2, y2 = (float(c) for c in bbox)
+        except (TypeError, ValueError):
+            return None
+        return [x1, y1, x2 - x1, y2 - y1]
+
+    def _run_yolox_coco_eval(self) -> dict:
+        """Evaluate the served YOLOX model with COCO mAP over a val2017 subset.
+
+        Streams ``detection-datasets/coco`` (val; ``objects`` is a dict-of-lists
+        with xyxy ``bbox`` and 0..79 ``category``), builds a COCO ground-truth
+        dict from its per-image boxes/categories, runs the served model on each
+        image, and scores predictions with ``pycocotools`` COCOeval. Category
+        ids 0..79 are shared between GT and predictions (canonical COCO order).
+
+        Robust-but-strict: a bad per-sample response is logged and skipped
+        rather than crashing the evals workflow, but if nothing could be scored
+        at all (server returned no boxes, empty GT, or COCOeval error) the
+        result is FAIL — a serving/plumbing regression must not pass silently.
+
+        Returns ``accuracy_status`` / ``mAP_percent`` / ``num_images`` /
+        ``mean_latency``.
+        """
+        # Lazy imports: heavy deps only needed for this eval.
+        from datasets import load_dataset
+        from pycocotools.coco import COCO
+        from pycocotools.cocoeval import COCOeval
+
+        task = self.all_params.tasks[0]
+        published = task.score.published_score
+        tolerance = task.score.tolerance
+        num_images = int(
+            os.environ.get("YOLOX_COCO_NUM_IMAGES", DEFAULT_COCO_NUM_IMAGES)
+        )
+
+        images_meta: list = []
+        annotations: list = []
+        predictions: list = []
+        latencies: list = []
+        ann_id = 1
+        logged_pred = False
+
+        try:
+            logger.info(
+                "YOLOX COCO eval: streaming %s[%s], %d images",
+                COCO_HF_DATASET,
+                COCO_HF_SPLIT,
+                num_images,
+            )
+            ds = load_dataset(COCO_HF_DATASET, split=COCO_HF_SPLIT, streaming=True)
+            for i, sample in enumerate(itertools.islice(ds, num_images), start=1):
+                try:
+                    image_id = int(sample["image_id"])
+                    image = sample["image"]
+                    if not hasattr(image, "width"):
+                        # Undecoded {bytes, path} dict — decode to PIL.
+                        from PIL import Image as _PILImage
+
+                        image = _PILImage.open(io.BytesIO(image["bytes"]))
+                    width = int(sample.get("width") or image.width)
+                    height = int(sample.get("height") or image.height)
+                    images_meta.append(
+                        {"id": image_id, "width": width, "height": height}
+                    )
+
+                    objects = sample.get("objects") or {}
+                    categories = objects.get("category") or []
+                    bboxes = objects.get("bbox") or []
+                    for cat, bbox in zip(categories, bboxes):
+                        xywh = self._bbox_xyxy_to_xywh(bbox)
+                        if xywh is None or cat is None:
+                            continue
+                        annotations.append(
+                            {
+                                "id": ann_id,
+                                "image_id": image_id,
+                                "category_id": int(cat),
+                                "bbox": xywh,
+                                "area": float(xywh[2] * xywh[3]),
+                                "iscrowd": 0,
+                            }
+                        )
+                        ann_id += 1
+
+                    dets, elapsed = self._yolox_detect(self._pil_to_jpeg_bytes(image))
+                    latencies.append(elapsed)
+                    if not logged_pred:
+                        logger.info(
+                            "YOLOX COCO eval: first image returned %d detections "
+                            "(sample=%s)",
+                            len(dets),
+                            dets[0] if dets else None,
+                        )
+                        logged_pred = True
+                    for box, score, cls_ind in dets:
+                        xywh = self._bbox_xyxy_to_xywh(box)
+                        if xywh is None:
+                            continue
+                        predictions.append(
+                            {
+                                "image_id": image_id,
+                                "category_id": int(cls_ind),
+                                "bbox": xywh,
+                                "score": float(score),
+                            }
+                        )
+                except Exception as e:  # noqa: BLE001 - skip a bad sample, keep going
+                    logger.warning("YOLOX COCO eval: skipping sample %d: %s", i, e)
+                if i % 10 == 0:
+                    logger.info("YOLOX COCO eval: %d images processed", i)
+        except Exception:
+            logger.exception("YOLOX COCO eval: dataset/inference loop failed")
+
+        mean_latency = sum(latencies) / len(latencies) if latencies else 0.0
+        image_ids = [m["id"] for m in images_meta]
+
+        mAP = 0.0
+        scored = False
+        try:
+            if predictions and annotations:
+                coco_gt = COCO()
+                coco_gt.dataset = {
+                    "images": images_meta,
+                    "annotations": annotations,
+                    "categories": [{"id": c, "name": str(c)} for c in range(80)],
+                }
+                coco_gt.createIndex()
+                coco_dt = coco_gt.loadRes(predictions)
+                coco_eval = COCOeval(coco_gt, coco_dt, "bbox")
+                coco_eval.params.imgIds = image_ids
+                coco_eval.evaluate()
+                coco_eval.accumulate()
+                coco_eval.summarize()
+                mAP = max(float(coco_eval.stats[0]), 0.0)
+                scored = True
+            else:
+                logger.warning(
+                    "YOLOX COCO eval: nothing to score (predictions=%d, "
+                    "annotations=%d) - is the server returning detection boxes?",
+                    len(predictions),
+                    len(annotations),
+                )
+        except Exception:
+            logger.exception("YOLOX COCO eval: COCOeval failed; mAP=0.0")
+
+        mAP_percent = mAP * 100.0
+        if scored and published:
+            accuracy_status = ReportCheckTypes.from_result(
+                mAP_percent >= published * (1.0 - tolerance)
+            )
+        elif scored and not published:
+            # No reference score configured — cannot judge the mAP.
+            accuracy_status = ReportCheckTypes.NA
+        else:
+            # Could not compute a real mAP: the server returned no detection
+            # boxes, ground truth was empty, or COCOeval errored. For a release
+            # gate this is a FAIL, not NA — a serving/plumbing regression must
+            # not pass silently.
+            logger.error(
+                "YOLOX COCO eval: could not score mAP (preds=%d, anns=%d); "
+                "failing accuracy_check (is the server returning boxes?)",
+                len(predictions),
+                len(annotations),
+            )
+            accuracy_status = ReportCheckTypes.FAIL
+
+        logger.info(
+            "YOLOX COCO eval: mAP=%.4f (%.2f%%) images=%d preds=%d anns=%d "
+            "published=%s -> accuracy_status=%s",
+            mAP,
+            mAP_percent,
+            len(image_ids),
+            len(predictions),
+            len(annotations),
+            published,
+            accuracy_status,
+        )
+        return {
+            "accuracy_status": accuracy_status,
+            "mAP_percent": mAP_percent,
+            "num_images": len(image_ids),
+            "mean_latency": mean_latency,
+        }


### PR DESCRIPTION
This PR includes:
- Uplift tt-forge-models (FORGE_MODELS_SHA → [2e59f9b5](https://github.com/tenstorrent/tt-forge-models/commit/2e59f9b5f72a6bfacace309d4a809300f4ad4eb7)): pulls the YOLOX loader change that exposes detection boxes + numeric scores from output_postprocess and fixes a double-decode (decode_in_inference=False) that was exp-overflowing box coordinates to inf/NaN. Required because the CNN serving path previously returned only class labels, so real detection accuracy couldn't be measured.
- yolox_nano eval completion (`utils/media_clients/cnn_client.py`):
    - Accuracy — real COCO mAP via _run_yolox_coco_eval: streams `detection-datasets/coco` (val), builds an in-memory pycocotools GT (xyxy→xywh, shared 0–79 category ids), scores the served model's detections with COCOeval (bbox); mAP = stats[0].
    - accuracy_check: PASS iff mAP ≥ published (25.8) × (1 − tolerance=0.05) (≥ 24.51%); replaces the ImageNet-classification stand-in.
    - `tput_user = 1/latency`: emitted from the eval so the enforced functional/complete tput_check reads real throughput instead of defaulting to 0.
    - Fail-strict: FAIL (not NA) when nothing can be scored (server returns no boxes / empty GT / COCOeval error), so a serving regression can't pass silently; malformed/None boxes are skipped per-sample.
    - Server passthrough: forge_runner forwards the new boxes/scores in the search-image response (backward-compatible for other CNNs).
    - Deps: pycocotools added to the evals venv (requirements/evals-run-script.txt).

For reference: yolox_nano on latest main: https://github.com/tenstorrent/tt-shield/actions/runs/28817751590 

Tests Run:
(using docker image ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:32ba899570c08cc95b3e9d78dc9b36aae0d4b8d9_22d914c_85476296597)
- efficientnet: https://github.com/tenstorrent/tt-shield/actions/runs/28824701980 
- mobilenetv2: https://github.com/tenstorrent/tt-shield/actions/runs/28824788035
- resnet-50: https://github.com/tenstorrent/tt-shield/actions/runs/28824834751
- segformer: https://github.com/tenstorrent/tt-shield/actions/runs/28824877071
- vit: https://github.com/tenstorrent/tt-shield/actions/runs/28824909046
- vovnet: https://github.com/tenstorrent/tt-shield/actions/runs/28824945901
- yolox_nano: https://github.com/tenstorrent/tt-shield/actions/runs/28822150589