### PR TITLE
[Helm v0.2] CI: nightly real-hardware smoke for the chart

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,8 +2,5 @@ self-hosted-runner:
   labels:
     - tt-ubuntu-2204-large-stable
     - tt-ubuntu-2204-xlarge-stable
-    # Tenstorrent hardware pools (shared with tt-operator's integration-rke2):
-    # ephemeral KVM VMs with a card passed through and tt-kmd preloaded. Used by
-    # helm-hw-smoke.yml.
     - tt-ubuntu-2204-n150-stable
     - tt-ubuntu-2204-bh-loudbox-viommu-stable

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,8 @@ self-hosted-runner:
   labels:
     - tt-ubuntu-2204-large-stable
     - tt-ubuntu-2204-xlarge-stable
+    # Tenstorrent hardware pools (shared with tt-operator's integration-rke2):
+    # ephemeral KVM VMs with a card passed through and tt-kmd preloaded. Used by
+    # helm-hw-smoke.yml.
+    - tt-ubuntu-2204-n150-stable
+    - tt-ubuntu-2204-bh-loudbox-viommu-stable

--- a/.github/scripts/helm_hw_smoke.sh
+++ b/.github/scripts/helm_hw_smoke.sh
@@ -16,6 +16,10 @@
 #                                   Never the steady state: the smoke guards
 #                                   that pin.
 #   HUGEPAGES                       true|false (default: probe the node)
+#   POD_PROXY                       http proxy the Pod should use for weight
+#                                   downloads (default: $HTTPS_PROXY with its
+#                                   host resolved to an IP, since the Pod's DNS
+#                                   cannot resolve the runner's proxy Service)
 #   HUGEPAGES_SIZE                  hugepages-1Gi request/limit when they are on
 #                                   (default: the node's allocatable). The chart
 #                                   asks for 32Gi regardless of board count,
@@ -43,6 +47,7 @@ RELEASE="${RELEASE:-ttis-hw}"
 IMAGE_TAG="${IMAGE_TAG:-}"
 HUGEPAGES="${HUGEPAGES:-}"
 HUGEPAGES_SIZE="${HUGEPAGES_SIZE:-}"
+POD_PROXY="${POD_PROXY:-}"
 HF_TOKEN="${HF_TOKEN:-}"
 HF_CACHE_DIR="${HF_CACHE_DIR:-}"
 PULL_SECRET="${PULL_SECRET:-}"
@@ -105,12 +110,24 @@ HELM_SET+=(--set "hugepages.enabled=$HUGEPAGES")
 # The chart's 32Gi request is Galaxy-sized and fixed, so on a smaller host the
 # Pod is unschedulable for a reason that has nothing to do with what we assert.
 # Capacity adaptation, like CPU_REQUEST / MEMORY_REQUEST.
-if [ "$HUGEPAGES" = "true" ]; then
-  [ -n "$HUGEPAGES_SIZE" ] || HUGEPAGES_SIZE="$hp_alloc"
-  if [ -n "$HUGEPAGES_SIZE" ]; then
-    info "hugepages request/limit -> $HUGEPAGES_SIZE (chart default is 32Gi)"
-    HELM_SET+=(--set "defaults.resources.requests.hugepages-1Gi=$HUGEPAGES_SIZE"
-               --set "defaults.resources.limits.hugepages-1Gi=$HUGEPAGES_SIZE")
+if [ "$HUGEPAGES" = "true" ] && [ -z "$HUGEPAGES_SIZE" ]; then
+  HUGEPAGES_SIZE="$hp_alloc"
+fi
+
+# The Pod downloads weights from HuggingFace, and on a proxied runner it cannot
+# inherit the proxy: the host resolves the proxy Service through the outer
+# cluster's DNS, the Pod cannot. Resolve it to an IP, as tt-operator does for
+# its own spawned pods. No-op where nothing is proxied.
+if [ -z "$POD_PROXY" ] && [ -n "${HTTPS_PROXY:-${https_proxy:-}}" ]; then
+  proxy_url="${HTTPS_PROXY:-$https_proxy}"
+  proxy_host="$(printf '%s' "$proxy_url" | sed -E 's,^[a-z]+://,,; s,/.*$,,; s,:[0-9]+$,,')"
+  proxy_port="$(printf '%s' "$proxy_url" | sed -nE 's,.*:([0-9]+)/?$,\1,p')"
+  proxy_ip="$(getent hosts "$proxy_host" | awk '{print $1; exit}' || true)"
+  if [ -n "$proxy_ip" ]; then
+    POD_PROXY="http://${proxy_ip}:${proxy_port:-3128}"
+    info "pod proxy -> $POD_PROXY (from $proxy_url)"
+  else
+    warn "could not resolve the proxy host $proxy_host — the Pod will have no egress and a weight download will fail"
   fi
 fi
 
@@ -122,12 +139,37 @@ if [ -z "$API_KEY" ]; then
 fi
 HELM_SET+=(--set "auth.apiKey=$API_KEY")
 
-# A values file, not --set: the path contains the model name, and model names
-# contain dots that --set reads as separators.
+# A values file, not --set: the row path contains the model name (and model names
+# contain dots that --set reads as separators), and NO_PROXY contains commas.
+if [ -n "$IMAGE_TAG" ] || [ -n "$CPU_REQUEST" ] || [ -n "$MEMORY_REQUEST" ] \
+   || [ -n "$HUGEPAGES_SIZE" ] || [ -n "$POD_PROXY" ]; then
+  OVERRIDES="$(mktemp /tmp/hw-smoke-overrides.XXXXXX)"
+  : > "$OVERRIDES"
+  if [ -n "$HUGEPAGES_SIZE" ] || [ -n "$POD_PROXY" ]; then
+    {
+      echo "defaults:"
+      if [ -n "$HUGEPAGES_SIZE" ]; then
+        echo "  resources:"
+        echo "    requests:"
+        echo "      hugepages-1Gi: \"$HUGEPAGES_SIZE\""
+        echo "    limits:"
+        echo "      hugepages-1Gi: \"$HUGEPAGES_SIZE\""
+      fi
+      if [ -n "$POD_PROXY" ]; then
+        echo "  extraEnv:"
+        echo "    - name: HTTPS_PROXY"
+        echo "      value: \"$POD_PROXY\""
+        echo "    - name: HTTP_PROXY"
+        echo "      value: \"$POD_PROXY\""
+        echo "    - name: NO_PROXY"
+        echo "      value: \"${NO_PROXY:-${no_proxy:-}}\""
+      fi
+    } >> "$OVERRIDES"
+  fi
+fi
 if [ -n "$IMAGE_TAG" ] || [ -n "$CPU_REQUEST" ] || [ -n "$MEMORY_REQUEST" ]; then
   { [ -n "$ENGINE" ] && [ -n "$IMPL" ]; } \
     || fail "IMAGE_TAG / CPU_REQUEST / MEMORY_REQUEST address models.<model>.<engine>.<device>.impls.<impl>, so ENGINE and IMPL must be set explicitly"
-  OVERRIDES="$(mktemp /tmp/hw-smoke-overrides.XXXXXX)"
   {
     echo "models:"
     echo "  \"$MODEL\":"
@@ -145,8 +187,10 @@ if [ -n "$IMAGE_TAG" ] || [ -n "$CPU_REQUEST" ] || [ -n "$MEMORY_REQUEST" ]; the
       [ -n "$CPU_REQUEST" ]    && echo "                cpu: \"$CPU_REQUEST\""
       [ -n "$MEMORY_REQUEST" ] && echo "                memory: \"$MEMORY_REQUEST\""
     fi
-  } > "$OVERRIDES"
-  info "row overrides:"
+  } >> "$OVERRIDES"
+fi
+if [ -n "$OVERRIDES" ]; then
+  info "overrides:"
   sed 's/^/       /' "$OVERRIDES"
   HELM_SET+=(-f "$OVERRIDES")
 fi

--- a/.github/scripts/helm_hw_smoke.sh
+++ b/.github/scripts/helm_hw_smoke.sh
@@ -1,69 +1,32 @@
 #!/usr/bin/env bash
-# ---------------------------------------------------------------------------
-# Hardware smoke — the chart's runtime assumptions, on real silicon.
+# Runs the chart on a Tenstorrent board (nightly / on-demand, see
+# .github/workflows/helm-hw-smoke.yml). Needs a cluster where tt-operator is
+# already publishing devices: hw_smoke_bootstrap.sh makes one out of a bare
+# runner, or point KUBECONFIG at a prepared cluster and run this alone.
 #
-# Third tier of the chart's CI (nightly / on-demand, see
-# .github/workflows/helm-hw-smoke.yml):
-#   render gate  (helm-chart-validate) -> the manifests are well-formed
-#   install gate (helm-install-kind)   -> a live API server accepts them, and the
-#                                         Pod stalls only for lack of a device
-#   THIS         (hardware smoke)      -> a real inference image, on a real board,
-#                                         actually serves
-#
-# Asserts only what the two cheaper tiers cannot:
-#   1. the DRA claim allocates and /dev/tenstorrent/<N> lands inside the real
-#      inference container (no privileged, no hostPath) — not a busybox probe
-#   2. the Pod reaches Ready inside the startupProbe budget without a restart,
-#      i.e. the computed compile window survives contact with real compile time
-#   3. the served API answers: /health, /v1/models, and one inference call
-#   4. `helm uninstall` releases the board — no Pod stuck Terminating
-#
-# NOT re-tested here: that the DRA driver can hand out devices at all
-# (tt-operator's dra-smoke owns that), the model x device matrix (the nightly
-# models-ci-config job), or anything render/install already covers.
-#
-# Preconditions: a cluster with tt-operator installed and its DRA layer already
-# publishing devices. .github/scripts/hw_smoke_bootstrap.sh creates exactly that
-# on a bare Tenstorrent runner; on a prepared cluster (e.g. a lab box running
-# k3s + tt-operator) point KUBECONFIG at it and run this script on its own.
-#
-# Usage:
 #   MODEL=Qwen3-Embedding-4B DEVICE=n150 bash .github/scripts/helm_hw_smoke.sh
 #
 # Knobs (all optional):
-#   MODEL / DEVICE / ENGINE / IMPL  chart selection (ENGINE/IMPL only when the
-#                                   row is ambiguous or an override is used)
+#   MODEL / DEVICE / ENGINE / IMPL  chart selection (ENGINE+IMPL are required for
+#                                   IMAGE_TAG and the *_REQUEST overrides, which
+#                                   address the values row by path)
 #   NAMESPACE / RELEASE             where to install
-#   IMAGE_TAG                       override the row's pinned image tag. Use only
-#                                   to separate "the chart is broken" from "the
-#                                   pinned image is stale" — never as the steady
-#                                   state, or the smoke stops guarding the pin.
-#                                   Needs ENGINE + IMPL set (the values path).
+#   IMAGE_TAG                       override the row's pinned tag, to tell "the
+#                                   chart is broken" from "the pin is stale".
+#                                   Never the steady state: the smoke guards
+#                                   that pin.
 #   HUGEPAGES                       true|false (default: probe the node)
-#   HF_TOKEN                        needed only for gated weights
-#   HF_CACHE_DIR                    host dir holding pre-downloaded weights
-#   PULL_SECRET                     name of an existing docker-registry secret
+#   HF_TOKEN                        gated weights only
+#   HF_CACHE_DIR                    host dir with pre-downloaded weights
+#   PULL_SECRET                     existing docker-registry secret to use
 #   API_PROBE                       chat|embeddings|models (default: from image)
-#   API_KEY                         bearer key to install with and then send.
-#                                   Default: a fresh random key per run. The
-#                                   chart's auth.apiKey carries it (API_KEY for
-#                                   media/forge, VLLM_API_KEY for vllm), so the
-#                                   smoke exercises the chart's own auth wiring
-#                                   rather than an image default — including the
-#                                   negative case, that an unauthenticated call
-#                                   is refused.
-#   INFER_MODEL_ID                  `model` field for the inference call. Default:
-#                                   the id from /v1/models, except that the media
-#                                   server reports a local snapshot path there
-#                                   while its runner only accepts the HF repo id,
-#                                   so an HF cache path is converted back to
-#                                   <org>/<name>.
-#   MAX_WAIT_SECONDS                how long we wait for Ready (default 2700).
-#                                   Independent of the chart's own budget; both
-#                                   are reported so a timeout is unambiguous.
-#   CPU_REQUEST / MEMORY_REQUEST    shrink the row's requests when the runner is
-#                                   smaller than the model's production ask
-# ---------------------------------------------------------------------------
+#   API_KEY                         bearer key to install via auth.apiKey and
+#                                   then send. Default: fresh random per run.
+#   INFER_MODEL_ID                  `model` for the inference call (default: the
+#                                   id from /v1/models, HF cache path converted)
+#   MAX_WAIT_SECONDS                Ready timeout (default 2700). Independent of
+#                                   the chart's budget; both get reported.
+#   CPU_REQUEST / MEMORY_REQUEST    shrink the row's requests on a small runner
 set -euo pipefail
 
 CHART="${CHART:-charts/tt-inference-server}"
@@ -116,10 +79,8 @@ diagnostics() {
   kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp 2>/dev/null | tail -30 || true
 }
 
-# Seconds between two RFC3339 timestamps as k8s reports them.
 secs_between() { echo $(( $(date -d "$2" +%s) - $(date -d "$1" +%s) )); }
 
-# ---------------------------------------------------------------------------
 log "chart selection"
 HELM_SET=(--set "model=$MODEL" --set "device=$DEVICE")
 [ -n "$ENGINE" ]       && HELM_SET+=(--set "engine=$ENGINE")
@@ -128,9 +89,7 @@ HELM_SET=(--set "model=$MODEL" --set "device=$DEVICE")
 [ -n "$HF_CACHE_DIR" ] && HELM_SET+=(--set "hfCacheDir=$HF_CACHE_DIR")
 [ -n "$PULL_SECRET" ]  && HELM_SET+=(--set "defaults.image.pullSecrets[0].name=$PULL_SECRET")
 
-# hugepages: default to what the node can actually back. A board needs 1Gi pages
-# unless the host runs it through an IOMMU (see the chart's hugepages values), and
-# a runner with none would leave the Pod Pending for a reason unrelated to DRA.
+# A runner with no 1Gi pages would leave the Pod Pending unrelated to DRA.
 if [ -z "$HUGEPAGES" ]; then
   hp_alloc="$(kubectl get nodes -o jsonpath='{.items[0].status.allocatable.hugepages-1Gi}' 2>/dev/null || true)"
   case "${hp_alloc:-0}" in ""|0|0Gi|0Ki) HUGEPAGES=false ;; *) HUGEPAGES=true ;; esac
@@ -138,18 +97,16 @@ if [ -z "$HUGEPAGES" ]; then
 fi
 HELM_SET+=(--set "hugepages.enabled=$HUGEPAGES")
 
-# Auth is a required decision for media/forge rows (auth.apiKey or
-# auth.disabled), so pick a key per run and prove below that it is enforced.
-# Random rather than fixed: a fixed one would still pass if the chart quietly
-# stopped wiring it and the server fell back to its built-in default.
+# Random rather than fixed: a fixed key would still pass if the chart stopped
+# wiring it and the server fell back to its built-in default.
 if [ -z "$API_KEY" ]; then
   API_KEY="$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
   [ -n "${GITHUB_ACTIONS:-}" ] && printf '::add-mask::%s\n' "$API_KEY"
 fi
 HELM_SET+=(--set "auth.apiKey=$API_KEY")
 
-# Per-row overrides go through a values file, not --set: the values path contains
-# the model name, and model names contain dots that --set reads as separators.
+# A values file, not --set: the path contains the model name, and model names
+# contain dots that --set reads as separators.
 if [ -n "$IMAGE_TAG" ] || [ -n "$CPU_REQUEST" ] || [ -n "$MEMORY_REQUEST" ]; then
   { [ -n "$ENGINE" ] && [ -n "$IMPL" ]; } \
     || fail "IMAGE_TAG / CPU_REQUEST / MEMORY_REQUEST address models.<model>.<engine>.<device>.impls.<impl>, so ENGINE and IMPL must be set explicitly"
