### PR TITLE
Restore 3600s server health-wait default + honor per-model `tensor_cache_timeout` (v2)

### DIFF
--- a/tt-inference-server-v2/llm_module/server_control.py
+++ b/tt-inference-server-v2/llm_module/server_control.py
@@ -21,7 +21,7 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_WAIT_HEALTHY_TIMEOUT_S = 1200.0
+DEFAULT_WAIT_HEALTHY_TIMEOUT_S = 3600.0
 DEFAULT_HEALTH_PATH = "/health"
 DEFAULT_POLL_INTERVAL_S = 10
 

--- a/tt-inference-server-v2/test_module/llm_tests/llm_eval_tests.py
+++ b/tt-inference-server-v2/test_module/llm_tests/llm_eval_tests.py
@@ -26,7 +26,10 @@ from ..context import MediaContext
 
 logger = logging.getLogger(__name__)
 
-_WAIT_HEALTHY_TIMEOUT_S = 1200.0
+# Fallback health-wait budget when the model spec doesn't set one. The per-model
+# value comes from DeviceModelSpec.tensor_cache_timeout (first-compile/warmup for
+# large forge LLMs can exceed 1200s); bump it per model in the model spec.
+_DEFAULT_WAIT_HEALTHY_TIMEOUT_S = 3600.0
 
 
 def _device_label(ctx: MediaContext) -> str:
@@ -272,7 +275,15 @@ def run_llm_eval(ctx: MediaContext, *, auth_token: str = "") -> List[Block]:
         service_port=ctx.server_port,
         auth_token=auth_token,
     )
-    if not server.wait_for_healthy(timeout=_WAIT_HEALTHY_TIMEOUT_S):
+    health_timeout = (
+        getattr(
+            getattr(ctx.model_spec, "device_model_spec", None),
+            "tensor_cache_timeout",
+            None,
+        )
+        or _DEFAULT_WAIT_HEALTHY_TIMEOUT_S
+    )
+    if not server.wait_for_healthy(timeout=health_timeout):
         logger.error("⛔ inference server not healthy; aborting evals.")
         blocks = [_fail_block(ctx, t, "inference server not healthy") for t in tasks]
         _accept(ctx, blocks)


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-inference-server/issues/4512

### Problem description

Routing eval/release through `tt-inference-server-v2` (#4348) hardcoded the server health-wait to **1200s** and stopped consulting the per-model `DeviceModelSpec.tensor_cache_timeout` (default **3600s**; prod LLMs set it to **5400–6400s** in `prod/llm.yaml`) that the v1 path used. Models whose first-compile warmup exceeds 1200s then fail the **evals** step even though the server comes up — the health-wait aborts and the eval tasks are recorded as blockers, failing the release.

1200s was not a deliberate fast-fail: the design is long, per-model waits (prod values go *up* to 5400–6400s), and the field is also consumed by `helm_generator/base_mapper.py`. The v2 hardcode broke this for every model that set `tensor_cache_timeout`, not just forge.

Observed on Qwen3-8B forge (tt-shield run `28692820991`): ~25 min first-compile warmup. Evals aborted at 1200s (`did not become healthy within 1200s`), while the server came up ~5 min later and the benchmarks step (fresh wait) ran cleanly — confirming a too-short, non-per-model timeout, not a server failure.

### What's changed

Restore per-model health-wait budgeting:

- `test_module/llm_tests/llm_eval_tests.py` — read the wait from `device_model_spec.tensor_cache_timeout`, falling back to 3600s.
- `llm_module/server_control.py` — `DEFAULT_WAIT_HEALTHY_TIMEOUT_S` 1200 → 3600 (covers the benchmark/other steps that rely on the default).

Per-model override: set `tensor_cache_timeout` in the model's spec (already used in `prod/llm.yaml`). The wait is a polling ceiling — it returns as soon as `/health` passes — so a larger value never delays fast-compiling models; it only lets slow ones finish warming up. No server rebuild needed: this code runs in the eval client from the branch checkout, not inside the served image.

### Checklist

- [x] Forge Qwen3-8B model w/ this change on branch: https://github.com/tenstorrent/tt-shield/actions/runs/28696213435 is able to warmup now without hitting 1200s timeout (though later hits other issues, will follow up)

```
2026-07-04 06:22:14,393 [INFO] llm_module.server_control: ✅ Inference server is healthy at http://127.0.0.1:8000/health
2026-07-04 06:22:14,406 [INFO] test_module.llm_tests.llm_eval_tests: Running eval task=r1_gpqa_diamond
```