### PR TITLE
acceptance: honor SPEC_TESTS known_issues waivers

### DIFF
--- a/report_module/__init__.py
+++ b/report_module/__init__.py
@@ -7,6 +7,7 @@ from report_module.acceptance_criteria import (
     acceptance_criteria_check,
     build_acceptance_export,
     format_acceptance_summary_markdown,
+    fully_waived_task_types,
     task_failure_blockers,
 )
 from report_module.generator import (
@@ -26,6 +27,7 @@ __all__ = [
     "SchemaLike",
     "ACCEPTANCE_EXPORT_KEYS",
     "acceptance_criteria_check",
+    "fully_waived_task_types",
     "task_failure_blockers",
     "build_acceptance_export",
     "format_acceptance_summary_markdown",

--- a/report_module/acceptance_criteria.py
+++ b/report_module/acceptance_criteria.py
@@ -18,6 +18,11 @@ KIND_BENCHMARKS = "benchmarks"
 KIND_EVALS = "evals"
 KIND_SPEC_TESTS = "spec_tests"
 
+# TaskOutcome.task_type for the spec-test task, i.e. MediaTaskType.SPEC_TESTS
+# .value. A separate namespace from the block kinds above; not imported from
+# test_module to keep report_module free of that dependency.
+SPEC_TESTS_TASK_TYPE = "spec_tests"
+
 TARGET_LEVELS = ("functional", "complete", "target")
 CHECK_SUFFIX = "_check"
 FAIL_CHECK_INT = 3
@@ -104,7 +109,7 @@ def acceptance_criteria_check(
     categories = [
         _check_benchmarks(schema, model_status),
         _check_evals(schema, known_issues, model_status),
-        _check_spec_tests(schema),
+        _check_spec_tests(schema, known_issues),
     ]
     blockers: Dict[str, str] = {}
     for category in categories:
@@ -114,6 +119,7 @@ def acceptance_criteria_check(
 
 def task_failure_blockers(
     outcomes: Iterable[Tuple[str, int, bool]],
+    waived_task_types: Optional[Iterable[str]] = None,
 ) -> Dict[str, str]:
     """Blockers for workflow tasks whose process exited non-zero.
 
@@ -122,10 +128,16 @@ def task_failure_blockers(
     missing category as ``NA`` rather than a failure. Surfacing the raw task
     exit code here keeps the acceptance verdict consistent with the workflow's
     return code so a crash can never be laundered into a silent ``PASS``.
+
+    ``waived_task_types`` suppresses the exit-code blocker for tasks whose block
+    was fully waived; a task that produced no block always blocks.
     """
+    waived = set(waived_task_types or ())
     blockers: Dict[str, str] = {}
     for task_type, exit_code, produced_block in outcomes:
         if exit_code == 0:
+            continue
+        if produced_block and task_type in waived:
             continue
         detail = (
             "and produced no report block"
@@ -136,6 +148,22 @@ def task_failure_blockers(
             f"Task '{task_type}' failed (exit={exit_code}) {detail}."
         )
     return blockers
+
+
+def fully_waived_task_types(categories: Iterable["CategoryResult"]) -> set:
+    """Task types whose every failure was waived, so their exit code is expected.
+
+    Spec tests only, as policy: other categories' non-zero exits always block.
+    ``waived`` also holds status-tier masking (#4830), which must not excuse a
+    task that exited non-zero.
+    """
+    return {
+        SPEC_TESTS_TASK_TYPE
+        for category in categories
+        if category.name == CATEGORY_SPEC_TESTS
+        and category.waived
+        and not category.blockers
+    }
 
 
 def _find_waiver(
@@ -457,7 +485,53 @@ def _check_evals(
     )
 
 
-def _check_spec_tests(schema: ReportSchema) -> CategoryResult:
+def _failing_spec_cases(block: Block) -> List[str]:
+    """Failing case names from ``parameter_conformance_summary``, if itemised.
+
+    One suite block covers many pytest functions, so a waiver can name one case.
+    """
+    summary = block.data.get("parameter_conformance_summary")
+    if not isinstance(summary, list):
+        return []
+    return [
+        row.get("test_case")
+        for row in summary
+        if isinstance(row, Mapping)
+        and "FAIL" in str(row.get("status", "")).upper()
+        and row.get("test_case")
+    ]
+
+
+def _spec_waiver(
+    block: Block, known_issues: Optional[Iterable[Any]]
+) -> Optional[str]:
+    """Waiver reason for this block, or None.
+
+    Matches a waiver naming the suite, else only when every failing case is
+    individually waived -- so an unwaived regression alongside a known issue
+    still blocks. Cases that are not itemised cannot be waived case by case.
+    """
+    if not known_issues:
+        return None
+
+    suite_name = block.data.get("test_name") or block.data.get("task_name")
+    reason = _find_waiver(known_issues, "SPEC_TESTS", suite_name)
+    if reason is not None:
+        return reason
+
+    reasons = []
+    for case in _failing_spec_cases(block):
+        case_reason = _find_waiver(known_issues, "SPEC_TESTS", case)
+        if case_reason is None:
+            return None
+        reasons.append(f"{case}: {case_reason}")
+    return "; ".join(reasons) if reasons else None
+
+
+def _check_spec_tests(
+    schema: ReportSchema,
+    known_issues: Optional[Iterable[Any]] = None,
+) -> CategoryResult:
     spec_blocks = [
         b
         for b in schema.sections
@@ -469,16 +543,25 @@ def _check_spec_tests(schema: ReportSchema) -> CategoryResult:
         return CategoryResult(CATEGORY_SPEC_TESTS, STATUS_NA, 0, 0)
 
     blockers: Dict[str, str] = {}
+    waived: Dict[str, str] = {}
     failed = 0
     skipped = 0
     na = 0
     for block in spec_blocks:
         test_status = _block_test_status(block)
         if test_status.is_blocking:
-            blockers[f"spec.{_block_key(block)}"] = (
+            block_key = f"spec.{_block_key(block)}"
+            message = (
                 f"{block.title or block.kind} reported status={test_status.value} "
                 f"(attempts={block.data.get('attempts', '?')})"
             )
+            # A model_spec known_issues waiver (workflow_type SPEC_TESTS)
+            # demotes the blocker to a non-fatal waiver, mirroring evals above.
+            reason = _spec_waiver(block, known_issues)
+            if reason is not None:
+                waived[block_key] = f"{message} (waived: {reason})"
+                continue
+            blockers[block_key] = message
             failed += 1
         elif test_status is TestStatus.SKIP:
             skipped += 1
@@ -494,6 +577,7 @@ def _check_spec_tests(schema: ReportSchema) -> CategoryResult:
         na=na,
         skipped=skipped,
         blockers=blockers,
+        waived=waived,
     )
 
 

--- a/report_module/acceptance_criteria.py
+++ b/report_module/acceptance_criteria.py
@@ -150,20 +150,33 @@ def task_failure_blockers(
     return blockers
 
 
-def fully_waived_task_types(categories: Iterable["CategoryResult"]) -> set:
+def fully_waived_task_types(
+    schema: ReportSchema, known_issues: Optional[Iterable[Any]] = None
+) -> set:
     """Task types whose every failure was waived, so their exit code is expected.
 
-    Spec tests only, as policy: other categories' non-zero exits always block.
-    ``waived`` also holds status-tier masking (#4830), which must not excuse a
-    task that exited non-zero.
+    Spec tests only, as policy: other categories' non-zero exits always block
+    (and ``CategoryResult.waived`` also holds #4830's status-tier masking, which
+    must never excuse one).
+
+    Deliberately walks the raw blocks rather than reading the Spec Tests
+    category: the category drops :data:`INFRA_TASK_TYPES` blocks, while the
+    task's exit code counts them, so "category clean apart from waivers" is a
+    strictly weaker claim than "every failure was waived". One unwaived
+    health/unit/stability/integration failure keeps the exit-code blocker.
     """
-    return {
-        SPEC_TESTS_TASK_TYPE
-        for category in categories
-        if category.name == CATEGORY_SPEC_TESTS
-        and category.waived
-        and not category.blockers
-    }
+    blocking = [
+        b
+        for b in schema.sections
+        if b.kind == KIND_SPEC_TESTS
+        and isinstance(b.data, Mapping)
+        and _block_test_status(b).is_blocking
+    ]
+    if not blocking:
+        return set()
+    if any(_spec_waiver(b, known_issues) is None for b in blocking):
+        return set()
+    return {SPEC_TESTS_TASK_TYPE}
 
 
 def _find_waiver(
@@ -502,9 +515,7 @@ def _failing_spec_cases(block: Block) -> List[str]:
     ]
 
 
-def _spec_waiver(
-    block: Block, known_issues: Optional[Iterable[Any]]
-) -> Optional[str]:
+def _spec_waiver(block: Block, known_issues: Optional[Iterable[Any]]) -> Optional[str]:
     """Waiver reason for this block, or None.
 
     Matches a waiver naming the suite, else only when every failing case is

--- a/tests/report_module/test_acceptance_criteria.py
+++ b/tests/report_module/test_acceptance_criteria.py
@@ -616,8 +616,9 @@ def test_waived_spec_task_does_not_block_on_exit_code():
     # A waived suite still exits non-zero -- that is exactly what the waiver
     # covers -- so the task-level blocker must not re-block the run.
     schema = _schema(_spec_suite(["test_penalties"]))
-    _, _, cats = acceptance_criteria_check(schema, _waiver("test_penalties"))
-    waived_types = fully_waived_task_types(cats)
+    waivers = _waiver("test_penalties")
+    acceptance_criteria_check(schema, waivers)
+    waived_types = fully_waived_task_types(schema, waivers)
     assert "spec_tests" in waived_types
     blockers = task_failure_blockers(
         [("spec_tests", 1, True)], waived_task_types=waived_types
@@ -627,9 +628,9 @@ def test_waived_spec_task_does_not_block_on_exit_code():
 
 def test_unwaived_spec_task_still_blocks_on_exit_code():
     schema = _schema(_spec_suite(["test_n"]))
-    _, _, cats = acceptance_criteria_check(schema, _waiver("test_penalties"))
     blockers = task_failure_blockers(
-        [("spec_tests", 1, True)], waived_task_types=fully_waived_task_types(cats)
+        [("spec_tests", 1, True)],
+        waived_task_types=fully_waived_task_types(schema, _waiver("test_penalties")),
     )
     assert "task:spec_tests" in blockers
 
@@ -638,9 +639,9 @@ def test_crash_without_block_blocks_even_when_waived():
     # No report block means the suite never ran to completion; a waiver must
     # not launder that into a PASS.
     schema = _schema(_spec_suite(["test_penalties"]))
-    _, _, cats = acceptance_criteria_check(schema, _waiver("test_penalties"))
     blockers = task_failure_blockers(
-        [("spec_tests", 1, False)], waived_task_types=fully_waived_task_types(cats)
+        [("spec_tests", 1, False)],
+        waived_task_types=fully_waived_task_types(schema, _waiver("test_penalties")),
     )
     assert "task:spec_tests" in blockers
     assert "produced no report block" in blockers["task:spec_tests"]
@@ -650,8 +651,7 @@ def test_fully_waived_task_types_empty_when_category_has_blockers():
     # Partial coverage: one case waived, one not -> category still blocks, so
     # the task exit code must keep blocking too.
     schema = _schema(_spec_suite(["test_n", "test_logprobs"]))
-    _, _, cats = acceptance_criteria_check(schema, _waiver("test_n"))
-    assert fully_waived_task_types(cats) == set()
+    assert fully_waived_task_types(schema, _waiver("test_n")) == set()
 
 
 def test_status_tier_masked_evals_do_not_excuse_a_crashed_eval_task():
@@ -660,9 +660,78 @@ def test_status_tier_masked_evals_do_not_excuse_a_crashed_eval_task():
     # raised, so that must still block -- masking a score is not a licence to
     # ignore a crash.
     schema = _schema(_eval({"task_name": "ifeval", "accuracy_check": 3}))
-    _, _, cats = acceptance_criteria_check(schema, None, "EXPERIMENTAL")
-    assert fully_waived_task_types(cats) == set()
+    accepted, _, _ = acceptance_criteria_check(schema, None, "EXPERIMENTAL")
+    assert accepted is True
+    assert fully_waived_task_types(schema, None) == set()
     blockers = task_failure_blockers(
-        [("evaluation", 1, True)], waived_task_types=fully_waived_task_types(cats)
+        [("evaluation", 1, True)],
+        waived_task_types=fully_waived_task_types(schema, None),
     )
     assert "task:evaluation" in blockers
+
+
+def _infra_spec(test_name, task_type="unit", status="fail"):
+    """A spec block whose task_type INFRA_TASK_TYPES hides from the category."""
+    return Block(
+        kind="spec_tests",
+        title=test_name,
+        task_type=task_type,
+        data={
+            "success": False,
+            "status": status,
+            "attempts": 1,
+            "test_name": test_name,
+        },
+    )
+
+
+def test_unwaived_infra_spec_failure_keeps_exit_code_blocker():
+    # LoggerForkSafetyTest (TASK_TYPE="unit") is a prerequisite in every suite and
+    # is invisible to the Spec Tests category, but its failure is in the task's
+    # exit code. A waiver on a sibling functional case must not excuse it.
+    schema = _schema(
+        _spec_suite(["test_penalties"]), _infra_spec("LoggerForkSafetyTest")
+    )
+    waivers = _waiver("test_penalties")
+    accepted, blockers, _ = acceptance_criteria_check(schema, waivers)
+    assert accepted is True and blockers == {}  # category cannot see the infra block
+    assert fully_waived_task_types(schema, waivers) == set()
+    assert "task:spec_tests" in task_failure_blockers(
+        [("spec_tests", 1, True)],
+        waived_task_types=fully_waived_task_types(schema, waivers),
+    )
+
+
+def test_waived_infra_spec_failure_is_exempt():
+    # An infra failure named by its own waiver is covered like any other.
+    schema = _schema(
+        _spec_suite(["test_penalties"]), _infra_spec("LoggerForkSafetyTest")
+    )
+    waivers = _waiver("test_penalties") + _waiver("LoggerForkSafetyTest")
+    assert fully_waived_task_types(schema, waivers) == {"spec_tests"}
+
+
+def test_passing_infra_spec_block_does_not_defeat_the_exemption():
+    schema = _schema(
+        _spec_suite(["test_penalties"]),
+        _infra_spec("LoggerForkSafetyTest", status="pass"),
+    )
+    waivers = _waiver("test_penalties")
+    assert fully_waived_task_types(schema, waivers) == {"spec_tests"}
+
+
+def test_nameless_infra_block_is_not_waived_by_a_named_waiver():
+    # A block carrying no test_name (defensive: every BaseTest path sets one)
+    # must not match a waiver that names a task — a None suite name is not a
+    # wildcard. Only a workflow-wide waiver covers it.
+    nameless = Block(
+        kind="spec_tests",
+        title="Mystery",
+        task_type="infra",
+        data={"success": False, "status": "fail", "attempts": 1},
+    )
+    schema = _schema(_spec_suite(["test_penalties"]), nameless)
+    assert fully_waived_task_types(schema, _waiver("test_penalties")) == set()
+    assert fully_waived_task_types(
+        schema, _waiver("test_penalties") + _waiver(None)
+    ) == {"spec_tests"}

--- a/tests/report_module/test_acceptance_criteria.py
+++ b/tests/report_module/test_acceptance_criteria.py
@@ -19,6 +19,7 @@ from report_module.acceptance_criteria import (
     STATUS_PASS,
     CategoryResult,
     acceptance_criteria_check,
+    fully_waived_task_types,
     build_acceptance_export,
     format_acceptance_summary_markdown,
     task_failure_blockers,
@@ -536,3 +537,132 @@ def test_build_acceptance_export_failure_defaults_model_status():
     assert export["acceptance_blockers"] == {"benchmarks:B": "bad"}
     assert export["acceptance_criteria_metadata"]["enforcement_result"] == "FAIL"
     assert export["acceptance_criteria_metadata"]["model_status"] == ""
+
+
+def _spec_suite(failing, passing=(), status="fail"):
+    """A suite-style spec block with per-case verdicts (VLLMParamConformanceTest shape)."""
+    summary = [{"test_case": c, "status": "❌ FAIL"} for c in failing]
+    summary += [{"test_case": c, "status": "✅ PASS"} for c in passing]
+    return _spec(
+        status,
+        attempts=1,
+        test_name="VLLMParamConformanceTest",
+        parameter_conformance_summary=summary,
+    )
+
+
+def _waiver(task_name, workflow="SPEC_TESTS"):
+    return [{"workflow_type": workflow, "task_name": task_name, "reason": "known"}]
+
+
+def test_spec_known_issue_waives_by_case_name():
+    # Waiver naming an individual pytest function demotes the block, matching the
+    # per-case granularity the v1 acceptance path had.
+    schema = _schema(_spec_suite(["test_penalties"], passing=["test_stop"]))
+    accepted, blockers, cats = acceptance_criteria_check(
+        schema, _waiver("test_penalties")
+    )
+    by_name = {c.name: c for c in cats}
+    assert accepted is True and blockers == {}
+    assert by_name[CATEGORY_SPEC_TESTS].status == STATUS_PASS
+    assert "spec.spec_tests:T" in by_name[CATEGORY_SPEC_TESTS].waived
+
+
+def test_spec_known_issue_waives_by_suite_name():
+    schema = _schema(_spec_suite(["test_n"]))
+    accepted, _, _ = acceptance_criteria_check(
+        schema, _waiver("VLLMParamConformanceTest")
+    )
+    assert accepted is True
+
+
+def test_spec_known_issue_partial_coverage_still_blocks():
+    # test_n is waived but test_logprobs is not, so the block must still fail —
+    # a waiver must never mask an unlisted regression in the same suite.
+    schema = _schema(_spec_suite(["test_n", "test_logprobs"]))
+    accepted, blockers, _ = acceptance_criteria_check(schema, _waiver("test_n"))
+    assert accepted is False and "spec.spec_tests:T" in blockers
+
+
+def test_spec_known_issue_wrong_workflow_still_blocks():
+    schema = _schema(_spec_suite(["test_n"]))
+    accepted, _, _ = acceptance_criteria_check(
+        schema, _waiver("test_n", workflow="EVALS")
+    )
+    assert accepted is False
+
+
+def test_spec_known_issue_workflow_wide_waiver_applies():
+    # task_name=None matches every task in the workflow.
+    schema = _schema(_spec_suite(["test_n"]))
+    accepted, _, _ = acceptance_criteria_check(schema, _waiver(None))
+    assert accepted is True
+
+
+def test_spec_block_without_case_summary_needs_suite_level_waiver():
+    # No itemised cases (e.g. success:false blocks), so a case-level waiver can't
+    # be evaluated and must not silently pass.
+    schema = _schema(_spec("fail", attempts=1, test_name="OtherTest"))
+    accepted, _, _ = acceptance_criteria_check(schema, _waiver("test_n"))
+    assert accepted is False
+    accepted, _, _ = acceptance_criteria_check(schema, _waiver("OtherTest"))
+    assert accepted is True
+
+
+# --- task-level exit-code blocker vs waivers ------------------------------
+
+
+def test_waived_spec_task_does_not_block_on_exit_code():
+    # A waived suite still exits non-zero -- that is exactly what the waiver
+    # covers -- so the task-level blocker must not re-block the run.
+    schema = _schema(_spec_suite(["test_penalties"]))
+    _, _, cats = acceptance_criteria_check(schema, _waiver("test_penalties"))
+    waived_types = fully_waived_task_types(cats)
+    assert "spec_tests" in waived_types
+    blockers = task_failure_blockers(
+        [("spec_tests", 1, True)], waived_task_types=waived_types
+    )
+    assert blockers == {}
+
+
+def test_unwaived_spec_task_still_blocks_on_exit_code():
+    schema = _schema(_spec_suite(["test_n"]))
+    _, _, cats = acceptance_criteria_check(schema, _waiver("test_penalties"))
+    blockers = task_failure_blockers(
+        [("spec_tests", 1, True)], waived_task_types=fully_waived_task_types(cats)
+    )
+    assert "task:spec_tests" in blockers
+
+
+def test_crash_without_block_blocks_even_when_waived():
+    # No report block means the suite never ran to completion; a waiver must
+    # not launder that into a PASS.
+    schema = _schema(_spec_suite(["test_penalties"]))
+    _, _, cats = acceptance_criteria_check(schema, _waiver("test_penalties"))
+    blockers = task_failure_blockers(
+        [("spec_tests", 1, False)], waived_task_types=fully_waived_task_types(cats)
+    )
+    assert "task:spec_tests" in blockers
+    assert "produced no report block" in blockers["task:spec_tests"]
+
+
+def test_fully_waived_task_types_empty_when_category_has_blockers():
+    # Partial coverage: one case waived, one not -> category still blocks, so
+    # the task exit code must keep blocking too.
+    schema = _schema(_spec_suite(["test_n", "test_logprobs"]))
+    _, _, cats = acceptance_criteria_check(schema, _waiver("test_n"))
+    assert fully_waived_task_types(cats) == set()
+
+
+def test_status_tier_masked_evals_do_not_excuse_a_crashed_eval_task():
+    # #4830 masks eval failures for EXPERIMENTAL into the same `waived` bucket
+    # an explicit waiver uses. An eval task only exits non-zero when its runner
+    # raised, so that must still block -- masking a score is not a licence to
+    # ignore a crash.
+    schema = _schema(_eval({"task_name": "ifeval", "accuracy_check": 3}))
+    _, _, cats = acceptance_criteria_check(schema, None, "EXPERIMENTAL")
+    assert fully_waived_task_types(cats) == set()
+    blockers = task_failure_blockers(
+        [("evaluation", 1, True)], waived_task_types=fully_waived_task_types(cats)
+    )
+    assert "task:evaluation" in blockers

--- a/tests/workflow_module/test_execution.py
+++ b/tests/workflow_module/test_execution.py
@@ -8,12 +8,15 @@ from __future__ import annotations
 
 import json
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
-from report_module import ReportSchema
+from report_module import GenerateResult, ReportSchema
+from report_module.schema import Block
 from workflow_module.execution import (
     OrchestratorMetadata,
     TaskOutcome,
+    WorkflowExecution,
     WorkflowResult,
 )
 from workflow_module.workflows import ReleaseWorkflow
@@ -133,3 +136,119 @@ class TestInjectMetadata:
             "model_impl",
         ):
             assert absent not in schema.metadata
+
+
+# --- run() return code vs. spec-test waivers -------------------------------
+
+
+def _spec_block(title, task_type, status, **extra):
+    return Block(
+        kind="spec_tests",
+        title=title,
+        task_type=task_type,
+        data={"success": status == "pass", "status": status, "attempts": 1, **extra},
+    )
+
+
+def _waived_conformance():
+    """A failing VLLMParamConformanceTest suite whose only failing case is waived."""
+    return _spec_block(
+        "Vllm Chat Completions",
+        "functional",
+        "fail",
+        test_name="VLLMParamConformanceTest",
+        parameter_conformance_summary=[
+            {"test_case": "test_penalties", "status": "❌ FAIL"}
+        ],
+    )
+
+
+WAIVER = [
+    {"workflow_type": "SPEC_TESTS", "task_name": "test_penalties", "reason": "#3888"}
+]
+
+
+class _FakeWorkflow(WorkflowExecution):
+    """Drives the real acceptance + return-code path over a canned schema."""
+
+    name = "fake"
+
+    def __init__(self, blocks, outcomes, known_issues):
+        ctx = MagicMock()
+        ctx.service_port = 8000
+        ctx.output_path = "/tmp"
+        super().__init__(ctx)
+        self._blocks = blocks
+        self._outcomes = outcomes
+        self._known = known_issues
+
+    def prepare(self):
+        pass
+
+    def run_tasks(self):
+        return self._outcomes
+
+    def format_results(self):
+        return ReportSchema(metadata={"report_id": "r"}, sections=list(self._blocks))
+
+    def inject_metadata(self, schema):
+        pass
+
+    def generate_report(self, schema):
+        return GenerateResult(Path("r.md"), Path("r.json"), "")
+
+    def _known_issues(self):
+        return self._known
+
+    def _model_status(self):
+        return None
+
+
+class TestRunReturnCode:
+    """The third gate: a waived spec task must drop out of ``failed_tasks``,
+    but only when the waiver actually accounts for every failure."""
+
+    def test_waived_spec_task_returns_zero(self):
+        result = _FakeWorkflow(
+            [_waived_conformance()],
+            [TaskOutcome("spec_tests", 1, 1.0, "spec_tests")],
+            WAIVER,
+        ).run()
+        assert result.return_code == 0
+
+    def test_unwaived_infra_failure_in_same_task_returns_one(self):
+        # LoggerForkSafetyTest is invisible to the Spec Tests category
+        # (TASK_TYPE "unit"), so only the raw-block walk can catch it.
+        result = _FakeWorkflow(
+            [
+                _waived_conformance(),
+                _spec_block(
+                    "Logger Fork Safety",
+                    "unit",
+                    "fail",
+                    test_name="LoggerForkSafetyTest",
+                ),
+            ],
+            [TaskOutcome("spec_tests", 1, 1.0, "spec_tests")],
+            WAIVER,
+        ).run()
+        assert result.return_code == 1
+
+    def test_waiver_does_not_excuse_a_different_failed_task(self):
+        result = _FakeWorkflow(
+            [_waived_conformance()],
+            [
+                TaskOutcome("spec_tests", 1, 1.0, "spec_tests"),
+                TaskOutcome("evaluation", 1, 1.0, "evals"),
+            ],
+            WAIVER,
+        ).run()
+        assert result.return_code == 1
+
+    def test_unwaived_spec_failure_returns_one(self):
+        result = _FakeWorkflow(
+            [_waived_conformance()],
+            [TaskOutcome("spec_tests", 1, 1.0, "spec_tests")],
+            None,
+        ).run()
+        assert result.return_code == 1

--- a/workflow_module/execution.py
+++ b/workflow_module/execution.py
@@ -364,12 +364,16 @@ class WorkflowExecution(ABC):
         self, schema: ReportSchema, task_outcomes: Sequence[TaskOutcome]
     ) -> Tuple[bool, dict, set]:
         model_status = self._model_status()
+        known_issues = self._known_issues()
         accepted, blockers, categories = acceptance_criteria_check(
-            schema, known_issues=self._known_issues(), model_status=model_status
+            schema, known_issues=known_issues, model_status=model_status
         )
-        waived_task_types = fully_waived_task_types(categories)
+        waived_task_types = fully_waived_task_types(schema, known_issues)
         crash_blockers = task_failure_blockers(
-            ((o.task_type, o.exit_code, o.block_kind is not None) for o in task_outcomes),
+            (
+                (o.task_type, o.exit_code, o.block_kind is not None)
+                for o in task_outcomes
+            ),
             waived_task_types=waived_task_types,
         )
         if crash_blockers:

--- a/workflow_module/execution.py
+++ b/workflow_module/execution.py
@@ -18,7 +18,15 @@ import time
 from abc import ABC
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, List, Optional, Sequence, Tuple
+from typing import (
+    TYPE_CHECKING,
+    ClassVar,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 from report_module import (
     GenerateResult,
@@ -26,6 +34,7 @@ from report_module import (
     ReportSchema,
     acceptance_criteria_check,
     build_acceptance_export,
+    fully_waived_task_types,
     task_failure_blockers,
 )
 from test_module.task_types import MediaTaskType
@@ -59,6 +68,10 @@ class TaskOutcome:
     @property
     def succeeded(self) -> bool:
         return self.exit_code == 0
+
+    def is_waived(self, waived_task_types: Iterable[str]) -> bool:
+        """Whether a non-zero exit is explained by a waiver on this task's block."""
+        return self.block_kind is not None and self.task_type in waived_task_types
 
 
 @dataclass(frozen=True)
@@ -263,7 +276,9 @@ class WorkflowExecution(ABC):
             )
 
         try:
-            accepted, _blockers = self.apply_acceptance_criteria(schema, task_outcomes)
+            accepted, _blockers, waived_task_types = self.apply_acceptance_criteria(
+                schema, task_outcomes
+            )
             self.inject_metadata(schema)
             gen = self.generate_report(schema)
         except Exception as e:
@@ -277,7 +292,11 @@ class WorkflowExecution(ABC):
                 error=str(e),
             )
 
-        failed_tasks = [outcome for outcome in task_outcomes if not outcome.succeeded]
+        failed_tasks = [
+            o
+            for o in task_outcomes
+            if not o.succeeded and not o.is_waived(waived_task_types)
+        ]
         return_code = 0 if accepted and not failed_tasks else 1
         if failed_tasks:
             self.logger.error(
@@ -343,13 +362,15 @@ class WorkflowExecution(ABC):
 
     def apply_acceptance_criteria(
         self, schema: ReportSchema, task_outcomes: Sequence[TaskOutcome]
-    ) -> Tuple[bool, dict]:
+    ) -> Tuple[bool, dict, set]:
         model_status = self._model_status()
         accepted, blockers, categories = acceptance_criteria_check(
             schema, known_issues=self._known_issues(), model_status=model_status
         )
+        waived_task_types = fully_waived_task_types(categories)
         crash_blockers = task_failure_blockers(
-            (o.task_type, o.exit_code, o.block_kind is not None) for o in task_outcomes
+            ((o.task_type, o.exit_code, o.block_kind is not None) for o in task_outcomes),
+            waived_task_types=waived_task_types,
         )
         if crash_blockers:
             blockers = {**blockers, **crash_blockers}
@@ -362,7 +383,7 @@ class WorkflowExecution(ABC):
             "PASS" if accepted else "FAIL",
             len(blockers),
         )
-        return accepted, blockers
+        return accepted, blockers, waived_task_types
 
     def _known_issues(self) -> Optional[list]:
         """model_spec known_issues (waivers) for this device, or None.

--- a/workflow_module/workflows.py
+++ b/workflow_module/workflows.py
@@ -304,7 +304,7 @@ class PrefillDecodeWorkflow(WorkflowExecution):
 
     def apply_acceptance_criteria(self, schema, task_outcomes):
         self.logger.info("Acceptance: N/A (prefill_decode has no acceptance gate)")
-        return True, {}
+        return True, {}, set()
 
     def _inject_model_spec_metadata(self, meta: dict) -> None:
         """Report the served model, not the placeholder catalog spec."""


### PR DESCRIPTION
## Ticket

Fixes #4881

## Problem

A `known_issues` waiver with `workflow_type: SPEC_TESTS` has no effect on the acceptance verdict -- including the one already shipped for Llama-3.3-70B-Instruct on P300X2 (`test_penalties`, #3888). Every spec-test failure is an unconditional acceptance blocker, and there is no workaround: model status does not help (`required_target_tiers` gates benchmark tiers only, so #4830 masks nothing here), leaving "remove the model from the test matrix" as the only way to get a green run.

Three gates each independently keep a waived run red, so all three have to move together:

1. `acceptance_criteria_check` passed `known_issues` to `_check_evals` only, so `_check_spec_tests` recorded a blocker regardless of what was declared.
2. `task_failure_blockers` turned the suite's non-zero exit into a second, waiver-blind blocker.
3. the workflow return code counted the waived suite as a failed task, so `run.py` exited 1 and CI showed red even when acceptance passed.

## Changes

- `report_module/acceptance_criteria.py`: `_check_spec_tests()` takes `known_issues` and demotes a matched block into the existing `waived` bucket; new `_spec_waiver()` / `_failing_spec_cases()` match per failing case (from `parameter_conformance_summary`) falling back to the suite name; new `fully_waived_task_types()`; `task_failure_blockers()` gains `waived_task_types`.
- `workflow_module/execution.py`: `TaskOutcome.is_waived()` holds the single "exempt only if it produced a block and its category was fully waived" rule; `apply_acceptance_criteria()` returns the waived task types alongside the verdict; the return code no longer counts a waived task as failed.
- `workflow_module/workflows.py`: `PrefillDecodeWorkflow.apply_acceptance_criteria` override updated for the widened return.
- `report_module/__init__.py`: export `fully_waived_task_types`.
- `tests/report_module/test_acceptance_criteria.py`: case-level / suite-level / workflow-wide / wrong-workflow / partial-coverage / no-itemised-cases waivers, the exit-code exemption, and the crash-still-blocks and tier-masking-does-not-excuse guards.

## Behaviour change

A release can now go green while a spec suite genuinely failed. That is what a waiver means, and the failure is still reported (`Spec Tests: PASS (0/1 passed, 1 waived)`, with every failing case listed), but it is visible on CI dashboards and worth agreeing on explicitly.

## Not changed

- `CategoryResult.waived` remains one bucket holding both `known_issues` waivers and #4830's status-tier masking. That is why the exit-code exemption is `spec_tests`-only: an eval or benchmark that exits non-zero did so because its runner raised, and tier masking must not excuse that. Splitting `waived` from `informational` would remove the special case and is worth a follow-up.
- `_check_evals` is not refactored to share a waiver helper -- the literally common part is three lines, while the interesting logic (tier masking vs. all-cases-covered) differs.
- `workflows/acceptance_criteria.py` -- still no caller; untouched.

## Test plan

- [x] `pytest tests/report_module/ tests/workflow_module/` -- 339 passing
- [x] **Problem, pre-fix** -- [tt-shield run 31112530808](https://github.com/tenstorrent/tt-shield/actions/runs/31112530808): Falcon3-7B-Instruct release on P150 with a five-case `SPEC_TESTS` waiver declared on the model spec. `Acceptance: FAIL (2 blockers)` (`spec.spec_tests:...` and `task:spec_tests`), `Spec Tests: FAIL`, `rc=1`, job red -- the declared waiver is inert.
- [x] **Fixed, this commit** -- [tt-shield run 31119770401](https://github.com/tenstorrent/tt-shield/actions/runs/31119770401) (`TT-Inference SHA: 5cac1097cee1`): same model / device / docker image, same waiver, plus this fix. That branch also carries the Falcon3 spec-test enablement, which is what makes a spec-test suite run at all; the fix commit itself is byte-identical to `56872e035` on the PR branch. `Acceptance: PASS (0 blockers)`, `Spec Tests: PASS (0/1 passed, 1 waived)`, `rc=0`, `run-tests` job green -- while `test_logprobs`, `test_n`, `test_non_uniform_seeding`, `test_penalties` and `test_seed_reproducibility` all still fail and are still listed in the report.

The fixed run's *overall* conclusion reads `failure` because its `determine-server-type` job was cancelled during the 2026-08-06 GitHub Actions incident; the `run-tests` job that executes the release succeeded, and the verdict above is from its log. 
 