### PR TITLE
Make image benchmark batch count configurable per-model

### DIFF
--- a/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
@@ -35,7 +35,7 @@ from ..test_status import ImageGenerationTestStatus
 logger = logging.getLogger(__name__)
 
 
-SDXL_BENCHMARK_NUM_BATCHES = 3
+DEFAULT_IMAGE_BENCHMARK_NUM_BATCHES = 3
 
 SDXL_SD35_BENCHMARK_NUM_PROMPTS = 20
 SDXL_SD35_INFERENCE_STEPS = 20
@@ -466,11 +466,16 @@ def run_image_benchmark(ctx: MediaContext) -> Block:
         max_concurrency = None
         if runner_in_use in _SDXL_BENCHMARK_RUNNERS:
             max_concurrency = ctx.model_spec.device_model_spec.max_concurrency
+            num_batches = getattr(
+                ctx.model_spec.device_model_spec,
+                "image_benchmark_num_batches",
+                DEFAULT_IMAGE_BENCHMARK_NUM_BATCHES,
+            )
             if max_concurrency and max_concurrency > 0:
-                num_calls = SDXL_BENCHMARK_NUM_BATCHES * max_concurrency
+                num_calls = num_batches * max_concurrency
                 logger.info(
                     f"Overriding num_calls for {runner_in_use} to {num_calls} prompts "
-                    f"({SDXL_BENCHMARK_NUM_BATCHES} batches x {max_concurrency} concurrent requests)"
+                    f"({num_batches} batches x {max_concurrency} concurrent requests)"
                 )
             else:
                 max_concurrency = None

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -366,7 +366,7 @@ class DeviceModelSpec:
     # Default 3 × exponential backoff = hours of burn on permanent 4xx.
     eval_max_retries: Optional[int] = None
     # num_calls = num_batches * max_concurrency.
-    # Uniform default of 3 across all image models; override per model in the YAML spec 
+    # Uniform default of 3 across all image models; override per model in the YAML spec
     image_benchmark_num_batches: int = 3
 
     def __post_init__(self):

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -365,6 +365,9 @@ class DeviceModelSpec:
     # When set, run_evals appends max_retries=<N> to lm-eval --model_args.
     # Default 3 × exponential backoff = hours of burn on permanent 4xx.
     eval_max_retries: Optional[int] = None
+    # num_calls = num_batches * max_concurrency.
+    # Uniform default of 3 across all image models; override per model in the YAML spec 
+    image_benchmark_num_batches: int = 3
 
     def __post_init__(self):
         self.validate_data()


### PR DESCRIPTION
Keep a uniform default of 3 batches across all image models (no behavior change out of the box). Allow the batch count to be overridden at the model level, so individual models can run more or fewer batches when needed.
Issue: https://github.com/tenstorrent/tt-inference-server/issues/2848?issue=tenstorrent%7Ctt-inference-server%7C3922
