### PR TITLE
Support LG AI Research's EXAONE 4.5

### DIFF
--- a/vllm-tt-metal/extra_models/exaone45/vllm_metadata.json
+++ b/vllm-tt-metal/extra_models/exaone45/vllm_metadata.json
@@ -1,0 +1,4 @@
+{
+    "arch": "Exaone4_5_ForConditionalGeneration",
+    "main_class": "models.tt_transformers.tt.generator_vllm:Exaone4_5_ForConditionalGeneration"
+}

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -378,6 +378,13 @@ def register_tt_models(impl_id=None):
         "models.tt_transformers.tt.generator_vllm:TTArceeForCausalLM",
     )
 
+    # EXAONE-4.5 - Text (the HF checkpoint is multimodal; the TT class serves
+    # its text decoder only — hybrid LLLG sliding/full attention, TP over the mesh)
+    ModelRegistry.register_model(
+        "TTExaone4_5_ForConditionalGeneration",
+        "models.tt_transformers.tt.generator_vllm:Exaone4_5_ForConditionalGeneration",
+    )
+
 
 def model_setup(model_spec_json):
     # step 1: validate env vars passed in

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -636,6 +636,33 @@ templates:
       tool_call_parser_name: hermes
 
 - weights:
+    - LGAI-EXAONE/EXAONE-4.5-33B
+  impl: tt_transformers
+  system_requirements:
+    firmware:
+      specifier: ">=18.12.0"
+      mode: STRICT
+    kmd:
+      specifier: ">=2.4.1"
+      mode: STRICT
+  inference_engine: VLLM
+  model_type: LLM
+  supported_modalities:
+    - text  # vision tower ported (models/demos/exaone45_vl) but not wired through vLLM yet
+  device_model_specs:
+    - device: P150X8
+      max_concurrency: 32
+      # 128K cap: chunked prefill is unsupported on the sliding-window layers;
+      # tt-metal MAX_PREFILL_CHUNK_SIZES declares {"P150x8": 128}.
+      max_context: 131072
+      default_impl: true
+      override_tt_config:
+        trace_region_size: 94371840  # 90 MB, per tt-metal models/model_trace_region_sizes.yaml
+  status: EXPERIMENTAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+
+- weights:
     - Qwen/Qwen3-32B
   impl: tt_transformers
   system_requirements:

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -658,6 +658,14 @@ templates:
       default_impl: true
       override_tt_config:
         trace_region_size: 94371840  # 90 MB, per tt-metal models/model_trace_region_sizes.yaml
+      vllm_args:
+        # EXAONE-4.5 is a reasoning model (thinking on by default in its chat
+        # template) with hermes-style tool calls. Parser names follow LG's
+        # official serve command (github.com/LG-AI-EXAONE/EXAONE-4.5):
+        # --reasoning-parser qwen3 --enable-auto-tool-choice --tool-call-parser hermes
+        reasoning-parser: qwen3
+        enable-auto-tool-choice: true
+        tool-call-parser: hermes
   status: EXPERIMENTAL
   env_vars:
     VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1


### PR DESCRIPTION
This PR implements [EXAONE 4.5](https://huggingface.co/LGAI-EXAONE/EXAONE-4.5-33B) model from LG AI Research.

EXAONE 4.5 is a popular multimodal LLM model used in Korea. Many customers ask for EXAONE 4.5 support, so implementation is needed.

For now, It's 8 * p150 setup with TP=8.

Closes #5022

## What

Serves `LGAI-EXAONE/EXAONE-4.5-33B` (text) on P150X8 / BH LoudBox via the tt_transformers impl, TP=8. Two commits:

1. **Dev-catalog entry** (`7df5f994`) — `workflows/model_specs/dev/llm.yaml`: EXPERIMENTAL, max_concurrency 32, `max_context: 131072` (chunked prefill is unsupported on the model's sliding-window layers, so 128K is the hard cap despite the checkpoint's 262K `max_position_embeddings`), `trace_region_size: 90000000` per tt-metal's `models/model_trace_region_sizes.yaml`. Also registers `TTExaone4_5_ForConditionalGeneration` in `run_vllm_api_server.py::register_tt_models` (same pattern as `TTArceeForCausalLM`).
2. **EXTRA_MODELS_DIR bundle** (`b4238f69`) — the `register_tt_models()` call in the API-server process does **not** propagate to vLLM's spawned EngineCore, so the TT platform plugin rejected the arch at `check_and_update_config`. The plugin's `EXTRA_MODELS_DIR` bundle hook runs inside every process, which is the intended no-source-edit path. Launch with `EXTRA_MODELS_DIR=<repo>/vllm-tt-metal/extra_models`. (`vllm_metadata.json` is force-added past the repo-wide `*.json` ignore.)

## Requires
- tt-metal branch `changh95/exaone45` (≥ `6b601646f26`), which carries the model support and the `Exaone4_5_ForConditionalGeneration` generator_vllm class. (Companion tt-metal PR: tenstorrent/tt-metal#54335.)
- transformers ≥ 5.12.1 (native `exaone4_5`).

## Validated (bare-metal `--local-server`, P150x8)

```bash
EXTRA_MODELS_DIR=$PWD/vllm-tt-metal/extra_models \
python3 run.py --model EXAONE-4.5-33B --tt-device p150x8 --workflow server \
  --local-server --dev-mode --tt-metal-home <tt-metal> --no-auth \
  --skip-system-sw-validation   # KMD 2.9.1-pre trips the STRICT prerelease check
```
- `/health` 200, `/v1/models` lists the model at 128K context
- chat completions (KO/EN) finish with `stop`; 8/8 concurrent requests continuously batched ("Running: 8 reqs")
- upstream vLLM 0.25.1 (source, `VLLM_TARGET_DEVICE=empty`) + tenstorrent/vllm-tt-plugin

## Notes / follow-ups
- `<think>` arrives inline in `content`; a `reasoning_parser` metadata entry can split it out later.
- Eval/benchmark configs (`eval_config.py`, perf reference JSON) not included — gates `--workflow evals/release` only.
- KMD version parser rejects `2.9.1-pre` as a prerelease under STRICT `>=2.4.1`; possibly worth fixing in `run_system_software_validation.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
