### PR TITLE
Add ASR audio pipeline latency metrics

### DIFF
--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -450,6 +450,18 @@ class AudioResponseFormat(Enum):
     OGG = "ogg"
 
 
+class AudioInputFormat(Enum):
+    """ASR workflow: container formats accepted on the transcription path.
+
+    UNKNOWN covers input that matches no known header, which is rejected during
+    conversion but still needs a name to be reported under.
+    """
+
+    WAV = "wav"
+    MP3 = "mp3"
+    UNKNOWN = "unknown"
+
+
 SDXL_VALID_IMAGE_RESOLUTIONS = frozenset({(1024, 1024), (512, 512)})
 
 

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -453,7 +453,7 @@ class AudioResponseFormat(Enum):
 class AudioInputFormat(Enum):
     """Container formats accepted on the transcription path.
 
-    UNKNOWN matches no known header: rejected, but still needs a metric label.
+    UNKNOWN matches no known header and is rejected.
     """
 
     WAV = "wav"

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -451,10 +451,9 @@ class AudioResponseFormat(Enum):
 
 
 class AudioInputFormat(Enum):
-    """ASR workflow: container formats accepted on the transcription path.
+    """Container formats accepted on the transcription path.
 
-    UNKNOWN covers input that matches no known header, which is rejected during
-    conversion but still needs a name to be reported under.
+    UNKNOWN matches no known header: rejected, but still needs a metric label.
     """
 
     WAV = "wav"

--- a/tt-media-server/model_services/audio_service.py
+++ b/tt-media-server/model_services/audio_service.py
@@ -26,16 +26,21 @@ def audio_worker_function(
     should_preprocess = settings.allow_audio_preprocessing and is_preprocessing_enabled
 
     # Process audio
-    audio_array, duration = audio_manager.to_audio_array(
-        audio_file_data, should_preprocess
-    )
+    prepared = audio_manager.to_audio_array(audio_file_data, should_preprocess)
+    audio_array = prepared.audio_array
     segments = (
         audio_manager.apply_diarization_with_vad(audio_array, perform_diarization)
         if should_preprocess
         else None
     )
 
-    return (audio_array, duration, segments)
+    return (
+        audio_array,
+        prepared.duration,
+        segments,
+        prepared.source_sample_rate,
+        prepared.source_channels,
+    )
 
 
 class AudioService(BaseService):
@@ -64,6 +69,8 @@ class AudioService(BaseService):
                 audio_array,
                 duration,
                 segments,
+                source_sample_rate,
+                source_channels,
             ) = await self._cpu_workload_handler.execute_task(
                 request.file,
                 request.is_preprocessing_enabled,
@@ -73,6 +80,10 @@ class AudioService(BaseService):
             request._audio_array = audio_array
             request._duration = duration
             request._segments = segments
+            # The submitted operating point, kept for the stage-throughput
+            # labels: the array itself is already mono at the default rate.
+            request._source_sample_rate = source_sample_rate
+            request._source_channels = source_channels
 
             if segments:
                 self.logger.info(
@@ -118,6 +129,13 @@ class AudioService(BaseService):
         ]
 
         new_request._duration = segment["end"] - segment["start"]
+        # A segment inherits the parent's operating point; it is the same audio.
+        new_request._source_sample_rate = getattr(
+            original_request, "_source_sample_rate", None
+        )
+        new_request._source_channels = getattr(
+            original_request, "_source_channels", None
+        )
         new_request.file = None  # Clear file data to save memory
 
         return new_request

--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
@@ -1938,6 +1938,367 @@
       "title": "Processing Bucket Occupancy (set the floor from this)",
       "type": "table"
     }
+    ,
+    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 109 }, "id": 810, "panels": [], "title": "ASR Stage Throughput (Whisper feature extraction and encoder)", "type": "row" },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Audio seconds consumed per wall-clock second per stage. Above 1.0 the stage keeps pace with live audio. Feature extraction is the preprocessing ceiling and normally sits well above the encoder — convergence means preprocessing has become the limit. The combined line is front-end capacity: audio seconds over extraction plus encoder time.\n\nEffective throughput, not utilisation: short chunks are padded to the 30s frame, so encoder cost is fixed per chunk and this falls with chunk length. A drop can mean fan-out rose, not that the device slowed — read against Chunk Fan-out above.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 0, "thresholdsStyle": { "mode": "line" } }, "unit": "none", "decimals": 1, "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }, { "color": "green", "value": 1 }] } } },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 110 },
+      "id": 36,
+      "options": { "legend": { "calcs": ["mean", "min"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_feature_extraction_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval])) / sum(rate(tt_media_server_audio_feature_extraction_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval]))",
+          "legendFormat": "feature extraction",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval])) / sum(rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval]))",
+          "legendFormat": "encoder",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval])) / (sum(rate(tt_media_server_audio_feature_extraction_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval])) + sum(rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval])))",
+          "legendFormat": "combined front-end",
+          "refId": "C"
+        }
+      ],
+      "title": "Stage Throughput (audio seconds/s, 1.0 = real time)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Batch: a larger batch amortises one encoder pass over more audio, so throughput should rise with it — a flat line means batching buys nothing. Device: divergence on the same model is the fleet-capacity signal. Both exclude the trace-capture call.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "none", "decimals": 1 } },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 110 },
+      "id": 37,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (batch) (rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval])) / sum by (batch) (rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval]))",
+          "legendFormat": "batch {{batch}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (device_id) (rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval])) / sum by (device_id) (rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval]))",
+          "legendFormat": "device {{device_id}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Encoder Throughput by Batch and Device",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Per-batch wall time in each stage. Extraction is host CPU over fixed-size frames, so it should be near-flat — a rising p95 points at host contention, not the model. The encoder spans device preprocessing, the encoder stack and the synchronize.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 119 },
+      "id": 38,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(tt_media_server_audio_feature_extraction_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[5m])))",
+          "legendFormat": "extraction p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(tt_media_server_audio_feature_extraction_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[5m])))",
+          "legendFormat": "extraction p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(tt_media_server_audio_encoder_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[5m])))",
+          "legendFormat": "encoder p50",
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(tt_media_server_audio_encoder_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[5m])))",
+          "legendFormat": "encoder p95",
+          "refId": "D"
+        }
+      ],
+      "title": "Stage Latency Quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Mean encoder time by trace_hit. trace_hit=\"false\" is the trace-capture call: it runs the encoder twice, so every other panel filters it out. Kept visible for its rate — a steady stream of captures means the batch bucket keeps changing and traces are thrown away rather than replayed.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" }, "overrides": [{ "matcher": { "id": "byName", "options": "capture calls/s" }, "properties": [{ "id": "unit", "value": "reqps" }, { "id": "custom.axisPlacement", "value": "right" }] }] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 119 },
+      "id": 39,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (trace_hit) (rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum by (trace_hit) (rate(tt_media_server_audio_encoder_duration_seconds_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "mean encoder s (trace_hit={{trace_hit}})",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_encoder_duration_seconds_count{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"false\"}[5m]))",
+          "legendFormat": "capture calls/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Trace-Capture Overhead (excluded from the panels above)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Cumulative count at or below each bucket boundary. The smallest `le` with a non-zero count is the real lower bound — everything below is wasted resolution; if the largest finite bucket holds everything, the ceiling can come down. Re-read after any change to chunk length or device count.",
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 127 },
+      "id": 40,
+      "options": { "showHeader": true, "sortBy": [{ "displayName": "le", "desc": false }] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (le) (increase(tt_media_server_audio_feature_extraction_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "extraction {{le}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (le) (increase(tt_media_server_audio_encoder_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "encoder {{le}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Stage Duration Bucket Occupancy (set the buckets from this)",
+      "type": "table"
+    }
+
+    ,
+    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 135 }, "id": 820, "panels": [], "title": "ASR VAD Overhead", "type": "row" },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Wall time to find speech and endpoint boundaries, per request. VAD gates when inference starts, so this is pure added latency ahead of the encoder — compare it against Chunk First-Item Latency to see which dominates. Quantiles cover successful runs only; a timeout shows up as delay under outcome=\"failed\", not as a non-event.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 136 },
+      "id": 41,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(tt_media_server_audio_vad_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",outcome=\"ok\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(tt_media_server_audio_vad_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",outcome=\"ok\"}[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (outcome) (rate(tt_media_server_audio_vad_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum by (outcome) (rate(tt_media_server_audio_vad_seconds_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "mean ({{outcome}})",
+          "refId": "C"
+        }
+      ],
+      "title": "VAD Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "CPU consumed by the VAD worker process divided by its wall time — cores in use, not the caller's clock. Above 1.0 the model went multi-threaded; well below 1.0 with a high latency means the worker was waiting, not computing. Mean CPU seconds per request is the number to multiply by request rate when sizing host cores.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "thresholdsStyle": { "mode": "line" } }, "unit": "none", "decimals": 2, "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }, { "color": "orange", "value": 1 }] } }, "overrides": [{ "matcher": { "id": "byName", "options": "mean CPU seconds" }, "properties": [{ "id": "unit", "value": "s" }, { "id": "custom.axisPlacement", "value": "right" }] }] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 136 },
+      "id": 42,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_vad_cpu_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum(rate(tt_media_server_audio_vad_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",outcome=\"ok\"}[5m]))",
+          "legendFormat": "cores in use",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_vad_cpu_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum(rate(tt_media_server_audio_vad_cpu_seconds_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "mean CPU seconds",
+          "refId": "B"
+        }
+      ],
+      "title": "VAD CPU Utilisation",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Speech segments returned per request. This is the endpointing-health signal a duration alone will not show: a collapse toward 1 means VAD stopped splitting and the whole request becomes one long chunk, a jump into the hundreds means it is fragmenting and every fragment pays a full encoder frame. Read against Chunk Fan-out above, which is what these segments merge into.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 144 },
+      "id": 43,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_vad_segments_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum(rate(tt_media_server_audio_vad_segments_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "mean segments",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(tt_media_server_audio_vad_segments_bucket{service=~\"$service\",model_type=~\"$model_type\"}[5m])))",
+          "legendFormat": "p95 segments",
+          "refId": "B"
+        }
+      ],
+      "title": "VAD Segments per Request",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Share of VAD calls that returned nothing, against the call rate. A failure is not a dropped request — the caller falls back to one segment spanning the whole audio, so the cost lands downstream as one oversized chunk. Any sustained non-zero share means the audio venv worker is timing out or respawning.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 10 }, "unit": "percentunit", "min": 0 }, "overrides": [{ "matcher": { "id": "byName", "options": "VAD calls/s" }, "properties": [{ "id": "unit", "value": "reqps" }, { "id": "custom.axisPlacement", "value": "right" }] }] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 144 },
+      "id": 44,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_vad_seconds_count{service=~\"$service\",model_type=~\"$model_type\",outcome=\"failed\"}[5m])) / clamp_min(sum(rate(tt_media_server_audio_vad_seconds_count{service=~\"$service\",model_type=~\"$model_type\"}[5m])), 0.0001)",
+          "legendFormat": "failure share",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_vad_seconds_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "VAD calls/s",
+          "refId": "B"
+        }
+      ],
+      "title": "VAD Failure Share",
+      "type": "timeseries"
+    }
+
+    ,
+    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 152 }, "id": 830, "panels": [], "title": "ASR Input Preparation and Chunking", "type": "row" },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Time to base64-decode, container-decode, resample and length-check submitted audio, before VAD sees it. Split by container: mp3 carries a real decode cost that wav does not, so a shift in the format mix moves this without anything regressing. Observed on success only — rejected uploads (unknown header, oversize) never reach it, so the call rate here is accepted requests, not offered load.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" }, "overrides": [{ "matcher": { "id": "byName", "options": "accepted/s" }, "properties": [{ "id": "unit", "value": "reqps" }, { "id": "custom.axisPlacement", "value": "right" }] }] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 153 },
+      "id": 45,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(tt_media_server_audio_input_preparation_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[5m])))",
+          "legendFormat": "p95",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (format) (rate(tt_media_server_audio_input_preparation_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum by (format) (rate(tt_media_server_audio_input_preparation_seconds_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "mean ({{format}})",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_input_preparation_seconds_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "accepted/s",
+          "refId": "C"
+        }
+      ],
+      "title": "Input Preparation Latency by Format",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "The segment-merge step only — VAD and diarization are inference and live in the row above, so this is pure host arithmetic and should stay in the microseconds. Per-chunk cost divides it by the chunks produced, which is the number to watch if merging ever stops being free. diarization mode merges within speaker boundaries and so does more work than vad_only.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 153 },
+      "id": 46,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (mode) (rate(tt_media_server_audio_chunking_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum by (mode) (rate(tt_media_server_audio_chunking_seconds_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "mean per request ({{mode}})",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (mode) (rate(tt_media_server_audio_chunking_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum by (mode) (rate(tt_media_server_audio_chunks_per_request_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "per chunk produced ({{mode}})",
+          "refId": "B"
+        }
+      ],
+      "title": "Chunking Latency by Mode",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Chunk fan-out split by mode, the multiplier on every per-chunk cost downstream: each chunk pays a full 30s encoder frame however short it is. diarization should sit above vad_only because speaker changes force a chunk boundary that duration alone would not. A rise here with flat VAD segment counts means merging is splitting more, not that the audio changed.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 161 },
+      "id": 47,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (mode) (rate(tt_media_server_audio_chunks_per_request_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum by (mode) (rate(tt_media_server_audio_chunks_per_request_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "mean ({{mode}})",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.95, sum by (le, mode) (rate(tt_media_server_audio_chunks_per_request_bucket{service=~\"$service\",model_type=~\"$model_type\"}[5m])))",
+          "legendFormat": "p95 ({{mode}})",
+          "refId": "B"
+        }
+      ],
+      "title": "Chunks per Request by Mode",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Mean host-side seconds per request for the three stages that run before the device is touched, stacked. All three are observed once per request, so the heights are directly comparable and the total is the fixed latency floor no device speed-up can remove. VAD normally dominates by orders of magnitude; if input preparation ever rivals it, look at the format mix.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 25, "stacking": { "mode": "normal", "group": "A" } }, "unit": "s" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 161 },
+      "id": 48,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_input_preparation_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum(rate(tt_media_server_audio_input_preparation_seconds_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "input preparation",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_vad_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum(rate(tt_media_server_audio_vad_seconds_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "VAD",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_chunking_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum(rate(tt_media_server_audio_chunking_seconds_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "chunking",
+          "refId": "C"
+        }
+      ],
+      "title": "Host-Side Front-End Cost per Request",
+      "type": "timeseries"
+    }
+
   ],
   "refresh": "5s",
   "schemaVersion": 38,

--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
@@ -1787,13 +1787,13 @@
         { "id": "organize", "options": { "excludeByName": { "Time": true, "Value": true, "__name__": true, "job": true, "instance": true } } }
       ]
     },
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 83 }, "id": 800, "panels": [], "title": "ASR Per-Chunk Latency (streaming only)", "type": "row" },
+    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 173 }, "id": 860, "panels": [], "title": "ASR Per-Chunk Latency (streaming only)", "type": "row" },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Time from chunk hand-off to the first emitted item. Bundles log-mel extraction (~2ms, constant because Whisper pads every chunk to a 30s frame), the encoder pass and the first decode step: tt-metal's WhisperGenerator fuses all three, so they cannot be separated. Unaffected by consumer backpressure.",
       "fieldConfig": { "defaults": { "custom": { "scaleDistribution": { "type": "log", "log": 10 } }, "unit": "s" } },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 84 },
-      "id": 30,
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 174 },
+      "id": 60,
       "options": {
         "calculate": false,
         "color": { "scheme": "Spectral", "mode": "scheme", "exponent": 0.5, "steps": 64, "reverse": false },
@@ -1817,8 +1817,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Wall time to transcribe one chunk end to end. The streaming loop yields to its consumer inside this span, so a slow client inflates this without inflating the first-item metric.",
       "fieldConfig": { "defaults": { "custom": { "scaleDistribution": { "type": "log", "log": 10 } }, "unit": "s" } },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 84 },
-      "id": 31,
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 174 },
+      "id": 61,
       "options": {
         "calculate": false,
         "color": { "scheme": "Spectral", "mode": "scheme", "exponent": 0.5, "steps": 64, "reverse": false },
@@ -1842,8 +1842,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Quantiles of both per-chunk spans. First-item is contained in processing by construction, so the first-item lines should always sit below their processing counterparts.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 93 },
-      "id": 32,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 183 },
+      "id": 62,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -1878,8 +1878,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Mean seconds per chunk, derived from _sum / _count rather than quantiles, alongside chunk fan-out. Fan-out is the multiplier that makes per-chunk cost matter: every chunk pays a full 30s-frame encoder pass regardless of how short it is, so a heavily diarized request does many times the encoder work of the same audio in fewer chunks.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 } } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 93 },
-      "id": 33,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 183 },
+      "id": 63,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -1902,8 +1902,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Cumulative observation count at or below each bucket boundary over the selected range. Buckets are cumulative, so the smallest `le` with a non-zero count is the real lower bound of the distribution: everything below it is wasted resolution and the floor can be raised to it.",
       "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 101 },
-      "id": 34,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 191 },
+      "id": 64,
       "options": { "showHeader": true, "sortBy": [{ "displayName": "le", "desc": false }] },
       "targets": [
         {
@@ -1922,8 +1922,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Cumulative observation count at or below each bucket boundary over the selected range. Read the top boundary the same way: if the largest finite bucket already holds every observation, the ceiling can be lowered.",
       "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 101 },
-      "id": 35,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 191 },
+      "id": 65,
       "options": { "showHeader": true, "sortBy": [{ "displayName": "le", "desc": false }] },
       "targets": [
         {
@@ -1939,13 +1939,13 @@
       "type": "table"
     }
     ,
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 109 }, "id": 810, "panels": [], "title": "ASR Stage Throughput (feature extraction and encoder)", "type": "row" },
+    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 199 }, "id": 861, "panels": [], "title": "ASR Stage Throughput (feature extraction and encoder)", "type": "row" },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
-      "description": "Recorded by the ASR runner only; empty for other model types. Audio seconds each stage converts per second **spent inside that stage** — the stage's own capacity, not the server's ingest rate. The denominator is stage-busy time, not wall-clock time, so this does NOT tell you whether the fleet keeps pace with live audio: an encoder busy 10% of the time reads ten times the real-time factor. Use `Ingest Rate` for the keeps-pace question and read this as headroom.\n\nFeature extraction is the preprocessing ceiling and normally sits well above the encoder — convergence means preprocessing has become the limit. The combined line is audio seconds over extraction plus encoder time.\n\nCapacity, not utilisation: short chunks are padded to the 30s frame, so both stages cost the same per chunk whatever its length and this falls with chunk length. A drop can mean fan-out rose, not that the device slowed — read against Chunk Fan-out above.",
+      "description": "Recorded by the ASR runner only; empty for other model types. Also empty until tt-metal #53717 (PerfMetrics) is in the pinned tt-metal build: the runner probes for it at import and leaves these counters untouched when it is absent, so an empty row here means the dependency has not landed yet, not that the server is idle. Cross-check with the VAD and Input Preparation rows below, which do not depend on it. Audio seconds each stage converts per second **spent inside that stage** — the stage's own capacity, not the server's ingest rate. The denominator is stage-busy time, not wall-clock time, so this does NOT tell you whether the fleet keeps pace with live audio: an encoder busy 10% of the time reads ten times the real-time factor. Use `Ingest Rate` for the keeps-pace question and read this as headroom.\n\nFeature extraction is the preprocessing ceiling and normally sits well above the encoder — convergence means preprocessing has become the limit. The combined line is audio seconds over extraction plus encoder time.\n\nCapacity, not utilisation: short chunks are padded to the 30s frame, so both stages cost the same per chunk whatever its length and this falls with chunk length. A drop can mean fan-out rose, not that the device slowed — read against Chunk Fan-out above.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 0 }, "unit": "suffix:audio-s/s", "decimals": 1 } },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 110 },
-      "id": 36,
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 200 },
+      "id": 66,
       "options": { "legend": { "calcs": ["mean", "min"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -1974,8 +1974,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Audio seconds per encoder-busy second, broken down. Batch: a larger batch amortises one encoder pass over more audio, so this should rise with it — a flat line means batching buys nothing. Device: divergence on the same model is the fleet-capacity signal. Both exclude the trace-capture call.\n\nSame stage-busy denominator as Stage Capacity, so these are per-device capacity figures and are independent of how loaded the device is.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "suffix:audio-s/s", "decimals": 1 } },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 110 },
-      "id": 37,
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 200 },
+      "id": 67,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -1998,8 +1998,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Per-batch wall time in each stage. Extraction is host CPU over fixed-size frames, so it should be near-flat — a rising p95 points at host contention, not the model. The encoder spans device preprocessing, the encoder stack and the synchronize.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 119 },
-      "id": 38,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 209 },
+      "id": 68,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -2034,8 +2034,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Mean encoder time by trace_hit. trace_hit=\"false\" is the trace-capture call: it runs the encoder twice, so the per-stage lines filter it out. Two exceptions include it deliberately, because feature extraction carries no trace_hit label and a one-sided filter would divide mismatched sets: Stage Capacity's combined line and Ingest Rate. Kept visible for its rate — a steady stream of captures means the batch bucket keeps changing and traces are thrown away rather than replayed.\n\nExpect this to be flat after startup: the capture counter freezes once every batch bucket has a trace, so rate() over it goes to zero and target A's trace_hit=\"false\" series drops out.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" }, "overrides": [{ "matcher": { "id": "byName", "options": "capture calls/s" }, "properties": [{ "id": "unit", "value": "reqps" }, { "id": "custom.axisPlacement", "value": "right" }] }] },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 119 },
-      "id": 39,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 209 },
+      "id": 69,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -2058,8 +2058,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Audio seconds ingested per wall-clock second — the real-time factor, and the only panel in this row that answers \"can the fleet keep pace with live audio?\". Above 1.0 the server consumes audio faster than real time; below 1.0 a live stream falls behind and the backlog grows.\n\nThis is the bare numerator of Stage Capacity, with no stage-busy denominator, so it moves with offered load as well as device speed: a low value on an idle server means nothing was submitted, not that the encoder is slow. Read it against Stage Capacity — capacity high but ingest below 1.0 means the front end has headroom and the bottleneck is elsewhere.\n\nSourced from the feature-extraction counter, which carries no trace_hit label, so trace-capture batches are included.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "thresholdsStyle": { "mode": "line" } }, "unit": "suffix:audio-s/s", "decimals": 2, "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }, { "color": "green", "value": 1 }] } } },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 127 },
-      "id": 49,
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 217 },
+      "id": 70,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -2082,8 +2082,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Cumulative count at or below each bucket boundary, both stages joined on `le`. The smallest `le` with a non-zero count is the real lower bound — everything below is wasted resolution; if the largest finite bucket holds everything, the ceiling can come down. Re-read after any change to chunk length or device count.\n\n`le` is converted to a number before sorting: as the raw string label it sorts lexicographically, which puts `+Inf` first and `10.0` ahead of `2.5` and makes the \"smallest non-zero\" reading above wrong. `+Inf` does not parse and sorts last.",
       "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 127 },
-      "id": 40,
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 217 },
+      "id": 71,
       "options": { "showHeader": true, "sortBy": [{ "displayName": "le", "desc": false }] },
       "transformations": [
         { "id": "joinByField", "options": { "byField": "le", "mode": "outer" } },
@@ -2117,8 +2117,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Feature-extraction capacity split by the operating point the audio was submitted at. `sample_rate` and `channels` are the source values read off the container header, not the array the extractor sees — audio_manager downmixes to mono and resamples to 16 kHz before the runner is reached, so these are the only record of what arrived.\n\n`unknown` means the decode path normalised the source away before it could be read: ffmpeg is invoked with `-ar/-ac`, so every non-WAV format lands here until an ffprobe pass is added. `mixed` means a batch's items disagreed and the batch was credited under neither.\n\nA high-rate or multi-channel source costs more to decode but not more to extract — the array is mono 16 kHz by then — so a split here points at the decode stage, not the extractor.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "suffix:audio-s/s", "decimals": 1 } },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 135 },
-      "id": 50,
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 225 },
+      "id": 72,
       "options": { "legend": { "calcs": ["mean", "min"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -2143,13 +2143,13 @@
       "title": "Feature Extraction Capacity by Source Rate, Channels and Batch",
       "type": "timeseries"
     },
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 143 }, "id": 820, "panels": [], "title": "ASR VAD Overhead", "type": "row" },
+    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 233 }, "id": 862, "panels": [], "title": "ASR VAD Overhead", "type": "row" },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Wall time to find speech and endpoint boundaries, per request. VAD gates when inference starts, so this is pure added latency ahead of the encoder — compare it against Chunk First-Item Latency to see which dominates. Quantiles cover successful runs only; a timeout shows up as delay under outcome=\"failed\", not as a non-event.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 144 },
-      "id": 41,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 234 },
+      "id": 73,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -2178,8 +2178,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "CPU consumed by the VAD worker process divided by its wall time — cores in use, not the caller's clock. Above 1.0 the model went multi-threaded; well below 1.0 with a high latency means the worker was waiting, not computing. Mean CPU seconds per request is the number to multiply by request rate when sizing host cores.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "thresholdsStyle": { "mode": "line" } }, "unit": "none", "decimals": 2, "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }, { "color": "orange", "value": 1 }] } }, "overrides": [{ "matcher": { "id": "byName", "options": "mean CPU seconds" }, "properties": [{ "id": "unit", "value": "s" }, { "id": "custom.axisPlacement", "value": "right" }] }] },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 144 },
-      "id": 42,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 234 },
+      "id": 74,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -2202,8 +2202,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Speech segments returned per request. This is the endpointing-health signal a duration alone will not show: a collapse toward 1 means VAD stopped splitting and the whole request becomes one long chunk, a jump into the hundreds means it is fragmenting and every fragment pays a full encoder frame. Read against Chunk Fan-out above, which is what these segments merge into.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 152 },
-      "id": 43,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 242 },
+      "id": 75,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -2226,8 +2226,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Share of VAD calls that returned nothing, against the call rate. A failure is not a dropped request — the caller falls back to one segment spanning the whole audio, so the cost lands downstream as one oversized chunk. Any sustained non-zero share means the audio venv worker is timing out or respawning.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 10 }, "unit": "percentunit", "min": 0 }, "overrides": [{ "matcher": { "id": "byName", "options": "VAD calls/s" }, "properties": [{ "id": "unit", "value": "reqps" }, { "id": "custom.axisPlacement", "value": "right" }] }] },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 152 },
-      "id": 44,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 242 },
+      "id": 76,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -2248,13 +2248,13 @@
     }
 
     ,
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 160 }, "id": 830, "panels": [], "title": "ASR Input Preparation and Chunking", "type": "row" },
+    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 250 }, "id": 863, "panels": [], "title": "ASR Input Preparation and Chunking", "type": "row" },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Time to base64-decode, container-decode, resample and length-check submitted audio, before VAD sees it. Split by container: mp3 carries a real decode cost that wav does not, so a shift in the format mix moves this without anything regressing. Observed on success only — rejected uploads (unknown header, oversize) never reach it, so the call rate here is accepted requests, not offered load.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" }, "overrides": [{ "matcher": { "id": "byName", "options": "accepted/s" }, "properties": [{ "id": "unit", "value": "reqps" }, { "id": "custom.axisPlacement", "value": "right" }] }] },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 161 },
-      "id": 45,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 251 },
+      "id": 77,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -2283,8 +2283,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "The segment-merge step only — VAD and diarization are inference and live in the row above, so this is pure host arithmetic and should stay in the microseconds. Per-chunk cost divides it by the chunks produced, which is the number to watch if merging ever stops being free. diarization mode merges within speaker boundaries and so does more work than vad_only.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 161 },
-      "id": 46,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 251 },
+      "id": 78,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -2307,8 +2307,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Chunk fan-out split by mode, the multiplier on every per-chunk cost downstream: each chunk pays a full 30s encoder frame however short it is. diarization should sit above vad_only because speaker changes force a chunk boundary that duration alone would not. A rise here with flat VAD segment counts means merging is splitting more, not that the audio changed.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 169 },
-      "id": 47,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 259 },
+      "id": 79,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {
@@ -2331,8 +2331,8 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Mean host-side seconds per request for the three stages that run before the device is touched, stacked. All three are observed once per request, so the heights are directly comparable and the total is the fixed latency floor no device speed-up can remove. VAD normally dominates by orders of magnitude; if input preparation ever rivals it, look at the format mix.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 25, "stacking": { "mode": "normal", "group": "A" } }, "unit": "s" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 169 },
-      "id": 48,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 259 },
+      "id": 80,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
         {

--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
@@ -1787,7 +1787,7 @@
         { "id": "organize", "options": { "excludeByName": { "Time": true, "Value": true, "__name__": true, "job": true, "instance": true } } }
       ]
     },
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 83 }, "id": 800, "panels": [], "title": "ASR Per-Chunk Latency (Whisper streaming only)", "type": "row" },
+    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 83 }, "id": 800, "panels": [], "title": "ASR Per-Chunk Latency (streaming only)", "type": "row" },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Time from chunk hand-off to the first emitted item. Bundles log-mel extraction (~2ms, constant because Whisper pads every chunk to a 30s frame), the encoder pass and the first decode step: tt-metal's WhisperGenerator fuses all three, so they cannot be separated. Unaffected by consumer backpressure.",
@@ -1939,10 +1939,10 @@
       "type": "table"
     }
     ,
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 109 }, "id": 810, "panels": [], "title": "ASR Stage Throughput (Whisper feature extraction and encoder)", "type": "row" },
+    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 109 }, "id": 810, "panels": [], "title": "ASR Stage Throughput (feature extraction and encoder)", "type": "row" },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
-      "description": "Audio seconds consumed per wall-clock second per stage. Above 1.0 the stage keeps pace with live audio. Feature extraction is the preprocessing ceiling and normally sits well above the encoder — convergence means preprocessing has become the limit. The combined line is front-end capacity: audio seconds over extraction plus encoder time.\n\nEffective throughput, not utilisation: short chunks are padded to the 30s frame, so encoder cost is fixed per chunk and this falls with chunk length. A drop can mean fan-out rose, not that the device slowed — read against Chunk Fan-out above.",
+      "description": "Recorded by the ASR runner only; empty for other model types. Audio seconds consumed per wall-clock second per stage. Above 1.0 the stage keeps pace with live audio. Feature extraction is the preprocessing ceiling and normally sits well above the encoder — convergence means preprocessing has become the limit. The combined line is front-end capacity: audio seconds over extraction plus encoder time.\n\nEffective throughput, not utilisation: short chunks are padded to the 30s frame, so encoder cost is fixed per chunk and this falls with chunk length. A drop can mean fan-out rose, not that the device slowed — read against Chunk Fan-out above.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 0, "thresholdsStyle": { "mode": "line" } }, "unit": "none", "decimals": 1, "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }, { "color": "green", "value": 1 }] } } },
       "gridPos": { "h": 9, "w": 12, "x": 0, "y": 110 },
       "id": 36,

--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
@@ -1786,6 +1786,157 @@
       "transformations": [
         { "id": "organize", "options": { "excludeByName": { "Time": true, "Value": true, "__name__": true, "job": true, "instance": true } } }
       ]
+    },
+    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 83 }, "id": 800, "panels": [], "title": "ASR Per-Chunk Latency (Whisper streaming only)", "type": "row" },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Time from chunk hand-off to the first emitted item. Bundles log-mel extraction (~2ms, constant because Whisper pads every chunk to a 30s frame), the encoder pass and the first decode step: tt-metal's WhisperGenerator fuses all three, so they cannot be separated. Unaffected by consumer backpressure.",
+      "fieldConfig": { "defaults": { "custom": { "scaleDistribution": { "type": "log", "log": 10 } }, "unit": "s" } },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 84 },
+      "id": 30,
+      "options": {
+        "calculate": false,
+        "color": { "scheme": "Spectral", "mode": "scheme", "exponent": 0.5, "steps": 64, "reverse": false },
+        "legend": { "show": true },
+        "tooltip": { "show": true, "yHistogram": false },
+        "yAxis": { "axisPlacement": "left", "unit": "s" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (le) (rate(tt_media_server_audio_chunk_first_token_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Chunk First-Item Latency Heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Wall time to transcribe one chunk end to end. The streaming loop yields to its consumer inside this span, so a slow client inflates this without inflating the first-item metric.",
+      "fieldConfig": { "defaults": { "custom": { "scaleDistribution": { "type": "log", "log": 10 } }, "unit": "s" } },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 84 },
+      "id": 31,
+      "options": {
+        "calculate": false,
+        "color": { "scheme": "Spectral", "mode": "scheme", "exponent": 0.5, "steps": 64, "reverse": false },
+        "legend": { "show": true },
+        "tooltip": { "show": true, "yHistogram": false },
+        "yAxis": { "axisPlacement": "left", "unit": "s" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (le) (rate(tt_media_server_audio_chunk_processing_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Chunk Processing Latency Heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Quantiles of both per-chunk spans. First-item is contained in processing by construction, so the first-item lines should always sit below their processing counterparts.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 93 },
+      "id": 32,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(tt_media_server_audio_chunk_first_token_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[5m])))",
+          "legendFormat": "first-item p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(tt_media_server_audio_chunk_first_token_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[5m])))",
+          "legendFormat": "first-item p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(tt_media_server_audio_chunk_processing_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[5m])))",
+          "legendFormat": "processing p50",
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(tt_media_server_audio_chunk_processing_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[5m])))",
+          "legendFormat": "processing p95",
+          "refId": "D"
+        }
+      ],
+      "title": "Per-Chunk Latency Quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Mean seconds per chunk, derived from _sum / _count rather than quantiles, alongside chunk fan-out. Fan-out is the multiplier that makes per-chunk cost matter: every chunk pays a full 30s-frame encoder pass regardless of how short it is, so a heavily diarized request does many times the encoder work of the same audio in fewer chunks.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 } } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 93 },
+      "id": 33,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_chunk_processing_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum(rate(tt_media_server_audio_chunk_processing_seconds_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "mean seconds per chunk",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_chunks_per_request_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum(rate(tt_media_server_audio_chunks_per_request_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "mean chunks per request",
+          "refId": "B"
+        }
+      ],
+      "title": "Mean Cost per Chunk and Chunk Fan-out",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Cumulative observation count at or below each bucket boundary over the selected range. Buckets are cumulative, so the smallest `le` with a non-zero count is the real lower bound of the distribution: everything below it is wasted resolution and the floor can be raised to it.",
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 101 },
+      "id": 34,
+      "options": { "showHeader": true, "sortBy": [{ "displayName": "le", "desc": false }] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (le) (increase(tt_media_server_audio_chunk_first_token_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "First-Item Bucket Occupancy (set the floor from this)",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Cumulative observation count at or below each bucket boundary over the selected range. Read the top boundary the same way: if the largest finite bucket already holds every observation, the ceiling can be lowered.",
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 101 },
+      "id": 35,
+      "options": { "showHeader": true, "sortBy": [{ "displayName": "le", "desc": false }] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (le) (increase(tt_media_server_audio_chunk_processing_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Processing Bucket Occupancy (set the floor from this)",
+      "type": "table"
     }
   ],
   "refresh": "5s",

--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
@@ -1942,8 +1942,8 @@
     { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 109 }, "id": 810, "panels": [], "title": "ASR Stage Throughput (feature extraction and encoder)", "type": "row" },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
-      "description": "Recorded by the ASR runner only; empty for other model types. Audio seconds consumed per wall-clock second per stage. Above 1.0 the stage keeps pace with live audio. Feature extraction is the preprocessing ceiling and normally sits well above the encoder — convergence means preprocessing has become the limit. The combined line is front-end capacity: audio seconds over extraction plus encoder time.\n\nEffective throughput, not utilisation: short chunks are padded to the 30s frame, so encoder cost is fixed per chunk and this falls with chunk length. A drop can mean fan-out rose, not that the device slowed — read against Chunk Fan-out above.",
-      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 0, "thresholdsStyle": { "mode": "line" } }, "unit": "none", "decimals": 1, "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }, { "color": "green", "value": 1 }] } } },
+      "description": "Recorded by the ASR runner only; empty for other model types. Audio seconds each stage converts per second **spent inside that stage** — the stage's own capacity, not the server's ingest rate. The denominator is stage-busy time, not wall-clock time, so this does NOT tell you whether the fleet keeps pace with live audio: an encoder busy 10% of the time reads ten times the real-time factor. Use `Ingest Rate` for the keeps-pace question and read this as headroom.\n\nFeature extraction is the preprocessing ceiling and normally sits well above the encoder — convergence means preprocessing has become the limit. The combined line is audio seconds over extraction plus encoder time.\n\nCapacity, not utilisation: short chunks are padded to the 30s frame, so both stages cost the same per chunk whatever its length and this falls with chunk length. A drop can mean fan-out rose, not that the device slowed — read against Chunk Fan-out above.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 0 }, "unit": "suffix:audio-s/s", "decimals": 1 } },
       "gridPos": { "h": 9, "w": 12, "x": 0, "y": 110 },
       "id": 36,
       "options": { "legend": { "calcs": ["mean", "min"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
@@ -1962,18 +1962,18 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "sum(rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval])) / (sum(rate(tt_media_server_audio_feature_extraction_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval])) + sum(rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval])))",
-          "legendFormat": "combined front-end",
+          "expr": "sum(rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval])) / (sum(rate(tt_media_server_audio_feature_extraction_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval])) + sum(rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval])))",
+          "legendFormat": "combined front-end (incl. trace capture)",
           "refId": "C"
         }
       ],
-      "title": "Stage Throughput (audio seconds/s, 1.0 = real time)",
+      "title": "Stage Capacity (audio seconds per stage-busy second)",
       "type": "timeseries"
     },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
-      "description": "Batch: a larger batch amortises one encoder pass over more audio, so throughput should rise with it — a flat line means batching buys nothing. Device: divergence on the same model is the fleet-capacity signal. Both exclude the trace-capture call.",
-      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "none", "decimals": 1 } },
+      "description": "Audio seconds per encoder-busy second, broken down. Batch: a larger batch amortises one encoder pass over more audio, so this should rise with it — a flat line means batching buys nothing. Device: divergence on the same model is the fleet-capacity signal. Both exclude the trace-capture call.\n\nSame stage-busy denominator as Stage Capacity, so these are per-device capacity figures and are independent of how loaded the device is.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "suffix:audio-s/s", "decimals": 1 } },
       "gridPos": { "h": 9, "w": 12, "x": 12, "y": 110 },
       "id": 37,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
@@ -2032,7 +2032,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
-      "description": "Mean encoder time by trace_hit. trace_hit=\"false\" is the trace-capture call: it runs the encoder twice, so every other panel filters it out. Kept visible for its rate — a steady stream of captures means the batch bucket keeps changing and traces are thrown away rather than replayed.",
+      "description": "Mean encoder time by trace_hit. trace_hit=\"false\" is the trace-capture call: it runs the encoder twice, so the per-stage lines filter it out. Two exceptions include it deliberately, because feature extraction carries no trace_hit label and a one-sided filter would divide mismatched sets: Stage Capacity's combined line and Ingest Rate. Kept visible for its rate — a steady stream of captures means the batch bucket keeps changing and traces are thrown away rather than replayed.\n\nExpect this to be flat after startup: the capture counter freezes once every batch bucket has a trace, so rate() over it goes to zero and target A's trace_hit=\"false\" series drops out.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" }, "overrides": [{ "matcher": { "id": "byName", "options": "capture calls/s" }, "properties": [{ "id": "unit", "value": "reqps" }, { "id": "custom.axisPlacement", "value": "right" }] }] },
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 119 },
       "id": 39,
@@ -2056,9 +2056,33 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Audio seconds ingested per wall-clock second — the real-time factor, and the only panel in this row that answers \"can the fleet keep pace with live audio?\". Above 1.0 the server consumes audio faster than real time; below 1.0 a live stream falls behind and the backlog grows.\n\nThis is the bare numerator of Stage Capacity, with no stage-busy denominator, so it moves with offered load as well as device speed: a low value on an idle server means nothing was submitted, not that the encoder is slow. Read it against Stage Capacity — capacity high but ingest below 1.0 means the front end has headroom and the bottleneck is elsewhere.\n\nSourced from the feature-extraction counter, which carries no trace_hit label, so trace-capture batches are included.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "thresholdsStyle": { "mode": "line" } }, "unit": "suffix:audio-s/s", "decimals": 2, "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }, { "color": "green", "value": 1 }] } } },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 127 },
+      "id": 49,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_audio_feature_extraction_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval]))",
+          "legendFormat": "ingest rate",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (device_id) (rate(tt_media_server_audio_feature_extraction_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval]))",
+          "legendFormat": "device {{device_id}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Ingest Rate (audio seconds/s, 1.0 = real time)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Cumulative count at or below each bucket boundary. The smallest `le` with a non-zero count is the real lower bound — everything below is wasted resolution; if the largest finite bucket holds everything, the ceiling can come down. Re-read after any change to chunk length or device count.",
       "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 127 },
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 127 },
       "id": 40,
       "options": { "showHeader": true, "sortBy": [{ "displayName": "le", "desc": false }] },
       "targets": [

--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
@@ -1950,19 +1950,19 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "sum(rate(tt_media_server_audio_feature_extraction_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval])) / sum(rate(tt_media_server_audio_feature_extraction_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval]))",
+          "expr": "sum(rate(tt_media_server_audio_feature_extraction_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval])) / sum(rate(tt_media_server_audio_feature_extraction_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval]))",
           "legendFormat": "feature extraction",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "sum(rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval])) / sum(rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval]))",
+          "expr": "sum(rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\",trace_hit=\"true\"}[$__rate_interval])) / sum(rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\",trace_hit=\"true\"}[$__rate_interval]))",
           "legendFormat": "encoder",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "sum(rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval])) / (sum(rate(tt_media_server_audio_feature_extraction_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval])) + sum(rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval])))",
+          "expr": "sum(rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval])) / (sum(rate(tt_media_server_audio_feature_extraction_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval])) + sum(rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval])))",
           "legendFormat": "combined front-end (incl. trace capture)",
           "refId": "C"
         }
@@ -1980,13 +1980,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "sum by (batch) (rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval])) / sum by (batch) (rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval]))",
+          "expr": "sum by (batch) (rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\",trace_hit=\"true\"}[$__rate_interval])) / sum by (batch) (rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\",trace_hit=\"true\"}[$__rate_interval]))",
           "legendFormat": "batch {{batch}}",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "sum by (device_id) (rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval])) / sum by (device_id) (rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[$__rate_interval]))",
+          "expr": "sum by (device_id) (rate(tt_media_server_audio_encoder_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\",trace_hit=\"true\"}[$__rate_interval])) / sum by (device_id) (rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\",trace_hit=\"true\"}[$__rate_interval]))",
           "legendFormat": "device {{device_id}}",
           "refId": "B"
         }
@@ -2004,25 +2004,25 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(tt_media_server_audio_feature_extraction_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(tt_media_server_audio_feature_extraction_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])))",
           "legendFormat": "extraction p50",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(tt_media_server_audio_feature_extraction_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(tt_media_server_audio_feature_extraction_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])))",
           "legendFormat": "extraction p95",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(tt_media_server_audio_encoder_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(tt_media_server_audio_encoder_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\",trace_hit=\"true\"}[5m])))",
           "legendFormat": "encoder p50",
           "refId": "C"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(tt_media_server_audio_encoder_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"true\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(tt_media_server_audio_encoder_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\",trace_hit=\"true\"}[5m])))",
           "legendFormat": "encoder p95",
           "refId": "D"
         }
@@ -2040,13 +2040,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "sum by (trace_hit) (rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\"}[5m])) / sum by (trace_hit) (rate(tt_media_server_audio_encoder_duration_seconds_count{service=~\"$service\",model_type=~\"$model_type\"}[5m]))",
+          "expr": "sum by (trace_hit) (rate(tt_media_server_audio_encoder_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])) / sum by (trace_hit) (rate(tt_media_server_audio_encoder_duration_seconds_count{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m]))",
           "legendFormat": "mean encoder s (trace_hit={{trace_hit}})",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "sum(rate(tt_media_server_audio_encoder_duration_seconds_count{service=~\"$service\",model_type=~\"$model_type\",trace_hit=\"false\"}[5m]))",
+          "expr": "sum(rate(tt_media_server_audio_encoder_duration_seconds_count{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\",trace_hit=\"false\"}[5m]))",
           "legendFormat": "capture calls/s",
           "refId": "B"
         }
@@ -2064,13 +2064,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "sum(rate(tt_media_server_audio_feature_extraction_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval]))",
+          "expr": "sum(rate(tt_media_server_audio_feature_extraction_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval]))",
           "legendFormat": "ingest rate",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "sum by (device_id) (rate(tt_media_server_audio_feature_extraction_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\"}[$__rate_interval]))",
+          "expr": "sum by (device_id) (rate(tt_media_server_audio_feature_extraction_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval]))",
           "legendFormat": "device {{device_id}}",
           "refId": "B"
         }
@@ -2080,15 +2080,20 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
-      "description": "Cumulative count at or below each bucket boundary. The smallest `le` with a non-zero count is the real lower bound — everything below is wasted resolution; if the largest finite bucket holds everything, the ceiling can come down. Re-read after any change to chunk length or device count.",
+      "description": "Cumulative count at or below each bucket boundary, both stages joined on `le`. The smallest `le` with a non-zero count is the real lower bound — everything below is wasted resolution; if the largest finite bucket holds everything, the ceiling can come down. Re-read after any change to chunk length or device count.\n\n`le` is converted to a number before sorting: as the raw string label it sorts lexicographically, which puts `+Inf` first and `10.0` ahead of `2.5` and makes the \"smallest non-zero\" reading above wrong. `+Inf` does not parse and sorts last.",
       "fieldConfig": { "defaults": { "unit": "short" } },
       "gridPos": { "h": 8, "w": 16, "x": 8, "y": 127 },
       "id": 40,
       "options": { "showHeader": true, "sortBy": [{ "displayName": "le", "desc": false }] },
+      "transformations": [
+        { "id": "joinByField", "options": { "byField": "le", "mode": "outer" } },
+        { "id": "convertFieldType", "options": { "conversions": [{ "targetField": "le", "destinationType": "number" }] } },
+        { "id": "organize", "options": { "excludeByName": { "Time": true, "Time 1": true, "Time 2": true }, "renameByName": { "Value #A": "extraction count", "Value #B": "encoder count" } } }
+      ],
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "sum by (le) (increase(tt_media_server_audio_feature_extraction_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[$__range]))",
+          "expr": "sum by (le) (increase(tt_media_server_audio_feature_extraction_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__range]))",
           "format": "table",
           "instant": true,
           "legendFormat": "extraction {{le}}",
@@ -2096,7 +2101,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
-          "expr": "sum by (le) (increase(tt_media_server_audio_encoder_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\"}[$__range]))",
+          "expr": "sum by (le) (increase(tt_media_server_audio_encoder_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__range]))",
           "format": "table",
           "instant": true,
           "legendFormat": "encoder {{le}}",
@@ -2108,12 +2113,42 @@
     }
 
     ,
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 135 }, "id": 820, "panels": [], "title": "ASR VAD Overhead", "type": "row" },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Feature-extraction capacity split by the operating point the audio was submitted at. `sample_rate` and `channels` are the source values read off the container header, not the array the extractor sees — audio_manager downmixes to mono and resamples to 16 kHz before the runner is reached, so these are the only record of what arrived.\n\n`unknown` means the decode path normalised the source away before it could be read: ffmpeg is invoked with `-ar/-ac`, so every non-WAV format lands here until an ffprobe pass is added. `mixed` means a batch's items disagreed and the batch was credited under neither.\n\nA high-rate or multi-channel source costs more to decode but not more to extract — the array is mono 16 kHz by then — so a split here points at the decode stage, not the extractor.",
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "suffix:audio-s/s", "decimals": 1 } },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 135 },
+      "id": 50,
+      "options": { "legend": { "calcs": ["mean", "min"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (sample_rate) (rate(tt_media_server_audio_feature_extraction_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval])) / sum by (sample_rate) (rate(tt_media_server_audio_feature_extraction_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval]))",
+          "legendFormat": "{{sample_rate}} Hz",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (channels) (rate(tt_media_server_audio_feature_extraction_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval])) / sum by (channels) (rate(tt_media_server_audio_feature_extraction_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval]))",
+          "legendFormat": "{{channels}} ch",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (batch) (rate(tt_media_server_audio_feature_extraction_input_seconds_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval])) / sum by (batch) (rate(tt_media_server_audio_feature_extraction_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval]))",
+          "legendFormat": "batch {{batch}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Feature Extraction Capacity by Source Rate, Channels and Batch",
+      "type": "timeseries"
+    },
+    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 143 }, "id": 820, "panels": [], "title": "ASR VAD Overhead", "type": "row" },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Wall time to find speech and endpoint boundaries, per request. VAD gates when inference starts, so this is pure added latency ahead of the encoder — compare it against Chunk First-Item Latency to see which dominates. Quantiles cover successful runs only; a timeout shows up as delay under outcome=\"failed\", not as a non-event.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 136 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 144 },
       "id": 41,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
@@ -2143,7 +2178,7 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "CPU consumed by the VAD worker process divided by its wall time — cores in use, not the caller's clock. Above 1.0 the model went multi-threaded; well below 1.0 with a high latency means the worker was waiting, not computing. Mean CPU seconds per request is the number to multiply by request rate when sizing host cores.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "thresholdsStyle": { "mode": "line" } }, "unit": "none", "decimals": 2, "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }, { "color": "orange", "value": 1 }] } }, "overrides": [{ "matcher": { "id": "byName", "options": "mean CPU seconds" }, "properties": [{ "id": "unit", "value": "s" }, { "id": "custom.axisPlacement", "value": "right" }] }] },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 136 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 144 },
       "id": 42,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
@@ -2167,7 +2202,7 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Speech segments returned per request. This is the endpointing-health signal a duration alone will not show: a collapse toward 1 means VAD stopped splitting and the whole request becomes one long chunk, a jump into the hundreds means it is fragmenting and every fragment pays a full encoder frame. Read against Chunk Fan-out above, which is what these segments merge into.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 144 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 152 },
       "id": 43,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
@@ -2191,7 +2226,7 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Share of VAD calls that returned nothing, against the call rate. A failure is not a dropped request — the caller falls back to one segment spanning the whole audio, so the cost lands downstream as one oversized chunk. Any sustained non-zero share means the audio venv worker is timing out or respawning.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 10 }, "unit": "percentunit", "min": 0 }, "overrides": [{ "matcher": { "id": "byName", "options": "VAD calls/s" }, "properties": [{ "id": "unit", "value": "reqps" }, { "id": "custom.axisPlacement", "value": "right" }] }] },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 144 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 152 },
       "id": 44,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
@@ -2213,12 +2248,12 @@
     }
 
     ,
-    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 152 }, "id": 830, "panels": [], "title": "ASR Input Preparation and Chunking", "type": "row" },
+    { "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 160 }, "id": 830, "panels": [], "title": "ASR Input Preparation and Chunking", "type": "row" },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Time to base64-decode, container-decode, resample and length-check submitted audio, before VAD sees it. Split by container: mp3 carries a real decode cost that wav does not, so a shift in the format mix moves this without anything regressing. Observed on success only — rejected uploads (unknown header, oversize) never reach it, so the call rate here is accepted requests, not offered load.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" }, "overrides": [{ "matcher": { "id": "byName", "options": "accepted/s" }, "properties": [{ "id": "unit", "value": "reqps" }, { "id": "custom.axisPlacement", "value": "right" }] }] },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 153 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 161 },
       "id": 45,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
@@ -2248,7 +2283,7 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "The segment-merge step only — VAD and diarization are inference and live in the row above, so this is pure host arithmetic and should stay in the microseconds. Per-chunk cost divides it by the chunks produced, which is the number to watch if merging ever stops being free. diarization mode merges within speaker boundaries and so does more work than vad_only.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "s" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 153 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 161 },
       "id": 46,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
@@ -2272,7 +2307,7 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Chunk fan-out split by mode, the multiplier on every per-chunk cost downstream: each chunk pays a full 30s encoder frame however short it is. diarization should sit above vad_only because speaker changes force a chunk boundary that duration alone would not. A rise here with flat VAD segment counts means merging is splitting more, not that the audio changed.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0 }, "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 161 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 169 },
       "id": 47,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
@@ -2296,7 +2331,7 @@
       "datasource": { "type": "prometheus", "uid": "$datasource" },
       "description": "Mean host-side seconds per request for the three stages that run before the device is touched, stacked. All three are observed once per request, so the heights are directly comparable and the total is the fixed latency floor no device speed-up can remove. VAD normally dominates by orders of magnitude; if input preparation ever rivals it, look at the format mix.",
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 25, "stacking": { "mode": "normal", "group": "A" } }, "unit": "s" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 161 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 169 },
       "id": 48,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [

--- a/tt-media-server/telemetry/telemetry_client.py
+++ b/tt-media-server/telemetry/telemetry_client.py
@@ -78,6 +78,30 @@ post_processing_duration = Histogram(
     ["model_type", "post_processing_enabled"],
 )
 
+# Buckets are calibrated against measured WAV decode
+audio_input_preparation_duration = Histogram(
+    "tt_media_server_audio_input_preparation_seconds",
+    "Time to decode, resample and prepare submitted audio for inference",
+    ["model_type", "format"],
+    buckets=(
+        0.0002,
+        0.0005,
+        0.001,
+        0.002,
+        0.005,
+        0.01,
+        0.02,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        1.0,
+        2.5,
+        5.0,
+        float("inf"),
+    ),
+)
+
 # Model inference metrics
 model_inference_duration = Histogram(
     "tt_media_server_model_inference_duration_seconds",

--- a/tt-media-server/telemetry/telemetry_client.py
+++ b/tt-media-server/telemetry/telemetry_client.py
@@ -150,6 +150,61 @@ audio_chunks_per_request = Histogram(
     buckets=(1, 2, 4, 8, 16, 32, 64, 128, float("inf")),
 )
 
+# VAD gates when inference starts and ends, so a timeout here is delay, not a
+# non-event: `outcome` keeps failed runs visible without skewing the ok quantiles.
+audio_vad_duration = Histogram(
+    "tt_media_server_audio_vad_seconds",
+    "Wall time to identify speech and endpoint boundaries",
+    ["model_type", "outcome"],
+    buckets=(
+        0.005,
+        0.01,
+        0.025,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        1.0,
+        2.5,
+        5.0,
+        10.0,
+        30.0,
+        float("inf"),
+    ),
+)
+
+# CPU consumed by the VAD worker process, not the caller's wall clock. Divide by
+# audio_vad_seconds for utilisation: >1 means the model went multi-threaded.
+audio_vad_cpu_duration = Histogram(
+    "tt_media_server_audio_vad_cpu_seconds",
+    "CPU time consumed by the VAD worker process for one request",
+    ["model_type"],
+    buckets=(
+        0.005,
+        0.01,
+        0.025,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        1.0,
+        2.5,
+        5.0,
+        10.0,
+        30.0,
+        float("inf"),
+    ),
+)
+
+# Endpoint count. A collapse toward 1, or a jump into the hundreds, is the
+# signature of bad endpointing that a duration alone will not show.
+audio_vad_segments = Histogram(
+    "tt_media_server_audio_vad_segments",
+    "Speech segments returned by VAD for one request",
+    ["model_type"],
+    buckets=(0, 1, 2, 4, 8, 16, 32, 64, 128, 256, float("inf")),
+)
+
 # Model inference metrics
 model_inference_duration = Histogram(
     "tt_media_server_model_inference_duration_seconds",

--- a/tt-media-server/telemetry/telemetry_client.py
+++ b/tt-media-server/telemetry/telemetry_client.py
@@ -251,6 +251,91 @@ audio_vad_segments = Histogram(
     buckets=(0, 1, 2, 4, 8, 16, 32, 64, 128, 256, float("inf")),
 )
 
+# --- Feature extraction and encoder throughput ------------------------------
+#
+# Stage timings come from tt-metal's `PerfMetrics` (tt-metal #53717). Throughput
+# is a counter pair rather than a ready-made rate, so it aggregates across
+# workers and survives scrape gaps:
+#
+#     audio-seconds/s = rate(<stage>_input_seconds_total) / rate(<stage>_duration_seconds_sum)
+#
+# `_input_seconds_total` is accounted server-side, not read off
+# PerfMetrics.total_audio_s, which sums raw submitted durations: the extractor
+# truncates each item to one 30s frame, so a longer submission would inflate
+# both throughputs by the truncation ratio.
+#
+# These are *effective* audio throughput, not device utilisation: a short chunk
+# is padded up to the frame, so encoder cost is fixed per chunk and throughput
+# falls roughly linearly with chunk length.
+audio_feature_extraction_input_seconds = Counter(
+    "tt_media_server_audio_feature_extraction_input_seconds_total",
+    "Audio duration converted into acoustic features",
+    ["model_type", "device_id", "sample_rate", "channels", "batch"],
+)
+
+# Host-side log-mel over a batch already padded to fixed frames, so near-constant
+# per item: measured ~2ms per chunk. Dense from 1ms to 100ms, a decade of
+# headroom above for a host that starves the extractor.
+audio_feature_extraction_duration = Histogram(
+    "tt_media_server_audio_feature_extraction_duration_seconds",
+    "Wall time spent extracting acoustic features for one batch",
+    ["model_type", "device_id", "sample_rate", "channels", "batch"],
+    buckets=(
+        0.001,
+        0.0025,
+        0.005,
+        0.01,
+        0.02,
+        0.03,
+        0.05,
+        0.075,
+        0.1,
+        0.25,
+        0.5,
+        1.0,
+        2.5,
+        float("inf"),
+    ),
+)
+
+# `trace_hit="false"` is the call that captures the encoder trace for a batch
+# bucket: it runs the encoder eagerly and again under capture, so its duration is
+# a one-off outlier. Labelled rather than dropped, so the cost stays visible
+# while steady-state panels filter on trace_hit="true".
+audio_encoder_input_seconds = Counter(
+    "tt_media_server_audio_encoder_input_seconds_total",
+    "Audio duration processed by the acoustic encoder",
+    ["model_type", "device_id", "model_name", "language", "batch", "trace_hit"],
+)
+
+# Encoder input preprocessing, the encoder stack, and the synchronize that makes
+# its result observable — compute, not enqueue. Bounded above by the chunk
+# first-item span (mean 0.45s including first decode), so the grid is dense from
+# 10ms to 500ms with room to 10s for trace-capture calls.
+audio_encoder_duration = Histogram(
+    "tt_media_server_audio_encoder_duration_seconds",
+    "Wall time spent in the acoustic encoder for one batch",
+    ["model_type", "device_id", "model_name", "language", "batch", "trace_hit"],
+    buckets=(
+        0.01,
+        0.025,
+        0.05,
+        0.075,
+        0.1,
+        0.15,
+        0.2,
+        0.3,
+        0.4,
+        0.5,
+        0.75,
+        1.0,
+        2.5,
+        5.0,
+        10.0,
+        float("inf"),
+    ),
+)
+
 # Model inference metrics
 model_inference_duration = Histogram(
     "tt_media_server_model_inference_duration_seconds",

--- a/tt-media-server/telemetry/telemetry_client.py
+++ b/tt-media-server/telemetry/telemetry_client.py
@@ -122,22 +122,68 @@ audio_chunking_duration = Histogram(
     ),
 )
 
-# One observation per chunk, so ms/chunk and p50/p99 read straight off this.
-audio_chunk_preparation_duration = Histogram(
-    "tt_media_server_audio_chunk_preparation_seconds",
-    "Time to slice and prepare a single audio chunk for inference",
+# Closest available proxy for per-chunk input preparation: tt-metal's
+# WhisperGenerator fuses log-mel extraction with the encoder pass and the first
+# decode step, so this bundles all three and cannot separate them from here.
+#
+# Buckets are fitted to measured data (whisper-large-v3, one p300c chip, ~8s
+# chunks, VAD-only): mean 0.45s with 84% of observations in 0.25-0.5s, so the
+# grid is dense there and sparse outside. Nothing landed below 0.25s, but the
+# floor keeps headroom for distil-large-v3, whose shorter decode should sit
+# lower. Encoder cost is fixed because every chunk is padded to a 30s frame, so
+# this barely moves with chunk length.
+audio_chunk_first_token_duration = Histogram(
+    "tt_media_server_audio_chunk_first_token_seconds",
+    "Time from chunk hand-off until the first item is emitted for that chunk",
     ["model_type"],
     buckets=(
-        0.000005,
-        0.00001,
-        0.00005,
-        0.0001,
-        0.0005,
-        0.001,
-        0.005,
-        0.01,
-        0.05,
         0.1,
+        0.2,
+        0.3,
+        0.4,
+        0.5,
+        0.65,
+        0.8,
+        1.0,
+        1.5,
+        2.5,
+        5.0,
+        10.0,
+        30.0,
+        float("inf"),
+    ),
+)
+
+# One observation per chunk, so ms/chunk and p50/p99 read straight off this.
+# Wall time, not compute: the streaming loop yields to its consumer inside this
+# span, so a slow client shows up here but not in the first-item histogram.
+#
+# Measured mean is 1.4s for ~8s chunks, with 87% of observations in 1.0-2.5s;
+# the grid is dense there. Unlike the first-item span this does scale with chunk
+# length, because decode step count follows the transcribed content, so the
+# lower buckets carry the short-chunk (diarized) case.
+#
+# 1.75 splits what was otherwise a single bucket holding over half the
+# observations, with p90 sitting on its 2.0 boundary: without it every quantile
+# from p50 to p90 resolves to the same interpolation across one wide bucket.
+audio_chunk_processing_duration = Histogram(
+    "tt_media_server_audio_chunk_processing_seconds",
+    "Wall time to transcribe a single audio chunk end to end",
+    ["model_type"],
+    buckets=(
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        1.25,
+        1.5,
+        1.75,
+        2.0,
+        2.5,
+        3.5,
+        5.0,
+        10.0,
+        30.0,
         float("inf"),
     ),
 )

--- a/tt-media-server/telemetry/telemetry_client.py
+++ b/tt-media-server/telemetry/telemetry_client.py
@@ -102,6 +102,54 @@ audio_input_preparation_duration = Histogram(
     ),
 )
 
+# Segment-merge step only, observed once per request; microsecond floor.
+audio_chunking_duration = Histogram(
+    "tt_media_server_audio_chunking_seconds",
+    "Time to merge VAD/diarization segments into inference-sized audio chunks",
+    ["model_type", "mode"],
+    buckets=(
+        0.00001,
+        0.00005,
+        0.0001,
+        0.0005,
+        0.001,
+        0.005,
+        0.01,
+        0.05,
+        0.1,
+        0.5,
+        float("inf"),
+    ),
+)
+
+# One observation per chunk, so ms/chunk and p50/p99 read straight off this.
+audio_chunk_preparation_duration = Histogram(
+    "tt_media_server_audio_chunk_preparation_seconds",
+    "Time to slice and prepare a single audio chunk for inference",
+    ["model_type"],
+    buckets=(
+        0.000005,
+        0.00001,
+        0.00005,
+        0.0001,
+        0.0005,
+        0.001,
+        0.005,
+        0.01,
+        0.05,
+        0.1,
+        float("inf"),
+    ),
+)
+
+# Chunk fan-out; divides audio_chunking_seconds down to a per-chunk cost.
+audio_chunks_per_request = Histogram(
+    "tt_media_server_audio_chunks_per_request",
+    "Number of inference chunks produced for one audio request",
+    ["model_type", "mode"],
+    buckets=(1, 2, 4, 8, 16, 32, 64, 128, float("inf")),
+)
+
 # Model inference metrics
 model_inference_duration = Histogram(
     "tt_media_server_model_inference_duration_seconds",

--- a/tt-media-server/telemetry/telemetry_client.py
+++ b/tt-media-server/telemetry/telemetry_client.py
@@ -274,26 +274,32 @@ audio_feature_extraction_input_seconds = Counter(
 )
 
 # Host-side log-mel over a batch already padded to fixed frames, so near-constant
-# per item: measured ~2ms per chunk. Dense from 1ms to 100ms, a decade of
-# headroom above for a host that starves the extractor.
+# per item: measured ~2ms per chunk.
+#
+# The grid is dense across 1-4ms because that is where the mode sits. An earlier
+# version started at 0.001 and jumped straight to 0.0025, which put the whole
+# distribution in one bucket and made p50 and p95 interpolate the same interval —
+# the two quantiles moved together and neither meant anything. The tail stops at
+# 0.5 rather than 2.5: extraction is host CPU over a fixed frame count, so a
+# half-second batch already means severe host starvation and finer resolution
+# above that buys nothing.
 audio_feature_extraction_duration = Histogram(
     "tt_media_server_audio_feature_extraction_duration_seconds",
     "Wall time spent extracting acoustic features for one batch",
     ["model_type", "device_id", "sample_rate", "channels", "batch"],
     buckets=(
+        0.0005,
         0.001,
-        0.0025,
-        0.005,
+        0.0015,
+        0.002,
+        0.003,
+        0.004,
+        0.006,
         0.01,
         0.02,
-        0.03,
         0.05,
-        0.075,
         0.1,
-        0.25,
         0.5,
-        1.0,
-        2.5,
         float("inf"),
     ),
 )

--- a/tt-media-server/tests/test_audio_manager.py
+++ b/tt-media-server/tests/test_audio_manager.py
@@ -619,3 +619,125 @@ def test_apply_diarization_with_vad_falls_back_to_vad_when_diarization_empty():
     mockWarning.assert_any_call(
         "Diarization returned no segments - falling back to VAD-only mode"
     )
+
+
+def _histogram_count(name, labels):
+    """Observation count, or zero if the series does not exist yet."""
+    from prometheus_client import REGISTRY
+
+    value = REGISTRY.get_sample_value(f"{name}_count", labels)
+    return 0 if value is None else value
+
+
+def _histogram_sum(name, labels):
+    from prometheus_client import REGISTRY
+
+    value = REGISTRY.get_sample_value(f"{name}_sum", labels)
+    return 0 if value is None else value
+
+
+def _vad_only_manager():
+    """VAD-only manager with stubbed models."""
+    manager = AudioManager()
+    manager._vad_model = True
+    manager._diarization_model = None
+    manager._apply_vad = lambda _audio: [
+        {"start": 0.0, "end": 1.0},
+        {"start": 2.0, "end": 3.0},
+    ]
+    return manager
+
+
+@patch("utils.audio_manager.settings", new=DummySettings())
+def test_chunking_metrics_recorded_for_vad_only_mode():
+    """Observed once per request, tagged with the mode actually used."""
+    labels = {"model_type": "tt-whisper", "mode": "vad_only"}
+    duration_before = _histogram_count("tt_media_server_audio_chunking_seconds", labels)
+    count_before = _histogram_count("tt_media_server_audio_chunks_per_request", labels)
+
+    manager = _vad_only_manager()
+    chunks = manager.apply_diarization_with_vad(
+        np.zeros(16000 * 4, dtype=np.float32), enable_diarization=False
+    )
+
+    assert (
+        _histogram_count("tt_media_server_audio_chunking_seconds", labels)
+        == duration_before + 1
+    )
+    assert (
+        _histogram_count("tt_media_server_audio_chunks_per_request", labels)
+        == count_before + 1
+    )
+    assert len(chunks) >= 1
+
+
+@patch("utils.audio_manager.settings", new=DummySettings())
+def test_chunks_per_request_observes_actual_chunk_count():
+    """The observed value is the chunk count; ms/chunk derives from it."""
+    labels = {"model_type": "tt-whisper", "mode": "vad_only"}
+    sum_before = _histogram_sum("tt_media_server_audio_chunks_per_request", labels)
+
+    manager = _vad_only_manager()
+    chunks = manager.apply_diarization_with_vad(
+        np.zeros(16000 * 4, dtype=np.float32), enable_diarization=False
+    )
+
+    delta = (
+        _histogram_sum("tt_media_server_audio_chunks_per_request", labels) - sum_before
+    )
+    assert delta == len(chunks)
+
+
+@patch("utils.audio_manager.settings", new=DummySettings())
+def test_chunking_mode_label_reports_diarization_when_it_runs():
+    """A successful diarization run is tagged `diarization`."""
+    labels = {"model_type": "tt-whisper", "mode": "diarization"}
+    before = _histogram_count("tt_media_server_audio_chunking_seconds", labels)
+
+    manager = AudioManager()
+    manager._vad_model = True
+    manager._diarization_model = True
+    manager._apply_vad = lambda _audio: [{"start": 0.0, "end": 1.0}]
+    manager._apply_diarization = lambda _audio: [
+        {"start": 0.0, "end": 1.0, "text": "", "speaker": "SPEAKER_00"}
+    ]
+
+    manager.apply_diarization_with_vad(
+        np.zeros(16000 * 4, dtype=np.float32), enable_diarization=True
+    )
+
+    assert (
+        _histogram_count("tt_media_server_audio_chunking_seconds", labels) == before + 1
+    )
+
+
+@patch("utils.audio_manager.settings", new=DummySettings())
+def test_chunking_mode_label_falls_back_when_diarization_yields_nothing():
+    """Empty diarization degrades to vad_only, and the label follows."""
+    diarization_labels = {"model_type": "tt-whisper", "mode": "diarization"}
+    fallback_labels = {"model_type": "tt-whisper", "mode": "vad_only"}
+    diarization_before = _histogram_count(
+        "tt_media_server_audio_chunking_seconds", diarization_labels
+    )
+    fallback_before = _histogram_count(
+        "tt_media_server_audio_chunking_seconds", fallback_labels
+    )
+
+    manager = AudioManager()
+    manager._vad_model = True
+    manager._diarization_model = True
+    manager._apply_vad = lambda _audio: [{"start": 0.0, "end": 1.0}]
+    manager._apply_diarization = lambda _audio: []
+
+    manager.apply_diarization_with_vad(
+        np.zeros(16000 * 4, dtype=np.float32), enable_diarization=True
+    )
+
+    assert (
+        _histogram_count("tt_media_server_audio_chunking_seconds", fallback_labels)
+        == fallback_before + 1
+    )
+    assert (
+        _histogram_count("tt_media_server_audio_chunking_seconds", diarization_labels)
+        == diarization_before
+    )

--- a/tt-media-server/tests/test_audio_manager.py
+++ b/tt-media-server/tests/test_audio_manager.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+from config.constants import AudioInputFormat
 
 # audio_manager no longer imports torch/whisperx at module load time; those
 # packages live in the separate audio_venv and are only invoked through the
@@ -25,6 +26,7 @@ class DummySettings:
     max_audio_duration_with_preprocessing_seconds = 120
     audio_chunk_duration_seconds = 10
     model_service = "AUDIO"
+    model_runner = "tt-whisper"
     preprocessing_model_weights_path = None
 
 
@@ -64,6 +66,31 @@ def test_to_audio_array_invalid_type():
     manager = AudioManager()
     with pytest.raises(ValueError):
         manager.to_audio_array(123, False)
+
+
+@pytest.mark.parametrize(
+    "audio_bytes, expected",
+    [
+        (generate_dummy_wav_bytes(), AudioInputFormat.WAV),
+        (b"ID3\x04\x00\x00\x00\x00\x00\x00", AudioInputFormat.MP3),
+        (b"\xff\xfb\x90\x00", AudioInputFormat.MP3),
+        (b"\xff\xf3\x90\x00", AudioInputFormat.MP3),
+        (b"\xff\xf2\x90\x00", AudioInputFormat.MP3),
+        (b"OggS\x00\x02\x00\x00", AudioInputFormat.UNKNOWN),
+        (b"RIFF\x00\x00\x00\x00AVI ", AudioInputFormat.UNKNOWN),
+        (b"", AudioInputFormat.UNKNOWN),
+        (b"RIFF", AudioInputFormat.UNKNOWN),
+    ],
+)
+def test_detect_audio_format(audio_bytes, expected):
+    assert AudioManager._detect_audio_format(audio_bytes) is expected
+
+
+@patch("utils.audio_manager.settings", new=DummySettings())
+def test_convert_to_audio_array_rejects_unknown_format():
+    manager = AudioManager()
+    with pytest.raises(ValueError, match="Unsupported audio format"):
+        manager._convert_to_audio_array(b"OggS\x00\x02", AudioInputFormat.UNKNOWN)
 
 
 @patch("utils.audio_manager.settings", new=DummySettings())

--- a/tt-media-server/tests/test_audio_manager.py
+++ b/tt-media-server/tests/test_audio_manager.py
@@ -5,8 +5,9 @@
 import io
 import json
 import os
+import subprocess
 import wave
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
@@ -741,3 +742,133 @@ def test_chunking_mode_label_falls_back_when_diarization_yields_nothing():
         _histogram_count("tt_media_server_audio_chunking_seconds", diarization_labels)
         == diarization_before
     )
+
+
+def _vad_manager(segments, cpu_before=1.0, cpu_after=1.5):
+    """Manager whose VAD worker returns `segments` and reports fixed CPU."""
+    manager = AudioManager()
+    manager._vad_model = True
+    worker = Mock()
+    worker.run = Mock(return_value=segments)
+    worker.cpu_seconds = Mock(side_effect=[cpu_before, cpu_after])
+    manager._audio_venv_worker = worker
+    return manager
+
+
+@patch("utils.audio_manager.settings", new=DummySettings())
+def test_vad_metrics_recorded_on_success():
+    """Duration is tagged ok, and the segment count is observed."""
+    ok = {"model_type": "tt-whisper", "outcome": "ok"}
+    plain = {"model_type": "tt-whisper"}
+    duration_before = _histogram_count("tt_media_server_audio_vad_seconds", ok)
+    segments_before = _histogram_sum("tt_media_server_audio_vad_segments", plain)
+
+    manager = _vad_manager([{"start": 0.0, "end": 1.0}, {"start": 2.0, "end": 3.0}])
+    manager._apply_vad(np.zeros(16000, dtype=np.float32))
+
+    assert (
+        _histogram_count("tt_media_server_audio_vad_seconds", ok) == duration_before + 1
+    )
+    assert (
+        _histogram_sum("tt_media_server_audio_vad_segments", plain)
+        == segments_before + 2
+    )
+
+
+@patch("utils.audio_manager.settings", new=DummySettings())
+def test_vad_cpu_delta_is_observed():
+    """CPU is the worker's own delta, not the caller's wall clock."""
+    plain = {"model_type": "tt-whisper"}
+    before = _histogram_sum("tt_media_server_audio_vad_cpu_seconds", plain)
+
+    manager = _vad_manager([], cpu_before=2.0, cpu_after=2.75)
+    manager._apply_vad(np.zeros(16000, dtype=np.float32))
+
+    delta = _histogram_sum("tt_media_server_audio_vad_cpu_seconds", plain) - before
+    assert delta == pytest.approx(0.75)
+
+
+@patch("utils.audio_manager.settings", new=DummySettings())
+def test_vad_failure_is_timed_but_tagged_failed():
+    """A VAD timeout is real added delay, so it must not vanish from the metric."""
+    failed = {"model_type": "tt-whisper", "outcome": "failed"}
+    ok = {"model_type": "tt-whisper", "outcome": "ok"}
+    failed_before = _histogram_count("tt_media_server_audio_vad_seconds", failed)
+    ok_before = _histogram_count("tt_media_server_audio_vad_seconds", ok)
+    segments_before = _histogram_count(
+        "tt_media_server_audio_vad_segments", {"model_type": "tt-whisper"}
+    )
+
+    manager = _vad_manager(None)
+    assert manager._apply_vad(np.zeros(16000, dtype=np.float32)) is None
+
+    assert (
+        _histogram_count("tt_media_server_audio_vad_seconds", failed)
+        == failed_before + 1
+    )
+    assert _histogram_count("tt_media_server_audio_vad_seconds", ok) == ok_before
+    # No segments were produced, so nothing is observed for the endpoint count.
+    assert (
+        _histogram_count(
+            "tt_media_server_audio_vad_segments", {"model_type": "tt-whisper"}
+        )
+        == segments_before
+    )
+
+
+@patch("utils.audio_manager.settings", new=DummySettings())
+def test_vad_skipped_entirely_records_nothing():
+    """No VAD model means no work done, so no observation."""
+    labels = {"model_type": "tt-whisper", "outcome": "ok"}
+    before = _histogram_count("tt_media_server_audio_vad_seconds", labels)
+
+    manager = AudioManager()
+    manager._vad_model = None
+    manager._audio_venv_worker = None
+
+    assert manager._apply_vad(np.zeros(16000, dtype=np.float32)) is None
+    assert _histogram_count("tt_media_server_audio_vad_seconds", labels) == before
+
+
+@patch("utils.audio_manager.settings", new=DummySettings())
+def test_vad_cpu_not_observed_when_counter_resets():
+    """A respawn resets the counter; a negative delta is not this call's compute."""
+    plain = {"model_type": "tt-whisper"}
+    before = _histogram_count("tt_media_server_audio_vad_cpu_seconds", plain)
+
+    manager = _vad_manager([], cpu_before=9.0, cpu_after=0.2)
+    manager._apply_vad(np.zeros(16000, dtype=np.float32))
+
+    assert _histogram_count("tt_media_server_audio_vad_cpu_seconds", plain) == before
+
+
+@patch("utils.audio_manager.settings", new=DummySettings())
+def test_vad_cpu_not_observed_when_proc_unreadable():
+    """cpu_seconds returning None must not be arithmetic'd into an observation."""
+    plain = {"model_type": "tt-whisper"}
+    before = _histogram_count("tt_media_server_audio_vad_cpu_seconds", plain)
+
+    manager = _vad_manager([], cpu_before=None, cpu_after=None)
+    manager._apply_vad(np.zeros(16000, dtype=np.float32))
+
+    assert _histogram_count("tt_media_server_audio_vad_cpu_seconds", plain) == before
+
+
+def test_cpu_seconds_measures_a_real_subprocess():
+    """Exercises the /proc parsing against a real CPU-bound child."""
+    worker = AudioVenvWorker(logger=Mock())
+    worker._proc = subprocess.Popen(
+        ["/usr/bin/python3", "-c", "x=0\nfor i in range(8_000_000): x+=i"]
+    )
+    try:
+        assert worker.cpu_seconds() is not None
+        worker._proc.wait(timeout=60)
+    finally:
+        if worker._proc.poll() is None:
+            worker._proc.kill()
+
+
+def test_cpu_seconds_returns_none_without_a_process():
+    worker = AudioVenvWorker(logger=Mock())
+    worker._proc = None
+    assert worker.cpu_seconds() is None

