### PR TITLE
[tt-media-server] MiniMax-H3 video+audio runner (draft)

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -27,6 +27,7 @@ class SupportedModels(Enum):
     WAN_2_2_I2V_DISTILL = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
     WAN_2_2_I2V_LORA = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
     WAN_2_2_I2V_LIGHTNING = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+    MINIMAX_H3 = "MiniMaxAI/MiniMax-H3"
     DISTIL_WHISPER_LARGE_V3 = "distil-whisper/distil-large-v3"
     OPENAI_WHISPER_LARGE_V3 = "openai/whisper-large-v3"
     PYANNOTE_SPEAKER_DIARIZATION = "pyannote/speaker-diarization-3.0"
@@ -76,6 +77,7 @@ class ModelNames(Enum):
     WAN_2_2_I2V_DISTILL = "Wan2.2-I2V-Distill-LightX2V"
     WAN_2_2_I2V_LORA = "Wan2.2-I2V-LoRA"
     WAN_2_2_I2V_LIGHTNING = "Wan2.2-I2V-Lightning"
+    MINIMAX_H3 = "MiniMax-H3"
     DISTIL_WHISPER_LARGE_V3 = "distil-large-v3"
     OPENAI_WHISPER_LARGE_V3 = "whisper-large-v3"
     MICROSOFT_RESNET_50 = "resnet-50"
@@ -127,6 +129,7 @@ class ModelRunners(Enum):
     TT_WAN_2_2_I2V_DISTILL = "tt-wan2.2-i2v-distill"
     TT_WAN_2_2_I2V_LORA = "tt-wan2.2-i2v-lora"
     TT_WAN_2_2_I2V_LIGHTNING = "tt-wan2.2-i2v-lightning"
+    TT_MINIMAX_H3 = "tt-minimax-h3"
     TT_WHISPER = "tt-whisper"
     VLLMForge = "vllm_forge"
     TT_YOLOV4 = "tt-yolov4"
