### PR TITLE
Add Qwen3-TTS 1.7B/0.6B on N150 and N300 in tt media server

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -372,6 +372,28 @@
         }
       }
     },
+    "Qwen3-TTS-12Hz-1.7B-Base": {
+      "inference_engine": "MEDIA",
+      "ci": {
+        "nightly": {
+          "devices": [
+            "N150",
+            "N300"
+          ]
+        }
+      }
+    },
+    "Qwen3-TTS-12Hz-0.6B-Base": {
+      "inference_engine": "MEDIA",
+      "ci": {
+        "nightly": {
+          "devices": [
+            "N150",
+            "N300"
+          ]
+        }
+      }
+    },
     "bge-m3": {
       "implementations": [
         {

--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -380,6 +380,12 @@
             "N150",
             "N300"
           ]
+        },
+        "release": {
+          "devices": [
+            "N150",
+            "N300"
+          ]
         }
       }
     },
@@ -387,6 +393,12 @@
       "inference_engine": "MEDIA",
       "ci": {
         "nightly": {
+          "devices": [
+            "N150",
+            "N300"
+          ]
+        },
+        "release": {
           "devices": [
             "N150",
             "N300"

--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -264,11 +264,11 @@
                 "P300X2"
               ]
             },
-            "release": {
-              "devices": [
-                "GALAXY"
-              ]
-            },
+            // "release": {
+            //   "devices": [
+            //     "GALAXY"
+            //   ]
+            // },
             "weekly": {
               "devices": [
                 "GALAXY",

--- a/docs/model_support/tts/Qwen3-TTS-12Hz-0.6B-Base_n150.md
+++ b/docs/model_support/tts/Qwen3-TTS-12Hz-0.6B-Base_n150.md
@@ -1,0 +1,38 @@
+# Qwen3-TTS-12Hz-0.6B-Base Tenstorrent Support on N150
+
+#### Useful links
+
+- [N150 details](https://tenstorrent.com/hardware/wormhole)
+- [Search other tts models](./README.md)
+- [Search other models by model type](../../../README.md#models-by-model-type)
+
+`Qwen3-TTS-12Hz-0.6B-Base` is also supported on hardware:
+
+- [N300](Qwen3-TTS-12Hz-0.6B-Base_n300.md)
+
+## Quickstart - Deploy Qwen3-TTS-12Hz-0.6B-Base Inference Server on n150
+
+See [prerequisites](../../prerequisites.md) for system software setup, e.g. for first-run or when experiencing issues.
+
+This model is supported by [tt-media-server](../../../tt-media-server/README.md) inference engine.
+
+Dev catalog: use `--dev-mode`. Japanese text is auto-detected. Default voice is jim.
+
+**via run.py command**
+
+```bash
+python3 run.py --model Qwen3-TTS-12Hz-0.6B-Base --device n150 --workflow server --dev-mode
+```
+For details on the run.py command, see the [run.py CLI Options](../../workflows_user_guide.md#runpy-cli-options) section of the User Guide.
+
+## Model Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Weights | [Qwen/Qwen3-TTS-12Hz-0.6B-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-0.6B-Base) |
+| Model Status | 🔵 Functional |
+| Max Batch Size | 1 |
+| Device mesh | (1, 1) |
+| Implementation Code | [qwen3-tts](https://github.com/tenstorrent/tt-metal/tree/888379c/models/demos/qwen3_tts) |
+| tt-metal Commit | `888379c` |
+| Sample rate | 24000 Hz |

--- a/docs/model_support/tts/Qwen3-TTS-12Hz-0.6B-Base_n300.md
+++ b/docs/model_support/tts/Qwen3-TTS-12Hz-0.6B-Base_n300.md
@@ -1,0 +1,38 @@
+# Qwen3-TTS-12Hz-0.6B-Base Tenstorrent Support on N300
+
+#### Useful links
+
+- [N300 details](https://tenstorrent.com/hardware/wormhole)
+- [Search other tts models](./README.md)
+- [Search other models by model type](../../../README.md#models-by-model-type)
+
+`Qwen3-TTS-12Hz-0.6B-Base` is also supported on hardware:
+
+- [N150](Qwen3-TTS-12Hz-0.6B-Base_n150.md)
+
+## Quickstart - Deploy Qwen3-TTS-12Hz-0.6B-Base Inference Server on n300
+
+See [prerequisites](../../prerequisites.md) for system software setup, e.g. for first-run or when experiencing issues.
+
+This model is supported by [tt-media-server](../../../tt-media-server/README.md) inference engine.
+
+Dev catalog: use `--dev-mode`. Japanese text is auto-detected. Default voice is jim.
+
+**via run.py command**
+
+```bash
+python3 run.py --model Qwen3-TTS-12Hz-0.6B-Base --device n300 --workflow server --dev-mode
+```
+For details on the run.py command, see the [run.py CLI Options](../../workflows_user_guide.md#runpy-cli-options) section of the User Guide.
+
+## Model Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Weights | [Qwen/Qwen3-TTS-12Hz-0.6B-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-0.6B-Base) |
+| Model Status | 🔵 Functional |
+| Max Batch Size | 1 |
+| Device mesh | (1, 2) TP=2 |
+| Implementation Code | [qwen3-tts](https://github.com/tenstorrent/tt-metal/tree/888379c/models/demos/qwen3_tts) |
+| tt-metal Commit | `888379c` |
+| Sample rate | 24000 Hz |

--- a/docs/model_support/tts/Qwen3-TTS-12Hz-1.7B-Base_n150.md
+++ b/docs/model_support/tts/Qwen3-TTS-12Hz-1.7B-Base_n150.md
@@ -1,0 +1,38 @@
+# Qwen3-TTS-12Hz-1.7B-Base Tenstorrent Support on N150
+
+#### Useful links
+
+- [N150 details](https://tenstorrent.com/hardware/wormhole)
+- [Search other tts models](./README.md)
+- [Search other models by model type](../../../README.md#models-by-model-type)
+
+`Qwen3-TTS-12Hz-1.7B-Base` is also supported on hardware:
+
+- [N300](Qwen3-TTS-12Hz-1.7B-Base_n300.md)
+
+## Quickstart - Deploy Qwen3-TTS-12Hz-1.7B-Base Inference Server on n150
+
+See [prerequisites](../../prerequisites.md) for system software setup, e.g. for first-run or when experiencing issues.
+
+This model is supported by [tt-media-server](../../../tt-media-server/README.md) inference engine.
+
+Dev catalog: use `--dev-mode`. Japanese text is auto-detected. Default voice is jim.
+
+**via run.py command**
+
+```bash
+python3 run.py --model Qwen3-TTS-12Hz-1.7B-Base --device n150 --workflow server --dev-mode
+```
+For details on the run.py command, see the [run.py CLI Options](../../workflows_user_guide.md#runpy-cli-options) section of the User Guide.
+
+## Model Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Weights | [Qwen/Qwen3-TTS-12Hz-1.7B-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base) |
+| Model Status | 🔵 Functional |
+| Max Batch Size | 1 |
+| Device mesh | (1, 1) |
+| Implementation Code | [qwen3-tts](https://github.com/tenstorrent/tt-metal/tree/888379c/models/demos/qwen3_tts) |
+| tt-metal Commit | `888379c` |
+| Sample rate | 24000 Hz |

--- a/docs/model_support/tts/Qwen3-TTS-12Hz-1.7B-Base_n300.md
+++ b/docs/model_support/tts/Qwen3-TTS-12Hz-1.7B-Base_n300.md
@@ -1,0 +1,38 @@
+# Qwen3-TTS-12Hz-1.7B-Base Tenstorrent Support on N300
+
+#### Useful links
+
+- [N300 details](https://tenstorrent.com/hardware/wormhole)
+- [Search other tts models](./README.md)
+- [Search other models by model type](../../../README.md#models-by-model-type)
+
+`Qwen3-TTS-12Hz-1.7B-Base` is also supported on hardware:
+
+- [N150](Qwen3-TTS-12Hz-1.7B-Base_n150.md)
+
+## Quickstart - Deploy Qwen3-TTS-12Hz-1.7B-Base Inference Server on n300
+
+See [prerequisites](../../prerequisites.md) for system software setup, e.g. for first-run or when experiencing issues.
+
+This model is supported by [tt-media-server](../../../tt-media-server/README.md) inference engine.
+
+Dev catalog: use `--dev-mode`. Japanese text is auto-detected. Default voice is jim.
+
+**via run.py command**
+
+```bash
+python3 run.py --model Qwen3-TTS-12Hz-1.7B-Base --device n300 --workflow server --dev-mode
+```
+For details on the run.py command, see the [run.py CLI Options](../../workflows_user_guide.md#runpy-cli-options) section of the User Guide.
+
+## Model Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Weights | [Qwen/Qwen3-TTS-12Hz-1.7B-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base) |
+| Model Status | 🔵 Functional |
+| Max Batch Size | 1 |
+| Device mesh | (1, 2) TP=2 |
+| Implementation Code | [qwen3-tts](https://github.com/tenstorrent/tt-metal/tree/888379c/models/demos/qwen3_tts) |
+| tt-metal Commit | `888379c` |
+| Sample rate | 24000 Hz |

--- a/docs/model_support/tts/README.md
+++ b/docs/model_support/tts/README.md
@@ -11,3 +11,5 @@ Models with status: TOP_PERF, COMPLETE, or FUNCTIONAL.
 | Model Name | [BH QuietBox 2](https://tenstorrent.com/hardware/tt-quietbox) | [P150](https://tenstorrent.com/hardware/blackhole) | [N150](https://tenstorrent.com/hardware/wormhole) | [N300](https://tenstorrent.com/hardware/wormhole) |
 | --- | --- | --- | --- | --- |
 | [speecht5_tts](speecht5_tts_p300x2.md) | [🛠️ Experimental](speecht5_tts_p300x2.md) | [🛠️ Experimental](speecht5_tts_p150.md) | [🟢 Complete](speecht5_tts_n150.md) | [🟢 Complete](speecht5_tts_n300.md) |
+| [Qwen3-TTS-12Hz-1.7B-Base](Qwen3-TTS-12Hz-1.7B-Base_n150.md) | — | — | [🔵 Functional](Qwen3-TTS-12Hz-1.7B-Base_n150.md) | [🔵 Functional](Qwen3-TTS-12Hz-1.7B-Base_n300.md) |
+| [Qwen3-TTS-12Hz-0.6B-Base](Qwen3-TTS-12Hz-0.6B-Base_n150.md) | — | — | [🔵 Functional](Qwen3-TTS-12Hz-0.6B-Base_n150.md) | [🔵 Functional](Qwen3-TTS-12Hz-0.6B-Base_n300.md) |

--- a/reference_config/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/reference_config/benchmarking/benchmark_targets/model_performance_reference.json
@@ -6927,5 +6927,61 @@
                 }
             }
         ]
+    },
+    "Qwen3-TTS-12Hz-1.7B-Base": {
+        "n150": [
+            {
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "task_type": "tts",
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 2000,
+                        "rtr": 1.97
+                    }
+                }
+            }
+        ],
+        "n300": [
+            {
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "task_type": "tts",
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 180,
+                        "rtr": 1.97
+                    }
+                }
+            }
+        ]
+    },
+    "Qwen3-TTS-12Hz-0.6B-Base": {
+        "n150": [
+            {
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "task_type": "tts",
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 2000,
+                        "rtr": 1.97
+                    }
+                }
+            }
+        ],
+        "n300": [
+            {
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "task_type": "tts",
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 180,
+                        "rtr": 1.97
+                    }
+                }
+            }
+        ]
     }
 }

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -4189,6 +4189,44 @@ _eval_config_list = [
         ],
     ),
     EvalConfig(
+        hf_model_repo="Qwen/Qwen3-TTS-12Hz-1.7B-Base",
+        tasks=[
+            EvalTask(
+                task_name="tts_generation",
+                workflow_venv_type=WorkflowVenvType.EVALS_META,
+                include_path="work_dir",
+                max_concurrent=None,
+                apply_chat_template=False,
+                score=EvalTaskScore(
+                    # No traceable published WER for this repo; the reported
+                    # score is intelligibility (100 - WER%) from the live run.
+                    published_score=None,
+                    published_score_ref="",
+                    score_func=lambda results: 0.0,
+                ),
+            ),
+        ],
+    ),
+    EvalConfig(
+        hf_model_repo="Qwen/Qwen3-TTS-12Hz-0.6B-Base",
+        tasks=[
+            EvalTask(
+                task_name="tts_generation",
+                workflow_venv_type=WorkflowVenvType.EVALS_META,
+                include_path="work_dir",
+                max_concurrent=None,
+                apply_chat_template=False,
+                score=EvalTaskScore(
+                    # No traceable published WER for this repo; the reported
+                    # score is intelligibility (100 - WER%) from the live run.
+                    published_score=None,
+                    published_score_ref="",
+                    score_func=lambda results: 0.0,
+                ),
+            ),
+        ],
+    ),
+    EvalConfig(
         hf_model_repo="openai/gpt-oss-20b",
         tasks=[
             EvalTask(

--- a/test_module/server_tests_config.json
+++ b/test_module/server_tests_config.json
@@ -31,7 +31,9 @@
             "bge-m3"
         ],
         "TTS": [
-            "speecht5_tts"
+            "speecht5_tts",
+            "Qwen3-TTS-12Hz-1.7B-Base",
+            "Qwen3-TTS-12Hz-0.6B-Base"
         ],
         "VIDEO": [
             "Wan2.2-T2V-A14B-Diffusers",
@@ -92,6 +94,7 @@
             "bge": "BGE embedding model tests",
             "qwen3_emb": "Qwen3 embedding model tests",
             "speecht5": "SpeechT5 TTS model tests",
+            "qwen3_tts": "Qwen3-TTS model tests",
             "wan": "Wan video generation model tests",
             "wan_i2v": "Wan image-to-video generation model tests",
             "mochi": "Mochi video generation model tests",
@@ -363,6 +366,18 @@
             "compatible_devices": [
                 "n150",
                 "p150"
+            ]
+        },
+        "qwen3_tts": {
+            "id_name": "qwen3-tts",
+            "weights": [
+                "Qwen3-TTS-12Hz-1.7B-Base",
+                "Qwen3-TTS-12Hz-0.6B-Base"
+            ],
+            "category": "TTS",
+            "compatible_devices": [
+                "n150",
+                "n300"
             ]
         },
         "gpt_oss_20b": {

--- a/test_module/test_suites/tts.json
+++ b/test_module/test_suites/tts.json
@@ -1,7 +1,43 @@
 {
-    "_description": "Test suites for TTS model category (SpeechT5)",
+    "_description": "Test suites for TTS model category (SpeechT5, Qwen3-TTS)",
     "_category": "TTS",
     "test_matrices": [
+        {
+            "models": [
+                "qwen3_tts"
+            ],
+            "devices": [
+                "n150",
+                "n300"
+            ],
+            "test_cases": [
+                {
+                    "template": "SpeechT5TTSTest",
+                    "enabled": true,
+                    "description": "SpeechT5 TTS functionality test"
+                },
+                {
+                    "template": "TTSLoadTest",
+                    "enabled": true,
+                    "description": "TTS load test",
+                    "targets": {
+                        "tts_generation_time": 10,
+                        "sample_count": 10,
+                        "compare_audio": true
+                    }
+                },
+                {
+                    "template": "TTSParamTest",
+                    "enabled": true,
+                    "description": "TTS parameter variations test"
+                },
+                {
+                    "template": "TTSIntegrationTest",
+                    "enabled": true,
+                    "description": "TTS error handling and validation test"
+                }
+            ]
+        },
         {
             "models": [
                 "speecht5"

--- a/tests/test_model_catalog_yaml.py
+++ b/tests/test_model_catalog_yaml.py
@@ -32,6 +32,7 @@ def test_impl_registry_is_populated():
     # impl_id of each registry entry must match its key
     for impl_id, impl in _IMPL_REGISTRY.items():
         assert impl.impl_id == impl_id
+    assert _IMPL_REGISTRY["qwen3_tts"].code_path == "models/demos/qwen3_tts"
 
 
 def test_build_system_requirements_full():

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -45,6 +45,8 @@ class SupportedModels(Enum):
     QWEN_3_8B = "Qwen/Qwen3-8B"
     QWEN_3_32B = "Qwen/Qwen3-32B"
     SPEECHT5_TTS = "microsoft/speecht5_tts"
+    QWEN3_TTS_1_7B = "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    QWEN3_TTS_0_6B = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
     GEMMA_1_1_2B_IT = "google/gemma-1.1-2b-it"
     GEMMA_4_31B_IT = "google/gemma-4-31B-it"
     MISTRAL_SMALL_3_1_24B_INSTRUCT_2503 = (
@@ -102,6 +104,8 @@ class ModelNames(Enum):
     QWEN_3_8B = "Qwen3-8B"
     QWEN_3_32B = "Qwen3-32B"
     SPEECHT5_TTS = "speecht5_tts"
+    QWEN3_TTS_1_7B = "Qwen3-TTS-12Hz-1.7B-Base"
+    QWEN3_TTS_0_6B = "Qwen3-TTS-12Hz-0.6B-Base"
     GEMMA_1_1_2B_IT = "gemma-1.1-2b-it"
     GEMMA_4_31B_IT = "gemma-4-31b-it"
     MISTRAL_SMALL_3_1_24B_INSTRUCT_2503 = "Mistral-Small-3.1-24B-Instruct-2503"
@@ -160,6 +164,7 @@ class ModelRunners(Enum):
     LLM_TEST = "llm_test"
     LLAMA_RUNNER = "llama_runner"
     TT_SPEECHT5_TTS = "tt-speecht5-tts"
+    TT_QWEN3_TTS = "tt-qwen3-tts"
     TT_XLA_SDXL = "tt-xla-sdxl"
     TT_Z_IMAGE_TURBO = "tt-z-image-turbo"
 
@@ -241,6 +246,7 @@ MODEL_SERVICE_RUNNER_MAP = {
     },
     ModelServices.TEXT_TO_SPEECH: {
         ModelRunners.TT_SPEECHT5_TTS,
+        ModelRunners.TT_QWEN3_TTS,
     },
 }
 
@@ -338,6 +344,10 @@ INFERENCE_MODEL_RUNNER_TO_MODEL_NAMES_MAP = {
         ModelNames.FALCON3_7B_INSTRUCT,
     },
     ModelRunners.TT_SPEECHT5_TTS: {ModelNames.SPEECHT5_TTS},
+    ModelRunners.TT_QWEN3_TTS: {
+        ModelNames.QWEN3_TTS_1_7B,
+        ModelNames.QWEN3_TTS_0_6B,
+    },
     ModelRunners.TT_XLA_SDXL: {
         ModelNames.STABLE_DIFFUSION_XL_BASE,
         ModelNames.STABLE_DIFFUSION_XL_512,
@@ -1050,6 +1060,18 @@ ModelConfigs = {
         "device_mesh_shape": (1, 1),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_1.value,
+        "max_batch_size": 1,
+    },
+    (ModelRunners.TT_QWEN3_TTS, DeviceTypes.N150): {
+        "device_mesh_shape": (1, 1),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_1.value,
+        "max_batch_size": 1,
+    },
+    (ModelRunners.TT_QWEN3_TTS, DeviceTypes.N300): {
+        "device_mesh_shape": (1, 2),
+        "is_galaxy": False,
+        "device_ids": DeviceIds.DEVICE_IDS_2_GROUP.value,
         "max_batch_size": 1,
     },
     (ModelRunners.TT_SPEECHT5_TTS, DeviceTypes.P150): {

--- a/tt-media-server/domain/text_to_speech_request.py
+++ b/tt-media-server/domain/text_to_speech_request.py
@@ -38,6 +38,8 @@ class TextToSpeechRequest(BaseRequest):
         None  # Base64-encoded or raw bytes of speaker embedding
     )
     speaker_id: Optional[str] = None  # ID for pre-configured speaker embeddings
+    voice_clone_audio: Optional[str] = None  # Base64-encoded WAV/MP3/FLAC
+    voice_clone_text: Optional[str] = None  # transcript of clone clip
 
     # Response format: wav (default), mp3, ogg, json, or verbose_json
     response_format: str = "wav"

--- a/tt-media-server/main.py
+++ b/tt-media-server/main.py
@@ -2,11 +2,16 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
-# IMPORTANT: telemetry.multiprocess_setup MUST be the very first project
-# import. It sets PROMETHEUS_MULTIPROC_DIR before any other module gets a
-# chance to import prometheus_client and instantiate Counter/Histogram
-# objects. If this import is moved or removed, multiprocess metrics from
-# device/cpu workers will silently stop being collected.
+# Spawn before any Process: fork after parent imports ttnn leaks trace
+# capture state into Qwen3-TTS init_server_context.
+import multiprocessing as _mp
+
+if _mp.get_start_method(allow_none=True) != "spawn":
+    _mp.set_start_method("spawn", force=True)
+
+# IMPORTANT: telemetry.multiprocess_setup MUST be the first *project* import
+# after the spawn fix. It sets PROMETHEUS_MULTIPROC_DIR before any other
+# module gets a chance to import prometheus_client.
 import telemetry.multiprocess_setup  # noqa: F401  (import for side effect)
 
 import os

--- a/tt-media-server/tests/conftest.py
+++ b/tt-media-server/tests/conftest.py
@@ -710,6 +710,9 @@ runner_mocks = {
     "tt_model_runners.speecht5_runner": {
         "TTSpeechT5Runner": create_mock_runner_class("TTSpeechT5Runner")
     },
+    "tt_model_runners.qwen3_tts_runner": {
+        "TTQwen3TTSRunner": create_mock_runner_class("TTQwen3TTSRunner")
+    },
     "tt_model_runners.forge_runners": {},
     "tt_model_runners.forge_runners.runners": {
         "ForgeResnetRunner": create_mock_runner_class("ForgeResnetRunner"),

--- a/tt-media-server/tt_model_runners/qwen3_tts_runner.py
+++ b/tt-media-server/tt_model_runners/qwen3_tts_runner.py
@@ -1,0 +1,407 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+"""Qwen3-TTS media-server runner.
+
+N150: ``ttnn.open_device`` (mesh CQ rejects H2D during trace capture).
+N300 TP=2: mesh ``(1, 2)`` + ``FABRIC_1D``.
+Voice: ``speaker_id`` (default ``jim``) or ``voice_clone_audio`` + ``voice_clone_text``.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("TT_QWEN3_CP_FP32", "1")
+
+import asyncio
+import base64
+import io
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+import soundfile as sf
+import torch
+from config.constants import SupportedModels
+from config.settings import settings
+from domain.text_to_speech_request import TextToSpeechRequest
+from domain.text_to_speech_response import TextToSpeechResponse
+from telemetry.telemetry_client import TelemetryEvent
+from tt_model_runners.base_metal_device_runner import BaseMetalDeviceRunner
+from utils.decorators import log_execution_time
+from utils.logger import log_exception_chain
+from utils.voice_prompts import DEFAULT_VOICE_ID, VoicePromptManager
+
+_DEFAULT_HF_ID = SupportedModels.QWEN3_TTS_1_7B.value
+_KNOWN_LANGUAGES = (
+    "english",
+    "chinese",
+    "german",
+    "italian",
+    "portuguese",
+    "spanish",
+    "japanese",
+    "korean",
+    "french",
+    "russian",
+)
+SAMPLE_RATE_HZ = 24000
+
+
+def _looks_japanese(text: str) -> bool:
+    return any("\u3040" <= ch <= "\u30ff" or "\u4e00" <= ch <= "\u9fff" for ch in text)
+
+
+def _tts_api():
+    from models.demos.qwen3_tts.tt import server as api
+
+    return api
+
+
+class Qwen3TTSConstants:
+    L1_SMALL_SIZE = 32768
+    TRACE_REGION_SIZE = 512_000_000
+    NUM_COMMAND_QUEUES = 2
+    MAX_NEW_TOKENS = 256
+
+
+class TTQwen3TTSRunner(BaseMetalDeviceRunner):
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+        os.environ.pop("TT_MM_THROTTLE_PERF", None)
+        os.environ.pop("TT_METAL_CACHE", None)
+
+        self.model = None
+        self.ctx = None
+        self.tokenizer = None
+        self.main_weights = None
+        self.decoder_weights = None
+        self.config = None
+        self.voice_prompts: Optional[VoicePromptManager] = None
+        self._post_warmup_rng_state = None
+        self._opened_mesh = False
+        self.hf_id = self._resolve_hf_id()
+
+        rows, cols = self.settings.device_mesh_shape
+        self.is_tensor_parallel = (rows * cols) > 1
+        if self.is_tensor_parallel:
+            os.environ.pop("TT_METAL_FABRIC_DISABLE", None)
+        elif not settings.is_galaxy:
+            os.environ["TT_METAL_FABRIC_DISABLE"] = "1"
+
+    def _resolve_hf_id(self) -> str:
+        weights = self.settings.model_weights_path or _DEFAULT_HF_ID
+        name = Path(weights).name
+        if "0.6B" in name:
+            return SupportedModels.QWEN3_TTS_0_6B.value
+        if "1.7B" in name:
+            return SupportedModels.QWEN3_TTS_1_7B.value
+        if isinstance(weights, str) and weights.startswith("Qwen/"):
+            return weights
+        return _DEFAULT_HF_ID
+
+    def get_pipeline_device_params(self):
+        import ttnn
+
+        device_params = {
+            "l1_small_size": Qwen3TTSConstants.L1_SMALL_SIZE,
+            "trace_region_size": Qwen3TTSConstants.TRACE_REGION_SIZE,
+            "num_command_queues": Qwen3TTSConstants.NUM_COMMAND_QUEUES,
+        }
+        if self.is_tensor_parallel:
+            device_params["fabric_config"] = ttnn.FabricConfig.FABRIC_1D
+        return device_params
+
+    def _configure_fabric(self, updated_device_params):
+        import ttnn
+
+        try:
+            fabric_config = updated_device_params.pop("fabric_config", None)
+            if fabric_config:
+                ttnn.set_fabric_config(fabric_config)
+            return fabric_config
+        except Exception as e:
+            log_exception_chain(
+                self.logger, self.device_id, "Fabric configuration failed", e
+            )
+            raise RuntimeError(f"Fabric configuration failed: {str(e)}") from e
+
+    def set_device(self):
+        """N150: plain ``open_device`` (trace H2D). N300 TP=2: mesh (1, 2)."""
+        if self.is_tensor_parallel:
+            self._opened_mesh = True
+            return super().set_device()
+
+        import ttnn
+
+        if self.ttnn_device is None:
+            params = self.get_updated_device_params(self.get_pipeline_device_params())
+            params.pop("dispatch_core_config", None)
+            params.pop("fabric_config", None)
+            self.ttnn_device = ttnn.open_device(device_id=0, **params)
+            self.ttnn_device.enable_program_cache()
+        self.max_batch_size = self.settings.max_batch_size
+        return self.ttnn_device
+
+    def close_device(self):
+        import ttnn
+
+        try:
+            if self.ttnn_device is None:
+                return True
+            if self._opened_mesh:
+                ttnn.close_mesh_device(self.ttnn_device)
+            else:
+                ttnn.close_device(self.ttnn_device)
+            self.ttnn_device = None
+            return True
+        except Exception as e:
+            self.logger.error(f"Device {self.device_id}: Failed to close device: {e}")
+            raise
+
+    def _load_qwen_weights(self):
+        return _tts_api().load_weights(self.hf_id)
+
+    def load_weights(self) -> bool:
+        self.logger.info(
+            f"Device {self.device_id}: Prefetching Qwen3-TTS weights ({self.hf_id})"
+        )
+        self.main_weights, self.decoder_weights = self._load_qwen_weights()
+        return True
+
+    def _language_for(self, request: TextToSpeechRequest) -> str:
+        env_lang = os.environ.get("QWEN3_TTS_LANGUAGE", "").strip().lower()
+        speaker = (request.speaker_id or "").strip().lower()
+        if speaker in _KNOWN_LANGUAGES:
+            return speaker
+        if env_lang in _KNOWN_LANGUAGES:
+            return env_lang
+        if _looks_japanese(request.text):
+            return "japanese"
+        return "english"
+
+    def _initialize_models(self) -> None:
+        from transformers import AutoTokenizer
+
+        from models.demos.qwen3_tts.tt.qwen3_tts import Qwen3TTS
+
+        api = _tts_api()
+        if self.ttnn_device is None:
+            raise RuntimeError("ttnn_device not initialized; set_device() must run first")
+
+        if self.main_weights is None or self.decoder_weights is None:
+            self.main_weights, self.decoder_weights = self._load_qwen_weights()
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.hf_id, trust_remote_code=True
+        )
+
+        from models.demos.qwen3_tts.tt.model_config import talker_config_for_hf_id
+
+        talker_config = talker_config_for_hf_id(self.hf_id)
+        model_kwargs = {
+            "device": self.ttnn_device,
+            "state_dict": self.main_weights,
+            "talker_config": talker_config,
+        }
+
+        self.logger.info(
+            f"Device {self.device_id}: Building Qwen3TTS ({self.hf_id}) "
+            f"TT_QWEN3_CP_FP32={os.environ.get('TT_QWEN3_CP_FP32', '0')}"
+        )
+        self.model = Qwen3TTS(**model_kwargs)
+
+        max_new = int(
+            os.environ.get("TT_QWEN3_MAX_NEW_TOKENS", Qwen3TTSConstants.MAX_NEW_TOKENS)
+        )
+        self.config = api.TTSConfig(max_new_tokens=max_new)
+        self.config.greedy = False
+        self.config.repetition_penalty = float(
+            os.environ.get("TT_QWEN3_REP_PENALTY", "1.15")
+        )
+        self.config.hidden_size = talker_config.hidden_size
+
+        self.logger.info(
+            f"Device {self.device_id}: Capturing TTS server context (traces)..."
+        )
+        self.ctx = api.init_server_context(
+            self.ttnn_device, self.model, self.config, self.main_weights
+        )
+
+        self.voice_prompts = VoicePromptManager()
+        self.voice_prompts.preload()
+        self.voice_prompts.precompute_speaker_embeddings(self.model)
+        self.logger.info(
+            f"Device {self.device_id}: Voice prompts ready: "
+            f"{self.voice_prompts.list_available()}"
+        )
+        self._post_warmup_rng_state = torch.get_rng_state()
+
+    @log_execution_time(
+        "Qwen3-TTS warmup",
+        TelemetryEvent.DEVICE_WARMUP,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    async def warmup(self) -> bool:
+        try:
+            if self.ttnn_device is None:
+                raise ValueError("Device not initialized. Call set_device() first.")
+            await asyncio.to_thread(self._initialize_models)
+            self.logger.info(f"Device {self.device_id}: Qwen3-TTS warmup complete")
+            return True
+        except Exception as e:
+            self.logger.error(f"Device {self.device_id}: Qwen3-TTS load failed: {e}")
+            raise RuntimeError(
+                f"Device {self.device_id}: Model loading failed: {str(e)}"
+            ) from e
+
+    def _resolve_voice(
+        self, request: TextToSpeechRequest
+    ) -> Tuple[torch.Tensor, str, torch.Tensor, str]:
+        api = _tts_api()
+        clone_audio_b64 = request.voice_clone_audio
+        clone_text = request.voice_clone_text
+        if clone_audio_b64 and clone_text:
+            self.logger.info("Voice resolution: ad-hoc clone from request payload")
+            audio_bytes = base64.b64decode(clone_audio_b64)
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+                tmp.write(audio_bytes)
+                tmp_path = tmp.name
+            try:
+                ref_codes, audio_data = api.encode_reference_audio(
+                    tmp_path, main_weights=None
+                )
+            finally:
+                Path(tmp_path).unlink(missing_ok=True)
+            return ref_codes, clone_text, audio_data, "<adhoc>"
+
+        voice_id = request.speaker_id or DEFAULT_VOICE_ID
+        if voice_id in _KNOWN_LANGUAGES:
+            voice_id = DEFAULT_VOICE_ID
+        prompt = self.voice_prompts.get(voice_id) if self.voice_prompts else None
+        if prompt is None:
+            available = (
+                self.voice_prompts.list_available() if self.voice_prompts else []
+            )
+            raise ValueError(
+                f"Unknown voice_id={voice_id!r}. Available: {available}. "
+                "Or pass voice_clone_audio + voice_clone_text for ad-hoc cloning."
+            )
+        return prompt.ref_codes, prompt.ref_text, prompt.audio_data, voice_id
+
+    def _trim_ref(self, ref_codes, audio_data, ref_text, target_text):
+        from models.demos.qwen3_tts.demo.reference_icl_utils import (
+            trim_reference_for_icl_conditioning,
+        )
+
+        return trim_reference_for_icl_conditioning(
+            ref_codes, audio_data, self.tokenizer, ref_text, target_text
+        )
+
+    def _synthesize(self, request: TextToSpeechRequest) -> TextToSpeechResponse:
+        import time as _time
+
+        api = _tts_api()
+        if self.model is None or self.ctx is None:
+            raise RuntimeError("Model not loaded. Call warmup() first.")
+
+        t_total = _time.perf_counter()
+        ref_codes, ref_text, audio_data, voice_id = self._resolve_voice(request)
+        ref_codes, audio_data = self._trim_ref(
+            ref_codes, audio_data, ref_text, request.text
+        )
+
+        cached = (
+            self.voice_prompts.get(voice_id)
+            if (self.voice_prompts and voice_id != "<adhoc>")
+            else None
+        )
+        if cached is not None and cached.speaker_embedding is not None:
+            speaker_embedding = cached.speaker_embedding
+        else:
+            speaker_embedding = self.model.extract_speaker_embedding(audio_data)
+
+        language = self._language_for(request)
+        inputs_embeds_tt, trailing_text_hidden, tts_pad_embed, _ = (
+            api.create_icl_embedding_ttnn(
+                target_text=request.text,
+                ref_text=ref_text,
+                ref_codes=ref_codes,
+                speaker_embedding=speaker_embedding,
+                tokenizer=self.tokenizer,
+                model=self.model,
+                device=self.ttnn_device,
+                config=self.config,
+                main_weights=self.main_weights,
+                language=language,
+            )
+        )
+
+        if self._post_warmup_rng_state is not None:
+            torch.set_rng_state(self._post_warmup_rng_state)
+
+        codes, _timings, _perf = api.run_inference(
+            ctx=self.ctx,
+            model=self.model,
+            device=self.ttnn_device,
+            inputs_embeds_tt=inputs_embeds_tt,
+            trailing_text_hidden=trailing_text_hidden,
+            tts_pad_embed=tts_pad_embed,
+            config=self.config,
+            use_2cq=True,
+        )
+        if codes is None:
+            raise RuntimeError("Qwen3-TTS generation returned no codec frames")
+
+        if (
+            getattr(self.config, "trim_codec_frames", 0) > 0
+            and len(codes) > self.config.trim_codec_frames
+        ):
+            codes = codes[self.config.trim_codec_frames :]
+
+        audio = api.decode_audio(codes, self.decoder_weights)
+        audio_np = audio.squeeze().detach().cpu().float().numpy()
+        duration_s = float(len(audio_np)) / SAMPLE_RATE_HZ
+
+        buf = io.BytesIO()
+        sf.write(buf, audio_np, SAMPLE_RATE_HZ, format="WAV")
+        b64_audio = base64.b64encode(buf.getvalue()).decode("ascii")
+
+        total_ms = (_time.perf_counter() - t_total) * 1000
+        rtf = (total_ms / 1000.0) / duration_s if duration_s > 0 else float("inf")
+        self.logger.info(
+            f"Device {self.device_id}: voice={voice_id} lang={language} "
+            f"frames={len(codes)} audio={duration_s:.2f}s "
+            f"total={total_ms:.0f}ms RTF={rtf:.3f}"
+        )
+        return TextToSpeechResponse(
+            audio=b64_audio,
+            duration=duration_s,
+            sample_rate=SAMPLE_RATE_HZ,
+            format="wav",
+            speaker_id=None if voice_id == "<adhoc>" else voice_id,
+        )
+
+    async def _run_async(self, requests: list[TextToSpeechRequest]):
+        if not requests:
+            raise ValueError("Empty request list")
+        if len(requests) > 1:
+            self.logger.warning(
+                f"Device {self.device_id}: Qwen3-TTS supports batch=1; "
+                f"processing first of {len(requests)} requests"
+            )
+        request = requests[0]
+        if request is None or not request.text or not request.text.strip():
+            raise ValueError("Text cannot be empty")
+        return await asyncio.to_thread(self._synthesize, request)
+
+    @log_execution_time(
+        "Qwen3-TTS inference",
+        TelemetryEvent.MODEL_INFERENCE,
+        os.environ.get("TT_VISIBLE_DEVICES"),
+    )
+    def run(self, requests: list[TextToSpeechRequest]):
+        result = asyncio.run(self._run_async(requests))
+        return [result] if result is not None else []

--- a/tt-media-server/tt_model_runners/qwen3_tts_runner.py
+++ b/tt-media-server/tt_model_runners/qwen3_tts_runner.py
@@ -239,6 +239,15 @@ class TTQwen3TTSRunner(BaseMetalDeviceRunner):
         )
         self._post_warmup_rng_state = torch.get_rng_state()
 
+    def _warmup_inference(self) -> None:
+        # init_server_context captures load traces only. First live /v1/audio/speech
+        # still JIT-compiles ICL + decode for that language/length (~12s per worker).
+        for text in ("テスト", "Hello, this is a test."):
+            self.logger.info(
+                f"Device {self.device_id}: Warm-up synth text={text!r}"
+            )
+            self._synthesize(TextToSpeechRequest(text=text, response_format="wav"))
+
     @log_execution_time(
         "Qwen3-TTS warmup",
         TelemetryEvent.DEVICE_WARMUP,
@@ -249,6 +258,7 @@ class TTQwen3TTSRunner(BaseMetalDeviceRunner):
             if self.ttnn_device is None:
                 raise ValueError("Device not initialized. Call set_device() first.")
             await asyncio.to_thread(self._initialize_models)
+            await asyncio.to_thread(self._warmup_inference)
             self.logger.info(f"Device {self.device_id}: Qwen3-TTS warmup complete")
             return True
         except Exception as e:

--- a/tt-media-server/tt_model_runners/runner_fabric.py
+++ b/tt-media-server/tt_model_runners/runner_fabric.py
@@ -166,6 +166,9 @@ AVAILABLE_RUNNERS = {
     ModelRunners.TT_SPEECHT5_TTS: lambda wid: __import__(
         "tt_model_runners.speecht5_runner", fromlist=["TTSpeechT5Runner"]
     ).TTSpeechT5Runner(wid),
+    ModelRunners.TT_QWEN3_TTS: lambda wid: __import__(
+        "tt_model_runners.qwen3_tts_runner", fromlist=["TTQwen3TTSRunner"]
+    ).TTQwen3TTSRunner(wid),
     ModelRunners.TT_XLA_SDXL: lambda wid: __import__(
         "tt_model_runners.forge_runners.sdxl_forge_runner",
         fromlist=["SDXLForgeRunner"],

--- a/tt-media-server/utils/runner_utils.py
+++ b/tt-media-server/utils/runner_utils.py
@@ -52,6 +52,7 @@ def setup_runner_environment(
     _RUNNERS_REQUIRING_MESH_DESCRIPTOR = {
         ModelRunners.TT_WHISPER.value,
         ModelRunners.TT_SPEECHT5_TTS.value,
+        ModelRunners.TT_QWEN3_TTS.value,
         # Training runners init a tt-metal device directly (via torch-xla). On a
         # single Blackhole chip of a P300 board, tt-metal otherwise selects the
         # CUSTOM cluster type and asserts that a fabric mesh graph descriptor

--- a/tt-media-server/utils/voice_prompts.py
+++ b/tt-media-server/utils/voice_prompts.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+"""Voice prompt manager for Qwen3-TTS (ICL ref audio + transcript by voice_id).
+
+Default voice: jim clip in tt-metal ``models/demos/qwen3_tts/demo/``.
+Extra: ``QWEN3_TTS_REF_AUDIO`` / ``QWEN3_TTS_REF_TEXT`` as id ``custom``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import torch
+
+from utils.logger import TTLogger
+
+DEFAULT_VOICE_ID = "jim"
+
+
+@dataclass
+class VoicePrompt:
+    voice_id: str
+    ref_codes: torch.Tensor  # [seq_len, 16]
+    ref_text: str
+    audio_data: torch.Tensor  # [num_samples] @ 24 kHz
+    speaker_embedding: object = None
+
+
+def _jim_prompt() -> Tuple[str, Path, str]:
+    import models.demos.qwen3_tts.demo as demo_pkg
+
+    # demo/ is a namespace package (no __init__.py), so __file__ is None.
+    demo_dir = Path(next(iter(demo_pkg.__path__))).resolve()
+    wav = demo_dir / "jim_reference.wav"
+    txt = wav.with_suffix(".txt")
+    ref_text = (
+        txt.read_text(encoding="utf-8").strip()
+        if txt.is_file()
+        else "So basically you put up the high level overview slides."
+    )
+    return DEFAULT_VOICE_ID, wav, ref_text
+
+
+class VoicePromptManager:
+    """Pre-loads built-in voice prompts and looks them up by ID at request time."""
+
+    def __init__(self, tt_metal_home: Optional[str] = None):
+        self.logger = TTLogger()
+        self._voices: Dict[str, VoicePrompt] = {}
+        self._tt_metal_home = Path(
+            tt_metal_home or os.environ.get("TT_METAL_HOME", ".")
+        )
+
+    def _iter_voice_specs(self) -> List[Tuple[str, Path, str]]:
+        specs = []
+        try:
+            specs.append(_jim_prompt())
+        except Exception as e:
+            self.logger.warning(f"VoicePromptManager: jim default unavailable: {e}")
+        env_audio = os.environ.get("QWEN3_TTS_REF_AUDIO")
+        if env_audio:
+            p = Path(env_audio)
+            env_text = os.environ.get("QWEN3_TTS_REF_TEXT")
+            sibling = p.with_suffix(".txt")
+            if env_text:
+                ref_text = env_text
+            elif sibling.is_file():
+                ref_text = sibling.read_text(encoding="utf-8").strip()
+            else:
+                ref_text = "Reference audio transcript."
+            specs.append(("custom", p, ref_text))
+        return specs
+
+    def preload(self) -> None:
+        from models.demos.qwen3_tts.tt.server import encode_reference_audio
+
+        for voice_id, audio_path, ref_text in self._iter_voice_specs():
+            p = Path(audio_path)
+            if not p.is_absolute():
+                p = (self._tt_metal_home / audio_path).resolve()
+            if not p.is_file():
+                self.logger.warning(
+                    f"VoicePromptManager: missing audio for {voice_id!r} at {p} — skipping"
+                )
+                continue
+            try:
+                ref_codes, audio_data = encode_reference_audio(
+                    str(p), main_weights=None
+                )
+            except Exception as e:
+                self.logger.error(
+                    f"VoicePromptManager: failed to encode {voice_id!r} ({p}): {e}"
+                )
+                continue
+            self._voices[voice_id] = VoicePrompt(
+                voice_id=voice_id,
+                ref_codes=ref_codes,
+                ref_text=ref_text,
+                audio_data=audio_data,
+            )
+            self.logger.info(
+                f"VoicePromptManager: pre-loaded {voice_id!r} from {p.name} "
+                f"({ref_codes.shape[0]} frames, {len(audio_data) / 24000:.2f}s)"
+            )
+
+    def list_available(self) -> List[str]:
+        return sorted(self._voices.keys())
+
+    def get(self, voice_id: str) -> Optional[VoicePrompt]:
+        return self._voices.get(voice_id)
+
+    def precompute_speaker_embeddings(self, model) -> None:
+        """Run ECAPA once per voice so later requests skip on-device conv2d prep."""
+        for voice_id, prompt in self._voices.items():
+            if prompt.speaker_embedding is not None:
+                continue
+            try:
+                prompt.speaker_embedding = model.extract_speaker_embedding(
+                    prompt.audio_data
+                )
+                self.logger.info(
+                    f"VoicePromptManager: cached speaker embedding for {voice_id!r}"
+                )
+            except Exception as e:
+                self.logger.error(
+                    f"VoicePromptManager: speaker-embedding precompute failed for "
+                    f"{voice_id!r}: {e}"
+                )

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -268,6 +268,12 @@ speecht5_impl = ImplSpec(
     repo_url="https://github.com/tenstorrent/tt-metal",
     code_path="models/experimental/speecht5_tts",
 )
+qwen3_tts_impl = ImplSpec(
+    impl_id="qwen3_tts",
+    impl_name="qwen3-tts",
+    repo_url="https://github.com/tenstorrent/tt-metal",
+    code_path="models/demos/qwen3_tts",
+)
 forge_vllm_plugin_impl = ImplSpec(
     impl_id="forge_vllm_plugin",
     impl_name="forge-vllm-plugin",
@@ -316,6 +322,7 @@ _IMPL_REGISTRY: Dict[str, ImplSpec] = {
     "deepseek_r1_galaxy": deepseek_r1_galaxy_impl,
     "whisper": whisper_impl,
     "speecht5_tts": speecht5_impl,
+    "qwen3_tts": qwen3_tts_impl,
     "forge_vllm_plugin": forge_vllm_plugin_impl,
     "tt_vllm_plugin": tt_vllm_plugin_impl,
     "sdxl_forge": sdxl_forge_impl,

--- a/workflows/model_specs/dev/audio_tts.yaml
+++ b/workflows/model_specs/dev/audio_tts.yaml
@@ -131,3 +131,22 @@ templates:
       env_vars:
         TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto"
   status: EXPERIMENTAL
+
+- weights:
+    - Qwen/Qwen3-TTS-12Hz-1.7B-Base
+    - Qwen/Qwen3-TTS-12Hz-0.6B-Base
+  impl: qwen3_tts
+  min_disk_gb: 25
+  min_ram_gb: 16
+  model_type: TEXT_TO_SPEECH
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: N150
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+    - device: N300
+      max_concurrency: 1
+      max_context: 65536  # 64 * 1024
+      default_impl: true
+  status: FUNCTIONAL


### PR DESCRIPTION
## Summary
- Register `Qwen3-TTS-12Hz-1.7B-Base` and `Qwen3-TTS-12Hz-0.6B-Base` for **N150** and **N300** 
- Japanese is auto-detected from hiragana/katakana/kanji. Default voice is jim.
- Models CI nightly: both models on N150 and N300.
**tt-metal pin for image build:** `tvardhineni/jp-stt-tts-n150` @ `888379c`. 
Models CI / `--docker-server` must build from that SHA (`--dev-mode`, `--override-docker-image` until prod promotion).
## Test plan
- [x] `run.py --dev-mode --help` lists both Qwen3-TTS models
- [x] Local `/v1/audio/speech` HTTP 200, 24 kHz WAV: 1.7B + 0.6B × N150 + N300 × EN + JA
- [ ] Models CI nightly build from metal `888379c`
- [ ] Do not include `tt-media-server/generated/fabric/*`