--- a/tt-media-server/tests/test_audio_manager.py
+++ b/tt-media-server/tests/test_audio_manager.py
@@ -48,18 +48,21 @@ def test_to_audio_array_base64():
     import base64
 
     b64 = base64.b64encode(wav_bytes).decode()
-    arr, duration = manager.to_audio_array(b64, False)
-    assert isinstance(arr, np.ndarray)
-    assert duration > 0
+    prepared = manager.to_audio_array(b64, False)
+    assert isinstance(prepared.audio_array, np.ndarray)
+    assert prepared.duration > 0
 
 
 @patch("utils.audio_manager.settings", new=DummySettings())
 def test_to_audio_array_bytes():
     manager = AudioManager()
     wav_bytes = generate_dummy_wav_bytes()
-    arr, duration = manager.to_audio_array(wav_bytes, False)
-    assert isinstance(arr, np.ndarray)
-    assert duration > 0
+    prepared = manager.to_audio_array(wav_bytes, False)
+    assert isinstance(prepared.audio_array, np.ndarray)
+    assert prepared.duration > 0
+    # The dummy WAV's own header, not the resampled array's.
+    assert prepared.source_sample_rate == 16000
+    assert prepared.source_channels == 1
 
 
 @patch("utils.audio_manager.settings", new=DummySettings())

