### PR TITLE
Migrate prod catalog to leaf-granular entries

### DIFF
--- a/workflows/model_specs/prod/audio_tts.yaml
+++ b/workflows/model_specs/prod/audio_tts.yaml
@@ -7,6 +7,69 @@ templates:
 # =============================================================================
 - weights:
     - openai/whisper-large-v3
+  version: "0.17.0"
+  tt_metal_commit: "8c48a10"
+  impl: whisper
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: AUDIO
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: N150
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: whisper-large-v3
+- weights:
+    - openai/whisper-large-v3
+  version: "0.17.0"
+  tt_metal_commit: "8c48a10"
+  impl: whisper
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: AUDIO
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: N300
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: whisper-large-v3
+- weights:
+    - openai/whisper-large-v3
+  version: "0.17.0"
+  tt_metal_commit: "8c48a10"
+  impl: whisper
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: AUDIO
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 32
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: whisper-large-v3
+- weights:
+    - openai/whisper-large-v3
+  version: "0.17.0"
+  tt_metal_commit: "8c48a10"
+  impl: whisper
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: AUDIO
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 4
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: whisper-large-v3
+- weights:
     - distil-whisper/distil-large-v3
   version: "0.17.0"
   tt_metal_commit: "8c48a10"
@@ -18,24 +81,96 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
-      default_impl: true
-    - device: N300
-      max_concurrency: 1
-      max_context: 65536  # 64 * 1024
-      default_impl: true
-    - device: GALAXY
-      max_concurrency: 32
-      max_context: 65536  # 64 * 1024
-      default_impl: true
-    - device: T3K
-      max_concurrency: 4
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
   status: COMPLETE
+  model_display_name: whisper-large-v3
+- weights:
+    - distil-whisper/distil-large-v3
+  version: "0.17.0"
+  tt_metal_commit: "8c48a10"
+  impl: whisper
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: AUDIO
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: N300
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: whisper-large-v3
+- weights:
+    - distil-whisper/distil-large-v3
+  version: "0.17.0"
+  tt_metal_commit: "8c48a10"
+  impl: whisper
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: AUDIO
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 32
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: whisper-large-v3
+- weights:
+    - distil-whisper/distil-large-v3
+  version: "0.17.0"
+  tt_metal_commit: "8c48a10"
+  impl: whisper
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: AUDIO
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 4
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: whisper-large-v3
 
 - weights:
     - openai/whisper-large-v3
+  version: "0.15.0"
+  tt_metal_commit: "25891d3"
+  impl: whisper
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: AUDIO
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: P150
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+      env_vars:
+        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto"
+  status: COMPLETE
+  model_display_name: whisper-large-v3
+- weights:
+    - openai/whisper-large-v3
+  version: "0.15.0"
+  tt_metal_commit: "25891d3"
+  impl: whisper
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: AUDIO
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 4
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+      env_vars:
+        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto"
+  status: COMPLETE
+  model_display_name: whisper-large-v3
+- weights:
     - distil-whisper/distil-large-v3
   version: "0.15.0"
   tt_metal_commit: "25891d3"
@@ -47,17 +182,30 @@ templates:
   device_model_specs:
     - device: P150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       env_vars:
         TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto"
+  status: COMPLETE
+  model_display_name: whisper-large-v3
+- weights:
+    - distil-whisper/distil-large-v3
+  version: "0.15.0"
+  tt_metal_commit: "25891d3"
+  impl: whisper
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: AUDIO
+  inference_engine: MEDIA
+  device_model_specs:
     - device: P300X2
       max_concurrency: 4
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       env_vars:
         TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto"
   status: COMPLETE
+  model_display_name: whisper-large-v3
 
 - weights:
     - microsoft/speecht5_tts
@@ -71,11 +219,22 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+  status: COMPLETE
+- weights:
+    - microsoft/speecht5_tts
+  version: "0.9.0"
+  tt_metal_commit: "a9b09e0"
+  impl: speecht5_tts
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: TEXT_TO_SPEECH
+  inference_engine: MEDIA
+  device_model_specs:
     - device: N300
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
   status: COMPLETE
 
@@ -91,13 +250,24 @@ templates:
   device_model_specs:
     - device: P150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       env_vars:
         TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto"
+  status: EXPERIMENTAL
+- weights:
+    - microsoft/speecht5_tts
+  version: "0.15.0"
+  tt_metal_commit: "25891d3"
+  impl: speecht5_tts
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: TEXT_TO_SPEECH
+  inference_engine: MEDIA
+  device_model_specs:
     - device: P300X2
       max_concurrency: 4
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       env_vars:
         TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto"

--- a/workflows/model_specs/prod/cnn.yaml
+++ b/workflows/model_specs/prod/cnn.yaml
@@ -25,6 +25,18 @@ templates:
         VLLM__MAX_NUM_BATCHED_TOKENS: "2048"
         VLLM__MAX_MODEL_LENGTH: "2048"
         VLLM__MIN_MODEL_LENGTH: "32"
+- weights:
+    - Qwen/Qwen3-4B
+  tt_metal_commit: "2496be4"
+  version: "0.12.0"
+  impl: forge_vllm_plugin
+  min_disk_gb: 15
+  min_ram_gb: 8
+  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756"
+  model_type: LLM
+  inference_engine: FORGE
+  uses_tensor_model_cache: false
+  device_model_specs:
     - device: N300
       max_concurrency: 1
       max_context: 2048
@@ -54,6 +66,18 @@ templates:
         VLLM__MAX_NUM_BATCHED_TOKENS: "2048"
         VLLM__MAX_MODEL_LENGTH: "2048"
         VLLM__MIN_MODEL_LENGTH: "32"
+- weights:
+    - meta-llama/Llama-3.2-3B
+  tt_metal_commit: "2496be4"
+  version: "0.12.0"
+  impl: forge_vllm_plugin
+  min_disk_gb: 15
+  min_ram_gb: 8
+  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756"
+  model_type: LLM
+  inference_engine: FORGE
+  uses_tensor_model_cache: false
+  device_model_specs:
     - device: N300
       max_concurrency: 1
       max_context: 2048
@@ -76,11 +100,22 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+- weights:
+    - resnet-50
+  version: "0.13.0"
+  tt_metal_commit: "079a2c2"
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: CNN
+  inference_engine: FORGE
+  status: FUNCTIONAL
+  device_model_specs:
     - device: N300
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
 
 - weights:
@@ -96,11 +131,22 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+- weights:
+    - vovnet
+  version: "0.13.0"
+  tt_metal_commit: "079a2c2"
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: CNN
+  inference_engine: FORGE
+  status: COMPLETE
+  device_model_specs:
     - device: N300
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
 
 - weights:
@@ -116,11 +162,22 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+- weights:
+    - mobilenetv2
+  version: "0.13.0"
+  tt_metal_commit: "079a2c2"
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: CNN
+  inference_engine: FORGE
+  status: COMPLETE
+  device_model_specs:
     - device: N300
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
 
 - weights:
@@ -136,11 +193,22 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+- weights:
+    - efficientnet
+  tt_metal_commit: "2496be4"
+  version: "0.12.0"
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673"
+  model_type: CNN
+  inference_engine: FORGE
+  device_model_specs:
     - device: N300
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
 
 - weights:
@@ -156,11 +224,22 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+- weights:
+    - segformer
+  version: "0.13.0"
+  tt_metal_commit: "079a2c2"
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: CNN
+  inference_engine: FORGE
+  status: FUNCTIONAL
+  device_model_specs:
     - device: N300
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
 
 - weights:
@@ -176,11 +255,22 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+- weights:
+    - vit
+  version: "0.13.0"
+  tt_metal_commit: "079a2c2"
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: CNN
+  inference_engine: FORGE
+  status: COMPLETE
+  device_model_specs:
     - device: N300
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
 
 - weights:
@@ -196,11 +286,22 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+- weights:
+    - unet
+  tt_metal_commit: "2496be4"
+  version: "0.12.0"
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  docker_image: "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673"
+  model_type: CNN
+  inference_engine: FORGE
+  device_model_specs:
     - device: N300
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
 - weights:
     - tiiuae/Falcon3-7B-Instruct
@@ -215,7 +316,7 @@ templates:
   device_model_specs:
     - device: P150
       max_concurrency: 32
-      max_context: 32768  # Falcon3 native max_position_embeddings
+      max_context: 32768      # Falcon3 native max_position_embeddings
       default_impl: true
       eval_max_retries: 1
       env_vars:
@@ -227,11 +328,11 @@ templates:
         CPU_SAMPLING: "false"
         ENABLE_TRACE: "true"
         KV_CACHE_DTYPE: "bfp_bf8"
-        # 1024 (not 2048): Falcon3 head_dim=256 makes the b32 prefill SDPA buffer
-        # DRAM-OOM at chunk 2048 during trace-capture.
+            # 1024 (not 2048): Falcon3 head_dim=256 makes the b32 prefill SDPA buffer
+            # DRAM-OOM at chunk 2048 during trace-capture.
         PREFILL_CHUNK_SIZE: "1024"
-        MIN_NUM_SEQS: "1"  # b1-prefill: compile [1,n] graph alongside [32,n] (tt-xla #5281)
-        PREFILL_BATCH_THRESHOLD: "16"  # route <=16 pending prefills to b1, serially
+        MIN_NUM_SEQS: "1"      # b1-prefill: compile [1,n] graph alongside [32,n] (tt-xla #5281)
+        PREFILL_BATCH_THRESHOLD: "16"      # route <=16 pending prefills to b1, serially
 - weights:
     - yolox_nano
   version: "0.18.0"
@@ -245,9 +346,20 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+- weights:
+    - yolox_nano
+  version: "0.18.0"
+  tt_metal_commit: "c49bb76"
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: CNN
+  inference_engine: FORGE
+  status: COMPLETE
+  device_model_specs:
     - device: P150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true

--- a/workflows/model_specs/prod/embedding.yaml
+++ b/workflows/model_specs/prod/embedding.yaml
@@ -18,7 +18,7 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       env_vars:
         VLLM__MAX_NUM_BATCHED_TOKENS: "3072"
@@ -27,9 +27,20 @@ templates:
         VLLM__MAX_NUM_SEQS: "8"
         MAX_BATCH_SIZE: "8"
         DEFAULT_THROTTLE_LEVEL: "0"
+- weights:
+    - BAAI/bge-large-en-v1.5
+  tt_metal_commit: "65718bb"
+  version: "0.12.0"
+  impl: tt_vllm_plugin
+  min_disk_gb: 15
+  min_ram_gb: 6
+  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756"
+  model_type: EMBEDDING
+  inference_engine: MEDIA
+  device_model_specs:
     - device: N300
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       env_vars:
         VLLM__MAX_NUM_BATCHED_TOKENS: "6144"
@@ -38,9 +49,20 @@ templates:
         VLLM__MAX_NUM_SEQS: "16"
         MAX_BATCH_SIZE: "16"
         DEFAULT_THROTTLE_LEVEL: "0"
+- weights:
+    - BAAI/bge-large-en-v1.5
+  tt_metal_commit: "65718bb"
+  version: "0.12.0"
+  impl: tt_vllm_plugin
+  min_disk_gb: 15
+  min_ram_gb: 6
+  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756"
+  model_type: EMBEDDING
+  inference_engine: MEDIA
+  device_model_specs:
     - device: T3K
       max_concurrency: 4
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       env_vars:
         VLLM__MAX_NUM_BATCHED_TOKENS: "6144"
@@ -49,9 +71,20 @@ templates:
         VLLM__MAX_NUM_SEQS: "16"
         MAX_BATCH_SIZE: "16"
         DEFAULT_THROTTLE_LEVEL: "0"
+- weights:
+    - BAAI/bge-large-en-v1.5
+  tt_metal_commit: "65718bb"
+  version: "0.12.0"
+  impl: tt_vllm_plugin
+  min_disk_gb: 15
+  min_ram_gb: 6
+  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756"
+  model_type: EMBEDDING
+  inference_engine: MEDIA
+  device_model_specs:
     - device: GALAXY
       max_concurrency: 32
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       env_vars:
         VLLM__MAX_NUM_BATCHED_TOKENS: "3072"
@@ -60,8 +93,8 @@ templates:
         VLLM__MAX_NUM_SEQS: "8"
         MAX_BATCH_SIZE: "8"
         DEFAULT_THROTTLE_LEVEL: "0"
-        # Disable Inspector RPC to prevent port conflicts with 32 concurrent workers
-        # Each worker would otherwise try to bind to the same port (50051)
+            # Disable Inspector RPC to prevent port conflicts with 32 concurrent workers
+            # Each worker would otherwise try to bind to the same port (50051)
         TT_METAL_INSPECTOR_RPC: "0"
 
 - weights:
@@ -77,34 +110,67 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       env_vars:
         VLLM__MAX_NUM_BATCHED_TOKENS: "1024"
         VLLM__MAX_MODEL_LENGTH: "1024"
         VLLM__MIN_CONTEXT_LENGTH: "32"
         VLLM__MAX_NUM_SEQS: "1"
+- weights:
+    - Qwen/Qwen3-Embedding-8B
+  tt_metal_commit: "555f240"
+  version: "0.12.0"
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756"
+  model_type: EMBEDDING
+  inference_engine: MEDIA
+  device_model_specs:
     - device: N300
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       env_vars:
         VLLM__MAX_NUM_BATCHED_TOKENS: "8192"
         VLLM__MAX_MODEL_LENGTH: "4096"
         VLLM__MIN_CONTEXT_LENGTH: "32"
         VLLM__MAX_NUM_SEQS: "2"
+- weights:
+    - Qwen/Qwen3-Embedding-8B
+  tt_metal_commit: "555f240"
+  version: "0.12.0"
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756"
+  model_type: EMBEDDING
+  inference_engine: MEDIA
+  device_model_specs:
     - device: T3K
       max_concurrency: 4
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       env_vars:
         VLLM__MAX_NUM_BATCHED_TOKENS: "8192"
         VLLM__MAX_MODEL_LENGTH: "4096"
         VLLM__MIN_CONTEXT_LENGTH: "32"
         VLLM__MAX_NUM_SEQS: "2"
