### PR TITLE
[Qwen3.6-27B] Disable `on_device_sampling` for now

### DIFF
--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -391,7 +391,8 @@ templates:
         # Magic number; follows vllm nightly:
         # https://github.com/tenstorrent/tt-metal/actions/runs/28493777891/job/84457052459#step:10:1
         trace_region_size: 268435456
-        # sample_on_device_mode: decode_only
+        # TODO: turn this back on after the model supports this
+        # sample_on_device_mode: decode_only 
   # EXPERIMENTAL: no target performance has been set yet, so we can't classify
   # this as FUNCTIONAL, COMPLETE, or top-perf.
   status: EXPERIMENTAL

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -391,7 +391,7 @@ templates:
         # Magic number; follows vllm nightly:
         # https://github.com/tenstorrent/tt-metal/actions/runs/28493777891/job/84457052459#step:10:1
         trace_region_size: 268435456
-        sample_on_device_mode: decode_only
+        # sample_on_device_mode: decode_only
   # EXPERIMENTAL: no target performance has been set yet, so we can't classify
   # this as FUNCTIONAL, COMPLETE, or top-perf.
   status: EXPERIMENTAL


### PR DESCRIPTION
Currently, tt-metal PR for on-device-sampling has not been merged.  Enabling it in tt-inference-server causes errors in CI.  Temporarily disable now to re-enable when on-device-sampling PR gets merged to main. 