--- a/tt-media-server/tests/test_whisper_chunk_metrics.py
+++ b/tt-media-server/tests/test_whisper_chunk_metrics.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+"""Per-chunk preparation metric on the streaming ASR path.
+
+conftest mocks out `tt_model_runners.whisper_runner`, so this imports the real
+module: conftest already stubs everything it needs bar the tt-metal
+`models.demos.audio` tree, stubbed below. Both swaps are undone per test.
+"""
+
+import asyncio
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from prometheus_client import REGISTRY
+
+METRIC = "tt_media_server_audio_chunk_preparation_seconds"
+_METRIC_ATTR = "audio_chunk_preparation_duration"
+_AUDIO_STUBS = (
+    "models.demos.audio",
+    "models.demos.audio.whisper",
+    "models.demos.audio.whisper.tt",
+    "models.demos.audio.whisper.tt.ttnn_optimized_functional_whisper",
+    "models.demos.audio.whisper.tt.whisper_generator",
+)
+
+
+def _pin_real_collector():
+    """Pin the real histogram onto telemetry.telemetry_client.
+
+    test_device_worker* leave a Mock there, which would swallow every observe.
+    The registry keeps the one reference that survives that swap.
+    """
+    collector = REGISTRY._names_to_collectors[METRIC]
+    module = sys.modules.get("telemetry.telemetry_client")
+    if module is None:
+        # A bare stub, not a re-import: that would re-register every histogram.
+        module = types.ModuleType("telemetry.telemetry_client")
+        module.TelemetryEvent = MagicMock()
+        sys.modules["telemetry.telemetry_client"] = module
+    had_attr = hasattr(module, _METRIC_ATTR)
+    previous = getattr(module, _METRIC_ATTR, None)
+    setattr(module, _METRIC_ATTR, collector)
+    return module, had_attr, previous
+
+
+@pytest.fixture
+def whisper_module():
+    saved = {name: sys.modules.get(name) for name in _AUDIO_STUBS}
+    saved["tt_model_runners.whisper_runner"] = sys.modules.get(
+        "tt_model_runners.whisper_runner"
+    )
+    telemetry_module, had_attr, previous_metric = _pin_real_collector()
+
+    for name in _AUDIO_STUBS:
+        stub = types.ModuleType(name)
+        stub.__dict__.update(
+            {
+                "WHISPER_L1_SMALL_SIZE": 0,
+                "WHISPER_TRACE_REGION_SIZE": 0,
+                "convert_to_ttnn": MagicMock(),
+                "create_custom_mesh_preprocessor": MagicMock(),
+                "init_kv_cache": MagicMock(),
+                "GenerationParams": MagicMock(),
+                "WhisperGenerator": MagicMock(),
+            }
+        )
+        sys.modules[name] = stub
+
+    sys.modules.pop("tt_model_runners.whisper_runner", None)
+    try:
+        yield importlib.import_module("tt_model_runners.whisper_runner")
+    finally:
+        if had_attr:
+            setattr(telemetry_module, _METRIC_ATTR, previous_metric)
+        else:
+            delattr(telemetry_module, _METRIC_ATTR)
+        for name, module in saved.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def _metric(field, labels={"model_type": "tt-whisper"}):
+    value = REGISTRY.get_sample_value(f"{METRIC}_{field}", labels)
+    return 0 if value is None else value
+
+
+def _request(segments, sample_rate=16000, seconds=10):
+    request = MagicMock()
+    request._segments = segments
+    request._audio_array = np.zeros(sample_rate * seconds, dtype=np.float32)
+    request._duration = float(seconds)
+    request._task_id = "task-1"
+    request.stream = True
+    request.prompt = None
+    return request
+
+
+def _runner(whisper_module):
+    """Carries only what the streaming loop touches."""
+    runner = MagicMock()
+    runner.settings.default_sample_rate = 16000
+    runner.settings.model_runner = "tt-whisper"
+    runner.device_id = 0
+
+    async def execute_pipeline(_audio, _stream, _params, prompt=None):
+        async def generator():
+            yield ("text", 0.0, 1.0)
+            yield ("final", 0.0, 1.0, True)
+
+        return generator()
+
+    runner._execute_pipeline = execute_pipeline
+    runner._create_generation_params = MagicMock(return_value={})
+    return whisper_module.TTWhisperRunner._process_segments_streaming.__get__(runner)
+
+
+def _drain(bound_method, request):
+    async def run():
+        return [item async for item in bound_method(request)]
+
+    return asyncio.run(run())
+
+
+def test_records_one_observation_per_prepared_chunk(whisper_module):
+    """ms/chunk needs one observation per chunk, not per request."""
+    segments = [
+        {"start": 0.0, "end": 2.0, "speaker": "SPEAKER_00"},
+        {"start": 2.0, "end": 4.0, "speaker": "SPEAKER_01"},
+        {"start": 4.0, "end": 6.0, "speaker": "SPEAKER_00"},
+    ]
+    before = _metric("count")
+
+    _drain(_runner(whisper_module), _request(segments))
+
+    assert _metric("count") == before + len(segments)
+
+
+def test_skipped_empty_chunks_are_not_observed(whisper_module):
+    """Zero-length chunks feed no inference, so must not be counted."""
+    segments = [
+        {"start": 0.0, "end": 2.0, "speaker": "SPEAKER_00"},
+        {"start": 3.0, "end": 3.0, "speaker": "SPEAKER_01"},  # empty slice
+        {"start": 4.0, "end": 6.0, "speaker": "SPEAKER_00"},
+    ]
+    before = _metric("count")
+
+    _drain(_runner(whisper_module), _request(segments))
+
+    assert _metric("count") == before + 2
+
+
+def test_observed_duration_is_finite_and_non_negative(whisper_module):
+    """Catches an unset or misordered perf_counter span."""
+    sum_before = _metric("sum")
+    count_before = _metric("count")
+
+    _drain(_runner(whisper_module), _request([{"start": 0.0, "end": 2.0}]))
+
+    delta = _metric("sum") - sum_before
+    assert _metric("count") == count_before + 1
+    assert 0 <= delta < 5.0

