### PR TITLE
Embedding path: add BGE-M3 and Qwen3-Embedding-8B to cpp_server, validated on n150, locally

### DIFF
--- a/tt-media-server/cpp_server/include/config/types.hpp
+++ b/tt-media-server/cpp_server/include/config/types.hpp
@@ -93,6 +93,7 @@ enum class ModelRunnerType {
   TT_SDXL_EDIT,
   TT_TTS,
   TT_BGE_LARGE_EN,
+  TT_BGE_M3,
   EMBEDDING_MOCK,
 };
 
@@ -154,6 +155,8 @@ inline std::string toString(ModelRunnerType m) {
       return "tt_tts";
     case ModelRunnerType::TT_BGE_LARGE_EN:
       return "tt_bge_large_en";
+    case ModelRunnerType::TT_BGE_M3:
+      return "tt_bge_m3";
     case ModelRunnerType::EMBEDDING_MOCK:
       return "embedding_mock";
   }
@@ -173,6 +176,8 @@ inline std::string toClientRunnerName(ModelRunnerType m) {
       return "tt-tts";
     case ModelRunnerType::TT_BGE_LARGE_EN:
       return "bge_large_en_v1_5";
+    case ModelRunnerType::TT_BGE_M3:
+      return "bge-m3";
     case ModelRunnerType::MOCK:
     case ModelRunnerType::MOCK_PIPELINE:
     case ModelRunnerType::MOCK_SCHEDULER:

--- a/tt-media-server/cpp_server/include/config/types.hpp
+++ b/tt-media-server/cpp_server/include/config/types.hpp
@@ -94,6 +94,7 @@ enum class ModelRunnerType {
   TT_TTS,
   TT_BGE_LARGE_EN,
   TT_BGE_M3,
+  TT_QWEN_EMBEDDING_8B,
   EMBEDDING_MOCK,
 };
 
@@ -157,6 +158,8 @@ inline std::string toString(ModelRunnerType m) {
       return "tt_bge_large_en";
     case ModelRunnerType::TT_BGE_M3:
       return "tt_bge_m3";
+    case ModelRunnerType::TT_QWEN_EMBEDDING_8B:
+      return "tt_qwen_embedding_8b";
     case ModelRunnerType::EMBEDDING_MOCK:
       return "embedding_mock";
   }
@@ -178,6 +181,8 @@ inline std::string toClientRunnerName(ModelRunnerType m) {
       return "bge_large_en_v1_5";
     case ModelRunnerType::TT_BGE_M3:
       return "bge-m3";
+    case ModelRunnerType::TT_QWEN_EMBEDDING_8B:
+      return "qwen_embedding_8b";
     case ModelRunnerType::MOCK:
     case ModelRunnerType::MOCK_PIPELINE:
     case ModelRunnerType::MOCK_SCHEDULER:

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -555,6 +555,10 @@ const std::vector<EmbeddingModelEntry>& embeddingModels() {
        "BAAI/bge-large-en-v1.5",
        "bge-large-en-v1.5",
        {{"n150", 8}, {"n300", 16}, {"t3k", 16}, {"galaxy", 8}}},
+      {ModelRunnerType::TT_BGE_M3,
+       "BAAI/bge-m3",
+       "bge-m3",
+       {{"n150", 32}, {"n300", 32}, {"t3k", 32}, {"galaxy", 32}}},
       // The mock needs no device and no Python. The "" device entry is
       // deliberate: CI runs it with nothing set.
       {ModelRunnerType::EMBEDDING_MOCK,

--- a/tt-media-server/cpp_server/src/config/settings.cpp
+++ b/tt-media-server/cpp_server/src/config/settings.cpp
@@ -559,6 +559,12 @@ const std::vector<EmbeddingModelEntry>& embeddingModels() {
        "BAAI/bge-m3",
        "bge-m3",
        {{"n150", 32}, {"n300", 32}, {"t3k", 32}, {"galaxy", 32}}},
+      // Galaxy batch 1: ModelConfigs has no max_batch_size key there, so
+      // Python resolves the Settings default (1); max_num_seqs=1 keeps it.
+      {ModelRunnerType::TT_QWEN_EMBEDDING_8B,
+       "Qwen/Qwen3-Embedding-8B",
+       "Qwen3-Embedding-8B",
+       {{"n150", 1}, {"n300", 2}, {"t3k", 2}, {"galaxy", 1}}},
       // The mock needs no device and no Python. The "" device entry is
       // deliberate: CI runs it with nothing set.
       {ModelRunnerType::EMBEDDING_MOCK,

--- a/tt-media-server/cpp_server/src/runtime/runners/embedding_runner_factory.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/embedding_runner_factory.cpp
@@ -22,6 +22,7 @@ std::unique_ptr<IEmbeddingRunner> makeEmbeddingRunner(
       return std::make_unique<MockEmbeddingRunner>(cfg);
     case config::ModelRunnerType::TT_BGE_LARGE_EN:
     case config::ModelRunnerType::TT_BGE_M3:
+    case config::ModelRunnerType::TT_QWEN_EMBEDDING_8B:
       return std::make_unique<EmbeddingRunner>(cfg);
     default:
       throw std::runtime_error(

--- a/tt-media-server/cpp_server/src/runtime/runners/embedding_runner_factory.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/embedding_runner_factory.cpp
@@ -21,6 +21,7 @@ std::unique_ptr<IEmbeddingRunner> makeEmbeddingRunner(
     case config::ModelRunnerType::EMBEDDING_MOCK:
       return std::make_unique<MockEmbeddingRunner>(cfg);
     case config::ModelRunnerType::TT_BGE_LARGE_EN:
+    case config::ModelRunnerType::TT_BGE_M3:
       return std::make_unique<EmbeddingRunner>(cfg);
     default:
       throw std::runtime_error(

--- a/tt-media-server/scripts/capture_embedding_golden.py
+++ b/tt-media-server/scripts/capture_embedding_golden.py
@@ -2,9 +2,9 @@
 #
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
-"""Phase 1 golden capture: reference embeddings from the Python BGE runner.
+"""Phase 1 golden capture: reference embeddings from a Python embedding runner.
 
-Runs a fixed prompt set through BGELargeENRunner and writes a JSON file used
+Runs a fixed prompt set through the selected runner and writes a JSON file used
 later to validate the C++ server (same prompts must yield the same vectors).
 
 Each prompt is embedded twice: alone (batch of 1) and inside a full batch.
@@ -13,32 +13,54 @@ so both references are stored to avoid chasing phantom mismatches later.
 
 Usage (tt-metal worktree venv active):
 
-    TT_METAL_HOME=/localdev/jzivanovic/tt-metal-65718bb \
+    TT_METAL_HOME=<worktree> \
     PYTHONPATH="$TT_METAL_HOME:$PWD" \
-    python scripts/capture_embedding_golden.py
+    python scripts/capture_embedding_golden.py [model]
+
+where [model] is one of: bge-large (default), bge-m3, qwen3-8b.
+Output goes to scripts/goldens/<model>_<device>.json.
 """
 
 import os
+import re
 import sys
 
+# {cli name: (ModelNames value for MODEL env, runner class, HF model id)}
+CAPTURE_MODELS = {
+    "bge-large": ("bge-large-en-v1.5", "BGELargeENRunner", "BAAI/bge-large-en-v1.5"),
+    "bge-m3": ("bge-m3", "BGEM3Runner", "BAAI/bge-m3"),
+    "qwen3-8b": (
+        "Qwen3-Embedding-8B",
+        "Qwen3Embedding8BRunner",
+        "Qwen/Qwen3-Embedding-8B",
+    ),
+}
+
+_choice = sys.argv[1] if len(sys.argv) > 1 else "bge-large"
+if _choice not in CAPTURE_MODELS:
+    print(f"unknown model {_choice!r}; expected one of {sorted(CAPTURE_MODELS)}")
+    sys.exit(2)
+_model_env, _runner_class, MODEL_ID = CAPTURE_MODELS[_choice]
+
 # Must happen before any tt-media-server import (Settings reads env at import).
-os.environ.setdefault("MODEL", "bge-large-en-v1.5")
+os.environ.setdefault("MODEL", _model_env)
 os.environ.setdefault("DEVICE", "n150")
 os.environ.setdefault("DEVICE_IDS", "(0)")
 
 import asyncio  # noqa: E402
 import datetime  # noqa: E402
 import json  # noqa: E402
-import re  # noqa: E402
 import subprocess  # noqa: E402
 
 from domain.text_embedding_request import TextEmbeddingRequest  # noqa: E402
-from tt_model_runners.embedding_runner import BGELargeENRunner  # noqa: E402
 
-MODEL_ID = "BAAI/bge-large-en-v1.5"
-MAX_MODEL_LEN = 384
+import tt_model_runners.embedding_runner as _runners  # noqa: E402
+
+DEVICE = os.environ["DEVICE"]
 OUTPUT_PATH = os.path.join(
-    os.path.dirname(__file__), "goldens", "bge_large_en_v1_5_n150.json"
+    os.path.dirname(__file__),
+    "goldens",
+    f"{re.sub(r'[^a-z0-9]+', '_', MODEL_ID.split('/')[-1].lower())}_{DEVICE}.json",
 )
 
 # The tt-metal BGE demo logs its internal device-vs-CPU check during warmup;
@@ -61,17 +83,34 @@ def _install_pcc_sink() -> None:
 
 
 def _repeat_to_token_count(hf_tokenizer, target: int) -> str:
-    """Build a prompt whose untruncated token count is exactly `target`."""
-    n = target  # first guess; BERT adds [CLS]/[SEP]
-    while True:
-        text = " ".join(["hello"] * n)
-        count = len(hf_tokenizer(text, truncation=False)["input_ids"])
-        if count == target:
-            return text
-        n += target - count
+    """Build a prompt whose untruncated token count is exactly `target`.
+
+    Tokenizers differ in tokens-per-word ("hello" is 1 token for BERT but 2
+    for XLM-Roberta), so a fixed-step correction can oscillate forever.
+    Instead: binary-search the largest word count at or below the target,
+    then top up one token at a time with a short filler word.
+    """
+
+    def tokens(words: list[str]) -> int:
+        return len(hf_tokenizer(" ".join(words), truncation=False)["input_ids"])
+
+    lo, hi = 1, target
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if tokens(["hello"] * mid) <= target:
+            lo = mid
+        else:
+            hi = mid - 1
+    words = ["hello"] * lo
+    while tokens(words) < target:
+        words.append("a")
+    if tokens(words) != target:
+        raise RuntimeError(f"cannot hit exactly {target} tokens; got {tokens(words)}")
+    return " ".join(words)
 
 
-def build_prompts(hf_tokenizer) -> list[dict]:
+def build_prompts(hf_tokenizer, max_model_len: int) -> list[dict]:
+    over_limit_words = max_model_len + max_model_len // 2
     prompts = [
         {"id": "single_token", "text": "cat"},
         {
@@ -79,10 +118,13 @@ def build_prompts(hf_tokenizer) -> list[dict]:
             "text": "The quick brown fox jumps over the lazy dog.",
         },
         {
-            "id": "exact_384",
-            "text": _repeat_to_token_count(hf_tokenizer, MAX_MODEL_LEN),
+            "id": f"exact_{max_model_len}",
+            "text": _repeat_to_token_count(hf_tokenizer, max_model_len),
         },
-        {"id": "over_limit_600", "text": " ".join(["hello"] * 600)},
+        {
+            "id": f"over_limit_{over_limit_words}",
+            "text": " ".join(["hello"] * over_limit_words),
+        },
         {
             "id": "non_ascii",
             "text": "Beograd je glavni grad Srbije. Летње вече на Дунаву. 東京は日本の首都です。",
@@ -119,9 +161,10 @@ def embed(runner, texts: list[str]) -> list:
 def main() -> int:
     _install_pcc_sink()
 
-    runner = BGELargeENRunner("0")
+    runner = getattr(_runners, _runner_class)("0")
+    max_model_len = int(runner.max_model_len)
     hf_tokenizer = runner.tokenizer.tokenizer  # underlying HF AutoTokenizer
-    prompts = build_prompts(hf_tokenizer)
+    prompts = build_prompts(hf_tokenizer, max_model_len)
 
     print(f"[golden] {len(prompts)} prompts prepared", flush=True)
     runner.set_device()
@@ -163,9 +206,9 @@ def main() -> int:
     golden = {
         "metadata": {
             "model": MODEL_ID,
-            "device": "n150",
+            "device": DEVICE,
             "tt_metal_commit": commit,
-            "max_model_len": MAX_MODEL_LEN,
+            "max_model_len": max_model_len,
             "batch_size": batch_size,
             "embedding_dim": len(prompts[0]["embedding_single"]),
             "warmup_pcc": _warmup_pcc[0] if _warmup_pcc else None,

--- a/tt-media-server/scripts/embedding_python_baseline.py
+++ b/tt-media-server/scripts/embedding_python_baseline.py
@@ -2,12 +2,14 @@
 #
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
-"""Phase 1 baseline: prove BGELargeENRunner works from plain Python.
+"""Phase 1 baseline: prove an embedding runner works from plain Python.
 
 Run from the tt-media-server directory with the tt-metal venv active and
 PYTHONPATH including the tt-metal repo root (for models.demos imports):
 
-    PYTHONPATH=$TT_METAL_HOME python scripts/embedding_python_baseline.py
+    PYTHONPATH=$TT_METAL_HOME python scripts/embedding_python_baseline.py [model]
+
+where [model] is one of: bge-large (default), bge-m3, qwen3-8b.
 
 Environment (MODEL / DEVICE) must be set before importing anything from
 `config`, because config.settings builds its Settings singleton at import
@@ -18,30 +20,49 @@ import os
 import sys
 import time
 
+# {cli name: (ModelNames value for MODEL env, runner class, HF model id)}
+BASELINE_MODELS = {
+    "bge-large": ("bge-large-en-v1.5", "BGELargeENRunner", "BAAI/bge-large-en-v1.5"),
+    "bge-m3": ("bge-m3", "BGEM3Runner", "BAAI/bge-m3"),
+    "qwen3-8b": (
+        "Qwen3-Embedding-8B",
+        "Qwen3Embedding8BRunner",
+        "Qwen/Qwen3-Embedding-8B",
+    ),
+}
+
+_choice = sys.argv[1] if len(sys.argv) > 1 else "bge-large"
+if _choice not in BASELINE_MODELS:
+    print(f"unknown model {_choice!r}; expected one of {sorted(BASELINE_MODELS)}")
+    sys.exit(2)
+_model_env, _runner_class, MODEL_ID = BASELINE_MODELS[_choice]
+
 # Must happen before any tt-media-server import (Settings reads env at import).
-os.environ.setdefault("MODEL", "bge-large-en-v1.5")
+os.environ.setdefault("MODEL", _model_env)
 os.environ.setdefault("DEVICE", "n150")
 os.environ.setdefault("DEVICE_IDS", "(0)")
 
 import asyncio  # noqa: E402
 
 from domain.text_embedding_request import TextEmbeddingRequest  # noqa: E402
-from tt_model_runners.embedding_runner import BGELargeENRunner  # noqa: E402
 
-MODEL_ID = "BAAI/bge-large-en-v1.5"
+import tt_model_runners.embedding_runner as _runners  # noqa: E402
+
 PROMPT = "The quick brown fox jumps over the lazy dog."
 
 
 def main() -> int:
-    print("[baseline] constructing BGELargeENRunner('0')", flush=True)
-    runner = BGELargeENRunner("0")
+    print(f"[baseline] constructing {_runner_class}('0')", flush=True)
+    runner = getattr(_runners, _runner_class)("0")
 
     print("[baseline] set_device() ...", flush=True)
     t0 = time.time()
     runner.set_device()
     print(f"[baseline] set_device() done in {time.time() - t0:.1f}s", flush=True)
 
-    print("[baseline] warmup() (loads weights, may download ~1.3 GB) ...", flush=True)
+    print(
+        "[baseline] warmup() (loads weights, may download them first) ...", flush=True
+    )
     t0 = time.time()
     ok = asyncio.run(runner.warmup())
     print(f"[baseline] warmup() -> {ok} in {time.time() - t0:.1f}s", flush=True)


### PR DESCRIPTION
## Summary

Onboards two new embedding models to the C++ server's embedding path, on top of
the v1 cleanup (#4951) which made model selection config-driven:

- **BAAI/bge-m3** (`MODEL_RUNNER_TYPE=tt_bge_m3`)
- **Qwen/Qwen3-Embedding-8B** (`MODEL_RUNNER_TYPE=tt_qwen_embedding_8b`)

Both serve through the same pybind11 runner as BGE-large: the C++ worker exports
MODEL/DEVICE/MODEL_RUNNER for the model selected by `MODEL_RUNNER_TYPE`, and
Python's `runner_fabric` instantiates the matching runner class.

## What changed

- `config/types.hpp` — `TT_BGE_M3` and `TT_QWEN_EMBEDDING_8B` enumerators with
  their `toString`/`toClientRunnerName` cases.
- `config/settings.cpp` — one catalog row per model: HF id, internal model name,
  and per-device `max_batch_size` mirroring `config/constants.py`
  (BGE-M3: 32 on all devices; Qwen: 1 on n150/galaxy, 2 on n300/t3k). The
  existing worker-side check verifies the C++ batch cap agrees with Python's
  resolved value at startup.
- `embedding_runner_factory.cpp` — route the new runner types to `EmbeddingRunner`.
- `scripts/capture_embedding_golden.py`, `scripts/embedding_python_baseline.py` —
  generalized from BGE-only to any embedding model, so goldens can be captured
  per model/device.

## Testing (n150)

Per model, at its pinned tt-metal commit: captured golden vectors through the
Python baseline, then served through the C++ server and compared with
`scripts/compare_embedding_golden.py`:

| Model | tt-metal | Result |
|---|---|---|
| BGE-large-en-v1.5 | `65718bb` | sequential bit-exact, concurrent burst green |
| BGE-M3 | `71c49f2` | sequential bit-exact, concurrent burst green |
| Qwen3-Embedding-8B | `555f240` | sequential bit-exact, concurrent burst green |

Note: BGE-M3's demo lands in tt-metal after the other models' pins, so the three
models currently require different tt-metal checkouts.

Mock path (`MODEL_RUNNER_TYPE=embedding_mock`) and the embedding codec unit
tests remain green.
