### PR TITLE
Add 3 forge embedding models to release CI (QB2 p300x2)

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -349,6 +349,11 @@
             "P300X2"
           ]
         },
+        "release": {
+          "devices": [
+            "P300X2"
+          ]
+        },
         "weekly": {
           "devices": [
             "N150"
@@ -360,6 +365,11 @@
       "inference_engine": "FORGE",
       "ci": {
         "nightly": {
+          "devices": [
+            "P300X2"
+          ]
+        },
+        "release": {
           "devices": [
             "P300X2"
           ]
@@ -396,6 +406,11 @@
           "inference_engine": "FORGE",
           "ci": {
             "nightly": {
+              "devices": [
+                "P300X2"
+              ]
+            },
+            "release": {
               "devices": [
                 "P300X2"
               ]


### PR DESCRIPTION
### Problem description
- The 3 forge embedding models onboarded in #4920 (Qwen3-Embedding-0.6B, Qwen3-Embedding-4B, bge-m3) were added to nightly CI only but not release workflow

### What's changed
  - `.github/workflows/models-ci-config.json`: add `release` (P300X2) alongside `nightly` for the 3 forge embedding models.