--- a/tt-media-server/tests/test_whisper_chunk_metrics.py
+++ b/tt-media-server/tests/test_whisper_chunk_metrics.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
-"""Per-chunk preparation metric on the streaming ASR path.
+"""Per-chunk latency metrics on the streaming ASR path.
 
 conftest mocks out `tt_model_runners.whisper_runner`, so this imports the real
 module: conftest already stubs everything it needs bar the tt-metal
@@ -18,8 +18,13 @@ import numpy as np
 import pytest
 from prometheus_client import REGISTRY
 
-METRIC = "tt_media_server_audio_chunk_preparation_seconds"
-_METRIC_ATTR = "audio_chunk_preparation_duration"
+FIRST_TOKEN = "tt_media_server_audio_chunk_first_token_seconds"
+PROCESSING = "tt_media_server_audio_chunk_processing_seconds"
+_LABELS = {"model_type": "tt-whisper"}
+_METRIC_ATTRS = {
+    "audio_chunk_first_token_duration": FIRST_TOKEN,
+    "audio_chunk_processing_duration": PROCESSING,
+}
 _AUDIO_STUBS = (
     "models.demos.audio",
     "models.demos.audio.whisper",
@@ -27,34 +32,37 @@ _AUDIO_STUBS = (
     "models.demos.audio.whisper.tt.ttnn_optimized_functional_whisper",
     "models.demos.audio.whisper.tt.whisper_generator",
 )
+# A chunk normally streams text before the final marker closes it out.
+_DEFAULT_ITEMS = (("text", 0.0, 1.0), ("final", 0.0, 1.0, True))
 
 
-def _pin_real_collector():
-    """Pin the real histogram onto telemetry.telemetry_client.
+def _pin_real_collectors():
+    """Pin the real histograms onto telemetry.telemetry_client.
 
-    test_device_worker* leave a Mock there, which would swallow every observe.
+    Other test modules leave a Mock there, which would swallow every observe.
     The registry keeps the one reference that survives that swap.
     """
-    collector = REGISTRY._names_to_collectors[METRIC]
     module = sys.modules.get("telemetry.telemetry_client")
     if module is None:
         # A bare stub, not a re-import: that would re-register every histogram.
         module = types.ModuleType("telemetry.telemetry_client")
         module.TelemetryEvent = MagicMock()
         sys.modules["telemetry.telemetry_client"] = module
-    had_attr = hasattr(module, _METRIC_ATTR)
-    previous = getattr(module, _METRIC_ATTR, None)
-    setattr(module, _METRIC_ATTR, collector)
-    return module, had_attr, previous
+
+    saved = []
+    for attr, name in _METRIC_ATTRS.items():
+        saved.append((attr, hasattr(module, attr), getattr(module, attr, None)))
+        setattr(module, attr, REGISTRY._names_to_collectors[name])
+    return module, saved
 
 
 @pytest.fixture
 def whisper_module():
-    saved = {name: sys.modules.get(name) for name in _AUDIO_STUBS}
-    saved["tt_model_runners.whisper_runner"] = sys.modules.get(
+    saved_modules = {name: sys.modules.get(name) for name in _AUDIO_STUBS}
+    saved_modules["tt_model_runners.whisper_runner"] = sys.modules.get(
         "tt_model_runners.whisper_runner"
     )
-    telemetry_module, had_attr, previous_metric = _pin_real_collector()
+    telemetry_module, saved_attrs = _pin_real_collectors()
 
     for name in _AUDIO_STUBS:
         stub = types.ModuleType(name)
@@ -75,19 +83,20 @@ def whisper_module():
     try:
         yield importlib.import_module("tt_model_runners.whisper_runner")
     finally:
-        if had_attr:
-            setattr(telemetry_module, _METRIC_ATTR, previous_metric)
-        else:
-            delattr(telemetry_module, _METRIC_ATTR)
-        for name, module in saved.items():
+        for attr, had_attr, previous in saved_attrs:
+            if had_attr:
+                setattr(telemetry_module, attr, previous)
+            else:
+                delattr(telemetry_module, attr)
+        for name, module in saved_modules.items():
             if module is None:
                 sys.modules.pop(name, None)
             else:
                 sys.modules[name] = module
 
 
-def _metric(field, labels={"model_type": "tt-whisper"}):
-    value = REGISTRY.get_sample_value(f"{METRIC}_{field}", labels)
+def _metric(metric, field):
+    value = REGISTRY.get_sample_value(f"{metric}_{field}", _LABELS)
     return 0 if value is None else value
 
 
@@ -102,7 +111,7 @@ def _request(segments, sample_rate=16000, seconds=10):
     return request
 
 
-def _runner(whisper_module):
+def _runner(whisper_module, items=_DEFAULT_ITEMS):
     """Carries only what the streaming loop touches."""
     runner = MagicMock()
     runner.settings.default_sample_rate = 16000
@@ -111,8 +120,8 @@ def _runner(whisper_module):
 
     async def execute_pipeline(_audio, _stream, _params, prompt=None):
         async def generator():
-            yield ("text", 0.0, 1.0)
-            yield ("final", 0.0, 1.0, True)
+            for item in items:
+                yield item
 
         return generator()
 
@@ -128,18 +137,20 @@ def _drain(bound_method, request):
     return asyncio.run(run())
 
 
-def test_records_one_observation_per_prepared_chunk(whisper_module):
+def test_both_metrics_record_once_per_chunk(whisper_module):
     """ms/chunk needs one observation per chunk, not per request."""
     segments = [
         {"start": 0.0, "end": 2.0, "speaker": "SPEAKER_00"},
         {"start": 2.0, "end": 4.0, "speaker": "SPEAKER_01"},
         {"start": 4.0, "end": 6.0, "speaker": "SPEAKER_00"},
     ]
-    before = _metric("count")
+    first_token_before = _metric(FIRST_TOKEN, "count")
+    processing_before = _metric(PROCESSING, "count")
 
     _drain(_runner(whisper_module), _request(segments))
 
-    assert _metric("count") == before + len(segments)
+    assert _metric(FIRST_TOKEN, "count") == first_token_before + len(segments)
+    assert _metric(PROCESSING, "count") == processing_before + len(segments)
 
 
 def test_skipped_empty_chunks_are_not_observed(whisper_module):
@@ -149,20 +160,51 @@ def test_skipped_empty_chunks_are_not_observed(whisper_module):
         {"start": 3.0, "end": 3.0, "speaker": "SPEAKER_01"},  # empty slice
         {"start": 4.0, "end": 6.0, "speaker": "SPEAKER_00"},
     ]
-    before = _metric("count")
+    first_token_before = _metric(FIRST_TOKEN, "count")
+    processing_before = _metric(PROCESSING, "count")
 
     _drain(_runner(whisper_module), _request(segments))
 
-    assert _metric("count") == before + 2
+    assert _metric(FIRST_TOKEN, "count") == first_token_before + 2
+    assert _metric(PROCESSING, "count") == processing_before + 2
 
 
-def test_observed_duration_is_finite_and_non_negative(whisper_module):
-    """Catches an unset or misordered perf_counter span."""
-    sum_before = _metric("sum")
-    count_before = _metric("count")
+def test_first_item_observed_when_final_marker_arrives_first(whisper_module):
+    """A chunk that yields only the final marker still paid the encode cost.
+
+    The observation therefore has to sit ahead of the is_final `break`, not
+    behind it.
+    """
+    first_token_before = _metric(FIRST_TOKEN, "count")
+
+    _drain(
+        _runner(whisper_module, items=(("final", 0.0, 1.0, True),)),
+        _request([{"start": 0.0, "end": 2.0}]),
+    )
+
+    assert _metric(FIRST_TOKEN, "count") == first_token_before + 1
+
+
+def test_first_item_span_is_contained_in_the_processing_span(whisper_module):
+    """Both clocks start together, so first-item can never exceed the total."""
+    first_token_before = _metric(FIRST_TOKEN, "sum")
+    processing_before = _metric(PROCESSING, "sum")
 
     _drain(_runner(whisper_module), _request([{"start": 0.0, "end": 2.0}]))
 
-    delta = _metric("sum") - sum_before
-    assert _metric("count") == count_before + 1
+    first_token_delta = _metric(FIRST_TOKEN, "sum") - first_token_before
+    processing_delta = _metric(PROCESSING, "sum") - processing_before
+    assert first_token_delta <= processing_delta
+
+
+@pytest.mark.parametrize("metric", [FIRST_TOKEN, PROCESSING])
+def test_observed_duration_is_finite_and_non_negative(whisper_module, metric):
+    """Catches an unset or misordered perf_counter span."""
+    sum_before = _metric(metric, "sum")
+    count_before = _metric(metric, "count")
+
+    _drain(_runner(whisper_module), _request([{"start": 0.0, "end": 2.0}]))
+
+    delta = _metric(metric, "sum") - sum_before
+    assert _metric(metric, "count") == count_before + 1
     assert 0 <= delta < 5.0

--- a/tt-media-server/tests/test_whisper_chunk_metrics.py
+++ b/tt-media-server/tests/test_whisper_chunk_metrics.py
@@ -127,7 +127,9 @@ def _runner(whisper_module, items=_DEFAULT_ITEMS):
     runner.settings.model_runner = "tt-whisper"
     runner.device_id = 0
 
-    async def execute_pipeline(_audio, _stream, _params, prompt=None):
+    async def execute_pipeline(
+        _audio, _stream, _params, prompt=None, audio_profile=None
+    ):
         async def generator():
             for item in items:
                 yield item

--- a/tt-media-server/tests/test_whisper_chunk_metrics.py
+++ b/tt-media-server/tests/test_whisper_chunk_metrics.py
@@ -58,10 +58,14 @@ def _pin_real_collectors():
 
 @pytest.fixture
 def whisper_module():
-    saved_modules = {name: sys.modules.get(name) for name in _AUDIO_STUBS}
-    saved_modules["tt_model_runners.whisper_runner"] = sys.modules.get(
-        "tt_model_runners.whisper_runner"
-    )
+    # Every tt_model_runners entry goes, not just whisper_runner: other modules
+    # park a Mock at `tt_model_runners.base_device_runner`, reached through the
+    # base class, and re-importing over that yields a Mock TTWhisperRunner.
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in list(_AUDIO_STUBS)
+        + [name for name in sys.modules if name.startswith("tt_model_runners")]
+    }
     telemetry_module, saved_attrs = _pin_real_collectors()
 
     for name in _AUDIO_STUBS:
@@ -79,7 +83,9 @@ def whisper_module():
         )
         sys.modules[name] = stub
 
-    sys.modules.pop("tt_model_runners.whisper_runner", None)
+    for name in list(sys.modules):
+        if name.startswith("tt_model_runners"):
+            sys.modules.pop(name, None)
     try:
         yield importlib.import_module("tt_model_runners.whisper_runner")
     finally:
@@ -88,6 +94,9 @@ def whisper_module():
                 setattr(telemetry_module, attr, previous)
             else:
                 delattr(telemetry_module, attr)
+        for name in list(sys.modules):
+            if name.startswith("tt_model_runners"):
+                sys.modules.pop(name, None)
         for name, module in saved_modules.items():
             if module is None:
                 sys.modules.pop(name, None)

--- a/tt-media-server/tests/test_whisper_stage_throughput.py
+++ b/tt-media-server/tests/test_whisper_stage_throughput.py
@@ -263,6 +263,46 @@ def test_batch_audio_seconds_sum_per_item(whisper_module):
     assert context["encoder_labels"]["batch"] == "2"
 
 
+def test_batch_padding_is_not_credited_as_audio(whisper_module):
+    """A 2-item batch is zero-padded to the longer item before submission.
+
+    The arrays therefore both measure 25s, but only 30s of real audio went in.
+    Deriving duration from the submitted array would credit the pad and report
+    50s, inflating both stage throughputs by 1.67x.
+    """
+    runner = _runner(whisper_module)
+    padded = _batch(25.0, count=2)
+
+    assert runner._audio_stage_context(padded)["audio_seconds"] == pytest.approx(50.0)
+
+    context = runner._audio_stage_context(padded, audio_durations=[5.0, 25.0])
+    assert context["audio_seconds"] == pytest.approx(30.0)
+    assert context["feature_labels"]["batch"] == "2"
+
+
+def test_supplied_durations_are_still_capped_at_the_frame(whisper_module):
+    """The clamp has to survive the override, or an over-long submitted
+    duration reintroduces the inflation the extractor's truncation causes."""
+    runner = _runner(whisper_module)
+    context = runner._audio_stage_context(
+        _batch(90.0, count=2), audio_durations=[90.0, 10.0]
+    )
+
+    assert context["audio_seconds"] == pytest.approx(40.0)
+
+
+def test_missing_durations_fall_back_to_the_array(whisper_module):
+    """Every non-batched caller passes nothing; the array stays the source."""
+    runner = _runner(whisper_module)
+
+    assert runner._audio_stage_context(_batch(7.0), audio_durations=None)[
+        "audio_seconds"
+    ] == pytest.approx(7.0)
+    assert runner._audio_stage_context(_batch(7.0, count=2), audio_durations=[3.0])[
+        "audio_seconds"
+    ] == pytest.approx(10.0)
+
+
 def test_labels_carry_the_operating_point(whisper_module):
     runner = _runner(whisper_module)
     context = runner._audio_stage_context(_batch(4.0, sample_rate=8000))

--- a/tt-media-server/tests/test_whisper_stage_throughput.py
+++ b/tt-media-server/tests/test_whisper_stage_throughput.py
@@ -1,0 +1,450 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+"""Feature-extraction and encoder throughput on the Whisper path.
+
+`whisper_runner` probes for tt-metal's `PerfMetrics` (#53717) at import time, so
+the stub below carries it. Its absence is the older-tt-metal case covered by
+`test_absent_perf_metrics_*`.
+"""
+
+import asyncio
+import importlib
+import sys
+import types
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from prometheus_client import REGISTRY
+
+FEATURE_INPUT = "tt_media_server_audio_feature_extraction_input_seconds_total"
+FEATURE_DURATION = "tt_media_server_audio_feature_extraction_duration_seconds"
+ENCODER_INPUT = "tt_media_server_audio_encoder_input_seconds_total"
+ENCODER_DURATION = "tt_media_server_audio_encoder_duration_seconds"
+
+_METRIC_ATTRS = {
+    "audio_feature_extraction_input_seconds": FEATURE_INPUT,
+    "audio_feature_extraction_duration": FEATURE_DURATION,
+    "audio_encoder_input_seconds": ENCODER_INPUT,
+    "audio_encoder_duration": ENCODER_DURATION,
+    "audio_chunk_first_token_duration": "tt_media_server_audio_chunk_first_token_seconds",
+    "audio_chunk_processing_duration": "tt_media_server_audio_chunk_processing_seconds",
+}
+_AUDIO_STUBS = (
+    "models.demos.audio",
+    "models.demos.audio.whisper",
+    "models.demos.audio.whisper.tt",
+    "models.demos.audio.whisper.tt.ttnn_optimized_functional_whisper",
+    "models.demos.audio.whisper.tt.whisper_generator",
+)
+
+_FEATURE_LABELS = {
+    "model_type": "tt-whisper",
+    "device_id": "0",
+    "sample_rate": "16000",
+    "channels": "1",
+    "batch": "1",
+}
+_ENCODER_LABELS = {
+    "model_type": "tt-whisper",
+    "device_id": "0",
+    "model_name": "distil-large-v3",
+    "language": "English",
+    "batch": "1",
+    "trace_hit": "true",
+}
+
+
+@dataclass
+class StubPerfMetrics:
+    """Mirrors the fields whisper_runner reads off the real PerfMetrics."""
+
+    feature_extract_s: float = 0.01
+    encoder_s: float = 0.2
+    total_audio_s: float = 0.0
+    ttft: float = 0.0
+    decode_throughput: float = 0.0
+    encoder_trace_hit: bool = True
+
+
+def _pin_real_collectors():
+    """Pin the real collectors onto telemetry.telemetry_client.
+
+    Other test modules leave a Mock there that swallows every observation; the
+    registry keeps the one reference surviving that swap.
+    """
+    module = sys.modules.get("telemetry.telemetry_client")
+    if module is None:
+        # A bare stub, not a re-import: that would re-register every collector.
+        module = types.ModuleType("telemetry.telemetry_client")
+        module.TelemetryEvent = MagicMock()
+        sys.modules["telemetry.telemetry_client"] = module
+
+    saved = []
+    for attr, name in _METRIC_ATTRS.items():
+        saved.append((attr, hasattr(module, attr), getattr(module, attr, None)))
+        setattr(module, attr, REGISTRY._names_to_collectors[name])
+    return module, saved
+
+
+def _whisper_module(with_perf_metrics=True):
+    # Every tt_model_runners entry goes, not just whisper_runner: other modules
+    # park a Mock at `tt_model_runners.base_device_runner`, reached through the
+    # base class, and re-importing over that yields a Mock TTWhisperRunner.
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in list(_AUDIO_STUBS)
+        + [name for name in sys.modules if name.startswith("tt_model_runners")]
+    }
+    telemetry_module, saved_attrs = _pin_real_collectors()
+
+    for name in _AUDIO_STUBS:
+        stub = types.ModuleType(name)
+        stub.__dict__.update(
+            {
+                "WHISPER_L1_SMALL_SIZE": 0,
+                "WHISPER_TRACE_REGION_SIZE": 0,
+                "convert_to_ttnn": MagicMock(),
+                "create_custom_mesh_preprocessor": MagicMock(),
+                "init_kv_cache": MagicMock(),
+                "GenerationParams": MagicMock(),
+                "WhisperGenerator": MagicMock(),
+            }
+        )
+        if with_perf_metrics:
+            stub.PerfMetrics = StubPerfMetrics
+        sys.modules[name] = stub
+
+    for name in list(sys.modules):
+        if name.startswith("tt_model_runners"):
+            sys.modules.pop(name, None)
+    module = importlib.import_module("tt_model_runners.whisper_runner")
+    return module, (telemetry_module, saved_attrs, saved_modules)
+
+
+def _restore(state):
+    telemetry_module, saved_attrs, saved_modules = state
+    for attr, had_attr, previous in saved_attrs:
+        if had_attr:
+            setattr(telemetry_module, attr, previous)
+        else:
+            delattr(telemetry_module, attr)
+    for name in list(sys.modules):
+        if name.startswith("tt_model_runners"):
+            sys.modules.pop(name, None)
+    for name, module in saved_modules.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+
+
+@pytest.fixture
+def whisper_module():
+    module, state = _whisper_module()
+    try:
+        yield module
+    finally:
+        _restore(state)
+
+
+@pytest.fixture
+def whisper_module_without_perf_metrics():
+    module, state = _whisper_module(with_perf_metrics=False)
+    try:
+        yield module
+    finally:
+        _restore(state)
+
+
+def _counter(metric, labels):
+    value = REGISTRY.get_sample_value(metric, labels)
+    return 0.0 if value is None else value
+
+
+def _histogram(metric, field, labels):
+    value = REGISTRY.get_sample_value(f"{metric}_{field}", labels)
+    return 0.0 if value is None else value
+
+
+def _runner(whisper_module, frame_seconds=30.0):
+    """Carries only what the throughput helpers touch."""
+    runner = MagicMock()
+    runner.settings.default_sample_rate = 16000
+    runner.settings.model_runner = "tt-whisper"
+    runner.settings.model_weights_path = "distil-whisper/distil-large-v3"
+    runner.settings.audio_language = "English"
+    runner.device_id = 0
+    runner._encoder_frame_seconds = frame_seconds
+
+    runner_class = whisper_module.TTWhisperRunner
+    for name in (
+        "_audio_stage_context",
+        "_record_audio_stage_throughput",
+        "_stream_with_stage_metrics",
+    ):
+        setattr(runner, name, getattr(runner_class, name).__get__(runner))
+    runner._find_perf_metrics = runner_class._find_perf_metrics
+    return runner
+
+
+def _batch(seconds, sample_rate=16000, count=1):
+    array = np.zeros(int(sample_rate * seconds), dtype=np.float32)
+    return [(sample_rate, array)] * count
+
+
+def test_stage_metrics_recorded_once_per_batch(whisper_module):
+    runner = _runner(whisper_module)
+    feature_before = _counter(FEATURE_INPUT, _FEATURE_LABELS)
+    encoder_before = _counter(ENCODER_INPUT, _ENCODER_LABELS)
+    feature_count_before = _histogram(FEATURE_DURATION, "count", _FEATURE_LABELS)
+    encoder_count_before = _histogram(ENCODER_DURATION, "count", _ENCODER_LABELS)
+
+    context = runner._audio_stage_context(_batch(8.0))
+    result = (
+        "text",
+        None,
+        None,
+        StubPerfMetrics(feature_extract_s=0.01, encoder_s=0.2),
+    )
+    assert runner._record_audio_stage_throughput(result, context) is True
+
+    assert _counter(FEATURE_INPUT, _FEATURE_LABELS) == pytest.approx(
+        feature_before + 8.0
+    )
+    assert _counter(ENCODER_INPUT, _ENCODER_LABELS) == pytest.approx(
+        encoder_before + 8.0
+    )
+    assert _histogram(FEATURE_DURATION, "count", _FEATURE_LABELS) == (
+        feature_count_before + 1
+    )
+    assert _histogram(ENCODER_DURATION, "count", _ENCODER_LABELS) == (
+        encoder_count_before + 1
+    )
+
+
+def test_throughput_derives_from_the_counter_pair(whisper_module):
+    """Both halves of the ratio must move together in the same units."""
+    runner = _runner(whisper_module)
+    input_before = _counter(ENCODER_INPUT, _ENCODER_LABELS)
+    sum_before = _histogram(ENCODER_DURATION, "sum", _ENCODER_LABELS)
+
+    context = runner._audio_stage_context(_batch(15.0))
+    runner._record_audio_stage_throughput(
+        ("text", None, None, StubPerfMetrics(encoder_s=0.5)), context
+    )
+
+    audio_delta = _counter(ENCODER_INPUT, _ENCODER_LABELS) - input_before
+    time_delta = _histogram(ENCODER_DURATION, "sum", _ENCODER_LABELS) - sum_before
+    assert audio_delta / time_delta == pytest.approx(30.0)
+
+
+def test_audio_seconds_are_capped_at_one_encoder_frame(whisper_module):
+    """The extractor truncates to the frame; crediting the full submission
+    would inflate throughput by that ratio."""
+    runner = _runner(whisper_module)
+
+    assert runner._audio_stage_context(_batch(90.0))["audio_seconds"] == pytest.approx(
+        30.0
+    )
+    assert runner._audio_stage_context(_batch(12.0))["audio_seconds"] == pytest.approx(
+        12.0
+    )
+
+
+def test_batch_audio_seconds_sum_per_item(whisper_module):
+    runner = _runner(whisper_module)
+    context = runner._audio_stage_context(_batch(10.0, count=2))
+
+    assert context["audio_seconds"] == pytest.approx(20.0)
+    assert context["feature_labels"]["batch"] == "2"
+    assert context["encoder_labels"]["batch"] == "2"
+
+
+def test_labels_carry_the_operating_point(whisper_module):
+    runner = _runner(whisper_module)
+    context = runner._audio_stage_context(_batch(4.0, sample_rate=8000))
+
+    assert context["feature_labels"] == {
+        "model_type": "tt-whisper",
+        "device_id": "0",
+        "sample_rate": "8000",
+        "channels": "1",
+        "batch": "1",
+    }
+    assert context["encoder_labels"] == {
+        "model_type": "tt-whisper",
+        "device_id": "0",
+        "model_name": "distil-large-v3",
+        "language": "English",
+        "batch": "1",
+    }
+
+
+def test_trace_capture_call_is_labelled_not_dropped(whisper_module):
+    """Panels filter the capture call out on the label, so it must be recorded
+    under trace_hit="false" rather than dropped."""
+    runner = _runner(whisper_module)
+    miss_labels = dict(_ENCODER_LABELS, trace_hit="false")
+    hit_before = _counter(ENCODER_INPUT, _ENCODER_LABELS)
+    miss_before = _counter(ENCODER_INPUT, miss_labels)
+
+    context = runner._audio_stage_context(_batch(5.0))
+    runner._record_audio_stage_throughput(
+        ("text", None, None, StubPerfMetrics(encoder_trace_hit=False)), context
+    )
+
+    assert _counter(ENCODER_INPUT, miss_labels) == pytest.approx(miss_before + 5.0)
+    assert _counter(ENCODER_INPUT, _ENCODER_LABELS) == pytest.approx(hit_before)
+
+
+def test_zero_duration_stage_is_not_credited_with_audio(whisper_module):
+    """generate()'s no-valid-output paths return zeroed timings."""
+    runner = _runner(whisper_module)
+    feature_before = _counter(FEATURE_INPUT, _FEATURE_LABELS)
+    encoder_before = _counter(ENCODER_INPUT, _ENCODER_LABELS)
+
+    context = runner._audio_stage_context(_batch(5.0))
+    recorded = runner._record_audio_stage_throughput(
+        ("text", None, None, StubPerfMetrics(feature_extract_s=0.0, encoder_s=0.0)),
+        context,
+    )
+
+    assert recorded is False
+    assert _counter(FEATURE_INPUT, _FEATURE_LABELS) == pytest.approx(feature_before)
+    assert _counter(ENCODER_INPUT, _ENCODER_LABELS) == pytest.approx(encoder_before)
+
+
+def test_result_without_perf_metrics_records_nothing(whisper_module):
+    runner = _runner(whisper_module)
+    before = _counter(FEATURE_INPUT, _FEATURE_LABELS)
+
+    context = runner._audio_stage_context(_batch(5.0))
+    assert runner._record_audio_stage_throughput(("text", 0.0, 1.0), context) is False
+    assert _counter(FEATURE_INPUT, _FEATURE_LABELS) == pytest.approx(before)
+
+
+def test_streaming_records_once_across_every_yield(whisper_module):
+    """Every yield repeats the timings; per-item recording would multiply one
+    batch by its token count."""
+    runner = _runner(whisper_module)
+    perf = StubPerfMetrics()
+    items = [
+        ("a", None, None, perf, False),
+        ("b", None, None, perf, False),
+        ("final", None, None, perf, True),
+    ]
+    before = _counter(FEATURE_INPUT, _FEATURE_LABELS)
+    count_before = _histogram(FEATURE_DURATION, "count", _FEATURE_LABELS)
+
+    context = runner._audio_stage_context(_batch(6.0))
+    drained = list(runner._stream_with_stage_metrics(iter(items), context))
+
+    assert drained == items
+    assert _counter(FEATURE_INPUT, _FEATURE_LABELS) == pytest.approx(before + 6.0)
+    assert _histogram(FEATURE_DURATION, "count", _FEATURE_LABELS) == count_before + 1
+
+
+def test_streaming_keeps_looking_past_a_metric_free_first_yield(whisper_module):
+    runner = _runner(whisper_module)
+    before = _counter(FEATURE_INPUT, _FEATURE_LABELS)
+
+    context = runner._audio_stage_context(_batch(3.0))
+    list(
+        runner._stream_with_stage_metrics(
+            iter([("a", None, None), ("b", None, None, StubPerfMetrics(), True)]),
+            context,
+        )
+    )
+
+    assert _counter(FEATURE_INPUT, _FEATURE_LABELS) == pytest.approx(before + 3.0)
+
+
+def test_is_final_tracks_the_trailing_bool_not_a_fixed_index(whisper_module):
+    """A PerfMetrics at the old index 3 must not read as a final marker."""
+    is_final = whisper_module.TTWhisperRunner._is_final_result
+
+    assert is_final(("text", None, None, StubPerfMetrics(), True)) is True
+    assert is_final(("text", None, None, StubPerfMetrics(), False)) is False
+    assert is_final(("text", None, None, True)) is True
+    assert is_final(("text", None, None, False)) is False
+    # Non-streaming tuples end in a PerfMetrics or a tensor, never a bool.
+    assert is_final(("text", None, None, StubPerfMetrics())) is False
+    assert is_final(("text", None, None)) is False
+    assert is_final("text") is False
+
+
+def test_frame_seconds_come_from_the_loaded_extractor(whisper_module):
+    resolve = whisper_module.TTWhisperRunner._resolve_encoder_frame_seconds
+
+    assert resolve(
+        types.SimpleNamespace(n_samples=480000, sampling_rate=16000)
+    ) == pytest.approx(30.0)
+    assert resolve(types.SimpleNamespace(chunk_length=20)) == pytest.approx(20.0)
+    # A MagicMock extractor must not turn the cap into a Mock arithmetic result.
+    assert resolve(MagicMock()) == pytest.approx(
+        whisper_module.WHISPER_ENCODER_FRAME_SECONDS
+    )
+    assert resolve(None) == pytest.approx(whisper_module.WHISPER_ENCODER_FRAME_SECONDS)
+
+
+def test_perf_metrics_are_requested_when_tt_metal_supports_them(whisper_module):
+    assert whisper_module.WHISPER_PERF_METRICS_SUPPORTED is True
+
+
+def test_absent_perf_metrics_leaves_the_request_off(
+    whisper_module_without_perf_metrics,
+):
+    """Without PerfMetrics, asking for metrics only changes the tuple arity."""
+    assert whisper_module_without_perf_metrics.WHISPER_PERF_METRICS_SUPPORTED is False
+
+
+def test_absent_perf_metrics_still_resolves_the_final_marker(
+    whisper_module_without_perf_metrics,
+):
+    is_final = whisper_module_without_perf_metrics.TTWhisperRunner._is_final_result
+
+    assert is_final(("text", 0.0, 1.0, True)) is True
+    assert is_final(("text", 0.0, 1.0)) is False
+
+
+def test_streaming_path_yields_unchanged_items(whisper_module):
+    """The wrapper must be transparent to the streaming loop's tuple handling."""
+    runner = _runner(whisper_module)
+    context = runner._audio_stage_context(_batch(2.0))
+
+    async def drain():
+        return [
+            item
+            for item in runner._stream_with_stage_metrics(
+                iter([("only", None, None, StubPerfMetrics(), True)]), context
+            )
+        ]
+
+    assert asyncio.run(drain()) == [("only", None, None, StubPerfMetrics(), True)]
+
+
+def test_dashboard_queries_match_the_exposed_series(whisper_module):
+    """A rename that misses the panels silently empties them."""
+    import json
+    import re
+    from pathlib import Path
+
+    registered = set(REGISTRY._names_to_collectors)
+    dashboard = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "monitoring/grafana/dashboards/tt_media_server_python.json"
+        ).read_text()
+    )
+    queried = set()
+    for panel in dashboard["panels"]:
+        for target in panel.get("targets", []):
+            queried.update(
+                re.findall(r"tt_media_server_audio_\w+", target.get("expr", ""))
+            )
+
+    assert queried, "dashboard no longer queries the audio metrics"
+    assert queried <= registered, sorted(queried - registered)

