### PR TITLE
Move generic workflow enums into engine-owned module

### DIFF
--- a/llm_module/agentic_traces/runs.py
+++ b/llm_module/agentic_traces/runs.py
@@ -24,7 +24,7 @@ from reference_config.agentic_traces.agentic_traces_config import (
     AgenticTracesRunSpec,
     TraceSource,
 )
-from workflows.workflow_types import AgenticTracesMode
+from workflow_module.engine_types import AgenticTracesMode
 
 # Trace sources with a working client. Both the InferenceX AIPerf fork and the
 # SwarmOne ``swo-bench`` replay engine are wired; any source added to the config

--- a/llm_module/benchmark_configs.py
+++ b/llm_module/benchmark_configs.py
@@ -31,7 +31,7 @@ def get_llm_configs(
         get_benchmark_config,
         select_smoke_test_benchmark_config,
     )
-    from workflows.workflow_types import EvalLimitMode
+    from workflow_module.engine_types import EvalLimitMode
 
     benchmark_config = get_benchmark_config(model_spec)
 

--- a/llm_module/drivers/agentic.py
+++ b/llm_module/drivers/agentic.py
@@ -11,7 +11,7 @@ import logging
 from pathlib import Path
 from typing import Any, List, Optional
 
-from workflows.workflow_types import EvalLimitMode
+from workflow_module.engine_types import EvalLimitMode
 
 from ..agentic.swebench import SWEbenchRunConfig, run as run_swebench
 from ..agentic.terminal_bench import TerminalBenchRunConfig, run as run_terminal_bench

--- a/llm_module/eval_command.py
+++ b/llm_module/eval_command.py
@@ -16,7 +16,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
 from utils.url_helpers import build_base_url
-from workflows.workflow_types import EvalLimitMode, WorkflowVenvType
+from workflow_module.engine_types import EvalLimitMode
+from workflows.workflow_types import WorkflowVenvType
 from workflows.workflow_venvs import VENV_CONFIGS
 
 if TYPE_CHECKING:

--- a/llm_module/eval_configs.py
+++ b/llm_module/eval_configs.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import logging
 from typing import List
 
-from workflows.workflow_types import EvalLimitMode, WorkflowVenvType
+from workflow_module.engine_types import EvalLimitMode
+from workflows.workflow_types import WorkflowVenvType
 
 from .eval_command import _get_limit_mode, _parse_eval_samples_mapping
 

--- a/llm_module/parsers/agentic.py
+++ b/llm_module/parsers/agentic.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Mapping, Optional, Union
 
 from reference_config.evals.eval_config import accept_eval_score, resolve_eval_reference
 from report_module.schema import Block
-from workflows.workflow_types import ReportCheckTypes
+from workflow_module.engine_types import ReportCheckTypes
 
 from .base import LLMResultParser
 

--- a/llm_module/target_checks.py
+++ b/llm_module/target_checks.py
@@ -16,7 +16,7 @@ import logging
 from typing import Any, Dict, Mapping, Optional, Tuple
 
 from report_module.schema import Block
-from workflows.workflow_types import ReportCheckTypes
+from workflow_module.engine_types import ReportCheckTypes
 
 logger = logging.getLogger(__name__)
 

--- a/report_module/acceptance_criteria.py
+++ b/report_module/acceptance_criteria.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
-from workflows.workflow_types import ModelStatusTypes
+from workflow_module.engine_types import ModelStatusTypes
 
 from .schema import Block, ReportSchema
 from .status import TestStatus, glyph_for_label

--- a/test_module/dispatch.py
+++ b/test_module/dispatch.py
@@ -25,7 +25,7 @@ from typing import Callable, List, Optional, Tuple
 
 from report_module.schema import Block
 from workflow_module import accept_blocks
