### PR TITLE
vcankovic/vllm-tt-plugin: switch vLLM source from the tenstorrent/vllm fork to vllm-tt-plugin + upstream vLLM

### DIFF
--- a/run.py
+++ b/run.py
@@ -258,9 +258,11 @@ def parse_arguments():
         "--vllm-dir",
         type=str,
         default=os.getenv("vllm_dir"),
-        help="[for --local-server] Host path to the vLLM source tree to export as vllm_dir "
-        "and append to PYTHONPATH. Defaults to vllm_dir from the environment when set, "
-        "otherwise tt-metal-home/vllm.",
+        help="[DEPRECATED, ignored] Formerly the host path to a vLLM source tree, exported "
+        "as vllm_dir and appended to PYTHONPATH. vLLM is now an ordinary installed package "
+        "in the tt-metal venv and the TT platform comes from the separately installed "
+        "vllm-tt-plugin, so no source tree is needed. Accepted for backwards compatibility; "
+        "will be removed in a future release.",
     )
     parser.add_argument(
         "--limit-samples-mode",
@@ -689,8 +691,12 @@ def parse_arguments():
         args.device = infer_default_device(args.model, args.engine)
     args.tt_device = args.device
 
-    if not args.vllm_dir and args.tt_metal_home:
-        args.vllm_dir = str(Path(args.tt_metal_home).expanduser() / "vllm")
+    if args.vllm_dir:
+        logger.warning(
+            "--vllm-dir (or the vllm_dir env var) is deprecated and ignored: vLLM is "
+            "installed into the tt-metal venv as an ordinary package and the TT platform "
+            "is provided by vllm-tt-plugin, so no vLLM source tree is used."
+        )
 
     # indirectly set additional flags for CI-mode
     if args.ci_mode:
@@ -881,7 +887,6 @@ def format_cli_args_summary(runtime_config):
         f"  no_auth:                    {runtime_config.no_auth}",
         f"  tt_metal_python_venv_dir:   {runtime_config.tt_metal_python_venv_dir}",
         f"  tt_metal_home:              {runtime_config.tt_metal_home}",
-        f"  vllm_dir:                   {runtime_config.vllm_dir}",
         f"  service_port:               {runtime_config.service_port}",
         f"  bind_host:                  {runtime_config.bind_host}",
         f"  docker_override_image:      {runtime_config.override_docker_image}",

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -123,6 +123,13 @@ This will build all missing `dev` containers for the given `model_spec.py` and p
 python3 scripts/build_docker_images.py --push
 ```
 
+> **Note:** this script takes `vllm_commit` straight from the model spec catalogue (it has no
+> `--vllm-commit` override) and passes it to `TT_VLLM_COMMIT_SHA_OR_TAG`, which the Dockerfile now
+> resolves against [`tenstorrent/vllm-tt-plugin`](https://github.com/tenstorrent/vllm-tt-plugin).
+> Any spec still pinned to a `tenstorrent/vllm` fork commit will fail at `git checkout` in the
+> builder. Repin those `vllm_commit` values to plugin commits before a bulk build. Note that CI is
+> unaffected — it goes through `build_single_docker.sh` with an explicitly resolved SHA.
+
 #### outputs
 
 - `workflow_logs/docker_build_logs/build_summary_{date}_{time}.json`: list of all outcomes of docker image script, includes `build_attempted`, `build_succeeded`, and `remote_exists` which list the status of docker images.
@@ -171,6 +178,11 @@ Only if needed, will see in `release_logs/release_artifacts_summary.md` if any i
 ```bash
 python3 scripts/build_docker_images.py --push --release
 ```
+
+> **Note:** as in step 3b of the dev release, `vllm_commit` comes straight from the model spec
+> catalogue and is resolved against
+> [`tenstorrent/vllm-tt-plugin`](https://github.com/tenstorrent/vllm-tt-plugin). Specs still pinned
+> to a `tenstorrent/vllm` fork commit will fail at `git checkout` in the builder.
 
 #### outputs
 

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -510,8 +510,9 @@ class TestModelSpecCliArgsCompatibility:
 
         assert args.tt_metal_home == "/env/tt-metal"
 
-    def test_vllm_dir_defaults_from_env(self, base_args):
-        """Test --vllm-dir falls back to vllm_dir env var."""
+    def test_vllm_dir_still_accepted_from_env(self, base_args):
+        """--vllm-dir is deprecated but still parsed, so old invocations and an
+        exported vllm_dir do not become hard errors."""
         full_args = base_args + ["--local-server", "--tt-metal-home", "/srv/tt-metal"]
         with patch.dict(os.environ, {"vllm_dir": "/env/vllm"}, clear=False):
             with patch("sys.argv", ["run.py"] + full_args):
@@ -519,13 +520,20 @@ class TestModelSpecCliArgsCompatibility:
 
         assert args.vllm_dir == "/env/vllm"
 
-    def test_vllm_dir_defaults_from_tt_metal_home(self, base_args):
-        """Test --vllm-dir defaults to tt-metal-home/vllm."""
-        full_args = base_args + ["--local-server", "--tt-metal-home", "/srv/tt-metal"]
-        with patch("sys.argv", ["run.py"] + full_args):
-            args = parse_arguments()
+    def test_vllm_dir_is_not_derived_from_tt_metal_home(self, base_args):
+        """No vLLM source tree is assumed any more.
 
-        assert args.vllm_dir == "/srv/tt-metal/vllm"
+        vLLM is an ordinary installed package in the tt-metal venv and the TT
+        platform comes from the separately installed vllm-tt-plugin, so run.py
+        must not synthesise a tt-metal-home/vllm path.
+        """
+        full_args = base_args + ["--local-server", "--tt-metal-home", "/srv/tt-metal"]
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("vllm_dir", None)
+            with patch("sys.argv", ["run.py"] + full_args):
+                args = parse_arguments()
+
+        assert args.vllm_dir is None
 
     def test_host_hf_cache_bare_flag_defaults_from_env(self, base_args):
         """Test bare --host-hf-cache resolves via HOST_HF_HOME/HF_HOME defaults."""

--- a/tests/test_run_local_server.py
+++ b/tests/test_run_local_server.py
@@ -15,10 +15,8 @@ from workflows.run_local_server import (
     build_local_server_env,
     generate_local_run_command,
     install_local_server_requirements,
-    install_vllm_tt_plugin_if_present,
     run_local_command,
     run_local_server,
-    vllm_tt_plugin_source_path,
 )
 from workflows.runtime_config import RuntimeConfig
 
@@ -109,7 +107,7 @@ class TestRunLocalServer:
         assert "--disable-trace-capture" in command
         assert env["TT_METAL_HOME"] == str(tt_metal_home)
         assert env["APP_DIR"] == str(repo_root)
-        assert env["vllm_dir"] == str(tt_metal_home / "vllm")
+        assert "vllm_dir" not in env
         assert process_name.startswith("tt-inference-server-local-")
 
     def test_install_local_server_requirements_uses_tt_metal_venv(self, tmp_path):
@@ -142,9 +140,16 @@ class TestRunLocalServer:
         assert str(requirements_path) in install_command
         assert run_command_mock.call_args_list[0].kwargs["check"] is True
 
-    def test_install_local_server_requirements_also_installs_plugin_when_present(
+    def test_install_local_server_requirements_does_not_install_vllm_or_plugin(
         self, tmp_path
     ):
+        """Only requirements.txt is installed here.
+
+        vLLM and vllm-tt-plugin are installed by the plugin repo's
+        docs/install-vllm-tt.sh, which owns the vLLM version pin and the
+        dependency overrides. Installing either from here risks a mismatched
+        pair; validate_setup probes that both are present instead.
+        """
         repo_root = tmp_path / "repo"
         requirements_path = repo_root / "vllm-tt-metal" / "requirements.txt"
         requirements_path.parent.mkdir(parents=True)
@@ -155,98 +160,17 @@ class TestRunLocalServer:
         python_bin_dir.mkdir(parents=True)
         (python_bin_dir / "python").write_text("")
 
-        # Stage a vllm checkout that ships the plugin source.
-        vllm_dir = tmp_path / "vllm"
-        plugin_dir = vllm_tt_plugin_source_path(vllm_dir)
-        plugin_dir.mkdir(parents=True)
-        (plugin_dir / "pyproject.toml").write_text(
-            "[project]\nname = 'vllm-tt-plugin'\n"
-        )
-
-        runtime_config = self._make_runtime_config(
-            tt_metal_home, vllm_dir=str(vllm_dir)
-        )
+        runtime_config = self._make_runtime_config(tt_metal_home)
 
         with patch("workflows.run_local_server.run_command") as run_command_mock, patch(
             "workflows.run_local_server.UV_EXEC", Path("/tmp/uv")
         ):
             install_local_server_requirements(runtime_config, repo_root=repo_root)
 
-        # Two calls: requirements.txt then plugin editable install.
-        assert run_command_mock.call_count == 2
-        plugin_command = run_command_mock.call_args_list[1].args[0]
-        assert "pip install" in plugin_command
-        assert "--no-deps" in plugin_command
-        assert " -e " in plugin_command
-        assert str(plugin_dir) in plugin_command
-        assert run_command_mock.call_args_list[1].kwargs["check"] is True
-
-    def test_install_vllm_tt_plugin_if_present_skips_when_dir_missing(self, tmp_path):
-        repo_root = tmp_path / "repo"
-        (repo_root / "vllm-tt-metal").mkdir(parents=True)
-
-        tt_metal_home = tmp_path / "tt-metal"
-        python_bin_dir = tt_metal_home / "python_env" / "bin"
-        python_bin_dir.mkdir(parents=True)
-        (python_bin_dir / "python").write_text("")
-
-        vllm_dir = tmp_path / "vllm"
-        vllm_dir.mkdir()
-        runtime_config = self._make_runtime_config(
-            tt_metal_home, vllm_dir=str(vllm_dir)
-        )
-
-        with patch("workflows.run_local_server.run_command") as run_command_mock:
-            result = install_vllm_tt_plugin_if_present(
-                runtime_config, repo_root=repo_root
-            )
-
-        assert result is False
-        run_command_mock.assert_not_called()
-
-    def test_install_vllm_tt_plugin_if_present_invokes_uv_pip_when_dir_exists(
-        self, tmp_path
-    ):
-        repo_root = tmp_path / "repo"
-        (repo_root / "vllm-tt-metal").mkdir(parents=True)
-
-        tt_metal_home = tmp_path / "tt-metal"
-        python_bin_dir = tt_metal_home / "python_env" / "bin"
-        python_bin_dir.mkdir(parents=True)
-        venv_python = python_bin_dir / "python"
-        venv_python.write_text("")
-
-        vllm_dir = tmp_path / "vllm"
-        plugin_dir = vllm_tt_plugin_source_path(vllm_dir)
-        plugin_dir.mkdir(parents=True)
-        (plugin_dir / "pyproject.toml").write_text(
-            "[project]\nname = 'vllm-tt-plugin'\n"
-        )
-
-        runtime_config = self._make_runtime_config(
-            tt_metal_home, vllm_dir=str(vllm_dir)
-        )
-
-        with patch("workflows.run_local_server.run_command") as run_command_mock, patch(
-            "workflows.run_local_server.UV_EXEC", Path("/tmp/uv")
-        ):
-            result = install_vllm_tt_plugin_if_present(
-                runtime_config, repo_root=repo_root
-            )
-
-        assert result is True
-        run_command_mock.assert_called_once()
-        install_command = run_command_mock.call_args.args[0]
-        assert str(Path("/tmp/uv")) in install_command
-        assert "pip install" in install_command
-        assert f"--python {venv_python}" in install_command
-        assert "--no-deps" in install_command
-        assert " -e " in install_command
-        # The plugin source path appears as an absolute path ending with the
-        # canonical plugins/vllm-tt-plugin suffix.
-        assert str(plugin_dir) in install_command
-        assert "plugins/vllm-tt-plugin" in install_command
-        assert run_command_mock.call_args.kwargs["check"] is True
+        assert run_command_mock.call_count == 1
+        install_command = run_command_mock.call_args_list[0].args[0]
+        assert str(requirements_path) in install_command
+        assert " -e " not in install_command
 
     def test_build_local_server_env_sets_expected_overrides(self, tmp_path):
         repo_root = tmp_path / "repo"
@@ -289,11 +213,11 @@ class TestRunLocalServer:
         pythonpath_parts = env["PYTHONPATH"].split(os.pathsep)
         assert str(tt_metal_home) in pythonpath_parts
         assert str(repo_root) in pythonpath_parts
-        assert env["vllm_dir"] == str(tt_metal_home / "vllm")
-        assert pythonpath_parts[-1] == str(tt_metal_home / "vllm")
+        assert "vllm_dir" not in env
+        assert str(tt_metal_home / "vllm") not in pythonpath_parts
         assert str(tt_metal_home / "build" / "lib") in env["LD_LIBRARY_PATH"]
 
-    def test_build_local_server_env_uses_explicit_vllm_dir(self, tmp_path):
+    def test_build_local_server_env_ignores_deprecated_vllm_dir(self, tmp_path):
         repo_root = tmp_path / "repo"
         entrypoint = repo_root / "vllm-tt-metal" / "src" / "run_vllm_api_server.py"
         entrypoint.parent.mkdir(parents=True)
@@ -324,10 +248,15 @@ class TestRunLocalServer:
             repo_root=repo_root,
         )
 
+        # --vllm-dir is deprecated and ignored: vLLM is an installed package in
+        # the tt-metal venv, not a source checkout, so neither the vllm_dir export
+        # nor the PYTHONPATH append survives.
         assert env["APP_DIR"] == str(repo_root)
+        assert "vllm_dir" not in env
         pythonpath_parts = env["PYTHONPATH"].split(os.pathsep)
-        assert env["vllm_dir"] == str(vllm_dir.resolve())
-        assert pythonpath_parts[-1] == str(vllm_dir.resolve())
+        assert str(vllm_dir.resolve()) not in pythonpath_parts
+        assert pythonpath_parts[0] == str(tt_metal_home.resolve())
+        assert pythonpath_parts[1] == str(repo_root)
 
     def test_build_local_server_env_uses_setup_host_default_cache_root(self, tmp_path):
         repo_root = tmp_path / "repo"

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -6,7 +6,7 @@
 
 import os
 from argparse import Namespace
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -14,7 +14,6 @@ from reference_config.agentic_traces.agentic_traces_config import (
     AGENTIC_TRACES_CONFIGS,
     TraceSource,
 )
-from workflows.run_local_server import vllm_tt_plugin_source_path
 from workflows.runtime_config import RuntimeConfig
 from workflows.utils import check_path_permissions_for_uid
 from workflows.validate_setup import (
@@ -508,15 +507,20 @@ class TestLocalServerValidation:
 
         mock_get_log_dir.return_value = tmp_path / "logs"
 
-        # No vllm checkout, so plugin install + check are skipped and the only
-        # run_command call is the existing `import vllm` probe.
         validate_local_setup(model_spec, runtime_config, tmp_path / "runtime.json")
 
         mock_ensure_dir.assert_called_once_with(tmp_path / "logs")
-        mock_run_command.assert_any_call(
-            [str(venv_python), "-c", "import vllm"], logger=ANY
-        )
-        assert mock_run_command.call_count == 1
+        # Two probes, both unconditional: vLLM importable, then the vllm-tt-plugin
+        # `tt` platform entry point registered. Neither needs a source checkout.
+        assert mock_run_command.call_count == 2
+        calls = mock_run_command.call_args_list
+        assert calls[0].args[0] == [str(venv_python), "-c", "import vllm"]
+        probe_cmd = calls[1].args[0]
+        assert probe_cmd[0] == str(venv_python)
+        assert probe_cmd[1] == "-c"
+        assert "import vllm_tt_plugin" in probe_cmd[2]
+        assert "vllm.platform_plugins" in probe_cmd[2]
+        assert "'tt' in eps" in probe_cmd[2]
 
     @patch("workflows.validate_setup.run_command", return_value=1)
     @patch("workflows.validate_setup.ensure_readwriteable_dir")
@@ -546,21 +550,21 @@ class TestLocalServerValidation:
         mock_ensure_dir.assert_called_once_with(tmp_path / "logs")
         mock_run_command.assert_called_once()
 
-    @patch("workflows.run_local_server.run_command", return_value=0)
-    @patch("workflows.validate_setup.run_command", return_value=0)
     @patch("workflows.validate_setup.ensure_readwriteable_dir")
     @patch("workflows.validate_setup.get_default_workflow_root_log_dir")
-    def test_validate_local_setup_installs_and_verifies_tt_plugin_when_present(
+    def test_validate_local_setup_probes_tt_plugin_without_a_vllm_checkout(
         self,
         mock_get_log_dir,
         mock_ensure_dir,
-        mock_validate_run_command,
-        mock_runlocal_run_command,
         tmp_path,
     ):
-        """When the vLLM checkout ships plugins/vllm-tt-plugin, local-server
-        validation must (a) editable-install the plugin via run_local_server's
-        install helper and (b) probe that the `tt` entry-point is registered.
+        """The `tt` entry-point probe must run unconditionally.
+
+        vllm-tt-plugin is its own repository now, installed into the tt-metal
+        venv by its docs/install-vllm-tt.sh. There is no plugin source tree
+        under the vLLM checkout to gate the probe on, and gating on one meant
+        validation was silently skipped in exactly the case it was needed --
+        letting `vllm serve` fail later with no TT platform registered.
         """
         tt_metal_home = tmp_path / "tt-metal"
         python_bin_dir = tt_metal_home / "python_env" / "bin"
@@ -568,96 +572,27 @@ class TestLocalServerValidation:
         venv_python = python_bin_dir / "python"
         venv_python.write_text("")
 
-        # Stage the plugin source so the validator detects it.
-        vllm_dir = tmp_path / "vllm"
-        plugin_dir = vllm_tt_plugin_source_path(vllm_dir)
-        plugin_dir.mkdir(parents=True)
-        (plugin_dir / "pyproject.toml").write_text(
-            "[project]\nname = 'vllm-tt-plugin'\n"
-        )
-
         model_spec = self._make_model_spec()
         runtime_config = self._make_runtime_config()
         runtime_config.tt_metal_home = str(tt_metal_home)
-        runtime_config.vllm_dir = str(vllm_dir)
         runtime_config.skip_system_sw_validation = True
 
         mock_get_log_dir.return_value = tmp_path / "logs"
 
-        validate_local_setup(model_spec, runtime_config, tmp_path / "runtime.json")
-
-        # The plugin install happens through workflows.run_local_server.run_command
-        # because install_vllm_tt_plugin_if_present is defined in that module.
-        mock_runlocal_run_command.assert_called_once()
-        plugin_install_cmd = mock_runlocal_run_command.call_args.args[0]
-        assert "pip install" in plugin_install_cmd
-        assert "--no-deps" in plugin_install_cmd
-        assert "plugins/vllm-tt-plugin" in plugin_install_cmd
-        assert mock_runlocal_run_command.call_args.kwargs["check"] is True
-
-        # The validator side does two calls: `import vllm` and the entry-point check.
-        validate_calls = mock_validate_run_command.call_args_list
-        assert len(validate_calls) == 2
-        assert validate_calls[0].args[0] == [str(venv_python), "-c", "import vllm"]
-        entry_point_cmd = validate_calls[1].args[0]
-        assert entry_point_cmd[0] == str(venv_python)
-        assert entry_point_cmd[1] == "-c"
-        script = entry_point_cmd[2]
-        assert "import vllm_tt_plugin" in script
-        assert "vllm.platform_plugins" in script
-        assert "'tt' in eps" in script
-
-    @patch("workflows.run_local_server.run_command", return_value=0)
-    @patch("workflows.validate_setup.ensure_readwriteable_dir")
-    @patch("workflows.validate_setup.get_default_workflow_root_log_dir")
-    def test_validate_local_setup_raises_when_tt_plugin_entry_point_missing(
-        self,
-        mock_get_log_dir,
-        mock_ensure_dir,
-        mock_runlocal_run_command,
-        tmp_path,
-    ):
-        """If the plugin install succeeds but the entry-point check fails
-        (e.g. wheel staleness, missing pip --editable refresh), validation
-        must raise an actionable error rather than letting `vllm serve`
-        crash later.
-        """
-        tt_metal_home = tmp_path / "tt-metal"
-        python_bin_dir = tt_metal_home / "python_env" / "bin"
-        python_bin_dir.mkdir(parents=True)
-        (python_bin_dir / "python").write_text("")
-
-        vllm_dir = tmp_path / "vllm"
-        plugin_dir = vllm_tt_plugin_source_path(vllm_dir)
-        plugin_dir.mkdir(parents=True)
-        (plugin_dir / "pyproject.toml").write_text(
-            "[project]\nname = 'vllm-tt-plugin'\n"
-        )
-
-        model_spec = self._make_model_spec()
-        runtime_config = self._make_runtime_config()
-        runtime_config.tt_metal_home = str(tt_metal_home)
-        runtime_config.vllm_dir = str(vllm_dir)
-        runtime_config.skip_system_sw_validation = True
-
-        mock_get_log_dir.return_value = tmp_path / "logs"
-
-        # `import vllm` (call 1) succeeds with rc=0; the plugin entry-point
-        # probe (call 2) fails with rc=1.
+        # Deliberately no vLLM checkout staged anywhere. `import vllm` succeeds
+        # (rc=0); the plugin probe fails (rc=1) and must surface as an error.
         with patch(
             "workflows.validate_setup.run_command", side_effect=[0, 1]
-        ) as mock_validate_run_command:
-            with pytest.raises(
-                ValueError,
-                match=r"`vllm_tt_plugin` Python package",
-            ):
+        ) as mock_run_command:
+            with pytest.raises(ValueError, match=r"`vllm_tt_plugin` Python package"):
                 validate_local_setup(
                     model_spec, runtime_config, tmp_path / "runtime.json"
                 )
 
-            assert mock_validate_run_command.call_count == 2
-
-        mock_runlocal_run_command.assert_called_once()
+            assert mock_run_command.call_count == 2
+            probe_script = mock_run_command.call_args_list[1].args[0][2]
+            assert "import vllm_tt_plugin" in probe_script
+            assert "vllm.platform_plugins" in probe_script
 
 
 class TestAgenticTracesRegistration:

--- a/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
+++ b/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
@@ -81,6 +81,8 @@ RUN /bin/bash -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ENV UV_HTTP_RETRIES=10
 
 # Build tt-metal - clone with minimal history, build, and clean
+# uv's cache grows to ~3G here and ~11G after the vLLM install; the builder stage is
+# discarded, but its layers still fill the container storage fs during image export.
 RUN /bin/bash -c "git clone https://github.com/tenstorrent-metal/tt-metal.git ${TT_METAL_HOME} \
     && cd ${TT_METAL_HOME} \
     && git checkout ${TT_METAL_COMMIT_SHA_OR_TAG} \
@@ -89,7 +91,8 @@ RUN /bin/bash -c "git clone https://github.com/tenstorrent-metal/tt-metal.git ${
     && ( for i in 1 2 3 4 5; do CXX=clang++-17 CC=clang-17 bash ./create_venv.sh && exit 0; echo 'create_venv.sh failed, retrying in 30s'; sleep 30; done; exit 1 ) \
     && source ${PYTHON_ENV_DIR}/bin/activate \
     && if [ -f 'models/demos/qwen25_vl/requirements.txt' ]; then uv pip install -r models/demos/qwen25_vl/requirements.txt; fi \
-    && rm -rf ${TT_METAL_HOME}/.git"
+    && rm -rf ${TT_METAL_HOME}/.git \
+    && { uv cache clean || echo 'WARN: uv cache clean failed'; true; }"
 
 # Build vllm-tt-plugin - clone with minimal history and clean.
 # The plugin owns the vLLM version pin and its dependency overrides, so the
@@ -100,7 +103,8 @@ RUN /bin/bash -c "git clone https://github.com/tenstorrent/vllm-tt-plugin.git ${
     && source ${PYTHON_ENV_DIR}/bin/activate \
     && uv pip install --upgrade pip \
     && source docs/install-vllm-tt.sh \
-    && rm -rf ${vllm_tt_plugin_dir}/.git"
+    && rm -rf ${vllm_tt_plugin_dir}/.git \
+    && { uv cache clean || echo 'WARN: uv cache clean failed'; true; }"
 
 # Build tt-smi in separate venv to avoid conflicts with tt-metal venv
 RUN /bin/bash -c "git clone https://github.com/tenstorrent/tt-smi.git ${TT_SMI_DIR} \

--- a/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
+++ b/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
@@ -29,7 +29,7 @@ ENV TT_METAL_COMMIT_SHA_OR_TAG=${TT_METAL_COMMIT_SHA_OR_TAG} \
     CONFIG=Release \
     TT_METAL_ENV=dev \
     VLLM_TARGET_DEVICE="tt" \
-    vllm_dir=${HOME_DIR}/vllm \
+    vllm_tt_plugin_dir=${HOME_DIR}/vllm-tt-plugin \
     TT_SMI_DIR=${HOME_DIR}/tt-smi \
     LOGURU_LEVEL=INFO \
     # Rust build dependencies, for backward compatibility with tt-metal 
@@ -91,17 +91,16 @@ RUN /bin/bash -c "git clone https://github.com/tenstorrent-metal/tt-metal.git ${
     && if [ -f 'models/demos/qwen25_vl/requirements.txt' ]; then uv pip install -r models/demos/qwen25_vl/requirements.txt; fi \
     && rm -rf ${TT_METAL_HOME}/.git"
 
-# Build vllm - clone with minimal history and clean
-# Use uv pip to match tt-metal's package manager (see tt-metal commit 29d59d1)
-# Use --index-strategy unsafe-best-match to allow uv to find packages across all indexes
-RUN /bin/bash -c "git clone https://github.com/tenstorrent/vllm.git ${vllm_dir} \
-    && cd ${vllm_dir} \
+# Build vllm-tt-plugin - clone with minimal history and clean.
+# The plugin owns the vLLM version pin and its dependency overrides, so the
+# install is delegated to its own docs/install-vllm-tt.sh rather than restated here
+RUN /bin/bash -c "git clone https://github.com/tenstorrent/vllm-tt-plugin.git ${vllm_tt_plugin_dir} \
+    && cd ${vllm_tt_plugin_dir} \
     && git checkout ${TT_VLLM_COMMIT_SHA_OR_TAG} \
     && source ${PYTHON_ENV_DIR}/bin/activate \
     && uv pip install --upgrade pip \
-    && VLLM_TARGET_DEVICE=empty uv pip install --index-strategy unsafe-best-match -e . --extra-index-url https://download.pytorch.org/whl/cpu \
-    && if [ -d plugins/vllm-tt-plugin ]; then uv pip install --index-strategy unsafe-best-match -e 'plugins/vllm-tt-plugin[runtime]' --extra-index-url https://download.pytorch.org/whl/cpu; fi \
-    && rm -rf ${vllm_dir}/.git"
+    && source docs/install-vllm-tt.sh \
+    && rm -rf ${vllm_tt_plugin_dir}/.git"
 
 # Build tt-smi in separate venv to avoid conflicts with tt-metal venv
 RUN /bin/bash -c "git clone https://github.com/tenstorrent/tt-smi.git ${TT_SMI_DIR} \
@@ -140,7 +139,7 @@ ENV TT_METAL_COMMIT_SHA_OR_TAG=${TT_METAL_COMMIT_SHA_OR_TAG} \
     CONFIG=Release \
     TT_METAL_ENV=dev \
     VLLM_TARGET_DEVICE="tt" \
-    vllm_dir=${HOME_DIR}/vllm \
+    vllm_tt_plugin_dir=${HOME_DIR}/vllm-tt-plugin \
     TT_SMI_DIR=${HOME_DIR}/tt-smi \
     LOGURU_LEVEL=INFO \
     TT_METAL_LOGS_PATH=${HOME_DIR}/logs
@@ -180,9 +179,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} \
     ${TT_METAL_HOME} ${TT_METAL_HOME}
 
-# Copy complete vllm installation  
+# Copy the vllm-tt-plugin source tree. This is the editable-install target, so it
+# must land at the same absolute path as in the builder or the .pth link breaks.
+# vLLM itself needs no COPY of its own: it is a regular (non-editable) install
+# inside ${PYTHON_ENV_DIR}/site-packages, already copied with TT_METAL_HOME above.
 COPY --from=builder --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} \
-    ${vllm_dir} ${vllm_dir}
+    ${vllm_tt_plugin_dir} ${vllm_tt_plugin_dir}
 
 # Copy complete tt-smi installation  
 COPY --from=builder --chown=${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} \

--- a/workflows/run_local_server.py
+++ b/workflows/run_local_server.py
@@ -39,12 +39,6 @@ def _prepend_env_path(value: Path, existing: str) -> str:
     return os.pathsep.join(parts)
 
 
-def _append_env_path(existing: str, value: Path) -> str:
-    parts = [existing] if existing else []
-    parts.append(str(value))
-    return os.pathsep.join(parts)
-
-
 def _format_env_exports(env) -> str:
     export_lines = []
     for key in sorted(env):
@@ -63,11 +57,6 @@ def get_local_server_paths(runtime_config, repo_root=None):
         if runtime_config.tt_metal_python_venv_dir
         else tt_metal_home / "python_env"
     )
-    vllm_dir = (
-        Path(runtime_config.vllm_dir).expanduser().resolve()
-        if getattr(runtime_config, "vllm_dir", None)
-        else (tt_metal_home / "vllm").resolve()
-    )
     entrypoint_path = (
         repo_root_path / "vllm-tt-metal" / "src" / "run_vllm_api_server.py"
     )
@@ -76,7 +65,6 @@ def get_local_server_paths(runtime_config, repo_root=None):
         "app_dir": repo_root_path,
         "tt_metal_home": tt_metal_home,
         "python_env_dir": python_env_dir,
-        "vllm_dir": vllm_dir,
         "venv_python": python_env_dir / "bin" / "python",
         "entrypoint_path": entrypoint_path,
         "requirements_path": repo_root_path / "vllm-tt-metal" / "requirements.txt",
@@ -147,7 +135,6 @@ def build_local_server_env(
     app_dir = paths["app_dir"]
     tt_metal_home = paths["tt_metal_home"]
     python_env_dir = paths["python_env_dir"]
-    vllm_dir = paths["vllm_dir"]
     storage_paths = ensure_local_server_storage_paths(
         model_spec, runtime_config, setup_config
     )
@@ -159,12 +146,14 @@ def build_local_server_env(
     env["APP_DIR"] = str(app_dir)
     env["TT_METAL_HOME"] = str(tt_metal_home)
     env["PYTHON_ENV_DIR"] = str(python_env_dir)
-    env["vllm_dir"] = str(vllm_dir)
-    pythonpath = _prepend_env_path(
+    # No vllm_dir export and no vLLM source dir on PYTHONPATH: vLLM is a normal
+    # installed package in the tt-metal venv (from PyPI, via the plugin's
+    # install-vllm-tt.sh) rather than a source checkout, and vllm_tt_plugin is
+    # pip-installed too. Nothing under vllm-tt-metal/src or utils/ reads either.
+    env["PYTHONPATH"] = _prepend_env_path(
         tt_metal_home,
         _prepend_env_path(app_dir, env.get("PYTHONPATH", "")),
     )
-    env["PYTHONPATH"] = _append_env_path(pythonpath, vllm_dir)
     env["LD_LIBRARY_PATH"] = _prepend_env_path(
         tt_metal_home / "build" / "lib", env.get("LD_LIBRARY_PATH", "")
     )
@@ -240,49 +229,6 @@ def generate_local_run_command(
     return command, env, process_name
 
 
-def vllm_tt_plugin_source_path(vllm_dir: Path) -> Path:
-    """Return the on-disk location of the vllm-tt-plugin source tree inside a vLLM checkout.
-
-    The plugin package was introduced by tenstorrent/vllm commit a072e40a6
-    ("Extract TT backend into plugin package (Phase 1)", 2026-05-04). Older
-    vLLM checkouts do not contain this directory and continue to ship the TT
-    platform inside vllm core.
-    """
-    return Path(vllm_dir) / "plugins" / "vllm-tt-plugin"
-
-
-def install_vllm_tt_plugin_if_present(runtime_config, repo_root=None) -> bool:
-    """Editable-install the vllm-tt-plugin package into the tt-metal venv if it
-    exists in the user's vLLM checkout.
-
-    Mirrors the conditional install added to
-    vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile by PR #3370. The plugin owns
-    the ``tt`` entry in ``vllm.platform_plugins`` since tenstorrent/vllm
-    commit a072e40a6 ("Extract TT backend into plugin package (Phase 1)").
-
-    Returns True when the plugin source was found and an install command was
-    invoked, False when the plugin directory does not exist (older vLLM
-    checkouts that still bundle the TT platform inside vllm core).
-    """
-    paths = get_local_server_paths(runtime_config, repo_root=repo_root)
-    vllm_dir = paths["vllm_dir"]
-    plugin_path = vllm_tt_plugin_source_path(vllm_dir)
-    if not (plugin_path / "pyproject.toml").exists():
-        logger.info(
-            f"Skipping vllm-tt-plugin install: source not present at {plugin_path}"
-        )
-        return False
-
-    install_command = (
-        f"{shlex.quote(str(UV_EXEC))} pip install "
-        f"--python {shlex.quote(str(paths['venv_python']))} "
-        f"--no-deps -e {shlex.quote(str(plugin_path))}"
-    )
-    logger.info(f"Installing vllm-tt-plugin into tt-metal venv from: {plugin_path}")
-    run_command(install_command, logger=logger, check=True)
-    return True
-
-
 def install_local_server_requirements(runtime_config, repo_root=None):
     paths = get_local_server_paths(runtime_config, repo_root=repo_root)
     requirements_path = paths["requirements_path"]
@@ -301,7 +247,10 @@ def install_local_server_requirements(runtime_config, repo_root=None):
     )
     run_command(install_command, logger=logger, check=True)
 
-    install_vllm_tt_plugin_if_present(runtime_config, repo_root=repo_root)
+    # vLLM and vllm-tt-plugin are NOT installed here. The plugin lives in its own
+    # repository and its docs/install-vllm-tt.sh owns the vLLM version pin plus the
+    # dependency overrides, so installing either from here risks a mismatched pair.
+    # workflows.validate_setup probes that both are present before the server starts.
 
 
 def _terminate_process_group(process: subprocess.Popen, process_name: str):

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -263,44 +263,24 @@ def _validate_local_vllm_installation(runtime_config):
 
 
 def _validate_local_vllm_tt_plugin(runtime_config, venv_python: Path):
-    """Ensure the vllm-tt-plugin package is installed and registered when the
-    user's vLLM checkout requires it.
+    """Ensure the vllm-tt-plugin package is installed and registers the TT platform.
 
-    Since tenstorrent/vllm commit a072e40a6 (2026-05-04, "Extract TT backend
-    into plugin package (Phase 1)") the TT platform lives in a separate
-    editable package at ``$VLLM_DIR/plugins/vllm-tt-plugin``. Without that
-    package installed, ``vllm/platforms/tt.py`` raises
-    ``ModuleNotFoundError: No module named 'vllm_tt_plugin'`` when
-    ``vllm serve`` starts up.
+    The TT platform lives in https://github.com/tenstorrent/vllm-tt-plugin, a
+    standalone repository installed into the tt-metal venv by its own
+    ``docs/install-vllm-tt.sh`` (which installs upstream vLLM first, then the
+    plugin). Without it, vLLM starts with no ``tt`` platform registered.
 
-    When the plugin source directory exists in the vLLM checkout this helper
-    will:
+    The probe runs unconditionally: it only needs the *installed* package, and
+    there is no plugin source tree inside the vLLM checkout to key off. An
+    earlier version gated this on ``$VLLM_DIR/plugins/vllm-tt-plugin`` existing
+    -- the layout back when the plugin shipped inside the fork -- which meant
+    validation silently no-opped for every standalone-plugin setup, i.e. in
+    exactly the case it was meant to catch.
 
-    1. Editable-install it into the tt-metal venv (idempotent, mirrors the
-       dev Dockerfile behaviour added by tt-inference-server PR #3370).
-    2. Run a strict in-process check that ``import vllm_tt_plugin`` works AND
-       that the ``tt`` entry is registered under the ``vllm.platform_plugins``
-       entry-point group.
-
-    When the plugin source is absent (older vLLM checkouts that still ship
-    TT support inside vllm core) both steps are skipped.
+    Installing is deliberately not attempted here: the plugin's install script
+    owns the vLLM version pin and its dependency overrides, so installing the
+    plugin alone risks pairing it with an incompatible vLLM.
     """
-    # Local import to avoid a module-level circular dependency:
-    # workflows.run_local_server -> workflows.setup_host -> workflows.validate_setup
-    from workflows.run_local_server import (  # noqa: PLC0415
-        install_vllm_tt_plugin_if_present,
-        vllm_tt_plugin_source_path,
-    )
-
-    plugin_path = vllm_tt_plugin_source_path(_get_local_vllm_dir(runtime_config))
-    if not (plugin_path / "pyproject.toml").exists():
-        logger.info(
-            f"Skipping vllm-tt-plugin validation: source not present at {plugin_path}"
-        )
-        return
-
-    install_vllm_tt_plugin_if_present(runtime_config)
-
     check_script = (
         "import vllm_tt_plugin; "
         "from importlib.metadata import entry_points; "
@@ -315,26 +295,18 @@ def _validate_local_vllm_tt_plugin(runtime_config, venv_python: Path):
             "`vllm_tt_plugin` Python package (the TT platform plugin) "
             "to be installed in the tt-metal python environment and to register "
             "the `tt` entry under the `vllm.platform_plugins` entry-point group.\n"
-            f"Plugin source detected at: {plugin_path}\n"
-            "Auto-install via this validator failed or the entry point did not "
-            "register. Re-install the plugin by running the canonical script "
-            f"from the vLLM repo: `cd {_get_local_vllm_dir(runtime_config)} && "
-            "bash tt_metal/install-vllm-tt.sh`\n"
+            "Install it into the tt-metal python environment with:\n"
+            "  git clone https://github.com/tenstorrent/vllm-tt-plugin.git\n"
+            "  cd vllm-tt-plugin && source docs/install-vllm-tt.sh\n"
+            "That script installs upstream vLLM (VLLM_TARGET_DEVICE=empty) plus "
+            "the plugin; run it with the tt-metal venv activated. Verify with:\n"
+            f"  {venv_python} -c 'import vllm_tt_plugin, ttnn; print(\"ok\")'\n"
             "See vllm-tt-metal/README.md for the full local installation steps."
         )
     logger.info(
         f"✅ validated vllm-tt-plugin install and `tt` platform_plugins entry "
         f"point registration with: {venv_python}"
     )