--- a/tt-media-server/tests/test_whisper_stage_throughput.py
+++ b/tt-media-server/tests/test_whisper_stage_throughput.py
@@ -59,10 +59,17 @@ _ENCODER_LABELS = {
 
 @dataclass
 class StubPerfMetrics:
-    """Mirrors the fields whisper_runner reads off the real PerfMetrics."""
+    """Mirrors the fields whisper_runner reads off the real PerfMetrics.
 
-    feature_extract_s: float = 0.01
-    encoder_s: float = 0.2
+    Defaults match tt-metal's dataclass exactly, zeros included. They used to
+    be 0.01/0.2, which made a bare StubPerfMetrics() record where a bare
+    PerfMetrics() records nothing — so a test could assert positive recording
+    against a value the real generator never produces. Every test that wants a
+    recording now has to say so.
+    """
+
+    feature_extract_s: float = 0.0
+    encoder_s: float = 0.0
     total_audio_s: float = 0.0
     ttft: float = 0.0
     decode_throughput: float = 0.0
@@ -305,13 +312,15 @@ def test_missing_durations_fall_back_to_the_array(whisper_module):
 
 def test_labels_carry_the_operating_point(whisper_module):
     runner = _runner(whisper_module)
-    context = runner._audio_stage_context(_batch(4.0, sample_rate=8000))
+    context = runner._audio_stage_context(
+        _batch(4.0), audio_profile={"sample_rate": "8000", "channels": "2"}
+    )
 
     assert context["feature_labels"] == {
         "model_type": "tt-whisper",
         "device_id": "0",
         "sample_rate": "8000",
-        "channels": "1",
+        "channels": "2",
         "batch": "1",
     }
     assert context["encoder_labels"] == {
@@ -321,6 +330,45 @@ def test_labels_carry_the_operating_point(whisper_module):
         "language": "English",
         "batch": "1",
     }
+
+
+def test_labels_fall_back_to_the_pipeline_operating_point(whisper_module):
+    """Warmup and any caller that has no request pass no profile."""
+    runner = _runner(whisper_module)
+    labels = runner._audio_stage_context(_batch(4.0))["feature_labels"]
+
+    assert labels["sample_rate"] == "16000"
+    assert labels["channels"] == "1"
+
+
+def test_source_profile_reports_what_was_submitted(whisper_module):
+    """The array is always mono at the default rate by the time the runner sees
+    it, so these labels have to come off the request, not the array."""
+    profile = whisper_module.TTWhisperRunner._audio_profile
+
+    request = MagicMock()
+    request._source_sample_rate = 44100
+    request._source_channels = 2
+    assert profile(request) == {"sample_rate": "44100", "channels": "2"}
+
+
+def test_unobservable_source_profile_is_not_reported_as_real(whisper_module):
+    """ffmpeg normalises before the WAV header is read, so the source is None."""
+    profile = whisper_module.TTWhisperRunner._audio_profile
+
+    request = MagicMock()
+    request._source_sample_rate = None
+    request._source_channels = None
+    assert profile(request) == {"sample_rate": "unknown", "channels": "unknown"}
+
+
+def test_disagreeing_batch_reports_mixed_rather_than_one_item(whisper_module):
+    profile = whisper_module.TTWhisperRunner._audio_profile
+
+    first, second = MagicMock(), MagicMock()
+    first._source_sample_rate, first._source_channels = 44100, 2
+    second._source_sample_rate, second._source_channels = 16000, 2
+    assert profile([first, second]) == {"sample_rate": "mixed", "channels": "2"}
 
 
 def test_trace_capture_call_is_labelled_not_dropped(whisper_module):
@@ -333,7 +381,14 @@ def test_trace_capture_call_is_labelled_not_dropped(whisper_module):
 
     context = runner._audio_stage_context(_batch(5.0))
     runner._record_audio_stage_throughput(
-        ("text", None, None, StubPerfMetrics(encoder_trace_hit=False)), context
+        # The capture call runs the encoder twice, hence the outlier timing.
+        (
+            "text",
+            None,
+            None,
+            StubPerfMetrics(encoder_s=0.9, encoder_trace_hit=False),
+        ),
+        context,
     )
 
     assert _counter(ENCODER_INPUT, miss_labels) == pytest.approx(miss_before + 5.0)
@@ -370,7 +425,7 @@ def test_streaming_records_once_across_every_yield(whisper_module):
     """Every yield repeats the timings; per-item recording would multiply one
     batch by its token count."""
     runner = _runner(whisper_module)
-    perf = StubPerfMetrics()
+    perf = StubPerfMetrics(feature_extract_s=0.01, encoder_s=0.2)
     items = [
         ("a", None, None, perf, False),
         ("b", None, None, perf, False),
@@ -394,7 +449,18 @@ def test_streaming_keeps_looking_past_a_metric_free_first_yield(whisper_module):
     context = runner._audio_stage_context(_batch(3.0))
     list(
         runner._stream_with_stage_metrics(
-            iter([("a", None, None), ("b", None, None, StubPerfMetrics(), True)]),
+            iter(
+                [
+                    ("a", None, None),
+                    (
+                        "b",
+                        None,
+                        None,
+                        StubPerfMetrics(feature_extract_s=0.01, encoder_s=0.2),
+                        True,
+                    ),
+                ]
+            ),
             context,
         )
     )

--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -293,6 +293,13 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
             else:
                 audio_data = audio_arrays
 
+            # Measured before the pad above, which is silence: throughput has to
+            # be credited the audio that was actually submitted, or a batch of
+            # unequal lengths reports the longer item's duration twice.
+            audio_durations = [
+                len(arr) / self.settings.default_sample_rate for arr in audio_arrays
+            ]
+
             # prompt is batch-homogeneous in tt-metal's WhisperGenerator: take the
             # first request's prompt and warn if requests disagree.
             prompts = {req.prompt for req in requests if req.prompt is not None}
@@ -307,6 +314,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                 stream=False,
                 generation_params=generation_params,
                 prompt=prompt,
+                audio_durations=audio_durations,
             )
 
             responses = []
@@ -351,22 +359,31 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
             return float(chunk_length)
         return WHISPER_ENCODER_FRAME_SECONDS
 
-    def _audio_stage_context(self, current_batch):
-        """Label values and the audio seconds the two stages actually consume.
+    def _audio_stage_context(self, current_batch, audio_durations=None):
+        """Label values and the useful audio seconds credited to the two stages.
 
         Counted here rather than read off PerfMetrics.total_audio_s, which sums
         submitted durations: an item longer than one frame is truncated to it.
         Reachable here — chunking never splits a single long VAD segment, so
         uninterrupted speech becomes one long chunk.
+
+        `audio_durations` overrides the duration derived from each array's
+        length. Batched calls zero-pad the shorter item up to the longer one
+        before submitting, and that pad is silence no stage turns into useful
+        features — measuring the submitted array would credit it as real audio.
         """
         frame_seconds = self._encoder_frame_seconds
         audio_seconds = 0.0
         channels = 1
         sample_rate = self.settings.default_sample_rate
-        for rate, audio_array in current_batch:
+        for index, (rate, audio_array) in enumerate(current_batch):
             if rate:
                 sample_rate = rate
-                audio_seconds += min(audio_array.shape[0] / rate, frame_seconds)
+                if audio_durations is not None and index < len(audio_durations):
+                    duration = audio_durations[index]
+                else:
+                    duration = audio_array.shape[0] / rate
+                audio_seconds += min(duration, frame_seconds)
             if audio_array.ndim > 1:
                 channels = audio_array.shape[1]
 
@@ -922,6 +939,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                     Union[GenerationParams, List[GenerationParams]]
                 ] = None,
                 prompt: Optional[str] = None,
+                audio_durations: Optional[List[float]] = None,
             ):
                 try:
                     # Validate pipeline inputs
@@ -976,7 +994,9 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                         return result
 
                     # Built here: only this scope knows what was submitted.
-                    stage_context = self._audio_stage_context(current_batch)
+                    stage_context = self._audio_stage_context(
+                        current_batch, audio_durations=audio_durations
+                    )
                     if stream:
                         # Streaming defers every stage to the first pull, so the
                         # timings do not exist yet.

--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -31,7 +31,8 @@ from models.demos.audio.whisper.tt.whisper_generator import (
 from models.demos.utils.common_demo_utils import get_mesh_mappers
 from telemetry.telemetry_client import (
     TelemetryEvent,
-    audio_chunk_preparation_duration,
+    audio_chunk_first_token_duration,
+    audio_chunk_processing_duration,
 )
 from transformers import (
     AutoFeatureExtractor,
@@ -347,7 +348,6 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
         chunk_count = 0
 
         for i, segment in enumerate(request._segments):
-            chunk_prep_start = time.perf_counter()
             start_time = segment["start"]
             end_time = segment["end"]
             speaker = segment.get("speaker", f"SPEAKER_{i:02d}")
@@ -367,11 +367,10 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                 f"Device {self.device_id}: Processing segment {i + 1}/{len(request._segments)}: {start_time:.2f}s-{end_time:.2f}s, speaker: {speaker}"
             )
 
-            # Past the empty-chunk `continue`: skipped chunks feed no inference.
-            audio_chunk_preparation_duration.labels(
-                model_type=self.settings.model_runner
-            ).observe(time.perf_counter() - chunk_prep_start)
-
+            # `_execute_pipeline` only builds the async generator; the log-mel
+            # extraction and the device passes are deferred to the first pull
+            # below, so the clock has to start here and stop inside the loop.
+            chunk_start = time.perf_counter()
             async_generator = await self._execute_pipeline(
                 segment_audio,
                 request.stream,
@@ -381,9 +380,18 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
 
             segment_prefix = f"[{speaker}] "
             first_token = True
+            first_item_observed = False
             segment_text_parts = []
 
             async for partial_result in async_generator:
+                # Ahead of the is_final check: a chunk whose only item is the
+                # final marker still paid the extraction and encode cost.
+                if not first_item_observed:
+                    audio_chunk_first_token_duration.labels(
+                        model_type=self.settings.model_runner
+                    ).observe(time.perf_counter() - chunk_start)
+                    first_item_observed = True
+
                 text_part, start, end = TextUtils.extract_text(partial_result)
                 # Check is_final flag
                 if isinstance(partial_result, tuple) and len(partial_result) >= 4:
@@ -415,6 +423,13 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                     }
 
                 segment_text_parts.append(text_part)
+
+            # Reached on both generator exhaustion and the is_final `break`. The
+            # span covers the `yield`s above, so it is wall time per chunk and
+            # includes any consumer backpressure, not compute alone.
+            audio_chunk_processing_duration.labels(
+                model_type=self.settings.model_runner
+            ).observe(time.perf_counter() - chunk_start)
 
             # Build segment data for final result
             segment_result = TextUtils.concatenate_chunks(segment_text_parts)

--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -117,10 +117,15 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                 self.logger.info(
                     f"Device {self.device_id}: Starting model warmup with {len(dummy_audio)} samples"
                 )
-                await self.pipeline(dummy_audio)
+                # Excluded from the stage metrics: these are cold, they capture
+                # the encoder traces, and their 1s of silence is not offered
+                # load. The encoder side would be filtered out anyway by
+                # trace_hit="false", but feature extraction has no such label,
+                # so warmup would otherwise sit in its panels permanently.
+                await self.pipeline(dummy_audio, record_stage_metrics=False)
                 if self.settings.max_batch_size > 1:
                     warmup_batch = [dummy_audio, dummy_audio]
-                    await self.pipeline(warmup_batch)
+                    await self.pipeline(warmup_batch, record_stage_metrics=False)
                 self.logger.info(
                     f"Device {self.device_id}: Model warmup completed successfully"
                 )
@@ -184,6 +189,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                     request.stream,
                     self._create_generation_params(request),
                     prompt=request.prompt,
+                    audio_profile=self._audio_profile(request),
                 )
 
                 if request.stream:
@@ -249,19 +255,19 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
         return request
 
     async def _execute_pipeline(
-        self, audio_data, stream, generation_params, prompt=None
+        self, audio_data, stream, generation_params, prompt=None, audio_profile=None
     ):
         """Main pipeline execution method"""
         try:
             if stream:
                 # Return the async generator
                 return self._execute_pipeline_streaming(
-                    audio_data, generation_params, prompt
+                    audio_data, generation_params, prompt, audio_profile
                 )
             else:
                 # Return the single result
                 return await self._execute_pipeline_non_streaming(
-                    audio_data, generation_params, prompt
+                    audio_data, generation_params, prompt, audio_profile
                 )
 
         except Exception as e:
@@ -315,6 +321,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                 generation_params=generation_params,
                 prompt=prompt,
                 audio_durations=audio_durations,
+                audio_profile=self._audio_profile(requests),
             )
 
             responses = []
@@ -359,7 +366,35 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
             return float(chunk_length)
         return WHISPER_ENCODER_FRAME_SECONDS
 
-    def _audio_stage_context(self, current_batch, audio_durations=None):
+    @staticmethod
+    def _audio_profile(requests):
+        """The submitted operating point shared by a batch of requests.
+
+        `sample_rate` and `channels` describe what arrived, not what reaches the
+        extractor: audio_manager downmixes to mono and resamples to the default
+        rate before the runner sees an array, so deriving these from the array
+        would report a constant. "unknown" covers a decode path that normalised
+        them away (ffmpeg) and "mixed" a batch whose items disagree, so neither
+        case is silently reported as a real value.
+        """
+        if not isinstance(requests, (list, tuple)):
+            requests = [requests]
+
+        def _shared(attr):
+            values = {getattr(req, attr, None) for req in requests}
+            if len(values) != 1:
+                return "mixed"
+            value = values.pop()
+            return "unknown" if value is None else str(value)
+
+        return {
+            "sample_rate": _shared("_source_sample_rate"),
+            "channels": _shared("_source_channels"),
+        }
+
+    def _audio_stage_context(
+        self, current_batch, audio_durations=None, audio_profile=None
+    ):
         """Label values and the useful audio seconds credited to the two stages.
 
         Counted here rather than read off PerfMetrics.total_audio_s, which sums
@@ -374,18 +409,19 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
         """
         frame_seconds = self._encoder_frame_seconds
         audio_seconds = 0.0
-        channels = 1
-        sample_rate = self.settings.default_sample_rate
         for index, (rate, audio_array) in enumerate(current_batch):
             if rate:
-                sample_rate = rate
                 if audio_durations is not None and index < len(audio_durations):
                     duration = audio_durations[index]
                 else:
                     duration = audio_array.shape[0] / rate
                 audio_seconds += min(duration, frame_seconds)
-            if audio_array.ndim > 1:
-                channels = audio_array.shape[1]
+
+        profile = audio_profile or {}
+        sample_rate = profile.get("sample_rate") or str(
+            self.settings.default_sample_rate
+        )
+        channels = profile.get("channels") or "1"
 
         model_name = (
             os.path.basename((self.settings.model_weights_path or "").rstrip("/"))
@@ -397,8 +433,8 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
             "feature_labels": {
                 "model_type": self.settings.model_runner,
                 "device_id": device_id,
-                "sample_rate": str(sample_rate),
-                "channels": str(channels),
+                "sample_rate": sample_rate,
+                "channels": channels,
                 "batch": str(len(current_batch)),
             },
             "encoder_labels": {
@@ -490,7 +526,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
         )
 
     async def _execute_pipeline_streaming(
-        self, audio_data, generation_params, prompt=None
+        self, audio_data, generation_params, prompt=None, audio_profile=None
     ):
         """Async generator for streaming results"""
         generator = await self.pipeline(
@@ -498,13 +534,14 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
             stream=True,
             generation_params=generation_params,
             prompt=prompt,
+            audio_profile=audio_profile,
         )
 
         for item in generator:
             yield item
 
     async def _execute_pipeline_non_streaming(
-        self, audio_data, generation_params, prompt=None
+        self, audio_data, generation_params, prompt=None, audio_profile=None
     ):
         """Non-streaming pipeline execution"""
         result = await self.pipeline(
@@ -512,6 +549,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
             stream=False,
             generation_params=generation_params,
             prompt=prompt,
+            audio_profile=audio_profile,
         )
 
         if result is None:
@@ -555,6 +593,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                 request.stream,
                 self._create_generation_params(request),
                 prompt=request.prompt,
+                audio_profile=self._audio_profile(request),
             )
 
             segment_prefix = f"[{speaker}] "
@@ -670,6 +709,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                 request.stream,
                 self._create_generation_params(request),
                 prompt=request.prompt,
+                audio_profile=self._audio_profile(request),
             )
 
             cleaned_text, start, end = TextUtils.extract_text(segment_result)
@@ -940,6 +980,8 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                 ] = None,
                 prompt: Optional[str] = None,
                 audio_durations: Optional[List[float]] = None,
+                record_stage_metrics: bool = True,
+                audio_profile: Optional[dict] = None,
             ):
                 try:
                     # Validate pipeline inputs
@@ -990,12 +1032,14 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
 
                     result = await asyncio.to_thread(_run)
 
-                    if not WHISPER_PERF_METRICS_SUPPORTED:
+                    if not WHISPER_PERF_METRICS_SUPPORTED or not record_stage_metrics:
                         return result
 
                     # Built here: only this scope knows what was submitted.
                     stage_context = self._audio_stage_context(
-                        current_batch, audio_durations=audio_durations
+                        current_batch,
+                        audio_durations=audio_durations,
+                        audio_profile=audio_profile,
                     )
                     if stream:
                         # Streaming defers every stage to the first pull, so the

--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import os
+import time
 from typing import List, Optional, Union
 
 import numpy as np
@@ -28,7 +29,10 @@ from models.demos.audio.whisper.tt.whisper_generator import (
     WhisperGenerator,
 )
 from models.demos.utils.common_demo_utils import get_mesh_mappers
-from telemetry.telemetry_client import TelemetryEvent
+from telemetry.telemetry_client import (
+    TelemetryEvent,
+    audio_chunk_preparation_duration,
+)
 from transformers import (
     AutoFeatureExtractor,
     AutoProcessor,
@@ -343,6 +347,7 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
         chunk_count = 0
 
         for i, segment in enumerate(request._segments):
+            chunk_prep_start = time.perf_counter()
             start_time = segment["start"]
             end_time = segment["end"]
             speaker = segment.get("speaker", f"SPEAKER_{i:02d}")
@@ -361,6 +366,11 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
             self.logger.info(
                 f"Device {self.device_id}: Processing segment {i + 1}/{len(request._segments)}: {start_time:.2f}s-{end_time:.2f}s, speaker: {speaker}"
             )
+
+            # Past the empty-chunk `continue`: skipped chunks feed no inference.
+            audio_chunk_preparation_duration.labels(
+                model_type=self.settings.model_runner
+            ).observe(time.perf_counter() - chunk_prep_start)
 
             async_generator = await self._execute_pipeline(
                 segment_audio,

--- a/tt-media-server/tt_model_runners/whisper_runner.py
+++ b/tt-media-server/tt_model_runners/whisper_runner.py
@@ -33,6 +33,10 @@ from telemetry.telemetry_client import (
     TelemetryEvent,
     audio_chunk_first_token_duration,
     audio_chunk_processing_duration,
+    audio_encoder_duration,
+    audio_encoder_input_seconds,
+    audio_feature_extraction_duration,
+    audio_feature_extraction_input_seconds,
 )
 from transformers import (
     AutoFeatureExtractor,
@@ -47,11 +51,28 @@ from utils.text_utils import TextUtils
 # two-command-queue (2CQ) trace execution path
 WHISPER_NUM_COMMAND_QUEUES = 2
 
+# Fallback frame length when the extractor does not advertise one.
+WHISPER_ENCODER_FRAME_SECONDS = 30.0
+
+try:
+    # tt-metal #53717 packs the stage timings into PerfMetrics. Probed, not
+    # assumed: without it, asking for perf metrics only changes the tuple arity.
+    from models.demos.audio.whisper.tt.whisper_generator import (  # noqa: F401
+        PerfMetrics,
+    )
+
+    WHISPER_PERF_METRICS_SUPPORTED = True
+except ImportError:
+    WHISPER_PERF_METRICS_SUPPORTED = False
+
 
 class TTWhisperRunner(BaseMetalDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
         self.pipeline = None
+        # Replaced with the loaded extractor's real frame length once the
+        # pipeline is created.
+        self._encoder_frame_seconds = WHISPER_ENCODER_FRAME_SECONDS
 
     def get_pipeline_device_params(self):
         device_params = {
@@ -310,6 +331,147 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
             )
             raise RuntimeError(f"Audio processing failed: {str(e)}") from e
 
+    @staticmethod
+    def _resolve_encoder_frame_seconds(feature_extractor):
+        """Length of the fixed frame every batch item is padded or truncated to.
+
+        Whisper's extractor pads to `n_samples` (30s at 16kHz), so this caps the
+        audio either stage can consume per item whatever was submitted.
+        """
+        n_samples = getattr(feature_extractor, "n_samples", None)
+        sampling_rate = getattr(feature_extractor, "sampling_rate", None)
+        if (
+            isinstance(n_samples, (int, float))
+            and isinstance(sampling_rate, (int, float))
+            and sampling_rate
+        ):
+            return n_samples / sampling_rate
+        chunk_length = getattr(feature_extractor, "chunk_length", None)
+        if isinstance(chunk_length, (int, float)) and chunk_length:
+            return float(chunk_length)
+        return WHISPER_ENCODER_FRAME_SECONDS
+
+    def _audio_stage_context(self, current_batch):
+        """Label values and the audio seconds the two stages actually consume.
+
+        Counted here rather than read off PerfMetrics.total_audio_s, which sums
+        submitted durations: an item longer than one frame is truncated to it.
+        Reachable here — chunking never splits a single long VAD segment, so
+        uninterrupted speech becomes one long chunk.
+        """
+        frame_seconds = self._encoder_frame_seconds
+        audio_seconds = 0.0
+        channels = 1
+        sample_rate = self.settings.default_sample_rate
+        for rate, audio_array in current_batch:
+            if rate:
+                sample_rate = rate
+                audio_seconds += min(audio_array.shape[0] / rate, frame_seconds)
+            if audio_array.ndim > 1:
+                channels = audio_array.shape[1]
+
+        model_name = (
+            os.path.basename((self.settings.model_weights_path or "").rstrip("/"))
+            or "unknown"
+        )
+        device_id = str(self.device_id) if self.device_id is not None else "unknown"
+        return {
+            "audio_seconds": audio_seconds,
+            "feature_labels": {
+                "model_type": self.settings.model_runner,
+                "device_id": device_id,
+                "sample_rate": str(sample_rate),
+                "channels": str(channels),
+                "batch": str(len(current_batch)),
+            },
+            "encoder_labels": {
+                "model_type": self.settings.model_runner,
+                "device_id": device_id,
+                "model_name": model_name,
+                "language": self.settings.audio_language or "unknown",
+                "batch": str(len(current_batch)),
+            },
+        }
+
+    @staticmethod
+    def _find_perf_metrics(result):
+        """Pull the PerfMetrics out of a returned or yielded tuple.
+
+        Matched on shape, not type, so its position in the tuple can move.
+        """
+        if not isinstance(result, tuple):
+            return None
+        for item in result:
+            if hasattr(item, "feature_extract_s") and hasattr(item, "encoder_s"):
+                return item
+        return None
+
+    def _record_audio_stage_throughput(self, result, context):
+        """Record feature-extraction and encoder throughput for one batch.
+
+        Returns whether anything was recorded, so the streaming wrapper knows
+        when to stop looking. Each stage is gated on a positive duration:
+        generate()'s no-valid-output paths return zeroed timings, and crediting
+        audio against a zero-second stage reports unbounded throughput.
+        """
+        perf = self._find_perf_metrics(result)
+        if perf is None:
+            return False
+
+        audio_seconds = context["audio_seconds"]
+        recorded = False
+
+        feature_extract_s = getattr(perf, "feature_extract_s", 0.0) or 0.0
+        if feature_extract_s > 0:
+            labels = context["feature_labels"]
+            audio_feature_extraction_input_seconds.labels(**labels).inc(audio_seconds)
+            audio_feature_extraction_duration.labels(**labels).observe(
+                feature_extract_s
+            )
+            recorded = True
+
+        encoder_s = getattr(perf, "encoder_s", 0.0) or 0.0
+        if encoder_s > 0:
+            # The capture call runs the encoder twice; labelled, not dropped,
+            # so the cost stays visible.
+            trace_hit = bool(getattr(perf, "encoder_trace_hit", True))
+            labels = dict(
+                context["encoder_labels"], trace_hit="true" if trace_hit else "false"
+            )
+            audio_encoder_input_seconds.labels(**labels).inc(audio_seconds)
+            audio_encoder_duration.labels(**labels).observe(encoder_s)
+            recorded = True
+
+        return recorded
+
+    def _stream_with_stage_metrics(self, generator, context):
+        """Record the stage timings once, off the first yield that carries them.
+
+        Both stages run once per generate() call, ahead of the decode loop, and
+        every yield repeats the same timings — recording per item would multiply
+        one batch by its token count.
+        """
+        recorded = False
+        for item in generator:
+            if not recorded:
+                recorded = self._record_audio_stage_throughput(item, context)
+            yield item
+
+    @staticmethod
+    def _is_final_result(item):
+        """Whether a streamed item is the final marker for its chunk.
+
+        The flag is always last but its index shifts with return_perf_metrics,
+        so key off the trailing bool. Non-streaming tuples end in a tensor or a
+        PerfMetrics and never match.
+        """
+        return (
+            isinstance(item, tuple)
+            and len(item) >= 4
+            and isinstance(item[-1], bool)
+            and item[-1]
+        )
+
     async def _execute_pipeline_streaming(
         self, audio_data, generation_params, prompt=None
     ):
@@ -393,12 +555,9 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                     first_item_observed = True
 
                 text_part, start, end = TextUtils.extract_text(partial_result)
-                # Check is_final flag
-                if isinstance(partial_result, tuple) and len(partial_result) >= 4:
-                    is_final = partial_result[3]
-                    if is_final:
-                        final_text = text_part
-                        break
+                if self._is_final_result(partial_result):
+                    final_text = text_part
+                    break
 
                 # Add speaker prefix to first token for streaming display
                 if first_token:
@@ -533,12 +692,9 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
         async for chunk in result_generator:
             cleaned_text, start, end = TextUtils.extract_text(chunk)
 
-            # Check is_final flag
-            if isinstance(chunk, tuple) and len(chunk) >= 4:
-                is_final = chunk[3]
-                if is_final:
-                    final_text = cleaned_text
-                    break
+            if self._is_final_result(chunk):
+                final_text = cleaned_text
+                break
 
             # Yield non-empty chunks
             if not cleaned_text:
@@ -755,6 +911,10 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                 max_batch_size=self.settings.max_batch_size,
             )
 
+            self._encoder_frame_seconds = self._resolve_encoder_frame_seconds(
+                feature_extractor
+            )
+
             async def _model_pipeline(
                 audio_data,
                 stream=False,
@@ -807,10 +967,23 @@ class TTWhisperRunner(BaseMetalDeviceRunner):
                             task=self.settings.audio_task,
                             prompt=prompt or None,
                             stream_generation=stream,
-                            return_perf_metrics=False,
+                            return_perf_metrics=WHISPER_PERF_METRICS_SUPPORTED,
                         )
 
-                    return await asyncio.to_thread(_run)
+                    result = await asyncio.to_thread(_run)
+
+                    if not WHISPER_PERF_METRICS_SUPPORTED:
+                        return result
+
+                    # Built here: only this scope knows what was submitted.
+                    stage_context = self._audio_stage_context(current_batch)
+                    if stream:
+                        # Streaming defers every stage to the first pull, so the
+                        # timings do not exist yet.
+                        return self._stream_with_stage_metrics(result, stage_context)
+
+                    self._record_audio_stage_throughput(result, stage_context)
+                    return result
                 except Exception as e:
                     self.logger.error(
                         f"Device {self.device_id}: Pipeline execution failed: {e}"

--- a/tt-media-server/utils/audio_manager.py
+++ b/tt-media-server/utils/audio_manager.py
@@ -13,7 +13,7 @@ import tempfile
 import time
 import uuid
 from pathlib import Path
-from typing import List, Optional
+from typing import List, NamedTuple, Optional
 
 import numpy as np
 from config.constants import AudioInputFormat, SupportedModels
@@ -41,6 +41,21 @@ AUDIO_VENV_PYTHON = os.getenv(
 
 # Path to the diarize.py script invoked inside the audio venv.
 DIARIZE_SCRIPT = Path(__file__).parent / "diarize.py"
+
+
+class PreparedAudio(NamedTuple):
+    """Decoded audio plus the operating point it was submitted at.
+
+    `audio_array` is always mono at `settings.default_sample_rate`; the two
+    source fields record what arrived, which is otherwise destroyed by the
+    downmix and resample. Either is None when the decode path could not
+    observe it (ffmpeg normalises before the WAV header is parsed).
+    """
+
+    audio_array: np.ndarray
+    duration: float
+    source_sample_rate: Optional[int] = None
+    source_channels: Optional[int] = None
 
 
 class AudioVenvWorker:
@@ -382,9 +397,19 @@ class AudioManager:
 
             audio_format = self._detect_audio_format(audio_bytes)
             self._validate_file_size(audio_bytes)
-            audio_array = self._convert_to_audio_array(audio_bytes, audio_format)
-            prepared = self._validate_and_truncate_duration(
+            (
+                audio_array,
+                source_sample_rate,
+                source_channels,
+            ) = self._convert_to_audio_array(audio_bytes, audio_format)
+            audio_array, duration_seconds = self._validate_and_truncate_duration(
                 audio_array, should_preprocess
+            )
+            prepared = PreparedAudio(
+                audio_array=audio_array,
+                duration=duration_seconds,
+                source_sample_rate=source_sample_rate,
+                source_channels=source_channels,
             )
         except Exception as e:
             self._logger.error(f"Failed to decode audio data: {e}")
@@ -754,7 +779,11 @@ class AudioManager:
 
     @log_execution_time("Converting to audio array")
     def _convert_to_audio_array(self, audio_bytes, audio_format):
-        """Convert audio file bytes (WAV/MP3) to numpy array."""
+        """Convert audio file bytes (WAV/MP3) to numpy array.
+
+        Returns (array, source_sample_rate, source_channels); the latter two are
+        None when the decode path normalised them away before they could be read.
+        """
         if audio_format is AudioInputFormat.WAV:
             self._logger.info("Processing WAV file format")
             return self._decode_wav_file(audio_bytes)
@@ -865,7 +894,10 @@ class AudioManager:
             self._logger.info(
                 f"Loaded WAV: {len(audio_array)} samples, duration: {len(audio_array) / settings.default_sample_rate:.2f}s"
             )
-            return audio_array.astype(np.float32)
+            # Header values, i.e. what was submitted — the array itself has been
+            # downmixed to mono and resampled to default_sample_rate above, so
+            # these are the only surviving record of the source operating point.
+            return audio_array.astype(np.float32), sample_rate, num_channels
 
         except Exception as e:
             self._logger.error(f"Failed to decode WAV file: {e}")
@@ -884,7 +916,11 @@ class AudioManager:
             self._logger.info(
                 f"{format_name} to WAV conversion completed successfully (in-memory)"
             )
-            return self._decode_wav_file(wav_bytes)
+            audio_array, _, _ = self._decode_wav_file(wav_bytes)
+            # decode_to_wav forces `-ar <default> -ac 1`, so the WAV it hands
+            # back reports ffmpeg's output, not the source. Reported as unknown
+            # rather than as a real value; recovering it needs an ffprobe pass.
+            return audio_array, None, None
         except subprocess.CalledProcessError as e:
             self._logger.error(f"ffmpeg conversion failed: {e}")
             raise ValueError(

--- a/tt-media-server/utils/audio_manager.py
+++ b/tt-media-server/utils/audio_manager.py
@@ -19,7 +19,11 @@ import numpy as np
 from config.constants import AudioInputFormat, SupportedModels
 from config.settings import settings
 from domain.audio_text_response import AudioTextResponse, AudioTextSegment
-from telemetry.telemetry_client import audio_input_preparation_duration
+from telemetry.telemetry_client import (
+    audio_chunking_duration,
+    audio_chunks_per_request,
+    audio_input_preparation_duration,
+)
 
 from utils.decorators import log_execution_time
 from utils.ffmpeg_utils import decode_to_wav as ffmpeg_decode_to_wav
@@ -440,9 +444,20 @@ class AudioManager:
 
         normalized_segments = self._normalize_speaker_ids(vad_segments)
 
+        # Merge only: VAD and diarization are inference, not chunking.
+        chunking_start = time.perf_counter()
         whisper_chunks = self._merge_vad_segments_by_speaker_and_duration(
             normalized_segments
         )
+        chunking_elapsed = time.perf_counter() - chunking_start
+
+        mode = "diarization" if enable_diarization else "vad_only"
+        audio_chunking_duration.labels(
+            model_type=settings.model_runner, mode=mode
+        ).observe(chunking_elapsed)
+        audio_chunks_per_request.labels(
+            model_type=settings.model_runner, mode=mode
+        ).observe(len(whisper_chunks))
 
         if enable_diarization:
             self._logger.info(

--- a/tt-media-server/utils/audio_manager.py
+++ b/tt-media-server/utils/audio_manager.py
@@ -23,6 +23,9 @@ from telemetry.telemetry_client import (
     audio_chunking_duration,
     audio_chunks_per_request,
     audio_input_preparation_duration,
+    audio_vad_cpu_duration,
+    audio_vad_duration,
+    audio_vad_segments,
 )
 
 from utils.decorators import log_execution_time
@@ -99,6 +102,28 @@ class AudioVenvWorker:
 
     def is_running(self) -> bool:
         return self._proc is not None and self._proc.poll() is None
+
+    def cpu_seconds(self) -> Optional[float]:
+        """CPU time this worker has used so far, or None if unreadable.
+
+        Read from /proc rather than rusage: the worker is persistent, so a
+        per-call delta on this is attributable to that call, whereas
+        RUSAGE_CHILDREN would fold in every other child of the process.
+        """
+        proc = self._proc
+        if proc is None or proc.poll() is not None:
+            return None
+
+        try:
+            with open(f"/proc/{proc.pid}/stat") as stat_file:
+                stat = stat_file.read()
+            # comm can itself contain spaces and parens, so split after the last ')'.
+            fields = stat[stat.rindex(")") + 2 :].split()
+            utime, stime = int(fields[11]), int(fields[12])
+        except (OSError, ValueError, IndexError):
+            return None
+
+        return (utime + stime) / os.sysconf("SC_CLK_TCK")
 
     def start(self) -> None:
         """Spawn the worker and block until it signals ready.
@@ -636,15 +661,37 @@ class AudioManager:
 
         self._logger.info("Applying VAD via audio venv worker...")
 
-        segments = self._audio_venv_worker.run(
+        worker = self._audio_venv_worker
+        cpu_before = worker.cpu_seconds()
+        start = time.perf_counter()
+        segments = worker.run(
             mode="vad",
             audio_array=audio_array,
             timeout_seconds=self._VAD_TIMEOUT_SECONDS,
         )
+        elapsed = time.perf_counter() - start
+        cpu_after = worker.cpu_seconds()
+
+        audio_vad_duration.labels(
+            model_type=settings.model_runner,
+            outcome="ok" if segments is not None else "failed",
+        ).observe(elapsed)
+
+        # A respawn or a killed worker resets the counter, so a negative delta is
+        # not this call's compute and is dropped rather than clamped to zero.
+        if cpu_before is not None and cpu_after is not None:
+            cpu_used = cpu_after - cpu_before
+            if cpu_used >= 0:
+                audio_vad_cpu_duration.labels(model_type=settings.model_runner).observe(
+                    cpu_used
+                )
 
         if segments is None:
             return None
 
+        audio_vad_segments.labels(model_type=settings.model_runner).observe(
+            len(segments)
+        )
         self._logger.info(f"VAD detected {len(segments)} speech segments")
         return segments
 

--- a/tt-media-server/utils/audio_manager.py
+++ b/tt-media-server/utils/audio_manager.py
@@ -10,14 +10,16 @@ import selectors
 import struct
 import subprocess
 import tempfile
+import time
 import uuid
 from pathlib import Path
 from typing import List, Optional
 
 import numpy as np
-from config.constants import SupportedModels
+from config.constants import AudioInputFormat, SupportedModels
 from config.settings import settings
 from domain.audio_text_response import AudioTextResponse, AudioTextSegment
+from telemetry.telemetry_client import audio_input_preparation_duration
 
 from utils.decorators import log_execution_time
 from utils.ffmpeg_utils import decode_to_wav as ffmpeg_decode_to_wav
@@ -335,6 +337,7 @@ class AudioManager:
 
     def to_audio_array(self, file, should_preprocess):
         """Convert audio file (base64 string or raw bytes) to numpy array for audio model inference."""
+        start = time.perf_counter()
         try:
             if isinstance(file, str):
                 # Base64-encoded string
@@ -348,12 +351,21 @@ class AudioManager:
                 )
                 raise ValueError(f"Unsupported file input type: {type(file).__name__}")
 
+            audio_format = self._detect_audio_format(audio_bytes)
             self._validate_file_size(audio_bytes)
-            audio_array = self._convert_to_audio_array(audio_bytes)
-            return self._validate_and_truncate_duration(audio_array, should_preprocess)
+            audio_array = self._convert_to_audio_array(audio_bytes, audio_format)
+            prepared = self._validate_and_truncate_duration(
+                audio_array, should_preprocess
+            )
         except Exception as e:
             self._logger.error(f"Failed to decode audio data: {e}")
             raise ValueError(f"Failed to process audio data: {str(e)}")
+
+        # Observed only on success
+        audio_input_preparation_duration.labels(
+            model_type=settings.model_runner, format=audio_format.value
+        ).observe(time.perf_counter() - start)
+        return prepared
 
     @log_execution_time("Applying VAD and optional diarization")
     def apply_diarization_with_vad(self, audio_array, enable_diarization):
@@ -660,30 +672,38 @@ class AudioManager:
                 f"Audio file too large: {len(audio_bytes)} bytes. Maximum allowed: {settings.max_audio_size_bytes} bytes"
             )
 
