### PR TITLE
Fix Slot Copy Logic

### DIFF
--- a/tt-media-server/cpp_server/src/services/prefix_cache_router.cpp
+++ b/tt-media-server/cpp_server/src/services/prefix_cache_router.cpp
@@ -408,12 +408,14 @@ void PrefixCacheRouter::getSlot(
   if (tt::config::llmMode() == tt::config::LLMMode::DECODE_ONLY &&
       acquired.has_value() && !acquired->candidatesList.empty()) {
     const auto& best = acquired->candidatesList.front();
-    if (domain::prefix_cache::BlockMatcher::passesHitThreshold(best)) {
+    const uint32_t bestMatchedTokens =
+        domain::prefix_cache::BlockMatcher::blocksToTokens(best.matchedBlocks);
+    if (domain::prefix_cache::BlockMatcher::passesHitThreshold(best) &&
+        bestMatchedTokens >= tt::config::minTokensToCopy()) {
       auto session = callbacks.getSession(best.sessionId);
       if (session) {
         slotToCopyFrom = session->getSlotId();
-        copyMatchedTokens = domain::prefix_cache::BlockMatcher::blocksToTokens(
-            best.matchedBlocks);
+        copyMatchedTokens = bestMatchedTokens;
         callbacks.lockSlot(*slotToCopyFrom);
         TT_LOG_INFO(
             "[PrefixCacheRouter::getSlot] Will copy from slotId={} "

--- a/tt-media-server/cpp_server/src/services/prefix_cache_router.cpp
+++ b/tt-media-server/cpp_server/src/services/prefix_cache_router.cpp
@@ -410,8 +410,7 @@ void PrefixCacheRouter::getSlot(
     const auto& best = acquired->candidatesList.front();
     const uint32_t bestMatchedTokens =
         domain::prefix_cache::BlockMatcher::blocksToTokens(best.matchedBlocks);
-    if (domain::prefix_cache::BlockMatcher::passesHitThreshold(best) &&
-        bestMatchedTokens >= tt::config::minTokensToCopy()) {
+    if (bestMatchedTokens >= tt::config::minTokensToCopy()) {
       auto session = callbacks.getSession(best.sessionId);
       if (session) {
         slotToCopyFrom = session->getSlotId();

--- a/tt-media-server/cpp_server/tests/unit/services/prefix_cache_router_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/services/prefix_cache_router_test.cpp
@@ -36,6 +36,7 @@ class PrefixCacheRouterTest : public ::testing::Test {
 
   void SetUp() override {
     setenv("PREFIX_CACHE_HIT_THRESHOLD", "0", 1);
+    setenv("MIN_TOKENS_TO_COPY", "0", 1);
     setenv("KV_CACHE_FIRST_BLOCK_SIZE", "32", 1);
     setenv("KV_CACHE_BLOCK_SIZE", "32", 1);
 


### PR DESCRIPTION
## Problem
We want to rely only on `MIN_TOKENS_TO_COPY` for Slot Copy mechanism 