### PR TITLE
Add image-generation metrics

### DIFF
--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
@@ -581,7 +581,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
-      "description": "Conditioning encode time per request, p50 and p99, in milliseconds. 'all' is the pipeline-level encoder span; clip / t5 / qwen are the individual encoders nested inside it, so do not add them to 'all'.",
+      "description": "Conditioning encode time per request, p50 and p99, in milliseconds. 'all' is the pipeline-level encoder span; clip / t5 / qwen / image are nested inside it, so do not add them to 'all'.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },

--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "TT Media Server (Python) - request latency, pipeline stages, multihost video-gen breakdown, and per-process infrastructure. Transient asset; sunsets with the Python server (~4 months).",
+  "description": "TT Media Server (Python) - request latency, pipeline stages, image-generation stage breakdown (denoising / VAE decode / conditioning), multihost video-gen breakdown, and per-process infrastructure. Transient asset; sunsets with the Python server (~4 months).",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -273,6 +273,413 @@
     {
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 800,
+      "title": "Image Generation (denoising / VAE decode / conditioning)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Completed denoising steps per second across all image models. This is the core generation capacity number: it moves with resolution, step count and batching.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 2 }
+            ]
+          },
+          "unit": "cps",
+          "decimals": 2
+        }
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 24 },
+      "id": 30,
+      "options": { "colorMode": "background_solid", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_image_denoise_steps_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval]))",
+          "legendFormat": "steps/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Denoising Throughput (steps/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Images per second converted from latents to pixels by the VAE. Compare against denoising throughput: if this is the lower number, reconstruction is the limiter, not denoising.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+          "unit": "cps",
+          "decimals": 3
+        }
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 24 },
+      "id": 31,
+      "options": { "colorMode": "background_solid", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_image_vae_images_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval]))",
+          "legendFormat": "images/s",
+          "refId": "A"
+        }
+      ],
+      "title": "VAE Decode (images/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Megapixels per second out of the VAE. Resolution-independent view of reconstruction capacity - images/s alone makes a 512x512 model look faster than a 1024x1024 one at equal silicon cost.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": null }] },
+          "unit": "short",
+          "decimals": 2
+        }
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 24 },
+      "id": 32,
+      "options": { "colorMode": "background_solid", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(tt_media_server_image_vae_pixels_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval])) / 1e6",
+          "legendFormat": "MP/s",
+          "refId": "A"
+        }
+      ],
+      "title": "VAE Decode (megapixels/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Conditioning encode time as a share of total engine time. High values mean prompt encoding - not denoising - dominates, which is the usual signature of short/low-step image requests.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 20 },
+              { "color": "red", "value": 40 }
+            ]
+          },
+          "unit": "percent",
+          "decimals": 1,
+          "max": 100,
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 24 },
+      "id": 33,
+      "options": { "colorMode": "background_solid", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "100 * sum(rate(tt_media_server_image_conditioning_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\",encoder=\"all\"}[5m])) / clamp_min(sum(rate(tt_media_server_image_engine_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])), 0.000001)",
+          "legendFormat": "conditioning %",
+          "refId": "A"
+        }
+      ],
+      "title": "Conditioning % of Engine Time",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Denoising steps/s split by resolution and batch size. Doubling resolution should cut steps/s; batching should raise it. If batching does not raise it, the batch is not being formed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2, "drawStyle": "line", "showPoints": "never" },
+          "unit": "cps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 29 },
+      "id": 34,
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "mean", "max"], "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (resolution, batch) (rate(tt_media_server_image_denoise_steps_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval]))",
+          "legendFormat": "{{resolution}} batch={{batch}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Denoising steps/s by resolution & batch",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Denoising steps/s split by device and sampler. Divergence between devices running the same model and sampler is a per-host problem; divergence between samplers is expected.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2, "drawStyle": "line", "showPoints": "never" },
+          "unit": "cps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 29 },
+      "id": 35,
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "mean", "max"], "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (device_id, sampler, model_type) (rate(tt_media_server_image_denoise_steps_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval]))",
+          "legendFormat": "{{model_type}} dev={{device_id}} {{sampler}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Denoising steps/s by device & sampler",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Per-step denoising latency, p50 and p99, by resolution and batch. The reciprocal of p50 is the per-device step rate; a widening p50-p99 gap means some steps are stalling.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 0, "lineWidth": 2, "drawStyle": "line", "showPoints": "never" },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*p99.*" },
+            "properties": [{ "id": "custom.lineStyle", "value": { "dash": [10, 10], "fill": "dash" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 37 },
+      "id": 36,
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "max"], "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.50, sum by (le, resolution, batch) (rate(tt_media_server_image_denoise_step_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])))",
+          "legendFormat": "{{resolution}} batch={{batch}} p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.99, sum by (le, resolution, batch) (rate(tt_media_server_image_denoise_step_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])))",
+          "legendFormat": "{{resolution}} batch={{batch}} p99",
+          "refId": "B"
+        }
+      ],
+      "title": "Denoising step latency p50 / p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Heatmap of per-step denoising latency. Each row is a bucket; intensity = count. Shows bimodal step timing (e.g. first step paying a compile or cache cost) that quantiles hide.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "scaleDistribution": { "type": "linear" } },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 37 },
+      "id": 37,
+      "options": {
+        "calculate": false,
+        "color": { "scheme": "Spectral", "mode": "scheme", "exponent": 0.5, "steps": 64, "reverse": false },
+        "legend": { "show": true },
+        "tooltip": { "show": true, "yHistogram": false },
+        "yAxis": { "axisPlacement": "left", "unit": "s" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (le) (rate(tt_media_server_image_denoise_step_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Denoising step latency heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "VAE decode throughput per resolution and batch, in images/s and megapixels/s. Flat images/s while denoising steps/s climbs means the VAE has become the bottleneck.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2, "drawStyle": "line", "showPoints": "never" },
+          "unit": "cps"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*MP/s.*" },
+            "properties": [{ "id": "unit", "value": "short" }, { "id": "custom.axisPlacement", "value": "right" }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 45 },
+      "id": 38,
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "mean"], "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (resolution, batch) (rate(tt_media_server_image_vae_images_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval]))",
+          "legendFormat": "{{resolution}} batch={{batch}} images/s",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum by (resolution) (rate(tt_media_server_image_vae_pixels_total{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[$__rate_interval])) / 1e6",
+          "legendFormat": "{{resolution}} MP/s",
+          "refId": "B"
+        }
+      ],
+      "title": "VAE decode throughput (images/s & MP/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "VAE decode latency p50/p99 per resolution and batch. Rising with batch means the decode is not amortising across the batch.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 0, "lineWidth": 2, "drawStyle": "line", "showPoints": "never" },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*p99.*" },
+            "properties": [{ "id": "custom.lineStyle", "value": { "dash": [10, 10], "fill": "dash" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 45 },
+      "id": 39,
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "max"], "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.50, sum by (le, resolution, batch) (rate(tt_media_server_image_vae_decode_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])))",
+          "legendFormat": "{{resolution}} batch={{batch}} p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.99, sum by (le, resolution, batch) (rate(tt_media_server_image_vae_decode_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])))",
+          "legendFormat": "{{resolution}} batch={{batch}} p99",
+          "refId": "B"
+        }
+      ],
+      "title": "VAE decode latency p50 / p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Conditioning encode time per request, p50 and p99, in milliseconds. 'all' is the pipeline-level encoder span; clip / t5 / qwen are the individual encoders nested inside it, so do not add them to 'all'.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 0, "lineWidth": 2, "drawStyle": "line", "showPoints": "never" },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*p99.*" },
+            "properties": [{ "id": "custom.lineStyle", "value": { "dash": [10, 10], "fill": "dash" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 53 },
+      "id": 40,
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "max"], "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "1000 * histogram_quantile(0.50, sum by (le, encoder) (rate(tt_media_server_image_conditioning_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])))",
+          "legendFormat": "{{encoder}} p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "1000 * histogram_quantile(0.99, sum by (le, encoder) (rate(tt_media_server_image_conditioning_duration_seconds_bucket{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])))",
+          "legendFormat": "{{encoder}} p99",
+          "refId": "B"
+        }
+      ],
+      "title": "Conditioning encoder time p50 / p99 (ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Conditioning encode time as a percent of engine time, per model. Climbing here on short requests is the signal that prompt encoding, not generation, is what the user is waiting for.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2, "drawStyle": "line", "showPoints": "never" },
+          "unit": "percent",
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 53 },
+      "id": 41,
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "mean", "max"], "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "100 * sum by (model_type) (rate(tt_media_server_image_conditioning_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\",encoder=\"all\"}[5m])) / clamp_min(sum by (model_type) (rate(tt_media_server_image_engine_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])), 0.000001)",
+          "legendFormat": "{{model_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Conditioning share of engine time (%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$datasource" },
+      "description": "Where engine time goes: conditioning vs denoising vs VAE decode, as a percent of total engine time. Whichever band is widest is the thing to optimise. Bands will not sum to 100% on runners that cannot report every stage (Z-Image-Turbo reports only the total).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 60, "lineWidth": 1, "drawStyle": "line", "stacking": { "mode": "normal" }, "showPoints": "never" },
+          "unit": "percent",
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 61 },
+      "id": 42,
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "mean"], "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "100 * sum(rate(tt_media_server_image_conditioning_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\",encoder=\"all\"}[5m])) / clamp_min(sum(rate(tt_media_server_image_engine_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])), 0.000001)",
+          "legendFormat": "conditioning",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "100 * sum(rate(tt_media_server_image_denoise_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])) / clamp_min(sum(rate(tt_media_server_image_engine_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])), 0.000001)",
+          "legendFormat": "denoising",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "100 * sum(rate(tt_media_server_image_vae_decode_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])) / clamp_min(sum(rate(tt_media_server_image_engine_duration_seconds_sum{service=~\"$service\",model_type=~\"$model_type\",device_id=~\"$device_id\"}[5m])), 0.000001)",
+          "legendFormat": "vae decode",
+          "refId": "C"
+        }
+      ],
+      "title": "Engine time split: conditioning vs denoising vs VAE decode (%)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 69 },
       "id": 400,
       "title": "Multihost / Per-Device (video gen drill-down)",
       "type": "row"
@@ -287,7 +694,7 @@
           "unit": "s"
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 24 },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 70 },
       "id": 8,
       "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "max"], "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
@@ -311,7 +718,7 @@
           "unit": "reqps"
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 24 },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 70 },
       "id": 9,
       "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "mean"], "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
@@ -334,7 +741,7 @@
           "unit": "s"
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 33 },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 79 },
       "id": 10,
       "options": {
         "calculate": false,
@@ -371,7 +778,7 @@
           }
         ]
       },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 33 },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 79 },
       "id": 11,
       "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "sum"], "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
@@ -403,7 +810,7 @@
           "unit": "s"
         }
       },
-      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 42 },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 88 },
       "id": 12,
       "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
@@ -419,7 +826,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 49 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 95 },
       "id": 500,
       "title": "Lifecycle (warmup / model load / download)",
       "type": "row"
@@ -434,7 +841,7 @@
           "unit": "s"
         }
       },
-      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 50 },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 96 },
       "id": 13,
       "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["last", "max"], "showLegend": true } },
       "targets": [
@@ -463,7 +870,7 @@
           "custom": { "align": "auto", "displayMode": "color-text" }
         }
       },
