### PR TITLE
Set LongBench tasks for meta-llama/Llama-3.1-8B-Instruct to apply_chat_template=False

### DIFF
--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -3121,6 +3121,7 @@ _eval_config_list = [
                         "unit": "percent",
                     },
                 ),
+
             ),
             EvalTask(
                 task_name="longbench_fewshot_e",
@@ -3139,6 +3140,7 @@ _eval_config_list = [
             ),
             EvalTask(
                 task_name="longbench_multi_e",
+                apply_chat_template=False,
                 min_context_required=16384,
                 score=EvalTaskScore(
                     published_score=None,
@@ -3154,6 +3156,7 @@ _eval_config_list = [
             ),
             EvalTask(
                 task_name="longbench_single_e",
+                apply_chat_template=False,
                 min_context_required=16384,
                 score=EvalTaskScore(
                     published_score=None,
@@ -3169,6 +3172,7 @@ _eval_config_list = [
             ),
             EvalTask(
                 task_name="longbench_summarization_e",
+                apply_chat_template=False,
                 min_context_required=16384,
                 score=EvalTaskScore(
                     published_score=None,
@@ -3184,6 +3188,7 @@ _eval_config_list = [
             ),
             EvalTask(
                 task_name="longbench_synthetic_e",
+                apply_chat_template=False,
                 min_context_required=16384,
                 score=EvalTaskScore(
                     published_score=None,
@@ -3285,6 +3290,7 @@ _eval_config_list = [
             ),
             EvalTask(
                 task_name="longbench_code_e",
+                apply_chat_template=False,
                 min_context_required=16384,
                 score=EvalTaskScore(
                     published_score=None,
@@ -3300,6 +3306,7 @@ _eval_config_list = [
             ),
             EvalTask(
                 task_name="longbench_fewshot_e",
+                apply_chat_template=False,
                 min_context_required=16384,
                 score=EvalTaskScore(
                     published_score=None,

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -3121,7 +3121,6 @@ _eval_config_list = [
                         "unit": "percent",
                     },
                 ),
-
             ),
             EvalTask(
                 task_name="longbench_fewshot_e",


### PR DESCRIPTION
closes https://github.com/tenstorrent/tt-inference-server/issues/4692

GPU scores for llama is run with apply_chat_template=False: https://github.com/tenstorrent/tt-inference-server/issues/1948#issuecomment-3821456040 does not pass in apply_chat_template, which goes to defaulted apply_chat_template=False behaviour specified in https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/evaluator.py

However, apply_chat_template is defaulted to True in EvalTask configuration https://github.com/tenstorrent/tt-inference-server/blob/main/evals/eval_config.py

Thus, there needs to be a patch for https://github.com/tenstorrent/tt-inference-server/pull/1986/changes