### PR TITLE
Onboard quetzal war-room spec tests: Qwen3.6-27B + gemma-4-31B-it + gpt-oss-120b (tool-call/reasoning conformance)

### DIFF
--- a/llm_module/test_vllm_gemma4_toolcall.py
+++ b/llm_module/test_vllm_gemma4_toolcall.py
@@ -1,0 +1,381 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""gemma-4-31B-it tool-call / reasoning-parser conformance suite.
+
+These repros are gemma-4-specific: the serving stack runs the ``gemma4``
+reasoning parser together with the ``gemma4`` tool-call parser (see the
+``google/gemma-4-31B-it`` device rows in
+``workflows/model_specs/dev/llm.yaml`` -- ``reasoning_parser_name: gemma4`` /
+``tool_call_parser_name: gemma4``, activated by ``enable-auto-tool-choice`` +
+``--tool-call-parser gemma4`` and ``--reasoning-parser gemma4`` in the QB2
+``vllm_args``). They are wired only for ``gemma_4_31b`` via
+``VLLMGemma4ToolCallTest`` and mirror the structure of
+``test_vllm_qwen36_toolcall.py`` (Qwen3.6-27B).
+
+The two conformance properties asserted here:
+
+1. **Structured tool_calls emitted** -- a thinking-enabled prompt with a tool
+   provided must stream a single, well-formed tool call: the gemma4 parser
+   emits ``finish_reason: "tool_calls"`` with a populated ``tool_calls`` array
+   whose ``arguments`` parse as JSON, even after a reasoning block. A leak of
+   gemma4's raw tool-call control tokens (``<|tool_call>`` / ``<tool_call|>``)
+   into ``content`` means the tool parser is inert (the exact defect the
+   flag-reconcile audit flagged: ``tool_call_parser`` registered but not
+   activated) -- the arguments would then be un-parseable and the assertion
+   fails.
+2. **Reasoning parser strips correctly** -- with a streaming JSON
+   ``response_format`` the gemma4 reasoning parser must keep the reasoning in
+   ``reasoning_content`` and never leak a reasoning delimiter (``<think>`` /
+   ``</think>``) or a raw tool-call control token into ``content``, so the
+   accumulated content parses as JSON.
+
+NOTE (draft wiring): serving for the quetzal war-room models is still being
+unblocked (chunked serving), so this suite is wired-but-pending-serving -- it
+is expected to run once serving works, not to pass today.
+"""
+
+import json
+import time
+
+import pytest
+import requests
+
+# --- Tool-calling + reasoning repro (gemma4 tool parser) ---
+# Weather tool; a thinking-enabled prompt that should reliably trigger a single
+# tool call after a reasoning block.
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_current_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+            },
+            "required": ["location", "unit"],
+        },
+    },
+}
+THINKING_TOOL_MESSAGES = [
+    {
+        "role": "system",
+        "content": (
+            "You must think before every response. First write at least one "
+            "sentence of reasoning, then give a concise final answer in plain text."
+        ),
+    },
+    {
+        "role": "user",
+        "content": "What is the weather like in Boston, MA in fahrenheit?",
+    },
+]
+
+# --- Streaming reasoning-parser repro (gemma4 reasoning parser) ---
+# The gemma4 reasoning parser must keep reasoning out of the content stream; a
+# leaked reasoning delimiter or raw tool-call control token means the
+# accumulated content is not valid JSON even though the request asked for a JSON
+# response_format.
+JSON_OBJECT_MESSAGES = [
+    {
+        "role": "user",
+        "content": (
+            "Return ONLY a minified JSON object with EXACTLY these keys and "
+            'constraints: {"location":string, "temperature":integer '
+            '[-100..100], "conditions":"sunny|cloudy|rainy|snowy", '
+            '"unit":"celsius", "readings":[{t:integer, ts:ISO-8601 UTC Z} x '
+            "3]}. No code fences, no extra text, no newlines. Example shape "
+            "only; fill realistic values for Boston."
+        ),
+    }
+]
+
+# gemma4 emits its reasoning through the reasoning channel and its tool calls
+# wrapped in these control tokens (serving/gemma4_vllm_tool_parser.py:
+# TOOL_CALL_START/END). ANY of these landing in ``content`` -- or a bare
+# ``<think>``/``</think>`` reasoning delimiter -- is a parser leak.
+_LEAK_MARKERS = (
+    "</think>",
+    "</think",
+    "<think>",
+    "<think",
+    "<|tool_call>",
+    "<tool_call|>",
+    "<|tool_call",
+    "tool_call|>",
+)
+
+# The failure is intermittent, so repeat each scenario a small number of times
+# to make a regression deterministic without inflating runtime.
+_TOOL_THINKING_RUNS = 20
+_JSON_STREAMING_RUNS = 4
+
+# The console ingress rate-limits back-to-back expensive streams: subsequent
+# requests are rejected (404, or a mid-stream ChunkedEncodingError) and recover
+# after a rolling window. Space the START of each run at least this many seconds
+# after the previous run's start (gap-aware), and retry a rate-limited run this
+# many times before giving up.
+_JSON_STREAMING_MIN_GAP_S = 120
+_JSON_STREAMING_MAX_RETRIES = 3
+
+
+def _stream_chat_completion(api_client, payload):
+    """Send a streaming chat-completion and reconstruct the single choice.
+
+    Returns a dict with the accumulated ``reasoning_content``, ``content``, the
+    ordered list of raw ``content_deltas``, aggregated ``tool_calls`` (indexed
+    by their delta index), and the terminal ``finish_reason``. Raises the
+    underlying HTTPError so callers can distinguish an unsupported request from
+    a bad completion.
+    """
+    response = api_client(payload, stream=True, timeout=120)
+
+    reasoning_parts = []
+    content_parts = []
+    tool_calls = {}
+    finish_reason = None
+
+    for line in response.iter_lines(decode_unicode=True):
+        if not line or not line.startswith("data: "):
+            continue
+        data = line[len("data: ") :]
+        if data.strip() == "[DONE]":
+            break
+        chunk = json.loads(data)
+        choices = chunk.get("choices") or []
+        if not choices:
+            continue
+        choice = choices[0]
+        delta = choice.get("delta") or {}
+
+        if delta.get("reasoning_content"):
+            reasoning_parts.append(delta["reasoning_content"])
+        if delta.get("content"):
+            content_parts.append(delta["content"])
+
+        for tc in delta.get("tool_calls") or []:
+            idx = tc.get("index", 0)
+            slot = tool_calls.setdefault(idx, {"name": "", "arguments": ""})
+            fn = tc.get("function") or {}
+            if fn.get("name"):
+                slot["name"] = fn["name"]
+            if fn.get("arguments"):
+                slot["arguments"] += fn["arguments"]
+
+        if choice.get("finish_reason"):
+            finish_reason = choice["finish_reason"]
+
+    return {
+        "reasoning_content": "".join(reasoning_parts),
+        "content": "".join(content_parts),
+        "content_deltas": content_parts,
+        "tool_calls": tool_calls,
+        "finish_reason": finish_reason,
+    }
+
+
+def _find_reasoning_leak(content):
+    """Return the reasoning/tool control token that leaked into ``content``.
+
+    The parser can split a marker across deltas, so the check is run against
+    the *joined* content. Any marker landing in content is a leak.
+    """
+    for marker in _LEAK_MARKERS:
+        if marker in content:
+            return marker
+    return None
+
+
+def _is_rate_limit_error(exc):
+    """Return True when an exception looks like a transient ingress rate-limit.
+
+    The console ingress rejects excess streaming requests as ``404`` (observed)
+    or ``429``, or cuts the stream mid-flight so ``requests`` raises a
+    ``ChunkedEncodingError``. All are transient and should be retried rather
+    than counted as a parser failure. Auth errors (401/403) are NOT rate-limits.
+    """
+    if isinstance(exc, requests.exceptions.ChunkedEncodingError):
+        return True
+    msg = str(exc)
+    return "404" in msg or "429" in msg or "Response ended prematurely" in msg
+
+
+def _stream_one_run_with_backoff(api_client, base_payload, run_idx, prev_start):
+    """Run a single streaming attempt, spacing and retrying around rate-limits.
+
+    Returns ``(result, start_ts)`` where ``start_ts`` is when the successful
+    attempt began (so the next run can be spaced relative to it). Auth errors
+    (401/403) and unsupported-payload errors propagate to the caller (the
+    latter as ``pytest.skip`` -- the model does not support the payload).
+    """
+    if prev_start is not None:
+        remaining = _JSON_STREAMING_MIN_GAP_S - (time.monotonic() - prev_start)
+        if remaining > 0:
+            print(
+                f"[run {run_idx}] waiting {remaining:.0f}s before next run "
+                "to stay under the ingress rate-limit..."
+            )
+            time.sleep(remaining)
+
+    attempt = 0
+    while True:
+        start_ts = time.monotonic()
+        try:
+            result = _stream_chat_completion(api_client, base_payload)
+            return result, start_ts
+        except (
+            requests.exceptions.HTTPError,
+            requests.exceptions.ChunkedEncodingError,
+        ) as e:
+            if _is_rate_limit_error(e):
+                if attempt >= _JSON_STREAMING_MAX_RETRIES:
+                    pytest.skip(
+                        f"[run {run_idx}] rate-limited/truncated after "
+                        f"{attempt} retries ({e}); the ingress limit did not "
+                        "clear within the retry budget -- infra flake, not a "
+                        "parser failure."
+                    )
+                attempt += 1
+                print(
+                    f"[run {run_idx}] transient rate-limit/truncation "
+                    f"({type(e).__name__}); retry {attempt}/"
+                    f"{_JSON_STREAMING_MAX_RETRIES} after "
+                    f"{_JSON_STREAMING_MIN_GAP_S}s..."
+                )
+                time.sleep(_JSON_STREAMING_MIN_GAP_S)
+                continue
+            msg = str(e)
+            if "401" in msg or "403" in msg:
+                raise
+            pytest.skip(
+                "Server rejected the streaming tool-call/response_format "
+                f"payload; model likely does not support this path: {e}"
+            )
+
+
+def test_streaming_tool_call_with_thinking(report_test, api_client, request):
+    """gemma4: streaming + tools + enable_thinking must emit the tool call.
+
+    A correctly-behaving host emits ``finish_reason: "tool_calls"`` with a
+    populated ``tool_calls`` array on every run, even after a reasoning block,
+    and the tool call's ``arguments`` must parse as JSON and target the provided
+    tool. The test runs the repro multiple times and fails if ANY run drops the
+    tool call, leaks gemma4's raw ``<|tool_call>`` control tokens into content,
+    or emits unparseable arguments.
+    """
+    base_payload = {
+        "messages": THINKING_TOOL_MESSAGES,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "temperature": 1,
+        "top_p": 1,
+        "max_tokens": 4096,
+        "tools": [WEATHER_TOOL],
+        "chat_template_kwargs": {"enable_thinking": True},
+    }
+
+    results = []
+    prev_start = None
+    for i in range(_TOOL_THINKING_RUNS):
+        result, prev_start = _stream_one_run_with_backoff(
+            api_client, base_payload, i, prev_start
+        )
+        results.append(result)
+
+    failures = []
+    for i, result in enumerate(results):
+        has_tool_call = any(slot["name"] for slot in result["tool_calls"].values())
+        # A raw tool-call control token in content means the gemma4 tool parser
+        # never fired (registered-but-inert) -- catch it explicitly.
+        leak = _find_reasoning_leak(result["content"])
+        if result["finish_reason"] != "tool_calls" or not has_tool_call or leak:
+            failures.append(
+                f"run {i}: finish_reason={result['finish_reason']!r}, "
+                f"tool_calls={result['tool_calls']!r}, "
+                f"content_leak={leak!r}, "
+                f"reasoning_len={len(result['reasoning_content'])}, "
+                f"content={result['content']!r}"
+            )
+            continue
+        # Structured-arguments conformance: gemma4 must emit tool-call
+        # arguments that parse as a JSON object.
+        first_call = next(iter(result["tool_calls"].values()))
+        try:
+            json.loads(first_call["arguments"])
+        except (json.JSONDecodeError, ValueError):
+            failures.append(
+                f"run {i}: tool_call arguments not valid JSON: "
+                f"{first_call['arguments']!r}"
+            )
+
+    assert not failures, (
+        f"{len(failures)}/{len(results)} streaming runs failed the "
+        "tool-call conformance (expected finish_reason='tool_calls' with a "
+        "populated tool_calls array whose arguments parse as JSON on every "
+        "run, and no raw <|tool_call> control token leaking into content). "
+        "Failing runs:\n" + "\n".join(failures)
+    )
+
+    # Sanity-check the emitted tool call targets the provided tool.
+    first = results[0]
+    first_call = next(iter(first["tool_calls"].values()))
+    assert first_call["name"] == WEATHER_TOOL["function"]["name"], (
+        f"Expected tool call '{WEATHER_TOOL['function']['name']}', "
+        f"got '{first_call['name']}'."
+    )
+
+
+def test_streaming_json_object_no_reasoning_leak(report_test, api_client, request):
+    """gemma4 reasoning parser: streaming json_object must not leak reasoning.
+
+    With ``response_format: {"type": "json_object"}`` and ``stream: true`` the
+    reasoning tokens and any tool-call control token must stay out of the
+    content stream, so the accumulated content parses as JSON. The test fails if
+    ANY run leaks a reasoning/tool marker into content or the content does not
+    parse as JSON.
+    """
+    base_payload = {
+        "messages": JSON_OBJECT_MESSAGES,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "temperature": 1,
+        "top_p": 1,
+        "max_tokens": 8192,
+        "response_format": {"type": "json_object"},
+        "chat_template_kwargs": {"enable_thinking": True},
+    }
+
+    failures = []
+    completed = 0
+    prev_start = None
+    for i in range(_JSON_STREAMING_RUNS):
+        result, prev_start = _stream_one_run_with_backoff(
+            api_client, base_payload, i, prev_start
+        )
+        completed += 1
+        content = result["content"]
+        leak = _find_reasoning_leak(content)
+        try:
+            json.loads(content)
+            content_valid_json = True
+        except (json.JSONDecodeError, ValueError):
+            content_valid_json = False
+        ok = leak is None and content_valid_json
+        detail = (
+            f"reasoning_leak={leak!r}, content_valid_json={content_valid_json}, "
+            f"first_content_deltas={result['content_deltas'][:6]!r}, "
+            f"content={content!r}"
+        )
+        print(f"[run {i}] {'OK' if ok else 'LEAK/INVALID'}: {detail}")
+        if not ok:
+            failures.append(f"run {i}: {detail}")
+
+    assert not failures, (
+        f"{len(failures)}/{completed} streaming runs leaked reasoning / a "
+        "tool-call control token into content or produced invalid JSON "
+        "(expected reasoning to stay in reasoning_content and content to be a "
+        "clean, parseable JSON object). Failing runs:\n" + "\n".join(failures)
+    )

--- a/llm_module/test_vllm_gptoss120b_toolcall.py
+++ b/llm_module/test_vllm_gptoss120b_toolcall.py
@@ -1,0 +1,381 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""gpt-oss-120b tool-call / reasoning-parser conformance suite.
+
+These repros are gpt-oss-specific: the serving stack runs the
+``openai_gptoss`` reasoning parser together with the ``openai`` tool-call
+parser (see the ``openai/gpt-oss-120b`` device rows in
+``workflows/model_specs/dev/llm.yaml`` -- ``reasoning_parser_name:
+openai_gptoss`` / ``tool_call_parser_name: openai``). gpt-oss emits a Harmony
+transcript -- ``<|channel|>analysis<|message|>...<|channel|>final<|message|>
+...`` -- and only the final channel is the answer; the reasoning parser routes
+the analysis channel to ``reasoning_content``. They are wired only for
+``gpt_oss_120b`` via ``VLLMGptOss120bToolCallTest`` and mirror the structure of
+``test_vllm_qwen36_toolcall.py`` (Qwen3.6-27B).
+
+The two conformance properties asserted here:
+
+1. **Structured tool_calls emitted** -- a prompt with a tool provided must
+   stream a single, well-formed tool call: the openai tool parser emits
+   ``finish_reason: "tool_calls"`` with a populated ``tool_calls`` array whose
+   ``arguments`` parse as JSON, even after a Harmony analysis channel. A leak of
+   Harmony control tokens (``<|channel|>`` / ``<|message|>`` / ``<|start|>`` /
+   ``<|end|>``) into ``content`` means the reasoning/tool parsers are inert (the
+   exact defect the flag-reconcile audit flagged) -- the arguments would then be
+   un-parseable and the assertion fails.
+2. **Reasoning parser strips correctly** -- with a streaming JSON
+   ``response_format`` the openai_gptoss reasoning parser must keep the analysis
+   channel in ``reasoning_content`` and never leak a Harmony control token into
+   ``content``, so the accumulated content parses as JSON.
+
+NOTE (draft wiring): serving for the quetzal war-room models is still being
+unblocked (chunked serving), so this suite is wired-but-pending-serving -- it
+is expected to run once serving works, not to pass today.
+"""
+
+import json
+import time
+
+import pytest
+import requests
+
+# --- Tool-calling + reasoning repro (openai tool parser) ---
+# Weather tool; a prompt that should reliably trigger a single tool call after
+# gpt-oss's Harmony analysis channel.
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_current_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+            },
+            "required": ["location", "unit"],
+        },
+    },
+}
+THINKING_TOOL_MESSAGES = [
+    {
+        "role": "system",
+        "content": (
+            "You must think before every response. First reason briefly, then "
+            "give a concise final answer in plain text."
+        ),
+    },
+    {
+        "role": "user",
+        "content": "What is the weather like in Boston, MA in fahrenheit?",
+    },
+]
+
+# --- Streaming reasoning-parser repro (openai_gptoss reasoning parser) ---
+# The openai_gptoss reasoning parser must keep the Harmony analysis channel out
+# of the content stream; a leaked Harmony control token means the accumulated
+# content is not valid JSON even though the request asked for a JSON
+# response_format.
+JSON_OBJECT_MESSAGES = [
+    {
+        "role": "user",
+        "content": (
+            "Return ONLY a minified JSON object with EXACTLY these keys and "
+            'constraints: {"location":string, "temperature":integer '
+            '[-100..100], "conditions":"sunny|cloudy|rainy|snowy", '
+            '"unit":"celsius", "readings":[{t:integer, ts:ISO-8601 UTC Z} x '
+            "3]}. No code fences, no extra text, no newlines. Example shape "
+            "only; fill realistic values for Boston."
+        ),
+    }
+]
+
+# gpt-oss routes its analysis channel to reasoning_content; the Harmony control
+# tokens delimit the channelled transcript (serving/reasoning.py: CHANNEL_OPEN /
+# CHANNEL_MESSAGE, plus the start/end/return message-boundary tokens). ANY of
+# these landing in ``content`` is a parser leak. "analysis"/"final" are the
+# channel *names* but are ordinary English words, so they are intentionally NOT
+# leak markers (they would false-positive on normal prose).
+_LEAK_MARKERS = (
+    "<|channel|>",
+    "<|message|>",
+    "<|start|>",
+    "<|end|>",
+    "<|return|>",
+    "<|constrain|>",
+    "<|channel",
+    "<|message",
+)
+
+# The failure is intermittent, so repeat each scenario a small number of times
+# to make a regression deterministic without inflating runtime.
+_TOOL_THINKING_RUNS = 20
+_JSON_STREAMING_RUNS = 4
+
+# The console ingress rate-limits back-to-back expensive streams: subsequent
+# requests are rejected (404, or a mid-stream ChunkedEncodingError) and recover
+# after a rolling window. Space the START of each run at least this many seconds
+# after the previous run's start (gap-aware), and retry a rate-limited run this
+# many times before giving up.
+_JSON_STREAMING_MIN_GAP_S = 120
+_JSON_STREAMING_MAX_RETRIES = 3
+
+
+def _stream_chat_completion(api_client, payload):
+    """Send a streaming chat-completion and reconstruct the single choice.
+
+    Returns a dict with the accumulated ``reasoning_content``, ``content``, the
+    ordered list of raw ``content_deltas``, aggregated ``tool_calls`` (indexed
+    by their delta index), and the terminal ``finish_reason``. Raises the
+    underlying HTTPError so callers can distinguish an unsupported request from
+    a bad completion.
+    """
+    response = api_client(payload, stream=True, timeout=120)
+
+    reasoning_parts = []
+    content_parts = []
+    tool_calls = {}
+    finish_reason = None
+
+    for line in response.iter_lines(decode_unicode=True):
+        if not line or not line.startswith("data: "):
+            continue
+        data = line[len("data: ") :]
+        if data.strip() == "[DONE]":
+            break
+        chunk = json.loads(data)
+        choices = chunk.get("choices") or []
+        if not choices:
+            continue
+        choice = choices[0]
+        delta = choice.get("delta") or {}
+
+        if delta.get("reasoning_content"):
+            reasoning_parts.append(delta["reasoning_content"])
+        if delta.get("content"):
+            content_parts.append(delta["content"])
+
+        for tc in delta.get("tool_calls") or []:
+            idx = tc.get("index", 0)
+            slot = tool_calls.setdefault(idx, {"name": "", "arguments": ""})
+            fn = tc.get("function") or {}
+            if fn.get("name"):
+                slot["name"] = fn["name"]
+            if fn.get("arguments"):
+                slot["arguments"] += fn["arguments"]
+
+        if choice.get("finish_reason"):
+            finish_reason = choice["finish_reason"]
+
+    return {
+        "reasoning_content": "".join(reasoning_parts),
+        "content": "".join(content_parts),
+        "content_deltas": content_parts,
+        "tool_calls": tool_calls,
+        "finish_reason": finish_reason,
+    }
+
+
+def _find_reasoning_leak(content):
+    """Return the Harmony control token that leaked into ``content``, if any.
+
+    The parser can split a marker across deltas, so the check is run against
+    the *joined* content. Any marker landing in content is a leak.
+    """
+    for marker in _LEAK_MARKERS:
+        if marker in content:
+            return marker
+    return None
+
+
+def _is_rate_limit_error(exc):
+    """Return True when an exception looks like a transient ingress rate-limit.
+
+    The console ingress rejects excess streaming requests as ``404`` (observed)
+    or ``429``, or cuts the stream mid-flight so ``requests`` raises a
+    ``ChunkedEncodingError``. All are transient and should be retried rather
+    than counted as a parser failure. Auth errors (401/403) are NOT rate-limits.
+    """
+    if isinstance(exc, requests.exceptions.ChunkedEncodingError):
+        return True
+    msg = str(exc)
+    return "404" in msg or "429" in msg or "Response ended prematurely" in msg
+
+
+def _stream_one_run_with_backoff(api_client, base_payload, run_idx, prev_start):
+    """Run a single streaming attempt, spacing and retrying around rate-limits.
+
+    Returns ``(result, start_ts)`` where ``start_ts`` is when the successful
+    attempt began (so the next run can be spaced relative to it). Auth errors
+    (401/403) and unsupported-payload errors propagate to the caller (the
+    latter as ``pytest.skip`` -- the model does not support the payload).
+    """
+    if prev_start is not None:
+        remaining = _JSON_STREAMING_MIN_GAP_S - (time.monotonic() - prev_start)
+        if remaining > 0:
+            print(
+                f"[run {run_idx}] waiting {remaining:.0f}s before next run "
+                "to stay under the ingress rate-limit..."
+            )
+            time.sleep(remaining)
+
+    attempt = 0
+    while True:
+        start_ts = time.monotonic()
+        try:
+            result = _stream_chat_completion(api_client, base_payload)
+            return result, start_ts
+        except (
+            requests.exceptions.HTTPError,
+            requests.exceptions.ChunkedEncodingError,
+        ) as e:
+            if _is_rate_limit_error(e):
+                if attempt >= _JSON_STREAMING_MAX_RETRIES:
+                    pytest.skip(
+                        f"[run {run_idx}] rate-limited/truncated after "
+                        f"{attempt} retries ({e}); the ingress limit did not "
+                        "clear within the retry budget -- infra flake, not a "
+                        "parser failure."
+                    )
+                attempt += 1
+                print(
+                    f"[run {run_idx}] transient rate-limit/truncation "
+                    f"({type(e).__name__}); retry {attempt}/"
+                    f"{_JSON_STREAMING_MAX_RETRIES} after "
+                    f"{_JSON_STREAMING_MIN_GAP_S}s..."
+                )
+                time.sleep(_JSON_STREAMING_MIN_GAP_S)
+                continue
+            msg = str(e)
+            if "401" in msg or "403" in msg:
+                raise
+            pytest.skip(
+                "Server rejected the streaming tool-call/response_format "
+                f"payload; model likely does not support this path: {e}"
+            )
+
+
+def test_streaming_tool_call_with_thinking(report_test, api_client, request):
+    """openai tool parser: streaming + tools must emit the tool call.
+
+    A correctly-behaving host emits ``finish_reason: "tool_calls"`` with a
+    populated ``tool_calls`` array on every run, even after a Harmony analysis
+    channel, and the tool call's ``arguments`` must parse as JSON and target the
+    provided tool. The test runs the repro multiple times and fails if ANY run
+    drops the tool call, leaks a Harmony control token into content, or emits
+    unparseable arguments.
+    """
+    base_payload = {
+        "messages": THINKING_TOOL_MESSAGES,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "temperature": 1,
+        "top_p": 1,
+        "max_tokens": 4096,
+        "tools": [WEATHER_TOOL],
+    }
+
+    results = []
+    prev_start = None
+    for i in range(_TOOL_THINKING_RUNS):
+        result, prev_start = _stream_one_run_with_backoff(
+            api_client, base_payload, i, prev_start
+        )
+        results.append(result)
+
+    failures = []
+    for i, result in enumerate(results):
+        has_tool_call = any(slot["name"] for slot in result["tool_calls"].values())
+        # A raw Harmony control token in content means the reasoning/tool
+        # parsers never fired (registered-but-inert) -- catch it explicitly.
+        leak = _find_reasoning_leak(result["content"])
+        if result["finish_reason"] != "tool_calls" or not has_tool_call or leak:
+            failures.append(
+                f"run {i}: finish_reason={result['finish_reason']!r}, "
+                f"tool_calls={result['tool_calls']!r}, "
+                f"content_leak={leak!r}, "
+                f"reasoning_len={len(result['reasoning_content'])}, "
+                f"content={result['content']!r}"
+            )
+            continue
+        # Structured-arguments conformance: the openai parser must emit
+        # tool-call arguments that parse as a JSON object.
+        first_call = next(iter(result["tool_calls"].values()))
+        try:
+            json.loads(first_call["arguments"])
+        except (json.JSONDecodeError, ValueError):
+            failures.append(
+                f"run {i}: tool_call arguments not valid JSON: "
+                f"{first_call['arguments']!r}"
+            )
+
+    assert not failures, (
+        f"{len(failures)}/{len(results)} streaming runs failed the "
+        "tool-call conformance (expected finish_reason='tool_calls' with a "
+        "populated tool_calls array whose arguments parse as JSON on every "
+        "run, and no Harmony control token leaking into content). "
+        "Failing runs:\n" + "\n".join(failures)
+    )
+
+    # Sanity-check the emitted tool call targets the provided tool.
+    first = results[0]
+    first_call = next(iter(first["tool_calls"].values()))
+    assert first_call["name"] == WEATHER_TOOL["function"]["name"], (
+        f"Expected tool call '{WEATHER_TOOL['function']['name']}', "
+        f"got '{first_call['name']}'."
+    )
+
+
+def test_streaming_json_object_no_reasoning_leak(report_test, api_client, request):
+    """openai_gptoss reasoning parser: streaming json_object must not leak.
+
+    With ``response_format: {"type": "json_object"}`` and ``stream: true`` the
+    Harmony analysis channel and every Harmony control token must stay out of
+    the content stream, so the accumulated content parses as JSON. The test
+    fails if ANY run leaks a Harmony control token into content or the content
+    does not parse as JSON.
+    """
+    base_payload = {
+        "messages": JSON_OBJECT_MESSAGES,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "temperature": 1,
+        "top_p": 1,
+        "max_tokens": 8192,
+        "response_format": {"type": "json_object"},
+    }
+
+    failures = []
+    completed = 0
+    prev_start = None
+    for i in range(_JSON_STREAMING_RUNS):
+        result, prev_start = _stream_one_run_with_backoff(
+            api_client, base_payload, i, prev_start
+        )
+        completed += 1
+        content = result["content"]
+        leak = _find_reasoning_leak(content)
+        try:
+            json.loads(content)
+            content_valid_json = True
+        except (json.JSONDecodeError, ValueError):
+            content_valid_json = False
+        ok = leak is None and content_valid_json
+        detail = (
+            f"reasoning_leak={leak!r}, content_valid_json={content_valid_json}, "
+            f"first_content_deltas={result['content_deltas'][:6]!r}, "
+            f"content={content!r}"
+        )
+        print(f"[run {i}] {'OK' if ok else 'LEAK/INVALID'}: {detail}")
+        if not ok:
+            failures.append(f"run {i}: {detail}")
+
+    assert not failures, (
+        f"{len(failures)}/{completed} streaming runs leaked the Harmony "
+        "analysis channel / a control token into content or produced invalid "
+        "JSON (expected reasoning to stay in reasoning_content and content to "
+        "be a clean, parseable JSON object). Failing runs:\n"
+        + "\n".join(failures)
+    )

