### PR TITLE
Dockerize migration worker and cluster deployment script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,9 @@ tt-media-server/Dockerfile.*
 **/node_modules
 **/*.log
 **/*.tmp
+
+# cpp_server local artifacts are large and are never image inputs.
+tt-media-server/cpp_server/build
+tt-media-server/cpp_server/build-*
+tt-media-server/cpp_server/compile_commands.json
+tt-media-server/cpp_server/tt-llm-engine

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -683,11 +683,9 @@ jobs:
     permissions:
       contents: read
     env:
-      # The broker advertises listener as kafka:9092, so the test binary
-      # (running on the runner host, not inside tt_net) redirects to
-      # 'kafka' after its initial connect. /etc/hosts maps kafka ->
-      # 127.0.0.1; keep any injected HTTP proxy out of the loop for it.
-      no_proxy: "localhost,127.0.0.1,::1,kafka"
+      no_proxy: "localhost,127.0.0.1,::1"
+      KAFKA_ADVERTISED_HOST: "127.0.0.1"
+      KAFKA_PUBLISH_ADDRESS: "127.0.0.1"
       CI_CCACHE: "1"
       CCACHE_DIR: ${{ github.workspace }}/tt-media-server/.cache/ccache
     defaults:
@@ -726,21 +724,11 @@ jobs:
           ./build.sh --blaze --kafka
 
       - name: Start dev Kafka broker
-        # KAFKA_PUBLISH_PORT publishes 9092 to the host so the test binary,
-        # which runs on the runner (not inside tt_net), can dial the broker.
-        env:
-          KAFKA_PUBLISH_PORT: "1"
         run: bash cpp_server/scripts/dev-kafka.sh up
-
-      - name: Make 'kafka' resolvable on the runner
-        # advertised.listeners=kafka:9092 means the broker's metadata
-        # response redirects clients to that DNS name after their initial
-        # localhost:9092 connect. Point it at loopback.
-        run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 
       - name: Run remote_kv_manager_e2e_test
         env:
-          KAFKA_BROKERS: "kafka:9092"
+          KAFKA_BROKERS: "127.0.0.1:9092"
         run: ./cpp_server/build/remote_kv_manager_e2e_test
 
       - name: Show Kafka broker logs on failure

--- a/tt-media-server/Dockerfile.migration-worker
+++ b/tt-media-server/Dockerfile.migration-worker
@@ -1,0 +1,143 @@
+# syntax=docker/dockerfile:1.7
+
+ARG TT_LLM_ENGINE_IMAGE
+
+FROM ${TT_LLM_ENGINE_IMAGE} AS engine
+
+FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-light-amd64:latest AS builder
+
+ARG TT_LLM_ENGINE_IMAGE
+ARG TT_INFERENCE_SERVER_COMMIT_SHA=unknown
+
+ENV TT_METAL_HOME=/opt/tt-llm-engine-src/tt-metal \
+    TT_METAL_RUNTIME_ROOT=/opt/tt-llm-engine-src/tt-metal \
+    CMAKE_PREFIX_PATH=/opt/tt-llm-engine:/opt/tt-llm-engine-src/tt-metal/build_Release/lib/cmake:/opt/tt-llm-engine-src/tt-metal/build_Release/_deps/nlohmann_json-build \
+    LD_LIBRARY_PATH=/opt/tt-llm-engine-src/tt-metal/build_Release/lib:/opt/tt-llm-engine-src/tt-metal/build_Release/tt_stl:/opt/tt-llm-engine/lib
+
+COPY --from=engine /opt/tt-llm-engine /opt/tt-llm-engine
+COPY --from=engine /opt/tt-llm-engine-src /opt/tt-llm-engine-src
+
+COPY tt-media-server/cpp_server/install_dependencies.sh /tmp/install_dependencies.sh
+RUN /tmp/install_dependencies.sh --kafka \
+    && apt-get update -qq \
+    && apt-get install -y --no-install-recommends \
+        libasio-dev \
+        libcurl4-openssl-dev \
+        libgflags-dev \
+        libgoogle-glog-dev \
+        libgrpc++-dev \
+        libgrpc-dev \
+        libhiredis-dev \
+        libibverbs-dev \
+        libjemalloc-dev \
+        libmsgpack-dev \
+        libnuma-dev \
+        libprotobuf-dev \
+        libunwind-dev \
+        liburing-dev \
+        libxxhash-dev \
+        libyaml-cpp-dev \
+        libzstd-dev \
+        ninja-build \
+        patchelf \
+        protobuf-compiler \
+        protobuf-compiler-grpc \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY tt-media-server/cpp_server/third_party/Mooncake/extern/yalantinglibs /tmp/yalantinglibs
+RUN cmake -S /tmp/yalantinglibs -B /tmp/yalantinglibs-build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_BENCHMARK=OFF \
+        -DBUILD_EXAMPLES=OFF \
+        -DBUILD_UNIT_TESTS=OFF \
+    && cmake --build /tmp/yalantinglibs-build \
+    && cmake --install /tmp/yalantinglibs-build \
+    && rm -rf /tmp/yalantinglibs /tmp/yalantinglibs-build
+
+WORKDIR /src/cpp_server
+COPY tt-media-server/cpp_server /src/cpp_server
+RUN rm -rf /src/cpp_server/build /src/cpp_server/tt-llm-engine \
+    && ln -s /opt/tt-llm-engine-src /src/cpp_server/tt-llm-engine
+
+RUN --mount=type=cache,id=migration-worker-cmake,target=/work/build \
+    --mount=type=cache,id=migration-worker-ccache,target=/root/.cache/ccache \
+    set -eux; \
+    marker=/work/build/.tt-llm-engine-image; \
+    if [ ! -f "${marker}" ] || [ "$(cat "${marker}")" != "${TT_LLM_ENGINE_IMAGE}" ]; then \
+        rm -rf /work/build/* /work/build/.[!.]* /work/build/..?*; \
+        printf '%s' "${TT_LLM_ENGINE_IMAGE}" > "${marker}"; \
+    fi; \
+    cmake -S /src/cpp_server -B /work/build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -DCMAKE_TOOLCHAIN_FILE="${TT_METAL_HOME}/cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake" \
+        -DTT_METAL_HOME="${TT_METAL_HOME}" \
+        -DENABLE_BLAZE=ON \
+        -DENABLE_KV_TABLE=ON \
+        -DENABLE_MOONCAKE=ON \
+        -DKAFKA_ENABLED=ON; \
+    cmake --build /work/build --target mooncake_kv_migration_worker -j"$(nproc)"; \
+    install -D /work/build/mooncake_kv_migration_worker /out/bin/mooncake_kv_migration_worker; \
+    mkdir -p /out/lib; \
+    ldd /out/bin/mooncake_kv_migration_worker | awk '/=> \// {print $3}' | while read -r library; do \
+        case "${library}" in \
+            /opt/*|/work/*|/src/*|/usr/local/lib/*) \
+                cp -L "${library}" "/out/lib/$(basename "${library}")" ;; \
+        esac; \
+    done; \
+    ldd /out/bin/mooncake_kv_migration_worker \
+        | awk 'index($0, "not found") { missing=1 } END { exit missing }'
+
+FROM ubuntu:22.04 AS runtime
+
+ARG TT_LLM_ENGINE_IMAGE
+ARG TT_INFERENCE_SERVER_COMMIT_SHA=unknown
+
+LABEL org.opencontainers.image.revision="${TT_INFERENCE_SERVER_COMMIT_SHA}" \
+      org.opencontainers.image.source="https://github.com/tenstorrent/tt-inference-server" \
+      tt-llm-engine.image="${TT_LLM_ENGINE_IMAGE}"
+
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        hostname \
+        libatomic1 \
+        libcurl4 \
+        libgflags2.2 \
+        libgoogle-glog0v5 \
+        libhwloc15 \
+        libibverbs1 \
+        libjsoncpp25 \
+        libnl-3-200 \
+        libnl-route-3-200 \
+        libnuma1 \
+        libprotobuf23 \
+        librdkafka++1 \
+        librdkafka1 \
+        libssl3 \
+        libudev1 \
+        libunwind8 \
+        libyaml-cpp0.7 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV WORKER_BIN=/usr/local/bin/mooncake_kv_migration_worker \
+    TT_METAL_HOME=/opt/tt-metal-runtime \
+    TT_METAL_RUNTIME_ROOT=/opt/tt-metal-runtime \
+    LD_LIBRARY_PATH=/usr/local/lib
+
+COPY --from=builder /out/bin/mooncake_kv_migration_worker /usr/local/bin/mooncake_kv_migration_worker
+COPY --from=builder /out/lib/ /usr/local/lib/
+COPY --from=engine /opt/tt-llm-engine-src/tt-metal/tt_metal/soc_descriptors /opt/tt-metal-runtime/tt_metal/soc_descriptors
+COPY --from=builder /src/cpp_server/tests/e2e/scripts/migration_worker_launch.sh /usr/local/bin/migration_worker_launch.sh
+
+RUN chmod 0755 /usr/local/bin/migration_worker_launch.sh \
+    && ldconfig \
+    && ldd /usr/local/bin/mooncake_kv_migration_worker \
+    && ldd /usr/local/bin/mooncake_kv_migration_worker \
+        | awk 'index($0, "not found") { missing=1 } END { exit missing }'
+
+STOPSIGNAL SIGTERM
+ENTRYPOINT ["/usr/local/bin/migration_worker_launch.sh"]

--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -1638,7 +1638,7 @@ if(KAFKA_ENABLED)
     # (transport_lib) with the Kafka request/ack loop (kv_migration_worker).
     # Gated on `transfer_engine` since the Mooncake transport is what makes
     # the bring-up meaningful; without it the binary would have nothing to
-    # publish/discover and would only exercise the stub executor path.
+    # publish/discover and would only exercise dry-run request logging.
     if(TARGET transfer_engine)
         # Unified Kafka->migration worker: one --role prefill|decode binary that
         # drives the real data plane on a Kafka trigger. Compiles

--- a/tt-media-server/cpp_server/include/runtime/worker/stub_migration_executor.hpp
+++ b/tt-media-server/cpp_server/include/runtime/worker/stub_migration_executor.hpp
@@ -11,7 +11,7 @@
 namespace tt::worker {
 
 /**
- * Placeholder executor used until the real Mooncake-backed executor lands.
+ * Device-less executor used by migration-worker dry-run mode.
  *
  * Behaviour: logs the request and invokes onDone synchronously with the
  * configured terminal status (default SUCCESSFUL). The "synchronous fast

--- a/tt-media-server/cpp_server/include/transport/kv_migration_endpoints.hpp
+++ b/tt-media-server/cpp_server/include/transport/kv_migration_endpoints.hpp
@@ -165,8 +165,9 @@ class KvControlChannelConnector {
  * Unit-test fakes: factory returns an already-connected peer transport; the
  * server keeps the historical single-session path.
  *
- * Lifetime: `receiver` must outlive this server. stop() (also called by the
- * dtor) tears listen + all sessions down and joins threads; it is idempotent.
+ * Lifetime: a non-null `receiver` must outlive this server. A null receiver
+ * enables control-only dry-run mode. stop() (also called by the dtor) tears
+ * listen + all sessions down and joins threads; it is idempotent.
  */
 class KvMigrationReceiverServer {
  public:
@@ -181,6 +182,13 @@ class KvMigrationReceiverServer {
   ///        and shared by every accepted prefill session.
   KvMigrationReceiverServer(uint16_t port, ServerTransportFactory factory,
                             MooncakeKvReceiver& receiver,
+                            std::vector<uint8_t> localTableBlob = {},
+                            std::chrono::milliseconds receiveTimeout =
+                                KvControlChannel::kDefaultReceiveTimeout,
+                            std::chrono::milliseconds pollInterval =
+                                KvControlChannel::kDefaultPollInterval);
+  KvMigrationReceiverServer(uint16_t port, ServerTransportFactory factory,
+                            MooncakeKvReceiver* receiver,
                             std::vector<uint8_t> localTableBlob = {},
                             std::chrono::milliseconds receiveTimeout =
                                 KvControlChannel::kDefaultReceiveTimeout,
@@ -224,7 +232,7 @@ class KvMigrationReceiverServer {
 
   uint16_t port_;
   ServerTransportFactory factory_;
-  MooncakeKvReceiver& receiver_;
+  MooncakeKvReceiver* receiver_;
   std::shared_ptr<const std::vector<uint8_t>> local_table_blob_;
   std::chrono::milliseconds receive_timeout_;
   std::chrono::milliseconds poll_interval_;

--- a/tt-media-server/cpp_server/include/transport/kv_migration_orchestrator.hpp
+++ b/tt-media-server/cpp_server/include/transport/kv_migration_orchestrator.hpp
@@ -73,6 +73,11 @@ class KvMigrationReceiver {
   KvMigrationReceiver(
       KvControlChannel& channel, MooncakeKvReceiver& receiver,
       std::shared_ptr<const std::vector<uint8_t>> localTableBlob = nullptr);
+  /// A null receiver enables control-only dry-run mode: TABLE_EXCHANGE is
+  /// served, while migration requests are logged and rejected.
+  KvMigrationReceiver(
+      KvControlChannel& channel, MooncakeKvReceiver* receiver,
+      std::shared_ptr<const std::vector<uint8_t>> localTableBlob = nullptr);
 
   /// Init-time table exchange: receive the peer's table, then send ours.
   /// Also stores the peer blob via peerTableBlob() / peerTable().
@@ -109,7 +114,7 @@ class KvMigrationReceiver {
   bool handleTableExchange(const KvControlMessage& msg);
 
   KvControlChannel& channel_;
-  MooncakeKvReceiver& receiver_;
+  MooncakeKvReceiver* receiver_;
   std::shared_ptr<const std::vector<uint8_t>> local_table_blob_;
   std::vector<uint8_t> peer_table_blob_;
   std::shared_ptr<const IKvTable> peer_table_;

--- a/tt-media-server/cpp_server/scripts/build_migration_worker_image.sh
+++ b/tt-media-server/cpp_server/scripts/build_migration_worker_image.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly CPP_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+readonly MEDIA_ROOT="$(cd "${CPP_ROOT}/.." && pwd)"
+readonly REPO_ROOT="$(cd "${MEDIA_ROOT}/.." && pwd)"
+readonly DOCKERFILE="${MEDIA_ROOT}/Dockerfile.migration-worker"
+readonly ENGINE_SHA="$(git -C "${REPO_ROOT}" ls-tree HEAD \
+  tt-media-server/cpp_server/tt-llm-engine | awk '{print $3}')"
+readonly DEFAULT_ENGINE_IMAGE="ghcr.io/tenstorrent/tt-llm-engine/blaze:${ENGINE_SHA}"
+
+ENGINE_IMAGE="${TT_LLM_ENGINE_IMAGE:-${DEFAULT_ENGINE_IMAGE}}"
+IMAGE="${MIGRATION_WORKER_IMAGE:-tt-migration-worker:dev}"
+IMAGE_WAS_SET="${MIGRATION_WORKER_IMAGE:+1}"
+PUSH=0
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--engine-image IMAGE] [--image IMAGE] [--push]
+
+Options:
+  --engine-image IMAGE  Prebuilt tt-llm-engine dependency image
+                        (default: ${DEFAULT_ENGINE_IMAGE})
+  --image IMAGE         Output image (default: ${IMAGE})
+  --push                Push directly to the configured registry
+  -h, --help            Show this help
+
+Environment alternatives:
+  TT_LLM_ENGINE_IMAGE, MIGRATION_WORKER_IMAGE
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --engine-image)
+      ENGINE_IMAGE="$2"
+      shift 2
+      ;;
+    --image)
+      IMAGE="$2"
+      IMAGE_WAS_SET=1
+      shift 2
+      ;;
+    --push)
+      PUSH=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -n "${ENGINE_SHA}" && -n "${ENGINE_IMAGE}" ]] || {
+  echo "ERROR: could not resolve the tt-llm-engine dependency image" >&2
+  exit 2
+}
+if [[ "${PUSH}" -eq 1 && -z "${IMAGE_WAS_SET}" ]]; then
+  echo "ERROR: --push requires --image or MIGRATION_WORKER_IMAGE" >&2
+  exit 2
+fi
+command -v docker >/dev/null 2>&1 || {
+  echo "ERROR: docker is not installed" >&2
+  exit 1
+}
+docker buildx version >/dev/null
+
+COMMIT_SHA="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+OUTPUT_ARGS=(--load)
+[[ "${PUSH}" -eq 1 ]] && OUTPUT_ARGS=(--push)
+
+docker buildx build \
+  --file "${DOCKERFILE}" \
+  --build-arg "TT_LLM_ENGINE_IMAGE=${ENGINE_IMAGE}" \
+  --build-arg "TT_INFERENCE_SERVER_COMMIT_SHA=${COMMIT_SHA}" \
+  --tag "${IMAGE}" \
+  "${OUTPUT_ARGS[@]}" \
+  "${REPO_ROOT}"

