### PR TITLE
acceptance: mask evals/benchmarks blockers per model status tier

### DIFF
--- a/report_module/acceptance_criteria.py
+++ b/report_module/acceptance_criteria.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
+from workflows.workflow_types import ModelStatusTypes
+
 from .schema import Block, ReportSchema
 from .status import TestStatus, glyph_for_label
 
@@ -23,6 +25,30 @@ FAIL_CHECK_INT = 3
 STATUS_PASS = "PASS"
 STATUS_FAIL = "FAIL"
 STATUS_NA = "NA"
+
+
+def _enforced_benchmark_tiers(model_status: Optional[str]) -> Tuple[str, ...]:
+    """Benchmark target tiers whose failures block acceptance for this model status.
+
+    Falls back to enforcing every tier when the status is missing or
+    unrecognized, so an absent/garbled status can never accidentally loosen
+    acceptance.
+    """
+    status = ModelStatusTypes.resolve(model_status)
+    if status is None:
+        return TARGET_LEVELS
+    return tuple(status.required_target_tiers)
+
+
+def _evals_enforced(model_status: Optional[str]) -> bool:
+    """Whether eval accuracy failures block acceptance for this model status."""
+    status = ModelStatusTypes.resolve(model_status)
+    return True if status is None else status.evals_enforced
+
+
+def _informational_suffix(model_status: Optional[str]) -> str:
+    """Message suffix for a check masked to informational-only by tier."""
+    return f"(informational: model status={model_status or 'unknown'})"
 
 
 def _status_badge(status: str) -> str:
@@ -73,10 +99,11 @@ class CategoryResult:
 def acceptance_criteria_check(
     schema: ReportSchema,
     known_issues: Optional[Iterable[Any]] = None,
+    model_status: Optional[str] = None,
 ) -> Tuple[bool, Dict[str, str], List[CategoryResult]]:
     categories = [
-        _check_benchmarks(schema),
-        _check_evals(schema, known_issues),
+        _check_benchmarks(schema, model_status),
+        _check_evals(schema, known_issues, model_status),
         _check_spec_tests(schema),
     ]
     blockers: Dict[str, str] = {}
@@ -234,12 +261,17 @@ def _detail(category: CategoryResult) -> str:
     return ", ".join(parts)
 
 
-def _check_benchmarks(schema: ReportSchema) -> CategoryResult:
+def _check_benchmarks(
+    schema: ReportSchema, model_status: Optional[str] = None
+) -> CategoryResult:
     benchmark_blocks = [b for b in schema.sections if b.kind == KIND_BENCHMARKS]
     if not benchmark_blocks:
         return CategoryResult(CATEGORY_BENCHMARKS, STATUS_NA, 0, 0)
 
+    enforced_tiers = _enforced_benchmark_tiers(model_status)
+
     blockers: Dict[str, str] = {}
+    waived: Dict[str, str] = {}
     failed = 0
     skipped = 0
     na = 0
@@ -260,6 +292,7 @@ def _check_benchmarks(schema: ReportSchema) -> CategoryResult:
             continue
 
         block_blockers: Dict[str, str] = {}
