### PR TITLE
feat(tt-media-server): allow presigned URL downloads for I2V image prompts

### DIFF
--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -136,9 +136,10 @@ class Settings(BaseSettings):
     # Presigned S3/GCS GET URLs are plain https URLs: validation covers scheme
     # and hostname only, so query-string auth passes through untouched.
     media_url_download_enabled: bool = True
-    # Comma-separated exact hostnames (e.g. "bucket.s3.us-east-1.amazonaws.com").
-    # Empty allows any domain; set it on deployments reachable by untrusted
-    # clients — the allowlist is the SSRF guard, and it is checked again on
+    # Comma-separated hostnames, exact ("bucket.s3.us-east-1.amazonaws.com")
+    # or label-anchored wildcards ("*.s3.us-east-1.amazonaws.com"). REQUIRED
+    # for URL downloads: while empty, every URL-valued media field is refused
+    # with 400 — the allowlist is the SSRF guard, and it is checked again on
     # every redirect hop.
     media_url_allowed_domains: str = ""
     # 7,500,000 bytes base64-encode to exactly MAX_BASE64_IMAGE_LEN

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -132,6 +132,24 @@ class Settings(BaseSettings):
     audio_task: str = AudioTasks.TRANSCRIBE.value
     audio_language: str = "English"
 
+    # Client-supplied media URL download settings (#4974).
+    # Presigned S3/GCS GET URLs are plain https URLs: validation covers scheme
+    # and hostname only, so query-string auth passes through untouched.
+    media_url_download_enabled: bool = True
+    # Comma-separated exact hostnames (e.g. "bucket.s3.us-east-1.amazonaws.com").
+    # Empty allows any domain; set it on deployments reachable by untrusted
+    # clients — the allowlist is the SSRF guard, and it is checked again on
+    # every redirect hop.
+    media_url_allowed_domains: str = ""
+    # 7,500,000 bytes base64-encode to exactly MAX_BASE64_IMAGE_LEN
+    # (10,000,000 chars, domain/video_i2v_generate_request.py). A larger
+    # default would pass the endpoint and then fail the field cap when an
+    # SP-runner worker re-validates ImagePromptEntry mid-job.
+    media_url_max_bytes: int = 7_500_000
+    # Total deadline for one asset: covers redirects and the full body read.
+    media_url_timeout_seconds: float = 30.0
+    media_url_max_redirects: int = 5
+
     # Telemetry settings
     enable_telemetry: bool = True
     prometheus_endpoint: str = "/metrics"

