### PR TITLE
[Model-Bringup] Migrate DiffusionGemma to vLLM TT plugin

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -10,6 +10,21 @@
         }
       }
     },
+    "diffusiongemma-26B-A4B-it": {
+      "inference_engine": "vLLM",
+      "ci": {
+        "nightly": {
+          "devices": [
+            "P300X2"
+          ]
+        },
+        "release": {
+          "devices": [
+            "P300X2"
+          ]
+        }
+      }
+    },
     "Falcon3-7B-Instruct": {
       "inference_engine": "FORGE",
       "ci": {

--- a/llm_module/config.py
+++ b/llm_module/config.py
@@ -49,6 +49,9 @@ class ServerConnection:
     # repo (e.g. moonshotai/Kimi-* ships a custom tokenizer). Driven per
     # model from the spec metadata; off by default for safety.
     tokenizer_trust_remote_code: bool = False
+    # Models that commit more than one token per engine step use block-level
+    # latency/throughput as their primary benchmark semantics.
+    output_block_size: int = 1
     # Extra Prometheus ``/metrics`` endpoints (cpp_server workers) scraped
     # by AIPerf via ``--server-metrics``, in addition to the load target in
     # ``base_url``. Read by both the prefix-cache and agentic-traces

--- a/llm_module/drivers/vllm.py
+++ b/llm_module/drivers/vllm.py
@@ -82,10 +82,21 @@ def build_vllm_bench_serve_argv(
         str(result_filename),
     ]
 
-    if uses_remote_base_url(server.url_with_port, server.is_remote):
+    # vLLM's openai-chat benchmark defaults to temperature=0.0, while
+    # DiffusionGemma's model-owned sampler accepts only the neutral value.
+    if "diffusiongemma" in server.model.lower():
+        cmd.extend(["--temperature", "1.0"])
+
+    is_remote_base_url = uses_remote_base_url(
+        server.url_with_port,
+        server.is_remote,
+    )
+    if server.tokenizer_trust_remote_code or is_remote_base_url:
+        cmd.append("--trust-remote-code")
+
+    if is_remote_base_url:
         cmd.extend(["--base-url", server.url_with_port])
         cmd.extend(["--ready-check-timeout-sec", "0"])
-        cmd.extend(["--trust-remote-code"])
         if auth_token:
             headers.append(f"Authorization=Bearer {auth_token}")
     else:
@@ -93,7 +104,7 @@ def build_vllm_bench_serve_argv(
         cmd.extend(
             [
                 "--extra-body",
-                json.dumps({"truncate_prompt_tokens": str(config.isl)}),
+                json.dumps({"truncate_prompt_tokens": config.isl}),
             ]
         )
 
@@ -136,6 +147,8 @@ class VLLMBenchDriver(LLMDriver):
 
         rc = run_command(cmd, env=env, timeout_s=context.per_run_timeout_s)
         raw = load_json(result_filename) if rc == 0 else None
+        if raw is not None and server.output_block_size > 1:
+            raw["tt_output_block_size"] = server.output_block_size
         return DriverResult(return_code=rc, raw=raw, raw_path=result_filename)
 
 

--- a/llm_module/eval_command.py
+++ b/llm_module/eval_command.py
@@ -234,9 +234,10 @@ def build_eval_command(
     effective_gen_kwargs = _clamp_max_gen_toks(
         task.gen_kwargs, device_max_context, task.task_name
     )
-    effective_gen_kwargs = _inject_seed_into_gen_kwargs(
-        effective_gen_kwargs, getattr(task, "seed", None)
-    )
+    if getattr(task, "propagate_seed_to_gen_kwargs", True):
+        effective_gen_kwargs = _inject_seed_into_gen_kwargs(
+            effective_gen_kwargs, getattr(task, "seed", None)
+        )
 
     optional_model_args = []
     if effective_max_concurrent:
@@ -277,6 +278,20 @@ def build_eval_command(
     else:
         lm_eval_exec = task_venv_config.venv_path / "bin" / "lm_eval"
 
+    lm_eval_prefix = [str(lm_eval_exec)]
+    if (
+        task.workflow_venv_type == WorkflowVenvType.EVALS_COMMON
+        and task.eval_class == "local-chat-completions"
+        and not getattr(task, "propagate_seed_to_gen_kwargs", True)
+    ):
+        # The pinned lm-eval adapter always copies its model seed into OpenAI
+        # payloads, independently of --gen_kwargs. Use the scoped wrapper so
+        # --seed still controls harness RNGs without reaching the server.
+        lm_eval_prefix = [
+            str(task_venv_config.venv_path / "bin" / "python"),
+            str(Path(__file__).with_name("lm_eval_no_server_seed.py")),
+        ]
+
     model_kwargs_list = [f"{k}={v}" for k, v in task.model_kwargs.items()]
     model_kwargs_list += optional_model_args
     model_kwargs_str = ",".join(model_kwargs_list)
@@ -292,7 +307,7 @@ def build_eval_command(
     # fmt: off
     if task.workflow_venv_type == WorkflowVenvType.EVALS_VISION:
         cmd = [
-            str(lm_eval_exec),
+            *lm_eval_prefix,
             "--tasks", task.task_name,
             "--model", eval_class,
             "--model_args", (
@@ -311,7 +326,7 @@ def build_eval_command(
         ]
     elif task.workflow_venv_type == WorkflowVenvType.EVALS_AUDIO:
         cmd = [
-            str(lm_eval_exec),
+            *lm_eval_prefix,
             "--model", eval_class,
             "--model_args", (
                 f"model={model_spec.hf_model_repo},"
@@ -325,7 +340,7 @@ def build_eval_command(
         ]
     else:
         cmd = [
-            str(lm_eval_exec),
+            *lm_eval_prefix,
             "--tasks", task.task_name,
             "--model", eval_class,
             "--model_args", (

--- a/llm_module/lm_eval_no_server_seed.py
+++ b/llm_module/lm_eval_no_server_seed.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+
+"""Run lm-eval without forwarding its harness seed to chat completions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _drop_server_seed(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a request payload with lm-eval's implicit seed removed."""
+    payload.pop("seed", None)
+    return payload
+
+
+def _patch_local_chat_completion() -> None:
+    from lm_eval.models.openai_completions import LocalChatCompletion
+
+    original_create_payload = LocalChatCompletion._create_payload
+
+    def _create_payload_without_seed(self, *args, **kwargs):
+        return _drop_server_seed(original_create_payload(self, *args, **kwargs))
+
+    LocalChatCompletion._create_payload = _create_payload_without_seed
+
+
+def main() -> None:
+    _patch_local_chat_completion()
+    from lm_eval.__main__ import cli_evaluate
+
+    cli_evaluate()
+
+
+if __name__ == "__main__":
+    main()

--- a/llm_module/parsers/agentic.py
+++ b/llm_module/parsers/agentic.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import math
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Union
@@ -37,6 +38,7 @@ class AgenticEvalParser(LLMResultParser):
 
     def parse(self, raw: Mapping[str, Any], *, device: str = "") -> Block:
         metrics = extract_harbor_metrics(raw)
+        execution_error = _harbor_execution_error(raw, metrics)
         targets: Dict[str, Any] = {"task_name": self.task_name}
         if device:
             targets["device"] = device
@@ -66,6 +68,8 @@ class AgenticEvalParser(LLMResultParser):
                 score=self.score,
                 metrics=metrics,
                 limit_mode=self.limit_mode,
+                success=execution_error is None,
+                error=execution_error,
             ),
         )
 
@@ -113,7 +117,12 @@ def _build_evals_data(
     else:
         normalized_score = _normalize_accuracy_to_percent(accuracy)
 
-    if normalized_score is not None and score is not None:
+    if not success:
+        normalized_score = None
+        ratio_pub = "N/A"
+        ratio_ref = "N/A"
+        accuracy_check = ReportCheckTypes.FAIL
+    elif normalized_score is not None and score is not None:
         ratio_pub: Union[float, str] = (
             normalized_score / published if published else "N/A"
         )
@@ -121,10 +130,6 @@ def _build_evals_data(
             normalized_score / reference if reference else "N/A"
         )
         accuracy_check = compute_accuracy_check(metrics, score, limit_mode)
-    elif not success:
-        ratio_pub = "N/A"
-        ratio_ref = "N/A"
-        accuracy_check = ReportCheckTypes.FAIL
     else:
         ratio_pub = "N/A"
         ratio_ref = "N/A"
@@ -168,6 +173,64 @@ def extract_harbor_metrics(raw: Mapping[str, Any]) -> Dict[str, Any]:
     if mean_seconds is not None:
         metrics["mean_seconds_per_task"] = mean_seconds
     return metrics
+
+
+def _harbor_execution_error(
+    raw: Mapping[str, Any], metrics: Mapping[str, Any]
+) -> Optional[str]:
+    """Return why a Harbor result did not contain a completed evaluation.
+
+    Harbor can exit successfully after every configured trial fails in setup.
+    In that case ``result.json`` exists, but its aggregate has ``n_trials=0``
+    and no score metric. Treat aggregate validity separately from score policy:
+    a real evaluated 0% score has a finite aggregate and positive trial count.
+    """
+
+    n_trials = metrics.get("n_trials")
+    if not isinstance(n_trials, int) or isinstance(n_trials, bool):
+        return "Harbor result is missing a valid integer n_trials aggregate."
+    if n_trials <= 0:
+        return (
+            f"Harbor result reports n_trials={n_trials}; "
+            "no completed trials were evaluated."
+        )
+
+    accuracy = metrics.get("accuracy")
+    if not _is_finite_number(accuracy):
+        return "Harbor result is missing a valid finite aggregate score."
+
+    if _all_trial_results_are_exceptions(raw):
+        return (
+            "Harbor result contains only infrastructure/runtime exceptions; "
+            "no trial reached evaluation."
+        )
+    return None
+
+
+def _all_trial_results_are_exceptions(raw: Mapping[str, Any]) -> bool:
+    trial_results = raw.get("trial_results")
+    if not isinstance(trial_results, list) or not trial_results:
+        return False
+
+    for trial in trial_results:
+        if not isinstance(trial, Mapping):
+            return False
+        if not isinstance(trial.get("exception_info"), Mapping):
+            return False
+        verifier_result = trial.get("verifier_result")
+        if isinstance(verifier_result, Mapping) and isinstance(
+            verifier_result.get("rewards"), Mapping
+        ):
+            return False
+    return True
+
+
+def _is_finite_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
 
 
 def _mean_seconds_per_task(
@@ -262,8 +325,7 @@ def _extract_harbor_summary_metrics(raw: Mapping[str, Any]) -> Dict[str, Any]:
         (
             metric.get("mean")
             for metric in metrics_list
-            if isinstance(metric, Mapping)
-            and isinstance(metric.get("mean"), (int, float))
+            if isinstance(metric, Mapping) and _is_finite_number(metric.get("mean"))
         ),
         None,
     )
@@ -274,7 +336,7 @@ def _extract_harbor_summary_metrics(raw: Mapping[str, Any]) -> Dict[str, Any]:
     if mean_metric is not None:
         metrics["accuracy"] = mean_metric
         metrics["pass_at_1"] = mean_metric
-    if isinstance(n_trials, int):
+    if isinstance(n_trials, int) and not isinstance(n_trials, bool):
         metrics["n_trials"] = n_trials
     if n_resolved is not None:
         metrics["n_resolved"] = n_resolved

--- a/llm_module/parsers/vllm.py
+++ b/llm_module/parsers/vllm.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import math
 from typing import Any, Dict, Mapping, Optional
 
 from report_module.schema import Block
@@ -43,6 +44,41 @@ class VLLMBenchParser(LLMResultParser):
             "request_throughput": _round(raw.get("request_throughput"), 4),
             "error_request_count": _errors(raw.get("failed")),
         }
+        output_block_size = _num_int(raw.get("tt_output_block_size")) or 1
+        if output_block_size > 1:
+            blocks_per_request = _blocks_per_request(
+                raw,
+                completed=completed,
+                output_block_size=output_block_size,
+            )
+            request_throughput = _num(raw.get("request_throughput"))
+            mean_e2el_ms = _num(raw.get("mean_e2el_ms"))
+            record.update(
+                {
+                    "metric_semantics": "block_granular",
+                    "output_block_size": output_block_size,
+                    "output_blocks_per_request": _round(blocks_per_request, 4),
+                    "output_blocks_per_second": _round(
+                        request_throughput * blocks_per_request
+                        if request_throughput is not None and blocks_per_request
+                        else None,
+                        4,
+                    ),
+                    # vLLM's token TPOT divides inter-event time by every token ID
+                    # delivered in that event. A 256-ID block can therefore report
+                    # a near-zero TPOT even though producing it took tens of
+                    # seconds. Derive latency from request E2EL and the number of
+                    # scheduling blocks that request emitted instead.
+                    "mean_block_latency_ms": _round(
+                        mean_e2el_ms / blocks_per_request
+                        if mean_e2el_ms is not None and blocks_per_request
+                        else None,
+                        4,
+                    ),
+                    "primary_throughput_metric": "output_blocks_per_second",
+                    "primary_latency_metric": "mean_block_latency_ms",
+                }
+            )
         return self._wrap_record(record)
 
 
@@ -69,6 +105,27 @@ def _per_request(total: Any, completed: Optional[float]) -> Optional[float]:
 def _per_request_int(total: Any, completed: Optional[float]) -> Optional[int]:
     value = _per_request(total, completed)
     return int(round(value)) if value is not None else None
+
+
+def _blocks_per_request(
+    raw: Mapping[str, Any],
+    *,
+    completed: float | None,
+    output_block_size: int,
+) -> float | None:
+    output_lens = raw.get("output_lens")
+    if isinstance(output_lens, list) and output_lens:
+        valid_lens = [_num(value) for value in output_lens]
+        if all(value is not None and value >= 0 for value in valid_lens):
+            return sum(
+                math.ceil(value / output_block_size) if value else 0
+                for value in valid_lens
+            ) / len(valid_lens)
+
+    output_tokens = _per_request(raw.get("total_output_tokens"), completed)
+    if output_tokens is None or output_tokens <= 0:
+        return None
+    return float(math.ceil(output_tokens / output_block_size))
 
 
 def _errors(value: Any) -> Optional[int]:

--- a/llm_module/test_vllm_diffusiongemma.py
+++ b/llm_module/test_vllm_diffusiongemma.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""DiffusionGemma block-serving and request-admission regression gates."""
+
+import json
+
+import pytest
+import requests
+
+from test_fixtures.conftest import _get_bearer_token
+
+CANVAS_LENGTH = 256
+SIMPLE_MESSAGES = [
+    {
+        "role": "user",
+        "content": "Think briefly, then answer the arithmetic question: 2 + 2.",
+    }
+]
+
+
+def _auth_headers():
+    headers = {"Content-Type": "application/json"}
+    if token := _get_bearer_token():
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _api_root(endpoint_url):
+    return endpoint_url.split("/v1/", maxsplit=1)[0]
+
+
+def _assert_healthy(endpoint_url):
+    response = requests.get(
+        f"{_api_root(endpoint_url)}/health",
+        headers=_auth_headers(),
+        timeout=30,
+    )
+    response.raise_for_status()
+
+
+def _completion_request(endpoint_url, model_name, prompt, *, max_tokens):
+    return requests.post(
+        f"{_api_root(endpoint_url)}/v1/completions",
+        headers=_auth_headers(),
+        json={
+            "model": model_name,
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "ignore_eos": True,
+        },
+        timeout=1800,
+    )
+
+
+def _stream_response(response):
+    reasoning_parts = []
+    content_parts = []
+    usage = None
+    finish_reason = None
+
+    for line in response.iter_lines(decode_unicode=True):
+        if not line or not line.startswith("data: "):
+            continue
+        payload = line[len("data: ") :]
+        if payload.strip() == "[DONE]":
+            break
+        chunk = json.loads(payload)
+        if chunk.get("usage"):
+            usage = chunk["usage"]
+        choices = chunk.get("choices") or []
+        if not choices:
+            continue
+        choice = choices[0]
+        delta = choice.get("delta") or {}
+        reasoning = delta.get("reasoning_content") or delta.get("reasoning")
+        if reasoning:
+            reasoning_parts.append(reasoning)
+        if delta.get("content"):
+            content_parts.append(delta["content"])
+        if choice.get("finish_reason"):
+            finish_reason = choice["finish_reason"]
+
+    return {
+        "reasoning": "".join(reasoning_parts),
+        "content": "".join(content_parts),
+        "usage": usage,
+        "finish_reason": finish_reason,
+    }
+
+
+def test_single_canvas_sync_completion(report_test, api_client, endpoint_url):
+    response = api_client(
+        {
+            "messages": SIMPLE_MESSAGES,
+            "max_tokens": CANVAS_LENGTH,
+            "ignore_eos": True,
+        },
+        timeout=600,
+    )
+
+    assert response["usage"]["completion_tokens"] == CANVAS_LENGTH
+    message = response["choices"][0]["message"]
+    assert message.get("content"), "parser-off scoring must retain output in content"
+    _assert_healthy(endpoint_url)
+
+
+def test_second_canvas_is_trimmed_at_request_limit(
+    report_test, api_client, endpoint_url
+):
+    # 300 commits one full 256-token canvas and only 44 tokens from the next.
+    # This catches both one-token scheduler accounting and missing stop trimming.
+    response = api_client(
+        {
+            "messages": SIMPLE_MESSAGES,
+            "max_tokens": 300,
+            "ignore_eos": True,
+        },
+        timeout=900,
+    )
+
+    assert response["usage"]["completion_tokens"] == 300
+    assert response["choices"][0]["finish_reason"] == "length"
+    _assert_healthy(endpoint_url)
+
+
+def test_streaming_keeps_final_answer_in_content_for_scoring(
+    report_test, api_client, endpoint_url
+):
+    response = api_client(
+        {
+            "messages": SIMPLE_MESSAGES,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "max_tokens": 1024,
+        },
+        stream=True,
+        timeout=1200,
+    )
+    result = _stream_response(response)
+
+    # The production scoring launch intentionally omits --reasoning-parser.
+    # vLLM 0.24 otherwise moves text before <channel|> (including some boxed
+    # answers) into reasoning, while lm-eval reads only message.content.
+    assert not result["reasoning"]
+    assert result["content"], "parser-off scoring lost the generated answer"
+    assert result["usage"] is not None
+    assert result["usage"]["completion_tokens"] <= 1024
+    assert result["finish_reason"] in {"stop", "length"}
+    _assert_healthy(endpoint_url)
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("logprobs", True),
+        ("response_format", {"type": "json_object"}),
+        ("bad_words", ["forbidden"]),
+        ("seed", 42),
+        ("temperature", 0.5),
+        ("top_k", 10),
+        ("top_p", 0.9),
+        ("presence_penalty", 0.5),
+        ("frequency_penalty", 0.5),
+        ("repetition_penalty", 1.1),
+        ("n", 2),
+    ],
+)
+def test_unsupported_sampling_parameter_is_4xx_without_engine_exit(
+    report_test, api_client, endpoint_url, parameter, value
+):
+    with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+        api_client(
+            {
+                "messages": SIMPLE_MESSAGES,
+                "max_tokens": CANVAS_LENGTH,
+                parameter: value,
+            },
+            timeout=60,
+        )
+
+    assert "400" in str(exc_info.value) or "422" in str(exc_info.value)
+    _assert_healthy(endpoint_url)
+
+
+def test_exact_context_and_canvas_fit(report_test, endpoint_url, max_context, request):
+    model_name = request.config.getoption("--model-name")
+    response = _completion_request(
+        endpoint_url,
+        model_name,
+        [2] * (max_context - CANVAS_LENGTH),
+        max_tokens=CANVAS_LENGTH,
+    )
+    response.raise_for_status()
+
+    body = response.json()
+    assert body["usage"]["prompt_tokens"] == max_context - CANVAS_LENGTH
+    assert body["usage"]["completion_tokens"] == CANVAS_LENGTH
+    _assert_healthy(endpoint_url)
+
+
+def test_prompt_must_reserve_a_full_canvas(
+    report_test, endpoint_url, max_context, request
+):
+    model_name = request.config.getoption("--model-name")
+    response = _completion_request(
+        endpoint_url,
+        model_name,
+        [2] * (max_context - CANVAS_LENGTH + 1),
+        max_tokens=1,
+    )
+
+    assert response.status_code in {400, 422}, response.text
+    assert "256" in response.text or "canvas" in response.text.lower()
+    _assert_healthy(endpoint_url)

--- a/llm_module/test_vllm_diffusiongemma.py
+++ b/llm_module/test_vllm_diffusiongemma.py
@@ -157,17 +157,10 @@ def test_streaming_keeps_final_answer_in_content_for_scoring(
         ("logprobs", True),
         ("response_format", {"type": "json_object"}),
         ("bad_words", ["forbidden"]),
-        ("seed", 42),
-        ("temperature", 0.5),
-        ("top_k", 10),
-        ("top_p", 0.9),
-        ("presence_penalty", 0.5),
-        ("frequency_penalty", 0.5),
-        ("repetition_penalty", 1.1),
         ("n", 2),
     ],
 )
-def test_unsupported_sampling_parameter_is_4xx_without_engine_exit(
+def test_unsupported_response_parameter_is_4xx_without_engine_exit(
     report_test, api_client, endpoint_url, parameter, value
 ):
     with pytest.raises(requests.exceptions.HTTPError) as exc_info:
@@ -181,6 +174,31 @@ def test_unsupported_sampling_parameter_is_4xx_without_engine_exit(
         )
 
     assert "400" in str(exc_info.value) or "422" in str(exc_info.value)
+    _assert_healthy(endpoint_url)
+
+
+def test_transport_sampling_parameters_are_accepted_and_ignored(
+    report_test, api_client, endpoint_url
+):
+    response = api_client(
+        {
+            "messages": SIMPLE_MESSAGES,
+            "max_tokens": CANVAS_LENGTH,
+            "ignore_eos": True,
+            "seed": 42,
+            "temperature": 0.5,
+            "top_k": 10,
+            "top_p": 0.9,
+            "min_p": 0.1,
+            "presence_penalty": 0.5,
+            "frequency_penalty": 0.5,
+            "repetition_penalty": 1.1,
+        },
+        timeout=600,
+    )
+
+    assert response["usage"]["completion_tokens"] == CANVAS_LENGTH
+    assert response["choices"]
     _assert_healthy(endpoint_url)
 
 

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -204,6 +204,9 @@ class EvalTask:
     # LM_EVAL_PRESERVE_REASONING when this is True.
     capture_reasoning: bool = False
     gen_kwargs: Dict[str, str] = field(default_factory=lambda: {"stream": "False"})
+    # Keep the harness RNG seed (--seed) while allowing model-owned samplers to
+    # opt out of receiving it as an OpenAI request sampling parameter.
+    propagate_seed_to_gen_kwargs: bool = True
     model_kwargs: Dict[str, str] = field(default_factory=lambda: {})
     # Note: include_path is specified relative to the respective venv
     include_path: str = None
@@ -5243,6 +5246,120 @@ _eval_config_list = [
                 ),
                 limit_samples_map={
                     EvalLimitMode.SMOKE_TEST: 5,
+                },
+            ),
+        ],
+    ),
+    EvalConfig(
+        hf_model_repo="google/diffusiongemma-26B-A4B-it",
+        tasks=[
+            EvalTask(
+                # Official DiffusionGemma protocol: GPQA-Diamond 0-shot CoT with
+                # flexible extraction of the final "(X)" answer. The server-side
+                # chat template and diffusion_gemma reasoning parser expose the
+                # final answer through message.content.
+                task_name="gpqa_diamond_cot_zeroshot",
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=70.0,
+                    gpu_reference_score_ref="Internal DiffusionGemma GPU GPQA baseline",
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["exact_match,flexible-extract"],
+                        "unit": "percent",
+                    },
+                    # The shared gate accepts score/reference >= 1 - tolerance.
+                    # A 3-point margin on the 70% GPU baseline sets the boundary
+                    # at 67%; attainable GPQA scores are discrete, so the first
+                    # passing score is strictly greater than 67%.
+                    tolerance=3 / 70,
+                ),
+                workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
+                use_chat_api=True,
+                # GPQA prompts fit in a much smaller evaluation window than the
+                # model's 256K serving capacity. Keeping the eval budget at 16K
+                # avoids allocating context that the task cannot use.
+                model_kwargs={"max_length": 16384},
+                gen_kwargs={
+                    # local-chat-completions requires non-streamed responses.
+                    "stream": "false",
+                    # Override this lm-eval task's deterministic defaults. DG
+                    # samples on device and only accepts neutral API values.
+                    "do_sample": "true",
+                    "temperature": 1.0,
+                    # Leave room for the longest 2432-token GPQA prompt and emit
+                    # only whole 256-token diffusion canvases:
+                    # (16384 - 2432) // 256 * 256 = 13824.
+                    "max_gen_toks": 13824,
+                    "until": [],
+                },
+                propagate_seed_to_gen_kwargs=False,
+                limit_samples_map={
+                    EvalLimitMode.SMOKE_TEST: 5,
+                    EvalLimitMode.CI_NIGHTLY: 0.05,
+                },
+            ),
+            EvalTask(
+                task_name="terminal_bench_2_1",
+                workflow_venv_type=WorkflowVenvType.EVALS_AGENTIC,
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref=None,
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["accuracy"],
+                        "unit": "percent",
+                    },
+                ),
+                agentic_eval_config=TerminalBenchEvalConfig(
+                    dataset="terminal-bench/terminal-bench-2-1",
+                    agent="terminus-2",
+                    n_concurrent_trials=1,
+                    n_attempts=1,
+                    n_tasks=89,
+                    override_cpus=16,
+                    override_memory_mb=32 * 1024,
+                    # The selected tasks are estimated at 5-20 expert minutes.
+                    # DiffusionGemma is slower than the reference agents, but a
+                    # bounded 45-minute budget keeps a stuck trial from
+                    # consuming an entire nightly window.
+                    agent_timeout_sec=45 * 60,
+                    agent_kwargs={
+                        "parser_name": "json",
+                        "temperature": 1.0,
+                        "model_info": {
+                            # The deterministic CI tasks have short
+                            # instructions and artifacts. Bound accumulated
+                            # tool history so an unproductive loop cannot grow
+                            # into a device-fatal long prefill.
+                            "max_input_tokens": 16 * 1024,
+                            "max_output_tokens": 4 * 1024,
+                        },
+                        "llm_kwargs": {
+                            # DiffusionGemma's model-owned sampler accepts only
+                            # the neutral vLLM sampling values.
+                            "top_p": 1.0,
+                            # Emit only whole 256-token diffusion canvases.
+                            "max_tokens": 4 * 1024,
+                            "timeout": 15 * 60,
+                        },
+                    },
+                    # Together these exercise OpenSSL/file verification, Git
+                    # recovery, and edit/compile/formal-proof loops without the
+                    # multi-hour build, cryptanalysis, or VM tasks.
+                    task_names_map={
+                        EvalLimitMode.CI_NIGHTLY: [
+                            "terminal-bench/fix-git",
+                            "terminal-bench/openssl-selfsigned-cert",
+                            "terminal-bench/prove-plus-comm",
+                        ],
+                    },
+                ),
+                limit_samples_map={
+                    EvalLimitMode.SMOKE_TEST: 1,
                 },
             ),
         ],

--- a/test_module/llm_tests/llm_performance_tests.py
+++ b/test_module/llm_tests/llm_performance_tests.py
@@ -61,12 +61,19 @@ def run_llm_performance(
     exported as the bearer token); empty string disables auth.
     """
     server_base_url = ctx.server_url if ctx.remote_server else ctx.server_host
+    metadata = getattr(ctx.model_spec, "metadata", {}) or {}
+    tokenizer_trust_remote_code = bool(
+        metadata.get("tokenizer_trust_remote_code", False)
+    )
+
     server = ServerConnection(
         base_url=server_base_url,
         service_port=ctx.server_port,
         model=ctx.model_spec.hf_model_repo,
         auth_token=auth_token,
         is_remote=ctx.remote_server,
+        tokenizer_trust_remote_code=tokenizer_trust_remote_code,
+        output_block_size=int(metadata.get("output_block_size", 1)),
     )
     output_dir = Path(ctx.output_path) / output_subdir
     device_label = ctx.device.name if hasattr(ctx.device, "name") else str(ctx.device)

--- a/test_module/llm_tests/vllm_param_conformance_test.py
+++ b/test_module/llm_tests/vllm_param_conformance_test.py
@@ -109,6 +109,7 @@ class VLLMParamConformanceTest(BaseTest):
             endpoint_url,
             "--model-name",
             model_name,
+            *self._extra_pytest_args(),
             "-q",
         ]
         logger.info("Running vLLM parameter suite: %s", " ".join(command))
@@ -153,6 +154,9 @@ class VLLMParamConformanceTest(BaseTest):
             )
 
         return json.loads(report_path.read_text())
+
+    def _extra_pytest_args(self) -> List[str]:
+        return []
 
     def _record_pytest_output(
         self, return_code: Optional[int], stdout: Optional[bytes]
@@ -252,6 +256,22 @@ class VLLMQwen3StreamingParamConformanceTest(VLLMParamConformanceTest):
     PYTEST_FILENAME = "test_vllm_qwen3_streaming.py"
     ENDPOINT_PATH = "/v1/chat/completions"
     REPORT_TASK_NAME = "vllm_qwen3_streaming"
+
+
+class VLLMDiffusionGemmaParamConformanceTest(VLLMParamConformanceTest):
+    """Run DiffusionGemma's block-serving and admission regression suite."""
+
+    KIND = "vllm_diffusiongemma"
+    PYTEST_FILENAME = "test_vllm_diffusiongemma.py"
+    ENDPOINT_PATH = "/v1/chat/completions"
+    REPORT_TASK_NAME = "vllm_diffusiongemma"
+
+    def _extra_pytest_args(self) -> List[str]:
+        if self.ctx is None:
+            return []
+        device_spec = getattr(self.ctx.model_spec, "device_model_spec", None)
+        max_context = getattr(device_spec, "max_context", None)
+        return ["--max-context", str(max_context)] if max_context is not None else []
 
 
 def run_vllm_param_conformance(

--- a/test_module/server_tests_config.json
+++ b/test_module/server_tests_config.json
@@ -42,7 +42,8 @@
             "Qwen3-32B",
             "Llama-3.1-8B-Instruct",
             "Llama-3.3-70B-Instruct",
-            "gpt-oss-20b"
+            "gpt-oss-20b",
+            "diffusiongemma-26B-A4B-it"
         ]
     },
     "available_markers": {
@@ -362,6 +363,16 @@
             "compatible_devices": [
                 "n150",
                 "p150"
+            ]
+        },
+        "diffusiongemma_26b": {
+            "id_name": "diffusiongemma-26b-a4b-it",
+            "weights": [
+                "diffusiongemma-26B-A4B-it"
+            ],
+            "category": "LLM",
+            "compatible_devices": [
+                "p300x2"
             ]
         },
         "gpt_oss_20b": {
@@ -888,6 +899,22 @@
                 "param",
                 "e2e",
                 "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 0,
+                "retry_delay": 10,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "VLLMDiffusionGemmaParamConformanceTest": {
+            "module": "test_module.llm_tests.vllm_param_conformance_test",
+            "markers": [
+                "param",
+                "e2e",
+                "slow",
+                "heavy"
             ],
             "test_config": {
                 "test_timeout": 3600,

--- a/test_module/test_suites/llm.json
+++ b/test_module/test_suites/llm.json
@@ -81,6 +81,21 @@
                     "description": "Qwen3-32B streaming reasoning/tool-call regressions"
                 }
             ]
+        },
+        {
+            "models": [
+                "diffusiongemma_26b"
+            ],
+            "devices": [
+                "p300x2"
+            ],
+            "test_cases": [
+                {
+                    "template": "VLLMDiffusionGemmaParamConformanceTest",
+                    "enabled": true,
+                    "description": "DiffusionGemma block-serving and request-admission gates"
+                }
+            ]
         }
     ]
 }

--- a/tests/llm_module/test_diffusiongemma_block_metrics.py
+++ b/tests/llm_module/test_diffusiongemma_block_metrics.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+
+import pytest
+
+from llm_module.parsers.vllm import VLLMBenchParser
+
+
+def _parse_block_metrics(
+    *,
+    completed,
+    total_output_tokens,
+    request_throughput,
+    mean_e2el_ms,
+    output_lens=None,
+):
+    return (
+        VLLMBenchParser()
+        .parse(
+            {
+                "completed": completed,
+                "total_input_tokens": 128 * completed,
+                "total_output_tokens": total_output_tokens,
+                "request_throughput": request_throughput,
+                "mean_e2el_ms": mean_e2el_ms,
+                # vLLM divides inter-event time by token count. For block-emitting
+                # models this is near zero when one event contains 128 token IDs.
+                "mean_tpot_ms": 0.00025,
+                "output_throughput": total_output_tokens / 100.0,
+                "tt_output_block_size": 256,
+                **({"output_lens": output_lens} if output_lens is not None else {}),
+            },
+            device="P300X2",
+        )
+        .data
+    )
+
+
+def test_partial_output_block_uses_request_latency_not_token_tpot():
+    data = _parse_block_metrics(
+        completed=8,
+        total_output_tokens=1024,
+        request_throughput=0.0461580898,
+        mean_e2el_ms=21664.4408,
+    )
+
+    assert data["output_blocks_per_request"] == 1
+    assert data["output_blocks_per_second"] == pytest.approx(0.0462)
+    assert data["mean_block_latency_ms"] == pytest.approx(21664.4408)
+
+
+def test_multi_block_latency_amortizes_request_e2el_over_emitted_blocks():
+    data = _parse_block_metrics(
+        completed=4,
+        total_output_tokens=4096,
+        request_throughput=0.0129386199,
+        mean_e2el_ms=77287.7441,
+    )
+
+    assert data["output_blocks_per_request"] == 4
+    assert data["output_blocks_per_second"] == pytest.approx(0.0518)
+    assert data["mean_block_latency_ms"] == pytest.approx(19321.936)
+
+
+def test_block_count_uses_each_actual_emitted_output_length():
+    data = _parse_block_metrics(
+        completed=3,
+        total_output_tokens=514,
+        request_throughput=0.3,
+        mean_e2el_ms=4000.0,
+        output_lens=[1, 256, 257],
+    )
+
+    # ceil(1/256) + ceil(256/256) + ceil(257/256) = 4 actual
+    # scheduling blocks across three requests.
+    assert data["output_blocks_per_request"] == pytest.approx(4 / 3, abs=1e-4)
+    assert data["output_blocks_per_second"] == pytest.approx(0.4)
+    assert data["mean_block_latency_ms"] == pytest.approx(3000.0)

--- a/tests/llm_module/test_parsers.py
+++ b/tests/llm_module/test_parsers.py
@@ -185,6 +185,25 @@ def test_vllm_derives_isl_osl_and_maps_percentiles():
     assert data["error_request_count"] is None
 
 
+def test_vllm_exposes_block_metrics_for_block_diffusion():
+    data = (
+        VLLMBenchParser()
+        .parse(
+            {**VLLM_RAW, "tt_output_block_size": 256},
+            device="P300X2",
+        )
+        .data
+    )
+
+    assert data["metric_semantics"] == "block_granular"
+    assert data["output_block_size"] == 256
+    assert data["output_blocks_per_request"] == 1
+    assert data["output_blocks_per_second"] == pytest.approx(2.1)
+    assert data["mean_block_latency_ms"] == pytest.approx(4200.0)
+    assert data["primary_throughput_metric"] == "output_blocks_per_second"
+    assert data["primary_latency_metric"] == "mean_block_latency_ms"
+
+
 def test_vllm_errors_surface_from_failed_count():
     data = VLLMBenchParser().parse({**VLLM_RAW, "failed": 4}, device="N150").data
     assert data["error_request_count"] == 4

--- a/tests/llm_module/test_vllm_driver.py
+++ b/tests/llm_module/test_vllm_driver.py
@@ -2,6 +2,7 @@
 #
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
+import json
 from pathlib import Path
 
 from llm_module.config import LLMRunConfig, ServerConnection
@@ -59,6 +60,66 @@ def test_local_server_uses_host_port_and_truncation():
     assert cmd[cmd.index("--host") + 1] == "127.0.0.1"
     assert cmd[cmd.index("--port") + 1] == "8000"
     assert "--base-url" not in cmd
-    assert '"truncate_prompt_tokens": "128"' in cmd[cmd.index("--extra-body") + 1]
+    assert json.loads(cmd[cmd.index("--extra-body") + 1]) == {
+        "truncate_prompt_tokens": 128
+    }
+    assert "--trust-remote-code" not in cmd
     header_values = cmd[cmd.index("--header") + 1 :]
     assert header_values == ["Accept-Encoding=identity"]
+
+
+def test_local_server_trusts_remote_code_when_spec_opts_in():
+    server = ServerConnection(
+        base_url="http://127.0.0.1",
+        service_port=8000,
+        model="google/diffusiongemma-26B-A4B-it",
+        is_remote=False,
+        tokenizer_trust_remote_code=True,
+    )
+    cmd, _ = build_vllm_bench_serve_argv(
+        vllm_binary="/venv/bin/vllm",
+        config=_config(),
+        server=server,
+        result_filename=_result_path(),
+    )
+
+    assert cmd.count("--trust-remote-code") == 1
+    assert cmd[cmd.index("--host") + 1] == "127.0.0.1"
+
+
+def test_diffusiongemma_benchmark_uses_random_dataset():
+    cmd, _ = build_vllm_bench_serve_argv(
+        vllm_binary="vllm",
+        config=_config(),
+        server=ServerConnection(
+            base_url="http://127.0.0.1",
+            service_port=8000,
+            model="google/diffusiongemma-26B-A4B-it",
+            is_remote=False,
+            tokenizer_trust_remote_code=True,
+        ),
+        result_filename=_result_path(),
+    )
+
+    assert cmd[cmd.index("--dataset-name") + 1] == "random"
+    assert cmd[cmd.index("--temperature") + 1] == "1.0"
+    assert "--dataset-path" not in cmd
+    assert "--sonnet-input-len" not in cmd
+
+
+def test_remote_server_passes_trust_remote_code_once():
+    server = ServerConnection(
+        base_url="https://console.tenstorrent.com:443",
+        service_port=443,
+        model="google/diffusiongemma-26B-A4B-it",
+        is_remote=True,
+        tokenizer_trust_remote_code=True,
+    )
+    cmd, _ = build_vllm_bench_serve_argv(
+        vllm_binary="vllm",
+        config=_config(),
+        server=server,
+        result_filename=_result_path(),
+    )
+
+    assert cmd.count("--trust-remote-code") == 1

--- a/tests/test_diffusiongemma_eval_config.py
+++ b/tests/test_diffusiongemma_eval_config.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+import os
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from llm_module.eval_command import build_eval_command
+from llm_module.lm_eval_no_server_seed import _drop_server_seed
+from reference_config.evals.eval_config import (
+    EvalTask,
+    _eval_config_map,
+    accept_eval_score,
+    resolve_eval_reference,
+)
+from workflows.workflow_types import EvalLimitMode
+
+
+def _eval_tasks():
+    return _eval_config_map["google/diffusiongemma-26B-A4B-it"].tasks
+
+
+def _task(task_name):
+    return next(task for task in _eval_tasks() if task.task_name == task_name)
+
+
+def _gpqa_task():
+    return _task("gpqa_diamond_cot_zeroshot")
+
+
+def _build_command(task):
+    model_spec = SimpleNamespace(
+        model_id="diffusiongemma-26B-A4B-it",
+        model_name="diffusiongemma-26B-A4B-it",
+        hf_model_repo="google/diffusiongemma-26B-A4B-it",
+        device_model_spec=SimpleNamespace(
+            max_context=262144,
+            max_concurrency=1,
+            eval_max_retries=0,
+        ),
+    )
+    return build_eval_command(
+        task,
+        model_spec,
+        "P300x2",
+        "/tmp/evals",
+        8000,
+    )
+
+
+def _command_gen_kwargs(command):
+    raw = command[command.index("--gen_kwargs") + 1]
+    return dict(item.split("=", 1) for item in raw.split(","))
+
+
+def test_diffusiongemma_release_evals_are_gpqa_and_terminal_bench_only():
+    assert [task.task_name for task in _eval_tasks()] == [
+        "gpqa_diamond_cot_zeroshot",
+        "terminal_bench_2_1",
+    ]
+
+    task = _gpqa_task()
+
+    assert task.use_chat_api is True
+    assert task.model_kwargs["max_length"] == 16384
+    assert task.gen_kwargs["stream"] == "false"
+    assert task.score.score_func_kwargs["result_keys"] == [
+        "exact_match,flexible-extract"
+    ]
+
+
+def test_diffusiongemma_gpqa_gpu_reference_requires_more_than_67_percent():
+    task = _gpqa_task()
+    score = task.score
+
+    assert score.gpu_reference_score == 70.0
+    assert score.tolerance == pytest.approx(3 / 70)
+
+    reference = resolve_eval_reference(score, None)
+    assert accept_eval_score(reference, 132 / 198 * 100, n_total=198) is False
+    assert accept_eval_score(reference, 133 / 198 * 100, n_total=198) is True
+
+
+def test_diffusiongemma_nightly_gpqa_uses_the_same_quality_gate():
+    task = _gpqa_task()
+    reference = resolve_eval_reference(task.score, EvalLimitMode.CI_NIGHTLY)
+
+    # A 5% GPQA subset has approximately ten questions, so its attainable
+    # scores jump by ten points: 60% fails and 70% passes the >67% boundary.
+    assert reference["is_subset_reference"] is False
+    assert accept_eval_score(reference, 60.0, n_total=10) is False
+    assert accept_eval_score(reference, 70.0, n_total=10) is True
+
+
+def test_diffusiongemma_gpqa_reserves_whole_canvas_output_budget():
+    task = _gpqa_task()
+
+    assert task.gen_kwargs["max_gen_toks"] == 13824
+    assert (
+        task.gen_kwargs["max_gen_toks"]
+        == (task.model_kwargs["max_length"] - 2432) // 256 * 256
+    )
+
+
+def test_diffusiongemma_gpqa_uses_neutral_model_owned_sampling_params():
+    task = _gpqa_task()
+
+    assert task.gen_kwargs["do_sample"] == "true"
+    assert task.gen_kwargs["temperature"] == 1.0
+    assert task.propagate_seed_to_gen_kwargs is False
+    for unsupported_key in (
+        "top_k",
+        "top_p",
+        "logprobs",
+        "response_format",
+        "bad_words",
+    ):
+        assert unsupported_key not in task.gen_kwargs
+
+
+def test_diffusiongemma_gpqa_keeps_harness_seed_out_of_server_requests():
+    command = _build_command(_gpqa_task())
+    gen_kwargs = _command_gen_kwargs(command)
+
+    assert gen_kwargs["do_sample"] == "true"
+    assert gen_kwargs["temperature"] == "1.0"
+    assert "seed" not in gen_kwargs
+    assert command[command.index("--seed") + 1] == "42"
+    assert command[0].endswith("/bin/python")
+    assert command[1].endswith("llm_module/lm_eval_no_server_seed.py")
+
+
+def test_diffusiongemma_gpqa_seed_wrapper_removes_adapter_seed():
+    payload = {"model": "diffusiongemma", "seed": 42, "temperature": 1.0}
+
+    assert _drop_server_seed(payload) == {
+        "model": "diffusiongemma",
+        "temperature": 1.0,
+    }
+
+
+def test_eval_task_propagates_seed_to_server_by_default():
+    task = EvalTask(
+        task_name="seeded_sampling",
+        gen_kwargs={"do_sample": "true", "temperature": 1.0},
+    )
+    command = _build_command(task)
+
+    assert _command_gen_kwargs(command)["seed"] == "42"
+    assert command[command.index("--seed") + 1] == "42"
+    assert command[0].endswith("/bin/lm_eval")
+
+
+def test_diffusiongemma_terminal_bench_ci_is_small_and_single_request():
+    task = _task("terminal_bench_2_1")
+    config = task.agentic_eval_config
+
+    assert config.n_concurrent_trials == 1
+    assert config.n_attempts == 1
+    assert config.task_names_map[EvalLimitMode.CI_NIGHTLY] == [
+        "terminal-bench/fix-git",
+        "terminal-bench/openssl-selfsigned-cert",
+        "terminal-bench/prove-plus-comm",
+    ]
+    assert config.agent_timeout_sec == 45 * 60
+    assert config.agent_kwargs["temperature"] == 1.0
+    assert config.agent_kwargs["model_info"] == {
+        "max_input_tokens": 16 * 1024,
+        "max_output_tokens": 4 * 1024,
+    }
+    assert config.agent_kwargs["llm_kwargs"] == {
+        "top_p": 1.0,
+        "max_tokens": 4 * 1024,
+        "timeout": 15 * 60,
+    }
+
+
+def test_diffusiongemma_dev_catalog_maps_gpqa_into_release_evals():
+    env = {**os.environ, "MODEL_SPECS_ENV": "dev"}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from reference_config.evals.eval_config import EVAL_CONFIGS; "
+                "assert 'diffusiongemma-26B-A4B-it' in EVAL_CONFIGS"
+            ),
+        ],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_diffusiongemma_models_ci_config.py
+++ b/tests/test_diffusiongemma_models_ci_config.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODELS_CI_CONFIG = REPO_ROOT / ".github" / "workflows" / "models-ci-config.json"
+
+
+def test_diffusiongemma_runs_nightly_and_release_on_p300x2():
+    models = json.loads(MODELS_CI_CONFIG.read_text())["models"]
+    config = models["diffusiongemma-26B-A4B-it"]
+
+    assert config["inference_engine"] == "vLLM"
+    assert config["ci"]["nightly"]["devices"] == ["P300X2"]
+    assert config["ci"]["release"]["devices"] == ["P300X2"]

--- a/tests/test_diffusiongemma_server_suite.py
+++ b/tests/test_diffusiongemma_server_suite.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+from test_module.test_categorization_system.suite_loader import (
+    load_server_tests_config,
+    load_suite_files_by_category,
+)
+
+
+def test_diffusiongemma_server_suite_expands_on_p300x2():
+    suites = load_suite_files_by_category("llm")
+    suite = next(
+        suite for suite in suites if suite["id"] == "diffusiongemma-26b-a4b-it-p300x2"
+    )
+
+    assert suite["weights"] == ["diffusiongemma-26B-A4B-it"]
+    assert suite["device"] == "p300x2"
+    assert suite["test_cases"] == [
+        {
+            "template": "VLLMDiffusionGemmaParamConformanceTest",
+            "enabled": True,
+            "description": ("DiffusionGemma block-serving and request-admission gates"),
+        }
+    ]
+
+
+def test_diffusiongemma_server_template_points_to_model_specific_suite():
+    config = load_server_tests_config()
+    template = config["test_templates"]["VLLMDiffusionGemmaParamConformanceTest"]
+
+    assert template["module"] == "test_module.llm_tests.vllm_param_conformance_test"
+    assert {"param", "e2e", "slow", "heavy"} <= set(template["markers"])

--- a/tests/test_model_catalog_yaml.py
+++ b/tests/test_model_catalog_yaml.py
@@ -2,6 +2,8 @@
 #
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
+import json
+
 from workflows.utils import get_repo_root_path
 from workflows.model_spec import (
     DeviceModelSpec,
@@ -254,3 +256,58 @@ def test_catalog_yaml_loads_and_every_template_expands(env, yaml_name):
     for t in templates:
         specs = t.expand_to_specs()
         assert specs, f"{env}/{yaml_name}: template {t.weights} expanded to zero specs"
+
+
+def test_diffusiongemma_dev_spec_matches_validated_256k_contract():
+    templates = load_templates_from_yaml(MODEL_SPECS_DIR / "dev" / "llm.yaml")
+    template = next(
+        t for t in templates if t.weights == ["google/diffusiongemma-26B-A4B-it"]
+    )
+    spec = template.expand_to_specs()[0]
+    device_spec = spec.device_model_spec
+
+    assert device_spec.max_context == 262144
+    assert device_spec.max_concurrency == 1
+    assert device_spec.vllm_args["block_size"] == "64"
+    assert device_spec.vllm_args["max_model_len"] == "262144"
+    assert device_spec.vllm_args["max_num_batched_tokens"] == "262144"
+    assert device_spec.vllm_args["max_num_seqs"] == "1"
+    assert (
+        device_spec.vllm_args["default-chat-template-kwargs"]
+        == '{"enable_thinking": true}'
+    )
+    # vLLM 0.24 makes the DiffusionGemma parser effective, but lm-eval only
+    # scores message.content. Keep scored serving parser-off so a final boxed
+    # answer cannot be moved exclusively into message.reasoning.
+    assert "reasoning-parser" not in device_spec.vllm_args
+    assert "reasoning_parser_name" not in spec.metadata
+    assert spec.metadata["output_block_size"] == 256
+    assert (
+        spec.metadata["max_effective_input_tokens"]
+        == device_spec.max_context - spec.metadata["output_block_size"]
+    )
+    assert spec.has_builtin_warmup is True
+
+    env = device_spec.env_vars
+    assert env["DG_UPFRONT_CAPTURE"] == "1"
+    assert env["DG_MODEL_OWNED_HYBRID_KV"] == "1"
+    assert env["DG_UPFRONT_COARSE_PREFILL_BUCKETS"] == "1"
+    assert env["DG_UPFRONT_LAZY_PREFILL_RECAPTURE"] == "1"
+    assert env["DG_PREFILL_CHUNK_SIZE"] == "16384"
+    assert env["DG_PREFILL_RAGGED_CHUNK"] == "1024"
+    assert env["DG_DENOISE_REVEAL_PMAX"] == "262144"
+    assert env["DG_UPFRONT_PREFILL_WARMUP_LENS"] == "32,64,96"
+    assert env["DISABLE_METAL_OP_TIMEOUT"] == "1"
+    assert int(env["DG_TRACE_REGION_SIZE"]) == 3758096384
+    additional_config = json.loads(device_spec.vllm_args["additional_config"])
+    assert additional_config == {
+        "tt": {
+            "sample_on_device_mode": "all",
+            "enable_model_warmup": True,
+            "trace_mode": "all",
+            "trace_region_size": 3758096384,
+        }
+    }
+    assert (
+        int(env["DG_TRACE_REGION_SIZE"]) == additional_config["tt"]["trace_region_size"]
+    )

--- a/tests/test_module/llm_tests/test_agentic_eval_tests.py
+++ b/tests/test_module/llm_tests/test_agentic_eval_tests.py
@@ -12,6 +12,8 @@ from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from llm_module import DriverContext, ServerConnection
 from llm_module.drivers.agentic import (
     build_swebench_config,
@@ -31,6 +33,8 @@ from llm_module.parsers.agentic import (
     compute_accuracy_check,
     extract_harbor_metrics,
 )
+from report_module.acceptance_criteria import acceptance_criteria_check
+from report_module.schema import ReportSchema
 from test_module.llm_tests.agentic_eval_tests import _select_agentic_tasks
 from workflows.workflow_types import EvalLimitMode, ReportCheckTypes, WorkflowVenvType
 
@@ -154,6 +158,35 @@ HARBOR_RESULT_FIXTURE = {
     },
 }
 
+HARBOR_ZERO_TRIALS_FIXTURE = {
+    "stats": {
+        "n_completed_trials": 5,
+        "n_errored_trials": 5,
+        "evals": {
+            "terminal_bench_2": {
+                "metrics": [],
+                "n_trials": 0,
+                "n_errors": 5,
+                "exception_stats": {
+                    "RuntimeError": [f"task-{index}" for index in range(5)]
+                },
+                "pass_at_k": {"1": 0.0},
+            }
+        },
+    },
+    "trial_results": [
+        {
+            "trial_name": f"task-{index}",
+            "verifier_result": None,
+            "exception_info": {
+                "exception_type": "RuntimeError",
+                "exception_message": "environment setup failed",
+            },
+        }
+        for index in range(5)
+    ],
+}
+
 
 class TestAgenticParser:
     def test_parse_harbor_result_to_evals_block(self):
@@ -174,6 +207,108 @@ class TestAgenticParser:
         assert block.data["accuracy_check"] == ReportCheckTypes.PASS
         assert "success" not in block.data
         assert "accuracy" not in block.data
+
+    def test_zero_trial_result_fails_closed_and_blocks_acceptance(self):
+        block = AgenticEvalParser(
+            task_name="terminal_bench_2", score=FakeScore()
+        ).parse(HARBOR_ZERO_TRIALS_FIXTURE, device="N150")
+
+        assert block.targets["n_trials"] == 0
+        assert block.targets["pass_at_1"] == 0.0
+        assert block.data["score"] is None
+        assert block.data["accuracy_check"] == ReportCheckTypes.FAIL
+        assert block.data["success"] is False
+        assert "n_trials=0" in block.data["error"]
+
+        accepted, blockers, _ = acceptance_criteria_check(
+            ReportSchema(metadata={"report_id": "zero-trials"}, sections=[block])
+        )
+        assert accepted is False
+        assert blockers
+
+    def test_positive_trials_with_zero_score_is_evaluated(self):
+        raw = {
+            "stats": {
+                "evals": {
+                    "terminal_bench_2": {
+                        "metrics": [{"mean": 0.0}],
+                        "n_trials": 5,
+                        "n_errors": 0,
+                        "reward_stats": {
+                            "reward": {"0.0": [f"task-{index}" for index in range(5)]}
+                        },
+                        "pass_at_k": {"1": 0.0},
+                    }
+                }
+            }
+        }
+
+        block = AgenticEvalParser(
+            task_name="terminal_bench_2", score=FakeScore()
+        ).parse(raw, device="N150")
+
+        assert block.targets["n_trials"] == 5
+        assert block.data["score"] == 0.0
+        assert block.data["accuracy_check"] == ReportCheckTypes.FAIL
+        assert "success" not in block.data
+        assert "error" not in block.data
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            {"stats": {"evals": {}}},
+            {
+                "stats": {
+                    "evals": {
+                        "terminal_bench_2": {
+                            "metrics": [],
+                            "n_trials": 5,
+                        }
+                    }
+                }
+            },
+        ],
+    )
+    def test_missing_or_invalid_harbor_aggregate_fails_closed(self, raw):
+        block = AgenticEvalParser(
+            task_name="terminal_bench_2", score=FakeScore()
+        ).parse(raw, device="N150")
+
+        assert block.data["score"] is None
+        assert block.data["accuracy_check"] == ReportCheckTypes.FAIL
+        assert block.data["success"] is False
+        assert "Harbor result" in block.data["error"]
+
+    def test_exception_only_trials_fail_even_with_positive_aggregate_count(self):
+        raw = {
+            "stats": {
+                "evals": {
+                    "terminal_bench_2": {
+                        "metrics": [{"mean": 0.0}],
+                        "n_trials": 2,
+                        "n_errors": 2,
+                    }
+                }
+            },
+            "trial_results": [
+                {
+                    "exception_info": {"exception_type": "RuntimeError"},
+                    "verifier_result": None,
+                },
+                {
+                    "exception_info": {"exception_type": "TimeoutError"},
+                    "verifier_result": None,
+                },
+            ],
+        }
+
+        block = AgenticEvalParser(
+            task_name="terminal_bench_2", score=FakeScore()
+        ).parse(raw, device="N150")
+
+        assert block.data["accuracy_check"] == ReportCheckTypes.FAIL
+        assert block.data["success"] is False
+        assert "only infrastructure/runtime exceptions" in block.data["error"]
 
     def test_mean_seconds_per_task_from_harbor_timing(self):
         raw = {

--- a/tests/test_module/llm_tests/test_vllm_param_conformance_tests.py
+++ b/tests/test_module/llm_tests/test_vllm_param_conformance_tests.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from test_module._test_common import TestConfig
 from test_module.llm_tests.vllm_param_conformance_test import (
     DEFAULT_MODEL_NAME,
+    VLLMDiffusionGemmaParamConformanceTest,
     VLLMParamConformanceTest,
 )
 
@@ -54,3 +55,19 @@ def test_resolve_model_name_defaults_when_unresolved():
     test = _make_test(ctx)
 
     assert test._resolve_model_name() == DEFAULT_MODEL_NAME
+
+
+def test_diffusiongemma_suite_receives_catalog_max_context():
+    ctx = _fake_ctx(
+        hf_model_repo="google/diffusiongemma-26B-A4B-it",
+        model_name="diffusiongemma-26B-A4B-it",
+    )
+    ctx.model_spec.device_model_spec = SimpleNamespace(max_context=262144)
+    test = VLLMDiffusionGemmaParamConformanceTest(
+        TestConfig({}),
+        {},
+        ctx=ctx,
+    )
+
+    assert test.PYTEST_FILENAME == "test_vllm_diffusiongemma.py"
+    assert test._extra_pytest_args() == ["--max-context", "262144"]

--- a/tests/test_run_vllm_api_server.py
+++ b/tests/test_run_vllm_api_server.py
@@ -254,6 +254,9 @@ def test_diffusiongemma_launch_uses_standalone_plugin_vllm_024_contract(
     assert value("--block-size") == "64"
     assert value("--generation-config") == "vllm"
     assert value("--default-chat-template-kwargs") == '{"enable_thinking": true}'
+    assert "--no-enable-prefix-caching" in argv
+    assert "--no-enable-chunked-prefill" in argv
+    assert "--no-async-scheduling" in argv
     assert json.loads(value("--additional-config")) == {
         "tt": {
             "sample_on_device_mode": "all",

--- a/tests/test_run_vllm_api_server.py
+++ b/tests/test_run_vllm_api_server.py
@@ -14,9 +14,16 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from workflows.model_spec import load_templates_from_yaml
 from workflows.utils import get_repo_root_path
 
 MODULE_PATH = get_repo_root_path() / "vllm-tt-metal" / "src" / "run_vllm_api_server.py"
+DEV_LLM_SPECS_PATH = (
+    get_repo_root_path() / "workflows" / "model_specs" / "dev" / "llm.yaml"
+)
+VLLM_DOCKERFILE_PATH = (
+    get_repo_root_path() / "vllm-tt-metal" / "vllm.tt-metal.src.dev.Dockerfile"
+)
 
 
 def _build_catalog():
@@ -214,6 +221,60 @@ def test_set_vllm_sys_argv_logs_multiline_bash_command(
     )
 
 
+def test_diffusiongemma_launch_uses_standalone_plugin_vllm_024_contract(
+    monkeypatch, run_vllm_api_server_module
+):
+    template = next(
+        item
+        for item in load_templates_from_yaml(DEV_LLM_SPECS_PATH)
+        if item.weights == ["google/diffusiongemma-26B-A4B-it"]
+    )
+    device_spec = template.expand_to_specs()[0].device_model_spec
+    monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py"])
+
+    run_vllm_api_server_module.set_vllm_sys_argv(
+        argparse.Namespace(service_port=8000),
+        [],
+        device_spec.vllm_args,
+    )
+
+    # FlexibleArgumentParser accepts underscores, but normalize them here to
+    # compare against the canonical vLLM 0.24 serve flag spellings.
+    argv = [
+        token.replace("_", "-") if token.startswith("--") else token
+        for token in sys.argv[1:]
+    ]
+
+    def value(flag):
+        return argv[argv.index(flag) + 1]
+
+    assert value("--max-model-len") == "262144"
+    assert value("--max-num-batched-tokens") == "262144"
+    assert value("--max-num-seqs") == "1"
+    assert value("--block-size") == "64"
+    assert value("--generation-config") == "vllm"
+    assert value("--default-chat-template-kwargs") == '{"enable_thinking": true}'
+    assert json.loads(value("--additional-config")) == {
+        "tt": {
+            "sample_on_device_mode": "all",
+            "enable_model_warmup": True,
+            "trace_mode": "all",
+            "trace_region_size": 3758096384,
+        }
+    }
+    assert "--reasoning-parser" not in argv
+    assert "--vllm-dir" not in argv
+
+
+def test_vllm_dockerfile_checks_out_supplied_standalone_plugin_ref():
+    dockerfile = VLLM_DOCKERFILE_PATH.read_text()
+
+    assert "git clone https://github.com/tenstorrent/vllm-tt-plugin.git" in dockerfile
+    assert "git checkout ${TT_VLLM_COMMIT_SHA_OR_TAG}" in dockerfile
+    assert "source docs/install-vllm-tt.sh" in dockerfile
+    assert "git clone https://github.com/tenstorrent/vllm.git" not in dockerfile
+
+
 @pytest.mark.parametrize(
     ("argv", "expected_port"),
     [
@@ -229,6 +290,29 @@ def test_resolve_service_port_reads_port_from_sys_argv(
     monkeypatch.setenv("SERVICE_PORT", "8000")
 
     assert run_vllm_api_server_module.resolve_service_port() == expected_port
+
+
+def test_model_spec_can_disable_and_clear_inherited_metal_timeout(
+    monkeypatch, run_vllm_api_server_module
+):
+    monkeypatch.setenv("TT_METAL_OPERATION_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.setenv(
+        "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE", "stale-triage-command"
+    )
+    model_spec = {
+        "device_model_spec": {
+            "env_vars": {
+                "DISABLE_METAL_OP_TIMEOUT": "1",
+            }
+        }
+    }
+
+    run_vllm_api_server_module.set_runtime_env_vars(model_spec)
+    run_vllm_api_server_module.set_metal_timeout_env_vars()
+
+    assert os.environ["DISABLE_METAL_OP_TIMEOUT"] == "1"
+    assert "TT_METAL_OPERATION_TIMEOUT_SECONDS" not in os.environ
+    assert "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE" not in os.environ
 
 
 def test_main_passes_passthrough_port_to_trace_capture(
@@ -263,10 +347,17 @@ def test_main_passes_passthrough_port_to_trace_capture(
         run_vllm_api_server_module, "ensure_weights_available", MagicMock()
     )
     monkeypatch.setattr(run_vllm_api_server_module, "register_tt_models", MagicMock())
+    env_setup_order = []
     monkeypatch.setattr(
-        run_vllm_api_server_module, "set_metal_timeout_env_vars", MagicMock()
+        run_vllm_api_server_module,
+        "set_metal_timeout_env_vars",
+        MagicMock(side_effect=lambda: env_setup_order.append("metal_timeout")),
     )
-    monkeypatch.setattr(run_vllm_api_server_module, "set_runtime_env_vars", MagicMock())
+    monkeypatch.setattr(
+        run_vllm_api_server_module,
+        "set_runtime_env_vars",
+        MagicMock(side_effect=lambda _spec: env_setup_order.append("runtime_env")),
+    )
     monkeypatch.setattr(run_vllm_api_server_module, "runtime_settings", MagicMock())
     monkeypatch.setattr(run_vllm_api_server_module.runpy, "run_module", MagicMock())
     monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py"])
@@ -282,6 +373,7 @@ def test_main_passes_passthrough_port_to_trace_capture(
         disable_trace_capture=False,
         service_port=9001,
     )
+    assert env_setup_order == ["runtime_env", "metal_timeout"]
 
 
 def _weights_spec():

--- a/tests/test_run_vllm_api_server.py
+++ b/tests/test_run_vllm_api_server.py
@@ -270,7 +270,9 @@ def test_vllm_dockerfile_checks_out_supplied_standalone_plugin_ref():
     dockerfile = VLLM_DOCKERFILE_PATH.read_text()
 
     assert "git clone https://github.com/tenstorrent/vllm-tt-plugin.git" in dockerfile
-    assert "git checkout ${TT_VLLM_COMMIT_SHA_OR_TAG}" in dockerfile
+    assert "git checkout '${TT_VLLM_COMMIT_SHA_OR_TAG}'" in dockerfile
+    assert "git ls-remote origin" in dockerfile
+    assert 'git fetch --depth 1 origin \\"\\${resolved_sha}\\"' in dockerfile
     assert "source docs/install-vllm-tt.sh" in dockerfile
     assert "git clone https://github.com/tenstorrent/vllm.git" not in dockerfile
 

--- a/tests/workflow_module/test_agentic_workflow.py
+++ b/tests/workflow_module/test_agentic_workflow.py
@@ -17,12 +17,12 @@ from workflow_module.workflows import (
 )
 
 
-def _fake_block() -> Block:
+def _fake_block(*, success=True) -> Block:
     return Block(
         kind="evals",
         task_type="llm",
         title="Agentic Eval — test_task",
-        data={"success": True, "accuracy_check": 1, "accuracy": 0.6},
+        data={"success": success, "accuracy_check": 1, "accuracy": 0.6},
     )
 
 
@@ -82,6 +82,19 @@ class TestAgenticWorkflowRunTasks:
         assert len(outcomes) == 1
         assert outcomes[0].exit_code == 1
         assert outcomes[0].block_kind is None
+
+    def test_failed_result_block_gives_failed_outcome(self):
+        wf = self._make_workflow()
+        block = _fake_block(success=False)
+        with patch(
+            "test_module.llm_tests.agentic_eval_tests.run_llm_agentic_eval",
+            return_value=[block],
+        ):
+            outcomes = wf.run_tasks()
+
+        assert len(outcomes) == 1
+        assert outcomes[0].exit_code == 1
+        assert outcomes[0].block_kind == "evals"
 
     def test_runner_returns_empty_list_gives_failed_outcome(self):
         wf = self._make_workflow()

--- a/vllm-tt-metal/requirements.txt
+++ b/vllm-tt-metal/requirements.txt
@@ -1,3 +1,5 @@
 # additional inference server and client script requirements
 pyjwt==2.7.0
 requests==2.32.3
+# Required for the native DiffusionGemma architecture.
+transformers==5.12.1

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -491,9 +491,16 @@ def set_metal_timeout_env_vars():
     TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE so that tt-triage runs
     automatically when an op dispatch hangs.
 
-    Disabled when DISABLE_METAL_OP_TIMEOUT=1 is set (via run.py --disable-metal-timeout).
+    Disabled when DISABLE_METAL_OP_TIMEOUT=1 is set by either the model spec or
+    ``run.py --disable-metal-timeout``.
     """
     if os.getenv("DISABLE_METAL_OP_TIMEOUT") == "1":
+        # DISABLE_METAL_OP_TIMEOUT is an inference-server control flag; tt-metal
+        # itself only reads these two variables. Clear inherited values so an
+        # explicit model/CLI disable cannot leave a previously configured timeout
+        # active in this process.
+        os.environ.pop("TT_METAL_OPERATION_TIMEOUT_SECONDS", None)
+        os.environ.pop("TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE", None)
         logger.info("Metal op timeout disabled via DISABLE_METAL_OP_TIMEOUT=1")
         return
 
@@ -770,9 +777,11 @@ def main():
     impl_id = model_spec.get("impl", {}).get("impl_id")
     register_tt_models(impl_id)
 
-    # Step 4: Set runtime environment variables and vLLM server args
-    set_metal_timeout_env_vars()
+    # Step 4: Set runtime environment variables and vLLM server args. Model env
+    # must be installed first because it may explicitly disable the generic
+    # five-second Metal operation timeout.
     set_runtime_env_vars(model_spec)
+    set_metal_timeout_env_vars()
     runtime_settings(model_spec, no_auth=args.no_auth)
     default_vllm_args = model_spec["device_model_spec"]["vllm_args"]
     set_vllm_sys_argv(args, remaining_sys_argv, default_vllm_args)

--- a/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
+++ b/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
@@ -99,7 +99,20 @@ RUN /bin/bash -c "git clone https://github.com/tenstorrent-metal/tt-metal.git ${
 # install is delegated to its own docs/install-vllm-tt.sh rather than restated here
 RUN /bin/bash -c "git clone https://github.com/tenstorrent/vllm-tt-plugin.git ${vllm_tt_plugin_dir} \
     && cd ${vllm_tt_plugin_dir} \
-    && git checkout ${TT_VLLM_COMMIT_SHA_OR_TAG} \
+    && (git checkout '${TT_VLLM_COMMIT_SHA_OR_TAG}' \
+        || { resolved_shas=\$(git ls-remote origin '${TT_VLLM_COMMIT_SHA_OR_TAG}' | awk '{print \$1}' | sort -u); \
+             if [ -z \"\${resolved_shas}\" ]; then \
+                 resolved_shas=\$(git ls-remote origin | awk -v prefix='${TT_VLLM_COMMIT_SHA_OR_TAG}' 'index(\$1, prefix) == 1 {print \$1}' | sort -u); \
+             fi; \
+             resolved_count=\$(printf '%s\n' \"\${resolved_shas}\" | awk 'NF {count++} END {print count + 0}'); \
+             if [ \"\${resolved_count}\" -ne 1 ]; then \
+                 echo 'Unable to resolve plugin ref ${TT_VLLM_COMMIT_SHA_OR_TAG} to one remote commit' >&2; \
+                 exit 1; \
+             fi; \
+             resolved_sha=\$(printf '%s\n' \"\${resolved_shas}\" | awk 'NF {print; exit}'); \
+             git fetch --depth 1 origin \"\${resolved_sha}\" \
+             && git checkout --detach \"\${resolved_sha}\"; \
+           }) \
     && source ${PYTHON_ENV_DIR}/bin/activate \
     && uv pip install --upgrade pip \
     && source docs/install-vllm-tt.sh \

--- a/workflow_module/workflows.py
+++ b/workflow_module/workflows.py
@@ -183,6 +183,20 @@ class AgenticWorkflow(WorkflowExecution):
             self.logger.error("❌ agentic produced no blocks (%.1fs)", elapsed)
             return [TaskOutcome("evaluation", 1, elapsed, None)]
 
+        failed_blocks = [
+            block
+            for block in blocks
+            if isinstance(block.data, dict) and block.data.get("success") is False
+        ]
+        if failed_blocks:
+            self.logger.error(
+                "❌ agentic produced %d failed block(s) out of %d (%.1fs)",
+                len(failed_blocks),
+                len(blocks),
+                elapsed,
+            )
+            return [TaskOutcome("evaluation", 1, elapsed, blocks[0].kind)]
+
         self.logger.info(
             "✅ agentic blocks=%d kind=%s (%.1fs)",
             len(blocks),

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -294,6 +294,12 @@ qwen36_blackhole_impl = ImplSpec(
     repo_url="https://github.com/tenstorrent/tt-metal",
     code_path="models/demos/blackhole/qwen36",
 )
+diffusion_gemma_impl = ImplSpec(
+    impl_id="diffusion_gemma",
+    impl_name="diffusion-gemma",
+    repo_url="https://github.com/tenstorrent/tt-metal",
+    code_path="models/experimental/diffusion_gemma",
+)
 training_lora_impl = ImplSpec(
     impl_id="training_lora",
     impl_name="training-lora",
@@ -320,6 +326,7 @@ _IMPL_REGISTRY: Dict[str, ImplSpec] = {
     "tt_vllm_plugin": tt_vllm_plugin_impl,
     "sdxl_forge": sdxl_forge_impl,
     "qwen36_blackhole": qwen36_blackhole_impl,
+    "diffusion_gemma": diffusion_gemma_impl,
     "training_lora": training_lora_impl,
     "qwen36_blackhole_b8": qwen36_blackhole_b8_impl,
 }

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -341,6 +341,12 @@ templates:
       vllm_args:
         generation-config: vllm
         default-chat-template-kwargs: '{"enable_thinking": true}'
+        # vLLM 0.24 enables these generative defaults before the TT platform
+        # hook runs. DiffusionGemma owns whole-prompt prefill/KV and emits
+        # synchronous 256-token blocks, so reject the defaults at CLI parsing.
+        no-enable-prefix-caching: true
+        no-enable-chunked-prefill: true
+        no-async-scheduling: true
         # Deliberately omit --reasoning-parser for scored GPQA runs. vLLM 0.24
         # honors the parser's request to retain <channel|> delimiters, which can
         # move the boxed answer from message.content into message.reasoning.

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -296,6 +296,67 @@ templates:
       # by enable-auto-tool-choice in vllm_args above.
       tool_call_parser_name: gemma4
 
+# DiffusionGemma model implementation: tenstorrent/tt-metal#52120.
+# Block-granular vLLM support: tenstorrent/tt-metal#47488.
+- weights:
+    - google/diffusiongemma-26B-A4B-it
+  impl: diffusion_gemma
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 1
+      # Validated on QB2 across every power-of-two bucket from 128 through 256K.
+      # DeviceModelSpec derives block_size=64, max_num_seqs=1 and
+      # max_num_batched_tokens=max_context from these fields.
+      max_context: 262144
+      default_impl: true
+      env_vars:
+        MESH_DEVICE: "P150x4"
+        VLLM_RPC_TIMEOUT: "1800000"
+        VLLM_ENABLE_V1_MULTIPROCESSING: "0"
+        DISABLE_METAL_OP_TIMEOUT: "1"
+        DG_VLLM_GUMBEL_MODE: "device"
+        DG_UPFRONT_CAPTURE: "1"
+        DG_MODEL_OWNED_HYBRID_KV: "1"
+        DG_UPFRONT_COARSE_PREFILL_BUCKETS: "1"
+        DG_UPFRONT_LAZY_PREFILL_RECAPTURE: "1"
+        DG_PREFILL_CHUNK_SIZE: "16384"
+        # A 2048-token ragged-MoE slice needs a 176 MiB embedding output.
+        # After a 118-turn Terminal-Bench trial fragmented DRAM, its 23 MiB
+        # per-bank allocation killed EngineCore despite 1.30 GiB total free.
+        # Halving the bounded inner slice keeps the same per-token computation
+        # while reducing that contiguous allocation to 11 MiB per bank.
+        DG_PREFILL_RAGGED_CHUNK: "1024"
+        DG_DENOISE_REVEAL_PMAX: "262144"
+        DG_DENOISE_SLIDING_WINDOW: "1"
+        # Keep startup bounded; unseen buckets atomically release, compile and
+        # recapture their resident traces on first use.
+        DG_UPFRONT_PREFILL_WARMUP_LENS: "32,64,96"
+        DG_TRACE_REGION_SIZE: "3758096384"
+      override_tt_config:
+        sample_on_device_mode: all
+        enable_model_warmup: true
+        trace_mode: all
+        trace_region_size: 3758096384
+      vllm_args:
+        generation-config: vllm
+        default-chat-template-kwargs: '{"enable_thinking": true}'
+        # Deliberately omit --reasoning-parser for scored GPQA runs. vLLM 0.24
+        # honors the parser's request to retain <channel|> delimiters, which can
+        # move the boxed answer from message.content into message.reasoning.
+        # lm-eval scores content only; parser-off preserves the validated answer
+        # bytes while keeping the model's thinking chat template enabled.
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    google/diffusiongemma-26B-A4B-it:
+      tokenizer_trust_remote_code: true
+      output_block_size: 256
+      # A request must leave one full output canvas inside max_context.
+      max_effective_input_tokens: 261888
+
 - weights:
     - Qwen/Qwen3-8B
   impl: tt_transformers


### PR DESCRIPTION
## Summary
- migrate DiffusionGemma image installation from the vLLM fork to the standalone `vllm-tt-plugin` and its upstream vLLM 0.24 pin
- preserve the validated 256K model configuration, GPQA/Terminal Bench release coverage, block metrics, and fail-closed conformance checks
- pin synchronous uncached block-serving launch defaults and support exact fork-PR plugin commits during composed CI builds
- validate OpenAI transport sampling controls as accepted-but-ignored while continuing to reject response-shaping and host-logits parameters

## Test plan
- [x] Focused migration/config/server tests: 46 passed
- [x] DiffusionGemma conformance suite collection: 10 tests
- [x] Ruff check and format
- [x] Standalone-plugin image build completed in the previous composed run
- [ ] P300X2 release validation: https://github.com/tenstorrent/tt-shield/actions/runs/31348632121

## Paired changes
- standalone plugin: https://github.com/tenstorrent/vllm-tt-plugin/pull/30
- tt-metal adapter/runtime: https://github.com/tenstorrent/tt-metal/pull/52120