+        block_informational: Dict[str, str] = {}
         target_checks = _resolve_nested(block.data, "target_checks")
         if not isinstance(target_checks, Mapping):
             block_blockers[f"{block_key}.target_checks"] = (
@@ -283,11 +316,14 @@ def _check_benchmarks(schema: ReportSchema) -> CategoryResult:
                     any_check_seen = True
                     if not _passes_check(check_value):
                         metric = check_name[: -len(CHECK_SUFFIX)]
-                        block_blockers[f"{block_key}.{lvl}.{check_name}"] = (
-                            _format_benchmark_failure(
-                                lvl, check_name, metric, level_checks
-                            )
+                        failure = _format_benchmark_failure(
+                            lvl, check_name, metric, level_checks
                         )
+                        key = f"{block_key}.{lvl}.{check_name}"
+                        if lvl in enforced_tiers:
+                            block_blockers[key] = failure
+                        else:
+                            block_informational[key] = failure
             if not any_check_seen:
                 block_blockers[f"{block_key}.target_checks"] = (
                     "No *_check fields found across any tier."
@@ -296,6 +332,12 @@ def _check_benchmarks(schema: ReportSchema) -> CategoryResult:
         if block_blockers:
             failed += 1
             blockers.update(block_blockers)
+        if block_informational:
+            waived[block_key] = (
+                f"{len(block_informational)} tier check(s) failed but are "
+                f"informational-only {_informational_suffix(model_status)}: "
+                + "; ".join(block_informational.values())
+            )
 
     non_pass = failed + skipped + na
     if failed:
@@ -312,17 +354,20 @@ def _check_benchmarks(schema: ReportSchema) -> CategoryResult:
         na=na,
         skipped=skipped,
         blockers=blockers,
+        waived=waived,
     )
 
 
 def _check_evals(
     schema: ReportSchema,
     known_issues: Optional[Iterable[Any]] = None,
+    model_status: Optional[str] = None,
 ) -> CategoryResult:
     eval_blocks = [b for b in schema.sections if b.kind == KIND_EVALS]
     if not eval_blocks:
         return CategoryResult(CATEGORY_EVALS, STATUS_NA, 0, 0)
 
+    evals_enforced = _evals_enforced(model_status)
     blockers: Dict[str, str] = {}
     waived: Dict[str, str] = {}
     failed = 0
@@ -339,11 +384,17 @@ def _check_evals(
         explicit = _explicit_status(block)
         if explicit is not None:
             if explicit.is_blocking:
-                blockers[block_key] = (
+                explicit_message = (
                     f"{block.title or block.kind} reported status={explicit.value} "
                     f"(attempts={data.get('attempts', '?')})"
                 )
-                failed += 1
+                if evals_enforced:
+                    blockers[block_key] = explicit_message
+                    failed += 1
+                else:
+                    waived[block_key] = (
+                        f"{explicit_message} {_informational_suffix(model_status)}"
+                    )
             elif explicit is TestStatus.SKIP:
                 skipped += 1
             elif explicit is TestStatus.NA:
@@ -379,6 +430,11 @@ def _check_evals(
         if reason is not None:
             waived[block_key] = f"{message} (waived: {reason})"
             continue
+
+        if not evals_enforced:
+            waived[block_key] = f"{message} {_informational_suffix(model_status)}"
+            continue
+
         blockers[block_key] = message
         failed += 1
 

--- a/tests/report_module/test_acceptance_criteria.py
+++ b/tests/report_module/test_acceptance_criteria.py
@@ -220,6 +220,111 @@ def test_summary_detail_absent_vs_all_na_are_distinguished():
     assert "1 NA" in present_md
 
 
+# --- Model-status-aware tier masking ---------------------------------------
+
+
+def test_benchmark_failing_check_blocks_at_functional_status():
+    # FUNCTIONAL requires the "functional" tier -- a failing functional check
+    # still blocks, same as with no status at all.
+    schema = _schema(
+        _bench({"functional": {"ttft_check": 3, "ttft": 100, "ttft_ratio": 1.2}})
+    )
+    accepted, blockers, _ = acceptance_criteria_check(schema, model_status="FUNCTIONAL")
+    assert accepted is False
+    assert "benchmarks:B.functional.ttft_check" in blockers
+
+
+def test_benchmark_failing_check_informational_at_experimental_status():
+    # EXPERIMENTAL requires no tiers -- the same failing check is masked to a
+    # waiver instead of a blocker, and the run is accepted.
+    schema = _schema(
+        _bench({"target": {"ttft_check": 3, "ttft": 100, "ttft_ratio": 1.2}})
+    )
+    accepted, blockers, cats = acceptance_criteria_check(
+        schema, model_status="EXPERIMENTAL"
+    )
+    by_name = {c.name: c for c in cats}
+    assert accepted is True and blockers == {}
+    assert "benchmarks:B" in by_name[CATEGORY_BENCHMARKS].waived
+
+
+def test_benchmark_failing_complete_tier_still_blocks_at_complete_status():
+    # COMPLETE requires functional + complete -- a failing "complete" tier
+    # check still blocks. The also-failing "target" tier doesn't add a
+    # blocker, but is still surfaced (as waived/informational) rather than
+    # silently dropped just because the block already failed elsewhere.
+    schema = _schema(
+        _bench(
+            {
+                "complete": {"ttft_check": 3, "ttft": 100, "ttft_ratio": 1.2},
+                "target": {"ttft_check": 3, "ttft": 100, "ttft_ratio": 1.5},
+            }
+        )
+    )
+    accepted, blockers, cats = acceptance_criteria_check(
+        schema, model_status="COMPLETE"
+    )
+    by_name = {c.name: c for c in cats}
+    assert accepted is False
+    assert "benchmarks:B.complete.ttft_check" in blockers
+    assert "benchmarks:B.target.ttft_check" not in blockers
+    assert "benchmarks:B" in by_name[CATEGORY_BENCHMARKS].waived
+
+
+def test_benchmark_unrecognized_status_falls_back_to_fully_enforced():
+    # A missing/garbled status must never accidentally loosen acceptance.
+    schema = _schema(
+        _bench({"target": {"ttft_check": 3, "ttft": 100, "ttft_ratio": 1.2}})
+    )
+    accepted, blockers, _ = acceptance_criteria_check(
+        schema, model_status="not_a_real_status"
+    )
+    assert accepted is False
+    assert "benchmarks:B.target.ttft_check" in blockers
+
+
+def test_eval_accuracy_check_fail_informational_at_experimental_status():
+    schema = _schema(_eval({"accuracy_check": 3}))
+    accepted, blockers, cats = acceptance_criteria_check(
+        schema, model_status="EXPERIMENTAL"
+    )
+    by_name = {c.name: c for c in cats}
+    assert accepted is True and blockers == {}
+    assert "evals:E" in by_name[CATEGORY_EVALS].waived
+
+
+def test_eval_accuracy_check_fail_still_blocks_at_functional_status():
+    schema = _schema(_eval({"accuracy_check": 3}))
+    accepted, blockers, _ = acceptance_criteria_check(schema, model_status="FUNCTIONAL")
+    assert accepted is False
+    assert "Accuracy check failed" in blockers["evals:E"]
+
+
+def test_eval_explicit_error_informational_at_experimental_status():
+    schema = _schema(_eval({"status": "error", "attempts": 2}))
+    accepted, blockers, cats = acceptance_criteria_check(
+        schema, model_status="EXPERIMENTAL"
+    )
+    by_name = {c.name: c for c in cats}
+    assert accepted is True and blockers == {}
+    assert "evals:E" in by_name[CATEGORY_EVALS].waived
+
+
+def test_eval_known_issue_waiver_takes_precedence_over_status_message():
+    # Both an EXPERIMENTAL status and a known_issues waiver would mask this --
+    # the known_issue reason should still be the one recorded.
+    schema = _schema(_eval({"task_name": "ifeval", "accuracy_check": 3}))
+    known_issues = [
+        {"workflow_type": "EVALS", "task_name": "ifeval", "reason": "tracked in #4733"}
+    ]
+    accepted, blockers, cats = acceptance_criteria_check(
+        schema, known_issues=known_issues, model_status="EXPERIMENTAL"
+    )
+    by_name = {c.name: c for c in cats}
+    assert accepted is True and blockers == {}
+    assert "waived: tracked in #4733" in by_name[CATEGORY_EVALS].waived["evals:E"]
+
+
 # --- Spec tests -----------------------------------------------------------
 
 

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -762,6 +762,20 @@ class TestRequiredTargetTiers:
             "target",
         ]
 
+    def test_evals_enforced_false_only_for_experimental(self):
+        assert ModelStatusTypes.EXPERIMENTAL.evals_enforced is False
+        assert ModelStatusTypes.FUNCTIONAL.evals_enforced is True
+        assert ModelStatusTypes.COMPLETE.evals_enforced is True
+        assert ModelStatusTypes.TOP_PERF.evals_enforced is True
+
+    def test_resolve_looks_up_by_name(self):
+        assert ModelStatusTypes.resolve("EXPERIMENTAL") is ModelStatusTypes.EXPERIMENTAL
+
+    def test_resolve_returns_none_for_missing_or_unrecognized(self):
+        assert ModelStatusTypes.resolve(None) is None
+        assert ModelStatusTypes.resolve("") is None
+        assert ModelStatusTypes.resolve("not_a_real_status") is None
+
 
 class TestEnforceAcceptanceCriteria:
     """Tests for the enforce_acceptance_criteria function."""

--- a/workflow_module/execution.py
+++ b/workflow_module/execution.py
@@ -317,8 +317,9 @@ class WorkflowExecution(ABC):
     def apply_acceptance_criteria(
         self, schema: ReportSchema, task_outcomes: Sequence[TaskOutcome]
     ) -> Tuple[bool, dict]:
+        model_status = self._model_status()
         accepted, blockers, categories = acceptance_criteria_check(
-            schema, known_issues=self._known_issues()
+            schema, known_issues=self._known_issues(), model_status=model_status
         )
         crash_blockers = task_failure_blockers(
             (o.task_type, o.exit_code, o.block_kind is not None) for o in task_outcomes
@@ -327,9 +328,7 @@ class WorkflowExecution(ABC):
             blockers = {**blockers, **crash_blockers}
             accepted = False
         schema.metadata.update(
-            build_acceptance_export(
-                accepted, blockers, categories, self._model_status()
-            )
+            build_acceptance_export(accepted, blockers, categories, model_status)
         )
         self.logger.info(
             "Acceptance: %s (%d blocker(s))",

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 from enum import Enum, IntEnum, auto
-from typing import List
+from typing import List, Optional
 
 
 class WorkflowType(IntEnum):
@@ -323,6 +323,30 @@ class ModelStatusTypes(IntEnum):
             ModelStatusTypes.TOP_PERF: ["functional", "complete", "target"],
         }
         return tier_map[self]
+
+    @property
+    def evals_enforced(self) -> bool:
+        """Whether eval accuracy failures block acceptance at this status.
+
+        Reuses required_target_tiers' signal (empty only for EXPERIMENTAL) so
+        a model still in bring-up isn't blocked on eval accuracy either.
+        """
+        return bool(self.required_target_tiers)
+
+    @classmethod
+    def resolve(cls, name: Optional[str]) -> Optional["ModelStatusTypes"]:
+        """Best-effort ``name`` -> member lookup, or ``None`` if missing/unrecognized.
+
+        Unlike :meth:`EvalLimitMode.from_string`, this never raises: callers
+        use a missing/garbled status as a signal to fall back to the
+        strictest (fully-enforced) behavior rather than crash.
+        """
+        if not name:
+            return None
+        try:
+            return cls[name]
+        except KeyError:
+            return None
 
 
 class EvalLimitMode(IntEnum):


### PR DESCRIPTION
## Ticket

Fixes #4829

## Problem

Model status is documented (`ModelStatusTypes.required_target_tiers`) to make an EXPERIMENTAL model's eval/benchmark failures informational-only, but the acceptance path every release actually runs never consulted model status -- so EXPERIMENTAL models (e.g. Falcon3-7B-Instruct) were still blocked by known-failing checks.

## Changes

- `workflows/workflow_types.py`: `ModelStatusTypes.resolve(name)` (safe lookup) and `ModelStatusTypes.evals_enforced` (named signal for eval gating, alongside the existing `required_target_tiers` for benchmarks).
- `report_module/acceptance_criteria.py`: threads `model_status` through `acceptance_criteria_check()`; masks non-enforced benchmark tiers and (new) evals into the existing `waived` bucket instead of blocking. Also fixes a silent-drop when a block fails both an enforced and a non-enforced tier at once.
- `workflow_module/execution.py`: passes the already-loaded model status into `acceptance_criteria_check()`.
- Tests: tier-masking coverage in `test_acceptance_criteria.py` / `test_model_specification.py`.

## Not changed

- `workflow_module/summary_report.py::generate_summary_report()` (multi-run benchmark summary rollup) still calls `acceptance_criteria_check()` without a status, since it aggregates across runs that may span multiple models -- fully-enforced behavior there is unchanged.
- `workflows/acceptance_criteria.py` -- left as-is; still no caller. Could be removed in a follow-up now that its logic lives in the production path.

## Test plan

- [x] `pytest tests/report_module/test_acceptance_criteria.py tests/llm_module/test_target_checks.py tests/workflows/test_acceptance_criteria.py tests/test_model_specification.py` -- all passing (255 total)
- [x] **Problem, pre-fix** -- [tt-shield run 30538027563](https://github.com/tenstorrent/tt-shield/actions/runs/30538027563/job/90860523831): Falcon3-7B-Instruct (EXPERIMENTAL) release fails (`Acceptance: FAIL`, 1 blocker) solely on the known-failing `ifeval` accuracy check.
- [x] **Fixed, this branch** -- [tt-shield run 30560194221](https://github.com/tenstorrent/tt-shield/actions/runs/30560194221): same model/device/docker image, this branch -- `conclusion: success`. `ifeval` now reported as informational/waived instead of a blocker.
- [x] **Demo (FUNCTIONAL status)** -- [tt-shield run 30565286813](https://github.com/tenstorrent/tt-shield/actions/runs/30565286813): same fix, Falcon3-7B-Instruct forge status bumped to `FUNCTIONAL` on a throwaway branch, same docker image -- fails acceptance on `ifeval` again, confirming the masking is status-driven, not a blanket disable.
