### PR TITLE
add: Kokoro-82M text-to-speech model (media server, P150)

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -626,6 +626,16 @@
         }
       }
     },
+    "kokoro_tts": {
+      "inference_engine": "MEDIA",
+      "ci": {
+        "nightly": {
+          "devices": [
+            "P150"
+          ]
+        }
+      }
+    },
     "speecht5_tts": {
       "inference_engine": "MEDIA",
       "ci": {

--- a/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/benchmarking/benchmark_targets/model_performance_reference.json
@@ -6840,6 +6840,22 @@
             }
         ]
     },
+    "kokoro_tts": {
+        "p150": [
+            {
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "task_type": "tts",
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 3800,
+                        "rtr": 2.0,
+                        "tolerance": 0.05
+                    }
+                }
+            }
+        ]
+    },
     "speecht5_tts": {
         "n150": [
             {

--- a/evals/eval_config.py
+++ b/evals/eval_config.py
@@ -3926,6 +3926,39 @@ _eval_config_list = [
             ),
         ],
     ),
+    # Kokoro-82M TTS quality eval. Metric (run_tts_eval, tt-inference-server-v2):
+    # synthesize -> whisper-base ASR -> word-level WER over LibriTTS-R test.clean,
+    # reported as intelligibility % (100 - WER%); PASS when avg WER <= 0.20.
+    # model_type TEXT_TO_SPEECH auto-routes here, so no v2 change is needed; the
+    # score_func below is a no-op (the v1 lm-eval path is unused for TTS).
+    EvalConfig(
+        hf_model_repo="hexgrad/Kokoro-82M",
+        tasks=[
+            EvalTask(
+                task_name="tts_generation",
+                workflow_venv_type=WorkflowVenvType.EVALS_META,
+                include_path="work_dir",
+                max_concurrent=None,
+                apply_chat_template=False,
+                score=EvalTaskScore(
+                    published_score=92.95,
+                    published_score_ref=(
+                        "No official published intelligibility benchmark for "
+                        "hexgrad/Kokoro-82M; uses the measured reference below."
+                    ),
+                    gpu_reference_score=92.95,
+                    gpu_reference_score_ref=(
+                        "Reference (CPU torch) Kokoro-82M via the run_tts_eval WER "
+                        "round-trip (whisper-base ASR) on LibriTTS-R test.clean, "
+                        "10 samples: avg WER 7.05% -> 92.95% intelligibility "
+                        "(100 - WER%). CPU/GPU are accuracy-equivalent for the "
+                        "reference model. 2026-07-20."
+                    ),
+                    score_func=lambda results: 0.0,
+                ),
+            ),
+        ],
+    ),
     EvalConfig(
         hf_model_repo="openai/gpt-oss-20b",
         tasks=[

--- a/tt-inference-server-v2/test_module/server_tests_config.json
+++ b/tt-inference-server-v2/test_module/server_tests_config.json
@@ -91,6 +91,7 @@
             "bge": "BGE embedding model tests",
             "qwen3_emb": "Qwen3 embedding model tests",
             "speecht5": "SpeechT5 TTS model tests",
+            "kokoro": "Kokoro-82M TTS model tests",
             "wan": "Wan video generation model tests",
             "wan_i2v": "Wan image-to-video generation model tests",
             "mochi": "Mochi video generation model tests",
@@ -361,6 +362,15 @@
             "category": "TTS",
             "compatible_devices": [
                 "n150",
+                "p150"
+            ]
+        },
+        "kokoro": {
+            "weights": [
+                "kokoro_tts"
+            ],
+            "category": "TTS",
+            "compatible_devices": [
                 "p150"
             ]
         },

--- a/tt-inference-server-v2/test_module/test_suites/tts.json
+++ b/tt-inference-server-v2/test_module/test_suites/tts.json
@@ -1,5 +1,5 @@
 {
-    "_description": "Test suites for TTS model category (SpeechT5)",
+    "_description": "Test suites for TTS model category (SpeechT5, Kokoro-82M)",
     "_category": "TTS",
     "test_matrices": [
         {
@@ -20,6 +20,36 @@
                     "template": "TTSLoadTest",
                     "enabled": true,
                     "description": "TTS load test",
+                    "targets": {
+                        "tts_generation_time": 10,
+                        "sample_count": 10,
+                        "compare_audio": true
+                    }
+                },
+                {
+                    "template": "TTSParamTest",
+                    "enabled": true,
+                    "description": "TTS parameter variations test"
+                },
+                {
+                    "template": "TTSIntegrationTest",
+                    "enabled": true,
+                    "description": "TTS error handling and validation test"
+                }
+            ]
+        },
+        {
+            "models": [
+                "kokoro"
+            ],
+            "devices": [
+                "p150"
+            ],
+            "test_cases": [
+                {
+                    "template": "TestTTSServerHealth",
+                    "enabled": true,
+                    "description": "TTS server health test",
                     "targets": {
                         "tts_generation_time": 10,
                         "sample_count": 10,

--- a/tt-media-server/Dockerfile
+++ b/tt-media-server/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && apt-get install -y \
     gosu \
     libgl1 \
     libsndfile1 \
+    espeak-ng \
     wget \
     git-lfs \
     nano \

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -41,6 +41,7 @@ class SupportedModels(Enum):
     QWEN_3_8B = "Qwen/Qwen3-8B"
     QWEN_3_32B = "Qwen/Qwen3-32B"
     SPEECHT5_TTS = "microsoft/speecht5_tts"
+    KOKORO_82M = "hexgrad/Kokoro-82M"
     GEMMA_1_1_2B_IT = "google/gemma-1.1-2b-it"
     GEMMA_4_31B_IT = "google/gemma-4-31B-it"
     FALCON3_7B_INSTRUCT = "tiiuae/Falcon3-7B-Instruct"
@@ -91,6 +92,7 @@ class ModelNames(Enum):
     QWEN_3_8B = "Qwen3-8B"
     QWEN_3_32B = "Qwen3-32B"
     SPEECHT5_TTS = "speecht5_tts"
+    KOKORO_82M = "Kokoro-82M"
     GEMMA_1_1_2B_IT = "gemma-1.1-2b-it"
     GEMMA_4_31B_IT = "gemma-4-31b-it"
     FALCON3_7B_INSTRUCT = "Falcon3-7B-Instruct"
@@ -141,6 +143,7 @@ class ModelRunners(Enum):
     LLM_TEST = "llm_test"
     LLAMA_RUNNER = "llama_runner"
     TT_SPEECHT5_TTS = "tt-speecht5-tts"
+    TT_KOKORO_82M = "tt-kokoro-tts"
     TT_XLA_SDXL = "tt-xla-sdxl"
     TT_Z_IMAGE_TURBO = "tt-z-image-turbo"
 
@@ -215,6 +218,7 @@ MODEL_SERVICE_RUNNER_MAP = {
     },
     ModelServices.TEXT_TO_SPEECH: {
         ModelRunners.TT_SPEECHT5_TTS,
+        ModelRunners.TT_KOKORO_82M,
     },
 }
 
@@ -270,6 +274,7 @@ INFERENCE_MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
         ModelNames.FALCON3_7B_INSTRUCT,
     },
     ModelRunners.TT_SPEECHT5_TTS: {ModelNames.SPEECHT5_TTS},
+    ModelRunners.TT_KOKORO_82M: {ModelNames.KOKORO_82M},
     ModelRunners.TT_XLA_SDXL: {
         ModelNames.STABLE_DIFFUSION_XL_BASE,
         ModelNames.STABLE_DIFFUSION_XL_512,
@@ -973,6 +978,15 @@ ModelConfigs = {
         "device_mesh_shape": (1, 1),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_4.value,
+        "max_batch_size": 1,
+    },
+    # Kokoro-82M: single-chip P150, full pipeline on device (TT plbert, StyleTTS2
+    # predictor, text encoder, ISTFTNet vocoder; no ring fabric, no CCL). See
+    # models/demos/audio/kokoro (KokoroGenerator).
+    (ModelRunners.TT_KOKORO_82M, DeviceTypes.P150): {
+        "device_mesh_shape": (1, 1),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_1.value,
         "max_batch_size": 1,
     },
     (ModelRunners.TT_WHISPER, DeviceTypes.N300): {

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -980,9 +980,6 @@ ModelConfigs = {
         "device_ids": DeviceIds.DEVICE_IDS_4.value,
         "max_batch_size": 1,
     },
-    # Kokoro-82M: single-chip P150, full pipeline on device (TT plbert, StyleTTS2
-    # predictor, text encoder, ISTFTNet vocoder; no ring fabric, no CCL). See
-    # models/demos/audio/kokoro (KokoroGenerator).
     (ModelRunners.TT_KOKORO_82M, DeviceTypes.P150): {
         "device_mesh_shape": (1, 1),
         "is_galaxy": False,

--- a/tt-media-server/domain/text_to_speech_request.py
+++ b/tt-media-server/domain/text_to_speech_request.py
@@ -42,6 +42,10 @@ class TextToSpeechRequest(BaseRequest):
     # Response format: wav (default), mp3, ogg, json, or verbose_json
     response_format: str = "wav"
 
+    # When true, stream audio chunk-by-chunk as an NDJSON StreamingResponse
+    # (one JSON object per synthesized chunk) instead of one finished file.
+    stream: bool = False
+
     @field_validator("response_format", mode="before")
     @classmethod
     def validate_response_format(cls, v):

--- a/tt-media-server/install_requirements.sh
+++ b/tt-media-server/install_requirements.sh
@@ -29,3 +29,10 @@ uv pip install \
     --overrides "${SCRIPT_DIR}/uv-overrides.txt" \
     -r "${SCRIPT_DIR}/requirements.txt" \
     "$@"
+
+# Kokoro-82M TTS: install without deps so `misaki[en]` -> spaCy is not pulled in.
+# spaCy requires numpy 2.x and would break tt-metal's numpy<2 pin. The media
+# runner uses the espeak G2P path (misaki.espeak) and stubs spaCy, so the [en]
+# extra is not needed; kokoro's runtime deps (torch, numpy, transformers,
+# huggingface_hub, misaki, soundfile) are provided by requirements.txt / the env.
+uv pip install --no-deps "kokoro>=0.9.4"

--- a/tt-media-server/model_services/text_to_speech_service.py
+++ b/tt-media-server/model_services/text_to_speech_service.py
@@ -52,6 +52,14 @@ class TextToSpeechService(BaseService):
             warmup_task_data=(minimal_wav_base64, "wav"),
         )
 
+    def handle_streaming_chunk(self, chunk):
+        """Extract the per-chunk TextToSpeechResponse from a streaming_chunk dict.
+
+        The runner emits ``{"type": "streaming_chunk", "chunk": <TextToSpeechResponse>}``
+        for each on-device chunk; unlike the text-based base implementation there is
+        no ``.text`` to gate on, so pass the audio response through as-is."""
+        return chunk.get("chunk")
+
     async def _set_result_to_wav(self, result: TextToSpeechResponse) -> None:
         """Encode result.audio to WAV and set result.output_bytes and result.format."""
         result.output_bytes = await self._cpu_workload_handler.execute_task(
@@ -72,12 +80,16 @@ class TextToSpeechService(BaseService):
 
     @log_execution_time("TTS post-processing")
     async def post_process(
-        self, result: TextToSpeechResponse, input_request: TextToSpeechRequest
+        self, result: TextToSpeechResponse, input_request: TextToSpeechRequest = None
     ) -> TextToSpeechResponse:
         """
         Convert result.audio (base64 WAV from runner) to requested format.
         If mp3/ogg requested but ffmpeg is unavailable or encoding fails, fall back to WAV.
         """
+        # Streaming path (base_service.process_streaming_request calls post_process
+        # with no input_request): each chunk is already a base64 WAV — pass through.
+        if input_request is None:
+            return result
         fmt = input_request.response_format.lower()
         if fmt not in AUDIO_RESPONSE_FORMATS:
             return result

--- a/tt-media-server/open_ai_api/text_to_speech.py
+++ b/tt-media-server/open_ai_api/text_to_speech.py
@@ -3,9 +3,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 
+import json
+
 from config.constants import AUDIO_RESPONSE_FORMATS
 from domain.text_to_speech_request import TextToSpeechRequest
 from fastapi import APIRouter, Depends, HTTPException, Response, Security
+from fastapi.responses import StreamingResponse
 from model_services.base_service import BaseService
 from resolver.service_resolver import service_resolver
 from security.api_key_checker import get_api_key
@@ -22,9 +25,25 @@ TTS_MEDIA_TYPES = {
 async def handle_tts_request(tts_request, service):
     """
     Runner returns base64; post_process converts to requested format.
-    Here we return result.output_bytes (WAV/MP3/OGG) or JSON with base64.
+
+    Non-streaming: return result.output_bytes (WAV/MP3/OGG) or JSON with base64.
+    Streaming (``stream=true``): return an NDJSON StreamingResponse, one JSON
+    object per synthesized chunk (each with a base64 WAV of that chunk), as the
+    runner produces them on device (mirrors the Whisper streaming endpoint).
     """
     try:
+        if getattr(tts_request, "stream", False):
+            try:
+                service.scheduler.check_is_model_ready()
+            except Exception:
+                raise HTTPException(status_code=405, detail="Model is not ready")
+
+            async def result_stream():
+                async for partial in service.process_streaming_request(tts_request):
+                    yield json.dumps(get_dict_response(partial)) + "\n"
+
+            return StreamingResponse(result_stream(), media_type="application/x-ndjson")
+
         result = await service.process_request(tts_request)
         fmt = tts_request.response_format.lower()
         if fmt in AUDIO_RESPONSE_FORMATS:

--- a/tt-media-server/requirements.txt
+++ b/tt-media-server/requirements.txt
@@ -22,6 +22,17 @@ torch==2.7.1+cpu
 torchaudio==2.7.1+cpu
 requests
 num2words
+# --- Kokoro-82M TTS host deps (kokoro itself is installed --no-deps in
+# install_requirements.sh to avoid misaki[en] -> spaCy). Versions are pinned to
+# tt-metal's numpy-1.26 env: scipy/transformers releases that do NOT require
+# numpy>=2, and phonemizer-fork (NOT phonemizer) whose EspeakWrapper API
+# misaki.espeak expects. Validated to import together under numpy 1.26.4.
+misaki
+soundfile
+phonemizer-fork==3.3.2
+espeakng-loader==0.2.4
+scipy==1.17.1
+transformers==5.10.2
 
 
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/tt-media-server/tests/test_text_to_speech_api.py
+++ b/tt-media-server/tests/test_text_to_speech_api.py
@@ -211,6 +211,7 @@ class TestRealImplementation:
         mock_service.process_request = AsyncMock(return_value=mock_response)
 
         mock_request = MagicMock()
+        mock_request.stream = False
         mock_format = MagicMock()
         mock_format.lower.return_value = "wav"
         mock_request.response_format = mock_format
@@ -228,6 +229,7 @@ class TestRealImplementation:
         mock_service.process_request = AsyncMock(return_value=mock_response)
 
         mock_request = MagicMock()
+        mock_request.stream = False
         mock_format = MagicMock()
         mock_format.lower.return_value = "wav"
         mock_request.response_format = mock_format
@@ -245,6 +247,7 @@ class TestRealImplementation:
         mock_service.process_request = AsyncMock(return_value=mock_response)
 
         mock_request = MagicMock()
+        mock_request.stream = False
         mock_format = MagicMock()
         mock_format.lower.return_value = "mp3"
         mock_request.response_format = mock_format
@@ -264,6 +267,7 @@ class TestRealImplementation:
         mock_service.process_request = AsyncMock(return_value=mock_response)
 
         mock_request = MagicMock()
+        mock_request.stream = False
         mock_format = MagicMock()
         mock_format.lower.return_value = "ogg"
         mock_request.response_format = mock_format
@@ -282,6 +286,7 @@ class TestRealImplementation:
         mock_service.process_request = AsyncMock(return_value=mock_response)
 
         mock_request = MagicMock()
+        mock_request.stream = False
         mock_format = MagicMock()
         mock_format.lower.return_value = "mp3"
         mock_request.response_format = mock_format
@@ -302,6 +307,7 @@ class TestRealImplementation:
         mock_service.process_request = AsyncMock(return_value=mock_response)
 
         mock_request = MagicMock()
+        mock_request.stream = False
         mock_format = MagicMock()
         mock_format.lower.return_value = "verbose_json"
         mock_request.response_format = mock_format
@@ -318,6 +324,7 @@ class TestRealImplementation:
         mock_service.process_request = AsyncMock(return_value=mock_response)
 
         mock_request = MagicMock()
+        mock_request.stream = False
         mock_format = MagicMock()
         mock_format.lower.return_value = "wav"
         mock_request.response_format = mock_format

--- a/tt-media-server/tt_model_runners/kokoro_runner.py
+++ b/tt-media-server/tt_model_runners/kokoro_runner.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+"""Media-server runner for hexgrad/Kokoro-82M text-to-speech.
+
+Kokoro-82M is a non-autoregressive StyleTTS2 / ISTFTNet TTS model. The entire
+pipeline runs on a single Tenstorrent P150: TT plbert (the only attention
+transformer), the StyleTTS2 prosody predictor, the text encoder, and the
+ISTFTNet vocoder. This runner is a thin adapter over
+``models.demos.audio.kokoro.tt.generator.KokoroGenerator``, which owns the text
+frontend (grapheme-to-phoneme, plbert-context chunking) and the on-device
+synthesis — mirroring how the Whisper runner wraps ``WhisperGenerator``.
+
+The generator synthesizes chunk-by-chunk and can stream each chunk's waveform as
+it is produced on device (``KokoroGenerator.stream``); the single-file
+``/v1/audio/speech`` response is assembled from that same on-device stream via
+``KokoroGenerator.generate``.
+"""
+
+import asyncio
+import base64
+import io
+import os
+from typing import List
+
+import numpy as np
+import soundfile as sf
+from domain.text_to_speech_request import TextToSpeechRequest
+from domain.text_to_speech_response import TextToSpeechResponse
+from telemetry.telemetry_client import TelemetryEvent
+from tt_model_runners.base_metal_device_runner import BaseMetalDeviceRunner
+from utils.decorators import log_execution_time
+
+from models.demos.audio.kokoro.tt.generator import build_generator
+
+MODEL_ID = "hexgrad/Kokoro-82M"
+SAMPLE_RATE = 24000  # Kokoro / ISTFTNet output rate
+DEFAULT_VOICE = "af_heart"
+# ISTFTNet vocoder convs need an L1_SMALL scratch region that grows with a chunk's
+# frame count; the generator caps chunk size (CHUNK_PHONEME_TOKENS) to stay within
+# the validated envelope, and this gives headroom above the 32 KB the per-stage
+# device tests use.
+L1_SMALL_SIZE = 65536
+TRACE_REGION_SIZE = 90_000_000
+
+
+class TTKokoroRunner(BaseMetalDeviceRunner):
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self.generator = None  # KokoroGenerator (fully on-device, P150)
+
+    # --------------------------------------------------------------- device
+    def get_pipeline_device_params(self):
+        # set_device / close_device use the BaseMetalDeviceRunner defaults; the
+        # single-chip mesh-graph descriptor is supplied per-device via the model
+        # spec (env_vars: TT_MESH_GRAPH_DESC_PATH), like the other P150 runners.
+        return {
+            "l1_small_size": L1_SMALL_SIZE,
+            "trace_region_size": TRACE_REGION_SIZE,
+        }
+
+    def close_device(self):
+        if self.generator is not None:
+            self.generator.teardown()
+            self.generator = None
+        return super().close_device()
+
+    # ---------------------------------------------------------- model setup
+    def load_weights(self):
+        """Verify weights are reachable (HF cache) without touching the device."""
+        from huggingface_hub import hf_hub_download
+
+        hf_hub_download(MODEL_ID, "config.json")
+        hf_hub_download(MODEL_ID, "kokoro-v1_0.pth")
+        return True
+
+    @log_execution_time(
+        "Kokoro model load",
+        TelemetryEvent.DEVICE_WARMUP,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    async def warmup(self) -> bool:
+        if self.ttnn_device is None:
+            raise ValueError("Device not initialized. Call set_device() first.")
+        self.generator = await asyncio.to_thread(
+            build_generator, self.ttnn_device, MODEL_ID, DEFAULT_VOICE
+        )
+        # Exercise the on-device path once so kernels/programs are compiled before
+        # the first real request (mirrors the other MEDIA runners' warmup).
+        await asyncio.to_thread(self.generator.generate, "Hello.", DEFAULT_VOICE, 1.0)
+        self.logger.info(f"Device {self.device_id}: Kokoro warmup complete")
+        return True
+
+    # ------------------------------------------------------------ inference
+    def _synthesize(self, text: str, voice: str, speed: float) -> np.ndarray:
+        """Full on-device synthesis. ``KokoroGenerator.generate`` consumes the
+        per-chunk on-device stream and joins the chunks into one waveform."""
+        return self.generator.generate(text, voice, speed)
+
+    def _np_to_b64_wav(self, audio: np.ndarray) -> str:
+        buffer = io.BytesIO()
+        sf.write(buffer, audio, SAMPLE_RATE, format="WAV")
+        return base64.b64encode(buffer.getvalue()).decode("utf-8")
+
+    def _resolve_voice(self, voice: str) -> str:
+        """Preload the voice pack (populating the generator cache) with fallback to
+        the default voice, so the synth path never re-hits a missing-voice error."""
+        try:
+            self.generator._load_voice(voice)
+            return voice
+        except FileNotFoundError:
+            self.logger.warning(
+                f"Voice '{voice}' not found; falling back to {DEFAULT_VOICE}"
+            )
+            self.generator._load_voice(DEFAULT_VOICE)
+            return DEFAULT_VOICE
+
+    async def _stream_chunks(self, request, text: str, voice: str, speed: float):
+        """Async generator: one ``streaming_chunk`` dict per on-device chunk (each a
+        base64 WAV of that chunk), then a ``final_result`` sentinel. Consumed by the
+        device worker's streaming path; each chunk is synthesized on device and the
+        blocking ``next()`` is offloaded so the event loop stays responsive."""
+        gen = self.generator.stream(text, voice, speed)
+        sentinel = object()
+        while True:
+            chunk = await asyncio.to_thread(next, gen, sentinel)
+            if chunk is sentinel:
+                break
+            yield {
+                "type": "streaming_chunk",
+                "chunk": TextToSpeechResponse(
+                    audio=self._np_to_b64_wav(chunk),
+                    duration=len(chunk) / SAMPLE_RATE,
+                    sample_rate=SAMPLE_RATE,
+                    format="wav",
+                    speaker_id=voice,
+                ),
+                "task_id": request._task_id,
+            }
+        # Audio is fully delivered via the chunks above; the final sentinel just
+        # closes the stream (return=False -> nothing extra yielded to the client).
+        yield {
+            "type": "final_result",
+            "result": None,
+            "task_id": request._task_id,
+            "return": False,
+        }
+
+    async def _run_async(self, requests: List[TextToSpeechRequest]):
+        if self.generator is None:
+            raise RuntimeError("Model not loaded. Call warmup() first.")
+        if len(requests) > 1:
+            self.logger.warning(
+                f"Device {self.device_id}: batch not supported; processing first of "
+                f"{len(requests)} requests"
+            )
+        request = requests[0]
+        if request is None or not request.text or not request.text.strip():
+            raise ValueError("Text cannot be empty")
+
+        voice = await asyncio.to_thread(
+            self._resolve_voice, request.speaker_id or DEFAULT_VOICE
+        )
+
+        # Streaming: return an async generator the device worker drives chunk-by-chunk.
+        if getattr(request, "stream", False):
+            return self._stream_chunks(request, request.text, voice, 1.0)
+
+        audio = await asyncio.to_thread(self._synthesize, request.text, voice, 1.0)
+        return TextToSpeechResponse(
+            audio=self._np_to_b64_wav(audio),
+            duration=len(audio) / SAMPLE_RATE,
+            sample_rate=SAMPLE_RATE,
+            format="wav",
+            speaker_id=voice,
+        )
+
+    @log_execution_time(
+        "Run Kokoro inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    def run(self, requests: List[TextToSpeechRequest]):
+        result = asyncio.run(self._run_async(requests))
+        return [result] if result is not None else []

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -141,6 +141,9 @@ AVAILABLE_RUNNERS = {
     ModelRunners.TT_SPEECHT5_TTS: lambda wid: __import__(
         "tt_model_runners.speecht5_runner", fromlist=["TTSpeechT5Runner"]
     ).TTSpeechT5Runner(wid),
+    ModelRunners.TT_KOKORO_82M: lambda wid: __import__(
+        "tt_model_runners.kokoro_runner", fromlist=["TTKokoroRunner"]
+    ).TTKokoroRunner(wid),
     ModelRunners.TT_XLA_SDXL: lambda wid: __import__(
         "tt_model_runners.forge_runners.sdxl_forge_runner",
         fromlist=["SDXLForgeRunner"],

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -267,6 +267,12 @@ speecht5_impl = ImplSpec(
     repo_url="https://github.com/tenstorrent/tt-metal",
     code_path="models/experimental/speecht5_tts",
 )
+kokoro_impl = ImplSpec(
+    impl_id="kokoro_tts",
+    impl_name="kokoro-tts",
+    repo_url="https://github.com/tenstorrent/tt-metal",
+    code_path="models/demos/audio/kokoro",
+)
 forge_vllm_plugin_impl = ImplSpec(
     impl_id="forge_vllm_plugin",
     impl_name="forge-vllm-plugin",
@@ -302,6 +308,7 @@ _IMPL_REGISTRY: Dict[str, ImplSpec] = {
     "deepseek_r1_galaxy": deepseek_r1_galaxy_impl,
     "whisper": whisper_impl,
     "speecht5_tts": speecht5_impl,
+    "kokoro_tts": kokoro_impl,
     "forge_vllm_plugin": forge_vllm_plugin_impl,
     "tt_vllm_plugin": tt_vllm_plugin_impl,
     "sdxl_forge": sdxl_forge_impl,

--- a/workflows/model_specs/dev/audio_tts.yaml
+++ b/workflows/model_specs/dev/audio_tts.yaml
@@ -131,3 +131,22 @@ templates:
       env_vars:
         TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto"
   status: EXPERIMENTAL
+
+# Kokoro-82M: the full pipeline runs on device (single-chip P150) — TT plbert,
+# StyleTTS2 prosody predictor, text encoder, and the ISTFTNet vocoder. See
+# models/demos/audio/kokoro (KokoroGenerator / KokoroDevicePipeline).
+- weights:
+    - hexgrad/Kokoro-82M
+  impl: kokoro_tts
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: TEXT_TO_SPEECH
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: P150
+      max_concurrency: 1
+      max_context: 512  # plbert context length; single-chip on-device pipeline
+      default_impl: true
+      env_vars:
+        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto"
+  status: EXPERIMENTAL


### PR DESCRIPTION
### Summary
Serves `hexgrad/Kokoro-82M` through the media server on a single Blackhole **P150**, with the **full pipeline on device** via the tt-metal `KokoroGenerator` (tenstorrent/tt-metal#50489). `TTKokoroRunner` is a thin adapter over the generator (like the Whisper runner over `WhisperGenerator`), using the base `BaseMetalDeviceRunner.set_device`; the single-chip p150 mesh-graph descriptor is supplied per-device via the model spec.

`POST /v1/audio/speech` supports **file output** (wav/mp3/ogg or JSON base64) and **streaming** (`stream=true` → NDJSON, one base64 WAV per on-device chunk), mirroring the Whisper streaming path.

Model Readiness: #4704

### Notes for reviewers
- Depends on the tt-metal implementation (tenstorrent/tt-metal#50489, `models/demos/audio/kokoro`).
- **Base branch:** targets `main`. `docs/development.md` prescribes branching off `dev`, but `dev` is ~3 months / 768 commits stale, so `main` is the active branch.
- Status: **EXPERIMENTAL**, P150 only. Measured (warm): RTR ~1.9–2.27×, TTFT ~3.3 s.
