### PR TITLE
Qwen3_embedding_8B - Mesh shape change for t3k and n300 and Concurrency raised to 32 for Galaxy

### DIFF
--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -5878,6 +5878,8 @@ models:
             env:
               - name: ARCH_NAME
                 value: wormhole_b0
+              - name: BENCHMARK_MAX_CONCURRENCY
+                value: '32'
               - name: MESH_DEVICE
                 value: TG
               - name: VLLM__MAX_MODEL_LENGTH

--- a/tt-media-server/config/constants.py
+++ b/tt-media-server/config/constants.py
@@ -1347,7 +1347,7 @@ ModelConfigs = {
         "queue_for_multiprocessing": QueueType.FasterFifo.value,
     },
     (ModelRunners.QWEN_EMBEDDING_8B, DeviceTypes.N300): {
-        "device_mesh_shape": (2, 1),
+        "device_mesh_shape": (1, 2),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_1.value,
         "max_batch_size": 2,
@@ -1363,7 +1363,7 @@ ModelConfigs = {
         "queue_for_multiprocessing": QueueType.FasterFifo.value,
     },
     (ModelRunners.QWEN_EMBEDDING_8B, DeviceTypes.T3K): {
-        "device_mesh_shape": (2, 1),
+        "device_mesh_shape": (1, 2),
         "is_galaxy": False,
         "device_ids": DeviceIds.DEVICE_IDS_4.value,
         "max_batch_size": 2,

--- a/workflows/model_specs/dev/embedding.yaml
+++ b/workflows/model_specs/dev/embedding.yaml
@@ -160,6 +160,7 @@ templates:
         VLLM__MAX_MODEL_LENGTH: "1024"
         VLLM__MIN_CONTEXT_LENGTH: "32"
         VLLM__MAX_NUM_SEQS: "1"
+        BENCHMARK_MAX_CONCURRENCY: "32"  # 32 workers x 1 seq each
 
 - weights:
     - Qwen/Qwen3-Embedding-4B

--- a/workflows/model_specs/prod/embedding.yaml
+++ b/workflows/model_specs/prod/embedding.yaml
@@ -111,6 +111,7 @@ templates:
         VLLM__MAX_MODEL_LENGTH: "1024"
         VLLM__MIN_CONTEXT_LENGTH: "32"
         VLLM__MAX_NUM_SEQS: "1"
+        BENCHMARK_MAX_CONCURRENCY: "32"  # 32 workers x 1 seq each
 
 - weights:
     - Qwen/Qwen3-Embedding-4B


### PR DESCRIPTION
Link to failed run (t3k): https://github.com/tenstorrent/tt-shield/actions/runs/32488809637/job/96791471973

Error - Incompatible sharding strategy set by model and mesh_device shape in tt-media-server for t3k and n300:

<img width="1592" height="48" alt="image" src="https://github.com/user-attachments/assets/2888a7a0-29fa-4d0d-8501-045c1bc7cc75" />



##

Concurrency 1 run on 6u: https://github.com/tenstorrent/tt-shield/actions/runs/32864290132/job/97870608804


Concurrency 32 run on 6u: https://github.com/tenstorrent/tt-shield/actions/runs/32976046805/job/98215729255