-      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 50 },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 96 },
       "id": 14,
       "options": { "showHeader": true },
       "targets": [
@@ -493,7 +900,7 @@
           "custom": { "align": "auto", "displayMode": "color-text" }
         }
       },
-      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 50 },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 96 },
       "id": 15,
       "options": { "showHeader": true },
       "targets": [
@@ -524,7 +931,7 @@
           }
         ]
       },
-      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 57 },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 103 },
       "id": 16,
       "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "sum"], "showLegend": true } },
       "targets": [
@@ -548,7 +955,7 @@
           "unit": "s"
         }
       },
-      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 57 },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 103 },
       "id": 17,
       "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "max"], "showLegend": true } },
       "targets": [
@@ -564,7 +971,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 64 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 110 },
       "id": 600,
       "title": "Infrastructure (per-process, host-wide)",
       "type": "row"
@@ -579,7 +986,7 @@
           "unit": "percent"
         }
       },
-      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 65 },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 111 },
       "id": 18,
       "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
       "targets": [
@@ -603,7 +1010,7 @@
           "unit": "decmbytes"
         }
       },
-      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 65 },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 111 },
       "id": 19,
       "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
       "targets": [
@@ -627,7 +1034,7 @@
           "unit": "none"
         }
       },
-      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 65 },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 111 },
       "id": 20,
       "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
       "targets": [
@@ -651,7 +1058,7 @@
           "unit": "none"
         }
       },
-      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 71 },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 117 },
       "id": 21,
       "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
       "targets": [
@@ -675,7 +1082,7 @@
           "unit": "none"
         }
       },
-      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 71 },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 117 },
       "id": 22,
       "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
       "targets": [
@@ -699,7 +1106,7 @@
           "unit": "ops"
         }
       },
-      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 71 },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 117 },
       "id": 23,
       "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
       "targets": [
@@ -721,7 +1128,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 77 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 123 },
       "id": 700,
       "title": "System Info",
       "type": "row"
@@ -736,7 +1143,7 @@
           "custom": { "align": "auto", "displayMode": "auto" }
         }
       },
-      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 78 },
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 124 },
       "id": 24,
       "options": { "showHeader": true },
       "targets": [
@@ -757,7 +1164,7 @@
   ],
   "refresh": "5s",
   "schemaVersion": 38,
