### PR TITLE
Rename Dynamo Environment Variables

### DIFF
--- a/.github/workflows/cpp-heavy-checks.yml
+++ b/.github/workflows/cpp-heavy-checks.yml
@@ -739,12 +739,11 @@ jobs:
       ETCD_ENDPOINTS: http://127.0.0.1:2379
       DYN_REQUEST_PLANE: tcp
       DYN_EVENT_PLANE: zmq
-      DYNAMO_DISCOVERY_BACKEND: etcd
-      DYNAMO_ETCD_ENDPOINTS: http://127.0.0.1:2379
-      DYNAMO_NAMESPACE: default
-      DYNAMO_COMPONENT: backend
-      DYNAMO_ENDPOINT_NAME: generate
-      DYNAMO_ENDPOINT_ENABLED: "1"
+      DYN_ETCD_ENDPOINTS: http://127.0.0.1:2379
+      DYN_NAMESPACE: default
+      DYN_COMPONENT: backend
+      DYN_ENDPOINT_NAME: generate
+      DYN_ENDPOINT_ENABLED: "1"
       LLM_DEVICE_BACKEND: mock_pipeline
       MODEL_NAME: deepseek-ai/DeepSeek-R1-0528
     defaults:
@@ -766,7 +765,7 @@ jobs:
 
       # No-docker etcd: grab the upstream signed binary tarball from the
       # etcd-io GitHub release. Two cpp_server backends registering under the
-      # same DYNAMO_NAMESPACE/COMPONENT/ENDPOINT need a shared discovery
+      # same DYN_NAMESPACE/COMPONENT/ENDPOINT need a shared discovery
       # store; the script's default `file` backend does an unconditional
       # `rm -rf ${DYN_FILE_STORE}` at startup, so concurrent starts would
       # race-delete each other's registrations. etcd avoids that.
@@ -1078,12 +1077,11 @@ jobs:
       ETCD_ENDPOINTS: http://127.0.0.1:2379
       DYN_REQUEST_PLANE: tcp
       DYN_EVENT_PLANE: zmq
-      DYNAMO_DISCOVERY_BACKEND: etcd
-      DYNAMO_ETCD_ENDPOINTS: http://127.0.0.1:2379
-      DYNAMO_NAMESPACE: default
-      DYNAMO_COMPONENT: backend
-      DYNAMO_ENDPOINT_NAME: generate
-      DYNAMO_ENDPOINT_ENABLED: "1"
+      DYN_ETCD_ENDPOINTS: http://127.0.0.1:2379
+      DYN_NAMESPACE: default
+      DYN_COMPONENT: backend
+      DYN_ENDPOINT_NAME: generate
+      DYN_ENDPOINT_ENABLED: "1"
       LLM_DEVICE_BACKEND: mock_pipeline
       MODEL_NAME: deepseek-ai/DeepSeek-R1-0528
     defaults:
@@ -1204,9 +1202,9 @@ jobs:
 
       - name: Run prefix cache E2E tests against Dynamo frontend
         env:
-          DYNAMO_HOST: '127.0.0.1'
-          DYNAMO_PORT: '8000'
-          DYNAMO_MODEL: 'deepseek-ai/DeepSeek-R1-0528'
+          DYN_HOST: '127.0.0.1'
+          DYN_PORT: '8000'
+          DYN_MODEL: 'deepseek-ai/DeepSeek-R1-0528'
           KV_CACHE_FIRST_BLOCK_SIZE: '128'
           KV_CACHE_BLOCK_SIZE: '32'
         run: |

--- a/dynamo_frontend/DEPLOY.md
+++ b/dynamo_frontend/DEPLOY.md
@@ -65,7 +65,7 @@ frontend host port `8080`,
 `LLM_DEVICE_BACKEND=pipeline_manager`, `MODEL_NAME=tt-cpp-server`.
 `PREFILL_DIRECT_SOCKET_PORT` defaults to `9000` when `--prefill-direct` is used.
 `PREFILL_WORKER_COUNT` can set the same value as `--prefill-workers`.
-`DYNAMO_ROUTING_NAMESPACE` defaults to `dynamo` when
+`DYN_ROUTING_NAMESPACE` defaults to `dynamo` when
 `--dynamo-routing` is used, producing the documented Dynamo endpoints
 `dynamo.decode.generate` and `dynamo.prefill.generate`.
 
@@ -95,7 +95,7 @@ Prometheus scrapes `prefill-gateway:9091`.
 2. **etcd** — starts it (publishing `:2379`) and waits until
   `etcdctl endpoint health` passes.
 3. **Worker** — starts cpp_server with etcd discovery
-  (`DYNAMO_ETCD_ENDPOINTS=http://etcd:2379`), the model-specific env, and
+  (`DYN_ETCD_ENDPOINTS=http://etcd:2379`), the model-specific env, and
    `--device /dev/tenstorrent` when the card is present. Waits up to 60s for it
    to register `v1/instances/…`; on failure it dumps the worker logs and exits.
    With `--local-build`, the entrypoint runs the bind-mounted binary
@@ -122,12 +122,12 @@ Prometheus scrapes `prefill-gateway:9091`.
    requests route prefill work through the gateway.
 7. **Dynamo routing (experimental)** — with
    `--dynamo-routing`, starts the worker as `LLM_MODE=decode` with
-   `DYNAMO_ROUTING=1` on `dynamo.decode.generate`, then starts
+   `DYN_ROUTING=1` on `dynamo.decode.generate`, then starts
    `--prefill-workers` managed `LLM_MODE=prefill` workers with
-   `DYNAMO_ENDPOINT_ENABLED=1`,
-   `DYNAMO_WORKER_TYPE=prefill`, `DYNAMO_MODEL_TYPE=Prefill`, and endpoint
+   `DYN_ENDPOINT_ENABLED=1`,
+   `DYN_WORKER_TYPE=prefill`, `DYN_MODEL_TYPE=Prefill`, and endpoint
    `dynamo.prefill.generate`. `worker_type=prefill` carries the actual role;
-   `DYNAMO_MODEL_TYPE=Prefill` keeps the current released `ai-dynamo` frontend
+   `DYN_MODEL_TYPE=Prefill` keeps the current released `ai-dynamo` frontend
    compatible until `Tokens+Empty` is accepted for prefill workers. Dynamo's
    integrated router owns the local-vs-remote prefill decision; when a
    request reaches decode, cpp_server prefills locally instead of reapplying

--- a/dynamo_frontend/deploy.sh
+++ b/dynamo_frontend/deploy.sh
@@ -48,7 +48,7 @@ MONITORING_ENABLED=1
 MONITORING_STARTED=0
 PREFILL_GATEWAY_ENABLED=0
 PREFILL_DIRECT_ENABLED=0
