### PR TITLE
Validate the release package against the declared scope

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -194,33 +194,6 @@ jobs:
             --tt-metal-commit "${TT_METAL_COMMIT}" \
             --vllm-commit "${VLLM_COMMIT}"
 
-      # ----- Step 1b: fail if promotion produced a shadowed duplicate model_id.
-      #       promote_dev_spec_to_prod.py keys its upsert on the device SET, so
-      #       adding a device appends a new prod block instead of replacing the
-      #       old one; both then expand to the same model_id and the docs
-      #       generator renders the dead one (hit Qwen3.6-27B / Qwen3-Embedding-4B
-      #       at v0.20.0). Inspect the just-promoted PROD catalogue directly (the
-      #       JSON export dedupes via a {model_id: spec} dict and would hide it). -----
-      - name: "Step 1b — assert promotion produced no shadowed duplicates"
-        env:
-          MODEL_SPECS_ENV: prod
-        run: |
-          python3 - <<'PY'
-          import collections, sys
-          from workflows.model_spec import spec_templates
-          seen = collections.defaultdict(list)
-          for t in spec_templates:
-              for s in t.expand_to_specs():
-                  seen[s.model_id].append(getattr(t, "version", None))
-          dups = {k: v for k, v in seen.items() if len(v) > 1}
-          for k, v in sorted(dups.items()):
-              print(f"::error::duplicate model_id {k} produced by prod templates {v} - "
-                    "the older block is unreachable and will be rendered into the docs")
-          if dups:
-              sys.exit(f"{len(dups)} shadowed duplicate model_id(s) in the prod catalogue")
-          print(f"OK - {len(seen)} unique model_ids, no duplicates")
-          PY
-
       # ----- Step 2: regenerate model-support docs + release_model_spec.json ----
       - name: "Step 2 — export model spec (docs + JSON)"
         run: python3 scripts/release/export_model_spec.py

--- a/scripts/release/README_MANUAL.md
+++ b/scripts/release/README_MANUAL.md
@@ -408,11 +408,46 @@ Release Notes must be added describing new supported engine features.
 
 ## Step 3: Downloading workflow artifacts and assets upload to Release Object
 
- We need to download all the workflow_logs from a given tt-shield runId job. Of course we should consider only models which are in the scope for the release. Afterwards, we zip them as `vx.xx.x-release_artifacts.zip` and upload that artifact to release object as an Asset.
+ We need to download all the workflow_logs from a given tt-shield runId job, for the
+models in scope for the release, and package them as `vx.x.x-release_artifacts.zip`
+to upload to the Release Object as an Asset.
 
-To do so we can use the script currently implemented in the tt-shield repository:
-Once we clone the tt-shield repository, we can find the script at this path:
-`.github/scripts/release_tools/build_release_artifact/build_release_artifacts.py`
+`scripts/release/build_release_artifacts.py` in **this** repository does that, and
+it is the copy `release-automation.yml` runs, so in the normal flow you take the
+`release-artifacts-v<version>` run artifact rather than running the script by hand.
+Run it directly to rebuild the package outside a pipeline run, or to override the
+scope.
+
+Use this copy. tt-shield carries a second one at
+`.github/scripts/release_tools/build_release_artifact/build_release_artifacts.py`,
+which earlier revisions of this document pointed at; it is not what the pipeline
+runs and the two will drift.
+
+### What the package contains
+
+```
+vx.x.x-release_artifacts.zip
+└── vx.x.x-release_artifacts/
+    ├── workflow_logs_release_<model>_<device>.zip      one per released leaf
+    ├── workflow_logs_release_<model>_<device>.zip
+    └── ...
+```
+
+Each inner zip is that job's tt-shield artifact bundle, carried byte for byte
+(`ai_summaries/`, `docker_server/`, `run_logs/`, `runtime_model_specs/`,
+`reports_output/`, and so on). The outer zip is uncompressed — the bundles are
+already deflate zips, so recompressing them buys under 1%.
+
+This layout has been identical since v0.13.0. Do not change it without checking
+who consumes it.
+
+> **Opening the package on macOS.** Off the Release page it is two archives deep and
+> double-clicking works. `release-automation.yml` also publishes it as the
+> `release-artifacts-v<version>` run artifact, and Actions wraps any artifact in a
+> zip of its own — that download is three archives deep, which macOS Archive
+> Utility refuses with "unsupported format". Use `unzip` on it, or take the asset
+> from the Release page once it is published. The package itself is fine; every
+> published asset from v0.13.0 on opens.
 
 As input properties we need to pass:
 - runId of the release job that contains our workflow logs uploaded
@@ -424,7 +459,7 @@ list `promote_dev_spec_to_prod.py` consumes), so the models no longer need to be
 listed by hand:
 
 ```bash
-python3 build_release_artifacts.py \
+python3 scripts/release/build_release_artifacts.py \
         --run-id 26592936143 \
         --version v0.15.0 \
         --output-dir .
@@ -435,7 +470,7 @@ that are not in the release list — pass one or more `--model MODEL=dev1,dev2`
 flags instead:
 
 ```bash
-python3 build_release_artifacts.py \
+python3 scripts/release/build_release_artifacts.py \
         --run-id 26592936143 \
         --version v0.15.0 \
         --model speecht5_tts=p150,p300x2 \

--- a/scripts/release/build_release_artifacts.py
+++ b/scripts/release/build_release_artifacts.py
@@ -42,7 +42,7 @@ The release package, however, names the inner zips after the *device*
      the job-name mapping can't resolve a device, it falls back to classifying
      bundles purely by that internal token.
 
-Requirements: Python 3.8+, the GitHub CLI ``gh`` installed and authenticated
+Requirements: Python 3.10+, the GitHub CLI ``gh`` installed and authenticated
 (``gh auth status``) with ``repo`` scope.
 
 Usage
@@ -67,9 +67,8 @@ model, or to package models that are not in the release list):
         --model whisper-large-v3=p150,p300x2 \
         --output-dir .
 
-Other flags: --repo, --ci-config, --output-dir, --keep-temp, --strict (turn the
-internal device-token check from a warning into a hard error), --reference-zip
-<prev.zip> (sanity-check the output layout against a previous release package).
+Other flags: --repo, --ci-config, --output-dir, --keep-temp, and --strict
+(turn the internal device-token check from a warning into a hard error).
 """
 
 from __future__ import annotations
@@ -84,14 +83,21 @@ import time
 import zipfile
 from pathlib import Path
 
-# Make the repo root importable so we can reuse the canonical DeviceTypes enum
-# (scripts/release/ -> repo root is three parents up).
-from _bootstrap import REPO_ROOT  # noqa: E402  (sets sys.path for imports below)
-from workflows.workflow_types import DeviceTypes  # noqa: E402
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.release.model_spec_resolver import (  # noqa: E402
+    collect_release_combos,
+    load_dev_model_spec_sources,
+    resolve_release_combos,
+)
+from scripts.release.release_scope import extract_bundle_identity  # noqa: E402
+from utils.model_naming import model_name_variants, slugify_model_id  # noqa: E402
 
 ARTIFACT_PREFIX = "workflow_logs_release_"
 DEFAULT_REPO = "tenstorrent/tt-shield"
 DEFAULT_CI_CONFIG = REPO_ROOT / ".github" / "workflows" / "models-ci-config.json"
+DEFAULT_DEV_DIR = REPO_ROOT / "workflows" / "model_specs" / "dev"
 
 # ---------------------------------------------------------------------------
 # Defaults — override any of them on the command line.
@@ -100,42 +106,45 @@ DEFAULT_VERSION = "v0.15.0"
 DEFAULT_RUN_ID = "26592936143"
 
 
-# ---------------------------------------------------------------------------
-# release scope from models-ci-config.json
-# ---------------------------------------------------------------------------
-def iter_implementations(model_entry: dict):
-    """Yield each implementation dict for a CI-config model entry.
-
-    Handles both the flat shape ({inference_engine, ci}) and the
-    implementations:[...] array shape (mirrors promote_dev_spec_to_prod.py).
-    """
-    if "implementations" in model_entry:
-        yield from model_entry["implementations"]
-    else:
-        yield model_entry
-
-
-def collect_release_models(ci_config: dict) -> dict[str, list[str]]:
-    """Build {model: [device, ...]} from the entries marked ``release`` in
-    models-ci-config.json.
-
-    Device tokens are the lowercased canonical device names (``p150``,
-    ``p300x2``, ``galaxy``) — the same tokens run.py, the tt-shield release job
-    names, and the release-package inner-zip names use. Devices are aggregated
-    across a model's implementations and de-duplicated, preserving config order.
-    """
-    models: dict[str, list[str]] = {}
-    for model_name, entry in ci_config.get("models", {}).items():
-        for impl in iter_implementations(entry):
-            release = impl.get("ci", {}).get("release")
-            if not release:
-                continue
-            for device in release.get("devices", []):
-                token = DeviceTypes.from_string(device).name.lower()
-                bucket = models.setdefault(model_name, [])
-                if token not in bucket:
-                    bucket.append(token)
-    return models
+def resolve_configured_scope(ci_config: dict, dev_dir: Path):
+    combos = collect_release_combos(ci_config)
+    resolved = resolve_release_combos(
+        combos,
+        load_dev_model_spec_sources(dev_dir),
+    )
+    expected = {}
+    models = {}
+    identity_selectors = {}
+    archive_owners = {}
+    for item in resolved:
+        model = item.identity[0]
+        device = item.combo.device.name.lower()
+        key = (model, device)
+        archive_key = (slugify_model_id(model), device)
+        prior_selector = identity_selectors.get(item.identity)
+        if prior_selector is not None:
+            raise ValueError(
+                f"Configured selectors {prior_selector!r} and {item.combo!r} "
+                f"resolve to duplicate artifact identity {item.identity!r}"
+            )
+        identity_selectors[item.identity] = item.combo
+        archive_owner = archive_owners.get(archive_key)
+        if archive_owner is not None and archive_owner != item.identity:
+            raise ValueError(
+                f"Release identities {archive_owner!r} and {item.identity!r} "
+                f"collide on artifact filename token {archive_key!r}"
+            )
+        archive_owners[archive_key] = item.identity
+        if key in expected and expected[key] != item.identity:
+            raise ValueError(
+                f"Artifact names cannot distinguish exact identities "
+                f"{expected[key]!r} and {item.identity!r}"
+            )
+        expected[key] = item.identity
+        models.setdefault(model, [])
+        if device not in models[model]:
+            models[model].append(device)
+    return models, expected
 
 
 # ---------------------------------------------------------------------------
@@ -182,21 +191,34 @@ def runner_of(artifact_name: str, model: str) -> str:
     exactly, so models that share a prefix (foo vs foo-turbo) are unambiguous
     because of the underscore boundary after the model name.
     """
-    rest = artifact_name[len(ARTIFACT_PREFIX) + len(model) + 1 :]  # "<runner>_<suffix>"
+    token = artifact_model_token(artifact_name, model)
+    if token is None:
+        raise ValueError(f"Artifact {artifact_name!r} does not match model {model!r}")
+    rest = artifact_name[len(ARTIFACT_PREFIX) + len(token) + 1 :]
     return rest.rsplit("_", 1)[0]
+
+
+def artifact_model_token(artifact_name: str, model: str) -> str | None:
+    matches = [
+        token
+        for token in model_name_variants(model)
+        if artifact_name.startswith(f"{ARTIFACT_PREFIX}{token}_")
+    ]
+    return max(matches, key=len) if matches else None
 
 
 def device_from_jobs(jobs: list[dict], model: str, runner: str) -> str | None:
     """Find the device a (model, runner) pair ran on, from the job name
     pattern ``run-release-<model>-<runner>-<device>``."""
