### PR TITLE
Count thought delimiters as KV rows in the multi-turn resume position

### DIFF
--- a/tt-media-server/cpp_server/CMakeLists.txt
+++ b/tt-media-server/cpp_server/CMakeLists.txt
@@ -1282,6 +1282,17 @@ target_include_directories(prefix_cache_router_test PRIVATE
     ${prometheus-cpp_SOURCE_DIR}/core/include
 )
 
+add_executable(gemma4_think_position_test
+    tests/unit/services/gemma4_think_position_test.cpp
+    src/domain/prefix_cache/block_matcher.cpp
+)
+target_link_libraries(gemma4_think_position_test PRIVATE
+    llm_runner_lib Drogon::Drogon prometheus-cpp::core GTest::gtest_main)
+target_include_directories(gemma4_think_position_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${prometheus-cpp_SOURCE_DIR}/core/include
+)
+
 add_executable(mock_remote_kv_manager_test
     tests/unit/services/mock_remote_kv_manager_test.cpp
     src/services/mock_remote_kv_manager.cpp
@@ -1596,6 +1607,7 @@ gtest_discover_tests(worker_metrics_shm_test)
 gtest_discover_tests(concurrent_map_test)
 gtest_discover_tests(session_test)
 gtest_discover_tests(prefix_cache_router_test)
+gtest_discover_tests(gemma4_think_position_test)
 gtest_discover_tests(session_manager_test)
 gtest_discover_tests(worker_manager_test)
 gtest_discover_tests(llm_service_test)

--- a/tt-media-server/cpp_server/include/utils/conversation_hasher.hpp
+++ b/tt-media-server/cpp_server/include/utils/conversation_hasher.hpp
@@ -93,7 +93,7 @@ std::string renderLastUserTurn(const std::vector<ChatMessage>& messages,
 struct BlockHashInfo {
   uint64_t hash;
   uint32_t
-      accumulatedThinkTokens;  // Thinking content tokens (excluding markers)
+      accumulatedThinkTokens;  // KV rows used by thinking, markers included
 };
 
 /**
@@ -178,7 +178,8 @@ std::vector<uint64_t> getPrefixCacheHashesByBlocks(
  *
  * Thinking tokens (content between thinkStartId and thinkEndId markers) are
  * excluded from the hash computation but their count is tracked. The markers
- * themselves are also excluded from both the hash and the count.
+ * are excluded from the hash too, but ARE counted: the count feeds a KV
+ * position, and a marker occupies a row like any other token.
  *
  * Uses the same marker state machine as session tracking to classify tokens as
  * thinking or non-thinking.

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -90,10 +90,12 @@ void Session::addGeneratedToken(uint32_t tokenId) {
 
   if (tokenId == thinkStartTokenId_) {
     inThinkingBlock_ = true;
+    ++accumulatedThinkTokens_;  // Marker occupies a KV row
   } else if (tokenId == thinkEndTokenId_) {
     inThinkingBlock_ = false;
+    ++accumulatedThinkTokens_;  // Marker occupies a KV row
   } else if (inThinkingBlock_) {
-    ++accumulatedThinkTokens_;  // Only content tokens, not markers
+    ++accumulatedThinkTokens_;
   }
 }
 

--- a/tt-media-server/cpp_server/src/utils/conversation_hasher.cpp
+++ b/tt-media-server/cpp_server/src/utils/conversation_hasher.cpp
@@ -208,11 +208,13 @@ std::vector<BlockHashInfo> getPrefixCacheHashesByBlocksWithThinking(
       // Mirror the session-side think marker state machine.
       if (token == thinkStartId) {
         inThinking = true;
-        continue;  // Skip marker, don't count
+        ++thinkCount;  // Marker occupies a KV row
+        continue;      // Skip marker, don't hash
       }
       if (token == thinkEndId) {
         inThinking = false;
-        continue;  // Skip marker, don't count
+        ++thinkCount;  // Marker occupies a KV row
+        continue;      // Skip marker, don't hash
       }
       if (inThinking) {
         ++thinkCount;  // Count content token, don't hash

--- a/tt-media-server/cpp_server/tests/unit/services/gemma4_think_position_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/services/gemma4_think_position_test.cpp
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+// The resume position a cached turn is continued from is
+//     matchedTokens + accumulatedThinkTokens          (llm_pipeline.cpp)
+// and it must equal the number of KV rows the matched prefix occupies.
+//
+// Thought delimiters are excluded from the block hash, which is correct: they
+// are structure, and templates that strip thinking from the re-rendered history
+// (gemma-4, deepseek-r1) do not carry them in the next prompt. But they are
+// ordinary generated tokens and each occupies a KV row, so they must be counted.
+// Before the fix they were excluded from both, leaving the resume position short
+// by two rows per thought block and compounding over a conversation.
+//
+// Host-only: token ids, hashing and block arithmetic, no device.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+#include "domain/prefix_cache/block_matcher.hpp"
+#include "utils/conversation_hasher.hpp"
+#include "utils/tokenizers/tokenizer.hpp"
+
+namespace {
+
+constexpr uint32_t kBlockSize = 32;
+constexpr uint32_t kContentBase = 1000;  // ordinary tokens, far from the markers
+
+class Gemma4ThinkPositionTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    // modelType() and the block sizes cache on first use.
+    setenv("MODEL", "google/gemma-4-31B-it", 1);
+    setenv("LLM_MODE", "regular", 1);
+    setenv("KV_CACHE_FIRST_BLOCK_SIZE", "32", 1);
+    setenv("KV_CACHE_BLOCK_SIZE", "32", 1);
+  }
+};
+
+TEST_F(Gemma4ThinkPositionTest, ThoughtChannelDelimitersAreTheThinkTokenPair) {
+  const auto [thinkStart, thinkEnd] = tt::utils::tokenizers::thinkTokenIds();
+  EXPECT_EQ(thinkStart, 100u) << "<|channel>";
+  EXPECT_EQ(thinkEnd, 101u) << "<channel|>";
+}
+
+TEST_F(Gemma4ThinkPositionTest, ResumePositionMatchesResidentKvRows) {
+  const auto [thinkStart, thinkEnd] = tt::utils::tokenizers::thinkTokenIds();
+
+  // 128 visible tokens = exactly 4 blocks at 32/32, so no partial-block
+  // remainder muddies the arithmetic.
+  constexpr uint32_t kVisible = 4 * kBlockSize;
+  constexpr uint32_t kThinkContent = 10;
+  constexpr uint32_t kMarkers = 2;
+
+  std::vector<uint32_t> tokens;
+  uint32_t next = kContentBase;
+  for (uint32_t i = 0; i < 40; ++i) tokens.push_back(next++);
+  tokens.push_back(thinkStart);
+  for (uint32_t i = 0; i < kThinkContent; ++i) tokens.push_back(next++);
+  tokens.push_back(thinkEnd);
+  for (uint32_t i = 0; i < kVisible - 40; ++i) tokens.push_back(next++);
+
+  const auto blocks = tt::utils::getPrefixCacheHashesByBlocksWithThinking(
+      tokens, thinkStart, thinkEnd);
+  ASSERT_FALSE(blocks.empty());
+
+  const uint32_t matchedTokens =
+      tt::domain::prefix_cache::BlockMatcher::blocksToTokens(blocks.size());
+  const uint32_t thinkRows = blocks.back().accumulatedThinkTokens;
+
+  EXPECT_EQ(matchedTokens, kVisible) << "markers and thinking stay out of the hash";
+  EXPECT_EQ(thinkRows, kThinkContent + kMarkers) << "delimiters occupy rows too";
+  EXPECT_EQ(matchedTokens + thinkRows, tokens.size())
+      << "resume position must equal the rows the prefix occupies";
+}
+
+TEST_F(Gemma4ThinkPositionTest, DriftDoesNotAccumulateAcrossThoughtBlocks) {
+  const auto [thinkStart, thinkEnd] = tt::utils::tokenizers::thinkTokenIds();
+  constexpr uint32_t kVisiblePerTurn = 2 * kBlockSize;
+  constexpr uint32_t kThinkPerTurn = 8;
+
+  for (uint32_t turns : {1u, 2u, 3u, 8u}) {
+    std::vector<uint32_t> tokens;
+    uint32_t next = kContentBase;
+    for (uint32_t t = 0; t < turns; ++t) {
+      for (uint32_t i = 0; i < kVisiblePerTurn; ++i) tokens.push_back(next++);
+      tokens.push_back(thinkStart);
+      for (uint32_t i = 0; i < kThinkPerTurn; ++i) tokens.push_back(next++);
+      tokens.push_back(thinkEnd);
+    }
+
+    const auto blocks = tt::utils::getPrefixCacheHashesByBlocksWithThinking(
+        tokens, thinkStart, thinkEnd);
+    ASSERT_FALSE(blocks.empty());
+    const uint32_t resume =
+        tt::domain::prefix_cache::BlockMatcher::blocksToTokens(blocks.size()) +
+        blocks.back().accumulatedThinkTokens;
+
+    EXPECT_EQ(resume, tokens.size())
+        << "after " << turns << " thought block(s) the resume position is short by "
+        << (tokens.size() - resume) << " row(s)";
+  }
+}
+
+// Thinking disabled: no markers, no correction, position is the token count.
+TEST_F(Gemma4ThinkPositionTest, NoThinkingLeavesTheCountAtZero) {
+  std::vector<uint32_t> tokens;
+  for (uint32_t i = 0; i < 4 * kBlockSize; ++i) tokens.push_back(kContentBase + i);
+
+  const auto blocks = tt::utils::getPrefixCacheHashesByBlocksWithThinking(
+      tokens, tt::utils::tokenizers::kNoTokenId,
+      tt::utils::tokenizers::kNoTokenId);
+  ASSERT_FALSE(blocks.empty());
+  EXPECT_EQ(blocks.back().accumulatedThinkTokens, 0u);
+  EXPECT_EQ(tt::domain::prefix_cache::BlockMatcher::blocksToTokens(blocks.size()),
+            tokens.size());
+}
+
+}  // namespace

--- a/tt-media-server/cpp_server/tests/unit/services/gemma4_think_position_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/services/gemma4_think_position_test.cpp
@@ -27,8 +27,8 @@
 
 namespace {
 
-constexpr uint32_t kBlockSize = 32;
-constexpr uint32_t kContentBase =
+constexpr uint32_t K_BLOCK_SIZE = 32;
+constexpr uint32_t K_CONTENT_BASE =
     1000;  // ordinary tokens, far from the markers
 
 class Gemma4ThinkPositionTest : public ::testing::Test {
@@ -53,12 +53,12 @@ TEST_F(Gemma4ThinkPositionTest, ResumePositionMatchesResidentKvRows) {
 
   // 128 visible tokens = exactly 4 blocks at 32/32, so no partial-block
   // remainder muddies the arithmetic.
-  constexpr uint32_t kVisible = 4 * kBlockSize;
+  constexpr uint32_t kVisible = 4 * K_BLOCK_SIZE;
   constexpr uint32_t kThinkContent = 10;
   constexpr uint32_t kMarkers = 2;
 
   std::vector<uint32_t> tokens;
-  uint32_t next = kContentBase;
+  uint32_t next = K_CONTENT_BASE;
   for (uint32_t i = 0; i < 40; ++i) tokens.push_back(next++);
   tokens.push_back(thinkStart);
   for (uint32_t i = 0; i < kThinkContent; ++i) tokens.push_back(next++);
@@ -83,7 +83,7 @@ TEST_F(Gemma4ThinkPositionTest, ResumePositionMatchesResidentKvRows) {
 
 TEST_F(Gemma4ThinkPositionTest, DriftDoesNotAccumulateAcrossThoughtBlocks) {
   const auto [thinkStart, thinkEnd] = tt::utils::tokenizers::thinkTokenIds();
-  constexpr uint32_t kVisiblePerTurn = 2 * kBlockSize;
+  constexpr uint32_t kVisiblePerTurn = 2 * K_BLOCK_SIZE;
   constexpr uint32_t kThinkPerTurn = 8;
   constexpr uint32_t kMarkers = 2;
 
@@ -93,7 +93,7 @@ TEST_F(Gemma4ThinkPositionTest, DriftDoesNotAccumulateAcrossThoughtBlocks) {
   // reaches the same shape because the visible tokens of later turns follow it.
   for (uint32_t turns : {1u, 2u, 3u, 8u}) {
     std::vector<uint32_t> tokens;
-    uint32_t next = kContentBase;
+    uint32_t next = K_CONTENT_BASE;
     for (uint32_t t = 0; t < turns; ++t) {
       tokens.push_back(thinkStart);
       for (uint32_t i = 0; i < kThinkPerTurn; ++i) tokens.push_back(next++);
@@ -120,8 +120,8 @@ TEST_F(Gemma4ThinkPositionTest, DriftDoesNotAccumulateAcrossThoughtBlocks) {
 // Thinking disabled: no markers, no correction, position is the token count.
 TEST_F(Gemma4ThinkPositionTest, NoThinkingLeavesTheCountAtZero) {
   std::vector<uint32_t> tokens;
-  for (uint32_t i = 0; i < 4 * kBlockSize; ++i)
-    tokens.push_back(kContentBase + i);
+  for (uint32_t i = 0; i < 4 * K_BLOCK_SIZE; ++i)
+    tokens.push_back(K_CONTENT_BASE + i);
 
   const auto blocks = tt::utils::getPrefixCacheHashesByBlocksWithThinking(
       tokens, tt::utils::tokenizers::kNoTokenId,

--- a/tt-media-server/cpp_server/tests/unit/services/gemma4_think_position_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/services/gemma4_think_position_test.cpp
@@ -8,9 +8,10 @@
 // Thought delimiters are excluded from the block hash, which is correct: they
 // are structure, and templates that strip thinking from the re-rendered history
 // (gemma-4, deepseek-r1) do not carry them in the next prompt. But they are
-// ordinary generated tokens and each occupies a KV row, so they must be counted.
-// Before the fix they were excluded from both, leaving the resume position short
-// by two rows per thought block and compounding over a conversation.
+// ordinary generated tokens and each occupies a KV row, so they must be
+// counted. Before the fix they were excluded from both, leaving the resume
+// position short by two rows per thought block and compounding over a
+// conversation.
 //
 // Host-only: token ids, hashing and block arithmetic, no device.
 
@@ -27,7 +28,8 @@
 namespace {
 
 constexpr uint32_t kBlockSize = 32;
-constexpr uint32_t kContentBase = 1000;  // ordinary tokens, far from the markers
+constexpr uint32_t kContentBase =
+    1000;  // ordinary tokens, far from the markers
 
 class Gemma4ThinkPositionTest : public ::testing::Test {
  protected:
@@ -71,8 +73,10 @@ TEST_F(Gemma4ThinkPositionTest, ResumePositionMatchesResidentKvRows) {
       tt::domain::prefix_cache::BlockMatcher::blocksToTokens(blocks.size());
   const uint32_t thinkRows = blocks.back().accumulatedThinkTokens;
 
-  EXPECT_EQ(matchedTokens, kVisible) << "markers and thinking stay out of the hash";
-  EXPECT_EQ(thinkRows, kThinkContent + kMarkers) << "delimiters occupy rows too";
+  EXPECT_EQ(matchedTokens, kVisible)
+      << "markers and thinking stay out of the hash";
+  EXPECT_EQ(thinkRows, kThinkContent + kMarkers)
+      << "delimiters occupy rows too";
   EXPECT_EQ(matchedTokens + thinkRows, tokens.size())
       << "resume position must equal the rows the prefix occupies";
 }
@@ -81,15 +85,20 @@ TEST_F(Gemma4ThinkPositionTest, DriftDoesNotAccumulateAcrossThoughtBlocks) {
   const auto [thinkStart, thinkEnd] = tt::utils::tokenizers::thinkTokenIds();
   constexpr uint32_t kVisiblePerTurn = 2 * kBlockSize;
   constexpr uint32_t kThinkPerTurn = 8;
+  constexpr uint32_t kMarkers = 2;
 
+  // A block records the think count as it stood when the block completed, and a
+  // partial trailing block is never hashed -- so thinking must precede the last
+  // boundary to be represented. Put it at the head of each turn; a real stream
+  // reaches the same shape because the visible tokens of later turns follow it.
   for (uint32_t turns : {1u, 2u, 3u, 8u}) {
     std::vector<uint32_t> tokens;
     uint32_t next = kContentBase;
     for (uint32_t t = 0; t < turns; ++t) {
-      for (uint32_t i = 0; i < kVisiblePerTurn; ++i) tokens.push_back(next++);
       tokens.push_back(thinkStart);
       for (uint32_t i = 0; i < kThinkPerTurn; ++i) tokens.push_back(next++);
       tokens.push_back(thinkEnd);
+      for (uint32_t i = 0; i < kVisiblePerTurn; ++i) tokens.push_back(next++);
     }
 
     const auto blocks = tt::utils::getPrefixCacheHashesByBlocksWithThinking(
@@ -99,8 +108,11 @@ TEST_F(Gemma4ThinkPositionTest, DriftDoesNotAccumulateAcrossThoughtBlocks) {
         tt::domain::prefix_cache::BlockMatcher::blocksToTokens(blocks.size()) +
         blocks.back().accumulatedThinkTokens;
 
+    EXPECT_EQ(blocks.back().accumulatedThinkTokens,
+              turns * (kThinkPerTurn + kMarkers));
     EXPECT_EQ(resume, tokens.size())
-        << "after " << turns << " thought block(s) the resume position is short by "
+        << "after " << turns
+        << " thought block(s) the resume position is short by "
         << (tokens.size() - resume) << " row(s)";
   }
 }
@@ -108,15 +120,17 @@ TEST_F(Gemma4ThinkPositionTest, DriftDoesNotAccumulateAcrossThoughtBlocks) {
 // Thinking disabled: no markers, no correction, position is the token count.
 TEST_F(Gemma4ThinkPositionTest, NoThinkingLeavesTheCountAtZero) {
   std::vector<uint32_t> tokens;
-  for (uint32_t i = 0; i < 4 * kBlockSize; ++i) tokens.push_back(kContentBase + i);
+  for (uint32_t i = 0; i < 4 * kBlockSize; ++i)
+    tokens.push_back(kContentBase + i);
 
   const auto blocks = tt::utils::getPrefixCacheHashesByBlocksWithThinking(
       tokens, tt::utils::tokenizers::kNoTokenId,
       tt::utils::tokenizers::kNoTokenId);
   ASSERT_FALSE(blocks.empty());
   EXPECT_EQ(blocks.back().accumulatedThinkTokens, 0u);
-  EXPECT_EQ(tt::domain::prefix_cache::BlockMatcher::blocksToTokens(blocks.size()),
-            tokens.size());
+  EXPECT_EQ(
+      tt::domain::prefix_cache::BlockMatcher::blocksToTokens(blocks.size()),
+      tokens.size());
 }
 
 }  // namespace


### PR DESCRIPTION
## The defect

A cached conversation is continued from

```cpp
// src/services/llm_pipeline.cpp:139
req->kv_position_id = result.matchedTokens + result.accumulatedThinkTokens;
```

which must equal the number of KV rows the matched prefix occupies — the same
file calls it "the first free KV index".

Thought delimiters are excluded from **both** terms. Documented, in
`conversation_hasher.hpp`:

> Thinking tokens … are excluded from the hash computation but their count is
> tracked. **The markers themselves are also excluded from both the hash and the
> count.**

But they are ordinary generated tokens and each occupies a row, so the resume
position runs short by two per thought block and compounds over a conversation.
The delta prefill then overwrites live rows at the tail of the previous response
and writes everything after it two positions early.

## Why the change is this small

One loop produces two outputs with opposite requirements:

| output | exclude markers? | |
|---|---|---|
| block hash | **yes — correct as written** | they are structure, and templates that strip thinking from the re-rendered history do not carry them in the next prompt, so hashing them would break matching |
| think count | **no — this is the bug** | the count feeds a KV position, and a marker occupies a row |

A single `continue` served both. This keeps the hashing behaviour exactly and
changes only the count, in both state machines — they mirror each other by
design and must agree.

## Evidence

Measured against the deployed build (`gemma-4-31B-it`, greedy, thinking on) by
replaying a live multi-turn conversation and comparing the server's resume
position with the rows actually resident. Both sides derive from the same
`matchedTokens`, so block quantization cancels.

| turn | matchedTokens | thinkTokens | server resume | correct | gap | delimiters in prefix |
|-----:|--------------:|------------:|--------------:|--------:|----:|---------------------:|
| 1 | 1088 | 170  | 1258 | 1260 | **2** | 2 ✅ |
| 2 | 1600 | 170  | 1770 | 1772 | **2** | 2 ✅ |
| 3 | 2176 | 683  | 2859 | 2863 | **4** | 4 ✅ |
| 4 | 3200 | 1593 | 4793 | 4800 | 7 | 6 |
| 7 | 5024 | 3369 | 8393 | 8404 | 11 | 10 |

The first three continuations match the delimiter count exactly, with nothing
fitted. Later turns carry a constant +1 that never widens — unexplained, most
likely an artefact of the measuring harness — so the growing component is
entirely the delimiters. Extrapolated, ~20 rows by turn 13, where a recorded
agent task derailed.

`matchedTokens`/`thinkTokens` come from the worker's existing
`"Slot acquired"` log line; no instrumentation was added.

## Scope

Not Gemma-specific. `currentBlock.push_back(token)` is unreachable for a marker,
so markers never reach `matchedTokens` for any model. Rendering a past thinking
turn through each deployed tokenizer:

| model | delimiters | thinking in re-rendered history |
|---|---|---|
| gemma-4-31B-it | `<\|channel>` / `<channel\|>` | stripped — measured here |
| **deepseek-r1-0528** | `<think>` / `</think>` | stripped — same exposure, unmeasured |
| kimi-k2.6 / k2.7-code | `<think>` / `</think>` | kept in the prompt |
| minimax-m3 | `<think>` / `</think>` | kept in the prompt |

Where thinking survives the re-render the delta-slicing question differs, but the
undercount applies there too and this change adds each delimiter exactly once —
they were never in `matchedTokens` to double-count against.

## Safety

`accumulatedThinkTokens` is subtracted in three places, which looks like a hazard
and is not: each subtraction is the exact inverse of the addition, so the result
is invariant.

| site | | result |
|---|---|---|
| `decode_slot_reservation.cpp:19-28`, `:33-44` | `(matched−1)+think`, `+1`, `−think` | `matched` |
| `decode_slot_reservation.cpp:76-82` | same shape | `matched` |
| `disaggregation_service.cpp:946` | `(matched+think) − think` | `matched` |

`matchedTokens` is also the right value for the consumer: the prompt carries no
thinking, so the resident *prompt* token count is exactly `matchedTokens`.
`llm_pipeline.cpp:265-270` and `:292` do the same cancelling inverse. Slot-copy
paths pass `think=0` by construction.

No existing test pins the old behaviour — `prefix_cache_router_test.cpp` and
`session_manager_test.cpp` assert only `matchedTokens` relationships and that
`clearSessionBlockThinkTokens` zeroes the count.

## Follow-ups, not in this PR

1. **Rename the field.** `accumulatedThinkTokens` now means rows, not words —
   `thinkKvRows` or similar. Mechanical but noisy; kept out to keep this
   reviewable.
2. **Unclosed thought blocks.** A turn that hits `max_tokens` mid-thought never
   emits the closing delimiter, so the state machine stays inside thinking and
   the accounting detaches entirely — measured 3009 rows once. Needs a
   turn-boundary reset. The same hazard is documented for qwen3 in
   `workflows/model_specs/prod/llm.yaml`, mitigated there by disabling thinking —
   an option gemma-4 does not have, since the spec forces it on for ~10 points of
   eval score.
3. **Assert the invariant.** Nothing anywhere checks that the resume position
   equals the resident row count. tt-blaze hit this same bug class and fixed it
   structurally in #3512 by having the backend report the KV frontier it wrote —
   "two independent claims about the same rows, where before there was one claim
   compared against itself."

## Status

Draft. **Not compiled locally** — my environment lacks Drogon, so CI is the first
build of the added test. Causation is also not proven: the drift is measured and
consistent with the observed corruption, but demonstrating it *causes* the
garbling means landing this and replaying the failing conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