+- weights:
+    - Qwen/Qwen3-Embedding-8B
+  tt_metal_commit: "555f240"
+  version: "0.12.0"
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756"
+  model_type: EMBEDDING
+  inference_engine: MEDIA
+  device_model_specs:
     - device: GALAXY
       max_concurrency: 32
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       env_vars:
         VLLM__MAX_NUM_BATCHED_TOKENS: "1024"
@@ -134,6 +200,16 @@ templates:
         VLLM__MAX_NUM_SEQS: "1"
         MAX_BATCH_SIZE: "1"
         DEFAULT_THROTTLE_LEVEL: "0"
+- weights:
+    - Qwen/Qwen3-Embedding-4B
+  version: "0.20.0"
+  tt_metal_commit: "de59f8a"
+  impl: forge_vllm_plugin
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: EMBEDDING
+  inference_engine: FORGE
+  device_model_specs:
     - device: N300
       max_concurrency: 1
       max_context: 65536
@@ -145,6 +221,16 @@ templates:
         VLLM__MAX_NUM_SEQS: "1"
         MAX_BATCH_SIZE: "1"
         DEFAULT_THROTTLE_LEVEL: "0"
+- weights:
+    - Qwen/Qwen3-Embedding-4B
+  version: "0.20.0"
+  tt_metal_commit: "de59f8a"
+  impl: forge_vllm_plugin
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: EMBEDDING
+  inference_engine: FORGE
+  device_model_specs:
     - device: T3K
       max_concurrency: 4
       max_context: 65536
@@ -156,6 +242,16 @@ templates:
         VLLM__MAX_NUM_SEQS: "1"
         MAX_BATCH_SIZE: "1"
         DEFAULT_THROTTLE_LEVEL: "0"
+- weights:
+    - Qwen/Qwen3-Embedding-4B
+  version: "0.20.0"
+  tt_metal_commit: "de59f8a"
+  impl: forge_vllm_plugin
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: EMBEDDING
+  inference_engine: FORGE
+  device_model_specs:
     - device: GALAXY
       max_concurrency: 32
       max_context: 65536
@@ -168,6 +264,16 @@ templates:
         MAX_BATCH_SIZE: "1"
         DEFAULT_THROTTLE_LEVEL: "0"
 
+- weights:
+    - Qwen/Qwen3-Embedding-4B
+  version: "0.20.0"
+  tt_metal_commit: "de59f8a"
+  impl: forge_vllm_plugin
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: EMBEDDING
+  inference_engine: FORGE
+  device_model_specs:
     - device: P300X2
       max_concurrency: 4
       max_context: 65536
@@ -178,10 +284,10 @@ templates:
         VLLM__MAX_MODEL_LENGTH: "128"
         VLLM__MIN_CONTEXT_LENGTH: "32"
         VLLM__MAX_NUM_SEQS: "8"
-        BENCHMARK_MAX_CONCURRENCY: "32"   # 4 workers x 8 seqs
+        BENCHMARK_MAX_CONCURRENCY: "32"       # 4 workers x 8 seqs
         MAX_BATCH_SIZE: "8"
-        # Each worker sees a single chip, which tt-metal classifies as a CUSTOM
-        # cluster and refuses to init without an explicit descriptor.
+            # Each worker sees a single chip, which tt-metal classifies as a CUSTOM
+            # cluster and refuses to init without an explicit descriptor.
         TT_MESH_GRAPH_DESC_PATH: "/home/container_app_user/app/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto"
         USE_DYNAMIC_BATCHER: "false"
         DEFAULT_THROTTLE_LEVEL: "0"
@@ -206,10 +312,10 @@ templates:
         VLLM__MAX_MODEL_LENGTH: "128"
         VLLM__MIN_CONTEXT_LENGTH: "32"
         VLLM__MAX_NUM_SEQS: "8"
-        BENCHMARK_MAX_CONCURRENCY: "32"   # 4 workers x 8 seqs
+        BENCHMARK_MAX_CONCURRENCY: "32"       # 4 workers x 8 seqs
         MAX_BATCH_SIZE: "8"
-        # Each worker sees a single chip, which tt-metal classifies as a CUSTOM
-        # cluster and refuses to init without an explicit descriptor.
+            # Each worker sees a single chip, which tt-metal classifies as a CUSTOM
+            # cluster and refuses to init without an explicit descriptor.
         TT_MESH_GRAPH_DESC_PATH: "/home/container_app_user/app/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto"
         USE_DYNAMIC_BATCHER: "false"
         DEFAULT_THROTTLE_LEVEL: "0"
@@ -234,10 +340,10 @@ templates:
         VLLM__MAX_MODEL_LENGTH: "128"
         VLLM__MIN_CONTEXT_LENGTH: "32"
         VLLM__MAX_NUM_SEQS: "8"
-        BENCHMARK_MAX_CONCURRENCY: "32"   # 4 workers x 8 seqs
+        BENCHMARK_MAX_CONCURRENCY: "32"       # 4 workers x 8 seqs
         MAX_BATCH_SIZE: "8"
-        # Each worker sees a single chip, which tt-metal classifies as a CUSTOM
-        # cluster and refuses to init without an explicit descriptor.
+            # Each worker sees a single chip, which tt-metal classifies as a CUSTOM
+            # cluster and refuses to init without an explicit descriptor.
         TT_MESH_GRAPH_DESC_PATH: "/home/container_app_user/app/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto"
         USE_DYNAMIC_BATCHER: "false"
         DEFAULT_THROTTLE_LEVEL: "0"

--- a/workflows/model_specs/prod/image.yaml
+++ b/workflows/model_specs/prod/image.yaml
@@ -8,6 +8,77 @@ templates:
 # For both: STABLE_DIFFUSION_XL_BASE and STABLE_DIFFUSION_XL_IMG2IMG
 - weights:
     - stabilityai/stable-diffusion-xl-base-1.0
+  version: "0.11.1"
+  tt_metal_commit: bac8b34
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+      # img2img uses the same weights as base SDXL
+  hf_weights_repo: stabilityai/stable-diffusion-xl-base-1.0
+  device_model_specs:
+    - device: N150
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: stable-diffusion-xl-base-1.0
+- weights:
+    - stabilityai/stable-diffusion-xl-base-1.0
+  version: "0.11.1"
+  tt_metal_commit: bac8b34
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+      # img2img uses the same weights as base SDXL
+  hf_weights_repo: stabilityai/stable-diffusion-xl-base-1.0
+  device_model_specs:
+    - device: N300
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: stable-diffusion-xl-base-1.0
+- weights:
+    - stabilityai/stable-diffusion-xl-base-1.0
+  version: "0.11.1"
+  tt_metal_commit: bac8b34
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+      # img2img uses the same weights as base SDXL
+  hf_weights_repo: stabilityai/stable-diffusion-xl-base-1.0
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 4
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: stable-diffusion-xl-base-1.0
+- weights:
+    - stabilityai/stable-diffusion-xl-base-1.0
+  version: "0.11.1"
+  tt_metal_commit: bac8b34
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+      # img2img uses the same weights as base SDXL
+  hf_weights_repo: stabilityai/stable-diffusion-xl-base-1.0
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 16
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: stable-diffusion-xl-base-1.0
+- weights:
     - stabilityai/stable-diffusion-xl-base-1.0-img-2-img
   version: "0.11.1"
   tt_metal_commit: bac8b34
@@ -16,26 +87,69 @@ templates:
   min_ram_gb: 6
   model_type: IMAGE
   inference_engine: MEDIA
-  # img2img uses the same weights as base SDXL
+      # img2img uses the same weights as base SDXL
   hf_weights_repo: stabilityai/stable-diffusion-xl-base-1.0
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
-      default_impl: true
-    - device: N300
-      max_concurrency: 1
-      max_context: 65536  # 64 * 1024
-      default_impl: true
-    - device: T3K
-      max_concurrency: 4
-      max_context: 65536  # 64 * 1024
-      default_impl: true
-    - device: GALAXY
-      max_concurrency: 16
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
   status: COMPLETE
+  model_display_name: stable-diffusion-xl-base-1.0
+- weights:
+    - stabilityai/stable-diffusion-xl-base-1.0-img-2-img
+  version: "0.11.1"
+  tt_metal_commit: bac8b34
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+      # img2img uses the same weights as base SDXL
+  hf_weights_repo: stabilityai/stable-diffusion-xl-base-1.0
+  device_model_specs:
+    - device: N300
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: stable-diffusion-xl-base-1.0
+- weights:
+    - stabilityai/stable-diffusion-xl-base-1.0-img-2-img
+  version: "0.11.1"
+  tt_metal_commit: bac8b34
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+      # img2img uses the same weights as base SDXL
+  hf_weights_repo: stabilityai/stable-diffusion-xl-base-1.0
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 4
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: stable-diffusion-xl-base-1.0
+- weights:
+    - stabilityai/stable-diffusion-xl-base-1.0-img-2-img
+  version: "0.11.1"
+  tt_metal_commit: bac8b34
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+      # img2img uses the same weights as base SDXL
+  hf_weights_repo: stabilityai/stable-diffusion-xl-base-1.0
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 16
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: stable-diffusion-xl-base-1.0
 
 - weights:
     - stabilityai/stable-diffusion-3.5-large
@@ -49,11 +163,22 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+  status: COMPLETE
+- weights:
+    - stabilityai/stable-diffusion-3.5-large
+  version: "0.9.0"
+  tt_metal_commit: c180ef7
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
     - device: GALAXY
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
   status: COMPLETE
 
@@ -70,24 +195,123 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+  status: COMPLETE
+- weights:
+    - diffusers/stable-diffusion-xl-1.0-inpainting-0.1
+  version: "0.12.0"
+  tt_metal_commit: fbbbd2d
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd"
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
     - device: N300
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+  status: COMPLETE
+- weights:
+    - diffusers/stable-diffusion-xl-1.0-inpainting-0.1
+  version: "0.12.0"
+  tt_metal_commit: fbbbd2d
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd"
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
     - device: T3K
       max_concurrency: 4
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+  status: COMPLETE
+- weights:
+    - diffusers/stable-diffusion-xl-1.0-inpainting-0.1
+  version: "0.12.0"
+  tt_metal_commit: fbbbd2d
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  docker_image: "ghcr.io/tenstorrent/tt-media-inference-server:0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd"
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
     - device: GALAXY
       max_concurrency: 32
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
   status: COMPLETE
 
 - weights:
     - black-forest-labs/FLUX.1-dev
+  version: "0.10.0"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: FLUX.1-dev
+- weights:
+    - black-forest-labs/FLUX.1-dev
+  version: "0.10.0"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: FLUX.1-dev
+- weights:
+    - black-forest-labs/FLUX.1-dev
+  version: "0.10.0"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: P300
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: FLUX.1-dev
+- weights:
+    - black-forest-labs/FLUX.1-dev
+  version: "0.10.0"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: P150X4
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: FLUX.1-dev
+- weights:
     - black-forest-labs/FLUX.1-schnell
   version: "0.10.0"
   tt_metal_commit: 555f240
@@ -99,24 +323,76 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
-      default_impl: true
-    - device: GALAXY
-      max_concurrency: 1
-      max_context: 65536  # 64 * 1024
-      default_impl: true
-    - device: P300
-      max_concurrency: 1
-      max_context: 65536  # 64 * 1024
-      default_impl: true
-    - device: P150X4
-      max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
   status: COMPLETE
+  model_display_name: FLUX.1-dev
+- weights:
+    - black-forest-labs/FLUX.1-schnell
+  version: "0.10.0"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: FLUX.1-dev
+- weights:
+    - black-forest-labs/FLUX.1-schnell
+  version: "0.10.0"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: P300
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: FLUX.1-dev
+- weights:
+    - black-forest-labs/FLUX.1-schnell
+  version: "0.10.0"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: P150X4
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: FLUX.1-dev
 
 - weights:
     - black-forest-labs/FLUX.1-dev
+  version: "0.10.1"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: P150X8
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: COMPLETE
+  model_display_name: FLUX.1-dev
+- weights:
     - black-forest-labs/FLUX.1-schnell
   version: "0.10.1"
   tt_metal_commit: 555f240
@@ -128,9 +404,10 @@ templates:
   device_model_specs:
     - device: P150X8
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
   status: COMPLETE
+  model_display_name: FLUX.1-dev
 
 - weights:
     - black-forest-labs/FLUX.1-dev
@@ -144,7 +421,7 @@ templates:
   device_model_specs:
     - device: P300X2
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 55000000
@@ -162,7 +439,7 @@ templates:
   device_model_specs:
     - device: P300X2
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 55000000
@@ -180,24 +457,90 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+  status: COMPLETE
+- weights:
+    - Motif-Technologies/Motif-Image-6B-Preview
+  version: "0.9.0"
+  tt_metal_commit: c180ef7
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
     - device: GALAXY
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+  status: COMPLETE
+- weights:
+    - Motif-Technologies/Motif-Image-6B-Preview
+  version: "0.9.0"
+  tt_metal_commit: c180ef7
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
     - device: P150X8
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+  status: COMPLETE
+- weights:
+    - Motif-Technologies/Motif-Image-6B-Preview
+  version: "0.9.0"
+  tt_metal_commit: c180ef7
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
     - device: P300X2
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
   status: COMPLETE
 
 - weights:
     - Qwen/Qwen-Image
