### PR TITLE
[feature] - SwarmOne swo-bench trace source for `agentic_traces`

### DIFF
--- a/docs/workflow_development.md
+++ b/docs/workflow_development.md
@@ -556,9 +556,10 @@ harness; both implemented sources are listed in `SUPPORTED_TRACE_SOURCES`
 ([`llm_module/agentic_traces/runs.py`](../llm_module/agentic_traces/runs.py)).
 A source added to the config schema without a driver still fails loudly with
 `NotImplementedError` at plan time, so selecting it can never look like a clean
-empty sweep. When a run's model config lists several sources and
-`--agentic-traces-sources` is unset, every configured source runs; the orchestrator
-dispatches each run to the driver for its `trace_source`.
+empty sweep. When `--agentic-traces-sources` is unset, every configured source
+runs **except** those listed in `OPT_IN_TRACE_SOURCES`, which must be named
+explicitly (see `default_run_specs`); the orchestrator dispatches each run to the
+driver for its `trace_source`.
 
 - **`inferencex_agentx`** — the AIPerf fork vendored in InferenceX, driven by
   [`AIPerfAgenticTracesDriver`](../llm_module/drivers/aiperf_agentic_traces.py).
@@ -571,9 +572,12 @@ dispatches each run to the driver for its `trace_source`.
   InferenceX clone entirely. It replays recorded Claude-Code / Codex coding
   scenarios (`swo-bench list-scenarios`) turn-by-turn with growing history, and
   the replay plan is built server-side by the SwarmOne backend. A **SwarmOne
-  license** is required and checked up front in
-  [`workflows/validate_setup.py`](../workflows/validate_setup.py): set
-  `SWO_LICENSE_KEY` or write the key to `~/.swarmone/license.key`. The scenario's
+  license** is required (`SWO_LICENSE_KEY`, or the key written to
+  `~/.swarmone/license.key`), which is why `swarmone` is listed in
+  `OPT_IN_TRACE_SOURCES`: registering a SwarmOne run for a model leaves that
+  model's plain sweep untouched, and the license is only demanded — up front, in
+  [`workflows/validate_setup.py`](../workflows/validate_setup.py) — once
+  `--agentic-traces-sources swarmone` asks for it. The scenario's
   `--model-context-length` is always supplied from the ModelSpec (with context
   auto-resolution disabled) because the Tenstorrent Console `/v1/models` does not
   report the window.

--- a/docs/workflow_development.md
+++ b/docs/workflow_development.md
@@ -552,9 +552,48 @@ doomed run.
 ### Trace sources
 
 `TraceSource` is pluggable so configs and `--agentic-traces-sources` can name a
-harness. `inferencex_agentx` is implemented; `swarmone` is a recognized value with
-no client integration yet and raises `NotImplementedError` at plan time, so
-selecting it can never look like a clean empty sweep.
+harness; both implemented sources are listed in `SUPPORTED_TRACE_SOURCES`
+([`llm_module/agentic_traces/runs.py`](../llm_module/agentic_traces/runs.py)).
+A source added to the config schema without a driver still fails loudly with
+`NotImplementedError` at plan time, so selecting it can never look like a clean
+empty sweep. When a run's model config lists several sources and
+`--agentic-traces-sources` is unset, every configured source runs; the orchestrator
+dispatches each run to the driver for its `trace_source`.
+
+- **`inferencex_agentx`** — the AIPerf fork vendored in InferenceX, driven by
+  [`AIPerfAgenticTracesDriver`](../llm_module/drivers/aiperf_agentic_traces.py).
+- **`swarmone`** — SwarmOne's [`swo-bench`](https://swarmone.ai/docs/swo-bench)
+  replay engine, driven by
+  [`SwoBenchAgenticTracesDriver`](../llm_module/drivers/swo_bench_agentic_traces.py).
+  `swo-bench` is a normal PyPI package pinned in
+  [`requirements/agentic-traces.txt`](../requirements/agentic-traces.txt), so no
+  git checkout is needed; a config whose runs are all `swarmone` skips the
+  InferenceX clone entirely. It replays recorded Claude-Code / Codex coding
+  scenarios (`swo-bench list-scenarios`) turn-by-turn with growing history, and
+  the replay plan is built server-side by the SwarmOne backend. A **SwarmOne
+  license** is required and checked up front in
+  [`workflows/validate_setup.py`](../workflows/validate_setup.py): set
+  `SWO_LICENSE_KEY` or write the key to `~/.swarmone/license.key`. The scenario's
+  `--model-context-length` is always supplied from the ModelSpec (with context
+  auto-resolution disabled) because the Tenstorrent Console `/v1/models` does not
+  report the window.
+
+  For each SwarmOne run, `full` replays every task of the scenario at the
+  configured concurrency while `ci` narrows to a single short task at concurrency
+  1 (per-run mode scoping via `AgenticTracesRunSpec.modes`). SwarmOne runs are
+  request-count-driven rather than wall-clock-bounded, so their subprocess
+  timeout comes from `estimated_run_seconds` rather than the profiling-window
+  formula. Example:
+
+```bash
+MODEL_SPECS_ENV=dev python run.py \
+    --model Kimi-K2.7-Code \
+    --workflow agentic_traces \
+    --agentic-traces-sources swarmone \
+    --agentic-traces-mode ci \
+    --device super_cluster \
+    --server-url http://localhost:8000
+```
 
 ### Reported metrics and what invalidates a run
 

--- a/llm_module/agentic_traces/__init__.py
+++ b/llm_module/agentic_traces/__init__.py
@@ -13,16 +13,22 @@ per-ModelSpec configuration lives in
 
 from .runs import (
     SUPPORTED_TRACE_SOURCES,
+    SWARMONE_CI_TIMEOUT_SECONDS,
+    SWARMONE_FULL_TIMEOUT_SECONDS,
     AgenticTracesRun,
     build_runs,
+    estimated_run_seconds,
     summarize_runs,
     total_planned_seconds,
 )
 
 __all__ = [
     "SUPPORTED_TRACE_SOURCES",
+    "SWARMONE_CI_TIMEOUT_SECONDS",
+    "SWARMONE_FULL_TIMEOUT_SECONDS",
     "AgenticTracesRun",
     "build_runs",
+    "estimated_run_seconds",
     "summarize_runs",
     "total_planned_seconds",
 ]

--- a/llm_module/agentic_traces/runs.py
+++ b/llm_module/agentic_traces/runs.py
@@ -26,10 +26,21 @@ from reference_config.agentic_traces.agentic_traces_config import (
 )
 from workflows.workflow_types import AgenticTracesMode
 
-# Trace sources with a working client. SWARMONE is a registered config value
-# with no harness yet, so it fails loudly at plan time instead of producing an
-# empty (silently passing) sweep.
-SUPPORTED_TRACE_SOURCES: Tuple[TraceSource, ...] = (TraceSource.INFERENCEX_AGENTX,)
+# Trace sources with a working client. Both the InferenceX AIPerf fork and the
+# SwarmOne ``swo-bench`` replay engine are wired; any source added to the config
+# schema without a driver would still fail loudly at plan time (see build_runs).
+SUPPORTED_TRACE_SOURCES: Tuple[TraceSource, ...] = (
+    TraceSource.INFERENCEX_AGENTX,
+    TraceSource.SWARMONE,
+)
+
+# swo-bench replays real recorded sessions rather than profiling for a fixed
+# wall-clock window, so its runtime is driven by the scenario's request count,
+# not ``benchmark_duration``. These bound the per-run subprocess timeout for
+# SwarmOne runs (the FULL SWE-bench-python scenario is ~700 requests across
+# three tasks); the InferenceX estimate stays duration + grace.
+SWARMONE_FULL_TIMEOUT_SECONDS = 8 * 3600
+SWARMONE_CI_TIMEOUT_SECONDS = 3600
 
 
 @dataclass(frozen=True)
@@ -58,6 +69,14 @@ class AgenticTracesRun:
     use_server_token_count: bool
     gpu_telemetry: bool
     mode: AgenticTracesMode
+    # SwarmOne swo-bench knobs. Unused by the InferenceX/AIPerf driver, so they
+    # carry harmless defaults on ``inferencex_agentx`` runs.
+    task: Optional[str] = None
+    resident: Optional[int] = None
+    cache_mode: str = "realistic"
+    history_mode: str = "faithful"
+    max_tokens: int = 4096
+    max_tokens_mode: str = "flat"
     env: Dict[str, str] = field(default_factory=dict)
     # Free-form provenance echoed into the result payload for the report.
     metadata: Dict[str, Any] = field(default_factory=dict)