@@ -184,11 +141,6 @@ WANT_BOARD="$(printf '%s\n' "$RENDERED" | awk -F'"' '/boardName ==/{print $(NF-1
 WANT_COUNT="$(printf '%s\n' "$RENDERED" | awk '$1=="count:"{print $2; exit}')"
 info "model=$MODEL device=$DEVICE image=$IMAGE_REF hugepages=$HUGEPAGES"
 
-# ---------------------------------------------------------------------------
-# Precondition — the DRA layer this smoke sits on top of. Asserted, not tested:
-# a missing DeviceClass or a device-less ResourceSlice is a cluster/driver
-# problem, and saying so up front keeps it from reading as a chart failure.
-# ---------------------------------------------------------------------------
 log "precondition: tt-operator's DRA layer is publishing devices"
 kubectl get deviceclass "$DEVICE_CLASS" >/dev/null 2>&1 \
   || fail "DeviceClass $DEVICE_CLASS not found — tt-operator (tt-dra-driver) is not installed on this cluster"
@@ -202,9 +154,6 @@ HAVE="$(kubectl get resourceslices \
   || fail "the DRA layer publishes ${HAVE:-0} board(s) of type $WANT_BOARD, the claim needs $WANT_COUNT — precondition unmet (fabric topology / tt-dra-driver), not a chart failure"
 ok "$HAVE $WANT_BOARD board(s) published in ResourceSlices"
 
-# ---------------------------------------------------------------------------
-# 1. Real image + DRA claim -> /dev/tenstorrent inside the container
-# ---------------------------------------------------------------------------
 log "install $RELEASE into namespace $NAMESPACE"
 helm install "$RELEASE" "$CHART" --namespace "$NAMESPACE" --create-namespace "${HELM_SET[@]}"
 INSTALLED_AT="$(date -u +%s)"
@@ -238,7 +187,6 @@ done
   || fail "ResourceClaim $CLAIM never allocated — the scheduler found no free $WANT_BOARD board for this Pod"
 ok "claim $CLAIM allocated: $DEVICES"
 
-# The point of the DRA path is that the device arrives without either of these.
 priv="$(kubectl -n "$NAMESPACE" get pod "$POD" -o jsonpath='{.spec.containers[0].securityContext.privileged}')"
 [ "${priv:-false}" != "true" ] || fail "the container runs privileged — the DRA path should not need it"
 hostpaths="$(kubectl -n "$NAMESPACE" get pod "$POD" \
@@ -270,9 +218,6 @@ injected="$(kubectl -n "$NAMESPACE" exec "$POD" -c inference-server -- \
 kubectl -n "$NAMESPACE" exec "$POD" -c inference-server -- ls -l /dev/tenstorrent || true
 ok "$injected /dev/tenstorrent device node(s) injected into the real inference container"
 
-# ---------------------------------------------------------------------------
-# 2. Ready inside the startupProbe budget, with no restart
-# ---------------------------------------------------------------------------
 log "Ready inside the compile window"
 ft="$(kubectl -n "$NAMESPACE" get pod "$POD" -o jsonpath='{.spec.containers[0].startupProbe.failureThreshold}')"
 ps="$(kubectl -n "$NAMESPACE" get pod "$POD" -o jsonpath='{.spec.containers[0].startupProbe.periodSeconds}')"
@@ -305,9 +250,6 @@ ok "Ready after ${COMPILE}s of compile/warmup (${TOTAL}s from helm install), 0 r
 [ "$PCT" -lt 80 ] \
   || warn "compile used ${PCT}% of the startupProbe budget (${COMPILE}s of ${BUDGET}s) — the window is close to too small for this row"
 
-# ---------------------------------------------------------------------------
-# 3. The served API answers
-# ---------------------------------------------------------------------------
 log "the served API answers"
 SVC="$(kubectl -n "$NAMESPACE" get svc -l app.kubernetes.io/instance="$RELEASE" \
   -o jsonpath='{.items[0].metadata.name}')"
@@ -326,8 +268,7 @@ ok "/health 200"
 AUTH=()
 [ -n "$API_KEY" ] && AUTH=(-H "Authorization: Bearer $API_KEY")
 
-# /v1/models is open on the media server but guarded by vLLM once VLLM_API_KEY
-# is set, so send the key here as well.
+# vLLM guards /v1/models once VLLM_API_KEY is set, so send the key here too.
 code="$(curl -s -o /tmp/hw-smoke-models.json -w '%{http_code}' \
   "${AUTH[@]+"${AUTH[@]}"}" "http://127.0.0.1:${LOCAL_PORT}/v1/models")"
 [ "$code" = "200" ] || fail "/v1/models returned $code"
@@ -336,11 +277,9 @@ SERVED_ID="$(python3 -c 'import json;d=json.load(open("/tmp/hw-smoke-models.json
   || fail "/v1/models returned 200 but listed no model: $(head -c 300 /tmp/hw-smoke-models.json)"
 ok "/v1/models 200, serving id=$SERVED_ID"
 
-# /v1/models advertises what the server calls itself; the inference route wants
-# what its runner recognises. On the media server those differ: it reports
-# settings.model_weights_path (an HF snapshot directory) unless SERVED_MODEL_NAME
-# is set, but the runner only accepts the HF repo id, so posting the advertised
-# id back gets "Model <path> is not supported by <Runner>". Convert the path.
+# The media server advertises settings.model_weights_path (an HF snapshot dir)
+# but its runner only accepts the HF repo id, so posting the advertised id back
+# gets "Model <path> is not supported by <Runner>". Convert the path.
 if [ -z "$INFER_MODEL_ID" ]; then
   case "$SERVED_ID" in
     *models--*/snapshots/*)
@@ -381,10 +320,8 @@ case "$API_PROBE" in
 esac
 
 if [ -n "$INFER_PATH" ]; then
-  # Negative first: with a key installed, an unauthenticated call must be
-  # refused. Without this, "200 with the key" would also pass on a server that
-  # ignores the key entirely — which is exactly the state the chart's auth
-  # values exist to prevent.
+  # Negative first: without this, "200 with the key" would also pass on a
+  # server that ignores the key entirely.
   if [ -n "$API_KEY" ]; then
     code="$(curl -s -o /dev/null -w '%{http_code}' -H 'Content-Type: application/json' \
       -d "$PAYLOAD" "http://127.0.0.1:${LOCAL_PORT}${INFER_PATH}")"
@@ -416,14 +353,9 @@ fi
 kill "$PF_PID" 2>/dev/null || true
 PF_PID=""
 
-# ---------------------------------------------------------------------------
-# 4. Uninstall releases the board
-#
-# The hazard: the kubelet cannot finish NodeUnprepareResources if the DRA plugin
-# is gone or wedged, and the Pod then sits in Terminating with the board still
-# held. `helm uninstall --wait` returning is not proof — poll until the Pod
-# object is really gone.
-# ---------------------------------------------------------------------------
+# 4. Uninstall releases the board. `helm uninstall --wait` returning is not
+# proof: if the DRA plugin is wedged the kubelet cannot finish
+# NodeUnprepareResources and the Pod sits in Terminating still holding it.
 log "uninstall releases the board"
 helm uninstall "$RELEASE" --namespace "$NAMESPACE" --wait
 gone=""

--- a/.github/scripts/helm_hw_smoke.sh
+++ b/.github/scripts/helm_hw_smoke.sh
@@ -43,6 +43,22 @@
 #   HF_CACHE_DIR                    host dir holding pre-downloaded weights
 #   PULL_SECRET                     name of an existing docker-registry secret
 #   API_PROBE                       chat|embeddings|models (default: from image)
+#   API_KEY                         sent as `Authorization: Bearer <API_KEY>`.
+#                                   The media / forge server guards its inference
+#                                   routes with a static key (API_KEY env,
+#                                   default "your-secret-key", or NO_AUTH=1 to
+#                                   turn auth off — see
+#                                   tt-media-server/security/api_key_checker.py)
+#                                   and the chart configures neither, so a
+#                                   chart-deployed one runs on that default.
+#                                   vLLM images are open unless VLLM_API_KEY /
+#                                   JWT_SECRET is set, so leave this empty there.
+#   INFER_MODEL_ID                  `model` field for the inference call. Default:
+#                                   the id from /v1/models, except that the media
+#                                   server reports a local snapshot path there
+#                                   while its runner only accepts the HF repo id,
+#                                   so an HF cache path is converted back to
+#                                   <org>/<name>.
 #   MAX_WAIT_SECONDS                how long we wait for Ready (default 2700).
 #                                   Independent of the chart's own budget; both
 #                                   are reported so a timeout is unambiguous.
@@ -64,6 +80,8 @@ HF_TOKEN="${HF_TOKEN:-}"
 HF_CACHE_DIR="${HF_CACHE_DIR:-}"
 PULL_SECRET="${PULL_SECRET:-}"
 API_PROBE="${API_PROBE:-}"
+API_KEY="${API_KEY:-}"
+INFER_MODEL_ID="${INFER_MODEL_ID:-}"
 MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-2700}"
 CPU_REQUEST="${CPU_REQUEST:-}"
 MEMORY_REQUEST="${MEMORY_REQUEST:-}"
@@ -303,6 +321,28 @@ SERVED_ID="$(python3 -c 'import json;d=json.load(open("/tmp/hw-smoke-models.json
   || fail "/v1/models returned 200 but listed no model: $(head -c 300 /tmp/hw-smoke-models.json)"
 ok "/v1/models 200, serving id=$SERVED_ID"
 
+AUTH=()
+[ -n "$API_KEY" ] && AUTH=(-H "Authorization: Bearer $API_KEY")
+
+# /v1/models advertises what the server calls itself; the inference route wants
+# what its runner recognises. On the media server those differ: it reports
+# settings.model_weights_path (an HF snapshot directory) unless SERVED_MODEL_NAME
+# is set, but the runner only accepts the HF repo id, so posting the advertised
+# id back gets "Model <path> is not supported by <Runner>". Convert the path.
+if [ -z "$INFER_MODEL_ID" ]; then
+  case "$SERVED_ID" in
+    *models--*/snapshots/*)
+      repo="${SERVED_ID#*models--}"
+      repo="${repo%%/snapshots/*}"
+      INFER_MODEL_ID="$(printf '%s' "$repo" | sed 's/--/\//')"
+      info "the served id is an HF cache path -> using repo id $INFER_MODEL_ID for the inference call"
+      ;;
+    *)
+      INFER_MODEL_ID="$SERVED_ID"
+      ;;
+  esac
+fi
+
 if [ -z "$API_PROBE" ]; then
   case "$IMAGE_REF" in
     *vllm-tt-metal-src*) API_PROBE=chat ;;
@@ -313,9 +353,10 @@ fi
 case "$API_PROBE" in
   chat)
     code="$(curl -s -o /tmp/hw-smoke-infer.json -w '%{http_code}' \
-      -H 'Content-Type: application/json' \
-      -d "{\"model\":\"${SERVED_ID}\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hello.\"}],\"max_tokens\":16}" \
+      -H 'Content-Type: application/json' "${AUTH[@]+"${AUTH[@]}"}" \
+      -d "{\"model\":\"${INFER_MODEL_ID}\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hello.\"}],\"max_tokens\":16}" \
       "http://127.0.0.1:${LOCAL_PORT}/v1/chat/completions")"
+    [ "$code" != "401" ] || fail "/v1/chat/completions returned 401 — the server wants an API key and API_KEY is $([ -n "$API_KEY" ] && echo "wrong" || echo "unset")"
     [ "$code" = "200" ] \
       || fail "/v1/chat/completions returned $code: $(head -c 300 /tmp/hw-smoke-infer.json)"
     python3 -c 'import json,sys;d=json.load(open("/tmp/hw-smoke-infer.json"));sys.exit(0 if (d["choices"][0]["message"].get("content") or "").strip() else 1)' \
@@ -324,9 +365,10 @@ case "$API_PROBE" in
     ;;
   embeddings)
     code="$(curl -s -o /tmp/hw-smoke-infer.json -w '%{http_code}' \
-      -H 'Content-Type: application/json' \
-      -d "{\"model\":\"${SERVED_ID}\",\"input\":\"hello from the hardware smoke\"}" \
+      -H 'Content-Type: application/json' "${AUTH[@]+"${AUTH[@]}"}" \
+      -d "{\"model\":\"${INFER_MODEL_ID}\",\"input\":\"hello from the hardware smoke\"}" \
       "http://127.0.0.1:${LOCAL_PORT}/v1/embeddings")"
+    [ "$code" != "401" ] || fail "/v1/embeddings returned 401 — the server wants an API key and API_KEY is $([ -n "$API_KEY" ] && echo "wrong" || echo "unset"); the media/forge image defaults to \"your-secret-key\" (tt-media-server/security/api_key_checker.py)"
     [ "$code" = "200" ] \
       || fail "/v1/embeddings returned $code: $(head -c 300 /tmp/hw-smoke-infer.json)"
     dims="$(python3 -c 'import json;d=json.load(open("/tmp/hw-smoke-infer.json"));print(len((d.get("data") or [{}])[0].get("embedding") or []))')"
@@ -389,6 +431,7 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo "| boards allocated | \`$DEVICES\` (asked for $WANT_COUNT x $WANT_BOARD) |"
     echo "| hugepages | \`$HUGEPAGES\` |"
     echo "| compile to Ready | ${COMPILE}s of the chart's ${BUDGET}s startupProbe budget (${PCT}%) |"
-    echo "| served id | \`$SERVED_ID\` (probe: $API_PROBE) |"
+    echo "| served id | \`$SERVED_ID\` |"
+    echo "| inference call | \`$API_PROBE\` as \`$INFER_MODEL_ID\`$([ -n "$API_KEY" ] && echo ", API key sent") |"
   } >> "$GITHUB_STEP_SUMMARY"
 fi

--- a/.github/scripts/helm_hw_smoke.sh
+++ b/.github/scripts/helm_hw_smoke.sh
@@ -43,16 +43,14 @@
 #   HF_CACHE_DIR                    host dir holding pre-downloaded weights
 #   PULL_SECRET                     name of an existing docker-registry secret
 #   API_PROBE                       chat|embeddings|models (default: from image)
-#   API_KEY                         sent as `Authorization: Bearer <API_KEY>`.
-#                                   The media / forge server guards its inference
-#                                   routes with a static key (API_KEY env,
-#                                   default "your-secret-key", or NO_AUTH=1 to
-#                                   turn auth off — see
-#                                   tt-media-server/security/api_key_checker.py)
-#                                   and the chart configures neither, so a
-#                                   chart-deployed one runs on that default.
-#                                   vLLM images are open unless VLLM_API_KEY /
-#                                   JWT_SECRET is set, so leave this empty there.
+#   API_KEY                         bearer key to install with and then send.
+#                                   Default: a fresh random key per run. The
+#                                   chart's auth.apiKey carries it (API_KEY for
+#                                   media/forge, VLLM_API_KEY for vllm), so the
+#                                   smoke exercises the chart's own auth wiring
+#                                   rather than an image default — including the
+#                                   negative case, that an unauthenticated call
+#                                   is refused.
 #   INFER_MODEL_ID                  `model` field for the inference call. Default:
 #                                   the id from /v1/models, except that the media
 #                                   server reports a local snapshot path there
@@ -138,6 +136,16 @@ if [ -z "$HUGEPAGES" ]; then
   info "HUGEPAGES not set -> $HUGEPAGES (node allocatable hugepages-1Gi=${hp_alloc:-0})"
 fi
 HELM_SET+=(--set "hugepages.enabled=$HUGEPAGES")
+
+# Auth is a required decision for media/forge rows (auth.apiKey or
+# auth.disabled), so pick a key per run and prove below that it is enforced.
+# Random rather than fixed: a fixed one would still pass if the chart quietly
+# stopped wiring it and the server fell back to its built-in default.
+if [ -z "$API_KEY" ]; then
+  API_KEY="$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+  [ -n "${GITHUB_ACTIONS:-}" ] && printf '::add-mask::%s\n' "$API_KEY"
+fi
+HELM_SET+=(--set "auth.apiKey=$API_KEY")
 
 # Per-row overrides go through a values file, not --set: the values path contains
 # the model name, and model names contain dots that --set reads as separators.
@@ -314,15 +322,18 @@ code="$(curl -s -o /tmp/hw-smoke-health.json -w '%{http_code}' "http://127.0.0.1
   || fail "/health returned $code (port-forward: $(tr '\n' ' ' < /tmp/hw-smoke-pf.log | tail -c 200))"
 ok "/health 200"
 
-code="$(curl -s -o /tmp/hw-smoke-models.json -w '%{http_code}' "http://127.0.0.1:${LOCAL_PORT}/v1/models")"
+AUTH=()
+[ -n "$API_KEY" ] && AUTH=(-H "Authorization: Bearer $API_KEY")
+
+# /v1/models is open on the media server but guarded by vLLM once VLLM_API_KEY
+# is set, so send the key here as well.
+code="$(curl -s -o /tmp/hw-smoke-models.json -w '%{http_code}' \
+  "${AUTH[@]+"${AUTH[@]}"}" "http://127.0.0.1:${LOCAL_PORT}/v1/models")"
 [ "$code" = "200" ] || fail "/v1/models returned $code"
 SERVED_ID="$(python3 -c 'import json;d=json.load(open("/tmp/hw-smoke-models.json"));print((d.get("data") or [{}])[0].get("id",""))')"
 [ -n "$SERVED_ID" ] \
   || fail "/v1/models returned 200 but listed no model: $(head -c 300 /tmp/hw-smoke-models.json)"
 ok "/v1/models 200, serving id=$SERVED_ID"
-
-AUTH=()
-[ -n "$API_KEY" ] && AUTH=(-H "Authorization: Bearer $API_KEY")
 
 # /v1/models advertises what the server calls itself; the inference route wants
 # what its runner recognises. On the media server those differ: it reports
@@ -352,37 +363,55 @@ if [ -z "$API_PROBE" ]; then
 fi
 case "$API_PROBE" in
   chat)
-    code="$(curl -s -o /tmp/hw-smoke-infer.json -w '%{http_code}' \
-      -H 'Content-Type: application/json' "${AUTH[@]+"${AUTH[@]}"}" \
-      -d "{\"model\":\"${INFER_MODEL_ID}\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hello.\"}],\"max_tokens\":16}" \
-      "http://127.0.0.1:${LOCAL_PORT}/v1/chat/completions")"
-    [ "$code" != "401" ] || fail "/v1/chat/completions returned 401 — the server wants an API key and API_KEY is $([ -n "$API_KEY" ] && echo "wrong" || echo "unset")"
-    [ "$code" = "200" ] \
-      || fail "/v1/chat/completions returned $code: $(head -c 300 /tmp/hw-smoke-infer.json)"
-    python3 -c 'import json,sys;d=json.load(open("/tmp/hw-smoke-infer.json"));sys.exit(0 if (d["choices"][0]["message"].get("content") or "").strip() else 1)' \
-      || fail "/v1/chat/completions returned 200 but generated no content: $(head -c 300 /tmp/hw-smoke-infer.json)"
-    ok "/v1/chat/completions 200 with generated content"
+    INFER_PATH=/v1/chat/completions
+    PAYLOAD="{\"model\":\"${INFER_MODEL_ID}\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hello.\"}],\"max_tokens\":16}"
     ;;
   embeddings)
-    code="$(curl -s -o /tmp/hw-smoke-infer.json -w '%{http_code}' \
-      -H 'Content-Type: application/json' "${AUTH[@]+"${AUTH[@]}"}" \
-      -d "{\"model\":\"${INFER_MODEL_ID}\",\"input\":\"hello from the hardware smoke\"}" \
-      "http://127.0.0.1:${LOCAL_PORT}/v1/embeddings")"
-    [ "$code" != "401" ] || fail "/v1/embeddings returned 401 — the server wants an API key and API_KEY is $([ -n "$API_KEY" ] && echo "wrong" || echo "unset"); the media/forge image defaults to \"your-secret-key\" (tt-media-server/security/api_key_checker.py)"
-    [ "$code" = "200" ] \
-      || fail "/v1/embeddings returned $code: $(head -c 300 /tmp/hw-smoke-infer.json)"
-    dims="$(python3 -c 'import json;d=json.load(open("/tmp/hw-smoke-infer.json"));print(len((d.get("data") or [{}])[0].get("embedding") or []))')"
-    [ "${dims:-0}" -gt 0 ] \
-      || fail "/v1/embeddings returned 200 but an empty vector: $(head -c 300 /tmp/hw-smoke-infer.json)"
-    ok "/v1/embeddings 200 with a ${dims}-dimension vector"
+    INFER_PATH=/v1/embeddings
+    PAYLOAD="{\"model\":\"${INFER_MODEL_ID}\",\"input\":\"hello from the hardware smoke\"}"
     ;;
   models)
+    INFER_PATH=""
     info "API_PROBE=models — inference call skipped by request"
     ;;
   *)
     fail "unknown API_PROBE=$API_PROBE (want chat|embeddings|models)"
     ;;
 esac
+
+if [ -n "$INFER_PATH" ]; then
+  # Negative first: with a key installed, an unauthenticated call must be
+  # refused. Without this, "200 with the key" would also pass on a server that
+  # ignores the key entirely — which is exactly the state the chart's auth
+  # values exist to prevent.
+  if [ -n "$API_KEY" ]; then
+    code="$(curl -s -o /dev/null -w '%{http_code}' -H 'Content-Type: application/json' \
+      -d "$PAYLOAD" "http://127.0.0.1:${LOCAL_PORT}${INFER_PATH}")"
+    [ "$code" = "401" ] \
+      || fail "$INFER_PATH answered $code without a key while auth.apiKey was installed — the key is not being enforced (expected 401)"
+    ok "$INFER_PATH without a key -> 401 (auth.apiKey is enforced)"
+  fi
+
+  code="$(curl -s -o /tmp/hw-smoke-infer.json -w '%{http_code}' \
+    -H 'Content-Type: application/json' "${AUTH[@]+"${AUTH[@]}"}" \
+    -d "$PAYLOAD" "http://127.0.0.1:${LOCAL_PORT}${INFER_PATH}")"
+  [ "$code" = "200" ] \
+    || fail "$INFER_PATH returned $code: $(head -c 300 /tmp/hw-smoke-infer.json)"
+
+  case "$API_PROBE" in
+    chat)
+      python3 -c 'import json,sys;d=json.load(open("/tmp/hw-smoke-infer.json"));sys.exit(0 if (d["choices"][0]["message"].get("content") or "").strip() else 1)' \
+        || fail "$INFER_PATH returned 200 but generated no content: $(head -c 300 /tmp/hw-smoke-infer.json)"
+      ok "$INFER_PATH 200 with generated content"
+      ;;
+    embeddings)
+      dims="$(python3 -c 'import json;d=json.load(open("/tmp/hw-smoke-infer.json"));print(len((d.get("data") or [{}])[0].get("embedding") or []))')"
+      [ "${dims:-0}" -gt 0 ] \
+        || fail "$INFER_PATH returned 200 but an empty vector: $(head -c 300 /tmp/hw-smoke-infer.json)"
+      ok "$INFER_PATH 200 with a ${dims}-dimension vector"
+      ;;
+  esac
+fi
 kill "$PF_PID" 2>/dev/null || true
 PF_PID=""
 

--- a/.github/scripts/helm_hw_smoke.sh
+++ b/.github/scripts/helm_hw_smoke.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Hardware smoke — the chart's runtime assumptions, on real silicon.
+#
+# Third tier of the chart's CI (see .github/workflows/helm-hw-smoke.yml):
+#   render gate  (helm-chart-validate) -> the manifests are well-formed
+#   install gate (helm-install-kind)   -> a live API server accepts them, and the
+#                                         Pod stalls only for lack of a device
+#   THIS         (hardware smoke)      -> a real inference image, on a real board,
+#                                         actually serves
+#
+# Asserts only what the two cheaper tiers cannot:
+#   1. the DRA claim allocates and /dev/tenstorrent/<N> lands inside the real
+#      inference container (no privileged, no hostPath) — not a busybox probe
+#   2. the Pod reaches Ready inside the startupProbe budget without a restart,
+#      i.e. the computed compile window survives contact with real compile time
+#   3. the served API answers: /health, /v1/models, and one inference call
+#   4. `helm uninstall` releases the board — no Pod stuck Terminating
+#
+# NOT re-tested here: that the DRA driver can hand out devices at all
+# (tt-operator's dra-smoke owns that), the model x device matrix (the nightly
+# models-ci-config job), or anything render/install already covers.
+#
+# Preconditions: a cluster with tt-operator installed and its DRA layer already
+# publishing devices. .github/scripts/hw_smoke_bootstrap.sh creates exactly that
+# on a bare Tenstorrent runner; on a prepared cluster (e.g. a lab box running
+# k3s + tt-operator) point KUBECONFIG at it and run this script on its own.
+#
+# Usage:
+#   MODEL=Qwen3-Embedding-4B DEVICE=n150 bash .github/scripts/helm_hw_smoke.sh
+#
+# Knobs (all optional):
+#   MODEL / DEVICE / ENGINE / IMPL  chart selection (ENGINE/IMPL only when the
+#                                   row is ambiguous or an override is used)
+#   NAMESPACE / RELEASE             where to install
+#   IMAGE_TAG                       override the row's pinned image tag. Use only
+#                                   to separate "the chart is broken" from "the
+#                                   pinned image is stale" — never as the steady
+#                                   state, or the smoke stops guarding the pin.
+#                                   Needs ENGINE + IMPL set (the values path).
+#   HUGEPAGES                       true|false (default: probe the node)
+#   HF_TOKEN                        needed only for gated weights
+#   HF_CACHE_DIR                    host dir holding pre-downloaded weights
+#   PULL_SECRET                     name of an existing docker-registry secret
+#   API_PROBE                       chat|embeddings|models (default: from image)
+#   MAX_WAIT_SECONDS                how long we wait for Ready (default 2700).
+#                                   Independent of the chart's own budget; both
+#                                   are reported so a timeout is unambiguous.
+#   CPU_REQUEST / MEMORY_REQUEST    shrink the row's requests when the runner is
+#                                   smaller than the model's production ask
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+CHART="${CHART:-charts/tt-inference-server}"
+MODEL="${MODEL:-Qwen3-Embedding-4B}"
+DEVICE="${DEVICE:-n150}"
+ENGINE="${ENGINE:-}"
+IMPL="${IMPL:-}"
+NAMESPACE="${NAMESPACE:-ttis-hw-smoke}"
+RELEASE="${RELEASE:-ttis-hw}"
+IMAGE_TAG="${IMAGE_TAG:-}"
+HUGEPAGES="${HUGEPAGES:-}"
+HF_TOKEN="${HF_TOKEN:-}"
+HF_CACHE_DIR="${HF_CACHE_DIR:-}"
+PULL_SECRET="${PULL_SECRET:-}"
+API_PROBE="${API_PROBE:-}"
+MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-2700}"
+CPU_REQUEST="${CPU_REQUEST:-}"
+MEMORY_REQUEST="${MEMORY_REQUEST:-}"
+LOCAL_PORT="${LOCAL_PORT:-18000}"
+DEVICE_CLASS="${DEVICE_CLASS:-tenstorrent.com}"
+
+log()  { printf '\n=== %s ===\n' "$*"; }
+info() { printf '     %s\n' "$*"; }
+ok()   { printf 'OK   %s\n' "$*"; }
+warn() { printf '::warning::%s\n' "$*"; }
+fail() { printf '::error::%s\n' "$*" >&2; diagnostics; exit 1; }
+
+PF_PID=""
+OVERRIDES=""
+cleanup() {
+  if [ -n "$PF_PID" ]; then
+    kill "$PF_PID" 2>/dev/null || true
+    PF_PID=""
+  fi
+  [ -n "$OVERRIDES" ] && rm -f "$OVERRIDES"
+  return 0
+}
+trap cleanup EXIT
+
+diagnostics() {
+  printf '\n----- diagnostics -----\n'
+  kubectl -n "$NAMESPACE" get pods -o wide 2>/dev/null || true
+  kubectl -n "$NAMESPACE" describe pods 2>/dev/null | tail -80 || true
+  kubectl -n "$NAMESPACE" get resourceclaim,resourceclaimtemplate -o yaml 2>/dev/null | tail -60 || true
+  kubectl get resourceslices -o yaml 2>/dev/null | tail -80 || true
+  kubectl -n "$NAMESPACE" logs -l app.kubernetes.io/instance="$RELEASE" \
+    --tail=150 --all-containers --prefix 2>/dev/null || true
+  kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp 2>/dev/null | tail -30 || true
+}
+
+# Seconds between two RFC3339 timestamps as k8s reports them.
+secs_between() { echo $(( $(date -d "$2" +%s) - $(date -d "$1" +%s) )); }
+
+# ---------------------------------------------------------------------------
+log "chart selection"
+HELM_SET=(--set "model=$MODEL" --set "device=$DEVICE")
+[ -n "$ENGINE" ]       && HELM_SET+=(--set "engine=$ENGINE")
+[ -n "$IMPL" ]         && HELM_SET+=(--set "impl=$IMPL")
+[ -n "$HF_TOKEN" ]     && HELM_SET+=(--set "hfToken=$HF_TOKEN")
+[ -n "$HF_CACHE_DIR" ] && HELM_SET+=(--set "hfCacheDir=$HF_CACHE_DIR")
+[ -n "$PULL_SECRET" ]  && HELM_SET+=(--set "defaults.image.pullSecrets[0].name=$PULL_SECRET")
+
+# hugepages: default to what the node can actually back. A board needs 1Gi pages
+# unless the host runs it through an IOMMU (see the chart's hugepages values), and
+# a runner with none would leave the Pod Pending for a reason unrelated to DRA.
+if [ -z "$HUGEPAGES" ]; then
+  hp_alloc="$(kubectl get nodes -o jsonpath='{.items[0].status.allocatable.hugepages-1Gi}' 2>/dev/null || true)"
+  case "${hp_alloc:-0}" in ""|0|0Gi|0Ki) HUGEPAGES=false ;; *) HUGEPAGES=true ;; esac
+  info "HUGEPAGES not set -> $HUGEPAGES (node allocatable hugepages-1Gi=${hp_alloc:-0})"
+fi
+HELM_SET+=(--set "hugepages.enabled=$HUGEPAGES")
+
+# Per-row overrides go through a values file, not --set: the values path contains
+# the model name, and model names contain dots that --set reads as separators.
+if [ -n "$IMAGE_TAG" ] || [ -n "$CPU_REQUEST" ] || [ -n "$MEMORY_REQUEST" ]; then
+  { [ -n "$ENGINE" ] && [ -n "$IMPL" ]; } \
+    || fail "IMAGE_TAG / CPU_REQUEST / MEMORY_REQUEST address models.<model>.<engine>.<device>.impls.<impl>, so ENGINE and IMPL must be set explicitly"
+  OVERRIDES="$(mktemp /tmp/hw-smoke-overrides.XXXXXX)"
+  {
+    echo "models:"
+    echo "  \"$MODEL\":"
+    echo "    \"$ENGINE\":"
+    echo "      \"$DEVICE\":"
+    echo "        impls:"
+    echo "          \"$IMPL\":"
+    if [ -n "$IMAGE_TAG" ]; then
+      echo "            image:"
+      echo "              tag: \"$IMAGE_TAG\""
+    fi
+    if [ -n "$CPU_REQUEST" ] || [ -n "$MEMORY_REQUEST" ]; then
+      echo "            resources:"
+      echo "              requests:"
+      [ -n "$CPU_REQUEST" ]    && echo "                cpu: \"$CPU_REQUEST\""
+      [ -n "$MEMORY_REQUEST" ] && echo "                memory: \"$MEMORY_REQUEST\""
+    fi
+  } > "$OVERRIDES"
+  info "row overrides:"
+  sed 's/^/       /' "$OVERRIDES"
+  HELM_SET+=(-f "$OVERRIDES")
+fi
+
+RENDERED="$(helm template "$RELEASE" "$CHART" --namespace "$NAMESPACE" "${HELM_SET[@]}")" \
+  || fail "helm template failed for model=$MODEL device=$DEVICE — does that model/engine/device/impl row exist?"
+IMAGE_REF="$(printf '%s\n' "$RENDERED" | awk '$1=="image:" && $2 ~ /ghcr.io|docker.io|\//{print $2}' | grep -v busybox | head -1)"
+WANT_BOARD="$(printf '%s\n' "$RENDERED" | awk -F'"' '/boardName ==/{print $(NF-1)}')"
+WANT_COUNT="$(printf '%s\n' "$RENDERED" | awk '$1=="count:"{print $2; exit}')"
+info "model=$MODEL device=$DEVICE image=$IMAGE_REF hugepages=$HUGEPAGES"
+
+# ---------------------------------------------------------------------------
+# Precondition — the DRA layer this smoke sits on top of. Asserted, not tested:
+# a missing DeviceClass or a device-less ResourceSlice is a cluster/driver
+# problem, and saying so up front keeps it from reading as a chart failure.
+# ---------------------------------------------------------------------------
+log "precondition: tt-operator's DRA layer is publishing devices"
+kubectl get deviceclass "$DEVICE_CLASS" >/dev/null 2>&1 \
+  || fail "DeviceClass $DEVICE_CLASS not found — tt-operator (tt-dra-driver) is not installed on this cluster"
+[ -n "$WANT_COUNT" ] \
+  || fail "the chart rendered no ResourceClaimTemplate for device=$DEVICE (a non-TT device?) — nothing for this smoke to assert"
+info "the claim asks for $WANT_COUNT x boardName=$WANT_BOARD"
+HAVE="$(kubectl get resourceslices \
+  -o jsonpath='{range .items[*]}{range .spec.devices[*]}{.attributes.boardName.string}{"\n"}{end}{end}' 2>/dev/null \
+  | grep -c "^${WANT_BOARD}$" || true)"
+[ "${HAVE:-0}" -ge "$WANT_COUNT" ] \
+  || fail "the DRA layer publishes ${HAVE:-0} board(s) of type $WANT_BOARD, the claim needs $WANT_COUNT — precondition unmet (fabric topology / tt-dra-driver), not a chart failure"
+ok "$HAVE $WANT_BOARD board(s) published in ResourceSlices"
+
+# ---------------------------------------------------------------------------
+# 1. Real image + DRA claim -> /dev/tenstorrent inside the container
+# ---------------------------------------------------------------------------
+log "install $RELEASE into namespace $NAMESPACE"
+helm install "$RELEASE" "$CHART" --namespace "$NAMESPACE" --create-namespace "${HELM_SET[@]}"
+INSTALLED_AT="$(date -u +%s)"
+
+POD=""
+for _ in $(seq 1 60); do
+  POD="$(kubectl -n "$NAMESPACE" get pod -l app.kubernetes.io/instance="$RELEASE" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  [ -n "$POD" ] && break
+  sleep 2
+done
+[ -n "$POD" ] || fail "the Deployment never created a Pod"
+info "pod=$POD"
+
+log "the DRA claim allocates a board"
+CLAIM=""
+for _ in $(seq 1 60); do
+  CLAIM="$(kubectl -n "$NAMESPACE" get resourceclaim -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  [ -n "$CLAIM" ] && break
+  sleep 2
+done
+[ -n "$CLAIM" ] || fail "no ResourceClaim was generated from the chart's ResourceClaimTemplate"
+DEVICES=""
+for _ in $(seq 1 60); do
+  DEVICES="$(kubectl -n "$NAMESPACE" get resourceclaim "$CLAIM" \
+    -o jsonpath='{range .status.allocation.devices.results[*]}{.device}{" "}{end}' 2>/dev/null || true)"
+  [ -n "${DEVICES// /}" ] && break
+  sleep 5
+done
+[ -n "${DEVICES// /}" ] \
+  || fail "ResourceClaim $CLAIM never allocated — the scheduler found no free $WANT_BOARD board for this Pod"
+ok "claim $CLAIM allocated: $DEVICES"
+
+# The point of the DRA path is that the device arrives without either of these.
+priv="$(kubectl -n "$NAMESPACE" get pod "$POD" -o jsonpath='{.spec.containers[0].securityContext.privileged}')"
+[ "${priv:-false}" != "true" ] || fail "the container runs privileged — the DRA path should not need it"
+hostpaths="$(kubectl -n "$NAMESPACE" get pod "$POD" \
+  -o jsonpath='{range .spec.volumes[*]}{.hostPath.path}{"\n"}{end}' | grep -c '^/dev/tenstorrent' || true)"
+[ "${hostpaths:-0}" -eq 0 ] || fail "the Pod mounts /dev/tenstorrent by hostPath — DRA should be injecting it instead"
+ok "no privileged container, no /dev/tenstorrent hostPath"
+
+log "the container starts and sees its board"
+state=""
+for _ in $(seq 1 180); do
+  state="$(kubectl -n "$NAMESPACE" get pod "$POD" \
+    -o jsonpath='{.status.containerStatuses[0].state}' 2>/dev/null || true)"
+  case "$state" in *running*) break ;; esac
+  [ "$(kubectl -n "$NAMESPACE" get pod "$POD" -o jsonpath='{.status.phase}')" = "Failed" ] \
+    && fail "the Pod reached phase Failed before the container started"
+  sleep 10
+done
+case "$state" in
+  *running*) ;;
+  *) fail "the container never started within 30m (image pull or init container stuck): ${state:-<none>}" ;;
+esac
+STARTED_AT="$(kubectl -n "$NAMESPACE" get pod "$POD" \
+  -o jsonpath='{.status.containerStatuses[0].state.running.startedAt}')"
+info "container started at $STARTED_AT"
+injected="$(kubectl -n "$NAMESPACE" exec "$POD" -c inference-server -- \
+  sh -c 'find /dev/tenstorrent -maxdepth 1 -type c | wc -l' 2>/dev/null | tr -d '[:space:]')"
+[ "${injected:-0}" -eq "$WANT_COUNT" ] \
+  || fail "the container sees ${injected:-0} /dev/tenstorrent device node(s), the claim allocated $WANT_COUNT"
+kubectl -n "$NAMESPACE" exec "$POD" -c inference-server -- ls -l /dev/tenstorrent || true
+ok "$injected /dev/tenstorrent device node(s) injected into the real inference container"
+
+# ---------------------------------------------------------------------------
+# 2. Ready inside the startupProbe budget, with no restart
+# ---------------------------------------------------------------------------
+log "Ready inside the compile window"
+ft="$(kubectl -n "$NAMESPACE" get pod "$POD" -o jsonpath='{.spec.containers[0].startupProbe.failureThreshold}')"
+ps="$(kubectl -n "$NAMESPACE" get pod "$POD" -o jsonpath='{.spec.containers[0].startupProbe.periodSeconds}')"
+{ [ -n "$ft" ] && [ -n "$ps" ] && [ "$ft" -gt 0 ] && [ "$ps" -gt 0 ]; } \
+  || fail "no usable startupProbe on the container — the compile window is unguarded"
+BUDGET=$(( ft * ps ))
+info "chart budget = failureThreshold($ft) x periodSeconds($ps) = ${BUDGET}s; this smoke waits up to ${MAX_WAIT_SECONDS}s"
+deadline=$(( $(date -u +%s) + MAX_WAIT_SECONDS ))
+ready=""
+while [ "$(date -u +%s)" -lt "$deadline" ]; do
+  ready="$(kubectl -n "$NAMESPACE" get pod "$POD" \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)"
+  [ "$ready" = "True" ] && break
+  restarts="$(kubectl -n "$NAMESPACE" get pod "$POD" \
+    -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null || echo 0)"
+  [ "${restarts:-0}" -gt 0 ] \
+    && fail "the container restarted ${restarts}x before becoming Ready — the startupProbe budget (${BUDGET}s) expired mid-compile, or the server crashed"
+  sleep 15
+done
+[ "$ready" = "True" ] \
+  || fail "the Pod did not become Ready within ${MAX_WAIT_SECONDS}s (the chart's own budget is ${BUDGET}s) — compile is slower than either, or /health never answered"
+READY_AT="$(kubectl -n "$NAMESPACE" get pod "$POD" \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].lastTransitionTime}')"
+COMPILE="$(secs_between "$STARTED_AT" "$READY_AT")"
+TOTAL=$(( $(date -d "$READY_AT" +%s) - INSTALLED_AT ))
+restarts="$(kubectl -n "$NAMESPACE" get pod "$POD" -o jsonpath='{.status.containerStatuses[0].restartCount}')"
+[ "${restarts:-0}" -eq 0 ] || fail "the Pod is Ready but its container restarted ${restarts}x on the way"
+PCT=$(( COMPILE * 100 / BUDGET ))
+ok "Ready after ${COMPILE}s of compile/warmup (${TOTAL}s from helm install), 0 restarts — ${PCT}% of the ${BUDGET}s budget"
+[ "$PCT" -lt 80 ] \
+  || warn "compile used ${PCT}% of the startupProbe budget (${COMPILE}s of ${BUDGET}s) — the window is close to too small for this row"
+
+# ---------------------------------------------------------------------------
+# 3. The served API answers
+# ---------------------------------------------------------------------------
+log "the served API answers"
+SVC="$(kubectl -n "$NAMESPACE" get svc -l app.kubernetes.io/instance="$RELEASE" \
+  -o jsonpath='{.items[0].metadata.name}')"
+kubectl -n "$NAMESPACE" port-forward "svc/$SVC" "${LOCAL_PORT}:8000" >/tmp/hw-smoke-pf.log 2>&1 &
+PF_PID=$!
+for _ in $(seq 1 30); do
+  curl -sf -o /dev/null "http://127.0.0.1:${LOCAL_PORT}/health" && break
+  sleep 2
+done
+
+code="$(curl -s -o /tmp/hw-smoke-health.json -w '%{http_code}' "http://127.0.0.1:${LOCAL_PORT}/health")"
+[ "$code" = "200" ] \
+  || fail "/health returned $code (port-forward: $(tr '\n' ' ' < /tmp/hw-smoke-pf.log | tail -c 200))"
+ok "/health 200"
+
+code="$(curl -s -o /tmp/hw-smoke-models.json -w '%{http_code}' "http://127.0.0.1:${LOCAL_PORT}/v1/models")"
+[ "$code" = "200" ] || fail "/v1/models returned $code"
+SERVED_ID="$(python3 -c 'import json;d=json.load(open("/tmp/hw-smoke-models.json"));print((d.get("data") or [{}])[0].get("id",""))')"
+[ -n "$SERVED_ID" ] \
+  || fail "/v1/models returned 200 but listed no model: $(head -c 300 /tmp/hw-smoke-models.json)"
+ok "/v1/models 200, serving id=$SERVED_ID"
+
+if [ -z "$API_PROBE" ]; then
+  case "$IMAGE_REF" in
+    *vllm-tt-metal-src*) API_PROBE=chat ;;
+    *)                   API_PROBE=embeddings ;;
+  esac
+  info "API_PROBE not set -> $API_PROBE (from the resolved image)"
+fi
+case "$API_PROBE" in
+  chat)
+    code="$(curl -s -o /tmp/hw-smoke-infer.json -w '%{http_code}' \
+      -H 'Content-Type: application/json' \
+      -d "{\"model\":\"${SERVED_ID}\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hello.\"}],\"max_tokens\":16}" \
+      "http://127.0.0.1:${LOCAL_PORT}/v1/chat/completions")"
+    [ "$code" = "200" ] \
+      || fail "/v1/chat/completions returned $code: $(head -c 300 /tmp/hw-smoke-infer.json)"
+    python3 -c 'import json,sys;d=json.load(open("/tmp/hw-smoke-infer.json"));sys.exit(0 if (d["choices"][0]["message"].get("content") or "").strip() else 1)' \
+      || fail "/v1/chat/completions returned 200 but generated no content: $(head -c 300 /tmp/hw-smoke-infer.json)"
+    ok "/v1/chat/completions 200 with generated content"
+    ;;
+  embeddings)
+    code="$(curl -s -o /tmp/hw-smoke-infer.json -w '%{http_code}' \
+      -H 'Content-Type: application/json' \
+      -d "{\"model\":\"${SERVED_ID}\",\"input\":\"hello from the hardware smoke\"}" \
+      "http://127.0.0.1:${LOCAL_PORT}/v1/embeddings")"
+    [ "$code" = "200" ] \
+      || fail "/v1/embeddings returned $code: $(head -c 300 /tmp/hw-smoke-infer.json)"
+    dims="$(python3 -c 'import json;d=json.load(open("/tmp/hw-smoke-infer.json"));print(len((d.get("data") or [{}])[0].get("embedding") or []))')"
+    [ "${dims:-0}" -gt 0 ] \
+      || fail "/v1/embeddings returned 200 but an empty vector: $(head -c 300 /tmp/hw-smoke-infer.json)"
+    ok "/v1/embeddings 200 with a ${dims}-dimension vector"
+    ;;
+  models)
+    info "API_PROBE=models — inference call skipped by request"
+    ;;
+  *)
+    fail "unknown API_PROBE=$API_PROBE (want chat|embeddings|models)"
+    ;;
+esac
+kill "$PF_PID" 2>/dev/null || true
+PF_PID=""
+
+# ---------------------------------------------------------------------------
+# 4. Uninstall releases the board
+#
+# The hazard: the kubelet cannot finish NodeUnprepareResources if the DRA plugin
+# is gone or wedged, and the Pod then sits in Terminating with the board still
+# held. `helm uninstall --wait` returning is not proof — poll until the Pod
+# object is really gone.
+# ---------------------------------------------------------------------------
+log "uninstall releases the board"
+helm uninstall "$RELEASE" --namespace "$NAMESPACE" --wait
+gone=""
+for _ in $(seq 1 60); do
+  left="$(kubectl -n "$NAMESPACE" get pod -l app.kubernetes.io/instance="$RELEASE" -o name 2>/dev/null | wc -l | tr -d ' ')"
+  [ "$left" = "0" ] && { gone=yes; break; }
+  sleep 5
+done
+[ -n "$gone" ] \
+  || fail "the Pod was still present 300s after uninstall — stuck Terminating means the board is still claimed: $(kubectl -n "$NAMESPACE" get pod -l app.kubernetes.io/instance="$RELEASE" -o wide | tail -2)"
+for kind in resourceclaim resourceclaimtemplate; do
+  left=""
+  for _ in $(seq 1 30); do
+    left="$(kubectl -n "$NAMESPACE" get "$kind" -o name 2>/dev/null | wc -l | tr -d ' ')"
+    [ "$left" = "0" ] && break
+    sleep 2
+  done
+  [ "$left" = "0" ] || fail "$left $kind left in $NAMESPACE after uninstall"
+done
+ok "Pod and claim gone, board released"
+
+kubectl delete namespace "$NAMESPACE" --wait=false >/dev/null 2>&1 || true
+
+log "hardware smoke PASSED"
+printf 'model=%s device=%s image=%s compile=%ss budget=%ss (%s%%)\n' \
+  "$MODEL" "$DEVICE" "$IMAGE_REF" "$COMPILE" "$BUDGET" "$PCT"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Hardware smoke passed"
+    echo ""
+    echo "| | |"
+    echo "|---|---|"
+    echo "| model / device | \`$MODEL\` / \`$DEVICE\` |"
+    echo "| image | \`$IMAGE_REF\` |"
+    echo "| boards allocated | \`$DEVICES\` (asked for $WANT_COUNT x $WANT_BOARD) |"
+    echo "| hugepages | \`$HUGEPAGES\` |"
+    echo "| compile to Ready | ${COMPILE}s of the chart's ${BUDGET}s startupProbe budget (${PCT}%) |"
+    echo "| served id | \`$SERVED_ID\` (probe: $API_PROBE) |"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/.github/scripts/helm_hw_smoke.sh
+++ b/.github/scripts/helm_hw_smoke.sh
@@ -2,7 +2,8 @@
 # ---------------------------------------------------------------------------
 # Hardware smoke — the chart's runtime assumptions, on real silicon.
 #
-# Third tier of the chart's CI (see .github/workflows/helm-hw-smoke.yml):
+# Third tier of the chart's CI (nightly / on-demand, see
+# .github/workflows/helm-hw-smoke.yml):
 #   render gate  (helm-chart-validate) -> the manifests are well-formed
 #   install gate (helm-install-kind)   -> a live API server accepts them, and the
 #                                         Pod stalls only for lack of a device

--- a/.github/scripts/helm_hw_smoke.sh
+++ b/.github/scripts/helm_hw_smoke.sh
@@ -16,6 +16,10 @@
 #                                   Never the steady state: the smoke guards
 #                                   that pin.
 #   HUGEPAGES                       true|false (default: probe the node)
+#   HUGEPAGES_SIZE                  hugepages-1Gi request/limit when they are on
+#                                   (default: the node's allocatable). The chart
+#                                   asks for 32Gi regardless of board count,
+#                                   which no single-board host can schedule.
 #   HF_TOKEN                        gated weights only
 #   HF_CACHE_DIR                    host dir with pre-downloaded weights
 #   PULL_SECRET                     existing docker-registry secret to use
@@ -38,6 +42,7 @@ NAMESPACE="${NAMESPACE:-ttis-hw-smoke}"
 RELEASE="${RELEASE:-ttis-hw}"
 IMAGE_TAG="${IMAGE_TAG:-}"
 HUGEPAGES="${HUGEPAGES:-}"
+HUGEPAGES_SIZE="${HUGEPAGES_SIZE:-}"
 HF_TOKEN="${HF_TOKEN:-}"
 HF_CACHE_DIR="${HF_CACHE_DIR:-}"
 PULL_SECRET="${PULL_SECRET:-}"
@@ -89,13 +94,25 @@ HELM_SET=(--set "model=$MODEL" --set "device=$DEVICE")
 [ -n "$HF_CACHE_DIR" ] && HELM_SET+=(--set "hfCacheDir=$HF_CACHE_DIR")
 [ -n "$PULL_SECRET" ]  && HELM_SET+=(--set "defaults.image.pullSecrets[0].name=$PULL_SECRET")
 
+hp_alloc="$(kubectl get nodes -o jsonpath='{.items[0].status.allocatable.hugepages-1Gi}' 2>/dev/null || true)"
 # A runner with no 1Gi pages would leave the Pod Pending unrelated to DRA.
 if [ -z "$HUGEPAGES" ]; then
-  hp_alloc="$(kubectl get nodes -o jsonpath='{.items[0].status.allocatable.hugepages-1Gi}' 2>/dev/null || true)"
   case "${hp_alloc:-0}" in ""|0|0Gi|0Ki) HUGEPAGES=false ;; *) HUGEPAGES=true ;; esac
   info "HUGEPAGES not set -> $HUGEPAGES (node allocatable hugepages-1Gi=${hp_alloc:-0})"
 fi
 HELM_SET+=(--set "hugepages.enabled=$HUGEPAGES")
+
+# The chart's 32Gi request is Galaxy-sized and fixed, so on a smaller host the
+# Pod is unschedulable for a reason that has nothing to do with what we assert.
+# Capacity adaptation, like CPU_REQUEST / MEMORY_REQUEST.
+if [ "$HUGEPAGES" = "true" ]; then
+  [ -n "$HUGEPAGES_SIZE" ] || HUGEPAGES_SIZE="$hp_alloc"
+  if [ -n "$HUGEPAGES_SIZE" ]; then
+    info "hugepages request/limit -> $HUGEPAGES_SIZE (chart default is 32Gi)"
+    HELM_SET+=(--set "defaults.resources.requests.hugepages-1Gi=$HUGEPAGES_SIZE"
+               --set "defaults.resources.limits.hugepages-1Gi=$HUGEPAGES_SIZE")
+  fi
+fi
 
 # Random rather than fixed: a fixed key would still pass if the chart stopped
 # wiring it and the server fell back to its built-in default.
@@ -183,8 +200,14 @@ for _ in $(seq 1 60); do
   [ -n "${DEVICES// /}" ] && break
   sleep 5
 done
-[ -n "${DEVICES// /}" ] \
-  || fail "ResourceClaim $CLAIM never allocated — the scheduler found no free $WANT_BOARD board for this Pod"
+if [ -z "${DEVICES// /}" ]; then
+  # The claim is allocated during scheduling, so anything that makes the Pod
+  # unschedulable (hugepages, cpu, memory) leaves it unallocated too. Report
+  # what the scheduler actually said.
+  why="$(kubectl -n "$NAMESPACE" get events --field-selector reason=FailedScheduling \
+    -o jsonpath='{.items[-1:].message}' 2>/dev/null || true)"
+  fail "ResourceClaim $CLAIM never allocated. Scheduler: ${why:-<no FailedScheduling event>}"
+fi
 ok "claim $CLAIM allocated: $DEVICES"
 
 priv="$(kubectl -n "$NAMESPACE" get pod "$POD" -o jsonpath='{.spec.containers[0].securityContext.privileged}')"

--- a/.github/scripts/helm_hw_smoke.sh
+++ b/.github/scripts/helm_hw_smoke.sh
@@ -320,7 +320,7 @@ AUTH=()
 code="$(curl -s -o /tmp/hw-smoke-models.json -w '%{http_code}' \
   "${AUTH[@]+"${AUTH[@]}"}" "http://127.0.0.1:${LOCAL_PORT}/v1/models")"
 [ "$code" = "200" ] || fail "/v1/models returned $code"
-SERVED_ID="$(python3 -c 'import json;d=json.load(open("/tmp/hw-smoke-models.json"));print((d.get("data") or [{}])[0].get("id",""))')"
+SERVED_ID="$(python3 -c 'import json;d=json.load(open("/tmp/hw-smoke-models.json"));print((d.get("data") or [{}])[0].get("id",""))' 2>/dev/null || true)"
 [ -n "$SERVED_ID" ] \
   || fail "/v1/models returned 200 but listed no model: $(head -c 300 /tmp/hw-smoke-models.json)"
 ok "/v1/models 200, serving id=$SERVED_ID"
@@ -391,7 +391,7 @@ if [ -n "$INFER_PATH" ]; then
       ok "$INFER_PATH 200 with generated content"
       ;;
     embeddings)
-      dims="$(python3 -c 'import json;d=json.load(open("/tmp/hw-smoke-infer.json"));print(len((d.get("data") or [{}])[0].get("embedding") or []))')"
+      dims="$(python3 -c 'import json;d=json.load(open("/tmp/hw-smoke-infer.json"));print(len((d.get("data") or [{}])[0].get("embedding") or []))' 2>/dev/null || true)"
       [ "${dims:-0}" -gt 0 ] \
         || fail "$INFER_PATH returned 200 but an empty vector: $(head -c 300 /tmp/hw-smoke-infer.json)"
       ok "$INFER_PATH 200 with a ${dims}-dimension vector"

--- a/.github/scripts/helm_hw_smoke.sh
+++ b/.github/scripts/helm_hw_smoke.sh
@@ -20,10 +20,6 @@
 #                                   downloads (default: $HTTPS_PROXY with its
 #                                   host resolved to an IP, since the Pod's DNS
 #                                   cannot resolve the runner's proxy Service)
-#   HUGEPAGES_SIZE                  hugepages-1Gi request/limit when they are on
-#                                   (default: the node's allocatable). The chart
-#                                   asks for 32Gi regardless of board count,
-#                                   which no single-board host can schedule.
 #   HF_TOKEN                        gated weights only
 #   HF_CACHE_DIR                    host dir with pre-downloaded weights
 #   PULL_SECRET                     existing docker-registry secret to use
@@ -46,7 +42,6 @@ NAMESPACE="${NAMESPACE:-ttis-hw-smoke}"
 RELEASE="${RELEASE:-ttis-hw}"
 IMAGE_TAG="${IMAGE_TAG:-}"
 HUGEPAGES="${HUGEPAGES:-}"
-HUGEPAGES_SIZE="${HUGEPAGES_SIZE:-}"
 POD_PROXY="${POD_PROXY:-}"
 HF_TOKEN="${HF_TOKEN:-}"
 HF_CACHE_DIR="${HF_CACHE_DIR:-}"
@@ -107,13 +102,6 @@ if [ -z "$HUGEPAGES" ]; then
 fi
 HELM_SET+=(--set "hugepages.enabled=$HUGEPAGES")
 
-# The chart's 32Gi request is Galaxy-sized and fixed, so on a smaller host the
-# Pod is unschedulable for a reason that has nothing to do with what we assert.
-# Capacity adaptation, like CPU_REQUEST / MEMORY_REQUEST.
-if [ "$HUGEPAGES" = "true" ] && [ -z "$HUGEPAGES_SIZE" ]; then
-  HUGEPAGES_SIZE="$hp_alloc"
-fi
-
 # The Pod downloads weights from HuggingFace, and on a proxied runner it cannot
 # inherit the proxy: the host resolves the proxy Service through the outer
 # cluster's DNS, the Pod cannot. Resolve it to an IP, as tt-operator does for
@@ -142,19 +130,12 @@ HELM_SET+=(--set "auth.apiKey=$API_KEY")
 # A values file, not --set: the row path contains the model name (and model names
 # contain dots that --set reads as separators), and NO_PROXY contains commas.
 if [ -n "$IMAGE_TAG" ] || [ -n "$CPU_REQUEST" ] || [ -n "$MEMORY_REQUEST" ] \
-   || [ -n "$HUGEPAGES_SIZE" ] || [ -n "$POD_PROXY" ]; then
+   || [ -n "$POD_PROXY" ]; then
   OVERRIDES="$(mktemp /tmp/hw-smoke-overrides.XXXXXX)"
   : > "$OVERRIDES"
-  if [ -n "$HUGEPAGES_SIZE" ] || [ -n "$POD_PROXY" ]; then
+  if [ -n "$POD_PROXY" ]; then
     {
       echo "defaults:"
-      if [ -n "$HUGEPAGES_SIZE" ]; then
-        echo "  resources:"
-        echo "    requests:"
-        echo "      hugepages-1Gi: \"$HUGEPAGES_SIZE\""
-        echo "    limits:"
-        echo "      hugepages-1Gi: \"$HUGEPAGES_SIZE\""
-      fi
       if [ -n "$POD_PROXY" ]; then
         echo "  extraEnv:"
         echo "    - name: HTTPS_PROXY"

--- a/.github/scripts/hw_smoke_bootstrap.sh
+++ b/.github/scripts/hw_smoke_bootstrap.sh
@@ -1,32 +1,15 @@
 #!/usr/bin/env bash
-# ---------------------------------------------------------------------------
-# Bootstrap a Tenstorrent hardware runner into a cluster the chart can run on.
+# Turns a bare Tenstorrent runner (ephemeral KVM VM, card passed through, tt-kmd
+# preloaded) into what helm_hw_smoke.sh needs: an RKE2 cluster with tt-operator
+# publishing devices. tt-k8s-driver-manager stays off — the runner's kmd is
+# already loaded, and reinstalling it costs two DKMS builds and a device churn
+# window per run. tt-telemetry / jobset / kubepmix are off as unused.
 #
-# The hardware smoke (.github/scripts/helm_hw_smoke.sh) assumes "tt-operator is
-# installed and publishing devices". On the shared TT runner pool that is not a
-# given: the runners are ephemeral KVM VMs with a card passed through and tt-kmd
-# preloaded, and nothing else. This script turns one into that assumption:
-#
-#   RKE2 single-node cluster (DRA is GA in the pinned k8s) ->
-#   tt-operator umbrella, NFD + tt-fabric-manager + tt-dra-driver only ->
-#   devices published in a ResourceSlice
-#
-# tt-k8s-driver-manager is deliberately OFF: the runner already has tt-kmd
-# loaded, and letting the manager reinstall it would add two DKMS builds and a
-# device churn window to every run for nothing this smoke asserts. Same for
-# tt-telemetry / jobset / kubepmix (kubepmix would also drag in cert-manager).
-#
-# THE PLUGIN RESTART, and why it is here rather than in the smoke: the DRA
-# kubelet plugin discovers boards through tt-fabric-manager's GetTopology and
-# publishes a ResourceSlice. If it comes up before TTFM has topology, it
-# publishes a slice with no devices and does not refresh it for the life of the
-# pod — claims then never allocate. In tt-operator's own integration-rke2 runs
-# this is visible as `dra-smoke` failing on 40 of 42 job instances; the two that
-# allocated are exactly the two where the plugin pod happened to (re)start ~45s
-# after the driver was up. Restarting the DaemonSet once TTFM is Ready makes
-# that ordering deliberate instead of lucky.
-#
-# Usage:  bash .github/scripts/hw_smoke_bootstrap.sh
+# The DRA kubelet plugin only discovers boards at startup, so one that comes up
+# before tt-fabric-manager has topology publishes a device-less ResourceSlice and
+# never refreshes it — hence the restart once TTFM is Ready. In tt-operator's own
+# integration-rke2 runs, dra-smoke fails on 40 of 42 jobs for exactly this, and
+# both that allocated are ones where the plugin happened to restart late.
 #
 # Knobs (all optional):
 #   RKE2_VERSION           pinned RKE2 release (k8s >= 1.34 needed: DRA GA)
@@ -38,7 +21,6 @@
 #                          ghcr.io anonymously.
 #   SKIP_CLUSTER=true      cluster + tt-operator are already there; only run the
 #                          preflight and the device-publication wait
-# ---------------------------------------------------------------------------
 set -euo pipefail
 
 RKE2_VERSION="${RKE2_VERSION:-v1.36.1+rke2r2}"
@@ -58,17 +40,12 @@ ok()   { printf 'OK   %s\n' "$*"; }
 warn() { printf '::warning::%s\n' "$*"; }
 fail() { printf '::error::%s\n' "$*" >&2; exit 1; }
 
-# Export a value to later workflow steps when running under Actions.
 export_env() {
   info "$1=$2"
   [ -n "${GITHUB_ENV:-}" ] && echo "$1=$2" >> "$GITHUB_ENV"
   return 0
 }
 
-# ---------------------------------------------------------------------------
-# Preflight — what this host actually is. Cheap, and it turns "the Pod stayed
-# Pending" into a one-line answer later.
-# ---------------------------------------------------------------------------
 log "preflight: the runner"
 [ -d /dev/tenstorrent ] || fail "no /dev/tenstorrent — this is not a Tenstorrent runner (or tt-kmd is not loaded)"
 DEV_COUNT="$(find /dev/tenstorrent -maxdepth 1 -type c | wc -l | tr -d ' ')"
@@ -97,8 +74,6 @@ info "1Gi hugepages: nr=$NR_HP free=$FREE_HP"
 if [ "$HUGEPAGES_NEEDED" = "true" ] && [ "$NR_HP" = "0" ]; then
   warn "the boards are in an identity IOMMU domain (hugepages required) but the host has no 1Gi hugepages — the chart will be installed with hugepages off and the device may fail to open"
 fi
-# The smoke asks the node, not this script, but exporting it keeps the decision
-# visible in the log and lets a caller override it per run.
 if [ "$HUGEPAGES_NEEDED" = "true" ] && [ "$NR_HP" != "0" ]; then
   export_env HW_SMOKE_HUGEPAGES true
 else
@@ -115,10 +90,7 @@ if [ "$SKIP_CLUSTER" = "true" ]; then
   info "SKIP_CLUSTER=true — leaving the cluster and tt-operator alone"
 else
 
-# ---------------------------------------------------------------------------
-# RKE2. Mirrors tt-operator's setup-rke2-cluster action (same runner pool, same
-# proxy traversal problem), minus cert-manager: nothing we install needs it.
-# ---------------------------------------------------------------------------
+# Mirrors tt-operator's setup-rke2-cluster action, minus cert-manager.
 log "install RKE2 $RKE2_VERSION"
 curl -sfL https://get.rke2.io -o /tmp/rke2-install.sh
 sudo -E INSTALL_RKE2_VERSION="$RKE2_VERSION" bash /tmp/rke2-install.sh
@@ -174,9 +146,6 @@ kubectl api-resources --api-group=resource.k8s.io 2>/dev/null | grep -q resource
   || fail "this cluster does not serve resource.k8s.io — DRA is not available (need k8s >= 1.34)"
 ok "cluster up, resource.k8s.io served"
 
-# ---------------------------------------------------------------------------
-# tt-operator: the DRA layer the chart consumes.
-# ---------------------------------------------------------------------------
 log "install tt-operator $TT_OPERATOR_VERSION (NFD + tt-fabric-manager + tt-dra-driver)"
 kubectl create namespace "$OPERATOR_NS" --dry-run=client -o yaml | kubectl apply -f -
 OP_SET=(
@@ -205,9 +174,6 @@ helm install "$RELEASE" "$TT_OPERATOR_CHART" --version "$TT_OPERATOR_VERSION" \
 
 fi  # SKIP_CLUSTER
 
-# ---------------------------------------------------------------------------
-# Devices published. See the header for why the plugin gets restarted.
-# ---------------------------------------------------------------------------
 log "wait for tt-fabric-manager, then republish the DRA slice"
 # The DaemonSets are created by the install above, but NFD has to label the node
 # before their pods are scheduled — poll for the objects rather than assume.

--- a/.github/scripts/hw_smoke_bootstrap.sh
+++ b/.github/scripts/hw_smoke_bootstrap.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Bootstrap a Tenstorrent hardware runner into a cluster the chart can run on.
+#
+# The hardware smoke (.github/scripts/helm_hw_smoke.sh) assumes "tt-operator is
+# installed and publishing devices". On the shared TT runner pool that is not a
+# given: the runners are ephemeral KVM VMs with a card passed through and tt-kmd
+# preloaded, and nothing else. This script turns one into that assumption:
+#
+#   RKE2 single-node cluster (DRA is GA in the pinned k8s) ->
+#   tt-operator umbrella, NFD + tt-fabric-manager + tt-dra-driver only ->
+#   devices published in a ResourceSlice
+#
+# tt-k8s-driver-manager is deliberately OFF: the runner already has tt-kmd
+# loaded, and letting the manager reinstall it would add two DKMS builds and a
+# device churn window to every run for nothing this smoke asserts. Same for
+# tt-telemetry / jobset / kubepmix (kubepmix would also drag in cert-manager).
+#
+# THE PLUGIN RESTART, and why it is here rather than in the smoke: the DRA
+# kubelet plugin discovers boards through tt-fabric-manager's GetTopology and
+# publishes a ResourceSlice. If it comes up before TTFM has topology, it
+# publishes a slice with no devices and does not refresh it for the life of the
+# pod — claims then never allocate. In tt-operator's own integration-rke2 runs
+# this is visible as `dra-smoke` failing on 40 of 42 job instances; the two that
+# allocated are exactly the two where the plugin pod happened to (re)start ~45s
+# after the driver was up. Restarting the DaemonSet once TTFM is Ready makes
+# that ordering deliberate instead of lucky.
+#
+# Usage:  bash .github/scripts/hw_smoke_bootstrap.sh
+#
+# Knobs (all optional):
+#   RKE2_VERSION           pinned RKE2 release (k8s >= 1.34 needed: DRA GA)
+#   TT_OPERATOR_VERSION    umbrella chart version to install
+#   OPERATOR_NS            namespace for tt-operator (default tt-operator-system)
+#   GHCR_USERNAME / GHCR_TOKEN
+#                          create a pull secret and wire it into the subcharts.
+#                          Only needed where the container runtime cannot pull
+#                          ghcr.io anonymously.
+#   SKIP_CLUSTER=true      cluster + tt-operator are already there; only run the
+#                          preflight and the device-publication wait
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+RKE2_VERSION="${RKE2_VERSION:-v1.36.1+rke2r2}"
+TT_OPERATOR_CHART="${TT_OPERATOR_CHART:-oci://ghcr.io/tenstorrent/helm/tt-operator}"
+TT_OPERATOR_VERSION="${TT_OPERATOR_VERSION:-0.2.0}"
+OPERATOR_NS="${OPERATOR_NS:-tt-operator-system}"
+RELEASE="${TT_OPERATOR_RELEASE:-tt-operator}"
+GHCR_USERNAME="${GHCR_USERNAME:-}"
+GHCR_TOKEN="${GHCR_TOKEN:-}"
+PULL_SECRET="${PULL_SECRET:-tt-operator-image-pulltoken}"
+SKIP_CLUSTER="${SKIP_CLUSTER:-false}"
+SLICE_TIMEOUT="${SLICE_TIMEOUT:-300}"
+
+log()  { printf '\n=== %s ===\n' "$*"; }
+info() { printf '     %s\n' "$*"; }
+ok()   { printf 'OK   %s\n' "$*"; }
+warn() { printf '::warning::%s\n' "$*"; }
+fail() { printf '::error::%s\n' "$*" >&2; exit 1; }
+
+# Export a value to later workflow steps when running under Actions.
+export_env() {
+  info "$1=$2"
+  [ -n "${GITHUB_ENV:-}" ] && echo "$1=$2" >> "$GITHUB_ENV"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Preflight — what this host actually is. Cheap, and it turns "the Pod stayed
+# Pending" into a one-line answer later.
+# ---------------------------------------------------------------------------
+log "preflight: the runner"
+[ -d /dev/tenstorrent ] || fail "no /dev/tenstorrent — this is not a Tenstorrent runner (or tt-kmd is not loaded)"
+DEV_COUNT="$(find /dev/tenstorrent -maxdepth 1 -type c | wc -l | tr -d ' ')"
+[ "$DEV_COUNT" -ge 1 ] || fail "/dev/tenstorrent exists but holds no device node"
+info "device nodes: $DEV_COUNT"
+if [ -r /sys/module/tenstorrent/version ]; then
+  info "tt-kmd: $(cat /sys/module/tenstorrent/version)"
+else
+  warn "tt-kmd version unreadable (/sys/module/tenstorrent/version) — module not loaded via DKMS?"
+fi
+
+# IOMMU mode decides whether the boards need 1Gi hugepages at all: a device in a
+# translating domain (DMA / DMA-FQ) does not, one in identity/passthrough does.
+HUGEPAGES_NEEDED=true
+for d in /sys/bus/pci/devices/*; do
+  [ -r "$d/vendor" ] || continue
+  [ "$(cat "$d/vendor")" = "0x1e52" ] || continue
+  itype="$(cat "$d/iommu_group/type" 2>/dev/null || echo unknown)"
+  info "$(basename "$d") iommu_group type=$itype"
+  case "$itype" in DMA*) HUGEPAGES_NEEDED=false ;; esac
+  break
+done
+NR_HP="$(cat /sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages 2>/dev/null || echo 0)"
+FREE_HP="$(cat /sys/kernel/mm/hugepages/hugepages-1048576kB/free_hugepages 2>/dev/null || echo 0)"
+info "1Gi hugepages: nr=$NR_HP free=$FREE_HP"
+if [ "$HUGEPAGES_NEEDED" = "true" ] && [ "$NR_HP" = "0" ]; then
+  warn "the boards are in an identity IOMMU domain (hugepages required) but the host has no 1Gi hugepages — the chart will be installed with hugepages off and the device may fail to open"
+fi
+# The smoke asks the node, not this script, but exporting it keeps the decision
+# visible in the log and lets a caller override it per run.
+if [ "$HUGEPAGES_NEEDED" = "true" ] && [ "$NR_HP" != "0" ]; then
+  export_env HW_SMOKE_HUGEPAGES true
+else
+  export_env HW_SMOKE_HUGEPAGES false
+fi
+
+info "cpu(s)=$(nproc) memory=$(awk '/MemTotal/{printf "%.0fGi", $2/1048576}' /proc/meminfo)"
+info "disk: $(df -h --output=avail / | tail -1 | tr -d ' ') available on /"
+AVAIL_GB="$(df --output=avail -BG / | tail -1 | tr -dc '0-9')"
+[ "${AVAIL_GB:-0}" -ge 60 ] \
+  || warn "only ${AVAIL_GB}Gi free on / — an inference image plus weights and a compile cache usually needs more; a pull failure here is capacity, not the chart"
+
+if [ "$SKIP_CLUSTER" = "true" ]; then
+  info "SKIP_CLUSTER=true — leaving the cluster and tt-operator alone"
+else
+
+# ---------------------------------------------------------------------------
+# RKE2. Mirrors tt-operator's setup-rke2-cluster action (same runner pool, same
+# proxy traversal problem), minus cert-manager: nothing we install needs it.
+# ---------------------------------------------------------------------------
+log "install RKE2 $RKE2_VERSION"
+curl -sfL https://get.rke2.io -o /tmp/rke2-install.sh
+sudo -E INSTALL_RKE2_VERSION="$RKE2_VERSION" bash /tmp/rke2-install.sh
+
+# Containerd inside RKE2 needs the proxy on its own process tree, or every
+# in-cluster image pull (ghcr.io, registry.k8s.io) dies. The runner's default
+# no_proxy covers none of the cluster CIDRs, so spell them out.
+NPROXY="127.0.0.1,localhost,::1,10.0.0.0/8,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,${no_proxy:-}"
+sudo mkdir -p /etc/systemd/system/rke2-server.service.d
+sudo tee /etc/systemd/system/rke2-server.service.d/proxy.conf >/dev/null <<EOF
+[Service]
+Environment="HTTPS_PROXY=${HTTPS_PROXY:-${https_proxy:-}}"
+Environment="HTTP_PROXY=${HTTP_PROXY:-${http_proxy:-}}"
+Environment="NO_PROXY=${NPROXY}"
+Environment="https_proxy=${https_proxy:-${HTTPS_PROXY:-}}"
+Environment="http_proxy=${http_proxy:-${HTTP_PROXY:-}}"
+Environment="no_proxy=${NPROXY}"
+EOF
+sudo systemctl daemon-reload
+sudo systemctl enable rke2-server
+# --no-block: systemd's Type=notify deadline is tighter than rke2's first start
+# (etcd init + image load). Wait on the real ready signal, rke2.yaml on disk.
+sudo systemctl start --no-block rke2-server
+sudo timeout 600 bash -c 'until [ -s /etc/rancher/rke2/rke2.yaml ]; do sleep 5; done' \
+  || fail "rke2-server never wrote a kubeconfig — check journalctl -u rke2-server"
+mkdir -p "$HOME/.kube"
+sudo install -m 0600 -o "$USER" -g "$USER" /etc/rancher/rke2/rke2.yaml "$HOME/.kube/config"
+export KUBECONFIG="$HOME/.kube/config"
+export_env KUBECONFIG "$HOME/.kube/config"
+export NO_PROXY="$NPROXY" no_proxy="$NPROXY"
+export_env NO_PROXY "$NPROXY"
+export_env no_proxy "$NPROXY"
+
+if ! command -v kubectl >/dev/null; then
+  KCTL_VER="$(curl -sfL https://dl.k8s.io/release/stable.txt)"
+  curl -sfL -o /tmp/kubectl "https://dl.k8s.io/release/${KCTL_VER}/bin/linux/amd64/kubectl"
+  sudo install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+fi
+command -v helm >/dev/null || curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+kubectl version --client
+helm version --short
+
+log "wait for the API server and the node"
+timeout 300 bash -c 'until kubectl get --raw=/readyz >/dev/null 2>&1; do sleep 5; done' \
+  || fail "API server never became ready"
+# The node object can lag /readyz; `kubectl wait --all` errors with "no matching
+# resources" in that window, so block until at least one Node exists first.
+# shellcheck disable=SC2016  # the poll must evaluate inside the timeout'd shell
+timeout 180 bash -c 'until [ "$(kubectl get nodes --no-headers 2>/dev/null | wc -l)" -gt 0 ]; do sleep 3; done'
+kubectl wait --for=condition=Ready node --all --timeout=5m
+kubectl get nodes -o wide
+kubectl api-resources --api-group=resource.k8s.io 2>/dev/null | grep -q resourceslices \
+  || fail "this cluster does not serve resource.k8s.io — DRA is not available (need k8s >= 1.34)"
+ok "cluster up, resource.k8s.io served"
+
+# ---------------------------------------------------------------------------
+# tt-operator: the DRA layer the chart consumes.
+# ---------------------------------------------------------------------------
+log "install tt-operator $TT_OPERATOR_VERSION (NFD + tt-fabric-manager + tt-dra-driver)"
+kubectl create namespace "$OPERATOR_NS" --dry-run=client -o yaml | kubectl apply -f -
+OP_SET=(
+  --set tt-k8s-driver-manager.enabled=false
+  --set tt-telemetry.enabled=false
+  --set jobset.enabled=false
+  --set kubepmix.enabled=false
+)
+if [ -n "$GHCR_TOKEN" ]; then
+  echo "$GHCR_TOKEN" | helm registry login ghcr.io --username "${GHCR_USERNAME:-x}" --password-stdin
+  kubectl create secret docker-registry "$PULL_SECRET" -n "$OPERATOR_NS" \
+    --docker-server=ghcr.io --docker-username="${GHCR_USERNAME:-x}" --docker-password="$GHCR_TOKEN" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  for sub in tt-fabric-manager tt-dra-driver; do
+    OP_SET+=(--set "${sub}.imagePullSecrets[0].name=$PULL_SECRET")
+  done
+  info "pull secret $PULL_SECRET staged and wired into the subcharts"
+else
+  info "no GHCR_TOKEN given — relying on anonymous ghcr.io pulls"
+fi
+# No --wait: the DRA kubelet plugin crash-loops until the TTFM agent answers
+# GetTopology, so "all resources Ready" is not a meaningful install gate here.
+# The rollout waits below are, and they say which component is late.
+helm install "$RELEASE" "$TT_OPERATOR_CHART" --version "$TT_OPERATOR_VERSION" \
+  -n "$OPERATOR_NS" "${OP_SET[@]}"
+
+fi  # SKIP_CLUSTER
+
+# ---------------------------------------------------------------------------
+# Devices published. See the header for why the plugin gets restarted.
+# ---------------------------------------------------------------------------
+log "wait for tt-fabric-manager, then republish the DRA slice"
+# The DaemonSets are created by the install above, but NFD has to label the node
+# before their pods are scheduled — poll for the objects rather than assume.
+FM_DS=""; DRA_DS=""
+for _ in $(seq 1 60); do
+  FM_DS="$(kubectl -n "$OPERATOR_NS" get ds -o name 2>/dev/null | grep -m1 'fabric-manager-agent' || true)"
+  DRA_DS="$(kubectl -n "$OPERATOR_NS" get ds -l app.kubernetes.io/name=tt-dra-driver -o name 2>/dev/null | head -1)"
+  { [ -n "$FM_DS" ] && [ -n "$DRA_DS" ]; } && break
+  sleep 5
+done
+[ -n "$FM_DS" ] || fail "no tt-fabric-manager agent DaemonSet in $OPERATOR_NS — tt-dra-driver would have no topology source"
+[ -n "$DRA_DS" ] || fail "no tt-dra-driver DaemonSet in $OPERATOR_NS"
+kubectl -n "$OPERATOR_NS" rollout status "$FM_DS" --timeout=10m
+kubectl -n "$OPERATOR_NS" rollout status "$DRA_DS" --timeout=10m
+
+info "restarting $DRA_DS so discovery runs with topology already up"
+kubectl -n "$OPERATOR_NS" rollout restart "$DRA_DS"
+kubectl -n "$OPERATOR_NS" rollout status "$DRA_DS" --timeout=10m
+
+log "wait for boards in a ResourceSlice"
+published=""
+end=$(( $(date -u +%s) + SLICE_TIMEOUT ))
+while [ "$(date -u +%s)" -lt "$end" ]; do
+  published="$(kubectl get resourceslices \
+    -o jsonpath='{range .items[*]}{range .spec.devices[*]}{.name}{"="}{.attributes.boardName.string}{" "}{end}{end}' 2>/dev/null || true)"
+  [ -n "${published// /}" ] && break
+  sleep 5
+done
+if [ -z "${published// /}" ]; then
+  kubectl get resourceslices -o yaml || true
+  kubectl -n "$OPERATOR_NS" logs "$DRA_DS" --tail=80 || true
+  kubectl -n "$OPERATOR_NS" logs "$FM_DS" --tail=80 || true
+  fail "no devices published within ${SLICE_TIMEOUT}s — tt-fabric-manager reported no topology on this runner, so no claim can allocate (environment, not the chart)"
+fi
+ok "boards published: $published"
+kubectl get deviceclass

--- a/.github/workflows/helm-hw-smoke.yml
+++ b/.github/workflows/helm-hw-smoke.yml
@@ -113,13 +113,10 @@ jobs:
           HUGEPAGES: ${{ env.HW_SMOKE_HUGEPAGES }}
           # Only gated weights need this; the default row is ungated.
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          # The media / forge server guards its inference routes with a static
-          # key and the chart configures neither API_KEY nor NO_AUTH, so a
-          # chart-deployed server runs on the image's default. Passing that
-          # default here keeps the smoke honest about what the chart ships;
-          # leave it empty for vLLM rows, which are open unless VLLM_API_KEY or
-          # JWT_SECRET is set. See tt-media-server/security/api_key_checker.py.
-          API_KEY: ${{ (github.event.inputs.api-probe || 'embeddings') == 'chat' && '' || 'your-secret-key' }}
+          # API_KEY is left to the script: it mints a fresh key per run, installs
+          # it through the chart's auth.apiKey, and checks both that an
+          # authenticated call succeeds and that an unauthenticated one is
+          # refused. Set this only to pin a key for debugging.
         run: bash .github/scripts/helm_hw_smoke.sh
 
       - name: Diagnostics on failure

--- a/.github/workflows/helm-hw-smoke.yml
+++ b/.github/workflows/helm-hw-smoke.yml
@@ -1,0 +1,135 @@
+name: Helm Chart Hardware Smoke
+
+# Real-hardware tier of the chart's CI. The two cheaper tiers live in
+# test-gate.yml and run on every PR:
+#
+#   helm-chart-validate  render + kubeconform + DRA claim structure
+#   helm-install-kind    a live k8s 1.34 API server installs the chart and the
+#                        Pod stays Pending only because no device exists
+#
+# This one runs the chart on a Tenstorrent board: one small model, one device
+# shape, asserting only what neither of the above can — that a real inference
+# image gets its device through the DRA claim, comes up inside the startupProbe
+# compile window, answers on /v1/..., and gives the board back on uninstall.
+# See .github/scripts/helm_hw_smoke.sh for the asserts themselves.
+#
+# Deliberately NOT per-PR: it takes a scarce board for well over an hour (image
+# pull, weight download, compile), so it is manual (workflow_dispatch) or opt-in
+# on a PR by adding the `ci:hw-smoke` label. Nothing here gates test-gate.yml.
+#
+# Preconditions this workflow creates for itself: the runner pool is bare (a KVM
+# VM with a card passed through and tt-kmd preloaded), so the first step stands
+# up RKE2 + tt-operator via .github/scripts/hw_smoke_bootstrap.sh.
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner pool to take a board from.
+        type: choice
+        default: tt-ubuntu-2204-n150-stable
+        options:
+          - tt-ubuntu-2204-n150-stable
+          - tt-ubuntu-2204-bh-loudbox-viommu-stable
+      model:
+        description: Chart model value.
+        default: Qwen3-Embedding-4B
+      device:
+        description: Chart device value. Must match the runner's board.
+        default: n150
+      engine:
+        description: Chart engine value (pins the values row).
+        default: forge
+      impl:
+        description: Chart impl value (pins the values row).
+        default: forge_vllm_plugin
+      image-tag:
+        description: >-
+          Override the row's pinned image tag. For separating "the chart is
+          broken" from "the pinned image is stale" — leave empty normally.
+        default: ""
+      api-probe:
+        description: Inference call to make (chat, embeddings, or models to skip).
+        type: choice
+        default: embeddings
+        options: [embeddings, chat, models]
+      max-wait-seconds:
+        description: How long to wait for Ready before failing.
+        default: "2700"
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - "charts/**"
+      - ".github/scripts/helm_hw_smoke.sh"
+      - ".github/scripts/hw_smoke_bootstrap.sh"
+      - ".github/workflows/helm-hw-smoke.yml"
+
+# One board at a time per ref. A superseded PR run is cancelled; a manual run is
+# not, so an intentional dispatch never loses its board to a push.
+concurrency:
+  group: helm-hw-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  hw-smoke:
+    name: Hardware Smoke (${{ github.event.inputs.model || 'Qwen3-Embedding-4B' }} / ${{ github.event.inputs.device || 'n150' }})
+    # On a PR this needs the opt-in label; a dispatch is the opt-in.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:hw-smoke')
+    runs-on: ${{ github.event.inputs.runner || 'tt-ubuntu-2204-n150-stable' }}
+    # Generous on purpose: a ~20GB image pull plus weight download plus first
+    # compile dominates, and the smoke's own Ready budget is 45m by default.
+    timeout-minutes: 150
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Bootstrap (RKE2 + tt-operator + published boards)
+        env:
+          # Optional: only needed where the container runtime cannot pull
+          # ghcr.io anonymously. Absent secrets resolve to empty, which is
+          # exactly the "anonymous" path.
+          GHCR_USERNAME: ${{ github.repository_owner }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PULL_PAT }}
+        run: bash .github/scripts/hw_smoke_bootstrap.sh
+
+      - name: Hardware smoke
+        env:
+          MODEL: ${{ github.event.inputs.model || 'Qwen3-Embedding-4B' }}
+          DEVICE: ${{ github.event.inputs.device || 'n150' }}
+          ENGINE: ${{ github.event.inputs.engine || 'forge' }}
+          IMPL: ${{ github.event.inputs.impl || 'forge_vllm_plugin' }}
+          IMAGE_TAG: ${{ github.event.inputs.image-tag }}
+          API_PROBE: ${{ github.event.inputs.api-probe || 'embeddings' }}
+          MAX_WAIT_SECONDS: ${{ github.event.inputs.max-wait-seconds || '2700' }}
+          # Set by the bootstrap step from the runner's IOMMU mode; the script
+          # falls back to probing the node when it is empty.
+          HUGEPAGES: ${{ env.HW_SMOKE_HUGEPAGES }}
+          # Only gated weights need this; the default row is ungated.
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: bash .github/scripts/helm_hw_smoke.sh
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get nodes -o wide || true
+          kubectl get pods -A -o wide || true
+          kubectl get resourceslices,deviceclasses -o wide || true
+          kubectl -n tt-operator-system logs -l app.kubernetes.io/name=tt-dra-driver --tail=100 || true
+          sudo journalctl -u rke2-server --no-pager | tail -60 || true
+
+      # The runner VM is destroyed at job end, so this is not for its sake: it
+      # keeps the teardown ORDER on record and makes the workflow safe to point
+      # at a persistent cluster. Removing tt-operator first would take the DRA
+      # kubelet plugin out from under a running Pod, and NodeUnprepareResources
+      # can then never complete — the Pod sticks in Terminating holding a board.
+      - name: Teardown (workload first, then tt-operator)
+        if: always()
+        run: |
+          helm uninstall ttis-hw -n ttis-hw-smoke --wait --timeout 5m || true
+          kubectl -n ttis-hw-smoke wait --for=delete pod --all --timeout=5m || true
+          helm uninstall tt-operator -n tt-operator-system --wait --timeout 5m || true

--- a/.github/workflows/helm-hw-smoke.yml
+++ b/.github/workflows/helm-hw-smoke.yml
@@ -13,9 +13,9 @@ name: Helm Chart Hardware Smoke
 # compile window, answers on /v1/..., and gives the board back on uninstall.
 # See .github/scripts/helm_hw_smoke.sh for the asserts themselves.
 #
-# Deliberately NOT per-PR: it takes a scarce board for well over an hour (image
-# pull, weight download, compile), so it is manual (workflow_dispatch) or opt-in
-# on a PR by adding the `ci:hw-smoke` label. Nothing here gates test-gate.yml.
+# Deliberately NOT per-PR: it holds a scarce board for the whole run, so it is
+# manual (workflow_dispatch) or opt-in on a PR by adding the `ci:hw-smoke`
+# label. Nothing here gates test-gate.yml.
 #
 # Preconditions this workflow creates for itself: the runner pool is bare (a KVM
 # VM with a card passed through and tt-kmd preloaded), so the first step stands
@@ -82,8 +82,10 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'ci:hw-smoke')
     runs-on: ${{ github.event.inputs.runner || 'tt-ubuntu-2204-n150-stable' }}
-    # Generous on purpose: a ~20GB image pull plus weight download plus first
-    # compile dominates, and the smoke's own Ready budget is 45m by default.
+    # Measured on a T3K lab box for the default row: ~13m wall clock end to end
+    # (5GB image pull, 8GB weight download, 408s to Ready). Left generous because
+    # a larger model or a cold proxy can multiply the pull and compile, and the
+    # smoke's own Ready budget is 45m by default.
     timeout-minutes: 150
     steps:
       - uses: actions/checkout@v5
@@ -111,6 +113,13 @@ jobs:
           HUGEPAGES: ${{ env.HW_SMOKE_HUGEPAGES }}
           # Only gated weights need this; the default row is ungated.
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # The media / forge server guards its inference routes with a static
+          # key and the chart configures neither API_KEY nor NO_AUTH, so a
+          # chart-deployed server runs on the image's default. Passing that
+          # default here keeps the smoke honest about what the chart ships;
+          # leave it empty for vLLM rows, which are open unless VLLM_API_KEY or
+          # JWT_SECRET is set. See tt-media-server/security/api_key_checker.py.
+          API_KEY: ${{ (github.event.inputs.api-probe || 'embeddings') == 'chat' && '' || 'your-secret-key' }}
         run: bash .github/scripts/helm_hw_smoke.sh
 
       - name: Diagnostics on failure

--- a/.github/workflows/helm-hw-smoke.yml
+++ b/.github/workflows/helm-hw-smoke.yml
@@ -34,10 +34,10 @@ on:
           "the pinned image is stale". Leave empty normally.
         default: ""
       api-probe:
-        description: Inference call to make (chat, embeddings, or models to skip).
+        description: Inference call to make. auto picks from the resolved image.
         type: choice
-        default: embeddings
-        options: [embeddings, chat, models]
+        default: auto
+        options: [auto, embeddings, chat, models]
       max-wait-seconds:
         description: How long to wait for Ready before failing.
         default: "2700"
@@ -74,7 +74,8 @@ jobs:
           ENGINE: ${{ github.event.inputs.engine || 'forge' }}
           IMPL: ${{ github.event.inputs.impl || 'forge_vllm_plugin' }}
           IMAGE_TAG: ${{ github.event.inputs.image-tag }}
-          API_PROBE: ${{ github.event.inputs.api-probe || 'embeddings' }}
+          # Empty lets the script pick from the image; a value pins it.
+          API_PROBE: ${{ github.event.inputs.api-probe == 'auto' && '' || github.event.inputs.api-probe }}
           MAX_WAIT_SECONDS: ${{ github.event.inputs.max-wait-seconds || '2700' }}
           HUGEPAGES: ${{ env.HW_SMOKE_HUGEPAGES }}  # set by the bootstrap step
           HF_TOKEN: ${{ secrets.HF_TOKEN }}         # only gated weights need it

--- a/.github/workflows/helm-hw-smoke.yml
+++ b/.github/workflows/helm-hw-smoke.yml
@@ -1,34 +1,9 @@
 name: Helm Chart Hardware Smoke
 
-# Real-hardware tier of the chart's CI. The two cheaper tiers live in
-# test-gate.yml and run on every PR:
-#
-#   helm-chart-validate  render + kubeconform + DRA claim structure
-#   helm-install-kind    a live k8s 1.34 API server installs the chart and the
-#                        Pod stays Pending only because no device exists
-#
-# This one runs the chart on a Tenstorrent board: one small model, one device
-# shape, asserting only what neither of the above can — that a real inference
-# image gets its device through the DRA claim, comes up inside the startupProbe
-# compile window, answers on /v1/..., and gives the board back on uninstall.
-# See .github/scripts/helm_hw_smoke.sh for the asserts themselves.
-#
-# Deliberately NOT per-PR: it holds a scarce board for the whole run. It runs
-# nightly, plus on demand — workflow_dispatch takes a ref, so a chart PR can be
-# validated on hardware before merge without a per-PR trigger. Nothing here
-# gates test-gate.yml.
-#
-# Preconditions this workflow creates for itself: the runner pool is bare (a KVM
-# VM with a card passed through and tt-kmd preloaded), so the first step stands
-# up RKE2 + tt-operator via .github/scripts/hw_smoke_bootstrap.sh.
+# Not per-PR: this holds a scarce Tenstorrent board for the whole run. The runner
+# pool is bare, so hw_smoke_bootstrap.sh stands up RKE2 + tt-operator first.
 
 on:
-  # GitHub cron is UTC and does not observe DST. 20:17 UTC is 05:17 JST /
-  # ~21:17 CET — clear of this repo's other nightlies (02:00, 11:00, 23:00 UTC)
-  # and in the lull between the CET evening and the JST morning, when the shared
-  # Tenstorrent pool is least contended. Not on the hour: scheduled runs pile up
-  # at :00 and get delayed or dropped. Only the default branch's copy of this
-  # file is ever scheduled, so this starts firing once the PR lands.
   schedule:
     - cron: "17 20 * * *"
 
@@ -55,8 +30,8 @@ on:
         default: forge_vllm_plugin
       image-tag:
         description: >-
-          Override the row's pinned image tag. For separating "the chart is
-          broken" from "the pinned image is stale" — leave empty normally.
+          Override the row's pinned image tag, to tell "the chart is broken" from
+          "the pinned image is stale". Leave empty normally.
         default: ""
       api-probe:
         description: Inference call to make (chat, embeddings, or models to skip).
@@ -67,9 +42,8 @@ on:
         description: How long to wait for Ready before failing.
         default: "2700"
 
-# One board at a time. Never cancel in flight: every run here is deliberate (a
-# nightly or a dispatch), and killing one mid-compile wastes the board's hour
-# and can leave a Pod terminating on a claim.
+# One board at a time, and never cancel: killing a run mid-compile can leave a
+# Pod terminating on its claim.
 concurrency:
   group: helm-hw-smoke
   cancel-in-progress: false
@@ -81,19 +55,14 @@ jobs:
   hw-smoke:
     name: Hardware Smoke (${{ github.event.inputs.model || 'Qwen3-Embedding-4B' }} / ${{ github.event.inputs.device || 'n150' }})
     runs-on: ${{ github.event.inputs.runner || 'tt-ubuntu-2204-n150-stable' }}
-    # Measured on a T3K lab box for the default row: ~13m wall clock end to end
-    # (5GB image pull, 8GB weight download, 408s to Ready). Left generous because
-    # a larger model or a cold proxy can multiply the pull and compile, and the
-    # smoke's own Ready budget is 45m by default.
+    # ~13m end to end for the default row; generous for bigger models.
     timeout-minutes: 150
     steps:
       - uses: actions/checkout@v5
 
       - name: Bootstrap (RKE2 + tt-operator + published boards)
         env:
-          # Optional: only needed where the container runtime cannot pull
-          # ghcr.io anonymously. Absent secrets resolve to empty, which is
-          # exactly the "anonymous" path.
+          # Only needed where the runtime cannot pull ghcr.io anonymously.
           GHCR_USERNAME: ${{ github.repository_owner }}
           GHCR_TOKEN: ${{ secrets.GHCR_PULL_PAT }}
         run: bash .github/scripts/hw_smoke_bootstrap.sh
@@ -107,15 +76,8 @@ jobs:
           IMAGE_TAG: ${{ github.event.inputs.image-tag }}
           API_PROBE: ${{ github.event.inputs.api-probe || 'embeddings' }}
           MAX_WAIT_SECONDS: ${{ github.event.inputs.max-wait-seconds || '2700' }}
-          # Set by the bootstrap step from the runner's IOMMU mode; the script
-          # falls back to probing the node when it is empty.
-          HUGEPAGES: ${{ env.HW_SMOKE_HUGEPAGES }}
-          # Only gated weights need this; the default row is ungated.
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          # API_KEY is left to the script: it mints a fresh key per run, installs
-          # it through the chart's auth.apiKey, and checks both that an
-          # authenticated call succeeds and that an unauthenticated one is
-          # refused. Set this only to pin a key for debugging.
+          HUGEPAGES: ${{ env.HW_SMOKE_HUGEPAGES }}  # set by the bootstrap step
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}         # only gated weights need it
         run: bash .github/scripts/helm_hw_smoke.sh
 
       - name: Diagnostics on failure
@@ -127,11 +89,8 @@ jobs:
           kubectl -n tt-operator-system logs -l app.kubernetes.io/name=tt-dra-driver --tail=100 || true
           sudo journalctl -u rke2-server --no-pager | tail -60 || true
 
-      # The runner VM is destroyed at job end, so this is not for its sake: it
-      # keeps the teardown ORDER on record and makes the workflow safe to point
-      # at a persistent cluster. Removing tt-operator first would take the DRA
-      # kubelet plugin out from under a running Pod, and NodeUnprepareResources
-      # can then never complete — the Pod sticks in Terminating holding a board.
+      # Order matters: removing tt-operator first strands the DRA plugin and the
+      # Pod sticks in Terminating on its claim.
       - name: Teardown (workload first, then tt-operator)
         if: always()
         run: |

--- a/.github/workflows/helm-hw-smoke.yml
+++ b/.github/workflows/helm-hw-smoke.yml
@@ -13,15 +13,25 @@ name: Helm Chart Hardware Smoke
 # compile window, answers on /v1/..., and gives the board back on uninstall.
 # See .github/scripts/helm_hw_smoke.sh for the asserts themselves.
 #
-# Deliberately NOT per-PR: it holds a scarce board for the whole run, so it is
-# manual (workflow_dispatch) or opt-in on a PR by adding the `ci:hw-smoke`
-# label. Nothing here gates test-gate.yml.
+# Deliberately NOT per-PR: it holds a scarce board for the whole run. It runs
+# nightly, plus on demand — workflow_dispatch takes a ref, so a chart PR can be
+# validated on hardware before merge without a per-PR trigger. Nothing here
+# gates test-gate.yml.
 #
 # Preconditions this workflow creates for itself: the runner pool is bare (a KVM
 # VM with a card passed through and tt-kmd preloaded), so the first step stands
 # up RKE2 + tt-operator via .github/scripts/hw_smoke_bootstrap.sh.
 
 on:
+  # GitHub cron is UTC and does not observe DST. 20:17 UTC is 05:17 JST /
+  # ~21:17 CET — clear of this repo's other nightlies (02:00, 11:00, 23:00 UTC)
+  # and in the lull between the CET evening and the JST morning, when the shared
+  # Tenstorrent pool is least contended. Not on the hour: scheduled runs pile up
+  # at :00 and get delayed or dropped. Only the default branch's copy of this
+  # file is ever scheduled, so this starts firing once the PR lands.
+  schedule:
+    - cron: "17 20 * * *"
+
   workflow_dispatch:
     inputs:
       runner:
@@ -56,20 +66,13 @@ on:
       max-wait-seconds:
         description: How long to wait for Ready before failing.
         default: "2700"
-  pull_request:
-    branches: ["main"]
-    types: [opened, synchronize, reopened, labeled]
-    paths:
-      - "charts/**"
-      - ".github/scripts/helm_hw_smoke.sh"
-      - ".github/scripts/hw_smoke_bootstrap.sh"
-      - ".github/workflows/helm-hw-smoke.yml"
 
-# One board at a time per ref. A superseded PR run is cancelled; a manual run is
-# not, so an intentional dispatch never loses its board to a push.
+# One board at a time. Never cancel in flight: every run here is deliberate (a
+# nightly or a dispatch), and killing one mid-compile wastes the board's hour
+# and can leave a Pod terminating on a claim.
 concurrency:
-  group: helm-hw-smoke-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: helm-hw-smoke
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -77,10 +80,6 @@ permissions:
 jobs:
   hw-smoke:
     name: Hardware Smoke (${{ github.event.inputs.model || 'Qwen3-Embedding-4B' }} / ${{ github.event.inputs.device || 'n150' }})
-    # On a PR this needs the opt-in label; a dispatch is the opt-in.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'ci:hw-smoke')
     runs-on: ${{ github.event.inputs.runner || 'tt-ubuntu-2204-n150-stable' }}
     # Measured on a T3K lab box for the default row: ~13m wall clock end to end
     # (5GB image pull, 8GB weight download, 408s to Ready). Left generous because

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1209,6 +1209,26 @@ jobs:
             | grep -qE '^[[:space:]]*HF_HOME:' \
             && { echo "::error::HF_HOME set for a vllm row — those images own their weight location"; exit 1; } || true
 
+      - name: Verify hugepages are sized per device
+        run: |
+          set -e
+          # One 1Gi page per ASIC, from deviceChipCounts. device:expected
+          for pair in n150:1Gi n300:2Gi t3k:8Gi galaxy:32Gi; do
+            device="${pair%%:*}"; want="${pair##*:}"
+            helm template ttis charts/tt-inference-server \
+              --set model=Llama-3.1-8B-Instruct --set device="$device" \
+              | grep -qE "^[[:space:]]*hugepages-1Gi: ${want}\$" \
+              || { echo "::error::$device must request $want of hugepages"; exit 1; }
+          done
+          helm template ttis charts/tt-inference-server \
+            --set model=Llama-3.1-8B-Instruct --set device=n150 --set hugepages.size=4Gi \
+            | grep -qE '^[[:space:]]*hugepages-1Gi: 4Gi$' \
+            || { echo "::error::hugepages.size did not override the per-device size"; exit 1; }
+          helm template ttis charts/tt-inference-server \
+            --set model=Llama-3.1-8B-Instruct --set device=n150 --set hugepages.enabled=false \
+            | grep -q hugepages \
+            && { echo "::error::hugepages.enabled=false left a hugepages reference"; exit 1; } || true
+
       - name: Verify startupProbe budget derives from progressDeadlineSeconds
         run: |
           set -e

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1127,10 +1127,14 @@ jobs:
           FAILED=0
           while IFS=',' read -r model engine device; do
             echo "--- Validating: $model / $engine / $device"
+            # auth.apiKey satisfies the chart's fail-closed auth check (media and
+            # forge engines require an explicit apiKey or auth.disabled) and
+            # renders the Secret's key branch so kubeconform sees it too.
             RENDERED=$(helm template ci-test charts/tt-inference-server \
                 --set "model=$model" \
                 --set "engine=$engine" \
-                --set "device=$device") || { echo "FAILED (render): $model / $engine / $device"; FAILED=1; continue; }
+                --set "device=$device" \
+                --set auth.apiKey=ci-render-key) || { echo "FAILED (render): $model / $engine / $device"; FAILED=1; continue; }
             if ! echo "$RENDERED" | kubeconform -strict -summary; then
               echo "FAILED (kubeconform): $model / $engine / $device"
               FAILED=1
@@ -1164,6 +1168,50 @@ jobs:
             echo "$RENDERED" | grep -qE '^[[:space:]]*path: /dev/tenstorrent$' \
               && { echo "::error::hostPath /dev/tenstorrent present for $device"; exit 1; } || true
           done
+
+      - name: Verify auth wiring and the HF cache location
+        run: |
+          set -e
+          # media/forge authenticate their inference routes with a literal bearer
+          # key and fall back to the image's built-in default when API_KEY is
+          # unset, so the chart fails closed until the operator picks. Render-level
+          # checks: the gate itself, both ways of satisfying it, the per-engine
+          # env name, and that the HF cache lands on the persistent volume.
+          echo "--- media/forge with neither auth.apiKey nor auth.disabled must fail"
+          if helm template ttis charts/tt-inference-server \
+              --set model=Qwen3-Embedding-4B --set device=n150 >/dev/null 2>&1; then
+            echo "::error::a forge row rendered with no auth values — the fail-closed auth check is gone"
+            exit 1
+          fi
+
+          echo "--- auth.apiKey -> API_KEY in the Secret (media/forge)"
+          helm template ttis charts/tt-inference-server \
+            --set model=Qwen3-Embedding-4B --set device=n150 --set auth.apiKey=k \
+            --show-only templates/secret.yaml | grep -qE '^[[:space:]]*API_KEY: "k"$' \
+            || { echo "::error::auth.apiKey did not land as API_KEY for a forge row"; exit 1; }
+
+          echo "--- auth.disabled -> NO_AUTH in the ConfigMap (media/forge)"
+          helm template ttis charts/tt-inference-server \
+            --set model=Qwen3-Embedding-4B --set device=n150 --set auth.disabled=true \
+            --show-only templates/configmap.yaml | grep -qE '^[[:space:]]*NO_AUTH: "1"$' \
+            || { echo "::error::auth.disabled did not set NO_AUTH for a forge row"; exit 1; }
+
+          echo "--- auth.apiKey -> VLLM_API_KEY in the Secret (vllm)"
+          helm template ttis charts/tt-inference-server \
+            --set model=Qwen3-8B --set device=n150 --set engine=vllm --set auth.apiKey=k \
+            --show-only templates/secret.yaml | grep -qE '^[[:space:]]*VLLM_API_KEY: "k"$' \
+            || { echo "::error::auth.apiKey did not land as VLLM_API_KEY for a vllm row"; exit 1; }
+
+          echo "--- HF_HOME points at the persistent cache volume (media/forge only)"
+          helm template ttis charts/tt-inference-server \
+            --set model=Qwen3-Embedding-4B --set device=n150 --set auth.disabled=true \
+            --show-only templates/configmap.yaml \
+            | grep -qE '^[[:space:]]*HF_HOME: "/home/container_app_user/cache_root/huggingface"$' \
+            || { echo "::error::HF_HOME must point into the cache volume, or weights are re-downloaded on every restart"; exit 1; }
+          helm template ttis charts/tt-inference-server \
+            --set model=Qwen3-8B --set device=n150 --set engine=vllm --set auth.apiKey=k \
+            | grep -qE '^[[:space:]]*HF_HOME:' \
+            && { echo "::error::HF_HOME set for a vllm row — those images own their weight location"; exit 1; } || true
 
       - name: Verify startupProbe budget derives from progressDeadlineSeconds
         run: |

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1127,9 +1127,8 @@ jobs:
           FAILED=0
           while IFS=',' read -r model engine device; do
             echo "--- Validating: $model / $engine / $device"
-            # auth.apiKey satisfies the chart's fail-closed auth check (media and
-            # forge engines require an explicit apiKey or auth.disabled) and
-            # renders the Secret's key branch so kubeconform sees it too.
+            # Satisfies the chart's fail-closed auth check for media/forge rows,
+            # and renders the Secret's key branch for kubeconform.
             RENDERED=$(helm template ci-test charts/tt-inference-server \
                 --set "model=$model" \
                 --set "engine=$engine" \
@@ -1172,11 +1171,8 @@ jobs:
       - name: Verify auth wiring and the HF cache location
         run: |
           set -e
-          # media/forge authenticate their inference routes with a literal bearer
-          # key and fall back to the image's built-in default when API_KEY is
-          # unset, so the chart fails closed until the operator picks. Render-level
-          # checks: the gate itself, both ways of satisfying it, the per-engine
-          # env name, and that the HF cache lands on the persistent volume.
+          # media/forge fall back to the image's built-in key when API_KEY is
+          # unset, so the chart fails closed until the operator picks.
           echo "--- media/forge with neither auth.apiKey nor auth.disabled must fail"
           if helm template ttis charts/tt-inference-server \
               --set model=Qwen3-Embedding-4B --set device=n150 >/dev/null 2>&1; then

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1229,6 +1229,27 @@ jobs:
             | grep -q hugepages \
             && { echo "::error::hugepages.enabled=false left a hugepages reference"; exit 1; } || true
 
+          echo "--- contradictory auth values must fail"
+          if helm template ttis charts/tt-inference-server \
+              --set model=Qwen3-Embedding-4B --set device=n150 \
+              --set auth.apiKey=k --set auth.disabled=true >/dev/null 2>&1; then
+            echo "::error::auth.apiKey together with auth.disabled rendered instead of failing"
+            exit 1
+          fi
+
+          echo "--- sizing hugepages through resources must fail (request/limit must match)"
+          if helm template ttis charts/tt-inference-server \
+              --set model=Llama-3.1-8B-Instruct --set device=n150 \
+              --set defaults.resources.requests.hugepages-1Gi=64Gi >/dev/null 2>&1; then
+            echo "::error::resources.requests.hugepages-1Gi rendered instead of pointing at hugepages.size"
+            exit 1
+          fi
+
+          echo "--- a non-Tenstorrent device gets no hugepages plumbing at all"
+          helm template ttis charts/tt-inference-server \
+            --set model=Llama-3.1-8B-Instruct --set device=gpu | grep -qi hugepage \
+            && { echo "::error::a gpu row still references hugepages"; exit 1; } || true
+
       - name: Verify startupProbe budget derives from progressDeadlineSeconds
         run: |
           set -e

--- a/charts/tt-inference-server/README.md
+++ b/charts/tt-inference-server/README.md
@@ -238,6 +238,7 @@ Set per release, typically via `--set`.
 | `auth.apiKey` | yes* | `""` | Bearer key clients must send. Stored in the release Secret as `API_KEY` (media/forge) or `VLLM_API_KEY` (vllm). *Required for `media` and `forge` engines unless `auth.disabled=true`: those servers guard their inference routes with a literal bearer key and fall back to a well-known built-in default when unset. |
 | `auth.disabled` | no | `false` | Run the server with authentication off (`NO_AUTH=1`). media/forge only — vLLM is already open when `auth.apiKey` is unset. |
 | `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
+| `hugepages.size` | no | `""` | Hugepage request/limit when enabled. Empty means one 1Gi page per ASIC of the chosen device (`deviceChipCounts`) — 1Gi on an n150, 8Gi on a T3K, 32Gi on a Galaxy. |
 | `podMonitor.enabled` | no | `false` | Emit a `PodMonitor` scraping the server's `/metrics`. Requires the Prometheus Operator CRDs (`monitoring.coreos.com`); leave `false` on clusters without them. |
 | `podMonitor.labels` | no | `{release: prometheus}` | Labels on the `PodMonitor`; must match your Prometheus's `podMonitorSelector` or it won't be scraped. The default matches tt-telemetry's chart and the kube-prometheus-stack convention (`podMonitorSelector` defaults to `release: <the stack's release name>`); override when yours is named differently. |
 | `podMonitor.interval` | no | `30s` | Scrape interval. |
@@ -265,10 +266,8 @@ All fields under `defaults` apply to every model/engine/device/impl unless overr
 | `defaults.service.port` | `8000` | Service port. |
 | `defaults.service.targetPort` | `8000` | Container target port. |
 | `defaults.service.annotations` | `{}` | Annotations applied to the Service. |
-| `defaults.resources.limits.hugepages-1Gi` | `32Gi` | Hugepage limit. Dropped when `hugepages.enabled=false`. (`cpu` and `memory` limits are unset by default.) |
 | `defaults.resources.requests.cpu` | `"6"` | CPU request. |
 | `defaults.resources.requests.memory` | `64Gi` | Memory request (often overridden per impl). |
-| `defaults.resources.requests.hugepages-1Gi` | `32Gi` | Hugepage request. Dropped when `hugepages.enabled=false`. |
 | `defaults.probes.startup.periodSeconds` | `15` | startupProbe poll interval (must be `> 0`). The startupProbe is always rendered — it owns the model compile/warmup window, and while it runs the kubelet suppresses liveness/readiness so a slow compile never triggers a restart. `failureThreshold` is not set here — the Deployment derives it as `ceil(progressDeadlineSeconds / periodSeconds)`, so the startup budget tracks the max compile time and the Pod flips to `1/1` as soon as one poll succeeds. |
 | `defaults.probes.liveness.enabled` | `true` | Enable liveness probe. |
 | `defaults.probes.liveness.path` | `/v1/models` | Liveness probe HTTP path (`/tt-liveness` for non-vllm engines). |

--- a/charts/tt-inference-server/README.md
+++ b/charts/tt-inference-server/README.md
@@ -235,6 +235,8 @@ Set per release, typically via `--set`.
 | `impl` | no | `""` | Pin the implementation when a device offers more than one. Defaults to `models.<model>.<engine>.<device>.defaultImpl`. |
 | `hfToken` | yes* | `""` | HuggingFace token. Injected as `HF_TOKEN`. Required unless weights are pre-downloaded via `hfCacheDir`. |
 | `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
+| `auth.apiKey` | yes* | `""` | Bearer key clients must send. Stored in the release Secret as `API_KEY` (media/forge) or `VLLM_API_KEY` (vllm). *Required for `media` and `forge` engines unless `auth.disabled=true`: those servers guard their inference routes with a literal bearer key and fall back to a well-known built-in default when unset. |
+| `auth.disabled` | no | `false` | Run the server with authentication off (`NO_AUTH=1`). media/forge only — vLLM is already open when `auth.apiKey` is unset. |
 | `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
 | `podMonitor.enabled` | no | `false` | Emit a `PodMonitor` scraping the server's `/metrics`. Requires the Prometheus Operator CRDs (`monitoring.coreos.com`); leave `false` on clusters without them. |
 | `podMonitor.labels` | no | `{release: prometheus}` | Labels on the `PodMonitor`; must match your Prometheus's `podMonitorSelector` or it won't be scraped. The default matches tt-telemetry's chart and the kube-prometheus-stack convention (`podMonitorSelector` defaults to `release: <the stack's release name>`); override when yours is named differently. |
@@ -393,6 +395,29 @@ helm install my-model ./charts/tt-inference-server \
 
 The host path is mounted read-only at `/mnt/hf-cache` inside the container. The chart sets `MODEL_WEIGHTS_DIR` (vLLM) or `MODEL_WEIGHTS_PATH` + `DOWNLOAD_WEIGHTS_FROM_SERVICE=false` (media) accordingly.
 
+### Authentication
+
+The media and forge servers check a literal `Authorization: Bearer $API_KEY` on
+their inference routes (`/health` and `/v1/models` stay open) and fall back to a
+well-known built-in key when `API_KEY` is unset — authenticated-looking, but not
+authenticated. The chart therefore fails the install for those engines until you
+choose:
+
+```bash
+# authenticate with your own key (lands in the release Secret as API_KEY)
+helm install my-model ./charts/tt-inference-server \
+  --set model="Qwen3-Embedding-4B" --set device=n150 \
+  --set auth.apiKey="$(openssl rand -hex 16)"
+
+# or run without auth, e.g. behind your own gateway
+helm install my-model ./charts/tt-inference-server \
+  --set model="Qwen3-Embedding-4B" --set device=n150 \
+  --set auth.disabled=true
+```
+
+vLLM engines need no such gate: they are unauthenticated unless `VLLM_API_KEY`
+is set, which is where `auth.apiKey` lands for them.
+
 ### Extra Environment Variables
 
 Inject arbitrary environment variables via `defaults.extraEnv`. Each entry supports either a literal `value` or a `valueFrom` reference:
@@ -411,6 +436,11 @@ defaults:
 ```
 
 Literal values are written into the ConfigMap. `valueFrom` entries are injected directly into the container spec and are not stored in the ConfigMap.
+
+For `media` and `forge` engines the chart also sets
+`HF_HOME=/home/container_app_user/cache_root/huggingface`, so downloaded weights
+land on the cache volume instead of the container's ephemeral layer and survive a
+Pod restart. vLLM images manage their own weight location under `CACHE_ROOT`.
 
 ### Custom Node Scheduling
 

--- a/charts/tt-inference-server/README.md.gotmpl
+++ b/charts/tt-inference-server/README.md.gotmpl
@@ -235,6 +235,8 @@ Set per release, typically via `--set`.
 | `impl` | no | `""` | Pin the implementation when a device offers more than one. Defaults to `models.<model>.<engine>.<device>.defaultImpl`. |
 | `hfToken` | yes* | `""` | HuggingFace token. Injected as `HF_TOKEN`. Required unless weights are pre-downloaded via `hfCacheDir`. |
 | `hfCacheDir` | no | `""` | Host path to a pre-downloaded HuggingFace weights directory. Mounted read-only at `/mnt/hf-cache`; skips download at startup. |
+| `auth.apiKey` | yes* | `""` | Bearer key clients must send. Stored in the release Secret as `API_KEY` (media/forge) or `VLLM_API_KEY` (vllm). *Required for `media` and `forge` engines unless `auth.disabled=true`: those servers guard their inference routes with a literal bearer key and fall back to a well-known built-in default when unset. |
+| `auth.disabled` | no | `false` | Run the server with authentication off (`NO_AUTH=1`). media/forge only — vLLM is already open when `auth.apiKey` is unset. |
 | `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
 | `podMonitor.enabled` | no | `false` | Emit a `PodMonitor` scraping the server's `/metrics`. Requires the Prometheus Operator CRDs (`monitoring.coreos.com`); leave `false` on clusters without them. |
 | `podMonitor.labels` | no | `{release: prometheus}` | Labels on the `PodMonitor`; must match your Prometheus's `podMonitorSelector` or it won't be scraped. The default matches tt-telemetry's chart and the kube-prometheus-stack convention (`podMonitorSelector` defaults to `release: <the stack's release name>`); override when yours is named differently. |
@@ -300,6 +302,29 @@ helm install my-model ./charts/tt-inference-server \
 
 The host path is mounted read-only at `/mnt/hf-cache` inside the container. The chart sets `MODEL_WEIGHTS_DIR` (vLLM) or `MODEL_WEIGHTS_PATH` + `DOWNLOAD_WEIGHTS_FROM_SERVICE=false` (media) accordingly.
 
+### Authentication
+
+The media and forge servers check a literal `Authorization: Bearer $API_KEY` on
+their inference routes (`/health` and `/v1/models` stay open) and fall back to a
+well-known built-in key when `API_KEY` is unset — authenticated-looking, but not
+authenticated. The chart therefore fails the install for those engines until you
+choose:
+
+```bash
+# authenticate with your own key (lands in the release Secret as API_KEY)
+helm install my-model ./charts/tt-inference-server \
+  --set model="Qwen3-Embedding-4B" --set device=n150 \
+  --set auth.apiKey="$(openssl rand -hex 16)"
+
+# or run without auth, e.g. behind your own gateway
+helm install my-model ./charts/tt-inference-server \
+  --set model="Qwen3-Embedding-4B" --set device=n150 \
+  --set auth.disabled=true
+```
+
+vLLM engines need no such gate: they are unauthenticated unless `VLLM_API_KEY`
+is set, which is where `auth.apiKey` lands for them.
+
 ### Extra Environment Variables
 
 Inject arbitrary environment variables via `defaults.extraEnv`. Each entry supports either a literal `value` or a `valueFrom` reference:
@@ -318,6 +343,11 @@ defaults:
 ```
 
 Literal values are written into the ConfigMap. `valueFrom` entries are injected directly into the container spec and are not stored in the ConfigMap.
+
+For `media` and `forge` engines the chart also sets
+`HF_HOME=/home/container_app_user/cache_root/huggingface`, so downloaded weights
+land on the cache volume instead of the container's ephemeral layer and survive a
+Pod restart. vLLM images manage their own weight location under `CACHE_ROOT`.
 
 ### Custom Node Scheduling
 

--- a/charts/tt-inference-server/README.md.gotmpl
+++ b/charts/tt-inference-server/README.md.gotmpl
@@ -238,6 +238,7 @@ Set per release, typically via `--set`.
 | `auth.apiKey` | yes* | `""` | Bearer key clients must send. Stored in the release Secret as `API_KEY` (media/forge) or `VLLM_API_KEY` (vllm). *Required for `media` and `forge` engines unless `auth.disabled=true`: those servers guard their inference routes with a literal bearer key and fall back to a well-known built-in default when unset. |
 | `auth.disabled` | no | `false` | Run the server with authentication off (`NO_AUTH=1`). media/forge only — vLLM is already open when `auth.apiKey` is unset. |
 | `hugepages.enabled` | no | `true` | Whether Tenstorrent boards need 1Gi hugepages. Set `false` on IOMMU + KMD 1.29.0+ clusters to drop the `hugepages-1Gi` request/limit, the `/dev/hugepages-1G` volume + mounts, and the `cleanup-hugepages` initContainer. |
+| `hugepages.size` | no | `""` | Hugepage request/limit when enabled. Empty means one 1Gi page per ASIC of the chosen device (`deviceChipCounts`) — 1Gi on an n150, 8Gi on a T3K, 32Gi on a Galaxy. |
 | `podMonitor.enabled` | no | `false` | Emit a `PodMonitor` scraping the server's `/metrics`. Requires the Prometheus Operator CRDs (`monitoring.coreos.com`); leave `false` on clusters without them. |
 | `podMonitor.labels` | no | `{release: prometheus}` | Labels on the `PodMonitor`; must match your Prometheus's `podMonitorSelector` or it won't be scraped. The default matches tt-telemetry's chart and the kube-prometheus-stack convention (`podMonitorSelector` defaults to `release: <the stack's release name>`); override when yours is named differently. |
 | `podMonitor.interval` | no | `30s` | Scrape interval. |
@@ -265,10 +266,8 @@ All fields under `defaults` apply to every model/engine/device/impl unless overr
 | `defaults.service.port` | `8000` | Service port. |
 | `defaults.service.targetPort` | `8000` | Container target port. |
 | `defaults.service.annotations` | `{}` | Annotations applied to the Service. |
-| `defaults.resources.limits.hugepages-1Gi` | `32Gi` | Hugepage limit. Dropped when `hugepages.enabled=false`. (`cpu` and `memory` limits are unset by default.) |
 | `defaults.resources.requests.cpu` | `"6"` | CPU request. |
 | `defaults.resources.requests.memory` | `64Gi` | Memory request (often overridden per impl). |
-| `defaults.resources.requests.hugepages-1Gi` | `32Gi` | Hugepage request. Dropped when `hugepages.enabled=false`. |
 | `defaults.probes.startup.periodSeconds` | `15` | startupProbe poll interval (must be `> 0`). The startupProbe is always rendered — it owns the model compile/warmup window, and while it runs the kubelet suppresses liveness/readiness so a slow compile never triggers a restart. `failureThreshold` is not set here — the Deployment derives it as `ceil(progressDeadlineSeconds / periodSeconds)`, so the startup budget tracks the max compile time and the Pod flips to `1/1` as soon as one poll succeeds. |
 | `defaults.probes.liveness.enabled` | `true` | Enable liveness probe. |
 | `defaults.probes.liveness.path` | `/v1/models` | Liveness probe HTTP path (`/tt-liveness` for non-vllm engines). |

--- a/charts/tt-inference-server/templates/_helpers.tpl
+++ b/charts/tt-inference-server/templates/_helpers.tpl
@@ -33,11 +33,9 @@ Validate required values and that model/engine/device/impl resolves.
 {{- end }}
 
 {{/*
-Auth is a decision, not a default: the media/forge server guards its inference
-routes with a literal bearer key and falls back to a well-known built-in one
-when API_KEY is unset, which looks authenticated but is not. Fail closed and
-make the operator pick. (vLLM needs no such gate: it is open unless
-VLLM_API_KEY is set, and setting auth.apiKey is what sets it.)
+media/forge fall back to a well-known built-in key when API_KEY is unset, which
+looks authenticated but is not, so make the operator pick. vLLM needs no gate:
+it is open unless VLLM_API_KEY is set, which is what auth.apiKey sets.
 */}}
 {{- $auth := .Values.auth | default dict }}
 {{- if or (eq $engine "media") (eq $engine "forge") }}
@@ -159,10 +157,6 @@ with `with (include … | trim)`.
 {{- end }}
 {{- end }}
 
-{{/*
-In-container mount point of the cache volume. Single source for the ConfigMap's
-CACHE_ROOT, the container's volumeMount, and anything derived from it (HF_HOME).
-*/}}
 {{- define "tt-inference-server.cacheRoot" -}}
 /home/container_app_user/cache_root
 {{- end -}}

--- a/charts/tt-inference-server/templates/_helpers.tpl
+++ b/charts/tt-inference-server/templates/_helpers.tpl
@@ -31,6 +31,20 @@ Validate required values and that model/engine/device/impl resolves.
   {{- $available := keys $deviceEntry.impls | sortAlpha | join ", " }}
   {{- fail (printf "No impl '%s' for model '%s' on engine '%s' device '%s'. Available impls: %s" $impl .Values.model $engine .Values.device $available) }}
 {{- end }}
+
+{{/*
+Auth is a decision, not a default: the media/forge server guards its inference
+routes with a literal bearer key and falls back to a well-known built-in one
+when API_KEY is unset, which looks authenticated but is not. Fail closed and
+make the operator pick. (vLLM needs no such gate: it is open unless
+VLLM_API_KEY is set, and setting auth.apiKey is what sets it.)
+*/}}
+{{- $auth := .Values.auth | default dict }}
+{{- if or (eq $engine "media") (eq $engine "forge") }}
+  {{- if and (not (dig "apiKey" "" $auth)) (not (dig "disabled" false $auth)) }}
+    {{- fail (printf "engine '%s' authenticates its inference routes with a bearer key, and leaving it unset would silently use the server image's built-in default. Set auth.apiKey=<key> (stored in the release Secret as API_KEY), or auth.disabled=true to run without auth." $engine) }}
+  {{- end }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -144,6 +158,14 @@ with `with (include … | trim)`.
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+In-container mount point of the cache volume. Single source for the ConfigMap's
+CACHE_ROOT, the container's volumeMount, and anything derived from it (HF_HOME).
+*/}}
+{{- define "tt-inference-server.cacheRoot" -}}
+/home/container_app_user/cache_root
+{{- end -}}
 
 {{/*
 Cache hostPath — defaults to /opt/cache/<model>-<device>-<impl>. Includes impl

--- a/charts/tt-inference-server/templates/_helpers.tpl
+++ b/charts/tt-inference-server/templates/_helpers.tpl
@@ -38,6 +38,9 @@ looks authenticated but is not, so make the operator pick. vLLM needs no gate:
 it is open unless VLLM_API_KEY is set, which is what auth.apiKey sets.
 */}}
 {{- $auth := .Values.auth | default dict }}
