### PR TITLE
cpp_server: drop reasoning_sampling from blaze_utils

### DIFF
--- a/tt-media-server/cpp_server/include/config/runner_config.hpp
+++ b/tt-media-server/cpp_server/include/config/runner_config.hpp
@@ -72,7 +72,6 @@ struct BlazeConfig : RunnerConfigBase {
 
   // Generation fallbacks read by blaze_utils
   size_t maxContextLength = defaults::MAX_CONTEXT_LENGTH;
-  bool sampleOnlyInReasoning = false;
 };
 
 struct EmbeddingConfig : RunnerConfigBase {};

--- a/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_utils.hpp
+++ b/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_utils.hpp
@@ -62,8 +62,7 @@ inline void logISRequest(const sch::ISRequest& req) {
       "migration_start_position={} migrate_from_slot={} "
       "gen.max_new_tokens={} gen.spec_decode={} gen.ignore_eos={} "
       "gen.sampling.temp={} gen.sampling.top_p={} gen.sampling.top_k={} "
-      "gen.reasoning_sampling.temp={} gen.reasoning_sampling.top_p={} "
-      "gen.reasoning_sampling.top_k={} gen.disaggregated_decode={} "
+      "gen.disaggregated_decode={} "
       "gen.starts_in_thinking={} gen.await_kv_migration={} gen.prefill_only={} "
       "gen.relaxed_acceptance_threshold={} gen.stop_token_count={}",
       requestTypeToString(req.type), req.request_id, req.slot_id,
@@ -72,9 +71,7 @@ inline void logISRequest(const sch::ISRequest& req) {
       formatOptional(req.migration_start_position),
       formatOptional(req.migrate_from_slot), gen.max_new_tokens,
       gen.spec_decode, gen.ignore_eos, gen.sampling.temperature,
-      gen.sampling.top_p, gen.sampling.top_k,
-      gen.reasoning_sampling.temperature, gen.reasoning_sampling.top_p,
-      gen.reasoning_sampling.top_k, gen.disaggregated_decode,
+      gen.sampling.top_p, gen.sampling.top_k, gen.disaggregated_decode,
       gen.starts_in_thinking, gen.await_kv_migration, gen.prefill_only,
       gen.relaxed_acceptance_threshold, gen.stop_tokens.size());
 }
@@ -117,7 +114,7 @@ inline sch::ISRequest makeStopRequest(uint32_t requestId, uint32_t slotId) {
 inline sch::GenerationParams makeGenerationParams(
     const tt::config::BlazeConfig& config,
     const tt::domain::llm::Sequence& seq) {
-  const sch::PhaseSamplingParams userSampling{
+  const sch::SamplingParams userSampling{
       .temperature = seq.getSamplingParams().temperature,
       .top_p = seq.getSamplingParams().top_p.value_or(1.0f),
       .top_k = static_cast<int32_t>(seq.getSamplingParams().top_k.value_or(-1)),
@@ -129,7 +126,6 @@ inline sch::GenerationParams makeGenerationParams(
       .spec_decode = seq.getSamplingParams().fast_mode,
       .ignore_eos = seq.getSamplingParams().ignore_eos,
       .sampling = userSampling,
-      .reasoning_sampling = userSampling,
       .disaggregated_decode = config.enableMigration && seq.isDisaggregated(),
       .starts_in_thinking = seq.getStartsInThinking(),
       .stop_tokens = seq.getSamplingParams().stop_token_ids,
@@ -140,8 +136,8 @@ inline void postProcessSamplingParams(const tt::config::BlazeConfig& config,
                                       sch::GenerationParams& params) {
   if (config.sampleOnlyInReasoning) {
     // We argmax outside the reasoning phase
-    params.sampling = sch::PhaseSamplingParams{
-        .temperature = 1.0f, .top_p = 1.0f, .top_k = 1};
+    params.sampling =
+        sch::SamplingParams{.temperature = 1.0f, .top_p = 1.0f, .top_k = 1};
   }
 }
 

--- a/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_utils.hpp
+++ b/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_utils.hpp
@@ -114,7 +114,7 @@ inline sch::ISRequest makeStopRequest(uint32_t requestId, uint32_t slotId) {
 inline sch::GenerationParams makeGenerationParams(
     const tt::config::BlazeConfig& config,
     const tt::domain::llm::Sequence& seq) {
-  const sch::SamplingParams userSampling{
+  const sch::SamplingParams sampling{
       .temperature = seq.getSamplingParams().temperature,
       .top_p = seq.getSamplingParams().top_p.value_or(1.0f),
       .top_k = static_cast<int32_t>(seq.getSamplingParams().top_k.value_or(-1)),
@@ -125,20 +125,11 @@ inline sch::GenerationParams makeGenerationParams(
               static_cast<int>(config.maxContextLength))),
       .spec_decode = seq.getSamplingParams().fast_mode,
       .ignore_eos = seq.getSamplingParams().ignore_eos,
-      .sampling = userSampling,
+      .sampling = sampling,
       .disaggregated_decode = config.enableMigration && seq.isDisaggregated(),
       .starts_in_thinking = seq.getStartsInThinking(),
       .stop_tokens = seq.getSamplingParams().stop_token_ids,
   };
-}
-
-inline void postProcessSamplingParams(const tt::config::BlazeConfig& config,
-                                      sch::GenerationParams& params) {
-  if (config.sampleOnlyInReasoning) {
-    // We argmax outside the reasoning phase
-    params.sampling =
-        sch::SamplingParams{.temperature = 1.0f, .top_p = 1.0f, .top_k = 1};
-  }
 }
 
 inline void fillSequenceFields(const tt::config::BlazeConfig& config,
@@ -149,7 +140,6 @@ inline void fillSequenceFields(const tt::config::BlazeConfig& config,
   if (seq.getKVPositionId().has_value()) {  // override position id
     req.position_id = *seq.getKVPositionId();
   }
-  postProcessSamplingParams(config, req.gen);
   if (config.enableMigration) {
     req.migration_uuid = seq.getMigrationId();
   }

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -391,7 +391,6 @@ BlazeConfig blazeConfig() {
 
     // Generation fallbacks read by blaze_utils
     cfg.maxContextLength = maxContextLength();
-    cfg.sampleOnlyInReasoning = sampleOnlyInReasoning();
     return cfg;
   }();
   return cached;
@@ -537,24 +536,6 @@ Model model() {
   static const Model cached =
       modelFromString(envString("MODEL", defaults::MODEL));
   return cached;
-}
-
-bool sampleOnlyInReasoning() {
-  switch (modelType()) {
-    // DeepSeek samples only inside the reasoning phase; argmax otherwise.
-    case ModelType::DEEPSEEK_R1_0528:
-      return true;
-    case ModelType::LLAMA_3_1_8B_INSTRUCT:
-    case ModelType::KIMI_K2_6:
-    case ModelType::KIMI_K2_7_CODE:
-    case ModelType::GPT_OSS_120B:
-    case ModelType::MINIMAX_M2_7:
-    case ModelType::GLM_5_1:
-    case ModelType::GLM_5_2:
-    case ModelType::DEEPSEEK_V4_PRO:
-      return false;
-  }
-  return false;
 }
 
 LLMMode llmMode() {


### PR DESCRIPTION
A bug in blitz deepseek model required us to differentiate sampling between reasoning and assistant outputs, forcing argmax for assistant.

Since blitz deepseek is legacy, we are removing this code considering it a tech debt.

Related tt-llm-engine PR https://github.com/tenstorrent/tt-llm-engine/pull/225