### PR TITLE
Introduce TestStatus enum and close the report / exit-code mismatch

### DIFF
--- a/tt-inference-server-v2/report_module/acceptance_criteria.py
+++ b/tt-inference-server-v2/report_module/acceptance_criteria.py
@@ -168,7 +168,6 @@ def _check_benchmarks(schema: ReportSchema) -> CategoryResult:
     for block in benchmark_blocks:
         block_key = _block_key(block)
 
-        
         explicit = _explicit_status(block)
         if explicit is not None:
             if explicit.is_blocking:
@@ -251,7 +250,6 @@ def _check_evals(schema: ReportSchema) -> CategoryResult:
         block_key = _block_key(block)
         data = block.data if isinstance(block.data, Mapping) else None
 
-       
         explicit = _explicit_status(block)
         if explicit is not None:
             if explicit.is_blocking:

--- a/tt-inference-server-v2/report_module/acceptance_criteria.py
+++ b/tt-inference-server-v2/report_module/acceptance_criteria.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Mapping, Tuple
 
 from .schema import Block, ReportSchema
+from .status import TestStatus
 
 # Three canonical kinds emitted by every runner. Acceptance routes by
 # this field alone — no substring matching, no frozensets, no regex.
@@ -37,11 +38,12 @@ class CategoryResult:
     total: int
     failed: int
     na: int = 0
+    skipped: int = 0
     blockers: Dict[str, str] = field(default_factory=dict)
 
     @property
     def passed(self) -> int:
-        return self.total - self.failed - self.na
+        return self.total - self.failed - self.na - self.skipped
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -51,6 +53,7 @@ class CategoryResult:
             "passed": self.passed,
             "failed": self.failed,
             "na": self.na,
+            "skipped": self.skipped,
             "blockers": dict(self.blockers),
         }
 
@@ -146,6 +149,8 @@ def _detail(category: CategoryResult) -> str:
     parts = [f"{category.passed}/{category.total} passed"]
     if category.failed:
         parts.append(f"{category.failed} failed")
+    if category.skipped:
+        parts.append(f"{category.skipped} skipped")
     if category.na:
         parts.append(f"{category.na} NA")
     return ", ".join(parts)
@@ -158,8 +163,25 @@ def _check_benchmarks(schema: ReportSchema) -> CategoryResult:
 
     blockers: Dict[str, str] = {}
     failed = 0
+    skipped = 0
+    na = 0
     for block in benchmark_blocks:
         block_key = _block_key(block)
+
+        
+        explicit = _explicit_status(block)
+        if explicit is not None:
+            if explicit.is_blocking:
+                blockers[block_key] = (
+                    f"{block.title or block.kind} reported status={explicit.value}"
+                )
+                failed += 1
+            elif explicit is TestStatus.SKIP:
+                skipped += 1
+            elif explicit is TestStatus.NA:
+                na += 1
+            continue
+
         block_blockers: Dict[str, str] = {}
         target_checks = _resolve_nested(block.data, "target_checks")
         if not isinstance(target_checks, Mapping):
@@ -198,12 +220,20 @@ def _check_benchmarks(schema: ReportSchema) -> CategoryResult:
             failed += 1
             blockers.update(block_blockers)
 
-    status = STATUS_FAIL if failed else STATUS_PASS
+    non_pass = failed + skipped + na
+    if failed:
+        status = STATUS_FAIL
+    elif non_pass == len(benchmark_blocks) and (skipped or na):
+        status = STATUS_NA
+    else:
+        status = STATUS_PASS
     return CategoryResult(
         CATEGORY_BENCHMARKS,
         status,
         len(benchmark_blocks),
         failed,
+        na=na,
+        skipped=skipped,
         blockers=blockers,
     )
 
@@ -216,9 +246,25 @@ def _check_evals(schema: ReportSchema) -> CategoryResult:
     blockers: Dict[str, str] = {}
     failed = 0
     na = 0
+    skipped = 0
     for block in eval_blocks:
         block_key = _block_key(block)
         data = block.data if isinstance(block.data, Mapping) else None
+
+       
+        explicit = _explicit_status(block)
+        if explicit is not None:
+            if explicit.is_blocking:
+                blockers[block_key] = (
+                    f"{block.title or block.kind} reported status={explicit.value} "
+                    f"(attempts={data.get('attempts', '?')})"
+                )
+                failed += 1
+            elif explicit is TestStatus.SKIP:
+                skipped += 1
+            elif explicit is TestStatus.NA:
+                na += 1
+            continue
 
         # success=False is decisive — a test that self-reported failure
         # is a blocker regardless of any accuracy_check value alongside it.
@@ -243,9 +289,10 @@ def _check_evals(schema: ReportSchema) -> CategoryResult:
         elif state == STATUS_NA:
             na += 1
 
+    non_pass = failed + na + skipped
     if failed:
         status = STATUS_FAIL
-    elif na == len(eval_blocks):
+    elif na == len(eval_blocks) or (skipped and non_pass == len(eval_blocks)):
         status = STATUS_NA
     else:
         status = STATUS_PASS
@@ -255,6 +302,7 @@ def _check_evals(schema: ReportSchema) -> CategoryResult:
         len(eval_blocks),
         failed,
         na=na,
+        skipped=skipped,
         blockers=blockers,
     )
 
@@ -272,14 +320,20 @@ def _check_spec_tests(schema: ReportSchema) -> CategoryResult:
 
     blockers: Dict[str, str] = {}
     failed = 0
+    skipped = 0
+    na = 0
     for block in spec_blocks:
-        success = block.data.get("success")
-        if success is False:
+        test_status = _block_test_status(block)
+        if test_status.is_blocking:
             blockers[f"spec.{_block_key(block)}"] = (
-                f"{block.title or block.kind} reported success=False "
+                f"{block.title or block.kind} reported status={test_status.value} "
                 f"(attempts={block.data.get('attempts', '?')})"
             )
             failed += 1
+        elif test_status is TestStatus.SKIP:
+            skipped += 1
+        elif test_status is TestStatus.NA:
+            na += 1
 
     status = STATUS_FAIL if failed else STATUS_PASS
     return CategoryResult(
@@ -287,6 +341,8 @@ def _check_spec_tests(schema: ReportSchema) -> CategoryResult:
         status,
         len(spec_blocks),
         failed,
+        na=na,
+        skipped=skipped,
         blockers=blockers,
     )
 
@@ -326,6 +382,28 @@ def _block_key(block: Block) -> str:
     if block.title:
         return f"{block.kind}:{block.title}"
     return block.kind
+
+
+def _block_test_status(block: Block) -> TestStatus:
+    """Resolve a block's :class:`TestStatus`, falling back to legacy fields."""
+    data = block.data if isinstance(block.data, Mapping) else {}
+    resolved = TestStatus.from_value(data.get("status"))
+    if resolved is not None:
+        return resolved
+    return TestStatus.from_legacy(
+        data.get("success"), skipped=bool(data.get("skipped"))
+    )
+
+
+def _explicit_status(block: Block):
+    """Return the block's explicit :class:`TestStatus`, or None if unset.
+
+    Unlike :func:`_block_test_status`, this does *not* infer a status from
+    legacy fields — evals/benchmarks without a ``status`` keep their existing
+    accuracy_check / target_checks grading.
+    """
+    data = block.data if isinstance(block.data, Mapping) else {}
+    return TestStatus.from_value(data.get("status"))
 
 
 def _level_passes(level_checks: Mapping[str, Any]) -> bool:

--- a/tt-inference-server-v2/report_module/display.py
+++ b/tt-inference-server-v2/report_module/display.py
@@ -102,6 +102,8 @@ DISPLAY_NAMES: Dict[str, str] = {
     "published_score_ref": "Published Score Ref",
     "score": "Score",
     "accuracy_check": "Accuracy Check",
+    # Benchmarks report a performance-target verdict, not an accuracy check.
+    "target_check": "Target Check",
     # Liveness / infra
     "status": "Status",
     "expected_devices": "Expected Devices",

--- a/tt-inference-server-v2/report_module/generator.py
+++ b/tt-inference-server-v2/report_module/generator.py
@@ -40,6 +40,11 @@ _METADATA_RENDERING_KEYS = frozenset(ACCEPTANCE_EXPORT_KEYS)
 _EVALS_KIND = "evals"
 _CONSOLIDATED_EVALS_TITLE = "Accuracy Evaluations"
 
+# Divider placed between the preamble and each top-level result section so
+# adjacent sections (e.g. a benchmark table and the "📋 Summary" block) are
+# visually separated in both raw CI logs and rendered markdown.
+_SECTION_SEPARATOR = "\n\n---\n\n"
+
 
 @dataclass(frozen=True)
 class GenerateResult:
@@ -146,7 +151,7 @@ def _assemble_release_markdown(
     }
     metadata_json = json.dumps(visible_metadata, indent=4, default=str)
     metadata_block = (
-        f"### Metadata: {schema.model_name} on {schema.device}\n"
+        f"### Metadata: {schema.model_name} on {schema.device}\n\n"
         f"```json\n{metadata_json}\n```"
     )
     preamble = [header, metadata_block]
@@ -157,7 +162,8 @@ def _assemble_release_markdown(
         preamble.append(acceptance_md)
 
     sections = _inject_spec_test_summary(rendered_pairs, schema.metadata)
-    return "\n\n".join(preamble + sections)
+    preamble_md = "\n\n".join(preamble)
+    return _SECTION_SEPARATOR.join([preamble_md] + sections)
 
 
 def _inject_spec_test_summary(
@@ -277,7 +283,7 @@ def _build_spec_test_summary_markdown(
     ]
     results_table = "\n".join([result_header] + result_rows)
 
-    return f"## 📋 Summary\n{summary_table}\n\n## 🧪 Test Results\n{results_table}"
+    return f"## 📋 Summary\n\n{summary_table}\n\n## 🧪 Test Results\n\n{results_table}"
 
 
 def _coerce_float(value: Any) -> float:

--- a/tt-inference-server-v2/report_module/generator.py
+++ b/tt-inference-server-v2/report_module/generator.py
@@ -206,9 +206,7 @@ def _run_status(run: Mapping[str, Any]) -> TestStatus:
     resolved = TestStatus.from_value(run.get("status"))
     if resolved is not None:
         return resolved
-    return TestStatus.from_legacy(
-        run.get("success"), skipped=bool(run.get("skipped"))
-    )
+    return TestStatus.from_legacy(run.get("success"), skipped=bool(run.get("skipped")))
 
 
 def _run_description(run: Mapping[str, Any], status: TestStatus) -> str:

--- a/tt-inference-server-v2/report_module/generator.py
+++ b/tt-inference-server-v2/report_module/generator.py
@@ -22,6 +22,15 @@ from report_module import renderers
 from report_module.acceptance_criteria import ACCEPTANCE_EXPORT_KEYS
 from report_module.report_file_saver import ReportFileSaver
 from report_module.schema import Block, ReportSchema, SchemaLike
+from report_module.status import TestStatus
+
+_STATUS_GLYPHS = {
+    TestStatus.PASS: "✅",
+    TestStatus.FAIL: "❌",
+    TestStatus.ERROR: "❌",
+    TestStatus.SKIP: "⏭️",
+    TestStatus.NA: "🟨",
+}
 
 logger = logging.getLogger(__name__)
 
@@ -192,6 +201,31 @@ def _spec_test_runs(block: Block) -> List[Mapping[str, Any]]:
     return []
 
 
+def _run_status(run: Mapping[str, Any]) -> TestStatus:
+    """Resolve a run's :class:`TestStatus`, falling back to legacy fields."""
+    resolved = TestStatus.from_value(run.get("status"))
+    if resolved is not None:
+        return resolved
+    return TestStatus.from_legacy(
+        run.get("success"), skipped=bool(run.get("skipped"))
+    )
+
+
+def _run_description(run: Mapping[str, Any], status: TestStatus) -> str:
+    """Description column: append the reason/error for non-pass outcomes."""
+    description = str(run.get("description") or "")
+    if status is TestStatus.SKIP or status is TestStatus.NA:
+        reason = str(run.get("reason") or "")
+        if reason:
+            return f"{description} — {status.value.upper()}: {reason}".lstrip(" —")
+    if status is TestStatus.ERROR:
+        error = run.get("error")
+        message = error.get("message") if isinstance(error, Mapping) else None
+        if message:
+            return f"{description} — ERROR: {message}".lstrip(" —")
+    return description
+
+
 def _build_spec_test_summary_markdown(
     runs: Sequence[Mapping[str, Any]], generated_at: str
 ) -> str:
@@ -200,19 +234,24 @@ def _build_spec_test_summary_markdown(
         return ""
 
     total = len(runs)
-    passed = sum(1 for r in runs if r.get("success") is True)
-    failed = sum(1 for r in runs if r.get("success") is False)
-    skipped = 0
+    statuses = [_run_status(run) for run in runs]
+    passed = sum(1 for s in statuses if s is TestStatus.PASS)
+    failed = sum(1 for s in statuses if s.is_blocking)
+    skipped = sum(1 for s in statuses if s is TestStatus.SKIP)
+    na = sum(1 for s in statuses if s is TestStatus.NA)
     attempted = passed + failed
     total_duration = sum(_coerce_float(r.get("elapsed_seconds")) for r in runs)
     total_attempts = sum(_coerce_int(r.get("attempts")) for r in runs)
-    success_rate = (passed / total * 100.0) if total else 0.0
+    # Success rate excludes non-blocking skips/NA — they weren't graded.
+    gradable = passed + failed
+    success_rate = (passed / gradable * 100.0) if gradable else 0.0
 
     summary_rows = [
         ("Total Tests", str(total)),
         ("Passed", str(passed)),
         ("Failed", str(failed)),
         ("Skipped", str(skipped)),
+        ("NA", str(na)),
         ("Attempted", str(attempted)),
         ("Success Rate", f"{success_rate:.1f}%"),
         ("Total Duration", f"{total_duration:.2f}s"),
@@ -230,13 +269,13 @@ def _build_spec_test_summary_markdown(
     )
     result_rows = [
         "| {status} | {name} | {duration:.2f}s | {attempts} | {description} |".format(
-            status="✅" if run.get("success") is True else "❌",
+            status=_STATUS_GLYPHS.get(status, "❌"),
             name=str(run.get("test_name") or ""),
             duration=_coerce_float(run.get("elapsed_seconds")),
             attempts=_coerce_int(run.get("attempts")),
-            description=str(run.get("description") or ""),
+            description=_run_description(run, status),
         )
-        for run in runs
+        for run, status in zip(runs, statuses)
     ]
     results_table = "\n".join([result_header] + result_rows)
 

--- a/tt-inference-server-v2/report_module/renderers.py
+++ b/tt-inference-server-v2/report_module/renderers.py
@@ -37,12 +37,13 @@ HIDDEN_COLUMNS = frozenset(
 )
 
 GENERIC_KINDS: tuple[str, ...] = (
-    "benchmarks",
     "spec_tests",
     "stress_tests",
 )
 
 EVALS_KIND = "evals"
+
+BENCHMARKS_KIND = "benchmarks"
 
 EVALS_METHODOLOGY_NOTE = (
     "Note: The ratio to published scores defines if eval ran roughly correctly, "
@@ -51,6 +52,13 @@ EVALS_METHODOLOGY_NOTE = (
     "GPU reference within a +/- tolerance. If a value GPU reference is not "
     "available, the accuracy check is based on the direct ratio to the published "
     "score."
+)
+
+BENCHMARK_TIER_NOTE = (
+    "Note: The Target Check column reflects only the strictest `target` tier. "
+    "The Target Checks table grades three tiers — functional, complete, and "
+    "target — from most to least lenient. Acceptance criteria pass a benchmark "
+    "when any single tier meets all of its checks."
 )
 
 _REGISTRY: Dict[str, RendererFn] = {}
@@ -318,6 +326,36 @@ def render_evals(block: Block, metadata: Mapping[str, Any]) -> str:
     if not table:
         return ""
     return f"{heading}\n\n{table}\n\n{EVALS_METHODOLOGY_NOTE}"
+
+
+def _has_target_checks(block: Block) -> bool:
+    """Whether the block carries a tiered ``target_checks`` mapping.
+
+    Handles both shapes: top-level (audio sweep, run summaries) and nested
+    one level under a section dict (image/video/cnn/etc. "Benchmarks").
+    """
+    data = block.data
+    if not isinstance(data, Mapping):
+        return False
+    if isinstance(data.get(_TARGET_CHECKS_KEY), Mapping):
+        return True
+    return any(
+        isinstance(value, Mapping)
+        and isinstance(value.get(_TARGET_CHECKS_KEY), Mapping)
+        for value in data.values()
+    )
+
+
+@register(BENCHMARKS_KIND)
+def render_benchmarks(block: Block, metadata: Mapping[str, Any]) -> str:
+    """Render a benchmark block, appending the tier note when tiered
+    ``target_checks`` are present (LLM benchmarks without tiers get none)."""
+    table = render_generic_table(block, metadata)
+    if not table:
+        return ""
+    if _has_target_checks(block):
+        return f"{table}\n\n{BENCHMARK_TIER_NOTE}"
+    return table
 
 
 for _kind in GENERIC_KINDS:

--- a/tt-inference-server-v2/report_module/status.py
+++ b/tt-inference-server-v2/report_module/status.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Canonical test-outcome vocabulary shared by the test and report modules."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+
+class TestStatus(str, Enum):
+    """Outcome of a single test run.
+
+    Distinguishes the ways a test can "not pass" so the report and the process
+    exit code tell the same story:
+
+    - ``PASS``  ran and met its criteria.
+    - ``FAIL``  ran and did not meet its criteria           -> blocking.
+    - ``ERROR`` raised unexpectedly (crash / setup failure) -> blocking.
+    - ``SKIP``  intentionally not run (needs a ``reason``)  -> non-blocking.
+    - ``NA``    ran but produced no gradable result         -> non-blocking.
+    """
+
+    PASS = "pass"
+    FAIL = "fail"
+    ERROR = "error"
+    SKIP = "skip"
+    NA = "na"
+
+    @property
+    def is_blocking(self) -> bool:
+        """Whether this status should fail the workflow / count as a blocker."""
+        return self in _BLOCKING_STATUSES
+
+    @classmethod
+    def from_value(cls, value: object) -> Optional["TestStatus"]:
+        """Coerce a raw ``block.data['status']`` value to a member, or None.
+
+        Accepts an existing member or its string value (case-insensitively);
+        anything unrecognised returns ``None`` so callers can fall back to the
+        legacy boolean ``success`` field.
+        """
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, str):
+            try:
+                return cls(value.strip().lower())
+            except ValueError:
+                return None
+        return None
+
+    @classmethod
+    def from_legacy(cls, success: object, skipped: bool = False) -> "TestStatus":
+        """Derive a status from the pre-enum ``success``/``skipped`` fields.
+
+        Used for blocks produced before they carried an explicit ``status``.
+        """
+        if skipped:
+            return cls.SKIP
+        return cls.PASS if success is True else cls.FAIL
+
+
+_BLOCKING_STATUSES = frozenset({TestStatus.FAIL, TestStatus.ERROR})
+
+
+__all__ = ["TestStatus"]

--- a/tt-inference-server-v2/test_module/_test_common/__init__.py
+++ b/tt-inference-server-v2/test_module/_test_common/__init__.py
@@ -5,7 +5,8 @@
 from .base_test import BaseTest
 from .blockify import block_id, sweep_envelope
 from .hardware_requirements import HardwareRequirement
-from .report_types import ReportCheckTypes
+from .exceptions import NotApplicable, SkipTest
+from .report_types import ReportCheckTypes, TestStatus
 from .target_check import MetricSpec, PerformanceTargets, run_tiered_check
 from .test_classes import TestCase, TestConfig, TestReport, TestTarget
 
@@ -13,11 +14,14 @@ __all__ = [
     "BaseTest",
     "HardwareRequirement",
     "MetricSpec",
+    "NotApplicable",
     "PerformanceTargets",
     "ReportCheckTypes",
+    "SkipTest",
     "TestCase",
     "TestConfig",
     "TestReport",
+    "TestStatus",
     "TestTarget",
     "block_id",
     "run_tiered_check",

--- a/tt-inference-server-v2/test_module/_test_common/base_test.py
+++ b/tt-inference-server-v2/test_module/_test_common/base_test.py
@@ -158,9 +158,7 @@ class BaseTest(ABC):
         structured ``signal.data`` diagnostics are merged underneath them.
         """
         status = TestStatus.SKIP if isinstance(signal, SkipTest) else TestStatus.NA
-        logger.info(
-            "⏭  %s -> %s: %s", type(self).__name__, status.value, signal.reason
-        )
+        logger.info("⏭  %s -> %s: %s", type(self).__name__, status.value, signal.reason)
         data: Dict[str, Any] = {
             "success": False,
             "status": status.value,

--- a/tt-inference-server-v2/test_module/_test_common/base_test.py
+++ b/tt-inference-server-v2/test_module/_test_common/base_test.py
@@ -19,7 +19,9 @@ from report_module.schema import Block
 from utils.url_helpers import DEFAULT_DEPLOY_URL, build_base_url
 
 from .blockify import block_id
+from .exceptions import NotApplicable, SkipTest, TestOutcomeSignal
 from .hardware_requirements import HardwareRequirement
+from .report_types import TestStatus
 from .test_classes import TestConfig
 
 if TYPE_CHECKING:
@@ -208,6 +210,7 @@ class BaseTest(ABC):
         logger.warning("⏭  Skipping %s — %s", type(self).__name__, reason)
         return {
             "success": False,
+            "status": TestStatus.SKIP.value,
             "skipped": True,
             "reason": reason,
             "hardware_requirement": self.HARDWARE_REQUIREMENT.value,
@@ -251,6 +254,7 @@ class BaseTest(ABC):
 
         skip_data = self._assert_hardware_ready()
         if skip_data is not None:
+            skip_data.setdefault("status", TestStatus.SKIP.value)
             skip_data.setdefault("attempts", 0)
             skip_data.setdefault("logs", list(self.logs))
             skip_data.setdefault("elapsed_seconds", time.monotonic() - run_started)
@@ -289,6 +293,12 @@ class BaseTest(ABC):
                     data: Dict[str, Any] = {**result}
                 else:
                     data = {"result": result}
+                # A test may self-declare NA/SKIP in its result dict; otherwise
+                # derive the status from the boolean success it reported.
+                status = TestStatus.from_value(data.get("status")) or (
+                    TestStatus.PASS if success else TestStatus.FAIL
+                )
+                data["status"] = status.value
                 data["success"] = success
                 data["attempts"] = attempts_used
                 data["logs"] = list(self.logs)
@@ -315,6 +325,33 @@ class BaseTest(ABC):
                         "type": "TimeoutError",
                         "message": error_msg,
                         "exception": str(e),
+                    }
+                )
+
+            except TestOutcomeSignal as e:
+                # Intentional non-error outcome: do not retry, do not fail.
+                status = (
+                    TestStatus.SKIP
+                    if isinstance(e, SkipTest)
+                    else TestStatus.NA
+                )
+                logger.info(
+                    "⏭  %s -> %s: %s",
+                    type(self).__name__,
+                    status.value,
+                    e.reason,
+                )
+                return self._block(
+                    {
+                        "success": False,
+                        "status": status.value,
+                        "skipped": isinstance(e, SkipTest),
+                        "reason": e.reason,
+                        "attempts": attempts_used,
+                        "logs": list(self.logs),
+                        "elapsed_seconds": time.monotonic() - run_started,
+                        "test_name": type(self).__name__,
+                        "description": self.description,
                     }
                 )
 
@@ -383,9 +420,12 @@ class BaseTest(ABC):
                 "message": "Tests failed after all retry attempts",
             }
         )
+        # Reaching here means every attempt raised or timed out — the test
+        # never ran to a clean verdict, so this is an ERROR, not a FAIL.
         failure_block = self._block(
             {
                 "success": False,
+                "status": TestStatus.ERROR.value,
                 "attempts": attempts_used,
                 "logs": list(self.logs),
                 "elapsed_seconds": time.monotonic() - run_started,

--- a/tt-inference-server-v2/test_module/_test_common/base_test.py
+++ b/tt-inference-server-v2/test_module/_test_common/base_test.py
@@ -145,12 +145,43 @@ class BaseTest(ABC):
             data=data,
         )
 
-    def _assert_hardware_ready(self) -> Optional[Dict[str, Any]]:
+    def _outcome_block(
+        self,
+        signal: TestOutcomeSignal,
+        attempts: int,
+        run_started: float,
+    ) -> Block:
+        """Build a Block for an intentional non-error outcome (SKIP / NA).
+
+        Shared by the retry loop (a test raised ``SkipTest``/``NotApplicable``)
+        and the pre-loop hardware gate. Envelope keys are authoritative; any
+        structured ``signal.data`` diagnostics are merged underneath them.
+        """
+        status = TestStatus.SKIP if isinstance(signal, SkipTest) else TestStatus.NA
+        logger.info(
+            "⏭  %s -> %s: %s", type(self).__name__, status.value, signal.reason
+        )
+        data: Dict[str, Any] = {
+            "success": False,
+            "status": status.value,
+            "skipped": isinstance(signal, SkipTest),
+            "reason": signal.reason,
+            "attempts": attempts,
+            "logs": list(self.logs),
+            "elapsed_seconds": time.monotonic() - run_started,
+            "test_name": type(self).__name__,
+            "description": self.description,
+        }
+        for key, value in signal.data.items():
+            data.setdefault(key, value)
+        return self._block(data)
+
+    def _assert_hardware_ready(self) -> None:
         """Hardware-readiness gate consulted by :meth:`run_tests`.
 
         Returns ``None`` if the board has enough ready chips for this test's
-        :attr:`HARDWARE_REQUIREMENT`, else a "skipped" dict that
-        :meth:`run_tests` wraps into a Block.
+        :attr:`HARDWARE_REQUIREMENT`, else raises :class:`SkipTest` so the test
+        is reported as SKIP (never run) rather than a failure.
 
         The check is intentionally non-fatal on "we can't tell" failure modes
         (server unreachable, non-200 response, non-JSON body): those return
@@ -207,17 +238,15 @@ class BaseTest(ABC):
             f"{type(self).__name__} requires {required} ready chip(s) "
             f"({self.HARDWARE_REQUIREMENT.value}); found {ready}/{total} ready."
         )
-        logger.warning("⏭  Skipping %s — %s", type(self).__name__, reason)
-        return {
-            "success": False,
-            "status": TestStatus.SKIP.value,
-            "skipped": True,
-            "reason": reason,
-            "hardware_requirement": self.HARDWARE_REQUIREMENT.value,
-            "ready_count": ready,
-            "total_workers": total,
-            "required_count": required,
-        }
+        raise SkipTest(
+            reason,
+            data={
+                "hardware_requirement": self.HARDWARE_REQUIREMENT.value,
+                "ready_count": ready,
+                "total_workers": total,
+                "required_count": required,
+            },
+        )
 
     def run_tests(self) -> Block:
         """Run the test with retry/log accounting and return a Block.
@@ -252,15 +281,10 @@ class BaseTest(ABC):
         attempts_used = 0
         run_started = time.monotonic()
 
-        skip_data = self._assert_hardware_ready()
-        if skip_data is not None:
-            skip_data.setdefault("status", TestStatus.SKIP.value)
-            skip_data.setdefault("attempts", 0)
-            skip_data.setdefault("logs", list(self.logs))
-            skip_data.setdefault("elapsed_seconds", time.monotonic() - run_started)
-            skip_data.setdefault("test_name", type(self).__name__)
-            skip_data.setdefault("description", self.description)
-            return self._block(skip_data)
+        try:
+            self._assert_hardware_ready()
+        except TestOutcomeSignal as e:
+            return self._outcome_block(e, attempts=0, run_started=run_started)
 
         for attempt in range(self.retry_attempts + 1):
             attempts_used = attempt + 1
@@ -330,30 +354,7 @@ class BaseTest(ABC):
 
             except TestOutcomeSignal as e:
                 # Intentional non-error outcome: do not retry, do not fail.
-                status = (
-                    TestStatus.SKIP
-                    if isinstance(e, SkipTest)
-                    else TestStatus.NA
-                )
-                logger.info(
-                    "⏭  %s -> %s: %s",
-                    type(self).__name__,
-                    status.value,
-                    e.reason,
-                )
-                return self._block(
-                    {
-                        "success": False,
-                        "status": status.value,
-                        "skipped": isinstance(e, SkipTest),
-                        "reason": e.reason,
-                        "attempts": attempts_used,
-                        "logs": list(self.logs),
-                        "elapsed_seconds": time.monotonic() - run_started,
-                        "test_name": type(self).__name__,
-                        "description": self.description,
-                    }
-                )
+                return self._outcome_block(e, attempts_used, run_started)
 
             except SystemExit as e:
                 last_exception = e

--- a/tt-inference-server-v2/test_module/_test_common/base_test.py
+++ b/tt-inference-server-v2/test_module/_test_common/base_test.py
@@ -19,7 +19,7 @@ from report_module.schema import Block
 from utils.url_helpers import DEFAULT_DEPLOY_URL, build_base_url
 
 from .blockify import block_id
-from .exceptions import NotApplicable, SkipTest, TestOutcomeSignal
+from .exceptions import SkipTest, TestOutcomeSignal
 from .hardware_requirements import HardwareRequirement
 from .report_types import TestStatus
 from .test_classes import TestConfig

--- a/tt-inference-server-v2/test_module/_test_common/exceptions.py
+++ b/tt-inference-server-v2/test_module/_test_common/exceptions.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Control-flow exceptions a test can raise to declare a non-error outcome.
+
+These let a test opt out of the default "any exception is an ERROR" handling
+in :meth:`BaseTest.run_tests`. Both require a human-readable ``reason`` so the
+report can explain *why* the test did not produce a graded result.
+"""
+
+from __future__ import annotations
+
+
+class TestOutcomeSignal(Exception):
+    """Base class for exceptions that map to a non-error :class:`TestStatus`."""
+
+    def __init__(self, reason: str):
+        if not reason or not reason.strip():
+            raise ValueError(f"{type(self).__name__} requires a non-empty reason")
+        super().__init__(reason)
+        self.reason = reason
+
+
+class SkipTest(TestOutcomeSignal):
+    """Raise to mark a run as ``SKIP`` (intentionally not run, non-blocking)."""
+
+
+class NotApplicable(TestOutcomeSignal):
+    """Raise to mark a run as ``NA`` (ran but not gradable, non-blocking)."""
+
+
+__all__ = ["NotApplicable", "SkipTest", "TestOutcomeSignal"]

--- a/tt-inference-server-v2/test_module/_test_common/exceptions.py
+++ b/tt-inference-server-v2/test_module/_test_common/exceptions.py
@@ -6,20 +6,25 @@
 
 These let a test opt out of the default "any exception is an ERROR" handling
 in :meth:`BaseTest.run_tests`. Both require a human-readable ``reason`` so the
-report can explain *why* the test did not produce a graded result.
+report can explain *why* the test did not produce a graded result. An optional
+``data`` mapping carries structured diagnostics (e.g. chip counts) that get
+merged into the emitted Block without overriding its envelope keys.
 """
 
 from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional
 
 
 class TestOutcomeSignal(Exception):
     """Base class for exceptions that map to a non-error :class:`TestStatus`."""
 
-    def __init__(self, reason: str):
+    def __init__(self, reason: str, data: Optional[Mapping[str, Any]] = None):
         if not reason or not reason.strip():
             raise ValueError(f"{type(self).__name__} requires a non-empty reason")
         super().__init__(reason)
         self.reason = reason
+        self.data: Dict[str, Any] = dict(data or {})
 
 
 class SkipTest(TestOutcomeSignal):

--- a/tt-inference-server-v2/test_module/_test_common/report_types.py
+++ b/tt-inference-server-v2/test_module/_test_common/report_types.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from enum import IntEnum, auto
 
+from report_module.status import TestStatus
+
 
 class ReportCheckTypes(IntEnum):
     NA = auto()
@@ -31,4 +33,4 @@ class ReportCheckTypes(IntEnum):
         return disp_map[check_type]
 
 
-__all__ = ["ReportCheckTypes"]
+__all__ = ["ReportCheckTypes", "TestStatus"]

--- a/tt-inference-server-v2/test_module/_test_common/target_check.py
+++ b/tt-inference-server-v2/test_module/_test_common/target_check.py
@@ -243,7 +243,7 @@ def run_tiered_check(
     target_checks = evaluate_tiered(targets, specs)
     _log_tiered(target_checks)
     summary = summary_from_tiered(target_checks)
-    logger.info(f"Overall accuracy_check (target tier): {summary.name}")
+    logger.info(f"Overall target_check (target tier): {summary.name}")
     return target_checks, summary
 
 

--- a/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
@@ -346,7 +346,7 @@ def _run_whisper_benchmark_sweep(ctx: MediaContext, num_calls: int) -> Block:
             f"Whisper sweep must include {GATE_LABEL!r} (got {list(metrics_by_label)})"
         )
     ttft_value, tsu_value, rtr_value = metrics_by_label[GATE_LABEL]
-    target_checks, _accuracy_check = _audio_target_checks(
+    target_checks, _target_check = _audio_target_checks(
         ctx, ttft_value, tsu_value, rtr_value
     )
 
@@ -388,7 +388,7 @@ def run_audio_benchmark(ctx: MediaContext) -> Block:
     ttft_value = _audio_avg(status_list, "ttft")
     rtr_value = _audio_avg(status_list, "rtr")
     tsu_value = _audio_avg(status_list, "tsu")
-    target_checks, accuracy_check = _audio_target_checks(
+    target_checks, target_check = _audio_target_checks(
         ctx, ttft_value, tsu_value, rtr_value
     )
 
@@ -412,7 +412,7 @@ def run_audio_benchmark(ctx: MediaContext) -> Block:
                 "rtr": rtr_value,
                 "streaming_enabled": is_streaming_enabled_for_whisper(ctx),
                 "preprocessing_enabled": is_preprocessing_enabled_for_whisper(ctx),
-                "accuracy_check": accuracy_check,
+                "target_check": target_check,
                 "target_checks": target_checks,
             },
         },

--- a/tt-inference-server-v2/test_module/benchmark_tests/cnn_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/cnn_benchmark_tests.py
@@ -211,7 +211,7 @@ def run_cnn_benchmark(ctx: MediaContext) -> Block:
         else 0
     )
     # Sequential single-user benchmark, so tput_user = total throughput.
-    target_checks, accuracy_check = _cnn_target_checks(
+    target_checks, target_check = _cnn_target_checks(
         ctx, ttft_value, inference_steps_per_second
     )
     return Block(
@@ -234,7 +234,7 @@ def run_cnn_benchmark(ctx: MediaContext) -> Block:
                 "ttft": ttft_value,
                 "inference_steps_per_second": inference_steps_per_second,
                 "tput_user": inference_steps_per_second,
-                "accuracy_check": accuracy_check,
+                "target_check": target_check,
                 "target_checks": target_checks,
             },
         },

--- a/tt-inference-server-v2/test_module/benchmark_tests/embedding_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/embedding_benchmark_tests.py
@@ -165,7 +165,7 @@ def run_embedding_benchmark(ctx: MediaContext) -> Block:
         total_input_tokens / benchmark_duration if benchmark_duration else 0.0
     )
     tput_user = tput_prefill / float(concurrency) if concurrency else 0.0
-    target_checks, accuracy_check = _embedding_target_checks(
+    target_checks, target_check = _embedding_target_checks(
         ctx, tput_user, tput_prefill, mean_e2el
     )
 
@@ -188,7 +188,7 @@ def run_embedding_benchmark(ctx: MediaContext) -> Block:
                 "tput_prefill": tput_prefill,
                 "e2el": mean_e2el,
                 "req_tput": req_tput,
-                "accuracy_check": accuracy_check,
+                "target_check": target_check,
                 "target_checks": target_checks,
             },
         },

--- a/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
@@ -499,7 +499,7 @@ def run_image_benchmark(ctx: MediaContext) -> Block:
     total_elapsed = sum(s.elapsed for s in status_list)
     # tput_user is per-user image throughput (images/sec = 1 / avg latency).
     tput_user = len(status_list) / total_elapsed if total_elapsed > 0 else 0
-    target_checks, accuracy_check = _image_target_checks(ctx, ttft_value, tput_user)
+    target_checks, target_check = _image_target_checks(ctx, ttft_value, tput_user)
     num_inference_steps_used = status_list[0].num_inference_steps if status_list else 0
     benchmarks_data = {
         "num_requests": len(status_list),
@@ -512,7 +512,7 @@ def run_image_benchmark(ctx: MediaContext) -> Block:
             "ttft_ms": ttft_value * 1000,
             "inference_steps_per_second": inference_steps_per_second,
             "tput_user": tput_user,
-            "accuracy_check": accuracy_check,
+            "target_check": target_check,
             "target_checks": target_checks,
         }
     )

--- a/tt-inference-server-v2/test_module/benchmark_tests/tts_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/tts_benchmark_tests.py
@@ -233,7 +233,7 @@ def run_tts_benchmark(ctx: MediaContext) -> Block:
     ttft_value = _tts_avg(status_list, "ttft_ms")
     rtr_value = _tts_avg(status_list, "rtr")
     p90_ttft, p95_ttft = _tts_tail_latency(status_list)
-    target_checks, accuracy_check = _tts_target_checks(ctx, ttft_value, rtr_value)
+    target_checks, target_check = _tts_target_checks(ctx, ttft_value, rtr_value)
 
     return Block(
         kind="benchmarks",
@@ -248,7 +248,7 @@ def run_tts_benchmark(ctx: MediaContext) -> Block:
                 "rtr": rtr_value,
                 "ttft_p90": p90_ttft / 1000,
                 "ttft_p95": p95_ttft / 1000,
-                "accuracy_check": accuracy_check,
+                "target_check": target_check,
                 "target_checks": target_checks,
             },
         },

--- a/tt-inference-server-v2/test_module/benchmark_tests/video_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/video_benchmark_tests.py
@@ -23,6 +23,7 @@ from report_module.schema import Block
 from .._test_common import (
     MetricSpec,
     ReportCheckTypes,
+    SkipTest,
     block_id,
     run_tiered_check,
 )
@@ -224,6 +225,12 @@ def run_video_benchmark(ctx: MediaContext) -> Block:
     logger.info(
         f"Running benchmarks for model: {ctx.model_spec.model_name} on device: {ctx.device.name}"
     )
+    model_name = ctx.model_spec.model_name
+    if model_name not in VIDEO_INFERENCE_STEPS:
+        raise SkipTest(
+            f"video benchmark not implemented for model {model_name!r}; "
+            f"supported: {sorted(VIDEO_INFERENCE_STEPS)}"
+        )
     require_health(ctx)
 
     try:

--- a/tt-inference-server-v2/test_module/benchmark_tests/video_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/video_benchmark_tests.py
@@ -248,7 +248,7 @@ def run_video_benchmark(ctx: MediaContext) -> Block:
         else 0
     )
     # Sequential single-user benchmark, so tput_user = total throughput.
-    target_checks, accuracy_check = _video_target_checks(
+    target_checks, target_check = _video_target_checks(
         ctx, ttft_value, inference_steps_per_second
     )
     return Block(
@@ -271,7 +271,7 @@ def run_video_benchmark(ctx: MediaContext) -> Block:
                 "ttft": ttft_value,
                 "inference_steps_per_second": inference_steps_per_second,
                 "tput_user": inference_steps_per_second,
-                "accuracy_check": accuracy_check,
+                "target_check": target_check,
                 "target_checks": target_checks,
             },
         },

--- a/tt-inference-server-v2/test_module/dispatch.py
+++ b/tt-inference-server-v2/test_module/dispatch.py
@@ -26,7 +26,14 @@ from typing import Callable, List, Optional, Tuple
 from report_module.schema import Block
 from workflow_module import accept_blocks
 
-from ._test_common import TestConfig, sweep_envelope
+from ._test_common import (
+    SkipTest,
+    TestConfig,
+    TestStatus,
+    block_id,
+    sweep_envelope,
+)
+from ._test_common.exceptions import TestOutcomeSignal
 from .benchmark_tests import (
     run_audio_benchmark,
     run_cnn_benchmark,
@@ -67,6 +74,44 @@ BENCHMARK_DISPATCH: dict[str, MediaRunner] = {
     "TEXT_TO_SPEECH": run_tts_benchmark,
     "VIDEO": run_video_benchmark,
 }
+
+
+_MEDIA_TASK_BLOCK_KIND = {
+    MediaTaskType.EVALUATION: "evals",
+    MediaTaskType.BENCHMARK: "benchmarks",
+}
+
+
+def _media_outcome_block(
+    ctx: MediaContext,
+    task_type: MediaTaskType,
+    status: TestStatus,
+    reason: Optional[str] = None,
+    exc: Optional[Exception] = None,
+) -> Block:
+    """Build an evals/benchmarks Block for a non-pass, blockless outcome.
+
+    Lets a media runner that was skipped (``SkipTest``), was not gradable
+    (``NotApplicable``), or crashed produce a *visible* Block carrying an
+    explicit :class:`TestStatus` — instead of vanishing behind a bare
+    ``(1, None)`` return value.
+    """
+    kind = _MEDIA_TASK_BLOCK_KIND.get(task_type, "spec_tests")
+    data: dict = {
+        "success": False,
+        "status": status.value,
+        "test_name": ctx.model_spec.model_name,
+    }
+    if reason:
+        data["reason"] = reason
+    if exc is not None:
+        data["error"] = {"type": type(exc).__name__, "message": str(exc)}
+    return Block(
+        kind=kind,
+        id=block_id(ctx) or None,
+        title=kind.replace("_", " ").title(),
+        data=data,
+    )
 
 
 def run_media_task(
@@ -112,9 +157,19 @@ def run_media_task(
 
     try:
         block = runner(ctx)
+    except TestOutcomeSignal as e:
+        # Intentional non-error outcome (skip / not-applicable): emit a
+        # visible, non-blocking Block and keep the task green.
+        status = TestStatus.SKIP if isinstance(e, SkipTest) else TestStatus.NA
+        logger.info("⏭  %s -> %s: %s", task_type.value, status.value, e.reason)
+        block = _media_outcome_block(ctx, task_type, status, reason=e.reason)
+        accept_blocks([block], envelope=sweep_envelope(ctx))
+        return 0, block
     except Exception as e:
         logger.exception("%s runner raised: %s", task_type.value, e)
-        return 1, None
+        block = _media_outcome_block(ctx, task_type, TestStatus.ERROR, exc=e)
+        accept_blocks([block], envelope=sweep_envelope(ctx))
+        return 1, block
 
     accept_blocks([block], envelope=sweep_envelope(ctx))
     return 0, block
@@ -155,6 +210,41 @@ def _maybe_cap_num_prompts(case: dict, cap: Optional[int]) -> dict:
         cap,
     )
     return new_case
+
+
+def _error_block(case: dict, ctx: MediaContext, exc: Exception) -> Block:
+    """Build a spec_tests Block for a test that raised before producing one.
+
+    Without this, a class that fails to import/instantiate/run would bump the
+    failure counter but emit no Block, making the crash invisible in the
+    report while still failing the workflow.
+    """
+    return Block(
+        kind="spec_tests",
+        id=block_id(ctx) or None,
+        title=str(case.get("name") or "spec_test").replace("_", " ").title(),
+        task_type=None,
+        targets=dict(case.get("targets") or {}),
+        data={
+            "success": False,
+            "status": TestStatus.ERROR.value,
+            "attempts": 0,
+            "test_name": str(case.get("name") or ""),
+            "description": str(case.get("description") or ""),
+            "error": {"type": type(exc).__name__, "message": str(exc)},
+        },
+    )
+
+
+def _block_status(block: Block) -> TestStatus:
+    """Resolve a Block's :class:`TestStatus`, falling back to legacy fields."""
+    data = block.data if isinstance(block.data, dict) else {}
+    resolved = TestStatus.from_value(data.get("status"))
+    if resolved is not None:
+        return resolved
+    return TestStatus.from_legacy(
+        data.get("success"), skipped=bool(data.get("skipped"))
+    )
 
 
 def _instantiate_spec_test(case: dict, ctx: MediaContext):
@@ -233,19 +323,21 @@ def run_spec_tests(ctx: MediaContext) -> Tuple[int, Optional[Block]]:
                 block = test.run_tests()
             except Exception as e:
                 logger.exception("  ❌ %s raised: %s", class_name, e)
+                blocks.append(_error_block(patched, ctx, e))
                 failures += 1
                 continue
             blocks.append(block)
-            if (
-                not isinstance(block.data, dict)
-                or block.data.get("success") is not True
-            ):
+            status = _block_status(block)
+            if status.is_blocking:
                 logger.error(
-                    "  ❌ %s did not report success=True (data=%r)",
+                    "  ❌ %s -> %s (data=%r)",
                     class_name,
+                    status.value,
                     block.data,
                 )
                 failures += 1
+            elif status in (TestStatus.SKIP, TestStatus.NA):
+                logger.info("  ⏭  %s -> %s", class_name, status.value)
 
     if not blocks:
         return 1, None

--- a/tt-inference-server-v2/test_module/dispatch.py
+++ b/tt-inference-server-v2/test_module/dispatch.py
@@ -165,9 +165,7 @@ def run_media_task(
                 f"model_type={model_type_name!r} (unsupported by design)"
             )
             logger.warning("⏭  %s -> skip: %s", task_type.value, reason)
-            block = _media_outcome_block(
-                ctx, task_type, TestStatus.SKIP, reason=reason
-            )
+            block = _media_outcome_block(ctx, task_type, TestStatus.SKIP, reason=reason)
             accept_blocks([block], envelope=sweep_envelope(ctx))
             return 0, block
 

--- a/tt-inference-server-v2/test_module/dispatch.py
+++ b/tt-inference-server-v2/test_module/dispatch.py
@@ -25,6 +25,7 @@ from typing import Callable, List, Optional, Tuple
 
 from report_module.schema import Block
 from workflow_module import accept_blocks
+from workflows.workflow_types import ModelType
 
 from ._test_common import (
     SkipTest,
@@ -76,6 +77,14 @@ BENCHMARK_DISPATCH: dict[str, MediaRunner] = {
 }
 
 
+_NO_MEDIA_RUNNER: frozenset[ModelType] = frozenset({ModelType.VLM, ModelType.LLM})
+
+_registered_media_types = set(EVAL_DISPATCH) | set(BENCHMARK_DISPATCH)
+assert not any(mt.name in _registered_media_types for mt in _NO_MEDIA_RUNNER), (
+    "A ModelType in _NO_MEDIA_RUNNER also has a registered media runner"
+)
+
+
 _MEDIA_TASK_BLOCK_KIND = {
     MediaTaskType.EVALUATION: "evals",
     MediaTaskType.BENCHMARK: "benchmarks",
@@ -122,7 +131,10 @@ def run_media_task(
     Returns:
         ``(exit_code, block)`` where ``exit_code`` is ``0`` on success and
         ``1`` on any failure, and ``block`` is the runner's emitted Block on
-        success (``None`` on failure or when the model_type has no runner).
+        success (``None`` on failure). A model_type with no registered runner
+        yields a *visible* Block instead of a silent failure: a non-blocking
+        SKIP (``(0, block)``) if the type is runnerless by design
+        (:data:`_NO_MEDIA_RUNNER`), otherwise a blocking ERROR (``(1, block)``).
         The block is also handed to ``workflow_module.accept_blocks`` so a
         sweep-level accumulator can pick it up alongside the return value.
 
@@ -147,13 +159,28 @@ def run_media_task(
     )
     runner = dispatch.get(model_type_name)
     if runner is None:
-        logger.error(
-            "No %s runner registered for model_type=%r. Known types: %s",
-            task_type.value,
-            model_type_name,
-            sorted(dispatch),
+        if ctx.model_spec.model_type in _NO_MEDIA_RUNNER:
+            reason = (
+                f"{task_type.value} has no media runner for "
+                f"model_type={model_type_name!r} (unsupported by design)"
+            )
+            logger.warning("⏭  %s -> skip: %s", task_type.value, reason)
+            block = _media_outcome_block(
+                ctx, task_type, TestStatus.SKIP, reason=reason
+            )
+            accept_blocks([block], envelope=sweep_envelope(ctx))
+            return 0, block
+
+        # Unexpected: a model type that should have a runner doesn't. Surface a
+        # blocking, visible ERROR rather than a silent (1, None) failure.
+        error = RuntimeError(
+            f"no {task_type.value} runner registered for "
+            f"model_type={model_type_name!r}; known types: {sorted(dispatch)}"
         )
-        return 1, None
+        logger.error("❌ %s -> error: %s", task_type.value, error)
+        block = _media_outcome_block(ctx, task_type, TestStatus.ERROR, exc=error)
+        accept_blocks([block], envelope=sweep_envelope(ctx))
+        return 1, block
 
     try:
         block = runner(ctx)

--- a/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/audio_eval_tests.py
@@ -477,8 +477,9 @@ def run_audio_eval(ctx: MediaContext) -> Block:
             "published_score": task.score.published_score,
             "score": ttft_value,
             "published_score_ref": task.score.published_score_ref,
-            # TODO: replace hardcoded PASS with a real accuracy evaluation.
-            "accuracy_check": ReportCheckTypes.PASS,
+            # Non-whisper audio models have no accuracy evaluation implemented,
+            # so accuracy is Not Applicable (non-blocking)
+            "accuracy_check": ReportCheckTypes.NA,
             "t/s/u": tsu_value,
             "rtr": rtr_value,
         },

--- a/tt-inference-server-v2/test_module/eval_tests/cnn_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/cnn_eval_tests.py
@@ -220,6 +220,9 @@ def run_cnn_eval(ctx: MediaContext) -> Block:
         data["published_score"] = task.score.published_score
         data["score"] = ttft_value
         data["published_score_ref"] = task.score.published_score_ref
+        # Non-MobileNet CNNs only get a timing benchmark here, no accuracy grade,
+        # so accuracy is Not Applicable (non-blocking).
+        data["accuracy_check"] = ReportCheckTypes.NA
 
     return Block(
         kind="evals",

--- a/tt-inference-server-v2/test_module/eval_tests/cnn_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/cnn_eval_tests.py
@@ -28,6 +28,12 @@ logger = logging.getLogger(__name__)
 
 
 CNN_MOBILENETV2_RUNNER = "tt-xla-mobilenetv2"
+
+_VISION_STATUS_TO_CHECK: dict[int, ReportCheckTypes] = {
+    0: ReportCheckTypes.NA,
+    2: ReportCheckTypes.PASS,
+    3: ReportCheckTypes.FAIL,
+}
 # Reuse the ImageNet subset prepared by VisionEvalsTest so benchmarks and
 # accuracy evals exercise the model with the exact same inputs.
 IMAGENET_DATASET_DIR = "server_tests/datasets/imagenet_subset"
@@ -174,8 +180,9 @@ def _run_mobilenetv2_eval(ctx: MediaContext) -> dict:
     logger.info(f"VisionEvalsTest model results: {model_results}")
 
     device_result = model_results.get("device", {})
-    device_result["accuracy_status"] = model_results.get(
-        "accuracy_status", ReportCheckTypes.NA
+    raw_status = model_results.get("accuracy_status")
+    device_result["accuracy_status"] = _VISION_STATUS_TO_CHECK.get(
+        raw_status, ReportCheckTypes.NA
     )
     logger.info(f"VisionEvalsTest device eval_results: {device_result}")
     return device_result

--- a/tt-inference-server-v2/test_module/eval_tests/embedding_eval_tests.py
+++ b/tt-inference-server-v2/test_module/eval_tests/embedding_eval_tests.py
@@ -16,7 +16,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from report_module.schema import Block
 
-from .._test_common import block_id
+from .._test_common import ReportCheckTypes, block_id
 from ..context import HardwareRequirement, MediaContext, require_health
 
 logger = logging.getLogger(__name__)
@@ -156,6 +156,9 @@ def run_embedding_eval(ctx: MediaContext) -> Block:
         targets={"task_name": ctx.all_params.tasks[0].task_name},
         data={
             "task_name": ctx.all_params.tasks[0].task_name,
+            # MTEB produces correlation metrics but no reference score to grade
+            # against, so accuracy is Not Applicable (non-blocking).
+            "accuracy_check": ReportCheckTypes.NA,
             **metrics,
         },
     )

--- a/tt-inference-server-v2/test_module/llm_tests/llm_eval_tests.py
+++ b/tt-inference-server-v2/test_module/llm_tests/llm_eval_tests.py
@@ -21,7 +21,7 @@ from report_module.schema import Block
 from workflow_module import accept_blocks
 from workflows.utils import run_command
 
-from .._test_common import ReportCheckTypes, block_id
+from .._test_common import ReportCheckTypes, TestStatus, block_id
 from ..context import MediaContext
 
 logger = logging.getLogger(__name__)
@@ -174,13 +174,14 @@ def _score_one(
 def blocks_for_task(ctx: MediaContext, task, results: dict) -> List[Block]:
     """Score ``task`` against ``results`` and build one Block per task/subtask.
 
-    Returns ``[]`` when the task has no score defined or produced no matching
-    results (the caller surfaces a FAIL block for a task that ran but scored
-    nothing).
+    A task that ran but has no score defined is not gradable -> one NA Bloc.
+    A task with a score but no matching results still returns ``[]`` so the
+    caller can surface a FAIL block for a task that ran but scored nothing.
     """
     if not task.score:
-        logger.info("Skipping %s: no eval score defined.", task.task_name)
-        return []
+        reason = "no eval score defined"
+        logger.info("%s ran but is not gradable: %s.", task.task_name, reason)
+        return [_status_block(ctx, task, TestStatus.NA, reason)]
 
     blocks: List[Block] = []
     for t_key in _target_keys(task, results):
@@ -229,6 +230,33 @@ def _fail_block(ctx: MediaContext, task, error: str) -> Block:
             "score": None,
             "accuracy_check": ReportCheckTypes.FAIL,
             "error": error,
+        },
+    )
+
+
+def _status_block(ctx: MediaContext, task, status: TestStatus, reason: str) -> Block:
+    """Build a non-graded evals Block carrying an explicit ``status``.
+
+    Keeps a task that was intentionally not run (SKIP) or ran but couldn't be
+    graded (NA) *visible* in the report instead of silently vanishing. The
+    explicit ``status`` short-circuits acceptance grading, so the block is
+    non-blocking.
+    """
+    score = getattr(task, "score", None)
+    return Block(
+        kind="evals",
+        task_type="llm",
+        title=f"LLM Eval — {task.task_name}",
+        id=block_id(ctx) or None,
+        targets={"task_name": task.task_name},
+        data={
+            "task_name": task.task_name,
+            "status": status.value,
+            "skipped": status is TestStatus.SKIP,
+            "reason": reason,
+            "tolerance": getattr(score, "tolerance", None),
+            "published_score": getattr(score, "published_score", None),
+            "score": None,
         },
     )
 
@@ -296,15 +324,16 @@ def run_llm_eval(ctx: MediaContext, *, auth_token: str = "") -> List[Block]:
     )
     ran_tasks = []
     rc_by_task = {}
+    skipped_blocks: List[Block] = []
     for task in tasks:
         min_ctx = getattr(task, "min_context_required", None)
         if min_ctx and device_max_context and device_max_context < min_ctx:
-            logger.warning(
-                "Skipping %s: requires max_context >= %s, device provides %s.",
-                task.task_name,
-                min_ctx,
-                device_max_context,
+            reason = (
+                f"requires max_context >= {min_ctx}, device provides "
+                f"{device_max_context}"
             )
+            logger.warning("⏭  Skipping %s: %s.", task.task_name, reason)
+            skipped_blocks.append(_status_block(ctx, task, TestStatus.SKIP, reason))
             continue
         health = server.get_health()
         if getattr(health, "status_code", 200) != 200:
@@ -319,7 +348,7 @@ def run_llm_eval(ctx: MediaContext, *, auth_token: str = "") -> List[Block]:
         ran_tasks.append(task)
 
     results = merge_eval_results(discover_eval_results(ctx.output_path, ctx.model_spec))
-    blocks: List[Block] = []
+    blocks: List[Block] = list(skipped_blocks)
     for task in ran_tasks:
         task_blocks = blocks_for_task(ctx, task, results)
         if task_blocks:

--- a/tt-inference-server-v2/test_module/unit_tests/logger_fork_safety_test.py
+++ b/tt-inference-server-v2/test_module/unit_tests/logger_fork_safety_test.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 from report_module.schema import Block
 
-from .._test_common import BaseTest, TestConfig
+from .._test_common import BaseTest, SkipTest, TestConfig
 
 if TYPE_CHECKING:
     from ..context import MediaContext
@@ -59,8 +59,7 @@ class LoggerForkSafetyTest(BaseTest):
 
     async def _run_specific_test_async(self):
         if not hasattr(os, "fork"):
-            logger.warning("os.fork() not available, skipping test")
-            return {"success": True, "skipped": True, "reason": "fork not available"}
+            raise SkipTest("os.fork() not available on this platform")
 
         logger.info("Testing logger fork safety with held lock...")
 

--- a/tt-inference-server-v2/tests/report_module/test_acceptance_criteria.py
+++ b/tt-inference-server-v2/tests/report_module/test_acceptance_criteria.py
@@ -38,15 +38,16 @@ def _categories_by_name(schema: ReportSchema):
 
 
 def test_category_result_passed_and_to_dict():
-    cat = CategoryResult("Benchmarks", STATUS_FAIL, total=5, failed=2, na=1)
-    assert cat.passed == 2
+    cat = CategoryResult("Benchmarks", STATUS_FAIL, total=5, failed=2, na=1, skipped=1)
+    assert cat.passed == 1
     assert cat.to_dict() == {
         "name": "Benchmarks",
         "status": STATUS_FAIL,
         "total": 5,
-        "passed": 2,
+        "passed": 1,
         "failed": 2,
         "na": 1,
+        "skipped": 1,
         "blockers": {},
     }
 
@@ -171,6 +172,126 @@ def test_spec_tests_success_true_passes():
     assert by_name[CATEGORY_SPEC_TESTS].status == STATUS_PASS
 
 
+# --- Spec tests: status-aware (SKIP / ERROR / NA) -------------------------
+
+
+def _spec(status_value: str, **extra) -> Block:
+    data = {"success": status_value == "pass", "status": status_value, **extra}
+    return Block(kind="spec_tests", title="T", task_type="functional", data=data)
+
+
+def test_spec_skip_is_non_blocking():
+    schema = _schema(_spec("skip", skipped=True, reason="no board"))
+    accepted, blockers, cats = acceptance_criteria_check(schema)
+    cat = {c.name: c for c in cats}[CATEGORY_SPEC_TESTS]
+    assert accepted is True and blockers == {}
+    assert cat.skipped == 1 and cat.failed == 0 and cat.status == STATUS_PASS
+
+
+def test_spec_na_is_non_blocking():
+    schema = _schema(_spec("na"))
+    accepted, blockers, cats = acceptance_criteria_check(schema)
+    cat = {c.name: c for c in cats}[CATEGORY_SPEC_TESTS]
+    assert accepted is True and blockers == {}
+    assert cat.na == 1 and cat.failed == 0
+
+
+def test_spec_error_blocks():
+    schema = _schema(_spec("error", error={"type": "AttributeError", "message": "x"}))
+    accepted, blockers, cats = acceptance_criteria_check(schema)
+    cat = {c.name: c for c in cats}[CATEGORY_SPEC_TESTS]
+    assert accepted is False
+    assert "spec.spec_tests:T" in blockers
+    assert "status=error" in blockers["spec.spec_tests:T"]
+    assert cat.failed == 1
+
+
+def test_spec_status_takes_precedence_over_success_flag():
+    # success flag says failure, but explicit SKIP status must win (non-blocking).
+    block = Block(
+        kind="spec_tests",
+        title="T",
+        task_type="functional",
+        data={"success": False, "status": "skip", "reason": "gated"},
+    )
+    accepted, blockers, _ = acceptance_criteria_check(_schema(block))
+    assert accepted is True and blockers == {}
+
+
+def test_mixed_spec_statuses_counts():
+    schema = _schema(
+        _spec("pass"),
+        _spec("skip", skipped=True, reason="r"),
+        _spec("na"),
+    )
+    accepted, blockers, cats = acceptance_criteria_check(schema)
+    cat = {c.name: c for c in cats}[CATEGORY_SPEC_TESTS]
+    assert accepted is True
+    assert cat.total == 3 and cat.passed == 1 and cat.skipped == 1 and cat.na == 1
+
+
+# --- Evals: explicit status overrides accuracy heuristics -----------------
+
+
+def test_eval_explicit_skip_is_non_blocking():
+    schema = _schema(_eval({"success": False, "status": "skip", "reason": "gated"}))
+    accepted, blockers, cats = acceptance_criteria_check(schema)
+    cat = {c.name: c for c in cats}[CATEGORY_EVALS]
+    assert accepted is True and blockers == {}
+    assert cat.skipped == 1
+
+
+def test_eval_explicit_error_blocks():
+    schema = _schema(_eval({"success": False, "status": "error"}))
+    accepted, blockers, _ = acceptance_criteria_check(schema)
+    assert accepted is False
+    assert "status=error" in blockers["evals:E"]
+
+
+# --- Benchmarks: status short-circuits target_checks ----------------------
+
+
+def test_benchmark_skip_is_non_blocking_without_target_checks():
+    # A skipped benchmark has no target_checks; it must NOT trip the
+    # "Missing target_checks" blocker.
+    schema = _schema(
+        Block(kind="benchmarks", title="B", data={"status": "skip", "reason": "gated"})
+    )
+    accepted, blockers, cats = acceptance_criteria_check(schema)
+    cat = {c.name: c for c in cats}[CATEGORY_BENCHMARKS]
+    assert accepted is True and blockers == {}
+    assert cat.skipped == 1 and cat.status == STATUS_NA
+
+
+def test_benchmark_error_blocks():
+    schema = _schema(Block(kind="benchmarks", title="B", data={"status": "error"}))
+    accepted, blockers, _ = acceptance_criteria_check(schema)
+    assert accepted is False
+    assert "status=error" in blockers["benchmarks:B"]
+
+
+def test_benchmark_passing_target_checks_still_pass_with_status_absent():
+    schema = _schema(
+        _bench({"target": {"ttft_check": 2, "ttft": 100, "ttft_ratio": 0.8}})
+    )
+    accepted, blockers, cats = acceptance_criteria_check(schema)
+    cat = {c.name: c for c in cats}[CATEGORY_BENCHMARKS]
+    assert accepted is True and blockers == {}
+    assert cat.status == STATUS_PASS and cat.skipped == 0
+
+
+def test_benchmark_mixed_skip_and_pass_is_pass():
+    schema = _schema(
+        _bench({"target": {"ttft_check": 2, "ttft": 100, "ttft_ratio": 0.8}}),
+        Block(kind="benchmarks", title="B2", data={"status": "skip", "reason": "x"}),
+    )
+    accepted, _, cats = acceptance_criteria_check(schema)
+    cat = {c.name: c for c in cats}[CATEGORY_BENCHMARKS]
+    assert accepted is True
+    assert cat.total == 2 and cat.passed == 1 and cat.skipped == 1
+    assert cat.status == STATUS_PASS
+
+
 # --- Markdown summary -----------------------------------------------------
 
 
@@ -180,6 +301,15 @@ def test_summary_markdown_passing():
     assert "Acceptance status: `PASS`" in md
     assert "All acceptance criteria passed." in md
     assert "2/2 passed" in md
+
+
+def test_summary_markdown_detail_shows_skipped():
+    categories = [
+        CategoryResult(CATEGORY_SPEC_TESTS, STATUS_PASS, total=3, failed=0, skipped=1)
+    ]
+    md = format_acceptance_summary_markdown(True, {}, categories)
+    assert "2/3 passed" in md
+    assert "1 skipped" in md
 
 
 def test_summary_markdown_includes_model_status():

--- a/tt-inference-server-v2/tests/report_module/test_generator.py
+++ b/tt-inference-server-v2/tests/report_module/test_generator.py
@@ -13,12 +13,56 @@ import pytest
 
 from report_module.generator import (
     ReportGenerator,
+    _build_spec_test_summary_markdown,
     _coerce_schema,
     _collapse_same_heading_blocks,
     _consolidate_eval_blocks,
     generate_report,
 )
 from report_module.schema import Block, ReportSchema
+
+
+def test_spec_summary_distinguishes_skip_error_from_pass_fail():
+    runs = [
+        {"test_name": "A", "status": "pass", "success": True, "attempts": 1},
+        {"test_name": "B", "status": "fail", "success": False, "attempts": 1},
+        {
+            "test_name": "C",
+            "status": "error",
+            "success": False,
+            "attempts": 0,
+            "error": {"message": "boom"},
+        },
+        {
+            "test_name": "D",
+            "status": "skip",
+            "success": False,
+            "reason": "no board",
+            "attempts": 0,
+        },
+        {"test_name": "E", "status": "na", "reason": "no dataset", "attempts": 0},
+    ]
+    md = _build_spec_test_summary_markdown(runs, "2026-07-05")
+
+    assert "| Passed | 1 |" in md
+    assert "| Failed | 2 |" in md  # fail + error both blocking
+    assert "| Skipped | 1 |" in md
+    assert "| NA | 1 |" in md
+    # Success rate excludes non-blocking skip/NA: 1 pass / (1 pass + 2 blocking).
+    assert "| Success Rate | 33.3% |" in md
+    # Distinct glyphs + reason surfaced in the description column.
+    assert "⏭️" in md and "🟨" in md
+    assert "no board" in md and "boom" in md
+
+
+def test_spec_summary_legacy_rows_without_status():
+    runs = [
+        {"test_name": "A", "success": True, "attempts": 1},
+        {"test_name": "B", "success": False, "attempts": 1},
+    ]
+    md = _build_spec_test_summary_markdown(runs, "2026-07-05")
+    assert "| Passed | 1 |" in md
+    assert "| Failed | 1 |" in md
 
 
 def _eval_block(task: str, **data) -> Block:

--- a/tt-inference-server-v2/tests/report_module/test_status.py
+++ b/tt-inference-server-v2/tests/report_module/test_status.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for the :class:`report_module.status.TestStatus` outcome enum."""
+
+from __future__ import annotations
+
+import pytest
+
+from report_module.status import TestStatus
+
+
+@pytest.mark.parametrize(
+    "status, blocking",
+    [
+        (TestStatus.PASS, False),
+        (TestStatus.FAIL, True),
+        (TestStatus.ERROR, True),
+        (TestStatus.SKIP, False),
+        (TestStatus.NA, False),
+    ],
+)
+def test_is_blocking(status, blocking):
+    assert status.is_blocking is blocking
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("pass", TestStatus.PASS),
+        ("FAIL", TestStatus.FAIL),
+        ("  Skip  ", TestStatus.SKIP),
+        (TestStatus.NA, TestStatus.NA),
+    ],
+)
+def test_from_value_accepts_known_spellings(raw, expected):
+    assert TestStatus.from_value(raw) is expected
+
+
+@pytest.mark.parametrize("raw", ["", "bogus", None, 3, True])
+def test_from_value_returns_none_for_unknown(raw):
+    assert TestStatus.from_value(raw) is None
+
+
+def test_from_legacy_maps_success_boolean():
+    assert TestStatus.from_legacy(True) is TestStatus.PASS
+    assert TestStatus.from_legacy(False) is TestStatus.FAIL
+    assert TestStatus.from_legacy(None) is TestStatus.FAIL
+
+
+def test_from_legacy_skipped_wins_over_success():
+    assert TestStatus.from_legacy(False, skipped=True) is TestStatus.SKIP
+    assert TestStatus.from_legacy(True, skipped=True) is TestStatus.SKIP

--- a/tt-inference-server-v2/tests/test_module/benchmark_tests/__init__.py
+++ b/tt-inference-server-v2/tests/test_module/benchmark_tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC

--- a/tt-inference-server-v2/tests/test_module/benchmark_tests/test_video_benchmark_tests.py
+++ b/tt-inference-server-v2/tests/test_module/benchmark_tests/test_video_benchmark_tests.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for video benchmark dispatch guards."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from test_module._test_common import SkipTest
+from test_module.benchmark_tests import video_benchmark_tests as mod
+
+
+def _ctx(model_name):
+    return SimpleNamespace(
+        model_spec=SimpleNamespace(model_name=model_name),
+        device=SimpleNamespace(name="t3k"),
+    )
+
+
+def test_unsupported_video_model_raises_skip():
+    # I2V has no inference-step profile: previously a KeyError (crash -> ERROR),
+    # now a visible, non-blocking SkipTest that run_media_task maps to SKIP.
+    with pytest.raises(SkipTest) as exc:
+        mod.run_video_benchmark(_ctx("Wan2.2-I2V-A14B-Diffusers"))
+    assert "not implemented" in str(exc.value)
+    assert "Wan2.2-I2V-A14B-Diffusers" in str(exc.value)

--- a/tt-inference-server-v2/tests/test_module/eval_tests/__init__.py
+++ b/tt-inference-server-v2/tests/test_module/eval_tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC

--- a/tt-inference-server-v2/tests/test_module/eval_tests/test_cnn_eval_tests.py
+++ b/tt-inference-server-v2/tests/test_module/eval_tests/test_cnn_eval_tests.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for the CNN eval boundary that translates VisionEvalsTest status codes.
+
+VisionEvalsTest emits its own accuracy status codes (0=undefined, 2=pass,
+3=fail). Acceptance grading treats any unrecognized int as PASS, so the raw
+``0`` (undefined / missing accuracy data) used to grade as a silent pass. These
+tests pin the translation to ``ReportCheckTypes`` and the acceptance contract.
+"""
+
+from __future__ import annotations
+
+from report_module.acceptance_criteria import (
+    CATEGORY_EVALS,
+    STATUS_NA,
+    STATUS_PASS,
+    acceptance_criteria_check,
+)
+from report_module.schema import Block, ReportSchema
+
+from test_module._test_common import ReportCheckTypes
+from test_module.eval_tests.cnn_eval_tests import _VISION_STATUS_TO_CHECK
+
+
+def _eval_category(accuracy_check):
+    block = Block(kind="evals", title="E", data={"accuracy_check": accuracy_check})
+    schema = ReportSchema(metadata={"report_id": "r"}, sections=[block])
+    accepted, blockers, categories = acceptance_criteria_check(schema)
+    category = {c.name: c for c in categories}[CATEGORY_EVALS]
+    return accepted, blockers, category
+
+
+def test_vision_status_mapping_aligns_with_report_check_types():
+    assert _VISION_STATUS_TO_CHECK == {
+        0: ReportCheckTypes.NA,
+        2: ReportCheckTypes.PASS,
+        3: ReportCheckTypes.FAIL,
+    }
+
+
+def test_raw_undefined_vision_code_would_grade_as_pass():
+    # Documents the hazard the mapping guards against: the raw undefined code
+    # (0) bypasses acceptance's FAIL/NA cases and falls through to PASS.
+    _, _, category = _eval_category(0)
+    assert category.status == STATUS_PASS
+
+
+def test_mapped_undefined_vision_code_grades_as_na():
+    accepted, blockers, category = _eval_category(_VISION_STATUS_TO_CHECK[0])
+    assert accepted is True and blockers == {}
+    assert category.status == STATUS_NA

--- a/tt-inference-server-v2/tests/test_module/llm_tests/test_llm_eval_tests.py
+++ b/tt-inference-server-v2/tests/test_module/llm_tests/test_llm_eval_tests.py
@@ -12,7 +12,7 @@ import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from test_module._test_common import ReportCheckTypes
+from test_module._test_common import ReportCheckTypes, TestStatus
 from test_module.llm_tests import llm_eval_tests as mod
 
 _MOD = "test_module.llm_tests.llm_eval_tests"
@@ -150,8 +150,12 @@ class TestBlocksForTask:
         assert b.data["score"] == 0.0
         assert b.data["accuracy_check"] == ReportCheckTypes.FAIL
 
-    def test_task_without_score_is_skipped(self):
-        assert self._blocks(_task(score=None), {"gpqa": {"acc,none": 0.9}}) == []
+    def test_task_without_score_is_na(self):
+        # A task that ran but has no score defined is not gradable -> NA (was
+        # previously dropped, which made the caller mislabel it as a FAIL).
+        (b,) = self._blocks(_task(score=None), {"gpqa": {"acc,none": 0.9}})
+        assert b.data["status"] == TestStatus.NA.value
+        assert b.data["reason"] == "no eval score defined"
 
 
 # --- reading lm-eval result JSON ---------------------------------------------
@@ -237,11 +241,15 @@ class TestRunLLMEval:
         run_task.assert_called_once()
 
     def test_min_context_skip(self):
+        # Task needs more context than the device provides: not run, but now a
+        # visible SKIP block instead of silently vanishing.
         out, run_task, _accept = self._run(
             [_task("longctx", min_context_required=200000)]
         )
         run_task.assert_not_called()
-        assert out == []
+        assert len(out) == 1
+        assert out[0].data["status"] == TestStatus.SKIP.value
+        assert "requires max_context >= 200000" in out[0].data["reason"]
 
 
 # --- EvalsWorkflow override --------------------------------------------------

--- a/tt-inference-server-v2/tests/test_module/test_base_test_status.py
+++ b/tt-inference-server-v2/tests/test_module/test_base_test_status.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests that ``BaseTest.run_tests`` emits the right ``TestStatus`` per outcome.
+
+These exercise the real retry/return machinery with a concrete subclass; the
+only thing stubbed is the hardware-readiness probe (an external HTTP call),
+which each subclass overrides to a no-op so the underlying test path runs.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from report_module.status import TestStatus
+from test_module._test_common import NotApplicable, SkipTest, TestConfig
+from test_module._test_common.base_test import BaseTest
+
+_CONFIG = TestConfig(
+    {"timeout": 5, "retry_attempts": 0, "retry_delay": 0, "break_on_failure": False}
+)
+
+
+class _BaseNoHardwareGate(BaseTest):
+    """Subclass that skips the network hardware probe for unit testing."""
+
+    KIND = "unit_probe"
+    TASK_TYPE = "unit"
+
+    def _assert_hardware_ready(self) -> None:
+        return None
+
+    async def _run_specific_test_async(self):  # pragma: no cover - overridden
+        raise NotImplementedError
+
+
+def _run(cls) -> Dict[str, Any]:
+    return cls(_CONFIG, {}).run_tests().data
+
+
+def test_passing_test_reports_pass():
+    class _T(_BaseNoHardwareGate):
+        async def _run_specific_test_async(self):
+            return {"success": True, "value": 42}
+
+    data = _run(_T)
+    assert data["status"] == TestStatus.PASS.value
+    assert data["success"] is True
+    assert data["value"] == 42
+
+
+def test_result_without_success_key_defaults_to_pass():
+    class _T(_BaseNoHardwareGate):
+        async def _run_specific_test_async(self):
+            return {"value": 1}
+
+    data = _run(_T)
+    assert data["status"] == TestStatus.PASS.value
+    assert data["success"] is True
+
+
+def test_success_false_reports_fail():
+    class _T(_BaseNoHardwareGate):
+        async def _run_specific_test_async(self):
+            return {"success": False}
+
+    data = _run(_T)
+    assert data["status"] == TestStatus.FAIL.value
+    assert data["success"] is False
+
+
+def test_result_can_self_declare_na():
+    class _T(_BaseNoHardwareGate):
+        async def _run_specific_test_async(self):
+            return {"success": True, "status": TestStatus.NA.value}
+
+    data = _run(_T)
+    assert data["status"] == TestStatus.NA.value
+
+
+def test_raised_exception_reports_error_not_fail():
+    class _T(_BaseNoHardwareGate):
+        async def _run_specific_test_async(self):
+            raise ValueError("boom")
+
+    data = _run(_T)
+    assert data["status"] == TestStatus.ERROR.value
+    assert data["success"] is False
+    assert data["error"]["type"] == "ValueError"
+    assert data["error"]["message"] == "boom"
+
+
+def test_skip_signal_reports_skip_with_reason():
+    class _T(_BaseNoHardwareGate):
+        async def _run_specific_test_async(self):
+            raise SkipTest("no accelerator present")
+
+    data = _run(_T)
+    assert data["status"] == TestStatus.SKIP.value
+    assert data["skipped"] is True
+    assert data["reason"] == "no accelerator present"
+
+
+def test_not_applicable_signal_reports_na_with_reason():
+    class _T(_BaseNoHardwareGate):
+        async def _run_specific_test_async(self):
+            raise NotApplicable("reference dataset unavailable")
+
+    data = _run(_T)
+    assert data["status"] == TestStatus.NA.value
+    assert data["reason"] == "reference dataset unavailable"
+
+
+def test_hardware_gate_skip_reports_skip():
+    class _T(BaseTest):
+        KIND = "unit_probe"
+        TASK_TYPE = "unit"
+
+        def _assert_hardware_ready(self):
+            raise SkipTest(
+                "not enough chips",
+                data={"ready_count": 1, "required_count": 4},
+            )
+
+        async def _run_specific_test_async(self):  # pragma: no cover
+            raise AssertionError("should not run when hardware gate skips")
+
+    data = _run(_T)
+    assert data["status"] == TestStatus.SKIP.value
+    assert data["skipped"] is True
+    assert data["reason"] == "not enough chips"
+    assert data["attempts"] == 0
+    # Structured diagnostics attached to the signal survive into the Block.
+    assert data["ready_count"] == 1
+    assert data["required_count"] == 4
+
+
+def test_outcome_signal_data_is_merged_without_overriding_envelope():
+    class _T(_BaseNoHardwareGate):
+        async def _run_specific_test_async(self):
+            # ``status`` is an envelope key and must win over signal data.
+            raise SkipTest("gated", data={"device": "n300", "status": "pass"})
+
+    data = _run(_T)
+    assert data["status"] == TestStatus.SKIP.value
+    assert data["device"] == "n300"
+
+
+def test_skip_and_na_signals_require_reason():
+    with pytest.raises(ValueError):
+        SkipTest("")
+    with pytest.raises(ValueError):
+        NotApplicable("   ")

--- a/tt-inference-server-v2/tests/test_module/test_dispatch_status.py
+++ b/tt-inference-server-v2/tests/test_module/test_dispatch_status.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for the status helpers + media-task wiring in ``test_module.dispatch``.
+
+Covers the spec-test exit-code fix and its extension to evals/benchmarks:
+  - ``_error_block`` / ``_media_outcome_block``: a crash or intentional skip
+    still becomes a *visible* Block (closes the report/exit-code gap).
+  - ``_block_status``: resolves a Block's TestStatus with a legacy fallback.
+  - ``run_media_task``: skip -> non-blocking (rc=0), crash -> visible ERROR
+    Block (rc=1).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from report_module.schema import Block
+from report_module.status import TestStatus
+from test_module import dispatch
+from test_module._test_common import NotApplicable, SkipTest
+from test_module.dispatch import (
+    _block_status,
+    _error_block,
+    _media_outcome_block,
+    run_media_task,
+)
+from test_module.task_types import MediaTaskType
+from workflows.workflow_types import ModelType
+
+
+def _fake_ctx(model="speecht5_tts", device="N150", model_type=ModelType.AUDIO):
+    return SimpleNamespace(
+        model_spec=SimpleNamespace(model_name=model, model_type=model_type),
+        device=SimpleNamespace(name=device),
+    )
+
+
+# --- spec-test helpers ----------------------------------------------------
+
+
+def test_error_block_is_visible_error_block():
+    case = {"name": "TestTTSServerHealth", "description": "load test", "targets": {}}
+    block = _error_block(case, _fake_ctx(), AttributeError("no attribute"))
+    assert block.kind == "spec_tests"
+    assert block.data["status"] == TestStatus.ERROR.value
+    assert block.data["success"] is False
+    assert block.data["error"]["type"] == "AttributeError"
+    assert block.data["error"]["message"] == "no attribute"
+    assert block.id == "speecht5_tts_N150"
+
+
+def test_block_status_prefers_explicit_status():
+    block = Block(kind="spec_tests", data={"status": "skip", "success": False})
+    assert _block_status(block) is TestStatus.SKIP
+
+
+def test_block_status_falls_back_to_success_flag():
+    assert _block_status(Block(kind="spec_tests", data={"success": True})) is (
+        TestStatus.PASS
+    )
+    assert _block_status(Block(kind="spec_tests", data={"success": False})) is (
+        TestStatus.FAIL
+    )
+
+
+def test_block_status_falls_back_to_skipped_flag():
+    block = Block(kind="spec_tests", data={"success": False, "skipped": True})
+    assert _block_status(block) is TestStatus.SKIP
+
+
+# --- media outcome block (evals / benchmarks) -----------------------------
+
+
+def test_media_outcome_block_kind_follows_task_type():
+    skip = _media_outcome_block(
+        _fake_ctx(), MediaTaskType.BENCHMARK, TestStatus.SKIP, reason="no board"
+    )
+    assert skip.kind == "benchmarks"
+    assert skip.data["status"] == TestStatus.SKIP.value
+    assert skip.data["reason"] == "no board"
+
+    err = _media_outcome_block(
+        _fake_ctx(), MediaTaskType.EVALUATION, TestStatus.ERROR, exc=RuntimeError("x")
+    )
+    assert err.kind == "evals"
+    assert err.data["status"] == TestStatus.ERROR.value
+    assert err.data["error"]["message"] == "x"
+
+
+# --- run_media_task -------------------------------------------------------
+
+
+def _patch_runner(monkeypatch, task_type, runner):
+    target = (
+        "EVAL_DISPATCH"
+        if task_type == MediaTaskType.EVALUATION
+        else ("BENCHMARK_DISPATCH")
+    )
+    monkeypatch.setattr(dispatch, target, {"AUDIO": runner})
+    monkeypatch.setattr(dispatch, "accept_blocks", lambda *a, **k: True)
+
+
+def test_run_media_task_skip_is_non_blocking(monkeypatch):
+    def runner(ctx):
+        raise SkipTest("feature not enabled for this device")
+
+    _patch_runner(monkeypatch, MediaTaskType.BENCHMARK, runner)
+    rc, block = run_media_task(_fake_ctx(), MediaTaskType.BENCHMARK)
+    assert rc == 0
+    assert block.kind == "benchmarks"
+    assert block.data["status"] == TestStatus.SKIP.value
+
+
+def test_run_media_task_not_applicable_is_non_blocking(monkeypatch):
+    def runner(ctx):
+        raise NotApplicable("no reference dataset")
+
+    _patch_runner(monkeypatch, MediaTaskType.EVALUATION, runner)
+    rc, block = run_media_task(_fake_ctx(), MediaTaskType.EVALUATION)
+    assert rc == 0
+    assert block.data["status"] == TestStatus.NA.value
+
+
+def test_run_media_task_crash_emits_visible_error_block(monkeypatch):
+    def runner(ctx):
+        raise ValueError("kaboom")
+
+    _patch_runner(monkeypatch, MediaTaskType.EVALUATION, runner)
+    rc, block = run_media_task(_fake_ctx(), MediaTaskType.EVALUATION)
+    assert rc == 1
+    assert block is not None and block.kind == "evals"
+    assert block.data["status"] == TestStatus.ERROR.value
+    assert block.data["error"]["message"] == "kaboom"
+
+
+def test_run_media_task_no_runner_by_design_is_skip(monkeypatch):
+    # A model type that is runnerless *by design* (_NO_MEDIA_RUNNER): previously
+    # (1, None) — a silent failure. Now a non-blocking, visible SKIP block.
+    monkeypatch.setattr(dispatch, "EVAL_DISPATCH", {})
+    monkeypatch.setattr(dispatch, "accept_blocks", lambda *a, **k: True)
+    rc, block = run_media_task(
+        _fake_ctx(model_type=ModelType.VLM), MediaTaskType.EVALUATION
+    )
+    assert rc == 0
+    assert block is not None and block.kind == "evals"
+    assert block.data["status"] == TestStatus.SKIP.value
+    assert "unsupported by design" in block.data["reason"]
+
+
+def test_run_media_task_missing_expected_runner_is_error(monkeypatch):
+    # A model type that *should* have a runner but doesn't: a real registration
+    # bug -> blocking, visible ERROR block (not a silent (1, None)).
+    monkeypatch.setattr(dispatch, "EVAL_DISPATCH", {})
+    monkeypatch.setattr(dispatch, "accept_blocks", lambda *a, **k: True)
+    rc, block = run_media_task(
+        _fake_ctx(model_type=ModelType.AUDIO), MediaTaskType.EVALUATION
+    )
+    assert rc == 1
+    assert block is not None and block.kind == "evals"
+    assert block.data["status"] == TestStatus.ERROR.value
+    assert "no evaluation runner registered" in block.data["error"]["message"]
+
+
+def test_run_media_task_success_passthrough(monkeypatch):
+    good = Block(kind="benchmarks", data={"target_checks": {}})
+
+    def runner(ctx):
+        return good
+
+    _patch_runner(monkeypatch, MediaTaskType.BENCHMARK, runner)
+    rc, block = run_media_task(_fake_ctx(), MediaTaskType.BENCHMARK)
+    assert rc == 0 and block is good

--- a/tt-inference-server-v2/workflow_module/summary_report.py
+++ b/tt-inference-server-v2/workflow_module/summary_report.py
@@ -144,13 +144,13 @@ def _summary_target_checks(
 
 
 def aggregate_to_block(aggregate: BenchmarkAggregate) -> Block:
-    target_checks, accuracy_check = _summary_target_checks(aggregate)
+    target_checks, target_check = _summary_target_checks(aggregate)
     statistics = [
         _stats_record(name, stats) for name, stats in aggregate.metrics.items()
     ]
     data = {
         "num_runs": aggregate.run_count,
-        "accuracy_check": accuracy_check,
+        "target_check": target_check,
         "statistics": statistics,
         "target_checks": target_checks,
     }

--- a/utils/sdxl_accuracy_utils/sdxl_accuracy_utils.py
+++ b/utils/sdxl_accuracy_utils/sdxl_accuracy_utils.py
@@ -13,8 +13,6 @@ import urllib.request
 
 from PIL import Image
 
-from utils.sdxl_accuracy_utils.clip_encoder import CLIPEncoder
-from utils.sdxl_accuracy_utils.fid_score import calculate_fid_score
 from workflows.workflow_types import ReportCheckTypes
 
 COCO_CAPTIONS_DOWNLOAD_PATH = "https://github.com/mlcommons/inference/raw/4b1d1156c23965172ae56eacdd8372f8897eb771/text_to_image/coco2014/captions/captions_source.tsv"
@@ -72,6 +70,9 @@ def save_images_as_pil(status_list: list, output_folder: str):
 
 
 def calculate_metrics(status_list: list, image_resolution: tuple = (1024, 1024)):
+    from utils.sdxl_accuracy_utils.clip_encoder import CLIPEncoder
+    from utils.sdxl_accuracy_utils.fid_score import calculate_fid_score
+
     prompts = [status.prompt for status in status_list]
     images = []
     decode_errors = 0


### PR DESCRIPTION
## Summary
Adds a canonical test-outcome vocabulary (TestStatus: PASS/FAIL/ERROR/SKIP/NA) and control-flow signals (SkipTest, NotApplicable), then migrates the ad-hoc skip/NA/"silent bail" handling across the v2 test flow onto it. The core goal: every task outcome now produces a visible report block with the correct blocking semantics, instead of vanishing (return 1, None / continue) or being mis-graded.

## Motivation
Several paths returned (1, None), continue, or an empty list on intentional skips or unsupported configs, so the workflow exit code and the report disagreed, and some "evals" reported a misleading PASS/blocker FAIL when they were really ungradable or not run.

## Changes
**- Honest test-status handling** 

Introduced a proper TestStatus enum (report_module/status.py) and threaded it through dispatch, base tests, and acceptance so results stop faking PASS when data is missing:
Skips are explicit: skip-shaped tests now raise SkipTest(reason); 
Fixed the exit-code vs. report mismatch so failures propagate correctly.

**-  Report readability & naming**

Renamed the benchmark table column Accuracy Check → Target Check (evals keep "Accuracy Check"); display-only, acceptance gating unchanged.
Added a tier-explanation note under benchmark tables (why Target Check = FAIL can still pass acceptance).
Improved markdown spacing

**- Dependency cleanup**

open-clip-torch / scipy / torchvision made optional — only needed when actually scoring images (sdxl_accuracy_utils.py).

**- Tests**

New coverage: test_status.py, test_base_test_status.py, test_dispatch_status.py, plus additions for acceptance, generator, CNN/LLM evals, and video benchmarks.

##Test CI runs

whisper -> https://github.com/tenstorrent/tt-shield/actions/runs/28799363757
FLUX -> https://github.com/tenstorrent/tt-shield/actions/runs/28799389532