### PR TITLE
Add: decoupled server lifecycle

### DIFF
--- a/run_workflows.py
+++ b/run_workflows.py
@@ -63,6 +63,12 @@ from workflow_module.model_catalog import (  # noqa: E402
     get_model_spec_provider,
     register_model_spec_provider,
 )
+from workflow_module.server_lifecycle import (  # noqa: E402
+    register_server_lifecycle,
+)
+from workflows.server_lifecycle_provider import (  # noqa: E402
+    TenstorrentServerLifecycle,
+)
 
 logger = logging.getLogger("tt_workflow_runner")
 
@@ -538,6 +544,7 @@ def main() -> int:
     # model spec provider before any command building touches it.
     register_model_spec_provider(TenstorrentModelSpecProvider())
     register_device_catalog(TenstorrentDeviceCatalog())
+    register_server_lifecycle(TenstorrentServerLifecycle())
     args = parse_args()
     logging.basicConfig(
         level=_LOG_LEVELS[args.log_level],

--- a/workflow_module/command_factory.py
+++ b/workflow_module/command_factory.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import List, Optional
 
 from workflows.runtime_config import RuntimeConfig
-from workflows.workflow_types import InferenceEngine
 
 from utils.url_helpers import is_remote_server, resolve_deploy_url
 
@@ -38,6 +37,7 @@ from .execution import (
     SpecDecodeOptions,
 )
 from .model_catalog import ModelSpecLike, get_model_spec_provider
+from .server_lifecycle import get_server_lifecycle
 
 # Workflows whose LLM path runs the standard-eval / perf-benchmark child.
 _LLM_BENCH_WORKFLOWS = frozenset({"benchmarks", "release"})
@@ -373,7 +373,7 @@ def _build_spec_decode_options(
 
 
 def _engine_from_runtime_spec_json(path: Optional[str]) -> Optional[str]:
-    """``inference_engine`` (enum value, e.g. ``"forge"``) from the runtime spec JSON."""
+    """``inference_engine`` (adapter value form, e.g. ``"forge"``) from the runtime spec JSON."""
     if not path:
         return None
     try:
@@ -383,10 +383,9 @@ def _engine_from_runtime_spec_json(path: Optional[str]) -> Optional[str]:
             )
     except (OSError, ValueError):
         return None
-    # Serialized as the enum value ("forge"/"media"/"vLLM"); tolerate the name form too.
-    if engine in InferenceEngine.__members__:
-        return InferenceEngine[engine].value
-    return engine or None
+    # Serialized as the enum value ("forge"/"media"/"vLLM"); the adapter
+    # tolerates the name form too.
+    return get_server_lifecycle().normalize_engine_value(engine)
 
 
 def _resolve_auth_token(args: argparse.Namespace) -> str:
@@ -410,7 +409,7 @@ def _resolve_auth_token(args: argparse.Namespace) -> str:
             engine = getattr(spec.inference_engine, "value", spec.inference_engine)
         except Exception:  # pragma: no cover - defensive
             engine = None
-    if engine in (InferenceEngine.FORGE.value, InferenceEngine.MEDIA.value):
+    if get_server_lifecycle().uses_literal_api_key(engine):
         return os.getenv("VLLM_API_KEY") or os.getenv("API_KEY") or "your-secret-key"
     return _mint_jwt_if_secret(getattr(args, "jwt_secret", None))
 

--- a/workflow_module/commands.py
+++ b/workflow_module/commands.py
@@ -79,8 +79,6 @@ class ServerLaunchSpec:
             raise ValueError(f"unknown server mode: {self.mode!r}") from e
 
 
-_UNKNOWN_MODE = object()
-
 # The dispatch watchdog's signature. tt-metal raises this when the device stops
 # draining its fetch queue, which on Galaxy has shown up intermittently during the
 # model's prefill warmup sweep. It is worth naming explicitly so a retry says *why*
@@ -287,8 +285,9 @@ def _teardown_server(spec: ServerLaunchSpec, payload: Any) -> None:
 class ServerCommand(Command):
     """Bring up the inference server as the first step of a run.
 
-    Wraps ``workflows.run_docker_server`` / ``run_local_server`` so server
-    bring-up is a command in the same list the :class:`WorkflowRunner` executes.
+    Delegates to the registered :class:`ServerLifecycle` (vendor adapter:
+    docker/local launchers) so server bring-up is a command in the same list
+    the :class:`WorkflowRunner` executes.
     """
 
     name = "server"
@@ -318,13 +317,6 @@ class ServerCommand(Command):
                 _teardown_server(spec, None)
                 continue
 
-            if payload is _UNKNOWN_MODE:
-                return CommandResult(
-                    command_name=self.name,
-                    return_code=1,
-                    error=f"unknown server mode: {spec.mode!r}",
-                )
-
             ready_error = _wait_until_ready(spec, payload)
             if ready_error is None:
                 if attempt > 1:
@@ -352,25 +344,17 @@ class ServerCommand(Command):
         )
 
     def _launch_once(self, spec: ServerLaunchSpec) -> Any:
-        from workflows.run_docker_server import run_docker_server
-        from workflows.run_local_server import run_local_server
+        # Deferred: the seam's lazy default imports the adapter-side provider,
+        # which imports this module for ServerMode.
+        from .server_lifecycle import get_server_lifecycle
 
-        if spec.mode is ServerMode.DOCKER:
-            return run_docker_server(
-                spec.model_spec,
-                spec.runtime_config,
-                spec.setup_config,
-                spec.json_fpath,
-            )
-        if spec.mode is ServerMode.LOCAL:
-            return run_local_server(
-                spec.model_spec,
-                spec.runtime_config,
-                spec.json_fpath,
-                spec.setup_config,
-            )
-        # ServerLaunchSpec rejects unknown modes
-        return _UNKNOWN_MODE  # pragma: no cover
+        return get_server_lifecycle().launch(
+            spec.mode,
+            spec.model_spec,
+            spec.runtime_config,
+            spec.setup_config,
+            spec.json_fpath,
+        )
 
 
 class VenvCommand(Command):

--- a/workflow_module/server_lifecycle.py
+++ b/workflow_module/server_lifecycle.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional, Protocol, runtime_checkable
 
+from workflow_module.commands import ServerMode
+
 logger = logging.getLogger(__name__)
 
 
@@ -32,7 +34,7 @@ class ServerLifecycle(Protocol):
 
     def launch(
         self,
-        mode: Any,
+        mode: ServerMode,
         model_spec: Any,
         runtime_config: Any,
         setup_config: Any,

--- a/workflow_module/server_lifecycle.py
+++ b/workflow_module/server_lifecycle.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+
+"""Engine-owned server lifecycle seam.
+
+The engine assumes a running inference server; who brings it up (and how
+its auth works) is vendor adapter business. This module defines the seam:
+
+- :class:`ServerLifecycle` — launch an inference server for a run, and
+  answer server-facing policy questions the engine needs (bearer-token
+  scheme, engine-name normalization).
+
+The Tenstorrent implementation (docker/local launchers, tt-media-server
+literal-key vs vLLM JWT auth) lives adapter-side and is injected via
+:func:`register_server_lifecycle` at process entry. A lazy Tenstorrent
+default is kept for backward compatibility during the extraction; it is
+the marked Phase-2 removal point.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ServerLifecycle(Protocol):
+    """Brings up the inference server and owns server-facing auth policy."""
+
+    def launch(
+        self,
+        mode: Any,
+        model_spec: Any,
+        runtime_config: Any,
+        setup_config: Any,
+        json_fpath: Optional[str],
+    ) -> Any:
+        """Bring up the server for ``mode`` (docker/local); returns launch payload.
+
+        Raises on failure; the caller converts to a command result.
+        """
+        ...
+
+    def uses_literal_api_key(self, inference_engine_value: Optional[str]) -> bool:
+        """Whether the server for this engine expects a literal ``Bearer $API_KEY``.
+
+        Tenstorrent: tt-media-server (forge/media) checks a literal key;
+        only the vLLM (tt-metal) server validates a JWT — a minted JWT sent
+        to a forge/media server 401s every request.
+        """
+        ...
+
+    def normalize_engine_value(self, raw: Optional[str]) -> Optional[str]:
+        """Normalize a serialized engine identifier to the adapter's value form.
+
+        Runtime spec JSON may carry either the enum value (``"forge"``) or
+        the enum name (``"FORGE"``); the adapter maps both to its canonical
+        value form. Returns ``None`` for missing input.
+        """
+        ...
+
+
+_lifecycle: Optional[ServerLifecycle] = None
+
+
+def register_server_lifecycle(lifecycle: ServerLifecycle) -> None:
+    """Install the process-wide server lifecycle (called at entry points)."""
+    global _lifecycle
+    _lifecycle = lifecycle
+
+
+def get_server_lifecycle() -> ServerLifecycle:
+    """Return the registered lifecycle, lazily defaulting to the TT launchers.
+
+    EXTRACTION SEAM (Phase 2 removal point): the lazy default keeps
+    pre-extraction callers working without an explicit registration. Once the
+    engine is packaged separately, this fallback disappears and entry points
+    must register a lifecycle explicitly.
+    """
+    global _lifecycle
+    if _lifecycle is None:
+        from workflows.server_lifecycle_provider import TenstorrentServerLifecycle
+
+        logger.debug("No ServerLifecycle registered; using Tenstorrent launchers.")
+        _lifecycle = TenstorrentServerLifecycle()
+    return _lifecycle

--- a/workflows/server_lifecycle_provider.py
+++ b/workflows/server_lifecycle_provider.py
@@ -16,6 +16,7 @@ import logging
 from typing import Any, Optional
 
 from workflow_module.commands import ServerMode
+from workflow_module.server_lifecycle import ServerLifecycle
 from workflows.workflow_types import InferenceEngine
 
 logger = logging.getLogger(__name__)
@@ -26,12 +27,12 @@ _LITERAL_KEY_ENGINE_VALUES = frozenset(
 )
 
 
-class TenstorrentServerLifecycle:
+class TenstorrentServerLifecycle(ServerLifecycle):
     """``ServerLifecycle`` over the Tenstorrent docker/local launchers."""
 
     def launch(
         self,
-        mode: Any,
+        mode: ServerMode,
         model_spec: Any,
         runtime_config: Any,
         setup_config: Any,

--- a/workflows/server_lifecycle_provider.py
+++ b/workflows/server_lifecycle_provider.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Tenstorrent implementation of the engine's server lifecycle seam.
+
+Adapts the Tenstorrent docker/local server launchers and the
+tt-media-server vs vLLM(tt-metal) bearer-token policy to
+:class:`workflow_module.server_lifecycle.ServerLifecycle` so the engine
+never imports the launcher stack or the ``InferenceEngine`` taxonomy.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from workflow_module.commands import ServerMode
+from workflows.workflow_types import InferenceEngine
+
+logger = logging.getLogger(__name__)
+
+# Engines whose servers validate a literal ``Bearer $API_KEY`` (no JWT decode).
+_LITERAL_KEY_ENGINE_VALUES = frozenset(
+    {InferenceEngine.FORGE.value, InferenceEngine.MEDIA.value}
+)
+
+
+class TenstorrentServerLifecycle:
+    """``ServerLifecycle`` over the Tenstorrent docker/local launchers."""
+
+    def launch(
+        self,
+        mode: Any,
+        model_spec: Any,
+        runtime_config: Any,
+        setup_config: Any,
+        json_fpath: Optional[str],
+    ) -> Any:
+        if mode is ServerMode.DOCKER:
+            from workflows.run_docker_server import run_docker_server
+
+            return run_docker_server(
+                model_spec,
+                runtime_config,
+                setup_config,
+                json_fpath,
+            )
+        if mode is ServerMode.LOCAL:
+            from workflows.run_local_server import run_local_server
+
+            return run_local_server(
+                model_spec,
+                runtime_config,
+                json_fpath,
+                setup_config,
+            )
+        raise ValueError(f"unknown server mode: {mode!r}")
+
+    def uses_literal_api_key(self, inference_engine_value: Optional[str]) -> bool:
+        return inference_engine_value in _LITERAL_KEY_ENGINE_VALUES
+
+    def normalize_engine_value(self, raw: Optional[str]) -> Optional[str]:
+        if not raw:
+            return None
+        # Tolerate the enum *name* form ("FORGE") as well as the value form.
+        if raw in InferenceEngine.__members__:
+            return InferenceEngine[raw].value
+        return raw


### PR DESCRIPTION
## Summary

Phase 1, PR4 of the standalone-validation-framework decoupling (stacked on `ipastalTT/phase1-device-catalog`).

Introduces an engine-owned `ServerLifecycle` seam so server bring-up and server-facing auth policy are vendor-adapter concerns injected at process entry, instead of the engine importing the Tenstorrent launcher stack and `InferenceEngine` taxonomy directly.

- `workflow_module/server_lifecycle.py` (new): `ServerLifecycle` protocol —
  - `launch(mode, model_spec, runtime_config, setup_config, json_fpath)` — bring up the inference server (docker/local)
  - `uses_literal_api_key(engine_value)` — tt-media-server (forge/media) expects a literal `Bearer $API_KEY`; only the vLLM (tt-metal) server validates a JWT
  - `normalize_engine_value(raw)` — tolerates enum-name vs enum-value forms in serialized runtime specs
  - process-wide registry (`register_server_lifecycle` / `get_server_lifecycle`) with a lazy Tenstorrent default marked as the Phase-2 removal point
- `workflows/server_lifecycle_provider.py` (new): `TenstorrentServerLifecycle` adapting `run_docker_server` / `run_local_server` (exact argument orders preserved) and the forge/media literal-key policy
- `workflow_module/commands.py`: `ServerCommand.execute` delegates to the registered lifecycle instead of importing `workflows.run_docker_server` / `run_local_server`
- `workflow_module/command_factory.py`: `_resolve_auth_token` / `_engine_from_runtime_spec_json` go through the lifecycle; `InferenceEngine` import dropped
- `run_workflows.py`: registers `TenstorrentServerLifecycle` at startup

## Test plan

- [x] `ruff check` / `ruff format --check` clean on touched files
- [x] Full suite: 1543 passed, 10 skipped (5 `test_helm_generator` errors are a pre-existing missing `ruamel` dep in this env)
- [ ] Draft PR; merge after PR1–PR3 land