### PR TITLE
remove: 256k OSL from benchmarks

### DIFF
--- a/reference_config/benchmarking/benchmark_config.py
+++ b/reference_config/benchmarking/benchmark_config.py
@@ -111,7 +111,6 @@ BENCHMARK_ISL_OSL_PAIRS = [
 # NOTE: To support future models with larger context lengths, add near-max ISL-OSL
 # pairs here; they will be automatically filtered by the per-model context cap.
 SUPER_CLUSTER_EXTRA_ISL_OSL_PAIRS = [
-    (128, 256000 - 128),
     (196608, 128),  # 192K
     (256000 - 128, 128),  # 240K
 ]


### PR DESCRIPTION
256k OSL is taking too long on benchmarks vllm sweep.
We remove them and if it is needed we can run it manually.