### PR TITLE
Fix Mochi pipeline call to match latest tt-metal API (merge this first)

### DIFF
--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -8,6 +8,7 @@ import io
 import os
 from abc import abstractmethod
 
+import numpy as np
 import ttnn
 from config.constants import (
     WAN22_NUM_FRAMES,
@@ -328,17 +329,24 @@ class TTMochi1Runner(TTDiTRunner):
     def run(self, requests: list[VideoGenerateRequest]):
         self.logger.debug(f"Device {self.device_id}: Running inference")
         request = requests[0]
+        # MochiPipeline.__call__ takes prompts/negative_prompts lists since the
+        # tt_dit pipeline refactor; num_frames/height/width/output_type moved to
+        # MochiPipelineConfig defaults (168 frames, 480x848).
         frames = self.pipeline(
-            prompt=request.prompt,
-            negative_prompt=request.negative_prompt,
+            prompts=[request.prompt],
+            negative_prompts=[request.negative_prompt or ""],
             num_inference_steps=request.num_inference_steps,
             guidance_scale=3.5,
-            num_frames=168,  # TODO: Parameterize output dimensions.
-            height=480,
-            width=848,
-            output_type="np",
             seed=int(request.seed or 0),
         )
+        # The pipeline returns PIL frames (or a tensor); the video exporter
+        # needs a (batch, frames, H, W, C) uint8 array.
+        if hasattr(frames, "cpu"):
+            frames = frames.cpu().numpy()
+        elif isinstance(frames, list):
+            frames = np.stack(
+                [np.stack([np.asarray(f) for f in video]) for video in frames]
+            )
         self.logger.debug(f"Device {self.device_id}: Inference completed")
         return frames
 


### PR DESCRIPTION
Mochi video generation fails on every current media image because `TTMochi1Runner.run` still uses the pre-refactor `MochiPipeline.__call__` signature. The model loads, runs the full denoise, then dies with `MochiPipeline.__call__() got an unexpected keyword argument 'prompt'` (and after that, postprocessing rejects the PIL output with `'list' object has no attribute 'ndim'`).

Same treatment Wan2.2 got in #4032:

- [x] Pass `prompts`/`negative_prompts` as lists; drop `num_frames`/`height`/`width`/`output_type`, which moved into `MochiPipelineConfig` defaults (168 frames, 480x848)
- [x] Convert the pipeline output (PIL frame lists, or a tensor) into the `(batch, frames, H, W, C)` uint8 array the MP4 exporter expects
- [x] Verified on a Blackhole QuietBox 2 (P300x2, 2x2 mesh) against the `0.18.0-c49bb76` media image with this exact change applied: warmup completes and a 12-step generation returns a valid MP4

Note the prod spec still pins mochi to `0.10.0-555f240`, whose bundled tt-metal predates the Mochi BH mesh fixes and rejects the P300x2 mesh outright — spec bump is a separate small PR.