### PR TITLE
Harden release resolution against ambiguous catalog entries

### DIFF
--- a/docs/model_support/llm/Llama-3.2-3B_n150.md
+++ b/docs/model_support/llm/Llama-3.2-3B_n150.md
@@ -5,7 +5,7 @@ Supported weights variants for this model implementation are:
 - `Llama-3.2-3B`: [meta-llama/Llama-3.2-3B](https://huggingface.co/meta-llama/Llama-3.2-3B) **(default)** 
 - `Llama-3.2-3B-Instruct`: [meta-llama/Llama-3.2-3B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct)
 
-To use non-default weights, replace `Llama-3.2-3B` in commands below.
+Weight variants use more than one released configuration; see the configuration table below.
 
 #### Useful links
 
@@ -58,3 +58,9 @@ For details on the run.py command, see the [run.py CLI Options](../../workflows_
 | tt-metal Commit | `20edc39` |
 | vLLM Commit | `03cb300` |
 | Docker Image | `ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.3.0-20edc39-03cb300` |
+
+#### Additional released configurations
+
+| Weights | Implementation | Max Batch Size | Max Context Length | tt-metal Commit | vLLM Commit | Docker Image |
+|---|---|---|---|---|---|---|
+| [meta-llama/Llama-3.2-3B](https://huggingface.co/meta-llama/Llama-3.2-3B) | `forge-vllm-plugin` | 1 | 2048 | `2496be4` | `-` | `ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756` |

--- a/docs/model_support/llm/Llama-3.2-3B_n300.md
+++ b/docs/model_support/llm/Llama-3.2-3B_n300.md
@@ -5,7 +5,7 @@ Supported weights variants for this model implementation are:
 - `Llama-3.2-3B`: [meta-llama/Llama-3.2-3B](https://huggingface.co/meta-llama/Llama-3.2-3B) **(default)** 
 - `Llama-3.2-3B-Instruct`: [meta-llama/Llama-3.2-3B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct)
 
-To use non-default weights, replace `Llama-3.2-3B` in commands below.
+Weight variants use more than one released configuration; see the configuration table below.
 
 #### Useful links
 
@@ -58,3 +58,9 @@ For details on the run.py command, see the [run.py CLI Options](../../workflows_
 | tt-metal Commit | `20edc39` |
 | vLLM Commit | `03cb300` |
 | Docker Image | `ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.3.0-20edc39-03cb300` |
+
+#### Additional released configurations
+
+| Weights | Implementation | Max Batch Size | Max Context Length | tt-metal Commit | vLLM Commit | Docker Image |
+|---|---|---|---|---|---|---|
+| [meta-llama/Llama-3.2-3B](https://huggingface.co/meta-llama/Llama-3.2-3B) | `forge-vllm-plugin` | 1 | 2048 | `2496be4` | `-` | `ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756` |

--- a/docs/model_support/llm/Qwen3-32B_galaxy.md
+++ b/docs/model_support/llm/Qwen3-32B_galaxy.md
@@ -53,6 +53,12 @@ For details on the run.py command, see the [run.py CLI Options](../../workflows_
 | vLLM Commit | `7c6685a` |
 | Docker Image | `ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.11.1-bac8b34-7c6685a` |
 
+#### Additional released configurations
+
+| Weights | Implementation | Max Batch Size | Max Context Length | tt-metal Commit | vLLM Commit | Docker Image |
+|---|---|---|---|---|---|---|
+| [Qwen/Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B) | `tt-transformers` | 128 | 131072 | `e95ffa5` | `48eba14` | `ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-e95ffa5-48eba14` |
+
 ---
 
 ## GALAXY_T3K Configuration

--- a/release_model_spec.json
+++ b/release_model_spec.json
@@ -34,6 +34,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -245,25 +246,26 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
                       "ttft_ms": 180.0,
                       "tput_user": 13.100000000000001,
-                      "tput": 1710.4,
+                      "tput": 427.6,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 36.0,
                       "tput_user": 65.5,
-                      "tput": 8552.0,
+                      "tput": 2138.0,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 18.0,
                       "tput_user": 131.0,
-                      "tput": 17104.0,
+                      "tput": 4276.0,
                       "tolerance": 0.0
                     }
                   },
@@ -369,6 +371,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -496,25 +499,26 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
                       "ttft_ms": 510.0,
                       "tput_user": 2.7,
-                      "tput": 343.6,
+                      "tput": 85.9,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 102.0,
                       "tput_user": 13.5,
-                      "tput": 1718.0,
+                      "tput": 429.5,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 51.0,
                       "tput_user": 27.0,
-                      "tput": 3436.0,
+                      "tput": 859.0,
                       "tolerance": 0.0
                     }
                   },
@@ -637,6 +641,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -1023,6 +1028,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -1147,6 +1153,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -1273,6 +1280,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -1484,6 +1492,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -1696,26 +1705,56 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": 4,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 620.0,
-                      "tput_user": 4.1000000000000005,
-                      "tput": 532.8000000000001,
+                      "ttft_ms": 300.0,
+                      "tput_user": 15.600000000000001,
+                      "tput": 15.600000000000001,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 124.0,
-                      "tput_user": 20.5,
-                      "tput": 2664.0,
+                      "ttft_ms": 60.0,
+                      "tput_user": 78.0,
+                      "tput": 78.0,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 62.0,
-                      "tput_user": 41.0,
-                      "tput": 5328.0,
-                      "tolerance": 0.0
+                      "ttft_ms": 203.2,
+                      "tput_user": 55.1,
+                      "tput": 51.2,
+                      "tolerance": 0.05
+                    }
+                  },
+                  "target_peak_perf": {
+                    "customer_functional": 0.1,
+                    "customer_complete": 0.5,
+                    "customer_sellable": 0.8
+                  },
+                  "num_inference_steps": null,
+                  "structured_dataset": null,
+                  "structured_output_ratio": null
+                },
+                {
+                  "isl": 128,
+                  "osl": 128,
+                  "max_concurrency": 32,
+                  "num_prompts": 256,
+                  "image_height": null,
+                  "image_width": null,
+                  "images_per_prompt": null,
+                  "task_type": "text",
+                  "data_parallel": 4,
+                  "theoretical_ttft_ms": null,
+                  "theoretical_tput_user": null,
+                  "targets": {
+                    "target": {
+                      "ttft_ms": 4360.9,
+                      "tput_user": 50.4,
+                      "tput": 617.1,
+                      "tolerance": 0.05
                     }
                   },
                   "target_peak_perf": {
@@ -1836,26 +1875,56 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": 4,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 620.0,
-                      "tput_user": 4.1000000000000005,
-                      "tput": 532.8000000000001,
+                      "ttft_ms": 300.0,
+                      "tput_user": 15.600000000000001,
+                      "tput": 15.600000000000001,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 124.0,
-                      "tput_user": 20.5,
-                      "tput": 2664.0,
+                      "ttft_ms": 60.0,
+                      "tput_user": 78.0,
+                      "tput": 78.0,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 62.0,
-                      "tput_user": 41.0,
-                      "tput": 5328.0,
-                      "tolerance": 0.0
+                      "ttft_ms": 203.2,
+                      "tput_user": 55.1,
+                      "tput": 51.2,
+                      "tolerance": 0.05
+                    }
+                  },
+                  "target_peak_perf": {
+                    "customer_functional": 0.1,
+                    "customer_complete": 0.5,
+                    "customer_sellable": 0.8
+                  },
+                  "num_inference_steps": null,
+                  "structured_dataset": null,
+                  "structured_output_ratio": null
+                },
+                {
+                  "isl": 128,
+                  "osl": 128,
+                  "max_concurrency": 32,
+                  "num_prompts": 256,
+                  "image_height": null,
+                  "image_width": null,
+                  "images_per_prompt": null,
+                  "task_type": "text",
+                  "data_parallel": 4,
+                  "theoretical_ttft_ms": null,
+                  "theoretical_tput_user": null,
+                  "targets": {
+                    "target": {
+                      "ttft_ms": 4360.9,
+                      "tput_user": 50.4,
+                      "tput": 617.1,
+                      "tolerance": 0.05
                     }
                   },
                   "target_peak_perf": {
@@ -1966,25 +2035,26 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
                       "ttft_ms": 620.0,
                       "tput_user": 4.1000000000000005,
-                      "tput": 133.20000000000002,
+                      "tput": 4.1000000000000005,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 124.0,
                       "tput_user": 20.5,
-                      "tput": 666.0,
+                      "tput": 20.5,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 62.0,
                       "tput_user": 41.0,
-                      "tput": 1332.0,
+                      "tput": 41.0,
                       "tolerance": 0.0
                     }
                   },
@@ -2276,6 +2346,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -2412,6 +2483,7 @@
                   "image_width": 896,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -2690,6 +2762,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -2813,6 +2886,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -3032,6 +3106,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -3072,6 +3147,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -3199,6 +3275,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -3239,6 +3316,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -3460,6 +3538,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -3587,6 +3666,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -3808,6 +3888,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -4015,6 +4096,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -4222,6 +4304,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -4363,6 +4446,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -4501,6 +4585,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -4642,6 +4727,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -4783,6 +4869,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -5024,25 +5111,26 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
                       "ttft_ms": 1190.0,
                       "tput_user": 2.0,
-                      "tput": 244.0,
+                      "tput": 61.0,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 238.0,
                       "tput_user": 10.0,
-                      "tput": 1220.0,
+                      "tput": 305.0,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 119.0,
                       "tput_user": 20.0,
-                      "tput": 2440.0,
+                      "tput": 610.0,
                       "tolerance": 0.0
                     }
                   },
@@ -5165,6 +5253,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -5503,6 +5592,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -5744,25 +5834,26 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
                       "ttft_ms": 1130.0,
                       "tput_user": 1.9000000000000001,
-                      "tput": 244.0,
+                      "tput": 61.0,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 226.0,
                       "tput_user": 9.5,
-                      "tput": 1220.0,
+                      "tput": 305.0,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 113.0,
                       "tput_user": 19.0,
-                      "tput": 2440.0,
+                      "tput": 610.0,
                       "tolerance": 0.0
                     }
                   },
@@ -5885,6 +5976,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -6223,6 +6315,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -7336,6 +7429,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -7456,6 +7550,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -7578,6 +7673,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -7702,6 +7798,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -7822,6 +7919,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -7944,6 +8042,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -8068,6 +8167,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -8189,6 +8289,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -8308,6 +8409,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -8427,6 +8529,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -8548,6 +8651,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -8671,6 +8775,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -8794,6 +8899,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -8915,6 +9021,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -9038,6 +9145,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -9161,6 +9269,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -9286,6 +9395,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -9326,6 +9436,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -9527,6 +9638,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -9650,6 +9762,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -9799,6 +9912,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -9924,6 +10038,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -10057,6 +10172,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -10338,6 +10454,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -10378,6 +10495,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -10616,6 +10734,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -10739,6 +10858,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -10864,6 +10984,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -11065,6 +11186,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -11188,6 +11310,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -11421,25 +11544,26 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
                       "ttft_ms": 300.0,
                       "tput_user": 3.7,
-                      "tput": 29.6,
+                      "tput": 3.7,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 60.0,
                       "tput_user": 18.5,
-                      "tput": 148.0,
+                      "tput": 18.5,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 30.0,
                       "tput_user": 37.0,
-                      "tput": 296.0,
+                      "tput": 37.0,
                       "tolerance": 0.0
                     }
                   },
@@ -11794,25 +11918,26 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
                       "ttft_ms": 290.0,
                       "tput_user": 7.300000000000001,
-                      "tput": 29.200000000000003,
+                      "tput": 7.300000000000001,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 58.0,
                       "tput_user": 36.5,
-                      "tput": 146.0,
+                      "tput": 36.5,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 29.0,
                       "tput_user": 73.0,
-                      "tput": 292.0,
+                      "tput": 73.0,
                       "tolerance": 0.0
                     }
                   },
@@ -12032,6 +12157,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -12545,6 +12671,7 @@
                   "image_width": 896,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -12671,6 +12798,7 @@
                   "image_width": 896,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -12975,6 +13103,7 @@
                   "image_width": 896,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -13198,25 +13327,26 @@
                   "image_width": 896,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
                       "ttft_ms": 760.0,
                       "tput_user": 4.3,
-                      "tput": 309.20000000000005,
+                      "tput": 77.30000000000001,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 152.0,
                       "tput_user": 21.5,
-                      "tput": 1546.0,
+                      "tput": 386.5,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 76.0,
                       "tput_user": 43.0,
-                      "tput": 3092.0,
+                      "tput": 773.0,
                       "tolerance": 0.0
                     }
                   },
@@ -13605,6 +13735,7 @@
                   "image_width": 512,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -13729,6 +13860,7 @@
                   "image_width": 512,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -13850,6 +13982,7 @@
                   "image_width": 512,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -13975,6 +14108,7 @@
                   "image_width": 512,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -14096,6 +14230,7 @@
                   "image_width": 512,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -14226,6 +14361,7 @@
                   "image_width": 512,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -14352,6 +14488,7 @@
                   "image_width": 512,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -14482,6 +14619,7 @@
                   "image_width": 512,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -14602,6 +14740,7 @@
                   "image_width": 512,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -14724,6 +14863,7 @@
                   "image_width": 512,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -14844,6 +14984,7 @@
                   "image_width": 512,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -14966,6 +15107,7 @@
                   "image_width": 512,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -15090,6 +15232,7 @@
                   "image_width": 512,
                   "images_per_prompt": 1,
                   "task_type": "vlm",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -15214,6 +15357,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "video",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -15329,6 +15473,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "video",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -15442,6 +15587,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "video",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -15559,6 +15705,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "video",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -15676,6 +15823,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "video",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -15795,6 +15943,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "video",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -15910,6 +16059,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "video",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -16023,6 +16173,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "video",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -16140,6 +16291,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "video",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -16257,6 +16409,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "video",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -16377,6 +16530,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -16490,6 +16644,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -16605,6 +16760,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -16720,6 +16876,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -16835,6 +16992,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -16948,6 +17106,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -17063,6 +17222,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -17178,6 +17338,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -17293,6 +17454,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -17408,6 +17570,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -17523,6 +17686,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -17636,6 +17800,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -17751,6 +17916,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -17866,6 +18032,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -17981,6 +18148,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -18096,6 +18264,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -18209,6 +18378,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -18322,6 +18492,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -18435,6 +18606,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -18548,6 +18720,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -18667,6 +18840,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -18782,6 +18956,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -18895,6 +19070,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -19008,6 +19184,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -19121,6 +19298,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -19234,6 +19412,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -19353,6 +19532,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -19468,6 +19648,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -19581,6 +19762,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -20068,6 +20250,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "image",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -20183,6 +20366,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "asr",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -20370,6 +20554,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "asr",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -20483,6 +20668,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "asr",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -20598,6 +20784,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "asr",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -20713,6 +20900,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "asr",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -20830,6 +21018,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "asr",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -21017,6 +21206,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "asr",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -21130,6 +21320,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "asr",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -21245,6 +21436,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "asr",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -21360,6 +21552,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "asr",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -21477,6 +21670,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "tts",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -21590,6 +21784,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "tts",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -21855,6 +22050,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -21980,6 +22176,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -22107,6 +22304,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -22234,6 +22432,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -22363,6 +22562,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -22484,6 +22684,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -22607,6 +22808,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -22730,6 +22932,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -22779,7 +22982,8 @@
                 "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
                 "VLLM__MAX_MODEL_LENGTH": "1024",
                 "VLLM__MIN_CONTEXT_LENGTH": "32",
-                "VLLM__MAX_NUM_SEQS": "1"
+                "VLLM__MAX_NUM_SEQS": "1",
+                "BENCHMARK_MAX_CONCURRENCY": "32"
               },
               "tensor_cache_timeout": 3600.0,
               "system_requirements": null,
@@ -22794,7 +22998,8 @@
               "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
               "VLLM__MAX_MODEL_LENGTH": "1024",
               "VLLM__MIN_CONTEXT_LENGTH": "32",
-              "VLLM__MAX_NUM_SEQS": "1"
+              "VLLM__MAX_NUM_SEQS": "1",
+              "BENCHMARK_MAX_CONCURRENCY": "32"
             },
             "tt_metal_commit": "555f240",
             "vllm_commit": null,
@@ -22853,6 +23058,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -22978,6 +23184,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -23105,6 +23312,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -23232,6 +23440,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -23357,6 +23566,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -23494,6 +23704,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -23631,6 +23842,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "embedding",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -23768,6 +23980,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -23887,6 +24100,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -24010,6 +24224,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -24123,6 +24338,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -24240,6 +24456,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -24353,6 +24570,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -24470,6 +24688,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -24583,6 +24802,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -24700,6 +24920,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -24813,6 +25034,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -24930,6 +25152,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -25043,6 +25266,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -25160,6 +25384,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -25273,6 +25498,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -25390,6 +25616,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -25503,6 +25730,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -25620,6 +25848,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "text",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -25757,6 +25986,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {
@@ -25870,6 +26100,7 @@
                   "image_width": null,
                   "images_per_prompt": null,
                   "task_type": "cnn",
+                  "data_parallel": null,
                   "theoretical_ttft_ms": null,
                   "theoretical_tput_user": null,
                   "targets": {

--- a/release_model_spec.json
+++ b/release_model_spec.json
@@ -3464,61 +3464,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 1210.0,
-                      "tput_user": 2.0,
-                      "tput": null,
+                      "ttft_ms": 1150.0,
+                      "tput_user": 1.8,
+                      "tput": 59.300000000000004,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 242.0,
-                      "tput_user": 10.0,
-                      "tput": null,
+                      "ttft_ms": 230.0,
+                      "tput_user": 9.0,
+                      "tput": 296.5,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 121.0,
-                      "tput_user": 20.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                },
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 32,
-                  "num_prompts": 64,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 38720.0,
-                      "tput_user": 2.0,
-                      "tput": 64.0,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 7744.0,
-                      "tput_user": 10.0,
-                      "tput": 320.0,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 3872.0,
-                      "tput_user": 20.0,
-                      "tput": 640.0,
+                      "ttft_ms": 115.0,
+                      "tput_user": 18.0,
+                      "tput": 593.0,
                       "tolerance": 0.0
                     }
                   },
@@ -3631,61 +3591,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 130.0,
-                      "tput_user": 8.200000000000001,
-                      "tput": null,
+                      "ttft_ms": 510.0,
+                      "tput_user": 7.1000000000000005,
+                      "tput": 237.10000000000002,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 26.0,
-                      "tput_user": 41.0,
-                      "tput": null,
+                      "ttft_ms": 102.0,
+                      "tput_user": 35.5,
+                      "tput": 1185.5,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 13.0,
-                      "tput_user": 82.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                },
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 32,
-                  "num_prompts": 64,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 130.0,
-                      "tput_user": 8.200000000000001,
-                      "tput": 262.40000000000003,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 26.0,
-                      "tput_user": 41.0,
-                      "tput": 1312.0,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 13.0,
-                      "tput_user": 82.0,
-                      "tput": 2624.0,
+                      "ttft_ms": 51.0,
+                      "tput_user": 71.0,
+                      "tput": 2371.0,
                       "tolerance": 0.0
                     }
                   },
@@ -4099,21 +4019,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 160.0,
-                      "tput_user": 6.6000000000000005,
-                      "tput": null,
+                      "ttft_ms": 370.0,
+                      "tput_user": 4.7,
+                      "tput": 151.5,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 32.0,
-                      "tput_user": 33.0,
-                      "tput": null,
+                      "ttft_ms": 74.0,
+                      "tput_user": 23.5,
+                      "tput": 757.5,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 16.0,
-                      "tput_user": 66.0,
-                      "tput": null,
+                      "ttft_ms": 37.0,
+                      "tput_user": 47.0,
+                      "tput": 1515.0,
                       "tolerance": 0.0
                     }
                   },
@@ -5108,21 +5028,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 380.0,
-                      "tput_user": 2.8000000000000003,
-                      "tput": null,
+                      "ttft_ms": 1190.0,
+                      "tput_user": 2.0,
+                      "tput": 244.0,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 76.0,
-                      "tput_user": 14.0,
-                      "tput": null,
+                      "ttft_ms": 238.0,
+                      "tput_user": 10.0,
+                      "tput": 1220.0,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 38.0,
-                      "tput_user": 28.0,
-                      "tput": null,
+                      "ttft_ms": 119.0,
+                      "tput_user": 20.0,
+                      "tput": 2440.0,
                       "tolerance": 0.0
                     }
                   },
@@ -5249,21 +5169,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 380.0,
-                      "tput_user": 2.8000000000000003,
-                      "tput": null,
+                      "ttft_ms": 1190.0,
+                      "tput_user": 2.0,
+                      "tput": 61.0,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 76.0,
-                      "tput_user": 14.0,
-                      "tput": null,
+                      "ttft_ms": 238.0,
+                      "tput_user": 10.0,
+                      "tput": 305.0,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 38.0,
-                      "tput_user": 28.0,
-                      "tput": null,
+                      "ttft_ms": 119.0,
+                      "tput_user": 20.0,
+                      "tput": 610.0,
                       "tolerance": 0.0
                     }
                   },
@@ -5373,48 +5293,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 1,
-                  "num_prompts": 8,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 960.0,
-                      "tput_user": 2.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 192.0,
-                      "tput_user": 10.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 96.0,
-                      "tput_user": 20.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "meta-llama/Llama-3.1-70B",
                 "block_size": "64",
@@ -5514,48 +5393,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 32,
-                  "num_prompts": 256,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 640.0,
-                      "tput_user": 1.8,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 128.0,
-                      "tput_user": 9.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 64.0,
-                      "tput_user": 18.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "meta-llama/Llama-3.1-70B",
                 "block_size": "64",
@@ -5910,21 +5748,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 380.0,
-                      "tput_user": 2.8000000000000003,
-                      "tput": null,
+                      "ttft_ms": 1130.0,
+                      "tput_user": 1.9000000000000001,
+                      "tput": 244.0,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 76.0,
-                      "tput_user": 14.0,
-                      "tput": null,
+                      "ttft_ms": 226.0,
+                      "tput_user": 9.5,
+                      "tput": 1220.0,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 38.0,
-                      "tput_user": 28.0,
-                      "tput": null,
+                      "ttft_ms": 113.0,
+                      "tput_user": 19.0,
+                      "tput": 2440.0,
                       "tolerance": 0.0
                     }
                   },
@@ -6051,21 +5889,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 380.0,
-                      "tput_user": 2.8000000000000003,
-                      "tput": null,
+                      "ttft_ms": 1130.0,
+                      "tput_user": 1.9000000000000001,
+                      "tput": 61.0,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 76.0,
-                      "tput_user": 14.0,
-                      "tput": null,
+                      "ttft_ms": 226.0,
+                      "tput_user": 9.5,
+                      "tput": 305.0,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 38.0,
-                      "tput_user": 28.0,
-                      "tput": null,
+                      "ttft_ms": 113.0,
+                      "tput_user": 19.0,
+                      "tput": 610.0,
                       "tolerance": 0.0
                     }
                   },
@@ -6175,48 +6013,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 1,
-                  "num_prompts": 8,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 960.0,
-                      "tput_user": 2.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 192.0,
-                      "tput_user": 10.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 96.0,
-                      "tput_user": 20.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "meta-llama/Llama-3.1-70B-Instruct",
                 "block_size": "64",
@@ -6316,48 +6113,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 32,
-                  "num_prompts": 256,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 640.0,
-                      "tput_user": 1.8,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 128.0,
-                      "tput_user": 9.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 64.0,
-                      "tput_user": 18.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "meta-llama/Llama-3.1-70B-Instruct",
                 "block_size": "64",
@@ -6698,48 +6454,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 1,
-                  "num_prompts": 8,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 380.0,
-                      "tput_user": 2.8000000000000003,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 76.0,
-                      "tput_user": 14.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 38.0,
-                      "tput_user": 28.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
                 "block_size": "64",
@@ -6840,48 +6555,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 1,
-                  "num_prompts": 8,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 380.0,
-                      "tput_user": 2.8000000000000003,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 76.0,
-                      "tput_user": 14.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 38.0,
-                      "tput_user": 28.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
                 "block_size": "64",
@@ -6979,48 +6653,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 1,
-                  "num_prompts": 8,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 960.0,
-                      "tput_user": 2.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 192.0,
-                      "tput_user": 10.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 96.0,
-                      "tput_user": 20.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
                 "block_size": "64",
@@ -7121,48 +6754,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 32,
-                  "num_prompts": 256,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 640.0,
-                      "tput_user": 1.8,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 128.0,
-                      "tput_user": 9.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 64.0,
-                      "tput_user": 18.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
                 "block_size": "64",
@@ -7263,48 +6855,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 1,
-                  "num_prompts": 8,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 890.0,
-                      "tput_user": 1.7000000000000002,
-                      "tput": 1.7000000000000002,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 178.0,
-                      "tput_user": 8.5,
-                      "tput": 8.5,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 89.0,
-                      "tput_user": 17.0,
-                      "tput": 17.0,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
                 "block_size": "64",
@@ -8155,21 +7706,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 60.0,
-                      "tput_user": 18.3,
-                      "tput": null,
+                      "ttft_ms": 90.0,
+                      "tput_user": 16.8,
+                      "tput": 509.1,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 12.0,
-                      "tput_user": 91.5,
-                      "tput": null,
+                      "ttft_ms": 18.0,
+                      "tput_user": 84.0,
+                      "tput": 2545.5,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 6.0,
-                      "tput_user": 183.0,
-                      "tput": null,
+                      "ttft_ms": 9.0,
+                      "tput_user": 168.0,
+                      "tput": 5091.0,
                       "tolerance": 0.0
                     }
                   },
@@ -8275,21 +7826,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 60.0,
-                      "tput_user": 18.3,
-                      "tput": null,
+                      "ttft_ms": 100.0,
+                      "tput_user": 32.300000000000004,
+                      "tput": 1018.3000000000001,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 12.0,
-                      "tput_user": 91.5,
-                      "tput": null,
+                      "ttft_ms": 20.0,
+                      "tput_user": 161.5,
+                      "tput": 5091.5,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 6.0,
-                      "tput_user": 183.0,
-                      "tput": null,
+                      "ttft_ms": 10.0,
+                      "tput_user": 323.0,
+                      "tput": 10183.0,
                       "tolerance": 0.0
                     }
                   },
@@ -8397,21 +7948,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 60.0,
-                      "tput_user": 18.3,
-                      "tput": null,
+                      "ttft_ms": 70.0,
+                      "tput_user": 35.800000000000004,
+                      "tput": 4073.0,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 12.0,
-                      "tput_user": 91.5,
-                      "tput": null,
+                      "ttft_ms": 14.0,
+                      "tput_user": 179.0,
+                      "tput": 20365.0,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 6.0,
-                      "tput_user": 183.0,
-                      "tput": null,
+                      "ttft_ms": 7.0,
+                      "tput_user": 358.0,
+                      "tput": 40730.0,
                       "tolerance": 0.0
                     }
                   },
@@ -9124,21 +8675,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 170.0,
-                      "tput_user": 6.1000000000000005,
-                      "tput": null,
+                      "ttft_ms": 210.0,
+                      "tput_user": 5.6000000000000005,
+                      "tput": 5.6000000000000005,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 34.0,
-                      "tput_user": 30.5,
-                      "tput": null,
+                      "ttft_ms": 42.0,
+                      "tput_user": 28.0,
+                      "tput": 28.0,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 17.0,
-                      "tput_user": 61.0,
-                      "tput": null,
+                      "ttft_ms": 21.0,
+                      "tput_user": 56.0,
+                      "tput": 56.0,
                       "tolerance": 0.0
                     }
                   },
@@ -9247,21 +8798,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 170.0,
-                      "tput_user": 6.1000000000000005,
-                      "tput": null,
+                      "ttft_ms": 200.0,
+                      "tput_user": 10.9,
+                      "tput": 10.9,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 34.0,
-                      "tput_user": 30.5,
-                      "tput": null,
+                      "ttft_ms": 40.0,
+                      "tput_user": 54.5,
+                      "tput": 54.5,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 17.0,
-                      "tput_user": 61.0,
-                      "tput": null,
+                      "ttft_ms": 20.0,
+                      "tput_user": 109.0,
+                      "tput": 109.0,
                       "tolerance": 0.0
                     }
                   },
@@ -9368,21 +8919,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 170.0,
-                      "tput_user": 6.1000000000000005,
-                      "tput": null,
+                      "ttft_ms": 120.0,
+                      "tput_user": 16.7,
+                      "tput": 16.7,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 34.0,
-                      "tput_user": 30.5,
-                      "tput": null,
+                      "ttft_ms": 24.0,
+                      "tput_user": 83.5,
+                      "tput": 83.5,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 17.0,
-                      "tput_user": 61.0,
-                      "tput": null,
+                      "ttft_ms": 12.0,
+                      "tput_user": 167.0,
+                      "tput": 167.0,
                       "tolerance": 0.0
                     }
                   },
@@ -11069,21 +10620,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 890.0,
+                      "ttft_ms": 510.0,
                       "tput_user": 2.1,
-                      "tput": null,
+                      "tput": 2.1,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 178.0,
+                      "ttft_ms": 102.0,
                       "tput_user": 10.5,
-                      "tput": null,
+                      "tput": 10.5,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 89.0,
+                      "ttft_ms": 51.0,
                       "tput_user": 21.0,
-                      "tput": null,
+                      "tput": 21.0,
                       "tolerance": 0.0
                     }
                   },
@@ -11192,21 +10743,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 580.0,
-                      "tput_user": 4.2,
-                      "tput": null,
+                      "ttft_ms": 400.0,
+                      "tput_user": 4.1000000000000005,
+                      "tput": 4.1000000000000005,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 116.0,
-                      "tput_user": 21.0,
-                      "tput": null,
+                      "ttft_ms": 80.0,
+                      "tput_user": 20.5,
+                      "tput": 20.5,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 58.0,
-                      "tput_user": 42.0,
-                      "tput": null,
+                      "ttft_ms": 40.0,
+                      "tput_user": 41.0,
+                      "tput": 41.0,
                       "tolerance": 0.0
                     }
                   },
@@ -11317,61 +10868,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 230.0,
-                      "tput_user": 17.0,
-                      "tput": null,
+                      "ttft_ms": 290.0,
+                      "tput_user": 7.300000000000001,
+                      "tput": 7.300000000000001,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 46.0,
-                      "tput_user": 85.0,
-                      "tput": null,
+                      "ttft_ms": 58.0,
+                      "tput_user": 36.5,
+                      "tput": 36.5,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 23.0,
-                      "tput_user": 170.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                },
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 8,
-                  "num_prompts": 256,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 10880.0,
-                      "tput_user": 6.6819999999999995,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 2176.0,
-                      "tput_user": 33.41,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 1088.0,
-                      "tput_user": 66.82,
-                      "tput": null,
+                      "ttft_ms": 29.0,
+                      "tput_user": 73.0,
+                      "tput": 73.0,
                       "tolerance": 0.0
                     }
                   },
@@ -11558,21 +11069,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 570.0,
+                      "ttft_ms": 340.0,
                       "tput_user": 3.3000000000000003,
-                      "tput": null,
+                      "tput": 3.3000000000000003,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 114.0,
+                      "ttft_ms": 68.0,
                       "tput_user": 16.5,
-                      "tput": null,
+                      "tput": 16.5,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 57.0,
+                      "ttft_ms": 34.0,
                       "tput_user": 33.0,
-                      "tput": null,
+                      "tput": 33.0,
                       "tolerance": 0.0
                     }
                   },
@@ -11683,19 +11194,19 @@
                     "functional": {
                       "ttft_ms": 300.0,
                       "tput_user": 3.7,
-                      "tput": null,
+                      "tput": 3.7,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 60.0,
                       "tput_user": 18.5,
-                      "tput": null,
+                      "tput": 18.5,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 30.0,
                       "tput_user": 37.0,
-                      "tput": null,
+                      "tput": 37.0,
                       "tolerance": 0.0
                     }
                   },
@@ -11816,48 +11327,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 1,
-                  "num_prompts": 8,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 500.0,
-                      "tput_user": 4.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 100.0,
-                      "tput_user": 20.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 50.0,
-                      "tput_user": 40.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "meta-llama/Llama-3.1-8B-Instruct",
                 "block_size": "64",
@@ -11957,19 +11427,19 @@
                     "functional": {
                       "ttft_ms": 300.0,
                       "tput_user": 3.7,
-                      "tput": null,
+                      "tput": 29.6,
                       "tolerance": 0.0
                     },
                     "complete": {
                       "ttft_ms": 60.0,
                       "tput_user": 18.5,
-                      "tput": null,
+                      "tput": 148.0,
                       "tolerance": 0.0
                     },
                     "target": {
                       "ttft_ms": 30.0,
                       "tput_user": 37.0,
-                      "tput": null,
+                      "tput": 296.0,
                       "tolerance": 0.0
                     }
                   },
@@ -12074,48 +11544,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 1,
-                  "num_prompts": 8,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 150.0,
-                      "tput_user": 12.5,
-                      "tput": 12.5,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 30.0,
-                      "tput_user": 62.5,
-                      "tput": 62.5,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 15.0,
-                      "tput_user": 125.0,
-                      "tput": 125.0,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "meta-llama/Llama-3.1-8B-Instruct",
                 "block_size": "64",
