### PR TITLE
Fix Disaggregation Deserialization and Copy Overhead

### DIFF
--- a/tt-media-server/cpp_server/include/sockets/i_socket_transport.hpp
+++ b/tt-media-server/cpp_server/include/sockets/i_socket_transport.hpp
@@ -49,6 +49,18 @@ class ISocketTransport {
   virtual std::string getStatus() const = 0;
 
   virtual bool sendRawData(std::span<const uint8_t> data) = 0;
+
+  /**
+   * @brief Ownership-transfer send: hands the payload buffer to the transport.
+   *
+   * Lets transports avoid copying large payloads (e.g. pass the buffer straight
+   * to a zero-copy zmq::message_t) on the hot decode->prefill path. The default
+   * copies via the span overload, so transports that don't care need no change.
+   */
+  virtual bool sendRawData(std::vector<uint8_t>&& data) {
+    return sendRawData(std::span<const uint8_t>(data.data(), data.size()));
+  }
+
   virtual std::vector<uint8_t> receiveRawData() = 0;
 
   /**

--- a/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_manager.hpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "sockets/i_socket_transport.hpp"
@@ -141,7 +142,7 @@ bool SocketManager::sendObject(std::string_view messageType, const T& obj) {
 
   try {
     std::vector<uint8_t> data = wire::serializeMessage(messageType, obj);
-    return transport->sendRawData(data);
+    return transport->sendRawData(std::move(data));
   } catch (const std::exception& e) {
     TT_LOG_ERROR("[SocketManager] Serialization error: {}", e.what());
     return false;

--- a/tt-media-server/cpp_server/include/sockets/socket_serialization.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_serialization.hpp
@@ -6,42 +6,87 @@
 #include <cereal/archives/binary.hpp>
 #include <cereal/types/string.hpp>
 #include <cstdint>
+#include <istream>
+#include <ostream>
 #include <span>
-#include <sstream>
+#include <streambuf>
 #include <string>
 #include <string_view>
 #include <vector>
 
 namespace tt::sockets::wire {
 
+namespace detail {
+
+/**
+ * @brief std::streambuf that appends bytes straight into a
+ * std::vector<uint8_t>.
+ *
+ * Lets Cereal serialize directly into the final output buffer, avoiding
+ * std::ostringstream's reallocating growth plus the extra str()/vector copies
+ * of the whole payload that the previous implementation paid on every send.
+ */
+class VectorOutStreamBuf : public std::streambuf {
+ public:
+  explicit VectorOutStreamBuf(std::vector<uint8_t>& out) : out_(out) {}
+
+ protected:
+  std::streamsize xsputn(const char* s, std::streamsize n) override {
+    const auto* bytes = reinterpret_cast<const uint8_t*>(s);
+    out_.insert(out_.end(), bytes, bytes + n);
+    return n;
+  }
+
+  int_type overflow(int_type ch) override {
+    if (ch != traits_type::eof()) {
+      out_.push_back(static_cast<uint8_t>(ch));
+    }
+    return ch;
+  }
+
+ private:
+  std::vector<uint8_t>& out_;
+};
+
+/**
+ * @brief Read-only std::streambuf over an existing byte span (zero-copy).
+ *
+ * Points Cereal's input archive straight at the received buffer so the payload
+ * is never copied into an intermediate std::string + std::istringstream just to
+ * be parsed. The span must outlive any archive reading from this buffer; the
+ * archive only reads (sgetn/sbumpc) and never writes the get area, so the
+ * const_cast below is safe.
+ */
+class SpanInStreamBuf : public std::streambuf {
+ public:
+  explicit SpanInStreamBuf(std::span<const uint8_t> data) {
+    auto* base = const_cast<char*>(reinterpret_cast<const char*>(data.data()));
+    setg(base, base, base + data.size());
+  }
+};
+
+}  // namespace detail
+
 template <typename T>
 std::vector<uint8_t> serializeMessage(std::string_view messageType,
                                       const T& obj) {
-  std::ostringstream oss;
+  std::vector<uint8_t> out;
+  detail::VectorOutStreamBuf buf(out);
+  std::ostream os(&buf);
   {
-    cereal::BinaryOutputArchive archive(oss);
+    cereal::BinaryOutputArchive archive(os);
     std::string messageTypeString(messageType);
     archive(messageTypeString);
     obj.write(archive);
   }
-
-  const std::string serialized = oss.str();
-  return {serialized.begin(), serialized.end()};
-}
-
-inline std::string toSerializedString(std::span<const uint8_t> data) {
-  if (data.empty()) {
-    return {};
-  }
-  const auto* bytes = reinterpret_cast<const char*>(data.data());
-  return {bytes, data.size()};
+  return out;
 }
 
 inline std::string readMessageType(std::span<const uint8_t> data) {
-  std::string serialized = toSerializedString(data);
-  std::istringstream iss(serialized);
+  detail::SpanInStreamBuf buf(data);
+  std::istream is(&buf);
 
-  cereal::BinaryInputArchive archive(iss);
+  cereal::BinaryInputArchive archive(is);
   std::string messageType;
   archive(messageType);
   return messageType;
@@ -49,10 +94,10 @@ inline std::string readMessageType(std::span<const uint8_t> data) {
 
 template <typename T>
 T deserializePayload(std::span<const uint8_t> data) {
-  std::string serialized = toSerializedString(data);
-  std::istringstream iss(serialized);
+  detail::SpanInStreamBuf buf(data);
+  std::istream is(&buf);
 
-  cereal::BinaryInputArchive archive(iss);
+  cereal::BinaryInputArchive archive(is);
   std::string ignoredMessageType;
   archive(ignoredMessageType);
   return T::read(archive);

--- a/tt-media-server/cpp_server/include/sockets/zmq_socket_transport.hpp
+++ b/tt-media-server/cpp_server/include/sockets/zmq_socket_transport.hpp
@@ -52,6 +52,7 @@ class ZmqSocketTransport : public ISocketTransport,
   std::string getStatus() const override;
 
   bool sendRawData(std::span<const uint8_t> data) override;
+  bool sendRawData(std::vector<uint8_t>&& data) override;
   std::vector<uint8_t> receiveRawData() override;
 
   void setConnectionLostCallback(std::function<void()> callback) override;
@@ -79,8 +80,8 @@ class ZmqSocketTransport : public ISocketTransport,
 
   // Transport-specific send/receive halves. Only ioThread calls these methods;
   // no other thread touches socket.
-  bool sendAsRouter(const std::vector<uint8_t>& data);
-  bool sendAsDealer(const std::vector<uint8_t>& data);
+  bool sendAsRouter(std::vector<uint8_t>&& data);
+  bool sendAsDealer(std::vector<uint8_t>&& data);
   std::vector<uint8_t> receiveAsRouter();
   std::vector<uint8_t> receiveAsDealer();
 

--- a/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
+++ b/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
@@ -11,8 +11,11 @@
 namespace tt::sockets {
 
 namespace {
-constexpr auto MESSAGE_LOOP_SLEEP = std::chrono::milliseconds(10);
-}
+// Idle backoff only — applied when no message is pending. A burst of concurrent
+// messages is drained in a single pass (see messageLoop), so this no longer
+// serializes requests at the poll interval the way the old 10ms did.
+constexpr auto MESSAGE_LOOP_IDLE_WAIT = std::chrono::milliseconds(1);
+}  // namespace
 
 SocketManager::~SocketManager() { stop(); }
 
@@ -75,16 +78,31 @@ void SocketManager::stop() {
 
 void SocketManager::messageLoop(std::stop_token stopToken) {
   while (running && !stopToken.stop_requested()) {
+    bool drainedAny = false;
     try {
-      auto data = transport->receiveRawData();
-      if (!data.empty()) {
+      // Drain every message the transport currently has buffered in one pass.
+      // Previously we handled a single message per iteration and then slept, so
+      // a burst of N concurrent messages was admitted at the poll interval
+      // (N * 10ms) — that was the dominant decode->prefill "socket" latency,
+      // growing ~10ms per concurrent request. Draining here collapses the burst
+      // into a single pass so all queued requests are admitted immediately.
+      while (running && !stopToken.stop_requested()) {
+        auto data = transport->receiveRawData();
+        if (data.empty()) {
+          break;
+        }
         handleIncomingMessage(data);
+        drainedAny = true;
       }
     } catch (const std::exception& e) {
       TT_LOG_ERROR("[SocketManager] Message loop error: {}", e.what());
     }
 
-    std::this_thread::sleep_for(MESSAGE_LOOP_SLEEP);
+    // Back off only when idle; kept short (1ms) so first-message latency after
+    // an idle period stays low instead of the old fixed 10ms poll.
+    if (!drainedAny) {
+      std::this_thread::sleep_for(MESSAGE_LOOP_IDLE_WAIT);
+    }
   }
 }
 

--- a/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
+++ b/tt-media-server/cpp_server/src/sockets/socket_manager.cpp
@@ -12,8 +12,7 @@ namespace tt::sockets {
 
 namespace {
 // Idle backoff only — applied when no message is pending. A burst of concurrent
-// messages is drained in a single pass (see messageLoop), so this no longer
-// serializes requests at the poll interval the way the old 10ms did.
+// messages is drained in a single pass (see messageLoop)
 constexpr auto MESSAGE_LOOP_IDLE_WAIT = std::chrono::milliseconds(1);
 }  // namespace
 
@@ -81,11 +80,6 @@ void SocketManager::messageLoop(std::stop_token stopToken) {
     bool drainedAny = false;
     try {
       // Drain every message the transport currently has buffered in one pass.
-      // Previously we handled a single message per iteration and then slept, so
-      // a burst of N concurrent messages was admitted at the poll interval
-      // (N * 10ms) — that was the dominant decode->prefill "socket" latency,
-      // growing ~10ms per concurrent request. Draining here collapses the burst
-      // into a single pass so all queued requests are admitted immediately.
       while (running && !stopToken.stop_requested()) {
         auto data = transport->receiveRawData();
         if (data.empty()) {
@@ -98,8 +92,7 @@ void SocketManager::messageLoop(std::stop_token stopToken) {
       TT_LOG_ERROR("[SocketManager] Message loop error: {}", e.what());
     }
 
-    // Back off only when idle; kept short (1ms) so first-message latency after
-    // an idle period stays low instead of the old fixed 10ms poll.
+    // Back off only when idle
     if (!drainedAny) {
       std::this_thread::sleep_for(MESSAGE_LOOP_IDLE_WAIT);
     }

--- a/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
+++ b/tt-media-server/cpp_server/src/sockets/zmq_socket_transport.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <memory>
 #include <utility>
+#include <vector>
 #include <zmq.hpp>
 
 #include "sockets/zmq_socket_options.hpp"
@@ -22,6 +23,21 @@ constexpr auto IO_IDLE_WAIT = std::chrono::milliseconds(1);
 std::string makeMonitorEndpoint(const void* self) {
   return "inproc://zmq-monitor-" +
          std::to_string(reinterpret_cast<uintptr_t>(self));
+}
+
+// Deallocator for zero-copy zmq::message_t: reclaims the heap-owned payload
+// buffer once zmq has finished transmitting it. `hint` is the vector pointer.
+void freeOwnedBuffer(void* /*data*/, void* hint) {
+  delete static_cast<std::vector<uint8_t>*>(hint);
+}
+
+// Wraps a byte buffer in a zero-copy zmq::message_t: zmq borrows the buffer in
+// place instead of copying it, and calls freeOwnedBuffer once it is done. The
+// deallocator runs whether the send succeeds or the message is dropped, so the
+// buffer is freed exactly once with no leak on EAGAIN.
+zmq::message_t makeOwnedMessage(std::vector<uint8_t>&& data) {
+  auto* owned = new std::vector<uint8_t>(std::move(data));
+  return zmq::message_t(owned->data(), owned->size(), freeOwnedBuffer, owned);
 }
 }  // namespace
 
@@ -250,10 +266,14 @@ std::string ZmqSocketTransport::getStatus() const {
 }
 
 bool ZmqSocketTransport::sendRawData(std::span<const uint8_t> data) {
+  return sendRawData(std::vector<uint8_t>(data.begin(), data.end()));
+}
+
+bool ZmqSocketTransport::sendRawData(std::vector<uint8_t>&& data) {
   if (!running || !ioActive) return false;
 
   auto request = std::make_shared<SendRequest>();
-  request->data.assign(data.begin(), data.end());
+  request->data = std::move(data);
   auto result = request->result.get_future();
 
   if (!sendQueue.pushIf(std::move(request),
@@ -280,8 +300,9 @@ bool ZmqSocketTransport::processPendingSends() {
 
     bool ok = false;
     try {
-      ok = running && (mode == Mode::SERVER ? sendAsRouter(request->data)
-                                            : sendAsDealer(request->data));
+      ok = running &&
+           (mode == Mode::SERVER ? sendAsRouter(std::move(request->data))
+                                 : sendAsDealer(std::move(request->data)));
     } catch (const zmq::error_t& e) {
       TT_LOG_ERROR("[ZmqSocketTransport] Send failed: {}", e.what());
     }
@@ -321,7 +342,7 @@ void ZmqSocketTransport::failPendingSends() {
   }
 }
 
-bool ZmqSocketTransport::sendAsRouter(const std::vector<uint8_t>& data) {
+bool ZmqSocketTransport::sendAsRouter(std::vector<uint8_t>&& data) {
   // ROUTER must prefix every outgoing message with the peer's identity.
   if (!routerPeerReady.load()) {
     TT_LOG_DEBUG(
@@ -331,13 +352,13 @@ bool ZmqSocketTransport::sendAsRouter(const std::vector<uint8_t>& data) {
   zmq::message_t idFrame(peerId.data(), peerId.size());
   socket->send(idFrame, zmq::send_flags::sndmore);
 
-  zmq::message_t msg(data.data(), data.size());
+  zmq::message_t msg = makeOwnedMessage(std::move(data));
   auto result = socket->send(msg, zmq::send_flags::dontwait);
   return result.has_value();
 }
 
-bool ZmqSocketTransport::sendAsDealer(const std::vector<uint8_t>& data) {
-  zmq::message_t msg(data.data(), data.size());
+bool ZmqSocketTransport::sendAsDealer(std::vector<uint8_t>&& data) {
+  zmq::message_t msg = makeOwnedMessage(std::move(data));
   auto result = socket->send(msg, zmq::send_flags::dontwait);
   return result.has_value();
 }


### PR DESCRIPTION
## Problem
With E2E testing of disaggregated models, we observed that for concurrent requests the first request to reach the server got an unfair advantage — the scheduler works fast enough that it scheduled 4–7 chunks of the first request into an empty pipeline, instead of round-robining across the requests as you'd expect given they're concurrent (arriving to Dynamo within ~2ms of each other).

This was caused by ~10–20ms of overhead per request in the inference server, which staggered when each request actually reached prefill.

Below are tables with relevant timestamps of concurrent requests through the server, and how long each step takes. One thing that stood out was the socket transfer. It's expected to take some time, since the payload is large (55K tokens), but what was not expected was a staircase of latency — the requests affecting one another.

## Implementation
In a previous PR we limited the token size to uint32_t, which halved the payload.
In this PR we cut the number of copies on this path, and change the socket manager's receive loop to drain all pending messages per iteration instead of one-per-poll (and drop the poll/sleep from 10ms to 1ms idle).

In the future it would be good to switch to fully event-driven request processing on the prefill side, but since the results with these changes are already quite good, that can be a follow-up.

## Testing
### Before
```
┌──────┬───────────┬─────────┬──────────┬────────┬────────────┬───────────────┐
│ task │ DYN prepr │ DYN→dec │ dec work │ socket │ pref admit │ arrive→submit │
├──────┼───────────┼─────────┼──────────┼────────┼────────────┼───────────────┤
│ 3    │ 43.2      │ 2.9     │ 1.3      │ 5.9    │ 2.1        │ 55.4          │
├──────┼───────────┼─────────┼──────────┼────────┼────────────┼───────────────┤
│ 5    │ 48.9      │ 2.1     │ 1.6      │ 11.6   │ 1.6        │ 66.0          │
├──────┼───────────┼─────────┼──────────┼────────┼────────────┼───────────────┤
│ 7    │ 51.7      │ 2.0     │ 1.2      │ 19.0   │ 1.3        │ 76.2          │
├──────┼───────────┼─────────┼──────────┼────────┼────────────┼───────────────┤
│ 9    │ 53.0      │ 1.8     │ 1.6      │ 27.5   │ 1.2        │ 86.8          │
└──────┴───────────┴─────────┴──────────┴────────┴────────────┴───────────────┘
```

### After
```
┌──────┬───────────┬─────────┬──────────┬────────┬────────────┬───────────────┐
│ task │ DYN prepr │ DYN→dec │ dec work │ socket │ pref admit │ arrive→submit │
├──────┼───────────┼─────────┼──────────┼────────┼────────────┼───────────────┤
│ 1    │ 17.9      │ 1.6     │ 2.1      │ 1.9    │ 0.4        │ 23.8          │
├──────┼───────────┼─────────┼──────────┼────────┼────────────┼───────────────┤
│ 3    │ 18.8      │ 1.4     │ 1.9      │ 2.4    │ 0.5        │ 25.0          │
├──────┼───────────┼─────────┼──────────┼────────┼────────────┼───────────────┤
│ 5    │ 15.9      │ 3.7     │ 1.8      │ 2.6    │ 0.6        │ 24.6          │
├──────┼───────────┼─────────┼──────────┼────────┼────────────┼───────────────┤
│ 7    │ 17.2      │ 2.6     │ 1.6      │ 2.8    │ 0.6        │ 24.8          │
└──────┴───────────┴─────────┴──────────┴────────┴────────────┴───────────────┘
```