+  version: "0.9.0"
+  tt_metal_commit: be88351
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+      env_vars:
+        TT_DIT_CACHE_DIR: /tmp/TT_DIT_CACHE
+  status: FUNCTIONAL
+  model_display_name: Qwen-Image
+- weights:
+    - Qwen/Qwen-Image
+  version: "0.9.0"
+  tt_metal_commit: be88351
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 1
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+  status: FUNCTIONAL
+  model_display_name: Qwen-Image
+- weights:
     - Qwen/Qwen-Image-2512
   version: "0.9.0"
   tt_metal_commit: be88351
@@ -209,15 +552,28 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       env_vars:
         TT_DIT_CACHE_DIR: /tmp/TT_DIT_CACHE
+  status: FUNCTIONAL
+  model_display_name: Qwen-Image
+- weights:
+    - Qwen/Qwen-Image-2512
+  version: "0.9.0"
+  tt_metal_commit: be88351
+  impl: tt_transformers
+  min_disk_gb: 15
+  min_ram_gb: 6
+  model_type: IMAGE
+  inference_engine: MEDIA
+  device_model_specs:
     - device: GALAXY
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
   status: FUNCTIONAL
+  model_display_name: Qwen-Image
 - weights:
     - Tongyi-MAI/Z-Image-Turbo
   version: "0.17.0"

--- a/workflows/model_specs/prod/llm.yaml
+++ b/workflows/model_specs/prod/llm.yaml
@@ -15,23 +15,55 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 1
-      max_context: 16384  # 16 * 1024
+      max_context: 16384      # 16 * 1024
       default_impl: true
       env_vars:
         VLLM_ENABLE_RESPONSES_API_STORE: 1
         VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS: 1
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    openai/gpt-oss-20b:
+      reasoning_parser_name: openai_gptoss
+      tool_call_parser_name: openai
+- weights:
+    - openai/gpt-oss-20b
+  impl: gpt_oss
+  version: "0.10.0"
+  tt_metal_commit: e867533
+  vllm_commit: 8f36910
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY_T3K
       max_concurrency: 1
-      max_context: 16384  # 16 * 1024
+      max_context: 16384      # 16 * 1024
       default_impl: true
       env_vars:
         TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    openai/gpt-oss-20b:
+      reasoning_parser_name: openai_gptoss
+      tool_call_parser_name: openai
+- weights:
+    - openai/gpt-oss-20b
+  impl: gpt_oss
+  version: "0.10.0"
+  tt_metal_commit: e867533
+  vllm_commit: 8f36910
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY
-      max_concurrency: 128  # 32 * 4
-      max_context: 131072  # 128 * 1024
+      max_concurrency: 128      # 32 * 4
+      max_context: 131072      # 128 * 1024
       default_impl: true
       env_vars:
-        MESH_DEVICE: "(4, 8)"  # Override default TG->(8,4) to use (4,8) mesh grid
+        MESH_DEVICE: "(4, 8)"      # Override default TG->(8,4) to use (4,8) mesh grid
       vllm_args:
         data_parallel_size: 4
   status: EXPERIMENTAL
@@ -53,33 +85,53 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 1
-      max_context: 16384  # 16 * 1024
+      max_context: 16384      # 16 * 1024
       default_impl: true
       tensor_cache_timeout: 5400.0
       override_tt_config:
-        trace_region_size: 134217728  # 128 MB; vLLM default 50 MB is too small for long prefill
+        trace_region_size: 134217728      # 128 MB; vLLM default 50 MB is too small for long prefill
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    openai/gpt-oss-120b:
+      reasoning_parser_name: openai_gptoss
+      tool_call_parser_name: openai
+- weights:
+    - openai/gpt-oss-120b
+  version: "0.17.0"
+  tt_metal_commit: "8c48a10"
+  vllm_commit: "f52987a"
+  impl: gpt_oss
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY
-      max_concurrency: 32  # currently limiting client-side max_concurrency=32 to allow workflows to
-      # complete else they will timeout due to hitting the vLLM RPC recv 30min timeout
-      max_context: 131072  # 128 * 1024
+      max_concurrency: 32      # currently limiting client-side max_concurrency=32 to allow workflows to
+          # complete else they will timeout due to hitting the vLLM RPC recv 30min timeout
+      max_context: 131072      # 128 * 1024
       default_impl: true
       tensor_cache_timeout: 5400.0
       env_vars:
-        MESH_DEVICE: "(4, 8)"  # Override default TG->(8,4) to use (4,8) mesh grid
+        MESH_DEVICE: "(4, 8)"      # Override default TG->(8,4) to use (4,8) mesh grid
         TT_MM_THROTTLE_PERF: 2
       vllm_args:
         data_parallel_size: 4
-        max_num_seqs: 32  # override the default inferred by max_concurrency
+        max_num_seqs: 32      # override the default inferred by max_concurrency
       override_tt_config:
         sample_on_device_mode: all
-        trace_region_size: 134217728  # 128 MB; vLLM default 50 MB is too small for long prefill
+        trace_region_size: 134217728      # 128 MB; vLLM default 50 MB is too small for long prefill
       known_issues:
         - workflow_type: EVALS
           task_name: aime25
-          reason: "Model implementation is producing non-deterministic outputs causing this eval task to pass/fail flakily. Masking this part of the acceptance criteria due to other evals passing consistently."
+          reason: "Model implementation is producing non-deterministic outputs causing
+            this eval task to pass/fail flakily. Masking this part of the acceptance
+            criteria due to other evals passing consistently."
         - workflow_type: EVALS
           task_name: gpqa_diamond_cot_zeroshot
-          reason: "Model implementation is producing non-deterministic outputs causing this eval task to pass/fail flakily. Masking this part of the acceptance criteria due to other evals passing consistently."
+          reason: "Model implementation is producing non-deterministic outputs causing
+            this eval task to pass/fail flakily. Masking this part of the acceptance
+            criteria due to other evals passing consistently."
   status: EXPERIMENTAL
   has_builtin_warmup: true
   env_vars:
@@ -96,19 +148,31 @@ templates:
   tt_metal_commit: ae65ee5
   vllm_commit: 35f023f
   inference_engine: VLLM
-  # need to add default sampling params here because they're
-  # not in generation_config.json
-  # see: https://github.com/tenstorrent/tt-inference-server/issues/1066
+      # need to add default sampling params here because they're
+      # not in generation_config.json
+      # see: https://github.com/tenstorrent/tt-inference-server/issues/1066
   device_model_specs:
     - device: N300
       max_concurrency: 32
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       vllm_args:
         override_generation_config: '{"temperature": 0.5, "top_k": 50, "top_p": 0.95}'
+  status: EXPERIMENTAL
+- weights:
+    - arcee-ai/AFM-4.5B
+  impl: tt_transformers
+  version: "0.3.0"
+  tt_metal_commit: ae65ee5
+  vllm_commit: 35f023f
+  inference_engine: VLLM
+      # need to add default sampling params here because they're
+      # not in generation_config.json
+      # see: https://github.com/tenstorrent/tt-inference-server/issues/1066
+  device_model_specs:
     - device: T3K
       max_concurrency: 32
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       vllm_args:
         override_generation_config: '{"temperature": 0.5, "top_k": 50, "top_p": 0.95}'
@@ -124,7 +188,7 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 32
-      max_context: 32768  # 32 * 1024
+      max_context: 32768      # 32 * 1024
       default_impl: true
       override_tt_config:
         l1_small_size: 4096
@@ -146,16 +210,55 @@ templates:
       default_impl: true
       override_tt_config:
         trace_region_size: 51000000
+  status: FUNCTIONAL
+  metadata:
+    Qwen/Qwen3-8B:
+      reasoning_parser_name: qwen3
+      tool_call_parser_name: hermes
+- weights:
+    - Qwen/Qwen3-8B
+  impl: tt_transformers
+  version: "0.10.0"
+  tt_metal_commit: e0e0500
+  vllm_commit: 409b1cd
+  inference_engine: VLLM
+  device_model_specs:
     - device: N300
       max_concurrency: 32
       max_context: 40960
       default_impl: true
       override_tt_config:
         trace_region_size: 65000000
+  status: FUNCTIONAL
+  metadata:
+    Qwen/Qwen3-8B:
+      reasoning_parser_name: qwen3
+      tool_call_parser_name: hermes
+- weights:
+    - Qwen/Qwen3-8B
+  impl: tt_transformers
+  version: "0.10.0"
+  tt_metal_commit: e0e0500
+  vllm_commit: 409b1cd
+  inference_engine: VLLM
+  device_model_specs:
     - device: T3K
       max_concurrency: 32
       max_context: 40960
       default_impl: true
+  status: FUNCTIONAL
+  metadata:
+    Qwen/Qwen3-8B:
+      reasoning_parser_name: qwen3
+      tool_call_parser_name: hermes
+- weights:
+    - Qwen/Qwen3-8B
+  impl: tt_transformers
+  version: "0.10.0"
+  tt_metal_commit: e0e0500
+  vllm_commit: 409b1cd
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY_T3K
       max_concurrency: 32
       max_context: 40960
@@ -165,8 +268,21 @@ templates:
         TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       override_tt_config:
         fabric_config: FABRIC_1D
+  status: FUNCTIONAL
+  metadata:
+    Qwen/Qwen3-8B:
+      reasoning_parser_name: qwen3
+      tool_call_parser_name: hermes
+- weights:
+    - Qwen/Qwen3-8B
+  impl: tt_transformers
+  version: "0.10.0"
+  tt_metal_commit: e0e0500
+  vllm_commit: 409b1cd
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY
-      max_concurrency: 128  # 32 * 4
+      max_concurrency: 128      # 32 * 4
       max_context: 40960
       default_impl: true
       env_vars:
@@ -211,9 +327,9 @@ templates:
   inference_engine: VLLM
   device_model_specs:
     - device: GALAXY
-      max_concurrency: 32  # 8 * 4
-      # NOTE: model natively supports 40K but use this to override max_num_batched_tokens
-      max_context: 131072  # 128 * 1024
+      max_concurrency: 32      # 8 * 4
+          # NOTE: model natively supports 40K but use this to override max_num_batched_tokens
+      max_context: 131072      # 128 * 1024
       default_impl: true
       env_vars:
         VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
@@ -249,22 +365,52 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 54000000
+  status: FUNCTIONAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    Qwen/Qwen3-32B:
+      reasoning_parser_name: qwen3
+      tool_call_parser_name: hermes
+- weights:
+    - Qwen/Qwen3-32B
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: e95ffa5
+  vllm_commit: 48eba14
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY_T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       env_vars:
         TT_MM_THROTTLE_PERF: 5
         TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
       override_tt_config:
         fabric_config: FABRIC_1D
+  status: FUNCTIONAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    Qwen/Qwen3-32B:
+      reasoning_parser_name: qwen3
+      tool_call_parser_name: hermes
+- weights:
+    - Qwen/Qwen3-32B
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: e95ffa5
+  vllm_commit: 48eba14
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY
-      max_concurrency: 128  # 32 * 4
-      max_context: 131072  # 128 * 1024
+      max_concurrency: 128      # 32 * 4
+      max_context: 131072      # 128 * 1024
       default_impl: false
       override_tt_config:
         trace_region_size: 66147328
@@ -298,7 +444,7 @@ templates:
   device_model_specs:
     - device: P150X8
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 61341696
@@ -327,10 +473,10 @@ templates:
   device_model_specs:
     - device: P300X2
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       override_tt_config:
-        trace_region_size: 402653184  # 384 * 1024 * 1024
+        trace_region_size: 402653184      # 384 * 1024 * 1024
   status: FUNCTIONAL
   has_builtin_warmup: true
   env_vars:
@@ -350,15 +496,37 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 32
-      max_context: 32768  # 32 * 1024
+      max_context: 32768      # 32 * 1024
       default_impl: true
+  status: COMPLETE
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+- weights:
+    - mistralai/Mistral-7B-Instruct-v0.3
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 9b67e09
+  vllm_commit: a91b644
+  inference_engine: VLLM
+  device_model_specs:
     - device: N300
       max_concurrency: 32
-      max_context: 32768  # 32 * 1024
+      max_context: 32768      # 32 * 1024
       default_impl: true
+  status: COMPLETE
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+- weights:
+    - mistralai/Mistral-7B-Instruct-v0.3
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 9b67e09
+  vllm_commit: a91b644
+  inference_engine: VLLM
+  device_model_specs:
     - device: T3K
       max_concurrency: 32
-      max_context: 32768  # 32 * 1024
+      max_context: 32768      # 32 * 1024
       default_impl: true
   status: COMPLETE
   env_vars:
@@ -374,19 +542,49 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
+  status: FUNCTIONAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    Qwen/QwQ-32B:
+      reasoning_parser_name: deepseek_r1
+      tool_call_parser_name: hermes
+- weights:
+    - Qwen/QwQ-32B
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: e95ffa5
+  vllm_commit: 48eba14
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY
-      max_concurrency: 128  # 32 * 4
-      max_context: 131072  # 128 * 1024
+      max_concurrency: 128      # 32 * 4
+      max_context: 131072      # 128 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 27381760
       env_vars:
         TT_MM_THROTTLE_PERF: 5
+  status: FUNCTIONAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    Qwen/QwQ-32B:
+      reasoning_parser_name: deepseek_r1
+      tool_call_parser_name: hermes
+- weights:
+    - Qwen/QwQ-32B
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: e95ffa5
+  vllm_commit: 48eba14
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY_T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       env_vars:
         TT_MM_THROTTLE_PERF: 5
@@ -403,7 +601,6 @@ templates:
 
 - weights:
     - Qwen/Qwen2.5-72B
-    - Qwen/Qwen2.5-72B-Instruct
   impl: tt_transformers
   version: "0.9.0"
   tt_metal_commit: 13f44c5
@@ -412,23 +609,55 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       tensor_cache_timeout: 5400.0
       override_tt_config:
         trace_region_size: 66000000
