### PR TITLE
Bump tt-forge to 1.4.0.dev20260718001745 for LLM blocker fixes

### DIFF
--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
 --extra-index-url https://download.pytorch.org/whl/cpu
-# 1.4.0 dev/nightly built 2026-07-05. Supersedes the 2026-07-04 build.
-tt-forge==1.4.0.dev20260705001833
+# 1.4.0 dev/nightly built 2026-07-18. Supersedes the 2026-07-05 build.
+tt-forge==1.4.0.dev20260718001745
 
 tabulate
 timm # input preprocessing


### PR DESCRIPTION
### Issue

- https://github.com/tenstorrent/tt-xla/issues/5664
- https://github.com/tenstorrent/tt-xla/issues/5504
- https://github.com/tenstorrent/tt-xla/issues/5579

### What's Changed

Version bump of `tt-forge` to `1.4.0.dev20260718001745` in `tt-media-server/tt_model_runners/forge_runners/requirements.txt` (supersedes the `2026-07-05` build from #4519).

This brings some new tt-xla changes including a memory leak fix, a hang fix, and the chunked-SDPA prefill row_major assert fix affecting all LLMs

### Checklist

- [ ] `efficientnet`: https://github.com/tenstorrent/tt-shield/actions/runs/29668069191 (fails identically on `main` with no wheel bump: https://github.com/tenstorrent/tt-shield/actions/runs/29669645288 -- confirmed pre-existing `app:server` / liveness endpoint 405 harness bug, unrelated to this PR)
- [x] `mobilenetv2`: https://github.com/tenstorrent/tt-shield/actions/runs/29668069731
- [x] `resnet-50`: https://github.com/tenstorrent/tt-shield/actions/runs/29668070374
- [x] `segformer`: https://github.com/tenstorrent/tt-shield/actions/runs/29668071037
- [x] `vit`: https://github.com/tenstorrent/tt-shield/actions/runs/29668071652
- [x] `vovnet`: https://github.com/tenstorrent/tt-shield/actions/runs/29668072380
- [x] `Falcon3-7B-Instruct`: https://github.com/tenstorrent/tt-shield/actions/runs/29627002910
- [x] `Qwen3-4B` : https://github.com/tenstorrent/tt-shield/actions/runs/29632532949
