### PR TITLE
Add DeviceCatalog seam between engine and TT device taxonomy

### DIFF
--- a/run_workflows.py
+++ b/run_workflows.py
@@ -51,10 +51,14 @@ _REPO_ROOT = Path(__file__).resolve().parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from workflows.device_catalog_provider import TenstorrentDeviceCatalog  # noqa: E402
 from workflows.model_spec_provider import TenstorrentModelSpecProvider  # noqa: E402
-from workflows.workflow_types import DeviceTypes  # noqa: E402
 
 from workflow_module import CommandFactory, WorkflowRunner  # noqa: E402
+from workflow_module.device_catalog import (  # noqa: E402
+    get_device_catalog,
+    register_device_catalog,
+)
 from workflow_module.model_catalog import (  # noqa: E402
     get_model_spec_provider,
     register_model_spec_provider,
@@ -74,7 +78,7 @@ def parse_args() -> argparse.Namespace:
     from workflow_module import WORKFLOW_REGISTRY
 
     valid_models = get_model_spec_provider().model_names()
-    valid_devices = sorted({d.name.lower() for d in DeviceTypes})
+    valid_devices = get_device_catalog().device_names()
     valid_workflows = sorted(WORKFLOW_REGISTRY)
 
     parser = argparse.ArgumentParser(
@@ -533,6 +537,7 @@ def main() -> int:
     # Entry-point injection: install the Tenstorrent catalog as the engine's
     # model spec provider before any command building touches it.
     register_model_spec_provider(TenstorrentModelSpecProvider())
+    register_device_catalog(TenstorrentDeviceCatalog())
     args = parse_args()
     logging.basicConfig(
         level=_LOG_LEVELS[args.log_level],

--- a/test_module/stress_tests/run_stress_tests.py
+++ b/test_module/stress_tests/run_stress_tests.py
@@ -25,9 +25,9 @@ sys.path.insert(0, str(test_module_dir))
 
 from stress_tests import StressTests
 from stress_tests.stress_tests_args import StressTestsArgs
+from workflow_module.device_catalog import get_device_catalog
 from workflow_module.model_catalog import get_model_spec_provider
 from workflows.runtime_config import RuntimeConfig
-from workflows.workflow_types import DeviceTypes
 from workflows.workflow_config import (
     WORKFLOW_STRESS_TESTS_CONFIG,
 )
@@ -123,7 +123,7 @@ if __name__ == "__main__":
                     else:
                         parsed_workflow_args[key] = value
 
-    device = DeviceTypes.from_string(device_str)
+    device = get_device_catalog().from_string(device_str)
     workflow_config = WORKFLOW_STRESS_TESTS_CONFIG
     logger.info(f"workflow_config=: {workflow_config}")
     logger.info(f"model_spec=: {model_spec}")

--- a/test_module/stress_tests/stress_tests_config.py
+++ b/test_module/stress_tests/stress_tests_config.py
@@ -2,8 +2,8 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
+from workflow_module.device_catalog import get_device_catalog
 from workflow_module.model_catalog import get_model_spec_provider
-from workflows.workflow_types import DeviceTypes
 
 # Removed get_model_id - using MODEL_SPECS directly
 from typing import List, Dict, Tuple, Set
@@ -111,8 +111,8 @@ class StressTestParamSpace:
         else:
             self._resolve_model_config()
 
-        # Convert device string to DeviceTypes enum
-        self.device_type = DeviceTypes.from_string(self.device)
+        # Convert device string to an engine device token
+        self.device_type = get_device_catalog().from_string(self.device)
 
         # Extract parameter boundaries from model config
         self._extract_parameter_boundaries()

--- a/test_module/stress_tests/stress_tests_core.py
+++ b/test_module/stress_tests/stress_tests_core.py
@@ -34,7 +34,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-from workflows.workflow_types import DeviceTypes
+from workflow_module.device_catalog import get_device_catalog
 from .stress_tests_config import StressTestParamSpace, enforce_context_limit
 from .stress_tests_args import StressTestsArgs
 
@@ -61,7 +61,7 @@ class StressTests:
         self._setup_environment_variables()
 
         # Setup device and concurrency configuration
-        self.device = DeviceTypes.from_string(self.test_args.device)
+        self.device = get_device_catalog().from_string(self.test_args.device)
         self.max_concurrent_value = self.model_spec.device_model_spec.max_concurrency
 
         # Configure endurance mode if specified

--- a/workflow_module/command_factory.py
+++ b/workflow_module/command_factory.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from workflows.runtime_config import RuntimeConfig
-from workflows.workflow_types import DeviceTypes, InferenceEngine
+from workflows.workflow_types import InferenceEngine
 
 from utils.url_helpers import is_remote_server, resolve_deploy_url
 
@@ -27,6 +27,7 @@ from .commands import (
     SummaryCommand,
     WorkflowCommand,
 )
+from .device_catalog import get_device_catalog
 from .execution import (
     AgenticTracesOptions,
     LLMBenchOptions,
@@ -141,7 +142,7 @@ def _build_context(
     if args.num_prompts is not None:
         model_spec.cli_args["sdxl_num_prompts"] = max(2, args.num_prompts)
 
-    device = DeviceTypes.from_string(args.device)
+    device = get_device_catalog().from_string(args.device)
     runtime_config = _load_runtime_config(args.runtime_model_spec_json)
     # An explicit --agentic-benchmark on the engine command line overrides the
     # value carried in the runtime_config JSON, so a direct run_workflows.py

--- a/workflow_module/device_catalog.py
+++ b/workflow_module/device_catalog.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+
+"""Engine-owned device catalog seam.
+
+The engine only ever reads a device's ``name`` (for CLI choices, report
+metadata, and suite filtering) — vendor hardware taxonomies like
+Tenstorrent's ``DeviceTypes`` (N150, T3K, GALAXY, ...) are adapter content.
+This module defines the seam:
+
+- :class:`DeviceLike` — an opaque device token exposing ``name``.
+- :class:`DeviceCatalog` — who can parse a CLI device string and list the
+  valid device names.
+
+The Tenstorrent implementation lives adapter-side and is injected via
+:func:`register_device_catalog` at process entry. A lazy Tenstorrent
+default is kept for backward compatibility during the extraction; it is
+the marked Phase-2 removal point.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class DeviceLike(Protocol):
+    """Opaque device token the engine carries through to reports."""
+
+    name: str
+
+
+@runtime_checkable
+class DeviceCatalog(Protocol):
+    """Resolves CLI device strings without exposing the vendor taxonomy."""
+
+    def device_names(self) -> List[str]:
+        """All selectable device names, lowercase (for CLI choices)."""
+        ...
+
+    def from_string(self, name: str) -> DeviceLike:
+        """Parse a device string into a token. Raises ``ValueError`` if unknown."""
+        ...
+
+
+_catalog: DeviceCatalog | None = None
+
+
+def register_device_catalog(catalog: DeviceCatalog) -> None:
+    """Install the process-wide device catalog (called at entry points)."""
+    global _catalog
+    _catalog = catalog
+
+
+def get_device_catalog() -> DeviceCatalog:
+    """Return the registered catalog, lazily defaulting to the TT taxonomy.
+
+    EXTRACTION SEAM (Phase 2 removal point): the lazy default keeps
+    pre-extraction callers working without an explicit registration. Once the
+    engine is packaged separately, this fallback disappears and entry points
+    must register a catalog explicitly.
+    """
+    global _catalog
+    if _catalog is None:
+        from workflows.device_catalog_provider import TenstorrentDeviceCatalog
+
+        logger.debug("No DeviceCatalog registered; using Tenstorrent taxonomy.")
+        _catalog = TenstorrentDeviceCatalog()
+    return _catalog

--- a/workflows/device_catalog_provider.py
+++ b/workflows/device_catalog_provider.py
@@ -13,10 +13,11 @@ from __future__ import annotations
 
 from typing import List
 
+from workflow_module.device_catalog import DeviceCatalog
 from workflows.workflow_types import DeviceTypes
 
 
-class TenstorrentDeviceCatalog:
+class TenstorrentDeviceCatalog(DeviceCatalog):
     """``DeviceCatalog`` over the Tenstorrent ``DeviceTypes`` enum."""
 
     def device_names(self) -> List[str]:

--- a/workflows/device_catalog_provider.py
+++ b/workflows/device_catalog_provider.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Tenstorrent implementation of the engine's device catalog seam.
+
+Adapts the Tenstorrent hardware taxonomy (``DeviceTypes``) to
+:class:`workflow_module.device_catalog.DeviceCatalog` so the engine never
+imports vendor device enums directly.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from workflows.workflow_types import DeviceTypes
+
+
+class TenstorrentDeviceCatalog:
+    """``DeviceCatalog`` over the Tenstorrent ``DeviceTypes`` enum."""
+
+    def device_names(self) -> List[str]:
+        return sorted({d.name.lower() for d in DeviceTypes})
+
+    def from_string(self, name: str) -> DeviceTypes:
+        return DeviceTypes.from_string(name)


### PR DESCRIPTION
## Summary
- Third decoupling PR for the standalone validation framework extraction (Phase 1), stacked on the model-spec-provider PR.
- Introduces `workflow_module.device_catalog` with two protocols: `DeviceLike` (an opaque device token exposing only `name` — the single attribute the engine reads, confirmed by `MediaContext.device`'s existing `Any` typing and the `hasattr`-guarded `ctx.device.name` usages throughout `test_module`) and `DeviceCatalog` (`from_string` / `device_names`), plus a process-wide registry.
- The Tenstorrent implementation moves adapter-side to `workflows/device_catalog_provider.py` over `DeviceTypes`.
- Engine call sites no longer import `DeviceTypes`: `run_workflows.py` (CLI device choices + catalog registration in `main()`), `command_factory` (context building), and the stress tests (`stress_tests_config`, `stress_tests_core`, `run_stress_tests` — the `device == model_spec.device_type` assertion still holds since the TT catalog returns `DeviceTypes` members).
- A lazy TT default in `get_device_catalog()` keeps pre-extraction callers working; it is explicitly marked as the Phase-2 removal point.

No behavior change: the engine only ever consumed `.name`; vendor hardware knowledge (mesh strings, product names, topology, data-parallel mapping) stays in the adapter.

## Test plan
- [x] Full suite: `pytest tests/ -q --continue-on-collection-errors` — 1543 passed, 10 skipped (5 `test_helm_generator` collection errors pre-existing on `main`)
- [x] `ruff check` + `ruff format --check` clean on all touched files
- [x] Grep: zero `DeviceTypes` code references remaining in engine packages (docstring mentions only)