### PR TITLE
Fix Accummulated Think Token Calculations

### DIFF
--- a/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/SKILL.md
+++ b/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/SKILL.md
@@ -13,9 +13,12 @@ description: Checklist for onboarding a new LLM to the cpp_server inference back
 | 1 | `include/config/types.hpp` | `ModelType` + `Model` enum values, `MODEL_MAPPINGS` (`Model`→HF id), `modelTypeFromDeviceBackend` short-name branch |
 | 2 | `src/config/settings.cpp` | `modelType()` resolver: HF id → `ModelType` (else silently falls back to DeepSeek) |
 | 3 | `scripts/fetch_tokenizers.sh` | download **all** needed files into `tokenizers/<hf-id>/` |
-| 4 | `src/utils/tokenizers/tokenizer.cpp` | `tokenizerDirForModel`, `createTokenizer` (defaults to `DeepseekTokenizer`), `staticInfoFor` + a `StaticTokenizerInfo` (eos/stop/think token ids) |
+| 4 | `src/utils/tokenizers/tokenizer.cpp` | `tokenizerDirForModel`, `createTokenizer` (defaults to `DeepseekTokenizer`), `staticInfoFor` + a `StaticTokenizerInfo` (eos/stop/think token ids, **think-marker history flags**) |
 | 5 | `src/dynamo/discovery.cpp` | `runtimeParsersForModelType` (reasoning + tool-call parser ids), `buildMdcJson` (publishes `generation_config.json`) |
 | 6 | deploy + verify | `deploy.sh --hf-model-id <hf-id>`, confirm loads / registers / answers |
+
+Helper: `python3 render_think_history.py [<hf-id>]` (this directory) renders the
+fetched chat templates and prints the think ids and history flags step 4 needs.
 
 Reference: [tenstorrent/tt-inference-server#4143](https://github.com/tenstorrent/tt-inference-server/pull/4143) (and the GPT-OSS/MiniMax onboarding commits).
 
@@ -63,8 +66,49 @@ the model because `eos_token_id` is absent (model carries it only in
      - `eosTokenId` = `eos_token_id` from **config.json** (the single primary id),
      - `stopTokenIds` = the remaining ids from **generation_config.json** `eos_token_id`
        (often a list — e.g. gpt-oss `[200002, 199999, 200012]` → eos `200002`, stops `{199999, 200012}`),
-     - for reasoning models, `thinkStartTokenId`/`thinkEndTokenId` (`<think>`/`</think>`);
-       Harmony-style models (gpt-oss) have no think tokens.
+     - for reasoning models, `thinkStartTokenId`/`thinkEndTokenId` — **read the
+       pair out of the model's own chat template, do not copy a sibling's**
+       (MiniMax-M3 reasons in `<mm:think>`/`</mm:think>` while M2.7 uses
+       `<think>`/`</think>`, and both pairs exist in M3's vocab, so the wrong
+       ids parse fine and silently never match). Harmony-style models (gpt-oss)
+       have no think tokens: leave the ids unset, because `<|channel|>` there
+       also opens the `final` channel and would trip the marker state machine
+       on ordinary answers.
+     - `thinkStartInHistory` / `thinkEndInHistory` — see below.
+
+   **Think-marker history flags.** Every delimiter occupies a KV row, but the
+   prefix cache reconstructs "first free KV row" as
+   `matched_tokens + accumulatedThinkTokens`, where `matched_tokens` counts only
+   HASHED tokens. So each delimiter row must be counted — unless the chat
+   template re-renders that delimiter into later turns' prompts, in which case
+   the next prompt supplies the row itself and counting it again shifts the
+   turn. Get it wrong and nothing fails loudly: the conversation drifts a row or
+   two per turn and long multi-turn sessions degrade into nonsense.
+
+   Derive the values, don't guess — run from this directory:
+
+```bash
+python3 render_think_history.py <hf-id>     # omit the id to sweep every model
+```
+
+   It renders a two-turn conversation and reports, per delimiter, whether the
+   **past** assistant turn still contains it. Use the `reasoning NOT echoed`
+   block (clients rarely send `reasoning_content` back) and set the flags for
+   the pair you configured as `thinkStartTokenId`/`thinkEndTokenId` — the script
+   lists every think-like special token, and only that pair matters. The three
+   shapes seen so far:
+
+   | Template renders a past think block as | Flags |
+   |---|---|
+   | nothing (DeepSeek-R1, Gemma-4, MiniMax-M2.7) | `false, false` |
+   | a bare closing tag (GLM-5.1, MiniMax-M3) | `false, true` |
+   | empty `<think></think>` (Kimi, GLM-5.2) | `true, true` |
+
+   Known limitation: the flags are static, so a client that DOES echo
+   `reasoning_content` back changes the rendering (the script prints that case
+   too) and the accounting is off by the reasoning length for that request.
+   Pin whatever you choose in `ConversationHasherThinkRows`
+   (`tests/unit/model/conversation_hasher_test.cpp`).
 
 5. **Dynamo discovery** in `src/dynamo/discovery.cpp`:
    - `runtimeParsersForModelType` → return `{reasoning_parser, tool_call_parser}`

--- a/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/SKILL.md
+++ b/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/SKILL.md
@@ -104,9 +104,23 @@ python3 render_think_history.py <hf-id>     # omit the id to sweep every model
    | a bare closing tag (GLM-5.1, MiniMax-M3) | `false, true` |
    | empty `<think></think>` (Kimi, GLM-5.2) | `true, true` |
 
-   Known limitation: the flags are static, so a client that DOES echo
-   `reasoning_content` back changes the rendering (the script prints that case
-   too) and the accounting is off by the reasoning length for that request.
+   Known limitations — the flags are static, but the rendering they describe is
+   not, so they are only right for the Dynamo path with a non-echoing client:
+
+   - **Two renderers, one flag.** These values describe the model's own
+     `chat_template.jinja`, which is what the Dynamo frontend applies before
+     sending `token_ids`. The local Drogon route (`/v1/chat/completions` →
+     `ChatCompletionRequest::toLLMRequest`) instead renders through
+     `DeepseekTokenizer::applyChatTemplate`, which every `ModelType` currently
+     shares and which emits a past assistant turn as `<｜Assistant｜>content` —
+     no delimiters, for any model. So on that path the true flags are always
+     `false, false`, and any model registered otherwise (Kimi, GLM-5.1/5.2,
+     MiniMax-M3) undercounts 1–2 KV rows per turn there. Fixing it properly
+     means giving those models real templates rather than adjusting the flags.
+   - **Echoed reasoning.** A client that DOES send `reasoning_content` back
+     changes the rendering again (the script prints that case too); the
+     accounting is then off by the reasoning length for that request.
+
    Pin whatever you choose in `ConversationHasherThinkRows`
    (`tests/unit/model/conversation_hasher_test.cpp`).
 

--- a/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/render_think_history.py
+++ b/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/render_think_history.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Derive thinkStartInHistory / thinkEndInHistory for a model's StaticTokenizerInfo.
+
+Renders each model's chat template for a two-turn conversation and reports which
+think delimiters survive in the HISTORY (the part before the new user turn).
+A delimiter that survives is re-supplied by the next prompt; one that does not
+is a KV row only accumulatedThinkTokens can account for.
+
+    python3 render_think_history.py                    # every fetched model
+    python3 render_think_history.py zai-org/GLM-5.1    # one model
+
+Requires jinja2 (no model weights, no tokenizer load — templates only).
+"""
+import datetime
+import glob
+import json
+import os
+import sys
+
+from jinja2.exceptions import TemplateError
+from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+TOKENIZERS = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../../tokenizers")
+)
+MARKER_HINTS = ("think", "channel")
+TURN2 = "SECOND_USER_TURN"
+
+
+def load_template(model_dir):
+    path = os.path.join(model_dir, "chat_template.jinja")
+    if os.path.exists(path):
+        return open(path).read()
+    cfg = json.load(open(os.path.join(model_dir, "tokenizer_config.json")))
+    tpl = cfg.get("chat_template")
+    return tpl[0]["template"] if isinstance(tpl, list) else tpl
+
+
+def bos_token(model_dir):
+    tok = json.load(open(os.path.join(model_dir, "tokenizer_config.json"))).get("bos_token")
+    return (tok.get("content") if isinstance(tok, dict) else tok) or ""
+
+
+def special_tokens(model_dir):
+    """All special tokens as {content: id}, from tokenizer.json when present and
+    from tokenizer_config.json's added_tokens_decoder otherwise (Kimi ships a
+    tiktoken.model instead of a tokenizer.json)."""
+    tokens = {}
+    path = os.path.join(model_dir, "tokenizer.json")
+    if os.path.exists(path):
+        for t in json.load(open(path)).get("added_tokens", []):
+            tokens[t["content"]] = t["id"]
+    cfg_path = os.path.join(model_dir, "tokenizer_config.json")
+    if os.path.exists(cfg_path):
+        decoder = json.load(open(cfg_path)).get("added_tokens_decoder", {})
+        for tok_id, entry in decoder.items():
+            content = entry.get("content") if isinstance(entry, dict) else entry
+            if content:
+                tokens.setdefault(content, int(tok_id))
+    return tokens
+
+
+def marker_candidates(model_dir):
+    """Special tokens that look like think delimiters, as {content: id}."""
+    return {
+        content: tok_id
+        for content, tok_id in special_tokens(model_dir).items()
+        if any(h in content.lower() for h in MARKER_HINTS)
+    }
+
+
+def render(tpl, messages, bos, **kwargs):
+    # loopcontrols: some templates (Kimi) use {% break %} inside their history
+    # loop, which plain jinja2 rejects.
+    env = ImmutableSandboxedEnvironment(
+        trim_blocks=True, lstrip_blocks=True,
+        extensions=["jinja2.ext.loopcontrols"])
+    env.globals["raise_exception"] = lambda m: (_ for _ in ()).throw(TemplateError(m))
+    env.globals["strftime_now"] = lambda f: datetime.datetime.now().strftime(f)
+    env.filters["tojson"] = lambda x, **kw: json.dumps(x)
+    return env.from_string(tpl).render(
+        messages=messages, add_generation_prompt=True, bos_token=bos,
+        eos_token="", tools=None, **kwargs)
+
+
+def conversation(echo_reasoning, with_assistant=True):
+    turns = [{"role": "user", "content": "FIRST_USER_TURN"}]
+    if with_assistant:
+        assistant = {"role": "assistant", "content": "FIRST_ANSWER"}
+        if echo_reasoning:
+            assistant["reasoning_content"] = "FIRST_REASONING"
+            assistant["reasoning"] = "FIRST_REASONING"
+        turns.append(assistant)
+    turns.append({"role": "user", "content": TURN2})
+    return turns
+
+
+def history_of(prompt):
+    """Everything before the new user turn — i.e. what later turns re-render."""
+    idx = prompt.find(TURN2)
+    return prompt if idx < 0 else prompt[:idx]
+
+
+def report(model, model_dir, thinking_kwargs):
+    tpl = load_template(model_dir)
+    if not tpl:
+        print(f"{model}: no chat template fetched — cannot verify\n")
+        return
+    bos = bos_token(model_dir)
+    markers = marker_candidates(model_dir)
+    print(f"{model}")
+    if not markers:
+        print("  no think-like special tokens found "
+              "(non-reasoning model → leave both flags at their default)\n")
+        return
+    for echo in (False, True):
+        hist = history_of(render(tpl, conversation(echo), bos, **thinking_kwargs))
+        # A template may DOCUMENT its delimiters in the system prompt (MiniMax
+        # does), so a bare substring search over the history lies. Diff against
+        # the same conversation minus the assistant turn: only the delta was
+        # contributed by rendering a past think block.
+        baseline = history_of(
+            render(tpl, conversation(echo, with_assistant=False), bos,
+                   **thinking_kwargs))
+        label = ("reasoning echoed back" if echo
+                 else "reasoning NOT echoed (use this one)")
+        print(f"  [{label}]")
+        print(f"    assistant turn renders as: {hist[len(os.path.commonprefix([hist, baseline])):]!r}")
+        for content, tok_id in sorted(markers.items(), key=lambda kv: kv[1]):
+            kept = hist.count(content) > baseline.count(content)
+            print(f"    {content:<14} id={tok_id:<7} "
+                  f"{'kept in history  -> InHistory=true' if kept else 'dropped          -> InHistory=false'}")
+    print()
+
+
+def main():
+    wanted = sys.argv[1:]
+    dirs = sorted(glob.glob(os.path.join(TOKENIZERS, "*", "*")))
+    if wanted:
+        dirs = [d for d in dirs if "/".join(d.split("/")[-2:]) in wanted]
+        if not dirs:
+            sys.exit(f"no fetched tokenizer matched {wanted} under {TOKENIZERS}")
+    for d in dirs:
+        model = "/".join(d.split("/")[-2:])
+        try:
+            report(model, d, {"enable_thinking": True})
+        except Exception as exc:  # template bugs / unsupported jinja extensions
+            print(f"{model}: RENDER FAILED: {type(exc).__name__}: {exc}")
+            print("  fall back to reading the template's history branch by hand\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/render_think_history.py
+++ b/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/render_think_history.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
 #!/usr/bin/env python3
 """Derive thinkStartInHistory / thinkEndInHistory for a model's StaticTokenizerInfo.
 

--- a/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/render_think_history.py
+++ b/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/render_think_history.py
@@ -1,8 +1,8 @@
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 #
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
-#!/usr/bin/env python3
 """Derive thinkStartInHistory / thinkEndInHistory for a model's StaticTokenizerInfo.
 
 Renders each model's chat template for a two-turn conversation and reports which

--- a/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/render_think_history.py
+++ b/tt-media-server/cpp_server/.claude/skills/add-model-dynamo/render_think_history.py
@@ -15,6 +15,7 @@ is a KV row only accumulatedThinkTokens can account for.
 
 Requires jinja2 (no model weights, no tokenizer load — templates only).
 """
+
 import datetime
 import glob
 import json
@@ -41,7 +42,9 @@ def load_template(model_dir):
 
 
 def bos_token(model_dir):
-    tok = json.load(open(os.path.join(model_dir, "tokenizer_config.json"))).get("bos_token")
+    tok = json.load(open(os.path.join(model_dir, "tokenizer_config.json"))).get(
+        "bos_token"
+    )
     return (tok.get("content") if isinstance(tok, dict) else tok) or ""
 
 
@@ -77,14 +80,19 @@ def render(tpl, messages, bos, **kwargs):
     # loopcontrols: some templates (Kimi) use {% break %} inside their history
     # loop, which plain jinja2 rejects.
     env = ImmutableSandboxedEnvironment(
-        trim_blocks=True, lstrip_blocks=True,
-        extensions=["jinja2.ext.loopcontrols"])
+        trim_blocks=True, lstrip_blocks=True, extensions=["jinja2.ext.loopcontrols"]
+    )
     env.globals["raise_exception"] = lambda m: (_ for _ in ()).throw(TemplateError(m))
     env.globals["strftime_now"] = lambda f: datetime.datetime.now().strftime(f)
     env.filters["tojson"] = lambda x, **kw: json.dumps(x)
     return env.from_string(tpl).render(
-        messages=messages, add_generation_prompt=True, bos_token=bos,
-        eos_token="", tools=None, **kwargs)
+        messages=messages,
+        add_generation_prompt=True,
+        bos_token=bos,
+        eos_token="",
+        tools=None,
+        **kwargs,
+    )
 
 
 def conversation(echo_reasoning, with_assistant=True):
