### PR TITLE
feat(agentic-traces): borrow the Kimi template for requirements-driven runs

### DIFF
--- a/reference_config/agentic_traces/agentic_traces_config.py
+++ b/reference_config/agentic_traces/agentic_traces_config.py
@@ -20,12 +20,15 @@ config, and in ``tests/reference_config/test_agentic_traces_config.py``.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional, Tuple
 
 from llm_module.agentic_traces.schema import TraceSource
 from workflows.utils import map_configs_by_attr
 from workflows.workflow_types import AgenticTracesMode
+
+logger = logging.getLogger(__name__)
 
 # The InferenceX ``inferencex-agentx-mvp`` scenario rejects a profiling window
 # shorter than this (see its scenario definition in the InferenceX repo:
@@ -72,6 +75,10 @@ class AgenticTracesRunSpec:
     slice_duration: float = 1.0
     max_context_length: Optional[int] = None
     tokenizer_trust_remote_code: Optional[bool] = None
+    # True reads token counts off the streaming ``usage`` chunk; TT endpoints
+    # honour ``stream_options.include_usage``, so this works and matches the
+    # served token counts. False would count ISL/OSL with the local tokenizer
+    # instead, ``vllm bench serve`` style.
     use_server_token_count: bool = True
     gpu_telemetry: bool = False
     # SwarmOne (``swo-bench replay``) knobs. Ignored by the InferenceX/AIPerf
@@ -399,6 +406,71 @@ def get_agentic_traces_config(model_spec) -> Optional[AgenticTracesConfig]:
     return AGENTIC_TRACES_CONFIGS.get(model_id)
 
 
+# impl_id stamped on specs synthesized from a requirements document for
+# off-catalog models (see workflows/model_spec_provider.py). Such a model can
+# never have an AGENTIC_TRACES_CONFIGS entry, so the strict lookup above would
+# always refuse it.
+_REQUIREMENTS_SYNTHESIZED_IMPL_ID = "requirements_synthesized"
+
+# Template borrowed for requirements-driven runs: the Kimi K2.7-Code config,
+# currently the only onboarded one. Its default sweep is the
+# InferenceX Weka replay (SwarmOne is opt-in, so no swo-bench license is
+# needed); the InferenceX pin and mode settings carry over unchanged.
+_REQUIREMENTS_TEMPLATE_MODEL_ID = "id_tt-transformers_Kimi-K2.7-Code_super_cluster"
+
+
+def _borrows_template(model_spec) -> bool:
+    """Whether ``model_spec`` may fall back to the template.
+
+    Two cases, both requirements-driven. A synthesized spec is off-catalog and
+    so can never have an entry. A *catalog* spec without one is the same
+    situation in practice: being in the catalog says the model can be served,
+    not that it is onboarded to this workflow, so adding a model for evals
+    would otherwise turn a working requirements sweep into a refusal.
+
+    Requirements mode is read from argv rather than passed in, because every
+    process that needs this already receives ``--requirements-json``: run.py
+    and run_workflows.py from the operator, the launchers because
+    workflow_dispatch forwards it.
+    """
+    impl_id = getattr(getattr(model_spec, "impl", None), "impl_id", None)
+    if impl_id == _REQUIREMENTS_SYNTHESIZED_IMPL_ID:
+        return True
+    from workflows.requirements_cli import requirements_mode_in_argv
+
+    return requirements_mode_in_argv()
+
+
+def get_agentic_traces_config_or_template(model_spec) -> Optional[AgenticTracesConfig]:
+    """Config for ``model_spec``, borrowing a template for requirements runs.
+
+    Strict catalog lookup first. When the model has no entry and the run is
+    requirements-driven, returns the Kimi K2.7-Code config retargeted at this
+    ``model_id`` — the traces are recorded traffic replayed against whatever
+    server is under test, so the run shape is not model-specific. A plain
+    ``--workflow agentic_traces`` on a model with no entry still gets ``None``
+    (refuse to run), unchanged.
+    """
+    config = get_agentic_traces_config(model_spec)
+    if config is not None:
+        return config
+    if not _borrows_template(model_spec):
+        return None
+    template = AGENTIC_TRACES_CONFIGS.get(_REQUIREMENTS_TEMPLATE_MODEL_ID)
+    if template is None:
+        return None
+    model_id = getattr(model_spec, "model_id", None)
+    if not model_id:
+        return None
+    logger.warning(
+        "No agentic-traces config for model_id=%r; borrowing the %r template "
+        "(requirements-driven run).",
+        model_id,
+        _REQUIREMENTS_TEMPLATE_MODEL_ID,
+    )
+    return replace(template, model_id=model_id)
+
+
 def default_run_specs(
     config: AgenticTracesConfig,
 ) -> Tuple[AgenticTracesRunSpec, ...]:
@@ -463,5 +535,6 @@ __all__ = [
     "default_run_specs",
     "for_model_ids",
     "get_agentic_traces_config",
+    "get_agentic_traces_config_or_template",
     "resolve_run_specs",
 ]

--- a/tests/workflow_module/test_requirements_target_pack.py
+++ b/tests/workflow_module/test_requirements_target_pack.py
@@ -379,3 +379,100 @@ def test_target_pack_delegates_unspecified_content(pack):
     assert pack.extra_spec_metadata_fields() == (
         TenstorrentTargetPack().extra_spec_metadata_fields()
     )
+
+
+# --- agentic traces: template fallback for off-catalog models ----------------
+
+_KIMI_TEMPLATE_MODEL_ID = "id_tt-transformers_Kimi-K2.7-Code_super_cluster"
+
+
+def _synthesized_spec():
+    return TenstorrentModelSpecProvider().synthesize(
+        model_name="acme/tiny-llm",
+        hf_model_repo="acme/tiny-llm",
+        device="super_cluster",
+        max_context=8192,
+        max_concurrency=16,
+    )
+
+
+def test_agentic_traces_borrows_kimi_template_for_synthesized_spec():
+    from reference_config.agentic_traces.agentic_traces_config import (
+        AGENTIC_TRACES_CONFIGS,
+        get_agentic_traces_config,
+        get_agentic_traces_config_or_template,
+    )
+
+    spec = _synthesized_spec()
+    # Strict lookup still refuses: the synthesized model_id has no entry.
+    assert get_agentic_traces_config(spec) is None
+
+    config = get_agentic_traces_config_or_template(spec)
+    template = AGENTIC_TRACES_CONFIGS[_KIMI_TEMPLATE_MODEL_ID]
+    assert config is not None
+    assert config.model_id == spec.model_id  # retargeted, not Kimi's id
+    assert config.runs == template.runs
+    assert config.inferencex_git_ref == template.inferencex_git_ref
+
+
+def test_agentic_traces_template_fallback_leaves_catalog_models_strict():
+    from types import SimpleNamespace
+
+    from reference_config.agentic_traces.agentic_traces_config import (
+        get_agentic_traces_config_or_template,
+    )
+
+    # A catalog spec with no entry still gets None outside requirements mode:
+    # a plain --workflow agentic_traces refuses rather than silently measuring
+    # against a borrowed run shape. (pytest's argv has no --requirements-json.)
+    spec = SimpleNamespace(
+        model_id="id_tt-transformers_Some-Model_t3k",
+        impl=SimpleNamespace(impl_id="tt-transformers"),
+    )
+    assert get_agentic_traces_config_or_template(spec) is None
+
+
+def test_agentic_traces_borrows_template_for_catalog_spec_in_requirements_mode(
+    monkeypatch,
+):
+    import sys
+    from types import SimpleNamespace
+
+    from reference_config.agentic_traces.agentic_traces_config import (
+        get_agentic_traces_config_or_template,
+    )
+
+    # Being in the catalog says the model can be served, not that it is
+    # onboarded to agentic traces -- a model added for evals has no entry. A
+    # requirements document that asks for an agentic sweep has already said it
+    # wants one, so it borrows rather than refusing.
+    spec = SimpleNamespace(
+        model_id="id_tt-transformers_Some-Model_t3k",
+        impl=SimpleNamespace(impl_id="tt-transformers"),
+    )
+    monkeypatch.setattr(sys, "argv", ["run.py", "--requirements-json", "doc.json"])
+    config = get_agentic_traces_config_or_template(spec)
+    assert config is not None
+    assert config.model_id == spec.model_id  # retargeted, not Kimi's id
+
+
+def test_agentic_traces_template_fallback_preserves_own_entry():
+    from types import SimpleNamespace
+
+    from reference_config.agentic_traces.agentic_traces_config import (
+        AGENTIC_TRACES_CONFIGS,
+        get_agentic_traces_config_or_template,
+    )
+
+    spec = SimpleNamespace(model_id=_KIMI_TEMPLATE_MODEL_ID, impl=None)
+    assert (
+        get_agentic_traces_config_or_template(spec)
+        is AGENTIC_TRACES_CONFIGS[_KIMI_TEMPLATE_MODEL_ID]
+    )
+
+
+def test_requirements_pack_agentic_traces_config_uses_template(pack):
+    spec = _synthesized_spec()
+    config = pack.agentic_traces_config(spec)
+    assert config is not None
+    assert config.model_id == spec.model_id

