### PR TITLE
Init MigrationLayerClientAdapter with create factory

### DIFF
--- a/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_utils.hpp
+++ b/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_utils.hpp
@@ -338,7 +338,10 @@ makeShmemOrMockMigrationClient(const tt::config::BlazeConfig& config) {
   switch (config.runner_type) {
     case tt::config::ModelRunnerType::PIPELINE_MANAGER:
 #ifdef ENABLE_BLAZE_MIGRATION
-      return std::make_unique<sch::MigrationLayerClientAdapter>(
+      // create() waits (retries) for the migration endpoint's shmem queues to appear
+      // instead of throwing immediately, so the server can start before the endpoint
+      // is up. Timeout via TT_MIGRATION_CLIENT_ATTACH_TIMEOUT_MS (default 2 min).
+      return sch::MigrationLayerClientAdapter::create(
           config.migrationCmdQueueName, config.migrationTableQueueName,
           config.migrationRespQueueName);
 #else
@@ -448,7 +451,10 @@ makeDecodeMigrationClientInterface(const tt::config::BlazeConfig& config) {
   switch (config.runner_type) {
     case tt::config::ModelRunnerType::PIPELINE_MANAGER:
 #ifdef ENABLE_BLAZE_MIGRATION
-      return std::make_unique<sch::MigrationLayerClientAdapter>(
+      // create() waits (retries) for the migration endpoint's shmem queues to appear
+      // instead of throwing immediately, so the server can start before the endpoint
+      // is up. Timeout via TT_MIGRATION_CLIENT_ATTACH_TIMEOUT_MS (default 2 min).
+      return sch::MigrationLayerClientAdapter::create(
           config.migrationCmdQueueName, config.migrationTableQueueName,
           config.migrationRespQueueName);
 #else

--- a/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_utils.hpp
+++ b/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_utils.hpp
@@ -338,9 +338,10 @@ makeShmemOrMockMigrationClient(const tt::config::BlazeConfig& config) {
   switch (config.runner_type) {
     case tt::config::ModelRunnerType::PIPELINE_MANAGER:
 #ifdef ENABLE_BLAZE_MIGRATION
-      // create() waits (retries) for the migration endpoint's shmem queues to appear
-      // instead of throwing immediately, so the server can start before the endpoint
-      // is up. Timeout via TT_MIGRATION_CLIENT_ATTACH_TIMEOUT_MS (default 2 min).
+      // create() waits (retries) for the migration endpoint's shmem queues to
+      // appear instead of throwing immediately, so the server can start before
+      // the endpoint is up. Timeout via TT_MIGRATION_CLIENT_ATTACH_TIMEOUT_MS
+      // (default 2 min).
       return sch::MigrationLayerClientAdapter::create(
           config.migrationCmdQueueName, config.migrationTableQueueName,
           config.migrationRespQueueName);
@@ -451,9 +452,10 @@ makeDecodeMigrationClientInterface(const tt::config::BlazeConfig& config) {
   switch (config.runner_type) {
     case tt::config::ModelRunnerType::PIPELINE_MANAGER:
 #ifdef ENABLE_BLAZE_MIGRATION
-      // create() waits (retries) for the migration endpoint's shmem queues to appear
-      // instead of throwing immediately, so the server can start before the endpoint
-      // is up. Timeout via TT_MIGRATION_CLIENT_ATTACH_TIMEOUT_MS (default 2 min).
+      // create() waits (retries) for the migration endpoint's shmem queues to
+      // appear instead of throwing immediately, so the server can start before
+      // the endpoint is up. Timeout via TT_MIGRATION_CLIENT_ATTACH_TIMEOUT_MS
+      // (default 2 min).
       return sch::MigrationLayerClientAdapter::create(
           config.migrationCmdQueueName, config.migrationTableQueueName,
           config.migrationRespQueueName);


### PR DESCRIPTION
This PR correlates with: [https://github.com/tenstorrent/tt-llm-engine/pull/216/changes](https://github.com/tenstorrent/tt-llm-engine/pull/216/changes). It removes direct dependency between migration layer and inference server, so they can start in any order and inference server waits until migration layer is ready.