### PR TITLE
BGE-M3: data-parallel serving on one N300, and batch assembly for a fixed-shape device

### DIFF
--- a/docs/model_support/embedding/README.md
+++ b/docs/model_support/embedding/README.md
@@ -11,7 +11,7 @@ Models with EXPERIMENTAL status are under active development and may have stabil
 | Model Name | [WH Galaxy](https://tenstorrent.com/hardware/galaxy) | [BH QuietBox 2](https://tenstorrent.com/hardware/tt-quietbox) | [WH LoudBox/QuietBox](https://tenstorrent.com/hardware/tt-loudbox) | [N150](https://tenstorrent.com/hardware/wormhole) | [N300](https://tenstorrent.com/hardware/wormhole) |
 | --- | --- | --- | --- | --- | --- |
 | [bge-large-en-v1.5](bge-large-en-v1.5_galaxy.md) | [🛠️ Experimental](bge-large-en-v1.5_galaxy.md) | - | [🛠️ Experimental](bge-large-en-v1.5_t3k.md) | [🛠️ Experimental](bge-large-en-v1.5_n150.md) | [🛠️ Experimental](bge-large-en-v1.5_n300.md) |
-| [bge-m3](bge-m3_p300x2.md) | - | [🛠️ Experimental](bge-m3_p300x2.md) | - | - | - |
+| [bge-m3](bge-m3_p300x2.md) | - | [🛠️ Experimental](bge-m3_p300x2.md) | - | - | [🛠️ Experimental](bge-m3_n300.md) |
 | [Qwen3-Embedding-0.6B](Qwen3-Embedding-0.6B_p300x2.md) | - | [🛠️ Experimental](Qwen3-Embedding-0.6B_p300x2.md) | - | - | - |
 | [Qwen3-Embedding-4B](Qwen3-Embedding-4B_galaxy.md) | [🛠️ Experimental](Qwen3-Embedding-4B_galaxy.md) | [🛠️ Experimental](Qwen3-Embedding-4B_p300x2.md) | [🛠️ Experimental](Qwen3-Embedding-4B_t3k.md) | [🛠️ Experimental](Qwen3-Embedding-4B_n150.md) | [🛠️ Experimental](Qwen3-Embedding-4B_n300.md) |
 | [Qwen3-Embedding-8B](Qwen3-Embedding-8B_galaxy.md) | [🛠️ Experimental](Qwen3-Embedding-8B_galaxy.md) | - | [🛠️ Experimental](Qwen3-Embedding-8B_t3k.md) | [🛠️ Experimental](Qwen3-Embedding-8B_n150.md) | [🛠️ Experimental](Qwen3-Embedding-8B_n300.md) |

--- a/docs/model_support/embedding/bge-m3_n300.md
+++ b/docs/model_support/embedding/bge-m3_n300.md
@@ -1,0 +1,50 @@
+# bge-m3 Tenstorrent Support on N300
+
+#### Useful links
+
+- [N300 details](https://tenstorrent.com/hardware/wormhole)
+- [Search other embedding models](./README.md)
+- [Search other models by model type](../../../README.md#models-by-model-type)
+
+`bge-m3` is also supported on hardware:
+
+- [BH QuietBox 2](bge-m3_p300x2.md)
+
+## Quickstart - Deploy bge-m3 Inference Server on n300
+
+See [prerequisites](../../prerequisites.md) for system software setup, e.g. for first-run or when experiencing issues.
+
+This model is supported by [vLLM (tt-metal integration fork)](../../../vllm-tt-metal/README.md) inference engine.
+
+**docker run command**
+
+```bash
+docker run \
+  --env "HF_TOKEN=$HF_TOKEN" \
+  --ipc host \
+  --publish 8000:8000 \
+  --device /dev/tenstorrent \
+  --mount type=bind,src=/dev/hugepages-1G,dst=/dev/hugepages-1G \
+  --volume volume_id_bge-m3:/home/container_app_user/cache_root \
+  ghcr.io/tenstorrent/tt-media-inference-server:0.20.0-bc294789ec3 \
+  --model bge-m3 \
+  --tt-device n300
+```
+
+**via run.py command**
+
+```bash
+python3 run.py --model bge-m3 --device n300 --workflow server --docker-server
+```
+For details on the run.py command, see the [run.py CLI Options](../../workflows_user_guide.md#runpy-cli-options) section of the User Guide.
+
+## Model Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Weights | [BAAI/bge-m3](https://huggingface.co/BAAI/bge-m3) |
+| Model Status | 🛠️ Experimental |
+| Max Batch Size | 12 |
+| Implementation Code | [tt-vllm-plugin](https://github.com/tenstorrent/tt-inference-server/tree/dev/tt-vllm-plugin/tree/bc294789ec3/tt_vllm_plugin) |
+| tt-metal Commit | `bc294789ec3` |
+| Docker Image | `ghcr.io/tenstorrent/tt-media-inference-server:0.20.0-bc294789ec3` |

--- a/docs/model_support/embedding/bge-m3_p300x2.md
+++ b/docs/model_support/embedding/bge-m3_p300x2.md
@@ -6,6 +6,10 @@
 - [Search other embedding models](./README.md)
 - [Search other models by model type](../../../README.md#models-by-model-type)
 
+`bge-m3` is also supported on hardware:
+
+- [N300](bge-m3_n300.md)
+
 ## Quickstart - Deploy bge-m3 Inference Server on BH QuietBox 2
 
 See [prerequisites](../../prerequisites.md) for system software setup, e.g. for first-run or when experiencing issues.

--- a/docs/model_support/models_by_hardware.md
+++ b/docs/model_support/models_by_hardware.md
@@ -201,6 +201,7 @@ This page lists all supported models organized by hardware type.
 | 🛠️ Experimental | CNN | [efficientnet](cnn/efficientnet_n300.md) |
 | 🛠️ Experimental | CNN | [unet](cnn/unet_n300.md) |
 | 🛠️ Experimental | Embedding | [bge-large-en-v1.5](embedding/bge-large-en-v1.5_n300.md) |
+| 🛠️ Experimental | Embedding | [bge-m3](embedding/bge-m3_n300.md) |
 | 🛠️ Experimental | Embedding | [Qwen3-Embedding-4B](embedding/Qwen3-Embedding-4B_n300.md) |
 | 🛠️ Experimental | Embedding | [Qwen3-Embedding-8B](embedding/Qwen3-Embedding-8B_n300.md) |
 | 🛠️ Experimental | LLM | [AFM-4.5B](llm/AFM-4.5B_n300.md) |

--- a/release_model_spec.json
+++ b/release_model_spec.json
@@ -24078,6 +24078,91 @@
             "cli_args": {}
           }
         }
+      },
+      "N300": {
+        "media": {
+          "tt_vllm_plugin": {
+            "model_id": "id_tt-vllm-plugin_bge-m3_n300",
+            "impl": {
+              "impl_id": "tt_vllm_plugin",
+              "impl_name": "tt-vllm-plugin",
+              "repo_url": "https://github.com/tenstorrent/tt-inference-server/tree/dev/tt-vllm-plugin",
+              "code_path": "tt_vllm_plugin"
+            },
+            "hf_model_repo": "BAAI/bge-m3",
+            "model_name": "bge-m3",
+            "inference_engine": "media",
+            "device_type": "N300",
+            "device_model_spec": {
+              "device": "N300",
+              "max_concurrency": 12,
+              "max_context": 8192,
+              "max_tokens_all_users_override": null,
+              "perf_targets_map": {},
+              "default_impl": true,
+              "perf_reference": [],
+              "vllm_args": {
+                "model": "BAAI/bge-large-en-v1.5",
+                "block_size": "64",
+                "max_model_len": "65536",
+                "max_num_seqs": "1",
+                "max_num_batched_tokens": "65536",
+                "max-log-len": "32",
+                "seed": "9472",
+                "additional_config": "{\"tt\": {}}"
+              },
+              "override_tt_config": {},
+              "env_vars": {
+                "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
+                "MESH_DEVICE": "N300",
+                "ARCH_NAME": "wormhole_b0",
+                "VLLM__MAX_MODEL_LENGTH": "8192",
+                "VLLM__MAX_NUM_SEQS": "12",
+                "MAX_BATCH_SIZE": "12"
+              },
+              "tensor_cache_timeout": 3600.0,
+              "system_requirements": null,
+              "known_issues": [],
+              "eval_max_retries": null,
+              "image_benchmark_num_batches": 3
+            },
+            "system_requirements": null,
+            "env_vars": {
+              "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
+              "MESH_DEVICE": "N300",
+              "ARCH_NAME": "wormhole_b0",
+              "VLLM__MAX_MODEL_LENGTH": "8192",
+              "VLLM__MAX_NUM_SEQS": "12",
+              "MAX_BATCH_SIZE": "12"
+            },
+            "tt_metal_commit": "bc294789ec3",
+            "vllm_commit": null,
+            "hf_weights_repo": "BAAI/bge-m3",
+            "param_count": null,
+            "min_disk_gb": 25,
+            "min_ram_gb": 16,
+            "model_type": "EMBEDDING",
+            "repacked": 0,
+            "version": "0.12.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
+            "status": "EXPERIMENTAL",
+            "code_link": "https://github.com/tenstorrent/tt-inference-server/tree/dev/tt-vllm-plugin/tree/65718bb/tt_vllm_plugin",
+            "override_tt_config": {},
+            "supported_modalities": [
+              "text"
+            ],
+            "subdevice_type": null,
+            "uses_tensor_model_cache": true,
+            "has_builtin_warmup": false,
+            "metadata": {},
+            "cli_args": {
+              "model": "BAAI/bge-m3",
+              "max_model_len": "8192",
+              "max_num_seqs": "12",
+              "max_num_batched_tokens": "98304"
+            }
+          }
+        }
       }
     },
     "Qwen/Qwen3-4B": {

--- a/release_model_spec.json
+++ b/release_model_spec.json
@@ -23943,6 +23943,138 @@
       }
     },
     "BAAI/bge-m3": {
+      "N300": {
+        "vLLM": {
+          "tt_vllm_plugin": {
+            "model_id": "id_tt-vllm-plugin_bge-m3_n300",
+            "impl": {
+              "impl_id": "tt_vllm_plugin",
+              "impl_name": "tt-vllm-plugin",
+              "repo_url": "https://github.com/tenstorrent/tt-inference-server/tree/dev/tt-vllm-plugin",
+              "code_path": "tt_vllm_plugin"
+            },
+            "hf_model_repo": "BAAI/bge-m3",
+            "model_name": "bge-m3",
+            "inference_engine": "vLLM",
+            "device_type": "N300",
+            "device_model_spec": {
+              "device": "N300",
+              "max_concurrency": 12,
+              "max_context": 8192,
+              "max_tokens_all_users_override": null,
+              "perf_targets_map": {},
+              "default_impl": true,
+              "perf_reference": [
+                {
+                  "isl": null,
+                  "osl": null,
+                  "max_concurrency": 1,
+                  "num_prompts": null,
+                  "image_height": null,
+                  "image_width": null,
+                  "images_per_prompt": null,
+                  "task_type": "embedding",
+                  "data_parallel": null,
+                  "theoretical_ttft_ms": null,
+                  "theoretical_tput_user": null,
+                  "targets": {
+                    "functional": {
+                      "ttft_ms": null,
+                      "tput_user": 575.0,
+                      "tput": null,
+                      "tolerance": 0.0
+                    },
+                    "complete": {
+                      "ttft_ms": null,
+                      "tput_user": 2875.0,
+                      "tput": null,
+                      "tolerance": 0.0
+                    },
+                    "target": {
+                      "ttft_ms": null,
+                      "tput_user": 5750.0,
+                      "tput": null,
+                      "tolerance": 0.0
+                    }
+                  },
+                  "target_peak_perf": {
+                    "customer_functional": 0.1,
+                    "customer_complete": 0.5,
+                    "customer_sellable": 0.8
+                  },
+                  "num_inference_steps": null,
+                  "structured_dataset": null,
+                  "structured_output_ratio": null
+                }
+              ],
+              "vllm_args": {
+                "model": "BAAI/bge-m3",
+                "block_size": "64",
+                "max_model_len": "8192",
+                "max_num_seqs": "12",
+                "max_num_batched_tokens": "8192",
+                "max-log-len": "32",
+                "seed": "9472",
+                "additional_config": "{\"tt\": {}}"
+              },
+              "override_tt_config": {},
+              "env_vars": {
+                "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
+                "MESH_DEVICE": "(2,1)",
+                "ARCH_NAME": "wormhole_b0",
+                "MAX_MODEL_LENGTH": "8192",
+                "MAX_NUM_SEQS": "12",
+                "MAX_BATCH_SIZE": "12",
+                "USE_DYNAMIC_BATCHER": "false",
+                "BATCH_LINGER_SECONDS": "0.3",
+                "DEFAULT_THROTTLE_LEVEL": "0"
+              },
+              "tensor_cache_timeout": 3600.0,
+              "system_requirements": null,
+              "known_issues": [],
+              "eval_max_retries": null,
+              "image_benchmark_num_batches": 3
+            },
+            "system_requirements": null,
+            "env_vars": {
+              "VLLM_CONFIGURE_LOGGING": "1",
+              "VLLM_RPC_TIMEOUT": "900000",
+              "VLLM_TARGET_DEVICE": "tt",
+              "TORCHDYNAMO_DISABLE": "1",
+              "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
+              "MESH_DEVICE": "(2,1)",
+              "ARCH_NAME": "wormhole_b0",
+              "MAX_MODEL_LENGTH": "8192",
+              "MAX_NUM_SEQS": "12",
+              "MAX_BATCH_SIZE": "12",
+              "USE_DYNAMIC_BATCHER": "false",
+              "BATCH_LINGER_SECONDS": "0.3",
+              "DEFAULT_THROTTLE_LEVEL": "0"
+            },
+            "tt_metal_commit": "bc294789ec3",
+            "vllm_commit": null,
+            "hf_weights_repo": "BAAI/bge-m3",
+            "param_count": null,
+            "min_disk_gb": 25,
+            "min_ram_gb": 16,
+            "model_type": "EMBEDDING",
+            "repacked": 0,
+            "version": "0.20.0",
+            "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.20.0-bc294789ec3",
+            "status": "EXPERIMENTAL",
+            "code_link": "https://github.com/tenstorrent/tt-inference-server/tree/dev/tt-vllm-plugin/tree/bc294789ec3/tt_vllm_plugin",
+            "override_tt_config": {},
+            "supported_modalities": [
+              "text"
+            ],
+            "subdevice_type": null,
+            "uses_tensor_model_cache": true,
+            "has_builtin_warmup": false,
+            "metadata": {},
+            "cli_args": {}
+          }
+        }
+      },
       "P300X2": {
         "forge": {
           "forge_vllm_plugin": {
@@ -24076,91 +24208,6 @@
             "has_builtin_warmup": false,
             "metadata": {},
             "cli_args": {}
-          }
-        }
-      },
-      "N300": {
-        "media": {
-          "tt_vllm_plugin": {
-            "model_id": "id_tt-vllm-plugin_bge-m3_n300",
-            "impl": {
-              "impl_id": "tt_vllm_plugin",
-              "impl_name": "tt-vllm-plugin",
-              "repo_url": "https://github.com/tenstorrent/tt-inference-server/tree/dev/tt-vllm-plugin",
-              "code_path": "tt_vllm_plugin"
-            },
-            "hf_model_repo": "BAAI/bge-m3",
-            "model_name": "bge-m3",
-            "inference_engine": "media",
-            "device_type": "N300",
-            "device_model_spec": {
-              "device": "N300",
-              "max_concurrency": 12,
-              "max_context": 8192,
-              "max_tokens_all_users_override": null,
-              "perf_targets_map": {},
-              "default_impl": true,
-              "perf_reference": [],
-              "vllm_args": {
-                "model": "BAAI/bge-large-en-v1.5",
-                "block_size": "64",
-                "max_model_len": "65536",
-                "max_num_seqs": "1",
-                "max_num_batched_tokens": "65536",
-                "max-log-len": "32",
-                "seed": "9472",
-                "additional_config": "{\"tt\": {}}"
-              },
-              "override_tt_config": {},
-              "env_vars": {
-                "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
-                "MESH_DEVICE": "N300",
-                "ARCH_NAME": "wormhole_b0",
-                "VLLM__MAX_MODEL_LENGTH": "8192",
-                "VLLM__MAX_NUM_SEQS": "12",
-                "MAX_BATCH_SIZE": "12"
-              },
-              "tensor_cache_timeout": 3600.0,
-              "system_requirements": null,
-              "known_issues": [],
-              "eval_max_retries": null,
-              "image_benchmark_num_batches": 3
-            },
-            "system_requirements": null,
-            "env_vars": {
-              "WH_ARCH_YAML": "wormhole_b0_80_arch_eth_dispatch.yaml",
-              "MESH_DEVICE": "N300",
-              "ARCH_NAME": "wormhole_b0",
-              "VLLM__MAX_MODEL_LENGTH": "8192",
-              "VLLM__MAX_NUM_SEQS": "12",
-              "MAX_BATCH_SIZE": "12"
-            },
-            "tt_metal_commit": "bc294789ec3",
-            "vllm_commit": null,
-            "hf_weights_repo": "BAAI/bge-m3",
-            "param_count": null,
-            "min_disk_gb": 25,
-            "min_ram_gb": 16,
-            "model_type": "EMBEDDING",
-            "repacked": 0,
-            "version": "0.12.0",
-            "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
-            "status": "EXPERIMENTAL",
-            "code_link": "https://github.com/tenstorrent/tt-inference-server/tree/dev/tt-vllm-plugin/tree/65718bb/tt_vllm_plugin",
-            "override_tt_config": {},
-            "supported_modalities": [
-              "text"
-            ],
-            "subdevice_type": null,
-            "uses_tensor_model_cache": true,
-            "has_builtin_warmup": false,
-            "metadata": {},
-            "cli_args": {
-              "model": "BAAI/bge-m3",
-              "max_model_len": "8192",
-              "max_num_seqs": "12",
-              "max_num_batched_tokens": "98304"
-            }
           }
         }
       }

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -38,6 +38,10 @@ class Settings(BaseSettings):
     device_ids: str = DeviceIds.DEVICE_IDS_32.value
     is_galaxy: bool = True  # used for graph device split and class init
     device_mesh_shape: tuple = (1, 1)
+    # Seconds the device worker waits for a batch to reach max_batch_size after the
+    # first request arrives. A fixed-shape forward costs the same for 1 request as
+    # for max_batch_size, so waiting raises throughput. 0.0 disables the wait.
+    batch_linger_seconds: float = 0.0
     reset_device_command: str = "tt-smi -r"
     reset_device_sleep_time: float = 5.0
     allow_deep_reset: bool = False

--- a/tt-media-server/device_workers/device_worker.py
+++ b/tt-media-server/device_workers/device_worker.py
@@ -185,6 +185,7 @@ def device_worker(
             max_messages_to_get=settings.max_batch_size,
             block=True,
             timeout=0.2,  # 200ms timeout - the batch queue will handle optimal batching
+            linger=settings.batch_linger_seconds,
         )
         if requests is None or len(requests) == 0:
             continue

--- a/tt-media-server/model_services/queues/memory_queue.py
+++ b/tt-media-server/model_services/queues/memory_queue.py
@@ -314,6 +314,7 @@ class SharedMemoryChunkQueue(TTQueueInterface):
         max_messages_to_get: int = 100,
         block: bool = True,
         timeout: float = None,
+        linger: float = 0.0,
     ) -> list:
         """
         Get multiple items at once - optimized batch version.
@@ -322,6 +323,11 @@ class SharedMemoryChunkQueue(TTQueueInterface):
             max_messages_to_get: Maximum number of items to retrieve
             block: If True, wait for at least one item
             timeout: Maximum time to wait (only used if block=True)
+            linger: After the first item arrives, keep waiting up to this many
+                seconds for the batch to reach max_messages_to_get. A device that
+                runs one fixed-shape forward per batch pays the same cost for 1
+                item as for max_messages_to_get, so a short wait here raises
+                throughput. 0.0 keeps the original behaviour.
 
         Returns:
             List of items (may be empty if block=False and queue is empty)
@@ -345,10 +351,30 @@ class SharedMemoryChunkQueue(TTQueueInterface):
             # We have at least one item, break out of the waiting loop
             break
 
+        # Give the batch time to fill. The producer writes one item per request,
+        # so without this the reader takes whatever landed in the same instant and
+        # a fixed-shape device runs mostly padding. Stop early once the batch is
+        # full, and never raise: the caller treats a timeout as fatal.
+        if linger > 0 and max_messages_to_get > 1:
+            linger_deadline = time.time() + linger
+            while time.time() < linger_deadline:
+                write_idx = self._get_write_idx()
+                pending = (
+                    write_idx - read_idx
+                    if write_idx >= read_idx
+                    else (self.capacity - read_idx) + write_idx
+                )
+                if pending >= max_messages_to_get:
+                    break
+                time.sleep(0.001)
+
         # Calculate how many items we can read in one batch
         if read_idx < 0 or read_idx >= self.capacity:
             self.logger.error(f"CORRUPTION: read_idx {read_idx} out of bounds!")
             return []
+
+        # Re-read: the linger above may have admitted more items.
+        write_idx = self._get_write_idx()
 
         # Calculate available items
         if write_idx >= read_idx:

--- a/tt-media-server/model_services/queues/tt_batch_fifo_queue.py
+++ b/tt-media-server/model_services/queues/tt_batch_fifo_queue.py
@@ -69,6 +69,7 @@ class TTBatchFifoQueue(TTQueueInterface):
         max_messages_to_get: int = 100,
         block: bool = True,
         timeout: Optional[float] = None,
+        linger: float = 0.0,  # accepted for interface parity; this queue batches itself
     ) -> List:
         """
         Smart batching get_many that tries to get full batches.

--- a/tt-media-server/model_services/queues/tt_faster_fifo_queue.py
+++ b/tt-media-server/model_services/queues/tt_faster_fifo_queue.py
@@ -64,6 +64,7 @@ class TTFasterFifoQueue(TTQueueInterface):
         max_messages_to_get: int = 100,
         block: bool = True,
         timeout: Optional[float] = None,
+        linger: float = 0.0,  # accepted for interface parity; this queue batches itself
     ) -> List:
         """
         Get multiple items at once - much faster than individual gets.

--- a/tt-media-server/model_services/queues/tt_queue.py
+++ b/tt-media-server/model_services/queues/tt_queue.py
@@ -2,6 +2,7 @@
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
+import time
 from multiprocessing import get_context
 from multiprocessing.queues import Queue
 from queue import Empty
@@ -45,9 +46,15 @@ class TTQueue(Queue, TTQueueInterface):
         max_messages_to_get: int = 100,
         block: bool = True,
         timeout: Optional[float] = None,
+        linger: float = 0.0,
     ) -> List:
         """
         multiprocessing.Queue doesn't have batch get, get one item as fallback
