### PR TITLE
Add LTX-2.3 distilled audio-video runner to the media server (EXPERIMENTAL)

### DIFF
--- a/tt-inference-server-v2/test_module/server_tests_config.json
+++ b/tt-inference-server-v2/test_module/server_tests_config.json
@@ -36,7 +36,8 @@
         "VIDEO": [
             "Wan2.2-T2V-A14B-Diffusers",
             "Wan2.2-I2V-A14B-Diffusers",
-            "mochi-1-preview"
+            "mochi-1-preview",
+            "LTX-2.3"
         ],
         "LLM": [
             "Qwen3-32B",
@@ -94,6 +95,7 @@
             "wan": "Wan video generation model tests",
             "wan_i2v": "Wan image-to-video generation model tests",
             "mochi": "Mochi video generation model tests",
+            "ltx": "LTX-2.3 distilled audio-video generation model tests",
             "mobilenetv2": "MobileNetV2 CNN model tests",
             "bge_m3": "BGE-M3 embedding model tests"
         }
@@ -228,6 +230,17 @@
                 "p150x4",
                 "p150x8",
                 "p300x2"
+            ]
+        },
+        "ltx": {
+            "id_name": "ltx-2.3",
+            "weights": [
+                "LTX-2.3"
+            ],
+            "category": "VIDEO",
+            "compatible_devices": [
+                "p150x8",
+                "blackhole_galaxy"
             ]
         },
         "sdxl": {

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -25,6 +25,7 @@ class SupportedModels(Enum):
     WAN_2_2_I2V_ANISORA = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
     WAN_2_2_I2V_DISTILL = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
     WAN_2_2_I2V_LORA = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+    LTX_2_3 = "Lightricks/LTX-2.3"
     DISTIL_WHISPER_LARGE_V3 = "distil-whisper/distil-large-v3"
     OPENAI_WHISPER_LARGE_V3 = "openai/whisper-large-v3"
     PYANNOTE_SPEAKER_DIARIZATION = "pyannote/speaker-diarization-3.0"
@@ -68,6 +69,7 @@ class ModelNames(Enum):
     WAN_2_2_I2V_ANISORA = "Wan2.2-I2V-AniSora-V3.2"
     WAN_2_2_I2V_DISTILL = "Wan2.2-I2V-Distill-LightX2V"
     WAN_2_2_I2V_LORA = "Wan2.2-I2V-LoRA"
+    LTX_2_3 = "LTX-2.3"
     DISTIL_WHISPER_LARGE_V3 = "distil-large-v3"
     OPENAI_WHISPER_LARGE_V3 = "whisper-large-v3"
     MICROSOFT_RESNET_50 = "resnet-50"
@@ -115,6 +117,7 @@ class ModelRunners(Enum):
     TT_WAN_2_2_I2V_ANISORA = "tt-wan2.2-i2v-anisora"
     TT_WAN_2_2_I2V_DISTILL = "tt-wan2.2-i2v-distill"
     TT_WAN_2_2_I2V_LORA = "tt-wan2.2-i2v-lora"
+    TT_LTX_2_3 = "tt-ltx-2.3"
     TT_WHISPER = "tt-whisper"
     VLLMForge = "vllm_forge"
     TT_YOLOV4 = "tt-yolov4"
@@ -207,6 +210,7 @@ MODEL_SERVICE_RUNNER_MAP = {
         ModelRunners.TT_WAN_2_2_I2V_ANISORA,
         ModelRunners.TT_WAN_2_2_I2V_DISTILL,
         ModelRunners.TT_WAN_2_2_I2V_LORA,
+        ModelRunners.TT_LTX_2_3,
         ModelRunners.SP_RUNNER,
     },
     ModelServices.TRAINING: {
@@ -236,6 +240,7 @@ INFERENCE_MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.TT_WAN_2_2_I2V_ANISORA: {ModelNames.WAN_2_2_I2V_ANISORA},
     ModelRunners.TT_WAN_2_2_I2V_DISTILL: {ModelNames.WAN_2_2_I2V_DISTILL},
     ModelRunners.TT_WAN_2_2_I2V_LORA: {ModelNames.WAN_2_2_I2V_LORA},
+    ModelRunners.TT_LTX_2_3: {ModelNames.LTX_2_3},
     ModelRunners.SP_RUNNER: {
         ModelNames.WAN_2_2,
         ModelNames.WAN_2_2_I2V,
@@ -374,6 +379,11 @@ def wan22_target_resolution(mesh_shape: Tuple[int, int]) -> Resolution:
     if is_large_mesh(mesh_shape):
         return WAN22_RESOLUTION_LARGE_MESH
     return WAN22_RESOLUTION_SMALL_MESH
+
+
+LTX23_NUM_FRAMES = 145
+# 1080 padded up to a 32-tile multiple (34 * 32) for tile alignment.
+LTX23_RESOLUTION = Resolution(height=1088, width=1920)
 
 
 AUDIO_RESPONSE_FORMATS = frozenset(e.value for e in AudioResponseFormat)
@@ -915,6 +925,22 @@ ModelConfigs = {
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_32_GROUP.value,
         "max_batch_size": 1,
+        "request_processing_timeout_seconds": 5000,
+    },
+    (ModelRunners.TT_LTX_2_3, DeviceTypes.P150X8): {
+        "device_mesh_shape": (2, 4),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_8_GROUP.value,
+        "max_batch_size": 1,
+        "download_weights_from_service": False,
+        "request_processing_timeout_seconds": 5000,
+    },
+    (ModelRunners.TT_LTX_2_3, DeviceTypes.BLACKHOLE_GALAXY): {
+        "device_mesh_shape": (4, 8),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_32_GROUP.value,
+        "max_batch_size": 1,
+        "download_weights_from_service": False,
         "request_processing_timeout_seconds": 5000,
     },
     (ModelRunners.SP_RUNNER, DeviceTypes.N150): {

--- a/tt-media-server/tests/test_video_manager.py
+++ b/tt-media-server/tests/test_video_manager.py
@@ -2,7 +2,9 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
+import os
 import subprocess
+import wave
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -12,7 +14,16 @@ from utils.video_manager import (
     _normalize_channels,
     _normalize_dtype_single,
     _normalize_shape,
+    _write_temp_wav,
 )
+
+
+def _mock_ffmpeg_ok():
+    """A Popen mock that behaves like a successful streaming ffmpeg run."""
+    proc = MagicMock()
+    proc.wait.return_value = 0
+    proc.stderr.read.return_value = b""
+    return proc
 
 
 @pytest.fixture
@@ -260,3 +271,33 @@ class TestEnsureFaststart:
         VideoManager.ensure_faststart("/tmp/in.mp4", "/tmp/out.mp4")
         actual_timeout = proc.communicate.call_args[1]["timeout"]
         assert actual_timeout == _FFMPEG_REMUX_TIMEOUT_S
+
+
+class TestStreamPlanarToFfmpeg:
+    """A wrong plane_order silently color-swaps the video, so pin the RGB→gbrp map."""
+
+    @patch("utils.video_manager.subprocess.Popen")
+    def test_writes_planes_in_order(self, mock_popen):
+        proc = _mock_ffmpeg_ok()
+        mock_popen.return_value = proc
+        # plane c filled with value c so the written order is verifiable.
+        arr = np.stack([np.full((1, 2, 2), c, dtype=np.uint8) for c in range(3)])
+        VideoManager._stream_planar_to_ffmpeg(["ffmpeg"], arr, t_frames=1, plane_order=(1, 2, 0))
+        written = [call.args[0].flat[0] for call in proc.stdin.write.call_args_list]
+        assert written == [1, 2, 0]
+
+
+class TestWriteTempWav:
+    """_write_temp_wav silently mangles audio if the channel/dtype handling breaks."""
+
+    def test_channels_first_float_stereo(self):
+        # (2, N) float → transposed to (N, 2) and scaled to int16.
+        path = _write_temp_wav(np.full((2, 100), 0.5, dtype=np.float32), 16000)
+        try:
+            with wave.open(path, "rb") as w:
+                assert w.getnchannels() == 2
+                assert w.getnframes() == 100
+                samples = np.frombuffer(w.readframes(100), dtype=np.int16)
+            assert np.all(np.abs(samples.astype(int) - 16383) <= 1)
+        finally:
+            os.remove(path)

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -10,6 +10,8 @@ from abc import abstractmethod
 
 import ttnn
 from config.constants import (
+    LTX23_NUM_FRAMES,
+    LTX23_RESOLUTION,
     WAN22_NUM_FRAMES,
     ModelRunners,
     ModelServices,
@@ -23,6 +25,8 @@ from domain.video_generate_request import VideoGenerateRequest
 from domain.video_i2v_generate_request import ImagePromptEntry, VideoI2VGenerateRequest
 from models.common.utility_functions import is_blackhole
 from models.tt_dit.pipelines.flux1.pipeline_flux1 import Flux1Pipeline
+from models.tt_dit.pipelines.ltx.pipeline_ltx_distilled import LTXDistilledPipeline
+from models.tt_dit.pipelines.ltx.pipeline_ltx import DEFAULT_NEGATIVE_PROMPT as LTX23_REFERENCE_NEGATIVE_PROMPT
 from models.tt_dit.pipelines.mochi.pipeline_mochi import MochiPipeline
 from models.tt_dit.pipelines.motif.pipeline_motif import MotifPipeline
 from models.tt_dit.pipelines.qwenimage.pipeline_qwenimage import (
@@ -55,6 +59,7 @@ dit_runner_log_map = {
     ModelRunners.TT_WAN_2_2_I2V_ANISORA.value: "Wan22-I2V-AniSora",
     ModelRunners.TT_WAN_2_2_I2V_DISTILL.value: "Wan22-I2V-Distill",
     ModelRunners.TT_WAN_2_2_I2V_LORA.value: "Wan22-I2V-LoRA",
+    ModelRunners.TT_LTX_2_3.value: "LTX-2.3",
     ModelRunners.TT_QWEN_IMAGE.value: "Qwen-Image",
     ModelRunners.TT_QWEN_IMAGE_2512.value: "Qwen-Image-2512",
     ModelRunners.SP_RUNNER.value: "SP-Runner",
@@ -945,3 +950,136 @@ class TTWan22I2VLoRARunner(TTDiTRunner):
 
     def _build_warmup_video_request(self) -> VideoI2VGenerateRequest:
         return _wan22_i2v_warmup_request("A golden retriever running on a sandy beach")
+
+
+LTX23_TRACE_REGION_BYTES = 500_000_000  # video s1+s2 + BWE/vocoder traces at 1080p
+LTX23_GALAXY_ROUTER_MAX_PAYLOAD_BYTES = 8192
+# Depthwise audio taps (native ttnn.conv1d) run an UntilizeWithHalo gather that needs L1_SMALL.
+LTX23_L1_SMALL_BYTES = 32768
+# Distilled transformer file + Gemma-3 encoder; the latent upscaler is pinned in the pipeline.
+LTX23_DISTILLED_FILENAME = "ltx-2.3-22b-distilled-1.1.safetensors"
+LTX23_GEMMA_REPO = "google/gemma-3-12b-it-qat-q4_0-unquantized"
+LTX23_FPS = 24  # distilled output frame rate; audio decode + AV mux must agree
+# Distilled denoise is a fixed sigma schedule (8 + 3) and guidance-free (no CFG), so the request's
+# num_inference_steps and negative_prompt have no effect; surfaced (not applied) for transparency.
+LTX23_STAGE1_STEPS = 8
+LTX23_STAGE2_STEPS = 3
+LTX23_TOTAL_STEPS = LTX23_STAGE1_STEPS + LTX23_STAGE2_STEPS
+
+
+def _ltx23_dit_device_params(mesh_shape: tuple) -> dict:
+    # Tracing is always on for LTX-2.3, so the trace region is always reserved.
+    device_params: dict = {
+        "l1_small_size": LTX23_L1_SMALL_BYTES,
+        "trace_region_size": LTX23_TRACE_REGION_BYTES,
+    }
+    if is_large_mesh(mesh_shape):
+        device_params["fabric_config"] = ttnn.FabricConfig.FABRIC_1D_RING
+        router_config = ttnn.FabricRouterConfig()
+        router_config.max_packet_payload_size_bytes = (
+            LTX23_GALAXY_ROUTER_MAX_PAYLOAD_BYTES
+        )
+        device_params["fabric_router_config"] = router_config
+    else:
+        device_params["fabric_config"] = ttnn.FabricConfig.FABRIC_1D
+    if is_blackhole():
+        device_params["reliability_mode"] = ttnn.FabricReliabilityMode.RELAXED_INIT
+    return device_params
+
+
+def _ltx23_pipeline_args(request, resolution) -> dict:
+    # Distilled generate() has no steps/negative_prompt knob (fixed sigma schedule). No output_path →
+    # generate() returns (frames, audio); "rgb" = on-device uint8 RGB planar for the server to encode.
+    pipeline_args = {
+        "prompt": request.prompt,
+        "output_type": "rgb",
+        "num_frames": LTX23_NUM_FRAMES,
+        "height": resolution.height,
+        "width": resolution.width,
+        "fps": LTX23_FPS,
+    }
+    if request.seed is not None:
+        pipeline_args["seed"] = int(request.seed)
+    return pipeline_args
+
+
+class TTLtx23DistilledRunner(TTDiTRunner):
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self.resolution = LTX23_RESOLUTION
+        # Encode AV in the device-worker process so raw frames never cross the result-queue pickle.
+        self.export_in_runner = True
+
+    def create_pipeline(self):
+        try:
+            # A real file path, not "dir:file": the pipeline's checkpoint resolver treats a
+            # ":"-joined value as an HF "repo_id:file" and rejects an absolute mount path.
+            checkpoint_path = os.path.join(
+                self.settings.model_weights_path, LTX23_DISTILLED_FILENAME
+            )
+            return LTXDistilledPipeline.create_pipeline(
+                mesh_device=self.ttnn_device,
+                checkpoint_name=checkpoint_path,
+                gemma_path=LTX23_GEMMA_REPO,
+                num_frames=LTX23_NUM_FRAMES,
+                height=self.resolution.height,
+                width=self.resolution.width,
+                traced=True,
+                run_warmup=True,
+            )
+        except Exception as e:
+            log_exception_chain(
+                self.logger,
+                self.device_id,
+                "LTX-2.3 pipeline creation failed",
+                e,
+            )
+            raise
+
+    def load_weights(self):
+        return False
+
+    def get_pipeline_device_params(self):
+        return _ltx23_dit_device_params(self.settings.device_mesh_shape)
+
+    def _log_distilled_contract(self, request: VideoGenerateRequest) -> None:
+        """Surface, once, that the distilled model ignores num_inference_steps/negative_prompt
+        rather than silently dropping them: it runs a fixed 8+3 sigma schedule and is guidance-free
+        (no CFG). num_inference_steps has a non-None default, so it can't be told from an explicit
+        value — hence the contract is stated once, not re-logged per request. The negative_prompt
+        note is per-request because it keys off a value the client actually supplied."""
+        if not getattr(self, "_logged_distilled_contract", False):
+            self.logger.info(
+                f"LTX-2.3 distilled: fixed {LTX23_TOTAL_STEPS}-step schedule "
+                f"(stage1={LTX23_STAGE1_STEPS} + stage2={LTX23_STAGE2_STEPS}); guidance-free (no CFG). "
+                f"num_inference_steps is ignored. "
+                f"Reference negative prompt (NOT applied): {LTX23_REFERENCE_NEGATIVE_PROMPT}"
+            )
+            self._logged_distilled_contract = True
+        if request.negative_prompt:
+            self.logger.info("Ignoring negative_prompt: distilled model is guidance-free.")
+
+    @log_execution_time(
+        f"{dit_runner_log_map[get_settings().model_runner]} inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    def run(self, requests: list[VideoGenerateRequest]):
+        self.logger.debug(f"Device {self.device_id}: Running inference")
+        self._log_distilled_contract(requests[0])
+        frames, audio = self.pipeline.generate(
+            **_ltx23_pipeline_args(requests[0], self.resolution)
+        )
+        self.logger.debug(f"Device {self.device_id}: Inference completed")
+        if self.export_in_runner:
+            from utils.video_manager import VideoManager
+
+            return [
+                VideoManager().export_rgb_planar_to_mp4_with_audio(
+                    frames,
+                    audio.waveform,
+                    audio.sampling_rate,
+                    fps=LTX23_FPS,
+                )
+            ]
+        return (frames, audio)

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -58,6 +58,9 @@ AVAILABLE_RUNNERS = {
     ModelRunners.TT_WAN_2_2_I2V_LORA: lambda wid: __import__(
         "tt_model_runners.dit_runners", fromlist=["TTWan22I2VLoRARunner"]
     ).TTWan22I2VLoRARunner(wid),
+    ModelRunners.TT_LTX_2_3: lambda wid: __import__(
+        "tt_model_runners.dit_runners", fromlist=["TTLtx23DistilledRunner"]
+    ).TTLtx23DistilledRunner(wid),
     ModelRunners.TT_WHISPER: lambda wid: __import__(
         "tt_model_runners.whisper_runner", fromlist=["TTWhisperRunner"]
     ).TTWhisperRunner(wid),

--- a/tt-media-server/utils/video_manager.py
+++ b/tt-media-server/utils/video_manager.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 
 import os
 import subprocess
+import tempfile
+import threading
 import uuid
+import wave
 from pathlib import Path
 
 import numpy as np
@@ -65,6 +68,115 @@ class VideoManager:
         except Exception as e:
             self._logger.error(f"Video export failed: {e}")
             raise RuntimeError(f"Failed to export video: {e}") from e
+
+    @log_execution_time("Exporting RGB-planar video+audio to MP4")
+    def export_rgb_planar_to_mp4_with_audio(
+        self,
+        frames,
+        audio_waveform,
+        sample_rate: int,
+        fps: int = 24,
+    ) -> str:
+        """Export planar RGB frames + audio to an AV MP4 (H.264 yuv420p + AAC).
+
+        ``frames`` is RGB planar, (B, 3, T, H, W) or (3, T, H, W) uint8 (planes R, G, B). It streams
+        as ffmpeg ``gbrp`` (channels-first, so the device gather has a large innermost dim); libx264
+        does RGB→yuv420p. Audio is muxed from a temp WAV.
+        """
+        arr = frames.frames if hasattr(frames, "frames") else frames
+        arr = np.asarray(arr)
+        if arr.ndim == 5:
+            arr = arr[0]
+        if arr.ndim != 4 or arr.shape[0] != 3:
+            raise ValueError(f"Expected RGB planar (3, T, H, W), got {arr.shape}")
+        _, t_frames, height, width = arr.shape
+
+        _VIDEO_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+        output_path = str(_VIDEO_OUTPUT_DIR / f"{uuid.uuid4()}.mp4")
+        crf = max(_MIN_CRF, min(_MAX_CRF, int(os.environ.get("TT_VIDEO_EXPORT_CRF", "23"))))
+        preset = os.environ.get("TT_VIDEO_EXPORT_PRESET", "ultrafast").strip()
+
+        wav_path = _write_temp_wav(audio_waveform, sample_rate)
+        try:
+            cmd = [
+                "ffmpeg", "-y", "-nostats", "-loglevel", "error",
+                "-f", "rawvideo", "-pix_fmt", "gbrp",
+                "-s", f"{width}x{height}", "-r", str(fps),
+                "-i", "-",
+                "-i", wav_path,
+                "-c:v", "libx264", "-crf", str(crf), "-pix_fmt", "yuv420p",
+            ]
+            if preset:
+                cmd += ["-preset", preset]
+            cmd += ["-c:a", "aac", "-b:a", "192k", "-movflags", "+faststart", output_path]
+            # gbrp plane order is G, B, R; frames are R, G, B.
+            self._stream_planar_to_ffmpeg(cmd, arr, t_frames, plane_order=(1, 2, 0))
+            return output_path
+        except Exception as e:
+            self._logger.error(f"RGB-planar export failed: {e}")
+            raise RuntimeError(f"Failed to export RGB-planar video+audio: {e}") from e
+        finally:
+            try:
+                os.remove(wav_path)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _run_streaming_ffmpeg(cmd, write_stdin, timeout: int = _FFMPEG_ENCODE_TIMEOUT_S) -> None:
+        """Run ffmpeg while ``write_stdin(pipe)`` feeds its stdin.
+
+        stderr is drained on a separate thread throughout the write: for the
+        largest payloads (1080p planar) ffmpeg's stderr can outrun a fixed pipe
+        buffer, and reading it only after the full stdin write would let a full
+        stderr pipe stall ffmpeg's stdin reads and deadlock the writer.
+        """
+        process = subprocess.Popen(
+            cmd, stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
+        )
+        stderr_box: list[bytes] = []
+        drainer = threading.Thread(
+            target=lambda: stderr_box.append(process.stderr.read()), daemon=True
+        )
+        drainer.start()
+        try:
+            write_stdin(process.stdin)
+            process.stdin.close()
+            rc = process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+            drainer.join(timeout=5)
+            raise RuntimeError("FFmpeg export timed out") from None
+        except Exception:
+            process.kill()
+            process.wait()
+            drainer.join(timeout=5)
+            raise
+        drainer.join(timeout=5)
+        if rc != 0:
+            stderr = b"".join(c for c in stderr_box if c)
+            error_msg = stderr.decode(errors="replace") if stderr else "Unknown error"
+            raise RuntimeError(f"FFmpeg failed: {error_msg}")
+
+    @classmethod
+    def _stream_planar_to_ffmpeg(
+        cls,
+        cmd: list[str],
+        arr: NDArray,
+        t_frames: int,
+        plane_order: tuple[int, int, int] = (0, 1, 2),
+        timeout: int = _FFMPEG_ENCODE_TIMEOUT_S,
+    ) -> None:
+        """Stream planar frames (arr[c, t] = (H, W) per plane) to ffmpeg in ``plane_order``."""
+
+        def write_stdin(stdin):
+            for t in range(t_frames):
+                for c in plane_order:
+                    # arr[c, t] is already C-contiguous; write its buffer directly to skip a
+                    # ~900MB/frame-set tobytes() copy on the export critical path.
+                    stdin.write(np.ascontiguousarray(arr[c, t]))
+
+        cls._run_streaming_ffmpeg(cmd, write_stdin, timeout)
 
     @staticmethod
     def _build_encode_cmd(
@@ -144,40 +256,22 @@ class VideoManager:
             error_msg = stderr.decode(errors="replace") if stderr else "Unknown error"
             raise RuntimeError(f"FFmpeg failed: {error_msg}")
 
-    @staticmethod
+    @classmethod
     def _stream_to_ffmpeg(
+        cls,
         cmd: list[str],
         frames: NDArray,
         timeout: int = _FFMPEG_ENCODE_TIMEOUT_S,
     ) -> None:
         """Stream frames one-by-one to ffmpeg, converting dtype per-frame."""
-        process = subprocess.Popen(
-            cmd,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-        )
 
-        try:
+        def write_stdin(stdin):
             for frame in frames:
                 if frame.dtype != np.uint8:
                     frame = _normalize_dtype_single(frame)
-                process.stdin.write(frame.tobytes())
-            process.stdin.close()
-            stderr = process.stderr.read()
-            rc = process.wait(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait()
-            raise RuntimeError("FFmpeg export timed out") from None
-        except Exception:
-            process.kill()
-            process.wait()
-            raise
+                stdin.write(frame.tobytes())
 
-        if rc != 0:
-            error_msg = stderr.decode(errors="replace") if stderr else "Unknown error"
-            raise RuntimeError(f"FFmpeg failed: {error_msg}")
+        cls._run_streaming_ffmpeg(cmd, write_stdin, timeout)
 
     @classmethod
     def ensure_faststart(cls, input_path: str, output_path: str) -> None:
@@ -231,3 +325,36 @@ def _normalize_dtype_single(frame: NDArray) -> NDArray[np.uint8]:
         return frame.clip(0, 255).astype(np.uint8)
 
     return frame.clip(0, 255).astype(np.uint8)
+
+
+def _write_temp_wav(waveform, sample_rate: int) -> str:
+    """Stage an audio waveform to a temp 16-bit PCM WAV for ffmpeg muxing.
+
+    Accepts torch or numpy: mono ``(N,)``, interleaved ``(N, C)``, or
+    channels-first stereo ``(2, N)`` (the decoder's layout), float [-1, 1] or
+    int16. Channels-first is only disambiguated for stereo.
+    """
+    arr = waveform.detach().cpu().numpy() if hasattr(waveform, "detach") else np.asarray(waveform)
+    if arr.ndim == 1:
+        arr = arr[:, None]
+    # (2, N) → (N, 2): the decoder emits channels-first stereo.
+    if arr.shape[1] != 2 and arr.shape[0] == 2:
+        arr = arr.T
+    if arr.dtype != np.int16:
+        arr = (np.clip(arr, -1.0, 1.0) * 32767.0).astype(np.int16)
+
+    fd, path = tempfile.mkstemp(suffix=".wav")
+    os.close(fd)
+    try:
+        with wave.open(path, "wb") as w:
+            w.setnchannels(arr.shape[1])
+            w.setsampwidth(2)
+            w.setframerate(int(sample_rate))
+            w.writeframes(np.ascontiguousarray(arr).tobytes())
+    except Exception:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        raise
+    return path

--- a/workflows/model_specs/dev/video.yaml
+++ b/workflows/model_specs/dev/video.yaml
@@ -48,6 +48,33 @@ templates:
   status: COMPLETE
 
 - weights:
+    - Lightricks/LTX-2.3
+    - google/gemma-3-12b-it-qat-q4_0-unquantized
+  version: "0.1.0"
+  tt_metal_commit: 8c82ed67e2b
+  impl: tt_transformers
+  min_disk_gb: 120
+  min_ram_gb: 64
+  model_type: VIDEO
+  inference_engine: MEDIA
+  env_vars:
+    TT_DIT_CACHE_DIR: /home/container_app_user/cache_root/tt_dit_cache
+  device_model_specs:
+    - device: P150X8
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+      override_tt_config:
+        trace_region_size: 300000000
+    - device: BLACKHOLE_GALAXY
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+      override_tt_config:
+        trace_region_size: 300000000
+  status: EXPERIMENTAL
+
+- weights:
     - Wan-AI/Wan2.2-T2V-A14B-Diffusers
   impl: tt_transformers
   min_disk_gb: 60

--- a/workflows/model_specs/prod/video.yaml
+++ b/workflows/model_specs/prod/video.yaml
@@ -88,6 +88,33 @@ templates:
   status: COMPLETE
 
 - weights:
+    - Lightricks/LTX-2.3
+    - google/gemma-3-12b-it-qat-q4_0-unquantized
+  version: "0.1.0"
+  tt_metal_commit: 8c82ed67e2b
+  impl: tt_transformers
+  min_disk_gb: 120
+  min_ram_gb: 64
+  model_type: VIDEO
+  inference_engine: MEDIA
+  env_vars:
+    TT_DIT_CACHE_DIR: /home/container_app_user/cache_root/tt_dit_cache
+  device_model_specs:
+    - device: P150X8
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+      override_tt_config:
+        trace_region_size: 300000000
+    - device: BLACKHOLE_GALAXY
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+      override_tt_config:
+        trace_region_size: 300000000
+  status: EXPERIMENTAL
+
+- weights:
     - Wan-AI/Wan2.2-T2V-A14B-Diffusers
   version: "0.17.0"
   tt_metal_commit: "8c48a10"


### PR DESCRIPTION
# Add LTX-2.3 distilled audio-video runner to the media server (EXPERIMENTAL)

## Summary
Serves the LTX-2.3 **distilled** text-to-(audio+video) pipeline as a media-server video
runner on Blackhole single-host meshes: `P150X8` (2×4) and `BLACKHOLE_GALAXY` (4×8). The
runner drives the tt-metal `LTXDistilledPipeline`, receives `(frames, audio)`, and encodes the
AV MP4 (H.264 + AAC) **inside the device-worker process** so raw frames never cross the
result-queue pickle.

## What's included
- **Registry** (`tt-media-server/config/constants.py`): `LTX-2.3` added to
  `SupportedModels` / `ModelNames` / `ModelRunners` and the service/runner/name/`ModelConfigs`
  maps; `TT_LTX_2_3` in the fabric runner registry (`tt_model_runners/runner_fabric.py`).
- **Runner** (`tt_model_runners/dit_runners.py`): `TTLtx23DistilledRunner`, on the fabric
  device-worker path. Fixed **8+3 sigma schedule**, **guidance-free (no CFG)**; the request's
  `num_inference_steps` / `negative_prompt` are surfaced in the log but not applied.
- **Device params**: `l1_small_size=32K` (depthwise audio taps use `UntilizeWithHalo`), 500 MB
  trace region gated on `LTX_TRACED`, 1D-ring fabric + router payload cap on large mesh,
  `RELAXED_INIT` on Blackhole.
- **AV export** (`utils/video_manager.py`): device-worker RGB-planar → libx264 (yuv420p) + AAC.
  ffmpeg streaming drains stderr on a thread (avoids a 1080p stdin/stderr deadlock); the export
  helpers have unit coverage.
- **Model specs** (`workflows/model_specs/{dev,prod}/video.yaml`): status **EXPERIMENTAL**,
  pinned `tt_metal_commit 8c82ed67e2b` (main; contains the LTX distilled pipeline + API).
  Tracing is always on.

## Dependencies
- tt-metal main (pin `8c82ed67e2b`) — provides `LTXDistilledPipeline.create_pipeline` and
  `generate(...)`.
- Weights: `Lightricks/LTX-2.3` (distilled safetensors) + `google/gemma-3-12b-it-qat-q4_0-unquantized`.

## Testing
- BH 4×8, main-pinned tt-metal: server launches, opens the 4×8 mesh, loads the full pipeline
  (distilled transformer + VAE + upscaler + audio decoder + vocoder + Gemma) via the fixed
  checkpoint path, and enters the distilled 2-stage trace warmup (145f @ 1088×1920). _<add PCC /
  output-quality evidence from a full inference>_

## Review addressed in this branch
- Reverted the LTX-only text on the shared `VideoGenerateRequest` schema + T2V example (WAN/Mochi
  honor `negative_prompt`/`num_inference_steps`); LTX contract stays in the runner log.
- `_log_distilled_contract` logged once (the `num_inference_steps` note previously fired every request).
- Added `env_vars: TT_DIT_CACHE_DIR` to the LTX specs, matching sibling MEDIA models.
- Registered LTX in `tt-inference-server-v2/test_module/server_tests_config.json` (v1 file deleted upstream).
- Dropped the unshipped device-YUV export path (not on the pinned tt-metal); RGB is authoritative.
- Made tracing always-on (removed the `LTX_TRACED` toggle that was read in two places).
- Hardened ffmpeg streaming against a 1080p stdin/stderr deadlock + unit-tested the export helpers.
- Fixed the distilled checkpoint reference to a real file path (`dir/file`, not `dir:file`) — the
  pin's resolver rejected the `:` form with `HFValidationError`; device-confirmed on BH 4×8.

## Open items
1. **Warmup/inference not yet run to completion on a pinned-tt-metal build.** Verified through
   weight-load + warmup-entry; the only local tt-metal is a feature branch whose experimental
   attention path hangs LTX trace-capture, so warmup couldn't complete there. Needs a run on a clean
   `tt-metal@8c82ed67e2b` build to capture output/PCC.
2. LTX is **registered** for server tests but has no functional LTX test case yet (marker collects nothing).
3. Minor (pre-existing / low-priority): `tests/conftest.py` runner mock map omits the runner and a
   fixture-name mismatch means `AVAILABLE_RUNNERS` registrations aren't class-verified;
   `ltx23_target_resolution` ignores its `mesh_shape` arg.

Status: **EXPERIMENTAL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