@@ -12369,61 +11798,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 230.0,
-                      "tput_user": 17.0,
-                      "tput": null,
+                      "ttft_ms": 290.0,
+                      "tput_user": 7.300000000000001,
+                      "tput": 29.200000000000003,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 46.0,
-                      "tput_user": 85.0,
-                      "tput": null,
+                      "ttft_ms": 58.0,
+                      "tput_user": 36.5,
+                      "tput": 146.0,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 23.0,
-                      "tput_user": 170.0,
-                      "tput": null,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                },
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 32,
-                  "num_prompts": 256,
-                  "image_height": null,
-                  "image_width": null,
-                  "images_per_prompt": null,
-                  "task_type": "text",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 10880.0,
-                      "tput_user": 6.6819999999999995,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 2176.0,
-                      "tput_user": 33.41,
-                      "tput": null,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 1088.0,
-                      "tput_user": 66.82,
-                      "tput": null,
+                      "ttft_ms": 29.0,
+                      "tput_user": 73.0,
+                      "tput": 292.0,
                       "tolerance": 0.0
                     }
                   },
@@ -13402,48 +12791,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 1,
-                  "num_prompts": 8,
-                  "image_height": 896,
-                  "image_width": 896,
-                  "images_per_prompt": 1,
-                  "task_type": "vlm",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 2020.0,
-                      "tput_user": 4.2,
-                      "tput": 134.4,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 404.0,
-                      "tput_user": 21.0,
-                      "tput": 672.0,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 202.0,
-                      "tput_user": 42.0,
-                      "tput": 1344.0,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "google/medgemma-4b-it",
                 "block_size": "64",
@@ -13528,48 +12876,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 1,
-                  "num_prompts": 8,
-                  "image_height": 896,
-                  "image_width": 896,
-                  "images_per_prompt": 1,
-                  "task_type": "vlm",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 1020.0,
-                      "tput_user": 7.800000000000001,
-                      "tput": 268.8,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 204.0,
-                      "tput_user": 39.0,
-                      "tput": 1344.0,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 102.0,
-                      "tput_user": 78.0,
-                      "tput": 2688.0,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "google/medgemma-4b-it",
                 "block_size": "64",
@@ -14014,48 +13321,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 1,
-                  "num_prompts": 8,
-                  "image_height": 896,
-                  "image_width": 896,
-                  "images_per_prompt": 1,
-                  "task_type": "vlm",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 760.0,
-                      "tput_user": 4.3,
-                      "tput": 77.30000000000001,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 152.0,
-                      "tput_user": 21.5,
-                      "tput": 386.5,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 76.0,
-                      "tput_user": 43.0,
-                      "tput": 773.0,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "google/medgemma-27b-it",
                 "block_size": "64",
@@ -14237,48 +13503,7 @@
               "max_tokens_all_users_override": null,
               "perf_targets_map": {},
               "default_impl": true,
-              "perf_reference": [
-                {
-                  "isl": 128,
-                  "osl": 128,
-                  "max_concurrency": 1,
-                  "num_prompts": 8,
-                  "image_height": 896,
-                  "image_width": 896,
-                  "images_per_prompt": 1,
-                  "task_type": "vlm",
-                  "theoretical_ttft_ms": null,
-                  "theoretical_tput_user": null,
-                  "targets": {
-                    "functional": {
-                      "ttft_ms": 760.0,
-                      "tput_user": 4.3,
-                      "tput": 309.20000000000005,
-                      "tolerance": 0.0
-                    },
-                    "complete": {
-                      "ttft_ms": 152.0,
-                      "tput_user": 21.5,
-                      "tput": 1546.0,
-                      "tolerance": 0.0
-                    },
-                    "target": {
-                      "ttft_ms": 76.0,
-                      "tput_user": 43.0,
-                      "tput": 3092.0,
-                      "tolerance": 0.0
-                    }
-                  },
-                  "target_peak_perf": {
-                    "customer_functional": 0.1,
-                    "customer_complete": 0.5,
-                    "customer_sellable": 0.8
-                  },
-                  "num_inference_steps": null,
-                  "structured_dataset": null,
-                  "structured_output_ratio": null
-                }
-              ],
+              "perf_reference": [],
               "vllm_args": {
                 "model": "google/medgemma-27b-it",
                 "block_size": "64",
@@ -15503,21 +14728,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 3390.0,
+                      "ttft_ms": 3570.0,
                       "tput_user": 3.1,
-                      "tput": null,
+                      "tput": 76.2,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 678.0,
+                      "ttft_ms": 714.0,
                       "tput_user": 15.5,
-                      "tput": null,
+                      "tput": 381.0,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 339.0,
+                      "ttft_ms": 357.0,
                       "tput_user": 31.0,
-                      "tput": null,
+                      "tput": 762.0,
                       "tolerance": 0.0
                     }
                   },
@@ -15623,21 +14848,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 950.0,
+                      "ttft_ms": 1020.0,
                       "tput_user": 12.200000000000001,
-                      "tput": null,
+                      "tput": 304.7,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 190.0,
+                      "ttft_ms": 204.0,
                       "tput_user": 61.0,
-                      "tput": null,
+                      "tput": 1523.5,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 95.0,
+                      "ttft_ms": 102.0,
                       "tput_user": 122.0,
-                      "tput": null,
+                      "tput": 3047.0,
                       "tolerance": 0.0
                     }
                   },
@@ -15869,21 +15094,21 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 3030.0,
+                      "ttft_ms": 3220.0,
                       "tput_user": 2.0,
-                      "tput": null,
+                      "tput": 52.0,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 606.0,
+                      "ttft_ms": 644.0,
                       "tput_user": 10.0,
-                      "tput": null,
+                      "tput": 260.0,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 303.0,
+                      "ttft_ms": 322.0,
                       "tput_user": 20.0,
-                      "tput": null,
+                      "tput": 520.0,
                       "tolerance": 0.0
                     }
                   },
@@ -17614,20 +16839,20 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 125000.0,
-                      "tput_user": 0.008,
+                      "ttft_ms": 110000.0,
+                      "tput_user": 0.0091,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 25000.0,
-                      "tput_user": 0.04,
+                      "ttft_ms": 22000.0,
+                      "tput_user": 0.0455,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 12500.0,
-                      "tput_user": 0.08,
+                      "ttft_ms": 11000.0,
+                      "tput_user": 0.091,
                       "tput": null,
                       "tolerance": 0.0
                     }
@@ -17727,20 +16952,20 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 125000.0,
-                      "tput_user": 0.008,
+                      "ttft_ms": 110000.0,
+                      "tput_user": 0.0091,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 25000.0,
-                      "tput_user": 0.04,
+                      "ttft_ms": 22000.0,
+                      "tput_user": 0.0455,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 12500.0,
-                      "tput_user": 0.08,
+                      "ttft_ms": 11000.0,
+                      "tput_user": 0.091,
                       "tput": null,
                       "tolerance": 0.0
                     }
@@ -17842,20 +17067,20 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 125000.0,
-                      "tput_user": 0.008,
+                      "ttft_ms": 110000.0,
+                      "tput_user": 0.0091,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 25000.0,
-                      "tput_user": 0.04,
+                      "ttft_ms": 22000.0,
+                      "tput_user": 0.0455,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 12500.0,
-                      "tput_user": 0.08,
+                      "ttft_ms": 11000.0,
+                      "tput_user": 0.091,
                       "tput": null,
                       "tolerance": 0.0
                     }
@@ -17957,20 +17182,20 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 125000.0,
-                      "tput_user": 0.008,
+                      "ttft_ms": 110000.0,
+                      "tput_user": 0.0091,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 25000.0,
-                      "tput_user": 0.04,
+                      "ttft_ms": 22000.0,
+                      "tput_user": 0.0455,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 12500.0,
-                      "tput_user": 0.08,
+                      "ttft_ms": 11000.0,
+                      "tput_user": 0.091,
                       "tput": null,
                       "tolerance": 0.0
                     }
@@ -21609,20 +20834,20 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 8000.0,
-                      "tput_user": 5.631,
+                      "ttft_ms": 4000.0,
+                      "tput_user": 11.262,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 1600.0,
-                      "tput_user": 28.155,
+                      "ttft_ms": 800.0,
+                      "tput_user": 56.31,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 800.0,
-                      "tput_user": 56.31,
+                      "ttft_ms": 400.0,
+                      "tput_user": 112.62,
                       "tput": null,
                       "tolerance": 0.0
                     }
@@ -21796,20 +21021,20 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 8000.0,
-                      "tput_user": 6.555,
+                      "ttft_ms": 4000.0,
+                      "tput_user": 13.11,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 1600.0,
-                      "tput_user": 32.775,
+                      "ttft_ms": 800.0,
+                      "tput_user": 65.55,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 800.0,
-                      "tput_user": 65.55,
+                      "ttft_ms": 400.0,
+                      "tput_user": 131.1,
                       "tput": null,
                       "tolerance": 0.0
                     }
@@ -21909,20 +21134,20 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 8000.0,
-                      "tput_user": 5.38,
+                      "ttft_ms": 4000.0,
+                      "tput_user": 10.76,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 1600.0,
-                      "tput_user": 26.9,
+                      "ttft_ms": 800.0,
+                      "tput_user": 53.8,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 800.0,
-                      "tput_user": 53.8,
+                      "ttft_ms": 400.0,
+                      "tput_user": 107.6,
                       "tput": null,
                       "tolerance": 0.0
                     }
@@ -22024,20 +21249,20 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 27000.0,
-                      "tput_user": 4.7,
+                      "ttft_ms": 12500.0,
+                      "tput_user": 13.0,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 5400.0,
-                      "tput_user": 23.5,
+                      "ttft_ms": 2500.0,
+                      "tput_user": 65.0,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 2700.0,
-                      "tput_user": 47.0,
+                      "ttft_ms": 1250.0,
+                      "tput_user": 130.0,
                       "tput": null,
                       "tolerance": 0.0
                     }
