### PR TITLE
[Helm v0.2] docs: inference-server on tt-operator (#4868)

### DIFF
--- a/charts/tt-inference-server/Chart.yaml
+++ b/charts/tt-inference-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tt-inference-server
-description: Tenstorrent inference server — vLLM and media backends on Galaxy hardware
+description: Tenstorrent inference server — vLLM, media, and forge backends on Tenstorrent hardware
 type: application
 version: 0.2.0
 appVersion: "0.12.0"

--- a/charts/tt-inference-server/README.md
+++ b/charts/tt-inference-server/README.md
@@ -175,7 +175,7 @@ Set per release, typically via `--set`.
 | `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
 | `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
 | `podMonitor.enabled` | no | `false` | Emit a `PodMonitor` scraping the server's `/metrics`. Requires the Prometheus Operator CRDs (`monitoring.coreos.com`); leave `false` on clusters without them. |
-| `podMonitor.labels` | no | `{}` | Extra labels on the `PodMonitor`. Set the label your Prometheus's `podMonitorSelector` matches (e.g. `release: kube-prometheus-stack`). |
+| `podMonitor.labels` | no | `{release: prometheus}` | Labels on the `PodMonitor`; must match your Prometheus's `podMonitorSelector` or it won't be scraped. The default matches tt-telemetry's chart and the kube-prometheus-stack convention (`podMonitorSelector` defaults to `release: <the stack's release name>`); override when yours is named differently. |
 | `podMonitor.interval` | no | `30s` | Scrape interval. |
 | `podMonitor.path` | no | `/metrics` | Metrics HTTP path (scraped on the `http` port). |
 | `cache.hostPath` | no | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>-<impl>`. |
@@ -581,11 +581,10 @@ helm install my-model ./charts/tt-inference-server \
   --set model="Llama-3.1-8B-Instruct" \
   --set device=galaxy \
   --set hfToken="hf_xxx" \
-  --set podMonitor.enabled=true \
-  --set podMonitor.labels.release=kube-prometheus-stack
+  --set podMonitor.enabled=true
 ```
 
-The label must match your Prometheus's `podMonitorSelector` (e.g. `release: kube-prometheus-stack`) or it won't be scraped; see the [Values Reference](#values-reference) for the other `podMonitor.*` options and the Prometheus Operator CRD requirement.
+`podMonitor.labels` defaults to `release: prometheus`, matching tt-telemetry's chart and a kube-prometheus-stack installed under the release name `prometheus`. If your Prometheus release is named differently, override it (`--set podMonitor.labels.release=<release-name>`) or the `PodMonitor` won't be scraped; see the [Values Reference](#values-reference) for the other `podMonitor.*` options and the Prometheus Operator CRD requirement.
 
 The chart ships no Grafana dashboard (metrics differ per engine). For vLLM, import the [official vLLM dashboard](https://docs.vllm.ai/en/stable/examples/online_serving/prometheus_grafana/) ([JSON](https://github.com/vllm-project/vllm/tree/main/examples/observability/prometheus_grafana)) via Grafana → Import, pointed at your Prometheus. For media-server / forge, build panels in Grafana Explore from the scraped metrics.
 

--- a/charts/tt-inference-server/README.md
+++ b/charts/tt-inference-server/README.md
@@ -174,6 +174,10 @@ Set per release, typically via `--set`.
 | `hfToken` | yes* | `""` | HuggingFace token. Injected as `HF_TOKEN`. Required unless weights are pre-downloaded via `hfCacheDir`. |
 | `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
 | `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
+| `podMonitor.enabled` | no | `false` | Emit a `PodMonitor` scraping the server's `/metrics`. Requires the Prometheus Operator CRDs (`monitoring.coreos.com`); leave `false` on clusters without them. |
+| `podMonitor.labels` | no | `{}` | Extra labels on the `PodMonitor`. Set the label your Prometheus's `podMonitorSelector` matches (e.g. `release: kube-prometheus-stack`). |
+| `podMonitor.interval` | no | `30s` | Scrape interval. |
+| `podMonitor.path` | no | `/metrics` | Metrics HTTP path (scraped on the `http` port). |
 | `cache.hostPath` | no | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>-<impl>`. |
 | `nameOverride` | no | `""` | Overrides the chart name component in resource names. |
 | `fullnameOverride` | no | `""` | Fully overrides the resource name prefix. |
@@ -560,6 +564,34 @@ helm install my-model ./charts/tt-inference-server \
   --set hfToken="hf_xxx" \
   --set cache.hostPath="/mnt/fast-nvme/cache"
 ```
+
+### Monitoring
+
+Metrics come from two independent sources, each enabled separately:
+
+| Source | Measures | Owned by | Enable with |
+|---|---|---|---|
+| App metrics | Inference server: request rate, latency, tokens/s, queue depth | this chart (consumer) | `podMonitor.enabled=true` |
+| Device telemetry | Tenstorrent boards: temperature, power, chip utilization | tt-operator (supply side) | `tt-telemetry.enabled=true` on tt-operator |
+
+**App metrics** — vLLM and media-server expose `/metrics`. Set `podMonitor.enabled=true` to emit a `PodMonitor` that Prometheus scrapes:
+
+```bash
+helm install my-model ./charts/tt-inference-server \
+  --set model="Llama-3.1-8B-Instruct" \
+  --set device=galaxy \
+  --set hfToken="hf_xxx" \
+  --set podMonitor.enabled=true \
+  --set podMonitor.labels.release=kube-prometheus-stack
+```
+
+The label must match your Prometheus's `podMonitorSelector` (e.g. `release: kube-prometheus-stack`) or it won't be scraped; see the [Values Reference](#values-reference) for the other `podMonitor.*` options and the Prometheus Operator CRD requirement.
+
+The chart ships no Grafana dashboard (metrics differ per engine). For vLLM, import the [official vLLM dashboard](https://docs.vllm.ai/en/stable/examples/online_serving/prometheus_grafana/) ([JSON](https://github.com/vllm-project/vllm/tree/main/examples/observability/prometheus_grafana)) via Grafana → Import, pointed at your Prometheus. For media-server / forge, build panels in Grafana Explore from the scraped metrics.
+
+**Device telemetry** is not part of this chart. It is a tt-operator component (`tt-telemetry`) — a cluster-wide singleton with a separate lifecycle. The cluster admin enables it by setting the `tt-telemetry.enabled=true` subchart value when installing the tt-operator umbrella chart (`oci://ghcr.io/tenstorrent/helm/tt-operator`); see the [tt-operator documentation](https://docs.tenstorrent.com/cloud-native-support/) for the full install procedure.
+
+Correlating the two (device × app) is future work — it needs a supply-side bridge exporter that maps devices to pods.
 
 ---
 

--- a/charts/tt-inference-server/README.md
+++ b/charts/tt-inference-server/README.md
@@ -1,8 +1,22 @@
 # tt-inference-server Helm Chart
 
-Deploys vLLM and media inference backends on Tenstorrent Galaxy hardware.
+Deploys vLLM, media, and forge inference backends on Tenstorrent hardware.
 
 **Chart version:** 0.2.0 | **App version:** 0.12.0
+
+## Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Requirements](#requirements)
+- [Device Acquisition (DRA)](#device-acquisition-dra)
+- [Quick Start](#quick-start)
+- [Chart Structure](#chart-structure)
+- [Configuration System](#configuration-system)
+- [Values Reference](#values-reference)
+- [Defaults Reference](#defaults-reference)
+- [Supported Models](#supported-models)
+- [Advanced Usage](#advanced-usage)
 
 ---
 
@@ -17,10 +31,26 @@ Three engines are supported:
 - **forge** — models served via the tt-forge backend
 
 Devices are acquired through **Dynamic Resource Allocation (DRA)**: each Pod
-declares a `ResourceClaim` that the [tt-operator](https://github.com/tenstorrent/tt-operator)
+declares a `ResourceClaim` that the [tt-operator](https://docs.tenstorrent.com/tt-operator/latest/)
 DRA driver satisfies by allocating Tenstorrent boards and injecting the matching
 `/dev/tenstorrent/<N>` node(s). The container runs **unprivileged**, with **no
 `hostPath` on `/dev/tenstorrent`**, and multiple Pods can share one Node.
+
+---
+
+## Architecture
+
+tt-operator (the **supply side**) and this chart (the **consumer**) have
+separate lifecycles, connected only through DRA:
+
+- **tt-operator** is an umbrella chart of cluster-singleton components (the DRA
+  driver, fabric manager, node-feature-discovery, ...). There is no standalone
+  `tt-operator` image. A cluster administrator installs it **once per cluster**.
+- **This chart** (the consumer) requests devices through a `ResourceClaim` and
+  never installs, bundles, or depends on tt-operator as a sub-chart — cluster
+  singletons and per-model workloads have different lifecycle granularity, and
+  bundling would make each model release co-own the cluster-wide device
+  foundation (a `helm uninstall` of one model would tear it down for the others).
 
 ---
 
@@ -30,24 +60,21 @@ DRA driver satisfies by allocating Tenstorrent boards and injecting the matching
   from 1.34 (DRA GA). Verify the API is present:
   `kubectl api-resources --api-group=resource.k8s.io`.
 - **tt-operator installed on the cluster**, providing at least the DRA driver
-  (`tt-dra-driver`), the fabric manager (`tt-fabric-manager`, which the DRA
-  driver queries to enumerate devices), and node-feature-discovery. tt-operator
-  is a cluster-level prerequisite installed **once by an administrator**, on a
-  lifecycle separate from this chart — this chart never installs or manages it,
-  it only emits a `ResourceClaim` that the driver fulfils.
+  ([`tt-dra-driver`](https://docs.tenstorrent.com/tt-dra-driver/latest/)), the
+  fabric manager ([`tt-fabric-manager`](https://docs.tenstorrent.com/tt-fabric-manager/latest/),
+  which the DRA driver queries to enumerate devices), and
+  [node-feature-discovery](https://docs.tenstorrent.com/tt-operator/latest/components/node-feature-discovery.html). See
+  [Architecture](#architecture) for how its lifecycle relates to this chart.
 
-Minimal tt-operator install (device acquisition only):
+The tt-operator chart and its component images are **public on GHCR** — the
+`helm install` below needs no authentication on a standard cluster.
+
+Install tt-operator (v0.2 doesn't use its multi-node scheduling, so `jobset` and
+`kubepmix` are turned off):
 
 ```bash
-kubectl create namespace tt-operator-system
-# GHCR pull secret (k3s/containerd cannot pull the component images anonymously)
-kubectl create secret generic ghcr \
-  --from-file=.dockerconfigjson=$HOME/.docker/config.json \
-  --type=kubernetes.io/dockerconfigjson -n tt-operator-system
 helm install tt-operator oci://ghcr.io/tenstorrent/helm/tt-operator \
-  --version 0.2.0 -n tt-operator-system \
-  --set tt-k8s-driver-manager.enabled=false \
-  --set tt-telemetry.enabled=false \
+  --version 0.2.0 -n tt-operator-system --create-namespace \
   --set jobset.enabled=false \
   --set kubepmix.enabled=false
 # Verify: a DeviceClass and a per-node ResourceSlice appear
@@ -55,8 +82,10 @@ kubectl get deviceclass          # tenstorrent.com
 kubectl get resourceslices       # <node> / tenstorrent.com, one device per board
 ```
 
-> The other tt-operator sub-charts (driver-manager, telemetry, jobset, kubepmix)
-> are optional and documented separately.
+> The remaining sub-charts — `node-feature-discovery`, `tt-k8s-driver-manager`,
+> `tt-fabric-manager`, `tt-dra-driver`, `tt-telemetry` — stay at their defaults.
+> See the [tt-operator docs](https://docs.tenstorrent.com/tt-operator/latest/) for
+> what each sub-chart does and how to configure it.
 
 ---
 
@@ -96,6 +125,8 @@ claims and stuck `Terminating`.
 
 ## Quick Start
 
+> **Prerequisite:** tt-operator must already be installed on the cluster (see [Requirements](#requirements)). Without its DRA driver the Pod can't acquire a device and stays `Pending`.
+
 Three values are required at install time:
 
 ```bash
@@ -125,15 +156,46 @@ charts/tt-inference-server/
 
 ### templates/_helpers.tpl
 
-Contains the core logic for this chart:
+The chart's named templates (all prefixed `tt-inference-server.`), grouped by role:
 
-- **`tt-inference-server.validateValues`** — fails the render if `model` or `device` is missing, or if the resolved `model`/`engine`/`device`/`impl` has no entry in the `models` map.
-- **`tt-inference-server.resolvedEngine`** — picks the engine: `.Values.engine` if set, the sole engine offering the device, otherwise `models.<model>.defaultEngine` when more than one engine offers it.
-- **`tt-inference-server.resolvedImpl`** — picks the implementation: `.Values.impl` if set, otherwise `models.<model>.<engine>.<device>.defaultImpl`.
-- **`tt-inference-server.resolvedConfig`** — deep-merges `defaults` with the resolved impl block (`models.<model>.<engine>.<device>.impls.<impl>`) and returns the effective config as YAML (see [Configuration System](#configuration-system)).
-- **`tt-inference-server.image`** — assembles the container image string (`repository:tag`) from the resolved config.
-- **`tt-inference-server.cacheHostPath`** — returns `cache.hostPath` if set, otherwise generates `/opt/cache/<model>-<device>-<impl>`.
-- Standard Helm name helpers: `tt-inference-server.name`, `tt-inference-server.fullname`, `tt-inference-server.labels`, `tt-inference-server.selectorLabels`.
+**Config resolution** — resolve `model` + `device` into an effective config:
+
+| Helper | Purpose |
+|---|---|
+| `validateValues` | Fails the render if `model`/`device` is missing, or the resolved combination has no entry in `models`. |
+| `resolvedEngine` | Picks the engine: `.Values.engine`, else the sole engine offering the device, else `models.<model>.defaultEngine`. |
+| `resolvedImpl` | Picks the impl: `.Values.impl`, else `models.<model>.<engine>.<device>.defaultImpl`. |
+| `resolvedConfig` | Deep-merges `defaults` with the resolved impl block into the effective config (see [Configuration System](#configuration-system)). |
+
+**Derived values** — build fields from the resolved config:
+
+| Helper | Purpose |
+|---|---|
+| `image` | Container image string `repository:tag`. |
+| `containerEnv` | Container env, merged from spec env, hf-cache env, and `extraEnv` `valueFrom` entries. |
+| `cacheHostPath` | `cache.hostPath` if set, else `/opt/cache/<model>-<device>-<impl>`. |
+| `draDeviceCount` | DRA board count for `device` from `deviceBoardCounts` (fails for unsupported shapes). |
+| `draBoardName` | DRA `boardName` the `ResourceClaim` selects, from `deviceBoardNames`. |
+
+**Naming** — `name`, `fullname`, `chart`, `labels`, `selectorLabels`, `configmapName`, `secretName`: standard Helm name/label helpers.
+
+### Init Containers
+
+Run before the inference server starts:
+
+**`fix-cache-permissions`** (always)
+Runs `chown -R 1000:1000 /cache` on the cache host path volume. The inference server runs as UID 1000 and requires write access to the cache directory, which may be created by root on the host.
+
+**`cleanup-hugepages`** (only when `hugepages.enabled`)
+Removes stale hugepage files left by previous runs, **scoped to this Pod's
+DRA-allocated board(s)** only. The init container requests the same
+`ResourceClaim` as the main container, so the DRA driver injects its
+`/dev/tenstorrent/<N>` node(s); the container then deletes only
+`/dev/hugepages-1G/device_<N>_*tenstorrent` (and the bare `tenstorrent` file for
+board 0) for each allocated `N`. This is required now that multiple Pods can run
+on one Node — a global `rm` would delete a co-located running Pod's hugepage
+files. Without the cleanup, a replacement Pod reusing the same board may fail to
+acquire hugepages if a previous Pod exited uncleanly.
 
 ---
 
@@ -223,283 +285,94 @@ All fields under `defaults` apply to every model/engine/device/impl unless overr
 
 ### vLLM
 
-| Model | Device |
+| Model | Devices |
 |---|---|
-| `AFM-4.5B` | n300 |
-| `AFM-4.5B` | t3k |
+| `AFM-4.5B` | n300, t3k |
 | `DeepSeek-R1-0528` | galaxy |
-| `DeepSeek-R1-Distill-Llama-70B` | galaxy |
-| `DeepSeek-R1-Distill-Llama-70B` | galaxy_t3k |
-| `DeepSeek-R1-Distill-Llama-70B` | p150x4 |
-| `DeepSeek-R1-Distill-Llama-70B` | p150x8 |
-| `DeepSeek-R1-Distill-Llama-70B` | p300x2 |
-| `DeepSeek-R1-Distill-Llama-70B` | t3k |
-| `Llama-3.1-70B` | galaxy |
-| `Llama-3.1-70B` | galaxy_t3k |
-| `Llama-3.1-70B` | p150x4 |
-| `Llama-3.1-70B` | p150x8 |
-| `Llama-3.1-70B` | p300x2 |
-| `Llama-3.1-70B` | t3k |
-| `Llama-3.1-70B-Instruct` | galaxy |
-| `Llama-3.1-70B-Instruct` | galaxy_t3k |
-| `Llama-3.1-70B-Instruct` | p150x4 |
-| `Llama-3.1-70B-Instruct` | p150x8 |
-| `Llama-3.1-70B-Instruct` | p300x2 |
-| `Llama-3.1-70B-Instruct` | t3k |
-| `Llama-3.1-8B` | galaxy |
-| `Llama-3.1-8B` | galaxy_t3k |
-| `Llama-3.1-8B` | gpu |
-| `Llama-3.1-8B` | n150 |
-| `Llama-3.1-8B` | n300 |
-| `Llama-3.1-8B` | p100 |
-| `Llama-3.1-8B` | p150 |
-| `Llama-3.1-8B` | p150x4 |
-| `Llama-3.1-8B` | p150x8 |
-| `Llama-3.1-8B` | p300 |
-| `Llama-3.1-8B` | p300x2 |
-| `Llama-3.1-8B` | t3k |
-| `Llama-3.1-8B-Instruct` | galaxy |
-| `Llama-3.1-8B-Instruct` | galaxy_t3k |
-| `Llama-3.1-8B-Instruct` | gpu |
-| `Llama-3.1-8B-Instruct` | n150 |
-| `Llama-3.1-8B-Instruct` | n300 |
-| `Llama-3.1-8B-Instruct` | p100 |
-| `Llama-3.1-8B-Instruct` | p150 |
-| `Llama-3.1-8B-Instruct` | p150x4 |
-| `Llama-3.1-8B-Instruct` | p150x8 |
-| `Llama-3.1-8B-Instruct` | p300 |
-| `Llama-3.1-8B-Instruct` | p300x2 |
-| `Llama-3.1-8B-Instruct` | t3k |
-| `Llama-3.2-11B-Vision` | n300 |
-| `Llama-3.2-11B-Vision` | t3k |
-| `Llama-3.2-11B-Vision-Instruct` | n300 |
-| `Llama-3.2-11B-Vision-Instruct` | t3k |
-| `Llama-3.2-1B` | n150 |
-| `Llama-3.2-1B` | n300 |
-| `Llama-3.2-1B` | t3k |
-| `Llama-3.2-1B-Instruct` | n150 |
-| `Llama-3.2-1B-Instruct` | n300 |
-| `Llama-3.2-1B-Instruct` | t3k |
-| `Llama-3.2-3B` | n150 |
-| `Llama-3.2-3B` | n300 |
-| `Llama-3.2-3B` | t3k |
-| `Llama-3.2-3B-Instruct` | n150 |
-| `Llama-3.2-3B-Instruct` | n300 |
-| `Llama-3.2-3B-Instruct` | t3k |
+| `DeepSeek-R1-Distill-Llama-70B` | galaxy, p150x4, p150x8, p300x2, t3k |
+| `Llama-3.1-70B` | galaxy, p150x4, p150x8, p300x2, t3k |
+| `Llama-3.1-70B-Instruct` | galaxy, p150x4, p150x8, p300x2, t3k |
+| `Llama-3.1-8B` | galaxy, gpu, n150, n300, p100, p150, p150x4, p150x8, p300, p300x2, t3k |
+| `Llama-3.1-8B-Instruct` | galaxy, gpu, n150, n300, p100, p150, p150x4, p150x8, p300, p300x2, t3k |
+| `Llama-3.2-11B-Vision` | n300, t3k |
+| `Llama-3.2-11B-Vision-Instruct` | n300, t3k |
+| `Llama-3.2-1B` | n150, n300, t3k |
+| `Llama-3.2-1B-Instruct` | n150, n300, t3k |
+| `Llama-3.2-3B` | n150, n300, t3k |
+| `Llama-3.2-3B-Instruct` | n150, n300, t3k |
 | `Llama-3.2-90B-Vision` | t3k |
 | `Llama-3.2-90B-Vision-Instruct` | t3k |
-| `Llama-3.3-70B-Instruct` | galaxy |
-| `Llama-3.3-70B-Instruct` | galaxy_t3k |
-| `Llama-3.3-70B-Instruct` | p150x4 |
-| `Llama-3.3-70B-Instruct` | p150x8 |
-| `Llama-3.3-70B-Instruct` | p300x2 |
-| `Llama-3.3-70B-Instruct` | t3k |
-| `Mistral-7B-Instruct-v0.3` | n150 |
-| `Mistral-7B-Instruct-v0.3` | n300 |
-| `Mistral-7B-Instruct-v0.3` | t3k |
-| `QwQ-32B` | galaxy |
-| `QwQ-32B` | galaxy_t3k |
-| `QwQ-32B` | t3k |
-| `Qwen2.5-72B` | galaxy |
-| `Qwen2.5-72B` | galaxy_t3k |
-| `Qwen2.5-72B` | t3k |
-| `Qwen2.5-72B-Instruct` | galaxy |
-| `Qwen2.5-72B-Instruct` | galaxy_t3k |
-| `Qwen2.5-72B-Instruct` | t3k |
-| `Qwen2.5-7B` | n150x4 |
-| `Qwen2.5-7B` | n300 |
-| `Qwen2.5-7B-Instruct` | n150x4 |
-| `Qwen2.5-7B-Instruct` | n300 |
-| `Qwen2.5-Coder-32B-Instruct` | galaxy_t3k |
+| `Llama-3.3-70B-Instruct` | galaxy, p150x4, p150x8, p300x2, t3k |
+| `Mistral-7B-Instruct-v0.3` | n150, n300, t3k |
+| `QwQ-32B` | galaxy, t3k |
+| `Qwen2.5-72B` | galaxy, t3k |
+| `Qwen2.5-72B-Instruct` | galaxy, t3k |
+| `Qwen2.5-7B` | n150x4, n300 |
+| `Qwen2.5-7B-Instruct` | n150x4, n300 |
 | `Qwen2.5-Coder-32B-Instruct` | t3k |
 | `Qwen2.5-VL-32B-Instruct` | t3k |
-| `Qwen2.5-VL-3B-Instruct` | n150 |
-| `Qwen2.5-VL-3B-Instruct` | n300 |
-| `Qwen2.5-VL-72B-Instruct` | gpu |
-| `Qwen2.5-VL-72B-Instruct` | t3k |
-| `Qwen2.5-VL-7B-Instruct` | n150 |
-| `Qwen2.5-VL-7B-Instruct` | n300 |
-| `Qwen3-32B` | galaxy |
-| `Qwen3-32B` | galaxy_t3k |
-| `Qwen3-32B` | p150x8 |
-| `Qwen3-32B` | p300x2 |
-| `Qwen3-32B` | t3k |
-| `Qwen3-8B` | galaxy |
-| `Qwen3-8B` | galaxy_t3k |
-| `Qwen3-8B` | n150 |
-| `Qwen3-8B` | n300 |
-| `Qwen3-8B` | p300 |
-| `Qwen3-8B` | t3k |
+| `Qwen2.5-VL-3B-Instruct` | n150, n300 |
+| `Qwen2.5-VL-72B-Instruct` | gpu, t3k |
+| `Qwen2.5-VL-7B-Instruct` | n150, n300 |
+| `Qwen3-32B` | galaxy, p150x8, p300x2, t3k |
+| `Qwen3-8B` | galaxy, n150, n300, p300, t3k |
 | `Qwen3-VL-32B-Instruct` | t3k |
-| `Qwen3.6-27B` | p150x8 |
-| `Qwen3.6-27B` | p300x2 |
+| `Qwen3.6-27B` | p150x8, p300x2 |
 | `gemma-3-1b-it` | n150 |
-| `gemma-3-27b-it` | galaxy |
-| `gemma-3-27b-it` | galaxy_t3k |
-| `gemma-3-27b-it` | p300x2 |
-| `gemma-3-27b-it` | t3k |
-| `gemma-3-4b-it` | n150 |
-| `gemma-3-4b-it` | n300 |
-| `gemma-3-4b-it` | p150 |
-| `gemma-3-4b-it` | t3k |
+| `gemma-3-27b-it` | galaxy, p300x2, t3k |
+| `gemma-3-4b-it` | n150, n300, p150, t3k |
 | `gemma-4-31B-it` | p300x2 |
-| `gpt-oss-120b` | galaxy |
-| `gpt-oss-120b` | p300x2 |
-| `gpt-oss-120b` | t3k |
-| `gpt-oss-20b` | galaxy |
-| `gpt-oss-20b` | galaxy_t3k |
-| `gpt-oss-20b` | t3k |
-| `medgemma-27b-it` | galaxy |
-| `medgemma-27b-it` | galaxy_t3k |
-| `medgemma-27b-it` | p300x2 |
-| `medgemma-27b-it` | t3k |
-| `medgemma-4b-it` | n150 |
-| `medgemma-4b-it` | n300 |
-| `medgemma-4b-it` | p150 |
-| `medgemma-4b-it` | t3k |
+| `gpt-oss-120b` | galaxy, p300x2, t3k |
+| `gpt-oss-20b` | galaxy, t3k |
+| `medgemma-27b-it` | galaxy, p300x2, t3k |
+| `medgemma-4b-it` | n150, n300, p150, t3k |
 
 ### Media
 
-| Model | Device |
+| Model | Devices |
 |---|---|
-| `FLUX.1-dev` | galaxy |
-| `FLUX.1-dev` | p150x4 |
-| `FLUX.1-dev` | p150x8 |
-| `FLUX.1-dev` | p300 |
-| `FLUX.1-dev` | p300x2 |
-| `FLUX.1-dev` | t3k |
-| `FLUX.1-schnell` | galaxy |
-| `FLUX.1-schnell` | p150x4 |
-| `FLUX.1-schnell` | p150x8 |
-| `FLUX.1-schnell` | p300 |
-| `FLUX.1-schnell` | p300x2 |
-| `FLUX.1-schnell` | t3k |
+| `FLUX.1-dev` | galaxy, p150x4, p150x8, p300, p300x2, t3k |
+| `FLUX.1-schnell` | galaxy, p150x4, p150x8, p300, p300x2, t3k |
 | `Llama-3.1-70B` | t3k |
-| `Motif-Image-6B-Preview` | galaxy |
-| `Motif-Image-6B-Preview` | p150x8 |
-| `Motif-Image-6B-Preview` | p300x2 |
-| `Motif-Image-6B-Preview` | t3k |
-| `Qwen-Image` | galaxy |
-| `Qwen-Image` | t3k |
-| `Qwen-Image-2512` | galaxy |
-| `Qwen-Image-2512` | t3k |
-| `Qwen3-Embedding-8B` | galaxy |
-| `Qwen3-Embedding-8B` | n150 |
-| `Qwen3-Embedding-8B` | n300 |
-| `Qwen3-Embedding-8B` | t3k |
-| `Wan2.2-I2V-A14B-Diffusers` | galaxy |
-| `Wan2.2-I2V-A14B-Diffusers` | p150x4 |
-| `Wan2.2-I2V-A14B-Diffusers` | p150x8 |
-| `Wan2.2-I2V-A14B-Diffusers` | p300x2 |
-| `Wan2.2-I2V-A14B-Diffusers` | t3k |
-| `Wan2.2-T2V-A14B-Diffusers` | galaxy |
-| `Wan2.2-T2V-A14B-Diffusers` | p150x4 |
-| `Wan2.2-T2V-A14B-Diffusers` | p150x8 |
-| `Wan2.2-T2V-A14B-Diffusers` | p300x2 |
-| `Wan2.2-T2V-A14B-Diffusers` | t3k |
+| `Motif-Image-6B-Preview` | galaxy, p150x8, p300x2, t3k |
+| `Qwen-Image` | galaxy, t3k |
+| `Qwen-Image-2512` | galaxy, t3k |
+| `Qwen3-Embedding-8B` | galaxy, n150, n300, t3k |
+| `Wan2.2-I2V-A14B-Diffusers` | galaxy, p150x4, p150x8, p300x2, t3k |
+| `Wan2.2-T2V-A14B-Diffusers` | galaxy, p150x4, p150x8, p300x2, t3k |
 | `Z-Image-Turbo` | p300x2 |
-| `bge-large-en-v1.5` | galaxy |
-| `bge-large-en-v1.5` | n150 |
-| `bge-large-en-v1.5` | n300 |
-| `bge-large-en-v1.5` | t3k |
-| `distil-large-v3` | galaxy |
-| `distil-large-v3` | n150 |
-| `distil-large-v3` | n300 |
-| `distil-large-v3` | p150 |
-| `distil-large-v3` | p300 |
-| `distil-large-v3` | p300x2 |
-| `distil-large-v3` | t3k |
-| `mochi-1-preview` | galaxy |
-| `mochi-1-preview` | p150x4 |
-| `mochi-1-preview` | p150x8 |
-| `mochi-1-preview` | p300x2 |
-| `mochi-1-preview` | t3k |
-| `speecht5_tts` | n150 |
-| `speecht5_tts` | n300 |
-| `speecht5_tts` | p150 |
-| `speecht5_tts` | p300 |
-| `speecht5_tts` | p300x2 |
-| `stable-diffusion-3.5-large` | galaxy |
-| `stable-diffusion-3.5-large` | t3k |
-| `stable-diffusion-xl-1.0-inpainting-0.1` | galaxy |
-| `stable-diffusion-xl-1.0-inpainting-0.1` | n150 |
-| `stable-diffusion-xl-1.0-inpainting-0.1` | n300 |
-| `stable-diffusion-xl-1.0-inpainting-0.1` | p150 |
-| `stable-diffusion-xl-1.0-inpainting-0.1` | p150x4 |
-| `stable-diffusion-xl-1.0-inpainting-0.1` | p150x8 |
-| `stable-diffusion-xl-1.0-inpainting-0.1` | p300x2 |
-| `stable-diffusion-xl-1.0-inpainting-0.1` | t3k |
-| `stable-diffusion-xl-base-1.0` | galaxy |
-| `stable-diffusion-xl-base-1.0` | n150 |
-| `stable-diffusion-xl-base-1.0` | n300 |
-| `stable-diffusion-xl-base-1.0` | p150 |
-| `stable-diffusion-xl-base-1.0` | p150x4 |
-| `stable-diffusion-xl-base-1.0` | p150x8 |
-| `stable-diffusion-xl-base-1.0` | p300x2 |
-| `stable-diffusion-xl-base-1.0` | t3k |
-| `stable-diffusion-xl-base-1.0-img-2-img` | galaxy |
-| `stable-diffusion-xl-base-1.0-img-2-img` | n150 |
-| `stable-diffusion-xl-base-1.0-img-2-img` | n300 |
-| `stable-diffusion-xl-base-1.0-img-2-img` | p150 |
-| `stable-diffusion-xl-base-1.0-img-2-img` | p150x4 |
-| `stable-diffusion-xl-base-1.0-img-2-img` | p150x8 |
-| `stable-diffusion-xl-base-1.0-img-2-img` | p300x2 |
-| `stable-diffusion-xl-base-1.0-img-2-img` | t3k |
-| `whisper-large-v3` | galaxy |
-| `whisper-large-v3` | n150 |
-| `whisper-large-v3` | n300 |
-| `whisper-large-v3` | p150 |
-| `whisper-large-v3` | p300 |
-| `whisper-large-v3` | p300x2 |
-| `whisper-large-v3` | t3k |
+| `bge-large-en-v1.5` | galaxy, n150, n300, t3k |
+| `distil-large-v3` | galaxy, n150, n300, p150, p300, p300x2, t3k |
+| `mochi-1-preview` | galaxy, p150x4, p150x8, p300x2, t3k |
+| `speecht5_tts` | n150, n300, p150, p300, p300x2 |
+| `stable-diffusion-3.5-large` | galaxy, t3k |
+| `stable-diffusion-xl-1.0-inpainting-0.1` | galaxy, n150, n300, p150, p150x4, p150x8, p300x2, t3k |
+| `stable-diffusion-xl-base-1.0` | galaxy, n150, n300, p150, p150x4, p150x8, p300x2, t3k |
+| `stable-diffusion-xl-base-1.0-img-2-img` | galaxy, n150, n300, p150, p150x4, p150x8, p300x2, t3k |
+| `whisper-large-v3` | galaxy, n150, n300, p150, p300, p300x2, t3k |
 
 ### Forge
 
-| Model | Device |
+| Model | Devices |
 |---|---|
-| `Falcon3-7B-Instruct` | n150 |
-| `Falcon3-7B-Instruct` | n300 |
-| `Falcon3-7B-Instruct` | p150 |
-| `Llama-3.1-8B-Instruct` | n150 |
-| `Llama-3.1-8B-Instruct` | n300 |
-| `Llama-3.1-8B-Instruct` | p150 |
-| `Llama-3.2-3B` | n150 |
-| `Llama-3.2-3B` | n300 |
-| `Llama-3.2-3B` | p150 |
-| `Llama-3.2-3B-Instruct` | n150 |
-| `Llama-3.2-3B-Instruct` | n300 |
-| `Llama-3.2-3B-Instruct` | p150 |
-| `Qwen3-4B` | n150 |
-| `Qwen3-4B` | n300 |
-| `Qwen3-4B` | p150 |
-| `Qwen3-8B` | n150 |
-| `Qwen3-8B` | n300 |
-| `Qwen3-8B` | p150 |
+| `Falcon3-7B-Instruct` | n150, n300, p150 |
+| `Llama-3.1-8B-Instruct` | n150, n300, p150 |
+| `Llama-3.2-3B` | n150, n300, p150 |
+| `Llama-3.2-3B-Instruct` | n150, n300, p150 |
+| `Qwen3-4B` | n150, n300, p150 |
+| `Qwen3-8B` | n150, n300, p150 |
 | `Qwen3-Embedding-0.6B` | p300x2 |
-| `Qwen3-Embedding-4B` | galaxy |
-| `Qwen3-Embedding-4B` | n150 |
-| `Qwen3-Embedding-4B` | n300 |
-| `Qwen3-Embedding-4B` | p300x2 |
-| `Qwen3-Embedding-4B` | t3k |
+| `Qwen3-Embedding-4B` | galaxy, n150, n300, p300x2, t3k |
 | `bge-m3` | p300x2 |
-| `efficientnet` | n150 |
-| `efficientnet` | n300 |
-| `mobilenetv2` | n150 |
-| `mobilenetv2` | n300 |
-| `resnet-50` | n150 |
-| `resnet-50` | n300 |
-| `segformer` | n150 |
-| `segformer` | n300 |
-| `stable-diffusion-xl-base-1.0` | p150x8 |
-| `stable-diffusion-xl-base-1.0` | p300x2 |
-| `unet` | n150 |
-| `unet` | n300 |
-| `vit` | n150 |
-| `vit` | n300 |
-| `vovnet` | n150 |
-| `vovnet` | n300 |
-| `yolox_nano` | n150 |
-| `yolox_nano` | p150 |
+| `efficientnet` | n150, n300 |
+| `mobilenetv2` | n150, n300 |
+| `resnet-50` | n150, n300 |
+| `segformer` | n150, n300 |
+| `stable-diffusion-xl-base-1.0` | p150x8, p300x2 |
+| `unet` | n150, n300 |
+| `vit` | n150, n300 |
+| `vovnet` | n150, n300 |
+| `yolox_nano` | n150, p150 |
 
 To add a new model, add an entry under `models.<name>.<engine>.<device>` in `values.yaml`, where `<engine>` is one of `vllm`, `media`, or `forge`, and the device block contains an `impls.<impl-id>` entry with `image.repository` and `image.tag`.
 
@@ -588,27 +461,6 @@ helm install my-model ./charts/tt-inference-server \
 
 The chart ships no Grafana dashboard (metrics differ per engine). For vLLM, import the [official vLLM dashboard](https://docs.vllm.ai/en/stable/examples/online_serving/prometheus_grafana/) ([JSON](https://github.com/vllm-project/vllm/tree/main/examples/observability/prometheus_grafana)) via Grafana → Import, pointed at your Prometheus. For media-server / forge, build panels in Grafana Explore from the scraped metrics.
 
-**Device telemetry** is not part of this chart. It is a tt-operator component (`tt-telemetry`) — a cluster-wide singleton with a separate lifecycle. The cluster admin enables it by setting the `tt-telemetry.enabled=true` subchart value when installing the tt-operator umbrella chart (`oci://ghcr.io/tenstorrent/helm/tt-operator`); see the [tt-operator documentation](https://docs.tenstorrent.com/cloud-native-support/) for the full install procedure.
+**Device telemetry** is not part of this chart. It is a tt-operator component (`tt-telemetry`) — a cluster-wide singleton with a separate lifecycle. The cluster admin enables it by setting the `tt-telemetry.enabled=true` subchart value when installing the tt-operator umbrella chart (`oci://ghcr.io/tenstorrent/helm/tt-operator`); see the [tt-telemetry documentation](https://docs.tenstorrent.com/tt-telemetry/latest/) for details.
 
 Correlating the two (device × app) is future work — it needs a supply-side bridge exporter that maps devices to pods.
-
----
-
-## Init Containers
-
-`fix-cache-permissions` always runs before the inference server starts;
-`cleanup-hugepages` runs only when `hugepages.enabled` (the default).
-
-**`fix-cache-permissions`**
-Runs `chown -R 1000:1000 /cache` on the cache host path volume. The inference server runs as UID 1000 and requires write access to the cache directory, which may be created by root on the host.
-
-**`cleanup-hugepages`** (only when `hugepages.enabled`)
-Removes stale hugepage files left by previous runs, **scoped to this Pod's
-DRA-allocated board(s)** only. The init container requests the same
-`ResourceClaim` as the main container, so the DRA driver injects its
-`/dev/tenstorrent/<N>` node(s); the container then deletes only
-`/dev/hugepages-1G/device_<N>_*tenstorrent` (and the bare `tenstorrent` file for
-board 0) for each allocated `N`. This is required now that multiple Pods can run
-on one Node — a global `rm` would delete a co-located running Pod's hugepage
-files. Without the cleanup, a replacement Pod reusing the same board may fail to
-acquire hugepages if a previous Pod exited uncleanly.

--- a/charts/tt-inference-server/README.md.gotmpl
+++ b/charts/tt-inference-server/README.md.gotmpl
@@ -1,8 +1,22 @@
 # tt-inference-server Helm Chart
 
-Deploys vLLM and media inference backends on Tenstorrent Galaxy hardware.
+Deploys vLLM, media, and forge inference backends on Tenstorrent hardware.
 
 **Chart version:** {{ .Version }} | **App version:** {{ .AppVersion }}
+
+## Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Requirements](#requirements)
+- [Device Acquisition (DRA)](#device-acquisition-dra)
+- [Quick Start](#quick-start)
+- [Chart Structure](#chart-structure)
+- [Configuration System](#configuration-system)
+- [Values Reference](#values-reference)
+- [Defaults Reference](#defaults-reference)
+- [Supported Models](#supported-models)
+- [Advanced Usage](#advanced-usage)
 
 ---
 
@@ -17,10 +31,26 @@ Three engines are supported:
 - **forge** — models served via the tt-forge backend
 
 Devices are acquired through **Dynamic Resource Allocation (DRA)**: each Pod
-declares a `ResourceClaim` that the [tt-operator](https://github.com/tenstorrent/tt-operator)
+declares a `ResourceClaim` that the [tt-operator](https://docs.tenstorrent.com/tt-operator/latest/)
 DRA driver satisfies by allocating Tenstorrent boards and injecting the matching
 `/dev/tenstorrent/<N>` node(s). The container runs **unprivileged**, with **no
 `hostPath` on `/dev/tenstorrent`**, and multiple Pods can share one Node.
+
+---
+
+## Architecture
+
+tt-operator (the **supply side**) and this chart (the **consumer**) have
+separate lifecycles, connected only through DRA:
+
+- **tt-operator** is an umbrella chart of cluster-singleton components (the DRA
+  driver, fabric manager, node-feature-discovery, ...). There is no standalone
+  `tt-operator` image. A cluster administrator installs it **once per cluster**.
+- **This chart** (the consumer) requests devices through a `ResourceClaim` and
+  never installs, bundles, or depends on tt-operator as a sub-chart — cluster
+  singletons and per-model workloads have different lifecycle granularity, and
+  bundling would make each model release co-own the cluster-wide device
+  foundation (a `helm uninstall` of one model would tear it down for the others).
 
 ---
 
@@ -30,24 +60,21 @@ DRA driver satisfies by allocating Tenstorrent boards and injecting the matching
   from 1.34 (DRA GA). Verify the API is present:
   `kubectl api-resources --api-group=resource.k8s.io`.
 - **tt-operator installed on the cluster**, providing at least the DRA driver
-  (`tt-dra-driver`), the fabric manager (`tt-fabric-manager`, which the DRA
-  driver queries to enumerate devices), and node-feature-discovery. tt-operator
-  is a cluster-level prerequisite installed **once by an administrator**, on a
-  lifecycle separate from this chart — this chart never installs or manages it,
-  it only emits a `ResourceClaim` that the driver fulfils.
+  ([`tt-dra-driver`](https://docs.tenstorrent.com/tt-dra-driver/latest/)), the
+  fabric manager ([`tt-fabric-manager`](https://docs.tenstorrent.com/tt-fabric-manager/latest/),
+  which the DRA driver queries to enumerate devices), and
+  [node-feature-discovery](https://docs.tenstorrent.com/tt-operator/latest/components/node-feature-discovery.html). See
+  [Architecture](#architecture) for how its lifecycle relates to this chart.
 
-Minimal tt-operator install (device acquisition only):
+The tt-operator chart and its component images are **public on GHCR** — the
+`helm install` below needs no authentication on a standard cluster.
+
+Install tt-operator (v0.2 doesn't use its multi-node scheduling, so `jobset` and
+`kubepmix` are turned off):
 
 ```bash
-kubectl create namespace tt-operator-system
-# GHCR pull secret (k3s/containerd cannot pull the component images anonymously)
-kubectl create secret generic ghcr \
-  --from-file=.dockerconfigjson=$HOME/.docker/config.json \
-  --type=kubernetes.io/dockerconfigjson -n tt-operator-system
 helm install tt-operator oci://ghcr.io/tenstorrent/helm/tt-operator \
-  --version 0.2.0 -n tt-operator-system \
-  --set tt-k8s-driver-manager.enabled=false \
-  --set tt-telemetry.enabled=false \
+  --version 0.2.0 -n tt-operator-system --create-namespace \
   --set jobset.enabled=false \
   --set kubepmix.enabled=false
 # Verify: a DeviceClass and a per-node ResourceSlice appear
@@ -55,8 +82,10 @@ kubectl get deviceclass          # tenstorrent.com
 kubectl get resourceslices       # <node> / tenstorrent.com, one device per board
 ```
 
-> The other tt-operator sub-charts (driver-manager, telemetry, jobset, kubepmix)
-> are optional and documented separately.
+> The remaining sub-charts — `node-feature-discovery`, `tt-k8s-driver-manager`,
+> `tt-fabric-manager`, `tt-dra-driver`, `tt-telemetry` — stay at their defaults.
+> See the [tt-operator docs](https://docs.tenstorrent.com/tt-operator/latest/) for
+> what each sub-chart does and how to configure it.
 
 ---
 
@@ -96,6 +125,8 @@ claims and stuck `Terminating`.
 
 ## Quick Start
 
+> **Prerequisite:** tt-operator must already be installed on the cluster (see [Requirements](#requirements)). Without its DRA driver the Pod can't acquire a device and stays `Pending`.
+
 Three values are required at install time:
 
 ```bash
@@ -125,15 +156,46 @@ charts/tt-inference-server/
 
 ### templates/_helpers.tpl
 
-Contains the core logic for this chart:
+The chart's named templates (all prefixed `tt-inference-server.`), grouped by role:
 
-- **`tt-inference-server.validateValues`** — fails the render if `model` or `device` is missing, or if the resolved `model`/`engine`/`device`/`impl` has no entry in the `models` map.
-- **`tt-inference-server.resolvedEngine`** — picks the engine: `.Values.engine` if set, the sole engine offering the device, otherwise `models.<model>.defaultEngine` when more than one engine offers it.
-- **`tt-inference-server.resolvedImpl`** — picks the implementation: `.Values.impl` if set, otherwise `models.<model>.<engine>.<device>.defaultImpl`.
-- **`tt-inference-server.resolvedConfig`** — deep-merges `defaults` with the resolved impl block (`models.<model>.<engine>.<device>.impls.<impl>`) and returns the effective config as YAML (see [Configuration System](#configuration-system)).
-- **`tt-inference-server.image`** — assembles the container image string (`repository:tag`) from the resolved config.
-- **`tt-inference-server.cacheHostPath`** — returns `cache.hostPath` if set, otherwise generates `/opt/cache/<model>-<device>-<impl>`.
-- Standard Helm name helpers: `tt-inference-server.name`, `tt-inference-server.fullname`, `tt-inference-server.labels`, `tt-inference-server.selectorLabels`.
+**Config resolution** — resolve `model` + `device` into an effective config:
+
+| Helper | Purpose |
+|---|---|
+| `validateValues` | Fails the render if `model`/`device` is missing, or the resolved combination has no entry in `models`. |
+| `resolvedEngine` | Picks the engine: `.Values.engine`, else the sole engine offering the device, else `models.<model>.defaultEngine`. |
+| `resolvedImpl` | Picks the impl: `.Values.impl`, else `models.<model>.<engine>.<device>.defaultImpl`. |
+| `resolvedConfig` | Deep-merges `defaults` with the resolved impl block into the effective config (see [Configuration System](#configuration-system)). |
+
+**Derived values** — build fields from the resolved config:
+
+| Helper | Purpose |
+|---|---|
+| `image` | Container image string `repository:tag`. |
+| `containerEnv` | Container env, merged from spec env, hf-cache env, and `extraEnv` `valueFrom` entries. |
+| `cacheHostPath` | `cache.hostPath` if set, else `/opt/cache/<model>-<device>-<impl>`. |
+| `draDeviceCount` | DRA board count for `device` from `deviceBoardCounts` (fails for unsupported shapes). |
+| `draBoardName` | DRA `boardName` the `ResourceClaim` selects, from `deviceBoardNames`. |
+
+**Naming** — `name`, `fullname`, `chart`, `labels`, `selectorLabels`, `configmapName`, `secretName`: standard Helm name/label helpers.
+
+### Init Containers
+
+Run before the inference server starts:
+
+**`fix-cache-permissions`** (always)
+Runs `chown -R 1000:1000 /cache` on the cache host path volume. The inference server runs as UID 1000 and requires write access to the cache directory, which may be created by root on the host.
+
+**`cleanup-hugepages`** (only when `hugepages.enabled`)
+Removes stale hugepage files left by previous runs, **scoped to this Pod's
+DRA-allocated board(s)** only. The init container requests the same
+`ResourceClaim` as the main container, so the DRA driver injects its
+`/dev/tenstorrent/<N>` node(s); the container then deletes only
+`/dev/hugepages-1G/device_<N>_*tenstorrent` (and the bare `tenstorrent` file for
+board 0) for each allocated `N`. This is required now that multiple Pods can run
+on one Node — a global `rm` would delete a co-located running Pod's hugepage
+files. Without the cleanup, a replacement Pod reusing the same board may fail to
+acquire hugepages if a previous Pod exited uncleanly.
 
 ---
 
@@ -306,27 +368,6 @@ helm install my-model ./charts/tt-inference-server \
 
 The chart ships no Grafana dashboard (metrics differ per engine). For vLLM, import the [official vLLM dashboard](https://docs.vllm.ai/en/stable/examples/online_serving/prometheus_grafana/) ([JSON](https://github.com/vllm-project/vllm/tree/main/examples/observability/prometheus_grafana)) via Grafana → Import, pointed at your Prometheus. For media-server / forge, build panels in Grafana Explore from the scraped metrics.
 
-**Device telemetry** is not part of this chart. It is a tt-operator component (`tt-telemetry`) — a cluster-wide singleton with a separate lifecycle. The cluster admin enables it by setting the `tt-telemetry.enabled=true` subchart value when installing the tt-operator umbrella chart (`oci://ghcr.io/tenstorrent/helm/tt-operator`); see the [tt-operator documentation](https://docs.tenstorrent.com/cloud-native-support/) for the full install procedure.
+**Device telemetry** is not part of this chart. It is a tt-operator component (`tt-telemetry`) — a cluster-wide singleton with a separate lifecycle. The cluster admin enables it by setting the `tt-telemetry.enabled=true` subchart value when installing the tt-operator umbrella chart (`oci://ghcr.io/tenstorrent/helm/tt-operator`); see the [tt-telemetry documentation](https://docs.tenstorrent.com/tt-telemetry/latest/) for details.
 
 Correlating the two (device × app) is future work — it needs a supply-side bridge exporter that maps devices to pods.
-
----
-
-## Init Containers
-
-`fix-cache-permissions` always runs before the inference server starts;
-`cleanup-hugepages` runs only when `hugepages.enabled` (the default).
-
-**`fix-cache-permissions`**
-Runs `chown -R 1000:1000 /cache` on the cache host path volume. The inference server runs as UID 1000 and requires write access to the cache directory, which may be created by root on the host.
-
-**`cleanup-hugepages`** (only when `hugepages.enabled`)
-Removes stale hugepage files left by previous runs, **scoped to this Pod's
-DRA-allocated board(s)** only. The init container requests the same
-`ResourceClaim` as the main container, so the DRA driver injects its
-`/dev/tenstorrent/<N>` node(s); the container then deletes only
-`/dev/hugepages-1G/device_<N>_*tenstorrent` (and the bare `tenstorrent` file for
-board 0) for each allocated `N`. This is required now that multiple Pods can run
-on one Node — a global `rm` would delete a co-located running Pod's hugepage
-files. Without the cleanup, a replacement Pod reusing the same board may fail to
-acquire hugepages if a previous Pod exited uncleanly.

--- a/charts/tt-inference-server/README.md.gotmpl
+++ b/charts/tt-inference-server/README.md.gotmpl
@@ -174,6 +174,10 @@ Set per release, typically via `--set`.
 | `hfToken` | yes* | `""` | HuggingFace token. Injected as `HF_TOKEN`. Required unless weights are pre-downloaded via `hfCacheDir`. |
 | `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
 | `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
+| `podMonitor.enabled` | no | `false` | Emit a `PodMonitor` scraping the server's `/metrics`. Requires the Prometheus Operator CRDs (`monitoring.coreos.com`); leave `false` on clusters without them. |
+| `podMonitor.labels` | no | `{}` | Extra labels on the `PodMonitor`. Set the label your Prometheus's `podMonitorSelector` matches (e.g. `release: kube-prometheus-stack`). |
+| `podMonitor.interval` | no | `30s` | Scrape interval. |
+| `podMonitor.path` | no | `/metrics` | Metrics HTTP path (scraped on the `http` port). |
 | `cache.hostPath` | no | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>-<impl>`. |
 | `nameOverride` | no | `""` | Overrides the chart name component in resource names. |
 | `fullnameOverride` | no | `""` | Fully overrides the resource name prefix. |
@@ -278,6 +282,34 @@ helm install my-model ./charts/tt-inference-server \
   --set hfToken="hf_xxx" \
   --set cache.hostPath="/mnt/fast-nvme/cache"
 ```
+
+### Monitoring
+
+Metrics come from two independent sources, each enabled separately:
+
+| Source | Measures | Owned by | Enable with |
+|---|---|---|---|
+| App metrics | Inference server: request rate, latency, tokens/s, queue depth | this chart (consumer) | `podMonitor.enabled=true` |
+| Device telemetry | Tenstorrent boards: temperature, power, chip utilization | tt-operator (supply side) | `tt-telemetry.enabled=true` on tt-operator |
+
+**App metrics** — vLLM and media-server expose `/metrics`. Set `podMonitor.enabled=true` to emit a `PodMonitor` that Prometheus scrapes:
+
+```bash
+helm install my-model ./charts/tt-inference-server \
+  --set model="Llama-3.1-8B-Instruct" \
+  --set device=galaxy \
+  --set hfToken="hf_xxx" \
+  --set podMonitor.enabled=true \
+  --set podMonitor.labels.release=kube-prometheus-stack
+```
+
+The label must match your Prometheus's `podMonitorSelector` (e.g. `release: kube-prometheus-stack`) or it won't be scraped; see the [Values Reference](#values-reference) for the other `podMonitor.*` options and the Prometheus Operator CRD requirement.
+
+The chart ships no Grafana dashboard (metrics differ per engine). For vLLM, import the [official vLLM dashboard](https://docs.vllm.ai/en/stable/examples/online_serving/prometheus_grafana/) ([JSON](https://github.com/vllm-project/vllm/tree/main/examples/observability/prometheus_grafana)) via Grafana → Import, pointed at your Prometheus. For media-server / forge, build panels in Grafana Explore from the scraped metrics.
+
+**Device telemetry** is not part of this chart. It is a tt-operator component (`tt-telemetry`) — a cluster-wide singleton with a separate lifecycle. The cluster admin enables it by setting the `tt-telemetry.enabled=true` subchart value when installing the tt-operator umbrella chart (`oci://ghcr.io/tenstorrent/helm/tt-operator`); see the [tt-operator documentation](https://docs.tenstorrent.com/cloud-native-support/) for the full install procedure.
+
+Correlating the two (device × app) is future work — it needs a supply-side bridge exporter that maps devices to pods.
 
 ---
 

--- a/charts/tt-inference-server/README.md.gotmpl
+++ b/charts/tt-inference-server/README.md.gotmpl
@@ -175,7 +175,7 @@ Set per release, typically via `--set`.
 | `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
 | `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
 | `podMonitor.enabled` | no | `false` | Emit a `PodMonitor` scraping the server's `/metrics`. Requires the Prometheus Operator CRDs (`monitoring.coreos.com`); leave `false` on clusters without them. |
-| `podMonitor.labels` | no | `{}` | Extra labels on the `PodMonitor`. Set the label your Prometheus's `podMonitorSelector` matches (e.g. `release: kube-prometheus-stack`). |
+| `podMonitor.labels` | no | `{release: prometheus}` | Labels on the `PodMonitor`; must match your Prometheus's `podMonitorSelector` or it won't be scraped. The default matches tt-telemetry's chart and the kube-prometheus-stack convention (`podMonitorSelector` defaults to `release: <the stack's release name>`); override when yours is named differently. |
 | `podMonitor.interval` | no | `30s` | Scrape interval. |
 | `podMonitor.path` | no | `/metrics` | Metrics HTTP path (scraped on the `http` port). |
 | `cache.hostPath` | no | `""` | Override the host path used for the ttnn cache volume. Defaults to `/opt/cache/<model>-<device>-<impl>`. |
@@ -299,11 +299,10 @@ helm install my-model ./charts/tt-inference-server \
   --set model="Llama-3.1-8B-Instruct" \
   --set device=galaxy \
   --set hfToken="hf_xxx" \
-  --set podMonitor.enabled=true \
-  --set podMonitor.labels.release=kube-prometheus-stack
+  --set podMonitor.enabled=true
 ```
 
-The label must match your Prometheus's `podMonitorSelector` (e.g. `release: kube-prometheus-stack`) or it won't be scraped; see the [Values Reference](#values-reference) for the other `podMonitor.*` options and the Prometheus Operator CRD requirement.
+`podMonitor.labels` defaults to `release: prometheus`, matching tt-telemetry's chart and a kube-prometheus-stack installed under the release name `prometheus`. If your Prometheus release is named differently, override it (`--set podMonitor.labels.release=<release-name>`) or the `PodMonitor` won't be scraped; see the [Values Reference](#values-reference) for the other `podMonitor.*` options and the Prometheus Operator CRD requirement.
 
 The chart ships no Grafana dashboard (metrics differ per engine). For vLLM, import the [official vLLM dashboard](https://docs.vllm.ai/en/stable/examples/online_serving/prometheus_grafana/) ([JSON](https://github.com/vllm-project/vllm/tree/main/examples/observability/prometheus_grafana)) via Grafana → Import, pointed at your Prometheus. For media-server / forge, build panels in Grafana Explore from the scraped metrics.
 

--- a/charts/tt-inference-server/_supportedModels.gotmpl
+++ b/charts/tt-inference-server/_supportedModels.gotmpl
@@ -16,6 +16,10 @@ next helm-docs run — no manual edit to this file or README.md.gotmpl.
 {{- $values := .Files.Get "values.yaml" | fromYaml -}}
 {{- $labels := dict "vllm" "vLLM" "media" "Media" "forge" "Forge" -}}
 {{- $engineOrder := list "vllm" "media" "forge" -}}
+{{- /* Deployable device shapes: those with a DRA board count, plus the non-TT
+       passthrough devices. Others (e.g. galaxy_t3k) fail at render, so exclude
+       them from the catalogue. */ -}}
+{{- $supported := concat (keys (default (dict) $values.deviceBoardCounts)) (list "gpu" "cpu") -}}
 {{- $groups := dict -}}
 {{- range $name, $cfg := $values.models -}}
   {{- range $engine, $devices := $cfg -}}
@@ -32,12 +36,14 @@ next helm-docs run — no manual edit to this file or README.md.gotmpl.
 
 ### {{ index $labels $engine | default ($engine | title) }}
 
-| Model | Device |
+| Model | Devices |
 |---|---|
 {{- range (index $groups $engine) }}
 {{- $name := .name }}
-{{- range $device, $_ := .devices }}
-| `{{ $name }}` | {{ $device }} |
+{{- $devs := list }}
+{{- range $device, $_ := .devices }}{{- if has $device $supported }}{{- $devs = append $devs $device }}{{- end }}{{- end }}
+{{- if $devs }}
+| `{{ $name }}` | {{ $devs | sortAlpha | join ", " }} |
 {{- end }}
 {{- end }}
 {{- end }}
@@ -47,12 +53,14 @@ next helm-docs run — no manual edit to this file or README.md.gotmpl.
 
 ### {{ index $labels $engine | default ($engine | title) }}
 
-| Model | Device |
+| Model | Devices |
 |---|---|
 {{- range $entries }}
 {{- $name := .name }}
-{{- range $device, $_ := .devices }}
-| `{{ $name }}` | {{ $device }} |
+{{- $devs := list }}
+{{- range $device, $_ := .devices }}{{- if has $device $supported }}{{- $devs = append $devs $device }}{{- end }}{{- end }}
+{{- if $devs }}
+| `{{ $name }}` | {{ $devs | sortAlpha | join ", " }} |
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/tt-inference-server/templates/podmonitor.yaml
+++ b/charts/tt-inference-server/templates/podmonitor.yaml
@@ -1,0 +1,25 @@
+{{- $podMonitor := .Values.podMonitor | default dict }}
+{{- if dig "enabled" false $podMonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "tt-inference-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- /* merge so user labels add to, but never duplicate, the standard label keys. */ -}}
+    {{- $labels := merge (include "tt-inference-server.labels" . | fromYaml) ($podMonitor.labels | default dict) }}
+    {{- toYaml $labels | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tt-inference-server.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    # /metrics is served on the API port, not a separate one.
+    - port: http
+      {{- with $podMonitor.path }}
+      path: {{ . }}
+      {{- end }}
+      {{- with $podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+{{- end }}

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -41,9 +41,13 @@ hugepages:
 # CRDs (monitoring.coreos.com), and rendering one without them fails at install.
 podMonitor:
   enabled: false
-  # Set the label your Prometheus's podMonitorSelector matches (e.g.
-  # release: kube-prometheus-stack), or the PodMonitor won't be scraped.
-  labels: {}
+  # Labels added to the PodMonitor so your Prometheus's podMonitorSelector
+  # matches it, or it won't be scraped. The default matches tt-telemetry's chart
+  # and the kube-prometheus-stack convention (its podMonitorSelector defaults to
+  # release: <the stack's own release name>). Override when your Prometheus was
+  # installed under a different release name.
+  labels:
+    release: prometheus
   interval: 30s
   path: /metrics
 

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -36,6 +36,17 @@ hfCacheDir: ""
 hugepages:
   enabled: true
 
+# PodMonitor scraping the inference server's own /metrics (vLLM and media-server
+# expose it). Disabled by default: a PodMonitor needs the Prometheus Operator
+# CRDs (monitoring.coreos.com), and rendering one without them fails at install.
+podMonitor:
+  enabled: false
+  # Set the label your Prometheus's podMonitorSelector matches (e.g.
+  # release: kube-prometheus-stack), or the PodMonitor won't be scraped.
+  labels: {}
+  interval: 30s
+  path: /metrics
+
 # ---------------------------------------------------------------------------
 # Defaults — merged with (and overridden by) per-model config below.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #4859. Stacked on #4927 — merge that first.

Documentation for running tt-inference-server on tt-operator: adds an Architecture section (single DRA path, tt-operator as a separate-lifecycle prerequisite that the chart consumes but never bundles), fills in requirements + the minimal tt-operator install, links each component's docs, adds a TOC, and compacts the Supported Models table.

README-only (regenerated via helm-docs).

Closes #4868.