--- a/workflows/requirements_target_pack.py
+++ b/workflows/requirements_target_pack.py
@@ -490,9 +490,18 @@ class RequirementsTargetPack(TargetPack):
                 )
         return config
 
-    # --- agentic traces (delegated) ---
+    # --- agentic traces (delegated, with template fallback) ---
     def agentic_traces_config(self, model_spec: Any) -> Optional[Any]:
-        return self._delegate.agentic_traces_config(model_spec)
+        # The document has no agentic-traces section, so content comes from the
+        # catalog; for an off-catalog (synthesized) spec, borrow the Kimi
+        # K2.7-Code template rather than refusing to run.
+        from reference_config.agentic_traces.agentic_traces_config import (
+            get_agentic_traces_config_or_template,
+        )
+
+        return self._delegate.agentic_traces_config(
+            model_spec
+        ) or get_agentic_traces_config_or_template(model_spec)
 
     def resolve_agentic_run_specs(
         self,

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -161,10 +161,13 @@ def validate_runtime_args(model_spec, runtime_config):
         from reference_config.agentic_traces.agentic_traces_config import (
             TraceSource,
             default_run_specs,
-            get_agentic_traces_config,
+            get_agentic_traces_config_or_template,
         )
 
-        agentic_traces_config = get_agentic_traces_config(model_spec)
+        # The _or_template variant borrows the Kimi K2.7-Code config for
+        # requirements-driven runs; a plain --workflow agentic_traces still
+        # fails here when the model has no entry.
+        agentic_traces_config = get_agentic_traces_config_or_template(model_spec)
         assert agentic_traces_config is not None, (
             f"Model:={model_spec.model_name} (model_id={model_spec.model_id}) has "
             "no AGENTIC_TRACES_CONFIGS entry. Add one to "

--- a/workflows/workflow_venvs.py
+++ b/workflows/workflow_venvs.py
@@ -253,10 +253,13 @@ def setup_agentic_traces(
     """
     from reference_config.agentic_traces.agentic_traces_config import (
         TraceSource,
-        get_agentic_traces_config,
+        get_agentic_traces_config_or_template,
     )
 
-    config = get_agentic_traces_config(model_spec)
+    # The _or_template variant borrows the Kimi K2.7-Code config for
+    # requirements-driven runs, so the InferenceX pin is available for them
+    # too.
+    config = get_agentic_traces_config_or_template(model_spec)
     if config is None:
         logger.error(
             "No agentic-traces config registered for model_id=%s. Add an entry "


### PR DESCRIPTION
A model with no AGENTIC_TRACES_CONFIGS entry borrows the Kimi K2.7-Code config when the run is requirements-driven: synthesized off-catalog specs (which can never have an entry) and catalog specs alike. Being in the catalog says a model can be served, not that it is onboarded to this workflow, so a model added for evals would otherwise turn a working requirements sweep into a refusal.

Requirements mode is read via requirements_mode_in_argv(); every process that needs it already receives --requirements-json (run.py/run_workflows.py from the operator, the launchers because workflow_dispatch forwards it), so no plumbing is added. A plain --workflow agentic_traces on a model with no entry still refuses.

Also documents that use_server_token_count=True works against TT endpoints (they honour stream_options.include_usage).

Stack: part 1 of 6. Base for ipastalTT/st/2-agentic-metrics.

Made with [Cursor](https://cursor.com)