### PR TITLE
productization: Quetzal GPT-OSS-120B SWE attempt — BLOCKED at fail-closed topology admission

### DIFF
--- a/productization/quetzal_gptoss120b/README.md
+++ b/productization/quetzal_gptoss120b/README.md
@@ -52,4 +52,39 @@ scored result. No patch. PCC **not measured**.
   the qualified Llama row) targeting the S8192 candidate. **Not** wired into `dev/llm.yaml` here.
 - `quetzal_gptoss120b_serve_attempt_76030.log` — raw serve traceback.
 
+## Update — LEGITIMATE unblock attempt (job 76034, real device receipt)
+
+Per coordinator direction, the topology-admission gate was legitimately unblocked (no
+fabricated receipt). Fetched the qualified quetzal source `071e23cd` (which ships the
+producer), cloned it in-allocation, and ran the **real** `serving.topology_evidence`
+bounded-mesh device smoke (mesh opened/closed/synchronized, exit 0) →
+`serving.topology_admission`. This produced a genuine
+`quetzal.topology-admission-result.v1` receipt (Ring/links=2, chip_count 4, mesh [2,2],
+descriptor `f4c9fb5a…`, zero holders) whose pinned evidence SHAs (`smoke bf3311c6`,
+`selection 1852bfcc`, `emit f296b704`) match the consumer's hardcoded constants.
+
+With that receipt, the canonical serve advanced through **three** fail-closed gates:
+
+1. ✅ topology admission (real device receipt)
+2. ✅ quetzal source identity — installed quetzal `3a3873fe` (the candidate's actual
+   compile `source_git_commit`) and set `TT_QUETZAL_COMMIT_SHA=3a3873fe` truthfully
+3. ✅ bundle-manifest trusted-root proof (`QUETZAL_BUNDLE_MANIFEST_SHA256=012daa4f…`)
+
+**New terminal blocker** — `run_vllm_api_server.py:512 _validate_quetzal_auxiliary_references`:
+`RuntimeError: QUETZAL_AUXILIARY_ROOTS_JSON is invalid JSON`. The S8192 candidate's v2
+bundle declares an auxiliary `streamed_cache` (`openai_gpt-oss-120b-streamed-cache`,
+sha256 `2eef319a…`, 217 MoE expert tensorbins) whose digest-addressed read-only root is
+**not staged** on `/mnt` (only the unrelated S1024 package's `2b2e528a` root exists).
+Behind it, the candidate's `qualification_manifest` has an **empty `charter_pcc`**, so the
+validator would next raise *"Quetzal TT-Metal runtime mismatch: package requires None"*.
+Both are because the S8192 artifact is an unsealed **investigating** candidate — its own
+manifest says "canonical TTIS endpoint, bounded SWE … remain". Sealing it (staging the
+auxiliary, forging a `charter_pcc`) is a qualification/trusted-root step and was **not**
+fabricated.
+
+Net: the topology gate is genuinely cleared; the wall is now the artifact's unsealed
+qualification state, not the topology contract. See
+`quetzal_gptoss120b_swe_LEGIT_UNBLOCK_76034_20260904.json` and
+`topology_receipt_and_serve_logs_76034.txt`.
+
 Do **not** auto-merge. This documents a blocker; it does not claim qualification.

--- a/productization/quetzal_gptoss120b/README.md
+++ b/productization/quetzal_gptoss120b/README.md
@@ -1,0 +1,55 @@
+# Quetzal-generated GPT-OSS-120B — canonical SWE attempt (BLOCKED at fail-closed admission)
+
+Overnight attempt (2026-09-03/04) to run the full SWE flow for **Quetzal-generated
+`openai/gpt-oss-120b`** via canonical `run.py --impl quetzal` on a dedicated exabox QB2
+node (`qb2-120-p04t08`, job 76030, 4× Blackhole p300c / mesh p150x4).
+
+## Result: BLOCKED at serve (honest, no green theater)
+
+The canonical serve stops **before** vLLM launch / weight load at the fail-closed
+GPT-OSS-120B Quetzal topology-admission precheck:
+
+```
+run.py:1103 -> workflows/quetzal_topology_admission.py:306
+QuetzalTopologyAdmissionError: GPT-OSS-120B Quetzal requires QUETZAL_TOPOLOGY_ADMISSION_JSON
+```
+
+`validate_gpt120_quetzal_preweight_admission` fires for any `gpt-oss-120b` quetzal
+model_spec and requires a fresh (<900 s), same-allocation topology-admission receipt
+(`quetzal.topology-admission-result.v1`) with a SHA-pinned qualified descriptor
+(`descriptor_sha256 = f4c9fb5a…`, Ring / links=2, chip_count 4, mesh [2,2],
+`device_holders_after 0`) plus SHA-pinned evidence.
+
+- The on-node mesh descriptor **matches** the pinned `f4c9fb5a…` — the qualified topology
+  config is present on this hardware. The block is the **missing producer**, not wrong hardware.
+- The producer that legitimately emits the receipt (a bounded-mesh topology smoke, shipped by
+  the qualified quetzal source `071e23cd`) is **not installed** on the node — only the consumer
+  (`quetzal_topology_admission.py`) and its unit test are present. Installed quetzal is
+  `2e7c0670` (a gemma serving branch).
+- Hand-crafting a passing `QUETZAL_TOPOLOGY_ADMISSION_JSON` would be an *adapter around a
+  fail-closed gate precheck* — **declined** per the honesty mandate.
+
+## Not reached
+
+`/v1/models` 200 · `QuetzalEngine` in logs · tool-call smoke · SWE multi-step loop · edit/submit ·
+scored result. No patch. PCC **not measured**.
+
+## Secondary findings
+
+- The only **enrolled** gpt-oss-120b quetzal artifact in ttis `d1c15178` is **S1024** with
+  prefill buckets `128,1024` (chunked prefill) → would additionally hit the known chunked-SDPA
+  `attention_sink` gap even if admission passed.
+- A separate **S8192/C8192 one-shot** candidate exists (`/mnt` candidates, `qualification_state:
+  investigating`, experts bfp4_b) that would avoid the chunked path, but it is **not enrolled** in
+  the fail-closed lane and still trips the same admission precheck. The catalog row here targets it.
+- The `openai` tool-call parser + `openai_gptoss` reasoning parser **are** correctly wired in this
+  ttis (the fix for the earlier bespoke malformed-tool-call failure) — present but unexercised.
+
+## Files
+
+- `quetzal_gptoss120b_swe_BLOCKED_76030_20260903.json` — full receipt (`ttis.local-swe-gate/v1`).
+- `quetzal_gptoss120b_catalog_row_20260903.yaml` — authored `impl: quetzal` catalog row (mirrors
+  the qualified Llama row) targeting the S8192 candidate. **Not** wired into `dev/llm.yaml` here.
+- `quetzal_gptoss120b_serve_attempt_76030.log` — raw serve traceback.
+
+Do **not** auto-merge. This documents a blocker; it does not claim qualification.

--- a/productization/quetzal_gptoss120b/quetzal_gptoss120b_catalog_row_20260903.yaml
+++ b/productization/quetzal_gptoss120b/quetzal_gptoss120b_catalog_row_20260903.yaml
@@ -1,0 +1,84 @@
+# --- Quetzal-generated GPT-OSS-120B impl:quetzal serve lane (QB2/P300X2, bare-metal --local-server) ---
+# Mirrors the qualified Llama-3.2-1B row (quetzal_llama1b_catalog_row_20260903.yaml) but
+# targets the fresh S8192/C8192 one-shot GPT-OSS-120B candidate on /mnt (qualification_state:
+# investigating). Authored 2026-09-03 for the overnight SWE attempt on qb2-120-p04t08 (job 76030).
+#
+# HONEST STATUS: this row was authored and the canonical run.py --impl quetzal serve WAS attempted.
+# It is BLOCKED before vLLM/weight-load by the fail-closed GPT-OSS-120B Quetzal topology-admission
+# precheck (run.py:1103 -> workflows.quetzal_topology_admission.validate_gpt120_quetzal_preweight_admission),
+# which requires env QUETZAL_TOPOLOGY_ADMISSION_JSON pointing at a fresh (<900s) same-allocation
+# topology-admission receipt (schema quetzal.topology-admission-result.v1, descriptor_sha256
+# f4c9fb5a..., Ring/links=2, chip_count 4, mesh [2,2], device_holders_after 0) + SHA-pinned evidence.
+# The producer that emits that receipt (bounded-mesh topology smoke from the qualified quetzal
+# source 071e23cd) is NOT installed on the node (installed quetzal = 2e7c0670, a gemma serving branch).
+# Hand-crafting the receipt is a forbidden "adapter around a fail-closed gate precheck" -> declined.
+#
+# The one-shot S8192/C8192 artifact below (prefill seq_len 8192, NOT chunked) would avoid the known
+# chunked-SDPA attention_sink gap that the enrolled S1024 "128,1024"-bucket row hits, IF admission
+# could be legitimately satisfied.
+- weights:
+    - openai/gpt-oss-120b
+  impl: quetzal
+  inference_engine: VLLM
+  model_type: LLM
+  supported_modalities:
+    - text
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 1
+      max_context: 8192
+      default_impl: false
+      env_vars:
+        ARCH_NAME: blackhole
+        MESH_DEVICE: P150x4
+        HF_HOME: /mnt/models/huggingface
+        QUETZAL_VLLM: "1"
+        QUETZAL_MODEL: openai/gpt-oss-120b
+        QUETZAL_HF_REVISION: b5c939de8f754692c1647ca79fbf85e8c1e70f8a
+        # Candidate compiled with quetzal source 3a3873fe (from prefill metadata source_git_commit).
+        QUETZAL_REQUIRED_SOURCE_REVISION: 3a3873fefd4317d885c0602d3d7648db9e89f8e3
+        TT_QUETZAL_COMMIT_SHA: 3a3873fefd4317d885c0602d3d7648db9e89f8e3
+        QUETZAL_PACKAGE_ID: sha256-v2-f24d53fe00ceab8af797d2dced45e7b073f6c0e328205f95c8d37a3e1783b29f-cc1b6f9b581f2ff115be908f267c4b98bec4ab9b433f6d87bb0dd893dd406d66-def12a5e31923879495445e77cfabe5f37991bb5723106c321a9120b5f1ae050
+        QUETZAL_BUNDLE_MANIFEST_SHA256: 012daa4f16bc108dd7d7e1ea582c5bb432d661fd934dea438ffdf6ee37a29769
+        QZ_MODELS_ROOT: /mnt/models/huggingface/quetzal/nkapre/candidates/sha256-v2-f24d53fe00ceab8af797d2dced45e7b073f6c0e328205f95c8d37a3e1783b29f-cc1b6f9b581f2ff115be908f267c4b98bec4ab9b433f6d87bb0dd893dd406d66-def12a5e31923879495445e77cfabe5f37991bb5723106c321a9120b5f1ae050
+        QUETZAL_PACKAGE_ROOT: /mnt/models/huggingface/quetzal/nkapre/candidates/sha256-v2-f24d53fe00ceab8af797d2dced45e7b073f6c0e328205f95c8d37a3e1783b29f-cc1b6f9b581f2ff115be908f267c4b98bec4ab9b433f6d87bb0dd893dd406d66-def12a5e31923879495445e77cfabe5f37991bb5723106c321a9120b5f1ae050
+        QZ_QUALIFICATION_MANIFEST: /mnt/models/huggingface/quetzal/nkapre/candidates/sha256-v2-f24d53fe00ceab8af797d2dced45e7b073f6c0e328205f95c8d37a3e1783b29f-cc1b6f9b581f2ff115be908f267c4b98bec4ab9b433f6d87bb0dd893dd406d66-def12a5e31923879495445e77cfabe5f37991bb5723106c321a9120b5f1ae050/qualification_manifest.yaml
+        QUETZAL_PREFILL_GENERATED_PY: /mnt/models/huggingface/quetzal/nkapre/candidates/sha256-v2-f24d53fe00ceab8af797d2dced45e7b073f6c0e328205f95c8d37a3e1783b29f-cc1b6f9b581f2ff115be908f267c4b98bec4ab9b433f6d87bb0dd893dd406d66-def12a5e31923879495445e77cfabe5f37991bb5723106c321a9120b5f1ae050/compiled/openai_gpt-oss-120b-s8192-c8192-p150x4-b1/full/prefill/generated.py
+        QUETZAL_PREFILL_METADATA_JSON: /mnt/models/huggingface/quetzal/nkapre/candidates/sha256-v2-f24d53fe00ceab8af797d2dced45e7b073f6c0e328205f95c8d37a3e1783b29f-cc1b6f9b581f2ff115be908f267c4b98bec4ab9b433f6d87bb0dd893dd406d66-def12a5e31923879495445e77cfabe5f37991bb5723106c321a9120b5f1ae050/compiled/openai_gpt-oss-120b-s8192-c8192-p150x4-b1/full/prefill/metadata.json
+        QUETZAL_DECODE_GENERATED_PY: /mnt/models/huggingface/quetzal/nkapre/candidates/sha256-v2-f24d53fe00ceab8af797d2dced45e7b073f6c0e328205f95c8d37a3e1783b29f-cc1b6f9b581f2ff115be908f267c4b98bec4ab9b433f6d87bb0dd893dd406d66-def12a5e31923879495445e77cfabe5f37991bb5723106c321a9120b5f1ae050/compiled/openai_gpt-oss-120b-s8192-c8192-p150x4-b1/full/decode/generated.py
+        QUETZAL_DECODE_METADATA_JSON: /mnt/models/huggingface/quetzal/nkapre/candidates/sha256-v2-f24d53fe00ceab8af797d2dced45e7b073f6c0e328205f95c8d37a3e1783b29f-cc1b6f9b581f2ff115be908f267c4b98bec4ab9b433f6d87bb0dd893dd406d66-def12a5e31923879495445e77cfabe5f37991bb5723106c321a9120b5f1ae050/compiled/openai_gpt-oss-120b-s8192-c8192-p150x4-b1/full/decode/metadata.json
+        QUETZAL_WEIGHTS: /mnt/models/huggingface/quetzal/nkapre/candidates/sha256-v2-f24d53fe00ceab8af797d2dced45e7b073f6c0e328205f95c8d37a3e1783b29f-cc1b6f9b581f2ff115be908f267c4b98bec4ab9b433f6d87bb0dd893dd406d66-def12a5e31923879495445e77cfabe5f37991bb5723106c321a9120b5f1ae050/compiled_weights/openai_gpt-oss-120b-s8192-c8192-p150x4-b1/full/weights.pt
+        # MoE 128-expert artifact: dense runtime, experts quantized bfp4_b (from candidate manifest).
+        QZ_MOE_RUNTIME: dense
+        QZ_MOE_WEIGHT_DTYPE: bfloat4_b
+        TTQ_L1_SMALL_SIZE: "16384"
+        QZ_MMAP_WEIGHTS: "1"
+        TTQ_STREAM_WEIGHTS: "1"
+        HF_HUB_OFFLINE: "1"
+        TRANSFORMERS_OFFLINE: "1"
+        VLLM_PLUGINS: quetzal_model_registry,tt
+        TT_VLLM_BUILTIN_MODELS: "0"
+        TT_MESH_GRAPH_DESC_PATH: /var/tmp/nkapre/quetzal-327de968/serving/mesh_graph_descriptors/p150_x4_2ch_mesh_graph_descriptor.textproto
+        TTQ_ROW_ALL_REDUCE_TOPOLOGY: Ring
+        TTQ_TUNED_ROW_ALL_REDUCE: "1"
+        TTQ_TUNED_ROW_ALL_REDUCE_LINKS: "2"
+      vllm_args:
+        block_size: 64
+        max_model_len: 8192
+        max_num_seqs: 1
+        revision: b5c939de8f754692c1647ca79fbf85e8c1e70f8a
+        tokenizer_revision: b5c939de8f754692c1647ca79fbf85e8c1e70f8a
+        # GPT-OSS harmony: openai tool-call parser + openai_gptoss reasoning parser.
+        # This is the fix for the earlier bespoke run's malformed-tool-call failure.
+        enable-auto-tool-choice: true
+        tool-call-parser: openai
+      override_tt_config:
+        fabric_config: FABRIC_1D
+        l1_small_size: 16384
+        trace_region_size: 90000000
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+  metadata:
+    openai/gpt-oss-120b:
+      reasoning_parser_name: openai_gptoss
+      tool_call_parser_name: openai


### PR DESCRIPTION
## Summary

Overnight attempt to run the **full SWE flow** for Quetzal-generated `openai/gpt-oss-120b`
via canonical `run.py --impl quetzal` on a dedicated exabox QB2 node
(`qb2-120-p04t08`, job 76030, 4× Blackhole p300c / mesh p150x4).

**Honest result: BLOCKED at serve** — before vLLM launch / weight load — at the fail-closed
GPT-OSS-120B Quetzal topology-admission precheck:

```
run.py:1103 -> workflows/quetzal_topology_admission.py:306
QuetzalTopologyAdmissionError: GPT-OSS-120B Quetzal requires QUETZAL_TOPOLOGY_ADMISSION_JSON
```

`validate_gpt120_quetzal_preweight_admission` fires for any `gpt-oss-120b` quetzal spec and
requires a fresh (<900 s), same-allocation topology-admission receipt with a SHA-pinned
qualified descriptor (`f4c9fb5a…`, Ring/links=2, chip_count 4, mesh [2,2], zero device holders).

- The on-node descriptor **matches** the pinned SHA → the qualified topology is present on this
  hardware; the block is the **missing receipt producer**, not wrong hardware.
- The producer (bounded-mesh topology smoke from qualified quetzal source `071e23cd`) is **not
  installed** — only the consumer + its unit test are on-node; installed quetzal is `2e7c0670`
  (gemma branch).
- Hand-crafting a passing receipt = *adapter around a fail-closed gate precheck* → **declined**.

## What this PR adds (docs/receipt only — no engine changes)

- `productization/quetzal_gptoss120b/` — full receipt (`ttis.local-swe-gate/v1`), raw serve
  traceback, README, and an authored `impl: quetzal` catalog row (mirrors the qualified Llama
  row) targeting the S8192/C8192 one-shot candidate. **The row is NOT wired into `dev/llm.yaml`.**

## Not reached

`/v1/models` 200 · tool-call smoke · SWE loop · scored result. No patch. PCC **not measured**.

## Secondary findings

- The only **enrolled** gpt-oss-120b quetzal artifact is **S1024** with chunked prefill buckets
  `128,1024` → would additionally hit the known chunked-SDPA `attention_sink` gap.
- The `openai` / `openai_gptoss` tool+reasoning parsers are correctly wired here (the fix for the
  earlier bespoke malformed-tool-call failure) — present but unexercised.

⚠️ **Do not auto-merge.** Documents a blocker; does not claim qualification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)