### PR TITLE
Add c64 prefix-cache presets and high-ISL SUPER_CLUSTER benchmark sweep

### DIFF
--- a/docs/benchmarking_tools.md
+++ b/docs/benchmarking_tools.md
@@ -325,6 +325,19 @@ Scenarios and per-preset grids are defined in
 `--prefix-cache-scenarios-json`, subset with `--prefix-cache-scenarios`, and
 point `mooncake_trace` at a production trace via `--prefix-cache-trace`.
 
+### Presets (`--prefix-cache-preset`)
+
+| Preset | Shape |
+|--------|-------|
+| `ci` | Tiny regression sweep. |
+| `full` | Comprehensive serving-validation sweep (default). |
+| `highcache_50k` | 50K shared + 5K ISL + 500 OSL @ c32, ~90.9% hit-rate. |
+| `highcache_55k_c64` | 90% prefix @ mean ISL 55K, c64 (49.5K shared + 5.5K ISL + 500 OSL), 512 reqs. `shared_system` + matched `baseline`. |
+| `highcache_256k_c64` | 90% prefix @ mean ISL 256K, c64 (230.4K shared + 25.6K ISL + 500 OSL), 256 reqs. `shared_system` + matched `baseline`. |
+
+For the c64 presets, the `shared_system` run's **P50 TTFT** reads the warm
+(cache-hit) path and its **P99 TTFT** reads the cold (first-touch) tail.
+
 See [the workflow development guide](workflow_development.md#prefix-caching-benchmark)
 for flags, report layout, and TT hardware notes (prefix caching may be disabled
 in `tt-vllm-plugin` until lifted).

--- a/docs/workflow_development.md
+++ b/docs/workflow_development.md
@@ -252,7 +252,8 @@ reuse the existing venv. This mirrors how the `VenvCommand`s built by
 each workflow's venv at execute time.
 
 Scenarios (`shared_system`, `prefix_pool`, `multi_turn`, `baseline`,
-`mooncake_trace`) and per-preset grids (`ci`, `full`, `highcache_50k`) are
+`mooncake_trace`) and per-preset grids (`ci`, `full`, `highcache_50k`,
+`highcache_55k_c64`, `highcache_256k_c64`) are
 JSON-defined and overridable with `--prefix-cache-scenarios-json`. Override the
 mooncake trace input with `--prefix-cache-trace`; the in-tree fixture at
 [`llm_module/prefix_cache/sample_traces/ci_mooncake.jsonl`](../llm_module/prefix_cache/sample_traces/ci_mooncake.jsonl)
@@ -349,6 +350,33 @@ scrapes into `server_metrics_export.jsonl`; on Tenstorrent hardware the
 `tt-vllm-plugin` currently disables prefix caching, so the hit-rate column
 renders as `null` until that's lifted (validation work was done against a
 reference GPU vLLM).
+
+### `highcache_55k_c64` / `highcache_256k_c64` presets (90% prefix @ c64)
+
+Two concurrency-64 presets characterize prefix-caching at a fixed **90% prefix
+ratio** for two mean-ISL points, each pairing a `shared_system` run with a matched
+zero-prefix `baseline`:
+
+| Preset | Shared prefix | New ISL | OSL | Total ISL | Hit-rate | Concurrency | Requests |
+|---|---|---|---|---|---|---|---|
+| `highcache_55k_c64`  | 49 500  | 5 500  | 500 | 55 000  | 49500/55000 = 90.0%   | 64 | 512 (8 waves) |
+| `highcache_256k_c64` | 230 400 | 25 600 | 500 | 256 000 | 230400/256000 = 90.0% | 64 | 256 (4 waves) |
+
+Within the `shared_system` run the **P50 TTFT** reads the warm/cache-hit path and
+the **P99 TTFT** reads the cold/first-touch tail, so a single run reports both cold
+and warm behavior; the matched `baseline` isolates the caching uplift. The
+`highcache_256k_c64` total of 256 500 tokens/request stays under the 256K
+(`262144`) context with headroom. The default `time_to_first_token:4000` goodput
+bar is not meaningful for a 256K cold prompt — override it with
+`--prefix-cache-goodput` when validating that shape.
+
+```bash
+python run.py --model Kimi-K2.6 --workflow benchmarks --tt-device super_cluster \
+    --server-url <endpoint> --service-port 443 \
+    --prefix-cache --prefix-cache-preset highcache_55k_c64 \
+    --prefix-cache-scenarios shared_system,baseline \
+    --prefix-cache-metrics-url <worker-host:port>
+```
 
 ## Speculative-decoding benchmark
 

