### PR TITLE
Return Correct Response for Mid-Size Prompts

### DIFF
--- a/tt-media-server/cpp_server/include/config/runner_config.hpp
+++ b/tt-media-server/cpp_server/include/config/runner_config.hpp
@@ -14,6 +14,8 @@
 
 namespace tt::config {
 
+size_t maxContextLength();
+
 struct RunnerConfigBase {
   ModelRunnerType runner_type = ModelRunnerType::MOCK;
 };
@@ -35,7 +37,7 @@ struct MediaRunnerConfigBase : RunnerConfigBase {
 };
 
 struct LLMConfig : RunnerConfigBase {
-  size_t max_num_batched_tokens = 64 * defaults::MAX_CONTEXT_LENGTH;
+  size_t max_num_batched_tokens = 64 * maxContextLength();
   size_t max_in_flight_count = 64;
   std::vector<uint32_t> stop_token_ids;  // Set by tt::config::llmEngineConfig()
                                          // from active tokenizer strategy

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -158,6 +158,13 @@ size_t maxContextLength();
  * defaults::MAX_ISL. */
 size_t maxISL();
 
+/** Per-message capacity (bytes) of the IPC task queue, derived at runtime from
+ * maxContextLength() so overriding MAX_CONTEXT_LENGTH also resizes the queue
+ * buffer (mirrors defaults::TASK_QUEUE_MAX_MSG_SIZE, which is only the
+ * default). Sized to hold maxContextLength() token ids plus non-token sequence
+ * fields. */
+size_t taskQueueMaxMsgSize();
+
 /** Minimum matched tokens required to justify a slot copy operation.
  * From MIN_TOKENS_TO_COPY. Default: defaults::MIN_TOKENS_TO_COPY. */
 size_t minTokensToCopy();

--- a/tt-media-server/cpp_server/include/ipc/boost/boost_memory_queue.hpp
+++ b/tt-media-server/cpp_server/include/ipc/boost/boost_memory_queue.hpp
@@ -50,11 +50,15 @@ class MemoryQueue {
    *  previous process that crashed without cleanup. Falls back to
    *  open_only + drain if removal is not possible (e.g. race with
    *  another process, container permission issues). */
-  MemoryQueue(const std::string& name, int capacity) : name_(name) {
+  MemoryQueue(const std::string& name, int capacity,
+              size_t maxMsgSize = MAX_MSG_SIZE)
+      : name_(name) {
+    if (maxMsgSize == 0) maxMsgSize = MAX_MSG_SIZE;
     bi_ipc::message_queue::remove(name.c_str());
     try {
       queue_ = std::make_unique<bi_ipc::message_queue>(
-          bi_ipc::create_only, name.c_str(), capacity, MAX_MSG_SIZE);
+          bi_ipc::create_only, name.c_str(), capacity, maxMsgSize);
+      max_msg_size_ = queue_->get_max_msg_size();
     } catch (const bi_ipc::interprocess_exception&) {
       TT_LOG_WARN(
           "[ipc::boost::MemoryQueue] '{}' still exists after remove, "
@@ -62,6 +66,7 @@ class MemoryQueue {
           name);
       queue_ = std::make_unique<bi_ipc::message_queue>(bi_ipc::open_only,
                                                        name.c_str());
+      max_msg_size_ = queue_->get_max_msg_size();
       drain();
     }
   }
@@ -171,13 +176,15 @@ class MemoryQueue {
   }
 
  private:
-  static std::vector<char>& sendBuffer() {
-    thread_local std::vector<char> buf(MAX_MSG_SIZE);
+  std::vector<char>& sendBuffer() const {
+    thread_local std::vector<char> buf;
+    if (buf.size() < max_msg_size_) buf.resize(max_msg_size_);
     return buf;
   }
 
-  static std::vector<char>& recvBuffer() {
-    thread_local std::vector<char> buf(MAX_MSG_SIZE);
+  std::vector<char>& recvBuffer() const {
+    thread_local std::vector<char> buf;
+    if (buf.size() < max_msg_size_) buf.resize(max_msg_size_);
     return buf;
   }
 
@@ -192,9 +199,11 @@ class MemoryQueue {
   explicit MemoryQueue(const std::string& name) : name_(name) {
     queue_ = std::make_unique<bi_ipc::message_queue>(bi_ipc::open_only,
                                                      name.c_str());
+    max_msg_size_ = queue_->get_max_msg_size();
   }
 
   std::string name_;
+  size_t max_msg_size_ = MAX_MSG_SIZE;
   std::unique_ptr<bi_ipc::message_queue> queue_;
 };
 

--- a/tt-media-server/cpp_server/include/ipc/boost/boost_task_queue.hpp
+++ b/tt-media-server/cpp_server/include/ipc/boost/boost_task_queue.hpp
@@ -8,6 +8,7 @@
 
 #include "config/defaults.hpp"
 #include "config/runner_config.hpp"
+#include "config/settings.hpp"
 #include "ipc/boost/boost_memory_queue.hpp"
 #include "ipc/interface/task_queue.hpp"
 
@@ -23,7 +24,8 @@ class TaskQueue : public tt::ipc::ITaskQueue {
 
   /** Create a new queue (main process). */
   TaskQueue(const std::string& name, int capacity)
-      : queue_(std::make_unique<Queue>(name, capacity)) {}
+      : queue_(std::make_unique<Queue>(name, capacity,
+                                       tt::config::taskQueueMaxMsgSize())) {}
 
   /** Open an existing queue (worker process). */
   explicit TaskQueue(const std::string& name)

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -650,6 +650,12 @@ size_t maxISL() {
   return cached;
 }
 
+size_t taskQueueMaxMsgSize() {
+  static const size_t cached = maxContextLength() * sizeof(uint32_t) +
+                               defaults::MAX_SEQUENCE_NON_TOKEN_BYTES;
+  return cached;
+}
+
 size_t minTokensToCopy() {
   static const size_t cached = static_cast<size_t>(
       envUlong("MIN_TOKENS_TO_COPY", defaults::MIN_TOKENS_TO_COPY));

--- a/tt-media-server/cpp_server/src/dynamo/discovery.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/discovery.cpp
@@ -23,8 +23,6 @@ namespace tt::dynamo {
 
 namespace {
 
-constexpr int K_CONTEXT_LENGTH = 131072;
-
 /// Used only when a referenced file is missing/unreadable. The frontend
 /// blake3-validates every file it fetches from the MDC, so for files that
 /// exist we must publish their real digest (see fileChecksum); an all-zero
@@ -255,7 +253,7 @@ Json::Value buildMdcJson(const DiscoveryConfig& c) {
   promptFormatter["hf_tokenizer_config_json"] = std::move(hfTokCfg);
   card["prompt_formatter"] = std::move(promptFormatter);
 
-  card["context_length"] = K_CONTEXT_LENGTH;
+  card["context_length"] = static_cast<int>(tt::config::maxContextLength());
   card["kv_cache_block_size"] =
       static_cast<int>(tt::config::kvCacheBlockSize());
   card["migration_limit"] = 0;


### PR DESCRIPTION
## Issue
[#852 - 500 error with large (but not too large) input to Kimi](https://github.com/tenstorrent/tt-cloud-console/issues/852)

## Problem
We observed inconsistent error handling for requests that exceeded the supported context length.

Requests larger than 131072 tokens correctly returned HTTP 400, while requests between 65536 and 131072 tokens incorrectly resulted in HTTP 500 errors. The latter was caused by the cpp_server silently overflowing its internal memory queues.

## Implementation
With this PR, cpp_server now correctly advertises the model's maximum context length to Dynamo, and allocates its internal memory queues based on the configured `MAX_CONTEXT_LENGTH` environment variable.

As a result, users can control the supported context length by setting `MAX_CONTEXT_LENGTH`. Requests that exceed this configured limit are now rejected by Dynamo Frontend with the expected HTTP 400 response, instead of failing later with an internal server error.


## Testing
### `MAX_CONTEXT_LENGTH=65536`
```
┌────────┬───────────────┬────────────────────────────────────────────────────┐
│ rounds │ prompt_tokens │                       result                       │
├────────┼───────────────┼────────────────────────────────────────────────────┤
│ 35     │ 58,472        │ ✅ 200                                             │
├────────┼───────────────┼────────────────────────────────────────────────────┤
│ 50     │ 83,468        │ ✅ 400 ("maximum context length is 65536 tokens…") │
├────────┼───────────────┼────────────────────────────────────────────────────┤
│ 70     │ 116,796       │ ✅ 400                                             │
├────────┼───────────────┼────────────────────────────────────────────────────┤
│ 130    │ 216,886       │ ✅ 400                                             │
└────────┴───────────────┴────────────────────────────────────────────────────┘

```

### `MAX_CONTEXT_LENGTH=131072`
```
┌────────┬───────────────┬────────────┬───────────────────────────────────────┐
│ rounds │ prompt_tokens │ before fix │ after fix (MAX_CONTEXT_LENGTH=131072) │
├────────┼───────────────┼────────────┼───────────────────────────────────────┤
│ 35     │ 58,464        │ ✅ 200     │ ✅ 200                                │
├────────┼───────────────┼────────────┼───────────────────────────────────────┤
│ 50     │ 83,478        │ ❌ 500     │ ✅ 200                                │
├────────┼───────────────┼────────────┼───────────────────────────────────────┤
│ 70     │ 116,810       │ ❌ 500     │ ✅ 200                                │
├────────┼───────────────┼────────────┼───────────────────────────────────────┤
│ 90     │ 150,188       │ ✅ 400     │ ✅ 400                                │
├────────┼───────────────┼────────────┼───────────────────────────────────────┤
│ 130    │ 216,876       │ ✅ 400     │ ✅ 400                                │
└────────┴───────────────┴────────────┴───────────────────────────────────────┘
```