+  status: FUNCTIONAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+    MAX_PREFILL_CHUNK_SIZE: "16"
+  metadata:
+    Qwen/Qwen2.5-72B:
+      tool_call_parser_name: hermes
+  model_display_name: Qwen2.5-72B
+- weights:
+    - Qwen/Qwen2.5-72B
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 13f44c5
+  vllm_commit: 0edd242
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY
-      max_concurrency: 128  # 32 * 4
-      max_context: 131072  # 128 * 1024
+      max_concurrency: 128      # 32 * 4
+      max_context: 131072      # 128 * 1024
       default_impl: true
       tensor_cache_timeout: 5400.0
       override_tt_config:
         trace_region_size: 66000000
       env_vars:
         TT_MM_THROTTLE_PERF: 5
+  status: FUNCTIONAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+    MAX_PREFILL_CHUNK_SIZE: "16"
+  metadata:
+    Qwen/Qwen2.5-72B:
+      tool_call_parser_name: hermes
+  model_display_name: Qwen2.5-72B
+- weights:
+    - Qwen/Qwen2.5-72B
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 13f44c5
+  vllm_commit: 0edd242
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY_T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       tensor_cache_timeout: 5400.0
       override_tt_config:
@@ -444,11 +673,124 @@ templates:
   metadata:
     Qwen/Qwen2.5-72B:
       tool_call_parser_name: hermes
+  model_display_name: Qwen2.5-72B
+- weights:
+    - Qwen/Qwen2.5-72B-Instruct
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 13f44c5
+  vllm_commit: 0edd242
+  inference_engine: VLLM
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 66000000
+  status: FUNCTIONAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+    MAX_PREFILL_CHUNK_SIZE: "16"
+  metadata:
     Qwen/Qwen2.5-72B-Instruct:
       tool_call_parser_name: hermes
+  model_display_name: Qwen2.5-72B
+- weights:
+    - Qwen/Qwen2.5-72B-Instruct
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 13f44c5
+  vllm_commit: 0edd242
+  inference_engine: VLLM
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 128      # 32 * 4
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 66000000
+      env_vars:
+        TT_MM_THROTTLE_PERF: 5
+  status: FUNCTIONAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+    MAX_PREFILL_CHUNK_SIZE: "16"
+  metadata:
+    Qwen/Qwen2.5-72B-Instruct:
+      tool_call_parser_name: hermes
+  model_display_name: Qwen2.5-72B
+- weights:
+    - Qwen/Qwen2.5-72B-Instruct
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 13f44c5
+  vllm_commit: 0edd242
+  inference_engine: VLLM
+  device_model_specs:
+    - device: GALAXY_T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 40000000
+        fabric_config: FABRIC_1D
+      env_vars:
+        TT_MM_THROTTLE_PERF: 5
+        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
+  status: FUNCTIONAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+    MAX_PREFILL_CHUNK_SIZE: "16"
+  metadata:
+    Qwen/Qwen2.5-72B-Instruct:
+      tool_call_parser_name: hermes
+  model_display_name: Qwen2.5-72B
 
 - weights:
     - Qwen/Qwen2.5-7B
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 5b5db8a
+  vllm_commit: e771fff
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N300
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      override_tt_config:
+        trace_region_size: 60000000
+  status: EXPERIMENTAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    Qwen/Qwen2.5-7B:
+      tool_call_parser_name: hermes
+  model_display_name: Qwen2.5-7B
+- weights:
+    - Qwen/Qwen2.5-7B
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 5b5db8a
+  vllm_commit: e771fff
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N150X4
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+  status: EXPERIMENTAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    Qwen/Qwen2.5-7B:
+      tool_call_parser_name: hermes
+  model_display_name: Qwen2.5-7B
+- weights:
     - Qwen/Qwen2.5-7B-Instruct
   impl: tt_transformers
   version: "0.9.0"
@@ -458,28 +800,39 @@ templates:
   device_model_specs:
     - device: N300
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 60000000
+  status: EXPERIMENTAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    Qwen/Qwen2.5-7B-Instruct:
+      tool_call_parser_name: hermes
+  model_display_name: Qwen2.5-7B
+- weights:
+    - Qwen/Qwen2.5-7B-Instruct
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 5b5db8a
+  vllm_commit: e771fff
+  inference_engine: VLLM
+  device_model_specs:
     - device: N150X4
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
   status: EXPERIMENTAL
   env_vars:
     VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
   metadata:
-    Qwen/Qwen2.5-7B:
-      tool_call_parser_name: hermes
     Qwen/Qwen2.5-7B-Instruct:
       tool_call_parser_name: hermes
+  model_display_name: Qwen2.5-7B
 
 - weights:
     - meta-llama/Llama-3.3-70B-Instruct
-    - meta-llama/Llama-3.1-70B
-    - meta-llama/Llama-3.1-70B-Instruct
-    - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
   impl: llama3_70b_galaxy
   version: "0.10.0"
   tt_metal_commit: e867533
@@ -487,8 +840,8 @@ templates:
   inference_engine: VLLM
   device_model_specs:
     - device: GALAXY
-      max_concurrency: 32  # 8 * 4
-      max_context: 131072  # 128 * 1024
+      max_concurrency: 32      # 8 * 4
+      max_context: 131072      # 128 * 1024
       default_impl: true
       tensor_cache_timeout: 5400.0
       vllm_args:
@@ -511,13 +864,110 @@ templates:
   metadata:
     meta-llama/Llama-3.3-70B-Instruct:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
+    - meta-llama/Llama-3.1-70B
+  impl: llama3_70b_galaxy
+  version: "0.10.0"
+  tt_metal_commit: e867533
+  vllm_commit: 8f36910
+  inference_engine: VLLM
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 32      # 8 * 4
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      vllm_args:
+        data_parallel_size: 4
+      override_tt_config:
+        dispatch_core_axis: col
+        sample_on_device_mode: all
+        fabric_config: FABRIC_1D_RING
+        worker_l1_size: 1344544
+        trace_region_size: 215000000
+  system_requirements:
+    firmware:
+      specifier: ">=18.6.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.1.0"
+      mode: STRICT
+  status: COMPLETE
+  has_builtin_warmup: true
+  metadata:
     meta-llama/Llama-3.1-70B:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
+    - meta-llama/Llama-3.1-70B-Instruct
+  impl: llama3_70b_galaxy
+  version: "0.10.0"
+  tt_metal_commit: e867533
+  vllm_commit: 8f36910
+  inference_engine: VLLM
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 32      # 8 * 4
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      vllm_args:
+        data_parallel_size: 4
+      override_tt_config:
+        dispatch_core_axis: col
+        sample_on_device_mode: all
+        fabric_config: FABRIC_1D_RING
+        worker_l1_size: 1344544
+        trace_region_size: 215000000
+  system_requirements:
+    firmware:
+      specifier: ">=18.6.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.1.0"
+      mode: STRICT
+  status: COMPLETE
+  has_builtin_warmup: true
+  metadata:
     meta-llama/Llama-3.1-70B-Instruct:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
+    - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  impl: llama3_70b_galaxy
+  version: "0.10.0"
+  tt_metal_commit: e867533
+  vllm_commit: 8f36910
+  inference_engine: VLLM
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 32      # 8 * 4
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      vllm_args:
+        data_parallel_size: 4
+      override_tt_config:
+        dispatch_core_axis: col
+        sample_on_device_mode: all
+        fabric_config: FABRIC_1D_RING
+        worker_l1_size: 1344544
+        trace_region_size: 215000000
+  system_requirements:
+    firmware:
+      specifier: ">=18.6.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.1.0"
+      mode: STRICT
+  status: COMPLETE
+  has_builtin_warmup: true
+  metadata:
     deepseek-ai/DeepSeek-R1-Distill-Llama-70B:
       reasoning_parser_name: deepseek_r1
       tool_call_parser_name: deepseek_v3
+  model_display_name: Llama-3.3-70B-Instruct
 
 - weights:
     - deepseek-ai/DeepSeek-R1-0528
@@ -528,14 +978,28 @@ templates:
   inference_engine: VLLM
   device_model_specs:
     - device: GALAXY
-      max_concurrency: 256  # 32 * 8
+      max_concurrency: 256      # 32 * 8
       max_context: 2048
       default_impl: true
       tensor_cache_timeout: 6400.0
       vllm_args:
         max_model_len: "2048"
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+  metadata:
+    deepseek-ai/DeepSeek-R1-0528:
+      reasoning_parser_name: deepseek_r1
+      tool_call_parser_name: deepseek_v3
+- weights:
+    - deepseek-ai/DeepSeek-R1-0528
+  impl: deepseek_r1_galaxy
+  version: "0.12.0"
+  tt_metal_commit: 805f43d
+  vllm_commit: a45c614
+  inference_engine: VLLM
+  device_model_specs:
     - device: DUAL_GALAXY
-      max_concurrency: 256  # 32 * 8; 32 per DP rank * 8 ranks
+      max_concurrency: 256      # 32 * 8; 32 per DP rank * 8 ranks
       max_context: 32768
       default_impl: true
       tensor_cache_timeout: 6400.0
@@ -549,8 +1013,22 @@ templates:
         env_passthrough:
           - DEEPSEEK_V3_CACHE
           - DEEPSEEK_V3_HF_MODEL
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+  metadata:
+    deepseek-ai/DeepSeek-R1-0528:
+      reasoning_parser_name: deepseek_r1
+      tool_call_parser_name: deepseek_v3
+- weights:
+    - deepseek-ai/DeepSeek-R1-0528
+  impl: deepseek_r1_galaxy
+  version: "0.12.0"
+  tt_metal_commit: 805f43d
+  vllm_commit: a45c614
+  inference_engine: VLLM
+  device_model_specs:
     - device: QUAD_GALAXY
-      max_concurrency: 512  # 32 * 16; 32 per DP rank * 16 ranks
+      max_concurrency: 512      # 32 * 16; 32 per DP rank * 16 ranks
       max_context: 32768
       default_impl: true
       vllm_args:
@@ -573,8 +1051,95 @@ templates:
 
 - weights:
     - meta-llama/Llama-3.3-70B-Instruct
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=18.8.0"
+      mode: SUGGESTED
+    kmd:
+      specifier: ">=2.2.0"
+      mode: SUGGESTED
+  version: "0.11.1"
+  tt_metal_commit: 750ca54
+  vllm_commit: 38dee8c
+  inference_engine: VLLM
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 30000000
+      env_vars:
+        MAX_PREFILL_CHUNK_SIZE: "32"
+        VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.3-70B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
     - meta-llama/Llama-3.1-70B
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=18.8.0"
+      mode: SUGGESTED
+    kmd:
+      specifier: ">=2.2.0"
+      mode: SUGGESTED
+  version: "0.11.1"
+  tt_metal_commit: 750ca54
+  vllm_commit: 38dee8c
+  inference_engine: VLLM
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 30000000
+      env_vars:
+        MAX_PREFILL_CHUNK_SIZE: "32"
+        VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.1-70B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
     - meta-llama/Llama-3.1-70B-Instruct
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=18.8.0"
+      mode: SUGGESTED
+    kmd:
+      specifier: ">=2.2.0"
+      mode: SUGGESTED
+  version: "0.11.1"
+  tt_metal_commit: 750ca54
+  vllm_commit: 38dee8c
+  inference_engine: VLLM
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 30000000
+      env_vars:
+        MAX_PREFILL_CHUNK_SIZE: "32"
+        VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.1-70B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
     - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
   impl: tt_transformers
   system_requirements:
@@ -591,7 +1156,7 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       tensor_cache_timeout: 5400.0
       override_tt_config:
@@ -601,21 +1166,13 @@ templates:
         VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
   status: FUNCTIONAL
   metadata:
-    meta-llama/Llama-3.3-70B-Instruct:
-      tool_call_parser_name: llama3_json
-    meta-llama/Llama-3.1-70B:
-      tool_call_parser_name: llama3_json
-    meta-llama/Llama-3.1-70B-Instruct:
-      tool_call_parser_name: llama3_json
     deepseek-ai/DeepSeek-R1-Distill-Llama-70B:
       reasoning_parser_name: deepseek_r1
       tool_call_parser_name: deepseek_v3
+  model_display_name: Llama-3.3-70B-Instruct
 
 - weights:
     - meta-llama/Llama-3.3-70B-Instruct
-    - meta-llama/Llama-3.1-70B
-    - meta-llama/Llama-3.1-70B-Instruct
-    - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
   impl: tt_transformers
   version: "0.10.1"
   tt_metal_commit: 555f240
@@ -624,7 +1181,7 @@ templates:
   device_model_specs:
     - device: P150X4
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       tensor_cache_timeout: 5400.0
       override_tt_config:
@@ -636,9 +1193,22 @@ templates:
         kmd:
           specifier: ">=2.3.0"
           mode: STRICT
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.3-70B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
+    - meta-llama/Llama-3.3-70B-Instruct
+  impl: tt_transformers
+  version: "0.10.1"
+  tt_metal_commit: 555f240
+  vllm_commit: 22be241
+  inference_engine: VLLM
+  device_model_specs:
     - device: P150X8
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       tensor_cache_timeout: 5400.0
       override_tt_config:
@@ -654,18 +1224,278 @@ templates:
   metadata:
     meta-llama/Llama-3.3-70B-Instruct:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
+    - meta-llama/Llama-3.1-70B
+  impl: tt_transformers
+  version: "0.10.1"
+  tt_metal_commit: 555f240
+  vllm_commit: 22be241
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P150X4
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 30000000
+      system_requirements:
+        firmware:
+          specifier: ">=18.5.0"
+          mode: STRICT
+        kmd:
+          specifier: ">=2.3.0"
+          mode: STRICT
+  status: FUNCTIONAL
+  metadata:
     meta-llama/Llama-3.1-70B:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
