### PR TITLE
fix: spec tests model name resolution

### DIFF
--- a/tt-inference-server-v2/test_module/llm_tests/vllm_param_conformance_test.py
+++ b/tt-inference-server-v2/test_module/llm_tests/vllm_param_conformance_test.py
@@ -165,9 +165,9 @@ class VLLMParamConformanceTest(BaseTest):
 
     def _resolve_model_name(self) -> str:
         if self.ctx is not None:
-            model_name = getattr(self.ctx.model_spec, "model_name", None)
-            if model_name:
-                return str(model_name)
+            hf_model_repo = getattr(self.ctx.model_spec, "hf_model_repo", None)
+            if hf_model_repo:
+                return str(hf_model_repo)
         return str(self.config.get("model") or DEFAULT_MODEL_NAME)
 
     @staticmethod

--- a/tt-inference-server-v2/tests/test_module/llm_tests/test_vllm_param_conformance_tests.py
+++ b/tt-inference-server-v2/tests/test_module/llm_tests/test_vllm_param_conformance_tests.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+
+"""Tests for the vLLM parameter-conformance spec-test wrappers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from test_module._test_common import TestConfig
+from test_module.llm_tests.vllm_param_conformance_test import (
+    DEFAULT_MODEL_NAME,
+    VLLMParamConformanceTest,
+)
+
+
+def _make_test(ctx) -> VLLMParamConformanceTest:
+    return VLLMParamConformanceTest(TestConfig({}), {}, ctx=ctx)
+
+
+def _fake_ctx(*, hf_model_repo=None, model_name=None):
+    """Minimal ctx stub carrying only what BaseTest.__init__ touches."""
+    model_spec = SimpleNamespace(hf_model_repo=hf_model_repo, model_name=model_name)
+    return SimpleNamespace(
+        model_spec=model_spec,
+        service_port=8000,
+        base_url="http://127.0.0.1:8000",
+    )
+
+
+def test_resolve_model_name_uses_hf_model_repo_not_short_name():
+    """Regression for #4489: the suite must send the full served name.
+
+    The local vLLM server registers the model under hf_model_repo, so
+    returning the short model_name causes a 404 "model does not exist".
+    """
+    ctx = _fake_ctx(
+        hf_model_repo="meta-llama/Llama-3.1-8B-Instruct",
+        model_name="Llama-3.1-8B-Instruct",
+    )
+    test = _make_test(ctx)
+
+    assert test._resolve_model_name() == "meta-llama/Llama-3.1-8B-Instruct"
+
+
+def test_resolve_model_name_falls_back_to_config_without_ctx():
+    test = VLLMParamConformanceTest(TestConfig({"model": "org/some-model"}), {})
+
+    assert test._resolve_model_name() == "org/some-model"
+
+
+def test_resolve_model_name_defaults_when_unresolved():
+    ctx = _fake_ctx(hf_model_repo=None, model_name=None)
+    test = _make_test(ctx)
+
+    assert test._resolve_model_name() == DEFAULT_MODEL_NAME


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #4489 that caused **all** LLM release/spec-test
jobs to fail with vLLM `404 The model '<name>' does not exist`.

Root cause chain:
- #4489 added model-name injection in `server_tests/conftest.py` — `api_client`
  now stamps `--model-name` onto every request payload when `model` is absent
  (needed so the remote console for Kimi/MiniMax/gpt-oss can route requests).
- The v2 spec test `VLLMParamConformanceTest._resolve_model_name()` returned the
  **short** `model_spec.model_name` (e.g. `Llama-3.1-8B-Instruct`).
- The local vLLM server registers the model under its full `hf_model_repo`
  (`meta-llama/Llama-3.1-8B-Instruct`; set in `ModelSpec.__post_init__`, no
  `--served-model-name`), so the injected short name 404'd on every request.

Before #4489 the suite sent no `model` field and the server used its single
loaded model, so the mismatch was invisible.

## Fix

`_resolve_model_name()` now resolves `ctx.model_spec.hf_model_repo` instead of
the short `model_name`. This matches v1 `server_tests/run_tests.py` (which passes
`model_spec.hf_model_repo`) and every other server-facing v2 test
(`llm_performance_tests.py`, `agentic_eval_tests.py`), including the remote-console
path. `server_tests/conftest.py` is unchanged — its injection is now always fed the
correct served name for both local and remote endpoints.

Also adds a regression unit test asserting the resolver returns `hf_model_repo`
(not the short name) when the two differ.

## Test plan

- [x] `tt-inference-server-v2/tests/test_module/llm_tests/test_vllm_param_conformance_tests.py` — 3 passing
- [x] Models CI Dispatch: `Llama-3.1-8B-Instruct` on `p300x2`, tt-metal `stable`, vLLM `stable`, using stable test branch `ipastalTT/fix-conformance-model-name-stable` — `spec_tests` / `VLLMParamConformanceTest` passes with no `model_not_found_404` errors -> url : https://github.com/tenstorrent/tt-shield/actions/runs/28997466745/job/86050073513