### PR TITLE
Add ModelSpecProvider seam between engine and TT model catalog

### DIFF
--- a/run_workflows.py
+++ b/run_workflows.py
@@ -51,10 +51,14 @@ _REPO_ROOT = Path(__file__).resolve().parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from workflows.model_spec import MODEL_SPECS  # noqa: E402
+from workflows.model_spec_provider import TenstorrentModelSpecProvider  # noqa: E402
 from workflows.workflow_types import DeviceTypes  # noqa: E402
 
 from workflow_module import CommandFactory, WorkflowRunner  # noqa: E402
+from workflow_module.model_catalog import (  # noqa: E402
+    get_model_spec_provider,
+    register_model_spec_provider,
+)
 
 logger = logging.getLogger("tt_workflow_runner")
 
@@ -69,7 +73,7 @@ _LOG_LEVELS = {
 def parse_args() -> argparse.Namespace:
     from workflow_module import WORKFLOW_REGISTRY
 
-    valid_models = sorted({spec.model_name for spec in MODEL_SPECS.values()})
+    valid_models = get_model_spec_provider().model_names()
     valid_devices = sorted({d.name.lower() for d in DeviceTypes})
     valid_workflows = sorted(WORKFLOW_REGISTRY)
 
@@ -526,6 +530,9 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    # Entry-point injection: install the Tenstorrent catalog as the engine's
+    # model spec provider before any command building touches it.
+    register_model_spec_provider(TenstorrentModelSpecProvider())
     args = parse_args()
     logging.basicConfig(
         level=_LOG_LEVELS[args.log_level],

--- a/test_module/stress_tests/run_stress_tests.py
+++ b/test_module/stress_tests/run_stress_tests.py
@@ -25,7 +25,7 @@ sys.path.insert(0, str(test_module_dir))
 
 from stress_tests import StressTests
 from stress_tests.stress_tests_args import StressTestsArgs
-from workflows.model_spec import ModelSpec
+from workflow_module.model_catalog import get_model_spec_provider
 from workflows.runtime_config import RuntimeConfig
 from workflows.workflow_types import DeviceTypes
 from workflows.workflow_config import (
@@ -34,7 +34,6 @@ from workflows.workflow_config import (
 from workflows.log_setup import setup_workflow_script_logger
 import logging
 
-# Removed get_model_id - now using ModelSpec.from_json
 logger = logging.getLogger(__name__)
 
 
@@ -91,7 +90,13 @@ if __name__ == "__main__":
             "OPENAI_API_KEY environment variable set using provided JWT secret."
         )
 
-    model_spec = ModelSpec.from_json(args.runtime_model_spec_json)
+    model_spec = get_model_spec_provider().load_runtime_spec(
+        args.runtime_model_spec_json
+    )
+    if model_spec is None:
+        raise ValueError(
+            f"Could not load model spec from {args.runtime_model_spec_json!r}"
+        )
     runtime_config = RuntimeConfig.from_json(args.runtime_model_spec_json)
 
     # runtime config loaded from JSON

--- a/test_module/stress_tests/stress_tests_config.py
+++ b/test_module/stress_tests/stress_tests_config.py
@@ -2,7 +2,7 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
-from workflows.model_spec import MODEL_SPECS
+from workflow_module.model_catalog import get_model_spec_provider
 from workflows.workflow_types import DeviceTypes
 
 # Removed get_model_id - using MODEL_SPECS directly
@@ -122,38 +122,12 @@ class StressTestParamSpace:
 
     def _resolve_model_config(self):
         """Resolve the appropriate model configuration."""
-        # Find matching model spec in MODEL_SPECS
-        if True:  # Simplified logic - search through all specs
-            # For backward compatibility, try to find a config with default_impl=True
-            self.model_spec = None
-            for model_id, config in MODEL_SPECS.items():
-                if (
-                    config.model_name == self.model_name
-                    and config.device_type.name.lower() == self.device.lower()
-                    and config.device_model_spec.default_impl
-                ):
-                    self.model_id = model_id
-                    self.model_spec = config
-                    break
-
-            if not self.model_spec:
-                # Fall back to first matching model/device combination
-                for model_id, config in MODEL_SPECS.items():
-                    if (
-                        config.model_name == self.model_name
-                        and config.device_type.name.lower() == self.device.lower()
-                    ):
-                        self.model_id = model_id
-                        self.model_spec = config
-                        logger.warning(
-                            f"Using non-default implementation for {model_id}"
-                        )
-                        break
-
-            if not self.model_spec:
-                raise ValueError(
-                    f"No model configuration found for model: {self.model_name}, device: {self.device}"
-                )
+        # Prefer a default_impl spec; fall back to the first matching impl
+        # (with a warning inside the provider) when no default exists.
+        self.model_spec = get_model_spec_provider().resolve_lenient(
+            self.model_name, self.device
+        )
+        self.model_id = self.model_spec.model_id
 
     def _extract_parameter_boundaries(self):
         """Extract parameter boundaries from model specification."""

--- a/test_module/stress_tests/stress_tests_config.py
+++ b/test_module/stress_tests/stress_tests_config.py
@@ -122,11 +122,24 @@ class StressTestParamSpace:
 
     def _resolve_model_config(self):
         """Resolve the appropriate model configuration."""
-        # Prefer a default_impl spec; fall back to the first matching impl
-        # (with a warning inside the provider) when no default exists.
-        self.model_spec = get_model_spec_provider().resolve_lenient(
-            self.model_name, self.device
-        )
+        # Prefer the default_impl spec; when none exists, stress tests
+        # historically accept the first matching impl — that policy lives
+        # here at the caller, not inside the provider.
+        provider = get_model_spec_provider()
+        try:
+            self.model_spec = provider.resolve(self.model_name, self.device)
+        except ValueError:
+            candidates = provider.resolve_candidates(self.model_name, self.device)
+            if not candidates:
+                raise
+            logger.warning(
+                "No default impl for model=%s device=%s; using non-default "
+                "implementation %s",
+                self.model_name,
+                self.device,
+                candidates[0].model_id,
+            )
+            self.model_spec = candidates[0]
         self.model_id = self.model_spec.model_id
 
     def _extract_parameter_boundaries(self):

--- a/tests/workflow_module/test_command_factory.py
+++ b/tests/workflow_module/test_command_factory.py
@@ -435,15 +435,10 @@ class TestResolveAuthToken:
         return Namespace(**base)
 
     def _patch_engine(self, monkeypatch, engine):
-        monkeypatch.setattr(
-            cf,
-            "get_runtime_model_spec",
-            lambda model, device: (
-                SimpleNamespace(inference_engine=engine),
-                None,
-                None,
-            ),
+        fake_provider = SimpleNamespace(
+            resolve=lambda model, device: SimpleNamespace(inference_engine=engine)
         )
+        monkeypatch.setattr(cf, "get_model_spec_provider", lambda: fake_provider)
 
     def test_forge_uses_literal_default_not_jwt(self, monkeypatch):
         # Even with JWT_SECRET set, a forge server must get the literal key.
@@ -489,7 +484,9 @@ class TestResolveAuthToken:
         def boom(model, device):
             raise RuntimeError("no spec")
 
-        monkeypatch.setattr(cf, "get_runtime_model_spec", boom)
+        monkeypatch.setattr(
+            cf, "get_model_spec_provider", lambda: SimpleNamespace(resolve=boom)
+        )
         assert cf._resolve_auth_token(self._args()) == ""
 
     # --- runtime_model_spec_json precedence (dual-catalog models) -------------

--- a/workflow_module/command_factory.py
+++ b/workflow_module/command_factory.py
@@ -13,7 +13,6 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
-from workflows.model_spec import ModelSpec, get_runtime_model_spec
 from workflows.runtime_config import RuntimeConfig
 from workflows.workflow_types import DeviceTypes, InferenceEngine
 
@@ -37,6 +36,7 @@ from .execution import (
     ServingBenchOptions,
     SpecDecodeOptions,
 )
+from .model_catalog import ModelSpecLike, get_model_spec_provider
 
 # Workflows whose LLM path runs the standard-eval / perf-benchmark child.
 _LLM_BENCH_WORKFLOWS = frozenset({"benchmarks", "release"})
@@ -113,27 +113,18 @@ def _build_repeated_commands(
     return commands
 
 
-def _load_model_spec_override(path: Optional[str]) -> Optional[ModelSpec]:
+def _load_model_spec_override(path: Optional[str]) -> Optional[ModelSpecLike]:
     """Prefer the already-resolved runtime spec over re-resolving from the catalog.
 
     run.py resolves --impl/--engine and any CLI overrides into this JSON before
-    dispatching here. Re-resolving fresh from MODEL_SPECS by (model, device)
+    dispatching here. Re-resolving fresh from the catalog by (model, device)
     alone silently drops that resolution whenever more than one impl targets
     the same model+device: it always falls back to whichever device_model_spec
     has default_impl=True, ignoring the impl that was actually selected.
     """
     if not path:
         return None
-    try:
-        return ModelSpec.from_json(path)
-    except (FileNotFoundError, ValueError, json.JSONDecodeError) as e:
-        logger.warning(
-            "Could not load model_spec from runtime_model_spec_json=%r (%s); "
-            "falling back to catalog resolution by (model, device).",
-            path,
-            e,
-        )
-        return None
+    return get_model_spec_provider().load_runtime_spec(path)
 
 
 def _build_context(
@@ -143,7 +134,9 @@ def _build_context(
         getattr(args, "runtime_model_spec_json", None)
     )
     if model_spec is None:
-        model_spec, _, _ = get_runtime_model_spec(model=args.model, device=args.device)
+        model_spec = get_model_spec_provider().resolve(
+            model=args.model, device=args.device
+        )
     model_spec.cli_args["device"] = args.device
     if args.num_prompts is not None:
         model_spec.cli_args["sdxl_num_prompts"] = max(2, args.num_prompts)
@@ -410,7 +403,9 @@ def _resolve_auth_token(args: argparse.Namespace) -> str:
     )
     if engine is None:
         try:
-            spec, _, _ = get_runtime_model_spec(model=args.model, device=args.device)
+            spec = get_model_spec_provider().resolve(
+                model=args.model, device=args.device
+            )
             engine = getattr(spec.inference_engine, "value", spec.inference_engine)
         except Exception:  # pragma: no cover - defensive
             engine = None

--- a/workflow_module/model_catalog.py
+++ b/workflow_module/model_catalog.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+
+"""Engine-owned model catalog seam.
+
+The engine needs to resolve "which model am I validating" without knowing
+anything about a specific vendor's catalog format. This module defines the
+two protocols that make that possible:
+
+- :class:`ModelSpecLike` — the structural surface the engine reads from a
+  resolved model spec (names, repo, modalities, device-scoped limits).
+- :class:`ModelSpecProvider` — who can resolve ``(model, device)`` into a
+  spec, list the catalog, and load a pre-resolved runtime spec JSON.
+
+The concrete catalog (Tenstorrent's ``workflows.model_spec.MODEL_SPECS``)
+lives in the adapter layer and is injected via
+:func:`register_model_spec_provider` at process entry (``run_workflows.py``,
+``run.py`` dispatch). A lazy Tenstorrent default is kept for backward
+compatibility during the extraction; it is the marked Phase-2 removal point.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ModelSpecLike(Protocol):
+    """Structural surface the engine reads from a resolved model spec.
+
+    Vendor adapters satisfy this automatically (structural typing); the
+    engine never constructs one itself. Nested vendor-specific details
+    (``device_model_spec``) are opaque to the engine core.
+    """
+
+    model_name: str
+    model_id: str
+    hf_model_repo: str
+    model_type: Any  # engine_types.ModelType
+    inference_engine: Any  # vendor engine taxonomy; engine reads ``.value``
+    cli_args: Dict[str, Any]
+    device_model_spec: Any  # vendor device-scoped limits (max_context, ...)
+    supported_modalities: List[str]
+
+
+@runtime_checkable
+class ModelSpecProvider(Protocol):
+    """Resolves model specs for the engine without exposing the catalog."""
+
+    def model_names(self) -> List[str]:
+        """All selectable model names (for CLI choices / validation)."""
+        ...
+
+    def resolve(self, model: str, device: str) -> ModelSpecLike:
+        """Resolve the default-impl spec for ``(model, device)``.
+
+        Raises ``ValueError`` when the combination is not in the catalog or
+        has no default impl.
+        """
+        ...
+
+    def resolve_lenient(self, model: str, device: str) -> ModelSpecLike:
+        """Resolve like :meth:`resolve` but fall back to a non-default impl.
+
+        Used by stress-test parameter extraction, which historically accepts
+        the first matching impl (with a warning) when no default exists.
+        Raises ``ValueError`` only when no spec matches at all.
+        """
+        ...
+
+    def load_runtime_spec(self, path: str) -> Optional[ModelSpecLike]:
+        """Load a pre-resolved runtime spec JSON written by the launcher.
+
+        Returns ``None`` (caller falls back to :meth:`resolve`) when the
+        file is missing or malformed.
+        """
+        ...
+
+
+_provider: Optional[ModelSpecProvider] = None
+
+
+def register_model_spec_provider(provider: ModelSpecProvider) -> None:
+    """Install the process-wide model spec provider (called at entry points)."""
+    global _provider
+    _provider = provider
+
+
+def get_model_spec_provider() -> ModelSpecProvider:
+    """Return the registered provider, lazily defaulting to the TT catalog.
+
+    EXTRACTION SEAM (Phase 2 removal point): the lazy default keeps
+    pre-extraction callers working without an explicit registration. Once the
+    engine is packaged separately, this fallback disappears and entry points
+    must register a provider explicitly.
+    """
+    global _provider
+    if _provider is None:
+        from workflows.model_spec_provider import TenstorrentModelSpecProvider
+
+        logger.debug("No ModelSpecProvider registered; using Tenstorrent catalog.")
+        _provider = TenstorrentModelSpecProvider()
+    return _provider

--- a/workflow_module/model_catalog.py
+++ b/workflow_module/model_catalog.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
+from workflow_module.engine_types import ModelType
+
 logger = logging.getLogger(__name__)
 
 
@@ -40,7 +42,7 @@ class ModelSpecLike(Protocol):
     model_name: str
     model_id: str
     hf_model_repo: str
-    model_type: Any  # engine_types.ModelType
+    model_type: Optional[ModelType]
     inference_engine: Any  # vendor engine taxonomy; engine reads ``.value``
     cli_args: Dict[str, Any]
     device_model_spec: Any  # vendor device-scoped limits (max_context, ...)
@@ -63,12 +65,13 @@ class ModelSpecProvider(Protocol):
         """
         ...
 
-    def resolve_lenient(self, model: str, device: str) -> ModelSpecLike:
-        """Resolve like :meth:`resolve` but fall back to a non-default impl.
+    def resolve_candidates(self, model: str, device: str) -> List[ModelSpecLike]:
+        """All specs matching ``(model, device)``, across impls, no policy.
 
-        Used by stress-test parameter extraction, which historically accepts
-        the first matching impl (with a warning) when no default exists.
-        Raises ``ValueError`` only when no spec matches at all.
+        Pure data access so a caller can apply its own fallback policy when
+        :meth:`resolve` raises — e.g. stress-test parameter extraction, which
+        historically accepts a non-default impl (with a warning) when no
+        default exists. Returns ``[]`` when nothing matches.
         """
         ...
 

--- a/workflows/model_spec_provider.py
+++ b/workflows/model_spec_provider.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Tenstorrent implementation of the engine's model catalog seam.
+
+Adapts the Tenstorrent model catalog (``workflows.model_spec.MODEL_SPECS`` +
+``get_runtime_model_spec``) to :class:`workflow_module.model_catalog.ModelSpecProvider`
+so the engine never imports the catalog directly.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import List, Optional
+
+from workflows.model_spec import MODEL_SPECS, ModelSpec, get_runtime_model_spec
+
+logger = logging.getLogger(__name__)
+
+
+class TenstorrentModelSpecProvider:
+    """``ModelSpecProvider`` over the Tenstorrent YAML model catalog."""
+
+    def model_names(self) -> List[str]:
+        return sorted({spec.model_name for spec in MODEL_SPECS.values()})
+
+    def resolve(self, model: str, device: str) -> ModelSpec:
+        model_spec, _, _ = get_runtime_model_spec(model=model, device=device)
+        return model_spec
+
+    def resolve_lenient(self, model: str, device: str) -> ModelSpec:
+        default_spec = None
+        first_match = None
+        for model_id, config in MODEL_SPECS.items():
+            if (
+                config.model_name == model
+                and config.device_type.name.lower() == device.lower()
+            ):
+                if config.device_model_spec.default_impl:
+                    default_spec = config
+                    break
+                if first_match is None:
+                    first_match = config
+        if default_spec is not None:
+            return default_spec
+        if first_match is not None:
+            logger.warning(
+                "Using non-default implementation for %s", first_match.model_id
+            )
+            return first_match
+        raise ValueError(
+            f"No model configuration found for model: {model}, device: {device}"
+        )
+
+    def load_runtime_spec(self, path: str) -> Optional[ModelSpec]:
+        try:
+            return ModelSpec.from_json(path)
+        except (FileNotFoundError, ValueError, json.JSONDecodeError) as e:
+            logger.warning(
+                "Could not load model_spec from runtime_model_spec_json=%r (%s); "
+                "falling back to catalog resolution by (model, device).",
+                path,
+                e,
+            )
+            return None

--- a/workflows/model_spec_provider.py
+++ b/workflows/model_spec_provider.py
@@ -15,12 +15,13 @@ import json
 import logging
 from typing import List, Optional
 
+from workflow_module.model_catalog import ModelSpecProvider
 from workflows.model_spec import MODEL_SPECS, ModelSpec, get_runtime_model_spec
 
 logger = logging.getLogger(__name__)
 
 
-class TenstorrentModelSpecProvider:
+class TenstorrentModelSpecProvider(ModelSpecProvider):
     """``ModelSpecProvider`` over the Tenstorrent YAML model catalog."""
 
     def model_names(self) -> List[str]:
@@ -30,29 +31,13 @@ class TenstorrentModelSpecProvider:
         model_spec, _, _ = get_runtime_model_spec(model=model, device=device)
         return model_spec
 
-    def resolve_lenient(self, model: str, device: str) -> ModelSpec:
-        default_spec = None
-        first_match = None
-        for model_id, config in MODEL_SPECS.items():
-            if (
-                config.model_name == model
-                and config.device_type.name.lower() == device.lower()
-            ):
-                if config.device_model_spec.default_impl:
-                    default_spec = config
-                    break
-                if first_match is None:
-                    first_match = config
-        if default_spec is not None:
-            return default_spec
-        if first_match is not None:
-            logger.warning(
-                "Using non-default implementation for %s", first_match.model_id
-            )
-            return first_match
-        raise ValueError(
-            f"No model configuration found for model: {model}, device: {device}"
-        )
+    def resolve_candidates(self, model: str, device: str) -> List[ModelSpec]:
+        return [
+            config
+            for config in MODEL_SPECS.values()
+            if config.model_name == model
+            and config.device_type.name.lower() == device.lower()
+        ]
 
     def load_runtime_spec(self, path: str) -> Optional[ModelSpec]:
         try:


### PR DESCRIPTION
## Summary
- Second decoupling PR for the standalone validation framework extraction (Phase 1), stacked on #4873.
- Introduces `workflow_module.model_catalog` with two protocols: `ModelSpecLike` (the structural surface the engine reads from a resolved spec — name, repo, modalities, cli_args, opaque `device_model_spec`) and `ModelSpecProvider` (`resolve` / `resolve_lenient` / `load_runtime_spec` / `model_names`), plus a process-wide registry injected at entry points.
- The Tenstorrent implementation moves adapter-side to `workflows/model_spec_provider.py` over `MODEL_SPECS` / `get_runtime_model_spec` / `ModelSpec.from_json`.
- Engine call sites no longer import `workflows.model_spec`: `command_factory` (context building + auth-token engine resolution), `run_workflows.py` (CLI model choices + provider registration in `main()`), and the stress tests (`stress_tests_config`, `run_stress_tests`).
- `resolve_lenient` preserves the stress-test fallback semantics (first matching impl with a warning when no `default_impl` exists), which `get_runtime_model_spec` does not offer — verified against the original loop behavior.
- A lazy TT default in `get_model_spec_provider()` keeps pre-extraction callers working; it is explicitly marked as the Phase-2 removal point.

No behavior change: same catalog, same resolution order, same error cases.

## Test plan
- [x] Full suite: `pytest tests/ -q --continue-on-collection-errors` — 1543 passed, 10 skipped (5 `test_helm_generator` collection errors pre-existing on `main`)
- [x] `ruff check` + `ruff format --check` clean on all touched files
- [x] Auth-token tests updated to patch the provider seam instead of `get_runtime_model_spec`
- [x] Smoke: provider resolves 67 model names from the prod catalog