### PR TITLE
Build Blaze As Default

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -61,7 +61,7 @@ cd tt-media-server/cpp_server
 cd tt-llm-engine
 ./setup.sh --all
 cd ..
-./build.sh --blaze
+./build.sh
 ```
 
 Set `TT_INFERENCE_DEV_IMAGE` to override the local Docker image tag:

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -83,4 +83,4 @@ cd "${llm_engine}"
 
 cd "${cpp_server}"
 cleanup_moved_cmake_build_dir "${cpp_server}/build" "${cpp_server}"
-./build.sh --blaze
+./build.sh

--- a/.github/workflows/cpp-heavy-checks.yml
+++ b/.github/workflows/cpp-heavy-checks.yml
@@ -1286,7 +1286,7 @@ jobs:
       - name: Build C++ server with ThreadSanitizer
         run: |
           cd cpp_server
-          ./build.sh --tsan
+          ./build.sh --tsan --blaze
 
       - name: Archive C++ tokenizer bundle
         run: |
@@ -1312,13 +1312,15 @@ jobs:
           uv pip install guidellm
           echo "PATH=${{ github.workspace }}/tt-media-server/.venv/bin:$PATH" >> $GITHUB_ENV
 
-      - name: Start TSan-instrumented server (mock_pipeline)
+      - name: Start TSan-instrumented server (mock_scheduler)
         env:
           TSAN_OPTIONS: "suppressions=${{ github.workspace }}/tt-media-server/cpp_server/tsan_suppressions.txt:halt_on_error=0:second_deadlock_stack=1:history_size=7:log_path=tsan-server"
         run: |
           bash cpp_server/scripts/ci/wait_for_port_free.sh --port 8001 --label "TSan-instrumented server"
           cd cpp_server/build
-          ./tt_media_server_cpp -p 8001 -t 4 > ../../tsan_server.log 2>&1 &
+          # mock_scheduler = CPU-only MockDecodeScheduler (no device); the LLM
+          # runner it needs is only compiled with --blaze (see build step).
+          LLM_DEVICE_BACKEND=mock_scheduler ./tt_media_server_cpp -p 8001 -t 4 > ../../tsan_server.log 2>&1 &
           echo $! > ../../tsan_server.pid
           cd ../..
           bash cpp_server/scripts/ci/wait_for_liveness.sh \

--- a/.github/workflows/cpp-heavy-checks.yml
+++ b/.github/workflows/cpp-heavy-checks.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Build C++ server
         run: |
           cd cpp_server
-          ./build.sh --blaze
+          ./build.sh
           cd ..
 
       - name: Archive C++ build
@@ -122,7 +122,7 @@ jobs:
       - name: Build C++ server
         run: |
           cd cpp_server
-          ./build.sh --blaze
+          ./build.sh
           cd ..
 
       - name: Set up uv
@@ -287,7 +287,7 @@ jobs:
       - name: Build C++ server
         run: |
           cd cpp_server
-          ./build.sh --blaze
+          ./build.sh
           cd ..
 
       - name: Set up uv
@@ -481,7 +481,7 @@ jobs:
       - name: Build C++ server
         run: |
           cd cpp_server
-          ./build.sh --blaze
+          ./build.sh
           cd ..
 
       - name: Configure prefill_gateway
@@ -1286,7 +1286,7 @@ jobs:
       - name: Build C++ server with ThreadSanitizer
         run: |
           cd cpp_server
-          ./build.sh --tsan --blaze
+          ./build.sh --tsan
 
       - name: Archive C++ tokenizer bundle
         run: |
@@ -1318,8 +1318,6 @@ jobs:
         run: |
           bash cpp_server/scripts/ci/wait_for_port_free.sh --port 8001 --label "TSan-instrumented server"
           cd cpp_server/build
-          # mock_scheduler = CPU-only MockDecodeScheduler (no device); the LLM
-          # runner it needs is only compiled with --blaze (see build step).
           LLM_DEVICE_BACKEND=mock_scheduler ./tt_media_server_cpp -p 8001 -t 4 > ../../tsan_server.log 2>&1 &
           echo $! > ../../tsan_server.pid
           cd ../..

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -652,7 +652,7 @@ jobs:
       - name: C++ lint check (build with clang-tidy)
         run: |
           cd cpp_server
-          ./build.sh --clang-tidy --blaze
+          ./build.sh --clang-tidy
 
   prefill-gateway-format-check:
     needs: detect-changes
@@ -750,7 +750,7 @@ jobs:
       - name: Build C++ server
         run: |
           cd cpp_server
-          ./build.sh --blaze
+          ./build.sh
           cd ..
 
       - name: Run C++ unit tests
@@ -766,7 +766,7 @@ jobs:
     # #4294: builds bringup_mooncake_worker with the Mooncake Transfer Engine
     # (--mooncake) and runs the single-host MPI discovery test
     # (run_migration_workers_mpi.sh, registered as the MooncakeMpiDiscovery
-    # ctest). Mooncake isn't part of the --blaze build, so this is a dedicated
+    # ctest). Mooncake is not part of the default build, so this is a dedicated
     # job rather than another step in cpp-build. The TCP+HTTP-only subset
     # (USE_TCP/USE_HTTP, no etcd/redis/rust) keeps the system deps minimal.
     runs-on: ubuntu-latest
@@ -929,7 +929,7 @@ jobs:
       - name: Build C++ server with Kafka enabled
         run: |
           cd cpp_server
-          ./build.sh --blaze --kafka
+          ./build.sh --kafka
 
       - name: Start dev Kafka broker
         # KAFKA_PUBLISH_PORT publishes 9092 to the host so the test binary,

--- a/mooncake/poc-transfer-engine/README.md
+++ b/mooncake/poc-transfer-engine/README.md
@@ -61,7 +61,7 @@ surface, and how this attaches to the existing tt-llm-engine migration worker.
 
 The Mooncake `transfer_engine` is built **from source** out of the vendored submodule
 (`third_party/Mooncake`), so a fresh clone needs two one-time setup steps before
-`./build.sh --mooncake` will configure. (Plain `./build.sh` / `--blaze` builds don't
+`./build.sh --mooncake` will configure. (Plain `./build.sh` builds don't
 need any of this — Mooncake is only pulled in by `--mooncake`.)
 
 ### 1. Check out the Mooncake submodule — recursively
@@ -128,23 +128,23 @@ build output under that root — **not** from inside `build/`):
 
 ```bash
 ./build.sh                    # both guards OFF — transport_lib/transport_test still build (no-op fallbacks)
