### PR TITLE
Bump tt-forge to 1.4.0.dev20260704002153

### DIFF
--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,10 +1,7 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
 --extra-index-url https://download.pytorch.org/whl/cpu
-# Custom 1.3.0 dev/nightly built 2026-06-05, as baked into the tt-shield forge
-# image tag e03b231b1de926cd8f9a0e1a2d39dd1df599f7a7_46a7c96_79778041239.
-# Supersedes 1.2.0.dev20260530002932 (gemma-4-31b-it was first validated on
-# that older build); carries the gemma-4-31b TP support the stock 1.3.0 lacks.
-tt-forge==1.3.0
+# 1.4.0 dev/nightly built 2026-07-04. Supersedes the released 1.3.0.
+tt-forge==1.4.0.dev20260704002153
 
 tabulate
 timm # input preprocessing


### PR DESCRIPTION
Version bump of `tt-forge` to `1.4.0.dev20260704002153` in `tt-media-server/tt_model_runners/forge_runners/requirements.txt` (supersedes the released `1.3.0`).

This brings several features to help LLMs that got merged in last few days

- https://github.com/tenstorrent/tt-xla/issues/4986
- https://github.com/tenstorrent/tt-xla/issues/5281
- https://github.com/tenstorrent/tt-xla/issues/5468

### Checklist

- [x] `efficientnet`: https://github.com/tenstorrent/tt-shield/actions/runs/28711062736
- [x] `mobilenetv2`: https://github.com/tenstorrent/tt-shield/actions/runs/28711063298
- [x] `resnet-50`: https://github.com/tenstorrent/tt-shield/actions/runs/28711063802
- [x] `segformer`: https://github.com/tenstorrent/tt-shield/actions/runs/28711064332
- [x] `vit`: https://github.com/tenstorrent/tt-shield/actions/runs/28711064896
- [x] `vovnet`: https://github.com/tenstorrent/tt-shield/actions/runs/28711065486
- [x] `Falcon3-7B-Instruct`: https://github.com/tenstorrent/tt-shield/actions/runs/28711231576/job/85146392236

FYI @ddilbazTT 