### PR TITLE
Raise Motif trace region to 50MB for the p300x2 (2,2) mesh

### DIFF
--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -275,7 +275,7 @@ class TTMotifImage6BPreviewRunner(TTDiTRunner):
             raise
 
     def get_pipeline_device_params(self):
-        return {"l1_small_size": 32768, "trace_region_size": 31000000}
+        return {"l1_small_size": 32768, "trace_region_size": 50000000}
 
 
 # Runner for Qwen-Image and Qwen-Image-2512. Model weights from settings.model_weights_path determine the exact model variant.


### PR DESCRIPTION
## Problem

Deploying `Motif-Image-6B-Preview` on BH QuietBox 2 (p300x2) fails during device init:

```
TT_FATAL: Creating trace buffers of size 37961728B on MeshDevice 1, but only 31000000B is allocated for trace region. (assert.hpp:104)
```

The Motif runner requests a 31MB trace region, which fits the tp=4 layouts (T3K/Galaxy/P150X8) but not the p300x2 `(2, 2)` mesh, where tensor-parallel factor 2 leaves ~38MB of trace per device.

## Fix

One line: raise `trace_region_size` from 31MB to 50MB in `TTMotifImage6BPreviewRunner.get_pipeline_device_params`. 50MB is what the tt-metal Motif pipeline tests (`models/tt_dit/tests/models/motif`) already use, and the existing tp=4 layouts fit comfortably within it.

## How to reproduce

1. On a p300x2 host, run Motif with the 0.18.0 media image and a tt-metal build that has a `(2, 2)` Motif mesh preset (submitted separately to tt-metal).
2. Warmup dies with the TT_FATAL above.
3. With this change, warmup completes and `POST /v1/images/generations` returns a 1024x1024 image in ~7s.

## Verification

Hardware-verified on p300x2 (4x Blackhole p300c chips) by hot-patching the 0.18.0 image: warmup completes, two separate 1024x1024 generations served end-to-end through TT-Studio.

Related: the prod spec re-pin for Motif is in a separate PR (the pinned 0.9.0 image cannot launch Motif at all).