### PR TITLE
Add TTS Sample Cache

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -1096,6 +1096,12 @@ target_link_libraries(tokenizer_test PRIVATE llm_runner_lib GTest::gtest_main)
 add_executable(tts_prompt_compiler_test tests/unit/model/tts_prompt_compiler_test.cpp)
 target_link_libraries(tts_prompt_compiler_test PRIVATE llm_runner_lib GTest::gtest_main)
 
+add_executable(voice_sample_cache_test tests/unit/utils/voice_sample_cache_test.cpp)
+target_link_libraries(voice_sample_cache_test PRIVATE xxhash_lib GTest::gtest_main)
+target_include_directories(voice_sample_cache_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
 add_executable(conversation_hasher_test tests/unit/model/conversation_hasher_test.cpp)
 target_link_libraries(conversation_hasher_test PRIVATE llm_runner_lib GTest::gtest_main)
 
@@ -1451,6 +1457,7 @@ gtest_discover_tests(sequence_test)
 gtest_discover_tests(lockfree_queue_test)
 gtest_discover_tests(tokenizer_test)
 gtest_discover_tests(tts_prompt_compiler_test)
+gtest_discover_tests(voice_sample_cache_test)
 gtest_discover_tests(conversation_hasher_test)
 gtest_discover_tests(cancel_queue_test)
 gtest_discover_tests(worker_metrics_shm_test)

--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -1065,6 +1065,17 @@ if(ENABLE_BLAZE)
         ${CMAKE_CURRENT_SOURCE_DIR}/include
     )
 