@@ -228,6 +231,7 @@ MODEL_SERVICE_RUNNER_MAP = {
         ModelRunners.TT_WAN_2_2_I2V_DISTILL,
         ModelRunners.TT_WAN_2_2_I2V_LORA,
         ModelRunners.TT_WAN_2_2_I2V_LIGHTNING,
+        ModelRunners.TT_MINIMAX_H3,
         ModelRunners.SP_RUNNER,
     },
     ModelServices.TRAINING: {
@@ -290,6 +294,7 @@ INFERENCE_MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
     ModelRunners.TT_WAN_2_2_I2V_DISTILL: {ModelNames.WAN_2_2_I2V_DISTILL},
     ModelRunners.TT_WAN_2_2_I2V_LORA: {ModelNames.WAN_2_2_I2V_LORA},
     ModelRunners.TT_WAN_2_2_I2V_LIGHTNING: {ModelNames.WAN_2_2_I2V_LIGHTNING},
+    ModelRunners.TT_MINIMAX_H3: {ModelNames.MINIMAX_H3},
     ModelRunners.SP_RUNNER: {
         ModelNames.WAN_2_2,
         ModelNames.WAN_2_2_T2V_PRODIA,
@@ -437,6 +442,22 @@ def wan22_target_resolution(mesh_shape: Tuple[int, int]) -> Resolution:
     if is_large_mesh(mesh_shape):
         return WAN22_RESOLUTION_LARGE_MESH
     return WAN22_RESOLUTION_SMALL_MESH
+
+
+# --- MiniMax-H3 (text -> video + native stereo audio) inference shape policy ---
+# H3 runs on a 17n+5 temporal grid; 124 frames is ~5s @ 24fps, the default
+# short-clip length. Small Blackhole meshes (P150X4 (1,4), P300X2 (2,2)) run the
+# native short-edge-512 tier; Galaxy-class meshes ((4,8) / (4,32)) go larger.
+MINIMAX_H3_NUM_FRAMES = 124
+MINIMAX_H3_RESOLUTION_LARGE_MESH = Resolution(height=768, width=1344)
+MINIMAX_H3_RESOLUTION_SMALL_MESH = Resolution(height=512, width=512)
+
+
+def minimax_h3_target_resolution(mesh_shape: Tuple[int, int]) -> Resolution:
+    """Resolve MiniMax-H3 target resolution from a (rows, cols) mesh shape."""
+    if is_large_mesh(mesh_shape):
+        return MINIMAX_H3_RESOLUTION_LARGE_MESH
+    return MINIMAX_H3_RESOLUTION_SMALL_MESH
 
 
 AUDIO_RESPONSE_FORMATS = frozenset(e.value for e in AudioResponseFormat)
@@ -1492,6 +1513,33 @@ ModelConfigs = {
         "device_ids": DeviceIds.DEVICE_IDS_4_GROUP.value,
         "max_batch_size": 1,
         "request_processing_timeout_seconds": 1500,
+    },
+    # MiniMax-H3 (text -> video + native stereo audio). 1-to-many Blackhole:
+    # single QB2 (1,4) and QuietBox GE (2,2) run the small-mesh tier; Galaxy
+    # (4,8) is the upstream-tuned large-mesh preset. The runner supplies explicit
+    # tp/sp/num_links for the small meshes upstream does not yet preset.
+    (ModelRunners.TT_MINIMAX_H3, DeviceTypes.P150X4): {
+        "device_mesh_shape": (1, 4),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_4_GROUP.value,
+        "max_batch_size": 1,
+        "download_weights_from_service": False,
+        "request_processing_timeout_seconds": 5000,
+    },
+    (ModelRunners.TT_MINIMAX_H3, DeviceTypes.P300X2): {
+        "device_mesh_shape": (2, 2),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_4_GROUP.value,
+        "max_batch_size": 1,
+        "download_weights_from_service": False,
+        "request_processing_timeout_seconds": 5000,
+    },
+    (ModelRunners.TT_MINIMAX_H3, DeviceTypes.GALAXY): {
+        "device_mesh_shape": (4, 8),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_32_GROUP.value,
+        "max_batch_size": 1,
+        "request_processing_timeout_seconds": 5000,
     },
     (ModelRunners.TRAINING_LORA, DeviceTypes.P150): {
         "device_mesh_shape": (1, 1),

--- a/tt-media-server/domain/video_generate_request.py
+++ b/tt-media-server/domain/video_generate_request.py
@@ -25,3 +25,9 @@ class VideoGenerateRequest(BaseRequest):
         le=MAX_VIDEO_INFERENCE_STEPS,
     )
     seed: Optional[int] = None
+    # Optional output geometry. Additive/backward-compatible: models that fix their own
+    # resolution/duration (Wan, Mochi) ignore these; the MiniMax-H3 runner honors them (clamped to
+    # the model's envelope). width/height are pixels (snapped /32); num_frames is on the 17n+5 grid.
+    width: Optional[int] = Field(default=None, gt=0)
+    height: Optional[int] = Field(default=None, gt=0)
+    num_frames: Optional[int] = Field(default=None, gt=0)

--- a/tt-media-server/tests/test_minimax_h3_runner.py
+++ b/tt-media-server/tests/test_minimax_h3_runner.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Tests for the MiniMax-H3 video+audio runner and its audio-mux export path.
+
+Split by dependency so the audio/config tests run anywhere (no ttnn / no
+hardware), while the runner-registration test that imports the tt_dit pipeline
+stack runs inside the media-server container.
+"""
+
+import shutil
+import subprocess
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Config wiring (import-light: config.constants pulls no ttnn)
+# ---------------------------------------------------------------------------
+
+
+def test_minimax_h3_registered_in_service_and_name_maps():
+    from config.constants import (
+        INFERENCE_MODEL_RUNNER_TO_MODEL_NAMES_MAP,
+        MODEL_SERVICE_RUNNER_MAP,
+        ModelNames,
+        ModelRunners,
+        ModelServices,
+    )
+
+    assert ModelRunners.TT_MINIMAX_H3 in MODEL_SERVICE_RUNNER_MAP[ModelServices.VIDEO]
+    assert INFERENCE_MODEL_RUNNER_TO_MODEL_NAMES_MAP[ModelRunners.TT_MINIMAX_H3] == {
+        ModelNames.MINIMAX_H3
+    }
+
+
+@pytest.mark.parametrize(
+    "device_type_name, expected_mesh",
+    [("P150X4", (1, 4)), ("P300X2", (2, 2)), ("GALAXY", (4, 8))],
+)
+def test_minimax_h3_model_configs_cover_1_to_many_blackhole(
+    device_type_name, expected_mesh
+):
+    from config.constants import DeviceTypes, ModelConfigs, ModelRunners
+
+    key = (ModelRunners.TT_MINIMAX_H3, DeviceTypes[device_type_name])
+    assert key in ModelConfigs, f"missing ModelConfigs row for {device_type_name}"
+    assert ModelConfigs[key]["device_mesh_shape"] == expected_mesh
+    assert ModelConfigs[key]["max_batch_size"] == 1
+
+
+def test_minimax_h3_target_resolution_scales_with_mesh():
+    from config.constants import minimax_h3_target_resolution
+
+    small = minimax_h3_target_resolution((1, 4))
+    large = minimax_h3_target_resolution((4, 8))
+    assert (large.height * large.width) > (small.height * small.width)
+
+
+# ---------------------------------------------------------------------------
+# Runner registration (imports the tt_dit pipeline stack — container only)
+# ---------------------------------------------------------------------------
+
+
+def test_minimax_h3_in_available_runners():
+    ttnn = pytest.importorskip("ttnn")  # noqa: F841  (skips outside the container)
+    from config.constants import ModelRunners
+    from tt_model_runners.runner_fabric import AVAILABLE_RUNNERS
+
+    assert ModelRunners.TT_MINIMAX_H3 in AVAILABLE_RUNNERS
+    assert callable(AVAILABLE_RUNNERS[ModelRunners.TT_MINIMAX_H3])
+
+
+# ---------------------------------------------------------------------------
+# Audio mux (needs numpy + ffmpeg; no ttnn / no hardware)
+# ---------------------------------------------------------------------------
+
+_HAVE_FFMPEG = (
+    shutil.which("ffmpeg") is not None and shutil.which("ffprobe") is not None
+)
+_needs_ffmpeg = pytest.mark.skipif(
+    not _HAVE_FFMPEG, reason="ffmpeg/ffprobe not present"
+)
+
+
+def _stream_types(path: str) -> list[str]:
+    out = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "stream=codec_type",
+            "-of",
+            "default=nw=1:nk=1",
+            path,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.split()
+
+
+def _dummy_frames(n=8, h=64, w=64):
+    return (np.random.rand(n, h, w, 3) * 255).astype(np.uint8)
+
+
+def _dummy_stereo(sample_rate=32000, seconds=1):
+    # Channels-first (2, N) float32 in [-1, 1] — MiniMax-H3's native audio shape.
+    n = sample_rate * seconds
+    t = np.linspace(0, seconds, n, endpoint=False)
+    left = 0.3 * np.sin(2 * np.pi * 220 * t)
+    right = 0.3 * np.sin(2 * np.pi * 330 * t)
+    return np.stack([left, right]).astype(np.float32)
+
+
+@_needs_ffmpeg
+def test_export_to_mp4_video_only_has_no_audio_stream():
+    from utils.video_manager import VideoManager
+
+    path = VideoManager().export_to_mp4(_dummy_frames(), fps=8)
+    types = _stream_types(path)
+    assert "video" in types
+    assert "audio" not in types
+
+
+@_needs_ffmpeg
+def test_export_to_mp4_with_audio_muxes_aac_track():
+    from utils.video_manager import VideoManager
+
+    path = VideoManager().export_to_mp4(
+        _dummy_frames(), fps=8, audio=_dummy_stereo(), sample_rate=32000
+    )
+    types = _stream_types(path)
+    assert "video" in types
+    assert "audio" in types
+
+
+@_needs_ffmpeg
+def test_export_to_mp4_pulls_audio_off_result_object():
+    """An object exposing .frames/.audio/.sample_rate (VideoWithAudio-shaped)
+    should be muxed without the caller passing audio explicitly."""
+    from utils.video_manager import VideoManager
+
+    class _Result:
+        frames = _dummy_frames()
+        audio = _dummy_stereo()
+        sample_rate = 32000
+
+    path = VideoManager().export_to_mp4(_Result(), fps=8)
+    types = _stream_types(path)
+    assert "video" in types
+    assert "audio" in types
+
+
+@_needs_ffmpeg
+def test_write_wav_handles_mono_and_both_layouts():
+    from utils.video_manager import _audio_to_int16_frames
+
+    # channels-first stereo (2, N)
+    frames, ch = _audio_to_int16_frames(_dummy_stereo())
+    assert ch == 2 and frames.dtype == np.int16 and frames.shape[1] == 2
+    # mono (N,)
+    frames, ch = _audio_to_int16_frames(np.zeros(1000, dtype=np.float32))
+    assert ch == 1 and frames.shape[1] == 1
+    # samples-first stereo (N, 2)
+    frames, ch = _audio_to_int16_frames(np.zeros((1000, 2), dtype=np.float32))
+    assert ch == 2 and frames.shape == (1000, 2)

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -1164,9 +1164,10 @@ class VideoWithAudio:
     muxer without changing the video worker/service call sites.
     """
 
-    frames: np.ndarray  # (T, H, W, 3) uint8  -- MiniMaxH3Output.frames
-    audio: np.ndarray  # (2, N) float32 [-1, 1] -- MiniMaxH3Output.audio (stereo)
+    frames: np.ndarray  # (F, H, W, 3) uint8   -- from MiniMaxH3Output.video
+    audio: np.ndarray  # (2, N) float32 [-1, 1] -- from MiniMaxH3Output.audio (stereo)
     sample_rate: int  # MiniMaxH3Output.sampling_rate (e.g. 32000)
+    fps: int = 24  # MiniMaxH3Output.fps -- used by export_to_mp4 for the video rate
 
 
 # Explicit parallel params for the small Blackhole meshes upstream does not yet
@@ -1174,9 +1175,14 @@ class VideoWithAudio:
 # from a validated 1x4 Blackhole run; (2, 2) mirrors the same factors and is
 # still to be validated on hardware. Remove an entry once it lands as a real
 # upstream _PRESETS_BH row and create_pipeline can resolve it from the mesh.
+# tp_axis=1 puts TP across the 4-chip axis (mirrors the galaxy preset's TP=4 on
+# its 4-chip axis 0); sp_axis is the size-1/size-2 axis. topology MUST be non-None
+# -- upstream treats any None in (tp_axis, sp_axis, num_links, topology) as "use a
+# preset" and rejects the shape. A single QB2 is a physical line, so Linear (not
+# the galaxy's Ring, which needs a torus wrap link the box does not have).
 _MINIMAX_H3_SMALL_MESH_PARAMS = {
-    (1, 4): dict(tp_axis=1, sp_axis=0, num_links=2, topology=None),
-    (2, 2): dict(tp_axis=1, sp_axis=0, num_links=2, topology=None),
+    (1, 4): dict(tp_axis=1, sp_axis=0, num_links=2, topology=ttnn.Topology.Linear),
+    (2, 2): dict(tp_axis=1, sp_axis=0, num_links=2, topology=ttnn.Topology.Linear),
 }
 
 
@@ -1250,10 +1256,31 @@ class TTMiniMaxH3Runner(TTDiTRunner):
         self.logger.debug(f"Device {self.device_id}: Running inference")
         out = self.pipeline(**_minimax_h3_pipeline_args(requests[0], self.resolution))
         self.logger.debug(f"Device {self.device_id}: Inference completed")
-        # Return both streams so the exporter muxes the audio into the mp4.
-        return VideoWithAudio(
-            frames=out.frames, audio=out.audio, sample_rate=out.sampling_rate
+        # MiniMaxH3Output.video is (1, 3, F, H, W) float in [0, 1]; the exporter
+        # wants (F, H, W, 3) uint8 (channels-last). audio is (1, 2, samples) ->
+        # (2, samples). Return both so the exporter muxes the audio into the mp4.
+        frames = (
+            out.video[0]  # (3, F, H, W)
+            .permute(1, 2, 3, 0)  # (F, H, W, 3)
+            .clamp(0, 1)
+            .mul(255)
+            .round()
+            .to("cpu")
+            .numpy()
+            .astype(np.uint8)
         )
+        audio = out.audio[0].to("cpu").numpy()  # (2, samples)
+        # The device worker indexes the return per-request (``responses[i]``) and
+        # checks ``len(responses)``, so return a one-element sequence (batch=1),
+        # matching the Wan/Mochi runners' batch-axis return.
+        return [
+            VideoWithAudio(
+                frames=frames,
+                audio=audio,
+                sample_rate=out.sampling_rate,
+                fps=out.fps,
+            )
+        ]
 
     def get_pipeline_device_params(self):
         return _minimax_h3_dit_device_params(self.settings.device_mesh_shape)

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -1342,6 +1342,18 @@ class TTMiniMaxH3Runner(TTDiTRunner):
             self.logger.info(
                 f"Device {self.device_id}: enabled denoise trace-capture for mesh {mesh}"
             )
+        # Memory-tight small meshes: evict stages between phases (coresident=False) instead of keeping
+        # all three resident. Upstream defaults untuned shapes to coresident=True, which keeps the
+        # transformer resident AND accumulating its per-request cached buffers (the padded-sequence
+        # zero rows) across jobs -> a per-job DRAM leak that OOMs/wedges after ~10 back-to-back renders.
+        # Eviction drops those buffers each phase (cost: a ~1s per-shape rebuild). H3_CORESIDENT=1 forces
+        # the resident path back for A/B or on a roomier mesh.
+        if os.environ.get("H3_CORESIDENT", "0") != "1" and not is_large_mesh(mesh):
+            try:
+                pipe.coresident = False
+                self.logger.info(f"Device {self.device_id}: coresident=False (evict stages) for mesh {mesh}")
+            except Exception as e:
+                self.logger.debug(f"Device {self.device_id}: could not set coresident: {e}")
         return pipe
 
     def load_weights(self):

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -1216,7 +1216,13 @@ def _minimax_h3_pipeline_args(request: VideoGenerateRequest, resolution) -> dict
     def _snap_len(n):
         n = max(22, int(n))  # 17n+5 grid, n>=1 -> 22 frames minimum
         k = max(1, round((n - 5) / 17.0))
-        return min(17 * k + 5, 362)  # ~15 s cap
+        # Hard duration ceiling. On the 1x4, clips beyond ~5 s (124f) OOM unreliably: the VAE decode
+        # buffer scales with FRAME COUNT (not resolution), so downscaling the picture doesn't save a
+        # 10 s clip -- it needs a ~79 MB contiguous DRAM block the fragmented free space can't provide.
+        # Default 124 (~5.2 s) is the proven-robust max; H3_MAX_FRAMES raises it on a roomier mesh /
+        # after bf8 frees DRAM. Legacy allowed ~15 s; that needs more DRAM headroom, not a bigger cap.
+        cap = int(os.environ.get("H3_MAX_FRAMES", "124"))
+        return min(17 * k + 5, cap)
 
     w = _snap32(request.width) if getattr(request, "width", None) else resolution.width
     h = _snap32(request.height) if getattr(request, "height", None) else resolution.height

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -7,15 +7,18 @@ import base64
 import io
 import os
 from abc import abstractmethod
+from dataclasses import dataclass
 
 import numpy as np
 import ttnn
 from config.constants import (
+    MINIMAX_H3_NUM_FRAMES,
     WAN22_NUM_FRAMES,
     ModelRunners,
     ModelServices,
     SupportedModels,
     is_large_mesh,
+    minimax_h3_target_resolution,
     wan22_target_resolution,
 )
 from config.settings import get_settings
@@ -25,6 +28,7 @@ from domain.video_i2v_generate_request import ImagePromptEntry, VideoI2VGenerate
 from huggingface_hub import hf_hub_download
 from models.common.utility_functions import is_blackhole
 from models.tt_dit.pipelines.flux1.pipeline_flux1 import Flux1Pipeline
+from models.tt_dit.pipelines.minimax_h3.pipeline_minimax_h3 import MiniMaxH3Pipeline
 from models.tt_dit.pipelines.mochi.pipeline_mochi import MochiPipeline
 from models.tt_dit.pipelines.motif.pipeline_motif import MotifPipeline
 from models.tt_dit.pipelines.qwenimage.pipeline_qwenimage import (
@@ -61,6 +65,7 @@ dit_runner_log_map = {
     ModelRunners.TT_WAN_2_2_I2V_LIGHTNING.value: "Wan22-I2V-Lightning",
     ModelRunners.TT_QWEN_IMAGE.value: "Qwen-Image",
     ModelRunners.TT_QWEN_IMAGE_2512.value: "Qwen-Image-2512",
+    ModelRunners.TT_MINIMAX_H3.value: "MiniMax-H3",
     ModelRunners.SP_RUNNER.value: "SP-Runner",
 }
 
@@ -1138,3 +1143,117 @@ class TTWan22I2VLightningRunner(TTDiTRunner):
 
     def _build_warmup_video_request(self) -> VideoI2VGenerateRequest:
         return _wan22_i2v_warmup_request()
+
+
+# ---------------------------------------------------------------------------
+# MiniMax-H3 (text -> video + native stereo audio)
+#
+# H3 is the first video model here that also emits audio, so its runner returns
+# both streams (VideoWithAudio) and the exporter muxes the audio into the mp4
+# (utils/video_manager.export_to_mp4). Everything else mirrors the Wan/Mochi
+# DiT runner pattern and drives the upstream tt_dit MiniMax-H3 pipeline.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VideoWithAudio:
+    """Runner result carrying both streams.
+
+    ``export_to_mp4`` already special-cases an object exposing ``.frames``;
+    returning this (instead of a bare frame array) is how the audio reaches the
+    muxer without changing the video worker/service call sites.
+    """
+
+    frames: np.ndarray  # (T, H, W, 3) uint8  -- MiniMaxH3Output.frames
+    audio: np.ndarray  # (2, N) float32 [-1, 1] -- MiniMaxH3Output.audio (stereo)
+    sample_rate: int  # MiniMaxH3Output.sampling_rate (e.g. 32000)
+
+
+# Explicit parallel params for the small Blackhole meshes upstream does not yet
+# preset (its _PRESETS_BH covers only (4, 8) galaxy and (4, 32) quad). Values
+# from a validated 1x4 Blackhole run; (2, 2) mirrors the same factors and is
+# still to be validated on hardware. Remove an entry once it lands as a real
+# upstream _PRESETS_BH row and create_pipeline can resolve it from the mesh.
+_MINIMAX_H3_SMALL_MESH_PARAMS = {
+    (1, 4): dict(tp_axis=1, sp_axis=0, num_links=2, topology=None),
+    (2, 2): dict(tp_axis=1, sp_axis=0, num_links=2, topology=None),
+}
+
+
+def _minimax_h3_dit_device_params(mesh_shape: tuple) -> dict:
+    """Fabric / trace-region policy for MiniMax-H3, mirroring the Wan2.2 helper.
+
+    Blackhole uses RELAXED_INIT; large (galaxy-class) meshes get the bigger
+    trace region and the galaxy router config. Small meshes use plain FABRIC_1D.
+    """
+    device_params = _wan22_dit_device_params(mesh_shape)
+    if is_large_mesh(mesh_shape) and is_blackhole():
+        # H3's DiT trace is comparable to Wan2.2's; reuse the galaxy bump.
+        device_params["trace_region_size"] = WAN22_GALAXY_BH_TRACE_REGION_BYTES
+    return device_params
+
+
+def _minimax_h3_pipeline_args(request: VideoGenerateRequest, resolution) -> dict:
+    """Map an OpenAI-style VideoGenerateRequest onto the upstream __call__.
+
+    H3 is guidance-distilled (cfg=1), so there is no guidance_scale. An I2V/fl2va
+    variant would additionally decode request.image_prompts into ``image=`` /
+    ``last_image=`` (first-frame conditioning).
+    """
+    seed = int(request.seed) if request.seed is not None else 0
+    return dict(
+        prompt=request.prompt,
+        num_inference_steps=request.num_inference_steps,
+        num_frames=MINIMAX_H3_NUM_FRAMES,
+        height=resolution.height,
+        width=resolution.width,
+        seed=seed,
+    )
+
+
+class TTMiniMaxH3Runner(TTDiTRunner):
+    """MiniMax-H3 t2va (text -> video + native stereo audio) on the upstream pipeline."""
+
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        self.resolution = minimax_h3_target_resolution(self.settings.device_mesh_shape)
+
+    def create_pipeline(self):
+        mesh = tuple(self.settings.device_mesh_shape)
+        # {} on (4, 8) / (4, 32): let the upstream _PRESETS_BH pick the shape.
+        overrides = _MINIMAX_H3_SMALL_MESH_PARAMS.get(mesh, {})
+        try:
+            return MiniMaxH3Pipeline.create_pipeline(
+                mesh_device=self.ttnn_device,
+                weights_dir=self.settings.model_weights_path,
+                task="t2va",
+                **overrides,
+            )
+        except Exception as e:
+            log_exception_chain(
+                self.logger,
+                self.device_id,
+                "MiniMax-H3 pipeline creation failed",
+                e,
+            )
+            raise
+
+    def load_weights(self):
+        return False  # weights load during pipeline creation (as Wan/Mochi)
+
+    @log_execution_time(
+        f"{dit_runner_log_map[get_settings().model_runner]} inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    def run(self, requests: list[VideoGenerateRequest]):
+        self.logger.debug(f"Device {self.device_id}: Running inference")
+        out = self.pipeline(**_minimax_h3_pipeline_args(requests[0], self.resolution))
+        self.logger.debug(f"Device {self.device_id}: Inference completed")
+        # Return both streams so the exporter muxes the audio into the mp4.
+        return VideoWithAudio(
+            frames=out.frames, audio=out.audio, sample_rate=out.sampling_rate
+        )
+
+    def get_pipeline_device_params(self):
+        return _minimax_h3_dit_device_params(self.settings.device_mesh_shape)

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -1333,7 +1333,11 @@ class TTMiniMaxH3Runner(TTDiTRunner):
             raise
         # Upstream auto-enables denoise trace-capture only for the quad galaxy; enable it for our
         # small mesh too (eager denoise is host-dispatch-bound). First gen per (shape, steps) captures.
-        if getattr(pipe, "trace_denoise", None) is False and not is_large_mesh(mesh):
+        if (
+            os.environ.get("H3_TRACE_DENOISE", "0") == "1"
+            and getattr(pipe, "trace_denoise", None) is False
+            and not is_large_mesh(mesh)
+        ):
             pipe.trace_denoise = True
             self.logger.info(
                 f"Device {self.device_id}: enabled denoise trace-capture for mesh {mesh}"

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -1207,29 +1207,111 @@ def _minimax_h3_pipeline_args(request: VideoGenerateRequest, resolution) -> dict
     ``last_image=`` (first-frame conditioning).
     """
     seed = int(request.seed) if request.seed is not None else 0
+
+    # Output geometry: an explicit request overrides the mesh default, clamped to the H3 envelope
+    # (short edge <= 768, long edge <= 1344, snapped to /32; duration on the 17n+5 grid, <= ~15 s).
+    def _snap32(x):
+        return max(32, int(round(float(x) / 32.0)) * 32)
+
+    def _snap_len(n):
+        n = max(22, int(n))  # 17n+5 grid, n>=1 -> 22 frames minimum
+        k = max(1, round((n - 5) / 17.0))
+        return min(17 * k + 5, 362)  # ~15 s cap
+
+    w = _snap32(request.width) if getattr(request, "width", None) else resolution.width
+    h = _snap32(request.height) if getattr(request, "height", None) else resolution.height
+    lo, hi = min(w, h), max(w, h)
+    lo, hi = min(lo, 768), min(hi, 1344)
+    w, h = (lo, hi) if w <= h else (hi, lo)
+
+    nf_default = int(os.environ.get("H3_NUM_FRAMES", MINIMAX_H3_NUM_FRAMES))
+    num_frames = _snap_len(request.num_frames) if getattr(request, "num_frames", None) else nf_default
+
+    # Cap pixel*frame load and downscale resolution to fit (keeping duration), like the legacy
+    # max_load. On the 1x4 this is set by DRAM *fragmentation*: a large (~63M, 10s@512) decode
+    # fragments the free space so the NEXT large clip OOMs; clips in the ~42M zone run back-to-back
+    # indefinitely. So 5s stays full-res, 10s renders ~415^2. Raise H3_MAX_LOAD on a roomier mesh.
+    max_load = int(os.environ.get("H3_MAX_LOAD", "42000000"))
+    load = w * h * num_frames
+    if load > max_load:
+        scale = (max_load / load) ** 0.5
+        w = max(256, int(w * scale) // 32 * 32)
+        h = max(256, int(h * scale) // 32 * 32)
+
     return dict(
         prompt=request.prompt,
         num_inference_steps=request.num_inference_steps,
-        num_frames=MINIMAX_H3_NUM_FRAMES,
-        height=resolution.height,
-        width=resolution.width,
+        num_frames=num_frames,
+        height=h,
+        width=w,
         seed=seed,
     )
 
 
+# Per-step progress: the media-server job API is coarse and the upstream pipeline exposes no
+# callback, but its denoise loop calls module-level build_row_timesteps once per step. Wrap it to
+# publish {phase, step, total} to a file keyed by the job id (the bot reads it for a live bar).
+_H3_PROGRESS_DIR = os.environ.get("H3_PROGRESS_DIR", "/tmp/h3-progress")
+_h3_progress = {"key": None, "step": 0, "total": 0}
+
+
+def _h3_write_progress(phase: str) -> None:
+    key = _h3_progress["key"]
+    if not key:
+        return
+    try:
+        import json
+
+        os.makedirs(_H3_PROGRESS_DIR, exist_ok=True)
+        path = os.path.join(_H3_PROGRESS_DIR, f"{key}.json")
+        tmp = f"{path}.tmp"
+        with open(tmp, "w") as f:
+            f.write(
+                json.dumps(
+                    {"phase": phase, "step": _h3_progress["step"], "total": _h3_progress["total"]}
+                )
+            )
+        os.replace(tmp, path)
+    except Exception:
+        pass
+
+
+def _h3_install_progress_hook() -> None:
+    from models.tt_dit.pipelines.minimax_h3 import pipeline_minimax_h3 as _pm
+
+    if getattr(_pm, "_brt_progress_wrapped", False):
+        return
+    _orig = _pm.build_row_timesteps
+
+    def _wrapped(*args, **kwargs):
+        _h3_progress["step"] += 1
+        _h3_write_progress("denoising")
+        return _orig(*args, **kwargs)
+
+    _pm.build_row_timesteps = _wrapped
+    _pm._brt_progress_wrapped = True
+
+
+_h3_install_progress_hook()
+
+
 class TTMiniMaxH3Runner(TTDiTRunner):
-    """MiniMax-H3 t2va (text -> video + native stereo audio) on the upstream pipeline."""
+    """MiniMax-H3 on the upstream pipeline. One runner serves both t2va (text -> video+audio) and
+    fl2va (keyframe -> video+audio): /generations/i2v routes here with image_prompts, which run()
+    decodes into the pipeline's image=/last_image=. (Kept out of I2V_MODEL_RUNNERS so t2v isn't
+    rejected.)"""
 
     def __init__(self, device_id: str):
         super().__init__(device_id)
         self.resolution = minimax_h3_target_resolution(self.settings.device_mesh_shape)
+        self.image_manager = ImageManager()
 
     def create_pipeline(self):
         mesh = tuple(self.settings.device_mesh_shape)
         # {} on (4, 8) / (4, 32): let the upstream _PRESETS_BH pick the shape.
         overrides = _MINIMAX_H3_SMALL_MESH_PARAMS.get(mesh, {})
         try:
-            return MiniMaxH3Pipeline.create_pipeline(
+            pipe = MiniMaxH3Pipeline.create_pipeline(
                 mesh_device=self.ttnn_device,
                 weights_dir=self.settings.model_weights_path,
                 task="t2va",
@@ -1243,6 +1325,14 @@ class TTMiniMaxH3Runner(TTDiTRunner):
                 e,
             )
             raise
+        # Upstream auto-enables denoise trace-capture only for the quad galaxy; enable it for our
+        # small mesh too (eager denoise is host-dispatch-bound). First gen per (shape, steps) captures.
+        if getattr(pipe, "trace_denoise", None) is False and not is_large_mesh(mesh):
+            pipe.trace_denoise = True
+            self.logger.info(
+                f"Device {self.device_id}: enabled denoise trace-capture for mesh {mesh}"
+            )
+        return pipe
 
     def load_weights(self):
         return False  # weights load during pipeline creation (as Wan/Mochi)
@@ -1254,14 +1344,39 @@ class TTMiniMaxH3Runner(TTDiTRunner):
     )
     def run(self, requests: list[VideoGenerateRequest]):
         self.logger.debug(f"Device {self.device_id}: Running inference")
-        out = self.pipeline(**_minimax_h3_pipeline_args(requests[0], self.resolution))
-        self.logger.debug(f"Device {self.device_id}: Inference completed")
-        # MiniMaxH3Output.video is (1, 3, F, H, W) float in [0, 1]; the exporter
-        # wants (F, H, W, 3) uint8 (channels-last). audio is (1, 2, samples) ->
-        # (2, samples). Return both so the exporter muxes the audio into the mp4.
+        req = requests[0]
+        # Arm per-step progress for this job (key == API job id == request._task_id).
+        _h3_progress["key"] = getattr(req, "_task_id", None)
+        _h3_progress["step"] = 0
+        _h3_progress["total"] = int(getattr(req, "num_inference_steps", None) or 8)
+        _h3_write_progress("starting")
+
+        args = _minimax_h3_pipeline_args(req, self.resolution)
+        # fl2va: /generations/i2v routes here with image_prompts; decode the first (and optional
+        # last) keyframe into image=/last_image=. Absent -> plain t2va.
+        image_prompts = getattr(req, "image_prompts", None)
+        if image_prompts:
+            tgt = (args["width"], args["height"])
+            entries = sorted(image_prompts, key=lambda e: e.frame_pos)
+            args["image"] = self.image_manager.base64_to_pil_image(
+                entries[0].image, target_size=tgt, target_mode="RGB"
+            )
+            if len(entries) > 1 and entries[-1].frame_pos >= args["num_frames"] - 1:
+                args["last_image"] = self.image_manager.base64_to_pil_image(
+                    entries[-1].image, target_size=tgt, target_mode="RGB"
+                )
+
+        try:
+            out = self.pipeline(**args)
+            _h3_progress["step"] = _h3_progress["total"]
+            _h3_write_progress("decoding")
+        finally:
+            self.logger.debug(f"Device {self.device_id}: Inference completed")
+        # MiniMaxH3Output.video is (1, 3, F, H, W) float in [0, 1] -> (F, H, W, 3) uint8; audio is
+        # (1, 2, samples) -> (2, samples). Return both so the exporter muxes the audio into the mp4.
         frames = (
-            out.video[0]  # (3, F, H, W)
-            .permute(1, 2, 3, 0)  # (F, H, W, 3)
+            out.video[0]
+            .permute(1, 2, 3, 0)
             .clamp(0, 1)
             .mul(255)
             .round()
@@ -1269,10 +1384,11 @@ class TTMiniMaxH3Runner(TTDiTRunner):
             .numpy()
             .astype(np.uint8)
         )
-        audio = out.audio[0].to("cpu").numpy()  # (2, samples)
-        # The device worker indexes the return per-request (``responses[i]``) and
-        # checks ``len(responses)``, so return a one-element sequence (batch=1),
-        # matching the Wan/Mochi runners' batch-axis return.
+        audio = out.audio[0].to("cpu").numpy()
+        # Free per-shape device state so a different-shape next job doesn't OOM the tight mesh.
+        self._release_per_shape_state()
+        # Device worker indexes the return per-request (responses[i]) and checks len(responses),
+        # so return a one-element sequence (batch=1), like the Wan/Mochi runners.
         return [
             VideoWithAudio(
                 frames=frames,
@@ -1281,6 +1397,32 @@ class TTMiniMaxH3Runner(TTDiTRunner):
                 fps=out.fps,
             )
         ]
+
+    def _release_per_shape_state(self) -> None:
+        """Drop per-(H, W, frames) device buffers between renders so varying geometry doesn't OOM.
+
+        Best-effort: the denoise trace (re-captured cheaply) and the VAE's per-shape decoder cache
+        (rebuilt in ~1 s), then force reclaim. Resident text/DiT weights are untouched.
+        """
+        pipe = self.pipeline
+        try:
+            pipe.release_traces()
+        except Exception as e:
+            self.logger.debug(f"Device {self.device_id}: release_traces skipped: {e}")
+        try:
+            vae = getattr(pipe, "_vae", None)
+            decoders = getattr(vae, "_decoders", None)
+            if decoders:
+                decoders.clear()
+        except Exception as e:
+            self.logger.debug(f"Device {self.device_id}: vae decoder clear skipped: {e}")
+        try:
+            import gc
+
+            gc.collect()
+            ttnn.synchronize_device(self.ttnn_device)
+        except Exception as e:
+            self.logger.debug(f"Device {self.device_id}: reclaim skipped: {e}")
 
     def get_pipeline_device_params(self):
         return _minimax_h3_dit_device_params(self.settings.device_mesh_shape)

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -43,6 +43,9 @@ AVAILABLE_RUNNERS = {
     ModelRunners.TT_WAN_2_2: lambda wid: __import__(
         "tt_model_runners.dit_runners", fromlist=["TTWan22Runner"]
     ).TTWan22Runner(wid),
+    ModelRunners.TT_MINIMAX_H3: lambda wid: __import__(
+        "tt_model_runners.dit_runners", fromlist=["TTMiniMaxH3Runner"]
+    ).TTMiniMaxH3Runner(wid),
     ModelRunners.TT_WAN_2_2_T2V_PRODIA: lambda wid: __import__(
         "tt_model_runners.dit_runners", fromlist=["TTWan22T2VProdiaRunner"]
     ).TTWan22T2VProdiaRunner(wid),

--- a/tt-media-server/utils/video_manager.py
+++ b/tt-media-server/utils/video_manager.py
@@ -61,12 +61,16 @@ class VideoManager:
             TT_VIDEO_EXPORT_CRF: 0–51, lower = better quality. Default 23.
             TT_VIDEO_EXPORT_PRESET: ultrafast … veryslow. Default medium.
         """
-        # Pull audio off a result object (e.g. VideoWithAudio) before it is
-        # collapsed to a bare frame array below. Explicit args take precedence.
+        # Pull audio (and the model's frame rate) off a result object (e.g.
+        # VideoWithAudio) before it is collapsed to a bare frame array below.
+        # Explicit args take precedence.
         if audio is None and hasattr(frames, "audio"):
             audio = frames.audio
             if sample_rate is None:
                 sample_rate = getattr(frames, "sample_rate", None)
+        _obj_fps = getattr(frames, "fps", None)
+        if _obj_fps:
+            fps = int(_obj_fps)
         if hasattr(frames, "frames"):
             frames = frames.frames
 

--- a/tt-media-server/utils/video_manager.py
+++ b/tt-media-server/utils/video_manager.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import subprocess
 import uuid
+import wave
 from pathlib import Path
 
 import numpy as np
@@ -19,6 +20,8 @@ _MIN_CRF = 0
 _MAX_CRF = 51
 _FFMPEG_ENCODE_TIMEOUT_S = 600
 _FFMPEG_REMUX_TIMEOUT_S = 60
+_FFMPEG_MUX_TIMEOUT_S = 120
+_AUDIO_AAC_BITRATE = "192k"
 _VIDEO_OUTPUT_DIR = Path("/tmp/videos")
 _VALID_CHANNEL_COUNTS = (1, 3, 4)
 _RGB_CHANNELS = 3
@@ -33,17 +36,37 @@ class VideoManager:
         self._logger = TTLogger()
 
     @log_execution_time("Exporting video to MP4")
-    def export_to_mp4(self, frames: NDArray, fps: int = 16) -> str:
+    def export_to_mp4(
+        self,
+        frames: NDArray,
+        fps: int = 16,
+        audio: NDArray | None = None,
+        sample_rate: int | None = None,
+    ) -> str:
         """
-        Export frames to MP4 (H.264 via ffmpeg).
+        Export frames to MP4 (H.264 via ffmpeg), optionally muxing an audio track.
 
         Frames are streamed to ffmpeg one at a time so encoding overlaps with
         Python-side dtype conversion, avoiding large temporary allocations.
+
+        Audio is optional and fully backward-compatible: silent models pass
+        ``audio=None`` and get exactly the previous video-only output. When the
+        runner returns an object exposing ``.frames`` and ``.audio`` (e.g. an
+        audio-capable video model such as MiniMax-H3), the audio is pulled off
+        that object automatically. When present, the encoded video is muxed with
+        an AAC track via a second ffmpeg pass; the API contract is unchanged
+        (still one ``video/mp4``, now with sound).
 
         Env (optional):
             TT_VIDEO_EXPORT_CRF: 0–51, lower = better quality. Default 23.
             TT_VIDEO_EXPORT_PRESET: ultrafast … veryslow. Default medium.
         """
+        # Pull audio off a result object (e.g. VideoWithAudio) before it is
+        # collapsed to a bare frame array below. Explicit args take precedence.
+        if audio is None and hasattr(frames, "audio"):
+            audio = frames.audio
+            if sample_rate is None:
+                sample_rate = getattr(frames, "sample_rate", None)
         if hasattr(frames, "frames"):
             frames = frames.frames
 
@@ -60,11 +83,65 @@ class VideoManager:
         try:
             cmd = self._build_encode_cmd(frames, output_path, fps, crf, preset)
             self._stream_to_ffmpeg(cmd, frames)
+
+            if audio is not None and sample_rate:
+                output_path = self._mux_audio_into_mp4(
+                    output_path, audio, int(sample_rate)
+                )
             return output_path
 
         except Exception as e:
             self._logger.error(f"Video export failed: {e}")
             raise RuntimeError(f"Failed to export video: {e}") from e
+
+    def _mux_audio_into_mp4(
+        self, video_path: str, audio: NDArray, sample_rate: int
+    ) -> str:
+        """Mux a stereo/mono audio track into an already-encoded silent mp4.
+
+        Writes the audio to a temp WAV, then remuxes with ``-c:v copy -c:a aac``
+        (video is not re-encoded). Returns the path to the muxed file and removes
+        the silent intermediate. On any failure the original silent video is
+        kept and returned, so audio never breaks video delivery.
+        """
+        wav_path = str(_VIDEO_OUTPUT_DIR / f"{uuid.uuid4()}.wav")
+        muxed_path = str(_VIDEO_OUTPUT_DIR / f"{uuid.uuid4()}.mp4")
+        try:
+            channels = _write_wav(audio, sample_rate, wav_path)
+            cmd = [
+                "ffmpeg",
+                "-y",
+                "-i",
+                video_path,
+                "-i",
+                wav_path,
+                "-c:v",
+                "copy",
+                "-c:a",
+                "aac",
+                "-b:a",
+                _AUDIO_AAC_BITRATE,
+                "-ac",
+                str(channels),
+                "-map",
+                "0:v:0",
+                "-map",
+                "1:a:0",
+                "-shortest",
+                "-movflags",
+                "+faststart",
+                muxed_path,
+            ]
+            self._run_ffmpeg(cmd, timeout=_FFMPEG_MUX_TIMEOUT_S)
+        except Exception as e:
+            self._logger.error(f"Audio mux failed, keeping silent video: {e}")
+            _safe_unlink(muxed_path)
+            return video_path
+        finally:
+            _safe_unlink(wav_path)
+
+        _safe_unlink(video_path)
+        return muxed_path
 
     @staticmethod
     def _build_encode_cmd(
@@ -231,3 +308,51 @@ def _normalize_dtype_single(frame: NDArray) -> NDArray[np.uint8]:
         return frame.clip(0, 255).astype(np.uint8)
 
     return frame.clip(0, 255).astype(np.uint8)
+
+
+def _audio_to_int16_frames(audio: NDArray) -> tuple[NDArray, int]:
+    """Normalize an audio array to interleaved int16 (num_samples, channels).
+
+    Accepts mono ``(N,)``, or 2D in either layout — channels-first ``(C, N)``
+    (the model's native stereo shape) or samples-first ``(N, C)``. Float input
+    in [-1, 1] is scaled to int16; integer input is passed through as int16.
+    """
+    audio = np.asarray(audio)
+    if audio.ndim == 1:
+        audio = audio[:, np.newaxis]  # (N, 1)
+    elif audio.ndim == 2:
+        rows, cols = audio.shape
+        # Channels-first if the first axis is the small one (1 or 2) and clearly
+        # shorter than the sample axis.
+        if rows in (1, 2) and rows < cols:
+            audio = audio.T  # (C, N) -> (N, C)
+    else:
+        raise ValueError(f"Unexpected audio dimensions: {audio.shape}")
+
+    if np.issubdtype(audio.dtype, np.floating):
+        audio = np.clip(audio, -1.0, 1.0)
+        audio = (audio * 32767.0).round().astype(np.int16)
+    else:
+        audio = audio.astype(np.int16)
+
+    channels = audio.shape[1]
+    return np.ascontiguousarray(audio), channels
+
+
+def _write_wav(audio: NDArray, sample_rate: int, path: str) -> int:
+    """Write audio to a 16-bit PCM WAV file. Returns the channel count."""
+    frames, channels = _audio_to_int16_frames(audio)
+    with wave.open(path, "wb") as wav:
+        wav.setnchannels(channels)
+        wav.setsampwidth(2)  # int16
+        wav.setframerate(int(sample_rate))
+        wav.writeframes(frames.tobytes())
+    return channels
+
+
+def _safe_unlink(path: str) -> None:
+    """Remove a file if it exists, ignoring errors (best-effort cleanup)."""
+    try:
+        os.remove(path)
+    except OSError:
+        pass


### PR DESCRIPTION
> **Draft.** Config wiring + the audio-in-mp4 shared-infra change are tested (9/9 locally, incl. real ffmpeg mux verified with ffprobe). The **on-device runner path is untested** — it needs the built media-server image, H3 weights, and a Blackhole mesh. Opening for design review while hardware validation is arranged with the upstream MiniMax-H3 owners.

### What this adds

A `tt-media-server` **VIDEO runner for MiniMax-H3** that drives the **upstream** `tt_dit` MiniMax-H3 pipeline (`models/tt_dit/pipelines/minimax_h3`) — it does **not** vendor a parallel port. MiniMax-H3 is text → **video + native stereo audio**, the first video model here that also emits sound.

### Changes

| Area | Change |
|---|---|
| `config/constants.py` | `SupportedModels`/`ModelNames`/`ModelRunners.MINIMAX_H3`; register in the VIDEO service map + runner→names map; `MINIMAX_H3_NUM_FRAMES` + `minimax_h3_target_resolution`; `ModelConfigs` rows for **1-to-many Blackhole** — `P150X4` (1,4), `P300X2` (2,2), `GALAXY` (4,8) |
| `tt_model_runners/dit_runners.py` | `TTMiniMaxH3Runner` (mirrors the Wan/Mochi DiT runners) + `VideoWithAudio` result + device-param/pipeline-arg helpers |
| `tt_model_runners/runner_fabric.py` | register `TT_MINIMAX_H3` |
| `utils/video_manager.py` | `export_to_mp4` gains an **optional audio track** (2nd ffmpeg pass, `-c:v copy -c:a aac`); backward-compatible — silent models pass `audio=None` and get the exact previous output; auto-pulls audio off a `VideoWithAudio` result |
| `tests/test_minimax_h3_runner.py` | config-wiring + audio-mux tests (no hardware) and a ttnn-gated runner-registration test (container/CI) |

### The audio-in-mp4 change (the one shared-infra piece — wants review)

`export_to_mp4(frames)` is video-only today. This makes it `export_to_mp4(frames, audio=None, sample_rate=None)`: when audio is present, the encoded video is remuxed with an AAC track (`-map 0:v -map 1:a -shortest`). **Fully backward-compatible** — every existing silent model is untouched, the `POST /v1/videos/generations` contract is unchanged (still one `video/mp4`, now with sound). This sets the precedent for future audio-capable video models.

### Two things to settle with the maintainers / upstream H3 owners

1. **Small-mesh presets.** Upstream `_PRESETS_BH` covers only `(4,8)` galaxy and `(4,32)` quad — there is **no single-QB2 / small-BH preset**. The runner supplies explicit `tp/sp/num_links` for `(1,4)`/`(2,2)` in the meantime; longer term these should land as real `_PRESETS_BH` rows. The `(1,4)` values come from a validated 1×4 Blackhole run; `(2,2)` still needs hardware validation.
2. **Ownership / device matrix.** Confirm nobody else is building this runner, and that the `ModelConfigs` rows match your validated meshes.

### Testing

- **Local (this PR, no hardware): 9/9** — config wiring resolves through the real settings resolver (`MODEL_RUNNER=tt-minimax-h3` + `DEVICE=p150x4` → `(1,4)` / `device_ids=(0,1,2,3)` / `MiniMaxAI/MiniMax-H3`); audio mux produces an mp4 whose `ffprobe` shows both a video **and** an AAC audio stream; video-only path still emits no audio stream; WAV writer handles mono / `(C,N)` / `(N,C)` layouts.
- **Container/CI:** the ttnn-gated runner-registration test runs in the built image.
- **Not yet run:** full on-device generate (needs image + weights + Blackhole mesh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)