### PR TITLE
TEST-IGNORE (release 0.20.0 preparation)

### DIFF
--- a/.github/workflows/test-tt-llm-engine-pull.yml
+++ b/.github/workflows/test-tt-llm-engine-pull.yml
@@ -12,7 +12,7 @@ name: tt-llm-engine pull smoke test
 on:
   push:
     branches:
-      - vcankovic/test-tt-llm-engine-pull
+      - vcankovic/test-tt-llm-engine-docker
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-tt-llm-engine-pull.yml
+++ b/.github/workflows/test-tt-llm-engine-pull.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.TT_LLM_ENGINE }}
+          password: ${{ secrets.SHIELD_TT_LLM_ENGINE }}
 
       - name: Pull tt-llm-engine image
         run: |

--- a/.github/workflows/test-tt-llm-engine-pull.yml
+++ b/.github/workflows/test-tt-llm-engine-pull.yml
@@ -30,11 +30,15 @@ jobs:
 
     steps:
       - name: Log in to GHCR
+        # Using the repo-scoped PAT (TT_LLM_ENGINE) instead of the default
+        # GITHUB_TOKEN. Needed when the tt-llm-engine package on GHCR is
+        # Private and the consumer repo isn't explicitly granted access.
+        # The PAT must have the `read:packages` scope.
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.TT_LLM_ENGINE }}
 
       - name: Pull tt-llm-engine image
         run: |

--- a/.github/workflows/test-tt-llm-engine-pull.yml
+++ b/.github/workflows/test-tt-llm-engine-pull.yml
@@ -1,0 +1,79 @@
+name: tt-llm-engine pull smoke test
+
+# Quick smoke test: can this repo's workflow pull the tt-llm-engine image
+# from ghcr.io using only the default secrets.GITHUB_TOKEN?
+#
+# If this succeeds, no PAT/extra wiring is needed for Phase 3 of the
+# Dockerfile.blaze split. If it fails with 'denied' / 'unauthorized',
+# the tt-llm-engine package on GHCR is still Private and either needs
+# to be set to Internal OR have this repo added under
+# "Manage Actions access" with role Read.
+
+on:
+  push:
+    branches:
+      - vcankovic/test-tt-llm-engine-pull
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read   # required so GITHUB_TOKEN gets pull scope for GHCR
+
+env:
+  IMAGE: ghcr.io/tenstorrent/tt-llm-engine/test:latest
+
+jobs:
+  pull:
+    name: Pull image with GITHUB_TOKEN
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull tt-llm-engine image
+        run: |
+          set -euo pipefail
+          echo "Attempting: docker pull ${IMAGE}"
+          docker pull "$IMAGE"
+          echo ""
+          echo "=== Pull succeeded ==="
+          docker image ls "$IMAGE"
+          docker image inspect "$IMAGE" --format 'Digest: {{.Id}}'
+
+      - name: Smoke-check expected paths exist
+        run: |
+          set -euo pipefail
+          docker run --rm "$IMAGE" bash -c '
+            echo "--- /opt/tt-llm-engine/lib (engine .so + cmake) ---"
+            ls -lh /opt/tt-llm-engine/lib/libtt_llm_engine*.so* 2>/dev/null || echo "MISSING"
+            ls /opt/tt-llm-engine/lib/cmake/tt-llm-engine/ 2>/dev/null || echo "MISSING"
+            echo ""
+            echo "--- /opt/tt-llm-engine-src/tt-metal/build_Release/lib (metal .so) ---"
+            ls -lh /opt/tt-llm-engine-src/tt-metal/build_Release/lib/ 2>/dev/null | head -10 || echo "MISSING"
+            echo ""
+            echo "--- baked SHAs ---"
+            cat /opt/tt-llm-engine/SHA 2>/dev/null && echo "(engine)"
+            cat /opt/tt-llm-engine-src/tt-metal/SHA 2>/dev/null && echo "(metal)"
+          '
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## tt-llm-engine pull smoke test"
+            echo ""
+            echo "- Image: \`${IMAGE}\`"
+            echo "- Result: ${{ job.status }}"
+            echo ""
+            echo "If status is **success**, \`secrets.GITHUB_TOKEN\` is sufficient — no PAT needed for Dockerfile.blaze Phase 3."
+            echo ""
+            echo "If status is **failure** with \`denied\` / \`unauthorized\`, the tt-llm-engine package on GHCR needs to be:"
+            echo "  - set to **Internal** (any org member can pull), OR"
+            echo "  - kept **Private** but with this repo added under *Manage Actions access* → role *Read*"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
<!--
metadata:run_id=28189250228
metadata:version=v0.20.0
-->

# Summary of Changes

* Uplifted Qwen3.6-27B on on Blackhole QuietBox 2
* Added support for Qwen3-Embedding-4B on Blackhole QuietBox 2
* Added support for Qwen3-Embedding-0.6B on Blackhole QuietBox 2
* Added support for bge-m3 on Blackhole QuietBox 2

# Model Spec Release Updates


This document shows model specification updates.

| Impl | Model Arch | Weights | Devices | TT-Metal Commit Change | Status Change | CI Job Link |
|------|------------|---------|---------|------------------------|---------------|-------------|
| `qwen36_blackhole` | `Qwen3.6-27B` | `Qwen/Qwen3.6-27B` | P300X2 | `c49bb76` | [EXPERIMENTAL] | [CI Link](https://github.com/tenstorrent/tt-shield/actions/runs/29037835062/job/86249012895) |
| `forge_vllm_plugin` | `Qwen3-Embedding-4B` | `Qwen/Qwen3-Embedding-4B` | P300X2 | `c49bb76` | [EXPERIMENTAL] | [CI Link](https://github.com/tenstorrent/tt-shield/actions/runs/29037835062/job/86249012896) |
| `forge_vllm_plugin` | `Qwen3-Embedding-0.6B` | `Qwen/Qwen3-Embedding-0.6B` | P300X2 | `c49bb76` | [EXPERIMENTAL] | [CI Link](https://github.com/tenstorrent/tt-shield/actions/runs/29037835062/job/86215988084) |
| `forge_vllm_plugin` | `bge-m3` | `BAAI/bge-m3` | P300X2 | `c49bb76` | [COMPLETE] | [CI Link](https://github.com/tenstorrent/tt-shield/actions/runs/29037835062/job/86215988046) |

# Release Artifacts Summary

## Images Promoted from Models CI

- https://ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7
- https://ghcr.io/tenstorrent/tt-media-inference-server-forge:0.18.0-c49bb76

**Total:** 2
