### PR TITLE
Bump tt-forge to 1.4.0.dev20260705001833

### DIFF
--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
 --extra-index-url https://download.pytorch.org/whl/cpu
-# 1.4.0 dev/nightly built 2026-07-04. Supersedes the released 1.3.0.
-tt-forge==1.4.0.dev20260704002153
+# 1.4.0 dev/nightly built 2026-07-05. Supersedes the 2026-07-04 build.
+tt-forge==1.4.0.dev20260705001833
 
 tabulate
 timm # input preprocessing


### PR DESCRIPTION
### Issue

https://github.com/tenstorrent/tt-inference-server/issues/4518

### What's Changed

Version bump of `tt-forge` to `1.4.0.dev20260705001833` in `tt-media-server/tt_model_runners/forge_runners/requirements.txt` (supersedes the `2026-07-04` build from #4514).

This brings one feature to mitigate DRAM OOM by reducing fragmentation and fixes chunk-2048 prefill OOMs on long-context forge LLMs (e.g. Llama-3.1-8B @ `max_model_len=65536`, Qwen3-8B) that failed on the `2026-07-04` build despite sufficient total DRAM.

- https://github.com/tenstorrent/tt-xla/pull/5523 

### Checklist

- [x] `efficientnet`: https://github.com/tenstorrent/tt-shield/actions/runs/28728615143
- [x] `mobilenetv2`: https://github.com/tenstorrent/tt-shield/actions/runs/28728615697
- [x] `resnet-50`: https://github.com/tenstorrent/tt-shield/actions/runs/28728616150
- [x] `segformer`: https://github.com/tenstorrent/tt-shield/actions/runs/28728616632
- [x] `vit`: https://github.com/tenstorrent/tt-shield/actions/runs/28728617119
- [x] `vovnet`: https://github.com/tenstorrent/tt-shield/actions/runs/28728617695
- [x] `Falcon3-7B-Instruct`: https://github.com/tenstorrent/tt-shield/actions/runs/28728618259