-./build.sh --blaze            # real UMD device-DRAM backend (USE_METAL_CPP_LIB)
+./build.sh            # real UMD device-DRAM backend (USE_METAL_CPP_LIB)
 ./build.sh --mooncake         # real Mooncake transport (TCP+RDMA) → also builds transport_migration_e2e
-./build.sh --blaze --mooncake # both real backends — required for the device-DRAM (real HW) e2e path
+./build.sh --mooncake # both real backends — required for the device-DRAM (real HW) e2e path
 
 cd build && ctest --output-on-failure        # runs transport_test in any configuration
 
 # Two-process acceptance harness (stays in cpp_server; needs a --mooncake build):
 tests/e2e/scripts/run_transport_migration_e2e.sh                 # transport-only loopback, no HW
 STORAGE=device SRC_DEVICE_ID=0 DST_DEVICE_ID=1 \
-  tests/e2e/scripts/run_transport_migration_e2e.sh               # real device DRAM, two boards (build with --blaze --mooncake)
+  tests/e2e/scripts/run_transport_migration_e2e.sh               # real device DRAM, two boards (build with --mooncake)
 
 # #4209 worker discovery via the Mooncake Metadata Service (host RAM only, two hosts):
 tests/integration/run_mooncake_metadata_server.sh                 # start the metadata service
 tests/integration/run_migration_worker_discovery.sh               # single-host smoke (auto-starts service)
 ```
 
-Build guards: `USE_METAL_CPP_LIB` (real UMD I/O, via `--blaze`) and
+Build guards: `USE_METAL_CPP_LIB` (real UMD I/O) and
 `TT_TRANSPORT_WITH_MOONCAKE` (real Mooncake transport, via `--mooncake`). Each real
 backend sits behind a guard with a no-op fallback, so the library and unit test build
 in **every** configuration.
@@ -154,7 +154,7 @@ in **every** configuration.
 | Step | Status |
 |------|--------|
 | Interfaces + host-DRAM round-trip + worker staging (`transport_test`, any build) | impl |
-| Device-DRAM backend single-galaxy round-trip (UMD, `--blaze`) | impl |
+| Device-DRAM backend single-galaxy round-trip (UMD) | impl |
 | Mooncake transport loopback TCP (host backend, `--mooncake`) | impl |
 | Two-galaxy acceptance, both backends enabled | pending a two-process HW run |
 | Metadata-service worker discovery, two hosts, host RAM (#4209) | impl |

--- a/mooncake/poc-transfer-engine/adr-mooncake-backend.md
+++ b/mooncake/poc-transfer-engine/adr-mooncake-backend.md
@@ -145,7 +145,7 @@ transport (with a zero-copy `acquire/publish`) while this branch *splits* them
 differ (MPI rank + `KvChunkAddressTable` vs `openSegment`/offset + P2PHANDSHAKE);
 receiver-write and ACK/fault semantics differ (DCN receiver-drains-then-writes vs
 Mooncake one-sided write); and Mooncake currently builds inside tt-llm-engine
-(`DS_ENABLE_MOONCAKE`, needs `ENABLE_BLAZE`) while `transport_lib` is dependency-free.
+(`DS_ENABLE_MOONCAKE`) while `transport_lib` is dependency-free.
 
 ## Mooncake API surface (verified against upstream `main`)
 

--- a/tt-media-server/Dockerfile.blaze
+++ b/tt-media-server/Dockerfile.blaze
@@ -145,7 +145,7 @@ RUN export CARGO_HOME=${HOME_DIR}/.cargo \
 COPY --from=engine /opt/tt-llm-engine     /opt/tt-llm-engine
 COPY --from=engine /opt/tt-llm-engine-src /opt/tt-llm-engine-src
 
-# ----- Build cpp_server with ENABLE_BLAZE=ON -----
+# ----- Build cpp_server with ENABLE_BLAZE_MIGRATION=ON -----
 # cpp_server/CMakeLists.txt uses find_package(tt-llm-engine CONFIG QUIET)
 # (with add_subdirectory fallback for local dev), so this build links
 # against /opt/tt-llm-engine instead of recompiling tt-llm-engine in-tree.

--- a/tt-media-server/cpp_server/.cursor/skills/profile-cpp-server/SKILL.md
+++ b/tt-media-server/cpp_server/.cursor/skills/profile-cpp-server/SKILL.md
@@ -19,11 +19,11 @@ For `tt_media_server_cpp` you usually want both: the worker's `BlazeRunner::step
 
 All paths below are relative to `tt-media-server/cpp_server/`.
 
-1. **Build the server with the BlazeRunner code path enabled.** Without `--blaze`, the runner registry falls back to `MOCK` and you'll be profiling the wrong code.
+1. **Build the server.** tt-llm-engine/Blaze is always built in, so the BlazeRunner code path is used automatically.
 
    ```bash
    cd tt-media-server/cpp_server
-   ./build.sh --blaze
+   ./build.sh
    ```
 
    Verify the binary is fresh and not stripped:
@@ -33,7 +33,7 @@ All paths below are relative to `tt-media-server/cpp_server/`.
    ls build/tt_media_server_cpp
    ```
 
-2. **Start the server with the mock pipeline backend, and stash its PID for step 6.** Tokenizer files must be in place (`./build.sh --blaze` fetches them; for an ad-hoc download see `build.sh:200`). Capturing `$!` immediately is the simplest way to make sure cleanup later kills the right process and not some other `tt_media_server_cpp` (`pkill -f` is too broad — see the warning in step 6).
+2. **Start the server with the mock pipeline backend, and stash its PID for step 6.** Tokenizer files must be in place (`./build.sh` fetches them; for an ad-hoc download see `build.sh:200`). Capturing `$!` immediately is the simplest way to make sure cleanup later kills the right process and not some other `tt_media_server_cpp` (`pkill -f` is too broad — see the warning in step 6).
 
    ```bash
    LLM_DEVICE_BACKEND=mock_pipeline ./build/tt_media_server_cpp \
@@ -45,11 +45,9 @@ All paths below are relative to `tt-media-server/cpp_server/`.
    until curl -sf http://127.0.0.1:8000/tt-liveness \
             | grep -q '"model_ready":true'; do sleep 1; done
 