-DYNAMO_ROUTING_ENABLED=0
+DYN_ROUTING_ENABLED=0
 PREFILL_GATEWAY_STARTED=0
 PREFILL_WORKERS_STARTED=()
 PREFILL_WORKER_COUNT="${PREFILL_WORKER_COUNT:-1}"
@@ -150,7 +150,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --prefill-workers) PREFILL_WORKER_COUNT="$2"; shift 2 ;;
         --prefill-direct) PREFILL_DIRECT_ENABLED=1;       shift ;;
-        --dynamo-routing) DYNAMO_ROUTING_ENABLED=1; shift ;;
+        --dynamo-routing) DYN_ROUTING_ENABLED=1; shift ;;
         --no-monitoring)  MONITORING_ENABLED=0;             shift ;;
         *) echo "Unknown argument: $1" >&2; usage ;;
     esac
@@ -175,7 +175,7 @@ if [[ "$MONITORING_ENABLED" == "1" ]]; then
     [[ -f "$MONITORING_COMPOSE" ]] || die "monitoring compose file not found: $MONITORING_COMPOSE"
     docker compose version >/dev/null 2>&1 || die "docker compose is required for monitoring"
 fi
-ROUTING_MODE_COUNT=$((PREFILL_GATEWAY_ENABLED + PREFILL_DIRECT_ENABLED + DYNAMO_ROUTING_ENABLED))
+ROUTING_MODE_COUNT=$((PREFILL_GATEWAY_ENABLED + PREFILL_DIRECT_ENABLED + DYN_ROUTING_ENABLED))
 [[ "$ROUTING_MODE_COUNT" -le 1 ]] || die "--prefill-direct, --prefill-gateway, and --dynamo-routing are mutually exclusive"
 if [[ "$PREFILL_GATEWAY_ENABLED" == "1" ]]; then
     ensure_prefill_gateway_image
