### PR TITLE
Make HF_TOKEN optional for public (non-gated) models

### DIFF
--- a/run.py
+++ b/run.py
@@ -869,15 +869,32 @@ def handle_secrets(runtime_config):
             "Set API_KEY in .env or as an environment variable."
         )
 
+    # HF_TOKEN is not strictly required even where it is expected: public
+    # (non-gated) models download anonymously, and setup_host.check_hf_access
+    # fails fast with an actionable error for gated repos. Never prompt for it
+    # on a non-interactive stdin (e.g. spawned by TT-Studio) — getpass() there
+    # hangs forever or dies with EOFError.
+    def _hf_token_optional(key: str) -> bool:
+        return key == "HF_TOKEN" and not sys.stdin.isatty()
+
+    _anon_warning = (
+        "HF_TOKEN is not set — proceeding without a token. Public models "
+        "download anonymously; gated models require HF_TOKEN in .env or the "
+        "environment."
+    )
+
     # load secrets from env file or prompt user to enter them once
     if not load_dotenv():
         env_vars = {}
         for key in required_env_vars:
             _val = os.getenv(key)
+            if not _val and _hf_token_optional(key):
+                logger.warning(_anon_warning)
+                continue
             if not _val:
                 _val = getpass.getpass(f"Enter your {key}: ").strip()
             env_vars[key] = _val
-        assert all([env_vars[k] for k in required_env_vars])
+        assert all([env_vars[k] for k in env_vars])
         write_dotenv(env_vars)
         # read back secrets to current process env vars
         check = load_dotenv()
@@ -885,6 +902,9 @@ def handle_secrets(runtime_config):
     else:
         logger.info("Using secrets from .env file.")
         for key in required_env_vars:
+            if not os.getenv(key) and _hf_token_optional(key):
+                logger.warning(_anon_warning)
+                continue
             assert os.getenv(key), (
                 f"Required environment variable {key} is not set in .env file."
             )

