### PR TITLE
automated release pipeline implementation

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -1,4 +1,4 @@
-name: Release Automation (promote specs, docs & docker images)
+name: Release Automation (promote specs, docs, helm & docker images)
 
 run-name: ${{ inputs.version && format('Release automation v{0}', inputs.version) || 'Release automation (push)' }}
 

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -288,6 +288,19 @@ jobs:
           git push -f origin "refs/tags/${TAG}"
           echo "Tagged HEAD and pushed '${TAG}'."
 
+      - name: "git branch <tag> from release HEAD + push"
+        # README_MANUAL also cuts a v<version> BRANCH (besides the tag) from the
+        # release HEAD. Use `git branch -f` (NOT switch/checkout) so HEAD stays on
+        # the current release branch — later steps (crane copy / re-bake / verify /
+        # post-release) are unaffected. The branch is taken from HEAD (never
+        # references 'stable' or the branch name), and NO branch is deleted. Force
+        # so a re-run re-points the (temp) branch instead of failing.
+        run: |
+          TAG="v${RELEASE_VERSION}${TAG_SUFFIX}"
+          git branch -f "${TAG}" HEAD
+          git push -f origin "refs/heads/${TAG}"
+          echo "Created branch '${TAG}' at release HEAD and pushed it (stable left intact)."
+
       # Preserve the generated files so they can be inspected / downloaded.
       - name: "Upload generated changes as an artifact"
         if: always()

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -1,53 +1,54 @@
-name: Release Automation (promote specs, docs & helm)
+name: Release Automation (promote specs, docs & docker images)
 
 run-name: ${{ inputs.version && format('Release automation v{0}', inputs.version) || 'Release automation (push)' }}
 
 # ---------------------------------------------------------------------------
-# Automates the release pipeline:
+# Automates the release pipeline (dispatch-only). In order:
+#   - Guard: only the sanctioned release branch may run.
+#   - Validate inputs: version == VERSION file; vllm-commit present when the
+#     release ships vLLM; tt-metal/vllm commits match the tt-shield run.
 #   1. promote_dev_spec_to_prod.py  (dev -> prod model specs, release-scoped)
+#   1b. assert no shadowed duplicate model_id in the promoted prod catalogue
 #   2. export_model_spec.py         (docs/model_support + release_model_spec.json)
 #   3. python -m workflows.helm_generator  (charts/.../values.yaml)
 #   4. helm-docs                    (chart README / supported-models docs)
-# then, from the runner:
-#   git add . && git commit -m "v<version><suffix>" && git push
-#   git tag v<version><suffix> && git push origin v<version><suffix>
-# finally:
-#   create branch post-release-v<version><post-suffix> off main, carrying this
-#   branch's VERSION + models-ci-config.json onto it, re-run all 4 steps from above and push it.
+#   - commit + push the generated files to the release branch, then tag.
+#   - build the release-artifacts zip from the tt-shield run (upload artifact).
+#   - resolve tt-shield source images -> map to release images -> crane copy
+#     (publish) -> re-bake the prod catalogue into the vLLM image -> verify.
+#   - create post-release-v<version> off main (carry VERSION + models-ci-config,
+#     re-run the 4 generators) and open a draft PR to main.
+# Suffixes (tag-suffix / post-release-suffix) mark testing artifacts; empty = real release.
 # ---------------------------------------------------------------------------
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version for the run title, e.g. 0.18.0 (must match the VERSION file, which stays the source of truth)"
+        description: "Release version for the run title, e.g. 0.21.0 - must match the VERSION"
         required: true
-        default: "0.18.0"
-        type: string
-      tt-metal-commit:
-        description: "tt-metal commit SHA pinned into the promoted prod specs"
-        required: true
-        default: "c49bb76"
-        type: string
-      vllm-commit:
-        description: "vLLM commit SHA (needed for LLM / VLLM models)"
-        required: false
-        default: "6b4a3a7"
         type: string
       tt-shield-run-id:
-        description: "tt-shield Release run ID (reserved for the later artifact step; NOT used by the four commands here)"
+        description: "tt-shield Release run ID"
+        required: true
+        type: string
+      tt-metal-commit:
+        description: "tt-metal commit SHA pinned into the prod catalogue"
+        required: true
+        type: string
+      vllm-commit:
+        description: "vLLM commit SHA (needed for LLM models)"
         required: false
-        default: "29037835062"
         type: string
       tag-suffix:
-        description: "Suffix appended to the commit message & tag. Keep '-temp' while testing; clear it for a real release."
+        description: "Suffix appended to the commit message & tag. Empty for a real release; set e.g. '-temp' while testing."
         required: false
-        default: "-temp"
+        default: ""
         type: string
       post-release-suffix:
-        description: "Suffix for the post-release branch (post-release-v<version><suffix>). Keep '-test' while testing; clear it for a real release."
+        description: "Suffix for the post-release branch. Empty for a real release; set e.g. '-test' while testing."
         required: false
-        default: "-test"
+        default: ""
         type: string
 
 # The pipeline commits generated files + a tag to the branch and opens a draft PR.
@@ -72,6 +73,20 @@ jobs:
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:
+      # Refuse to run from anywhere but the sanctioned release branches. Runs
+      # first (before checkout) so a wrong branch (e.g. main) fails immediately.
+      - name: "Guard: allowed release branch only"
+        env:
+          REF: ${{ github.ref_name }}
+        run: |
+          case "$REF" in
+            stable | vcankovic/automated-release-pipeline)
+              echo "Branch '$REF' is allowed — proceeding." ;;
+            *)
+              echo "::error::Release automation may only run from 'stable', 'vcankovic/stable-automated-release-pipeline', or 'vcankovic/automated-release-pipeline'. Refusing to run on '$REF'."
+              exit 1 ;;
+          esac
+
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -104,7 +119,6 @@ jobs:
 
       - name: Resolve inputs
         env:
-          EVENT_NAME: ${{ github.event_name }}
           IN_VERSION: ${{ github.event.inputs.version }}
           IN_TT_METAL_COMMIT: ${{ github.event.inputs['tt-metal-commit'] }}
           IN_VLLM_COMMIT: ${{ github.event.inputs['vllm-commit'] }}
@@ -123,30 +137,54 @@ jobs:
             echo "::error::version input ('$IN_VERSION') does not match the VERSION file ('$RELEASE_VERSION'). Update the input or the VERSION file so they agree."
             exit 1
           fi
+          if [ -z "$IN_TT_SHIELD_RUN_ID" ]; then
+            echo "::error::tt-shield-run-id is required"; exit 1
+          fi
+          # If this release ships any vLLM model, vllm-commit is mandatory: an
+          # empty value would pin an empty vllm_commit in prod and produce a
+          # malformed image tag '<ver>-<ttm>-'. Derive the release engine
+          # families from the config (same rule the crane publish step uses).
+          RELEASE_FAMS=$(python3 -c "import json,sys; sys.path.insert(0,'.'); from workflows.workflow_types import InferenceEngine as E; c=json.load(open('.github/workflows/models-ci-config.json')); print(' '.join(sorted({E.from_string(i['inference_engine']).value.lower() for _n,e in c['models'].items() for i in e.get('implementations',[e]) if i.get('ci',{}).get('release')})))")
+          echo "Release engine families: ${RELEASE_FAMS:-<none>}"
+          case " ${RELEASE_FAMS} " in
+            *" vllm "*)
+              if [ -z "$IN_VLLM_COMMIT" ]; then
+                echo "::error::this release ships vLLM models (families: ${RELEASE_FAMS}) but vllm-commit is empty — provide it."
+                exit 1
+              fi ;;
+          esac
           {
             echo "RELEASE_VERSION=${RELEASE_VERSION}"
-            echo "TT_METAL_COMMIT=${IN_TT_METAL_COMMIT:-c49bb76}"
-            echo "VLLM_COMMIT=${IN_VLLM_COMMIT:-6b4a3a7}"
-            echo "TT_SHIELD_RUN_ID=${IN_TT_SHIELD_RUN_ID:-29037835062}"
+            echo "TT_METAL_COMMIT=${IN_TT_METAL_COMMIT}"
+            echo "VLLM_COMMIT=${IN_VLLM_COMMIT}"
+            echo "TT_SHIELD_RUN_ID=${IN_TT_SHIELD_RUN_ID}"
           } >> "$GITHUB_ENV"
-          # Suffixes: on dispatch use the inputs verbatim (may be empty for a
-          # real release); on push default to the testing suffixes.
-          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
-            echo "TAG_SUFFIX=${IN_TAG_SUFFIX}" >> "$GITHUB_ENV"
-            echo "POST_RELEASE_SUFFIX=${IN_POST_RELEASE_SUFFIX}" >> "$GITHUB_ENV"
-          else
-            echo "TAG_SUFFIX=-temp" >> "$GITHUB_ENV"
-            echo "POST_RELEASE_SUFFIX=-test" >> "$GITHUB_ENV"
-          fi
+          # Suffixes: use the dispatch inputs verbatim (empty = real release).
+          {
+            echo "TAG_SUFFIX=${IN_TAG_SUFFIX}"
+            echo "POST_RELEASE_SUFFIX=${IN_POST_RELEASE_SUFFIX}"
+          } >> "$GITHUB_ENV"
 
       - name: Show effective parameters
         run: |
           echo "version          = ${RELEASE_VERSION}"
           echo "tt-metal-commit  = ${TT_METAL_COMMIT}"
           echo "vllm-commit      = ${VLLM_COMMIT}"
