### PR TITLE
Move TraceSource engine-side as agentic-traces schema

### DIFF
--- a/llm_module/agentic_traces/__init__.py
+++ b/llm_module/agentic_traces/__init__.py
@@ -21,12 +21,14 @@ from .runs import (
     summarize_runs,
     total_planned_seconds,
 )
+from .schema import TraceSource
 
 __all__ = [
     "SUPPORTED_TRACE_SOURCES",
     "SWARMONE_CI_TIMEOUT_SECONDS",
     "SWARMONE_FULL_TIMEOUT_SECONDS",
     "AgenticTracesRun",
+    "TraceSource",
     "build_runs",
     "estimated_run_seconds",
     "summarize_runs",

--- a/llm_module/agentic_traces/runs.py
+++ b/llm_module/agentic_traces/runs.py
@@ -17,14 +17,17 @@ every knob is a concrete value.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 
-from reference_config.agentic_traces.agentic_traces_config import (
-    AgenticTracesConfig,
-    AgenticTracesRunSpec,
-    TraceSource,
-)
 from workflow_module.engine_types import AgenticTracesMode
+
+from .schema import TraceSource
+
+if TYPE_CHECKING:
+    from reference_config.agentic_traces.agentic_traces_config import (
+        AgenticTracesConfig,
+        AgenticTracesRunSpec,
+    )
 
 # Trace sources with a working client. Both the InferenceX AIPerf fork and the
 # SwarmOne ``swo-bench`` replay engine are wired; any source added to the config

--- a/llm_module/agentic_traces/schema.py
+++ b/llm_module/agentic_traces/schema.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+
+"""Engine-owned agentic-traces schema.
+
+``TraceSource`` keys the trace-replay harnesses the engine knows how to
+dispatch. The *keys* are engine-generic; the per-model *content* (which
+sources/datasets/refs a model runs) is adapter business in
+``reference_config/agentic_traces/agentic_traces_config.py``, which
+re-exports ``TraceSource`` for pre-extraction callers.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class TraceSource(Enum):
+    """Where a run's agentic traces come from.
+
+    ``INFERENCEX_AGENTX`` replays the SemiAnalysis Weka coding traces through
+    the AIPerf fork vendored in the InferenceX repo. ``SWARMONE`` replays
+    SwarmOne's recorded coding sessions through its ``swo-bench`` CLI.
+    """
+
+    INFERENCEX_AGENTX = "inferencex_agentx"
+    SWARMONE = "swarmone"
+
+    @classmethod
+    def from_string(cls, name: str) -> "TraceSource":
+        key = name.strip().upper().replace("-", "_")
+        try:
+            return cls[key]
+        except KeyError:
+            valid = ", ".join(sorted(m.value for m in cls))
+            raise ValueError(f"Invalid TraceSource: {name!r}. Valid: {valid}")
+
+
+__all__ = ["TraceSource"]

--- a/reference_config/agentic_traces/agentic_traces_config.py
+++ b/reference_config/agentic_traces/agentic_traces_config.py
@@ -21,9 +21,9 @@ config, and in ``tests/reference_config/test_agentic_traces_config.py``.
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
+from llm_module.agentic_traces.schema import TraceSource
 from workflows.utils import map_configs_by_attr
 from workflows.workflow_types import AgenticTracesMode
 
@@ -35,27 +35,6 @@ AGENTIC_TRACES_MIN_PROFILE_SECONDS = 900
 
 # Scenarios known to enforce AGENTIC_TRACES_MIN_PROFILE_SECONDS.
 _MIN_DURATION_SCENARIOS = frozenset({"inferencex-agentx-mvp"})
-
-
-class TraceSource(Enum):
-    """Where a run's agentic traces come from.
-
-    ``INFERENCEX_AGENTX`` replays the SemiAnalysis Weka coding traces through
-    the AIPerf fork vendored in the InferenceX repo. ``SWARMONE`` replays
-    SwarmOne's recorded coding sessions through its ``swo-bench`` CLI.
-    """
-
-    INFERENCEX_AGENTX = "inferencex_agentx"
-    SWARMONE = "swarmone"
-
-    @classmethod
-    def from_string(cls, name: str) -> "TraceSource":
-        key = name.strip().upper().replace("-", "_")
-        try:
-            return cls[key]
-        except KeyError:
-            valid = ", ".join(sorted(m.value for m in cls))
-            raise ValueError(f"Invalid TraceSource: {name!r}. Valid: {valid}")
 
 
 # Sources that a sweep only runs when it names them explicitly via

--- a/test_module/llm_tests/agentic_traces_tests.py
+++ b/test_module/llm_tests/agentic_traces_tests.py
@@ -47,7 +47,7 @@ from llm_module.parsers.aiperf_agentic_traces import AIPerfAgenticTracesParser
 from llm_module.parsers.swo_bench_agentic_traces import SwoBenchAgenticTracesParser
 from llm_module.runner import RunnerResult
 from llm_module.server_control import ServerController
-from reference_config.agentic_traces.agentic_traces_config import TraceSource
+from llm_module.agentic_traces.schema import TraceSource
 from workflow_module import accept_blocks
 from workflow_module.engine_types import AgenticTracesMode
 from workflow_module.target_pack import get_target_pack


### PR DESCRIPTION
## Summary
- Moves the TraceSource enum to llm_module/agentic_traces/schema.py and re-exports it from reference_config's agentic_traces_config, which keeps the per-model content (run specs, mode settings, git-ref pins). 
- TraceSource keys the trace-replay harnesses the engine dispatches on, so the keys belong to the engine — the same split applied to WorkflowVenvType in the venv-provisioner PR.
- runs.py imports TraceSource from the schema module and narrows its AgenticTracesConfig/AgenticTracesRunSpec imports to TYPE_CHECKING (adapter config types the engine only reads structurally). agentic_traces_tests.py takes TraceSource from the engine module; its config lookups already go through the TargetPack.
## Why
Completes the agentic-traces decoupling started in PR6: the engine owns the dispatch keys while reference_config keeps the vendor content. Adapter callers (workflow_venvs, validate_setup, tests) keep working via the re-export, so it's a no-behavior-change move.

## Test plan
- [x] pytest test_module/llm_tests/agentic_traces_tests.py
- [x] Import check: reference_config re-export still resolves for adapter callers
- [x] pytest tests/workflow_module