### PR TITLE
dev catalog: add impl:quetzal + gemma-4-31B-it quetzal serve row (experimental)

### DIFF
--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -374,6 +374,17 @@ training_lora_impl = ImplSpec(
     code_path="tt-media-server/tt_model_runners/forge_training_runners/training_lora_runner.py",
 )
 
+quetzal_impl = ImplSpec(
+    impl_id="quetzal",
+    impl_name="quetzal",
+    repo_url="https://github.com/tenstorrent/tt-quetzalcoatlus",
+    # Serves the quetzal-GENERATED (compiler-lite HF->TTNN) artifact through
+    # the real vLLM tt-plugin. QuetzalLlamaForCausalLM (serving/quetzal_vllm.py)
+    # is bound inside the vLLM process by the vllm-tt-plugin registration patch
+    # (QUETZAL_VLLM=1); code_path is doc-link only (dev catalog, no tt_metal_commit).
+    code_path="serving/quetzal_vllm.py",
+)
+
 _IMPL_REGISTRY: Dict[str, ImplSpec] = {
     "tt_transformers": tt_transformers_impl,
     "llama3_70b_galaxy": llama3_70b_galaxy_impl,
@@ -389,6 +400,7 @@ _IMPL_REGISTRY: Dict[str, ImplSpec] = {
     "qwen36_blackhole_vlm": qwen36_blackhole_vlm_impl,
     "diffusion_gemma": diffusion_gemma_impl,
     "training_lora": training_lora_impl,
+    "quetzal": quetzal_impl,
 }
 
 

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -353,6 +353,34 @@ templates:
       tool_call_parser_name: gemma4
 
 - weights:
+    - google/gemma-4-31B-it
+  # QUETZAL-GENERATED artifact served via impl:quetzal (vllm-tt-plugin, QUETZAL_VLLM=1).
+  # EXPERIMENTAL / status: investigating -- gemma-4-31B-it quetzal artifact is BELOW the
+  # 0.99 PCC bar (diffuse bf16 residual-stream accumulation over ~60 sandwich-norm layers).
+  # Measured on native silicon 2026-09-04 (job 75983, QB2 p150x4): S4096 monolithic prefill
+  # PCC = 0.98449 vs CPU bf16 reference; nearest chunked S1024/C32768 PCC = 0.96962 (job 75449).
+  # This row exists for REPRODUCIBILITY of the --impl quetzal serve path; it is NOT a qualified
+  # release. Parsers mirror the native gemma-4-31B-it row (gemma4).
+  impl: quetzal
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P300X2  # QB2 (2x P300, 4-chip TP mesh == P150x4)
+      max_concurrency: 1  # generated vLLM adapter owns one recurrent KV row (B1); PR #27 get_max_tokens_all_users
+      max_context: 4096   # S4096 monolithic serve pair; chunked 32K (C32768) is emit-proven, serve-unproven
+      default_impl: false
+      env_vars:
+        MESH_DEVICE: "P150x4"
+        QUETZAL_VLLM: "1"
+        TTQ_ROPE_INV_FREQ_FP32: "1"
+      override_tt_config:
+        fabric_config: FABRIC_1D
+      vllm_args:
+        enable-auto-tool-choice: true
+        tool-call-parser: gemma4
+        reasoning-parser: gemma4
+  status: EXPERIMENTAL
+  has_builtin_warmup: false
+- weights:
     - google/gemma-4-12B-it
   impl: tt_transformers
   # Dev specs omit tt_metal_commit/vllm_commit (base ModelSpecTemplate rejects


### PR DESCRIPTION
## What
Adds the `quetzal` impl to `_IMPL_REGISTRY` (serves the quetzal-GENERATED HF→TTNN artifact through the real vLLM tt-plugin; `QUETZAL_VLLM=1` binds `serving/quetzal_vllm.py:QuetzalLlamaForCausalLM`), and an **EXPERIMENTAL** `google/gemma-4-31B-it` `impl: quetzal` dev row on `P300X2` (QB2 = p150x4, B1, `gemma4` tool/reasoning parsers). Enables `run.py --model google/gemma-4-31B-it --impl quetzal`.

## Why (reproducibility, NOT a qualified release)
This row reproduces the `--impl quetzal` serve path for gemma. It is deliberately **not** a qualified release row: the gemma-4-31B-it quetzal artifact is **below the 0.99 PCC bar** (diffuse bf16 residual-stream accumulation over ~60 sandwich-norm layers; `qualification_state: investigating`).

Native-silicon measurements (QB2 p150x4, 2026-09-04, job 75983):
- **S4096 monolithic prefill PCC = 0.98449** vs CPU bf16 reference (4 mesh shards, no host fallbacks) — first on-silicon measurement of the S4096 charter shape (previously "not measured").
- Nearest chunked S1024/C32768 PCC = **0.96962** (job 75449).

## Notes
- DEV catalog: no `tt_metal_commit`/`vllm_commit` pins (base template rejects them; image supplied at runtime).
- `max_concurrency: 1` — the generated vLLM adapter owns one recurrent KV row (B1; get_max_tokens_all_users, tt-vllm PR #27).
- `max_context: 4096` — S4096 serve pair; chunked 32K (C32768) is emit-proven, serve-unproven.
- Please do **not** auto-merge; this is for review of the serve-path wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