-   # Confirm Blaze runner (not the MOCK fallback) was selected.
+   # Confirm the Blaze runner was selected.
    grep -E "Creating Blaze runner|RunnerRegistry" server.log | head
    # Expect: "[RunnerRegistry] Creating Blaze runner (pipeline_manager)"
-   # If you see "No factory registered for (llm, mock_pipeline); falling back
-   # to MOCK", the binary was built without --blaze — go back to step 1.
    ```
 
 3. **Drive load and capture.** A flamegraph of an idle process is mostly Tracy / metrics / epoll noise — push traffic during the capture window. The script then handles `perf record`, `stackcollapse-perf`, `flamegraph.pl`, and kernel-frame folding.

--- a/tt-media-server/cpp_server/AGENTS.md
+++ b/tt-media-server/cpp_server/AGENTS.md
@@ -27,7 +27,7 @@ title alone.
 ## Build
 
 ```bash
-./build.sh --blaze
+./build.sh
 ```
 
 ## Run

--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -241,18 +241,14 @@ FetchContent_Declare(
 set(CPPZMQ_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(cppzmq)
 
-# Option to enable tt-llm-engine (formerly tt-blaze pipeline_manager)
-option(ENABLE_BLAZE "Enable tt-llm-engine support" OFF)
-# Real shmem migration (MigrationLayerClientAdapter + migration_client static lib).
-# mock_pipeline CI builds use --blaze only; disaggregated pipeline_manager runs
-# need --blaze-with-migration (implies ENABLE_BLAZE).
-option(ENABLE_BLAZE_MIGRATION "Build real shmem migration client (requires ENABLE_BLAZE)" OFF)
-if(ENABLE_BLAZE_MIGRATION AND NOT ENABLE_BLAZE)
-    message(FATAL_ERROR "ENABLE_BLAZE_MIGRATION=ON requires ENABLE_BLAZE=ON (use build.sh --blaze-with-migration)")
-endif()
 
-if(ENABLE_BLAZE)
-    # Prefer a pre-built tt-llm-engine discovered via find_package — this is
+# Real shmem migration (MigrationLayerClientAdapter + migration_client static lib).
+# tt-llm-engine/mock_pipeline is always built; disaggregated pipeline_manager
+# runs additionally need --blaze-with-migration.
+option(ENABLE_BLAZE_MIGRATION "Build real shmem migration client" OFF)
+
+
+# Prefer a pre-built tt-llm-engine discovered via find_package — this is
     # the path used by the Docker build, which pulls /opt/tt-llm-engine out
     # of the tt-llm-engine builder image and sets CMAKE_PREFIX_PATH so the
     # package is locatable. Fall back to building the in-tree submodule for
@@ -276,15 +272,12 @@ if(ENABLE_BLAZE)
         message(STATUS "tt-llm-engine: building from in-tree submodule (legacy path)")
     else()
         message(FATAL_ERROR
-            "ENABLE_BLAZE=ON but tt-llm-engine is neither installed "
+            "tt-llm-engine is neither installed "
             "(find_package failed) nor present in source tree at "
             "${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine. "
             "Either ensure the prebuilt image's /opt/tt-llm-engine is on "
             "CMAKE_PREFIX_PATH, or initialize the tt-llm-engine submodule.")
     endif()
-else()
-    message(STATUS "tt-llm-engine: DISABLED (use -DENABLE_BLAZE=ON to enable)")
-endif()
 
 # Mooncake Transfer Engine (TCP + RDMA) is vendored as a top-level git submodule
 # at third_party/Mooncake (pinned to release v0.3.11.post1) and built directly
@@ -473,15 +466,13 @@ set(LLM_RUNNER_LIB_SOURCES
     src/api/route_registry.cpp
 )
 
-# Add tt-llm-engine-dependent sources only when ENABLE_BLAZE is ON
-if(ENABLE_BLAZE)
-    list(APPEND LLM_RUNNER_LIB_SOURCES
+# Add tt-llm-engine-dependent sources
+list(APPEND LLM_RUNNER_LIB_SOURCES
         src/runtime/runners/blaze_runner/blaze_decode_runner.cpp
         src/runtime/runners/blaze_runner/blaze_prefill_runner.cpp
         src/runtime/runners/blaze_runner/blaze_scheduler_factory.cpp
     )
-    message(STATUS "llm_runner_lib: including tt-llm-engine-dependent sources (ENABLE_BLAZE=ON)")
-endif()
+    message(STATUS "llm_runner_lib: including tt-llm-engine-dependent sources")
 
 add_library(llm_runner_lib ${LLM_RUNNER_LIB_SOURCES})
 target_include_directories(llm_runner_lib PUBLIC
@@ -491,73 +482,68 @@ target_include_directories(llm_runner_lib PUBLIC
 # Link tokenizers_cpp, JsonCpp, xgrammar (guided decoding), and xxhash (stable hashing)
 target_link_libraries(llm_runner_lib PUBLIC tokenizers_cpp JsonCpp::JsonCpp xgrammar xxhash_lib)
 
-# Link tt-llm-engine when ENABLE_BLAZE is ON: prefer Full (SocketPipeline + TT::Metalium),
+# Link tt-llm-engine: prefer Full (SocketPipeline + TT::Metalium),
 # fall back to Core (mock pipeline only).
-if(ENABLE_BLAZE)
-    if(TARGET TtLlmEngine::Full)
-        target_link_libraries(llm_runner_lib PUBLIC TtLlmEngine::Full)
-        message(STATUS "Linking llm_runner_lib against TtLlmEngine::Full")
-    elseif(TARGET TtLlmEngine::Core)
-        target_link_libraries(llm_runner_lib PUBLIC TtLlmEngine::Core)
-        message(STATUS "Linking llm_runner_lib against TtLlmEngine::Core")
-    endif()
-    target_compile_definitions(llm_runner_lib PUBLIC ENABLE_BLAZE)
-    # Detect where the tt-llm-engine source tree lives. Two layouts are supported:
-    #   1. Monolithic flow (main's Dockerfile.blaze): cpp_server/tt-llm-engine/ —
-    #      cloned in-tree during the Docker build.
-    #   2. Slim flow (v2 Dockerfile.blaze): /opt/tt-llm-engine-src/ — COPY'd from
-    #      the prebuilt tt-llm-engine image's source tree.
-    # Both layouts expose the same subdirectories (src/, disaggregation/, tt-metal/),
-    # so a single root variable lets every consumer-of-engine-source path adapt.
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/CMakeLists.txt")
-        set(_TT_LLM_ENGINE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine")
-        message(STATUS "tt-llm-engine source: in-tree at ${_TT_LLM_ENGINE_ROOT}")
-    elseif(EXISTS "/opt/tt-llm-engine-src/CMakeLists.txt")
-        set(_TT_LLM_ENGINE_ROOT "/opt/tt-llm-engine-src")
-        message(STATUS "tt-llm-engine source: slim engine image at ${_TT_LLM_ENGINE_ROOT}")
-    else()
-        message(FATAL_ERROR
-            "ENABLE_BLAZE=ON but tt-llm-engine source not found. Expected either "
-            "${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/ (in-tree clone, monolithic flow) "
-            "or /opt/tt-llm-engine-src/ (slim engine image flow).")
-    endif()
-
-    # Header-only MigrationClientInterface implementations (MigrationLayerClientAdapter,
-    # MockMigrationClient) live under the engine's src tree rather than its public
-    # include tree; blaze_utils.hpp instantiates them, so expose that path.
-    target_include_directories(llm_runner_lib PUBLIC
-        ${_TT_LLM_ENGINE_ROOT}/src)
-
-    if(ENABLE_BLAZE_MIGRATION)
-        target_compile_definitions(llm_runner_lib PUBLIC ENABLE_BLAZE_MIGRATION)
-        # MigrationLayerClientAdapter forwards to migration_worker::MigrationLayerClient,
-        # whose implementation lives in the disaggregation/migration project. That
-        # project is a standalone CMake project() (own CPM cache + find_package(MPI)),
-        # so it can't be add_subdirectory'd here. Its client is lightweight though
-        # (just POSIX shmem queues), so we compile the two needed translation units
-        # directly into a small static lib and link it in. There is a single concrete
-        # implementation (no mock/real .so swap), so static linking is sufficient for
-        # both Core and LD_PRELOAD'd Full runs.
-        set(_MIG_DIR ${_TT_LLM_ENGINE_ROOT}/disaggregation/migration)
-        set(_MIG_TT_STL "${_TT_LLM_ENGINE_ROOT}/tt-metal/tt_stl")
-        add_library(migration_client STATIC
-            ${_MIG_DIR}/src/migration_client.cpp
-            ${_MIG_DIR}/src/file_lock_guard.cpp)
-        set_target_properties(migration_client PROPERTIES POSITION_INDEPENDENT_CODE ON)
-        target_include_directories(migration_client PUBLIC
-            ${_MIG_DIR}/include
-            ${_MIG_DIR}/src/worker
-            ${_TT_LLM_ENGINE_ROOT}/src/common
-            ${TT_METAL_INCLUDE_DIRS}
-            ${_MIG_TT_STL})
-        target_link_libraries(migration_client PUBLIC spdlog::spdlog PRIVATE rt)
-        target_link_libraries(llm_runner_lib PUBLIC migration_client)
-        message(STATUS "Blaze migration client: ENABLED (ENABLE_BLAZE_MIGRATION=ON)")
-    else()
-        message(STATUS "Blaze migration client: DISABLED (use build.sh --blaze-with-migration for pipeline_manager shmem migration)")
-    endif()
+if(TARGET TtLlmEngine::Full)
+    target_link_libraries(llm_runner_lib PUBLIC TtLlmEngine::Full)
+    message(STATUS "Linking llm_runner_lib against TtLlmEngine::Full")
+elseif(TARGET TtLlmEngine::Core)
+    target_link_libraries(llm_runner_lib PUBLIC TtLlmEngine::Core)
+    message(STATUS "Linking llm_runner_lib against TtLlmEngine::Core")
+endif()
+# Detect where the tt-llm-engine source tree lives. Two layouts are supported:
+#   1. Monolithic flow (main's Dockerfile.blaze): cpp_server/tt-llm-engine/ —
+#      cloned in-tree during the Docker build.
+#   2. Slim flow (v2 Dockerfile.blaze): /opt/tt-llm-engine-src/ — COPY'd from
+#      the prebuilt tt-llm-engine image's source tree.
+# Both layouts expose the same subdirectories (src/, disaggregation/, tt-metal/),
+# so a single root variable lets every consumer-of-engine-source path adapt.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/CMakeLists.txt")
+    set(_TT_LLM_ENGINE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine")
+    message(STATUS "tt-llm-engine source: in-tree at ${_TT_LLM_ENGINE_ROOT}")
+elseif(EXISTS "/opt/tt-llm-engine-src/CMakeLists.txt")
+    set(_TT_LLM_ENGINE_ROOT "/opt/tt-llm-engine-src")
+    message(STATUS "tt-llm-engine source: slim engine image at ${_TT_LLM_ENGINE_ROOT}")
 else()
-    message(STATUS "Skipping tt-llm-engine linking (ENABLE_BLAZE=OFF)")
+    message(FATAL_ERROR
+        "tt-llm-engine source not found. Expected either "
+        "${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/ (in-tree clone, monolithic flow) "
+        "or /opt/tt-llm-engine-src/ (slim engine image flow).")
+endif()
+
+# Header-only MigrationClientInterface implementations (MigrationLayerClientAdapter,
+# MockMigrationClient) live under the engine's src tree rather than its public
+# include tree; blaze_utils.hpp instantiates them, so expose that path.
+target_include_directories(llm_runner_lib PUBLIC
+    ${_TT_LLM_ENGINE_ROOT}/src)
+
+if(ENABLE_BLAZE_MIGRATION)
+    target_compile_definitions(llm_runner_lib PUBLIC ENABLE_BLAZE_MIGRATION)
+    # MigrationLayerClientAdapter forwards to migration_worker::MigrationLayerClient,
+    # whose implementation lives in the disaggregation/migration project. That
+    # project is a standalone CMake project() (own CPM cache + find_package(MPI)),
+    # so it can't be add_subdirectory'd here. Its client is lightweight though
+    # (just POSIX shmem queues), so we compile the two needed translation units
+    # directly into a small static lib and link it in. There is a single concrete
+    # implementation (no mock/real .so swap), so static linking is sufficient for
+    # both Core and LD_PRELOAD'd Full runs.
+    set(_MIG_DIR ${_TT_LLM_ENGINE_ROOT}/disaggregation/migration)
+    set(_MIG_TT_STL "${_TT_LLM_ENGINE_ROOT}/tt-metal/tt_stl")
+    add_library(migration_client STATIC
+        ${_MIG_DIR}/src/migration_client.cpp
+        ${_MIG_DIR}/src/file_lock_guard.cpp)
+    set_target_properties(migration_client PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    target_include_directories(migration_client PUBLIC
+        ${_MIG_DIR}/include
+        ${_MIG_DIR}/src/worker
+        ${_TT_LLM_ENGINE_ROOT}/src/common
+        ${TT_METAL_INCLUDE_DIRS}
+        ${_MIG_TT_STL})
+    target_link_libraries(migration_client PUBLIC spdlog::spdlog PRIVATE rt)
+    target_link_libraries(llm_runner_lib PUBLIC migration_client)
+    message(STATUS "Blaze migration client: ENABLED (ENABLE_BLAZE_MIGRATION=ON)")
+else()
+    message(STATUS "Blaze migration client: DISABLED (use build.sh --blaze-with-migration for pipeline_manager shmem migration)")
 endif()
 if(USE_EXTERNAL_FMT)
     target_link_libraries(llm_runner_lib PUBLIC Boost::boost spdlog::spdlog fmt::fmt)
@@ -838,7 +824,7 @@ if(TARGET transfer_engine)
 
     # Real KV-cache migration (table-addressed mirror + orchestration over a
     # TCP control channel). Self-contained TCP control transport, links only
-    # transport_lib. host mode runs with no hardware; device mode needs --blaze;
+    # transport_lib. host mode runs with no hardware;
     # real-table (--table <pb>) needs -DENABLE_KV_TABLE=ON.
     add_executable(transport_kv_migration_e2e
         tests/e2e/transport_kv_migration_e2e.cpp)
@@ -934,36 +920,33 @@ target_link_libraries(dynamo_protocol_test PRIVATE
 target_include_directories(dynamo_protocol_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
+add_executable(blaze_decode_runner_test
+    tests/integration/runners/blaze_decode_runner_test.cpp
+    src/runtime/worker/single_process_worker_metrics.cpp
+    src/runtime/worker/worker_metrics_shm.cpp
+)
+target_link_libraries(blaze_decode_runner_test PRIVATE llm_runner_lib GTest::gtest_main)
+target_include_directories(blaze_decode_runner_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
 
-if(ENABLE_BLAZE)
-    add_executable(blaze_decode_runner_test
-        tests/integration/runners/blaze_decode_runner_test.cpp
-        src/runtime/worker/single_process_worker_metrics.cpp
-        src/runtime/worker/worker_metrics_shm.cpp
-    )
-    target_link_libraries(blaze_decode_runner_test PRIVATE llm_runner_lib GTest::gtest_main)
-    target_include_directories(blaze_decode_runner_test PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-    )
+add_executable(blaze_prefill_runner_test
+    tests/integration/runners/blaze_prefill_runner_test.cpp
+    src/runtime/worker/single_process_worker_metrics.cpp
+    src/runtime/worker/worker_metrics_shm.cpp
+)
+target_link_libraries(blaze_prefill_runner_test PRIVATE llm_runner_lib GTest::gtest_main)
+target_include_directories(blaze_prefill_runner_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
 
-    add_executable(blaze_prefill_runner_test
-        tests/integration/runners/blaze_prefill_runner_test.cpp
-        src/runtime/worker/single_process_worker_metrics.cpp
-        src/runtime/worker/worker_metrics_shm.cpp
-    )
-    target_link_libraries(blaze_prefill_runner_test PRIVATE llm_runner_lib GTest::gtest_main)
-    target_include_directories(blaze_prefill_runner_test PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-    )
-
-    add_executable(mock_schedulers_test
-        tests/unit/runners/mock_schedulers_test.cpp
-    )
-    target_link_libraries(mock_schedulers_test PRIVATE llm_runner_lib GTest::gtest_main)
-    target_include_directories(mock_schedulers_test PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-    )
-endif()
+add_executable(mock_schedulers_test
+    tests/unit/runners/mock_schedulers_test.cpp
+)
+target_link_libraries(mock_schedulers_test PRIVATE llm_runner_lib GTest::gtest_main)
+target_include_directories(mock_schedulers_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
 
 add_executable(sequence_test tests/unit/model/sequence_test.cpp)
 target_link_libraries(sequence_test PRIVATE
@@ -1299,11 +1282,9 @@ gtest_discover_tests(kv_migration_orchestrator_test)
 if(ENABLE_KV_TABLE)
     gtest_discover_tests(kv_chunk_address_table_adapter_test)
 endif()
-if(ENABLE_BLAZE)
-    gtest_discover_tests(blaze_decode_runner_test)
-    gtest_discover_tests(blaze_prefill_runner_test)
-    gtest_discover_tests(mock_schedulers_test)
-endif()
+gtest_discover_tests(blaze_decode_runner_test)
+gtest_discover_tests(blaze_prefill_runner_test)
+gtest_discover_tests(mock_schedulers_test)
 gtest_discover_tests(sequence_test)
 gtest_discover_tests(lockfree_queue_test)
 gtest_discover_tests(tokenizer_test)
@@ -1399,26 +1380,21 @@ if(KAFKA_ENABLED)
     )
 
     # RemoteKVManagerAdapter - bridges IRemoteKVManager to MigrationClientInterface
-    # Only built when ENABLE_BLAZE is ON (requires tt-llm-engine headers)
     # Note: disaggregation/migration/include is needed for migration_client.hpp
     # which migration_client_interface.hpp includes for event types.
-    if(ENABLE_BLAZE)
-        add_library(remote_kv_adapter
-            src/services/remote_kv_manager_adapter.cpp
-        )
-        target_include_directories(remote_kv_adapter PUBLIC
-            ${CMAKE_CURRENT_SOURCE_DIR}/include
-            ${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/include
-            ${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/disaggregation/migration/include
-        )
-        target_link_libraries(remote_kv_adapter PUBLIC
-            messaging
-            spdlog::spdlog
-        )
-        message(STATUS "remote_kv_adapter: ENABLED (ENABLE_BLAZE=ON)")
-    else()
-        message(STATUS "remote_kv_adapter: DISABLED (requires ENABLE_BLAZE=ON)")
-    endif()
+    add_library(remote_kv_adapter
+        src/services/remote_kv_manager_adapter.cpp
+    )
+    target_include_directories(remote_kv_adapter PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/tt-llm-engine/disaggregation/migration/include
+    )
+    target_link_libraries(remote_kv_adapter PUBLIC
+        messaging
+        spdlog::spdlog
+    )
+    message(STATUS "remote_kv_adapter: ENABLED")
 
     # Migration worker library (for consumer instances)
     add_library(migration_worker
@@ -1696,8 +1672,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE stb_image_write)
 # runner with a different workspace path). Without this, CMake bakes the
 # absolute build-time path into RUNPATH and ld.so fails to find
 # libtt_llm_engine_core.so.0 elsewhere.
-if(ENABLE_BLAZE)
-    # $ORIGIN/tt-llm-engine keeps libtt_llm_engine_core.so.0 / libtt_llm_engine.so.0
+# $ORIGIN/tt-llm-engine keeps libtt_llm_engine_core.so.0 / libtt_llm_engine.so.0
     # resolvable when the build artifact is unpacked on a different machine.
     # INSTALL_RPATH_USE_LINK_PATH TRUE additionally appends the absolute link
     # directories (e.g. tt-llm-engine/tt-metal/build_Release/lib where libfmt.so.11,
@@ -1709,7 +1684,6 @@ if(ENABLE_BLAZE)
         INSTALL_RPATH "$ORIGIN/tt-llm-engine"
         INSTALL_RPATH_USE_LINK_PATH TRUE
     )
-endif()
 
 # Compiler warnings
 target_compile_options(${PROJECT_NAME} PRIVATE

--- a/tt-media-server/cpp_server/build.sh
+++ b/tt-media-server/cpp_server/build.sh
@@ -12,7 +12,6 @@ BUILD_TYPE="Release"
 SANITIZE_THREAD="OFF"
 SANITIZE_ADDRESS="OFF"
 ENABLE_TRACY="OFF"
-ENABLE_BLAZE="OFF"
 ENABLE_BLAZE_MIGRATION="OFF"
 CLANG_TIDY="OFF"
 TOOLCHAIN_PATH_ARG=""
@@ -42,12 +41,7 @@ while [[ $# -gt 0 ]]; do
             BUILD_TYPE="Debug"
             shift
             ;;
-        --blaze)
-            ENABLE_BLAZE="ON"
-            shift
-            ;;
         --blaze-with-migration)
-            ENABLE_BLAZE="ON"
             ENABLE_BLAZE_MIGRATION="ON"
             shift
             ;;
@@ -87,8 +81,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --tsan               Build with ThreadSanitizer for data-race detection"
             echo "  --asan               Build with AddressSanitizer + LeakSanitizer for memory/leak detection"
             echo "  --tracy              Build with Tracy profiling instrumentation"
-            echo "  --blaze              Build with tt-llm-engine / mock_pipeline support"
-            echo "  --blaze-with-migration  Same as --blaze plus real shmem migration (pipeline_manager)"
+            echo "  --blaze-with-migration  Real shmem migration (pipeline_manager)"
             echo "  --clang-tidy          Run clang-tidy during build (lint = build, same as tt-metal)"
             echo "  --kafka              Enable Kafka (CMake KAFKA_ENABLED=ON; needs librdkafka-dev)"
             echo "  --mooncake           Build with the Mooncake Transfer Engine transport (third_party/Mooncake; RDMA always on)"
@@ -118,7 +111,6 @@ echo "  Build type: ${BUILD_TYPE}"
 echo "  ThreadSanitizer: ${SANITIZE_THREAD}"
 echo "  AddressSanitizer: ${SANITIZE_ADDRESS}"
 echo "  Tracy: ${ENABLE_TRACY}"
-echo "  Blaze: ${ENABLE_BLAZE}"
 echo "  Blaze migration: ${ENABLE_BLAZE_MIGRATION}"
 echo "  Clang-Tidy: ${CLANG_TIDY}"
 echo "  Kafka (KAFKA_ENABLED): ${KAFKA_ENABLED}"
@@ -247,7 +239,6 @@ CMAKE_ARGS=(
     -DSANITIZE_THREAD="${SANITIZE_THREAD}"
     -DSANITIZE_ADDRESS="${SANITIZE_ADDRESS}"
     -DENABLE_TRACY="${ENABLE_TRACY}"
-    -DENABLE_BLAZE="${ENABLE_BLAZE}"
     -DENABLE_BLAZE_MIGRATION="${ENABLE_BLAZE_MIGRATION}"
     -DCLANG_TIDY="${CLANG_TIDY}"
     -DKAFKA_ENABLED="${KAFKA_ENABLED}"

--- a/tt-media-server/cpp_server/build_exabox.sh
+++ b/tt-media-server/cpp_server/build_exabox.sh
@@ -39,7 +39,6 @@ BUILD_TYPE="Release"
 SANITIZE_THREAD="OFF"
 SANITIZE_ADDRESS="OFF"
 ENABLE_TRACY="OFF"
-ENABLE_BLAZE="OFF"
 ENABLE_BLAZE_MIGRATION="OFF"
 CLANG_TIDY="OFF"
 TOOLCHAIN_PATH_ARG=""
@@ -55,9 +54,7 @@ while [[ $# -gt 0 ]]; do
         --tsan)          SANITIZE_THREAD="ON"; BUILD_TYPE="Debug"; shift ;;
         --asan)          SANITIZE_ADDRESS="ON"; BUILD_TYPE="Debug"; shift ;;
         --tracy)         ENABLE_TRACY="ON"; shift ;;
-        --blaze)         ENABLE_BLAZE="ON"; shift ;;
         --blaze-with-migration)
-            ENABLE_BLAZE="ON"
             ENABLE_BLAZE_MIGRATION="ON"
             shift
             ;;
@@ -77,8 +74,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --tsan               ThreadSanitizer"
             echo "  --asan               AddressSanitizer"
             echo "  --tracy              Tracy profiling"
-            echo "  --blaze              tt-llm-engine / mock_pipeline support"
-            echo "  --blaze-with-migration  Same as --blaze plus real shmem migration"
+            echo "  --blaze-with-migration  Real shmem migration (pipeline_manager)"
             echo "  --clang-tidy         Run clang-tidy during build"
             echo "  --kafka              Kafka support (needs librdkafka-dev)"
             echo "  --mooncake           Build with the Mooncake Transfer Engine transport (third_party/Mooncake; RDMA always on)"
@@ -284,7 +280,6 @@ echo "  Building TT Media Server (C++ Drogon)"
 echo "  Build type:    ${BUILD_TYPE}"
 echo "  Local prefix:  ${LOCAL_PREFIX}"
 echo "  Rust:          $(command -v cargo) ($(cargo --version 2>/dev/null || echo '?'))"
-echo "  Blaze:         ${ENABLE_BLAZE}"
 echo "  Blaze migration: ${ENABLE_BLAZE_MIGRATION}"
 echo "  Kafka:         ${KAFKA_ENABLED}"
 echo "=============================================="
@@ -379,7 +374,6 @@ CMAKE_ARGS=(
     -DSANITIZE_THREAD="${SANITIZE_THREAD}"
     -DSANITIZE_ADDRESS="${SANITIZE_ADDRESS}"
     -DENABLE_TRACY="${ENABLE_TRACY}"
-    -DENABLE_BLAZE="${ENABLE_BLAZE}"
     -DENABLE_BLAZE_MIGRATION="${ENABLE_BLAZE_MIGRATION}"
     -DCLANG_TIDY="${CLANG_TIDY}"
     -DKAFKA_ENABLED="${KAFKA_ENABLED}"

--- a/tt-media-server/cpp_server/src/services/model_service_registration.cpp
+++ b/tt-media-server/cpp_server/src/services/model_service_registration.cpp
@@ -12,6 +12,9 @@
 #include "config/settings.hpp"
 #include "config/types.hpp"
 #include "ipc/media_payload_ipc.hpp"
+#include "runtime/runners/blaze_runner/blaze_decode_runner.hpp"
+#include "runtime/runners/blaze_runner/blaze_prefill_runner.hpp"
+#include "runtime/runners/blaze_runner/blaze_scheduler_factory.hpp"
 #include "runtime/runners/embedding_runner.hpp"
 #include "runtime/runners/image_ipc_runner.hpp"
 #include "runtime/runners/runner_registry.hpp"
@@ -24,12 +27,6 @@
 #include "services/llm_service.hpp"
 #include "services/service_registry.hpp"
 #include "utils/logger.hpp"
-
-#ifdef ENABLE_BLAZE
-#include "runtime/runners/blaze_runner/blaze_decode_runner.hpp"
-#include "runtime/runners/blaze_runner/blaze_prefill_runner.hpp"
-#include "runtime/runners/blaze_runner/blaze_scheduler_factory.hpp"
-#endif
 
 namespace tt::services {
 
@@ -45,7 +42,6 @@ void registerLLM() {
 
   auto& runners = utils::RunnerRegistry::instance();
 
-#ifdef ENABLE_BLAZE
   auto blazeFactory =
       [](const config::RunnerConfig& cfg, ipc::IResultQueue* resultQueue,
          ipc::ITaskQueue* taskQueue,
@@ -71,7 +67,6 @@ void registerLLM() {
   runners.registerIpcRunner(config::ModelService::LLM,
                             config::ModelRunnerType::MOCK_SCHEDULER,
                             blazeFactory);
-#endif
 
   auto& routes = api::RouteRegistry::instance();
   routes.registerRoute(config::ModelService::LLM, "POST",

--- a/tt-media-server/cpp_server/src/transport/README.md
+++ b/tt-media-server/cpp_server/src/transport/README.md
@@ -308,15 +308,14 @@ Every real backend sits behind a guard with a no-op fallback, so `transport_lib`
 
 | Guard | Enables | Flag |
 |-------|---------|------|
-| `USE_METAL_CPP_LIB` | real UMD device-DRAM I/O | `--blaze` |
-| `TT_TRANSPORT_WITH_MOONCAKE` | real Mooncake transport | `--mooncake` (implies `--blaze`) |
+| `USE_METAL_CPP_LIB` | real UMD device-DRAM I/O | / |
+| `TT_TRANSPORT_WITH_MOONCAKE` | real Mooncake transport | `--mooncake` |
 | `TT_TRANSPORT_WITH_KV_TABLE` | real `KvChunkAddressTable` adapter (protobuf) | `-DENABLE_KV_TABLE=ON` (needs `migration_lib`) |
 
 ## Build & run
 
 ```bash
