### PR TITLE
remove other evals for gemma4-31b

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -514,19 +514,33 @@
       }
     },
     "gemma-4-31B-it": {
-      "inference_engine": "vLLM",
-      "ci": {
-        "nightly": {
-          "devices": [
-            "P300X2"
-          ]
+      "implementations": [
+        {
+          "inference_engine": "vLLM",
+          "ci": {
+            "nightly": {
+              "devices": [
+                "P300X2"
+              ]
+            },
+            "release": {
+              "devices": [
+                "P300X2"
+              ]
+            }
+          }
         },
-        "release": {
-          "devices": [
-            "P300X2"
-          ]
+        {
+          "inference_engine": "FORGE",
+          "ci": {
+            "nightly": {
+              "devices": [
+                "P300X2"
+              ]
+            }
+          }
         }
-      }
+      ]
     },
     "gemma-4-12B-it": {
       "inference_engine": "vLLM",

--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -528,16 +528,6 @@
         }
       }
     },
-    "gemma-4-31b-it": {
-      "inference_engine": "FORGE",
-      "ci": {
-        "nightly": {
-          "devices": [
-            "P300X2"
-          ]
-        }
-      }
-    },
     "gemma-4-12B-it": {
       "inference_engine": "vLLM",
       "ci": {

--- a/benchmarking/summary_report.py
+++ b/benchmarking/summary_report.py
@@ -108,7 +108,7 @@ def extract_params_from_filename(filename: str) -> Dict[str, Any]:
     image_pattern = r"""
         ^benchmark_
         (?P<model>.+?)                            # Model name (non-greedy, allows everything)
-        (?:_(?P<device>N150|N300|P100|P150|T3K|p150x4|p150x8|p300x2|P300x2|p300|P300|TG|GALAXY|n150|n300|p100|p150|galaxy_t3k|t3k|tg|galaxy|gpu|GPU))?  # Optional device
+        (?:_(?P<device>N150|N300|P100|P150|T3K|p150x4|p150x8|p300x2|P300x2|p300|P300|TG|GALAXY|n150|n300|p100|p150|galaxy_t3k|t3k|tg|galaxy|gpu|GPU|super_cluster|SUPER_CLUSTER|Super-Cluster))?  # Optional device
         _(?P<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})
         _isl-(?P<isl>\d+)
         _osl-(?P<osl>\d+)
@@ -156,7 +156,7 @@ def extract_params_from_filename(filename: str) -> Dict[str, Any]:
     structured_pattern = r"""
         ^benchmark_structured_
         (?P<model>.+?)
-        (?:_(?P<device>N150|N300|P100|P150|T3K|p150x4|p150x8|p300x2|P300x2|p300|P300|n150x4|TG|GALAXY|n150|n300|p100|p150|galaxy_t3k|t3k|tg|galaxy|gpu|GPU))?
+        (?:_(?P<device>N150|N300|P100|P150|T3K|p150x4|p150x8|p300x2|P300x2|p300|P300|n150x4|TG|GALAXY|n150|n300|p100|p150|galaxy_t3k|t3k|tg|galaxy|gpu|GPU|super_cluster|SUPER_CLUSTER|Super-Cluster))?
         _(?P<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})
         _dataset-(?P<dataset>.+?)
         _(?P<so_tag>no-so|so-[\d.]+)
@@ -188,7 +188,7 @@ def extract_params_from_filename(filename: str) -> Dict[str, Any]:
     text_pattern = r"""
         ^benchmark_
         (?P<model>.+?)                            # Model name (non-greedy, allows everything)
-        (?:_(?P<device>N150|N300|P100|P150|T3K|p150x4|p150x8|p300x2|P300x2|p300|P300|n150x4|TG|GALAXY|n150|n300|p100|p150|galaxy_t3k|t3k|tg|galaxy|gpu|GPU))?  # Optional device
+        (?:_(?P<device>N150|N300|P100|P150|T3K|p150x4|p150x8|p300x2|P300x2|p300|P300|n150x4|TG|GALAXY|n150|n300|p100|p150|galaxy_t3k|t3k|tg|galaxy|gpu|GPU|super_cluster|SUPER_CLUSTER|Super-Cluster))?  # Optional device
         _(?P<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})
         _isl-(?P<isl>\d+)
         _osl-(?P<osl>\d+)
@@ -218,7 +218,7 @@ def extract_params_from_filename(filename: str) -> Dict[str, Any]:
     cnn_pattern = r"""
         ^benchmark_
         (?P<model_id>id_.+?)                      # Model ID (starts with id_)
-        (?:_(?P<device>N150|N300|P100|P150|T3K|p150x4|p150x8|p300x2|P300x2|p300|P300|TG|GALAXY|n150|n300|p100|p150|t3k|tg|galaxy|gpu|GPU))?  # Optional device
+        (?:_(?P<device>N150|N300|P100|P150|T3K|p150x4|p150x8|p300x2|P300x2|p300|P300|TG|GALAXY|n150|n300|p100|p150|t3k|tg|galaxy|gpu|GPU|super_cluster|SUPER_CLUSTER|Super-Cluster))?  # Optional device
         _(?P<timestamp>\d+\.?\d*)                 # Timestamp (can be float)
         \.json$
     """
@@ -480,7 +480,7 @@ def process_benchmark_file(filepath: str) -> Dict[str, Any]:
         "model_name": params["model_name"],
         "model_id": data.get("model_id", ""),
         "backend": data.get("backend", ""),
-        "device": params.get("device", ""),
+        "device": params.get("device") or "",
         "input_sequence_length": params["input_sequence_length"],
         "output_sequence_length": params["output_sequence_length"],
         "max_con": actual_max_con,
@@ -1090,7 +1090,18 @@ def generate_report(files, output_dir, report_id, metadata={}, model_spec=None):
     model_name = metadata["model_name"]
     device = results[0].get("device")
     if "device" in metadata:
-        assert metadata["device"] == device, "Device mismatch in metadata"
+        ## this change is for v2 LLM benchmarks which don't have a device in the filename
+        ## so we need to use the device from the metadata
+        meta_device = metadata["device"]
+        for row in results:
+            row_device = row.get("device")
+            if row_device in (None, "", NOT_MEASURED_STR):
+                row["device"] = meta_device
+            else:
+                assert meta_device.lower() == str(row_device).lower(), (
+                    f"Device mismatch in metadata: {meta_device!r} vs {row_device!r}"
+                )
+        device = meta_device
 
     # save stats
     data_file_path = output_dir / "data" / f"benchmark_stats_{report_id}.csv"

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -3698,11 +3698,12 @@ _eval_config_list = [
     # Context window per the Gemma 4 model card
     # (https://ai.google.dev/gemma/docs/core/model_card_4): the medium models
     # 31B / 26B-A4B / 12B support 256K tokens; the small E2B / E4B support 128K.
-    # Agentic max_input_tokens + max_output_tokens are sized to fit the model's
-    # native window (the agent sends ~input+output per request); run the vLLM
-    # server with a matching --max-model-len (262144 for 256K models, 131072 for
-    # the E-models). NOTE: only the 31B agentic tasks are bumped to 256K so far;
-    # 26B-A4B / 12B still carry the 128K (96K+32K) placeholder budgets.
+    # Agentic max_input_tokens + max_output_tokens (on non-31B variants) are
+    # sized to fit the model's native window (the agent sends ~input+output per
+    # request); run the vLLM server with a matching --max-model-len (262144 for
+    # 256K models, 131072 for the E-models). gemma-4-31B-it keeps GPQA only for
+    # release (no EVALS_AGENTIC tasks) so #4491 does not dispatch terminal/SWE
+    # on QB2; 26B-A4B / 12B still carry the 128K (96K+32K) placeholder budgets.
     # =========================================================================
     EvalConfig(
         hf_model_repo="google/gemma-4-31B-it",
@@ -3773,134 +3774,12 @@ _eval_config_list = [
                     EvalLimitMode.SMOKE_TEST: 0.01,
                 },
             ),
-            EvalTask(
-                task_name="terminal_bench_2",
-                workflow_venv_type=WorkflowVenvType.EVALS_AGENTIC,
-                score=EvalTaskScore(
-                    published_score=42.9,
-                    published_score_ref="https://huggingface.co/Qwen/Qwen3.6-27B",
-                    # Full terminal-bench-2 (89 tasks), terminus-2, single
-                    # H100 NVL bring-your-own vLLM (gemma-4-31B-it, max-model-len
-                    # 204800, enable_thinking=true), temp=1.0/top_p=0.95/
-                    # top_k=20, 112K in / 80K out, 2026-06-17. 40/89 solved =
-                    # 44.94%, which exceeds the published 42.9. 16 tasks hit
-                    # timeouts (15 AgentTimeoutError at the 3h/task limit + 1
-                    # VerifierTimeoutError) and scored 0, so 44.94 is a floor;
-                    # raising agent_timeout_sec could recover a few.
-                    gpu_reference_score=44.94,
-                    gpu_reference_score_ref="run.py --workflow evals terminal_bench_2 full (89), H100 gemma-4-31B-it bring-your-own vLLM w/ enable_thinking=true, 2026-06-17",
-                    score_func=score_task_single_key,
-                    score_func_kwargs={
-                        "result_keys": ["accuracy"],
-                        "unit": "percent",
-                    },
-                ),
-                agentic_eval_config=TerminalBenchEvalConfig(
-                    dataset="terminal-bench/terminal-bench-2",
-                    agent="terminus-2",
-                    n_concurrent_trials=5,
-                    n_attempts=1,
-                    n_tasks=None,  # full dataset
-                    override_cpus=32,
-                    override_memory_mb=48 * 1024,
-                    agent_timeout_sec=3 * 60 * 60,
-                    agent_kwargs={
-                        "parser_name": "json",
-                        "temperature": 1.0,
-                        "model_info": {
-                            # gemma-4-31B native ctx is 256K (model card), but a
-                            # single H100 NVL (94GB, bf16 KV) only holds a
-                            # 210,605-token KV cache, so a request can't exceed
-                            # ~205K. We serve at --max-model-len 204800 (200K).
-                            # The agent sends ~max_input + max_output per
-                            # request, so keep them under 204800: 112K + 80K =
-                            # 196K (~8K headroom for chat template + tool defs).
-                            # SWE/Terminal prompts rarely approach 200K, so the
-                            # 256K->200K cap should not affect scores.
-                            "max_input_tokens": 112 * 1024,
-                            "max_output_tokens": 80 * 1024,
-                        },
-                        "llm_kwargs": {
-                            "top_p": 0.95,
-                            "max_tokens": 80 * 1024,
-                            "timeout": 60 * 60,
-                            "extra_body": {
-                                "top_k": 20,
-                            },
-                        },
-                    },
-                    task_names_map={
-                        EvalLimitMode.CI_NIGHTLY: [
-                            "terminal-bench/caffe-cifar-10",
-                            "terminal-bench/password-recovery",
-                            "terminal-bench/portfolio-optimization",
-                            "terminal-bench/hf-model-inference",
-                            "terminal-bench/financial-document-processor",
-                        ],
-                    },
-                ),
-                limit_samples_map={
-                    EvalLimitMode.SMOKE_TEST: 5,
-                },
-            ),
-            EvalTask(
-                task_name="swe_bench_verified",
-                workflow_venv_type=WorkflowVenvType.EVALS_AGENTIC,
-                score=EvalTaskScore(
-                    published_score=52.0,
-                    published_score_ref="https://huggingface.co/Qwen/Qwen3.6-27B",
-                    # Full SWE-bench Verified (500), mini-swe-agent, single
-                    # H100 NVL bring-your-own vLLM (gemma-4-31B-it, max-model-len
-                    # 204800, enable_thinking=true), temp=1.0/top_p=0.95/
-                    # top_k=20, 160K in / 32K out, 2026-06-18. 324/500 resolved
-                    # = 64.80%, which exceeds the published 52.0 (ratio 1.25).
-                    gpu_reference_score=64.80,
-                    gpu_reference_score_ref="run.py --workflow evals swe_bench_verified full (500), H100 gemma-4-31B-it bring-your-own vLLM w/ enable_thinking=true, 2026-06-18",
-                    score_func=score_task_single_key,
-                    score_func_kwargs={
-                        "result_keys": ["accuracy"],
-                        "unit": "percent",
-                    },
-                ),
-                swebench_eval_config=SWEbenchEvalConfig(
-                    dataset_name="SWE-bench/SWE-bench_Verified",
-                    sweagent_subset="verified",
-                    dataset_split="test",
-                    agent_backend="mini-swe-agent",
-                    n_concurrent_trials=5,
-                    max_workers=8,
-                    n_tasks=None,  # full dataset
-                    temperature=1.0,
-                    top_p=0.95,
-                    # gemma-4-31B native ctx is 256K (model card), but a single
-                    # H100 NVL (94GB, bf16 KV) only holds a 210,605-token KV
-                    # cache, so a request can't exceed ~205K. We serve at
-                    # --max-model-len 204800 (200K). mini-swe-agent sends
-                    # ~max_input + max_output per request, so keep under 204800:
-                    # 160K + 32K = 192K (~8K headroom). SWE prompts rarely
-                    # approach 200K, so the 256K->200K cap should not affect
-                    # scores.
-                    max_input_tokens=160 * 1024,
-                    max_output_tokens=32 * 1024,
-                    completion_kwargs={
-                        "extra_body": {
-                            "top_k": 20,
-                        },
-                    },
-                    instance_ids_map={
-                        EvalLimitMode.CI_NIGHTLY: [
-                            "django__django-11299",
-                            "astropy__astropy-14096",
-                            "matplotlib__matplotlib-25332",
-                            "sympy__sympy-13551",
-                            "scikit-learn__scikit-learn-14629",
-                        ],
-                    },
-                ),
-                limit_samples_map={
-                    EvalLimitMode.SMOKE_TEST: 5,
-                },
-            ),
+            # terminal_bench_2 / swe_bench_verified intentionally omitted for
+            # gemma-4-31B-it. After #4491, any EVALS_AGENTIC task is dispatched
+            # as a v2 release child; those harnesses are sized for H100 (~200K
+            # ctx, 32 CPUs) and fail on QB2 release (max_context=49152, 16
+            # CPUs). Keep release scoped to GPQA (+ benches), matching the
+            # pre-#4491 gemma4 release gate.
         ],
     ),
     EvalConfig(

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -3764,8 +3764,12 @@ _eval_config_list = [
                     "top_k": 20,
                     "top_p": 0.95,
                 },
+                # CI_NIGHTLY 0.05 (~10 samples), not the usual 0.2: reasoning
+                # eval (~48K tokens/sample) served batch-1, so samples run
+                # sequentially and dominate CI runtime. Widen EvalTaskScore
+                # tolerance if the small-N accuracy gate flakes.
                 limit_samples_map={
-                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.CI_NIGHTLY: 0.05,
                     EvalLimitMode.SMOKE_TEST: 0.01,
                 },
             ),

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -1073,6 +1073,19 @@ class TestMediaServerDockerEnvVars:
         assert env_vars["MODEL_RUNNER_TYPE"] == "tt_sdxl_generate"
         assert env_vars["DEVICE_IDS"].replace(" ", "").count("(") > 1
 
+    def test_non_cpp_media_persists_hf_cache_on_cache_root(self):
+        """Whisper (uvicorn media server) must place HF_HOME on the cache_root
+        volume so weights survive container restarts."""
+        model_spec, _, _ = get_runtime_model_spec(
+            model="whisper-large-v3",
+            device="n150",
+        )
+
+        env_vars = get_media_server_docker_env_vars(model_spec)
+
+        assert env_vars.get("SERVER_MODE") != "cpp"
+        assert env_vars["HF_HOME"] == "/home/container_app_user/cache_root/huggingface"
+
 
 class TestSecretsHandling:
     """Tests for secrets handling functionality."""

--- a/tests/test_run_vllm_api_server.py
+++ b/tests/test_run_vllm_api_server.py
@@ -6,6 +6,7 @@
 import argparse
 import importlib.util
 import json
+import os
 import sys
 import types
 from pathlib import Path
@@ -284,3 +285,65 @@ def test_main_passes_passthrough_port_to_trace_capture(
         disable_trace_capture=False,
         service_port=9001,
     )
+
+
+def _weights_spec():
+    return {
+        "model_name": "Mistral-7B-Instruct-v0.3",
+        "hf_model_repo": "mistralai/Mistral-7B-Instruct-v0.3",
+    }
+
+
+def test_ensure_weights_available_resumes_partial_download(
+    monkeypatch, tmp_path, run_vllm_api_server_module
+):
+    """A non-empty (partially-downloaded) weights dir must still trigger
+    snapshot_download so missing files are fetched, rather than being treated
+    as complete."""
+    monkeypatch.delenv("MODEL_WEIGHTS_DIR", raising=False)
+    monkeypatch.setenv("CACHE_ROOT", str(tmp_path))
+    spec = _weights_spec()
+    weights_path = tmp_path / "weights" / spec["model_name"]
+    weights_path.mkdir(parents=True)
+    (weights_path / "config.json").write_text("{}")  # partial download
+
+    result = run_vllm_api_server_module.ensure_weights_available(spec)
+
+    run_vllm_api_server_module.snapshot_download.assert_called_once()
+    kwargs = run_vllm_api_server_module.snapshot_download.call_args.kwargs
+    assert kwargs["repo_id"] == spec["hf_model_repo"]
+    assert Path(kwargs["local_dir"]) == weights_path
+    assert result == weights_path
+    assert os.environ["MODEL_WEIGHTS_DIR"] == str(weights_path)
+
+
+def test_ensure_weights_available_falls_back_when_hub_unreachable(
+    monkeypatch, tmp_path, run_vllm_api_server_module
+):
+    """If the hub is unreachable but weights already exist locally, startup
+    proceeds with the existing weights instead of crashing."""
+    monkeypatch.delenv("MODEL_WEIGHTS_DIR", raising=False)
+    monkeypatch.setenv("CACHE_ROOT", str(tmp_path))
+    run_vllm_api_server_module.snapshot_download.side_effect = RuntimeError("offline")
+    spec = _weights_spec()
+    weights_path = tmp_path / "weights" / spec["model_name"]
+    weights_path.mkdir(parents=True)
+    (weights_path / "config.json").write_text("{}")
+
+    result = run_vllm_api_server_module.ensure_weights_available(spec)
+
+    assert result == weights_path
+    assert os.environ["MODEL_WEIGHTS_DIR"] == str(weights_path)
+
+
+def test_ensure_weights_available_raises_when_unreachable_and_no_weights(
+    monkeypatch, tmp_path, run_vllm_api_server_module
+):
+    """If the hub is unreachable and nothing is cached locally, the failure
+    must surface rather than starting with no weights."""
+    monkeypatch.delenv("MODEL_WEIGHTS_DIR", raising=False)
+    monkeypatch.setenv("CACHE_ROOT", str(tmp_path))
+    run_vllm_api_server_module.snapshot_download.side_effect = RuntimeError("offline")
+
+    with pytest.raises(RuntimeError):
+        run_vllm_api_server_module.ensure_weights_available(_weights_spec())

--- a/tests/test_setup_host.py
+++ b/tests/test_setup_host.py
@@ -888,3 +888,53 @@ class TestSetupHostValidation:
             host_weights_dir="/nonexistent/path/to/weights",
         )
         assert manager.check_setup() is False
+
+
+class TestSetupWeightsHostVolumeResume:
+    """setup_weights_huggingface (host-volume branch) must always invoke the
+    resumable `hf download` and fall back to existing weights only when the hub
+    is unreachable and the local copy is already complete."""
+
+    @pytest.fixture
+    def manager(self, tiny_model_spec, temp_dir):
+        mgr = HostSetupManager(
+            model_spec=tiny_model_spec,
+            hf_token="hf_test_token_123456",
+            host_volume=str(temp_dir / "persistent_volume"),
+        )
+        venv = MagicMock()
+        venv.venv_path = temp_dir / "fake_venv"
+        (venv.venv_path / "bin").mkdir(parents=True, exist_ok=True)
+        (venv.venv_path / "bin" / "hf").write_text("#!/bin/bash")
+        with patch("workflows.setup_host.VENV_CONFIGS") as mock_venv_configs:
+            mock_venv_configs.__getitem__ = MagicMock(return_value=venv)
+            yield mgr
+
+    def test_downloads_even_when_weights_present(self, manager):
+        """A complete-looking dir must not skip the download (it may be partial);
+        hf download runs and resumes/verifies."""
+        with patch.object(manager, "check_model_weights_dir", return_value=True), patch(
+            "subprocess.run"
+        ) as mock_run:
+            mock_run.return_value.returncode = 0
+            manager.setup_weights_huggingface()
+        mock_run.assert_called_once()
+
+    def test_falls_back_to_existing_when_hub_unreachable(self, manager):
+        """hf download failure with complete local weights continues instead of
+        raising."""
+        with patch.object(manager, "check_model_weights_dir", return_value=True), patch(
+            "subprocess.run"
+        ) as mock_run:
+            mock_run.return_value.returncode = 1
+            manager.setup_weights_huggingface()  # must not raise
+        mock_run.assert_called_once()
+
+    def test_raises_when_hub_unreachable_and_incomplete(self, manager):
+        """hf download failure without complete local weights must surface."""
+        with patch.object(
+            manager, "check_model_weights_dir", return_value=False
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 1
+            with pytest.raises(AssertionError):
+                manager.setup_weights_huggingface()

--- a/tt-media-server/tests/test_base_device_runner.py
+++ b/tt-media-server/tests/test_base_device_runner.py
@@ -3,7 +3,9 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 import logging
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tt_model_runners.base_device_runner import BaseDeviceRunner
@@ -279,6 +281,50 @@ class TestBaseDeviceRunnerWeightsGate(unittest.TestCase):
             assert any("HF_TOKEN" in msg for msg in warning_msgs), (
                 "default runner should still emit HF_TOKEN warning when env is unset"
             )
+
+    @patch.dict("os.environ", {"HF_HOME": "/nonexistent/hf/home"}, clear=True)
+    @patch("tt_model_runners.base_device_runner.setup_runner_environment")
+    @patch("tt_model_runners.base_device_runner.get_settings")
+    def test_missing_hf_home_dir_does_not_crash(
+        self, mock_get_settings, mock_setup_env
+    ):
+        """A configured-but-not-yet-created HF_HOME must not crash __init__
+        (os.scandir would otherwise raise); the warning still fires."""
+        mock_settings = MagicMock()
+        mock_settings.device_mesh_shape = (1, 1)
+        mock_settings.use_dynamic_batcher = False
+        mock_get_settings.return_value = mock_settings
+
+        with patch("tt_model_runners.base_device_runner.TTLogger") as mock_logger_class:
+            mock_logger = MagicMock()
+            mock_logger_class.return_value = mock_logger
+
+            ConcreteDeviceRunner(self.device_id)  # must not raise
+
+            warning_msgs = [str(c) for c in mock_logger.warning.call_args_list]
+            assert any("HF_TOKEN" in msg for msg in warning_msgs)
+
+    @patch("tt_model_runners.base_device_runner.setup_runner_environment")
+    @patch("tt_model_runners.base_device_runner.get_settings")
+    def test_no_warning_when_hf_home_populated(self, mock_get_settings, mock_setup_env):
+        """A populated HF_HOME suppresses the warning even without HF_TOKEN."""
+        mock_settings = MagicMock()
+        mock_settings.device_mesh_shape = (1, 1)
+        mock_settings.use_dynamic_batcher = False
+        mock_get_settings.return_value = mock_settings
+
+        with tempfile.TemporaryDirectory() as hf_home:
+            Path(hf_home, "models--foo").mkdir()
+            with patch.dict("os.environ", {"HF_HOME": hf_home}, clear=True), patch(
+                "tt_model_runners.base_device_runner.TTLogger"
+            ) as mock_logger_class:
+                mock_logger = MagicMock()
+                mock_logger_class.return_value = mock_logger
+
+                ConcreteDeviceRunner(self.device_id)
+
+                warning_msgs = [str(c) for c in mock_logger.warning.call_args_list]
+                assert not any("HF_TOKEN" in msg for msg in warning_msgs)
 
 
 if __name__ == "__main__":

--- a/tt-media-server/tt_model_runners/base_device_runner.py
+++ b/tt-media-server/tt_model_runners/base_device_runner.py
@@ -35,12 +35,15 @@ class BaseDeviceRunner(ABC):
                 num_torch_threads = 16 if self.settings.use_dynamic_batcher else 1
             setup_runner_environment(device_id, cpu_threads, num_torch_threads)
 
+        hf_home = os.getenv("HF_HOME")
+        # os.scandir raises if HF_HOME points at a not-yet-created dir, so guard on isdir.
+        hf_home_populated = (
+            bool(hf_home) and os.path.isdir(hf_home) and any(os.scandir(hf_home))
+        )
         if (
             self.requires_weights
-            and not os.getenv("HF_TOKEN", None)
-            and not (
-                os.getenv("HF_HOME", None) and any(os.scandir(os.getenv("HF_HOME")))
-            )
+            and not os.getenv("HF_TOKEN")
+            and not hf_home_populated
         ):
             self.logger.warning(
                 "HF_TOKEN environment variable is not set and no cached models found in HF_HOME. Some models may not load properly."

--- a/utils/device_utils.py
+++ b/utils/device_utils.py
@@ -22,6 +22,7 @@ DEVICE_TO_MESH_STR = {
     "DUAL_GALAXY": "(8,8)",
     "QUAD_GALAXY": "(8,16)",
     "GPU": "GPU",
+    "SUPER_CLUSTER": "Super-Cluster",
 }
 
 

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -302,18 +302,28 @@ def ensure_weights_available(model_spec: dict) -> Path:
         logger.info(f"Using pre-mounted weights from MODEL_WEIGHTS_DIR: {weights_path}")
         return weights_path
 
-    # Default: download weights into cache_root
+    # Default: download weights into cache_root.
+    # snapshot_download resumes partial downloads and skips files already present, so
+    # always invoke it: a partially-downloaded directory looks non-empty but would crash
+    # the server at load time if treated as complete. Fall back to existing weights only
+    # when the hub is unreachable, preserving offline startup with complete weights.
     cache_root = Path(os.getenv("CACHE_ROOT", "/home/container_app_user/cache_root"))
     model_name = model_spec["model_name"]
     weights_path = cache_root / "weights" / model_name
+    hf_repo = model_spec.get("hf_weights_repo") or model_spec["hf_model_repo"]
 
-    if not weights_path.exists() or not any(weights_path.iterdir()):
-        hf_repo = model_spec.get("hf_weights_repo") or model_spec["hf_model_repo"]
-        logger.info(f"Downloading weights from {hf_repo} to {weights_path}")
-        weights_path.mkdir(parents=True, exist_ok=True)
+    weights_path.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Downloading weights from {hf_repo} to {weights_path}")
+    try:
         snapshot_download(repo_id=hf_repo, local_dir=weights_path)
-    else:
-        logger.info(f"Weights already exist at {weights_path}")
+    except Exception as e:
+        if any(weights_path.iterdir()):
+            logger.warning(
+                f"Could not reach Hugging Face to verify weights ({e}); "
+                f"using existing weights at {weights_path}"
+            )
+        else:
+            raise
 
     os.environ["MODEL_WEIGHTS_DIR"] = str(weights_path)
     return weights_path

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -177,11 +177,17 @@ templates:
         # logits; the default p150_x4 descriptor (selected from MESH_DEVICE) is correct.
         MESH_DEVICE: "P150x4"
         GEMMA4_PAGE_BLOCK_SIZE: "64"
-        # Size the hybrid-off all-user KV pool to fit QB2 DRAM. The container
-        # sizes the pool from Gemma4ForCausalLM.get_max_tokens_all_users, which
-        # honors this env override (value kept here, gated by device + model,
-        # rather than hardcoded in tt-metal).
+        # Full-cache single pool (hybrid kv-cache groups OFF). Hybrid/bounded
+        # (GEMMA4_HYBRID_KV_CACHE_GROUPS=1) serves to ISL 4096 but the benchmark
+        # sweep TT_FATALs at ISL >= 8192 (chunked-prefill SDPA head_dim mismatch,
+        # needs a tt-metal op fix); re-enable + raise GEMMA4_MAX_TOKENS_ALL_USERS
+        # once fixed. Pool sized to QB2 DRAM via get_max_tokens_all_users.
         GEMMA4_MAX_TOKENS_ALL_USERS: "49152"
+        # Generator-level chunked prefill (#49083 fix): an 8192+ prompt as one
+        # full-length chunk hits the nlp_concat_heads fetch-queue hang. 4096 is
+        # the largest chunk that both traces and avoids the wedge (8192 either
+        # wedges eager or OOMs traced).
+        GEMMA4_GEN_PREFILL_CHUNK: "4096"
       override_tt_config:
         fabric_config: FABRIC_1D
         trace_region_size: 200000000

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -145,6 +145,7 @@ def get_media_server_docker_env_vars(model_spec):
 
     env_vars = {
         "CACHE_ROOT": "/home/container_app_user/cache_root",  # TODO: remove this
+        "HF_HOME": "/home/container_app_user/cache_root/huggingface",  # Keep HF weight cache on the persistent cache_root volume
         "MODEL": model_spec.model_name,
         "DEVICE": model_spec.device_type.name.lower(),
     }

--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -589,9 +589,9 @@ class HostSetupManager:
             / "weights"
             / self.model_spec.model_name
         )
-        if self.check_model_weights_dir(host_weights_dir):
-            logger.info("Weights already exist in host volume, skipping download")
-            return
+        # Always run `hf download`; it resumes partial downloads and skips files
+        # already present. weights_complete only gates the offline fallback below.
+        weights_complete = self.check_model_weights_dir(host_weights_dir)
         host_weights_dir.mkdir(parents=True, exist_ok=True)
         cmd = [
             str(hf_exec),
@@ -605,7 +605,13 @@ class HostSetupManager:
         logger.info(f"Downloading model to host volume: {hf_repo}")
         logger.info(f"Command: {shlex.join(cmd)}")
         result = subprocess.run(cmd)
-        assert result.returncode == 0, f"⛔ Error during: {' '.join(cmd)}"
+        if result.returncode != 0 and weights_complete:
+            logger.warning(
+                f"Could not reach Hugging Face to verify weights; "
+                f"using existing weights at {host_weights_dir}"
+            )
+        else:
+            assert result.returncode == 0, f"⛔ Error during: {' '.join(cmd)}"
         logger.info(f"✅ Using weights directory: {host_weights_dir}")
 
     def setup_weights_local(self):

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -87,6 +87,7 @@ class DeviceTypes(IntEnum):
     GALAXY_T3K = auto()
     DUAL_GALAXY = auto()
     QUAD_GALAXY = auto()
+    SUPER_CLUSTER = auto()
 
     @classmethod
     def from_string(cls, name: str):
@@ -118,6 +119,7 @@ class DeviceTypes(IntEnum):
             DeviceTypes.DUAL_GALAXY: "(8,8)",
             DeviceTypes.QUAD_GALAXY: "(8,16)",
             DeviceTypes.GPU: "GPU",
+            DeviceTypes.SUPER_CLUSTER: "Super-Cluster",
         }
         if self not in mapping:
             raise ValueError(f"Invalid DeviceType: {self}")
@@ -141,6 +143,7 @@ class DeviceTypes(IntEnum):
             DeviceTypes.GALAXY_T3K: "WH Galaxy",
             DeviceTypes.DUAL_GALAXY: "Dual WH Galaxy",
             DeviceTypes.QUAD_GALAXY: "Quad WH Galaxy",
+            DeviceTypes.SUPER_CLUSTER: "BH Super-Cluster",
         }
         if self not in mapping:
             raise ValueError(f"Invalid DeviceType: {self}")
@@ -179,12 +182,17 @@ class DeviceTypes(IntEnum):
             DeviceTypes.P300,
             DeviceTypes.P300X2,
             DeviceTypes.BLACKHOLE_GALAXY,
+            DeviceTypes.SUPER_CLUSTER,
         )
         return self in blackhole_devices
 
     def is_multihost(self) -> bool:
         """Check if this device type requires multi-host deployment."""
-        return self in {DeviceTypes.DUAL_GALAXY, DeviceTypes.QUAD_GALAXY}
+        return self in {
+            DeviceTypes.DUAL_GALAXY,
+            DeviceTypes.QUAD_GALAXY,
+            DeviceTypes.SUPER_CLUSTER,
+        }
 
     def get_multihost_num_hosts(self) -> int:
         """Get expected number of hosts for multi-host device types.
@@ -230,6 +238,7 @@ class DeviceTypes(IntEnum):
             (DeviceTypes.BLACKHOLE_GALAXY, 32): DeviceTypes.P150,
             (DeviceTypes.DUAL_GALAXY, 8): DeviceTypes.T3K,
             (DeviceTypes.QUAD_GALAXY, 16): DeviceTypes.T3K,
+            (DeviceTypes.SUPER_CLUSTER, 1): DeviceTypes.SUPER_CLUSTER,
         }
         if (self, data_parallel) not in data_parallel_map:
             raise ValueError(


### PR DESCRIPTION
https://github.com/tenstorrent/tt-inference-server/pull/4491 adds that if the model has any EVALS_AGENTIC tasks → also run an agentic child (on release CI)

For release CI, we eval test on only `r1_gpqa_diamond` (EVALS_COMMON), therefore this PR removes entries of `terminal_bench_2` and `swe_bench_verified`