@@ -114,8 +122,10 @@ def report(model, model_dir, thinking_kwargs):
     markers = marker_candidates(model_dir)
     print(f"{model}")
     if not markers:
-        print("  no think-like special tokens found "
-              "(non-reasoning model → leave both flags at their default)\n")
+        print(
+            "  no think-like special tokens found "
+            "(non-reasoning model → leave both flags at their default)\n"
+        )
         return
     for echo in (False, True):
         hist = history_of(render(tpl, conversation(echo), bos, **thinking_kwargs))
@@ -124,16 +134,23 @@ def report(model, model_dir, thinking_kwargs):
         # the same conversation minus the assistant turn: only the delta was
         # contributed by rendering a past think block.
         baseline = history_of(
-            render(tpl, conversation(echo, with_assistant=False), bos,
-                   **thinking_kwargs))
-        label = ("reasoning echoed back" if echo
-                 else "reasoning NOT echoed (use this one)")
+            render(
+                tpl, conversation(echo, with_assistant=False), bos, **thinking_kwargs
+            )
+        )
+        label = (
+            "reasoning echoed back" if echo else "reasoning NOT echoed (use this one)"
+        )
         print(f"  [{label}]")
-        print(f"    assistant turn renders as: {hist[len(os.path.commonprefix([hist, baseline])):]!r}")
+        print(
+            f"    assistant turn renders as: {hist[len(os.path.commonprefix([hist, baseline])) :]!r}"
+        )
         for content, tok_id in sorted(markers.items(), key=lambda kv: kv[1]):
             kept = hist.count(content) > baseline.count(content)
-            print(f"    {content:<14} id={tok_id:<7} "
-                  f"{'kept in history  -> InHistory=true' if kept else 'dropped          -> InHistory=false'}")
+            print(
+                f"    {content:<14} id={tok_id:<7} "
+                f"{'kept in history  -> InHistory=true' if kept else 'dropped          -> InHistory=false'}"
+            )
     print()
 
 

--- a/tt-media-server/cpp_server/include/domain/session.hpp
+++ b/tt-media-server/cpp_server/include/domain/session.hpp
@@ -214,6 +214,10 @@ class Session {
   uint32_t accumulatedThinkTokens_ = 0;
   uint32_t thinkStartTokenId_ = 0;
   uint32_t thinkEndTokenId_ = 0;
+  // Whether this model's chat template re-renders each delimiter into later
+  // turns' prompts; a delimiter it drops is a KV row only this counter tracks.
+  bool thinkStartInHistory_ = false;
+  bool thinkEndInHistory_ = false;
 
   static std::string generateUuid();
 };

--- a/tt-media-server/cpp_server/include/domain/session.hpp
+++ b/tt-media-server/cpp_server/include/domain/session.hpp
@@ -209,15 +209,11 @@ class Session {
       onComplete_;
   std::function<void(const std::string&)> onNoHashes_;
 
-  // Thinking token tracking
-  bool inThinkingBlock_ = false;
-  uint32_t accumulatedThinkTokens_ = 0;
-  uint32_t thinkStartTokenId_ = 0;
-  uint32_t thinkEndTokenId_ = 0;
-  // Whether this model's chat template re-renders each delimiter into later
-  // turns' prompts; a delimiter it drops is a KV row only this counter tracks.
-  bool thinkStartInHistory_ = false;
-  bool thinkEndInHistory_ = false;
+  // Thinking-token accounting, resolved per model in initTokenAccumulator()
+  // and consumed by finalizeAndRegisterHashes().
+  uint32_t thinkStartTokenId_ = utils::tokenizers::kNoTokenId;
+  uint32_t thinkEndTokenId_ = utils::tokenizers::kNoTokenId;
+  utils::tokenizers::ThinkMarkersInHistory markersInHistory_;
 
   static std::string generateUuid();
 };

