### PR TITLE
Bump torch version

### DIFF
--- a/tt-media-server/requirements.txt
+++ b/tt-media-server/requirements.txt
@@ -18,8 +18,8 @@ silero_vad
 tqdm
 uvicorn
 whisperx==3.4.3
-torch==2.7.1+cpu
-torchaudio==2.7.1+cpu
+torch==2.10.0+cpu
+torchaudio==2.10.0+cpu
 requests
 num2words
 


### PR DESCRIPTION
While running the models in `tt-inference-server` using the [Bring Your Own Server (optional Uvicorn) path](https://github.com/tenstorrent/tt-inference-server/blob/kmabee/forge_llm_integration_doc/FORGE_MODEL_INTEGRATION_GUIDE.md#bring-your-own-server-the-optional-uvicorn-path), I encountered the following error:

```
File "/localdev/ctr-dmahidhar/tt-xla/tt-inference-server/tt-media-server/resolver/service_resolver.py", line 60, in service_resolver
    _service_holders[model_service] = _SUPPORTED_MODEL_SERVICES[model_service]()
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/localdev/ctr-dmahidhar/tt-xla/tt-inference-server/tt-media-server/resolver/service_resolver.py", line 19, in <lambda>
    ).LLMService(),
      ^^^^^^^^^^^^
  File "/localdev/ctr-dmahidhar/tt-xla/tt-inference-server/tt-media-server/model_services/llm_service.py", line 10, in __init__
    super().__init__()
  File "/localdev/ctr-dmahidhar/tt-xla/tt-inference-server/tt-media-server/utils/decorators.py", line 27, in sync_wrapper
    result = func(
             ^^^^^
  File "/localdev/ctr-dmahidhar/tt-xla/tt-inference-server/tt-media-server/model_services/base_service.py", line 25, in __init__
    HuggingFaceUtils().download_weights()
  File "/localdev/ctr-dmahidhar/tt-xla/tt-inference-server/tt-media-server/utils/hugging_face_utils.py", line 73, in download_weights
    raise RuntimeError("Missing required dependency: huggingface_hub")
RuntimeError: Missing required dependency: huggingface_hub

```

After further debugging, I found that the [requirements.txt](https://github.com/tenstorrent/tt-inference-server/blob/main/tt-media-server/requirements.txt#L21) file was using torch==2.7.1+cpu, which is incompatible with the version required by tt-xla. The tt-xla project uses torch==2.10.0+cpu. After updating the requirements.txt file to use the correct PyTorch version and reinstalling the dependencies, the above-mentioned error was resolved.