+
+        ``linger`` keeps waiting after the first item for the batch to reach
+        ``max_messages_to_get``. A device that runs one fixed-shape forward per
+        batch pays the same cost for 1 item as for a full batch, so a short wait
+        raises throughput. 0.0 keeps the original behaviour.
         """
         batch = []
 
@@ -62,7 +69,8 @@ class TTQueue(Queue, TTQueueInterface):
             return []
 
         # Aggressively try to get more items
-        for _ in range(max_messages_to_get - 1):
+        deadline = (time.monotonic() + linger) if linger > 0 else None
+        while len(batch) < max_messages_to_get:
             try:
                 item = self.get_nowait()
                 if item is None:
@@ -70,8 +78,14 @@ class TTQueue(Queue, TTQueueInterface):
                     batch.append(None)
                     break
                 batch.append(item)
+                continue
             except Exception:
+                pass
+            # The queue is empty right now. Wait for a producer, unless the linger
+            # window has closed.
+            if deadline is None or time.monotonic() >= deadline:
                 break
+            time.sleep(0.001)
 
         return batch
 

--- a/tt-media-server/model_services/queues/tt_queue_interface.py
+++ b/tt-media-server/model_services/queues/tt_queue_interface.py
@@ -60,8 +60,12 @@ class TTQueueInterface(ABC):
         max_messages_to_get: int = 100,
         block: bool = True,
         timeout: Optional[float] = None,
+        linger: float = 0.0,
     ) -> List[Any]:
-        """Get multiple items from the queue."""
+        """Get multiple items from the queue.
+
+        ``linger`` optionally waits after the first item for the batch to fill.
+        """
         pass
 
     @abstractmethod

--- a/tt-media-server/tt_model_runners/embedding_runner.py
+++ b/tt-media-server/tt_model_runners/embedding_runner.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
 
+import asyncio
 import os
 
 import torch
@@ -27,6 +28,25 @@ def _model_location_generator(model_version: str) -> str:
 class EmbeddingRunner(BaseMetalDeviceRunner):
     def __init__(self, device_id: str):
         super().__init__(device_id)
+        # One device, one forward at a time. Created here so every subclass has it.
+        self._device_lock = asyncio.Lock()
+
+    async def _run_async(self, requests: list[TextEmbeddingRequest]):
+        """Run one batch off the event loop.
+
+        device_worker schedules every request through this method and reads
+        result[0], so an embedding runner needs it just as a text runner does.
+
+        run() holds the device for the whole forward, which would otherwise block
+        the loop and stall the health endpoint. A thread keeps the loop free.
+
+        The lock is required. device_worker keeps max_batch_size requests in
+        flight, and every one of them refills the same traced input buffers on the
+        same device. Two threads inside run() overwrite each other and return
+        non-finite embeddings, which then fail JSON encoding.
+        """
+        async with self._device_lock:
+            return await asyncio.to_thread(self.run, requests)
 
     def _process_result(
         self,
@@ -127,6 +147,19 @@ class BGEM3Runner(EmbeddingRunner):
             "num_command_queues": 2,
             "trace_region_size": self.settings.trace_region_size,
         }
+
+    def _configure_fabric(self, updated_device_params):
+        """Turn fabric on for the 2-chip mesh.
+
+        The base runner returns None, which leaves fabric off. Opening a (2, 1) mesh
+        then fails with "Timed out waiting for ETH heartbeat", because the two chips
+        talk over ethernet. A single-chip mesh needs no fabric.
+        """
+        if tuple(self.settings.device_mesh_shape) == (1, 1):
+            return None
+        fabric_config = updated_device_params.pop("fabric_config", ttnn.FabricConfig.FABRIC_1D)
+        ttnn.set_fabric_config(fabric_config)
+        return fabric_config
 
     def run(self, requests: list[TextEmbeddingRequest]):
         self._validate_requests(requests)

--- a/tt-vllm-plugin/tt_vllm_plugin/__init__.py
+++ b/tt-vllm-plugin/tt_vllm_plugin/__init__.py
@@ -64,5 +64,21 @@ def register_models():
             "Qwen3-Embedding model may not be available. Ensure tt-metal is in Python path."
         )
 
+    # Register BGE-M3 embedding model (TTXLMRobertaModel)
+    # BGE-M3 reports the architecture XLMRobertaModel, and platform.py prepends "TT".
+    try:
+        ModelRegistry.register_model(
+            "TTXLMRobertaModel",
+            "models.demos.wormhole.bge_m3.demo.generator_vllm:BgeM3ForEmbedding",
+        )
+        print("Registered BGE-M3 embedding model")
+    except Exception as e:
+        import logging
+
+        logging.warning(
+            f"Failed to register TTXLMRobertaModel (BGE-M3): {e}. "
+            "BGE-M3 model may not be available. Ensure tt-metal is in Python path."
+        )
+
     # Add additional model registrations here as needed
     # ModelRegistry.register_model("AnotherModel", "path.to:ModelClass")

--- a/tt-vllm-plugin/tt_vllm_plugin/v1/worker/tt_model_runner_pooling.py
+++ b/tt-vllm-plugin/tt_vllm_plugin/v1/worker/tt_model_runner_pooling.py
@@ -194,6 +194,10 @@ class TTModelRunnerPooling:
             input_ids=tokens,
             attention_mask=attention_mask,
         )
+        # A model that carries several heads returns them in a dict. Take the dense
+        # vectors, which is what a pooling request asks for.
+        if isinstance(embeddings, dict):
+            embeddings = embeddings["dense_vecs"]
 
         # Convert embeddings to list of tensors format expected by vLLM
         # embeddings shape: [batch_size, embedding_dim]

--- a/workflows/model_specs/prod/embedding.yaml
+++ b/workflows/model_specs/prod/embedding.yaml
@@ -323,6 +323,34 @@ templates:
 - weights:
     - BAAI/bge-m3
   version: "0.20.0"
+  tt_metal_commit: "bc294789ec3"
+  impl: tt_vllm_plugin
+  min_disk_gb: 25
+  min_ram_gb: 16
+  model_type: EMBEDDING
+  inference_engine: VLLM
+  device_model_specs:
+    - device: N300
+      max_concurrency: 12
+      max_context: 8192
+      default_impl: true
+      env_vars:
+        # Both chips form one mesh. ModelArgs turns on the data-parallel serving
+        # modules at batch 12 over 8192 tokens, and each chip then runs 6 rows.
+        MESH_DEVICE: "(2,1)"
+        MAX_MODEL_LENGTH: "8192"
+        MAX_NUM_SEQS: "12"
+        MAX_BATCH_SIZE: "12"
+        # settings.py turns the dynamic batcher on whenever max_num_seqs > 1, but
+        # that worker sends one request per call to the runner. The serial worker
+        # collects up to MAX_BATCH_SIZE and runs them in one forward, which is what
+        # this fixed-shape path needs. Measured over 60 requests at 8192 tokens:
+        # 66.9 s with the dynamic batcher, 24.1 s without it.
+        USE_DYNAMIC_BATCHER: "false"
+        DEFAULT_THROTTLE_LEVEL: "0"
+- weights:
+    - BAAI/bge-m3
+  version: "0.20.0"
   tt_metal_commit: "de59f8a"
   impl: forge_vllm_plugin
   min_disk_gb: 15

--- a/workflows/model_specs/prod/embedding.yaml
+++ b/workflows/model_specs/prod/embedding.yaml
@@ -347,6 +347,10 @@ templates:
         # this fixed-shape path needs. Measured over 60 requests at 8192 tokens:
         # 66.9 s with the dynamic batcher, 24.1 s without it.
         USE_DYNAMIC_BATCHER: "false"
+        # Wait this long after the first request for the batch to reach 12. One
+        # forward costs the same for 1 request as for 12, so the wait pays for
+        # itself. Over 60 requests at 8192 tokens: 26.3 s without it, 6.8 s with.
+        BATCH_LINGER_SECONDS: "0.3"
         DEFAULT_THROTTLE_LEVEL: "0"
 - weights:
     - BAAI/bge-m3


### PR DESCRIPTION
### Ticket

N/A

### What's changed

This branch serves `BAAI/bge-m3` on one N300 through tt-media-server. It uses the
batch 12 over 8192 token data-parallel path from tt-metal.

Both chips form one `(2,1)` mesh. The host passes batch 12, `ShardTensorToMesh`
splits it 6+6, and each chip runs a full-sequence replica with no collectives.
The forward replays a captured trace.

**Where the model comes from**

`runner_fabric` already maps `ModelRunners.BGEM3` to `BGEM3Runner`, and that
runner already imports `bge_m3.demo.generator_vllm:BgeM3ForEmbedding`. The
data-parallel selection and the trace live inside that class in tt-metal, so
both engines get them without a runner change.

### Starting point

The first working configuration ran 60 requests in **66.95 s**: 0.90 req/s and
7342 tok/s.

The device runs one B12/S8192 forward in 989 ms. Sixty requests in batches of 12
is five forwards, so the floor is about 5 s. The whole gap sat in request
handling, not in the model.

I instrumented `BGEM3Runner.run` to record the batch size the device received:

| Batch size | Count |
| --- | --- |
| 1 | 6 |
| 2 | 3 |
| 3 | 1 |
| 4 | 3 |
| 5 | 4 |
| 7 | 2 |

That is 19 forwards for 60 requests. The average batch held 3.2 requests and
never reached 12. A fixed-shape device pays the same 989 ms whatever the batch
holds, so most of that work was padding.

### Fixes

- **`_run_async` on `EmbeddingRunner`.** `device_worker` schedules every request
  through `device_runner._run_async([req])` and reads `result[0]`, but the
  embedding runners only had `run()`. A request raised `AttributeError` before it
  reached the device. The base class now runs the batch through
  `asyncio.to_thread`, so a forward does not block the event loop or `/health`.

- **A device lock around the forward.** `device_worker` keeps `max_batch_size`
  requests in flight, and each one refills the same traced input buffers on the
  same device. Two threads inside `run()` overwrote each other and returned
  non-finite embeddings, which failed JSON encoding with `Out of range float
  values are not JSON compliant`. Trace replay binds to the buffers it recorded,
  so the caller must serialize.

- **Fabric for a multi-chip mesh.** `_configure_fabric` returns `None` on the
  base runner. Opening a `(2,1)` mesh without fabric fails with `Timed out
  waiting for ETH heartbeat`. `BGEM3Runner` now sets `FABRIC_1D` for any mesh
  wider than one chip.

- **`linger` on `get_many`.** The queue returned as soon as one item existed, so
  the worker took whatever landed in that instant. After the first item,
  `get_many` now waits up to `batch_linger_seconds` for the batch to reach
  `max_batch_size`, and returns early once it is full. The default is `0.0`, so
  every other caller keeps its current behaviour. All five implementations behind
  `TTQueueInterface` accept the parameter.

- **`USE_DYNAMIC_BATCHER=false` in the catalog entry.** `settings.py` enables the
  dynamic batcher whenever `max_num_seqs > 1`, but
  `device_worker_dynamic_batch.handle_non_streaming` calls the runner once per
  request. The serial `device_worker` is the one that collects up to
  `max_batch_size` and passes the whole list to `run()`. Over 60 requests: 66.95 s
  with the dynamic batcher, 26.29 s without it.

- **Dense vectors from a multi-head return.** `tt_model_runner_pooling` indexed
  `embeddings[i]`, but bge-m3 returns a dict of dense, sparse, and colbert heads,
  so it indexed the dict. It now takes `dense_vecs` when the return is a dict. A
  model that returns a plain tensor is unaffected.

- **Catalog entry, then regenerate.** The entry belongs in
  `workflows/model_specs/prod/embedding.yaml`, which is what `MODEL_SPECS` loads.
  `release_model_spec.json` is generated from it, so I added the entry to the
  catalog and ran `scripts/release/export_model_spec.py`. That also produced
  `docs/model_support/embedding/bge-m3_n300.md`.

### Result

`vllm bench serve`, 60 requests, ISL 8192, concurrency 12, `--num-warmups 12`:

```
Successful requests:                     60
Failed requests:                         0
Benchmark duration (s):                  6.58
Total input tokens:                      491520
Request throughput (req/s):              9.12
Total token throughput (tok/s):          74691.92
Mean E2EL (ms):                          1311.97
P99 E2EL (ms):                           1335.36
```

| Configuration | Duration | req/s | tok/s |
| --- | --- | --- | --- |
| Dynamic batcher (default) | 66.95 s | 0.90 | 7342 |
| Serial worker | 26.29 s | 2.28 | 18696 |
| Serial worker + 300 ms linger | 6.77 s | 8.86 | 72622 |
| Plus an explicit warmup batch | **6.58 s** | **9.12** | **74692** |

That is 10.2 times the first configuration, and 75 percent of the device ceiling
of five forwards at 989 ms. Every batch now holds 12 requests, and the latency
spread is tight: P99 1335 ms against a mean of 1312 ms.

### Reviewer notes

1. **The remaining 1.56 s is host work serialized with the device.** Tokenizing
   12 rows of 8192 tokens costs about 107 ms per batch while the device is idle.
   The forward also measures 1141 ms inside the server against 987 ms when I call
   it directly, and I did not isolate that 152 ms. Closing the gap needs a
   tokenization prefetch thread in the worker loop. I wrote a version, measured
   no gain, and reverted it: the split alone overlaps nothing, and my first
   prefetch attempt risked dropping requests. It deserves its own change.

2. **The dynamic batcher name is inverted for a fixed-shape device.**
   `device_worker_dynamic_batch` sends one request per call, and the serial
   `device_worker` is the one that batches. `settings.py` auto-enables the former,
   so the default configuration defeats batching for any runner that wants a full
   batch. The catalog entry opts out, but the default is worth revisiting.

3. **`DEVICE_IDS` names the physical card, not logical chips.**
   `runner_utils.py` exports it as `TT_VISIBLE_DEVICES`. On a host with four
   N300s, `"(0),(1)"` starts two workers on two different cards, and a `(2,1)`
   mesh over them fails on the ethernet heartbeat. `"(2)"` selects card 2, and
   both of its chips appear as logical 0 and 1.

4. **`--local-server` cannot serve this model.** It launches
   `vllm-tt-metal/src/run_vllm_api_server.py`, which requires the external
   `vllm_tt_plugin`. That plugin returns `[]` from
   `get_supported_pooling_tasks()` with the comment `TT backend does not support
   pooling/embedding tasks yet`. So the vLLM route is blocked on plugin work, not
   on configuration. The in-repo `tt_vllm_plugin` does have a pooling runner, and
   the registration in this branch targets it.