-    marker = f"run-release-{model}-{runner}-"
     for job in jobs:
-        leaf = job.get("name", "").split("/")[-1].strip()
-        idx = leaf.find(marker)
-        if idx != -1:
-            tail = leaf[idx + len(marker) :].strip()
-            if tail:
-                return tail.split()[0]  # device token has no spaces
+        name = job.get("name", "").strip()
+        for token in model_name_variants(model):
+            marker = f"run-release-{token}-{runner}-"
+            idx = name.find(marker)
+            if idx != -1:
+                tail = name[idx + len(marker) :].strip()
+                if tail:
+                    return tail.split()[0]
     return None
 
 
@@ -205,6 +227,25 @@ def token_in_names(names: list[str], device: str) -> bool:
     ``p150`` does NOT match inside the runner label ``p150b``)."""
     pat = re.compile(r"(?<![0-9A-Za-z])" + re.escape(device) + r"(?![0-9A-Za-z])")
     return any(pat.search(n) for n in names)
+
+
+def validate_bundle_identity(bundle: Path, expected_identity):
+    actual_identity = extract_bundle_identity(bundle)
+    if actual_identity != expected_identity:
+        raise ValueError(
+            f"Runtime identity {actual_identity!r} does not match configured "
+            f"{expected_identity!r}"
+        )
+    return actual_identity
+
+
+def validate_staged_identity_set(expected, validated) -> None:
+    if validated != expected:
+        raise ValueError(
+            "Staged runtime identities do not match configured scope: "
+            f"missing={sorted(expected - validated)!r}, "
+            f"extra={sorted(validated - expected)!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -252,10 +293,14 @@ def resolve_model(
     repo: str,
     tmp: Path,
     cache: dict[int, Path],
+    expected_identities: dict[tuple[str, str], tuple] | None = None,
 ) -> dict[str, dict]:
     """Return {device: artifact} for the requested devices of one model."""
+    expected_identities = expected_identities or {}
     candidates = [
-        a for a in artifacts if a["name"].startswith(f"{ARTIFACT_PREFIX}{model}_")
+        artifact
+        for artifact in artifacts
+        if artifact_model_token(artifact["name"], model) is not None
     ]
     if not candidates:
         sys.exit(
@@ -264,12 +309,12 @@ def resolve_model(
         )
 
     # Primary: map each candidate's runner -> device via the run's job names.
-    by_device: dict[str, dict] = {}
+    by_device: dict[str, list[dict]] = {}
     for a in candidates:
         runner = runner_of(a["name"], model)
         dev = device_from_jobs(jobs, model, runner)
-        if dev and dev not in by_device:
-            by_device[dev] = a
+        if dev:
+            by_device.setdefault(dev, []).append(a)
 
     # Fallback: for any still-missing requested device, classify candidates by
     # the device token embedded in their own file names (ground truth).
@@ -280,7 +325,7 @@ def resolve_model(
                 names = zf.namelist()
             for d in devices:
                 if d not in by_device and token_in_names(names, d):
-                    by_device[d] = a
+                    by_device.setdefault(d, []).append(a)
 
     chosen: dict[str, dict] = {}
     for d in devices:
@@ -292,7 +337,30 @@ def resolve_model(
                 f"       Devices resolved for this model: {found}.\n"
                 f"       Candidate runner labels seen: {runners}."
             )
-        chosen[d] = by_device[d]
+        device_candidates = by_device[d]
+        expected_identity = expected_identities.get((model, d))
+        if expected_identity is None:
+            chosen[d] = device_candidates[0]
+            continue
+
+        matching = []
+        rejected = []
+        for artifact in device_candidates:
+            path = download_artifact(repo, artifact, tmp, cache)
+            try:
+                validate_bundle_identity(path, expected_identity)
+            except ValueError as exc:
+                rejected.append(f"{artifact['name']!r}: {exc}")
+            else:
+                matching.append(artifact)
+        if len(matching) != 1:
+            details = "; ".join(rejected) or "none"
+            sys.exit(
+                f"ERROR: expected one artifact for exact identity "
+                f"{expected_identity!r}, found {len(matching)}. "
+                f"Rejected candidates: {details}"
+            )
+        chosen[d] = matching[0]
     return chosen
 
 
@@ -321,36 +389,6 @@ def package(version: str, staged: dict[str, Path], out_dir: Path) -> Path:
             zf.writestr(info, src.read_bytes())
 
     return out_path
-
-
-def validate_structure(zip_path: Path, reference: Path | None) -> None:
-    """Assert the produced package has the expected shape; optionally diff the
-    inner-zip naming pattern against a previous release package."""
-    with zipfile.ZipFile(zip_path) as zf:
-        infos = zf.infolist()
-    top_dirs = {i.filename.split("/")[0] for i in infos}
-    if len(top_dirs) != 1:
-        sys.exit(
-            f"ERROR: expected exactly one top-level folder, found: {sorted(top_dirs)}"
-        )
-    inner = [i for i in infos if not i.filename.endswith("/")]
-    for i in inner:
-        if not i.filename.endswith(".zip"):
-            sys.exit(f"ERROR: unexpected non-zip entry in package: {i.filename}")
-        if i.compress_type != zipfile.ZIP_STORED:
-            sys.exit(f"ERROR: entry not stored uncompressed: {i.filename}")
-
-    if reference and reference.exists():
-        pat = re.compile(r"^[^/]+/workflow_logs_release_.+\.zip$")
-        with zipfile.ZipFile(reference) as zf:
-            ref_inner = [n for n in zf.namelist() if not n.endswith("/")]
-        ours_ok = all(pat.match(i.filename) for i in inner)
-        ref_ok = all(pat.match(n) for n in ref_inner)
-        status = "matches" if (ours_ok and ref_ok) else "DIFFERS FROM"
-        print(
-            f"  Layout vs reference '{reference.name}': inner-zip naming {status} "
-            f"the 'workflow_logs_release_<model>_<device>.zip' pattern."
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -392,6 +430,11 @@ def main() -> None:
         help="CI config JSON providing the default release model list "
         f"(default: {DEFAULT_CI_CONFIG}). Ignored when --model is given.",
     )
+    ap.add_argument(
+        "--dev-dir",
+        default=str(DEFAULT_DEV_DIR),
+        help="Dev catalog used to resolve exact config identities",
+    )
     ap.add_argument("--run-id", default=DEFAULT_RUN_ID, help="Actions run ID")
     ap.add_argument(
         "--version", default=DEFAULT_VERSION, help="Release version, e.g. v0.15.0"
@@ -412,11 +455,6 @@ def main() -> None:
         help="Where to write the final zip. Accepts absolute path, relative path, or '.' for cwd (default: cwd)",
     )
     ap.add_argument(
-        "--reference-zip",
-        default=None,
-        help="Optional previous release zip to sanity-check layout against",
-    )
-    ap.add_argument(
         "--keep-temp",
         action="store_true",
         help="Keep the temp download dir for inspection",
@@ -430,13 +468,25 @@ def main() -> None:
 
     if args.model:
         models = parse_model_specs(args.model)
+        expected_identities = {}
+        print(
+            "WARNING: manual --model scope does not perform final exact-identity "
+            "verification.",
+            file=sys.stderr,
+        )
     else:
         ci_config_path = Path(args.ci_config).expanduser()
         try:
             ci_config = json.loads(ci_config_path.read_text())
         except FileNotFoundError:
             sys.exit(f"ERROR: CI config not found: {ci_config_path}")
-        models = collect_release_models(ci_config)
+        try:
+            models, expected_identities = resolve_configured_scope(
+                ci_config,
+                Path(args.dev_dir).expanduser(),
+            )
+        except ValueError as exc:
+            sys.exit(f"ERROR: {exc}")
         if not models:
             sys.exit(
                 f"ERROR: no models are marked 'release' in {ci_config_path}.\n"
@@ -445,9 +495,6 @@ def main() -> None:
 
     out_dir = Path(args.output_dir).expanduser().resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
-    reference = (
-        Path(args.reference_zip).expanduser().resolve() if args.reference_zip else None
-    )
 
     print(f"Repo:    {args.repo}")
     print(f"Run:     {args.run_id}")
@@ -465,15 +512,35 @@ def main() -> None:
     tmp_dir = Path(tempfile.mkdtemp(prefix="release_artifacts_"))
     cache: dict[int, Path] = {}
     staged: dict[str, Path] = {}  # inner-zip filename -> staged path
+    validated_identities = set()
 
     try:
         for model, devices in models.items():
             chosen = resolve_model(
-                model, devices, artifacts, jobs, args.repo, tmp_dir, cache
+                model,
+                devices,
+                artifacts,
+                jobs,
+                args.repo,
+                tmp_dir,
+                cache,
+                expected_identities,
             )
             for device in devices:
                 artifact = chosen[device]
                 src = download_artifact(args.repo, artifact, tmp_dir, cache)
+
+                expected_identity = expected_identities.get((model, device))
+                if expected_identity is not None:
+                    try:
+                        validated_identities.add(
+                            validate_bundle_identity(src, expected_identity)
+                        )
+                    except ValueError as exc:
+                        sys.exit(
+                            f"ERROR: bundle '{artifact['name']}' has invalid "
+                            f"runtime-spec evidence: {exc}"
+                        )
 
                 # ground-truth check: the device must appear as a token inside the bundle
                 with zipfile.ZipFile(src) as zf:
@@ -488,7 +555,7 @@ def main() -> None:
                         sys.exit(f"ERROR: {msg}")
                     print(f"  WARNING: {msg}")
 
-                inner_name = f"{ARTIFACT_PREFIX}{model}_{device}.zip"
+                inner_name = f"{ARTIFACT_PREFIX}{slugify_model_id(model)}_{device}.zip"
                 staged_path = tmp_dir / inner_name
                 staged_path.write_bytes(src.read_bytes())
                 staged[inner_name] = staged_path
@@ -497,9 +564,18 @@ def main() -> None:
                     f"({artifact.get('size_in_bytes', '?')} bytes)"
                 )
 
+        expected_identity_set = set(expected_identities.values())
+        if expected_identity_set:
+            try:
+                validate_staged_identity_set(
+                    expected_identity_set,
+                    validated_identities,
+                )
+            except ValueError as exc:
+                sys.exit(f"ERROR: {exc}")
+
         print(f"\nPackaging {len(staged)} bundles ...")
         out_path = package(args.version, staged, out_dir)
-        validate_structure(out_path, reference)
         print(f"\nDone: {out_path}  ({out_path.stat().st_size} bytes)")
     finally:
         if args.keep_temp:

--- a/scripts/release/build_release_artifacts.py
+++ b/scripts/release/build_release_artifacts.py
@@ -107,27 +107,19 @@ DEFAULT_RUN_ID = "26592936143"
 
 
 def resolve_configured_scope(ci_config: dict, dev_dir: Path):
-    combos = collect_release_combos(ci_config)
+    # resolve_release_combos() rejects two selectors resolving to one identity.
     resolved = resolve_release_combos(
-        combos,
+        collect_release_combos(ci_config),
         load_dev_model_spec_sources(dev_dir),
     )
     expected = {}
     models = {}
-    identity_selectors = {}
     archive_owners = {}
     for item in resolved:
         model = item.identity[0]
         device = item.combo.device.name.lower()
         key = (model, device)
         archive_key = (slugify_model_id(model), device)
-        prior_selector = identity_selectors.get(item.identity)
-        if prior_selector is not None:
-            raise ValueError(
-                f"Configured selectors {prior_selector!r} and {item.combo!r} "
-                f"resolve to duplicate artifact identity {item.identity!r}"
-            )
-        identity_selectors[item.identity] = item.combo
         archive_owner = archive_owners.get(archive_key)
         if archive_owner is not None and archive_owner != item.identity:
             raise ValueError(

--- a/scripts/release/create_post_release_pr.py
+++ b/scripts/release/create_post_release_pr.py
@@ -269,8 +269,6 @@ def build_rows(scope, current_prod, base_prod, jobs, tt_shield_repo, run_id, ver
                 "ci_url": job_urls.get(identity),
             }
         )
-    if {row["identity"] for row in rows} != set(identities):
-        raise ValueError("Release-note row identities do not match resolved scope")
     return rows
 
 

--- a/scripts/release/create_post_release_pr.py
+++ b/scripts/release/create_post_release_pr.py
@@ -102,17 +102,26 @@ def model_name_from_weight(weight: str) -> str:
 # release scope (exact leaves, shared with promote_dev_spec_to_prod.py)
 # ---------------------------------------------------------------------------
 def resolve_release_scope(ci_config: dict, dev_dir: Path):
-    combos = collect_release_combos(ci_config)
-    sources = load_dev_model_spec_sources(dev_dir)
-    resolved = resolve_release_combos(combos, sources)
-    seen = {}
+    # resolve_release_combos() rejects two selectors resolving to one identity.
+    resolved = resolve_release_combos(
+        collect_release_combos(ci_config),
+        load_dev_model_spec_sources(dev_dir),
+    )
+    # A CI job name carries only repository and device, so two identities that
+    # share that pair cannot be told apart when a row is linked to its job.
+    # Check the whole scope here rather than while matching jobs: that path is
+    # skipped whenever the GitHub API returns nothing, which would make an
+    # ambiguous release scope pass or fail depending on the network.
+    owner_by_repo_device = {}
     for item in resolved:
-        if item.identity in seen:
+        repo_device = item.identity[:2]
+        owner = owner_by_repo_device.get(repo_device)
+        if owner is not None:
             raise ValueError(
-                f"Configured selectors {seen[item.identity]!r} and {item.combo!r} "
-                f"resolve to duplicate identity {item.identity!r}"
+                f"CI job names cannot distinguish release identities "
+                f"{[owner, item.identity]!r}"
             )
-        seen[item.identity] = item.combo
+        owner_by_repo_device[repo_device] = item.identity
     return tuple(resolved)
 
 
@@ -186,15 +195,6 @@ def fetch_run_jobs(repo: str, run_id: str, token: str) -> list[dict] | None:
 def _matching_ci_jobs(jobs, *, identity, scope_identities) -> list[dict]:
     if not jobs:
         return []
-    same_model_device = [
-        candidate
-        for candidate in scope_identities
-        if candidate[0] == identity[0] and candidate[1] == identity[1]
-    ]
-    if len(same_model_device) > 1:
-        raise ValueError(
-            f"CI job names cannot distinguish release identities {same_model_device!r}"
-        )
     other_repos = [candidate[0] for candidate in scope_identities]
     return [
         job

--- a/scripts/release/create_post_release_pr.py
+++ b/scripts/release/create_post_release_pr.py
@@ -15,14 +15,16 @@ The body has four sections:
   # Model Spec Release Updates    -> AUTO-GENERATED table (the tricky part)
   # Release Artifacts Summary     -> auto-listed promoted images + Total (from --promoted-images)
 
-The "Model Spec Release Updates" table has one row per (model, device) release
-combo taken from ``.github/workflows/models-ci-config.json`` (the ``ci.release``
-entries), matched to its ``workflows/model_specs/prod/*.yaml`` block. Columns:
+The "Model Spec Release Updates" table has one row per released runtime leaf --
+the (hf_model_repo, device, engine, impl_id) tuple that a release actually
+publishes. Each ``ci.release`` entry in ``.github/workflows/models-ci-config.json``
+is resolved against the dev catalogue to exactly one such leaf, and that leaf is
+then looked up in ``workflows/model_specs/prod/*.yaml`` by identity. Columns:
 
-  Impl                   <- prod block ``impl:``
-  Model Arch             <- the models-ci-config.json model key
-  Weights                <- prod block ``weights:`` (all, <br>-joined)
-  Devices                <- the release device from models-ci-config.json
+  Impl                   <- impl_id of the released leaf
+  Model Arch             <- weight basename (the models-ci-config.json model key)
+  Weights                <- the released weight
+  Devices                <- the released device
   TT-Metal Commit Change <- old->new (old = base branch's prod; new = this branch)
                             "`old` -> `new`" if changed, else "`new`"
   Status Change          <- "No change [STATUS]" if unchanged, else the new STATUS
@@ -31,6 +33,10 @@ entries), matched to its ``workflows/model_specs/prod/*.yaml`` block. Columns:
                             the tt-shield run's ``run-release-<model>-...-<device>`` job
 
 Any value that cannot be computed is rendered as ``UNKNOWN``.
+
+Resolution is by exact identity throughout: a selector that matches no leaf, or
+more than one, aborts instead of silently reporting whichever prod block happened
+to come first.
 
 """
 
