### PR TITLE
Add Wan2.2-Lightning I2V model runner

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -25,6 +25,7 @@ class SupportedModels(Enum):
     WAN_2_2_I2V_ANISORA = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
     WAN_2_2_I2V_DISTILL = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
     WAN_2_2_I2V_LORA = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+    WAN_2_2_I2V_LIGHTNING = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
     DISTIL_WHISPER_LARGE_V3 = "distil-whisper/distil-large-v3"
     OPENAI_WHISPER_LARGE_V3 = "openai/whisper-large-v3"
     PYANNOTE_SPEAKER_DIARIZATION = "pyannote/speaker-diarization-3.0"
@@ -71,6 +72,7 @@ class ModelNames(Enum):
     WAN_2_2_I2V_ANISORA = "Wan2.2-I2V-AniSora-V3.2"
     WAN_2_2_I2V_DISTILL = "Wan2.2-I2V-Distill-LightX2V"
     WAN_2_2_I2V_LORA = "Wan2.2-I2V-LoRA"
+    WAN_2_2_I2V_LIGHTNING = "Wan2.2-I2V-Lightning"
     DISTIL_WHISPER_LARGE_V3 = "distil-large-v3"
     OPENAI_WHISPER_LARGE_V3 = "whisper-large-v3"
     MICROSOFT_RESNET_50 = "resnet-50"
@@ -119,6 +121,7 @@ class ModelRunners(Enum):
     TT_WAN_2_2_I2V_ANISORA = "tt-wan2.2-i2v-anisora"
     TT_WAN_2_2_I2V_DISTILL = "tt-wan2.2-i2v-distill"
     TT_WAN_2_2_I2V_LORA = "tt-wan2.2-i2v-lora"
+    TT_WAN_2_2_I2V_LIGHTNING = "tt-wan2.2-i2v-lightning"
     TT_WHISPER = "tt-whisper"
     VLLMForge = "vllm_forge"
     TT_YOLOV4 = "tt-yolov4"