--- a/tt-media-server/cpp_server/include/utils/conversation_hasher.hpp
+++ b/tt-media-server/cpp_server/include/utils/conversation_hasher.hpp
@@ -92,8 +92,12 @@ std::string renderLastUserTurn(const std::vector<ChatMessage>& messages,
  */
 struct BlockHashInfo {
   uint64_t hash;
-  uint32_t
-      accumulatedThinkTokens;  // Thinking content tokens (excluding markers)
+  // KV rows occupied by thinking up to and including this block that a LATER
+  // turn's prompt will not contain: the reasoning content, plus each delimiter
+  // this model's chat template drops from history (see
+  // tokenizers::ThinkMarkersInHistory). This is the correction that turns a
+  // block-aligned match back into a KV row index, so it counts ROWS, not words.
+  uint32_t accumulatedThinkTokens;
 };
 
 /**
@@ -176,23 +180,34 @@ std::vector<uint64_t> getPrefixCacheHashesByBlocks(
 /**
  * Compute per-block KV cache hashes, filtering out thinking tokens.
  *
- * Thinking tokens (content between thinkStartId and thinkEndId markers) are
- * excluded from the hash computation but their count is tracked. The markers
- * themselves are also excluded from both the hash and the count.
+ * Thinking tokens (content between thinkStartId and thinkEndId markers) and
+ * the markers themselves are excluded from the hash computation — a later turn
+ * whose prompt no longer carries the reasoning must still match these blocks.
+ *
+ * The think COUNT is a different question: it exists to rebuild a KV row index
+ * from a block-aligned match, so it must count every row the later prompt will
+ * not supply. Reasoning content always counts. A delimiter counts only when
+ * this model's chat template drops it from history — pass
+ * thinkStartInHistory / thinkEndInHistory from
+ * tokenizers::thinkMarkersInHistory(). Counting a delimiter the next prompt
+ * still contains shifts every following turn forward; not counting one it
+ * drops shifts them back.
  *
  * Uses the same marker state machine as session tracking to classify tokens as
- * thinking or non-thinking.
+ * thinking or non-thinking; Session::addGeneratedToken must stay in step.
  *
  * @param tokens Token-id sequence to hash.
  * @param thinkStartId Token ID for <|begin_think|> (kNoThinkTokenId to disable)
  * @param thinkEndId Token ID for <|end_think|>
+ * @param thinkStartInHistory True iff later prompts re-render thinkStartId.
+ * @param thinkEndInHistory True iff later prompts re-render thinkEndId.
  * @param parentHash Optional seed hash from a prior block.
- * @param parentThinkCount Accumulated think tokens from prior blocks.
+ * @param parentThinkCount Accumulated think rows from prior blocks.
  * @return Vector of BlockHashInfo (one per full block of non-thinking tokens).
  */
 std::vector<BlockHashInfo> getPrefixCacheHashesByBlocksWithThinking(
     std::span<const uint32_t> tokens, uint32_t thinkStartId,
-    uint32_t thinkEndId, uint64_t parentHash = 0,
-    uint32_t parentThinkCount = 0);
+    uint32_t thinkEndId, bool thinkStartInHistory, bool thinkEndInHistory,
+    uint64_t parentHash = 0, uint32_t parentThinkCount = 0);
 
 }  // namespace tt::utils