@@ -22139,20 +21364,20 @@
                   "theoretical_tput_user": null,
                   "targets": {
                     "functional": {
-                      "ttft_ms": 19000.0,
-                      "tput_user": 6.2,
+                      "ttft_ms": 8000.0,
+                      "tput_user": 38.0,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "complete": {
-                      "ttft_ms": 3800.0,
-                      "tput_user": 31.0,
+                      "ttft_ms": 1600.0,
+                      "tput_user": 190.0,
                       "tput": null,
                       "tolerance": 0.0
                     },
                     "target": {
-                      "ttft_ms": 1900.0,
-                      "tput_user": 62.0,
+                      "ttft_ms": 800.0,
+                      "tput_user": 380.0,
                       "tput": null,
                       "tolerance": 0.0
                     }

--- a/scripts/release/generate_model_support_docs.py
+++ b/scripts/release/generate_model_support_docs.py
@@ -411,7 +411,9 @@ def group_templates_by_model(
     groups = defaultdict(list)
     for template in templates:
         display_name = get_model_display_name(template)
-        key = (template.model_type, display_name) if include_model_type else display_name
+        key = (
+            (template.model_type, display_name) if include_model_type else display_name
+        )
         groups[key].append(template)
     return dict(groups)
 

--- a/scripts/release/generate_model_support_docs.py
+++ b/scripts/release/generate_model_support_docs.py
@@ -232,7 +232,7 @@ def get_model_display_name(template: ModelSpecTemplate) -> str:
 def coalesce_catalog_groups_for_docs(
     templates: List[ModelSpecTemplate],
 ) -> List[ModelSpecTemplate]:
-    """Reconstruct complete generated template groups for stable docs output."""
+    """Combine only leaf variants sharing one device and runtime configuration."""
 
     def shared_signature(template):
         data = asdict(template)
@@ -262,42 +262,48 @@ def coalesce_catalog_groups_for_docs(
     coalesced = []
     for key in ordered_keys:
         members = grouped[key]
-        if len(members) == 1 or members[0].catalog_group is None:
+        if members[0].catalog_group is None:
             coalesced.extend(members)
             continue
 
-        weights = list(
-            dict.fromkeys(weight for item in members for weight in item.weights)
-        )
-        devices = {}
-        metadata = {}
-        observed_pairs = set()
-        homogeneous = all(
-            shared_signature(item) == shared_signature(members[0])
-            for item in members[1:]
-        )
+        buckets = []
         for item in members:
-            metadata.update(item.metadata)
-            for weight in item.weights:
-                for device_spec in item.device_model_specs:
-                    observed_pairs.add((weight, device_spec.device))
-                    existing = devices.setdefault(device_spec.device, device_spec)
-                    if device_signature(existing) != device_signature(device_spec):
-                        homogeneous = False
+            for device_spec in item.device_model_specs:
+                shared = shared_signature(item)
+                device = device_signature(device_spec)
+                bucket = next(
+                    (
+                        candidate
+                        for candidate in buckets
+                        if candidate["shared"] == shared
+                        and candidate["device"] == device
+                    ),
+                    None,
+                )
+                if bucket is None:
+                    bucket = {
+                        "template": item,
+                        "device_spec": device_spec,
+                        "shared": shared,
+                        "device": device,
+                        "weights": [],
+                        "metadata": {},
+                    }
+                    buckets.append(bucket)
+                for weight in item.weights:
+                    if weight not in bucket["weights"]:
+                        bucket["weights"].append(weight)
+                bucket["metadata"].update(item.metadata)
 
-        expected_pairs = {(weight, device) for weight in weights for device in devices}
-        if not homogeneous or observed_pairs != expected_pairs:
-            coalesced.extend(members)
-            continue
-
-        coalesced.append(
-            replace(
-                members[0],
-                weights=weights,
-                device_model_specs=list(devices.values()),
-                metadata=metadata,
+        for bucket in buckets:
+            coalesced.append(
+                replace(
+                    bucket["template"],
+                    weights=bucket["weights"],
+                    device_model_specs=[bucket["device_spec"]],
+                    metadata=bucket["metadata"],
+                )
             )
-        )
     return coalesced
 
 
@@ -521,36 +527,43 @@ def generate_model_page_group_page(
 
     # Collect devices in this group that support the model
     supported_devices_in_group = []
-    device_template_map = {}  # device -> (template, dev_spec)
+    device_template_map = defaultdict(list)  # device -> [(template, dev_spec)]
     for device in group.device_ordering:
         for template in templates:
             for dev_spec in template.device_model_specs:
                 if dev_spec.device == device:
-                    supported_devices_in_group.append(device)
-                    device_template_map[device] = (template, dev_spec)
+                    device_template_map[device].append((template, dev_spec))
                     break
-            if device in device_template_map:
-                break
+        if device_template_map[device]:
+            supported_devices_in_group.append(device)
 
     if not supported_devices_in_group:
         return f"# {model_name} - No devices found in group {group.name}\n"
 
     # Use first supported device for common sections
     first_device = supported_devices_in_group[0]
-    first_template, first_dev_spec = device_template_map[first_device]
+    first_device_templates = device_template_map[first_device]
+    first_template, first_dev_spec = first_device_templates[0]
 
     # Page title with group name
     lines.append(f"# {model_name} Tenstorrent Support on {group.name}")
     lines.append("")
 
     # Supported weights (only show if multiple weights are supported)
-    if first_template.weights and len(first_template.weights) > 1:
-        default_weights = first_template.weights[0]
+    supported_weights = list(
+        dict.fromkeys(
+            weight
+            for template, _ in first_device_templates
+            for weight in template.weights
+        )
+    )
+    if len(supported_weights) > 1:
+        default_weights = supported_weights[0]
         default_weights_name = default_weights.split("/")[-1]
 
         lines.append("Supported weights variants for this model implementation are:")
         lines.append("")
-        for idx, weight in enumerate(first_template.weights):
+        for idx, weight in enumerate(supported_weights):
             weight_name = weight.split("/")[-1]
             if idx == 0:
                 lines.append(
@@ -562,9 +575,15 @@ def generate_model_page_group_page(
                 )
 
         lines.append("")
-        lines.append(
-            f"To use non-default weights, replace `{default_weights_name}` in commands below."
-        )
+        if len(first_device_templates) == 1:
+            lines.append(
+                f"To use non-default weights, replace `{default_weights_name}` in commands below."
+            )
+        else:
+            lines.append(
+                "Weight variants use more than one released configuration; "
+                "see the configuration table below."
+            )
         lines.append("")
 
     # Useful links section
@@ -606,7 +625,8 @@ def generate_model_page_group_page(
 
     # Generate sections for each supported device in the group
     for idx, device in enumerate(supported_devices_in_group):
-        target_template, target_dev_spec = device_template_map[device]
+        device_templates = device_template_map[device]
+        target_template, target_dev_spec = device_templates[0]
         product_name = device.to_product_str()
 
         # Section header for secondary devices
@@ -746,6 +766,37 @@ def generate_model_page_group_page(
 
         lines.append(f"| Docker Image | `{docker_image}` |")
         lines.append("")
+
+        if len(device_templates) > 1:
+            lines.append("#### Additional released configurations")
+            lines.append("")
+            lines.append(
+                "| Weights | Implementation | tt-metal Commit | vLLM Commit | Docker Image |"
+            )
+            lines.append(
+                "|---------|----------------|-----------------|-------------|--------------|"
+            )
+            for alternate, _ in device_templates[1:]:
+                alternate_weights = ", ".join(
+                    f"[{weight}](https://huggingface.co/{weight})"
+                    for weight in alternate.weights
+                )
+                alternate_image = (
+                    alternate.docker_image
+                    or generate_default_docker_link(
+                        alternate.version,
+                        alternate.tt_metal_commit,
+                        alternate.vllm_commit,
+                        inference_engine=alternate.inference_engine,
+                        multihost=device.is_multihost(),
+                    )
+                )
+                lines.append(
+                    f"| {alternate_weights} | `{alternate.impl.impl_name}` | "
+                    f"`{alternate.tt_metal_commit}` | "
+                    f"`{alternate.vllm_commit or '-'}` | `{alternate_image}` |"
+                )
+            lines.append("")
 
     return "\n".join(lines)
 

--- a/scripts/release/generate_model_support_docs.py
+++ b/scripts/release/generate_model_support_docs.py
@@ -247,16 +247,27 @@ def coalesce_model_families_for_docs(
 
     def device_signature(device_spec):
         data = asdict(device_spec)
+        # perf_reference is derived from model_performance_reference.json, keyed
+        # by the family's model_display_name, so family members share it today
+        # and comparing it here would only add float noise. If targets ever
+        # become per-weight, drop this pop -- otherwise leaves with different
+        # targets would silently coalesce into one documented configuration.
         data.pop("perf_reference", None)
         return data
 
     grouped = defaultdict(list)
     ordered_keys = []
-    for template in templates:
+    for index, template in enumerate(templates):
         key = (
-            get_model_display_name(template),
-            template.inference_engine,
-            template.impl.impl_id,
+            (
+                "family",
+                template.model_type,
+                template.model_display_name,
+                template.inference_engine,
+                template.impl.impl_id,
+            )
+            if template.model_display_name
+            else ("template", index)
         )
         if key not in grouped:
             ordered_keys.append(key)
@@ -394,7 +405,9 @@ def get_page_group_status_link(
 
 def group_templates_by_model(
     templates: List[ModelSpecTemplate],
-) -> Dict[str, List[ModelSpecTemplate]]:
+    *,
+    include_model_type: bool = False,
+) -> Dict[object, List[ModelSpecTemplate]]:
     """
     Group templates by their model display name.
     Multiple templates may exist for the same model targeting different devices.
@@ -402,7 +415,8 @@ def group_templates_by_model(
     groups = defaultdict(list)
     for template in templates:
         display_name = get_model_display_name(template)
-        groups[display_name].append(template)
+        key = (template.model_type, display_name) if include_model_type else display_name
+        groups[key].append(template)
     return dict(groups)
 
 
@@ -1016,7 +1030,7 @@ def generate_models_by_hardware_page(templates: List[ModelSpecTemplate]) -> str:
     devices_with_templates = get_devices_with_templates(templates)
 
     # Group templates by model name
-    model_groups = group_templates_by_model(templates)
+    model_groups = group_templates_by_model(templates, include_model_type=True)
 
     # Iterate through all devices with page group mappings (excluding EXCLUDED_DEVICES)
     for device in get_devices_with_templates_ordered():
@@ -1034,7 +1048,7 @@ def generate_models_by_hardware_page(templates: List[ModelSpecTemplate]) -> str:
 
         # Collect models that support this device
         device_models = []
-        for model_name, model_templates in model_groups.items():
+        for (_, model_name), model_templates in model_groups.items():
             status_enum = get_device_status_enum_for_model(model_templates, device)
             if status_enum is not None:
                 model_type = get_model_type_for_templates(model_templates)
@@ -1192,9 +1206,9 @@ def generate_doc_pages(
         write_file(output_path / subdir / "README.md", page_content, dry_run)
 
     # Group templates by model name and generate per-page-group pages in subdirectories
-    model_groups = group_templates_by_model(templates)
+    model_groups = group_templates_by_model(templates, include_model_type=True)
 
-    for model_name, model_templates in model_groups.items():
+    for (_, model_name), model_templates in model_groups.items():
         # Get model type subdirectory
         model_type = get_model_type_for_templates(model_templates)
         subdir = get_model_subdir(model_type)

--- a/scripts/release/generate_model_support_docs.py
+++ b/scripts/release/generate_model_support_docs.py
@@ -770,13 +770,13 @@ def generate_model_page_group_page(
         if len(device_templates) > 1:
             lines.append("#### Additional released configurations")
             lines.append("")
-            lines.append(
-                "| Weights | Implementation | tt-metal Commit | vLLM Commit | Docker Image |"
-            )
-            lines.append(
-                "|---------|----------------|-----------------|-------------|--------------|"
-            )
-            for alternate, _ in device_templates[1:]:
+            columns = ["Weights", "Implementation", "Max Batch Size"]
+            if model_type in (ModelType.LLM, ModelType.VLM):
+                columns.append("Max Context Length")
+            columns.extend(["tt-metal Commit", "vLLM Commit", "Docker Image"])
+            lines.append("| " + " | ".join(columns) + " |")
+            lines.append("|" + "|".join("---" for _ in columns) + "|")
+            for alternate, alternate_dev_spec in device_templates[1:]:
                 alternate_weights = ", ".join(
                     f"[{weight}](https://huggingface.co/{weight})"
                     for weight in alternate.weights
@@ -791,11 +791,21 @@ def generate_model_page_group_page(
                         multihost=device.is_multihost(),
                     )
                 )
-                lines.append(
-                    f"| {alternate_weights} | `{alternate.impl.impl_name}` | "
-                    f"`{alternate.tt_metal_commit}` | "
-                    f"`{alternate.vllm_commit or '-'}` | `{alternate_image}` |"
+                values = [
+                    alternate_weights,
+                    f"`{alternate.impl.impl_name}`",
+                    str(alternate_dev_spec.max_concurrency),
+                ]
+                if model_type in (ModelType.LLM, ModelType.VLM):
+                    values.append(str(alternate_dev_spec.max_context))
+                values.extend(
+                    [
+                        f"`{alternate.tt_metal_commit}`",
+                        f"`{alternate.vllm_commit or '-'}`",
+                        f"`{alternate_image}`",
+                    ]
                 )
+                lines.append("| " + " | ".join(values) + " |")
             lines.append("")
 
     return "\n".join(lines)

--- a/scripts/release/generate_model_support_docs.py
+++ b/scripts/release/generate_model_support_docs.py
@@ -21,7 +21,7 @@ Usage:
 import re
 import sys
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -224,7 +224,81 @@ def generate_section_anchor(section_title: str) -> str:
 
 def get_model_display_name(template: ModelSpecTemplate) -> str:
     """Get the display name for a model template."""
-    return model_weights_to_model_name(template.weights[0])
+    return template.model_display_name or model_weights_to_model_name(
+        template.weights[0]
+    )
+
+
+def coalesce_catalog_groups_for_docs(
+    templates: List[ModelSpecTemplate],
+) -> List[ModelSpecTemplate]:
+    """Reconstruct complete generated template groups for stable docs output."""
+
+    def shared_signature(template):
+        data = asdict(template)
+        for field_name in (
+            "weights",
+            "device_model_specs",
+            "metadata",
+            "model_display_name",
+            "catalog_group",
+        ):
+            data.pop(field_name, None)
+        return data
+
+    def device_signature(device_spec):
+        data = asdict(device_spec)
+        data.pop("perf_reference", None)
+        return data
+
+    grouped = defaultdict(list)
+    ordered_keys = []
+    for index, template in enumerate(templates):
+        key = template.catalog_group or f"ungrouped:{index}"
+        if key not in grouped:
+            ordered_keys.append(key)
+        grouped[key].append(template)
+
+    coalesced = []
+    for key in ordered_keys:
+        members = grouped[key]
+        if len(members) == 1 or members[0].catalog_group is None:
+            coalesced.extend(members)
+            continue
+
+        weights = list(
+            dict.fromkeys(weight for item in members for weight in item.weights)
+        )
+        devices = {}
+        metadata = {}
+        observed_pairs = set()
+        homogeneous = all(
+            shared_signature(item) == shared_signature(members[0])
+            for item in members[1:]
+        )
+        for item in members:
+            metadata.update(item.metadata)
+            for weight in item.weights:
+                for device_spec in item.device_model_specs:
+                    observed_pairs.add((weight, device_spec.device))
+                    existing = devices.setdefault(device_spec.device, device_spec)
+                    if device_signature(existing) != device_signature(device_spec):
+                        homogeneous = False
+
+        expected_pairs = {(weight, device) for weight in weights for device in devices}
+        if not homogeneous or observed_pairs != expected_pairs:
+            coalesced.extend(members)
+            continue
+
+        coalesced.append(
+            replace(
+                members[0],
+                weights=weights,
+                device_model_specs=list(devices.values()),
+                metadata=metadata,
+            )
+        )
+    return coalesced
 
 
 def get_model_device_filename(model_name: str, device: DeviceTypes) -> str:
@@ -1029,6 +1103,7 @@ def generate_doc_pages(
         output_dir: Output directory for docs (default: docs/model_support)
         dry_run: If True, print what would be written without writing
     """
+    templates = coalesce_catalog_groups_for_docs(templates)
     output_path = Path(output_dir)
 
     print(f"Generating Model Support documentation from {len(templates)} templates")
@@ -1103,6 +1178,7 @@ def update_readme_model_support(
         readme_path: Path to README.md file (default: README.md)
         dry_run: If True, print what would change without writing
     """
+    templates = coalesce_catalog_groups_for_docs(templates)
     readme_file = Path(readme_path)
     if not readme_file.exists():
         print(f"Warning: README.md not found at {readme_path}, skipping update")

--- a/scripts/release/generate_model_support_docs.py
+++ b/scripts/release/generate_model_support_docs.py
@@ -246,14 +246,10 @@ def coalesce_model_families_for_docs(
         return data
 
     def device_signature(device_spec):
-        data = asdict(device_spec)
-        # perf_reference is derived from model_performance_reference.json, keyed
-        # by the family's model_display_name, so family members share it today
-        # and comparing it here would only add float noise. If targets ever
-        # become per-weight, drop this pop -- otherwise leaves with different
-        # targets would silently coalesce into one documented configuration.
-        data.pop("perf_reference", None)
-        return data
+        # Catalog device specs carry no perf_reference: the field is rejected in
+        # YAML and only filled in during expansion, so there is nothing here to
+        # exclude from the comparison.
+        return asdict(device_spec)
 
     grouped = defaultdict(list)
     ordered_keys = []

--- a/scripts/release/generate_model_support_docs.py
+++ b/scripts/release/generate_model_support_docs.py
@@ -229,10 +229,10 @@ def get_model_display_name(template: ModelSpecTemplate) -> str:
     )
 
 
-def coalesce_catalog_groups_for_docs(
+def coalesce_model_families_for_docs(
     templates: List[ModelSpecTemplate],
 ) -> List[ModelSpecTemplate]:
-    """Combine only leaf variants sharing one device and runtime configuration."""
+    """Combine model-family leaves sharing one device and runtime configuration."""
 
     def shared_signature(template):
         data = asdict(template)
@@ -241,7 +241,6 @@ def coalesce_catalog_groups_for_docs(
             "device_model_specs",
             "metadata",
             "model_display_name",
-            "catalog_group",
         ):
             data.pop(field_name, None)
         return data
@@ -253,8 +252,12 @@ def coalesce_catalog_groups_for_docs(
 
     grouped = defaultdict(list)
     ordered_keys = []
-    for index, template in enumerate(templates):
-        key = template.catalog_group or f"ungrouped:{index}"
+    for template in templates:
+        key = (
+            get_model_display_name(template),
+            template.inference_engine,
+            template.impl.impl_id,
+        )
         if key not in grouped:
             ordered_keys.append(key)
         grouped[key].append(template)
@@ -262,10 +265,6 @@ def coalesce_catalog_groups_for_docs(
     coalesced = []
     for key in ordered_keys:
         members = grouped[key]
-        if members[0].catalog_group is None:
-            coalesced.extend(members)
-            continue
-
         buckets = []
         for item in members:
             for device_spec in item.device_model_specs:
@@ -1164,7 +1163,7 @@ def generate_doc_pages(
         output_dir: Output directory for docs (default: docs/model_support)
         dry_run: If True, print what would be written without writing
     """
-    templates = coalesce_catalog_groups_for_docs(templates)
+    templates = coalesce_model_families_for_docs(templates)
     output_path = Path(output_dir)
 
     print(f"Generating Model Support documentation from {len(templates)} templates")
@@ -1239,7 +1238,7 @@ def update_readme_model_support(
         readme_path: Path to README.md file (default: README.md)
         dry_run: If True, print what would change without writing
     """
-    templates = coalesce_catalog_groups_for_docs(templates)
+    templates = coalesce_model_families_for_docs(templates)
     readme_file = Path(readme_path)
     if not readme_file.exists():
         print(f"Warning: README.md not found at {readme_path}, skipping update")

--- a/scripts/release/generate_model_support_docs.py
+++ b/scripts/release/generate_model_support_docs.py
@@ -544,6 +544,14 @@ def generate_model_page_group_page(
                     device_template_map[device].append((template, dev_spec))
                     break
         if device_template_map[device]:
+            # The default implementation is what a user gets without asking for
+            # one, so it is the configuration the page documents; the rest go
+            # into the additional-configurations table. Taking the first entry
+            # in catalog order instead made that depend on entry order, so a
+            # non-default impl listed first became the headline configuration
+            # and its batch and context limits went into the quickstart. Stable
+            # sort, so catalog order still decides among equals.
+            device_template_map[device].sort(key=lambda item: not item[1].default_impl)
             supported_devices_in_group.append(device)
 
     if not supported_devices_in_group:

--- a/scripts/release/model_spec_resolver.py
+++ b/scripts/release/model_spec_resolver.py
@@ -6,7 +6,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Tuple
+from typing import Dict, Iterable, List, Tuple
 
 from workflows.model_spec import (
     MODEL_SPEC_CATALOG_FILES,
@@ -152,14 +152,20 @@ def load_dev_model_spec_sources(dev_dir: Path) -> List[ModelSpecSource]:
     sources: List[ModelSpecSource] = []
     for filename in MODEL_SPEC_CATALOG_FILES:
         path = Path(dev_dir) / filename
-        for template_index, template in enumerate(load_templates_from_yaml(path)):
-            for spec in template.expand_to_specs():
-                weight_index = template.weights.index(spec.hf_model_repo)
-                device_index = next(
-                    index
-                    for index, device_spec in enumerate(template.device_model_specs)
-                    if device_spec.device == spec.device_type
-                )
+        for template_index, template in enumerate(
+            load_templates_from_yaml(path, env="dev")
+        ):
+            # expand_to_specs() iterates weights first and devices second, so
+            # provenance comes from position. Searching the lists by value would
+            # silently return the first match for a repeated weight or device.
+            positions = [
+                (weight_index, device_index)
+                for weight_index in range(len(template.weights))
+                for device_index in range(len(template.device_model_specs))
+            ]
+            for spec, (weight_index, device_index) in zip(
+                template.expand_to_specs(), positions, strict=True
+            ):
                 sources.append(
                     ModelSpecSource(
                         spec=spec,
@@ -222,6 +228,24 @@ def resolve_release_combos(
     combos: Iterable[ReleaseCombo],
     sources: Iterable[ModelSpecSource],
 ) -> List[ResolvedReleaseCombo]:
-    """Resolve every release tuple in input order, failing on the first error."""
+    """Resolve every release tuple in input order, failing on the first error.
+
+    Two configured selectors that land on one runtime leaf leave the release
+    scope ambiguous for every consumer -- promotion, release notes, and artifact
+    packaging would each have to pick a winner. Reject it once, here, so those
+    consumers can treat the resolved list as an exact set.
+    """
     source_list = list(sources)
-    return [resolve_release_combo(combo, source_list) for combo in combos]
+    resolved: List[ResolvedReleaseCombo] = []
+    selector_by_identity: Dict[LeafIdentity, ReleaseCombo] = {}
+    for combo in combos:
+        item = resolve_release_combo(combo, source_list)
+        previous = selector_by_identity.get(item.identity)
+        if previous is not None:
+            raise ValueError(
+                f"Configured selectors {previous!r} and {combo!r} resolve to "
+                f"duplicate identity {item.identity!r}"
+            )
+        selector_by_identity[item.identity] = combo
+        resolved.append(item)
+    return resolved

--- a/scripts/release/model_spec_resolver.py
+++ b/scripts/release/model_spec_resolver.py
@@ -67,18 +67,18 @@ def iter_implementations(model_entry: dict) -> Iterable[dict]:
     implementations = model_entry.get("implementations")
     if implementations is None:
         yield model_entry
-    else:
-        if not isinstance(implementations, list) or not implementations:
+        return
+    if not isinstance(implementations, list) or not implementations:
+        raise ValueError(
+            f"Model implementations must be a non-empty list, got "
+            f"{implementations!r}"
+        )
+    for implementation in implementations:
+        if not isinstance(implementation, dict):
             raise ValueError(
-                f"Model implementations must be a non-empty list, got "
-                f"{implementations!r}"
+                f"Model implementation must be an object, got {implementation!r}"
             )
-        for implementation in implementations:
-            if not isinstance(implementation, dict):
-                raise ValueError(
-                    f"Model implementation must be an object, got {implementation!r}"
-                )
-            yield implementation
+        yield implementation
 
 
 def _release_device(raw_device: str) -> DeviceTypes:

--- a/scripts/release/model_spec_resolver.py
+++ b/scripts/release/model_spec_resolver.py
@@ -70,8 +70,7 @@ def iter_implementations(model_entry: dict) -> Iterable[dict]:
         return
     if not isinstance(implementations, list) or not implementations:
         raise ValueError(
-            f"Model implementations must be a non-empty list, got "
-            f"{implementations!r}"
+            f"Model implementations must be a non-empty list, got {implementations!r}"
         )
     for implementation in implementations:
         if not isinstance(implementation, dict):

--- a/scripts/release/model_spec_resolver.py
+++ b/scripts/release/model_spec_resolver.py
@@ -22,6 +22,9 @@ from workflows.workflow_types import DeviceTypes, InferenceEngine
 
 LeafIdentity = Tuple[str, str, str, str]
 
+# models-ci-config schema uses the CI-facing BH_GALAXY label while model
+# catalogs and DeviceTypes use the canonical BLACKHOLE_GALAXY identity.
+# All release consumers normalize through collect_release_combos.
 _RELEASE_DEVICE_ALIASES = {
     "BH_GALAXY": "BLACKHOLE_GALAXY",
 }

--- a/scripts/release/model_spec_resolver.py
+++ b/scripts/release/model_spec_resolver.py
@@ -24,7 +24,8 @@ LeafIdentity = Tuple[str, str, str, str]
 
 # models-ci-config schema uses the CI-facing BH_GALAXY label while model
 # catalogs and DeviceTypes use the canonical BLACKHOLE_GALAXY identity.
-# All release consumers normalize through collect_release_combos.
+# Release consumers that resolve device identities normalize through
+# collect_release_combos; engine-family-only workflow parsing does not read it.
 _RELEASE_DEVICE_ALIASES = {
     "BH_GALAXY": "BLACKHOLE_GALAXY",
 }

--- a/scripts/release/model_spec_resolver.py
+++ b/scripts/release/model_spec_resolver.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Resolve release-scope CI entries to exact dev catalog leaves."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+from workflows.model_spec import (
+    MODEL_SPEC_CATALOG_FILES,
+    ModelSpec,
+    ModelSpecTemplate,
+    load_templates_from_yaml,
+    model_spec_leaf_identity,
+    resolve_model_spec,
+    validate_model_specs,
+)
+from workflows.workflow_types import DeviceTypes, InferenceEngine
+
+
+LeafIdentity = Tuple[str, str, str, str]
+
+_RELEASE_DEVICE_ALIASES = {
+    "BH_GALAXY": "BLACKHOLE_GALAXY",
+}
+
+
+@dataclass(frozen=True)
+class ReleaseCombo:
+    model_name: str
+    engine: InferenceEngine
+    device: DeviceTypes
+
+
+@dataclass(frozen=True)
+class ModelSpecSource:
+    spec: ModelSpec
+    template: ModelSpecTemplate
+    path: Path
+    template_index: int
+    weight_index: int
+    device_index: int
+
+
+@dataclass(frozen=True)
+class ResolvedReleaseCombo:
+    combo: ReleaseCombo
+    model_spec: ModelSpec
+    identity: LeafIdentity
+    source_path: Path
+    template_index: int
+    weight_index: int
+    device_index: int
+    source_template: ModelSpecTemplate
+
+
+def iter_implementations(model_entry: dict) -> Iterable[dict]:
+    """Yield flat and multi-engine CI entries through one interface."""
+    if not isinstance(model_entry, dict):
+        raise ValueError(f"Model CI entry must be an object, got {model_entry!r}")
+    implementations = model_entry.get("implementations")
+    if implementations is None:
+        yield model_entry
+    else:
+        if not isinstance(implementations, list) or not implementations:
+            raise ValueError(
+                f"Model implementations must be a non-empty list, got "
+                f"{implementations!r}"
+            )
+        for implementation in implementations:
+            if not isinstance(implementation, dict):
+                raise ValueError(
+                    f"Model implementation must be an object, got {implementation!r}"
+                )
+            yield implementation
+
+
+def _release_device(raw_device: str) -> DeviceTypes:
+    if not isinstance(raw_device, str):
+        raise ValueError(f"Release device must be a string, got {raw_device!r}")
+    normalized = _RELEASE_DEVICE_ALIASES.get(raw_device.upper(), raw_device)
+    try:
+        return DeviceTypes.from_string(normalized)
+    except ValueError as exc:
+        raise ValueError(f"Invalid release device {raw_device!r}") from exc
+
+
+def collect_release_combos(ci_config: dict) -> List[ReleaseCombo]:
+    """Return the ordered, de-duplicated release scope from CI configuration."""
+    if not isinstance(ci_config, dict):
+        raise ValueError("CI configuration must be an object")
+    models = ci_config.get("models", {})
+    if not isinstance(models, dict):
+        raise ValueError("CI configuration 'models' must be an object")
+
+    combos: List[ReleaseCombo] = []
+    seen = set()
+    for model_name, model_entry in models.items():
+        for implementation in iter_implementations(model_entry):
+            ci = implementation.get("ci", {})
+            if not isinstance(ci, dict):
+                raise ValueError(
+                    f"CI schedules must be an object for model {model_name!r}"
+                )
+            release = ci.get("release")
+            if release is None:
+                continue
+            if not isinstance(release, dict):
+                raise ValueError(
+                    f"Release schedule must be an object for model {model_name!r}"
+                )
+
+            raw_devices = release.get("devices")
+            if raw_devices == "ALL":
+                raise ValueError(
+                    f"Release devices cannot be 'ALL' for model {model_name!r}"
+                )
+            if not isinstance(raw_devices, list) or not raw_devices:
+                raise ValueError(
+                    f"Release devices must be a non-empty list for model {model_name!r}"
+                )
+
+            raw_engine = implementation.get("inference_engine")
+            try:
+                engine = InferenceEngine.from_string(raw_engine)
+            except (KeyError, AttributeError) as exc:
+                raise ValueError(
+                    f"Invalid release inference engine {raw_engine!r} "
+                    f"for model {model_name!r}"
+                ) from exc
+
+            for raw_device in raw_devices:
+                combo = ReleaseCombo(
+                    model_name=model_name,
+                    engine=engine,
+                    device=_release_device(raw_device),
+                )
+                if combo not in seen:
+                    combos.append(combo)
+                    seen.add(combo)
+    return combos
+
+
+def load_dev_model_spec_sources(dev_dir: Path) -> List[ModelSpecSource]:
+    """Load and validate expanded dev leaves while retaining YAML provenance."""
+    sources: List[ModelSpecSource] = []
+    for filename in MODEL_SPEC_CATALOG_FILES:
+        path = Path(dev_dir) / filename
+        for template_index, template in enumerate(load_templates_from_yaml(path)):
+            for spec in template.expand_to_specs():
+                weight_index = template.weights.index(spec.hf_model_repo)
+                device_index = next(
+                    index
+                    for index, device_spec in enumerate(template.device_model_specs)
+                    if device_spec.device == spec.device_type
+                )
+                sources.append(
+                    ModelSpecSource(
+                        spec=spec,
+                        template=template,
+                        path=path,
+                        template_index=template_index,
+                        weight_index=weight_index,
+                        device_index=device_index,
+                    )
+                )
+
+    validate_model_specs([source.spec for source in sources])
+    return sources
+
+
+def resolve_release_combo(
+    combo: ReleaseCombo,
+    sources: Iterable[ModelSpecSource],
+) -> ResolvedReleaseCombo:
+    """Resolve one release tuple to its unique default dev leaf and provenance."""
+    source_list = list(sources)
+    model_spec = resolve_model_spec(
+        (source.spec for source in source_list),
+        model=combo.model_name,
+        device=combo.device,
+        engine=combo.engine,
+        catalog_name="dev release catalog",
+    )
+    if not model_spec.device_model_spec.default_impl:
+        raise ValueError(
+            f"Release combo {combo!r} does not resolve to an explicit default "
+            f"implementation; selected {model_spec_leaf_identity(model_spec)!r}"
+        )
+
+    identity = model_spec_leaf_identity(model_spec)
+    matching_sources = [
+        source
+        for source in source_list
+        if model_spec_leaf_identity(source.spec) == identity
+    ]
+    if len(matching_sources) != 1:
+        raise ValueError(
+            f"Expected one source template for release identity {identity!r}, "
+            f"found {len(matching_sources)}"
+        )
+    source = matching_sources[0]
+    return ResolvedReleaseCombo(
+        combo=combo,
+        model_spec=model_spec,
+        identity=identity,
+        source_path=source.path,
+        template_index=source.template_index,
+        weight_index=source.weight_index,
+        device_index=source.device_index,
+        source_template=source.template,
+    )
+
+
+def resolve_release_combos(
+    combos: Iterable[ReleaseCombo],
+    sources: Iterable[ModelSpecSource],
+) -> List[ResolvedReleaseCombo]:
+    """Resolve every release tuple in input order, failing on the first error."""
+    source_list = list(sources)
+    return [resolve_release_combo(combo, source_list) for combo in combos]

--- a/scripts/release/promote_dev_spec_to_prod.py
+++ b/scripts/release/promote_dev_spec_to_prod.py
@@ -277,6 +277,7 @@ def _validate_candidate_catalog(candidate_text: dict[str, str]):
         prod_dir.mkdir()
         for filename in MODEL_SPEC_CATALOG_FILES:
             (prod_dir / filename).write_text(candidate_text[filename])
+            _load_document(prod_dir / filename)
         templates = [
             template
             for filename in MODEL_SPEC_CATALOG_FILES
@@ -449,6 +450,13 @@ def promote(
             raw_template = _parse_block(lines)
             identity = _flat_template_identity(raw_template)
             prod_locations[identity] = (filename, segment_index, raw_template)
+
+    for identity, (filename, _, _) in prod_locations.items():
+        if identity in target_filenames and filename != target_filenames[identity]:
+            raise ValueError(
+                f"Release identity {identity!r} belongs to {filename!r}, "
+                f"but dev source is {target_filenames[identity]!r}"
+            )
 
     for identity, leaf in promoted_leaves.items():
         location = prod_locations.get(identity)

--- a/scripts/release/promote_dev_spec_to_prod.py
+++ b/scripts/release/promote_dev_spec_to_prod.py
@@ -281,7 +281,7 @@ def _validate_candidate_catalog(candidate_text: dict[str, str]):
         templates = [
             template
             for filename in MODEL_SPEC_CATALOG_FILES
-            for template in load_templates_from_yaml(prod_dir / filename)
+            for template in load_templates_from_yaml(prod_dir / filename, env="prod")
         ]
         return get_model_spec_map(templates)
 
@@ -363,15 +363,9 @@ def promote(
     sources = load_dev_model_spec_sources(Path(dev_dir))
     resolved = resolve_release_combos(combos, sources)
 
-    resolved_by_identity = {}
-    for item in resolved:
-        existing = resolved_by_identity.get(item.identity)
-        if existing is not None and existing.combo != item.combo:
-            raise ValueError(
-                f"Multiple configured combos resolve to {item.identity!r}: "
-                f"{existing.combo!r} and {item.combo!r}"
-            )
-        resolved_by_identity[item.identity] = item
+    # resolve_release_combos() rejects two selectors that collide on one
+    # identity, so this index keeps every resolved entry.
+    resolved_by_identity = {item.identity: item for item in resolved}
 
     needs_vllm = any(
         item.combo.engine == InferenceEngine.VLLM
@@ -423,15 +417,11 @@ def promote(
     before_templates = [
         template
         for filename in MODEL_SPEC_CATALOG_FILES
-        for template in load_templates_from_yaml(prod_dir / filename)
+        for template in load_templates_from_yaml(prod_dir / filename, env="prod")
     ]
-    before_specs_by_identity = {
-        model_spec_leaf_identity(spec): spec
-        for spec in get_model_spec_map(before_templates).values()
-    }
     before_payloads = {
-        identity: spec.get_serialized_dict()
-        for identity, spec in before_specs_by_identity.items()
+        model_spec_leaf_identity(spec): spec.get_serialized_dict()
+        for spec in get_model_spec_map(before_templates).values()
     }
     original_text = {}
     candidate_segments = {}

--- a/scripts/release/promote_dev_spec_to_prod.py
+++ b/scripts/release/promote_dev_spec_to_prod.py
@@ -6,6 +6,7 @@
 """Promote exact release-scoped dev leaves into a leaf-granular prod catalog."""
 
 import argparse
+import hashlib
 import json
 import sys
 import tempfile
@@ -148,11 +149,28 @@ def _filter_metadata(template: CommentedMap, weight: str) -> None:
     template["metadata"] = filtered
 
 
+def _catalog_group(template: CommentedMap) -> str:
+    existing = template.get("catalog_group")
+    if existing:
+        return str(existing)
+    weights = [str(weight) for weight in template.get("weights", [])]
+    payload = {
+        "model_display_name": template.get("model_display_name")
+        or (Path(weights[0]).name if weights else ""),
+        "weights": sorted(weights),
+        "inference_engine": str(template.get("inference_engine", "")),
+        "impl": str(template.get("impl", "")),
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:16]
+    return f"doc:{digest}"
+
+
 def _make_leaf(
     template: CommentedMap,
     weight_index: int,
     device_index: int,
-    catalog_group: str | None = None,
 ) -> tuple[LeafIdentity, CommentedMap]:
     weights = template.get("weights")
     devices = template.get("device_model_specs")
@@ -174,16 +192,13 @@ def _make_leaf(
     leaf["model_display_name"] = (
         template.get("model_display_name") or Path(str(weights[0])).name
     )
-    group = template.get("catalog_group") or catalog_group
-    if group is not None:
-        leaf["catalog_group"] = group
+    leaf["catalog_group"] = _catalog_group(template)
     _filter_metadata(leaf, weight)
     return _template_identity(leaf, weight, leaf["device_model_specs"][0]), leaf
 
 
 def _leafize_template(
     template: CommentedMap,
-    catalog_group: str | None = None,
 ) -> list[tuple[LeafIdentity, CommentedMap]]:
     weights = template.get("weights")
     devices = template.get("device_model_specs")
@@ -192,7 +207,7 @@ def _leafize_template(
     if not isinstance(devices, list) or not devices:
         raise ValueError("Template device_model_specs must be a non-empty list")
     return [
-        _make_leaf(template, weight_index, device_index, catalog_group)
+        _make_leaf(template, weight_index, device_index)
         for weight_index in range(len(weights))
         for device_index in range(len(devices))
     ]
@@ -424,7 +439,6 @@ def promote(
             raw_template,
             item.weight_index,
             item.device_index,
-            f"dev:{item.source_path.name}:{item.template_index}",
         )
         if actual_identity != identity:
             raise ValueError(
@@ -469,15 +483,11 @@ def promote(
         segments = split_into_blocks(text)
         candidate_segments[filename] = [(kind, list(lines)) for kind, lines in segments]
 
-        block_index = 0
         for kind, lines in segments:
             if kind != "block":
                 continue
             raw_template = _parse_block(lines)
-            for identity, leaf in _leafize_template(
-                raw_template,
-                f"prod:{filename}:{block_index}",
-            ):
+            for identity, leaf in _leafize_template(raw_template):
                 if identity in before_leaves:
                     raise ValueError(
                         f"Duplicate prod identity {identity!r} in "
@@ -485,7 +495,6 @@ def promote(
                     )
                 before_leaves[identity] = _semantic_value(leaf)
                 owner_filenames[identity] = filename
-            block_index += 1
 
     for identity, filename in owner_filenames.items():
         if identity in target_filenames and filename != target_filenames[identity]:
@@ -496,16 +505,11 @@ def promote(
 
     found_targets = set()
     for filename, segments in candidate_segments.items():
-        block_index = 0
         for segment_index, (kind, lines) in enumerate(list(segments)):
             if kind != "block":
                 continue
             raw_template = _parse_block(lines)
-            leaves = _leafize_template(
-                raw_template,
-                f"prod:{filename}:{block_index}",
-            )
-            block_index += 1
+            leaves = _leafize_template(raw_template)
             found_targets.update(
                 identity for identity, _ in leaves if identity in promoted_leaves
             )

--- a/scripts/release/promote_dev_spec_to_prod.py
+++ b/scripts/release/promote_dev_spec_to_prod.py
@@ -3,350 +3,681 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
-"""
-Promote dev model specs to prod for every model-device combination marked
-``release`` in models-ci-config.json.
-
-For each (model, inference_engine, device) under ``ci.release`` in the CI config,
-the matching template in workflows/model_specs/dev/ is copied into the same-named
-file in workflows/model_specs/prod/, upserting by
-(impl, inference_engine, weights, devices) identity.
-
-Dev templates intentionally omit the release pins (``version``,
-``tt_metal_commit`` and ``vllm_commit``); promotion injects them from CLI flags
-into each promoted prod block. ``--version`` and ``--tt-metal-commit`` are
-required; ``--vllm-commit`` is required only when one or more promoted templates
-use the VLLM inference engine and is injected only into those templates.
-
-The catalogue YAML files are hand-authored with inconsistent block-sequence
-indentation (top-level list items at column 0, nested lists indented to column 4),
-which no single ruamel.yaml indent setting can reproduce. Round-tripping a whole
-file therefore reformats every untouched template. To preserve formatting exactly,
-this tool splices template TEXT blocks: each catalogue file is segmented into
-top-level ``- ...`` template blocks and the filler between them; only the specific
-blocks that change are replaced/appended, so untouched templates stay byte-identical.
-"""
+"""Promote exact release-scoped dev leaves into a leaf-granular prod catalog."""
 
 import argparse
 import json
-import re
 import sys
-from collections import namedtuple
+import tempfile
+from copy import deepcopy
+from dataclasses import asdict
+from io import StringIO
 from pathlib import Path
 
-import yaml
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
+from ruamel.yaml.error import YAMLError as RuamelYAMLError
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
+from yaml import YAMLError as PyYAMLError
 
-# Add repo root to path for imports
+# Add repo root to path for direct script execution.
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from scripts.release.model_spec_resolver import (  # noqa: E402
+    LeafIdentity,
+    collect_release_combos,
+    load_dev_model_spec_sources,
+    resolve_release_combos,
+)
+from workflows.model_spec import (  # noqa: E402
+    MODEL_SPEC_CATALOG_FILES,
+    get_model_spec_map,
+    load_templates_from_yaml,
+    model_spec_leaf_identity,
+)
 from workflows.workflow_types import DeviceTypes, InferenceEngine  # noqa: E402
+
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 DEFAULT_CI_CONFIG = REPO_ROOT / ".github" / "workflows" / "models-ci-config.json"
 DEFAULT_DEV_DIR = REPO_ROOT / "workflows" / "model_specs" / "dev"
 DEFAULT_PROD_DIR = REPO_ROOT / "workflows" / "model_specs" / "prod"
 
-ReleaseCombo = namedtuple("ReleaseCombo", ["model_name", "engine", "device"])
-
-# A matched dev template: its upsert identity, parsed dict, and exact source lines.
-MatchedBlock = namedtuple("MatchedBlock", ["identity", "template", "lines"])
-
-# A top-level template item starts with "- " (or a bare "-") at column 0.
-_TEMPLATE_ITEM_RE = re.compile(r"^-(\s|$)")
+_PIN_FIELDS = ("version", "tt_metal_commit", "vllm_commit")
 
 
-def model_name_from_weight(weight: str) -> str:
-    """Extract the model name (basename) from a HuggingFace repo path."""
-    return Path(weight).name
+def _round_trip_yaml() -> YAML:
+    yaml = YAML(typ="rt")
+    yaml.allow_duplicate_keys = False
+    yaml.preserve_quotes = True
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    return yaml
 
 
-def iter_implementations(model_entry: dict):
-    """Yield each implementation dict for a CI-config model entry.
-
-    Handles both the flat shape ({inference_engine, ci}) and the
-    implementations:[...] array shape.
-    """
-    if "implementations" in model_entry:
-        yield from model_entry["implementations"]
-    else:
-        yield model_entry
-
-
-def collect_release_combos(ci_config: dict) -> set:
-    """Return the set of ReleaseCombo(model_name, engine, device) marked release."""
-    combos = set()
-    for model_name, entry in ci_config.get("models", {}).items():
-        for impl in iter_implementations(entry):
-            release = impl.get("ci", {}).get("release")
-            if not release:
-                continue
-            engine = InferenceEngine.from_string(impl["inference_engine"])
-            for device in release.get("devices", []):
-                combos.add(
-                    ReleaseCombo(model_name, engine, DeviceTypes.from_string(device))
-                )
-    return combos
-
-
-def template_engine(template: dict) -> InferenceEngine:
-    return InferenceEngine.from_string(template["inference_engine"])
-
-
-def template_devices(template: dict) -> set:
-    return {
-        DeviceTypes.from_string(d["device"])
-        for d in template.get("device_model_specs", [])
-    }
-
-
-def template_model_names(template: dict) -> set:
-    return {model_name_from_weight(w) for w in template.get("weights", [])}
-
-
-def template_matches(template: dict, combo: ReleaseCombo) -> bool:
-    """True if the template provides the given release combo."""
-    return (
-        combo.model_name in template_model_names(template)
-        and combo.engine == template_engine(template)
-        and combo.device in template_devices(template)
-    )
-
-
-def template_identity(template: dict):
-    """Upsert identity for a template block: (impl, engine, weights, devices).
-
-    The device set is part of the identity because the catalogue intentionally
-    holds multiple blocks per (impl, engine, weights) — one per device group
-    (e.g. the same model validated on different hardware at different commits).
-    Without devices, distinct blocks would collide and overwrite each other.
-    """
-    return (
-        template["impl"],
-        template_engine(template),
-        frozenset(template.get("weights", [])),
-        frozenset(template_devices(template)),
-    )
+def _load_document(path: Path) -> CommentedMap:
+    document = _round_trip_yaml().load(path.read_text())
+    if not isinstance(document, CommentedMap) or not isinstance(
+        document.get("templates"), CommentedSeq
+    ):
+        raise ValueError(f"Catalog {path} must contain a templates sequence")
+    return document
 
 
 def split_into_blocks(text: str):
-    """Segment catalogue text into ("block", lines) and ("filler", lines) parts.
-
-    A "block" is a top-level ``- ...`` template item: its first line plus all
-    following indented body lines. "filler" is everything else (the ``templates:``
-    header, column-0 comment banners, blank lines). Concatenating every segment's
-    lines reproduces ``text`` exactly.
-    """
+    """Split catalog text into top-level template blocks and untouched filler."""
     lines = text.splitlines(keepends=True)
     segments = []
-    i = 0
-    while i < len(lines):
-        if _TEMPLATE_ITEM_RE.match(lines[i].rstrip("\n")):
-            block = [lines[i]]
-            i += 1
-            # Body lines are indented. A blank line is interior to the block only
-            # if an indented line follows it (after any run of blanks); otherwise
-            # it separates this block from the next template and stays filler.
-            while i < len(lines):
-                if lines[i].startswith((" ", "\t")):
-                    block.append(lines[i])
-                    i += 1
-                elif lines[i].strip() == "":
-                    j = i
-                    while j < len(lines) and lines[j].strip() == "":
-                        j += 1
-                    if j < len(lines) and lines[j].startswith((" ", "\t")):
-                        block.extend(lines[i:j])
-                        i = j
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if line.startswith("- ") or line.rstrip("\n") == "-":
+            block = [line]
+            index += 1
+            while index < len(lines):
+                if lines[index].startswith((" ", "\t")):
+                    block.append(lines[index])
+                    index += 1
+                elif lines[index].strip() == "":
+                    lookahead = index
+                    while lookahead < len(lines) and lines[lookahead].strip() == "":
+                        lookahead += 1
+                    if lookahead < len(lines) and lines[lookahead].startswith(
+                        (" ", "\t")
+                    ):
+                        block.extend(lines[index:lookahead])
+                        index = lookahead
                     else:
                         break
                 else:
                     break
             segments.append(("block", block))
         else:
-            segments.append(("filler", [lines[i]]))
-            i += 1
+            segments.append(("filler", [line]))
+            index += 1
     return segments
 
 
-def parse_block(block_lines) -> dict:
-    """Parse a template block's text into a plain dict."""
-    parsed = yaml.safe_load("".join(block_lines))
-    assert isinstance(parsed, list) and len(parsed) == 1, (
-        f"expected a single-item YAML list, got: {''.join(block_lines)!r}"
-    )
+def _parse_block(lines) -> CommentedMap:
+    parsed = _round_trip_yaml().load("".join(lines))
+    if (
+        not isinstance(parsed, CommentedSeq)
+        or len(parsed) != 1
+        or not isinstance(parsed[0], CommentedMap)
+    ):
+        raise ValueError(f"Expected one YAML template block, got {''.join(lines)!r}")
     return parsed[0]
 
 
-def find_matches(dev_dir: Path, combos: set):
-    """Scan dev catalogue files for templates matching any release combo.
-
-    Returns (matches_by_file, unmatched):
-      - matches_by_file: dict filename -> list of MatchedBlock, in file order,
-        de-duplicated by identity.
-      - unmatched: set of combos that matched no dev template.
-    """
-    matched_combos = set()
-    matches_by_file = {}
-    for dev_file in sorted(Path(dev_dir).glob("*.yaml")):
-        picked = []
-        picked_ids = set()
-        for kind, lines in split_into_blocks(dev_file.read_text()):
-            if kind != "block":
-                continue
-            template = parse_block(lines)
-            hits = [c for c in combos if template_matches(template, c)]
-            if not hits:
-                continue
-            matched_combos.update(hits)
-            identity = template_identity(template)
-            if identity not in picked_ids:
-                picked.append(MatchedBlock(identity, template, lines))
-                picked_ids.add(identity)
-        if picked:
-            matches_by_file[dev_file.name] = picked
-    unmatched = combos - matched_combos
-    return matches_by_file, unmatched
+def _render_block(template: CommentedMap) -> list[str]:
+    """Render one template using the repository's top-level list indentation."""
+    stream = StringIO()
+    _round_trip_yaml().dump(template, stream)
+    lines = stream.getvalue().splitlines(keepends=True)
+    if not lines:
+        raise ValueError("Cannot render an empty template")
+    return [f"- {lines[0]}"] + [f"  {line}" for line in lines[1:]]
 
 
-def upsert_block(segments, identity, lines) -> str:
-    """Replace the block segment with matching identity, else append a new one.
-
-    Operates in place on the ``segments`` list from split_into_blocks. Returns
-    "updated" if an existing same-identity block was replaced, else "appended".
-    """
-    for idx, (kind, seg_lines) in enumerate(segments):
-        if kind == "block" and template_identity(parse_block(seg_lines)) == identity:
-            segments[idx] = ("block", list(lines))
-            return "updated"
-
-    last_block_idx = None
-    for idx, (kind, _) in enumerate(segments):
-        if kind == "block":
-            last_block_idx = idx
-    new_segment = ("block", _ensure_trailing_newline(list(lines)))
-    if last_block_idx is None:
-        segments.append(new_segment)
-    else:
-        # Ensure the block we insert after ends in a newline so the two don't
-        # fuse onto one line.
-        _ensure_trailing_newline(segments[last_block_idx][1])
-        segments.insert(last_block_idx + 1, new_segment)
-    return "appended"
+def _template_identity(
+    template: CommentedMap,
+    weight: str,
+    device_spec: CommentedMap,
+) -> LeafIdentity:
+    try:
+        device = DeviceTypes.from_string(str(device_spec["device"])).to_string()
+        engine = InferenceEngine.from_string(str(template["inference_engine"])).value
+        impl_id = str(template["impl"])
+    except (AttributeError, KeyError, ValueError) as exc:
+        raise ValueError(
+            f"Invalid catalog leaf for weight {weight!r}: {template!r}"
+        ) from exc
+    return (str(weight), device, engine, impl_id)
 
 
-def _ensure_trailing_newline(lines):
-    """Guarantee the block's last line ends with a newline (safe to append after)."""
-    if lines and not lines[-1].endswith("\n"):
-        lines[-1] += "\n"
-    return lines
+def _filter_metadata(template: CommentedMap, weight: str) -> None:
+    metadata = template.get("metadata")
+    if not metadata:
+        template.pop("metadata", None)
+        return
+    selected = metadata.get(weight)
+    if selected is None:
+        template.pop("metadata", None)
+        return
+    filtered = CommentedMap()
+    filtered[weight] = deepcopy(selected)
+    template["metadata"] = filtered
 
 
-# Release-pin keys, matched at the template's top-level (2-space) indent.
-_PIN_LINE_RE = re.compile(r"^  (version|tt_metal_commit|vllm_commit):")
+def _make_leaf(
+    template: CommentedMap,
+    weight_index: int,
+    device_index: int,
+    catalog_group: str | None = None,
+) -> tuple[LeafIdentity, CommentedMap]:
+    weights = template.get("weights")
+    devices = template.get("device_model_specs")
+    if not isinstance(weights, list) or not isinstance(devices, list):
+        raise ValueError("Template must contain weights and device_model_specs lists")
+    try:
+        weight = str(weights[weight_index])
+        device_spec = devices[device_index]
+    except IndexError as exc:
+        raise ValueError(
+            f"Leaf indexes out of range: weight={weight_index}, device={device_index}"
+        ) from exc
+    if not isinstance(device_spec, CommentedMap):
+        raise ValueError(f"Device model spec must be a mapping: {device_spec!r}")
+
+    leaf = deepcopy(template)
+    leaf["weights"] = CommentedSeq([deepcopy(weights[weight_index])])
+    leaf["device_model_specs"] = CommentedSeq([deepcopy(device_spec)])
+    leaf["model_display_name"] = (
+        template.get("model_display_name") or Path(str(weights[0])).name
+    )
+    group = template.get("catalog_group") or catalog_group
+    if group is not None:
+        leaf["catalog_group"] = group
+    _filter_metadata(leaf, weight)
+    return _template_identity(leaf, weight, leaf["device_model_specs"][0]), leaf
 
 
-def inject_pin_fields(lines, *, version, tt_metal_commit, vllm_commit=None):
-    """Return the block's lines with the release pins injected.
+def _leafize_template(
+    template: CommentedMap,
+    catalog_group: str | None = None,
+) -> list[tuple[LeafIdentity, CommentedMap]]:
+    weights = template.get("weights")
+    devices = template.get("device_model_specs")
+    if not isinstance(weights, list) or not weights:
+        raise ValueError("Template weights must be a non-empty list")
+    if not isinstance(devices, list) or not devices:
+        raise ValueError("Template device_model_specs must be a non-empty list")
+    return [
+        _make_leaf(template, weight_index, device_index, catalog_group)
+        for weight_index in range(len(weights))
+        for device_index in range(len(devices))
+    ]
 
-    Any pre-existing pin line is dropped first, so the result is deterministic and
-    idempotent. The new lines are inserted right after the ``weights`` block (before
-    the first other top-level key), at the template's 2-space indent. Values are
-    quoted so commit-like strings (e.g. ``1e23``) are never parsed as numbers.
 
-    ``vllm_commit`` is injected only when provided (the caller passes it solely for
-    VLLM templates).
-    """
-    body = [ln for ln in lines if not _PIN_LINE_RE.match(ln)]
+def _has_unsafe_yaml_structure(value) -> bool:
+    anchor = getattr(value, "anchor", None)
+    if anchor is not None and anchor.value is not None:
+        return True
+    if isinstance(value, CommentedMap):
+        if getattr(value, "merge", None):
+            return True
+        return any(
+            _has_unsafe_yaml_structure(key) or _has_unsafe_yaml_structure(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_has_unsafe_yaml_structure(item) for item in value)
+    return False
+
+
+def _inject_pins(
+    leaf: CommentedMap,
+    *,
+    version: str,
+    tt_metal_commit: str,
+    vllm_commit: str | None,
+) -> None:
+    for field in _PIN_FIELDS:
+        leaf.pop(field, None)
+
+    keys = list(leaf)
+    insert_at = (
+        keys.index("device_model_specs") if "device_model_specs" in keys else len(keys)
+    )
     pins = [
-        f'  version: "{version}"\n',
-        f'  tt_metal_commit: "{tt_metal_commit}"\n',
+        ("version", version),
+        ("tt_metal_commit", tt_metal_commit),
     ]
     if vllm_commit is not None:
-        pins.append(f'  vllm_commit: "{vllm_commit}"\n')
-
-    insert_at = len(body)
-    for idx in range(1, len(body)):
-        if re.match(r"^  \S", body[idx]):
-            insert_at = idx
-            break
-    return body[:insert_at] + pins + body[insert_at:]
-
-
-def _render(segments) -> str:
-    return "".join(line for _, seg_lines in segments for line in seg_lines)
-
-
-def promote(
-    ci_config_path, dev_dir, prod_dir, *, tt_metal_commit, version, vllm_commit=None
-) -> dict:
-    """Promote release-marked dev templates into prod.
-
-    ``version`` and ``tt_metal_commit`` are injected into every promoted block.
-    ``vllm_commit`` is injected only into VLLM-engine templates and is required
-    when any promoted template uses the VLLM engine (raises ValueError otherwise).
-
-    Returns a report dict:
-      - combos: set of all release combos
-      - matches_by_file: dict filename -> list of MatchedBlock
-      - unmatched: set of combos with no dev template
-      - actions: dict filename -> list of (identity, "appended"|"updated")
-      - changed_files: list of prod filenames whose content would change
-    """
-    ci_config = json.loads(Path(ci_config_path).read_text())
-    combos = collect_release_combos(ci_config)
-    matches_by_file, unmatched = find_matches(Path(dev_dir), combos)
-
-    needs_vllm = any(
-        template_engine(block.template) == InferenceEngine.VLLM
-        for matched in matches_by_file.values()
-        for block in matched
-    )
-    if needs_vllm and vllm_commit is None:
-        raise ValueError(
-            "--vllm-commit is required: one or more promoted templates use the VLLM inference engine."
+        pins.append(("vllm_commit", vllm_commit))
+    for offset, (key, value) in enumerate(pins):
+        leaf.insert(
+            insert_at + offset,
+            key,
+            DoubleQuotedScalarString(value),
         )
 
-    actions = {}
-    changed_files = []
-    for filename, matched in matches_by_file.items():
-        prod_file = Path(prod_dir) / filename
-        original = prod_file.read_text() if prod_file.exists() else ""
-        segments = split_into_blocks(original)
 
-        file_actions = []
-        for block in matched:
-            is_vllm = template_engine(block.template) == InferenceEngine.VLLM
-            lines = inject_pin_fields(
-                block.lines,
-                version=version,
-                tt_metal_commit=tt_metal_commit,
-                vllm_commit=vllm_commit if is_vllm else None,
-            )
-            action = upsert_block(segments, block.identity, lines)
-            file_actions.append((block.identity, action))
-        actions[filename] = file_actions
+def _semantic_value(value):
+    if isinstance(value, dict):
+        return {str(key): _semantic_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_semantic_value(item) for item in value]
+    return value
 
-        new_text = _render(segments)
-        if new_text != original:
-            changed_files.append(filename)
-            prod_file.parent.mkdir(parents=True, exist_ok=True)
-            prod_file.write_text(new_text)
 
+def _set_explicit_perf_reference(leaf: CommentedMap, model_spec) -> None:
+    """Freeze the expanded leaf's derived performance reference in prod YAML."""
+    device_spec = leaf["device_model_specs"][0]
+    device_spec["perf_reference"] = [
+        _semantic_value(asdict(task))
+        for task in model_spec.device_model_spec.perf_reference
+    ]
+
+
+def _append_block(segments, lines) -> None:
+    last_block_index = next(
+        (
+            index
+            for index in range(len(segments) - 1, -1, -1)
+            if segments[index][0] == "block"
+        ),
+        None,
+    )
+    segment = ("block", lines)
+    if last_block_index is None:
+        for index, (kind, filler_lines) in enumerate(segments):
+            if kind == "filler" and any(
+                line.strip() == "templates: []" for line in filler_lines
+            ):
+                segments[index] = (
+                    "filler",
+                    [
+                        "templates:\n" if line.strip() == "templates: []" else line
+                        for line in filler_lines
+                    ],
+                )
+        segments.append(segment)
+    else:
+        if segments[last_block_index][1] and not segments[last_block_index][1][
+            -1
+        ].endswith("\n"):
+            segments[last_block_index][1][-1] += "\n"
+        segments.insert(last_block_index + 1, segment)
+
+
+def _render_segments(segments) -> str:
+    return "".join(line for _, lines in segments for line in lines)
+
+
+def _validate_candidate_catalog(candidate_text: dict[str, str]):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        prod_dir = Path(temp_dir) / "prod"
+        prod_dir.mkdir()
+        for filename in MODEL_SPEC_CATALOG_FILES:
+            (prod_dir / filename).write_text(candidate_text[filename])
+        templates = [
+            template
+            for filename in MODEL_SPEC_CATALOG_FILES
+            for template in load_templates_from_yaml(prod_dir / filename)
+        ]
+        return get_model_spec_map(templates)
+
+
+def _identity_json(identity: LeafIdentity) -> list[str]:
+    return list(identity)
+
+
+def report_to_jsonable(report: dict) -> dict:
+    """Convert the structured promotion report into deterministic JSON data."""
     return {
-        "combos": combos,
-        "matches_by_file": matches_by_file,
-        "unmatched": unmatched,
-        "actions": actions,
-        "changed_files": changed_files,
+        "ok": True,
+        "dry_run": report["dry_run"],
+        "configured_combos": [
+            {
+                "model_name": combo.model_name,
+                "engine": combo.engine.value,
+                "device": combo.device.to_string(),
+            }
+            for combo in report["configured_combos"]
+        ],
+        "requested_identities": [
+            _identity_json(identity) for identity in report["requested_identities"]
+        ],
+        "resolved": [
+            {
+                "identity": _identity_json(item.identity),
+                "source_path": str(item.source_path),
+                "template_index": item.template_index,
+                "weight_index": item.weight_index,
+                "device_index": item.device_index,
+            }
+            for item in report["resolved"]
+        ],
+        "actions": [
+            {"identity": _identity_json(identity), "action": action}
+            for identity, action in report["actions"].items()
+        ],
+        "added_identities": [
+            _identity_json(identity) for identity in report["added_identities"]
+        ],
+        "updated_identities": [
+            _identity_json(identity) for identity in report["updated_identities"]
+        ],
+        "unchanged_identities": [
+            _identity_json(identity) for identity in report["unchanged_identities"]
+        ],
+        "retained_identities": [
+            _identity_json(identity) for identity in report["retained_identities"]
+        ],
+        "changed_files": report["changed_files"],
+        "leaf_count_before": report["leaf_count_before"],
+        "leaf_count_after": report["leaf_count_after"],
     }
 
 
-def _combo_str(combo: ReleaseCombo) -> str:
-    return f"{combo.model_name} [{combo.engine.name}] on {combo.device.name}"
+def _require_non_empty(name: str, value: str | None) -> str:
+    if value is None or not value.strip():
+        raise ValueError(f"{name} must be a non-empty value")
+    return value
+
+
+def promote(
+    ci_config_path,
+    dev_dir,
+    prod_dir,
+    *,
+    tt_metal_commit,
+    version,
+    vllm_commit=None,
+    dry_run=False,
+) -> dict:
+    """Plan, validate, and optionally write exact leaf promotion."""
+    version = _require_non_empty("version", version)
+    tt_metal_commit = _require_non_empty("tt_metal_commit", tt_metal_commit)
+
+    ci_config = json.loads(Path(ci_config_path).read_text())
+    combos = collect_release_combos(ci_config)
+    sources = load_dev_model_spec_sources(Path(dev_dir))
+    resolved = resolve_release_combos(combos, sources)
+
+    resolved_by_identity = {}
+    for item in resolved:
+        existing = resolved_by_identity.get(item.identity)
+        if existing is not None and existing.combo != item.combo:
+            raise ValueError(
+                f"Multiple configured combos resolve to {item.identity!r}: "
+                f"{existing.combo!r} and {item.combo!r}"
+            )
+        resolved_by_identity[item.identity] = item
+
+    needs_vllm = any(
+        item.combo.engine == InferenceEngine.VLLM
+        for item in resolved_by_identity.values()
+    )
+    if needs_vllm:
+        vllm_commit = _require_non_empty("vllm_commit", vllm_commit)
+
+    raw_dev_documents = {}
+    promoted_leaves = {}
+    target_filenames = {}
+    for identity, item in resolved_by_identity.items():
+        document = raw_dev_documents.setdefault(
+            item.source_path,
+            _load_document(item.source_path),
+        )
+        try:
+            raw_template = document["templates"][item.template_index]
+        except IndexError as exc:
+            raise ValueError(
+                f"Source template index changed for release identity {identity!r}"
+            ) from exc
+        if _has_unsafe_yaml_structure(raw_template):
+            raise ValueError(
+                f"Source template for {identity!r} uses YAML anchors or merge keys"
+            )
+        actual_identity, leaf = _make_leaf(
+            raw_template,
+            item.weight_index,
+            item.device_index,
+            f"dev:{item.source_path.name}:{item.template_index}",
+        )
+        if actual_identity != identity:
+            raise ValueError(
+                f"Source provenance mismatch: expected {identity!r}, "
+                f"found {actual_identity!r}"
+            )
+        _set_explicit_perf_reference(leaf, item.model_spec)
+        _inject_pins(
+            leaf,
+            version=version,
+            tt_metal_commit=tt_metal_commit,
+            vllm_commit=vllm_commit
+            if item.combo.engine == InferenceEngine.VLLM
+            else None,
+        )
+        promoted_leaves[identity] = leaf
+        target_filenames[identity] = item.source_path.name
+
+    prod_dir = Path(prod_dir)
+    before_templates = [
+        template
+        for filename in MODEL_SPEC_CATALOG_FILES
+        for template in load_templates_from_yaml(prod_dir / filename)
+    ]
+    before_specs_by_identity = {
+        model_spec_leaf_identity(spec): spec
+        for spec in get_model_spec_map(before_templates).values()
+    }
+    before_payloads = {
+        identity: spec.get_serialized_dict()
+        for identity, spec in before_specs_by_identity.items()
+    }
+    original_text = {}
+    candidate_segments = {}
+    before_leaves = {}
+    owner_filenames = {}
+
+    for filename in MODEL_SPEC_CATALOG_FILES:
+        path = prod_dir / filename
+        text = path.read_text()
+        original_text[filename] = text
+        segments = split_into_blocks(text)
+        candidate_segments[filename] = [(kind, list(lines)) for kind, lines in segments]
+
+        block_index = 0
+        for kind, lines in segments:
+            if kind != "block":
+                continue
+            raw_template = _parse_block(lines)
+            for identity, leaf in _leafize_template(
+                raw_template,
+                f"prod:{filename}:{block_index}",
+            ):
+                if identity in before_leaves:
+                    raise ValueError(
+                        f"Duplicate prod identity {identity!r} in "
+                        f"{owner_filenames[identity]!r} and {filename!r}"
+                    )
+                before_leaves[identity] = _semantic_value(leaf)
+                owner_filenames[identity] = filename
+            block_index += 1
+
+    for identity, filename in owner_filenames.items():
+        if identity in target_filenames and filename != target_filenames[identity]:
+            raise ValueError(
+                f"Release identity {identity!r} would move from {filename!r} "
+                f"to {target_filenames[identity]!r}"
+            )
+
+    found_targets = set()
+    for filename, segments in candidate_segments.items():
+        block_index = 0
+        for segment_index, (kind, lines) in enumerate(list(segments)):
+            if kind != "block":
+                continue
+            raw_template = _parse_block(lines)
+            leaves = _leafize_template(
+                raw_template,
+                f"prod:{filename}:{block_index}",
+            )
+            block_index += 1
+            found_targets.update(
+                identity for identity, _ in leaves if identity in promoted_leaves
+            )
+            target_requires_update = any(
+                identity in promoted_leaves
+                and _semantic_value(old_leaf)
+                != _semantic_value(promoted_leaves[identity])
+                for identity, old_leaf in leaves
+            )
+            has_explicit_perf_references = all(
+                "perf_reference" in leaf["device_model_specs"][0] for _, leaf in leaves
+            )
+            if (
+                len(leaves) == 1
+                and has_explicit_perf_references
+                and not target_requires_update
+            ):
+                continue
+            if _has_unsafe_yaml_structure(raw_template):
+                raise ValueError(
+                    f"Template in {filename!r} uses YAML anchors or merge keys "
+                    "and cannot be leafized safely"
+                )
+
+            rendered_lines = []
+            for identity, old_leaf in leaves:
+                replacement = promoted_leaves.get(identity)
+                if replacement is None:
+                    replacement = old_leaf
+                    _set_explicit_perf_reference(
+                        replacement,
+                        before_specs_by_identity[identity],
+                    )
+                rendered_lines.extend(_render_block(replacement))
+                if identity in promoted_leaves:
+                    found_targets.add(identity)
+            segments[segment_index] = ("block", rendered_lines)
+
+    for identity, leaf in promoted_leaves.items():
+        if identity in found_targets:
+            continue
+        filename = target_filenames[identity]
+        if filename not in candidate_segments:
+            raise ValueError(
+                f"No prod catalog file {filename!r} for release identity {identity!r}"
+            )
+        _append_block(candidate_segments[filename], _render_block(leaf))
+
+    candidate_text = {
+        filename: _render_segments(segments)
+        for filename, segments in candidate_segments.items()
+    }
+
+    after_leaves = {}
+    for filename, text in candidate_text.items():
+        for kind, lines in split_into_blocks(text):
+            if kind != "block":
+                continue
+            raw_template = _parse_block(lines)
+            weights = raw_template.get("weights", [])
+            devices = raw_template.get("device_model_specs", [])
+            if len(weights) != 1 or len(devices) != 1:
+                raise ValueError(
+                    f"Candidate prod block in {filename!r} is not leaf-granular"
+                )
+            identity, leaf = _leafize_template(raw_template)[0]
+            if identity in after_leaves:
+                raise ValueError(f"Candidate prod contains duplicate {identity!r}")
+            after_leaves[identity] = _semantic_value(leaf)
+
+    requested = tuple(promoted_leaves)
+    requested_set = set(requested)
+    before_set = set(before_leaves)
+    after_set = set(after_leaves)
+    non_target_before = before_set - requested_set
+    non_target_after = after_set - requested_set
+    if non_target_before != non_target_after:
+        raise ValueError(
+            "Promotion changed non-requested identity membership: "
+            f"removed={sorted(non_target_before - non_target_after)!r}, "
+            f"added={sorted(non_target_after - non_target_before)!r}"
+        )
+    if not requested_set <= after_set:
+        raise ValueError(
+            f"Candidate prod is missing requested identities "
+            f"{sorted(requested_set - after_set)!r}"
+        )
+
+    candidate_model_specs = _validate_candidate_catalog(candidate_text)
+    after_payloads = {
+        model_spec_leaf_identity(spec): spec.get_serialized_dict()
+        for spec in candidate_model_specs.values()
+    }
+    for identity in non_target_before:
+        if before_payloads[identity] != after_payloads[identity]:
+            raise ValueError(
+                f"Promotion changed non-requested leaf payload {identity!r}"
+            )
+
+    actions = {}
+    for identity in requested:
+        if identity not in before_payloads:
+            actions[identity] = "added"
+        elif before_payloads[identity] != after_payloads[identity]:
+            actions[identity] = "updated"
+        else:
+            actions[identity] = "unchanged"
+
+    changed_files = [
+        filename
+        for filename in MODEL_SPEC_CATALOG_FILES
+        if candidate_text[filename] != original_text[filename]
+    ]
+    if not dry_run:
+        staged_paths = {}
+        try:
+            for filename in changed_files:
+                staged_path = prod_dir / f".{filename}.promotion.tmp"
+                staged_path.write_text(candidate_text[filename])
+                staged_paths[filename] = staged_path
+            for filename, staged_path in staged_paths.items():
+                staged_path.replace(prod_dir / filename)
+        finally:
+            for staged_path in staged_paths.values():
+                if staged_path.exists():
+                    staged_path.unlink()
+
+    return {
+        "dry_run": dry_run,
+        "configured_combos": combos,
+        "resolved": tuple(resolved_by_identity.values()),
+        "requested_identities": requested,
+        "actions": actions,
+        "added_identities": tuple(
+            identity for identity, action in actions.items() if action == "added"
+        ),
+        "updated_identities": tuple(
+            identity for identity, action in actions.items() if action == "updated"
+        ),
+        "unchanged_identities": tuple(
+            identity for identity, action in actions.items() if action == "unchanged"
+        ),
+        "retained_identities": tuple(sorted(non_target_after)),
+        "changed_files": changed_files,
+        "leaf_count_before": len(before_leaves),
+        "leaf_count_after": len(after_leaves),
+    }
+
+
+def _print_human_report(report: dict) -> None:
+    mode = "DRY RUN" if report["dry_run"] else "APPLIED"
+    print(f"{mode}: {len(report['configured_combos'])} configured release combos")
+    for item in report["resolved"]:
+        print(
+            f"RESOLVED  {item.combo.model_name} [{item.combo.engine.value}] "
+            f"on {item.combo.device.to_string()} -> {item.identity} "
+            f"({item.source_path}:{item.template_index}/"
+            f"{item.weight_index}/{item.device_index})"
+        )
+    for identity, action in report["actions"].items():
+        print(f"{action.upper():9} {identity}")
+    print(f"RETAINED  {len(report['retained_identities'])} existing identities")
+    print(f"Prod leaves: {report['leaf_count_before']} -> {report['leaf_count_after']}")
+    print(
+        f"{len(report['changed_files'])} prod file(s) changed: "
+        f"{report['changed_files']}"
+    )
 
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
-        description="Promote release-marked dev model specs into the prod catalogue."
+        description="Promote exact dev leaves into a leaf-granular prod catalog."
     )
     parser.add_argument("--ci-config", type=Path, default=DEFAULT_CI_CONFIG)
     parser.add_argument("--dev-dir", type=Path, default=DEFAULT_DEV_DIR)
@@ -354,6 +685,8 @@ def main(argv=None) -> int:
     parser.add_argument("--tt-metal-commit", required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--vllm-commit", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--json", action="store_true", dest="json_output")
     args = parser.parse_args(argv)
 
     try:
@@ -364,28 +697,28 @@ def main(argv=None) -> int:
             tt_metal_commit=args.tt_metal_commit,
             version=args.version,
             vllm_commit=args.vllm_commit,
+            dry_run=args.dry_run,
         )
-    except ValueError as exc:
+    except (OSError, PyYAMLError, RuamelYAMLError, ValueError) as exc:
+        if args.json_output:
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "error": str(exc),
+                        "error_type": type(exc).__name__,
+                    },
+                    indent=2,
+                )
+            )
+            return 2
         parser.error(str(exc))
 
-    for filename, file_actions in sorted(report["actions"].items()):
-        for identity, action in file_actions:
-            impl, engine, weights, devices = identity
-            print(
-                f"{action.upper():8} {filename}: "
-                f"{impl} [{engine.name}] {sorted(weights)} "
-                f"on {sorted(d.name for d in devices)}"
-            )
-    changed = report["changed_files"]
-    print(f"{len(changed)} prod file(s) changed: {sorted(changed)}")
-
-    for combo in sorted(
-        report["unmatched"],
-        key=lambda c: (c.model_name, c.engine.name, c.device.name),
-    ):
-        print(f"WARNING: no dev template found for {_combo_str(combo)}")
-
-    return 1 if report["unmatched"] else 0
+    if args.json_output:
+        print(json.dumps(report_to_jsonable(report), indent=2))
+    else:
+        _print_human_report(report)
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/release/promote_dev_spec_to_prod.py
+++ b/scripts/release/promote_dev_spec_to_prod.py
@@ -155,10 +155,11 @@ def _catalog_group(template: CommentedMap) -> str:
     if existing:
         return str(existing)
     weights = [str(weight) for weight in template.get("weights", [])]
+    # Group identity describes the logical docs owner, not its current members.
+    # Adding or removing a weight must not split re-promoted leaves from siblings.
     payload = {
         "model_display_name": template.get("model_display_name")
         or (Path(weights[0]).name if weights else ""),
-        "weights": sorted(weights),
         "inference_engine": str(template.get("inference_engine", "")),
         "impl": str(template.get("impl", "")),
     }

--- a/scripts/release/promote_dev_spec_to_prod.py
+++ b/scripts/release/promote_dev_spec_to_prod.py
@@ -116,7 +116,8 @@ def _render_block(template: CommentedMap) -> list[str]:
     lines = stream.getvalue().splitlines(keepends=True)
     if not lines:
         raise ValueError("Cannot render an empty template")
-    return [f"- {lines[0]}"] + [f"  {line}" for line in lines[1:]]
+    rendered = [f"- {lines[0]}"] + [f"  {line}" for line in lines[1:]]
+    return ["\n" if line.strip() == "" else line for line in rendered]
 
 
 def _template_identity(

--- a/scripts/release/promote_dev_spec_to_prod.py
+++ b/scripts/release/promote_dev_spec_to_prod.py
@@ -6,12 +6,10 @@
 """Promote exact release-scoped dev leaves into a leaf-granular prod catalog."""
 
 import argparse
-import hashlib
 import json
 import sys
 import tempfile
 from copy import deepcopy
-from dataclasses import asdict
 from io import StringIO
 from pathlib import Path
 
@@ -150,25 +148,6 @@ def _filter_metadata(template: CommentedMap, weight: str) -> None:
     template["metadata"] = filtered
 
 
-def _catalog_group(template: CommentedMap) -> str:
-    existing = template.get("catalog_group")
-    if existing:
-        return str(existing)
-    weights = [str(weight) for weight in template.get("weights", [])]
-    # Group identity describes the logical docs owner, not its current members.
-    # Adding or removing a weight must not split re-promoted leaves from siblings.
-    payload = {
-        "model_display_name": template.get("model_display_name")
-        or (Path(weights[0]).name if weights else ""),
-        "inference_engine": str(template.get("inference_engine", "")),
-        "impl": str(template.get("impl", "")),
-    }
-    digest = hashlib.sha256(
-        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
-    ).hexdigest()[:16]
-    return f"doc:{digest}"
-
-
 def _make_leaf(
     template: CommentedMap,
     weight_index: int,
@@ -191,28 +170,18 @@ def _make_leaf(
     leaf = deepcopy(template)
     leaf["weights"] = CommentedSeq([deepcopy(weights[weight_index])])
     leaf["device_model_specs"] = CommentedSeq([deepcopy(device_spec)])
-    leaf["model_display_name"] = (
-        template.get("model_display_name") or Path(str(weights[0])).name
-    )
-    leaf["catalog_group"] = _catalog_group(template)
     _filter_metadata(leaf, weight)
     return _template_identity(leaf, weight, leaf["device_model_specs"][0]), leaf
 
 
-def _leafize_template(
-    template: CommentedMap,
-) -> list[tuple[LeafIdentity, CommentedMap]]:
+def _flat_template_identity(template: CommentedMap) -> LeafIdentity:
     weights = template.get("weights")
     devices = template.get("device_model_specs")
-    if not isinstance(weights, list) or not weights:
-        raise ValueError("Template weights must be a non-empty list")
-    if not isinstance(devices, list) or not devices:
-        raise ValueError("Template device_model_specs must be a non-empty list")
-    return [
-        _make_leaf(template, weight_index, device_index)
-        for weight_index in range(len(weights))
-        for device_index in range(len(devices))
-    ]
+    if not isinstance(weights, list) or len(weights) != 1:
+        raise ValueError("Prod template must contain exactly one weight")
+    if not isinstance(devices, list) or len(devices) != 1:
+        raise ValueError("Prod template must contain exactly one device")
+    return _template_identity(template, str(weights[0]), devices[0])
 
 
 def _has_unsafe_yaml_structure(value) -> bool:
@@ -265,15 +234,6 @@ def _semantic_value(value):
     if isinstance(value, (list, tuple)):
         return [_semantic_value(item) for item in value]
     return value
-
-
-def _set_explicit_perf_reference(leaf: CommentedMap, model_spec) -> None:
-    """Freeze the expanded leaf's derived performance reference in prod YAML."""
-    device_spec = leaf["device_model_specs"][0]
-    device_spec["perf_reference"] = [
-        _semantic_value(asdict(task))
-        for task in model_spec.device_model_spec.perf_reference
-    ]
 
 
 def _append_block(segments, lines) -> None:
@@ -447,7 +407,6 @@ def promote(
                 f"Source provenance mismatch: expected {identity!r}, "
                 f"found {actual_identity!r}"
             )
-        _set_explicit_perf_reference(leaf, item.model_spec)
         _inject_pins(
             leaf,
             version=version,
@@ -475,8 +434,7 @@ def promote(
     }
     original_text = {}
     candidate_segments = {}
-    before_leaves = {}
-    owner_filenames = {}
+    prod_locations = {}
 
     for filename in MODEL_SPEC_CATALOG_FILES:
         path = prod_dir / filename
@@ -485,73 +443,22 @@ def promote(
         segments = split_into_blocks(text)
         candidate_segments[filename] = [(kind, list(lines)) for kind, lines in segments]
 
-        for kind, lines in segments:
+        for segment_index, (kind, lines) in enumerate(segments):
             if kind != "block":
                 continue
             raw_template = _parse_block(lines)
-            for identity, leaf in _leafize_template(raw_template):
-                if identity in before_leaves:
-                    raise ValueError(
-                        f"Duplicate prod identity {identity!r} in "
-                        f"{owner_filenames[identity]!r} and {filename!r}"
-                    )
-                before_leaves[identity] = _semantic_value(leaf)
-                owner_filenames[identity] = filename
-
-    for identity, filename in owner_filenames.items():
-        if identity in target_filenames and filename != target_filenames[identity]:
-            raise ValueError(
-                f"Release identity {identity!r} would move from {filename!r} "
-                f"to {target_filenames[identity]!r}"
-            )
-
-    found_targets = set()
-    for filename, segments in candidate_segments.items():
-        for segment_index, (kind, lines) in enumerate(list(segments)):
-            if kind != "block":
-                continue
-            raw_template = _parse_block(lines)
-            leaves = _leafize_template(raw_template)
-            found_targets.update(
-                identity for identity, _ in leaves if identity in promoted_leaves
-            )
-            target_requires_update = any(
-                identity in promoted_leaves
-                and _semantic_value(old_leaf)
-                != _semantic_value(promoted_leaves[identity])
-                for identity, old_leaf in leaves
-            )
-            has_explicit_perf_references = all(
-                "perf_reference" in leaf["device_model_specs"][0] for _, leaf in leaves
-            )
-            if (
-                len(leaves) == 1
-                and has_explicit_perf_references
-                and not target_requires_update
-            ):
-                continue
-            if _has_unsafe_yaml_structure(raw_template):
-                raise ValueError(
-                    f"Template in {filename!r} uses YAML anchors or merge keys "
-                    "and cannot be leafized safely"
-                )
-
-            rendered_lines = []
-            for identity, old_leaf in leaves:
-                replacement = promoted_leaves.get(identity)
-                if replacement is None:
-                    replacement = old_leaf
-                    _set_explicit_perf_reference(
-                        replacement,
-                        before_specs_by_identity[identity],
-                    )
-                rendered_lines.extend(_render_block(replacement))
-                if identity in promoted_leaves:
-                    found_targets.add(identity)
-            segments[segment_index] = ("block", rendered_lines)
+            identity = _flat_template_identity(raw_template)
+            prod_locations[identity] = (filename, segment_index, raw_template)
 
     for identity, leaf in promoted_leaves.items():
-        if identity in found_targets:
+        location = prod_locations.get(identity)
+        if location is not None:
+            filename, segment_index, current = location
+            if _semantic_value(current) != _semantic_value(leaf):
+                candidate_segments[filename][segment_index] = (
+                    "block",
+                    _render_block(leaf),
+                )
             continue
         filename = target_filenames[identity]
         if filename not in candidate_segments:
@@ -565,51 +472,19 @@ def promote(
         for filename, segments in candidate_segments.items()
     }
 
-    after_leaves = {}
-    for filename, text in candidate_text.items():
-        for kind, lines in split_into_blocks(text):
-            if kind != "block":
-                continue
-            raw_template = _parse_block(lines)
-            weights = raw_template.get("weights", [])
-            devices = raw_template.get("device_model_specs", [])
-            if len(weights) != 1 or len(devices) != 1:
-                raise ValueError(
-                    f"Candidate prod block in {filename!r} is not leaf-granular"
-                )
-            identity, leaf = _leafize_template(raw_template)[0]
-            if identity in after_leaves:
-                raise ValueError(f"Candidate prod contains duplicate {identity!r}")
-            after_leaves[identity] = _semantic_value(leaf)
-
     requested = tuple(promoted_leaves)
     requested_set = set(requested)
-    before_set = set(before_leaves)
-    after_set = set(after_leaves)
-    non_target_before = before_set - requested_set
-    non_target_after = after_set - requested_set
-    if non_target_before != non_target_after:
-        raise ValueError(
-            "Promotion changed non-requested identity membership: "
-            f"removed={sorted(non_target_before - non_target_after)!r}, "
-            f"added={sorted(non_target_after - non_target_before)!r}"
-        )
-    if not requested_set <= after_set:
-        raise ValueError(
-            f"Candidate prod is missing requested identities "
-            f"{sorted(requested_set - after_set)!r}"
-        )
-
     candidate_model_specs = _validate_candidate_catalog(candidate_text)
     after_payloads = {
         model_spec_leaf_identity(spec): spec.get_serialized_dict()
         for spec in candidate_model_specs.values()
     }
-    for identity in non_target_before:
-        if before_payloads[identity] != after_payloads[identity]:
-            raise ValueError(
-                f"Promotion changed non-requested leaf payload {identity!r}"
-            )
+    after_set = set(after_payloads)
+    if not requested_set <= after_set:
+        raise ValueError(
+            f"Candidate prod is missing requested identities "
+            f"{sorted(requested_set - after_set)!r}"
+        )
 
     actions = {}
     for identity in requested:
@@ -654,10 +529,10 @@ def promote(
         "unchanged_identities": tuple(
             identity for identity, action in actions.items() if action == "unchanged"
         ),
-        "retained_identities": tuple(sorted(non_target_after)),
+        "retained_identities": tuple(sorted(after_set - requested_set)),
         "changed_files": changed_files,
-        "leaf_count_before": len(before_leaves),
-        "leaf_count_after": len(after_leaves),
+        "leaf_count_before": len(before_payloads),
+        "leaf_count_after": len(after_payloads),
     }
 
 

--- a/scripts/release/promote_dev_spec_to_prod.py
+++ b/scripts/release/promote_dev_spec_to_prod.py
@@ -494,6 +494,18 @@ def promote(
             f"{sorted(requested_set - after_set)!r}"
         )
 
+    # A release may only move the identities it asked for. Everything else in
+    # prod must survive byte-identical, so a block-splitting or rendering defect
+    # that damages a neighbouring leaf fails the promotion instead of shipping.
+    for identity in sorted(after_set - requested_set):
+        if identity not in before_payloads:
+            raise ValueError(f"Promotion introduced unrequested identity {identity!r}")
+        if before_payloads[identity] != after_payloads[identity]:
+            raise ValueError(f"Promotion changed retained identity {identity!r}")
+    dropped = sorted(set(before_payloads) - after_set)
+    if dropped:
+        raise ValueError(f"Promotion dropped existing identities {dropped!r}")
+
     actions = {}
     for identity in requested:
         if identity not in before_payloads:

--- a/tests/test_model_catalog_yaml.py
+++ b/tests/test_model_catalog_yaml.py
@@ -95,6 +95,18 @@ def test_build_device_model_spec_with_known_issues_and_overrides():
     ]
 
 
+def test_catalog_device_spec_rejects_explicit_performance_reference():
+    with pytest.raises(ValueError, match="must not define perf_reference"):
+        _build_device_model_spec(
+            {
+                "device": "N150",
+                "max_concurrency": 1,
+                "max_context": 1024,
+                "perf_reference": [],
+            }
+        )
+
+
 def test_build_template_resolves_all_enum_and_impl_references():
     template = _build_template(
         {

--- a/tests/test_model_catalog_yaml.py
+++ b/tests/test_model_catalog_yaml.py
@@ -259,6 +259,17 @@ def test_catalog_yaml_loads_and_every_template_expands(env, yaml_name):
         assert specs, f"{env}/{yaml_name}: template {t.weights} expanded to zero specs"
 
 
+def test_multiweight_dev_templates_define_stable_display_name():
+    for yaml_name in EXPECTED_CATALOG_FILES:
+        templates = load_templates_from_yaml(MODEL_SPECS_DIR / "dev" / yaml_name)
+        for template in templates:
+            if len(template.weights) > 1:
+                assert template.model_display_name, (
+                    f"dev/{yaml_name}: multiweight template {template.weights!r} "
+                    "must define model_display_name"
+                )
+
+
 @pytest.mark.parametrize("env", EXPECTED_CATALOG_ENVS)
 def test_catalog_environment_has_unambiguous_expanded_identities(env):
     """Validate identities across category-file boundaries within one environment."""

--- a/tests/test_model_catalog_yaml.py
+++ b/tests/test_model_catalog_yaml.py
@@ -15,6 +15,7 @@ from workflows.model_spec import (
     _build_device_model_spec,
     _build_system_requirements,
     _build_template,
+    get_model_spec_map,
     load_templates_from_yaml,
     tt_transformers_impl,
 )
@@ -256,6 +257,19 @@ def test_catalog_yaml_loads_and_every_template_expands(env, yaml_name):
     for t in templates:
         specs = t.expand_to_specs()
         assert specs, f"{env}/{yaml_name}: template {t.weights} expanded to zero specs"
+
+
+@pytest.mark.parametrize("env", EXPECTED_CATALOG_ENVS)
+def test_catalog_environment_has_unambiguous_expanded_identities(env):
+    """Validate identities across category-file boundaries within one environment."""
+    templates = [
+        template
+        for yaml_name in EXPECTED_CATALOG_FILES
+        for template in load_templates_from_yaml(MODEL_SPECS_DIR / env / yaml_name)
+    ]
+    expanded_count = sum(len(template.expand_to_specs()) for template in templates)
+
+    assert len(get_model_spec_map(templates)) == expanded_count
 
 
 def test_diffusiongemma_dev_spec_matches_validated_256k_contract():

--- a/tests/test_model_catalog_yaml.py
+++ b/tests/test_model_catalog_yaml.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
 import json
+from dataclasses import replace
 
 from workflows.utils import get_repo_root_path
 from workflows.model_spec import (
@@ -105,6 +106,50 @@ def test_catalog_device_spec_rejects_explicit_performance_reference():
                 "perf_reference": [],
             }
         )
+
+
+def test_expansion_carries_every_catalog_device_field_but_perf_reference():
+    """Expansion may substitute the derived field and nothing else.
+
+    ``image_benchmark_num_batches`` was configurable in the catalog for a month
+    without reaching the runtime spec, because expansion rebuilt the device spec
+    from a hand-written field list. Compare against the whole catalog spec so a
+    field added later cannot be dropped the same way.
+    """
+    template = _build_template(
+        {
+            "weights": ["Qwen/Qwen3-8B"],
+            "impl": "tt_transformers",
+            "inference_engine": "VLLM",
+            "device_model_specs": [
+                {
+                    "device": "N150",
+                    "max_concurrency": 32,
+                    "max_context": 32768,
+                    "default_impl": True,
+                    "image_benchmark_num_batches": 7,
+                    "eval_max_retries": 1,
+                    "tensor_cache_timeout": 60.0,
+                },
+            ],
+        },
+        "dev",
+    )
+    catalog_spec = template.device_model_specs[0]
+
+    runtime_spec = template.expand_to_specs()[0].device_model_spec
+
+    assert runtime_spec.image_benchmark_num_batches == 7
+    # ModelSpec.__post_init__ adds the weight to the runtime spec's vllm_args,
+    # so check that one separately. Blanking it on both sides lets __post_init__
+    # rebuild the same derived args and leaves every other field comparable.
+    assert runtime_spec.vllm_args == {
+        **catalog_spec.vllm_args,
+        "model": "Qwen/Qwen3-8B",
+    }
+    assert replace(runtime_spec, vllm_args={}, perf_reference=[]) == replace(
+        catalog_spec, vllm_args={}, perf_reference=[]
+    )
 
 
 def test_build_template_resolves_all_enum_and_impl_references():

--- a/tests/test_model_catalog_yaml.py
+++ b/tests/test_model_catalog_yaml.py
@@ -96,6 +96,26 @@ def test_build_device_model_spec_with_known_issues_and_overrides():
     ]
 
 
+def test_catalog_device_spec_accepts_perf_targets_map():
+    """The tiers are settable per device; the reference numbers are not.
+
+    `perf_targets_map` says what fraction of theoretical counts as passing, which
+    is a property of the stack on that board. `perf_reference` is the theoretical
+    number itself, a property of the model and the hardware, so it is derived and
+    rejected here. Keeping both readable in one place because the pair is easy to
+    confuse.
+    """
+    spec = _build_device_model_spec(
+        {
+            "device": "P300X2",
+            "max_concurrency": 16,
+            "max_context": 1024,
+            "perf_targets_map": {"complete": 0.30},
+        }
+    )
+    assert spec.perf_targets_map == {"complete": 0.30}
+
+
 def test_catalog_device_spec_rejects_explicit_performance_reference():
     with pytest.raises(ValueError, match="must not define perf_reference"):
         _build_device_model_spec(

--- a/tests/test_model_catalog_yaml.py
+++ b/tests/test_model_catalog_yaml.py
@@ -276,9 +276,10 @@ def test_multiweight_dev_templates_define_stable_display_name():
         templates = load_templates_from_yaml(MODEL_SPECS_DIR / "dev" / yaml_name)
         for template in templates:
             if len(template.weights) > 1:
-                assert template.model_display_name, (
+                expected = template.weights[0].split("/")[-1]
+                assert template.model_display_name == expected, (
                     f"dev/{yaml_name}: multiweight template {template.weights!r} "
-                    "must define model_display_name"
+                    f"must define model_display_name={expected!r}"
                 )
 
 

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -672,7 +672,13 @@ class TestSystemIntegration:
             model_display_name=model_display_name,
         )
 
-    def test_model_display_name_is_performance_reference_lookup_key(self, monkeypatch):
+    def test_performance_reference_is_looked_up_per_weight(self, monkeypatch):
+        """Every weight is graded against the targets measured for itself.
+
+        Keying the lookup on the family name applied one member's numbers to all
+        of its siblings, so a model built to be faster or slower than the family
+        head was judged at a bar that had never been measured for it.
+        """
         lookups = []
         monkeypatch.setattr(
             "workflows.model_spec.get_perf_reference_map",
@@ -686,7 +692,7 @@ class TestSystemIntegration:
 
         template.expand_to_specs()
 
-        assert lookups == ["stable-model-family"]
+        assert lookups == ["model-base", "model-instruct"]
 
     def test_model_spec_map_generation(self, sample_impl):
         """Test spec map generation from templates."""

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -634,6 +634,41 @@ class TestModelSpecSystem:
 class TestSystemIntegration:
     """Integration tests for the model spec system."""
 
+    @staticmethod
+    def _impl(impl_id):
+        return ImplSpec(
+            impl_id=impl_id,
+            impl_name=impl_id,
+            repo_url=f"https://github.com/test/{impl_id}",
+            code_path=f"models/{impl_id}",
+        )
+
+    @staticmethod
+    def _template(
+        impl,
+        *,
+        weights=None,
+        device=DeviceTypes.N150,
+        engine=InferenceEngine.VLLM.value,
+        default_impl=False,
+    ):
+        return ProdModelSpecTemplate(
+            impl=impl,
+            version="0.0.0",
+            tt_metal_commit="v1.0.0",
+            vllm_commit="abc123",
+            inference_engine=engine,
+            device_model_specs=[
+                DeviceModelSpec(
+                    device=device,
+                    max_concurrency=16,
+                    max_context=64 * 1024,
+                    default_impl=default_impl,
+                ),
+            ],
+            weights=weights or ["test/model-A"],
+        )
+
     def test_model_spec_map_generation(self, sample_impl):
         """Test spec map generation from templates."""
         templates = [
@@ -661,6 +696,85 @@ class TestSystemIntegration:
             assert isinstance(spec, ModelSpec)
             assert model_id.startswith("id_")
             assert spec.model_id == model_id
+
+    def test_model_spec_map_rejects_duplicate_leaf_identity(self):
+        template = self._template(self._impl("impl-a"))
+
+        with pytest.raises(ValueError) as exc_info:
+            get_model_spec_map([template, template])
+
+        message = str(exc_info.value)
+        assert "Duplicate model spec leaf identity" in message
+        assert "test/model-A" in message
+        assert DeviceTypes.N150.to_string() in message
+        assert InferenceEngine.VLLM.value in message
+        assert "impl-a" in message
+
+    def test_model_spec_map_rejects_multiple_default_implementations(self):
+        templates = [
+            self._template(self._impl("impl-a"), default_impl=True),
+            self._template(self._impl("impl-b"), default_impl=True),
+        ]
+
+        with pytest.raises(ValueError) as exc_info:
+            get_model_spec_map(templates)
+
+        message = str(exc_info.value)
+        assert "Multiple default implementations" in message
+        assert "test/model-A" in message
+        assert DeviceTypes.N150.to_string() in message
+        assert InferenceEngine.VLLM.value in message
+        assert "impl-a" in message
+        assert "impl-b" in message
+
+    def test_model_spec_map_accepts_one_default_implementation(self):
+        templates = [
+            self._template(self._impl("impl-a"), default_impl=True),
+            self._template(self._impl("impl-b")),
+        ]
+
+        assert len(get_model_spec_map(templates)) == 2
+
+    def test_model_spec_map_accepts_no_default_implementation(self):
+        templates = [
+            self._template(self._impl("impl-a")),
+            self._template(self._impl("impl-b")),
+        ]
+
+        assert len(get_model_spec_map(templates)) == 2
+
+    def test_model_spec_map_accepts_distinct_leaf_groups(self):
+        templates = [
+            self._template(self._impl("impl-a"), default_impl=True),
+            self._template(
+                self._impl("impl-a"),
+                device=DeviceTypes.N300,
+                default_impl=True,
+            ),
+            self._template(
+                self._impl("impl-b"),
+                weights=["test/model-B"],
+                engine=InferenceEngine.MEDIA.value,
+                default_impl=True,
+            ),
+        ]
+
+        assert len(get_model_spec_map(templates)) == 3
+
+    def test_model_spec_map_rejects_distinct_leaves_with_same_model_id(self):
+        impl = self._impl("impl-a")
+        templates = [
+            self._template(impl, weights=["org-one/model-A"]),
+            self._template(impl, weights=["org-two/model-A"]),
+        ]
+
+        with pytest.raises(ValueError) as exc_info:
+            get_model_spec_map(templates)
+
+        message = str(exc_info.value)
+        assert "maps to multiple leaf identities" in message
+        assert "org-one/model-A" in message
+        assert "org-two/model-A" in message
 
     def test_export_model_specs_json_includes_metadata(
         self, sample_impl, sample_device_model_spec, tmp_path

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -652,6 +652,7 @@ class TestSystemIntegration:
         device=DeviceTypes.N150,
         engine=InferenceEngine.VLLM.value,
         default_impl=False,
+        model_display_name=None,
     ):
         return ProdModelSpecTemplate(
             impl=impl,
@@ -668,7 +669,24 @@ class TestSystemIntegration:
                 ),
             ],
             weights=weights or ["test/model-A"],
+            model_display_name=model_display_name,
         )
+
+    def test_model_display_name_is_performance_reference_lookup_key(self, monkeypatch):
+        lookups = []
+        monkeypatch.setattr(
+            "workflows.model_spec.get_perf_reference_map",
+            lambda model_name, targets: lookups.append(model_name) or {},
+        )
+        template = self._template(
+            self._impl("impl-a"),
+            weights=["org/model-base", "org/model-instruct"],
+            model_display_name="stable-model-family",
+        )
+
+        template.expand_to_specs()
+
+        assert lookups == ["stable-model-family"]
 
     def test_model_spec_map_generation(self, sample_impl):
         """Test spec map generation from templates."""

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -21,6 +21,7 @@ from workflows.model_spec import (
     VersionRequirement,
     export_model_specs_json,
     get_model_spec_map,
+    resolve_model_spec,
     spec_templates,
     SystemRequirements,
 )
@@ -775,6 +776,159 @@ class TestSystemIntegration:
         assert "maps to multiple leaf identities" in message
         assert "org-one/model-A" in message
         assert "org-two/model-A" in message
+
+    def test_resolve_model_spec_selects_engine_scoped_default(self):
+        specs = [
+            spec
+            for template in [
+                self._template(self._impl("impl-a")),
+                self._template(self._impl("impl-b"), default_impl=True),
+            ]
+            for spec in template.expand_to_specs()
+        ]
+
+        selected = resolve_model_spec(
+            specs,
+            model="test/model-A",
+            device="n150",
+            engine="vllm",
+            catalog_name="test dev catalog",
+        )
+
+        assert selected.impl.impl_id == "impl-b"
+
+    def test_resolve_model_spec_selects_explicit_non_default_impl(self):
+        specs = [
+            spec
+            for template in [
+                self._template(self._impl("impl-a"), default_impl=True),
+                self._template(self._impl("impl-b")),
+            ]
+            for spec in template.expand_to_specs()
+        ]
+
+        selected = resolve_model_spec(
+            specs,
+            model="model-A",
+            device=DeviceTypes.N150,
+            engine=InferenceEngine.VLLM,
+            impl="impl-b",
+        )
+
+        assert selected.impl.impl_id == "impl-b"
+
+    def test_resolve_model_spec_rejects_engine_scoped_order_fallback(self):
+        specs = [
+            spec
+            for template in [
+                self._template(self._impl("impl-a")),
+                self._template(self._impl("impl-b")),
+            ]
+            for spec in template.expand_to_specs()
+        ]
+
+        with pytest.raises(ValueError, match="No unique default implementation"):
+            resolve_model_spec(
+                specs,
+                model="model-A",
+                device="N150",
+                engine="VLLM",
+            )
+
+    def test_resolve_model_spec_accepts_sole_engine_candidate_without_default(self):
+        [spec] = self._template(self._impl("impl-a")).expand_to_specs()
+
+        assert (
+            resolve_model_spec(
+                [spec],
+                model="model-A",
+                device="N150",
+                engine="VLLM",
+            )
+            is spec
+        )
+
+    def test_resolve_model_spec_preserves_cross_engine_default_precedence(self):
+        [vllm_spec] = self._template(
+            self._impl("impl-a"), default_impl=True
+        ).expand_to_specs()
+        [media_spec] = self._template(
+            self._impl("impl-b"),
+            engine=InferenceEngine.MEDIA.value,
+            default_impl=True,
+        ).expand_to_specs()
+
+        assert (
+            resolve_model_spec(
+                [vllm_spec, media_spec],
+                model="model-A",
+                device="N150",
+            )
+            is vllm_spec
+        )
+
+    def test_resolve_model_spec_rejects_basename_collision(self):
+        specs = [
+            spec
+            for template in [
+                self._template(self._impl("impl-a"), weights=["org-one/model-A"]),
+                self._template(self._impl("impl-b"), weights=["org-two/model-A"]),
+            ]
+            for spec in template.expand_to_specs()
+        ]
+
+        with pytest.raises(ValueError) as exc_info:
+            resolve_model_spec(
+                specs,
+                model="model-A",
+                device="N150",
+                engine="VLLM",
+            )
+
+        message = str(exc_info.value)
+        assert "ambiguous" in message
+        assert "org-one/model-A" in message
+        assert "org-two/model-A" in message
+
+    def test_resolve_model_spec_full_repo_disambiguates_basename_collision(self):
+        specs = [
+            spec
+            for template in [
+                self._template(
+                    self._impl("impl-a"),
+                    weights=["org-one/model-A"],
+                    default_impl=True,
+                ),
+                self._template(
+                    self._impl("impl-b"),
+                    weights=["org-two/model-A"],
+                    default_impl=True,
+                ),
+            ]
+            for spec in template.expand_to_specs()
+        ]
+
+        selected = resolve_model_spec(
+            specs,
+            model="org-two/model-A",
+            device="N150",
+            engine="VLLM",
+        )
+
+        assert selected.hf_model_repo == "org-two/model-A"
+
+    def test_resolve_model_spec_rejects_missing_leaf(self):
+        [spec] = self._template(
+            self._impl("impl-a"), default_impl=True
+        ).expand_to_specs()
+
+        with pytest.raises(ValueError, match="No model spec matches"):
+            resolve_model_spec(
+                [spec],
+                model="model-A",
+                device="N300",
+                engine="VLLM",
+            )
 
     def test_export_model_specs_json_includes_metadata(
         self, sample_impl, sample_device_model_spec, tmp_path

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -782,9 +782,7 @@ class TestSystemIntegration:
         the untouched tiers stay put.
         """
         base = self._real_reference_template({}).expand_to_specs()[0]
-        halved = self._real_reference_template(
-            {"complete": 0.25}
-        ).expand_to_specs()[0]
+        halved = self._real_reference_template({"complete": 0.25}).expand_to_specs()[0]
 
         base_targets = base.device_model_spec.perf_reference[0].targets
         halved_targets = halved.device_model_spec.perf_reference[0].targets

--- a/tests/test_model_specification.py
+++ b/tests/test_model_specification.py
@@ -694,6 +694,112 @@ class TestSystemIntegration:
 
         assert lookups == ["model-base", "model-instruct"]
 
+    def _template_with_device_targets(self, device_targets, template_targets=None):
+        """A two-device template where only the second device overrides its tiers."""
+        impl = self._impl("impl-a")
+        return ProdModelSpecTemplate(
+            impl=impl,
+            version="0.0.0",
+            tt_metal_commit="v1.0.0",
+            vllm_commit="abc123",
+            inference_engine=InferenceEngine.VLLM.value,
+            perf_targets_map=template_targets or {},
+            device_model_specs=[
+                DeviceModelSpec(
+                    device=DeviceTypes.N150, max_concurrency=16, max_context=1024
+                ),
+                DeviceModelSpec(
+                    device=DeviceTypes.N300,
+                    max_concurrency=16,
+                    max_context=1024,
+                    perf_targets_map=device_targets,
+                ),
+            ],
+            weights=["test/model-A"],
+        )
+
+    def test_device_perf_targets_override_the_template_tiers(self, monkeypatch):
+        """A device can be graded at a different fraction of theoretical.
+
+        The theoretical reference is a property of the model and the hardware, so
+        it stays shared; what a device may differ in is how much of it counts as
+        passing. Before this the field existed on `DeviceModelSpec`, was accepted
+        from catalog YAML, and was never read -- the tiers always came from the
+        template.
+        """
+        calls = []
+        monkeypatch.setattr(
+            "workflows.model_spec.get_perf_reference_map",
+            lambda model_name, targets: calls.append(dict(targets)) or {},
+        )
+
+        self._template_with_device_targets({"complete": 0.30}).expand_to_specs()
+
+        template_default = {"functional": 0.10, "complete": 0.50, "target": 1.0}
+        assert calls == [
+            template_default,
+            # tier-by-tier: `complete` loosened, the others inherited
+            {**template_default, "complete": 0.30},
+        ]
+
+    def test_a_device_without_an_override_reuses_the_template_map(self, monkeypatch):
+        """The common case must not pay for the feature: one lookup per weight."""
+        calls = []
+        monkeypatch.setattr(
+            "workflows.model_spec.get_perf_reference_map",
+            lambda model_name, targets: calls.append(dict(targets)) or {},
+        )
+
+        self._template_with_device_targets({}).expand_to_specs()
+
+        assert calls == [{"functional": 0.10, "complete": 0.50, "target": 1.0}]
+
+    def _real_reference_template(self, device_targets):
+        """A template on a weight that actually has reference data, so the tiers
+        are computed from real numbers rather than a monkeypatched map."""
+        return ProdModelSpecTemplate(
+            impl=self._impl("impl-a"),
+            version="0.0.0",
+            tt_metal_commit="v1.0.0",
+            vllm_commit="abc123",
+            inference_engine=InferenceEngine.VLLM.value,
+            device_model_specs=[
+                DeviceModelSpec(
+                    device=DeviceTypes.P300X2,
+                    max_concurrency=16,
+                    max_context=1024,
+                    perf_targets_map=device_targets,
+                ),
+            ],
+            weights=["google/gemma-4-31b-it"],
+        )
+
+    def test_device_override_reaches_the_expanded_targets(self):
+        """End to end against the real reference data, not a monkeypatch.
+
+        `tput` scales with the percentage and `ttft_ms` divides by it, so halving
+        `complete` halves the throughput bar and doubles the latency budget, while
+        the untouched tiers stay put.
+        """
+        base = self._real_reference_template({}).expand_to_specs()[0]
+        halved = self._real_reference_template(
+            {"complete": 0.25}
+        ).expand_to_specs()[0]
+
+        base_targets = base.device_model_spec.perf_reference[0].targets
+        halved_targets = halved.device_model_spec.perf_reference[0].targets
+
+        assert base_targets["complete"].tput == pytest.approx(37 * 0.50)
+        assert halved_targets["complete"].tput == pytest.approx(37 * 0.25)
+        assert halved_targets["complete"].ttft_ms == pytest.approx(46 / 0.25)
+        # tier-by-tier: `functional` and `target` are inherited unchanged
+        assert halved_targets["functional"].tput == pytest.approx(
+            base_targets["functional"].tput
+        )
+        assert halved_targets["target"].tput == pytest.approx(
+            base_targets["target"].tput
+        )
+
     def test_model_spec_map_generation(self, sample_impl):
         """Test spec map generation from templates."""
         templates = [

--- a/tests/test_promote_dev_spec_to_prod.py
+++ b/tests/test_promote_dev_spec_to_prod.py
@@ -543,3 +543,32 @@ def test_docs_coalesce_flat_weights_by_stable_model_family(tmp_path):
 
     assert len(coalesced) == 1
     assert coalesced[0].weights == ["org/model-base", "org/model-instruct"]
+
+
+def test_docs_do_not_coalesce_implicit_basename_collisions(tmp_path):
+    _, prod_dir = _write_catalogs(
+        tmp_path,
+        dev_llm="templates: []\n",
+        prod_llm="""
+            templates:
+            - weights: [org-a/shared]
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "1.0.0"
+              tt_metal_commit: metal
+              vllm_commit: vllm
+              device_model_specs:
+                - {device: N150, max_concurrency: 1, max_context: 1024}
+            - weights: [org-b/shared]
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "1.0.0"
+              tt_metal_commit: metal
+              vllm_commit: vllm
+              device_model_specs:
+                - {device: N150, max_concurrency: 1, max_context: 1024}
+        """,
+    )
+    templates = load_templates_from_yaml(prod_dir / "llm.yaml")
+
+    assert coalesce_model_families_for_docs(templates) == templates

--- a/tests/test_promote_dev_spec_to_prod.py
+++ b/tests/test_promote_dev_spec_to_prod.py
@@ -10,11 +10,13 @@ import textwrap
 
 import pytest
 import yaml
+from ruamel.yaml.comments import CommentedMap
 
 from scripts.release.promote_dev_spec_to_prod import (
     DEFAULT_CI_CONFIG,
     DEFAULT_DEV_DIR,
     DEFAULT_PROD_DIR,
+    _catalog_group,
     main,
     promote,
 )
@@ -35,6 +37,24 @@ PINS = {
     "version": "9.9.9",
     "vllm_commit": "new-vllm",
 }
+
+
+def test_catalog_group_ignores_weight_membership_but_distinguishes_impl():
+    template = CommentedMap(
+        {
+            "weights": ["org/model-base"],
+            "model_display_name": "model",
+            "inference_engine": "VLLM",
+            "impl": "tt_transformers",
+        }
+    )
+    original = _catalog_group(template)
+
+    template["weights"].append("org/model-instruct")
+    assert _catalog_group(template) == original
+
+    template["impl"] = "forge_vllm_plugin"
+    assert _catalog_group(template) != original
 
 
 def _write_catalogs(tmp_path, *, dev_llm, prod_llm):
@@ -526,7 +546,7 @@ def test_full_prod_flattening_preserves_generated_documentation(tmp_path):
     assert _file_tree(after_docs) == _file_tree(before_docs)
 
 
-def test_docs_do_not_coalesce_heterogeneous_release_pins(tmp_path):
+def test_docs_show_limits_for_heterogeneous_release_configurations(tmp_path):
     _, prod_dir = _write_catalogs(
         tmp_path,
         dev_llm="templates: []\n",
@@ -551,12 +571,20 @@ def test_docs_do_not_coalesce_heterogeneous_release_pins(tmp_path):
               catalog_group: shared
               model_display_name: model
               device_model_specs:
-                - {device: N150, max_concurrency: 1, max_context: 1024}
+                - {device: N150, max_concurrency: 8, max_context: 65536}
         """,
     )
     templates = load_templates_from_yaml(prod_dir / "llm.yaml")
 
     assert coalesce_catalog_groups_for_docs(templates) == templates
+    docs = tmp_path / "docs"
+    with contextlib.redirect_stdout(io.StringIO()):
+        generate_doc_pages(templates, str(docs))
+    page = (docs / "llm" / "model_n150.md").read_text()
+    assert (
+        "| Weights | Implementation | Max Batch Size | Max Context Length |"
+    ) in page
+    assert "| 8 | 65536 |" in page
 
 
 def test_real_catalog_promotion_is_exact_leaf_granular_and_idempotent(tmp_path):

--- a/tests/test_promote_dev_spec_to_prod.py
+++ b/tests/test_promote_dev_spec_to_prod.py
@@ -33,6 +33,26 @@ PINS = {
 }
 
 
+_DEFAULT_IMPL_ENTRY = """
+            - weights: [org/model]
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "1.0.0"
+              tt_metal_commit: aaaaaaa
+              vllm_commit: aaaaaaa
+              device_model_specs:
+                - {device: N150, max_concurrency: 32, max_context: 65536, default_impl: true}"""
+
+_ALTERNATE_IMPL_ENTRY = """
+            - weights: [org/model]
+              impl: forge_vllm_plugin
+              inference_engine: FORGE
+              version: "2.0.0"
+              tt_metal_commit: bbbbbbb
+              device_model_specs:
+                - {device: N150, max_concurrency: 1, max_context: 2048}"""
+
+
 def _write_catalogs(tmp_path, *, dev_llm, prod_llm):
     dev_dir = tmp_path / "dev"
     prod_dir = tmp_path / "prod"
@@ -494,6 +514,37 @@ def test_second_promotion_is_byte_idempotent(tmp_path):
     assert {
         path.name: path.read_bytes() for path in prod_dir.glob("*.yaml")
     } == after_first
+
+
+@pytest.mark.parametrize("default_first", [True, False])
+def test_docs_document_the_default_impl_regardless_of_catalog_order(
+    tmp_path, default_first
+):
+    """The page headlines the default implementation, not the first entry.
+
+    Selecting by catalog order let a non-default impl become the documented
+    configuration merely by being listed first, putting its own batch and
+    context limits into the quickstart a reader copies.
+    """
+    entries = [_DEFAULT_IMPL_ENTRY, _ALTERNATE_IMPL_ENTRY]
+    if not default_first:
+        entries.reverse()
+    _, prod_dir = _write_catalogs(
+        tmp_path,
+        dev_llm="templates: []\n",
+        prod_llm="templates:" + "".join(entries) + "\n",
+    )
+    templates = load_templates_from_yaml(prod_dir / "llm.yaml")
+
+    docs = tmp_path / "docs"
+    with contextlib.redirect_stdout(io.StringIO()):
+        generate_doc_pages(templates, str(docs))
+    page = (docs / "llm" / "model_n150.md").read_text()
+
+    assert "| Implementation Code | [tt-transformers" in page
+    assert "| Max Batch Size | 32 |" in page
+    assert "#### Additional released configurations" in page
+    assert "| `forge-vllm-plugin` |" in page
 
 
 def test_docs_show_limits_for_heterogeneous_release_configurations(tmp_path):

--- a/tests/test_promote_dev_spec_to_prod.py
+++ b/tests/test_promote_dev_spec_to_prod.py
@@ -10,6 +10,7 @@ import textwrap
 import pytest
 import yaml
 
+import scripts.release.promote_dev_spec_to_prod as promote_module
 from scripts.release.promote_dev_spec_to_prod import (
     main,
     promote,
@@ -276,6 +277,29 @@ def test_resolution_failure_does_not_write_any_prod_file(tmp_path):
     before = {path.name: path.read_bytes() for path in prod_dir.glob("*.yaml")}
 
     with pytest.raises(ValueError, match="No model spec matches"):
+        promote(ci_path, dev_dir, prod_dir, **PINS)
+
+    assert {path.name: path.read_bytes() for path in prod_dir.glob("*.yaml")} == before
+
+
+def test_damaged_retained_leaf_fails_before_write(tmp_path, monkeypatch):
+    """A release may only move the identities it asked for.
+
+    Block splitting and rendering rewrite catalog text around leaves the
+    release never selected. Simulate such a defect and require the promotion to
+    refuse it rather than ship a silently altered released configuration.
+    """
+    ci_path, dev_dir, prod_dir = _flat_fixture(tmp_path)
+    before = {path.name: path.read_bytes() for path in prod_dir.glob("*.yaml")}
+
+    render_segments = promote_module._render_segments
+
+    def damage_unrelated_leaf(segments):
+        return render_segments(segments).replace("unrelated-metal", "damaged-metal")
+
+    monkeypatch.setattr(promote_module, "_render_segments", damage_unrelated_leaf)
+
+    with pytest.raises(ValueError, match="changed retained identity"):
         promote(ci_path, dev_dir, prod_dir, **PINS)
 
     assert {path.name: path.read_bytes() for path in prod_dir.glob("*.yaml")} == before

--- a/tests/test_promote_dev_spec_to_prod.py
+++ b/tests/test_promote_dev_spec_to_prod.py
@@ -610,3 +610,62 @@ def test_real_catalog_promotion_is_exact_leaf_granular_and_idempotent(tmp_path):
     assert {
         path.name: path.read_bytes() for path in prod_copy.glob("*.yaml")
     } == snapshot
+
+
+def test_partial_multiweight_release_keeps_sibling_docs_and_stable_group(tmp_path):
+    prod_copy = tmp_path / "prod"
+    shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
+    empty_config = _write_ci(tmp_path, {})
+    promote(
+        empty_config,
+        DEFAULT_DEV_DIR,
+        prod_copy,
+        version="base",
+        tt_metal_commit="base-metal",
+    )
+    release_config = _write_ci(
+        tmp_path,
+        {"Llama-3.1-8B": _vllm_release_entry("N150")},
+    )
+
+    promote(
+        release_config,
+        DEFAULT_DEV_DIR,
+        prod_copy,
+        version="next",
+        tt_metal_commit="next-metal",
+        vllm_commit="next-vllm",
+    )
+    docs = tmp_path / "docs"
+    with contextlib.redirect_stdout(io.StringIO()):
+        generate_doc_pages(
+            [
+                template
+                for filename in MODEL_SPEC_CATALOG_FILES
+                for template in load_templates_from_yaml(prod_copy / filename)
+            ],
+            str(docs),
+        )
+
+    n150 = (docs / "llm" / "Llama-3.1-8B_n150.md").read_text()
+    n300 = (docs / "llm" / "Llama-3.1-8B_n300.md").read_text()
+    assert "Llama-3.1-8B-Instruct" in n150
+    assert "Additional released configurations" in n150
+    assert "Llama-3.1-8B-Instruct" in n300
+
+    llama_groups = {
+        template["catalog_group"]
+        for template in _raw_templates(prod_copy)
+        if template.get("model_display_name") == "Llama-3.1-8B"
+        and template["impl"] == "tt_transformers"
+        and any(
+            weight
+            in {
+                "meta-llama/Llama-3.1-8B",
+                "meta-llama/Llama-3.1-8B-Instruct",
+            }
+            for weight in template["weights"]
+        )
+    }
+    assert len(llama_groups) == 1
+    assert next(iter(llama_groups)).startswith("doc:")

--- a/tests/test_promote_dev_spec_to_prod.py
+++ b/tests/test_promote_dev_spec_to_prod.py
@@ -1,770 +1,612 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
+import contextlib
+import io
 import json
+import shutil
 import textwrap
 
 import pytest
+import yaml
 
 from scripts.release.promote_dev_spec_to_prod import (
     DEFAULT_CI_CONFIG,
     DEFAULT_DEV_DIR,
     DEFAULT_PROD_DIR,
-    ReleaseCombo,
-    collect_release_combos,
-    find_matches,
-    iter_implementations,
     main,
-    model_name_from_weight,
     promote,
-    split_into_blocks,
-    template_identity,
-    template_matches,
-    upsert_block,
+)
+from scripts.release.generate_model_support_docs import (
+    coalesce_catalog_groups_for_docs,
+    generate_doc_pages,
+)
+from workflows.model_spec import (
+    MODEL_SPEC_CATALOG_FILES,
+    get_model_spec_map,
+    load_templates_from_yaml,
 )
 from workflows.workflow_types import DeviceTypes, InferenceEngine
 
-# Release pins injected by promotion. version="0.2.0" lets the existing
-# "version bumped from dev" assertions keep working now that the source is the
-# CLI flag rather than the dev template.
-PINS = {"tt_metal_commit": "abc1234", "version": "0.2.0", "vllm_commit": "def5678"}
-PIN_ARGS = [
-    "--tt-metal-commit",
-    "abc1234",
-    "--version",
-    "0.2.0",
-    "--vllm-commit",
-    "def5678",
-]
+
+PINS = {
+    "tt_metal_commit": "new-metal",
+    "version": "9.9.9",
+    "vllm_commit": "new-vllm",
+}
 
 
-def test_model_name_from_weight_strips_org_prefix():
-    assert model_name_from_weight("meta-llama/Llama-3.1-8B-Instruct") == (
-        "Llama-3.1-8B-Instruct"
-    )
-    assert model_name_from_weight("openai/gpt-oss-20b") == "gpt-oss-20b"
+def _write_catalogs(tmp_path, *, dev_llm, prod_llm):
+    dev_dir = tmp_path / "dev"
+    prod_dir = tmp_path / "prod"
+    dev_dir.mkdir()
+    prod_dir.mkdir()
+    for filename in MODEL_SPEC_CATALOG_FILES:
+        (dev_dir / filename).write_text("templates: []\n")
+        (prod_dir / filename).write_text("templates: []\n")
+    (dev_dir / "llm.yaml").write_text(textwrap.dedent(dev_llm))
+    (prod_dir / "llm.yaml").write_text(textwrap.dedent(prod_llm))
+    return dev_dir, prod_dir
 
 
-def test_iter_implementations_flat_shape():
-    entry = {"inference_engine": "FORGE", "ci": {"nightly": {"devices": ["P150"]}}}
-    assert list(iter_implementations(entry)) == [entry]
+def _write_ci(tmp_path, models):
+    path = tmp_path / "ci.json"
+    path.write_text(json.dumps({"models": models}))
+    return path
 
 
-def test_iter_implementations_array_shape():
-    impl_a = {"inference_engine": "vLLM", "ci": {}}
-    impl_b = {"inference_engine": "FORGE", "ci": {}}
-    entry = {"implementations": [impl_a, impl_b]}
-    assert list(iter_implementations(entry)) == [impl_a, impl_b]
-
-
-def test_collect_release_combos_array_and_flat_shapes():
-    ci_config = {
-        "models": {
-            "Llama-3.1-8B-Instruct": {
-                "implementations": [
-                    {
-                        "inference_engine": "vLLM",
-                        "ci": {
-                            "nightly": {"devices": ["N150"]},
-                            "release": {"devices": ["GALAXY", "P300X2"]},
-                        },
-                    },
-                    {
-                        "inference_engine": "FORGE",
-                        "ci": {"nightly": {"devices": ["P150"]}},
-                    },
-                ]
-            },
-            "whisper-large-v3": {
-                "inference_engine": "MEDIA",
-                "ci": {"release": {"devices": ["P150"]}},
-            },
-            "Falcon3-7B-Instruct": {
-                "inference_engine": "FORGE",
-                "ci": {"nightly": {"devices": ["P150"]}},
-            },
-        }
-    }
-    combos = collect_release_combos(ci_config)
-    assert combos == {
-        ReleaseCombo("Llama-3.1-8B-Instruct", InferenceEngine.VLLM, DeviceTypes.GALAXY),
-        ReleaseCombo("Llama-3.1-8B-Instruct", InferenceEngine.VLLM, DeviceTypes.P300X2),
-        ReleaseCombo("whisper-large-v3", InferenceEngine.MEDIA, DeviceTypes.P150),
-    }
-
-
-def test_collect_release_combos_ignores_nightly_and_weekly():
-    ci_config = {
-        "models": {
-            "m": {
-                "inference_engine": "vLLM",
-                "ci": {
-                    "nightly": {"devices": ["GALAXY"]},
-                    "weekly": {"devices": ["GALAXY"]},
-                },
-            }
-        }
-    }
-    assert collect_release_combos(ci_config) == set()
-
-
-def _llama_template():
+def _vllm_release_entry(*devices):
     return {
-        "weights": ["meta-llama/Llama-3.1-8B-Instruct"],
-        "impl": "tt_transformers",
-        "inference_engine": "VLLM",
-        "device_model_specs": [
-            {"device": "GALAXY", "max_concurrency": 32},
-            {"device": "N150", "max_concurrency": 1},
-            {"device": "P300X2", "max_concurrency": 8},
-        ],
+        "inference_engine": "vLLM",
+        "ci": {"release": {"devices": list(devices)}},
     }
 
 
-def test_template_matches_on_basename_engine_and_device():
-    combo = ReleaseCombo(
-        "Llama-3.1-8B-Instruct", InferenceEngine.VLLM, DeviceTypes.GALAXY
-    )
-    assert template_matches(_llama_template(), combo) is True
-
-
-def test_template_does_not_match_wrong_device():
-    combo = ReleaseCombo("Llama-3.1-8B-Instruct", InferenceEngine.VLLM, DeviceTypes.T3K)
-    assert template_matches(_llama_template(), combo) is False
-
-
-def test_template_does_not_match_wrong_engine():
-    combo = ReleaseCombo(
-        "Llama-3.1-8B-Instruct", InferenceEngine.FORGE, DeviceTypes.GALAXY
-    )
-    assert template_matches(_llama_template(), combo) is False
-
-
-def test_template_identity_is_impl_engine_weights_and_devices():
-    # devices are part of the identity: the catalogue holds multiple blocks per
-    # (impl, engine, weights), one per device group, so they must not collide.
-    assert template_identity(_llama_template()) == (
-        "tt_transformers",
-        InferenceEngine.VLLM,
-        frozenset({"meta-llama/Llama-3.1-8B-Instruct"}),
-        frozenset({DeviceTypes.GALAXY, DeviceTypes.N150, DeviceTypes.P300X2}),
+def _template_identity(template):
+    return (
+        template["weights"][0],
+        DeviceTypes.from_string(
+            template["device_model_specs"][0]["device"]
+        ).to_string(),
+        InferenceEngine.from_string(template["inference_engine"]).value,
+        template["impl"],
     )
 
 
-def test_template_identity_distinguishes_blocks_with_different_devices():
-    # Same model/impl/engine, different device groups → different identities.
-    base = {
-        "weights": ["meta-llama/Llama-3.1-8B-Instruct"],
-        "impl": "tt_transformers",
-        "inference_engine": "VLLM",
+def _load_leaf_templates(prod_dir):
+    templates = []
+    for filename in MODEL_SPEC_CATALOG_FILES:
+        data = yaml.safe_load((prod_dir / filename).read_text())
+        for template in data["templates"]:
+            assert len(template["weights"]) == 1
+            assert len(template["device_model_specs"]) == 1
+            templates.append(template)
+    return {_template_identity(template): template for template in templates}
+
+
+def _raw_templates(prod_dir):
+    return [
+        template
+        for filename in MODEL_SPEC_CATALOG_FILES
+        for template in yaml.safe_load((prod_dir / filename).read_text())["templates"]
+    ]
+
+
+def _file_tree(root):
+    return {
+        str(path.relative_to(root)): path.read_text()
+        for path in root.rglob("*")
+        if path.is_file()
     }
-    galaxy = {**base, "device_model_specs": [{"device": "GALAXY"}]}
-    p300 = {**base, "device_model_specs": [{"device": "P300X2"}]}
-    assert template_identity(galaxy) != template_identity(p300)
 
 
-def _write(path, text):
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(textwrap.dedent(text))
+def _serialized_catalog(prod_dir):
+    templates = [
+        template
+        for filename in MODEL_SPEC_CATALOG_FILES
+        for template in load_templates_from_yaml(prod_dir / filename)
+    ]
+    return {
+        model_id: spec.get_serialized_dict()
+        for model_id, spec in get_model_spec_map(templates).items()
+    }
 
 
-def test_find_matches_picks_whole_template_and_reports_unmatched(tmp_path):
-    dev = tmp_path / "dev"
-    _write(
-        dev / "llm.yaml",
-        """
-        templates:
-        - weights:
-            - meta-llama/Llama-3.1-8B-Instruct
-          impl: tt_transformers
-          inference_engine: VLLM
-          device_model_specs:
-            - device: GALAXY
-              max_concurrency: 32
-            - device: N150
-              max_concurrency: 1
+def _grouped_fixture(tmp_path):
+    dev_dir, prod_dir = _write_catalogs(
+        tmp_path,
+        dev_llm="""
+            templates:
+            - weights:
+                - org/model-A
+                - org/model-B
+              impl: tt_transformers
+              inference_engine: VLLM
+              device_model_specs:
+                - device: N150
+                  max_concurrency: 16
+                  max_context: 65536
+                  default_impl: true
+                - device: N300
+                  max_concurrency: 8
+                  max_context: 32768
+                  default_impl: true
+              metadata:
+                org/model-A:
+                  note: new-a
+                org/model-B:
+                  note: new-b
+        """,
+        prod_llm="""
+            templates:
+            # This unrelated leaf must retain its released semantics.
+            - weights:
+                - org/unrelated
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "0.5.0"
+              tt_metal_commit: "unrelated-metal"
+              vllm_commit: "unrelated-vllm"
+              device_model_specs:
+                - device: N150
+                  max_concurrency: 1
+                  max_context: 1024
+
+            - weights:
+                - org/model-A
+                - org/model-B
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "1.0.0"
+              tt_metal_commit: "old-metal"
+              vllm_commit: "old-vllm"
+              device_model_specs:
+                - device: N150
+                  max_concurrency: 2
+                  max_context: 4096
+                  default_impl: true
+                - device: N300
+                  max_concurrency: 4
+                  max_context: 8192
+                  default_impl: true
+              metadata:
+                org/model-A:
+                  note: old-a
+                org/model-B:
+                  note: old-b
         """,
     )
-    combos = {
-        ReleaseCombo("Llama-3.1-8B-Instruct", InferenceEngine.VLLM, DeviceTypes.GALAXY),
-        ReleaseCombo("nonexistent", InferenceEngine.VLLM, DeviceTypes.GALAXY),
-    }
-    matches_by_file, unmatched = find_matches(dev, combos)
-
-    assert list(matches_by_file.keys()) == ["llm.yaml"]
-    picked = matches_by_file["llm.yaml"]
-    assert len(picked) == 1
-    # whole template: the non-release N150 device is still present
-    devices = [d["device"] for d in picked[0].template["device_model_specs"]]
-    assert devices == ["GALAXY", "N150"]
-    # the raw source lines are carried for verbatim splicing
-    assert "".join(picked[0].lines).startswith("- weights:")
-    assert unmatched == {
-        ReleaseCombo("nonexistent", InferenceEngine.VLLM, DeviceTypes.GALAXY)
-    }
+    ci_path = _write_ci(
+        tmp_path,
+        {"model-A": _vllm_release_entry("N150")},
+    )
+    return ci_path, dev_dir, prod_dir
 
 
-def test_find_matches_dedups_template_matched_by_two_combos(tmp_path):
-    dev = tmp_path / "dev"
-    _write(
-        dev / "llm.yaml",
-        """
-        templates:
-        - weights:
-            - meta-llama/Llama-3.1-8B-Instruct
-          impl: tt_transformers
-          inference_engine: VLLM
-          device_model_specs:
-            - device: GALAXY
-            - device: P300X2
+def test_grouped_owner_is_leafized_and_only_target_semantics_change(tmp_path):
+    ci_path, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+
+    report = promote(ci_path, dev_dir, prod_dir, **PINS)
+
+    target = ("org/model-A", "N150", "vLLM", "tt_transformers")
+    assert report["actions"] == {target: "updated"}
+    assert report["leaf_count_before"] == 5
+    assert report["leaf_count_after"] == 5
+    assert report["changed_files"] == ["llm.yaml"]
+
+    text = (prod_dir / "llm.yaml").read_text()
+    assert "# This unrelated leaf must retain its released semantics." in text
+    leaves = _load_leaf_templates(prod_dir)
+    assert len(leaves) == 5
+
+    promoted = leaves[target]
+    assert promoted["version"] == "9.9.9"
+    assert promoted["tt_metal_commit"] == "new-metal"
+    assert promoted["vllm_commit"] == "new-vllm"
+    assert promoted["device_model_specs"][0]["max_context"] == 65536
+    assert promoted["metadata"] == {"org/model-A": {"note": "new-a"}}
+    unrelated = leaves[("org/unrelated", "N150", "vLLM", "tt_transformers")]
+    assert unrelated["version"] == "0.5.0"
+    assert unrelated["tt_metal_commit"] == "unrelated-metal"
+    assert unrelated["vllm_commit"] == "unrelated-vllm"
+
+    for identity in (
+        ("org/model-A", "N300", "vLLM", "tt_transformers"),
+        ("org/model-B", "N150", "vLLM", "tt_transformers"),
+        ("org/model-B", "N300", "vLLM", "tt_transformers"),
+    ):
+        sibling = leaves[identity]
+        assert sibling["version"] == "1.0.0"
+        assert sibling["tt_metal_commit"] == "old-metal"
+        assert sibling["vllm_commit"] == "old-vllm"
+        assert sibling["metadata"] == {
+            identity[0]: {"note": f"old-{identity[0][-1].lower()}"}
+        }
+
+
+def test_new_target_is_appended_as_exact_leaf(tmp_path):
+    dev_dir, prod_dir = _write_catalogs(
+        tmp_path,
+        dev_llm="""
+            templates:
+            - weights:
+                - org/new-model
+              impl: tt_transformers
+              inference_engine: VLLM
+              device_model_specs:
+                - device: N150
+                  max_concurrency: 1
+                  max_context: 2048
+                  default_impl: true
+        """,
+        prod_llm="templates: []\n",
+    )
+    ci_path = _write_ci(
+        tmp_path,
+        {"new-model": _vllm_release_entry("N150")},
+    )
+
+    report = promote(ci_path, dev_dir, prod_dir, **PINS)
+
+    identity = ("org/new-model", "N150", "vLLM", "tt_transformers")
+    assert report["actions"] == {identity: "added"}
+    assert report["leaf_count_before"] == 0
+    assert report["leaf_count_after"] == 1
+    assert identity in _load_leaf_templates(prod_dir)
+
+
+def test_resolution_failure_does_not_write_any_prod_file(tmp_path):
+    ci_path, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+    ci_path = _write_ci(
+        tmp_path,
+        {
+            "model-A": _vllm_release_entry("N150"),
+            "missing-model": _vllm_release_entry("N150"),
+        },
+    )
+    before = {path.name: path.read_bytes() for path in prod_dir.glob("*.yaml")}
+
+    with pytest.raises(ValueError, match="No model spec matches"):
+        promote(ci_path, dev_dir, prod_dir, **PINS)
+
+    assert {path.name: path.read_bytes() for path in prod_dir.glob("*.yaml")} == before
+
+
+def test_duplicate_prod_identity_fails_before_write(tmp_path):
+    dev_dir, prod_dir = _write_catalogs(
+        tmp_path,
+        dev_llm="""
+            templates:
+            - weights: [org/model-A]
+              impl: tt_transformers
+              inference_engine: VLLM
+              device_model_specs:
+                - {device: N150, max_concurrency: 1, max_context: 1024, default_impl: true}
+        """,
+        prod_llm="""
+            templates:
+            - weights: [org/model-A]
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "1.0.0"
+              tt_metal_commit: old
+              vllm_commit: old
+              device_model_specs:
+                - {device: N150, max_concurrency: 1, max_context: 1024}
+            - weights: [org/model-A]
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "2.0.0"
+              tt_metal_commit: newer
+              vllm_commit: newer
+              device_model_specs:
+                - {device: N150, max_concurrency: 1, max_context: 1024}
         """,
     )
-    combos = {
-        ReleaseCombo("Llama-3.1-8B-Instruct", InferenceEngine.VLLM, DeviceTypes.GALAXY),
-        ReleaseCombo("Llama-3.1-8B-Instruct", InferenceEngine.VLLM, DeviceTypes.P300X2),
-    }
-    matches_by_file, unmatched = find_matches(dev, combos)
-    assert len(matches_by_file["llm.yaml"]) == 1
-    assert unmatched == set()
+    ci_path = _write_ci(tmp_path, {"model-A": _vllm_release_entry("N150")})
+    before = (prod_dir / "llm.yaml").read_bytes()
+
+    with pytest.raises(ValueError, match="Duplicate model spec leaf identity"):
+        promote(ci_path, dev_dir, prod_dir, **PINS)
+
+    assert (prod_dir / "llm.yaml").read_bytes() == before
 
 
-def test_split_into_blocks_roundtrips_and_separates_filler():
-    text = textwrap.dedent(
-        """\
-        templates:
-        # banner
-        - weights:
-            - openai/gpt-oss-20b
-          impl: gpt_oss
-          inference_engine: VLLM
+@pytest.mark.parametrize("vllm_commit", [None, "", "   "])
+def test_vllm_target_requires_non_empty_vllm_commit(tmp_path, vllm_commit):
+    ci_path, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+    before = (prod_dir / "llm.yaml").read_bytes()
 
-        - weights:
-            - meta-llama/Llama-3.1-8B-Instruct
-          impl: tt_transformers
-          inference_engine: VLLM
-        """
-    )
-    segments = split_into_blocks(text)
-    # joining all segment lines reproduces the input byte-for-byte
-    assert "".join(line for _, lines in segments for line in lines) == text
-    kinds = [kind for kind, _ in segments]
-    # header + banner are filler; two template blocks; blank line between is filler
-    assert kinds.count("block") == 2
-    blocks = ["".join(lines) for kind, lines in segments if kind == "block"]
-    assert blocks[0].startswith("- weights:\n    - openai/gpt-oss-20b")
-    assert blocks[1].startswith("- weights:\n    - meta-llama/Llama-3.1-8B-Instruct")
-
-
-def test_split_into_blocks_keeps_blank_line_inside_a_body():
-    # A blank line followed by more indented body is interior to the block, not a
-    # separator — otherwise the block (and its parsed identity) would be truncated.
-    text = textwrap.dedent(
-        """\
-        templates:
-        - weights:
-            - openai/gpt-oss-20b
-          impl: gpt_oss
-          inference_engine: VLLM
-
-          device_model_specs:
-            - device: T3K
-        """
-    )
-    segments = split_into_blocks(text)
-    assert "".join(line for _, lines in segments for line in lines) == text
-    blocks = [lines for kind, lines in segments if kind == "block"]
-    assert len(blocks) == 1
-    from scripts.release.promote_dev_spec_to_prod import parse_block
-
-    parsed = parse_block(blocks[0])
-    # the device survived the interior blank line
-    assert parsed["device_model_specs"] == [{"device": "T3K"}]
-
-
-def _block_lines(text):
-    text = textwrap.dedent(text)
-    (kind, lines) = next(seg for seg in split_into_blocks(text) if seg[0] == "block")
-    assert kind == "block"
-    return lines
-
-
-def test_upsert_block_appends_new_template():
-    segments = split_into_blocks("templates:\n")
-    lines = _block_lines(
-        """
-        - weights:
-            - meta-llama/Llama-3.1-8B-Instruct
-          impl: tt_transformers
-          inference_engine: VLLM
-          device_model_specs:
-            - device: GALAXY
-        """
-    )
-    identity = ("tt_transformers", InferenceEngine.VLLM, frozenset({"x"}))
-    action = upsert_block(segments, identity, lines)
-    assert action == "appended"
-    assert sum(1 for kind, _ in segments if kind == "block") == 1
-
-
-def test_upsert_block_replaces_same_identity_and_leaves_others_byte_identical():
-    other = """\
-- weights:
-    - openai/gpt-oss-20b
-  impl: gpt_oss
-  inference_engine: VLLM
-  version: "9.9.9"
-  device_model_specs:
-    - device: T3K
-"""
-    old = """\
-- weights:
-    - meta-llama/Llama-3.1-8B-Instruct
-  impl: tt_transformers
-  inference_engine: VLLM
-  version: "0.1.0"
-  device_model_specs:
-    - device: GALAXY
-"""
-    segments = split_into_blocks("templates:\n" + other + old)
-
-    new_lines = _block_lines(old.replace("0.1.0", "0.2.0"))
-    from scripts.release.promote_dev_spec_to_prod import parse_block
-
-    identity = template_identity(parse_block(_block_lines(old)))
-    action = upsert_block(segments, identity, new_lines)
-
-    assert action == "updated"
-    rendered = "".join(line for _, lines in segments for line in lines)
-    # the other template is untouched byte-for-byte; only the target version changed
-    assert other in rendered
-    assert "0.2.0" in rendered
-    assert "0.1.0" not in rendered
-
-
-def _build_tree(tmp_path):
-    """dev has a Llama template with an inline comment; prod has an older copy."""
-    dev = tmp_path / "dev"
-    prod = tmp_path / "prod"
-    _write(
-        dev / "llm.yaml",
-        """
-        templates:
-        - weights:
-            - meta-llama/Llama-3.1-8B-Instruct
-          impl: tt_transformers
-          inference_engine: VLLM
-          device_model_specs:
-            - device: GALAXY
-              max_context: 16384  # 16 * 1024
-            - device: N150
-              max_context: 4096
-        """,
-    )
-    _write(
-        prod / "llm.yaml",
-        """
-        templates:
-        - weights:
-            - meta-llama/Llama-3.1-8B-Instruct
-          impl: tt_transformers
-          inference_engine: VLLM
-          version: "0.1.0"
-          device_model_specs:
-            - device: GALAXY
-              max_context: 16384
-            - device: N150
-              max_context: 4096
-        """,
-    )
-    ci = tmp_path / "ci.json"
-    ci.write_text(
-        json.dumps(
-            {
-                "models": {
-                    "Llama-3.1-8B-Instruct": {
-                        "inference_engine": "vLLM",
-                        "ci": {"release": {"devices": ["GALAXY"]}},
-                    }
-                }
-            }
+    with pytest.raises(ValueError, match="vllm_commit"):
+        promote(
+            ci_path,
+            dev_dir,
+            prod_dir,
+            version=PINS["version"],
+            tt_metal_commit=PINS["tt_metal_commit"],
+            vllm_commit=vllm_commit,
         )
+
+    assert (prod_dir / "llm.yaml").read_bytes() == before
+
+
+def test_dry_run_json_reports_changes_without_writing(tmp_path, capsys):
+    ci_path, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+    before = (prod_dir / "llm.yaml").read_bytes()
+
+    result = main(
+        [
+            "--ci-config",
+            str(ci_path),
+            "--dev-dir",
+            str(dev_dir),
+            "--prod-dir",
+            str(prod_dir),
+            "--version",
+            PINS["version"],
+            "--tt-metal-commit",
+            PINS["tt_metal_commit"],
+            "--vllm-commit",
+            PINS["vllm_commit"],
+            "--dry-run",
+            "--json",
+        ]
     )
-    return ci, dev, prod
+
+    assert result == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    assert report["dry_run"] is True
+    assert report["actions"][0]["action"] == "updated"
+    assert report["resolved"][0]["source_path"].endswith("llm.yaml")
+    assert report["changed_files"] == ["llm.yaml"]
+    assert (prod_dir / "llm.yaml").read_bytes() == before
 
 
-def test_promote_updates_prod_preserving_comment_and_whole_template(tmp_path):
-    ci, dev, prod = _build_tree(tmp_path)
-    report = promote(ci, dev, prod, **PINS)
+def test_json_error_is_machine_readable_and_does_not_write(tmp_path, capsys):
+    _, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+    ci_path = _write_ci(
+        tmp_path,
+        {"missing-model": _vllm_release_entry("N150")},
+    )
+    before = (prod_dir / "llm.yaml").read_bytes()
 
-    text = (prod / "llm.yaml").read_text()
-    assert "0.2.0" in text  # version bumped from dev
-    assert "0.1.0" not in text  # old block replaced in place, not duplicated
-    assert "# 16 * 1024" in text  # inline comment preserved
-    assert "device: N150" in text  # whole template copied (non-release device)
-    assert report["unmatched"] == set()
-    assert "llm.yaml" in report["changed_files"]
+    result = main(
+        [
+            "--ci-config",
+            str(ci_path),
+            "--dev-dir",
+            str(dev_dir),
+            "--prod-dir",
+            str(prod_dir),
+            "--version",
+            PINS["version"],
+            "--tt-metal-commit",
+            PINS["tt_metal_commit"],
+            "--vllm-commit",
+            PINS["vllm_commit"],
+            "--dry-run",
+            "--json",
+        ]
+    )
+
+    assert result == 2
+    error = json.loads(capsys.readouterr().out)
+    assert error["ok"] is False
+    assert error["error_type"] == "ValueError"
+    assert "No model spec matches" in error["error"]
+    assert (prod_dir / "llm.yaml").read_bytes() == before
 
 
-def test_promote_injects_pins_and_result_passes_prod_enforcement(tmp_path):
-    """A stripped dev block is promoted with the pins injected, and the resulting
-    prod file loads under the prod required-fields enforcement."""
-    from workflows.model_spec import load_templates_from_yaml
-
-    dev = tmp_path / "dev"
-    prod = tmp_path / "prod"  # parent dir name "prod" => enforcement is active
-    _write(
-        dev / "llm.yaml",
+@pytest.mark.parametrize(
+    "invalid_prod",
+    [
+        "templates:\n- weights: [\n",
         """
         templates:
-        - weights:
-            - meta-llama/Llama-3.1-8B-Instruct
+        - weights: [org/model-A]
+          impl: tt_transformers
           impl: tt_transformers
           inference_engine: VLLM
+          version: "1.0.0"
+          tt_metal_commit: old
+          vllm_commit: old
           device_model_specs:
-            - device: GALAXY
-              max_concurrency: 32
-              max_context: 4096
-              default_impl: true
+            - {device: N150, max_concurrency: 1, max_context: 1024}
         """,
+    ],
+)
+def test_yaml_errors_are_machine_readable_and_do_not_write(
+    tmp_path, capsys, invalid_prod
+):
+    ci_path, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+    (prod_dir / "llm.yaml").write_text(textwrap.dedent(invalid_prod))
+    before = (prod_dir / "llm.yaml").read_bytes()
+
+    result = main(
+        [
+            "--ci-config",
+            str(ci_path),
+            "--dev-dir",
+            str(dev_dir),
+            "--prod-dir",
+            str(prod_dir),
+            "--version",
+            PINS["version"],
+            "--tt-metal-commit",
+            PINS["tt_metal_commit"],
+            "--vllm-commit",
+            PINS["vllm_commit"],
+            "--dry-run",
+            "--json",
+        ]
     )
-    # prod already has this template pinned at an older release (update path).
-    _write(
-        prod / "llm.yaml",
-        """
-        templates:
-        - weights:
-            - meta-llama/Llama-3.1-8B-Instruct
-          impl: tt_transformers
-          inference_engine: VLLM
-          version: "0.0.1"
-          tt_metal_commit: "old"
-          vllm_commit: "old"
-          device_model_specs:
-            - device: GALAXY
-              max_concurrency: 32
-              max_context: 4096
-              default_impl: true
-        """,
+
+    assert result == 2
+    error = json.loads(capsys.readouterr().out)
+    assert error["ok"] is False
+    assert error["error"]
+    assert (prod_dir / "llm.yaml").read_bytes() == before
+
+
+def test_second_promotion_is_byte_idempotent(tmp_path):
+    ci_path, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+    promote(ci_path, dev_dir, prod_dir, **PINS)
+    after_first = {path.name: path.read_bytes() for path in prod_dir.glob("*.yaml")}
+
+    report = promote(ci_path, dev_dir, prod_dir, **PINS)
+
+    assert report["changed_files"] == []
+    assert set(report["unchanged_identities"]) == set(report["requested_identities"])
+    assert {
+        path.name: path.read_bytes() for path in prod_dir.glob("*.yaml")
+    } == after_first
+
+
+def test_full_prod_flattening_has_no_expanded_semantic_diff(tmp_path):
+    prod_copy = tmp_path / "prod"
+    shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
+    before = _serialized_catalog(prod_copy)
+    ci_path = _write_ci(tmp_path, {})
+
+    report = promote(
+        ci_path,
+        DEFAULT_DEV_DIR,
+        prod_copy,
+        version=PINS["version"],
+        tt_metal_commit=PINS["tt_metal_commit"],
     )
-    ci = tmp_path / "ci.json"
-    ci.write_text(
-        json.dumps(
-            {
-                "models": {
-                    "Llama-3.1-8B-Instruct": {
-                        "inference_engine": "vLLM",
-                        "ci": {"release": {"devices": ["GALAXY"]}},
-                    }
-                }
-            }
+
+    assert report["leaf_count_before"] == 225
+    assert report["leaf_count_after"] == 225
+    assert _serialized_catalog(prod_copy) == before
+    assert len(_load_leaf_templates(prod_copy)) == 225
+    for template in _raw_templates(prod_copy):
+        assert "perf_reference" in template["device_model_specs"][0]
+        assert template["model_display_name"]
+        assert template["catalog_group"]
+
+
+def test_full_prod_flattening_preserves_generated_documentation(tmp_path):
+    prod_copy = tmp_path / "prod"
+    shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
+    ci_path = _write_ci(tmp_path, {})
+    before_docs = tmp_path / "docs-before"
+    after_docs = tmp_path / "docs-after"
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        generate_doc_pages(
+            [
+                template
+                for filename in MODEL_SPEC_CATALOG_FILES
+                for template in load_templates_from_yaml(prod_copy / filename)
+            ],
+            str(before_docs),
         )
-    )
 
     promote(
-        ci,
-        dev,
-        prod,
-        tt_metal_commit="deadbeef",
-        version="1.2.3",
-        vllm_commit="cafef00d",
+        ci_path,
+        DEFAULT_DEV_DIR,
+        prod_copy,
+        version=PINS["version"],
+        tt_metal_commit=PINS["tt_metal_commit"],
     )
 
-    text = (prod / "llm.yaml").read_text()
-    assert 'version: "1.2.3"' in text
-    assert 'tt_metal_commit: "deadbeef"' in text
-    assert 'vllm_commit: "cafef00d"' in text
-
-    templates = load_templates_from_yaml(prod / "llm.yaml")
-    assert templates[0].version == "1.2.3"
-    assert templates[0].tt_metal_commit == "deadbeef"
-    assert templates[0].vllm_commit == "cafef00d"
-
-
-def test_promote_requires_vllm_commit_for_vllm_template(tmp_path):
-    """Omitting vllm_commit raises when a promoted template is VLLM-engine."""
-    ci, dev, prod = _build_tree(tmp_path)  # _build_tree uses inference_engine VLLM
-    with pytest.raises(ValueError, match="vllm-commit"):
-        promote(ci, dev, prod, tt_metal_commit="abc1234", version="1.0.0")
-
-
-def test_promote_non_vllm_template_omits_vllm_commit(tmp_path):
-    """FORGE/MEDIA templates need no vllm_commit and get none injected."""
-    dev = tmp_path / "dev"
-    prod = tmp_path / "prod"
-    _write(
-        dev / "cnn.yaml",
-        """
-        templates:
-        - weights:
-            - resnet-50
-          impl: tt_transformers
-          inference_engine: FORGE
-          device_model_specs:
-            - device: N150
-              max_concurrency: 1
-              max_context: 4096
-              default_impl: true
-        """,
-    )
-    ci = tmp_path / "ci.json"
-    ci.write_text(
-        json.dumps(
-            {
-                "models": {
-                    "resnet-50": {
-                        "inference_engine": "FORGE",
-                        "ci": {"release": {"devices": ["N150"]}},
-                    }
-                }
-            }
-        )
-    )
-    # No vllm_commit passed, and none required.
-    report = promote(ci, dev, prod, tt_metal_commit="abc1234", version="1.0.0")
-    text = (prod / "cnn.yaml").read_text()
-    assert 'version: "1.0.0"' in text
-    assert 'tt_metal_commit: "abc1234"' in text
-    assert "vllm_commit" not in text
-    assert report["unmatched"] == set()
-
-
-def test_main_errors_when_vllm_commit_missing(tmp_path):
-    """main() exits non-zero (argparse error) when vllm_commit is needed but absent."""
-    ci, dev, prod = _build_tree(tmp_path)
-    with pytest.raises(SystemExit) as exc:
-        main(
+    with contextlib.redirect_stdout(io.StringIO()):
+        generate_doc_pages(
             [
-                "--ci-config",
-                str(ci),
-                "--dev-dir",
-                str(dev),
-                "--prod-dir",
-                str(prod),
-                "--tt-metal-commit",
-                "abc1234",
-                "--version",
-                "1.0.0",
-            ]
+                template
+                for filename in MODEL_SPEC_CATALOG_FILES
+                for template in load_templates_from_yaml(prod_copy / filename)
+            ],
+            str(after_docs),
         )
-    assert exc.value.code == 2  # argparse usage error
+
+    assert _file_tree(after_docs) == _file_tree(before_docs)
 
 
-def test_promote_appends_new_release_template_and_stays_valid_yaml(tmp_path):
-    import yaml as _yaml
-
-    dev = tmp_path / "dev"
-    prod = tmp_path / "prod"
-    # dev has a release template on P300X2 that prod does not have yet.
-    _write(
-        dev / "llm.yaml",
-        """
-        templates:
-        - weights:
-            - meta-llama/Llama-3.1-8B-Instruct
-          impl: tt_transformers
-          inference_engine: VLLM
-          device_model_specs:
-            - device: P300X2
-              max_context: 4096
+def test_docs_do_not_coalesce_heterogeneous_release_pins(tmp_path):
+    _, prod_dir = _write_catalogs(
+        tmp_path,
+        dev_llm="templates: []\n",
+        prod_llm="""
+            templates:
+            - weights: [org/model-A]
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "1.0.0"
+              tt_metal_commit: old
+              vllm_commit: old
+              catalog_group: shared
+              model_display_name: model
+              device_model_specs:
+                - {device: N150, max_concurrency: 1, max_context: 1024}
+            - weights: [org/model-B]
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "2.0.0"
+              tt_metal_commit: new
+              vllm_commit: new
+              catalog_group: shared
+              model_display_name: model
+              device_model_specs:
+                - {device: N150, max_concurrency: 1, max_context: 1024}
         """,
     )
-    # prod has only an unrelated template; it must survive byte-for-byte. It also
-    # deliberately ends WITHOUT a trailing newline to exercise the append seam.
-    existing = (
-        "templates:\n"
-        "- weights:\n"
-        "    - openai/gpt-oss-20b\n"
-        "  impl: gpt_oss\n"
-        "  inference_engine: VLLM\n"
-        "  device_model_specs:\n"
-        "    - device: T3K"  # no trailing newline
-    )
-    (prod).mkdir(parents=True, exist_ok=True)
-    (prod / "llm.yaml").write_text(existing)
-    ci = tmp_path / "ci.json"
-    ci.write_text(
-        json.dumps(
-            {
-                "models": {
-                    "Llama-3.1-8B-Instruct": {
-                        "inference_engine": "vLLM",
-                        "ci": {"release": {"devices": ["P300X2"]}},
-                    }
-                }
-            }
-        )
+    templates = load_templates_from_yaml(prod_dir / "llm.yaml")
+
+    assert coalesce_catalog_groups_for_docs(templates) == templates
+
+
+def test_real_catalog_promotion_is_exact_leaf_granular_and_idempotent(tmp_path):
+    prod_copy = tmp_path / "prod"
+    shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
+
+    report = promote(
+        DEFAULT_CI_CONFIG,
+        DEFAULT_DEV_DIR,
+        prod_copy,
+        **PINS,
     )
 
-    report = promote(ci, dev, prod, **PINS)
-
-    assert report["actions"]["llm.yaml"] == [
+    expected = {
         (
-            template_identity(
-                {
-                    "impl": "tt_transformers",
-                    "inference_engine": "VLLM",
-                    "weights": ["meta-llama/Llama-3.1-8B-Instruct"],
-                    "device_model_specs": [{"device": "P300X2"}],
-                }
-            ),
-            "appended",
+            "google/diffusiongemma-26B-A4B-it",
+            "P300X2",
+            "vLLM",
+            "diffusion_gemma",
+        ),
+        ("Qwen/Qwen3-32B", "GALAXY", "vLLM", "qwen3_32b_galaxy"),
+    }
+    assert set(report["requested_identities"]) == expected
+    assert set(report["added_identities"]) == {
+        (
+            "google/diffusiongemma-26B-A4B-it",
+            "P300X2",
+            "vLLM",
+            "diffusion_gemma",
         )
-    ]
-    text = (prod / "llm.yaml").read_text()
-    # the pre-existing block is intact (not fused with the appended one)
-    assert "    - device: T3K\n" in text
-    # the result is still valid YAML with both templates
-    parsed = _yaml.safe_load(text)
-    weights = {tuple(t["weights"]) for t in parsed["templates"]}
-    assert ("openai/gpt-oss-20b",) in weights
-    assert ("meta-llama/Llama-3.1-8B-Instruct",) in weights
-
-
-def test_promote_is_idempotent(tmp_path):
-    ci, dev, prod = _build_tree(tmp_path)
-    promote(ci, dev, prod, **PINS)
-    after_first = (prod / "llm.yaml").read_text()
-    report = promote(ci, dev, prod, **PINS)
-    assert (prod / "llm.yaml").read_text() == after_first
-    assert report["changed_files"] == []
-
-
-def test_promote_reports_unmatched_combo(tmp_path):
-    ci, dev, prod = _build_tree(tmp_path)
-    ci.write_text(
-        json.dumps(
-            {
-                "models": {
-                    "ghost-model": {
-                        "inference_engine": "vLLM",
-                        "ci": {"release": {"devices": ["GALAXY"]}},
-                    }
-                }
-            }
-        )
-    )
-    report = promote(ci, dev, prod, **PINS)
-    assert (
-        ReleaseCombo("ghost-model", InferenceEngine.VLLM, DeviceTypes.GALAXY)
-        in report["unmatched"]
+    }
+    assert set(report["updated_identities"]) == {
+        ("Qwen/Qwen3-32B", "GALAXY", "vLLM", "qwen3_32b_galaxy")
+    }
+    assert report["leaf_count_before"] == 225
+    assert report["leaf_count_after"] == 226
+    assert len(_load_leaf_templates(prod_copy)) == 226
+    assert all(
+        "perf_reference" in template["device_model_specs"][0]
+        for template in _raw_templates(prod_copy)
     )
 
-
-def test_main_returns_zero_and_writes(tmp_path, capsys):
-    ci, dev, prod = _build_tree(tmp_path)
-    rc = main(
-        [
-            "--ci-config",
-            str(ci),
-            "--dev-dir",
-            str(dev),
-            "--prod-dir",
-            str(prod),
-            *PIN_ARGS,
-        ]
+    snapshot = {path.name: path.read_bytes() for path in prod_copy.glob("*.yaml")}
+    second = promote(
+        DEFAULT_CI_CONFIG,
+        DEFAULT_DEV_DIR,
+        prod_copy,
+        **PINS,
     )
-    assert rc == 0
-    assert "0.2.0" in (prod / "llm.yaml").read_text()
-
-
-def test_main_returns_nonzero_on_unmatched(tmp_path, capsys):
-    ci, dev, prod = _build_tree(tmp_path)
-    ci.write_text(
-        json.dumps(
-            {
-                "models": {
-                    "ghost-model": {
-                        "inference_engine": "vLLM",
-                        "ci": {"release": {"devices": ["GALAXY"]}},
-                    }
-                }
-            }
-        )
-    )
-    rc = main(
-        [
-            "--ci-config",
-            str(ci),
-            "--dev-dir",
-            str(dev),
-            "--prod-dir",
-            str(prod),
-            *PIN_ARGS,
-        ]
-    )
-    assert rc == 1
-    assert "ghost-model" in capsys.readouterr().out
-
-
-def test_real_repo_release_combos_all_match_dev():
-    """Every release-marked combo in the real ci-config exists in the dev catalogue."""
-    ci_config = json.loads(DEFAULT_CI_CONFIG.read_text())
-    combos = collect_release_combos(ci_config)
-    assert combos, "expected at least one release combo in the real ci-config"
-    _, unmatched = find_matches(DEFAULT_DEV_DIR, combos)
-    assert unmatched == set(), f"release combos missing from dev: {unmatched}"
-
-
-def test_real_repo_promote_against_prod_succeeds(tmp_path):
-    """Promoting against the real catalogues runs cleanly with no unmatched combos.
-
-    Writes to a temp copy so the repo's prod/ is never touched.
-    """
-    import shutil
-
-    prod_copy = tmp_path / "prod"
-    shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
-    report = promote(DEFAULT_CI_CONFIG, DEFAULT_DEV_DIR, prod_copy, **PINS)
-    assert report["unmatched"] == set()
-
-
-def test_real_repo_promote_only_touches_release_blocks(tmp_path):
-    """Promoting against the real catalogues must be surgical.
-
-    dev and prod diverge over time, so release blocks legitimately change. But a
-    template block that was NOT promoted must never be altered or reformatted:
-    every non-promoted prod block stays byte-identical.
-    """
-    import shutil
-
-    from scripts.release.promote_dev_spec_to_prod import parse_block
-
-    prod_copy = tmp_path / "prod"
-    shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
-    combos = collect_release_combos(json.loads(DEFAULT_CI_CONFIG.read_text()))
-    matches_by_file, _ = find_matches(DEFAULT_DEV_DIR, combos)
-    report = promote(DEFAULT_CI_CONFIG, DEFAULT_DEV_DIR, prod_copy, **PINS)
-
-    def blocks(text):
-        return {
-            template_identity(parse_block(lines)): "".join(lines)
-            for kind, lines in split_into_blocks(text)
-            if kind == "block"
-        }
-
-    for filename in report["changed_files"]:
-        promoted = {mb.identity for mb in matches_by_file.get(filename, [])}
-        before = blocks((DEFAULT_PROD_DIR / filename).read_text())
-        after = blocks((prod_copy / filename).read_text())
-        changed = {i for i in before if before[i] != after.get(i)}
-        added = set(after) - set(before)
-        assert changed <= promoted, (
-            f"{filename}: non-release blocks changed: {changed - promoted}"
-        )
-        assert added <= promoted, (
-            f"{filename}: non-release blocks added: {added - promoted}"
-        )
-
-
-def test_real_repo_promote_is_idempotent(tmp_path):
-    """A second promote run against the same prod produces no further change."""
-    import shutil
-
-    prod_copy = tmp_path / "prod"
-    shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
-    promote(DEFAULT_CI_CONFIG, DEFAULT_DEV_DIR, prod_copy, **PINS)
-    snapshot = {p.name: p.read_text() for p in prod_copy.glob("*.yaml")}
-    report = promote(DEFAULT_CI_CONFIG, DEFAULT_DEV_DIR, prod_copy, **PINS)
-    assert report["changed_files"] == []
-    assert {p.name: p.read_text() for p in prod_copy.glob("*.yaml")} == snapshot
+    assert second["changed_files"] == []
+    assert {
+        path.name: path.read_bytes() for path in prod_copy.glob("*.yaml")
+    } == snapshot

--- a/tests/test_promote_dev_spec_to_prod.py
+++ b/tests/test_promote_dev_spec_to_prod.py
@@ -5,28 +5,21 @@
 import contextlib
 import io
 import json
-import shutil
 import textwrap
 
 import pytest
 import yaml
-from ruamel.yaml.comments import CommentedMap
 
 from scripts.release.promote_dev_spec_to_prod import (
-    DEFAULT_CI_CONFIG,
-    DEFAULT_DEV_DIR,
-    DEFAULT_PROD_DIR,
-    _catalog_group,
     main,
     promote,
 )
 from scripts.release.generate_model_support_docs import (
-    coalesce_catalog_groups_for_docs,
+    coalesce_model_families_for_docs,
     generate_doc_pages,
 )
 from workflows.model_spec import (
     MODEL_SPEC_CATALOG_FILES,
-    get_model_spec_map,
     load_templates_from_yaml,
 )
 from workflows.workflow_types import DeviceTypes, InferenceEngine
@@ -37,24 +30,6 @@ PINS = {
     "version": "9.9.9",
     "vllm_commit": "new-vllm",
 }
-
-
-def test_catalog_group_ignores_weight_membership_but_distinguishes_impl():
-    template = CommentedMap(
-        {
-            "weights": ["org/model-base"],
-            "model_display_name": "model",
-            "inference_engine": "VLLM",
-            "impl": "tt_transformers",
-        }
-    )
-    original = _catalog_group(template)
-
-    template["weights"].append("org/model-instruct")
-    assert _catalog_group(template) == original
-
-    template["impl"] = "forge_vllm_plugin"
-    assert _catalog_group(template) != original
 
 
 def _write_catalogs(tmp_path, *, dev_llm, prod_llm):
@@ -105,35 +80,7 @@ def _load_leaf_templates(prod_dir):
     return {_template_identity(template): template for template in templates}
 
 
-def _raw_templates(prod_dir):
-    return [
-        template
-        for filename in MODEL_SPEC_CATALOG_FILES
-        for template in yaml.safe_load((prod_dir / filename).read_text())["templates"]
-    ]
-
-
-def _file_tree(root):
-    return {
-        str(path.relative_to(root)): path.read_text()
-        for path in root.rglob("*")
-        if path.is_file()
-    }
-
-
-def _serialized_catalog(prod_dir):
-    templates = [
-        template
-        for filename in MODEL_SPEC_CATALOG_FILES
-        for template in load_templates_from_yaml(prod_dir / filename)
-    ]
-    return {
-        model_id: spec.get_serialized_dict()
-        for model_id, spec in get_model_spec_map(templates).items()
-    }
-
-
-def _grouped_fixture(tmp_path):
+def _flat_fixture(tmp_path):
     dev_dir, prod_dir = _write_catalogs(
         tmp_path,
         dev_llm="""
@@ -175,6 +122,37 @@ def _grouped_fixture(tmp_path):
 
             - weights:
                 - org/model-A
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "1.0.0"
+              tt_metal_commit: "old-metal"
+              vllm_commit: "old-vllm"
+              device_model_specs:
+                - device: N150
+                  max_concurrency: 2
+                  max_context: 4096
+                  default_impl: true
+              metadata:
+                org/model-A:
+                  note: old-a
+
+            - weights:
+                - org/model-A
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "1.0.0"
+              tt_metal_commit: "old-metal"
+              vllm_commit: "old-vllm"
+              device_model_specs:
+                - device: N300
+                  max_concurrency: 4
+                  max_context: 8192
+                  default_impl: true
+              metadata:
+                org/model-A:
+                  note: old-a
+
+            - weights:
                 - org/model-B
               impl: tt_transformers
               inference_engine: VLLM
@@ -186,13 +164,23 @@ def _grouped_fixture(tmp_path):
                   max_concurrency: 2
                   max_context: 4096
                   default_impl: true
+              metadata:
+                org/model-B:
+                  note: old-b
+
+            - weights:
+                - org/model-B
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "1.0.0"
+              tt_metal_commit: "old-metal"
+              vllm_commit: "old-vllm"
+              device_model_specs:
                 - device: N300
                   max_concurrency: 4
                   max_context: 8192
                   default_impl: true
               metadata:
-                org/model-A:
-                  note: old-a
                 org/model-B:
                   note: old-b
         """,
@@ -204,8 +192,8 @@ def _grouped_fixture(tmp_path):
     return ci_path, dev_dir, prod_dir
 
 
-def test_grouped_owner_is_leafized_and_only_target_semantics_change(tmp_path):
-    ci_path, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+def test_only_exact_target_leaf_changes(tmp_path):
+    ci_path, dev_dir, prod_dir = _flat_fixture(tmp_path)
 
     report = promote(ci_path, dev_dir, prod_dir, **PINS)
 
@@ -277,7 +265,7 @@ def test_new_target_is_appended_as_exact_leaf(tmp_path):
 
 
 def test_resolution_failure_does_not_write_any_prod_file(tmp_path):
-    ci_path, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+    ci_path, dev_dir, prod_dir = _flat_fixture(tmp_path)
     ci_path = _write_ci(
         tmp_path,
         {
@@ -335,7 +323,7 @@ def test_duplicate_prod_identity_fails_before_write(tmp_path):
 
 @pytest.mark.parametrize("vllm_commit", [None, "", "   "])
 def test_vllm_target_requires_non_empty_vllm_commit(tmp_path, vllm_commit):
-    ci_path, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+    ci_path, dev_dir, prod_dir = _flat_fixture(tmp_path)
     before = (prod_dir / "llm.yaml").read_bytes()
 
     with pytest.raises(ValueError, match="vllm_commit"):
@@ -352,7 +340,7 @@ def test_vllm_target_requires_non_empty_vllm_commit(tmp_path, vllm_commit):
 
 
 def test_dry_run_json_reports_changes_without_writing(tmp_path, capsys):
-    ci_path, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+    ci_path, dev_dir, prod_dir = _flat_fixture(tmp_path)
     before = (prod_dir / "llm.yaml").read_bytes()
 
     result = main(
@@ -385,7 +373,7 @@ def test_dry_run_json_reports_changes_without_writing(tmp_path, capsys):
 
 
 def test_json_error_is_machine_readable_and_does_not_write(tmp_path, capsys):
-    _, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+    _, dev_dir, prod_dir = _flat_fixture(tmp_path)
     ci_path = _write_ci(
         tmp_path,
         {"missing-model": _vllm_release_entry("N150")},
@@ -440,7 +428,7 @@ def test_json_error_is_machine_readable_and_does_not_write(tmp_path, capsys):
 def test_yaml_errors_are_machine_readable_and_do_not_write(
     tmp_path, capsys, invalid_prod
 ):
-    ci_path, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+    ci_path, dev_dir, prod_dir = _flat_fixture(tmp_path)
     (prod_dir / "llm.yaml").write_text(textwrap.dedent(invalid_prod))
     before = (prod_dir / "llm.yaml").read_bytes()
 
@@ -471,7 +459,7 @@ def test_yaml_errors_are_machine_readable_and_do_not_write(
 
 
 def test_second_promotion_is_byte_idempotent(tmp_path):
-    ci_path, dev_dir, prod_dir = _grouped_fixture(tmp_path)
+    ci_path, dev_dir, prod_dir = _flat_fixture(tmp_path)
     promote(ci_path, dev_dir, prod_dir, **PINS)
     after_first = {path.name: path.read_bytes() for path in prod_dir.glob("*.yaml")}
 
@@ -482,68 +470,6 @@ def test_second_promotion_is_byte_idempotent(tmp_path):
     assert {
         path.name: path.read_bytes() for path in prod_dir.glob("*.yaml")
     } == after_first
-
-
-def test_full_prod_flattening_has_no_expanded_semantic_diff(tmp_path):
-    prod_copy = tmp_path / "prod"
-    shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
-    before = _serialized_catalog(prod_copy)
-    ci_path = _write_ci(tmp_path, {})
-
-    report = promote(
-        ci_path,
-        DEFAULT_DEV_DIR,
-        prod_copy,
-        version=PINS["version"],
-        tt_metal_commit=PINS["tt_metal_commit"],
-    )
-
-    assert report["leaf_count_before"] == 225
-    assert report["leaf_count_after"] == 225
-    assert _serialized_catalog(prod_copy) == before
-    assert len(_load_leaf_templates(prod_copy)) == 225
-    for template in _raw_templates(prod_copy):
-        assert "perf_reference" in template["device_model_specs"][0]
-        assert template["model_display_name"]
-        assert template["catalog_group"]
-
-
-def test_full_prod_flattening_preserves_generated_documentation(tmp_path):
-    prod_copy = tmp_path / "prod"
-    shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
-    ci_path = _write_ci(tmp_path, {})
-    before_docs = tmp_path / "docs-before"
-    after_docs = tmp_path / "docs-after"
-
-    with contextlib.redirect_stdout(io.StringIO()):
-        generate_doc_pages(
-            [
-                template
-                for filename in MODEL_SPEC_CATALOG_FILES
-                for template in load_templates_from_yaml(prod_copy / filename)
-            ],
-            str(before_docs),
-        )
-
-    promote(
-        ci_path,
-        DEFAULT_DEV_DIR,
-        prod_copy,
-        version=PINS["version"],
-        tt_metal_commit=PINS["tt_metal_commit"],
-    )
-
-    with contextlib.redirect_stdout(io.StringIO()):
-        generate_doc_pages(
-            [
-                template
-                for filename in MODEL_SPEC_CATALOG_FILES
-                for template in load_templates_from_yaml(prod_copy / filename)
-            ],
-            str(after_docs),
-        )
-
-    assert _file_tree(after_docs) == _file_tree(before_docs)
 
 
 def test_docs_show_limits_for_heterogeneous_release_configurations(tmp_path):
@@ -558,7 +484,6 @@ def test_docs_show_limits_for_heterogeneous_release_configurations(tmp_path):
               version: "1.0.0"
               tt_metal_commit: old
               vllm_commit: old
-              catalog_group: shared
               model_display_name: model
               device_model_specs:
                 - {device: N150, max_concurrency: 1, max_context: 1024}
@@ -568,7 +493,6 @@ def test_docs_show_limits_for_heterogeneous_release_configurations(tmp_path):
               version: "2.0.0"
               tt_metal_commit: new
               vllm_commit: new
-              catalog_group: shared
               model_display_name: model
               device_model_specs:
                 - {device: N150, max_concurrency: 8, max_context: 65536}
@@ -576,7 +500,7 @@ def test_docs_show_limits_for_heterogeneous_release_configurations(tmp_path):
     )
     templates = load_templates_from_yaml(prod_dir / "llm.yaml")
 
-    assert coalesce_catalog_groups_for_docs(templates) == templates
+    assert coalesce_model_families_for_docs(templates) == templates
     docs = tmp_path / "docs"
     with contextlib.redirect_stdout(io.StringIO()):
         generate_doc_pages(templates, str(docs))
@@ -587,113 +511,35 @@ def test_docs_show_limits_for_heterogeneous_release_configurations(tmp_path):
     assert "| 8 | 65536 |" in page
 
 
-def test_real_catalog_promotion_is_exact_leaf_granular_and_idempotent(tmp_path):
-    prod_copy = tmp_path / "prod"
-    shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
-
-    report = promote(
-        DEFAULT_CI_CONFIG,
-        DEFAULT_DEV_DIR,
-        prod_copy,
-        **PINS,
-    )
-
-    expected = {
-        (
-            "google/diffusiongemma-26B-A4B-it",
-            "P300X2",
-            "vLLM",
-            "diffusion_gemma",
-        ),
-        ("Qwen/Qwen3-32B", "GALAXY", "vLLM", "qwen3_32b_galaxy"),
-    }
-    assert set(report["requested_identities"]) == expected
-    assert set(report["added_identities"]) == {
-        (
-            "google/diffusiongemma-26B-A4B-it",
-            "P300X2",
-            "vLLM",
-            "diffusion_gemma",
-        )
-    }
-    assert set(report["updated_identities"]) == {
-        ("Qwen/Qwen3-32B", "GALAXY", "vLLM", "qwen3_32b_galaxy")
-    }
-    assert report["leaf_count_before"] == 225
-    assert report["leaf_count_after"] == 226
-    assert len(_load_leaf_templates(prod_copy)) == 226
-    assert all(
-        "perf_reference" in template["device_model_specs"][0]
-        for template in _raw_templates(prod_copy)
-    )
-
-    snapshot = {path.name: path.read_bytes() for path in prod_copy.glob("*.yaml")}
-    second = promote(
-        DEFAULT_CI_CONFIG,
-        DEFAULT_DEV_DIR,
-        prod_copy,
-        **PINS,
-    )
-    assert second["changed_files"] == []
-    assert {
-        path.name: path.read_bytes() for path in prod_copy.glob("*.yaml")
-    } == snapshot
-
-
-def test_partial_multiweight_release_keeps_sibling_docs_and_stable_group(tmp_path):
-    prod_copy = tmp_path / "prod"
-    shutil.copytree(DEFAULT_PROD_DIR, prod_copy)
-    empty_config = _write_ci(tmp_path, {})
-    promote(
-        empty_config,
-        DEFAULT_DEV_DIR,
-        prod_copy,
-        version="base",
-        tt_metal_commit="base-metal",
-    )
-    release_config = _write_ci(
+def test_docs_coalesce_flat_weights_by_stable_model_family(tmp_path):
+    _, prod_dir = _write_catalogs(
         tmp_path,
-        {"Llama-3.1-8B": _vllm_release_entry("N150")},
+        dev_llm="templates: []\n",
+        prod_llm="""
+            templates:
+            - weights: [org/model-base]
+              model_display_name: model
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "1.0.0"
+              tt_metal_commit: metal
+              vllm_commit: vllm
+              device_model_specs:
+                - {device: N150, max_concurrency: 1, max_context: 1024}
+            - weights: [org/model-instruct]
+              model_display_name: model
+              impl: tt_transformers
+              inference_engine: VLLM
+              version: "1.0.0"
+              tt_metal_commit: metal
+              vllm_commit: vllm
+              device_model_specs:
+                - {device: N150, max_concurrency: 1, max_context: 1024}
+        """,
     )
+    templates = load_templates_from_yaml(prod_dir / "llm.yaml")
 
-    promote(
-        release_config,
-        DEFAULT_DEV_DIR,
-        prod_copy,
-        version="next",
-        tt_metal_commit="next-metal",
-        vllm_commit="next-vllm",
-    )
-    docs = tmp_path / "docs"
-    with contextlib.redirect_stdout(io.StringIO()):
-        generate_doc_pages(
-            [
-                template
-                for filename in MODEL_SPEC_CATALOG_FILES
-                for template in load_templates_from_yaml(prod_copy / filename)
-            ],
-            str(docs),
-        )
+    coalesced = coalesce_model_families_for_docs(templates)
 
-    n150 = (docs / "llm" / "Llama-3.1-8B_n150.md").read_text()
-    n300 = (docs / "llm" / "Llama-3.1-8B_n300.md").read_text()
-    assert "Llama-3.1-8B-Instruct" in n150
-    assert "Additional released configurations" in n150
-    assert "Llama-3.1-8B-Instruct" in n300
-
-    llama_groups = {
-        template["catalog_group"]
-        for template in _raw_templates(prod_copy)
-        if template.get("model_display_name") == "Llama-3.1-8B"
-        and template["impl"] == "tt_transformers"
-        and any(
-            weight
-            in {
-                "meta-llama/Llama-3.1-8B",
-                "meta-llama/Llama-3.1-8B-Instruct",
-            }
-            for weight in template["weights"]
-        )
-    }
-    assert len(llama_groups) == 1
-    assert next(iter(llama_groups)).startswith("doc:")
+    assert len(coalesced) == 1
+    assert coalesced[0].weights == ["org/model-base", "org/model-instruct"]

--- a/tests/test_release_model_spec_resolver.py
+++ b/tests/test_release_model_spec_resolver.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts.release.model_spec_resolver import (
+    ReleaseCombo,
+    collect_release_combos,
+    load_dev_model_spec_sources,
+    resolve_release_combo,
+    resolve_release_combos,
+)
+from workflows.model_spec import MODEL_SPEC_CATALOG_FILES, resolve_model_spec
+from workflows.workflow_types import DeviceTypes, InferenceEngine
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CI_CONFIG = REPO_ROOT / ".github" / "workflows" / "models-ci-config.json"
+DEV_CATALOG = REPO_ROOT / "workflows" / "model_specs" / "dev"
+
+
+def _write_dev_catalog(tmp_path, *, default_impl=True):
+    dev_dir = tmp_path / "dev"
+    dev_dir.mkdir()
+    (dev_dir / "llm.yaml").write_text(
+        textwrap.dedent(
+            f"""\
+            templates:
+            - weights:
+                - Qwen/Qwen3-32B
+                - Qwen/Qwen3-14B
+              impl: qwen3_32b_galaxy
+              inference_engine: VLLM
+              device_model_specs:
+                - device: GALAXY
+                  max_concurrency: 32
+                  max_context: 131072
+                  default_impl: {str(default_impl).lower()}
+                - device: BLACKHOLE_GALAXY
+                  max_concurrency: 8
+                  max_context: 32768
+                  default_impl: {str(default_impl).lower()}
+
+            - weights:
+                - Qwen/Qwen3-32B
+              impl: tt_transformers
+              inference_engine: VLLM
+              device_model_specs:
+                - device: GALAXY
+                  max_concurrency: 1
+                  max_context: 32768
+                  default_impl: false
+            """
+        )
+    )
+    for filename in MODEL_SPEC_CATALOG_FILES:
+        if filename != "llm.yaml":
+            (dev_dir / filename).write_text("templates: []\n")
+    return dev_dir
+
+
+def test_collect_release_combos_is_ordered_and_normalizes_aliases():
+    ci_config = {
+        "models": {
+            "model-a": {
+                "implementations": [
+                    {
+                        "inference_engine": "vLLM",
+                        "ci": {
+                            "release": {"devices": ["GALAXY", "BH_GALAXY", "GALAXY"]}
+                        },
+                    },
+                    {
+                        "inference_engine": "FORGE",
+                        "ci": {"nightly": {"devices": ["P150"]}},
+                    },
+                ]
+            },
+            "model-b": {
+                "inference_engine": "MEDIA",
+                "ci": {"release": {"devices": ["P150"]}},
+            },
+        }
+    }
+
+    assert collect_release_combos(ci_config) == [
+        ReleaseCombo("model-a", InferenceEngine.VLLM, DeviceTypes.GALAXY),
+        ReleaseCombo(
+            "model-a",
+            InferenceEngine.VLLM,
+            DeviceTypes.BLACKHOLE_GALAXY,
+        ),
+        ReleaseCombo("model-b", InferenceEngine.MEDIA, DeviceTypes.P150),
+    ]
+
+
+def test_collect_release_combos_rejects_all_devices():
+    ci_config = {
+        "models": {
+            "model-a": {
+                "inference_engine": "vLLM",
+                "ci": {"release": {"devices": "ALL"}},
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="cannot be 'ALL'"):
+        collect_release_combos(ci_config)
+
+
+def test_resolve_release_combo_returns_exact_leaf_and_source(tmp_path):
+    dev_dir = _write_dev_catalog(tmp_path)
+    sources = load_dev_model_spec_sources(dev_dir)
+    combo = ReleaseCombo(
+        "Qwen3-32B",
+        InferenceEngine.VLLM,
+        DeviceTypes.GALAXY,
+    )
+
+    resolved = resolve_release_combo(combo, sources)
+
+    assert resolved.identity == (
+        "Qwen/Qwen3-32B",
+        "GALAXY",
+        "vLLM",
+        "qwen3_32b_galaxy",
+    )
+    assert resolved.source_path == dev_dir / "llm.yaml"
+    assert resolved.template_index == 0
+    assert resolved.weight_index == 0
+    assert resolved.device_index == 0
+    assert resolved.source_template.weights == [
+        "Qwen/Qwen3-32B",
+        "Qwen/Qwen3-14B",
+    ]
+    assert len(resolved.source_template.device_model_specs) == 2
+
+
+def test_dev_source_loading_ignores_yaml_files_runtime_does_not_load(tmp_path):
+    dev_dir = _write_dev_catalog(tmp_path)
+    (dev_dir / "extra.yaml").write_text("not: valid: yaml\n")
+
+    sources = load_dev_model_spec_sources(dev_dir)
+
+    assert sources
+    assert {source.path.name for source in sources} == {"llm.yaml"}
+
+
+def test_resolve_release_combo_requires_explicit_default(tmp_path):
+    sources = load_dev_model_spec_sources(
+        _write_dev_catalog(tmp_path, default_impl=False)
+    )
+    combo = ReleaseCombo(
+        "Qwen3-14B",
+        InferenceEngine.VLLM,
+        DeviceTypes.GALAXY,
+    )
+
+    with pytest.raises(ValueError, match="explicit default implementation"):
+        resolve_release_combo(combo, sources)
+
+
+@pytest.mark.parametrize(
+    "ci_config,error",
+    [
+        ({"models": []}, "'models' must be an object"),
+        (
+            {"models": {"model-a": {"implementations": ["bad"]}}},
+            "implementation must be an object",
+        ),
+        (
+            {
+                "models": {
+                    "model-a": {
+                        "inference_engine": "vLLM",
+                        "ci": {"release": {"devices": [123]}},
+                    }
+                }
+            },
+            "device must be a string",
+        ),
+    ],
+)
+def test_collect_release_combos_rejects_malformed_shapes(ci_config, error):
+    with pytest.raises(ValueError, match=error):
+        collect_release_combos(ci_config)
+
+
+def test_real_release_scope_resolves_to_runtime_equivalent_dev_leaves():
+    combos = collect_release_combos(json.loads(CI_CONFIG.read_text()))
+    sources = load_dev_model_spec_sources(DEV_CATALOG)
+
+    resolved = resolve_release_combos(combos, sources)
+
+    assert combos
+    assert len(resolved) == len(combos)
+    specs = [source.spec for source in sources]
+    for item in resolved:
+        runtime_spec = resolve_model_spec(
+            specs,
+            model=item.combo.model_name,
+            device=item.combo.device,
+            engine=item.combo.engine,
+            catalog_name="test dev catalog",
+        )
+        assert runtime_spec is item.model_spec
+
+    qwen = next(
+        item
+        for item in resolved
+        if item.combo.model_name == "Qwen3-32B"
+        and item.combo.device == DeviceTypes.GALAXY
+        and item.combo.engine == InferenceEngine.VLLM
+    )
+    assert qwen.identity == (
+        "Qwen/Qwen3-32B",
+        "GALAXY",
+        "vLLM",
+        "qwen3_32b_galaxy",
+    )
+
+
+def test_real_release_scope_matches_dev_runtime_subprocess():
+    script = textwrap.dedent(
+        """\
+        import json
+        from pathlib import Path
+        from scripts.release.model_spec_resolver import collect_release_combos
+        from workflows.model_spec import get_runtime_model_spec, model_spec_leaf_identity
+
+        config = json.loads(Path(".github/workflows/models-ci-config.json").read_text())
+        identities = []
+        for combo in collect_release_combos(config):
+            spec, _, _ = get_runtime_model_spec(
+                model=combo.model_name,
+                device=combo.device.to_string(),
+                engine=combo.engine.value,
+            )
+            identities.append(model_spec_leaf_identity(spec))
+        print(json.dumps(identities))
+        """
+    )
+    env = {**os.environ, "MODEL_SPECS_ENV": "dev", "PYTHONDONTWRITEBYTECODE": "1"}
+
+    output = subprocess.check_output(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+    )
+
+    combos = collect_release_combos(json.loads(CI_CONFIG.read_text()))
+    sources = load_dev_model_spec_sources(DEV_CATALOG)
+    expected = [list(item.identity) for item in resolve_release_combos(combos, sources)]
+    assert json.loads(output) == expected

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -106,6 +106,7 @@ def mock_model_spec():
     mock_spec = MagicMock()
     mock_spec.model_id = "id_tt-transformers_Mistral-7B-Instruct-v0.3_n150"
     mock_spec.model_name = "Mistral-7B-Instruct-v0.3"
+    mock_spec.hf_model_repo = "mistralai/Mistral-7B-Instruct-v0.3"
     mock_spec.tt_metal_commit = "test-commit"
     mock_spec.vllm_commit = "test-vllm-commit"
     mock_spec.inference_engine = "vLLM"
@@ -602,6 +603,7 @@ class TestArgsInference:
         spec = MagicMock()
         spec.model_id = model_id
         spec.model_name = "Mistral-7B-Instruct-v0.3"
+        spec.hf_model_repo = "mistralai/Mistral-7B-Instruct-v0.3"
         spec.device_type = DeviceTypes.N150
         spec.inference_engine = "vLLM"
         spec.impl.impl_name = impl_name
@@ -852,6 +854,7 @@ class TestOverrideArgsIntegration:
         mock_model_spec = MagicMock()
         mock_model_spec.model_id = "id_tt-transformers_Mistral-7B-Instruct-v0.3_n150"
         mock_model_spec.model_name = "Mistral-7B-Instruct-v0.3"
+        mock_model_spec.hf_model_repo = "mistralai/Mistral-7B-Instruct-v0.3"
         mock_model_spec.device_type = DeviceTypes.N150
         mock_model_spec.inference_engine = "vLLM"
         mock_model_spec.impl.impl_name = "tt-transformers"
@@ -876,6 +879,7 @@ class TestOverrideArgsIntegration:
         mock_model_spec = MagicMock()
         mock_model_spec.model_id = "test-model-id"
         mock_model_spec.model_name = "Mistral-7B-Instruct-v0.3"
+        mock_model_spec.hf_model_repo = "mistralai/Mistral-7B-Instruct-v0.3"
         mock_model_spec.device_type = "n150"
         mock_model_spec.docker_image = "test:image"
         mock_model_spec.impl.impl_name = "tt-transformers"

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1072,8 +1072,9 @@ class ModelSpecTemplate:
         specs = []
 
         for weight in self.weights:
-            perf_reference_map = get_perf_reference_map(
-                model_weights_to_model_name(weight), self.perf_targets_map
+            weight_model_name = model_weights_to_model_name(weight)
+            template_reference_map = get_perf_reference_map(
+                weight_model_name, self.perf_targets_map
             )
             for device_model_spec in self.device_model_specs:
                 device_type = device_model_spec.device
@@ -1081,6 +1082,25 @@ class ModelSpecTemplate:
                 model_id = get_model_id(
                     self.impl.impl_name, model_name, device_type.name.lower()
                 )
+
+                # A device may be graded against a different fraction of
+                # theoretical than the rest of the template -- one board where
+                # this impl is known to reach less. Its map overrides the
+                # template's tier by tier, so a device can loosen `complete`
+                # without restating the others, and the theoretical reference
+                # itself stays shared (it is a property of the model and the
+                # hardware, not of the stack). Recomputed only when the device
+                # actually overrides; otherwise this is one map per weight.
+                if device_model_spec.perf_targets_map:
+                    perf_reference_map = get_perf_reference_map(
+                        weight_model_name,
+                        {
+                            **self.perf_targets_map,
+                            **device_model_spec.perf_targets_map,
+                        },
+                    )
+                else:
+                    perf_reference_map = template_reference_map
 
                 # Perf reference for this device accounting for impl features
                 # e.g. data parallelism factor

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -10,7 +10,7 @@ import re
 import yaml
 from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Union
 
 from workflows.utils import (
     get_repo_root_path,
@@ -1258,8 +1258,9 @@ if _MODEL_SPECS_ENV not in _VALID_MODEL_SPECS_ENVS:
     )
 
 # One catalog file per model category. Load order determines spec_templates
-# order, which in turn determines MODEL_SPECS dict insertion order.
-_CATALOG_FILES = (
+# order, which in turn determines MODEL_SPECS dict insertion order. Release
+# resolution uses this same list so it cannot discover specs runtime ignores.
+MODEL_SPEC_CATALOG_FILES = (
     "llm.yaml",
     "vlm.yaml",
     "video.yaml",
@@ -1272,7 +1273,7 @@ _CATALOG_FILES = (
 
 spec_templates: List["ModelSpecTemplate"] = [
     template
-    for fname in _CATALOG_FILES
+    for fname in MODEL_SPEC_CATALOG_FILES
     for template in load_templates_from_yaml(
         _MODEL_SPECS_DIR / _MODEL_SPECS_ENV / fname
     )
@@ -1409,6 +1410,104 @@ IMAGE_PINNED_MODEL_SPECS: List[ModelSpec] = [
 ]
 
 
+def resolve_model_spec(
+    specs: Iterable[ModelSpec],
+    *,
+    model: str,
+    device: Union[str, DeviceTypes],
+    engine: Optional[Union[str, InferenceEngine]] = None,
+    impl: Optional[str] = None,
+    catalog_name: str = "catalog",
+) -> ModelSpec:
+    """Resolve one model request from an explicit set of expanded specs."""
+    if not isinstance(model, str) or not model:
+        raise ValueError(
+            f"Model selector must be a non-empty string for {catalog_name}"
+        )
+    model_name = Path(model).name
+    try:
+        device_type = (
+            device
+            if isinstance(device, DeviceTypes)
+            else DeviceTypes.from_string(device)
+        )
+    except (AttributeError, ValueError) as exc:
+        raise ValueError(f"Invalid device {device!r} for {catalog_name}") from exc
+
+    try:
+        engine_value = (
+            engine.value
+            if isinstance(engine, InferenceEngine)
+            else InferenceEngine.from_string(engine).value
+            if engine
+            else None
+        )
+    except (AttributeError, KeyError, ValueError) as exc:
+        raise ValueError(
+            f"Invalid inference engine {engine!r} for {catalog_name}"
+        ) from exc
+
+    spec_list = list(specs)
+    if "/" in model:
+        model_specs = [spec for spec in spec_list if spec.hf_model_repo == model]
+    else:
+        model_specs = [spec for spec in spec_list if spec.model_name == model_name]
+        hf_repos = sorted({spec.hf_model_repo for spec in model_specs})
+        if len(hf_repos) > 1:
+            raise ValueError(
+                f"Model basename {model_name!r} is ambiguous in {catalog_name}; "
+                f"matching Hugging Face repositories: {hf_repos!r}; "
+                "use the full Hugging Face repository"
+            )
+
+    candidates = [
+        spec
+        for spec in model_specs
+        if spec.device_type == device_type
+        and (engine_value is None or spec.inference_engine == engine_value)
+        and (impl is None or spec.impl.impl_name == impl)
+    ]
+    query = (
+        f"model={model_name!r}, device={device_type.to_string()!r}, "
+        f"engine={engine_value!r}, impl={impl!r}"
+    )
+    if not candidates:
+        raise ValueError(f"No model spec matches {query} in {catalog_name}")
+
+    default_specs = [spec for spec in candidates if spec.device_model_spec.default_impl]
+
+    # Preserve the existing no-engine runtime behavior. Defaults in different
+    # engines are valid and engine inference historically follows catalog order.
+    if engine_value is None:
+        selected_spec = next(iter(default_specs), None)
+        if selected_spec is not None:
+            return selected_spec
+        if impl is not None:
+            return candidates[0]
+        raise ValueError(
+            f"Model {model_name!r} does not have a default impl for "
+            f"device={device_type.to_string()!r} in {catalog_name}; "
+            "pass --impl or --engine"
+        )
+
+    if len(default_specs) == 1:
+        return default_specs[0]
+    if len(default_specs) > 1:
+        identities = sorted(model_spec_leaf_identity(spec) for spec in default_specs)
+        raise ValueError(
+            f"Multiple default implementations match {query} in {catalog_name}: "
+            f"{identities!r}"
+        )
+    if len(candidates) == 1:
+        return candidates[0]
+
+    identities = sorted(model_spec_leaf_identity(spec) for spec in candidates)
+    raise ValueError(
+        f"No unique default implementation matches {query} in {catalog_name}; "
+        f"candidates: {identities!r}"
+    )
+
+
 def get_runtime_model_spec(
     model: str,
     device: str,
@@ -1428,42 +1527,16 @@ def get_runtime_model_spec(
     Returns ``(model_spec, resolved_impl, resolved_engine)`` so the caller
     can construct a fully-initialised RuntimeConfig in one step.
     """
-    device_type = DeviceTypes.from_string(device)
-
-    candidate_specs = [
-        spec
-        for spec in MODEL_SPECS.values()
-        if spec.model_name == model
-        and spec.device_type == device_type
-        and (not engine or spec.inference_engine == engine)
-        and (not impl or spec.impl.impl_name == impl)
-    ]
-
-    if not candidate_specs:
-        engine_msg = f", engine={engine}" if engine else ""
-        impl_msg = f", impl={impl}" if impl else ""
-        raise ValueError(
-            f"Model:={model} does not support device:={device}{engine_msg}{impl_msg} "
-            f"in the {_MODEL_SPECS_ENV!r} catalog"
-        )
-
-    default_spec = next(
-        (spec for spec in candidate_specs if spec.device_model_spec.default_impl),
-        None,
+    model_spec = resolve_model_spec(
+        MODEL_SPECS.values(),
+        model=model,
+        device=device,
+        engine=engine,
+        impl=impl,
+        catalog_name=f"{_MODEL_SPECS_ENV!r} catalog",
     )
-    selected_spec = default_spec or (candidate_specs[0] if (impl or engine) else None)
-
-    if selected_spec is None:
-        raise ValueError(
-            f"Model:={model} does not have a default impl for "
-            f"device:={device}, engine:={engine} in the {_MODEL_SPECS_ENV!r} catalog; "
-            f"you must pass --impl or --engine"
-        )
-
-    resolved_impl = selected_spec.impl.impl_name
-    resolved_engine = engine if engine else selected_spec.inference_engine
-
-    model_spec = MODEL_SPECS[selected_spec.model_id]
+    resolved_impl = model_spec.impl.impl_name
+    resolved_engine = model_spec.inference_engine
     return model_spec, resolved_impl, resolved_engine
 
 

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1072,12 +1072,6 @@ class ModelSpecTemplate:
         specs = []
 
         for weight in self.weights:
-            # Targets are looked up for the weight being expanded, not for the
-            # family it is listed under. A family member is a different model:
-            # grading it against a sibling's numbers reports a pass or a fail
-            # that was never measured for it. A weight with no entry in
-            # model_performance_reference.json therefore carries no targets
-            # rather than borrowing another model's.
             perf_reference_map = get_perf_reference_map(
                 model_weights_to_model_name(weight), self.perf_targets_map
             )
@@ -1094,12 +1088,6 @@ class ModelSpecTemplate:
                     device_model_spec, perf_reference_map
                 )
 
-                # Carry the catalog device spec over wholesale and substitute only
-                # the derived field. Listing the copied fields by hand silently
-                # dropped every field added later without updating the list, so a
-                # catalog setting reached the dataclass but never the runtime spec.
-                # perf_reference stays explicit because it is the one field the
-                # catalog must not supply -- see _build_device_model_spec().
                 device_model_spec_with_perf = replace(
                     device_model_spec, perf_reference=perf_reference
                 )

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -427,10 +427,6 @@ class KnownIssue:
         return task_name is not None and self.task_name == task_name
 
 
-class ExplicitPerfReference(list):
-    """Marker for generated YAML references that must not be re-derived."""
-
-
 @dataclass(frozen=True)
 class DeviceModelSpec:
     """
@@ -1033,10 +1029,9 @@ class ModelSpecTemplate:
     )
     has_builtin_warmup: bool = False
     metadata: Dict[str, Dict] = field(default_factory=dict)
-    # Generated leaf-granular prod entries retain the display grouping of their
-    # source template so documentation layout does not change during migration.
+    # Leaf-granular prod entries retain their source model family. This keeps
+    # documentation grouping and performance-reference lookup stable.
     model_display_name: Optional[str] = None
-    catalog_group: Optional[str] = None
 
     def __post_init__(self):
         self._validate_data()
@@ -1076,7 +1071,9 @@ class ModelSpecTemplate:
         specs = []
 
         # Generate performance reference map
-        main_model_name = model_weights_to_model_name(self.weights[0])
+        main_model_name = self.model_display_name or model_weights_to_model_name(
+            self.weights[0]
+        )
         perf_reference_map = get_perf_reference_map(
             main_model_name, self.perf_targets_map
         )
@@ -1091,12 +1088,8 @@ class ModelSpecTemplate:
 
                 # Perf reference for this device accounting for impl features
                 # e.g. data parallelism factor
-                perf_reference = (
-                    device_model_spec.perf_reference
-                    if isinstance(
-                        device_model_spec.perf_reference, ExplicitPerfReference
-                    )
-                    else get_perf_reference(device_model_spec, perf_reference_map)
+                perf_reference = get_perf_reference(
+                    device_model_spec, perf_reference_map
                 )
 
                 # Create a new device_model_spec with performance reference data
@@ -1190,21 +1183,6 @@ def _build_system_requirements(data: Optional[Dict]) -> Optional["SystemRequirem
 def _build_device_model_spec(data: Dict) -> "DeviceModelSpec":
     kwargs = dict(data)
     kwargs["device"] = DeviceTypes.from_string(kwargs["device"])
-    if "perf_reference" in kwargs:
-        perf_reference = []
-        for task_data in kwargs["perf_reference"]:
-            if isinstance(task_data, BenchmarkTaskParams):
-                perf_reference.append(task_data)
-                continue
-            task_kwargs = dict(task_data)
-            task_kwargs["targets"] = {
-                target_name: PerformanceTarget(**target_data)
-                if isinstance(target_data, dict)
-                else target_data
-                for target_name, target_data in task_kwargs.get("targets", {}).items()
-            }
-            perf_reference.append(BenchmarkTaskParams(**task_kwargs))
-        kwargs["perf_reference"] = ExplicitPerfReference(perf_reference)
     if "system_requirements" in kwargs:
         kwargs["system_requirements"] = _build_system_requirements(
             kwargs["system_requirements"]

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1246,12 +1246,23 @@ def _build_template(data: Dict, env: str = "prod") -> "ModelSpecTemplate":
         raise ValueError(f"{env} template {weights}: {exc}") from exc
 
 
-def load_templates_from_yaml(path: Path) -> List["ModelSpecTemplate"]:
+def load_templates_from_yaml(
+    path: Path, env: Optional[str] = None
+) -> List["ModelSpecTemplate"]:
+    """Load one catalog file as templates for the given catalog environment.
+
+    ``env`` selects the template contract -- "prod" requires release pins, dev
+    rejects them -- so callers that already know which catalog they are reading
+    should pass it. It defaults to the parent directory name because the runtime
+    catalogs live in ``model_specs/<env>/``, but relying on that default makes
+    the contract depend on where a file happens to sit.
+    """
     with open(path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
     if not data or "templates" not in data:
         raise ValueError(f"YAML file {path} is empty or missing 'templates' key")
-    env = path.parent.name
+    if env is None:
+        env = path.parent.name
     return [_build_template(t, env) for t in data["templates"]]
 
 
@@ -1285,7 +1296,7 @@ spec_templates: List["ModelSpecTemplate"] = [
     template
     for fname in MODEL_SPEC_CATALOG_FILES
     for template in load_templates_from_yaml(
-        _MODEL_SPECS_DIR / _MODEL_SPECS_ENV / fname
+        _MODEL_SPECS_DIR / _MODEL_SPECS_ENV / fname, env=_MODEL_SPECS_ENV
     )
 ]
 
@@ -1298,11 +1309,6 @@ def model_spec_leaf_identity(spec: ModelSpec) -> Tuple[str, str, str, str]:
         spec.inference_engine,
         spec.impl.impl_id,
     )
-
-
-def model_spec_default_group(spec: ModelSpec) -> Tuple[str, str, str]:
-    """Return the identity shared by implementation alternatives."""
-    return model_spec_leaf_identity(spec)[:3]
 
 
 def validate_model_specs(specs: List[ModelSpec]) -> None:
@@ -1328,7 +1334,9 @@ def validate_model_specs(specs: List[ModelSpec]) -> None:
     for spec in specs:
         if not spec.device_model_spec.default_impl:
             continue
-        group = model_spec_default_group(spec)
+        # Implementation alternatives share everything but impl_id, so trimming
+        # it off the leaf identity yields the group that must hold one default.
+        group = model_spec_leaf_identity(spec)[:3]
         defaults_by_group.setdefault(group, []).append(spec.impl.impl_id)
 
     for group, impl_ids in defaults_by_group.items():

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1279,6 +1279,55 @@ spec_templates: List["ModelSpecTemplate"] = [
 ]
 
 
+def model_spec_leaf_identity(spec: ModelSpec) -> Tuple[str, str, str, str]:
+    """Return the exact identity of one expanded catalog leaf."""
+    return (
+        spec.hf_model_repo,
+        spec.device_type.to_string(),
+        spec.inference_engine,
+        spec.impl.impl_id,
+    )
+
+
+def model_spec_default_group(spec: ModelSpec) -> Tuple[str, str, str]:
+    """Return the identity shared by implementation alternatives."""
+    return model_spec_leaf_identity(spec)[:3]
+
+
+def validate_model_specs(specs: List[ModelSpec]) -> None:
+    """Reject catalog identities that would resolve or collapse ambiguously."""
+    specs_by_identity: Dict[Tuple[str, str, str, str], ModelSpec] = {}
+    identities_by_model_id: Dict[str, Tuple[str, str, str, str]] = {}
+
+    for spec in specs:
+        identity = model_spec_leaf_identity(spec)
+        if identity in specs_by_identity:
+            raise ValueError(f"Duplicate model spec leaf identity: {identity!r}")
+        specs_by_identity[identity] = spec
+
+        previous_identity = identities_by_model_id.get(spec.model_id)
+        if previous_identity is not None and previous_identity != identity:
+            raise ValueError(
+                f"Model ID {spec.model_id!r} maps to multiple leaf identities: "
+                f"{previous_identity!r} and {identity!r}"
+            )
+        identities_by_model_id[spec.model_id] = identity
+
+    defaults_by_group: Dict[Tuple[str, str, str], List[str]] = {}
+    for spec in specs:
+        if not spec.device_model_spec.default_impl:
+            continue
+        group = model_spec_default_group(spec)
+        defaults_by_group.setdefault(group, []).append(spec.impl.impl_id)
+
+    for group, impl_ids in defaults_by_group.items():
+        if len(impl_ids) > 1:
+            raise ValueError(
+                f"Multiple default implementations for model spec group {group!r}: "
+                f"{impl_ids!r}"
+            )
+
+
 def get_model_spec_map(
     templates: List[ModelSpecTemplate],
 ) -> Dict[str, ModelSpec]:
@@ -1291,11 +1340,9 @@ def get_model_spec_map(
     Returns:
         Dictionary mapping model_id to ModelSpec instances
     """
-    model_spec_map = {}
-    for template in templates:
-        for spec in template.expand_to_specs():
-            model_spec_map[spec.model_id] = spec
-    return model_spec_map
+    specs = [spec for template in templates for spec in template.expand_to_specs()]
+    validate_model_specs(specs)
+    return {spec.model_id: spec for spec in specs}
 
 
 def export_model_specs_json(model_specs: dict, output_path: Path) -> int:

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1092,22 +1092,14 @@ class ModelSpecTemplate:
                     device_model_spec, perf_reference_map
                 )
 
-                # Create a new device_model_spec with performance reference data
-                device_model_spec_with_perf = DeviceModelSpec(
-                    device=device_model_spec.device,
-                    max_concurrency=device_model_spec.max_concurrency,
-                    max_context=device_model_spec.max_context,
-                    max_tokens_all_users_override=device_model_spec.max_tokens_all_users_override,
-                    perf_targets_map=device_model_spec.perf_targets_map,
-                    default_impl=device_model_spec.default_impl,
-                    perf_reference=perf_reference,
-                    vllm_args=device_model_spec.vllm_args,
-                    override_tt_config=device_model_spec.override_tt_config,
-                    env_vars=device_model_spec.env_vars,
-                    tensor_cache_timeout=device_model_spec.tensor_cache_timeout,
-                    system_requirements=device_model_spec.system_requirements,
-                    known_issues=device_model_spec.known_issues,
-                    eval_max_retries=device_model_spec.eval_max_retries,
+                # Carry the catalog device spec over wholesale and substitute only
+                # the derived field. Listing the copied fields by hand silently
+                # dropped every field added later without updating the list, so a
+                # catalog setting reached the dataclass but never the runtime spec.
+                # perf_reference stays explicit because it is the one field the
+                # catalog must not supply -- see _build_device_model_spec().
+                device_model_spec_with_perf = replace(
+                    device_model_spec, perf_reference=perf_reference
                 )
                 spec = ModelSpec(
                     # Core identity

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -427,6 +427,10 @@ class KnownIssue:
         return task_name is not None and self.task_name == task_name
 
 
+class ExplicitPerfReference(list):
+    """Marker for generated YAML references that must not be re-derived."""
+
+
 @dataclass(frozen=True)
 class DeviceModelSpec:
     """
@@ -1029,6 +1033,10 @@ class ModelSpecTemplate:
     )
     has_builtin_warmup: bool = False
     metadata: Dict[str, Dict] = field(default_factory=dict)
+    # Generated leaf-granular prod entries retain the display grouping of their
+    # source template so documentation layout does not change during migration.
+    model_display_name: Optional[str] = None
+    catalog_group: Optional[str] = None
 
     def __post_init__(self):
         self._validate_data()
@@ -1083,8 +1091,12 @@ class ModelSpecTemplate:
 
                 # Perf reference for this device accounting for impl features
                 # e.g. data parallelism factor
-                perf_reference = get_perf_reference(
-                    device_model_spec, perf_reference_map
+                perf_reference = (
+                    device_model_spec.perf_reference
+                    if isinstance(
+                        device_model_spec.perf_reference, ExplicitPerfReference
+                    )
+                    else get_perf_reference(device_model_spec, perf_reference_map)
                 )
 
                 # Create a new device_model_spec with performance reference data
@@ -1178,6 +1190,21 @@ def _build_system_requirements(data: Optional[Dict]) -> Optional["SystemRequirem
 def _build_device_model_spec(data: Dict) -> "DeviceModelSpec":
     kwargs = dict(data)
     kwargs["device"] = DeviceTypes.from_string(kwargs["device"])
+    if "perf_reference" in kwargs:
+        perf_reference = []
+        for task_data in kwargs["perf_reference"]:
+            if isinstance(task_data, BenchmarkTaskParams):
+                perf_reference.append(task_data)
+                continue
+            task_kwargs = dict(task_data)
+            task_kwargs["targets"] = {
+                target_name: PerformanceTarget(**target_data)
+                if isinstance(target_data, dict)
+                else target_data
+                for target_name, target_data in task_kwargs.get("targets", {}).items()
+            }
+            perf_reference.append(BenchmarkTaskParams(**task_kwargs))
+        kwargs["perf_reference"] = ExplicitPerfReference(perf_reference)
     if "system_requirements" in kwargs:
         kwargs["system_requirements"] = _build_system_requirements(
             kwargs["system_requirements"]

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1029,8 +1029,9 @@ class ModelSpecTemplate:
     )
     has_builtin_warmup: bool = False
     metadata: Dict[str, Dict] = field(default_factory=dict)
-    # Leaf-granular prod entries retain their source model family. This keeps
-    # documentation grouping and performance-reference lookup stable.
+    # Leaf-granular prod entries retain their source model family, which a
+    # single-weight entry cannot imply. This keeps documentation grouping
+    # stable; performance targets are looked up per weight and do not use it.
     model_display_name: Optional[str] = None
 
     def __post_init__(self):
@@ -1070,15 +1071,16 @@ class ModelSpecTemplate:
         """Expand this template into individual ModelSpec instances."""
         specs = []
 
-        # Generate performance reference map
-        main_model_name = self.model_display_name or model_weights_to_model_name(
-            self.weights[0]
-        )
-        perf_reference_map = get_perf_reference_map(
-            main_model_name, self.perf_targets_map
-        )
-
         for weight in self.weights:
+            # Targets are looked up for the weight being expanded, not for the
+            # family it is listed under. A family member is a different model:
+            # grading it against a sibling's numbers reports a pass or a fail
+            # that was never measured for it. A weight with no entry in
+            # model_performance_reference.json therefore carries no targets
+            # rather than borrowing another model's.
+            perf_reference_map = get_perf_reference_map(
+                model_weights_to_model_name(weight), self.perf_targets_map
+            )
             for device_model_spec in self.device_model_specs:
                 device_type = device_model_spec.device
                 model_name = Path(weight).name

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -1183,6 +1183,11 @@ def _build_system_requirements(data: Optional[Dict]) -> Optional["SystemRequirem
 def _build_device_model_spec(data: Dict) -> "DeviceModelSpec":
     kwargs = dict(data)
     kwargs["device"] = DeviceTypes.from_string(kwargs["device"])
+    if "perf_reference" in kwargs:
+        raise ValueError(
+            "Catalog YAML must not define perf_reference; it is derived from "
+            "model_performance_reference.json"
+        )
     if "system_requirements" in kwargs:
         kwargs["system_requirements"] = _build_system_requirements(
             kwargs["system_requirements"]

--- a/workflows/model_specs/dev/audio_tts.yaml
+++ b/workflows/model_specs/dev/audio_tts.yaml
@@ -8,6 +8,7 @@ templates:
 - weights:
     - openai/whisper-large-v3
     - distil-whisper/distil-large-v3
+  model_display_name: whisper-large-v3
   impl: whisper
   min_disk_gb: 15
   min_ram_gb: 6
@@ -35,6 +36,7 @@ templates:
 - weights:
     - openai/whisper-large-v3
     - distil-whisper/distil-large-v3
+  model_display_name: whisper-large-v3
   impl: whisper
   min_disk_gb: 15
   min_ram_gb: 6
@@ -56,6 +58,7 @@ templates:
 - weights:
     - openai/whisper-large-v3
     - distil-whisper/distil-large-v3
+  model_display_name: whisper-large-v3
   impl: whisper
   min_disk_gb: 15
   min_ram_gb: 6

--- a/workflows/model_specs/dev/image.yaml
+++ b/workflows/model_specs/dev/image.yaml
@@ -9,6 +9,7 @@ templates:
 - weights:
     - stabilityai/stable-diffusion-xl-base-1.0
     - stabilityai/stable-diffusion-xl-base-1.0-img-2-img
+  model_display_name: stable-diffusion-xl-base-1.0
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -147,6 +148,7 @@ templates:
 - weights:
     - black-forest-labs/FLUX.1-dev
     - black-forest-labs/FLUX.1-schnell
+  model_display_name: FLUX.1-dev
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -174,6 +176,7 @@ templates:
 - weights:
     - black-forest-labs/FLUX.1-dev
     - black-forest-labs/FLUX.1-schnell
+  model_display_name: FLUX.1-dev
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6
@@ -247,6 +250,7 @@ templates:
 - weights:
     - Qwen/Qwen-Image
     - Qwen/Qwen-Image-2512
+  model_display_name: Qwen-Image
   impl: tt_transformers
   min_disk_gb: 15
   min_ram_gb: 6

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -789,6 +789,7 @@ templates:
 - weights:
     - Qwen/Qwen2.5-72B
     - Qwen/Qwen2.5-72B-Instruct
+  model_display_name: Qwen2.5-72B
   impl: tt_transformers
   inference_engine: VLLM
   device_model_specs:
@@ -834,6 +835,7 @@ templates:
 - weights:
     - Qwen/Qwen2.5-7B
     - Qwen/Qwen2.5-7B-Instruct
+  model_display_name: Qwen2.5-7B
   impl: tt_transformers
   inference_engine: VLLM
   device_model_specs:
@@ -861,6 +863,7 @@ templates:
     - meta-llama/Llama-3.1-70B
     - meta-llama/Llama-3.1-70B-Instruct
     - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  model_display_name: Llama-3.3-70B-Instruct
   impl: llama3_70b_galaxy
   inference_engine: VLLM
   device_model_specs:
@@ -964,6 +967,7 @@ templates:
     - meta-llama/Llama-3.1-70B
     - meta-llama/Llama-3.1-70B-Instruct
     - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  model_display_name: Llama-3.3-70B-Instruct
   impl: tt_transformers
   system_requirements:
     firmware:
@@ -1001,6 +1005,7 @@ templates:
     - meta-llama/Llama-3.1-70B
     - meta-llama/Llama-3.1-70B-Instruct
     - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  model_display_name: Llama-3.3-70B-Instruct
   impl: tt_transformers
   inference_engine: VLLM
   device_model_specs:
@@ -1049,6 +1054,7 @@ templates:
     - meta-llama/Llama-3.1-70B
     - meta-llama/Llama-3.1-70B-Instruct
     - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  model_display_name: Llama-3.3-70B-Instruct
   impl: tt_transformers
   system_requirements:
     firmware:
@@ -1088,6 +1094,7 @@ templates:
     - meta-llama/Llama-3.1-70B
     - meta-llama/Llama-3.1-70B-Instruct
     - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  model_display_name: Llama-3.3-70B-Instruct
   impl: tt_transformers
   system_requirements:
     firmware:
@@ -1125,6 +1132,7 @@ templates:
 - weights:
     - meta-llama/Llama-3.2-1B
     - meta-llama/Llama-3.2-1B-Instruct
+  model_display_name: Llama-3.2-1B
   impl: tt_transformers
   inference_engine: VLLM
   device_model_specs:
@@ -1153,6 +1161,7 @@ templates:
 - weights:
     - meta-llama/Llama-3.2-3B
     - meta-llama/Llama-3.2-3B-Instruct
+  model_display_name: Llama-3.2-3B
   impl: tt_transformers
   inference_engine: VLLM
   device_model_specs:
@@ -1180,6 +1189,7 @@ templates:
 - weights:
     - meta-llama/Llama-3.1-8B
     - meta-llama/Llama-3.1-8B-Instruct
+  model_display_name: Llama-3.1-8B
   impl: tt_transformers
   inference_engine: VLLM
   device_model_specs:
@@ -1215,6 +1225,7 @@ templates:
 - weights:
     - meta-llama/Llama-3.1-8B
     - meta-llama/Llama-3.1-8B-Instruct
+  model_display_name: Llama-3.1-8B
   impl: tt_transformers
   inference_engine: VLLM
   device_model_specs:
@@ -1256,6 +1267,7 @@ templates:
 - weights:
     - meta-llama/Llama-3.1-8B
     - meta-llama/Llama-3.1-8B-Instruct
+  model_display_name: Llama-3.1-8B
   impl: tt_transformers
   inference_engine: VLLM
   device_model_specs:
@@ -1278,6 +1290,7 @@ templates:
 - weights:
     - meta-llama/Llama-3.1-8B
     - meta-llama/Llama-3.1-8B-Instruct
+  model_display_name: Llama-3.1-8B
   impl: tt_transformers
   system_requirements:
     firmware:
@@ -1306,6 +1319,7 @@ templates:
 - weights:
     - meta-llama/Llama-3.1-8B
     - meta-llama/Llama-3.1-8B-Instruct
+  model_display_name: Llama-3.1-8B
   impl: tt_transformers
   system_requirements:
     firmware:
@@ -1374,6 +1388,7 @@ templates:
 - weights:
     - meta-llama/Llama-3.1-8B
     - meta-llama/Llama-3.1-8B-Instruct
+  model_display_name: Llama-3.1-8B
   impl: tt_transformers
   inference_engine: VLLM
   device_model_specs:
@@ -1652,6 +1667,7 @@ templates:
 - weights:
     - meta-llama/Llama-3.2-3B
     - meta-llama/Llama-3.2-3B-Instruct
+  model_display_name: Llama-3.2-3B
   impl: forge_vllm_plugin
   min_disk_gb: 15
   min_ram_gb: 8

--- a/workflows/model_specs/dev/vlm.yaml
+++ b/workflows/model_specs/dev/vlm.yaml
@@ -8,6 +8,7 @@ templates:
 - weights:
     - google/gemma-3-4b-it
     - google/medgemma-4b-it
+  model_display_name: gemma-3-4b-it
   impl: tt_transformers
   inference_engine: VLLM
   device_model_specs:
@@ -62,6 +63,7 @@ templates:
 - weights:
     - google/gemma-3-27b-it
     - google/medgemma-27b-it
+  model_display_name: gemma-3-27b-it
   impl: tt_transformers
   inference_engine: VLLM
   device_model_specs:
@@ -250,6 +252,7 @@ templates:
 - weights:
     - meta-llama/Llama-3.2-11B-Vision
     - meta-llama/Llama-3.2-11B-Vision-Instruct
+  model_display_name: Llama-3.2-11B-Vision
   impl: tt_transformers
   inference_engine: VLLM
   device_model_specs:
@@ -270,6 +273,7 @@ templates:
 - weights:
     - meta-llama/Llama-3.2-90B-Vision
     - meta-llama/Llama-3.2-90B-Vision-Instruct
+  model_display_name: Llama-3.2-90B-Vision
   impl: tt_transformers
   inference_engine: VLLM
   device_model_specs:


### PR DESCRIPTION
## Summary

Makes the release resolver strict: every release selector must resolve to exactly one
runtime leaf `(hf_model_repo, device, inference_engine, impl_id)`, or the run fails.
Zero matches, multiple matches, and two selectors resolving to the same leaf are all
hard errors now.

Stacked with #5021. Neither PR can merge alone.

## Problem

The old resolver matched catalog blocks by `(basename, engine, device-membership)` and
took the first hit. If a basename existed under two HF orgs (e.g. the same short model
name under `meta-llama/` and `deepseek-ai/`), the match was ambiguous and which one won
depended on YAML order — silently. Promotion and release notes had the same issue:
they matched coarse catalog blocks, not exact leaves.

## What changes

- **Strict resolution**: `resolve_model_spec()` accepts a full HF repo id or a
  basename; if a basename maps to more than one repo, it raises instead of guessing
- **Leaf uniqueness**: `validate_model_specs()` rejects duplicate leaf identities
  and a `model_id` that maps to multiple distinct identities
- **Per-weight perf targets**: performance reference targets are now looked up per
  individual weight instead of once per family head. This exposed some models that
  had no real target — `model_performance_reference.json` needs a follow-up tidy
- **Docs page**: now documents the default impl, not whichever catalog entry came first
- **`model_display_name`** on `ModelSpecTemplate` and prod catalog: records the family
  a leaf came from, used only for docs grouping
- **Unified resolver**: `get_runtime_model_spec()` now delegates to
  `resolve_model_spec()`, so `run.py --model` uses the same resolution path as the
  release flow. No breaking changes — everything works as before, but through one
  resolver instead of two

Must merge before #4722.