+    - meta-llama/Llama-3.1-70B
+  impl: tt_transformers
+  version: "0.10.1"
+  tt_metal_commit: 555f240
+  vllm_commit: 22be241
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P150X8
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 268435456
+      system_requirements:
+        firmware:
+          specifier: ">=18.12.0"
+          mode: STRICT
+        kmd:
+          specifier: ">=2.4.1"
+          mode: STRICT
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.1-70B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
+    - meta-llama/Llama-3.1-70B-Instruct
+  impl: tt_transformers
+  version: "0.10.1"
+  tt_metal_commit: 555f240
+  vllm_commit: 22be241
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P150X4
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 30000000
+      system_requirements:
+        firmware:
+          specifier: ">=18.5.0"
+          mode: STRICT
+        kmd:
+          specifier: ">=2.3.0"
+          mode: STRICT
+  status: FUNCTIONAL
+  metadata:
     meta-llama/Llama-3.1-70B-Instruct:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
+    - meta-llama/Llama-3.1-70B-Instruct
+  impl: tt_transformers
+  version: "0.10.1"
+  tt_metal_commit: 555f240
+  vllm_commit: 22be241
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P150X8
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 268435456
+      system_requirements:
+        firmware:
+          specifier: ">=18.12.0"
+          mode: STRICT
+        kmd:
+          specifier: ">=2.4.1"
+          mode: STRICT
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.1-70B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
+    - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  impl: tt_transformers
+  version: "0.10.1"
+  tt_metal_commit: 555f240
+  vllm_commit: 22be241
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P150X4
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 30000000
+      system_requirements:
+        firmware:
+          specifier: ">=18.5.0"
+          mode: STRICT
+        kmd:
+          specifier: ">=2.3.0"
+          mode: STRICT
+  status: FUNCTIONAL
+  metadata:
     deepseek-ai/DeepSeek-R1-Distill-Llama-70B:
       reasoning_parser_name: deepseek_r1
       tool_call_parser_name: deepseek_v3
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
+    - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  impl: tt_transformers
+  version: "0.10.1"
+  tt_metal_commit: 555f240
+  vllm_commit: 22be241
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P150X8
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 268435456
+      system_requirements:
+        firmware:
+          specifier: ">=18.12.0"
+          mode: STRICT
+        kmd:
+          specifier: ">=2.4.1"
+          mode: STRICT
+  status: FUNCTIONAL
+  metadata:
+    deepseek-ai/DeepSeek-R1-Distill-Llama-70B:
+      reasoning_parser_name: deepseek_r1
+      tool_call_parser_name: deepseek_v3
+  model_display_name: Llama-3.3-70B-Instruct
 
 - weights:
     - meta-llama/Llama-3.3-70B-Instruct
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=19.2.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.5.0"
+      mode: STRICT
+  version: "0.16.0"
+  tt_metal_commit: 669d59e
+  vllm_commit: "3334377"
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 402653184      # 384 * 1024 * 1024
+      known_issues:
+        - workflow_type: SPEC_TESTS
+          task_name: test_penalties
+          reason: "test_penalties length-change assertion (server_tests/test_cases/test_vllm_chat_completions.py:289)
+            is over-strict for short, low-repetition prompts decoded near-greedily;
+            presence_penalty=1.2 legitimately produced identical output. Model meets
+            FUNCTIONAL expectations. Tracked in #3888."
+  status: FUNCTIONAL
+  has_builtin_warmup: true
+  metadata:
+    meta-llama/Llama-3.3-70B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
     - meta-llama/Llama-3.1-70B
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=19.2.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.5.0"
+      mode: STRICT
+  version: "0.16.0"
+  tt_metal_commit: 669d59e
+  vllm_commit: "3334377"
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 402653184      # 384 * 1024 * 1024
+      known_issues:
+        - workflow_type: SPEC_TESTS
+          task_name: test_penalties
+          reason: "test_penalties length-change assertion (server_tests/test_cases/test_vllm_chat_completions.py:289)
+            is over-strict for short, low-repetition prompts decoded near-greedily;
+            presence_penalty=1.2 legitimately produced identical output. Model meets
+            FUNCTIONAL expectations. Tracked in #3888."
+  status: FUNCTIONAL
+  has_builtin_warmup: true
+  metadata:
+    meta-llama/Llama-3.1-70B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
     - meta-llama/Llama-3.1-70B-Instruct
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=19.2.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.5.0"
+      mode: STRICT
+  version: "0.16.0"
+  tt_metal_commit: 669d59e
+  vllm_commit: "3334377"
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      override_tt_config:
+        trace_region_size: 402653184      # 384 * 1024 * 1024
+      known_issues:
+        - workflow_type: SPEC_TESTS
+          task_name: test_penalties
+          reason: "test_penalties length-change assertion (server_tests/test_cases/test_vllm_chat_completions.py:289)
+            is over-strict for short, low-repetition prompts decoded near-greedily;
+            presence_penalty=1.2 legitimately produced identical output. Model meets
+            FUNCTIONAL expectations. Tracked in #3888."
+  status: FUNCTIONAL
+  has_builtin_warmup: true
+  metadata:
+    meta-llama/Llama-3.1-70B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
     - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
   impl: tt_transformers
   system_requirements:
@@ -682,32 +1512,123 @@ templates:
   device_model_specs:
     - device: P300X2
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       tensor_cache_timeout: 5400.0
       override_tt_config:
-        trace_region_size: 402653184  # 384 * 1024 * 1024
+        trace_region_size: 402653184      # 384 * 1024 * 1024
       known_issues:
         - workflow_type: SPEC_TESTS
           task_name: test_penalties
-          reason: "test_penalties length-change assertion (server_tests/test_cases/test_vllm_chat_completions.py:289) is over-strict for short, low-repetition prompts decoded near-greedily; presence_penalty=1.2 legitimately produced identical output. Model meets FUNCTIONAL expectations. Tracked in #3888."
+          reason: "test_penalties length-change assertion (server_tests/test_cases/test_vllm_chat_completions.py:289)
+            is over-strict for short, low-repetition prompts decoded near-greedily;
+            presence_penalty=1.2 legitimately produced identical output. Model meets
+            FUNCTIONAL expectations. Tracked in #3888."
   status: FUNCTIONAL
   has_builtin_warmup: true
   metadata:
-    meta-llama/Llama-3.3-70B-Instruct:
-      tool_call_parser_name: llama3_json
-    meta-llama/Llama-3.1-70B:
-      tool_call_parser_name: llama3_json
-    meta-llama/Llama-3.1-70B-Instruct:
-      tool_call_parser_name: llama3_json
     deepseek-ai/DeepSeek-R1-Distill-Llama-70B:
       reasoning_parser_name: deepseek_r1
       tool_call_parser_name: deepseek_v3
+  model_display_name: Llama-3.3-70B-Instruct
 
 - weights:
     - meta-llama/Llama-3.3-70B-Instruct
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=18.6.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.1.0"
+      mode: STRICT
+  version: "0.2.0"
+  tt_metal_commit: v0.62.0-rc33
+  vllm_commit: e7c329b
+  inference_engine: VLLM
+  device_model_specs:
+    - device: GALAXY_T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      env_vars:
+        TT_MM_THROTTLE_PERF: 5
+        MAX_PREFILL_CHUNK_SIZE: "32"
+        VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
+      override_tt_config:
+        fabric_config: FABRIC_1D
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.3-70B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
     - meta-llama/Llama-3.1-70B
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=18.6.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.1.0"
+      mode: STRICT
+  version: "0.2.0"
+  tt_metal_commit: v0.62.0-rc33
+  vllm_commit: e7c329b
+  inference_engine: VLLM
+  device_model_specs:
+    - device: GALAXY_T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      env_vars:
+        TT_MM_THROTTLE_PERF: 5
+        MAX_PREFILL_CHUNK_SIZE: "32"
+        VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
+      override_tt_config:
+        fabric_config: FABRIC_1D
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.1-70B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
     - meta-llama/Llama-3.1-70B-Instruct
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=18.6.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.1.0"
+      mode: STRICT
+  version: "0.2.0"
+  tt_metal_commit: v0.62.0-rc33
+  vllm_commit: e7c329b
+  inference_engine: VLLM
+  device_model_specs:
+    - device: GALAXY_T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      tensor_cache_timeout: 5400.0
+      env_vars:
+        TT_MM_THROTTLE_PERF: 5
+        MAX_PREFILL_CHUNK_SIZE: "32"
+        VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
+      override_tt_config:
+        fabric_config: FABRIC_1D
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.1-70B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.3-70B-Instruct
+- weights:
     - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
   impl: tt_transformers
   system_requirements:
@@ -724,7 +1645,7 @@ templates:
   device_model_specs:
     - device: GALAXY_T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       tensor_cache_timeout: 5400.0
       env_vars:
@@ -736,18 +1657,72 @@ templates:
         fabric_config: FABRIC_1D
   status: FUNCTIONAL
   metadata:
-    meta-llama/Llama-3.3-70B-Instruct:
-      tool_call_parser_name: llama3_json
-    meta-llama/Llama-3.1-70B:
-      tool_call_parser_name: llama3_json
-    meta-llama/Llama-3.1-70B-Instruct:
-      tool_call_parser_name: llama3_json
     deepseek-ai/DeepSeek-R1-Distill-Llama-70B:
       reasoning_parser_name: deepseek_r1
       tool_call_parser_name: deepseek_v3
+  model_display_name: Llama-3.3-70B-Instruct
 
 - weights:
     - meta-llama/Llama-3.2-1B
+  impl: tt_transformers
+  version: "0.11.1"
+  tt_metal_commit: 84b4c53
+  vllm_commit: 222ee06
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N150
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  status: FUNCTIONAL
+  has_builtin_warmup: true
+  metadata:
+    meta-llama/Llama-3.2-1B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.2-1B
+- weights:
+    - meta-llama/Llama-3.2-1B
+  impl: tt_transformers
+  version: "0.11.1"
+  tt_metal_commit: 84b4c53
+  vllm_commit: 222ee06
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N300
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  status: FUNCTIONAL
+  has_builtin_warmup: true
+  metadata:
+    meta-llama/Llama-3.2-1B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.2-1B
+- weights:
+    - meta-llama/Llama-3.2-1B
+  impl: tt_transformers
+  version: "0.11.1"
+  tt_metal_commit: 84b4c53
+  vllm_commit: 222ee06
+  inference_engine: VLLM
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  status: FUNCTIONAL
+  has_builtin_warmup: true
+  metadata:
+    meta-llama/Llama-3.2-1B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.2-1B
+- weights:
     - meta-llama/Llama-3.2-1B-Instruct
   impl: tt_transformers
   version: "0.11.1"
@@ -757,28 +1732,111 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
-      default_impl: true
-    - device: N300
-      max_concurrency: 32
-      max_context: 131072  # 128 * 1024
-      default_impl: true
-    - device: T3K
-      max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
   env_vars:
     VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
   status: FUNCTIONAL
   has_builtin_warmup: true
   metadata:
-    meta-llama/Llama-3.2-1B:
-      tool_call_parser_name: llama3_json
     meta-llama/Llama-3.2-1B-Instruct:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.2-1B
+- weights:
+    - meta-llama/Llama-3.2-1B-Instruct
+  impl: tt_transformers
+  version: "0.11.1"
+  tt_metal_commit: 84b4c53
+  vllm_commit: 222ee06
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N300
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  status: FUNCTIONAL
+  has_builtin_warmup: true
+  metadata:
+    meta-llama/Llama-3.2-1B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.2-1B
+- weights:
+    - meta-llama/Llama-3.2-1B-Instruct
+  impl: tt_transformers
+  version: "0.11.1"
+  tt_metal_commit: 84b4c53
+  vllm_commit: 222ee06
+  inference_engine: VLLM
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  status: FUNCTIONAL
+  has_builtin_warmup: true
+  metadata:
+    meta-llama/Llama-3.2-1B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.2-1B
 
 - weights:
     - meta-llama/Llama-3.2-3B
+  impl: tt_transformers
+  version: "0.3.0"
+  tt_metal_commit: 20edc39
+  vllm_commit: 03cb300
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N150
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      override_tt_config:
+        trace_region_size: 10000000
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.2-3B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.2-3B
+- weights:
+    - meta-llama/Llama-3.2-3B
+  impl: tt_transformers
+  version: "0.3.0"
+  tt_metal_commit: 20edc39
+  vllm_commit: 03cb300
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N300
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.2-3B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.2-3B
+- weights:
+    - meta-llama/Llama-3.2-3B
+  impl: tt_transformers
+  version: "0.3.0"
+  tt_metal_commit: 20edc39
+  vllm_commit: 03cb300
+  inference_engine: VLLM
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.2-3B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.2-3B
+- weights:
     - meta-llama/Llama-3.2-3B-Instruct
   impl: tt_transformers
   version: "0.3.0"
@@ -788,27 +1846,125 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 10000000
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.2-3B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.2-3B
+- weights:
+    - meta-llama/Llama-3.2-3B-Instruct
+  impl: tt_transformers
+  version: "0.3.0"
+  tt_metal_commit: 20edc39
+  vllm_commit: 03cb300
+  inference_engine: VLLM
+  device_model_specs:
     - device: N300
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
-      default_impl: true
-    - device: T3K
-      max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
   status: FUNCTIONAL
   metadata:
-    meta-llama/Llama-3.2-3B:
-      tool_call_parser_name: llama3_json
     meta-llama/Llama-3.2-3B-Instruct:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.2-3B