@@ -111,6 +130,12 @@ def build_runs(
     settings = config.settings_for_mode(mode)
     specs = tuple(run_specs) if run_specs is not None else config.runs
 
+    # A spec with an explicit ``modes`` tuple only runs in those modes; ``None``
+    # participates in every mode (the InferenceX default). This lets SwarmOne
+    # give FULL and CI different task/concurrency shapes without a shared mode
+    # setting leaking across trace sources.
+    specs = tuple(spec for spec in specs if spec.modes is None or mode in spec.modes)
+
     unsupported = sorted(
         {
             spec.trace_source.value
@@ -160,6 +185,12 @@ def build_runs(
                 use_server_token_count=spec.use_server_token_count,
                 gpu_telemetry=spec.gpu_telemetry,
                 mode=mode,
+                task=spec.task,
+                resident=spec.resident,
+                cache_mode=spec.cache_mode,
+                history_mode=spec.history_mode,
+                max_tokens=spec.max_tokens,
+                max_tokens_mode=spec.max_tokens_mode,
                 env=dict(spec.env),
                 metadata={
                     "model_id": getattr(model_spec, "model_id", ""),
@@ -177,15 +208,41 @@ def summarize_runs(runs: Sequence[AgenticTracesRun]) -> str:
         return "[agentic-traces] No runs planned."
     lines = [f"[agentic-traces] Planned {len(runs)} run(s):"]
     for run in runs:
-        lines.append(
-            f"  - {run.label}: source={run.trace_source.value} "
-            f"scenario={run.scenario} dataset={run.public_dataset} "
-            f"concurrency={run.concurrency} duration={run.benchmark_duration}s "
-            f"warmup={run.warmup_requests_per_lane}req/lane "
-            f"entries={run.num_dataset_entries} "
-            f"max_context={run.max_context_length}"
-        )
+        if run.trace_source is TraceSource.SWARMONE:
+            lines.append(
+                f"  - {run.label}: source=swarmone "
+                f"scenario={run.scenario} task={run.task or 'ALL'} "
+                f"concurrency={run.concurrency} "
+                f"resident={run.resident or run.concurrency} "
+                f"cache={run.cache_mode} history={run.history_mode} "
+                f"max_tokens={run.max_tokens} "
+                f"max_context={run.max_context_length}"
+            )
+        else:
+            lines.append(
+                f"  - {run.label}: source={run.trace_source.value} "
+                f"scenario={run.scenario} dataset={run.public_dataset} "
+                f"concurrency={run.concurrency} duration={run.benchmark_duration}s "
+                f"warmup={run.warmup_requests_per_lane}req/lane "
+                f"entries={run.num_dataset_entries} "
+                f"max_context={run.max_context_length}"
+            )
     return "\n".join(lines)
+
+
+def estimated_run_seconds(run: AgenticTracesRun) -> int:
+    """Per-run runtime estimate used to size the subprocess timeout.
+
+    InferenceX profiles for a fixed window, so its estimate is the profiling
+    duration plus warmup and grace. SwarmOne replays a recorded scenario whose
+    length is request-count-driven rather than wall-clock-bounded, so it uses a
+    generous mode-based ceiling instead.
+    """
+    if run.trace_source is TraceSource.SWARMONE:
+        if run.mode is AgenticTracesMode.CI:
+            return SWARMONE_CI_TIMEOUT_SECONDS
+        return SWARMONE_FULL_TIMEOUT_SECONDS
+    return run.benchmark_duration + run.warmup_grace_period
 
 
 def total_planned_seconds(runs: Sequence[AgenticTracesRun]) -> int:
@@ -205,8 +262,11 @@ def total_planned_seconds(runs: Sequence[AgenticTracesRun]) -> int:
 
 __all__ = [
     "SUPPORTED_TRACE_SOURCES",
+    "SWARMONE_CI_TIMEOUT_SECONDS",
+    "SWARMONE_FULL_TIMEOUT_SECONDS",
     "AgenticTracesRun",
     "build_runs",
+    "estimated_run_seconds",
     "summarize_runs",
     "total_planned_seconds",
 ]

--- a/llm_module/drivers/__init__.py
+++ b/llm_module/drivers/__init__.py
@@ -9,6 +9,7 @@ from .aiperf_agentic_traces import (
 )
 from .aiperf_prefix_cache import AIPerfPrefixCacheDriver, PrefixCacheDriverResult
 from .aiperf_spec_decode import AIPerfSpecDecodeDriver, SpecDecodeDriverResult
+from .swo_bench_agentic_traces import SwoBenchAgenticTracesDriver
 from .agentic import (
     AgenticEvalDriver,
     SWEbenchAgenticDriver,
@@ -31,6 +32,7 @@ __all__ = [
     "AIPerfSpecDecodeDriver",
     "PrefixCacheDriverResult",
     "SpecDecodeDriverResult",
+    "SwoBenchAgenticTracesDriver",
     "GenAIPerfDriver",
     "GuideLLMDriver",
     "SWEbenchAgenticDriver",

--- a/llm_module/drivers/swo_bench_agentic_traces.py
+++ b/llm_module/drivers/swo_bench_agentic_traces.py
@@ -1,0 +1,482 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+
+"""``swo-bench replay`` driver for SwarmOne agentic trace replay.
+
+Drives the SwarmOne ``swo-bench`` CLI (installed into the AGENTIC_TRACES venv;
+see ``setup_agentic_traces`` in ``workflows/workflow_venvs.py``). swo-bench owns
+the recorded Claude-Code / Codex coding scenarios and the replay plan (built
+server-side by the SwarmOne backend), so this driver only translates one
+:class:`AgenticTracesRun` into its CLI and reads the ``-o`` results JSON back.
+
+Like the AIPerf agentic-traces driver, this is intentionally not an
+:class:`llm_module.drivers.base.LLMDriver`: ``LLMDriver`` is bound to
+``LLMRunConfig`` (isl / osl / concurrency / num_prompts), which cannot express a
+trace-replay run.
+
+The SwarmOne license key is never placed on the command line (it would leak into
+run logs). swo-bench resolves it from the ``SWO_LICENSE_KEY`` environment
+variable or ``~/.swarmone/license.key``; the process env is inherited by the
+subprocess, and ``run.py`` fails fast when neither is present for a swarmone run.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+from ..agentic_traces import AgenticTracesRun
+from ..config import DriverContext, ServerConnection
+from ._subprocess import load_json, run_command, safe_filename_part
+from .aiperf_agentic_traces import AgenticTracesDriverResult
+
+logger = logging.getLogger(__name__)
+
+# Name of the swo-bench ``-o`` results file written into each run's artifact dir.
+_RESULTS_FILENAME = "swo_bench_results.json"
+
+
+class SwoBenchAgenticTracesDriver:
+    """Run one SwarmOne swo-bench replay scenario end-to-end.
+
+    Per :class:`AgenticTracesRun`:
+
+    1. Build the ``swo-bench replay`` CLI for the configured scenario (+ task).
+    2. Execute it (license comes from the inherited env, never argv).
+    3. Parse the ``-o`` results JSON.
+    4. Persist a combined per-run JSON and return it to the caller.
+    """
+
+    name = "swo_bench_agentic_traces"
+
+    def __init__(
+        self,
+        *,
+        venv_python: Optional[Path] = None,
+        artifact_root: Optional[Path] = None,
+        model_repo: str = "",
+        model_id: str = "",
+        output_dir: Optional[Path] = None,
+    ) -> None:
+        self.venv_python = Path(venv_python) if venv_python else Path(sys.executable)
+        self.artifact_root = Path(artifact_root) if artifact_root else None
+        self.model_repo = model_repo
+        self.model_id = model_id
+        self.output_dir = Path(output_dir) if output_dir else None
+
+    def run(
+        self,
+        trace_run: AgenticTracesRun,
+        server: ServerConnection,
+        context: DriverContext,
+    ) -> AgenticTracesDriverResult:
+        if self.artifact_root is None:
+            raise RuntimeError("SwoBenchAgenticTracesDriver: artifact_root not set")
+        if self.output_dir is None:
+            raise RuntimeError("SwoBenchAgenticTracesDriver: output_dir not set")
+
+        artifact_dir = self.artifact_root / safe_filename_part(
+            trace_run.filesafe_label()
+        )
+        if artifact_dir.exists():
+            shutil.rmtree(artifact_dir)
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        results_path = artifact_dir / _RESULTS_FILENAME
+
+        cmd = build_swo_bench_cmd(
+            run=trace_run,
+            venv_python=self.venv_python,
+            model_name=server.model or self.model_repo,
+            url=server.url_with_port,
+            results_path=results_path,
+            auth_token=server.auth_token,
+        )
+        _log_run_header(trace_run)
+
+        # swo-bench reads the license from SWO_LICENSE_KEY / ~/.swarmone; the
+        # sweep-level env (context.extra_env) is inherited, run-level env last.
+        env = dict(context.extra_env)
+        env.update(trace_run.env)
+
+        rc = run_command(cmd, env=env, timeout_s=context.per_run_timeout_s)
+        if rc != 0:
+            logger.error(
+                "[agentic-traces] swo-bench failed for %s with rc=%d. Inspect the "
+                "output above and %s for details.",
+                trace_run.label,
+                rc,
+                results_path,
+            )
+            return AgenticTracesDriverResult(
+                return_code=rc, payload=None, raw_path=None
+            )
+
+        metrics = parse_swo_bench_output(results_path)
+        if not metrics:
+            logger.error(
+                "[agentic-traces] No metrics parsed from %s; skipping result save.",
+                results_path,
+            )
+            return AgenticTracesDriverResult(return_code=1, payload=None, raw_path=None)
+
+        invalid_reason = _invalid_result_reason(metrics)
+        if invalid_reason:
+            logger.error(
+                "[agentic-traces] %s produced an unusable result: %s.",
+                trace_run.label,
+                invalid_reason,
+            )
+            return AgenticTracesDriverResult(return_code=1, payload=None, raw_path=None)
+
+        payload = _build_payload(
+            run=trace_run,
+            metrics=metrics,
+            model_repo=server.model or self.model_repo,
+            artifact_dir=artifact_dir,
+        )
+        raw_path = _save_payload(
+            payload=payload,
+            output_dir=self.output_dir,
+            model_id=self.model_id or self.model_repo,
+            label=trace_run.filesafe_label(),
+        )
+        _log_run_summary(trace_run, metrics)
+        return AgenticTracesDriverResult(
+            return_code=0, payload=payload, raw_path=raw_path
+        )
+
+
+def _swo_endpoint(url: str) -> str:
+    """Normalize a server URL into the OpenAI base swo-bench's ``-e`` expects.
+
+    swo-bench takes the ``/v1`` base (e.g. ``http://localhost:8000/v1``) and
+    appends the chat-completions path itself, unlike AIPerf which takes the bare
+    host plus an explicit ``--endpoint``.
+    """
+    url = url.rstrip("/")
+    if not url.startswith("http"):
+        url = f"http://{url}"
+    if not url.endswith("/v1"):
+        url = f"{url}/v1"
+    return url
+
+
+def build_swo_bench_cmd(
+    *,
+    run: AgenticTracesRun,
+    venv_python: Path,
+    model_name: str,
+    url: str,
+    results_path: Path,
+    auth_token: str = "",
+) -> List[str]:
+    """Construct the ``swo-bench replay`` CLI for one SwarmOne run.
+
+    The scenario (``-s``) selects a recorded multi-turn coding session set;
+    ``-t`` narrows to a single task. ``-j`` caps in-flight requests and ``-r``
+    sets how many distinct conversations stay resident. ``--model-context-length``
+    is always passed (and context auto-resolution disabled) because the
+    Tenstorrent Console ``/v1/models`` does not report the window, which would
+    otherwise abort the run (see SWO_BENCH_REPORT.md).
+    """
+    resident = run.resident if run.resident is not None else run.concurrency
+    cmd: List[str] = [
+        str(venv_python),
+        "-m",
+        "swo_bench",
+        "replay",
+        "--scenario",
+        run.scenario,
+    ]
+    if run.task:
+        cmd.extend(["--task", run.task])
+    cmd.extend(
+        [
+            "--endpoint",
+            _swo_endpoint(url),
+            "--model",
+            model_name,
+            "--concurrent",
+            str(run.concurrency),
+            "--resident",
+            str(resident),
+            "--model-context-length",
+            str(run.max_context_length),
+            "--no-resolve-model-context",
+            "--cache-mode",
+            run.cache_mode,
+            "--history-mode",
+            run.history_mode,
+            "--max-tokens",
+            str(run.max_tokens),
+            "--max-tokens-mode",
+            run.max_tokens_mode,
+            "--verbose-text",
+            "--json-output",
+            str(results_path),
+        ]
+    )
+    if auth_token:
+        cmd.extend(["--api-key", auth_token])
+    return cmd
+
+
+def parse_swo_bench_output(results_path: Path) -> Dict[str, Any]:
+    """Parse swo-bench's ``--json-output`` file into a flat metrics dict.
+
+    The keys mirror the AIPerf agentic-traces payload where the two tools
+    measure the same quantity (TTFT, latency, throughput, counts), so both
+    sources collapse into one coherent ``agentic_traces`` report section, plus a
+    few swo-bench-specific fields (prefix-cache-aware prefill rate, session id).
+
+    swo-bench's own aggregate percentiles live under ``report.metrics``; totals
+    that it does not aggregate (input tokens) are summed from ``timings``.
+    """
+    summary = load_json(results_path) or {}
+    if not summary:
+        return {}
+
+    report = summary.get("report")
+    report = report if isinstance(report, Mapping) else {}
+    agg = report.get("metrics")
+    agg = agg if isinstance(agg, Mapping) else {}
+    if not agg:
+        logger.warning(
+            "swo-bench results at %s carry no report.metrics block", results_path
+        )
+        return {}
+
+    def _block(tag: str) -> Mapping[str, Any]:
+        value = agg.get(tag)
+        return value if isinstance(value, Mapping) else {}
+
+    def _num(value: Any, default: float = 0.0) -> float:
+        return float(value) if isinstance(value, (int, float)) else default
+
+    def _int(value: Any, default: int = 0) -> int:
+        return int(value) if isinstance(value, (int, float)) else default
+
+    ttft = _block("ttft_ms")
+    latency = _block("latency_ms")
+    decode = _block("decode_tok_per_sec")
+    prefill = _block("prefill_tok_per_sec")
+    itl = _block("itl_ms_p50")
+
+    successful = _int(agg.get("successful"))
+    failed = _int(agg.get("failed"))
+    total_requests = _int(agg.get("total_requests"), successful + failed)
+    wall_clock_s = _num(agg.get("wall_clock_s")) or (
+        _num(summary.get("wall_clock_ms")) / 1000.0
+    )
+
+    timings = summary.get("timings")
+    total_input_tokens = 0
+    if isinstance(timings, list):
+        for t in timings:
+            if isinstance(t, Mapping):
+                total_input_tokens += _int(t.get("prompt_tokens"))
+    total_output_tokens = _int(agg.get("total_output_tokens"))
+
+    metrics: Dict[str, Any] = {
+        # Latency. TTFT is the headline metric for long-context agentic prefill.
+        "mean_ttft_ms": _num(ttft.get("mean")),
+        "median_ttft_ms": _num(ttft.get("p50")),
+        "p90_ttft_ms": _num(ttft.get("p90")),
+        "p99_ttft_ms": _num(ttft.get("p99")),
+        "min_ttft_ms": _num(ttft.get("min")),
+        "max_ttft_ms": _num(ttft.get("max")),
+        "mean_e2el_ms": _num(latency.get("mean")),
+        "median_e2el_ms": _num(latency.get("p50")),
+        "p90_e2el_ms": _num(latency.get("p90")),
+        "p99_e2el_ms": _num(latency.get("p99")),
+        "min_e2el_ms": _num(latency.get("min")),
+        "max_e2el_ms": _num(latency.get("max")),
+        # Inter-token latency reads implausibly low from swo-bench (a streaming
+        # measurement artifact per SWO_BENCH_REPORT.md); surfaced for parity but
+        # decode tok/s and TTFT are the reliable signals.
+        "mean_tpot_ms": _num(itl.get("mean")),
+        "median_tpot_ms": _num(itl.get("p50")),
+        # Throughput. Per-user decode rate while streaming, plus the aggregate.
+        "output_token_throughput_per_user": _num(decode.get("mean")),
+        "median_output_token_throughput_per_user": _num(decode.get("p50")),
+        "p90_output_token_throughput_per_user": _num(decode.get("p90")),
+        "min_output_token_throughput_per_user": _num(decode.get("min")),
+        "output_token_throughput": _num(agg.get("aggregate_throughput_tok_s")),
+        "total_token_throughput": _num(agg.get("aggregate_throughput_tok_s")),
+        # Prefix-cache-aware prefill rate: the metric fixed-ISL sweeps cannot
+        # capture (most of each grown prompt is a cache hit).
+        "prefill_tok_per_sec_mean": _num(prefill.get("mean")),
+        "prefill_tok_per_sec_p50": _num(prefill.get("p50")),
+        "prefill_tok_per_sec_p90": _num(prefill.get("p90")),
+        # Counts. ``completed`` keeps the sibling drivers' meaning (successful
+        # requests); ``completed_with_errors`` is success + error.
+        "completed": successful,
+        "completed_with_errors": total_requests,
+        "error_request_count": failed,
+        "error_rate_pct": (100.0 * failed / total_requests) if total_requests else 0.0,
+        "total_input_tokens": total_input_tokens,
+        "total_output_tokens": total_output_tokens,
+        "mean_isl": (total_input_tokens / total_requests) if total_requests else 0.0,
+        "mean_osl": (total_output_tokens / successful) if successful else 0.0,
+        "measured_benchmark_duration": wall_clock_s,
+        "request_throughput": (total_requests / wall_clock_s) if wall_clock_s else 0.0,
+        # Provenance for reproducibility.
+        "swo_session_id": summary.get("session_id"),
+        "swo_source_label": summary.get("source"),
+        "swo_bench_version": _swo_bench_version(),
+    }
+
+    # swo-bench >=3 also emits duty-cycle fields at the top level; surface the
+    # capacity-relevant ones when present (older runs omit them).
+    for key in (
+        "active_throughput_tok_per_s",
+        "concurrency_peak",
+        "concurrency_mean",
+        "ready_starved_events",
+        "pace_idle_ms",
+        "tool_idle_ms",
+    ):
+        if key in summary and isinstance(summary[key], (int, float)):
+            metrics[key] = summary[key]
+
+    return metrics
+
+
+def _swo_bench_version() -> Optional[str]:
+    """Best-effort swo-bench version for the result payload (never raises)."""
+    try:
+        from importlib.metadata import version
+
+        return version("swo-bench")
+    except Exception:  # noqa: BLE001 -- provenance only
+        return None
+
+
+def _invalid_result_reason(metrics: Mapping[str, Any]) -> Optional[str]:
+    """Why ``metrics`` cannot be reported, or ``None`` when it is usable.
+
+    swo-bench can exit 0 with a result that must not be published: a run where
+    every request failed (e.g. a 401 from a missing token) would otherwise
+    render as a row of zeros.
+    """
+    completed = int(metrics.get("completed") or 0)
+    if completed <= 0:
+        return "no request completed successfully"
+    mean_ttft_ms = float(metrics.get("mean_ttft_ms") or 0.0)
+    if mean_ttft_ms <= 0.0:
+        return f"mean TTFT was {mean_ttft_ms} across {completed} request(s)"
+    return None
+
+
+def _build_payload(
+    *,
+    run: AgenticTracesRun,
+    metrics: Dict[str, Any],
+    model_repo: str,
+    artifact_dir: Path,
+) -> Dict[str, Any]:
+    """Combine swo-bench metrics with the run's provenance."""
+    resident = run.resident if run.resident is not None else run.concurrency
+    return {
+        "date": datetime.now().strftime("%Y%m%d-%H%M%S"),
+        "backend": "swo-bench",
+        "task_type": "agentic_traces",
+        "trace_source": run.trace_source.value,
+        "label": run.label,
+        "mode": run.mode.to_string(),
+        "model_id": model_repo,
+        "tokenizer_id": model_repo,
+        "scenario": run.scenario,
+        "task": run.task,
+        "concurrency": run.concurrency,
+        "max_concurrency": run.concurrency,
+        "resident": resident,
+        "cache_mode": run.cache_mode,
+        "history_mode": run.history_mode,
+        "max_tokens": run.max_tokens,
+        "max_tokens_mode": run.max_tokens_mode,
+        "max_context_length": run.max_context_length,
+        "artifact_dir": str(artifact_dir),
+        "metadata": dict(run.metadata or {}),
+        **metrics,
+    }
+
+
+def _save_payload(
+    *,
+    payload: Dict[str, Any],
+    output_dir: Path,
+    model_id: str,
+    label: str,
+) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    filename = (
+        f"swo_bench_agentic_traces_{safe_filename_part(model_id)}_{timestamp}"
+        f"_{safe_filename_part(label)}.json"
+    )
+    filepath = output_dir / filename
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+    logger.info("Agentic-traces (swo-bench) result saved to: %s", filepath)
+    return filepath
+
+
+def _log_run_header(run: AgenticTracesRun) -> None:
+    resident = run.resident if run.resident is not None else run.concurrency
+    logger.info(
+        "[agentic-traces] %s: source=swarmone scenario=%s task=%s concurrency=%d "
+        "resident=%d cache=%s history=%s max_tokens=%d max_context=%d",
+        run.label,
+        run.scenario,
+        run.task or "ALL",
+        run.concurrency,
+        resident,
+        run.cache_mode,
+        run.history_mode,
+        run.max_tokens,
+        run.max_context_length,
+    )
+
+
+def _log_run_summary(run: AgenticTracesRun, metrics: Mapping[str, Any]) -> None:
+    logger.info("=" * 80)
+    logger.info(
+        "[agentic-traces] %s completed=%s errors=%s (%.2f%%) duration=%.0fs",
+        run.label,
+        metrics.get("completed"),
+        metrics.get("error_request_count"),
+        float(metrics.get("error_rate_pct", 0) or 0),
+        float(metrics.get("measured_benchmark_duration", 0) or 0),
+    )
+    logger.info(
+        "[agentic-traces]   TTFT mean/p90/p99 = %.1f/%.1f/%.1f ms; "
+        "latency p50/p99 = %.1f/%.1f ms",
+        float(metrics.get("mean_ttft_ms", 0) or 0),
+        float(metrics.get("p90_ttft_ms", 0) or 0),
+        float(metrics.get("p99_ttft_ms", 0) or 0),
+        float(metrics.get("median_e2el_ms", 0) or 0),
+        float(metrics.get("p99_e2el_ms", 0) or 0),
+    )
+    logger.info(
+        "[agentic-traces]   decode tok/s/user mean/p50 = %.1f/%.1f; "
+        "aggregate tok/s = %.1f; prefill tok/s p50 = %.1f",
+        float(metrics.get("output_token_throughput_per_user", 0) or 0),
+        float(metrics.get("median_output_token_throughput_per_user", 0) or 0),
+        float(metrics.get("output_token_throughput", 0) or 0),
+        float(metrics.get("prefill_tok_per_sec_p50", 0) or 0),
+    )
+    logger.info("=" * 80)
+
+
+__all__ = [
+    "SwoBenchAgenticTracesDriver",
+    "build_swo_bench_cmd",
+    "parse_swo_bench_output",
+]

--- a/llm_module/drivers/swo_bench_agentic_traces.py
+++ b/llm_module/drivers/swo_bench_agentic_traces.py
@@ -15,10 +15,12 @@ Like the AIPerf agentic-traces driver, this is intentionally not an
 ``LLMRunConfig`` (isl / osl / concurrency / num_prompts), which cannot express a
 trace-replay run.
 
-The SwarmOne license key is never placed on the command line (it would leak into
-run logs). swo-bench resolves it from the ``SWO_LICENSE_KEY`` environment
-variable or ``~/.swarmone/license.key``; the process env is inherited by the
-subprocess, and ``run.py`` fails fast when neither is present for a swarmone run.
+No credential is ever placed on the command line: :func:`llm_module.drivers.
+_subprocess.run_command` logs the full argv, so both the SwarmOne license and
+the endpoint bearer token travel by environment instead. swo-bench resolves the
+license from ``SWO_LICENSE_KEY`` or ``~/.swarmone/license.key`` (``run.py`` fails
+fast when neither is present for a swarmone run) and the token from
+``SWO_REPLAY_API_KEY`` (see :func:`build_swo_bench_env`).
 """
 
 from __future__ import annotations
@@ -95,13 +97,14 @@ class SwoBenchAgenticTracesDriver:
             model_name=server.model or self.model_repo,
             url=server.url_with_port,
             results_path=results_path,
-            auth_token=server.auth_token,
         )
         _log_run_header(trace_run)
 
-        # swo-bench reads the license from SWO_LICENSE_KEY / ~/.swarmone; the
-        # sweep-level env (context.extra_env) is inherited, run-level env last.
+        # swo-bench reads the license from SWO_LICENSE_KEY / ~/.swarmone and the
+        # endpoint token from SWO_REPLAY_API_KEY, so neither reaches argv (which
+        # the subprocess runner logs). Sweep-level env first, run-level env last.
         env = dict(context.extra_env)
+        env.update(build_swo_bench_env(server.auth_token))
         env.update(trace_run.env)
 
         rc = run_command(cmd, env=env, timeout_s=context.per_run_timeout_s)
@@ -167,6 +170,39 @@ def _swo_endpoint(url: str) -> str:
     return url
 
 
+def swo_bench_executable(venv_python: Path) -> Path:
+    """Locate the ``swo-bench`` console script beside ``venv_python``.
+
+    Unlike aiperf, the swo_bench package ships no ``__main__``, so
+    ``python -m swo_bench`` fails outright. The console script is also the only
+    entry point that sets Click's ``auto_envvar_prefix``, which is what lets the
+    API key travel by environment instead of argv.
+    """
+    candidate = Path(venv_python).parent / "swo-bench"
+    if candidate.exists():
+        return candidate
+    found = shutil.which("swo-bench")
+    if found:
+        return Path(found)
+    raise RuntimeError(
+        f"swo-bench executable not found next to {venv_python} or on PATH. "
+        "It is installed into the AGENTIC_TRACES venv from "
+        "requirements/agentic-traces.txt."
+    )
+
+
+def build_swo_bench_env(auth_token: str) -> Dict[str, str]:
+    """Environment carrying the endpoint credential for ``swo-bench replay``.
+
+    The bearer token must not go on the command line: the subprocess runner logs
+    the full argv, so ``--api-key`` would print the caller's key into every run
+    log. ``swo-bench``'s CLI group sets ``auto_envvar_prefix="SWO"``, so Click
+    reads ``--api-key`` for the ``replay`` subcommand from this variable. The
+    license key travels the same way, via ``SWO_LICENSE_KEY``.
+    """
+    return {"SWO_REPLAY_API_KEY": auth_token} if auth_token else {}
+
+
 def build_swo_bench_cmd(
     *,
     run: AgenticTracesRun,
@@ -174,7 +210,6 @@ def build_swo_bench_cmd(
     model_name: str,
     url: str,
     results_path: Path,
-    auth_token: str = "",
 ) -> List[str]:
     """Construct the ``swo-bench replay`` CLI for one SwarmOne run.
 
@@ -184,12 +219,12 @@ def build_swo_bench_cmd(
     is always passed (and context auto-resolution disabled) because the
     Tenstorrent Console ``/v1/models`` does not report the window, which would
     otherwise abort the run (see SWO_BENCH_REPORT.md).
+
+    Credentials are deliberately absent; see :func:`build_swo_bench_env`.
     """
     resident = run.resident if run.resident is not None else run.concurrency
     cmd: List[str] = [
-        str(venv_python),
-        "-m",
-        "swo_bench",
+        str(swo_bench_executable(venv_python)),
         "replay",
         "--scenario",
         run.scenario,
@@ -222,8 +257,6 @@ def build_swo_bench_cmd(
             str(results_path),
         ]
     )
-    if auth_token:
-        cmd.extend(["--api-key", auth_token])
     return cmd
 
 
@@ -266,7 +299,6 @@ def parse_swo_bench_output(results_path: Path) -> Dict[str, Any]:
     latency = _block("latency_ms")
     decode = _block("decode_tok_per_sec")
     prefill = _block("prefill_tok_per_sec")
-    itl = _block("itl_ms_p50")
 
     successful = _int(agg.get("successful"))
     failed = _int(agg.get("failed"))
@@ -297,11 +329,12 @@ def parse_swo_bench_output(results_path: Path) -> Dict[str, Any]:
         "p99_e2el_ms": _num(latency.get("p99")),
         "min_e2el_ms": _num(latency.get("min")),
         "max_e2el_ms": _num(latency.get("max")),
-        # Inter-token latency reads implausibly low from swo-bench (a streaming
-        # measurement artifact per SWO_BENCH_REPORT.md); surfaced for parity but
-        # decode tok/s and TTFT are the reliable signals.
-        "mean_tpot_ms": _num(itl.get("mean")),
-        "median_tpot_ms": _num(itl.get("p50")),
+        # No TPOT: swo-bench's ``itl_ms_p50`` is not a usable inter-token
+        # latency. A live Qwen3-32B run reported a mean of 0.01 ms (~100k
+        # tok/s) while decode_tok_per_sec said 38.9 tok/s, so it measures
+        # something other than the gap between tokens. Publishing it would put
+        # a plausible-looking 0.0 next to AIPerf's real TPOT and invite the
+        # comparison; the raw value stays in the results JSON on disk.
         # Throughput. Per-user decode rate while streaming, plus the aggregate.
         "output_token_throughput_per_user": _num(decode.get("mean")),
         "median_output_token_throughput_per_user": _num(decode.get("p50")),
@@ -388,6 +421,11 @@ def _build_payload(
         "backend": "swo-bench",
         "task_type": "agentic_traces",
         "trace_source": run.trace_source.value,
+        # Only reached once ``_invalid_result_reason`` cleared the run, so the
+        # verdict is settled here. Recording it keeps the report's Submission
+        # column meaningful for swo-bench rows: swo-bench has no scenario-level
+        # verdict of its own, and an absent field renders as an alarming N/A.
+        "submission_valid": True,
         "label": run.label,
         "mode": run.mode.to_string(),
         "model_id": model_repo,
@@ -478,5 +516,7 @@ def _log_run_summary(run: AgenticTracesRun, metrics: Mapping[str, Any]) -> None:
 __all__ = [
     "SwoBenchAgenticTracesDriver",
     "build_swo_bench_cmd",
+    "build_swo_bench_env",
     "parse_swo_bench_output",
+    "swo_bench_executable",
 ]

--- a/llm_module/parsers/__init__.py
+++ b/llm_module/parsers/__init__.py
@@ -5,11 +5,13 @@
 from .aiperf_agentic_traces import AIPerfAgenticTracesParser
 from .aiperf_prefix_cache import AIPerfPrefixCacheParser
 from .aiperf_spec_decode import AIPerfSpecDecodeParser
+from .swo_bench_agentic_traces import SwoBenchAgenticTracesParser
 from .base import LLMResultParser
 
 __all__ = [
     "AIPerfAgenticTracesParser",
     "AIPerfPrefixCacheParser",
     "AIPerfSpecDecodeParser",
+    "SwoBenchAgenticTracesParser",
     "LLMResultParser",
 ]

--- a/llm_module/parsers/swo_bench_agentic_traces.py
+++ b/llm_module/parsers/swo_bench_agentic_traces.py
@@ -11,8 +11,10 @@ kind with the InferenceX/AIPerf parser so the report generator collapses both
 harnesses' rows into a single section; the ``backend`` / ``trace_source`` fields
 distinguish them.
 
-No dedicated renderer is registered: the payload is a flat record, which is what
-the generic renderer expects.
+Sharing the kind also means sharing
+:mod:`report_module.agentic_traces_renderer`, which keys its per-source prose
+and its swo-bench columns off ``trace_source``. A field added here only reaches
+the report once it is listed in one of that module's column groups.
 """
 
 from __future__ import annotations

--- a/llm_module/parsers/swo_bench_agentic_traces.py
+++ b/llm_module/parsers/swo_bench_agentic_traces.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+
+"""Parser for the SwarmOne swo-bench agentic trace-replay driver output.
+
+Consumes the combined payload from
+:class:`llm_module.drivers.swo_bench_agentic_traces.SwoBenchAgenticTracesDriver`
+and emits one :class:`report_module.schema.Block`. It shares the ``agentic_traces``
+kind with the InferenceX/AIPerf parser so the report generator collapses both
+harnesses' rows into a single section; the ``backend`` / ``trace_source`` fields
+distinguish them.
+
+No dedicated renderer is registered: the payload is a flat record, which is what
+the generic renderer expects.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Mapping
+
+from report_module.schema import Block
+
+from .base import LLMResultParser
+
+
+class SwoBenchAgenticTracesParser(LLMResultParser):
+    kind = "agentic_traces"
+
+    def parse(self, raw: Mapping[str, Any], *, device: str = "") -> Block:
+        record = dict(raw)
+        record.setdefault("kind", self.kind)
+        record["model"] = str(raw.get("model_id") or raw.get("model") or "")
+        record["device"] = device
+        record["timestamp"] = _normalize_timestamp(raw.get("date"))
+
+        # error_rate_pct is a percentage; carry a fraction alongside it so it can
+        # be compared to a failed-request threshold without unit confusion.
+        error_rate_pct = raw.get("error_rate_pct")
+        if isinstance(error_rate_pct, (int, float)):
+            record["error_rate"] = float(error_rate_pct) / 100.0
+
+        # Surface run provenance as first-class fields: a replay number is only
+        # reproducible alongside the client version, session, and mode.
+        metadata = raw.get("metadata") or {}
+        if isinstance(metadata, Mapping):
+            for key in ("model_id", "mode"):
+                if key in metadata and key not in record:
+                    record[key] = metadata[key]
+
+        return self._wrap_record(record)
+
+
+def _normalize_timestamp(raw_date: Any) -> str:
+    """Return ``YYYY-MM-DD HH:MM:SS`` (best effort, never raises)."""
+    if isinstance(raw_date, str) and raw_date:
+        for fmt in ("%Y%m%d-%H%M%S", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"):
+            try:
+                return dt.datetime.strptime(raw_date, fmt).strftime("%Y-%m-%d %H:%M:%S")
+            except ValueError:
+                continue
+        return raw_date
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+__all__ = ["SwoBenchAgenticTracesParser"]

--- a/reference_config/agentic_traces/agentic_traces_config.py
+++ b/reference_config/agentic_traces/agentic_traces_config.py
@@ -41,9 +41,8 @@ class TraceSource(Enum):
     """Where a run's agentic traces come from.
 
     ``INFERENCEX_AGENTX`` replays the SemiAnalysis Weka coding traces through
-    the AIPerf fork vendored in the InferenceX repo. ``SWARMONE`` is registered
-    so configs and CLI selection can name it, but building runs for it raises
-    ``NotImplementedError`` until its harness is integrated.
+    the AIPerf fork vendored in the InferenceX repo. ``SWARMONE`` replays
+    SwarmOne's recorded coding sessions through its ``swo-bench`` CLI.
     """
 
     INFERENCEX_AGENTX = "inferencex_agentx"
@@ -57,6 +56,13 @@ class TraceSource(Enum):
         except KeyError:
             valid = ", ".join(sorted(m.value for m in cls))
             raise ValueError(f"Invalid TraceSource: {name!r}. Valid: {valid}")
+
+
+# Sources that a sweep only runs when it names them explicitly via
+# ``--agentic-traces-sources``. SwarmOne's swo-bench needs a paid SwarmOne
+# license, so having it configured for a model must not make that license a
+# precondition for the model's plain ``--workflow agentic_traces`` run.
+OPT_IN_TRACE_SOURCES: Tuple[TraceSource, ...] = (TraceSource.SWARMONE,)
 
 
 @dataclass(frozen=True)
@@ -414,6 +420,26 @@ def get_agentic_traces_config(model_spec) -> Optional[AgenticTracesConfig]:
     return AGENTIC_TRACES_CONFIGS.get(model_id)
 
 
+def default_run_specs(
+    config: AgenticTracesConfig,
+) -> Tuple[AgenticTracesRunSpec, ...]:
+    """The runs a sweep gets when it does not name its sources explicitly.
+
+    Opt-in sources (see :data:`OPT_IN_TRACE_SOURCES`) are held back: merely
+    registering a SwarmOne run for a model must not turn a SwarmOne license
+    into a precondition for that model's plain ``--workflow agentic_traces``
+    run, which otherwise only needed the InferenceX client.
+
+    The exception is a config with *nothing but* opt-in runs -- there the
+    opt-in source is the only harness available, so withholding it would leave
+    an empty sweep. Such a run does require the license, unavoidably.
+    """
+    always_on = tuple(
+        run for run in config.runs if run.trace_source not in OPT_IN_TRACE_SOURCES
+    )
+    return always_on or config.runs
+
+
 def resolve_run_specs(
     config: AgenticTracesConfig,
     *,
@@ -423,21 +449,24 @@ def resolve_run_specs(
     """Apply CLI-level narrowing/overrides to a config.
 
     Returns the (possibly ref-overridden) config alongside the selected run
-    specs so the caller can pass both to the run builder.
+    specs so the caller can pass both to the run builder. With no explicit
+    ``trace_sources`` the selection comes from :func:`default_run_specs`, which
+    holds back opt-in sources.
     """
     effective = config
     if git_ref_override:
         effective = replace(config, inferencex_git_ref=git_ref_override)
-    runs = effective.runs
-    if trace_sources:
-        wanted = set(trace_sources)
-        runs = tuple(run for run in runs if run.trace_source in wanted)
-        if not runs:
-            raise ValueError(
-                f"No agentic-trace runs for model_id={config.model_id!r} match "
-                f"trace source(s) {sorted(s.value for s in wanted)}. "
-                f"Configured: {sorted(s.value for s in config.trace_sources())}"
-            )
+    if not trace_sources:
+        return effective, default_run_specs(effective)
+
+    wanted = set(trace_sources)
+    runs = tuple(run for run in effective.runs if run.trace_source in wanted)
+    if not runs:
+        raise ValueError(
+            f"No agentic-trace runs for model_id={config.model_id!r} match "
+            f"trace source(s) {sorted(s.value for s in wanted)}. "
+            f"Configured: {sorted(s.value for s in config.trace_sources())}"
+        )
     return effective, runs
 
 
@@ -450,7 +479,9 @@ __all__ = [
     "CI_MODE_SETTINGS",
     "DEFAULT_MODE_SETTINGS",
     "FULL_MODE_SETTINGS",
+    "OPT_IN_TRACE_SOURCES",
     "TraceSource",
+    "default_run_specs",
     "for_model_ids",
     "get_agentic_traces_config",
     "resolve_run_specs",

--- a/reference_config/agentic_traces/agentic_traces_config.py
+++ b/reference_config/agentic_traces/agentic_traces_config.py
@@ -89,6 +89,23 @@ class AgenticTracesRunSpec:
     tokenizer_trust_remote_code: Optional[bool] = None
     use_server_token_count: bool = True
     gpu_telemetry: bool = False
+    # SwarmOne (``swo-bench replay``) knobs. Ignored by the InferenceX/AIPerf
+    # driver, so they can stay at their defaults on ``inferencex_agentx`` specs.
+    # ``task`` selects a single task from a multi-task swo-bench scenario (its
+    # ``-t``); ``None`` replays every task. ``resident`` is swo-bench's ``-r``
+    # (distinct conversations kept active); ``None`` defaults to ``concurrency``.
+    # ``cache_mode`` / ``history_mode`` / ``max_tokens`` / ``max_tokens_mode``
+    # mirror the swo-bench defaults documented in SWO_BENCH_REPORT.md.
+    task: Optional[str] = None
+    resident: Optional[int] = None
+    cache_mode: str = "realistic"
+    history_mode: str = "faithful"
+    max_tokens: int = 4096
+    max_tokens_mode: str = "flat"
+    # Modes this run participates in. ``None`` means every mode (the InferenceX
+    # default). SwarmOne uses it to give FULL and CI different task/concurrency
+    # shapes without a shared mode-settings override leaking across sources.
+    modes: Optional[Tuple[AgenticTracesMode, ...]] = None
     # AIPERF_* process env. These are read by AIPerf itself, not passed as
     # flags: the two timeouts cover dataset download plus per-service profile
     # configuration for the ~400-trace Weka datasets, the WEKA_LIVE toggle
@@ -127,10 +144,47 @@ class AgenticTracesRunSpec:
                 f"{self.trajectory_start_min_ratio} max="
                 f"{self.trajectory_start_max_ratio}"
             )
+        if self.resident is not None and self.resident < 1:
+            raise ValueError(
+                f"AgenticTracesRunSpec.resident must be >= 1 when set, "
+                f"got {self.resident}"
+            )
+        if self.max_tokens < 1:
+            raise ValueError(
+                f"AgenticTracesRunSpec.max_tokens must be >= 1, got {self.max_tokens}"
+            )
+        valid_cache_modes = {"realistic", "allcold", "allwarm"}
+        if self.cache_mode not in valid_cache_modes:
+            raise ValueError(
+                f"AgenticTracesRunSpec.cache_mode must be one of "
+                f"{sorted(valid_cache_modes)}, got {self.cache_mode!r}"
+            )
+        valid_history_modes = {"live", "recorded", "faithful"}
+        if self.history_mode not in valid_history_modes:
+            raise ValueError(
+                f"AgenticTracesRunSpec.history_mode must be one of "
+                f"{sorted(valid_history_modes)}, got {self.history_mode!r}"
+            )
+        valid_max_tokens_modes = {"flat", "recorded-completion"}
+        if self.max_tokens_mode not in valid_max_tokens_modes:
+            raise ValueError(
+                f"AgenticTracesRunSpec.max_tokens_mode must be one of "
+                f"{sorted(valid_max_tokens_modes)}, got {self.max_tokens_mode!r}"
+            )
 
     @property
     def label(self) -> str:
-        """Short identifier used for artifact dirs and report rows."""
+        """Short identifier used for artifact dirs and report rows.
+
+        SwarmOne specs key on scenario (+ optional task) rather than the
+        InferenceX ``public_dataset``, which they leave unset.
+        """
+        if self.trace_source is TraceSource.SWARMONE:
+            parts = [self.trace_source.value, self.scenario]
+            if self.task:
+                parts.append(self.task)
+            parts.append(f"c{self.concurrency}")
+            return "_".join(parts)
         return f"{self.trace_source.value}_{self.public_dataset}_c{self.concurrency}"
 
     @property
@@ -237,10 +291,16 @@ class AgenticTracesConfig:
     def __post_init__(self) -> None:
         if not self.model_id.strip():
             raise ValueError("AgenticTracesConfig.model_id must not be empty")
-        if not self.inferencex_git_ref.strip():
+        # The InferenceX pin is only meaningful when an InferenceX run is
+        # configured; a swarmone-only config leaves it empty and never clones
+        # the repo (see setup_agentic_traces).
+        needs_inferencex_ref = any(
+            run.trace_source is TraceSource.INFERENCEX_AGENTX for run in self.runs
+        )
+        if needs_inferencex_ref and not self.inferencex_git_ref.strip():
             raise ValueError(
                 f"AgenticTracesConfig.inferencex_git_ref must not be empty "
-                f"for model_id={self.model_id!r}"
+                f"for model_id={self.model_id!r} (it has inferencex_agentx runs)"
             )
         if not self.runs:
             raise ValueError(
@@ -309,6 +369,28 @@ _agentic_traces_config_list: List[AgenticTracesConfig] = [
                 trace_source=TraceSource.INFERENCEX_AGENTX,
                 public_dataset="semianalysis_cc_traces_weka_062126_256k",
                 concurrency=64,
+            ),
+            # SwarmOne swo-bench replay of the recorded Kimi Claude-Code
+            # SWE-bench sessions. FULL replays all three tasks (sympy-bugfix,
+            # httpx-coverage, monorepo-refactor) at concurrency 8; CI replays
+            # only the short sympy-bugfix task at concurrency 1. The scenario id
+            # is the swo-bench catalog name (see `swo-bench list-scenarios`),
+            # not the InferenceX ``public_dataset``. Both shapes match the
+            # hand-validated runs in SWO_BENCH_REPORT.md.
+            AgenticTracesRunSpec(
+                trace_source=TraceSource.SWARMONE,
+                scenario="claude-code-swe-bench-python-kimi-k2.7-code",
+                public_dataset="",
+                concurrency=8,
+                modes=(AgenticTracesMode.FULL,),
+            ),
+            AgenticTracesRunSpec(
+                trace_source=TraceSource.SWARMONE,
+                scenario="claude-code-swe-bench-python-kimi-k2.7-code",
+                public_dataset="",
+                task="sympy-bugfix",
+                concurrency=1,
+                modes=(AgenticTracesMode.CI,),
             ),
         ),
     ),

--- a/report_module/agentic_traces_renderer.py
+++ b/report_module/agentic_traces_renderer.py
@@ -15,6 +15,13 @@ The config table is transposed (one row per field) because it is the same
 handful of values for every run and its values are long, so as columns they set
 the width of the whole report.
 
+Two harnesses share this kind -- the InferenceX AIPerf fork and SwarmOne's
+swo-bench -- and a sweep can mix them. The tables are common ground (a column no
+run emitted is dropped, so each source only pays width for its own metrics),
+while the surrounding prose is selected per source: describing swo-bench numbers
+as AIPerf's, or defining metrics the report does not contain, is worse than
+silence.
+
 Registered with :func:`report_module.renderers.register` at import time (see the
 bottom of this module).
 """
@@ -31,6 +38,11 @@ from report_module.schema import Block
 logger = logging.getLogger(__name__)
 
 NA = "N/A"
+
+# ``TraceSource`` values, duplicated rather than imported: report_module renders
+# whatever a Block carries and does not otherwise depend on reference_config.
+INFERENCEX_SOURCE = "inferencex_agentx"
+SWARMONE_SOURCE = "swarmone"
 
 # The run identity carried by every table so rows can be lined up across them.
 # The generated `label` is long and redundant with these three, so it is only
@@ -66,15 +78,25 @@ LATENCY_COLUMNS: List[Tuple[str, str]] = [
 
 THROUGHPUT_COLUMNS: List[Tuple[str, str]] = [
     ("output_token_throughput_per_user", "Out Tok/s/User"),
+    ("median_output_token_throughput_per_user", "Out Tok/s/User P50"),
     ("e2e_output_token_throughput_per_user", "E2E Tok/s/User"),
     ("output_token_throughput", "Output Tok/s"),
     ("total_token_throughput", "Total Tok/s"),
+    ("active_throughput_tok_per_s", "Total Tok/s (Active)"),
     ("request_throughput", "Req/s"),
     ("effective_prefill_throughput", "Prefill Tok/s"),
     ("active_prefill_throughput", "Prefill Tok/s (Active)"),
+    # swo-bench measures prefill per request against the prompt actually sent,
+    # so a cache hit shows up as a very high rate; it is not comparable to
+    # AIPerf's run-averaged effective_prefill_throughput above.
+    ("prefill_tok_per_sec_mean", "Prefill Tok/s/Req Avg"),
+    ("prefill_tok_per_sec_p50", "Prefill Tok/s/Req P50"),
+    ("prefill_tok_per_sec_p90", "Prefill Tok/s/Req P90"),
     ("effective_decode_throughput", "Decode Tok/s"),
     ("active_decode_throughput", "Decode Tok/s (Active)"),
     ("effective_concurrency", "Eff. Concur"),
+    ("concurrency_mean", "Concur Avg"),
+    ("concurrency_peak", "Concur Peak"),
     ("mean_tokens_in_flight", "Tok In Flight Avg"),
     ("max_tokens_in_flight", "Tok In Flight Max"),
     ("mean_isl", "ISL Mean"),
@@ -101,6 +123,9 @@ HEALTH_COLUMNS: List[Tuple[str, str]] = [
     ("branch_children_delayed", "Br. Delayed"),
     ("branch_parents_failed_due_to_child_error", "Br. Parent Failed"),
     ("branch_joins_suppressed", "Br. Joins Dropped"),
+    ("ready_starved_events", "Ready Starved"),
+    ("pace_idle_ms", "Pace Idle (ms)"),
+    ("tool_idle_ms", "Tool Idle (ms)"),
     ("measured_benchmark_duration", "Measured (s)"),
     ("error_summary", "Top Errors"),
 ]
@@ -109,12 +134,18 @@ HEALTH_COLUMNS: List[Tuple[str, str]] = [
 CONFIG_FIELDS: List[Tuple[str, str]] = [
     ("label", "Run"),
     ("scenario", "Scenario"),
+    ("task", "Task"),
     ("public_dataset", "Dataset"),
     ("dataset_hf_name", "Dataset Repo"),
     ("dataset_num_entries", "Trace Pool"),
     ("benchmark_duration", "Profiling Window (s)"),
     ("warmup_requests_per_lane", "Warmup (req/lane)"),
     ("warmup_grace_period", "Warmup Grace (s)"),
+    ("resident", "Resident Sessions"),
+    ("cache_mode", "Cache Mode"),
+    ("history_mode", "History Mode"),
+    ("max_tokens", "Max Tokens"),
+    ("max_tokens_mode", "Max Tokens Mode"),
     ("max_context_length", "Max Context"),
     ("failed_request_threshold", "Fail Threshold"),
     ("trajectory_start_min_ratio", "Trajectory Start Min"),
@@ -122,6 +153,8 @@ CONFIG_FIELDS: List[Tuple[str, str]] = [
     ("random_seed", "Random Seed"),
     ("inferencex_git_ref", "Client Ref"),
     ("aiperf_version", "AIPerf Version"),
+    ("swo_bench_version", "swo-bench Version"),
+    ("swo_session_id", "swo-bench Session"),
     ("benchmark_id", "Benchmark ID"),
     ("run_started_at", "Started"),
     ("run_ended_at", "Ended"),
@@ -132,10 +165,15 @@ _THROUGHPUT_KEYS = frozenset(
     {
         "output_token_throughput",
         "output_token_throughput_per_user",
+        "median_output_token_throughput_per_user",
         "e2e_output_token_throughput_per_user",
         "total_token_throughput",
+        "active_throughput_tok_per_s",
         "effective_prefill_throughput",
         "active_prefill_throughput",
+        "prefill_tok_per_sec_mean",
+        "prefill_tok_per_sec_p50",
+        "prefill_tok_per_sec_p90",
         "effective_decode_throughput",
         "active_decode_throughput",
     }
@@ -173,6 +211,12 @@ _INT_KEYS = frozenset(
         "total_output_tokens",
         "mean_tokens_in_flight",
         "max_tokens_in_flight",
+        "ready_starved_events",
+        "pace_idle_ms",
+        "tool_idle_ms",
+        "resident",
+        "max_tokens",
+        "concurrency_peak",
     }
 )
 
@@ -189,9 +233,102 @@ _RATIO_KEYS = frozenset(
         "failed_request_threshold",
         "slice_duration",
         "effective_concurrency",
+        "concurrency_mean",
         "connection_reuse_rate",
     }
 )
+
+
+# Metric definitions, grouped by the harness that produces the metric. Emitting
+# only the groups whose source is present keeps a swo-bench-only report from
+# defining AIPerf metrics it never measured (and crediting AIPerf for the ones
+# it did).
+SHARED_DEFINITIONS: List[str] = [
+    # TPOT is not here: only AIPerf reports a usable one, and naming it in a
+    # swo-bench report would define a column that report does not contain.
+    "**TTFT / E2EL**: time to first token and end-to-end request latency. "
+    "Long-context agentic prefill makes TTFT the headline metric, so its "
+    "spread is reported.",
+    "**Out Tok/s/User**: decode speed while a request is streaming, i.e. how "
+    "fast a single agent's turn produces text.",
+    "**Reqs OK / Errors / Error %**: successful requests (the sample size "
+    "behind every latency stat), failed ones, and the failure share.",
+    "**Measured (s)**: actual wall clock the run occupied.",
+]
+
+INFERENCEX_DEFINITIONS: List[str] = [
+    "**TPOT**: inter-token latency, i.e. the gap between streamed tokens once "
+    "generation is under way.",
+    "**TTFOT**: time to the first token the user actually sees. On a reasoning "
+    "model the gap to TTFT is time spent emitting reasoning tokens.",
+    "**CO-Adj E2EL**: latency corrected for coordinated omission, so it "
+    "includes the time a request spent waiting to be dispatched. It tracks "
+    "E2EL until requests start queueing.",
+    "**Err-Adj TTFT / E2EL**: percentiles with failed requests folded in, so a "
+    "run that got fast by erroring out cannot look good. Omitted when a run "
+    "had no errors.",
+    "**E2E Tok/s/User**: divides by whole-request wall clock rather than "
+    "streaming time, so it includes prefill and is the user-visible speed of "
+    "an agentic turn; expect it to be several times lower than "
+    "**Out Tok/s/User**.",
+    "**Prefill / Decode Tok/s**: the phase split of serving throughput, "
+    "averaged over the whole run. The **(Active)** variants only count the "
+    "windows where that phase was actually working, so the ratio between them "
+    "is the phase's duty cycle.",
+    "**Eff. Concur**: concurrency actually in flight. Trace replay honours the "
+    "recorded think time, so this sits below the requested **Concur** by "
+    "design; a large shortfall means the intended load was never applied.",
+    "**Tok In Flight**: KV footprint across in-flight requests. Compare the "
+    "max against **Max Context**.",
+    "**Ctx Overflow**: requests whose trace exceeded **Max Context**. Non-zero "
+    "means the replay was truncated and no longer matches what was recorded; "
+    "above 1% the scenario invalidates the submission.",
+    "**OSL Mismatch / OSL Diff %**: responses whose length did not match the "
+    "trace's recorded output, and by how much. Non-zero means the replayed "
+    "conversation diverged from what was recorded.",
+    "**Cache Hit %**: measured from the serving engine's own counters over the "
+    "profiling window, so the cache-priming warmup is excluded. **Theo. Cache "
+    "Hit %** is the reuse inherent to the traces, i.e. the upper bound the "
+    "engine was offered. A measured rate well below it means the cache was "
+    "evicting reuse the workload had available. Omitted when the server "
+    "exposes no such counters.",
+    "**Credit Drops**: requests the load generator could not dispatch on the "
+    "trace's schedule. Non-zero means the recorded timing was not reproduced, "
+    "usually because the server was saturated.",
+    "**Conn Reuse**: fraction of requests served on a reused connection. Below "
+    "1.0 means connections were being torn down, which is what shows up as "
+    "`ServerDisconnectedError`.",
+    "**Branches**: subagent trajectories spawned during replay. Any errored, "
+    "truncated, or delayed child, any parent failed by its child, or any "
+    "dropped join means the fan-out did not replay as recorded.",
+    "**Fail Threshold**: the error rate above which the scenario aborts the run.",
+    "**Measured (s)** should track **Profiling Window (s)**; a large shortfall "
+    "means the run ended early.",
+]
+
+SWARMONE_DEFINITIONS: List[str] = [
+    "**Prefill Tok/s/Req**: prefill rate for one request measured over the "
+    "whole prompt sent, so a prefix-cache hit reads as a very high rate. "
+    "Capturing that cache-served prefill is the point of the metric -- it is "
+    "what a fixed-ISL sweep cannot show -- but it is a per-request rate, not a "
+    "serving-capacity figure, so do not read it against the run-averaged "
+    "prefill columns.",
+    "**TPOT** is deliberately absent: swo-bench's inter-token figure is not a "
+    "usable latency (a live run reported 0.01 ms per token against a measured "
+    "38.9 tok/s), so **Out Tok/s/User** and **TTFT** are the latency signals "
+    "for these rows.",
+    "**Total Tok/s (Active)**, **Concur Avg / Peak**: throughput and "
+    "concurrency counted only while requests were in flight, which excludes "
+    "the replay's simulated tool time. Compare against the requested "
+    "**Concur** to see how much of it the recorded sessions actually asked "
+    "for.",
+    "**Ready Starved**: turns that were ready to dispatch but had no free "
+    "slot. Non-zero means **Resident Sessions** bounded the run rather than "
+    "the server.",
+    "**Pace / Tool Idle (ms)**: time the harness deliberately spent idle "
+    "reproducing the recorded think and tool-call time. It is inside "
+    "**Measured (s)** but is not server time.",
+]
 
 
 def _format_value(key: str, value: Any) -> str:
@@ -318,6 +455,82 @@ def _resolve_client_ref(rows: Sequence[Mapping[str, Any]]) -> Optional[str]:
     return None
 
 
+def _resolve_field(rows: Sequence[Mapping[str, Any]], key: str) -> Optional[str]:
+    for row in rows:
+        value = row.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _tool_paragraphs(rows: Sequence[Mapping[str, Any]]) -> List[str]:
+    """Describe each harness that contributed a row.
+
+    A mixed sweep runs two unrelated clients over two unrelated trace sets, so
+    one blurb cannot honestly cover both -- and crediting AIPerf for a swo-bench
+    row would misattribute the numbers.
+    """
+    sources = {str(row.get("trace_source") or "") for row in rows}
+    paragraphs: List[str] = []
+
+    if INFERENCEX_SOURCE in sources:
+        client_ref = _resolve_client_ref(rows)
+        ref_note = f" pinned at `{client_ref}`" if client_ref else ""
+        paragraphs.append(
+            "**`inferencex_agentx` rows:** the AIPerf fork vendored in "
+            "[InferenceX](https://github.com/SemiAnalysisAI/InferenceX)"
+            f"{ref_note}, driving the `inferencex-agentx-mvp` scenario. Each run "
+            "replays recorded multi-turn agentic coding traces with their original "
+            "timing, including subagent fan-out, so the load shape is the trace's "
+            "rather than a synthetic ISL/OSL grid."
+        )
+
+    if SWARMONE_SOURCE in sources:
+        version = _resolve_field(rows, "swo_bench_version")
+        version_note = f" v{version}" if version else ""
+        paragraphs.append(
+            "**`swarmone` rows:** SwarmOne's "
+            "[`swo-bench`](https://swarmone.ai/docs/swo-bench)"
+            f"{version_note} replay engine. Each run replays recorded Claude-Code "
+            "/ Codex coding sessions turn by turn with growing history, so the "
+            "prompt is mostly a prefix-cache hit that grows through the session "
+            "-- the shape a fixed-ISL sweep cannot produce. The replay plan is "
+            "built server-side by the SwarmOne backend."
+        )
+
+    paragraphs.append(
+        "Numbers are only comparable across runs from the same source on the "
+        "same client revision and trace set."
+    )
+    return paragraphs
+
+
+def _submission_caption(rows: Sequence[Mapping[str, Any]]) -> str:
+    """Explain what the Submission verdict means for the sources present.
+
+    The two harnesses reach the verdict differently, and reporting one
+    explanation over both would overstate what swo-bench actually checks.
+    """
+    sources = {str(row.get("trace_source") or "") for row in rows}
+    sentences: List[str] = []
+    if INFERENCEX_SOURCE in sources:
+        sentences.append(
+            "For `inferencex_agentx` it is the scenario's own verdict, not "
+            "ours: it folds static scenario-lock violations, a context-overflow "
+            "rate above 1%, and early cancellation into one flag."
+        )
+    if SWARMONE_SOURCE in sources:
+        sentences.append(
+            "swo-bench publishes no such verdict, so for `swarmone` it is our "
+            "own completeness check (the run returned successful requests with "
+            "a plausible TTFT)."
+        )
+    sentences.append(
+        "An invalid run is failed by the driver and never reaches this table."
+    )
+    return " ".join(sentences)
+
+
 def render_agentic_traces(block: Block, metadata: Mapping[str, Any]) -> str:
     """Render every agentic-trace run into the report section."""
     records = _extract_records(block)
@@ -330,17 +543,8 @@ def render_agentic_traces(block: Block, metadata: Mapping[str, Any]) -> str:
     heading_suffix = f" for {suffix}" if suffix else ""
     parts: List[str] = [f"### Agentic Trace Replay{heading_suffix}"]
 
-    client_ref = _resolve_client_ref(rows)
-    ref_note = f" pinned at `{client_ref}`" if client_ref else ""
-    parts.append(
-        "**Benchmarking Tool:** the AIPerf fork vendored in "
-        "[InferenceX](https://github.com/SemiAnalysisAI/InferenceX)"
-        f"{ref_note}, driving the `inferencex-agentx-mvp` scenario. Each run "
-        "replays recorded multi-turn agentic coding traces with their original "
-        "timing, including subagent fan-out, so the load shape is the trace's "
-        "rather than a synthetic ISL/OSL grid. Numbers are only comparable "
-        "across runs on the same client revision and dataset."
-    )
+    parts.append("**Benchmarking Tools:**")
+    parts.extend(_tool_paragraphs(rows))
 
     latency = _table(rows, LATENCY_COLUMNS)
     if latency:
@@ -354,11 +558,7 @@ def render_agentic_traces(block: Block, metadata: Mapping[str, Any]) -> str:
     if health:
         parts.append(
             "#### Run Health & Validity\n\n"
-            "**Submission** is the scenario's own verdict, not ours: it folds "
-            "static scenario-lock violations, a context-overflow rate above "
-            "1%, and early cancellation into one flag. An invalid run is "
-            "failed by the driver and is not a reportable number.\n\n"
-            f"{health}"
+            f"**Submission** {_submission_caption(rows)}\n\n{health}"
         )
 
     config = _vertical_table(rows, CONFIG_FIELDS)
@@ -371,65 +571,21 @@ def render_agentic_traces(block: Block, metadata: Mapping[str, Any]) -> str:
             f"can be traced back to what produced it.\n\n{config}"
         )
 
-    parts.append(
-        "**Metric definitions:**\n"
-        "> - **TTFT / TPOT / E2EL**: AIPerf time-to-first-token, inter-token "
-        "latency, and end-to-end request latency from "
-        "`profile_export_aiperf.json`. Long-context agentic prefill makes TTFT "
-        "the headline metric, so its spread is reported.\n"
-        "> - **TTFOT**: time to the first token the user actually sees. On a "
-        "reasoning model the gap to TTFT is time spent emitting reasoning "
-        "tokens.\n"
-        "> - **CO-Adj E2EL**: latency corrected for coordinated omission, so it "
-        "includes the time a request spent waiting to be dispatched. It tracks "
-        "E2EL until requests start queueing.\n"
-        "> - **Err-Adj TTFT / E2EL**: percentiles with failed requests folded "
-        "in, so a run that got fast by erroring out cannot look good. Omitted "
-        "when a run had no errors.\n"
-        "> - **Out Tok/s/User**: decode speed while a request is streaming. "
-        "**E2E Tok/s/User** divides by whole-request wall clock instead, so it "
-        "includes prefill and is the user-visible speed of an agentic turn; "
-        "expect it to be several times lower.\n"
-        "> - **Prefill / Decode Tok/s**: the phase split of serving throughput, "
-        "averaged over the whole run. The **(Active)** variants only count the "
-        "windows where that phase was actually working, so the ratio between "
-        "them is the phase's duty cycle.\n"
-        "> - **Eff. Concur**: concurrency actually in flight. Trace replay "
-        "honours the recorded think time, so this sits below the requested "
-        "**Concur** by design; a large shortfall means the intended load was "
-        "never applied.\n"
-        "> - **Tok In Flight**: KV footprint across in-flight requests. Compare "
-        "the max against **Max Context**.\n"
-        "> - **Reqs OK / Errors**: successful requests (the sample size behind "
-        "every latency stat) versus failed ones. **Error %** is AIPerf's "
-        "`request_error_rate`; the run aborts if it exceeds **Fail "
-        "Threshold**.\n"
-        "> - **Ctx Overflow**: requests whose trace exceeded **Max Context**. "
-        "Non-zero means the replay was truncated and no longer matches what was "
-        "recorded; above 1% the scenario invalidates the submission.\n"
-        "> - **OSL Mismatch / OSL Diff %**: responses whose length did not "
-        "match the trace's recorded output, and by how much. Non-zero means the "
-        "replayed conversation diverged from what was recorded.\n"
-        "> - **Cache Hit %**: measured from the serving engine's own counters "
-        "over the profiling window, so the cache-priming warmup is excluded. "
-        "**Theo. Cache Hit %** is the reuse inherent to the traces, i.e. the "
-        "upper bound the engine was offered. A measured rate well below it means "
-        "the cache was evicting reuse the workload had available. Omitted when "
-        "the server exposes no such counters.\n"
-        "> - **Credit Drops**: requests the load generator could not dispatch "
-        "on the trace's schedule. Non-zero means the recorded timing was not "
-        "reproduced, usually because the server was saturated.\n"
-        "> - **Conn Reuse**: fraction of requests served on a reused "
-        "connection. Below 1.0 means connections were being torn down, which is "
-        "what shows up as `ServerDisconnectedError`.\n"
-        "> - **Branches**: subagent trajectories spawned during replay. Any "
-        "errored, truncated, or delayed child, any parent failed by its child, "
-        "or any dropped join means the fan-out did not replay as recorded.\n"
-        "> - **Measured (s)**: actual profiling wall clock, which should track "
-        "**Profiling Window (s)**; a large shortfall means the run ended early."
-    )
+    parts.append(_definitions_block(rows))
 
     return "\n\n".join(parts)
+
+
+def _definitions_block(rows: Sequence[Mapping[str, Any]]) -> str:
+    """Emit only the metric definitions the report's sources actually produced."""
+    sources = {str(row.get("trace_source") or "") for row in rows}
+    bullets = list(SHARED_DEFINITIONS)
+    if INFERENCEX_SOURCE in sources:
+        bullets.extend(INFERENCEX_DEFINITIONS)
+    if SWARMONE_SOURCE in sources:
+        bullets.extend(SWARMONE_DEFINITIONS)
+    body = "\n".join(f"> - {bullet}" for bullet in bullets)
+    return f"**Metric definitions:**\n{body}"
 
 
 # Register at import time so any code path that imports report_module picks the

--- a/requirements/agentic-traces.txt
+++ b/requirements/agentic-traces.txt
@@ -44,3 +44,11 @@ huggingface_hub[cli]>=0.25.0
 # trust_remote_code, which imports tiktoken (and blobfile to fetch the vocab).
 tiktoken
 blobfile
+
+# SwarmOne swo-bench replay client (TraceSource.SWARMONE). It replays recorded
+# Claude-Code / Codex coding sessions against the endpoint; the replay plan is
+# built server-side by the SwarmOne backend. Unlike the InferenceX AIPerf fork
+# this is a normal PyPI package, so it installs here rather than via a git
+# checkout. A SwarmOne license (SWO_LICENSE_KEY / ~/.swarmone/license.key) is
+# required at run time, checked up front in run.py.
+swo-bench==3.1.2

--- a/run.py
+++ b/run.py
@@ -494,9 +494,9 @@ def parse_arguments():
         type=str,
         default=None,
         help="Comma-separated trace sources to run (inferencex_agentx, swarmone). When "
-        "unset, runs every source configured for the model. swarmone replays SwarmOne "
-        "swo-bench scenarios and requires a SwarmOne license (SWO_LICENSE_KEY or "
-        "~/.swarmone/license.key).",
+        "unset, runs every configured source except opt-in ones. swarmone is opt-in: "
+        "it replays SwarmOne swo-bench scenarios and needs a SwarmOne license "
+        "(SWO_LICENSE_KEY or ~/.swarmone/license.key), so name it explicitly to run it.",
     )
     agentic_traces_group.add_argument(
         "--agentic-traces-duration",

--- a/run.py
+++ b/run.py
@@ -494,8 +494,9 @@ def parse_arguments():
         type=str,
         default=None,
         help="Comma-separated trace sources to run (inferencex_agentx, swarmone). When "
-        "unset, runs every source configured for the model. swarmone has no client "
-        "integration yet and fails fast if selected.",
+        "unset, runs every source configured for the model. swarmone replays SwarmOne "
+        "swo-bench scenarios and requires a SwarmOne license (SWO_LICENSE_KEY or "
+        "~/.swarmone/license.key).",
     )
     agentic_traces_group.add_argument(
         "--agentic-traces-duration",

--- a/test_module/llm_tests/agentic_traces_tests.py
+++ b/test_module/llm_tests/agentic_traces_tests.py
@@ -30,6 +30,7 @@ from typing import Optional, Sequence
 from llm_module import ServerConnection
 from llm_module.agentic_traces import (
     build_runs,
+    estimated_run_seconds,
     summarize_runs,
     total_planned_seconds,
 )
@@ -38,7 +39,9 @@ from llm_module.drivers.aiperf_agentic_traces import (
     AgenticTracesDriverResult,
     AIPerfAgenticTracesDriver,
 )
+from llm_module.drivers.swo_bench_agentic_traces import SwoBenchAgenticTracesDriver
 from llm_module.parsers.aiperf_agentic_traces import AIPerfAgenticTracesParser
+from llm_module.parsers.swo_bench_agentic_traces import SwoBenchAgenticTracesParser
 from llm_module.runner import RunnerResult
 from llm_module.server_control import ServerController
 from reference_config.agentic_traces.agentic_traces_config import (
@@ -153,27 +156,46 @@ def run_agentic_traces(
         return result
 
     logger.info(summarize_runs(runs))
-    logger.info(
-        "[agentic-traces] InferenceX client pinned at %s",
-        effective_config.inferencex_git_ref,
-    )
+    # The pinned InferenceX ref only matters when an InferenceX run is planned;
+    # a swarmone-only sweep never clones it.
+    if any(run.trace_source is TraceSource.INFERENCEX_AGENTX for run in runs):
+        logger.info(
+            "[agentic-traces] InferenceX client pinned at %s",
+            effective_config.inferencex_git_ref,
+        )
 
     output_root = Path(ctx.output_path) / output_subdir
-    artifact_root = output_root / "aiperf_artifacts"
     output_root.mkdir(parents=True, exist_ok=True)
-    artifact_root.mkdir(parents=True, exist_ok=True)
 
     model_repo = getattr(spec, "hf_model_repo", "") or ""
     model_id = getattr(spec, "model_id", "") or model_repo
     device_label = ctx.device.name if hasattr(ctx.device, "name") else str(ctx.device)
+    resolved_venv_python = Path(venv_python) if venv_python else Path(sys.executable)
 
-    driver = AIPerfAgenticTracesDriver(
-        venv_python=Path(venv_python) if venv_python else Path(sys.executable),
-        artifact_root=artifact_root,
+    # One driver per trace source, each writing under its own artifact subtree so
+    # a mixed sweep keeps AIPerf and swo-bench artifacts separate.
+    aiperf_driver = AIPerfAgenticTracesDriver(
+        venv_python=resolved_venv_python,
+        artifact_root=output_root / "aiperf_artifacts",
         model_repo=model_repo,
         model_id=model_id,
         output_dir=output_root,
     )
+    swo_bench_driver = SwoBenchAgenticTracesDriver(
+        venv_python=resolved_venv_python,
+        artifact_root=output_root / "swo_bench_artifacts",
+        model_repo=model_repo,
+        model_id=model_id,
+        output_dir=output_root,
+    )
+    drivers = {
+        TraceSource.INFERENCEX_AGENTX: aiperf_driver,
+        TraceSource.SWARMONE: swo_bench_driver,
+    }
+    parsers = {
+        TraceSource.INFERENCEX_AGENTX: AIPerfAgenticTracesParser(),
+        TraceSource.SWARMONE: SwoBenchAgenticTracesParser(),
+    }
 
     server = ServerConnection(
         base_url=ctx.server_host,
@@ -192,12 +214,13 @@ def run_agentic_traces(
     context = DriverContext(
         output_dir=output_root,
         device=device_label,
-        # The request-bounded warmup has no wall-clock cap, so warmup_grace_period
-        # is the allowance for it rather than a guarantee; the timeout backstops.
+        # Size the single per-run timeout to the longest-running planned run.
+        # The estimate is source-aware: InferenceX profiles for a fixed window
+        # (its request-bounded warmup has no wall-clock cap, so warmup_grace_period
+        # is the allowance, not a guarantee) while swo-bench replays a
+        # request-count-driven scenario (see ``estimated_run_seconds``).
         per_run_timeout_s=float(
-            max(run.benchmark_duration for run in runs)
-            + max(run.warmup_grace_period for run in runs)
-            + _TIMEOUT_HEADROOM_SECONDS
+            max(estimated_run_seconds(run) for run in runs) + _TIMEOUT_HEADROOM_SECONDS
         ),
     )
     logger.info(
@@ -212,7 +235,6 @@ def run_agentic_traces(
         result.return_codes.append(1)
         return result
 
-    parser = AIPerfAgenticTracesParser()
     for i, run in enumerate(runs, 1):
         if server_controller is not None and not _server_still_healthy(
             server_controller, result
@@ -223,6 +245,8 @@ def run_agentic_traces(
         if i > 1 and inter_run_sleep_s:
             time.sleep(inter_run_sleep_s)
 
+        driver = drivers[run.trace_source]
+        parser = parsers[run.trace_source]
         outcome: AgenticTracesDriverResult = driver.run(run, server, context)
         result.return_codes.append(outcome.return_code)
         if outcome.return_code != 0 or outcome.payload is None:

--- a/test_module/llm_tests/agentic_traces_tests.py
+++ b/test_module/llm_tests/agentic_traces_tests.py
@@ -5,17 +5,19 @@
 """Orchestrator for the agentic trace-replay benchmark.
 
 Bridges ``test_module`` to ``llm_module``: resolves the per-ModelSpec config,
-expands it into runs for the requested :class:`AgenticTracesMode`, executes one
-:class:`AIPerfAgenticTracesDriver` invocation per run, converts each payload into
-a :class:`report_module.schema.Block` via
-:class:`AIPerfAgenticTracesParser`, and forwards the Blocks to
-``workflow_module.accept_blocks`` so the unified report generator picks them up.
+expands it into runs for the requested :class:`AgenticTracesMode`, dispatches
+each run to the driver for its :class:`TraceSource`, converts each payload into
+a :class:`report_module.schema.Block` via that source's parser, and forwards the
+Blocks to ``workflow_module.accept_blocks`` so the unified report generator
+picks them up.
 
 Modeled on :mod:`test_module.llm_tests.prefix_cache_tests`. The one structural
 difference is the timeout: a full-length agentic run profiles for an hour after
 warming the cache, which comfortably exceeds the 2h default in
-:class:`llm_module.config.DriverContext`, so the per-run timeout is derived from
-the plan instead of left at the default.
+:class:`llm_module.config.DriverContext`, so each run's timeout is derived from
+its own entry in the plan instead of left at the default. Deriving it per run
+rather than once for the sweep keeps a short run's hang short even when a
+long-running source is planned alongside it.
 """
 
 from __future__ import annotations
@@ -23,6 +25,7 @@ from __future__ import annotations
 import logging
 import sys
 import time
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Sequence
@@ -211,23 +214,13 @@ def run_agentic_traces(
         ),
         prefix_cache_metrics_urls=tuple(metrics_urls or ()),
     )
-    context = DriverContext(
-        output_dir=output_root,
-        device=device_label,
-        # Size the single per-run timeout to the longest-running planned run.
-        # The estimate is source-aware: InferenceX profiles for a fixed window
-        # (its request-bounded warmup has no wall-clock cap, so warmup_grace_period
-        # is the allowance, not a guarantee) while swo-bench replays a
-        # request-count-driven scenario (see ``estimated_run_seconds``).
-        per_run_timeout_s=float(
-            max(estimated_run_seconds(run) for run in runs) + _TIMEOUT_HEADROOM_SECONDS
-        ),
-    )
+    # Timeouts are sized per run rather than once for the sweep: a mixed sweep
+    # spans very different shapes (a swarmone replay is allowed hours, an
+    # InferenceX profile is a fixed window), and a sweep-wide maximum would let
+    # a hung short run hold the cluster for the longest run's allowance.
+    base_context = DriverContext(output_dir=output_root, device=device_label)
     logger.info(
-        "[agentic-traces] Per-run subprocess timeout: %.0fs (planned sweep "
-        "wall-clock: %ds)",
-        context.per_run_timeout_s,
-        total_planned_seconds(runs),
+        "[agentic-traces] Planned sweep wall-clock: %ds", total_planned_seconds(runs)
     )
 
     if server_controller is not None and not server_controller.wait_for_healthy():
@@ -241,12 +234,24 @@ def run_agentic_traces(
         ):
             break
 
-        logger.info("[agentic-traces] Running %d/%d: %s", i, len(runs), run.label)
+        # The estimate is source-aware: InferenceX profiles for a fixed window
+        # (its request-bounded warmup has no wall-clock cap, so
+        # warmup_grace_period is the allowance, not a guarantee) while swo-bench
+        # replays a request-count-driven scenario (see ``estimated_run_seconds``).
+        run_timeout_s = float(estimated_run_seconds(run) + _TIMEOUT_HEADROOM_SECONDS)
+        logger.info(
+            "[agentic-traces] Running %d/%d: %s (timeout %.0fs)",
+            i,
+            len(runs),
+            run.label,
+            run_timeout_s,
+        )
         if i > 1 and inter_run_sleep_s:
             time.sleep(inter_run_sleep_s)
 
         driver = drivers[run.trace_source]
         parser = parsers[run.trace_source]
+        context = replace(base_context, per_run_timeout_s=run_timeout_s)
         outcome: AgenticTracesDriverResult = driver.run(run, server, context)
         result.return_codes.append(outcome.return_code)
         if outcome.return_code != 0 or outcome.payload is None:

--- a/tests/llm_module/test_agentic_traces.py
+++ b/tests/llm_module/test_agentic_traces.py
@@ -37,7 +37,9 @@ from llm_module.drivers.aiperf_agentic_traces import (
 )
 from llm_module.drivers.swo_bench_agentic_traces import (
     build_swo_bench_cmd,
+    build_swo_bench_env,
     parse_swo_bench_output,
+    swo_bench_executable,
 )
 from llm_module.drivers.swo_bench_agentic_traces import (
     _invalid_result_reason as _swo_invalid_result_reason,
@@ -1106,6 +1108,15 @@ class TestSwarmOneConfigWithoutInferencex:
         assert runs[0].trace_source is TraceSource.SWARMONE
 
 
+@pytest.fixture
+def swo_venv(tmp_path):
+    """A venv bin layout holding the console script swo-bench installs."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "swo-bench").write_text("#!/bin/sh\n")
+    return bin_dir
+
+
 class TestSwoBenchCommand:
     def _run(self, mode=AgenticTracesMode.CI):
         config = AGENTIC_TRACES_CONFIGS[KIMI_MODEL_ID]
@@ -1115,10 +1126,10 @@ class TestSwoBenchCommand:
             if run.trace_source is TraceSource.SWARMONE
         ][0]
 
-    def _cmd(self, mode=AgenticTracesMode.CI, **kwargs):
+    def _cmd(self, swo_venv, mode=AgenticTracesMode.CI, **kwargs):
         defaults = dict(
             run=self._run(mode),
-            venv_python=Path("/venv/bin/python"),
+            venv_python=swo_venv / "python",
             model_name="moonshotai/Kimi-K2.7-Code",
             url="http://localhost:8000",
             results_path=Path("/tmp/artifacts/swo_bench_results.json"),
@@ -1126,33 +1137,36 @@ class TestSwoBenchCommand:
         defaults.update(kwargs)
         return build_swo_bench_cmd(**defaults)
 
-    def test_invokes_the_venv_swo_bench_module(self):
-        cmd = self._cmd()
-        assert cmd[:4] == ["/venv/bin/python", "-m", "swo_bench", "replay"]
+    def test_invokes_the_venv_console_script(self, swo_venv):
+        """swo_bench ships no ``__main__``, so ``python -m swo_bench`` aborts
+        with "cannot be directly executed" before reaching the endpoint."""
+        cmd = self._cmd(swo_venv)
+        assert cmd[:2] == [str(swo_venv / "swo-bench"), "replay"]
+        assert "-m" not in cmd
 
-    def test_carries_scenario_task_and_context(self):
-        cmd = self._cmd()
+    def test_carries_scenario_task_and_context(self, swo_venv):
+        cmd = self._cmd(swo_venv)
         assert cmd[cmd.index("--scenario") + 1] == SWO_SCENARIO
         assert cmd[cmd.index("--task") + 1] == "sympy-bugfix"
         assert cmd[cmd.index("--model-context-length") + 1] == "262144"
         assert "--no-resolve-model-context" in cmd
 
-    def test_endpoint_gets_v1_suffix(self):
-        cmd = self._cmd()
+    def test_endpoint_gets_v1_suffix(self, swo_venv):
+        cmd = self._cmd(swo_venv)
         assert cmd[cmd.index("--endpoint") + 1] == "http://localhost:8000/v1"
 
-    def test_bare_host_gets_scheme_and_v1(self):
-        cmd = self._cmd(url="localhost:8000")
+    def test_bare_host_gets_scheme_and_v1(self, swo_venv):
+        cmd = self._cmd(swo_venv, url="localhost:8000")
         assert cmd[cmd.index("--endpoint") + 1] == "http://localhost:8000/v1"
 
-    def test_concurrency_and_resident_default_together(self):
-        cmd = self._cmd(mode=AgenticTracesMode.CI)
+    def test_concurrency_and_resident_default_together(self, swo_venv):
+        cmd = self._cmd(swo_venv, mode=AgenticTracesMode.CI)
         assert cmd[cmd.index("--concurrent") + 1] == "1"
         # resident defaults to concurrency when unset in the spec.
         assert cmd[cmd.index("--resident") + 1] == "1"
 
-    def test_replay_knobs_and_output(self):
-        cmd = self._cmd()
+    def test_replay_knobs_and_output(self, swo_venv):
+        cmd = self._cmd(swo_venv)
         assert cmd[cmd.index("--cache-mode") + 1] == "realistic"
         assert cmd[cmd.index("--history-mode") + 1] == "faithful"
         assert cmd[cmd.index("--max-tokens") + 1] == "4096"
@@ -1162,21 +1176,55 @@ class TestSwoBenchCommand:
             "/tmp/artifacts/swo_bench_results.json"
         )
 
-    def test_full_mode_replays_all_tasks(self):
-        cmd = self._cmd(mode=AgenticTracesMode.FULL)
+    def test_full_mode_replays_all_tasks(self, swo_venv):
+        cmd = self._cmd(swo_venv, mode=AgenticTracesMode.FULL)
         assert "--task" not in cmd
         assert cmd[cmd.index("--concurrent") + 1] == "8"
 
-    def test_api_key_only_present_with_a_token(self):
-        assert "--api-key" not in self._cmd()
-        cmd = self._cmd(auth_token="tok123")
-        assert cmd[cmd.index("--api-key") + 1] == "tok123"
 
-    def test_license_never_appears_on_argv(self):
-        cmd = self._cmd(auth_token="tok123")
+class TestSwoBenchCredentials:
+    """Neither the licence nor the endpoint token may reach argv.
+
+    ``run_command`` logs the command it executes, so a credential passed as a
+    flag is written into every run log.
+    """
+
+    def test_no_credential_appears_on_argv(self, swo_venv):
+        cmd = TestSwoBenchCommand()._cmd(swo_venv)
         joined = " ".join(cmd)
-        assert "--license-key" not in joined
-        assert "SWO_LICENSE_KEY" not in joined
+        for leaked in ("--api-key", "--license-key", "SWO_LICENSE_KEY"):
+            assert leaked not in joined
+
+    def test_the_token_travels_by_environment(self):
+        assert build_swo_bench_env("tok123") == {"SWO_REPLAY_API_KEY": "tok123"}
+
+    def test_no_token_sets_no_variable(self):
+        """An unauthenticated endpoint must not get an empty bearer token."""
+        assert build_swo_bench_env("") == {}
+
+
+class TestSwoBenchExecutable:
+    def test_prefers_the_console_script_beside_the_interpreter(self, swo_venv):
+        assert swo_bench_executable(swo_venv / "python") == swo_venv / "swo-bench"
+
+    def test_falls_back_to_path(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "llm_module.drivers.swo_bench_agentic_traces.shutil.which",
+            lambda name: "/usr/local/bin/swo-bench",
+        )
+        assert swo_bench_executable(tmp_path / "python") == Path(
+            "/usr/local/bin/swo-bench"
+        )
+
+    def test_a_missing_executable_names_where_it_comes_from(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "llm_module.drivers.swo_bench_agentic_traces.shutil.which",
+            lambda name: None,
+        )
+        with pytest.raises(RuntimeError, match="agentic-traces.txt"):
+            swo_bench_executable(tmp_path / "python")
 
 
 def _swo_results(**overrides):
@@ -1258,6 +1306,14 @@ class TestSwoBenchOutputParsing:
         assert metrics["output_token_throughput"] == 107.59
         assert metrics["prefill_tok_per_sec_p50"] == 276.16
         assert metrics["measured_benchmark_duration"] == 67.05
+
+    def test_inter_token_latency_is_not_published(self, tmp_path):
+        """swo-bench's itl_ms_p50 is not a usable TPOT: a live run reported
+        0.01 ms/token beside a measured 38.9 tok/s decode rate. Emitting it
+        would render a false 0.0 next to AIPerf's real TPOT."""
+        metrics = parse_swo_bench_output(_write_swo_results(tmp_path))
+        assert "mean_tpot_ms" not in metrics
+        assert "median_tpot_ms" not in metrics
 
     def test_counts_and_error_rate(self, tmp_path):
         metrics = parse_swo_bench_output(_write_swo_results(tmp_path))

--- a/tests/llm_module/test_agentic_traces.py
+++ b/tests/llm_module/test_agentic_traces.py
@@ -1010,13 +1010,44 @@ class TestSwarmOneModeScoping:
         assert inferencex[0].concurrency == expected
         assert inferencex[0].concurrency != 1
 
-    def test_default_sweep_runs_both_sources(self):
+    def test_default_selection_holds_swarmone_back(self):
+        """swarmone is opt-in, so an unnarrowed sweep must not pull it in and
+        make a SwarmOne license a precondition for every Kimi run."""
         config = AGENTIC_TRACES_CONFIGS[KIMI_MODEL_ID]
+        _, specs = resolve_run_specs(config)
+        sources = {spec.trace_source for spec in specs}
+        assert sources == {TraceSource.INFERENCEX_AGENTX}
+
+    def test_explicitly_selecting_both_sources_runs_both(self):
+        config = AGENTIC_TRACES_CONFIGS[KIMI_MODEL_ID]
+        _, specs = resolve_run_specs(
+            config,
+            trace_sources=(TraceSource.INFERENCEX_AGENTX, TraceSource.SWARMONE),
+        )
         sources = {
             run.trace_source
-            for run in build_runs(config, _FakeModelSpec(), mode=AgenticTracesMode.FULL)
+            for run in build_runs(
+                config,
+                _FakeModelSpec(),
+                mode=AgenticTracesMode.FULL,
+                run_specs=specs,
+            )
         }
         assert sources == {TraceSource.INFERENCEX_AGENTX, TraceSource.SWARMONE}
+
+    def test_a_swarmone_only_config_still_runs_by_default(self):
+        """Holding back the only configured source would leave an empty sweep."""
+        config = AgenticTracesConfig(
+            model_id="id_test",
+            inferencex_git_ref=None,
+            runs=(
+                AgenticTracesRunSpec(
+                    trace_source=TraceSource.SWARMONE, scenario=SWO_SCENARIO
+                ),
+            ),
+        )
+        _, specs = resolve_run_specs(config)
+        assert [spec.trace_source for spec in specs] == [TraceSource.SWARMONE]
 
     def test_swarmone_timeout_estimate_is_generous(self):
         full = self._swo_runs(AgenticTracesMode.FULL)[0]

--- a/tests/llm_module/test_agentic_traces.py
+++ b/tests/llm_module/test_agentic_traces.py
@@ -10,9 +10,11 @@ hour in (or worse, as a plausible-looking row of numbers):
 * every configured model pins an InferenceX ref and covers every mode,
 * no mode can drop below the scenario's 900s profiling floor,
 * the derived knobs (max context, trust-remote-code) track the ModelSpec,
-* selecting the unimplemented SwarmOne source fails loudly instead of
-  producing an empty sweep,
-* the emitted CLI carries the flags the scenario requires.
+* a trace source with no driver still fails loudly instead of producing an
+  empty sweep, while the two implemented sources (InferenceX, SwarmOne) build,
+* SwarmOne's per-mode scoping runs all tasks at load in ``full`` and a single
+  short task at concurrency 1 in ``ci``,
+* the emitted CLI (AIPerf and swo-bench) carries the flags the scenario requires.
 """
 
 from __future__ import annotations
@@ -22,13 +24,26 @@ from pathlib import Path
 
 import pytest
 
-from llm_module.agentic_traces import build_runs, summarize_runs, total_planned_seconds
+from llm_module.agentic_traces import (
+    build_runs,
+    estimated_run_seconds,
+    summarize_runs,
+    total_planned_seconds,
+)
 from llm_module.drivers.aiperf_agentic_traces import (
     _invalid_result_reason,
     build_aiperf_cmd,
     parse_aiperf_output,
 )
+from llm_module.drivers.swo_bench_agentic_traces import (
+    build_swo_bench_cmd,
+    parse_swo_bench_output,
+)
+from llm_module.drivers.swo_bench_agentic_traces import (
+    _invalid_result_reason as _swo_invalid_result_reason,
+)
 from llm_module.parsers.aiperf_agentic_traces import AIPerfAgenticTracesParser
+from llm_module.parsers.swo_bench_agentic_traces import SwoBenchAgenticTracesParser
 from reference_config.agentic_traces.agentic_traces_config import (
     AGENTIC_TRACES_CONFIGS,
     AGENTIC_TRACES_MIN_PROFILE_SECONDS,
@@ -296,24 +311,55 @@ class TestTraceSourceSelection:
         with pytest.raises(ValueError, match="Invalid TraceSource"):
             TraceSource.from_string("mystery_traces")
 
-    def test_swarmone_run_raises_not_implemented(self):
+    def test_swarmone_run_builds(self):
+        """SwarmOne is a supported source; building its runs must not raise."""
+        config = AgenticTracesConfig(
+            model_id="id_test",
+            inferencex_git_ref="abc123",
+            runs=(
+                AgenticTracesRunSpec(
+                    trace_source=TraceSource.SWARMONE,
+                    scenario="claude-code-swe-bench-python-kimi-k2.7-code",
+                    public_dataset="",
+                ),
+            ),
+        )
+        runs = build_runs(config, _FakeModelSpec())
+        assert len(runs) == 1
+        assert runs[0].trace_source is TraceSource.SWARMONE
+
+    def test_unimplemented_source_still_fails_loudly(self):
+        """A source outside SUPPORTED_TRACE_SOURCES fails at plan time."""
+        import llm_module.agentic_traces.runs as runs_mod
+
         config = AgenticTracesConfig(
             model_id="id_test",
             inferencex_git_ref="abc123",
             runs=(AgenticTracesRunSpec(trace_source=TraceSource.SWARMONE),),
         )
-        with pytest.raises(NotImplementedError, match="swarmone"):
-            build_runs(config, _FakeModelSpec())
+        original = runs_mod.SUPPORTED_TRACE_SOURCES
+        runs_mod.SUPPORTED_TRACE_SOURCES = (TraceSource.INFERENCEX_AGENTX,)
+        try:
+            with pytest.raises(NotImplementedError, match="swarmone"):
+                build_runs(config, _FakeModelSpec())
+        finally:
+            runs_mod.SUPPORTED_TRACE_SOURCES = original
 
     def test_narrowing_to_a_configured_source_keeps_its_runs(self):
         config = AGENTIC_TRACES_CONFIGS[KIMI_MODEL_ID]
         _, runs = resolve_run_specs(
             config, trace_sources=(TraceSource.INFERENCEX_AGENTX,)
         )
-        assert len(runs) == len(config.runs)
+        assert runs
+        assert all(r.trace_source is TraceSource.INFERENCEX_AGENTX for r in runs)
 
     def test_narrowing_to_an_unconfigured_source_raises(self):
-        config = AGENTIC_TRACES_CONFIGS[KIMI_MODEL_ID]
+        # A config that only has an InferenceX run rejects a swarmone selection.
+        config = AgenticTracesConfig(
+            model_id="id_test",
+            inferencex_git_ref="abc123",
+            runs=(AgenticTracesRunSpec(trace_source=TraceSource.INFERENCEX_AGENTX),),
+        )
         with pytest.raises(ValueError, match="do not match|No agentic-trace runs"):
             resolve_run_specs(config, trace_sources=(TraceSource.SWARMONE,))
 
@@ -908,3 +954,335 @@ class TestParser:
         block = AIPerfAgenticTracesParser().parse({"model_id": "m"})
         assert "error_rate" not in block.data
         assert "submission_status" not in block.data
+
+
+SWO_SCENARIO = "claude-code-swe-bench-python-kimi-k2.7-code"
+
+
+class TestSwarmOneModeScoping:
+    """The Kimi config runs SwarmOne all-tasks at load in full, sympy c1 in ci."""
+
+    def _swo_runs(self, mode):
+        config = AGENTIC_TRACES_CONFIGS[KIMI_MODEL_ID]
+        return [
+            run
+            for run in build_runs(config, _FakeModelSpec(), mode=mode)
+            if run.trace_source is TraceSource.SWARMONE
+        ]
+
+    def test_full_runs_every_task_at_load(self):
+        runs = self._swo_runs(AgenticTracesMode.FULL)
+        assert len(runs) == 1
+        run = runs[0]
+        assert run.scenario == SWO_SCENARIO
+        assert run.task is None
+        assert run.concurrency == 8
+
+    def test_ci_narrows_to_one_task_at_concurrency_one(self):
+        runs = self._swo_runs(AgenticTracesMode.CI)
+        assert len(runs) == 1
+        run = runs[0]
+        assert run.task == "sympy-bugfix"
+        assert run.concurrency == 1
+
+    def test_inferencex_run_is_unchanged_by_swarmone_ci(self):
+        """SwarmOne's CI c1 scoping must not shrink the InferenceX CI run.
+
+        The InferenceX run keeps its own configured concurrency (from its spec /
+        CI mode settings), never SwarmOne's concurrency of 1.
+        """
+        config = AGENTIC_TRACES_CONFIGS[KIMI_MODEL_ID]
+        inferencex_spec = next(
+            spec
+            for spec in config.runs
+            if spec.trace_source is TraceSource.INFERENCEX_AGENTX
+        )
+        expected = (
+            config.settings_for_mode(AgenticTracesMode.CI).concurrency
+            or inferencex_spec.concurrency
+        )
+        inferencex = [
+            run
+            for run in build_runs(config, _FakeModelSpec(), mode=AgenticTracesMode.CI)
+            if run.trace_source is TraceSource.INFERENCEX_AGENTX
+        ]
+        assert len(inferencex) == 1
+        assert inferencex[0].concurrency == expected
+        assert inferencex[0].concurrency != 1
+
+    def test_default_sweep_runs_both_sources(self):
+        config = AGENTIC_TRACES_CONFIGS[KIMI_MODEL_ID]
+        sources = {
+            run.trace_source
+            for run in build_runs(config, _FakeModelSpec(), mode=AgenticTracesMode.FULL)
+        }
+        assert sources == {TraceSource.INFERENCEX_AGENTX, TraceSource.SWARMONE}
+
+    def test_swarmone_timeout_estimate_is_generous(self):
+        full = self._swo_runs(AgenticTracesMode.FULL)[0]
+        ci = self._swo_runs(AgenticTracesMode.CI)[0]
+        assert estimated_run_seconds(full) == 8 * 3600
+        assert estimated_run_seconds(ci) == 3600
+
+    def test_swarmone_label_keys_on_scenario_and_task(self):
+        ci = self._swo_runs(AgenticTracesMode.CI)[0]
+        assert "swarmone" in ci.label
+        assert SWO_SCENARIO in ci.label
+        assert "sympy-bugfix" in ci.label
+        assert ci.label.endswith("_ci")
+
+
+class TestSwarmOneRunSpecValidation:
+    def test_bad_cache_mode_is_rejected(self):
+        with pytest.raises(ValueError, match="cache_mode"):
+            AgenticTracesRunSpec(trace_source=TraceSource.SWARMONE, cache_mode="turbo")
+
+    def test_bad_history_mode_is_rejected(self):
+        with pytest.raises(ValueError, match="history_mode"):
+            AgenticTracesRunSpec(
+                trace_source=TraceSource.SWARMONE, history_mode="rewind"
+            )
+
+    def test_bad_max_tokens_mode_is_rejected(self):
+        with pytest.raises(ValueError, match="max_tokens_mode"):
+            AgenticTracesRunSpec(
+                trace_source=TraceSource.SWARMONE, max_tokens_mode="dynamic"
+            )
+
+    def test_zero_max_tokens_is_rejected(self):
+        with pytest.raises(ValueError, match="max_tokens"):
+            AgenticTracesRunSpec(trace_source=TraceSource.SWARMONE, max_tokens=0)
+
+    def test_zero_resident_is_rejected(self):
+        with pytest.raises(ValueError, match="resident"):
+            AgenticTracesRunSpec(trace_source=TraceSource.SWARMONE, resident=0)
+
+
+class TestSwarmOneConfigWithoutInferencex:
+    def test_swarmone_only_config_needs_no_git_ref(self):
+        config = AgenticTracesConfig(
+            model_id="id_swo_only",
+            inferencex_git_ref="",
+            runs=(
+                AgenticTracesRunSpec(
+                    trace_source=TraceSource.SWARMONE,
+                    scenario=SWO_SCENARIO,
+                    public_dataset="",
+                ),
+            ),
+        )
+        runs = build_runs(config, _FakeModelSpec())
+        assert runs[0].trace_source is TraceSource.SWARMONE
+
+
+class TestSwoBenchCommand:
+    def _run(self, mode=AgenticTracesMode.CI):
+        config = AGENTIC_TRACES_CONFIGS[KIMI_MODEL_ID]
+        return [
+            run
+            for run in build_runs(config, _FakeModelSpec(), mode=mode)
+            if run.trace_source is TraceSource.SWARMONE
+        ][0]
+
+    def _cmd(self, mode=AgenticTracesMode.CI, **kwargs):
+        defaults = dict(
+            run=self._run(mode),
+            venv_python=Path("/venv/bin/python"),
+            model_name="moonshotai/Kimi-K2.7-Code",
+            url="http://localhost:8000",
+            results_path=Path("/tmp/artifacts/swo_bench_results.json"),
+        )
+        defaults.update(kwargs)
+        return build_swo_bench_cmd(**defaults)
+
+    def test_invokes_the_venv_swo_bench_module(self):
+        cmd = self._cmd()
+        assert cmd[:4] == ["/venv/bin/python", "-m", "swo_bench", "replay"]
+
+    def test_carries_scenario_task_and_context(self):
+        cmd = self._cmd()
+        assert cmd[cmd.index("--scenario") + 1] == SWO_SCENARIO
+        assert cmd[cmd.index("--task") + 1] == "sympy-bugfix"
+        assert cmd[cmd.index("--model-context-length") + 1] == "262144"
+        assert "--no-resolve-model-context" in cmd
+
+    def test_endpoint_gets_v1_suffix(self):
+        cmd = self._cmd()
+        assert cmd[cmd.index("--endpoint") + 1] == "http://localhost:8000/v1"
+
+    def test_bare_host_gets_scheme_and_v1(self):
+        cmd = self._cmd(url="localhost:8000")
+        assert cmd[cmd.index("--endpoint") + 1] == "http://localhost:8000/v1"
+
+    def test_concurrency_and_resident_default_together(self):
+        cmd = self._cmd(mode=AgenticTracesMode.CI)
+        assert cmd[cmd.index("--concurrent") + 1] == "1"
+        # resident defaults to concurrency when unset in the spec.
+        assert cmd[cmd.index("--resident") + 1] == "1"
+
+    def test_replay_knobs_and_output(self):
+        cmd = self._cmd()
+        assert cmd[cmd.index("--cache-mode") + 1] == "realistic"
+        assert cmd[cmd.index("--history-mode") + 1] == "faithful"
+        assert cmd[cmd.index("--max-tokens") + 1] == "4096"
+        assert cmd[cmd.index("--max-tokens-mode") + 1] == "flat"
+        assert "--verbose-text" in cmd
+        assert cmd[cmd.index("--json-output") + 1] == (
+            "/tmp/artifacts/swo_bench_results.json"
+        )
+
+    def test_full_mode_replays_all_tasks(self):
+        cmd = self._cmd(mode=AgenticTracesMode.FULL)
+        assert "--task" not in cmd
+        assert cmd[cmd.index("--concurrent") + 1] == "8"
+
+    def test_api_key_only_present_with_a_token(self):
+        assert "--api-key" not in self._cmd()
+        cmd = self._cmd(auth_token="tok123")
+        assert cmd[cmd.index("--api-key") + 1] == "tok123"
+
+    def test_license_never_appears_on_argv(self):
+        cmd = self._cmd(auth_token="tok123")
+        joined = " ".join(cmd)
+        assert "--license-key" not in joined
+        assert "SWO_LICENSE_KEY" not in joined
+
+
+def _swo_results(**overrides):
+    """A trimmed swo-bench ``--json-output`` file (real 3.x schema)."""
+    results = {
+        "session_id": "bench_session_abc",
+        "source": SWO_SCENARIO,
+        "endpoint": "http://localhost:8000/v1",
+        "model": "moonshotai/Kimi-K2.7-Code",
+        "config": {"concurrency": 1, "max_tokens": 4096, "max_requests": None},
+        "wall_clock_ms": 67053.4,
+        "timings": [
+            {"index": 0, "status": "success", "prompt_tokens": 1015},
+            {"index": 1, "status": "success", "prompt_tokens": 21834},
+        ],
+        "report": {
+            "metrics": {
+                "aggregate_throughput_tok_s": 107.59,
+                "decode_tok_per_sec": {
+                    "max": 142.7,
+                    "mean": 106.09,
+                    "min": 52.13,
+                    "p50": 113.31,
+                    "p90": 127.64,
+                    "p99": 142.7,
+                },
+                "failed": 0,
+                "itl_ms_p50": {"mean": 0.02, "p50": 0.02},
+                "latency_ms": {
+                    "max": 7324.25,
+                    "mean": 2481.6,
+                    "min": 485.18,
+                    "p50": 1692.27,
+                    "p90": 5078.3,
+                    "p99": 7324.25,
+                },
+                "prefill_tok_per_sec": {
+                    "mean": 500.81,
+                    "p50": 276.16,
+                    "p90": 985.43,
+                },
+                "successful": 26,
+                "total_output_tokens": 7214,
+                "total_requests": 26,
+                "ttft_ms": {
+                    "max": 7314.14,
+                    "mean": 2553.08,
+                    "min": 484.15,
+                    "p50": 1691.08,
+                    "p90": 5078.19,
+                    "p99": 7314.14,
+                },
+                "wall_clock_s": 67.05,
+            },
+            "summary": "26/26 requests succeeded",
+        },
+    }
+    results.update(overrides)
+    return results
+
+
+def _write_swo_results(tmp_path, **overrides):
+    path = tmp_path / "swo_bench_results.json"
+    path.write_text(json.dumps(_swo_results(**overrides)))
+    return path
+
+
+class TestSwoBenchOutputParsing:
+    def test_missing_file_yields_no_metrics(self, tmp_path):
+        assert parse_swo_bench_output(tmp_path / "nope.json") == {}
+
+    def test_reads_latency_and_throughput(self, tmp_path):
+        metrics = parse_swo_bench_output(_write_swo_results(tmp_path))
+        assert metrics["mean_ttft_ms"] == 2553.08
+        assert metrics["median_ttft_ms"] == 1691.08
+        assert metrics["p99_ttft_ms"] == 7314.14
+        assert metrics["median_e2el_ms"] == 1692.27
+        assert metrics["output_token_throughput_per_user"] == 106.09
+        assert metrics["output_token_throughput"] == 107.59
+        assert metrics["prefill_tok_per_sec_p50"] == 276.16
+        assert metrics["measured_benchmark_duration"] == 67.05
+
+    def test_counts_and_error_rate(self, tmp_path):
+        metrics = parse_swo_bench_output(_write_swo_results(tmp_path))
+        assert metrics["completed"] == 26
+        assert metrics["completed_with_errors"] == 26
+        assert metrics["error_request_count"] == 0
+        assert metrics["error_rate_pct"] == 0.0
+
+    def test_input_tokens_summed_from_timings(self, tmp_path):
+        metrics = parse_swo_bench_output(_write_swo_results(tmp_path))
+        assert metrics["total_input_tokens"] == 1015 + 21834
+        assert metrics["total_output_tokens"] == 7214
+
+    def test_provenance_is_carried(self, tmp_path):
+        metrics = parse_swo_bench_output(_write_swo_results(tmp_path))
+        assert metrics["swo_session_id"] == "bench_session_abc"
+        assert metrics["swo_source_label"] == SWO_SCENARIO
+
+    def test_missing_report_block_yields_no_metrics(self, tmp_path):
+        path = tmp_path / "swo_bench_results.json"
+        path.write_text(json.dumps({"session_id": "x", "timings": []}))
+        assert parse_swo_bench_output(path) == {}
+
+
+class TestSwoBenchResultValidity:
+    def test_healthy_run_is_usable(self, tmp_path):
+        metrics = parse_swo_bench_output(_write_swo_results(tmp_path))
+        assert _swo_invalid_result_reason(metrics) is None
+
+    def test_zero_successful_requests_is_rejected(self, tmp_path):
+        results = _swo_results()
+        results["report"]["metrics"]["successful"] = 0
+        results["report"]["metrics"]["failed"] = 26
+        path = tmp_path / "swo_bench_results.json"
+        path.write_text(json.dumps(results))
+        metrics = parse_swo_bench_output(path)
+        assert "no request completed" in (_swo_invalid_result_reason(metrics) or "")
+
+
+class TestSwoBenchParser:
+    def test_block_kind_and_error_rate(self, tmp_path):
+        metrics = parse_swo_bench_output(_write_swo_results(tmp_path))
+        block = SwoBenchAgenticTracesParser().parse(
+            {
+                "model_id": "moonshotai/Kimi-K2.7-Code",
+                "date": "20260727-120000",
+                "trace_source": "swarmone",
+                "backend": "swo-bench",
+                "metadata": {"mode": "ci"},
+                **metrics,
+            },
+            device="super_cluster",
+        )
+        assert block.kind == "agentic_traces"
+        assert block.data["trace_source"] == "swarmone"
+        assert block.data["error_rate"] == pytest.approx(0.0)
+        assert block.data["mode"] == "ci"
+        assert block.targets["device"] == "super_cluster"
+        assert block.targets["timestamp"] == "2026-07-27 12:00:00"

--- a/tests/report_module/test_agentic_traces_renderer.py
+++ b/tests/report_module/test_agentic_traces_renderer.py
@@ -100,6 +100,68 @@ def _record(**overrides):
     return record
 
 
+def _swo_record(**overrides):
+    """One run record shaped like the swo-bench driver payload.
+
+    The two harnesses share the ``agentic_traces`` kind and this renderer, but
+    overlap only partially: swo-bench has no scenario verdict, no branch or
+    cache counters, and contributes prefill/duty-cycle metrics of its own.
+    """
+    record = {
+        "kind": "agentic_traces",
+        "model": "moonshotai/Kimi-K2.7-Code",
+        "backend": "swo-bench",
+        "trace_source": "swarmone",
+        "label": "swarmone_claude-code-mixed_sympy-bugfix_c1_ci",
+        "mode": "ci",
+        "scenario": "claude-code-mixed",
+        "task": "sympy-bugfix",
+        "concurrency": 1,
+        "resident": 1,
+        "cache_mode": "warm",
+        "history_mode": "full",
+        "max_tokens": 4096,
+        "max_tokens_mode": "cap",
+        "max_context_length": 262144,
+        "artifact_dir": "/very/long/path/that/should/not/reach/the/report",
+        "submission_valid": True,
+        "mean_ttft_ms": 5321.4,
+        "median_ttft_ms": 4102.8,
+        "p90_ttft_ms": 11204.6,
+        "p99_ttft_ms": 19883.1,
+        "mean_e2el_ms": 18422.7,
+        "median_e2el_ms": 7712.2,
+        "p99_e2el_ms": 98211.5,
+        # No TPOT: the driver suppresses swo-bench's unusable inter-token figure.
+        "output_token_throughput_per_user": 96.3,
+        "median_output_token_throughput_per_user": 101.7,
+        "output_token_throughput": 38.2,
+        "total_token_throughput": 38.2,
+        "prefill_tok_per_sec_mean": 24518.9,
+        "prefill_tok_per_sec_p50": 21044.3,
+        "prefill_tok_per_sec_p90": 40122.7,
+        "active_throughput_tok_per_s": 88.6,
+        "concurrency_mean": 0.62,
+        "concurrency_peak": 1,
+        "ready_starved_events": 0,
+        "pace_idle_ms": 41200,
+        "tool_idle_ms": 18300,
+        "completed": 27,
+        "error_request_count": 0,
+        "error_rate_pct": 0.0,
+        "mean_isl": 88214.6,
+        "mean_osl": 812.4,
+        "total_input_tokens": 2381794,
+        "total_output_tokens": 21935,
+        "request_throughput": 0.031,
+        "measured_benchmark_duration": 871.2,
+        "swo_session_id": "3f1c9a20-77bd-4a0e-9d1e-2f5b6c8a1d44",
+        "swo_bench_version": "3.1.2",
+    }
+    record.update(overrides)
+    return record
+
+
 def _render(*records):
     block = Block(
         kind="agentic_traces",
@@ -279,3 +341,107 @@ class TestMultipleRuns:
         )
         latency_table = out.split("#### Per-run Throughput")[0]
         assert latency_table.index("| 8 ") < latency_table.index("| 32 ")
+
+
+class TestSwarmOneRows:
+    """swo-bench shares this renderer, so its metrics must reach the report and
+    its rows must not be described as AIPerf's."""
+
+    def test_swarmone_specific_metrics_reach_the_report(self):
+        out = _render(_swo_record())
+        for header in (
+            "Prefill Tok/s/Req Avg",
+            "Total Tok/s (Active)",
+            "Concur Peak",
+            "Ready Starved",
+            "Pace Idle (ms)",
+        ):
+            assert header in out, f"{header} missing from the report"
+
+    def test_swarmone_config_reaches_the_config_table(self):
+        config = _render(_swo_record()).split("#### Run Configuration")[1]
+        for label in ("Task", "Resident Sessions", "Cache Mode", "History Mode"):
+            assert label in config, f"{label} missing from the config table"
+        assert "sympy-bugfix" in config
+        assert "3.1.2" in config
+        assert "3f1c9a20-77bd-4a0e-9d1e-2f5b6c8a1d44" in config
+
+    def test_a_healthy_run_is_not_reported_as_unknown(self):
+        """The driver rejects an unusable run, so a row that reaches the report
+        is valid; it used to render N/A because the field went unset."""
+        health = _render(_swo_record()).split("#### Run Health")[1]
+        assert "✅ valid" in health
+        assert "| N/A" not in health.split("\n\n")[2]
+
+    def test_the_tool_blurb_credits_swo_bench_not_aiperf(self):
+        out = _render(_swo_record())
+        assert "swo-bench" in out
+        assert "AIPerf" not in out
+        assert "InferenceX" not in out
+
+    def test_aiperf_only_metrics_are_not_defined(self):
+        """Defining metrics the report does not contain is worse than silence."""
+        out = _render(_swo_record())
+        for absent in ("CO-Adj E2EL", "Credit Drops", "Theo. Cache Hit %", "TTFOT"):
+            assert absent not in out, f"{absent} defined for a swo-bench-only report"
+
+    def test_tpot_is_absent_and_its_absence_explained(self):
+        """swo-bench's inter-token figure is unusable, so the driver drops it;
+        the column must then disappear rather than render a false 0.0."""
+        out = _render(_swo_record())
+        assert "TPOT Avg" not in out
+        assert "**TPOT** is deliberately absent" in out
+
+    def test_no_definition_promises_a_tpot_column(self):
+        """The shared bullet used to read "TTFT / TPOT / E2EL", defining a
+        column this report does not have and contradicting the note below."""
+        out = _render(_swo_record())
+        assert "**TTFT / E2EL**" in out
+        assert "TTFT / TPOT / E2EL" not in out
+
+    def test_an_aiperf_report_carries_no_swarmone_definitions(self):
+        out = _render(_record())
+        assert "Ready Starved" not in out
+        assert "Prefill Tok/s/Req" not in out
+        assert "deliberately absent" not in out
+
+    def test_an_aiperf_report_still_defines_tpot(self):
+        """AIPerf does report a usable TPOT, so moving the definition out of the
+        shared group must not lose it."""
+        out = _render(_record())
+        assert "TPOT Avg" in out
+        assert "**TPOT**: inter-token latency" in out
+
+
+class TestMixedSweep:
+    """A default sweep can run both harnesses into one section."""
+
+    def test_both_tools_are_described(self):
+        out = _render(_record(), _swo_record())
+        assert "`inferencex_agentx` rows:" in out
+        assert "`swarmone` rows:" in out
+
+    def test_both_definition_sets_are_present(self):
+        out = _render(_record(), _swo_record())
+        assert "CO-Adj E2EL" in out
+        assert "Ready Starved" in out
+
+    def test_the_submission_caption_covers_both_verdicts(self):
+        out = _render(_record(), _swo_record())
+        caption = out.split("#### Run Health & Validity")[1].split("\n\n")[1]
+        assert "scenario's own verdict" in caption
+        assert "own completeness check" in caption
+
+    def test_each_source_keeps_its_own_columns(self):
+        """Columns are shared ground: a metric only one harness emits shows for
+        that row and N/A for the other, rather than being dropped."""
+        throughput = _render(_record(), _swo_record()).split("#### Per-run Throughput")[
+            1
+        ]
+        assert "Prefill Tok/s/Req Avg" in throughput
+        assert "Tok In Flight Avg" in throughput
+
+    def test_rows_sort_with_inferencex_first(self):
+        out = _render(_swo_record(), _record())
+        latency = out.split("#### Per-run Throughput")[0]
+        assert latency.index("| inferencex_agentx ") < latency.index("| swarmone ")

--- a/tests/test_module/llm_tests/test_agentic_traces_tests.py
+++ b/tests/test_module/llm_tests/test_agentic_traces_tests.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from llm_module.agentic_traces import estimated_run_seconds
 from llm_module.drivers.aiperf_agentic_traces import AgenticTracesDriverResult
 from test_module.llm_tests import agentic_traces_tests
 from test_module.llm_tests.agentic_traces_tests import run_agentic_traces
@@ -299,6 +300,29 @@ class TestTraceSourceDispatch:
         _run, _server, context = swo_driver.run.call_args[0]
         # SwarmOne CI timeout floor is 1h plus headroom.
         assert context.per_run_timeout_s >= 3600
+
+    def test_each_run_gets_its_own_timeout(self, tmp_path):
+        """A sweep-wide maximum would hand SwarmOne's multi-hour allowance to
+        the InferenceX run, leaving a hung one parked on the cluster for it."""
+        patcher, aiperf_driver, swo_driver = self._both_drivers()
+        with patcher:
+            run_agentic_traces(
+                _ctx(tmp_path=tmp_path),
+                mode="ci",
+                trace_sources="inferencex_agentx,swarmone",
+                inter_run_sleep_s=0,
+            )
+
+        aiperf_run, _, aiperf_context = aiperf_driver.run.call_args[0]
+        swo_run, _, swo_context = swo_driver.run.call_args[0]
+        headroom = agentic_traces_tests._TIMEOUT_HEADROOM_SECONDS
+        assert aiperf_context.per_run_timeout_s == (
+            estimated_run_seconds(aiperf_run) + headroom
+        )
+        assert swo_context.per_run_timeout_s == (
+            estimated_run_seconds(swo_run) + headroom
+        )
+        assert aiperf_context.per_run_timeout_s < swo_context.per_run_timeout_s
 
     def test_artifacts_land_under_the_output_path(self, tmp_path):
         outcome = AgenticTracesDriverResult(

--- a/tests/test_module/llm_tests/test_agentic_traces_tests.py
+++ b/tests/test_module/llm_tests/test_agentic_traces_tests.py
@@ -240,7 +240,7 @@ class TestTraceSourceDispatch:
         run = swo_driver.run.call_args[0][0]
         assert run.trace_source.value == "swarmone"
 
-    def test_default_sweep_runs_both_sources(self, tmp_path):
+    def _both_drivers(self):
         aiperf_driver = MagicMock()
         aiperf_driver.run.return_value = AgenticTracesDriverResult(
             return_code=0, payload=_ok_payload("aiperf"), raw_path=None
@@ -249,13 +249,34 @@ class TestTraceSourceDispatch:
         swo_driver.run.return_value = AgenticTracesDriverResult(
             return_code=0, payload=_ok_payload("swo"), raw_path=None
         )
-        with patch.multiple(
+        patcher = patch.multiple(
             agentic_traces_tests,
             AIPerfAgenticTracesDriver=MagicMock(return_value=aiperf_driver),
             SwoBenchAgenticTracesDriver=MagicMock(return_value=swo_driver),
-        ):
+        )
+        return patcher, aiperf_driver, swo_driver
+
+    def test_default_sweep_skips_the_opt_in_swarmone_source(self, tmp_path):
+        """Without --agentic-traces-sources the sweep must stay as it was
+        before SwarmOne was configured: InferenceX only, no license needed."""
+        patcher, aiperf_driver, swo_driver = self._both_drivers()
+        with patcher:
             result = run_agentic_traces(
                 _ctx(tmp_path=tmp_path), mode="ci", inter_run_sleep_s=0
+            )
+
+        assert result.return_codes == [0]
+        aiperf_driver.run.assert_called_once()
+        swo_driver.run.assert_not_called()
+
+    def test_naming_both_sources_runs_both(self, tmp_path):
+        patcher, aiperf_driver, swo_driver = self._both_drivers()
+        with patcher:
+            result = run_agentic_traces(
+                _ctx(tmp_path=tmp_path),
+                mode="ci",
+                trace_sources="inferencex_agentx,swarmone",
+                inter_run_sleep_s=0,
             )
 
         assert result.return_codes == [0, 0]

--- a/tests/test_module/llm_tests/test_agentic_traces_tests.py
+++ b/tests/test_module/llm_tests/test_agentic_traces_tests.py
@@ -8,7 +8,8 @@ The driver is stubbed throughout: what is under test is the sweep loop's
 bookkeeping. The failure paths matter most, because each one is a way a broken
 run could otherwise be reported as a clean pass:
 
-* a model with no config, or an unimplemented trace source, must not run,
+* a model with no config, or an unknown trace-source name, must not run,
+* each run is dispatched to the driver for its trace source,
 * a failed run must record a non-zero code even if a sibling run succeeded,
 * the per-run subprocess timeout must exceed the planned wall-clock window.
 """
@@ -61,12 +62,40 @@ def _ok_payload(label: str = "run") -> dict:
 
 
 def _driver_returning(*outcomes):
-    """Patch the driver class so each run() call returns the next outcome."""
+    """Patch the AIPerf driver so each run() call returns the next outcome.
+
+    Also stubs the swo-bench driver with a driver that raises if called, so an
+    inferencex-narrowed sweep that accidentally dispatched a swarmone run would
+    fail loudly rather than silently shell out.
+    """
     driver = MagicMock()
     driver.run.side_effect = list(outcomes)
-    return patch.object(
-        agentic_traces_tests, "AIPerfAgenticTracesDriver", return_value=driver
-    ), driver
+    swo_driver = MagicMock()
+    swo_driver.run.side_effect = AssertionError(
+        "swo-bench driver called in an inferencex-only sweep"
+    )
+    patcher = patch.multiple(
+        agentic_traces_tests,
+        AIPerfAgenticTracesDriver=MagicMock(return_value=driver),
+        SwoBenchAgenticTracesDriver=MagicMock(return_value=swo_driver),
+    )
+    return patcher, driver
+
+
+def _swo_driver_returning(*outcomes):
+    """Patch the swo-bench driver; stub the AIPerf driver to fail if called."""
+    swo_driver = MagicMock()
+    swo_driver.run.side_effect = list(outcomes)
+    aiperf_driver = MagicMock()
+    aiperf_driver.run.side_effect = AssertionError(
+        "AIPerf driver called in a swarmone-only sweep"
+    )
+    patcher = patch.multiple(
+        agentic_traces_tests,
+        AIPerfAgenticTracesDriver=MagicMock(return_value=aiperf_driver),
+        SwoBenchAgenticTracesDriver=MagicMock(return_value=swo_driver),
+    )
+    return patcher, swo_driver
 
 
 class TestPlanningFailures:
@@ -74,17 +103,6 @@ class TestPlanningFailures:
         patcher, driver = _driver_returning()
         with patcher:
             result = run_agentic_traces(_ctx(model_id="id_nope", tmp_path=tmp_path))
-
-        assert result.return_codes == [1]
-        assert result.blocks == []
-        driver.run.assert_not_called()
-
-    def test_unimplemented_trace_source_does_not_run(self, tmp_path):
-        patcher, driver = _driver_returning()
-        with patcher:
-            result = run_agentic_traces(
-                _ctx(tmp_path=tmp_path), trace_sources="swarmone"
-            )
 
         assert result.return_codes == [1]
         assert result.blocks == []
@@ -121,7 +139,10 @@ class TestSweepLoop:
         patcher, driver = _driver_returning(outcome)
         with patcher:
             result = run_agentic_traces(
-                _ctx(tmp_path=tmp_path), mode="ci", inter_run_sleep_s=0
+                _ctx(tmp_path=tmp_path),
+                mode="ci",
+                trace_sources="inferencex_agentx",
+                inter_run_sleep_s=0,
             )
 
         assert result.return_codes == [0]
@@ -136,7 +157,10 @@ class TestSweepLoop:
         patcher, _ = _driver_returning(outcome)
         with patcher:
             result = run_agentic_traces(
-                _ctx(tmp_path=tmp_path), mode="ci", inter_run_sleep_s=0
+                _ctx(tmp_path=tmp_path),
+                mode="ci",
+                trace_sources="inferencex_agentx",
+                inter_run_sleep_s=0,
             )
 
         assert result.return_codes == [124]
@@ -149,7 +173,12 @@ class TestSweepLoop:
         )
         patcher, driver = _driver_returning(outcome)
         with patcher:
-            run_agentic_traces(_ctx(tmp_path=tmp_path), mode="ci", inter_run_sleep_s=0)
+            run_agentic_traces(
+                _ctx(tmp_path=tmp_path),
+                mode="ci",
+                trace_sources="inferencex_agentx",
+                inter_run_sleep_s=0,
+            )
 
         run, _server, context = driver.run.call_args[0]
         planned = run.benchmark_duration + run.warmup_grace_period
@@ -164,6 +193,7 @@ class TestSweepLoop:
             run_agentic_traces(
                 _ctx(tmp_path=tmp_path),
                 mode="ci",
+                trace_sources="inferencex_agentx",
                 git_ref_override="cafebabe",
                 inter_run_sleep_s=0,
             )
@@ -180,6 +210,7 @@ class TestSweepLoop:
             run_agentic_traces(
                 _ctx(tmp_path=tmp_path),
                 mode="ci",
+                trace_sources="inferencex_agentx",
                 auth_token="tok123",
                 inter_run_sleep_s=0,
             )
@@ -188,12 +219,79 @@ class TestSweepLoop:
         assert server.auth_token == "tok123"
         assert server.url_with_port == "http://localhost:8000"
 
+
+class TestTraceSourceDispatch:
+    def test_swarmone_dispatches_to_the_swo_driver(self, tmp_path):
+        outcome = AgenticTracesDriverResult(
+            return_code=0, payload=_ok_payload(), raw_path=None
+        )
+        patcher, swo_driver = _swo_driver_returning(outcome)
+        with patcher:
+            result = run_agentic_traces(
+                _ctx(tmp_path=tmp_path),
+                mode="ci",
+                trace_sources="swarmone",
+                inter_run_sleep_s=0,
+            )
+
+        assert result.return_codes == [0]
+        assert [b.kind for b in result.blocks] == ["agentic_traces"]
+        swo_driver.run.assert_called_once()
+        run = swo_driver.run.call_args[0][0]
+        assert run.trace_source.value == "swarmone"
+
+    def test_default_sweep_runs_both_sources(self, tmp_path):
+        aiperf_driver = MagicMock()
+        aiperf_driver.run.return_value = AgenticTracesDriverResult(
+            return_code=0, payload=_ok_payload("aiperf"), raw_path=None
+        )
+        swo_driver = MagicMock()
+        swo_driver.run.return_value = AgenticTracesDriverResult(
+            return_code=0, payload=_ok_payload("swo"), raw_path=None
+        )
+        with patch.multiple(
+            agentic_traces_tests,
+            AIPerfAgenticTracesDriver=MagicMock(return_value=aiperf_driver),
+            SwoBenchAgenticTracesDriver=MagicMock(return_value=swo_driver),
+        ):
+            result = run_agentic_traces(
+                _ctx(tmp_path=tmp_path), mode="ci", inter_run_sleep_s=0
+            )
+
+        assert result.return_codes == [0, 0]
+        aiperf_driver.run.assert_called_once()
+        swo_driver.run.assert_called_once()
+
+    def test_swo_driver_gets_a_generous_timeout(self, tmp_path):
+        outcome = AgenticTracesDriverResult(
+            return_code=0, payload=_ok_payload(), raw_path=None
+        )
+        patcher, swo_driver = _swo_driver_returning(outcome)
+        with patcher:
+            run_agentic_traces(
+                _ctx(tmp_path=tmp_path),
+                mode="ci",
+                trace_sources="swarmone",
+                inter_run_sleep_s=0,
+            )
+
+        _run, _server, context = swo_driver.run.call_args[0]
+        # SwarmOne CI timeout floor is 1h plus headroom.
+        assert context.per_run_timeout_s >= 3600
+
     def test_artifacts_land_under_the_output_path(self, tmp_path):
         outcome = AgenticTracesDriverResult(
             return_code=0, payload=_ok_payload(), raw_path=None
         )
         patcher, _ = _driver_returning(outcome)
         with patcher:
-            run_agentic_traces(_ctx(tmp_path=tmp_path), mode="ci", inter_run_sleep_s=0)
+            run_agentic_traces(
+                _ctx(tmp_path=tmp_path),
+                mode="ci",
+                trace_sources="inferencex_agentx",
+                inter_run_sleep_s=0,
+            )
 
-        assert (tmp_path / "agentic_traces" / "aiperf_artifacts").is_dir()
+        # The orchestrator creates the output root; the (mocked) driver would
+        # create its own per-run artifact subtree.
+        assert (tmp_path / "agentic_traces").is_dir()

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -687,7 +687,15 @@ class TestAgenticTracesRegistration:
         return config
 
     def _validate(self, spec, runtime_config):
-        with patch.dict("workflows.validate_setup.MODEL_SPECS", {spec.model_id: spec}):
+        # These tests exercise the AGENTIC_TRACES_CONFIGS registration gate, not
+        # the SwarmOne license gate, so treat a license as present regardless of
+        # the (CI) host's environment. The license gate has its own tests below.
+        with patch.dict(
+            "workflows.validate_setup.MODEL_SPECS", {spec.model_id: spec}
+        ), patch(
+            "workflows.validate_setup._swarmone_license_available",
+            return_value=True,
+        ):
             validate_runtime_args(spec, runtime_config)
 
     def test_unregistered_model_is_rejected(self):
@@ -733,6 +741,61 @@ class TestAgenticTracesRegistration:
             "workflows.validate_setup.can_dispatch_to_engine", lambda *a, **k: True
         )
         self._validate(spec, self._runtime_config("release"))
+
+
+class TestSwarmOneLicenseGate:
+    """A swarmone run needs a swo-bench license, checked up front in run.py.
+
+    The check fires when the workflow is ``agentic_traces`` and swarmone is
+    among the selected/configured sources, so a multi-minute venv build (and,
+    for a mixed config, a completed InferenceX run) is never wasted on a sweep
+    that will fail the moment the swo-bench driver looks for its key.
+    """
+
+    def _spec(self):
+        registered_id = next(iter(AGENTIC_TRACES_CONFIGS))
+        spec = MagicMock()
+        spec.model_id = registered_id
+        spec.model_name = "Kimi-K2.7-Code"
+        spec.inference_engine = "vLLM"
+        return spec
+
+    def _config(self, **overrides):
+        return RuntimeConfig(
+            model="Kimi-K2.7-Code",
+            workflow="agentic_traces",
+            device="super_cluster",
+            **overrides,
+        )
+
+    def _validate(self, spec, config):
+        with patch.dict("workflows.validate_setup.MODEL_SPECS", {spec.model_id: spec}):
+            validate_runtime_args(spec, config)
+
+    def test_missing_license_is_rejected_when_swarmone_configured(self):
+        spec = self._spec()
+        with patch(
+            "workflows.validate_setup._swarmone_license_available", return_value=False
+        ):
+            with pytest.raises(ValueError, match="SwarmOne license"):
+                self._validate(spec, self._config())
+
+    def test_present_license_passes(self):
+        spec = self._spec()
+        with patch(
+            "workflows.validate_setup._swarmone_license_available", return_value=True
+        ):
+            self._validate(spec, self._config())
+
+    def test_selecting_only_inferencex_skips_the_license_check(self):
+        """Narrowing away from swarmone means no license is needed."""
+        spec = self._spec()
+        with patch(
+            "workflows.validate_setup._swarmone_license_available", return_value=False
+        ):
+            self._validate(
+                spec, self._config(agentic_traces_sources="inferencex_agentx")
+            )
 
 
 class TestCheckImageVersionSupported:

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -12,6 +12,7 @@ import pytest
 
 from reference_config.agentic_traces.agentic_traces_config import (
     AGENTIC_TRACES_CONFIGS,
+    TraceSource,
 )
 from workflows.run_local_server import vllm_tt_plugin_source_path
 from workflows.runtime_config import RuntimeConfig
@@ -687,14 +688,13 @@ class TestAgenticTracesRegistration:
         return config
 
     def _validate(self, spec, runtime_config):
-        # These tests exercise the AGENTIC_TRACES_CONFIGS registration gate, not
-        # the SwarmOne license gate, so treat a license as present regardless of
-        # the (CI) host's environment. The license gate has its own tests below.
+        # No license, deliberately: these paths must not depend on one. The
+        # host running the suite may happen to have a key, so pin it to absent.
         with patch.dict(
             "workflows.validate_setup.MODEL_SPECS", {spec.model_id: spec}
         ), patch(
             "workflows.validate_setup._swarmone_license_available",
-            return_value=True,
+            return_value=False,
         ):
             validate_runtime_args(spec, runtime_config)
 
@@ -716,7 +716,11 @@ class TestAgenticTracesRegistration:
         assert "git ref" in message
 
     def test_registered_model_passes(self):
-        """Guards against the assertion firing on an onboarded model."""
+        """Guards against the assertion firing on an onboarded model.
+
+        Runs without a SwarmOne license on purpose: the plain sweep must stay
+        usable for a model that merely has an opt-in SwarmOne run configured.
+        """
         registered_id = next(iter(AGENTIC_TRACES_CONFIGS))
         spec = self._spec(registered_id, model_name="Kimi-K2.7-Code")
         config = RuntimeConfig(
@@ -746,10 +750,11 @@ class TestAgenticTracesRegistration:
 class TestSwarmOneLicenseGate:
     """A swarmone run needs a swo-bench license, checked up front in run.py.
 
-    The check fires when the workflow is ``agentic_traces`` and swarmone is
-    among the selected/configured sources, so a multi-minute venv build (and,
-    for a mixed config, a completed InferenceX run) is never wasted on a sweep
-    that will fail the moment the swo-bench driver looks for its key.
+    The check fires only when swarmone will actually run, so a multi-minute
+    venv build is never wasted on a sweep that will fail the moment the
+    swo-bench driver looks for its key -- while a plain sweep of a model that
+    merely *has* a swarmone run configured stays license-free, because swarmone
+    is opt-in.
     """
 
     def _spec(self):
@@ -768,34 +773,72 @@ class TestSwarmOneLicenseGate:
             **overrides,
         )
 
-    def _validate(self, spec, config):
-        with patch.dict("workflows.validate_setup.MODEL_SPECS", {spec.model_id: spec}):
+    def _validate(self, spec, config, *, license_available):
+        with patch.dict(
+            "workflows.validate_setup.MODEL_SPECS", {spec.model_id: spec}
+        ), patch(
+            "workflows.validate_setup._swarmone_license_available",
+            return_value=license_available,
+        ):
             validate_runtime_args(spec, config)
 
-    def test_missing_license_is_rejected_when_swarmone_configured(self):
+    def test_configured_but_unselected_swarmone_needs_no_license(self):
+        """The regression this gate once caused: Kimi gaining a swarmone run
+        made ``--workflow agentic_traces`` demand a license from everyone."""
         spec = self._spec()
-        with patch(
-            "workflows.validate_setup._swarmone_license_available", return_value=False
-        ):
-            with pytest.raises(ValueError, match="SwarmOne license"):
-                self._validate(spec, self._config())
+        assert any(
+            run.trace_source is TraceSource.SWARMONE
+            for run in AGENTIC_TRACES_CONFIGS[spec.model_id].runs
+        ), "fixture no longer covers the mixed-source case this test guards"
+        self._validate(spec, self._config(), license_available=False)
 
-    def test_present_license_passes(self):
+    def test_missing_license_is_rejected_when_swarmone_is_selected(self):
         spec = self._spec()
-        with patch(
-            "workflows.validate_setup._swarmone_license_available", return_value=True
-        ):
-            self._validate(spec, self._config())
+        with pytest.raises(ValueError, match="SwarmOne license"):
+            self._validate(
+                spec,
+                self._config(agentic_traces_sources="swarmone"),
+                license_available=False,
+            )
+
+    def test_the_error_says_how_to_proceed_without_swarmone(self):
+        """Someone who just wants the InferenceX sweep needs a way out."""
+        spec = self._spec()
+        with pytest.raises(ValueError) as exc:
+            self._validate(
+                spec,
+                self._config(agentic_traces_sources="swarmone"),
+                license_available=False,
+            )
+        message = str(exc.value)
+        assert "SWO_LICENSE_KEY" in message
+        assert "--agentic-traces-sources swarmone" in message
+
+    def test_present_license_allows_an_explicit_swarmone_sweep(self):
+        spec = self._spec()
+        self._validate(
+            spec,
+            self._config(agentic_traces_sources="swarmone"),
+            license_available=True,
+        )
+
+    def test_selecting_swarmone_alongside_inferencex_still_needs_a_license(self):
+        spec = self._spec()
+        with pytest.raises(ValueError, match="SwarmOne license"):
+            self._validate(
+                spec,
+                self._config(agentic_traces_sources="inferencex_agentx,swarmone"),
+                license_available=False,
+            )
 
     def test_selecting_only_inferencex_skips_the_license_check(self):
         """Narrowing away from swarmone means no license is needed."""
         spec = self._spec()
-        with patch(
-            "workflows.validate_setup._swarmone_license_available", return_value=False
-        ):
-            self._validate(
-                spec, self._config(agentic_traces_sources="inferencex_agentx")
-            )
+        self._validate(
+            spec,
+            self._config(agentic_traces_sources="inferencex_agentx"),
+            license_available=False,
+        )
 
 
 class TestCheckImageVersionSupported:

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -37,6 +37,21 @@ def _uses_external_runtime_model_spec(runtime_config) -> bool:
     return bool(runtime_config.runtime_model_spec_json)
 
 
+def _swarmone_license_available() -> bool:
+    """Whether a SwarmOne swo-bench license can be resolved.
+
+    Mirrors swo-bench's own resolution order (env var, then the config file);
+    the key itself is never read into run.py, only its presence is checked.
+    """
+    if os.environ.get("SWO_LICENSE_KEY"):
+        return True
+    key_file = Path.home() / ".swarmone" / "license.key"
+    try:
+        return key_file.is_file() and bool(key_file.read_text().strip())
+    except OSError:
+        return False
+
+
 def _check_image_version_supported(model_spec):
     """Refuse to run a pre-0.11 vLLM image with this run.py.
 
@@ -121,15 +136,40 @@ def validate_runtime_args(model_spec, runtime_config):
         # that the AGENTIC_TRACES venv setup performs -- and, for a release run,
         # rather than after the evals and benchmarks that precede the child.
         from reference_config.agentic_traces.agentic_traces_config import (
+            TraceSource,
             get_agentic_traces_config,
         )
 
-        assert get_agentic_traces_config(model_spec) is not None, (
+        agentic_traces_config = get_agentic_traces_config(model_spec)
+        assert agentic_traces_config is not None, (
             f"Model:={model_spec.model_name} (model_id={model_spec.model_id}) has "
             "no AGENTIC_TRACES_CONFIGS entry. Add one to "
             "reference_config/agentic_traces/agentic_traces_config.py, including "
             "the InferenceX git ref to pin."
         )
+
+        # A SwarmOne run needs a swo-bench license; require it up front (like
+        # HF_TOKEN) rather than failing minutes into the run inside the driver.
+        sources_arg = getattr(args, "agentic_traces_sources", None)
+        if sources_arg:
+            selected = {
+                part.strip().lower().replace("-", "_")
+                for part in sources_arg.split(",")
+                if part.strip()
+            }
+            swarmone_selected = TraceSource.SWARMONE.value in selected
+        else:
+            swarmone_selected = any(
+                run.trace_source is TraceSource.SWARMONE
+                for run in agentic_traces_config.runs
+            )
+        if swarmone_selected and not _swarmone_license_available():
+            raise ValueError(
+                "⛔ --workflow agentic_traces with the swarmone trace source "
+                "requires a SwarmOne license. Set the SWO_LICENSE_KEY environment "
+                "variable or write the key to ~/.swarmone/license.key. Request a "
+                "key from benb@swarmone.ai."
+            )
 
     if workflow_type == WorkflowType.STRESS_TESTS:
         pass  # Model support already validated via MODEL_SPECS check

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -137,6 +137,7 @@ def validate_runtime_args(model_spec, runtime_config):
         # rather than after the evals and benchmarks that precede the child.
         from reference_config.agentic_traces.agentic_traces_config import (
             TraceSource,
+            default_run_specs,
             get_agentic_traces_config,
         )
 
@@ -150,6 +151,9 @@ def validate_runtime_args(model_spec, runtime_config):
 
         # A SwarmOne run needs a swo-bench license; require it up front (like
         # HF_TOKEN) rather than failing minutes into the run inside the driver.
+        # Only when SwarmOne will actually run, though: it is an opt-in source,
+        # so a model that merely has a SwarmOne run configured still runs its
+        # plain sweep (InferenceX only) without a license.
         sources_arg = getattr(args, "agentic_traces_sources", None)
         if sources_arg:
             selected = {
@@ -157,18 +161,19 @@ def validate_runtime_args(model_spec, runtime_config):
                 for part in sources_arg.split(",")
                 if part.strip()
             }
-            swarmone_selected = TraceSource.SWARMONE.value in selected
+            swarmone_will_run = TraceSource.SWARMONE.value in selected
         else:
-            swarmone_selected = any(
+            swarmone_will_run = any(
                 run.trace_source is TraceSource.SWARMONE
-                for run in agentic_traces_config.runs
+                for run in default_run_specs(agentic_traces_config)
             )
-        if swarmone_selected and not _swarmone_license_available():
+        if swarmone_will_run and not _swarmone_license_available():
             raise ValueError(
-                "⛔ --workflow agentic_traces with the swarmone trace source "
-                "requires a SwarmOne license. Set the SWO_LICENSE_KEY environment "
-                "variable or write the key to ~/.swarmone/license.key. Request a "
-                "key from benb@swarmone.ai."
+                "⛔ The swarmone agentic-traces source requires a SwarmOne "
+                "license. Set the SWO_LICENSE_KEY environment variable or write "
+                "the key to ~/.swarmone/license.key. Request a key from "
+                "benb@swarmone.ai. To run without SwarmOne, drop "
+                "`--agentic-traces-sources swarmone`."
             )
 
     if workflow_type == WorkflowType.STRESS_TESTS:

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -252,6 +252,7 @@ def setup_agentic_traces(
     silently benchmark a client it was not pinned to.
     """
     from reference_config.agentic_traces.agentic_traces_config import (
+        TraceSource,
         get_agentic_traces_config,
     )
 
@@ -264,6 +265,19 @@ def setup_agentic_traces(
             getattr(model_spec, "model_id", "<unknown>"),
         )
         return False
+
+    # The InferenceX AIPerf fork is only needed for inferencex_agentx runs. A
+    # config whose runs are all SwarmOne relies solely on the swo-bench package
+    # installed from agentic-traces.txt, so skip the multi-minute clone/install.
+    if not any(
+        run.trace_source is TraceSource.INFERENCEX_AGENTX for run in config.runs
+    ):
+        logger.info(
+            "No InferenceX runs configured for model_id=%s; skipping InferenceX "
+            "checkout (SwarmOne swo-bench is installed from agentic-traces.txt).",
+            getattr(model_spec, "model_id", "<unknown>"),
+        )
+        return True
 
     git_ref = config.inferencex_git_ref
     repo_dir = venv_config.venv_path / "InferenceX"


### PR DESCRIPTION
Relating to issue https://github.com/tenstorrent/tt-inference-server/issues/4790

## Summary
Implements `TraceSource.SWARMONE` inside the existing `agentic_traces` workflow, filling the previously stubbed enum value. SwarmOne's [`swo-bench`](https://swarmone.ai) replay engine now runs as a first-class trace source alongside the InferenceX/AIPerf harness — no new top-level workflow. It replays recorded Claude-Code / Codex coding sessions (`swo-bench list-scenarios`) turn-by-turn with growing history, with the replay plan built server-side by the SwarmOne backend.

By default (no `--agentic-traces-sources`), a model configured for both sources runs **both** harnesses; each run is dispatched to the driver for its `trace_source`.

## What's included
- **New driver** (`llm_module/drivers/swo_bench_agentic_traces.py`): builds the `swo-bench replay` CLI and parses swo-bench's `report.metrics` JSON into a flat dict aligned with the AIPerf agentic payload (TTFT, latency, decode/prefill throughput, counts) plus swo-specific fields (session id, source label, version). Always passes `--model-context-length` from the ModelSpec with `--no-resolve-model-context` (the TT Console `/v1/models` omits the window), and keeps the license out of argv.
- **New parser** (`llm_module/parsers/swo_bench_agentic_traces.py`): emits `Block(kind="agentic_traces")` so both harnesses collapse into one report section.
- **Config** (`reference_config/.../agentic_traces_config.py`): swo-bench knobs on `AgenticTracesRunSpec` (`task`, `resident`, `cache_mode`, `history_mode`, `max_tokens`, `max_tokens_mode`) with validation, a per-spec `modes` tuple for mode scoping, source-aware `label`, and relaxed `inferencex_git_ref` (only required when an InferenceX run exists). Registers Kimi SwarmOne runs: **FULL** = all tasks @ c8, **CI** = `sympy-bugfix` @ c1.
- **Run model** (`llm_module/agentic_traces/runs.py`): `SWARMONE` added to `SUPPORTED_TRACE_SOURCES`, mode filtering in `build_runs`, and a request-count-driven `estimated_run_seconds` (CI ~1h / FULL ~8h) since swo-bench isn't wall-clock-bounded.
- **Orchestrator** (`test_module/llm_tests/agentic_traces_tests.py`): dispatch per run by `trace_source`, separate `aiperf_artifacts/` vs `swo_bench_artifacts/` roots, InferenceX pin logged only when relevant.
- **Venv & license**: `swo-bench==3.1.2` pinned in `requirements/agentic-traces.txt`; `setup_agentic_traces` skips the InferenceX clone for swarmone-only configs; `validate_setup.py` fails fast when a SwarmOne license (`SWO_LICENSE_KEY` / `~/.swarmone/license.key`) is missing.
- **Docs & tests**: `docs/workflow_development.md` + `run.py` help updated; new SwarmOne build/CLI/parse/dispatch coverage.

## Design note
Used a per-spec `modes` tuple (FULL/CI scoping) instead of a shared `mode_settings.task` field — a shared mode setting would have leaked SwarmOne's CI `concurrency=1` onto the InferenceX CI run. This keeps the InferenceX runs untouched.

## Usage
```bash
python run.py --model Kimi-K2.7-Code --workflow agentic_traces \
    --agentic-traces-sources swarmone --agentic-traces-mode ci \
    --device super_cluster --server-url http://localhost:8000
```
Requires a SwarmOne license via `SWO_LICENSE_KEY` or `~/.swarmone/license.key`.

## Test plan
- [x] `tests/llm_module/test_agentic_traces.py`, `tests/test_module/llm_tests/test_agentic_traces_tests.py`, `tests/report_module/test_agentic_traces_renderer.py` — 144 passed
- [x] Wider suites (`tests/llm_module`, `tests/workflow_module`, `tests/workflows`, `tests/test_validate_setup.py`, `tests/test_run_arguments.py`) — 645 passed
- [x] No lint errors
- [x] Agentic Trace Replay for Qwen/Qwen3-32B