+{{- if and (dig "apiKey" "" $auth) (dig "disabled" false $auth) }}
+  {{- fail "auth.apiKey and auth.disabled are contradictory: the server would honour NO_AUTH and serve unauthenticated while the key sits in the release Secret. Set one." }}
+{{- end }}
 {{- if or (eq $engine "media") (eq $engine "forge") }}
   {{- if and (not (dig "apiKey" "" $auth)) (not (dig "disabled" false $auth)) }}
     {{- fail (printf "engine '%s' authenticates its inference routes with a bearer key, and leaving it unset would silently use the server image's built-in default. Set auth.apiKey=<key> (stored in the release Secret as API_KEY), or auth.disabled=true to run without auth." $engine) }}

--- a/charts/tt-inference-server/templates/_helpers.tpl
+++ b/charts/tt-inference-server/templates/_helpers.tpl
@@ -157,6 +157,21 @@ with `with (include … | trim)`.
 {{- end }}
 {{- end }}
 
+{{/*
+hugepages-1Gi request/limit: hugepages.size when set, else one 1Gi page per ASIC
+of the device (deviceChipCounts). Empty for a device with no chip count (gpu/cpu,
+or a shape the map does not cover), which drops the request entirely.
+*/}}
+{{- define "tt-inference-server.hugepagesSize" -}}
+{{- $override := dig "size" "" (.Values.hugepages | default dict) -}}
+{{- if $override -}}
+{{- $override -}}
+{{- else -}}
+{{- $chips := index (.Values.deviceChipCounts | default dict) (.Values.device | lower) -}}
+{{- if $chips -}}{{- printf "%dGi" (int $chips) -}}{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "tt-inference-server.cacheRoot" -}}
 /home/container_app_user/cache_root
 {{- end -}}