@@ -51,15 +57,26 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
-from workflows.workflow_types import DeviceTypes, InferenceEngine  # noqa: E402
+from scripts.release.model_spec_resolver import (  # noqa: E402
+    collect_release_combos,
+    load_dev_model_spec_sources,
+    resolve_release_combos,
+)
+from scripts.release.release_scope import (  # noqa: E402
+    UNKNOWN,
+    expand_raw_prod_blocks,
+    load_prod_leaves,
+)
+from utils.model_naming import ci_job_matches_device  # noqa: E402
+from workflows.model_spec import MODEL_SPEC_CATALOG_FILES  # noqa: E402
 
 DEFAULT_CI_CONFIG = REPO_ROOT / ".github" / "workflows" / "models-ci-config.json"
+DEFAULT_DEV_DIR = REPO_ROOT / "workflows" / "model_specs" / "dev"
 DEFAULT_PROD_DIR = REPO_ROOT / "workflows" / "model_specs" / "prod"
 DEFAULT_VERSION_FILE = REPO_ROOT / "VERSION"
 DEFAULT_REPO = "tenstorrent/tt-inference-server"
 DEFAULT_TT_SHIELD_REPO = "tenstorrent/tt-shield"
 TOKEN_ENV_VARS = ("TMP_VCANKOVIC_SHIELD_CRANE_PAT", "GH_PAT", "GITHUB_TOKEN")
