### PR TITLE
disable gateway e2e test

### DIFF
--- a/tt-media-server/prefill_gateway/CMakeLists.txt
+++ b/tt-media-server/prefill_gateway/CMakeLists.txt
@@ -238,4 +238,5 @@ _gateway_add_unit_test(prefill_registry_test)
 _gateway_add_unit_test(dispatcher_test)
 _gateway_add_unit_test(gateway_metrics_test)
 _gateway_add_unit_test(gateway_health_test)
-_gateway_add_e2e_test(gateway_e2e_test)
+# Disabled:
+# _gateway_add_e2e_test(gateway_e2e_test)


### PR DESCRIPTION
don't add it to gateway
might be cleaner to add it and skip it, but then we'd keep building it which isn't necessary 