### PR TITLE
[Helm v0.2] switch device acquisition to DRA ResourceClaim

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1134,21 +1134,16 @@ jobs:
               echo "FAILED (kubeconform): $model / $engine / $device"
               FAILED=1
             fi
-            # Universal DRA safety invariants — must hold for every device:
-            # no privileged mode and no hostPath on /dev/tenstorrent.
-            if echo "$RENDERED" | grep -qE '^[[:space:]]*privileged: true$'; then
-              echo "::error::privileged:true present in $model/$engine/$device"; FAILED=1; fi
-            if echo "$RENDERED" | grep -qE '^[[:space:]]*path: /dev/tenstorrent$'; then
-              echo "::error::hostPath /dev/tenstorrent present in $model/$engine/$device"; FAILED=1; fi
           done < /tmp/helm-matrix.txt
           exit $FAILED
 
-      - name: Verify DRA claim structure and board counts
+      - name: Verify DRA claim structure, board counts, and safety invariants
         run: |
           set -e
-          # Check the DRA claim structure and the per-device board count across
-          # representative shapes (1 / 4 / 32 boards). The "no privileged / no
-          # hostPath" invariants are enforced for all devices in the matrix step.
+          # Check the DRA claim structure and per-device board count across
+          # representative shapes (1 / 4 / 32 boards), plus the safety invariants
+          # (no privileged, no hostPath on /dev/tenstorrent). The invariants are
+          # device-independent, so checking these representative renders covers them.
           # device:expected-count
           for pair in n300:1 t3k:4 galaxy:32; do
             device="${pair%%:*}"; want="${pair##*:}"
@@ -1163,6 +1158,10 @@ jobs:
               || { echo "::error::$device must request $want board(s) via DRA"; exit 1; }
             echo "$RENDERED" | grep -qE 'resourceClaimTemplateName:' \
               || { echo "::error::Pod does not reference the ResourceClaimTemplate for $device"; exit 1; }
+            echo "$RENDERED" | grep -qE '^[[:space:]]*privileged: true$' \
+              && { echo "::error::privileged:true present for $device"; exit 1; } || true
+            echo "$RENDERED" | grep -qE '^[[:space:]]*path: /dev/tenstorrent$' \
+              && { echo "::error::hostPath /dev/tenstorrent present for $device"; exit 1; } || true
           done
 
   ci-gate:

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1096,6 +1096,13 @@ jobs:
           import yaml
           with open('charts/tt-inference-server/values.yaml') as f:
               v = yaml.safe_load(f)
+          # A device is renderable iff the chart can produce a manifest for it:
+          # it has a DRA board count (deviceBoardCounts), or it is a
+          # non-Tenstorrent device (gpu/cpu, no ResourceClaim). Devices absent
+          # from both (topology-sensitive partitions like galaxy_t3k) fail the
+          # render on purpose — skip them. Derived from the same source the chart
+          # uses (deviceBoardCounts), so it can never drift from the template.
+          supported = set(v.get('deviceBoardCounts', {})) | {"gpu", "cpu"}
           # models[model][engine][device]; skip scalar metadata (e.g. defaultEngine)
           for model, engines in v['models'].items():
               for engine, devices in engines.items():
@@ -1103,6 +1110,8 @@ jobs:
                       continue
                   for device, dev_cfg in devices.items():
                       if not isinstance(dev_cfg, dict):
+                          continue
+                      if device not in supported:
                           continue
                       print(f"{model},{engine},{device}")
           EOF
@@ -1117,28 +1126,44 @@ jobs:
           FAILED=0
           while IFS=',' read -r model engine device; do
             echo "--- Validating: $model / $engine / $device"
-            if ! helm template ci-test charts/tt-inference-server \
+            RENDERED=$(helm template ci-test charts/tt-inference-server \
                 --set "model=$model" \
                 --set "engine=$engine" \
-                --set "device=$device" \
-                | kubeconform -strict -summary; then
-              echo "FAILED: $model / $engine / $device"
+                --set "device=$device") || { echo "FAILED (render): $model / $engine / $device"; FAILED=1; continue; }
+            if ! echo "$RENDERED" | kubeconform -strict -summary; then
+              echo "FAILED (kubeconform): $model / $engine / $device"
               FAILED=1
             fi
+            # Universal DRA safety invariants — must hold for every device:
+            # no privileged mode and no hostPath on /dev/tenstorrent.
+            if echo "$RENDERED" | grep -qE '^[[:space:]]*privileged: true$'; then
+              echo "::error::privileged:true present in $model/$engine/$device"; FAILED=1; fi
+            if echo "$RENDERED" | grep -qE '^[[:space:]]*path: /dev/tenstorrent$'; then
+              echo "::error::hostPath /dev/tenstorrent present in $model/$engine/$device"; FAILED=1; fi
           done < /tmp/helm-matrix.txt
           exit $FAILED
 
-      - name: Verify safety invariants
+      - name: Verify DRA claim structure and board counts
         run: |
           set -e
-          RENDERED=$(helm template ttis charts/tt-inference-server \
-            --set model=Llama-3.1-8B-Instruct --set device=galaxy)
-          echo "$RENDERED" | grep -qE '^[[:space:]]*type: Recreate$' \
-            || { echo "::error::Deployment must use 'strategy: type: Recreate' (see issue #2801)"; exit 1; }
-          echo "$RENDERED" | grep -qE '^[[:space:]]*podAntiAffinity:[[:space:]]*$' \
-            || { echo "::error::podAntiAffinity block missing — device-collision protection broken (see #2801)"; exit 1; }
-          echo "$RENDERED" | grep -qE 'topologyKey: kubernetes.io/hostname' \
-            || { echo "::error::Chart's podAntiAffinity term has wrong topologyKey — device-collision scope broken (see #2801)"; exit 1; }
+          # Check the DRA claim structure and the per-device board count across
+          # representative shapes (1 / 4 / 32 boards). The "no privileged / no
+          # hostPath" invariants are enforced for all devices in the matrix step.
+          # device:expected-count
+          for pair in n300:1 t3k:4 galaxy:32; do
+            device="${pair%%:*}"; want="${pair##*:}"
+            echo "--- DRA structure: Llama-3.1-8B-Instruct / $device (expect count $want)"
+            RENDERED=$(helm template ttis charts/tt-inference-server \
+              --set model=Llama-3.1-8B-Instruct --set device="$device")
+            echo "$RENDERED" | grep -qE '^[[:space:]]*kind: ResourceClaimTemplate$' \
+              || { echo "::error::ResourceClaimTemplate missing for $device"; exit 1; }
+            echo "$RENDERED" | grep -qE '^[[:space:]]*deviceClassName: tenstorrent.com$' \
+              || { echo "::error::deviceClassName missing/incorrect for $device"; exit 1; }
+            echo "$RENDERED" | grep -qE "^[[:space:]]*count: ${want}\$" \
+              || { echo "::error::$device must request $want board(s) via DRA"; exit 1; }
+            echo "$RENDERED" | grep -qE 'resourceClaimTemplateName:' \
+              || { echo "::error::Pod does not reference the ResourceClaimTemplate for $device"; exit 1; }
+          done
 
   ci-gate:
     name: CI Gate

