### PR TITLE
tests url image generation for wan2.2 via 

### DIFF
--- a/test_module/load_param_tests/video_generation_i2v_test.py
+++ b/test_module/load_param_tests/video_generation_i2v_test.py
@@ -4,9 +4,11 @@
 
 """End-to-end test for Wan2.2 Image-to-Video generation.
 
-Uploads a fixture image as the conditioning frame, submits a job to
-``POST /v1/videos/generations/i2v``, polls until completion, and asserts
-the returned MP4 is a non-empty file.
+Submits a conditioning image to ``POST /v1/videos/generations/i2v``, polls
+until completion, and asserts the returned MP4 is a non-empty file. When the
+test target supplies ``image_url``, the URL is passed through unchanged so the
+live server must download and resolve it before Wan2.2 generation starts.
+Without that target, the checked-in fixture is sent as inline base64.
 
 Requires the server to be booted with ``MODEL_RUNNER=tt-wan2.2-i2v``.
 """
@@ -18,6 +20,7 @@ import logging
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 import aiohttp
 from report_module.schema import Block
@@ -87,16 +90,35 @@ class VideoGenerationI2VTest(BaseTest):
         submit_url = f"{self.base_url}{SUBMIT_PATH}"
         logger.info(f"Testing I2V generation at {submit_url}")
 
-        image_b64 = _load_fixture_image_base64()
-        payload = {
-            "prompt": (
+        image_url = self.targets.get("image_url")
+        if image_url:
+            image_prompt = image_url
+            image_source = "url"
+            prompt = (
+                "The silver sports car accelerates smoothly down the country "
+                "road as the camera tracks alongside it, cinematic motion"
+            )
+            parsed_image_url = urlsplit(image_url)
+            logger.info(
+                "Using remote I2V conditioning image: scheme=%s host=%s",
+                parsed_image_url.scheme,
+                parsed_image_url.hostname,
+            )
+        else:
+            image_prompt = _load_fixture_image_base64()
+            image_source = "inline_base64"
+            prompt = (
                 "A tranquil sunrise over rolling hills, soft golden light, "
                 "cinematic camera pan"
-            ),
+            )
+            logger.info("Using inline-base64 I2V conditioning image")
+
+        payload = {
+            "prompt": prompt,
             "negative_prompt": "blurry, low quality, distorted",
             "num_inference_steps": num_inference_steps,
             "seed": 42,
-            "image_prompts": [{"image": image_b64, "frame_pos": 0}],
+            "image_prompts": [{"image": image_prompt, "frame_pos": 0}],
         }
 
         session_timeout = aiohttp.ClientTimeout(total=self.poll_timeout)
@@ -105,11 +127,20 @@ class VideoGenerationI2VTest(BaseTest):
         ) as session:
             job_id = await self._submit_job(session, submit_url, payload)
             if not job_id:
-                return {"success": False, "reason": "submit_failed"}
+                return {
+                    "success": False,
+                    "reason": "submit_failed",
+                    "image_source": image_source,
+                }
 
             file_path = await self._poll_until_complete(session, job_id)
             if not file_path:
-                return {"success": False, "reason": "poll_failed", "job_id": job_id}
+                return {
+                    "success": False,
+                    "reason": "poll_failed",
+                    "job_id": job_id,
+                    "image_source": image_source,
+                }
 
             file_size = (
                 Path(file_path).stat().st_size if Path(file_path).exists() else 0
@@ -121,6 +152,7 @@ class VideoGenerationI2VTest(BaseTest):
                 "job_id": job_id,
                 "file_path": file_path,
                 "file_size_bytes": file_size,
+                "image_source": image_source,
             }
 
     async def _submit_job(

--- a/test_module/load_param_tests/video_generation_i2v_test.py
+++ b/test_module/load_param_tests/video_generation_i2v_test.py
@@ -95,8 +95,8 @@ class VideoGenerationI2VTest(BaseTest):
             image_prompt = image_url
             image_source = "url"
             prompt = (
-                "The silver sports car accelerates smoothly down the country "
-                "road as the camera tracks alongside it, cinematic motion"
+                "The Earth and Moon slowly rotate in space as the camera glides "
+                "past them, cinematic orbital motion"
             )
             parsed_image_url = urlsplit(image_url)
             logger.info(

--- a/test_module/test_suites/video.json
+++ b/test_module/test_suites/video.json
@@ -68,7 +68,8 @@
                     "targets": {
                         "num_inference_steps": 40,
                         "poll_timeout": 1200,
-                        "poll_interval": 5
+                        "poll_interval": 5,
+                        "image_url": "https://pixnio.com/free-images/2019/01/10/2019-01-10-10-11-54.jpg"
                     },
                     "model_targets": {
                         "wan_i2v+t3k": {

--- a/test_module/test_suites/video.json
+++ b/test_module/test_suites/video.json
@@ -69,7 +69,7 @@
                         "num_inference_steps": 40,
                         "poll_timeout": 1200,
                         "poll_interval": 5,
-                        "image_url": "https://pixnio.com/free-images/2019/01/10/2019-01-10-10-11-54.jpg"
+                        "image_url": "https://images-assets.nasa.gov/image/PIA00342/PIA00342~medium.jpg"
                     },
                     "model_targets": {
                         "wan_i2v+t3k": {

--- a/tests/test_module/test_matrix_expansion.py
+++ b/tests/test_module/test_matrix_expansion.py
@@ -206,31 +206,39 @@ class TestVideoMatrixExpansion:
     }
     # Expected VideoGenerationI2VTest targets per expanded suite. p150x4 keeps
     # the base poll_timeout (no per-device override).
+    WAN_I2V_IMAGE_URL = (
+        "https://pixnio.com/free-images/2019/01/10/2019-01-10-10-11-54.jpg"
+    )
     WAN_I2V_TARGETS = {
         "wan-i2v-t3k": {
             "num_inference_steps": 40,
             "poll_timeout": 1500,
             "poll_interval": 5,
+            "image_url": WAN_I2V_IMAGE_URL,
         },
         "wan-i2v-galaxy": {
             "num_inference_steps": 40,
             "poll_timeout": 550,
             "poll_interval": 5,
+            "image_url": WAN_I2V_IMAGE_URL,
         },
         "wan-i2v-p150x4": {
             "num_inference_steps": 40,
             "poll_timeout": 1200,
             "poll_interval": 5,
+            "image_url": WAN_I2V_IMAGE_URL,
         },
         "wan-i2v-p150x8": {
             "num_inference_steps": 40,
             "poll_timeout": 900,
             "poll_interval": 5,
+            "image_url": WAN_I2V_IMAGE_URL,
         },
         "wan-i2v-p300x2": {
             "num_inference_steps": 40,
             "poll_timeout": 800,
             "poll_interval": 5,
+            "image_url": WAN_I2V_IMAGE_URL,
         },
     }
 

--- a/tests/test_module/test_matrix_expansion.py
+++ b/tests/test_module/test_matrix_expansion.py
@@ -207,7 +207,7 @@ class TestVideoMatrixExpansion:
     # Expected VideoGenerationI2VTest targets per expanded suite. p150x4 keeps
     # the base poll_timeout (no per-device override).
     WAN_I2V_IMAGE_URL = (
-        "https://pixnio.com/free-images/2019/01/10/2019-01-10-10-11-54.jpg"
+        "https://images-assets.nasa.gov/image/PIA00342/PIA00342~medium.jpg"
     )
     WAN_I2V_TARGETS = {
         "wan-i2v-t3k": {

--- a/tt-media-server/fix_dependencies.sh
+++ b/tt-media-server/fix_dependencies.sh
@@ -12,4 +12,4 @@ uv pip install torch torchvision torchaudio --index-url https://download.pytorch
 # the CUDA torch wheels we just replaced with CPU-only ones above).
 uv pip install xformers --no-deps
 
-uv pip install diffusers
+uv pip install "diffusers==0.39.0"

--- a/workflows/model_specs/dev/video.yaml
+++ b/workflows/model_specs/dev/video.yaml
@@ -134,6 +134,7 @@ templates:
   inference_engine: MEDIA
   env_vars:
     TT_DIT_CACHE_DIR: /home/container_app_user/cache_root/tt_dit_cache
+    MEDIA_URL_ALLOWED_DOMAINS: pixnio.com
   device_model_specs:
     - device: T3K
       max_concurrency: 1

--- a/workflows/model_specs/dev/video.yaml
+++ b/workflows/model_specs/dev/video.yaml
@@ -133,8 +133,8 @@ templates:
   model_type: VIDEO
   inference_engine: MEDIA
   env_vars:
-    TT_DIT_CACHE_DIR: /home/container_app_user/cache_root/tt_dit_cache_wan_i2v_tile_v1
-    MEDIA_URL_ALLOWED_DOMAINS: pixnio.com
+    TT_DIT_CACHE_DIR: /home/container_app_user/cache_root/tt_dit_cache
+    MEDIA_URL_ALLOWED_DOMAINS: images-assets.nasa.gov
   device_model_specs:
     - device: T3K
       max_concurrency: 1

--- a/workflows/model_specs/dev/video.yaml
+++ b/workflows/model_specs/dev/video.yaml
@@ -133,7 +133,7 @@ templates:
   model_type: VIDEO
   inference_engine: MEDIA
   env_vars:
-    TT_DIT_CACHE_DIR: /home/container_app_user/cache_root/tt_dit_cache
+    TT_DIT_CACHE_DIR: /home/container_app_user/cache_root/tt_dit_cache_wan_i2v_tile_v1
     MEDIA_URL_ALLOWED_DOMAINS: pixnio.com
   device_model_specs:
     - device: T3K


### PR DESCRIPTION
closes https://github.com/tenstorrent/tt-inference-server/issues/5030

## Scope
previously, we were only able to supply conditioning images through base64.
recently, this pr https://github.com/tenstorrent/tt-inference-server/pull/4983 allows us to pass in urls, specifically preassigned s3 urls for conditioning images.

thus, we should create tests to verify:

the images can actually be supplied correctly via url to an actual model (we use wan2.2)
the model is able to generate content via the images supplied

## Handoff Notes
tt-media-server/fix_dependencies.sh fixes a dependency issue causing huggingface errors. the issue is already being tracked here https://github.com/tenstorrent/tt-inference-server/issues/4998. once the fix goes in, this file should be removed before merging to main

Previously, we had the following bug:
`2026-08-26 17:04:00,051 - ERROR - Error in worker -1: layout mismatch: expected Layout.TILE, got Layout.ROW_MAJOR while loading '/home/container_app_user/cache_root/tt_dit_cache/Wan2.2-I2V-A14B-Diffusers/transformer_2/CP1_0_TP4_0_SP8_1_mesh4x8_bf16_FSDP/blocks.0.norm2.weight.tensorbin'`

We force new dir instead of /home/container_app_user/cache_root/tt_dit_cache/,  through yaml config:
https://github.com/tenstorrent/tt-shield/actions/runs/33089795519

The above run made it to the tests, but since we sourced images from pixnio, but this has the following issue:
`[ERROR] test_module.load_param_tests.video_generation_i2v_test: I2V submit failed: status=422 body={"detail":"Media URL returned HTTP 403 (an expired presigned URL typically returns 403): https://pixnio.com/free-images/2019/01/10/2019-01-10-10-11-54.jpg"}`

Thus, switched to a different url provider. This leads to the latest run:
https://github.com/tenstorrent/tt-shield/actions/runs/33108540141

## Next steps:
get results of latest run. fix any errors that appear - the tests themselves should be clear, itll most likely be runner issues or things out of scope.

