### PR TITLE
Fix: HF_HOME Permission issue with Falcon3-7B-Instruct

### DIFF
--- a/tt-media-server/run_uvicorn.sh
+++ b/tt-media-server/run_uvicorn.sh
@@ -29,4 +29,18 @@ if [ -n "${TT_KV_POOL_GB:-}" ]; then
     fi
 fi
 
+# HF_HOME (a persistent cache_root path set by the launcher) isn't always
+# writable by this uid. Fall back to a per-user cache so model download/load 
+# never crashes at startup (sacrifices cache persistence for media model weights).
+if [ -n "${HF_HOME:-}" ]; then
+    if ( mkdir -p "${HF_HOME}" && touch "${HF_HOME}/.hf_write_test" ) 2>/dev/null; then
+        rm -f "${HF_HOME}/.hf_write_test"
+    else
+        _hf_fallback="${HOME:-/home/container_app_user}/.cache/huggingface"
+        echo "[run_uvicorn] HF_HOME=${HF_HOME} not writable; falling back to ${_hf_fallback} (weights will not persist)"
+        mkdir -p "${_hf_fallback}"
+        export HF_HOME="${_hf_fallback}"
+    fi
+fi
+
 uvicorn --host 0.0.0.0 main:app --lifespan on --port "${SERVICE_PORT:-8000}"

--- a/tt-media-server/tests/test_run_uvicorn_hf_home.py
+++ b/tt-media-server/tests/test_run_uvicorn_hf_home.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+"""run_uvicorn.sh must guarantee HF_HOME is writable before launching the
+server. If the launcher-provided HF_HOME (a persistent cache_root path) isn't
+writable by this uid — e.g. a bind-mounted cache_root in CI, or an image
+without the root-entrypoint permission fixup — it falls back to a per-user
+cache so model download/load never crashes at startup."""
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "run_uvicorn.sh"
+
+# A path on the read-only procfs: mkdir fails for every uid (incl. root), so it
+# reliably exercises the "not writable" branch regardless of test environment.
+UNWRITABLE_HF_HOME = "/proc/tt_hf_nowrite"
+
+
+def _source_and_report(hf_home, home):
+    """Source run_uvicorn.sh with uvicorn stubbed, return the resulting HF_HOME.
+
+    The stub replaces the real server launch with an echo, so sourcing the
+    script only runs the startup guards. --skip-venv avoids venv activation.
+    """
+    stub = (
+        f'uvicorn() {{ echo "RESULT_HF_HOME=$HF_HOME"; }}; '
+        f'source "{SCRIPT}" --skip-venv'
+    )
+    env = {**os.environ, "HOME": home}
+    env.pop("TT_KV_POOL_GB", None)  # skip the unrelated worker-patch block
+    if hf_home is None:
+        env.pop("HF_HOME", None)
+    else:
+        env["HF_HOME"] = hf_home
+    result = subprocess.run(
+        ["bash", "-c", stub], capture_output=True, text=True, env=env
+    )
+    assert result.returncode == 0, result.stderr
+    for line in result.stdout.splitlines():
+        if line.startswith("RESULT_HF_HOME="):
+            return line[len("RESULT_HF_HOME=") :]
+    raise AssertionError(f"stub did not run; output:\n{result.stdout}\n{result.stderr}")
+
+
+def test_unwritable_hf_home_falls_back_to_user_cache():
+    with tempfile.TemporaryDirectory() as home:
+        hf_home = _source_and_report(UNWRITABLE_HF_HOME, home)
+        assert hf_home == str(Path(home) / ".cache" / "huggingface")
+        assert Path(hf_home).is_dir()  # fallback dir was created
+
+
+def test_writable_hf_home_is_kept():
+    with tempfile.TemporaryDirectory() as home:
+        target = str(Path(home) / "persistent" / "huggingface")
+        hf_home = _source_and_report(target, home)
+        assert hf_home == target
+        assert not (Path(target) / ".hf_write_test").exists()  # probe cleaned up
+
+
+def test_unset_hf_home_is_left_unset():
+    with tempfile.TemporaryDirectory() as home:
+        assert _source_and_report(None, home) == ""


### PR DESCRIPTION
## Summary

Fixes #4574 — a regression from #4397. On the Forge/media server, HuggingFace weight download crashed with `Permission denied: /home/container_app_user/cache_root/huggingface`; the server never became healthy and the release job timed out and failed. vLLM was unaffected.

## Root cause

#4397 set `HF_HOME=/home/container_app_user/cache_root/huggingface` for media/forge containers so weights persist on the `cache_root` volume. This works for the media image (its `docker-entrypoint.sh` runs as root and makes the mounted `cache_root` group-writable, then drops to `container_app_user`). But `Dockerfile.forge` has **no entrypoint** — it runs directly as `container_app_user` (uid 1000) with no permission fixup, so on a bind-mounted `cache_root` (owned by another uid, e.g. in CI) uid 1000 can't create `cache_root/huggingface` → crash. #4397 guarded the "dir doesn't exist yet" case but not "dir isn't writable".

## Fix

`tt-media-server/run_uvicorn.sh` (the shared entry both images launch, before Python/`transformers` load) now probes `HF_HOME` for writability and falls back to a per-user cache (`$HOME/.cache/huggingface`) if it isn't writable:

- **Writable `cache_root`** (media image) → `HF_HOME` kept → weights persist (unchanged behavior).
- **Unwritable `cache_root`** (forge image / bind mount) → falls back to the uid-owned ephemeral cache → server starts. This is exactly the pre-#4397 behavior, so the worst case is the state that ran successfully for months.

Placed in the shell entry (not the Python code or the host-side launcher) because writability is a container-runtime property — it depends on the runtime uid and the mounted volume, neither knowable host-side — and running before the interpreter avoids `transformers`/`huggingface_hub` import-time cache-path caching. It corrects the env once in the parent, so all consumers (download, `from_pretrained`, the `scandir` guard, speaker embeddings) and spawned workers inherit the fix.

## Changes

| File | Change |
|------|--------|
| `tt-media-server/run_uvicorn.sh` | Fall back to a writable per-user cache when `HF_HOME` isn't writable |
| `tt-media-server/tests/test_run_uvicorn_hf_home.py` | Tests: unwritable → fallback (dir created); writable → kept (probe cleaned up); unset → no-op |

## CI Runs
https://github.com/tenstorrent/tt-shield/actions/runs/29027954274
