### PR TITLE
`VenvProvisioner` seam 

### DIFF
--- a/llm_module/drivers/agentic.py
+++ b/llm_module/drivers/agentic.py
@@ -148,10 +148,10 @@ def _agentic_venv_python() -> Optional[Path]:
     behavior.
     """
     try:
-        from workflows.workflow_types import WorkflowVenvType
-        from workflows.workflow_venvs import VENV_CONFIGS
+        from workflow_module.engine_types import WorkflowVenvType
+        from workflow_module.venv_provisioner import get_venv_provisioner
 
-        return VENV_CONFIGS[WorkflowVenvType.EVALS_AGENTIC].venv_python
+        return Path(get_venv_provisioner().venv_python(WorkflowVenvType.EVALS_AGENTIC))
     except Exception as e:  # pragma: no cover - defensive
         logger.warning("Could not resolve EVALS_AGENTIC venv python (%s).", e)
         return None

--- a/llm_module/eval_command.py
+++ b/llm_module/eval_command.py
@@ -296,7 +296,7 @@ def build_eval_command(
         # payloads, independently of --gen_kwargs. Use the scoped wrapper so
         # --seed still controls harness RNGs without reaching the server.
         lm_eval_prefix = [
-            str(task_venv_config.venv_path / "bin" / "python"),
+            str(task_venv_path / "bin" / "python"),
             str(Path(__file__).with_name("lm_eval_no_server_seed.py")),
         ]
 

--- a/llm_module/eval_command.py
+++ b/llm_module/eval_command.py
@@ -17,8 +17,8 @@ from typing import TYPE_CHECKING, List, Optional
 
 from utils.url_helpers import build_base_url
 from workflow_module.engine_types import EvalLimitMode
-from workflows.workflow_types import WorkflowVenvType
-from workflows.workflow_venvs import VENV_CONFIGS
+from workflow_module.engine_types import WorkflowVenvType
+from workflow_module.venv_provisioner import get_venv_provisioner
 
 if TYPE_CHECKING:
     from reference_config.evals.eval_config import EvalTask
@@ -196,7 +196,7 @@ def build_eval_command(
     else:
         base_url = f"{host_with_port}/v1"
     eval_class = task.eval_class
-    task_venv_config = VENV_CONFIGS[task.workflow_venv_type]
+    task_venv_path = get_venv_provisioner().venv_path(task.workflow_venv_type)
     if task.use_chat_api:
         api_url = f"{base_url}/chat/completions"
     else:
@@ -275,9 +275,9 @@ def build_eval_command(
         WorkflowVenvType.EVALS_VISION,
         WorkflowVenvType.EVALS_AUDIO,
     ]:
-        lm_eval_exec = task_venv_config.venv_path / "bin" / "lmms-eval"
+        lm_eval_exec = task_venv_path / "bin" / "lmms-eval"
     else:
-        lm_eval_exec = task_venv_config.venv_path / "bin" / "lm_eval"
+        lm_eval_exec = task_venv_path / "bin" / "lm_eval"
 
     lm_eval_prefix = [str(lm_eval_exec)]
     # TODO: remove this once diffusiongemma vLLM can ignore the seed gen kwarg
@@ -374,14 +374,14 @@ def build_eval_command(
             # relative to cwd. Give each invocation its own staging dir with a
             # symlink that masquerades as it, so parallel runs don't race.
             meta_data_dir = (
-                task_venv_config.venv_path
+                task_venv_path
                 / "llama-cookbook/end-to-end-use-cases/benchmarks/llm_eval_harness/meta_eval"
                 / f"work_dir_{model_spec.model_name}"
             )
             staging_dir = Path(
                 tempfile.mkdtemp(
                     prefix=f"meta_eval_{model_spec.model_name}_",
-                    dir=task_venv_config.venv_path,
+                    dir=task_venv_path,
                 )
             )
             atexit.register(shutil.rmtree, staging_dir, ignore_errors=True)
@@ -390,8 +390,8 @@ def build_eval_command(
             cmd.append(staging_work_dir)
             os.chdir(staging_dir)
         else:
-            cmd.append(task_venv_config.venv_path / task.include_path)
-            os.chdir(task_venv_config.venv_path)
+            cmd.append(task_venv_path / task.include_path)
+            os.chdir(task_venv_path)
     if task.apply_chat_template:
         cmd.append("--apply_chat_template")  # Flag argument (no value)
 

--- a/llm_module/eval_configs.py
+++ b/llm_module/eval_configs.py
@@ -10,7 +10,7 @@ import logging
 from typing import List
 
 from workflow_module.engine_types import EvalLimitMode
-from workflows.workflow_types import WorkflowVenvType
+from workflow_module.engine_types import WorkflowVenvType
 
 from .eval_command import _get_limit_mode, _parse_eval_samples_mapping
 

--- a/run_workflows.py
+++ b/run_workflows.py
@@ -66,8 +66,14 @@ from workflow_module.model_catalog import (  # noqa: E402
 from workflow_module.server_lifecycle import (  # noqa: E402
     register_server_lifecycle,
 )
+from workflow_module.venv_provisioner import (  # noqa: E402
+    register_venv_provisioner,
+)
 from workflows.server_lifecycle_provider import (  # noqa: E402
     TenstorrentServerLifecycle,
+)
+from workflows.venv_provisioner_provider import (  # noqa: E402
+    TenstorrentVenvProvisioner,
 )
 
 logger = logging.getLogger("tt_workflow_runner")
@@ -545,6 +551,7 @@ def main() -> int:
     register_model_spec_provider(TenstorrentModelSpecProvider())
     register_device_catalog(TenstorrentDeviceCatalog())
     register_server_lifecycle(TenstorrentServerLifecycle())
+    register_venv_provisioner(TenstorrentVenvProvisioner())
     args = parse_args()
     logging.basicConfig(
         level=_LOG_LEVELS[args.log_level],

--- a/test_module/benchmark_tests/audio_benchmark_tests.py
+++ b/test_module/benchmark_tests/audio_benchmark_tests.py
@@ -19,7 +19,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from workflows.utils import (
+from workflow_module.context_helpers import (
     get_num_calls,
     is_preprocessing_enabled_for_whisper,
     is_streaming_enabled_for_whisper,

--- a/test_module/benchmark_tests/embedding_benchmark_tests.py
+++ b/test_module/benchmark_tests/embedding_benchmark_tests.py
@@ -17,7 +17,7 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from reference_config.benchmarking.benchmark_config import select_vllm_benchmark_venv
-from workflows.workflow_venvs import VENV_CONFIGS
+from workflow_module.venv_provisioner import get_venv_provisioner
 
 from report_module.schema import Block
 
@@ -81,8 +81,11 @@ def _run_embedding_transcription_benchmark(ctx: MediaContext) -> dict:
     model, isl, num_calls, concurrency = _embedding_params(ctx)
 
     # Must match the venv workflow_dispatch provisions for this model.
-    venv_config = VENV_CONFIGS.get(select_vllm_benchmark_venv(ctx.model_spec))
-    vllm_exec = venv_config.venv_path / "bin" / "vllm"
+    vllm_exec = (
+        get_venv_provisioner().venv_path(select_vllm_benchmark_venv(ctx.model_spec))
+        / "bin"
+        / "vllm"
+    )
 
     os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
 

--- a/test_module/benchmark_tests/image_benchmark_tests.py
+++ b/test_module/benchmark_tests/image_benchmark_tests.py
@@ -21,7 +21,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from report_module.schema import Block
 
-from workflows.utils import get_num_calls
+from workflow_module.context_helpers import get_num_calls
 
 from .._test_common import (
     MetricSpec,

--- a/test_module/benchmark_tests/tts_benchmark_tests.py
+++ b/test_module/benchmark_tests/tts_benchmark_tests.py
@@ -19,7 +19,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from workflows.utils import get_num_calls
+from workflow_module.context_helpers import get_num_calls
 
 from report_module.schema import Block
 

--- a/test_module/benchmark_tests/video_benchmark_tests.py
+++ b/test_module/benchmark_tests/video_benchmark_tests.py
@@ -16,7 +16,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from workflows.utils import get_num_calls
+from workflow_module.context_helpers import get_num_calls
 
 from report_module.schema import Block
 from report_module.status import TestStatus

--- a/test_module/eval_tests/audio_eval_tests.py
+++ b/test_module/eval_tests/audio_eval_tests.py
@@ -21,7 +21,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from report_module.schema import Block
 
-from workflows.utils import (
+from workflow_module.context_helpers import (
     get_num_calls,
     is_preprocessing_enabled_for_whisper,
     is_streaming_enabled_for_whisper,

--- a/test_module/eval_tests/embedding_eval_tests.py
+++ b/test_module/eval_tests/embedding_eval_tests.py
@@ -15,8 +15,8 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from workflows.workflow_types import WorkflowVenvType
-from workflows.workflow_venvs import VENV_CONFIGS
+from workflow_module.engine_types import WorkflowVenvType
+from workflow_module.venv_provisioner import get_venv_provisioner
 
 from report_module.schema import Block
 
@@ -59,8 +59,11 @@ def _run_embedding_mteb_eval(ctx: MediaContext) -> dict:
     """Run the MTEB eval inside the EVALS_EMBEDDING venv and return metrics."""
     model_name, isl, dimensions = _embedding_model_config(ctx)
 
-    venv_config = VENV_CONFIGS.get(WorkflowVenvType.EVALS_EMBEDDING)
-    venv_python = venv_config.venv_path / "bin" / "python"
+    venv_python = (
+        get_venv_provisioner().venv_path(WorkflowVenvType.EVALS_EMBEDDING)
+        / "bin"
+        / "python"
+    )
     if not venv_python.is_file():
         raise FileNotFoundError(
             f"EVALS_EMBEDDING venv python not found at {venv_python}; "

--- a/test_module/eval_tests/image_eval_tests.py
+++ b/test_module/eval_tests/image_eval_tests.py
@@ -27,7 +27,7 @@ from utils.sdxl_accuracy_utils.sdxl_accuracy_utils import (
     calculate_metrics,
     sdxl_get_prompts,
 )
-from workflows.utils import is_sdxl_num_prompts_enabled
+from workflow_module.context_helpers import is_sdxl_num_prompts_enabled
 
 from .._test_common import block_id
 from ..context import HardwareRequirement, MediaContext, require_health

--- a/test_module/eval_tests/tts_eval_tests.py
+++ b/test_module/eval_tests/tts_eval_tests.py
@@ -17,7 +17,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from report_module.schema import Block
 
-from workflows.utils import get_num_calls
+from workflow_module.context_helpers import get_num_calls
 
 from .._test_common import ReportCheckTypes, block_id
 from ..context import HardwareRequirement, MediaContext, require_health

--- a/test_module/eval_tests/whisper_eval_test.py
+++ b/test_module/eval_tests/whisper_eval_test.py
@@ -265,12 +265,16 @@ class WhisperEvalTest(BaseTest):
             if str(repo_root) not in sys.path:
                 sys.path.insert(0, str(repo_root))
 
-            from workflows.workflow_types import WorkflowVenvType
-            from workflows.workflow_venvs import VENV_CONFIGS
+            from workflow_module.engine_types import WorkflowVenvType
+            from workflow_module.venv_provisioner import get_venv_provisioner
 
-            if WorkflowVenvType.EVALS_AUDIO in VENV_CONFIGS:
-                venv_config = VENV_CONFIGS[WorkflowVenvType.EVALS_AUDIO]
-                lmms_path = venv_config.venv_path / "bin" / "lmms-eval"
+            provisioner = get_venv_provisioner()
+            if provisioner.has_venv(WorkflowVenvType.EVALS_AUDIO):
+                lmms_path = (
+                    provisioner.venv_path(WorkflowVenvType.EVALS_AUDIO)
+                    / "bin"
+                    / "lmms-eval"
+                )
                 logger.info(
                     "EVALS_AUDIO venv lmms-eval path: %s (exists=%s)",
                     lmms_path,

--- a/test_module/llm_tests/agentic_eval_tests.py
+++ b/test_module/llm_tests/agentic_eval_tests.py
@@ -20,7 +20,7 @@ from llm_module import (
 )
 from report_module.schema import Block
 from utils.auth_helpers import setup_tests_auth
-from workflows.workflow_types import WorkflowVenvType
+from workflow_module.engine_types import WorkflowVenvType
 from workflow_module import accept_blocks
 
 from .._test_common import sweep_envelope

--- a/test_module/llm_tests/llm_eval_tests.py
+++ b/test_module/llm_tests/llm_eval_tests.py
@@ -22,7 +22,7 @@ from reference_config.evals.eval_config import accept_eval_score, resolve_eval_r
 from report_module.schema import Block
 from workflow_module import accept_blocks
 from workflow_module.engine_types import EvalLimitMode
-from workflows.utils import run_command
+from workflow_module.proc import run_command
 
 from .._test_common import ReportCheckTypes, TestStatus, block_id
 from ..context import MediaContext

--- a/tests/workflow_module/test_commands.py
+++ b/tests/workflow_module/test_commands.py
@@ -12,6 +12,7 @@ error handling) is tested without running a real workflow.
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -176,22 +177,28 @@ def _install_fake_venv_stack(
     run_rc=0,
     recorder=None,
 ):
-    """Stand in fake ``workflows.workflow_venvs`` / ``workflows.utils`` modules so
+    """Register a fake ``VenvProvisioner`` and stub ``proc.run_command`` so
     VenvCommand resolves a venv + runs a subprocess without touching the disk.
     """
 