+- weights:
+    - meta-llama/Llama-3.2-3B-Instruct
+  impl: tt_transformers
+  version: "0.3.0"
+  tt_metal_commit: 20edc39
+  vllm_commit: 03cb300
+  inference_engine: VLLM
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.2-3B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.2-3B
 
 - weights:
     - meta-llama/Llama-3.1-8B
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 25305db
+  vllm_commit: 6e67d2d
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N150
+      max_concurrency: 32
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+      override_tt_config:
+        trace_region_size: 52000000
+  status: COMPLETE
+  metadata:
+    meta-llama/Llama-3.1-8B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 25305db
+  vllm_commit: 6e67d2d
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N300
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      override_tt_config:
+        trace_region_size: 70000000
+  status: COMPLETE
+  metadata:
+    meta-llama/Llama-3.1-8B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 25305db
+  vllm_commit: 6e67d2d
+  inference_engine: VLLM
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      override_tt_config:
+        trace_region_size: 117000000
+  status: COMPLETE
+  metadata:
+    meta-llama/Llama-3.1-8B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 25305db
+  vllm_commit: 6e67d2d
+  inference_engine: VLLM
+  device_model_specs:
+    - device: GPU
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+  status: COMPLETE
+  metadata:
+    meta-llama/Llama-3.1-8B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
     - meta-llama/Llama-3.1-8B-Instruct
   impl: tt_transformers
   version: "0.9.0"
@@ -818,36 +1974,73 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 32
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 52000000
+  status: COMPLETE
+  metadata:
+    meta-llama/Llama-3.1-8B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B-Instruct
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 25305db
+  vllm_commit: 6e67d2d
+  inference_engine: VLLM
+  device_model_specs:
     - device: N300
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 70000000
+  status: COMPLETE
+  metadata:
+    meta-llama/Llama-3.1-8B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B-Instruct
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 25305db
+  vllm_commit: 6e67d2d
+  inference_engine: VLLM
+  device_model_specs:
     - device: T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 117000000
+  status: COMPLETE
+  metadata:
+    meta-llama/Llama-3.1-8B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B-Instruct
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 25305db
+  vllm_commit: 6e67d2d
+  inference_engine: VLLM
+  device_model_specs:
     - device: GPU
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
   status: COMPLETE
   metadata:
-    meta-llama/Llama-3.1-8B:
-      tool_call_parser_name: llama3_json
     meta-llama/Llama-3.1-8B-Instruct:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
 
 - weights:
     - meta-llama/Llama-3.1-8B
-    - meta-llama/Llama-3.1-8B-Instruct
   version: "0.18.0"
   tt_metal_commit: "c49bb76"
   vllm_commit: "6b4a3a7"
@@ -856,16 +2049,29 @@ templates:
   device_model_specs:
     - device: P100
       max_concurrency: 32
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 90000000
+  status: EXPERIMENTAL
+  metadata:
+    meta-llama/Llama-3.1-8B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B
+  version: "0.18.0"
+  tt_metal_commit: "c49bb76"
+  vllm_commit: "6b4a3a7"
+  impl: tt_transformers
+  inference_engine: VLLM
+  device_model_specs:
     - device: P150
       max_concurrency: 32
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       override_tt_config:
-        trace_region_size: 900000000  # match P100 (single BH chip); 50MB default too small for prefill trace (#4005)
+        trace_region_size: 900000000      # match P100 (single BH chip); 50MB default too small for prefill trace (#4005)
       known_issues:
         - workflow_type: EVALS
           task_name: meta_ifeval
@@ -875,23 +2081,87 @@ templates:
           reason: "meta_gpqa_cot measured scores flakily pass the >=95% threshold https://github.com/tenstorrent/tt-inference-server/issues/4360#issuecomment-4799932610."
         - workflow_type: EVALS
           task_name: longbench_fewshot_e
-          reason: "longbench_fewshot_e known issue with longbench code sub-task where the chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121. Masked due to other longbench subtasks passing."
+          reason: "longbench_fewshot_e known issue with longbench code sub-task where
+            the chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
         - workflow_type: EVALS
           task_name: longbench_summarization_e
-          reason: "longbench_summarization_e measured score is ~94% which does not satisfy the >=95% threshold  https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121. Masked due to other longbench subtasks passing."
+          reason: "longbench_summarization_e measured score is ~94% which does not satisfy
+            the >=95% threshold  https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
         - workflow_type: EVALS
           task_name: longbench_code_e
-          reason: "longbench_code_e known issue with longbench code sub-task where the chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121. Masked due to other longbench subtasks passing."
+          reason: "longbench_code_e known issue with longbench code sub-task where the
+            chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
   status: EXPERIMENTAL
   metadata:
     meta-llama/Llama-3.1-8B:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B-Instruct
+  version: "0.18.0"
+  tt_metal_commit: "c49bb76"
+  vllm_commit: "6b4a3a7"
+  impl: tt_transformers
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P100
+      max_concurrency: 32
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+      override_tt_config:
+        trace_region_size: 90000000
+  status: EXPERIMENTAL
+  metadata:
     meta-llama/Llama-3.1-8B-Instruct:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B-Instruct
+  version: "0.18.0"
+  tt_metal_commit: "c49bb76"
+  vllm_commit: "6b4a3a7"
+  impl: tt_transformers
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P150
+      max_concurrency: 32
+      max_context: 65536      # 64 * 1024
+      default_impl: true
+      override_tt_config:
+        trace_region_size: 900000000      # match P100 (single BH chip); 50MB default too small for prefill trace (#4005)
+      known_issues:
+        - workflow_type: EVALS
+          task_name: meta_ifeval
+          reason: "meta_ifeval measured scores flakily pass the >=95% threshold https://github.com/tenstorrent/tt-inference-server/issues/4360#issuecomment-4799932610."
+        - workflow_type: EVALS
+          task_name: meta_gpqa_cot
+          reason: "meta_gpqa_cot measured scores flakily pass the >=95% threshold https://github.com/tenstorrent/tt-inference-server/issues/4360#issuecomment-4799932610."
+        - workflow_type: EVALS
+          task_name: longbench_fewshot_e
+          reason: "longbench_fewshot_e known issue with longbench code sub-task where
+            the chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
+        - workflow_type: EVALS
+          task_name: longbench_summarization_e
+          reason: "longbench_summarization_e measured score is ~94% which does not satisfy
+            the >=95% threshold  https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
+        - workflow_type: EVALS
+          task_name: longbench_code_e
+          reason: "longbench_code_e known issue with longbench code sub-task where the
+            chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
+  status: EXPERIMENTAL
+  metadata:
+    meta-llama/Llama-3.1-8B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
 
 - weights:
     - meta-llama/Llama-3.1-8B
-    - meta-llama/Llama-3.1-8B-Instruct
   impl: tt_transformers
   version: "0.10.0"
   tt_metal_commit: 55fd115
@@ -899,8 +2169,8 @@ templates:
   inference_engine: VLLM
   device_model_specs:
     - device: P150X4
-      max_concurrency: 128  # 32 * 4
-      max_context: 131072  # 128 * 1024
+      max_concurrency: 128      # 32 * 4
+      max_context: 131072      # 128 * 1024
       default_impl: true
       override_tt_config:
         sample_on_device_mode: decode_only
@@ -909,11 +2179,57 @@ templates:
   metadata:
     meta-llama/Llama-3.1-8B:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B-Instruct
+  impl: tt_transformers
+  version: "0.10.0"
+  tt_metal_commit: 55fd115
+  vllm_commit: aa4ae1e
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P150X4
+      max_concurrency: 128      # 32 * 4
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      override_tt_config:
+        sample_on_device_mode: decode_only
+        trace_region_size: 70000000
+  status: COMPLETE
+  metadata:
     meta-llama/Llama-3.1-8B-Instruct:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
 
 - weights:
     - meta-llama/Llama-3.1-8B
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=18.12.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.4.1"
+      mode: STRICT
+  version: "0.10.1"
+  tt_metal_commit: 555f240
+  vllm_commit: 22be241
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P150X8
+      max_concurrency: 256      # 32 * 8
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      vllm_args:
+        data_parallel_size: 8
+      override_tt_config:
+        sample_on_device_mode: decode_only
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.1-8B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
     - meta-llama/Llama-3.1-8B-Instruct
   impl: tt_transformers
   system_requirements:
@@ -929,8 +2245,8 @@ templates:
   inference_engine: VLLM
   device_model_specs:
     - device: P150X8
-      max_concurrency: 256  # 32 * 8
-      max_context: 131072  # 128 * 1024
+      max_concurrency: 256      # 32 * 8
+      max_context: 131072      # 128 * 1024
       default_impl: true
       vllm_args:
         data_parallel_size: 8
@@ -938,13 +2254,111 @@ templates:
         sample_on_device_mode: decode_only
   status: FUNCTIONAL
   metadata:
-    meta-llama/Llama-3.1-8B:
-      tool_call_parser_name: llama3_json
     meta-llama/Llama-3.1-8B-Instruct:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
 
 - weights:
     - meta-llama/Llama-3.1-8B
+  version: "0.19.0"
+  tt_metal_commit: "b204341"
+  vllm_commit: "9bd099c"
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=19.2.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.5.0"
+      mode: STRICT
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      override_tt_config:
+        sample_on_device_mode: decode_only
+        trace_region_size: 155000000
+      known_issues:
+        - workflow_type: EVALS
+          task_name: meta_ifeval
+          reason: "meta_ifeval measured scores flakily pass the >=95% threshold https://github.com/tenstorrent/tt-inference-server/issues/4360#issuecomment-4799932610."
+        - workflow_type: EVALS
+          task_name: meta_gpqa_cot
+          reason: "meta_gpqa_cot measured scores flakily pass the >=95% threshold https://github.com/tenstorrent/tt-inference-server/issues/4360#issuecomment-4799932610."
+        - workflow_type: EVALS
+          task_name: longbench_code_e
+          reason: "longbench_code_e known issue with longbench code sub-task where the
+            chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
+        - workflow_type: EVALS
+          task_name: longbench_fewshot_e
+          reason: "longbench_fewshot_e known issue with longbench code sub-task where
+            the chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
+        - workflow_type: EVALS
+          task_name: longbench_summarization_e
+          reason: "longbench_summarization_e measured score is ~94% which does not satisfy
+            the >=95% threshold  https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.1-8B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B
+  version: "0.19.0"
+  tt_metal_commit: "b204341"
+  vllm_commit: "9bd099c"
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=19.2.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.5.0"
+      mode: STRICT
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P300
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      env_vars:
+        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto"
+      override_tt_config:
+        sample_on_device_mode: decode_only
+        trace_region_size: 56000000
+      known_issues:
+        - workflow_type: EVALS
+          task_name: meta_ifeval
+          reason: "meta_ifeval measured scores flakily pass the >=95% threshold https://github.com/tenstorrent/tt-inference-server/issues/4360#issuecomment-4799932610."
+        - workflow_type: EVALS
+          task_name: meta_gpqa_cot
+          reason: "meta_gpqa_cot measured scores flakily pass the >=95% threshold https://github.com/tenstorrent/tt-inference-server/issues/4360#issuecomment-4799932610."
+        - workflow_type: EVALS
+          task_name: longbench_code_e
+          reason: "longbench_code_e known issue with longbench code sub-task where the
+            chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
+        - workflow_type: EVALS
+          task_name: longbench_fewshot_e
+          reason: "longbench_fewshot_e known issue with longbench code sub-task where
+            the chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
+        - workflow_type: EVALS
+          task_name: longbench_summarization_e
+          reason: "longbench_summarization_e measured score is ~94% which does not satisfy
+            the >=95% threshold  https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.1-8B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
     - meta-llama/Llama-3.1-8B-Instruct
   version: "0.19.0"
   tt_metal_commit: "b204341"
@@ -961,7 +2375,7 @@ templates:
   device_model_specs:
     - device: P300X2
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       override_tt_config:
         sample_on_device_mode: decode_only
@@ -975,16 +2389,42 @@ templates:
           reason: "meta_gpqa_cot measured scores flakily pass the >=95% threshold https://github.com/tenstorrent/tt-inference-server/issues/4360#issuecomment-4799932610."
         - workflow_type: EVALS
           task_name: longbench_code_e
-          reason: "longbench_code_e known issue with longbench code sub-task where the chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121. Masked due to other longbench subtasks passing."
+          reason: "longbench_code_e known issue with longbench code sub-task where the
+            chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
         - workflow_type: EVALS
           task_name: longbench_fewshot_e
-          reason: "longbench_fewshot_e known issue with longbench code sub-task where the chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121. Masked due to other longbench subtasks passing."
+          reason: "longbench_fewshot_e known issue with longbench code sub-task where
+            the chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
         - workflow_type: EVALS
           task_name: longbench_summarization_e
-          reason: "longbench_summarization_e measured score is ~94% which does not satisfy the >=95% threshold  https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121. Masked due to other longbench subtasks passing."
+          reason: "longbench_summarization_e measured score is ~94% which does not satisfy
+            the >=95% threshold  https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
+  status: FUNCTIONAL
+  metadata:
+    meta-llama/Llama-3.1-8B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B-Instruct
+  version: "0.19.0"
+  tt_metal_commit: "b204341"
+  vllm_commit: "9bd099c"
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=19.2.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.5.0"
+      mode: STRICT
+  inference_engine: VLLM
+  device_model_specs:
     - device: P300
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       env_vars:
         TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto"
@@ -1000,23 +2440,27 @@ templates:
           reason: "meta_gpqa_cot measured scores flakily pass the >=95% threshold https://github.com/tenstorrent/tt-inference-server/issues/4360#issuecomment-4799932610."
         - workflow_type: EVALS
           task_name: longbench_code_e
-          reason: "longbench_code_e known issue with longbench code sub-task where the chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121. Masked due to other longbench subtasks passing."
+          reason: "longbench_code_e known issue with longbench code sub-task where the
+            chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
         - workflow_type: EVALS
           task_name: longbench_fewshot_e
-          reason: "longbench_fewshot_e known issue with longbench code sub-task where the chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121. Masked due to other longbench subtasks passing."
+          reason: "longbench_fewshot_e known issue with longbench code sub-task where
+            the chat templating interferes with prompt templating https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
         - workflow_type: EVALS
           task_name: longbench_summarization_e
