### PR TITLE
Resolve DeviceMap unique_id to UMD device index in buildDeviceIo (#4738)

### DIFF
--- a/tt-media-server/cpp_server/include/transport/umd_device_access.hpp
+++ b/tt-media-server/cpp_server/include/transport/umd_device_access.hpp
@@ -6,10 +6,32 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <unordered_map>
 
 #include "transport/transfer_types.hpp"
 
 namespace tt::transport {
+
+/**
+ * @brief Enumerate the visible UMD devices once, mapping each chip's 64-bit
+ *        ASIC `unique_id` to its 0-based `UmdDevice::open()` index.
+ *
+ * The DeviceMap keys a FabricNode to a chip's stable ASIC `unique_id` (the
+ * third device-map column; see device_map.hpp / print_local_device_map). But
+ * `UmdDeviceAccess`/`UmdDevice::open()` take a 0-based index into the sorted
+ * set of visible MMIO chips, NOT a unique_id — casting the id to an index opens
+ * the wrong chip (or aborts). This resolver bridges the two: enumerate
+ * `count()` chips via `open(i)` + `unique_id()` a single time, so a caller can
+ * translate a device-map unique_id into the index `open()` actually expects.
+ * Mirrors the disaggregation worker's `open_all_devices`
+ * (chip_index_by_unique).
+ *
+ * @note Enumerating opens each visible chip once (the shared UMD Cluster makes
+ *       re-opening cheap); call it ONCE and reuse the map, never per device.
+ * @note The no-tt-metal fallback build returns an empty map (there are no real
+ *       devices to open); a non-empty DeviceMap then resolves to a clean miss.
+ */
+std::unordered_map<uint64_t, int> enumerateUmdDevicesByUniqueId();
 
 /**
  * @brief Access wrapper for TT device DRAM via the UMD (User-Mode Driver).
@@ -60,6 +82,14 @@ class UmdDeviceAccess {
    * @return true on success.
    */
   bool write(NocAddr addr, const void* hostBuffer, std::size_t size);
+
+  /**
+   * @brief Number of DRAM channels (Metal dram_views) on the opened device.
+   * @return the channel count, or 0 if the device failed to open or tt-metal is
+   *         not in this build. A NocAddr's channel must be `<
+   * numDramChannels()`.
+   */
+  uint32_t numDramChannels() const;
 
  private:
   // Hides tt-metal's UmdDevice from this header.

--- a/tt-media-server/cpp_server/src/mooncake_kv_migration_worker_main.cpp
+++ b/tt-media-server/cpp_server/src/mooncake_kv_migration_worker_main.cpp
@@ -22,8 +22,10 @@
 // DeviceMap comes from a localhost socket (--engine-handoff-port) or a
 // --device-map file; socket wins if both are set. Prefill and decode then swap
 // tables over the control channel (TABLE_EXCHANGE / #4295). TE/Mooncake moves
-// KV bytes only. MultiDeviceUmd uses the map; an empty map may use the
-// single-mesh placeholder, but a non-empty map with a missing entry is fatal.
+// KV bytes only. MultiDeviceUmd uses the map, resolving each entry's ASIC
+// unique_id to the device index UMD open() expects; an empty map may use the
+// single-mesh placeholder, but a non-empty map with a missing/unresolvable
+// entry is fatal.
 // KV_MIGRATION_MODE=dry-run keeps discovery, control-table exchange, health,
 // and Kafka active without opening devices or moving KV data.
 
@@ -391,10 +393,14 @@ std::shared_ptr<MooncakeTransferEngine> makeEngine(const WorkerConfig& cfg) {
 }
 
 // One UmdDeviceAccess per device this host owns in `table`.
-// - Non-empty deviceMap: every local device must be present (hard error if
-// not).
-// - Empty deviceMap: single-mesh hosts may use the & 0xFFFF placeholder; a
-//   multi-mesh host with no map is a hard error (cross-mesh collision).
+// - Non-empty deviceMap: the entry's value is a chip's 64-bit ASIC unique_id
+//   (the third device-map column), NOT a device index. It is resolved through
+//   the once-built unique_id -> index lookup into the 0-based index
+//   UmdDevice::open() expects; every local device must resolve (hard error if
+//   not).
+// - Empty deviceMap: single-mesh hosts may use the & 0xFFFF placeholder (which
+//   feeds the raw low 16 bits of the device id straight to open() as an index);
+//   a multi-mesh host with no map is a hard error (cross-mesh collision).
 std::unique_ptr<MultiDeviceUmd> buildDeviceIo(const IKvTable& table,
                                               const std::string& host,
                                               const DeviceMap& deviceMap) {
@@ -418,12 +424,34 @@ std::unique_ptr<MultiDeviceUmd> buildDeviceIo(const IKvTable& table,
     return nullptr;
   }
 
+  // Build the unique_id -> device-index lookup ONCE (enumerating opens every
+  // visible chip). Only map mode consults it; the empty-map placeholder path
+  // never needs it, so skip the enumeration cost there.
+  const std::unordered_map<uint64_t, int> uniqueIdToIndex =
+      deviceMap.empty() ? std::unordered_map<uint64_t, int>{}
+                        : enumerateUmdDevicesByUniqueId();
+
+  // DRAM-channel count per opened device, for the channel-range check below.
+  std::unordered_map<LocalDeviceId, uint32_t> channelsByDevice;
+
   for (const auto& loc : allHostLocations(table, host)) {
     if (umd->hasDevice(loc.device)) continue;
     const auto mapped = deviceMap.umdChip(loc.device);
     int chip = 0;
     if (mapped) {
-      chip = static_cast<int>(*mapped);
+      // Map mode: `*mapped` is the chip's ASIC unique_id — resolve it to the
+      // index open() expects. A miss means the map names a chip not visible on
+      // this host: open nothing and fail cleanly (a wrong index would open the
+      // wrong chip and corrupt KV).
+      const auto it = uniqueIdToIndex.find(*mapped);
+      if (it == uniqueIdToIndex.end()) {
+        TT_LOG_ERROR(
+            "[worker] DeviceMap unique_id {} for device {} (mesh={} chip={}) "
+            "on host '{}' matches no visible UMD device — not opening",
+            *mapped, loc.device, loc.device >> 16, loc.device & 0xFFFFu, host);
+        return nullptr;
+      }
+      chip = it->second;
     } else if (deviceMap.empty()) {
       chip = static_cast<int>(loc.device & 0xFFFFu);
     } else {
@@ -433,7 +461,26 @@ std::unique_ptr<MultiDeviceUmd> buildDeviceIo(const IKvTable& table,
           loc.device, loc.device >> 16, loc.device & 0xFFFFu, host);
       return nullptr;
     }
-    umd->addDevice(loc.device, std::make_shared<UmdDeviceAccess>(chip));
+    auto access = std::make_shared<UmdDeviceAccess>(chip);
+    channelsByDevice[loc.device] = access->numDramChannels();
+    umd->addDevice(loc.device, std::move(access));
+  }
+
+  // Reject KV locations whose NoC channel is out of range for the opened
+  // device — an early catch for a table/device-map mismatch (wrong chip, or a
+  // table built for a different arch) before any migration read/write. A 0
+  // channel count means unknown (open failed / fallback build), so skip.
+  for (const auto& loc : allHostLocations(table, host)) {
+    const auto chIt = channelsByDevice.find(loc.device);
+    if (chIt == channelsByDevice.end() || chIt->second == 0) continue;
+    const uint32_t channel = nocChannel(loc.noc_addr);
+    if (channel >= chIt->second) {
+      TT_LOG_ERROR(
+          "[worker] KV location on device {} (host '{}') uses DRAM channel {} "
+          "but the device has only {} channel(s) — table/device-map mismatch",
+          loc.device, host, channel, chIt->second);
+      return nullptr;
+    }
   }
   return umd;
 }

--- a/tt-media-server/cpp_server/src/transport/README.md
+++ b/tt-media-server/cpp_server/src/transport/README.md
@@ -180,7 +180,12 @@ process, `--role prefill|decode`. The transport-lib pieces it composes:
   socket resolve rejects an empty handoff (no silent placeholder push). Device
   map is **required** when a host's table spans multiple meshes — the
   `& 0xFFFF` placeholder collides across meshes and is refused once a non-empty
-  map is in play. Until the model runner pushes the map itself:
+  map is in play. At open, `buildDeviceIo` resolves each entry's ASIC
+  `umd_chip_id` to the local visible-device index via a one-time enumeration
+  (`enumerateUmdDevicesByUniqueId`); an id matching no visible chip is a clean
+  fail (nothing opened), and a KV location whose NoC channel exceeds the opened
+  chip's DRAM-channel count is rejected as a table/device-map mismatch. Until
+  the model runner pushes the map itself:
 
   ```bash
   mooncake_kv_migration_worker ... --table /tmp/local.pb --engine-handoff-port 18700

--- a/tt-media-server/cpp_server/src/transport/umd_device_access.cpp
+++ b/tt-media-server/cpp_server/src/transport/umd_device_access.cpp
@@ -63,6 +63,47 @@ UmdDeviceAccess::UmdDeviceAccess(UmdDeviceAccess&&) noexcept = default;
 UmdDeviceAccess& UmdDeviceAccess::operator=(UmdDeviceAccess&&) noexcept =
     default;
 
+uint32_t UmdDeviceAccess::numDramChannels() const {
+  return impl_->device == nullptr ? 0u : impl_->device->num_dram_channels();
+}
+
+// Enumerate every visible UMD chip once: open by 0-based index, read its ASIC
+// unique_id, and record unique_id -> index. This is the same eager enumeration
+// the disaggregation worker does in open_all_devices; here we keep only the
+// (unique_id -> index) map so buildDeviceIo can translate a device-map
+// unique_id into the index UmdDevice::open() expects. The opened handles are
+// dropped at loop end — the shared per-process Cluster stays alive, so
+// re-opening the chosen chips later is cheap.
+std::unordered_map<uint64_t, int> enumerateUmdDevicesByUniqueId() {
+  std::unordered_map<uint64_t, int> byUniqueId;
+  const int count = dis::UmdDevice::count();
+  for (int i = 0; i < count; ++i) {
+    try {
+      auto dev = dis::UmdDevice::open(i);
+      if (dev == nullptr) {
+        TT_LOG_WARN("[UmdDeviceAccess] enumerate: open({}) returned null", i);
+        continue;
+      }
+      const uint64_t uid = dev->unique_id();
+      const auto [it, inserted] = byUniqueId.emplace(uid, i);
+      if (!inserted) {
+        TT_LOG_WARN(
+            "[UmdDeviceAccess] enumerate: duplicate unique_id {} at indices {} "
+            "and {}; keeping {}",
+            uid, it->second, i, it->second);
+      }
+    } catch (const std::exception& e) {
+      TT_LOG_WARN("[UmdDeviceAccess] enumerate: open({}) failed: {}", i,
+                  e.what());
+    }
+  }
+  TT_LOG_INFO(
+      "[UmdDeviceAccess] enumerated {} of {} visible device(s) by "
+      "unique_id",
+      byUniqueId.size(), count);
+  return byUniqueId;
+}
+
 bool UmdDeviceAccess::read(NocAddr addr, std::size_t size, void* hostBuffer) {
   if (impl_->device == nullptr) {
     TT_LOG_WARN("[UmdDeviceAccess] read on closed/unopened deviceId={}",
@@ -158,6 +199,17 @@ UmdDeviceAccess::UmdDeviceAccess(UmdDeviceAccess&&) noexcept = default;
 
 UmdDeviceAccess& UmdDeviceAccess::operator=(UmdDeviceAccess&&) noexcept =
     default;
+
+uint32_t UmdDeviceAccess::numDramChannels() const { return 0u; }
+
+// No devices without tt-metal: return an empty map so a non-empty DeviceMap
+// resolves to a clean miss (and buildDeviceIo fails without opening anything).
+std::unordered_map<uint64_t, int> enumerateUmdDevicesByUniqueId() {
+  TT_LOG_WARN(
+      "[UmdDeviceAccess] enumerate by unique_id unavailable (built without "
+      "tt-metal); returning empty map");
+  return {};
+}
 
 bool UmdDeviceAccess::read(NocAddr addr, std::size_t size,
                            void* /*hostBuffer*/) {

--- a/tt-media-server/cpp_server/tests/e2e/TRANSPORT_KV_MIGRATION_E2E.md
+++ b/tt-media-server/cpp_server/tests/e2e/TRANSPORT_KV_MIGRATION_E2E.md
@@ -387,7 +387,11 @@ and the UMD local index equals the table's chip id.
 **not** need a device map. If it byte-mismatches while host mode passes, supply
 one: a file with `mesh chip umd_chip_id` per line, via `DEVICE_MAP=<file>` (or
 `--device-map`). Resolving `umd_chip_id` (ASIC unique id) is a
-CreateDevice-capable step; get it from the engine/tooling for your cluster.
+CreateDevice-capable step; get it from the engine/tooling for your cluster. At
+open, the worker enumerates the visible chips once and maps each `umd_chip_id`
+to its local device index; a value that is a plain local index (not the ASIC
+unique id) or names a chip not visible on the host fails to open rather than
+silently addressing the wrong chip.
 
 **Discovery is NOT required** — the static `--peer-control` list is the control
 endpoint interface; discovery is only its production replacement.
@@ -574,11 +578,15 @@ python3 scripts/migration_cli.py produce --migration-id 702 \
 The worker's `--device-map` uses the same `mesh chip umd_chip_id` file as §9. It
 is **required on the decode side when that host's table spans multiple meshes**:
 the placeholder `chip = chip_id` aliases meshes onto the same physical chips, so
-a multi-layer migration silently overwrites itself — and the worker has no
-self-check to catch it (only `kv_seed_verify` would). Prefill is typically
-single-mesh → no map. Pass the **same** map to the decode worker and to
-`kv_seed_verify --mode verify`. Build it by listing the host's `(mesh, chip)`
-nodes from the table and assigning each a distinct local UMD chip.
+a multi-layer migration silently overwrites itself. The worker's channel-range
+self-check catches a table/device-map mismatch only when a KV location's NoC
+channel exceeds the opened chip's DRAM-channel count; it does **not** catch mesh
+aliasing (only `kv_seed_verify` would). Prefill is typically single-mesh → no
+map. Pass the **same** map to the decode worker and to `kv_seed_verify --mode
+verify`. Build it by listing the host's `(mesh, chip)` nodes from the table and
+giving each its chip's 64-bit ASIC `umd_chip_id` (the same value as §9 /
+`print_local_device_map`), which the worker resolves to the local UMD device
+index at open — do **not** hand-assign a small local index.
 
 ### 13.6 Worker CLI reference
 


### PR DESCRIPTION
The DeviceMap's third column is a chip's 64-bit ASIC unique_id, but UmdDevice::open() takes a 0-based visible-chip index, casting the id straight to an index aborted or opened the wrong chip. Resolve each entry through a once-built unique_id->index lookup (enumerateUmdDevicesByUniqueId), fail cleanly on a miss, and reject KV channels beyond the chip's DRAM-channel count.