### PR TITLE
Document version-agnostic ULFM OpenMPI detection (MINFRA-1646)

### DIFF
--- a/tt-media-server/scripts/install_mpi4py_ulfm.sh
+++ b/tt-media-server/scripts/install_mpi4py_ulfm.sh
@@ -14,6 +14,12 @@
 # Usage:
 #   1. source your environment (e.g. source python_env/bin/activate)
 #   2. run this script: $ bash scripts/install_mpi4py_ulfm.sh
+#
+# Version-agnostic by design (MINFRA-1646): this scans /opt/*/bin/ompi_info
+# for whichever ULFM-enabled OpenMPI is actually installed, rather than
+# hardcoding a version path. When the base image's OpenMPI is bumped (e.g.
+# v5.0.7-ulfm -> v5.0.10-ulfm), this script picks up the new prefix
+# automatically and needs no change.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Part of [MINFRA-1646](https://tenstorrent.atlassian.net/browse/MINFRA-1646) — unifying OpenMPI installs across metal/exabox on 5.0.10.

Unlike [tt-llm-engine](https://github.com/tenstorrent/tt-llm-engine/pull/387) and [tt-orchestration#223](https://github.com/tenstorrent/tt-orchestration/pull/223), this repo has **no hardcoded OpenMPI version to bump** — searched all Dockerfiles and scripts here; every one either builds `FROM` tt-metal's mutable `:latest` tag, takes a prebuilt image via a build-arg, or (in `install_mpi4py_ulfm.sh`) scans `/opt/*/bin/ompi_info` at build time for whichever ULFM-enabled OpenMPI happens to be installed. So this repo already picks up 5.0.10 automatically once the base image it builds from does.

This PR is doc-only: it adds a short comment to `install_mpi4py_ulfm.sh` making that version-agnostic behavior explicit, so the next person doing an OpenMPI bump doesn't have to re-derive it.

## Related

- `images/wan-worker/Dockerfile` in tt-orchestration (a *different* repo) does pin an immutable base image tag and an `INFERENCE_SERVER_REF` commit into this repo — that one's still blocked on an unrelated issue (the pinned commit's branch was deleted after merge) and needs a WAN owner, tracked separately in [tt-orchestration#223](https://github.com/tenstorrent/tt-orchestration/pull/223).