--- a/tt-media-server/cpp_server/include/utils/conversation_hasher.hpp
+++ b/tt-media-server/cpp_server/include/utils/conversation_hasher.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "domain/llm/chat_message.hpp"
+#include "utils/tokenizers/tokenizer.hpp"
 
 namespace tt::utils {
 
@@ -92,11 +93,10 @@ std::string renderLastUserTurn(const std::vector<ChatMessage>& messages,
  */
 struct BlockHashInfo {
   uint64_t hash;
-  // KV rows occupied by thinking up to and including this block that a LATER
-  // turn's prompt will not contain: the reasoning content, plus each delimiter
-  // this model's chat template drops from history (see
-  // tokenizers::ThinkMarkersInHistory). This is the correction that turns a
-  // block-aligned match back into a KV row index, so it counts ROWS, not words.
+  // KV rows up to and including this block that a LATER turn's prompt will not
+  // re-supply: the reasoning content, plus each delimiter this model's chat
+  // template drops from history. Adding it to a block-aligned match recovers
+  // the KV row index, so it counts ROWS, not words.
   uint32_t accumulatedThinkTokens;
 };
 
@@ -180,34 +180,26 @@ std::vector<uint64_t> getPrefixCacheHashesByBlocks(
 /**
  * Compute per-block KV cache hashes, filtering out thinking tokens.
  *
- * Thinking tokens (content between thinkStartId and thinkEndId markers) and
- * the markers themselves are excluded from the hash computation — a later turn
- * whose prompt no longer carries the reasoning must still match these blocks.
- *
- * The think COUNT is a different question: it exists to rebuild a KV row index
- * from a block-aligned match, so it must count every row the later prompt will
- * not supply. Reasoning content always counts. A delimiter counts only when
- * this model's chat template drops it from history — pass
- * thinkStartInHistory / thinkEndInHistory from
- * tokenizers::thinkMarkersInHistory(). Counting a delimiter the next prompt
- * still contains shifts every following turn forward; not counting one it
+ * Reasoning content and both markers are excluded from the hash, so a later
+ * turn whose prompt no longer carries the reasoning still matches these
+ * blocks. The think COUNT is a separate question and must not follow the
+ * hash: it counts only the rows the later prompt will not re-supply, so a
+ * delimiter counts only when this model's template drops it from history
+ * (pass tokenizers::thinkMarkersInHistory()). Counting a delimiter the next
+ * prompt still contains shifts every following turn forward; missing one it
  * drops shifts them back.
  *
- * Uses the same marker state machine as session tracking to classify tokens as
- * thinking or non-thinking; Session::addGeneratedToken must stay in step.
- *
  * @param tokens Token-id sequence to hash.
- * @param thinkStartId Token ID for <|begin_think|> (kNoThinkTokenId to disable)
+ * @param thinkStartId Token ID for <|begin_think|> (kNoTokenId to disable)
  * @param thinkEndId Token ID for <|end_think|>
- * @param thinkStartInHistory True iff later prompts re-render thinkStartId.
- * @param thinkEndInHistory True iff later prompts re-render thinkEndId.
+ * @param markersInHistory Which delimiters later prompts re-render.
  * @param parentHash Optional seed hash from a prior block.
  * @param parentThinkCount Accumulated think rows from prior blocks.
  * @return Vector of BlockHashInfo (one per full block of non-thinking tokens).
  */
 std::vector<BlockHashInfo> getPrefixCacheHashesByBlocksWithThinking(
     std::span<const uint32_t> tokens, uint32_t thinkStartId,
-    uint32_t thinkEndId, bool thinkStartInHistory, bool thinkEndInHistory,
+    uint32_t thinkEndId, tokenizers::ThinkMarkersInHistory markersInHistory,
     uint64_t parentHash = 0, uint32_t parentThinkCount = 0);
 
 }  // namespace tt::utils

--- a/tt-media-server/cpp_server/include/utils/tokenizers/tokenizer.hpp
+++ b/tt-media-server/cpp_server/include/utils/tokenizers/tokenizer.hpp
@@ -209,11 +209,37 @@ struct StaticTokenizerInfo {
   std::vector<uint32_t> assistantHeaderSequence;
   uint32_t thinkStartTokenId = kNoTokenId;
   uint32_t thinkEndTokenId = kNoTokenId;
+  // Does this model's chat template re-render the think delimiter into LATER
+  // turns' prompts? See ThinkMarkersInHistory below. Default false ("dropped")
+  // because that is both the common case and the safe one: a delimiter the
+  // next prompt does not carry is a KV row nothing else accounts for.
+  bool thinkStartInHistory = false;
+  bool thinkEndInHistory = false;
 };
 
 /** Per-model thinking marker token IDs (O(1), no tokenizer.json parse). */
 std::pair<uint32_t, uint32_t> thinkTokenIdsFor(config::ModelType model);
 std::pair<uint32_t, uint32_t> thinkTokenIds();
+
+/**
+ * Which think delimiters this model's chat template re-renders into the
+ * prompts of LATER turns (i.e. when the finished think block has become
+ * history).
+ *
+ * This drives prefix-cache position accounting, not tokenization. Every
+ * delimiter occupies a KV row, but only the ones the next turn's prompt no
+ * longer contains have to be added back when reconstructing "first free KV
+ * index" from a block-aligned match — the ones the template still emits are
+ * supplied by the prompt itself and would be double-counted. Verified per
+ * model by rendering `tokenizers/<hf-id>/chat_template.jinja` for a two-turn
+ * conversation (see the `add-model-dynamo` skill).
+ */
+struct ThinkMarkersInHistory {
+  bool start = false;
+  bool end = false;
+};
+ThinkMarkersInHistory thinkMarkersInHistoryFor(config::ModelType model);
+ThinkMarkersInHistory thinkMarkersInHistory();
 
 /**
  * Static constants for `model`. Throws std::invalid_argument if no entry

--- a/tt-media-server/cpp_server/include/utils/tokenizers/tokenizer.hpp
+++ b/tt-media-server/cpp_server/include/utils/tokenizers/tokenizer.hpp
@@ -209,10 +209,7 @@ struct StaticTokenizerInfo {
   std::vector<uint32_t> assistantHeaderSequence;
   uint32_t thinkStartTokenId = kNoTokenId;
   uint32_t thinkEndTokenId = kNoTokenId;
-  // Does this model's chat template re-render the think delimiter into LATER
-  // turns' prompts? See ThinkMarkersInHistory below. Default false ("dropped")
-  // because that is both the common case and the safe one: a delimiter the
-  // next prompt does not carry is a KV row nothing else accounts for.
+  // See ThinkMarkersInHistory. Default false ("dropped from history").
   bool thinkStartInHistory = false;
   bool thinkEndInHistory = false;
 };
@@ -222,17 +219,12 @@ std::pair<uint32_t, uint32_t> thinkTokenIdsFor(config::ModelType model);
 std::pair<uint32_t, uint32_t> thinkTokenIds();
 
 /**
- * Which think delimiters this model's chat template re-renders into the
- * prompts of LATER turns (i.e. when the finished think block has become
- * history).
- *
- * This drives prefix-cache position accounting, not tokenization. Every
- * delimiter occupies a KV row, but only the ones the next turn's prompt no
- * longer contains have to be added back when reconstructing "first free KV
- * index" from a block-aligned match — the ones the template still emits are
- * supplied by the prompt itself and would be double-counted. Verified per
- * model by rendering `tokenizers/<hf-id>/chat_template.jinja` for a two-turn
- * conversation (see the `add-model-dynamo` skill).
+ * Which think delimiters this model's chat template re-renders once the think
+ * block has become history. Drives prefix-cache position accounting, not
+ * tokenization: every delimiter occupies a KV row, but only the ones the next
+ * prompt no longer carries must be added back when reconstructing the first
+ * free KV index from a block-aligned match. Derive per model with the
+ * `add-model-dynamo` skill's render_think_history.py.
  */
 struct ThinkMarkersInHistory {
   bool start = false;

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -62,9 +62,9 @@ void Session::initTokenAccumulator(
   initialBlocks_ = std::move(initialBlocks);
   parentHash_ = initialBlocks_.empty() ? 0 : initialBlocks_.back().hash;
   // Think tokens live in the KV cache but are excluded from block hashes, so
-  // re-hashing the prompt cannot recover the count from earlier turns (the
-  // prompt does not re-encode prior <think> markers). Seed it explicitly from
-  // the matched KV prefix on a HIT so the count accumulates across turns.
+  // re-hashing the prompt cannot recover the count from earlier turns (a later
+  // prompt no longer carries the prior turn's reasoning). Seed it explicitly
+  // from the matched KV prefix on a HIT so the count accumulates across turns.
   parentThinkCount_ = parentThinkCount;
   onComplete_ = std::move(onComplete);
   onNoHashes_ = std::move(onNoHashes);
@@ -75,6 +75,9 @@ void Session::initTokenAccumulator(
   auto [thinkStart, thinkEnd] = utils::tokenizers::thinkTokenIds();
   thinkStartTokenId_ = thinkStart;
   thinkEndTokenId_ = thinkEnd;
+  const auto markersInHistory = utils::tokenizers::thinkMarkersInHistory();
+  thinkStartInHistory_ = markersInHistory.start;
+  thinkEndInHistory_ = markersInHistory.end;
   inThinkingBlock_ = false;
   accumulatedThinkTokens_ = parentThinkCount_;
 }
@@ -90,10 +93,14 @@ void Session::addGeneratedToken(uint32_t tokenId) {
 
   if (tokenId == thinkStartTokenId_) {
     inThinkingBlock_ = true;
+    // The delimiter occupies a KV row. It is this counter's job unless the
+    // chat template re-renders it into later prompts (mirrors the hasher).
+    if (!thinkStartInHistory_) ++accumulatedThinkTokens_;
   } else if (tokenId == thinkEndTokenId_) {
     inThinkingBlock_ = false;
+    if (!thinkEndInHistory_) ++accumulatedThinkTokens_;
   } else if (inThinkingBlock_) {
-    ++accumulatedThinkTokens_;  // Only content tokens, not markers
+    ++accumulatedThinkTokens_;  // Reasoning content
   }
 }
 
@@ -108,8 +115,8 @@ void Session::finalizeAndRegisterHashes() {
   // Compute new block info continuing from parent (avoids re-hashing matched
   // prefix). Uses thinking-aware hashing to exclude thinking tokens from hash.
   auto newBlocks = utils::getPrefixCacheHashesByBlocksWithThinking(
-      allDeltaTokens, thinkStartTokenId_, thinkEndTokenId_, parentHash_,
-      parentThinkCount_);
+      allDeltaTokens, thinkStartTokenId_, thinkEndTokenId_,
+      thinkStartInHistory_, thinkEndInHistory_, parentHash_, parentThinkCount_);
 
   // Only register if new blocks were formed
   if (!newBlocks.empty()) {

--- a/tt-media-server/cpp_server/src/domain/session.cpp
+++ b/tt-media-server/cpp_server/src/domain/session.cpp
@@ -45,8 +45,6 @@ bool Session::clearInFlight() {
   parentThinkCount_ = 0;
   onComplete_ = nullptr;
   onNoHashes_ = nullptr;
-  inThinkingBlock_ = false;
-  accumulatedThinkTokens_ = 0;
   return true;
 }
 
@@ -71,37 +69,15 @@ void Session::initTokenAccumulator(
   generatedTokens_.clear();
   being_generated_ = true;
 
-  // Initialize thinking token tracking
+  // Thinking-token accounting inputs for finalizeAndRegisterHashes().
   auto [thinkStart, thinkEnd] = utils::tokenizers::thinkTokenIds();
   thinkStartTokenId_ = thinkStart;
   thinkEndTokenId_ = thinkEnd;
-  const auto markersInHistory = utils::tokenizers::thinkMarkersInHistory();
-  thinkStartInHistory_ = markersInHistory.start;
-  thinkEndInHistory_ = markersInHistory.end;
-  inThinkingBlock_ = false;
-  accumulatedThinkTokens_ = parentThinkCount_;
+  markersInHistory_ = utils::tokenizers::thinkMarkersInHistory();
 }
 
 void Session::addGeneratedToken(uint32_t tokenId) {
   generatedTokens_.push_back(tokenId);
-
-  // Track thinking state using the same marker rules as prefix hashing.
-  const bool thinkingEnabled =
-      thinkStartTokenId_ != utils::tokenizers::kNoTokenId &&
-      thinkEndTokenId_ != utils::tokenizers::kNoTokenId;
-  if (!thinkingEnabled) return;
-
-  if (tokenId == thinkStartTokenId_) {
-    inThinkingBlock_ = true;
-    // The delimiter occupies a KV row. It is this counter's job unless the
-    // chat template re-renders it into later prompts (mirrors the hasher).
-    if (!thinkStartInHistory_) ++accumulatedThinkTokens_;
-  } else if (tokenId == thinkEndTokenId_) {
-    inThinkingBlock_ = false;
-    if (!thinkEndInHistory_) ++accumulatedThinkTokens_;
-  } else if (inThinkingBlock_) {
-    ++accumulatedThinkTokens_;  // Reasoning content
-  }
 }
 
 void Session::finalizeAndRegisterHashes() {
@@ -115,8 +91,8 @@ void Session::finalizeAndRegisterHashes() {
   // Compute new block info continuing from parent (avoids re-hashing matched
   // prefix). Uses thinking-aware hashing to exclude thinking tokens from hash.
   auto newBlocks = utils::getPrefixCacheHashesByBlocksWithThinking(
-      allDeltaTokens, thinkStartTokenId_, thinkEndTokenId_,
-      thinkStartInHistory_, thinkEndInHistory_, parentHash_, parentThinkCount_);
+      allDeltaTokens, thinkStartTokenId_, thinkEndTokenId_, markersInHistory_,
+      parentHash_, parentThinkCount_);
 
   // Only register if new blocks were formed
   if (!newBlocks.empty()) {

--- a/tt-media-server/cpp_server/src/services/prefix_cache_router.cpp
+++ b/tt-media-server/cpp_server/src/services/prefix_cache_router.cpp
@@ -20,8 +20,10 @@ std::vector<utils::BlockHashInfo> PrefixCacheRouter::computeBlockInfos(
     return {};
   }
   auto [thinkStart, thinkEnd] = utils::tokenizers::thinkTokenIds();
-  return utils::getPrefixCacheHashesByBlocksWithThinking(promptTokenIds,
-                                                         thinkStart, thinkEnd);
+  const auto markersInHistory = utils::tokenizers::thinkMarkersInHistory();
+  return utils::getPrefixCacheHashesByBlocksWithThinking(
+      promptTokenIds, thinkStart, thinkEnd, markersInHistory.start,
+      markersInHistory.end);
 }
 
 std::optional<PrefixCacheRouter::AcquireResult>

--- a/tt-media-server/cpp_server/src/services/prefix_cache_router.cpp
+++ b/tt-media-server/cpp_server/src/services/prefix_cache_router.cpp
@@ -20,10 +20,9 @@ std::vector<utils::BlockHashInfo> PrefixCacheRouter::computeBlockInfos(
     return {};
   }
   auto [thinkStart, thinkEnd] = utils::tokenizers::thinkTokenIds();
-  const auto markersInHistory = utils::tokenizers::thinkMarkersInHistory();
   return utils::getPrefixCacheHashesByBlocksWithThinking(
-      promptTokenIds, thinkStart, thinkEnd, markersInHistory.start,
-      markersInHistory.end);
+      promptTokenIds, thinkStart, thinkEnd,
+      utils::tokenizers::thinkMarkersInHistory());
 }
 
 std::optional<PrefixCacheRouter::AcquireResult>

--- a/tt-media-server/cpp_server/src/utils/conversation_hasher.cpp
+++ b/tt-media-server/cpp_server/src/utils/conversation_hasher.cpp
@@ -117,10 +117,12 @@ PrefixCachingInfo computePrefixCachingInfoFromTokens(
     std::span<const uint32_t> tokens) {
   PrefixCachingInfo info;
 
-  // Hash non-thinking tokens into per-block hashes, tracking think counts.
+  // Hash non-thinking tokens into per-block hashes, tracking think rows.
   auto [thinkStart, thinkEnd] = tokenizers::thinkTokenIds();
-  info.blocks =
-      getPrefixCacheHashesByBlocksWithThinking(tokens, thinkStart, thinkEnd);
+  const auto markersInHistory = tokenizers::thinkMarkersInHistory();
+  info.blocks = getPrefixCacheHashesByBlocksWithThinking(
+      tokens, thinkStart, thinkEnd, markersInHistory.start,
+      markersInHistory.end);
 
   TT_LOG_INFO("[TokenHasher] tokens={} blocks={}", tokens.size(),
               info.blocks.size());
@@ -185,7 +187,8 @@ std::vector<uint64_t> getPrefixCacheHashesByBlocks(
 
 std::vector<BlockHashInfo> getPrefixCacheHashesByBlocksWithThinking(
     std::span<const uint32_t> tokens, uint32_t thinkStartId,
-    uint32_t thinkEndId, uint64_t parentHash, uint32_t parentThinkCount) {
+    uint32_t thinkEndId, bool thinkStartInHistory, bool thinkEndInHistory,
+    uint64_t parentHash, uint32_t parentThinkCount) {
   const bool filterThinking = (thinkStartId != tokenizers::kNoTokenId &&
                                thinkEndId != tokenizers::kNoTokenId);
   const size_t firstBlockSize = tt::config::prefixCacheFirstBlockSize();
@@ -208,14 +211,19 @@ std::vector<BlockHashInfo> getPrefixCacheHashesByBlocksWithThinking(
       // Mirror the session-side think marker state machine.
       if (token == thinkStartId) {
         inThinking = true;
-        continue;  // Skip marker, don't count
+        // Never hashed (a later prompt may not carry it), but it does occupy a
+        // KV row — count that row unless the template re-renders the marker,
+        // in which case the later prompt supplies it.
+        if (!thinkStartInHistory) ++thinkCount;
+        continue;
       }
       if (token == thinkEndId) {
         inThinking = false;
-        continue;  // Skip marker, don't count
+        if (!thinkEndInHistory) ++thinkCount;  // Same as thinkStartId above
+        continue;
       }
       if (inThinking) {
-        ++thinkCount;  // Count content token, don't hash
+        ++thinkCount;  // Count content row, don't hash
         continue;
       }
     }

--- a/tt-media-server/cpp_server/src/utils/conversation_hasher.cpp
+++ b/tt-media-server/cpp_server/src/utils/conversation_hasher.cpp
@@ -209,8 +209,6 @@ std::vector<BlockHashInfo> getPrefixCacheHashesByBlocksWithThinking(
       // Mirror the session-side think marker state machine.
       if (token == thinkStartId) {
         inThinking = true;
-        // Not hashed, but it occupies a KV row unless the template
-        // re-renders it, in which case the later prompt supplies that row.
         if (!markersInHistory.start) ++thinkCount;
         continue;
       }

--- a/tt-media-server/cpp_server/src/utils/conversation_hasher.cpp
+++ b/tt-media-server/cpp_server/src/utils/conversation_hasher.cpp
@@ -119,10 +119,8 @@ PrefixCachingInfo computePrefixCachingInfoFromTokens(
 
   // Hash non-thinking tokens into per-block hashes, tracking think rows.
   auto [thinkStart, thinkEnd] = tokenizers::thinkTokenIds();
-  const auto markersInHistory = tokenizers::thinkMarkersInHistory();
   info.blocks = getPrefixCacheHashesByBlocksWithThinking(
-      tokens, thinkStart, thinkEnd, markersInHistory.start,
-      markersInHistory.end);
+      tokens, thinkStart, thinkEnd, tokenizers::thinkMarkersInHistory());
 
   TT_LOG_INFO("[TokenHasher] tokens={} blocks={}", tokens.size(),
               info.blocks.size());
@@ -187,7 +185,7 @@ std::vector<uint64_t> getPrefixCacheHashesByBlocks(
 
 std::vector<BlockHashInfo> getPrefixCacheHashesByBlocksWithThinking(
     std::span<const uint32_t> tokens, uint32_t thinkStartId,
-    uint32_t thinkEndId, bool thinkStartInHistory, bool thinkEndInHistory,
+    uint32_t thinkEndId, tokenizers::ThinkMarkersInHistory markersInHistory,
     uint64_t parentHash, uint32_t parentThinkCount) {
   const bool filterThinking = (thinkStartId != tokenizers::kNoTokenId &&
                                thinkEndId != tokenizers::kNoTokenId);
@@ -211,15 +209,14 @@ std::vector<BlockHashInfo> getPrefixCacheHashesByBlocksWithThinking(
       // Mirror the session-side think marker state machine.
       if (token == thinkStartId) {
         inThinking = true;
-        // Never hashed (a later prompt may not carry it), but it does occupy a
-        // KV row — count that row unless the template re-renders the marker,
-        // in which case the later prompt supplies it.
-        if (!thinkStartInHistory) ++thinkCount;
+        // Not hashed, but it occupies a KV row unless the template
+        // re-renders it, in which case the later prompt supplies that row.
+        if (!markersInHistory.start) ++thinkCount;
         continue;
       }
       if (token == thinkEndId) {
         inThinking = false;
-        if (!thinkEndInHistory) ++thinkCount;  // Same as thinkStartId above
+        if (!markersInHistory.end) ++thinkCount;
         continue;
       }
       if (inThinking) {

--- a/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
+++ b/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
@@ -284,6 +284,10 @@ const StaticTokenizerInfo& deepseekR1Info() {
       /*assistantHeaderSequence=*/{128804},
       /*thinkStartTokenId=*/128798,
       /*thinkEndTokenId=*/128799,
+      // Past assistant turns render as `content.split('</think>')[-1]`, so the
+      // reasoning and BOTH delimiters are gone from later prompts.
+      /*thinkStartInHistory=*/false,
+      /*thinkEndInHistory=*/false,
   };
   return kInfo;
 }
@@ -306,6 +310,11 @@ const StaticTokenizerInfo& kimiK26Info() {
       /*assistantHeaderSequence=*/{163588},
       /*thinkStartTokenId=*/163606,  // <think>
       /*thinkEndTokenId=*/163607,    // </think>
+      // Past assistant turns keep both delimiters (`<think></think>` when the
+      // client does not echo reasoning_content back), so the next prompt
+      // supplies those KV rows itself.
+      /*thinkStartInHistory=*/true,
+      /*thinkEndInHistory=*/true,
   };
   return kInfo;
 }
@@ -322,6 +331,11 @@ const StaticTokenizerInfo& kimiK27CodeInfo() {
       /*assistantHeaderSequence=*/{163588},
       /*thinkStartTokenId=*/163606,  // <think>
       /*thinkEndTokenId=*/163607,    // </think>
+      // Past assistant turns keep both delimiters (`<think></think>` when the
+      // client does not echo reasoning_content back), so the next prompt
+      // supplies those KV rows itself.
+      /*thinkStartInHistory=*/true,
+      /*thinkEndInHistory=*/true,
   };
   return kInfo;
 }
@@ -352,13 +366,20 @@ const StaticTokenizerInfo& minimaxM27Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/200050,  // <think>
       /*thinkEndTokenId=*/200051,    // </think>
+      // Past assistant turns render as the answer alone — no delimiters.
+      /*thinkStartInHistory=*/false,
+      /*thinkEndInHistory=*/false,
   };
   return kInfo;
 }
 
-// IDs verified against the fetched MiniMax-M3 tokenizer. Same special-token
-// layout as M2.7 (eos 200020, <think>/</think> 200050/200051); the top-level
-// config.json carries no eos_token_id, so discovery.cpp publishes the
+// IDs verified against the fetched MiniMax-M3 tokenizer. Same eos layout as
+// M2.7 (200020), but M3 reasons in <mm:think>/</mm:think> (200059/200060), NOT
+// the <think>/</think> pair M2.7 uses — its chat template defines
+// think_begin_token = '<mm:think>' and the frontend runs the separate
+// "minimax_m3" reasoning parser. Both pairs exist in the vocab, so the M2.7 ids
+// parse fine and simply never match, silently disabling think filtering. The
+// top-level config.json carries no eos_token_id, so discovery.cpp publishes the
 // generation_config.json that contains it.
 const StaticTokenizerInfo& minimaxM3Info() {
   static const StaticTokenizerInfo kInfo{
@@ -366,8 +387,13 @@ const StaticTokenizerInfo& minimaxM3Info() {
       /*stopTokenIds=*/{},
       /*eosTokenId=*/200020,  // [e~[
       /*assistantHeaderSequence=*/{},
-      /*thinkStartTokenId=*/200050,  // <think>
-      /*thinkEndTokenId=*/200051,    // </think>
+      /*thinkStartTokenId=*/200059,  // <mm:think>
+      /*thinkEndTokenId=*/200060,    // </mm:think>
+      // A past assistant turn is prefixed with a bare `</mm:think>` when the
+      // client does not echo reasoning back; the opening tag only survives
+      // when it does.
+      /*thinkStartInHistory=*/false,
+      /*thinkEndInHistory=*/true,
   };
   return kInfo;
 }
@@ -387,6 +413,10 @@ const StaticTokenizerInfo& glm51Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/154841,  // <think>
       /*thinkEndTokenId=*/154842,    // </think>
+      // Past assistant turns are prefixed with a bare `</think>`; the opening
+      // tag and the reasoning itself are dropped.
+      /*thinkStartInHistory=*/false,
+      /*thinkEndInHistory=*/true,
   };
   return kInfo;
 }
@@ -405,6 +435,9 @@ const StaticTokenizerInfo& glm52Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/154841,  // <think>
       /*thinkEndTokenId=*/154842,    // </think>
+      // Past assistant turns keep both delimiters (`<think></think>`).
+      /*thinkStartInHistory=*/true,
+      /*thinkEndInHistory=*/true,
   };
   return kInfo;
 }
@@ -421,6 +454,11 @@ const StaticTokenizerInfo& deepseekV4ProInfo() {
       /*assistantHeaderSequence=*/{128804},  // <｜Assistant｜>
       /*thinkStartTokenId=*/128821,          // <think>
       /*thinkEndTokenId=*/128822,            // </think>
+      // UNVERIFIED: no chat template is fetched for V4-Pro, so this assumes the
+      // R1-0528 behaviour (both delimiters dropped from history). Re-check once
+      // tokenizers/deepseek-ai/DeepSeek-V4-Pro/ carries a template.
+      /*thinkStartInHistory=*/false,
+      /*thinkEndInHistory=*/false,
   };
   return kInfo;
 }
@@ -443,6 +481,10 @@ const StaticTokenizerInfo& gemma431bItInfo() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/100,  // <|channel>
       /*thinkEndTokenId=*/101,    // <channel|>
+      // strip_thinking() removes the whole `<|channel>thought…<channel|>` span
+      // from past model turns, delimiters included, in both thinking modes.
+      /*thinkStartInHistory=*/false,
+      /*thinkEndInHistory=*/false,
   };
   return kInfo;
 }
@@ -490,6 +532,15 @@ std::pair<uint32_t, uint32_t> thinkTokenIdsFor(config::ModelType model) {
 
 std::pair<uint32_t, uint32_t> thinkTokenIds() {
   return thinkTokenIdsFor(config::modelType());
+}
+
+ThinkMarkersInHistory thinkMarkersInHistoryFor(config::ModelType model) {
+  const auto& info = staticInfoFor(model);
+  return {info.thinkStartInHistory, info.thinkEndInHistory};
+}
+
+ThinkMarkersInHistory thinkMarkersInHistory() {
+  return thinkMarkersInHistoryFor(config::modelType());
 }
 
 }  // namespace tt::utils::tokenizers

--- a/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
+++ b/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
@@ -284,6 +284,7 @@ const StaticTokenizerInfo& deepseekR1Info() {
       /*assistantHeaderSequence=*/{128804},
       /*thinkStartTokenId=*/128798,
       /*thinkEndTokenId=*/128799,
+      // History renders as `content.split('</think>')[-1]`: no delimiters.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/false,
   };
@@ -308,6 +309,7 @@ const StaticTokenizerInfo& kimiK26Info() {
       /*assistantHeaderSequence=*/{163588},
       /*thinkStartTokenId=*/163606,  // <think>
       /*thinkEndTokenId=*/163607,    // </think>
+      // History keeps both delimiters (renders `<think></think>`).
       /*thinkStartInHistory=*/true,
       /*thinkEndInHistory=*/true,
   };
@@ -326,6 +328,7 @@ const StaticTokenizerInfo& kimiK27CodeInfo() {
       /*assistantHeaderSequence=*/{163588},
       /*thinkStartTokenId=*/163606,  // <think>
       /*thinkEndTokenId=*/163607,    // </think>
+      // History keeps both delimiters (renders `<think></think>`).
       /*thinkStartInHistory=*/true,
       /*thinkEndInHistory=*/true,
   };
@@ -358,6 +361,7 @@ const StaticTokenizerInfo& minimaxM27Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/200050,  // <think>
       /*thinkEndTokenId=*/200051,    // </think>
+      // History renders as the answer alone: no delimiters.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/false,
   };
