### PR TITLE
Fix: pinned datasets and pyarrow in requirements/v2-run-script.txt

### DIFF
--- a/requirements/v2-run-script.txt
+++ b/requirements/v2-run-script.txt
@@ -39,4 +39,5 @@ pytest-asyncio==1.3.0
 # to keep the eager import chain self-contained.
 jinja2
 librosa
-datasets
+datasets==5.0.0
+pyarrow==24.0.0


### PR DESCRIPTION
- Regression from PR #4503: routing speecht5_tts to v2 moved TTSLoadTest into the .venv_v2_run_script venv, and the PR added datasets unpinned to requirements/v2-run-script.txt.
- Upinned datasets backtracked to a pre-2.20 version that uses pa.PyExtensionType, while pyarrow resolved to 24.0.0 -> AttributeError on from datasets import load_dataset.

On-nightly fail: https://github.com/tenstorrent/tt-shield/actions/runs/28902830865/job/85756472948
CI run: https://github.com/tenstorrent/tt-shield/actions/runs/29036771418