-./build.sh                  # both guards OFF — everything builds (no-op fallbacks)
-./build.sh --blaze          # real UMD device-DRAM
+./build.sh                  # real UMD device-DRAM
 ./build.sh --mooncake       # real Mooncake transport → builds the e2e harnesses
 
 cd build && ctest --output-on-failure          # unit tests (any config)
@@ -330,7 +329,7 @@ cd build && ctest --output-on-failure          # unit tests (any config)
 ./build/transport_kv_migration_e2e
 # Hardware / real-table paths can't run in one gtest process, so they stay on the
 # two-process shell harness (--role sender|receiver):
-MODE=device  tests/e2e/scripts/run_transport_kv_migration_e2e.sh      # real device DRAM (--blaze + HW)
+MODE=device  tests/e2e/scripts/run_transport_kv_migration_e2e.sh      # real device DRAM
 TABLE=prefill_kv_table.pb DECODE_TABLE=decoder_kv_table.pb \
              tests/e2e/scripts/run_transport_kv_migration_e2e.sh      # real table (-DENABLE_KV_TABLE=ON)
 ```
@@ -345,7 +344,7 @@ TABLE=prefill_kv_table.pb DECODE_TABLE=decoder_kv_table.pb \
 | orchestration (Begin/MirrorReady/Done/Ack) over a threaded channel | unit-tested |
 | multi-host n→m fan-out (routing via `hostsForRequest`, per-host orchestration, partial-failure reporting) | unit-tested (fakes) |
 | real Mooncake TCP, host store (full round trip, fan-out) | ctest `TransportKvMigrationE2E` (`--mooncake` build, no HW) |
-| real UMD device DRAM / real `.pb` table / multi-host scale-out | manual shell-harness run (+`--blaze`/HW/`ENABLE_KV_TABLE`) |
+| real UMD device DRAM / real `.pb` table / multi-host scale-out | manual shell-harness run (+HW/`ENABLE_KV_TABLE`) |
 
 The sender computing both `mirror_offset` **and** the dst `NocAddr` is what makes
 device→device RDMA a localized swap: drop the mirror, WRITE straight to the
@@ -426,7 +425,7 @@ WORKER_BIN=./build/bringup_mooncake_worker \
 | Step | Status |
 |------|--------|
 | Interfaces + host-DRAM round-trip + worker staging (`transport_test`, any build) | impl |
-| Device-DRAM backend single-galaxy round-trip (UMD, `--blaze`) | impl |
+| Device-DRAM backend single-galaxy round-trip (UMD) | impl |
 | Mooncake transport loopback TCP (host backend, `--mooncake`) | impl |
 | Two-galaxy acceptance, both backends enabled | pending a two-process HW run |
 | Metadata-service worker discovery, two hosts, host RAM (#4209, `migration_worker_discovery`) | **validated** (two hosts, 1 MiB tensor, byte-verified MATCH) |
@@ -443,10 +442,10 @@ The existing KV-migration worker lives in
 [`../../tt-llm-engine/disaggregation/migration/`](../../tt-llm-engine/disaggregation/migration/)
 and already moves KV cache galaxy-to-galaxy over **MPI/DCN** with ULFM fault
 tolerance. It routes all transport through an abstract `SenderBackend` /
-`ReceiverBackend` interface (today only `DcnSenderBackend`). Add a 
+`ReceiverBackend` interface (today only `DcnSenderBackend`). Add a
 `MooncakeSenderBackend` implementing that same interface. Mooncake fills
 *capability* gaps (multi-NIC RDMA bandwidth, dynamic membership, a pooled global
-KV-cache store with cross-request prefix reuse), not a correctness hole. 
+KV-cache store with cross-request prefix reuse), not a correctness hole.
 
 **Discovery lifecycle (post-merge):** discovery resolves peers once at bring-up and the
 worker then holds the handles until SIGTERM. Steady-state membership changes are not yet

--- a/tt-media-server/cpp_server/tests/e2e/scripts/migration_e2e/preflight.py
+++ b/tt-media-server/cpp_server/tests/e2e/scripts/migration_e2e/preflight.py
@@ -28,7 +28,7 @@ def preflight(cfg: Config) -> None:
     if not cfg.worker_bin.is_file() or not os.access(cfg.worker_bin, os.X_OK):
         raise PreflightError(
             f"{cfg.worker_bin} not found/executable. "
-            "Build it: ./build.sh --blaze --kafka --mooncake"
+            "Build it: ./build.sh --kafka --mooncake"
         )
     if shutil.which("mpirun") is None:
         raise PreflightError("mpirun not found; install Open MPI to run this test.")

--- a/tt-media-server/cpp_server/tests/e2e/scripts/run_transport_kv_migration_e2e.sh
+++ b/tt-media-server/cpp_server/tests/e2e/scripts/run_transport_kv_migration_e2e.sh
@@ -23,7 +23,7 @@
 # Env overrides:
 #   ROLE=both|receiver|sender  (default both — both procs on this host/loopback;
 #                          receiver/sender launch ONE side for a two-galaxy run)
-#   MODE=host|device      (default host — runs anywhere; device needs HW+--blaze)
+#   MODE=host|device      (default host — runs anywhere; device needs HW)
 #   TABLE=builtin|<path>   (default builtin; <path> needs -DENABLE_KV_TABLE=ON)
 #   DECODE_TABLE=<path>    (sender, real-table mode: the decode-side .pb)
 #   CONTROL_HOST=<ip>      (sender: where the receiver's control channel lives;

--- a/tt-media-server/cpp_server/tests/e2e/transport_kv_migration_e2e.cpp
+++ b/tt-media-server/cpp_server/tests/e2e/transport_kv_migration_e2e.cpp
@@ -23,7 +23,7 @@
 //                    Runs on any --mooncake build, no hardware. The byte
 //                    content is a deterministic pattern keyed by (layer,pos),
 //                    so the receiver verifies without an out-of-band payload.
-//   --mode device  : real TT device DRAM via UMD (needs --blaze --mooncake +
+//   --mode device  : real TT device DRAM via UMD (needs --mooncake +
 //                    hardware). The sender first writes the pattern into its
 //                    source devices, then migrates; the receiver verifies.
 //

--- a/tt-media-server/cpp_server/tests/integration/integration_test_helpers.hpp
+++ b/tt-media-server/cpp_server/tests/integration/integration_test_helpers.hpp
@@ -33,11 +33,9 @@
 #include "ipc/in_memory/in_memory_result_queue.hpp"
 #include "ipc/in_memory/in_memory_task_queue.hpp"
 #include "ipc/interface/result_queue.hpp"
-#ifdef ENABLE_BLAZE
 #include "runtime/runners/blaze_runner/blaze_decode_runner.hpp"
 #include "runtime/runners/blaze_runner/blaze_prefill_runner.hpp"
 #include "runtime/runners/blaze_runner/blaze_scheduler_factory.hpp"
-#endif
 #include "services/memory_services/memory_manager.hpp"
 #include "services/session_manager.hpp"
 #include "utils/conversation_hasher.hpp"
@@ -235,7 +233,6 @@ void runConcurrently(F&& f, int numThreads = 2) {
 // Base runner test harness
 // ---------------------------------------------------------------------------
 
-#ifdef ENABLE_BLAZE
 // Base harness for testing Blaze runners (prefill and decode).
 // Manages IPC queues, memory manager, and runner lifecycle.
 template <typename RunnerType>
@@ -371,6 +368,5 @@ class RunnerTestHarness {
   std::exception_ptr runnerError_;
   bool isShutdown_ = false;
 };
-#endif  // ENABLE_BLAZE
 
 }  // namespace tt::test


### PR DESCRIPTION
## Problem
Previously Inference Server supported two build configurations:
- Default - used the mock_model_runner
- Blaze - used tt-llm-engine, which determined at runtime whether to run the real pipeline or the mock pipeline

Following recent changes, the `mock_model_runner` was removed from Inference Server, and as a result the default build no longer started a model during warmup, causing the warmup to never occurre and Heavy Checks to fail.

## Implementation
With this PR, Blaze becomes the default build configuration, eliminating the need for the `--blaze` flag

## Testing
https://github.com/tenstorrent/tt-inference-server/actions/runs/28949598407