### PR TITLE
docs(Qwen3.6-27B p300x2): caution on 0.18.0 pin (#49513); correct Max Batch Size to verified 4 @ 262144 ctx

### DIFF
--- a/docs/model_support/llm/Qwen3.6-27B_p300x2.md
+++ b/docs/model_support/llm/Qwen3.6-27B_p300x2.md
@@ -27,6 +27,8 @@ docker run \
   --tt-device p300x2
 ```
 
+> **Caution (build pin):** the pinned `0.18.0-c49bb76-6b4a3a7` image carries the "coherent but incorrect" generation bug for this model ([tt-metal#49513](https://github.com/tenstorrent/tt-metal/issues/49513)). Use a 0.19.0+ build that includes [tt-metal#48861](https://github.com/tenstorrent/tt-metal/pull/48861) (chunked-GDN C++ op) and commit `c355c15b` (weight loading).
+
 **via run.py command**
 
 ```bash
@@ -40,9 +42,11 @@ For details on the run.py command, see the [run.py CLI Options](../../workflows_
 |-----------|-------|
 | Weights | [Qwen/Qwen3.6-27B](https://huggingface.co/Qwen/Qwen3.6-27B) |
 | Model Status | 🛠️ Experimental |
-| Max Batch Size | 1 |
+| Max Batch Size | 4 @ 262144 ctx (see note below) |
 | Max Context Length | 262144 |
 | Implementation Code | [qwen36-blackhole](https://github.com/tenstorrent/tt-metal/tree/c49bb76/models/demos/blackhole/qwen36) |
 | tt-metal Commit | `c49bb76` |
 | vLLM Commit | `6b4a3a7` |
 | Docker Image | `ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7` |
+
+> **Batch size note:** independently verified on a TT-QuietBox 2 (4×P150): `max_num_seqs=4` at full 262144 ctx decodes 4 requests concurrently (61.87 tok/s aggregate @4; 4-prompt concurrent correctness gate 4/4), while `max_num_seqs=8` at 262144 ctx OOMs in device DRAM (`bank_manager.cpp:462`). Batch=8 is available via the 64k-context spec from [#4706](https://github.com/tenstorrent/tt-inference-server/pull/4706).


### PR DESCRIPTION
The p300x2 doc for Qwen3.6-27B still pins the 0.18.0-`c49bb76` + `6b4a3a7` build — which carries the [tt-metal#49513](https://github.com/tenstorrent/tt-metal/issues/49513) "coherent but incorrect" bug for this model — and documents "Max Batch Size 1" at 262144 ctx.

This PR:
1. Adds a caution at the quickstart pin pointing users to 0.19.0+ builds that include [tt-metal#48861](https://github.com/tenstorrent/tt-metal/pull/48861) + `c355c15b`.
2. Corrects the batch ceiling: batch=4 at full 262144 ctx is verified working on 4×P150 hardware (61.87 tok/s aggregate @4, 4-prompt concurrent correctness gate 4/4), while batch=8 at 262144 ctx OOMs in device DRAM (`bank_manager.cpp:462`) — so the accurate statement is "batch up to 4 @ 262144 ctx; batch 8 only via the 64k-ctx spec from #4706".

---
*Drafted by CQL AI (Canada Quant Labs' AI research agent) and verified by a human who takes responsibility for its contents. All figures and log excerpts were observed on our own hardware (TT-QuietBox 2, 4× Blackhole).*