-UNKNOWN = "UNKNOWN"
 
 STATIC_SW_VERSIONS = (
     "# SW versions recommended for Wormhole Galaxy:\n\n"
@@ -77,133 +94,53 @@ def _safe_repo_path(p) -> Path:
     return resolved
 
 
-# ---------------------------------------------------------------------------
-# release scope (mirrors promote_dev_spec_to_prod.py)
-# ---------------------------------------------------------------------------
-def iter_implementations(model_entry: dict):
-    """Yield each implementation dict (flat or implementations:[...] shape)."""
-    if "implementations" in model_entry:
-        yield from model_entry["implementations"]
-    else:
-        yield model_entry
-
-
 def model_name_from_weight(weight: str) -> str:
     return Path(weight).name
 
 
-def collect_release_combos(
-    ci_config: dict,
-) -> list[tuple[str, InferenceEngine, DeviceTypes]]:
-    """Ordered, de-duplicated list of (model_name, engine, device) marked release."""
-    combos: list[tuple[str, InferenceEngine, DeviceTypes]] = []
-    seen: set = set()
-    for model_name, entry in ci_config.get("models", {}).items():
-        for impl in iter_implementations(entry):
-            release = impl.get("ci", {}).get("release")
-            if not release:
-                continue
-            try:
-                engine = InferenceEngine.from_string(impl["inference_engine"])
-            except (ValueError, KeyError):
-                engine = None
-            for device in release.get("devices", []):
-                try:
-                    dev = DeviceTypes.from_string(device)
-                except ValueError:
-                    continue
-                key = (model_name, engine, dev)
-                if key not in seen:
-                    seen.add(key)
-                    combos.append((model_name, engine, dev))
-    return combos
+# ---------------------------------------------------------------------------
+# release scope (exact leaves, shared with promote_dev_spec_to_prod.py)
+# ---------------------------------------------------------------------------
+def resolve_release_scope(ci_config: dict, dev_dir: Path):
+    combos = collect_release_combos(ci_config)
+    sources = load_dev_model_spec_sources(dev_dir)
+    resolved = resolve_release_combos(combos, sources)
+    seen = {}
+    for item in resolved:
+        if item.identity in seen:
+            raise ValueError(
+                f"Configured selectors {seen[item.identity]!r} and {item.combo!r} "
+                f"resolve to duplicate identity {item.identity!r}"
+            )
+        seen[item.identity] = item.combo
+    return tuple(resolved)
 
 
 # ---------------------------------------------------------------------------
 # prod catalogue parsing
 # ---------------------------------------------------------------------------
-def _parse_catalogue(text: str) -> list[dict]:
-    data = yaml.safe_load(text)
-    if isinstance(data, dict):
-        data = data.get("templates") or next(
-            (v for v in data.values() if isinstance(v, list)), []
-        )
-    return [b for b in (data or []) if isinstance(b, dict)]
+def load_prod_blocks_from_ref(ref: str) -> list[dict]:
+    """Raw prod blocks from a git ref.
 
-
-def load_prod_blocks_from_dir(prod_dir: Path) -> list[dict]:
-    prod_dir = _safe_repo_path(prod_dir)
+    The base ref may predate the leaf-granular prod catalogue, so the blocks are
+    returned unexpanded and widened by expand_raw_prod_blocks() instead.
+    """
     blocks: list[dict] = []
-    for f in sorted(prod_dir.glob("*.yaml")):
-        blocks += _parse_catalogue(f.read_text())
-    return blocks
-
-
-def load_prod_blocks_from_ref(ref: str, prod_filenames: list[str]) -> list[dict]:
-    blocks: list[dict] = []
-    for name in prod_filenames:
+    for filename in MODEL_SPEC_CATALOG_FILES:
         try:
             text = subprocess.run(
-                ["git", "show", f"{ref}:workflows/model_specs/prod/{name}"],
+                ["git", "show", f"{ref}:workflows/model_specs/prod/{filename}"],
                 capture_output=True,
                 text=True,
                 check=True,
             ).stdout
-        except subprocess.CalledProcessError:
-            continue  # file absent on that ref
-        blocks += _parse_catalogue(text)
+        except subprocess.CalledProcessError as exc:
+            raise ValueError(
+                f"Could not read prod catalog {filename!r} from base ref {ref!r}"
+            ) from exc
+        document = yaml.safe_load(text) or {}
+        blocks.extend(document.get("templates", []))
     return blocks
-
-
-def _block_engine(block: dict):
-    try:
-        return InferenceEngine.from_string(block.get("inference_engine", ""))
-    except (ValueError, KeyError):
-        return None
-
-
-def _block_devices(block: dict) -> set:
-    out = set()
-    for d in block.get("device_model_specs", []) or []:
-        try:
-            out.add(DeviceTypes.from_string(d.get("device", "")))
-        except ValueError:
-            pass
-    return out
-
-
-def _block_models(block: dict) -> set:
-    return {model_name_from_weight(w) for w in block.get("weights", []) or []}
-
-
-def find_block(
-    blocks, model_name, engine, device, prefer_version=None, prefer_impl=None
-) -> dict | None:
-    """A prod block that provides (model_name, engine) on `device`.
-
-    Matches by device MEMBERSHIP (not the exact device-set). When several blocks
-    match (a stale block from a prior release plus the just-promoted one, or two
-    impls), prefer (1) the block at `prefer_version`, then (2) `prefer_impl`,
-    else the first match — so the table reports the release block, not a stale one.
-    """
-    matches = [
-        b
-        for b in blocks
-        if model_name in _block_models(b)
-        and _block_engine(b) == engine
-        and device in _block_devices(b)
-    ]
-    if not matches:
-        return None
-    if prefer_version is not None:
-        for b in matches:
-            if str(b.get("version")) == str(prefer_version):
-                return b
-    if prefer_impl is not None:
-        for b in matches:
-            if b.get("impl") == prefer_impl:
-                return b
-    return matches[0]
 
 
 # ---------------------------------------------------------------------------
@@ -212,24 +149,21 @@ def find_block(
 def resolve_token(explicit: str | None) -> str | None:
     if explicit:
         return explicit
-    for name in TOKEN_ENV_VARS:
-        val = os.environ.get(name)
-        if val:
-            return val
-    return None
+    return next(
+        (os.environ[name] for name in TOKEN_ENV_VARS if os.environ.get(name)),
+        None,
+    )
 
 
 def fetch_run_jobs(repo: str, run_id: str, token: str) -> list[dict] | None:
     """All jobs of a workflow run, or None if unreachable (no access/expired)."""
-    owner_repo = repo
     jobs: list[dict] = []
-    page = 1
-    while True:
+    for page in range(1, 16):
         url = (
-            f"https://api.github.com/repos/{owner_repo}/actions/runs/{run_id}"
+            f"https://api.github.com/repos/{repo}/actions/runs/{run_id}"
             f"/jobs?per_page=100&page={page}"
         )
-        req = urllib.request.Request(
+        request = urllib.request.Request(
             url,
             headers={
                 "Authorization": f"Bearer {token}",
@@ -239,79 +173,104 @@ def fetch_run_jobs(repo: str, run_id: str, token: str) -> list[dict] | None:
             },
         )
         try:
-            with urllib.request.urlopen(req, timeout=60) as resp:
-                data = json.loads(resp.read())
+            with urllib.request.urlopen(request, timeout=60) as response:
+                batch = json.loads(response.read()).get("jobs", [])
         except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError):
             return None
-        batch = data.get("jobs", [])
-        jobs += batch
-        if len(batch) < 100 or page >= 15:
+        jobs.extend(batch)
+        if len(batch) < 100:
             break
-        page += 1
     return jobs
 
 
-def ci_job_url(
-    jobs, repo: str, run_id: str, model_name: str, device: DeviceTypes
-) -> str | None:
-    """URL of the run-release-<model>-<runner>-<device> job for this combo."""
+def _matching_ci_jobs(jobs, *, identity, scope_identities) -> list[dict]:
     if not jobs:
-        return None
-    token = device.name.lower()  # device token used in tt-shield job names
-    prefix = f"run-release-{model_name}-"
-    for job in jobs:
-        leaf = job.get("name", "").split("/")[-1].strip()
-        if leaf.startswith(prefix) and leaf.endswith(f"-{token}"):
-            return f"https://github.com/{repo}/actions/runs/{run_id}/job/{job['id']}"
-    return None
+        return []
+    same_model_device = [
+        candidate
+        for candidate in scope_identities
+        if candidate[0] == identity[0] and candidate[1] == identity[1]
+    ]
+    if len(same_model_device) > 1:
+        raise ValueError(
+            f"CI job names cannot distinguish release identities {same_model_device!r}"
+        )
+    other_repos = [candidate[0] for candidate in scope_identities]
+    return [
+        job
+        for job in jobs
+        if ci_job_matches_device(
+            job.get("name", ""),
+            "release",
+            identity[0],
+            identity[1],
+            other_repos,
+        )
+    ]
 
 
 # ---------------------------------------------------------------------------
 # row model + rendering
 # ---------------------------------------------------------------------------
-def build_rows(new_blocks, old_blocks, combos, jobs, tt_shield_repo, run_id, version):
+def build_rows(scope, current_prod, base_prod, jobs, tt_shield_repo, run_id, version):
+    identities = tuple(item.identity for item in scope)
+    job_urls: dict = {}
+    job_owners: dict = {}
+    if jobs and run_id:
+        for identity in identities:
+            matches = _matching_ci_jobs(
+                jobs, identity=identity, scope_identities=identities
+            )
+            if len(matches) > 1:
+                raise ValueError(
+                    f"Multiple CI jobs match release identity {identity!r}"
+                )
+            if not matches:
+                job_urls[identity] = None
+                continue
+            job_id = matches[0]["id"]
+            owner = job_owners.get(job_id)
+            if owner is not None and owner != identity:
+                raise ValueError(
+                    f"CI job {job_id!r} ambiguously matches {owner!r} and {identity!r}"
+                )
+            job_owners[job_id] = identity
+            job_urls[identity] = (
+                f"https://github.com/{tt_shield_repo}/actions/runs/"
+                f"{run_id}/job/{job_id}"
+            )
+
     rows = []
-    seen: set = set()
-    for model_name, engine, device in combos:
-        # NEW = the just-promoted block (prefer this release's version) so a stale
-        # prior-release block on the same device can't shadow it. OLD = the base
-        # block for the SAME impl, so old->new is apples-to-apples.
-        new_b = find_block(
-            new_blocks, model_name, engine, device, prefer_version=version
-        )
-        old_b = find_block(
-            old_blocks,
-            model_name,
-            engine,
-            device,
-            prefer_version=version,
-            prefer_impl=(new_b or {}).get("impl"),
-        )
-
-        # De-duplicate: one row per (prod block weights+engine, device). A block
-        # bundling several weights (e.g. whisper) yields a single row.
-        ident_block = new_b or old_b
-        weights = tuple((ident_block or {}).get("weights", []) or [])
-        dedup_key = (weights, engine, device)
-        if dedup_key in seen:
-            continue
-        seen.add(dedup_key)
-
+    for item in scope:
+        identity = item.identity
+        # The release publishes this exact leaf, so prod must carry it at the
+        # release version. A miss here means the promotion step did not run, ran
+        # against a different scope, or wrote a different pin.
+        current = current_prod.get(identity)
+        if current is None:
+            raise ValueError(f"Current prod is missing release identity {identity!r}")
+        if current.pin.version != version:
+            raise ValueError(
+                f"Prod identity {identity!r} has version {current.pin.version!r}, "
+                f"expected {version!r}"
+            )
+        before = base_prod.get(identity)
         rows.append(
             {
-                "impl": (new_b or old_b or {}).get("impl"),
-                "model_arch": model_name,
-                "weights": list(weights),
-                "device": device,
-                "tt_before": (old_b or {}).get("tt_metal_commit"),
-                "tt_after": (new_b or {}).get("tt_metal_commit"),
-                "status_before": (old_b or {}).get("status"),
-                "status_after": (new_b or {}).get("status"),
-                "ci_url": ci_job_url(jobs, tt_shield_repo, run_id, model_name, device)
-                if (jobs and run_id)
-                else None,
+                "identity": identity,
+                "impl": identity[3],
+                "model_arch": model_name_from_weight(identity[0]),
+                "weights": [identity[0]],
+                "device": identity[1],
+                "tt_before": before.pin.tt_metal_commit if before else None,
+                "tt_after": current.pin.tt_metal_commit,
+                "status_before": before.status if before else None,
+                "status_after": current.status,
+                "ci_url": job_urls.get(identity),
             }
         )
+    if {row["identity"] for row in rows} != set(identities):
+        raise ValueError("Release-note row identities do not match resolved scope")
     return rows
 
 
@@ -353,7 +312,7 @@ def render_table(rows) -> str:
         impl = f"`{r['impl']}`" if r["impl"] else UNKNOWN
         arch = f"`{r['model_arch']}`" if r["model_arch"] else UNKNOWN
         weights = _weights_cell(r["weights"])
-        device = r["device"].name if r["device"] else UNKNOWN
+        device = r["device"] or UNKNOWN
         commit = _commit_cell(r["tt_before"], r["tt_after"])
         status = _status_cell(r["status_before"], r["status_after"])
         ci = f"[CI Link]({r['ci_url']})" if r["ci_url"] else UNKNOWN
@@ -469,6 +428,12 @@ def main() -> None:
     ap.add_argument("--tt-shield-repo", default=DEFAULT_TT_SHIELD_REPO)
     ap.add_argument("--ci-config", type=Path, default=DEFAULT_CI_CONFIG)
     ap.add_argument(
+        "--dev-dir",
+        type=Path,
+        default=DEFAULT_DEV_DIR,
+        help="dev catalogue the release selectors are resolved against",
+    )
+    ap.add_argument(
         "--prod-dir",
         type=Path,
         default=DEFAULT_PROD_DIR,
@@ -513,15 +478,6 @@ def main() -> None:
     head_branch = args.head_branch or current_branch()
     title = f"Post release v{version}"
 
-    ci_config = json.loads(args.ci_config.read_text())
-    combos = collect_release_combos(ci_config)
-
-    new_blocks = load_prod_blocks_from_dir(args.prod_dir)
-    prod_filenames = [
-        f.name for f in sorted(_safe_repo_path(args.prod_dir).glob("*.yaml"))
-    ]
-    old_blocks = load_prod_blocks_from_ref(args.base_ref, prod_filenames)
-
     # CI jobs (best-effort; UNKNOWN on any failure).
     jobs = None
     if args.tt_shield_run_id:
@@ -546,15 +502,23 @@ def main() -> None:
             file=sys.stderr,
         )
 
-    rows = build_rows(
-        new_blocks,
-        old_blocks,
-        combos,
-        jobs,
-        args.tt_shield_repo,
-        args.tt_shield_run_id,
-        version,
-    )
+    try:
+        ci_config = json.loads(args.ci_config.read_text())
+        scope = resolve_release_scope(ci_config, _safe_repo_path(args.dev_dir))
+        current_prod = load_prod_leaves(_safe_repo_path(args.prod_dir))
+        base_prod = expand_raw_prod_blocks(load_prod_blocks_from_ref(args.base_ref))
+        rows = build_rows(
+            scope,
+            current_prod,
+            base_prod,
+            jobs,
+            args.tt_shield_repo,
+            args.tt_shield_run_id,
+            version,
+        )
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        sys.exit(f"ERROR: {exc}")
+
     body = render_body(version, args.tt_shield_run_id, rows, promoted_images)
 
     print(f"Version:      {version}", file=sys.stderr)

--- a/scripts/release/create_post_release_pr.py
+++ b/scripts/release/create_post_release_pr.py
@@ -64,11 +64,10 @@ from scripts.release.model_spec_resolver import (  # noqa: E402
 )
 from scripts.release.release_scope import (  # noqa: E402
     UNKNOWN,
-    expand_raw_prod_blocks,
     load_prod_leaves,
+    load_prod_leaves_from_ref,
 )
 from utils.model_naming import ci_job_matches_device  # noqa: E402
-from workflows.model_spec import MODEL_SPEC_CATALOG_FILES  # noqa: E402
 
 DEFAULT_CI_CONFIG = REPO_ROOT / ".github" / "workflows" / "models-ci-config.json"
 DEFAULT_DEV_DIR = REPO_ROOT / "workflows" / "model_specs" / "dev"
@@ -123,33 +122,6 @@ def resolve_release_scope(ci_config: dict, dev_dir: Path):
             )
         owner_by_repo_device[repo_device] = item.identity
     return tuple(resolved)
-
-
-# ---------------------------------------------------------------------------
-# prod catalogue parsing
-# ---------------------------------------------------------------------------
-def load_prod_blocks_from_ref(ref: str) -> list[dict]:
-    """Raw prod blocks from a git ref.
-
-    The base ref may predate the leaf-granular prod catalogue, so the blocks are
-    returned unexpanded and widened by expand_raw_prod_blocks() instead.
-    """
-    blocks: list[dict] = []
-    for filename in MODEL_SPEC_CATALOG_FILES:
-        try:
-            text = subprocess.run(
-                ["git", "show", f"{ref}:workflows/model_specs/prod/{filename}"],
-                capture_output=True,
-                text=True,
-                check=True,
-            ).stdout
-        except subprocess.CalledProcessError as exc:
-            raise ValueError(
-                f"Could not read prod catalog {filename!r} from base ref {ref!r}"
-            ) from exc
-        document = yaml.safe_load(text) or {}
-        blocks.extend(document.get("templates", []))
-    return blocks
 
 
 # ---------------------------------------------------------------------------
@@ -504,7 +476,7 @@ def main() -> None:
         ci_config = json.loads(args.ci_config.read_text())
         scope = resolve_release_scope(ci_config, _safe_repo_path(args.dev_dir))
         current_prod = load_prod_leaves(_safe_repo_path(args.prod_dir))
-        base_prod = expand_raw_prod_blocks(load_prod_blocks_from_ref(args.base_ref))
+        base_prod = load_prod_leaves_from_ref(args.base_ref)
         rows = build_rows(
             scope,
             current_prod,

--- a/scripts/release/release_scope.py
+++ b/scripts/release/release_scope.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Exact release-scope evidence shared by release tooling."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+from scripts.release.model_spec_resolver import LeafIdentity
+from workflows.model_spec import (
+    MODEL_SPEC_CATALOG_FILES,
+    get_model_spec_map,
+    load_templates_from_yaml,
+    model_spec_leaf_identity,
+)
+from workflows.workflow_types import DeviceTypes, InferenceEngine
+
+
+NOTE_COLUMNS = (
+    "Impl ID",
+    "HF Repository",
+    "Device",
+    "Engine",
+    "Version",
+    "TT-Metal Commit",
+    "vLLM Commit",
+    "Status Change",
+    "CI Job Link",
+)
+UNKNOWN = "UNKNOWN"
+
+
+@dataclass(frozen=True)
+class ProdPin:
+    version: str
+    tt_metal_commit: str
+    vllm_commit: str | None
+    docker_image: str | None
+
+
+@dataclass(frozen=True)
+class ProdLeaf:
+    identity: LeafIdentity
+    pin: ProdPin
+    status: str
+
+
+def _required_string(value, field: str, identity: LeafIdentity) -> str:
+    if value is None or not str(value).strip():
+        raise ValueError(f"Prod leaf {identity!r} is missing {field}")
+    return str(value)
+
+
+def load_prod_leaves(prod_dir: Path, *, require_leaf_granular: bool = True):
+    """Load and index exact prod leaves from the runtime catalog file set."""
+    prod_dir = Path(prod_dir)
+    templates = []
+    for filename in MODEL_SPEC_CATALOG_FILES:
+        path = prod_dir / filename
+        try:
+            file_templates = load_templates_from_yaml(path)
+        except KeyError as exc:
+            raise ValueError(
+                f"Prod catalog {path} contains an invalid enum value: {exc}"
+            ) from exc
+        if require_leaf_granular:
+            for template in file_templates:
+                if len(template.weights) != 1 or len(template.device_model_specs) != 1:
+                    raise ValueError(
+                        f"Prod template in {path} is not leaf-granular: "
+                        f"weights={template.weights!r}, "
+                        f"devices={[item.device.name for item in template.device_model_specs]!r}"
+                    )
+        templates.extend(file_templates)
+
+    model_specs = get_model_spec_map(templates)
+    leaves = {}
+    for spec in model_specs.values():
+        identity = model_spec_leaf_identity(spec)
+        version = _required_string(spec.version, "version", identity)
+        tt_metal_commit = _required_string(
+            spec.tt_metal_commit, "tt_metal_commit", identity
+        )
+        vllm_commit = spec.vllm_commit
+        if identity[2] == InferenceEngine.VLLM.value:
+            vllm_commit = _required_string(vllm_commit, "vllm_commit", identity)
+        leaf = ProdLeaf(
+            identity=identity,
+            pin=ProdPin(
+                version=version,
+                tt_metal_commit=tt_metal_commit,
+                vllm_commit=str(vllm_commit) if vllm_commit else None,
+                docker_image=spec.docker_image,
+            ),
+            status=spec.status.name,
+        )
+        if identity in leaves:
+            raise ValueError(f"Duplicate prod identity {identity!r}")
+        leaves[identity] = leaf
+    return leaves
+
+
+def expand_raw_prod_blocks(blocks: Iterable[dict]):
+    """Expand coarse historical prod blocks for exact before-value lookup."""
+    leaves = {}
+    for block in blocks:
+        try:
+            engine = InferenceEngine.from_string(block["inference_engine"]).value
+            impl_id = str(block["impl"])
+            weights = block["weights"]
+            devices = block["device_model_specs"]
+        except (AttributeError, KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid prod block: {block!r}") from exc
+        for weight in weights:
+            for device_spec in devices:
+                device = DeviceTypes.from_string(device_spec["device"]).to_string()
+                identity = (str(weight), device, engine, impl_id)
+                if identity in leaves:
+                    raise ValueError(f"Duplicate historical prod identity {identity!r}")
+                version = block.get("version")
+                tt_metal_commit = block.get("tt_metal_commit")
+                vllm_commit = block.get("vllm_commit")
+                leaves[identity] = ProdLeaf(
+                    identity=identity,
+                    pin=ProdPin(
+                        version=str(version) if version is not None else "",
+                        tt_metal_commit=str(tt_metal_commit)
+                        if tt_metal_commit is not None
+                        else "",
+                        vllm_commit=str(vllm_commit)
+                        if vllm_commit is not None
+                        else None,
+                        docker_image=block.get("docker_image"),
+                    ),
+                    status=str(block.get("status") or "EXPERIMENTAL"),
+                )
+    return leaves
+
+
+def identity_from_model_spec_document(document: dict) -> LeafIdentity:
+    """Extract exact identity from modern or legacy runtime-spec JSON."""
+    if not isinstance(document, dict):
+        raise ValueError("Runtime model spec must be a JSON object")
+    if isinstance(document.get("runtime_model_spec"), dict):
+        document = document["runtime_model_spec"]
+    elif isinstance(document.get("model_spec"), dict):
+        document = document["model_spec"]
+
+    try:
+        hf_repo = document["hf_model_repo"]
+        raw_device = document.get("device_type")
+        if raw_device is None:
+            raw_device = document["device_model_spec"]["device"]
+        raw_engine = document["inference_engine"]
+        implementation = document["impl"]
+        impl_id = (
+            implementation["impl_id"] if isinstance(implementation, dict) else None
+        )
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            "Runtime model spec is missing exact identity fields "
+            "(hf_model_repo, device_type, inference_engine, impl.impl_id)"
+        ) from exc
+    raw_values = {
+        "hf_model_repo": hf_repo,
+        "device_type": raw_device,
+        "inference_engine": raw_engine,
+        "impl.impl_id": impl_id,
+    }
+    invalid = [
+        field
+        for field, value in raw_values.items()
+        if not isinstance(value, str) or not value.strip()
+    ]
+    if invalid:
+        raise ValueError(
+            f"Runtime model spec has invalid exact identity fields: {invalid!r}"
+        )
+    hf_repo = hf_repo.strip()
+    impl_id = impl_id.strip()
+    try:
+        device = DeviceTypes.from_string(raw_device.strip()).to_string()
+        engine = InferenceEngine.from_string(raw_engine.strip()).value
+    except (KeyError, ValueError) as exc:
+        raise ValueError("Runtime model spec has an invalid device or engine") from exc
+    return (hf_repo, device, engine, impl_id)
+
+
+def _is_runtime_spec_path(name: str) -> bool:
+    path = PurePosixPath(name)
+    return path.suffix.lower() == ".json" and any(
+        part in {"runtime_model_specs", "run_specs"} for part in path.parts
+    )
+
+
+def extract_bundle_identity(bundle: Path | bytes) -> LeafIdentity:
+    """Require one consistent exact identity across a workflow-log bundle."""
+    source = io.BytesIO(bundle) if isinstance(bundle, bytes) else Path(bundle)
+    identities = set()
+    candidate_count = 0
+    try:
+        with zipfile.ZipFile(source) as archive:
+            runtime_paths = set()
+            for info in archive.infolist():
+                name = info.filename
+                if not _is_runtime_spec_path(name):
+                    continue
+                if name in runtime_paths:
+                    raise ValueError(
+                        f"Workflow artifact contains duplicate runtime model spec "
+                        f"path {name!r}"
+                    )
+                runtime_paths.add(name)
+                candidate_count += 1
+                try:
+                    document = json.loads(archive.read(info))
+                except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                    raise ValueError(
+                        f"Invalid runtime model spec JSON {name!r}"
+                    ) from exc
+                identities.add(identity_from_model_spec_document(document))
+    except zipfile.BadZipFile as exc:
+        raise ValueError("Workflow artifact is not a valid ZIP") from exc
+
+    if candidate_count == 0:
+        raise ValueError("Workflow artifact contains no runtime model spec JSON")
+    if len(identities) != 1:
+        raise ValueError(
+            f"Workflow artifact contains conflicting runtime identities: "
+            f"{sorted(identities)!r}"
+        )
+    return next(iter(identities))

--- a/scripts/release/release_scope.py
+++ b/scripts/release/release_scope.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 
 import io
 import json
+import subprocess
+import tempfile
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Iterable
-
 from scripts.release.model_spec_resolver import LeafIdentity
 from workflows.model_spec import (
     MODEL_SPEC_CATALOG_FILES,
@@ -111,57 +111,44 @@ def load_prod_leaves(prod_dir: Path):
     return leaves
 
 
-def expand_raw_prod_blocks(blocks: Iterable[dict]):
-    """Expand coarse historical prod blocks for exact before-value lookup."""
-    leaves = {}
-    for block in blocks:
-        try:
-            engine = InferenceEngine.from_string(block["inference_engine"]).value
-            impl_id = str(block["impl"])
-            weights = block["weights"]
-            devices = block["device_model_specs"]
-        except (AttributeError, KeyError, TypeError, ValueError) as exc:
-            raise ValueError(f"Invalid prod block: {block!r}") from exc
-        for weight in weights:
-            for device_spec in devices:
-                device = DeviceTypes.from_string(device_spec["device"]).to_string()
-                identity = (str(weight), device, engine, impl_id)
-                if identity in leaves:
-                    raise ValueError(f"Duplicate historical prod identity {identity!r}")
-                version = block.get("version")
-                tt_metal_commit = block.get("tt_metal_commit")
-                vllm_commit = block.get("vllm_commit")
-                leaves[identity] = ProdLeaf(
-                    identity=identity,
-                    pin=ProdPin(
-                        version=str(version) if version is not None else "",
-                        tt_metal_commit=str(tt_metal_commit)
-                        if tt_metal_commit is not None
-                        else "",
-                        vllm_commit=str(vllm_commit)
-                        if vllm_commit is not None
-                        else None,
-                        docker_image=block.get("docker_image"),
-                    ),
-                    status=str(block.get("status") or "EXPERIMENTAL"),
-                )
-    return leaves
+def load_prod_leaves_from_ref(ref: str):
+    """Index the prod catalogue at a git ref by exact leaf identity.
+
+    The base side of a release comparison is read through the same loader as the
+    working tree, so both sides are validated identically and a change is only
+    ever reported between two leaves that exist. This requires the ref to carry
+    the leaf-granular catalogue; a coarse ref fails here rather than being
+    widened on the fly into leaves the catalogue never actually pinned.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        prod_dir = Path(temp_dir) / "prod"
+        prod_dir.mkdir()
+        for filename in MODEL_SPEC_CATALOG_FILES:
+            try:
+                text = subprocess.run(
+                    ["git", "show", f"{ref}:workflows/model_specs/prod/{filename}"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                ).stdout
+            except subprocess.CalledProcessError as exc:
+                raise ValueError(
+                    f"Could not read prod catalog {filename!r} from ref {ref!r}"
+                ) from exc
+            (prod_dir / filename).write_text(text)
+        return load_prod_leaves(prod_dir)
 
 
 def identity_from_model_spec_document(document: dict) -> LeafIdentity:
-    """Extract exact identity from modern or legacy runtime-spec JSON."""
+    """Extract exact identity from a runtime-spec JSON document."""
     if not isinstance(document, dict):
         raise ValueError("Runtime model spec must be a JSON object")
     if isinstance(document.get("runtime_model_spec"), dict):
         document = document["runtime_model_spec"]
-    elif isinstance(document.get("model_spec"), dict):
-        document = document["model_spec"]
 
     try:
         hf_repo = document["hf_model_repo"]
-        raw_device = document.get("device_type")
-        if raw_device is None:
-            raw_device = document["device_model_spec"]["device"]
+        raw_device = document["device_type"]
         raw_engine = document["inference_engine"]
         implementation = document["impl"]
         impl_id = (
@@ -200,7 +187,7 @@ def identity_from_model_spec_document(document: dict) -> LeafIdentity:
 def _is_runtime_spec_path(name: str) -> bool:
     path = PurePosixPath(name)
     return path.suffix.lower() == ".json" and any(
-        part in {"runtime_model_specs", "run_specs"} for part in path.parts
+        part == "runtime_model_specs" for part in path.parts
     )
 
 

--- a/scripts/release/release_scope.py
+++ b/scripts/release/release_scope.py
@@ -58,26 +58,30 @@ def _required_string(value, field: str, identity: LeafIdentity) -> str:
     return str(value)
 
 
-def load_prod_leaves(prod_dir: Path, *, require_leaf_granular: bool = True):
-    """Load and index exact prod leaves from the runtime catalog file set."""
+def load_prod_leaves(prod_dir: Path):
+    """Load and index exact prod leaves from the runtime catalog file set.
+
+    One weight and one device per prod entry is a permanent invariant of the
+    generated catalog, not an option: every release consumer indexes prod by
+    exact leaf identity and a coarse entry has no single one.
+    """
     prod_dir = Path(prod_dir)
     templates = []
     for filename in MODEL_SPEC_CATALOG_FILES:
         path = prod_dir / filename
         try:
-            file_templates = load_templates_from_yaml(path)
+            file_templates = load_templates_from_yaml(path, env="prod")
         except KeyError as exc:
             raise ValueError(
                 f"Prod catalog {path} contains an invalid enum value: {exc}"
             ) from exc
-        if require_leaf_granular:
-            for template in file_templates:
-                if len(template.weights) != 1 or len(template.device_model_specs) != 1:
-                    raise ValueError(
-                        f"Prod template in {path} is not leaf-granular: "
-                        f"weights={template.weights!r}, "
-                        f"devices={[item.device.name for item in template.device_model_specs]!r}"
-                    )
+        for template in file_templates:
+            if len(template.weights) != 1 or len(template.device_model_specs) != 1:
+                raise ValueError(
+                    f"Prod template in {path} is not leaf-granular: "
+                    f"weights={template.weights!r}, "
+                    f"devices={[item.device.name for item in template.device_model_specs]!r}"
+                )
         templates.extend(file_templates)
 
     model_specs = get_model_spec_map(templates)
@@ -101,8 +105,8 @@ def load_prod_leaves(prod_dir: Path, *, require_leaf_granular: bool = True):
             ),
             status=spec.status.name,
         )
-        if identity in leaves:
-            raise ValueError(f"Duplicate prod identity {identity!r}")
+        # get_model_spec_map() runs validate_model_specs(), which already
+        # rejects a repeated leaf identity, so this index cannot collide.
         leaves[identity] = leaf
     return leaves
 

--- a/tests/test_build_release_artifacts.py
+++ b/tests/test_build_release_artifacts.py
@@ -215,7 +215,7 @@ def test_config_scope_rejects_short_and_full_selector_aliases(tmp_path):
         }
     }
 
-    with pytest.raises(ValueError, match="duplicate artifact identity"):
+    with pytest.raises(ValueError, match="duplicate identity"):
         resolve_configured_scope(config, _write_dev(tmp_path))
 
 

--- a/tests/test_build_release_artifacts.py
+++ b/tests/test_build_release_artifacts.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+import io
+import json
+import zipfile
+
+import pytest
+
+from scripts.release.build_release_artifacts import (
+    artifact_model_token,
+    device_from_jobs,
+    resolve_model,
+    resolve_configured_scope,
+    runner_of,
+    validate_bundle_identity,
+    validate_staged_identity_set,
+)
+from workflows.model_spec import MODEL_SPEC_CATALOG_FILES
+
+
+IDENTITY = ("Qwen/Qwen3-32B", "GALAXY", "vLLM", "qwen3_32b_galaxy")
+
+
+def _write_dev(tmp_path):
+    dev = tmp_path / "dev"
+    dev.mkdir()
+    for filename in MODEL_SPEC_CATALOG_FILES:
+        (dev / filename).write_text("templates: []\n")
+    (dev / "llm.yaml").write_text(
+        """
+templates:
+- weights: [Qwen/Qwen3-32B]
+  impl: qwen3_32b_galaxy
+  inference_engine: VLLM
+  device_model_specs:
+    - {device: GALAXY, max_concurrency: 32, max_context: 131072, default_impl: true}
+""".lstrip()
+    )
+    return dev
+
+
+def _bundle(tmp_path, identity=IDENTITY, name="bundle.zip"):
+    path = tmp_path / name
+    document = {
+        "runtime_model_spec": {
+            "hf_model_repo": identity[0],
+            "device_type": identity[1],
+            "inference_engine": identity[2],
+            "impl": {"impl_id": identity[3]},
+        }
+    }
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("runtime_model_specs/spec.json", json.dumps(document))
+    return path
+
+
+def test_config_scope_resolves_exact_artifact_identity(tmp_path):
+    config = {
+        "models": {
+            "Qwen3-32B": {
+                "inference_engine": "vLLM",
+                "ci": {"release": {"devices": ["GALAXY"]}},
+            }
+        }
+    }
+
+    models, expected = resolve_configured_scope(config, _write_dev(tmp_path))
+
+    assert models == {"Qwen/Qwen3-32B": ["galaxy"]}
+    assert expected == {("Qwen/Qwen3-32B", "galaxy"): IDENTITY}
+
+
+def test_artifact_and_job_matching_support_full_name_variants():
+    artifact = "workflow_logs_release_Qwen__Qwen3-32B_runner_default"
+    assert artifact_model_token(artifact, "Qwen/Qwen3-32B") == "Qwen__Qwen3-32B"
+    assert runner_of(artifact, "Qwen/Qwen3-32B") == "runner"
+
+    jobs = [{"name": "run-tests / run-release-Qwen/Qwen3-32B-runner-GALAXY"}]
+    assert device_from_jobs(jobs, "Qwen/Qwen3-32B", "runner") == "GALAXY"
+
+
+def test_bundle_runtime_identity_must_match_config(tmp_path):
+    bundle = _bundle(tmp_path)
+    assert validate_bundle_identity(bundle, IDENTITY) == IDENTITY
+
+    with pytest.raises(ValueError, match="does not match"):
+        validate_bundle_identity(
+            bundle,
+            ("Qwen/Qwen3-32B", "N150", "vLLM", "qwen3_32b_galaxy"),
+        )
+
+
+def test_artifact_resolution_selects_unique_exact_identity(tmp_path, monkeypatch):
+    wrong = _bundle(
+        tmp_path,
+        ("Qwen/Qwen3-32B", "N150", "vLLM", "qwen3_32b_galaxy"),
+        "wrong.zip",
+    )
+    correct = _bundle(tmp_path, name="correct.zip")
+    artifacts = [
+        {
+            "id": 1,
+            "name": "workflow_logs_release_Qwen__Qwen3-32B_old_default",
+        },
+        {
+            "id": 2,
+            "name": "workflow_logs_release_Qwen__Qwen3-32B_new_default",
+        },
+    ]
+    jobs = [
+        {"name": "run-release-Qwen/Qwen3-32B-old-galaxy"},
+        {"name": "run-release-Qwen/Qwen3-32B-new-galaxy"},
+    ]
+    paths = {1: wrong, 2: correct}
+    monkeypatch.setattr(
+        "scripts.release.build_release_artifacts.download_artifact",
+        lambda repo, artifact, tmp, cache: paths[artifact["id"]],
+    )
+
+    chosen = resolve_model(
+        "Qwen/Qwen3-32B",
+        ["galaxy"],
+        artifacts,
+        jobs,
+        "org/repo",
+        tmp_path,
+        {},
+        {("Qwen/Qwen3-32B", "galaxy"): IDENTITY},
+    )
+
+    assert chosen == {"galaxy": artifacts[1]}
+
+    paths[1] = correct
+    with pytest.raises(SystemExit, match="found 2"):
+        resolve_model(
+            "Qwen/Qwen3-32B",
+            ["galaxy"],
+            artifacts,
+            jobs,
+            "org/repo",
+            tmp_path,
+            {},
+            {("Qwen/Qwen3-32B", "galaxy"): IDENTITY},
+        )
+
+
+def test_bundle_validator_rejects_missing_runtime_spec(tmp_path):
+    path = tmp_path / "empty.zip"
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("run_logs/log.txt", "nothing")
+    path.write_bytes(buffer.getvalue())
+
+    with pytest.raises(ValueError, match="no runtime model spec"):
+        validate_bundle_identity(path, IDENTITY)
+
+
+def test_staged_runtime_identities_must_equal_configured_scope():
+    other = ("org/other", "N150", "vLLM", "tt_transformers")
+
+    validate_staged_identity_set({IDENTITY}, {IDENTITY})
+
+    with pytest.raises(ValueError, match="missing=.*Qwen/Qwen3-32B"):
+        validate_staged_identity_set({IDENTITY}, set())
+    with pytest.raises(ValueError, match="extra=.*org/other"):
+        validate_staged_identity_set({IDENTITY}, {IDENTITY, other})
+
+
+def test_config_scope_rejects_model_device_engine_collision(tmp_path):
+    dev = _write_dev(tmp_path)
+    with (dev / "llm.yaml").open("a") as file:
+        file.write(
+            """
+- weights: [Qwen/Qwen3-32B]
+  impl: forge_vllm_plugin
+  inference_engine: FORGE
+  device_model_specs:
+    - {device: GALAXY, max_concurrency: 1, max_context: 1024, default_impl: true}
+"""
+        )
+    config = {
+        "models": {
+            "Qwen3-32B": {
+                "implementations": [
+                    {
+                        "inference_engine": "vLLM",
+                        "ci": {"release": {"devices": ["GALAXY"]}},
+                    },
+                    {
+                        "inference_engine": "FORGE",
+                        "ci": {"release": {"devices": ["GALAXY"]}},
+                    },
+                ]
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="collide on artifact filename"):
+        resolve_configured_scope(config, dev)
+
+
+def test_config_scope_rejects_short_and_full_selector_aliases(tmp_path):
+    config = {
+        "models": {
+            "Qwen3-32B": {
+                "inference_engine": "vLLM",
+                "ci": {"release": {"devices": ["GALAXY"]}},
+            },
+            "Qwen/Qwen3-32B": {
+                "inference_engine": "vLLM",
+                "ci": {"release": {"devices": ["GALAXY"]}},
+            },
+        }
+    }
+
+    with pytest.raises(ValueError, match="duplicate artifact identity"):
+        resolve_configured_scope(config, _write_dev(tmp_path))
+
+
+def test_config_scope_rejects_non_injective_artifact_slugs(tmp_path):
+    dev = tmp_path / "dev"
+    dev.mkdir()
+    for filename in MODEL_SPEC_CATALOG_FILES:
+        (dev / filename).write_text("templates: []\n")
+    (dev / "llm.yaml").write_text(
+        """
+templates:
+- weights: [org/model]
+  impl: tt_transformers
+  inference_engine: VLLM
+  device_model_specs:
+    - {device: N150, max_concurrency: 1, max_context: 1024, default_impl: true}
+- weights: [org__model]
+  impl: qwen3_32b_galaxy
+  inference_engine: VLLM
+  device_model_specs:
+    - {device: N150, max_concurrency: 1, max_context: 1024, default_impl: true}
+""".lstrip()
+    )
+    config = {
+        "models": {
+            "org/model": {
+                "inference_engine": "vLLM",
+                "ci": {"release": {"devices": ["N150"]}},
+            },
+            "org__model": {
+                "inference_engine": "vLLM",
+                "ci": {"release": {"devices": ["N150"]}},
+            },
+        }
+    }
+
+    with pytest.raises(ValueError, match="collide on artifact filename"):
+        resolve_configured_scope(config, dev)

--- a/tests/test_create_post_release_pr.py
+++ b/tests/test_create_post_release_pr.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+import json
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.release.create_post_release_pr import (
+    build_rows,
+    load_prod_blocks_from_ref,
+    render_body,
+    render_table,
+    resolve_release_scope,
+)
+from scripts.release.release_scope import (
+    ProdLeaf,
+    ProdPin,
+    expand_raw_prod_blocks,
+)
+from workflows.model_spec import MODEL_SPEC_CATALOG_FILES
+
+
+IDENTITY = ("Qwen/Qwen3-32B", "GALAXY", "vLLM", "qwen3_32b_galaxy")
+
+
+def _write_dev(tmp_path):
+    dev = tmp_path / "dev"
+    dev.mkdir()
+    for filename in MODEL_SPEC_CATALOG_FILES:
+        (dev / filename).write_text("templates: []\n")
+    (dev / "llm.yaml").write_text(
+        """
+templates:
+- weights: [Qwen/Qwen3-32B]
+  impl: qwen3_32b_galaxy
+  inference_engine: VLLM
+  device_model_specs:
+    - {device: GALAXY, max_concurrency: 32, max_context: 131072, default_impl: true}
+    - {device: BLACKHOLE_GALAXY, max_concurrency: 8, max_context: 32768, default_impl: true}
+- weights: [Qwen/Qwen3-32B]
+  impl: tt_transformers
+  inference_engine: VLLM
+  device_model_specs:
+    - {device: GALAXY, max_concurrency: 1, max_context: 32768}
+""".lstrip()
+    )
+    return dev
+
+
+def _scope(tmp_path):
+    config = {
+        "models": {
+            "Qwen3-32B": {
+                "inference_engine": "vLLM",
+                "ci": {"release": {"devices": ["GALAXY"]}},
+            }
+        }
+    }
+    return resolve_release_scope(config, _write_dev(tmp_path))
+
+
+def _prod_leaf(version="1.2.3"):
+    return ProdLeaf(
+        identity=IDENTITY,
+        pin=ProdPin(version, "metal", "vllm", "ghcr.io/image:tag"),
+        status="FUNCTIONAL",
+    )
+
+
+def test_exact_release_row_uses_default_leaf_full_repo_and_pins(tmp_path):
+    scope = _scope(tmp_path)
+    base = expand_raw_prod_blocks(
+        [
+            {
+                "weights": ["Qwen/Qwen3-32B", "Qwen/Qwen3-14B"],
+                "impl": "qwen3_32b_galaxy",
+                "inference_engine": "VLLM",
+                "version": "1.0.0",
+                "tt_metal_commit": "old-metal",
+                "vllm_commit": "old-vllm",
+                "status": "FUNCTIONAL",
+                "device_model_specs": [{"device": "GALAXY"}],
+            }
+        ]
+    )
+
+    rows = build_rows(
+        scope,
+        {IDENTITY: _prod_leaf()},
+        base,
+        jobs=None,
+        tt_shield_repo="tenstorrent/tt-shield",
+        run_id=None,
+        version="1.2.3",
+    )
+    table = render_table(rows)
+
+    assert [item.identity for item in scope] == [IDENTITY]
+    assert table.count("Qwen/Qwen3-32B") == 1
+    assert "Qwen/Qwen3-14B" not in table
+    # The base block bundled two weights under one pin; only the released leaf
+    # is reported, and its commit is shown as the old -> new change.
+    assert "`old-metal` → `metal`" in table
+    assert "No change [FUNCTIONAL]" in table
+
+
+def test_missing_or_wrong_version_current_prod_fails(tmp_path):
+    scope = _scope(tmp_path)
+    with pytest.raises(ValueError, match="missing"):
+        build_rows(scope, {}, {}, None, "repo/name", None, "1.2.3")
+    with pytest.raises(ValueError, match="has version"):
+        build_rows(
+            scope,
+            {IDENTITY: _prod_leaf("other")},
+            {},
+            None,
+            "repo/name",
+            None,
+            "1.2.3",
+        )
+
+
+def test_retained_same_version_leaf_outside_cleaned_scope_is_ignored(tmp_path):
+    scope = _scope(tmp_path)
+    extra_identity = ("org/deferred", "N150", "media", "whisper")
+    prod = {
+        IDENTITY: _prod_leaf(),
+        extra_identity: ProdLeaf(
+            extra_identity,
+            ProdPin("1.2.3", "metal", None, None),
+            "FUNCTIONAL",
+        ),
+    }
+
+    rows = build_rows(scope, prod, {}, None, "repo/name", None, "1.2.3")
+
+    assert [row["identity"] for row in rows] == [IDENTITY]
+
+
+def test_ci_job_matching_supports_full_repo_and_rejects_ambiguity(tmp_path):
+    scope = _scope(tmp_path)
+    jobs = [
+        {
+            "id": 42,
+            "name": "run-tests / run-release-Qwen__Qwen3-32B-runner-GALAXY",
+        }
+    ]
+    rows = build_rows(
+        scope,
+        {IDENTITY: _prod_leaf()},
+        {},
+        jobs,
+        "tenstorrent/tt-shield",
+        "123",
+        "1.2.3",
+    )
+    assert rows[0]["ci_url"].endswith("/job/42")
+
+    with pytest.raises(ValueError, match="Multiple CI jobs"):
+        build_rows(
+            scope,
+            {IDENTITY: _prod_leaf()},
+            {},
+            jobs * 2,
+            "tenstorrent/tt-shield",
+            "123",
+            "1.2.3",
+        )
+
+
+def test_short_and_full_selectors_resolving_same_identity_fail(tmp_path):
+    config = {
+        "models": {
+            "Qwen3-32B": {
+                "inference_engine": "vLLM",
+                "ci": {"release": {"devices": ["GALAXY"]}},
+            },
+            "Qwen/Qwen3-32B": {
+                "inference_engine": "vLLM",
+                "ci": {"release": {"devices": ["GALAXY"]}},
+            },
+        }
+    }
+
+    with pytest.raises(ValueError, match="duplicate identity"):
+        resolve_release_scope(config, _write_dev(tmp_path))
+
+
+def test_rendered_table_is_json_independent_and_exact(tmp_path):
+    scope = _scope(tmp_path)
+    rows = build_rows(
+        scope,
+        {IDENTITY: _prod_leaf()},
+        {},
+        None,
+        "repo/name",
+        None,
+        "1.2.3",
+    )
+
+    assert json.dumps(rows, default=str)
+    assert (
+        "| Impl | Model Arch | Weights | Devices | TT-Metal Commit Change | "
+        "Status Change | CI Job Link |"
+    ) in render_table(rows)
+
+
+def test_body_carries_release_metadata_and_promoted_images():
+    """The release pipeline reads both back out of the PR body.
+
+    The metadata comment identifies the run and version for the Release Object,
+    and the promoted image list is the publish plan; neither is recoverable from
+    the table, so a body missing them silently loses release provenance.
+    """
+    body = render_body(
+        "1.2.3",
+        "999",
+        rows=[],
+        promoted_images=["ghcr.io/tenstorrent/a:v1.2.3", "https://ghcr.io/b:v1.2.3"],
+    )
+
+    assert body.startswith(
+        "<!--\nmetadata:run_id=999\nmetadata:version=v1.2.3\n-->\n\n"
+    )
+    assert "- https://ghcr.io/tenstorrent/a:v1.2.3" in body
+    assert "- https://ghcr.io/b:v1.2.3" in body
+    assert "**Total:** 2" in body
+
+
+def test_invalid_base_ref_fails_instead_of_appearing_new(monkeypatch):
+    def fail(*args, **kwargs):
+        raise subprocess.CalledProcessError(128, args[0])
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    with pytest.raises(ValueError, match="Could not read prod catalog"):
+        load_prod_blocks_from_ref("not-a-ref")
+
+
+def test_one_legacy_basename_job_cannot_link_two_repositories():
+    identity_a = ("org-a/shared", "N150", "vLLM", "impl-a")
+    identity_b = ("org-b/shared", "N150", "vLLM", "impl-b")
+    scope = [
+        SimpleNamespace(identity=identity_a),
+        SimpleNamespace(identity=identity_b),
+    ]
+    prod = {
+        identity_a: ProdLeaf(
+            identity_a, ProdPin("1.2.3", "metal", "vllm", None), "FUNCTIONAL"
+        ),
+        identity_b: ProdLeaf(
+            identity_b, ProdPin("1.2.3", "metal", "vllm", None), "FUNCTIONAL"
+        ),
+    }
+    jobs = [{"id": 1, "name": "run-release-shared-runner-N150"}]
+
+    with pytest.raises(ValueError, match="ambiguously matches"):
+        build_rows(scope, prod, {}, jobs, "repo/name", "123", "1.2.3")

--- a/tests/test_create_post_release_pr.py
+++ b/tests/test_create_post_release_pr.py
@@ -10,7 +10,6 @@ import pytest
 
 from scripts.release.create_post_release_pr import (
     build_rows,
-    load_prod_blocks_from_ref,
     render_body,
     render_table,
     resolve_release_scope,
@@ -18,7 +17,7 @@ from scripts.release.create_post_release_pr import (
 from scripts.release.release_scope import (
     ProdLeaf,
     ProdPin,
-    expand_raw_prod_blocks,
+    load_prod_leaves_from_ref,
 )
 from workflows.model_spec import MODEL_SPEC_CATALOG_FILES
 
@@ -72,20 +71,13 @@ def _prod_leaf(version="1.2.3"):
 
 def test_exact_release_row_uses_default_leaf_full_repo_and_pins(tmp_path):
     scope = _scope(tmp_path)
-    base = expand_raw_prod_blocks(
-        [
-            {
-                "weights": ["Qwen/Qwen3-32B", "Qwen/Qwen3-14B"],
-                "impl": "qwen3_32b_galaxy",
-                "inference_engine": "VLLM",
-                "version": "1.0.0",
-                "tt_metal_commit": "old-metal",
-                "vllm_commit": "old-vllm",
-                "status": "FUNCTIONAL",
-                "device_model_specs": [{"device": "GALAXY"}],
-            }
-        ]
-    )
+    base = {
+        IDENTITY: ProdLeaf(
+            identity=IDENTITY,
+            pin=ProdPin("1.0.0", "old-metal", "old-vllm", None),
+            status="FUNCTIONAL",
+        )
+    }
 
     rows = build_rows(
         scope,
@@ -98,11 +90,10 @@ def test_exact_release_row_uses_default_leaf_full_repo_and_pins(tmp_path):
     )
     table = render_table(rows)
 
+    # The dev catalogue offers two impls on GALAXY; only the default one is the
+    # release leaf, and its commit is reported as the old -> new change.
     assert [item.identity for item in scope] == [IDENTITY]
     assert table.count("Qwen/Qwen3-32B") == 1
-    assert "Qwen/Qwen3-14B" not in table
-    # The base block bundled two weights under one pin; only the released leaf
-    # is reported, and its commit is shown as the old -> new change.
     assert "`old-metal` → `metal`" in table
     assert "No change [FUNCTIONAL]" in table
 
@@ -236,7 +227,7 @@ def test_invalid_base_ref_fails_instead_of_appearing_new(monkeypatch):
 
     monkeypatch.setattr(subprocess, "run", fail)
     with pytest.raises(ValueError, match="Could not read prod catalog"):
-        load_prod_blocks_from_ref("not-a-ref")
+        load_prod_leaves_from_ref("not-a-ref")
 
 
 def test_one_legacy_basename_job_cannot_link_two_repositories():

--- a/tests/test_release_artifact_package.py
+++ b/tests/test_release_artifact_package.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""The release package layout is a compatibility surface, so pin it.
+
+Every published asset from v0.13.0 on has the same shape: one top-level folder
+named after the archive, one uncompressed ``workflow_logs_release_*.zip`` per
+released leaf, each bundle carried exactly as tt-shield produced it. Consumers
+depend on that, and it survived a change of packaging tool at v0.16.0 without
+anyone testing it. These tests exist so that changing it has to be deliberate.
+"""
+
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+# build_release_artifacts.py runs as a script and resolves its own imports off
+# sys.path; import it the way the release pipeline does.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "release"))
+
+from scripts.release.build_release_artifacts import package  # noqa: E402
+
+
+BUNDLES = (
+    "workflow_logs_release_Qwen__Qwen3-32B_galaxy.zip",
+    "workflow_logs_release_google__diffusiongemma-26B-A4B-it_p300x2.zip",
+)
+
+
+@pytest.fixture
+def staged(tmp_path: Path) -> dict[str, Path]:
+    out = {}
+    for name in BUNDLES:
+        src = tmp_path / name
+        with zipfile.ZipFile(src, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("run_logs/run.log", f"log for {name}\n")
+            zf.writestr("runtime_model_specs/spec.json", '{"ok": true}')
+        out[name] = src
+    return out
+
+
+def _entries(path: Path) -> dict[str, zipfile.ZipInfo]:
+    with zipfile.ZipFile(path) as zf:
+        return {i.filename: i for i in zf.infolist()}
+
+
+def test_layout_is_one_folder_holding_the_bundles(tmp_path, staged):
+    out = package("v0.0.0", staged, tmp_path)
+    assert out.name == "v0.0.0-release_artifacts.zip"
+    assert set(_entries(out)) == {"v0.0.0-release_artifacts/"} | {
+        f"v0.0.0-release_artifacts/{name}" for name in BUNDLES
+    }
+
+
+def test_bundles_are_carried_byte_for_byte(tmp_path, staged):
+    """The bundle is what tt-shield produced; packaging must not rewrite it."""
+    out = package("v0.0.0", staged, tmp_path)
+    with zipfile.ZipFile(out) as zf:
+        for name, src in staged.items():
+            assert zf.read(f"v0.0.0-release_artifacts/{name}") == src.read_bytes()
+
+
+def test_entries_are_stored_not_recompressed(tmp_path, staged):
+    """The bundles are already deflate zips; recompressing them buys under 1%."""
+    out = package("v0.0.0", staged, tmp_path)
+    for info in _entries(out).values():
+        assert info.compress_type == zipfile.ZIP_STORED

--- a/tests/test_release_scope.py
+++ b/tests/test_release_scope.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+import io
+import json
+import zipfile
+
+import pytest
+
+from scripts.release.release_scope import (
+    extract_bundle_identity,
+    identity_from_model_spec_document,
+)
+
+
+IDENTITY = ("org/model", "N150", "vLLM", "tt_transformers")
+
+
+def _model_spec():
+    return {
+        "hf_model_repo": IDENTITY[0],
+        "device_type": IDENTITY[1],
+        "inference_engine": IDENTITY[2],
+        "impl": {"impl_id": IDENTITY[3], "impl_name": "tt-transformers"},
+    }
+
+
+def _bundle_bytes(document=None, *, path="runtime_model_specs/spec.json"):
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        if document is not None:
+            archive.writestr(path, json.dumps(document))
+    return buffer.getvalue()
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {"runtime_model_spec": _model_spec(), "runtime_config": {}},
+        {"model_spec": _model_spec()},
+        _model_spec(),
+    ],
+)
+def test_identity_from_modern_and_legacy_runtime_specs(document):
+    assert identity_from_model_spec_document(document) == IDENTITY
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("hf_model_repo", None),
+        ("hf_model_repo", "   "),
+        ("device_type", 123),
+        ("inference_engine", None),
+    ],
+)
+def test_runtime_identity_rejects_non_string_or_empty_fields(field, value):
+    document = _model_spec()
+    document[field] = value
+    with pytest.raises(ValueError, match="invalid exact identity fields"):
+        identity_from_model_spec_document(document)
+
+    document = _model_spec()
+    document["impl"]["impl_id"] = value
+    with pytest.raises(ValueError, match="invalid exact identity fields"):
+        identity_from_model_spec_document(document)
+
+
+def test_extract_bundle_identity_accepts_legacy_run_specs():
+    bundle = _bundle_bytes({"model_spec": _model_spec()}, path="run_specs/old.json")
+
+    assert extract_bundle_identity(bundle) == IDENTITY
+
+
+def test_extract_bundle_identity_rejects_missing_and_conflicting_specs():
+    with pytest.raises(ValueError, match="no runtime model spec"):
+        extract_bundle_identity(_bundle_bytes())
+
+    other = {**_model_spec(), "hf_model_repo": "org/other"}
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("runtime_model_specs/a.json", json.dumps(_model_spec()))
+        archive.writestr("runtime_model_specs/b.json", json.dumps(other))
+
+    with pytest.raises(ValueError, match="conflicting runtime identities"):
+        extract_bundle_identity(buffer.getvalue())
+
+
+def test_extract_bundle_identity_rejects_duplicate_runtime_spec_path():
+    buffer = io.BytesIO()
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        with zipfile.ZipFile(buffer, "w") as archive:
+            archive.writestr(
+                "runtime_model_specs/spec.json",
+                json.dumps(_model_spec()),
+            )
+            archive.writestr(
+                "runtime_model_specs/spec.json",
+                json.dumps({**_model_spec(), "hf_model_repo": "org/other"}),
+            )
+
+    with pytest.raises(ValueError, match="duplicate runtime model spec path"):
+        extract_bundle_identity(buffer.getvalue())

