### PR TITLE
BlazeDecodeRunner: finish ctx-exhausted decode with `reason=length`

### DIFF
--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_decode_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_decode_runner.cpp
@@ -632,15 +632,23 @@ void BlazeDecodeRunner::handleSchedulerOutput(const ds::OutputMessage& output) {
   slotContext.lastProgressTime = std::chrono::steady_clock::now();
   auto taskId = slotContext.taskId.value();
   if (output.ctx_exhausted) {
-    TT_LOG_INFO(
+    // Context exhaustion mid-decode is a normal end of generation for OpenAI
+    // clients: everything up to this token was produced correctly, so finish
+    // the stream with FLAG_FINAL only and let the service report
+    // finish_reason="length". FLAG_ERROR here used to surface through the
+    // dynamo transport as a bare {"code":500,"message":"error"} body, which
+    // the frontend cannot parse as a completion — a fully generated answer
+    // was dropped on the floor with no server-side log above INFO.
+    TT_LOG_WARN(
         "[BlazeDecodeRunner] handleSchedulerOutput: ctx_exhausted for "
-        "slotId={}",
-        output.slot_id);
+        "taskId={}, slotId={} at position_id={} after {} generated tokens; "
+        "finishing stream with reason=length",
+        taskId, output.slot_id, output.position_id,
+        slotContext.tokensGenerated);
     slotManager.setSlotAsIdle(output.slot_id);
     metrics.decrementActiveRequests();
-    ipc::helpers::pushToken(
-        *resultQueue, taskId, output.token_id,
-        ipc::SharedToken::FLAG_ERROR | ipc::SharedToken::FLAG_FINAL, 0, 0);
+    ipc::helpers::pushToken(*resultQueue, taskId, output.token_id,
+                            ipc::SharedToken::FLAG_FINAL, 0, 0);
     return;
   }
   bool finished = output.is_complete;

--- a/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_prefill_runner.cpp
+++ b/tt-media-server/cpp_server/src/runtime/runners/blaze_runner/blaze_prefill_runner.cpp
@@ -634,6 +634,15 @@ void BlazePrefillRunner::handleSchedulerOutput(
   }
   auto taskId = slotContext.taskId.value();
   if (output.ctx_exhausted) {
+    // Prefill exhaustion means the prompt itself did not fit — unlike the
+    // decode-side case there is no partial answer to salvage, so FLAG_ERROR
+    // is correct. Log it loudly: this branch used to push the error token
+    // silently, leaving nothing in the server log to explain the client 500.
+    TT_LOG_WARN(
+        "[BlazePrefillRunner] handleSchedulerOutput: ctx_exhausted during "
+        "prefill for taskId={}, slotId={} (prompt does not fit the slot's "
+        "context); failing the request",
+        taskId, output.slot_id);
     slotManager.setSlotAsIdle(output.slot_id);
     tt::worker::SingleProcessWorkerMetrics::instance()
         .decrementActiveRequests();

--- a/tt-media-server/cpp_server/src/services/llm_service.cpp
+++ b/tt-media-server/cpp_server/src/services/llm_service.cpp
@@ -286,6 +286,16 @@ void LLMService::consumerLoopForWorker(size_t workerIdx) {
               response.choices[0].finish_reason.has_value()) {
             finalReason = response.choices[0].finish_reason.value();
           }
+          if (!finalReason.has_value()) {
+            // Parity with the text-decode path below: a final token without a
+            // finish reason is a bug upstream, and "error" here becomes a 500
+            // through the dynamo transport — make it visible.
+            TT_LOG_WARN(
+                "[Consumer-{}] Final token for task {} (skip_text_decode) "
+                "reached cleanup without a finish reason; defaulting to "
+                "\"error\"",
+                workerIdx, taskId);
+          }
           tt::metrics::ServerMetrics::instance().onRequestCompleted(
               taskId, finalReason.value_or("error"));
           streamDecoders.erase(taskId);


### PR DESCRIPTION
*Discovered as part of Gemma 4 bringup*

A decode that runs out of slot context mid-generation used to push FLAG_ERROR|FLAG_FINAL. The dynamo transport encodes an error finish as a bare {"code":500,"message":"error"} body, which the dynamo frontend cannot parse as a chat completion — so a fully generated answer (observed: 6388 tokens, 31s of decode) was dropped and surfaced to the client as a 500 "Failed to parse chat completion response", with nothing above INFO in the server log. Hit repeatedly by agentic benchmarks whose sessions reach the 128K slot-context boundary (terminal-bench trials failed as InternalServerError despite completed generations).

Context exhaustion after successful decoding is a normal OpenAI end state: finish with FLAG_FINAL only, so the service reports finish_reason="length" and the generated text is returned.

Also:
- prefill runner: keep FLAG_ERROR for prompts that never fit (nothing to salvage), but log it at WARN — this branch used to fail silently too.
- llm_service (skip_text_decode path): WARN when a final token defaults its finish reason to "error", matching the text-decode path.