--- a/run.py
+++ b/run.py
@@ -44,6 +44,7 @@ from workflows.run_docker_server import (
 from workflows.runtime_config import RuntimeConfig
 from workflows.setup_host import setup_host
 from workflows.utils import (
+    can_prompt_interactively,
     ensure_readwriteable_dir,
     get_default_hf_home_path,
     get_default_workflow_root_log_dir,
@@ -845,17 +846,21 @@ def handle_secrets(runtime_config):
         WorkflowType.SERVING_BENCH,
         WorkflowType.PREFILL_DECODE,
     }
-    # --docker-server requires the HF_TOKEN env var to be available
-    huggingface_required = (
+    # These workflows expect an HF_TOKEN, but it is deliberately NOT in
+    # required_env_vars: public (non-gated) models download anonymously, and
+    # setup_host.check_hf_access is the single authority on HF access — it
+    # fails fast with an actionable error when a gated repo is requested with
+    # no token. Requiring it here would either prompt (hanging headless
+    # callers such as TT-Studio's uvicorn worker, whose stdin isatty() but has
+    # no controlling terminal to answer on) or hard-fail public-model deploys.
+    hf_token_expected = (
         workflow_type not in client_side_workflows or runtime_config.docker_server
     )
-    huggingface_required = huggingface_required and not runtime_config.interactive
+    hf_token_expected = hf_token_expected and not runtime_config.interactive
 
     required_env_vars = []
     if jwt_secret_required:
         required_env_vars.append("JWT_SECRET")
-    if huggingface_required:
-        required_env_vars += ["HF_TOKEN"]
 
     if (
         workflow_type == WorkflowType.SERVER
@@ -869,32 +874,24 @@ def handle_secrets(runtime_config):
             "Set API_KEY in .env or as an environment variable."
         )
 
-    # HF_TOKEN is not strictly required even where it is expected: public
-    # (non-gated) models download anonymously, and setup_host.check_hf_access
-    # fails fast with an actionable error for gated repos. Never prompt for it
-    # on a non-interactive stdin (e.g. spawned by TT-Studio) — getpass() there
-    # hangs forever or dies with EOFError.
-    def _hf_token_optional(key: str) -> bool:
-        return key == "HF_TOKEN" and not sys.stdin.isatty()
-
-    _anon_warning = (
-        "HF_TOKEN is not set — proceeding without a token. Public models "
-        "download anonymously; gated models require HF_TOKEN in .env or the "
-        "environment."
-    )
-
     # load secrets from env file or prompt user to enter them once
     if not load_dotenv():
         env_vars = {}
         for key in required_env_vars:
             _val = os.getenv(key)
-            if not _val and _hf_token_optional(key):
-                logger.warning(_anon_warning)
-                continue
             if not _val:
+                if not can_prompt_interactively():
+                    # A prompt here would block forever (or die with
+                    # EOFError) — fail with an actionable message instead.
+                    raise RuntimeError(
+                        f"Required environment variable {key} is not set and "
+                        "there is no controlling terminal to prompt for it. "
+                        f"Set {key} in .env or the environment."
+                    )
                 _val = getpass.getpass(f"Enter your {key}: ").strip()
             env_vars[key] = _val
-        assert all([env_vars[k] for k in env_vars])
+        missing = [k for k, v in env_vars.items() if not v]
+        assert not missing, f"Empty value for required secret(s): {', '.join(missing)}"
         write_dotenv(env_vars)
         # read back secrets to current process env vars
         check = load_dotenv()
@@ -902,12 +899,16 @@ def handle_secrets(runtime_config):
     else:
         logger.info("Using secrets from .env file.")
         for key in required_env_vars:
-            if not os.getenv(key) and _hf_token_optional(key):
-                logger.warning(_anon_warning)
-                continue
             assert os.getenv(key), (
                 f"Required environment variable {key} is not set in .env file."
             )
+
+    if hf_token_expected and not os.getenv("HF_TOKEN"):
+        logger.warning(
+            "HF_TOKEN is not set — proceeding without a token. Public models "
+            "download anonymously; gated models require HF_TOKEN in .env or "
+            "the environment."
+        )
 
 
 def get_current_commit_sha() -> str:

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -1254,7 +1254,7 @@ class TestSecretsHandling:
     def test_secrets_prompting(
         self, mock_getpass, mock_write_dotenv, mock_load_dotenv, mock_runtime_config
     ):
-        """Test prompting for missing secrets."""
+        """Test prompting for missing secrets on an interactive stdin."""
         mock_runtime_config.workflow = "server"
         mock_runtime_config.docker_server = True
         mock_runtime_config.interactive = False
@@ -1263,10 +1263,43 @@ class TestSecretsHandling:
         mock_getpass.side_effect = ["test-jwt", "test-hf"]
 
         with patch.dict(os.environ, {}, clear=True):
-            handle_secrets(mock_runtime_config)
+            with patch("sys.stdin.isatty", return_value=True):
+                handle_secrets(mock_runtime_config)
 
         assert mock_getpass.call_count == 2
         mock_write_dotenv.assert_called_once()
+
+    @patch("run.load_dotenv")
+    @patch("run.write_dotenv")
+    @patch("getpass.getpass")
+    def test_hf_token_optional_on_non_interactive_stdin(
+        self, mock_getpass, mock_write_dotenv, mock_load_dotenv, mock_runtime_config
+    ):
+        """Headless run (e.g. spawned by an orchestrator) with no HF_TOKEN must
+        not prompt: public models deploy anonymously."""
+        mock_runtime_config.workflow = "server"
+        mock_runtime_config.docker_server = True
+        mock_runtime_config.interactive = False
+
+        mock_load_dotenv.side_effect = [False, True]
+
+        with patch.dict(os.environ, {"JWT_SECRET": "test-jwt"}, clear=True):
+            with patch("sys.stdin.isatty", return_value=False):
+                handle_secrets(mock_runtime_config)
+
+        mock_getpass.assert_not_called()
+        mock_write_dotenv.assert_called_once_with({"JWT_SECRET": "test-jwt"})
+
+    def test_hf_token_optional_with_dotenv_loaded(self, mock_runtime_config):
+        """A .env without HF_TOKEN must not fail a headless run."""
+        mock_runtime_config.workflow = "server"
+        mock_runtime_config.docker_server = True
+        mock_runtime_config.interactive = False
+
+        with patch("run.load_dotenv", return_value=True):
+            with patch.dict(os.environ, {"JWT_SECRET": "test-jwt"}, clear=True):
+                with patch("sys.stdin.isatty", return_value=False):
+                    handle_secrets(mock_runtime_config)
 
 
 class TestUtilityFunctions:

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -1254,29 +1254,32 @@ class TestSecretsHandling:
     def test_secrets_prompting(
         self, mock_getpass, mock_write_dotenv, mock_load_dotenv, mock_runtime_config
     ):
-        """Test prompting for missing secrets on an interactive stdin."""
+        """On a real controlling terminal, missing required secrets are
+        prompted for. HF_TOKEN is never prompted here — check_hf_access is the
+        authority on HF access."""
         mock_runtime_config.workflow = "server"
         mock_runtime_config.docker_server = True
         mock_runtime_config.interactive = False
 
         mock_load_dotenv.side_effect = [False, True]
-        mock_getpass.side_effect = ["test-jwt", "test-hf"]
+        mock_getpass.side_effect = ["test-jwt"]
 
         with patch.dict(os.environ, {}, clear=True):
-            with patch("sys.stdin.isatty", return_value=True):
+            with patch("run.can_prompt_interactively", return_value=True):
                 handle_secrets(mock_runtime_config)
 
-        assert mock_getpass.call_count == 2
-        mock_write_dotenv.assert_called_once()
+        assert mock_getpass.call_count == 1
+        assert mock_getpass.call_args[0][0] == "Enter your JWT_SECRET: "
+        mock_write_dotenv.assert_called_once_with({"JWT_SECRET": "test-jwt"})
 
     @patch("run.load_dotenv")
     @patch("run.write_dotenv")
     @patch("getpass.getpass")
-    def test_hf_token_optional_on_non_interactive_stdin(
+    def test_hf_token_never_prompted(
         self, mock_getpass, mock_write_dotenv, mock_load_dotenv, mock_runtime_config
     ):
-        """Headless run (e.g. spawned by an orchestrator) with no HF_TOKEN must
-        not prompt: public models deploy anonymously."""
+        """A missing HF_TOKEN must never prompt, even interactively: public
+        models deploy anonymously and setup_host prompts (at most) once."""
         mock_runtime_config.workflow = "server"
         mock_runtime_config.docker_server = True
         mock_runtime_config.interactive = False
@@ -1284,22 +1287,50 @@ class TestSecretsHandling:
         mock_load_dotenv.side_effect = [False, True]
 
         with patch.dict(os.environ, {"JWT_SECRET": "test-jwt"}, clear=True):
-            with patch("sys.stdin.isatty", return_value=False):
+            with patch("run.can_prompt_interactively", return_value=True):
                 handle_secrets(mock_runtime_config)
 
         mock_getpass.assert_not_called()
         mock_write_dotenv.assert_called_once_with({"JWT_SECRET": "test-jwt"})
 
-    def test_hf_token_optional_with_dotenv_loaded(self, mock_runtime_config):
-        """A .env without HF_TOKEN must not fail a headless run."""
+    @patch("run.load_dotenv")
+    @patch("run.write_dotenv")
+    @patch("getpass.getpass")
+    def test_headless_missing_secret_fails_cleanly(
+        self, mock_getpass, mock_write_dotenv, mock_load_dotenv, mock_runtime_config
+    ):
+        """With no controlling terminal, a missing required secret must raise
+        an actionable error instead of blocking on getpass()."""
+        mock_runtime_config.workflow = "server"
+        mock_runtime_config.docker_server = True
+        mock_runtime_config.interactive = False
+
+        mock_load_dotenv.return_value = False
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("run.can_prompt_interactively", return_value=False):
+                with pytest.raises(RuntimeError, match="JWT_SECRET"):
+                    handle_secrets(mock_runtime_config)
+
+        mock_getpass.assert_not_called()
+        mock_write_dotenv.assert_not_called()
+
+    @patch("run.logger")
+    def test_hf_token_optional_with_dotenv_loaded(
+        self, mock_logger, mock_runtime_config
+    ):
+        """A .env without HF_TOKEN must not fail a headless run — it proceeds
+        with a warning about anonymous access."""
         mock_runtime_config.workflow = "server"
         mock_runtime_config.docker_server = True
         mock_runtime_config.interactive = False
 
         with patch("run.load_dotenv", return_value=True):
             with patch.dict(os.environ, {"JWT_SECRET": "test-jwt"}, clear=True):
-                with patch("sys.stdin.isatty", return_value=False):
-                    handle_secrets(mock_runtime_config)
+                handle_secrets(mock_runtime_config)
+
+        warnings = [str(c.args[0]) for c in mock_logger.warning.call_args_list]
+        assert any("HF_TOKEN is not set" in w for w in warnings)
 
 
 class TestUtilityFunctions:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -653,5 +653,80 @@ class TestMainWorkflowIntegration:
                 main()
 
 
+class TestCheckHfAccessAnonymous:
+    """check_hf_access with no token: the anonymous models-API lookup that
+    decides public (usable) vs gated (actionable failure)."""
+
+    @pytest.fixture
+    def manager(self):
+        model_id = "id_tt-transformers_Llama-3.1-8B-Instruct_n150"
+        return HostSetupManager(model_spec=MODEL_SPECS[model_id], automatic=True)
+
+    @staticmethod
+    def _api_response(payload, status=200):
+        return json.dumps(payload).encode(), status, {}
+
+    def test_public_repo_passes(self, manager):
+        with patch("workflows.setup_host.http_request") as mock_http:
+            mock_http.return_value = self._api_response(
+                {"gated": False, "siblings": [{"rfilename": "config.json"}]}
+            )
+            assert manager.check_hf_access("") is True
+
+    def test_gated_repo_fails(self, manager):
+        with patch("workflows.setup_host.http_request") as mock_http, patch(
+            "workflows.setup_host.logger"
+        ) as mock_logger:
+            mock_http.return_value = self._api_response(
+                {"gated": "manual", "siblings": [{"rfilename": "config.json"}]}
+            )
+            assert manager.check_hf_access("") is False
+        errors = " ".join(str(c.args[0]) for c in mock_logger.error.call_args_list)
+        assert "gated" in errors and "HF_TOKEN" in errors
+
+    def test_non_200_reports_status_not_json_error(self, manager):
+        """An HTML error body must report the HTTP status, not 'invalid JSON'."""
+        with patch("workflows.setup_host.http_request") as mock_http, patch(
+            "workflows.setup_host.logger"
+        ) as mock_logger:
+            mock_http.return_value = (b"<html>Too Many Requests</html>", 429, {})
+            assert manager.check_hf_access("") is False
+        errors = " ".join(str(c.args[0]) for c in mock_logger.error.call_args_list)
+        assert "HTTP 429" in errors
+        assert "Invalid JSON" not in errors
+
+    def test_empty_siblings_fails(self, manager):
+        with patch("workflows.setup_host.http_request") as mock_http:
+            mock_http.return_value = self._api_response(
+                {"gated": False, "siblings": []}
+            )
+            assert manager.check_hf_access("") is False
+
+    def test_network_error_fails_cleanly(self, manager):
+        """An offline/proxied host gets a clean failure, not a traceback."""
+        with patch("workflows.setup_host.http_request") as mock_http, patch(
+            "workflows.setup_host.logger"
+        ) as mock_logger:
+            mock_http.side_effect = Exception("connection refused")
+            assert manager.check_hf_access("") is False
+        errors = " ".join(str(c.args[0]) for c in mock_logger.error.call_args_list)
+        assert "Could not reach Hugging Face" in errors
+
+    def test_get_hf_env_vars_headless_never_prompts(self):
+        """Non-automatic setup with no controlling terminal must not call
+        getpass — it proceeds tokenless and check_hf_access decides."""
+        model_id = "id_tt-transformers_Llama-3.1-8B-Instruct_n150"
+        manager = HostSetupManager(model_spec=MODEL_SPECS[model_id], automatic=False)
+        manager.setup_config.host_hf_cache = None
+        with patch.dict(os.environ, {"HF_TOKEN": ""}), patch(
+            "workflows.setup_host.can_prompt_interactively", return_value=False
+        ), patch("getpass.getpass") as mock_getpass, patch.object(
+            manager, "check_hf_access", return_value=True
+        ) as mock_check:
+            manager.get_hf_env_vars()
+        mock_getpass.assert_not_called()
+        mock_check.assert_called_once_with("")
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -25,6 +25,7 @@ if project_root not in sys.path:
 
 from workflows.model_spec import ModelSpec
 from workflows.utils import (
+    can_prompt_interactively,
     get_default_persistent_volume_root,
     resolve_hf_snapshot_dir,
 )
@@ -202,12 +203,12 @@ class SetupConfig:
 
 
 def http_request(
-    url: str, method: str = "GET", headers: Dict[str, str] = None
+    url: str, method: str = "GET", headers: Dict[str, str] = None, timeout: float = 30
 ) -> Tuple[bytes, int, dict]:
     headers = headers or {}
     req = urllib.request.Request(url, headers=headers, method=method)
     try:
-        with urllib.request.urlopen(req) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.read(), resp.getcode(), dict(resp.headers)
     except urllib.error.HTTPError as e:
         return e.read(), e.getcode(), dict(e.headers)
@@ -387,11 +388,19 @@ class HostSetupManager:
 
     def get_hf_env_vars(self):
         self.hf_token = self.hf_token or os.getenv("HF_TOKEN", "")
-        if not self.hf_token and not self.automatic:
+        # Prompt only on a real controlling terminal: headless callers (CI,
+        # systemd, TT-Studio's uvicorn worker) proceed without a token and
+        # check_hf_access decides — public repos pass anonymously, gated
+        # repos fail fast with an actionable error.
+        if not self.hf_token and not self.automatic and can_prompt_interactively():
             self.hf_token = getpass.getpass(
                 "Enter your HF_TOKEN (leave empty for public models): "
             ).strip()
         assert self.check_hf_access(self.hf_token), "⛔ HF_TOKEN validation failed."
+        if self.hf_token:
+            # Later stages (weights download venv, docker env construction)
+            # read HF_TOKEN from the process env — export a prompted token.
+            os.environ["HF_TOKEN"] = self.hf_token
 
         if self.setup_config.host_hf_cache:
             hf_home = Path(self.setup_config.host_hf_cache)
@@ -408,17 +417,26 @@ class HostSetupManager:
             model_url = (
                 f"https://huggingface.co/api/models/{self.model_spec.hf_weights_repo}"
             )
-            data, status, _ = http_request(model_url)
             try:
-                json_data = json.loads(data.decode("utf-8"))
-            except json.JSONDecodeError:
-                logger.error("⛔ Invalid JSON response from Hugging Face.")
+                data, status, _ = http_request(model_url)
+            except Exception:
+                # http_request already logged the underlying error.
+                logger.error(
+                    f"⛔ Could not reach Hugging Face to check "
+                    f"{self.model_spec.hf_weights_repo}. Check network "
+                    "connectivity, or set HF_TOKEN in .env or the environment."
+                )
                 return False
             if status != 200:
                 logger.error(
                     f"⛔ Could not look up {self.model_spec.hf_weights_repo} "
                     f"on Hugging Face (HTTP {status})."
                 )
+                return False
+            try:
+                json_data = json.loads(data.decode("utf-8"))
+            except json.JSONDecodeError:
+                logger.error("⛔ Invalid JSON response from Hugging Face.")
                 return False
             if json_data.get("gated"):
                 logger.error(
@@ -431,7 +449,10 @@ class HostSetupManager:
                 logger.error("⛔ No files found in repository.")
                 return False
             logger.info(
-                "✅ No HF_TOKEN set — weights repo is public, using anonymous access."
+                f"✅ No HF_TOKEN set — weights repo "
+                f"{self.model_spec.hf_weights_repo} is public, using anonymous "
+                "access. (Only the weights repo was checked; models that pull "
+                "additional gated assets at runtime may still need a token.)"
             )
             return True
         if not token.startswith("hf_"):
@@ -509,7 +530,7 @@ class HostSetupManager:
 
         if not self.jwt_secret:
             self.jwt_secret = os.getenv("JWT_SECRET", "")
-        if not self.jwt_secret and not self.automatic:
+        if not self.jwt_secret and not self.automatic and can_prompt_interactively():
             self.jwt_secret = getpass.getpass("Enter your JWT_SECRET: ").strip()
 
         assert self.jwt_secret, "⛔ JWT_SECRET cannot be empty."

--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -388,7 +388,9 @@ class HostSetupManager:
     def get_hf_env_vars(self):
         self.hf_token = self.hf_token or os.getenv("HF_TOKEN", "")
         if not self.hf_token and not self.automatic:
-            self.hf_token = getpass.getpass("Enter your HF_TOKEN: ").strip()
+            self.hf_token = getpass.getpass(
+                "Enter your HF_TOKEN (leave empty for public models): "
+            ).strip()
         assert self.check_hf_access(self.hf_token), "⛔ HF_TOKEN validation failed."
 
         if self.setup_config.host_hf_cache:
@@ -399,7 +401,40 @@ class HostSetupManager:
             logger.info(f"✅ HF_HOME set to {self.setup_config.host_hf_cache}")
 
     def check_hf_access(self, token: str) -> int:
-        if not token or not token.startswith("hf_"):
+        if not token:
+            # No token: usable iff the weights repo is public. The models API
+            # serves gated repos' metadata anonymously, so inspect the `gated`
+            # field rather than the HTTP status.
+            model_url = (
+                f"https://huggingface.co/api/models/{self.model_spec.hf_weights_repo}"
+            )
+            data, status, _ = http_request(model_url)
+            try:
+                json_data = json.loads(data.decode("utf-8"))
+            except json.JSONDecodeError:
+                logger.error("⛔ Invalid JSON response from Hugging Face.")
+                return False
+            if status != 200:
+                logger.error(
+                    f"⛔ Could not look up {self.model_spec.hf_weights_repo} "
+                    f"on Hugging Face (HTTP {status})."
+                )
+                return False
+            if json_data.get("gated"):
+                logger.error(
+                    f"⛔ {self.model_spec.hf_weights_repo} is a gated model and "
+                    "cannot be downloaded anonymously. Set HF_TOKEN in .env or "
+                    "the environment."
+                )
+                return False
+            if not json_data.get("siblings"):
+                logger.error("⛔ No files found in repository.")
+                return False
+            logger.info(
+                "✅ No HF_TOKEN set — weights repo is public, using anonymous access."
+            )
+            return True
+        if not token.startswith("hf_"):
             logger.error("⛔ Invalid HF_TOKEN.")
             return False
         data, status, _ = http_request(
@@ -548,14 +583,19 @@ class HostSetupManager:
             )
             return
 
-        assert self.hf_token, "⛔ HF_TOKEN not set."
+        if not self.hf_token:
+            # check_hf_access already verified the repo is public; the `hf` CLI
+            # treats an empty HF_TOKEN env var as anonymous access.
+            logger.warning(
+                "HF_TOKEN not set — downloading weights anonymously (public repo)."
+            )
         if self.model_spec.repacked == 1:
             raise ValueError("⛔ Repacked models are not supported for Hugging Face.")
         # setup venv using uv
         venv_config = VENV_CONFIGS[WorkflowVenvType.HF_SETUP]
         venv_config.setup(model_spec=self.model_spec)
         os.environ["HF_HUB_DOWNLOAD_TIMEOUT"] = "60"
-        os.environ["HF_TOKEN"] = self.hf_token
+        os.environ["HF_TOKEN"] = self.hf_token or ""
         hf_exec = venv_config.venv_path / "bin" / "hf"
         assert hf_exec.exists(), (
             f"⛔ 'hf' CLI not found at: {hf_exec}. Check HF_SETUP venv installation."

--- a/workflows/utils.py
+++ b/workflows/utils.py
@@ -10,6 +10,7 @@ import os
 import re
 import shlex
 import subprocess
+import sys
 import tempfile
 import threading
 import uuid
@@ -17,6 +18,28 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
+
+
+def can_prompt_interactively() -> bool:
+    """True only when getpass() would read from a real controlling terminal.
+
+    sys.stdin.isatty() is not a sufficient signal: a worker spawned with
+    Popen(..., start_new_session=True) and no stdin= (e.g. TT-Studio's uvicorn
+    worker) inherits the launching terminal on fd 0 — isatty() is True — but
+    has no controlling terminal, so getpass() falls back to reading fd 0 and
+    blocks forever with nobody there to answer. On POSIX getpass() prompts on
+    /dev/tty when it can be opened, so /dev/tty openability is the precise
+    signal for whether a prompt can actually be answered.
+    """
+    if os.name != "posix":
+        return sys.stdin is not None and sys.stdin.isatty()
+    try:
+        fd = os.open("/dev/tty", os.O_RDWR)
+    except OSError:
+        return False
+    os.close(fd)
+    return True
+
 
 # SDXL num prompts limits
 SDXL_DEFAULT_NUM_PROMPTS = 100


### PR DESCRIPTION
run.py hard-requires HF_TOKEN for every --docker-server deploy, even for public models (Qwen, Mistral, ...) that download anonymously. When no token is set it falls back to an interactive getpass() prompt, which hangs forever — or dies with EOFError — when run.py is spawned headless by an orchestrator like TT-Studio. This is the run.py side of the failure tt-studio#1290 works around downstream.

- [x] handle_secrets: HF_TOKEN removed from required_env_vars entirely — never prompted for or asserted on; a missing token logs a warning and setup_host.check_hf_access is the single authority on HF access (matches TT-Studio's discrimination, so its workaround can be deleted)
- [x] Shared workflows.utils.can_prompt_interactively() guards every getpass site (handle_secrets, get_hf_env_vars, JWT_SECRET prompt), keyed on /dev/tty openability, not isatty() — a start_new_session worker inherits the terminal on fd 0 but has no controlling tty; headless callers with a missing required secret get an actionable RuntimeError instead of a hang
- [x] HostSetupManager.check_hf_access: with no token, validate via an anonymous models-API lookup — public repos pass, gated repos fail fast with an actionable message (the models API serves gated repos' metadata anonymously, so the `gated` field is inspected rather than the HTTP status). Hardened: 30s timeout, clean error when HF is unreachable, status checked before JSON parse, success message names the repo and notes only the weights repo was checked
- [x] setup_weights_huggingface: allow an empty token — the `hf` CLI treats an empty HF_TOKEN as anonymous access; a token prompted in get_hf_env_vars is exported to os.environ for later stages
- [x] Tests: anonymous check_hf_access branch (public/gated/non-200/empty-siblings/network-error), headless get_hf_env_vars never prompts, HF_TOKEN never prompted in handle_secrets, headless missing-JWT fails cleanly; test_run_arguments.py + test_workflows.py passing (117)
- [x] Verified live: anonymous check_hf_access returns True for Qwen/Qwen3-8B and False (gated error) for meta-llama/Llama-3.1-8B-Instruct; pty repro of TT-Studio's worker spawn confirms can_prompt_interactively() is False there while isatty() is True