### PR TITLE
Bump tt-forge to 1.5.0.dev20260812001218 for LLM blocker fixes

### DIFF
--- a/tt-media-server/tt_model_runners/forge_runners/requirements.txt
+++ b/tt-media-server/tt_model_runners/forge_runners/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
 --extra-index-url https://download.pytorch.org/whl/cpu
-# 1.4.0 dev/nightly built 2026-07-18. Supersedes the 2026-07-05 build.
-tt-forge==1.4.0
+# 1.5.0 dev/nightly built 2026-08-12. Supersedes the 1.4.0 release.
+tt-forge==1.5.0.dev20260812001218
 
 tabulate
 timm # input preprocessing


### PR DESCRIPTION
### Issue

- https://github.com/tenstorrent/tt-xla/issues/5892
- https://github.com/tenstorrent/tt-xla/issues/5778
- https://github.com/tenstorrent/tt-xla/issues/5521

### What's Changed

Version bump of `tt-forge` to `1.5.0.dev20260812001218` in `tt-media-server/tt_model_runners/forge_runners/requirements.txt` (supersedes the `1.4.0` release pin from #4827).

This brings in the tt-xla **Data Parallel** fixes, so the data-parallel tests pass again: DP row corruption — batch-axis sharding, `dp_size`-aligned request buckets and active-row chunked-prefill offset (tenstorrent/tt-xla#5893), `condense()` KV-cache corruption when a surviving request is relocated across a replica boundary (tenstorrent/tt-xla#5799), and Gemma 4 DP+TP generation without `ignore_eos_token=True` (tenstorrent/tt-xla#5941).

### Checklist

- [x] `efficientnet`: https://github.com/tenstorrent/tt-shield/actions/runs/31557803401
- [x] `mobilenetv2`: https://github.com/tenstorrent/tt-shield/actions/runs/31557808176
- [x] `resnet-50`: https://github.com/tenstorrent/tt-shield/actions/runs/31557813073
- [x] `segformer`: https://github.com/tenstorrent/tt-shield/actions/runs/31557818603
- [x] `vit`: https://github.com/tenstorrent/tt-shield/actions/runs/31557824004
- [x] `vovnet`: https://github.com/tenstorrent/tt-shield/actions/runs/31557828794
- [x] `Falcon3-7B-Instruct`: https://github.com/tenstorrent/tt-shield/actions/runs/31556782024
- [ ] `Qwen3-4B`: https://github.com/tenstorrent/tt-shield/actions/runs/31557837196