-    @log_execution_time("Converting to audio array")
-    def _convert_to_audio_array(self, audio_bytes):
-        """Convert audio file bytes (WAV/MP3) to numpy array."""
-
-        # Detect file format based on headers
+    @staticmethod
+    def _detect_audio_format(audio_bytes):
+        """Identify the container format from the file header."""
         if (
             len(audio_bytes) >= 12
             and audio_bytes[:4] == b"RIFF"
             and audio_bytes[8:12] == b"WAVE"
         ):
-            self._logger.info("Processing WAV file format")
-            return self._decode_wav_file(audio_bytes)
-        elif len(audio_bytes) >= 3 and (
+            return AudioInputFormat.WAV
+        if len(audio_bytes) >= 3 and (
             audio_bytes[:3] == b"ID3"
             or audio_bytes[:2] == b"\xff\xfb"
             or audio_bytes[:2] == b"\xff\xf3"
             or audio_bytes[:2] == b"\xff\xf2"
         ):
+            return AudioInputFormat.MP3
+        return AudioInputFormat.UNKNOWN
+
+    @log_execution_time("Converting to audio array")
+    def _convert_to_audio_array(self, audio_bytes, audio_format):
+        """Convert audio file bytes (WAV/MP3) to numpy array."""
+        if audio_format is AudioInputFormat.WAV:
+            self._logger.info("Processing WAV file format")
+            return self._decode_wav_file(audio_bytes)
+        if audio_format is AudioInputFormat.MP3:
             self._logger.info("Processing MP3 file format")
-            return self._decode_audio_file(audio_bytes, "MP3")
-        else:
-            raise ValueError(
-                "Unsupported audio format. Only WAV and MP3 files are supported."
+            return self._decode_audio_file(
+                audio_bytes, AudioInputFormat.MP3.value.upper()
             )
+        raise ValueError(
+            "Unsupported audio format. Only WAV and MP3 files are supported."
+        )
 
     @log_execution_time("Decoding WAV file")
     def _decode_wav_file(self, audio_bytes):


### PR DESCRIPTION
### Metrics added

Request-level, one observation each:

| Metric | Labels | Covers |
|---|---|---|
| `audio_input_preparation_seconds` | `model_type`, `format` | Decode + resample of the submitted file |
| `audio_vad_seconds` | `model_type`, `outcome` | Wall time of the VAD pass |
| `audio_vad_cpu_seconds` | `model_type` | CPU consumed by the VAD worker process |
| `audio_vad_segments` | `model_type` | Speech segments VAD returned |
| `audio_chunking_seconds` | `model_type`, `mode` | Merging segments into inference chunks |
| `audio_chunks_per_request` | `model_type`, `mode` | Chunk fan-out |

Per-chunk, one observation per chunk (Whisper streaming path):

| Metric | Labels | Covers |
|---|---|---|
| `audio_chunk_first_token_seconds` | `model_type` | Chunk hand-off until its first emitted item |
| `audio_chunk_processing_seconds` | `model_type` | Wall time to transcribe the chunk end to end |

All names are prefixed `tt_media_server_`.

## Dashboard

Adds an **ASR Per-Chunk Latency** row to the Python media server dashboard:
first-item and processing latency heatmaps, a combined quantiles timeseries, a
mean-cost/fan-out timeseries, and two bucket-occupancy tables for retuning
boundaries as hardware and models change.

## Validation

Measured on whisper-large-v3, one p300c Blackhole chip, 10s chunks, VAD-only,
streaming NDJSON, 60s audio fixture:

| | p50 | p90 | p99 |
|---|---|---|---|
| First item | 0.50s | 0.75s | 0.96s |
| Processing | 1.41s | 1.70s | 1.95s |

Bucket boundaries were fitted against this distribution rather than guessed.
An initial grid put 78% of first-item observations into a single bucket, which
made every quantile between p50 and p90 the same interpolation; the current
grid brings the largest bucket down to ~29% and drops six permanently empty
sub-100ms buckets.

<img width="1787" height="843" alt="Screenshot 2026-08-20 at 15 21 22" src="https://github.com/user-attachments/assets/08288f9e-a777-4cc9-9558-0598d9aad98e" />
<img width="1787" height="811" alt="Screenshot 2026-08-20 at 15 21 35" src="https://github.com/user-attachments/assets/96eb8d04-e02a-4d64-843c-c77f944e179c" />

