### PR TITLE
Use Blaze Build in Heavy Checks

### DIFF
--- a/.github/workflows/cpp-heavy-checks.yml
+++ b/.github/workflows/cpp-heavy-checks.yml
@@ -1286,7 +1286,7 @@ jobs:
       - name: Build C++ server with ThreadSanitizer
         run: |
           cd cpp_server
-          ./build.sh --tsan
+          ./build.sh --tsan --blaze
 
       - name: Archive C++ tokenizer bundle
         run: |
@@ -1312,7 +1312,7 @@ jobs:
           uv pip install guidellm
           echo "PATH=${{ github.workspace }}/tt-media-server/.venv/bin:$PATH" >> $GITHUB_ENV
 
-      - name: Start TSan-instrumented server (mock_pipeline)
+      - name: Start TSan-instrumented server
         env:
           TSAN_OPTIONS: "suppressions=${{ github.workspace }}/tt-media-server/cpp_server/tsan_suppressions.txt:halt_on_error=0:second_deadlock_stack=1:history_size=7:log_path=tsan-server"
         run: |

--- a/.github/workflows/nightly-cpp-benchmarks.yml
+++ b/.github/workflows/nightly-cpp-benchmarks.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build C++ server
         run: |
           cd cpp_server
-          ./build.sh
+          ./build.sh --blaze
           cd ..
 
       - name: Start C++ server

--- a/dynamo_frontend/DEPLOY.md
+++ b/dynamo_frontend/DEPLOY.md
@@ -23,7 +23,7 @@ worker instead of the image's, e.g. on a box without a Tenstorrent card — a
 build made without `TT_METAL_HOME` runs the mock backend):
 
 ```bash
-cd ../tt-media-server/cpp_server && ./build.sh        # produces build/tt_media_server_cpp
+cd ../tt-media-server/cpp_server && ./build.sh  --blaze      # produces build/tt_media_server_cpp
 cd ../../dynamo_frontend
 PROMETHEUS_HOST_PORT=9091 GRAFANA_HOST_PORT=3001 \
   ./deploy.sh --deepseek --local-build --llm-device-backend mock_pipeline

--- a/dynamo_frontend/deploy.sh
+++ b/dynamo_frontend/deploy.sh
@@ -163,7 +163,7 @@ if [[ -n "$LOCAL_BUILD" ]]; then
     CPP_SERVER_DIR_ABS="$(readlink -f "$CPP_SERVER_DIR" 2>/dev/null || true)"
     [[ -d "$CPP_SERVER_DIR_ABS" ]] || die "cpp_server directory not found: $CPP_SERVER_DIR"
     [[ -f "$CPP_SERVER_DIR_ABS/build/tt_media_server_cpp" ]] \
-        || die "no binary at $CPP_SERVER_DIR_ABS/build/tt_media_server_cpp — run ./build.sh first"
+        || die "no binary at $CPP_SERVER_DIR_ABS/build/tt_media_server_cpp — run ./build.sh --blaze first"
     log "using local build from $CPP_SERVER_DIR_ABS"
     LOCAL_BUILD_MOUNT+=(-v "${CPP_SERVER_DIR_ABS}/build:/home/container_app_user/app/server/cpp_server/build:ro")
     WORKER_ENTRYPOINT+=(--entrypoint /bin/bash)

--- a/tt-media-server/cpp_server/benchmarks/run_stack.sh
+++ b/tt-media-server/cpp_server/benchmarks/run_stack.sh
@@ -139,7 +139,7 @@ wait_ready() {
 }
 
 up() {
-    [[ -x "${BIN}" ]] || { log "no binary; building (mock)"; (cd "${CPP_DIR}" && env -u TT_METAL_HOME ./build.sh); }
+    [[ -x "${BIN}" ]] || { log "no binary; building (mock)"; (cd "${CPP_DIR}" && env -u TT_METAL_HOME ./build.sh --blaze); }
     teardown
     : > "${PIDFILE}"
     ensure_etcd

--- a/tt-media-server/cpp_server/tests/e2e/scripts/run_e2e_with_server.sh
+++ b/tt-media-server/cpp_server/tests/e2e/scripts/run_e2e_with_server.sh
@@ -34,7 +34,7 @@ trap cleanup EXIT
 # Build if binary is missing
 if [[ ! -x "$SERVER_BIN" ]]; then
     echo "Building server..."
-    cd "$PROJECT_DIR" && ./build.sh
+    cd "$PROJECT_DIR" && ./build.sh --blaze
 fi
 
 # Start server with mock backend


### PR DESCRIPTION
## Problem
Since the mock_model_runner was recently removed from cpp_server, the default build no longer passes the warmup stage because there is no model to start
Therefore, we need to use build with `--blaze` flag in order to have a running model we can test against in CI

## Testing
https://github.com/tenstorrent/tt-inference-server/actions/runs/28953630088