### PR TITLE
Add moonshotai/Kimi-K3 model spec and eval configs

### DIFF
--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -991,8 +991,8 @@ _eval_config_list = [
                 task_name="tau3_bench_banking",
                 workflow_venv_type=WorkflowVenvType.EVALS_AGENTIC,
                 score=EvalTaskScore(
-                    published_score=46.0,
-                    published_score_ref="https://artificialanalysis.ai/evaluations/tau3-banking?models=kimi-k3",
+                    published_score=33.4,
+                    published_score_ref="https://huggingface.co/moonshotai/Kimi-K3",
                     gpu_reference_score=27.84,
                     gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/4971#issuecomment-5422026498",
                     score_func=score_task_single_key,

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -1009,7 +1009,7 @@ _eval_config_list = [
                     task_names=["sierra-research/tau3-bench__tau3-banking_knowledge-*"],
                     # A single served instance is shared by the agent,
                     # the simulated user, and the Natural Language verifier.
-                    n_concurrent_trials=46, # 93/2 = 46.5 we round down to 46
+                    n_concurrent_trials=46,  # 93/2 = 46.5 we round down to 46
                     n_attempts=1,
                     n_tasks=97,
                     override_cpus=4,

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -884,6 +884,240 @@ _eval_config_list = [
         ],
     ),
     EvalConfig(
+        hf_model_repo="moonshotai/Kimi-K3",
+        tasks=[
+            EvalTask(
+                task_name="r1_gpqa_diamond",
+                workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
+                max_concurrent=64,
+                # This vLLM server only exposes /v1/chat/completions; the legacy
+                # text /v1/completions endpoint returns 404.
+                use_chat_api=True,
+                # K3 has always-on thinking, so the answer arrives in a separate
+                # reasoning_content field that would otherwise be dropped.
+                capture_reasoning=True,
+                score=EvalTaskScore(
+                    published_score=93.5,
+                    published_score_ref="https://artificialanalysis.ai/evaluations/gpqa-diamond?models=kimi-k3",
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref=None,
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": [
+                            "exact_match,none",
+                        ],
+                        "unit": "percent",
+                    },
+                ),
+                model_kwargs={
+                    "max_length": 256 * 1024,
+                    # Per-request HTTP timeout (lm-eval default 1800s). Long
+                    # reasoning generations on the shared console can exceed
+                    # 30min under load, so allow up to 2h before giving up.
+                    "timeout": 7200,
+                },
+                gen_kwargs={
+                    "max_gen_toks": 256 * 1024,
+                    # https://huggingface.co/moonshotai/Kimi-K3/blob/main/tokenizer_config.json
+                    "until": ["[EOS]"],
+                    "do_sample": "true",
+                    # Moonshot reports single-step benchmarks (GPQA Diamond,
+                    # HLE, vision without tools) at temperature 1.0 / top_p 0.95.
+                    "temperature": 1.0,
+                    "top_p": 0.95,
+                    "stream": "true",
+                },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 0.2,
+                    EvalLimitMode.SMOKE_TEST: 0.01,
+                },
+            ),
+            EvalTask(
+                task_name="terminal_bench_2_1",
+                workflow_venv_type=WorkflowVenvType.EVALS_AGENTIC,
+                score=EvalTaskScore(
+                    # Artificial Analysis runs Terminal-Bench with Terminus 2,
+                    # which is the harness configured below. Moonshot's own
+                    # 88.3 is measured with the Kimi Code harness and is not
+                    # comparable to this run.
+                    published_score=85.0,
+                    published_score_ref="https://artificialanalysis.ai/evaluations/terminalbench-v2-1?models=kimi-k3",
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref=None,
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["accuracy"],
+                        "unit": "percent",
+                    },
+                ),
+                agentic_eval_config=TerminalBenchEvalConfig(
+                    dataset="terminal-bench/terminal-bench-2-1",
+                    agent="terminus-2",
+                    n_concurrent_trials=16,
+                    n_attempts=1,
+                    n_tasks=89,
+                    override_cpus=16,
+                    override_memory_mb=32 * 1024,
+                    agent_timeout_sec=2 * 60 * 60,
+                    agent_kwargs={
+                        "parser_name": "json",
+                        "temperature": 1.0,
+                        "model_info": {
+                            # Half the 1M window: bounds accumulated tool
+                            # history so a looping trial cannot grow into a
+                            # prefill that starves the other 63 trials.
+                            "max_input_tokens": 1024 * 1024,
+                            "max_output_tokens": 256 * 1024,
+                        },
+                        "llm_kwargs": {
+                            # Moonshot evaluates agentic tasks at top_p 1.0.
+                            "top_p": 1.0,
+                            "max_tokens": 256 * 1024,
+                            "timeout": 60 * 60,
+                        },
+                    },
+                    task_names_map={
+                        EvalLimitMode.CI_NIGHTLY: [
+                            "terminal-bench/break-filter-js-from-html",
+                            "terminal-bench/cobol-modernization",
+                            "terminal-bench/compile-compcert",
+                            "terminal-bench/feal-differential-cryptanalysis",
+                            "terminal-bench/qemu-startup",
+                        ],
+                    },
+                ),
+                limit_samples_map={
+                    EvalLimitMode.SMOKE_TEST: 5,
+                },
+            ),
+            EvalTask(
+                task_name="tau3_bench_banking",
+                workflow_venv_type=WorkflowVenvType.EVALS_AGENTIC,
+                score=EvalTaskScore(
+                    published_score=46.0,
+                    published_score_ref="https://artificialanalysis.ai/evaluations/tau3-banking?models=kimi-k3",
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref=None,
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["accuracy"],
+                        "unit": "percent",
+                    },
+                    tolerance=0.10,
+                ),
+                agentic_eval_config=TerminalBenchEvalConfig(
+                    dataset="sierra-research/tau3-bench",
+                    agent="tau3_llm_agent",
+                    agent_import_path="adapters.tau3-bench.tau3_llm_agent:Tau3LLMAgent",
+                    task_names=["sierra-research/tau3-bench__tau3-banking_knowledge-*"],
+                    # A single served instance is shared by the agent,
+                    # the simulated user, and the Natural Language verifier.
+                    n_concurrent_trials=2,
+                    n_attempts=1,
+                    n_tasks=97,
+                    override_cpus=4,
+                    override_memory_mb=8 * 1024,
+                    agent_timeout_sec=3600,
+                    agent_kwargs={
+                        "tau2_trial_index": 0,
+                        "temperature": 1.0,
+                        # The adapter's build_llm_args() sets only temperature,
+                        # so top_p has to be pinned here to reach the agent.
+                        #
+                        # Must stay a JSON *string*: agent_kwargs are written
+                        # verbatim into the harbor config file, and the adapter
+                        # shlex.quotes this value onto the container command
+                        # line, which fails with TypeError on a dict.
+                        "llm_args_json": '{"top_p": 1.0}',
+                        "max_steps": 200,
+                        # Default is 120s; a single reasoning user-sim turn under
+                        # load can exceed that and trip an MCP request timeout.
+                        "tool_timeout_sec": 900,
+                        "read_timeout_sec": 120,
+                    },
+                    # NOTE: values injected here are passed to the Harbor
+                    # container verbatim. Unlike the task.toml env, the
+                    # "${VAR:-default}" template syntax is NOT resolved on this
+                    # path, so use literal values -- a templated model name
+                    # reaches litellm unexpanded and fails with "LLM Provider
+                    # NOT provided". OPENAI_BASE_URL / OPENAI_API_KEY are
+                    # intentionally omitted: the task's docker-compose already
+                    # substitutes those from the launching shell env.
+                    environment_env={
+                        "TAU2_USER_MODEL": "openai/moonshotai/Kimi-K3",
+                    },
+                    verifier_env={
+                        "TAU2_NL_ASSERTIONS_MODEL": "openai/moonshotai/Kimi-K3",
+                    },
+                    task_names_map={
+                        EvalLimitMode.CI_NIGHTLY: [
+                            "sierra-research/tau3-bench__tau3-banking_knowledge-task-001",
+                            "sierra-research/tau3-bench__tau3-banking_knowledge-task-022",
+                            "sierra-research/tau3-bench__tau3-banking_knowledge-task-050",
+                            "sierra-research/tau3-bench__tau3-banking_knowledge-task-075",
+                            "sierra-research/tau3-bench__tau3-banking_knowledge-task-100",
+                        ],
+                    },
+                ),
+                limit_samples_map={
+                    EvalLimitMode.SMOKE_TEST: 3,
+                },
+            ),
+            # Generate-then-answer LongBench v2 (chat API). Stock longbench2 is
+            # multiple_choice/loglikelihood and cannot run on chat-only servers.
+            # This is the long-context sweep for K3's 1M window: samples are
+            # selected from 256K ISL up to the top of the context budget.
+            EvalTask(
+                task_name="longbench2_generate",
+                max_concurrent=16,
+                workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
+                min_context_required=1048576,
+                use_chat_api=True,
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref=None,
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["exact_match,none"],
+                        "unit": "percent",
+                    },
+                ),
+                model_kwargs={
+                    "max_length": 1048576,
+                    "timeout": 7200,
+                },
+                gen_kwargs={
+                    "max_gen_toks": 96 * 1024,
+                    # https://huggingface.co/moonshotai/Kimi-K3/blob/main/tokenizer_config.json
+                    "until": ["[EOS]"],
+                    "do_sample": "true",
+                    "temperature": 1.0,
+                    "top_p": 0.95,
+                    "stream": "true",
+                },
+                # Select samples by input sequence length (ISL). ISL is measured
+                # by tokenizing each sample's context with `pretrained`; only
+                # samples with minimum_isl <= ISL <= maximum_isl are kept.
+                # ISL is measured on the raw context alone, so the ceiling also
+                # has to absorb the chat template, question and instruction
+                # wrapper on top of max_gen_toks (98304) before hitting the
+                # 1048576 window.
+                # Forwarded to the lm-eval fork loader via --metadata.
+                custom_dataset_kwargs={
+                    "minimum_isl": 256 * 1024,  # 256K
+                    "maximum_isl": 900 * 1000,  # 900K (< 1048576 - 96K gen)
+                    "pretrained": "moonshotai/Kimi-K3",
+                    "tokenizer_num_proc": 32,  # pre-process up to 32 samples in parallel
+                },
+                limit_samples_map={
+                    EvalLimitMode.SMOKE_TEST: 0.01,
+                },
+            ),
+        ],
+    ),
+    EvalConfig(
         hf_model_repo="MiniMaxAI/MiniMax-M2.7",
         tasks=[
             EvalTask(

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -899,8 +899,8 @@ _eval_config_list = [
                 score=EvalTaskScore(
                     published_score=93.5,
                     published_score_ref="https://artificialanalysis.ai/evaluations/gpqa-diamond?models=kimi-k3",
-                    gpu_reference_score=None,
-                    gpu_reference_score_ref=None,
+                    gpu_reference_score=91.92,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/4971#issuecomment-5395831460",
                     score_func=score_task_single_key,
                     score_func_kwargs={
                         "result_keys": [
@@ -942,8 +942,8 @@ _eval_config_list = [
                     # comparable to this run.
                     published_score=85.0,
                     published_score_ref="https://artificialanalysis.ai/evaluations/terminalbench-v2-1?models=kimi-k3",
-                    gpu_reference_score=None,
-                    gpu_reference_score_ref=None,
+                    gpu_reference_score=85.39,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/4971#issuecomment-5411123386",
                     score_func=score_task_single_key,
                     score_func_kwargs={
                         "result_keys": ["accuracy"],
@@ -953,7 +953,7 @@ _eval_config_list = [
                 agentic_eval_config=TerminalBenchEvalConfig(
                     dataset="terminal-bench/terminal-bench-2-1",
                     agent="terminus-2",
-                    n_concurrent_trials=16,
+                    n_concurrent_trials=64,
                     n_attempts=1,
                     n_tasks=89,
                     override_cpus=16,
@@ -963,9 +963,6 @@ _eval_config_list = [
                         "parser_name": "json",
                         "temperature": 1.0,
                         "model_info": {
-                            # Half the 1M window: bounds accumulated tool
-                            # history so a looping trial cannot grow into a
-                            # prefill that starves the other 63 trials.
                             "max_input_tokens": 1024 * 1024,
                             "max_output_tokens": 256 * 1024,
                         },
@@ -996,8 +993,8 @@ _eval_config_list = [
                 score=EvalTaskScore(
                     published_score=46.0,
                     published_score_ref="https://artificialanalysis.ai/evaluations/tau3-banking?models=kimi-k3",
-                    gpu_reference_score=None,
-                    gpu_reference_score_ref=None,
+                    gpu_reference_score=27.84,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/4971#issuecomment-5422026498",
                     score_func=score_task_single_key,
                     score_func_kwargs={
                         "result_keys": ["accuracy"],
@@ -1012,7 +1009,7 @@ _eval_config_list = [
                     task_names=["sierra-research/tau3-bench__tau3-banking_knowledge-*"],
                     # A single served instance is shared by the agent,
                     # the simulated user, and the Natural Language verifier.
-                    n_concurrent_trials=2,
+                    n_concurrent_trials=32,
                     n_attempts=1,
                     n_tasks=97,
                     override_cpus=4,
@@ -1069,15 +1066,15 @@ _eval_config_list = [
             # selected from 256K ISL up to the top of the context budget.
             EvalTask(
                 task_name="longbench2_generate",
-                max_concurrent=16,
+                max_concurrent=64,
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 min_context_required=1048576,
                 use_chat_api=True,
                 score=EvalTaskScore(
                     published_score=None,
                     published_score_ref=None,
-                    gpu_reference_score=None,
-                    gpu_reference_score_ref=None,
+                    gpu_reference_score=71.88,
+                    gpu_reference_score_ref="https://github.com/tenstorrent/tt-inference-server/issues/4971#issuecomment-5395831460",
                     score_func=score_task_single_key,
                     score_func_kwargs={
                         "result_keys": ["exact_match,none"],

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -889,7 +889,7 @@ _eval_config_list = [
             EvalTask(
                 task_name="r1_gpqa_diamond",
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
-                max_concurrent=64,
+                max_concurrent=93,
                 # This vLLM server only exposes /v1/chat/completions; the legacy
                 # text /v1/completions endpoint returns 404.
                 use_chat_api=True,
@@ -953,7 +953,7 @@ _eval_config_list = [
                 agentic_eval_config=TerminalBenchEvalConfig(
                     dataset="terminal-bench/terminal-bench-2-1",
                     agent="terminus-2",
-                    n_concurrent_trials=64,
+                    n_concurrent_trials=93,
                     n_attempts=1,
                     n_tasks=89,
                     override_cpus=16,
@@ -1009,7 +1009,7 @@ _eval_config_list = [
                     task_names=["sierra-research/tau3-bench__tau3-banking_knowledge-*"],
                     # A single served instance is shared by the agent,
                     # the simulated user, and the Natural Language verifier.
-                    n_concurrent_trials=32,
+                    n_concurrent_trials=46, # 93/2 = 46.5 we round down to 46
                     n_attempts=1,
                     n_tasks=97,
                     override_cpus=4,
@@ -1066,7 +1066,7 @@ _eval_config_list = [
             # selected from 256K ISL up to the top of the context budget.
             EvalTask(
                 task_name="longbench2_generate",
-                max_concurrent=64,
+                max_concurrent=93,
                 workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
                 min_context_required=1048576,
                 use_chat_api=True,

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -1560,6 +1560,32 @@ templates:
       # spec-decode, agentic-traces) must trust remote code to load it.
       tokenizer_trust_remote_code: true
 
+# Remote-served model: evaluated against an external OpenAI-compatible
+# endpoint via `--server-url`. The device entry is a placeholder so the model
+# resolves through MODEL_SPECS / EVAL_CONFIGS; no local TT serving is implied.
+- weights:
+    - moonshotai/Kimi-K3
+  impl: tt_transformers
+  inference_engine: MEDIA
+  device_model_specs:
+    - device: SUPER_CLUSTER
+      max_concurrency: 64
+      max_context: 1048576  # 1024 * 1024;
+      default_impl: true
+  status: EXPERIMENTAL
+  env_vars:
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+  metadata:
+    moonshotai/Kimi-K3:
+      remote_api_model: moonshotai/Kimi-K3
+      # K3 ships its own parsers, distinct from the kimi_k2 pair used by
+      # K2.6/K2.7-Code: https://recipes.vllm.ai/moonshotai/Kimi-K3
+      reasoning_parser_name: kimi_k3
+      tool_call_parser_name: kimi_k3
+      # Kimi ships a custom tokenizer; AIPerf-driven sweeps (prefix-cache,
+      # spec-decode, agentic-traces) must trust remote code to load it.
+      tokenizer_trust_remote_code: true
+
 - weights:
     - MiniMaxAI/MiniMax-M3
   impl: tt_transformers

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -1569,7 +1569,7 @@ templates:
   inference_engine: MEDIA
   device_model_specs:
     - device: SUPER_CLUSTER
-      max_concurrency: 64
+      max_concurrency: 93
       max_context: 1048576  # 1024 * 1024;
       default_impl: true
   status: EXPERIMENTAL


### PR DESCRIPTION
## Summary

Onboards `moonshotai/Kimi-K3` as a remote-served eval target: a dev-catalog
model spec plus four eval tasks (GPQA Diamond, Terminal-Bench 2.1, τ³-Bench
Banking, and a LongBench v2 long-context sweep), each with a measured
reference score from a bring-up run.

## Changes

**`workflows/model_specs/dev/llm.yaml`** — remote-served spec following the
existing K2.6 / K2.7-Code / MiniMax-M3 pattern: `SUPER_CLUSTER` placeholder
device, `MEDIA` engine, `EXPERIMENTAL` status, 1,048,576-token context.

**`reference_config/evals/eval_config.py`** — new `EvalConfig` block, placed
after Kimi-K2.7-Code to keep the Kimi models grouped.

## Measured results

| Task | Published | Measured | Ratio | Tolerance |
| --- | --- | --- | --- | --- |
| `r1_gpqa_diamond` | 93.5 | 91.92 | 0.98 | 0.05 |
| `terminal_bench_2_1` | 85.0 | 85.39 | 1.00 | 0.05 |
| `tau3_bench_banking` | 46.0 | 27.84 | 0.61 | 0.10 |
| `longbench2_generate` | — | 71.88 | — | 0.05 |

Published scores are from Artificial Analysis; every `gpu_reference_score` is
linked to its measuring run in #4971.

GPQA Diamond and Terminal-Bench both reproduce their published numbers, which
is good evidence those two harnesses are wired up correctly. LongBench v2 has
no published baseline to compare against, so 71.88 stands as the first
reference for the 256K–900K ISL band.

**τ³-Bench Banking reproduces only 61% of the published 46.0, and reviewers
should weigh in on whether that should block.** 

Be aware of what landing this reference does to the gate: the accuracy check
prefers `gpu_reference_score` over `published_score` when both are present, so
τ³ will be judged against 27.84.

## Notes

**Terminal-Bench reference score.** Moonshot publishes 88.3 using their own
Kimi Code harness, but this config runs Terminus 2, so the 85.0 from
Artificial Analysis is the apples-to-apples comparison. Called out in a
comment so the lower value doesn't read as a typo.

**Sampling follows Moonshot's stated methodology**, which splits by task type:
temperature 1.0 with top_p 0.95 for single-step tasks (GPQA, LongBench), and
top_p 1.0 for agentic tasks (Terminal-Bench, τ³) — see the τ³ caveat above.