--- a/tt-media-server/domain/video_i2v_generate_request.py
+++ b/tt-media-server/domain/video_i2v_generate_request.py
@@ -5,8 +5,9 @@
 """Image-to-Video request schema for Wan2.2 I2V.
 
 Extends ``VideoGenerateRequest`` with a list of image prompts. Each entry
-pairs a base64-encoded image with a frame position so the caller can anchor
-the generation at one or more frames across the output video.
+pairs an image — base64-encoded, or an http(s)/presigned URL (#4974) — with
+a frame position so the caller can anchor the generation at one or more
+frames across the output video.
 
 Validation mirrors the upstream ``WanPipelineI2V.prepare_latents`` contract.
 The pipeline-level ``num_frames`` (used by both the runner and the validators
@@ -19,6 +20,7 @@ from config.constants import WAN22_NUM_FRAMES
 from domain.video_generate_request import VideoGenerateRequest
 from pydantic import BaseModel, Field, field_validator
 from utils.image_manager import ImageManager
+from utils.media_downloader import is_media_url
 
 # The cap exists to bound HTTP body size, not to match
 # any pipeline constraint.
@@ -35,6 +37,13 @@ class ImagePromptEntry(BaseModel):
     @classmethod
     def validate_decodable_image(cls, v: str) -> str:
         """Ensure the base64 string decodes to a valid PIL image via ImageManager."""
+
+        if is_media_url(v):
+            # Remote asset (e.g. presigned S3 URL): downloaded, decoded, and
+            # policy-checked at the API layer before enqueue
+            # (open_ai_api/video.py), where failures map to real HTTP
+            # statuses instead of a blanket 422 here.
+            return v
 
         try:
             img = ImageManager().base64_to_pil_image(v)

--- a/tt-media-server/open_ai_api/video.py
+++ b/tt-media-server/open_ai_api/video.py
@@ -18,6 +18,7 @@ from config.constants import (
 from config.settings import settings
 from domain.video_generate_request import VideoGenerateRequest
 from domain.video_i2v_generate_request import (
+    MAX_BASE64_IMAGE_LEN,
     ImagePromptEntry,
     VideoI2VGenerateRequest,
 )
@@ -39,6 +40,14 @@ from resolver.service_resolver import service_resolver
 from security.api_key_checker import get_api_key
 from telemetry.telemetry_client import TelemetryEvent
 from utils.decorators import log_execution_time
+from utils.image_manager import ImageManager
+from utils.media_downloader import (
+    MediaDownloadFetchError,
+    MediaDownloadPolicyError,
+    MediaDownloadTooLargeError,
+    download_media_url,
+    is_media_url,
+)
 from utils.video_manager import VideoManager
 
 router = APIRouter()
@@ -180,6 +189,56 @@ def reject_text_to_video_on_i2v_deployment() -> None:
     )
 
 
+async def _resolve_image_prompt_urls(request: VideoGenerateRequest) -> None:
+    """Download URL-valued image prompts and replace them with base64 (#4974).
+
+    Runs at the API layer, before the job is enqueued, so runners and workers
+    keep seeing base64 exactly as with inline submissions. Fetch failures map
+    to request-scoped HTTP statuses here instead of surfacing as a 500 from a
+    worker mid-job.
+    """
+    image_prompts = getattr(request, "image_prompts", None) or []
+    # One download budget for the whole request: 81 URL entries must not hold
+    # the connection open for 81 full timeouts.
+    deadline = _time.monotonic() + settings.media_url_timeout_seconds
+    for entry in image_prompts:
+        if not is_media_url(entry.image):
+            continue
+        try:
+            media_bytes = await download_media_url(entry.image, deadline=deadline)
+        except MediaDownloadPolicyError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except MediaDownloadTooLargeError as e:
+            raise HTTPException(status_code=413, detail=str(e))
+        except MediaDownloadFetchError as e:
+            raise HTTPException(status_code=422, detail=str(e))
+
+        image_b64 = base64.b64encode(media_bytes).decode("ascii")
+        # Assignment below bypasses field validation, but SP-runner workers
+        # re-validate ImagePromptEntry mid-job — enforce the field cap here so
+        # an operator-raised media_url_max_bytes fails at submit, not in the
+        # worker.
+        if len(image_b64) > MAX_BASE64_IMAGE_LEN:
+            raise HTTPException(
+                status_code=413,
+                detail=(
+                    f"Downloaded media base64-encodes to {len(image_b64)} "
+                    f"chars, over the {MAX_BASE64_IMAGE_LEN}-char image cap"
+                ),
+            )
+        try:
+            ImageManager().base64_to_pil_image(image_b64)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "Downloaded media is not a decodable image "
+                    "(supported formats: PNG, JPEG, WebP, etc.)"
+                ),
+            ) from exc
+        entry.image = image_b64
+
+
 async def _submit_video_request(
     request: VideoGenerateRequest,
     service: BaseJobService,
@@ -194,6 +253,8 @@ async def _submit_video_request(
         service.scheduler.check_is_model_ready()
     except Exception:
         raise HTTPException(status_code=405, detail="Model is not ready")
+
+    await _resolve_image_prompt_urls(request)
 
     try:
         # Synchronous mode: process and return video directly

--- a/tt-media-server/tests/test_media_downloader.py
+++ b/tt-media-server/tests/test_media_downloader.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Policy matrix for utils/media_downloader.py (issue #4974).
+
+The downloader pulls client-supplied media (e.g. presigned S3 URLs) under a
+process-wide policy: http(s) only, optional exact-hostname allowlist checked
+on every redirect hop, a total deadline, and a streamed byte cap. Transports
+are faked so no test touches the network.
+"""
+
+import asyncio
+
+import time
+
+import httpx
+import pytest
+from config.settings import settings
+from utils.media_downloader import (
+    MediaDownloadError,
+    MediaDownloadFetchError,
+    MediaDownloadPolicyError,
+    MediaDownloadTooLargeError,
+    check_media_url_policy,
+    download_media_url,
+    is_media_url,
+)
+
+
+class _HandlerTransport(httpx.AsyncBaseTransport):
+    """Route every request through an async handler; allows sleeps."""
+
+    def __init__(self, handler):
+        self._handler = handler
+
+    async def handle_async_request(self, request):
+        return await self._handler(request)
+
+
+class _ChunkStream(httpx.AsyncByteStream):
+    """Body stream that never advertises Content-Length."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=_HandlerTransport(handler))
+
+
+@pytest.fixture
+def media_url_defaults(monkeypatch):
+    """Pin the media-URL settings so tests don't depend on env state."""
+    monkeypatch.setattr(settings, "media_url_download_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "media_url_allowed_domains", "", raising=False)
+    monkeypatch.setattr(settings, "media_url_max_bytes", 1024 * 1024, raising=False)
+    monkeypatch.setattr(settings, "media_url_timeout_seconds", 5.0, raising=False)
+    monkeypatch.setattr(settings, "media_url_max_redirects", 5, raising=False)
+    return settings
+
+
+class TestIsMediaUrl:
+    def test_http_and_https_are_urls(self):
+        assert is_media_url("http://host/x")
+        assert is_media_url("https://host/x")
+
+    def test_scheme_detection_is_case_insensitive(self):
+        assert is_media_url("HTTPS://Host/X")
+        assert is_media_url("Http://host/x")
+
+    def test_base64_and_other_schemes_are_not(self):
+        assert not is_media_url("iVBORw0KGgo=")
+        assert not is_media_url("data:image/png;base64,AAAA")
+        assert not is_media_url("ftp://host/x")
+        assert not is_media_url("file:///etc/passwd")
+
+
+class TestPolicy:
+    def test_rejects_non_http_scheme(self, media_url_defaults):
+        with pytest.raises(MediaDownloadPolicyError):
+            check_media_url_policy("ftp://host/x")
+
+    def test_rejects_missing_hostname(self, media_url_defaults):
+        with pytest.raises(MediaDownloadPolicyError):
+            check_media_url_policy("https:///no-host")
+
+    def test_rejects_disallowed_domain(self, media_url_defaults, monkeypatch):
+        monkeypatch.setattr(settings, "media_url_allowed_domains", "allowed.example")
+        with pytest.raises(MediaDownloadPolicyError):
+            check_media_url_policy("https://evil.example/x")
+
+    def test_allowlist_is_case_insensitive(self, media_url_defaults, monkeypatch):
+        monkeypatch.setattr(
+            settings, "media_url_allowed_domains", "BUCKET.S3.AmazonAWS.com"
+        )
+        check_media_url_policy("https://bucket.s3.amazonaws.com/key")
+
+    def test_empty_allowlist_allows_any_domain(self, media_url_defaults):
+        check_media_url_policy("https://anything.example/x")
+
+    def test_disabled_rejects_urls(self, media_url_defaults, monkeypatch):
+        monkeypatch.setattr(settings, "media_url_download_enabled", False)
+        with pytest.raises(MediaDownloadPolicyError):
+            check_media_url_policy("https://allowed.example/x")
+
+
+class TestDownload:
+    async def test_success_returns_bytes_and_keeps_query_auth(self, media_url_defaults):
+        seen = {}
+
+        async def handler(request):
+            seen["url"] = str(request.url)
+            return httpx.Response(200, content=b"png-bytes")
+
+        async with _client(handler) as client:
+            data = await download_media_url(
+                "https://bucket.s3.amazonaws.com/k.png?X-Amz-Signature=abc123",
+                client=client,
+            )
+        assert data == b"png-bytes"
+        # Presigned query-string auth must pass through untouched.
+        assert "X-Amz-Signature=abc123" in seen["url"]
+
+    async def test_follows_redirect_to_allowed_host(self, media_url_defaults):
+        async def handler(request):
+            if request.url.path == "/start":
+                return httpx.Response(302, headers={"location": "/final"})
+            return httpx.Response(200, content=b"after-redirect")
+
+        async with _client(handler) as client:
+            data = await download_media_url("https://host.example/start", client=client)
+        assert data == b"after-redirect"
+
+    async def test_redirect_to_disallowed_host_is_rejected(
+        self, media_url_defaults, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "media_url_allowed_domains", "allowed.example")
+
+        async def handler(request):
+            if request.url.host == "allowed.example":
+                return httpx.Response(
+                    302, headers={"location": "https://evil.example/steal"}
+                )
+            return httpx.Response(200, content=b"nope")
+
+        async with _client(handler) as client:
+            with pytest.raises(MediaDownloadPolicyError):
+                await download_media_url("https://allowed.example/x", client=client)
+
+    async def test_redirect_limit(self, media_url_defaults, monkeypatch):
+        monkeypatch.setattr(settings, "media_url_max_redirects", 2)
+
+        async def handler(request):
+            return httpx.Response(302, headers={"location": "/again"})
+
+        async with _client(handler) as client:
+            with pytest.raises(MediaDownloadPolicyError):
+                await download_media_url("https://host.example/x", client=client)
+
+    async def test_content_length_over_cap_rejected_before_read(
+        self, media_url_defaults, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "media_url_max_bytes", 10)
+
+        async def handler(request):
+            # Content-Length is set by httpx from the body size (100 > 10).
+            return httpx.Response(200, content=b"x" * 100)
+
+        async with _client(handler) as client:
+            with pytest.raises(MediaDownloadTooLargeError):
+                await download_media_url("https://host.example/x", client=client)
+
+    async def test_streamed_body_over_cap_rejected_mid_stream(
+        self, media_url_defaults, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "media_url_max_bytes", 10)
+
+        async def handler(request):
+            # No Content-Length header: the cap must trip while streaming.
+            return httpx.Response(200, stream=_ChunkStream([b"x" * 8, b"x" * 8]))
+
+        async with _client(handler) as client:
+            with pytest.raises(MediaDownloadTooLargeError):
+                await download_media_url("https://host.example/x", client=client)
+
+    async def test_origin_error_maps_to_fetch_error(self, media_url_defaults):
+        async def handler(request):
+            # An expired presigned URL surfaces as 403 from S3.
+            return httpx.Response(403, content=b"expired")
+
+        async with _client(handler) as client:
+            with pytest.raises(MediaDownloadFetchError):
+                await download_media_url("https://host.example/x", client=client)
+
+    async def test_total_deadline_covers_body_read(
+        self, media_url_defaults, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "media_url_timeout_seconds", 0.05)
+
+        async def handler(request):
+            await asyncio.sleep(0.2)
+            return httpx.Response(200, content=b"late")
+
+        async with _client(handler) as client:
+            with pytest.raises(MediaDownloadFetchError):
+                await download_media_url("https://host.example/x", client=client)
+
+    async def test_redirect_without_location_is_a_fetch_error(self, media_url_defaults):
+        async def handler(request):
+            return httpx.Response(302, content=b"lost")
+
+        async with _client(handler) as client:
+            with pytest.raises(MediaDownloadFetchError):
+                await download_media_url("https://host.example/x", client=client)
+
+    async def test_caller_supplied_deadline_is_shared(self, media_url_defaults):
+        async def handler(request):  # pragma: no cover - must never run
+            raise AssertionError("expired deadline must not send a request")
+
+        async with _client(handler) as client:
+            with pytest.raises(MediaDownloadFetchError):
+                await download_media_url(
+                    "https://host.example/x",
+                    client=client,
+                    deadline=time.monotonic() - 1,
+                )
+
+    async def test_misconfigured_allowlist_is_a_server_error(
+        self, media_url_defaults, monkeypatch
+    ):
+        # An operator typo must not surface as a client-fault policy error.
+        # A 64-char DNS label is invalid and fails IDNA encoding.
+        monkeypatch.setattr(
+            settings, "media_url_allowed_domains", "a" * 64 + ".example"
+        )
+
+        async def handler(request):  # pragma: no cover - must never run
+            raise AssertionError("misconfiguration must fail before any request")
+
+        async with _client(handler) as client:
+            with pytest.raises(MediaDownloadError) as exc_info:
+                await download_media_url("https://host.example/x", client=client)
+        assert type(exc_info.value) is MediaDownloadError
+
+    async def test_nonpositive_timeout_is_a_server_error(
+        self, media_url_defaults, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "media_url_timeout_seconds", 0)
+
+        async def handler(request):  # pragma: no cover - must never run
+            raise AssertionError("misconfiguration must fail before any request")
+
+        async with _client(handler) as client:
+            with pytest.raises(MediaDownloadError) as exc_info:
+                await download_media_url("https://host.example/x", client=client)
+        assert type(exc_info.value) is MediaDownloadError
+
+    async def test_disabled_rejects_before_any_request(
+        self, media_url_defaults, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "media_url_download_enabled", False)
+
+        async def handler(request):  # pragma: no cover - must never run
+            raise AssertionError("request must not be sent when disabled")
+
+        async with _client(handler) as client:
+            with pytest.raises(MediaDownloadPolicyError):
+                await download_media_url("https://host.example/x", client=client)

--- a/tt-media-server/tests/test_media_downloader.py
+++ b/tt-media-server/tests/test_media_downloader.py
@@ -5,9 +5,9 @@
 """Policy matrix for utils/media_downloader.py (issue #4974).
 
 The downloader pulls client-supplied media (e.g. presigned S3 URLs) under a
-process-wide policy: http(s) only, optional exact-hostname allowlist checked
-on every redirect hop, a total deadline, and a streamed byte cap. Transports
-are faked so no test touches the network.
+process-wide policy: http(s) only, a REQUIRED hostname allowlist (exact or
+label-anchored wildcard) checked on every redirect hop, a total deadline, and
+a streamed byte cap. Transports are faked so no test touches the network.
 """
 
 import asyncio
@@ -55,9 +55,18 @@ def _client(handler) -> httpx.AsyncClient:
 
 @pytest.fixture
 def media_url_defaults(monkeypatch):
-    """Pin the media-URL settings so tests don't depend on env state."""
+    """Pin the media-URL settings so tests don't depend on env state.
+
+    The allowlist is required (deny-when-empty), so the default covers every
+    hostname the download tests use.
+    """
     monkeypatch.setattr(settings, "media_url_download_enabled", True, raising=False)
-    monkeypatch.setattr(settings, "media_url_allowed_domains", "", raising=False)
+    monkeypatch.setattr(
+        settings,
+        "media_url_allowed_domains",
+        "host.example,bucket.s3.amazonaws.com,allowed.example",
+        raising=False,
+    )
     monkeypatch.setattr(settings, "media_url_max_bytes", 1024 * 1024, raising=False)
     monkeypatch.setattr(settings, "media_url_timeout_seconds", 5.0, raising=False)
     monkeypatch.setattr(settings, "media_url_max_redirects", 5, raising=False)
@@ -100,8 +109,33 @@ class TestPolicy:
         )
         check_media_url_policy("https://bucket.s3.amazonaws.com/key")
 
-    def test_empty_allowlist_allows_any_domain(self, media_url_defaults):
-        check_media_url_policy("https://anything.example/x")
+    def test_empty_allowlist_denies_all_urls(self, media_url_defaults, monkeypatch):
+        # The allowlist is required: deny-when-empty, not allow-all.
+        monkeypatch.setattr(settings, "media_url_allowed_domains", "")
+        with pytest.raises(MediaDownloadPolicyError):
+            check_media_url_policy("https://anything.example/x")
+
+    def test_wildcard_matches_any_subdomain_depth(
+        self, media_url_defaults, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "media_url_allowed_domains", "*.s3.amazonaws.com")
+        check_media_url_policy("https://bucket.s3.amazonaws.com/key")
+        check_media_url_policy("https://a.b.s3.amazonaws.com/key")
+
+    def test_wildcard_is_label_anchored(self, media_url_defaults, monkeypatch):
+        monkeypatch.setattr(settings, "media_url_allowed_domains", "*.s3.amazonaws.com")
+        # No '.' label boundary: a lookalike host must not match.
+        with pytest.raises(MediaDownloadPolicyError):
+            check_media_url_policy("https://evil-s3.amazonaws.com/key")
+        # The bare suffix itself must not match a '*.suffix' entry.
+        with pytest.raises(MediaDownloadPolicyError):
+            check_media_url_policy("https://s3.amazonaws.com/key")
+
+    def test_bare_star_entry_is_a_server_error(self, media_url_defaults, monkeypatch):
+        monkeypatch.setattr(settings, "media_url_allowed_domains", "*")
+        with pytest.raises(MediaDownloadError) as exc_info:
+            check_media_url_policy("https://host.example/x")
+        assert type(exc_info.value) is MediaDownloadError
 
     def test_disabled_rejects_urls(self, media_url_defaults, monkeypatch):
         monkeypatch.setattr(settings, "media_url_download_enabled", False)
@@ -187,6 +221,21 @@ class TestDownload:
         async with _client(handler) as client:
             with pytest.raises(MediaDownloadTooLargeError):
                 await download_media_url("https://host.example/x", client=client)
+
+    async def test_error_text_never_carries_the_query_string(self, media_url_defaults):
+        async def handler(request):
+            return httpx.Response(403, content=b"expired")
+
+        async with _client(handler) as client:
+            with pytest.raises(MediaDownloadFetchError) as exc_info:
+                await download_media_url(
+                    "https://bucket.s3.amazonaws.com/k.png?X-Amz-Signature=secret",
+                    client=client,
+                )
+        # Presigned query params are credentials; they must not leak into
+        # error details or logs.
+        assert "X-Amz-Signature" not in str(exc_info.value)
+        assert "secret" not in str(exc_info.value)
 
     async def test_origin_error_maps_to_fetch_error(self, media_url_defaults):
         async def handler(request):

--- a/tt-media-server/tests/test_video_media_url.py
+++ b/tt-media-server/tests/test_video_media_url.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""I2V presigned-URL wiring (issue #4974).
+
+``image_prompts[].image`` accepts an http(s) URL next to inline base64.
+The URL is downloaded at the API layer and replaced with base64 before the
+job is enqueued, so runners and workers keep seeing base64 only.
+"""
+
+import base64
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import PIL.Image
+import pytest
+from domain.video_generate_request import VideoGenerateRequest
+from domain.video_i2v_generate_request import (
+    ImagePromptEntry,
+    VideoI2VGenerateRequest,
+)
+from fastapi import HTTPException
+from open_ai_api.video import (
+    _resolve_image_prompt_urls,
+    submit_generate_video_i2v_request,
+)
+from utils.media_downloader import (
+    MediaDownloadFetchError,
+    MediaDownloadPolicyError,
+    MediaDownloadTooLargeError,
+)
+
+# Same 1x1 PNG as tests/test_video_api.py — hardcoded so the test does not
+# depend on PIL being real (conftest mocks PIL when Pillow is not installed).
+_TINY_PNG_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP8z8BQDwAEhQGAhKmM"
+    "IQAAAABJRU5ErkJggg=="
+)
+_TINY_PNG_BYTES = base64.b64decode(_TINY_PNG_BASE64)
+
+_URL = "https://bucket.s3.us-east-1.amazonaws.com/frame0.png?X-Amz-Signature=sig"
+
+_PIL_IS_MOCKED = isinstance(PIL.Image, MagicMock)
+
+
+class TestImagePromptEntryAcceptsUrls:
+    def test_url_value_skips_base64_validation(self):
+        entry = ImagePromptEntry(image=_URL, frame_pos=0)
+        assert entry.image == _URL
+
+    def test_inline_base64_still_validates(self):
+        entry = ImagePromptEntry(image=_TINY_PNG_BASE64, frame_pos=0)
+        assert entry.image == _TINY_PNG_BASE64
+
+    def test_garbage_string_is_still_rejected(self):
+        with pytest.raises(Exception):
+            ImagePromptEntry(image="not-a-url-and-not-base64!!", frame_pos=0)
+
+
+class TestResolveImagePromptUrls:
+    async def test_url_entry_is_replaced_with_base64(self):
+        request = VideoI2VGenerateRequest(
+            prompt="p",
+            image_prompts=[
+                {"image": _URL, "frame_pos": 0},
+                {"image": _TINY_PNG_BASE64, "frame_pos": 1},
+            ],
+        )
+        with patch(
+            "open_ai_api.video.download_media_url",
+            new=AsyncMock(return_value=_TINY_PNG_BYTES),
+        ) as mock_download:
+            await _resolve_image_prompt_urls(request)
+
+        mock_download.assert_awaited_once()
+        assert mock_download.await_args.args == (_URL,)
+        resolved = request.image_prompts[0].image
+        assert resolved != _URL
+        assert base64.b64decode(resolved) == _TINY_PNG_BYTES
+        # Inline entry untouched.
+        assert request.image_prompts[1].image == _TINY_PNG_BASE64
+
+    async def test_t2v_request_is_a_noop(self):
+        request = VideoGenerateRequest(prompt="p")
+        with patch(
+            "open_ai_api.video.download_media_url", new=AsyncMock()
+        ) as mock_download:
+            await _resolve_image_prompt_urls(request)
+        mock_download.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "error,status",
+        [
+            (MediaDownloadPolicyError("blocked"), 400),
+            (MediaDownloadTooLargeError("too big"), 413),
+            (MediaDownloadFetchError("HTTP 403"), 422),
+        ],
+    )
+    async def test_download_errors_map_to_http_statuses(self, error, status):
+        request = VideoI2VGenerateRequest(
+            prompt="p", image_prompts=[{"image": _URL, "frame_pos": 0}]
+        )
+        with patch(
+            "open_ai_api.video.download_media_url",
+            new=AsyncMock(side_effect=error),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _resolve_image_prompt_urls(request)
+        assert exc_info.value.status_code == status
+
+    async def test_oversized_download_is_rejected_with_413(self):
+        # 8,000,000 bytes base64-encode past the 10,000,000-char field cap;
+        # without the endpoint check this would 202 and then fail validation
+        # inside an SP-runner worker mid-job.
+        request = VideoI2VGenerateRequest(
+            prompt="p", image_prompts=[{"image": _URL, "frame_pos": 0}]
+        )
+        with patch(
+            "open_ai_api.video.download_media_url",
+            new=AsyncMock(return_value=b"x" * 8_000_000),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _resolve_image_prompt_urls(request)
+        assert exc_info.value.status_code == 413
+
+    @pytest.mark.skipif(
+        _PIL_IS_MOCKED, reason="needs real Pillow to detect a non-image body"
+    )
+    async def test_undecodable_download_is_rejected_with_422(self):
+        request = VideoI2VGenerateRequest(
+            prompt="p", image_prompts=[{"image": _URL, "frame_pos": 0}]
+        )
+        with patch(
+            "open_ai_api.video.download_media_url",
+            new=AsyncMock(return_value=b"<html>not an image</html>"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _resolve_image_prompt_urls(request)
+        assert exc_info.value.status_code == 422
+
+
+class TestSubmitPathResolvesUrls:
+    async def test_i2v_submit_invokes_url_resolution(self):
+        mock_service = MagicMock()
+        mock_service.create_job = AsyncMock(
+            return_value={"id": "job_1", "object": "video", "status": "pending"}
+        )
+        request = VideoI2VGenerateRequest(
+            prompt="p", image_prompts=[{"image": _TINY_PNG_BASE64, "frame_pos": 0}]
+        )
+        with patch(
+            "open_ai_api.video._resolve_image_prompt_urls", new=AsyncMock()
+        ) as mock_resolve:
+            response = await submit_generate_video_i2v_request(
+                request=request,
+                service=mock_service,
+                api_key="test_key",
+            )
+        assert response.status_code == 202
+        mock_resolve.assert_awaited_once_with(request)

--- a/tt-media-server/tests/test_video_media_url.py
+++ b/tt-media-server/tests/test_video_media_url.py
@@ -24,6 +24,7 @@ from open_ai_api.video import (
     _resolve_image_prompt_urls,
     submit_generate_video_i2v_request,
 )
+from utils.image_manager import ImageManager
 from utils.media_downloader import (
     MediaDownloadFetchError,
     MediaDownloadPolicyError,
@@ -137,6 +138,18 @@ class TestResolveImagePromptUrls:
             with pytest.raises(HTTPException) as exc_info:
                 await _resolve_image_prompt_urls(request)
         assert exc_info.value.status_code == 422
+
+
+class TestDecoderGuardsAgainstUnresolvedUrls:
+    """Runners must only ever see base64; a URL reaching the decoder means a
+    submit path skipped `_resolve_image_prompt_urls` — it must fail loudly."""
+
+    @pytest.mark.parametrize(
+        "value", ["https://host.example/a.png", "HTTP://host.example/a.png"]
+    )
+    def test_url_input_raises_a_clear_error(self, value):
+        with pytest.raises(ValueError, match="unresolved media URL"):
+            ImageManager().base64_to_pil_image(value)
 
 
 class TestSubmitPathResolvesUrls:

--- a/tt-media-server/utils/image_manager.py
+++ b/tt-media-server/utils/image_manager.py
@@ -105,6 +105,15 @@ class ImageManager:
         Returns:
             PIL Image object
         """
+        if base64_string[:8].lower().startswith(("http://", "https://")):
+            # Runners must only ever see base64: URL-valued media is downloaded
+            # and replaced at the API layer (#4974). Reaching this decoder with
+            # a URL means a submit path skipped that resolution — fail loudly
+            # instead of decoding garbage.
+            raise ValueError(
+                "unresolved media URL reached the image decoder; URLs must be "
+                "downloaded at the API layer before enqueue"
+            )
         if base64_string.startswith("data:"):
             base64_string = base64_string.split(",")[1]
         # Restore stripped padding so HTTP/JSON-trimmed strings decode cleanly.

--- a/tt-media-server/utils/media_downloader.py
+++ b/tt-media-server/utils/media_downloader.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Hardened downloader for client-supplied media URLs (#4974).
+
+Lets request media fields carry a presigned URL (e.g. S3) instead of inline
+base64. Every remote fetch in the request path must go through
+``download_media_url`` — side-channel fetches are how reference servers
+(vLLM, SGLang) reintroduced SSRF after hardening their main path.
+
+Policy, following SGLang's ``download_remote_media`` with vLLM's error
+taxonomy on top:
+
+* http(s) only; the optional exact-hostname allowlist is normalized (IDNA,
+  case, IP literals) and checked on the initial URL and on every redirect hop.
+* URLs are validated as ``httpx.URL`` — the same parser the client uses — so
+  a validator/client parser mismatch cannot bypass the allowlist.
+* Redirects are followed manually (301/302/303/307/308, capped) so each
+  destination is validated before a connection is made.
+* One total deadline covers all hops and the body read; the body is streamed
+  against the byte cap instead of buffered blindly. Callers can pass a shared
+  ``deadline`` so one request's assets share a single budget. Known
+  limitation: a origin that trickles bytes just inside the per-read timeout
+  can stretch a hop somewhat past the deadline (checked between chunks;
+  ``asyncio.timeout`` would close this but needs Python 3.11+).
+
+Error taxonomy (mapped to HTTP statuses at the endpoint):
+
+* ``MediaDownloadPolicyError`` — the URL violates server policy (400).
+* ``MediaDownloadTooLargeError`` — the body exceeds the byte cap (413).
+* ``MediaDownloadFetchError`` — the origin failed us: HTTP error such as an
+  expired presigned URL, network error, or deadline exceeded (422).
+* ``MediaDownloadError`` (base, raised directly) — server-side
+  misconfiguration; deliberately NOT caught at the endpoint so it surfaces
+  as a 500, not a client-fault 4xx.
+"""
+
+import asyncio
+import ipaddress
+import time
+from typing import Optional
+
+import httpx
+from config.settings import settings
+from utils.logger import TTLogger
+
+logger = TTLogger()
+
+_REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
+_READ_CHUNK_BYTES = 64 * 1024
+
+_shared_client: Optional[httpx.AsyncClient] = None
+_shared_client_loop: Optional[asyncio.AbstractEventLoop] = None
+_warned_open_allowlist = False
+
+
+class MediaDownloadError(Exception):
+    """Base class; raised directly only for server-side misconfiguration."""
+
+
+class MediaDownloadPolicyError(MediaDownloadError):
+    """URL violates server download policy (scheme, domain, redirects)."""
+
+
+class MediaDownloadTooLargeError(MediaDownloadError):
+    """Remote body exceeds the configured byte cap."""
+
+
+class MediaDownloadFetchError(MediaDownloadError):
+    """Origin returned an error, the network failed, or the deadline passed."""
+
+
+def is_media_url(value: str) -> bool:
+    """True when a media field value is a remote URL rather than base64.
+
+    Case-insensitive: ``HTTPS://`` must route to the URL path, not the
+    base64 decoder. No base64 payload can collide — ``:`` and ``/`` in the
+    prefix are outside the base64 alphabet.
+    """
+    return value[:8].lower().startswith(("http://", "https://"))
+
+
+def _normalize_hostname(hostname: str) -> str:
+    """Canonicalize a hostname for allowlist comparison.
+
+    IP literals collapse to their canonical text form; names are IDNA-encoded
+    and lowercased so unicode/case variants of an allowlisted domain match.
+    """
+    hostname = hostname.strip().rstrip(".")
+    if hostname.startswith("[") and hostname.endswith("]"):
+        hostname = hostname[1:-1]
+    try:
+        return str(ipaddress.ip_address(hostname))
+    except ValueError:
+        pass
+    try:
+        return hostname.encode("idna").decode("ascii").lower()
+    except UnicodeError as exc:
+        raise MediaDownloadPolicyError(f"Invalid hostname {hostname!r}") from exc
+
+
+def _allowed_domains() -> frozenset:
+    raw = settings.media_url_allowed_domains or ""
+    try:
+        return frozenset(
+            _normalize_hostname(domain) for domain in raw.split(",") if domain.strip()
+        )
+    except MediaDownloadPolicyError as exc:
+        # A bad allowlist entry is operator error, not client error: raise the
+        # base class so the endpoint surfaces 500 instead of blaming the caller.
+        raise MediaDownloadError(
+            f"Misconfigured media_url_allowed_domains: {exc}"
+        ) from exc
+
+
+def check_media_url_policy(url: str) -> httpx.URL:
+    """Validate one URL against the download policy; return it parsed.
+
+    Parses with ``httpx.URL`` — the exact representation the HTTP client
+    connects with — and is re-run on every redirect destination.
+    """
+    if not settings.media_url_download_enabled:
+        raise MediaDownloadPolicyError(
+            "Media URL download is disabled on this server "
+            "(media_url_download_enabled=false); send the asset inline."
+        )
+
+    try:
+        parsed = httpx.URL(url)
+    except httpx.InvalidURL as exc:
+        raise MediaDownloadPolicyError(f"Invalid media URL: {url!r}") from exc
+
+    if parsed.scheme not in ("http", "https") or not parsed.host:
+        raise MediaDownloadPolicyError(
+            f"Media URL must be http(s) with a hostname, got: {url!r}"
+        )
+
+    allowed = _allowed_domains()
+    if allowed:
+        hostname = _normalize_hostname(parsed.host)
+        if hostname not in allowed:
+            # Do not echo the allowlist: it is deployment configuration.
+            raise MediaDownloadPolicyError(
+                f"Media URL domain {hostname!r} is not in the allowed domains list"
+            )
+    return parsed
+
+
+def _get_shared_client() -> httpx.AsyncClient:
+    """Pooled client bound to the running loop.
+
+    Rebuilt if the loop changed (repeated TestClient runs) or the client was
+    closed; per-request deadlines are passed per call. Cross-request cookie
+    persistence is a state channel between unrelated clients' downloads, so
+    the jar is cleared on every acquisition.
+    """
+    global _shared_client, _shared_client_loop
+    loop = asyncio.get_running_loop()
+    if (
+        _shared_client is None
+        or _shared_client.is_closed
+        or _shared_client_loop is not loop
+    ):
+        _shared_client = httpx.AsyncClient()
+        _shared_client_loop = loop
+    _shared_client.cookies.clear()
+    return _shared_client
+
+
+def _warn_if_open_allowlist() -> None:
+    global _warned_open_allowlist
+    if _warned_open_allowlist:
+        return
+    if not _allowed_domains():
+        logger.warning(
+            "Media URL download is enabled with no media_url_allowed_domains; "
+            "any authenticated client can make this server fetch arbitrary "
+            "http(s) URLs (SSRF surface). Set an allowlist on deployments "
+            "reachable by untrusted clients."
+        )
+    _warned_open_allowlist = True
+
+
+async def download_media_url(
+    url: str,
+    *,
+    client: Optional[httpx.AsyncClient] = None,
+    deadline: Optional[float] = None,
+) -> bytes:
+    """Download one media asset under the configured URL policy.
+
+    Redirects are followed manually so every destination is validated before
+    a connection is made. The body is streamed to enforce both the total
+    deadline and the byte cap without first buffering an attacker-controlled
+    payload in memory.
+
+    Args:
+        url: The http(s) URL to fetch.
+        client: Override client (tests); defaults to the shared pooled client.
+        deadline: Optional ``time.monotonic()`` deadline shared across several
+            downloads (one budget per request). Defaults to now +
+            ``media_url_timeout_seconds``.
+    """
+    max_bytes = settings.media_url_max_bytes
+    max_redirects = max(0, settings.media_url_max_redirects)
+    timeout_seconds = settings.media_url_timeout_seconds
+    if timeout_seconds <= 0:
+        # Operator error → base class → 500 at the endpoint.
+        raise MediaDownloadError("media_url_timeout_seconds must be positive")
+
+    current = check_media_url_policy(url)
+    _warn_if_open_allowlist()
+    http_client = client if client is not None else _get_shared_client()
+    if deadline is None:
+        deadline = time.monotonic() + timeout_seconds
+
+    try:
+        for redirect_count in range(max_redirects + 1):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise MediaDownloadFetchError(f"Timed out downloading media URL: {url}")
+
+            async with http_client.stream(
+                "GET",
+                current,
+                timeout=remaining,
+                follow_redirects=False,
+            ) as response:
+                if response.status_code in _REDIRECT_STATUS_CODES:
+                    location = response.headers.get("location")
+                    if not location:
+                        raise MediaDownloadFetchError(
+                            f"Media URL returned redirect HTTP "
+                            f"{response.status_code} without a Location "
+                            f"header: {url}"
+                        )
+                    if redirect_count == max_redirects:
+                        raise MediaDownloadPolicyError(
+                            f"Media URL exceeded {max_redirects} redirects: {url}"
+                        )
+                    try:
+                        target = str(current.join(location))
+                    except httpx.InvalidURL as exc:
+                        raise MediaDownloadPolicyError(
+                            f"Invalid redirect location {location!r}"
+                        ) from exc
+                    current = check_media_url_policy(target)
+                    continue
+
+                if response.status_code >= 400:
+                    raise MediaDownloadFetchError(
+                        f"Media URL returned HTTP {response.status_code} "
+                        f"(an expired presigned URL typically returns 403): {url}"
+                    )
+
+                content_length = response.headers.get("content-length")
+                if content_length is not None:
+                    try:
+                        declared = int(content_length)
+                    except ValueError:
+                        declared = None
+                    if declared is not None and declared > max_bytes:
+                        raise MediaDownloadTooLargeError(
+                            f"Remote media declares {declared} bytes, over the "
+                            f"{max_bytes}-byte download cap"
+                        )
+
+                body = bytearray()
+                async for chunk in response.aiter_bytes(_READ_CHUNK_BYTES):
+                    if time.monotonic() > deadline:
+                        raise MediaDownloadFetchError(
+                            f"Timed out downloading media URL: {url}"
+                        )
+                    if len(body) + len(chunk) > max_bytes:
+                        raise MediaDownloadTooLargeError(
+                            f"Remote media exceeds the {max_bytes}-byte download cap"
+                        )
+                    body.extend(chunk)
+                return bytes(body)
+    except httpx.TimeoutException as exc:
+        raise MediaDownloadFetchError(
+            f"Timed out downloading media URL: {url}"
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise MediaDownloadFetchError(
+            f"Failed to download media URL: {url} ({exc})"
+        ) from exc
+
+    raise AssertionError("unreachable: redirect loop must return or raise")

--- a/tt-media-server/utils/media_downloader.py
+++ b/tt-media-server/utils/media_downloader.py
@@ -12,8 +12,14 @@ base64. Every remote fetch in the request path must go through
 Policy, following SGLang's ``download_remote_media`` with vLLM's error
 taxonomy on top:
 
-* http(s) only; the optional exact-hostname allowlist is normalized (IDNA,
-  case, IP literals) and checked on the initial URL and on every redirect hop.
+* http(s) only; the hostname allowlist is REQUIRED — with no
+  ``media_url_allowed_domains`` configured every URL-valued media field is
+  refused, so the SSRF surface only exists where an operator opened it.
+* Allowlist entries are exact hostnames, normalized (IDNA, case, IP
+  literals), or label-anchored wildcards: ``*.s3.amazonaws.com`` matches
+  ``bucket.s3.amazonaws.com`` at any subdomain depth but never the bare
+  suffix and never ``evil-s3.amazonaws.com`` (a ``.`` label boundary is
+  required). The check runs on the initial URL and on every redirect hop.
 * URLs are validated as ``httpx.URL`` — the same parser the client uses — so
   a validator/client parser mismatch cannot bypass the allowlist.
 * Redirects are followed manually (301/302/303/307/308, capped) so each
@@ -21,9 +27,11 @@ taxonomy on top:
 * One total deadline covers all hops and the body read; the body is streamed
   against the byte cap instead of buffered blindly. Callers can pass a shared
   ``deadline`` so one request's assets share a single budget. Known
-  limitation: a origin that trickles bytes just inside the per-read timeout
+  limitation: an origin that trickles bytes just inside the per-read timeout
   can stretch a hop somewhat past the deadline (checked between chunks;
   ``asyncio.timeout`` would close this but needs Python 3.11+).
+* Error and log text never carries the URL's query string — presigned query
+  parameters are short-lived credentials (``X-Amz-Signature``).
 
 Error taxonomy (mapped to HTTP statuses at the endpoint):
 
@@ -43,16 +51,12 @@ from typing import Optional
 
 import httpx
 from config.settings import settings
-from utils.logger import TTLogger
-
-logger = TTLogger()
 
 _REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
 _READ_CHUNK_BYTES = 64 * 1024
 
 _shared_client: Optional[httpx.AsyncClient] = None
 _shared_client_loop: Optional[asyncio.AbstractEventLoop] = None
-_warned_open_allowlist = False
 
 
 class MediaDownloadError(Exception):
@@ -81,6 +85,15 @@ def is_media_url(value: str) -> bool:
     return value[:8].lower().startswith(("http://", "https://"))
 
 
+def redact_url(url: str) -> str:
+    """Strip the query string and fragment for error/log text.
+
+    Presigned URLs carry credentials in the query (``X-Amz-Signature``,
+    expiry); they must never land in HTTP error details or server logs.
+    """
+    return url.split("#", 1)[0].split("?", 1)[0]
+
+
 def _normalize_hostname(hostname: str) -> str:
     """Canonicalize a hostname for allowlist comparison.
 
@@ -100,18 +113,42 @@ def _normalize_hostname(hostname: str) -> str:
         raise MediaDownloadPolicyError(f"Invalid hostname {hostname!r}") from exc
 
 
-def _allowed_domains() -> frozenset:
+def _allowed_domains() -> "tuple[frozenset, frozenset]":
+    """Parse the allowlist into (exact hostnames, wildcard suffixes).
+
+    A ``*.suffix`` entry contributes its normalized suffix; anything else is
+    an exact hostname. A bare ``*`` is refused — "allow everything" must not
+    be expressible through the allowlist.
+    """
     raw = settings.media_url_allowed_domains or ""
+    exact = set()
+    suffixes = set()
     try:
-        return frozenset(
-            _normalize_hostname(domain) for domain in raw.split(",") if domain.strip()
-        )
+        for domain in raw.split(","):
+            domain = domain.strip()
+            if not domain:
+                continue
+            if domain == "*" or domain == "*.":
+                raise MediaDownloadPolicyError("bare '*' entries are not allowed")
+            if domain.startswith("*."):
+                suffixes.add(_normalize_hostname(domain[2:]))
+            else:
+                exact.add(_normalize_hostname(domain))
     except MediaDownloadPolicyError as exc:
         # A bad allowlist entry is operator error, not client error: raise the
         # base class so the endpoint surfaces 500 instead of blaming the caller.
         raise MediaDownloadError(
             f"Misconfigured media_url_allowed_domains: {exc}"
         ) from exc
+    return frozenset(exact), frozenset(suffixes)
+
+
+def _hostname_is_allowed(hostname: str, exact: frozenset, suffixes: frozenset) -> bool:
+    if hostname in exact:
+        return True
+    # Label-anchored: "bucket.s3.amazonaws.com".endswith(".s3.amazonaws.com")
+    # is True, "evil-s3.amazonaws.com" and the bare suffix are not.
+    return any(hostname.endswith("." + suffix) for suffix in suffixes)
 
 
 def check_media_url_policy(url: str) -> httpx.URL:
@@ -126,24 +163,31 @@ def check_media_url_policy(url: str) -> httpx.URL:
             "(media_url_download_enabled=false); send the asset inline."
         )
 
+    exact, suffixes = _allowed_domains()
+    if not exact and not suffixes:
+        raise MediaDownloadPolicyError(
+            "Media URL download requires media_url_allowed_domains to be "
+            "configured on this server; send the asset inline."
+        )
+
     try:
         parsed = httpx.URL(url)
     except httpx.InvalidURL as exc:
-        raise MediaDownloadPolicyError(f"Invalid media URL: {url!r}") from exc
+        raise MediaDownloadPolicyError(
+            f"Invalid media URL: {redact_url(url)!r}"
+        ) from exc
 
     if parsed.scheme not in ("http", "https") or not parsed.host:
         raise MediaDownloadPolicyError(
-            f"Media URL must be http(s) with a hostname, got: {url!r}"
+            f"Media URL must be http(s) with a hostname, got: {redact_url(url)!r}"
         )
 
-    allowed = _allowed_domains()
-    if allowed:
-        hostname = _normalize_hostname(parsed.host)
-        if hostname not in allowed:
-            # Do not echo the allowlist: it is deployment configuration.
-            raise MediaDownloadPolicyError(
-                f"Media URL domain {hostname!r} is not in the allowed domains list"
-            )
+    hostname = _normalize_hostname(parsed.host)
+    if not _hostname_is_allowed(hostname, exact, suffixes):
+        # Do not echo the allowlist: it is deployment configuration.
+        raise MediaDownloadPolicyError(
+            f"Media URL domain {hostname!r} is not in the allowed domains list"
+        )
     return parsed
 
 
@@ -166,20 +210,6 @@ def _get_shared_client() -> httpx.AsyncClient:
         _shared_client_loop = loop
     _shared_client.cookies.clear()
     return _shared_client
-
-
-def _warn_if_open_allowlist() -> None:
-    global _warned_open_allowlist
-    if _warned_open_allowlist:
-        return
-    if not _allowed_domains():
-        logger.warning(
-            "Media URL download is enabled with no media_url_allowed_domains; "
-            "any authenticated client can make this server fetch arbitrary "
-            "http(s) URLs (SSRF surface). Set an allowlist on deployments "
-            "reachable by untrusted clients."
-        )
-    _warned_open_allowlist = True
 
 
 async def download_media_url(
@@ -210,16 +240,18 @@ async def download_media_url(
         raise MediaDownloadError("media_url_timeout_seconds must be positive")
 
     current = check_media_url_policy(url)
-    _warn_if_open_allowlist()
     http_client = client if client is not None else _get_shared_client()
     if deadline is None:
         deadline = time.monotonic() + timeout_seconds
 
+    safe_url = redact_url(url)
     try:
         for redirect_count in range(max_redirects + 1):
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                raise MediaDownloadFetchError(f"Timed out downloading media URL: {url}")
+                raise MediaDownloadFetchError(
+                    f"Timed out downloading media URL: {safe_url}"
+                )
 
             async with http_client.stream(
                 "GET",
@@ -233,17 +265,17 @@ async def download_media_url(
                         raise MediaDownloadFetchError(
                             f"Media URL returned redirect HTTP "
                             f"{response.status_code} without a Location "
-                            f"header: {url}"
+                            f"header: {safe_url}"
                         )
                     if redirect_count == max_redirects:
                         raise MediaDownloadPolicyError(
-                            f"Media URL exceeded {max_redirects} redirects: {url}"
+                            f"Media URL exceeded {max_redirects} redirects: {safe_url}"
                         )
                     try:
                         target = str(current.join(location))
                     except httpx.InvalidURL as exc:
                         raise MediaDownloadPolicyError(
-                            f"Invalid redirect location {location!r}"
+                            f"Invalid redirect location {redact_url(location)!r}"
                         ) from exc
                     current = check_media_url_policy(target)
                     continue
@@ -251,7 +283,8 @@ async def download_media_url(
                 if response.status_code >= 400:
                     raise MediaDownloadFetchError(
                         f"Media URL returned HTTP {response.status_code} "
-                        f"(an expired presigned URL typically returns 403): {url}"
+                        f"(an expired presigned URL typically returns 403): "
+                        f"{safe_url}"
                     )
 
                 content_length = response.headers.get("content-length")
@@ -270,7 +303,7 @@ async def download_media_url(
                 async for chunk in response.aiter_bytes(_READ_CHUNK_BYTES):
                     if time.monotonic() > deadline:
                         raise MediaDownloadFetchError(
-                            f"Timed out downloading media URL: {url}"
+                            f"Timed out downloading media URL: {safe_url}"
                         )
                     if len(body) + len(chunk) > max_bytes:
                         raise MediaDownloadTooLargeError(
@@ -280,11 +313,11 @@ async def download_media_url(
                 return bytes(body)
     except httpx.TimeoutException as exc:
         raise MediaDownloadFetchError(
-            f"Timed out downloading media URL: {url}"
+            f"Timed out downloading media URL: {safe_url}"
         ) from exc
     except httpx.HTTPError as exc:
         raise MediaDownloadFetchError(
-            f"Failed to download media URL: {url} ({exc})"
+            f"Failed to download media URL: {safe_url} ({type(exc).__name__})"
         ) from exc
 
     raise AssertionError("unreachable: redirect loop must return or raise")


### PR DESCRIPTION
## Summary

Closes #4974.

`image_prompts[].image` on `POST /v1/videos/generations/i2v` now accepts an http(s) URL — e.g. a presigned S3 GET URL — next to inline base64. The server downloads the asset at the API layer, before the job is enqueued, and replaces the URL with base64. Runners, SHM spill, and workers are unchanged and keep seeing base64 only.

**Change class: semantics-altering** — a new accepted input shape on the I2V endpoint. Inline-base64 and multipart-upload flows are byte-for-byte unchanged.

## Design

All remote fetches go through one hardened downloader (`tt-media-server/utils/media_downloader.py`). The design copies the strongest parts of the two reference stacks (researched against vLLM `MediaConnector` @ 583a0025 and SGLang `download_remote_media` @ 5f128395):

- **http(s) only**; `data:`/`file:`/other schemes never reach the downloader.
- **Required hostname allowlist** (`MEDIA_URL_ALLOWED_DOMAINS`): deny-when-empty — URL-valued media is refused until an allowlist is configured, so the SSRF surface only exists where an operator opened it. Entries are exact hostnames or label-anchored wildcards (`*.s3.amazonaws.com` matches `bucket.s3.amazonaws.com` at any depth, never the bare suffix, never `evil-s3.amazonaws.com`), normalized (IDNA, case, IP literals) and re-checked on **every redirect hop**. URLs are validated as `httpx.URL` — the same parser the client connects with — because both vLLM SSRF CVEs (GHSA-qh4c-xf7m-gxfc, GHSA-v359-jj2v-j536) came from validator/client parser mismatch.
- **Manual redirect following** (301/302/303/307/308, max 5 by default); redirect without `Location` fails closed.
- **One total deadline** (default 30 s) shared across all of a request's assets — 81 URL entries cannot hold the connection open for 81 timeouts.
- **Streamed byte cap** (default 7,500,000 bytes — base64-encodes to exactly the existing 10,000,000-char `ImagePromptEntry.image` field cap), enforced via Content-Length precheck and again mid-stream.
- **Error taxonomy**: policy violation → 400, over cap → 413, origin error/timeout → 422 (an expired presigned URL surfaces as 422, not 500), server misconfiguration → 500. Downloaded bytes must PIL-decode or the request 422s.
- Presigned URLs need no special casing: query-string auth passes through because validation covers scheme + hostname only.
- Error and log text redacts URLs to scheme+host+path — presigned query strings carry credentials (`X-Amz-Signature`).
- `ImageManager.base64_to_pil_image` fails loudly if an unresolved URL ever reaches a runner's decoder (defense-in-depth for the "runners only see base64" invariant).

New env-driven settings (`config/settings.py`): `media_url_download_enabled`, `media_url_allowed_domains`, `media_url_max_bytes`, `media_url_timeout_seconds`, `media_url_max_redirects`.

## What the reviewer should verify

- The allowlist/redirect/cap/deadline policy in `utils/media_downloader.py` matches the description above (it is the security boundary).
- `_resolve_image_prompt_urls` in `open_ai_api/video.py` is the only place URL-shaped `image` values can pass, and every submit path (`/generations`, `/generations/i2v`, sync and async) funnels through `_submit_video_request`.
- The 413 guard on encoded length keeps SP-runner workers (which re-validate `ImagePromptEntry` from the side-file) from failing mid-job.

## Testing

- 44 new unit tests: `tests/test_media_downloader.py` (policy matrix on fake transports — no network) and `tests/test_video_media_url.py` (schema acceptance, wiring, error mapping).
- Adjacent suites green: `test_video_api`, `test_image_manager`, `test_video_manager`, `test_video_runner`, `test_mock_video_runner`, `test_sp_runner`, `test_scheduler` (219 passed, 1 pre-existing skip).
- `ruff check` and `ruff format --check` clean with the CI-pinned ruff 0.15.0.

## Known limitations / follow-ups

- No retry/backoff for S3 503 SlowDown (vLLM retries these; deliberate v1 non-goal).
- An origin that trickles bytes just inside the per-read timeout can stretch a hop somewhat past the deadline (closing this needs `asyncio.timeout`, Python 3.11+; base image is py3.10).
- URL acceptance for image (img2img/edits) and audio endpoints, and presigned *output* upload, are follow-ups; the downloader is written to be reused there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