@@ -380,6 +384,8 @@ const StaticTokenizerInfo& minimaxM3Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/200059,  // <mm:think>
       /*thinkEndTokenId=*/200060,    // </mm:think>
+      // History is prefixed with a bare `</mm:think>`; the opening tag only
+      // survives when the client echoes reasoning back.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/true,
   };
@@ -401,6 +407,7 @@ const StaticTokenizerInfo& glm51Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/154841,  // <think>
       /*thinkEndTokenId=*/154842,    // </think>
+      // History is prefixed with a bare `</think>`; opening tag dropped.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/true,
   };
@@ -421,6 +428,7 @@ const StaticTokenizerInfo& glm52Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/154841,  // <think>
       /*thinkEndTokenId=*/154842,    // </think>
+      // History keeps both delimiters (renders `<think></think>`).
       /*thinkStartInHistory=*/true,
       /*thinkEndInHistory=*/true,
   };
@@ -439,6 +447,8 @@ const StaticTokenizerInfo& deepseekV4ProInfo() {
       /*assistantHeaderSequence=*/{128804},  // <｜Assistant｜>
       /*thinkStartTokenId=*/128821,          // <think>
       /*thinkEndTokenId=*/128822,            // </think>
+      // The HF repo ships no chat template (fetch_tokenizers.sh), so history
+      // is rendered by DeepseekTokenizer, which emits no delimiters.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/false,
   };