@@ -303,7 +303,7 @@ start_prefill_worker() {
 
 wait_dynamo_prefill_workers() {
     local expected="$1"
-    local prefix="v1/instances/${DYNAMO_ROUTING_NAMESPACE:-dynamo}/prefill/generate/"
+    local prefix="v1/instances/${DYN_ROUTING_NAMESPACE:-dynamo}/prefill/generate/"
 
     log "waiting for ${expected} native prefill worker(s) to register with etcd (up to 60s)"
     for _ in $(seq 1 60); do
@@ -320,7 +320,7 @@ wait_dynamo_prefill_workers() {
         registered="$(docker exec "$ETCD_NAME" etcdctl get --prefix --keys-only "$prefix" 2>/dev/null | grep -c "^${prefix}" || true)"
         if (( registered >= expected )); then
             log "native prefill worker(s) registered:"
-            docker exec "$ETCD_NAME" etcdctl get --prefix --keys-only "v1/instances/${DYNAMO_ROUTING_NAMESPACE:-dynamo}/" | grep -v '^$' | sed 's/^/[deploy]   /'
+            docker exec "$ETCD_NAME" etcdctl get --prefix --keys-only "v1/instances/${DYN_ROUTING_NAMESPACE:-dynamo}/" | grep -v '^$' | sed 's/^/[deploy]   /'
             return
         fi
         sleep 1
@@ -335,7 +335,7 @@ if [[ "$PREFILL_GATEWAY_ENABLED" == "1" ]]; then
 
     for idx in $(seq 0 $((PREFILL_WORKER_COUNT - 1))); do
         start_prefill_worker "$(prefill_worker_name "$idx")" "managed gateway prefill worker ${idx}" "$PREFILL_WORKER_PORT" \
-            -e DYNAMO_ENDPOINT_ENABLED=0 \
+            -e DYN_ENDPOINT_ENABLED=0 \
             -e USE_PREFILL_GATEWAY=1 \
             -e SOCKET_HOST="$PREFILL_GATEWAY_NAME" \
             -e SOCKET_PORT="$PREFILL_CONNECT_PORT" \
@@ -344,7 +344,7 @@ if [[ "$PREFILL_GATEWAY_ENABLED" == "1" ]]; then
 fi
 
 WORKER_ROUTING_ENV=()
-if [[ "$PREFILL_GATEWAY_ENABLED" == "1" || "$PREFILL_DIRECT_ENABLED" == "1" || "$DYNAMO_ROUTING_ENABLED" == "1" ]]; then
+if [[ "$PREFILL_GATEWAY_ENABLED" == "1" || "$PREFILL_DIRECT_ENABLED" == "1" || "$DYN_ROUTING_ENABLED" == "1" ]]; then
     WORKER_ROUTING_ENV+=(
         -e LLM_MODE=decode
     )
@@ -363,25 +363,25 @@ elif [[ "$PREFILL_DIRECT_ENABLED" == "1" ]]; then
         -e SOCKET_HOST=0.0.0.0
         -e SOCKET_PORT="$PREFILL_DIRECT_SOCKET_PORT"
     )
-elif [[ "$DYNAMO_ROUTING_ENABLED" == "1" ]]; then
+elif [[ "$DYN_ROUTING_ENABLED" == "1" ]]; then
     WORKER_ROUTING_ENV+=(
-        -e DYNAMO_NAMESPACE="${DYNAMO_ROUTING_NAMESPACE:-dynamo}"
-        -e DYNAMO_COMPONENT=decode
-        -e DYNAMO_ENDPOINT_NAME=generate
-        -e DYNAMO_MODEL_TYPE=Chat
-        -e DYNAMO_WORKER_TYPE=decode
+        -e DYN_NAMESPACE="${DYN_ROUTING_NAMESPACE:-dynamo}"
+        -e DYN_COMPONENT=decode
+        -e DYN_ENDPOINT_NAME=generate
+        -e DYN_MODEL_TYPE=Chat
+        -e DYN_WORKER_TYPE=decode
         -e USE_PREFILL_GATEWAY=0
-        -e DYNAMO_ROUTING=1
+        -e DYN_ROUTING=1
     )
 fi
 
 log "starting worker ($WORKER_IMAGE)"
 docker run -d --name "$WORKER_NAME" --network "$NETWORK_NAME" --shm-size=2g \
     "${DEVICE_ARGS[@]}" "${LOCAL_BUILD_MOUNT[@]}" "${WORKER_ENTRYPOINT[@]}" \
-    -e DYNAMO_ENDPOINT_ENABLED=1 \
-    -e DYNAMO_DISCOVERY_BACKEND=etcd \
-    -e DYNAMO_ETCD_ENDPOINTS="http://${ETCD_NAME}:2379" \
-    -e DYNAMO_NAMESPACE=default -e DYNAMO_COMPONENT=backend -e DYNAMO_ENDPOINT_NAME=generate \
+    -e DYN_ENDPOINT_ENABLED=1 \
+    -e DYN_DISCOVERY_BACKEND=etcd \
+    -e DYN_ETCD_ENDPOINTS="http://${ETCD_NAME}:2379" \
+    -e DYN_NAMESPACE=default -e DYN_COMPONENT=backend -e DYN_ENDPOINT_NAME=generate \
     -e SERVER_MODE=cpp \
     -e MODEL="$HF_MODEL_ID" \
     -e LLM_DEVICE_BACKEND="$LLM_DEVICE_BACKEND" \
@@ -410,7 +410,7 @@ docker exec "$ETCD_NAME" etcdctl get --prefix --keys-only v1/ | grep -v '^$' | s
 
 if [[ "$PREFILL_DIRECT_ENABLED" == "1" ]]; then
     start_prefill_worker "$PREFILL_WORKER_NAME" "direct prefill worker" "$PREFILL_WORKER_PORT" \
-        -e DYNAMO_ENDPOINT_ENABLED=0 \
+        -e DYN_ENDPOINT_ENABLED=0 \
         -e USE_PREFILL_GATEWAY=0 \
         -e SOCKET_HOST="$WORKER_NAME" \
         -e SOCKET_PORT="$PREFILL_DIRECT_SOCKET_PORT" \
@@ -419,20 +419,20 @@ if [[ "$PREFILL_DIRECT_ENABLED" == "1" ]]; then
         -e TT_WORKER_METRICS_SHM=/tt_worker_metrics_prefill
 fi
 
-if [[ "$DYNAMO_ROUTING_ENABLED" == "1" ]]; then
+if [[ "$DYN_ROUTING_ENABLED" == "1" ]]; then
     for idx in $(seq 0 $((PREFILL_WORKER_COUNT - 1))); do
         start_prefill_worker "$(prefill_worker_name "$idx")" "Dynamo-registered prefill worker ${idx}" "$PREFILL_WORKER_PORT" \
-            -e DYNAMO_ENDPOINT_ENABLED=1 \
-            -e DYNAMO_ROUTING=1 \
+            -e DYN_ENDPOINT_ENABLED=1 \
+            -e DYN_ROUTING=1 \
             -e USE_PREFILL_GATEWAY=0 \
-            -e DYNAMO_DISCOVERY_BACKEND=etcd \
-            -e DYNAMO_ETCD_ENDPOINTS="http://${ETCD_NAME}:2379" \
-            -e DYNAMO_NAMESPACE="${DYNAMO_ROUTING_NAMESPACE:-dynamo}" \
-            -e DYNAMO_COMPONENT=prefill \
-            -e DYNAMO_ENDPOINT_NAME=generate \
-            -e DYNAMO_MODEL_TYPE=Prefill \
-            -e DYNAMO_MODEL_INPUT=Tokens \
-            -e DYNAMO_WORKER_TYPE=prefill \
+            -e DYN_DISCOVERY_BACKEND=etcd \
+            -e DYN_ETCD_ENDPOINTS="http://${ETCD_NAME}:2379" \
+            -e DYN_NAMESPACE="${DYN_ROUTING_NAMESPACE:-dynamo}" \
+            -e DYN_COMPONENT=prefill \
+            -e DYN_ENDPOINT_NAME=generate \
+            -e DYN_MODEL_TYPE=Prefill \
+            -e DYN_MODEL_INPUT=Tokens \
+            -e DYN_WORKER_TYPE=prefill \
             -e TT_MEMORY_REQUEST_QUEUE="tt_mem_requests_prefill_${idx}" \
             -e TT_MEMORY_RESULT_QUEUE="tt_mem_results_prefill_${idx}" \
             -e TT_WORKER_METRICS_SHM="/tt_worker_metrics_prefill_${idx}"
@@ -508,7 +508,7 @@ fi
 if [[ "$PREFILL_GATEWAY_ENABLED" == "1" ]]; then
     log "PrefillGateway metrics on ${PREFILL_GATEWAY_NAME}:${PREFILL_GATEWAY_METRICS_PORT} inside ${NETWORK_NAME}"
 fi
-if [[ "$DYNAMO_ROUTING_ENABLED" == "1" ]]; then
+if [[ "$DYN_ROUTING_ENABLED" == "1" ]]; then
     log "Dynamo routing enabled; Dynamo owns local-vs-remote prefill routing"
 fi
 log "tailing worker logs (Ctrl+C to tear down)"

--- a/tt-media-server/cpp_server/benchmarks/run_stack.sh
+++ b/tt-media-server/cpp_server/benchmarks/run_stack.sh
@@ -8,7 +8,7 @@
 # locally-built mock_pipeline binary. See benchmarks/test_prefill_decode.py.
 #
 #   ./run_stack.sh up                      # direct cpp_server socket split
-#   DYNAMO_ROUTING=1 ./run_stack.sh up
+#   DYN_ROUTING=1 ./run_stack.sh up
 #                                          # Dynamo decode/prefill routing split
 #   ./run_stack.sh down                    # tear everything down
 #
@@ -34,8 +34,8 @@ SERVER_PORT="${SERVER_PORT:-8001}"       # decode/regular REST + Dynamo worker s
 PREFILL_PORT="${PREFILL_PORT:-8002}"     # prefill REST
 SOCKET_PORT="${SOCKET_PORT:-9000}"       # decode<->prefill inter-server socket
 MAX_TOKENS_TO_PREFILL_ON_DECODE="${MAX_TOKENS_TO_PREFILL_ON_DECODE:-1000}"
-DYNAMO_ROUTING="${DYNAMO_ROUTING:-0}"
-DYNAMO_ROUTING_NAMESPACE="${DYNAMO_ROUTING_NAMESPACE:-dynamo}"
+DYN_ROUTING="${DYN_ROUTING:-0}"
+DYN_ROUTING_NAMESPACE="${DYN_ROUTING_NAMESPACE:-dynamo}"
 ETCD_NAME="${ETCD_NAME:-etcd}"
 PIDFILE="/tmp/tt_stack.pids"
 
@@ -108,14 +108,14 @@ worker_dynamo_env() {
     local component="${2:-backend}"
     local worker_type="${3:-}"
     local model_type="${4-Chat}"
-    echo "DYNAMO_ENDPOINT_ENABLED=1"
-    echo "DYNAMO_DISCOVERY_BACKEND=etcd"
-    echo "DYNAMO_ETCD_ENDPOINTS=${ETCD_ENDPOINTS}"
-    echo "DYNAMO_NAMESPACE=${namespace}"
-    echo "DYNAMO_COMPONENT=${component}"
-    echo "DYNAMO_ENDPOINT_NAME=generate"
-    [[ -n "${model_type}" ]] && echo "DYNAMO_MODEL_TYPE=${model_type}"
-    [[ -n "${worker_type}" ]] && echo "DYNAMO_WORKER_TYPE=${worker_type}"
+    echo "DYN_ENDPOINT_ENABLED=1"
+    echo "DYN_DISCOVERY_BACKEND=etcd"
+    echo "DYN_ETCD_ENDPOINTS=${ETCD_ENDPOINTS}"
+    echo "DYN_NAMESPACE=${namespace}"
+    echo "DYN_COMPONENT=${component}"
+    echo "DYN_ENDPOINT_NAME=generate"
+    [[ -n "${model_type}" ]] && echo "DYN_MODEL_TYPE=${model_type}"
+    [[ -n "${worker_type}" ]] && echo "DYN_WORKER_TYPE=${worker_type}"
 }
 
 worker_ipc_env() {
@@ -229,7 +229,7 @@ wait_ready() {
         fi
     done
 
-    if [[ "${DYNAMO_ROUTING}" == "1" ]]; then
+    if [[ "${DYN_ROUTING}" == "1" ]]; then
         log "waiting for Dynamo router activation"
         for i in $(seq 1 40); do
             if grep -aq "Prefill router activated successfully" "${FRONTEND_LOG}"; then
@@ -268,22 +268,22 @@ up() {
     : > "${PIDFILE}"
     ensure_etcd
 
-    if [[ "${DYNAMO_ROUTING}" == "1" ]]; then
+    if [[ "${DYN_ROUTING}" == "1" ]]; then
         log "Dynamo routing: decode :${SERVER_PORT} socket :${SOCKET_PORT}, prefill :${PREFILL_PORT}"
         start_worker "${DECODE_LOG}" "${SERVER_PORT}" \
-            $(worker_dynamo_env "${DYNAMO_ROUTING_NAMESPACE}" decode decode Chat) \
+            $(worker_dynamo_env "${DYN_ROUTING_NAMESPACE}" decode decode Chat) \
             $(worker_ipc_env dynamo_decode) \
             LLM_MODE=decode LLM_DEVICE_BACKEND=mock_pipeline \
             SOCKET_HOST=0.0.0.0 SOCKET_PORT="${SOCKET_PORT}" \
-            USE_PREFILL_GATEWAY=0 DYNAMO_ROUTING=1
+            USE_PREFILL_GATEWAY=0 DYN_ROUTING=1
         wait_worker_healthy "decode" "${SERVER_PORT}" "${DECODE_LOG}"
         start_worker "${PREFILL_LOG}" "${PREFILL_PORT}" \
-            $(worker_dynamo_env "${DYNAMO_ROUTING_NAMESPACE}" prefill prefill Prefill) \
+            $(worker_dynamo_env "${DYN_ROUTING_NAMESPACE}" prefill prefill Prefill) \
             $(worker_ipc_env dynamo_prefill) \
             LLM_MODE=prefill LLM_DEVICE_BACKEND=mock_pipeline \
             SOCKET_HOST=127.0.0.1 SOCKET_PORT="${SOCKET_PORT}" \
-            USE_PREFILL_GATEWAY=0 DYNAMO_ROUTING=1 \
-            DYNAMO_MODEL_INPUT=Tokens
+            USE_PREFILL_GATEWAY=0 DYN_ROUTING=1 \
+            DYN_MODEL_INPUT=Tokens
         wait_worker_healthy "prefill" "${PREFILL_PORT}" "${PREFILL_LOG}"
     else
         # Direct-mode /health requires the decode<->prefill socket to be

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -136,32 +136,32 @@ constexpr int DECODE_MAX_TOKEN_IDS = 1;
 
 // Dynamo backend (TCP `generate` endpoint that registers with NVIDIA Dynamo
 // frontends). All defaults are overridable via env vars; the endpoint is
-// off unless DYNAMO_ENDPOINT_ENABLED=1.
-constexpr bool DYNAMO_ENDPOINT_ENABLED = false;
+// off unless DYN_ENDPOINT_ENABLED=1.
+constexpr bool DYN_ENDPOINT_ENABLED = false;
 // When true, Dynamo owns prefill/decode routing and prefill-first
 // disaggregation is enabled (etcd discovers decode; ZMQ reserves slots).
-constexpr bool DYNAMO_ROUTING = false;
-constexpr const char* DYNAMO_BIND_HOST = "0.0.0.0";
-constexpr uint16_t DYNAMO_BIND_PORT = 0;  // 0 = OS-assigned ephemeral port.
-constexpr const char* DYNAMO_NAMESPACE = "default";
-constexpr const char* DYNAMO_COMPONENT = "backend";
-constexpr const char* DYNAMO_ENDPOINT_NAME = "generate";
-constexpr const char* DYNAMO_DISCOVERY_BACKEND = "etcd";
+constexpr bool DYN_ROUTING = false;
+constexpr const char* DYN_BIND_HOST = "0.0.0.0";
+constexpr uint16_t DYN_BIND_PORT = 0;  // 0 = OS-assigned ephemeral port.
+constexpr const char* DYN_NAMESPACE = "default";
+constexpr const char* DYN_COMPONENT = "backend";
+constexpr const char* DYN_ENDPOINT_NAME = "generate";
+constexpr const char* DYN_DISCOVERY_BACKEND = "etcd";
 
 // Discovery: etcd endpoint for Dynamo's KVStoreDiscovery.
-constexpr const char* DYNAMO_ETCD_ENDPOINTS = "http://etcd:2379/";
+constexpr const char* DYN_ETCD_ENDPOINTS = "http://etcd:2379/";
 // Lease TTL for instance + MDC entries in etcd. The keep-alive thread
 // refreshes the lease at half this interval so a missed tick doesn't trip
 // the reaper.
-constexpr int64_t DYNAMO_ETCD_LEASE_TTL_SECS = 10;
+constexpr int64_t DYN_ETCD_LEASE_TTL_SECS = 10;
 
 // Standard in-cluster ServiceAccount mount paths.
-constexpr const char* DYNAMO_KUBE_TOKEN_PATH =
+constexpr const char* DYN_KUBE_TOKEN_PATH =
     "/var/run/secrets/kubernetes.io/serviceaccount/token";
-constexpr const char* DYNAMO_KUBE_NAMESPACE_PATH =
+constexpr const char* DYN_KUBE_NAMESPACE_PATH =
     "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
 // Validate the API server's TLS certificate using mounted ServiceAccount CA.
-constexpr bool DYNAMO_KUBE_VALIDATE_CERT = true;
+constexpr bool DYN_KUBE_VALIDATE_CERT = true;
 
 constexpr unsigned MOCK_PREFILL_CHUNK_LATENCY_MS = 1353;
 constexpr unsigned MOCK_STAGE_LATENCY_US = 44;

--- a/tt-media-server/cpp_server/include/config/settings.hpp
+++ b/tt-media-server/cpp_server/include/config/settings.hpp
@@ -335,60 +335,60 @@ size_t memoryQueueCapacity();
 // ---------------------------------------------------------------------------
 
 /** Whether the Dynamo TCP `generate` endpoint should bind on startup. From
- * DYNAMO_ENDPOINT_ENABLED. Default: defaults::DYNAMO_ENDPOINT_ENABLED. */
+ * DYN_ENDPOINT_ENABLED. Default: defaults::DYN_ENDPOINT_ENABLED. */
 bool dynamoEndpointEnabled();
 
 /** Experimental: let Dynamo own disaggregated prefill routing instead of the
  * cpp_server socket/gateway path. Also enables prefill-first disaggregation
  * (etcd discovers decode peers; ZMQ reserves decode slots). From
- * DYNAMO_ROUTING. Default: defaults::DYNAMO_ROUTING. */
+ * DYN_ROUTING. Default: defaults::DYN_ROUTING. */
 bool dynamoRoutingEnabled();
 
-/** Bind host for the Dynamo listener. From DYNAMO_BIND_HOST. Default:
- * defaults::DYNAMO_BIND_HOST. */
+/** Bind host for the Dynamo listener. From DYN_BIND_HOST. Default:
+ * defaults::DYN_BIND_HOST. */
 std::string dynamoBindHost();
 
-/** Bind port for the Dynamo listener. From DYNAMO_BIND_PORT. Default:
- * defaults::DYNAMO_BIND_PORT (0 = OS-assigned). */
+/** Bind port for the Dynamo listener. From DYN_BIND_PORT. Default:
+ * defaults::DYN_BIND_PORT (0 = OS-assigned). */
 uint16_t dynamoBindPort();
 
-/** Etcd endpoint(s) the discovery client dials. From DYNAMO_ETCD_ENDPOINTS,
+/** Etcd endpoint(s) the discovery client dials. From DYN_ETCD_ENDPOINTS,
  * falling back to ETCD_ENDPOINTS (the env var Dynamo's own runtime reads).
- * Default: defaults::DYNAMO_ETCD_ENDPOINTS. */
+ * Default: defaults::DYN_ETCD_ENDPOINTS. */
 std::string dynamoEtcdEndpoints();
 
 /** Lease TTL (seconds) for etcd-backed discovery. From
- * DYNAMO_ETCD_LEASE_TTL_SECS. Default: defaults::DYNAMO_ETCD_LEASE_TTL_SECS. */
+ * DYN_ETCD_LEASE_TTL_SECS. Default: defaults::DYN_ETCD_LEASE_TTL_SECS. */
 int64_t dynamoEtcdLeaseTtlSecs();
 
-/** Discovery namespace key. From DYNAMO_NAMESPACE. Default:
- * defaults::DYNAMO_NAMESPACE. */
+/** Discovery namespace key. From DYN_NAMESPACE. Default:
+ * defaults::DYN_NAMESPACE. */
 std::string dynamoNamespace();
 
-/** Discovery component key. From DYNAMO_COMPONENT. Default:
- * defaults::DYNAMO_COMPONENT. */
+/** Discovery component key. From DYN_COMPONENT. Default:
+ * defaults::DYN_COMPONENT. */
 std::string dynamoComponent();
 
-/** Discovery endpoint key. From DYNAMO_ENDPOINT_NAME. Default:
- * defaults::DYNAMO_ENDPOINT_NAME. */
+/** Discovery endpoint key. From DYN_ENDPOINT_NAME. Default:
+ * defaults::DYN_ENDPOINT_NAME. */
 std::string dynamoEndpointName();
 
 /** Discovery backend selector: "etcd" (default) or "kubernetes". From
- * DYNAMO_DISCOVERY_BACKEND. Default: defaults::DYNAMO_DISCOVERY_BACKEND. */
+ * DYN_DISCOVERY_BACKEND. Default: defaults::DYN_DISCOVERY_BACKEND. */
 std::string dynamoDiscoveryBackend();
 
 /** Kubernetes API server base URL for the kubernetes discovery backend. From
- * DYNAMO_KUBE_API_SERVER, else derived from the in-cluster
+ * DYN_KUBE_API_SERVER, else derived from the in-cluster
  * KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT env vars, else
  * https://kubernetes.default.svc. */
 std::string dynamoKubeApiServer();
 
-/** Path to the ServiceAccount bearer token. From DYNAMO_KUBE_TOKEN_PATH.
- * Default: defaults::DYNAMO_KUBE_TOKEN_PATH. */
+/** Path to the ServiceAccount bearer token. From DYN_KUBE_TOKEN_PATH.
+ * Default: defaults::DYN_KUBE_TOKEN_PATH. */
 std::string dynamoKubeTokenPath();
 
 /** Whether to validate the API server TLS certificate. From
- * DYNAMO_KUBE_VALIDATE_CERT. Default: defaults::DYNAMO_KUBE_VALIDATE_CERT. */
+ * DYN_KUBE_VALIDATE_CERT. Default: defaults::DYN_KUBE_VALIDATE_CERT. */
 bool dynamoKubeValidateCert();
 
 /** Kubernetes namespace the worker's CR is created in. From POD_NAMESPACE, else

--- a/tt-media-server/cpp_server/include/services/disaggregation_service.hpp
+++ b/tt-media-server/cpp_server/include/services/disaggregation_service.hpp
@@ -58,7 +58,7 @@ class DisaggregationService {
       std::function<void(const tt::sockets::PrefillResultMessage&)> callback);
 
   /**
-   * Prefill-first path for Dynamo (DYNAMO_ROUTING=1): discover decode via
+   * Prefill-first path for Dynamo (DYN_ROUTING=1): discover decode via
    * etcd, reserve a decode slot over ZMQ, run one prefill token, and return a
    * PrefillResultMessage for disaggregated_params.
    */
@@ -67,7 +67,7 @@ class DisaggregationService {
       std::function<void(const tt::sockets::PrefillResultMessage&)> callback);
 
   /** Prefill-first path: etcd discovery + ZMQ slot reservation, then one
-   * prefill token. Requires DYNAMO_ROUTING=1. */
+   * prefill token. Requires DYN_ROUTING=1. */
   void handlePrefillFirstStreamingRequest(
       LLMRequest& request, const std::vector<uint64_t>& registrationHashes,
       const StreamCallback& callback);

--- a/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
+++ b/tt-media-server/cpp_server/include/sockets/socket_messages.hpp
@@ -284,7 +284,7 @@ struct PrefillCacheBlocksAddedMessage
 /**
  * Prefill -> decode: reserve a decode KV slot before running prefill-first
  * disaggregation. Transport is InterServerService (ZMQ); peer selection may
- * still use etcd discovery under DYNAMO_ROUTING.
+ * still use etcd discovery under DYN_ROUTING.
  */
 struct SlotReservationRequestMessage
     : SerializableMessage<SlotReservationRequestMessage> {

--- a/tt-media-server/cpp_server/scripts/start_dynamo.sh
+++ b/tt-media-server/cpp_server/scripts/start_dynamo.sh
@@ -11,7 +11,7 @@
 # Usage:
 #   ./scripts/start_dynamo.sh                              # default file store
 #   DYN_DISCOVERY_BACKEND=etcd ./scripts/start_dynamo.sh   # use etcd
-#   DYNAMO_DISCOVERY_PATH=/tmp/dyn HTTP_PORT=9000 ./scripts/start_dynamo.sh
+#   DYN_DISCOVERY_PATH=/tmp/dyn HTTP_PORT=9000 ./scripts/start_dynamo.sh
 
 set -euo pipefail
 
@@ -40,15 +40,12 @@ export DYN_REQUEST_PLANE="${DYN_REQUEST_PLANE:-tcp}"
 export DYN_EVENT_PLANE="${DYN_EVENT_PLANE:-zmq}"
 export DYN_FILE_STORE="${DYN_FILE_STORE:-/tmp/dynamo_store_kv}"
 export ETCD_ENDPOINTS="${ETCD_ENDPOINTS:-http://localhost:2379}"
-export DYNAMO_ENDPOINT_ENABLED=1
-# Mirror the Dynamo-side env into cpp_server's namespace so the C++ accessors
-# (which key off DYNAMO_*) see the same values without duplicating exports.
-export DYNAMO_DISCOVERY_BACKEND="${DYN_DISCOVERY_BACKEND:-etcd}"
-export DYNAMO_DISCOVERY_PATH="${DYNAMO_DISCOVERY_PATH:-${DYN_FILE_STORE}}"
-export DYNAMO_ETCD_ENDPOINTS="${DYNAMO_ETCD_ENDPOINTS:-${ETCD_ENDPOINTS}}"
-export DYNAMO_NAMESPACE="${DYNAMO_NAMESPACE:-default}"
-export DYNAMO_COMPONENT="${DYNAMO_COMPONENT:-backend}"
-export DYNAMO_ENDPOINT_NAME="${DYNAMO_ENDPOINT_NAME:-generate}"
+export DYN_ENDPOINT_ENABLED=1
+export DYN_DISCOVERY_PATH="${DYN_DISCOVERY_PATH:-${DYN_FILE_STORE}}"
+export DYN_ETCD_ENDPOINTS="${DYN_ETCD_ENDPOINTS:-${ETCD_ENDPOINTS}}"
+export DYN_NAMESPACE="${DYN_NAMESPACE:-default}"
+export DYN_COMPONENT="${DYN_COMPONENT:-backend}"
+export DYN_ENDPOINT_NAME="${DYN_ENDPOINT_NAME:-generate}"
 
 # Quick sanity check: when running with etcd, fail fast if the gateway isn't
 # reachable so we don't waste a minute booting cpp_server only to crash on
@@ -122,7 +119,7 @@ FRONTEND_PID=$!
 
 sleep 2
 
-echo "Starting cpp_server (DYNAMO_ENDPOINT_ENABLED=1)..."
+echo "Starting cpp_server (DYN_ENDPOINT_ENABLED=1)..."
 "${BIN}" -p "${SERVER_PORT}" &
 BACKEND_PID=$!
 

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -798,42 +798,41 @@ unsigned sessionAllocationMaxRetries() {
 }
 
 bool dynamoEndpointEnabled() {
-  return envBool("DYNAMO_ENDPOINT_ENABLED", defaults::DYNAMO_ENDPOINT_ENABLED);
+  return envBool("DYN_ENDPOINT_ENABLED", defaults::DYN_ENDPOINT_ENABLED);
 }
 
 bool dynamoRoutingEnabled() {
-  return envBool("DYNAMO_ROUTING", defaults::DYNAMO_ROUTING);
+  return envBool("DYN_ROUTING", defaults::DYN_ROUTING);
 }
 
 std::string dynamoBindHost() {
-  return envString("DYNAMO_BIND_HOST", defaults::DYNAMO_BIND_HOST);
+  return envString("DYN_BIND_HOST", defaults::DYN_BIND_HOST);
 }
 
 uint16_t dynamoBindPort() {
-  const unsigned long port =
-      envUlong("DYNAMO_BIND_PORT", defaults::DYNAMO_BIND_PORT);
+  const unsigned long port = envUlong("DYN_BIND_PORT", defaults::DYN_BIND_PORT);
   if (port > 65535) {
     TT_LOG_WARN(
-        "[Config] DYNAMO_BIND_PORT={} is out of range [0, 65535], using "
+        "[Config] DYN_BIND_PORT={} is out of range [0, 65535], using "
         "default={}",
-        port, defaults::DYNAMO_BIND_PORT);
-    return defaults::DYNAMO_BIND_PORT;
+        port, defaults::DYN_BIND_PORT);
+    return defaults::DYN_BIND_PORT;
   }
   return static_cast<uint16_t>(port);
 }
 
 std::string dynamoEtcdEndpoints() {
-  // Prefer DYNAMO_ETCD_ENDPOINTS (cpp_server-specific). Fall back to
+  // Prefer DYN_ETCD_ENDPOINTS (cpp_server-specific). Fall back to
   // ETCD_ENDPOINTS — Dynamo's Rust runtime reads the same name, so a single
   // export propagates to both processes when start_dynamo.sh wires them
   // together.
-  if (const char* v = std::getenv("DYNAMO_ETCD_ENDPOINTS"); v && *v) {
+  if (const char* v = std::getenv("DYN_ETCD_ENDPOINTS"); v && *v) {
     return v;
   }
   if (const char* v = std::getenv("ETCD_ENDPOINTS"); v && *v) {
     return v;
   }
-  return defaults::DYNAMO_ETCD_ENDPOINTS;
+  return defaults::DYN_ETCD_ENDPOINTS;
 }
 
 std::string specDecodeMode() {
@@ -854,34 +853,33 @@ size_t mtpLevel() {
 }
 
 int64_t dynamoEtcdLeaseTtlSecs() {
-  const char* v = std::getenv("DYNAMO_ETCD_LEASE_TTL_SECS");
-  if (!v || !*v) return defaults::DYNAMO_ETCD_LEASE_TTL_SECS;
+  const char* v = std::getenv("DYN_ETCD_LEASE_TTL_SECS");
+  if (!v || !*v) return defaults::DYN_ETCD_LEASE_TTL_SECS;
   try {
     return std::stoll(v);
   } catch (const std::exception&) {
-    return defaults::DYNAMO_ETCD_LEASE_TTL_SECS;
+    return defaults::DYN_ETCD_LEASE_TTL_SECS;
   }
 }
 
 std::string dynamoNamespace() {
-  return envString("DYNAMO_NAMESPACE", defaults::DYNAMO_NAMESPACE);
+  return envString("DYN_NAMESPACE", defaults::DYN_NAMESPACE);
 }
 
 std::string dynamoComponent() {
-  return envString("DYNAMO_COMPONENT", defaults::DYNAMO_COMPONENT);
+  return envString("DYN_COMPONENT", defaults::DYN_COMPONENT);
 }
 
 std::string dynamoEndpointName() {
-  return envString("DYNAMO_ENDPOINT_NAME", defaults::DYNAMO_ENDPOINT_NAME);
+  return envString("DYN_ENDPOINT_NAME", defaults::DYN_ENDPOINT_NAME);
 }
 
 std::string dynamoDiscoveryBackend() {
-  return envString("DYNAMO_DISCOVERY_BACKEND",
-                   defaults::DYNAMO_DISCOVERY_BACKEND);
+  return envString("DYN_DISCOVERY_BACKEND", defaults::DYN_DISCOVERY_BACKEND);
 }
 
 std::string dynamoKubeApiServer() {
-  if (const char* v = std::getenv("DYNAMO_KUBE_API_SERVER"); v && *v) {
+  if (const char* v = std::getenv("DYN_KUBE_API_SERVER"); v && *v) {
     return v;
   }
   const char* host = std::getenv("KUBERNETES_SERVICE_HOST");
@@ -895,12 +893,11 @@ std::string dynamoKubeApiServer() {
 }
 
 std::string dynamoKubeTokenPath() {
-  return envString("DYNAMO_KUBE_TOKEN_PATH", defaults::DYNAMO_KUBE_TOKEN_PATH);
+  return envString("DYN_KUBE_TOKEN_PATH", defaults::DYN_KUBE_TOKEN_PATH);
 }
 
 bool dynamoKubeValidateCert() {
-  return envBool("DYNAMO_KUBE_VALIDATE_CERT",
-                 defaults::DYNAMO_KUBE_VALIDATE_CERT);
+  return envBool("DYN_KUBE_VALIDATE_CERT", defaults::DYN_KUBE_VALIDATE_CERT);
 }
 
 std::string dynamoPodName() { return envString("POD_NAME", ""); }
@@ -911,7 +908,7 @@ std::string dynamoPodNamespace() {
   if (const char* v = std::getenv("POD_NAMESPACE"); v && *v) {
     return v;
   }
-  std::ifstream f(defaults::DYNAMO_KUBE_NAMESPACE_PATH);
+  std::ifstream f(defaults::DYN_KUBE_NAMESPACE_PATH);
   if (f) {
     std::string ns;
     std::getline(f, ns);

--- a/tt-media-server/cpp_server/src/dynamo/kube_client.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/kube_client.cpp
@@ -215,7 +215,7 @@ KubeClient::KubeClient(KubeClientConfig config) : cfg_(std::move(config)) {
   if (!cfg_.validate_cert) {
     TT_LOG_WARN(
         "[KubeClient] TLS certificate validation DISABLED "
-        "(DYNAMO_KUBE_VALIDATE_CERT=0) for {}",
+        "(DYN_KUBE_VALIDATE_CERT=0) for {}",
         cfg_.api_server);
   }
 }

--- a/tt-media-server/cpp_server/src/dynamo/request_handler.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/request_handler.cpp
@@ -114,7 +114,7 @@ void DynamoRequestHandler::handle(const GenerateRequest& dynReq,
       tt::config::llmMode() == tt::config::LLMMode::PREFILL_ONLY) {
     if (!disaggregation) {
       sendErrorAndDone(
-          "DYNAMO_ROUTING=1: prefill worker has no disaggregation "
+          "DYN_ROUTING=1: prefill worker has no disaggregation "
           "contract service",
           500);
       return;
@@ -228,7 +228,7 @@ void DynamoRequestHandler::handle(const GenerateRequest& dynReq,
           *prefillResult->slotId != tt::domain::INVALID_SLOT_ID;
       if (!hasReservedDecodeSlot) {
         sendErrorAndDone(
-            "DYNAMO_ROUTING=1: prefill result did not include a "
+            "DYN_ROUTING=1: prefill result did not include a "
             "reserved decode slot_id; slot reservation must complete "
             "before decode can continue",
             500);

--- a/tt-media-server/cpp_server/src/main.cpp
+++ b/tt-media-server/cpp_server/src/main.cpp
@@ -366,7 +366,7 @@ int main(int argc, char* argv[]) {
             tt::config::ModelService::LLM));
     if (!llmService) {
       TT_LOG_ERROR(
-          "[Main] DYNAMO_ENDPOINT_ENABLED=1 but LLM service is not "
+          "[Main] DYN_ENDPOINT_ENABLED=1 but LLM service is not "
           "registered; skipping Dynamo worker server.");
     } else {
       auto pipeline = std::make_shared<tt::services::LLMPipeline>(
@@ -388,7 +388,7 @@ int main(int argc, char* argv[]) {
         opts.backend = tt::dynamo::DiscoveryBackend::ETCD;
       } else {
         TT_LOG_ERROR(
-            "[Main] Unknown DYNAMO_DISCOVERY_BACKEND='{}'; expected 'etcd' or "
+            "[Main] Unknown DYN_DISCOVERY_BACKEND='{}'; expected 'etcd' or "
             "'kubernetes'. Falling back to 'etcd'.",
             discoveryBackend);
         opts.backend = tt::dynamo::DiscoveryBackend::ETCD;
@@ -398,7 +398,7 @@ int main(int argc, char* argv[]) {
       opts.etcd_lease_ttl_secs = tt::config::dynamoEtcdLeaseTtlSecs();
       // Model Deployment Card capabilities + Dynamo-native routing (shared by
       // both discovery backends).
-      if (const char* v = std::getenv("DYNAMO_MODEL_TYPE"); v && *v) {
+      if (const char* v = std::getenv("DYN_MODEL_TYPE"); v && *v) {
         opts.model_type = v;
       } else if (tt::config::dynamoRoutingEnabled() &&
                  tt::config::llmMode() == tt::config::LLMMode::PREFILL_ONLY) {
@@ -406,10 +406,10 @@ int main(int argc, char* argv[]) {
         // Prefill capability while still setting worker_type=prefill.
         opts.model_type = "Prefill";
       }
-      if (const char* v = std::getenv("DYNAMO_MODEL_INPUT"); v && *v) {
+      if (const char* v = std::getenv("DYN_MODEL_INPUT"); v && *v) {
         opts.model_input = v;
       }
-      if (const char* v = std::getenv("DYNAMO_WORKER_TYPE"); v && *v) {
+      if (const char* v = std::getenv("DYN_WORKER_TYPE"); v && *v) {
         opts.worker_type = v;
       } else if (tt::config::dynamoRoutingEnabled()) {
         switch (tt::config::llmMode()) {

--- a/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
+++ b/tt-media-server/cpp_server/src/services/disaggregation_service.cpp
@@ -481,7 +481,7 @@ void DisaggregationService::enqueuePrefillFirst(
   if (!tt::config::dynamoRoutingEnabled()) {
     throw std::runtime_error(
         "[DisaggregationService] Prefill-first slot reservation requires "
-        "DYNAMO_ROUTING=1");
+        "DYN_ROUTING=1");
   }
 
   auto tokenIds = std::get<std::vector<uint32_t>>(request.prompt);
@@ -808,7 +808,7 @@ void DisaggregationService::resolvePrefillSession(
     // resident again when this prefill completes (see prefill result callback).
     sessionManager->shrinkResidentPrefixToMatchedTokens(
         acquired->sessionId, acquired->numberOfMatchedTokens);
-    // Optional under DYNAMO_ROUTING (no InterServerService / ZMQ gateway).
+    // Optional under DYN_ROUTING (no InterServerService / ZMQ gateway).
     if (socketService) {
       socketService->sendPrefillCacheBlocksAdded(blockHashes(blockInfos));
     }
@@ -843,7 +843,7 @@ void DisaggregationService::resolvePrefillSession(
               "sessionId={} slotId={}",
               request->task_id, session.getSessionId(), session.getSlotId());
           sm->registerPrefixHash(session.getSessionId(), infos);
-          // Optional under DYNAMO_ROUTING (no InterServerService / ZMQ
+          // Optional under DYN_ROUTING (no InterServerService / ZMQ
           // gateway).
           if (socketService) {
             socketService->sendPrefillCacheBlocksAdded(blockHashes(infos));

--- a/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
@@ -334,7 +334,7 @@ bool LLMPipeline::willPrefillOnDecode(
   const size_t threshold = tt::config::maxTokensToPrefillOnDecode();
   if (tt::config::dynamoRoutingEnabled()) {
     TT_LOG_INFO(
-        "[LLMPipeline] DYNAMO_ROUTING=1 taskId={} deltaTokens={} "
+        "[LLMPipeline] DYN_ROUTING=1 taskId={} deltaTokens={} "
         "accepting Dynamo decode route; local prefill will run on decode",
         request.task_id, deltaTokens);
     return true;

--- a/tt-media-server/cpp_server/src/utils/service_factory.cpp
+++ b/tt-media-server/cpp_server/src/utils/service_factory.cpp
@@ -41,7 +41,7 @@ AuxiliaryServices buildAuxiliaryServices(
           std::make_shared<services::DisaggregationService>(mode, llm, socket);
       if (tt::config::dynamoRoutingEnabled()) {
         TT_LOG_INFO(
-            "[ServiceFactory] DYNAMO_ROUTING=1; etcd discovery + ZMQ slot "
+            "[ServiceFactory] DYN_ROUTING=1; etcd discovery + ZMQ slot "
             "reservation");
       }
       return {std::move(socket), std::move(disagg)};

--- a/tt-media-server/cpp_server/tests/e2e/dynamo_test_helpers.hpp
+++ b/tt-media-server/cpp_server/tests/e2e/dynamo_test_helpers.hpp
@@ -59,9 +59,9 @@ struct DynamoConfig {
 
   static DynamoConfig fromEnv() {
     DynamoConfig cfg;
-    if (const char* h = std::getenv("DYNAMO_HOST")) cfg.host = h;
-    if (const char* p = std::getenv("DYNAMO_PORT")) cfg.port = std::stoi(p);
-    if (const char* m = std::getenv("DYNAMO_MODEL")) cfg.model = m;
+    if (const char* h = std::getenv("DYN_HOST")) cfg.host = h;
+    if (const char* p = std::getenv("DYN_PORT")) cfg.port = std::stoi(p);
+    if (const char* m = std::getenv("DYN_MODEL")) cfg.model = m;
     return cfg;
   }
 };

--- a/tt-media-server/cpp_server/tests/e2e/prefix_cache_e2e_test.cpp
+++ b/tt-media-server/cpp_server/tests/e2e/prefix_cache_e2e_test.cpp
@@ -5,9 +5,9 @@
 //
 // This test connects to an external Dynamo frontend server. Set environment
 // variables to configure:
-//   DYNAMO_HOST (default: 127.0.0.1)
-//   DYNAMO_PORT (default: 8080)
-//   DYNAMO_MODEL (default: tt-cpp-server)
+//   DYN_HOST (default: 127.0.0.1)
+//   DYN_PORT (default: 8080)
+//   DYN_MODEL (default: tt-cpp-server)
 //
 // The test expects Dynamo to be running. Start it with:
 //   cd dynamo_frontend && ./deploy.sh --local-build
@@ -66,7 +66,7 @@ struct PrefixCacheTestConfig {
     PrefixCacheTestConfig cfg;
     cfg.dynamo = DynamoConfig::fromEnv();
     cfg.dynamo.model = "deepseek-ai/DeepSeek-R1-0528";
-    if (const char* m = std::getenv("DYNAMO_MODEL")) cfg.dynamo.model = m;
+    if (const char* m = std::getenv("DYN_MODEL")) cfg.dynamo.model = m;
     if (const char* fb = std::getenv("KV_CACHE_FIRST_BLOCK_SIZE"))
       cfg.firstBlockSize = std::stoul(fb);
     if (const char* bs = std::getenv("KV_CACHE_BLOCK_SIZE"))


### PR DESCRIPTION
## Issue
[#4661 Use same naming for environment variables in inference server as in Dynamo](https://github.com/tenstorrent/tt-inference-server/issues/4661)

## Problem
There was a mismatch in Dynamo/Inference server naming convention for env variables:
- Dynamo uses DYN_ prefix for environment variables
- Inference server uses DYNAMO_ prefix for environment variables