--- a/llm_module/test_vllm_gptoss120b_toolcall.py
+++ b/llm_module/test_vllm_gptoss120b_toolcall.py
@@ -376,6 +376,5 @@ def test_streaming_json_object_no_reasoning_leak(report_test, api_client, reques
         f"{len(failures)}/{completed} streaming runs leaked the Harmony "
         "analysis channel / a control token into content or produced invalid "
         "JSON (expected reasoning to stay in reasoning_content and content to "
-        "be a clean, parseable JSON object). Failing runs:\n"
-        + "\n".join(failures)
+        "be a clean, parseable JSON object). Failing runs:\n" + "\n".join(failures)
     )

--- a/llm_module/test_vllm_qwen36_toolcall.py
+++ b/llm_module/test_vllm_qwen36_toolcall.py
@@ -1,0 +1,358 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Qwen3.6-27B tool-call / reasoning-parser conformance suite.
+
+These repros are Qwen3.6-specific: the serving stack runs the ``qwen3``
+reasoning parser together with the ``qwen3_coder`` tool-call parser
+(see the ``Qwen/Qwen3.6-27B`` device rows in
+``workflows/model_specs/dev/llm.yaml``). They are wired only for
+``qwen36_27b`` via ``VLLMQwen36ToolCallTest`` and mirror the structure of
+``test_vllm_qwen3_streaming.py`` (Qwen3-32B).
+
+The two conformance properties asserted here:
+
+1. **Structured tool_calls emitted** -- a thinking-enabled prompt with a tool
+   provided must stream a single, well-formed tool call: the qwen3_coder parser
+   emits ``finish_reason: "tool_calls"`` with a populated ``tool_calls`` array
+   whose ``arguments`` parse as JSON, even after a ``<think>`` reasoning block.
+2. **Reasoning parser strips correctly** -- with a streaming JSON
+   ``response_format`` the qwen3 reasoning parser must keep the reasoning in
+   ``reasoning_content`` and never leak the ``</think>`` close tag (or trailing
+   reasoning tokens) into ``content``, so the accumulated content parses as JSON.
+
+NOTE (draft wiring): Qwen chunked serving is still being unblocked, so this
+suite is wired-but-pending-serving -- it is expected to run once serving works,
+not to pass today.
+"""
+
+import json
+import time
+
+import pytest
+import requests
+
+# --- Tool-calling + reasoning repro (qwen3_coder tool parser) ---
+# Weather tool; a thinking-enabled prompt that should reliably trigger a single
+# tool call after a reasoning block.
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_current_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+            },
+            "required": ["location", "unit"],
+        },
+    },
+}
+THINKING_TOOL_MESSAGES = [
+    {
+        "role": "system",
+        "content": (
+            "You must think before every response. First write at least one "
+            "sentence of reasoning, then give a concise final answer in plain text."
+        ),
+    },
+    {
+        "role": "user",
+        "content": "What is the weather like in Boston, MA in fahrenheit?",
+    },
+]
+
+# --- Streaming reasoning-parser repro (qwen3 reasoning parser) ---
+# The qwen3 reasoning parser must keep reasoning out of the content stream; a
+# leaked ``</think>`` close tag (observed split across deltas, e.g. ``'<'`` +
+# ``'/think>{'``) means the accumulated content is not valid JSON even though
+# the request asked for a JSON response_format.
+JSON_OBJECT_MESSAGES = [
+    {
+        "role": "user",
+        "content": (
+            "Return ONLY a minified JSON object with EXACTLY these keys and "
+            'constraints: {"location":string, "temperature":integer '
+            '[-100..100], "conditions":"sunny|cloudy|rainy|snowy", '
+            '"unit":"celsius", "readings":[{t:integer, ts:ISO-8601 UTC Z} x '
+            "3]}. No code fences, no extra text, no newlines. Example shape "
+            "only; fill realistic values for Boston."
+        ),
+    }
+]
+
+# The failure is intermittent, so repeat each scenario a small number of times
+# to make a regression deterministic without inflating runtime.
+_TOOL_THINKING_RUNS = 20
+_JSON_STREAMING_RUNS = 4
+
+# The console ingress rate-limits back-to-back expensive streams: subsequent
+# requests are rejected (404, or a mid-stream ChunkedEncodingError) and recover
+# after a rolling window. Space the START of each run at least this many seconds
+# after the previous run's start (gap-aware), and retry a rate-limited run this
+# many times before giving up.
+_JSON_STREAMING_MIN_GAP_S = 120
+_JSON_STREAMING_MAX_RETRIES = 3
+
+
+def _stream_chat_completion(api_client, payload):
+    """Send a streaming chat-completion and reconstruct the single choice.
+
+    Returns a dict with the accumulated ``reasoning_content``, ``content``, the
+    ordered list of raw ``content_deltas``, aggregated ``tool_calls`` (indexed
+    by their delta index), and the terminal ``finish_reason``. Raises the
+    underlying HTTPError so callers can distinguish an unsupported request from
+    a bad completion.
+    """
+    response = api_client(payload, stream=True, timeout=120)
+
+    reasoning_parts = []
+    content_parts = []
+    tool_calls = {}
+    finish_reason = None
+
+    for line in response.iter_lines(decode_unicode=True):
+        if not line or not line.startswith("data: "):
+            continue
+        data = line[len("data: ") :]
+        if data.strip() == "[DONE]":
+            break
+        chunk = json.loads(data)
+        choices = chunk.get("choices") or []
+        if not choices:
+            continue
+        choice = choices[0]
+        delta = choice.get("delta") or {}
+
+        if delta.get("reasoning_content"):
+            reasoning_parts.append(delta["reasoning_content"])
+        if delta.get("content"):
+            content_parts.append(delta["content"])
+
+        for tc in delta.get("tool_calls") or []:
+            idx = tc.get("index", 0)
+            slot = tool_calls.setdefault(idx, {"name": "", "arguments": ""})
+            fn = tc.get("function") or {}
+            if fn.get("name"):
+                slot["name"] = fn["name"]
+            if fn.get("arguments"):
+                slot["arguments"] += fn["arguments"]
+
+        if choice.get("finish_reason"):
+            finish_reason = choice["finish_reason"]
+
+    return {
+        "reasoning_content": "".join(reasoning_parts),
+        "content": "".join(content_parts),
+        "content_deltas": content_parts,
+        "tool_calls": tool_calls,
+        "finish_reason": finish_reason,
+    }
+
+
+def _find_think_leak(content):
+    """Return the ``</think>`` variant that leaked into ``content``, if any.
+
+    The reasoning parser can split the close tag across deltas, so the check is
+    run against the *joined* content. Any of the tag or its partial forms
+    landing in content is a leak.
+    """
+    for marker in ("</think>", "</think", "<think>", "<think"):
+        if marker in content:
+            return marker
+    return None
+
+
+def _is_rate_limit_error(exc):
+    """Return True when an exception looks like a transient ingress rate-limit.
+
+    The console ingress rejects excess streaming requests as ``404`` (observed)
+    or ``429``, or cuts the stream mid-flight so ``requests`` raises a
+    ``ChunkedEncodingError``. All are transient and should be retried rather
+    than counted as a parser failure. Auth errors (401/403) are NOT rate-limits.
+    """
+    if isinstance(exc, requests.exceptions.ChunkedEncodingError):
+        return True
+    msg = str(exc)
+    return "404" in msg or "429" in msg or "Response ended prematurely" in msg
+
+
+def _stream_one_run_with_backoff(api_client, base_payload, run_idx, prev_start):
+    """Run a single streaming attempt, spacing and retrying around rate-limits.
+
+    Returns ``(result, start_ts)`` where ``start_ts`` is when the successful
+    attempt began (so the next run can be spaced relative to it). Auth errors
+    (401/403) and unsupported-payload errors propagate to the caller (the
+    latter as ``pytest.skip`` -- the model does not support the payload).
+    """
+    if prev_start is not None:
+        remaining = _JSON_STREAMING_MIN_GAP_S - (time.monotonic() - prev_start)
+        if remaining > 0:
+            print(
+                f"[run {run_idx}] waiting {remaining:.0f}s before next run "
+                "to stay under the ingress rate-limit..."
+            )
+            time.sleep(remaining)
+
+    attempt = 0
+    while True:
+        start_ts = time.monotonic()
+        try:
+            result = _stream_chat_completion(api_client, base_payload)
+            return result, start_ts
+        except (
+            requests.exceptions.HTTPError,
+            requests.exceptions.ChunkedEncodingError,
+        ) as e:
+            if _is_rate_limit_error(e):
+                if attempt >= _JSON_STREAMING_MAX_RETRIES:
+                    pytest.skip(
+                        f"[run {run_idx}] rate-limited/truncated after "
+                        f"{attempt} retries ({e}); the ingress limit did not "
+                        "clear within the retry budget -- infra flake, not a "
+                        "parser failure."
+                    )
+                attempt += 1
+                print(
+                    f"[run {run_idx}] transient rate-limit/truncation "
+                    f"({type(e).__name__}); retry {attempt}/"
+                    f"{_JSON_STREAMING_MAX_RETRIES} after "
+                    f"{_JSON_STREAMING_MIN_GAP_S}s..."
+                )
+                time.sleep(_JSON_STREAMING_MIN_GAP_S)
+                continue
+            msg = str(e)
+            if "401" in msg or "403" in msg:
+                raise
+            pytest.skip(
+                "Server rejected the streaming tool-call/response_format "
+                f"payload; model likely does not support this path: {e}"
+            )
+
+
+def test_streaming_tool_call_with_thinking(report_test, api_client, request):
+    """qwen3_coder: streaming + tools + enable_thinking must emit the tool call.
+
+    A correctly-behaving host emits ``finish_reason: "tool_calls"`` with a
+    populated ``tool_calls`` array on every run, even after a ``<think>`` block,
+    and the tool call's ``arguments`` must parse as JSON and target the provided
+    tool. The test runs the repro multiple times and fails if ANY run drops the
+    tool call or emits unparseable arguments.
+    """
+    base_payload = {
+        "messages": THINKING_TOOL_MESSAGES,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "temperature": 1,
+        "top_p": 1,
+        "max_tokens": 4096,
+        "tools": [WEATHER_TOOL],
+        "chat_template_kwargs": {"thinking": True, "enable_thinking": True},
+    }
+
+    results = []
+    prev_start = None
+    for i in range(_TOOL_THINKING_RUNS):
+        result, prev_start = _stream_one_run_with_backoff(
+            api_client, base_payload, i, prev_start
+        )
+        results.append(result)
+
+    failures = []
+    for i, result in enumerate(results):
+        has_tool_call = any(slot["name"] for slot in result["tool_calls"].values())
+        if result["finish_reason"] != "tool_calls" or not has_tool_call:
+            failures.append(
+                f"run {i}: finish_reason={result['finish_reason']!r}, "
+                f"tool_calls={result['tool_calls']!r}, "
+                f"reasoning_len={len(result['reasoning_content'])}, "
+                f"content={result['content']!r}"
+            )
+            continue
+        # Structured-arguments conformance: qwen3_coder must emit tool-call
+        # arguments that parse as a JSON object.
+        first_call = next(iter(result["tool_calls"].values()))
+        try:
+            json.loads(first_call["arguments"])
+        except (json.JSONDecodeError, ValueError):
+            failures.append(
+                f"run {i}: tool_call arguments not valid JSON: "
+                f"{first_call['arguments']!r}"
+            )
+
+    assert not failures, (
+        f"{len(failures)}/{len(results)} streaming runs failed the "
+        "tool-call conformance (expected finish_reason='tool_calls' with a "
+        "populated tool_calls array whose arguments parse as JSON on every "
+        "run). Failing runs:\n" + "\n".join(failures)
+    )
+
+    # Sanity-check the emitted tool call targets the provided tool.
+    first = results[0]
+    first_call = next(iter(first["tool_calls"].values()))
+    assert first_call["name"] == WEATHER_TOOL["function"]["name"], (
+        f"Expected tool call '{WEATHER_TOOL['function']['name']}', "
+        f"got '{first_call['name']}'."
+    )
+
+
+def test_streaming_json_object_no_reasoning_leak(report_test, api_client, request):
+    """qwen3 reasoning parser: streaming json_object must not leak reasoning.
+
+    With ``response_format: {"type": "json_object"}`` and ``stream: true`` the
+    trailing reasoning tokens and the literal ``</think>`` close tag must stay
+    in ``reasoning_content`` and never appear as ``content`` deltas, so the
+    accumulated content parses as JSON. The test fails if ANY run leaks the
+    ``</think>`` tag into content or the content does not parse as JSON.
+    """
+    base_payload = {
+        "messages": JSON_OBJECT_MESSAGES,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "temperature": 1,
+        "repetition_penalty": 1,
+        "top_p": 1,
+        "stop": ["<|im_start|>", "<|im_end|>"],
+        "seed": None,
+        "min_p": 0,
+        "max_tokens": 8192,
+        "top_a": 0,
+        "frequency_penalty": 0,
+        "presence_penalty": 0,
+        "response_format": {"type": "json_object"},
+    }
+
+    failures = []
+    completed = 0
+    prev_start = None
+    for i in range(_JSON_STREAMING_RUNS):
+        result, prev_start = _stream_one_run_with_backoff(
+            api_client, base_payload, i, prev_start
+        )
+        completed += 1
+        content = result["content"]
+        leak = _find_think_leak(content)
+        try:
+            json.loads(content)
+            content_valid_json = True
+        except (json.JSONDecodeError, ValueError):
+            content_valid_json = False
+        ok = leak is None and content_valid_json
+        detail = (
+            f"think_leak={leak!r}, content_valid_json={content_valid_json}, "
+            f"first_content_deltas={result['content_deltas'][:6]!r}, "
+            f"content={content!r}"
+        )
+        print(f"[run {i}] {'OK' if ok else 'LEAK/INVALID'}: {detail}")
+        if not ok:
+            failures.append(f"run {i}: {detail}")
+
+    assert not failures, (
+        f"{len(failures)}/{completed} streaming runs leaked reasoning / a "
+        "</think> tag into content or produced invalid JSON (expected "
+        "reasoning to stay in reasoning_content and content to be a clean, "
+        "parseable JSON object). Failing runs:\n" + "\n".join(failures)
+    )

--- a/reference_config/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/reference_config/benchmarking/benchmark_targets/model_performance_reference.json
@@ -1,4 +1,41 @@
 {
+    "Qwen3.6-27B": {
+        "p300x2": [
+            {
+                "_comment": [
+                    "PLACEHOLDER theoretical skeleton for the Qwen3.6-27B",
+                    "(impl=qwen36_blackhole) EXPERIMENTAL onboarding. status is",
+                    "EXPERIMENTAL so benchmarks are not strictly required; this",
+                    "theoretical block exists only so a later status bump is",
+                    "unblocked. Numbers are mirrored from the same-device,",
+                    "same-class conc=1 isl/osl=128 anchor points (Qwen3-32B and",
+                    "gemma-4-31b-it both sit at ttft_ms=46, tput_user=37, tput=37",
+                    "on p300x2) and are NOT a measured or independently derived",
+                    "ceiling for this 27B model -- replace with real silicon",
+                    "measurement before grading against it.",
+                    "The functional(0.10)/complete(0.50)/target(1.0) status",
+                    "thresholds are NOT stored here: they come from the ModelSpec",
+                    "perf_targets_map default (workflows/model_spec.py) and can be",
+                    "loosened per device via perf_targets_map in the device YAML."
+                ],
+                "isl": 128,
+                "osl": 128,
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "task_type": "text",
+                "image_height": null,
+                "image_width": null,
+                "images_per_prompt": null,
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 46,
+                        "tput_user": 37,
+                        "tput": 37
+                    }
+                }
+            }
+        ]
+    },
     "gemma-4-31b-it": {
         "p300x2": [
             {

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -1843,6 +1843,33 @@ _eval_config_list = [
         hf_model_repo="Qwen/Qwen3.6-27B",
         tasks=[
             EvalTask(
+                # Second catalogue eval for Qwen3.6-27B (the onboarding
+                # checklist requires >=2 tasks); mirrors the gsm8k lane the
+                # nkapre/quetzal-swe-unified branch adds for this model,
+                # adapted to this branch's EvalTask API (that branch's
+                # chat_template_kwargs field does not exist here yet, so it is
+                # omitted). A bounded chat-API GSM8K collection lane: the
+                # reasoning plus visible final answer needs headroom, so
+                # max_gen_toks is 2048 (a silicon discriminator showed 768
+                # truncated 9/10 responses). This is a bounded collection task
+                # until a statistically useful TT/GPU baseline is recorded; it
+                # carries no published/reference score of its own -- the graded
+                # published/reference fields live on terminal_bench_2 below.
+                task_name="gsm8k",
+                workflow_venv_type=WorkflowVenvType.EVALS_COMMON,
+                use_chat_api=True,
+                max_concurrent=1,
+                gen_kwargs={
+                    "max_gen_toks": 2048,
+                    "do_sample": "false",
+                    "stream": "false",
+                },
+                limit_samples_map={
+                    EvalLimitMode.CI_NIGHTLY: 10,
+                    EvalLimitMode.SMOKE_TEST: 1,
+                },
+            ),
+            EvalTask(
                 task_name="terminal_bench_2",
                 workflow_venv_type=WorkflowVenvType.EVALS_AGENTIC,
                 score=EvalTaskScore(

--- a/test_module/llm_tests/vllm_param_conformance_test.py
+++ b/test_module/llm_tests/vllm_param_conformance_test.py
@@ -294,6 +294,24 @@ class VLLMQwen36ToolCallTest(VLLMParamConformanceTest):
     REPORT_TASK_NAME = "vllm_qwen36_toolcall"
 
 
+class VLLMGemma4ToolCallTest(VLLMParamConformanceTest):
+    """Run the gemma-4-31B-it tool-call / reasoning-parser regression suite."""
+
+    KIND = "vllm_gemma4_toolcall"
+    PYTEST_FILENAME = "test_vllm_gemma4_toolcall.py"
+    ENDPOINT_PATH = "/v1/chat/completions"
+    REPORT_TASK_NAME = "vllm_gemma4_toolcall"
+
+
+class VLLMGptOss120bToolCallTest(VLLMParamConformanceTest):
+    """Run the gpt-oss-120b tool-call / reasoning-parser regression suite."""
+
+    KIND = "vllm_gptoss120b_toolcall"
+    PYTEST_FILENAME = "test_vllm_gptoss120b_toolcall.py"
+    ENDPOINT_PATH = "/v1/chat/completions"
+    REPORT_TASK_NAME = "vllm_gptoss120b_toolcall"
+
+
 class VLLMDiffusionGemmaParamConformanceTest(VLLMParamConformanceTest):
     """Run DiffusionGemma's block-serving and admission regression suite."""
 