@@ -463,6 +473,8 @@ const StaticTokenizerInfo& gemma431bItInfo() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/100,  // <|channel>
       /*thinkEndTokenId=*/101,    // <channel|>
+      // strip_thinking() removes the whole `<|channel>…<channel|>` span from
+      // history, delimiters included, in both thinking modes.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/false,
   };

--- a/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
+++ b/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
@@ -284,7 +284,6 @@ const StaticTokenizerInfo& deepseekR1Info() {
       /*assistantHeaderSequence=*/{128804},
       /*thinkStartTokenId=*/128798,
       /*thinkEndTokenId=*/128799,
-      // History renders as `content.split('</think>')[-1]`: no delimiters.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/false,
   };
@@ -309,7 +308,6 @@ const StaticTokenizerInfo& kimiK26Info() {
       /*assistantHeaderSequence=*/{163588},
       /*thinkStartTokenId=*/163606,  // <think>
       /*thinkEndTokenId=*/163607,    // </think>
-      // History keeps both delimiters (renders `<think></think>`).
       /*thinkStartInHistory=*/true,
       /*thinkEndInHistory=*/true,
   };
@@ -328,7 +326,6 @@ const StaticTokenizerInfo& kimiK27CodeInfo() {
       /*assistantHeaderSequence=*/{163588},
       /*thinkStartTokenId=*/163606,  // <think>
       /*thinkEndTokenId=*/163607,    // </think>
-      // History keeps both delimiters (renders `<think></think>`).
       /*thinkStartInHistory=*/true,
       /*thinkEndInHistory=*/true,
   };
@@ -361,7 +358,6 @@ const StaticTokenizerInfo& minimaxM27Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/200050,  // <think>
       /*thinkEndTokenId=*/200051,    // </think>
-      // History renders as the answer alone: no delimiters.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/false,
   };
@@ -384,8 +380,6 @@ const StaticTokenizerInfo& minimaxM3Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/200059,  // <mm:think>
       /*thinkEndTokenId=*/200060,    // </mm:think>
-      // History is prefixed with a bare `</mm:think>`; the opening tag only
-      // survives when the client echoes reasoning back.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/true,
   };
@@ -407,7 +401,6 @@ const StaticTokenizerInfo& glm51Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/154841,  // <think>
       /*thinkEndTokenId=*/154842,    // </think>
-      // History is prefixed with a bare `</think>`; opening tag dropped.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/true,
   };
@@ -428,7 +421,6 @@ const StaticTokenizerInfo& glm52Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/154841,  // <think>
       /*thinkEndTokenId=*/154842,    // </think>
-      // History keeps both delimiters (renders `<think></think>`).
       /*thinkStartInHistory=*/true,
       /*thinkEndInHistory=*/true,
   };
@@ -447,8 +439,6 @@ const StaticTokenizerInfo& deepseekV4ProInfo() {
       /*assistantHeaderSequence=*/{128804},  // <｜Assistant｜>
       /*thinkStartTokenId=*/128821,          // <think>
       /*thinkEndTokenId=*/128822,            // </think>
-      // The HF repo ships no chat template (fetch_tokenizers.sh), so history
-      // is rendered by DeepseekTokenizer, which emits no delimiters.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/false,
   };
@@ -473,8 +463,6 @@ const StaticTokenizerInfo& gemma431bItInfo() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/100,  // <|channel>
       /*thinkEndTokenId=*/101,    // <channel|>
-      // strip_thinking() removes the whole `<|channel>…<channel|>` span from
-      // history, delimiters included, in both thinking modes.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/false,
   };

--- a/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
+++ b/tt-media-server/cpp_server/src/utils/tokenizers/tokenizer.cpp
@@ -284,8 +284,7 @@ const StaticTokenizerInfo& deepseekR1Info() {
       /*assistantHeaderSequence=*/{128804},
       /*thinkStartTokenId=*/128798,
       /*thinkEndTokenId=*/128799,
-      // Past assistant turns render as `content.split('</think>')[-1]`, so the
-      // reasoning and BOTH delimiters are gone from later prompts.
+      // History renders as `content.split('</think>')[-1]`: no delimiters.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/false,
   };
@@ -310,9 +309,7 @@ const StaticTokenizerInfo& kimiK26Info() {
       /*assistantHeaderSequence=*/{163588},
       /*thinkStartTokenId=*/163606,  // <think>
       /*thinkEndTokenId=*/163607,    // </think>
-      // Past assistant turns keep both delimiters (`<think></think>` when the
-      // client does not echo reasoning_content back), so the next prompt
-      // supplies those KV rows itself.
+      // History keeps both delimiters (renders `<think></think>`).
       /*thinkStartInHistory=*/true,
       /*thinkEndInHistory=*/true,
   };
@@ -331,9 +328,7 @@ const StaticTokenizerInfo& kimiK27CodeInfo() {
       /*assistantHeaderSequence=*/{163588},
       /*thinkStartTokenId=*/163606,  // <think>
       /*thinkEndTokenId=*/163607,    // </think>
-      // Past assistant turns keep both delimiters (`<think></think>` when the
-      // client does not echo reasoning_content back), so the next prompt
-      // supplies those KV rows itself.
+      // History keeps both delimiters (renders `<think></think>`).
       /*thinkStartInHistory=*/true,
       /*thinkEndInHistory=*/true,
   };