@@ -213,6 +216,7 @@ MODEL_SERVICE_RUNNER_MAP = {
         ModelRunners.TT_WAN_2_2_I2V_ANISORA,
         ModelRunners.TT_WAN_2_2_I2V_DISTILL,
         ModelRunners.TT_WAN_2_2_I2V_LORA,
+        ModelRunners.TT_WAN_2_2_I2V_LIGHTNING,
         ModelRunners.SP_RUNNER,
     },
     ModelServices.TRAINING: {
@@ -242,6 +246,7 @@ INFERENCE_MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.TT_WAN_2_2_I2V_ANISORA: {ModelNames.WAN_2_2_I2V_ANISORA},
     ModelRunners.TT_WAN_2_2_I2V_DISTILL: {ModelNames.WAN_2_2_I2V_DISTILL},
     ModelRunners.TT_WAN_2_2_I2V_LORA: {ModelNames.WAN_2_2_I2V_LORA},
+    ModelRunners.TT_WAN_2_2_I2V_LIGHTNING: {ModelNames.WAN_2_2_I2V_LIGHTNING},
     ModelRunners.SP_RUNNER: {
         ModelNames.WAN_2_2,
         ModelNames.WAN_2_2_I2V,
@@ -920,6 +925,13 @@ ModelConfigs = {
         "request_processing_timeout_seconds": 5000,
     },
     (ModelRunners.TT_WAN_2_2_I2V_LORA, DeviceTypes.BLACKHOLE_GALAXY): {
+        "device_mesh_shape": (4, 8),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_32_GROUP.value,
+        "max_batch_size": 1,
+        "request_processing_timeout_seconds": 5000,
+    },
+    (ModelRunners.TT_WAN_2_2_I2V_LIGHTNING, DeviceTypes.BLACKHOLE_GALAXY): {
         "device_mesh_shape": (4, 8),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_32_GROUP.value,

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -337,6 +337,7 @@ class Settings(BaseSettings):
             ModelRunners.TT_WAN_2_2_I2V_ANISORA.value,
             ModelRunners.TT_WAN_2_2_I2V_DISTILL.value,
             ModelRunners.TT_WAN_2_2_I2V_LORA.value,
+            ModelRunners.TT_WAN_2_2_I2V_LIGHTNING.value,
         ]:
             self.default_throttle_level = None
 

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -21,6 +21,7 @@ from config.settings import get_settings
 from domain.image_generate_request import ImageGenerateRequest
 from domain.video_generate_request import VideoGenerateRequest
 from domain.video_i2v_generate_request import ImagePromptEntry, VideoI2VGenerateRequest
+from huggingface_hub import hf_hub_download
 from models.common.utility_functions import is_blackhole
 from models.tt_dit.pipelines.flux1.pipeline_flux1 import Flux1Pipeline
 from models.tt_dit.pipelines.mochi.pipeline_mochi import MochiPipeline
@@ -55,6 +56,7 @@ dit_runner_log_map = {
     ModelRunners.TT_WAN_2_2_I2V_ANISORA.value: "Wan22-I2V-AniSora",
     ModelRunners.TT_WAN_2_2_I2V_DISTILL.value: "Wan22-I2V-Distill",
     ModelRunners.TT_WAN_2_2_I2V_LORA.value: "Wan22-I2V-LoRA",
+    ModelRunners.TT_WAN_2_2_I2V_LIGHTNING.value: "Wan22-I2V-Lightning",
     ModelRunners.TT_QWEN_IMAGE.value: "Qwen-Image",
     ModelRunners.TT_QWEN_IMAGE_2512.value: "Qwen-Image-2512",
     ModelRunners.SP_RUNNER.value: "SP-Runner",
@@ -386,6 +388,10 @@ WAN22_ANISORA_GUIDANCE_SCALE = 3.5
 # the validated good-quality / low-latency point (~9.3s traced). The client's
 # num_inference_steps is ignored, same as the distill runner.
 WAN22_ANISORA_NUM_STEPS = 8
+
+WAN22_LIGHTNING_NUM_STEPS = 4
+WAN22_LIGHTNING_BOUNDARY_RATIO = 0.875
+WAN22_LIGHTNING_FLOW_SHIFT = 5.0
 
 
 def _wan22_needs_ring_fabric(mesh_shape: tuple) -> bool:
@@ -945,3 +951,87 @@ class TTWan22I2VLoRARunner(TTDiTRunner):
 
     def _build_warmup_video_request(self) -> VideoI2VGenerateRequest:
         return _wan22_i2v_warmup_request("A golden retriever running on a sandy beach")
+
+
+class TTWan22I2VLightningRunner(TTDiTRunner):
+    """Wan2.2 I2V with lightx2v/Wan2.2-Lightning distilled LoRA weights."""
+
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self.resolution = wan22_target_resolution(self.settings.device_mesh_shape)
+        self.image_manager = ImageManager()
+
+    def create_pipeline(self):
+        try:
+            from models.tt_dit.experimental.pipelines.pipeline_wan_lora import (
+                WanPipelineI2VLora,
+            )
+
+            lora_high = os.environ.get("LORA_HIGH_PATH") or hf_hub_download(
+                repo_id="lightx2v/Wan2.2-Lightning",
+                filename="Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1/high_noise_model.safetensors",
+            )
+            lora_low = os.environ.get("LORA_LOW_PATH") or hf_hub_download(
+                repo_id="lightx2v/Wan2.2-Lightning",
+                filename="Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1/low_noise_model.safetensors",
+            )
+            self.logger.info(
+                f"Device {self.device_id}: Lightning adapters "
+                f"high={lora_high}, low={lora_low}"
+            )
+
+            return WanPipelineI2VLora.create_pipeline(
+                mesh_device=self.ttnn_device,
+                height=self.resolution.height,
+                width=self.resolution.width,
+                num_frames=WAN22_NUM_FRAMES,
+                boundary_ratio=WAN22_LIGHTNING_BOUNDARY_RATIO,
+                lora_high=lora_high,
+                lora_low=lora_low,
+            )
+        except Exception as e:
+            log_exception_chain(
+                self.logger, self.device_id, "Lightning I2V pipeline creation failed", e
+            )
+            raise
+
+    def load_weights(self):
+        return False
+
+    def _build_image_prompt(self, request: VideoI2VGenerateRequest) -> list:
+        return [
+            ImagePrompt(
+                image=self.image_manager.base64_to_pil_image(entry.image),
+                frame_pos=entry.frame_pos,
+            )
+            for entry in request.image_prompts
+        ]
+
+    @log_execution_time(
+        f"{dit_runner_log_map.get(get_settings().model_runner, 'Lightning')} inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    def run(self, requests: list[VideoI2VGenerateRequest]):
+        self.logger.debug(f"Device {self.device_id}: Running Lightning inference")
+        request = requests[0]
+        seed = int(request.seed) if request.seed is not None else 0
+        pipeline_args = {
+            "prompts": [request.prompt],
+            "num_inference_steps": WAN22_LIGHTNING_NUM_STEPS,
+            "guidance_scale": 1.0,
+            "guidance_scale_2": 1.0,
+            "flow_shift": WAN22_LIGHTNING_FLOW_SHIFT,
+            "seed": seed,
+            "traced": True,
+            "image_prompt": self._build_image_prompt(request),
+        }
+        frames = self.pipeline(**pipeline_args)
+        self.logger.debug(f"Device {self.device_id}: Lightning inference completed")
+        return frames
+
+    def get_pipeline_device_params(self):
+        return _wan22_dit_device_params(self.settings.device_mesh_shape)
+
+    def _build_warmup_video_request(self) -> VideoI2VGenerateRequest:
+        return _wan22_i2v_warmup_request()

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -58,6 +58,9 @@ AVAILABLE_RUNNERS = {
     ModelRunners.TT_WAN_2_2_I2V_LORA: lambda wid: __import__(
         "tt_model_runners.dit_runners", fromlist=["TTWan22I2VLoRARunner"]
     ).TTWan22I2VLoRARunner(wid),
+    ModelRunners.TT_WAN_2_2_I2V_LIGHTNING: lambda wid: __import__(
+        "tt_model_runners.dit_runners", fromlist=["TTWan22I2VLightningRunner"]
+    ).TTWan22I2VLightningRunner(wid),
     ModelRunners.TT_WHISPER: lambda wid: __import__(
         "tt_model_runners.whisper_runner", fromlist=["TTWhisperRunner"]
     ).TTWhisperRunner(wid),

--- a/tt-media-server/tt_model_runners/video_runner.py
+++ b/tt-media-server/tt_model_runners/video_runner.py
@@ -158,6 +158,7 @@ def _create_dit_runner(model_runner: str, rank: int):
         TTMochi1Runner,
         TTWan22I2VAniSoraRunner,
         TTWan22I2VDistillRunner,
+        TTWan22I2VLightningRunner,
         TTWan22I2VLoRARunner,
         TTWan22I2VProdiaRunner,
         TTWan22I2VRunner,
@@ -172,6 +173,7 @@ def _create_dit_runner(model_runner: str, rank: int):
         ModelRunners.TT_WAN_2_2_I2V_ANISORA.value: TTWan22I2VAniSoraRunner,
         ModelRunners.TT_WAN_2_2_I2V_DISTILL.value: TTWan22I2VDistillRunner,
         ModelRunners.TT_WAN_2_2_I2V_LORA.value: TTWan22I2VLoRARunner,
+        ModelRunners.TT_WAN_2_2_I2V_LIGHTNING.value: TTWan22I2VLightningRunner,
     }
     runner_class = runner_map.get(model_runner)
     if not runner_class:

--- a/workflows/model_specs/dev/video.yaml
+++ b/workflows/model_specs/dev/video.yaml
@@ -237,3 +237,20 @@ templates:
       max_context: 65536  # 64 * 1024
       default_impl: true
   status: FUNCTIONAL
+
+- weights:
+    - Wan-AI/Wan2.2-I2V-Lightning
+  impl: tt_transformers
+  min_disk_gb: 60
+  min_ram_gb: 32
+  model_type: VIDEO
+  inference_engine: MEDIA
+  hf_weights_repo: Wan-AI/Wan2.2-I2V-A14B-Diffusers
+  env_vars:
+    TT_DIT_CACHE_DIR: /home/container_app_user/cache_root/tt_dit_cache
+  device_model_specs:
+    - device: BLACKHOLE_GALAXY
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+  status: FUNCTIONAL


### PR DESCRIPTION
This PR adds support for the [lightx2v/Wan2.2-Lightning](https://huggingface.co/lightx2v/Wan2.2-Lightning) I2V. It uses the [experimental tt_dit Wan2.2 LoRA implementation](https://github.com/tenstorrent/tt-metal/blob/6544eb481ab6d75ac1844dc9ad68aa3569fee203/models/tt_dit/experimental/pipelines/pipeline_wan_lora.py).

Related issue: https://github.com/tenstorrent/tt-metal/issues/51207

Depends on https://github.com/tenstorrent/tt-metal/pull/51404