-    class _FakeVenvConfig:
+    class _FakeProvisioner:
         def __init__(self):
-            self.venv_python = venv_python
             self.setup_calls = []
 
-        def setup(self, model_spec=None):
+        def has_venv(self, vt):
+            return vt == venv_type
+
+        def venv_path(self, vt):
+            return Path(venv_python).parent.parent
+
+        def venv_python(self, vt):
+            return venv_python
+
+        def provision(self, vt, model_spec=None):
             self.setup_calls.append(model_spec)
             return setup_ok
 
-    config = _FakeVenvConfig()
-    venvs_mod = ModuleType("workflows.workflow_venvs")
-    venvs_mod.VENV_CONFIGS = {venv_type: config}
+    provisioner = _FakeProvisioner()
 
     def _run_command(command, logger=None, env=None, **kwargs):
         if recorder is not None:
@@ -199,12 +206,9 @@ def _install_fake_venv_stack(
             recorder["env"] = env
         return run_rc
 
-    utils_mod = ModuleType("workflows.utils")
-    utils_mod.run_command = _run_command
-
-    monkeypatch.setitem(sys.modules, "workflows.workflow_venvs", venvs_mod)
-    monkeypatch.setitem(sys.modules, "workflows.utils", utils_mod)
-    return config
+    monkeypatch.setattr("workflow_module.venv_provisioner._provisioner", provisioner)
+    monkeypatch.setattr("workflow_module.proc.run_command", _run_command)
+    return provisioner
 
 
 class TestVenvCommand:

--- a/workflow_module/command_factory.py
+++ b/workflow_module/command_factory.py
@@ -36,8 +36,10 @@ from .execution import (
     ServingBenchOptions,
     SpecDecodeOptions,
 )
+from .engine_types import WorkflowVenvType
 from .model_catalog import ModelSpecLike, get_model_spec_provider
 from .server_lifecycle import get_server_lifecycle
+from .venv_provisioner import get_venv_provisioner
 
 # Workflows whose LLM path runs the standard-eval / perf-benchmark child.
 _LLM_BENCH_WORKFLOWS = frozenset({"benchmarks", "release"})
@@ -253,8 +255,6 @@ def _release_bench_venv_python(args: argparse.Namespace) -> Optional[str]:
     A release run executes in the WORKFLOW_RUN_SCRIPT venv, so pin the default
     perf-tool venv (LLM_VLLM); the workflow dispatch provisions it before run.py.
     """
-    from workflows.workflow_types import WorkflowVenvType
-
     return _release_venv_python(args, WorkflowVenvType.LLM_VLLM)
 
 
@@ -262,9 +262,7 @@ def _release_venv_python(args: argparse.Namespace, venv_type) -> Optional[str]:
     """Interpreter pinned for release children that need a tool venv."""
     if getattr(args, "workflow", None) != "release":
         return None
-    from workflows.workflow_venvs import VENV_CONFIGS
-
-    return str(VENV_CONFIGS[venv_type].venv_python)
+    return get_venv_provisioner().venv_python(venv_type)
 
 
 def _build_llm_eval_options(args: argparse.Namespace) -> Optional[LLMEvalOptions]:
@@ -297,7 +295,6 @@ def _build_agentic_traces_options(
     is_release_child = workflow == "release" and getattr(args, "agentic_traces", False)
     if workflow != "agentic_traces" and not is_release_child:
         return None
-    from workflows.workflow_types import WorkflowVenvType
 
     return AgenticTracesOptions(
         mode=getattr(args, "agentic_traces_mode", None) or "full",
@@ -334,7 +331,6 @@ def _build_prefix_cache_options(
     """
     if not getattr(args, "prefix_cache", False):
         return None
-    from workflows.workflow_types import WorkflowVenvType
 
     return PrefixCacheOptions(
         preset=args.prefix_cache_preset,
@@ -362,7 +358,6 @@ def _build_spec_decode_options(
     """
     if not getattr(args, "spec_decode", False):
         return None
-    from workflows.workflow_types import WorkflowVenvType
 
     return SpecDecodeOptions(
         preset=args.spec_decode_preset,

--- a/workflow_module/commands.py
+++ b/workflow_module/commands.py
@@ -386,25 +386,24 @@ class VenvCommand(Command):
         import os
         import sys
 
-        from workflows.utils import run_command
+        from .proc import run_command
+        from .venv_provisioner import get_venv_provisioner
 
         if self.venv_type is None:
             python = sys.executable
         else:
-            from workflows.workflow_venvs import VENV_CONFIGS
+            provisioner = get_venv_provisioner()
 
             # Provision the primary venv plus any dependency venvs the workflow
             # needs before running.
             for venv_type in [self.venv_type, *self.dependency_venvs]:
-                try:
-                    venv_config = VENV_CONFIGS[venv_type]
-                except KeyError:
+                if not provisioner.has_venv(venv_type):
                     return CommandResult(
                         command_name=self.name,
                         return_code=1,
                         error=f"no venv config for {venv_type!r}",
                     )
-                if not venv_config.setup(model_spec=self.model_spec):
+                if not provisioner.provision(venv_type, model_spec=self.model_spec):
                     return CommandResult(
                         command_name=self.name,
                         return_code=1,
@@ -413,7 +412,7 @@ class VenvCommand(Command):
                             f"{getattr(venv_type, 'name', venv_type)}"
                         ),
                     )
-            python = str(VENV_CONFIGS[self.venv_type].venv_python)
+            python = provisioner.venv_python(self.venv_type)
 
         cmd = [python, *[str(a) for a in self.argv]]
         env = {**os.environ, **self.env} if self.env else None

--- a/workflow_module/context_helpers.py
+++ b/workflow_module/context_helpers.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+"""Run-context attribute helpers shared by (media) test modules.
+
+These read knobs off a run context (``ctx.model_spec.cli_args`` /
+``ctx.all_params``) and are engine-generic: they moved here from
+``workflows/utils.py`` so test modules never import the Tenstorrent
+adapter. ``workflows.utils`` re-exports them for pre-extraction callers.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# SDXL num prompts limits
+SDXL_DEFAULT_NUM_PROMPTS = 100
+SDXL_LOWER_BOUND_NUM_PROMPTS = 2
+SDXL_UPPER_BOUND_NUM_PROMPTS = 5000
+
+
+def is_streaming_enabled_for_whisper(self) -> bool:
+    """Determine if streaming is enabled for the Whisper model based on CLI args. Default to True if not set."""
+    logger.info("Checking if streaming is enabled for Whisper model")
+    cli_args = getattr(self.model_spec, "cli_args", {})
+
+    # Check if streaming arg exists and has a valid value
+    streaming_value = cli_args.get("streaming")
+    if streaming_value is None:
+        return True
+
+    # Convert to string and check if it's 'true'
+    streaming_enabled = str(streaming_value).lower() == "true"
+
+    return streaming_enabled
+
+
+def is_preprocessing_enabled_for_whisper(self) -> bool:
+    """Determine if preprocessing is enabled for the Whisper model based on CLI args. Default to True if not set."""
+    logger.info("Checking if preprocessing is enabled for Whisper model")
+
+    cli_args = getattr(self.model_spec, "cli_args", {})
+    preprocessing_value = cli_args.get("preprocessing")
+    if preprocessing_value is None:
+        return True
+
+    # Convert to string and check if it's 'true'
+    preprocessing_enabled = str(preprocessing_value).lower() == "true"
+
+    return preprocessing_enabled
+
+
+def is_sdxl_num_prompts_enabled(self) -> int:
+    """Determine the number of prompts to use for SDXL based on CLI args. Default to 100 if not set."""
+    logger.info("Checking if sdxl_num_prompts is set")
+
+    cli_args = getattr(self.model_spec, "cli_args", {})
+    sdxl_num_prompts = cli_args.get("sdxl_num_prompts")
+    if sdxl_num_prompts is None:
+        return SDXL_DEFAULT_NUM_PROMPTS
+
+    # Convert to int and return
+    num_prompts = int(sdxl_num_prompts)
+    if (
+        num_prompts < SDXL_LOWER_BOUND_NUM_PROMPTS
+        or num_prompts > SDXL_UPPER_BOUND_NUM_PROMPTS
+    ):
+        return SDXL_DEFAULT_NUM_PROMPTS
+
+    return num_prompts
+
+
+def get_num_calls(self) -> int:
+    """Get number of calls from benchmark parameters."""
+    logger.info("Extracting number of calls from benchmark parameters")
+
+    # Guard clause: Handle single config object case (evals)
+    if hasattr(self.all_params, "tasks") and not isinstance(
+        self.all_params, (list, tuple)
+    ):
+        return 2  # hard coding for evals
+
+    # Handle list/iterable case (benchmarks)
+    if isinstance(self.all_params, (list, tuple)):
+        return next(
+            (
+                getattr(param, "num_eval_runs", 2)
+                for param in self.all_params
+                if hasattr(param, "num_eval_runs")
+            ),
+            2,
+        )
+
+    return 2

--- a/workflow_module/engine_types.py
+++ b/workflow_module/engine_types.py
@@ -239,3 +239,41 @@ class ModelType(IntEnum):
             ModelType.TRAINING: "training",
         }
         return task_types[self]
+
+
+class WorkflowVenvType(IntEnum):
+    """Named tool-environment keys.
+
+    The *keys* are engine-generic (a standalone framework needs named tool
+    environments); the *content* — what each environment installs and where
+    it lives — is adapter business behind
+    :class:`workflow_module.venv_provisioner.VenvProvisioner`.
+    """
+
+    SYSTEM_SOFTWARE_VALIDATION = auto()
+    STRESS_TESTS_RUN_SCRIPT = auto()
+    STRESS_TESTS = auto()
+    EVALS_RUN_SCRIPT = auto()
+    TESTS_RUN_SCRIPT = auto()
+    BENCHMARKS_RUN_SCRIPT = auto()
+    REPORTS_RUN_SCRIPT = auto()
+    WORKFLOW_RUN_SCRIPT = auto()
+    PREFIX_CACHE = auto()
+    AGENTIC_TRACES = auto()
+    LLM_VLLM = auto()
+    LLM_GUIDELLM = auto()
+    LLM_AIPERF = auto()
+    SPEC_DECODE = auto()
+    EVALS_COMMON = auto()
+    EVALS_META = auto()
+    EVALS_VISION = auto()
+    EVALS_AUDIO = auto()
+    EVALS_EMBEDDING = auto()
+    EVALS_AGENTIC = auto()
+    BENCHMARKS_VLLM = auto()
+    BENCHMARKS_VLLM_FORGE = auto()
+    BENCHMARKS_GENAI_PERF = auto()
+    HF_SETUP = auto()
+    SERVER = auto()
+    TT_SMI = auto()
+    TT_TOPOLOGY = auto()

--- a/workflow_module/proc.py
+++ b/workflow_module/proc.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+"""Subprocess helpers for the engine core.
+
+Moved here from ``workflows/utils.py`` so engine packages never import the
+Tenstorrent adapter for a generic subprocess wrapper. ``workflows.utils``
+re-exports these for pre-extraction callers.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import subprocess
+import threading
+
+logger = logging.getLogger(__name__)
+
+
+def stream_subprocess_output(pipe, logger, level):
+    with pipe:
+        for line in iter(pipe.readline, ""):
+            logger.log(level, line.strip(), extra={"raw": True})
+
+
+def run_command(
+    command,
+    logger,
+    log_file_path=None,
+    shell=False,
+    copy_env=True,
+    env=None,
+    check=False,
+):
+    """
+    This function is a wrapper around subprocess.Popen and subprocess.run.
+    It is used to run a command and capture the stdout and stderr in the caller's logger.
+
+    Args:
+        command: Command to run. Can be a string or a list of strings.
+        logger: Logger to use for logging. Must be passed because the common use case is to capture the command's stdout and stderr in the caller's logger.
+        log_file_path: Path to log file. If None, stdout and stderr will be logged to the logger.
+        shell: Whether to use shell to run the command.
+        copy_env: Whether to copy the environment variables.
+        env: Environment variables to use.
+        check: Whether to check the return code. Set to True for commands that must succeed.
+    Returns:
+        Return code of the command.
+    Raises:
+        RuntimeError: If the command fails and check is True.
+        NotImplementedError: If copy_env is True and not implemented.
+        AssertionError: If command is not a list of strings.
+        ValueError: If command is None.
+        PermissionError: If the directory is not writable.
+        IOError: If the directory is not readable.
+    """
+    if not copy_env:
+        raise NotImplementedError("TODO")
+
+    if not env:
+        env = os.environ.copy()
+    # TODO: force usage to always use argument list
+    # use shlex to log full command before running
+
+    if command is None:
+        logger.error("No command provided to run_command.")
+    elif isinstance(command, str):
+        command = shlex.split(command)
+
+    assert isinstance(command, list), "Command must be a list of cmd arguments."
+
+    logger.info(f"Running command: {shlex.join(command)}")
+
+    if not log_file_path:
+        subproc_type = "subprocess.Popen"
+        # capture all output to stdout and stderr in current process
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=1,
+            text=True,
+            env=env,
+        )
+
+        stdout_thread = threading.Thread(
+            target=stream_subprocess_output,
+            args=(process.stdout, logger, logging.DEBUG),
+        )
+        stderr_thread = threading.Thread(
+            target=stream_subprocess_output,
+            args=(process.stderr, logger, logging.INFO),
+        )
+
+        stdout_thread.start()
+        stderr_thread.start()
+
+        stdout_thread.join()
+        stderr_thread.join()
+
+        process.wait()
+        return_code = process.returncode
+    else:
+        subproc_type = "subprocess.run"
+        logger.info(f"Logging output to: {log_file_path} ...")
+        with open(log_file_path, "a", buffering=1) as log_file:
+            result = subprocess.run(
+                command,
+                shell=shell,
+                stdout=log_file,
+                stderr=log_file,
+                check=check,
+                text=True,
+                env=env,
+            )
+            return_code = result.returncode
+
+    if return_code != 0:
+        error_message = (
+            f"⛔ {subproc_type} command failed with return code: {return_code}\n"
+            f"command: {shlex.join(command)}\n\n"
+            "See error messages in logs above this RuntimeError for details on actual cause of failure.\n"
+        )
+        if check:
+            raise RuntimeError(error_message)
+        else:
+            logger.error(
+                error_message
+                + "\nThis command is optional or can be recovered from failure (check=False set). Continuing ...\n"
+            )
+    return return_code

--- a/workflow_module/venv_provisioner.py
+++ b/workflow_module/venv_provisioner.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+
+"""Engine-owned tool-environment (venv) provisioning seam.
+
+The engine runs harnesses (lm_eval, lmms-eval, vllm bench, ...) out of
+named tool environments keyed by :class:`engine_types.WorkflowVenvType`.
+What each environment contains and how it is created is vendor adapter
+business. This module defines the seam:
+
+- :class:`VenvProvisioner` — resolve an environment's path/python and
+  provision it on demand.
+
+The Tenstorrent implementation (``workflows/workflow_venvs.py``'s
+``VENV_CONFIGS``) lives adapter-side and is injected via
+:func:`register_venv_provisioner` at process entry. A lazy Tenstorrent
+default is kept for backward compatibility during the extraction; it is
+the marked Phase-2 removal point.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class VenvProvisioner(Protocol):
+    """Resolves and provisions named tool environments."""
+
+    def has_venv(self, venv_type: Any) -> bool:
+        """Whether ``venv_type`` is a known environment."""
+        ...
+
+    def venv_path(self, venv_type: Any) -> Path:
+        """Root directory of the environment. Raises ``KeyError`` if unknown."""
+        ...
+
+    def venv_python(self, venv_type: Any) -> str:
+        """Python interpreter of the environment. Raises ``KeyError`` if unknown."""
+        ...
+
+    def provision(self, venv_type: Any, model_spec: Any = None) -> bool:
+        """Create/update the environment; returns True on success."""
+        ...
+
+
+_provisioner: Optional[VenvProvisioner] = None
+
+
+def register_venv_provisioner(provisioner: VenvProvisioner) -> None:
+    """Install the process-wide venv provisioner (called at entry points)."""
+    global _provisioner
+    _provisioner = provisioner
+
+
+def get_venv_provisioner() -> VenvProvisioner:
+    """Return the registered provisioner, lazily defaulting to VENV_CONFIGS.
+
+    EXTRACTION SEAM (Phase 2 removal point): the lazy default keeps
+    pre-extraction callers working without an explicit registration. Once the
+    engine is packaged separately, this fallback disappears and entry points
+    must register a provisioner explicitly.
+    """
+    global _provisioner
+    if _provisioner is None:
+        from workflows.venv_provisioner_provider import TenstorrentVenvProvisioner
+
+        logger.debug("No VenvProvisioner registered; using Tenstorrent VENV_CONFIGS.")
+        _provisioner = TenstorrentVenvProvisioner()
+    return _provisioner

--- a/workflow_module/workflows.py
+++ b/workflow_module/workflows.py
@@ -90,7 +90,7 @@ def _run_sweep_task(logger, label: str, run_sweep) -> TaskOutcome:
 
 def _has_agentic_tasks(ctx) -> bool:
     """True if the run's eval tasks include any EVALS_AGENTIC task."""
-    from workflows.workflow_types import WorkflowVenvType
+    from .engine_types import WorkflowVenvType
 
     tasks = getattr(getattr(ctx, "all_params", None), "tasks", None) or []
     return any(

--- a/workflows/utils.py
+++ b/workflows/utils.py
@@ -8,21 +8,25 @@ import base64
 import logging
 import os
 import re
-import shlex
-import subprocess
 import tempfile
-import threading
 import uuid
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
-# SDXL num prompts limits
-SDXL_DEFAULT_NUM_PROMPTS = 100
-SDXL_LOWER_BOUND_NUM_PROMPTS = 2
-SDXL_UPPER_BOUND_NUM_PROMPTS = 5000
-
+# Engine-generic helpers live in the engine core; re-exported here for
+# pre-extraction callers (v1 workflows and tests).
+from workflow_module.context_helpers import (  # noqa: E402,F401
+    SDXL_DEFAULT_NUM_PROMPTS,
+    SDXL_LOWER_BOUND_NUM_PROMPTS,
+    SDXL_UPPER_BOUND_NUM_PROMPTS,
+    get_num_calls,
+    is_preprocessing_enabled_for_whisper,
+    is_sdxl_num_prompts_enabled,
+    is_streaming_enabled_for_whisper,
+)
+from workflow_module.proc import run_command, stream_subprocess_output  # noqa: E402,F401
 
 # Minimum image version supported by this run.py. The vLLM docker image
 # interface was reshaped in v0.11.0 (commit 50db8ac7 "Simplify and improve
@@ -217,120 +221,6 @@ def ensure_readwriteable_dir(path, raise_on_fail=True, logger=logger):
         return False
 
 
-def stream_subprocess_output(pipe, logger, level):
-    with pipe:
-        for line in iter(pipe.readline, ""):
-            logger.log(level, line.strip(), extra={"raw": True})
-
-
-def run_command(
-    command,
-    logger,
-    log_file_path=None,
-    shell=False,
-    copy_env=True,
-    env=None,
-    check=False,
-):
-    """
-    This function is a wrapper around subprocess.Popen and subprocess.run.
-    It is used to run a command and capture the stdout and stderr in the caller's logger.
-
-    Args:
-        command: Command to run. Can be a string or a list of strings.
-        logger: Logger to use for logging. Must be passed because the common use case is to capture the command's stdout and stderr in the caller's logger.
-        log_file_path: Path to log file. If None, stdout and stderr will be logged to the logger.
-        shell: Whether to use shell to run the command.
-        copy_env: Whether to copy the environment variables.
-        env: Environment variables to use.
-        check: Whether to check the return code. Set to True for commands that must succeed.
-    Returns:
-        Return code of the command.
-    Raises:
-        RuntimeError: If the command fails and check is True.
-        NotImplementedError: If copy_env is True and not implemented.
-        AssertionError: If command is not a list of strings.
-        ValueError: If command is None.
-        PermissionError: If the directory is not writable.
-        IOError: If the directory is not readable.
-    """
-    if not copy_env:
-        raise NotImplementedError("TODO")
-
-    if not env:
-        env = os.environ.copy()
-    # TODO: force usage to always use argument list
-    # use shlex to log full command before running
-
-    if command is None:
-        logger.error("No command provided to run_command.")
-    elif isinstance(command, str):
-        command = shlex.split(command)
-
-    assert isinstance(command, list), "Command must be a list of cmd arguments."
-
-    logger.info(f"Running command: {shlex.join(command)}")
-
-    if not log_file_path:
-        subproc_type = "subprocess.Popen"
-        # capture all output to stdout and stderr in current process
-        process = subprocess.Popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            bufsize=1,
-            text=True,
-            env=env,
-        )
-
-        stdout_thread = threading.Thread(
-            target=stream_subprocess_output,
-            args=(process.stdout, logger, logging.DEBUG),
-        )
-        stderr_thread = threading.Thread(
-            target=stream_subprocess_output,
-            args=(process.stderr, logger, logging.INFO),
-        )
-
-        stdout_thread.start()
-        stderr_thread.start()
-
-        stdout_thread.join()
-        stderr_thread.join()
-
-        process.wait()
-        return_code = process.returncode
-    else:
-        subproc_type = "subprocess.run"
-        logger.info(f"Logging output to: {log_file_path} ...")
-        with open(log_file_path, "a", buffering=1) as log_file:
-            result = subprocess.run(
-                command,
-                shell=shell,
-                stdout=log_file,
-                stderr=log_file,
-                check=check,
-                text=True,
-                env=env,
-            )
-            return_code = result.returncode
-
-    if return_code != 0:
-        error_message = (
-            f"⛔ {subproc_type} command failed with return code: {return_code}\n"
-            f"command: {shlex.join(command)}\n\n"
-            "See error messages in logs above this RuntimeError for details on actual cause of failure.\n"
-        )
-        if check:
-            raise RuntimeError(error_message)
-        else:
-            logger.error(
-                error_message
-                + "\nThis command is optional or can be recovered from failure (check=False set). Continuing ...\n"
-            )
-    return return_code
-
-
 default_dotenv_path = get_repo_root_path() / ".env"
 
 
@@ -449,81 +339,6 @@ def resolve_hf_snapshot_dir(hf_repo: str, hf_home: Path) -> Optional[Path]:
 def get_weights_hf_cache_dir(hf_repo: str) -> Path:
     hf_home = get_default_hf_home_path()
     return resolve_hf_snapshot_dir(hf_repo, hf_home)
-
-
-def is_streaming_enabled_for_whisper(self) -> bool:
-    """Determine if streaming is enabled for the Whisper model based on CLI args. Default to True if not set."""
-    logger.info("Checking if streaming is enabled for Whisper model")
-    cli_args = getattr(self.model_spec, "cli_args", {})
-
-    # Check if streaming arg exists and has a valid value
-    streaming_value = cli_args.get("streaming")
-    if streaming_value is None:
-        return True
-
-    # Convert to string and check if it's 'true'
-    streaming_enabled = str(streaming_value).lower() == "true"
-
-    return streaming_enabled
-
-
-def is_preprocessing_enabled_for_whisper(self) -> bool:
-    """Determine if preprocessing is enabled for the Whisper model based on CLI args. Default to True if not set."""
-    logger.info("Checking if preprocessing is enabled for Whisper model")
-
-    cli_args = getattr(self.model_spec, "cli_args", {})
-    preprocessing_value = cli_args.get("preprocessing")
-    if preprocessing_value is None:
-        return True
-
-    # Convert to string and check if it's 'true'
-    preprocessing_enabled = str(preprocessing_value).lower() == "true"
-
-    return preprocessing_enabled
-
-
-def is_sdxl_num_prompts_enabled(self) -> int:
-    """Determine the number of prompts to use for SDXL based on CLI args. Default to 100 if not set."""
-    logger.info("Checking if sdxl_num_prompts is set")
-
-    cli_args = getattr(self.model_spec, "cli_args", {})
-    sdxl_num_prompts = cli_args.get("sdxl_num_prompts")
-    if sdxl_num_prompts is None:
-        return SDXL_DEFAULT_NUM_PROMPTS
-
-    # Convert to int and return
-    num_prompts = int(sdxl_num_prompts)
-    if (
-        num_prompts < SDXL_LOWER_BOUND_NUM_PROMPTS
-        or num_prompts > SDXL_UPPER_BOUND_NUM_PROMPTS
-    ):
-        return SDXL_DEFAULT_NUM_PROMPTS
-
-    return num_prompts
-
-
-def get_num_calls(self) -> int:
-    """Get number of calls from benchmark parameters."""
-    logger.info("Extracting number of calls from benchmark parameters")
-
-    # Guard clause: Handle single config object case (evals)
-    if hasattr(self.all_params, "tasks") and not isinstance(
-        self.all_params, (list, tuple)
-    ):
-        return 2  # hard coding for evals
-
-    # Handle list/iterable case (benchmarks)
-    if isinstance(self.all_params, (list, tuple)):
-        return next(
-            (
-                getattr(param, "num_eval_runs", 2)
-                for param in self.all_params
-                if hasattr(param, "num_eval_runs")
-            ),
-            2,
-        )
-
-    return 2
 
 
 # =============================================================================

--- a/workflows/venv_provisioner_provider.py
+++ b/workflows/venv_provisioner_provider.py
@@ -16,12 +16,13 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from workflow_module.venv_provisioner import VenvProvisioner
 from workflows.workflow_venvs import VENV_CONFIGS
 
 logger = logging.getLogger(__name__)
 
 
-class TenstorrentVenvProvisioner:
+class TenstorrentVenvProvisioner(VenvProvisioner):
     """``VenvProvisioner`` over the Tenstorrent ``VENV_CONFIGS`` registry."""
 
     def has_venv(self, venv_type: Any) -> bool:

--- a/workflows/venv_provisioner_provider.py
+++ b/workflows/venv_provisioner_provider.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Tenstorrent implementation of the engine's venv provisioning seam.
+
+Adapts ``workflows/workflow_venvs.py``'s ``VENV_CONFIGS`` (uv-managed
+per-tool environments) to
+:class:`workflow_module.venv_provisioner.VenvProvisioner` so the engine
+never imports the TT venv registry directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from workflows.workflow_venvs import VENV_CONFIGS
+
+logger = logging.getLogger(__name__)
+
+
+class TenstorrentVenvProvisioner:
+    """``VenvProvisioner`` over the Tenstorrent ``VENV_CONFIGS`` registry."""
+
+    def has_venv(self, venv_type: Any) -> bool:
+        return venv_type in VENV_CONFIGS
+
+    def venv_path(self, venv_type: Any) -> Path:
+        return VENV_CONFIGS[venv_type].venv_path
+
+    def venv_python(self, venv_type: Any) -> str:
+        return str(VENV_CONFIGS[venv_type].venv_python)
+
+    def provision(self, venv_type: Any, model_spec: Any = None) -> bool:
+        # VenvConfig.setup runs uv venv -> extra_dirs -> requirements ->
+        # setup_function hook, raising RuntimeError on failed steps.
+        return bool(VENV_CONFIGS[venv_type].setup(model_spec=model_spec))

--- a/workflows/workflow_types.py
+++ b/workflows/workflow_types.py
@@ -6,14 +6,14 @@
 
 Generic validation-framework enums (``WorkflowType``, ``ModelType``,
 ``ReportCheckTypes``, ``ModelStatusTypes``, ``EvalLimitMode``,
-``AgenticTracesMode``, ``BenchmarkTaskType``, ``VersionMode``) are owned by
-the engine in ``workflow_module/engine_types.py`` and re-exported here so
-existing ``workflows/`` callers keep working unchanged.
+``AgenticTracesMode``, ``BenchmarkTaskType``, ``VersionMode``,
+``WorkflowVenvType``) are owned by the engine in
+``workflow_module/engine_types.py`` and re-exported here so existing
+``workflows/`` callers keep working unchanged.
 
 The enums that remain defined in this module are Tenstorrent adapter