--- a/test_module/llm_tests/vllm_param_conformance_test.py
+++ b/test_module/llm_tests/vllm_param_conformance_test.py
@@ -285,6 +285,15 @@ class VLLMQwen3StreamingParamConformanceTest(VLLMParamConformanceTest):
     REPORT_TASK_NAME = "vllm_qwen3_streaming"
 
 
+class VLLMQwen36ToolCallTest(VLLMParamConformanceTest):
+    """Run the Qwen3.6-27B tool-call / reasoning-parser regression suite."""
+
+    KIND = "vllm_qwen36_toolcall"
+    PYTEST_FILENAME = "test_vllm_qwen36_toolcall.py"
+    ENDPOINT_PATH = "/v1/chat/completions"
+    REPORT_TASK_NAME = "vllm_qwen36_toolcall"
+
+
 class VLLMDiffusionGemmaParamConformanceTest(VLLMParamConformanceTest):
     """Run DiffusionGemma's block-serving and admission regression suite."""
 

--- a/test_module/server_tests_config.json
+++ b/test_module/server_tests_config.json
@@ -41,6 +41,8 @@
         "LLM": [
             "Qwen3-32B",
             "Qwen3.6-27B",
+            "gemma-4-31B-it",
+            "gpt-oss-120b",
             "Llama-3.1-8B-Instruct",
             "Llama-3.3-70B-Instruct",
             "gpt-oss-20b",
@@ -411,7 +413,28 @@
             "category": "LLM",
             "compatible_devices": [
                 "p300x2",
-                "p150x8"
+                "p150x8",
+                "p150x4"
+            ]
+        },
+        "gemma_4_31b": {
+            "id_name": "gemma-4-31b-it",
+            "weights": [
+                "gemma-4-31B-it"
+            ],
+            "category": "LLM",
+            "compatible_devices": [
+                "p300x2"
+            ]
+        },
+        "gpt_oss_120b": {
+            "id_name": "gpt-oss-120b",
+            "weights": [
+                "gpt-oss-120b"
+            ],
+            "category": "LLM",
+            "compatible_devices": [
+                "p300x2"
             ]
         },
         "llama_70b_family": {
@@ -922,6 +945,36 @@
             }
         },
         "VLLMQwen36ToolCallTest": {
+            "module": "test_module.llm_tests.vllm_param_conformance_test",
+            "markers": [
+                "param",
+                "e2e",
+                "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 0,
+                "retry_delay": 10,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "VLLMGemma4ToolCallTest": {
+            "module": "test_module.llm_tests.vllm_param_conformance_test",
+            "markers": [
+                "param",
+                "e2e",
+                "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 0,
+                "retry_delay": 10,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "VLLMGptOss120bToolCallTest": {
             "module": "test_module.llm_tests.vllm_param_conformance_test",
             "markers": [
                 "param",

--- a/test_module/server_tests_config.json
+++ b/test_module/server_tests_config.json
@@ -40,6 +40,7 @@
         ],
         "LLM": [
             "Qwen3-32B",
+            "Qwen3.6-27B",
             "Llama-3.1-8B-Instruct",
             "Llama-3.3-70B-Instruct",
             "gpt-oss-20b",
@@ -400,6 +401,17 @@
                 "galaxy_t3k",
                 "p150x8",
                 "p300x2"
+            ]
+        },
+        "qwen36_27b": {
+            "id_name": "qwen3.6-27b",
+            "weights": [
+                "Qwen3.6-27B"
+            ],
+            "category": "LLM",
+            "compatible_devices": [
+                "p300x2",
+                "p150x8"
             ]
         },
         "llama_70b_family": {
@@ -895,6 +907,21 @@
             }
         },
         "VLLMQwen3StreamingParamConformanceTest": {
+            "module": "test_module.llm_tests.vllm_param_conformance_test",
+            "markers": [
+                "param",
+                "e2e",
+                "slow"
+            ],
+            "test_config": {
+                "test_timeout": 3600,
+                "retry_attempts": 0,
+                "retry_delay": 10,
+                "break_on_failure": false,
+                "mock_mode": false
+            }
+        },
+        "VLLMQwen36ToolCallTest": {
             "module": "test_module.llm_tests.vllm_param_conformance_test",
             "markers": [
                 "param",

--- a/test_module/test_suites/llm.json
+++ b/test_module/test_suites/llm.json
@@ -6,6 +6,8 @@
             "models": [
                 "qwen3_32b",
                 "qwen36_27b",
+                "gemma_4_31b",
+                "gpt_oss_120b",
                 "llama_3_1_8b",
                 "llama_70b_family",
                 "gpt_oss_20b"
@@ -73,13 +75,45 @@
                 "qwen36_27b"
             ],
             "devices": [
-                "p300x2"
+                "p300x2",
+                "p150x8",
+                "p150x4"
             ],
             "test_cases": [
                 {
                     "template": "VLLMQwen36ToolCallTest",
                     "enabled": true,
                     "description": "Qwen3.6-27B tool-call / reasoning-parser regressions"
+                }
+            ]
+        },
+        {
+            "models": [
+                "gemma_4_31b"
+            ],
+            "devices": [
+                "p300x2"
+            ],
+            "test_cases": [
+                {
+                    "template": "VLLMGemma4ToolCallTest",
+                    "enabled": true,
+                    "description": "gemma-4-31B-it tool-call / reasoning-parser regressions"
+                }
+            ]
+        },
+        {
+            "models": [
+                "gpt_oss_120b"
+            ],
+            "devices": [
+                "p300x2"
+            ],
+            "test_cases": [
+                {
+                    "template": "VLLMGptOss120bToolCallTest",
+                    "enabled": true,
+                    "description": "gpt-oss-120b tool-call / reasoning-parser regressions"
                 }
             ]
         },

--- a/test_module/test_suites/llm.json
+++ b/test_module/test_suites/llm.json
@@ -5,6 +5,7 @@
         {
             "models": [
                 "qwen3_32b",
+                "qwen36_27b",
                 "llama_3_1_8b",
                 "llama_70b_family",
                 "gpt_oss_20b"
@@ -64,6 +65,21 @@
                     "template": "VLLMQwen3StreamingParamConformanceTest",
                     "enabled": true,
                     "description": "Qwen3-32B streaming reasoning/tool-call regressions"
+                }
+            ]
+        },
+        {
+            "models": [
+                "qwen36_27b"
+            ],
+            "devices": [
+                "p300x2"
+            ],
+            "test_cases": [
+                {
+                    "template": "VLLMQwen36ToolCallTest",
+                    "enabled": true,
+                    "description": "Qwen3.6-27B tool-call / reasoning-parser regressions"
                 }
             ]
         },


### PR DESCRIPTION
## What

Checklist-compliant onboarding of **Qwen3.6-27B** (impl `qwen36_blackhole`, status `EXPERIMENTAL`) to the tt-inference-server catalogue and spec-test framework, per the "new model checklist". Turns the out-of-band Slurm proofs into the checklist's prescribed file wiring.

**DRAFT wiring:** Qwen chunked serving is still being unblocked, so the live spec tests are **wired-but-pending-serving** — they are ready to run once serving works and are *not* expected to pass yet. No test-pass claims are made here.

## The 4-file checklist

**Step 1 — `workflows/model_specs/dev/llm.yaml`:** already present on `main` (Qwen3.6-27B, EXPERIMENTAL, device rows P300X2 / P150X8 / P150X4). Confirmed, no change. (Note: the entry uses impl `qwen36_blackhole`, not the `quetzal` label the checklist text used — left as-is to avoid an out-of-scope impl rename.)

**Step 2 — `reference_config/evals/eval_config.py`:** added a second eval task (`gsm8k`) to the Qwen3.6-27B `EvalConfig` so it meets the `>=2` tasks requirement. Reconciled with the `nkapre/quetzal-swe-unified` branch's gsm8k lane and adapted to this branch's `EvalTask` API (that branch's `chat_template_kwargs` field does not exist here, so it is omitted — no framework changes duplicated). Graded published/reference scores stay on `terminal_bench_2` (published 59.3 / gpu_ref 53.9).

**Step 3 — `reference_config/benchmarking/benchmark_targets/model_performance_reference.json`:** added a `Qwen3.6-27B` / `p300x2` **theoretical** target skeleton (placeholder mirrored from the same-device, same-class conc=1 anchor — Qwen3-32B and gemma-4-31b-it both sit at ttft 46 / tput_user 37 / tput 37 on p300x2). Since status is EXPERIMENTAL benchmarks are not strictly required; the skeleton unblocks a later status bump. functional(0.10)/complete(0.50)/target(1.0) thresholds come from the default `perf_targets_map`, not this file.

**Step 4 — Spec tests (Scenario B):**
- `test_module/server_tests_config.json`: `model_configs.qwen36_27b` (compatible_devices p300x2, p150x8), `Qwen3.6-27B` appended to `model_categories.LLM`, and the `VLLMQwen36ToolCallTest` template.
- `test_module/llm_tests/vllm_param_conformance_test.py`: `VLLMQwen36ToolCallTest(VLLMParamConformanceTest)` — a thin subclass mirroring `VLLMQwen3StreamingParamConformanceTest` (KIND `vllm_qwen36_toolcall`, endpoint `/v1/chat/completions`).
- `test_module/test_suites/llm.json`: **additive** — `qwen36_27b` appended to the shared `VLLMParamConformanceTest` matrix (so it keeps shared coverage on p300x2 + p150x8) **plus** an exclusive `VLLMQwen36ToolCallTest` matrix on p300x2.
- `llm_module/test_vllm_qwen36_toolcall.py`: the pytest — qwen3_coder tool-call conformance (structured `tool_calls` emitted with JSON-parseable arguments after a `<think>` block) + qwen3 reasoning-parser strip (no `</think>` leak into content).

## Static validation
- `python -m json.tool` on all 3 edited JSON files — OK
- `py_compile` on the two python files + eval_config — OK
- `suite_loader.load_suite_files()` expands `qwen36_27b` to **3 suites**: shared `VLLMParamConformanceTest` on p300x2 and p150x8, exclusive `VLLMQwen36ToolCallTest` on p300x2
- `eval_config` imports; Qwen3.6-27B now has 2 tasks; perf map resolves to functional 3.7 / complete 18.5 / target 37.0

Do **not** merge — draft pending serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — extend spec tests to gemma-4-31B-it + gpt-oss-120b (all three war-room models)

Completes the **final "Done when" checklist item (spec tests)** for the two
remaining quetzal models, so all three (Qwen3.6-27B, gemma-4-31B-it,
gpt-oss-120b) now carry conformance + tool-call/reasoning-parser coverage. Also
fixes a fail-open device-string gap the audit caught.

### Spec-test classes added (mirror `VLLMQwen36ToolCallTest`)
- **`VLLMGemma4ToolCallTest`** → `llm_module/test_vllm_gemma4_toolcall.py` —
  real parsers per `dev/llm.yaml`: reasoning `gemma4`, tool `gemma4`. Leak
  markers include gemma4's raw tool-call control tokens `<|tool_call>` /
  `<tool_call|>`.
- **`VLLMGptOss120bToolCallTest`** → `llm_module/test_vllm_gptoss120b_toolcall.py`
  — reasoning `openai_gptoss`, tool `openai`. Leak markers are the Harmony
  control tokens `<|channel|>` / `<|message|>` / `<|start|>` / `<|end|>`.

Each validates **structured `tool_calls` on `/v1/chat/completions`** (arguments
parse as JSON) **AND** that the reasoning parser keeps reasoning in
`reasoning_content` without leaking its control tokens into `content` — the
same defect (tool_call_parser registered-but-inert) the Qwen suite targets.

### Additive matrix wiring (`test_module/test_suites/llm.json`)
- `gemma_4_31b` + `gpt_oss_120b` appended to the **shared**
  `VLLMParamConformanceTest` matrix models (kept on p300x2).
- One **exclusive** tool-call matrix each: `VLLMGemma4ToolCallTest` /p300x2 and
  `VLLMGptOss120bToolCallTest` / p300x2.

### Device-string reconcile (audit's key catch — VERIFIED, not guessed)
The ttis spec-test runner matches on **`ctx.device.name.lower()`**
(`test_module/dispatch.py` → `TestFilter.filter_by_device`, exact
case-insensitive compare) — i.e. the `DeviceTypes` enum name of the **launched
catalogue device row**. For QB2:
- gemma / gpt: only a `P300X2` catalogue row exists (MESH_DEVICE `P150x4` is
  internal), so the runner emits **`p300x2`** — `compatible_devices = [p300x2]`.
- Qwen3.6-27B: three catalogue rows → runner can emit **`p300x2` / `p150x8` /
  `p150x4`**. Its `compatible_devices` previously omitted `p150x4`, so a
  `p150x4` launch **silently NO-MATCHed** (fail-open). **Added `p150x4`** to
  `qwen36_27b` `compatible_devices` and its tool-call matrix devices so no QB2
  launch mode is dropped.

### `server_tests_config.json`
`model_configs.gemma_4_31b` + `model_configs.gpt_oss_120b`,
`model_categories.LLM += gemma-4-31B-it, gpt-oss-120b`, and the two
`test_templates` (`VLLMGemma4ToolCallTest`, `VLLMGptOss120bToolCallTest`).

### Static validation
- `python -m json.tool` on both edited JSON — OK; `py_compile` on the two new
  pytests + the conformance module — OK.
- `suite_loader.load_suite_files_by_category("llm")` expands: **Qwen3.6-27B → 6
  suites** (shared + tool-call on each of p300x2/p150x8/p150x4), **gemma-4-31B-it
  → 2** (shared + tool-call on p300x2), **gpt-oss-120b → 2** (shared + tool-call
  on p300x2).
- Runtime `TestFilter().filter_by_model(m).filter_by_device(d)` matches (no
  NO-MATCH) for every (model, QB2-device) pair, resolving to the correct
  template modules.
- 15 `tests/test_module/test_matrix_expansion.py` unit tests pass.

Still **wired-but-pending-serving** (chunked serving blocked) — do **not** merge.

### Side finding (reported, not fixed here — out of this repo)
`tt-quetzalcoatlus/serving/serve_vllm_openai.sh` launches the vLLM server with
`--model / --max_num_seqs / --block_size / --max-model-len / --port /
--additional-config` (+ optional `--served-model-name`) and **passes neither
`--enable-auto-tool-choice` nor `--tool-call-parser` (nor `--reasoning-parser`)**
— so on *that* script's path the tool/reasoning parsers are inert. The canonical
ttis path activates them via `vllm_args` in `dev/llm.yaml`, so these spec tests
exercise the correct (parser-on) configuration.
