### PR TITLE
Validate base64 image for image to video generation

### DIFF
--- a/tt-media-server/domain/video_i2v_generate_request.py
+++ b/tt-media-server/domain/video_i2v_generate_request.py
@@ -13,13 +13,10 @@ The pipeline-level ``num_frames`` (used by both the runner and the validators
 below) is the single source of truth in ``config.constants.WAN22_NUM_FRAMES``.
 """
 
-import base64
-from io import BytesIO
 from typing import List
 
 from config.constants import WAN22_NUM_FRAMES
 from domain.video_generate_request import VideoGenerateRequest
-from PIL import Image
 from pydantic import BaseModel, Field, field_validator
 
 # The cap exists to bound HTTP body size, not to match
@@ -36,24 +33,20 @@ class ImagePromptEntry(BaseModel):
     @field_validator("image")
     @classmethod
     def validate_decodable_image(cls, v: str) -> str:
-        """Ensure the base64 string decodes to a valid image."""
-        raw = v
-        if raw.startswith("data:"):
-            raw = raw.split(",", 1)[1]
-        # Restore padding stripped during transport.
-        raw += "=" * (-len(raw) % 4)
+        """Ensure the base64 string decodes to a valid PIL image via ImageManager."""
+        from utils.image_manager import ImageManager
+
         try:
-            image_bytes = base64.b64decode(raw, validate=True)
-        except Exception as exc:
-            raise ValueError("image is not valid base64-encoded data") from exc
-        try:
-            img = Image.open(BytesIO(image_bytes))
-            img.load()
+            img = ImageManager().base64_to_pil_image(v)
         except Exception as exc:
             raise ValueError(
-                "image does not decode to a valid image "
+                "image could not be decoded to a valid PIL image "
                 "(supported formats: PNG, JPEG, WebP, etc.)"
             ) from exc
+        if img.size[0] < 1 or img.size[1] < 1:
+            raise ValueError(
+                "image has invalid dimensions (width and height must be >= 1)"
+            )
         return v
 
 

--- a/tt-media-server/domain/video_i2v_generate_request.py
+++ b/tt-media-server/domain/video_i2v_generate_request.py
@@ -18,6 +18,7 @@ from typing import List
 from config.constants import WAN22_NUM_FRAMES
 from domain.video_generate_request import VideoGenerateRequest
 from pydantic import BaseModel, Field, field_validator
+from utils.image_manager import ImageManager
 
 # The cap exists to bound HTTP body size, not to match
 # any pipeline constraint.
@@ -34,7 +35,6 @@ class ImagePromptEntry(BaseModel):
     @classmethod
     def validate_decodable_image(cls, v: str) -> str:
         """Ensure the base64 string decodes to a valid PIL image via ImageManager."""
-        from utils.image_manager import ImageManager
 
         try:
             img = ImageManager().base64_to_pil_image(v)

--- a/tt-media-server/domain/video_i2v_generate_request.py
+++ b/tt-media-server/domain/video_i2v_generate_request.py
@@ -13,10 +13,13 @@ The pipeline-level ``num_frames`` (used by both the runner and the validators
 below) is the single source of truth in ``config.constants.WAN22_NUM_FRAMES``.
 """
 
+import base64
+from io import BytesIO
 from typing import List
 
 from config.constants import WAN22_NUM_FRAMES
 from domain.video_generate_request import VideoGenerateRequest
+from PIL import Image
 from pydantic import BaseModel, Field, field_validator
 
 # The cap exists to bound HTTP body size, not to match
@@ -29,6 +32,31 @@ class ImagePromptEntry(BaseModel):
 
     image: str = Field(min_length=1, max_length=MAX_BASE64_IMAGE_LEN)
     frame_pos: int = Field(default=0, ge=0, lt=WAN22_NUM_FRAMES)
