### PR TITLE
Increase Default Max Tokens

### DIFF
--- a/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
+++ b/tt-media-server/cpp_server/include/dynamo/dynamo_protocol.hpp
@@ -199,7 +199,7 @@ struct GenerateRequest {
   std::vector<uint32_t> token_ids;
 
   // StopConditions ---------------------------------------------------------
-  int max_tokens = 128;
+  std::optional<int> max_tokens;
   std::optional<int> min_tokens;
   std::vector<int> stop_token_ids;
   std::vector<std::string> stop;

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_endpoint.cpp
@@ -53,7 +53,8 @@ std::shared_ptr<tt::domain::llm::LLMRequest> buildLLMRequest(
   req->full_prompt_tokens_count = req->prompt_tokens_count;
 
   if (!dyn.model.empty()) req->model = dyn.model;
-  req->max_tokens = dyn.max_tokens;
+  req->max_tokens =
+      dyn.max_tokens.value_or(static_cast<int>(tt::config::maxContextLength()));
   if (dyn.min_tokens.has_value()) req->min_tokens = *dyn.min_tokens;
   req->stop_token_ids = dyn.stop_token_ids;
   req->stop = dyn.stop;

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include "domain/llm/llm_error_reason.hpp"
+#include "domain/llm/llm_request.hpp"
 #include "utils/logger.hpp"
 
 namespace tt::dynamo {
@@ -496,7 +497,8 @@ void DynamoServer::process_request(const trantor::TcpConnectionPtr& conn,
       TT_LOG_DEBUG(
           "[DynamoServer] Request id={} input_tokens={} max_tokens={} "
           "address={}",
-          id, genReq.token_ids.size(), genReq.max_tokens, connInfo.address);
+          id, genReq.token_ids.size(),
+          tt::domain::llm::detail::optStr(genReq.max_tokens), connInfo.address);
       handler_(genReq, connInfo);
     } catch (const std::exception& e) {
       TT_LOG_ERROR("[DynamoServer] request dispatch failed id={}: {}", id,

--- a/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/dynamo_protocol.cpp
@@ -25,7 +25,6 @@
 #include <utility>
 
 #include "domain/llm/llm_error_reason.hpp"
-#include "domain/llm/llm_request.hpp"
 #include "utils/logger.hpp"
 
 namespace tt::dynamo {
@@ -498,7 +497,9 @@ void DynamoServer::process_request(const trantor::TcpConnectionPtr& conn,
           "[DynamoServer] Request id={} input_tokens={} max_tokens={} "
           "address={}",
           id, genReq.token_ids.size(),
-          tt::domain::llm::detail::optStr(genReq.max_tokens), connInfo.address);
+          genReq.max_tokens.has_value() ? std::to_string(*genReq.max_tokens)
+                                        : "None",
+          connInfo.address);
       handler_(genReq, connInfo);
     } catch (const std::exception& e) {
       TT_LOG_ERROR("[DynamoServer] request dispatch failed id={}: {}", id,


### PR DESCRIPTION
## Problem
When users did not specify `max_tokens`, the Dynamo endpoint defaulted to a value of 128. This then resulted in responses being cut off before the model had finished generating.
With this PR, the default is changed to `max_context_length`, allowing generation to continue unless the user explicitly specifies a lower `max_tokens` value.