### PR TITLE
Add Devstral-2-123B (forge DP+TP) integration for BH Galaxy

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -1,5 +1,15 @@
 {
   "models": {
+    "Devstral-2-123B-Instruct-2512": {
+      "inference_engine": "FORGE",
+      "ci": {
+        "nightly": {
+          "devices": [
+            "BH_GALAXY"
+          ]
+        }
+      }
+    },
     "DeepSeek-R1-0528": {
       "inference_engine": "vLLM",
       "ci": {

--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -7,6 +7,11 @@
           "devices": [
             "BH_GALAXY"
           ]
+        }, 
+        "release": {
+          "devices": [
+            "BH_GALAXY"
+          ]
         }
       }
     },

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -2469,6 +2469,72 @@ _eval_config_list = [
         ],
     ),
     EvalConfig(
+        hf_model_repo="mistralai/Devstral-2-123B-Instruct-2512",
+        tasks=[
+            # Short non-agentic evals for a shippable green; 192K agentic swe_bench
+            # dropped (bfp8 KV crashes the (4,8) mesh; forge decode too slow).
+            EvalTask(
+                task_name="humaneval_plus",
+                workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
+                # Completion-style: continues the signature+docstring as code
+                # (chat template -> prose -> pass@1=0).
+                apply_chat_template=False,
+                num_fewshot=0,
+                allow_code_execution=True,
+                score=EvalTaskScore(
+                    published_score=72.05,
+                    published_score_ref="https://arxiv.org/abs/2505.09388",
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref="TBD",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["pass@1,create_test"],
+                        "unit": "percent",
+                    },
+                ),
+                gen_kwargs={
+                    "max_gen_toks": 1024,
+                    "do_sample": "false",
+                    "stream": "false",
+                },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.1,
+                    EvalLimitMode.SMOKE_TEST: 0.01,
+                },
+            ),
+            EvalTask(
+                task_name="mbpp_plus",
+                workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
+                # Completion-style task -- see humaneval_plus above.
+                apply_chat_template=False,
+                num_fewshot=3,
+                allow_code_execution=True,
+                score=EvalTaskScore(
+                    published_score=72.05,
+                    published_score_ref="https://arxiv.org/abs/2505.09388",
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref="TBD",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["pass_at_1,none"],
+                        "unit": "percent",
+                    },
+                ),
+                gen_kwargs={
+                    "max_gen_toks": 1024,
+                    "do_sample": "false",
+                    "stream": "false",
+                },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.1,
+                    EvalLimitMode.SMOKE_TEST: 0.01,
+                },
+            ),
+            # gsm8k_cot removed: bare `dataset_path: gsm8k` rejected by the
+            # installed datasets (HfUriError; canonical repo is openai/gsm8k).
+        ],
+    ),
+    EvalConfig(
         hf_model_repo="mistralai/Mistral-7B-Instruct-v0.3",
         tasks=[
             EvalTask(

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -48,6 +48,7 @@ class SupportedModels(Enum):
     MISTRAL_SMALL_3_1_24B_INSTRUCT_2503 = (
         "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
     )
+    DEVSTRAL_2_123B = "mistralai/Devstral-2-123B-Instruct-2512"
     FALCON3_7B_INSTRUCT = "tiiuae/Falcon3-7B-Instruct"
     Z_IMAGE_TURBO = "Tongyi-MAI/Z-Image-Turbo"
     YOLOX_NANO = "Megvii-BaseDetection/YOLOX-Nano"
@@ -101,6 +102,7 @@ class ModelNames(Enum):
     GEMMA_1_1_2B_IT = "gemma-1.1-2b-it"
     GEMMA_4_31B_IT = "gemma-4-31b-it"
     MISTRAL_SMALL_3_1_24B_INSTRUCT_2503 = "Mistral-Small-3.1-24B-Instruct-2503"
+    DEVSTRAL_2_123B = "Devstral-2-123B-Instruct-2512"
     FALCON3_7B_INSTRUCT = "Falcon3-7B-Instruct"
     YOLOX_NANO = "yolox_nano"
     Z_IMAGE_TURBO = "Z-Image-Turbo"
@@ -133,6 +135,7 @@ class ModelRunners(Enum):
     VLLMForge_GEMMA4_31B = "vllm_forge_gemma4_31b"
     VLLMForge_QWEN_32B = "vllm_forge_qwen_32b"
     VLLMForge_MISTRAL_SMALL_31_24B = "vllm_forge_mistral_small_31_24b"
+    VLLMForge_DEVSTRAL_123B = "vllm_forge_devstral_123b"
     QWEN_EMBEDDING_8B = "qwen_embedding_8b"
     BGELargeEN_V1_5 = "bge_large_en_v1_5"
     BGEM3 = "bge-m3"
@@ -187,6 +190,7 @@ MODEL_SERVICE_RUNNER_MAP = {
         ModelRunners.VLLMForge_GEMMA4_31B,
         ModelRunners.VLLMForge_QWEN_32B,
         ModelRunners.VLLMForge_MISTRAL_SMALL_31_24B,
+        ModelRunners.VLLMForge_DEVSTRAL_123B,
         ModelRunners.LLM_TEST,
         ModelRunners.LLAMA_RUNNER,
         ModelRunners.LORA_SINGLE_CHIP,
@@ -304,6 +308,7 @@ INFERENCE_MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.VLLMForge_MISTRAL_SMALL_31_24B: {
         ModelNames.MISTRAL_SMALL_3_1_24B_INSTRUCT_2503
     },
+    ModelRunners.VLLMForge_DEVSTRAL_123B: {ModelNames.DEVSTRAL_2_123B},
     ModelRunners.QWEN_EMBEDDING_8B: {ModelNames.QWEN_3_EMBEDDING_8B},
     ModelRunners.BGELargeEN_V1_5: {ModelNames.BGE_LARGE_EN_V1_5},
     ModelRunners.BGEM3: {ModelNames.BGE_M3},
@@ -1171,6 +1176,16 @@ ModelConfigs = {
         "device_ids": DeviceIds.DEVICE_IDS_32_GROUP.value,
         # Dims env-driven via dev/llm.yaml env_vars (see gemma entry above); this
         # entry only carries the TP mesh topology.
+        "max_batch_size": 1,
+        "queue_for_multiprocessing": QueueType.FasterFifo.value,
+    },
+    (ModelRunners.VLLMForge_DEVSTRAL_123B, DeviceTypes.BLACKHOLE_GALAXY): {
+        # Devstral-2-123B on the BH Galaxy as a 4x8 DP+TP mesh. Plugin owns the 2D
+        # split, so hand it ONE worker over all 32 devices. is_galaxy=False + static
+        # device_ids bypasses settings._set_device_pairs_overrides().
+        "device_mesh_shape": (4, 8),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_32_GROUP.value,
         "max_batch_size": 1,
         "queue_for_multiprocessing": QueueType.FasterFifo.value,
     },

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -106,6 +106,10 @@ AVAILABLE_RUNNERS = {
         "tt_model_runners.vllm_forge_mistral_small_31_24b",
         fromlist=["VLLMForgeMistralSmall31_24BRunner"],
     ).VLLMForgeMistralSmall31_24BRunner(wid),
+    ModelRunners.VLLMForge_DEVSTRAL_123B: lambda wid: __import__(
+        "tt_model_runners.vllm_forge_devstral_123b",
+        fromlist=["VLLMForgeDevstral123BRunner"],
+    ).VLLMForgeDevstral123BRunner(wid),
     ModelRunners.TT_XLA_RESNET: lambda wid: __import__(
         "tt_model_runners.forge_runners.runners", fromlist=["ForgeResnetRunner"]
     ).ForgeResnetRunner(wid),

--- a/tt-media-server/tt_model_runners/vllm_forge_devstral_123b.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_devstral_123b.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+import asyncio
+import os
+import traceback
+
+from domain.completion_request import CompletionRequest
+from domain.completion_response import CompletionOutput, CompletionResult
+from telemetry.telemetry_client import TelemetryEvent
+from tt_model_runners.base_device_runner import BaseDeviceRunner
+from utils.decorators import log_execution_time
+from utils.sampling_params_builder import build_sampling_params
+from utils.text_utils import TextUtils
+from vllm import AsyncEngineArgs, AsyncLLMEngine, SamplingParams
+
+CHUNK_TYPE = "streaming_chunk"
+FINAL_TYPE = "final_result"
+
+
+class VLLMForgeDevstral123BRunner(BaseDeviceRunner):
+    """Forge vLLM runner for Devstral-2-123B on the BH Galaxy as a 4x8 DP+TP mesh.
+
+    First DP+TP model in tt-media-server, so it sets DP-specific additional_config
+    keys the pure-TP forge runners (gemma-4-31b, qwen3-32b) never touch:
+      - enable_data_parallel: fan the request batch across the DP replicas
+      - shard_weights_on_batch_axis=False: classic DP+TP -- weights TP-sharded and
+        REPLICATED across the 4 DP replicas (fewer CCLs); True = FSDP
+      - use_2d_mesh: the (DP, TP) grid is 2D (TP runners use 1D)
+      - mesh_shape=[DP, TP] from settings.device_mesh_shape ((4, 8))
+    Plugin owns the 2D split; tt-media-server hands it one worker over all 32 chips.
+    Requires env TT_RUNTIME_USING_BH_GALAXY=1.
+    """
+
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+
+    @log_execution_time(
+        "VLLM Forge Devstral-2-123B model load",
+        TelemetryEvent.DEVICE_WARMUP,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    async def warmup(self) -> bool:
+        self.logger.info(
+            f"Device {self.device_id}: Loading VLLM Forge Devstral-2-123B model "
+            f"(mesh_shape={tuple(self.settings.device_mesh_shape)} DP+TP)..."
+        )
+        prompt = "Hello, it's me"
+        # Env-tunable (mirrors vllm_forge_qwen_32b.py). CPU_SAMPLING defaults true:
+        # the on-device sampler yields token-soup on this 2D DP+TP mesh (#4440).
+        # Weights stay bfp_bf8 (fp8 ckpt -> bf16 -> bfp8): faster than bf16 and
+        # required to fit the 123B in the TP-8 weight slice.
+        optimization_level = int(os.getenv("OPTIMIZATION_LEVEL", "0"))
+        cpu_sampling = os.getenv("CPU_SAMPLING", "true").lower() == "true"
+        enable_trace = os.getenv("ENABLE_TRACE", "true").lower() == "true"
+        # FSDP weight sharding (batch axis): frees per-chip DRAM for larger KV/ctx;
+        # default False = classic TP-replicated weights.
+        shard_weights = (
+            os.getenv("SHARD_WEIGHTS_ON_BATCH_AXIS", "false").lower() == "true"
+        )
+        # Chunked prefill (plugin owns chunking); invariant: prefill_batch_threshold
+        # < max_num_seqs. Only passed when set.
+        prefill_chunk_size = os.getenv("PREFILL_CHUNK_SIZE")
+        min_num_seqs = os.getenv("MIN_NUM_SEQS")
+        prefill_batch_threshold = os.getenv("PREFILL_BATCH_THRESHOLD")
+        # KV cache dtype ("bfp_bf8" halves KV footprint); only set when env given,
+        # else plugin default (bf16). NB: bfp8 KV crashes the (4,8) mesh.
+        kv_cache_dtype = os.getenv("KV_CACHE_DTYPE")
+        mesh_shape = list(self.settings.device_mesh_shape)  # (DP, TP) -> [4, 8]
+        additional_config = {
+            "enable_const_eval": True,
+            # Validated value from tt-xla Devstral configs; NOT
+            # settings.vllm.min_context_length (whose default is 128).
+            "min_context_len": 32,
+            "enable_tensor_parallel": True,
+            "enable_data_parallel": True,
+            "shard_weights_on_batch_axis": shard_weights,
+            "use_2d_mesh": True,
+            "mesh_shape": mesh_shape,
+            "experimental_weight_dtype": "bfp_bf8",
+            "cpu_sampling": cpu_sampling,
+            "optimization_level": optimization_level,
+            "enable_trace": enable_trace,
+        }
+        if prefill_chunk_size:
+            additional_config["prefill_chunk_size"] = int(prefill_chunk_size)
+        if min_num_seqs:
+            additional_config["min_num_seqs"] = int(min_num_seqs)
+        if prefill_batch_threshold:
+            additional_config["prefill_batch_threshold"] = int(prefill_batch_threshold)
+        if kv_cache_dtype:
+            additional_config["experimental_kv_cache_dtype"] = kv_cache_dtype
+        engine_args = AsyncEngineArgs(
+            model=self.settings.vllm.model,
+            max_model_len=self.settings.vllm.max_model_length,
+            max_num_batched_tokens=self.settings.vllm.max_num_batched_tokens,
+            max_num_seqs=self.settings.vllm.max_num_seqs,
+            enable_chunked_prefill=False,
+            gpu_memory_utilization=self.settings.vllm.gpu_memory_utilization,
+            additional_config=additional_config,
+        )
+        self.logger.info(
+            f"Device {self.device_id}: additional_config={engine_args.additional_config}"
+        )
+        self.llm_engine = AsyncLLMEngine.from_engine_args(engine_args)
+
+        self.logger.info(f"Device {self.device_id}: Starting model warmup")
+        warmup_sampling_params = SamplingParams(temperature=0.0, max_tokens=10)
+        warmup_generator = self.llm_engine.generate(
+            prompt, warmup_sampling_params, "warmup_task_id"
+        )
+        async for _ in warmup_generator:
+            pass
+        self.logger.info(f"Device {self.device_id}: Model warmup completed")
+        return True
+
+    def _build_vllm_input(self, request: CompletionRequest):
+        if isinstance(request.prompt, str):
+            return request.prompt
+        elif isinstance(request.prompt, list):
+            return {"prompt_token_ids": request.prompt}
+        raise ValueError(f"Invalid prompt type: {type(request.prompt)}")
+
+    @log_execution_time(
+        "Run VLLM Forge Devstral-2-123B inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    def run(self, requests: list[CompletionRequest]):
+        """Synchronous wrapper for async inference"""
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(self._run_async(requests))
+
+    async def _run_async(self, requests: list[CompletionRequest]):
+        try:
+            self.logger.debug(
+                f"Device {self.device_id}: Running Devstral-2-123B inference"
+            )
+
+            request = requests[0]
+            if request.stream:
+                return self._generate_streaming(request)
+            else:
+                return await self._generate_non_streaming(requests)
+        except Exception as e:
+            self.logger.error(
+                f"Device {self.device_id}: Devstral-2-123B inference failed: {type(e).__name__}: {e}"
+            )
+            self.logger.error(
+                f"Device {self.device_id}: Full traceback: {traceback.format_exc()}"
+            )
+            raise RuntimeError(f"Devstral-2-123B inference failed: {str(e)}") from e
+
+    async def _generate_streaming(self, request: CompletionRequest):
+        """Yields CompletionOutput dicts for streaming generation."""
+
+        chunks = []
+        strip_eos = TextUtils.strip_eos
+        sampling_params = build_sampling_params(request)
+
+        async for request_output in self.llm_engine.generate(
+            self._build_vllm_input(request), sampling_params, request._task_id
+        ):
+            outputs = request_output.outputs
+            if not outputs:
+                continue
+
+            for output in outputs:
+                chunk_text = output.text
+                if not chunk_text:
+                    continue
+
+                if chunk_text.endswith(
+                    ("</s>", "<|endoftext|>", "<|im_end|>", "<end_of_turn>")
+                ):
+                    chunk_text = strip_eos(chunk_text)
+                    if not chunk_text:
+                        continue
+
+                chunks.append(chunk_text)
+
+                yield CompletionOutput(
+                    type=CHUNK_TYPE,
+                    data=CompletionResult(text=chunk_text),
+                )
+
+        self.logger.info(
+            f"Device {self.device_id}: Devstral-2-123B streaming generation completed"
+        )
+
+        yield CompletionOutput(
+            type=FINAL_TYPE,
+            data=CompletionResult(text=""),
+        )
+
+    async def process_request_non_streaming(
+        self, request: CompletionRequest
+    ) -> CompletionOutput:
+        self.logger.info(
+            f"Device {self.device_id}: Starting Devstral-2-123B non-streaming generation"
+        )
+
+        sampling_params = build_sampling_params(request)
+
+        generated_text = []
+        async for request_output in self.llm_engine.generate(
+            self._build_vllm_input(request), sampling_params, request._task_id
+        ):
+            if request_output.outputs:
+                generated_text.append(request_output.outputs[0].text)
+
+        generated_text = "".join(generated_text)
+
+        self.logger.info(
+            f"Device {self.device_id}: Devstral-2-123B non-streaming generation completed"
+        )
+
+        return CompletionOutput(
+            type=FINAL_TYPE,
+            data=CompletionResult(text=generated_text),
+        )
+
+    async def _generate_non_streaming(self, requests: list[CompletionRequest]):
+        tasks = [self.process_request_non_streaming(request) for request in requests]
+        self.logger.info(
+            f"Device {self.device_id}: Starting non-streaming batch generation for {len(tasks)} requests"
+        )
+        results = await asyncio.gather(*tasks)
+        self.logger.info(
+            f"Device {self.device_id}: Non-streaming batch generation completed for {len(tasks)} requests"
+        )
+        return results

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -1713,6 +1713,41 @@ templates:
         TT_MESH_GRAPH_DESC_PATH: "/home/container_app_user/app/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto"
 
 - weights:
+    # Devstral-2-123B Forge LLM (DP+TP) on the BH Galaxy (32-chip 4x8 mesh),
+    # mirroring the Mistral-Small forge block above. DP+TP additional_config keys
+    # live in the runner (tt_model_runners/vllm_forge_devstral_123b.py).
+    - mistralai/Devstral-2-123B-Instruct-2512
+  impl: forge_vllm_plugin
+  min_disk_gb: 300
+  min_ram_gb: 64
+  model_type: LLM
+  inference_engine: FORGE
+  uses_tensor_model_cache: false
+  status: EXPERIMENTAL
+  device_model_specs:
+    - device: BLACKHOLE_GALAXY
+      # Shippable short-context config. FSDP required (no-FSDP crashes (4,8)
+      # trace-capture); bf16 KV (bfp8 crashes the (4,8) mesh).
+      max_concurrency: 32  # DP4 x TP8
+      max_context: 8192
+      default_impl: true
+      eval_max_retries: 1
+      env_vars:
+        MAX_MODEL_LENGTH: "8192"
+        MAX_NUM_SEQS: "32"
+        GPU_MEMORY_UTILIZATION: "0.55"
+        SHARD_WEIGHTS_ON_BATCH_AXIS: "true"   # FSDP required (no-FSDP crashes (4,8) trace-capture)
+        OPTIMIZATION_LEVEL: "0"
+        ENABLE_TRACE: "true"
+        CPU_SAMPLING: "false"
+        TT_METAL_OPERATION_TIMEOUT_SECONDS: "120"
+        PREFILL_CHUNK_SIZE: "128"
+        MIN_NUM_SEQS: "1"
+        PREFILL_BATCH_THRESHOLD: "16"
+        TT_RUNTIME_USING_BH_GALAXY: "1"
+        TT_MESH_GRAPH_DESC_PATH: "/home/container_app_user/app/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto"
+
+- weights:
     - meta-llama/Llama-3.1-70B
   impl: forge_vllm_plugin
   min_disk_gb: 150


### PR DESCRIPTION
Adds the **forge-vllm-plugin** implementation of **Devstral-2-123B-Instruct-2512** on the **Blackhole Galaxy** (4×8 DP+TP mesh). Status: **EXPERIMENTAL**.

Serves 8192 / batch 32 with FSDP weight sharding and chunked prefill; bf16 KV (bfp8 KV crashes the (4,8)-mesh compile).

### Changes (basic model addition)
- Mesh-aware forge runner + `BLACKHOLE_GALAXY` ModelConfig `(4,8)`, `dev/llm.yaml` spec, runner_fabric registration.
- Minimal eval config: `humaneval_plus` + `mbpp_plus` (completion mode).
- `models-ci-config.json`: FORGE `nightly` on `BH_GALAXY`.

No shared engine/harness changes.

### Local validation
`run.py --workflow release --ci-mode` (EXPERIMENTAL): warms on all 32 devices, Acceptance **PASS** (rc=0); benchmark sizes to served 8192 (no 400s).

| Eval | pass@1 |
|---|---|
| humaneval_plus | 23.53 |
| mbpp_plus | 68.42 |

Scores are EXPERIMENTAL-waived; goal is that the forge path serves and runs e2e on BH Galaxy.