### PR TITLE
Fix TTS Tokenization

### DIFF
--- a/tt-media-server/cpp_server/include/config/runner_config.hpp
+++ b/tt-media-server/cpp_server/include/config/runner_config.hpp
@@ -121,6 +121,10 @@ struct TtsConfig : RunnerConfigBase {
   uint32_t audioSampleRateHz = defaults::TTS_AUDIO_SAMPLE_RATE_HZ;
   uint16_t audioChannels = defaults::TTS_AUDIO_CHANNELS;
 
+  // Literal BOS token prepended to the compiled prompt; empty = none.
+  // Read from the tokenizer's tokenizer_config.json in ttsEngineConfig().
+  std::string bosToken;
+
   // Socket descriptor prefixes written by the model launcher into /dev/shm.
   std::string encoderSocketDescriptorPrefix =
       defaults::TTS_ENCODER_SOCKET_DESCRIPTOR_PREFIX;

--- a/tt-media-server/cpp_server/include/utils/tts_prompt_compiler.hpp
+++ b/tt-media-server/cpp_server/include/utils/tts_prompt_compiler.hpp
@@ -62,10 +62,18 @@ inline void validatePromptInputs(
 
 inline std::string compilePromptString(
     const std::string& text, const std::optional<std::string>& description,
-    const std::vector<uint32_t>& promptSpeechIds = {}) {
+    const std::vector<uint32_t>& promptSpeechIds = {},
+    const std::string& bosToken = "") {
   validatePromptInputs(text, description);
 
   std::ostringstream prompt;
+  // Tokenizer::encode() calls tokenizers-cpp Encode(), which does NOT add
+  // special tokens, so BOS has to be part of the prompt string. Without it the
+  // model is decoded from a prefix it never saw in training — the reference
+  // compiler emits [BOS, <|bot|>, ...] and this produced [<|bot|>, ...].
+  if (!bosToken.empty()) {
+    prompt << bosToken;
+  }
   if (!promptSpeechIds.empty()) {
     prompt << tts_tokens::AUDIO_PROMPT_START_TOKEN;
     appendSpeechTokens(prompt, promptSpeechIds);
@@ -86,9 +94,10 @@ inline std::string compilePromptString(
 inline std::vector<uint32_t> compilePromptTokens(
     const tt::utils::tokenizers::Tokenizer& tokenizer, const std::string& text,
     const std::optional<std::string>& description,
-    const std::vector<uint32_t>& promptSpeechIds = {}) {
+    const std::vector<uint32_t>& promptSpeechIds = {},
+    const std::string& bosToken = "") {
   return tokenizer.encode(
-      compilePromptString(text, description, promptSpeechIds));
+      compilePromptString(text, description, promptSpeechIds, bosToken));
 }
 
 }  // namespace tt::utils::tts_prompt_compiler

--- a/tt-media-server/cpp_server/include/utils/tts_prompt_compiler.hpp
+++ b/tt-media-server/cpp_server/include/utils/tts_prompt_compiler.hpp
@@ -67,10 +67,6 @@ inline std::string compilePromptString(
   validatePromptInputs(text, description);
 
   std::ostringstream prompt;
-  // Tokenizer::encode() calls tokenizers-cpp Encode(), which does NOT add
-  // special tokens, so BOS has to be part of the prompt string. Without it the
-  // model is decoded from a prefix it never saw in training — the reference
-  // compiler emits [BOS, <|bot|>, ...] and this produced [<|bot|>, ...].
   if (!bosToken.empty()) {
     prompt << bosToken;
   }

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -583,12 +583,6 @@ TtsConfig ttsEngineConfig() {
 
     // Resolve the prompt-leading BOS from the tokenizer_config.json beside the
     // tokenizer, the same source the LLM tokenizers use
-    // (llama_tokenizer.cpp:41). That file is the authority on both halves of
-    // the question — it carries bos_token and add_bos_token — so a model
-    // trained without a leading BOS says so there rather than needing a
-    // server-side override. Best-effort by design: a missing or malformed
-    // config leaves bosToken empty and the prompt keeps its previous
-    // (BOS-less) shape instead of failing startup.
     if (!cfg.tokenizerPath.empty()) {
       const std::filesystem::path configPath =
           std::filesystem::path(cfg.tokenizerPath).parent_path() /

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -580,6 +580,39 @@ TtsConfig ttsEngineConfig() {
     }
     cfg.tokenizerPath = envString(
         "TTS_TOKENIZER_PATH", tokenizerPath(ModelType::LLAMA_3_1_8B_INSTRUCT));
+
+    // Resolve the prompt-leading BOS from the tokenizer_config.json beside the
+    // tokenizer, the same source the LLM tokenizers use
+    // (llama_tokenizer.cpp:41). That file is the authority on both halves of
+    // the question — it carries bos_token and add_bos_token — so a model
+    // trained without a leading BOS says so there rather than needing a
+    // server-side override. Best-effort by design: a missing or malformed
+    // config leaves bosToken empty and the prompt keeps its previous
+    // (BOS-less) shape instead of failing startup.
+    if (!cfg.tokenizerPath.empty()) {
+      const std::filesystem::path configPath =
+          std::filesystem::path(cfg.tokenizerPath).parent_path() /
+          "tokenizer_config.json";
+      try {
+        const auto tokenizerCfg =
+            utils::tokenizers::getTokenizerConfig(configPath.string());
+        if (tokenizerCfg.add_bos_token) {
+          cfg.bosToken = tokenizerCfg.bos_token;
+        }
+      } catch (const std::exception& e) {
+        TT_LOG_WARN("[Config] TTS BOS lookup failed ({}): {}",
+                    configPath.string(), e.what());
+      }
+    }
+    if (cfg.bosToken.empty()) {
+      TT_LOG_WARN(
+          "[Config] TTS prompt has no leading BOS; the reference compiler "
+          "prepends one (e.g. <|begin_of_text|>). Check bos_token / "
+          "add_bos_token in the tokenizer_config.json next to {}",
+          cfg.tokenizerPath);
+    } else {
+      TT_LOG_INFO("[Config] TTS prompt BOS = '{}'", cfg.bosToken);
+    }
     cfg.voiceSampleRateHz = static_cast<uint32_t>(envUlong(
         "TTS_VOICE_SAMPLE_RATE_HZ", defaults::TTS_VOICE_SAMPLE_RATE_HZ));
     cfg.voiceChannels = static_cast<uint16_t>(

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_tts_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_tts_runner.cpp
@@ -250,7 +250,7 @@ void BlazeTtsRunner::compilePromptTokens(
   const auto& tokenizer =
       tt::utils::tts_tokenizer::tokenizerForPath(config.tokenizerPath);
   task.promptTokens = tt::utils::tts_prompt_compiler::compilePromptTokens(
-      tokenizer, task.text, task.description, speechIds);
+      tokenizer, task.text, task.description, speechIds, config.bosToken);
 }
 
 void BlazeTtsRunner::allocateTask(ipc::tts::TtsIpcTask task) {

--- a/tt-media-server/cpp_server/src/services/tts_request_preprocessor.cpp
+++ b/tt-media-server/cpp_server/src/services/tts_request_preprocessor.cpp
@@ -97,7 +97,8 @@ tt::domain::tts::TtsTask TtsRequestPreprocessor::process(
     const auto& tokenizer =
         tt::utils::tts_tokenizer::tokenizerForPath(config.tokenizerPath);
     task.promptTokens = tt::utils::tts_prompt_compiler::compilePromptTokens(
-        tokenizer, request.text, request.description);
+        tokenizer, request.text, request.description, /*promptSpeechIds=*/{},
+        config.bosToken);
   }
 
   return task;

--- a/tt-media-server/cpp_server/tests/unit/model/tts_prompt_compiler_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/model/tts_prompt_compiler_test.cpp
@@ -59,4 +59,26 @@ TEST(TtsPromptCompilerTest, TokenizesCompiledPromptString) {
       tokenizer.encode(prompt));
 }
 
+TEST(TtsPromptCompilerTest, PrependsBosWhenProvided) {
+  EXPECT_EQ(compiler::compilePromptString("hello", std::nullopt, {},
+                                          "<|begin_of_text|>"),
+            "<|begin_of_text|><|bot|>hello<|speech_start|>");
+}
+
+TEST(TtsPromptCompilerTest, OmitsBosWhenEmpty) {
+  EXPECT_EQ(compiler::compilePromptString("hello", std::nullopt, {}, ""),
+            "<|bot|>hello<|speech_start|>");
+}
+
+// BOS leads the whole prompt — ahead of the audio/voice prompt blocks, not
+// just ahead of <|bot|>. The reference compiler emits [BOS, ...] first.
+TEST(TtsPromptCompilerTest, BosPrecedesAudioAndVoicePromptBlocks) {
+  const std::vector<uint32_t> speechIds = {12, 34};
+  EXPECT_EQ(compiler::compilePromptString("hello", std::string("calm voice"),
+                                          speechIds, "<|begin_of_text|>"),
+            "<|begin_of_text|><|audio_prompt_start|><|s_12|><|s_34|>"
+            "<|audio_prompt_end|><|voice_prompt_start|>calm voice"
+            "<|voice_prompt_end|><|bot|>hello<|speech_start|>");
+}
+
 }  // namespace

--- a/tt-media-server/cpp_server/tests/unit/model/tts_prompt_compiler_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/model/tts_prompt_compiler_test.cpp
@@ -70,8 +70,6 @@ TEST(TtsPromptCompilerTest, OmitsBosWhenEmpty) {
             "<|bot|>hello<|speech_start|>");
 }
 
-// BOS leads the whole prompt — ahead of the audio/voice prompt blocks, not
-// just ahead of <|bot|>. The reference compiler emits [BOS, ...] first.
 TEST(TtsPromptCompilerTest, BosPrecedesAudioAndVoicePromptBlocks) {
   const std::vector<uint32_t> speechIds = {12, 34};
   EXPECT_EQ(compiler::compilePromptString("hello", std::string("calm voice"),


### PR DESCRIPTION
## Problem
The BOS token was not being added to prompts, which resulted in incorrect token generation and in some cases the EOS token being omitted.