--- a/tests/test_release_scope.py
+++ b/tests/test_release_scope.py
@@ -38,11 +38,10 @@ def _bundle_bytes(document=None, *, path="runtime_model_specs/spec.json"):
     "document",
     [
         {"runtime_model_spec": _model_spec(), "runtime_config": {}},
-        {"model_spec": _model_spec()},
         _model_spec(),
     ],
 )
-def test_identity_from_modern_and_legacy_runtime_specs(document):
+def test_identity_from_wrapped_and_bare_runtime_specs(document):
     assert identity_from_model_spec_document(document) == IDENTITY
 
 
@@ -65,12 +64,6 @@ def test_runtime_identity_rejects_non_string_or_empty_fields(field, value):
     document["impl"]["impl_id"] = value
     with pytest.raises(ValueError, match="invalid exact identity fields"):
         identity_from_model_spec_document(document)
-
-
-def test_extract_bundle_identity_accepts_legacy_run_specs():
-    bundle = _bundle_bytes({"model_spec": _model_spec()}, path="run_specs/old.json")
-
-    assert extract_bundle_identity(bundle) == IDENTITY
 
 
 def test_extract_bundle_identity_rejects_missing_and_conflicting_specs():


### PR DESCRIPTION
## Summary

A release declares a scope — the exact set of runtime leaves it intends to publish.
Until now, nothing checked that the package it actually built matched that declaration.
A model whose CI job never ran simply didn't appear in the release, and nothing
downstream noticed. This PR makes the package prove it matches the scope.