--- a/llm_module/prefix_cache/manifest.json
+++ b/llm_module/prefix_cache/manifest.json
@@ -10,6 +10,13 @@
     "                    hit-rate target ~90.9% = 50000/(50000+5000). Pairs shared_system",
     "                    (100% reuse) with a matched zero-prefix baseline so the report",
     "                    isolates the TTFT (P50/P90/P99) uplift from prefix caching.",
+    "  - highcache_55k_c64  : 90% prefix ratio at mean ISL 55K, concurrency 64. 49.5K",
+    "                    shared prefix + 5.5K new ISL + 500 OSL (49500/55000 = 90.0%).",
+    "                    512 requests (8 waves of 64). shared_system + matched baseline.",
+    "  - highcache_256k_c64 : 90% prefix ratio at mean ISL 256K, concurrency 64. 230.4K",
+    "                    shared prefix + 25.6K new ISL + 500 OSL (230400/256000 = 90.0%;",
+    "                    total 256500 tokens <= 256K context). 256 requests (4 waves of",
+    "                    64). shared_system + matched baseline.",
     "Scenarios:",
     "  - shared_system  : single shared system prompt (100% prefix reuse).",
     "  - prefix_pool    : pool of N distinct prefixes; reuse_ratio = request_count / N.",
@@ -184,6 +191,67 @@
           "synthesis_grid": [
             {"name": "as_is"}
           ]
