### PR TITLE
Always Set Kv Position on Cache Hit Path

### DIFF
--- a/tt-media-server/cpp_server/include/services/session_resolution.hpp
+++ b/tt-media-server/cpp_server/include/services/session_resolution.hpp
@@ -49,7 +49,7 @@ inline uint32_t applyDeltaPrompt(tt::domain::llm::LLMRequest& req,
   tokens.erase(tokens.begin(), tokens.begin() + static_cast<ptrdiff_t>(skip));
   req.prompt_tokens_count = static_cast<int>(tokens.size());
 
-  if (options.setKvPositionId && matchedTokens > 0) {
+  if (options.setKvPositionId) {
     // First free KV index: the matched prefix fills indices [0, matchedTokens),
     // so the next token's KV is written at matchedTokens.
     req.kv_position_id = matchedTokens;

--- a/tt-media-server/cpp_server/tests/unit/model/apply_delta_prompt_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/model/apply_delta_prompt_test.cpp
@@ -81,16 +81,6 @@ TEST(ApplyDeltaPrompt, MultiTurnSuffix) {
   EXPECT_EQ(req.prompt_tokens_count, 1297);
 }
 
-// Zero matched tokens is a no-op.
-TEST(ApplyDeltaPrompt, ZeroMatchedTokens_NoOp) {
-  auto req = makeRequest(100);
-  applyDeltaPrompt(req, 0);
-
-  auto& tokens = std::get<std::vector<uint32_t>>(req.prompt);
-  EXPECT_EQ(tokens.size(), 100u);
-  EXPECT_FALSE(req.kv_position_id.has_value());
-}
-
 // matchedTokens >= total is a no-op.
 TEST(ApplyDeltaPrompt, MatchedExceedsTotal_NoOp) {
   auto req = makeRequest(50);


### PR DESCRIPTION
## Problem
Since `kv_position_id` stored in slot memory is not reset when a slot transitions to the Idle state, it should explicitly set on the cache-hit path as well. This ensures consistency and prevents accidentally reusing a stale `kv_position_id` left over from the slot's previous use.