-          reason: "longbench_summarization_e measured score is ~94% which does not satisfy the >=95% threshold  https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121. Masked due to other longbench subtasks passing."
+          reason: "longbench_summarization_e measured score is ~94% which does not satisfy
+            the >=95% threshold  https://github.com/tenstorrent/tt-inference-server/issues/4002#issuecomment-4708954121.
+            Masked due to other longbench subtasks passing."
   status: FUNCTIONAL
   metadata:
-    meta-llama/Llama-3.1-8B:
-      tool_call_parser_name: llama3_json
     meta-llama/Llama-3.1-8B-Instruct:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
 
 - weights:
     - meta-llama/Llama-3.1-8B
-    - meta-llama/Llama-3.1-8B-Instruct
   impl: tt_transformers
   version: "0.11.1"
   tt_metal_commit: bac8b34
@@ -1024,8 +2468,8 @@ templates:
   inference_engine: VLLM
   device_model_specs:
     - device: GALAXY
-      max_concurrency: 128  # 32 * 4
-      max_context: 131072  # 128 * 1024
+      max_concurrency: 128      # 32 * 4
+      max_context: 131072      # 128 * 1024
       default_impl: true
       vllm_args:
         data_parallel_size: 4
@@ -1034,9 +2478,30 @@ templates:
         sample_on_device_mode: all
       env_vars:
         TT_MM_THROTTLE_PERF: 5
+  system_requirements:
+    firmware:
+      specifier: ">=18.6.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.1.0"
+      mode: STRICT
+  status: FUNCTIONAL
+  has_builtin_warmup: true
+  metadata:
+    meta-llama/Llama-3.1-8B:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B
+  impl: tt_transformers
+  version: "0.11.1"
+  tt_metal_commit: bac8b34
+  vllm_commit: 7c6685a
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY_T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       env_vars:
         trace_region_size: 50000000
@@ -1056,8 +2521,70 @@ templates:
   metadata:
     meta-llama/Llama-3.1-8B:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B-Instruct
+  impl: tt_transformers
+  version: "0.11.1"
+  tt_metal_commit: bac8b34
+  vllm_commit: 7c6685a
+  inference_engine: VLLM
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 128      # 32 * 4
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      vllm_args:
+        data_parallel_size: 4
+      override_tt_config:
+        trace_region_size: 50000000
+        sample_on_device_mode: all
+      env_vars:
+        TT_MM_THROTTLE_PERF: 5
+  system_requirements:
+    firmware:
+      specifier: ">=18.6.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.1.0"
+      mode: STRICT
+  status: FUNCTIONAL
+  has_builtin_warmup: true
+  metadata:
     meta-llama/Llama-3.1-8B-Instruct:
       tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
+- weights:
+    - meta-llama/Llama-3.1-8B-Instruct
+  impl: tt_transformers
+  version: "0.11.1"
+  tt_metal_commit: bac8b34
+  vllm_commit: 7c6685a
+  inference_engine: VLLM
+  device_model_specs:
+    - device: GALAXY_T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      env_vars:
+        trace_region_size: 50000000
+        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
+        TT_MM_THROTTLE_PERF: 5
+      override_tt_config:
+        fabric_config: FABRIC_1D
+  system_requirements:
+    firmware:
+      specifier: ">=18.6.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.1.0"
+      mode: STRICT
+  status: FUNCTIONAL
+  has_builtin_warmup: true
+  metadata:
+    meta-llama/Llama-3.1-8B-Instruct:
+      tool_call_parser_name: llama3_json
+  model_display_name: Llama-3.1-8B
 
 - weights:
     - Qwen/Qwen2.5-Coder-32B-Instruct
@@ -1069,13 +2596,27 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 56000000
+  status: EXPERIMENTAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    Qwen/Qwen2.5-Coder-32B-Instruct:
+      tool_call_parser_name: hermes
+- weights:
+    - Qwen/Qwen2.5-Coder-32B-Instruct
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 17a5973
+  vllm_commit: aa4ae1e
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY_T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       env_vars:
         TT_MM_THROTTLE_PERF: 5
@@ -1098,7 +2639,7 @@ templates:
   device_model_specs:
     - device: P300X2
       max_concurrency: 1
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       tensor_cache_timeout: 5400.0
       env_vars:
@@ -1110,10 +2651,14 @@ templates:
       known_issues:
         - workflow_type: EVALS
           task_name: aime25
-          reason: "Model implementation is producing non-deterministic outputs causing this eval task to pass/fail flakily. Masking this part of the acceptance criteria due to other evals passing consistently."
+          reason: "Model implementation is producing non-deterministic outputs causing
+            this eval task to pass/fail flakily. Masking this part of the acceptance
+            criteria due to other evals passing consistently."
         - workflow_type: EVALS
           task_name: gpqa_diamond_cot_zeroshot
-          reason: "Model implementation is producing non-deterministic outputs causing this eval task to pass/fail flakily. Masking this part of the acceptance criteria due to other evals passing consistently."
+          reason: "Model implementation is producing non-deterministic outputs causing
+            this eval task to pass/fail flakily. Masking this part of the acceptance
+            criteria due to other evals passing consistently."
   status: EXPERIMENTAL
   has_builtin_warmup: true
   env_vars:
@@ -1128,55 +2673,55 @@ templates:
   tt_metal_commit: "c49bb76"
   vllm_commit: "6b4a3a7"
   impl: tt_transformers
-  # Dev specs omit tt_metal_commit/vllm_commit (base ModelSpecTemplate rejects
-  # them; only prod specs carry commits). The image is supplied at runtime via
-  # --override-docker-image; the prod gemma4 specs pin the build commits.
+      # Dev specs omit tt_metal_commit/vllm_commit (base ModelSpecTemplate rejects
+      # them; only prod specs carry commits). The image is supplied at runtime via
+      # --override-docker-image; the prod gemma4 specs pin the build commits.
   inference_engine: VLLM
   device_model_specs:
-    - device: P300X2  # QB2 (2x P300, 4-chip TP mesh)
+    - device: P300X2      # QB2 (2x P300, 4-chip TP mesh)
       max_concurrency: 1
-      # Hybrid-off DRAM ceiling on QB2: with hybrid KV groups disabled every one
-      # of the 60 layers allocates a full-length KV buffer, so the largest pool
-      # that fits in DRAM (and leaves prefill scratch headroom) is ~49K, not 131K.
-      # Drives max_model_len + max_num_batched_tokens; the matching KV-pool size is
-      # set via GEMMA4_MAX_TOKENS_ALL_USERS below. Servable prompt tops out at the
-      # 32768 power-of-2 prefill bucket (next bucket, 65536, exceeds this pool).
-      max_context: 49152  # 48 * 1024
+          # Hybrid-off DRAM ceiling on QB2: with hybrid KV groups disabled every one
+          # of the 60 layers allocates a full-length KV buffer, so the largest pool
+          # that fits in DRAM (and leaves prefill scratch headroom) is ~49K, not 131K.
+          # Drives max_model_len + max_num_batched_tokens; the matching KV-pool size is
+          # set via GEMMA4_MAX_TOKENS_ALL_USERS below. Servable prompt tops out at the
+          # 32768 power-of-2 prefill bucket (next bucket, 65536, exceeds this pool).
+      max_context: 49152      # 48 * 1024
       default_impl: true
       env_vars:
-        # QB2's 4 Blackhole chips are driven as a P150x4 (1,4) mesh — matches the
-        # passing vLLM nightly [BH-QB-2] Gemma4 entry. The custom p300_x2 descriptor
-        # laid the TP collectives over the wrong fabric links and corrupted decode
-        # logits; the default p150_x4 descriptor (selected from MESH_DEVICE) is correct.
+            # QB2's 4 Blackhole chips are driven as a P150x4 (1,4) mesh — matches the
+            # passing vLLM nightly [BH-QB-2] Gemma4 entry. The custom p300_x2 descriptor
+            # laid the TP collectives over the wrong fabric links and corrupted decode
+            # logits; the default p150_x4 descriptor (selected from MESH_DEVICE) is correct.
         MESH_DEVICE: "P150x4"
         GEMMA4_PAGE_BLOCK_SIZE: "64"
-        # Size the hybrid-off all-user KV pool to fit QB2 DRAM. The container
-        # sizes the pool from Gemma4ForCausalLM.get_max_tokens_all_users, which
-        # honors this env override (value kept here, gated by device + model,
-        # rather than hardcoded in tt-metal).
+            # Size the hybrid-off all-user KV pool to fit QB2 DRAM. The container
+            # sizes the pool from Gemma4ForCausalLM.get_max_tokens_all_users, which
+            # honors this env override (value kept here, gated by device + model,
+            # rather than hardcoded in tt-metal).
         GEMMA4_MAX_TOKENS_ALL_USERS: "49152"
       override_tt_config:
         fabric_config: FABRIC_1D
         trace_region_size: 200000000
-        # On-device decode sampling is required on the TP mesh so token ids
-        # >= 65536 are reachable (host sampling only sees device 0's vocab shard).
+            # On-device decode sampling is required on the TP mesh so token ids
+            # >= 65536 are reachable (host sampling only sees device 0's vocab shard).
         sample_on_device_mode: decode_only
       vllm_args:
-        # Sampling params (temp=1.0 / top_k=64 / top_p=0.95) load from the
-        # model's HF generation_config.json; evals override per-request. No
-        # override_generation_config here -- it would just restate the HF default.
-        # Activate the gemma4 tool_call_parser so tool_choice:"auto" clients
-        # (mini-swe-agent / SWE-Bench) work on a flag-free release run. vLLM
-        # requires --tool-call-parser alongside --enable-auto-tool-choice, so it
-        # is passed explicitly here; the gemma4 parser is registered by the
-        # vllm-tt-plugin entry point (tenstorrent/vllm #431).
+            # Sampling params (temp=1.0 / top_k=64 / top_p=0.95) load from the
+            # model's HF generation_config.json; evals override per-request. No
+            # override_generation_config here -- it would just restate the HF default.
+            # Activate the gemma4 tool_call_parser so tool_choice:"auto" clients
+            # (mini-swe-agent / SWE-Bench) work on a flag-free release run. vLLM
+            # requires --tool-call-parser alongside --enable-auto-tool-choice, so it
+            # is passed explicitly here; the gemma4 parser is registered by the
+            # vllm-tt-plugin entry point (tenstorrent/vllm #431).
         enable-auto-tool-choice: true
         tool-call-parser: gemma4
-        # Enable gemma-4 thinking server-side so the r1_gpqa_diamond /
-        # terminal-bench-2 / swe-bench-verified evals (methodology matched to
-        # tenstorrent/tt-inference-server#4331) get the reasoning channel the
-        # chat template otherwise suppresses (gemma-4 scores ~10pts lower w/o it).
-        # --reasoning-parser separates the thought channel into reasoning_content.
+            # Enable gemma-4 thinking server-side so the r1_gpqa_diamond /
+            # terminal-bench-2 / swe-bench-verified evals (methodology matched to
+            # tenstorrent/tt-inference-server#4331) get the reasoning channel the
+            # chat template otherwise suppresses (gemma-4 scores ~10pts lower w/o it).
+            # --reasoning-parser separates the thought channel into reasoning_content.
         default-chat-template-kwargs: '{"enable_thinking": true}'
         reasoning-parser: gemma4
   status: EXPERIMENTAL
@@ -1186,8 +2731,8 @@ templates:
   metadata:
     google/gemma-4-31B-it:
       reasoning_parser_name: gemma4
-      # tool parser ships in vllm-tt-plugin as of tenstorrent/vllm #431; activated
-      # by enable-auto-tool-choice in vllm_args above.
+          # tool parser ships in vllm-tt-plugin as of tenstorrent/vllm #431; activated
+          # by enable-auto-tool-choice in vllm_args above.
       tool_call_parser_name: gemma4
 - weights:
     - Qwen/Qwen3.6-27B
@@ -1220,6 +2765,23 @@ templates:
         trace_region_size: 1073741824
         l1_small_size: 24576
         sample_on_device_mode: decode_only
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+  metadata:
+    Qwen/Qwen3.6-27B:
+      reasoning_parser_name: qwen3
+      tool_call_parser_name: qwen3_coder
+- weights:
+    - Qwen/Qwen3.6-27B
+  version: "0.20.0"
+  tt_metal_commit: "de59f8a"
+  vllm_commit: "03fa3af"
+  impl: qwen36_blackhole
+  inference_engine: VLLM
+  model_type: LLM
+  supported_modalities:
+    - text
+  device_model_specs:
     - device: P150X8
       max_concurrency: 32
       max_context: 262144

--- a/workflows/model_specs/prod/video.yaml
+++ b/workflows/model_specs/prod/video.yaml
@@ -17,27 +17,71 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+  status: COMPLETE
+- weights:
+    - genmo/mochi-1-preview
+  version: "0.10.0"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 60
+  min_ram_gb: 32
+  model_type: VIDEO
+  inference_engine: MEDIA
+  device_model_specs:
     - device: GALAXY
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+  status: COMPLETE
+- weights:
+    - genmo/mochi-1-preview
+  version: "0.10.0"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 60
+  min_ram_gb: 32
+  model_type: VIDEO
+  inference_engine: MEDIA
+  device_model_specs:
     - device: P150X4
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 30000000
+  status: COMPLETE
+- weights:
+    - genmo/mochi-1-preview
+  version: "0.10.0"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 60
+  min_ram_gb: 32
+  model_type: VIDEO
+  inference_engine: MEDIA
+  device_model_specs:
     - device: P150X8
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 30000000
+  status: COMPLETE
+- weights:
+    - genmo/mochi-1-preview
+  version: "0.10.0"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 60
+  min_ram_gb: 32
+  model_type: VIDEO
+  inference_engine: MEDIA
+  device_model_specs:
     - device: P300X2
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 30000000
@@ -55,15 +99,37 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+  status: COMPLETE
+- weights:
+    - Wan-AI/Wan2.2-T2V-A14B-Diffusers
+  version: "0.10.0"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 60
+  min_ram_gb: 32
+  model_type: VIDEO
+  inference_engine: MEDIA
+  device_model_specs:
     - device: GALAXY
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
+  status: COMPLETE
+- weights:
+    - Wan-AI/Wan2.2-T2V-A14B-Diffusers
+  version: "0.10.0"
+  tt_metal_commit: 555f240
+  impl: tt_transformers
+  min_disk_gb: 60
+  min_ram_gb: 32
+  model_type: VIDEO
+  inference_engine: MEDIA
+  device_model_specs:
     - device: P150X4
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 30000000
@@ -81,7 +147,7 @@ templates:
   device_model_specs:
     - device: P150X8
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 30000000
@@ -101,7 +167,7 @@ templates:
   device_model_specs:
     - device: P300X2
       max_concurrency: 1
