### PR TITLE
Add google/gemma-4-31B-it Model Support

### DIFF
--- a/tt-media-server/cpp_server/include/config/types.hpp
+++ b/tt-media-server/cpp_server/include/config/types.hpp
@@ -55,6 +55,7 @@ enum class ModelType {
   GLM_5_1,
   GLM_5_2,
   DEEPSEEK_V4_PRO,
+  GEMMA_4_31B_IT,
 };
 
 enum class LLMMode {
@@ -107,6 +108,7 @@ enum class Model {
   GLM_5_1,
   GLM_5_2,
   DEEPSEEK_V4_PRO,
+  GEMMA_4_31B_IT,
 };
 
 struct ModelMapping {
@@ -125,6 +127,7 @@ static constexpr ModelMapping MODEL_MAPPINGS[] = {
     {Model::GLM_5_1, "zai-org/GLM-5.1"},
     {Model::GLM_5_2, "zai-org/GLM-5.2"},
     {Model::DEEPSEEK_V4_PRO, "deepseek-ai/DeepSeek-V4-Pro"},
+    {Model::GEMMA_4_31B_IT, "google/gemma-4-31B-it"},
 };
 
 inline std::string toString(Model m) {

--- a/tt-media-server/cpp_server/scripts/fetch_tokenizers.sh
+++ b/tt-media-server/cpp_server/scripts/fetch_tokenizers.sh
@@ -299,4 +299,20 @@ download_tokenizer \
     "false" \
     '{"model_type":"deepseek_v4","architectures":["DeepseekV4ForCausalLM"]}'
 
+# Gemma-4 31B Instruct (public, no auth). tokenizer.json is an LFS file, so the
+# base URL must be /resolve/main (/raw/main returns the LFS pointer). Ships its
+# chat template as a separate chat_template.jinja, so needs_chat_template is
+# "true". config.json carries the eos set [1, 106]; generation_config.json adds
+# <|tool_response> (50) and is fetched best-effort like every model. model_type
+# "gemma4" maps to the gemma4 reasoning + gemma4 tool-call Dynamo parsers in
+# discovery.cpp. The template uses no `.0` numeric indexing, so no minijinja
+# patch is needed.
+download_tokenizer \
+    "google/gemma-4-31B-it" \
+    "https://huggingface.co/google/gemma-4-31B-it/resolve/main" \
+    "false" \
+    '{"model_type":"gemma4","architectures":["Gemma4ForConditionalGeneration"]}' \
+    "json" \
+    "true"
+
 echo ""

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -68,6 +68,8 @@ std::string resolveBlazeSocketDescriptorPrefix() {
       return "glm";
     case ModelType::DEEPSEEK_V4_PRO:
       return "deepseek";
+    case ModelType::GEMMA_4_31B_IT:
+      return "gemma";
   }
   throw std::runtime_error("Unsupported model type for Blaze socket prefix");
 }
@@ -89,6 +91,8 @@ uint32_t resolveBlazeNumberOfPipelineStages() {
     case ModelType::GLM_5_1:
     case ModelType::GLM_5_2:
       return 80;
+    case ModelType::GEMMA_4_31B_IT:
+      return 62;
     default:
       return defaults::BLAZE_NUMBER_OF_PIPELINE_STAGES;
   }
@@ -775,6 +779,7 @@ ModelType modelType() {
     if (m == "zai-org/GLM-5.1") return ModelType::GLM_5_1;
     if (m == "zai-org/GLM-5.2") return ModelType::GLM_5_2;
     if (m == "deepseek-ai/DeepSeek-V4-Pro") return ModelType::DEEPSEEK_V4_PRO;
+    if (m == "google/gemma-4-31B-it") return ModelType::GEMMA_4_31B_IT;
     return ModelType::DEEPSEEK_R1_0528;
   }();
   return cached;

--- a/tt-media-server/cpp_server/src/dynamo/discovery.cpp
+++ b/tt-media-server/cpp_server/src/dynamo/discovery.cpp
@@ -162,6 +162,12 @@ RuntimeParsers runtimeParsersForModelType(const std::string& modelType) {
   if (modelType == "deepseek_v4") {
     return {"deepseek_v4", "deepseek_v4"};
   }
+  // Gemma 4 reasons in `<|channel>thought\n...<channel|>` and emits tool calls
+  // as `<|tool_call>call:name{...}<tool_call|>`; both are handled by the
+  // frontend's gemma4 parsers.
+  if (modelType == "gemma4") {
+    return {"gemma4", "gemma4"};
+  }
   // deepseek_v3 and unknown types default to DeepSeek R1 reasoning.
   return {"deepseek_r1", nullptr};
 }

--- a/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
+++ b/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
@@ -225,6 +225,8 @@ std::string tokenizerDirForModel(config::ModelType model) {
       return "zai-org/GLM-5.2";
     case config::ModelType::DEEPSEEK_V4_PRO:
       return "deepseek-ai/DeepSeek-V4-Pro";
+    case config::ModelType::GEMMA_4_31B_IT:
+      return "google/gemma-4-31B-it";
     case config::ModelType::DEEPSEEK_R1_0528:
     default:
       return "deepseek-ai/DeepSeek-R1-0528";
@@ -247,6 +249,7 @@ std::unique_ptr<Tokenizer> createTokenizer(config::ModelType model,
     case config::ModelType::MINIMAX_M3:
     case config::ModelType::GLM_5_1:
     case config::ModelType::GLM_5_2:
+    case config::ModelType::GEMMA_4_31B_IT:
       // These load their own model-specific files but currently reuse the
       // DeepSeek chat-template/tool-call behavior until a dedicated tokenizer
       // implementation is added.
@@ -422,6 +425,28 @@ const StaticTokenizerInfo& deepseekV4ProInfo() {
   return kInfo;
 }
 
+// IDs verified against the fetched Gemma-4-31B-it tokenizer (added_tokens in
+// tokenizer.json). Gemma 4 does NOT use <think>/</think>: reasoning is emitted
+// in a dedicated channel, `<|channel>thought\n ... <channel|>`, and the
+// template only ever opens the `thought` channel — so the channel delimiters
+// are the think-token pair here. Tool calls are
+// `<|tool_call>call:name{...}<tool_call|>`, handled by the gemma4 tool-call
+// parser on the frontend.
+const StaticTokenizerInfo& gemma431bItInfo() {
+  static const StaticTokenizerInfo kInfo{
+      /*modelName=*/"google/gemma-4-31B-it",
+      // config.json eos_token_id: [1, 106] = <eos>, <turn|>.
+      // generation_config.json widens it to [1, 106, 50], adding
+      // <|tool_response> (the turn ends when the model hands off to a tool).
+      /*stopTokenIds=*/{106, 50},
+      /*eosTokenId=*/1,  // <eos> (also text_config.eos_token_id)
+      /*assistantHeaderSequence=*/{},
+      /*thinkStartTokenId=*/100,  // <|channel>
+      /*thinkEndTokenId=*/101,    // <channel|>
+  };
+  return kInfo;
+}
+
 }  // namespace
 
 const StaticTokenizerInfo& staticInfoFor(config::ModelType model) {
@@ -446,6 +471,8 @@ const StaticTokenizerInfo& staticInfoFor(config::ModelType model) {
       return glm52Info();
     case config::ModelType::DEEPSEEK_V4_PRO:
       return deepseekV4ProInfo();
+    case config::ModelType::GEMMA_4_31B_IT:
+      return gemma431bItInfo();
   }
   throw std::invalid_argument(
       "tokenizers::staticInfoFor: no static info registered for ModelType " +


### PR DESCRIPTION
## Issue
We want to add support for `google/gemma-4-31B-it` model.
Here is an example of tokenized text:

```
<|turn>system\n<|think|>\n<turn|>\n<|turn>user\nWhat is 17 * 4?<turn|>\n<|turn>model\n<|channel>thought\n17 * 4 = 68. Simple arithmetic, answer directly.\n<channel|>17 * 4 = 68.<turn|>
```