### PR TITLE
fix: LLM benchmark blocks are excluded from acceptance criteria

### DIFF
--- a/llm_module/__init__.py
+++ b/llm_module/__init__.py
@@ -28,6 +28,7 @@ from .server_control import (
     ServerController,
 )
 from .spec_decode import SpecDecodeRun, build_runs as build_spec_decode_runs
+from .target_checks import apply_target_checks, build_target_checks
 
 __all__ = [
     "LLMRunConfig",
@@ -55,6 +56,8 @@ __all__ = [
     "make_agentic_driver",
     "LLMPerformanceRunner",
     "RunnerResult",
+    "apply_target_checks",
+    "build_target_checks",
     "ServerController",
     "HttpServerController",
     "RemoteOpenAIController",

--- a/llm_module/benchmark_configs.py
+++ b/llm_module/benchmark_configs.py
@@ -51,26 +51,41 @@ def get_llm_configs(
             f"for model_id={model_spec.model_id!r}. Configured devices: {available}."
         )
 
+    text_params = [
+        params
+        for task in benchmark_config.tasks
+        for params in task.param_map.get(device, [])
+        if params.isl is not None
+        and params.osl is not None
+        and params.task_type == "text"
+    ]
+
+    targets_by_shape = {
+        (params.isl, params.osl, params.max_concurrency): params.targets
+        for params in text_params
+        if params.targets
+    }
+
     configs: List[LLMRunConfig] = []
     seen = set()
-    for task in benchmark_config.tasks:
-        for params in task.param_map.get(device, []):
-            if params.isl is None or params.osl is None:
-                continue
-            if params.task_type != "text":
-                continue
-            key = (params.isl, params.osl, params.max_concurrency, params.num_prompts)
-            if key in seen:
-                continue
-            seen.add(key)
-            configs.append(
-                LLMRunConfig(
-                    isl=params.isl,
-                    osl=params.osl,
-                    max_concurrency=params.max_concurrency,
-                    num_prompts=params.num_prompts,
-                )
+    for params in text_params:
+        key = (params.isl, params.osl, params.max_concurrency, params.num_prompts)
+        if key in seen:
+            continue
+        seen.add(key)
+        configs.append(
+            LLMRunConfig(
+                isl=params.isl,
+                osl=params.osl,
+                max_concurrency=params.max_concurrency,
+                num_prompts=params.num_prompts,
+                targets=dict(
+                    targets_by_shape.get(
+                        (params.isl, params.osl, params.max_concurrency), {}
+                    )
+                ),
             )
+        )
 
     if not configs:
         logger.warning(

--- a/llm_module/config.py
+++ b/llm_module/config.py
@@ -32,6 +32,7 @@ class LLMRunConfig:
     osl: int
     max_concurrency: int
     num_prompts: int
+    targets: dict = field(default_factory=dict, compare=False)
 
 
 @dataclass(frozen=True)

--- a/llm_module/parsers/aiperf.py
+++ b/llm_module/parsers/aiperf.py
@@ -17,11 +17,12 @@ from .base import metric_stat_int as _stat_int
 
 
 class AIPerfParser(LLMResultParser):
-    kind = "aiperf"
+    tool = "aiperf"
+    tool_label = "AIPerf"
 
     def parse(self, raw: Mapping[str, Any], *, device: str = "") -> Block:
         record: Dict[str, Any] = {
-            "kind": self.kind,
+            "tool": self.tool,
             "model": _model_name(raw),
             "device": device,
             "timestamp": _timestamp(raw),

--- a/llm_module/parsers/base.py
+++ b/llm_module/parsers/base.py
@@ -11,16 +11,22 @@ from typing import Any, Dict, Mapping, Optional
 
 from report_module.schema import Block
 
+BENCHMARKS_KIND = "benchmarks"
+
 
 class LLMResultParser(ABC):
     """Adapt one LLM perf tool's raw JSON output into a report Block.
 
-    Each concrete parser owns a single ``kind`` and knows the schema of
-    that tool's result file. Drivers must not call parsers themselves;
-    the runner orchestrates ``driver.run() -> parser.parse()``.
+    Each concrete parser knows the schema of one tool's result file and
+    names that tool in ``tool`` / ``tool_label``; ``kind`` stays the
+    canonical report kind so the block is routed like every other
+    benchmark. Drivers must not call parsers themselves; the runner
+    orchestrates ``driver.run() -> parser.parse()``.
     """
 
-    kind: str
+    kind: str = BENCHMARKS_KIND
+    tool: str = ""
+    tool_label: str = ""
 
     @abstractmethod
     def parse(self, raw: Mapping[str, Any], *, device: str = "") -> Block:
@@ -32,15 +38,16 @@ class LLMResultParser(ABC):
         """Wrap a flat report record in the canonical Block shape.
 
         ``data`` carries the report sections only — never a duplicate of
-        the envelope fields (``kind``/``model``/``device``/``timestamp``).
-        Per-block envelope fields move to ``Block.targets`` so the
-        runner can build report-level metadata without hunting them out
-        of section data, while the renderer pulls model/device from the
-        schema's metadata via its existing fallback in
-        :func:`report_module.renderers._resolve_model_device`.
+        the envelope fields (``kind``/``tool``/``model``/``device``/
+        ``timestamp``). Per-block envelope fields move to
+        ``Block.targets`` so the runner can build report-level metadata
+        without hunting them out of section data, while the renderer
+        pulls model/device from the schema's metadata via its existing
+        fallback in :func:`report_module.renderers._resolve_model_device`.
 
         ``title`` sets the section heading the generic renderer emits;
-        leave it ``None`` to fall back to the kind-derived heading.
+        leave it ``None`` to fall back to the tool-derived heading (or,
+        for parsers with no ``tool``, to the kind-derived one).
         """
         model = str(record.get("model", ""))
         device = str(record.get("device", ""))
@@ -49,9 +56,11 @@ class LLMResultParser(ABC):
         section_data = {
             k: v
             for k, v in record.items()
-            if k not in ("kind", "model", "device", "timestamp")
+            if k not in ("kind", "tool", "model", "device", "timestamp")
         }
         targets: Dict[str, Any] = {}
+        if self.tool:
+            targets["tool"] = self.tool
         if model:
             targets["model"] = model
         if device:
@@ -61,10 +70,18 @@ class LLMResultParser(ABC):
         return Block(
             kind=self.kind,
             id=block_id or None,
-            title=title,
+            title=title or self._default_title(record),
             data=section_data,
             targets=targets,
         )
+
+    def _default_title(self, record: Mapping[str, Any]) -> Optional[str]:
+        """Heading for a benchmark block, naming the tool that ran it."""
+        del record  # title depends on the tool only
+        if not self.tool:
+            return None
+        label = self.tool_label or self.tool.replace("_", " ").title()
+        return f"{label} Benchmark"
 
 
 def round_metric(value: Any, digits: int) -> Any:

--- a/llm_module/parsers/genai_perf.py
+++ b/llm_module/parsers/genai_perf.py
@@ -17,11 +17,12 @@ from .base import metric_stat_int as _stat_int
 
 
 class GenAIPerfParser(LLMResultParser):
-    kind = "genai_perf"
+    tool = "genai_perf"
+    tool_label = "GenAI-Perf"
 
     def parse(self, raw: Mapping[str, Any], *, device: str = "") -> Block:
         record: Dict[str, Any] = {
-            "kind": self.kind,
+            "tool": self.tool,
             "model": _model_name(raw),
             "device": device,
             "timestamp": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),

--- a/llm_module/parsers/guidellm.py
+++ b/llm_module/parsers/guidellm.py
@@ -58,7 +58,13 @@ SLO = {
 
 
 class GuideLLMParser(LLMResultParser):
+    # Deliberately NOT the canonical ``benchmarks`` kind, unlike the
+    # other perf parsers: a GuideLLM block is a nested scenario report, so there is
+    # no perf_reference entry to grade it against and the acceptance
+    # Benchmarks category would only ever see it as ungradable.
     kind = "guidellm"
+    tool = "guidellm"
+    tool_label = "GuideLLM"
 
     def parse(self, raw: Mapping[str, Any], *, device: str = "") -> Block:
         md = raw.get("metadata") or {}

--- a/llm_module/parsers/vllm.py
+++ b/llm_module/parsers/vllm.py
@@ -16,12 +16,13 @@ from .base import round_metric as _round
 
 
 class VLLMBenchParser(LLMResultParser):
-    kind = "vllm"
+    tool = "vllm"
+    tool_label = "vLLM"
 
     def parse(self, raw: Mapping[str, Any], *, device: str = "") -> Block:
         completed = _num(raw.get("completed"))
         record: Dict[str, Any] = {
-            "kind": self.kind,
+            "tool": self.tool,
             "model": str(raw.get("model_id", "") or ""),
             "device": device,
             "timestamp": _format_date(raw.get("date", "")),

--- a/llm_module/runner.py
+++ b/llm_module/runner.py
@@ -9,7 +9,9 @@ Mirrors v1 ``benchmarking/run_benchmarks.py`` orchestration:
 1. ``server.wait_for_healthy()`` — block until the inference server is up.
 2. ``server.capture_traces(unique (isl,osl) pairs)`` — warm trace cache.
 3. For each ``LLMRunConfig`` in the sweep: health-check, sleep 2 s,
-   ``driver.run()``, ``driver.parse(raw)`` → ``Block``.
+   ``driver.run()``, ``driver.parse(raw)`` → ``Block``, then grade the
+   Block against the sweep point's perf targets
+   (:func:`llm_module.target_checks.apply_target_checks`).
 
 Returns the list of Blocks plus any nonzero driver exit codes the
 caller should surface.
@@ -29,6 +31,7 @@ from report_module.schema import Block
 from .config import DriverContext, LLMRunConfig, ServerConnection
 from .drivers.base import LLMDriver
 from .server_control import ServerController
+from .target_checks import apply_target_checks
 
 logger = logging.getLogger(__name__)
 
@@ -149,6 +152,7 @@ class LLMPerformanceRunner:
                 continue
 
             block = self.driver.parse(outcome.raw, device=context.device)
+            block = apply_target_checks(block, cfg)
             result.blocks.append(block)
 
         return result

--- a/llm_module/target_checks.py
+++ b/llm_module/target_checks.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Grade one LLM benchmark block against its sweep point's perf targets.
+
+The tiered targets come from the model spec's ``perf_reference`` entries
+(``functional`` / ``complete`` / ``target``), carried onto the sweep point
+by :func:`llm_module.benchmark_configs.get_llm_configs` and attached to the
+parsed Block here, in the runner.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from report_module.schema import Block
+from workflows.workflow_types import ReportCheckTypes
+
+logger = logging.getLogger(__name__)
+
+# (field name in target_checks, PerformanceTarget attribute, lower_is_better)
+_METRIC_SPECS: Tuple[Tuple[str, str, bool], ...] = (
+    ("ttft", "ttft_ms", True),
+    ("tput_user", "tput_user", False),
+    ("tput", "tput", False),
+)
+
+TIER_ORDER: Tuple[str, ...] = ("functional", "complete", "target")
+
+
+def _measured(record: Mapping[str, Any]) -> Dict[str, Optional[float]]:
+    """Pull the three graded metrics out of a flat perf record.
+
+    ``tput_user`` is per-user decode throughput: AIPerf and genai-perf
+    report it directly, ``vllm bench serve`` does not, so derive it from
+    mean TPOT the way v1's summary report did (``1000 / mean_tpot_ms``).
+    """
+    ttft = _as_float(record.get("mean_ttft_ms"))
+    tput_user = _as_float(record.get("tput_user"))
+    if tput_user is None:
+        tpot = _as_float(record.get("mean_tpot_ms"))
+        tput_user = 1000.0 / tpot if tpot else None
+    return {
+        "ttft": ttft,
+        "tput_user": tput_user,
+        "tput": _as_float(record.get("tps_decode_throughput")),
+    }
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _check(ratio: float, tolerance: float, lower_is_better: bool) -> ReportCheckTypes:
+    passed = ratio < (1 + tolerance) if lower_is_better else ratio > (1 - tolerance)
+    return ReportCheckTypes.from_result(passed)
+
+
+def build_target_checks(
+    targets: Mapping[str, Any], record: Mapping[str, Any]
+) -> Tuple[Dict[str, Dict[str, Any]], ReportCheckTypes]:
+    """Build the tiered ``target_checks`` dict and its one-line verdict.
+
+    ``targets`` maps a tier name to a ``workflows.utils_report.PerformanceTarget``.
+    Each tier gets ``<field>`` (the target), ``<field>_ratio`` and
+    ``<field>_check`` per metric; a metric the tier does not define, or one
+    the tool did not measure, is ``NA`` rather than a failure.
+
+    The verdict is the strictest tier that fully passes, reported as PASS
+    only when the ``target`` tier passes at least one real check and none
+    fail — matching how the acceptance check reads the same dict.
+    """
+    measured = _measured(record)
+    target_checks: Dict[str, Dict[str, Any]] = {}
+    for tier_name in TIER_ORDER:
+        tier_target = targets.get(tier_name)
+        if tier_target is None:
+            continue
+        tolerance = getattr(tier_target, "tolerance", 0.0) or 0.0
+        tier: Dict[str, Any] = {}
+        for field, target_attr, lower_is_better in _METRIC_SPECS:
+            target_value = getattr(tier_target, target_attr, None)
+            actual = measured.get(field)
+            if not target_value or target_value <= 0:
+                tier[f"{field}_check"] = ReportCheckTypes.NA
+                continue
+            tier[field] = target_value
+            if actual is None:
+                tier[f"{field}_ratio"] = 0.0
+                tier[f"{field}_check"] = ReportCheckTypes.NA
+                continue
+            ratio = actual / target_value
+            tier[f"{field}_ratio"] = ratio
+            tier[f"{field}_check"] = _check(ratio, tolerance, lower_is_better)
+        target_checks[tier_name] = tier
+    return target_checks, _verdict(target_checks)
+
+
+def _verdict(target_checks: Mapping[str, Mapping[str, Any]]) -> ReportCheckTypes:
+    """PASS/FAIL/NA for the strictest (``target``) tier."""
+    tier = target_checks.get("target", {})
+    real = [
+        value
+        for name, value in tier.items()
+        if name.endswith("_check") and value != ReportCheckTypes.NA
+    ]
+    if not real:
+        return ReportCheckTypes.NA
+    if any(value == ReportCheckTypes.FAIL for value in real):
+        return ReportCheckTypes.FAIL
+    return ReportCheckTypes.PASS
+
+
+def apply_target_checks(block: Block, config: Any) -> Block:
+    """Return ``block`` with ``target_checks`` / ``target_check`` attached.
+
+    Blocks that are not canonical benchmark blocks (prefix-cache,
+    spec-decode, GuideLLM — each with its own kind and no sweep-point
+    targets) pass through untouched, as do non-record payloads.
+
+    A sweep point with no configured targets is marked ``status="na"``:
+    acceptance then counts the block as ungradable instead of grading an
+    all-NA ``target_checks`` dict as a pass, so "no targets defined for
+    this config" cannot read as "benchmarks passed".
+    """
+    from .parsers.base import BENCHMARKS_KIND
+
+    if block.kind != BENCHMARKS_KIND or not isinstance(block.data, Mapping):
+        return block
+
+    targets = getattr(config, "targets", None) or {}
+    data = dict(block.data)
+    if not targets:
+        logger.warning(
+            "No perf targets for sweep point isl=%s osl=%s max_concurrency=%s; "
+            "benchmark block is reported as NA (ungraded).",
+            getattr(config, "isl", "?"),
+            getattr(config, "osl", "?"),
+            getattr(config, "max_concurrency", "?"),
+        )
+        data["status"] = "na"
+        data["target_check"] = ReportCheckTypes.NA
+        return _replace_data(block, data)
+
+    target_checks, verdict = build_target_checks(targets, block.data)
+    if verdict == ReportCheckTypes.NA:
+        data["status"] = "na"
+    data["target_check"] = verdict
+    data["target_checks"] = target_checks
+    return _replace_data(block, data, title=_graded_title(block.title, config))
+
+
+def _graded_title(title: Optional[str], config: Any) -> Optional[str]:
+    """Name the sweep point in the title of a graded block.
+
+    Ungraded sweep points keep the tool's shared title so the generator
+    collapses them into one sweep table. A graded block cannot join that
+    table — its tiered ``target_checks`` is a nested dict, which renders
+    as a blob in a multi-row table — so it takes a per-config title and
+    renders as its own section, which also keeps its acceptance blocker
+    keys distinct from every other sweep point's.
+    """
+    isl = getattr(config, "isl", None)
+    osl = getattr(config, "osl", None)
+    concurrency = getattr(config, "max_concurrency", None)
+    if isl is None or osl is None or concurrency is None:
+        return title
+    point = f"ISL {isl} / OSL {osl}, concurrency {concurrency}"
+    return f"{title} Targets — {point}" if title else f"Benchmark Targets — {point}"
+
+
+def _replace_data(
+    block: Block, data: Dict[str, Any], title: Optional[str] = None
+) -> Block:
+    return Block(
+        kind=block.kind,
+        data=data,
+        title=title if title is not None else block.title,
+        task_type=block.task_type,
+        id=block.id,
+        targets=dict(block.targets),
+    )
+
+
+__all__ = ["TIER_ORDER", "apply_target_checks", "build_target_checks"]

--- a/report_module/renderers.py
+++ b/report_module/renderers.py
@@ -19,7 +19,7 @@ from report_module.display import (
 from report_module.formatting import format_value
 from report_module.markdown_table import build_markdown_table
 from report_module.schema import Block
-from report_module.status import glyph_for_label
+from report_module.status import TestStatus, glyph_for_label
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +73,11 @@ BENCHMARK_TIER_NOTE = (
     "The Target Checks table grades three tiers — functional, complete, and "
     "target — from most to least lenient. Acceptance criteria pass a benchmark "
     "when any single tier meets all of its checks."
+)
+
+UNGRADED_SWEEP_NOTE = (
+    "Note: No perf targets are configured for these sweep points, so these "
+    "rows are reported for information only and are not graded."
 )
 
 _REGISTRY: Dict[str, RendererFn] = {}
@@ -200,6 +205,30 @@ PIVOT_VALUE_HEADER = "**value**"
 _CHECK_COLUMN_SUFFIX = "_check"
 _CHECK_INT_TO_LABEL: Dict[int, str] = {1: "NA", 2: "PASS", 3: "FAIL"}
 
+# Columns that carry a grading verdict rather than a measurement.
+_GRADING_COLUMNS: tuple[str, ...] = ("status", "target_check")
+
+
+def _is_na_cell(column: str, value: Any) -> bool:
+    if column.endswith(_CHECK_COLUMN_SUFFIX):
+        return _CHECK_INT_TO_LABEL.get(value) == "NA"
+    return TestStatus.from_value(value) is TestStatus.NA
+
+
+def _ungraded_columns(records: Sequence[Mapping[str, Any]]) -> frozenset:
+    """Grading columns to drop because not one row in the table is graded."""
+    present = frozenset(
+        column for column in _GRADING_COLUMNS if not _column_is_empty(column, records)
+    )
+    if not present:
+        return frozenset()
+    for record in records:
+        for column in present:
+            value = record.get(column)
+            if value is not None and not _is_na_cell(column, value):
+                return frozenset()
+    return present
+
 
 def _format_cell(column: str, value: Any) -> str:
     if (
@@ -293,7 +322,9 @@ def _footnote_for(block: Block) -> str | None:
     return FOOTNOTES.get(block.kind)
 
 
-def render_generic_table(block: Block, metadata: Mapping[str, Any]) -> str:
+def render_generic_table(
+    block: Block, metadata: Mapping[str, Any], extra_hidden: frozenset = frozenset()
+) -> str:
     """Render a block as a heading plus one or more markdown tables.
 
     - Multi-record blocks render as a single multi-row table (the
@@ -301,6 +332,9 @@ def render_generic_table(block: Block, metadata: Mapping[str, Any]) -> str:
     - Single-record blocks split the record's fields: scalar fields
       collapse into the main pivot table; fields whose value is a dict
       or list-of-dicts become their own H4 sub-table, in insertion order.
+
+    ``extra_hidden`` drops columns on top of the per-kind hidden set, for
+    callers that decide per-block what is worth showing.
     """
     records = _extract_records(block)
     if not records:
@@ -311,7 +345,7 @@ def render_generic_table(block: Block, metadata: Mapping[str, Any]) -> str:
         block.kind, model, device, block.title or "", block.task_type or ""
     )
     footnote = _footnote_for(block)
-    hidden = _hidden_columns(block.kind)
+    hidden = _hidden_columns(block.kind) | extra_hidden
 
     if len(records) > 1:
         table = _build_table(records, hidden=hidden)
@@ -392,14 +426,24 @@ def _has_target_checks(block: Block) -> bool:
 
 @register(BENCHMARKS_KIND)
 def render_benchmarks(block: Block, metadata: Mapping[str, Any]) -> str:
-    """Render a benchmark block, appending the tier note when tiered
-    ``target_checks`` are present (LLM benchmarks without tiers get none)."""
-    table = render_generic_table(block, metadata)
+    """Render a benchmark block plus whichever notes apply.
+
+    The tier note is appended when tiered ``target_checks`` are present (LLM
+    benchmarks without tiers get none). A sweep whose every row is ungraded
+    drops its all-NA grading columns and explains why instead: the block data
+    keeps ``status="na"`` either way, since that is what stops acceptance from
+    reading "no targets configured" as "benchmarks passed".
+    """
+    ungraded = _ungraded_columns(_extract_records(block))
+    table = render_generic_table(block, metadata, extra_hidden=ungraded)
     if not table:
         return ""
+    notes = []
     if _has_target_checks(block):
-        return f"{table}\n\n{BENCHMARK_TIER_NOTE}"
-    return table
+        notes.append(BENCHMARK_TIER_NOTE)
+    if ungraded:
+        notes.append(UNGRADED_SWEEP_NOTE)
+    return "\n\n".join([table, *notes])
 
 
 for _kind in GENERIC_KINDS:

--- a/report_module/renderers.py
+++ b/report_module/renderers.py
@@ -283,6 +283,16 @@ def _is_subtable_value(value: Any) -> bool:
     return False
 
 
+def _footnote_for(block: Block) -> str | None:
+    targets = block.targets if isinstance(block.targets, Mapping) else {}
+    tool = targets.get("tool")
+    if tool:
+        footnote = FOOTNOTES.get(str(tool))
+        if footnote:
+            return footnote
+    return FOOTNOTES.get(block.kind)
+
+
 def render_generic_table(block: Block, metadata: Mapping[str, Any]) -> str:
     """Render a block as a heading plus one or more markdown tables.
 
@@ -300,7 +310,7 @@ def render_generic_table(block: Block, metadata: Mapping[str, Any]) -> str:
     heading = _heading(
         block.kind, model, device, block.title or "", block.task_type or ""
     )
-    footnote = FOOTNOTES.get(block.kind)
+    footnote = _footnote_for(block)
     hidden = _hidden_columns(block.kind)
 
     if len(records) > 1:

--- a/tests/llm_module/test_benchmark_configs.py
+++ b/tests/llm_module/test_benchmark_configs.py
@@ -86,5 +86,59 @@ def test_vlm_configs_never_leak_non_text_params(spec):
     assert cfg_keys.isdisjoint(non_text_only)
 
 
+def _specs_with_text_targets():
+    """One LLM spec per model that defines tiered targets for a text config."""
+    seen = {}
+    for spec in MODEL_SPECS.values():
+        params = [
+            p
+            for task in get_benchmark_config(spec).tasks
+            for p in task.param_map.get(spec.device_type, [])
+            if p.task_type == "text" and p.targets
+        ]
+        if params:
+            seen.setdefault(spec.model_name, (spec, params))
+    return list(seen.values())[:5]
+
+
+@pytest.mark.parametrize(
+    "spec,targeted", _specs_with_text_targets(), ids=lambda v: getattr(v, "id", "")
+)
+def test_perf_reference_targets_reach_the_sweep_point(spec, targeted):
+    """Targets ride along on the config so the runner can grade the run.
+
+    They live on the spec's ``perf_reference`` params only; dropping them
+    here is what left LLM benchmark blocks with no ``target_checks``.
+    """
+    configs = get_llm_configs(spec, spec.device_type)
+    graded = {
+        (c.isl, c.osl, c.max_concurrency): c.targets for c in configs if c.targets
+    }
+
+    for params in targeted:
+        shape = (params.isl, params.osl, params.max_concurrency)
+        assert shape in graded, f"targets lost for {shape}"
+        assert graded[shape] == params.targets
+
+
+def test_sweep_points_without_a_perf_reference_carry_no_targets():
+    """Only configs the spec actually defines targets for are graded."""
+    spec, targeted = _specs_with_text_targets()[0]
+    shapes_with_targets = {(p.isl, p.osl, p.max_concurrency) for p in targeted}
+
+    for config in get_llm_configs(spec, spec.device_type):
+        shape = (config.isl, config.osl, config.max_concurrency)
+        assert bool(config.targets) == (shape in shapes_with_targets)
+
+
+def test_configs_stay_hashable_with_targets_attached():
+    """``targets`` is compare=False; sweep-point identity is the numbers."""
+    spec, _ = _specs_with_text_targets()[0]
+    configs = get_llm_configs(spec, spec.device_type)
+    assert len({hash(c) for c in configs}) == len(
+        {(c.isl, c.osl, c.max_concurrency, c.num_prompts) for c in configs}
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/llm_module/test_parsers.py
+++ b/tests/llm_module/test_parsers.py
@@ -207,6 +207,36 @@ def test_missing_metrics_yield_none_not_keyerror():
         assert data["mean_ttft_ms"] is None
 
 
+@pytest.mark.parametrize(
+    "parser,raw,tool",
+    [
+        (AIPerfParser(), AIPERF_RAW, "aiperf"),
+        (GenAIPerfParser(), GENAI_RAW, "genai_perf"),
+        (VLLMBenchParser(), VLLM_RAW, "vllm"),
+    ],
+)
+def test_perf_blocks_use_the_canonical_benchmarks_kind(parser, raw, tool):
+    """Acceptance criteria and the summary aggregator route on ``kind``.
+
+    A tool-named kind makes the block invisible to both: the Benchmarks
+    category reports "no blocks present" and the run passes ungraded.
+    """
+    block = parser.parse(raw, device="N150")
+
+    assert block.kind == "benchmarks"
+    # tool identity survives the shared kind, for footnotes and provenance
+    assert block.targets["tool"] == tool
+    assert block.title and block.title.endswith("Benchmark")
+    assert "tool" not in block.data
+
+
+def test_sweep_points_of_one_tool_share_a_title():
+    """Identical titles let the generator collapse the sweep into one table."""
+    first = VLLMBenchParser().parse(VLLM_RAW, device="N150")
+    second = VLLMBenchParser().parse({**VLLM_RAW, "max_concurrency": 32}, device="N150")
+    assert first.title == second.title == "vLLM Benchmark"
+
+
 def test_canonical_keys_have_display_names():
     # The flat keys must resolve to the shared, human display headers.
     assert display_name("mean_ttft_ms") == "TTFT (ms)"

--- a/tests/llm_module/test_runner.py
+++ b/tests/llm_module/test_runner.py
@@ -188,3 +188,38 @@ class TestRunnerResultOk:
         assert RunnerResult(return_codes=[]).ok is False
         assert RunnerResult(return_codes=[0, 1]).ok is False
         assert RunnerResult(return_codes=[0], parse_failures=[1]).ok is False
+
+
+class TestSweepPointGrading:
+    """The runner is where a Block meets the config that produced it, so it
+    is where perf targets get applied — the summary aggregator that used to
+    own target checks is never reached by the release workflow."""
+
+    @staticmethod
+    def _targeted_cfg():
+        from workflows.utils_report import PerformanceTarget
+
+        return LLMRunConfig(
+            isl=128,
+            osl=64,
+            max_concurrency=1,
+            num_prompts=8,
+            targets={"target": PerformanceTarget(ttft_ms=100.0)},
+        )
+
+    def test_graded_sweep_point_gets_target_checks(self):
+        driver = FakeDriver([_ok({"mean_ttft_ms": 50.0})])
+        result = _runner(driver, FakeController()).run(
+            [self._targeted_cfg()], _SERVER, _CTX
+        )
+
+        checks = result.blocks[0].data["target_checks"]
+        assert checks["target"]["ttft_ratio"] == 0.5
+        assert int(checks["target"]["ttft_check"]) == 2  # ReportCheckTypes.PASS
+
+    def test_ungraded_sweep_point_is_marked_na(self):
+        driver = FakeDriver([_ok({"mean_ttft_ms": 50.0})])
+        result = _runner(driver, FakeController()).run([_cfg()], _SERVER, _CTX)
+
+        assert result.blocks[0].data["status"] == "na"
+        assert "target_checks" not in result.blocks[0].data

--- a/tests/llm_module/test_target_checks.py
+++ b/tests/llm_module/test_target_checks.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for per-run LLM benchmark grading (``llm_module.target_checks``).
+
+Covers the grading itself and the contract that matters downstream: a
+graded block reaches ``report_module.acceptance_criteria`` with the
+``target_checks`` it needs, and an ungraded sweep point is reported as
+NA rather than passing silently.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_module.config import LLMRunConfig
+from llm_module.parsers.vllm import VLLMBenchParser
+from llm_module.target_checks import apply_target_checks, build_target_checks
+from report_module import acceptance_criteria_check
+from report_module.schema import Block, ReportSchema
+from workflows.utils_report import PerformanceTarget
+from workflows.workflow_types import ReportCheckTypes
+
+TARGETS = {
+    "functional": PerformanceTarget(ttft_ms=890.0, tput_user=1.7, tput=1.7),
+    "complete": PerformanceTarget(ttft_ms=178.0, tput_user=8.5, tput=8.5),
+    "target": PerformanceTarget(ttft_ms=89.0, tput_user=17.0, tput=17.0),
+}
+
+
+def _record(ttft=350.0, tpot=69.8, tput=13.9, **extra):
+    record = {
+        "concurrency": 1,
+        "num_requests": 8,
+        "input_sequence_length": 128,
+        "output_sequence_length": 128.0,
+        "mean_ttft_ms": ttft,
+        "mean_tpot_ms": tpot,
+        "tps_decode_throughput": tput,
+    }
+    record.update(extra)
+    return record
+
+
+def _cfg(targets=None, isl=128, osl=128, max_concurrency=1):
+    return LLMRunConfig(
+        isl=isl,
+        osl=osl,
+        max_concurrency=max_concurrency,
+        num_prompts=8,
+        targets=dict(targets or {}),
+    )
+
+
+def _block(record=None, kind="benchmarks", title="vLLM Benchmark"):
+    return Block(
+        kind=kind, data=record if record is not None else _record(), title=title
+    )
+
+
+class TestBuildTargetChecks:
+    def test_grades_every_tier_per_metric(self):
+        checks, verdict = build_target_checks(TARGETS, _record())
+
+        assert set(checks) == {"functional", "complete", "target"}
+        # 350ms TTFT clears the 890ms functional bar but not the 178ms one.
+        assert checks["functional"]["ttft_check"] == ReportCheckTypes.PASS
+        assert checks["complete"]["ttft_check"] == ReportCheckTypes.FAIL
+        assert checks["functional"]["ttft"] == 890.0
+        assert checks["functional"]["ttft_ratio"] == pytest.approx(350.0 / 890.0)
+        # verdict follows the strictest tier only
+        assert verdict == ReportCheckTypes.FAIL
+
+    def test_passes_when_strictest_tier_is_met(self):
+        _, verdict = build_target_checks(
+            TARGETS, _record(ttft=50.0, tpot=40.0, tput=25.0)
+        )
+        assert verdict == ReportCheckTypes.PASS
+
+    def test_derives_tput_user_from_tpot_when_tool_omits_it(self):
+        """``vllm bench serve`` reports no per-user throughput; TPOT gives it."""
+        checks, _ = build_target_checks(TARGETS, _record(tpot=100.0))
+        # 1000 / 100ms = 10 tok/s/user against the 8.5 "complete" target
+        assert checks["complete"]["tput_user_ratio"] == pytest.approx(10.0 / 8.5)
+        assert checks["complete"]["tput_user_check"] == ReportCheckTypes.PASS
+
+    def test_prefers_the_tools_own_tput_user(self):
+        checks, _ = build_target_checks(TARGETS, _record(tpot=100.0, tput_user=4.0))
+        assert checks["complete"]["tput_user_ratio"] == pytest.approx(4.0 / 8.5)
+
+    def test_tolerance_widens_the_bar(self):
+        tolerant = {"target": PerformanceTarget(ttft_ms=100.0, tolerance=0.2)}
+        strict = {"target": PerformanceTarget(ttft_ms=100.0, tolerance=0.0)}
+        record = _record(ttft=110.0)
+
+        assert build_target_checks(tolerant, record)[1] == ReportCheckTypes.PASS
+        assert build_target_checks(strict, record)[1] == ReportCheckTypes.FAIL
+
+    def test_undefined_target_and_unmeasured_metric_are_na_not_failures(self):
+        targets = {"target": PerformanceTarget(ttft_ms=89.0)}  # no tput targets
+        checks, _ = build_target_checks(targets, {"mean_ttft_ms": None})
+
+        assert checks["target"]["ttft_check"] == ReportCheckTypes.NA
+        assert checks["target"]["tput_check"] == ReportCheckTypes.NA
+        assert checks["target"]["tput_user_check"] == ReportCheckTypes.NA
+
+
+class TestApplyTargetChecks:
+    def test_graded_block_carries_checks_and_a_per_config_title(self):
+        block = apply_target_checks(_block(), _cfg(TARGETS))
+
+        assert (
+            block.data["target_checks"]["target"]["ttft_check"] == ReportCheckTypes.FAIL
+        )
+        assert block.data["target_check"] == ReportCheckTypes.FAIL
+        # per-config title: keeps blocker keys distinct and keeps the nested
+        # tier table out of the collapsed sweep table
+        assert (
+            block.title == "vLLM Benchmark Targets — ISL 128 / OSL 128, concurrency 1"
+        )
+        assert "status" not in block.data
+
+    def test_ungraded_sweep_point_is_na_and_keeps_the_shared_title(self):
+        block = apply_target_checks(_block(), _cfg())
+
+        assert block.data["status"] == "na"
+        assert block.data["target_check"] == ReportCheckTypes.NA
+        assert "target_checks" not in block.data
+        assert block.title == "vLLM Benchmark"
+
+    def test_leaves_non_benchmark_kinds_untouched(self):
+        """Prefix-cache / spec-decode blocks keep their own kind and shape."""
+        block = _block(kind="aiperf_prefix_cache")
+        assert apply_target_checks(block, _cfg(TARGETS)) is block
+
+    def test_grades_a_real_parsed_vllm_block(self):
+        raw = {
+            "model_id": "meta-llama/Llama-3.3-70B-Instruct",
+            "date": "20260727-035000",
+            "completed": 8,
+            "max_concurrency": 1,
+            "total_input_tokens": 1024,
+            "total_output_tokens": 1024,
+            "mean_ttft_ms": 350.3233,
+            "mean_tpot_ms": 69.809,
+            "output_throughput": 13.8884,
+        }
+        block = apply_target_checks(
+            VLLMBenchParser().parse(raw, device="P300X2"), _cfg(TARGETS)
+        )
+        assert block.kind == "benchmarks"
+        assert block.data["target_checks"]["functional"]["ttft_check"] == (
+            ReportCheckTypes.PASS
+        )
+
+
+class TestAcceptanceIntegration:
+    """The point of the exercise: benchmarks reach the acceptance verdict."""
+
+    @staticmethod
+    def _benchmarks(*blocks):
+        schema = ReportSchema(
+            metadata={"report_id": "r", "model_name": "m", "device": "d"},
+            sections=list(blocks),
+        )
+        accepted, blockers, categories = acceptance_criteria_check(schema)
+        category = next(c for c in categories if c.name == "Benchmarks")
+        return accepted, blockers, category
+
+    def test_a_regressed_sweep_point_blocks_the_run(self):
+        regressed = apply_target_checks(
+            _block(_record(ttft=35000.0, tpot=6980.0, tput=0.14)), _cfg(TARGETS)
+        )
+        accepted, blockers, category = self._benchmarks(regressed)
+
+        assert accepted is False
+        assert category.status == "FAIL"
+        assert any("ttft_check" in key for key in blockers)
+
+    def test_a_met_target_passes_with_the_block_counted(self):
+        graded = apply_target_checks(
+            _block(_record(ttft=50.0, tpot=40.0, tput=25.0)), _cfg(TARGETS)
+        )
+        accepted, _, category = self._benchmarks(graded)
+
+        assert accepted is True
+        assert (category.status, category.total, category.passed) == ("PASS", 1, 1)
+
+    def test_ungraded_blocks_are_na_not_a_silent_pass(self):
+        ungraded = apply_target_checks(_block(), _cfg())
+        accepted, blockers, category = self._benchmarks(ungraded)
+
+        # non-blocking, but visible: 1 block present and ungraded, never
+        # "no blocks present" and never a PASS nobody measured
+        assert (accepted, blockers) == (True, {})
+        assert (category.status, category.total, category.na) == ("NA", 1, 1)
+
+    def test_blocker_keys_stay_distinct_across_graded_sweep_points(self):
+        first = apply_target_checks(
+            _block(_record(ttft=35000.0, tpot=6980.0, tput=0.14)), _cfg(TARGETS)
+        )
+        second = apply_target_checks(
+            _block(_record(ttft=35000.0, tpot=6980.0, tput=0.14)),
+            _cfg(TARGETS, isl=1024, max_concurrency=32),
+        )
+        _, blockers, category = self._benchmarks(first, second)
+
+        assert category.failed == 2
+        assert sum("ISL 1024" in key for key in blockers) > 0
+        assert sum("ISL 128" in key for key in blockers) > 0

--- a/tests/report_module/test_generator.py
+++ b/tests/report_module/test_generator.py
@@ -280,3 +280,26 @@ class TestGenerate:
         assert "✅ PASS" in md
         # No metrics -> no per-block table heading.
         assert "### Bare" not in md
+
+    def test_perf_tool_footnote_survives_the_shared_benchmarks_kind(
+        self, tmp_path: Path
+    ):
+        """LLM perf blocks share ``kind="benchmarks"``; the tool on
+        ``Block.targets`` is what selects the methodology footnote."""
+        block = Block(
+            kind="benchmarks",
+            title="vLLM Benchmark",
+            targets={"tool": "vllm"},
+            data={"mean_ttft_ms": 350.3, "tps_decode_throughput": 13.9},
+        )
+        md = ReportGenerator().generate(_schema(block), tmp_path).markdown
+        assert "report the mean value across the benchmark run" in md
+
+    def test_benchmark_block_without_a_tool_has_no_perf_footnote(self, tmp_path: Path):
+        block = Block(
+            kind="benchmarks",
+            title="Image Benchmark",
+            data={"Benchmarks": {"ttft_ms": 350.3}},
+        )
+        md = ReportGenerator().generate(_schema(block), tmp_path).markdown
+        assert "report the mean value across the benchmark run" not in md


### PR DESCRIPTION
A release run produced 17 vLLM benchmark blocks; acceptance said Benchmarks: NA and passed. The parsers emitted kind: "vllm", but _check_benchmarks filters on kind == "benchmarks" , so it found zero blocks, and nothing ever compared the metrics to the functional/complete/target tiers in perf_reference. The category couldn't fail.

CI run: https://github.com/tenstorrent/tt-shield/actions/runs/30290328246