+    add_executable(blaze_tts_runner_test
+        tests/integration/runners/blaze_tts_runner_test.cpp
+        src/runtime/runners/blaze_runner/blaze_tts_runner.cpp
+        src/runtime/worker/single_process_worker_metrics.cpp
+        src/runtime/worker/worker_metrics_shm.cpp
+    )
+    target_link_libraries(blaze_tts_runner_test PRIVATE llm_runner_lib GTest::gtest_main)
+    target_include_directories(blaze_tts_runner_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+
     add_executable(mock_schedulers_test
         tests/unit/runners/mock_schedulers_test.cpp
     )
@@ -1451,6 +1462,7 @@ endif()
 if(ENABLE_BLAZE)
     gtest_discover_tests(blaze_decode_runner_test)
     gtest_discover_tests(blaze_prefill_runner_test)
+    gtest_discover_tests(blaze_tts_runner_test)
     gtest_discover_tests(mock_schedulers_test)
 endif()
 gtest_discover_tests(sequence_test)

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -96,6 +96,7 @@ constexpr unsigned WARMUP_TIMEOUT_MS = 150000;
  * the crash and restart the server instead of hanging silently.
  */
 constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 150000;
+constexpr size_t TTS_VOICE_SAMPLE_CACHE_SIZE = 128;
 
 constexpr const char* MODEL = "deepseek-ai/DeepSeek-R1-0528";
 constexpr const char* WIRE_FORMAT = "blaze";

--- a/tt-media-server/cpp_server/include/config/defaults.hpp
+++ b/tt-media-server/cpp_server/include/config/defaults.hpp
@@ -96,7 +96,7 @@ constexpr unsigned WARMUP_TIMEOUT_MS = 150000;
  * the crash and restart the server instead of hanging silently.
  */
 constexpr unsigned OUTPUT_HANG_TIMEOUT_MS = 150000;
-constexpr size_t TTS_VOICE_SAMPLE_CACHE_SIZE = 128;
+constexpr size_t TTS_VOICE_SAMPLE_CACHE_SIZE = 1024;
 
 constexpr const char* MODEL = "deepseek-ai/DeepSeek-R1-0528";
 constexpr const char* WIRE_FORMAT = "blaze";

--- a/tt-media-server/cpp_server/include/ipc/tts_ipc.hpp
+++ b/tt-media-server/cpp_server/include/ipc/tts_ipc.hpp
@@ -131,7 +131,6 @@ struct TtsAudioChunkMessage {
     message.task_id = taskId;
     message.chunkIndex = chunk.chunkIndex;
     message.sampleRateHz = chunk.sampleRateHz;
-
     message.channels = chunk.channels;
     message.samplesBf16 = chunk.samplesBf16;
     return message;

--- a/tt-media-server/cpp_server/include/ipc/tts_ipc.hpp
+++ b/tt-media-server/cpp_server/include/ipc/tts_ipc.hpp
@@ -131,6 +131,7 @@ struct TtsAudioChunkMessage {
     message.task_id = taskId;
     message.chunkIndex = chunk.chunkIndex;
     message.sampleRateHz = chunk.sampleRateHz;
+
     message.channels = chunk.channels;
     message.samplesBf16 = chunk.samplesBf16;
     return message;

--- a/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_tts_runner.hpp
+++ b/tt-media-server/cpp_server/include/runtime/runners/blaze_runner/blaze_tts_runner.hpp
@@ -18,6 +18,7 @@
 #include "ipc/tts_ipc.hpp"
 #include "runtime/runners/blaze_runner/tts_scheduler_interface.hpp"
 #include "runtime/runners/ipc_runner.hpp"
+#include "utils/voice_sample_cache.hpp"
 
 namespace tt::runners::blaze {
 
@@ -84,6 +85,8 @@ class BlazeTtsRunner : public IRunner {
   void handleStopAck(const tts_scheduler::SchedulerResponse& response);
   void handleEvictAck(const tts_scheduler::SchedulerResponse& response);
 
+  void compilePromptTokens(ipc::tts::TtsIpcTask& task,
+                           const std::vector<uint32_t>& speechIds);
   void allocateTask(ipc::tts::TtsIpcTask task);
   bool sendFinish(uint32_t taskId, domain::tts::TtsFinishReason reason,
                   std::string error = {},
@@ -104,6 +107,7 @@ class BlazeTtsRunner : public IRunner {
   ipc::ICancelQueue* cancelQueue;
   std::vector<SlotContext> slots;
   std::unordered_map<uint32_t, ipc::tts::TtsIpcTask> pendingVoiceEncodes;
+  utils::VoiceSampleCache voiceSampleCache;
   std::unordered_map<uint32_t, ipc::tts::TtsIpcTask> pendingAllocations;
   std::deque<PendingTerminalMessage> pendingTerminalMessages;
   std::vector<uint32_t> deferredStopSlots;

--- a/tt-media-server/cpp_server/include/utils/voice_sample_cache.hpp
+++ b/tt-media-server/cpp_server/include/utils/voice_sample_cache.hpp
@@ -5,10 +5,14 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <list>
 #include <stdexcept>
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
+#define XXH_INLINE_ALL
+#include "xxhash.h"
 
 namespace tt::utils {
 
@@ -28,91 +32,43 @@ class VoiceSampleCache {
     if (entry == entries.end()) {
       throw std::out_of_range("Voice sample cache entry does not exist");
     }
-    touch(entry->second);
-    return entry->second.speechIds;
+    entriesByRecency.splice(entriesByRecency.begin(), entriesByRecency,
+                            entry->second);
+    return entry->second->speechIds;
   }
 
   void add(const Samples& samples, SpeechIds speechIds) {
     if (capacity == 0) return;
     auto existing = entries.find(samples);
     if (existing != entries.end()) {
-      existing->second.speechIds = std::move(speechIds);
-      touch(existing->second);
+      existing->second->speechIds = std::move(speechIds);
+      entriesByRecency.splice(entriesByRecency.begin(), entriesByRecency,
+                              existing->second);
       return;
     }
     if (entries.size() == capacity) {
-      Entry* leastRecentlyUsed = heap.front();
-      entries.erase(leastRecentlyUsed->samples);
-      heap.front() = heap.back();
-      heap.pop_back();
-      if (!heap.empty()) {
-        heap.front()->heapIndex = 0;
-        siftDown(0);
-      }
+      entries.erase(entriesByRecency.back().samples);
+      entriesByRecency.pop_back();
     }
-    auto [entry, inserted] = entries.emplace(
-        samples,
-        Entry{samples, std::move(speechIds), ++accessOrder, heap.size()});
-    (void)inserted;
-    heap.push_back(&entry->second);
-    siftUp(entry->second.heapIndex);
+    entriesByRecency.push_front({samples, std::move(speechIds)});
+    entries.emplace(samples, entriesByRecency.begin());
   }
 
  private:
   struct SamplesHash {
     size_t operator()(const Samples& samples) const noexcept {
-      size_t hash = samples.size();
-      for (int16_t sample : samples) {
-        hash ^= static_cast<uint16_t>(sample) + 0x9e3779b9 + (hash << 6) +
-                (hash >> 2);
-      }
-      return hash;
+      if (samples.empty()) return 0;
+      return XXH64(samples.data(), samples.size() * sizeof(int16_t), 0);
     }
   };
   struct Entry {
     Samples samples;
     SpeechIds speechIds;
-    uint64_t accessOrder;
-    size_t heapIndex;
   };
-  void touch(Entry& entry) {
-    entry.accessOrder = ++accessOrder;
-    siftDown(entry.heapIndex);
-  }
-  void siftUp(size_t index) {
-    while (index > 0) {
-      const size_t parent = (index - 1) / 2;
-      if (heap[parent]->accessOrder <= heap[index]->accessOrder) return;
-      swapHeapEntries(parent, index);
-      index = parent;
-    }
-  }
-  void siftDown(size_t index) {
-    while (true) {
-      const size_t left = index * 2 + 1;
-      const size_t right = left + 1;
-      size_t smallest = index;
-      if (left < heap.size() &&
-          heap[left]->accessOrder < heap[smallest]->accessOrder)
-        smallest = left;
-      if (right < heap.size() &&
-          heap[right]->accessOrder < heap[smallest]->accessOrder)
-        smallest = right;
-      if (smallest == index) return;
-      swapHeapEntries(index, smallest);
-      index = smallest;
-    }
-  }
-  void swapHeapEntries(size_t first, size_t second) {
-    std::swap(heap[first], heap[second]);
-    heap[first]->heapIndex = first;
-    heap[second]->heapIndex = second;
-  }
 
   size_t capacity;
-  uint64_t accessOrder = 0;
-  std::unordered_map<Samples, Entry, SamplesHash> entries;
-  std::vector<Entry*> heap;
+  std::list<Entry> entriesByRecency;
+  std::unordered_map<Samples, std::list<Entry>::iterator, SamplesHash> entries;
 };
 
 }  // namespace tt::utils

--- a/tt-media-server/cpp_server/include/utils/voice_sample_cache.hpp
+++ b/tt-media-server/cpp_server/include/utils/voice_sample_cache.hpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace tt::utils {
+
+class VoiceSampleCache {
+ public:
+  using Samples = std::vector<int16_t>;
+  using SpeechIds = std::vector<uint32_t>;
+
+  explicit VoiceSampleCache(size_t capacity) : capacity(capacity) {}
+
+  bool exists(const Samples& samples) const {
+    return entries.find(samples) != entries.end();
+  }
+
+  SpeechIds get(const Samples& samples) {
+    auto entry = entries.find(samples);
+    if (entry == entries.end()) {
+      throw std::out_of_range("Voice sample cache entry does not exist");
+    }
+    touch(entry->second);
+    return entry->second.speechIds;
+  }
+
+  void add(const Samples& samples, SpeechIds speechIds) {
+    if (capacity == 0) return;
+    auto existing = entries.find(samples);
+    if (existing != entries.end()) {
+      existing->second.speechIds = std::move(speechIds);
+      touch(existing->second);
+      return;
+    }
+    if (entries.size() == capacity) {
+      Entry* leastRecentlyUsed = heap.front();
+      entries.erase(leastRecentlyUsed->samples);
+      heap.front() = heap.back();
+      heap.pop_back();
+      if (!heap.empty()) {
+        heap.front()->heapIndex = 0;
+        siftDown(0);
+      }
+    }
+    auto [entry, inserted] = entries.emplace(
+        samples,
+        Entry{samples, std::move(speechIds), ++accessOrder, heap.size()});
+    (void)inserted;
+    heap.push_back(&entry->second);
+    siftUp(entry->second.heapIndex);
+  }
+
+ private:
+  struct SamplesHash {
+    size_t operator()(const Samples& samples) const noexcept {
+      size_t hash = samples.size();
+      for (int16_t sample : samples) {
+        hash ^= static_cast<uint16_t>(sample) + 0x9e3779b9 + (hash << 6) +
+                (hash >> 2);
+      }
+      return hash;
+    }
+  };
+  struct Entry {
+    Samples samples;
+    SpeechIds speechIds;
+    uint64_t accessOrder;
+    size_t heapIndex;
+  };
+  void touch(Entry& entry) {
+    entry.accessOrder = ++accessOrder;
+    siftDown(entry.heapIndex);
+  }
+  void siftUp(size_t index) {
+    while (index > 0) {
+      const size_t parent = (index - 1) / 2;
+      if (heap[parent]->accessOrder <= heap[index]->accessOrder) return;
+      swapHeapEntries(parent, index);
+      index = parent;
+    }
+  }
+  void siftDown(size_t index) {
+    while (true) {
+      const size_t left = index * 2 + 1;
+      const size_t right = left + 1;
+      size_t smallest = index;
+      if (left < heap.size() &&
+          heap[left]->accessOrder < heap[smallest]->accessOrder)
+        smallest = left;
+      if (right < heap.size() &&
+          heap[right]->accessOrder < heap[smallest]->accessOrder)
+        smallest = right;
+      if (smallest == index) return;
+      swapHeapEntries(index, smallest);
+      index = smallest;
+    }
+  }
+  void swapHeapEntries(size_t first, size_t second) {
+    std::swap(heap[first], heap[second]);
+    heap[first]->heapIndex = first;
+    heap[second]->heapIndex = second;
+  }
+
+  size_t capacity;
+  uint64_t accessOrder = 0;
+  std::unordered_map<Samples, Entry, SamplesHash> entries;
+  std::vector<Entry*> heap;
+};
+
+}  // namespace tt::utils

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_tts_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_tts_runner.cpp
@@ -10,6 +10,7 @@
 #include <thread>
 #include <utility>
 
+#include "config/defaults.hpp"
 #include "runtime/worker/single_process_worker_metrics.hpp"
 #include "utils/logger.hpp"
 #include "utils/tts_prompt_compiler.hpp"
@@ -41,6 +42,7 @@ BlazeTtsRunner::BlazeTtsRunner(
       taskQueue(taskQueue),
       audioQueue(audioQueue),
       cancelQueue(cancelQueue),
+      voiceSampleCache(config::defaults::TTS_VOICE_SAMPLE_CACHE_SIZE),
       outputHangTimeout(this->config.outputHangTimeoutMs) {
   if (!this->scheduler) {
     throw std::invalid_argument("BlazeTtsRunner: scheduler must not be null");
@@ -218,20 +220,37 @@ void BlazeTtsRunner::drainTasks() {
 
 void BlazeTtsRunner::handleTask(ipc::tts::TtsIpcTask task) {
   if (!task.voiceWavPcm.empty()) {
-    sched::VoiceEncodeRequest request;
-    request.requestId = task.task_id;
-    request.wavPcm = std::move(task.voiceWavPcm);
-    if (!scheduler->enqueueVoiceEncode(std::move(request))) {
-      sendFinish(task.task_id, domain::tts::TtsFinishReason::Error,
-                 "TTS scheduler voice encoder queue is full");
+    if (voiceSampleCache.exists(task.voiceWavPcm)) {
+      try {
+        const auto cachedSpeechIds = voiceSampleCache.get(task.voiceWavPcm);
+        compilePromptTokens(task, cachedSpeechIds);
+      } catch (const std::exception& e) {
+        sendFinish(task.task_id, domain::tts::TtsFinishReason::Error, e.what());
+        return;
+      }
+    } else {
+      sched::VoiceEncodeRequest request;
+      request.requestId = task.task_id;
+      request.wavPcm = task.voiceWavPcm;
+      if (!scheduler->enqueueVoiceEncode(std::move(request))) {
+        sendFinish(task.task_id, domain::tts::TtsFinishReason::Error,
+                   "TTS scheduler voice encoder queue is full");
+        return;
+      }
+      pendingVoiceEncodes.emplace(task.task_id, std::move(task));
       return;
     }
-    const uint32_t taskId = task.task_id;
-    pendingVoiceEncodes.emplace(taskId, std::move(task));
-    return;
   }
 
   allocateTask(std::move(task));
+}
+
+void BlazeTtsRunner::compilePromptTokens(
+    ipc::tts::TtsIpcTask& task, const std::vector<uint32_t>& speechIds) {
+  const auto& tokenizer =
+      tt::utils::tts_tokenizer::tokenizerForPath(config.tokenizerPath);
+  task.promptTokens = tt::utils::tts_prompt_compiler::compilePromptTokens(
+      tokenizer, task.text, task.description, speechIds);
 }
 
 void BlazeTtsRunner::allocateTask(ipc::tts::TtsIpcTask task) {
@@ -299,10 +318,8 @@ void BlazeTtsRunner::handleVoiceEncodeResult(
   }
 
   try {
-    const auto& tokenizer =
-        tt::utils::tts_tokenizer::tokenizerForPath(config.tokenizerPath);
-    task.promptTokens = tt::utils::tts_prompt_compiler::compilePromptTokens(
-        tokenizer, task.text, task.description, result.speechIds);
+    voiceSampleCache.add(task.voiceWavPcm, result.speechIds);
+    compilePromptTokens(task, result.speechIds);
   } catch (const std::exception& e) {
     sendFinish(task.task_id, domain::tts::TtsFinishReason::Error, e.what());
     return;

--- a/tt-media-server/cpp_server/tests/integration/runners/blaze_tts_runner_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/runners/blaze_tts_runner_test.cpp
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#include "runtime/runners/blaze_runner/blaze_tts_runner.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "ipc/in_memory/in_memory_cancel_queue.hpp"
+
+namespace tt::runners::blaze {
+namespace {
+
+namespace sched = tts_scheduler;
+
+class RecordingTtsScheduler final : public sched::ITtsScheduler {
+ public:
+  void start() override {}
+  void stop() override {}
+  bool pushRequest(const sched::SchedulerRequest&) override { return true; }
+  bool submit(const sched::TtsSubmit&) override { return true; }
+  bool tryPopResponse(sched::SchedulerResponse&) override { return false; }
+  bool tryPopToken(sched::TokenOutput&) override { return false; }
+  bool tryPopAudio(sched::AudioOutput&) override { return false; }
+
+  bool enqueueVoiceEncode(sched::VoiceEncodeRequest request) override {
+    ++voiceEncodeCalls;
+    pendingResult.requestId = request.requestId;
+    pendingResult.speechIds = {12, 34, 56};
+    pendingResult.status = sched::VoiceEncodeStatus::Completed;
+    hasPendingResult = true;
+    return true;
+  }
+
+  bool tryPopVoiceEncodeResult(sched::VoiceEncodeResult& result) override {
+    if (!hasPendingResult) {
+      return false;
+    }
+    result = std::move(pendingResult);
+    hasPendingResult = false;
+    return true;
+  }
+
+  std::atomic<uint32_t> voiceEncodeCalls = 0;
+
+ private:
+  sched::VoiceEncodeResult pendingResult;
+  bool hasPendingResult = false;
+};
+
+std::string uniqueQueueName(const char* prefix) {
+  static std::atomic<uint32_t> sequence = 0;
+  return std::string(prefix) + "_" +
+         std::to_string(
+             std::chrono::steady_clock::now().time_since_epoch().count()) +
+         "_" + std::to_string(++sequence);
+}
+
+bool waitForFinish(ipc::tts::TtsAudioChunkQueue& audioQueue, uint32_t taskId) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (std::chrono::steady_clock::now() < deadline) {
+    ipc::tts::TtsAudioChunkMessage message;
+    if (audioQueue.tryPop(message) && message.task_id == taskId &&
+        message.isFinal()) {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  return false;
+}
+
+TEST(BlazeTtsRunnerIntegrationTest, ReusesSpeechIdsForMatchingVoiceSample) {
+  config::TtsConfig config;
+  config.maxUsers = 1;
+  config.taskQueueCapacity = 1;
+  config.audioQueueCapacity = 4;
+  config.tokenizerPath.clear();
+
+  ipc::tts::TtsTaskQueue taskQueue(uniqueQueueName("tts_task"), 4);
+  ipc::tts::TtsAudioChunkQueue audioQueue(uniqueQueueName("tts_audio"), 4);
+  ipc::in_memory::CancelQueue cancelQueue;
+  auto scheduler = std::make_unique<RecordingTtsScheduler>();
+  auto* schedulerPtr = scheduler.get();
+  BlazeTtsRunner runner(config, std::move(scheduler), &taskQueue, &audioQueue,
+                        &cancelQueue);
+  std::thread runnerThread([&runner] { runner.start(); });
+
+  const std::vector<int16_t> samples = {1, 2, 3, 4};
+  taskQueue.push({.task_id = 1, .text = "first", .voiceWavPcm = samples});
+  EXPECT_TRUE(waitForFinish(audioQueue, 1));
+  EXPECT_EQ(schedulerPtr->voiceEncodeCalls.load(), 1u);
+
+  taskQueue.push({.task_id = 2, .text = "second", .voiceWavPcm = samples});
+  EXPECT_TRUE(waitForFinish(audioQueue, 2));
+  EXPECT_EQ(schedulerPtr->voiceEncodeCalls.load(), 1u);
+
+  taskQueue.shutdown();
+  runnerThread.join();
+  taskQueue.remove();
+  audioQueue.remove();
+}
+
+}  // namespace
+}  // namespace tt::runners::blaze

--- a/tt-media-server/cpp_server/tests/unit/utils/voice_sample_cache_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/utils/voice_sample_cache_test.cpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+#include "utils/voice_sample_cache.hpp"
+
+#include <gtest/gtest.h>
+
+namespace tt::utils {
+namespace {
+
+TEST(VoiceSampleCacheTest, HitRefreshesAccessOrder) {
+  VoiceSampleCache cache(2);
+  const VoiceSampleCache::Samples first = {1, 2};
+  const VoiceSampleCache::Samples second = {3, 4};
+  const VoiceSampleCache::Samples third = {5, 6};
+  cache.add(first, {10});
+  cache.add(second, {20});
+  EXPECT_EQ(cache.get(first), (VoiceSampleCache::SpeechIds{10}));
+  cache.add(third, {30});
+  EXPECT_TRUE(cache.exists(first));
+  EXPECT_FALSE(cache.exists(second));
+}
+
+TEST(VoiceSampleCacheTest, ReplacesExistingEntryWithoutEviction) {
+  VoiceSampleCache cache(2);
+  const VoiceSampleCache::Samples first = {1};
+  const VoiceSampleCache::Samples second = {2};
+  cache.add(first, {10});
+  cache.add(second, {20});
+  cache.add(first, {11, 12});
+  EXPECT_EQ(cache.get(first), (VoiceSampleCache::SpeechIds{11, 12}));
+  EXPECT_EQ(cache.get(second), (VoiceSampleCache::SpeechIds{20}));
+}
+
+TEST(VoiceSampleCacheTest, EvictsLeastRecentlyUsedEntry) {
+  VoiceSampleCache cache(2);
+  const VoiceSampleCache::Samples first = {1};
+  const VoiceSampleCache::Samples second = {2};
+  const VoiceSampleCache::Samples third = {3};
+  cache.add(first, {10});
+  cache.add(second, {20});
+  cache.add(third, {30});
+  EXPECT_FALSE(cache.exists(first));
+  EXPECT_TRUE(cache.exists(second));
+  EXPECT_TRUE(cache.exists(third));
+}
+
+TEST(VoiceSampleCacheTest, ZeroCapacityDoesNotStoreEntries) {
+  VoiceSampleCache cache(0);
+  const VoiceSampleCache::Samples samples = {1};
+  cache.add(samples, {10});
+  EXPECT_FALSE(cache.exists(samples));
+}
+
+}  // namespace
+}  // namespace tt::utils


### PR DESCRIPTION
## Issue
[#4878 Cache encoded TTS voice samples](https://github.com/tenstorrent/tt-inference-server/issues/4878)

## Problem
We want to cache encoded voice samples so we can reuse them when possible and avoid the expensive compute required to encode them again.

With this implementation, we introduce a cache with a limited capacity and use LRU eviction when the capacity is reached.
