### PR TITLE
[Helm v0.2] Use startupProbe for the model compile window (#4870)

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1164,6 +1164,23 @@ jobs:
               && { echo "::error::hostPath /dev/tenstorrent present for $device"; exit 1; } || true
           done
 
+      - name: Verify startupProbe budget derives from progressDeadlineSeconds
+        run: |
+          set -e
+          # startupProbe is always rendered and its failureThreshold is computed as
+          # ceil(progressDeadlineSeconds / periodSeconds) (periodSeconds default 15).
+          # model:device:expected-failureThreshold (pd 5400 -> 360, pd 7200 -> 480)
+          for triple in gpt-oss-20b:t3k:360 gpt-oss-120b:t3k:480; do
+            model="${triple%%:*}"; rest="${triple#*:}"; device="${rest%%:*}"; want="${rest##*:}"
+            echo "--- startupProbe: $model / $device (expect failureThreshold $want)"
+            RENDERED=$(helm template ttis charts/tt-inference-server \
+              --set model="$model" --set device="$device")
+            echo "$RENDERED" | grep -qE '^[[:space:]]*startupProbe:$' \
+              || { echo "::error::startupProbe missing for $model/$device"; exit 1; }
+            echo "$RENDERED" | grep -qE "^[[:space:]]*failureThreshold: ${want}\$" \
+              || { echo "::error::$model/$device startupProbe.failureThreshold must be $want"; exit 1; }
+          done
+
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest

--- a/charts/tt-inference-server/README.md
+++ b/charts/tt-inference-server/README.md
@@ -155,7 +155,7 @@ defaults                                              ← baseline for every mod
 
 1. Resolve the engine — `n300` is offered by both `vllm` and `forge`, so `models.Llama-3.1-8B-Instruct.defaultEngine` (`vllm`) is used. Pass `--set engine=forge` to pick the other.
 2. Resolve the impl — `models.Llama-3.1-8B-Instruct.vllm.n300.defaultImpl` (`tt_transformers`).
-3. Start from the full `defaults` block, then deep-merge `models.Llama-3.1-8B-Instruct.vllm.n300.impls.tt_transformers` on top — overriding `image.repository`, `image.tag`, `resources`, probe delays, and `env`.
+3. Start from the full `defaults` block, then deep-merge `models.Llama-3.1-8B-Instruct.vllm.n300.impls.tt_transformers` on top — overriding `image.repository`, `image.tag`, `resources`, `progressDeadlineSeconds`, and `env`.
 
 Any field the resolved impl block does not set falls back to `defaults`.
 
@@ -200,12 +200,13 @@ All fields under `defaults` apply to every model/engine/device/impl unless overr
 | `defaults.resources.requests.cpu` | `"6"` | CPU request. |
 | `defaults.resources.requests.memory` | `64Gi` | Memory request (often overridden per impl). |
 | `defaults.resources.requests.hugepages-1Gi` | `32Gi` | Hugepage request. |
+| `defaults.probes.startup.periodSeconds` | `15` | startupProbe poll interval (must be `> 0`). The startupProbe is always rendered — it owns the model compile/warmup window, and while it runs the kubelet suppresses liveness/readiness so a slow compile never triggers a restart. `failureThreshold` is not set here — the Deployment derives it as `ceil(progressDeadlineSeconds / periodSeconds)`, so the startup budget tracks the max compile time and the Pod flips to `1/1` as soon as one poll succeeds. |
 | `defaults.probes.liveness.enabled` | `true` | Enable liveness probe. |
-| `defaults.probes.liveness.path` | `/v1/models` | Liveness probe HTTP path. |
-| `defaults.probes.liveness.initialDelaySeconds` | `2400` | Liveness probe initial delay. Set high due to model load times. |
+| `defaults.probes.liveness.path` | `/v1/models` | Liveness probe HTTP path (`/tt-liveness` for non-vllm engines). |
+| `defaults.probes.liveness.initialDelaySeconds` | `0` | Liveness probe initial delay. `0` because the startupProbe gates the compile window. |
 | `defaults.probes.readiness.enabled` | `true` | Enable readiness probe. |
-| `defaults.probes.readiness.path` | `/health` | Readiness probe HTTP path. |
-| `defaults.probes.readiness.initialDelaySeconds` | `2400` | Readiness probe initial delay. |
+| `defaults.probes.readiness.path` | `/health` | Readiness probe HTTP path (also used by the startupProbe). |
+| `defaults.probes.readiness.initialDelaySeconds` | `0` | Readiness probe initial delay. `0` because the startupProbe gates the compile window. |
 | `defaults.nodeSelector` | `{}` | Node selector applied to the pod. |
 | `defaults.tolerations` | `[]` | Tolerations applied to the pod. |
 | `defaults.affinity` | `{}` | User-supplied affinity, applied as-is. v0.2 no longer injects a 1-Pod-per-Node `podAntiAffinity` — DRA prevents device collisions by allocation, so multiple Pods may run on one Node. |

--- a/charts/tt-inference-server/README.md.gotmpl
+++ b/charts/tt-inference-server/README.md.gotmpl
@@ -155,7 +155,7 @@ defaults                                              ← baseline for every mod
 
 1. Resolve the engine — `n300` is offered by both `vllm` and `forge`, so `models.Llama-3.1-8B-Instruct.defaultEngine` (`vllm`) is used. Pass `--set engine=forge` to pick the other.
 2. Resolve the impl — `models.Llama-3.1-8B-Instruct.vllm.n300.defaultImpl` (`tt_transformers`).
-3. Start from the full `defaults` block, then deep-merge `models.Llama-3.1-8B-Instruct.vllm.n300.impls.tt_transformers` on top — overriding `image.repository`, `image.tag`, `resources`, probe delays, and `env`.
+3. Start from the full `defaults` block, then deep-merge `models.Llama-3.1-8B-Instruct.vllm.n300.impls.tt_transformers` on top — overriding `image.repository`, `image.tag`, `resources`, `progressDeadlineSeconds`, and `env`.
 
 Any field the resolved impl block does not set falls back to `defaults`.
 
@@ -200,12 +200,13 @@ All fields under `defaults` apply to every model/engine/device/impl unless overr
 | `defaults.resources.requests.cpu` | `"6"` | CPU request. |
 | `defaults.resources.requests.memory` | `64Gi` | Memory request (often overridden per impl). |
 | `defaults.resources.requests.hugepages-1Gi` | `32Gi` | Hugepage request. |
+| `defaults.probes.startup.periodSeconds` | `15` | startupProbe poll interval (must be `> 0`). The startupProbe is always rendered — it owns the model compile/warmup window, and while it runs the kubelet suppresses liveness/readiness so a slow compile never triggers a restart. `failureThreshold` is not set here — the Deployment derives it as `ceil(progressDeadlineSeconds / periodSeconds)`, so the startup budget tracks the max compile time and the Pod flips to `1/1` as soon as one poll succeeds. |
 | `defaults.probes.liveness.enabled` | `true` | Enable liveness probe. |
-| `defaults.probes.liveness.path` | `/v1/models` | Liveness probe HTTP path. |
-| `defaults.probes.liveness.initialDelaySeconds` | `2400` | Liveness probe initial delay. Set high due to model load times. |
+| `defaults.probes.liveness.path` | `/v1/models` | Liveness probe HTTP path (`/tt-liveness` for non-vllm engines). |
+| `defaults.probes.liveness.initialDelaySeconds` | `0` | Liveness probe initial delay. `0` because the startupProbe gates the compile window. |
 | `defaults.probes.readiness.enabled` | `true` | Enable readiness probe. |
-| `defaults.probes.readiness.path` | `/health` | Readiness probe HTTP path. |
-| `defaults.probes.readiness.initialDelaySeconds` | `2400` | Readiness probe initial delay. |
+| `defaults.probes.readiness.path` | `/health` | Readiness probe HTTP path (also used by the startupProbe). |
+| `defaults.probes.readiness.initialDelaySeconds` | `0` | Readiness probe initial delay. `0` because the startupProbe gates the compile window. |
 | `defaults.nodeSelector` | `{}` | Node selector applied to the pod. |
 | `defaults.tolerations` | `[]` | Tolerations applied to the pod. |
 | `defaults.affinity` | `{}` | User-supplied affinity, applied as-is. v0.2 no longer injects a 1-Pod-per-Node `podAntiAffinity` — DRA prevents device collisions by allocation, so multiple Pods may run on one Node. |

--- a/charts/tt-inference-server/templates/deployment.yaml
+++ b/charts/tt-inference-server/templates/deployment.yaml
@@ -2,6 +2,8 @@
 {{- $cfg := include "tt-inference-server.resolvedConfig" . | fromYaml }}
 {{- $engine := include "tt-inference-server.resolvedEngine" . }}
 {{- $ttCount := include "tt-inference-server.draDeviceCount" . }}
+{{- $startupPeriod := $cfg.probes.startup.periodSeconds | int }}
+{{- if le $startupPeriod 0 }}{{- fail "probes.startup.periodSeconds must be greater than 0 (it divides progressDeadlineSeconds to size the startupProbe budget)." }}{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -117,6 +119,20 @@ spec:
               - name: tt
             {{- end }}
           {{- end }}
+          # startupProbe owns the compile/warmup window: while it runs the kubelet
+          # suppresses liveness/readiness, then they take over immediately. The
+          # budget = failureThreshold × periodSeconds is derived from
+          # progressDeadlineSeconds so it always matches the max compile time; it
+          # flips to serving as soon as one poll succeeds, not after a fixed delay.
+          # Always rendered — disabling it would let liveness (initialDelaySeconds 0)
+          # kill the container mid-compile.
+          startupProbe:
+            httpGet:
+              path: {{ $cfg.probes.readiness.path | default "/health" }}
+              port: http
+            periodSeconds: {{ $startupPeriod }}
+            failureThreshold: {{ ceil (divf $cfg.progressDeadlineSeconds $startupPeriod) | int }}
+            timeoutSeconds: 5
           {{- if $cfg.probes.liveness.enabled }}
           livenessProbe:
             httpGet:

--- a/charts/tt-inference-server/templates/deployment.yaml
+++ b/charts/tt-inference-server/templates/deployment.yaml
@@ -124,8 +124,8 @@ spec:
           # budget = failureThreshold × periodSeconds is derived from
           # progressDeadlineSeconds so it always matches the max compile time; it
           # flips to serving as soon as one poll succeeds, not after a fixed delay.
-          # Always rendered — disabling it would let liveness (initialDelaySeconds 0)
-          # kill the container mid-compile.
+          # Always rendered — disabling it would let liveness (initialDelaySeconds
+          # defaults to 0) kill the container mid-compile.
           startupProbe:
             httpGet:
               path: {{ $cfg.probes.readiness.path | default "/health" }}
@@ -142,7 +142,6 @@ spec:
               path: {{ $cfg.probes.liveness.path }}
               {{- end }}
               port: http
-            initialDelaySeconds: {{ $cfg.probes.liveness.initialDelaySeconds }}
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
@@ -152,7 +151,6 @@ spec:
             httpGet:
               path: {{ $cfg.probes.readiness.path }}
               port: http
-            initialDelaySeconds: {{ $cfg.probes.readiness.initialDelaySeconds }}
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -67,14 +67,24 @@ defaults:
       memory: 64Gi
       hugepages-1Gi: 32Gi
   probes:
+    # startupProbe owns the model compile/warmup window; while it runs the kubelet
+    # suppresses liveness/readiness. Its failureThreshold is computed in the
+    # Deployment as ceil(progressDeadlineSeconds / periodSeconds), so the budget
+    # tracks the max compile time — no per-model initialDelaySeconds to hand-sync.
+    # Always rendered (no enable toggle): disabling it would let liveness, whose
+    # initialDelaySeconds is 0, restart the container mid-compile.
+    startup:
+      periodSeconds: 15
     liveness:
       enabled: true
       path: /v1/models
-      initialDelaySeconds: 2400
+      # 0: startupProbe gates the compile window, so liveness starts immediately
+      # once startup succeeds.
+      initialDelaySeconds: 0
     readiness:
       enabled: true
       path: /health
-      initialDelaySeconds: 2400
+      initialDelaySeconds: 0
   nodeSelector: {}
   tolerations: []
   # User-supplied affinity, applied as-is. v0.2: the chart no longer injects a
@@ -132,11 +142,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-e867533-8f36910
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 50Gi
@@ -169,11 +174,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-e867533-8f36910
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 50Gi
@@ -204,11 +204,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-e867533-8f36910
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 50Gi
@@ -238,11 +233,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.17.0-8c48a10-f52987a
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 300Gi
@@ -271,11 +261,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.17.0-8c48a10-f52987a
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 300Gi
@@ -304,11 +289,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.17.0-8c48a10-f52987a
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 300Gi
@@ -340,11 +320,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.3.0-ae65ee5-35f023f
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 10Gi
@@ -371,11 +346,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.3.0-ae65ee5-35f023f
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 10Gi
@@ -405,11 +375,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-c254ee3-c4f2327
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 2Gi
@@ -437,11 +402,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-e0e0500-409b1cd
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -466,11 +426,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-e0e0500-409b1cd
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -497,11 +452,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-e0e0500-409b1cd
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -528,11 +478,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-e0e0500-409b1cd
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -563,11 +508,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-e0e0500-409b1cd
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -594,11 +534,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-e867533-22be241
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -627,10 +562,7 @@ models:
               tag: 709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 12Gi
@@ -655,10 +587,7 @@ models:
               tag: 709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 12Gi
@@ -685,10 +614,7 @@ models:
               tag: 709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 12Gi
@@ -713,11 +639,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-bac8b34-7c6685a
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -741,11 +662,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-e95ffa5-48eba14
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -774,11 +690,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-e95ffa5-48eba14
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -807,11 +718,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-e95ffa5-48eba14
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -844,11 +750,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.1-555f240-22be241
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -875,11 +776,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.17.0-8c48a10-f52987a
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -909,11 +805,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-9b67e09-a91b644
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 17Gi
@@ -940,11 +831,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-9b67e09-a91b644
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 17Gi
@@ -973,11 +859,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-9b67e09-a91b644
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 17Gi
@@ -1009,11 +890,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-e95ffa5-48eba14
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -1042,11 +918,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-e95ffa5-48eba14
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -1075,11 +946,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-e95ffa5-48eba14
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -1115,11 +981,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-13f44c5-0edd242
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 180Gi
@@ -1150,11 +1011,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-13f44c5-0edd242
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 180Gi
@@ -1185,11 +1041,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-13f44c5-0edd242
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 180Gi
@@ -1227,11 +1078,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-13f44c5-0edd242
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 180Gi
@@ -1262,11 +1108,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-13f44c5-0edd242
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 180Gi
@@ -1297,11 +1138,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-13f44c5-0edd242
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 180Gi
@@ -1339,11 +1175,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-5b5db8a-e771fff
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 17Gi
@@ -1372,11 +1203,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-5b5db8a-e771fff
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 17Gi
@@ -1406,11 +1232,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-5b5db8a-e771fff
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 17Gi
@@ -1439,11 +1260,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-5b5db8a-e771fff
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 17Gi
@@ -1473,11 +1289,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-e867533-8f36910
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1502,11 +1313,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-750ca54-38dee8c
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1537,11 +1343,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.1-555f240-22be241
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1566,11 +1367,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.1-555f240-22be241
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1595,11 +1391,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.16.0-669d59e-3334377
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1624,11 +1415,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.2.0-v0.62.0-rc33-e7c329b
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1666,11 +1452,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-e867533-8f36910
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1695,11 +1476,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-750ca54-38dee8c
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1730,11 +1506,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.1-555f240-22be241
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1759,11 +1530,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.1-555f240-22be241
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1788,11 +1554,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.16.0-669d59e-3334377
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1817,11 +1578,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.2.0-v0.62.0-rc33-e7c329b
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1859,10 +1615,7 @@ models:
               tag: 0.11.1-2496be4
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -1892,11 +1645,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-e867533-8f36910
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1921,11 +1669,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-750ca54-38dee8c
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1956,11 +1699,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.1-555f240-22be241
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -1985,11 +1723,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.1-555f240-22be241
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -2014,11 +1747,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.16.0-669d59e-3334377
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -2043,11 +1771,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.2.0-v0.62.0-rc33-e7c329b
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -2085,11 +1808,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-e867533-8f36910
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -2114,11 +1832,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-750ca54-38dee8c
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -2149,11 +1862,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.1-555f240-22be241
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -2178,11 +1886,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.1-555f240-22be241
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -2207,11 +1910,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.16.0-669d59e-3334377
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -2236,11 +1934,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.2.0-v0.62.0-rc33-e7c329b
-            probes:
-              liveness:
-                initialDelaySeconds: 3600
-              readiness:
-                initialDelaySeconds: 3600
             resources:
               requests:
                 memory: 175Gi
@@ -2278,11 +1971,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.12.0-805f43d-a45c614
-            probes:
-              liveness:
-                initialDelaySeconds: 4266
-              readiness:
-                initialDelaySeconds: 4266
             env:
               - name: ARCH_NAME
                 value: wormhole_b0
@@ -2307,11 +1995,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-84b4c53-222ee06
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 2Gi
@@ -2338,11 +2021,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-84b4c53-222ee06
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 2Gi
@@ -2371,11 +2049,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-84b4c53-222ee06
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 2Gi
@@ -2407,11 +2080,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-84b4c53-222ee06
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 2Gi
@@ -2438,11 +2106,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-84b4c53-222ee06
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 2Gi
@@ -2471,11 +2134,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-84b4c53-222ee06
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 2Gi
@@ -2507,11 +2165,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.3.0-20edc39-03cb300
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 7Gi
@@ -2536,11 +2189,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.3.0-20edc39-03cb300
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 7Gi
@@ -2567,11 +2215,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.3.0-20edc39-03cb300
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 7Gi
@@ -2601,10 +2244,7 @@ models:
               tag: 0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 8Gi
@@ -2629,10 +2269,7 @@ models:
               tag: 0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 8Gi
@@ -2659,10 +2296,7 @@ models:
               tag: 709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 8Gi
@@ -2688,11 +2322,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.3.0-20edc39-03cb300
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 7Gi
@@ -2717,11 +2346,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.3.0-20edc39-03cb300
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 7Gi
@@ -2748,11 +2372,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.3.0-20edc39-03cb300
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 7Gi
@@ -2783,10 +2402,7 @@ models:
               tag: 709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 8Gi
@@ -2813,10 +2429,7 @@ models:
               tag: 709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 8Gi
@@ -2845,10 +2458,7 @@ models:
               tag: 709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 8Gi
@@ -2873,11 +2483,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-25305db-6e67d2d
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -2902,11 +2507,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-25305db-6e67d2d
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -2933,11 +2533,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-25305db-6e67d2d
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -2964,11 +2559,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-25305db-6e67d2d
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -2991,11 +2581,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.18.0-c49bb76-6b4a3a7
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3020,11 +2605,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.18.0-c49bb76-6b4a3a7
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3049,11 +2629,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-55fd115-aa4ae1e
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3078,11 +2653,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.1-555f240-22be241
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3107,11 +2677,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.19.0-b204341-9bd099c
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3136,11 +2701,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.19.0-b204341-9bd099c
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3167,11 +2727,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-bac8b34-7c6685a
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3198,11 +2753,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-bac8b34-7c6685a
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3238,11 +2788,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-25305db-6e67d2d
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3267,11 +2812,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-25305db-6e67d2d
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3298,11 +2838,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-25305db-6e67d2d
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3329,11 +2864,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-25305db-6e67d2d
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3356,11 +2886,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.18.0-c49bb76-6b4a3a7
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3385,11 +2910,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.18.0-c49bb76-6b4a3a7
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3414,11 +2934,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.0-55fd115-aa4ae1e
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3443,11 +2958,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.10.1-555f240-22be241
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3472,11 +2982,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.19.0-b204341-9bd099c
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3501,11 +3006,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.19.0-b204341-9bd099c
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3532,11 +3032,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-bac8b34-7c6685a
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3563,11 +3058,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.11.1-bac8b34-7c6685a
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 20Gi
@@ -3604,10 +3094,7 @@ models:
               tag: 709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 12Gi
@@ -3632,10 +3119,7 @@ models:
               tag: 709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 12Gi
@@ -3662,10 +3146,7 @@ models:
               tag: 709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 12Gi
@@ -3690,11 +3171,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-17a5973-aa4ae1e
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -3723,11 +3199,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-17a5973-aa4ae1e
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -3763,11 +3234,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-c254ee3-c4f2327
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 10Gi
@@ -3792,11 +3258,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-c254ee3-c4f2327
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 10Gi
@@ -3823,11 +3284,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-aecd1d7-0da90eb
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 10Gi
@@ -3854,11 +3310,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-aecd1d7-0da90eb
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 10Gi
@@ -3886,11 +3337,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-c254ee3-c4f2327
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 10Gi
@@ -3915,11 +3361,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-c254ee3-c4f2327
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 10Gi
@@ -3946,11 +3387,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-aecd1d7-0da90eb
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 10Gi
@@ -3977,11 +3413,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-aecd1d7-0da90eb
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 10Gi
@@ -4009,11 +3440,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-0b10c51-3499ffa
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 67Gi
@@ -4040,11 +3466,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-0b10c51-3499ffa
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 67Gi
@@ -4075,11 +3496,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-0b10c51-3499ffa
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 67Gi
@@ -4106,11 +3522,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-aecd1d7-0da90eb
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 67Gi
@@ -4138,11 +3549,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-0b10c51-3499ffa
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 67Gi
@@ -4169,11 +3575,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-0b10c51-3499ffa
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 67Gi
@@ -4204,11 +3605,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-0b10c51-3499ffa
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 67Gi
@@ -4235,11 +3631,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-aecd1d7-0da90eb
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 67Gi
@@ -4267,11 +3658,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.14.0-80180b9-7678b70
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -4303,11 +3689,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-c18569e-b2894d3
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 7Gi
@@ -4334,11 +3715,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-c18569e-b2894d3
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 7Gi
@@ -4370,11 +3746,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-c18569e-b2894d3
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 17Gi
@@ -4401,11 +3772,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-c18569e-b2894d3
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 17Gi
@@ -4437,11 +3803,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-c18569e-b2894d3
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 80Gi
@@ -4473,11 +3834,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-c18569e-b2894d3
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 180Gi
@@ -4506,11 +3862,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-c18569e-b2894d3
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 180Gi
@@ -4538,11 +3889,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-v0.61.1-rc1-5cbc982
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 27Gi
@@ -4569,11 +3915,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-v0.61.1-rc1-5cbc982
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 27Gi
@@ -4603,11 +3944,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-v0.61.1-rc1-5cbc982
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 27Gi
@@ -4634,11 +3970,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-v0.61.1-rc1-5cbc982
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 27Gi
@@ -4668,11 +3999,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-v0.61.1-rc1-5cbc982
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 225Gi
@@ -4704,11 +4030,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.9.0-v0.61.1-rc1-5cbc982
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 225Gi
@@ -4742,10 +4063,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -4766,10 +4084,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -4788,10 +4103,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -4810,10 +4122,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -4832,10 +4141,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -4857,10 +4163,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -4881,10 +4184,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -4903,10 +4203,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -4925,10 +4222,7 @@ models:
               tag: 0.10.1-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -4947,10 +4241,7 @@ models:
               tag: 0.17.0-8c48a10
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -4974,10 +4265,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -4996,10 +4284,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5020,10 +4305,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5044,10 +4326,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5066,10 +4345,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5088,10 +4364,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5110,10 +4383,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5132,10 +4402,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5156,10 +4423,7 @@ models:
               tag: 0.13.0-079a2c2
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5180,10 +4444,7 @@ models:
               tag: 0.13.0-079a2c2
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5206,10 +4467,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5228,10 +4486,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5252,10 +4507,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5276,10 +4528,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5298,10 +4547,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5320,10 +4566,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5342,10 +4585,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5364,10 +4604,7 @@ models:
               tag: 0.11.1-bac8b34
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5389,10 +4626,7 @@ models:
               tag: 0.9.0-c180ef7
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5413,10 +4647,7 @@ models:
               tag: 0.9.0-c180ef7
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5438,10 +4669,7 @@ models:
               tag: 0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5460,10 +4688,7 @@ models:
               tag: 0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5484,10 +4709,7 @@ models:
               tag: 0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5508,10 +4730,7 @@ models:
               tag: 0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5530,10 +4749,7 @@ models:
               tag: 0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5552,10 +4768,7 @@ models:
               tag: 0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5574,10 +4787,7 @@ models:
               tag: 0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5596,10 +4806,7 @@ models:
               tag: 0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5621,10 +4828,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5645,10 +4849,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5667,10 +4868,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5689,10 +4887,7 @@ models:
               tag: 0.17.0-8c48a10
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5711,10 +4906,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5733,10 +4925,7 @@ models:
               tag: 0.10.1-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5758,10 +4947,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5782,10 +4968,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5804,10 +4987,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5826,10 +5006,7 @@ models:
               tag: 0.18.0-c49bb76
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5848,10 +5025,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5870,10 +5044,7 @@ models:
               tag: 0.10.1-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5895,10 +5066,7 @@ models:
               tag: 0.9.0-c180ef7
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5919,10 +5087,7 @@ models:
               tag: 0.9.0-c180ef7
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5941,10 +5106,7 @@ models:
               tag: 0.9.0-c180ef7
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5963,10 +5125,7 @@ models:
               tag: 0.9.0-c180ef7
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -5988,10 +5147,7 @@ models:
               tag: 0.9.0-be88351
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6014,10 +5170,7 @@ models:
               tag: 0.9.0-be88351
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6039,10 +5192,7 @@ models:
               tag: 0.9.0-be88351
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6065,10 +5215,7 @@ models:
               tag: 0.9.0-be88351
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6090,10 +5237,7 @@ models:
               tag: 0.17.0-8c48a10
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6112,10 +5256,7 @@ models:
               tag: 0.17.0-8c48a10
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6136,10 +5277,7 @@ models:
               tag: 0.17.0-8c48a10
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6158,10 +5296,7 @@ models:
               tag: 0.17.0-8c48a10
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6182,10 +5317,7 @@ models:
               tag: 0.15.0-25891d3
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6206,10 +5338,7 @@ models:
               tag: 0.11.1-2508216
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6230,10 +5359,7 @@ models:
               tag: 0.15.0-25891d3
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6257,10 +5383,7 @@ models:
               tag: 0.17.0-8c48a10
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6279,10 +5402,7 @@ models:
               tag: 0.17.0-8c48a10
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6303,10 +5423,7 @@ models:
               tag: 0.17.0-8c48a10
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6325,10 +5442,7 @@ models:
               tag: 0.17.0-8c48a10
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6349,10 +5463,7 @@ models:
               tag: 0.15.0-25891d3
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6373,10 +5484,7 @@ models:
               tag: 0.11.1-2508216
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6397,10 +5505,7 @@ models:
               tag: 0.15.0-25891d3
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6424,10 +5529,7 @@ models:
               tag: 0.9.0-a9b09e0
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6446,10 +5548,7 @@ models:
               tag: 0.9.0-a9b09e0
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6470,10 +5569,7 @@ models:
               tag: 0.15.0-25891d3
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6494,10 +5590,7 @@ models:
               tag: 0.10.0-2508216
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6518,10 +5611,7 @@ models:
               tag: 0.15.0-25891d3
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6545,10 +5635,7 @@ models:
               tag: 0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6579,10 +5666,7 @@ models:
               tag: 0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6615,10 +5699,7 @@ models:
               tag: 0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6651,10 +5732,7 @@ models:
               tag: 0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6690,10 +5768,7 @@ models:
               tag: 0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6720,10 +5795,7 @@ models:
               tag: 0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6752,10 +5824,7 @@ models:
               tag: 0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6784,10 +5853,7 @@ models:
               tag: 0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6817,10 +5883,7 @@ models:
               tag: 0.20.0-de59f8a
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6851,10 +5914,7 @@ models:
               tag: 0.20.0-de59f8a
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6887,10 +5947,7 @@ models:
               tag: 0.20.0-de59f8a
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6923,10 +5980,7 @@ models:
               tag: 0.20.0-de59f8a
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7004,10 +6058,7 @@ models:
               tag: 0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 8Gi
@@ -7032,10 +6083,7 @@ models:
               tag: 0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 8Gi
@@ -7062,10 +6110,7 @@ models:
               tag: 709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 8Gi
@@ -7093,10 +6138,7 @@ models:
               tag: 0.13.0-079a2c2
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7115,10 +6157,7 @@ models:
               tag: 0.13.0-079a2c2
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7142,10 +6181,7 @@ models:
               tag: 0.13.0-079a2c2
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7164,10 +6200,7 @@ models:
               tag: 0.13.0-079a2c2
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7191,10 +6224,7 @@ models:
               tag: 0.13.0-079a2c2
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7213,10 +6243,7 @@ models:
               tag: 0.13.0-079a2c2
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7240,10 +6267,7 @@ models:
               tag: a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7262,10 +6286,7 @@ models:
               tag: a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7289,10 +6310,7 @@ models:
               tag: 0.13.0-079a2c2
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7311,10 +6329,7 @@ models:
               tag: 0.13.0-079a2c2
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7338,10 +6353,7 @@ models:
               tag: 0.13.0-079a2c2
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7360,10 +6372,7 @@ models:
               tag: 0.13.0-079a2c2
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7387,10 +6396,7 @@ models:
               tag: 0.18.0-c49bb76
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7409,10 +6415,7 @@ models:
               tag: 0.18.0-c49bb76
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7434,10 +6437,7 @@ models:
               tag: a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7456,10 +6456,7 @@ models:
               tag: a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -7483,10 +6480,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -7507,10 +6501,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -7529,10 +6520,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -7551,10 +6539,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -7573,10 +6558,7 @@ models:
               tag: 0.10.0-555f240
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 32Gi
@@ -7598,10 +6580,7 @@ models:
               tag: 709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 12Gi
@@ -7626,10 +6605,7 @@ models:
               tag: 709c6a767e00ee7f2803e20851193ac0d6aaff3b_e0b9595_75385194349
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 12Gi
@@ -7656,10 +6632,7 @@ models:
               tag: 0.18.0-c49bb76
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 12Gi
@@ -7703,10 +6676,7 @@ models:
               tag: 0.17.0-8c48a10
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 16Gi
@@ -7726,11 +6696,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.18.0-c49bb76-6b4a3a7
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 77Gi
@@ -7764,11 +6729,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.20.0-de59f8a-03fa3af
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 67Gi

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -72,19 +72,15 @@ defaults:
     # Deployment as ceil(progressDeadlineSeconds / periodSeconds), so the budget
     # tracks the max compile time — no per-model initialDelaySeconds to hand-sync.
     # Always rendered (no enable toggle): disabling it would let liveness, whose
-    # initialDelaySeconds is 0, restart the container mid-compile.
+    # initialDelaySeconds defaults to 0, restart the container mid-compile.
     startup:
       periodSeconds: 15
     liveness:
       enabled: true
       path: /v1/models
-      # 0: startupProbe gates the compile window, so liveness starts immediately
-      # once startup succeeds.
-      initialDelaySeconds: 0
     readiness:
       enabled: true
       path: /health
-      initialDelaySeconds: 0
   nodeSelector: {}
   tolerations: []
   # User-supplied affinity, applied as-is. v0.2: the chart no longer injects a

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -6007,10 +6007,7 @@ models:
               tag: 0.20.0-de59f8a
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6757,11 +6754,6 @@ models:
             image:
               repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
               tag: 0.20.0-de59f8a-03fa3af
-            probes:
-              liveness:
-                initialDelaySeconds: 2400
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 67Gi
@@ -6795,10 +6787,7 @@ models:
               tag: 0.20.0-de59f8a
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi
@@ -6842,10 +6831,7 @@ models:
               tag: 0.20.0-de59f8a
             probes:
               liveness:
-                initialDelaySeconds: 2400
                 path: /tt-liveness
-              readiness:
-                initialDelaySeconds: 2400
             resources:
               requests:
                 memory: 6Gi

--- a/tests/test_helm_generator/test_merge.py
+++ b/tests/test_helm_generator/test_merge.py
@@ -48,7 +48,6 @@ def _mapped(
     repository="ghcr.io/org/img",
     tag="1.0.0",
     progress=5400,
-    initial_delay=2400,
     liveness_path=None,
     memory="20Gi",
     env=(),
@@ -57,8 +56,8 @@ def _mapped(
         image=HelmImage(repository=repository, tag=tag),
         progress_deadline_seconds=progress,
         probes=HelmProbes(
-            liveness=HelmProbe(initial_delay_seconds=initial_delay, path=liveness_path),
-            readiness=HelmProbe(initial_delay_seconds=initial_delay),
+            liveness=HelmProbe(path=liveness_path),
+            readiness=HelmProbe(),
         ),
         resources=HelmResources(requests_memory=memory),
         env=[HelmEnvVar(name=k, value=v) for k, v in env],

--- a/tests/test_helm_generator/test_schema.py
+++ b/tests/test_helm_generator/test_schema.py
@@ -18,8 +18,8 @@ def _impl_config(**overrides):
         image=HelmImage(repository="ghcr.io/org/image", tag="1.0.0"),
         progress_deadline_seconds=5400,
         probes=HelmProbes(
-            liveness=HelmProbe(initial_delay_seconds=2400),
-            readiness=HelmProbe(initial_delay_seconds=2400),
+            liveness=HelmProbe(),
+            readiness=HelmProbe(),
         ),
     )
     defaults.update(overrides)
@@ -31,17 +31,24 @@ def test_image_yaml_dict():
     assert img.to_yaml_dict() == {"repository": "repo", "tag": "t"}
 
 
-def test_probe_omits_path_when_none():
-    assert HelmProbe(initial_delay_seconds=600).to_yaml_dict() == {
-        "initialDelaySeconds": 600
-    }
+def test_probe_omits_block_when_path_none():
+    assert HelmProbe().to_yaml_dict() == {}
 
 
 def test_probe_includes_path_when_set():
-    assert HelmProbe(initial_delay_seconds=600, path="/tt-liveness").to_yaml_dict() == {
-        "initialDelaySeconds": 600,
-        "path": "/tt-liveness",
-    }
+    assert HelmProbe(path="/tt-liveness").to_yaml_dict() == {"path": "/tt-liveness"}
+
+
+def test_probes_omitted_when_empty():
+    cfg = _impl_config()
+    assert "probes" not in cfg.to_yaml_dict()
+
+
+def test_probes_emits_only_liveness_path():
+    cfg = _impl_config(
+        probes=HelmProbes(liveness=HelmProbe(path="/tt-liveness"), readiness=HelmProbe())
+    )
+    assert cfg.to_yaml_dict()["probes"] == {"liveness": {"path": "/tt-liveness"}}
 
 
 def test_resources_omits_block_when_no_memory():

--- a/tests/test_helm_generator/test_schema.py
+++ b/tests/test_helm_generator/test_schema.py
@@ -46,7 +46,9 @@ def test_probes_omitted_when_empty():
 
 def test_probes_emits_only_liveness_path():
     cfg = _impl_config(
-        probes=HelmProbes(liveness=HelmProbe(path="/tt-liveness"), readiness=HelmProbe())
+        probes=HelmProbes(
+            liveness=HelmProbe(path="/tt-liveness"), readiness=HelmProbe()
+        )
     )
     assert cfg.to_yaml_dict()["probes"] == {"liveness": {"path": "/tt-liveness"}}
 

--- a/tests/test_helm_generator/test_vllm_mapper.py
+++ b/tests/test_helm_generator/test_vllm_mapper.py
@@ -42,13 +42,13 @@ def test_progress_deadline_seconds(vllm_spec):
     assert cfg.progress_deadline_seconds == expected
 
 
-def test_probes_initial_delay(vllm_spec):
+def test_probes_carry_no_timing_and_no_path_for_vllm(vllm_spec):
+    # vllm uses the default probe paths; the startupProbe owns the compile
+    # window, so no per-model probe timing is emitted.
     cfg = VllmMapper().map(vllm_spec).config
-    expected = int(vllm_spec.device_model_spec.tensor_cache_timeout * 2 / 3)
-    assert cfg.probes.liveness.initial_delay_seconds == expected
-    assert cfg.probes.readiness.initial_delay_seconds == expected
     assert cfg.probes.liveness.path is None
     assert cfg.probes.readiness.path is None
+    assert cfg.to_yaml_dict().get("probes") is None
 
 
 def test_env_list_sorted_and_includes_spec_env_vars(vllm_spec):

--- a/workflows/helm_generator/base_mapper.py
+++ b/workflows/helm_generator/base_mapper.py
@@ -32,8 +32,6 @@ COMMON_OWNED_PATHS: Set[Tuple[str, ...]] = {
     ("image", "repository"),
     ("image", "tag"),
     ("resources", "requests", "memory"),
-    ("probes", "liveness", "initialDelaySeconds"),
-    ("probes", "readiness", "initialDelaySeconds"),
     ("progressDeadlineSeconds",),
     ("env",),
 }
@@ -65,10 +63,6 @@ class HelmValuesMapper(ABC):
         return int(spec.device_model_spec.tensor_cache_timeout) + 1800
 
     @staticmethod
-    def _initial_delay_seconds(spec: ModelSpec) -> int:
-        return int(spec.device_model_spec.tensor_cache_timeout * 2 / 3)
-
-    @staticmethod
     def _requests_memory(spec: ModelSpec) -> Optional[str]:
         if spec.min_ram_gb is None:
             return None
@@ -84,19 +78,12 @@ class HelmValuesMapper(ABC):
 
     def _build_impl_config(self, spec: ModelSpec) -> HelmImplConfig:
         repo, tag = self._split_image(spec.docker_image)
-        initial_delay = self._initial_delay_seconds(spec)
         return HelmImplConfig(
             image=HelmImage(repository=repo, tag=tag),
             progress_deadline_seconds=self._progress_deadline_seconds(spec),
             probes=HelmProbes(
-                liveness=HelmProbe(
-                    initial_delay_seconds=initial_delay,
-                    path=self.liveness_path,
-                ),
-                readiness=HelmProbe(
-                    initial_delay_seconds=initial_delay,
-                    path=self.readiness_path,
-                ),
+                liveness=HelmProbe(path=self.liveness_path),
+                readiness=HelmProbe(path=self.readiness_path),
             ),
             resources=HelmResources(requests_memory=self._requests_memory(spec)),
             env=self._env_list(spec),

--- a/workflows/helm_generator/schema.py
+++ b/workflows/helm_generator/schema.py
@@ -19,14 +19,13 @@ class HelmImage:
 
 @dataclass(frozen=True)
 class HelmProbe:
-    initial_delay_seconds: int
+    # Only the HTTP path is per-model (engine-specific, e.g. /tt-liveness).
+    # Timing is not: the startupProbe owns the compile window and derives its
+    # budget from progressDeadlineSeconds in the Deployment.
     path: Optional[str] = None
 
     def to_yaml_dict(self) -> Dict[str, Any]:
-        out: Dict[str, Any] = {"initialDelaySeconds": self.initial_delay_seconds}
-        if self.path is not None:
-            out["path"] = self.path
-        return out
+        return {"path": self.path} if self.path is not None else {}
 
 
 @dataclass(frozen=True)
@@ -35,10 +34,14 @@ class HelmProbes:
     readiness: HelmProbe
 
     def to_yaml_dict(self) -> Dict[str, Any]:
-        return {
-            "liveness": self.liveness.to_yaml_dict(),
-            "readiness": self.readiness.to_yaml_dict(),
-        }
+        out: Dict[str, Any] = {}
+        liveness = self.liveness.to_yaml_dict()
+        if liveness:
+            out["liveness"] = liveness
+        readiness = self.readiness.to_yaml_dict()
+        if readiness:
+            out["readiness"] = readiness
+        return out
 
 
 @dataclass(frozen=True)
@@ -77,8 +80,10 @@ class HelmImplConfig:
         out: Dict[str, Any] = {
             "progressDeadlineSeconds": self.progress_deadline_seconds,
             "image": self.image.to_yaml_dict(),
-            "probes": self.probes.to_yaml_dict(),
         }
+        probes = self.probes.to_yaml_dict()
+        if probes:
+            out["probes"] = probes
         resources = self.resources.to_yaml_dict()
         if resources is not None:
             out["resources"] = resources


### PR DESCRIPTION
Part of #4859. Stacked on #4887 — merge that first.

Replaces the v0.1.0 large-`initialDelaySeconds` heuristic with a `startupProbe` that owns the compile/warmup window. The Pod now reports `READY 1/1` as soon as it serves (not after a fixed delay), and a long compile no longer risks a liveness restart.

`failureThreshold` is derived in the template as `ceil(progressDeadlineSeconds / periodSeconds)`, so the budget tracks the max compile time with no per-model probe timing to hand-sync. Per-model `initialDelaySeconds` is removed; the generator's `HelmProbe` is now path-only.

Verified on T3K (Qwen3-8B/n300): Pod reached `READY 1/1` ~12s after warmup vs the ~40 min fixed wait under v0.1.0.

Closes #4870.
