### PR TITLE
Adding forge DP embedding models on BH galaxy (Qwen3-Embedding-0.6B/-4B, bge-m3)

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -346,7 +346,18 @@
       "ci": {
         "weekly": {
           "devices": [
+            "BH_GALAXY",
             "N150"
+          ]
+        }
+      }
+    },
+    "Qwen3-Embedding-0.6B": {
+      "inference_engine": "FORGE",
+      "ci": {
+        "nightly": {
+          "devices": [
+            "BH_GALAXY"
           ]
         }
       }
@@ -363,17 +374,31 @@
       }
     },
     "bge-m3": {
-      "inference_engine": "MEDIA",
-      "ci": {
-        "nightly": {
-          "devices": [
-            "GALAXY",
-            "N150",
-            "N300",
-            "T3K"
-          ]
+      "implementations": [
+        {
+          "inference_engine": "MEDIA",
+          "ci": {
+            "nightly": {
+              "devices": [
+                "GALAXY",
+                "N150",
+                "N300",
+                "T3K"
+              ]
+            }
+          }
+        },
+        {
+          "inference_engine": "FORGE",
+          "ci": {
+            "nightly": {
+              "devices": [
+                "BH_GALAXY"
+              ]
+            }
+          }
         }
-      }
+      ]
     },
     "Wan2.2-T2V-A14B-Diffusers": {
       "inference_engine": "MEDIA",

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -6906,6 +6906,42 @@ models:
                 value: '1'
               - name: VLLM__MIN_CONTEXT_LENGTH
                 value: '32'
+      blackhole_galaxy:
+        defaultImpl: forge_vllm_plugin
+        impls:
+          forge_vllm_plugin:
+            progressDeadlineSeconds: 5400
+            image:
+              repository: ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge
+              tag: a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673
+            probes:
+              liveness:
+                initialDelaySeconds: 2400
+                path: /tt-liveness
+              readiness:
+                initialDelaySeconds: 2400
+            resources:
+              requests:
+                memory: 6Gi
+            env:
+              - name: ARCH_NAME
+                value: blackhole
+              - name: DEFAULT_THROTTLE_LEVEL
+                value: '0'
+              - name: MAX_BATCH_SIZE
+                value: '1'
+              - name: MESH_DEVICE
+                value: BH-Galaxy
+              - name: TT_METAL_INSPECTOR_RPC
+                value: '0'
+              - name: VLLM__MAX_MODEL_LENGTH
+                value: '128'
+              - name: VLLM__MAX_NUM_BATCHED_TOKENS
+                value: '128'
+              - name: VLLM__MAX_NUM_SEQS
+                value: '1'
+              - name: VLLM__MIN_CONTEXT_LENGTH
+                value: '32'
     defaultEngine: forge
   Qwen3-4B:
     forge:
@@ -7707,3 +7743,83 @@ models:
               - name: VLLM_TARGET_DEVICE
                 value: tt
     defaultEngine: vllm
+  Qwen3-Embedding-0.6B:
+    forge:
+      blackhole_galaxy:
+        defaultImpl: forge_vllm_plugin
+        impls:
+          forge_vllm_plugin:
+            progressDeadlineSeconds: 5400
+            image:
+              repository: ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge
+              tag: a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673
+            probes:
+              liveness:
+                initialDelaySeconds: 2400
+                path: /tt-liveness
+              readiness:
+                initialDelaySeconds: 2400
+            resources:
+              requests:
+                memory: 6Gi
+            env:
+              - name: ARCH_NAME
+                value: blackhole
+              - name: DEFAULT_THROTTLE_LEVEL
+                value: '0'
+              - name: MAX_BATCH_SIZE
+                value: '1'
+              - name: MESH_DEVICE
+                value: BH-Galaxy
+              - name: TT_METAL_INSPECTOR_RPC
+                value: '0'
+              - name: VLLM__MAX_MODEL_LENGTH
+                value: '128'
+              - name: VLLM__MAX_NUM_BATCHED_TOKENS
+                value: '128'
+              - name: VLLM__MAX_NUM_SEQS
+                value: '1'
+              - name: VLLM__MIN_CONTEXT_LENGTH
+                value: '32'
+    defaultEngine: forge
+  bge-m3:
+    forge:
+      blackhole_galaxy:
+        defaultImpl: forge_vllm_plugin
+        impls:
+          forge_vllm_plugin:
+            progressDeadlineSeconds: 5400
+            image:
+              repository: ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge
+              tag: a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673
+            probes:
+              liveness:
+                initialDelaySeconds: 2400
+                path: /tt-liveness
+              readiness:
+                initialDelaySeconds: 2400
+            resources:
+              requests:
+                memory: 6Gi
+            env:
+              - name: ARCH_NAME
+                value: blackhole
+              - name: DEFAULT_THROTTLE_LEVEL
+                value: '0'
+              - name: MAX_BATCH_SIZE
+                value: '1'
+              - name: MESH_DEVICE
+                value: BH-Galaxy
+              - name: MODEL_RUNNER
+                value: vllmforge_bge_m3
+              - name: TT_METAL_INSPECTOR_RPC
+                value: '0'
+              - name: VLLM__MAX_MODEL_LENGTH
+                value: '512'
+              - name: VLLM__MAX_NUM_BATCHED_TOKENS
+                value: '512'
+              - name: VLLM__MAX_NUM_SEQS
+                value: '1'
+              - name: VLLM__MIN_CONTEXT_LENGTH
+                value: '32'
+    defaultEngine: forge

--- a/reference_config/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/reference_config/benchmarking/benchmark_targets/model_performance_reference.json
@@ -6637,6 +6637,19 @@
                     }
                 }
             }
