### PR TITLE
Add TargetPack seam for reference_config content + per-device eval overrides

### DIFF
--- a/llm_module/benchmark_configs.py
+++ b/llm_module/benchmark_configs.py
@@ -29,19 +29,17 @@ def get_llm_configs(
     text-only, so any param without both ``isl`` and ``osl`` is dropped.
     ``limit_samples_mode`` honours v1's smoke-test selection when set.
     """
-    from reference_config.benchmarking.benchmark_config import (
-        get_benchmark_config,
-        select_smoke_test_benchmark_config,
-    )
     from workflow_module.engine_types import EvalLimitMode
+    from workflow_module.target_pack import get_target_pack
 
-    benchmark_config = get_benchmark_config(model_spec)
+    pack = get_target_pack()
+    benchmark_config = pack.benchmark_config(model_spec)
 
     if (
         limit_samples_mode
         and EvalLimitMode.from_string(limit_samples_mode) == EvalLimitMode.SMOKE_TEST
     ):
-        benchmark_config = select_smoke_test_benchmark_config(benchmark_config, device)
+        benchmark_config = pack.smoke_test_benchmark_config(benchmark_config, device)
 
     configured_devices = {
         dev for task in benchmark_config.tasks for dev in task.param_map

--- a/llm_module/eval_configs.py
+++ b/llm_module/eval_configs.py
@@ -68,17 +68,20 @@ def _select_tasks(tasks: list, runtime_config) -> list:
     return [selected_task]
 
 
-def get_llm_eval_tasks(model_spec, runtime_config=None) -> List:
+def get_llm_eval_tasks(model_spec, runtime_config=None, device=None) -> List:
     """Return the standard eval tasks for ``model_spec`` (empty if none).
 
-    Looks the model up in ``EVAL_CONFIGS`` by ``model_name``, drops non-standard
-    (agentic/media) task venvs, then applies --eval-samples / smoke-test
-    selection. Returns ``[]`` when the model has no standard eval tasks so the
-    caller can no-op cleanly (e.g. a model with only agentic evals).
+    Looks the model up in the registered target pack by ``model_name``, drops
+    non-standard (agentic/media) task venvs, applies per-device tier-2/3
+    overrides when ``device`` is given, then applies --eval-samples /
+    smoke-test selection. Returns ``[]`` when the model has no standard eval
+    tasks so the caller can no-op cleanly (e.g. a model with only agentic
+    evals).
     """
-    from reference_config.evals.eval_config import EVAL_CONFIGS
+    from workflow_module.target_pack import get_target_pack
 
-    eval_config = EVAL_CONFIGS.get(model_spec.model_name)
+    pack = get_target_pack()
+    eval_config = pack.eval_config(model_spec.model_name)
     if eval_config is None or not eval_config.tasks:
         logger.info("No EVAL_CONFIGS entry / tasks for model=%s", model_spec.model_name)
         return []
@@ -93,6 +96,9 @@ def get_llm_eval_tasks(model_spec, runtime_config=None) -> List:
             model_spec.model_name,
         )
         return []
+
+    if device is not None:
+        standard = [pack.resolve_eval_task_for_device(t, device) for t in standard]
 
     return _select_tasks(standard, runtime_config)
 

--- a/llm_module/parsers/agentic.py
+++ b/llm_module/parsers/agentic.py
@@ -10,9 +10,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Union
 
-from reference_config.evals.eval_config import accept_eval_score, resolve_eval_reference
 from report_module.schema import Block
 from workflow_module.engine_types import ReportCheckTypes
+from workflow_module.target_pack import get_target_pack
 
 from .base import LLMResultParser
 
@@ -41,7 +41,7 @@ class AgenticEvalParser(LLMResultParser):
         if device:
             targets["device"] = device
         if self.score is not None:
-            ref = resolve_eval_reference(self.score, self.limit_mode)
+            ref = get_target_pack().resolve_eval_reference(self.score, self.limit_mode)
             targets.update(
                 {
                     "tolerance": ref["tolerance"],
@@ -228,9 +228,9 @@ def compute_accuracy_check(
     if accuracy is None or score is None:
         return ReportCheckTypes.NA
     accuracy = _normalize_accuracy_to_percent(accuracy)
-    ref = resolve_eval_reference(score, limit_mode)
+    ref = get_target_pack().resolve_eval_reference(score, limit_mode)
     n_total = metrics.get("n_trials")
-    passed = accept_eval_score(ref, accuracy, n_total=n_total)
+    passed = get_target_pack().accept_eval_score(ref, accuracy, n_total=n_total)
     if passed is None:
         # No gpu reference; fall back to published score ratio.
         published = getattr(score, "published_score", None)

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -2,8 +2,9 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
+import logging
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from reference_config.evals.eval_utils import (
@@ -14,6 +15,8 @@ from reference_config.evals.eval_utils import (
 from workflows.model_spec import MODEL_SPECS
 from workflows.utils import map_configs_by_attr
 from workflows.workflow_types import EvalLimitMode, WorkflowVenvType
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -229,6 +232,16 @@ class EvalTask:
     allow_code_execution: bool = False
     agentic_eval_config: Optional[TerminalBenchEvalConfig] = None
     swebench_eval_config: Optional[SWEbenchEvalConfig] = None
+    # Per-device overrides, keyed by device name (e.g. "GALAXY",
+    # "SUPER_CLUSTER"; matched case-insensitively). EvalTask fields follow a
+    # three-tier device-variance model:
+    #   1. semantic identity (device-INVARIANT, rejected here): task_name,
+    #      workflow_venv_type, eval_class, num_fewshot, seed, include_path;
+    #   2. transport/execution (device-variant): max_concurrent, batch_size,
+    #      use_chat_api, apply_chat_template, gen_kwargs, model_kwargs, ...;
+    #   3. measured baselines (device-variant): score.
+    # Only tier-2/3 fields may appear in an override block.
+    device_overrides: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
     def __post_init__(self):
         self.validate_data()
@@ -250,7 +263,62 @@ class EvalTask:
             object.__setattr__(self, "model_kwargs", mk)
 
     def validate_data(self):
-        pass
+        tier1_fields = {
+            "task_name",
+            "workflow_venv_type",
+            "eval_class",
+            "num_fewshot",
+            "seed",
+            "include_path",
+            "device_overrides",
+        }
+        for device_key, overrides in self.device_overrides.items():
+            if not isinstance(overrides, dict):
+                raise ValueError(
+                    f"EvalTask {self.task_name!r}: device_overrides[{device_key!r}] "
+                    "must be a dict of field overrides"
+                )
+            unknown = set(overrides) - set(self.__dataclass_fields__)
+            if unknown:
+                raise ValueError(
+                    f"EvalTask {self.task_name!r}: device_overrides[{device_key!r}] "
+                    f"names unknown EvalTask fields: {sorted(unknown)}"
+                )
+            tier1 = set(overrides) & tier1_fields
+            if tier1:
+                raise ValueError(
+                    f"EvalTask {self.task_name!r}: device_overrides[{device_key!r}] "
+                    f"cannot override tier-1 (device-invariant) fields: {sorted(tier1)}"
+                )
+
+
+def resolve_task_for_device(task: "EvalTask", device) -> "EvalTask":
+    """Apply ``task``'s per-device overrides for ``device`` (identity if none).
+
+    ``device`` may be a device enum member (uses ``.name``) or a plain string;
+    matching is case-insensitive. Only tier-2 (transport/execution) and tier-3
+    (measured baseline) fields are overridable — see ``EvalTask`` validation.
+    """
+    if not device or not task.device_overrides:
+        return task
+    device_name = getattr(device, "name", device)
+    overrides = {
+        k: v
+        for key, v in task.device_overrides.items()
+        if key.upper() == str(device_name).upper()
+        for k, v in v.items()
+    }
+    if not overrides:
+        return task
+    resolved = replace(task, **overrides)
+    logger.info(
+        "Applied %d device override(s) for task=%s device=%s: %s",
+        len(overrides),
+        task.task_name,
+        device_name,
+        sorted(overrides),
+    )
+    return resolved
 
 
 @dataclass(frozen=True)

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -248,13 +248,23 @@ class EvalTask:
         self._infer_data()
 
     def _infer_data(self):
+        # Must stay idempotent: resolve_task_for_device() rebuilds the task via
+        # dataclasses.replace, which re-runs __post_init__ on already-inferred
+        # field values. Every inference here must be a fixed point.
         if self.use_chat_api and self.eval_class == "local-completions":
             object.__setattr__(self, "eval_class", "local-chat-completions")
+        elif not self.use_chat_api and self.eval_class == "local-chat-completions":
+            # Symmetric reverse: a device override can flip use_chat_api off on
+            # a task whose eval_class was already inferred to the chat variant.
+            object.__setattr__(self, "eval_class", "local-completions")
 
         if self.workflow_venv_type == WorkflowVenvType.EVALS_META:
             # max_concurrent is not supported in lm-eval==0.4.3
-            object.__setattr__(self, "batch_size", self.max_concurrent)
-            object.__setattr__(self, "max_concurrent", None)
+            # Guard on max_concurrent: after the first inference it is None, so
+            # re-inference must not copy None into batch_size.
+            if self.max_concurrent is not None:
+                object.__setattr__(self, "batch_size", self.max_concurrent)
+                object.__setattr__(self, "max_concurrent", None)
             # lm-eval 0.4.4's API models default add_bos_token=False. Llama is trained with a
             # leading BOS and regresses badly without it (meta_ifeval strict-format failures,
             # ~3pt drop crossing the 0.95 gate). Force BOS on for all meta tasks.

--- a/run_workflows.py
+++ b/run_workflows.py
@@ -66,11 +66,18 @@ from workflow_module.model_catalog import (  # noqa: E402
 from workflow_module.server_lifecycle import (  # noqa: E402
     register_server_lifecycle,
 )
+from workflow_module.target_pack import (  # noqa: E402
+    get_target_pack,
+    register_target_pack,
+)
 from workflow_module.venv_provisioner import (  # noqa: E402
     register_venv_provisioner,
 )
 from workflows.server_lifecycle_provider import (  # noqa: E402
     TenstorrentServerLifecycle,
+)
+from workflows.target_pack_provider import (  # noqa: E402
+    TenstorrentTargetPack,
 )
 from workflows.venv_provisioner_provider import (  # noqa: E402
     TenstorrentVenvProvisioner,
@@ -528,14 +535,11 @@ def parse_args() -> argparse.Namespace:
             f"(got --workflow {args.workflow})."
         )
     if args.agentic_traces_duration is not None:
-        from reference_config.agentic_traces.agentic_traces_config import (
-            AGENTIC_TRACES_MIN_PROFILE_SECONDS,
-        )
-
-        if args.agentic_traces_duration < AGENTIC_TRACES_MIN_PROFILE_SECONDS:
+        min_profile_seconds = get_target_pack().agentic_traces_min_profile_seconds()
+        if args.agentic_traces_duration < min_profile_seconds:
             parser.error(
                 "--agentic-traces-duration must be at least "
-                f"{AGENTIC_TRACES_MIN_PROFILE_SECONDS}s (the InferenceX "
+                f"{min_profile_seconds}s (the InferenceX "
                 f"scenario's floor), got {args.agentic_traces_duration}s."
             )
     if args.output_dir is None:
@@ -552,6 +556,7 @@ def main() -> int:
     register_device_catalog(TenstorrentDeviceCatalog())
     register_server_lifecycle(TenstorrentServerLifecycle())
     register_venv_provisioner(TenstorrentVenvProvisioner())
+    register_target_pack(TenstorrentTargetPack())
     args = parse_args()
     logging.basicConfig(
         level=_LOG_LEVELS[args.log_level],

--- a/test_module/_test_common/target_check.py
+++ b/test_module/_test_common/target_check.py
@@ -20,15 +20,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Shared performance targets JSON. Override at runtime by pointing
-# OVERRIDE_BENCHMARK_TARGETS at a different file.
-_DEFAULT_TARGETS_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "reference_config"
-    / "benchmarking"
-    / "benchmark_targets"
-    / "model_performance_reference.json"
-)
+# Shared performance targets JSON comes from the registered target pack.
+# Override at runtime by pointing OVERRIDE_BENCHMARK_TARGETS at a different file.
 
 
 # For latency-style metrics (lower is better) the threshold is target * multiplier;
@@ -78,7 +71,11 @@ class PerformanceTargets:
 
 def _resolve_targets_path() -> Path:
     override = os.getenv("OVERRIDE_BENCHMARK_TARGETS")
-    return Path(override) if override else _DEFAULT_TARGETS_PATH
+    if override:
+        return Path(override)
+    from workflow_module.target_pack import get_target_pack
+
+    return get_target_pack().performance_targets_path()
 
 
 _REFERENCE_CACHE: Optional[Dict[str, Any]] = None

--- a/test_module/eval_tests/video_generation_eval_test.py
+++ b/test_module/eval_tests/video_generation_eval_test.py
@@ -15,6 +15,8 @@ import imageio.v3 as iio
 import requests
 from PIL import Image
 
+from workflow_module.target_pack import get_target_pack
+
 from .._test_common import BaseTest
 from test_fixtures.server_helper import (
     DEFAULT_AUTHORIZATION,
@@ -40,9 +42,7 @@ VIDEO_JOB_STATUS_FAILED = "failed"
 VIDEO_JOB_STATUS_CANCELLED = "cancelled"
 DEFAULT_VIDEO_POLLING_INTERVAL_SECONDS = 5
 DEFAULT_VIDEO_TIMEOUT_SECONDS = 1200
-ACCURACY_REFERENCE_PATH = (
-    "reference_config/evals/eval_targets/model_accuracy_reference.json"
-)
+ACCURACY_REFERENCE_PATH = get_target_pack().accuracy_targets_path()
 DATASET_DIR = "test_fixtures/datasets/videos"
 # accuracy_check codes returned by _check_accuracy.
 ACCURACY_CHECK_FAIL = 3

--- a/test_module/llm_tests/agentic_traces_tests.py
+++ b/test_module/llm_tests/agentic_traces_tests.py
@@ -47,13 +47,10 @@ from llm_module.parsers.aiperf_agentic_traces import AIPerfAgenticTracesParser
 from llm_module.parsers.swo_bench_agentic_traces import SwoBenchAgenticTracesParser
 from llm_module.runner import RunnerResult
 from llm_module.server_control import ServerController
-from reference_config.agentic_traces.agentic_traces_config import (
-    TraceSource,
-    get_agentic_traces_config,
-    resolve_run_specs,
-)
+from reference_config.agentic_traces.agentic_traces_config import TraceSource
 from workflow_module import accept_blocks
 from workflow_module.engine_types import AgenticTracesMode
+from workflow_module.target_pack import get_target_pack
 
 from ..context import MediaContext
 
@@ -119,7 +116,7 @@ def run_agentic_traces(
     result = RunnerResult()
     spec = ctx.model_spec
 
-    config = get_agentic_traces_config(spec)
+    config = get_target_pack().agentic_traces_config(spec)
     if config is None:
         logger.error(
             "No agentic-traces config registered for model_id=%s. Add an entry to "
@@ -132,7 +129,7 @@ def run_agentic_traces(
     try:
         traces_mode = AgenticTracesMode.from_string(mode) or AgenticTracesMode.FULL
         selected_sources = _parse_trace_sources(trace_sources)
-        effective_config, run_specs = resolve_run_specs(
+        effective_config, run_specs = get_target_pack().resolve_agentic_run_specs(
             config,
             trace_sources=selected_sources,
             git_ref_override=git_ref_override,

--- a/test_module/llm_tests/llm_eval_tests.py
+++ b/test_module/llm_tests/llm_eval_tests.py
@@ -23,6 +23,7 @@ from report_module.schema import Block
 from workflow_module import accept_blocks
 from workflow_module.engine_types import EvalLimitMode
 from workflow_module.proc import run_command
+from workflow_module.target_pack import get_target_pack
 
 from .._test_common import ReportCheckTypes, TestStatus, block_id
 from ..context import MediaContext
@@ -202,7 +203,7 @@ def _score_one(
         ratio_to_reference: Union[float, str] = score / reference
         # Sample-count-aware for subset references, ratio for full-set.
         accuracy_check = ReportCheckTypes.from_result(
-            accept_eval_score(ref, score, n_total=n_total)
+            get_target_pack().accept_eval_score(ref, score, n_total=n_total)
         )
     else:
         ratio_to_reference = "N/A"
@@ -243,7 +244,7 @@ def blocks_for_task(
     # Under --ci-mode / --limit-samples-mode, compare the subset score against
     # the matching subset reference (mode_reference_scores) instead of the
     # full-dataset gpu_reference_score.
-    ref = resolve_eval_reference(task.score, _limit_mode(ctx))
+    ref = get_target_pack().resolve_eval_reference(task.score, _limit_mode(ctx))
 
     target_keys = _target_keys(task, results)
     total_samples = sum(
@@ -392,7 +393,7 @@ def run_llm_eval(ctx: MediaContext, *, auth_token: str = "") -> List[Block]:
     emits FAIL Blocks rather than silently dropping the task, so a release run
     surfaces the failure.
     """
-    tasks = get_llm_eval_tasks(ctx.model_spec, ctx.runtime_config)
+    tasks = get_llm_eval_tasks(ctx.model_spec, ctx.runtime_config, device=ctx.device)
     if not tasks:
         logger.info(
             "No standard eval tasks for model=%s; nothing to run.",

--- a/test_module/llm_tests/llm_eval_tests.py
+++ b/test_module/llm_tests/llm_eval_tests.py
@@ -18,7 +18,6 @@ from typing import List, Optional, Tuple, Union
 from llm_module import HttpServerController, RemoteOpenAIController
 from llm_module.eval_command import build_eval_command
 from llm_module.eval_configs import get_llm_eval_tasks
-from reference_config.evals.eval_config import accept_eval_score, resolve_eval_reference
 from report_module.schema import Block
 from workflow_module import accept_blocks
 from workflow_module.engine_types import EvalLimitMode

--- a/test_module/load_param_tests/video_generation_i2v_param_test.py
+++ b/test_module/load_param_tests/video_generation_i2v_param_test.py
@@ -31,6 +31,8 @@ from typing import TYPE_CHECKING
 import aiohttp
 from report_module.schema import Block
 
+from workflow_module.target_pack import get_target_pack
+
 from .._test_common import BaseTest, HardwareRequirement, TestConfig
 
 if TYPE_CHECKING:
@@ -39,9 +41,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Constants
-ACCURACY_REFERENCE_PATH = (
-    "reference_config/evals/eval_targets/model_accuracy_reference.json"
-)
+ACCURACY_REFERENCE_PATH = get_target_pack().accuracy_targets_path()
 
 # Fixture is sourced from the test_fixtures datasets directory, which is
 # the canonical location used by other v2 vision tests as well

--- a/test_module/load_param_tests/video_generation_param_test.py
+++ b/test_module/load_param_tests/video_generation_param_test.py
@@ -10,6 +10,7 @@ import time
 import aiohttp
 
 from report_module.schema import Block
+from workflow_module.target_pack import get_target_pack
 from .._test_common import BaseTest, TestConfig
 from typing import TYPE_CHECKING
 
@@ -19,9 +20,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Constants
-ACCURACY_REFERENCE_PATH = (
-    "reference_config/evals/eval_targets/model_accuracy_reference.json"
-)
+ACCURACY_REFERENCE_PATH = get_target_pack().accuracy_targets_path()
 
 # Base payload with default parameters
 default_payload = {

--- a/tests/workflows/test_eval_config_device_overrides.py
+++ b/tests/workflows/test_eval_config_device_overrides.py
@@ -83,3 +83,44 @@ def test_chat_api_override_reinfers_eval_class():
     assert task.eval_class == "local-completions"
     resolved = resolve_task_for_device(task, "SUPER_CLUSTER")
     assert resolved.eval_class == "local-chat-completions"
+
+
+def test_chat_api_off_override_reinfers_eval_class_back():
+    # The reverse direction: the base task's eval_class was already inferred to
+    # the chat variant; overriding use_chat_api off must flip it back.
+    task = EvalTask(
+        task_name="t",
+        use_chat_api=True,
+        device_overrides={"GALAXY": {"use_chat_api": False}},
+    )
+    assert task.eval_class == "local-chat-completions"
+    resolved = resolve_task_for_device(task, "GALAXY")
+    assert resolved.use_chat_api is False
+    assert resolved.eval_class == "local-completions"
+
+
+def test_evals_meta_override_preserves_batch_size():
+    # EVALS_META inference moves max_concurrent into batch_size (and Nones the
+    # former). Re-inference after replace() must not wipe batch_size to None —
+    # neither for an explicit batch_size override nor for an unrelated one.
+    from workflow_module.engine_types import WorkflowVenvType
+
+    task = EvalTask(
+        task_name="meta_ifeval",
+        workflow_venv_type=WorkflowVenvType.EVALS_META,
+        max_concurrent=32,
+        device_overrides={
+            "GALAXY": {"batch_size": 64},
+            "SUPER_CLUSTER": {"gen_kwargs": {"stream": "True"}},
+        },
+    )
+    assert task.batch_size == 32
+    assert task.max_concurrent is None
+
+    resolved = resolve_task_for_device(task, "GALAXY")
+    assert resolved.batch_size == 64
+    assert resolved.max_concurrent is None
+
+    resolved_unrelated = resolve_task_for_device(task, "SUPER_CLUSTER")
+    assert resolved_unrelated.batch_size == 32
+    assert resolved_unrelated.max_concurrent is None

--- a/tests/workflows/test_eval_config_device_overrides.py
+++ b/tests/workflows/test_eval_config_device_overrides.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for EvalTask per-device overrides (3-tier device-variance schema)."""
+
+import pytest
+
+from reference_config.evals.eval_config import EvalTask, resolve_task_for_device
+
+
+class _FakeDevice:
+    def __init__(self, name):
+        self.name = name
+
+
+def test_no_overrides_returns_task_unchanged():
+    task = EvalTask(task_name="t")
+    assert resolve_task_for_device(task, "GALAXY") is task
+    assert resolve_task_for_device(task, None) is task
+
+
+def test_matching_device_applies_tier2_overrides():
+    task = EvalTask(
+        task_name="t",
+        max_concurrent=32,
+        device_overrides={
+            "SUPER_CLUSTER": {
+                "max_concurrent": 38,
+                "use_chat_api": True,
+                "gen_kwargs": {"stream": "True"},
+            }
+        },
+    )
+    resolved = resolve_task_for_device(task, "SUPER_CLUSTER")
+    assert resolved.max_concurrent == 38
+    assert resolved.use_chat_api is True
+    assert resolved.gen_kwargs == {"stream": "True"}
+    # tier-1 identity untouched
+    assert resolved.task_name == "t"
+    # base task unchanged (frozen dataclass)
+    assert task.max_concurrent == 32
+
+
+def test_device_enum_and_case_insensitive_matching():
+    task = EvalTask(
+        task_name="t",
+        device_overrides={"galaxy": {"max_concurrent": 16}},
+    )
+    assert resolve_task_for_device(task, _FakeDevice("GALAXY")).max_concurrent == 16
+    assert resolve_task_for_device(task, "Galaxy").max_concurrent == 16
+
+
+def test_non_matching_device_returns_task_unchanged():
+    task = EvalTask(
+        task_name="t",
+        device_overrides={"SUPER_CLUSTER": {"max_concurrent": 38}},
+    )
+    assert resolve_task_for_device(task, "GALAXY") is task
+
+
+def test_tier1_override_rejected():
+    with pytest.raises(ValueError, match="device-invariant"):
+        EvalTask(
+            task_name="t",
+            device_overrides={"GALAXY": {"task_name": "other"}},
+        )
+
+
+def test_unknown_field_rejected():
+    with pytest.raises(ValueError, match="unknown EvalTask fields"):
+        EvalTask(
+            task_name="t",
+            device_overrides={"GALAXY": {"not_a_field": 1}},
+        )
+
+
+def test_chat_api_override_reinfers_eval_class():
+    task = EvalTask(
+        task_name="t",
+        device_overrides={"SUPER_CLUSTER": {"use_chat_api": True}},
+    )
+    assert task.eval_class == "local-completions"
+    resolved = resolve_task_for_device(task, "SUPER_CLUSTER")
+    assert resolved.eval_class == "local-chat-completions"

--- a/workflow_module/command_factory.py
+++ b/workflow_module/command_factory.py
@@ -192,12 +192,9 @@ def _resolve_server_url(
 
 
 def _resolve_eval_config(model_name: str):
-    try:
-        from reference_config.evals.eval_config import EVAL_CONFIGS
-    except Exception as e:
-        logger.warning("Could not import v1 EVAL_CONFIGS (%s); evals will fail.", e)
-        return None
-    cfg = EVAL_CONFIGS.get(model_name)
+    from .target_pack import get_target_pack
+
+    cfg = get_target_pack().eval_config(model_name)
     if cfg is None:
         logger.warning(
             "No EvalConfig registered for model=%r; eval task metadata will be empty.",

--- a/workflow_module/target_pack.py
+++ b/workflow_module/target_pack.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+
+"""Engine-owned validation-content seam (the "target pack").
+
+The engine's eval/benchmark/agentic-traces paths need vendor-supplied
+*content*: which eval tasks a model runs, what score references gate them,
+which benchmark sweep applies, which agentic-trace replay is configured, and
+where the measured reference-target JSONs live. That content is adapter
+business (Tenstorrent's lives under ``reference_config/``). This module
+defines the seam:
+
+- :class:`TargetPack` — lookups and scoring policy over that content.
+
+The Tenstorrent implementation is injected via :func:`register_target_pack`
+at process entry. A lazy Tenstorrent default is kept for backward
+compatibility during the extraction; it is the marked Phase-2 removal point.
+
+Eval-task fields follow a three-tier device-variance model:
+
+1. **Semantic identity** (device-invariant): ``task_name``, ``score``
+   references, ``num_fewshot``, ``seed``, ``workflow_venv_type``.
+2. **Transport/execution** (device-variant): ``max_concurrent``,
+   ``batch_size``, ``use_chat_api``, ``apply_chat_template``, ``gen_kwargs``
+   (e.g. streaming), ``model_kwargs``.
+3. **Measured baselines** (device-variant): ``score`` reference values.
+
+Tier-2/3 fields may be overridden per device via ``EvalTask.device_overrides``;
+the engine applies them through :meth:`TargetPack.resolve_eval_task_for_device`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Mapping, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class TargetPack(Protocol):
+    """Vendor validation content: configs, scoring policy, reference targets."""
+
+    # --- eval configs ---
+    def eval_config(self, model_name: str) -> Optional[Any]:
+        """The model's eval config (``.tasks`` list), or None if not onboarded."""
+        ...
+
+    def resolve_eval_reference(self, score: Any, limit_mode: Any) -> Mapping[str, Any]:
+        """Reference score/tolerance for a task score under a limit mode."""
+        ...
+
+    def accept_eval_score(
+        self,
+        ref: Mapping[str, Any],
+        score: float,
+        n_total: Optional[int] = None,
+    ) -> Optional[bool]:
+        """PASS/FAIL for an observed score against ``ref``; None if no reference."""
+        ...
+
+    def resolve_eval_task_for_device(self, task: Any, device: Any) -> Any:
+        """Apply the task's per-device tier-2/3 overrides (identity if none)."""
+        ...
+
+    # --- benchmark configs ---
+    def benchmark_config(self, model_spec: Any) -> Any:
+        """The model's benchmark sweep config."""
+        ...
+
+    def smoke_test_benchmark_config(self, config: Any, device: Any) -> Any:
+        """Narrow a benchmark config to its smoke-test shape for ``device``."""
+        ...
+
+    # --- agentic traces ---
+    def agentic_traces_config(self, model_spec: Any) -> Optional[Any]:
+        """The model's agentic-traces config, or None if not onboarded."""
+        ...
+
+    def resolve_agentic_run_specs(
+        self,
+        config: Any,
+        *,
+        trace_sources: Any = None,
+        git_ref_override: Optional[str] = None,
+    ) -> Any:
+        """Apply CLI-level source/ref narrowing to an agentic-traces config."""
+        ...
+
+    def agentic_traces_min_profile_seconds(self) -> int:
+        """Floor for a valid agentic-traces profiling window."""
+        ...
+
+    # --- measured reference data ---
+    def performance_targets_path(self) -> Path:
+        """Absolute path to the performance reference-targets JSON."""
+        ...
+
+    def accuracy_targets_path(self) -> Path:
+        """Absolute path to the accuracy reference-targets JSON."""
+        ...
+
+
+_target_pack: Optional[TargetPack] = None
+
+
+def register_target_pack(pack: TargetPack) -> None:
+    """Install the process-wide target pack (called at entry points)."""
+    global _target_pack
+    _target_pack = pack
+
+
+def get_target_pack() -> TargetPack:
+    """Return the registered pack, lazily defaulting to the TT reference_config.
+
+    EXTRACTION SEAM (Phase 2 removal point): the lazy default keeps
+    pre-extraction callers working without an explicit registration. Once the
+    engine is packaged separately, this fallback disappears and entry points
+    must register a pack explicitly.
+    """
+    global _target_pack
+    if _target_pack is None:
+        from workflows.target_pack_provider import TenstorrentTargetPack
+
+        logger.debug("No TargetPack registered; using Tenstorrent reference_config.")
+        _target_pack = TenstorrentTargetPack()
+    return _target_pack

--- a/workflows/target_pack_provider.py
+++ b/workflows/target_pack_provider.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Tenstorrent implementation of the engine's validation-content seam.
+
+Adapts the ``reference_config/`` corpus (eval configs, benchmark configs,
+agentic-traces configs, measured reference-target JSONs) to
+:class:`workflow_module.target_pack.TargetPack` so the engine never imports
+``reference_config`` directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TenstorrentTargetPack:
+    """``TargetPack`` over the Tenstorrent ``reference_config/`` corpus."""
+
+    # --- eval configs ---
+    def eval_config(self, model_name: str) -> Optional[Any]:
+        from reference_config.evals.eval_config import EVAL_CONFIGS
+
+        return EVAL_CONFIGS.get(model_name)
+
+    def resolve_eval_reference(self, score: Any, limit_mode: Any) -> Mapping[str, Any]:
+        from reference_config.evals.eval_config import resolve_eval_reference
+
+        return resolve_eval_reference(score, limit_mode)
+
+    def accept_eval_score(
+        self,
+        ref: Mapping[str, Any],
+        score: float,
+        n_total: Optional[int] = None,
+    ) -> Optional[bool]:
+        from reference_config.evals.eval_config import accept_eval_score
+
+        return accept_eval_score(ref, score, n_total=n_total)
+
+    def resolve_eval_task_for_device(self, task: Any, device: Any) -> Any:
+        from reference_config.evals.eval_config import resolve_task_for_device
+
+        return resolve_task_for_device(task, device)
+
+    # --- benchmark configs ---
+    def benchmark_config(self, model_spec: Any) -> Any:
+        from reference_config.benchmarking.benchmark_config import get_benchmark_config
+
+        return get_benchmark_config(model_spec)
+
+    def smoke_test_benchmark_config(self, config: Any, device: Any) -> Any:
+        from reference_config.benchmarking.benchmark_config import (
+            select_smoke_test_benchmark_config,
+        )
+
+        return select_smoke_test_benchmark_config(config, device)
+
+    # --- agentic traces ---
+    def agentic_traces_config(self, model_spec: Any) -> Optional[Any]:
+        from reference_config.agentic_traces.agentic_traces_config import (
+            get_agentic_traces_config,
+        )
+
+        return get_agentic_traces_config(model_spec)
+
+    def resolve_agentic_run_specs(
+        self,
+        config: Any,
+        *,
+        trace_sources: Any = None,
+        git_ref_override: Optional[str] = None,
+    ) -> Any:
+        from reference_config.agentic_traces.agentic_traces_config import (
+            resolve_run_specs,
+        )
+
+        return resolve_run_specs(
+            config,
+            trace_sources=trace_sources,
+            git_ref_override=git_ref_override,
+        )
+
+    def agentic_traces_min_profile_seconds(self) -> int:
+        from reference_config.agentic_traces.agentic_traces_config import (
+            AGENTIC_TRACES_MIN_PROFILE_SECONDS,
+        )
+
+        return AGENTIC_TRACES_MIN_PROFILE_SECONDS
+
+    # --- measured reference data ---
+    def performance_targets_path(self) -> Path:
+        return (
+            _REPO_ROOT
+            / "reference_config"
+            / "benchmarking"
+            / "benchmark_targets"
+            / "model_performance_reference.json"
+        )
+
+    def accuracy_targets_path(self) -> Path:
+        return (
+            _REPO_ROOT
+            / "reference_config"
+            / "evals"
+            / "eval_targets"
+            / "model_accuracy_reference.json"
+        )

--- a/workflows/target_pack_provider.py
+++ b/workflows/target_pack_provider.py
@@ -16,12 +16,14 @@ import logging
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
+from workflow_module.target_pack import TargetPack
+
 logger = logging.getLogger(__name__)
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-class TenstorrentTargetPack:
+class TenstorrentTargetPack(TargetPack):
     """``TargetPack`` over the Tenstorrent ``reference_config/`` corpus."""
 
     # --- eval configs ---


### PR DESCRIPTION
## Summary
- Introduces workflow_module/target_pack.py with a TargetPack protocol covering every validation-content lookup the engine needs: eval configs, eval-reference resolution + score acceptance, benchmark sweep configs, agentic-traces config lookup/narrowing, and the measured reference-target JSON paths. It's injected process-wide at the entry points, with a lazy Tenstorrent default marked as the Phase-2 removal point. The Tenstorrent implementation (workflows/target_pack_provider.py) adapts the reference_config/ corpus.
- Adds a three-tier device-variance schema to EvalTask: tier-1 semantic identity (task_name, venv, fewshot, seed) is device-invariant; tier-2 transport/execution (max_concurrent, batch_size, use_chat_api, gen_kwargs streaming, model_kwargs) and tier-3 measured baselines (score) can be overridden per device via EvalTask.device_overrides, validated at construction and applied by resolve_task_for_device. This lets e.g. gpt-oss-120b run max_concurrent=38 + chat API + streaming on SUPER_CLUSTER while keeping the GALAXY shape.
- Routes all engine call sites (eval_configs, command_factory, llm_eval_tests, agentic parser, benchmark_configs, agentic_traces_tests, target_check, video-generation tests, run_workflows duration floor) through the pack instead of importing reference_config directly.
## Why
Removes the engine's direct dependency on the Tenstorrent reference_config/ corpus — the last big content coupling — so validation content becomes an injectable adapter concern, and per-device eval differences are expressed as data rather than forked configs.