### PR TITLE
Add Qwen3-4B support on Blackhole P300

### DIFF
--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -341,6 +341,31 @@ templates:
       tool_call_parser_name: hermes
 
 - weights:
+    - Qwen/Qwen3-4B
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=19.2.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.5.0"
+      mode: STRICT
+  inference_engine: VLLM
+  device_model_specs:
+    # A single P300 card is a two-chip P150x2 mesh.
+    - device: P300
+      max_concurrency: 32
+      max_context: 40960
+      default_impl: true
+      env_vars:
+        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto"
+  status: EXPERIMENTAL
+  metadata:
+    Qwen/Qwen3-4B:
+      reasoning_parser_name: qwen3
+      tool_call_parser_name: hermes
+
+- weights:
     - Qwen/Qwen3-8B
   impl: tt_transformers
   system_requirements:

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -354,11 +354,13 @@ templates:
   device_model_specs:
     # A single P300 card is a two-chip P150x2 mesh.
     - device: P300
-      max_concurrency: 32
+      max_concurrency: 16
       max_context: 40960
       default_impl: true
       env_vars:
         TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto"
+      override_tt_config:
+        trace_region_size: 402653184  # 384 MiB for retained multi-shape trace captures
   status: EXPERIMENTAL
   metadata:
     Qwen/Qwen3-4B:


### PR DESCRIPTION
## Summary
- Add Qwen3-4B using `tt_transformers` and vLLM on P300/P150x2.
- Support 40,960-token context and concurrency 16.
- Allocate 384 MiB for retained trace captures.

## Benchmarks
All 19 sweep points passed.

| Conc. | Requests | ISL | OSL | TTFT ms | TPOT ms | Input TPS | Output TPS | Total TPS |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 8 | 128 | 128 | 347.6 | 19.9 | 44.5 | 44.5 | 89.0 |
| 16 | 128 | 128 | 128 | 898.2 | 21.8 | 558.7 | 558.7 | 1117.4 |
| 1 | 4 | 128 | 1024 | 39.6 | 20.3 | 6.1 | 49.2 | 55.3 |
| 16 | 64 | 128 | 1024 | 428.5 | 21.5 | 91.3 | 730.1 | 821.4 |
| 1 | 4 | 1024 | 128 | 76.0 | 20.8 | 377.0 | 47.1 | 424.2 |
| 16 | 64 | 1024 | 128 | 1002.5 | 23.2 | 4152.2 | 519.0 | 4671.2 |
| 1 | 4 | 2048 | 128 | 139.8 | 21.8 | 703.6 | 44.0 | 747.6 |
| 16 | 64 | 2048 | 128 | 2305.3 | 25.9 | 5852.4 | 365.8 | 6218.1 |
| 1 | 4 | 4096 | 128 | 228.8 | 23.7 | 1262.2 | 39.4 | 1301.6 |
| 9 | 36 | 4096 | 128 | 3094.1 | 27.4 | 5612.2 | 175.4 | 5787.6 |
| 1 | 2 | 8192 | 128 | 364.4 | 27.8 | 2105.5 | 32.9 | 2138.4 |
| 4 | 8 | 8192 | 128 | 1578.3 | 30.9 | 5954.8 | 93.0 | 6047.8 |
| 1 | 2 | 8192 | 1024 | 102.2 | 28.2 | 282.6 | 35.3 | 317.9 |
| 4 | 8 | 8192 | 1024 | 356.5 | 28.4 | 1114.1 | 139.3 | 1253.4 |
| 1 | 2 | 10000 | 1024 | 222.6 | 30.0 | 323.0 | 33.1 | 356.0 |
| 3 | 6 | 10000 | 1024 | 583.0 | 30.7 | 938.2 | 96.1 | 1034.2 |
| 1 | 2 | 16384 | 128 | 616.3 | 35.8 | 3173.9 | 24.8 | 3198.7 |
| 2 | 4 | 16384 | 128 | 931.6 | 38.1 | 5684.4 | 44.4 | 5728.8 |
| 1 | 1 | 32768 | 128 | 268.2 | 51.9 | 4778.8 | 18.7 | 4797.4 |

## Eval
GPQA Diamond evaluation is in progress; results will be added in a follow-up comment.