-
-
-def _get_local_vllm_dir(runtime_config) -> Path:
-    """Resolve $VLLM_DIR the same way workflows.run_local_server does."""
-    tt_metal_home = Path(runtime_config.tt_metal_home).expanduser().resolve()
-    vllm_dir = getattr(runtime_config, "vllm_dir", None)
-    if vllm_dir:
-        return Path(vllm_dir).expanduser().resolve()
-    return (tt_metal_home / "vllm").resolve()
 
 
 def validate_local_setup(model_spec, runtime_config, json_fpath):
@@ -548,21 +520,18 @@ def validate_local_server_paths(args):
         raise ValueError(f"⛔ --tt-metal-home is not a directory: {tt_metal_home}")
 
     python_env_dir = _get_local_server_python_env_dir(args)
-    vllm_dir = (
-        Path(args.vllm_dir).expanduser().resolve()
-        if getattr(args, "vllm_dir", None)
-        else (tt_metal_home / "vllm").resolve()
-    )
     venv_python = python_env_dir / "bin" / "python"
     build_lib_dir = tt_metal_home / "build" / "lib"
     entrypoint_path = (
         get_repo_root_path() / "vllm-tt-metal" / "src" / "run_vllm_api_server.py"
     )
 
+    # No vLLM source dir is required: vLLM is an installed package in the tt-metal
+    # venv, not a checkout. That it imports -- and that vllm-tt-plugin registers the
+    # `tt` platform -- is checked by _validate_local_vllm_installation later.
     required_paths = [
         ("python venv interpreter", venv_python),
         ("tt-metal build/lib", build_lib_dir),
-        ("vLLM source dir", vllm_dir),
         ("local server entrypoint", entrypoint_path),
     ]
     for label, path in required_paths:


### PR DESCRIPTION
Closes #4908 

tt-shield branch: `vcankovic/vllm-tt-plugin`
tt-inference-server branch: `vcankovic/vllm-tt-plugin`

tt-shield runs:
https://github.com/tenstorrent/tt-shield/actions/runs/31391330520/job/93483614241
https://github.com/tenstorrent/tt-shield/actions/runs/31418772124/job/93554276939

1. Install upstream vLLM + the plugin — `vllm.tt-metal.src.dev.Dockerfile`
clone `vllm-tt-plugin` and delegate to its `docs/install-vllm-tt.sh`. That script owns the vLLM version pin and dependency overrides. vLLM is now a regular install in `python_env/site-packages`.

2. Make the `--local-server` safety check work again — `workflows/validate_setup.py`
    Before starting the server, `run.py` checks that the TT plugin is actually installed. That check was wrapped in an "only if…" condition: only run it if a plugin folder can be found inside the vLLM checkout. Now that the plugin lives in its own repo there is no such folder, so the check was skipped every single time — meaning a missing plugin went unnoticed until the server tried to start and died with a confusing error. The check now always runs, because all it really needs is the installed VLLM package, not a folder on disk.
 A second check required a vLLM source folder to exist. Nobody has one any more (vLLM is installed from PyPI), so --local-server refused to start at all. Removed.

3. Drop fork folder  — `workflows/run_local_server.py, run.py`

   Deleted the two helpers that used to auto-install the plugin from inside the vLLM checkout — installation now   belongs to the plugin's own `install-vllm-tt.sh`, and we only verify it. Also removed the `vllm_dir` env export and the PYTHONPATH append, which only made sense when vLLM was a source checkout. --vllm-dir is deprecated but still accepted, so old scripts don't break.

4. Stop the image build running out of disk space — added `uv cache clean` to both builder stages

     `uv` caches every package it downloads or builds. The builder stage is discarded, so that cache is never reused, but it still filled the disk mid-build (~14 GB) and the build died with no space left on device.