### PR TITLE
Add Qwen3.8-27B model specs (dev + prod pins)

### DIFF
--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -7921,3 +7921,43 @@ models:
               - name: VLLM__MIN_CONTEXT_LENGTH
                 value: '32'
     defaultEngine: forge
+  Qwen3.8-27B:
+    vllm:
+      p300x2:
+        defaultImpl: qwen36_blackhole
+        impls:
+          qwen36_blackhole:
+            progressDeadlineSeconds: 5400
+            image:
+              repository: ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
+              tag: 0.20.0-9a04829-c127c17
+            probes:
+              liveness:
+                initialDelaySeconds: 2400
+              readiness:
+                initialDelaySeconds: 2400
+            resources:
+              requests:
+                memory: 67Gi
+            env:
+              - name: ARCH_NAME
+                value: blackhole
+              - name: HF_MODEL
+                value: Qwen/Qwen3.8-27B
+              - name: MESH_DEVICE
+                value: (1, 4)
+              - name: QWEN36_MAX_TOKENS_ALL_USERS
+                value: '525312'
+              - name: TORCHDYNAMO_DISABLE
+                value: '1'
+              - name: TT_MESH_GRAPH_DESC_PATH
+                value: ../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto
+              - name: TT_QWEN35_TEXT_VER
+                value: qwen36_blackhole
+              - name: VLLM_CONFIGURE_LOGGING
+                value: '1'
+              - name: VLLM_RPC_TIMEOUT
+                value: '900000'
+              - name: VLLM_TARGET_DEVICE
+                value: tt
+    defaultEngine: vllm

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -1372,6 +1372,76 @@ _eval_config_list = [
         ],
     ),
     EvalConfig(
+        # Qwen3.8-27B reuses the Qwen3.6-27B architecture byte-for-byte (same
+        # model_type qwen3_5), so it serves through the qwen36_blackhole impl
+        # and takes the same eval setup as Qwen3.6-27B above. This entry is
+        # what puts the model into EVAL_CONFIGS; without it the release
+        # workflow fails fast in validate_setup (evals are required).
+        hf_model_repo="Qwen/Qwen3.8-27B",
+        tasks=[
+            EvalTask(
+                task_name="terminal_bench_2",
+                workflow_venv_type=WorkflowVenvType.EVALS_AGENTIC,
+                # Scores are left unset for this first bring-up: Qwen3.8-27B has
+                # no published terminal_bench_2 number we can cite and no TT
+                # measurement of its own yet, so the task runs and reports its
+                # score but the accuracy check reports NA rather than grading
+                # against another model's bar. For reference, Qwen3.6-27B sits
+                # at 59.3 published / 53.9 GPU, which is the expected ballpark
+                # given architecture parity. Fill both in once a 3.8 run lands.
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref=None,
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["accuracy"],
+                        "unit": "percent",
+                    },
+                ),
+                agentic_eval_config=TerminalBenchEvalConfig(
+                    dataset="terminal-bench/terminal-bench-2",
+                    agent="terminus-2",
+                    n_concurrent_trials=5,
+                    n_attempts=1,
+                    n_tasks=89,
+                    override_cpus=16,
+                    override_memory_mb=48 * 1024,
+                    agent_timeout_sec=3 * 60 * 60,
+                    agent_kwargs={
+                        "parser_name": "json",
+                        "temperature": 1.0,
+                        "model_info": {
+                            "max_input_tokens": 256 * 1024,
+                            "max_output_tokens": 80 * 1024,
+                        },
+                        "llm_kwargs": {
+                            "top_p": 0.95,
+                            "max_tokens": 80 * 1024,
+                            "timeout": 60 * 60,
+                            "extra_body": {
+                                "top_k": 20,
+                            },
+                        },
+                    },
+                    task_names_map={
+                        EvalLimitMode.CI_NIGHTLY: [
+                            "terminal-bench/break-filter-js-from-html",
+                            "terminal-bench/cobol-modernization",
+                            "terminal-bench/compile-compcert",
+                            "terminal-bench/feal-differential-cryptanalysis",
+                            "terminal-bench/qemu-startup",
+                        ],
+                    },
+                ),
+                limit_samples_map={
+                    EvalLimitMode.SMOKE_TEST: 5,
+                },
+            ),
+        ],
+    ),
+    EvalConfig(
         hf_model_repo="arcee-ai/AFM-4.5B",
         tasks=[
             EvalTask(

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -418,6 +418,50 @@ templates:
       tool_call_parser_name: qwen3_coder
 
 - weights:
+    - Qwen/Qwen3.8-27B
+  impl: qwen36_blackhole
+  # Qwen3.8-27B (released 2026-08-14) reuses the Qwen3.6-27B architecture
+  # byte-for-byte (same model_type qwen3_5; config.json differs only in the
+  # transformers_version stamp), so it runs through the same tt-metal impl.
+  # Validated bare-metal on P300X2 on release day: text_demo traced_128 PASSED
+  # (TTFT 160ms, decode 26.53 tok/s — at parity with the Qwen3.6-27B targets)
+  # and a live vLLM OpenAI server (streaming, thinking mode, stop tokens with
+  # the new eos pair) at tt-metal 9a04829 with the tenstorrent/vllm fork
+  # @ 7c99bd3. Dev specs omit tt_metal_commit/vllm_commit (base
+  # ModelSpecTemplate rejects them); the prod entry pins the build commits.
+  inference_engine: VLLM
+  model_type: LLM
+  supported_modalities:
+    - text
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 32
+      max_context: 262144
+      max_tokens_all_users_override: 525312
+      default_impl: true
+      env_vars:
+        TT_QWEN35_TEXT_VER: qwen36_blackhole
+        HF_MODEL: Qwen/Qwen3.8-27B
+        MESH_DEVICE: "(1, 4)"
+        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto"
+        QWEN36_MAX_TOKENS_ALL_USERS: "525312"
+      vllm_args:
+        enable_auto_tool_choice: true
+        reasoning_parser: qwen3
+        tool_call_parser: qwen3_coder
+      override_tt_config:
+        fabric_config: FABRIC_1D
+        trace_region_size: 1073741824
+        l1_small_size: 24576
+        sample_on_device_mode: decode_only
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+  metadata:
+    Qwen/Qwen3.8-27B:
+      reasoning_parser_name: qwen3
+      tool_call_parser_name: qwen3_coder
+
+- weights:
     - Qwen/Qwen3-32B
   impl: qwen3_32b_galaxy
   inference_engine: VLLM

--- a/workflows/model_specs/prod/llm.yaml
+++ b/workflows/model_specs/prod/llm.yaml
@@ -1282,3 +1282,50 @@ templates:
     Qwen/Qwen3.6-27B:
       reasoning_parser_name: qwen3
       tool_call_parser_name: qwen3_coder
+- weights:
+    - Qwen/Qwen3.8-27B
+  version: "0.20.0"
+  # tt_metal_commit is the tt-metal main commit validated bare-metal on P300X2
+  # on 2026-08-14 (text_demo traced_128 + live vLLM server; TTFT 160ms, decode
+  # 26.53 tok/s at ISL 128). NOTE on vllm_commit: since #4907 the Dockerfile
+  # clones vllm-tt-plugin and checks this SHA out there (upstream vLLM is
+  # pinned by the plugin), so post-switch entries pin vllm-tt-plugin commits —
+  # NOT tenstorrent/vllm fork commits like the entries above. Bare-metal
+  # validation used the fork @ 7c99bd3; the plugin-path image from these pins
+  # still needs its own smoke run.
+  tt_metal_commit: "9a04829"
+  vllm_commit: "c127c17"
+  impl: qwen36_blackhole
+  inference_engine: VLLM
+  model_type: LLM
+  supported_modalities:
+    - text
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 32
+      max_context: 262144
+      max_tokens_all_users_override: 525312
+      default_impl: true
+      env_vars:
+        TT_QWEN35_TEXT_VER: qwen36_blackhole
+        HF_MODEL: Qwen/Qwen3.8-27B
+        MESH_DEVICE: "(1, 4)"
+        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto"
+        QWEN36_MAX_TOKENS_ALL_USERS: "525312"
+      vllm_args:
+        enable_auto_tool_choice: true
+        reasoning_parser: qwen3
+        tool_call_parser: qwen3_coder
+      override_tt_config:
+        fabric_config: FABRIC_1D
+        trace_region_size: 1073741824
+        l1_small_size: 24576
+        sample_on_device_mode: decode_only
+  # EXPERIMENTAL: no target performance has been set yet, so we can't classify
+  # this as FUNCTIONAL, COMPLETE, or top-perf.
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+  metadata:
+    Qwen/Qwen3.8-27B:
+      reasoning_parser_name: qwen3
+      tool_call_parser_name: qwen3_coder


### PR DESCRIPTION
Adds model specs for **Qwen/Qwen3.8-27B**, released this morning (2026-08-14).

**Why this is a small change:** Qwen3.8-27B is the same architecture as Qwen3.6-27B — same `model_type: qwen3_5`, and its config.json differs from 3.6's by only the transformers version stamp. It runs through the existing `qwen36_blackhole` tt-metal impl with no code changes. The two entries mirror the Qwen3.6-27B specs with the model name swapped.

**Validated on release day, bare metal on P300X2:**
- tt-metal `text_demo` traced_128: passed — TTFT 160 ms, decode 26.53 tok/s (at parity with the registered Qwen3.6-27B targets; the tt-metal pin includes the #51556 bucketing fix)
- Live vLLM OpenAI server: streaming, thinking mode (new default in 3.8), and clean stops with the new eos token pair all verified

**What's in the PR:**
- `dev/llm.yaml`: Qwen3.8-27B entry, P300X2 only (the validated device), mirroring the 3.6 dev entry. No commit pins — dev specs can't carry them.
- `prod/llm.yaml`: matching entry carrying the build pins, since that's where `build_docker_images.py` reads them: `tt_metal_commit: 9a04829`, `vllm_commit: c127c17`, version 0.20.0, status EXPERIMENTAL.

**One thing reviewers should know:** `vllm_commit` here is a **vllm-tt-plugin** SHA, not a tenstorrent/vllm fork SHA like the entries above it — since #4907 the Dockerfile clones vllm-tt-plugin, so this is the first entry pinned under the new scheme. Our bare-metal validation used the fork (`7c99bd3`); the docker image built from these pins uses the plugin path and still needs its own smoke run. Happy to adjust the pin or version if 0.21.0 conventions land differently.

Checks run locally: both catalogs load (299 dev / 226 prod specs), all 179 catalog/spec tests pass, and the prod entry resolves to docker image tag `0.20.0-9a04829-c127c17`.

CI run: https://github.com/tenstorrent/tt-shield/actions/runs/31826395848