-      max_context: 65536  # 64 * 1024
+      max_context: 65536      # 64 * 1024
       default_impl: true
       override_tt_config:
         trace_region_size: 30000000

--- a/workflows/model_specs/prod/vlm.yaml
+++ b/workflows/model_specs/prod/vlm.yaml
@@ -7,7 +7,6 @@ templates:
 # =============================================================================
 - weights:
     - google/gemma-3-4b-it
-    - google/medgemma-4b-it
   impl: tt_transformers
   version: "0.9.0"
   tt_metal_commit: c254ee3
@@ -16,17 +15,7 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
-      default_impl: true
-      vllm_args:
-        limit-mm-per-prompt: '{"image": 10}'
-        mm-processor-cache-gb: 0
-      override_tt_config:
-        l1_small_size: 4096
-        fabric_config: FABRIC_1D
-    - device: N300
-      max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       vllm_args:
         limit-mm-per-prompt: '{"image": 10}'
@@ -40,10 +29,85 @@ templates:
     - text
     - image
   has_builtin_warmup: true
+  model_display_name: gemma-3-4b-it
+- weights:
+    - google/gemma-3-4b-it
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: c254ee3
+  vllm_commit: c4f2327
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N300
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      vllm_args:
+        limit-mm-per-prompt: '{"image": 10}'
+        mm-processor-cache-gb: 0
+      override_tt_config:
+        l1_small_size: 4096
+        fabric_config: FABRIC_1D
+  model_type: VLM
+  status: EXPERIMENTAL
+  supported_modalities:
+    - text
+    - image
+  has_builtin_warmup: true
+  model_display_name: gemma-3-4b-it
+- weights:
+    - google/medgemma-4b-it
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: c254ee3
+  vllm_commit: c4f2327
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N150
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      vllm_args:
+        limit-mm-per-prompt: '{"image": 10}'
+        mm-processor-cache-gb: 0
+      override_tt_config:
+        l1_small_size: 4096
+        fabric_config: FABRIC_1D
+  model_type: VLM
+  status: EXPERIMENTAL
+  supported_modalities:
+    - text
+    - image
+  has_builtin_warmup: true
+  model_display_name: gemma-3-4b-it
+- weights:
+    - google/medgemma-4b-it
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: c254ee3
+  vllm_commit: c4f2327
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N300
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      vllm_args:
+        limit-mm-per-prompt: '{"image": 10}'
+        mm-processor-cache-gb: 0
+      override_tt_config:
+        l1_small_size: 4096
+        fabric_config: FABRIC_1D
+  model_type: VLM
+  status: EXPERIMENTAL
+  supported_modalities:
+    - text
+    - image
+  has_builtin_warmup: true
+  model_display_name: gemma-3-4b-it
 
 - weights:
     - google/gemma-3-27b-it
-    - google/medgemma-27b-it
   impl: tt_transformers
   version: "0.9.0"
   tt_metal_commit: 0b10c51
@@ -52,7 +116,7 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       vllm_args:
         limit-mm-per-prompt: '{"image": 10}'
@@ -61,9 +125,24 @@ templates:
         l1_small_size: 4096
         fabric_config: FABRIC_1D
         sample_on_device_mode: decode_only
+  model_type: VLM
+  status: EXPERIMENTAL
+  supported_modalities:
+    - text
+    - image
+  has_builtin_warmup: true
+  model_display_name: gemma-3-27b-it
+- weights:
+    - google/gemma-3-27b-it
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 0b10c51
+  vllm_commit: 3499ffa
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY_T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       env_vars:
         TT_MM_THROTTLE_PERF: 5
@@ -75,9 +154,24 @@ templates:
         l1_small_size: 4096
         fabric_config: FABRIC_1D
         sample_on_device_mode: decode_only
+  model_type: VLM
+  status: EXPERIMENTAL
+  supported_modalities:
+    - text
+    - image
+  has_builtin_warmup: true
+  model_display_name: gemma-3-27b-it
+- weights:
+    - google/gemma-3-27b-it
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 0b10c51
+  vllm_commit: 3499ffa
+  inference_engine: VLLM
+  device_model_specs:
     - device: GALAXY
-      max_concurrency: 32  # 8 * 4
-      max_context: 131072  # 128 * 1024
+      max_concurrency: 32      # 8 * 4
+      max_context: 131072      # 128 * 1024
       default_impl: true
       env_vars:
         TT_MM_THROTTLE_PERF: 5
@@ -95,6 +189,91 @@ templates:
     - text
     - image
   has_builtin_warmup: true
+  model_display_name: gemma-3-27b-it
+- weights:
+    - google/medgemma-27b-it
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 0b10c51
+  vllm_commit: 3499ffa
+  inference_engine: VLLM
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      vllm_args:
+        limit-mm-per-prompt: '{"image": 10}'
+        mm-processor-cache-gb: 0
+      override_tt_config:
+        l1_small_size: 4096
+        fabric_config: FABRIC_1D
+        sample_on_device_mode: decode_only
+  model_type: VLM
+  status: EXPERIMENTAL
+  supported_modalities:
+    - text
+    - image
+  has_builtin_warmup: true
+  model_display_name: gemma-3-27b-it
+- weights:
+    - google/medgemma-27b-it
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 0b10c51
+  vllm_commit: 3499ffa
+  inference_engine: VLLM
+  device_model_specs:
+    - device: GALAXY_T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      env_vars:
+        TT_MM_THROTTLE_PERF: 5
+        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto"
+      vllm_args:
+        limit-mm-per-prompt: '{"image": 10}'
+        mm-processor-cache-gb: 0
+      override_tt_config:
+        l1_small_size: 4096
+        fabric_config: FABRIC_1D
+        sample_on_device_mode: decode_only
+  model_type: VLM
+  status: EXPERIMENTAL
+  supported_modalities:
+    - text
+    - image
+  has_builtin_warmup: true
+  model_display_name: gemma-3-27b-it
+- weights:
+    - google/medgemma-27b-it
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: 0b10c51
+  vllm_commit: 3499ffa
+  inference_engine: VLLM
+  device_model_specs:
+    - device: GALAXY
+      max_concurrency: 32      # 8 * 4
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      env_vars:
+        TT_MM_THROTTLE_PERF: 5
+      vllm_args:
+        limit-mm-per-prompt: '{"image": 10}'
+        data_parallel_size: 4
+        mm-processor-cache-gb: 0
+      override_tt_config:
+        l1_small_size: 4096
+        fabric_config: FABRIC_1D_RING
+        sample_on_device_mode: decode_only
+  model_type: VLM
+  status: EXPERIMENTAL
+  supported_modalities:
+    - text
+    - image
+  has_builtin_warmup: true
+  model_display_name: gemma-3-27b-it
 
 - weights:
     - Qwen/Qwen3-VL-32B-Instruct
@@ -107,7 +286,7 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       vllm_args:
         mm-processor-cache-gb: 0
@@ -129,11 +308,29 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 32
-      max_context: 32768  # 32 * 1024
+      max_context: 32768      # 32 * 1024
       default_impl: true
+  status: EXPERIMENTAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  supported_modalities:
+    - text
+    - image
+  metadata:
+    Qwen/Qwen2.5-VL-3B-Instruct:
+      tool_call_parser_name: hermes
+- weights:
+    - Qwen/Qwen2.5-VL-3B-Instruct
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: c18569e
+  vllm_commit: b2894d3
+  inference_engine: VLLM
+  model_type: VLM
+  device_model_specs:
     - device: N300
       max_concurrency: 32
-      max_context: 32768  # 32 * 1024
+      max_context: 32768      # 32 * 1024
       default_impl: true
   status: EXPERIMENTAL
   env_vars:
@@ -156,11 +353,29 @@ templates:
   device_model_specs:
     - device: N150
       max_concurrency: 32
-      max_context: 32768  # 32 * 1024
+      max_context: 32768      # 32 * 1024
       default_impl: true
+  status: EXPERIMENTAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  supported_modalities:
+    - text
+    - image
+  metadata:
+    Qwen/Qwen2.5-VL-7B-Instruct:
+      tool_call_parser_name: hermes
+- weights:
+    - Qwen/Qwen2.5-VL-7B-Instruct
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: c18569e
+  vllm_commit: b2894d3
+  inference_engine: VLLM
+  model_type: VLM
+  device_model_specs:
     - device: N300
       max_concurrency: 32
-      max_context: 32768  # 32 * 1024
+      max_context: 32768      # 32 * 1024
       default_impl: true
       vllm_args:
         mm-processor-cache-gb: 0
@@ -187,7 +402,7 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       vllm_args:
         mm-processor-cache-gb: 0
@@ -212,7 +427,7 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       vllm_args:
         mm-processor-cache-gb: 0
@@ -230,6 +445,41 @@ templates:
 
 - weights:
     - meta-llama/Llama-3.2-11B-Vision
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: v0.61.1-rc1
+  vllm_commit: 5cbc982
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N300
+      max_concurrency: 16
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+  model_type: VLM
+  status: FUNCTIONAL
+  supported_modalities:
+    - text
+    - image
+  model_display_name: Llama-3.2-11B-Vision
+- weights:
+    - meta-llama/Llama-3.2-11B-Vision
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: v0.61.1-rc1
+  vllm_commit: 5cbc982
+  inference_engine: VLLM
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 16
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+  model_type: VLM
+  status: FUNCTIONAL
+  supported_modalities:
+    - text
+    - image
+  model_display_name: Llama-3.2-11B-Vision
+- weights:
     - meta-llama/Llama-3.2-11B-Vision-Instruct
   impl: tt_transformers
   version: "0.9.0"
@@ -239,20 +489,54 @@ templates:
   device_model_specs:
     - device: N300
       max_concurrency: 16
-      max_context: 131072  # 128 * 1024
-      default_impl: true
-    - device: T3K
-      max_concurrency: 16
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
   model_type: VLM
   status: FUNCTIONAL
   supported_modalities:
     - text
     - image
+  model_display_name: Llama-3.2-11B-Vision
+- weights:
+    - meta-llama/Llama-3.2-11B-Vision-Instruct
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: v0.61.1-rc1
+  vllm_commit: 5cbc982
+  inference_engine: VLLM
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 16
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+  model_type: VLM
+  status: FUNCTIONAL
+  supported_modalities:
+    - text
+    - image
+  model_display_name: Llama-3.2-11B-Vision
 
 - weights:
     - meta-llama/Llama-3.2-90B-Vision
+  impl: tt_transformers
+  version: "0.9.0"
+  tt_metal_commit: v0.61.1-rc1
+  vllm_commit: 5cbc982
+  inference_engine: VLLM
+  device_model_specs:
+    - device: T3K
+      max_concurrency: 32
+      max_context: 131072      # 128 * 1024
+      default_impl: true
+      env_vars:
+        MAX_PREFILL_CHUNK_SIZE: 16
+  model_type: VLM
+  status: FUNCTIONAL
+  supported_modalities:
+    - text
+    - image
+  model_display_name: Llama-3.2-90B-Vision
+- weights:
     - meta-llama/Llama-3.2-90B-Vision-Instruct
   impl: tt_transformers
   version: "0.9.0"
@@ -262,7 +546,7 @@ templates:
   device_model_specs:
     - device: T3K
       max_concurrency: 32
-      max_context: 131072  # 128 * 1024
+      max_context: 131072      # 128 * 1024
       default_impl: true
       env_vars:
         MAX_PREFILL_CHUNK_SIZE: 16
@@ -271,3 +555,4 @@ templates:
   supported_modalities:
     - text
     - image
+  model_display_name: Llama-3.2-90B-Vision


### PR DESCRIPTION
## Summary

Splits prod catalog entries so that each one describes exactly one runtime leaf:
one weight × one device × one engine × one impl. 75 blocks → 225 entries.

Format migration only — no code changes, no behaviour changes, no data corrections.

## Why

Today a catalog block groups several weights and devices under a single `version`,
`tt_metal_commit`, and `status`. When a release bumps one weight in the block, every
other weight gets the same pin — even ones that were never part of that release and
have no CI entry at all.

Real example: v0.16.0 (#4185) bumped this block in `prod/llm.yaml`:

```diff
 - weights:
     - meta-llama/Llama-3.3-70B-Instruct
     - meta-llama/Llama-3.1-70B
     - meta-llama/Llama-3.1-70B-Instruct
     - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
-  version: "0.10.1"
-  tt_metal_commit: 555f240
+  version: "0.16.0"
+  tt_metal_commit: 669d59e
```

Of those four weights, only `Llama-3.3-70B-Instruct` exists in `models-ci-config.json`.
The other three have no CI entry — no job ever ran for them — and one of them
(`DeepSeek-R1-Distill-Llama-70B`) is a completely different model family. All three were
silently pinned to 0.16.0 on commit `669d59e` and marked FUNCTIONAL with nothing behind
that claim.

This can't be fixed while the format groups them. Once each weight×device×engine×impl
combination is its own entry, we can audit and correct the pins individually. That data
cleanup is a separate follow-up — this PR carries all existing pins as-is so the diff
stays reviewable.