### PR TITLE
[Helm v0.2] hugepages-free mode (hugepages.enabled toggle) (#4866)

### DIFF
--- a/charts/tt-inference-server/README.md
+++ b/charts/tt-inference-server/README.md
@@ -173,6 +173,7 @@ Set per release, typically via `--set`.
 | `impl` | no | `""` | Pin the implementation when a device offers more than one. Defaults to `models.<model>.<engine>.<device>.defaultImpl`. |
 | `hfToken` | yes* | `""` | HuggingFace token. Injected as `HF_TOKEN`. Required unless weights are pre-downloaded via `hfCacheDir`. |
 | `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
+| `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
 | `cache.hostPath` | no | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>-<impl>`. |
 | `nameOverride` | no | `""` | Overrides the chart name component in resource names. |
 | `fullnameOverride` | no | `""` | Fully overrides the resource name prefix. |
@@ -196,10 +197,10 @@ All fields under `defaults` apply to every model/engine/device/impl unless overr
 | `defaults.service.port` | `8000` | Service port. |
 | `defaults.service.targetPort` | `8000` | Container target port. |
 | `defaults.service.annotations` | `{}` | Annotations applied to the Service. |
-| `defaults.resources.limits.hugepages-1Gi` | `32Gi` | Hugepage limit. (`cpu` and `memory` limits are unset by default.) |
+| `defaults.resources.limits.hugepages-1Gi` | `32Gi` | Hugepage limit. Dropped when `hugepages.enabled=false`. (`cpu` and `memory` limits are unset by default.) |
 | `defaults.resources.requests.cpu` | `"6"` | CPU request. |
 | `defaults.resources.requests.memory` | `64Gi` | Memory request (often overridden per impl). |
-| `defaults.resources.requests.hugepages-1Gi` | `32Gi` | Hugepage request. |
+| `defaults.resources.requests.hugepages-1Gi` | `32Gi` | Hugepage request. Dropped when `hugepages.enabled=false`. |
 | `defaults.probes.startup.periodSeconds` | `15` | startupProbe poll interval (must be `> 0`). The startupProbe is always rendered — it owns the model compile/warmup window, and while it runs the kubelet suppresses liveness/readiness so a slow compile never triggers a restart. `failureThreshold` is not set here — the Deployment derives it as `ceil(progressDeadlineSeconds / periodSeconds)`, so the startup budget tracks the max compile time and the Pod flips to `1/1` as soon as one poll succeeds. |
 | `defaults.probes.liveness.enabled` | `true` | Enable liveness probe. |
 | `defaults.probes.liveness.path` | `/v1/models` | Liveness probe HTTP path (`/tt-liveness` for non-vllm engines). |
@@ -564,12 +565,13 @@ helm install my-model ./charts/tt-inference-server \
 
 ## Init Containers
 
-Each pod runs two init containers before the inference server starts:
+`fix-cache-permissions` always runs before the inference server starts;
+`cleanup-hugepages` runs only when `hugepages.enabled` (the default).
 
 **`fix-cache-permissions`**
 Runs `chown -R 1000:1000 /cache` on the cache host path volume. The inference server runs as UID 1000 and requires write access to the cache directory, which may be created by root on the host.
 
-**`cleanup-hugepages`**
+**`cleanup-hugepages`** (only when `hugepages.enabled`)
 Removes stale hugepage files left by previous runs, **scoped to this Pod's
 DRA-allocated board(s)** only. The init container requests the same
 `ResourceClaim` as the main container, so the DRA driver injects its

--- a/charts/tt-inference-server/README.md.gotmpl
+++ b/charts/tt-inference-server/README.md.gotmpl
@@ -173,6 +173,7 @@ Set per release, typically via `--set`.
 | `impl` | no | `""` | Pin the implementation when a device offers more than one. Defaults to `models.<model>.<engine>.<device>.defaultImpl`. |
 | `hfToken` | yes* | `""` | HuggingFace token. Injected as `HF_TOKEN`. Required unless weights are pre-downloaded via `hfCacheDir`. |
 | `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
+| `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
 | `cache.hostPath` | no | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>-<impl>`. |
 | `nameOverride` | no | `""` | Overrides the chart name component in resource names. |
 | `fullnameOverride` | no | `""` | Fully overrides the resource name prefix. |
@@ -196,10 +197,10 @@ All fields under `defaults` apply to every model/engine/device/impl unless overr
 | `defaults.service.port` | `8000` | Service port. |
 | `defaults.service.targetPort` | `8000` | Container target port. |
 | `defaults.service.annotations` | `{}` | Annotations applied to the Service. |
-| `defaults.resources.limits.hugepages-1Gi` | `32Gi` | Hugepage limit. (`cpu` and `memory` limits are unset by default.) |
+| `defaults.resources.limits.hugepages-1Gi` | `32Gi` | Hugepage limit. Dropped when `hugepages.enabled=false`. (`cpu` and `memory` limits are unset by default.) |
 | `defaults.resources.requests.cpu` | `"6"` | CPU request. |
 | `defaults.resources.requests.memory` | `64Gi` | Memory request (often overridden per impl). |
-| `defaults.resources.requests.hugepages-1Gi` | `32Gi` | Hugepage request. |
+| `defaults.resources.requests.hugepages-1Gi` | `32Gi` | Hugepage request. Dropped when `hugepages.enabled=false`. |
 | `defaults.probes.startup.periodSeconds` | `15` | startupProbe poll interval (must be `> 0`). The startupProbe is always rendered — it owns the model compile/warmup window, and while it runs the kubelet suppresses liveness/readiness so a slow compile never triggers a restart. `failureThreshold` is not set here — the Deployment derives it as `ceil(progressDeadlineSeconds / periodSeconds)`, so the startup budget tracks the max compile time and the Pod flips to `1/1` as soon as one poll succeeds. |
 | `defaults.probes.liveness.enabled` | `true` | Enable liveness probe. |
 | `defaults.probes.liveness.path` | `/v1/models` | Liveness probe HTTP path (`/tt-liveness` for non-vllm engines). |
@@ -282,12 +283,13 @@ helm install my-model ./charts/tt-inference-server \
 
 ## Init Containers
 
-Each pod runs two init containers before the inference server starts:
+`fix-cache-permissions` always runs before the inference server starts;
+`cleanup-hugepages` runs only when `hugepages.enabled` (the default).
 
 **`fix-cache-permissions`**
 Runs `chown -R 1000:1000 /cache` on the cache host path volume. The inference server runs as UID 1000 and requires write access to the cache directory, which may be created by root on the host.
 
-**`cleanup-hugepages`**
+**`cleanup-hugepages`** (only when `hugepages.enabled`)
 Removes stale hugepage files left by previous runs, **scoped to this Pod's
 DRA-allocated board(s)** only. The init container requests the same
 `ResourceClaim` as the main container, so the DRA driver injects its

--- a/charts/tt-inference-server/templates/deployment.yaml
+++ b/charts/tt-inference-server/templates/deployment.yaml
@@ -4,6 +4,19 @@
 {{- $ttCount := include "tt-inference-server.draDeviceCount" . }}
 {{- $startupPeriod := $cfg.probes.startup.periodSeconds | int }}
 {{- if le $startupPeriod 0 }}{{- fail "probes.startup.periodSeconds must be greater than 0 (it divides progressDeadlineSeconds to size the startupProbe budget)." }}{{- end }}
+{{- /* default true (provision hugepages) when the hugepages map is absent/null or omits enabled. */ -}}
+{{- $hugepages := dig "enabled" true (.Values.hugepages | default dict) }}
+{{- $resources := $cfg.resources }}
+{{- if and $resources (not $hugepages) }}
+{{- /* hugepages disabled: strip hugepages-1Gi from a copy so $cfg is untouched. */ -}}
+{{- $resources = deepCopy $resources }}
+{{- range $group := list "limits" "requests" }}
+{{- if hasKey $resources $group }}
+{{- $_ := unset (index $resources $group) "hugepages-1Gi" }}
+{{- if not (index $resources $group) }}{{- $_ := unset $resources $group }}{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,6 +66,7 @@ spec:
           volumeMounts:
             - name: cache
               mountPath: /cache
+        {{- if $hugepages }}
         # Scoped hugepages cleanup: claim requested here so the DRA driver injects
         # /dev/tenstorrent/<N>; delete only THIS Pod's board files, not co-located Pods'.
         - name: cleanup-hugepages
@@ -75,6 +89,7 @@ spec:
           volumeMounts:
             - name: hugepages-1g
               mountPath: /dev/hugepages-1G
+        {{- end }}
       containers:
         - name: inference-server
           image: {{ include "tt-inference-server.image" . }}
@@ -102,16 +117,18 @@ spec:
           volumeMounts:
             - name: cache
               mountPath: /home/container_app_user/cache_root
+            {{- if $hugepages }}
             - name: hugepages-1g
               mountPath: /dev/hugepages-1G
+            {{- end }}
             {{- if .Values.hfCacheDir }}
             - name: hf-cache
               mountPath: /mnt/hf-cache
               readOnly: true
             {{- end }}
-          {{- if or $cfg.resources $ttCount }}
+          {{- if or $resources $ttCount }}
           resources:
-            {{- with $cfg.resources }}
+            {{- with $resources }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- if $ttCount }}
@@ -160,10 +177,12 @@ spec:
           hostPath:
             path: {{ include "tt-inference-server.cacheHostPath" . }}
             type: DirectoryOrCreate
+        {{- if $hugepages }}
         - name: hugepages-1g
           hostPath:
             path: /dev/hugepages-1G
             type: Directory
+        {{- end }}
         {{- if .Values.hfCacheDir }}
         - name: hf-cache
           hostPath:

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -29,6 +29,13 @@ cache:
 # (tt-media-server) env vars are set so each server picks up the name it reads.
 hfCacheDir: ""
 
+# Tenstorrent boards need 1Gi hugepages unless the cluster runs IOMMU + KMD
+# 1.29.0+, where they aren't required. When disabled, the chart drops the
+# hugepages-1Gi request/limit, the /dev/hugepages-1G volume + mounts, and the
+# cleanup-hugepages initContainer.
+hugepages:
+  enabled: true
+
 # ---------------------------------------------------------------------------
 # Defaults — merged with (and overridden by) per-model config below.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #4859. Stacked on #4919 — merge that first.

Adds a `hugepages.enabled` toggle (default `true`). When `false` — for IOMMU + KMD 1.29.0+ clusters where boards don't need hugepages — the chart drops the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. Default-on rendering is unchanged.

The `Recreate → RollingUpdate` item from #4859 is already handled by #4887 (`maxSurge=0` is still needed under DRA to free the board before the replacement starts), so it's not repeated here.

Verified on T3K (Qwen3-8B/n300) with `hugepages.enabled=false`: host at zero 1Gi hugepages under IOMMU DMA, device fabric init + inference served, Pod `READY 1/1`.

Closes #4866.