@@ -366,7 +361,7 @@ const StaticTokenizerInfo& minimaxM27Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/200050,  // <think>
       /*thinkEndTokenId=*/200051,    // </think>
-      // Past assistant turns render as the answer alone — no delimiters.
+      // History renders as the answer alone: no delimiters.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/false,
   };
@@ -389,9 +384,8 @@ const StaticTokenizerInfo& minimaxM3Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/200059,  // <mm:think>
       /*thinkEndTokenId=*/200060,    // </mm:think>
-      // A past assistant turn is prefixed with a bare `</mm:think>` when the
-      // client does not echo reasoning back; the opening tag only survives
-      // when it does.
+      // History is prefixed with a bare `</mm:think>`; the opening tag only
+      // survives when the client echoes reasoning back.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/true,
   };
@@ -413,8 +407,7 @@ const StaticTokenizerInfo& glm51Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/154841,  // <think>
       /*thinkEndTokenId=*/154842,    // </think>
-      // Past assistant turns are prefixed with a bare `</think>`; the opening
-      // tag and the reasoning itself are dropped.
+      // History is prefixed with a bare `</think>`; opening tag dropped.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/true,
   };
@@ -435,7 +428,7 @@ const StaticTokenizerInfo& glm52Info() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/154841,  // <think>
       /*thinkEndTokenId=*/154842,    // </think>
-      // Past assistant turns keep both delimiters (`<think></think>`).
+      // History keeps both delimiters (renders `<think></think>`).
       /*thinkStartInHistory=*/true,
       /*thinkEndInHistory=*/true,
   };
@@ -454,9 +447,8 @@ const StaticTokenizerInfo& deepseekV4ProInfo() {
       /*assistantHeaderSequence=*/{128804},  // <｜Assistant｜>
       /*thinkStartTokenId=*/128821,          // <think>
       /*thinkEndTokenId=*/128822,            // </think>
-      // UNVERIFIED: no chat template is fetched for V4-Pro, so this assumes the
-      // R1-0528 behaviour (both delimiters dropped from history). Re-check once
-      // tokenizers/deepseek-ai/DeepSeek-V4-Pro/ carries a template.
+      // The HF repo ships no chat template (fetch_tokenizers.sh), so history
+      // is rendered by DeepseekTokenizer, which emits no delimiters.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/false,
   };
@@ -481,8 +473,8 @@ const StaticTokenizerInfo& gemma431bItInfo() {
       /*assistantHeaderSequence=*/{},
       /*thinkStartTokenId=*/100,  // <|channel>
       /*thinkEndTokenId=*/101,    // <channel|>
-      // strip_thinking() removes the whole `<|channel>thought…<channel|>` span
-      // from past model turns, delimiters included, in both thinking modes.
+      // strip_thinking() removes the whole `<|channel>…<channel|>` span from
+      // history, delimiters included, in both thinking modes.
       /*thinkStartInHistory=*/false,
       /*thinkEndInHistory=*/false,
   };

