### PR TITLE
Re-pin Mochi prod spec to the 0.18.0 media image and add DiT cache env var (merge this after #4940)

### DIFF
--- a/workflows/model_specs/prod/video.yaml
+++ b/workflows/model_specs/prod/video.yaml
@@ -7,13 +7,15 @@ templates:
 # =============================================================================
 - weights:
     - genmo/mochi-1-preview
-  version: "0.10.0"
-  tt_metal_commit: 555f240
+  version: "0.18.0"
+  tt_metal_commit: "c49bb76"
   impl: tt_transformers
   min_disk_gb: 60
   min_ram_gb: 32
   model_type: VIDEO
   inference_engine: MEDIA
+  env_vars:
+    TT_DIT_CACHE_DIR: /home/container_app_user/cache_root/tt_dit_cache
   device_model_specs:
     - device: T3K
       max_concurrency: 1


### PR DESCRIPTION
The prod spec has Mochi frozen at `0.10.0-555f240`, whose bundled tt-metal predates the Mochi blackhole mesh fixes — on P300x2 the pipeline asserts ("Mochi has only been successfully tested on 2x2") before loading anything. Newer tt-metal also requires `TT_DIT_CACHE_DIR` in the container env; the runner no longer sets a default, so the model load fails without it. The dev template already carries the env var; only prod lags (Mochi has no `ci.release` entry in models-ci-config.json, so release automation never re-pins it — flagging that for maintainers rather than changing it here).

Same shape as the Wan2.2 entry below it (pinned `0.17.0/8c48a10` with the same env var).

- [x] Bump Mochi to `0.18.0` / `c49bb76` (newest published media image)
- [x] Add `TT_DIT_CACHE_DIR` at template level, matching the Wan2.2 entry
- [x] Verified on a Blackhole QuietBox 2 (P300x2): with this image + env var the 2x2 mesh initializes and the model loads and warms up

One dependency to be aware of: end-to-end video generation on this image also needs the runner-side call fix in #4940 — once a media image containing that lands, this pin should move to it.