### PR TITLE
[Helm v0.2] add optional app-metrics PodMonitor (#4867)

### DIFF
--- a/charts/tt-inference-server/README.md
+++ b/charts/tt-inference-server/README.md
@@ -175,7 +175,7 @@ Set per release, typically via `--set`.
 | `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
 | `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
 | `podMonitor.enabled` | no | `false` | Emit a `PodMonitor` scraping the server's `/metrics`. Requires the Prometheus Operator CRDs (`monitoring.coreos.com`); leave `false` on clusters without them. |
-| `podMonitor.labels` | no | `{}` | Extra labels on the `PodMonitor`. Set the label your Prometheus's `podMonitorSelector` matches (e.g. `release: kube-prometheus-stack`). |
+| `podMonitor.labels` | no | `{release: prometheus}` | Labels on the `PodMonitor`; must match your Prometheus's `podMonitorSelector` or it won't be scraped. The default matches tt-telemetry's chart and the kube-prometheus-stack convention (`podMonitorSelector` defaults to `release: <the stack's release name>`); override when yours is named differently. |
 | `podMonitor.interval` | no | `30s` | Scrape interval. |
 | `podMonitor.path` | no | `/metrics` | Metrics HTTP path (scraped on the `http` port). |
 | `cache.hostPath` | no | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>-<impl>`. |
@@ -581,11 +581,10 @@ helm install my-model ./charts/tt-inference-server \
   --set model="Llama-3.1-8B-Instruct" \
   --set device=galaxy \
   --set hfToken="hf_xxx" \
-  --set podMonitor.enabled=true \
-  --set podMonitor.labels.release=kube-prometheus-stack
+  --set podMonitor.enabled=true
 ```
 
-The label must match your Prometheus's `podMonitorSelector` (e.g. `release: kube-prometheus-stack`) or it won't be scraped; see the [Values Reference](#values-reference) for the other `podMonitor.*` options and the Prometheus Operator CRD requirement.
+`podMonitor.labels` defaults to `release: prometheus`, matching tt-telemetry's chart and a kube-prometheus-stack installed under the release name `prometheus`. If your Prometheus release is named differently, override it (`--set podMonitor.labels.release=<release-name>`) or the `PodMonitor` won't be scraped; see the [Values Reference](#values-reference) for the other `podMonitor.*` options and the Prometheus Operator CRD requirement.
 
 The chart ships no Grafana dashboard (metrics differ per engine). For vLLM, import the [official vLLM dashboard](https://docs.vllm.ai/en/stable/examples/online_serving/prometheus_grafana/) ([JSON](https://github.com/vllm-project/vllm/tree/main/examples/observability/prometheus_grafana)) via Grafana → Import, pointed at your Prometheus. For media-server / forge, build panels in Grafana Explore from the scraped metrics.
 

--- a/charts/tt-inference-server/README.md
+++ b/charts/tt-inference-server/README.md
@@ -174,6 +174,10 @@ Set per release, typically via `--set`.
 | `hfToken` | yes* | `""` | HuggingFace token. Injected as `HF_TOKEN`. Required unless weights are pre-downloaded via `hfCacheDir`. |
 | `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
 | `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
+| `podMonitor.enabled` | no | `false` | Emit a `PodMonitor` scraping the server's `/metrics`. Requires the Prometheus Operator CRDs (`monitoring.coreos.com`); leave `false` on clusters without them. |
+| `podMonitor.labels` | no | `{}` | Extra labels on the `PodMonitor`. Set the label your Prometheus's `podMonitorSelector` matches (e.g. `release: kube-prometheus-stack`). |
+| `podMonitor.interval` | no | `30s` | Scrape interval. |
+| `podMonitor.path` | no | `/metrics` | Metrics HTTP path (scraped on the `http` port). |
 | `cache.hostPath` | no | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>-<impl>`. |
 | `nameOverride` | no | `""` | Overrides the chart name component in resource names. |
 | `fullnameOverride` | no | `""` | Fully overrides the resource name prefix. |
@@ -560,6 +564,34 @@ helm install my-model ./charts/tt-inference-server \
   --set hfToken="hf_xxx" \
   --set cache.hostPath="/mnt/fast-nvme/cache"
 ```
+
+### Monitoring
+
+Metrics come from two independent sources, each enabled separately:
+
+| Source | Measures | Owned by | Enable with |
+|---|---|---|---|
+| App metrics | Inference server: request rate, latency, tokens/s, queue depth | this chart (consumer) | `podMonitor.enabled=true` |
+| Device telemetry | Tenstorrent boards: temperature, power, chip utilization | tt-operator (supply side) | `tt-telemetry.enabled=true` on tt-operator |
+
+**App metrics** — vLLM and media-server expose `/metrics`. Set `podMonitor.enabled=true` to emit a `PodMonitor` that Prometheus scrapes:
+
+```bash
+helm install my-model ./charts/tt-inference-server \
+  --set model="Llama-3.1-8B-Instruct" \
+  --set device=galaxy \
+  --set hfToken="hf_xxx" \
+  --set podMonitor.enabled=true \
+  --set podMonitor.labels.release=kube-prometheus-stack
+```
+
+The label must match your Prometheus's `podMonitorSelector` (e.g. `release: kube-prometheus-stack`) or it won't be scraped; see the [Values Reference](#values-reference) for the other `podMonitor.*` options and the Prometheus Operator CRD requirement.
+
+The chart ships no Grafana dashboard (metrics differ per engine). For vLLM, import the [official vLLM dashboard](https://docs.vllm.ai/en/stable/examples/online_serving/prometheus_grafana/) ([JSON](https://github.com/vllm-project/vllm/tree/main/examples/observability/prometheus_grafana)) via Grafana → Import, pointed at your Prometheus. For media-server / forge, build panels in Grafana Explore from the scraped metrics.
+
+**Device telemetry** is not part of this chart. It is a tt-operator component (`tt-telemetry`) — a cluster-wide singleton with a separate lifecycle. The cluster admin enables it by setting the `tt-telemetry.enabled=true` subchart value when installing the tt-operator umbrella chart (`oci://ghcr.io/tenstorrent/helm/tt-operator`); see the [tt-operator documentation](https://docs.tenstorrent.com/cloud-native-support/) for the full install procedure.
+
+Correlating the two (device × app) is future work — it needs a supply-side bridge exporter that maps devices to pods.
 
 ---
 

--- a/charts/tt-inference-server/README.md.gotmpl
+++ b/charts/tt-inference-server/README.md.gotmpl
@@ -174,6 +174,10 @@ Set per release, typically via `--set`.
 | `hfToken` | yes* | `""` | HuggingFace token. Injected as `HF_TOKEN`. Required unless weights are pre-downloaded via `hfCacheDir`. |
 | `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
 | `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
+| `podMonitor.enabled` | no | `false` | Emit a `PodMonitor` scraping the server's `/metrics`. Requires the Prometheus Operator CRDs (`monitoring.coreos.com`); leave `false` on clusters without them. |
+| `podMonitor.labels` | no | `{}` | Extra labels on the `PodMonitor`. Set the label your Prometheus's `podMonitorSelector` matches (e.g. `release: kube-prometheus-stack`). |
+| `podMonitor.interval` | no | `30s` | Scrape interval. |
+| `podMonitor.path` | no | `/metrics` | Metrics HTTP path (scraped on the `http` port). |
 | `cache.hostPath` | no | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>-<impl>`. |
 | `nameOverride` | no | `""` | Overrides the chart name component in resource names. |
 | `fullnameOverride` | no | `""` | Fully overrides the resource name prefix. |
@@ -278,6 +282,34 @@ helm install my-model ./charts/tt-inference-server \
   --set hfToken="hf_xxx" \
   --set cache.hostPath="/mnt/fast-nvme/cache"
 ```
+
+### Monitoring
+
+Metrics come from two independent sources, each enabled separately:
+
+| Source | Measures | Owned by | Enable with |
+|---|---|---|---|
+| App metrics | Inference server: request rate, latency, tokens/s, queue depth | this chart (consumer) | `podMonitor.enabled=true` |
+| Device telemetry | Tenstorrent boards: temperature, power, chip utilization | tt-operator (supply side) | `tt-telemetry.enabled=true` on tt-operator |
+
+**App metrics** — vLLM and media-server expose `/metrics`. Set `podMonitor.enabled=true` to emit a `PodMonitor` that Prometheus scrapes:
+
+```bash
+helm install my-model ./charts/tt-inference-server \
+  --set model="Llama-3.1-8B-Instruct" \
+  --set device=galaxy \
+  --set hfToken="hf_xxx" \
+  --set podMonitor.enabled=true \
+  --set podMonitor.labels.release=kube-prometheus-stack
+```
+
+The label must match your Prometheus's `podMonitorSelector` (e.g. `release: kube-prometheus-stack`) or it won't be scraped; see the [Values Reference](#values-reference) for the other `podMonitor.*` options and the Prometheus Operator CRD requirement.
+
+The chart ships no Grafana dashboard (metrics differ per engine). For vLLM, import the [official vLLM dashboard](https://docs.vllm.ai/en/stable/examples/online_serving/prometheus_grafana/) ([JSON](https://github.com/vllm-project/vllm/tree/main/examples/observability/prometheus_grafana)) via Grafana → Import, pointed at your Prometheus. For media-server / forge, build panels in Grafana Explore from the scraped metrics.
+
+**Device telemetry** is not part of this chart. It is a tt-operator component (`tt-telemetry`) — a cluster-wide singleton with a separate lifecycle. The cluster admin enables it by setting the `tt-telemetry.enabled=true` subchart value when installing the tt-operator umbrella chart (`oci://ghcr.io/tenstorrent/helm/tt-operator`); see the [tt-operator documentation](https://docs.tenstorrent.com/cloud-native-support/) for the full install procedure.
+
+Correlating the two (device × app) is future work — it needs a supply-side bridge exporter that maps devices to pods.
 
 ---
 

--- a/charts/tt-inference-server/README.md.gotmpl
+++ b/charts/tt-inference-server/README.md.gotmpl
@@ -175,7 +175,7 @@ Set per release, typically via `--set`.
 | `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
 | `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
 | `podMonitor.enabled` | no | `false` | Emit a `PodMonitor` scraping the server's `/metrics`. Requires the Prometheus Operator CRDs (`monitoring.coreos.com`); leave `false` on clusters without them. |
-| `podMonitor.labels` | no | `{}` | Extra labels on the `PodMonitor`. Set the label your Prometheus's `podMonitorSelector` matches (e.g. `release: kube-prometheus-stack`). |
+| `podMonitor.labels` | no | `{release: prometheus}` | Labels on the `PodMonitor`; must match your Prometheus's `podMonitorSelector` or it won't be scraped. The default matches tt-telemetry's chart and the kube-prometheus-stack convention (`podMonitorSelector` defaults to `release: <the stack's release name>`); override when yours is named differently. |
 | `podMonitor.interval` | no | `30s` | Scrape interval. |
 | `podMonitor.path` | no | `/metrics` | Metrics HTTP path (scraped on the `http` port). |
 | `cache.hostPath` | no | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>-<impl>`. |
@@ -299,11 +299,10 @@ helm install my-model ./charts/tt-inference-server \
   --set model="Llama-3.1-8B-Instruct" \
   --set device=galaxy \
   --set hfToken="hf_xxx" \
-  --set podMonitor.enabled=true \
-  --set podMonitor.labels.release=kube-prometheus-stack
+  --set podMonitor.enabled=true
 ```
 
-The label must match your Prometheus's `podMonitorSelector` (e.g. `release: kube-prometheus-stack`) or it won't be scraped; see the [Values Reference](#values-reference) for the other `podMonitor.*` options and the Prometheus Operator CRD requirement.
+`podMonitor.labels` defaults to `release: prometheus`, matching tt-telemetry's chart and a kube-prometheus-stack installed under the release name `prometheus`. If your Prometheus release is named differently, override it (`--set podMonitor.labels.release=<release-name>`) or the `PodMonitor` won't be scraped; see the [Values Reference](#values-reference) for the other `podMonitor.*` options and the Prometheus Operator CRD requirement.
 
 The chart ships no Grafana dashboard (metrics differ per engine). For vLLM, import the [official vLLM dashboard](https://docs.vllm.ai/en/stable/examples/online_serving/prometheus_grafana/) ([JSON](https://github.com/vllm-project/vllm/tree/main/examples/observability/prometheus_grafana)) via Grafana → Import, pointed at your Prometheus. For media-server / forge, build panels in Grafana Explore from the scraped metrics.
 

--- a/charts/tt-inference-server/templates/podmonitor.yaml
+++ b/charts/tt-inference-server/templates/podmonitor.yaml
@@ -1,0 +1,25 @@
+{{- $podMonitor := .Values.podMonitor | default dict }}
+{{- if dig "enabled" false $podMonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "tt-inference-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- /* merge so user labels add to, but never duplicate, the standard label keys. */ -}}
+    {{- $labels := merge (include "tt-inference-server.labels" . | fromYaml) ($podMonitor.labels | default dict) }}
+    {{- toYaml $labels | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tt-inference-server.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    # /metrics is served on the API port, not a separate one.
+    - port: http
+      {{- with $podMonitor.path }}
+      path: {{ . }}
+      {{- end }}
+      {{- with $podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+{{- end }}

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -41,9 +41,13 @@ hugepages:
 # CRDs (monitoring.coreos.com), and rendering one without them fails at install.
 podMonitor:
   enabled: false
-  # Set the label your Prometheus's podMonitorSelector matches (e.g.
-  # release: kube-prometheus-stack), or the PodMonitor won't be scraped.
-  labels: {}
+  # Labels added to the PodMonitor so your Prometheus's podMonitorSelector
+  # matches it, or it won't be scraped. The default matches tt-telemetry's chart
+  # and the kube-prometheus-stack convention (its podMonitorSelector defaults to
+  # release: <the stack's own release name>). Override when your Prometheus was
+  # installed under a different release name.
+  labels:
+    release: prometheus
   interval: 30s
   path: /metrics
 

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -36,6 +36,17 @@ hfCacheDir: ""
 hugepages:
   enabled: true
 
+# PodMonitor scraping the inference server's own /metrics (vLLM and media-server
+# expose it). Disabled by default: a PodMonitor needs the Prometheus Operator
+# CRDs (monitoring.coreos.com), and rendering one without them fails at install.
+podMonitor:
+  enabled: false
+  # Set the label your Prometheus's podMonitorSelector matches (e.g.
+  # release: kube-prometheus-stack), or the PodMonitor won't be scraped.
+  labels: {}
+  interval: 30s
+  path: /metrics
+
 # ---------------------------------------------------------------------------
 # Defaults — merged with (and overridden by) per-model config below.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #4859. Stacked on #4924 — merge that first.

Adds an optional `PodMonitor` (`podMonitor.enabled`, default `false`) scraping the inference server's own `/metrics` on the API port. Default off because a `PodMonitor` requires the Prometheus Operator CRDs (`monitoring.coreos.com`), which would fail to install without them. `podMonitor.labels` lets operators set the label their Prometheus's `podMonitorSelector` matches (e.g. `release: kube-prometheus-stack`).

No Grafana dashboard is bundled — metrics differ per engine (vLLM `vllm:*`; media-server/forge differ). The README points vLLM users to the official vLLM dashboard for import and media/forge to Grafana Explore; per-engine dashboards are tracked for v0.3 in #4925.

Verified e2e on T3K: with kube-prometheus-stack installed, both app metrics (vLLM) and device telemetry (tt-operator's tt-telemetry) are scraped and queryable in Grafana.

Closes #4867.