--- a/tt-media-server/cpp_server/scripts/deploy_migration_workers.sh
+++ b/tt-media-server/cpp_server/scripts/deploy_migration_workers.sh
@@ -6,11 +6,11 @@
 # workers across an Exabox cluster.
 #
 # One invocation brings up the whole stack:
-#   1. Starts the Mooncake HTTP discovery service on --discovery-host.
-#   2. Launches one mooncake_kv_migration_worker per host, each as its OWN
-#      process (local, or over ssh). One worker on each --prefill-host, one on
-#      each --decode-host. Each worker's logical tag (prefill-<i> / decode-<i>,
-#      or --{prefill,decode}-tags) is used as its --name, --host, and --peer key.
+#   1. Connects to the Mooncake HTTP discovery service from --discovery-server.
+#   2. Launches one migration-worker Docker container per host over SSH. One
+#      worker runs on each --prefill-host and each --decode-host. Each worker's
+#      logical tag (prefill-<i> / decode-<i>, or --{prefill,decode}-tags) is used
+#      as its --name, --host, and --peer key.
 #   3. Workers find each other through the discovery service (register-then-
 #      resolve) — a prefill resolves each decode tag to its routable host via the
 #      metadata service and dials its control channel. No MPI/collectives.
@@ -36,15 +36,13 @@
 # (point at it with --kafka-brokers, default kafka:9092).
 #
 # Requirements:
-#   * passwordless ssh from this host to --discovery-host and every worker host
-#   * the same mooncake_kv_migration_worker binary AND the KV .pb tables at the
-#     same path on all hosts (NFS share, or rsync first), built with the health
-#     server + Mooncake + kv-table; every worker host needs TT devices
-#   * curl on this host (health/readiness probes) and python3 (discovery probe)
+#   * passwordless ssh from this host to every worker host
+#   * Docker and the KV .pb tables at the configured paths on every worker host
+#   * curl on this host for health/readiness and discovery probes
 #
 # Example — 2 prefill hosts + 4 decode hosts (tables + tags from the config):
 #   ./scripts/deploy_migration_workers.sh \
-#     --discovery-host bh-glx-c01u02 \
+#     --discovery-server 10.32.89.65:8080 \
 #     --prefill-hosts  bh-glx-c01u02,bh-glx-c01u03 \
 #     --decode-hosts   bh-glx-c01u08,bh-glx-c02u02,bh-glx-c03u02,bh-glx-c04u02 \
 #     --health-port 9109
@@ -52,21 +50,26 @@
 set -uo pipefail
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Per-worker launcher for the REAL data-plane worker (mooncake_kv_migration_worker).
-readonly RANK_LAUNCH="${SCRIPT_DIR}/../tests/e2e/scripts/migration_worker_launch.sh"
-readonly META_SERVER="${SCRIPT_DIR}/../tests/integration/run_mooncake_metadata_server.sh"
 # Sourced (if present) before flag parsing, so --flags still override it. Holds
 # the table-coupled settings (table paths, host tags, device map).
 readonly DEFAULT_CONFIG="${SCRIPT_DIR}/migration_deploy.conf"
 
 # --- defaults (override via flags) ---
-DISCOVERY_HOST=""
+DISCOVERY_SERVER="${DISCOVERY_SERVER:-}"
 PREFILL_HOSTS=""
 DECODE_HOSTS=""
 LAYER_START=0
 LAYER_END=0
 BUILD_DIR="./build"
-WORKER_BIN=""
+WORKER_BIN="${WORKER_BIN:-/usr/local/bin/mooncake_kv_migration_worker}"
+WORKER_IMAGE="${MIGRATION_WORKER_IMAGE:-ghcr.io/tenstorrent/tt-shield/tt-migration-worker:23072026-225800}"
+MIGRATION_MODE="${KV_MIGRATION_MODE:-dry-run}"
+TT_LOG_LEVEL="${TT_LOG_LEVEL:-debug}"
+GHCR_USERNAME="${GHCR_USERNAME:-}"
+GHCR_TOKEN_FILE="${GHCR_TOKEN_FILE:-}"
+GHCR_TOKEN_VALUE="${GHCR_TOKEN:-}"
+unset GHCR_TOKEN
+IMAGE_PULL_PARALLELISM="${IMAGE_PULL_PARALLELISM:-4}"
 # The KV tables the real worker migrates (see migration_deploy.conf). Required.
 PREFILL_TABLE="${PREFILL_TABLE:-}"
 DECODE_TABLE="${DECODE_TABLE:-}"
@@ -84,7 +87,6 @@ PREFILL_TAGS="${PREFILL_TAGS:-}"
 DECODE_TAGS="${DECODE_TAGS:-}"
 # Optional alternate config file (else DEFAULT_CONFIG next to this script).
 CONFIG_FILE="${CONFIG_FILE:-}"
-DISCOVERY_PORT=8080
 # HTTP health port every worker exposes (/healthz /readyz /metrics). One worker
 # per host, so they all share it. REQUIRED — the watchdog probes it.
 HEALTH_PORT=0
@@ -94,12 +96,6 @@ HEALTH_PORT=0
 # metadata (this value is only the fallback for a peer that hasn't published).
 # Set in migration_deploy.conf or override with --control-port.
 CONTROL_PORT="${CONTROL_PORT:-18650}"
-# OPTIONAL container name. When set, workers run inside this container (via a
-# docker-exec --worker-bin wrapper) as root, so the sweep/teardown must kill them
-# with `docker exec <CONTAINER> pkill` — a host-side pkill as the deploy user
-# can't touch a root-in-container process, leaving stale workers + squatted ports
-# (exabox Bug A). Empty => host-side pkill (bare-host/in-container deploys).
-CONTAINER="${CONTAINER:-}"
 # Mirrors bringup_mooncake_worker's K_DEFAULT_HOST_DRAM_BYTES (4 GiB). Kept in
 # sync by hand; the worker also clamps/validates this against physical RAM.
 HOST_DRAM_BYTES=$((4 * 1024 * 1024 * 1024))
@@ -121,10 +117,11 @@ SWEEP_GRACE_SEC=5
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") --discovery-host H --prefill-hosts CSV --decode-hosts CSV --health-port PORT [options]
+Usage: $(basename "$0") --discovery-server IP:PORT --prefill-hosts CSV --decode-hosts CSV --health-port PORT [options]
 
 Required:
-  --discovery-host HOST    host that runs the Mooncake discovery service
+  --discovery-server IP:PORT
+                           existing Mooncake HTTP metadata server
   --prefill-hosts CSV      prefill hosts (one worker each); first is the master
   --decode-hosts CSV       decode hosts (one worker each); first is the master
   --health-port PORT       HTTP health port each worker serves (/healthz /readyz
@@ -148,15 +145,18 @@ fabric_node_host, not on the CLI):
   --decode-tags CSV        table host tags per decode host (default decode-<i>)
 
 Options:
-  --build-dir PATH         cpp_server build dir (default ${BUILD_DIR})
-  --worker-bin PATH        worker binary (default <build-dir>/mooncake_kv_migration_worker)
+  --image IMAGE            migration-worker Docker image (default ${WORKER_IMAGE})
+  --migration-mode MODE    device|dry-run (default ${MIGRATION_MODE})
+  --worker-bin PATH        binary path inside the image (default ${WORKER_BIN})
+  --log-level LEVEL        worker log level (default ${TT_LOG_LEVEL})
+  --ghcr-username USER     GHCR user; requires GHCR_TOKEN_FILE or GHCR_TOKEN
+  --ghcr-token-file FILE   local mode-600 file containing a read:packages token
+  --image-pull-parallelism N
+                           concurrent remote image pulls (default ${IMAGE_PULL_PARALLELISM})
+  --build-dir PATH         retained for engine handoff compatibility
   --handoff-sender PATH    engine_handoff_sender (default <build-dir>/engine_handoff_sender)
   --engine-handoff-port N  DeviceMap socket port (default 18700 if
                            --device-map-dir set; 0 = file --device-map)
-  --container NAME          workers run inside this container (docker-exec
-                           --worker-bin wrapper); sweep/teardown kill via
-                           'docker exec NAME pkill'. Omit for host-side pkill
-  --discovery-port PORT    discovery service port (default ${DISCOVERY_PORT})
   --host-dram-bytes N      per-worker pool, page-aligned (default 4 GiB)
   --discovery-timeout-sec S  peer discovery timeout (default ${DISCOVERY_TIMEOUT_SEC})
   --kafka-brokers HOST:PORT  existing broker prefill workers use (default ${KAFKA_BROKERS})
@@ -195,13 +195,19 @@ loadConfig() {
 parseArgs() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --discovery-host) DISCOVERY_HOST="$2"; shift 2 ;;
+      --discovery-server) DISCOVERY_SERVER="$2"; shift 2 ;;
       --prefill-hosts) PREFILL_HOSTS="$2"; shift 2 ;;
       --decode-hosts) DECODE_HOSTS="$2"; shift 2 ;;
       --layer-start) LAYER_START="$2"; shift 2 ;;
       --layer-end) LAYER_END="$2"; shift 2 ;;
       --build-dir) BUILD_DIR="$2"; shift 2 ;;
       --worker-bin) WORKER_BIN="$2"; shift 2 ;;
+      --image) WORKER_IMAGE="$2"; shift 2 ;;
+      --migration-mode) MIGRATION_MODE="$2"; shift 2 ;;
+      --log-level) TT_LOG_LEVEL="$2"; shift 2 ;;
+      --ghcr-username) GHCR_USERNAME="$2"; shift 2 ;;
+      --ghcr-token-file) GHCR_TOKEN_FILE="$2"; shift 2 ;;
+      --image-pull-parallelism) IMAGE_PULL_PARALLELISM="$2"; shift 2 ;;
       --config) CONFIG_FILE="$2"; shift 2 ;;
       --prefill-table) PREFILL_TABLE="$2"; shift 2 ;;
       --decode-table) DECODE_TABLE="$2"; shift 2 ;;
@@ -210,10 +216,8 @@ parseArgs() {
       --decode-tags) DECODE_TAGS="$2"; shift 2 ;;
       --handoff-sender) HANDOFF_SENDER_BIN="$2"; shift 2 ;;
       --engine-handoff-port) ENGINE_HANDOFF_PORT="$2"; shift 2 ;;
-      --discovery-port) DISCOVERY_PORT="$2"; shift 2 ;;
       --health-port) HEALTH_PORT="$2"; shift 2 ;;
       --control-port) CONTROL_PORT="$2"; shift 2 ;;
-      --container) CONTAINER="$2"; shift 2 ;;
       --host-dram-bytes) HOST_DRAM_BYTES="$2"; shift 2 ;;
       --discovery-timeout-sec) DISCOVERY_TIMEOUT_SEC="$2"; shift 2 ;;
       --kafka-brokers) KAFKA_BROKERS="$2"; shift 2 ;;
