### PR TITLE
Fix forge model crash on Blackhole (set mesh graph descriptor)

### DIFF
--- a/tt-media-server/tests/test_worker_utils.py
+++ b/tt-media-server/tests/test_worker_utils.py
@@ -204,6 +204,26 @@ class TestSetupRunnerEnvironment:
 
                             mock_galaxy.assert_not_called()
 
+    def test_calls_blackhole_setup_for_forge_runner(self):
+        """Forge runner on a Blackhole device must get the mesh descriptor (#4784)."""
+        with patch.dict(os.environ, {"TT_METAL_HOME": "/opt/tt-metal"}, clear=True):
+            with patch("utils.runner_utils.set_torch_thread_limits"):
+                with patch("utils.runner_utils.get_telemetry_client"):
+                    with patch(
+                        "utils.runner_utils._setup_blackhole_mesh_config"
+                    ) as mock_bh:
+                        mock_settings_forge = Mock()
+                        mock_settings_forge.enable_telemetry = False
+                        mock_settings_forge.is_galaxy = False
+                        mock_settings_forge.device = "p300x2"
+                        mock_settings_forge.model_runner = "vllm_forge"
+                        mock_settings_forge.default_throttle_level = None
+
+                        with patch("utils.runner_utils.settings", mock_settings_forge):
+                            setup_runner_environment("0")
+
+                            mock_bh.assert_called_once_with("/opt/tt-metal")
+
     def test_custom_cpu_threads(self):
         """Test custom cpu_threads parameter"""
         with patch.dict(os.environ, {}, clear=True):

--- a/tt-media-server/utils/runner_utils.py
+++ b/tt-media-server/utils/runner_utils.py
@@ -52,6 +52,14 @@ def setup_runner_environment(
     _RUNNERS_REQUIRING_MESH_DESCRIPTOR = {
         ModelRunners.TT_WHISPER.value,
         ModelRunners.TT_SPEECHT5_TTS.value,
+        # Forge (tt-xla) inits the device via torch_xla.device(), which aborts on a
+        # Blackhole CUSTOM cluster unless TT_MESH_GRAPH_DESC_PATH is set (see #4784).
+        ModelRunners.VLLMForge.value,
+        ModelRunners.VLLMForge_LLAMA_70B.value,
+        ModelRunners.VLLMForge_GEMMA4_31B.value,
+        ModelRunners.VLLMForge_QWEN_32B.value,
+        ModelRunners.VLLMForge_MISTRAL_SMALL_31_24B.value,
+        ModelRunners.VLLMForge_QWEN_EMBEDDING.value,
     }
     if settings.model_runner in _RUNNERS_REQUIRING_MESH_DESCRIPTOR:
         if settings.is_galaxy:


### PR DESCRIPTION
Forge models crash at startup on Blackhole boards (e.g. a single P150 on a P300x2). tt-metal needs a mesh graph descriptor path set for these, but forge runners were never added to the list of runners that get one — so device init aborts.

This adds the forge runners to that list. The existing device check means nothing changes for Wormhole (N150/N300).

Added two tests: forge on Blackhole now gets the descriptor, forge on Wormhole still doesn't.

Fixes #4784