### PR TITLE
collect_tt_triage_logs function added in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -37,6 +37,7 @@ from workflows.multihost_orchestrator import (
     setup_multihost_config,
 )
 from workflows.run_docker_server import (
+    collect_tt_triage_logs,
     format_docker_command,
     generate_docker_run_command,
 )
@@ -1037,7 +1038,8 @@ def main():
     tt_inference_server_sha = get_current_commit_sha()
 
     # step 3: setup logging and finalize run_id
-    run_timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    run_start = datetime.now()
+    run_timestamp = run_start.strftime("%Y-%m-%d_%H-%M-%S")
     run_id = get_run_id(
         timestamp=run_timestamp,
         model_id=model_id,
@@ -1200,7 +1202,19 @@ def main():
         )
         main_return_code = 0
     else:
-        main_return_code = WorkflowRunner(commands).run()
+        runner = WorkflowRunner(commands)
+        main_return_code = runner.run()
+        if runtime_config.docker_server:
+            # tt-metal writes a tt-triage report into the cache_root volume when
+            # it detects a device hang; copy it under workflow_logs/ so CI's
+            # existing artifact upload picks it up. Runs on success too -- the
+            # report is simply absent when nothing hung.
+            collect_tt_triage_logs(
+                setup_config=setup_config,
+                model_spec=model_spec,
+                dest_dir=log_path / "tt_triage",
+                since_ts=run_start.timestamp(),
+            )
     if main_return_code == 0:
         logger.info("Completed run.py.")
     else:

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -3,11 +3,14 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 import atexit
+import io
 import json
 import logging
 import os
 import shlex
+import shutil
 import subprocess
+import tarfile
 import threading
 import time
 import uuid
@@ -190,6 +193,108 @@ def generate_docker_volume_name(model_spec) -> str:
     The volume name excludes version to allow image upgrades without creating new volumes.
     """
     return f"volume_id_{model_spec.impl.impl_id}-{model_spec.model_name}"
+
+
+def collect_tt_triage_logs(
+    setup_config, model_spec, dest_dir: Path, since_ts: float = None
+) -> int:
+    """Copy tt-triage hang reports out of cache_root so CI can upload them.
+
+    tt-metal runs ``tools/triage/triage.py`` automatically when its dispatch
+    layer detects a device timeout (via the
+    ``TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE`` hook) and writes the report
+    to ``TT_TRIAGE_LOGS_PATH``, which :func:`generate_docker_run_command` points
+    at ``<cache_root>/logs`` in CI mode. ``cache_root`` is a docker volume, so
+    the reports outlive the container but sit outside ``workflow_logs/`` -- the
+    only tree CI uploads as an artifact. Copying them in makes the existing
+    upload step collect them with no CI-side change.
+
+    The volume is reused across runs, so ``since_ts`` (epoch seconds, normally
+    the start of this run) drops reports left behind by earlier runs rather
+    than misattributing them to this one.
+
+    Best-effort: logs and returns 0 on any failure, never raises, so a
+    collection problem can never mask the workload's own result.
+
+    Returns:
+        Number of reports collected into ``dest_dir``.
+    """
+    if setup_config is None:
+        return 0
+
+    dest_dir = Path(dest_dir)
+    try:
+        if setup_config.host_model_volume_root:
+            # cache_root is a host bind mount -- read it directly, no docker needed.
+            host_logs = Path(setup_config.host_model_volume_root) / "logs"
+            if not host_logs.is_dir():
+                logger.info(f"No tt-triage log directory at {host_logs}.")
+                return 0
+            ensure_readwriteable_dir(dest_dir)
+            for src in host_logs.iterdir():
+                if src.is_file():
+                    shutil.copy2(src, dest_dir / src.name)
+        else:
+            # cache_root is a named docker volume. Read the volume directly
+            # rather than `docker cp` from the server container: that container
+            # runs with --rm, so a hang that kills it also deletes it, and the
+            # hang is precisely the case a report exists for. Mount the volume
+            # into a throwaway container and tar to stdout, so the extracted
+            # files end up owned by the host user instead of root.
+            result = subprocess.run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--entrypoint",
+                    "tar",
+                    "--volume",
+                    f"{setup_config.docker_volume_name}:/cache_root:ro",
+                    model_spec.docker_image,
+                    "-cf",
+                    "-",
+                    "-C",
+                    "/cache_root/logs",
+                    ".",
+                ],
+                capture_output=True,
+            )
+            if result.returncode != 0:
+                # A missing logs/ directory is the common case: nothing hung.
+                stderr = result.stderr.decode(errors="replace").strip()
+                logger.info(
+                    "No tt-triage reports in docker volume "
+                    f"{setup_config.docker_volume_name}: {stderr}"
+                )
+                return 0
+            ensure_readwriteable_dir(dest_dir)
+            with tarfile.open(fileobj=io.BytesIO(result.stdout)) as tar:
+                try:
+                    tar.extractall(dest_dir, filter="data")
+                except TypeError:
+                    # filter= is only available on newer Python 3.10/3.11 patches.
+                    tar.extractall(dest_dir)
+
+        collected = sorted(p for p in dest_dir.iterdir() if p.is_file())
+        if since_ts is not None:
+            stale = [p for p in collected if p.stat().st_mtime < since_ts]
+            for path in stale:
+                # Left over from an earlier run sharing this volume.
+                path.unlink()
+            collected = [p for p in collected if p not in stale]
+
+        if collected:
+            logger.info(
+                f"Collected {len(collected)} tt-triage report(s) to {dest_dir}:"
+            )
+            for path in collected:
+                logger.info(f"  {path.name}")
+        else:
+            logger.info("No tt-triage reports from this run.")
+        return len(collected)
+    except Exception as e:
+        logger.warning(f"Failed to collect tt-triage reports: {e}")
+        return 0
 
 
 def format_docker_command(docker_command):


### PR DESCRIPTION
closes #5017.

## Summary

When a model hangs in CI, `tt-metal` automatically runs its own diagnostic tool `triage.py` and writes a report — but that report never uploaded anywhere. Once the job ends, it's gone.

This PR adds one extra step that grabs that report before the run finishes, so it gets uploaded automatically along with the rest.

## Example of the hang

`TT_THROW: TIMEOUT: device timeout, potential hang detected, the device is unrecoverable (assert.hpp:104)`


## Changes

- `run.py` — after a docker-server run finishes (whether it passed or failed), it now calls a new collect_tt_triage_logs() step.
- `workflows/run_docker_server.py` — this new function copies whatever report tt-metal wrote into workflow_logs/tt_triage/.
- If nothing hung, this step simply finds nothing and does nothing - it can never fail the run itself even if something goes wrong while collecting.

## Location

Once the report is copied into `workflow_logs/tt_triage/` no extra upload step is needed — CI already zips up the whole `workflow_logs/` folder and attaches it to the run as a downloadable file. The triage report just rides along in that same bundle.

## Test run 

Tested against a real tt-metal hang

https://github.com/tenstorrent/tt-shield/actions/runs/32837082154/job/97768303178

The hang happened, and right after, this showed up in the logs:

Collected 3 tt-triage report(s) to .
```
../workflow_logs/tt_triage:
  tt-triage-20260825-105042.log
```

## Additional step that presents tt_triage output

<img width="1265" height="629" alt="Screenshot 2026-08-25 at 14 16 13" src="https://github.com/user-attachments/assets/6ccf2227-bd46-4836-a57c-b871d8c9a8cf" />
