### PR TITLE
 fix(evals): add lm-eval[api] extra to evals-meta venv (pulls tenacity)

### DIFF
--- a/requirements/evals-meta.txt
+++ b/requirements/evals-meta.txt
@@ -13,7 +13,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 antlr4_python3_runtime==4.11
-lm-eval[math,ifeval,sentencepiece,vllm]==0.4.4
+lm-eval[api,math,ifeval,sentencepiece,vllm]==0.4.4
 pyjwt
 pillow
 datasets==3.1.0


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-inference-server/issues/4515

### Problem description

The `EVALS_META` workflow venv (built from `requirements/evals-meta.txt`) installed lm-eval without the `api` extra. Meta evals (`meta_ifeval` and others) run via lm-eval's `local-completions` API model, which requires `tenacity` — pulled in by the `api` extra. So the meta venv lacked `tenacity` and every meta eval aborted immediately with `ModuleNotFoundError: required packages ['tenacity'] are not installed`. `requirements/evals-common.txt` already includes `[api]`; only the meta venv was missing it.

Failing CI run (Llama-3.1-8B-Instruct forge release): https://github.com/tenstorrent/tt-shield/actions/runs/28697130708

### What's changed

Added the `api` extra to the lm-eval line in `requirements/evals-meta.txt` (one line). No code changes; this only widens the meta venv's dependency set to match how the meta evals are actually invoked.

### Verification

Re-dispatched the same Llama-3.1-8B-Instruct forge release with the fix: https://github.com/tenstorrent/tt-shield/actions/runs/28716967406

