### PR TITLE
use shallow clone depth=1 when cloning tt-metal for bulding vllm docker image

### DIFF
--- a/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
+++ b/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
@@ -81,8 +81,12 @@ RUN /bin/bash -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ENV UV_HTTP_RETRIES=10
 
 # Build tt-metal - clone with minimal history, build, and clean
-RUN /bin/bash -c "git clone https://github.com/tenstorrent-metal/tt-metal.git ${TT_METAL_HOME} \
+# A full-history clone of tt-metal has taken over an hour on CI, connection dropped ("fatal: early
+# EOF"). Only the pinned commit is needed, so fetch just that (matches the shallow
+# clone already used by tt-media-server/Dockerfile).
+RUN /bin/bash -c "git clone --depth 1 https://github.com/tenstorrent-metal/tt-metal.git ${TT_METAL_HOME} \
     && cd ${TT_METAL_HOME} \
+    && git fetch --depth 1 origin ${TT_METAL_COMMIT_SHA_OR_TAG} \
     && git checkout ${TT_METAL_COMMIT_SHA_OR_TAG} \
     && git submodule update --init --recursive \
     && bash ./build_metal.sh \


### PR DESCRIPTION
In previous days `on-nightly` jobs have been failing since the `git clone` operation of `tt-metal` couldn't be finished in 60 minites.
example: https://github.com/tenstorrent/tt-shield/actions/runs/31133048089/job/92726319171

## Error
error after 60 minutes of git clone operation:
```
2026-08-07T01:03:04Z  #11 0.851    Cloning into '/home/container_app_user/tt-metal'...
2026-08-07T02:04:21Z  #11 3678.4   error: 16157 bytes of body are still expected
2026-08-07T02:04:22Z  #11 3678.4   fetch-pack: unexpected disconnect while reading sideband packet
2026-08-07T02:04:22Z  #11 3678.4   fatal: early EOF
2026-08-07T02:04:22Z  #11 3678.4   fatal: fetch-pack: invalid index-pack output
2026-08-07T02:04:22Z  #11 ERROR: process "...git clone https://github.com/tenstorrent-metal/tt-metal.git..."
                                   did not complete successfully: exit code: 128
```

media server uses `shallow-clone depth=1` so we are setting the same for vllm docker image build to prevent the failures and to optimize the pipeline executuon.
## Fix
adding `--depth 1` in `git clone`

## Test
Tested run targeting the change on a new branch:
https://github.com/tenstorrent/tt-shield/actions/runs/31182413392/job/92878717066