-  "tags": ["tenstorrent", "tt-media-server", "python", "video-gen"],
+  "tags": ["tenstorrent", "tt-media-server", "python", "video-gen", "image-gen"],
   "templating": {
     "list": [
       {

--- a/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
+++ b/tt-media-server/monitoring/grafana/dashboards/tt_media_server_python.json
@@ -443,7 +443,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
-      "description": "Per-step denoising latency, p50 and p99, by resolution and batch. The reciprocal of p50 is the per-device step rate; a widening p50-p99 gap means some steps are stalling.",
+      "description": "Per-step denoising latency, p50 and p99, by resolution and batch. The reciprocal of p50 is the per-device step rate; a widening p50-p99 gap means some steps are stalling. Only the tt_dit models (SD3.5, Flux, Motif, Qwen-Image) report per-step timings; SDXL and Z-Image-Turbo report only a loop total, so they are absent here by design - use the denoise_duration_seconds panels for those.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -479,7 +479,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "$datasource" },
-      "description": "Heatmap of per-step denoising latency. Each row is a bucket; intensity = count. Shows bimodal step timing (e.g. first step paying a compile or cache cost) that quantiles hide.",
+      "description": "Heatmap of per-step denoising latency. Each row is a bucket; intensity = count. Shows bimodal step timing (e.g. first step paying a compile or cache cost) that quantiles hide. Only the tt_dit models (SD3.5, Flux, Motif, Qwen-Image) report per-step timings; SDXL and Z-Image-Turbo report only a loop total, so \"No data\" here means the runner cannot report it, not that the metric is broken.",
       "fieldConfig": {
         "defaults": {
           "custom": { "scaleDistribution": { "type": "linear" } },

--- a/tt-media-server/telemetry/image_metrics.py
+++ b/tt-media-server/telemetry/image_metrics.py
@@ -294,6 +294,10 @@ def record_image_run(
     ``step_seconds`` is per-step latency when the pipeline reports it.
     ``step_count`` only advances the completed-steps counter; the mean of the
     loop is not written into the per-step histogram.
+
+    If ``engine_seconds`` is omitted, it is filled from denoise + VAE +
+    ``encoder="all"`` so Grafana's conditioning-as-%-of-engine cannot divide
+    by an empty denominator.
     """
     batch = str(batch)
     denoise_labels = dict(
@@ -310,6 +314,9 @@ def record_image_run(
         batch=batch,
     )
 
+    engine_seconds = _resolve_engine_seconds(
+        engine_seconds, denoise_seconds, vae_seconds, conditioning_seconds
+    )
     if engine_seconds is not None:
         engine_duration.labels(**shape_labels).observe(engine_seconds)
 
@@ -348,6 +355,27 @@ def _now() -> float:
     return time.perf_counter()
 
 
+def _resolve_engine_seconds(
+    engine_seconds: float | None,
+    denoise_seconds: float | None,
+    vae_seconds: float | None,
+    conditioning_seconds: dict[str, float] | None,
+) -> float | None:
+    if engine_seconds is not None:
+        return engine_seconds
+    parts = []
+    if denoise_seconds is not None:
+        parts.append(denoise_seconds)
+    if vae_seconds is not None:
+        parts.append(vae_seconds)
+    all_cond = (conditioning_seconds or {}).get("all")
+    if all_cond is not None:
+        parts.append(all_cond)
+    if not parts:
+        return None
+    return sum(parts)
+
+
 class SdxlSectionTimings:
     """Read tt-metal's profiler spans around one ``generate_images()`` call.
 
@@ -361,7 +389,9 @@ class SdxlSectionTimings:
 
     Process-global state is safe here because image runners run one ``run()`` at
     a time per device-worker process; only ``sp_runner`` fans out concurrently
-    and it is not an image runner. An unreachable profiler leaves ``None``.
+    and it is not an image runner. An unreachable profiler, or a missing
+    ``image_gen`` span, falls back to wall clock of this context so engine
+    time is never absent while conditioning is exported.
     """
 
     DENOISE = "denoising_loop"
@@ -373,6 +403,7 @@ class SdxlSectionTimings:
         self.denoise_seconds: float | None = None
         self.vae_seconds: float | None = None
         self.engine_seconds: float | None = None
+        self._wall_start: float | None = None
 
     @staticmethod
     def _profiler() -> Any:
@@ -383,6 +414,7 @@ class SdxlSectionTimings:
         return profiler
 
     def __enter__(self) -> "SdxlSectionTimings":
+        self._wall_start = _now()
         profiler = self._profiler()
         if profiler is None:
             return self
@@ -396,15 +428,23 @@ class SdxlSectionTimings:
     def __exit__(self, exc_type, exc, tb) -> bool:
         if exc_type is not None:
             return False  # Failed run: report nothing rather than a bogus timing.
+        wall_seconds = None
+        if self._wall_start is not None:
+            wall_seconds = _now() - self._wall_start
         profiler = self._profiler()
         if profiler is None:
+            self.engine_seconds = wall_seconds
             return False
         try:
             self.denoise_seconds = self._last(profiler, self.DENOISE)
             self.vae_seconds = self._last(profiler, self.VAE)
             self.engine_seconds = self._last(profiler, self.ENGINE)
+            if self.engine_seconds is None:
+                self.engine_seconds = wall_seconds
         except Exception as exc:  # pragma: no cover
             logger.debug(f"Could not read tt-metal profiler spans: {exc}")
+            if self.engine_seconds is None:
+                self.engine_seconds = wall_seconds
         return False
 
     @staticmethod

--- a/tt-media-server/telemetry/image_metrics.py
+++ b/tt-media-server/telemetry/image_metrics.py
@@ -278,9 +278,9 @@ def record_image_run(
 ) -> None:
     """Export one image run's stage timings.
 
-    ``step_seconds`` is per-step data when the pipeline reports it; ``step_count``
-    is the fallback for pipelines that only report the loop total, where per-step
-    latency becomes the loop mean.
+    ``step_seconds`` is per-step latency when the pipeline reports it.
+    ``step_count`` only advances the completed-steps counter; the mean of the
+    loop is not written into the per-step histogram.
     """
     batch = str(batch)
     denoise_labels = dict(
@@ -301,9 +301,6 @@ def record_image_run(
         engine_duration.labels(**shape_labels).observe(engine_seconds)
 
     steps = list(step_seconds or [])
-    if not steps and step_count and denoise_seconds is not None and step_count > 0:
-        steps = [denoise_seconds / step_count] * step_count
-
     if steps:
         counter = denoise_steps_total.labels(**denoise_labels)
         histogram = denoise_step_duration.labels(**denoise_labels)

--- a/tt-media-server/telemetry/image_metrics.py
+++ b/tt-media-server/telemetry/image_metrics.py
@@ -125,6 +125,12 @@ def add_conditioning_seconds(
 
     ``all`` is the pipeline-level total used as % of engine; clip / t5 / qwen /
     image sit inside it and must not be added together with ``all``.
+
+    For runners that measure each encoder separately and have no span of their
+    own for the total, so ``all`` has to be built up from the parts -- i.e. the
+    SDXL path. **Not** for :class:`ImageStageRecorder`: tt_dit emits its own
+    ``encoder`` span for the total, so folding the nested spans in there too
+    would double-count ``all``.
     """
     store[encoder] = store.get(encoder, 0.0) + seconds
     if encoder != "all":
@@ -240,6 +246,11 @@ class ImageStageRecorder:
         elif _DENOISE_STEP_RE.match(name):
             self.step_seconds.append(seconds)
         elif name in _CONDITIONING_SECTIONS:
+            # Accumulate, not assign: under CFG the pipeline encodes the prompt
+            # and then the negative prompt, so the nested spans fire twice.
+            # Deliberately not add_conditioning_seconds() -- "encoder" is its
+            # own span here, so folding the nested ones into "all" would
+            # double-count it.
             encoder = _CONDITIONING_SECTIONS[name]
             self.conditioning_seconds[encoder] = (
                 self.conditioning_seconds.get(encoder, 0.0) + seconds

--- a/tt-media-server/telemetry/image_metrics.py
+++ b/tt-media-server/telemetry/image_metrics.py
@@ -118,6 +118,19 @@ _CONDITIONING_SECTIONS = {
 _DENOISE_STEP_RE = re.compile(r"^denoising_step_\d+$")
 
 
+def add_conditioning_seconds(
+    store: dict[str, float], encoder: str, seconds: float
+) -> None:
+    """Add one encoder span. Nested labels also increment ``all``.
+
+    ``all`` is the pipeline-level total used as % of engine; clip / t5 / qwen /
+    image sit inside it and must not be added together with ``all``.
+    """
+    store[encoder] = store.get(encoder, 0.0) + seconds
+    if encoder != "all":
+        store["all"] = store.get("all", 0.0) + seconds
+
+
 def format_resolution(width: Any, height: Any) -> str:
     """Render a ``WxH`` label value, or ``unknown`` if either side is missing."""
     try:

--- a/tt-media-server/telemetry/image_metrics.py
+++ b/tt-media-server/telemetry/image_metrics.py
@@ -227,7 +227,10 @@ class ImageStageRecorder:
         elif _DENOISE_STEP_RE.match(name):
             self.step_seconds.append(seconds)
         elif name in _CONDITIONING_SECTIONS:
-            self.conditioning_seconds[_CONDITIONING_SECTIONS[name]] = seconds
+            encoder = _CONDITIONING_SECTIONS[name]
+            self.conditioning_seconds[encoder] = (
+                self.conditioning_seconds.get(encoder, 0.0) + seconds
+            )
 
     # -- export ---------------------------------------------------------------
     def flush(self, images: Any = None, resolution: str | None = None) -> None:

--- a/tt-media-server/telemetry/image_metrics.py
+++ b/tt-media-server/telemetry/image_metrics.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Denoising / VAE decode / conditioning metrics for image generation.
+
+Two collection paths: :class:`ImageStageRecorder` consumes the ``on_event``
+stream tt_dit pipelines already emit; :class:`SdxlSectionTimings` reads the
+equivalent spans off tt-metal's profiler for SDXL, which has no event hook.
+Both buffer until the run ends, because ``resolution`` is read off the
+produced image.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Any
+
+from prometheus_client import Counter, Histogram
+from utils.logger import TTLogger
+
+logger = TTLogger()
+
+# prometheus_client's defaults stop at 10s; image runs take minutes, so every
+# histogram declares its own buckets or everything lands in +Inf.
+_STEP_BUCKETS = (
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1,
+    2,
+    5,
+    10,
+    20,
+    30,
+    60,
+    float("inf"),
+)
+_STAGE_BUCKETS = (0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60, 120, 300, float("inf"))
+_ENGINE_BUCKETS = (0.5, 1, 2, 5, 10, 20, 30, 60, 120, 300, 600, 1200, float("inf"))
+
+_DENOISE_LABELS = ["model_type", "device_id", "resolution", "sampler", "batch"]
+_VAE_LABELS = ["model_type", "device_id", "resolution", "batch"]
+_CONDITIONING_LABELS = ["model_type", "device_id", "encoder", "batch"]
+
+# --- Denoising throughput ----------------------------------------------------
+denoise_steps_total = Counter(
+    "tt_media_server_image_denoise_steps_total",
+    "Completed diffusion denoising steps",
+    _DENOISE_LABELS,
+)
+
+denoise_step_duration = Histogram(
+    "tt_media_server_image_denoise_step_duration_seconds",
+    "Duration of a single denoising step in seconds",
+    _DENOISE_LABELS,
+    buckets=_STEP_BUCKETS,
+)
+
+denoise_loop_duration = Histogram(
+    "tt_media_server_image_denoise_duration_seconds",
+    "Duration of the whole denoising loop in seconds",
+    _DENOISE_LABELS,
+    buckets=_STAGE_BUCKETS,
+)
+
+# --- VAE decode throughput ---------------------------------------------------
+vae_decode_duration = Histogram(
+    "tt_media_server_image_vae_decode_duration_seconds",
+    "Duration of the latent-to-pixel VAE decode in seconds",
+    _VAE_LABELS,
+    buckets=_STAGE_BUCKETS,
+)
+
+vae_images_total = Counter(
+    "tt_media_server_image_vae_images_total",
+    "Images decoded from latents by the VAE",
+    _VAE_LABELS,
+)
+
+vae_pixels_total = Counter(
+    "tt_media_server_image_vae_pixels_total",
+    "Pixels decoded from latents by the VAE",
+    _VAE_LABELS,
+)
+
+# --- Conditioning encoder time ----------------------------------------------
+conditioning_duration = Histogram(
+    "tt_media_server_image_conditioning_duration_seconds",
+    "Time spent encoding conditioning inputs (text, image, control) in seconds",
+    _CONDITIONING_LABELS,
+    buckets=_STAGE_BUCKETS,
+)
+
+# Engine total; its ``_sum`` is the denominator for conditioning-as-%-of-engine.
+engine_duration = Histogram(
+    "tt_media_server_image_engine_duration_seconds",
+    "Total in-engine image generation time in seconds",
+    _VAE_LABELS,
+    buckets=_ENGINE_BUCKETS,
+)
+
+UNKNOWN = "unknown"
+
+# tt_dit section name -> ``encoder`` label. ``encoder`` wraps the others, which
+# are nested inside it, so they are reported separately and must not be summed.
+_CONDITIONING_SECTIONS = {
+    "encoder": "all",
+    "clip_encoding": "clip",
+    "t5_encoding": "t5",
+    "qwen_encoding": "qwen",
+}
+
+_DENOISE_STEP_RE = re.compile(r"^denoising_step_\d+$")
+
+
+def format_resolution(width: Any, height: Any) -> str:
+    """Render a ``WxH`` label value, or ``unknown`` if either side is missing."""
+    try:
+        w, h = int(width), int(height)
+    except (TypeError, ValueError):
+        return UNKNOWN
+    if w <= 0 or h <= 0:
+        return UNKNOWN
+    return f"{w}x{h}"
+
+
+def resolution_of_images(images: Any) -> tuple[str, int, int]:
+    """Derive ``(resolution, image_count, pixels_per_image)`` from model output.
+
+    The produced image is the only shape source that works for every runner.
+    """
+    if images is None:
+        return UNKNOWN, 0, 0
+    if not isinstance(images, (list, tuple)):
+        images = [images]
+    count = len(images)
+    if count == 0:
+        return UNKNOWN, 0, 0
+
+    size = getattr(images[0], "size", None)
+    if not (isinstance(size, (list, tuple)) and len(size) == 2):
+        return UNKNOWN, count, 0
+
+    width, height = size
+    resolution = format_resolution(width, height)
+    if resolution == UNKNOWN:
+        return UNKNOWN, count, 0
+    return resolution, count, int(width) * int(height)
+
+
+def sampler_name(pipeline: Any) -> str:
+    """Best-effort sampler name: diffusers' public ``scheduler``, else tt_dit's
+    private ``_solvers``. Every tt_dit pipeline hardcodes ``EulerSolver``, so
+    that path is constant until tt-metal makes the solver configurable.
+    """
+    scheduler = getattr(pipeline, "scheduler", None)
+    if scheduler is not None:
+        return _kebab(type(scheduler).__name__)
+
+    solvers = getattr(pipeline, "_solvers", None)
+    if solvers:
+        try:
+            return _kebab(type(solvers[0]).__name__)
+        except (TypeError, IndexError):
+            return UNKNOWN
+    return UNKNOWN
+
+
+def _kebab(name: str) -> str:
+    return re.sub(r"(?<!^)(?=[A-Z])", "-", name).lower()
+
+
+class ImageStageRecorder:
+    """Turn a tt_dit ``on_event`` stream into image stage metrics.
+
+    Usable directly as a ``PipelineEventCallback``. Events are matched by class
+    name, not ``isinstance``, so this module never has to import tt-metal.
+    Nothing is exported until :meth:`flush`, so a run that raises part-way
+    through cannot report a fast denoise.
+    """
+
+    def __init__(
+        self,
+        model_type: str,
+        device_id: str | None,
+        sampler: str = UNKNOWN,
+        batch: int = 1,
+    ) -> None:
+        self.model_type = model_type
+        self.device_id = device_id or UNKNOWN
+        self.sampler = sampler or UNKNOWN
+        self.batch = str(batch)
+
+        self._open: dict[str, float] = {}
+        self.engine_seconds: float | None = None
+        self.denoise_seconds: float | None = None
+        self.vae_seconds: float | None = None
+        self.step_seconds: list[float] = []
+        self.conditioning_seconds: dict[str, float] = {}
+
+    # -- event intake ---------------------------------------------------------
+    def __call__(self, event: Any) -> None:
+        kind = type(event).__name__
+        name = getattr(event, "name", None)
+        if name is None:
+            return  # DenoiseStep and anything else tt-metal adds later.
+
+        if kind == "SectionStart":
+            self._open[name] = _now()
+        elif kind == "SectionEnd":
+            start = self._open.pop(name, None)
+            if start is not None:
+                self._record_section(name, _now() - start)
+
+    def _record_section(self, name: str, seconds: float) -> None:
+        if name == "total":
+            self.engine_seconds = seconds
+        elif name == "denoising":
+            self.denoise_seconds = seconds
+        elif name == "vae":
+            self.vae_seconds = seconds
+        elif _DENOISE_STEP_RE.match(name):
+            self.step_seconds.append(seconds)
+        elif name in _CONDITIONING_SECTIONS:
+            self.conditioning_seconds[_CONDITIONING_SECTIONS[name]] = seconds
+
+    # -- export ---------------------------------------------------------------
+    def flush(self, images: Any = None, resolution: str | None = None) -> None:
+        """Export the buffered run. Never raises into the inference path."""
+        try:
+            if resolution is None:
+                resolution, image_count, pixels = resolution_of_images(images)
+            else:
+                _, image_count, pixels = resolution_of_images(images)
+            record_image_run(
+                model_type=self.model_type,
+                device_id=self.device_id,
+                resolution=resolution,
+                sampler=self.sampler,
+                batch=self.batch,
+                engine_seconds=self.engine_seconds,
+                denoise_seconds=self.denoise_seconds,
+                step_seconds=self.step_seconds,
+                vae_seconds=self.vae_seconds,
+                conditioning_seconds=self.conditioning_seconds,
+                image_count=image_count,
+                pixels_per_image=pixels,
+            )
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - telemetry must not break inference
+            logger.warning(f"Failed to record image stage metrics: {exc}")
+
+
+def record_image_run(
+    *,
+    model_type: str,
+    device_id: str,
+    resolution: str,
+    sampler: str,
+    batch: str | int,
+    engine_seconds: float | None = None,
+    denoise_seconds: float | None = None,
+    step_seconds: list[float] | None = None,
+    step_count: int | None = None,
+    vae_seconds: float | None = None,
+    conditioning_seconds: dict[str, float] | None = None,
+    image_count: int = 0,
+    pixels_per_image: int = 0,
+) -> None:
+    """Export one image run's stage timings.
+
+    ``step_seconds`` is per-step data when the pipeline reports it; ``step_count``
+    is the fallback for pipelines that only report the loop total, where per-step
+    latency becomes the loop mean.
+    """
+    batch = str(batch)
+    denoise_labels = dict(
+        model_type=model_type,
+        device_id=device_id,
+        resolution=resolution,
+        sampler=sampler,
+        batch=batch,
+    )
+    shape_labels = dict(
+        model_type=model_type,
+        device_id=device_id,
+        resolution=resolution,
+        batch=batch,
+    )
+
+    if engine_seconds is not None:
+        engine_duration.labels(**shape_labels).observe(engine_seconds)
+
+    steps = list(step_seconds or [])
+    if not steps and step_count and denoise_seconds is not None and step_count > 0:
+        steps = [denoise_seconds / step_count] * step_count
+
+    if steps:
+        counter = denoise_steps_total.labels(**denoise_labels)
+        histogram = denoise_step_duration.labels(**denoise_labels)
+        for seconds in steps:
+            counter.inc()
+            histogram.observe(seconds)
+    elif step_count:
+        denoise_steps_total.labels(**denoise_labels).inc(step_count)
+
+    if denoise_seconds is not None:
+        denoise_loop_duration.labels(**denoise_labels).observe(denoise_seconds)
+
+    if vae_seconds is not None:
+        vae_decode_duration.labels(**shape_labels).observe(vae_seconds)
+        if image_count:
+            vae_images_total.labels(**shape_labels).inc(image_count)
+            if pixels_per_image:
+                vae_pixels_total.labels(**shape_labels).inc(
+                    image_count * pixels_per_image
+                )
+
+    for encoder, seconds in (conditioning_seconds or {}).items():
+        conditioning_duration.labels(
+            model_type=model_type,
+            device_id=device_id,
+            encoder=encoder,
+            batch=batch,
+        ).observe(seconds)
+
+
+def _now() -> float:
+    return time.perf_counter()
+
+
+class SdxlSectionTimings:
+    """Read tt-metal's profiler spans around one ``generate_images()`` call.
+
+    SDXL fuses denoising and VAE decode into one opaque ``run_tt_image_gen``
+    call, but that function brackets both with spans on tt-metal's global
+    ``Profiler``, each closed after a device synchronize.
+
+    Entry clears the tracked keys for two reasons: warmup and compile runs
+    record under the same names, and ``Profiler.times`` appends to a per-key
+    list forever that nothing in the media server drains.
+
+    Process-global state is safe here because image runners run one ``run()`` at
+    a time per device-worker process; only ``sp_runner`` fans out concurrently
+    and it is not an image runner. An unreachable profiler leaves ``None``.
+    """
+
+    DENOISE = "denoising_loop"
+    VAE = "vae_decode"
+    ENGINE = "image_gen"
+    KEYS = (DENOISE, VAE, ENGINE)
+
+    def __init__(self) -> None:
+        self.denoise_seconds: float | None = None
+        self.vae_seconds: float | None = None
+        self.engine_seconds: float | None = None
+
+    @staticmethod
+    def _profiler() -> Any:
+        try:
+            from models.common.utility_functions import profiler
+        except Exception:  # tt-metal not importable (CPU-only / test environments)
+            return None
+        return profiler
+
+    def __enter__(self) -> "SdxlSectionTimings":
+        profiler = self._profiler()
+        if profiler is None:
+            return self
+        try:
+            for key in self.KEYS:
+                profiler.times.pop(key, None)
+        except Exception as exc:  # pragma: no cover
+            logger.debug(f"Could not reset tt-metal profiler spans: {exc}")
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if exc_type is not None:
+            return False  # Failed run: report nothing rather than a bogus timing.
+        profiler = self._profiler()
+        if profiler is None:
+            return False
+        try:
+            self.denoise_seconds = self._last(profiler, self.DENOISE)
+            self.vae_seconds = self._last(profiler, self.VAE)
+            self.engine_seconds = self._last(profiler, self.ENGINE)
+        except Exception as exc:  # pragma: no cover
+            logger.debug(f"Could not read tt-metal profiler spans: {exc}")
+        return False
+
+    @staticmethod
+    def _last(profiler: Any, key: str) -> float | None:
+        samples = profiler.times.get(key)
+        if not samples:
+            return None
+        return float(samples[-1])

--- a/tt-media-server/tests/test_image_metrics.py
+++ b/tt-media-server/tests/test_image_metrics.py
@@ -21,6 +21,7 @@ from prometheus_client import REGISTRY
 from telemetry.image_metrics import (
     ImageStageRecorder,
     SdxlSectionTimings,
+    add_conditioning_seconds,
     format_resolution,
     record_image_run,
     resolution_of_images,
@@ -144,6 +145,22 @@ class TestSamplerName:
     def test_unknown_when_the_pipeline_exposes_neither(self):
         assert sampler_name(object()) == "unknown"
         assert sampler_name(None) == "unknown"
+
+
+class TestAddConditioningSeconds:
+    def test_nested_image_encode_folds_into_all(self):
+        store = {}
+        add_conditioning_seconds(store, "all", 0.4)
+        add_conditioning_seconds(store, "image", 0.6)
+        assert store["image"] == pytest.approx(0.6)
+        assert store["all"] == pytest.approx(1.0)
+
+    def test_all_does_not_double_count_itself(self):
+        store = {}
+        add_conditioning_seconds(store, "all", 0.4)
+        add_conditioning_seconds(store, "all", 0.1)
+        assert store["all"] == pytest.approx(0.5)
+        assert list(store) == ["all"]
 
 
 class TestImageStageRecorder:
@@ -415,6 +432,36 @@ class TestRecordImageRun:
         assert (
             sample("tt_media_server_image_vae_pixels_total", **shape) == 2 * 512 * 512
         )
+
+    def test_image_encoder_is_exported_separately_from_all(self):
+        model_type = "record-image-enc"
+        record_image_run(
+            model_type=model_type,
+            device_id="0",
+            resolution="1024x1024",
+            sampler="euler-solver",
+            batch=1,
+            engine_seconds=5.0,
+            conditioning_seconds={"all": 1.0, "image": 0.6},
+        )
+        for encoder, expected_sum in (("all", 1.0), ("image", 0.6)):
+            assert (
+                sample(
+                    "tt_media_server_image_conditioning_duration_seconds_count",
+                    model_type=model_type,
+                    device_id="0",
+                    encoder=encoder,
+                    batch="1",
+                )
+                == 1
+            )
+            assert sample(
+                "tt_media_server_image_conditioning_duration_seconds_sum",
+                model_type=model_type,
+                device_id="0",
+                encoder=encoder,
+                batch="1",
+            ) == pytest.approx(expected_sum)
 
     def test_absent_stages_produce_no_series(self):
         model_type = "record-sparse"

--- a/tt-media-server/tests/test_image_metrics.py
+++ b/tt-media-server/tests/test_image_metrics.py
@@ -314,7 +314,7 @@ class TestImageStageRecorder:
 
 
 class TestRecordImageRun:
-    def test_step_count_fallback_spreads_the_loop_across_steps(self):
+    def test_step_count_does_not_fabricate_per_step_latency(self):
         model_type = "record-fallback"
         record_image_run(
             model_type=model_type,
@@ -328,14 +328,18 @@ class TestRecordImageRun:
         labels = denoise_labels(model_type)
         assert sample("tt_media_server_image_denoise_steps_total", **labels) == 20
         assert (
+            sample("tt_media_server_image_denoise_duration_seconds_count", **labels)
+            == 1
+        )
+        assert sample(
+            "tt_media_server_image_denoise_duration_seconds_sum", **labels
+        ) == pytest.approx(4.0)
+        assert (
             sample(
                 "tt_media_server_image_denoise_step_duration_seconds_count", **labels
             )
-            == 20
+            is None
         )
-        assert sample(
-            "tt_media_server_image_denoise_step_duration_seconds_sum", **labels
-        ) == pytest.approx(4.0)
 
     def test_step_count_without_a_loop_time_still_advances_the_counter(self):
         model_type = "record-stepsonly"
@@ -358,7 +362,7 @@ class TestRecordImageRun:
             is None
         )
 
-    def test_per_step_observations_win_over_the_fallback(self):
+    def test_per_step_observations_win_over_step_count(self):
         model_type = "record-perstep"
         record_image_run(
             model_type=model_type,

--- a/tt-media-server/tests/test_image_metrics.py
+++ b/tt-media-server/tests/test_image_metrics.py
@@ -193,6 +193,43 @@ class TestImageStageRecorder:
             )
             assert count == 1, f"missing conditioning series for {encoder}"
 
+    def test_accumulates_nested_encoders_when_cfg_encodes_twice(self, monkeypatch):
+        """SD3.5 / Motif encode_cfg runs clip+t5 for the prompt, then again for the negative."""
+        clock = {"t": 0.0}
+        monkeypatch.setattr("telemetry.image_metrics._now", lambda: clock["t"])
+
+        recorder = ImageStageRecorder(
+            "recorder-cfg", "0", sampler="euler-solver", batch=1
+        )
+        clock["t"] = 0.0
+        recorder(SectionStart("encoder"))
+        recorder(SectionStart("clip_encoding"))
+        clock["t"] = 0.10
+        recorder(SectionEnd("clip_encoding"))
+        recorder(SectionStart("t5_encoding"))
+        clock["t"] = 0.40
+        recorder(SectionEnd("t5_encoding"))
+        recorder(SectionStart("clip_encoding"))
+        clock["t"] = 0.52
+        recorder(SectionEnd("clip_encoding"))
+        recorder(SectionStart("t5_encoding"))
+        clock["t"] = 0.82
+        recorder(SectionEnd("t5_encoding"))
+        recorder(SectionEnd("encoder"))
+
+        assert recorder.conditioning_seconds["clip"] == pytest.approx(0.22)
+        assert recorder.conditioning_seconds["t5"] == pytest.approx(0.60)
+        assert recorder.conditioning_seconds["all"] == pytest.approx(0.82)
+
+        recorder.flush([FakeImage()])
+        assert sample(
+            "tt_media_server_image_conditioning_duration_seconds_sum",
+            model_type="recorder-cfg",
+            device_id="0",
+            encoder="clip",
+            batch="1",
+        ) == pytest.approx(0.22)
+
     def test_maps_the_qwen_encoder_span(self):
         model_type = "recorder-qwen"
         recorder = ImageStageRecorder(model_type, "0", sampler="euler-solver", batch=1)

--- a/tt-media-server/tests/test_image_metrics.py
+++ b/tt-media-server/tests/test_image_metrics.py
@@ -1,0 +1,514 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Tests for the image-generation stage metrics.
+
+``telemetry.image_metrics`` imports neither tt-metal nor
+``telemetry.telemetry_client``, so these need no device and are immune to the
+``sys.modules`` Mock other test modules park under the latter.
+
+Prometheus collectors are process-global and cumulative, so each test uses its
+own ``model_type`` label value.
+"""
+
+import sys
+import types
+from dataclasses import dataclass
+
+import pytest
+from prometheus_client import REGISTRY
+from telemetry.image_metrics import (
+    ImageStageRecorder,
+    SdxlSectionTimings,
+    format_resolution,
+    record_image_run,
+    resolution_of_images,
+    sampler_name,
+)
+
+
+# Matched by class name, not import; mirrors tt_dit/pipelines/events.py.
+@dataclass(frozen=True)
+class SectionStart:
+    name: str
+
+
+@dataclass(frozen=True)
+class SectionEnd:
+    name: str
+
+
+@dataclass(frozen=True)
+class DenoiseStep:
+    step: int
+    total: int
+    sigma: float
+
+
+class FakeImage:
+    def __init__(self, width=1024, height=1024):
+        self.size = (width, height)
+
+
+def sample(name, **labels):
+    return REGISTRY.get_sample_value(name, labels)
+
+
+def denoise_labels(model_type, **overrides):
+    labels = dict(
+        model_type=model_type,
+        device_id="0",
+        resolution="1024x1024",
+        sampler="euler-solver",
+        batch="1",
+    )
+    labels.update(overrides)
+    return labels
+
+
+def shape_labels(model_type, **overrides):
+    labels = dict(
+        model_type=model_type,
+        device_id="0",
+        resolution="1024x1024",
+        batch="1",
+    )
+    labels.update(overrides)
+    return labels
+
+
+def drive_full_run(recorder, steps=4, encoders=("clip", "t5")):
+    """Replay the event order the tt_dit image pipelines actually emit."""
+    recorder(SectionStart("total"))
+    recorder(SectionStart("encoder"))
+    for encoder in encoders:
+        recorder(SectionStart(f"{encoder}_encoding"))
+        recorder(SectionEnd(f"{encoder}_encoding"))
+    recorder(SectionEnd("encoder"))
+    recorder(SectionStart("denoising"))
+    for i in range(steps):
+        recorder(SectionStart(f"denoising_step_{i}"))
+        recorder(SectionEnd(f"denoising_step_{i}"))
+    recorder(SectionEnd("denoising"))
+    recorder(SectionStart("vae"))
+    recorder(SectionEnd("vae"))
+    recorder(SectionEnd("total"))
+
+
+class TestResolutionHelpers:
+    def test_formats_width_by_height(self):
+        assert format_resolution(1024, 768) == "1024x768"
+
+    @pytest.mark.parametrize(
+        "width,height", [(None, 512), (512, None), (0, 512), (-1, 5)]
+    )
+    def test_rejects_unusable_dimensions(self, width, height):
+        assert format_resolution(width, height) == "unknown"
+
+    def test_reads_shape_off_produced_images(self):
+        assert resolution_of_images([FakeImage(512, 512), FakeImage(512, 512)]) == (
+            "512x512",
+            2,
+            512 * 512,
+        )
+
+    def test_accepts_a_bare_image(self):
+        assert resolution_of_images(FakeImage(64, 64)) == ("64x64", 1, 4096)
+
+    def test_missing_output_is_unknown_not_an_error(self):
+        assert resolution_of_images(None) == ("unknown", 0, 0)
+        assert resolution_of_images([]) == ("unknown", 0, 0)
+
+    def test_output_without_a_size_still_counts_images(self):
+        assert resolution_of_images([object()]) == ("unknown", 1, 0)
+
+
+class TestSamplerName:
+    def test_prefers_the_public_diffusers_scheduler(self):
+        class EulerDiscreteScheduler:
+            pass
+
+        pipeline = types.SimpleNamespace(scheduler=EulerDiscreteScheduler())
+        assert sampler_name(pipeline) == "euler-discrete-scheduler"
+
+    def test_falls_back_to_the_tt_dit_solver(self):
+        class EulerSolver:
+            pass
+
+        assert (
+            sampler_name(types.SimpleNamespace(_solvers=[EulerSolver()]))
+            == "euler-solver"
+        )
+
+    def test_unknown_when_the_pipeline_exposes_neither(self):
+        assert sampler_name(object()) == "unknown"
+        assert sampler_name(None) == "unknown"
+
+
+class TestImageStageRecorder:
+    def test_records_every_stage_of_a_full_run(self):
+        model_type = "recorder-full"
+        recorder = ImageStageRecorder(model_type, "0", sampler="euler-solver", batch=1)
+        drive_full_run(recorder, steps=4)
+        recorder.flush([FakeImage()])
+
+        labels = denoise_labels(model_type)
+        assert sample("tt_media_server_image_denoise_steps_total", **labels) == 4
+        assert (
+            sample(
+                "tt_media_server_image_denoise_step_duration_seconds_count", **labels
+            )
+            == 4
+        )
+        assert (
+            sample("tt_media_server_image_denoise_duration_seconds_count", **labels)
+            == 1
+        )
+
+        shape = shape_labels(model_type)
+        assert (
+            sample("tt_media_server_image_vae_decode_duration_seconds_count", **shape)
+            == 1
+        )
+        assert sample("tt_media_server_image_vae_images_total", **shape) == 1
+        assert sample("tt_media_server_image_vae_pixels_total", **shape) == 1024 * 1024
+        assert (
+            sample("tt_media_server_image_engine_duration_seconds_count", **shape) == 1
+        )
+
+    def test_reports_the_wrapper_and_each_nested_encoder_separately(self):
+        model_type = "recorder-encoders"
+        recorder = ImageStageRecorder(model_type, "0", sampler="euler-solver", batch=1)
+        drive_full_run(recorder, encoders=("clip", "t5"))
+        recorder.flush([FakeImage()])
+
+        for encoder in ("all", "clip", "t5"):
+            count = sample(
+                "tt_media_server_image_conditioning_duration_seconds_count",
+                model_type=model_type,
+                device_id="0",
+                encoder=encoder,
+                batch="1",
+            )
+            assert count == 1, f"missing conditioning series for {encoder}"
+
+    def test_maps_the_qwen_encoder_span(self):
+        model_type = "recorder-qwen"
+        recorder = ImageStageRecorder(model_type, "0", sampler="euler-solver", batch=1)
+        drive_full_run(recorder, encoders=("qwen",))
+        recorder.flush([FakeImage()])
+
+        assert (
+            sample(
+                "tt_media_server_image_conditioning_duration_seconds_count",
+                model_type=model_type,
+                device_id="0",
+                encoder="qwen",
+                batch="1",
+            )
+            == 1
+        )
+
+    def test_publishes_nothing_until_flush(self):
+        model_type = "recorder-nopublish"
+        recorder = ImageStageRecorder(model_type, "0", sampler="euler-solver", batch=1)
+        drive_full_run(recorder)
+
+        assert recorder.step_seconds
+        assert (
+            sample(
+                "tt_media_server_image_denoise_steps_total",
+                **denoise_labels(model_type),
+            )
+            is None
+        )
+
+    def test_an_unclosed_section_is_never_reported(self):
+        recorder = ImageStageRecorder("recorder-unclosed", "0")
+        recorder(SectionStart("denoising"))
+        recorder(SectionStart("denoising_step_0"))
+        # Run dies here: no SectionEnd arrives.
+        assert recorder.denoise_seconds is None
+        assert recorder.step_seconds == []
+
+    def test_ignores_events_without_a_section_name(self):
+        recorder = ImageStageRecorder("recorder-denoisestep", "0")
+        recorder(DenoiseStep(step=1, total=10, sigma=0.5))
+        assert recorder.step_seconds == []
+        assert recorder.engine_seconds is None
+
+    def test_unknown_resolution_when_output_shape_is_unreadable(self):
+        model_type = "recorder-noshape"
+        recorder = ImageStageRecorder(model_type, "0", sampler="euler-solver", batch=1)
+        drive_full_run(recorder, steps=2)
+        recorder.flush(None)
+
+        labels = denoise_labels(model_type, resolution="unknown")
+        assert sample("tt_media_server_image_denoise_steps_total", **labels) == 2
+        # No shape, so no pixel/image throughput is invented.
+        assert (
+            sample(
+                "tt_media_server_image_vae_images_total",
+                **shape_labels(model_type, resolution="unknown"),
+            )
+            is None
+        )
+
+    def test_missing_device_id_is_labelled_unknown(self):
+        model_type = "recorder-nodevice"
+        recorder = ImageStageRecorder(model_type, None, sampler="euler-solver", batch=1)
+        drive_full_run(recorder, steps=1)
+        recorder.flush([FakeImage()])
+
+        assert (
+            sample(
+                "tt_media_server_image_denoise_steps_total",
+                **denoise_labels(model_type, device_id="unknown"),
+            )
+            == 1
+        )
+
+    def test_flush_swallows_telemetry_failures(self):
+        recorder = ImageStageRecorder("recorder-raises", "0")
+        drive_full_run(recorder, steps=1)
+        # A bad resolution type must not propagate into the inference path.
+        recorder.flush(images=object(), resolution=object())
+
+
+class TestRecordImageRun:
+    def test_step_count_fallback_spreads_the_loop_across_steps(self):
+        model_type = "record-fallback"
+        record_image_run(
+            model_type=model_type,
+            device_id="0",
+            resolution="1024x1024",
+            sampler="euler-solver",
+            batch=1,
+            denoise_seconds=4.0,
+            step_count=20,
+        )
+        labels = denoise_labels(model_type)
+        assert sample("tt_media_server_image_denoise_steps_total", **labels) == 20
+        assert (
+            sample(
+                "tt_media_server_image_denoise_step_duration_seconds_count", **labels
+            )
+            == 20
+        )
+        assert sample(
+            "tt_media_server_image_denoise_step_duration_seconds_sum", **labels
+        ) == pytest.approx(4.0)
+
+    def test_step_count_without_a_loop_time_still_advances_the_counter(self):
+        model_type = "record-stepsonly"
+        record_image_run(
+            model_type=model_type,
+            device_id="0",
+            resolution="1024x1024",
+            sampler="euler-solver",
+            batch=1,
+            engine_seconds=12.0,
+            step_count=9,
+        )
+        labels = denoise_labels(model_type)
+        assert sample("tt_media_server_image_denoise_steps_total", **labels) == 9
+        # Per-step latency is unknown here and must not be fabricated.
+        assert (
+            sample(
+                "tt_media_server_image_denoise_step_duration_seconds_count", **labels
+            )
+            is None
+        )
+
+    def test_per_step_observations_win_over_the_fallback(self):
+        model_type = "record-perstep"
+        record_image_run(
+            model_type=model_type,
+            device_id="0",
+            resolution="1024x1024",
+            sampler="euler-solver",
+            batch=1,
+            denoise_seconds=1.0,
+            step_seconds=[0.1, 0.2, 0.3],
+            step_count=99,
+        )
+        labels = denoise_labels(model_type)
+        assert sample("tt_media_server_image_denoise_steps_total", **labels) == 3
+        assert sample(
+            "tt_media_server_image_denoise_step_duration_seconds_sum", **labels
+        ) == pytest.approx(0.6)
+
+    def test_batch_is_stringified_for_the_label(self):
+        model_type = "record-batch"
+        record_image_run(
+            model_type=model_type,
+            device_id="0",
+            resolution="512x512",
+            sampler="euler-solver",
+            batch=4,
+            step_count=1,
+        )
+        assert (
+            sample(
+                "tt_media_server_image_denoise_steps_total",
+                **denoise_labels(model_type, resolution="512x512", batch="4"),
+            )
+            == 1
+        )
+
+    def test_pixels_scale_with_the_image_count(self):
+        model_type = "record-pixels"
+        record_image_run(
+            model_type=model_type,
+            device_id="0",
+            resolution="512x512",
+            sampler="euler-solver",
+            batch=2,
+            vae_seconds=1.0,
+            image_count=2,
+            pixels_per_image=512 * 512,
+        )
+        shape = shape_labels(model_type, resolution="512x512", batch="2")
+        assert sample("tt_media_server_image_vae_images_total", **shape) == 2
+        assert (
+            sample("tt_media_server_image_vae_pixels_total", **shape) == 2 * 512 * 512
+        )
+
+    def test_absent_stages_produce_no_series(self):
+        model_type = "record-sparse"
+        record_image_run(
+            model_type=model_type,
+            device_id="0",
+            resolution="1024x1024",
+            sampler="euler-solver",
+            batch=1,
+            engine_seconds=5.0,
+        )
+        labels = denoise_labels(model_type)
+        assert sample("tt_media_server_image_denoise_steps_total", **labels) is None
+        assert (
+            sample("tt_media_server_image_denoise_duration_seconds_count", **labels)
+            is None
+        )
+        shape = shape_labels(model_type)
+        assert (
+            sample("tt_media_server_image_vae_decode_duration_seconds_count", **shape)
+            is None
+        )
+        assert (
+            sample("tt_media_server_image_engine_duration_seconds_count", **shape) == 1
+        )
+
+    def test_long_observations_land_in_real_buckets_not_inf(self):
+        # A 90s run must stay distinguishable from a 900s one.
+        model_type = "record-buckets"
+        record_image_run(
+            model_type=model_type,
+            device_id="0",
+            resolution="1024x1024",
+            sampler="euler-solver",
+            batch=1,
+            engine_seconds=90.0,
+            denoise_seconds=80.0,
+            step_seconds=[20.0, 20.0, 20.0, 20.0],
+            vae_seconds=8.0,
+            conditioning_seconds={"all": 2.0},
+        )
+        labels = denoise_labels(model_type)
+        assert (
+            sample(
+                "tt_media_server_image_denoise_step_duration_seconds_bucket",
+                le="30.0",
+                **labels,
+            )
+            == 4
+        )
+        shape = shape_labels(model_type)
+        assert (
+            sample(
+                "tt_media_server_image_engine_duration_seconds_bucket",
+                le="120.0",
+                **shape,
+            )
+            == 1
+        )
+
+
+class TestSdxlSectionTimings:
+    @pytest.fixture
+    def profiler(self):
+        """Install a stand-in for tt-metal's global Profiler singleton."""
+        saved = {
+            k: sys.modules.get(k)
+            for k in ("models", "models.common", "models.common.utility_functions")
+        }
+
+        class FakeProfiler:
+            def __init__(self):
+                self.times = {}
+
+        module = types.ModuleType("models.common.utility_functions")
+        module.profiler = FakeProfiler()
+        sys.modules["models"] = types.ModuleType("models")
+        sys.modules["models.common"] = types.ModuleType("models.common")
+        sys.modules["models.common.utility_functions"] = module
+        try:
+            yield module.profiler
+        finally:
+            for key, value in saved.items():
+                if value is None:
+                    sys.modules.pop(key, None)
+                else:
+                    sys.modules[key] = value
+
+    def test_reads_the_spans_recorded_during_the_call(self, profiler):
+        with SdxlSectionTimings() as timings:
+            profiler.times["denoising_loop"] = [4.0]
+            profiler.times["vae_decode"] = [1.5]
+            profiler.times["image_gen"] = [5.5]
+
+        assert timings.denoise_seconds == 4.0
+        assert timings.vae_seconds == 1.5
+        assert timings.engine_seconds == 5.5
+
+    def test_discards_spans_left_over_from_warmup(self, profiler):
+        profiler.times["denoising_loop"] = [99.0]
+        profiler.times["vae_decode"] = [99.0]
+        profiler.times["image_gen"] = [99.0]
+
+        with SdxlSectionTimings() as timings:
+            assert "denoising_loop" not in profiler.times
+            profiler.times["denoising_loop"] = [4.0]
+
+        assert timings.denoise_seconds == 4.0
+        assert timings.vae_seconds is None
+
+    def test_takes_the_last_span_when_several_were_recorded(self, profiler):
+        with SdxlSectionTimings() as timings:
+            profiler.times["denoising_loop"] = [1.0, 2.0, 3.0]
+        assert timings.denoise_seconds == 3.0
+
+    def test_a_failed_run_reports_nothing(self, profiler):
+        timings = SdxlSectionTimings()
+        with pytest.raises(RuntimeError):
+            with timings:
+                profiler.times["denoising_loop"] = [4.0]
+                raise RuntimeError("inference blew up")
+
+        assert timings.denoise_seconds is None
+        assert timings.engine_seconds is None
+
+    def test_does_not_suppress_the_exception(self, profiler):
+        with pytest.raises(ValueError):
+            with SdxlSectionTimings():
+                raise ValueError("must propagate")
+
+    def test_no_tt_metal_means_no_readings_and_no_crash(self):
+        for key in ("models.common.utility_functions", "models.common", "models"):
+            sys.modules.pop(key, None)
+        with SdxlSectionTimings() as timings:
+            pass
+        assert timings.denoise_seconds is None
+        assert timings.vae_seconds is None
+        assert timings.engine_seconds is None

--- a/tt-media-server/tests/test_image_metrics.py
+++ b/tt-media-server/tests/test_image_metrics.py
@@ -610,7 +610,9 @@ class TestSdxlSectionTimings:
         assert timings.denoise_seconds == 4.0
         assert timings.vae_seconds is None
 
-    def test_missing_image_gen_span_falls_back_to_wall_clock(self, profiler, monkeypatch):
+    def test_missing_image_gen_span_falls_back_to_wall_clock(
+        self, profiler, monkeypatch
+    ):
         clock = {"t": 0.0}
         monkeypatch.setattr("telemetry.image_metrics._now", lambda: clock["t"])
         with SdxlSectionTimings() as timings:
@@ -643,8 +645,10 @@ class TestSdxlSectionTimings:
                 raise ValueError("must propagate")
 
     def test_no_tt_metal_falls_back_to_wall_clock_for_engine(self, monkeypatch):
+        # Restore afterwards: on a box with tt-metal installed these are real
+        # modules, and dropping them would leak into every later test.
         for key in ("models.common.utility_functions", "models.common", "models"):
-            sys.modules.pop(key, None)
+            monkeypatch.delitem(sys.modules, key, raising=False)
         clock = {"t": 1.0}
         monkeypatch.setattr("telemetry.image_metrics._now", lambda: clock["t"])
         with SdxlSectionTimings() as timings:

--- a/tt-media-server/tests/test_image_metrics.py
+++ b/tt-media-server/tests/test_image_metrics.py
@@ -463,6 +463,44 @@ class TestRecordImageRun:
                 batch="1",
             ) == pytest.approx(expected_sum)
 
+    def test_missing_engine_is_filled_from_known_stages(self):
+        model_type = "record-engine-fallback"
+        record_image_run(
+            model_type=model_type,
+            device_id="0",
+            resolution="1024x1024",
+            sampler="euler-solver",
+            batch=1,
+            denoise_seconds=4.0,
+            vae_seconds=1.0,
+            conditioning_seconds={"all": 0.5, "clip": 0.2},
+        )
+        shape = shape_labels(model_type)
+        assert (
+            sample("tt_media_server_image_engine_duration_seconds_count", **shape) == 1
+        )
+        assert sample(
+            "tt_media_server_image_engine_duration_seconds_sum", **shape
+        ) == pytest.approx(5.5)
+
+    def test_explicit_engine_is_not_replaced_by_stage_sum(self):
+        model_type = "record-engine-kept"
+        record_image_run(
+            model_type=model_type,
+            device_id="0",
+            resolution="1024x1024",
+            sampler="euler-solver",
+            batch=1,
+            engine_seconds=10.0,
+            denoise_seconds=4.0,
+            vae_seconds=1.0,
+            conditioning_seconds={"all": 0.5},
+        )
+        shape = shape_labels(model_type)
+        assert sample(
+            "tt_media_server_image_engine_duration_seconds_sum", **shape
+        ) == pytest.approx(10.0)
+
     def test_absent_stages_produce_no_series(self):
         model_type = "record-sparse"
         record_image_run(
@@ -572,6 +610,18 @@ class TestSdxlSectionTimings:
         assert timings.denoise_seconds == 4.0
         assert timings.vae_seconds is None
 
+    def test_missing_image_gen_span_falls_back_to_wall_clock(self, profiler, monkeypatch):
+        clock = {"t": 0.0}
+        monkeypatch.setattr("telemetry.image_metrics._now", lambda: clock["t"])
+        with SdxlSectionTimings() as timings:
+            clock["t"] = 5.0
+            profiler.times["denoising_loop"] = [4.0]
+            profiler.times["vae_decode"] = [1.0]
+
+        assert timings.engine_seconds == pytest.approx(5.0)
+        assert timings.denoise_seconds == 4.0
+        assert timings.vae_seconds == 1.0
+
     def test_takes_the_last_span_when_several_were_recorded(self, profiler):
         with SdxlSectionTimings() as timings:
             profiler.times["denoising_loop"] = [1.0, 2.0, 3.0]
@@ -592,11 +642,13 @@ class TestSdxlSectionTimings:
             with SdxlSectionTimings():
                 raise ValueError("must propagate")
 
-    def test_no_tt_metal_means_no_readings_and_no_crash(self):
+    def test_no_tt_metal_falls_back_to_wall_clock_for_engine(self, monkeypatch):
         for key in ("models.common.utility_functions", "models.common", "models"):
             sys.modules.pop(key, None)
+        clock = {"t": 1.0}
+        monkeypatch.setattr("telemetry.image_metrics._now", lambda: clock["t"])
         with SdxlSectionTimings() as timings:
-            pass
+            clock["t"] = 3.5
+        assert timings.engine_seconds == pytest.approx(2.5)
         assert timings.denoise_seconds is None
         assert timings.vae_seconds is None
-        assert timings.engine_seconds is None

--- a/tt-media-server/tests/test_sdxl_image_conditioning.py
+++ b/tt-media-server/tests/test_sdxl_image_conditioning.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""``torch_image`` detection for the SDXL image-conditioning metric.
+
+``torch_image`` is the third *positional* parameter of the img2img pipeline's
+``generate_input_tensors``, so reading it out of ``kwargs`` alone silently
+misses positional calls and stops counting image conditioning.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# conftest mocks utils.logger but only provides TTLogger;
+# base_sdxl_runner also needs log_exception_chain
+sys.modules["utils.logger"].log_exception_chain = MagicMock()
+
+from tt_model_runners.base_sdxl_runner import BaseSDXLRunner
+
+
+class _ConcreteSDXLRunner(BaseSDXLRunner):
+    def run(self, requests):
+        pass
+
+    def _load_pipeline(self):
+        pass
+
+    def _distribute_block(self):
+        pass
+
+    def _warmup_inference_block(self):
+        pass
+
+    def _prepare_input_tensors_for_iteration(self, tensors):
+        pass
+
+
+# The two real tt-metal signatures this has to resolve against.
+def _txt2img_signature(
+    all_prompt_embeds_torch,
+    torch_add_text_embeds,
+    start_latent_seed=None,
+    fixed_seed_for_batch=False,
+    timesteps=None,
+    sigmas=None,
+):
+    pass
+
+
+def _img2img_signature(
+    all_prompt_embeds_torch,
+    torch_add_text_embeds,
+    torch_image,
+    start_latent_seed=None,
+    fixed_seed_for_batch=False,
+    timesteps=None,
+    sigmas=None,
+    denoising_start=None,
+):
+    pass
+
+
+def _make_runner(signature):
+    runner = _ConcreteSDXLRunner.__new__(_ConcreteSDXLRunner)
+    runner.device_id = "test-device"
+    runner.logger = MagicMock()
+    runner.tt_sdxl = MagicMock()
+    # Only the signature matters; bind_partial never calls through.
+    runner.tt_sdxl.generate_input_tensors = signature
+    runner._conditioning_seconds = {}
+    runner._warming_up = False
+    return runner
+
+
+class TestHasImageConditioning:
+    def test_txt2img_has_none(self):
+        runner = _make_runner(_txt2img_signature)
+        assert not runner._has_image_conditioning(
+            (), {"all_prompt_embeds_torch": 1, "torch_add_text_embeds": 2}
+        )
+
+    def test_img2img_keyword(self):
+        runner = _make_runner(_img2img_signature)
+        assert runner._has_image_conditioning(
+            (),
+            {
+                "all_prompt_embeds_torch": 1,
+                "torch_add_text_embeds": 2,
+                "torch_image": "IMG",
+            },
+        )
+
+    def test_img2img_positional(self):
+        """The regression this guards: torch_image passed by position."""
+        runner = _make_runner(_img2img_signature)
+        assert runner._has_image_conditioning((1, 2, "IMG"), {})
+
+    def test_img2img_positional_none_is_not_conditioning(self):
+        runner = _make_runner(_img2img_signature)
+        assert not runner._has_image_conditioning((1, 2, None), {})
+
+    def test_explicit_none_keyword_is_not_conditioning(self):
+        runner = _make_runner(_img2img_signature)
+        assert not runner._has_image_conditioning((), {"torch_image": None})
+
+    def test_txt2img_positional(self):
+        runner = _make_runner(_txt2img_signature)
+        assert not runner._has_image_conditioning((1, 2), {})
+
+    def test_opaque_signature_under_reports_rather_than_raising(self):
+        """A callable whose signature is only (*args, **kwargs) cannot be bound.
+
+        Positional detection then degrades to "no image conditioning" -- it
+        under-reports instead of raising into the inference path. Real pipelines
+        expose a concrete signature; this is the safety net.
+        """
+        runner = _make_runner(MagicMock())
+        assert runner._has_image_conditioning((1, 2, "IMG"), {}) is False
+        # The keyword form still works even without an introspectable signature.
+        assert runner._has_image_conditioning((), {"torch_image": "IMG"}) is True
+
+    def test_too_many_positionals_does_not_raise(self):
+        runner = _make_runner(_txt2img_signature)
+        assert not runner._has_image_conditioning(tuple(range(50)), {})
+
+
+class TestGenerateInputTensorsRecording:
+    def test_image_span_recorded_for_positional_img2img(self):
+        # Keep the real function as the attribute: wrapping it in a MagicMock
+        # would erase the signature that positional detection binds against.
+        runner = _make_runner(_img2img_signature)
+        runner._generate_input_tensors(1, 2, "IMG")
+        assert "image" in runner._conditioning_seconds
+        assert runner._conditioning_seconds["image"] >= 0.0
+        # Nested spans fold into the pipeline-level total on this path.
+        assert runner._conditioning_seconds["all"] == pytest.approx(
+            runner._conditioning_seconds["image"]
+        )
+
+    def test_no_image_span_for_txt2img(self):
+        runner = _make_runner(_txt2img_signature)
+        runner._generate_input_tensors(
+            all_prompt_embeds_torch=1, torch_add_text_embeds=2
+        )
+        assert runner._conditioning_seconds == {}
+
+    def test_warmup_is_not_recorded(self):
+        runner = _make_runner(_img2img_signature)
+        runner._warming_up = True
+        runner._generate_input_tensors(1, 2, "IMG")
+        assert runner._conditioning_seconds == {}

--- a/tt-media-server/tt_model_runners/base_sdxl_runner.py
+++ b/tt-media-server/tt_model_runners/base_sdxl_runner.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 import asyncio
+import inspect
 import os
 import time
 from abc import abstractmethod
@@ -276,17 +277,36 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
         return result
 
     def _generate_input_tensors(self, *args, **kwargs):
-        """Time VAE-encode of the input image on img2img / inpaint.
+        """Time image conditioning on img2img / inpaint.
 
         txt2img has no ``torch_image`` and is not counted as conditioning.
+
+        ``torch_image`` is the third *positional* parameter of the img2img
+        pipeline's ``generate_input_tensors``, so the argument is resolved
+        against the real signature rather than read out of ``kwargs`` -- a
+        positional call would otherwise silently stop counting.
         """
         start = time.perf_counter()
         result = self.tt_sdxl.generate_input_tensors(*args, **kwargs)
-        if not self._warming_up and kwargs.get("torch_image") is not None:
+        if not self._warming_up and self._has_image_conditioning(args, kwargs):
             add_conditioning_seconds(
                 self._conditioning_seconds, "image", time.perf_counter() - start
             )
         return result
+
+    def _has_image_conditioning(self, args, kwargs) -> bool:
+        """True when ``generate_input_tensors`` was given a ``torch_image``."""
+        if "torch_image" in kwargs:
+            return kwargs["torch_image"] is not None
+        if not args:
+            return False
+        try:
+            bound = inspect.signature(self.tt_sdxl.generate_input_tensors).bind_partial(
+                *args, **kwargs
+            )
+        except (TypeError, ValueError):
+            return False
+        return bound.arguments.get("torch_image") is not None
 
     def _ttnn_inference(self, tensors, prompts, needed_padding):
         images = []

--- a/tt-media-server/tt_model_runners/base_sdxl_runner.py
+++ b/tt-media-server/tt_model_runners/base_sdxl_runner.py
@@ -18,6 +18,7 @@ from models.demos.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import (
 )
 from telemetry.image_metrics import (
     SdxlSectionTimings,
+    add_conditioning_seconds,
     record_image_run,
     resolution_of_images,
     sampler_name,
@@ -262,13 +263,29 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
         """Time tt_sdxl.encode_prompts().
 
         It drives both CLIP encoders in one call, so there is no per-encoder
-        breakdown to report -- only ``encoder="all"``.
+        breakdown to report -- only ``encoder="all"`` until image encode is
+        added by :meth:`_generate_input_tensors`.
         """
         self._conditioning_seconds = {}
         start = time.perf_counter()
         result = self.tt_sdxl.encode_prompts(*args, **kwargs)
         if not self._warming_up:
-            self._conditioning_seconds = {"all": time.perf_counter() - start}
+            add_conditioning_seconds(
+                self._conditioning_seconds, "all", time.perf_counter() - start
+            )
+        return result
+
+    def _generate_input_tensors(self, *args, **kwargs):
+        """Time VAE-encode of the input image on img2img / inpaint.
+
+        txt2img has no ``torch_image`` and is not counted as conditioning.
+        """
+        start = time.perf_counter()
+        result = self.tt_sdxl.generate_input_tensors(*args, **kwargs)
+        if not self._warming_up and kwargs.get("torch_image") is not None:
+            add_conditioning_seconds(
+                self._conditioning_seconds, "image", time.perf_counter() - start
+            )
         return result
 
     def _ttnn_inference(self, tensors, prompts, needed_padding):

--- a/tt-media-server/tt_model_runners/base_sdxl_runner.py
+++ b/tt-media-server/tt_model_runners/base_sdxl_runner.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import os
+import time
 from abc import abstractmethod
 
 import ttnn
@@ -14,6 +15,12 @@ from models.demos.stable_diffusion_xl_base.tests.test_common import (
 )
 from models.demos.stable_diffusion_xl_base.tt.tt_sdxl_pipeline import (
     TtSDXLPipeline,
+)
+from telemetry.image_metrics import (
+    SdxlSectionTimings,
+    record_image_run,
+    resolution_of_images,
+    sampler_name,
 )
 from telemetry.telemetry_client import TelemetryEvent
 from tt_model_runners.base_metal_device_runner import BaseMetalDeviceRunner
@@ -30,6 +37,10 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
         self.pipeline = None
         self._current_lora_path: str | None = None
         self._current_lora_scale: float | None = None
+        # Measured around encode_prompts(), flushed in _ttnn_inference().
+        self._conditioning_seconds: dict[str, float] = {}
+        # Warmup calls run(); recording it would skew the stage metrics.
+        self._warming_up = False
 
     def get_pipeline_device_params(self):
         device_params = {
@@ -119,6 +130,7 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
 
         warmup_inference_timeout = 1000
 
+        self._warming_up = True
         try:
             await asyncio.wait_for(
                 asyncio.to_thread(self._warmup_inference_block),
@@ -137,6 +149,8 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
                 e,
             )
             raise
+        finally:
+            self._warming_up = False
 
         self.logger.info(f"Device {self.device_id}: Model warmup completed")
 
@@ -244,12 +258,28 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
                     f"Failed to load LoRA adapter '{requested_path}': {e}"
                 ) from e
 
+    def _encode_prompts(self, *args, **kwargs):
+        """Time tt_sdxl.encode_prompts().
+
+        It drives both CLIP encoders in one call, so there is no per-encoder
+        breakdown to report -- only ``encoder="all"``.
+        """
+        self._conditioning_seconds = {}
+        start = time.perf_counter()
+        result = self.tt_sdxl.encode_prompts(*args, **kwargs)
+        if not self._warming_up:
+            self._conditioning_seconds = {"all": time.perf_counter() - start}
+        return result
+
     def _ttnn_inference(self, tensors, prompts, needed_padding):
         images = []
         self.logger.info(f"Device {self.device_id}: Starting ttnn inference...")
         self._prepare_input_tensors_for_iteration(tensors)
 
-        imgs = self.tt_sdxl.generate_images()
+        # generate_images() resets the step count when it returns, so read it now.
+        num_steps = getattr(self.tt_sdxl, "num_inference_steps", None)
+        with SdxlSectionTimings() as timings:
+            imgs = self.tt_sdxl.generate_images()
 
         for idx, img in enumerate(imgs):
             if idx >= self.batch_size - needed_padding:
@@ -259,7 +289,44 @@ class BaseSDXLRunner(BaseMetalDeviceRunner):
             img = self.pipeline.image_processor.postprocess(img, output_type="pil")[0]
             images.append(img)
 
+        self._record_image_stage_metrics(images, needed_padding, num_steps, timings)
+
         return images
+
+    def _record_image_stage_metrics(self, images, needed_padding, num_steps, timings):
+        """Export the stage metrics for one SDXL generation."""
+        if self._warming_up:
+            return
+        try:
+            conditioning = self._conditioning_seconds
+            self._conditioning_seconds = {}
+
+            resolution, image_count, pixels = resolution_of_images(images)
+            batch = max(self.batch_size - needed_padding, len(images), 1)
+
+            # image_gen covers denoising + VAE only; add conditioning back so
+            # the engine total matches tt_dit's "total" span.
+            engine_seconds = timings.engine_seconds
+            if engine_seconds is not None and "all" in conditioning:
+                engine_seconds += conditioning["all"]
+
+            record_image_run(
+                model_type=self.settings.model_runner,
+                device_id=self.device_id,
+                resolution=resolution,
+                sampler=sampler_name(self.pipeline),
+                batch=batch,
+                engine_seconds=engine_seconds,
+                denoise_seconds=timings.denoise_seconds,
+                step_count=num_steps,
+                vae_seconds=timings.vae_seconds,
+                conditioning_seconds=conditioning,
+                image_count=image_count,
+                pixels_per_image=pixels,
+            )
+        except Exception as exc:
+            # Never fail an inference that already succeeded.
+            self.logger.warning(f"Failed to record image stage metrics: {exc}")
 
     def is_request_batchable(self, request, batch=None):
         if len(batch or []) >= self.max_batch_size:

--- a/tt-media-server/tt_model_runners/dit_runners.py
+++ b/tt-media-server/tt_model_runners/dit_runners.py
@@ -41,6 +41,7 @@ from models.tt_dit.pipelines.wan.pipeline_wan_i2v import (
     WanPipelineI2V,
 )
 from PIL import Image
+from telemetry.image_metrics import ImageStageRecorder, sampler_name
 from telemetry.telemetry_client import TelemetryEvent
 from tt_model_runners.base_metal_device_runner import BaseMetalDeviceRunner
 from utils.decorators import log_execution_time
@@ -80,6 +81,8 @@ class TTDiTRunner(BaseMetalDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
         self.pipeline = None
+        # Warmup calls run(); recording it would skew the stage metrics.
+        self._warming_up = False
 
     def _configure_fabric(self, updated_device_params):
         try:
@@ -163,18 +166,22 @@ class TTDiTRunner(BaseMetalDeviceRunner):
 
         # we use model_construct to create the request without validation
         # (warmup uses 2 inference steps which is below the normal minimum)
-        if self.settings.model_service == ModelServices.IMAGE.value:
-            self.run(
-                [
-                    ImageGenerateRequest.model_construct(
-                        prompt="Sunrise on a beach",
-                        negative_prompt="",
-                        num_inference_steps=2,
-                    )
-                ],
-            )
-        elif self.settings.model_service == ModelServices.VIDEO.value:
-            self.run([self._build_warmup_video_request()])
+        self._warming_up = True
+        try:
+            if self.settings.model_service == ModelServices.IMAGE.value:
+                self.run(
+                    [
+                        ImageGenerateRequest.model_construct(
+                            prompt="Sunrise on a beach",
+                            negative_prompt="",
+                            num_inference_steps=2,
+                        )
+                    ],
+                )
+            elif self.settings.model_service == ModelServices.VIDEO.value:
+                self.run([self._build_warmup_video_request()])
+        finally:
+            self._warming_up = False
 
         self.logger.info(f"Device {self.device_id}: Model warmup completed")
 
@@ -198,12 +205,26 @@ class TTDiTRunner(BaseMetalDeviceRunner):
     def run(self, requests: list[ImageGenerateRequest]):
         self.logger.debug(f"Device {self.device_id}: Running inference")
         request = requests[0]
+        # run_single_prompt is single-prompt by construction, hence batch=1.
+        recorder = (
+            None
+            if self._warming_up
+            else ImageStageRecorder(
+                model_type=self.settings.model_runner,
+                device_id=self.device_id,
+                sampler=sampler_name(self.pipeline),
+                batch=1,
+            )
+        )
         image = self.pipeline.run_single_prompt(
             prompt=request.prompt,
             negative_prompt=request.negative_prompt,
             num_inference_steps=request.num_inference_steps,
             seed=int(request.seed or 0),
+            on_event=recorder,
         )
+        if recorder is not None:
+            recorder.flush(image)
         self.logger.debug(f"Device {self.device_id}: Inference completed")
         return image
 

--- a/tt-media-server/tt_model_runners/sdxl_edit_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_edit_runner_trace.py
@@ -130,7 +130,7 @@ class TTSDXLEditRunner(TTSDXLImageToImageRunner):
         self.logger.debug(f"Device {self.device_id}: Starting text encoding...")
         self.tt_sdxl.compile_text_encoding()
 
-        all_prompt_embeds_torch, torch_add_text_embeds = self.tt_sdxl.encode_prompts(
+        all_prompt_embeds_torch, torch_add_text_embeds = self._encode_prompts(
             prompts, negative_prompts, prompts_2, negative_prompt_2
         )
 

--- a/tt-media-server/tt_model_runners/sdxl_edit_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_edit_runner_trace.py
@@ -144,7 +144,7 @@ class TTSDXLEditRunner(TTSDXLImageToImageRunner):
             tt_mask,
             tt_prompt_embeds,
             tt_add_text_embeds,
-        ) = self.tt_sdxl.generate_input_tensors(
+        ) = self._generate_input_tensors(
             torch_image=images,
             torch_masked_image=masked_images,
             torch_mask=masks,

--- a/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
@@ -94,14 +94,12 @@ class TTSDXLGenerateRunnerTrace(BaseSDXLRunner):
             prompts, negative_prompts, prompts_2, negative_prompt_2
         )
 
-        tt_latents, tt_prompt_embeds, tt_add_text_embeds = (
-            self._generate_input_tensors(
-                all_prompt_embeds_torch=all_prompt_embeds_torch,
-                torch_add_text_embeds=torch_add_text_embeds,
-                start_latent_seed=requests[0].seed,
-                timesteps=requests[0].timesteps,
-                sigmas=requests[0].sigmas,
-            )
+        tt_latents, tt_prompt_embeds, tt_add_text_embeds = self._generate_input_tensors(
+            all_prompt_embeds_torch=all_prompt_embeds_torch,
+            torch_add_text_embeds=torch_add_text_embeds,
+            start_latent_seed=requests[0].seed,
+            timesteps=requests[0].timesteps,
+            sigmas=requests[0].sigmas,
         )
 
         tensors = (

--- a/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
@@ -90,7 +90,7 @@ class TTSDXLGenerateRunnerTrace(BaseSDXLRunner):
         (
             all_prompt_embeds_torch,
             torch_add_text_embeds,
-        ) = self.tt_sdxl.encode_prompts(
+        ) = self._encode_prompts(
             prompts, negative_prompts, prompts_2, negative_prompt_2
         )
 

--- a/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_generate_runner_trace.py
@@ -95,7 +95,7 @@ class TTSDXLGenerateRunnerTrace(BaseSDXLRunner):
         )
 
         tt_latents, tt_prompt_embeds, tt_add_text_embeds = (
-            self.tt_sdxl.generate_input_tensors(
+            self._generate_input_tensors(
                 all_prompt_embeds_torch=all_prompt_embeds_torch,
                 torch_add_text_embeds=torch_add_text_embeds,
                 start_latent_seed=requests[0].seed,

--- a/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
@@ -130,7 +130,7 @@ class TTSDXLImageToImageRunner(BaseSDXLRunner):
         (
             all_prompt_embeds_torch,
             torch_add_text_embeds,
-        ) = self.tt_sdxl.encode_prompts(
+        ) = self._encode_prompts(
             prompts, negative_prompts, prompts_2, negative_prompt_2
         )
 

--- a/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
@@ -139,15 +139,13 @@ class TTSDXLImageToImageRunner(BaseSDXLRunner):
 
         self.logger.info(f"Device {self.device_id}: Generating input tensors...")
 
-        tt_latents, tt_prompt_embeds, tt_add_text_embeds = (
-            self._generate_input_tensors(
-                torch_image=images,
-                all_prompt_embeds_torch=all_prompt_embeds_torch,
-                torch_add_text_embeds=torch_add_text_embeds,
-                start_latent_seed=requests[0].seed,
-                timesteps=requests[0].timesteps,
-                sigmas=requests[0].sigmas,
-            )
+        tt_latents, tt_prompt_embeds, tt_add_text_embeds = self._generate_input_tensors(
+            torch_image=images,
+            all_prompt_embeds_torch=all_prompt_embeds_torch,
+            torch_add_text_embeds=torch_add_text_embeds,
+            start_latent_seed=requests[0].seed,
+            timesteps=requests[0].timesteps,
+            sigmas=requests[0].sigmas,
         )
 
         self.logger.debug(f"Device {self.device_id}: Preparing input tensors...")

--- a/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
+++ b/tt-media-server/tt_model_runners/sdxl_image_to_image_runner_trace.py
@@ -140,7 +140,7 @@ class TTSDXLImageToImageRunner(BaseSDXLRunner):
         self.logger.info(f"Device {self.device_id}: Generating input tensors...")
 
         tt_latents, tt_prompt_embeds, tt_add_text_embeds = (
-            self.tt_sdxl.generate_input_tensors(
+            self._generate_input_tensors(
                 torch_image=images,
                 all_prompt_embeds_torch=all_prompt_embeds_torch,
                 torch_add_text_embeds=torch_add_text_embeds,

--- a/tt-media-server/tt_model_runners/z_image_turbo_runner.py
+++ b/tt-media-server/tt_model_runners/z_image_turbo_runner.py
@@ -9,6 +9,7 @@ import time
 import ttnn
 from domain.image_generate_request import ImageGenerateRequest
 from tt_model_runners.base_metal_device_runner import BaseMetalDeviceRunner
+from telemetry.image_metrics import record_image_run, resolution_of_images
 from telemetry.telemetry_client import TelemetryEvent
 from utils.decorators import log_execution_time
 
@@ -72,15 +73,37 @@ class ZImageTurboRunner(BaseMetalDeviceRunner):
         request = requests[0]
         seed = int(request.seed or 0)
 
-        t_start = time.time()
+        t_start = time.perf_counter()
         image = self.pipeline.forward(
             prompt=request.prompt,
             steps=DEFAULT_STEPS,
             seed=seed,
         )
-        elapsed = time.time() - t_start
+        elapsed = time.perf_counter() - t_start
 
         self.logger.info(
             f"Device {self.device_id}: Generated in {elapsed:.2f}s  seed={seed}"
         )
+        self._record_image_stage_metrics([image], elapsed)
         return [image]
+
+    def _record_image_stage_metrics(self, images, elapsed):
+        """Export what this runner can see of the image stages.
+
+        forward() is a single opaque call with no stage boundaries, so only the
+        engine total and the fixed step count are knowable. The denoise / VAE /
+        conditioning splits stay absent rather than guessed.
+        """
+        try:
+            resolution, _, _ = resolution_of_images(images)
+            record_image_run(
+                model_type=self.settings.model_runner,
+                device_id=self.device_id,
+                resolution=resolution,
+                sampler="unknown",
+                batch=1,
+                engine_seconds=elapsed,
+                step_count=DEFAULT_STEPS,
+            )
+        except Exception as exc:
+            self.logger.warning(f"Failed to record image stage metrics: {exc}")


### PR DESCRIPTION
Adds the `tt_media_server_image_*` metric family: denoising throughput, VAE decode throughput, conditioning-encoder time + a 14-panel "Image Generation" row on the Python dashboard.


## New metrics

| Metric | Type | Labels | Covers |
|---|---|---|---|
| `tt_media_server_image_denoise_steps_total` | Counter | `model_type`, `device_id`, `resolution`, `sampler`, `batch` | Completed diffusion denoising steps → denoising throughput (steps/s). Incremented per real step where the pipeline reports them, otherwise bumped once by the run's step count. |
| `tt_media_server_image_denoise_step_duration_seconds` | Histogram | `model_type`, `device_id`, `resolution`, `sampler`, `batch` | Per-step denoising latency (p50/p99, heatmap). Only observed when the pipeline exposes real per-step spans — never fabricated from the loop mean. Buckets 10 ms → 60 s. |
| `tt_media_server_image_denoise_duration_seconds` | Histogram | `model_type`, `device_id`, `resolution`, `sampler`, `batch` | Duration of the whole denoising loop; the denoising slice of the engine-time split. Buckets 50 ms → 300 s. |
| `tt_media_server_image_vae_decode_duration_seconds` | Histogram | `model_type`, `device_id`, `resolution`, `batch` | Latent→pixel VAE decode latency (p50/p99) and the VAE slice of the engine-time split. Buckets 50 ms → 300 s. |
| `tt_media_server_image_vae_images_total` | Counter | `model_type`, `device_id`, `resolution`, `batch` | Images decoded out of latents → VAE throughput in images/s. |
| `tt_media_server_image_vae_pixels_total` | Counter | `model_type`, `device_id`, `resolution`, `batch` | Pixels decoded out of latents → resolution-normalized VAE throughput (MP/s). |
| `tt_media_server_image_conditioning_duration_seconds` | Histogram | `model_type`, `device_id`, `encoder`, `batch` | Time spent encoding conditioning inputs (text / image / control), broken out per encoder. Buckets 50 ms → 300 s. |
| `tt_media_server_image_engine_duration_seconds` | Histogram | `model_type`, `device_id`, `resolution`, `batch` | Total in-engine generation time; the denominator for conditioning-as-%-of-engine. Falls back to denoise + VAE + `encoder="all"` when no total span exists. Buckets 0.5 s → 1200 s. |

>  SDXL base 1.0 (tt-sdxl-trace) on a Blackhole p300x2 

<img width="1787" height="508" alt="Screenshot 2026-08-20 at 17 32 04" src="https://github.com/user-attachments/assets/c012b413-a46f-4b09-8235-6298b32dd31e" />
<img width="1787" height="863" alt="Screenshot 2026-08-20 at 17 31 46" src="https://github.com/user-attachments/assets/db486e0b-2f5e-45c8-8bf2-a7e79ef0eea5" />