+
+    @field_validator("image")
+    @classmethod
+    def validate_decodable_image(cls, v: str) -> str:
+        """Ensure the base64 string decodes to a valid image."""
+        raw = v
+        if raw.startswith("data:"):
+            raw = raw.split(",", 1)[1]
+        # Restore padding stripped during transport.
+        raw += "=" * (-len(raw) % 4)
+        try:
+            image_bytes = base64.b64decode(raw, validate=True)
+        except Exception as exc:
+            raise ValueError(
+                "image is not valid base64-encoded data"
+            ) from exc
+        try:
+            img = Image.open(BytesIO(image_bytes))
+            img.load()
+        except Exception as exc:
+            raise ValueError(
+                "image does not decode to a valid image "
+                "(supported formats: PNG, JPEG, WebP, etc.)"
+            ) from exc
+        return v
 
 
 class VideoI2VGenerateRequest(VideoGenerateRequest):

--- a/tt-media-server/domain/video_i2v_generate_request.py
+++ b/tt-media-server/domain/video_i2v_generate_request.py
@@ -45,9 +45,7 @@ class ImagePromptEntry(BaseModel):
         try:
             image_bytes = base64.b64decode(raw, validate=True)
         except Exception as exc:
-            raise ValueError(
-                "image is not valid base64-encoded data"
-            ) from exc
+            raise ValueError("image is not valid base64-encoded data") from exc
         try:
             img = Image.open(BytesIO(image_bytes))
             img.load()

--- a/tt-media-server/tests/test_video_api.py
+++ b/tt-media-server/tests/test_video_api.py
@@ -625,7 +625,9 @@ class TestVideoI2VGenerateRequestValidation:
         """Garbage string that isn't valid base64 should fail validation."""
         from pydantic import ValidationError
 
-        with pytest.raises(ValidationError, match="not valid base64"):
+        with pytest.raises(
+            ValidationError, match="could not be decoded to a valid PIL image"
+        ):
             ImagePromptEntry(image="not-a-real-image!!!", frame_pos=0)
 
     def test_valid_base64_non_image_rejected(self):
@@ -635,7 +637,9 @@ class TestVideoI2VGenerateRequestValidation:
         from pydantic import ValidationError
 
         fake = base64.b64encode(b"hello world this is not an image").decode()
-        with pytest.raises(ValidationError, match="does not decode to a valid image"):
+        with pytest.raises(
+            ValidationError, match="could not be decoded to a valid PIL image"
+        ):
             ImagePromptEntry(image=fake, frame_pos=0)
 
     def test_raw_base64_png_accepted(self):

--- a/tt-media-server/tests/test_video_api.py
+++ b/tt-media-server/tests/test_video_api.py
@@ -615,6 +615,34 @@ class TestVideoI2VGenerateRequestValidation:
         assert request.num_inference_steps == 30
         assert request.seed == 42
 
+    def test_valid_image_with_data_uri_prefix_accepted(self):
+        """base64 image with 'data:image/png;base64,' prefix should pass."""
+        prefixed = "data:image/png;base64," + _tiny_png_base64()
+        entry = ImagePromptEntry(image=prefixed, frame_pos=0)
+        assert entry.image == prefixed
+
+    def test_invalid_base64_rejected(self):
+        """Garbage string that isn't valid base64 should fail validation."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="not valid base64"):
+            ImagePromptEntry(image="not-a-real-image!!!", frame_pos=0)
+
+    def test_valid_base64_non_image_rejected(self):
+        """Valid base64 encoding of non-image bytes should fail validation."""
+        import base64
+
+        from pydantic import ValidationError
+
+        fake = base64.b64encode(b"hello world this is not an image").decode()
+        with pytest.raises(ValidationError, match="does not decode to a valid image"):
+            ImagePromptEntry(image=fake, frame_pos=0)
+
+    def test_raw_base64_png_accepted(self):
+        """Raw base64 PNG without data URI prefix should pass."""
+        entry = ImagePromptEntry(image=_tiny_png_base64(), frame_pos=0)
+        assert entry.frame_pos == 0
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add a check for base64 file and throw an api error if image(s) are not valid base64 files.

Broken image error:

<img width="1480" height="494" alt="image" src="https://github.com/user-attachments/assets/fca660b6-e052-4cd5-b4b3-a890e1085e2e" />
