### PR TITLE
 Fix audio TTFT ms/s comparison bug and normalize media ttft_check naming

### DIFF
--- a/tt-inference-server-v2/test_module/_test_common/__init__.py
+++ b/tt-inference-server-v2/test_module/_test_common/__init__.py
@@ -7,7 +7,12 @@ from .blockify import block_id, sweep_envelope
 from .hardware_requirements import HardwareRequirement
 from .exceptions import NotApplicable, SkipTest
 from .report_types import ReportCheckTypes, TestStatus
-from .target_check import MetricSpec, PerformanceTargets, run_tiered_check
+from .target_check import (
+    MetricSpec,
+    PerformanceTargets,
+    load_targets,
+    run_tiered_check,
+)
 from .test_classes import TestCase, TestConfig, TestReport, TestTarget
 from .video_generation_routing import (
     _load_fixture_image_base64,
@@ -38,6 +43,7 @@ __all__ = [
     "build_video_generation_payload",
     "get_video_generation_submit_endpoint",
     "is_i2v_video_model",
+    "load_targets",
     "run_tiered_check",
     "sweep_envelope",
 ]

--- a/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
@@ -30,6 +30,7 @@ from .._test_common import (
     MetricSpec,
     ReportCheckTypes,
     block_id,
+    load_targets,
     run_tiered_check,
 )
 from ..context import MediaContext, count_tokens, require_health
@@ -278,11 +279,21 @@ def _audio_target_checks(
     logger.info("Computing 3-tier target checks for TTFT, T/S/U (tput_user), RTR")
     # ttft is captured in seconds; targets.ttft_ms is ms.
     ttft_ms = ttft_value * 1000 if ttft_value else None
+    # Streaming runs are gated against the streaming TTFT target when the device
+    # defines one
+    targets = load_targets(ctx)
+    ttft_target_attr = "ttft_ms"
+    if is_streaming_enabled_for_whisper(ctx) and targets.ttft_streaming_ms is not None:
+        ttft_target_attr = "ttft_streaming_ms"
     return run_tiered_check(
         ctx,
         [
             MetricSpec(
-                "TTFT", ttft_ms, "ttft_ms", lower_is_better=True, field_name="ttft"
+                "TTFT",
+                ttft_ms,
+                ttft_target_attr,
+                lower_is_better=True,
+                field_name="ttft",
             ),
             MetricSpec(
                 "T/S/U",

--- a/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/audio_benchmark_tests.py
@@ -276,11 +276,13 @@ def _audio_target_checks(
     rtr_value: Optional[float],
 ) -> tuple[dict, ReportCheckTypes]:
     logger.info("Computing 3-tier target checks for TTFT, T/S/U (tput_user), RTR")
+    # ttft is captured in seconds; targets.ttft_ms is ms.
+    ttft_ms = ttft_value * 1000 if ttft_value else None
     return run_tiered_check(
         ctx,
         [
             MetricSpec(
-                "TTFT", ttft_value, "ttft_ms", lower_is_better=True, field_name="ttft"
+                "TTFT", ttft_ms, "ttft_ms", lower_is_better=True, field_name="ttft"
             ),
             MetricSpec(
                 "T/S/U",

--- a/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
+++ b/tt-inference-server-v2/test_module/benchmark_tests/image_benchmark_tests.py
@@ -440,7 +440,7 @@ def _image_target_checks(
         ctx,
         [
             MetricSpec(
-                "TTFT", ttft_ms, "ttft_ms", lower_is_better=True, field_name="ttft_ms"
+                "TTFT", ttft_ms, "ttft_ms", lower_is_better=True, field_name="ttft"
             ),
             MetricSpec(
                 "tput_user",


### PR DESCRIPTION
1. Reverted accidental rename in` image_benchmark_tests.py` field_name="ttft_ms" ->"ttft", so image emits `ttft_check` like everything else (undoes the divergence from PR #3895).
2. Fixed audio ms/s bug: `audio_target_checks `now converts ttft_value * 1000 before comparing against the ms target.
3. Streaming target selection: audio now uses `ttft_streaming_ms `when streaming, with fallback to `ttft_ms`.