-          echo "tt-shield-run-id = ${TT_SHIELD_RUN_ID}  (not used here)"
+          echo "tt-shield-run-id = ${TT_SHIELD_RUN_ID}"
           echo "commit/tag       = v${RELEASE_VERSION}${TAG_SUFFIX}"
           echo "post-release br  = post-release-v${RELEASE_VERSION}${POST_RELEASE_SUFFIX} (from main)"
+
+      # ----- Cross-check the hand-typed commits against what the tt-shield run
+      #       actually built, BEFORE any promote/commit/tag/publish. Fails fast on
+      #       a typo'd tt-metal-commit / vllm-commit (wrong pins + wrong image
+      #       tags). Empty vllm-commit is ignored here (guarded above by #8). -----
+      - name: "Validate input commits against the tt-shield run"
+        env:
+          GH_TOKEN: ${{ secrets.TMP_VCANKOVIC_SHIELD_CRANE_PAT }}
+        run: |
+          python3 scripts/release/resolve_release_source_images.py \
+            --run-id "${TT_SHIELD_RUN_ID}" \
+            --expect "ttm=${TT_METAL_COMMIT},vllm=${VLLM_COMMIT}"
 
       # ----- Step 1: promote dev model specs -> prod (release-scoped only) -----
       - name: "Step 1 — promote dev specs to prod"
@@ -155,6 +193,33 @@ jobs:
             --version "${RELEASE_VERSION}" \
             --tt-metal-commit "${TT_METAL_COMMIT}" \
             --vllm-commit "${VLLM_COMMIT}"
+
+      # ----- Step 1b: fail if promotion produced a shadowed duplicate model_id.
+      #       promote_dev_spec_to_prod.py keys its upsert on the device SET, so
+      #       adding a device appends a new prod block instead of replacing the
+      #       old one; both then expand to the same model_id and the docs
+      #       generator renders the dead one (hit Qwen3.6-27B / Qwen3-Embedding-4B
+      #       at v0.20.0). Inspect the just-promoted PROD catalogue directly (the
+      #       JSON export dedupes via a {model_id: spec} dict and would hide it). -----
+      - name: "Step 1b — assert promotion produced no shadowed duplicates"
+        env:
+          MODEL_SPECS_ENV: prod
+        run: |
+          python3 - <<'PY'
+          import collections, sys
+          from workflows.model_spec import spec_templates
+          seen = collections.defaultdict(list)
+          for t in spec_templates:
+              for s in t.expand_to_specs():
+                  seen[s.model_id].append(getattr(t, "version", None))
+          dups = {k: v for k, v in seen.items() if len(v) > 1}
+          for k, v in sorted(dups.items()):
+              print(f"::error::duplicate model_id {k} produced by prod templates {v} - "
+                    "the older block is unreachable and will be rendered into the docs")
+          if dups:
+              sys.exit(f"{len(dups)} shadowed duplicate model_id(s) in the prod catalogue")
+          print(f"OK - {len(seen)} unique model_ids, no duplicates")
+          PY
 
       # ----- Step 2: regenerate model-support docs + release_model_spec.json ----
       - name: "Step 2 — export model spec (docs + JSON)"
@@ -326,7 +391,7 @@ jobs:
           echo "media: $SRC_MEDIA -> $DST_MEDIA"
           echo "forge: $SRC_FORGE -> $DST_FORGE"
 
-          # Summary table + crane-copy preview (NOT executed here).
+          # Summary table + publish plan (source -> destination).
           {
             echo "## Release image publish plan (v${VER})"
             echo
@@ -336,7 +401,7 @@ jobs:
             echo "| media | \`$SRC_MEDIA\` | \`$DST_MEDIA\` |"
             echo "| forge | \`$SRC_FORGE\` | \`$DST_FORGE\` |"
             echo
-            echo "_Release-scoped crane copy commands are shown by the 'crane copy simulation' step below._"
+            echo "_Release-scoped crane copy commands are run by the 'crane copy (publish release images)' step below._"
           } >> "$GITHUB_STEP_SUMMARY"
 
       # ----- Install crane (google/go-containerregistry) — used to promote the
@@ -347,13 +412,12 @@ jobs:
             | sudo tar -xzf - -C /usr/local/bin crane
           crane version
 
-      # ----- REAL crane login to ghcr.io (README_MANUAL pattern), as
-      #       vcankovicTT with the TMP_VCANKOVIC_SHIELD_CRANE_PAT secret (a PAT
-      #       with read:packages for tt-shield + write:packages for
-      #       tt-inference-server). Login is real (the crane copy below is only
-      #       simulated). Verifies the login and, if a source image resolved,
-      #       that the token can actually PULL it (needs read:packages) — a read
-      #       failure is warned, not fatal, since this iteration only simulates. -----
+      # ----- crane login to ghcr.io (README_MANUAL pattern), as vcankovicTT with
+      #       the TMP_VCANKOVIC_SHIELD_CRANE_PAT secret (read:packages for
+      #       tt-shield + write:packages for tt-inference-server). Verifies the
+      #       login and, if a source image resolved, that the token can PULL it
+      #       (needs read:packages) — an early diagnostic; the real crane copy
+      #       below hard-fails if auth is insufficient. -----
       - name: "crane login to ghcr.io (real) + verify"
         env:
           CRANE_USER: vcankovicTT
@@ -377,13 +441,13 @@ jobs:
             break
           done
 
-      # ----- SIMULATION: print the crane copy commands that WOULD publish the
-      #       release images, gated by which ENGINE FAMILIES the current release
-      #       actually ships (from models-ci-config.json release entries, via the
-      #       InferenceEngine enum — same rule as generate_default_docker_link).
-      #       A family is copied only if it is in the release AND a source image
-      #       was built. Nothing is executed (dry-run). -----
-      - name: "crane copy preparation (dry-run)"
+      # ----- Publish the release images: crane copy each source -> destination,
+      #       gated by which ENGINE FAMILIES the current release actually ships
+      #       (from models-ci-config.json release entries, via the InferenceEngine
+      #       enum — same rule as generate_default_docker_link). A family is copied
+      #       only if it is in the release AND a source image was built. -----
+      - name: "crane copy (publish release images)"
+        id: crane-plan
         env:
           SRC_VLLM: ${{ steps.image-mapping.outputs.vllm_source }}
           DST_VLLM: ${{ steps.image-mapping.outputs.vllm_dest }}
@@ -401,6 +465,7 @@ jobs:
           in_release() { for f in $RELEASE_FAMS; do [ "$f" = "$1" ] && return 0; done; return 1; }
 
           copy_cmds=""
+          promoted=""   # just the destination images that will be published
           for fam in vllm media forge; do
             case "$fam" in
               vllm)  src="$SRC_VLLM";  dst="$DST_VLLM";;
@@ -415,42 +480,178 @@ jobs:
               cmd="crane copy ${src} ${dst}"
               echo "${cmd}"
               copy_cmds="${copy_cmds}${cmd}"$'\n'
+              promoted="${promoted}${dst}"$'\n'
+              crane copy "${src}" "${dst}" || { echo "::error::crane copy failed: ${src} -> ${dst}"; exit 1; }
             fi
           done
 
