### PR TITLE
added transformers in requirements

### DIFF
--- a/requirements/v2-run-script.txt
+++ b/requirements/v2-run-script.txt
@@ -24,6 +24,7 @@ torchvision
 open-clip-torch
 pillow
 requests
+transformers==4.57.1
 # LLM eval/release run in this venv and mint the server bearer token from
 # --jwt-secret (command_factory._mint_jwt_if_secret), so pyjwt must be here.
 pyjwt


### PR DESCRIPTION
resolves issue for Llama-3.1.8

https://github.com/tenstorrent/tt-shield/actions/runs/28811970558/job/85478203168#step:11:4687

```
ImportError while loading conftest '/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/tt-inference-server-v2/llm_module/conftest.py'.
................................
................................
from transformers import AutoTokenizer
E   ModuleNotFoundError: No module named 'transformers'
```