-from workflows.workflow_types import ModelType
+from workflow_module.engine_types import ModelType
 
 from ._test_common import (
     SkipTest,

--- a/test_module/llm_tests/agentic_traces_tests.py
+++ b/test_module/llm_tests/agentic_traces_tests.py
@@ -53,7 +53,7 @@ from reference_config.agentic_traces.agentic_traces_config import (
     resolve_run_specs,
 )
 from workflow_module import accept_blocks
-from workflows.workflow_types import AgenticTracesMode
+from workflow_module.engine_types import AgenticTracesMode
 
 from ..context import MediaContext
 

--- a/test_module/llm_tests/llm_eval_tests.py
+++ b/test_module/llm_tests/llm_eval_tests.py
@@ -20,8 +20,8 @@ from llm_module.eval_command import build_eval_command
 from llm_module.eval_configs import get_llm_eval_tasks
 from report_module.schema import Block
 from workflow_module import accept_blocks
+from workflow_module.engine_types import EvalLimitMode
 from workflows.utils import run_command
-from workflows.workflow_types import EvalLimitMode
 
 from .._test_common import ReportCheckTypes, TestStatus, block_id
 from ..context import MediaContext

--- a/test_module/serving_bench/presets.py
+++ b/test_module/serving_bench/presets.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Dict, Optional
 
-from workflows.workflow_types import EvalLimitMode
+from workflow_module.engine_types import EvalLimitMode
 
 # agentic_bench consumes all of these; the cpp benchmark suite ignores the
 # knobs it doesn't define.

--- a/workflow_module/engine_types.py
+++ b/workflow_module/engine_types.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+
+"""Engine-owned workflow types.
+
+These enums are generic validation-framework concepts (workflow kinds, model
+modalities, check/status classifications, limit modes). They live in the
+engine so engine packages never import from the host/adapter layer
+(``workflows/``). Tenstorrent-specific taxonomies (``DeviceTypes``,
+``InferenceEngine``, ``WorkflowVenvType``, ...) remain in
+``workflows/workflow_types.py``, which re-exports everything defined here
+for backward compatibility.
+"""
+
+from enum import IntEnum, auto
+from typing import List, Optional
+
+
+class WorkflowType(IntEnum):
+    BENCHMARKS = auto()
+    EVALS = auto()
+    STRESS_TESTS = auto()
+    SERVER = auto()
+    RELEASE = auto()
+    SPEC_TESTS = auto()
+    AGENTIC = auto()
+    AGENTIC_TRACES = auto()
+    SERVING_BENCH = auto()
+    PREFILL_DECODE = auto()
+
+    @classmethod
+    def from_string(cls, name: str):
+        try:
+            return cls[name.upper()]
+        except KeyError:
+            raise ValueError(f"Invalid TaskType: {name}")
+
+
+class BenchmarkTaskType(IntEnum):
+    HTTP_CLIENT_VLLM_API = auto()
+    HTTP_CLIENT_CNN_API = auto()
+    HTTP_CLIENT_VLLM_STRUCTURED_OUTPUT_API = auto()
+
+
+class ReportCheckTypes(IntEnum):
+    NA = auto()
+    PASS = auto()
+    FAIL = auto()
+
+    @classmethod
+    def from_result(cls, result: bool):
+        res_map = {
+            None: ReportCheckTypes.NA,
+            True: ReportCheckTypes.PASS,
+            False: ReportCheckTypes.FAIL,
+        }
+        return res_map[result]
+
+    @classmethod
+    def to_display_string(cls, check_type: str):
+        disp_map = {
+            ReportCheckTypes.NA: "N/A",
+            ReportCheckTypes.PASS: "PASS ✅",
+            ReportCheckTypes.FAIL: "FAIL ⛔",
+        }
+        return disp_map[check_type]
+
+
+class ModelStatusTypes(IntEnum):
+    """
+    EXPERIMENTAL: Model implementation is available, but is unstable or has performance issues.
+    FUNCTIONAL: Model runs functionally without issue, but performance is lower than expected.
+    COMPLETE: Operationally complete, performance is usable for most applications.
+    TOP_PERF: Performance close to theoretical peak, nearly fully optimized.
+    """
+
+    EXPERIMENTAL = auto()
+    FUNCTIONAL = auto()
+    COMPLETE = auto()
+    TOP_PERF = auto()
+
+    @property
+    def display_string(self) -> str:
+        return {
+            ModelStatusTypes.EXPERIMENTAL: "🛠️ Experimental",
+            ModelStatusTypes.FUNCTIONAL: "🟡 Functional",
+            ModelStatusTypes.COMPLETE: "🟢 Complete",
+            ModelStatusTypes.TOP_PERF: "🚀 Top Performance",
+        }[self]
+
+    @property
+    def required_target_tiers(self) -> List[str]:
+        """Tiers that MUST pass for a model at this status level.
+
+        Tiers not in this list are still computed and reported but
+        treated as informational -- failures are accepted and do not
+        block a release. This enables programmatic masking: e.g. an
+        EXPERIMENTAL model (forge, new bring-up) can fail every
+        performance benchmark and still be released.
+        """
+        tier_map = {
+            ModelStatusTypes.EXPERIMENTAL: [],
+            ModelStatusTypes.FUNCTIONAL: ["functional"],
+            ModelStatusTypes.COMPLETE: ["functional", "complete"],
+            ModelStatusTypes.TOP_PERF: ["functional", "complete", "target"],
+        }
+        return tier_map[self]
+
+    @property
+    def evals_enforced(self) -> bool:
+        """Whether eval accuracy failures block acceptance at this status.
+
+        Reuses required_target_tiers' signal (empty only for EXPERIMENTAL) so
+        a model still in bring-up isn't blocked on eval accuracy either.
+        """
+        return bool(self.required_target_tiers)
+
+    @classmethod
+    def resolve(cls, name: Optional[str]) -> Optional["ModelStatusTypes"]:
+        """Best-effort ``name`` -> member lookup, or ``None`` if missing/unrecognized.
+
+        Unlike :meth:`EvalLimitMode.from_string`, this never raises: callers
+        use a missing/garbled status as a signal to fall back to the
+        strictest (fully-enforced) behavior rather than crash.
+        """
+        if not name:
+            return None
+        try:
+            return cls[name]
+        except KeyError:
+            return None
+
+
+class EvalLimitMode(IntEnum):
+    SMOKE_TEST = auto()
+    CI_COMMIT = auto()
+    CI_NIGHTLY = auto()
+    CI_LONG = auto()
+
+    @classmethod
+    def from_string(cls, name: str):
+        if name is None:
+            return None
+        try:
+            return cls[name.upper().replace("-", "_")]
+        except KeyError:
+            raise ValueError(f"Invalid EvalLimitMode: {name}")
+
+
+class AgenticTracesMode(IntEnum):
+    """Duration profile for the ``agentic_traces`` workflow.
+
+    Deliberately separate from :class:`EvalLimitMode`: agentic trace replay is
+    bounded by wall-clock profiling time rather than a dataset sample count, and
+    the InferenceX scenario enforces its own duration floor (see
+    ``AGENTIC_TRACES_MIN_PROFILE_SECONDS``), so the eval limit modes do not
+    translate.
+
+    ``FULL`` is the reference run used for reportable numbers; ``CI`` is the
+    shortest run the scenario still permits.
+    """
+
+    FULL = auto()
+    CI = auto()
+
+    @classmethod
+    def from_string(cls, name: str):
+        if name is None:
+            return None
+        try:
+            return cls[name.upper().replace("-", "_")]
+        except KeyError:
+            raise ValueError(f"Invalid AgenticTracesMode: {name}")
+
+    def to_string(self) -> str:
+        return self.name.lower()
+
+
+class VersionMode(IntEnum):
+    """Defines the enforcement mode for a version requirement."""
+
+    STRICT = auto()  # Requirement must be met, raises an error otherwise.
+    SUGGESTED = auto()  # A warning is issued if the requirement is not met.
+
+
+class ModelType(IntEnum):
+    LLM = auto()
+    CNN = auto()
+    AUDIO = auto()
+    IMAGE = auto()
+    EMBEDDING = auto()
+    TEXT_TO_SPEECH = auto()
+    VIDEO = auto()
+    VLM = auto()  # Vision-Language Models (text+image-to-text)
+    TRAINING = auto()
+
+    @property
+    def display_name(self) -> str:
+        display_names = {
+            ModelType.LLM: "Large Language Model",
+            ModelType.CNN: "Convolutional Neural Network",
+            ModelType.AUDIO: "Audio",
+            ModelType.IMAGE: "Image",
+            ModelType.EMBEDDING: "Embedding",
+            ModelType.TEXT_TO_SPEECH: "Text-to-Speech",
+            ModelType.VIDEO: "Video",
+            ModelType.VLM: "Vision-Language Model",
+            ModelType.TRAINING: "Training",
+        }
+        return display_names[self]
+
+    @property
+    def short_name(self) -> str:
+        short_names = {
+            ModelType.LLM: "LLM",
+            ModelType.VLM: "VLM",
+            ModelType.AUDIO: "Audio",
+            ModelType.IMAGE: "Image",
+            ModelType.CNN: "CNN",
+            ModelType.EMBEDDING: "Embedding",
+            ModelType.TEXT_TO_SPEECH: "TTS",
+            ModelType.VIDEO: "Video",
+            ModelType.TRAINING: "Training",
+        }
+        return short_names[self]
+
+    @property
+    def task_type(self) -> str:
+        task_types = {
+            ModelType.LLM: "text",
+            ModelType.VLM: "vlm",
+            ModelType.AUDIO: "asr",  # Automatic Speech Recognition
+            ModelType.IMAGE: "image",
+            ModelType.CNN: "cnn",
+            ModelType.EMBEDDING: "embedding",
+            ModelType.TEXT_TO_SPEECH: "tts",
+            ModelType.VIDEO: "video",
+            ModelType.TRAINING: "training",
+        }
+        return task_types[self]

--- a/workflow_module/workflows.py
+++ b/workflow_module/workflows.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import ClassVar, Dict, List, Optional, Sequence, Type
 
 from test_module.task_types import MediaTaskType
-from workflows.workflow_types import ModelType
+from workflow_module.engine_types import ModelType
 
 from .execution import (
     AgenticTracesOptions,

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -2,28 +2,50 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
+"""Tenstorrent-specific workflow types + backward-compatible re-exports.
+
+Generic validation-framework enums (``WorkflowType``, ``ModelType``,
+``ReportCheckTypes``, ``ModelStatusTypes``, ``EvalLimitMode``,
+``AgenticTracesMode``, ``BenchmarkTaskType``, ``VersionMode``) are owned by
+the engine in ``workflow_module/engine_types.py`` and re-exported here so
+existing ``workflows/`` callers keep working unchanged.
+
+The enums that remain defined in this module are Tenstorrent adapter
+concerns: hardware taxonomy (``DeviceTypes``, ``SystemTopology``), inference
+stack (``InferenceEngine``, ``ModelSource``), and TT host venv provisioning
+(``WorkflowVenvType``).
+"""
+
 from enum import Enum, IntEnum, auto
-from typing import List, Optional
 
+from workflow_module.engine_types import (
+    AgenticTracesMode,
+    BenchmarkTaskType,
+    EvalLimitMode,
+    ModelStatusTypes,
+    ModelType,
+    ReportCheckTypes,
+    VersionMode,
+    WorkflowType,
+)
 
-class WorkflowType(IntEnum):
-    BENCHMARKS = auto()
-    EVALS = auto()
-    STRESS_TESTS = auto()
-    SERVER = auto()
-    RELEASE = auto()
-    SPEC_TESTS = auto()
-    AGENTIC = auto()
-    AGENTIC_TRACES = auto()
-    SERVING_BENCH = auto()
-    PREFILL_DECODE = auto()
-
-    @classmethod
-    def from_string(cls, name: str):
-        try:
-            return cls[name.upper()]
-        except KeyError:
-            raise ValueError(f"Invalid TaskType: {name}")
+__all__ = [
+    # re-exported engine-owned types
+    "AgenticTracesMode",
+    "BenchmarkTaskType",
+    "EvalLimitMode",
+    "ModelStatusTypes",
+    "ModelType",
+    "ReportCheckTypes",
+    "VersionMode",
+    "WorkflowType",
+    # Tenstorrent-specific types defined here
+    "WorkflowVenvType",
+    "DeviceTypes",
+    "SystemTopology",
+    "InferenceEngine",
+    "ModelSource",
+]
 
 
 class WorkflowVenvType(IntEnum):
@@ -54,12 +76,6 @@ class WorkflowVenvType(IntEnum):
     SERVER = auto()
     TT_SMI = auto()
     TT_TOPOLOGY = auto()
-
-
-class BenchmarkTaskType(IntEnum):
-    HTTP_CLIENT_VLLM_API = auto()
-    HTTP_CLIENT_CNN_API = auto()
-    HTTP_CLIENT_VLLM_STRUCTURED_OUTPUT_API = auto()
 
 
 class DeviceTypes(IntEnum):
@@ -262,147 +278,6 @@ class SystemTopology(Enum):
         raise ValueError(f"Unknown topology configuration: {value}")
 
 
-class ReportCheckTypes(IntEnum):
-    NA = auto()
-    PASS = auto()
-    FAIL = auto()
-
-    @classmethod
-    def from_result(cls, result: bool):
-        res_map = {
-            None: ReportCheckTypes.NA,
-            True: ReportCheckTypes.PASS,
-            False: ReportCheckTypes.FAIL,
-        }
-        return res_map[result]
-
-    @classmethod
-    def to_display_string(cls, check_type: str):
-        disp_map = {
-            ReportCheckTypes.NA: "N/A",
-            ReportCheckTypes.PASS: "PASS ✅",
-            ReportCheckTypes.FAIL: "FAIL ⛔",
-        }
-        return disp_map[check_type]
-
-
-class ModelStatusTypes(IntEnum):
-    """
-    EXPERIMENTAL: Model implementation is available, but is unstable or has performance issues.
-    FUNCTIONAL: Model runs functionally without issue, but performance is lower than expected.
-    COMPLETE: Operationally complete, performance is usable for most applications.
-    TOP_PERF: Performance close to theoretical peak, nearly fully optimized.
-    """
-
-    EXPERIMENTAL = auto()
-    FUNCTIONAL = auto()
-    COMPLETE = auto()
-    TOP_PERF = auto()
-
-    @property
-    def display_string(self) -> str:
-        return {
-            ModelStatusTypes.EXPERIMENTAL: "🛠️ Experimental",
-            ModelStatusTypes.FUNCTIONAL: "🟡 Functional",
-            ModelStatusTypes.COMPLETE: "🟢 Complete",
-            ModelStatusTypes.TOP_PERF: "🚀 Top Performance",
-        }[self]
-
-    @property
-    def required_target_tiers(self) -> List[str]:
-        """Tiers that MUST pass for a model at this status level.
-
-        Tiers not in this list are still computed and reported but
-        treated as informational -- failures are accepted and do not
-        block a release. This enables programmatic masking: e.g. an
-        EXPERIMENTAL model (forge, new bring-up) can fail every
-        performance benchmark and still be released.
-        """
-        tier_map = {
-            ModelStatusTypes.EXPERIMENTAL: [],
-            ModelStatusTypes.FUNCTIONAL: ["functional"],
-            ModelStatusTypes.COMPLETE: ["functional", "complete"],
-            ModelStatusTypes.TOP_PERF: ["functional", "complete", "target"],
-        }
-        return tier_map[self]
-
-    @property
-    def evals_enforced(self) -> bool:
-        """Whether eval accuracy failures block acceptance at this status.
-
-        Reuses required_target_tiers' signal (empty only for EXPERIMENTAL) so
-        a model still in bring-up isn't blocked on eval accuracy either.
-        """
-        return bool(self.required_target_tiers)
-
-    @classmethod
-    def resolve(cls, name: Optional[str]) -> Optional["ModelStatusTypes"]:
-        """Best-effort ``name`` -> member lookup, or ``None`` if missing/unrecognized.
-
-        Unlike :meth:`EvalLimitMode.from_string`, this never raises: callers
-        use a missing/garbled status as a signal to fall back to the
-        strictest (fully-enforced) behavior rather than crash.
-        """
-        if not name:
-            return None
-        try:
-            return cls[name]
-        except KeyError:
-            return None
-
-
-class EvalLimitMode(IntEnum):
-    SMOKE_TEST = auto()
-    CI_COMMIT = auto()
-    CI_NIGHTLY = auto()
-    CI_LONG = auto()
-
-    @classmethod
-    def from_string(cls, name: str):
-        if name is None:
-            return None
-        try:
-            return cls[name.upper().replace("-", "_")]
-        except KeyError:
-            raise ValueError(f"Invalid EvalLimitMode: {name}")
-
-
-class AgenticTracesMode(IntEnum):
-    """Duration profile for the ``agentic_traces`` workflow.
-
-    Deliberately separate from :class:`EvalLimitMode`: agentic trace replay is
-    bounded by wall-clock profiling time rather than a dataset sample count, and
-    the InferenceX scenario enforces its own duration floor (see
-    ``AGENTIC_TRACES_MIN_PROFILE_SECONDS``), so the eval limit modes do not
-    translate.
-
-    ``FULL`` is the reference run used for reportable numbers; ``CI`` is the
-    shortest run the scenario still permits.
-    """
-
-    FULL = auto()
-    CI = auto()
-
-    @classmethod
-    def from_string(cls, name: str):
-        if name is None:
-            return None
-        try:
-            return cls[name.upper().replace("-", "_")]
-        except KeyError:
-            raise ValueError(f"Invalid AgenticTracesMode: {name}")
-
-    def to_string(self) -> str:
-        return self.name.lower()
-
-
-class VersionMode(IntEnum):
-    """Defines the enforcement mode for a version requirement."""
-
-    STRICT = auto()  # Requirement must be met, raises an error otherwise.
-    SUGGESTED = auto()  # A warning is issued if the requirement is not met.
-
-
 class InferenceEngine(Enum):
     VLLM = "vLLM"
     MEDIA = "media"
@@ -428,60 +303,3 @@ class ModelSource(Enum):
     HUGGINGFACE = "huggingface"
     LOCAL = "local"
     NOACTION = "noaction"
-
-
-class ModelType(IntEnum):
-    LLM = auto()
-    CNN = auto()
-    AUDIO = auto()
-    IMAGE = auto()
-    EMBEDDING = auto()
-    TEXT_TO_SPEECH = auto()
-    VIDEO = auto()
-    VLM = auto()  # Vision-Language Models (text+image-to-text)
-    TRAINING = auto()
-
-    @property
-    def display_name(self) -> str:
-        display_names = {
-            ModelType.LLM: "Large Language Model",
-            ModelType.CNN: "Convolutional Neural Network",
-            ModelType.AUDIO: "Audio",
-            ModelType.IMAGE: "Image",
-            ModelType.EMBEDDING: "Embedding",
-            ModelType.TEXT_TO_SPEECH: "Text-to-Speech",
-            ModelType.VIDEO: "Video",
-            ModelType.VLM: "Vision-Language Model",
-            ModelType.TRAINING: "Training",
-        }
-        return display_names[self]
-
-    @property
-    def short_name(self) -> str:
-        short_names = {
-            ModelType.LLM: "LLM",
-            ModelType.VLM: "VLM",
-            ModelType.AUDIO: "Audio",
-            ModelType.IMAGE: "Image",
-            ModelType.CNN: "CNN",
-            ModelType.EMBEDDING: "Embedding",
-            ModelType.TEXT_TO_SPEECH: "TTS",
-            ModelType.VIDEO: "Video",
-            ModelType.TRAINING: "Training",
-        }
-        return short_names[self]
-
-    @property
-    def task_type(self) -> str:
-        task_types = {
-            ModelType.LLM: "text",
-            ModelType.VLM: "vlm",
-            ModelType.AUDIO: "asr",  # Automatic Speech Recognition
-            ModelType.IMAGE: "image",
-            ModelType.CNN: "cnn",
-            ModelType.EMBEDDING: "embedding",
-            ModelType.TEXT_TO_SPEECH: "tts",
-            ModelType.VIDEO: "video",
-            ModelType.TRAINING: "training",
-        }
-        return task_types[self]


### PR DESCRIPTION
## Summary
- First decoupling PR for the standalone validation framework extraction (Phase 1): relocates the 8 generic workflow enums (`WorkflowType`, `BenchmarkTaskType`, `ReportCheckTypes`, `ModelStatusTypes`, `EvalLimitMode`, `AgenticTracesMode`, `VersionMode`, `ModelType`) from `workflows/workflow_types.py` to a new engine-owned `workflow_module/engine_types.py`.
- `workflows/workflow_types.py` keeps the Tenstorrent-specific taxonomies (`DeviceTypes`, `SystemTopology`, `InferenceEngine`, `ModelSource`, `WorkflowVenvType`) and re-exports the moved enums, so all existing v1 callers are untouched.
- Updates the 13 engine import sites across `workflow_module` / `test_module` / `report_module` / `llm_module` to import from `workflow_module.engine_types`, establishing the dependency direction the extraction needs: adapter depends on engine core, never the reverse.

Purely mechanical: enum member order preserved (IntEnum values unchanged), no behavior change.

## Test plan
- [x] Full suite: `pytest tests/ -q --continue-on-collection-errors` — 1543 passed, 10 skipped (5 `test_helm_generator` collection errors are pre-existing on `main`, verified via clean worktree)
- [x] `ruff check` + `ruff format --check` clean on all touched files
- [x] Import smoke test incl. re-export identity (`workflows.workflow_types.ModelType is workflow_module.engine_types.ModelType`)

Made with [Cursor](https://cursor.com)