### PR TITLE
Add model naming

### DIFF
--- a/tests/test_model_naming.py
+++ b/tests/test_model_naming.py
@@ -1,0 +1,405 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+"""Tests for the model identity <-> name token contract.
+
+The contract is shared with tt-shield, which builds the CI artifact and job
+names this repo parses, so these tests are the executable definition of it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from utils.model_naming import (
+    MODEL_ID_SEP,
+    ci_job_matches_device,
+    ci_job_name,
+    device_from_ci_job_name,
+    is_artifact_name_safe,
+    model_name_variants,
+    slugify_model_id,
+    slugify_name_parts,
+    split_workflow_logs_artifact_name,
+    unslugify_model_id,
+    workflow_logs_artifact_prefix,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "utils" / "model_naming.py"
+CI_CONFIG = REPO_ROOT / ".github" / "workflows" / "models-ci-config.json"
+
+# Every shape a real model id takes: org-prefixed, bare, and carrying the
+# single underscores that force `__` as the separator.
+MODEL_IDS = [
+    "Qwen/Qwen3-32B",
+    "meta-llama/Llama-3.1-8B-Instruct",
+    "deepseek-ai/DeepSeek-R1-0528",
+    "microsoft/phi-1_5",
+    "resnet-50",
+    "yolox_nano",
+]
+
+
+class TestSlugifyRoundTrip:
+    @pytest.mark.parametrize("model_id", MODEL_IDS)
+    def test_round_trips_exactly(self, model_id):
+        assert unslugify_model_id(slugify_model_id(model_id)) == model_id
+
+    @pytest.mark.parametrize("model_id", MODEL_IDS)
+    def test_slug_is_a_single_path_component(self, model_id):
+        slug = slugify_model_id(model_id)
+        assert "/" not in slug
+        assert len(Path(slug).parts) == 1
+
+    @pytest.mark.parametrize("model_id", MODEL_IDS)
+    def test_slug_is_a_legal_artifact_name(self, model_id):
+        assert is_artifact_name_safe(slugify_model_id(model_id))
+
+    def test_org_prefix_is_escaped_not_stripped(self):
+        # Two orgs publishing the same basename must stay distinguishable.
+        assert slugify_model_id("Qwen/Qwen3-32B") == f"Qwen{MODEL_ID_SEP}Qwen3-32B"
+        assert slugify_model_id("a/model") != slugify_model_id("b/model")
+
+    def test_single_underscore_survives(self):
+        # The whole reason the separator is "__": a single "_" is ambiguous.
+        assert unslugify_model_id(slugify_model_id("microsoft/phi-1_5")) == (
+            "microsoft/phi-1_5"
+        )
+
+    def test_bare_ids_are_untouched_in_both_directions(self):
+        assert slugify_model_id("resnet-50") == "resnet-50"
+        assert unslugify_model_id("resnet-50") == "resnet-50"
+
+    def test_empty_is_empty(self):
+        assert slugify_model_id("") == ""
+        assert unslugify_model_id("") == ""
+
+    def test_windows_separator_and_space(self):
+        assert slugify_model_id("Qwen\\Qwen3-32B") == "Qwen__Qwen3-32B"
+        assert slugify_model_id("some model") == "some_model"
+
+    def test_all_ci_config_ids_round_trip(self):
+        """The contract must hold for every model the CI actually runs."""
+        models = json.loads(CI_CONFIG.read_text())["models"]
+        assert models, "models-ci-config.json has no models"
+        for model_id in models:
+            slug = slugify_model_id(model_id)
+            assert is_artifact_name_safe(slug), model_id
+            assert unslugify_model_id(slug) == model_id, model_id
+
+
+class TestSlugifyNameParts:
+    def test_joins_and_escapes(self):
+        assert slugify_name_parts("Qwen/Qwen3-32B", "p150") == "Qwen__Qwen3-32B_p150"
+
+    def test_drops_empty_parts_without_leaving_a_separator(self):
+        assert slugify_name_parts("Qwen/Qwen3-32B", None) == "Qwen__Qwen3-32B"
+        assert slugify_name_parts("", "p150") == "p150"
+        assert slugify_name_parts(None, "") == ""
+
+
+class TestModelNameVariants:
+    def test_canonical_form_comes_first(self):
+        assert model_name_variants("Qwen/Qwen3-32B")[0] == "Qwen__Qwen3-32B"
+
+    def test_covers_the_forms_producers_have_actually_used(self):
+        variants = model_name_variants("Qwen/Qwen3-32B")
+        assert set(variants) == {
+            "Qwen__Qwen3-32B",  # canonical
+            "Qwen/Qwen3-32B",  # unescaped (job names)
+            "Qwen_Qwen3-32B",  # tt-shield's old single-underscore step
+            "Qwen3-32B",  # pre-HF-prefix model id
+        }
+
+    def test_deduplicates_for_bare_ids(self):
+        assert model_name_variants("resnet-50") == ("resnet-50",)
+
+    def test_empty(self):
+        assert model_name_variants("") == ()
+
+
+class TestWorkflowLogsArtifactName:
+    def test_prefix_ends_with_a_boundary(self):
+        # Without the trailing "_", "foo" would also match "foo-turbo".
+        prefix = workflow_logs_artifact_prefix("release", "Qwen/Qwen3-32B")
+        assert prefix == "workflow_logs_release_Qwen__Qwen3-32B_"
+
+    def test_splits_canonical_name(self):
+        assert split_workflow_logs_artifact_name(
+            "workflow_logs_release_Qwen__Qwen3-32B_p150_default",
+            "release",
+            "Qwen/Qwen3-32B",
+        ) == ("p150", "default")
+
+    def test_runner_label_may_contain_underscores(self):
+        assert split_workflow_logs_artifact_name(
+            "workflow_logs_release_Qwen__Qwen3-32B_tt_beta_p150_vllm",
+            "release",
+            "Qwen/Qwen3-32B",
+        ) == ("tt_beta_p150", "vllm")
+
+    def test_prefix_sharing_models_are_unambiguous(self):
+        name = "workflow_logs_release_org__foo-turbo_p150_default"
+        assert split_workflow_logs_artifact_name(name, "release", "org/foo") is None
+        assert split_workflow_logs_artifact_name(name, "release", "org/foo-turbo") == (
+            "p150",
+            "default",
+        )
+
+    def test_rejects_other_models_and_other_workflows(self):
+        name = "workflow_logs_release_Qwen__Qwen3-32B_p150_default"
+        assert split_workflow_logs_artifact_name(name, "release", "org/other") is None
+        assert (
+            split_workflow_logs_artifact_name(name, "benchmarks", "Qwen/Qwen3-32B")
+            is None
+        )
+
+    def test_tolerates_producers_that_predate_the_contract(self):
+        """A bundle still resolves if it was named the old way."""
+        for name in (
+            "workflow_logs_release_Qwen_Qwen3-32B_p150_default",  # single "_"
+            "workflow_logs_release_Qwen3-32B_p150_default",  # no org prefix
+        ):
+            assert split_workflow_logs_artifact_name(
+                name, "release", "Qwen/Qwen3-32B"
+            ) == ("p150", "default")
+
+    def test_missing_suffix_is_not_a_match(self):
+        assert (
+            split_workflow_logs_artifact_name(
+                "workflow_logs_release_Qwen__Qwen3-32B_p150",
+                "release",
+                "Qwen/Qwen3-32B",
+            )
+            is None
+        )
+        assert (
+            split_workflow_logs_artifact_name("", "release", "Qwen/Qwen3-32B") is None
+        )
+
+
+class TestCiJobName:
+    def test_build_and_parse_round_trip(self):
+        name = ci_job_name("release", "Qwen/Qwen3-32B", "p150", "P150")
+        assert name == "run-release-Qwen__Qwen3-32B-p150-P150"
+        assert device_from_ci_job_name(name, "release", "Qwen/Qwen3-32B", "p150") == (
+            "P150"
+        )
+
+    def test_reusable_workflow_prefix_is_ignored(self):
+        name = "call-release / run-release-Qwen__Qwen3-32B-p150-P150"
+        assert (
+            device_from_ci_job_name(name, "release", "Qwen/Qwen3-32B", "p150") == "P150"
+        )
+
+    def test_unescaped_model_id_still_resolves(self):
+        """The bug this contract exists to prevent.
+
+        A producer that interpolates the raw id puts a "/" in the job name.
+        Stripping the caller prefix by splitting on "/" would eat the org
+        prefix along with it and lose the device.
+        """
+        name = "call-release / run-release-Qwen/Qwen3-32B-p150-P150"
+        assert (
+            device_from_ci_job_name(name, "release", "Qwen/Qwen3-32B", "p150") == "P150"
+        )
+
+    def test_trailing_punctuation_is_trimmed(self):
+        name = "run-tests (run-release-Qwen__Qwen3-32B-p150-P150)"
+        assert (
+            device_from_ci_job_name(name, "release", "Qwen/Qwen3-32B", "p150") == "P150"
+        )
+
+    def test_wrong_model_runner_or_workflow_returns_none(self):
+        name = "run-release-Qwen__Qwen3-32B-p150-P150"
+        assert device_from_ci_job_name(name, "release", "org/other", "p150") is None
+        assert (
+            device_from_ci_job_name(name, "release", "Qwen/Qwen3-32B", "n300") is None
+        )
+        assert (
+            device_from_ci_job_name(name, "benchmarks", "Qwen/Qwen3-32B", "p150")
+            is None
+        )
+        assert device_from_ci_job_name("", "release", "Qwen/Qwen3-32B", "p150") is None
+
+    def test_missing_device_returns_none(self):
+        assert (
+            device_from_ci_job_name(
+                "run-release-Qwen__Qwen3-32B-p150-", "release", "Qwen/Qwen3-32B", "p150"
+            )
+            is None
+        )
+
+
+class TestCiJobMatchesDevice:
+    """Matching with the device known and the runner label not."""
+
+    def test_matches_canonical_job_name(self):
+        name = ci_job_name("release", "Qwen/Qwen3-32B", "p150", "P150")
+        assert ci_job_matches_device(name, "release", "Qwen/Qwen3-32B", "P150")
+
+    def test_runner_label_containing_hyphens(self):
+        # The real shape from tt-shield run 6035.
+        name = (
+            "run-tests / run-release-meta-llama__Llama-3.3-70B-Instruct-bh-qb-ge-p300x2"
+        )
+        assert ci_job_matches_device(
+            name, "release", "meta-llama/Llama-3.3-70B-Instruct", "P300X2"
+        )
+
+    def test_device_comparison_is_case_insensitive(self):
+        name = "run-release-Qwen__Qwen3-32B-p150-p150"
+        assert ci_job_matches_device(name, "release", "Qwen/Qwen3-32B", "P150")
+        assert ci_job_matches_device(name, "release", "Qwen/Qwen3-32B", "p150")
+
+    def test_tolerates_producers_that_predate_the_contract(self):
+        for token in ("Qwen/Qwen3-32B", "Qwen_Qwen3-32B", "Qwen3-32B"):
+            name = f"run-tests / run-release-{token}-p150-p150"
+            assert ci_job_matches_device(name, "release", "Qwen/Qwen3-32B", "P150"), (
+                token
+            )
+
+    def test_a_missing_runner_label_is_not_a_match(self):
+        assert not ci_job_matches_device(
+            "run-release-Qwen__Qwen3-32B-p150", "release", "Qwen/Qwen3-32B", "p150"
+        )
+
+
+class TestCiJobPrefixSiblings:
+    """``-`` separates fields and also occurs inside model names, so a sibling's
+    job is only attributable once the other models in scope are known."""
+
+    SIBLING_JOB = "run-release-Qwen__Qwen3-32B-FP8-p150-P150"
+    OWN_JOB = "run-release-Qwen__Qwen3-32B-p150-P150"
+
+    def test_sibling_job_is_claimed_when_scope_is_unknown(self):
+        # Documents the residual ambiguity: with nothing to compare against,
+        # the shorter model still explains the name.
+        assert ci_job_matches_device(
+            self.SIBLING_JOB, "release", "Qwen/Qwen3-32B", "P150"
+        )
+
+    def test_sibling_job_is_left_to_the_sibling(self):
+        assert not ci_job_matches_device(
+            self.SIBLING_JOB,
+            "release",
+            "Qwen/Qwen3-32B",
+            "P150",
+            ["Qwen/Qwen3-32B-FP8"],
+        )
+
+    def test_sibling_still_claims_its_own_job(self):
+        assert ci_job_matches_device(
+            self.SIBLING_JOB,
+            "release",
+            "Qwen/Qwen3-32B-FP8",
+            "P150",
+            ["Qwen/Qwen3-32B"],
+        )
+
+    def test_own_job_survives_a_longer_sibling_in_scope(self):
+        assert ci_job_matches_device(
+            self.OWN_JOB, "release", "Qwen/Qwen3-32B", "P150", ["Qwen/Qwen3-32B-FP8"]
+        )
+
+    def test_self_in_scope_is_ignored(self):
+        assert ci_job_matches_device(
+            self.OWN_JOB, "release", "Qwen/Qwen3-32B", "P150", ["Qwen/Qwen3-32B"]
+        )
+
+    def test_unrelated_models_in_scope_do_not_interfere(self):
+        assert ci_job_matches_device(
+            self.OWN_JOB,
+            "release",
+            "Qwen/Qwen3-32B",
+            "P150",
+            ["meta-llama/Llama-3.1-8B-Instruct", "openai/whisper-large-v3"],
+        )
+
+    def test_device_must_be_a_whole_trailing_token(self):
+        name = "run-release-Qwen__Qwen3-32B-p150-p300x2"
+        assert not ci_job_matches_device(name, "release", "Qwen/Qwen3-32B", "x2")
+
+    def test_wrong_model_device_or_workflow_returns_false(self):
+        name = "run-release-Qwen__Qwen3-32B-p150-P150"
+        assert not ci_job_matches_device(name, "release", "org/other", "P150")
+        assert not ci_job_matches_device(name, "release", "Qwen/Qwen3-32B", "N300")
+        assert not ci_job_matches_device(name, "benchmarks", "Qwen/Qwen3-32B", "P150")
+        assert not ci_job_matches_device("", "release", "Qwen/Qwen3-32B", "P150")
+        assert not ci_job_matches_device(name, "release", "Qwen/Qwen3-32B", "")
+
+    def test_trailing_punctuation_is_trimmed(self):
+        name = "run-tests (run-release-Qwen__Qwen3-32B-p150-P150)"
+        assert ci_job_matches_device(name, "release", "Qwen/Qwen3-32B", "P150")
+
+    def test_agrees_with_device_from_ci_job_name_on_every_model(self):
+        # The two directions must not disagree.
+        for model_id in MODEL_IDS:
+            name = ci_job_name("release", model_id, "some-runner", "P300X2")
+            device = device_from_ci_job_name(name, "release", model_id, "some-runner")
+            assert device == "P300X2"
+            assert ci_job_matches_device(name, "release", model_id, device)
+
+
+class TestStandaloneUsability:
+    """tt-shield consumes this from a plain checkout, from shell, with no
+    ``pip install`` and no ``PYTHONPATH``. Keep both of those working."""
+
+    def test_module_imports_nothing_from_this_repo(self):
+        source = MODULE_PATH.read_text()
+        repo_packages = (
+            "workflows",
+            "workflow_module",
+            "report_module",
+            "llm_module",
+            "test_module",
+            "utils.",
+        )
+        for line in source.splitlines():
+            if line.startswith(("import ", "from ")):
+                assert not any(pkg in line for pkg in repo_packages), line
+
+    def test_runs_as_a_script_by_path(self, tmp_path):
+        # cwd deliberately outside the repo: no implicit package resolution.
+        out = subprocess.run(
+            [sys.executable, str(MODULE_PATH), "slugify", "Qwen/Qwen3-32B"],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+        )
+        assert out.returncode == 0, out.stderr
+        assert out.stdout.strip() == "Qwen__Qwen3-32B"
+
+    @pytest.mark.parametrize(
+        "args,expected",
+        [
+            (["slugify", "Qwen/Qwen3-32B"], "Qwen__Qwen3-32B"),
+            (["unslugify", "Qwen__Qwen3-32B"], "Qwen/Qwen3-32B"),
+            (
+                ["artifact-prefix", "release", "Qwen/Qwen3-32B"],
+                "workflow_logs_release_Qwen__Qwen3-32B_",
+            ),
+            (
+                ["job-name", "release", "Qwen/Qwen3-32B", "p150", "P150"],
+                "run-release-Qwen__Qwen3-32B-p150-P150",
+            ),
+        ],
+    )
+    def test_cli_commands(self, args, expected, capsys):
+        from utils.model_naming import main
+
+        assert main(args) == 0
+        assert capsys.readouterr().out.strip() == expected
+
+    def test_cli_rejects_bad_usage(self, capsys):
+        from utils.model_naming import main
+
+        assert main(["nope", "x"]) == 2
+        assert main(["slugify"]) == 2
+        assert main([]) == 0  # help

--- a/utils/model_naming.py
+++ b/utils/model_naming.py
@@ -1,0 +1,371 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+"""Canonical translation between a model *identity* and a model *name token*.
+
+A model has two distinct representations and they must not be confused:
+
+===============  ===================  =====================================
+representation   example              where it is used
+===============  ===================  =====================================
+data identity    ``Qwen/Qwen3-32B``   ``models-ci-config.json`` keys, report
+                                      ``metadata``, HTTP ``model`` params,
+                                      performance-target lookup, DB columns.
+                                      Used verbatim -- never escaped.
+name token       ``Qwen__Qwen3-32B``  filenames, directory names, GitHub
+                                      artifact names, CI job names. Escaped.
+===============  ===================  =====================================
+
+Since the model id became the full HF repo id, every name built from a model
+has to escape the org separator, and everything that reads such a name has to
+undo the escape. Those two sides live in *different repositories* -- tt-shield
+builds the artifact and job names, this repo parses them -- so the escape is a
+cross-repo contract, and both directions belong in one place.
+
+This module is that place. It is stdlib-only and imports nothing else from this
+repo, so it is importable from any package here and runnable as a standalone script from a
+plain checkout, with no ``pip install`` and no ``PYTHONPATH`` setup::
+
+    python tt-inference-server/utils/model_naming.py slugify "Qwen/Qwen3-32B"
+
+A consumer that needs the identity back should prefer reading it from data --
+report ``metadata.model_repo`` -- over reversing a name. Reverse a name only
+when the name is all you have.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Iterable, Optional, Tuple
+
+__all__ = [
+    "MODEL_ID_SEP",
+    "ARTIFACT_FORBIDDEN_CHARS",
+    "WORKFLOW_LOGS_PREFIX",
+    "slugify_model_id",
+    "unslugify_model_id",
+    "slugify_name_parts",
+    "model_name_variants",
+    "is_artifact_name_safe",
+    "workflow_logs_artifact_prefix",
+    "split_workflow_logs_artifact_name",
+    "ci_job_name",
+    "device_from_ci_job_name",
+    "ci_job_matches_device",
+]
+
+#: Escape sequence standing in for the HF org separator inside a name token.
+MODEL_ID_SEP = "__"
+
+#: Characters ``actions/upload-artifact`` rejects in an artifact name.
+ARTIFACT_FORBIDDEN_CHARS = '/\\:<>|*?"\r\n'
+
+#: Leading component of the per-run log bundle artifact name, produced by
+#: tt-shield's ``workflow_run-tests-with-inference-server.yml``.
+WORKFLOW_LOGS_PREFIX = "workflow_logs"
+
+
+# ---------------------------------------------------------------------------
+# core escape -- both directions
+# ---------------------------------------------------------------------------
+def slugify_model_id(model_id: str) -> str:
+    """Escape a model identity for use in a filename, path or artifact name.
+
+    Replaces the HF org separator with ``__`` and whitespace with ``_``,
+    preserving the org prefix. Safe for POSIX paths and for
+    ``actions/upload-artifact``.
+
+    >>> slugify_model_id("Qwen/Qwen3-32B")
+    'Qwen__Qwen3-32B'
+    >>> slugify_model_id("resnet-50")
+    'resnet-50'
+    """
+    if not model_id:
+        return ""
+    return (
+        model_id.replace("/", MODEL_ID_SEP)
+        .replace("\\", MODEL_ID_SEP)
+        .replace(" ", "_")
+    )
+
+
+def unslugify_model_id(slug: str) -> str:
+    """Recover a model identity from a token produced by :func:`slugify_model_id`.
+
+    Ids that carry no org prefix are returned unchanged, so this is safe to
+    apply to a token whose provenance is unknown.
+
+    >>> unslugify_model_id("Qwen__Qwen3-32B")
+    'Qwen/Qwen3-32B'
+    >>> unslugify_model_id("microsoft__phi-1_5")
+    'microsoft/phi-1_5'
+    >>> unslugify_model_id("resnet-50")
+    'resnet-50'
+    """
+    if not slug:
+        return ""
+    return slug.replace(MODEL_ID_SEP, "/")
+
+
+def slugify_name_parts(*parts: Optional[str]) -> str:
+    """Join non-empty ``parts`` with ``_`` and escape the result.
+
+    The shape used for composite names -- report ids and report block ids
+    (``<model>_<device>``). Empty and ``None`` parts are dropped, so a missing
+    device does not leave a dangling separator.
+
+    >>> slugify_name_parts("Qwen/Qwen3-32B", "p150")
+    'Qwen__Qwen3-32B_p150'
+    >>> slugify_name_parts("Qwen/Qwen3-32B", None)
+    'Qwen__Qwen3-32B'
+    """
+    kept = [p for p in parts if p]
+    if not kept:
+        return ""
+    return slugify_model_id("_".join(kept))
+
+
+def model_name_variants(model_id: str) -> Tuple[str, ...]:
+    """Every token a producer may plausibly have used for ``model_id``.
+
+    Ordered most- to least-canonical and de-duplicated. Readers match against
+    this instead of the canonical token alone, so a name survives producers
+    that have not adopted this module yet:
+
+    1. ``Qwen__Qwen3-32B`` -- canonical.
+    2. ``Qwen/Qwen3-32B``  -- unescaped. Cannot occur in an artifact name
+       (GitHub rejects ``/``) but does occur in job names, which allow it.
+    3. ``Qwen_Qwen3-32B``  -- the single-underscore escape tt-shield's shell
+       step used before this contract existed.
+    4. ``Qwen3-32B``       -- the bare name model ids had before they became
+       full HF repo ids. Last, because it is the only ambiguous one: two orgs
+       can share a basename. No two models in ``models-ci-config.json``
+       currently do.
+    """
+    if not model_id:
+        return ()
+    variants = [
+        slugify_model_id(model_id),
+        model_id,
+        model_id.replace("/", "_").replace("\\", "_").replace(" ", "_"),
+        model_id.rsplit("/", 1)[-1],
+    ]
+    seen = set()
+    return tuple(v for v in variants if v and not (v in seen or seen.add(v)))
+
+
+def is_artifact_name_safe(name: str) -> bool:
+    """True if ``name`` is acceptable to ``actions/upload-artifact``.
+
+    For asserting on the producing side, where the alternative is a job that
+    runs to completion and then fails on upload.
+    """
+    return bool(name) and not any(c in name for c in ARTIFACT_FORBIDDEN_CHARS)
+
+
+# ---------------------------------------------------------------------------
+# CI name grammars -- shared with tt-shield
+# ---------------------------------------------------------------------------
+def workflow_logs_artifact_prefix(workflow: str, model_id: str) -> str:
+    """``workflow_logs_<workflow>_<model>_`` -- the log bundle name prefix.
+
+    The trailing ``_`` is part of the prefix so that models sharing a prefix
+    (``foo`` vs ``foo-turbo``) stay unambiguous when filtering by
+    ``str.startswith``.
+    """
+    return f"{WORKFLOW_LOGS_PREFIX}_{workflow}_{slugify_model_id(model_id)}_"
+
+
+def split_workflow_logs_artifact_name(
+    name: str, workflow: str, model_id: str
+) -> Optional[Tuple[str, str]]:
+    """Split a log bundle artifact name into ``(runner, suffix)``.
+
+    Full grammar, as produced by tt-shield::
+
+        workflow_logs_<workflow>_<model>_<runner_label>_<impl-or-default>
+
+    Returns ``None`` if ``name`` is not this model's bundle. ``model_id`` and
+    ``workflow`` are required because the grammar is not self-delimiting: the
+    model token contains ``__`` and the runner label may contain ``_``, so the
+    boundaries are only recoverable when the model is known. The suffix is
+    taken from the last ``_``, leaving anything before it to the runner label.
+
+    >>> split_workflow_logs_artifact_name(
+    ...     "workflow_logs_release_Qwen__Qwen3-32B_p150_default",
+    ...     "release", "Qwen/Qwen3-32B")
+    ('p150', 'default')
+    """
+    if not name:
+        return None
+    for token in model_name_variants(model_id):
+        prefix = f"{WORKFLOW_LOGS_PREFIX}_{workflow}_{token}_"
+        if not name.startswith(prefix):
+            continue
+        rest = name[len(prefix) :]
+        if "_" not in rest:
+            return None
+        runner, suffix = rest.rsplit("_", 1)
+        return (runner, suffix) if runner else None
+    return None
+
+
+def ci_job_name(
+    workflow: str, model_id: str, runner_label: str, runner_type: str
+) -> str:
+    """``run-<workflow>-<model>-<runner_label>-<runner_type>``.
+
+    The per-matrix-entry job name. ``runner_type`` is the device, which is why
+    this name is the only place the device of a (model, runner) pair can be
+    recovered from -- it is absent from the artifact name.
+    """
+    return f"run-{workflow}-{slugify_model_id(model_id)}-{runner_label}-{runner_type}"
+
+
+def device_from_ci_job_name(
+    job_name: str, workflow: str, model_id: str, runner_label: str
+) -> Optional[str]:
+    """Recover the device from a job name built by :func:`ci_job_name`.
+
+    ``None`` if ``job_name`` is not this (model, runner) pair's job.
+
+    The GitHub jobs API prefixes a reusable workflow's job with its caller
+    (``"caller job / run-release-..."``), so the marker is searched for rather
+    than anchored at the start. It is deliberately *not* found by splitting on
+    ``/`` first: an unescaped model id contains ``/``, and splitting would eat
+    the org prefix along with the caller prefix.
+
+    >>> device_from_ci_job_name(
+    ...     "call-release / run-release-Qwen__Qwen3-32B-p150-P150",
+    ...     "release", "Qwen/Qwen3-32B", "p150")
+    'P150'
+    """
+    if not job_name:
+        return None
+    for token in model_name_variants(model_id):
+        marker = f"run-{workflow}-{token}-{runner_label}-"
+        idx = job_name.find(marker)
+        if idx == -1:
+            continue
+        tail = job_name[idx + len(marker) :].strip()
+        if not tail:
+            continue
+        # A device token has no spaces; trim the punctuation a wrapping job
+        # name description can leave behind ("..., P150)").
+        return tail.split()[0].strip(",)")
+    return None
+
+
+def _longest_matching_token(
+    job_name: str, workflow: str, model_id: str, device_suffix: str
+) -> Optional[int]:
+    """Length of the longest model token that explains ``job_name``.
+
+    ``None`` when no spelling of ``model_id`` matches. The length is what makes
+    :func:`ci_job_matches_device` able to rank two models against one name.
+    """
+    best: Optional[int] = None
+    for token in model_name_variants(model_id):
+        marker = f"run-{workflow}-{token}-"
+        idx = job_name.find(marker)
+        if idx == -1:
+            continue
+        tail = job_name[idx + len(marker) :].strip().rstrip(",)")
+        if tail.lower().endswith(device_suffix) and (best is None or len(token) > best):
+            best = len(token)
+    return best
+
+
+def ci_job_matches_device(
+    job_name: str,
+    workflow: str,
+    model_id: str,
+    device: str,
+    other_model_ids: Iterable[str] = (),
+) -> bool:
+    """True if ``job_name`` is the job for this ``(model, device)`` pair.
+
+    :func:`device_from_ci_job_name` run backwards, for a caller that knows the
+    device but not the runner label -- ``models-ci-config.json`` records the
+    device and leaves the runner to tt-shield. Anchoring on both ends of the
+    label leaves it unconstrained (``bh-qb-ge``); the device compares
+    case-insensitively since callers hold a ``DeviceTypes`` name.
+
+    Unlike the artifact grammar, this one separates fields with ``-``, which is
+    also the commonest character *inside* a model name, so a prefix sibling's
+    job is not distinguishable from this model's by string shape alone:
+    ``Qwen/Qwen3-32B`` and ``Qwen/Qwen3-32B-FP8`` both explain
+    ``run-release-Qwen__Qwen3-32B-FP8-p150-P150``. Pass the other models in
+    scope as ``other_model_ids`` and the longer explanation wins, so the
+    sibling's job is left to the sibling.
+
+    >>> ci_job_matches_device(
+    ...     "run-tests / run-release-meta-llama__Llama-3.3-70B-Instruct-bh-qb-ge-p300x2",
+    ...     "release", "meta-llama/Llama-3.3-70B-Instruct", "P300X2")
+    True
+    >>> ci_job_matches_device(
+    ...     "run-release-Qwen__Qwen3-32B-FP8-p150-P150",
+    ...     "release", "Qwen/Qwen3-32B", "P150", ["Qwen/Qwen3-32B-FP8"])
+    False
+    """
+    if not job_name or not device:
+        return False
+    # The leading "-" rejects a label-less name and "x2" vs "p300x2".
+    suffix = f"-{device}".lower()
+    own = _longest_matching_token(job_name, workflow, model_id, suffix)
+    if own is None:
+        return False
+    for other in other_model_ids:
+        if other == model_id:
+            continue
+        rival = _longest_matching_token(job_name, workflow, other, suffix)
+        if rival is not None and rival > own:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# CLI -- for producers that build names in shell (tt-shield's YAML steps)
+# ---------------------------------------------------------------------------
+_USAGE = """usage: model_naming.py <command> [args]
+
+  slugify <model_id>                            Qwen/Qwen3-32B -> Qwen__Qwen3-32B
+  unslugify <slug>                              Qwen__Qwen3-32B -> Qwen/Qwen3-32B
+  artifact-prefix <workflow> <model_id>         workflow_logs_<workflow>_<model>_
+  job-name <workflow> <model_id> <label> <type> run-<workflow>-<model>-<label>-<type>
+
+Writes the result to stdout, so a shell producer can do:
+
+  SLUG=$(python tt-inference-server/utils/model_naming.py slugify "$MODEL")
+"""
+
+_COMMANDS = {
+    "slugify": (1, lambda model: slugify_model_id(model)),
+    "unslugify": (1, lambda slug: unslugify_model_id(slug)),
+    "artifact-prefix": (2, workflow_logs_artifact_prefix),
+    "job-name": (4, ci_job_name),
+}
+
+
+def main(argv: Optional[list] = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args or args[0] in ("-h", "--help"):
+        sys.stdout.write(_USAGE)
+        return 0
+    command, rest = args[0], args[1:]
+    entry = _COMMANDS.get(command)
+    if entry is None:
+        sys.stderr.write(f"error: unknown command {command!r}\n\n{_USAGE}")
+        return 2
+    argc, fn = entry
+    if len(rest) != argc:
+        sys.stderr.write(
+            f"error: {command} takes {argc} argument(s), got {len(rest)}\n\n{_USAGE}"
+        )
+        return 2
+    sys.stdout.write(f"{fn(*rest)}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A model has two distinct representations and they must not be confused:
===============  ===================  =====================================
representation   example      
===============  ===================  =====================================
data identity    ``Qwen/Qwen3-32B``   
name token       ``Qwen__Qwen3-32B`` 
===============  ===================  =====================================
Since the model id became the full HF repo id, every name built from a model
has to escape the org separator, and everything that reads such a name has to
undo the escape. Those two sides live in *different repositories* -- tt-shield
builds the artifact and job names, this repo parses them -- so the escape is a
cross-repo contract, and both directions belong in one place.
