### PR TITLE
add: GLM-5.2 in eval_config and models specs

### DIFF
--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -315,8 +315,8 @@ _eval_config_list = [
                 score=EvalTaskScore(
                     published_score=91.2,
                     published_score_ref="https://huggingface.co/zai-org/GLM-5.2",
-                    gpu_reference_score=86.36,
-                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/4641#issuecomment-5032779273",
+                    gpu_reference_score=88.4,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/4641#issuecomment-5042840653",
                     score_func=score_task_single_key,
                     score_func_kwargs={
                         "result_keys": [

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -254,6 +254,256 @@ class EvalConfig:
 
 _eval_config_list = [
     EvalConfig(
+        hf_model_repo="zai-org/GLM-5.2",
+        tasks=[
+            # Generate-then-answer LongBench v2 (chat API). Stock longbench2 is
+            # multiple_choice/loglikelihood and cannot run on chat-only servers.
+            EvalTask(
+                task_name="longbench2_generate",
+                max_concurrent=16,
+                workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
+                # min_context_required=131000,
+                use_chat_api=True,
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=58.82,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/4641#issuecomment-5032779273",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["exact_match,none"],
+                        "unit": "percent",
+                    },
+                ),
+                model_kwargs={
+                    "max_length": 512000,
+                    "timeout": 7200,
+                },
+                gen_kwargs={
+                    "max_gen_toks": 96 * 1024,
+                    # https://huggingface.co/zai-org/GLM-5.2/blob/main/tokenizer.json
+                    # https://huggingface.co/zai-org/GLM-5.2/blob/main/config.json
+                    "until": ["<|endoftext|>"],
+                    "do_sample": "true",
+                    "temperature": 1.0,
+                    "top_p": 0.95,
+                    "stream": "true",
+                },
+                # Select samples by input sequence length (ISL). ISL is measured
+                # by tokenizing each sample's context with `pretrained`; only
+                # samples with minimum_isl <= ISL <= maximum_isl are kept.
+                # Keep maximum_isl below max_model_len (512000) minus max_gen_toks
+                # so no selected prompt overflows the server context.
+                # Forwarded to the lm-eval fork loader via --metadata.
+                custom_dataset_kwargs={
+                    "minimum_isl": 256 * 1024,  # 256K
+                    "maximum_isl": 400 * 1000,  # 400K (< 512000 server limit on GPU)
+                    "pretrained": "zai-org/GLM-5.2-FP8",
+                    "tokenizer_num_proc": 32,  # pre-process up to 32 samples in parallel
+                },
+                limit_samples_map={
+                    EvalLimitMode.SMOKE_TEST: 0.01,
+                },
+            ),
+            EvalTask(
+                task_name="gpqa_diamond_cot_zeroshot",
+                workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
+                max_concurrent=64,
+                # The remote Tenstorrent console only exposes /v1/chat/completions
+                # (text /v1/completions returns 404), so use the chat API.
+                use_chat_api=True,
+                score=EvalTaskScore(
+                    published_score=91.2,
+                    published_score_ref="https://huggingface.co/zai-org/GLM-5.2",
+                    gpu_reference_score=86.36,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/4641#issuecomment-5032779273",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": [
+                            "exact_match,flexible-extract",
+                        ],
+                        "unit": "percent",
+                    },
+                ),
+                model_kwargs={
+                    "max_length": 200 * 1024,
+                    # Per-request HTTP timeout (lm-eval default 1800s). Long
+                    # reasoning generations on the shared console can exceed
+                    # 30min under load, so allow up to 2h before giving up.
+                    "timeout": 7200,
+                },
+                gen_kwargs={
+                    "max_gen_toks": 200 * 1024,
+                    # https://huggingface.co/zai-org/GLM-5.2/blob/main/tokenizer.json
+                    # https://huggingface.co/zai-org/GLM-5.2/blob/main/config.json
+                    "until": ["<|endoftext|>"],
+                    "do_sample": "true",
+                    "temperature": 1.0,
+                    "top_p": 0.95,
+                    "stream": "true",
+                },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.999,
+                    EvalLimitMode.SMOKE_TEST: 0.01,
+                },
+            ),
+            EvalTask(
+                task_name="terminal_bench_2_1",
+                workflow_venv_type=WorkflowVenvType.EVALS_AGENTIC,
+                score=EvalTaskScore(
+                    published_score=81.0,
+                    published_score_ref="https://huggingface.co/zai-org/GLM-5.2",
+                    gpu_reference_score=77.5,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/4324#issuecomment-4815788892",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["accuracy"],
+                        "unit": "percent",
+                    },
+                ),
+                agentic_eval_config=TerminalBenchEvalConfig(
+                    dataset="terminal-bench/terminal-bench-2-1",
+                    agent="terminus-2",
+                    n_concurrent_trials=64,
+                    n_attempts=1,
+                    n_tasks=89,
+                    override_cpus=16,
+                    override_memory_mb=32 * 1024,
+                    agent_timeout_sec=2 * 60 * 60,
+                    agent_kwargs={
+                        "parser_name": "json",
+                        "temperature": 1.0,
+                        "model_info": {
+                            "max_input_tokens": 512 * 1024,
+                            "max_output_tokens": 64 * 1024,
+                        },
+                        "llm_kwargs": {
+                            "top_p": 0.95,
+                            "max_tokens": 64 * 1024,
+                            "timeout": 60 * 60,
+                        },
+                    },
+                    task_names_map={
+                        EvalLimitMode.CI_NIGHTLY: [
+                            "terminal-bench/break-filter-js-from-html",
+                            "terminal-bench/cobol-modernization",
+                            "terminal-bench/compile-compcert",
+                            "terminal-bench/feal-differential-cryptanalysis",
+                            "terminal-bench/qemu-startup",
+                        ],
+                    },
+                ),
+                limit_samples_map={
+                    EvalLimitMode.SMOKE_TEST: 5,
+                },
+            ),
+            EvalTask(
+                task_name="tau3_bench_banking",
+                workflow_venv_type=WorkflowVenvType.EVALS_AGENTIC,
+                score=EvalTaskScore(
+                    published_score=26.8,
+                    published_score_ref="https://artificialanalysis.ai/evaluations/tau3-banking?models=glm-5-2",
+                    gpu_reference_score=35.1,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/4641#issuecomment-5032779273",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["accuracy"],
+                        "unit": "percent",
+                    },
+                    tolerance=0.10,
+                ),
+                agentic_eval_config=TerminalBenchEvalConfig(
+                    dataset="sierra-research/tau3-bench",
+                    agent="tau3_llm_agent",
+                    agent_import_path="adapters.tau3-bench.tau3_llm_agent:Tau3LLMAgent",
+                    task_names=["sierra-research/tau3-bench__tau3-banking_knowledge-*"],
+                    # A single served instance is shared by the agent,
+                    # the simulated user, and the Natural Language verifier.
+                    n_concurrent_trials=64,
+                    n_attempts=1,
+                    n_tasks=97,
+                    override_cpus=4,
+                    override_memory_mb=8 * 1024,
+                    agent_timeout_sec=3600,
+                    agent_kwargs={
+                        "tau2_trial_index": 0,
+                        "temperature": 1.0,
+                        "max_steps": 200,
+                        # Default is 120s; a single reasoning user-sim turn under
+                        # load can exceed that and trip an MCP request timeout.
+                        "tool_timeout_sec": 900,
+                        "read_timeout_sec": 120,
+                    },
+                    # NOTE: values injected here are passed to the Harbor
+                    # container verbatim. Unlike the task.toml env, the
+                    # "${VAR:-default}" template syntax is NOT resolved on this
+                    # path, so use literal values -- a templated model name
+                    # reaches litellm unexpanded and fails with "LLM Provider
+                    # NOT provided". OPENAI_BASE_URL / OPENAI_API_KEY are
+                    # intentionally omitted: the task's docker-compose already
+                    # substitutes those from the launching shell env.
+                    environment_env={
+                        "TAU2_USER_MODEL": "openai/zai-org/GLM-5.2-FP8",
+                    },
+                    verifier_env={
+                        "TAU2_NL_ASSERTIONS_MODEL": "openai/zai-org/GLM-5.2-FP8",
+                    },
+                    task_names_map={
+                        EvalLimitMode.CI_NIGHTLY: [
+                            "sierra-research/tau3-bench__tau3-banking_knowledge-task-031",
+                            "sierra-research/tau3-bench__tau3-banking_knowledge-task-032",
+                            "sierra-research/tau3-bench__tau3-banking_knowledge-task-052",
+                            "sierra-research/tau3-bench__tau3-banking_knowledge-task-002",
+                        ],
+                    },
+                ),
+                limit_samples_map={
+                    EvalLimitMode.SMOKE_TEST: 3,
+                },
+            ),
+            EvalTask(
+                task_name="swe_bench_verified",
+                workflow_venv_type=WorkflowVenvType.EVALS_AGENTIC,
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=74.0,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/4641#issuecomment-5032779273",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["accuracy"],
+                        "unit": "percent",
+                    },
+                ),
+                swebench_eval_config=SWEbenchEvalConfig(
+                    dataset_name="SWE-bench/SWE-bench_Verified",
+                    sweagent_subset="verified",
+                    dataset_split="test",
+                    agent_backend="mini-swe-agent",
+                    n_concurrent_trials=64,
+                    max_workers=24,
+                    n_tasks=None,
+                    temperature=1.0,
+                    top_p=0.95,
+                    max_input_tokens=512 * 1024,
+                    max_output_tokens=64 * 1024,
+                    instance_ids_map={
+                        EvalLimitMode.CI_NIGHTLY: [
+                            "django__django-12143",
+                            "pytest-dev__pytest-5262",
+                            "django__django-14672",
+                            "sympy__sympy-13551",
+                            "sphinx-doc__sphinx-9281",
+                        ],
+                    },
+                ),
+                limit_samples_map={
+                    EvalLimitMode.SMOKE_TEST: 5,
+                },
+            ),
+        ],
+    ),
+    EvalConfig(
         hf_model_repo="moonshotai/Kimi-K2.6",
         tasks=[
             EvalTask(

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -1712,3 +1712,21 @@ templates:
         VLLM__MAX_NUM_BATCHED_TOKENS: "32768"
         VLLM__MAX_MODEL_LENGTH: "131072"
         VLLM__MIN_CONTEXT_LENGTH: "1024"
+
+- weights:
+    - zai-org/GLM-5.2
+  impl: tt_transformers
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: SUPER_CLUSTER
+      max_concurrency: 64
+      max_context: 1048576  # 1024 * 1024;
+      default_impl: true
+  status: EXPERIMENTAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    zai-org/GLM-5.2:
+      remote_api_model: zai-org/GLM-5.2
+      reasoning_parser_name: glm45
+      tool_call_parser_name: glm47


### PR DESCRIPTION
## Summary
Relating to #4641 

- Add the GLM-5.2 remote SUPER_CLUSTER model specification with 1M-token context support.
- Configure standard evaluations for long-context LongBench v2 and GPQA Diamond.
- Add Terminal-Bench 2.1, $t^3$-bench Banking, and SWE-Bench Verified agentic evaluations.