+          # Single source of truth for the publish list: expose the destination
+          # images (release-scoped + source built) so the PR step can list them
+          # under 'Images Promoted from Models CI'.
           {
-            echo "## crane copy simulation — release-scoped (v${RELEASE_VERSION}, DRY-RUN)"
+            echo "promoted_images<<PROMOTED_EOF"
+            printf '%s' "$promoted"
+            echo "PROMOTED_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## crane copy — release-scoped publish (v${RELEASE_VERSION})"
             echo
             echo "Release engine families: \`${RELEASE_FAMS:-<none>}\`"
             echo
-            echo "Commands that WOULD run (not executed):"
+            echo "Commands executed:"
             echo '```bash'
             if [ -n "$copy_cmds" ]; then printf '%s' "$copy_cmds"; else echo "# (nothing to publish)"; fi
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # ===== TEMPORARY — REMOVE AFTER A SUCCESSFUL TEST RUN ==================
-      # One REAL crane copy (actually pushes) of the media source image to a
-      # throwaway tt-inference-server test repo, purely to confirm crane copy /
-      # write:packages works end-to-end. It uses the login from the crane-login
-      # step above (persisted in ~/.docker/config.json within this job). It does
-      # NOT read or change the real media mapping/simulation — the destination is
-      # hardcoded here. Delete this whole step once the copy is verified.
-      - name: "TEMP: real crane copy test (media -> tt-media-server-dev test repo)"
+      # ----- Re-bake the model catalogue into the published vLLM image.
+      #       crane copy re-labels, it does not rebuild. The tt-shield source
+      #       image was built BEFORE this run promoted dev->prod, so its baked
+      #       /home/container_app_user/model_specs/model_spec.json holds the
+      #       PREVIOUS release's catalogue. Anything promoted in this release is
+      #       missing from it, so the container either dies with
+      #       "No model spec found" or silently serves the old config.
+      #       Affected v0.17.0 through v0.20.0 (gemma-4-31B-it, gpt-oss-120b,
+      #       Qwen3.6-27B, Llama-3.1-8B).
+      #       Appending the fresh catalogue as a new top layer leaves every other
+      #       layer byte-identical, so no model re-validation is needed.
+      #       vLLM only: media/forge containers take their config from host env
+      #       vars and bake no catalogue.
+      #       NOTE: must run AFTER the real vLLM `crane copy`.
+      - name: "Re-bake model catalogue into the published vLLM image"
         env:
-          SRC_MEDIA: ${{ steps.image-mapping.outputs.media_source }}
+          DST_VLLM: ${{ steps.image-mapping.outputs.vllm_dest }}
+          SRC_VLLM: ${{ steps.image-mapping.outputs.vllm_source }}
         run: |
-          if [ -z "$SRC_MEDIA" ] || [ "$SRC_MEDIA" = "None" ]; then
-            echo "No media source image resolved — skipping crane copy test."
+          set -euo pipefail
+          if [ -z "${DST_VLLM}" ] || [ "${DST_VLLM}" = "None" ]; then
+            echo "No vLLM image published this release - nothing to re-bake."
             exit 0
           fi
-          DST_TEST="ghcr.io/tenstorrent/tt-inference-server/tt-media-server-dev-ubuntu-22.04-amd64:${RELEASE_VERSION}-${TT_METAL_COMMIT}"
-          echo "TEST crane copy:"
-          echo "  src: ${SRC_MEDIA}"
-          echo "  dst: ${DST_TEST}"
-          crane copy "${SRC_MEDIA}" "${DST_TEST}"
-          echo "✅ crane copy test succeeded -> ${DST_TEST}"
-      # ===== END TEMPORARY ==================================================
+          if ! crane manifest "${DST_VLLM}" >/dev/null 2>&1; then
+            echo "::warning::${DST_VLLM} not in the registry - skipping re-bake."
+            exit 0
+          fi
+
+          REPO="${DST_VLLM%%:*}"
+
+          # The published tag is an OCI index (amd64 image + buildkit
+          # attestation); crane append needs a single image.
+          AMD64=$(crane manifest "${DST_VLLM}" | python3 -c "import json,sys; m=json.load(sys.stdin); print([x['digest'] for x in m['manifests'] if x['platform']['architecture']=='amd64'][0] if 'manifests' in m else '')")
+          if [ -z "${AMD64}" ]; then
+            echo "::error::could not resolve an amd64 manifest for ${DST_VLLM}"; exit 1
+          fi
+          echo "amd64 base: ${REPO}@${AMD64}"
+
+          # Generate from the promoted prod/ catalogue in this workspace.
+          python3 -c "from scripts.build_docker_images import generate_model_specs_json; generate_model_specs_json()"
+
+          BAKED_VER=$(python3 -c "import json; print(json.load(open('model_spec.json'))['release_version'])")
+          if [ "${BAKED_VER}" != "${RELEASE_VERSION}" ]; then
+            echo "::error::generated catalogue says ${BAKED_VER}, expected ${RELEASE_VERSION} - wrong branch or VERSION not bumped"
+            exit 1
+          fi
+
+          # Pack at the exact path + ownership the image uses
+          # (uid/gid 1000 = container_app_user) so the new layer masks the stale file.
+          rm -rf /tmp/catalog
+          mkdir -p /tmp/catalog/home/container_app_user/model_specs
+          cp model_spec.json /tmp/catalog/home/container_app_user/model_specs/
+          tar --owner=1000 --group=1000 -C /tmp/catalog -cf /tmp/catalog-layer.tar home
+
+          crane append -b "${REPO}@${AMD64}" -f /tmp/catalog-layer.tar -t "${DST_VLLM}"
+          NEW_DIGEST=$(crane digest "${DST_VLLM}")
+          echo "Re-baked ${DST_VLLM} -> ${NEW_DIGEST}"
+
+          {
+            echo "## Model catalogue re-baked into the published vLLM image"
+            echo
+            echo "- image: \`${DST_VLLM}\`"
+            echo "- catalogue release_version: \`${BAKED_VER}\`"
+            echo "- new digest: \`${NEW_DIGEST}\`"
+            echo "- rollback: \`crane copy ${SRC_VLLM} ${DST_VLLM}\`"
+            echo
+            echo "> Tag unchanged; the digest changes and the buildkit attestation is dropped."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ----- The gate: fail the release if the published image cannot resolve
+      #       every spec that points at it. Catches both known causes above and
+      #       any future one.
+      - name: "Verify published vLLM image resolves every spec pinned to it"
+        env:
+          DST_VLLM: ${{ steps.image-mapping.outputs.vllm_dest }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DST_VLLM}" ] || [ "${DST_VLLM}" = "None" ]; then
+            echo "No vLLM image published this release - nothing to verify."
+            exit 0
+          fi
+          if ! crane manifest "${DST_VLLM}" >/dev/null 2>&1; then
+            echo "::warning::${DST_VLLM} not in the registry - skipping verification."
+            exit 0
+          fi
+          python3 - <<'PY'
+          import io, json, os, subprocess, sys, tarfile
+
+          dst = os.environ["DST_VLLM"]
+          expected = os.environ["RELEASE_VERSION"]
+          repo = dst.rsplit(":", 1)[0]
+
+          def sh(args):
+              p = subprocess.run(args, capture_output=True)
+              if p.returncode:
+                  sys.exit(p.stderr.decode(errors="replace")[:300])
+              return p.stdout
+
+          idx = json.loads(sh(["crane", "manifest", dst]))
+          ref = dst
+          if "manifests" in idx:
+              ref = repo + "@" + next(m["digest"] for m in idx["manifests"]
+                                      if m.get("platform", {}).get("architecture") == "amd64")
+
+          man = json.loads(sh(["crane", "manifest", ref]))
+          baked = None
+          for layer in reversed(man["layers"]):
+              if layer["size"] > 3_000_000:
+                  continue
+              try:
+                  with tarfile.open(
+                      fileobj=io.BytesIO(sh(["crane", "blob", f"{repo}@{layer['digest']}"])),
+                      mode="r:gz",
+                  ) as tf:
+                      m = next((m for m in tf.getmembers()
+                                if m.name.endswith("model_specs/model_spec.json")), None)
+                      if m is None:
+                          continue
+                      baked = json.load(tf.extractfile(m))
+              except Exception:
+                  continue
+              break
+
+          if baked is None:
+              sys.exit(f"::error::no baked model_spec.json found in {dst}")
+          if baked["release_version"] != expected:
+              sys.exit(f"::error::{dst} bakes catalogue v{baked['release_version']}, expected v{expected}")
+
+          catalog = baked["model_specs"]
+          published = json.load(open("release_model_spec.json"))["model_specs"]
+
+          missing = []
+          for hf, devices in published.items():
+              for dev, engines in devices.items():
+                  for spec in (s for impls in engines.values() for s in impls.values()):
+                      if spec.get("docker_image") != dst:
+                          continue
+                      if hf not in catalog or dev not in catalog[hf]:
+                          missing.append(f"{hf} [{dev}]")
+
+          for entry in missing:
+              print(f"::error::{entry} is pinned to {dst} but absent from its baked catalogue")
+          if missing:
+              sys.exit(f"{len(missing)} spec(s) unresolvable inside the published image")
+          print(f"OK - catalogue v{baked['release_version']}, every spec pinned to this image resolves")
+          PY
 
       # ----- Post-release branch off main. Branches from origin/main, carries this branch's VERSION
       #       + models-ci-config.json onto it, RE-RUNS the same four generators
@@ -512,9 +713,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TMP_VCANKOVIC_SHIELD_CRANE_PAT: ${{ secrets.TMP_VCANKOVIC_SHIELD_CRANE_PAT }}
+          # Release-scoped publish list from the crane-plan step; rendered under
+          # 'Images Promoted from Models CI' in the PR body.
+          PROMOTED_IMAGES: ${{ steps.crane-plan.outputs.promoted_images }}
         run: |
           cp "${RUNNER_TEMP}/create_post_release_pr.py" scripts/release/create_post_release_pr.py
           python3 scripts/release/create_post_release_pr.py \
             --tt-shield-run-id "${TT_SHIELD_RUN_ID}" \
             --head-branch "${POST_RELEASE_BRANCH}" \
-            --base main
+            --base main \
+            --promoted-images "${PROMOTED_IMAGES}"

--- a/scripts/release/README_AUTOMATION.md
+++ b/scripts/release/README_AUTOMATION.md
@@ -1,0 +1,140 @@
+# Release process
+
+This document gives the step by step instructions for making a release using the automation - - **Release Automation (promote specs, docs & docker images)**.
+
+The release process is run from the GitHub Actions, by invoking the `release-automation.yml` pipeline 
+
+## Summary Diagram
+
+![release-summary-2025-08-14-1106.png](release-summary-2025-08-14-1106.png)
+
+## pre-requisite requirements
+permissions requirement:
+- Download only
+    - [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) (PAT)
+        - Read access to tt-shield repo.
+- Full release:
+    - [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) (PAT)
+        - Read access to tt-shield repo.
+        - Write access to tt-inference-server packages
+    - crane CLI (https://github.com/google/go-containerregistry/tree/main/cmd/crane)
+
+## Git Workflow Diagram
+
+Follow the git workflow for release described below in the diagram and step by step instructions below:
+
+![../../docs/ttis-git-workflows-2026-02-10](../../docs/ttis-git-workflows-2026-02-10.png)
+
+
+## Step 1: update `models-ci-config.json` on stable branch
+
+Within the `models-ci-config.json` file, update which models and devices should belong to the upcoming release. 
+Remove all the entries from the release list, which are not going to be actually released.
+
+## Step 2: update `VERSION` file on stable branch
+
+Bump the version of the `VERSION` file (major/minor/patch syntax).
+
+## Step 3: run 'Release Automation (promote specs, docs & docker images)' pipeline
+
+We need to run the pipeline by selecting the `stable` branch. In case we select some other branch pipeline execution will not be allowed.
+**stable** branch is the main source of truth for the release.
+
+When `stable` branch is selected we need to provide input values for the following:
+
+`Release version`: e.g. 0.21.0  - we provide this value in order to have the version embedded within the pipeline title execution:
+
+`tt-shield Release run ID`: - we need to find th shield release pipeline ID
+
+`tt-metal commit SHA`: 7 chars commit sha (we intentionally want to compare the metall commith sha as an input with the SHA that will be retrieved through the runId)
+
+`vLLM commit SHA`: 7 chars commit sha (we intentionally want to compare the metall commith sha as an input with the SHA that will be retrieved through the runId).
+
+Other two fields are optional and mainly used for testing purposes.
+
+Once we have all 4 mandatory fields populated we run the pipeline.
+
+## Step 4: execution of the automation pipeline
+
+Once dispatched, the pipeline runs the following sub-steps in order. Most are automatic; it stops (fails) early if any validation does not hold, so nothing is committed or published on a bad input.
+
+### 4.1 Branch guard
+Refuses to run unless the branch is `stable` (the sanctioned release branch). Any other branch fails immediately, before checkout.
+
+### 4.2 Environment setup
+Checks out `stable`, sets up Python, and installs the release dependencies plus `helm-docs`.
+
+### 4.3 Resolve & validate inputs
+Reads the `VERSION` file as the source of truth and validates the inputs against it:
+- the `Release version` input must equal the `VERSION` file (e.g. input `0.21.0` == `VERSION` `0.21.0`);
+- `tt-shield Release run ID` is required;
+- `vLLM commit SHA` is required when the release ships any vLLM model.
+
+A mismatch (e.g. input `0.20.0` but `VERSION` says `0.21.0`) fails the run here.
+
+### 4.4 Validate commits against the tt-shield run
+Reads the images the given tt-shield run actually built and confirms the `tt-metal` / `vLLM` commit inputs match them (the 7-char input must be a prefix of the built 40-char SHA). Guards against a typo'd commit that would pin the wrong build. Runs before any change is made.
+
+### 4.5 Promote dev → prod specs
+Runs `promote_dev_spec_to_prod.py`: copies the release-listed model specs from `dev` to `prod`, pinning this release's `version`, `tt_metal_commit` and `vllm_commit`.
+
+### 4.6 Duplicate guard
+Asserts the promotion did not create a **shadowed duplicate** (a stale prod block left behind for the same model+device). If found, the run fails so the dead block never reaches the docs/catalogue. (See the manual pre-flight in `README_MANUAL.md`.)
+
+### 4.7 Regenerate docs and release JSON
+Runs `export_model_spec.py` to rebuild `docs/model_support/**` and `release_model_spec.json` from the promoted `prod` catalogue.
+
+### 4.8 Regenerate the Helm chart
+Regenerates `charts/tt-inference-server/values.yaml` (helm generator) and the chart docs (`helm-docs`).
+
+### 4.9 Commit + push the generated files to `stable`
+Commits all generated changes (prod specs, docs, `release_model_spec.json`, Helm files) as `v<version>` and pushes them to `stable` (e.g. commit message `v0.21.0`).
+
+### 4.10 Tag the release
+Creates and pushes the release tag on `stable` (e.g. `v0.21.0`). This is the tag the GitHub Release Object targets in Step 5.
+
+### 4.11 Build the release-artifacts zip
+Downloads the per-model/device workflow artifacts from the tt-shield run and packs them into `v<version>-release_artifacts.zip`, uploaded as a pipeline artifact (this is what you download in Step 7).
+
+### 4.12 Resolve source images and map to release images
+Finds the `vllm` / `media` / `forge` dev images the tt-shield run built, and computes the destination release image tags. Example:
+- source: `ghcr.io/tenstorrent/tt-shield/vllm-tt-metal-src-dev-ubuntu-22.04-amd64:0.21.0-de59f8a…-6b4a3a7-<jobid>`
+- target: `ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.21.0-de59f8a-6b4a3a7`
+
+### 4.13 Publish the images (crane)
+Logs in to `ghcr.io` and copies each release-scoped image from the tt-shield registry to the tt-inference-server release registry (only the engine families this release actually ships).
+
+### 4.14 Re-bake the catalogue into the vLLM image
+`crane copy` only re-labels; the source image was built before this release promoted its specs, so its embedded `model_spec.json` is the previous catalogue. This step appends the freshly-promoted catalogue as a new top layer so the published vLLM image serves **this** release's specs (avoids "No model spec found"). vLLM only — media/forge bake no catalogue.
+
+### 4.15 Verify the published image
+Pulls the baked catalogue back out of the published vLLM image and confirms every spec pinned to that image resolves. Fails the release if anything is missing.
+
+### 4.16 Create the post-release branch and draft PR
+Branches `post-release-v<version>` from `main`, carries this release's `VERSION` + `models-ci-config.json` onto it, regenerates the specs/docs/Helm there, commits and pushes the branch, then opens a **draft PR** into `main`. The PR body is pre-filled with the model-spec update table and the list of promoted images — the notes used in Steps 5–6.
+
+## Step 5: Create GitHub RELEASE Object
+
+We need to create new Draft Release Object `vx.x.x` targeting the automatic tag created from the stable branch. We create new Release Object once the Release Manager and Customer Success team finish verification of the automatically created PR, which is filled with all the required notes required for the Release.
+
+## Step 6: copy paste Release notes from PR body
+
+Release Notes must be added describing new supported engine features.
+This is done by copying the PR body.
+
+After that we save Release Object in Draft status.
+
+## Step 7: Downloading workflow artifacts and assets upload to Release Object
+
+The automation pipeline will provide us with release artifacts in the Assets table, which are packed and prepared for the upload on the Release Object level.
+We need to download those locally, and upload that same zipped file as a packaged artifact on Release Object level.
+
+## Step 8: Release Object publishing
+
+At the end, we change the status of the Release Object to `Published` and mark the Release as the latest one.
+
+## Step 9: Update Release Zoo
+
+From the `tt-shield` Actions tab we need to run the `"Update Release Zoo"` action so the page on Models Dashboard is being refreshed.
+
+https://github.com/tenstorrent/tt-shield/actions/workflows/update-release-zoo.yml

--- a/scripts/release/README_MANUAL.md
+++ b/scripts/release/README_MANUAL.md
@@ -113,18 +113,19 @@ Once the script is executed we need to verify which changes are being introduced
 
  Run this immediately after promotion, before export_model_spec.py:
 ```bash 
- `PYTHONPATH=. python3 -c "
- import collections
- from workflows.model_spec import spec_templates
- seen = collections.defaultdict(list)
- for t in spec_templates:
-     for s in t.expand_to_specs():
-         seen[s.model_id].append(getattr(t, 'version', None))
- dups = {k: v for k, v in seen.items() if len(v) > 1}
- for k, v in sorted(dups.items()):
-     print('DUPLICATE', k, '<- versions', v)
- assert not dups, 'promotion created shadowed duplicate blocks'
- "`
+MODEL_SPECS_ENV=prod PYTHONPATH=. python3 -c "
+import collections
+from workflows.model_spec import spec_templates
+seen = collections.defaultdict(list)
+for t in spec_templates:
+    for s in t.expand_to_specs():
+        seen[s.model_id].append(getattr(t, 'version', None))
+dups = {k: v for k, v in seen.items() if len(v) > 1}
+for k, v in sorted(dups.items()):
+    print('DUPLICATE', k, '<- versions', v)
+assert not dups, 'promotion created shadowed duplicate blocks'
+print('OK: no duplicate model+device records')
+"
 ```
  
  If it fails, delete the older block from workflows/model_specs/prod/<type>.yaml and re-run. len(MODEL_SPECS) must be unchanged afterwards — the deleted block was unreachable, so release_model_spec.json and values.yaml will show no diff.
@@ -213,29 +214,139 @@ crane copy <src> <dst>
 
  crane copy re-labels; it does not rebuild. The tt-shield image was built before promotion, so its baked /home/container_app_user/model_specs/model_spec.json is the prod catalogue from the previous release. Any model or device promoted in this release will be missing from it — the container crashes (No model spec found) or silently serves the old config. This affected v0.17.0 through v0.20.0.
 
- Run this on the release branch, after export_model_spec.py, for each image you copied:
+# Manual catalogue re-bake (backfill a published vLLM image)
+
+Fix a published vLLM image whose baked `model_spec.json` is stale/missing a model, without rebuilding. vLLM only. Verify on an RC tag; the live tag changes only at step 10.
+
+**0. Setup** — name the image, an RC tag, and log in (read+write:packages).
 ```bash
- REPO=<dest repo>; TAG=<dest tag>
- Example:
- REPO=ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
- TAG=0.17.0-8c48a10-f52987a
-
- crane copy "$REPO@$(crane digest "$REPO:$TAG")" "$REPO:$TAG-precatalogfix"    # backup
- AMD64=$(crane manifest "$REPO:$TAG" | python3 -c "import json,sys;m=json.load(sys.stdin);print([x['digest'] for x in m['manifests'] if x['platform']['architecture']=='amd64'][0])")
-
- PYTHONPATH=. python3 -c "from scripts.build_docker_images import generate_model_specs_json; generate_model_specs_json()"
- rm -rf /tmp/catalog && mkdir -p /tmp/catalog/home/container_app_user/model_specs
- cp model_spec.json /tmp/catalog/home/container_app_user/model_specs/
- tar --owner=1000 --group=1000 -C /tmp/catalog -cf /tmp/catalog-layer.tar home
-
- crane append -b "$REPO@$AMD64" -f /tmp/catalog-layer.tar -t "$REPO:$TAG"
+export REPO=ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
+export TAG=0.18.0-c49bb76-6b4a3a7
+export RC=$TAG-catalogfix-rc1
+crane auth login ghcr.io -u <user> -p <PAT>
 ```
- Verification: the release_version inside the image must equal the release you are cutting. If it is one behind, the re-bake did not run.
+
+**1. Back up** the live image to a rollback tag.
+```bash
+INDEX=$(crane digest "$REPO:$TAG")
+crane copy "$REPO@$INDEX" "$REPO:$TAG-precatalogfix"
+```
+
+**2. Resolve** the amd64 image digest (what `crane append` needs).
+```bash
+AMD64=$(crane manifest "$REPO:$TAG" | python3 -c "import json,sys;m=json.load(sys.stdin);print([x['digest'] for x in m['manifests'] if x['platform']['architecture']=='amd64'][0])")
+```
+
+**3. Clean source** — bake from a known-clean `main`.
+```bash
+git checkout main && git pull
+git status --porcelain workflows/model_specs/prod/ VERSION   # must be empty
+```
+
+**4. Generate** `model_spec.json` from the prod catalogue.
+```bash
+PYTHONPATH=. python3 -c "from scripts.build_docker_images import generate_model_specs_json; generate_model_specs_json()"
+```
+
+**5. Pre-flight** — assert the fixed spec is present (KeyError = wrong branch, stop).
+```bash
+python3 -c "import json;print(json.load(open('model_spec.json'))['model_specs']['google/gemma-4-31B-it']['P300X2'])"
+```
+
+**6. Pack** the layer at the right path + ownership (uid/gid 1000).
+```bash
+rm -rf /tmp/catalog && mkdir -p /tmp/catalog/home/container_app_user/model_specs
+cp model_spec.json /tmp/catalog/home/container_app_user/model_specs/
+tar --owner=1000 --group=1000 -C /tmp/catalog -cf /tmp/catalog-layer.tar home
+```
+
+**7. Push to RC** (not the live tag yet).
+```bash
+crane append -b "$REPO@$AMD64" -f /tmp/catalog-layer.tar -t "$REPO:$RC"
+```
+
+**8. Verify RC** — pull the catalogue back out of the pushed image.
+```bash
+python3 - <<'PY'
+import io, json, os, subprocess, tarfile
+R, RC = os.environ["REPO"], os.environ["RC"]
+sh = lambda a: subprocess.run(a, capture_output=True, check=True).stdout
+man = json.loads(sh(["crane","manifest",f"{R}:{RC}"]))
+blob = sh(["crane","blob",f"{R}@{man['layers'][-1]['digest']}"])
+with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tf:
+    d = json.load(tf.extractfile(next(m for m in tf.getmembers() if m.name.endswith("model_spec.json"))))
+print("gemma present:", "google/gemma-4-31B-it" in d["model_specs"])
+PY
+```
+
+**9. Hardware test** the RC on the target device.
+```bash
+docker run --rm --env "HF_TOKEN=$HF_TOKEN" --ipc host --publish 8000:8000 \
+  --device /dev/tenstorrent --mount type=bind,src=/dev/hugepages-1G,dst=/dev/hugepages-1G \
+  --volume volume_id_gemma-4-31B-it:/home/container_app_user/cache_root \
+  "$REPO:$RC" --model gemma-4-31B-it --tt-device p300x2
+```
+
+**10. Promote** the verified RC to the live tag (only step that changes what users get).
+```bash
+crane copy "$REPO:$RC" "$REPO:$TAG"
+```
+
+**11. Confirm** with the exact user-facing command.
+```bash
+docker pull "$REPO:$TAG"
+python3 run.py --model gemma-4-31B-it --device p300x2 --workflow server --docker-server
+```
+
+**12. Rollback** if needed.
+```bash
+crane copy "$REPO:$TAG-precatalogfix" "$REPO:$TAG"
+```
+
+
+ **13. Verification** the release_version inside the image must equal the release you are cutting. If it is one behind, the re-bake did not run.
  ```bash
  crane export "$REPO:$TAG" - | tar -xO home/container_app_user/model_specs/model_spec.json \
   | python3 -c "import json,sys; print(json.load(sys.stdin)['release_version'])"
 ```
 Note: this drops the buildkit attestation and changes the digest — the tag stays the same. Only applies to vLLM images; media/forge containers get their config from host env vars.
+
+
+## Rollback — bad published/re-baked vLLM release image
+
+`REPO=ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64`
+`TAG=0.21.0-de59f8a-c127c17     # the published tag`
+`SRC=ghcr.io/tenstorrent/tt-shield/vllm-tt-metal-src-dev-ubuntu-22.04-amd64:0.21.0-<...>   # source that was copied`
+
+**Option 1** — undo the crane append (re-point tag to the un-baked copy):
+```bash
+crane copy "$SRC" "$REPO:$TAG"      # overwrites tag back to pre-append state
+crane digest "$REPO:$TAG"           # confirm digest changed
+```
+
+Option 2 — restore from the backup (if you snapshotted before re-bake):
+```bash
+crane copy "$REPO:$TAG-precatalogfix" "$REPO:$TAG"
+```
+
+Option 3 — fully unpublish (delete the tag):
+```bash
+crane delete "$REPO:$TAG"           # if GHCR rejects, use the API:
+PKG=tt-inference-server%2Fvllm-tt-metal-src-release-ubuntu-22.04-amd64
+VID=$(gh api "/orgs/tenstorrent/packages/container/$PKG/versions" --paginate \
+        --jq ".[] | select(.metadata.container.tags[]? == \"$TAG\") | .id")
+gh api --method DELETE "/orgs/tenstorrent/packages/container/$PKG/versions/$VID"
+```
+⚠️ Only if nothing pulled it yet — deleting a consumed tag breaks pullers; otherwise prefer Option 1/2 (overwrite).
+
+**Verify**
+```bash
+crane export "$REPO:$TAG" - | tar -xO home/container_app_user/model_specs/model_spec.json \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['release_version'])"
+```
+
+
+
 
 ## Step 3: verification through the list model images
 

--- a/scripts/release/README_ROLLBACK.md
+++ b/scripts/release/README_ROLLBACK.md
@@ -1,0 +1,140 @@
+# Release automation — rollback runbook
+
+How to undo the side effects of a release-automation run (`.github/workflows/release-automation.yml`)
+or a manual catalogue backfill when a run **fails partway** or **produces bad output**.
+
+## Principle
+- **Undo in reverse order of creation** (last thing first), and only what the run actually created.
+- **Reversibles** (git commit/tag, post-release branch, PR) → undo freely, they're fully in your control.
+- **The published image** is the careful one: **overwrite if it may have been pulled/consumed; delete only if it's brand-new and unused.**
+- Workflow **artifacts** (the uploaded zips) auto-expire — ignore them.
+
+## Prerequisites (auth)
+- **git**: push access to the release branch + permission to delete/move the tag (a protected branch may forbid force-reset — use `revert` then).
+- **gh**: authenticated with `pull-requests: write` (to close the PR).
+- **crane**: `crane auth login ghcr.io` with a token that has, on **tt-inference-server**, `write:packages` (overwrite) and — only for the delete option — `delete:packages`; and `read:packages` on **tt-shield** (to re-copy the source image).
+
+## Setup (fill these in for the run you are undoing)
+```bash
+REL_BRANCH=stable
+VERSION=0.21.0
+SUFFIX=                                   # empty for a real release; -temp/-test while testing
+TAG=v$VERSION$SUFFIX
+POST_BRANCH=post-release-v$VERSION$SUFFIX
+# vLLM release image (adjust repo for the family you published):
+REPO=ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64
+IMG=$REPO:$VERSION-<ttm>-<vllm>            # <ttm>,<vllm> = the release commits
+SRC=ghcr.io/tenstorrent/tt-shield/vllm-tt-metal-src-dev-ubuntu-22.04-amd64:<full-tag>   # source that was copied
+```
+
+## Find the identifiers
+```bash
+git fetch origin --tags --prune
+
+# release-branch bot commit (the "v<version>..." commit by github-actions[bot]):
+git log -1 --oneline origin/$REL_BRANCH
+git rev-parse "origin/$REL_BRANCH~1"       # the commit BEFORE it (reset target)
+
+# tag exists?
+git ls-remote origin "refs/tags/$TAG"
+
+# post-release branch + open PR:
+git ls-remote origin "refs/heads/$POST_BRANCH"
+gh pr list --repo tenstorrent/tt-inference-server --head "$POST_BRANCH" --state open --json number,url
+
+# image present + its current digest:
+crane manifest "$IMG" >/dev/null 2>&1 && crane digest "$IMG" || echo "image not published"
+```
+
+## Rollback by side effect (least → most serious)
+
+### 🟢 Low — throwaway, delete freely
+```bash
+# Draft PR (post-release -> main)
+gh pr close <PR_NUMBER> --repo tenstorrent/tt-inference-server --delete-branch
+
+# Post-release branch (if not already deleted by --delete-branch)
+git push origin :"$POST_BRANCH"
+```
+
+### 🟡 Medium — public but yours to control
+```bash
+# Tag
+git push origin :"refs/tags/$TAG"          # delete remote tag
+git tag -d "$TAG" 2>/dev/null || true      # delete local tag
+
+# Release-branch bot commit — choose ONE:
+git revert <BOT_SHA> && git push origin HEAD:$REL_BRANCH                 # safe, keeps history
+# or, if you may force-push and want it gone:
+git push origin --force-with-lease="$REL_BRANCH:<BOT_SHA>" <SHA_BEFORE_BOT>:$REL_BRANCH
+```
+
+### 🔴 High — the published / re-baked image
+```bash
+# A) Undo just the re-bake (re-point tag to the un-baked source copy):
+crane copy "$SRC" "$IMG"
+
+# B) Restore from the pre-mutation snapshot (if taken before re-bake):
+crane copy "$REPO:$VERSION-<ttm>-<vllm>-precatalogfix" "$IMG"
+
+# C) Replace with corrected content (re-run the correct re-bake, or copy a good image):
+crane copy <good-image> "$IMG"
+
+# D) Fully unpublish (ONLY if nothing pulled it yet):
+crane delete "$IMG"                        # if GHCR rejects, use the API:
+PKG=tt-inference-server%2Fvllm-tt-metal-src-release-ubuntu-22.04-amd64
+VID=$(gh api "/orgs/tenstorrent/packages/container/$PKG/versions" --paginate \
+        --jq ".[] | select(.metadata.container.tags[]? == \"$VERSION-<ttm>-<vllm>\") | .id")
+gh api --method DELETE "/orgs/tenstorrent/packages/container/$PKG/versions/$VID"
+```
+⚠️ **In use → overwrite (A/B/C). Brand-new & unused → delete (D).** Deleting a consumed tag breaks pullers.
+
+### ⚪ None — workflow artifacts
+The uploaded zips (`release-automation-generated-changes`, `release-artifacts-v<version>`) auto-expire; nothing to do.
+
+## Where it failed → what to undo
+| Run failed at | Already created → undo |
+|---|---|
+| guard / checkout / inputs / validate-commits | nothing pushed → just re-run (local only) |
+| promote / 1b / export / helm | local working tree only → `git checkout -- .` or re-run |
+| git push / tag | commit + tag → 🟡 |
+| crane copy / re-bake / verify | + image → 🔴 (then 🟡) |
+| post-release branch / commit / PR | + branch + PR → 🟢 (then 🔴/🟡 as needed) |
+
+## Full-abort order (reverse of creation)
+1. Close the PR 🟢
+2. Delete the post-release branch 🟢
+3. Fix or remove the image 🔴 (overwrite if consumed; delete only if unused)
+4. Delete the tag 🟡
+5. Revert/reset the release-branch commit 🟡
+
+## Other published images (media / forge)
+A multi-family release also publishes:
+```
+ghcr.io/tenstorrent/tt-media-inference-server:$VERSION-<ttm>
+ghcr.io/tenstorrent/tt-media-inference-server-forge:$VERSION-<ttm>
+```
+Roll them back the **same way** as the 🔴 image steps (overwrite from source, or delete if unused).
+Note: media/forge are **not** re-baked (they bake no catalogue), so there is no `-precatalogfix`
+snapshot and no re-bake to undo — only the `crane copy` publish.
+
+## Verify after rollback
+```bash
+git ls-remote origin "refs/tags/$TAG"                     # gone if tag deleted
+git ls-remote origin "refs/heads/$POST_BRANCH"            # gone if branch deleted
+gh pr view <PR_NUMBER> --repo tenstorrent/tt-inference-server --json state   # "CLOSED"
+git log -1 --oneline origin/$REL_BRANCH                   # bot commit reverted/removed
+# image restored to correct content (if overwritten):
+crane export "$IMG" - | tar -xO home/container_app_user/model_specs/model_spec.json \
+  | python3 -c "import json,sys; print('baked release_version =', json.load(sys.stdin)['release_version'])"
+```
+
+## Cautions
+- **Never delete an image that may already be in use** — overwrite the tag instead (pullers converge on the good content after a fresh `docker pull`).
+- **Force-reset on a shared branch** (`stable`) affects everyone — prefer `git revert`; coordinate if you must reset, and expect branch protection to block it.
+- Re-bake (`crane append`) **drops the buildkit attestation** by design — expected, not a fault.
+- **Snapshot before you mutate**: take `crane copy "$IMG" "$IMG-precatalogfix"` before any re-bake so option (B) is a one-liner.
+- Deleting registry versions needs `delete:packages` (may require org admin).
+
+## Related
+Manual catalogue backfill (its own backup/RC/promote + rollback): see `scripts/release/MANUAL_CATALOG_REBAKE.md`.

--- a/scripts/release/create_post_release_pr.py
+++ b/scripts/release/create_post_release_pr.py
@@ -13,7 +13,7 @@ The body has four sections:
   # Summary of Changes           -> header + placeholder (filled in manually)
   # SW versions recommended ...   -> static (tt-smi / Firmware / tt-kmd)
   # Model Spec Release Updates    -> AUTO-GENERATED table (the tricky part)
-  # Release Artifacts Summary     -> header + placeholder (filled in manually)
+  # Release Artifacts Summary     -> auto-listed promoted images + Total (from --promoted-images)
 
 The "Model Spec Release Updates" table has one row per (model, device) release
 combo taken from ``.github/workflows/models-ci-config.json`` (the ``ci.release``
@@ -176,20 +176,34 @@ def _block_models(block: dict) -> set:
     return {model_name_from_weight(w) for w in block.get("weights", []) or []}
 
 
-def find_block(blocks, model_name, engine, device) -> dict | None:
-    """First block that provides (model_name, engine) on `device`.
+def find_block(
+    blocks, model_name, engine, device, prefer_version=None, prefer_impl=None
+) -> dict | None:
+    """A prod block that provides (model_name, engine) on `device`.
 
-    Matches by device MEMBERSHIP (not the exact device-set), so a block that
-    bundles extra devices still matches the specific release device.
+    Matches by device MEMBERSHIP (not the exact device-set). When several blocks
+    match (a stale block from a prior release plus the just-promoted one, or two
+    impls), prefer (1) the block at `prefer_version`, then (2) `prefer_impl`,
+    else the first match — so the table reports the release block, not a stale one.
     """
-    for b in blocks:
-        if (
-            model_name in _block_models(b)
-            and _block_engine(b) == engine
-            and device in _block_devices(b)
-        ):
-            return b
-    return None
+    matches = [
+        b
+        for b in blocks
+        if model_name in _block_models(b)
+        and _block_engine(b) == engine
+        and device in _block_devices(b)
+    ]
+    if not matches:
+        return None
+    if prefer_version is not None:
+        for b in matches:
+            if str(b.get("version")) == str(prefer_version):
+                return b
+    if prefer_impl is not None:
+        for b in matches:
+            if b.get("impl") == prefer_impl:
+                return b
+    return matches[0]
 
 
 # ---------------------------------------------------------------------------
@@ -255,12 +269,24 @@ def ci_job_url(
 # ---------------------------------------------------------------------------
 # row model + rendering
 # ---------------------------------------------------------------------------
-def build_rows(new_blocks, old_blocks, combos, jobs, tt_shield_repo, run_id):
+def build_rows(new_blocks, old_blocks, combos, jobs, tt_shield_repo, run_id, version):
     rows = []
     seen: set = set()
     for model_name, engine, device in combos:
-        new_b = find_block(new_blocks, model_name, engine, device)
-        old_b = find_block(old_blocks, model_name, engine, device)
+        # NEW = the just-promoted block (prefer this release's version) so a stale
+        # prior-release block on the same device can't shadow it. OLD = the base
+        # block for the SAME impl, so old->new is apples-to-apples.
+        new_b = find_block(
+            new_blocks, model_name, engine, device, prefer_version=version
+        )
+        old_b = find_block(
+            old_blocks,
+            model_name,
+            engine,
+            device,
+            prefer_version=version,
+            prefer_impl=(new_b or {}).get("impl"),
+        )
 
         # De-duplicate: one row per (prod block weights+engine, device). A block
         # bundling several weights (e.g. whisper) yields a single row.
@@ -337,8 +363,28 @@ def render_table(rows) -> str:
     return "\n".join(lines)
 
 
-def render_body(version: str, rows) -> str:
+def _promoted_section(promoted_images) -> str:
+    """Render the 'Images Promoted from Models CI' section: one bullet per
+    destination image (https://-prefixed) followed by '**Total:** N'."""
+    lines = ["## Images Promoted from Models CI", ""]
+    for img in promoted_images:
+        url = img if img.startswith(("http://", "https://")) else f"https://{img}"
+        lines.append(f"- {url}")
+    if promoted_images:
+        lines.append("")
+    lines.append(f"**Total:** {len(promoted_images)}")
+    return "\n".join(lines) + "\n"
+
+
+def render_body(version: str, run_id, rows, promoted_images) -> str:
     return (
+        # Machine-readable metadata block (parsed by downstream tooling); keep
+        # it first, before the Summary. run_id = tt-shield Release run id,
+        # version = the release version with a leading 'v'.
+        "<!--\n"
+        f"metadata:run_id={run_id or ''}\n"
+        f"metadata:version=v{version}\n"
+        "-->\n\n"
         "# Summary of Changes\n\n"
         "<!-- Fill in the summary of changes manually. -->\n"
         "- placeholder\n\n\n"
@@ -346,9 +392,7 @@ def render_body(version: str, rows) -> str:
         + "\n"
         + render_table(rows)
         + "\n\n\n# Release Artifacts Summary\n\n"
-        "## Images Promoted from Models CI\n\n"
-        "<!-- Add promoted image paths manually. -->\n\n"
-        "**Total:** \n"
+        + _promoted_section(promoted_images)
     )
 
 
@@ -451,7 +495,19 @@ def main() -> None:
     ap.add_argument(
         "--output", type=Path, default=None, help="Also write the body to this file"
     )
+    ap.add_argument(
+        "--promoted-images",
+        default="",
+        help="Whitespace/newline-separated destination image URLs to list under "
+        "'Images Promoted from Models CI' (the release-scoped publish plan).",
+    )
     args = ap.parse_args()
+
+    # Destination images actually published (already release-scoped upstream);
+    # split on any whitespace/newlines and drop blanks / None sentinels.
+    promoted_images = [
+        img for img in args.promoted_images.split() if img and img != "None"
+    ]
 
     version = args.version or read_version(args.version_file)
     head_branch = args.head_branch or current_branch()
@@ -491,9 +547,15 @@ def main() -> None:
         )
 
     rows = build_rows(
-        new_blocks, old_blocks, combos, jobs, args.tt_shield_repo, args.tt_shield_run_id
+        new_blocks,
+        old_blocks,
+        combos,
+        jobs,
+        args.tt_shield_repo,
+        args.tt_shield_run_id,
+        version,
     )
-    body = render_body(version, rows)
+    body = render_body(version, args.tt_shield_run_id, rows, promoted_images)
 
     print(f"Version:      {version}", file=sys.stderr)
     print(f"Title:        {title}", file=sys.stderr)

--- a/scripts/release/resolve_release_source_images.py
+++ b/scripts/release/resolve_release_source_images.py
@@ -26,11 +26,22 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
+import time
 
 DEFAULT_REPO = "tenstorrent/tt-shield"
+
+# Job-log downloads (.../jobs/<id>/logs) 302-redirect to blob storage and can
+# fail transiently. Retry a few times with linear backoff before giving up, so
+# a one-off hiccup does not drop an image. Fetched with curl (not `gh api`):
+# newer gh refuses to emit logs containing ANSI escape sequences unless
+# --allow-escape-sequences is passed, a flag older gh lacks — curl has no such
+# guard, so this works the same locally and on the runner.
+LOG_FETCH_ATTEMPTS = 4
+LOG_FETCH_BACKOFF_SECONDS = 3
 
 # Build-job caller segment  ->  engine family. Order does not matter; matched by
 # exact segment equality so build-forge-media / build-blaze-media never collide
@@ -61,14 +72,14 @@ def run_gh(args: list[str], binary: bool = False):
 
 
 def list_jobs(repo: str, run_id: str) -> list[dict]:
-    """All jobs of a run as [{id, name}, ...]."""
+    """All jobs of a run as [{id, name, conclusion}, ...]."""
     out = run_gh(
         [
             "api",
             "--paginate",
             f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100",
             "--jq",
-            ".jobs[] | {id, name}",
+            ".jobs[] | {id, name, conclusion}",
         ]
     )
     return [json.loads(line) for line in out.splitlines() if line.strip()]
@@ -86,12 +97,64 @@ def job_family(job_name: str) -> str | None:
     return None
 
 
-def job_log(repo: str, job_id: int) -> str | None:
-    """Download a job's log via gh (which follows the log redirect), or None."""
-    try:
-        return run_gh(["api", f"repos/{repo}/actions/jobs/{job_id}/logs"])
-    except SystemExit:
-        return None
+def _gh_token() -> str | None:
+    """The token gh is configured to use (works locally and in CI where the
+    step sets GH_TOKEN), with env fallbacks. Used for the curl log download."""
+    proc = subprocess.run(["gh", "auth", "token"], capture_output=True)
+    if proc.returncode == 0:
+        tok = proc.stdout.decode(errors="replace").strip()
+        if tok:
+            return tok
+    for name in ("GH_TOKEN", "GITHUB_TOKEN", "GH_PAT"):
+        val = os.environ.get(name)
+        if val:
+            return val
+    return None
+
+
+def job_log(repo: str, job_id: int) -> tuple[str | None, str | None]:
+    """Download a job's log via curl, retrying transient failures.
+
+    Returns (log_text, None) on success, or (None, error_message) if every
+    attempt failed. Never silently returns an empty result — a persistent
+    failure is reported so the caller can fail loudly. curl (not `gh api`) is
+    used to avoid gh's escape-sequence guard on log output; `curl -L` follows
+    the redirect to blob storage and drops the auth header cross-host.
+    """
+    token = _gh_token()
+    if not token:
+        return None, "no GitHub token available (gh auth token / GH_TOKEN)"
+    url = f"https://api.github.com/repos/{repo}/actions/jobs/{job_id}/logs"
+    last_err = ""
+    for attempt in range(1, LOG_FETCH_ATTEMPTS + 1):
+        proc = subprocess.run(
+            [
+                "curl",
+                "-fsSL",
+                "-H",
+                f"Authorization: Bearer {token}",
+                "-H",
+                "Accept: application/vnd.github+json",
+                "-H",
+                "X-GitHub-Api-Version: 2022-11-28",
+                url,
+            ],
+            capture_output=True,
+        )
+        if proc.returncode == 0:
+            return proc.stdout.decode(errors="replace"), None
+        last_err = (
+            proc.stderr.decode(errors="replace").strip()
+            or f"curl exit {proc.returncode}"
+        )
+        print(
+            f"WARNING: log fetch for job {job_id} failed "
+            f"(attempt {attempt}/{LOG_FETCH_ATTEMPTS}): {last_err}",
+            file=sys.stderr,
+        )
+        if attempt < LOG_FETCH_ATTEMPTS:
+            time.sleep(LOG_FETCH_BACKOFF_SECONDS * attempt)
+    return None, last_err
 
 
 def extract_dev_image_tag(log_text: str) -> str | None:
@@ -101,18 +164,106 @@ def extract_dev_image_tag(log_text: str) -> str | None:
 
 
 def resolve_source_images(repo: str, run_id: str) -> dict[str, dict]:
-    """Return {family: {"image": tag|None, "build_job": name|None, "job_id": id|None}}."""
+    """Resolve each family's source dev image from the run's build jobs.
+
+    Returns {family: {image, build_job, job_id, conclusion, log_fetch_error}}.
+    `image` is None when: no build job matched, the build job did not succeed,
+    or (an error condition) the log could not be fetched / held no tag.
+    `log_fetch_error` is set only when the log download failed after retries.
+    """
     result = {
-        fam: {"image": None, "build_job": None, "job_id": None} for fam in FAMILIES
+        fam: {
+            "image": None,
+            "build_job": None,
+            "job_id": None,
+            "conclusion": None,
+            "log_fetch_error": None,
+        }
+        for fam in FAMILIES
     }
     for job in list_jobs(repo, run_id):
         fam = job_family(job.get("name", ""))
-        if fam is None or result[fam]["image"] is not None:
+        # First matching build job per family wins; skip non-build jobs and
+        # families already handled.
+        if fam is None or result[fam]["job_id"] is not None:
             continue
-        log = job_log(repo, job["id"])
-        tag = extract_dev_image_tag(log) if log else None
-        result[fam] = {"image": tag, "build_job": job.get("name"), "job_id": job["id"]}
+        result[fam]["build_job"] = job.get("name")
+        result[fam]["job_id"] = job["id"]
+        result[fam]["conclusion"] = job.get("conclusion")
+        # Only a successful build produces a publishable image; don't spend
+        # retries downloading logs for skipped/failed/cancelled builds.
+        if job.get("conclusion") != "success":
+            continue
+        log, err = job_log(repo, job["id"])
+        if log is None:
+            result[fam]["log_fetch_error"] = err
+            continue
+        result[fam]["image"] = extract_dev_image_tag(log)
     return result
+
+
+_HEX40_RE = re.compile(r"[0-9a-f]{40}")
+
+
+def _parse_tag_commits(image_ref: str | None) -> dict:
+    """Best-effort extract {tt_metal, vllm} from a tt-shield dev image ref. Tag shapes:
+      vllm/media: <ver>-<ttmetal40>-<vllm|other>-<jobid>
+      forge:      <ttmetal40>_<other>_<jobid>   (underscores, no version)
+    Only the vLLM family's `vllm` slot is meaningful (media/forge's 3rd token is a
+    different commit and is never read by the validator). The tag's VERSION is
+    intentionally NOT parsed: source images carry the PREVIOUS release version,
+    which never equals the release being cut — version is validated only against
+    the VERSION file (in the workflow's Resolve-inputs step), never the image."""
+    if not image_ref or image_ref == "None":
+        return {}
+    tag = image_ref.rsplit(":", 1)[-1]
+    out: dict = {}
+    m = _HEX40_RE.search(tag)
+    if m:
+        out["tt_metal"] = m.group(0)
+        nxt = re.split(r"[-_]", tag[m.end() :].lstrip("-_"), maxsplit=1)[0]
+        if nxt:
+            out["vllm"] = nxt
+    return out
+
+
+def validate_expected(result: dict[str, dict], expect: dict[str, str]) -> list[str]:
+    """Mismatches between the expected inputs and the commits the tt-shield run
+    actually baked. `expect` keys: ttm, vllm. tt-metal is a prefix match (input is
+    short, embedded SHA is 40-char); vllm is a prefix either way. VERSION is NOT
+    checked against the image — source images carry the previous release version;
+    the version input is validated only against the VERSION file, in the workflow."""
+    errors: list[str] = []
+    parsed = {fam: _parse_tag_commits(result[fam]["image"]) for fam in FAMILIES}
+
+    want = expect.get("ttm")
+    if want:
+        ttms = {fam: p["tt_metal"] for fam, p in parsed.items() if p.get("tt_metal")}
+        if not ttms:
+            errors.append(
+                f"tt-metal-commit '{want}': no built image found to verify against"
+            )
+        for fam, full in ttms.items():
+            if not full.startswith(want.lower()):
+                errors.append(
+                    f"tt-metal-commit '{want}' does not match the {fam} image (built {full[:12]}…)"
+                )
+
+    want = expect.get("vllm")
+    if want:
+        vref = result["vllm"]["image"]
+        got = (parsed["vllm"].get("vllm") or "").lower()
+        w = want.lower()
+        if not vref or vref == "None":
+            errors.append(
+                f"vllm-commit '{want}': no vLLM image was built to verify against"
+            )
+        elif not (got.startswith(w) or w.startswith(got)):
+            errors.append(
+                f"vllm-commit '{want}' does not match the vLLM image (built '{got}')"
+            )
+
+    return errors
 
 
 def main() -> None:
@@ -127,9 +278,32 @@ def main() -> None:
     ap.add_argument(
         "--json", action="store_true", help="Emit JSON instead of human-readable text"
     )
+    ap.add_argument(
+        "--expect",
+        default=None,
+        help="Validate the run's built images against expected commits, e.g. "
+        "'ttm=<sha>,vllm=<sha>'. Empty values are ignored. Exits "
+        "non-zero on any mismatch (skips the JSON/text report).",
+    )
     args = ap.parse_args()
 
     result = resolve_source_images(args.repo, args.run_id)
+
+    if args.expect:
+        expect = {
+            k: v
+            for kv in args.expect.split(",")
+            if "=" in kv
+            for k, v in [kv.split("=", 1)]
+            if v.strip()
+        }
+        errs = validate_expected(result, expect)
+        for e in errs:
+            print(f"::error::{e}", file=sys.stderr)
+        if errs:
+            sys.exit(f"{len(errs)} commit mismatch(es) vs tt-shield run {args.run_id}")
+        print(f"OK - inputs match the tt-shield run's built images: {expect}")
+        return
 
     if args.json:
         # Compact {family: image|None} plus a detailed block for traceability.
@@ -144,14 +318,41 @@ def main() -> None:
                 indent=2,
             )
         )
-        return
+    else:
+        print(f"Repo:   {args.repo}")
+        print(f"Run:    {args.run_id}")
+        print("Source dev images by engine family:")
+        for fam in FAMILIES:
+            image = result[fam]["image"]
+            print(f"  {fam:6s}: {image if image else 'None'}")
 
-    print(f"Repo:   {args.repo}")
-    print(f"Run:    {args.run_id}")
-    print("Source dev images by engine family:")
+    # Fail loudly: a build job that SUCCEEDED but produced no resolvable image is
+    # an error (log fetch failed after retries, or the tag was missing from the
+    # log) — never let that pass as a silent "None". Families with no build job,
+    # or a skipped/failed/cancelled build, legitimately have no image.
+    errors = []
     for fam in FAMILIES:
-        image = result[fam]["image"]
-        print(f"  {fam:6s}: {image if image else 'None'}")
+        r = result[fam]
+        if r["job_id"] is None or r["image"] or r["conclusion"] != "success":
+            continue
+        reason = (
+            f"log fetch failed after {LOG_FETCH_ATTEMPTS} attempts ({r['log_fetch_error']})"
+            if r["log_fetch_error"]
+            else "no dev image tag found in the job log"
+        )
+        errors.append(
+            f"{fam}: build job '{r['build_job']}' (id {r['job_id']}) succeeded "
+            f"but no image could be resolved — {reason}."
+        )
+
+    if errors:
+        print(
+            "\nERROR: could not resolve source image(s) for successful build job(s):",
+            file=sys.stderr,
+        )
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Example run

https://github.com/tenstorrent/tt-inference-server/actions/runs/32639852909

## What this PR adds — Release Automation pipeline

Adds `release-automation.yml` + supporting scripts/docs. Dispatched from the `stable` branch, it runs, in order:

1. **Guard** — only the pipeline from `stable` branch may run.
2. **Validate inputs** — `version` matches the `VERSION` file; `vllm-commit` required when the release ships vLLM; `tt-metal`/`vllm` commits match the given `tt-shield` run.
3. **Promote** dev → prod model specs (release-scoped) and assert no shadowed-duplicate specs.
4. **Regenerate** model-support docs + `release_model_spec.json`.
5. **Regenerate** the Helm chart (`values.yaml` + chart docs).
6. **Commit + push** the generated files to the `stable` branch, then **tag** it and create new release version branch
7. **Build + upload** the `v<version>-release_artifacts.zip` from the tt-shield run.
8. **Publish images** — resolve tt-shield source images → map to release images → `crane copy` → re-bake the prod catalogue into the vLLM image → verify.
9. **Open a draft PR** from `post-release-v<version>` into `main`, pre-filled with the model-spec update table and promoted-image list.

Docs: `README_AUTOMATION.md` (run instructions), `README_ROLLBACK.md` (rollback), `README_MANUAL.md` (manual/backfill).