### PR TITLE
Use unit32_t Consistently for Token IDs

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -1005,6 +1005,14 @@ if(ENABLE_BLAZE)
     target_include_directories(mock_schedulers_test PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
     )
+
+    add_executable(blaze_slot_manager_test
+        tests/unit/runners/blaze_slot_manager_test.cpp
+    )
+    target_link_libraries(blaze_slot_manager_test PRIVATE llm_runner_lib GTest::gtest_main)
+    target_include_directories(blaze_slot_manager_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
 endif()
 
 add_executable(sequence_test tests/unit/model/sequence_test.cpp)
@@ -1353,6 +1361,7 @@ if(ENABLE_BLAZE)
     gtest_discover_tests(blaze_decode_runner_test)
     gtest_discover_tests(blaze_prefill_runner_test)
     gtest_discover_tests(mock_schedulers_test)
+    gtest_discover_tests(blaze_slot_manager_test)
 endif()
 gtest_discover_tests(sequence_test)
 gtest_discover_tests(lockfree_queue_test)

--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -1005,14 +1005,6 @@ if(ENABLE_BLAZE)
     target_include_directories(mock_schedulers_test PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
     )
-
-    add_executable(blaze_slot_manager_test
-        tests/unit/runners/blaze_slot_manager_test.cpp
-    )
-    target_link_libraries(blaze_slot_manager_test PRIVATE llm_runner_lib GTest::gtest_main)
-    target_include_directories(blaze_slot_manager_test PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-    )
 endif()
 
 add_executable(sequence_test tests/unit/model/sequence_test.cpp)
@@ -1361,7 +1353,6 @@ if(ENABLE_BLAZE)
     gtest_discover_tests(blaze_decode_runner_test)
     gtest_discover_tests(blaze_prefill_runner_test)
     gtest_discover_tests(mock_schedulers_test)
-    gtest_discover_tests(blaze_slot_manager_test)
 endif()
 gtest_discover_tests(sequence_test)
 gtest_discover_tests(lockfree_queue_test)

--- a/tt-media-server/cpp_server/benchmarks/tokenizer_benchmark.cpp
+++ b/tt-media-server/cpp_server/benchmarks/tokenizer_benchmark.cpp
@@ -96,7 +96,7 @@ BenchmarkResult benchmarkEncode(const Tokenizer& tokenizer,
   }
 
   auto start = std::chrono::high_resolution_clock::now();
-  std::vector<int> tokens;
+  std::vector<uint32_t> tokens;
 
   for (size_t i = 0; i < NUM_BENCHMARK_ITERATIONS; ++i) {
     tokens = tokenizer.encode(text);
@@ -115,7 +115,7 @@ BenchmarkResult benchmarkEncode(const Tokenizer& tokenizer,
 }
 
 BenchmarkResult benchmarkDecode(const Tokenizer& tokenizer, size_t numTokens) {
-  std::vector<int> tokens;
+  std::vector<uint32_t> tokens;
   for (size_t i = 0; i < numTokens; ++i) {
     tokens.push_back(100 + (i % 1000));
   }

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -120,7 +120,7 @@ constexpr size_t MEMORY_QUEUE_CAPACITY = 128;
 // IPC message sizes
 constexpr size_t MAX_SEQUENCE_NON_TOKEN_BYTES = 4096;
 constexpr size_t TASK_QUEUE_MAX_MSG_SIZE =
-    MAX_CONTEXT_LENGTH * sizeof(int64_t) + MAX_SEQUENCE_NON_TOKEN_BYTES;
+    MAX_CONTEXT_LENGTH * sizeof(uint32_t) + MAX_SEQUENCE_NON_TOKEN_BYTES;
 constexpr size_t MEMORY_REQUEST_MAX_MSG_SIZE = 256;
 constexpr size_t MEMORY_RESULT_MAX_MSG_SIZE = 4096;
 

--- a/tt-media-server/cpp_server/include/config/runner_config.hpp
+++ b/tt-media-server/cpp_server/include/config/runner_config.hpp
@@ -37,8 +37,8 @@ struct MediaRunnerConfigBase : RunnerConfigBase {
 struct LLMConfig : RunnerConfigBase {
   size_t max_num_batched_tokens = 64 * defaults::MAX_CONTEXT_LENGTH;
   size_t max_in_flight_count = 64;
-  std::vector<int64_t> stop_token_ids;  // Set by tt::config::llmEngineConfig()
-                                        // from active tokenizer strategy
+  std::vector<uint32_t> stop_token_ids;  // Set by tt::config::llmEngineConfig()
+                                         // from active tokenizer strategy
   int eos = 1;
   size_t kvcache_block_size = 256;
   size_t num_kvcache_blocks = 512;

--- a/tt-media-server/cpp_server/include/domain/llm/llm_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/llm_request.hpp
@@ -70,7 +70,7 @@ struct LLMRequest : BaseRequest {
 
   // Prompt can be a string or a list of token ids
   // Can be either the original prompt or delta
-  std::variant<std::string, std::vector<int>> prompt;
+  std::variant<std::string, std::vector<uint32_t>> prompt;
 
   // Original chat messages used to derive `prompt`. Kept here so downstream
   // steps (session resolution, prefix-cache routing) don't need a separate
@@ -192,7 +192,7 @@ struct LLMRequest : BaseRequest {
       promptInfo =
           "\"" + detail::truncate(*s, detail::MAX_PROMPT_LOG_LENGTH) + "\"";
     } else {
-      auto& tokens = std::get<std::vector<int>>(prompt);
+      auto& tokens = std::get<std::vector<uint32_t>>(prompt);
       promptInfo = "<" + std::to_string(tokens.size()) + " token ids>";
     }
 

--- a/tt-media-server/cpp_server/include/domain/llm/llm_response.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/llm_response.hpp
@@ -78,7 +78,7 @@ struct LLMChoice {
   int index = 0;
   std::optional<Json::Value> logprobs;
   std::optional<std::string> finish_reason;
-  std::optional<int64_t> token_id;
+  std::optional<uint32_t> token_id;
   std::optional<Json::Value> tool_calls;
   uint32_t spec_accepts = 0;
   uint32_t spec_rejects = 0;

--- a/tt-media-server/cpp_server/include/domain/llm/prefill_request.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/prefill_request.hpp
@@ -19,7 +19,7 @@ namespace tt::domain::llm {
 struct PrefillRequest {
   uint32_t task_id;
   std::string prompt;
-  std::vector<int64_t> token_ids;
+  std::vector<uint32_t> token_ids;
   std::optional<int> max_tokens;
 
   explicit PrefillRequest(uint32_t taskId) : task_id(taskId) {}

--- a/tt-media-server/cpp_server/include/domain/llm/sequence.hpp
+++ b/tt-media-server/cpp_server/include/domain/llm/sequence.hpp
@@ -20,12 +20,12 @@ enum class SequenceStatus { WAITING, RUNNING, IN_FLIGHT, FINISHED, ABORTED };
 
 struct TokenResult {
   uint32_t taskId;
-  uint64_t tokenId = 0;
+  uint32_t tokenId = 0;
   std::optional<bool> finished;
   bool isError = false;
 
   TokenResult() = default;
-  TokenResult(uint32_t taskId, uint64_t tokenId,
+  TokenResult(uint32_t taskId, uint32_t tokenId,
               std::optional<bool> finished = {}, bool isError = false)
       : taskId(taskId),
         tokenId(tokenId),
@@ -35,10 +35,10 @@ struct TokenResult {
 
 class Sequence {
  public:
-  Sequence(uint32_t taskId, int blockSize, std::vector<int64_t> tokenIds,
+  Sequence(uint32_t taskId, int blockSize, std::vector<uint32_t> tokenIds,
            const SamplingParams& samplingParams = SamplingParams());
 
-  Sequence(uint32_t taskId, int blockSize, std::vector<int64_t> tokenIds,
+  Sequence(uint32_t taskId, int blockSize, std::vector<uint32_t> tokenIds,
            size_t numPromptTokens, std::optional<uint32_t> slotId,
            std::optional<uint32_t> prefillSlotId, bool continuation,
            bool disaggregated, std::unique_ptr<SamplingParams> samplingParams,
@@ -54,7 +54,7 @@ class Sequence {
   uint32_t taskId;
 
   size_t size() const { return tokenIds.size(); }
-  int64_t operator[](size_t i) const { return tokenIds[i]; }
+  uint32_t operator[](size_t i) const { return tokenIds[i]; }
 
   bool isFinished() const { return status == SequenceStatus::FINISHED; }
   bool isAborted() const { return status == SequenceStatus::ABORTED; }
@@ -76,17 +76,17 @@ class Sequence {
   void setPrefillKVCacheSlot(uint32_t slot) { prefillKvCacheSlot = slot; }
   uint32_t getPrefillKVCacheSlot() const { return prefillKvCacheSlot; }
 
-  std::vector<int64_t> block(size_t i) const;
-  std::vector<int64_t> completionTokenIds() const;
-  void appendToken(int64_t tokenId);
+  std::vector<uint32_t> block(size_t i) const;
+  std::vector<uint32_t> completionTokenIds() const;
+  void appendToken(uint32_t tokenId);
 
   SequenceStatus getStatus() const { return status; }
   void setStatus(SequenceStatus s) { status = s; }
 
-  const std::vector<int64_t>& getTokenIds() const { return tokenIds; }
+  const std::vector<uint32_t>& getTokenIds() const { return tokenIds; }
 
-  int64_t getLastToken() const { return lastToken; }
-  void setLastToken(int64_t t) { lastToken = t; }
+  uint32_t getLastToken() const { return lastToken; }
+  void setLastToken(uint32_t t) { lastToken = t; }
 
   size_t getNumPromptTokens() const { return numPromptTokens; }
   void setNumPromptTokens(size_t n) { numPromptTokens = n; }
@@ -133,8 +133,8 @@ class Sequence {
 
  private:
   SequenceStatus status = SequenceStatus::WAITING;
-  std::vector<int64_t> tokenIds;
-  int64_t lastToken = 0;
+  std::vector<uint32_t> tokenIds;
+  uint32_t lastToken = 0;
   std::optional<uint32_t> kvPositionId = std::nullopt;
   size_t numPromptTokens = 0;
   size_t numCachedTokens = 0;

--- a/tt-media-server/cpp_server/include/domain/session.hpp
+++ b/tt-media-server/cpp_server/include/domain/session.hpp
@@ -135,7 +135,7 @@ class Session {
    *        0 for a fresh session.
    */
   void initTokenAccumulator(
-      std::vector<int> deltaTokens,
+      std::vector<uint32_t> deltaTokens,
       std::vector<utils::BlockHashInfo> initialBlocks,
       std::function<void(const std::string&,
                          const std::vector<utils::BlockHashInfo>&)>
@@ -145,7 +145,7 @@ class Session {
   /**
    * Add a generated token to the accumulator.
    */
-  void addGeneratedToken(int tokenId);
+  void addGeneratedToken(uint32_t tokenId);
 
   /**
    * Compute final hashes and register any new blocks.
@@ -188,8 +188,8 @@ class Session {
       releaser_;  // injected by SessionManager (see release())
 
   // Streaming token accumulator (initialized per-request)
-  std::vector<int> deltaTokens_;
-  std::vector<int> generatedTokens_;
+  std::vector<uint32_t> deltaTokens_;
+  std::vector<uint32_t> generatedTokens_;
   std::vector<utils::BlockHashInfo> initialBlocks_;
   uint64_t parentHash_ = 0;
   uint32_t parentThinkCount_ = 0;
@@ -200,8 +200,8 @@ class Session {
   // Thinking token tracking
   bool inThinkingBlock_ = false;
   uint32_t accumulatedThinkTokens_ = 0;
-  int64_t thinkStartTokenId_ = 0;
-  int64_t thinkEndTokenId_ = 0;
+  uint32_t thinkStartTokenId_ = 0;
+  uint32_t thinkEndTokenId_ = 0;
 
   static std::string generateUuid();
 };

--- a/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
+++ b/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
@@ -167,7 +167,7 @@ struct DynamoUsage {
 };
 
 struct TokenChunk {
-  std::vector<int> token_ids;
+  std::vector<uint32_t> token_ids;
   std::optional<std::string> finish_reason;
   /// If set, signals a pre-stream error. stream_response will send this as an
   /// Annotated::error chunk so the Dynamo frontend can intercept it.
@@ -196,7 +196,7 @@ std::vector<uint8_t> encode_stream_final();
 
 struct GenerateRequest {
   std::string model;
-  std::vector<int> token_ids;
+  std::vector<uint32_t> token_ids;
 
   // StopConditions ---------------------------------------------------------
   int max_tokens = 128;

--- a/tt-media-server/cpp_server/include/ipc/helpers/token_push.hpp
+++ b/tt-media-server/cpp_server/include/ipc/helpers/token_push.hpp
@@ -12,7 +12,7 @@
 namespace tt::ipc::helpers {
 
 inline void pushToken(tt::ipc::IResultQueue& queue, uint32_t taskId,
-                      uint64_t tokenId, uint32_t flag = 0,
+                      uint32_t tokenId, uint32_t flag = 0,
                       uint32_t specAccepts = 0, uint32_t specRejects = 0) {
   tt::ipc::SharedToken token{};
   token.task_id = taskId;

--- a/tt-media-server/cpp_server/include/ipc/interface/result_queue.hpp
+++ b/tt-media-server/cpp_server/include/ipc/interface/result_queue.hpp
@@ -13,7 +13,7 @@ namespace tt::ipc {
 struct SharedToken {
   uint32_t token_index = 0;
   uint32_t flags = 0;
-  uint64_t token_id = 0;
+  uint32_t token_id = 0;
   uint32_t task_id = 0;
   uint32_t spec_accepts = 0;
   uint32_t spec_rejects = 0;

--- a/tt-media-server/cpp_server/include/ipc/posix/slot_ring_buffer.hpp
+++ b/tt-media-server/cpp_server/include/ipc/posix/slot_ring_buffer.hpp
@@ -36,7 +36,7 @@ struct alignas(8) Message {
   uint32_t taskId;
   uint32_t fastMode;
   uint32_t slotId;
-  uint64_t tokenIds[MaxTokenIds];
+  uint32_t tokenIds[MaxTokenIds];
 
   static constexpr size_t K_TOTAL_SIZE =
       tt::config::defaults::SHM_SLOTS * sizeof(Message);
@@ -54,7 +54,7 @@ struct ReadResult {
   uint32_t taskId;
   uint32_t maxTokens;
   bool fastMode = false;
-  std::vector<int64_t> tokenIds;
+  std::vector<uint32_t> tokenIds;
 };
 
 template <int MaxTokenIds>
@@ -109,7 +109,7 @@ class SlotRingBuffer {
     state = reinterpret_cast<SlotRingBufferState*>(memPointerState);
   }
 
-  void write(uint32_t taskId, const std::vector<int64_t>& tokenIds,
+  void write(uint32_t taskId, const std::vector<uint32_t>& tokenIds,
              uint32_t maxTokens, uint32_t slotId, bool fastMode = false) {
     if (static_cast<int>(tokenIds.size()) > MaxTokenIds) {
       throw std::runtime_error("SlotRingBuffer::write: token count " +
@@ -130,7 +130,7 @@ class SlotRingBuffer {
     slot.slotId = slotId;
     slot.numTokenIds = tokenIds.size();
     std::memcpy(slot.tokenIds, tokenIds.data(),
-                tokenIds.size() * sizeof(int64_t));
+                tokenIds.size() * sizeof(uint32_t));
 
     slot.switchState(FILLED);
     advanceWriterIndex();

--- a/tt-media-server/cpp_server/include/runtime/runners/llm_runner/block_manager.hpp
+++ b/tt-media-server/cpp_server/include/runtime/runners/llm_runner/block_manager.hpp
@@ -20,20 +20,20 @@ class Block {
  public:
   explicit Block(int blockId);
 
-  void update(int64_t hash, std::vector<int64_t> tokenIds);
+  void update(int64_t hash, std::vector<uint32_t> tokenIds);
   void reset();
 
   int blockId = 0;
   int refCount = 0;
   int64_t hash = -1;
-  std::vector<int64_t> tokenIds;
+  std::vector<uint32_t> tokenIds;
 };
 
 class BlockManager {
  public:
   BlockManager(size_t numBlocks, size_t blockSize);
 
-  static int64_t computeHash(const std::vector<int64_t>& tokenIds,
+  static int64_t computeHash(const std::vector<uint32_t>& tokenIds,
                              int64_t prefix = -1);
 
   bool allocate(tt::domain::llm::Sequence& seq);

--- a/tt-media-server/cpp_server/include/runtime/runners/llm_runner/hash.hpp
+++ b/tt-media-server/cpp_server/include/runtime/runners/llm_runner/hash.hpp
@@ -8,6 +8,6 @@
 
 namespace tt::runners::llm_engine {
 
-int64_t hashTokenIds(const std::vector<int64_t>& tokenIds, int64_t prefix);
+int64_t hashTokenIds(const std::vector<uint32_t>& tokenIds, int64_t prefix);
 
 }  // namespace tt::runners::llm_engine

--- a/tt-media-server/cpp_server/include/runtime/runners/schedulers/scheduler.hpp
+++ b/tt-media-server/cpp_server/include/runtime/runners/schedulers/scheduler.hpp
@@ -37,7 +37,7 @@ class Scheduler {
 
   /** Creates a sequence, takes ownership, and enqueues it for prefill. */
   tt::domain::llm::Sequence& addRequest(
-      uint32_t taskId, std::vector<int64_t> prompt,
+      uint32_t taskId, std::vector<uint32_t> prompt,
       const tt::domain::llm::SamplingParams& params =
           tt::domain::llm::SamplingParams());
 
@@ -69,7 +69,7 @@ class Scheduler {
    * @param token_ids  One token per sequence from the model.
    */
   void postprocess(std::vector<tt::domain::llm::Sequence*>& seqs,
-                   const std::vector<int64_t>& tokenIds);
+                   const std::vector<uint32_t>& tokenIds);
   void removeSequence(uint32_t taskId);
 
   /**
@@ -79,7 +79,7 @@ class Scheduler {
    */
   void abortRequest(uint32_t taskId);
 
-  bool isStopToken(int64_t tokenId) const {
+  bool isStopToken(uint32_t tokenId) const {
     return stopTokenIds.count(tokenId) > 0;
   }
 
@@ -114,7 +114,7 @@ class Scheduler {
 
   size_t maxInFlightCount;
   size_t maxNumBatchedTokens;
-  std::unordered_set<int64_t> stopTokenIds;
+  std::unordered_set<uint32_t> stopTokenIds;
   llm_engine::BlockManager blockManager;
   ipc::ITaskQueue* prefillQueue;
   std::unordered_map<uint32_t, std::unique_ptr<tt::domain::llm::Sequence>>

--- a/tt-media-server/cpp_server/include/services/llm_service.hpp
+++ b/tt-media-server/cpp_server/include/services/llm_service.hpp
@@ -92,7 +92,7 @@ class LLMService : public BaseStreamingService<LLMRequest, LLMStreamChunk> {
   std::shared_ptr<tt::ipc::ITaskQueue> taskQueue;
   std::unique_ptr<tt::worker::WorkerManager> workerManager;
   std::unique_ptr<tt::ipc::QueueManager> queueManager;
-  std::unordered_set<int64_t> stopTokenSet;
+  std::unordered_set<uint32_t> stopTokenSet;
 };
 
 }  // namespace tt::services

--- a/tt-media-server/cpp_server/include/services/session_resolution.hpp
+++ b/tt-media-server/cpp_server/include/services/session_resolution.hpp
@@ -34,7 +34,7 @@ inline uint32_t applyDeltaPrompt(tt::domain::llm::LLMRequest& req,
     return 0;
   }
 
-  auto& tokens = std::get<std::vector<int>>(req.prompt);
+  auto& tokens = std::get<std::vector<uint32_t>>(req.prompt);
   const size_t skip = static_cast<size_t>(matchedTokens);
   if (skip >= tokens.size()) {
     return 0;

--- a/tt-media-server/cpp_server/include/sockets/inter_server_service.hpp
+++ b/tt-media-server/cpp_server/include/sockets/inter_server_service.hpp
@@ -84,7 +84,7 @@ class InterServerService {
    */
   bool sendPrefillRequest(uint32_t taskId,
                           const std::vector<uint64_t>& registrationHashes,
-                          const std::vector<int64_t>& tokenIds,
+                          const std::vector<uint32_t>& tokenIds,
                           std::optional<int> maxTokens = std::nullopt,
                           std::optional<uint32_t> slotId = std::nullopt,
                           const tt::domain::llm::SamplingParams& sampling = {},

--- a/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
@@ -39,7 +39,7 @@ struct SerializableMessage {
 struct PrefillRequestMessage {
   uint32_t taskId;
   std::vector<uint64_t> registrationHashes;
-  std::vector<int64_t> tokenIds;
+  std::vector<uint32_t> tokenIds;
   std::optional<int> maxTokens;
   std::optional<uint32_t> slotId;
   std::optional<float> temperature;
@@ -69,7 +69,7 @@ struct PrefillRequestMessage {
   static PrefillRequestMessage read(Archive& ar) {
     uint32_t tid;
     std::vector<uint64_t> hashes;
-    std::vector<int64_t> tids;
+    std::vector<uint32_t> tids;
     int mt;
     uint32_t sid;
     bool hasTemp;
@@ -111,7 +111,7 @@ struct PrefillResultMessage {
   uint32_t taskId;
   std::string generatedText;
   bool error = false;
-  std::vector<int64_t> tokenIds;
+  std::vector<uint32_t> tokenIds;
   std::optional<int> remainingTokens;
   std::optional<uint32_t> slotId;
   std::optional<float> temperature;
@@ -146,7 +146,7 @@ struct PrefillResultMessage {
   static PrefillResultMessage read(Archive& ar) {
     uint32_t tid;
     std::string genText;
-    std::vector<int64_t> tids;
+    std::vector<uint32_t> tids;
     int rt;
     uint32_t sid;
     bool err;

--- a/tt-media-server/cpp_server/include/utils/conversation_hasher.hpp
+++ b/tt-media-server/cpp_server/include/utils/conversation_hasher.hpp
@@ -139,7 +139,7 @@ struct PrefixCachingInfo {
  * representation of the int sequence so two callers produce matching hashes
  * iff the underlying token ids are identical.
  */
-uint64_t hashTokenPrefix(std::span<const int> tokens);
+uint64_t hashTokenPrefix(std::span<const uint32_t> tokens);
 
 /**
  * Compute prefix caching routing information from a tokenized prompt.
@@ -149,7 +149,7 @@ uint64_t hashTokenPrefix(std::span<const int> tokens);
  * @return Complete routing information for prefix caching (per-block hashes).
  */
 PrefixCachingInfo computePrefixCachingInfoFromTokens(
-    std::span<const int> tokens);
+    std::span<const uint32_t> tokens);
 
 /**
  * Compute per-block KV cache hashes using vLLM's prefix caching approach.
@@ -170,8 +170,8 @@ PrefixCachingInfo computePrefixCachingInfoFromTokens(
  * @return Vector of per-block hashes (one per full block). Empty if the
  *         sequence is shorter than one block.
  */
-std::vector<uint64_t> getPrefixCacheHashesByBlocks(std::span<const int> tokens,
-                                                   uint64_t parentHash = 0);
+std::vector<uint64_t> getPrefixCacheHashesByBlocks(
+    std::span<const uint32_t> tokens, uint64_t parentHash = 0);
 
 /**
  * Compute per-block KV cache hashes, filtering out thinking tokens.
@@ -191,7 +191,8 @@ std::vector<uint64_t> getPrefixCacheHashesByBlocks(std::span<const int> tokens,
  * @return Vector of BlockHashInfo (one per full block of non-thinking tokens).
  */
 std::vector<BlockHashInfo> getPrefixCacheHashesByBlocksWithThinking(
-    std::span<const int> tokens, int64_t thinkStartId, int64_t thinkEndId,
-    uint64_t parentHash = 0, uint32_t parentThinkCount = 0);
+    std::span<const uint32_t> tokens, uint32_t thinkStartId,
+    uint32_t thinkEndId, uint64_t parentHash = 0,
+    uint32_t parentThinkCount = 0);
 
 }  // namespace tt::utils

--- a/tt-media-server/cpp_server/include/utils/tokenizers/deepseek_tokenizer.hpp
+++ b/tt-media-server/cpp_server/include/utils/tokenizers/deepseek_tokenizer.hpp
@@ -12,11 +12,13 @@ class DeepseekTokenizer final : public Tokenizer {
   using Tokenizer::Tokenizer;
 
   std::string modelName() const { return "deepseek-ai/DeepSeek-R1-0528"; }
-  std::vector<int64_t> stopTokenIds() const { return {1}; }
+  std::vector<uint32_t> stopTokenIds() const { return {1}; }
 
   // `<｜Assistant｜>` is a single special token (id 128804) and ends every
   // assistant generation prompt in DeepSeek's chat template.
-  std::vector<int> assistantHeaderSequence() const override { return {128804}; }
+  std::vector<uint32_t> assistantHeaderSequence() const override {
+    return {128804};
+  }
 
   std::string applyChatTemplate(
       const std::vector<tt::domain::llm::ChatMessage>& messages,

--- a/tt-media-server/cpp_server/include/utils/tokenizers/llama_tokenizer.hpp
+++ b/tt-media-server/cpp_server/include/utils/tokenizers/llama_tokenizer.hpp
@@ -12,13 +12,15 @@ class LlamaTokenizer final : public Tokenizer {
   using Tokenizer::Tokenizer;
 
   std::string modelName() const { return "meta-llama/Llama-3.1-8B-Instruct"; }
-  std::vector<int64_t> stopTokenIds() const { return {128001, 128008, 128009}; }
+  std::vector<uint32_t> stopTokenIds() const {
+    return {128001, 128008, 128009};
+  }
 
   // The assistant generation prompt is the multi-token sequence
   // `<|start_header_id|>assistant<|end_header_id|>\n\n`. Encoding it once
   // and matching the resulting id sequence in inbound prompts is what
   // anchors token-level prefix caching for Llama-3 chat templates.
-  std::vector<int> assistantHeaderSequence() const override;
+  std::vector<uint32_t> assistantHeaderSequence() const override;
 
   std::string applyChatTemplate(
       const std::vector<tt::domain::llm::ChatMessage>& messages,

--- a/tt-media-server/cpp_server/include/utils/tokenizers/tokenizer.hpp
+++ b/tt-media-server/cpp_server/include/utils/tokenizers/tokenizer.hpp
@@ -22,8 +22,7 @@ namespace tt::utils::tokenizers {
 using namespace tt::domain::llm;
 
 // Matches tt_llm_engine EMPTY_TOKEN: disables thinking-phase token matching.
-constexpr int64_t kNoTokenId =
-    static_cast<int64_t>(std::numeric_limits<uint32_t>::max());
+constexpr uint32_t kNoTokenId = std::numeric_limits<uint32_t>::max();
 
 /**
  * Parsed tokenizer_config.json (Hugging Face format).
@@ -84,7 +83,7 @@ class Tokenizer {
    * Encode text to token IDs.
    * @throws std::runtime_error if tokenizer not loaded.
    */
-  std::vector<int> encode(const std::string& text) const;
+  std::vector<uint32_t> encode(const std::string& text) const;
 
   /**
    * Decode token IDs to text.
@@ -93,14 +92,14 @@ class Tokenizer {
    *   before decoding. If false, all tokens are decoded as-is.
    * @throws std::runtime_error if tokenizer not loaded.
    */
-  std::string decode(const std::vector<int>& tokenIds,
+  std::string decode(const std::vector<uint32_t>& tokenIds,
                      bool skipSpecialTokens = true) const;
 
   /** Check if tokenizer is loaded and ready. */
   bool isLoaded() const;
 
   virtual std::string modelName() const = 0;
-  virtual std::vector<int64_t> stopTokenIds() const = 0;
+  virtual std::vector<uint32_t> stopTokenIds() const = 0;
 
   /**
    * Token id sequence that ends an assistant generation prompt in the
@@ -117,7 +116,7 @@ class Tokenizer {
    * Returns an empty vector when the tokenizer does not expose a stable
    * assistant marker; callers must then treat every request as fresh.
    */
-  virtual std::vector<int> assistantHeaderSequence() const { return {}; }
+  virtual std::vector<uint32_t> assistantHeaderSequence() const { return {}; }
 
   /**
    * Apply the model-specific chat template to a list of messages.
@@ -145,7 +144,7 @@ class Tokenizer {
      * token is part of an incomplete multi-byte UTF-8 sequence still being
      * buffered.
      */
-    std::string step(int tokenId);
+    std::string step(uint32_t tokenId);
 
     /**
      * Flush any remaining buffered tokens (call on final token).
@@ -156,7 +155,7 @@ class Tokenizer {
 
    private:
     const Tokenizer& tokenizer_;
-    std::vector<int> pending_;
+    std::vector<uint32_t> pending_;
     bool skipSpecialTokens_;
   };
 
@@ -168,7 +167,7 @@ class Tokenizer {
  protected:
   std::unique_ptr<::tokenizers::Tokenizer> tok_;
   TokenizerConfig cfg_;
-  std::unordered_set<int> specialTokenIds_;
+  std::unordered_set<uint32_t> specialTokenIds_;
 };
 
 /**
@@ -205,16 +204,16 @@ const Tokenizer& activeTokenizer();
  */
 struct StaticTokenizerInfo {
   std::string_view modelName;
-  std::vector<int64_t> stopTokenIds;
-  int64_t eosTokenId = kNoTokenId;
-  std::vector<int> assistantHeaderSequence;
-  int64_t thinkStartTokenId = kNoTokenId;
-  int64_t thinkEndTokenId = kNoTokenId;
+  std::vector<uint32_t> stopTokenIds;
+  uint32_t eosTokenId = kNoTokenId;
+  std::vector<uint32_t> assistantHeaderSequence;
+  uint32_t thinkStartTokenId = kNoTokenId;
+  uint32_t thinkEndTokenId = kNoTokenId;
 };
 
 /** Per-model thinking marker token IDs (O(1), no tokenizer.json parse). */
-std::pair<int64_t, int64_t> thinkTokenIdsFor(config::ModelType model);
-std::pair<int64_t, int64_t> thinkTokenIds();
+std::pair<uint32_t, uint32_t> thinkTokenIdsFor(config::ModelType model);
+std::pair<uint32_t, uint32_t> thinkTokenIds();
 
 /**
  * Static constants for `model`. Throws std::invalid_argument if no entry

--- a/tt-media-server/cpp_server/src/domain/llm/sequence.cpp
+++ b/tt-media-server/cpp_server/src/domain/llm/sequence.cpp
@@ -16,7 +16,7 @@ namespace tt::domain::llm {
 using Config = tt::config::LLMConfig;
 
 Sequence::Sequence(uint32_t taskId, int blockSize,
-                   std::vector<int64_t> inputTokenIds,
+                   std::vector<uint32_t> inputTokenIds,
                    const SamplingParams& inputSamplingParams)
     : taskId(taskId),
       status(SequenceStatus::WAITING),
@@ -30,7 +30,7 @@ Sequence::Sequence(uint32_t taskId, int blockSize,
 }
 
 Sequence::Sequence(uint32_t taskId, int blockSize,
-                   std::vector<int64_t> inputTokenIds, size_t numPromptTokens,
+                   std::vector<uint32_t> inputTokenIds, size_t numPromptTokens,
                    std::optional<uint32_t> slotId,
                    std::optional<uint32_t> prefillSlotId, bool continuation,
                    bool disaggregated,
@@ -60,7 +60,7 @@ Sequence::Sequence(uint32_t taskId, int blockSize,
   }
 }
 
-std::vector<int64_t> Sequence::block(size_t i) const {
+std::vector<uint32_t> Sequence::block(size_t i) const {
   size_t n = numBlocks();
   if (i >= n) {
     throw std::out_of_range("block index out of range");
@@ -70,14 +70,14 @@ std::vector<int64_t> Sequence::block(size_t i) const {
   return {tokenIds.begin() + start, tokenIds.begin() + end};
 }
 
-std::vector<int64_t> Sequence::completionTokenIds() const {
+std::vector<uint32_t> Sequence::completionTokenIds() const {
   if (numPromptTokens >= tokenIds.size()) {
     return {};
   }
   return {tokenIds.begin() + numPromptTokens, tokenIds.end()};
 }
 
-void Sequence::appendToken(int64_t tokenId) {
+void Sequence::appendToken(uint32_t tokenId) {
   tokenIds.push_back(tokenId);
   lastToken = tokenId;
 }
@@ -93,7 +93,7 @@ void Sequence::serialize(std::ostream& os) const {
            sizeof(numCachedTokens));
   os.write(reinterpret_cast<const char*>(&tokenIdsSize), sizeof(tokenIdsSize));
   os.write(reinterpret_cast<const char*>(tokenIds.data()),
-           tokenIdsSize * sizeof(int64_t));
+           tokenIdsSize * sizeof(uint32_t));
   os.write(reinterpret_cast<const char*>(&blockTableSize),
            sizeof(blockTableSize));
   os.write(reinterpret_cast<const char*>(blockTable.data()),
@@ -150,7 +150,7 @@ Sequence Sequence::deserialize(std::istream& is) {
 
   Config defaultConfig;
   Sequence seq(taskId, static_cast<int>(defaultConfig.kvcache_block_size),
-               std::vector<int64_t>{});
+               std::vector<uint32_t>{});
 
   is.read(reinterpret_cast<char*>(&seq.lastToken), sizeof(seq.lastToken));
   is.read(reinterpret_cast<char*>(&seq.numPromptTokens),
@@ -162,7 +162,7 @@ Sequence Sequence::deserialize(std::istream& is) {
   is.read(reinterpret_cast<char*>(&tokenIdsSize), sizeof(tokenIdsSize));
   seq.tokenIds.resize(tokenIdsSize);
   is.read(reinterpret_cast<char*>(seq.tokenIds.data()),
-          tokenIdsSize * sizeof(int64_t));
+          tokenIdsSize * sizeof(uint32_t));
 
   size_t blockTableSize;
   is.read(reinterpret_cast<char*>(&blockTableSize), sizeof(blockTableSize));

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -50,7 +50,7 @@ bool Session::clearInFlight() {
 }
 
 void Session::initTokenAccumulator(
-    std::vector<int> deltaTokens,
+    std::vector<uint32_t> deltaTokens,
     std::vector<utils::BlockHashInfo> initialBlocks,
     std::function<void(const std::string&,
                        const std::vector<utils::BlockHashInfo>&)>
@@ -75,7 +75,7 @@ void Session::initTokenAccumulator(
   accumulatedThinkTokens_ = parentThinkCount_;
 }
 
-void Session::addGeneratedToken(int tokenId) {
+void Session::addGeneratedToken(uint32_t tokenId) {
   generatedTokens_.push_back(tokenId);
 
   // Track thinking state using the same marker rules as prefix hashing.
@@ -84,9 +84,9 @@ void Session::addGeneratedToken(int tokenId) {
       thinkEndTokenId_ != utils::tokenizers::kNoTokenId;
   if (!thinkingEnabled) return;
 
-  if (tokenId == static_cast<int>(thinkStartTokenId_)) {
+  if (tokenId == thinkStartTokenId_) {
     inThinkingBlock_ = true;
-  } else if (tokenId == static_cast<int>(thinkEndTokenId_)) {
+  } else if (tokenId == thinkEndTokenId_) {
     inThinkingBlock_ = false;
   } else if (inThinkingBlock_) {
     ++accumulatedThinkTokens_;  // Only content tokens, not markers
@@ -97,7 +97,7 @@ void Session::finalizeAndRegisterHashes() {
   if (!onComplete_) return;
 
   // Combine delta prompt + generated tokens
-  std::vector<int> allDeltaTokens = deltaTokens_;
+  std::vector<uint32_t> allDeltaTokens = deltaTokens_;
   allDeltaTokens.insert(allDeltaTokens.end(), generatedTokens_.begin(),
                         generatedTokens_.end());
 

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
@@ -88,7 +88,7 @@ TokenChunk toTokenChunk(const tt::domain::llm::LLMStreamChunk& chunk,
                         bool isFinal) {
   TokenChunk out;
   if (!chunk.choices.empty() && chunk.choices.front().token_id.has_value()) {
-    out.token_ids = {static_cast<int>(*chunk.choices.front().token_id)};
+    out.token_ids = {static_cast<uint32_t>(*chunk.choices.front().token_id)};
   }
   if (isFinal) {
     if (!chunk.choices.empty()) {
@@ -213,8 +213,8 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
     // prompt (Kimi) begins generation already inside the reasoning span; other
     // reasoning models emit <think> themselves. Reasoning ends at </think>.
     struct UsageAccum {
-      int64_t thinkStart;
-      int64_t thinkEnd;
+      uint32_t thinkStart;
+      uint32_t thinkEnd;
       bool inReasoning;
       int completion = 0;
       int reasoning = 0;
@@ -228,9 +228,9 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
       usage->thinkStart = think.first;
       usage->thinkEnd = think.second;
       const auto kNo = tt::utils::tokenizers::kNoTokenId;
-      usage->inReasoning =
-          usage->thinkStart != kNo && !dynReq.token_ids.empty() &&
-          dynReq.token_ids.back() == static_cast<int>(usage->thinkStart);
+      usage->inReasoning = usage->thinkStart != kNo &&
+                           !dynReq.token_ids.empty() &&
+                           dynReq.token_ids.back() == usage->thinkStart;
     }
 
     // Capture which loop thread is serving this request — combined with the
@@ -371,11 +371,12 @@ GenerateHandler DynamoEndpoint::makeGenerateHandler() {
                 if (sessionPtr && !chunk.choices.empty() &&
                     chunk.choices[0].token_id) {
                   sessionPtr->addGeneratedToken(
-                      static_cast<int>(*chunk.choices[0].token_id));
+                      static_cast<uint32_t>(*chunk.choices[0].token_id));
                 }
 
                 if (!chunk.choices.empty() && chunk.choices[0].token_id) {
-                  const int tid = static_cast<int>(*chunk.choices[0].token_id);
+                  const uint32_t tid =
+                      static_cast<uint32_t>(*chunk.choices[0].token_id);
                   const auto kNo = tt::utils::tokenizers::kNoTokenId;
                   usage->completion += 1;
                   if (usage->thinkStart != kNo && tid == usage->thinkStart) {

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
@@ -56,7 +56,7 @@ std::string dumpJsonCompact(const Json::Value& v);  // defined below
 /// arrays, strings, floats, etc.) so the caller can fall back to the full JSON
 /// parser. Tolerates whitespace, negative ints, and a trailing comma.
 size_t scanIntArray(const char* s, size_t start, size_t n,
-                    std::vector<int>& out) {
+                    std::vector<uint32_t>& out) {
   if (start >= n || s[start] != '[') return std::string_view::npos;
   size_t i = start + 1;
   auto isWs = [](char c) {
@@ -82,7 +82,7 @@ size_t scanIntArray(const char* s, size_t start, size_t n,
       v = v * 10 + (s[i] - '0');
       ++i;
     }
-    out.push_back(neg ? -static_cast<int>(v) : static_cast<int>(v));
+    out.push_back(static_cast<uint32_t>(neg ? -v : v));
   }
   return std::string_view::npos;  // unterminated array
 }
@@ -311,7 +311,7 @@ GenerateRequest parse_generate_request(const std::vector<uint8_t>& bodyBytes) {
 
   size_t arrayStart = 0;
   if (findTokenIdsArray(body, arrayStart)) {
-    std::vector<int> ids;
+    std::vector<uint32_t> ids;
     const size_t arrayEnd = scanIntArray(data, arrayStart, n, ids);
     if (arrayEnd != std::string_view::npos) {
       std::string reduced;
@@ -335,7 +335,7 @@ GenerateRequest parse_generate_request(const std::vector<uint8_t>& bodyBytes) {
   if (j.isMember("token_ids") && j["token_ids"].isArray()) {
     req.token_ids.reserve(j["token_ids"].size());
     for (const auto& t : j["token_ids"]) {
-      req.token_ids.push_back(t.asInt());
+      req.token_ids.push_back(static_cast<uint32_t>(t.asUInt()));
     }
   }
   populateGenerateFields(req, j);
@@ -356,7 +356,7 @@ std::vector<uint8_t> encode_stream_chunk(const TokenChunk& chunk) {
 
   Json::Value tokenData(Json::objectValue);
   Json::Value tokenIds(Json::arrayValue);
-  for (int t : chunk.token_ids) tokenIds.append(t);
+  for (uint32_t t : chunk.token_ids) tokenIds.append(t);
   tokenData["token_ids"] = std::move(tokenIds);
   if (chunk.finish_reason.has_value()) {
     tokenData["finish_reason"] = *chunk.finish_reason;

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_decode_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_decode_runner.cpp
@@ -70,7 +70,7 @@ bool BlazeDecodeRunner::warmup() {
   warmupParams.max_tokens = 1;
   warmupParams.ignore_eos = true;
 
-  std::vector<int64_t> warmupTokens = {1};
+  std::vector<uint32_t> warmupTokens = {1};
   uint32_t warmupTaskId = 0;
 
   auto warmupSeq = std::make_unique<tt::domain::llm::Sequence>(

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_prefill_runner.cpp
@@ -69,7 +69,7 @@ bool BlazePrefillRunner::warmup() {
   warmupParams.max_tokens = 1;
   warmupParams.ignore_eos = true;
 
-  std::vector<int64_t> warmupTokens(tt::config::prefillChunkSize(), 12345);
+  std::vector<uint32_t> warmupTokens(tt::config::prefillChunkSize(), 12345);
   uint32_t warmupTaskId = 0;
 
   auto warmupSeq = std::make_unique<tt::domain::llm::Sequence>(

--- a/tt-media-server/cpp_server/src/runtime/runners/llama_model_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/llama_model_runner.cpp
@@ -96,7 +96,7 @@ void LlamaModelRunner::run(const std::vector<Sequence*>& seqs, bool isPrefill) {
       for (Sequence* seq : seqs) {
         py::list tokenIds;
         if (isPrefill) {
-          for (int64_t t : seq->getTokenIds()) tokenIds.append(t);
+          for (uint32_t t : seq->getTokenIds()) tokenIds.append(t);
         } else {
           tokenIds.append(seq->getTokenIds().back());
         }

--- a/tt-media-server/cpp_server/src/runtime/runners/llm_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/llm_runner.cpp
@@ -40,7 +40,7 @@ LLMRunner::LLMRunner(const Config& config, ipc::IResultQueue* resultQueue,
     auto encodedVocab = tok.getEncodedVocab();
     int vocabSize = static_cast<int>(encodedVocab.size());
     std::vector<int32_t> stopIds;
-    for (int64_t id : tt::utils::tokenizers::staticInfo().stopTokenIds) {
+    for (uint32_t id : tt::utils::tokenizers::staticInfo().stopTokenIds) {
       stopIds.push_back(static_cast<int32_t>(id));
     }
     guidedDecoder = std::make_unique<GuidedDecoderManager>(encodedVocab,
@@ -88,7 +88,7 @@ LLMRunner::LLMRunner(const Config& config, ipc::IResultQueue* resultQueue,
     }
 
     std::vector<Sequence*> seqs = {seq};
-    std::vector<int64_t> tokenIds = {static_cast<int64_t>(result.tokenId)};
+    std::vector<uint32_t> tokenIds = {result.tokenId};
     scheduler->postprocess(seqs, tokenIds);
 
     bool finished = seq->isFinished();

--- a/tt-media-server/cpp_server/src/runtime/runners/llm_runner/block_manager.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/llm_runner/block_manager.cpp
@@ -16,7 +16,7 @@ using Sequence = tt::domain::llm::Sequence;
 
 Block::Block(int blockId) : blockId(blockId) {}
 
-void Block::update(int64_t hash, std::vector<int64_t> tokenIds) {
+void Block::update(int64_t hash, std::vector<uint32_t> tokenIds) {
   this->hash = hash;
   this->tokenIds = std::move(tokenIds);
 }
@@ -41,7 +41,7 @@ BlockManager::BlockManager(size_t numBlocks, size_t blockSize)
   }
 }
 
-int64_t BlockManager::computeHash(const std::vector<int64_t>& tokenIds,
+int64_t BlockManager::computeHash(const std::vector<uint32_t>& tokenIds,
                                   int64_t prefix) {
   return hashTokenIds(tokenIds, prefix);
 }
@@ -87,7 +87,7 @@ bool BlockManager::allocate(Sequence& seq) {
   int64_t h = -1;
   bool cacheMiss = false;
   for (size_t i = 0; i < seq.numBlocks(); ++i) {
-    std::vector<int64_t> tokenIds = seq.block(i);
+    std::vector<uint32_t> tokenIds = seq.block(i);
     h = (tokenIds.size() == blockSize) ? computeHash(tokenIds, h) : -1;
     auto it = hashToBlockId.find(h);
     int blockId = (it != hashToBlockId.end()) ? it->second : -1;
@@ -161,7 +161,7 @@ void BlockManager::mayAppend(Sequence& seq) {
     assert(lastBlock.hash == -1);
     TT_LOG_DEBUG("[block_manager] may_append task_id={} fill_last_block len={}",
                  seq.taskId, len);
-    std::vector<int64_t> tokenIds = seq.block(seq.numBlocks() - 1);
+    std::vector<uint32_t> tokenIds = seq.block(seq.numBlocks() - 1);
     int64_t prefix =
         (blockTable.size() > 1)
             ? blocks[static_cast<size_t>(blockTable[blockTable.size() - 2])]

--- a/tt-media-server/cpp_server/src/runtime/runners/llm_runner/hash.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/llm_runner/hash.cpp
@@ -10,7 +10,7 @@ namespace tt::runners::llm_engine {
 static constexpr uint64_t K_FNV_PRIME = 1099511628211ULL;
 static constexpr uint64_t K_FNV_OFFSET = 0xcbf29ce484222325ULL;
 
-int64_t hashTokenIds(const std::vector<int64_t>& tokenIds, int64_t prefix) {
+int64_t hashTokenIds(const std::vector<uint32_t>& tokenIds, int64_t prefix) {
   uint64_t h = K_FNV_OFFSET;
   if (prefix != -1) {
     uint64_t p = static_cast<uint64_t>(prefix);
@@ -21,7 +21,7 @@ int64_t hashTokenIds(const std::vector<int64_t>& tokenIds, int64_t prefix) {
     }
   }
   const uint8_t* data = reinterpret_cast<const uint8_t*>(tokenIds.data());
-  size_t len = tokenIds.size() * sizeof(int64_t);
+  size_t len = tokenIds.size() * sizeof(uint32_t);
   for (size_t i = 0; i < len; ++i) {
     h ^= data[i];
     h *= K_FNV_PRIME;

--- a/tt-media-server/cpp_server/src/runtime/runners/schedulers/scheduler.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/schedulers/scheduler.cpp
@@ -45,7 +45,7 @@ bool Scheduler::isFinished() const {
   return prefillQueue->empty() && decodeQueue.empty();
 }
 
-Sequence& Scheduler::addRequest(uint32_t taskId, std::vector<int64_t> prompt,
+Sequence& Scheduler::addRequest(uint32_t taskId, std::vector<uint32_t> prompt,
                                 const SamplingParams& params) {
   auto seq =
       std::make_unique<Sequence>(std::move(taskId), static_cast<int>(blockSize),
@@ -160,11 +160,11 @@ void Scheduler::preempt(Sequence& seq) {
 }
 
 void Scheduler::postprocess(std::vector<Sequence*>& seqs,
-                            const std::vector<int64_t>& tokenIds) {
+                            const std::vector<uint32_t>& tokenIds) {
   ZoneScopedN("Scheduler::postprocess");
   for (size_t i = 0; i < seqs.size(); ++i) {
     Sequence* seq = seqs[i];
-    int64_t tokenId = tokenIds[i];
+    uint32_t tokenId = tokenIds[i];
     seq->appendToken(tokenId);
 
     bool isStopToken = stopTokenIds.count(tokenId) > 0;

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -96,8 +96,8 @@ void DisaggregationService::setupSocketHandlers() {
             // free slot, and the prompt is just that single trailing token.
             request.kv_position_id =
                 static_cast<uint32_t>(message.tokenIds.size() - 1);
-            request.prompt.emplace<std::vector<int>>(message.tokenIds.end() - 1,
-                                                     message.tokenIds.end());
+            request.prompt.emplace<std::vector<uint32_t>>(
+                message.tokenIds.end() - 1, message.tokenIds.end());
             request.max_tokens = message.remainingTokens;
             request.slotId = message.slotId;
             // Restore the sampling subset echoed back from the prefill server.
@@ -160,8 +160,8 @@ void DisaggregationService::setupSocketHandlers() {
 
           auto maxTokens = message.maxTokens;
 
-          request->prompt.emplace<std::vector<int>>(message.tokenIds.begin(),
-                                                    message.tokenIds.end());
+          request->prompt.emplace<std::vector<uint32_t>>(
+              message.tokenIds.begin(), message.tokenIds.end());
           auto slotId = message.slotId;
           request->slotId = slotId;
           request->decode_position_id = message.decodePositionId;
@@ -184,7 +184,7 @@ void DisaggregationService::setupSocketHandlers() {
                 // resolvePrefillSession (full prompt - remaining delta).
                 const size_t fullPromptTokens = message.tokenIds.size();
                 const size_t trimmedPromptTokens =
-                    std::get<std::vector<int>>(request->prompt).size();
+                    std::get<std::vector<uint32_t>>(request->prompt).size();
                 // Cached (reused) prompt tokens = the leading prefix this
                 // prefill did NOT recompute = what resolvePrefillSession
                 // trimmed off its own prefix-cache hit (fullPrompt - remaining
@@ -449,7 +449,7 @@ void DisaggregationService::handleStreamingRequest(
 
     auto maxTokens = request.max_tokens;
     auto slotId = request.slotId;
-    auto tokenIds = std::get<std::vector<int>>(request.prompt);
+    auto tokenIds = std::get<std::vector<uint32_t>>(request.prompt);
     // kv_position_id is the first free KV index (the matched prefix occupies
     // [0, kv_position_id)), which is exactly the position the prefill server
     // should resume writing from.
@@ -462,9 +462,8 @@ void DisaggregationService::handleStreamingRequest(
     int decodeSkipTokens = decodePositionId - request.accumulated_think_tokens;
 
     auto sent = socketService->sendPrefillRequest(
-        request.task_id, registrationHashes,
-        std::vector<int64_t>(tokenIds.begin(), tokenIds.end()), maxTokens,
-        slotId, tt::utils::mapper::mapSamplingParams(request), decodePositionId,
+        request.task_id, registrationHashes, tokenIds, maxTokens, slotId,
+        tt::utils::mapper::mapSamplingParams(request), decodePositionId,
         decodeSkipTokens);
 
     if (!sent) {

--- a/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
@@ -44,7 +44,7 @@ namespace {
  */
 tt::utils::PrefixCachingInfo computeRoutingInfo(
     const tt::domain::llm::LLMRequest& req) {
-  if (auto* tokens = std::get_if<std::vector<int>>(&req.prompt)) {
+  if (auto* tokens = std::get_if<std::vector<uint32_t>>(&req.prompt)) {
     // Full token-id dump: capped so we don't blow up the log line on long
     // prompts but keeps the head/tail context that matters for diagnosing
     // boundary detection. Set DYNAMO_LOG_FULL_TOKENS=1 to disable the cap.
@@ -74,7 +74,7 @@ tt::utils::PrefixCachingInfo computeRoutingInfo(
     const auto& header =
         tt::utils::tokenizers::staticInfo().assistantHeaderSequence;
     std::string headerStr;
-    for (int t : header) {
+    for (uint32_t t : header) {
       if (!headerStr.empty()) headerStr += ",";
       headerStr += std::to_string(t);
     }
@@ -133,7 +133,7 @@ void LLMPipeline::resolveSession(
     std::function<void()> cancelFn) const {
   size_t promptTokens = 0;
   const char* promptKind = "string";
-  if (auto* toks = std::get_if<std::vector<int>>(&req->prompt)) {
+  if (auto* toks = std::get_if<std::vector<uint32_t>>(&req->prompt)) {
     promptTokens = toks->size();
     promptKind = "tokens";
   }
@@ -215,7 +215,8 @@ void LLMPipeline::resolveSession(
             "thinkTokens={} deltaTokens={}",
             req->task_id, matchedTokens, thinkTokens, req->prompt_tokens_count);
 
-        if (auto* deltaTokens = std::get_if<std::vector<int>>(&req->prompt)) {
+        if (auto* deltaTokens =
+                std::get_if<std::vector<uint32_t>>(&req->prompt)) {
           req->session->initTokenAccumulator(
               *deltaTokens, routingInfo.blocks,
               [mgr = sessionManager_](
@@ -292,8 +293,8 @@ void LLMPipeline::resolveSession(
         req->accumulated_think_tokens =
             static_cast<int>(acquired->accumulatedThinkTokens);
 
-        std::vector<int> fullPrompt;
-        if (auto* p = std::get_if<std::vector<int>>(&req->prompt)) {
+        std::vector<uint32_t> fullPrompt;
+        if (auto* p = std::get_if<std::vector<uint32_t>>(&req->prompt)) {
           fullPrompt = *p;
         }
         session_resolution::applyDeltaPrompt(*req, matchedTokens,
@@ -410,8 +411,8 @@ void LLMPipeline::resolveSession(
           mgr->registerResponseId(session.getSessionId(), *req->responseId);
         }
 
-        std::vector<int> fullPrompt;
-        if (auto* p = std::get_if<std::vector<int>>(&req->prompt)) {
+        std::vector<uint32_t> fullPrompt;
+        if (auto* p = std::get_if<std::vector<uint32_t>>(&req->prompt)) {
           fullPrompt = *p;
         }
 
@@ -542,11 +543,11 @@ void LLMPipeline::dispatchGeneration(
             *request.kv_position_id -
             static_cast<uint32_t>(request.accumulated_think_tokens);
         const auto fullPromptTokens =
-            std::get<std::vector<int>>(request.prompt).size();
+            std::get<std::vector<uint32_t>>(request.prompt).size();
         session_resolution::applyDeltaPrompt(request, matchedTokens);
-        reusedPrefixTokens =
-            static_cast<int>(fullPromptTokens -
-                             std::get<std::vector<int>>(request.prompt).size());
+        reusedPrefixTokens = static_cast<int>(
+            fullPromptTokens -
+            std::get<std::vector<uint32_t>>(request.prompt).size());
       }
       TT_LOG_DEBUG("[LLMPipeline] Using prefill on decode for sessionId: {}",
                    request.sessionId.value_or("none"));

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -58,7 +58,7 @@ void LLMService::init(std::shared_ptr<tt::ipc::ITaskQueue> taskQueue,
   this->maxQueueSize = maxQueueSize;
 
   const auto& stopIds = tt::utils::tokenizers::staticInfo().stopTokenIds;
-  stopTokenSet = std::unordered_set<int64_t>(stopIds.begin(), stopIds.end());
+  stopTokenSet = std::unordered_set<uint32_t>(stopIds.begin(), stopIds.end());
 
   TT_LOG_INFO("[LLMService] Initialized (workers={})",
               this->workerManager->numWorkers());
@@ -146,14 +146,14 @@ std::string decodeToken(
     decoder = tt::utils::tokenizers::activeTokenizer().createStreamDecoder(
         skipSpecial);
   }
-  std::string delta = decoder->step(static_cast<int>(tokenId));
+  std::string delta = decoder->step(tokenId);
   if (isFinal) delta += decoder->flush();
   return delta;
 }
 
 LLMStreamChunk buildStreamChunk(
     const ipc::SharedToken& token, const std::string& delta,
-    const std::unordered_set<int64_t>& stopTokenSet) {
+    const std::unordered_set<uint32_t>& stopTokenSet) {
   LLMStreamChunk response{token.task_id};
   response.id = std::to_string(token.task_id);
   response.created = std::chrono::duration_cast<std::chrono::seconds>(
@@ -164,11 +164,11 @@ LLMStreamChunk buildStreamChunk(
   choice.index = token.token_index;
   choice.text = delta;
 
-  choice.token_id = static_cast<int64_t>(token.token_id);
+  choice.token_id = static_cast<uint32_t>(token.token_id);
   choice.spec_accepts = token.spec_accepts;
   choice.spec_rejects = token.spec_rejects;
   if (token.isFinal()) {
-    bool isStop = stopTokenSet.count(static_cast<int64_t>(token.token_id)) > 0;
+    bool isStop = stopTokenSet.count(static_cast<uint32_t>(token.token_id)) > 0;
     choice.finish_reason = isStop ? "stop" : "length";
   }
   response.choices.push_back(std::move(choice));
@@ -355,8 +355,8 @@ void LLMService::produceStream(
                             request.skip_text_decode};
   streamCallbacks.insert(taskId, std::move(entry));
 
-  auto prompt = std::get<std::vector<int>>(request.prompt);
-  std::vector<int64_t> tokenIds(prompt.begin(), prompt.end());
+  auto prompt = std::get<std::vector<uint32_t>>(request.prompt);
+  std::vector<uint32_t> tokenIds(prompt.begin(), prompt.end());
 
   tt::metrics::ServerMetrics::instance().onRequestSubmitted(
       taskId, static_cast<int>(tokenIds.size()));

--- a/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
+++ b/tt-media-server/cpp_server/src/sockets/inter_server_service.cpp
@@ -133,7 +133,7 @@ bool InterServerService::isEnabled() const { return enabled; }
 
 bool InterServerService::sendPrefillRequest(
     uint32_t taskId, const std::vector<uint64_t>& registrationHashes,
-    const std::vector<int64_t>& tokenIds, std::optional<int> maxTokens,
+    const std::vector<uint32_t>& tokenIds, std::optional<int> maxTokens,
     std::optional<uint32_t> slotId,
     const tt::domain::llm::SamplingParams& sampling, int decodePositionId,
     int decodeSkipTokens) {

--- a/tt-media-server/cpp_server/src/utils/conversation_hasher.cpp
+++ b/tt-media-server/cpp_server/src/utils/conversation_hasher.cpp
@@ -106,7 +106,7 @@ std::string renderLastUserTurn(const std::vector<ChatMessage>& messages,
   return rendered;
 }
 
-uint64_t hashTokenPrefix(std::span<const int> tokens) {
+uint64_t hashTokenPrefix(std::span<const uint32_t> tokens) {
   if (tokens.empty()) {
     return 0;
   }
@@ -114,7 +114,7 @@ uint64_t hashTokenPrefix(std::span<const int> tokens) {
 }
 
 PrefixCachingInfo computePrefixCachingInfoFromTokens(
-    std::span<const int> tokens) {
+    std::span<const uint32_t> tokens) {
   PrefixCachingInfo info;
 
   // Hash non-thinking tokens into per-block hashes, tracking think counts.
@@ -128,8 +128,8 @@ PrefixCachingInfo computePrefixCachingInfoFromTokens(
   return info;
 }
 
-std::vector<uint64_t> getPrefixCacheHashesByBlocks(std::span<const int> tokens,
-                                                   uint64_t parentHash) {
+std::vector<uint64_t> getPrefixCacheHashesByBlocks(
+    std::span<const uint32_t> tokens, uint64_t parentHash) {
   const size_t firstBlockSize = tt::config::kvCacheFirstBlockSize();
   const size_t blockSize = tt::config::kvCacheBlockSize();
 
@@ -142,8 +142,8 @@ std::vector<uint64_t> getPrefixCacheHashesByBlocks(std::span<const int> tokens,
     std::vector<uint64_t> hashes;
     size_t offset = 0;
     while (offset + blockSize <= tokens.size()) {
-      const int* blockStart = tokens.data() + offset;
-      const size_t blockBytes = blockSize * sizeof(int);
+      const uint32_t* blockStart = tokens.data() + offset;
+      const size_t blockBytes = blockSize * sizeof(uint32_t);
       parentHash = XXH64(blockStart, blockBytes, parentHash);
       hashes.push_back(parentHash);
       offset += blockSize;
@@ -166,15 +166,15 @@ std::vector<uint64_t> getPrefixCacheHashesByBlocks(std::span<const int> tokens,
   // common prefix shared across conversations with the same model config.
 
   // First block (larger, covers system prompt / preamble)
-  const size_t firstBlockBytes = firstBlockSize * sizeof(int);
+  const size_t firstBlockBytes = firstBlockSize * sizeof(uint32_t);
   parentHash = XXH64(tokens.data(), firstBlockBytes, parentHash);
   hashes.push_back(parentHash);
 
   // Remaining blocks use the standard block size
   size_t offset = firstBlockSize;
   while (offset + blockSize <= tokens.size()) {
-    const int* blockStart = tokens.data() + offset;
-    const size_t blockBytes = blockSize * sizeof(int);
+    const uint32_t* blockStart = tokens.data() + offset;
+    const size_t blockBytes = blockSize * sizeof(uint32_t);
     parentHash = XXH64(blockStart, blockBytes, parentHash);
     hashes.push_back(parentHash);
     offset += blockSize;
@@ -184,8 +184,8 @@ std::vector<uint64_t> getPrefixCacheHashesByBlocks(std::span<const int> tokens,
 }
 
 std::vector<BlockHashInfo> getPrefixCacheHashesByBlocksWithThinking(
-    std::span<const int> tokens, int64_t thinkStartId, int64_t thinkEndId,
-    uint64_t parentHash, uint32_t parentThinkCount) {
+    std::span<const uint32_t> tokens, uint32_t thinkStartId,
+    uint32_t thinkEndId, uint64_t parentHash, uint32_t parentThinkCount) {
   const bool filterThinking = (thinkStartId != tokenizers::kNoTokenId &&
                                thinkEndId != tokenizers::kNoTokenId);
   const size_t firstBlockSize = tt::config::kvCacheFirstBlockSize();
@@ -196,21 +196,21 @@ std::vector<BlockHashInfo> getPrefixCacheHashesByBlocksWithThinking(
   }
 
   std::vector<BlockHashInfo> result;
-  std::vector<int> currentBlock;
+  std::vector<uint32_t> currentBlock;
   currentBlock.reserve(std::max(firstBlockSize, blockSize));
 
   bool inThinking = false;
   uint32_t thinkCount = parentThinkCount;
   size_t targetBlockSize = (parentHash == 0) ? firstBlockSize : blockSize;
 
-  for (int token : tokens) {
+  for (uint32_t token : tokens) {
     if (filterThinking) {
       // Mirror the session-side think marker state machine.
-      if (token == static_cast<int>(thinkStartId)) {
+      if (token == thinkStartId) {
         inThinking = true;
         continue;  // Skip marker, don't count
       }
-      if (token == static_cast<int>(thinkEndId)) {
+      if (token == thinkEndId) {
         inThinking = false;
         continue;  // Skip marker, don't count
       }
@@ -225,8 +225,8 @@ std::vector<BlockHashInfo> getPrefixCacheHashesByBlocksWithThinking(
 
     if (currentBlock.size() == targetBlockSize) {
       // Block complete: hash it
-      parentHash = XXH64(currentBlock.data(), currentBlock.size() * sizeof(int),
-                         parentHash);
+      parentHash = XXH64(currentBlock.data(),
+                         currentBlock.size() * sizeof(uint32_t), parentHash);
       result.push_back({parentHash, thinkCount});
       currentBlock.clear();
       targetBlockSize = blockSize;  // All subsequent blocks use standard size

--- a/tt-media-server/cpp_server/src/utils/tokenizers/llama_tokenizer.cpp
+++ b/tt-media-server/cpp_server/src/utils/tokenizers/llama_tokenizer.cpp
@@ -61,13 +61,13 @@ std::string LlamaTokenizer::applyChatTemplate(
   return out.str();
 }
 
-std::vector<int> LlamaTokenizer::assistantHeaderSequence() const {
+std::vector<uint32_t> LlamaTokenizer::assistantHeaderSequence() const {
   // Llama-3 chat template ends every assistant generation prompt with the
   // multi-token sequence `<|start_header_id|>assistant<|end_header_id|>\n\n`.
   // Encode it once on first use; the result is stable for the process
   // lifetime so it's safe to cache (per Tokenizer instance — Tokenizer is
   // thread-local).
-  static thread_local std::vector<int> cached;
+  static thread_local std::vector<uint32_t> cached;
   if (cached.empty()) {
     std::string header =
         std::string(llamaHeaderStart) + "assistant" + llamaHeaderEnd + "\n\n";

--- a/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
+++ b/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
@@ -23,8 +23,8 @@ namespace tt::utils::tokenizers {
 
 namespace {
 
-std::unordered_set<int> parseSpecialTokenIds(const std::string& jsonBlob) {
-  std::unordered_set<int> ids;
+std::unordered_set<uint32_t> parseSpecialTokenIds(const std::string& jsonBlob) {
+  std::unordered_set<uint32_t> ids;
   Json::CharReaderBuilder builder;
   Json::Value root;
   std::string errs;
@@ -37,7 +37,7 @@ std::unordered_set<int> parseSpecialTokenIds(const std::string& jsonBlob) {
   for (const auto& tok : added) {
     if (tok.isMember("special") && tok["special"].asBool() &&
         tok.isMember("id")) {
-      ids.insert(tok["id"].asInt());
+      ids.insert(static_cast<uint32_t>(tok["id"].asInt()));
     }
   }
   return ids;
@@ -88,15 +88,18 @@ Tokenizer::Tokenizer(const std::string& path) {
 
 bool Tokenizer::isLoaded() const { return tok_ != nullptr; }
 
-std::vector<int> Tokenizer::encode(const std::string& text) const {
+std::vector<uint32_t> Tokenizer::encode(const std::string& text) const {
   if (!tok_) {
     throw std::runtime_error(
         "[TokenizerUtil] Tokenizer not loaded, cannot encode");
   }
-  return tok_->Encode(text);
+  // tokenizers-cpp emits int32_t ids; token ids are non-negative and well
+  // within uint32_t range, so this widening conversion is lossless.
+  const std::vector<int32_t> ids = tok_->Encode(text);
+  return std::vector<uint32_t>(ids.begin(), ids.end());
 }
 
-std::string Tokenizer::decode(const std::vector<int>& tokenIds,
+std::string Tokenizer::decode(const std::vector<uint32_t>& tokenIds,
                               bool skipSpecialTokens) const {
   if (!tok_) {
     throw std::runtime_error(
@@ -104,9 +107,15 @@ std::string Tokenizer::decode(const std::vector<int>& tokenIds,
   }
   if (tokenIds.empty()) return "";
 
+  // tokenizers-cpp Decode takes int32_t ids; convert without any value change
+  // (token ids fit in both types).
+  auto toI32 = [](const std::vector<uint32_t>& v) {
+    return std::vector<int32_t>(v.begin(), v.end());
+  };
+
   // Fast path: no special tokens to filter
   if (!skipSpecialTokens || specialTokenIds_.empty()) {
-    return tok_->Decode(tokenIds);
+    return tok_->Decode(toI32(tokenIds));
   }
 
   // Fast path: single token, check if special
@@ -114,15 +123,15 @@ std::string Tokenizer::decode(const std::vector<int>& tokenIds,
     if (specialTokenIds_.find(tokenIds[0]) != specialTokenIds_.end()) {
       return "";  // Special token, skip it
     }
-    return tok_->Decode(tokenIds);
+    return tok_->Decode(toI32(tokenIds));
   }
 
   // Slow path: multiple tokens, filter special tokens
-  std::vector<int> filtered;
+  std::vector<int32_t> filtered;
   filtered.reserve(tokenIds.size());
-  for (int id : tokenIds) {
+  for (uint32_t id : tokenIds) {
     if (specialTokenIds_.find(id) == specialTokenIds_.end()) {
-      filtered.push_back(id);
+      filtered.push_back(static_cast<int32_t>(id));
     }
   }
   if (filtered.empty()) return "";
@@ -161,7 +170,7 @@ Tokenizer::StreamDecoder::StreamDecoder(const Tokenizer& tokenizer,
                                         bool skipSpecialTokens)
     : tokenizer_(tokenizer), skipSpecialTokens_(skipSpecialTokens) {}
 
-std::string Tokenizer::StreamDecoder::step(int tokenId) {
+std::string Tokenizer::StreamDecoder::step(uint32_t tokenId) {
   if (pending_.empty()) {
     std::string decoded = tokenizer_.decode({tokenId}, skipSpecialTokens_);
     if (!endsWithReplacementChar(decoded)) {
@@ -426,12 +435,12 @@ const StaticTokenizerInfo& staticInfo() {
   return staticInfoFor(config::modelType());
 }
 
-std::pair<int64_t, int64_t> thinkTokenIdsFor(config::ModelType model) {
+std::pair<uint32_t, uint32_t> thinkTokenIdsFor(config::ModelType model) {
   const auto& info = staticInfoFor(model);
   return {info.thinkStartTokenId, info.thinkEndTokenId};
 }
 
-std::pair<int64_t, int64_t> thinkTokenIds() {
+std::pair<uint32_t, uint32_t> thinkTokenIds() {
   return thinkTokenIdsFor(config::modelType());
 }
 

--- a/tt-media-server/cpp_server/tests/integration/integration_test_helpers.hpp
+++ b/tt-media-server/cpp_server/tests/integration/integration_test_helpers.hpp
@@ -83,7 +83,7 @@ inline std::shared_ptr<ipc::ITaskQueue> makeInMemoryTaskQueue() {
 
 inline config::LLMConfig makeLLMConfig(
     int numBlocks = 128, int blockSize = 8, int eos = 0,
-    std::vector<int64_t> stopTokenIds = {},
+    std::vector<uint32_t> stopTokenIds = {},
     config::ModelRunnerType runnerType =
         config::ModelRunnerType::MOCK_PIPELINE) {
   config::LLMConfig cfg{};
@@ -101,8 +101,8 @@ inline config::LLMConfig makeLLMConfig(
 
 inline uint32_t generateTaskId() { return utils::TaskIDGenerator::generate(); }
 
-inline std::vector<int64_t> makeSequentialPrompt(size_t length) {
-  std::vector<int64_t> prompt(length);
+inline std::vector<uint32_t> makeSequentialPrompt(size_t length) {
+  std::vector<uint32_t> prompt(length);
   std::iota(prompt.begin(), prompt.end(), 0);
   return prompt;
 }
@@ -271,7 +271,7 @@ class RunnerTestHarness {
   // Submit a sequence to the runner's task queue.
   // Derived classes may override to set the correct KV cache slot method.
   void submitSequence(uint32_t taskId, uint32_t slotId,
-                      const std::vector<int64_t>& promptTokens,
+                      const std::vector<uint32_t>& promptTokens,
                       const domain::llm::SamplingParams& samplingParams) {
     domain::llm::Sequence seq(taskId, kDefaultBlockSize, promptTokens,
                               samplingParams);

--- a/tt-media-server/cpp_server/tests/integration/runners/blaze_decode_runner_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/runners/blaze_decode_runner_test.cpp
@@ -43,7 +43,7 @@ class EnvSetter {
 };
 
 constexpr uint64_t MOCK_PIPELINE_TOKEN_ID = 12345u;
-const std::vector<int64_t> DEFAULT_STOP_TOKEN_IDS = {987654321};
+const std::vector<uint32_t> DEFAULT_STOP_TOKEN_IDS = {987654321};
 
 // Length of the mock pipeline's reasoning preamble: think-open, three decode
 // tokens, think-close. Mirrors PipelineSimulator::kThinkPreambleLen.
@@ -84,7 +84,7 @@ class BlazeDecodeRunnerHarness
     : public test::RunnerTestHarness<BlazeDecodeRunner> {
  public:
   explicit BlazeDecodeRunnerHarness(
-      std::vector<int64_t> stopTokenIds = DEFAULT_STOP_TOKEN_IDS)
+      std::vector<uint32_t> stopTokenIds = DEFAULT_STOP_TOKEN_IDS)
       : test::RunnerTestHarness<BlazeDecodeRunner>(
             test::makeLLMConfig(128, 8, 0, std::move(stopTokenIds))) {}
 };

--- a/tt-media-server/cpp_server/tests/integration/runners/blaze_decode_runner_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/runners/blaze_decode_runner_test.cpp
@@ -344,7 +344,7 @@ TEST(BlazeDecodeRunnerIntegrationTest,
   for (size_t i = 0; i < userCount; ++i) {
     harness.submitSequence(
         taskIds[i], slotIds[i],
-        {static_cast<int64_t>(100 + i), static_cast<int64_t>(200 + i)},
+        {static_cast<uint32_t>(100 + i), static_cast<uint32_t>(200 + i)},
         samplingParams);
   }
 

--- a/tt-media-server/cpp_server/tests/integration/runners/blaze_prefill_runner_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/runners/blaze_prefill_runner_test.cpp
@@ -20,8 +20,8 @@ namespace tt::runners::blaze {
 
 namespace {
 
-constexpr uint64_t MOCK_DECODE_TOKEN_ID = 12345u;
-constexpr uint64_t EMPTY_TOKEN_ID = std::numeric_limits<uint32_t>::max();
+constexpr uint32_t MOCK_DECODE_TOKEN_ID = 12345u;
+constexpr uint32_t EMPTY_TOKEN_ID = std::numeric_limits<uint32_t>::max();
 
 // Specialized harness for prefill runner that uses setPrefillKVCacheSlot.
 class BlazePrefillRunnerHarness
@@ -248,7 +248,7 @@ TEST(BlazePrefillRunnerIntegrationTest,
   for (size_t i = 0; i < userCount; ++i) {
     harness.submitSequence(
         taskIds[i], slotIds[i],
-        {static_cast<int64_t>(100 + i), static_cast<int64_t>(200 + i)},
+        {static_cast<uint32_t>(100 + i), static_cast<uint32_t>(200 + i)},
         samplingParams);
   }
 

--- a/tt-media-server/cpp_server/tests/integration/runners/llm_runner_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/runners/llm_runner_test.cpp
@@ -46,7 +46,7 @@ TEST(LLMRunnerTest, AllTokensPublishedInOrder) {
   Config config = makeEngineConfig();
 
   struct Request {
-    std::vector<int64_t> prompt;
+    std::vector<uint32_t> prompt;
     int max_tokens;
   };
   std::vector<Request> requests = {
@@ -72,7 +72,7 @@ TEST(LLMRunnerTest, AllTokensPublishedInOrder) {
     taskIds.push_back(seq.taskId);
   }
 
-  std::unordered_map<uint32_t, std::vector<int64_t>> receivedTokens;
+  std::unordered_map<uint32_t, std::vector<uint32_t>> receivedTokens;
   std::atomic<int> finishedCount{0};
 
   std::thread consumer([&]() {
@@ -108,7 +108,7 @@ TEST(LLMRunnerTest, AllTokensPublishedInOrder) {
   // 30 tokens: think_start + 10 think + think_end + 18 visible
   // Visible tokens: first is "response", rest are " response" (round-trip
   // stable)
-  const std::vector<int64_t> expectedSeq0 = {
+  const std::vector<uint32_t> expectedSeq0 = {
       kThinkStart,         kThinkContent,       kWhitespace,
       kThinkContent,       kWhitespace,         kThinkContent,
       kWhitespace,         kThinkContent,       kWhitespace,
@@ -121,12 +121,12 @@ TEST(LLMRunnerTest, AllTokensPublishedInOrder) {
       kVisibleContentCont, kVisibleContentCont, kVisibleContentCont,
   };
   // 10 tokens: think_start + 9 think
-  const std::vector<int64_t> expectedSeq1 = {
+  const std::vector<uint32_t> expectedSeq1 = {
       kThinkStart,   kThinkContent, kWhitespace,   kThinkContent, kWhitespace,
       kThinkContent, kWhitespace,   kThinkContent, kWhitespace,   kThinkContent,
   };
   // 20 tokens: think_start + 10 think + think_end + 8 visible
-  const std::vector<int64_t> expectedSeq2 = {
+  const std::vector<uint32_t> expectedSeq2 = {
       kThinkStart,         kThinkContent,       kWhitespace,
       kThinkContent,       kWhitespace,         kThinkContent,
       kWhitespace,         kThinkContent,       kWhitespace,
@@ -174,7 +174,7 @@ TEST(LLMRunnerTest, StructuredOutputCompletesBeforeMaxTokens) {
       tt::utils::TaskIDGenerator::generate(), {1, 2, 3}, sp);
   uint32_t taskId = seq.taskId;
 
-  std::vector<int64_t> tokens;
+  std::vector<uint32_t> tokens;
   std::atomic<bool> done{false};
 
   std::thread consumer([&]() {

--- a/tt-media-server/cpp_server/tests/integration/server/prefill_integration_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/server/prefill_integration_test.cpp
@@ -421,7 +421,7 @@ TEST_F(PrefillIntegrationTest, MultiTurn_SubsequentRequestsAreContinuations) {
   server->setMemoryAutoRespond(false);
 
   // Generate a base set of 129 tokens (4 full blocks + 1) that grows each turn.
-  std::vector<int64_t> baseTokens;
+  std::vector<uint32_t> baseTokens;
   for (int i = 1; i <= 129; ++i) baseTokens.push_back(i * 100);
 
   // --- Turn 0: fresh ALLOCATE
@@ -565,8 +565,8 @@ TEST_F(PrefillIntegrationTest, SlotCopy_TriggeredWhenSessionInFlight) {
   uint32_t prefillSlotD = 0;
 
   // A long prefix (>= 2 blocks of 32 tokens each = 64+ tokens).
-  const std::vector<int64_t> baseTokens = [] {
-    std::vector<int64_t> t;
+  const std::vector<uint32_t> baseTokens = [] {
+    std::vector<uint32_t> t;
     for (int i = 1; i <= 96; ++i) t.push_back(i * 100);
     return t;
   }();
@@ -636,7 +636,7 @@ TEST_F(PrefillIntegrationTest, SlotCopy_TriggeredWhenSessionInFlight) {
   const uint32_t taskIdB = 99201;
   {
     // Extend the prompt by one block (32 tokens).
-    std::vector<int64_t> tokensB = baseTokens;
+    std::vector<uint32_t> tokensB = baseTokens;
     for (int i = 1; i <= 32; ++i) tokensB.push_back(10000 + i * 100);
 
     tt::sockets::PrefillRequestMessage req(taskIdB);
@@ -671,7 +671,7 @@ TEST_F(PrefillIntegrationTest, SlotCopy_TriggeredWhenSessionInFlight) {
   const uint32_t taskIdC = 99202;
   {
     // Same base tokens + different extension → same prefix but different tail.
-    std::vector<int64_t> tokensC = baseTokens;
+    std::vector<uint32_t> tokensC = baseTokens;
     for (int i = 1; i <= 32; ++i) tokensC.push_back(20000 + i * 100);
 
     tt::sockets::PrefillRequestMessage req(taskIdC);
@@ -741,7 +741,7 @@ TEST_F(PrefillIntegrationTest, SlotCopy_TriggeredWhenSessionInFlight) {
   {
     const uint32_t taskIdD = 99203;
     // Same tokens as C + one more block → extends C's prefix.
-    std::vector<int64_t> tokensD = baseTokens;
+    std::vector<uint32_t> tokensD = baseTokens;
     for (int i = 1; i <= 32; ++i) tokensD.push_back(20000 + i * 100);
     for (int i = 1; i <= 32; ++i) tokensD.push_back(30000 + i * 100);
 
@@ -819,8 +819,8 @@ TEST_F(PrefillIntegrationTest, SlotCopy_TriggeredWhenSessionInFlight) {
 TEST_F(PrefillIntegrationTest, SlotCopy_SkippedWhenSourceKvNotCommitted) {
   server->setMemoryAutoRespond(false);
 
-  const std::vector<int64_t> baseTokens = [] {
-    std::vector<int64_t> t;
+  const std::vector<uint32_t> baseTokens = [] {
+    std::vector<uint32_t> t;
     for (int i = 1; i <= 96; ++i) t.push_back(i * 100);
     return t;
   }();
@@ -870,7 +870,7 @@ TEST_F(PrefillIntegrationTest, SlotCopy_SkippedWhenSourceKvNotCommitted) {
   // --- Request C: same prefix, A is in-flight AND uncommitted → no copy. ---
   const uint32_t taskIdC = 99301;
   {
-    std::vector<int64_t> tokensC = baseTokens;
+    std::vector<uint32_t> tokensC = baseTokens;
     for (int i = 1; i <= 32; ++i) tokensC.push_back(20000 + i * 100);
 
     tt::sockets::PrefillRequestMessage req(taskIdC);
@@ -947,8 +947,8 @@ TEST_F(PrefillIntegrationTest, SlotCopy_CapsAtCommittedBlocksDuringExtension) {
   server->setMemoryAutoRespond(false);
 
   // 3 blocks of 32 tokens each = 96 tokens.
-  const std::vector<int64_t> baseTokens = [] {
-    std::vector<int64_t> t;
+  const std::vector<uint32_t> baseTokens = [] {
+    std::vector<uint32_t> t;
     for (int i = 1; i <= 96; ++i) t.push_back(i * 100);
     return t;
   }();
@@ -1004,7 +1004,7 @@ TEST_F(PrefillIntegrationTest, SlotCopy_CapsAtCommittedBlocksDuringExtension) {
   // The 4th block is registered for discovery but its KV is NOT resident.
   uint32_t a1TaskId = 0;
   {
-    std::vector<int64_t> tokensA1 = baseTokens;
+    std::vector<uint32_t> tokensA1 = baseTokens;
     for (int i = 1; i <= 32; ++i) tokensA1.push_back(10000 + i * 100);
 
     const uint32_t taskId = 99401;
@@ -1033,7 +1033,7 @@ TEST_F(PrefillIntegrationTest, SlotCopy_CapsAtCommittedBlocksDuringExtension) {
 
   // --- C: matches all 4 blocks; copy must be capped to the resident 3. ---
   {
-    std::vector<int64_t> tokensC = baseTokens;
+    std::vector<uint32_t> tokensC = baseTokens;
     for (int i = 1; i <= 32; ++i) tokensC.push_back(10000 + i * 100);
 
     const uint32_t taskId = 99402;

--- a/tt-media-server/cpp_server/tests/integration/sessions/cancellation_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/sessions/cancellation_test.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<tt::ipc::ITaskQueue> makeQueue() {
 
 Config makeConfig(int numBlocks = 128, int blockSize = 8,
                   int maxBatchedTokens = 256, int eos = 0,
-                  std::vector<int64_t> stopTokenIds = {}) {
+                  std::vector<uint32_t> stopTokenIds = {}) {
   Config c;
   c.num_kvcache_blocks = numBlocks;
   c.kvcache_block_size = blockSize;
@@ -43,9 +43,9 @@ Config makeConfig(int numBlocks = 128, int blockSize = 8,
   return c;
 }
 
-std::vector<int64_t> prompt(size_t len) {
-  std::vector<int64_t> p;
-  for (size_t i = 0; i < len; ++i) p.push_back(static_cast<int64_t>(i));
+std::vector<uint32_t> prompt(size_t len) {
+  std::vector<uint32_t> p;
+  for (size_t i = 0; i < len; ++i) p.push_back(static_cast<uint32_t>(i));
   return p;
 }
 

--- a/tt-media-server/cpp_server/tests/integration/sessions/llm_service_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/sessions/llm_service_test.cpp
@@ -39,7 +39,7 @@ TEST(LLMServiceProcessStreamingRequest, PushesSequenceToInjectedTaskQueue) {
   auto llmService = makeService(taskQueue);
 
   tt::domain::llm::LLMRequest request{/*taskId=*/7};
-  request.prompt = std::vector<int>{10, 20, 30};
+  request.prompt = std::vector<uint32_t>{10, 20, 30};
   request.skip_special_tokens = true;
 
   ASSERT_NO_THROW(llmService->submitStreamingRequest(
@@ -59,7 +59,7 @@ TEST(LLMServiceProcessStreamingRequest,
   auto taskQueue = std::make_shared<tt::ipc::in_memory::TaskQueue>();
   auto llmService = makeService(taskQueue);
   tt::domain::llm::LLMRequest request{/*taskId=*/7};
-  request.prompt = std::vector<int>{10, 20, 30};
+  request.prompt = std::vector<uint32_t>{10, 20, 30};
   request.skip_special_tokens = true;
 
   llmService->submitStreamingRequest(
@@ -79,8 +79,8 @@ TEST(LLMServiceProcessStreamingRequest,
   auto taskQueue = std::make_shared<tt::ipc::in_memory::TaskQueue>();
   auto llmService = makeService(taskQueue);
   tt::domain::llm::LLMRequest request{/*taskId=*/7};
-  auto thinkStartKimi26 = 163606;
-  request.prompt = std::vector<int>{10, 20, 30, thinkStartKimi26};
+  uint32_t thinkStartKimi26 = 163606;
+  request.prompt = std::vector<uint32_t>{10, 20, 30, thinkStartKimi26};
   request.skip_special_tokens = true;
 
   llmService->submitStreamingRequest(
@@ -100,10 +100,10 @@ TEST(LLMServiceProcessStreamingRequest,
   auto taskQueue = std::make_shared<tt::ipc::in_memory::TaskQueue>();
   auto llmService = makeService(taskQueue);
   tt::domain::llm::LLMRequest request{/*taskId=*/7};
-  auto thinkStartKimi26 = 163606;
-  auto thinkEndKimi26 = 163607;
+  uint32_t thinkStartKimi26 = 163606;
+  uint32_t thinkEndKimi26 = 163607;
   request.prompt =
-      std::vector<int>{10, 20, 30, thinkStartKimi26, thinkEndKimi26};
+      std::vector<uint32_t>{10, 20, 30, thinkStartKimi26, thinkEndKimi26};
   request.skip_special_tokens = true;
 
   llmService->submitStreamingRequest(
@@ -122,7 +122,7 @@ TEST(LLMServiceProcessStreamingRequest, PropagatesMigrationStartPosition) {
   auto taskQueue = std::make_shared<tt::ipc::in_memory::TaskQueue>();
   auto llmService = makeService(taskQueue);
   tt::domain::llm::LLMRequest request{/*taskId=*/7};
-  request.prompt = std::vector<int>{10, 20, 30};
+  request.prompt = std::vector<uint32_t>{10, 20, 30};
   request.skip_special_tokens = true;
   request.migrationStartPosition = 64;
 

--- a/tt-media-server/cpp_server/tests/unit/model/apply_delta_prompt_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/model/apply_delta_prompt_test.cpp
@@ -31,9 +31,9 @@ void applyDeltaPrompt(LLMRequest& req, uint32_t matchedTokens) {
 // Helper to create a request with N sequential tokens [0, 1, 2, ..., N-1].
 LLMRequest makeRequest(uint32_t numTokens) {
   LLMRequest req(/*taskId=*/1);
-  std::vector<int> tokens(numTokens);
+  std::vector<uint32_t> tokens(numTokens);
   std::iota(tokens.begin(), tokens.end(), 0);
-  req.prompt.emplace<std::vector<int>>(std::move(tokens));
+  req.prompt.emplace<std::vector<uint32_t>>(std::move(tokens));
   return req;
 }
 
@@ -46,7 +46,7 @@ TEST(ApplyDeltaPrompt, RemainderAlreadyAligned) {
   auto req = makeRequest(128);
   applyDeltaPrompt(req, 96);
 
-  auto& tokens = std::get<std::vector<int>>(req.prompt);
+  auto& tokens = std::get<std::vector<uint32_t>>(req.prompt);
   EXPECT_EQ(tokens.size(), 32u);
   EXPECT_EQ(tokens.front(), 96);       // first remaining token
   EXPECT_EQ(req.kv_position_id, 96u);  // first free KV index
@@ -61,7 +61,7 @@ TEST(ApplyDeltaPrompt, RemainderNotAligned_SentAsIs) {
   auto req = makeRequest(657);
   applyDeltaPrompt(req, 640);
 
-  auto& tokens = std::get<std::vector<int>>(req.prompt);
+  auto& tokens = std::get<std::vector<uint32_t>>(req.prompt);
   EXPECT_EQ(tokens.size(), 17u);
   EXPECT_EQ(tokens.front(), 640);
   EXPECT_EQ(req.kv_position_id, 640u);
@@ -74,7 +74,7 @@ TEST(ApplyDeltaPrompt, MultiTurnSuffix) {
   auto req = makeRequest(1937);
   applyDeltaPrompt(req, 640);
 
-  auto& tokens = std::get<std::vector<int>>(req.prompt);
+  auto& tokens = std::get<std::vector<uint32_t>>(req.prompt);
   EXPECT_EQ(tokens.size(), 1297u);  // 17 + 1280
   EXPECT_EQ(tokens.front(), 640);
   EXPECT_EQ(req.kv_position_id, 640u);
@@ -86,7 +86,7 @@ TEST(ApplyDeltaPrompt, ZeroMatchedTokens_NoOp) {
   auto req = makeRequest(100);
   applyDeltaPrompt(req, 0);
 
-  auto& tokens = std::get<std::vector<int>>(req.prompt);
+  auto& tokens = std::get<std::vector<uint32_t>>(req.prompt);
   EXPECT_EQ(tokens.size(), 100u);
   EXPECT_FALSE(req.kv_position_id.has_value());
 }
@@ -96,7 +96,7 @@ TEST(ApplyDeltaPrompt, MatchedExceedsTotal_NoOp) {
   auto req = makeRequest(50);
   applyDeltaPrompt(req, 50);
 
-  auto& tokens = std::get<std::vector<int>>(req.prompt);
+  auto& tokens = std::get<std::vector<uint32_t>>(req.prompt);
   EXPECT_EQ(tokens.size(), 50u);
   EXPECT_FALSE(req.kv_position_id.has_value());
 }
@@ -107,7 +107,7 @@ TEST(ApplyDeltaPrompt, LargePrompt) {
   auto req = makeRequest(2048);
   applyDeltaPrompt(req, 1504);
 
-  auto& tokens = std::get<std::vector<int>>(req.prompt);
+  auto& tokens = std::get<std::vector<uint32_t>>(req.prompt);
   EXPECT_EQ(tokens.size(), 544u);
   EXPECT_EQ(tokens.front(), 1504);
   EXPECT_EQ(req.kv_position_id, 1504u);
@@ -119,7 +119,7 @@ TEST(ApplyDeltaPrompt, ExactBoundaries) {
   auto req = makeRequest(256);
   applyDeltaPrompt(req, 192);
 
-  auto& tokens = std::get<std::vector<int>>(req.prompt);
+  auto& tokens = std::get<std::vector<uint32_t>>(req.prompt);
   EXPECT_EQ(tokens.size(), 64u);
   EXPECT_EQ(req.kv_position_id, 192u);
 }

--- a/tt-media-server/cpp_server/tests/unit/model/tokenizer_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/model/tokenizer_test.cpp
@@ -81,7 +81,7 @@ TEST_F(DeepseekTokenizerTest, CompareWithExpectedTokens) {
   // Pre-computed expected tokens from DeepSeek R1 05 28 tokenizer (without
   // special tokens) Generated using: tokenizer.encode(text,
   // add_special_tokens=False)
-  std::map<std::string, std::vector<int>> expectedTokens = {
+  std::map<std::string, std::vector<uint32_t>> expectedTokens = {
       {"Hello, world!", {19923, 14, 2058, 3}},
       {"The quick brown fox jumps over the lazy dog.",
        {671, 4787, 13769, 46012, 54994, 1060, 270, 41638, 6397, 16}},
@@ -411,7 +411,7 @@ TEST_F(DeepseekTokenizerTest, DecodeSpecialTokenMixedWithNormal) {
   auto helloIds = tokenizer().encode("Hello");
   ASSERT_FALSE(helloIds.empty());
 
-  std::vector<int> withSpecial = helloIds;
+  std::vector<uint32_t> withSpecial = helloIds;
   withSpecial.push_back(1);  // append EOS
 
   std::string skipped =

--- a/tt-media-server/cpp_server/tests/unit/scheduling/scheduler_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/scheduling/scheduler_test.cpp
@@ -301,7 +301,7 @@ TEST(PrefillFirstSchedulerTest,
     auto [decode_batch, is_prefill] = sched.schedule();
     ASSERT_FALSE(is_prefill);
     ASSERT_EQ(decode_batch.size(), 1u);
-    sched.postprocess(decode_batch, {static_cast<int64_t>(i + 2)});
+    sched.postprocess(decode_batch, {static_cast<uint32_t>(i + 2)});
   }
   ASSERT_EQ(runningSeq->size(), 9u);
 
@@ -331,7 +331,7 @@ TEST(PrefillFirstSchedulerTest,
     auto [decode_batch, is_prefill] = sched.schedule();
     ASSERT_FALSE(is_prefill);
     ASSERT_EQ(decode_batch.size(), 1u);
-    sched.postprocess(decode_batch, {static_cast<int64_t>(i + 2)});
+    sched.postprocess(decode_batch, {static_cast<uint32_t>(i + 2)});
   }
   ASSERT_EQ(runningSeq->size(), 9u);
 

--- a/tt-media-server/cpp_server/tests/unit/scheduling/scheduler_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/scheduling/scheduler_test.cpp
@@ -32,7 +32,7 @@ std::shared_ptr<tt::ipc::ITaskQueue> makeQueue() {
 
 Config makeConfig(int numBlocks = 32, int blockSize = 8,
                   int maxBatchedTokens = 256, int eos = 0,
-                  std::vector<int64_t> stopTokenIds = {}) {
+                  std::vector<uint32_t> stopTokenIds = {}) {
   Config c;
   c.num_kvcache_blocks = numBlocks;
   c.kvcache_block_size = blockSize;
@@ -42,9 +42,9 @@ Config makeConfig(int numBlocks = 32, int blockSize = 8,
   return c;
 }
 
-std::vector<int64_t> prompt(size_t len) {
-  std::vector<int64_t> p;
-  for (size_t i = 0; i < len; ++i) p.push_back(static_cast<int64_t>(i));
+std::vector<uint32_t> prompt(size_t len) {
+  std::vector<uint32_t> p;
+  for (size_t i = 0; i < len; ++i) p.push_back(static_cast<uint32_t>(i));
   return p;
 }
 
@@ -118,7 +118,7 @@ TEST(PrefillFirstSchedulerTest,
   auto [prefill_batch, is_prefill] = sched.schedule();
   ASSERT_TRUE(is_prefill);
   ASSERT_EQ(prefill_batch.size(), 1u);
-  std::vector<int64_t> tokens = {1};
+  std::vector<uint32_t> tokens = {1};
   sched.postprocess(prefill_batch, tokens);
 
   auto [decode_batch, is_decode] = sched.schedule();
@@ -128,7 +128,7 @@ TEST(PrefillFirstSchedulerTest,
 }
 
 TEST(PrefillFirstSchedulerTest, OneRequest_PrefillThenDecodeThenEos) {
-  Config config = makeConfig(32, 8, 256, 99, std::vector<int64_t>{99});
+  Config config = makeConfig(32, 8, 256, 99, std::vector<uint32_t>{99});
   auto queue = makeQueue();
   PrefillFirstScheduler sched{config, queue.get(), 1};
   sched.addRequest(nextId(), prompt(4),
@@ -194,7 +194,7 @@ TEST(PrefillFirstSchedulerTest,
 }
 
 TEST(PrefillFirstSchedulerTest, Postprocess_WhenEosToken_MarksFinished) {
-  Config config = makeConfig(32, 8, 256, 99, std::vector<int64_t>{99});
+  Config config = makeConfig(32, 8, 256, 99, std::vector<uint32_t>{99});
   auto queue = makeQueue();
   PrefillFirstScheduler sched{config, queue.get(), 1};
   Sequence seq{nextId(), 256, prompt(2),

--- a/tt-media-server/prefill_gateway/tests/gateway_e2e_test.cpp
+++ b/tt-media-server/prefill_gateway/tests/gateway_e2e_test.cpp
@@ -51,9 +51,8 @@ bool waitFor(Pred pred, std::chrono::milliseconds timeout = 2s) {
 
 uint64_t fakeMigrationId(uint32_t taskId) { return 1000ULL + taskId; }
 
-std::vector<int64_t> fakeTokenIds(uint32_t taskId) {
-  return {static_cast<int64_t>(taskId * 10 + 1),
-          static_cast<int64_t>(taskId * 10 + 2)};
+std::vector<uint32_t> fakeTokenIds(uint32_t taskId) {
+  return {taskId * 10 + 1, taskId * 10 + 2};
 }
 
 void populateFakePrefillResult(tt::sockets::PrefillResultMessage& result,


### PR DESCRIPTION
## Problem
Token IDs were represented inconsistently throughout the codebase, using types such as `int`, `unit32_t` and `int64_t` in different places. This resulted in unnecessary type conversions and increased the size of the Decode → Prefill ZMQ payload.

The Decode → Prefill path has become a bottleneck for workloads with large ISLs. This PR is the first step toward reducing that bottleneck and improving overall performance
```
┌──────┬───────────┬─────────┬──────────┬────────┬────────────┬───────────────┐
│ task │ DYN prepr │ DYN→dec │ dec work │ socket │ pref admit │ arrive→submit │
├──────┼───────────┼─────────┼──────────┼────────┼────────────┼───────────────┤
│ 3    │ 43.2      │ 2.9     │ 1.3      │ 5.9    │ 2.1        │ 55.4          │
├──────┼───────────┼─────────┼──────────┼────────┼────────────┼───────────────┤
│ 5    │ 48.9      │ 2.1     │ 1.6      │ 11.6   │ 1.6        │ 66.0          │
├──────┼───────────┼─────────┼──────────┼────────┼────────────┼───────────────┤
│ 7    │ 51.7      │ 2.0     │ 1.2      │ 19.0   │ 1.3        │ 76.2          │
├──────┼───────────┼─────────┼──────────┼────────┼────────────┼───────────────┤
│ 9    │ 53.0      │ 1.8     │ 1.6      │ 27.5   │ 1.2        │ 86.8          │
└──────┴───────────┴─────────┴──────────┴────────┴────────────┴───────────────┘
```

With this PR, we standardize the representation of Token IDs by using `uint32_t` consistently across the codebase

## Testing
https://github.com/tenstorrent/tt-inference-server/actions/runs/28806914843