--- a/charts/tt-inference-server/templates/configmap.yaml
+++ b/charts/tt-inference-server/templates/configmap.yaml
@@ -1,6 +1,35 @@
 {{- include "tt-inference-server.validateValues" . }}
 {{- $cfg := include "tt-inference-server.resolvedConfig" . | fromYaml }}
 {{- $engine := include "tt-inference-server.resolvedEngine" . }}
+{{- $auth := .Values.auth | default dict }}
+{{- $cacheRoot := include "tt-inference-server.cacheRoot" . }}
+{{- /*
+Built as a dict rather than emitted line by line: extraEnv may name a key the
+chart also sets, and two lines with the same key is invalid YAML. Later writes
+win, so a user's extraEnv literal overrides the chart's own entry.
+*/}}
+{{- $data := dict }}
+{{- if or (eq $engine "media") (eq $engine "forge") }}
+{{- $_ := set $data "MODEL" .Values.model }}
+{{- $_ := set $data "DEVICE" .Values.device }}
+{{- $_ := set $data "CACHE_ROOT" $cacheRoot }}
+{{- /*
+Keep the HuggingFace cache on the persistent cache volume. Without this the
+server downloads weights into the container's ephemeral layer (~/.cache) and
+pays the download again on every Pod restart. Matches the media/forge branch of
+workflows/run_docker_server.py. Not set for vllm: those images manage their own
+weight location under CACHE_ROOT, and hfCacheDir covers the pre-staged case.
+*/}}
+{{- $_ := set $data "HF_HOME" (printf "%s/huggingface" $cacheRoot) }}
+{{- if dig "disabled" false $auth }}
+{{- $_ := set $data "NO_AUTH" "1" }}
+{{- end }}
+{{- end }}
+{{- range $cfg.extraEnv }}
+{{- if .value }}
+{{- $_ := set $data .name (.value | toString) }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,13 +38,6 @@ metadata:
   labels:
     {{- include "tt-inference-server.labels" . | nindent 4 }}
 data:
-  {{- if or (eq $engine "media") (eq $engine "forge") }}
-  MODEL: {{ .Values.model | quote }}
-  DEVICE: {{ .Values.device | quote }}
-  CACHE_ROOT: "/home/container_app_user/cache_root"
-  {{- end }}
-  {{- range $cfg.extraEnv }}
-  {{- if .value }}
-  {{ .name }}: {{ .value | quote }}
-  {{- end }}
+  {{- range $k, $v := $data }}
+  {{ $k }}: {{ $v | quote }}
   {{- end }}

--- a/charts/tt-inference-server/templates/configmap.yaml
+++ b/charts/tt-inference-server/templates/configmap.yaml
@@ -4,9 +4,9 @@
 {{- $auth := .Values.auth | default dict }}
 {{- $cacheRoot := include "tt-inference-server.cacheRoot" . }}
 {{- /*
-Built as a dict rather than emitted line by line: extraEnv may name a key the
-chart also sets, and two lines with the same key is invalid YAML. Later writes
-win, so a user's extraEnv literal overrides the chart's own entry.
+A dict, not line-by-line output: extraEnv may name a key the chart also sets,
+and two YAML lines with one key is a broken render. Later writes win, so a
+user's extraEnv literal overrides the chart's.
 */}}
 {{- $data := dict }}
 {{- if or (eq $engine "media") (eq $engine "forge") }}
@@ -14,11 +14,9 @@ win, so a user's extraEnv literal overrides the chart's own entry.
 {{- $_ := set $data "DEVICE" .Values.device }}
 {{- $_ := set $data "CACHE_ROOT" $cacheRoot }}
 {{- /*
-Keep the HuggingFace cache on the persistent cache volume. Without this the
-server downloads weights into the container's ephemeral layer (~/.cache) and
-pays the download again on every Pod restart. Matches the media/forge branch of
-workflows/run_docker_server.py. Not set for vllm: those images manage their own
-weight location under CACHE_ROOT, and hfCacheDir covers the pre-staged case.
+Without this the weights land in the container's ephemeral layer (~/.cache) and
+are downloaded again on every Pod restart. vllm images own their weight location
+under CACHE_ROOT, so this mirrors run_docker_server.py's media/forge branch.
 */}}
 {{- $_ := set $data "HF_HOME" (printf "%s/huggingface" $cacheRoot) }}
 {{- if dig "disabled" false $auth }}

--- a/charts/tt-inference-server/templates/deployment.yaml
+++ b/charts/tt-inference-server/templates/deployment.yaml
@@ -116,7 +116,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: cache
-              mountPath: /home/container_app_user/cache_root
+              mountPath: {{ include "tt-inference-server.cacheRoot" . }}
             {{- if $hugepages }}
             - name: hugepages-1g
               mountPath: /dev/hugepages-1G

--- a/charts/tt-inference-server/templates/deployment.yaml
+++ b/charts/tt-inference-server/templates/deployment.yaml
@@ -6,12 +6,19 @@
 {{- if le $startupPeriod 0 }}{{- fail "probes.startup.periodSeconds must be greater than 0 (it divides progressDeadlineSeconds to size the startupProbe budget)." }}{{- end }}
 {{- /* default true (provision hugepages) when the hugepages map is absent/null or omits enabled. */ -}}
 {{- $hugepages := dig "enabled" true (.Values.hugepages | default dict) }}
-{{- /* Size hugepages per device; a copy so $cfg is untouched. */ -}}
 {{- $resources := deepCopy ($cfg.resources | default dict) }}
+{{- /* No size means the device needs no hugepages (gpu/cpu): turn the whole
+       feature off rather than mounting /dev/hugepages-1G with no reservation. */ -}}
 {{- $hpSize := include "tt-inference-server.hugepagesSize" . }}
+{{- $hugepages = and $hugepages (ne $hpSize "") }}
 {{- range $group := list "limits" "requests" }}
-{{- if and $hugepages $hpSize }}
-{{- $_ := set $resources $group (merge (dict "hugepages-1Gi" $hpSize) (index $resources $group | default dict)) }}
+{{- /* Sizing hugepages here would let requests and limits disagree, which k8s
+       rejects; hugepages.size is the one place that sets both. */ -}}
+{{- if hasKey (index $resources $group | default dict) "hugepages-1Gi" }}
+{{- fail (printf "set hugepages.size, not resources.%s.hugepages-1Gi: the request and limit must match and the chart sets both." $group) }}
+{{- end }}
+{{- if $hugepages }}
+{{- $_ := set $resources $group (merge (index $resources $group | default dict) (dict "hugepages-1Gi" $hpSize)) }}
 {{- else if hasKey $resources $group }}
 {{- $_ := unset (index $resources $group) "hugepages-1Gi" }}
 {{- if not (index $resources $group) }}{{- $_ := unset $resources $group }}{{- end }}

--- a/charts/tt-inference-server/templates/deployment.yaml
+++ b/charts/tt-inference-server/templates/deployment.yaml
@@ -6,15 +6,15 @@
 {{- if le $startupPeriod 0 }}{{- fail "probes.startup.periodSeconds must be greater than 0 (it divides progressDeadlineSeconds to size the startupProbe budget)." }}{{- end }}
 {{- /* default true (provision hugepages) when the hugepages map is absent/null or omits enabled. */ -}}
 {{- $hugepages := dig "enabled" true (.Values.hugepages | default dict) }}
-{{- $resources := $cfg.resources }}
-{{- if and $resources (not $hugepages) }}
-{{- /* hugepages disabled: strip hugepages-1Gi from a copy so $cfg is untouched. */ -}}
-{{- $resources = deepCopy $resources }}
+{{- /* Size hugepages per device; a copy so $cfg is untouched. */ -}}
+{{- $resources := deepCopy ($cfg.resources | default dict) }}
+{{- $hpSize := include "tt-inference-server.hugepagesSize" . }}
 {{- range $group := list "limits" "requests" }}
-{{- if hasKey $resources $group }}
+{{- if and $hugepages $hpSize }}
+{{- $_ := set $resources $group (merge (dict "hugepages-1Gi" $hpSize) (index $resources $group | default dict)) }}
+{{- else if hasKey $resources $group }}
 {{- $_ := unset (index $resources $group) "hugepages-1Gi" }}
 {{- if not (index $resources $group) }}{{- $_ := unset $resources $group }}{{- end }}
-{{- end }}
 {{- end }}
 {{- end }}
 apiVersion: apps/v1

--- a/charts/tt-inference-server/templates/secret.yaml
+++ b/charts/tt-inference-server/templates/secret.yaml
@@ -1,3 +1,5 @@
+{{- $engine := include "tt-inference-server.resolvedEngine" . }}
+{{- $apiKey := dig "apiKey" "" (.Values.auth | default dict) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,7 +8,18 @@ metadata:
   labels:
     {{- include "tt-inference-server.labels" . | nindent 4 }}
 type: Opaque
-{{- if .Values.hfToken }}
+{{- if or .Values.hfToken $apiKey }}
 stringData:
-  HF_TOKEN: {{ .Values.hfToken | quote }}
+  {{- with .Values.hfToken }}
+  HF_TOKEN: {{ . | quote }}
+  {{- end }}
+  {{- if $apiKey }}
+  {{- if eq $engine "vllm" }}
+  # vLLM enforces a literal bearer token on /v1/... when VLLM_API_KEY is set.
+  VLLM_API_KEY: {{ $apiKey | quote }}
+  {{- else }}
+  # media/forge compare the request's bearer token against API_KEY.
+  API_KEY: {{ $apiKey | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/tt-inference-server/templates/secret.yaml
+++ b/charts/tt-inference-server/templates/secret.yaml
@@ -15,10 +15,8 @@ stringData:
   {{- end }}
   {{- if $apiKey }}
   {{- if eq $engine "vllm" }}
-  # vLLM enforces a literal bearer token on /v1/... when VLLM_API_KEY is set.
   VLLM_API_KEY: {{ $apiKey | quote }}
   {{- else }}
-  # media/forge compare the request's bearer token against API_KEY.
   API_KEY: {{ $apiKey | quote }}
   {{- end }}
   {{- end }}

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -29,6 +29,21 @@ cache:
 # (tt-media-server) env vars are set so each server picks up the name it reads.
 hfCacheDir: ""
 
+# Inference-route authentication. The media and forge servers check a literal
+# `Authorization: Bearer $API_KEY` on their inference routes (/health and
+# /v1/models stay open) and fall back to a well-known built-in key when API_KEY
+# is unset, so the chart requires an explicit choice for those engines: set
+# apiKey, or set disabled=true to run without auth (e.g. behind your own
+# gateway). vLLM is unauthenticated unless VLLM_API_KEY is set, which is where
+# apiKey lands for vllm engines. Mirrors run.py's API_KEY / --no-auth contract.
+auth:
+  # Bearer key clients must send. Rendered into the release Secret as API_KEY
+  # (media/forge) or VLLM_API_KEY (vllm).
+  apiKey: ""
+  # Run the server with authentication off (NO_AUTH=1). media/forge only; vLLM
+  # is already open when apiKey is unset.
+  disabled: false
+
 # Tenstorrent boards need 1Gi hugepages unless the cluster runs IOMMU + KMD
 # 1.29.0+, where they aren't required. When disabled, the chart drops the
 # hugepages-1Gi request/limit, the /dev/hugepages-1G volume + mounts, and the

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -142,6 +142,22 @@ deviceBoardNames:
   p300x2: p300
   t3k: n300
 
+# ASIC count per device — tt-metal maps one 1Gi hugepage per ASIC, so this sizes the
+# hugepages request/limit. Generated from workflows/device_utils.py:BOARD_TYPE_COUNT_TO_DEVICE;
+# consumed by tt-inference-server.hugepagesSize.
+deviceChipCounts:
+  galaxy: 32
+  n150: 1
+  n150x4: 4
+  n300: 2
+  p100: 1
+  p150: 1
+  p150x4: 4
+  p150x8: 8
+  p300: 2
+  p300x2: 4
+  t3k: 8
+
 # DRA board count per device — number of Tenstorrent boards a ResourceClaim requests for each device shape.
 # Generated from workflows/device_utils.py:BOARD_TYPE_COUNT_TO_DEVICE; consumed by tt-inference-server.draDeviceCount.
 deviceBoardCounts:
@@ -164,21 +180,6 @@ deviceBoardCounts:
 # the generator only overwrites the keys it owns.
 # ---------------------------------------------------------------------------
 
-# ASIC count per device — tt-metal maps one 1Gi hugepage per ASIC, so this sizes the
-# hugepages request/limit. Generated from workflows/device_utils.py:BOARD_TYPE_COUNT_TO_DEVICE;
-# consumed by tt-inference-server.hugepagesSize.
-deviceChipCounts:
-  galaxy: 32
-  n150: 1
-  n150x4: 4
-  n300: 2
-  p100: 1
-  p150: 1
-  p150x4: 4
-  p150x8: 8
-  p300: 2
-  p300x2: 4
-  t3k: 8
 models:
   gpt-oss-20b:
     vllm:

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -29,19 +29,15 @@ cache:
 # (tt-media-server) env vars are set so each server picks up the name it reads.
 hfCacheDir: ""
 
-# Inference-route authentication. The media and forge servers check a literal
-# `Authorization: Bearer $API_KEY` on their inference routes (/health and
-# /v1/models stay open) and fall back to a well-known built-in key when API_KEY
-# is unset, so the chart requires an explicit choice for those engines: set
-# apiKey, or set disabled=true to run without auth (e.g. behind your own
-# gateway). vLLM is unauthenticated unless VLLM_API_KEY is set, which is where
-# apiKey lands for vllm engines. Mirrors run.py's API_KEY / --no-auth contract.
+# Inference-route authentication. media and forge servers check a literal
+# `Authorization: Bearer $API_KEY` (/health and /v1/models stay open) and fall
+# back to a well-known built-in key when unset, so one of these two is required
+# for those engines. vLLM is open unless VLLM_API_KEY is set.
 auth:
-  # Bearer key clients must send. Rendered into the release Secret as API_KEY
+  # Bearer key clients must send. Stored in the release Secret as API_KEY
   # (media/forge) or VLLM_API_KEY (vllm).
   apiKey: ""
-  # Run the server with authentication off (NO_AUTH=1). media/forge only; vLLM
-  # is already open when apiKey is unset.
+  # Serve without authentication (NO_AUTH=1). media/forge only.
   disabled: false
 
 # Tenstorrent boards need 1Gi hugepages unless the cluster runs IOMMU + KMD

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -46,6 +46,9 @@ auth:
 # cleanup-hugepages initContainer.
 hugepages:
   enabled: true
+  # Request/limit when enabled. Empty means one 1Gi page per ASIC of the chosen
+  # device (deviceChipCounts) — e.g. 1Gi on an n150, 8Gi on a T3K.
+  size: ""
 
 # PodMonitor scraping the inference server's own /metrics (vLLM and media-server
 # expose it). Disabled by default: a PodMonitor needs the Prometheus Operator
@@ -90,15 +93,15 @@ defaults:
     port: 8000
     targetPort: 8000
     annotations: {}
+  # hugepages-1Gi is not listed here: it is sized from the device's ASIC count
+  # (see hugepages.size).
   resources:
     limits:
 #      cpu: "8"
 #      memory: 480Gi #~90% of RAM available on Galaxy servers
-      hugepages-1Gi: 32Gi
     requests:
       cpu: "6"
       memory: 64Gi
-      hugepages-1Gi: 32Gi
   probes:
     # startupProbe owns the model compile/warmup window; while it runs the kubelet
     # suppresses liveness/readiness. Its failureThreshold is computed in the
@@ -160,6 +163,22 @@ deviceBoardCounts:
 # ModelSpec catalog. Hand edits to leaf values are preserved across re-runs;
 # the generator only overwrites the keys it owns.
 # ---------------------------------------------------------------------------
+
+# ASIC count per device — tt-metal maps one 1Gi hugepage per ASIC, so this sizes the
+# hugepages request/limit. Generated from workflows/device_utils.py:BOARD_TYPE_COUNT_TO_DEVICE;
+# consumed by tt-inference-server.hugepagesSize.
+deviceChipCounts:
+  galaxy: 32
+  n150: 1
+  n150x4: 4
+  n300: 2
+  p100: 1
+  p150: 1
+  p150x4: 4
+  p150x8: 8
+  p300: 2
+  p300x2: 4
+  t3k: 8
 models:
   gpt-oss-20b:
     vllm:

--- a/tests/test_chart/test_chart_resolver.py
+++ b/tests/test_chart/test_chart_resolver.py
@@ -29,6 +29,9 @@ def _render(*set_args):
         str(CHART),
         "--set",
         "hfToken=fake",
+        # media/forge rows fail closed without an auth choice.
+        "--set",
+        "auth.apiKey=fake",
     ]
     for s in set_args:
         cmd.extend(["--set", s])

--- a/workflows/device_utils.py
+++ b/workflows/device_utils.py
@@ -85,8 +85,8 @@ def dra_device_board_counts() -> Dict[str, int]:
     )
 
 
-# Boards that carry two ASICs; every other board type is single-chip. Same split
-# tt-smi reporting needs (see _board_type_counts_from_tt_smi).
+# Boards that carry two ASICs; every other board type is single-chip. Matches the
+# tt-dra-driver chipCount table (docs.tenstorrent.com/tt-dra-driver, single-host).
 _TWO_CHIP_BOARD_TYPES = {"n300", "p300"}
 
 
@@ -163,7 +163,7 @@ def _get_tt_smi_board_type_counts() -> Dict[str, int]:
         raw_board_type = _normalize_board_type(board_info.get("board_type", ""))
         board_type = raw_board_type.split(" ", 1)[0]
         if board_type:
-            if board_type in {"n300", "p300"}:
+            if board_type in _TWO_CHIP_BOARD_TYPES:
                 # tt-smi reports per-chip entries (e.g., n300 L/R), so convert chip
                 # counts to board counts after collapsing L/R suffixes.
                 board_chip_counts[board_type] = board_chip_counts.get(board_type, 0) + 1

--- a/workflows/device_utils.py
+++ b/workflows/device_utils.py
@@ -85,6 +85,26 @@ def dra_device_board_counts() -> Dict[str, int]:
     )
 
 
+# Boards that carry two ASICs; every other board type is single-chip. Same split
+# tt-smi reporting needs (see _board_type_counts_from_tt_smi).
+_TWO_CHIP_BOARD_TYPES = {"n300", "p300"}
+
+
+def dra_device_chip_counts() -> Dict[str, int]:
+    """Map device_key (e.g. "t3k") -> number of ASICs the device shape has.
+
+    Drives the chart's hugepage sizing: tt-metal maps one 1Gi page per ASIC, so
+    a device needs board_count x chips_per_board pages. Same source and device
+    coverage as dra_device_board_counts (see _dra_single_board_type_devices).
+    """
+    return dict(
+        sorted(
+            (key, count * (2 if bt in _TWO_CHIP_BOARD_TYPES else 1))
+            for key, bt, count in _dra_single_board_type_devices()
+        )
+    )
+
+
 def dra_device_board_names() -> Dict[str, str]:
     """Map device_key (e.g. "t3k") -> the tt-dra-driver `boardName` a DRA
     ResourceClaim selects (via CEL). Same source and device coverage as

--- a/workflows/helm_generator/README.md
+++ b/workflows/helm_generator/README.md
@@ -145,7 +145,8 @@ helm template charts/tt-inference-server \
   --set model=Llama-3.1-70B \
   --set device=t3k \
   --set engine=media \
-  --set hfToken=fake
+  --set hfToken=fake \
+  --set auth.apiKey=fake
 
 # pick a non-default impl
 helm template charts/tt-inference-server \

--- a/workflows/helm_generator/cli.py
+++ b/workflows/helm_generator/cli.py
@@ -21,11 +21,16 @@ from workflows.helm_generator.merge import (
     merge_spec,
     set_default_engine,
     set_device_board_counts,
+    set_device_chip_counts,
     set_device_board_names,
 )
 from workflows.helm_generator.schema import HelmModelSpec
 from workflows.helm_generator.yaml_io import dump_values, dumps_values, load_values
-from workflows.device_utils import dra_device_board_counts, dra_device_board_names
+from workflows.device_utils import (
+    dra_device_board_counts,
+    dra_device_board_names,
+    dra_device_chip_counts,
+)
 from workflows.model_spec import IMAGE_PINNED_MODEL_SPECS, ModelSpec
 from workflows.utils import get_repo_root_path
 
@@ -213,6 +218,14 @@ def generate(
     }
     if set_device_board_counts(doc, board_counts):
         logger.info("updated deviceBoardCounts")
+
+    # deviceChipCounts: ASIC count per device, sizing the hugepages request —
+    # same single source of truth and catalogue restriction as deviceBoardCounts.
+    chip_counts = {
+        k: v for k, v in dra_device_chip_counts().items() if k in used_devices
+    }
+    if set_device_chip_counts(doc, chip_counts):
+        logger.info("updated deviceChipCounts")
 
     # deviceBoardNames: the tt-dra-driver boardName the ResourceClaim selects (CEL)
     # for each device the catalogue offers — same single source of truth and same

--- a/workflows/helm_generator/merge.py
+++ b/workflows/helm_generator/merge.py
@@ -225,6 +225,45 @@ def set_device_board_counts(doc: Any, counts: Mapping[str, int]) -> bool:
     return True
 
 
+def set_device_chip_counts(doc: Any, counts: Mapping[str, int]) -> bool:
+    """Set/refresh the top-level `deviceChipCounts` map (device_key -> ASIC
+    count), inserted just before `models` for readability. Idempotent.
+
+    Returns True if the file changed.
+    """
+    from ruamel.yaml.comments import CommentedMap
+
+    desired = CommentedMap()
+    for key in sorted(counts):
+        desired[key] = int(counts[key])
+
+    existing = doc.get("deviceChipCounts")
+    if existing is not None and {k: int(v) for k, v in existing.items()} == {
+        k: int(v) for k, v in desired.items()
+    }:
+        return False
+
+    if "deviceChipCounts" in doc:
+        doc["deviceChipCounts"] = desired
+    else:
+        keys = list(doc.keys())
+        pos = keys.index("models") if "models" in keys else len(keys)
+        models_comment = getattr(doc, "ca", None) and doc.ca.items.get("models")
+        doc.insert(pos, "deviceChipCounts", desired)
+        doc.yaml_set_comment_before_after_key(
+            "deviceChipCounts",
+            before=(
+                "\nASIC count per device — tt-metal maps one 1Gi hugepage per ASIC, "
+                "so this sizes the\nhugepages request/limit. Generated from "
+                "workflows/device_utils.py:BOARD_TYPE_COUNT_TO_DEVICE;\nconsumed by "
+                "tt-inference-server.hugepagesSize."
+            ),
+        )
+        if models_comment is not None:
+            doc.ca.items["models"] = models_comment
+    return True
+
+
 def set_device_board_names(doc: Any, names: Mapping[str, str]) -> bool:
     """Set/refresh the top-level `deviceBoardNames` map (device_key -> tt-dra-driver
     `boardName`), inserted just before `models` for readability. Idempotent.

--- a/workflows/helm_generator/merge.py
+++ b/workflows/helm_generator/merge.py
@@ -247,8 +247,14 @@ def set_device_chip_counts(doc: Any, counts: Mapping[str, int]) -> bool:
         doc["deviceChipCounts"] = desired
     else:
         keys = list(doc.keys())
-        pos = keys.index("models") if "models" in keys else len(keys)
-        models_comment = getattr(doc, "ca", None) and doc.ca.items.get("models")
+        # A key's leading comment is stored on the key before it, so inserting
+        # here strands whatever comment introduced the key we displace. Insert
+        # ahead of deviceBoardCounts (keeping the DRA maps together and the
+        # per-model banner on `models`) and re-attach its comment afterwards.
+        if "deviceBoardCounts" in keys:
+            pos = keys.index("deviceBoardCounts")
+        else:
+            pos = keys.index("models") if "models" in keys else len(keys)
         doc.insert(pos, "deviceChipCounts", desired)
         doc.yaml_set_comment_before_after_key(
             "deviceChipCounts",
@@ -259,8 +265,16 @@ def set_device_chip_counts(doc: Any, counts: Mapping[str, int]) -> bool:
                 "tt-inference-server.hugepagesSize."
             ),
         )
-        if models_comment is not None:
-            doc.ca.items["models"] = models_comment
+        if "deviceBoardCounts" in keys:
+            doc.yaml_set_comment_before_after_key(
+                "deviceBoardCounts",
+                before=(
+                    "\nDRA board count per device — number of Tenstorrent boards a "
+                    "ResourceClaim requests for each device shape.\nGenerated from "
+                    "workflows/device_utils.py:BOARD_TYPE_COUNT_TO_DEVICE; consumed "
+                    "by tt-inference-server.draDeviceCount."
+                ),
+            )
     return True
 
 


### PR DESCRIPTION
Part of #4869. Adds the real-hardware tier of the chart's CI — above the render gate and the kind install gate.

**The smoke** (`.github/scripts/helm_hw_smoke.sh`) runs nightly at 20:17 UTC and on `workflow_dispatch` (which takes a ref, so a chart PR can be checked on hardware before merge). It gates nothing in `test-gate.yml`. It asserts only what the cheaper tiers cannot:

1. the DRA claim allocates and `/dev/tenstorrent/<N>` lands in the **real inference container** — no privileged, no hostPath
2. Ready inside the startupProbe budget, no restart, with the measured compile time reported against that budget
3. `/health`, `/v1/models`, one inference call — and that an unauthenticated call is refused
4. `helm uninstall` releases the board, no Pod stuck `Terminating`

The runner pool is bare, so `hw_smoke_bootstrap.sh` stands up RKE2 + tt-operator (NFD + TTFM + tt-dra-driver) first, and restarts the DRA kubelet plugin once TTFM is Ready — the plugin only discovers boards at startup, which is why tt-operator's own `dra-smoke` fails on 40 of 42 recent job instances.

**Chart changes**, all found by running the smoke:

- `auth.apiKey` → Secret as `API_KEY` (media/forge) or `VLLM_API_KEY` (vllm), `auth.disabled` → `NO_AUTH=1`, and media/forge now fail closed until one is set. **Breaking for those installs**: the servers fall back to a well-known built-in key when `API_KEY` is unset, so a chart-deployed one looks authenticated and is not.
- hugepages sized from the device's ASIC count (`deviceChipCounts`, generated from the same table as `deviceBoardCounts`) instead of a fixed 32Gi: n150 1Gi, n300 2Gi, t3k 8Gi, galaxy 32Gi — the last unchanged, and where the old constant came from. The fixed request made every host smaller than a Galaxy unschedulable. `hugepages.size` overrides.
- `HF_HOME` under the cache volume for media/forge, so weights survive a Pod restart instead of being re-downloaded.
- a `cacheRoot` helper replacing two hardcoded copies of the mount path, and ConfigMap `data` built as a dict so an `extraEnv` key colliding with a chart key no longer breaks the render.

Verified on the n150 pool ([run](https://github.com/tenstorrent/tt-inference-server/actions/runs/32477829484)): all four asserts, Ready after 506s of compile with the chart's computed 1Gi of hugepages, `/v1/embeddings` 401 without the key and 200 with it.
