### PR TITLE
Make sure to not copy during prefill

### DIFF
--- a/tt-media-server/cpp_server/include/domain/prefix_cache/block_matcher.hpp
+++ b/tt-media-server/cpp_server/include/domain/prefix_cache/block_matcher.hpp
@@ -42,7 +42,9 @@ class BlockMatcher {
 
   static std::optional<Candidate> findSlotToCopyFrom(
       const std::vector<Candidate>& candidates,
-      std::function<uint32_t(const std::string& sessionId)> getCommittedBlocks);
+      std::function<uint32_t(const std::string& sessionId)> getCommittedBlocks,
+      std::function<bool(const std::string& sessionId)> isCopyEligible =
+          nullptr);
 };
 
 }  // namespace tt::domain::prefix_cache

--- a/tt-media-server/cpp_server/include/domain/session.hpp
+++ b/tt-media-server/cpp_server/include/domain/session.hpp
@@ -18,8 +18,10 @@
 #include "utils/conversation_hasher.hpp"
 
 namespace tt::services {
-class SessionManager;  // friend: owns the locked state transitions below
-}
+class SessionManager;     // friend: owns the locked state transitions below
+class PrefixCacheRouter;  // friend: sets being_generated_ via
+                          // registerPrefixHash
+}  // namespace tt::services
 
 namespace tt::domain {
 
@@ -99,6 +101,8 @@ class Session {
     if (blocks < committed_blocks_) committed_blocks_ = blocks;
   }
 
+  bool isBeingGenerated() const { return being_generated_; }
+
   void setCancelFn(std::function<void()> fn) { cancelFn_ = std::move(fn); }
   std::function<void()> takeCancelFn() {
     return std::exchange(cancelFn_, nullptr);
@@ -172,6 +176,7 @@ class Session {
   // eviction data race. Each returns false (state unchanged) if its
   // precondition is not met.
   friend class tt::services::SessionManager;
+  friend class tt::services::PrefixCacheRouter;
   bool markPrepared();   // IDLE           -> PREPARED
   bool markInFlight();   // IDLE/PREPARED  -> IN_FLIGHT
   bool clearInFlight();  // IN_FLIGHT      -> IDLE, also clears cancelFn
@@ -186,6 +191,8 @@ class Session {
   SessionState state_{SessionState::IDLE};
   uint32_t committed_blocks_{
       0};  // resident prefix block count (see committedBlocks)
+  bool being_generated_{true};  // true until first registerPrefixHash via
+                                // initTokenAccumulator completes
   std::chrono::system_clock::time_point last_activity_time_;
   std::function<void()> cancelFn_;
   std::function<void()>

--- a/tt-media-server/cpp_server/include/services/prefix_cache_router.hpp
+++ b/tt-media-server/cpp_server/include/services/prefix_cache_router.hpp
@@ -121,7 +121,8 @@ class PrefixCacheRouter {
       const std::string& previousResponseId, std::function<void()> cancelFn);
 
   void registerPrefixHash(const std::string& sessionId,
-                          const std::vector<utils::BlockHashInfo>& blockInfos);
+                          const std::vector<utils::BlockHashInfo>& blockInfos,
+                          bool clearBeingGenerated = false);
 
   void registerResponseId(const std::string& sessionId,
                           const std::string& responseId);

--- a/tt-media-server/cpp_server/include/services/session_manager.hpp
+++ b/tt-media-server/cpp_server/include/services/session_manager.hpp
@@ -169,7 +169,8 @@ class SessionManager {
    * removed from that hash's index entry first.
    */
   void registerPrefixHash(const std::string& sessionId,
-                          const std::vector<utils::BlockHashInfo>& blockInfos);
+                          const std::vector<utils::BlockHashInfo>& blockInfos,
+                          bool clearBeingGenerated = false);
 
   /**
    * Response-id continuation lookup.

--- a/tt-media-server/cpp_server/src/domain/prefix_cache/block_matcher.cpp
+++ b/tt-media-server/cpp_server/src/domain/prefix_cache/block_matcher.cpp
@@ -150,11 +150,20 @@ BlockMatcher::computeMatchedBlocksForSession(
 
 std::optional<Candidate> BlockMatcher::findSlotToCopyFrom(
     const std::vector<Candidate>& candidates,
-    std::function<uint32_t(const std::string& sessionId)> getCommittedBlocks) {
+    std::function<uint32_t(const std::string& sessionId)> getCommittedBlocks,
+    std::function<bool(const std::string& sessionId)> isCopyEligible) {
   const std::size_t minTokens = tt::config::minTokensToCopy();
 
   for (const auto& candidate : candidates) {
     if (candidate.matchedBlocks == 0) {
+      continue;
+    }
+
+    if (isCopyEligible && !isCopyEligible(candidate.sessionId)) {
+      TT_LOG_DEBUG(
+          "[BlockMatcher] findSlotToCopyFrom: candidate sessionId={} is not "
+          "copy-eligible, skipping",
+          candidate.sessionId);
       continue;
     }
 

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -69,6 +69,7 @@ void Session::initTokenAccumulator(
   onComplete_ = std::move(onComplete);
   onNoHashes_ = std::move(onNoHashes);
   generatedTokens_.clear();
+  being_generated_ = true;
 
   // Initialize thinking token tracking
   auto [thinkStart, thinkEnd] = utils::tokenizers::thinkTokenIds();

--- a/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_pipeline.cpp
@@ -165,7 +165,8 @@ void LLMPipeline::resolveSession(
               std::move(fullPrompt), /*initialBlocks=*/{},
               [mgr](const std::string& sessionId,
                     const std::vector<tt::utils::BlockHashInfo>& blocks) {
-                mgr->registerPrefixHash(sessionId, blocks);
+                mgr->registerPrefixHash(sessionId, blocks,
+                                        /*clearBeingGenerated=*/true);
               },
               [mgr](const std::string& sessionId) {
                 mgr->closeSession(sessionId);

--- a/tt-media-server/cpp_server/src/services/prefix_cache_router.cpp
+++ b/tt-media-server/cpp_server/src/services/prefix_cache_router.cpp
@@ -171,7 +171,8 @@ PrefixCacheRouter::tryAcquireByResponseId(const std::string& previousResponseId,
 
 void PrefixCacheRouter::registerPrefixHash(
     const std::string& sessionId,
-    const std::vector<utils::BlockHashInfo>& blockInfos) {
+    const std::vector<utils::BlockHashInfo>& blockInfos,
+    bool clearBeingGenerated) {
   if (blockInfos.empty()) return;
 
   const uint64_t keyHash = blockInfos.front().hash;
@@ -204,6 +205,12 @@ void PrefixCacheRouter::registerPrefixHash(
       "[PrefixCacheRouter] registerPrefixHash: registered sessionId={} under "
       "keyHash={} with {} remaining blocks",
       sessionId, keyHash, blockInfos.size() - 1);
+
+  if (clearBeingGenerated) {
+    if (auto session = callbacks.getSession(sessionId)) {
+      session->being_generated_ = false;
+    }
+  }
 
   if (slotId != tt::domain::INVALID_SLOT_ID) {
     tt::metrics::ServerMetrics::instance().setSlotBlocks(
@@ -412,7 +419,7 @@ void PrefixCacheRouter::getSlot(
         domain::prefix_cache::BlockMatcher::blocksToTokens(best.matchedBlocks);
     if (bestMatchedTokens >= tt::config::minTokensToCopy()) {
       auto session = callbacks.getSession(best.sessionId);
-      if (session) {
+      if (session && !session->isBeingGenerated()) {
         slotToCopyFrom = session->getSlotId();
         copyMatchedTokens = bestMatchedTokens;
         callbacks.lockSlot(*slotToCopyFrom);

--- a/tt-media-server/cpp_server/src/services/session_manager.cpp
+++ b/tt-media-server/cpp_server/src/services/session_manager.cpp
@@ -708,8 +708,10 @@ void SessionManager::shrinkResidentPrefixToMatchedTokens(
 
 void SessionManager::registerPrefixHash(
     const std::string& sessionId,
-    const std::vector<utils::BlockHashInfo>& blockInfos) {
-  prefixCacheRouter->registerPrefixHash(sessionId, blockInfos);
+    const std::vector<utils::BlockHashInfo>& blockInfos,
+    bool clearBeingGenerated) {
+  prefixCacheRouter->registerPrefixHash(sessionId, blockInfos,
+                                        clearBeingGenerated);
 }
 
 std::optional<SessionManager::AcquiredSession>

--- a/tt-media-server/cpp_server/src/services/session_resolution.cpp
+++ b/tt-media-server/cpp_server/src/services/session_resolution.cpp
@@ -26,12 +26,13 @@ std::optional<SlotCopyPlan> prepareSlotCopy(
       [&sessionManager, mode](const std::string& sessionId) -> bool {
         // copy is eligible if the source session is not in-flight (prefill-only
         // mode) or not being generated (decode mode)
+        // or session is not in flight anymore
         auto session = sessionManager.getSession(sessionId);
         if (!session) return false;
         if (mode == tt::config::LLMMode::PREFILL_ONLY) {
           return !session->isInFlight();
         }
-        return !session->isBeingGenerated();
+        return !session->isBeingGenerated() || !session->isInFlight();
       });
   if (!copyCandidate.has_value()) {
     return std::nullopt;

--- a/tt-media-server/cpp_server/src/services/session_resolution.cpp
+++ b/tt-media-server/cpp_server/src/services/session_resolution.cpp
@@ -3,6 +3,7 @@
 
 #include "services/session_resolution.hpp"
 
+#include "config/settings.hpp"
 #include "domain/prefix_cache/block_matcher.hpp"
 #include "utils/logger.hpp"
 
@@ -16,9 +17,21 @@ std::optional<SlotCopyPlan> prepareSlotCopy(
     return std::nullopt;
   }
 
+  const auto mode = tt::config::llmMode();
   auto copyCandidate = domain::prefix_cache::BlockMatcher::findSlotToCopyFrom(
-      candidates, [&sessionManager](const std::string& sessionId) {
+      candidates,
+      [&sessionManager](const std::string& sessionId) {
         return sessionManager.getCommittedBlocks(sessionId);
+      },
+      [&sessionManager, mode](const std::string& sessionId) -> bool {
+        // copy is eligible if the source session is not in-flight (prefill-only
+        // mode) or not being generated (decode mode)
+        auto session = sessionManager.getSession(sessionId);
+        if (!session) return false;
+        if (mode == tt::config::LLMMode::PREFILL_ONLY) {
+          return !session->isInFlight();
+        }
+        return !session->isBeingGenerated();
       });
   if (!copyCandidate.has_value()) {
     return std::nullopt;

--- a/tt-media-server/cpp_server/tests/integration/server/prefill_integration_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/server/prefill_integration_test.cpp
@@ -706,10 +706,8 @@ TEST_F(PrefillIntegrationTest, SlotCopy_TriggeredWhenSessionInFlight) {
     ASSERT_TRUE(received)
         << "Request C: expected ALLOCATE (session is in-flight)";
     EXPECT_EQ(memReq.action, tt::domain::MemoryManagementAction::ALLOCATE);
-    ASSERT_TRUE(memReq.slotIdToCopyFrom.has_value())
-        << "Request C: ALLOCATE should have slotIdToCopyFrom (slot copy)";
-    EXPECT_EQ(*memReq.slotIdToCopyFrom, 0u)
-        << "Request C: slotIdToCopyFrom should be slot 0 (request A's slot)";
+    EXPECT_FALSE(memReq.slotIdToCopyFrom.has_value())
+        << "Request C: in-flight session is not copy-eligible in prefill mode";
 
     // Respond to ALLOCATE: assign slot 1.
     tt::domain::ManageMemoryResult memRes{};
@@ -718,13 +716,11 @@ TEST_F(PrefillIntegrationTest, SlotCopy_TriggeredWhenSessionInFlight) {
     memRes.slotId = 1;
     server->memoryResultQueue().push(memRes);
 
-    // The sequence for C should be flagged as a continuation (slot copy).
+    // No slot copy → C processes the full prompt (not a continuation).
     auto seq = server->taskQueue().receive();
     ASSERT_NE(seq, nullptr) << "Request C: no Sequence";
-    EXPECT_TRUE(seq->isContinuation())
-        << "Request C: must be a continuation (slot copy)";
-    ASSERT_TRUE(seq->getKVPositionId().has_value())
-        << "Request C: slot copy should set kv_position_id";
+    EXPECT_FALSE(seq->isContinuation())
+        << "Request C: must not be a continuation (no slot copy)";
     prefillSlotC = seq->getPrefillKVCacheSlot();
 
     // Complete request C.
@@ -1063,10 +1059,8 @@ TEST_F(PrefillIntegrationTest, SlotCopy_CapsAtCommittedBlocksDuringExtension) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     ASSERT_TRUE(received) << "C: expected ALLOCATE (session in-flight)";
-    ASSERT_TRUE(memReq.slotIdToCopyFrom.has_value())
-        << "C: ALLOCATE should carry slotIdToCopyFrom (slot copy)";
-    EXPECT_EQ(*memReq.slotIdToCopyFrom, sourceSlot)
-        << "C: should copy from the source session's slot";
+    EXPECT_FALSE(memReq.slotIdToCopyFrom.has_value())
+        << "C: in-flight session is not copy-eligible in prefill mode";
 
     tt::domain::ManageMemoryResult memRes{};
     memRes.taskId = memReq.taskId;
@@ -1076,16 +1070,8 @@ TEST_F(PrefillIntegrationTest, SlotCopy_CapsAtCommittedBlocksDuringExtension) {
 
     auto seq = server->taskQueue().receive();
     ASSERT_NE(seq, nullptr) << "C: no Sequence";
-    EXPECT_TRUE(seq->isContinuation()) << "C: must be a slot-copy continuation";
-    ASSERT_TRUE(seq->getKVPositionId().has_value());
-    // The crux: copy is capped at the 3 RESIDENT blocks (96 tokens), so
-    // kv_position_id is the first free KV index and the 4th block (32 tokens)
-    // is prefilled locally. Without the cap the copy would take all 4 blocks
-    // (kv_position_id 128, 0 delta tokens) and read the uncomputed 4th block.
-    EXPECT_EQ(*seq->getKVPositionId(), 96u)
-        << "C: copy must stop at the resident prefix (3 blocks = 96 tokens)";
-    EXPECT_EQ(seq->getNumPromptTokens(), 32u)
-        << "C: the 4th (non-resident) block must be prefilled locally";
+    EXPECT_FALSE(seq->isContinuation())
+        << "C: must not be a continuation (no slot copy)";
 
     tt::test::WorkerResponse(seq->taskId)
         .tokenWithFlags(99, tt::ipc::SharedToken::FLAG_FINAL)

--- a/tt-media-server/cpp_server/tests/unit/services/prefix_cache_router_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/services/prefix_cache_router_test.cpp
@@ -59,8 +59,9 @@ class PrefixCacheRouterTest : public ::testing::Test {
   }
 
   void registerBlocks(const std::string& sessionId,
-                      const std::vector<tt::utils::BlockHashInfo>& blocks) {
-    router->registerPrefixHash(sessionId, blocks);
+                      const std::vector<tt::utils::BlockHashInfo>& blocks,
+                      bool clearBeingGenerated = false) {
+    router->registerPrefixHash(sessionId, blocks, clearBeingGenerated);
   }
 
   void releaseSession(const std::string& sessionId) {
@@ -483,7 +484,7 @@ TEST_F(PrefixCacheRouterTest, GetSlot_BusyCandidate_CopiesFromSourceSlot) {
   auto threePrompt = makeThreeBlockPrompt();
   auto threeBlockInfos = router->computeBlockInfos(threePrompt);
   auto sessionId = addSession(22u);
-  registerBlocks(sessionId, threeBlockInfos);
+  registerBlocks(sessionId, threeBlockInfos, /*clearBeingGenerated=*/true);
   ASSERT_TRUE(
       router->tryAcquireByPrefixHash(threeBlockInfos, nullptr)->sessionFound);
 


### PR DESCRIPTION
Copy should not be triggered during:

- Prefilling
- Waiting for prefill to migrate KV

In order to do that 2 guardrails introduced. Copy is eligible only if:

- Prefill is done - not in flight on prefill
- On decode there is at least one extra hash generated - proving that mode is in decoding or session is not in flight


Issue sequence diagram:

<img width="1228" height="745" alt="image" src="https://github.com/user-attachments/assets/d8dd309c-8846-4ff1-9b1f-0a84a1810205" />