--- a/charts/tt-inference-server/Chart.yaml
+++ b/charts/tt-inference-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tt-inference-server
 description: Tenstorrent inference server — vLLM and media backends on Galaxy hardware
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.12.0"

--- a/charts/tt-inference-server/README.md
+++ b/charts/tt-inference-server/README.md
@@ -2,7 +2,7 @@
 
 Deploys vLLM and media inference backends on Tenstorrent Galaxy hardware.
 
-**Chart version:** 0.1.0 | **App version:** 0.12.0
+**Chart version:** 0.2.0 | **App version:** 0.12.0
 
 ---
 
@@ -15,6 +15,82 @@ Three engines are supported:
 - **vllm** — large language models served via the vLLM OpenAI-compatible API
 - **media** — image/audio/video/embedding models served via the tt-media-inference-server API
 - **forge** — models served via the tt-forge backend
+
+Devices are acquired through **Dynamic Resource Allocation (DRA)**: each Pod
+declares a `ResourceClaim` that the [tt-operator](https://github.com/tenstorrent/tt-operator)
+DRA driver satisfies by allocating Tenstorrent boards and injecting the matching
+`/dev/tenstorrent/<N>` node(s). The container runs **unprivileged**, with **no
+`hostPath` on `/dev/tenstorrent`**, and multiple Pods can share one Node.
+
+---
+
+## Requirements
+
+- **Kubernetes ≥ 1.34** — the chart emits `resource.k8s.io/v1`, which is served
+  from 1.34 (DRA GA). Verify the API is present:
+  `kubectl api-resources --api-group=resource.k8s.io`.
+- **tt-operator installed on the cluster**, providing at least the DRA driver
+  (`tt-dra-driver`), the fabric manager (`tt-fabric-manager`, which the DRA
+  driver queries to enumerate devices), and node-feature-discovery. tt-operator
+  is a cluster-level prerequisite installed **once by an administrator**, on a
+  lifecycle separate from this chart — this chart never installs or manages it,
+  it only emits a `ResourceClaim` that the driver fulfils.
+
+Minimal tt-operator install (device acquisition only):
+
+```bash
+kubectl create namespace tt-operator-system
+# GHCR pull secret (k3s/containerd cannot pull the component images anonymously)
+kubectl create secret generic ghcr \
+  --from-file=.dockerconfigjson=$HOME/.docker/config.json \
+  --type=kubernetes.io/dockerconfigjson -n tt-operator-system
+helm install tt-operator oci://ghcr.io/tenstorrent/helm/tt-operator \
+  --version 0.2.0 -n tt-operator-system \
+  --set tt-k8s-driver-manager.enabled=false \
+  --set tt-telemetry.enabled=false \
+  --set jobset.enabled=false \
+  --set kubepmix.enabled=false
+# Verify: a DeviceClass and a per-node ResourceSlice appear
+kubectl get deviceclass          # tenstorrent.com
+kubectl get resourceslices       # <node> / tenstorrent.com, one device per board
+```
+
+> The other tt-operator sub-charts (driver-manager, telemetry, jobset, kubepmix)
+> are optional and documented separately.
+
+---
+
+## Device Acquisition (DRA)
+
+The chart renders a `ResourceClaimTemplate`; every Pod gets its own claim from
+it. The number of boards requested is a function of `device` (not the model): it
+comes from the top-level `deviceBoardCounts` map in `values.yaml`, which the
+generator produces from `workflows/device_utils.py:BOARD_TYPE_COUNT_TO_DEVICE`
+(a single source of truth, not a per-model value):
+
+| device | boards requested (`count`) |
+|---|---|
+| `n150`, `n300`, `p100`, `p150`, `p300` | 1 |
+| `p300x2` | 2 |
+| `n150x4`, `p150x4`, `t3k` | 4 |
+| `p150x8` | 8 |
+| `galaxy` | 32 |
+
+**Multiple Pods per Node.** The scheduler places a Pod only once its claim can be
+allocated and never assigns the same board twice, so a T3K node can run e.g. four
+independent single-`n300` Pods. When all boards are claimed, an extra Pod stays
+`Pending` (`FailedScheduling: cannot allocate all claims`) until one frees.
+
+**Not yet supported (future work).** A board count is only sufficient when the
+claim takes a whole dedicated device. Topology-sensitive partitions — e.g.
+`galaxy_t3k` (a T3K mesh carved from a Galaxy that must be pinned to adjacent
+chips in one tray) — need DRA constraints (`constraints.matchAttribute` / CEL)
+matching topology attributes the tt-dra-driver does not yet publish. Installing
+such a device **fails at render time** with a clear message.
+
+**Teardown order.** Delete the inference workload *before* uninstalling
+tt-operator; removing the DRA driver first leaves Pods unable to release their
+claims and stuck `Terminating`.
 
 ---
 
@@ -110,6 +186,8 @@ All fields under `defaults` apply to every model/engine/device/impl unless overr
 |---|---|---|
 | `defaults.replicaCount` | `1` | Number of Deployment replicas. |
 | `defaults.progressDeadlineSeconds` | `3600` | Deployment progress deadline. Set high due to long model load times. |
+| `defaults.dra.deviceClassName` | `tenstorrent.com` | DRA `DeviceClass` (published by tt-operator) that the `ResourceClaim` selects. The board `count` is not set here — it is derived from `device` by `tt-inference-server.draDeviceCount`. |
+| `defaults.updateStrategy` | `RollingUpdate` (maxSurge 0, maxUnavailable 1) | Deployment update strategy. `maxSurge=0` terminates the old Pod before creating its replacement so its board and hugepages are freed first; `maxUnavailable=1` rolls one Pod at a time when `replicaCount > 1`. |
 | `defaults.podAnnotations` | `{}` | Annotations applied to the pod template. |
 | `defaults.podSecurityContext` | `{}` | Pod-level `securityContext`. |
 | `defaults.image.pullPolicy` | `IfNotPresent` | Image pull policy. |
@@ -130,7 +208,7 @@ All fields under `defaults` apply to every model/engine/device/impl unless overr
 | `defaults.probes.readiness.initialDelaySeconds` | `2400` | Readiness probe initial delay. |
 | `defaults.nodeSelector` | `{}` | Node selector applied to the pod. |
 | `defaults.tolerations` | `[]` | Tolerations applied to the pod. |
-| `defaults.affinity` | `{}` | Affinity rules applied to the pod. |
+| `defaults.affinity` | `{}` | User-supplied affinity, applied as-is. v0.2 no longer injects a 1-Pod-per-Node `podAntiAffinity` — DRA prevents device collisions by allocation, so multiple Pods may run on one Node. |
 | `defaults.extraEnv` | `[]` | Additional environment variables (see [Extra Environment Variables](#extra-environment-variables)). |
 
 ---
@@ -487,4 +565,12 @@ Each pod runs two init containers before the inference server starts:
 Runs `chown -R 1000:1000 /cache` on the cache host path volume. The inference server runs as UID 1000 and requires write access to the cache directory, which may be created by root on the host.
 
 **`cleanup-hugepages`**
-Removes stale hugepage files left by previous runs (`/dev/hugepages-1G/device_*_tenstorrent` and `/dev/hugepages-1G/tenstorrent`). Runs privileged. Without this cleanup, the inference server may fail to acquire hugepages if a previous pod exited uncleanly.
+Removes stale hugepage files left by previous runs, **scoped to this Pod's
+DRA-allocated board(s)** only. The init container requests the same
+`ResourceClaim` as the main container, so the DRA driver injects its
+`/dev/tenstorrent/<N>` node(s); the container then deletes only
+`/dev/hugepages-1G/device_<N>_*tenstorrent` (and the bare `tenstorrent` file for
+board 0) for each allocated `N`. This is required now that multiple Pods can run
+on one Node — a global `rm` would delete a co-located running Pod's hugepage
+files. Without the cleanup, a replacement Pod reusing the same board may fail to
+acquire hugepages if a previous Pod exited uncleanly.

--- a/charts/tt-inference-server/README.md
+++ b/charts/tt-inference-server/README.md
@@ -81,12 +81,12 @@ allocated and never assigns the same board twice, so a T3K node can run e.g. fou
 independent single-`n300` Pods. When all boards are claimed, an extra Pod stays
 `Pending` (`FailedScheduling: cannot allocate all claims`) until one frees.
 
-**Not yet supported (future work).** A board count is only sufficient when the
-claim takes a whole dedicated device. Topology-sensitive partitions — e.g.
-`galaxy_t3k` (a T3K mesh carved from a Galaxy that must be pinned to adjacent
-chips in one tray) — need DRA constraints (`constraints.matchAttribute` / CEL)
-matching topology attributes the tt-dra-driver does not yet publish. Installing
-such a device **fails at render time** with a clear message.
+**Not yet supported (future work).** A board count is correct only for a single DRA
+device (`n300` = one board = an adjacent on-board chip pair) or a whole dedicated node
+(`t3k`). Adjacency-partitioned requests — several separate devices that must be
+physically adjacent (QSFP-linked), e.g. `galaxy_t3k` or a Galaxy dual — can't be
+expressed (DRA allocates by count, not position), so they are absent from
+`deviceBoardCounts` and fail at render.
 
 **Teardown order.** Delete the inference workload *before* uninstalling
 tt-operator; removing the DRA driver first leaves Pods unable to release their

--- a/charts/tt-inference-server/README.md.gotmpl
+++ b/charts/tt-inference-server/README.md.gotmpl
@@ -16,6 +16,82 @@ Three engines are supported:
 - **media** — image/audio/video/embedding models served via the tt-media-inference-server API
 - **forge** — models served via the tt-forge backend
 
+Devices are acquired through **Dynamic Resource Allocation (DRA)**: each Pod
+declares a `ResourceClaim` that the [tt-operator](https://github.com/tenstorrent/tt-operator)
+DRA driver satisfies by allocating Tenstorrent boards and injecting the matching
+`/dev/tenstorrent/<N>` node(s). The container runs **unprivileged**, with **no
+`hostPath` on `/dev/tenstorrent`**, and multiple Pods can share one Node.
+
+---
+
+## Requirements
+
+- **Kubernetes ≥ 1.34** — the chart emits `resource.k8s.io/v1`, which is served
+  from 1.34 (DRA GA). Verify the API is present:
+  `kubectl api-resources --api-group=resource.k8s.io`.
+- **tt-operator installed on the cluster**, providing at least the DRA driver
+  (`tt-dra-driver`), the fabric manager (`tt-fabric-manager`, which the DRA
+  driver queries to enumerate devices), and node-feature-discovery. tt-operator
+  is a cluster-level prerequisite installed **once by an administrator**, on a
+  lifecycle separate from this chart — this chart never installs or manages it,
+  it only emits a `ResourceClaim` that the driver fulfils.
+
+Minimal tt-operator install (device acquisition only):
+
+```bash
+kubectl create namespace tt-operator-system
+# GHCR pull secret (k3s/containerd cannot pull the component images anonymously)
+kubectl create secret generic ghcr \
+  --from-file=.dockerconfigjson=$HOME/.docker/config.json \
+  --type=kubernetes.io/dockerconfigjson -n tt-operator-system
+helm install tt-operator oci://ghcr.io/tenstorrent/helm/tt-operator \
+  --version 0.2.0 -n tt-operator-system \
+  --set tt-k8s-driver-manager.enabled=false \
+  --set tt-telemetry.enabled=false \
+  --set jobset.enabled=false \
+  --set kubepmix.enabled=false
+# Verify: a DeviceClass and a per-node ResourceSlice appear
+kubectl get deviceclass          # tenstorrent.com
+kubectl get resourceslices       # <node> / tenstorrent.com, one device per board
+```
+
+> The other tt-operator sub-charts (driver-manager, telemetry, jobset, kubepmix)
+> are optional and documented separately.
+
+---
+
+## Device Acquisition (DRA)
+
+The chart renders a `ResourceClaimTemplate`; every Pod gets its own claim from
+it. The number of boards requested is a function of `device` (not the model): it
+comes from the top-level `deviceBoardCounts` map in `values.yaml`, which the
+generator produces from `workflows/device_utils.py:BOARD_TYPE_COUNT_TO_DEVICE`
+(a single source of truth, not a per-model value):
+
+| device | boards requested (`count`) |
+|---|---|
+| `n150`, `n300`, `p100`, `p150`, `p300` | 1 |
+| `p300x2` | 2 |
+| `n150x4`, `p150x4`, `t3k` | 4 |
+| `p150x8` | 8 |
+| `galaxy` | 32 |
+
+**Multiple Pods per Node.** The scheduler places a Pod only once its claim can be
+allocated and never assigns the same board twice, so a T3K node can run e.g. four
+independent single-`n300` Pods. When all boards are claimed, an extra Pod stays
+`Pending` (`FailedScheduling: cannot allocate all claims`) until one frees.
+
+**Not yet supported (future work).** A board count is only sufficient when the
+claim takes a whole dedicated device. Topology-sensitive partitions — e.g.
+`galaxy_t3k` (a T3K mesh carved from a Galaxy that must be pinned to adjacent
+chips in one tray) — need DRA constraints (`constraints.matchAttribute` / CEL)
+matching topology attributes the tt-dra-driver does not yet publish. Installing
+such a device **fails at render time** with a clear message.
+
+**Teardown order.** Delete the inference workload *before* uninstalling
+tt-operator; removing the DRA driver first leaves Pods unable to release their
+claims and stuck `Terminating`.
+
 ---
 
 ## Quick Start
@@ -110,6 +186,8 @@ All fields under `defaults` apply to every model/engine/device/impl unless overr
 |---|---|---|
 | `defaults.replicaCount` | `1` | Number of Deployment replicas. |
 | `defaults.progressDeadlineSeconds` | `3600` | Deployment progress deadline. Set high due to long model load times. |
+| `defaults.dra.deviceClassName` | `tenstorrent.com` | DRA `DeviceClass` (published by tt-operator) that the `ResourceClaim` selects. The board `count` is not set here — it is derived from `device` by `tt-inference-server.draDeviceCount`. |
+| `defaults.updateStrategy` | `RollingUpdate` (maxSurge 0, maxUnavailable 1) | Deployment update strategy. `maxSurge=0` terminates the old Pod before creating its replacement so its board and hugepages are freed first; `maxUnavailable=1` rolls one Pod at a time when `replicaCount > 1`. |
 | `defaults.podAnnotations` | `{}` | Annotations applied to the pod template. |
 | `defaults.podSecurityContext` | `{}` | Pod-level `securityContext`. |
 | `defaults.image.pullPolicy` | `IfNotPresent` | Image pull policy. |
@@ -130,7 +208,7 @@ All fields under `defaults` apply to every model/engine/device/impl unless overr
 | `defaults.probes.readiness.initialDelaySeconds` | `2400` | Readiness probe initial delay. |
 | `defaults.nodeSelector` | `{}` | Node selector applied to the pod. |
 | `defaults.tolerations` | `[]` | Tolerations applied to the pod. |
-| `defaults.affinity` | `{}` | Affinity rules applied to the pod. |
+| `defaults.affinity` | `{}` | User-supplied affinity, applied as-is. v0.2 no longer injects a 1-Pod-per-Node `podAntiAffinity` — DRA prevents device collisions by allocation, so multiple Pods may run on one Node. |
 | `defaults.extraEnv` | `[]` | Additional environment variables (see [Extra Environment Variables](#extra-environment-variables)). |
 
 ---
@@ -209,4 +287,12 @@ Each pod runs two init containers before the inference server starts:
 Runs `chown -R 1000:1000 /cache` on the cache host path volume. The inference server runs as UID 1000 and requires write access to the cache directory, which may be created by root on the host.
 
 **`cleanup-hugepages`**
-Removes stale hugepage files left by previous runs (`/dev/hugepages-1G/device_*_tenstorrent` and `/dev/hugepages-1G/tenstorrent`). Runs privileged. Without this cleanup, the inference server may fail to acquire hugepages if a previous pod exited uncleanly.
+Removes stale hugepage files left by previous runs, **scoped to this Pod's
+DRA-allocated board(s)** only. The init container requests the same
+`ResourceClaim` as the main container, so the DRA driver injects its
+`/dev/tenstorrent/<N>` node(s); the container then deletes only
+`/dev/hugepages-1G/device_<N>_*tenstorrent` (and the bare `tenstorrent` file for
+board 0) for each allocated `N`. This is required now that multiple Pods can run
+on one Node — a global `rm` would delete a co-located running Pod's hugepage
+files. Without the cleanup, a replacement Pod reusing the same board may fail to
+acquire hugepages if a previous Pod exited uncleanly.

--- a/charts/tt-inference-server/README.md.gotmpl
+++ b/charts/tt-inference-server/README.md.gotmpl
@@ -81,12 +81,12 @@ allocated and never assigns the same board twice, so a T3K node can run e.g. fou
 independent single-`n300` Pods. When all boards are claimed, an extra Pod stays
 `Pending` (`FailedScheduling: cannot allocate all claims`) until one frees.
 
-**Not yet supported (future work).** A board count is only sufficient when the
-claim takes a whole dedicated device. Topology-sensitive partitions — e.g.
-`galaxy_t3k` (a T3K mesh carved from a Galaxy that must be pinned to adjacent
-chips in one tray) — need DRA constraints (`constraints.matchAttribute` / CEL)
-matching topology attributes the tt-dra-driver does not yet publish. Installing
-such a device **fails at render time** with a clear message.
+**Not yet supported (future work).** A board count is correct only for a single DRA
+device (`n300` = one board = an adjacent on-board chip pair) or a whole dedicated node
+(`t3k`). Adjacency-partitioned requests — several separate devices that must be
+physically adjacent (QSFP-linked), e.g. `galaxy_t3k` or a Galaxy dual — can't be
+expressed (DRA allocates by count, not position), so they are absent from
+`deviceBoardCounts` and fail at render.
 
 **Teardown order.** Delete the inference workload *before* uninstalling
 tt-operator; removing the DRA driver first leaves Pods unable to release their

--- a/charts/tt-inference-server/templates/_helpers.tpl
+++ b/charts/tt-inference-server/templates/_helpers.tpl
@@ -181,6 +181,16 @@ DRA board count for .Values.device, read from the generated
 {{- end -}}
 
 {{/*
+DRA boardName for .Values.device, from the generated .Values.deviceBoardNames map.
+The ResourceClaim selects boards by this attribute (CEL). Returns "" for non-TT
+devices (gpu/cpu); only used when draDeviceCount is non-empty.
+*/}}
+{{- define "tt-inference-server.draBoardName" -}}
+{{- $names := .Values.deviceBoardNames | default dict -}}
+{{- index $names (.Values.device | lower) | default "" -}}
+{{- end -}}
+
+{{/*
 Chart name helpers
 */}}
 {{- define "tt-inference-server.name" -}}

--- a/charts/tt-inference-server/templates/_helpers.tpl
+++ b/charts/tt-inference-server/templates/_helpers.tpl
@@ -174,7 +174,6 @@ DRA board count for .Values.device, read from the generated
 {{- if hasKey $counts $d -}}
 {{- index $counts $d -}}
 {{- else if has $d $nonTT -}}
-{{- /* non-Tenstorrent device: intentionally no ResourceClaim */ -}}
 {{- else -}}
 {{- fail (printf "device '%s' is not supported via DRA in this chart. Topology-sensitive partitions (e.g. galaxy_t3k) are future work and need the tt-dra-driver to publish topology attributes. Supported: %s." $d (keys $counts | sortAlpha | join ", ")) -}}
 {{- end -}}

--- a/charts/tt-inference-server/templates/_helpers.tpl
+++ b/charts/tt-inference-server/templates/_helpers.tpl
@@ -161,6 +161,26 @@ so two impls on the same device don't share a cache directory.
 {{- end }}
 
 {{/*
+DRA board count for .Values.device, read from the generated
+.Values.deviceBoardCounts map (single source of truth). Returns:
+  - device in the map  -> its board count
+  - gpu/cpu (non-TT)   -> "" (no ResourceClaim)
+  - anything else      -> fail (e.g. galaxy_t3k; unsupported, fail closed)
+*/}}
+{{- define "tt-inference-server.draDeviceCount" -}}
+{{- $counts := .Values.deviceBoardCounts | default dict -}}
+{{- $nonTT := list "gpu" "cpu" -}}
+{{- $d := .Values.device | lower -}}
+{{- if hasKey $counts $d -}}
+{{- index $counts $d -}}
+{{- else if has $d $nonTT -}}
+{{- /* non-Tenstorrent device: intentionally no ResourceClaim */ -}}
+{{- else -}}
+{{- fail (printf "device '%s' is not supported via DRA in this chart. Topology-sensitive partitions (e.g. galaxy_t3k) are future work and need the tt-dra-driver to publish topology attributes. Supported: %s." $d (keys $counts | sortAlpha | join ", ")) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Chart name helpers
 */}}
 {{- define "tt-inference-server.name" -}}
@@ -207,25 +227,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Compose the final affinity object.
+Compose the final affinity object — user-supplied affinity, passed through as-is.
 
-Always prepends a hardcoded device-collision podAntiAffinity term to any
-user-supplied affinity. The term label-selects every pod of this chart
-across releases and uses topologyKey=kubernetes.io/hostname to enforce
-1:1 Pod-to-Node placement (issue #2801). Operators can freely add
-nodeAffinity / podAffinity / extra anti-affinity terms via .Values.affinity
-without losing the guarantee; the chart's term is unconditional and not
-values-driven so it cannot be disabled accidentally.
+Under DRA the scheduler prevents device collisions by allocation (two Pods can
+never be assigned the same board), so multiple Pods may run on one Node (e.g. 4
+single-n300 Pods on a T3K). Operators can supply their own nodeAffinity /
+podAffinity / podAntiAffinity via .Values.affinity.
 */}}
 {{- define "tt-inference-server.affinity" -}}
 {{- $cfg := include "tt-inference-server.resolvedConfig" . | fromYaml -}}
-{{- $aff := deepCopy (default (dict) $cfg.affinity) -}}
-{{- $autoTerm := dict
-     "labelSelector" (dict "matchLabels" (dict "app.kubernetes.io/name" (include "tt-inference-server.name" .)))
-     "topologyKey"   "kubernetes.io/hostname" -}}
-{{- $paa := default (dict) (index $aff "podAntiAffinity") -}}
-{{- $req := default (list) (index $paa "requiredDuringSchedulingIgnoredDuringExecution") -}}
-{{- $_   := set $paa "requiredDuringSchedulingIgnoredDuringExecution" (prepend $req $autoTerm) -}}
-{{- $_   := set $aff "podAntiAffinity" $paa -}}
-{{- toYaml $aff -}}
+{{- with $cfg.affinity -}}
+{{- toYaml . -}}
+{{- end -}}
 {{- end -}}

--- a/charts/tt-inference-server/templates/deployment.yaml
+++ b/charts/tt-inference-server/templates/deployment.yaml
@@ -1,6 +1,7 @@
 {{- include "tt-inference-server.validateValues" . }}
 {{- $cfg := include "tt-inference-server.resolvedConfig" . | fromYaml }}
 {{- $engine := include "tt-inference-server.resolvedEngine" . }}
+{{- $ttCount := include "tt-inference-server.draDeviceCount" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,14 +15,8 @@ spec:
   selector:
     matchLabels:
       {{- include "tt-inference-server.selectorLabels" . | nindent 6 }}
-  # Must be Recreate (not RollingUpdate): hugepages mmap'd by the terminating
-  # pod are not freed until it fully exits; a replacement pod would fail to
-  # allocate hugepages (see issue #2801). Trade-off: causes brief downtime
-  # during upgrades — acceptable because the chart's hardcoded podAntiAffinity
-  # already requires the only eligible node to be free. Hardcoded here (not
-  # values-driven) so a future maintainer cannot revert it inadvertently.
   strategy:
-    type: Recreate
+    {{- toYaml $cfg.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:
@@ -42,6 +37,13 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if $ttCount }}
+      # DRA: each Pod gets its own ResourceClaim generated from the
+      # ResourceClaimTemplate, satisfied by the tt-operator DRA driver.
+      resourceClaims:
+        - name: tt
+          resourceClaimTemplateName: {{ include "tt-inference-server.fullname" . }}-tt
+      {{- end }}
       initContainers:
         - name: fix-cache-permissions
           image: busybox
@@ -49,11 +51,25 @@ spec:
           volumeMounts:
             - name: cache
               mountPath: /cache
+        # Scoped hugepages cleanup: claim requested here so the DRA driver injects
+        # /dev/tenstorrent/<N>; delete only THIS Pod's board files, not co-located Pods'.
         - name: cleanup-hugepages
           image: busybox
-          command: ["sh", "-c", "rm -f /dev/hugepages-1G/device_*_tenstorrent /dev/hugepages-1G/tenstorrent && echo 'hugepage cleanup done'"]
-          securityContext:
-            privileged: true
+          command:
+            - sh
+            - -c
+            - |
+              boards=$(ls /dev/tenstorrent 2>/dev/null)
+              echo "scoped hugepage cleanup for boards: [$boards]"
+              for n in $boards; do
+                rm -f /dev/hugepages-1G/device_${n}_*tenstorrent
+                if [ "$n" = "0" ]; then rm -f /dev/hugepages-1G/tenstorrent; fi
+              done
+          {{- if $ttCount }}
+          resources:
+            claims:
+              - name: tt
+          {{- end }}
           volumeMounts:
             - name: hugepages-1g
               mountPath: /dev/hugepages-1G
@@ -84,8 +100,6 @@ spec:
           volumeMounts:
             - name: cache
               mountPath: /home/container_app_user/cache_root
-            - name: tenstorrent
-              mountPath: /dev/tenstorrent
             - name: hugepages-1g
               mountPath: /dev/hugepages-1G
             {{- if .Values.hfCacheDir }}
@@ -93,12 +107,16 @@ spec:
               mountPath: /mnt/hf-cache
               readOnly: true
             {{- end }}
-          {{- with $cfg.resources }}
+          {{- if or $cfg.resources $ttCount }}
           resources:
+            {{- with $cfg.resources }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if $ttCount }}
+            claims:
+              - name: tt
+            {{- end }}
           {{- end }}
-          securityContext:
-            privileged: true
           {{- if $cfg.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
@@ -128,10 +146,6 @@ spec:
           hostPath:
             path: {{ include "tt-inference-server.cacheHostPath" . }}
             type: DirectoryOrCreate
-        - name: tenstorrent
-          hostPath:
-            path: /dev/tenstorrent
-            type: Directory
         - name: hugepages-1g
           hostPath:
             path: /dev/hugepages-1G

--- a/charts/tt-inference-server/templates/resourceclaimtemplate.yaml
+++ b/charts/tt-inference-server/templates/resourceclaimtemplate.yaml
@@ -1,6 +1,7 @@
 {{- include "tt-inference-server.validateValues" . }}
 {{- $cfg := include "tt-inference-server.resolvedConfig" . | fromYaml }}
 {{- $count := include "tt-inference-server.draDeviceCount" . }}
+{{- $boardName := include "tt-inference-server.draBoardName" . }}
 {{- if $count }}
 # DRA ResourceClaim (one per Pod): tt-dra-driver allocates {{ $count }} Tenstorrent
 # board(s) for device "{{ .Values.device }}" and injects /dev/tenstorrent/<N> —
@@ -21,4 +22,8 @@ spec:
             deviceClassName: {{ $cfg.dra.deviceClassName }}
             allocationMode: ExactCount
             count: {{ $count }}
+            selectors:
+              - cel:
+                  expression: |-
+                    device.attributes["tenstorrent.com"].boardName == {{ $boardName | quote }}
 {{- end }}

--- a/charts/tt-inference-server/templates/resourceclaimtemplate.yaml
+++ b/charts/tt-inference-server/templates/resourceclaimtemplate.yaml
@@ -1,0 +1,24 @@
+{{- include "tt-inference-server.validateValues" . }}
+{{- $cfg := include "tt-inference-server.resolvedConfig" . | fromYaml }}
+{{- $count := include "tt-inference-server.draDeviceCount" . }}
+{{- if $count }}
+# DRA ResourceClaim (one per Pod): tt-dra-driver allocates {{ $count }} Tenstorrent
+# board(s) for device "{{ .Values.device }}" and injects /dev/tenstorrent/<N> —
+# no privileged mode or hostPath needed.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: {{ include "tt-inference-server.fullname" . }}-tt
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tt-inference-server.labels" . | nindent 4 }}
+spec:
+  spec:
+    devices:
+      requests:
+        - name: tt
+          exactly:
+            deviceClassName: {{ $cfg.dra.deviceClassName }}
+            allocationMode: ExactCount
+            count: {{ $count }}
+{{- end }}

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -35,6 +35,18 @@ hfCacheDir: ""
 defaults:
   replicaCount: 1
   progressDeadlineSeconds: 3600
+  # DRA: devices acquired via a ResourceClaim served by tt-operator's tt-dra-driver.
+  # Board count comes from deviceBoardCounts (per device); only the DeviceClass
+  # name is set here.
+  dra:
+    deviceClassName: tenstorrent.com
+  # maxSurge=0 frees the outgoing Pod's board + hugepages before its replacement
+  # starts; maxUnavailable=1 rolls one Pod at a time when replicaCount > 1.
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   podAnnotations: {}
   podSecurityContext: {}
   image:
@@ -65,14 +77,28 @@ defaults:
       initialDelaySeconds: 2400
   nodeSelector: {}
   tolerations: []
-  # User-supplied affinity. MERGED with the chart's hardcoded device-collision
-  # podAntiAffinity term (see tt-inference-server.affinity in _helpers.tpl) —
-  # nodeAffinity / podAffinity / extra podAntiAffinity terms all apply, but
-  # the 1:1 Pod-to-Node guarantee from issue #2801 is unconditional and cannot
-  # be disabled from values. replicaCount must not exceed the number of nodes
-  # matching nodeSelector/tolerations or pods will sit Pending.
+  # User-supplied affinity, applied as-is. v0.2: the chart no longer injects a
+  # 1:1-Pod-per-Node podAntiAffinity — DRA prevents device collisions by
+  # allocation, so multiple Pods may run on one Node (e.g. 4 single-n300 Pods on
+  # a T3K). Add your own nodeAffinity / podAffinity / podAntiAffinity here if
+  # needed.
   affinity: {}
   extraEnv: []
+
+# DRA board count per device — number of Tenstorrent boards a ResourceClaim requests for each device shape.
+# Generated from workflows/device_utils.py:BOARD_TYPE_COUNT_TO_DEVICE; consumed by tt-inference-server.draDeviceCount.
+deviceBoardCounts:
+  galaxy: 32
+  n150: 1
+  n150x4: 4
+  n300: 1
+  p100: 1
+  p150: 1
+  p150x4: 4
+  p150x8: 8
+  p300: 1
+  p300x2: 2
+  t3k: 4
 
 # ---------------------------------------------------------------------------
 # Per-model configuration — keyed by model -> engine -> device -> impl.

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -85,6 +85,21 @@ defaults:
   affinity: {}
   extraEnv: []
 
+# DRA boardName per device — the tt-dra-driver `boardName` attribute a ResourceClaim selects (CEL) for each device shape.
+# Generated from workflows/device_utils.py:BOARD_TYPE_COUNT_TO_DEVICE; consumed by tt-inference-server.draBoardName.
+deviceBoardNames:
+  galaxy: galaxy-wormhole
+  n150: n150
+  n150x4: n150
+  n300: n300
+  p100: p100
+  p150: p150
+  p150x4: p150
+  p150x8: p150
+  p300: p300
+  p300x2: p300
+  t3k: n300
+
 # DRA board count per device — number of Tenstorrent boards a ResourceClaim requests for each device shape.
 # Generated from workflows/device_utils.py:BOARD_TYPE_COUNT_TO_DEVICE; consumed by tt-inference-server.draDeviceCount.
 deviceBoardCounts:

--- a/tests/test_helm_generator/test_dra_board_maps.py
+++ b/tests/test_helm_generator/test_dra_board_maps.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+from workflows.device_utils import dra_device_board_counts, dra_device_board_names
+
+
+def test_board_count_and_name_maps_cover_identical_devices():
+    """The ResourceClaim template reads count from deviceBoardCounts and boardName
+    from deviceBoardNames; if a device had one but not the other, it would render an
+    unsatisfiable `boardName == ""` selector. Both maps derive from the same
+    generator, so their key sets must always match.
+    """
+    assert set(dra_device_board_counts()) == set(dra_device_board_names())
+
+
+def test_board_names_translate_galaxy_and_pass_through_others():
+    names = dra_device_board_names()
+    # Galaxy UBB is named differently by the driver than the tt-smi board_type.
+    assert names["galaxy"] == "galaxy-wormhole"
+    # Multi-board device shapes select by their single board type.
+    assert names["t3k"] == "n300"
+    assert names["n300"] == "n300"

--- a/workflows/device_utils.py
+++ b/workflows/device_utils.py
@@ -49,6 +49,21 @@ BOARD_TYPE_COUNT_TO_DEVICE: Dict[Tuple[Tuple[str, int], ...], DeviceTypes] = {
 }
 
 
+def dra_device_board_counts() -> Dict[str, int]:
+    """Map device_key (e.g. "t3k") -> number of Tenstorrent boards a DRA
+    ResourceClaim must request for that device shape.
+
+    Derived from BOARD_TYPE_COUNT_TO_DEVICE (the authoritative board-type/count
+    -> DeviceType mapping, also used for tt-smi device detection) so the Helm
+    chart's per-device DRA count has a single source of truth. The board count
+    is the total number of boards across the device's board-type tuple.
+    """
+    counts: Dict[str, int] = {}
+    for board_tuple, device in BOARD_TYPE_COUNT_TO_DEVICE.items():
+        counts[device.name.lower()] = sum(count for _, count in board_tuple)
+    return dict(sorted(counts.items()))
+
+
 def _collect_supported_devices_for_model(
     model_name: str, engine: Optional[str] = None
 ) -> Set[DeviceTypes]:

--- a/workflows/device_utils.py
+++ b/workflows/device_utils.py
@@ -5,7 +5,7 @@
 
 import json
 import subprocess
-from typing import Dict, Optional, Set, Tuple
+from typing import Dict, Iterator, Optional, Set, Tuple
 
 from workflows.model_spec import MODEL_SPECS
 from workflows.workflow_types import DeviceTypes, WorkflowVenvType
@@ -49,19 +49,53 @@ BOARD_TYPE_COUNT_TO_DEVICE: Dict[Tuple[Tuple[str, int], ...], DeviceTypes] = {
 }
 
 
+# tt-dra-driver boardName per board_type. Matches board_type except the Galaxy
+# UBBs, which the driver names differently.
+_DRA_BOARD_NAME_OVERRIDES: Dict[str, str] = {
+    "tt-galaxy-wh": "galaxy-wormhole",
+    "tt-galaxy-bh": "galaxy-blackhole",
+}
+
+
+def _dra_single_board_type_devices() -> Iterator[Tuple[str, str, int]]:
+    """Yield (device_key, board_type, board_count) for each DRA-deployable device.
+
+    Heterogeneous (multi-board-type) shapes are future work: they can't be
+    expressed as a single boardName selector, so they are skipped here. Both DRA
+    maps below are built from this one generator so deviceBoardCounts and
+    deviceBoardNames always cover the exact same devices (no count-without-name
+    drift that would render an unsatisfiable `boardName == ""` selector).
+    """
+    for board_tuple, device in BOARD_TYPE_COUNT_TO_DEVICE.items():
+        board_types = {board_type for board_type, _ in board_tuple}
+        if len(board_types) != 1:
+            continue
+        board_type = next(iter(board_types))
+        board_count = sum(count for _, count in board_tuple)
+        yield device.name.lower(), board_type, board_count
+
+
 def dra_device_board_counts() -> Dict[str, int]:
     """Map device_key (e.g. "t3k") -> number of Tenstorrent boards a DRA
-    ResourceClaim must request for that device shape.
-
-    Derived from BOARD_TYPE_COUNT_TO_DEVICE (the authoritative board-type/count
-    -> DeviceType mapping, also used for tt-smi device detection) so the Helm
-    chart's per-device DRA count has a single source of truth. The board count
-    is the total number of boards across the device's board-type tuple.
+    ResourceClaim must request. Single source of truth for the chart's per-device
+    board count (see _dra_single_board_type_devices).
     """
-    counts: Dict[str, int] = {}
-    for board_tuple, device in BOARD_TYPE_COUNT_TO_DEVICE.items():
-        counts[device.name.lower()] = sum(count for _, count in board_tuple)
-    return dict(sorted(counts.items()))
+    return dict(
+        sorted((key, count) for key, _bt, count in _dra_single_board_type_devices())
+    )
+
+
+def dra_device_board_names() -> Dict[str, str]:
+    """Map device_key (e.g. "t3k") -> the tt-dra-driver `boardName` a DRA
+    ResourceClaim selects (via CEL). Same source and device coverage as
+    dra_device_board_counts (see _dra_single_board_type_devices).
+    """
+    return dict(
+        sorted(
+            (key, _DRA_BOARD_NAME_OVERRIDES.get(bt, bt))
+            for key, bt, _count in _dra_single_board_type_devices()
+        )
+    )
 
 
 def _collect_supported_devices_for_model(

--- a/workflows/helm_generator/README.md
+++ b/workflows/helm_generator/README.md
@@ -11,6 +11,13 @@ Run the generator after a model spec changes; it produces an updated
 `values.yaml` while preserving comments and any hand-tuned keys the operator
 has added.
 
+It also mirrors a second source: the DRA per-device board maps
+`deviceBoardCounts` and `deviceBoardNames` are generated from
+[`workflows/device_utils.py`](../device_utils.py)`:BOARD_TYPE_COUNT_TO_DEVICE`.
+Drift in either source (`model_spec.py` or `device_utils.py`) is caught by
+`tests/test_helm_generator/test_values_in_sync.py`, which regenerates and diffs
+the committed `values.yaml`.
+
 ## Schema produced
 
 ```yaml

--- a/workflows/helm_generator/cli.py
+++ b/workflows/helm_generator/cli.py
@@ -21,10 +21,11 @@ from workflows.helm_generator.merge import (
     merge_spec,
     set_default_engine,
     set_device_board_counts,
+    set_device_board_names,
 )
 from workflows.helm_generator.schema import HelmModelSpec
 from workflows.helm_generator.yaml_io import dump_values, dumps_values, load_values
-from workflows.device_utils import dra_device_board_counts
+from workflows.device_utils import dra_device_board_counts, dra_device_board_names
 from workflows.model_spec import IMAGE_PINNED_MODEL_SPECS, ModelSpec
 from workflows.utils import get_repo_root_path
 
@@ -212,6 +213,15 @@ def generate(
     }
     if set_device_board_counts(doc, board_counts):
         logger.info("updated deviceBoardCounts")
+
+    # deviceBoardNames: the tt-dra-driver boardName the ResourceClaim selects (CEL)
+    # for each device the catalogue offers — same single source of truth and same
+    # catalogue restriction as deviceBoardCounts.
+    board_names = {
+        k: v for k, v in dra_device_board_names().items() if k in used_devices
+    }
+    if set_device_board_names(doc, board_names):
+        logger.info("updated deviceBoardNames")
 
     if dry_run:
         sys.stdout.write(dumps_values(doc))

--- a/workflows/helm_generator/cli.py
+++ b/workflows/helm_generator/cli.py
@@ -20,9 +20,11 @@ from workflows.helm_generator.merge import (
     format_change_summary,
     merge_spec,
     set_default_engine,
+    set_device_board_counts,
 )
 from workflows.helm_generator.schema import HelmModelSpec
 from workflows.helm_generator.yaml_io import dump_values, dumps_values, load_values
+from workflows.device_utils import dra_device_board_counts
 from workflows.model_spec import IMAGE_PINNED_MODEL_SPECS, ModelSpec
 from workflows.utils import get_repo_root_path
 
@@ -146,6 +148,24 @@ def map_specs(
     return out
 
 
+def _catalog_device_keys(doc: object) -> set:
+    """Device keys that actually appear in the values.yaml models catalogue
+    (models.<model>.<engine>.<device> where <device> has an impls block).
+    """
+    used: set = set()
+    models = getattr(doc, "get", lambda _k, _d=None: None)("models") or {}
+    for _model, engines in models.items():
+        if not isinstance(engines, dict):
+            continue
+        for _engine, devices in engines.items():
+            if not isinstance(devices, dict):
+                continue
+            for device, cfg in devices.items():
+                if isinstance(cfg, dict) and "impls" in cfg:
+                    used.add(device)
+    return used
+
+
 def generate(
     *,
     values_path: Path,
@@ -181,6 +201,17 @@ def generate(
     for model_name, engine in default_engines.items():
         if set_default_engine(doc, model_name, engine):
             logger.info("%s: defaultEngine=%s", model_name, engine)
+
+    # deviceBoardCounts: DRA board count for each device the catalogue offers.
+    # Restricted to devices present in models so the map is exactly "devices this
+    # chart can DRA-deploy" (devices with no known board count, e.g. galaxy_t3k,
+    # are simply absent and fail closed in tt-inference-server.draDeviceCount).
+    used_devices = _catalog_device_keys(doc)
+    board_counts = {
+        k: v for k, v in dra_device_board_counts().items() if k in used_devices
+    }
+    if set_device_board_counts(doc, board_counts):
+        logger.info("updated deviceBoardCounts")
 
     if dry_run:
         sys.stdout.write(dumps_values(doc))

--- a/workflows/helm_generator/merge.py
+++ b/workflows/helm_generator/merge.py
@@ -225,6 +225,49 @@ def set_device_board_counts(doc: Any, counts: Mapping[str, int]) -> bool:
     return True
 
 
+def set_device_board_names(doc: Any, names: Mapping[str, str]) -> bool:
+    """Set/refresh the top-level `deviceBoardNames` map (device_key -> tt-dra-driver
+    `boardName`), inserted just before `models` for readability. Idempotent.
+
+    Returns True if the file changed.
+    """
+    from ruamel.yaml.comments import CommentedMap
+
+    desired = CommentedMap()
+    for key in sorted(names):
+        desired[key] = str(names[key])
+
+    existing = doc.get("deviceBoardNames")
+    if existing is not None and {k: str(v) for k, v in existing.items()} == {
+        k: str(v) for k, v in desired.items()
+    }:
+        return False
+
+    if "deviceBoardNames" in doc:
+        doc["deviceBoardNames"] = desired
+    else:
+        # Insert just before deviceBoardCounts, which the CLI always writes first.
+        keys = list(doc.keys())
+        pos = keys.index("deviceBoardCounts")
+        counts_comment = getattr(doc, "ca", None) and doc.ca.items.get(
+            "deviceBoardCounts"
+        )
+        doc.insert(pos, "deviceBoardNames", desired)
+        doc.yaml_set_comment_before_after_key(
+            "deviceBoardNames",
+            # Leading newline renders a blank line after the preceding block.
+            before=(
+                "\nDRA boardName per device — the tt-dra-driver `boardName` attribute a "
+                "ResourceClaim selects (CEL) for each device shape.\n"
+                "Generated from workflows/device_utils.py:BOARD_TYPE_COUNT_TO_DEVICE; "
+                "consumed by tt-inference-server.draBoardName."
+            ),
+        )
+        if counts_comment is not None:
+            doc.ca.items["deviceBoardCounts"] = counts_comment
+    return True
+
+
 def format_path(path: PathTuple) -> str:
     return ".".join(path)
 
@@ -249,6 +292,7 @@ __all__: List[str] = [
     "merge_spec",
     "set_default_engine",
     "set_device_board_counts",
+    "set_device_board_names",
     "format_change_summary",
     "format_path",
 ]

--- a/workflows/helm_generator/merge.py
+++ b/workflows/helm_generator/merge.py
@@ -183,6 +183,48 @@ def set_default_engine(doc: Any, model_name: str, engine: str) -> bool:
     return True
 
 
+def set_device_board_counts(doc: Any, counts: Mapping[str, int]) -> bool:
+    """Set/refresh the top-level `deviceBoardCounts` map (device_key -> DRA
+    board count), inserted just before `models` for readability. Idempotent.
+
+    Returns True if the file changed.
+    """
+    from ruamel.yaml.comments import CommentedMap
+
+    desired = CommentedMap()
+    for key in sorted(counts):
+        desired[key] = int(counts[key])
+
+    existing = doc.get("deviceBoardCounts")
+    if existing is not None and {k: int(v) for k, v in existing.items()} == {
+        k: int(v) for k, v in desired.items()
+    }:
+        return False
+
+    if "deviceBoardCounts" in doc:
+        doc["deviceBoardCounts"] = desired
+    else:
+        keys = list(doc.keys())
+        pos = keys.index("models") if "models" in keys else len(keys)
+        # Inserting a key before `models` would otherwise swallow the comment
+        # block attached to `models`; capture and restore it around the insert.
+        models_comment = getattr(doc, "ca", None) and doc.ca.items.get("models")
+        doc.insert(pos, "deviceBoardCounts", desired)
+        doc.yaml_set_comment_before_after_key(
+            "deviceBoardCounts",
+            # Leading newline renders a blank line after the preceding block.
+            before=(
+                "\nDRA board count per device — number of Tenstorrent boards a "
+                "ResourceClaim requests for each device shape.\n"
+                "Generated from workflows/device_utils.py:BOARD_TYPE_COUNT_TO_DEVICE; "
+                "consumed by tt-inference-server.draDeviceCount."
+            ),
+        )
+        if models_comment is not None:
+            doc.ca.items["models"] = models_comment
+    return True
+
+
 def format_path(path: PathTuple) -> str:
     return ".".join(path)
 
@@ -206,6 +248,7 @@ __all__: List[str] = [
     "MergeResult",
     "merge_spec",
     "set_default_engine",
+    "set_device_board_counts",
     "format_change_summary",
     "format_path",
 ]


### PR DESCRIPTION
Switch the chart's device acquisition from the v0.1.0 stopgaps (privileged + hostPath `/dev/tenstorrent` + a hardcoded 1-Pod-per-Node `podAntiAffinity`) to **tt-operator DRA**. Each Pod declares a `ResourceClaim`; `tt-dra-driver` allocates Tenstorrent boards and injects the device node(s). Enables **multiple Pods per Node** and an unprivileged, hostPath-free Deployment.

Closes #4863, #4864, #4865. Part of #4859 (docs contribute to #4868, kept open).

## Changes

**DRA device acquisition — #4863**
- New `templates/resourceclaimtemplate.yaml`: one `ResourceClaimTemplate` per Pod
  (`deviceClassName: tenstorrent.com`, board `count`).
- `deployment.yaml`: reference the claim (`resources.claims` + `spec.resourceClaims`);
  remove `privileged` and the hostPath `/dev/tenstorrent`.

**DRA parameters, generated — #4864**
- `values.yaml`: `defaults.dra.deviceClassName`
- Generator + `_helpers.tpl`: top-level `deviceBoardCounts` (device → board count), derived from `device_utils.BOARD_TYPE_COUNT_TO_DEVICE`; `draDeviceCount` reads it.

**Multiple Pods per Node — #4865**
- `_helpers.tpl`: remove the hardcoded 1-Pod-per-Node `podAntiAffinity`.
- `deployment.yaml`: scope hugepages cleanup to the Pod's allocated board (`device_<N>_*`); `Recreate` → `RollingUpdate(maxSurge=0)`.

**CI & docs**
- `test-gate.yml`: assert DRA invariants (no privileged / no hostPath, claim + count); matrix skips devices absent from `deviceBoardCounts`.
- Docs (`README.md.gotmpl`) + chart version → `0.2.0`.

## Scope / future work
- Supported: whole-device shapes (n150, n300, t3k, p-series, galaxy=32).
- Not yet supported: topology-sensitive device group (e.g. `galaxy_t3k`) — needs driver topology attributes; fails render with a clear message. Tracked in #4890.

## Verification
- Validated on real T3K hardware (k3s 1.36 + tt-operator): one Pod at count=4 and four Pods at count=1 both serve inference; DRA release/reallocation verified on churn; `helm install` of this chart end-to-end.
- `helm template` / `kubeconform` / `helm lint` / `pytest` (incl. values-in-sync) all green ✅
