### PR TITLE
reverted models-ci-config for v0.21.0 preparation

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -264,6 +264,11 @@
                 "P300X2"
               ]
             },
+            "release": {
+              "devices": [
+                "GALAXY"
+              ]
+            },
             "weekly": {
               "devices": [
                 "GALAXY",
@@ -318,11 +323,6 @@
           "devices": [
             "P300X2"
           ]
-        },
-        "release": {
-          "devices": [
-            "P300X2"
-          ]
         }
       }
     },
@@ -344,11 +344,6 @@
             "P300X2"
           ]
         },
-        "release": {
-          "devices": [
-            "P300X2"
-          ]
-        },
         "weekly": {
           "devices": [
             "N150"
@@ -360,11 +355,6 @@
       "inference_engine": "FORGE",
       "ci": {
         "nightly": {
-          "devices": [
-            "P300X2"
-          ]
-        },
-        "release": {
           "devices": [
             "P300X2"
           ]
@@ -401,11 +391,6 @@
           "inference_engine": "FORGE",
           "ci": {
             "nightly": {
-              "devices": [
-                "P300X2"
-              ]
-            },
-            "release": {
               "devices": [
                 "P300X2"
               ]


### PR DESCRIPTION
reverting models-ci-config for `Qwen3-32B` on `Galaxy` planned for release `v0.21.0`