+        ],
+        "blackhole_galaxy": [
+            {
+                "max_concurrency": 32,
+                "task_type": "embedding",
+                "targets": {
+                    "theoretical": {
+                        "tput_user": 5750,
+                        "tput_prefill": 46000,
+                        "e2el_ms": 8300
+                    }
+                }
+            }
         ]
     },
     "Qwen3-Embedding-8B": {
@@ -6736,6 +6749,34 @@
         "galaxy": [
             {
                 "max_concurrency": 1,
+                "task_type": "embedding",
+                "targets": {
+                    "theoretical": {
+                        "tput_user": 6000,
+                        "tput_prefill": 6000,
+                        "e2el_ms": 100
+                    }
+                }
+            }
+        ],
+        "blackhole_galaxy": [
+            {
+                "max_concurrency": 32,
+                "task_type": "embedding",
+                "targets": {
+                    "theoretical": {
+                        "tput_user": 6000,
+                        "tput_prefill": 6000,
+                        "e2el_ms": 100
+                    }
+                }
+            }
+        ]
+    },
+    "Qwen3-Embedding-0.6B": {
+        "blackhole_galaxy": [
+            {
+                "max_concurrency": 32,
                 "task_type": "embedding",
                 "targets": {
                     "theoretical": {

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -3996,6 +3996,23 @@ _eval_config_list = [
         ],
     ),
     EvalConfig(
+        hf_model_repo="Qwen/Qwen3-Embedding-0.6B",
+        tasks=[
+            EvalTask(
+                task_name="embedding",
+                workflow_venv_type=WorkflowVenvType.EVALS_EMBEDDING,
+                include_path="work_dir",
+                max_concurrent=None,
+                apply_chat_template=False,
+                score=EvalTaskScore(
+                    published_score=64.33,
+                    published_score_ref="https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
+                    score_func=lambda results: 0.0,
+                ),
+            ),
+        ],
+    ),
+    EvalConfig(
         hf_model_repo="resnet-50",
         tasks=[
             EvalTask(

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -28,6 +28,7 @@ class SupportedModels(Enum):
     DISTIL_WHISPER_LARGE_V3 = "distil-whisper/distil-large-v3"
     OPENAI_WHISPER_LARGE_V3 = "openai/whisper-large-v3"
     PYANNOTE_SPEAKER_DIARIZATION = "pyannote/speaker-diarization-3.0"
+    QWEN_3_EMBEDDING_0_6B = "Qwen/Qwen3-Embedding-0.6B"
     QWEN_3_EMBEDDING_4B = "Qwen/Qwen3-Embedding-4B"
     QWEN_3_EMBEDDING_8B = "Qwen/Qwen3-Embedding-8B"
     BGE_LARGE_EN_V1_5 = "BAAI/bge-large-en-v1.5"
@@ -81,6 +82,7 @@ class ModelNames(Enum):
     SEGFORMER = "segformer"
     UNET = "unet"
     VIT = "vit"
+    QWEN_3_EMBEDDING_0_6B = "Qwen3-Embedding-0.6B"
     QWEN_3_EMBEDDING_4B = "Qwen3-Embedding-4B"
     QWEN_3_EMBEDDING_8B = "Qwen3-Embedding-8B"
     BGE_LARGE_EN_V1_5 = "bge-large-en-v1.5"
@@ -123,6 +125,8 @@ class ModelRunners(Enum):
     VLLMForge = "vllm_forge"
     TT_YOLOV4 = "tt-yolov4"
     VLLMForge_QWEN_EMBEDDING = "vllmforge_qwen_embedding"
+    VLLMForge_QWEN_EMBEDDING_0_6B = "vllmforge_qwen_embedding_0_6b"
+    VLLMForge_BGE_M3 = "vllmforge_bge_m3"
     VLLMForge_LLAMA_70B = "vllm_forge_llama_70b"
     VLLMForge_GEMMA4_31B = "vllm_forge_gemma4_31b"
     VLLMForge_QWEN_32B = "vllm_forge_qwen_32b"
@@ -187,6 +191,8 @@ MODEL_SERVICE_RUNNER_MAP = {
     },
     ModelServices.EMBEDDING: {
         ModelRunners.VLLMForge_QWEN_EMBEDDING,
+        ModelRunners.VLLMForge_QWEN_EMBEDDING_0_6B,
+        ModelRunners.VLLMForge_BGE_M3,
         ModelRunners.QWEN_EMBEDDING_8B,
         ModelRunners.BGELargeEN_V1_5,
         ModelRunners.BGEM3,
@@ -261,6 +267,7 @@ INFERENCE_MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.TT_XLA_VIT: {ModelNames.VIT},
     ModelRunners.TT_XLA_YOLOX_NANO: {ModelNames.YOLOX_NANO},
     ModelRunners.VLLMForge_QWEN_EMBEDDING: {ModelNames.QWEN_3_EMBEDDING_4B},
+    ModelRunners.VLLMForge_QWEN_EMBEDDING_0_6B: {ModelNames.QWEN_3_EMBEDDING_0_6B},
     ModelRunners.VLLMForge_LLAMA_70B: {ModelNames.LLAMA_3_1_70B},
     ModelRunners.VLLMForge_GEMMA4_31B: {ModelNames.GEMMA_4_31B_IT},
     ModelRunners.VLLMForge_QWEN_32B: {ModelNames.QWEN_3_32B},
@@ -270,6 +277,11 @@ INFERENCE_MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.QWEN_EMBEDDING_8B: {ModelNames.QWEN_3_EMBEDDING_8B},
     ModelRunners.BGELargeEN_V1_5: {ModelNames.BGE_LARGE_EN_V1_5},
     ModelRunners.BGEM3: {ModelNames.BGE_M3},
+    # Forge (forge-vllm-plugin) galaxy data-parallel variant of bge-m3. Shares
+    # the BGE_M3 model name with the MEDIA runner above; kept AFTER it so the
+    # name-only fallback still defaults to MEDIA. The forge serving path selects
+    # this runner explicitly via MODEL_RUNNER (set in the forge embedding.yaml).
+    ModelRunners.VLLMForge_BGE_M3: {ModelNames.BGE_M3},
     ModelRunners.VLLMForge: {
         ModelNames.LLAMA_3_2_3B,
         ModelNames.LLAMA_3_2_3B_INSTRUCT,
@@ -1074,6 +1086,51 @@ ModelConfigs = {
             "model": SupportedModels.QWEN_3_EMBEDDING_4B.value,
             "max_model_length": 1024,
             "max_num_batched_tokens": 1024,
+            "min_context_length": 32,
+            "max_num_seqs": 1,
+        },
+    },
+    # ----- BH Galaxy (Blackhole, 32x P150) data-parallel forge embeddings -----
+    # 32 independent single-chip (1,1) workers (DEVICE_IDS_32), model replicated
+    # per chip. Mirrors the production config validated standalone in tt-xla
+    # (b32 aggregate, opt=1, trace, bfp_bf8 weights -- the runner sets those
+    # additional_config knobs).
+    (ModelRunners.VLLMForge_QWEN_EMBEDDING, DeviceTypes.BLACKHOLE_GALAXY): {
+        "device_mesh_shape": (1, 1),
+        "is_galaxy": True,
+        "device_ids": DeviceIds.DEVICE_IDS_32.value,
+        "max_batch_size": 1,
+        "vllm": {
+            "model": SupportedModels.QWEN_3_EMBEDDING_4B.value,
+            "max_model_length": 128,
+            "max_num_batched_tokens": 128,
+            "min_context_length": 32,
+            "max_num_seqs": 1,
+        },
+    },
+    (ModelRunners.VLLMForge_QWEN_EMBEDDING_0_6B, DeviceTypes.BLACKHOLE_GALAXY): {
+        "device_mesh_shape": (1, 1),
+        "is_galaxy": True,
+        "device_ids": DeviceIds.DEVICE_IDS_32.value,
+        "max_batch_size": 1,
+        "vllm": {
+            "model": SupportedModels.QWEN_3_EMBEDDING_0_6B.value,
+            "max_model_length": 128,
+            "max_num_batched_tokens": 128,
+            "min_context_length": 32,
+            "max_num_seqs": 1,
+        },
+    },
+    (ModelRunners.VLLMForge_BGE_M3, DeviceTypes.BLACKHOLE_GALAXY): {
+        # bge-m3 validated at seq len 512 in tt-xla.
+        "device_mesh_shape": (1, 1),
+        "is_galaxy": True,
+        "device_ids": DeviceIds.DEVICE_IDS_32.value,
+        "max_batch_size": 1,
+        "vllm": {
+            "model": SupportedModels.BGE_M3.value,
+            "max_model_length": 512,
+            "max_num_batched_tokens": 512,
             "min_context_length": 32,
             "max_num_seqs": 1,
         },

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -84,6 +84,14 @@ AVAILABLE_RUNNERS = {
         "tt_model_runners.vllm_forge_qwen_embedding_runner",
         fromlist=["VLLMForgeEmbeddingQwenRunner"],
     ).VLLMForgeEmbeddingQwenRunner(wid),
+    ModelRunners.VLLMForge_QWEN_EMBEDDING_0_6B: lambda wid: __import__(
+        "tt_model_runners.vllm_forge_qwen_embedding_runner",
+        fromlist=["VLLMForgeEmbeddingQwenRunner"],
+    ).VLLMForgeEmbeddingQwenRunner(wid),
+    ModelRunners.VLLMForge_BGE_M3: lambda wid: __import__(
+        "tt_model_runners.vllm_forge_qwen_embedding_runner",
+        fromlist=["VLLMForgeEmbeddingQwenRunner"],
+    ).VLLMForgeEmbeddingQwenRunner(wid),
     ModelRunners.VLLMForge_LLAMA_70B: lambda wid: __import__(
         "tt_model_runners.vllm_forge_llama_70b",
         fromlist=["VLLMForgeLlama70BRunner"],

--- a/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
+++ b/tt-media-server/tt_model_runners/vllm_forge_qwen_embedding_runner.py
@@ -2,8 +2,9 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
+import os
+
 import vllm
-from config.settings import SupportedModels
 from domain.embedding_response import EmbeddingResponse
 from domain.text_embedding_request import TextEmbeddingRequest
 from transformers import AutoTokenizer
@@ -17,34 +18,51 @@ class VLLMForgeEmbeddingQwenRunner(BaseDeviceRunner):
         self.num_tokens_in_batch = 0
         self.dimensions_in_batch = None
 
+    @property
+    def model_name(self) -> str:
+        return self.settings.vllm.model
+
     @log_execution_time("Model warmup")
     async def warmup(self) -> bool:
-        self.logger.info(f"Device {self.device_id}: Loading model...")
+        model_name = self.model_name
+        self.logger.info(f"Device {self.device_id}: Loading model {model_name}...")
 
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            SupportedModels.QWEN_3_EMBEDDING_4B.value
-        )
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+        # Production knobs validated standalone in tt-xla (mirrors the forge LLM
+        # runners): opt>=1 for meaningful max_model_len, trace for decode-graph
+        # replay, bfp_bf8 weights (faster than bf16, halves weight DRAM traffic).
+        optimization_level = int(os.getenv("OPTIMIZATION_LEVEL", "1"))
+        enable_trace = os.getenv("ENABLE_TRACE", "true").lower() == "true"
 
         prompts = [
             "The capital of France is Paris",
         ]
+        additional_config = {
+            "enable_const_eval": False,
+            "batch_size": self.settings.max_batch_size,
+            "min_context_len": self.settings.vllm.min_context_length,
+            "experimental_weight_dtype": "bfp_bf8",
+            "optimization_level": optimization_level,
+            "enable_trace": enable_trace,
+        }
         llm_args = {
-            "model": SupportedModels.QWEN_3_EMBEDDING_4B.value,
+            "model": model_name,
             "dtype": "bfloat16",
             "disable_sliding_window": True,
             "enable_prefix_caching": False,
             "max_model_len": self.settings.vllm.max_model_length,
             "max_num_batched_tokens": self.settings.vllm.max_num_batched_tokens,
             "max_num_seqs": self.settings.vllm.max_num_seqs,
-            "additional_config": {
-                "enable_const_eval": False,
-                "batch_size": self.settings.max_batch_size,
-                "min_context_len": self.settings.vllm.min_context_length,
-            },
-            "hf_overrides": {
-                "is_matryoshka": True,
-            },
+            "additional_config": additional_config,
         }
+        # Matryoshka (variable output dimensions) is Qwen3-Embedding-specific;
+        # bge-m3 does not support it.
+        if "Qwen3-Embedding" in model_name:
+            llm_args["hf_overrides"] = {"is_matryoshka": True}
+        self.logger.info(
+            f"Device {self.device_id}: additional_config={additional_config}"
+        )
         self.llm = vllm.LLM(**llm_args)
 
         self.llm.embed(prompts)
@@ -72,7 +90,7 @@ class VLLMForgeEmbeddingQwenRunner(BaseDeviceRunner):
             self.num_tokens_in_batch + num_tokens
             > self.settings.vllm.max_num_batched_tokens
             or request.dimensions != self.dimensions_in_batch
-            or request.model != SupportedModels.QWEN_3_EMBEDDING_4B.value
+            or request.model != self.model_name
             or (batch is not None and request.model != batch[0].model)
         ):
             return False
@@ -87,7 +105,7 @@ class VLLMForgeEmbeddingQwenRunner(BaseDeviceRunner):
 
         # if only one request in batch, validate and set dimensions
         if self.num_tokens_in_batch == 0:
-            if requests[0].model != SupportedModels.QWEN_3_EMBEDDING_4B.value:
+            if requests[0].model != self.model_name:
                 raise ValueError(
                     f"Model {requests[0].model} is not supported by VLLMForgeEmbeddingQwenRunner"
                 )

--- a/workflows/model_specs/dev/embedding.yaml
+++ b/workflows/model_specs/dev/embedding.yaml
@@ -213,3 +213,58 @@ templates:
         VLLM__MAX_NUM_SEQS: "1"
         MAX_BATCH_SIZE: "1"
         DEFAULT_THROTTLE_LEVEL: "0"
+    - device: BLACKHOLE_GALAXY
+      max_concurrency: 32
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+      env_vars:
+        VLLM__MAX_NUM_BATCHED_TOKENS: "128"
+        VLLM__MAX_MODEL_LENGTH: "128"
+        VLLM__MIN_CONTEXT_LENGTH: "32"
+        VLLM__MAX_NUM_SEQS: "1"
+        MAX_BATCH_SIZE: "1"
+        DEFAULT_THROTTLE_LEVEL: "0"
+        TT_METAL_INSPECTOR_RPC: "0"
+
+- weights:
+    - Qwen/Qwen3-Embedding-0.6B
+  impl: forge_vllm_plugin
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: EMBEDDING
+  inference_engine: FORGE
+  device_model_specs:
+    - device: BLACKHOLE_GALAXY
+      max_concurrency: 32
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+      env_vars:
+        VLLM__MAX_NUM_BATCHED_TOKENS: "128"
+        VLLM__MAX_MODEL_LENGTH: "128"
+        VLLM__MIN_CONTEXT_LENGTH: "32"
+        VLLM__MAX_NUM_SEQS: "1"
+        MAX_BATCH_SIZE: "1"
+        DEFAULT_THROTTLE_LEVEL: "0"
+        TT_METAL_INSPECTOR_RPC: "0"
+
+- weights:
+    - BAAI/bge-m3
+  impl: forge_vllm_plugin
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: EMBEDDING
+  inference_engine: FORGE
+  device_model_specs:
+    - device: BLACKHOLE_GALAXY
+      max_concurrency: 32
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+      env_vars:
+        MODEL_RUNNER: "vllmforge_bge_m3"
+        VLLM__MAX_NUM_BATCHED_TOKENS: "512"
+        VLLM__MAX_MODEL_LENGTH: "512"
+        VLLM__MIN_CONTEXT_LENGTH: "32"
+        VLLM__MAX_NUM_SEQS: "1"
+        MAX_BATCH_SIZE: "1"
+        DEFAULT_THROTTLE_LEVEL: "0"
+        TT_METAL_INSPECTOR_RPC: "0"

--- a/workflows/model_specs/prod/embedding.yaml
+++ b/workflows/model_specs/prod/embedding.yaml
@@ -167,3 +167,72 @@ templates:
         VLLM__MAX_NUM_SEQS: "1"
         MAX_BATCH_SIZE: "1"
         DEFAULT_THROTTLE_LEVEL: "0"
+    - device: BLACKHOLE_GALAXY
+      # Data-parallel across the BH galaxy (32x P150): 32 single-chip workers.
+      # Config validated standalone in tt-xla.
+      max_concurrency: 32
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+      env_vars:
+        VLLM__MAX_NUM_BATCHED_TOKENS: "128"
+        VLLM__MAX_MODEL_LENGTH: "128"
+        VLLM__MIN_CONTEXT_LENGTH: "32"
+        VLLM__MAX_NUM_SEQS: "1"
+        MAX_BATCH_SIZE: "1"
+        DEFAULT_THROTTLE_LEVEL: "0"
+        # Disable Inspector RPC to prevent port conflicts with 32 concurrent workers
+        TT_METAL_INSPECTOR_RPC: "0"
+
+- weights:
+    - Qwen/Qwen3-Embedding-0.6B
+  tt_metal_commit: "2496be4"
+  version: "0.12.0"
+  impl: forge_vllm_plugin
+  min_disk_gb: 15
+  min_ram_gb: 6
+  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673"
+  model_type: EMBEDDING
+  inference_engine: FORGE
+  device_model_specs:
+    - device: BLACKHOLE_GALAXY
+      # Data-parallel across the BH galaxy (32x P150): 32 single-chip workers.
+      max_concurrency: 32
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+      env_vars:
+        VLLM__MAX_NUM_BATCHED_TOKENS: "128"
+        VLLM__MAX_MODEL_LENGTH: "128"
+        VLLM__MIN_CONTEXT_LENGTH: "32"
+        VLLM__MAX_NUM_SEQS: "1"
+        MAX_BATCH_SIZE: "1"
+        DEFAULT_THROTTLE_LEVEL: "0"
+        # Disable Inspector RPC to prevent port conflicts with 32 concurrent workers
+        TT_METAL_INSPECTOR_RPC: "0"
+
+- weights:
+    - BAAI/bge-m3
+  tt_metal_commit: "2496be4"
+  version: "0.12.0"
+  impl: forge_vllm_plugin
+  min_disk_gb: 15
+  min_ram_gb: 6
+  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673"
+  model_type: EMBEDDING
+  inference_engine: FORGE
+  device_model_specs:
+    - device: BLACKHOLE_GALAXY
+      # Forge data-parallel bge-m3 -- distinct from the MEDIA bge-m3 template.
+      # Selects its runner explicitly via MODEL_RUNNER (shared model name).
+      max_concurrency: 32
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+      env_vars:
+        MODEL_RUNNER: "vllmforge_bge_m3"
+        VLLM__MAX_NUM_BATCHED_TOKENS: "512"
+        VLLM__MAX_MODEL_LENGTH: "512"
+        VLLM__MIN_CONTEXT_LENGTH: "32"
+        VLLM__MAX_NUM_SEQS: "1"
+        MAX_BATCH_SIZE: "1"
+        DEFAULT_THROTTLE_LEVEL: "0"
+        # Disable Inspector RPC to prevent port conflicts with 32 concurrent workers
+        TT_METAL_INSPECTOR_RPC: "0"


### PR DESCRIPTION
### Summary
Wires three forge-vllm-plugin embedding models to serve data-parallel on BH galaxy. Qwen 0.6B is new, 4B gains a BH-galaxy path, bge-m3 gets a FORGE path alongside MEDIA. 8 files: constants/runner/fabric + dev+prod embedding.yaml + CI config + eval + perf. CI blocker on tt-shield (fixed here, needs green run), bh galaxy runners have not been able to pick up any jobs. We are tracking the issue in https://github.com/tenstorrent/tt-shield/issues/925

### Current status: 
- Wiring done + Tested locally:
    - config resolves for all three
    - JSON/YAML/schema valid
    - runs on a bh-galaxy machine in <1 min.
- CI pending green needs CI blocker to be resolved.