### PR TITLE
Bump tt-forge to 1.4.0

### DIFF
--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
 --extra-index-url https://download.pytorch.org/whl/cpu
 # 1.4.0 dev/nightly built 2026-07-18. Supersedes the 2026-07-05 build.
-tt-forge==1.4.0.dev20260718001745
+tt-forge==1.4.0
 
 tabulate
 timm # input preprocessing


### PR DESCRIPTION
Automated version bump of `tt-forge` to `1.4.0` in `tt-media-server/Dockerfile.forge`.

### Checklist

- [x] `efficientnet`: https://github.com/tenstorrent/tt-shield/actions/runs/30537988273
- [x] `mobilenetv2`: https://github.com/tenstorrent/tt-shield/actions/runs/30537994371
- [x] `resnet-50`: https://github.com/tenstorrent/tt-shield/actions/runs/30538001074
- [x] `segformer`: https://github.com/tenstorrent/tt-shield/actions/runs/30538007591
- [x] `vit`: https://github.com/tenstorrent/tt-shield/actions/runs/30538014141
- [x] `vovnet`: https://github.com/tenstorrent/tt-shield/actions/runs/30538020808
- [ ] `Falcon3-7B-Instruct`: https://github.com/tenstorrent/tt-shield/actions/runs/30538027563 (evals fail, expected)