-concerns: hardware taxonomy (``DeviceTypes``, ``SystemTopology``), inference
-stack (``InferenceEngine``, ``ModelSource``), and TT host venv provisioning
-(``WorkflowVenvType``).
+concerns: hardware taxonomy (``DeviceTypes``, ``SystemTopology``) and
+inference stack (``InferenceEngine``, ``ModelSource``).
 """
 
 from enum import Enum, IntEnum, auto
@@ -27,6 +27,7 @@ from workflow_module.engine_types import (
     ReportCheckTypes,
     VersionMode,
     WorkflowType,
+    WorkflowVenvType,
 )
 
 __all__ = [
@@ -39,43 +40,13 @@ __all__ = [
     "ReportCheckTypes",
     "VersionMode",
     "WorkflowType",
-    # Tenstorrent-specific types defined here
     "WorkflowVenvType",
+    # Tenstorrent-specific types defined here
     "DeviceTypes",
     "SystemTopology",
     "InferenceEngine",
     "ModelSource",
 ]
-
-
-class WorkflowVenvType(IntEnum):
-    SYSTEM_SOFTWARE_VALIDATION = auto()
-    STRESS_TESTS_RUN_SCRIPT = auto()
-    STRESS_TESTS = auto()
-    EVALS_RUN_SCRIPT = auto()
-    TESTS_RUN_SCRIPT = auto()
-    BENCHMARKS_RUN_SCRIPT = auto()
-    REPORTS_RUN_SCRIPT = auto()
-    WORKFLOW_RUN_SCRIPT = auto()
-    PREFIX_CACHE = auto()
-    AGENTIC_TRACES = auto()
-    LLM_VLLM = auto()
-    LLM_GUIDELLM = auto()
-    LLM_AIPERF = auto()
-    SPEC_DECODE = auto()
-    EVALS_COMMON = auto()
-    EVALS_META = auto()
-    EVALS_VISION = auto()
-    EVALS_AUDIO = auto()
-    EVALS_EMBEDDING = auto()
-    EVALS_AGENTIC = auto()
-    BENCHMARKS_VLLM = auto()
-    BENCHMARKS_VLLM_FORGE = auto()
-    BENCHMARKS_GENAI_PERF = auto()
-    HF_SETUP = auto()
-    SERVER = auto()
-    TT_SMI = auto()
-    TT_TOPOLOGY = auto()
 
 
 class DeviceTypes(IntEnum):


### PR DESCRIPTION
## Summary

Phase 1, PR5 of the standalone-validation-framework decoupling (stacked on `ipastalTT/phase1-server-lifecycle`).

Introduces an engine-owned `VenvProvisioner` seam and moves engine-generic utilities out of `workflows/`, so engine packages no longer import the Tenstorrent venv registry (`VENV_CONFIGS`) or `workflows.utils`.

- `workflow_module/venv_provisioner.py` (new): `VenvProvisioner` protocol — `has_venv` / `venv_path` / `venv_python` / `provision(venv_type, model_spec)` — plus process-wide registry with a lazy Tenstorrent default marked as the Phase-2 removal point
- `workflows/venv_provisioner_provider.py` (new): `TenstorrentVenvProvisioner` over `VENV_CONFIGS`, preserving `VenvConfig.setup(model_spec=...)` semantics exactly
- `WorkflowVenvType` moves to `workflow_module/engine_types.py` — the *keys* are engine-generic (named tool environments); the *content* (what each env installs, where it lives) stays adapter-side behind the provisioner. Re-exported from `workflows/workflow_types.py` for existing callers
- `workflow_module/proc.py` (new): `run_command` / `stream_subprocess_output` moved from `workflows/utils.py`
- `workflow_module/context_helpers.py` (new): run-context knob helpers moved from `workflows/utils.py` (`get_num_calls`, `is_sdxl_num_prompts_enabled`, whisper streaming/preprocessing toggles, SDXL constants)
- `workflows/utils.py` re-exports both groups for pre-extraction v1 callers
- All engine call sites migrated: `VenvCommand`, `command_factory` release-venv pinning, `eval_command`, agentic driver, whisper/embedding/media eval+benchmark tests
- `run_workflows.py`: registers `TenstorrentVenvProvisioner` at startup

## Test plan

- [x] `ruff check` / `ruff format` clean
- [x] Full suite: 1543 passed, 10 skipped (5 `test_helm_generator` errors are a pre-existing missing `ruamel` dep in this env)
- [x] `tests/workflow_module/test_commands.py::TestVenvCommand` updated to fake the provisioner seam instead of module-standing `workflows.workflow_venvs` / `workflows.utils`
- [ ] Draft PR; merge after PR4 lands