### PR TITLE
fix: stop client-input rejections from restarting video workers (#4811)

### DIFF
--- a/tt-media-server/device_workers/device_worker.py
+++ b/tt-media-server/device_workers/device_worker.py
@@ -10,6 +10,7 @@ from typing import Any
 from config.constants import SHUTDOWN_SIGNAL, CanaryProbeRequest
 from config.settings import settings
 from device_workers.worker_utils import initialize_device_worker
+from domain.errors import classify_worker_error
 from utils.logger import TTLogger
 
 
@@ -98,8 +99,20 @@ async def _continuous_fan_out(
             task_id = req._task_id
             exc = task.exception()
             if exc is not None:
+                # ``classify_worker_error`` keeps a client-input rejection on the
+                # queue as a ClientRequestError instance instead of flattening it
+                # into this f-string. The scheduler keys off the type to decide
+                # whether the failure counts against worker health (#4811).
                 error_queue.put(
-                    (worker_id, task_id, f"Worker {worker_id} execution error: {exc}")
+                    (
+                        worker_id,
+                        task_id,
+                        classify_worker_error(
+                            worker_id,
+                            exc,
+                            prefix=f"Worker {worker_id} execution error: ",
+                        ),
+                    )
                 )
                 continue
             result = task.result()
@@ -315,8 +328,11 @@ def device_worker(
             timeout_timer.cancel()
             error_msg = f"Worker {worker_id} execution error: {str(e)}"
             logger.error(error_msg)
+            payload = classify_worker_error(
+                worker_id, e, prefix=f"Worker {worker_id} execution error: "
+            )
             for request in requests:
-                error_queue.put((worker_id, request._task_id, error_msg))
+                error_queue.put((worker_id, request._task_id, payload))
             continue
 
         logger.debug(

--- a/tt-media-server/device_workers/device_worker_dynamic_batch.py
+++ b/tt-media-server/device_workers/device_worker_dynamic_batch.py
@@ -7,6 +7,7 @@ from multiprocessing import Queue
 
 from config.constants import SHUTDOWN_SIGNAL, CanaryProbeRequest
 from device_workers.worker_utils import initialize_device_worker
+from domain.errors import classify_worker_error
 from model_services.queues.memory_queue import SharedMemoryChunkQueue
 from model_services.queues.tt_queue import TTQueue
 from tt_model_runners.base_device_runner import BaseDeviceRunner
@@ -85,7 +86,9 @@ def device_worker(
             raise
         except Exception as e:
             logger.error(f"Streaming failed for task {request._task_id}: {e}")
-            error_queue.put((worker_id, request._task_id, str(e)))
+            error_queue.put(
+                (worker_id, request._task_id, classify_worker_error(worker_id, e))
+            )
 
     # Handle canary-monitor probe
     async def handle_canary(request):
@@ -114,7 +117,11 @@ def device_worker(
             raise
         except Exception as e:
             logger.error(f"Execution failed for task {request._task_id}: {e}")
-            error_queue.put((worker_id, request._task_id, str(e)))
+            # A client-input rejection stays a ClientRequestError instance so the
+            # scheduler can tell it apart from a device fault (#4811).
+            error_queue.put(
+                (worker_id, request._task_id, classify_worker_error(worker_id, e))
+            )
 
     async def cancel_listener():
         """Watch cancel_queue and cancel any matching in-flight asyncio task.

--- a/tt-media-server/domain/errors.py
+++ b/tt-media-server/domain/errors.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Request-caused failures, told apart from device faults (#4811).
+
+A per-request failure has two very different meanings depending on its cause:
+
+* **The client sent something we cannot serve.** Retrying is pointless, the
+  answer is 4xx, and the worker is perfectly healthy.
+* **The device or the runner broke.** The answer is 5xx, and enough of these in
+  a row mean the worker should be restarted.
+
+``Scheduler.error_listener`` used to treat both identically, so six bad-input
+requests walked a healthy worker past ``max_worker_restart_count`` into a
+restart (see #4811). Everything here exists so that the distinction survives the
+trip from wherever the failure happened — including inside a device worker
+process, or on the far side of the SHM boundary in the multihost peer — all the
+way to the code that decides whether a worker lives.
+
+Three carriers, in order of preference:
+
+1. :class:`ClientRequestError` raised directly by whatever validated the input.
+2. The ``"NNN: "`` prefix the peer's stringified ``HTTPException`` leaves on
+   ``VideoResponse.error_message`` (see :func:`parse_peer_status`).
+3. :data:`CLIENT_INPUT_EXCEPTIONS` — a deliberately narrow set of stdlib
+   exception types that only ever mean "the input was malformed". This is the
+   backstop for a rogue parameter nobody has validated yet: it cannot produce
+   the right HTTP status detail, but it does keep the failure off the worker's
+   health record.
+"""
+
+from __future__ import annotations
+
+import binascii
+import re
+import struct
+
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+__all__ = [
+    "CLIENT_INPUT_EXCEPTIONS",
+    "ClientRequestError",
+    "classify_worker_error",
+    "is_client_error",
+    "parse_peer_status",
+]
+
+
+class ClientRequestError(HTTPException):
+    """A failure caused by the request, not by the worker serving it.
+
+    Subclasses ``HTTPException`` on purpose:
+
+    * FastAPI already knows how to turn it into a response, so an endpoint's
+      existing ``except HTTPException: raise`` hands the caller the right status
+      with no extra plumbing.
+    * ``str(exc)`` renders as ``"400: <detail>"``, which is exactly the wire
+      format the multihost peer writes into SHM and :func:`parse_peer_status`
+      reads back. Raising this inside a runner keeps that loop closed for free.
+
+    ``HTTPException.__init__`` never calls ``super().__init__``, which leaves
+    ``args`` empty and makes the default pickle protocol reconstruct the
+    exception with no arguments — a ``TypeError`` on unpickle. These instances
+    cross a ``multiprocessing.Queue`` on every worker error, so ``__reduce__``
+    is defined explicitly rather than left to chance.
+    """
+
+    def __init__(self, detail: str, status_code: int = 400) -> None:
+        super().__init__(status_code=status_code, detail=detail)
+
+    def __reduce__(self):
+        return (self.__class__, (self.detail, self.status_code))
+
+
+# Narrow by design. These types mean "the bytes/values handed to us were the
+# wrong shape" and nothing else:
+#   * ``binascii.Error``      — base64 that does not decode
+#   * ``struct.error``        — a value that does not fit its SHM field, e.g. a
+#                               ``seed`` outside signed 64-bit
+#   * ``UnicodeDecodeError``  — text that is not valid UTF-8
+#   * ``ValidationError``     — a DTO rebuilt from a cross-process payload
+# ``ValueError`` and ``OSError`` are deliberately absent: device and runner code
+# raise those too, and misclassifying one of those would blind the watchdog.
+CLIENT_INPUT_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    ClientRequestError,
+    binascii.Error,
+    struct.error,
+    UnicodeDecodeError,
+    ValidationError,
+)
+
+# ``str(HTTPException(400, "..."))`` -> ``"400: ..."``. The multihost peer
+# stringifies its exception into ``VideoResponse.error_message``, so this prefix
+# is the only channel a 4xx has across the SHM boundary.
+_PEER_STATUS_RE = re.compile(r"^(4\d{2}): ")
+
+
+def parse_peer_status(error_message: object) -> int | None:
+    """Return the 4xx status the peer prefixed onto *error_message*, else None.
+
+    Only 4xx is recognised. A 5xx prefix, or no prefix at all, means "treat as a
+    worker fault" — the conservative direction, since a missed classification
+    costs one false restart while a wrong one would stop the watchdog from ever
+    restarting a genuinely sick worker.
+    """
+    if not isinstance(error_message, str):
+        return None
+    match = _PEER_STATUS_RE.match(error_message)
+    return int(match.group(1)) if match else None
+
+
+def is_client_error(exc: BaseException) -> bool:
+    """True when *exc* was caused by the request rather than by the worker."""
+    if isinstance(exc, ClientRequestError):
+        return True
+    # A 4xx HTTPException raised anywhere in the runner stack is a client error
+    # by definition, whether or not it used our subclass.
+    if isinstance(exc, HTTPException):
+        return 400 <= exc.status_code < 500
+    if isinstance(exc, CLIENT_INPUT_EXCEPTIONS):
+        return True
+    # Peer errors arrive wrapped: SPRunner raises
+    # ``RuntimeError("Runner error for task X: 400: ...")``. SPRunner converts
+    # these itself, but classify from the message too so an unconverted path
+    # still cannot cost the worker its life.
+    return _peer_status_in(str(exc)) is not None
+
+
+def _peer_status_in(message: str) -> int | None:
+    """Find a peer ``NNN: `` prefix anywhere in *message*, not just at the start.
+
+    ``SPRunner`` prefixes the peer's message with its own context, so the status
+    ends up mid-string.
+    """
+    for chunk in message.split(": "):
+        status = parse_peer_status(f"{chunk}: ")
+        if status is not None:
+            return status
+    return None
+
+
+def classify_worker_error(
+    worker_id: str,
+    exc: BaseException,
+    prefix: str = "",
+) -> ClientRequestError | str:
+    """Build the ``error_queue`` payload for *exc*.
+
+    Returns a :class:`ClientRequestError` when the request is at fault — the
+    scheduler keys off the type, so this must stay an instance and never be
+    flattened into a string — and ``f"{prefix}{exc}"`` otherwise, which is the
+    long-standing wire format for worker faults.
+    """
+    if isinstance(exc, ClientRequestError):
+        return exc
+
+    if is_client_error(exc):
+        status = (
+            exc.status_code
+            if isinstance(exc, HTTPException)
+            else _peer_status_in(str(exc)) or 400
+        )
+        detail = getattr(exc, "detail", None) or str(exc) or type(exc).__name__
+        return ClientRequestError(str(detail), status_code=status)
+
+    return f"{prefix}{exc}"

--- a/tt-media-server/domain/video_generate_request.py
+++ b/tt-media-server/domain/video_generate_request.py
@@ -8,6 +8,14 @@ from domain.base_request import BaseRequest
 from pydantic import Field
 
 
+# ``VideoShm.write_request`` packs the seed as a signed 64-bit int ("<q"), so a
+# value outside this range raises ``struct.error`` inside the device worker.
+# Bounding it here turns that into a 422 at the boundary instead of a 500 plus an
+# increment on the worker's error count (#4811).
+_MIN_SEED = -(2**63)
+_MAX_SEED = 2**63 - 1
+
+
 class VideoGenerateRequest(BaseRequest):
     # Required fields
     prompt: str
@@ -15,4 +23,4 @@ class VideoGenerateRequest(BaseRequest):
     # Optional fields
     negative_prompt: Optional[str] = None
     num_inference_steps: Optional[int] = Field(default=20, ge=12, le=50)
-    seed: Optional[int] = None
+    seed: Optional[int] = Field(default=None, ge=_MIN_SEED, le=_MAX_SEED)

--- a/tt-media-server/domain/video_i2v_generate_request.py
+++ b/tt-media-server/domain/video_i2v_generate_request.py
@@ -16,8 +16,10 @@ below) is the single source of truth in ``config.constants.WAN22_NUM_FRAMES``.
 from typing import List
 
 from config.constants import WAN22_NUM_FRAMES
+from domain.errors import ClientRequestError
 from domain.video_generate_request import VideoGenerateRequest
 from pydantic import BaseModel, Field, field_validator
+from utils.base64_image import validate_base64_image
 
 # The cap exists to bound HTTP body size, not to match
 # any pipeline constraint.
@@ -29,6 +31,30 @@ class ImagePromptEntry(BaseModel):
 
     image: str = Field(min_length=1, max_length=MAX_BASE64_IMAGE_LEN)
     frame_pos: int = Field(default=0, ge=0, lt=WAN22_NUM_FRAMES)
+
+    @field_validator("image")
+    @classmethod
+    def validate_image_is_decodable(cls, v: str) -> str:
+        """Reject a payload that is not a base64-encoded image.
+
+        Length alone used to be the only check here, so ``"!!!not-base64!!!"`` or
+        an arbitrary blob wrapped in ``data:image/png;base64,`` was accepted, sent
+        to the device, and only failed there — as a 500 to the client and an
+        increment on the worker's error count, six of which restart the worker
+        (#4811). ``validate_base64_image`` sniffs the header, so this stays cheap
+        enough to run on every request; anything that gets past it and fails the
+        real decode is caught in ``ImageManager`` and classified there.
+
+        Re-raised as ``ValueError`` so pydantic reports it like every other field
+        error on this schema and FastAPI answers 422 with the usual body. The
+        underlying ``ClientRequestError`` is the right type deeper in the stack
+        (it carries an HTTP status across the worker boundary) but here it would
+        bypass pydantic's error collection entirely.
+        """
+        try:
+            return validate_base64_image(v, what="image_prompts[].image")
+        except ClientRequestError as e:
+            raise ValueError(e.detail) from e
 
 
 class VideoI2VGenerateRequest(VideoGenerateRequest):

--- a/tt-media-server/model_services/scheduler.py
+++ b/tt-media-server/model_services/scheduler.py
@@ -14,6 +14,7 @@ from device_workers.device_worker import device_worker
 from device_workers.device_worker_dynamic_batch import (
     device_worker as device_worker_dynamic_batch,
 )
+from domain.errors import ClientRequestError
 from fastapi import HTTPException
 from telemetry.multiprocess_setup import mark_worker_dead
 from utils.decorators import log_execution_time
@@ -225,6 +226,7 @@ class Scheduler:
             "restart_count": 0,
             "is_ready": False,
             "error_count": 0,
+            "client_error_count": 0,
             "queue_index": worker_index,  # ✅ Track which queue this worker uses
         }
 
@@ -264,8 +266,13 @@ class Scheduler:
         # Start new worker
         self._start_worker(worker_id, queue_index=existing_queue_index)
         self.worker_info[worker_id]["restart_count"] = restart_count
-        # pass the error count from old worker -1 to give it a chance to recover
-        self.worker_info[worker_id]["error_count"] = old_info.get("error_count", 1) - 1
+        # A fresh process starts with a clean error record. Carrying the old count
+        # forward (previously ``old - 1``) left a restarted worker sitting one
+        # error below the threshold, so a single later failure restarted it again
+        # — which is how one bad client could restart a worker indefinitely
+        # (#4811). ``restart_count`` still accumulates, so the give-up and
+        # deep-reset escalation in ``worker_health_monitor`` is unaffected.
+        self.worker_info[worker_id]["error_count"] = 0
 
     async def result_listener(self):
         """✅ Read from ALL worker queues in parallel using batch reads"""
@@ -339,11 +346,27 @@ class Scheduler:
                     self.listener_running = False
                     break
 
-                self.worker_info[worker_id]["error_count"] += 1
-
-                self.logger.warning(
-                    f"Worker {worker_id} error count is : {self.worker_info[worker_id]['error_count']}"
-                )
+                # A per-request failure means one of two very different things,
+                # and the worker's life depends on telling them apart. Device and
+                # runner faults count toward ``max_worker_restart_count``; a
+                # request the client got wrong does not — it is answered with a
+                # 4xx and forgotten. Counting both is what let six bad-input
+                # requests restart a healthy worker (#4811). The device worker
+                # marks the difference by putting a ``ClientRequestError``
+                # instance on the queue instead of a message string.
+                info = self.worker_info[worker_id]
+                if isinstance(error, ClientRequestError):
+                    info["client_error_count"] = info.get("client_error_count", 0) + 1
+                    self.logger.warning(
+                        f"Worker {worker_id} rejected a client request "
+                        f"({error.status_code}); not counted against worker health "
+                        f"(client_error_count={info['client_error_count']})"
+                    )
+                else:
+                    info["error_count"] += 1
+                    self.logger.warning(
+                        f"Worker {worker_id} error count is : {info['error_count']}"
+                    )
 
                 self.logger.error(f"Error in worker {result_key}: {error}")
 
@@ -365,7 +388,16 @@ class Scheduler:
                 queue = self.result_queues.get(task_id)
 
                 if queue:
-                    await queue.put(Exception(error))
+                    # ``ClientRequestError`` is an HTTPException, so forwarding it
+                    # unwrapped is what turns these into the 4xx the client should
+                    # have got all along — ``_submit_video_request`` re-raises
+                    # HTTPException untouched, while a bare ``Exception`` fell
+                    # through to its 500 branch.
+                    await queue.put(
+                        error
+                        if isinstance(error, ClientRequestError)
+                        else Exception(error)
+                    )
 
             except Exception as e:
                 self.logger.error(f"Error in error_listener: {e}")
@@ -659,6 +691,9 @@ class Scheduler:
                 "is_ready": info["is_ready"],
                 "restart_count": info["restart_count"],
                 "error_count": info["error_count"],
+                # Rejected client requests, tracked separately so they stay
+                # visible without counting toward restarts (#4811).
+                "client_error_count": info.get("client_error_count", 0),
                 "ready_time": info["ready_time"] if "ready_time" in info else None,
             }
         return serializable_worker_info

--- a/tt-media-server/open_ai_api/video.py
+++ b/tt-media-server/open_ai_api/video.py
@@ -32,8 +32,10 @@ from fastapi import (
     Security,
     UploadFile,
 )
+from fastapi.encoders import jsonable_encoder
 from fastapi.responses import FileResponse, JSONResponse
 from model_services.base_job_service import BaseJobService
+from pydantic import ValidationError
 from resolver.service_resolver import service_resolver
 from security.api_key_checker import get_api_key
 from telemetry.telemetry_client import TelemetryEvent
@@ -311,13 +313,21 @@ async def submit_generate_video_i2v_upload(
     _validate_image_content_type(image)
     image_bytes = await _read_capped_upload(image)
     image_b64 = base64.b64encode(image_bytes).decode("ascii")
-    request = VideoI2VGenerateRequest(
-        prompt=prompt,
-        negative_prompt=negative_prompt,
-        num_inference_steps=num_inference_steps,
-        seed=seed,
-        image_prompts=[ImagePromptEntry(image=image_b64, frame_pos=frame_pos)],
-    )
+    try:
+        request = VideoI2VGenerateRequest(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            num_inference_steps=num_inference_steps,
+            seed=seed,
+            image_prompts=[ImagePromptEntry(image=image_b64, frame_pos=frame_pos)],
+        )
+    except ValidationError as e:
+        # This endpoint builds the DTO itself instead of letting FastAPI parse a
+        # body, so a validation failure would escape as an unhandled exception
+        # (500) rather than the 422 the equivalent JSON request gets. A declared
+        # content_type is no guarantee of the bytes behind it: a .png full of
+        # garbage lands here.
+        raise HTTPException(status_code=422, detail=jsonable_encoder(e.errors()))
     return await _submit_video_request(request, service)
 
 

--- a/tt-media-server/tests/conftest.py
+++ b/tt-media-server/tests/conftest.py
@@ -658,6 +658,57 @@ forge_runners_module.ForgeVitRunner = create_mock_runner_class("ForgeVitRunner")
 # The mocks are already in sys.modules, so imports will work correctly
 
 
+@pytest.fixture(autouse=True)
+def stop_sp_runner_drainers():
+    """Stop any ``SPRunner`` drainer thread a test leaves behind.
+
+    ``SPRunner.submit`` starts ``_drain_loop`` in a thread, and tests need it
+    running — it is what resolves the response future. Nothing stops it
+    afterwards: ``close_device`` is the only thing that sets ``_shutdown``, and
+    almost no test calls it. Against a ``MagicMock`` output SHM,
+    ``read_response`` returns instantly rather than blocking for its timeout, so
+    each abandoned drainer becomes a hot spin loop holding the GIL for the rest
+    of the session — roughly a full core each, measured.
+
+    Invisible on a developer box with cores to spare; brutal on a 2-vCPU CI
+    runner, where the leaked threads starve every test that runs afterwards. The
+    two SPRunner test modules were leaking 16 between them, which is most of why
+    the media suite took ~5.5 minutes; adding five more tests pushed it past 11
+    and the job was killed mid-run.
+
+    Kept here rather than in each module so a future SPRunner test cannot
+    reintroduce the cliff. The ``sys.modules`` guard makes it free for the
+    thousands of tests that never touch SPRunner: no import, no patch, no
+    teardown work. Runners are tracked by wrapping ``__init__`` because tests
+    construct them inline instead of taking them from a fixture.
+    """
+    module = sys.modules.get("tt_model_runners.sp_runner")
+    runner_cls = getattr(module, "SPRunner", None) if module else None
+    if runner_cls is None or isinstance(runner_cls, MagicMock):
+        yield
+        return
+
+    created = []
+    original_init = runner_cls.__init__
+
+    def tracking_init(self, *args, **kwargs):
+        created.append(self)
+        original_init(self, *args, **kwargs)
+
+    runner_cls.__init__ = tracking_init
+    try:
+        yield
+    finally:
+        runner_cls.__init__ = original_init
+
+    for runner in created:
+        runner._shutdown = True
+    for runner in created:
+        drainer = getattr(runner, "_drainer", None)
+        if drainer is not None:
+            drainer.join(timeout=5.0)
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--start-from",

--- a/tt-media-server/tests/test_device_worker.py
+++ b/tt-media-server/tests/test_device_worker.py
@@ -78,7 +78,7 @@ mock_logger = Mock()
 sys.modules["utils.logger"] = Mock()
 sys.modules["utils.logger"].TTLogger.return_value = mock_logger
 
-from device_workers.device_worker import device_worker
+from device_workers.device_worker import _continuous_fan_out, device_worker
 
 for module_name, original_module in {
     "config.settings": _orig_config_settings,
@@ -574,6 +574,101 @@ class TestDeviceWorkerIntegration:
                     assert error_tuple[1] == "timeout_task"
                     break
         assert found_timeout_error, f"No timeout error found in calls: {calls}"
+
+
+class TestErrorPayloadClassification:
+    """What the worker puts on ``error_queue`` decides whether the scheduler
+    counts the failure against worker health (#4811).
+
+    A client-input rejection has to arrive at ``error_listener`` as a
+    ``ClientRequestError`` instance; flattening it into an f-string (the old
+    behaviour) threw away the only signal the scheduler could classify on.
+    """
+
+    @staticmethod
+    def _request(task_id="task_rogue"):
+        req = Mock()
+        req._task_id = task_id
+        return req
+
+    def _fan_out(self, runner, requests, error_queue):
+        task_queue = Mock()
+        task_queue.get_many = Mock(return_value=[])
+        asyncio.new_event_loop().run_until_complete(
+            _continuous_fan_out(
+                device_runner=runner,
+                initial_requests=requests,
+                worker_id="worker_0",
+                result_queue=Mock(),
+                error_queue=error_queue,
+                task_queue=task_queue,
+                max_inflight=len(requests),
+                logger=Mock(),
+            )
+        )
+
+    def test_client_error_is_forwarded_as_the_exception_instance(self):
+        from domain.errors import ClientRequestError
+
+        error_queue = Mock()
+        error_queue.put = Mock()
+        raised = ClientRequestError("Could not decode image (804 bytes)")
+
+        class _Runner:
+            supports_continuous_fan_out = True
+
+            async def _run_async(self, requests):
+                raise raised
+
+        self._fan_out(_Runner(), [self._request()], error_queue)
+
+        worker_id, task_id, payload = error_queue.put.call_args[0][0]
+        assert worker_id == "worker_0"
+        assert task_id == "task_rogue"
+        assert isinstance(payload, ClientRequestError)
+        assert payload.status_code == 400
+
+    def test_device_fault_is_still_forwarded_as_a_prefixed_string(self):
+        """Control case — the existing wire format for real faults is unchanged,
+        so the scheduler keeps counting them."""
+        from domain.errors import ClientRequestError
+
+        error_queue = Mock()
+        error_queue.put = Mock()
+
+        class _Runner:
+            supports_continuous_fan_out = True
+
+            async def _run_async(self, requests):
+                raise RuntimeError("ttnn: mesh unresponsive")
+
+        self._fan_out(_Runner(), [self._request("task_dead")], error_queue)
+
+        _worker_id, _task_id, payload = error_queue.put.call_args[0][0]
+        assert not isinstance(payload, ClientRequestError)
+        assert payload == "Worker worker_0 execution error: ttnn: mesh unresponsive"
+
+    def test_input_shape_error_from_shm_packing_is_classified(self):
+        """``seed`` outside int64 raises ``struct.error`` in
+        ``VideoShm.write_request``, inside the worker. It is the client's bug,
+        so it must not cost the worker its life."""
+        import struct
+
+        from domain.errors import ClientRequestError
+
+        error_queue = Mock()
+        error_queue.put = Mock()
+
+        class _Runner:
+            supports_continuous_fan_out = True
+
+            async def _run_async(self, requests):
+                raise struct.error("argument out of range")
+
+        self._fan_out(_Runner(), [self._request("task_seed")], error_queue)
+
+        _worker_id, _task_id, payload = error_queue.put.call_args[0][0]
+        assert isinstance(payload, ClientRequestError)
 
 
 @pytest.fixture(autouse=True)

--- a/tt-media-server/tests/test_image_manager.py
+++ b/tt-media-server/tests/test_image_manager.py
@@ -120,6 +120,71 @@ class TestBase64ToPilImagePadding:
         assert image.size == (width, height)
 
 
+class TestBase64ToPilImageRejectsRogueInput:
+    """Decode failures are the client's fault and must say so (#4811).
+
+    This helper is the single choke point every I2V runner's
+    ``_build_image_prompt`` goes through, and it runs *inside the device worker*.
+    A bare ``binascii.Error`` / ``UnidentifiedImageError`` from here reached the
+    scheduler as an unclassifiable string, counted against ``error_count``, and
+    restarted the worker after six bad requests.
+    """
+
+    @pytest.mark.parametrize(
+        "payload,why",
+        [
+            ("!!!not-base64!!!", "not base64"),
+            ("data:image/png;base64,!!!!", "data URL wrapping non-base64"),
+            (base64.b64encode(b"x" * 804).decode("ascii"), "not an image"),
+            (base64.b64encode(b"%PDF-1.7 nope").decode("ascii"), "a PDF"),
+        ],
+    )
+    def test_rogue_payloads_raise_a_client_request_error(self, payload, why):
+        from domain.errors import ClientRequestError
+
+        with pytest.raises(ClientRequestError) as exc_info:
+            ImageManager().base64_to_pil_image(payload)
+
+        assert exc_info.value.status_code == 400
+
+    def test_truncated_but_correctly_headed_png_is_a_client_error(self):
+        """Passes a header sniff at the API boundary but still fails the real
+        decode — the layer that catches it is this one."""
+        from domain.errors import ClientRequestError
+
+        truncated = _png_bytes()[:20]
+
+        with pytest.raises(ClientRequestError):
+            ImageManager().base64_to_pil_image(
+                base64.b64encode(truncated).decode("ascii")
+            )
+
+    def test_the_error_message_is_prefixed_for_the_peer_wire_format(self):
+        """Rank 0 writes ``str(exc)`` into SHM, and ``SPRunner`` reads the status
+        back off that prefix. ``str()`` must therefore start with ``400: ``."""
+        from domain.errors import ClientRequestError
+
+        with pytest.raises(ClientRequestError) as exc_info:
+            ImageManager().base64_to_pil_image("!!!not-base64!!!")
+
+        assert str(exc_info.value).startswith("400: ")
+
+    def test_a_valid_image_still_decodes(self):
+        """Regression guard: classification must not swallow the happy path."""
+        encoded = base64.b64encode(_png_bytes()).decode("ascii")
+
+        assert ImageManager().base64_to_pil_image(encoded).size == (4, 4)
+
+    def test_line_wrapped_base64_still_decodes(self):
+        """MIME-style base64 (what ``base64`` CLI and some SDKs emit) is wrapped
+        at 76 columns. The old lenient ``b64decode`` ignored those newlines;
+        tightening to ``validate=True`` must not start rejecting them."""
+        wrapped = base64.encodebytes(_png_bytes(width=32, height=32)).decode("ascii")
+        assert "\n" in wrapped, "test setup: payload must be line-wrapped"
+
+        assert ImageManager().base64_to_pil_image(wrapped).size == (32, 32)
+
+
 class TestBase64ToPilImageResizeAndMode:
     """The padding fix must not regress the optional resize / mode-convert
     parameters that callers depend on for I2V conditioning preprocessing."""

--- a/tt-media-server/tests/test_scheduler_client_error_isolation.py
+++ b/tt-media-server/tests/test_scheduler_client_error_isolation.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
-import pickle
 import struct
 import sys
 from multiprocessing import Queue
@@ -125,27 +124,45 @@ async def _run_one_monitor_pass(scheduler: Scheduler) -> Mock:
 class TestClientRequestErrorContract:
     """``ClientRequestError`` is the marker that survives the process hop."""
 
-    def test_survives_the_multiprocessing_queue(self):
-        """The error crosses an ``mp.Queue``, so it MUST pickle.
+    @pytest.mark.parametrize(
+        "error,expected_status",
+        [
+            (ClientRequestError("bad image", status_code=422), 422),
+            (ClientRequestError("bad image"), 400),  # default status
+        ],
+    )
+    def test_survives_the_multiprocessing_queue(self, error, expected_status):
+        """The error crosses an ``mp.Queue``, so it MUST serialise.
 
         Starlette's ``HTTPException`` does not call ``super().__init__``, so its
-        ``args`` are empty and a naive subclass raises ``TypeError`` on unpickle
-        — which would kill ``error_listener`` instead of reporting the error.
+        ``args`` are empty and a naive subclass fails to reconstruct — which would
+        kill ``error_listener`` instead of reporting the error. Asserted through a
+        real queue rather than by calling a serialiser directly, so the test
+        exercises the production transport.
         """
         queue: Queue = Queue()
-        queue.put(ClientRequestError("bad image", status_code=422))
+        queue.put(error)
 
         revived = queue.get(timeout=5.0)
 
         assert isinstance(revived, ClientRequestError)
-        assert revived.status_code == 422
+        assert revived.status_code == expected_status
         assert revived.detail == "bad image"
 
-    def test_pickle_round_trip_preserves_status_and_detail(self):
-        revived = pickle.loads(pickle.dumps(ClientRequestError("nope")))
+    def test_reduce_carries_both_constructor_arguments(self):
+        """Pin the ``__reduce__`` hook the queue above depends on.
 
-        assert revived.status_code == 400
-        assert revived.detail == "nope"
+        The queue test proves the round trip works; this one says *why*, so a
+        regression points straight at the hook instead of at the transport.
+        """
+        factory, args = ClientRequestError("nope", status_code=413).__reduce__()
+
+        assert factory is ClientRequestError
+        assert args == ("nope", 413)
+
+        rebuilt = factory(*args)
+        assert rebuilt.status_code == 413
+        assert rebuilt.detail == "nope"
 
     def test_str_matches_the_peer_wire_format(self):
         """Rank 0 writes ``str(exc)`` into SHM, and the peer's ``400: `` prefix

--- a/tt-media-server/tests/test_scheduler_client_error_isolation.py
+++ b/tt-media-server/tests/test_scheduler_client_error_isolation.py
@@ -1,0 +1,433 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Client-input rejections must never count as worker execution errors (#4811).
+
+Issue #4811 was re-opened because PR #4817 patched one request signature
+(text-only ``POST /generations`` on an I2V-only deployment) rather than the
+mechanism its own title names: ``Scheduler.error_listener`` incremented
+``worker_info[...]["error_count"]`` for EVERY entry on ``error_queue``, with no
+distinction between "the device is dying" and "the client sent junk". Six
+bad-input requests therefore walked a perfectly healthy worker past
+``max_worker_restart_count`` into a restart, and with it ``/health`` 503 and a
+pod shutdown.
+
+The chain under test spans a process boundary in production:
+
+    runner raises  ->  device_worker  ->  error_queue  ->  error_listener
+                                          (mp.Queue)       -> worker_health_monitor
+
+``TestRogueRequestChain`` drives that whole chain in one process against a real
+``multiprocessing.Queue`` — so a payload that cannot pickle fails the test
+rather than silently taking the error listener down in production. The control
+case (a genuine device fault still restarts the worker) is asserted alongside
+every isolation case: the point is to stop miscounting client errors, not to
+blind the watchdog.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import pickle
+import struct
+import sys
+from multiprocessing import Queue
+from unittest.mock import Mock, patch
+
+import pytest
+
+# Mirror ``test_scheduler.py``'s settings stub so this module is self-sufficient
+# regardless of collection order. ``max_worker_restart_count`` is deliberately
+# the production default (5) so the counts below read like the issue's log.
+_mock_settings = Mock()
+_mock_settings.device_ids = "(0)"
+_mock_settings.max_queue_size = 10
+_mock_settings.max_batch_size = 1
+_mock_settings.use_queue_per_worker = False
+_mock_settings.use_dynamic_batcher = False
+_mock_settings.queue_for_multiprocessing = "default"
+_mock_settings.max_worker_restart_count = 5
+_mock_settings.allow_deep_reset = False
+_mock_settings.worker_check_sleep_timeout = 0.01
+sys.modules["config.settings"] = Mock()
+sys.modules["config.settings"].get_settings = Mock(return_value=_mock_settings)
+sys.modules["config.settings"].settings = _mock_settings
+sys.modules["config.settings"].Settings = Mock()
+
+from device_workers.device_worker import _continuous_fan_out  # noqa: E402
+from domain.errors import (  # noqa: E402
+    ClientRequestError,
+    classify_worker_error,
+    parse_peer_status,
+)
+from model_services.scheduler import Scheduler  # noqa: E402
+
+WORKER_ID = "0"
+
+# Verbatim from the issue's error log — the peer stringifies an
+# ``HTTPException(400, ...)``, which is where the ``400: `` prefix comes from.
+PEER_DECODE_ERROR = (
+    "400: Could not decode image (804 bytes): cannot identify image file "
+    "<_io.BytesIO object at 0x78810f8022a0>"
+)
+
+# Rogue but plausible: valid data URL, valid base64, bytes are not an image.
+# Same shape as the ``curl`` in the issue, sized to match its 804 bytes.
+ROGUE_IMAGE = "data:image/png;base64," + base64.b64encode(b"x" * 804).decode("ascii")
+
+
+def _make_scheduler() -> Scheduler:
+    with patch(
+        "model_services.scheduler.get_settings", return_value=_mock_settings
+    ), patch("model_services.scheduler.TTLogger", return_value=Mock()):
+        scheduler = Scheduler()
+    scheduler.worker_info[WORKER_ID] = {
+        "process": Mock(is_alive=Mock(return_value=True)),
+        "start_time": 0.0,
+        "restart_count": 0,
+        "is_ready": True,
+        "error_count": 0,
+        "queue_index": 0,
+    }
+    return scheduler
+
+
+async def _drain(scheduler: Scheduler, payloads: list) -> None:
+    """Feed *payloads* through the real ``error_listener`` and let it exit."""
+    for payload in payloads:
+        scheduler.error_queue.put((WORKER_ID, payload[0], payload[1]))
+    scheduler.error_queue.put((WORKER_ID, None, None))  # shutdown sentinel
+    await asyncio.wait_for(scheduler.error_listener(), timeout=10.0)
+
+
+async def _run_one_monitor_pass(scheduler: Scheduler) -> Mock:
+    """Run a single ``worker_health_monitor`` iteration; return the restart mock."""
+    scheduler.is_ready = True
+    scheduler.monitor_running = True
+    first_sleep = True
+
+    async def stop_after_one(_timeout):
+        nonlocal first_sleep
+        if first_sleep:
+            first_sleep = False
+            scheduler.monitor_running = False
+
+    with patch.object(scheduler, "restart_worker") as restart, patch(
+        "model_services.scheduler.asyncio.sleep", side_effect=stop_after_one
+    ):
+        await asyncio.wait_for(scheduler.worker_health_monitor(), timeout=5.0)
+    return restart
+
+
+class TestClientRequestErrorContract:
+    """``ClientRequestError`` is the marker that survives the process hop."""
+
+    def test_survives_the_multiprocessing_queue(self):
+        """The error crosses an ``mp.Queue``, so it MUST pickle.
+
+        Starlette's ``HTTPException`` does not call ``super().__init__``, so its
+        ``args`` are empty and a naive subclass raises ``TypeError`` on unpickle
+        — which would kill ``error_listener`` instead of reporting the error.
+        """
+        queue: Queue = Queue()
+        queue.put(ClientRequestError("bad image", status_code=422))
+
+        revived = queue.get(timeout=5.0)
+
+        assert isinstance(revived, ClientRequestError)
+        assert revived.status_code == 422
+        assert revived.detail == "bad image"
+
+    def test_pickle_round_trip_preserves_status_and_detail(self):
+        revived = pickle.loads(pickle.dumps(ClientRequestError("nope")))
+
+        assert revived.status_code == 400
+        assert revived.detail == "nope"
+
+    def test_str_matches_the_peer_wire_format(self):
+        """Rank 0 writes ``str(exc)`` into SHM, and the peer's ``400: `` prefix
+        is what ``parse_peer_status`` reads back on the server side. Keeping
+        ``__str__`` inherited from HTTPException closes that loop."""
+        assert str(ClientRequestError("Could not decode image")) == (
+            "400: Could not decode image"
+        )
+
+    def test_is_an_http_exception(self):
+        """So ``_submit_video_request``'s ``except HTTPException: raise`` hands
+        the client a 4xx without any per-endpoint plumbing."""
+        from fastapi import HTTPException
+
+        assert isinstance(ClientRequestError("x"), HTTPException)
+
+
+class TestParsePeerStatus:
+    """Translate the multihost peer's stringified error back into a status."""
+
+    def test_reads_the_status_from_the_issues_error_message(self):
+        assert parse_peer_status(PEER_DECODE_ERROR) == 400
+
+    @pytest.mark.parametrize("status", [400, 413, 422, 499])
+    def test_accepts_any_4xx(self, status):
+        assert parse_peer_status(f"{status}: something the client sent") == status
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "500: internal pipeline failure",
+            "503: peer unavailable",
+            "ttnn device hang",
+            "Runner error for task abc: watchdog timeout",
+            "",
+            "400 no colon so not a status prefix",
+            "40: too short to be a status",
+        ],
+    )
+    def test_rejects_everything_that_is_not_a_4xx_prefix(self, message):
+        """Anything unrecognised stays a worker fault — the conservative
+        direction. A missed classification costs a false restart; a wrong one
+        would blind the watchdog."""
+        assert parse_peer_status(message) is None
+
+    def test_tolerates_a_non_string(self):
+        assert parse_peer_status(None) is None
+
+
+class TestClassifyWorkerError:
+    """The type-based safety net for rogue params nobody validated yet."""
+
+    def test_client_request_error_is_passed_through_unchanged(self):
+        original = ClientRequestError("bad base64", status_code=422)
+
+        assert classify_worker_error(WORKER_ID, original) is original
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            binascii.Error("Invalid base64-encoded string"),
+            struct.error("argument out of range"),
+            UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),
+        ],
+    )
+    def test_input_shape_failures_classify_as_client_errors(self, exc):
+        """``struct.error`` is the live example: ``seed`` outside int64 blows up
+        in ``VideoShm.write_request`` inside the worker."""
+        classified = classify_worker_error(WORKER_ID, exc)
+
+        assert isinstance(classified, ClientRequestError)
+        assert classified.status_code == 400
+
+    def test_pydantic_validation_error_classifies_as_client_error(self):
+        from pydantic import ValidationError
+
+        from domain.video_generate_request import VideoGenerateRequest
+
+        try:
+            VideoGenerateRequest()  # missing required prompt
+        except ValidationError as e:
+            exc = e
+
+        assert isinstance(classify_worker_error(WORKER_ID, exc), ClientRequestError)
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            RuntimeError("ttnn device hang"),
+            ValueError("tensor shape mismatch on device"),
+            OSError("SHM segment gone"),
+            TimeoutError("REQUEST_TIMEOUT: response exceeded 600s"),
+        ],
+    )
+    def test_device_faults_stay_worker_faults(self, exc):
+        classified = classify_worker_error(WORKER_ID, exc, prefix="Worker 0 error: ")
+
+        assert not isinstance(classified, ClientRequestError)
+        assert isinstance(classified, str)
+        assert "Worker 0 error: " in classified
+
+    def test_peer_4xx_runtime_error_is_reclassified(self):
+        """``SPRunner`` raises ``ClientRequestError`` for a 4xx peer message, but
+        classify by message as well so an unconverted path still can't cost the
+        worker its life."""
+        classified = classify_worker_error(
+            WORKER_ID, RuntimeError(f"Runner error for task abc: {PEER_DECODE_ERROR}")
+        )
+
+        assert isinstance(classified, ClientRequestError)
+        assert classified.status_code == 400
+
+
+class TestErrorAccounting:
+    """``error_listener`` is where #4811 actually lived."""
+
+    @pytest.mark.asyncio
+    async def test_client_error_does_not_count_toward_worker_death(self):
+        scheduler = _make_scheduler()
+
+        await _drain(scheduler, [("task-a", ClientRequestError("bad image"))])
+
+        assert scheduler.worker_info[WORKER_ID]["error_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_client_error_is_still_counted_for_observability(self):
+        scheduler = _make_scheduler()
+
+        await _drain(scheduler, [("task-a", ClientRequestError("bad image"))])
+
+        assert scheduler.worker_info[WORKER_ID]["client_error_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_device_fault_still_counts(self):
+        """The watchdog must keep working — this is the control case."""
+        scheduler = _make_scheduler()
+
+        await _drain(scheduler, [("task-a", "Worker 0 execution error: device hang")])
+
+        assert scheduler.worker_info[WORKER_ID]["error_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_client_error_reaches_the_caller_as_a_4xx(self):
+        """Previously the caller got a bare ``Exception`` and the endpoint turned
+        it into a 500 for a request the client got wrong."""
+        scheduler = _make_scheduler()
+        scheduler.result_queues = {"task-a": asyncio.Queue()}
+
+        await _drain(
+            scheduler, [("task-a", ClientRequestError(PEER_DECODE_ERROR, 400))]
+        )
+
+        surfaced = await scheduler.result_queues["task-a"].get()
+        assert surfaced.status_code == 400
+        assert "Could not decode image" in str(surfaced.detail)
+
+    @pytest.mark.asyncio
+    async def test_client_error_on_a_chunked_task_id_routes_to_the_task(self):
+        """Streaming keys arrive as ``<task_id>_chunk_<n>``; the 4xx has to land
+        on the parent task's queue like the string path already does."""
+        scheduler = _make_scheduler()
+        scheduler.result_queues = {"task-a": asyncio.Queue()}
+
+        await _drain(scheduler, [("task-a_chunk_0", ClientRequestError("bad image"))])
+
+        surfaced = await scheduler.result_queues["task-a"].get()
+        assert surfaced.status_code == 400
+
+    def test_restart_resets_error_count(self):
+        """A fresh process has no errors. Carrying ``old - 1`` forward left a
+        restarted worker one bad request away from the next restart."""
+        scheduler = _make_scheduler()
+        scheduler.result_queues_by_worker = {0: Mock()}
+        scheduler.worker_info[WORKER_ID]["error_count"] = 6
+        scheduler.worker_info[WORKER_ID]["process"] = Mock(
+            is_alive=Mock(return_value=False)
+        )
+
+        with patch("model_services.scheduler.Process"), patch(
+            "model_services.scheduler.mark_worker_dead"
+        ):
+            scheduler.restart_worker(WORKER_ID)
+
+        assert scheduler.worker_info[WORKER_ID]["error_count"] == 0
+        assert scheduler.worker_info[WORKER_ID]["restart_count"] == 1
+
+
+class TestRogueRequestChain:
+    """End to end, from the runner's failure to the watchdog's decision."""
+
+    class _Request:
+        """What the worker sees of a ``VideoI2VGenerateRequest``."""
+
+        def __init__(self, task_id: str, image: str) -> None:
+            self._task_id = task_id
+            self.image_prompts = [Mock(image=image, frame_pos=0)]
+
+    class _DecodingRunner:
+        """Fails the way the I2V runners fail on a bad conditioning image.
+
+        ``dit_runners._build_image_prompt`` calls ``base64_to_pil_image``
+        directly, so going through the real ``ImageManager`` reproduces the
+        production failure instead of asserting against a hand-made exception.
+        """
+
+        supports_continuous_fan_out = True
+
+        async def _run_async(self, requests):
+            from utils.image_manager import ImageManager
+
+            entry = requests[0].image_prompts[0]
+            return [ImageManager().base64_to_pil_image(entry.image)]
+
+    class _DyingDeviceRunner:
+        supports_continuous_fan_out = True
+
+        async def _run_async(self, requests):
+            raise RuntimeError("ttnn: device watchdog fired, mesh unresponsive")
+
+    async def _run_requests(self, runner, count: int) -> tuple:
+        """Push *count* requests through the real fan-out and error listener."""
+        error_queue: Queue = Queue()
+        requests = [
+            TestRogueRequestChain._Request(f"task-{i}", ROGUE_IMAGE)
+            for i in range(count)
+        ]
+
+        task_queue = Mock()
+        task_queue.get_many = Mock(return_value=[])
+
+        await _continuous_fan_out(
+            device_runner=runner,
+            initial_requests=requests,
+            worker_id=WORKER_ID,
+            result_queue=Mock(),
+            error_queue=error_queue,
+            task_queue=task_queue,
+            max_inflight=count,
+            logger=Mock(),
+        )
+
+        scheduler = _make_scheduler()
+        scheduler.error_queue = error_queue
+        scheduler.result_queues = {r._task_id: asyncio.Queue() for r in requests}
+        error_queue.put((WORKER_ID, None, None))
+        await asyncio.wait_for(scheduler.error_listener(), timeout=10.0)
+        return scheduler, requests
+
+    @pytest.mark.asyncio
+    async def test_rogue_image_requests_never_restart_the_worker(self):
+        """The issue verbatim: 6 bad-input requests used to log
+        ``Worker 0 has too many errors (6), restarting``."""
+        over_threshold = _mock_settings.max_worker_restart_count + 1
+
+        scheduler, _ = await self._run_requests(self._DecodingRunner(), over_threshold)
+        restart = await _run_one_monitor_pass(scheduler)
+
+        assert scheduler.worker_info[WORKER_ID]["error_count"] == 0
+        assert scheduler.worker_info[WORKER_ID]["client_error_count"] == over_threshold
+        restart.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rogue_image_request_answers_the_client_with_a_400(self):
+        scheduler, requests = await self._run_requests(self._DecodingRunner(), 1)
+
+        surfaced = await scheduler.result_queues[requests[0]._task_id].get()
+        assert surfaced.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_genuine_device_faults_still_restart_the_worker(self):
+        """Control case. If this ever goes green-by-accident the watchdog is
+        blind and #4811's fix has overshot."""
+        over_threshold = _mock_settings.max_worker_restart_count + 1
+
+        scheduler, _ = await self._run_requests(
+            self._DyingDeviceRunner(), over_threshold
+        )
+        restart = await _run_one_monitor_pass(scheduler)
+
+        assert scheduler.worker_info[WORKER_ID]["error_count"] == over_threshold
+        restart.assert_called_once_with(WORKER_ID)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tt-media-server/tests/test_sp_runner.py
+++ b/tt-media-server/tests/test_sp_runner.py
@@ -869,5 +869,131 @@ class TestSPRunnerWarmup:
         assert mock_output.read_response.call_count == 2
 
 
+class TestPeerErrorClassification:
+    """A 4xx from the peer is the client's fault, not the worker's (#4811).
+
+    The peer stringifies an ``HTTPException`` into ``error_message``, so an input
+    rejection arrives as ``"400: ..."``. Flattening that into a plain
+    ``RuntimeError`` (the old behaviour) lost the distinction, and the scheduler
+    then counted a bad conditioning image against the worker's health.
+    """
+
+    def _respond_with(self, MockVideoShm, error_message: str):
+        mock_input, mock_output = _install_shm_factory(MockVideoShm)
+        mock_output.read_response.return_value = VideoResponse(
+            "i2v-task-id-000000000000000000",
+            VideoStatus.ERROR,
+            "",
+            error_message,
+        )
+        runner = SPRunner("dev0")
+        runner.set_device()
+        return runner
+
+    @patch("tt_model_runners.sp_runner.VideoShm")
+    def test_peer_4xx_becomes_a_client_request_error(self, MockVideoShm, tmp_video_dir):
+        """Message copied verbatim from #4811's log."""
+        from domain.errors import ClientRequestError
+
+        runner = self._respond_with(
+            MockVideoShm,
+            "400: Could not decode image (804 bytes): cannot identify image "
+            "file <_io.BytesIO object at 0x78810f8022a0>",
+        )
+        request = _MockI2VRequest(
+            image_prompts=[_ImagePromptStub(image="b64", frame_pos=0)]
+        )
+
+        with pytest.raises(ClientRequestError) as exc_info:
+            runner.run([request])
+
+        assert exc_info.value.status_code == 400
+        assert "Could not decode image" in str(exc_info.value.detail)
+
+    @patch("tt_model_runners.sp_runner.VideoShm")
+    def test_peer_422_keeps_its_status(self, MockVideoShm, tmp_video_dir):
+        from domain.errors import ClientRequestError
+
+        runner = self._respond_with(MockVideoShm, "422: frame_pos out of range")
+        request = _MockI2VRequest(
+            image_prompts=[_ImagePromptStub(image="b64", frame_pos=0)]
+        )
+
+        with pytest.raises(ClientRequestError) as exc_info:
+            runner.run([request])
+
+        assert exc_info.value.status_code == 422
+
+    @patch("tt_model_runners.sp_runner.VideoShm")
+    def test_unprefixed_peer_error_stays_a_worker_fault(
+        self, MockVideoShm, tmp_video_dir
+    ):
+        """The control case: a real device failure must keep counting toward
+        worker health, so it must NOT come back as a ClientRequestError."""
+        from domain.errors import ClientRequestError
+
+        runner = self._respond_with(MockVideoShm, "ttnn: mesh unresponsive")
+        request = _MockI2VRequest(
+            image_prompts=[_ImagePromptStub(image="b64", frame_pos=0)]
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            runner.run([request])
+
+        assert not isinstance(exc_info.value, ClientRequestError)
+        assert "mesh unresponsive" in str(exc_info.value)
+
+    @patch("tt_model_runners.sp_runner.VideoShm")
+    def test_peer_5xx_stays_a_worker_fault(self, MockVideoShm, tmp_video_dir):
+        from domain.errors import ClientRequestError
+
+        runner = self._respond_with(MockVideoShm, "500: pipeline crashed")
+        request = _MockI2VRequest(
+            image_prompts=[_ImagePromptStub(image="b64", frame_pos=0)]
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            runner.run([request])
+
+        assert not isinstance(exc_info.value, ClientRequestError)
+
+    @patch("tt_model_runners.sp_runner.VideoShm")
+    def test_client_error_path_still_unlinks_the_side_file(
+        self, MockVideoShm, tmp_video_dir
+    ):
+        """The new error type must not skip the tmpfs cleanup that the old
+        ``RuntimeError`` path did — a bad-input retry loop would otherwise leak
+        ~810 MB per request."""
+        from domain.errors import ClientRequestError
+
+        mock_input, mock_output = _install_shm_factory(MockVideoShm)
+        mock_output.read_response.return_value = VideoResponse(
+            "i2v-task-id-000000000000000000",
+            VideoStatus.ERROR,
+            "",
+            "400: Could not decode image (804 bytes)",
+        )
+
+        captured_path: dict = {}
+
+        def capture_path_at_write(req, timeout_s=None):
+            captured_path["path"] = req.image_path
+            assert os.path.exists(req.image_path)
+
+        mock_input.write_request.side_effect = capture_path_at_write
+
+        runner = SPRunner("dev0")
+        runner.set_device()
+        request = _MockI2VRequest(
+            image_prompts=[_ImagePromptStub(image="b64", frame_pos=0)]
+        )
+
+        with pytest.raises(ClientRequestError):
+            runner.run([request])
+
+        assert captured_path["path"]
+        assert not os.path.exists(captured_path["path"])
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tt-media-server/tests/test_video_api.py
+++ b/tt-media-server/tests/test_video_api.py
@@ -2,6 +2,7 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
+import base64
 import os
 import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,6 +23,7 @@ from open_ai_api.video import (
     get_video_metadata,
     reject_text_to_video_on_i2v_deployment,
     submit_generate_video_i2v_request,
+    submit_generate_video_i2v_upload,
     submit_generate_video_request,
 )
 
@@ -614,6 +616,245 @@ class TestVideoI2VGenerateRequestValidation:
         assert request.negative_prompt == "blurry"
         assert request.num_inference_steps == 30
         assert request.seed == 42
+
+
+# Valid base64, 804 bytes of payload, not an image — the size and shape of the
+# conditioning image in #4811's reproduction curl.
+_NOT_AN_IMAGE_BASE64 = base64.b64encode(b"x" * 804).decode("ascii")
+
+
+class TestRogueImagePayloadsRejectedAtTheBoundary:
+    """Undecodable conditioning images must not reach the device (#4811).
+
+    PR #4817 stopped text-only requests on an I2V deployment, but a request that
+    *does* carry ``image_prompts`` was only checked for string length. Anything
+    that is not a decodable image then failed inside the worker, where it counted
+    against ``error_count`` and cost the worker a restart every 6 requests.
+    """
+
+    @pytest.mark.parametrize(
+        "payload,why",
+        [
+            ("!!!not-base64!!!", "not base64 at all"),
+            ("data:image/png;base64,!!!!", "data URL wrapping non-base64"),
+            (_NOT_AN_IMAGE_BASE64, "valid base64, bytes are not an image"),
+            (
+                f"data:image/png;base64,{_NOT_AN_IMAGE_BASE64}",
+                "png content type, non-image bytes (the issue's payload)",
+            ),
+            (base64.b64encode(b"%PDF-1.7 not an image").decode("ascii"), "a PDF"),
+        ],
+    )
+    def test_rogue_image_payloads_are_rejected(self, payload, why):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ImagePromptEntry(image=payload, frame_pos=0)
+
+    @pytest.mark.parametrize(
+        "header",
+        [
+            b"\x89PNG\r\n\x1a\n" + b"\x00" * 32,
+            b"\xff\xd8\xff\xe0" + b"\x00" * 32,  # JPEG
+            b"GIF89a" + b"\x00" * 32,
+            b"BM" + b"\x00" * 32,  # BMP
+            b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 32,
+        ],
+    )
+    def test_real_image_headers_are_accepted(self, header):
+        """The boundary check is a header sniff, not a full decode: it must not
+        start 422-ing formats the pipeline can actually read."""
+        entry = ImagePromptEntry(
+            image=base64.b64encode(header).decode("ascii"), frame_pos=0
+        )
+        assert entry.frame_pos == 0
+
+    def test_a_real_png_is_still_accepted(self):
+        """Regression guard: the happy path must not move."""
+        entry = ImagePromptEntry(image=_tiny_png_base64(), frame_pos=0)
+        assert entry.image == _tiny_png_base64()
+
+    def test_padding_stripped_base64_is_still_accepted(self):
+        """HTTP/JSON transports strip ``=`` padding. The boundary check has to
+        restore it exactly like ``ImageManager.base64_to_pil_image`` does, or it
+        would reject images the runner can decode fine."""
+        entry = ImagePromptEntry(image=_tiny_png_base64().rstrip("="), frame_pos=0)
+        assert entry.image
+
+    def test_line_wrapped_base64_is_still_accepted(self):
+        """MIME-style wrapping at 76 columns is what the ``base64`` CLI produces.
+        The boundary must tolerate it, or a payload the runner decodes fine would
+        be rejected as malformed."""
+        b64 = _tiny_png_base64()
+        wrapped = "\n".join([b64[:40], b64[40:]])
+
+        entry = ImagePromptEntry(image=wrapped, frame_pos=0)
+        assert entry.image == wrapped
+
+    @pytest.mark.asyncio
+    async def test_rogue_request_never_reaches_the_service(self):
+        """The whole point: rejected during request parsing, so the scheduler and
+        the device worker never see it."""
+        from pydantic import ValidationError
+
+        mock_service = MagicMock()
+        mock_service.create_job = AsyncMock()
+
+        with pytest.raises(ValidationError):
+            VideoI2VGenerateRequest(
+                prompt="A serene mountain landscape with flowing water",
+                num_inference_steps=12,
+                seed=42,
+                image_prompts=[{"image": _NOT_AN_IMAGE_BASE64, "frame_pos": 0}],
+            )
+
+        mock_service.create_job.assert_not_called()
+
+
+class TestRogueSeedRejectedAtTheBoundary:
+    """``seed`` is packed as a signed 64-bit int in SHM (``ipc/video_shm.py``).
+
+    Out-of-range values used to be accepted by the API and then raise
+    ``struct.error`` inside the device worker — a different rogue-parameter
+    signature from the image case, with the same #4811 restart consequence.
+    """
+
+    @pytest.mark.parametrize("seed", [2**63, 2**64, -(2**63) - 1, 10**30])
+    def test_seed_outside_int64_is_rejected(self, seed):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            VideoGenerateRequest(prompt="A cat", seed=seed)
+
+    @pytest.mark.parametrize("seed", [0, 42, 2**63 - 1, -(2**63), None])
+    def test_seed_inside_int64_is_accepted(self, seed):
+        assert VideoGenerateRequest(prompt="A cat", seed=seed).seed == seed
+
+    def test_the_rejected_range_is_exactly_what_shm_cannot_pack(self):
+        """Pins the bound to its reason: the boundary rejects precisely the
+        values that would have blown up in ``VideoShm.write_request``."""
+        import struct
+
+        with pytest.raises(struct.error):
+            struct.pack("<q", 2**63)
+
+        struct.pack("<q", 2**63 - 1)  # in range, must not raise
+
+
+class TestI2VUploadRogueBytes:
+    """``/generations/i2v/upload`` builds the DTO in code, so a validation error
+    there would surface as a 500 unless the endpoint translates it."""
+
+    @pytest.mark.asyncio
+    async def test_png_content_type_with_garbage_bytes_is_a_422(self):
+        upload = MagicMock()
+        upload.content_type = "image/png"
+        upload.read = AsyncMock(side_effect=[b"x" * 804, b""])
+
+        mock_service = MagicMock()
+        mock_service.create_job = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await submit_generate_video_i2v_upload(
+                prompt="A cat",
+                image=upload,
+                service=mock_service,
+                api_key="test_key",
+            )
+
+        assert exc_info.value.status_code == 422
+        mock_service.create_job.assert_not_called()
+
+
+class TestRogueRequestOverHttp:
+    """The status the client actually receives, through a real FastAPI app.
+
+    The DTO tests above pin validation; this pins the contract #4811 complained
+    about — a rogue body must come back 4xx, not ``500 Internal Server Error``,
+    and must not reach the service.
+    """
+
+    @pytest.fixture
+    def mock_service(self):
+        service = MagicMock()
+        service.scheduler = MagicMock()
+        service.scheduler.check_is_model_ready = MagicMock()
+        service.create_job = AsyncMock(
+            return_value={"id": "job_1", "object": "video", "status": "pending"}
+        )
+        return service
+
+    @pytest.fixture
+    def client(self, mock_service):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from open_ai_api.video import router as video_router
+        from resolver.service_resolver import service_resolver
+        from security.api_key_checker import get_api_key
+
+        app = FastAPI()
+        app.include_router(video_router, prefix="/v1/videos")
+        app.dependency_overrides[service_resolver] = lambda: mock_service
+        app.dependency_overrides[get_api_key] = lambda: "test-key"
+        return TestClient(app)
+
+    def test_the_issues_payload_gets_a_422(self, client, mock_service):
+        """Body copied from #4811's reproduction curl, with its 804-byte
+        non-image conditioning payload."""
+        response = client.post(
+            "/v1/videos/generations/i2v",
+            json={
+                "model": "Wan-AI/Wan2.2-I2V-A14B-Diffusers",
+                "prompt": "A serene mountain landscape with flowing water",
+                "num_inference_steps": 12,
+                "seed": 42,
+                "image_prompts": [
+                    {
+                        "image": f"data:image/png;base64,{_NOT_AN_IMAGE_BASE64}",
+                        "frame_pos": 0,
+                    }
+                ],
+            },
+        )
+
+        assert response.status_code == 422
+        assert "image" in response.text
+        mock_service.create_job.assert_not_called()
+
+    def test_out_of_range_seed_gets_a_422(self, client, mock_service):
+        response = client.post(
+            "/v1/videos/generations/i2v",
+            json={
+                "prompt": "A cat",
+                "seed": 2**63,
+                "image_prompts": [{"image": _tiny_png_base64(), "frame_pos": 0}],
+            },
+        )
+
+        assert response.status_code == 422
+        mock_service.create_job.assert_not_called()
+
+    @patch("open_ai_api.video.settings")
+    def test_a_valid_i2v_request_still_reaches_the_service(
+        self, mock_settings, client, mock_service
+    ):
+        """Regression guard: the boundary checks must not shut the door on real
+        traffic."""
+        mock_settings.use_async_video = True
+        mock_settings.model_runner = "tt-wan2.2-i2v"
+
+        response = client.post(
+            "/v1/videos/generations/i2v",
+            json={
+                "prompt": "A serene mountain landscape with flowing water",
+                "num_inference_steps": 12,
+                "seed": 42,
+                "image_prompts": [{"image": _tiny_png_base64(), "frame_pos": 0}],
+            },
+        )
+
+        assert response.status_code == 202
+        mock_service.create_job.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tt-media-server/tt_model_runners/mock_video_runner_concurrent_i2v.py
+++ b/tt-media-server/tt_model_runners/mock_video_runner_concurrent_i2v.py
@@ -121,8 +121,14 @@ def validateI2VRequest(req) -> None:
             try:
                 imageManager.base64_to_pil_image(entry["image"])
             except Exception as e:
+                # ``400: `` prefix on purpose: the real multihost peer writes
+                # ``str(HTTPException(400, ...))`` into the response SHM, and
+                # ``SPRunner`` reads the status back off that prefix to keep a bad
+                # conditioning image off the worker's error budget (#4811). Without
+                # it the mock would drive a code path the production peer never
+                # takes.
                 raise ValueError(
-                    f"I2V mock: image_prompts[{idx}].image failed to decode: {e}"
+                    f"400: I2V mock: image_prompts[{idx}].image failed to decode: {e}"
                 ) from e
 
 

--- a/tt-media-server/tt_model_runners/sp_runner.py
+++ b/tt-media-server/tt_model_runners/sp_runner.py
@@ -28,6 +28,7 @@ from concurrent.futures import Future as CFuture
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 
 from config.constants import CANARY_DEEP_TASK_ID, CANARY_TASK_ID, CANARY_TASK_IDS
+from domain.errors import ClientRequestError, parse_peer_status
 from ipc.video_shm import (
     MAX_IMAGE_PATH_LEN,
     SP_WARMUP_TASK_ID,
@@ -653,6 +654,19 @@ class SPRunner(BaseDeviceRunner):
 
         if resp.status == VideoStatus.ERROR:
             self._try_unlink(resp.file_path)
+            # The peer stringifies its exception into ``error_message``, so an
+            # input rejection arrives as ``"400: ..."`` (Starlette's
+            # ``HTTPException.__str__``). Flattening every peer error into a
+            # RuntimeError lost that distinction, and the scheduler then counted a
+            # bad conditioning image against this worker's health — six such
+            # requests restarted it (#4811). 5xx and unprefixed messages stay
+            # RuntimeErrors so genuine device faults still count.
+            peer_status = parse_peer_status(resp.error_message)
+            if peer_status is not None:
+                raise ClientRequestError(
+                    f"Runner error for task {task_id}: {resp.error_message}",
+                    status_code=peer_status,
+                )
             raise RuntimeError(f"Runner error for task {task_id}: {resp.error_message}")
 
         mp4_path = resp.file_path

--- a/tt-media-server/tt_model_runners/video_runner.py
+++ b/tt-media-server/tt_model_runners/video_runner.py
@@ -60,6 +60,7 @@ from config.constants import (
     CANARY_TASK_IDS,
     ModelRunners,
 )
+from domain.errors import ClientRequestError
 from domain.video_generate_request import VideoGenerateRequest
 from domain.video_i2v_generate_request import (
     ImagePromptEntry,
@@ -73,6 +74,7 @@ from ipc.video_shm import (
     VideoStatus,
     cleanup_orphaned_video_files,
 )
+from pydantic import ValidationError
 from utils.logger import TTLogger
 
 _log = TTLogger("video_runner")
@@ -267,12 +269,23 @@ def video_request_to_generate_request(
     common = shm_names & gen_names
     base_kwargs = {name: getattr(req, name) for name in common}
 
-    if image_prompts:
-        return VideoI2VGenerateRequest(
-            **base_kwargs,
-            image_prompts=[ImagePromptEntry(**entry) for entry in image_prompts],
-        )
-    return VideoGenerateRequest(**base_kwargs)
+    try:
+        if image_prompts:
+            return VideoI2VGenerateRequest(
+                **base_kwargs,
+                image_prompts=[ImagePromptEntry(**entry) for entry in image_prompts],
+            )
+        return VideoGenerateRequest(**base_kwargs)
+    except ValidationError as e:
+        # Everything here came off the wire, so a schema failure is the client's
+        # bug. The caller writes ``str(exc)`` into the response SHM, and
+        # ``ClientRequestError`` renders as ``"400: ..."`` — the prefix
+        # ``SPRunner`` reads back to keep this off the worker's error budget
+        # (#4811). A bare ValidationError would arrive unprefixed and be counted
+        # as a device fault.
+        raise ClientRequestError(
+            f"Invalid request payload for task {req.task_id}: {e}"
+        ) from e
 
 
 def _write_response_to_shm(

--- a/tt-media-server/utils/base64_image.py
+++ b/tt-media-server/utils/base64_image.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Base64 image handling that request schemas can reach for.
+
+Deliberately stdlib-only. ``utils.image_manager`` imports torch, numpy and PIL,
+so a DTO validator cannot call into it without dragging the whole model stack
+into request parsing — and into every process that merely imports the domain
+layer. The decode half of that module lives here instead, and
+``ImageManager.base64_to_pil_image`` calls it, so the API boundary and the device
+runner agree byte-for-byte on what "decodable" means. If they disagreed we would
+be back to accepting requests the runner then rejects on the device, which is
+what #4811 was about.
+
+The validation here is a header sniff, not a full decode. That is the right
+depth for a request boundary: it costs nothing, needs no image library, and
+catches the whole class of failure in the issue ("cannot identify image file" is
+PIL failing to match a header). Payloads that pass the sniff but fail the real
+decode later — a truncated PNG, say — are caught in ``ImageManager`` and raised
+as :class:`~domain.errors.ClientRequestError` there, so they still never count
+against worker health.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+
+from domain.errors import ClientRequestError
+
+__all__ = [
+    "decode_base64_image",
+    "normalize_base64_payload",
+    "sniff_image_format",
+    "validate_base64_image",
+]
+
+# Header signatures for the formats the video and image pipelines actually read.
+# ``(offset, magic, name)`` — WebP needs the offset form because its magic sits
+# after the RIFF chunk size.
+_MAGIC_BYTES: tuple[tuple[int, bytes, str], ...] = (
+    (0, b"\x89PNG\r\n\x1a\n", "png"),
+    (0, b"\xff\xd8\xff", "jpeg"),
+    (0, b"GIF87a", "gif"),
+    (0, b"GIF89a", "gif"),
+    (0, b"BM", "bmp"),
+    (0, b"II*\x00", "tiff"),
+    (0, b"MM\x00*", "tiff"),
+    (8, b"WEBP", "webp"),
+)
+
+# Longest prefix any check above needs.
+_SNIFF_BYTES = 12
+
+
+def normalize_base64_payload(payload: str) -> str:
+    """Strip a ``data:`` URL wrapper and whitespace, and restore lost padding.
+
+    Three transport artefacts to undo, in order:
+
+    * a ``data:image/png;base64,`` prefix,
+    * embedded whitespace — MIME-style base64 (what the ``base64`` CLI emits) is
+      wrapped at 76 columns, and ``b64decode`` only tolerates that with
+      ``validate=False``, which also silently swallows genuine junk,
+    * stripped ``=`` padding, which HTTP transports and many JSON serialisers
+      drop.
+
+    Doing this in one place is what keeps the API boundary check and the runner's
+    decode from disagreeing about which payloads are valid.
+    """
+    if payload.startswith("data:"):
+        _, _, payload = payload.partition(",")
+    payload = "".join(payload.split())
+    return payload + "=" * (-len(payload) % 4)
+
+
+def decode_base64_image(payload: str, *, what: str = "image") -> bytes:
+    """Decode *payload* to raw bytes, or raise ``ClientRequestError`` (400).
+
+    ``validate=True`` so stray non-alphabet characters are an error instead of
+    being silently discarded — otherwise ``"!!!not-base64!!!"`` decodes to a few
+    junk bytes and the failure surfaces much later, as an undiagnosable image
+    error inside the device worker.
+    """
+    normalized = normalize_base64_payload(payload)
+    try:
+        return base64.b64decode(normalized, validate=True)
+    except (binascii.Error, ValueError) as e:
+        raise ClientRequestError(
+            f"Could not decode {what}: {payload[:32]!r}... is not valid base64 ({e})"
+        ) from e
+
+
+def sniff_image_format(raw: bytes) -> str | None:
+    """Return the image format *raw* starts with, or None if it isn't an image."""
+    for offset, magic, name in _MAGIC_BYTES:
+        if raw[offset : offset + len(magic)] == magic:
+            return name
+    return None
+
+
+def validate_base64_image(payload: str, *, what: str = "image") -> str:
+    """Return *payload* unchanged if it is a base64-encoded image, else raise.
+
+    Raises :class:`~domain.errors.ClientRequestError` (400) so the same failure
+    reads identically whether it is hit during request parsing or deeper in a
+    runner. Pydantic wraps it into a 422 when used as a field validator, which is
+    the correct status for a malformed request body.
+    """
+    raw = decode_base64_image(payload, what=what)
+    if sniff_image_format(raw) is None:
+        supported = sorted({name for _, _, name in _MAGIC_BYTES})
+        raise ClientRequestError(
+            f"Could not decode {what} ({len(raw)} bytes): the payload is valid "
+            f"base64 but not a recognised image. Supported: {supported}."
+        )
+    return payload

--- a/tt-media-server/utils/image_manager.py
+++ b/tt-media-server/utils/image_manager.py
@@ -7,8 +7,10 @@ from io import BytesIO
 
 import numpy as np
 import torch
+from domain.errors import ClientRequestError
 from fastapi import HTTPException, Path, UploadFile
 from PIL import Image
+from utils.base64_image import decode_base64_image
 
 
 class ImageManager:
@@ -104,19 +106,32 @@ class ImageManager:
 
         Returns:
             PIL Image object
+
+        Raises:
+            ClientRequestError: the payload is not a decodable image. This runs
+                inside the device worker (every I2V ``_build_image_prompt`` calls
+                it), where a bare ``binascii.Error``/``UnidentifiedImageError``
+                used to reach the scheduler as an unclassifiable string and count
+                against the worker's error budget — six bad requests then cost a
+                restart (#4811).
         """
-        if base64_string.startswith("data:"):
-            base64_string = base64_string.split(",")[1]
-        # Restore stripped padding so HTTP/JSON-trimmed strings decode cleanly.
-        base64_string += "=" * (-len(base64_string) % 4)
-        image_bytes = base64.b64decode(base64_string)
-        image = Image.open(BytesIO(image_bytes))
+        image_bytes = decode_base64_image(base64_string)
 
-        if image.mode != target_mode:
-            image = image.convert(target_mode)
+        try:
+            image = Image.open(BytesIO(image_bytes))
 
-        if target_size is not None:
-            image = image.resize(target_size, Image.Resampling.LANCZOS)
+            if image.mode != target_mode:
+                image = image.convert(target_mode)
+
+            if target_size is not None:
+                image = image.resize(target_size, Image.Resampling.LANCZOS)
+        except (OSError, ValueError) as e:
+            # Nothing here touches a device: open/convert/resize failures are
+            # always a property of the bytes the client sent (truncated file,
+            # unsupported subformat, corrupt stream).
+            raise ClientRequestError(
+                f"Could not decode image ({len(image_bytes)} bytes): {e}"
+            ) from e
 
         return image
 


### PR DESCRIPTION
Fixes #4811 (re-opened).

## Why the issue came back

#4817 added a route dependency that 422s **text-only** `POST /generations` on I2V-only deployments — one request signature. It never touched the mechanism the issue title names: `Scheduler.error_listener` incremented `worker_info[...]["error_count"]` for **every** entry on `error_queue`, with no distinction between "the device is dying" and "the client sent junk".

The chain behind the re-opened report, confirmed end to end:

1. Peer raises `HTTPException(400, "Could not decode image (804 bytes): ...")` for bad image bytes.
2. Rank 0 writes `str(e)` into SHM (`tt_model_runners/video_runner.py`) — that is where the `400: ` prefix in the log comes from (Starlette's `HTTPException.__str__`).
3. `SPRunner.await_result` flattened it into a plain `RuntimeError`, discarding the status.
4. `device_worker` pushed a bare string onto `error_queue`; `error_listener` counted it → 6th error → `Worker 0 has too many errors (6), restarting` → `/health` 503 → pod shutdown.
5. Amplifier: `restart_worker` carried `error_count - 1` forward, so the restarted worker sat at 5/6 and **one** more rogue request restarted it again.

Two rogue-parameter signatures reached that chain, both distinct from the one #4817 patched, both reproducible with no device:

- **`ImagePromptEntry.image`** was only length-checked, so undecodable base64 or valid-base64-but-not-an-image was accepted and failed on the device.
- **`seed`** was unbounded at the API but is packed as signed 64-bit in SHM (`ipc/video_shm.py`), so `seed: 2**63` raised `struct.error` *inside the worker*.

## Reproduction, before and after

Driving the real chain in one process (real `ImageManager` decode → real `_continuous_fan_out` → real `multiprocessing.Queue` → real `error_listener` → real `worker_health_monitor`) with 6 rogue image requests:

| | before | after |
| --- | --- | --- |
| rogue `image_prompts` at API | accepted, dispatched to device | rejected, 422 |
| `seed: 2**63` at API | accepted, dispatched to device | rejected, 422 |
| `error_count` after 6 rogue requests | **6** | **0** |
| `client_error_count` | n/a | 6 |
| what the client sees | `Exception` → **500** | `ClientRequestError` → **400** |
| worker | **restarted** | survived |

## The fix, in layers

**Root cause — error accounting** (`domain/errors.py`, `model_services/scheduler.py`)
- `ClientRequestError(HTTPException)`, with an explicit `__reduce__`: Starlette's `HTTPException` never calls `super().__init__`, so its `args` are empty and the default pickle protocol cannot revive it — and these instances cross an `mp.Queue` on every worker error.
- `error_listener` counts client rejections in a separate `client_error_count` (surfaced through `get_worker_info`, so the signal stays visible) and leaves `error_count` for device and runner faults only.
- It forwards the error unwrapped rather than as `Exception(error)`. Since `ClientRequestError` *is* an `HTTPException`, `_submit_video_request`'s existing `except HTTPException: raise` hands the caller the right status with no per-endpoint plumbing.
- `restart_worker` resets `error_count` to 0. `restart_count` still accumulates, so the give-up / deep-reset escalation in `worker_health_monitor` is untouched.

**Classification survives every hop**
- `SPRunner.await_result` reads the peer's `4xx: ` prefix; 5xx and unprefixed messages stay `RuntimeError`s so genuine device faults still count.
- `video_runner.video_request_to_generate_request` wraps DTO rebuild failures so they carry that prefix (otherwise the new validator would make rank 0 emit an unprefixed pydantic message that gets counted as a device fault).
- Both device workers keep the exception instance on the queue instead of flattening it into an f-string.
- A narrow exception-type tuple (`binascii.Error`, `struct.error`, `ValidationError`, `UnicodeDecodeError`) is the backstop for the *next* unvalidated parameter. `ValueError`/`OSError` are deliberately excluded — device code raises those too, and a wrong classification would blind the watchdog.

**Boundary validation, video only**
- `utils/base64_image.py` — stdlib-only so request schemas can import it without pulling torch/PIL into request parsing. `ImageManager.base64_to_pil_image` now calls the same decode helper, so the API and the device agree byte-for-byte on what "decodable" means.
- `ImagePromptEntry.image` header-sniffs the payload; `seed` is bounded to exactly the range SHM can pack; the i2v upload endpoint translates `ValidationError` to 422 instead of leaking a 500 (it builds the DTO itself, so FastAPI's usual handling does not apply).
- `mock_video_runner_concurrent_i2v` now prefixes its validation errors with `400: ` to match what the production peer emits, so the mock exercises the real code path.

## Tests

Red-first; every test below failed on `main` for the stated reason before the fix.

- `tests/test_scheduler_client_error_isolation.py` (new) — the accounting, the `ClientRequestError` wire contract, and the full chain end to end against a real `multiprocessing.Queue`, using the real `ImageManager` decode rather than a hand-made exception. `test_rogue_image_requests_never_restart_the_worker` is the issue verbatim.
- `tests/test_video_api.py` — rogue payloads rejected at the boundary and never reaching the service, including the issue's exact curl body posted through a real FastAPI app (422, `create_job` not called), plus regression guards that a real PNG and a valid I2V request still get through (202).
- `tests/test_sp_runner.py`, `tests/test_device_worker.py`, `tests/test_image_manager.py` — per-hop classification, plus the side-file cleanup that must still happen on the new error type.

**Every isolation case is paired with a control case** asserting that a genuine device fault still increments `error_count` and still restarts the worker. The goal is to stop miscounting client errors, not to blind the watchdog.

Suites: 1109 passed in `tt-media-server/tests/`, 1558 passed in `tests/`, `ruff check`/`format` clean. Four unrelated `test_memory_queue`/`test_tt_batch_fifo_queue` failures reproduce on `main` locally (macOS) on files this PR does not touch.

## Reviewer notes

- **One accepted contract change**: a base64 image must now carry a recognisable header (PNG/JPEG/GIF/BMP/WebP/TIFF). An exotic format some PIL plugin might have decoded now gets 422. The upload endpoint already restricted to png/jpeg/webp, so this is a superset of what we advertise. Line-wrapped and padding-stripped base64 are explicitly still accepted (tests pin both) — tightening to `validate=True` would otherwise have rejected MIME-wrapped payloads the old lenient decode tolerated.
- **Out of scope, deliberately**: `ImageToImageRequest.image` on the SDXL endpoints has the same unvalidated `image: str` shape. It picks up the classification fix for free through `ImageManager` — a bad image there stops costing worker health — but gets no new 422s. Say the word if you want the boundary check extended there too.
- **Not changed**: the watchdog stays cumulative (no rolling error window), and `prompt` length stays unbounded — `VideoShm._pack_string` truncates it safely, so it cannot produce this failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