--- a/tt-media-server/cpp_server/tests/integration/server/main_integration_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/server/main_integration_test.cpp
@@ -408,6 +408,16 @@ TEST_F(MainIntegrationTest,
   // Pre-fix, the matched prefix plateaued (corrupt blocks past the matched
   // prefix); the shared helper asserts it instead advances by a full block
   // every turn.
+  //
+  // Caveat on the borrowed tokenizer: think-row accounting is now per model
+  // (tokenizers::ThinkMarkersInHistory), and DeepSeek is registered as dropping
+  // both delimiters from history — while this conversation feeds them back like
+  // Kimi does. So the delimiter rows are counted here even though the next
+  // prompt re-supplies them, which is the Kimi mis-accounting this harness
+  // cannot express. The assertions below are deliberately shape-only (the
+  // prefix advances, never plateaus) and hold either way; the exact row
+  // arithmetic is pinned per policy in conversation_hasher_test's
+  // ConversationHasherThinkRows suite.
   const std::vector<std::string> userMessages = {
       "opening reasoning turn for the think-marker multiturn prefix cache test "
       "with plenty of words so this first message tokenizes to well over "

--- a/tt-media-server/cpp_server/tests/integration/server/main_integration_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/server/main_integration_test.cpp
@@ -407,9 +407,7 @@ TEST_F(MainIntegrationTest,
   //
   // Pre-fix, the matched prefix plateaued (corrupt blocks past the matched
   // prefix); the shared helper asserts it instead advances by a full block
-  // every turn. Assertions are shape-only: the think-row arithmetic depends on
-  // how the caller renders history, which this harness cannot vary, so it is
-  // pinned per policy in conversation_hasher_test's ThinkRows suite.
+  // every turn.
   const std::vector<std::string> userMessages = {
       "opening reasoning turn for the think-marker multiturn prefix cache test "
       "with plenty of words so this first message tokenizes to well over "

--- a/tt-media-server/cpp_server/tests/integration/server/main_integration_test.cpp
+++ b/tt-media-server/cpp_server/tests/integration/server/main_integration_test.cpp
@@ -407,17 +407,9 @@ TEST_F(MainIntegrationTest,
   //
   // Pre-fix, the matched prefix plateaued (corrupt blocks past the matched
   // prefix); the shared helper asserts it instead advances by a full block
-  // every turn.
-  //
-  // Caveat on the borrowed tokenizer: think-row accounting is now per model
-  // (tokenizers::ThinkMarkersInHistory), and DeepSeek is registered as dropping
-  // both delimiters from history — while this conversation feeds them back like
-  // Kimi does. So the delimiter rows are counted here even though the next
-  // prompt re-supplies them, which is the Kimi mis-accounting this harness
-  // cannot express. The assertions below are deliberately shape-only (the
-  // prefix advances, never plateaus) and hold either way; the exact row
-  // arithmetic is pinned per policy in conversation_hasher_test's
-  // ConversationHasherThinkRows suite.
+  // every turn. Assertions are shape-only: the think-row arithmetic depends on
+  // how the caller renders history, which this harness cannot vary, so it is
+  // pinned per policy in conversation_hasher_test's ThinkRows suite.
   const std::vector<std::string> userMessages = {
       "opening reasoning turn for the think-marker multiturn prefix cache test "
       "with plenty of words so this first message tokenizes to well over "

--- a/tt-media-server/cpp_server/tests/unit/model/conversation_hasher_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/model/conversation_hasher_test.cpp
@@ -176,3 +176,110 @@ TEST_F(ConversationHasherTest, RenderLastUserTurn_BosIncludedOnlyWithoutPrior) {
   EXPECT_NE(contDelta.compare(0, cfg.bos_token.size(), cfg.bos_token), 0)
       << "Continuations must not duplicate BOS already in the KV cache";
 }
+
+// ---------------------------------------------------------------------------
+// Think-row accounting (getPrefixCacheHashesByBlocksWithThinking)
+//
+// accumulatedThinkTokens is the correction that turns a block-aligned match
+// back into a KV row index: matched_tokens + accumulatedThinkTokens ==
+// kv_position_id, the first free KV index. So it must count every row the NEXT
+// turn's prompt will not re-supply — the reasoning content always, and each
+// delimiter only when this model's chat template drops it from history.
+//
+// The hashes must be identical under every policy: matching has to work across
+// a prompt that no longer carries the reasoning at all.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+constexpr uint32_t kThinkStart = 90001;
+constexpr uint32_t kThinkEnd = 90002;
+
+// [first block of ordinary tokens] <think> t t </think> [one more block]
+std::vector<uint32_t> tokensWithOneThinkBlock() {
+  const size_t firstBlockSize = tt::config::prefixCacheFirstBlockSize();
+  const size_t blockSize = tt::config::prefixCacheBlockSize();
+  std::vector<uint32_t> tokens;
+  tokens.reserve(firstBlockSize + blockSize + 4);
+  for (size_t i = 0; i < firstBlockSize; ++i) {
+    tokens.push_back(static_cast<uint32_t>(1000 + i));
+  }
+  tokens.push_back(kThinkStart);
+  tokens.push_back(70001);  // reasoning content
+  tokens.push_back(70002);  // reasoning content
+  tokens.push_back(kThinkEnd);
+  for (size_t i = 0; i < blockSize; ++i) {
+    tokens.push_back(static_cast<uint32_t>(2000 + i));
+  }
+  return tokens;
+}
+
+std::vector<BlockHashInfo> hashWithPolicy(bool startInHistory,
+                                          bool endInHistory) {
+  return getPrefixCacheHashesByBlocksWithThinking(tokensWithOneThinkBlock(),
+                                                  kThinkStart, kThinkEnd,
+                                                  startInHistory, endInHistory);
+}
+
+}  // namespace
+
+TEST(ConversationHasherThinkRows, CountsDelimitersDroppedFromHistory) {
+  // DeepSeek / Gemma / MiniMax-M2.7 shape: the next prompt carries neither
+  // delimiter, so both rows are this counter's responsibility.
+  auto blocks =
+      hashWithPolicy(/*startInHistory=*/false, /*endInHistory=*/false);
+  ASSERT_EQ(blocks.size(), 2u);
+  EXPECT_EQ(blocks[0].accumulatedThinkTokens, 0u)
+      << "the think block starts after the first block closes";
+  EXPECT_EQ(blocks[1].accumulatedThinkTokens, 4u)
+      << "2 reasoning tokens + both delimiters occupy KV rows the next "
+         "prompt will not contain";
+}
+
+TEST(ConversationHasherThinkRows, SkipsDelimitersKeptInHistory) {
+  // Kimi / GLM-5.2 shape: the template re-renders `<think></think>`, so those
+  // two rows arrive with the next prompt and must NOT be counted again.
+  auto blocks = hashWithPolicy(/*startInHistory=*/true, /*endInHistory=*/true);
+  ASSERT_EQ(blocks.size(), 2u);
+  EXPECT_EQ(blocks[1].accumulatedThinkTokens, 2u)
+      << "only the reasoning content is missing from the next prompt";
+}
+
+TEST(ConversationHasherThinkRows, CountsEachDelimiterIndependently) {
+  // GLM-5.1 / MiniMax-M3 shape: history keeps the closing delimiter only.
+  auto blocks = hashWithPolicy(/*startInHistory=*/false, /*endInHistory=*/true);
+  ASSERT_EQ(blocks.size(), 2u);
+  EXPECT_EQ(blocks[1].accumulatedThinkTokens, 3u)
+      << "2 reasoning tokens + the dropped opening delimiter";
+}
+
+TEST(ConversationHasherThinkRows, PolicyNeverChangesTheHashes) {
+  // The fingerprint side must stay policy-independent, otherwise a prompt that
+  // renders the delimiters differently stops matching its own session.
+  auto dropped = hashWithPolicy(false, false);
+  auto kept = hashWithPolicy(true, true);
+  auto mixed = hashWithPolicy(false, true);
+  ASSERT_EQ(dropped.size(), kept.size());
+  ASSERT_EQ(dropped.size(), mixed.size());
+  for (size_t i = 0; i < dropped.size(); ++i) {
+    EXPECT_EQ(dropped[i].hash, kept[i].hash) << "block " << i;
+    EXPECT_EQ(dropped[i].hash, mixed[i].hash) << "block " << i;
+  }
+}
+
+TEST(ConversationHasherThinkRows, MatchedPlusThinkEqualsKvRows) {
+  // The invariant the accounting exists to uphold, stated directly: for a
+  // prompt that re-renders neither delimiter, the matched (hashed) token count
+  // plus the think rows must equal the number of KV rows consumed.
+  const size_t firstBlockSize = tt::config::prefixCacheFirstBlockSize();
+  const size_t blockSize = tt::config::prefixCacheBlockSize();
+  const auto tokens = tokensWithOneThinkBlock();
+
+  auto blocks =
+      hashWithPolicy(/*startInHistory=*/false, /*endInHistory=*/false);
+  ASSERT_EQ(blocks.size(), 2u);
+
+  const size_t matchedTokens = firstBlockSize + blockSize;  // hashed tokens
+  EXPECT_EQ(matchedTokens + blocks.back().accumulatedThinkTokens, tokens.size())
+      << "kv_position_id must land on the first free KV row";
+}

--- a/tt-media-server/cpp_server/tests/unit/model/conversation_hasher_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/model/conversation_hasher_test.cpp
@@ -184,8 +184,8 @@ TEST_F(ConversationHasherTest, RenderLastUserTurn_BosIncludedOnlyWithoutPrior) {
 
 namespace {
 
-constexpr uint32_t kThinkStart = 90001;
-constexpr uint32_t kThinkEnd = 90002;
+constexpr uint32_t K_THINK_START = 90001;
+constexpr uint32_t K_THINK_END = 90002;
 
 // [first block of ordinary tokens] <think> t t </think> [one more block]
 std::vector<uint32_t> tokensWithOneThinkBlock() {
@@ -196,10 +196,10 @@ std::vector<uint32_t> tokensWithOneThinkBlock() {
   for (size_t i = 0; i < firstBlockSize; ++i) {
     tokens.push_back(static_cast<uint32_t>(1000 + i));
   }
-  tokens.push_back(kThinkStart);
+  tokens.push_back(K_THINK_START);
   tokens.push_back(70001);  // reasoning content
   tokens.push_back(70002);  // reasoning content
-  tokens.push_back(kThinkEnd);
+  tokens.push_back(K_THINK_END);
   for (size_t i = 0; i < blockSize; ++i) {
     tokens.push_back(static_cast<uint32_t>(2000 + i));
   }
@@ -209,7 +209,7 @@ std::vector<uint32_t> tokensWithOneThinkBlock() {
 std::vector<BlockHashInfo> hashWithPolicy(bool startInHistory,
                                           bool endInHistory) {
   return getPrefixCacheHashesByBlocksWithThinking(
-      tokensWithOneThinkBlock(), kThinkStart, kThinkEnd,
+      tokensWithOneThinkBlock(), K_THINK_START, K_THINK_END,
       {.start = startInHistory, .end = endInHistory});
 }
 

--- a/tt-media-server/cpp_server/tests/unit/model/conversation_hasher_test.cpp
+++ b/tt-media-server/cpp_server/tests/unit/model/conversation_hasher_test.cpp
@@ -177,18 +177,10 @@ TEST_F(ConversationHasherTest, RenderLastUserTurn_BosIncludedOnlyWithoutPrior) {
       << "Continuations must not duplicate BOS already in the KV cache";
 }
 
-// ---------------------------------------------------------------------------
-// Think-row accounting (getPrefixCacheHashesByBlocksWithThinking)
-//
-// accumulatedThinkTokens is the correction that turns a block-aligned match
-// back into a KV row index: matched_tokens + accumulatedThinkTokens ==
-// kv_position_id, the first free KV index. So it must count every row the NEXT
-// turn's prompt will not re-supply — the reasoning content always, and each
-// delimiter only when this model's chat template drops it from history.
-//
-// The hashes must be identical under every policy: matching has to work across
-// a prompt that no longer carries the reasoning at all.
-// ---------------------------------------------------------------------------
+// Think-row accounting: matched_tokens + accumulatedThinkTokens ==
+// kv_position_id, so the count must cover every row the NEXT turn's prompt
+// will not re-supply — the reasoning always, each delimiter only when the
+// chat template drops it from history. Hashes stay policy-independent.
 
 namespace {
 
@@ -216,16 +208,15 @@ std::vector<uint32_t> tokensWithOneThinkBlock() {
 
 std::vector<BlockHashInfo> hashWithPolicy(bool startInHistory,
                                           bool endInHistory) {
-  return getPrefixCacheHashesByBlocksWithThinking(tokensWithOneThinkBlock(),
-                                                  kThinkStart, kThinkEnd,
-                                                  startInHistory, endInHistory);
+  return getPrefixCacheHashesByBlocksWithThinking(
+      tokensWithOneThinkBlock(), kThinkStart, kThinkEnd,
+      {.start = startInHistory, .end = endInHistory});
 }
 
 }  // namespace
 
 TEST(ConversationHasherThinkRows, CountsDelimitersDroppedFromHistory) {
-  // DeepSeek / Gemma / MiniMax-M2.7 shape: the next prompt carries neither
-  // delimiter, so both rows are this counter's responsibility.
+  // DeepSeek / Gemma / MiniMax-M2.7 shape: neither delimiter comes back.
   auto blocks =
       hashWithPolicy(/*startInHistory=*/false, /*endInHistory=*/false);
   ASSERT_EQ(blocks.size(), 2u);
@@ -237,8 +228,8 @@ TEST(ConversationHasherThinkRows, CountsDelimitersDroppedFromHistory) {
 }
 
 TEST(ConversationHasherThinkRows, SkipsDelimitersKeptInHistory) {
-  // Kimi / GLM-5.2 shape: the template re-renders `<think></think>`, so those
-  // two rows arrive with the next prompt and must NOT be counted again.
+  // Kimi / GLM-5.2 shape: `<think></think>` is re-rendered, so those two rows
+  // arrive with the next prompt and must NOT be counted again.
   auto blocks = hashWithPolicy(/*startInHistory=*/true, /*endInHistory=*/true);
   ASSERT_EQ(blocks.size(), 2u);
   EXPECT_EQ(blocks[1].accumulatedThinkTokens, 2u)
@@ -254,8 +245,8 @@ TEST(ConversationHasherThinkRows, CountsEachDelimiterIndependently) {
 }
 
 TEST(ConversationHasherThinkRows, PolicyNeverChangesTheHashes) {
-  // The fingerprint side must stay policy-independent, otherwise a prompt that
-  // renders the delimiters differently stops matching its own session.
+  // Otherwise a prompt that renders the delimiters differently stops matching
+  // its own session.
   auto dropped = hashWithPolicy(false, false);
   auto kept = hashWithPolicy(true, true);
   auto mixed = hashWithPolicy(false, true);
@@ -268,9 +259,8 @@ TEST(ConversationHasherThinkRows, PolicyNeverChangesTheHashes) {
 }
 
 TEST(ConversationHasherThinkRows, MatchedPlusThinkEqualsKvRows) {
-  // The invariant the accounting exists to uphold, stated directly: for a
-  // prompt that re-renders neither delimiter, the matched (hashed) token count
-  // plus the think rows must equal the number of KV rows consumed.
+  // With neither delimiter re-rendered, hashed tokens + think rows must equal
+  // the KV rows consumed.
   const size_t firstBlockSize = tt::config::prefixCacheFirstBlockSize();
   const size_t blockSize = tt::config::prefixCacheBlockSize();
   const auto tokens = tokensWithOneThinkBlock();


### PR DESCRIPTION
## Issue
We encountered an issue with prefix caching for the Gemma 4 31B model, where rewind was not working correctly due to an incorrect think-token calculation. The calculation had been tailored to the Kimi model, where the start_think and end_think tokens from the previous turn are present in the tokenized prompt. However, this behavior is not consistent across models. For example, Gemma does not include these tokens in the same way.

As a result, our calculation was off by two tokens. During each rewind, we were therefore rewinding two rows too far, causing us to lose content.

## Implementation
To address this, we updated the Claude skill responsible for creating the StaticTokenizerInfo object for a model. The updated implementation takes into account how the chat template handles each turn, specifically whether start_think and end_think tokens are present in the tokenized prompt. This makes the think-token calculation model-aware and prevents incorrect rewind offsets for models whose chat templates handle these tokens differently.