### PR TITLE
Fix: VLLMParamConformanceTest fails in release workflow: "No module named pytest" in V2_RUN_SCRIPT venv

### DIFF
--- a/requirements/v2-run-script.txt
+++ b/requirements/v2-run-script.txt
@@ -27,3 +27,7 @@ requests
 # LLM eval/release run in this venv and mint the server bearer token from
 # --jwt-secret (command_factory._mint_jwt_if_secret), so pyjwt must be here.
 pyjwt
+# VLLMParamConformanceTest spawns its pytest suite via sys.executable (this
+# venv's python), so pytest must live here. 
+pytest==8.3.5
+pytest-asyncio==1.3.0


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-inference-server/issues/4525

The cleaner suggestion (run the suite from .venv_tests_run_script instead of sys.executable) sounds nicer but is actually worse here cus it couples v2 to v1 internals and it is heavier (`TESTS_RUN_SCRIPT `drags in torch, torchvision, transformers, datasets, open-clip-torch)