Stacked on #5027 and #5021; merge after both.

## What changes

**Bundle identity comes from artifact contents, not names.**
A new `release_scope` module reads the leaf identity out of each bundle's
`runtime_model_specs/*.json` and requires exactly one consistent identity per bundle.
Artifact names were never reliable identifiers — they carry no engine field, are escaped
differently by different producers, and two runs of the same model on the same runner
can share a name. The spec files inside the bundle have none of those problems.

**Every staged bundle is verified, and the set must match the scope exactly.**
Each bundle's identity is checked against the leaf it was staged for. After staging,
the full set is compared to the declared scope — missing bundles and extra bundles are
both hard errors with a message naming the specific leaf. Before this, packaging
silently accepted whatever artifacts it found, so a smaller-than-intended release looked
like a successful one.

**Release notes resolve from the catalog; CI jobs supply only the link.**
Ambiguity is now caught at scope resolution time instead of during job-name matching.
The old approach depended on the GitHub API returning data — when it returned nothing,
the ambiguity check was skipped entirely, so the guard was strongest exactly when it was
least needed.

Also removes the shadowed-duplicate assertion from `release-automation.yml` — catalog
validation now rejects that case outright, so the inline check was redundant.

## Verification

Exercised on a branch merging #5027, #5021, and this PR.
Release pipeline dispatched against a real tt-shield Release run, all 33 steps passed:

- [Run 32973379343](https://github.com/tenstorrent/tt-inference-server/actions/runs/32973379343)
  — full pass including `crane copy`, catalogue re-bake, and published-image gate.
  Source: [tt-shield Release run 32876507635](https://github.com/tenstorrent/tt-shield/actions/runs/32876507635).
- Test branch: [dcvijetic/release-e2e-test](https://github.com/tenstorrent/tt-inference-server/tree/dcvijetic/release-e2e-test)