### PR TITLE
new release pipeline: initial files to be committed for automating the release process

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -1,0 +1,520 @@
+name: Release Automation (promote specs, docs & helm)
+
+run-name: ${{ inputs.version && format('Release automation v{0}', inputs.version) || 'Release automation (push)' }}
+
+# ---------------------------------------------------------------------------
+# Automates the release pipeline:
+#   1. promote_dev_spec_to_prod.py  (dev -> prod model specs, release-scoped)
+#   2. export_model_spec.py         (docs/model_support + release_model_spec.json)
+#   3. python -m workflows.helm_generator  (charts/.../values.yaml)
+#   4. helm-docs                    (chart README / supported-models docs)
+# then, from the runner:
+#   git add . && git commit -m "v<version><suffix>" && git push
+#   git tag v<version><suffix> && git push origin v<version><suffix>
+# finally:
+#   create branch post-release-v<version><post-suffix> off main, carrying this
+#   branch's VERSION + models-ci-config.json onto it, re-run all 4 steps from above and push it.
+# ---------------------------------------------------------------------------
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version for the run title, e.g. 0.18.0 (must match the VERSION file, which stays the source of truth)"
+        required: true
+        default: "0.18.0"
+        type: string
+      tt-metal-commit:
+        description: "tt-metal commit SHA pinned into the promoted prod specs"
+        required: true
+        default: "c49bb76"
+        type: string
+      vllm-commit:
+        description: "vLLM commit SHA (needed for LLM / VLLM models)"
+        required: false
+        default: "6b4a3a7"
+        type: string
+      tt-shield-run-id:
+        description: "tt-shield Release run ID (reserved for the later artifact step; NOT used by the four commands here)"
+        required: false
+        default: "29037835062"
+        type: string
+      tag-suffix:
+        description: "Suffix appended to the commit message & tag. Keep '-temp' while testing; clear it for a real release."
+        required: false
+        default: "-temp"
+        type: string
+      post-release-suffix:
+        description: "Suffix for the post-release branch (post-release-v<version><suffix>). Keep '-test' while testing; clear it for a real release."
+        required: false
+        default: "-test"
+        type: string
+
+# The pipeline commits generated files + a tag to the branch and opens a draft PR.
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-automation-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PYTHON_VERSION: "3.12"
+  HELM_DOCS_VERSION: "1.14.2"
+  CRANE_VERSION: "0.21.5"
+
+jobs:
+  release-prep:
+    name: Promote specs, regenerate docs & helm, then commit + tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install Python dependencies
+        # requirements-dev.txt provides ruamel.yaml + jsonschema for the helm
+        # generator and PyYAML for the promote /
+        # export scripts. 
+        # One environment serves all four commands — CI does not .venv.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Install helm-docs
+        # helm-docs is a Go binary and is not present on ubuntu-latest.
+        run: |
+          curl -fsSL -o /tmp/helm-docs.tar.gz \
+            "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
+          sudo tar -xzf /tmp/helm-docs.tar.gz -C /usr/local/bin helm-docs
+          helm-docs --version
+
+      - name: Resolve inputs
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IN_VERSION: ${{ github.event.inputs.version }}
+          IN_TT_METAL_COMMIT: ${{ github.event.inputs['tt-metal-commit'] }}
+          IN_VLLM_COMMIT: ${{ github.event.inputs['vllm-commit'] }}
+          IN_TT_SHIELD_RUN_ID: ${{ github.event.inputs['tt-shield-run-id'] }}
+          IN_TAG_SUFFIX: ${{ github.event.inputs['tag-suffix'] }}
+          IN_POST_RELEASE_SUFFIX: ${{ github.event.inputs['post-release-suffix'] }}
+        run: |
+          # The VERSION file is the source of truth (checkout runs first, so it
+          # is present). The `version` input is only for the run title; require
+          # it to match the file so the title can never misrepresent the release.
+          RELEASE_VERSION="$(tr -d '[:space:]' < VERSION)"
+          if [ -z "$RELEASE_VERSION" ]; then
+            echo "::error::VERSION file is empty or missing"; exit 1
+          fi
+          if [ -n "$IN_VERSION" ] && [ "$IN_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "::error::version input ('$IN_VERSION') does not match the VERSION file ('$RELEASE_VERSION'). Update the input or the VERSION file so they agree."
+            exit 1
+          fi
+          {
+            echo "RELEASE_VERSION=${RELEASE_VERSION}"
+            echo "TT_METAL_COMMIT=${IN_TT_METAL_COMMIT:-c49bb76}"
+            echo "VLLM_COMMIT=${IN_VLLM_COMMIT:-6b4a3a7}"
+            echo "TT_SHIELD_RUN_ID=${IN_TT_SHIELD_RUN_ID:-29037835062}"
+          } >> "$GITHUB_ENV"
+          # Suffixes: on dispatch use the inputs verbatim (may be empty for a
+          # real release); on push default to the testing suffixes.
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "TAG_SUFFIX=${IN_TAG_SUFFIX}" >> "$GITHUB_ENV"
+            echo "POST_RELEASE_SUFFIX=${IN_POST_RELEASE_SUFFIX}" >> "$GITHUB_ENV"
+          else
+            echo "TAG_SUFFIX=-temp" >> "$GITHUB_ENV"
+            echo "POST_RELEASE_SUFFIX=-test" >> "$GITHUB_ENV"
+          fi
+
+      - name: Show effective parameters
+        run: |
+          echo "version          = ${RELEASE_VERSION}"
+          echo "tt-metal-commit  = ${TT_METAL_COMMIT}"
+          echo "vllm-commit      = ${VLLM_COMMIT}"
+          echo "tt-shield-run-id = ${TT_SHIELD_RUN_ID}  (not used here)"
+          echo "commit/tag       = v${RELEASE_VERSION}${TAG_SUFFIX}"
+          echo "post-release br  = post-release-v${RELEASE_VERSION}${POST_RELEASE_SUFFIX} (from main)"
+
+      # ----- Step 1: promote dev model specs -> prod (release-scoped only) -----
+      - name: "Step 1 — promote dev specs to prod"
+        run: |
+          python3 scripts/release/promote_dev_spec_to_prod.py \
+            --version "${RELEASE_VERSION}" \
+            --tt-metal-commit "${TT_METAL_COMMIT}" \
+            --vllm-commit "${VLLM_COMMIT}"
+
+      # ----- Step 2: regenerate model-support docs + release_model_spec.json ----
+      - name: "Step 2 — export model spec (docs + JSON)"
+        run: python3 scripts/release/export_model_spec.py
+
+      # ----- Step 3: regenerate charts/tt-inference-server/values.yaml ---------
+      - name: "Step 3 — generate Helm values.yaml"
+        run: python -m workflows.helm_generator
+
+      # ----- Step 4: regenerate chart README / supported-models docs ----------
+      - name: "Step 4 — generate Helm chart docs (helm-docs)"
+        run: |
+          helm-docs \
+            --chart-search-root=charts/tt-inference-server \
+            --template-files=_supportedModels.gotmpl \
+            --template-files=README.md.gotmpl
+
+      # ----- Show what the generators produced (before committing) ------------
+      - name: "Show generated changes (added or modified files)"
+        if: always()
+        run: |
+          echo "=== git status ==="
+          git status --short --untracked-files=all
+          echo
+          echo "=== git diff --stat ==="
+          git diff --stat
+          {
+            echo "## Release automation — v${RELEASE_VERSION}${TAG_SUFFIX}"
+            echo
+            echo "version=\`${RELEASE_VERSION}\`, tt-metal-commit=\`${TT_METAL_COMMIT}\`, vllm-commit=\`${VLLM_COMMIT}\`"
+            echo
+            echo '```'
+            git status --short --untracked-files=all
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ----- Commit + push + tag, from the pipeline (only if steps 1-4 ok) -----
+      - name: Configure git identity for push operation
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: "git add + git commit on stable branch"
+        run: |
+          TAG="v${RELEASE_VERSION}${TAG_SUFFIX}"
+          git add .
+          if git diff --cached --quiet; then
+            echo "No changes produced by the release-prep scripts — nothing to commit."
+            echo "COMMITTED=false" >> "$GITHUB_ENV"
+          else
+            git commit -m "${TAG}"
+            echo "Committed as '${TAG}'."
+            echo "COMMITTED=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: "git push on stable branch"
+        if: env.COMMITTED == 'true'
+        run: git push origin "HEAD:${{ github.ref_name }}"
+
+      - name: "git tag + git push origin <tag>"
+        # Force so re-runs of the pipeline re-point/replace the (temp) tag
+        # instead of failing on an already-existing tag.
+        run: |
+          TAG="v${RELEASE_VERSION}${TAG_SUFFIX}"
+          git tag -f "${TAG}"
+          git push -f origin "refs/tags/${TAG}"
+          echo "Tagged HEAD and pushed '${TAG}'."
+
+      # Preserve the generated files so they can be inspected / downloaded.
+      - name: "Upload generated changes as an artifact"
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-automation-generated-changes
+          path: |
+            workflows/model_specs/prod/**
+            release_model_spec.json
+            docs/model_support/**
+            charts/tt-inference-server/values.yaml
+            charts/tt-inference-server/README.md
+            README.md
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: "Build release artifacts zip (download from tt-shield)"
+        env:
+          GH_TOKEN: ${{ secrets.TMP_VCANKOVIC_SHIELD_CRANE_PAT }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/release_artifacts"
+          python3 scripts/release/build_release_artifacts.py \
+            --run-id "${TT_SHIELD_RUN_ID}" \
+            --version "v${RELEASE_VERSION}" \
+            --output-dir "${RUNNER_TEMP}/release_artifacts"
+
+      - name: "Upload release artifacts zip"
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-artifacts-v${{ env.RELEASE_VERSION }}
+          path: ${{ runner.temp }}/release_artifacts/*.zip
+          if-no-files-found: warn
+          retention-days: 7
+
+      # ----- Resolve the source dev images (vllm/media/forge) built by the
+      #       tt-shield run, and expose them as STEP OUTPUTS for later steps
+      #       plus a run-summary table.
+      - name: "Resolve source docker images (vllm/media/forge)"
+        id: source-images
+        env:
+          GH_TOKEN: ${{ secrets.TMP_VCANKOVIC_SHIELD_CRANE_PAT }}
+        run: |
+          python3 scripts/release/resolve_release_source_images.py \
+            --run-id "${TT_SHIELD_RUN_ID}" --json > "${RUNNER_TEMP}/source_images.json"
+          cat "${RUNNER_TEMP}/source_images.json"
+
+          # Expose one output per engine family (value or the literal "None").
+          for fam in vllm media forge; do
+            val=$(python3 -c "import json;print(json.load(open('${RUNNER_TEMP}/source_images.json'))['images']['$fam'] or 'None')")
+            echo "${fam}=${val}" >> "$GITHUB_OUTPUT"
+          done
+
+          # Human-readable summary on the run page.
+          {
+            echo "## Resolve source docker images (tt-shield run ${TT_SHIELD_RUN_ID})"
+            echo
+            echo "| Engine | Source dev image |"
+            echo "|--------|------------------|"
+            for fam in vllm media forge; do
+              val=$(python3 -c "import json;print(json.load(open('${RUNNER_TEMP}/source_images.json'))['images']['$fam'] or 'None')")
+              echo "| ${fam} | \`${val}\` |"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ----- Map each source dev image to the tt-inference-server RELEASE image
+      #       to publish, and emit the publish plan (source -> destination) as
+      #       step outputs + a crane-copy preview.
+      #         vllm  -> ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:<ver>-<ttm>-<vllm>
+      #         media -> ghcr.io/tenstorrent/tt-media-inference-server:<ver>-<ttm>
+      #         forge -> ghcr.io/tenstorrent/tt-media-inference-server-forge:<ver>-<ttm>
+      - name: "Map source -> target docker images to publish"
+        id: image-mapping
+        env:
+          SRC_VLLM: ${{ steps.source-images.outputs.vllm }}
+          SRC_MEDIA: ${{ steps.source-images.outputs.media }}
+          SRC_FORGE: ${{ steps.source-images.outputs.forge }}
+        run: |
+          # Destination tags built from the release inputs (mirrors
+          # generate_default_docker_link; commits truncated to 12 like it does).
+          VER="${RELEASE_VERSION}"
+          TTM="${TT_METAL_COMMIT:0:12}"
+          VLL="${VLLM_COMMIT:0:12}"
+          DST_VLLM="ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:${VER}-${TTM}-${VLL}"
+          DST_MEDIA="ghcr.io/tenstorrent/tt-media-inference-server:${VER}-${TTM}"
+          DST_FORGE="ghcr.io/tenstorrent/tt-media-inference-server-forge:${VER}-${TTM}"
+
+          # No source built for a family -> nothing to publish for it.
+          [ "$SRC_VLLM" = "None" ] && DST_VLLM="None"
+          [ "$SRC_MEDIA" = "None" ] && DST_MEDIA="None"
+          [ "$SRC_FORGE" = "None" ] && DST_FORGE="None"
+
+          # Publish plan as step outputs (source + destination per family).
+          {
+            echo "vllm_source=$SRC_VLLM";   echo "vllm_dest=$DST_VLLM"
+            echo "media_source=$SRC_MEDIA"; echo "media_dest=$DST_MEDIA"
+            echo "forge_source=$SRC_FORGE"; echo "forge_dest=$DST_FORGE"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "vllm : $SRC_VLLM -> $DST_VLLM"
+          echo "media: $SRC_MEDIA -> $DST_MEDIA"
+          echo "forge: $SRC_FORGE -> $DST_FORGE"
+
+          # Summary table + crane-copy preview (NOT executed here).
+          {
+            echo "## Release image publish plan (v${VER})"
+            echo
+            echo "| Engine | Source (tt-shield dev) | Destination (tt-inference-server release) |"
+            echo "|--------|------------------------|-------------------------------------------|"
+            echo "| vllm  | \`$SRC_VLLM\` | \`$DST_VLLM\` |"
+            echo "| media | \`$SRC_MEDIA\` | \`$DST_MEDIA\` |"
+            echo "| forge | \`$SRC_FORGE\` | \`$DST_FORGE\` |"
+            echo
+            echo "_Release-scoped crane copy commands are shown by the 'crane copy simulation' step below._"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ----- Install crane (google/go-containerregistry) — used to promote the
+      #       release images from tt-shield to tt-inference-server
+      - name: "Install crane"
+        run: |
+          curl -fsSL "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+            | sudo tar -xzf - -C /usr/local/bin crane
+          crane version
+
+      # ----- REAL crane login to ghcr.io (README_MANUAL pattern), as
+      #       vcankovicTT with the TMP_VCANKOVIC_SHIELD_CRANE_PAT secret (a PAT
+      #       with read:packages for tt-shield + write:packages for
+      #       tt-inference-server). Login is real (the crane copy below is only
+      #       simulated). Verifies the login and, if a source image resolved,
+      #       that the token can actually PULL it (needs read:packages) — a read
+      #       failure is warned, not fatal, since this iteration only simulates. -----
+      - name: "crane login to ghcr.io (real) + verify"
+        env:
+          CRANE_USER: vcankovicTT
+          CRANE_PAT: ${{ secrets.TMP_VCANKOVIC_SHIELD_CRANE_PAT }}
+          SRC_VLLM: ${{ steps.image-mapping.outputs.vllm_source }}
+          SRC_MEDIA: ${{ steps.image-mapping.outputs.media_source }}
+          SRC_FORGE: ${{ steps.image-mapping.outputs.forge_source }}
+        run: |
+          # Password via stdin so the token is never in the process args.
+          printf '%s' "$CRANE_PAT" | crane auth login ghcr.io -u "$CRANE_USER" --password-stdin
+          echo "✅ crane auth login ghcr.io succeeded as ${CRANE_USER}"
+
+          # Prove the token can pull a real source image (needs read:packages).
+          for src in "$SRC_VLLM" "$SRC_MEDIA" "$SRC_FORGE"; do
+            [ "$src" = "None" ] && continue
+            if crane manifest "$src" >/dev/null 2>&1; then
+              echo "✅ verified pull: $src"
+            else
+              echo "::warning::crane could not pull '$src' — the PAT likely lacks read:packages; crane copy would fail."
+            fi
+            break
+          done
+
+      # ----- SIMULATION: print the crane copy commands that WOULD publish the
+      #       release images, gated by which ENGINE FAMILIES the current release
+      #       actually ships (from models-ci-config.json release entries, via the
+      #       InferenceEngine enum — same rule as generate_default_docker_link).
+      #       A family is copied only if it is in the release AND a source image
+      #       was built. Nothing is executed (dry-run). -----
+      - name: "crane copy preparation (dry-run)"
+        env:
+          SRC_VLLM: ${{ steps.image-mapping.outputs.vllm_source }}
+          DST_VLLM: ${{ steps.image-mapping.outputs.vllm_dest }}
+          SRC_MEDIA: ${{ steps.image-mapping.outputs.media_source }}
+          DST_MEDIA: ${{ steps.image-mapping.outputs.media_dest }}
+          SRC_FORGE: ${{ steps.image-mapping.outputs.forge_source }}
+          DST_FORGE: ${{ steps.image-mapping.outputs.forge_dest }}
+        run: |
+          # Engine families the current release ships (reuses InferenceEngine).
+          # Single-line python so YAML block indentation can't corrupt it.
+          RELEASE_FAMS=$(python3 -c "import json,sys; sys.path.insert(0,'.'); from workflows.workflow_types import InferenceEngine as E; c=json.load(open('.github/workflows/models-ci-config.json')); print(' '.join(sorted({E.from_string(i['inference_engine']).value.lower() for _n,e in c['models'].items() for i in e.get('implementations',[e]) if i.get('ci',{}).get('release')})))")
+          echo "Release engine families: ${RELEASE_FAMS:-<none>}"
+          echo
+
+          in_release() { for f in $RELEASE_FAMS; do [ "$f" = "$1" ] && return 0; done; return 1; }
+
+          copy_cmds=""
+          for fam in vllm media forge; do
+            case "$fam" in
+              vllm)  src="$SRC_VLLM";  dst="$DST_VLLM";;
+              media) src="$SRC_MEDIA"; dst="$DST_MEDIA";;
+              forge) src="$SRC_FORGE"; dst="$DST_FORGE";;
+            esac
+            if ! in_release "$fam"; then
+              echo "# skip ${fam}: no ${fam} models in this release"
+            elif [ "$src" = "None" ] || [ -z "$src" ] || [ "$dst" = "None" ]; then
+              echo "# skip ${fam}: release ships ${fam} models but no source image was built (UNKNOWN)"
+            else
+              cmd="crane copy ${src} ${dst}"
+              echo "${cmd}"
+              copy_cmds="${copy_cmds}${cmd}"$'\n'
+            fi
+          done
+
+          {
+            echo "## crane copy simulation — release-scoped (v${RELEASE_VERSION}, DRY-RUN)"
+            echo
+            echo "Release engine families: \`${RELEASE_FAMS:-<none>}\`"
+            echo
+            echo "Commands that WOULD run (not executed):"
+            echo '```bash'
+            if [ -n "$copy_cmds" ]; then printf '%s' "$copy_cmds"; else echo "# (nothing to publish)"; fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ===== TEMPORARY — REMOVE AFTER A SUCCESSFUL TEST RUN ==================
+      # One REAL crane copy (actually pushes) of the media source image to a
+      # throwaway tt-inference-server test repo, purely to confirm crane copy /
+      # write:packages works end-to-end. It uses the login from the crane-login
+      # step above (persisted in ~/.docker/config.json within this job). It does
+      # NOT read or change the real media mapping/simulation — the destination is
+      # hardcoded here. Delete this whole step once the copy is verified.
+      - name: "TEMP: real crane copy test (media -> tt-media-server-dev test repo)"
+        env:
+          SRC_MEDIA: ${{ steps.image-mapping.outputs.media_source }}
+        run: |
+          if [ -z "$SRC_MEDIA" ] || [ "$SRC_MEDIA" = "None" ]; then
+            echo "No media source image resolved — skipping crane copy test."
+            exit 0
+          fi
+          DST_TEST="ghcr.io/tenstorrent/tt-inference-server/tt-media-server-dev-ubuntu-22.04-amd64:${RELEASE_VERSION}-${TT_METAL_COMMIT}"
+          echo "TEST crane copy:"
+          echo "  src: ${SRC_MEDIA}"
+          echo "  dst: ${DST_TEST}"
+          crane copy "${SRC_MEDIA}" "${DST_TEST}"
+          echo "✅ crane copy test succeeded -> ${DST_TEST}"
+      # ===== END TEMPORARY ==================================================
+
+      # ----- Post-release branch off main. Branches from origin/main, carries this branch's VERSION
+      #       + models-ci-config.json onto it, RE-RUNS the same four generators
+      #       there, then commits everything in ONE commit and pushes.
+      - name: "Post-release: branch from main + carry VERSION/config"
+        env:
+          SRC_REF: ${{ github.ref_name }}
+        run: |
+          NEW_BRANCH="post-release-v${RELEASE_VERSION}${POST_RELEASE_SUFFIX}"
+          {
+            echo "POST_RELEASE_BRANCH=${NEW_BRANCH}"
+            echo "POST_RELEASE_SRC_REF=${SRC_REF}"
+          } >> "$GITHUB_ENV"
+          echo "Creating '${NEW_BRANCH}' from main, carrying VERSION + models-ci-config.json from '${SRC_REF}'."
+
+          # Stash the carried files + the PR script (the post-release branch is
+          # main-based and won't contain this script) outside the repo before
+          # switching branches.
+          cp VERSION "${RUNNER_TEMP}/VERSION.carry"
+          cp .github/workflows/models-ci-config.json "${RUNNER_TEMP}/models-ci-config.json.carry"
+          cp scripts/release/create_post_release_pr.py "${RUNNER_TEMP}/create_post_release_pr.py"
+
+          # Branch off the latest main, then overlay the carried files.
+          git fetch origin main
+          git checkout -b "${NEW_BRANCH}" FETCH_HEAD
+          cp "${RUNNER_TEMP}/VERSION.carry" VERSION
+          cp "${RUNNER_TEMP}/models-ci-config.json.carry" .github/workflows/models-ci-config.json
+
+      - name: "Post-release: regenerate artifacts (same 4 steps, on post-release branch)"
+        run: |
+          python -m pip install -r requirements-dev.txt
+          python3 scripts/release/promote_dev_spec_to_prod.py \
+            --version "${RELEASE_VERSION}" \
+            --tt-metal-commit "${TT_METAL_COMMIT}" \
+            --vllm-commit "${VLLM_COMMIT}"
+          python3 scripts/release/export_model_spec.py
+          python -m workflows.helm_generator
+          helm-docs \
+            --chart-search-root=charts/tt-inference-server \
+            --template-files=_supportedModels.gotmpl \
+            --template-files=README.md.gotmpl
+
+      - name: "Post-release: commit + push the branch"
+        # ONE commit: carried VERSION/config + all regenerated artifacts.
+        # Force so re-runs replace the throwaway branch instead of failing.
+        run: |
+          git add .
+          if git diff --cached --quiet; then
+            echo "No changes vs main — pushing '${POST_RELEASE_BRANCH}' at main's tip."
+          else
+            git commit -m "post-release v${RELEASE_VERSION}${POST_RELEASE_SUFFIX}: carry VERSION/models-ci-config.json + regenerate prod specs, docs & helm (from ${POST_RELEASE_SRC_REF})"
+          fi
+          git push -f origin "${POST_RELEASE_BRANCH}"
+          echo "Pushed '${POST_RELEASE_BRANCH}'."
+
+      # ----- FINAL step: open the draft "Post release v<version>" PR
+      #       (post-release branch -> main) in the PR #4398 format.
+      - name: "Post-release: open draft PR -> main"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TMP_VCANKOVIC_SHIELD_CRANE_PAT: ${{ secrets.TMP_VCANKOVIC_SHIELD_CRANE_PAT }}
+        run: |
+          cp "${RUNNER_TEMP}/create_post_release_pr.py" scripts/release/create_post_release_pr.py
+          python3 scripts/release/create_post_release_pr.py \
+            --tt-shield-run-id "${TT_SHIELD_RUN_ID}" \
+            --head-branch "${POST_RELEASE_BRANCH}" \
+            --base main

--- a/scripts/release/create_post_release_pr.py
+++ b/scripts/release/create_post_release_pr.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -66,6 +67,14 @@ STATIC_SW_VERSIONS = (
     "- Firmware: 19.8.1\n"
     "- tt-kmd: 2.7.0\n"
 )
+
+
+def _safe_repo_path(p) -> Path:
+    """Resolve a supplied path and confine it to the repo root (guards path traversal)."""
+    resolved = Path(p).expanduser().resolve()
+    if resolved != REPO_ROOT and REPO_ROOT not in resolved.parents:
+        sys.exit(f"ERROR: path '{resolved}' is outside the repository root {REPO_ROOT}")
+    return resolved
 
 
 # ---------------------------------------------------------------------------
@@ -123,8 +132,9 @@ def _parse_catalogue(text: str) -> list[dict]:
 
 
 def load_prod_blocks_from_dir(prod_dir: Path) -> list[dict]:
+    prod_dir = _safe_repo_path(prod_dir)
     blocks: list[dict] = []
-    for f in sorted(Path(prod_dir).glob("*.yaml")):
+    for f in sorted(prod_dir.glob("*.yaml")):
         blocks += _parse_catalogue(f.read_text())
     return blocks
 
@@ -346,7 +356,7 @@ def render_body(version: str, rows) -> str:
 # CLI
 # ---------------------------------------------------------------------------
 def read_version(version_file: Path) -> str:
-    return version_file.read_text().strip()
+    return _safe_repo_path(version_file).read_text().strip()
 
 
 def current_branch() -> str:
@@ -359,6 +369,14 @@ def current_branch() -> str:
 
 
 def create_pr(repo, base, head, title, body) -> None:
+    # Validate the values that flow into the gh command. The call is list-form
+    # (not shell-interpreted), but validate anyway as defence-in-depth.
+    if not re.fullmatch(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+", repo):
+        sys.exit(f"ERROR: invalid repo '{repo}'")
+    if not re.fullmatch(r"[A-Za-z0-9._/-]+", base) or not re.fullmatch(
+        r"[A-Za-z0-9._/-]+", head
+    ):
+        sys.exit("ERROR: invalid branch ref for --base/--head")
     with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
         fh.write(body)
         body_path = fh.name
@@ -443,7 +461,9 @@ def main() -> None:
     combos = collect_release_combos(ci_config)
 
     new_blocks = load_prod_blocks_from_dir(args.prod_dir)
-    prod_filenames = [f.name for f in sorted(Path(args.prod_dir).glob("*.yaml"))]
+    prod_filenames = [
+        f.name for f in sorted(_safe_repo_path(args.prod_dir).glob("*.yaml"))
+    ]
     old_blocks = load_prod_blocks_from_ref(args.base_ref, prod_filenames)
 
     # CI jobs (best-effort; UNKNOWN on any failure).

--- a/scripts/release/create_post_release_pr.py
+++ b/scripts/release/create_post_release_pr.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+"""
+create_post_release_pr.py
+=========================
+
+Open a DRAFT "Post release v<version>" PR from the post-release branch into ``main``
+
+The body has four sections:
+
+  # Summary of Changes           -> header + placeholder (filled in manually)
+  # SW versions recommended ...   -> static (tt-smi / Firmware / tt-kmd)
+  # Model Spec Release Updates    -> AUTO-GENERATED table (the tricky part)
+  # Release Artifacts Summary     -> header + placeholder (filled in manually)
+
+The "Model Spec Release Updates" table has one row per (model, device) release
+combo taken from ``.github/workflows/models-ci-config.json`` (the ``ci.release``
+entries), matched to its ``workflows/model_specs/prod/*.yaml`` block. Columns:
+
+  Impl                   <- prod block ``impl:``
+  Model Arch             <- the models-ci-config.json model key
+  Weights                <- prod block ``weights:`` (all, <br>-joined)
+  Devices                <- the release device from models-ci-config.json
+  TT-Metal Commit Change <- old->new (old = base branch's prod; new = this branch)
+                            "`old` -> `new`" if changed, else "`new`"
+  Status Change          <- "No change [STATUS]" if unchanged, else the new STATUS
+                            (a newly-added model/device shows the new status alone)
+  CI Job Link            <- [CI Link](.../runs/<run-id>/job/<job-id>) resolved from
+                            the tt-shield run's ``run-release-<model>-...-<device>`` job
+
+Any value that cannot be computed is rendered as ``UNKNOWN``.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+from workflows.workflow_types import DeviceTypes, InferenceEngine  # noqa: E402
+
+DEFAULT_CI_CONFIG = REPO_ROOT / ".github" / "workflows" / "models-ci-config.json"
+DEFAULT_PROD_DIR = REPO_ROOT / "workflows" / "model_specs" / "prod"
+DEFAULT_VERSION_FILE = REPO_ROOT / "VERSION"
+DEFAULT_REPO = "tenstorrent/tt-inference-server"
+DEFAULT_TT_SHIELD_REPO = "tenstorrent/tt-shield"
+TOKEN_ENV_VARS = ("TMP_VCANKOVIC_SHIELD_CRANE_PAT", "GH_PAT", "GITHUB_TOKEN")
+UNKNOWN = "UNKNOWN"
+
+STATIC_SW_VERSIONS = (
+    "# SW versions recommended for Wormhole Galaxy:\n\n"
+    "- tt-smi: 4.0.0\n"
+    "- Firmware: 19.8.1\n"
+    "- tt-kmd: 2.7.0\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# release scope (mirrors promote_dev_spec_to_prod.py)
+# ---------------------------------------------------------------------------
+def iter_implementations(model_entry: dict):
+    """Yield each implementation dict (flat or implementations:[...] shape)."""
+    if "implementations" in model_entry:
+        yield from model_entry["implementations"]
+    else:
+        yield model_entry
+
+
+def model_name_from_weight(weight: str) -> str:
+    return Path(weight).name
+
+
+def collect_release_combos(
+    ci_config: dict,
+) -> list[tuple[str, InferenceEngine, DeviceTypes]]:
+    """Ordered, de-duplicated list of (model_name, engine, device) marked release."""
+    combos: list[tuple[str, InferenceEngine, DeviceTypes]] = []
+    seen: set = set()
+    for model_name, entry in ci_config.get("models", {}).items():
+        for impl in iter_implementations(entry):
+            release = impl.get("ci", {}).get("release")
+            if not release:
+                continue
+            try:
+                engine = InferenceEngine.from_string(impl["inference_engine"])
+            except (ValueError, KeyError):
+                engine = None
+            for device in release.get("devices", []):
+                try:
+                    dev = DeviceTypes.from_string(device)
+                except ValueError:
+                    continue
+                key = (model_name, engine, dev)
+                if key not in seen:
+                    seen.add(key)
+                    combos.append((model_name, engine, dev))
+    return combos
+
+
+# ---------------------------------------------------------------------------
+# prod catalogue parsing
+# ---------------------------------------------------------------------------
+def _parse_catalogue(text: str) -> list[dict]:
+    data = yaml.safe_load(text)
+    if isinstance(data, dict):
+        data = data.get("templates") or next(
+            (v for v in data.values() if isinstance(v, list)), []
+        )
+    return [b for b in (data or []) if isinstance(b, dict)]
+
+
+def load_prod_blocks_from_dir(prod_dir: Path) -> list[dict]:
+    blocks: list[dict] = []
+    for f in sorted(Path(prod_dir).glob("*.yaml")):
+        blocks += _parse_catalogue(f.read_text())
+    return blocks
+
+
+def load_prod_blocks_from_ref(ref: str, prod_filenames: list[str]) -> list[dict]:
+    blocks: list[dict] = []
+    for name in prod_filenames:
+        try:
+            text = subprocess.run(
+                ["git", "show", f"{ref}:workflows/model_specs/prod/{name}"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout
+        except subprocess.CalledProcessError:
+            continue  # file absent on that ref
+        blocks += _parse_catalogue(text)
+    return blocks
+
+
+def _block_engine(block: dict):
+    try:
+        return InferenceEngine.from_string(block.get("inference_engine", ""))
+    except (ValueError, KeyError):
+        return None
+
+
+def _block_devices(block: dict) -> set:
+    out = set()
+    for d in block.get("device_model_specs", []) or []:
+        try:
+            out.add(DeviceTypes.from_string(d.get("device", "")))
+        except ValueError:
+            pass
+    return out
+
+
+def _block_models(block: dict) -> set:
+    return {model_name_from_weight(w) for w in block.get("weights", []) or []}
+
+
+def find_block(blocks, model_name, engine, device) -> dict | None:
+    """First block that provides (model_name, engine) on `device`.
+
+    Matches by device MEMBERSHIP (not the exact device-set), so a block that
+    bundles extra devices still matches the specific release device.
+    """
+    for b in blocks:
+        if (
+            model_name in _block_models(b)
+            and _block_engine(b) == engine
+            and device in _block_devices(b)
+        ):
+            return b
+    return None
+
+
+# ---------------------------------------------------------------------------
+# CI job links (tenstorrent/tt-shield)
+# ---------------------------------------------------------------------------
+def resolve_token(explicit: str | None) -> str | None:
+    if explicit:
+        return explicit
+    for name in TOKEN_ENV_VARS:
+        val = os.environ.get(name)
+        if val:
+            return val
+    return None
+
+
+def fetch_run_jobs(repo: str, run_id: str, token: str) -> list[dict] | None:
+    """All jobs of a workflow run, or None if unreachable (no access/expired)."""
+    owner_repo = repo
+    jobs: list[dict] = []
+    page = 1
+    while True:
+        url = (
+            f"https://api.github.com/repos/{owner_repo}/actions/runs/{run_id}"
+            f"/jobs?per_page=100&page={page}"
+        )
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "create-post-release-pr",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                data = json.loads(resp.read())
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError):
+            return None
+        batch = data.get("jobs", [])
+        jobs += batch
+        if len(batch) < 100 or page >= 15:
+            break
+        page += 1
+    return jobs
+
+
+def ci_job_url(
+    jobs, repo: str, run_id: str, model_name: str, device: DeviceTypes
+) -> str | None:
+    """URL of the run-release-<model>-<runner>-<device> job for this combo."""
+    if not jobs:
+        return None
+    token = device.name.lower()  # device token used in tt-shield job names
+    prefix = f"run-release-{model_name}-"
+    for job in jobs:
+        leaf = job.get("name", "").split("/")[-1].strip()
+        if leaf.startswith(prefix) and leaf.endswith(f"-{token}"):
+            return f"https://github.com/{repo}/actions/runs/{run_id}/job/{job['id']}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# row model + rendering
+# ---------------------------------------------------------------------------
+def build_rows(new_blocks, old_blocks, combos, jobs, tt_shield_repo, run_id):
+    rows = []
+    seen: set = set()
+    for model_name, engine, device in combos:
+        new_b = find_block(new_blocks, model_name, engine, device)
+        old_b = find_block(old_blocks, model_name, engine, device)
+
+        # De-duplicate: one row per (prod block weights+engine, device). A block
+        # bundling several weights (e.g. whisper) yields a single row.
+        ident_block = new_b or old_b
+        weights = tuple((ident_block or {}).get("weights", []) or [])
+        dedup_key = (weights, engine, device)
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+
+        rows.append(
+            {
+                "impl": (new_b or old_b or {}).get("impl"),
+                "model_arch": model_name,
+                "weights": list(weights),
+                "device": device,
+                "tt_before": (old_b or {}).get("tt_metal_commit"),
+                "tt_after": (new_b or {}).get("tt_metal_commit"),
+                "status_before": (old_b or {}).get("status"),
+                "status_after": (new_b or {}).get("status"),
+                "ci_url": ci_job_url(jobs, tt_shield_repo, run_id, model_name, device)
+                if (jobs and run_id)
+                else None,
+            }
+        )
+    return rows
+
+
+def _commit_cell(before, after) -> str:
+    if after and before:
+        return f"`{before}` → `{after}`" if before != after else f"`{after}`"
+    if after:
+        return f"`{after}`"  # new model/device: new value only
+    return UNKNOWN
+
+
+def _status_cell(before, after) -> str:
+    if not after:
+        return UNKNOWN
+    if before and before == after:
+        return f"No change [{after}]"
+    return f"{after}"  # changed, or newly added -> the new status alone
+
+
+def _weights_cell(weights) -> str:
+    return "<br>".join(f"`{w}`" for w in weights) if weights else UNKNOWN
+
+
+def render_table(rows) -> str:
+    lines = [
+        "# Model Spec Release Updates\n",
+        "\nThis document shows model specification updates.\n",
+    ]
+    if not rows:
+        lines.append("\nNo model specification updates were detected.\n")
+        return "\n".join(lines)
+    lines.append(
+        "| Impl | Model Arch | Weights | Devices | TT-Metal Commit Change | Status Change | CI Job Link |"
+    )
+    lines.append(
+        "|------|------------|---------|---------|------------------------|---------------|-------------|"
+    )
+    for r in rows:
+        impl = f"`{r['impl']}`" if r["impl"] else UNKNOWN
+        arch = f"`{r['model_arch']}`" if r["model_arch"] else UNKNOWN
+        weights = _weights_cell(r["weights"])
+        device = r["device"].name if r["device"] else UNKNOWN
+        commit = _commit_cell(r["tt_before"], r["tt_after"])
+        status = _status_cell(r["status_before"], r["status_after"])
+        ci = f"[CI Link]({r['ci_url']})" if r["ci_url"] else UNKNOWN
+        lines.append(
+            f"| {impl} | {arch} | {weights} | {device} | {commit} | {status} | {ci} |"
+        )
+    return "\n".join(lines)
+
+
+def render_body(version: str, rows) -> str:
+    return (
+        "# Summary of Changes\n\n"
+        "<!-- Fill in the summary of changes manually. -->\n"
+        "- placeholder\n\n\n"
+        + STATIC_SW_VERSIONS
+        + "\n"
+        + render_table(rows)
+        + "\n\n\n# Release Artifacts Summary\n\n"
+        "## Images Promoted from Models CI\n\n"
+        "<!-- Add promoted image paths manually. -->\n\n"
+        "**Total:** \n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def read_version(version_file: Path) -> str:
+    return version_file.read_text().strip()
+
+
+def current_branch() -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def create_pr(repo, base, head, title, body) -> None:
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
+        fh.write(body)
+        body_path = fh.name
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                repo,
+                "--base",
+                base,
+                "--head",
+                head,
+                "--draft",
+                "--title",
+                title,
+                "--body-file",
+                body_path,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            sys.exit(f"ERROR: `gh pr create` failed:\n{proc.stderr}")
+        print(proc.stdout.strip())
+    finally:
+        os.unlink(body_path)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Open a draft 'Post release v<version>' PR (post-release branch -> main).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "--version", default=None, help="Release version (default: read VERSION file)"
+    )
+    ap.add_argument("--version-file", type=Path, default=DEFAULT_VERSION_FILE)
+    ap.add_argument(
+        "--tt-shield-run-id",
+        default=None,
+        help="tt-shield Release run id (for CI Job Links)",
+    )
+    ap.add_argument("--tt-shield-repo", default=DEFAULT_TT_SHIELD_REPO)
+    ap.add_argument("--ci-config", type=Path, default=DEFAULT_CI_CONFIG)
+    ap.add_argument(
+        "--prod-dir",
+        type=Path,
+        default=DEFAULT_PROD_DIR,
+        help="'new' prod catalogue (this branch's working tree)",
+    )
+    ap.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="git ref for 'old' prod + PR base history (default: origin/main)",
+    )
+    ap.add_argument("--base", default="main", help="PR base branch")
+    ap.add_argument(
+        "--head-branch", default=None, help="PR head branch (default: current branch)"
+    )
+    ap.add_argument("--repo", default=DEFAULT_REPO, help="Repo to open the PR on")
+    ap.add_argument(
+        "--token",
+        default=None,
+        help="Token for tt-shield reads (default: env TMP_VCANKOVIC_SHIELD_CRANE_PAT/GH_PAT/GITHUB_TOKEN)",
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true", help="Print the body; do not open a PR"
+    )
+    ap.add_argument(
+        "--output", type=Path, default=None, help="Also write the body to this file"
+    )
+    args = ap.parse_args()
+
+    version = args.version or read_version(args.version_file)
+    head_branch = args.head_branch or current_branch()
+    title = f"Post release v{version}"
+
+    ci_config = json.loads(args.ci_config.read_text())
+    combos = collect_release_combos(ci_config)
+
+    new_blocks = load_prod_blocks_from_dir(args.prod_dir)
+    prod_filenames = [f.name for f in sorted(Path(args.prod_dir).glob("*.yaml"))]
+    old_blocks = load_prod_blocks_from_ref(args.base_ref, prod_filenames)
+
+    # CI jobs (best-effort; UNKNOWN on any failure).
+    jobs = None
+    if args.tt_shield_run_id:
+        token = resolve_token(args.token)
+        if token:
+            jobs = fetch_run_jobs(args.tt_shield_repo, args.tt_shield_run_id, token)
+            if jobs is None:
+                print(
+                    "WARNING: could not read tt-shield jobs (no access / expired); "
+                    "CI Job Link cells will be UNKNOWN.",
+                    file=sys.stderr,
+                )
+        else:
+            print(
+                "WARNING: no token (TMP_VCANKOVIC_SHIELD_CRANE_PAT/GH_PAT/GITHUB_TOKEN); "
+                "CI Job Link cells will be UNKNOWN.",
+                file=sys.stderr,
+            )
+    else:
+        print(
+            "WARNING: --tt-shield-run-id not given; CI Job Link cells will be UNKNOWN.",
+            file=sys.stderr,
+        )
+
+    rows = build_rows(
+        new_blocks, old_blocks, combos, jobs, args.tt_shield_repo, args.tt_shield_run_id
+    )
+    body = render_body(version, rows)
+
+    print(f"Version:      {version}", file=sys.stderr)
+    print(f"Title:        {title}", file=sys.stderr)
+    print(f"Head -> Base: {head_branch} -> {args.base}", file=sys.stderr)
+    print(f"Release rows: {len(rows)}", file=sys.stderr)
+
+    if args.output:
+        args.output.write_text(body)
+        print(f"Wrote body to {args.output}", file=sys.stderr)
+
+    if args.dry_run:
+        print(body)
+        return
+
+    create_pr(args.repo, args.base, head_branch, title, body)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/resolve_release_source_images.py
+++ b/scripts/release/resolve_release_source_images.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+"""
+resolve_release_source_images.py
+================================
+
+From a tenstorrent/tt-shield "Release" Actions run, resolve the three SOURCE dev
+images produced by the run's build jobs, grouped by engine family:
+
+    vllm   <- build job "build-tt-inference-server"
+    media  <- build job "build-media-inference-server"
+    forge  <- build job "build-forge-media-inference-server"
+
+Usage
+-----
+    # human-readable
+    python3 scripts/release/resolve_release_source_images.py --run-id 29037835062
+
+    # machine-readable (for a later publish step to consume)
+    python3 scripts/release/resolve_release_source_images.py --run-id 29037835062 --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+DEFAULT_REPO = "tenstorrent/tt-shield"
+
+# Build-job caller segment  ->  engine family. Order does not matter; matched by
+# exact segment equality so build-forge-media / build-blaze-media never collide
+# with build-media.
+BUILD_JOB_FAMILY = {
+    "build-tt-inference-server": "vllm",
+    "build-media-inference-server": "media",
+    "build-forge-media-inference-server": "forge",
+}
+FAMILIES = ("vllm", "media", "forge")
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+# The build jobs write `dev-image-tag=<url>` (summary/output) and
+# `dev_image_tag=<url>` (GITHUB_OUTPUT); accept either separator. Capture the
+# ghcr.io reference up to the first quote / space / comma.
+_TAG_RE = re.compile(r"dev[-_]image[-_]tag=\s*(ghcr\.io/[^\s\"',]+)")
+
+
+def run_gh(args: list[str], binary: bool = False):
+    """Run a `gh` command, exiting with its stderr on failure."""
+    proc = subprocess.run(["gh", *args], capture_output=True)
+    if proc.returncode != 0:
+        sys.exit(
+            f"ERROR: `gh {' '.join(args)}` failed (exit {proc.returncode}):\n"
+            + proc.stderr.decode(errors="replace")
+        )
+    return proc.stdout if binary else proc.stdout.decode()
+
+
+def list_jobs(repo: str, run_id: str) -> list[dict]:
+    """All jobs of a run as [{id, name}, ...]."""
+    out = run_gh(
+        [
+            "api",
+            "--paginate",
+            f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100",
+            "--jq",
+            ".jobs[] | {id, name}",
+        ]
+    )
+    return [json.loads(line) for line in out.splitlines() if line.strip()]
+
+
+def job_family(job_name: str) -> str | None:
+    """Return the engine family for a build job, or None if it isn't one.
+
+    Matches any '/'-separated segment of the job name against BUILD_JOB_FAMILY
+    by exact equality (so build-forge-media / build-blaze-media don't collide
+    with build-media-inference-server)."""
+    for seg in (s.strip() for s in job_name.split("/")):
+        if seg in BUILD_JOB_FAMILY:
+            return BUILD_JOB_FAMILY[seg]
+    return None
+
+
+def job_log(repo: str, job_id: int) -> str | None:
+    """Download a job's log via gh (which follows the log redirect), or None."""
+    try:
+        return run_gh(["api", f"repos/{repo}/actions/jobs/{job_id}/logs"])
+    except SystemExit:
+        return None
+
+
+def extract_dev_image_tag(log_text: str) -> str | None:
+    """First `dev[-_]image[-_]tag=<ghcr ref>` value in the log, or None."""
+    m = _TAG_RE.search(_ANSI_RE.sub("", log_text))
+    return m.group(1) if m else None
+
+
+def resolve_source_images(repo: str, run_id: str) -> dict[str, dict]:
+    """Return {family: {"image": tag|None, "build_job": name|None, "job_id": id|None}}."""
+    result = {fam: {"image": None, "build_job": None, "job_id": None} for fam in FAMILIES}
+    for job in list_jobs(repo, run_id):
+        fam = job_family(job.get("name", ""))
+        if fam is None or result[fam]["image"] is not None:
+            continue
+        log = job_log(repo, job["id"])
+        tag = extract_dev_image_tag(log) if log else None
+        result[fam] = {"image": tag, "build_job": job.get("name"), "job_id": job["id"]}
+    return result
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Resolve the vllm/media/forge source dev images built by a tt-shield Release run.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--run-id", required=True, help="tt-shield Release Actions run ID")
+    ap.add_argument("--repo", default=DEFAULT_REPO, help=f"GitHub repo (default: {DEFAULT_REPO})")
+    ap.add_argument("--json", action="store_true", help="Emit JSON instead of human-readable text")
+    args = ap.parse_args()
+
+    result = resolve_source_images(args.repo, args.run_id)
+
+    if args.json:
+        # Compact {family: image|None} plus a detailed block for traceability.
+        print(
+            json.dumps(
+                {
+                    "run_id": args.run_id,
+                    "repo": args.repo,
+                    "images": {fam: result[fam]["image"] for fam in FAMILIES},
+                    "detail": result,
+                },
+                indent=2,
+            )
+        )
+        return
+
+    print(f"Repo:   {args.repo}")
+    print(f"Run:    {args.run_id}")
+    print("Source dev images by engine family:")
+    for fam in FAMILIES:
+        image = result[fam]["image"]
+        print(f"  {fam:6s}: {image if image else 'None'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/resolve_release_source_images.py
+++ b/scripts/release/resolve_release_source_images.py
@@ -102,7 +102,9 @@ def extract_dev_image_tag(log_text: str) -> str | None:
 
 def resolve_source_images(repo: str, run_id: str) -> dict[str, dict]:
     """Return {family: {"image": tag|None, "build_job": name|None, "job_id": id|None}}."""
-    result = {fam: {"image": None, "build_job": None, "job_id": None} for fam in FAMILIES}
+    result = {
+        fam: {"image": None, "build_job": None, "job_id": None} for fam in FAMILIES
+    }
     for job in list_jobs(repo, run_id):
         fam = job_family(job.get("name", ""))
         if fam is None or result[fam]["image"] is not None:
@@ -119,8 +121,12 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     ap.add_argument("--run-id", required=True, help="tt-shield Release Actions run ID")
-    ap.add_argument("--repo", default=DEFAULT_REPO, help=f"GitHub repo (default: {DEFAULT_REPO})")
-    ap.add_argument("--json", action="store_true", help="Emit JSON instead of human-readable text")
+    ap.add_argument(
+        "--repo", default=DEFAULT_REPO, help=f"GitHub repo (default: {DEFAULT_REPO})"
+    )
+    ap.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of human-readable text"
+    )
     args = ap.parse_args()
 
     result = resolve_source_images(args.repo, args.run_id)


### PR DESCRIPTION
## Pipeline example of the automatic release flow

https://github.com/tenstorrent/tt-inference-server/actions/runs/29991476797/job/89155116914

## Goal

To automate certain steps from the Release process, which is described in here https://github.com/tenstorrent/tt-inference-server/blob/main/scripts/release/README_MANUAL.md

## High level steps

The pipeline does:

- promotion of `dev` to `prod` catalogue on `stable` branch at the end of release cycle
- generation of the `release_model_spec.json` and docs on the `stable` branch at the end of release cycle
- helm generation and helm docs update at the end of release cycle
- git add and push on `stable` branch at the end of release cycle
- creation of the tag
- download of the release artifacts from the `tt-shield` release run
- crane copy of docker images from `tt-shield` to `tt-inference-server` repository
- creation of the `post-release-vx.x.x branch` that needs to be merged to `main` (automatic creation of the PR in Draft status that will be **manually** reviewed, approved and merged to `main`)

## Summary 
This PR is the initial version of the new .github workflow pipeline for automating the release process. 
Release process will be triggered manually on every 15th and the last day of the month (aligned with the `tt-metal` release cadence).
The new pipeline is intended to be run manually from the tt-inference-server repo, by targeting the `stable` branch.

Initial merge on `main` branch is required so that manual runs can be tested end-to-end, prior the final setup. In order to test manual workflow-dispatch runs, workflow `.yaml` must be present on the `main` branch. 
Further changes are expected, therefore this is not the final version of this pipeline (it still has many static fields hardcoded)

The new logic consists from 3 files:
- new `release-automation.yml` definition, pipeline to be run which manages the whole process
- new helper python script which resolves the docker images that needs to be crane copied from `tt-shield` to `tt-inference-server` repo
- new helper python script which creates and automatically populates the PullRequest for merging the `post-release-vx.x.x` branch to the `main`