@@ -228,17 +232,38 @@ parseArgs() {
 }
 
 validateArgs() {
-  [[ -n "${DISCOVERY_HOST}" ]] || die "--discovery-host is required"
+  [[ -n "${DISCOVERY_SERVER}" ]] || die "--discovery-server is required"
+  [[ "${DISCOVERY_SERVER}" =~ ^[^:/]+:[0-9]+$ ]] || \
+    die "--discovery-server must be IP:PORT, got: ${DISCOVERY_SERVER}"
   [[ -n "${PREFILL_HOSTS}" ]] || die "--prefill-hosts is required"
   [[ -n "${DECODE_HOSTS}" ]] || die "--decode-hosts is required"
   [[ "${HEALTH_PORT}" != "0" ]] || die "--health-port is required (the watchdog probes it)"
-  [[ -z "${WORKER_BIN}" ]] && WORKER_BIN="${BUILD_DIR}/mooncake_kv_migration_worker"
+  [[ -n "${WORKER_IMAGE}" ]] || die "--image is required"
+  [[ "${WORKER_BIN}" == /* ]] || die "--worker-bin must be an absolute container path"
+  [[ "${MIGRATION_MODE}" == "device" || "${MIGRATION_MODE}" == "dry-run" ]] || \
+    die "--migration-mode must be device|dry-run"
+  [[ "${IMAGE_PULL_PARALLELISM}" =~ ^[1-9][0-9]*$ ]] || \
+    die "--image-pull-parallelism must be a positive integer"
+  if [[ -n "${GHCR_TOKEN_FILE}" ]]; then
+    [[ -r "${GHCR_TOKEN_FILE}" ]] || die "GHCR token file is unreadable: ${GHCR_TOKEN_FILE}"
+    local tokenMode
+    tokenMode="$(stat -c '%a' "${GHCR_TOKEN_FILE}")" || \
+      die "cannot inspect GHCR token file: ${GHCR_TOKEN_FILE}"
+    (( (8#${tokenMode} & 077) == 0 )) || \
+      die "GHCR token file must not be accessible by group/others: ${GHCR_TOKEN_FILE}"
+    GHCR_TOKEN_VALUE="$(<"${GHCR_TOKEN_FILE}")"
+  fi
+  if [[ -n "${GHCR_TOKEN_VALUE}" && -z "${GHCR_USERNAME}" ]]; then
+    die "GHCR_USERNAME or --ghcr-username is required with a GHCR token"
+  fi
+  if [[ -n "${GHCR_USERNAME}" && -z "${GHCR_TOKEN_VALUE}" ]]; then
+    die "GHCR_TOKEN_FILE or GHCR_TOKEN is required with GHCR_USERNAME"
+  fi
   [[ -z "${HANDOFF_SENDER_BIN}" ]] && HANDOFF_SENDER_BIN="${BUILD_DIR}/engine_handoff_sender"
   [[ -n "${PREFILL_TABLE}" ]] || die "--prefill-table (or PREFILL_TABLE in config) is required"
   [[ -n "${DECODE_TABLE}" ]] || die "--decode-table (or DECODE_TABLE in config) is required"
-  # Tables live on the NFS-shared path, so a local check on the lead is enough.
-  [[ -f "${PREFILL_TABLE}" ]] || die "prefill table not found: ${PREFILL_TABLE}"
-  [[ -f "${DECODE_TABLE}" ]] || die "decode table not found: ${DECODE_TABLE}"
+  [[ "${PREFILL_TABLE}" == /* ]] || die "--prefill-table must be an absolute remote path"
+  [[ "${DECODE_TABLE}" == /* ]] || die "--decode-table must be an absolute remote path"
   # Device maps are OPTIONAL: unset => discovery-only e2e (no transfer). When set
   # it's a real transfer run, so the dir must exist and every worker's own
   # <tag>.devmap is checked in addWorkerSlot (fail-fast before any launch).
@@ -263,19 +288,13 @@ validateArgs() {
 # CSV -> count of non-empty fields.
 countHosts() { awk -F',' '{n=0; for(i=1;i<=NF;i++) if($i!="") n++; print n}' <<<"$1"; }
 
-# Is the given host name this machine? (covers localhost + this box's hostname)
-isLocalHost() {
-  local host="$1"
-  [[ "${host}" == "localhost" || "${host}" == "127.0.0.1" || "${host}" == "$(hostname)" || "${host}" == "$(hostname -s)" ]]
-}
-
 META_URI=""
-META_PID=""
-META_LOG="${META_LOG:-/tmp/tt_mc_deploy_metadata.log}"
 # Per-worker tracking. Parallel arrays, one entry per worker: role, role-local
 # index, host, table tag (== --name/--host/--peer), resolved <tag>.devmap,
-# health port, launcher PID, and consecutive-failure count.
-declare -a WK_ROLE=() WK_INDEX=() WK_HOST=() WK_TAG=() WK_DEVMAP=() WK_PORT=() WK_PID=() WK_FAILS=() WK_LOG=()
+# bind IP, container name, health port, launcher PID, and failure count.
+declare -a WK_ROLE=() WK_INDEX=() WK_HOST=() WK_TAG=() WK_DEVMAP=()
+declare -a WK_BIND_IP=() WK_CONTAINER=() WK_DOCKER=()
+declare -a WK_PORT=() WK_PID=() WK_FAILS=() WK_LOG=()
 # Resolved peer CSV per worker (WK_PEERS[s]) — the generic, role-agnostic peer
 # list this worker is launched with. See peersForWorker() for how it's derived.
 declare -a WK_PEERS=()
@@ -301,96 +320,48 @@ except Exception:
 PY
 }
 
-startDiscoveryService() {
-  META_URI="http://${DISCOVERY_HOST}:${DISCOVERY_PORT}/metadata"
-  echo "[deploy] starting discovery service on ${DISCOVERY_HOST}:${DISCOVERY_PORT}"
+verifyDiscoveryService() {
+  META_URI="http://${DISCOVERY_SERVER}/metadata"
+  echo "[deploy] using discovery service at ${META_URI}"
   if (( DRY_RUN )); then
-    echo "[dry-run] HTTP_PORT=${DISCOVERY_PORT} BIND_HOST=0.0.0.0 ${META_SERVER} (on ${DISCOVERY_HOST})"
     return 0
   fi
-
-  if isLocalHost "${DISCOVERY_HOST}"; then
-    HTTP_PORT="${DISCOVERY_PORT}" BIND_HOST="0.0.0.0" \
-      "${META_SERVER}" >"${META_LOG}" 2>&1 &
-  else
-    ssh "${SSH_OPTS[@]}" "${DISCOVERY_HOST}" \
-      "HTTP_PORT='${DISCOVERY_PORT}' BIND_HOST='0.0.0.0' bash '${META_SERVER}'" \
-      >"${META_LOG}" 2>&1 &
-  fi
-  META_PID=$!
-
   for _ in $(seq 1 20); do
-    probeMetadata "${META_URI}" && { echo "[deploy] discovery service ready at ${META_URI}"; return 0; }
+    probeMetadata "${META_URI}" && {
+      echo "[deploy] discovery service ready at ${META_URI}"
+      return 0
+    }
     sleep 0.5
   done
   echo "ERROR: discovery service not ready at ${META_URI}" >&2
-  cat "${META_LOG}" >&2 || true
   return 1
 }
 
-# Emit the shell program a sweep runs on a host: SIGTERM the worker, wait up to
-# `grace` seconds for a clean exit, SIGKILL any survivor, then FAIL loudly unless
-# both the process is gone and the health port is free. When a worker name ($3)
-# is given the match is scoped to exactly that worker (anchored so decode-1 never
-# matches decode-15), so an unrelated deploy or a co-located worker is never hit;
-# with no name it falls back to matching any migration worker on the host. Fed to
-# `bash -s` on stdin (local or over ssh) so the pattern never lands in a
-# process's argv — that both avoids self-matching the sweeper and keeps quoting
-# sane.
+# Emit the shell program that removes one named worker container and verifies
+# that its health port is free before a restart.
 sweepScript() {
-  local port="$1" grace="$2" name="${3:-}"
-  # Workers launched via docker-exec wrappers run as root with --pid=host.
-  # A non-root `docker exec … pkill` gets Permission denied and leaves them
-  # alive — always use -u root when CONTAINER is set.
-  local run=""
-  [[ -n "${CONTAINER}" ]] && run="docker exec -u root ${CONTAINER} "
-  # Prefer exact binary name (avoids pkill -f matching the ssh/docker cmdline).
-  # Optional --name scope for single-worker restart; teardown passes name too.
+  local port="$1" grace="$2" name="$3" dockerCommand="$4" container
+  container="$(containerNameForTag "${name}")"
   cat <<EOF
-killWorkers() {
-  if [ -n '${name}' ]; then
-    ${run}bash -lc 'pkill -9 -f "mooncake_kv_migration_worker.*--name ${name}([[:space:]]|\\\$)" 2>/dev/null || true'
-  else
-    ${run}bash -lc 'pids=\$(pgrep -x mooncake_kv_migration_worker 2>/dev/null); [ -n "\$pids" ] && kill -9 \$pids; true'
-  fi
-}
-killWorkers
-for _ in \$(seq 1 ${grace}); do
-  if [ -n '${name}' ]; then
-    ${run}bash -lc 'pgrep -af mooncake_kv_migration_worker 2>/dev/null | grep -q -- "--name ${name}"' || break
-  else
-    ${run}bash -lc 'pgrep -x mooncake_kv_migration_worker >/dev/null 2>&1' || break
-  fi
-  sleep 1
-  killWorkers
-done
-if [ -n '${name}' ]; then
-  if ${run}bash -lc 'pgrep -af mooncake_kv_migration_worker 2>/dev/null | grep -q -- "--name ${name}"'; then
-    echo "SWEEP_FAIL: worker still alive on \$(hostname -s)" >&2; exit 1
-  fi
-elif ${run}bash -lc 'pgrep -x mooncake_kv_migration_worker >/dev/null 2>&1'; then
-  echo "SWEEP_FAIL: worker still alive on \$(hostname -s)" >&2; exit 1
+${dockerCommand} stop --time ${grace} '${container}' >/dev/null 2>&1 || true
+${dockerCommand} rm -f '${container}' >/dev/null 2>&1 || true
+if ${dockerCommand} inspect '${container}' >/dev/null 2>&1; then
+  echo "SWEEP_FAIL: container ${container} still exists on \$(hostname -s)" >&2
+  exit 1
 fi
 if command -v ss >/dev/null 2>&1 && ss -ltnH 2>/dev/null | grep -q ":${port} "; then
-  echo "SWEEP_FAIL: port ${port} still bound on \$(hostname -s)" >&2; exit 1
+  echo "SWEEP_FAIL: port ${port} still bound on \$(hostname -s)" >&2
+  exit 1
 fi
-echo "SWEEP_OK: ${port} free on \$(hostname -s)"
+echo "SWEEP_OK: ${container} removed; ${port} free on \$(hostname -s)"
 EOF
 }
 
-# Kill the migration worker on a host and BLOCK until its process is gone and the
-# health port is free. Pass the worker name ($2) to scope the kill to exactly
-# that worker; omit it to match any migration worker on the host. Returns
-# non-zero if the port cannot be freed, so the caller refuses to relaunch into a
-# squatted port (the churn bug).
+# Remove the migration worker container and block until its health port is free.
 sweepWorkerOnHost() {
-  local host="$1" name="${2:-}" script
-  script="$(sweepScript "${HEALTH_PORT}" "${SWEEP_GRACE_SEC}" "${name}")"
-  if isLocalHost "${host}"; then
-    bash -s <<<"${script}"
-  else
-    ssh "${SSH_OPTS[@]}" "${host}" bash -s <<<"${script}"
-  fi
+  local host="$1" name="$2" dockerCommand="$3" script
+  script="$(sweepScript "${HEALTH_PORT}" "${SWEEP_GRACE_SEC}" "${name}" "${dockerCommand}")"
+  ssh "${SSH_OPTS[@]}" "${host}" bash -s <<<"${script}"
 }
 
 # A worker that died without deregistering leaves mooncake/rpc_meta/<name> (and
@@ -456,13 +427,94 @@ WORKER_PEERS so each decode has a single prefill owner \
   done
 }
 
-addWorkerSlot() {
-  local devmap=""
-  if [[ -n "${DEVICE_MAP_DIR}" ]]; then
-    devmap="${DEVICE_MAP_DIR}/$4.devmap"
-    [[ -f "${devmap}" ]] || die "device map not found for tag '$4': ${devmap}"
+containerNameForTag() {
+  local name="${1//[^a-zA-Z0-9_.-]/-}"
+  printf 'tt-migration-worker-%s' "${name}"
+}
+
+resolveBindIp() {
+  local host="$1" ip command
+  command="hostname -I 2>/dev/null | tr ' ' '\\n' | awk '/^10\\./ {print; exit}'"
+  ip="$(ssh "${SSH_OPTS[@]}" "${host}" "${command}")"
+  [[ "${ip}" =~ ^10(\.[0-9]{1,3}){3}$ ]] || \
+    die "no 10.* bind address found on ${host}; inspect with: ssh ${host} hostname -I"
+  printf '%s' "${ip}"
+}
+
+runOnHost() {
+  local host="$1" command="$2"
+  ssh "${SSH_OPTS[@]}" "${host}" "${command}"
+}
+
+resolveDockerCommand() {
+  local host="$1" command dockerCommand
+  command="if docker info >/dev/null 2>&1; then printf docker; \
+elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; \
+then printf 'sudo -n docker'; else exit 1; fi"
+  if ! dockerCommand="$(runOnHost "${host}" "${command}")"; then
+    return 1
   fi
+  printf '%s' "${dockerCommand}"
+}
+
+validateWorkerHost() {
+  local host="$1" requiredFile="$2" command
+  printf -v command 'test -r %q' "${requiredFile}"
+  runOnHost "${host}" "${command}" || \
+    die "${host}: file unreadable: ${requiredFile}"
+}
+
+ensureWorkerImage() {
+  local host="$1" dockerCommand="$2" command quotedUser quotedImage
+  printf -v command '%s image inspect %q >/dev/null 2>&1' \
+    "${dockerCommand}" "${WORKER_IMAGE}"
+  if runOnHost "${host}" "${command}"; then
+    echo "[deploy] ${host}: image available"
+    return 0
+  fi
+  if (( DRY_RUN )); then
+    echo "[dry-run] WARNING: ${WORKER_IMAGE} is not cached on ${host}; real deployment will pull it" >&2
+    return 0
+  fi
+  if [[ -z "${GHCR_TOKEN_VALUE}" ]]; then
+    printf -v command '%s pull %q' "${dockerCommand}" "${WORKER_IMAGE}"
+    runOnHost "${host}" "${command}" || {
+      echo "ERROR: ${host}: cannot pull ${WORKER_IMAGE}; provide GHCR_USERNAME with GHCR_TOKEN_FILE or GHCR_TOKEN" >&2
+      return 1
+    }
+    return 0
+  fi
+  printf -v quotedUser '%q' "${GHCR_USERNAME}"
+  printf -v quotedImage '%q' "${WORKER_IMAGE}"
+  command="set -eu; IFS= read -r token; config=\$(mktemp -d); \
+trap 'rm -rf \"\$config\"' EXIT; \
+printf '%s' \"\$token\" | ${dockerCommand} --config \"\$config\" login ghcr.io \
+--username ${quotedUser} --password-stdin >/dev/null; \
+${dockerCommand} --config \"\$config\" pull ${quotedImage}"
+  printf '%s\n' "${GHCR_TOKEN_VALUE}" |
+    ssh "${SSH_OPTS[@]}" "${host}" "${command}" || {
+      echo "ERROR: ${host}: authenticated pull failed for ${WORKER_IMAGE}" >&2
+      return 1
+    }
+}
+
+addWorkerSlot() {
+  local role="$1" host="$3" tag="$4" devmap="" table bindIp dockerCommand
+  if [[ -n "${DEVICE_MAP_DIR}" ]]; then
+    devmap="${DEVICE_MAP_DIR}/${tag}.devmap"
+    [[ -f "${devmap}" ]] || die "device map not found for tag '${tag}': ${devmap}"
+  fi
+  table="${DECODE_TABLE}"
+  [[ "${role}" == "prefill" ]] && table="${PREFILL_TABLE}"
+  if ! dockerCommand="$(resolveDockerCommand "${host}")"; then
+    die "${host}: cannot access Docker API; add the SSH user to the docker group or configure passwordless sudo for docker"
+  fi
+  validateWorkerHost "${host}" "${table}"
+  [[ -z "${devmap}" ]] || validateWorkerHost "${host}" "${devmap}"
+  bindIp="$(resolveBindIp "${host}")"
+  echo "[deploy] ${host}: docker='${dockerCommand}' MC_TCP_BIND_ADDRESS=${bindIp}"
   WK_ROLE+=("$1"); WK_INDEX+=("$2"); WK_HOST+=("$3"); WK_TAG+=("$4"); WK_DEVMAP+=("${devmap}")
+  WK_BIND_IP+=("${bindIp}"); WK_CONTAINER+=("$(containerNameForTag "${tag}")"); WK_DOCKER+=("${dockerCommand}")
   WK_PEERS+=("$(peersForWorker "$1" "$4")")
   WK_PORT+=("${HEALTH_PORT}"); WK_PID+=(""); WK_FAILS+=(0)
   WK_LOG+=("/tmp/tt_mc_deploy_$1-$2.log")
@@ -493,31 +545,79 @@ initWorkerSlots() {
   done
 }
 
-# The full env+command for the worker in slot $1. migration_worker_launch.sh
-# turns this env into the real worker's flags (--name/--host/--table/--peer),
-# so a relaunch reproduces the worker exactly. MC_TCP_BIND_ADDRESS=auto lets
-# each host resolve its own routable IP for peers to reach it on. PEERS is this
-# worker's resolved peer CSV (role-agnostic); the launcher forwards it as --peer.
+ensureAllWorkerImages() {
+  local -A seenHosts=()
+  local -a pids=() labels=()
+  local s i failed=0
+  for (( s = 0; s < ${#WK_HOST[@]}; s++ )); do
+    [[ -n "${seenHosts[${WK_HOST[$s]}]:-}" ]] && continue
+    seenHosts["${WK_HOST[$s]}"]=1
+    ensureWorkerImage "${WK_HOST[$s]}" "${WK_DOCKER[$s]}" &
+    pids+=("$!")
+    labels+=("${WK_HOST[$s]}")
+    if (( ${#pids[@]} >= IMAGE_PULL_PARALLELISM )); then
+      for (( i = 0; i < ${#pids[@]}; i++ )); do
+        if ! wait "${pids[$i]}"; then
+          echo "ERROR: image provisioning failed on ${labels[$i]}" >&2
+          failed=1
+        fi
+      done
+      pids=()
+      labels=()
+    fi
+  done
+  for (( i = 0; i < ${#pids[@]}; i++ )); do
+    if ! wait "${pids[$i]}"; then
+      echo "ERROR: image provisioning failed on ${labels[$i]}" >&2
+      failed=1
+    fi
+  done
+  (( failed == 0 )) || die "worker image provisioning failed"
+}
+
+# The full docker command for a worker slot. It stays attached to the SSH
+# session so worker logs are captured locally and the launcher PID remains a
+# useful teardown handle.
 workerCmd() {
-  local s="$1" role="${WK_ROLE[$s]}" tag="${WK_TAG[$s]}" devmap="${WK_DEVMAP[$s]}"
-  local peers="${WK_PEERS[$s]}"
-  # Socket DeviceMap: pass ENGINE_HANDOFF_PORT (deploy pushes the .devmap after
-  # start). File mode (port 0): pass DEVICE_MAP for --device-map. Discovery-only:
-  # neither.
-  local mapEnv=""
-  if [[ "${ENGINE_HANDOFF_PORT}" != "0" && -n "${devmap}" ]]; then
-    mapEnv="ENGINE_HANDOFF_PORT=${ENGINE_HANDOFF_PORT} "
-  elif [[ -n "${devmap}" ]]; then
-    mapEnv="DEVICE_MAP=${devmap} "
+  local s="$1" role="${WK_ROLE[$s]}" tag="${WK_TAG[$s]}"
+  local devmap="${WK_DEVMAP[$s]}" peers="${WK_PEERS[$s]}"
+  local bindIp="${WK_BIND_IP[$s]}" container="${WK_CONTAINER[$s]}" table
+  local -a cmd dockerCommand
+  read -r -a dockerCommand <<<"${WK_DOCKER[$s]}"
+  table="${DECODE_TABLE}"
+  [[ "${role}" == "prefill" ]] && table="${PREFILL_TABLE}"
+
+  cmd=(
+    "${dockerCommand[@]}" run --rm
+    --name "${container}"
+    --network host
+    --label "tt.migration.worker=${tag}"
+    -e "WORKER_ROLE=${role}"
+    -e "WORKER_BIN=${WORKER_BIN}"
+    -e "WORKER_TAG=${tag}"
+    -e "METADATA=${META_URI}"
+    -e "PEERS=${peers}"
+    -e "HEALTH_PORT=${HEALTH_PORT}"
+    -e "CONTROL_PORT=${CONTROL_PORT}"
+    -e "KV_MIGRATION_MODE=${MIGRATION_MODE}"
+    -e "KAFKA_BROKERS=${KAFKA_BROKERS}"
+    -e "MC_TCP_BIND_ADDRESS=${bindIp}"
+    -e "TT_LOG_LEVEL=${TT_LOG_LEVEL}"
+    -v "${table}:${table}:ro"
+  )
+  if [[ "${role}" == "prefill" ]]; then
+    cmd+=(-e "PREFILL_TABLE=${PREFILL_TABLE}")
+  else
+    cmd+=(-e "DECODE_TABLE=${DECODE_TABLE}")
   fi
-  printf '%s' "WORKER_ROLE=${role} WORKER_TAG=${tag} \
-WORKER_BIN=${WORKER_BIN} METADATA=${META_URI} \
-KAFKA_BROKERS=${KAFKA_BROKERS} HEALTH_PORT=${HEALTH_PORT} \
-CONTROL_PORT=${CONTROL_PORT} \
-${CONTAINER:+CTR=${CONTAINER} }\
-PREFILL_TABLE=${PREFILL_TABLE} DECODE_TABLE=${DECODE_TABLE} \
-${mapEnv}PEERS=${peers} \
-MC_TCP_BIND_ADDRESS=auto bash ${RANK_LAUNCH}"
+
+  if [[ "${ENGINE_HANDOFF_PORT}" != "0" && -n "${devmap}" ]]; then
+    cmd+=(-e "ENGINE_HANDOFF_PORT=${ENGINE_HANDOFF_PORT}")
+  elif [[ -n "${devmap}" ]]; then
+    cmd+=(-e "DEVICE_MAP=${devmap}" -v "${devmap}:${devmap}:ro")
+  fi
+  cmd+=("${WORKER_IMAGE}")
+  printf '%q ' "${cmd[@]}"
 }
 
 # Push <tag>.devmap to the worker on 127.0.0.1:ENGINE_HANDOFF_PORT (same box).
@@ -533,16 +633,9 @@ pushDeviceMapSlot() {
       echo "[dry-run] push DeviceMap ${tag} on ${host}: ${sendCmd}"
       return 0
     fi
-    if isLocalHost "${host}"; then
-      if bash -c "${sendCmd}" >/dev/null 2>&1; then
-        echo "[deploy] DeviceMap pushed to ${tag} on ${host} (port ${ENGINE_HANDOFF_PORT})"
-        return 0
-      fi
-    else
-      if ssh "${SSH_OPTS[@]}" "${host}" "${sendCmd}" >/dev/null 2>&1; then
-        echo "[deploy] DeviceMap pushed to ${tag} on ${host} (port ${ENGINE_HANDOFF_PORT})"
-        return 0
-      fi
+    if ssh "${SSH_OPTS[@]}" "${host}" "${sendCmd}" >/dev/null 2>&1; then
+      echo "[deploy] DeviceMap pushed to ${tag} on ${host} (port ${ENGINE_HANDOFF_PORT})"
+      return 0
     fi
     sleep 1
     attempt=$((attempt + 1))
@@ -550,31 +643,59 @@ pushDeviceMapSlot() {
   die "failed to push DeviceMap to ${tag} on ${host} after ${maxAttempts}s (is worker listening on :${ENGINE_HANDOFF_PORT}?)"
 }
 
-# (Re)launch the worker in slot $1, locally or over ssh, tracking its PID as a
-# kill handle only. For ssh the PID is the local ssh client (exits when the
-# remote worker exits *if* that ssh session still owns it); for local hosts
-# bash runs the worker in the background. Health probing uses /healthz, not
-# this PID — see workerSlotHealthy.
+containerIsRunning() {
+  local s="$1" command state
+  printf -v command "%s inspect --format '{{.State.Running}}' %q" \
+    "${WK_DOCKER[$s]}" "${WK_CONTAINER[$s]}"
+  state="$(runOnHost "${WK_HOST[$s]}" "${command}" 2>/dev/null)" || return 1
+  [[ "${state}" == "true" ]]
+}
+
+waitForContainerStart() {
+  local s="$1" pid="${WK_PID[$s]}" log="${WK_LOG[$s]}"
+  local deadline=$(( SECONDS + 60 )) rc
+  while (( SECONDS < deadline )); do
+    if containerIsRunning "${s}"; then
+      return 0
+    fi
+    if ! kill -0 "${pid}" 2>/dev/null; then
+      if wait "${pid}"; then rc=0; else rc=$?; fi
+      WK_PID[$s]=""
+      echo "ERROR: ${WK_ROLE[$s]}-${WK_INDEX[$s]} failed to launch on ${WK_HOST[$s]} (rc=${rc})" >&2
+      tail -n 20 "${log}" >&2
+      return 1
+    fi
+    sleep 0.25
+  done
+  echo "ERROR: timed out waiting for container ${WK_CONTAINER[$s]} on ${WK_HOST[$s]}" >&2
+  tail -n 20 "${log}" >&2
+  return 1
+}
+
+# Launch the worker over SSH and report success only after Docker confirms that
+# the named remote container is running.
 launchWorkerSlot() {
   local s="$1" role="${WK_ROLE[$s]}" index="${WK_INDEX[$s]}" host="${WK_HOST[$s]}"
   local log="${WK_LOG[$s]}" cmd
   cmd="$(workerCmd "${s}")"
   clearRpcMeta "${WK_TAG[$s]}"
+  sweepWorkerOnHost "${host}" "${WK_TAG[$s]}" "${WK_DOCKER[$s]}" >/dev/null || \
+    die "could not clear stale container for ${WK_TAG[$s]} on ${host}"
   : >"${log}"
-  if isLocalHost "${host}"; then
-    bash -c "${cmd}" >"${log}" 2>&1 &
-  else
-    ssh "${SSH_OPTS[@]}" "${host}" "${cmd}" >"${log}" 2>&1 &
-  fi
+  echo "[deploy] launching ${role}-${index} on ${host} (container=${WK_CONTAINER[$s]})"
+  ssh "${SSH_OPTS[@]}" "${host}" "${cmd}" >"${log}" 2>&1 &
   WK_PID[$s]=$!
   WK_FAILS[$s]=0
-  echo "[deploy] ${role}-${index} on ${host} started (pid ${WK_PID[$s]}, log ${log})"
-  pushDeviceMapSlot "${s}"
+  waitForContainerStart "${s}" || return 1
+  echo "[deploy] ${role}-${index} container running on ${host} (pid=${WK_PID[$s]}, log=${log})"
+  # pushDeviceMapSlot "${s}"
 }
 
 launchAllWorkers() {
   local s
-  for (( s = 0; s < ${#WK_ROLE[@]}; s++ )); do launchWorkerSlot "${s}"; done
+  for (( s = 0; s < ${#WK_ROLE[@]}; s++ )); do
+    launchWorkerSlot "${s}" || return 1
+  done
 }
 
 # Health = /healthz only. The launch PID is deploy's kill/sweep handle for a
@@ -638,7 +759,7 @@ superviseLoop() {
         # worker fails to bind, and the "restart" just churns launchers. If the
         # sweep can't free it, keep WK_FAILS so the next cycle retries the sweep.
         [[ -n "${WK_PID[$s]}" ]] && kill "${WK_PID[$s]}" 2>/dev/null
-        if sweepWorkerOnHost "${WK_HOST[$s]}" "${WK_TAG[$s]}"; then
+        if sweepWorkerOnHost "${WK_HOST[$s]}" "${WK_TAG[$s]}" "${WK_DOCKER[$s]}"; then
           launchWorkerSlot "${s}"
         else
           echo "[deploy] ERROR: could not free ${WK_HOST[$s]}:${HEALTH_PORT}; not relaunching (will retry next cycle)" >&2
@@ -670,15 +791,14 @@ cleanup() {
   for (( s = 0; s < ${#WK_PID[@]}; s++ )); do
     [[ -n "${WK_PID[$s]:-}" ]] && kill -9 "${WK_PID[$s]}" 2>/dev/null
   done
-  [[ -n "${META_PID:-}" ]] && kill -9 "${META_PID}" 2>/dev/null
 
-  # Hard-kill workers in parallel (root inside CONTAINER). Short grace — Ctrl-C
-  # must finish in seconds, not hang on TERM waits.
+  # Remove worker containers in parallel. Short grace keeps Ctrl-C teardown
+  # bounded even when a worker does not handle TERM promptly.
   local savedGrace="${SWEEP_GRACE_SEC}"
   SWEEP_GRACE_SEC=2
   local -a sweepPids=() sweepLabels=()
   for (( s = 0; s < ${#WK_ROLE[@]}; s++ )); do
-    sweepWorkerOnHost "${WK_HOST[$s]}" "${WK_TAG[$s]}" >/dev/null 2>&1 &
+    sweepWorkerOnHost "${WK_HOST[$s]}" "${WK_TAG[$s]}" "${WK_DOCKER[$s]}" >/dev/null 2>&1 &
     sweepPids+=("$!")
     sweepLabels+=("${WK_ROLE[$s]}-${WK_INDEX[$s]}@${WK_HOST[$s]}")
   done
@@ -714,8 +834,11 @@ main() {
   (( NUM_DECODE >= 1 )) || die "--decode-hosts must list at least one host"
 
   echo "[deploy] prefill hosts=${NUM_PREFILL} decode hosts=${NUM_DECODE} kafka=${KAFKA_BROKERS}"
+  echo "[deploy] image=${WORKER_IMAGE} mode=${MIGRATION_MODE}"
   echo "[deploy] tables: prefill=${PREFILL_TABLE} decode=${DECODE_TABLE}${DEVICE_MAP_DIR:+ device-map-dir=${DEVICE_MAP_DIR}}"
-  if [[ -z "${DEVICE_MAP_DIR}" ]]; then
+  if [[ "${MIGRATION_MODE}" == "dry-run" ]]; then
+    echo "[deploy] dry-run mode: discovery, table exchange, health, and Kafka enabled; device I/O disabled"
+  elif [[ -z "${DEVICE_MAP_DIR}" ]]; then
     echo "[deploy] no device-map-dir: discovery-only (workers register + are discoverable, but cannot move KV)"
   elif [[ "${ENGINE_HANDOFF_PORT}" != "0" ]]; then
     echo "[deploy] DeviceMap via socket handoff port=${ENGINE_HANDOFF_PORT} sender=${HANDOFF_SENDER_BIN}"
@@ -723,11 +846,10 @@ main() {
     echo "[deploy] DeviceMap via --device-map file (ENGINE_HANDOFF_PORT=0)"
   fi
 
-  trap 'cleanup 130' INT TERM
-  trap 'cleanup 0' EXIT
-  startDiscoveryService || exit 1
+  verifyDiscoveryService || exit 1
   initWorkerSlots
   assertExclusiveDecodePeers
+  ensureAllWorkerImages
 
   if (( DRY_RUN )); then
     local s
@@ -738,7 +860,9 @@ main() {
     echo "[deploy] dry-run complete"; CLEANUP_DONE=1; trap - EXIT INT TERM; exit 0
   fi
 
-  launchAllWorkers
+  trap 'cleanup 130' INT TERM
+  trap 'cleanup $?' EXIT
+  launchAllWorkers || exit 1
   waitReady || true
   superviseLoop
 }

--- a/tt-media-server/cpp_server/scripts/dev-kafka.sh
+++ b/tt-media-server/cpp_server/scripts/dev-kafka.sh
@@ -5,12 +5,12 @@
 # Single-container dev Kafka broker for cpp_server.
 #
 # Brings up apache/kafka:4.0.0 in single-node KRaft mode (combined broker +
-# controller) attached to the tt_net network. Cluster config is declared in
-# kafka-server.properties (sibling of this script), mounted into the image's
-# user-config layer.
+# controller), publishes port 9092, and advertises a host-routable address.
+# Cluster config is declared in kafka-server.properties (sibling of this
+# script), mounted into the image's user-config layer.
 #
 # Topic provisioning is intentionally NOT done here -- run
-#   python migration_cli.py setup
+#   python migration_cli.py --brokers <host-ip>:9092 setup
 # which uses the Kafka AdminClient over TCP. This mirrors the production
 # pattern (admin SDK called at deploy time) and avoids `docker exec`.
 
@@ -23,13 +23,9 @@ IMAGE="${KAFKA_IMAGE:-apache/kafka:4.0.0}"
 NETWORK="${KAFKA_NETWORK:-tt_net}"
 PROPS_FILE="${KAFKA_PROPS:-$SCRIPT_DIR/kafka-server.properties}"
 READY_TIMEOUT_S="${KAFKA_READY_TIMEOUT_S:-30}"
-# When non-empty, publish 9092 on the host so clients not attached to
-# NETWORK can reach the broker via localhost:9092. Callers must also
-# resolve `kafka` to 127.0.0.1 (e.g. /etc/hosts) because the broker
-# advertises listener as kafka:9092 -- clients get redirected there
-# after their initial connect. Used by CI; leave unset for local dev
-# where clients run inside NETWORK and get the hostname for free.
-PUBLISH_PORT="${KAFKA_PUBLISH_PORT:-}"
+ADVERTISED_HOST="${KAFKA_ADVERTISED_HOST:-10.32.89.65}"
+PUBLISH_ADDRESS="${KAFKA_PUBLISH_ADDRESS:-0.0.0.0}"
+BROKER_ENDPOINT="${ADVERTISED_HOST}:9092"
 
 usage() {
   cat <<EOF
@@ -49,8 +45,8 @@ Environment overrides:
   KAFKA_NETWORK           (default: $NETWORK)
   KAFKA_PROPS             (default: $PROPS_FILE)
   KAFKA_READY_TIMEOUT_S   (default: $READY_TIMEOUT_S)
-  KAFKA_PUBLISH_PORT      when non-empty, publish 9092 to the host
-                          (CI; requires host resolving 'kafka' to 127.0.0.1)
+  KAFKA_ADVERTISED_HOST   address clients use (default: $ADVERTISED_HOST)
+  KAFKA_PUBLISH_ADDRESS   host address Docker binds (default: $PUBLISH_ADDRESS)
 EOF
 }
 
@@ -70,7 +66,7 @@ wait_ready() {
   local deadline=$((SECONDS + READY_TIMEOUT_S))
   while [ $SECONDS -lt $deadline ]; do
     if docker exec "$CONTAINER" /opt/kafka/bin/kafka-broker-api-versions.sh \
-        --bootstrap-server kafka:9092 >/dev/null 2>&1; then
+        --bootstrap-server "$BROKER_ENDPOINT" >/dev/null 2>&1; then
       echo "Broker ready."
       return 0
     fi
@@ -92,24 +88,22 @@ cmd_up() {
   fi
   ensure_network
   docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
-  local port_args=()
-  if [ -n "$PUBLISH_PORT" ]; then
-    port_args=(-p 9092:9092)
-  fi
   docker run -d \
     --name "$CONTAINER" \
     --network "$NETWORK" \
     --restart unless-stopped \
-    "${port_args[@]}" \
+    -p "${PUBLISH_ADDRESS}:9092:9092" \
+    -e "KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093" \
+    -e "KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${BROKER_ENDPOINT}" \
     -v "$PROPS_FILE:/mnt/shared/config/server.properties:ro" \
     "$IMAGE" >/dev/null
-  echo "Started container '$CONTAINER' (image=$IMAGE network=$NETWORK${PUBLISH_PORT:+ port=9092->host})"
+  echo "Started container '$CONTAINER' (image=$IMAGE endpoint=$BROKER_ENDPOINT)"
   wait_ready
   cat <<EOF
 
 Next steps:
-  python $SCRIPT_DIR/migration_cli.py setup    # create app topics
-  python $SCRIPT_DIR/migration_cli.py status   # confirm
+  python $SCRIPT_DIR/migration_cli.py --brokers $BROKER_ENDPOINT setup
+  python $SCRIPT_DIR/migration_cli.py --brokers $BROKER_ENDPOINT status
 EOF
 }
 
@@ -131,7 +125,7 @@ cmd_status() {
     echo ""
     echo "=== topics ==="
     docker exec "$CONTAINER" /opt/kafka/bin/kafka-topics.sh \
-      --bootstrap-server kafka:9092 --list
+      --bootstrap-server "$BROKER_ENDPOINT" --list
   fi
 }
 

--- a/tt-media-server/cpp_server/scripts/kafka-server.properties
+++ b/tt-media-server/cpp_server/scripts/kafka-server.properties
@@ -5,8 +5,8 @@
 # truth for server.properties (it does NOT merge with the image's own
 # defaults), so every property the broker needs must be declared here.
 #
-# Layout: single-node KRaft, combined broker + controller, PLAINTEXT only,
-# attached to a docker network where clients address the broker as `kafka`.
+# Layout: single-node KRaft, combined broker + controller, PLAINTEXT only.
+# Clients reach the broker through the host's published port.
 
 # --- KRaft node identity & roles --------------------------------------------
 process.roles=broker,controller
@@ -19,11 +19,8 @@ controller.quorum.voters=1@localhost:9093
 # --- Listeners ---------------------------------------------------------------
 # Bind:   broker on 9092 (clients), controller on 9093 (Raft quorum)
 listeners=PLAINTEXT://:9092,CONTROLLER://:9093
-# Advertise: tell clients to reach the broker via the docker DNS name `kafka`.
-# This is the only property that *has* to differ from a vanilla single-node
-# setup; everything else in this file is just declaring the defaults
-# explicitly because the user mount replaces the image's shipped file.
-advertised.listeners=PLAINTEXT://kafka:9092
+# dev-kafka.sh overrides this with KAFKA_ADVERTISED_HOST.
+advertised.listeners=PLAINTEXT://10.32.89.65:9092
 # Which listener brokers use to talk to each other (combined mode: same as
 # client listener).
 inter.broker.listener.name=PLAINTEXT

--- a/tt-media-server/cpp_server/scripts/metadata_server/http_metadata_server.py
+++ b/tt-media-server/cpp_server/scripts/metadata_server/http_metadata_server.py
@@ -13,7 +13,6 @@ used by Mooncake. It can be used as an alternative to etcd for metadata storage.
 import argparse
 import asyncio
 import logging
-import os
 import signal
 import sys
 import threading

--- a/tt-media-server/cpp_server/scripts/metadata_server/http_metadata_server.py
+++ b/tt-media-server/cpp_server/scripts/metadata_server/http_metadata_server.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+HTTP Metadata Server for Mooncake.
+
+This module provides a simple HTTP server for storing and retrieving metadata
+used by Mooncake. It can be used as an alternative to etcd for metadata storage.
+"""
+
+import argparse
+import asyncio
+import logging
+import os
+import signal
+import sys
+import threading
+from enum import Enum
+from time import sleep
+
+from aiohttp import web
+
+
+class KVPoll(Enum):
+    """Status of the KV server."""
+
+    Failed = 0
+    Bootstrapping = 1
+    WaitingForInput = 2
+    Transferring = 3
+    Success = 4
+
+
+class KVBootstrapServer:
+    """HTTP server for storing and retrieving metadata."""
+
+    def __init__(self, port: int, host: str = "0.0.0.0"):
+        """Initialize the server.
+
+        Args:
+            port: Port to listen on
+            host: Host to bind to (default: 0.0.0.0)
+        """
+        self.port = port
+        self.host = host
+        self.app = web.Application()
+        self.store = dict()
+        self.lock = asyncio.Lock()
+        self._loop = None
+        self._runner = None
+        self.thread = None
+        self._setup_routes()
+
+    def run(self):
+        """Start the server in a background thread."""
+        self.thread = threading.Thread(target=self._run_server, daemon=True)
+        self.thread.start()
+        logging.info(f"HTTP Metadata Server started on {self.host}:{self.port}")
+        return self.thread
+
+    def _setup_routes(self):
+        """Set up the HTTP routes."""
+        self.app.router.add_route("*", "/metadata", self._handle_metadata)
+
+    async def _handle_metadata(self, request: web.Request):
+        """Handle metadata requests."""
+        key = request.query.get("key", "").strip()
+        if not key:
+            return web.Response(
+                text="metadata key is required",
+                status=400,
+                content_type="application/json",
+            )
+
+        if request.method == "GET":
+            return await self._handle_get(key)
+        elif request.method == "PUT":
+            return await self._handle_put(key, request)
+        elif request.method == "DELETE":
+            return await self._handle_delete(key)
+        return web.Response(
+            text="Method not allowed", status=405, content_type="application/json"
+        )
+
+    async def _handle_get(self, key):
+        """Handle GET requests."""
+        async with self.lock:
+            value = self.store.get(key)
+        if value is None:
+            return web.Response(
+                text="metadata not found", status=404, content_type="application/json"
+            )
+        return web.Response(body=value, status=200, content_type="application/json")
+
+    async def _handle_put(self, key, request):
+        """Handle PUT requests."""
+        data = await request.read()
+        async with self.lock:
+            if key.find("rpc_meta") != -1 and key in self.store:
+                return web.Response(
+                    text="Duplicate rpc_meta key not allowed",
+                    status=400,
+                    content_type="application/json",
+                )
+            self.store[key] = data
+        return web.Response(
+            text="metadata updated", status=200, content_type="application/json"
+        )
+
+    async def _handle_delete(self, key):
+        """Handle DELETE requests."""
+        async with self.lock:
+            if key not in self.store:
+                return web.Response(
+                    text="metadata not found",
+                    status=404,
+                    content_type="application/json",
+                )
+            del self.store[key]
+        return web.Response(
+            text="metadata deleted", status=200, content_type="application/json"
+        )
+
+    def _run_server(self):
+        """Run the server in the current thread."""
+        try:
+            # Event Loop
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+
+            self._runner = web.AppRunner(self.app)
+            self._loop.run_until_complete(self._runner.setup())
+
+            site = web.TCPSite(self._runner, host=self.host, port=self.port)
+            self._loop.run_until_complete(site.start())
+            self._loop.run_forever()
+        except Exception as e:
+            logging.error(f"Server error: {str(e)}")
+        finally:
+            # Cleanup
+            if self._runner is not None:
+                self._loop.run_until_complete(self._runner.cleanup())
+            if self._loop is not None:
+                self._loop.close()
+
+    def close(self):
+        """Shutdown the server."""
+        if self._loop is not None and self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            logging.info("Stopping server loop...")
+
+        if self.thread is not None and self.thread.is_alive():
+            self.thread.join(timeout=2)
+            logging.info("Server thread stopped")
+
+    def poll(self) -> KVPoll:
+        """Poll the server status."""
+        if self.thread is None:
+            return KVPoll.Failed
+        if not self.thread.is_alive():
+            return KVPoll.Failed
+        return KVPoll.Success
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="HTTP Metadata Server for Mooncake",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--port", type=int, default=8080, help="Port to listen on")
+    parser.add_argument("--host", type=str, default="0.0.0.0", help="Host to bind to")
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="INFO",
+        help="Logging level",
+    )
+    return parser.parse_args()
+
+
+def main():
+    """Main entry point for the mooncake_http_metadata_server command."""
+    args = parse_args()
+
+    # Configure logging
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    # Create and start the server
+    server = KVBootstrapServer(port=args.port, host=args.host)
+    server.run()
+
+    # Handle graceful shutdown
+    def signal_handler(sig, frame):
+        logging.info("Shutting down...")
+        server.close()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    # Keep the main thread alive
+    try:
+        while True:
+            sleep(1)
+    except KeyboardInterrupt:
+        server.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tt-media-server/cpp_server/scripts/metadata_server/http_metadata_server.py
+++ b/tt-media-server/cpp_server/scripts/metadata_server/http_metadata_server.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
 #!/usr/bin/env python3
 """
 HTTP Metadata Server for Mooncake.

--- a/tt-media-server/cpp_server/scripts/metadata_server/requirements.txt
+++ b/tt-media-server/cpp_server/scripts/metadata_server/requirements.txt
@@ -1,0 +1,1 @@
+aiohttp

--- a/tt-media-server/cpp_server/scripts/migration_cli.py
+++ b/tt-media-server/cpp_server/scripts/migration_cli.py
@@ -25,7 +25,7 @@ Examples:
 
 Configuration:
     --brokers <host:port>     Override the bootstrap address
-    KAFKA_BROKERS             Same, via env (default: kafka:9092)
+    KAFKA_BROKERS             Same, via env (default: 10.32.89.65:9092)
 """
 
 from __future__ import annotations
@@ -49,7 +49,7 @@ from confluent_kafka import (
 from confluent_kafka.admin import AdminClient, NewTopic
 
 
-DEFAULT_BROKERS = os.environ.get("KAFKA_BROKERS", "kafka:9092")
+DEFAULT_BROKERS = os.environ.get("KAFKA_BROKERS", "10.32.89.65:9092")
 REQUEST_TOPIC = "kv-migration-requests"
 ACK_TOPIC = "kv-migration-acks"
 DEFAULT_GROUP = "migration-workers"

--- a/tt-media-server/cpp_server/src/mooncake_kv_migration_worker_main.cpp
+++ b/tt-media-server/cpp_server/src/mooncake_kv_migration_worker_main.cpp
@@ -849,8 +849,7 @@ int runPrefill(const WorkerConfig& cfg) {
       "mode={} brokers={} req={} ack={}",
       cfg.name, connector.connectedCount(), connector.channelCount(),
       cfg.migrationMode == MigrationMode::DRY_RUN ? "dry-run" : "device",
-      brokers,
-      reqTopic, ackTopic);
+      brokers, reqTopic, ackTopic);
   worker.start();
 
   std::vector<std::string> peerNames;
@@ -1024,22 +1023,23 @@ int runDecode(const WorkerConfig& cfg) {
 
     // Segment name the sender opens for the data plane. With a metadata service
     // the mirror is registered under — and resolvable by — the worker's LOGICAL
-    // name (cfg.name): the same register-by-name / resolve-by-name discovery the
-    // bringup worker uses on main (PeerDiscoveryService), so the sender finds
-    // the peer through the metadata service instead of a hard-coded endpoint.
-    // Only P2PHANDSHAKE (no metadata registry to resolve a logical name) falls
-    // back to the engine's live IP:port. An explicit --segment always overrides.
+    // name (cfg.name): the same register-by-name / resolve-by-name discovery
+    // the bringup worker uses on main (PeerDiscoveryService), so the sender
+    // finds the peer through the metadata service instead of a hard-coded
+    // endpoint. Only P2PHANDSHAKE (no metadata registry to resolve a logical
+    // name) falls back to the engine's live IP:port. An explicit --segment
+    // always overrides.
     segment = cfg.segment;
     if (segment.empty()) {
-      segment = (cfg.metadata_uri == "P2PHANDSHAKE")
-                    ? engine->localServerName()
-                    : cfg.name;
+      segment = (cfg.metadata_uri == "P2PHANDSHAKE") ? engine->localServerName()
+                                                     : cfg.name;
     }
     receiver = std::make_unique<MooncakeKvReceiver>(
         engine, *device, resolved->table, cfg.host, segment);
     if (!receiver->registered()) {
-      TT_LOG_ERROR("[worker] decode '{}' failed to register mirror segment '{}'",
-                   cfg.name, segment);
+      TT_LOG_ERROR(
+          "[worker] decode '{}' failed to register mirror segment '{}'",
+          cfg.name, segment);
       return 1;
     }
   } else {
@@ -1052,9 +1052,9 @@ int runDecode(const WorkerConfig& cfg) {
   // Control server stores peer prefill .pb on TABLE_EXCHANGE, replies with
   // this decode .pb, then serves migrate Begin/Done. Long receive timeout
   // covers large table provisioning.
-  KvMigrationReceiverServer server{
-      cfg.control_port, makeServerTransport, receiver.get(), resolved->blob,
-      kDefaultTableExchangeTimeout};
+  KvMigrationReceiverServer server{cfg.control_port, makeServerTransport,
+                                   receiver.get(), resolved->blob,
+                                   kDefaultTableExchangeTimeout};
   if (!server.start()) {
     TT_LOG_ERROR("[worker] decode '{}' failed to start control server on :{}",
                  cfg.name, cfg.control_port);
@@ -1094,11 +1094,11 @@ int runDecode(const WorkerConfig& cfg) {
   // Control server listening and endpoint published: the decode worker has
   // finished its own bring-up, so flip it Ready.
   health.setLifecycle(WorkerLifecycle::Ready);
-  TT_LOG_INFO("[worker] decode '{}' READY: mode={} segment={} control_port={}",
-              cfg.name,
-              cfg.migrationMode == MigrationMode::DRY_RUN ? "dry-run"
-                                                          : "device",
-              segment.empty() ? "disabled" : segment, cfg.control_port);
+  TT_LOG_INFO(
+      "[worker] decode '{}' READY: mode={} segment={} control_port={}",
+      cfg.name,
+      cfg.migrationMode == MigrationMode::DRY_RUN ? "dry-run" : "device",
+      segment.empty() ? "disabled" : segment, cfg.control_port);
   while (!gStop.load()) {
     std::this_thread::sleep_for(std::chrono::milliseconds(K_IDLE_POLL_MS));
   }

--- a/tt-media-server/cpp_server/src/mooncake_kv_migration_worker_main.cpp
+++ b/tt-media-server/cpp_server/src/mooncake_kv_migration_worker_main.cpp
@@ -47,6 +47,7 @@
 #include "messaging/kafka_consumer.hpp"
 #include "messaging/kafka_producer.hpp"
 #include "runtime/worker/kv_migration_worker.hpp"
+#include "runtime/worker/stub_migration_executor.hpp"
 #include "sockets/tcp_socket_transport.hpp"
 #include "transport/device_map.hpp"  // DeviceMap (FabricNode -> UMD chip)
 #include "transport/engine_table_resolve.hpp"
@@ -107,9 +108,11 @@ std::string envOr(const char* key, const char* fallback) {
 }
 
 enum class Role { PREFILL, DECODE };
+enum class ExecutorMode { MOONCAKE, STUB };
 
 struct WorkerConfig {
   Role role = Role::PREFILL;
+  ExecutorMode executorMode = ExecutorMode::MOONCAKE;
   std::string metadata_uri;     // Mooncake metadata service (or P2PHANDSHAKE).
   std::string name;             // this worker's Mooncake server/segment name.
   std::string host;             // this node's host tag in the table.
@@ -176,7 +179,9 @@ void usage() {
          "0.0.0.0)\n"
          "  Kafka (prefill) via env: KAFKA_BROKERS, "
          "KAFKA_MIGRATION_REQUEST_TOPIC, KAFKA_MIGRATION_ACK_TOPIC, "
-         "KAFKA_GROUP_ID\n";
+         "KAFKA_GROUP_ID\n"
+         "  prefill executor via env: KV_MIGRATION_EXECUTOR=mooncake|stub "
+         "(default mooncake; stub skips device I/O and data transfer)\n";
 }
 
 // Parse "NAME=host:port" into (logical name, endpoint).
@@ -220,6 +225,15 @@ std::string hostOf(const std::string& serverName) {
 }
 
 bool parseConfig(int argc, char** argv, WorkerConfig& cfg) {
+  const std::string executorMode = envOr("KV_MIGRATION_EXECUTOR", "mooncake");
+  if (executorMode == "stub") {
+    cfg.executorMode = ExecutorMode::STUB;
+  } else if (executorMode != "mooncake") {
+    std::cerr << "KV_MIGRATION_EXECUTOR must be mooncake|stub, got: "
+              << executorMode << "\n";
+    return false;
+  }
+
   bool roleGiven = false;
   for (int i = 1; i < argc; ++i) {
     const std::string a = argv[i];
@@ -453,7 +467,19 @@ void warnIgnoredDeviceMapFile(const WorkerConfig& cfg) {
 }
 
 std::optional<ResolvedEngineTables> resolveWorkerTables(
-    const WorkerConfig& cfg) {
+    const WorkerConfig& cfg, bool includeDeviceMap = true) {
+  if (!includeDeviceMap) {
+    if (cfg.engine_handoff_port != 0 || !cfg.device_map_path.empty()) {
+      TT_LOG_WARN(
+          "[worker] stub executor ignores --engine-handoff-port and "
+          "--device-map");
+    }
+    const std::string& tablePath =
+        (cfg.role == Role::PREFILL) ? cfg.prefill_table_path : cfg.table_path;
+    return resolveEngineTables(0, makeHandoffListenTransport, tablePath, "",
+                               gStop);
+  }
+
   warnIgnoredDeviceMapFile(cfg);
   const std::string& tablePath =
       (cfg.role == Role::PREFILL) ? cfg.prefill_table_path : cfg.table_path;
@@ -688,7 +714,8 @@ int runPrefill(const WorkerConfig& cfg) {
   auto engine = makeEngine(cfg);
   if (!engine) return 1;
 
-  auto resolved = resolveWorkerTables(cfg);
+  auto resolved =
+      resolveWorkerTables(cfg, cfg.executorMode == ExecutorMode::MOONCAKE);
   if (!resolved) {
     if (gStop.load()) {
       TT_LOG_WARN(
@@ -699,11 +726,19 @@ int runPrefill(const WorkerConfig& cfg) {
     TT_LOG_ERROR("[worker] failed to resolve prefill table + device map");
     return 1;
   }
-  auto device = buildDeviceIo(*resolved->table, cfg.host, resolved->deviceMap);
-  if (!device) {
-    TT_LOG_ERROR("[worker] prefill '{}' failed to open devices (DeviceMap)",
-                 cfg.name);
-    return 1;
+  std::unique_ptr<MultiDeviceUmd> device;
+  if (cfg.executorMode == ExecutorMode::MOONCAKE) {
+    device = buildDeviceIo(*resolved->table, cfg.host, resolved->deviceMap);
+    if (!device) {
+      TT_LOG_ERROR("[worker] prefill '{}' failed to open devices (DeviceMap)",
+                   cfg.name);
+      return 1;
+    }
+  } else {
+    TT_LOG_WARN(
+        "[worker] prefill '{}' using stub executor: device I/O and Mooncake "
+        "data transfer are disabled",
+        cfg.name);
   }
 
   // Full-mesh barrier (k8s-friendly): stay alive with /healthz up and /readyz
@@ -765,10 +800,16 @@ int runPrefill(const WorkerConfig& cfg) {
     return 1;
   }
 
-  KvMigrationMultiHostSender sender(engine, *device, resolved->table,
-                                    decodeTable, cfg.host, connector.channels(),
-                                    &health);
-  auto executor = std::make_unique<MooncakeMigrationExecutor>(sender);
+  std::unique_ptr<KvMigrationMultiHostSender> sender;
+  std::unique_ptr<tt::worker::IMigrationExecutor> executor;
+  if (cfg.executorMode == ExecutorMode::STUB) {
+    executor = std::make_unique<tt::worker::StubMigrationExecutor>();
+  } else {
+    sender = std::make_unique<KvMigrationMultiHostSender>(
+        engine, *device, resolved->table, decodeTable, cfg.host,
+        connector.channels(), &health);
+    executor = std::make_unique<MooncakeMigrationExecutor>(*sender);
+  }
 
   const std::string brokers =
       envOr("KAFKA_BROKERS", tt::config::defaults::KAFKA_BROKERS);
@@ -802,8 +843,9 @@ int runPrefill(const WorkerConfig& cfg) {
   health.setLifecycle(WorkerLifecycle::Ready);
   TT_LOG_INFO(
       "[worker] prefill '{}' READY: {}/{} decode channels connected, "
-      "brokers={} req={} ack={}",
-      cfg.name, connector.connectedCount(), connector.channelCount(), brokers,
+      "executor={} brokers={} req={} ack={}",
+      cfg.name, connector.connectedCount(), connector.channelCount(),
+      cfg.executorMode == ExecutorMode::STUB ? "stub" : "mooncake", brokers,
       reqTopic, ackTopic);
   worker.start();
 
@@ -859,7 +901,8 @@ int runPrefill(const WorkerConfig& cfg) {
         }
         const auto channels = connector.channels();
         const auto chIt = channels.find(name);
-        if (chIt == channels.end() || !sender.addHost(name, chIt->second)) {
+        if (chIt == channels.end() ||
+            (sender != nullptr && !sender->addHost(name, chIt->second))) {
           wasConnected[name] = false;
           continue;
         }

--- a/tt-media-server/cpp_server/src/mooncake_kv_migration_worker_main.cpp
+++ b/tt-media-server/cpp_server/src/mooncake_kv_migration_worker_main.cpp
@@ -24,6 +24,8 @@
 // tables over the control channel (TABLE_EXCHANGE / #4295). TE/Mooncake moves
 // KV bytes only. MultiDeviceUmd uses the map; an empty map may use the
 // single-mesh placeholder, but a non-empty map with a missing entry is fatal.
+// KV_MIGRATION_MODE=dry-run keeps discovery, control-table exchange, health,
+// and Kafka active without opening devices or moving KV data.
 
 #include <unistd.h>
 
@@ -108,11 +110,11 @@ std::string envOr(const char* key, const char* fallback) {
 }
 
 enum class Role { PREFILL, DECODE };
-enum class ExecutorMode { MOONCAKE, STUB };
+enum class MigrationMode { DEVICE, DRY_RUN };
 
 struct WorkerConfig {
   Role role = Role::PREFILL;
-  ExecutorMode executorMode = ExecutorMode::MOONCAKE;
+  MigrationMode migrationMode = MigrationMode::DEVICE;
   std::string metadata_uri;     // Mooncake metadata service (or P2PHANDSHAKE).
   std::string name;             // this worker's Mooncake server/segment name.
   std::string host;             // this node's host tag in the table.
@@ -180,8 +182,9 @@ void usage() {
          "  Kafka (prefill) via env: KAFKA_BROKERS, "
          "KAFKA_MIGRATION_REQUEST_TOPIC, KAFKA_MIGRATION_ACK_TOPIC, "
          "KAFKA_GROUP_ID\n"
-         "  prefill executor via env: KV_MIGRATION_EXECUTOR=mooncake|stub "
-         "(default mooncake; stub skips device I/O and data transfer)\n";
+         "  worker mode via env: KV_MIGRATION_MODE=device|dry-run "
+         "(default device; dry-run keeps discovery, table exchange, health, "
+         "and Kafka but does not open devices or move KV data)\n";
 }
 
 // Parse "NAME=host:port" into (logical name, endpoint).
@@ -225,12 +228,12 @@ std::string hostOf(const std::string& serverName) {
 }
 
 bool parseConfig(int argc, char** argv, WorkerConfig& cfg) {
-  const std::string executorMode = envOr("KV_MIGRATION_EXECUTOR", "mooncake");
-  if (executorMode == "stub") {
-    cfg.executorMode = ExecutorMode::STUB;
-  } else if (executorMode != "mooncake") {
-    std::cerr << "KV_MIGRATION_EXECUTOR must be mooncake|stub, got: "
-              << executorMode << "\n";
+  const std::string migrationMode = envOr("KV_MIGRATION_MODE", "device");
+  if (migrationMode == "dry-run") {
+    cfg.migrationMode = MigrationMode::DRY_RUN;
+  } else if (migrationMode != "device") {
+    std::cerr << "KV_MIGRATION_MODE must be device|dry-run, got: "
+              << migrationMode << "\n";
     return false;
   }
 
@@ -471,7 +474,7 @@ std::optional<ResolvedEngineTables> resolveWorkerTables(
   if (!includeDeviceMap) {
     if (cfg.engine_handoff_port != 0 || !cfg.device_map_path.empty()) {
       TT_LOG_WARN(
-          "[worker] stub executor ignores --engine-handoff-port and "
+          "[worker] dry-run mode ignores --engine-handoff-port and "
           "--device-map");
     }
     const std::string& tablePath =
@@ -715,7 +718,7 @@ int runPrefill(const WorkerConfig& cfg) {
   if (!engine) return 1;
 
   auto resolved =
-      resolveWorkerTables(cfg, cfg.executorMode == ExecutorMode::MOONCAKE);
+      resolveWorkerTables(cfg, cfg.migrationMode == MigrationMode::DEVICE);
   if (!resolved) {
     if (gStop.load()) {
       TT_LOG_WARN(
@@ -727,7 +730,7 @@ int runPrefill(const WorkerConfig& cfg) {
     return 1;
   }
   std::unique_ptr<MultiDeviceUmd> device;
-  if (cfg.executorMode == ExecutorMode::MOONCAKE) {
+  if (cfg.migrationMode == MigrationMode::DEVICE) {
     device = buildDeviceIo(*resolved->table, cfg.host, resolved->deviceMap);
     if (!device) {
       TT_LOG_ERROR("[worker] prefill '{}' failed to open devices (DeviceMap)",
@@ -736,8 +739,8 @@ int runPrefill(const WorkerConfig& cfg) {
     }
   } else {
     TT_LOG_WARN(
-        "[worker] prefill '{}' using stub executor: device I/O and Mooncake "
-        "data transfer are disabled",
+        "[worker] prefill '{}' running in dry-run mode: device I/O and "
+        "Mooncake data transfer are disabled",
         cfg.name);
   }
 
@@ -802,7 +805,7 @@ int runPrefill(const WorkerConfig& cfg) {
 
   std::unique_ptr<KvMigrationMultiHostSender> sender;
   std::unique_ptr<tt::worker::IMigrationExecutor> executor;
-  if (cfg.executorMode == ExecutorMode::STUB) {
+  if (cfg.migrationMode == MigrationMode::DRY_RUN) {
     executor = std::make_unique<tt::worker::StubMigrationExecutor>();
   } else {
     sender = std::make_unique<KvMigrationMultiHostSender>(
@@ -843,9 +846,10 @@ int runPrefill(const WorkerConfig& cfg) {
   health.setLifecycle(WorkerLifecycle::Ready);
   TT_LOG_INFO(
       "[worker] prefill '{}' READY: {}/{} decode channels connected, "
-      "executor={} brokers={} req={} ack={}",
+      "mode={} brokers={} req={} ack={}",
       cfg.name, connector.connectedCount(), connector.channelCount(),
-      cfg.executorMode == ExecutorMode::STUB ? "stub" : "mooncake", brokers,
+      cfg.migrationMode == MigrationMode::DRY_RUN ? "dry-run" : "device",
+      brokers,
       reqTopic, ackTopic);
   worker.start();
 
@@ -942,6 +946,13 @@ int runPrefill(const WorkerConfig& cfg) {
           continue;
         }
         TT_LOG_INFO("[worker] TABLE_EXCHANGE with peer '{}' succeeded", name);
+        if (cfg.migrationMode == MigrationMode::DRY_RUN) {
+          TT_LOG_INFO(
+              "[worker] dry-run mode skips Mooncake segment refresh for '{}'",
+              name);
+          wasConnected[name] = now;
+          continue;
+        }
         if (engine->refreshSegment(name) == K_INVALID_SEGMENT) {
           TT_LOG_WARN(
               "[worker] refreshSegment('{}') after control UP failed; next "
@@ -988,7 +999,8 @@ int runDecode(const WorkerConfig& cfg) {
   auto engine = makeEngine(cfg);
   if (!engine) return 1;
 
-  auto resolved = resolveWorkerTables(cfg);
+  auto resolved =
+      resolveWorkerTables(cfg, cfg.migrationMode == MigrationMode::DEVICE);
   if (!resolved) {
     if (gStop.load()) {
       TT_LOG_WARN(
@@ -999,40 +1011,50 @@ int runDecode(const WorkerConfig& cfg) {
     TT_LOG_ERROR("[worker] failed to resolve decode table + device map");
     return 1;
   }
-  auto device = buildDeviceIo(*resolved->table, cfg.host, resolved->deviceMap);
-  if (!device) {
-    TT_LOG_ERROR("[worker] decode '{}' failed to open devices (DeviceMap)",
-                 cfg.name);
-    return 1;
-  }
+  std::unique_ptr<MultiDeviceUmd> device;
+  std::unique_ptr<MooncakeKvReceiver> receiver;
+  std::string segment;
+  if (cfg.migrationMode == MigrationMode::DEVICE) {
+    device = buildDeviceIo(*resolved->table, cfg.host, resolved->deviceMap);
+    if (!device) {
+      TT_LOG_ERROR("[worker] decode '{}' failed to open devices (DeviceMap)",
+                   cfg.name);
+      return 1;
+    }
 
-  // Segment name the sender opens for the data plane. With a metadata service
-  // the mirror is registered under — and resolvable by — the worker's LOGICAL
-  // name (cfg.name): the same register-by-name / resolve-by-name discovery the
-  // bringup worker uses on main (PeerDiscoveryService), so the sender finds the
-  // peer through the metadata service instead of a hard-coded endpoint. Only
-  // P2PHANDSHAKE (no metadata registry to resolve a logical name) falls back to
-  // the engine's live IP:port. An explicit --segment always overrides.
-  std::string segment = cfg.segment;
-  if (segment.empty()) {
-    segment = (cfg.metadata_uri == "P2PHANDSHAKE") ? engine->localServerName()
-                                                   : cfg.name;
-  }
-  // The mirror is registered as the Mooncake segment inside MooncakeKvReceiver.
-  MooncakeKvReceiver receiver(engine, *device, resolved->table, cfg.host,
-                              segment);
-  if (!receiver.registered()) {
-    TT_LOG_ERROR("[worker] decode '{}' failed to register mirror segment '{}'",
-                 cfg.name, segment);
-    return 1;
+    // Segment name the sender opens for the data plane. With a metadata service
+    // the mirror is registered under — and resolvable by — the worker's LOGICAL
+    // name (cfg.name): the same register-by-name / resolve-by-name discovery the
+    // bringup worker uses on main (PeerDiscoveryService), so the sender finds
+    // the peer through the metadata service instead of a hard-coded endpoint.
+    // Only P2PHANDSHAKE (no metadata registry to resolve a logical name) falls
+    // back to the engine's live IP:port. An explicit --segment always overrides.
+    segment = cfg.segment;
+    if (segment.empty()) {
+      segment = (cfg.metadata_uri == "P2PHANDSHAKE")
+                    ? engine->localServerName()
+                    : cfg.name;
+    }
+    receiver = std::make_unique<MooncakeKvReceiver>(
+        engine, *device, resolved->table, cfg.host, segment);
+    if (!receiver->registered()) {
+      TT_LOG_ERROR("[worker] decode '{}' failed to register mirror segment '{}'",
+                   cfg.name, segment);
+      return 1;
+    }
+  } else {
+    TT_LOG_WARN(
+        "[worker] decode '{}' running in dry-run mode: device I/O and "
+        "Mooncake mirror registration are disabled",
+        cfg.name);
   }
 
   // Control server stores peer prefill .pb on TABLE_EXCHANGE, replies with
   // this decode .pb, then serves migrate Begin/Done. Long receive timeout
   // covers large table provisioning.
-  KvMigrationReceiverServer server(cfg.control_port, makeServerTransport,
-                                   receiver, resolved->blob,
-                                   kDefaultTableExchangeTimeout);
+  KvMigrationReceiverServer server{
+      cfg.control_port, makeServerTransport, receiver.get(), resolved->blob,
+      kDefaultTableExchangeTimeout};
   if (!server.start()) {
     TT_LOG_ERROR("[worker] decode '{}' failed to start control server on :{}",
                  cfg.name, cfg.control_port);
@@ -1069,11 +1091,14 @@ int runDecode(const WorkerConfig& cfg) {
         cfg.name, cfg.peers.size() + cfg.discover_peers.size());
   }
 
-  // Mirror registered, control server listening, endpoint published: the decode
-  // worker has finished its own bring-up, so flip it Ready.
+  // Control server listening and endpoint published: the decode worker has
+  // finished its own bring-up, so flip it Ready.
   health.setLifecycle(WorkerLifecycle::Ready);
-  TT_LOG_INFO("[worker] decode '{}' READY: segment={} control_port={}",
-              cfg.name, segment, cfg.control_port);
+  TT_LOG_INFO("[worker] decode '{}' READY: mode={} segment={} control_port={}",
+              cfg.name,
+              cfg.migrationMode == MigrationMode::DRY_RUN ? "dry-run"
+                                                          : "device",
+              segment.empty() ? "disabled" : segment, cfg.control_port);
   while (!gStop.load()) {
     std::this_thread::sleep_for(std::chrono::milliseconds(K_IDLE_POLL_MS));
   }

--- a/tt-media-server/cpp_server/src/runtime/worker/stub_migration_executor.cpp
+++ b/tt-media-server/cpp_server/src/runtime/worker/stub_migration_executor.cpp
@@ -14,8 +14,8 @@ StubMigrationExecutor::StubMigrationExecutor(
 void StubMigrationExecutor::execute(uint64_t migrationId,
                                     const tt::services::MigrationRequest& req,
                                     DoneCallback onDone) {
-  TT_LOG_DEBUG(
-      "[StubMigrationExecutor] migration_id={} src_slot={} dst_slot={} "
+  TT_LOG_INFO(
+      "[DryRunMigrationExecutor] migration_id={} src_slot={} dst_slot={} "
       "layers=[{}..{}) src_pos=[{}..{}) dst_pos=[{}..{}) -> {}",
       migrationId, req.src_slot, req.dst_slot, req.layer_begin, req.layer_end,
       req.src_position_begin, req.src_position_end, req.dst_position_begin,

--- a/tt-media-server/cpp_server/src/transport/kv_migration_endpoints.cpp
+++ b/tt-media-server/cpp_server/src/transport/kv_migration_endpoints.cpp
@@ -148,6 +148,15 @@ KvMigrationReceiverServer::KvMigrationReceiverServer(
     std::vector<uint8_t> localTableBlob,
     std::chrono::milliseconds receiveTimeout,
     std::chrono::milliseconds pollInterval)
+    : KvMigrationReceiverServer(port, std::move(factory), &receiver,
+                                std::move(localTableBlob), receiveTimeout,
+                                pollInterval) {}
+
+KvMigrationReceiverServer::KvMigrationReceiverServer(
+    uint16_t port, ServerTransportFactory factory, MooncakeKvReceiver* receiver,
+    std::vector<uint8_t> localTableBlob,
+    std::chrono::milliseconds receiveTimeout,
+    std::chrono::milliseconds pollInterval)
     : port_(port),
       factory_(std::move(factory)),
       receiver_(receiver),

--- a/tt-media-server/cpp_server/src/transport/kv_migration_orchestrator.cpp
+++ b/tt-media-server/cpp_server/src/transport/kv_migration_orchestrator.cpp
@@ -228,10 +228,9 @@ bool KvMigrationReceiver::handle(const KvControlMessage& in) {
             "device or mirror is available",
             msg->uuid);
       }
-      const auto segment =
-          receiver_ != nullptr
-              ? receiver_->prepareMirror(sliceOf(*msg), msg->uuid)
-              : std::nullopt;
+      const auto segment = receiver_ != nullptr ? receiver_->prepareMirror(
+                                                      sliceOf(*msg), msg->uuid)
+                                                : std::nullopt;
       KvControlMessage ready;
       ready.type = KvControlType::MIRROR_READY;
       ready.uuid = msg->uuid;
@@ -247,9 +246,8 @@ bool KvMigrationReceiver::handle(const KvControlMessage& in) {
     case KvControlType::DONE_MARKER: {
       const bool ok = receiver_ != nullptr && receiver_->drain(msg->uuid);
       if (!ok) {
-        TT_LOG_ERROR(
-            "[KvMigrationReceiver] drain(uuid={}) failed{}",
-            msg->uuid, receiver_ == nullptr ? " (dry-run mode)" : "");
+        TT_LOG_ERROR("[KvMigrationReceiver] drain(uuid={}) failed{}", msg->uuid,
+                     receiver_ == nullptr ? " (dry-run mode)" : "");
       }
       // The Ack carries the drain status so the sender does not treat a failed
       // (partial/corrupt) drain as a successful migration.

--- a/tt-media-server/cpp_server/src/transport/kv_migration_orchestrator.cpp
+++ b/tt-media-server/cpp_server/src/transport/kv_migration_orchestrator.cpp
@@ -148,6 +148,11 @@ bool KvMigrationSender::migrate(uint64_t uuid,
 KvMigrationReceiver::KvMigrationReceiver(
     KvControlChannel& channel, MooncakeKvReceiver& receiver,
     std::shared_ptr<const std::vector<uint8_t>> localTableBlob)
+    : KvMigrationReceiver(channel, &receiver, std::move(localTableBlob)) {}
+
+KvMigrationReceiver::KvMigrationReceiver(
+    KvControlChannel& channel, MooncakeKvReceiver* receiver,
+    std::shared_ptr<const std::vector<uint8_t>> localTableBlob)
     : channel_(channel),
       receiver_(receiver),
       local_table_blob_(std::move(localTableBlob)) {}
@@ -217,7 +222,16 @@ bool KvMigrationReceiver::handle(const KvControlMessage& in) {
     case KvControlType::TABLE_EXCHANGE:
       return handleTableExchange(*msg);
     case KvControlType::BEGIN_MIGRATION: {
-      const auto segment = receiver_.prepareMirror(sliceOf(*msg), msg->uuid);
+      if (receiver_ == nullptr) {
+        TT_LOG_WARN(
+            "[KvMigrationReceiver] dry-run migration_id={} received; no "
+            "device or mirror is available",
+            msg->uuid);
+      }
+      const auto segment =
+          receiver_ != nullptr
+              ? receiver_->prepareMirror(sliceOf(*msg), msg->uuid)
+              : std::nullopt;
       KvControlMessage ready;
       ready.type = KvControlType::MIRROR_READY;
       ready.uuid = msg->uuid;
@@ -231,9 +245,11 @@ bool KvMigrationReceiver::handle(const KvControlMessage& in) {
       break;
     }
     case KvControlType::DONE_MARKER: {
-      const bool ok = receiver_.drain(msg->uuid);
+      const bool ok = receiver_ != nullptr && receiver_->drain(msg->uuid);
       if (!ok) {
-        TT_LOG_ERROR("[KvMigrationReceiver] drain(uuid={}) failed", msg->uuid);
+        TT_LOG_ERROR(
+            "[KvMigrationReceiver] drain(uuid={}) failed{}",
+            msg->uuid, receiver_ == nullptr ? " (dry-run mode)" : "");
       }
       // The Ack carries the drain status so the sender does not treat a failed
       // (partial/corrupt) drain as a successful migration.

--- a/tt-media-server/cpp_server/tests/e2e/scripts/migration_worker_launch.sh
+++ b/tt-media-server/cpp_server/tests/e2e/scripts/migration_worker_launch.sh
@@ -31,7 +31,8 @@
 # Decode also needs DECODE_TABLE. Prefill needs PREFILL_TABLE and non-empty
 #   PEERS; DECODE_TABLE is an optional disk fallback to control TABLE_EXCHANGE.
 # Optional: PEERS (see above), KAFKA_BROKERS, KAFKA_GROUP_ID,
-#   KV_MIGRATION_EXECUTOR (prefill: mooncake|stub), MC_TCP_BIND_ADDRESS
+#   KV_MIGRATION_MODE (device|dry-run; applies to both roles),
+#   MC_TCP_BIND_ADDRESS
 #   (unset/"auto" => detect this host's routable IP so peers can reach it),
 #   CONTROL_PORT (KV control port a decode binds + publishes to metadata;
 #   defaults to the worker's own default when unset), DEVICE_MAP (legacy file

--- a/tt-media-server/cpp_server/tests/e2e/scripts/migration_worker_launch.sh
+++ b/tt-media-server/cpp_server/tests/e2e/scripts/migration_worker_launch.sh
@@ -27,9 +27,11 @@
 #   initiates (prefill = sender).
 #
 # Required env (all roles): WORKER_ROLE, WORKER_BIN, METADATA, WORKER_TAG,
-#   HEALTH_PORT, DECODE_TABLE.
-# Prefill also needs: PREFILL_TABLE, and a non-empty PEERS.
-# Optional: PEERS (see above), KAFKA_BROKERS, KAFKA_GROUP_ID, MC_TCP_BIND_ADDRESS
+#   HEALTH_PORT.
+# Decode also needs DECODE_TABLE. Prefill needs PREFILL_TABLE and non-empty
+#   PEERS; DECODE_TABLE is an optional disk fallback to control TABLE_EXCHANGE.
+# Optional: PEERS (see above), KAFKA_BROKERS, KAFKA_GROUP_ID,
+#   KV_MIGRATION_EXECUTOR (prefill: mooncake|stub), MC_TCP_BIND_ADDRESS
 #   (unset/"auto" => detect this host's routable IP so peers can reach it),
 #   CONTROL_PORT (KV control port a decode binds + publishes to metadata;
 #   defaults to the worker's own default when unset), DEVICE_MAP (legacy file
@@ -44,7 +46,6 @@ die() { echo "ERROR: $*" >&2; exit 2; }
 : "${METADATA:?METADATA required}"
 : "${WORKER_TAG:?WORKER_TAG required}"
 : "${HEALTH_PORT:?HEALTH_PORT required}"
-: "${DECODE_TABLE:?DECODE_TABLE required}"
 
 # Cross-host deployment: advertise the IP peers can reach us on, never a
 # loopback. Only unset/"auto" is resolved here; a concrete value (e.g. a local
@@ -90,6 +91,7 @@ done
 
 case "${WORKER_ROLE}" in
   decode)
+    : "${DECODE_TABLE:?DECODE_TABLE required for decode}"
     # Receiver: registers KV mirror + serves control (TABLE_EXCHANGE reply +
     # migrate). Prefill initiates; decode does not. No Kafka.
     exec "${WORKER_BIN}" \
@@ -104,6 +106,8 @@ case "${WORKER_ROLE}" in
     ;;
   prefill)
     : "${PREFILL_TABLE:?PREFILL_TABLE required for prefill}"
+    decode_table_args=()
+    [[ -n "${DECODE_TABLE:-}" ]] && decode_table_args=(--decode-table "${DECODE_TABLE}")
     # The sender needs a control channel to every peer it might route to.
     (( ${#peer_args[@]} > 0 )) || die "prefill has no peers (PEERS empty)"
     # One consumer group per prefill so every prefill sees each request (Kafka
@@ -112,7 +116,8 @@ case "${WORKER_ROLE}" in
     exec "${WORKER_BIN}" \
       --role "${WORKER_ROLE}" \
       --metadata "${METADATA}" --name "${WORKER_TAG}" --host "${WORKER_TAG}" \
-      --prefill-table "${PREFILL_TABLE}" --decode-table "${DECODE_TABLE}" \
+      --prefill-table "${PREFILL_TABLE}" \
+      ${decode_table_args[@]+"${decode_table_args[@]}"} \
       "${peer_args[@]}" \
       ${peer_control_args[@]+"${peer_control_args[@]}"} \
       ${device_args[@]+"${device_args[@]}"} \

--- a/tt-media-server/cpp_server/tests/unit/transport/kv_migration_orchestrator_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/transport/kv_migration_orchestrator_test.cpp
@@ -91,6 +91,47 @@ struct DecodeNode {
   ~DecodeNode() { shutdown(); }
 };
 
+TEST(KvMigrationOrchestrator, DryRunServesTableExchangeAndRejectsMigration) {
+  auto ab = std::make_shared<Pipe>();
+  auto ba = std::make_shared<Pipe>();
+  auto senderTp =
+      std::make_shared<BlockingFakeTransport>(/*in=*/ba, /*out=*/ab);
+  auto receiverTp =
+      std::make_shared<BlockingFakeTransport>(/*in=*/ab, /*out=*/ba);
+  KvControlChannel senderCh{senderTp};
+  KvControlChannel receiverCh{receiverTp};
+
+  const std::vector<uint8_t> localTable{4, 5, 6};
+  KvMigrationReceiver receiverOrch{
+      receiverCh, static_cast<MooncakeKvReceiver*>(nullptr),
+      std::make_shared<const std::vector<uint8_t>>(localTable)};
+
+  KvControlMessage exchange;
+  exchange.type = KvControlType::TABLE_EXCHANGE;
+  exchange.role = static_cast<uint8_t>(TableExchangeRole::Sender);
+  exchange.table_blob = {1, 2, 3};
+  ASSERT_TRUE(senderCh.send(exchange));
+  ASSERT_TRUE(receiverOrch.serveOne());
+
+  const auto exchangeReply = senderCh.receive();
+  ASSERT_TRUE(exchangeReply.has_value());
+  EXPECT_EQ(exchangeReply->type, KvControlType::TABLE_EXCHANGE);
+  EXPECT_EQ(exchangeReply->table_blob, localTable);
+
+  KvControlMessage begin;
+  begin.type = KvControlType::BEGIN_MIGRATION;
+  begin.uuid = 42;
+  ASSERT_TRUE(senderCh.send(begin));
+  ASSERT_TRUE(receiverOrch.serveOne());
+
+  const auto ready = senderCh.receive();
+  ASSERT_TRUE(ready.has_value());
+  EXPECT_EQ(ready->type, KvControlType::MIRROR_READY);
+  EXPECT_EQ(ready->uuid, 42u);
+  EXPECT_FALSE(ready->ok);
+  EXPECT_TRUE(ready->segment_name.empty());
+}
+
 // The orchestrators drive a complete migration over the control channel: the
 // receiver runs on its own thread reacting to BeginMigration / DoneMarker while
 // the sender drives the sequence, and the bytes land on the decode devices.

--- a/tt-media-server/cpp_server/tests/unit/transport/kv_migration_orchestrator_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/transport/kv_migration_orchestrator_test.cpp
@@ -23,6 +23,7 @@
 #include "transport/in_memory_kv_table.hpp"
 #include "transport/kv_control_channel.hpp"
 #include "transport/kv_migration_multi_host_sender.hpp"
+#include "transport/kv_table_provisioning.hpp"
 #include "transport/mooncake_kv_receiver.hpp"
 #include "transport/mooncake_kv_sender.hpp"
 #include "transport/mooncake_migration_executor.hpp"


### PR DESCRIPTION
### Dockerizing the worker

```bash
docker run --rm --network host \
  -e WORKER_ROLE=prefill \
  -e WORKER_BIN=/usr/local/bin/mooncake_kv_migration_worker \
  -e WORKER_TAG=prefill-0 \
  -e METADATA=http://10.32.89.65:8080/metadata \
  -e PREFILL_TABLE=/tmp/tt-kv/prefill_kv_chunk_table.pb \
  -e PEERS=decode-0 \
  -e HEALTH_PORT=9109 \
  -e CONTROL_PORT=18650 \
  -e KV_MIGRATION_MODE=dry-run \
  -e KAFKA_BROKERS=10.32.89.65:9092 \
  -e MC_TCP_BIND_ADDRESS=10.32.89.65 \
  -e TT_LOG_LEVEL=debug \
  -v /tmp/tt-kv:/tmp/tt-kv:ro \
  ghcr.io/tenstorrent/tt-shield/tt-migration-worker:23072026-222200
```

Current **image size is 47MB**.

Deploy a set of workers accross the cluster
```bash
# Required for downloading internal docker images
export GHCR_USERNAME=dmadictt
export GHCR_TOKEN='ghp_...' # only read:packages privilege!

./deploy_migration_workers.sh \
  --discovery-server 10.32.89.65:8080 \
  --prefill-hosts bh-glx-110-d07u14 \
  --decode-hosts bh-glx-110-d08u14,bh-glx-120-c03u08 \
  --decode-table /data/dmadic/tt-kv/decoder_kv_table.pb \
  --prefill-table /data/dmadic/tt-kv/prefill_kv_chunk_table.pb \
  --health-port 9109 \
  --kafka-brokers 10.32.89.65:9092
```

Kafka and metadata service should be started independently
```bash
# Kafka
export KAFKA_ADVERTISED_HOST=10.32.89.99
export KAFKA_BROKERS="${KAFKA_ADVERTISED_HOST}:9092"
./dev-kafka.sh up
python migration_cli.py setup # To create topics
python migration_cli.py status

# Metadata service
python http_metadata_server.py
```
### Development environment

One of the exabox hosts is our development environment. After we do any code changes, we build a new version of the docker image and publish it. 

```bash
./build_migration_worker_image.sh --image tt-migration-worker:dev3
docker tag tt-migration-worker:dev3 ghcr.io/tenstorrent/tt-shield/tt-migration-worker:23072026-225800
docker login ghcr.io -u <GH_USERNAME>
docker push tt-migration-worker:dev3 ghcr.io/tenstorrent/tt-shield/tt-migration-worker:23072026-225800
```

Only the first docker build takes few minutes. Following ones are maximum one minute based on our latest tests.

Migration worker docker image uses [tt-llm-engine image](https://github.com/tenstorrent/tt-llm-engine/actions/workflows/build-image.yml) as a base.
By default, it will use an image built from the `tt-llm-engine` commit referenced in the codebase.

It also builds only the migration worker executable and its dependencies, without including the inference server code or dependencies.

### New dry-run mode

In order to test the discovery and table exchange, we have introduced a feature flag `KV_MIGRATION_MODE=dry-run`. When enabled, uses `StubMigrationExecutor` and avoids any code communicating with the device.

In the dry-run mode we can use arbitrary `WORKER_TAG`, even the ones that do not exist in the KV chunk tables.

### E2E validation

The code was tested successfully up to the point of discovery and table exchange between the workers.
Prefill host: bh-glx-110-d07u14
Decode hosts: bh-glx-110-d08u14,bh-glx-120-c03u08,bh-glx-b04u02

Prefill logs as proof
```bash
[2026-07-23 22:15:59.057484] [kv-migration-worker] [info] [worker] all 3 decode control channel(s) connected
[2026-07-23 22:15:59.057490] [kv-migration-worker] [info] [worker] waiting for control TABLE_EXCHANGE with all decode peers (local prefill blob 80148154 B)
[2026-07-23 22:16:00.170830] [kv-migration-worker] [info] [worker] TABLE_EXCHANGE with 'decode-0' ok (80148154 B local prefill blob)
[2026-07-23 22:16:01.373623] [kv-migration-worker] [info] [worker] TABLE_EXCHANGE with 'decode-1' ok (80148154 B local prefill blob)
[2026-07-23 22:16:02.564161] [kv-migration-worker] [info] [worker] TABLE_EXCHANGE with 'decode-2' ok (80148154 B local prefill blob)
[2026-07-23 22:16:02.568416] [kv-migration-worker] [info] [worker] prefill 'prefill-0' READY: 3/3 decode channels connected, mode=dry-run brokers=10.32.89.65:9092 req=kv-migration-requests ack=kv-migration-acks
[2026-07-23 22:16:02.568570] [kv-migration-worker] [info] [KvMigrationWorker] started (poll=100ms)
[2026-07-23 22:16:02.568619] [kv-migration-worker] [info] [KvMigrationWorker] consumer loop entered
```

We briefly tested the readiness endpoints, and the workers were shown as ready once discovery and table exchange is complete.
```
dmadic@slurm-login:~$ curl -f http://10.32.89.97:9109/readyz
{"ready":true,"worker":"host-0e3eb0e9"}
```

We even tested the rediscovery. If one of the decode worker containers gets stopped, the `deploy_migration_workers.sh` will restart it.
If prefill dies, this does not happen.