+        },
+        "baseline": {
+          "arrival_patterns": [{"pattern": "constant"}]
+        }
+      }
+    },
+    "highcache_55k_c64": {
+      "_comment": [
+        "90% prefix ratio at mean ISL 55K, concurrency 64.",
+        "49.5K shared (cacheable) prefix + 5.5K new ISL + 500 OSL.",
+        "Steady-state per-session KV-cache hit-rate = 49500/(49500+5500) = 90.0%.",
+        "shared_system sends the 49.5K prefix as an identical system message across",
+        "every session (100% reuse); its P50 TTFT reads the warm/cache-hit path and",
+        "its P99 TTFT reads the cold/first-touch tail. The matched zero-prefix baseline",
+        "(same 5.5K ISL / 500 OSL / c64) isolates the TTFT uplift from prefix caching.",
+        "request_count=512 (8 waves of 64) gives usable TTFT percentiles incl. P99.",
+        "Scrape the worker tt_prefix_cache_* counters with --prefix-cache-metrics-url",
+        "to populate the hit-rate column. Override the SLA bar with --prefix-cache-goodput."
+      ],
+      "request_count": 512,
+      "concurrencies": [64],
+      "goodput": "time_to_first_token:4000 output_token_throughput_per_user:45",
+      "isl_profiles": [
+        {"name": "new5500", "isl_mean": 5500, "isl_stddev": 0}
+      ],
+      "osl_mean": 500,
+      "osl_stddev": 0,
+      "scenarios": {
+        "shared_system": {
+          "shared_system_prompt_length": 49500,
+          "arrival_patterns": [{"pattern": "constant"}]
+        },
+        "baseline": {
+          "arrival_patterns": [{"pattern": "constant"}]
+        }
+      }
+    },
+    "highcache_256k_c64": {
+      "_comment": [
+        "90% prefix ratio at mean ISL 256K, concurrency 64.",
+        "230.4K shared (cacheable) prefix + 25.6K new ISL + 500 OSL.",
+        "Steady-state per-session KV-cache hit-rate = 230400/(230400+25600) = 90.0%.",
+        "Total tokens/request = 256500 <= 262144 (256K) context, so it fits with headroom.",
+        "shared_system P50 reads warm/cache-hit TTFT, P99 reads the cold/first-touch tail;",
+        "the matched zero-prefix baseline isolates the prefix-caching TTFT uplift.",
+        "request_count=256 (4 waves of 64) bounds the very heavy 256K-context runtime while",
+        "keeping usable percentiles. The 4000ms TTFT goodput bar is not meaningful for a",
+        "256K cold prompt -- override it per run with --prefix-cache-goodput if needed."
+      ],
+      "request_count": 256,
+      "concurrencies": [64],
+      "goodput": "time_to_first_token:4000 output_token_throughput_per_user:45",
+      "isl_profiles": [
+        {"name": "new25600", "isl_mean": 25600, "isl_stddev": 0}
+      ],
+      "osl_mean": 500,
+      "osl_stddev": 0,
+      "scenarios": {
+        "shared_system": {
+          "shared_system_prompt_length": 230400,
+          "arrival_patterns": [{"pattern": "constant"}]
         },
         "baseline": {
           "arrival_patterns": [{"pattern": "constant"}]

--- a/run.py
+++ b/run.py
@@ -478,12 +478,21 @@ def parse_arguments():
     prefix_cache_group.add_argument(
         "--prefix-cache-preset",
         type=str,
-        choices=["ci", "full", "highcache_50k"],
+        choices=[
+            "ci",
+            "full",
+            "highcache_50k",
+            "highcache_55k_c64",
+            "highcache_256k_c64",
+        ],
         default="full",
         help="Preset for --prefix-cache (default: full). 'ci' is a short regression sweep; "
         "'highcache_50k' simulates the customer trillion-scale shape (50K shared/cacheable "
         "prefix + 5K new ISL + 500 OSL at concurrency 32, ~90.9%% steady-state hit-rate) "
-        "with a matched zero-prefix baseline for TTFT-uplift comparison.",
+        "with a matched zero-prefix baseline for TTFT-uplift comparison. "
+        "'highcache_55k_c64' / 'highcache_256k_c64' characterize a 90%% prefix ratio at "
+        "mean ISL 55K / 256K at concurrency 64 (P50 = warm, P99 = cold TTFT), each with a "
+        "matched zero-prefix baseline.",
     )
     prefix_cache_group.add_argument(
         "--prefix-cache-scenarios",

--- a/run_workflows.py
+++ b/run_workflows.py
@@ -172,7 +172,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--prefix-cache-preset",
         type=str,
-        choices=["ci", "full", "highcache_50k"],
+        choices=[
+            "ci",
+            "full",
+            "highcache_50k",
+            "highcache_55k_c64",
+            "highcache_256k_c64",
+        ],
         default="full",
         help=(
             "Preset for --prefix-cache (default: full). 'ci' is a short "
@@ -180,7 +186,10 @@ def parse_args() -> argparse.Namespace:
             "validation sweep, 'highcache_50k' simulates the customer "
             "trillion-scale shape (50K shared/cacheable prefix + 5K new ISL + "
             "500 OSL at concurrency 32; ~90.9%% steady-state hit-rate) with a "
-            "matched zero-prefix baseline for TTFT-uplift comparison."
+            "matched zero-prefix baseline for TTFT-uplift comparison. "
+            "'highcache_55k_c64' / 'highcache_256k_c64' characterize a 90%% "
+            "prefix ratio at mean ISL 55K / 256K at concurrency 64 (P50 = warm, "
+            "P99 = cold TTFT), each paired with a matched zero-prefix baseline."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
Adds high-concurrency (64), high-ISL benchmark coverage for SUPER_CLUSTER /
remote-endpoint LLMs (e.g. Kimi-K2.x): two new prefix-cache presets, plus the
vLLM sweep changes needed to actually exercise concurrency 64 at large ISL.

## Changes

**Prefix-cache presets** — `tt-inference-server-v2/llm_module/prefix_cache/manifest.json`
- `highcache_55k_c64` — 90% prefix ratio at mean ISL 55K (49.5K shared + 5.5K new), c64.
- `highcache_256k_c64` — 90% prefix ratio at mean ISL 256K (230.4K shared + 25.6K new), c64.
- Each pairs `shared_system` (P50 = warm / P99 = cold TTFT) with a matched zero-prefix
  `baseline`. Registered in the `--prefix-cache-preset` choices in both v1 and v2 `run.py`.

**vLLM bench sweep (SUPER_CLUSTER)** — `benchmarking/benchmark_config.py`, `workflows/model_spec.py`
- Extra ISL points (192K, 240K) so the sweep reaches ~250K, below the 256K cap.
- SUPER_CLUSTER token budget = `max_context × max_concurrency`, so concurrency no longer
  collapses toward 1 at high ISL.
- Minimum `num_prompts` floor (256) for multi-user SUPER_CLUSTER sweep points.

**Agentic parallel-bench** — `tt-inference-server-v2/llm_module/agentic/*`, `drivers/vllm.py`
- Randomized, buffered request-size distribution for Harbor/SWE-bench workloads;
  parallel top-up load; single-JSON output.

## Tests & docs
Adds unit tests for the sweep concurrency/num_prompts floor and the parallel-bench;
updates the v2 README and `docs/benchmarking_tools.md`.

> Note: the sweep and agentic-bench commits are cherry-picked from
> `ipastalTT/add-vllm-sweep-all`.
