### PR TITLE
Update config for Forge's Mistral 3.1 24B

### DIFF
--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -215,6 +215,9 @@ class EvalTask:
             EvalLimitMode.SMOKE_TEST: 0.01,
         }
     )
+    # Let this task's scorer execute model-generated code on the eval host.
+    # Off by default: the host is the CI runner, not containerized.
+    allow_code_execution: bool = False
     agentic_eval_config: Optional[TerminalBenchEvalConfig] = None
     swebench_eval_config: Optional[SWEbenchEvalConfig] = None
 
@@ -2537,6 +2540,7 @@ _eval_config_list = [
                 task_name="humaneval_instruct",
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 use_chat_api=True,
+                allow_code_execution=True,
                 score=EvalTaskScore(
                     published_score=88.41,
                     published_score_ref="https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503",

--- a/test_module/llm_tests/llm_eval_tests.py
+++ b/test_module/llm_tests/llm_eval_tests.py
@@ -336,6 +336,15 @@ def _run_eval_task(ctx: MediaContext, task, auth_token: str) -> int:
     if auth_token:
         # lm-eval local-completions reads the bearer token from OPENAI_API_KEY.
         env["OPENAI_API_KEY"] = auth_token
+    if getattr(task, "allow_code_execution", False):
+        # HF evaluate's code_eval metric refuses to run without this. Scoped to
+        # this subprocess only -- never os.environ, the image, or the workflow
+        # env -- so it cannot leak to another task in the same run.
+        env["HF_ALLOW_CODE_EVAL"] = "1"
+        logger.warning(
+            "task=%s runs model-generated code on this host (allow_code_execution).",
+            task.task_name,
+        )
     logger.info("Running eval task=%s", task.task_name)
     return run_command(command=cmd, logger=logger, env=env)
 

--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -12,6 +12,8 @@ tabulate
 diffusers==0.37.1
 transformers
 
+mistral-common>=1.0.0 # mistral's tokenizer
+
 datasets # model training
 peft # model training
 

--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -12,7 +12,7 @@ tabulate
 diffusers==0.37.1
 transformers
 
-mistral-common>=1.0.0 # mistral's tokenizer
+mistral-common[image]==1.11.7 # mistral's tokenizer
 
 datasets # model training
 peft # model training

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -1383,7 +1383,7 @@ templates:
   device_model_specs:
     - device: SUPER_CLUSTER
       max_concurrency: 64
-      max_context: 262144  # 256 * 1024; 
+      max_context: 262144  # 256 * 1024;
       default_impl: true
   status: EXPERIMENTAL
   env_vars:
@@ -1408,7 +1408,7 @@ templates:
   device_model_specs:
     - device: SUPER_CLUSTER
       max_concurrency: 64
-      max_context: 204800  # 200 * 1024; 
+      max_context: 204800  # 200 * 1024;
       default_impl: true
   status: EXPERIMENTAL
   env_vars:
@@ -1444,7 +1444,7 @@ templates:
   device_model_specs:
     - device: SUPER_CLUSTER
       max_concurrency: 64
-      max_context: 262144  # 256 * 1024; 
+      max_context: 262144  # 256 * 1024;
       default_impl: true
   status: EXPERIMENTAL
   env_vars:
@@ -1465,7 +1465,7 @@ templates:
   device_model_specs:
     - device: SUPER_CLUSTER
       max_concurrency: 64
-      max_context: 1048576  # 1024 * 1024; 
+      max_context: 1048576  # 1024 * 1024;
       default_impl: true
   status: EXPERIMENTAL
   env_vars:
@@ -1713,6 +1713,13 @@ templates:
       max_context: 8192
       default_impl: true
       eval_max_retries: 1
+      known_issues:
+        - workflow_type: EVALS
+          task_name: gpqa_diamond_cot_zeroshot
+          reason: "35.86% vs published 45.96% (ratio 0.78, needs >=43.66%), cot_zeroshot methodology differs from the publisher's. Not a regression signal until gpu_reference_score is populated."
+        - workflow_type: EVALS
+          task_name: humaneval_instruct
+          reason: "79.27% vs published 88.41% (ratio 0.90, needs >=83.99%). Not a regression signal until gpu_reference_score is populated."
       env_vars:
         MAX_MODEL_LENGTH: "8192"
         MAX_NUM_SEQS: "32"


### PR DESCRIPTION
Make the Experimental weekly runs of Mistral 3.1 24B in tt-shield CI actually green by explicitly listing known issues. HumanEval is also additionally fixed by threading the required env. var.

Also, explicitly list Mistral's tokenizer as a dependency. It is currently pulled as a dependency of vLLM, but that can be silently dropped at any time.