### PR TITLE
fix(v2): forge eval/benchmark 401 for dual-catalog models — read engine from the runtime spec, not the catalog

### DIFF
--- a/tt-inference-server-v2/tests/workflow_module/test_command_factory.py
+++ b/tt-inference-server-v2/tests/workflow_module/test_command_factory.py
@@ -11,6 +11,7 @@ out of scope here.
 
 from __future__ import annotations
 
+import json
 from argparse import Namespace
 from types import SimpleNamespace
 
@@ -244,3 +245,50 @@ class TestResolveAuthToken:
 
         monkeypatch.setattr(cf, "get_runtime_model_spec", boom)
         assert cf._resolve_auth_token(self._args()) == ""
+
+    # --- runtime_model_spec_json precedence (dual-catalog models) -------------
+
+    def _spec_json(self, tmp_path, engine_name):
+        p = tmp_path / "runtime_model_spec.json"
+        p.write_text(
+            json.dumps({"runtime_model_spec": {"inference_engine": engine_name}})
+        )
+        return str(p)
+
+    def test_runtime_spec_json_forge_overrides_catalog_default(
+        self, tmp_path, monkeypatch
+    ):
+        # Dual-catalog model (e.g. Llama-3.1-8B-Instruct): the catalog default
+        # resolves vLLM, but the runtime spec JSON v1 handed us says forge — the
+        # forge server needs the literal key, not a JWT. The JSON serializes the
+        # enum *value* ("forge"), which is what v1 actually writes.
+        monkeypatch.setenv("JWT_SECRET", "secret-of-sufficient-length-123456")
+        for var in ("VLLM_API_KEY", "API_KEY", "OPENAI_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        self._patch_engine(monkeypatch, InferenceEngine.VLLM)  # catalog = wrong
+        args = self._args(runtime_model_spec_json=self._spec_json(tmp_path, "forge"))
+        assert cf._resolve_auth_token(args) == "your-secret-key"
+
+    def test_runtime_spec_json_vllm_mints_jwt_over_catalog(self, tmp_path, monkeypatch):
+        pytest.importorskip("jwt")
+        monkeypatch.setenv("JWT_SECRET", "secret-of-sufficient-length-123456")
+        self._patch_engine(monkeypatch, InferenceEngine.FORGE)  # catalog = wrong
+        args = self._args(runtime_model_spec_json=self._spec_json(tmp_path, "vLLM"))
+        assert cf._resolve_auth_token(args).count(".") == 2  # a JWT
+
+    def test_engine_from_runtime_spec_json(self, tmp_path):
+        # Real serialization is the enum value ("forge"); tolerate the name form.
+        assert (
+            cf._engine_from_runtime_spec_json(self._spec_json(tmp_path, "forge"))
+            == "forge"
+        )
+        assert (
+            cf._engine_from_runtime_spec_json(self._spec_json(tmp_path, "FORGE"))
+            == "forge"
+        )
+        assert (
+            cf._engine_from_runtime_spec_json(self._spec_json(tmp_path, "vLLM"))
+            == "vLLM"
+        )
+        assert cf._engine_from_runtime_spec_json(None) is None
+        assert cf._engine_from_runtime_spec_json("/no/such/file.json") is None

--- a/tt-inference-server-v2/workflow_module/command_factory.py
+++ b/tt-inference-server-v2/workflow_module/command_factory.py
@@ -267,20 +267,42 @@ def _build_spec_decode_options(
     )
 
 
+def _engine_from_runtime_spec_json(path: Optional[str]) -> Optional[str]:
+    """``inference_engine`` (enum value, e.g. ``"forge"``) from the runtime spec JSON."""
+    if not path:
+        return None
+    try:
+        with open(path, encoding="utf-8") as f:
+            engine = (json.load(f).get("runtime_model_spec") or {}).get(
+                "inference_engine"
+            )
+    except (OSError, ValueError):
+        return None
+    # Serialized as the enum value ("forge"/"media"/"vLLM"); tolerate the name form too.
+    if engine in InferenceEngine.__members__:
+        return InferenceEngine[engine].value
+    return engine or None
+
+
 def _resolve_auth_token(args: argparse.Namespace) -> str:
     """Resolve the bearer token the eval/benchmark clients send.
 
-    Forge/media servers (tt-media-server) check a *literal* ``Bearer $API_KEY``
-    (default ``your-secret-key``, see ``security/api_key_checker.py``) and do
-    NOT decode JWTs; only the vLLM/tt-metal server validates a JWT. Mirrors the
-    engine branch in v1 ``evals/run_evals.py`` — a JWT sent to a forge/media
-    server 401s. Falls back to the JWT path when the spec can't be resolved.
+    Forge/media servers check a *literal* ``Bearer $API_KEY`` and never decode
+    JWTs; only vLLM/tt-metal validates a JWT (a JWT to a forge/media server
+    401s). Take the engine from the ``--runtime-model-spec-json`` v1 already
+    resolved (via ``--impl``) -- re-resolving from the catalog picks the default
+    spec, which is wrong for dual-catalog models (e.g. Llama-3.1-8B-Instruct is
+    both FORGE and vLLM). Fall back to the catalog only when no JSON is present.
     """
-    try:
-        spec, _, _ = get_runtime_model_spec(model=args.model, device=args.device)
-        engine = getattr(spec.inference_engine, "value", spec.inference_engine)
-    except Exception:  # pragma: no cover - defensive
-        engine = None
+    engine = _engine_from_runtime_spec_json(
+        getattr(args, "runtime_model_spec_json", None)
+    )
+    if engine is None:
+        try:
+            spec, _, _ = get_runtime_model_spec(model=args.model, device=args.device)
+            engine = getattr(spec.inference_engine, "value", spec.inference_engine)
+        except Exception:  # pragma: no cover - defensive
+            engine = None
     if engine in (InferenceEngine.FORGE.value, InferenceEngine.MEDIA.value):
         return os.getenv("VLLM_API_KEY") or os.getenv("API_KEY") or "your-secret-key"
     return _mint_jwt_if_secret(getattr(args, "jwt_secret", None))


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-inference-server/issues/4517

Sibling of #4467 / PR #4468 (which added the FORGE/MEDIA → literal-key auth branch). That branch is correct; this fixes the engine it branches on being resolved wrongly for dual-catalog models.

### Problem description

`_resolve_auth_token` calls `get_runtime_model_spec(model, device)` with no impl/engine hint. For a model that exists in **both** the FORGE catalog (`dev/cnn.yaml`) and the vLLM catalog (`dev/llm.yaml`) it returns the model's *default* (vLLM) spec, takes the JWT branch, and mints a JWT. The deployed server is **forge-media**, which checks a literal `Bearer $API_KEY` and never decodes JWTs → **HTTP 401 on every eval/benchmark request**.

Confirmed by the dispatched forge runs: only the models that also have a vLLM spec 401 (Qwen3-8B, Llama-3.2-3B-Instruct, Llama-3.1-8B-Instruct); forge-only Qwen3-4B passed.

### What's changed

`_resolve_auth_token` now reads `inference_engine` from the `--runtime-model-spec-json` that v1 already resolved (via `--impl`) and hands to v2, falling back to the catalog lookup only when no JSON is present. The FORGE/MEDIA → literal-key branch from #4468 is unchanged. Net ~13 lines + a small helper. The JSON serializes `inference_engine` as the enum *value* (`"forge"`/`"media"`/`"vLLM"`), so the helper matches on the value (tolerating the name form).

### Tests

`test_command_factory.py::TestResolveAuthToken` — added: runtime-spec-JSON `FORGE` overrides a vLLM catalog default (→ literal key), JSON `VLLM` → JWT, and the helper's name→value / None cases. Existing cases unchanged (no JSON → catalog path).

### Validation

- Problem run (Llama-3.1-8B-Instruct forge release, 401s): https://github.com/tenstorrent/tt-shield/actions/runs/28716967406
- Re-dispatch with fix: https://github.com/tenstorrent/tt-shield/actions/runs/28727774059, the 401s are gone.
