### PR TITLE
SDXL: add LoRA rollback spec test, fix dropped ctx on LoRA load test

### DIFF
--- a/test_module/load_param_tests/__init__.py
+++ b/test_module/load_param_tests/__init__.py
@@ -31,6 +31,10 @@ from .image_generation_lora_load_test import (
     ImageGenerationLoraLoadTest,
     run_image_generation_lora_load,
 )
+from .image_generation_lora_rollback_test import (
+    ImageGenerationLoraRollbackTest,
+    run_image_generation_lora_rollback,
+)
 from .image_generation_param_test import (
     ImageGenerationParamTest,
     run_image_generation_param,
@@ -75,6 +79,7 @@ __all__ = [
     "EmbeddingParamTest",
     "ImageGenerationLoadTest",
     "ImageGenerationLoraLoadTest",
+    "ImageGenerationLoraRollbackTest",
     "ImageGenerationParamTest",
     "Img2ImgGenerationParamTest",
     "InpaintingGenerationParamTest",
@@ -98,6 +103,7 @@ __all__ = [
     "run_embedding_param",
     "run_image_generation_load",
     "run_image_generation_lora_load",
+    "run_image_generation_lora_rollback",
     "run_image_generation_param",
     "run_img2img_generation_param",
     "run_inpainting_generation_param",

--- a/test_module/load_param_tests/image_generation_lora_load_test.py
+++ b/test_module/load_param_tests/image_generation_lora_load_test.py
@@ -72,8 +72,14 @@ class ImageGenerationLoraLoadTest(BaseTest):
 
     """Concurrent load test mixing baseline and LoRA image-generation requests."""
 
-    def __init__(self, config: TestConfig, targets: dict, description: str = ""):
-        super().__init__(config, targets, description)
+    def __init__(
+        self,
+        config: TestConfig,
+        targets: dict,
+        description: str = "",
+        ctx: Optional["MediaContext"] = None,
+    ):
+        super().__init__(config, targets, description, ctx=ctx)
 
     async def _run_specific_test_async(self) -> dict:
         lora_configs = self._parse_lora_configs()

--- a/test_module/load_param_tests/image_generation_lora_rollback_test.py
+++ b/test_module/load_param_tests/image_generation_lora_rollback_test.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+"""Rollback test for LoRA adapter loading.
+
+Issues a strictly sequential sequence against a fixed prompt and seed:
+
+  1. baseline (no LoRA) -> image B1
+  2. with LoRA fused    -> image L
+  3. baseline (no LoRA) -> image B2
+
+and asserts:
+  * all three requests return 200,
+  * L != B1 -- the adapter was actually applied,
+  * B2 == B1 -- the adapter was cleanly removed and the runner is back in its
+    pre-LoRA state.
+
+The second assertion is what the concurrent ImageGenerationLoraLoadTest cannot
+check: it fires a mixed batch and only verifies that LoRA output differs from
+baseline, so a runner that applies an adapter and never unloads it still
+passes. Only a sequential baseline -> LoRA -> baseline walk catches a leaked
+adapter or a half-reverted state.
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import aiohttp
+from report_module.schema import Block
+
+from .._test_common import BaseTest, HardwareRequirement, TestConfig
+
+if TYPE_CHECKING:
+    from ..context import MediaContext
+from .server_helper import DEFAULT_AUTHORIZATION
+
+logger = logging.getLogger(__name__)
+
+ENDPOINT = "v1/images/generations"
+FIXED_PROMPT = "A beautiful sunset over a mountain landscape with vibrant colors"
+FIXED_SEED = 42
+DEFAULT_INFERENCE_STEPS = 20
+REQUEST_TIMEOUT_SEC = 5000
+
+
+@dataclass(frozen=True)
+class LoraSpec:
+    lora_path: str
+    lora_scale: float
+
+
+@dataclass
+class StepResult:
+    label: str
+    status_code: int
+    duration: float
+    image_data: Optional[str] = None
+    error: Optional[str] = None
+
+    @property
+    def success(self) -> bool:
+        return self.status_code == 200 and self.image_data is not None
+
+
+class ImageGenerationLoraRollbackTest(BaseTest):
+    KIND = "image_generation_lora_rollback"
+    TASK_TYPE = "image"
+    HARDWARE_REQUIREMENT = HardwareRequirement.FULL_BOARD
+
+    """Sequential baseline -> LoRA -> baseline rollback test."""
+
+    def __init__(
+        self,
+        config: TestConfig,
+        targets: dict,
+        description: str = "",
+        ctx: Optional["MediaContext"] = None,
+    ):
+        super().__init__(config, targets, description, ctx=ctx)
+
+    async def _run_specific_test_async(self) -> dict:
+        lora = self._parse_lora()
+        num_inference_steps = self.targets.get(
+            "num_inference_steps", DEFAULT_INFERENCE_STEPS
+        )
+
+        base_url = f"http://localhost:{self.service_port}"
+        url = f"{base_url}/{ENDPOINT}"
+        headers = {
+            "accept": "application/json",
+            "Authorization": f"Bearer {DEFAULT_AUTHORIZATION}",
+            "Content-Type": "application/json",
+        }
+        timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT_SEC)
+
+        # Sequential on purpose: the point is the runner's state transitions,
+        # so these must not overlap or be reordered by the batcher.
+        async with aiohttp.ClientSession(headers=headers, timeout=timeout) as session:
+            baseline_pre = await self._send(
+                session, url, num_inference_steps, "baseline-pre"
+            )
+            with_lora = await self._send(
+                session, url, num_inference_steps, "with-lora", lora=lora
+            )
+            baseline_post = await self._send(
+                session, url, num_inference_steps, "baseline-post"
+            )
+
+        return self._evaluate(baseline_pre, with_lora, baseline_post)
+
+    def _parse_lora(self) -> LoraSpec:
+        raw = self.targets.get("lora")
+        if not raw:
+            raise ValueError("targets.lora must be set (lora_path, lora_scale)")
+        return LoraSpec(lora_path=raw["lora_path"], lora_scale=raw["lora_scale"])
+
+    async def _send(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        num_inference_steps: int,
+        label: str,
+        lora: Optional[LoraSpec] = None,
+    ) -> StepResult:
+        payload = {
+            "prompt": FIXED_PROMPT,
+            "negative_prompt": "blurry, low quality, distorted",
+            "num_inference_steps": num_inference_steps,
+            "seed": FIXED_SEED,
+            "guidance_scale": 7.5,
+            "number_of_images": 1,
+        }
+        if lora is not None:
+            payload["lora_path"] = lora.lora_path
+            payload["lora_scale"] = lora.lora_scale
+
+        logger.info("Sending %s request", label)
+        start = time.perf_counter()
+        try:
+            async with session.post(url, json=payload) as response:
+                duration = time.perf_counter() - start
+                if response.status == 200:
+                    data = await response.json()
+                    images = data.get("images", [])
+                    return StepResult(
+                        label=label,
+                        status_code=200,
+                        duration=duration,
+                        image_data=images[0] if images else None,
+                    )
+                body = await response.text()
+                return StepResult(
+                    label=label,
+                    status_code=response.status,
+                    duration=duration,
+                    error=body[:500],
+                )
+        except Exception as exc:
+            return StepResult(
+                label=label,
+                status_code=0,
+                duration=time.perf_counter() - start,
+                error=str(exc),
+            )
+
+    def _evaluate(
+        self,
+        baseline_pre: StepResult,
+        with_lora: StepResult,
+        baseline_post: StepResult,
+    ) -> dict:
+        steps = (baseline_pre, with_lora, baseline_post)
+        failed = [r for r in steps if not r.success]
+        if failed:
+            labels = [
+                f"{r.label}: status={r.status_code} err={r.error}" for r in failed
+            ]
+            logger.error("%d/3 requests failed: %s", len(failed), labels)
+            return {
+                "success": False,
+                "error": f"{len(failed)} request(s) failed",
+                "failures": labels,
+            }
+
+        lora_differs = with_lora.image_data != baseline_pre.image_data
+        rollback_clean = baseline_pre.image_data == baseline_post.image_data
+
+        if not lora_differs:
+            logger.error(
+                "LoRA produced the same image as baseline-pre — adapter not applied"
+            )
+        else:
+            logger.info("LoRA output differs from baseline — adapter applied")
+
+        if not rollback_clean:
+            logger.error(
+                "baseline-post differs from baseline-pre — LoRA was not cleanly unloaded"
+            )
+        else:
+            logger.info("baseline-post matches baseline-pre — rollback is clean")
+
+        return {
+            "success": lora_differs and rollback_clean,
+            "lora_differs_from_baseline": lora_differs,
+            "rollback_clean": rollback_clean,
+            "durations": {
+                "baseline_pre": round(baseline_pre.duration, 2),
+                "with_lora": round(with_lora.duration, 2),
+                "baseline_post": round(baseline_post.duration, 2),
+            },
+        }
+
+
+def run_image_generation_lora_rollback(
+    ctx: "MediaContext", targets: dict | None = None
+) -> Block:
+    """Run :class:`ImageGenerationLoraRollbackTest` under ``ctx`` and return its Block."""
+    test_config = TestConfig(
+        {
+            "timeout": 1800,
+            "retry_attempts": 1,
+            "retry_delay": 10,
+            "break_on_failure": False,
+        }
+    )
+    return ImageGenerationLoraRollbackTest(
+        test_config, targets or {}, ctx=ctx
+    ).run_tests()

--- a/test_module/test_suites/image.json
+++ b/test_module/test_suites/image.json
@@ -95,6 +95,18 @@
                             }
                         ]
                     }
+                },
+                {
+                    "template": "ImageGenerationLoraRollbackTest",
+                    "enabled": true,
+                    "description": "Sequential baseline -> LoRA -> baseline (verifies clean unload)",
+                    "targets": {
+                        "num_inference_steps": 20,
+                        "lora": {
+                            "lora_path": "artificialguybr/ColoringBookRedmond-V2",
+                            "lora_scale": 1
+                        }
+                    }
                 }
             ]
         },

--- a/tests/test_module/test_matrix_expansion.py
+++ b/tests/test_module/test_matrix_expansion.py
@@ -34,16 +34,32 @@ class TestImageMatrixExpansionSDXL:
         assert not missing, f"SDXL suites missing from v2 image.json: {missing}"
 
     def test_sdxl_full_lora_suites(self):
-        """n150, t3k, galaxy should have 6 test cases including LoRA tests."""
+        """n150, t3k, galaxy should have 7 test cases including LoRA tests."""
         suites = load_suite_files_by_category("image")
         suite_map = {s["id"]: s for s in suites}
 
         for suite_id in ["sdxl-n150", "sdxl-t3k", "sdxl-galaxy"]:
             suite = suite_map[suite_id]
-            assert len(suite["test_cases"]) == 6, f"{suite_id}: expected 6 test cases"
+            assert len(suite["test_cases"]) == 7, f"{suite_id}: expected 7 test cases"
             templates = [tc["template"] for tc in suite["test_cases"]]
             assert "ImageGenerationEvalsTest" in templates
             assert "ImageGenerationLoraLoadTest" in templates
+            assert "ImageGenerationLoraRollbackTest" in templates
+
+    def test_sdxl_rollback_test_has_lora_target(self):
+        """The rollback test raises without targets.lora, so it must be configured."""
+        suites = load_suite_files_by_category("image")
+        suite_map = {s["id"]: s for s in suites}
+
+        for suite_id in ["sdxl-n150", "sdxl-t3k", "sdxl-galaxy"]:
+            case = next(
+                tc
+                for tc in suite_map[suite_id]["test_cases"]
+                if tc["template"] == "ImageGenerationLoraRollbackTest"
+            )
+            lora = case["targets"]["lora"]
+            assert lora["lora_path"] == "artificialguybr/ColoringBookRedmond-V2"
+            assert lora["lora_scale"] == 1
 
     def test_sdxl_galaxy_timing_differs(self):
         """Galaxy should have different LoadTest timing (20/28/45 vs 10/14/23)."""

--- a/tests/test_module/test_template_ctx_contract.py
+++ b/tests/test_module/test_template_ctx_contract.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Every spec-test template must accept ``ctx``.
+
+``dispatch._instantiate`` calls ``cls(config, targets, description=..., ctx=ctx)``
+and falls back to ``cls(config, targets)`` on TypeError. That fallback is a
+compatibility shim for older templates, but it fails silently: a template whose
+``__init__`` forgets ``ctx`` still constructs, then quietly loses
+``ctx.service_port``, ``ctx.base_url`` and its report ``block_id`` -- so its
+result can be misattributed rather than reported as broken.
+
+ImageGenerationLoraLoadTest was the one template in this state. This test pins
+the contract for all of them so the shim stays unused.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from test_module import eval_tests, load_param_tests
+from test_module._test_common import TestConfig
+
+
+def _template_classes():
+    seen = {}
+    for module in (load_param_tests, eval_tests):
+        for name in getattr(module, "__all__", dir(module)):
+            if not name.endswith("Test"):
+                continue
+            obj = getattr(module, name, None)
+            if inspect.isclass(obj):
+                seen.setdefault(name, obj)
+    return sorted(seen.items())
+
+
+TEMPLATES = _template_classes()
+
+
+def test_templates_discovered():
+    """Guard the guard: an empty list would make the test below vacuous."""
+    assert len(TEMPLATES) >= 15, f"only found {len(TEMPLATES)} templates"
+
+
+@pytest.mark.parametrize("name,cls", TEMPLATES, ids=[n for n, _ in TEMPLATES])
+def test_template_accepts_ctx(name, cls):
+    config = TestConfig(
+        {
+            "timeout": 10,
+            "retry_attempts": 0,
+            "retry_delay": 1,
+            "break_on_failure": False,
+        }
+    )
+    try:
+        cls(config, {}, description="d", ctx=None)
+    except TypeError as exc:
+        if "ctx" in str(exc):
+            pytest.fail(
+                f"{name}.__init__ does not accept ctx, so dispatch._instantiate "
+                f"silently falls back and drops ctx: {exc}"
+            )
+        # Some templates validate targets in __init__; that is not our concern.
+    except Exception:
+        # Only the ctx signature is under test here.
+        pass


### PR DESCRIPTION
## What

Two gaps in LoRA coverage, both on the tt-inference-server side.

### 1. Nothing checks that a LoRA adapter is *removed* again

`ImageGenerationLoraLoadTest` fires a mixed concurrent batch and asserts only that LoRA output **differs** from baseline. A runner that loads an adapter and then never unloads it passes that test.

`ImageGenerationLoraRollbackTest` walks baseline → LoRA → baseline sequentially against a fixed prompt and seed, and asserts both directions:
- `with-lora != baseline-pre` — adapter applied
- `baseline-post == baseline-pre` — adapter cleanly removed

Ported from the earlier `server_tests/` version onto the current `test_module/` layout, and wired into the sdxl matrix for n150/t3k/galaxy.

> Note this takes those suites from **6 spec tests to 7**. The matrix assertions are updated to match, and "full green" now includes this case.

### 2. `ImageGenerationLoraLoadTest.__init__` did not accept `ctx`

`dispatch._instantiate_spec_test` calls `cls(config, targets, description=..., ctx=ctx)` and falls back to `cls(config, targets)` on `TypeError`. So this did **not** crash — it silently constructed without ctx, losing `ctx.service_port`, `ctx.base_url` and the report `block_id`.

It was the only one of 19 templates in that state, and the compatibility fallback is exactly what hid it.

## Test

`tests/test_module/test_template_ctx_contract.py` pins the contract for every template so the fallback stays unused. Verified **non-vacuous** — reverting the one-line signature fix turns that parametrised case red.

169 passed in `tests/test_module/`. The pre-existing collection error in `tests/test_module/llm_tests/test_agentic_eval_tests.py` reproduces on clean main and is unrelated.

Refs #4352. Supersedes #3484 (pre-flattening paths).
