### PR TITLE
Re-pin Motif-Image-6B-Preview to the 0.18.0 media image

### DIFF
--- a/workflows/model_specs/prod/image.yaml
+++ b/workflows/model_specs/prod/image.yaml
@@ -170,8 +170,8 @@ templates:
 
 - weights:
     - Motif-Technologies/Motif-Image-6B-Preview
-  version: "0.9.0"
-  tt_metal_commit: c180ef7
+  version: "0.18.0"
+  tt_metal_commit: c49bb76
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6


### PR DESCRIPTION
## Problem

The prod image spec pins `Motif-Image-6B-Preview` to `tt-media-inference-server:0.9.0-c180ef7`, but that image cannot launch Motif via `run.py` on any device:

1. run.py derives `MODEL=Motif-Image-6B-Preview` from the spec weights, but the 0.9.0 server's `ModelNames` enum still has the old lowercase value `motif-image-6b-preview`, so the server dies at import with `ValueError: 'Motif-Image-6B-Preview' is not a valid ModelNames` before ever binding the port.
2. The 0.9.0 server has no Motif device configs for P150X8 or P300X2, both of which this spec entry lists.

So the documented quickstart (`python3 run.py --model Motif-Image-6B-Preview --device p300x2 --workflow server --docker-server`) fails on a 30s container-start timeout.

## Fix

Re-pin to `0.18.0-c49bb76` (the newest published media image): its enum accepts the exact-case MODEL value and it carries Motif device configs for all four listed devices.

## Verification

Hardware-verified on p300x2 via TT-Studio: with this image, Motif reaches pipeline creation on all devices. Full p300x2 serving additionally needs two one-line fixes — the tt-metal `(2, 2)` mesh preset (PR to tt-metal) and the trace-region raise (#4955) — after which warmup completes and 1024x1024 generations return in ~7s. T3K/GALAXY/P150X8 launch correctly with this re-pin alone.

## Steps to confirm

1. `python3 run.py --model Motif-Image-6B-Preview --device <t3k|p300x2> --workflow server --docker-server` with the old pin → container dies at import (see server log: `ValueError: ... not a valid ModelNames`).
2. Same command with this re-pin → server boots and reports the model on `/v1/models`.