### PR TITLE
test_module: pick spec-test constructor by signature, not by catching TypeError

### DIFF
--- a/test_module/dispatch.py
+++ b/test_module/dispatch.py
@@ -19,6 +19,7 @@ test class, runs it, and forwards the resulting Blocks to the accumulator.
 from __future__ import annotations
 
 import importlib
+import inspect
 import logging
 from copy import deepcopy
 from typing import Callable, List, Optional, Tuple
@@ -287,26 +288,53 @@ def _block_status(block: Block) -> TestStatus:
     )
 
 
+def _accepts_ctx(cls) -> bool:
+    """Whether ``cls.__init__`` can take a ``ctx`` keyword."""
+    try:
+        params = inspect.signature(cls.__init__).parameters
+    except (TypeError, ValueError):
+        # Un-introspectable __init__ (C-level, heavily wrapped): assume the
+        # rich form and let a genuine TypeError surface.
+        return True
+    if "ctx" in params:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+
 def _instantiate_spec_test(case: dict, ctx: MediaContext):
     """Import + construct a spec test class from a (filtered) test case dict.
 
     BaseTest accepts ``(config, targets, description="", ctx=None)`` but a
-    handful of test classes (e.g. ImageGenerationEvalsTest) override
-    ``__init__`` with just ``(config, targets)`` — so we try the rich form
-    first and fall back to the minimal one, patching ``description`` on
-    afterward so the summary block can still surface it.
+    handful of test classes override ``__init__`` with just
+    ``(config, targets)``. Those get the minimal form, with ``description``
+    patched on afterward so the summary block can still surface it.
+
+    The choice is made by inspecting the signature rather than by catching
+    ``TypeError`` from the rich call. Catching was wrong twice over: a class
+    that simply forgot ``ctx`` was constructed without it and silently lost
+    ``ctx.service_port``, ``ctx.base_url`` and its report ``block_id``; and a
+    ``TypeError`` raised *inside* a working ``__init__`` was swallowed, so the
+    constructor ran a second time and the error was reported against the
+    wrong call.
     """
     config = TestConfig(case.get("test_config") or {})
     targets = case.get("targets") or {}
     description = case.get("description") or ""
     module = importlib.import_module(case["module"])
     cls = getattr(module, case["name"])
-    try:
+
+    if _accepts_ctx(cls):
         return cls(config, targets, description=description, ctx=ctx)
-    except TypeError:
-        instance = cls(config, targets)
-        instance.description = description
-        return instance
+
+    logger.warning(
+        "%s.__init__ does not accept ctx; constructing without it. This test "
+        "will fall back to SERVICE_PORT/the default deploy URL and its report "
+        "block will have no block_id. Add ctx to its signature.",
+        cls.__name__,
+    )
+    instance = cls(config, targets)
+    instance.description = description
+    return instance
 
 
 def run_spec_tests(ctx: MediaContext) -> Tuple[int, Optional[Block]]:

--- a/tests/test_module/test_instantiate_spec_test.py
+++ b/tests/test_module/test_instantiate_spec_test.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""``_instantiate_spec_test`` picks the constructor form by signature.
+
+It used to call the rich form and catch ``TypeError``. That conflated two
+different situations:
+
+  * a class that forgot ``ctx`` -- constructed anyway, silently without ctx;
+  * a class whose ``__init__`` raises ``TypeError`` for its own reasons --
+    swallowed, constructor re-run, error attributed to the fallback call.
+
+Signature inspection separates them: the first is a warning, the second
+propagates untouched.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from test_module import dispatch
+
+MODULE_NAME = "tests.test_module._fake_spec_tests"
+
+
+class AcceptsCtx:
+    def __init__(self, config, targets, description="", ctx=None):
+        self.config = config
+        self.targets = targets
+        self.description = description
+        self.ctx = ctx
+
+
+class NoCtx:
+    """Legacy shape: (config, targets) only."""
+
+    instantiations = 0
+
+    def __init__(self, config, targets):
+        type(self).instantiations += 1
+        self.config = config
+        self.targets = targets
+        self.description = None
+
+
+class AcceptsKwargs:
+    def __init__(self, config, targets, **kwargs):
+        self.config = config
+        self.targets = targets
+        self.ctx = kwargs.get("ctx")
+        self.description = kwargs.get("description", "")
+
+
+class RaisesTypeErrorInside:
+    """Accepts ctx, but its own body raises TypeError."""
+
+    instantiations = 0
+
+    def __init__(self, config, targets, description="", ctx=None):
+        type(self).instantiations += 1
+        raise TypeError("targets['size'] must be an int, got str")
+
+
+@pytest.fixture(autouse=True)
+def _fake_module():
+    module = ModuleType(MODULE_NAME)
+    for cls in (AcceptsCtx, NoCtx, AcceptsKwargs, RaisesTypeErrorInside):
+        setattr(module, cls.__name__, cls)
+        cls.instantiations = 0
+    sys.modules[MODULE_NAME] = module
+    yield
+    del sys.modules[MODULE_NAME]
+
+
+def _case(name, **extra):
+    return {
+        "module": MODULE_NAME,
+        "name": name,
+        "description": "a description",
+        **extra,
+    }
+
+
+CTX = SimpleNamespace(service_port=9001, base_url="http://host:9001")
+
+
+def test_ctx_is_passed_when_accepted():
+    inst = dispatch._instantiate_spec_test(_case("AcceptsCtx"), CTX)
+    assert inst.ctx is CTX
+    assert inst.description == "a description"
+
+
+def test_var_keyword_signature_still_gets_ctx():
+    """**kwargs can absorb ctx, so it must not be treated as legacy."""
+    inst = dispatch._instantiate_spec_test(_case("AcceptsKwargs"), CTX)
+    assert inst.ctx is CTX
+
+
+def test_legacy_class_gets_minimal_form_and_description_patched(caplog):
+    with caplog.at_level("WARNING"):
+        inst = dispatch._instantiate_spec_test(_case("NoCtx"), CTX)
+    assert inst.description == "a description"
+    assert NoCtx.instantiations == 1
+    assert "does not accept ctx" in caplog.text
+    assert "NoCtx" in caplog.text
+
+
+def test_legacy_path_warns_so_the_gap_is_visible(caplog):
+    """The old code was silent here; that is what hid the LoRA load test bug."""
+    with caplog.at_level("WARNING"):
+        dispatch._instantiate_spec_test(_case("NoCtx"), CTX)
+    assert any(r.levelname == "WARNING" for r in caplog.records)
+
+
+def test_inner_type_error_propagates_and_does_not_retry():
+    with pytest.raises(TypeError, match=r"targets\['size'\] must be an int"):
+        dispatch._instantiate_spec_test(_case("RaisesTypeErrorInside"), CTX)
+    # The old except-TypeError path called __init__ a second time.
+    assert RaisesTypeErrorInside.instantiations == 1
+
+
+def test_accepts_ctx_helper():
+    assert dispatch._accepts_ctx(AcceptsCtx)
+    assert dispatch._accepts_ctx(AcceptsKwargs)
+    assert not dispatch._accepts_ctx(NoCtx)


### PR DESCRIPTION
## What

`_instantiate_spec_test` called `cls(config, targets, description=..., ctx=ctx)` and fell back to `cls(config, targets)` on `TypeError`. That conflated two unrelated situations and handled both badly.

**1. A class that simply forgot `ctx`** got constructed without it, silently. It then fell back to `SERVICE_PORT` / the default deploy URL instead of `ctx.service_port` / `ctx.base_url`, and its report block came out with no `block_id`. `ImageGenerationLoraLoadTest` was in exactly this state, and the fallback is why nobody noticed.

**2. A `TypeError` raised *inside* an otherwise-correct `__init__`** — target validation, a bad cast — was swallowed. The constructor then ran a **second time** with fewer arguments, so any side effects happened twice and the failure was reported against the fallback call rather than the real one.

## How

The form is now chosen by inspecting `__init__`:
- `ctx` is passed when the signature can take it (named parameter or `**kwargs`)
- the legacy form is used otherwise, and logs a **warning naming the class**
- a `TypeError` from inside `__init__` propagates untouched on the first attempt

Un-introspectable `__init__` is treated as ctx-accepting so a genuine `TypeError` still surfaces rather than being downgraded to the legacy path.

## Test

`tests/test_module/test_instantiate_spec_test.py`. Verified non-vacuous — **4 of the 6 fail against the previous implementation**, including the one asserting `__init__` is not run twice.

152 passed in `tests/test_module/`.

Refs #4352.
