### PR TITLE
feat(requirements): drive the agentic sweep from the document

### DIFF
--- a/reference_config/agentic_traces/agentic_traces_config.py
+++ b/reference_config/agentic_traces/agentic_traces_config.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field, replace
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from llm_module.agentic_traces.schema import TraceSource
 from workflows.utils import map_configs_by_attr
@@ -386,6 +386,17 @@ _agentic_traces_config_list: List[AgenticTracesConfig] = [
             ),
         ),
     ),
+    AgenticTracesConfig(
+        model_id="id_tt-transformers_gemma-4-31B-it_super_cluster",
+        inferencex_git_ref="ddeb02eb9c5c89f44e2e4950e741b499d0b8190a",
+        runs=(
+            AgenticTracesRunSpec(
+                trace_source=TraceSource.INFERENCEX_AGENTX,
+                public_dataset="semianalysis_cc_traces_weka_062126_256k",
+                concurrency=8,
+            ),
+        ),
+    ),
 ]
 
 AGENTIC_TRACES_CONFIGS: Dict[str, AgenticTracesConfig] = map_configs_by_attr(
@@ -471,6 +482,28 @@ def get_agentic_traces_config_or_template(model_spec) -> Optional[AgenticTracesC
     return replace(template, model_id=model_id)
 
 
+def replace_agentic_runs(
+    config: AgenticTracesConfig,
+    concurrencies: Sequence[int],
+) -> AgenticTracesConfig:
+    """Replay ``config``'s runs at each of ``concurrencies``.
+
+    A requirements document sweeps concurrency while holding the run shape
+    fixed, so each configured run is duplicated once per concurrency rather
+    than replaced: a config carrying both an InferenceX and a SwarmOne spec
+    still sweeps both. An empty ``concurrencies`` leaves the config alone, so a
+    document with no agentic sweep keeps the catalog's single operating point.
+    """
+    if not concurrencies:
+        return config
+    runs = tuple(
+        replace(run, concurrency=concurrency)
+        for run in config.runs
+        for concurrency in concurrencies
+    )
+    return replace(config, runs=runs)
+
+
 def default_run_specs(
     config: AgenticTracesConfig,
 ) -> Tuple[AgenticTracesRunSpec, ...]:
@@ -536,5 +569,6 @@ __all__ = [
     "for_model_ids",
     "get_agentic_traces_config",
     "get_agentic_traces_config_or_template",
+    "replace_agentic_runs",
     "resolve_run_specs",
 ]

--- a/tests/workflow_module/test_requirements_schema.py
+++ b/tests/workflow_module/test_requirements_schema.py
@@ -185,3 +185,98 @@ def test_invalid_comparator_rejected(tmp_path):
     path.write_text(json.dumps(doc_dict))
     with pytest.raises(RequirementsError, match="comparator"):
         load_requirements(path)
+
+
+def _agentic_doc(**overrides):
+    """A schema 2.6 document: identity nested, agentic sweep in workloads."""
+    workload = {
+        "kind": "agentic",
+        "id": "w1",
+        "name": "New agentic scenario",
+        "slo": {"ttftMs": 2000, "tpotMs": 20, "e2elMs": 20000},
+        "agenticWorkload": {"traces": [{"name": "AgentX - Claude Code"}]},
+        "agenticSweep": [
+            {"concurrency": 1, "e2elP90Ms": 16475.15},
+            {"concurrency": 8, "e2elP90Ms": 12242.25},
+        ],
+        "maxConcurrency": 64,
+    }
+    workload.update(overrides)
+    return {
+        "schemaVersion": "2.6.0",
+        "document": {
+            "id": "doc-1",
+            "meta": {"customer": "Ant"},
+            "model": {"name": "google/gemma-4-31B-it", "contextLength": 131072},
+            "deployment": {"hardware": "SC24", "maxConcurrencyPerInstance": 1},
+        },
+        "workloads": [workload],
+    }
+
+
+def _write(tmp_path, doc_dict):
+    path = tmp_path / "doc.json"
+    path.write_text(json.dumps(doc_dict))
+    return path
+
+
+def test_reads_identity_from_the_document_envelope(tmp_path):
+    """Schema 2.6 nests model/deployment/meta under 'document'."""
+    doc = load_requirements(_write(tmp_path, _agentic_doc()))
+
+    assert doc.id == "doc-1"
+    assert doc.model.name == "google/gemma-4-31B-it"
+    assert doc.deployment.hardware == "SC24"
+    assert doc.meta["customer"] == "Ant"
+
+
+def test_parses_the_agentic_sweep_and_its_slos(tmp_path):
+    doc = load_requirements(_write(tmp_path, _agentic_doc()))
+
+    (workload,) = doc.agentic_workloads
+    assert [p.concurrency for p in workload.sweep] == [1, 8]
+    assert workload.max_concurrency == 64
+    assert (workload.slo.ttft_ms, workload.slo.tpot_ms, workload.slo.e2el_ms) == (
+        2000,
+        20,
+        20000,
+    )
+
+
+def test_keeps_sweep_point_expectations_for_grading(tmp_path):
+    """Values we do not drive the run with still have to survive for grading."""
+    doc = load_requirements(_write(tmp_path, _agentic_doc()))
+
+    assert doc.agentic_workloads[0].sweep[0].reference["e2elP90Ms"] == 16475.15
+
+
+def test_ignores_non_agentic_workloads(tmp_path):
+    """A text workload is a benchmark scenario, not a trace replay."""
+    doc_dict = _agentic_doc()
+    doc_dict["workloads"].append({"kind": "text", "id": "w2"})
+
+    doc = load_requirements(_write(tmp_path, doc_dict))
+
+    assert [w.id for w in doc.agentic_workloads] == ["w1"]
+
+
+def test_sweep_point_without_concurrency_rejected(tmp_path):
+    doc_dict = _agentic_doc(agenticSweep=[{"e2elP90Ms": 1.0}])
+
+    with pytest.raises(RequirementsError, match="concurrency"):
+        load_requirements(_write(tmp_path, doc_dict))
+
+
+def test_flat_documents_still_load(tmp_path):
+    """Earlier 2.x revisions put identity at the top level and have no sweep."""
+    doc_dict = {
+        "schemaVersion": "2.1.0",
+        "model": {"name": "a/b"},
+        "deployment": {"hardware": "SC8"},
+    }
+
+    doc = load_requirements(_write(tmp_path, doc_dict))
+
+    assert doc.model.name == "a/b"
+    assert doc.deployment.hardware == "SC8"
+    assert doc.agentic_workloads == []

--- a/tests/workflow_module/test_requirements_target_pack.py
+++ b/tests/workflow_module/test_requirements_target_pack.py
@@ -476,3 +476,81 @@ def test_requirements_pack_agentic_traces_config_uses_template(pack):
     config = pack.agentic_traces_config(spec)
     assert config is not None
     assert config.model_id == spec.model_id
+
+
+# --- agentic sweep -----------------------------------------------------------
+
+
+def _agentic_pack(concurrencies, slo=None):
+    """A pack whose document sweeps ``concurrencies`` for an agentic workload."""
+    from workflow_module.requirements_schema import RequirementsDoc
+
+    doc_dict = {
+        "schemaVersion": "2.6.0",
+        "document": {
+            "id": "d",
+            "model": {"name": "google/gemma-4-31B-it"},
+            "deployment": {"hardware": "SC24"},
+        },
+        "workloads": [
+            {
+                "kind": "agentic",
+                "id": "w1",
+                "slo": slo or {},
+                "agenticSweep": [{"concurrency": c} for c in concurrencies],
+            }
+        ],
+    }
+    return RequirementsTargetPack(
+        RequirementsDoc.from_dict(doc_dict), TenstorrentTargetPack()
+    )
+
+
+def _base_config():
+    from reference_config.agentic_traces.agentic_traces_config import (
+        AGENTIC_TRACES_CONFIGS,
+        _REQUIREMENTS_TEMPLATE_MODEL_ID,
+    )
+
+    return AGENTIC_TRACES_CONFIGS[_REQUIREMENTS_TEMPLATE_MODEL_ID]
+
+
+def test_replace_agentic_runs_sweeps_every_concurrency():
+    from reference_config.agentic_traces.agentic_traces_config import (
+        replace_agentic_runs,
+    )
+
+    base = _base_config()
+
+    swept = replace_agentic_runs(base, [1, 8, 64])
+
+    assert [r.concurrency for r in swept.runs] == [
+        c for _ in base.runs for c in (1, 8, 64)
+    ]
+
+
+def test_replace_agentic_runs_leaves_config_alone_without_a_sweep():
+    """A document with no agentic sweep keeps the catalog's operating point."""
+    base = _base_config()
+    from reference_config.agentic_traces.agentic_traces_config import (
+        replace_agentic_runs,
+    )
+
+    assert replace_agentic_runs(base, []) is base
+
+
+def test_agentic_concurrencies_are_deduplicated_and_ordered():
+    pack = _agentic_pack([16, 1, 8, 1])
+
+    assert pack._agentic_concurrencies() == [1, 8, 16]
+
+
+def test_agentic_goodput_needs_slos():
+    """goodputPct targets alone cannot be graded: nothing defines 'good'."""
+    assert _agentic_pack([1]).agentic_traces_goodput() is None
+
+
+def test_agentic_goodput_built_from_workload_slos():
+    pack = _agentic_pack([1], slo={"ttftMs": 2000, "tpotMs": 20, "e2elMs": 20000})
+
+    assert pack.agentic_traces_goodput() == "ttft:2000 tpot:20 e2el:20000"

--- a/workflow_module/requirements_schema.py
+++ b/workflow_module/requirements_schema.py
@@ -209,6 +209,61 @@ class Scenario:
 
 
 @dataclass(frozen=True)
+class AgenticSweepPoint:
+    """One concurrency point in an agentic trace-replay sweep.
+
+    Only :attr:`concurrency` drives the run. The document's expected
+    measurements for the point are kept verbatim in :attr:`reference` so what
+    we measure can be graded against them, the same way :class:`SweepPoint`
+    carries a benchmark point's references.
+    """
+
+    concurrency: int
+    reference: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AgenticSweepPoint":
+        if data.get("concurrency") is None:
+            raise RequirementsError("agenticSweep[]: missing required 'concurrency'")
+        return cls(concurrency=int(data["concurrency"]), reference=dict(data))
+
+
+@dataclass(frozen=True)
+class AgenticWorkload:
+    """An agentic trace-replay workload: a concurrency sweep plus its SLOs.
+
+    The agentic counterpart to :class:`Scenario`. It sweeps concurrency alone
+    rather than (ISL, OSL, concurrency), because the prompt sizes come from the
+    replayed traces instead of the document.
+    """
+
+    id: str
+    name: Optional[str] = None
+    slo: Optional[Slo] = None
+    sweep: List[AgenticSweepPoint] = field(default_factory=list)
+    max_concurrency: Optional[int] = None
+    traces: List[Mapping[str, Any]] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AgenticWorkload":
+        workload_id = data.get("id") or data.get("name")
+        if not workload_id:
+            raise RequirementsError("workloads[]: missing required 'id'")
+        agentic = data.get("agenticWorkload")
+        traces = agentic.get("traces", []) if isinstance(agentic, Mapping) else []
+        return cls(
+            id=str(workload_id),
+            name=data.get("name"),
+            slo=Slo.from_dict(data.get("slo")),
+            sweep=[
+                AgenticSweepPoint.from_dict(p) for p in data.get("agenticSweep", [])
+            ],
+            max_concurrency=_as_optional_int(data.get("maxConcurrency")),
+            traces=[dict(t) for t in traces if isinstance(t, Mapping)],
+        )
+
+
+@dataclass(frozen=True)
 class ModelInfo:
     """Model identity from the requirements document."""
 
@@ -260,27 +315,37 @@ class RequirementsDoc:
     deployment: Deployment
     accuracy_evals: List[AccuracyEval] = field(default_factory=list)
     scenarios: List[Scenario] = field(default_factory=list)
+    agentic_workloads: List[AgenticWorkload] = field(default_factory=list)
     meta: Mapping[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "RequirementsDoc":
         schema_version = str(data.get("schemaVersion", ""))
         _check_schema_version(schema_version)
-        model_data = data.get("model")
+        # Later 2.x revisions wrap identity (model, deployment, meta) in a
+        # "document" envelope and carry the agentic sweep in a sibling
+        # "workloads" list; earlier ones put identity at the top level. Read
+        # identity from whichever is present so both shapes load.
+        envelope = data.get("document")
+        identity = envelope if isinstance(envelope, Mapping) else data
+        model_data = identity.get("model")
         if not isinstance(model_data, Mapping):
             raise RequirementsError("requirements: missing required 'model' object")
         return cls(
-            id=str(
-                data.get("id") or data.get("model", {}).get("name") or "requirements"
-            ),
+            id=str(identity.get("id") or model_data.get("name") or "requirements"),
             schema_version=schema_version,
             model=ModelInfo.from_dict(model_data),
-            deployment=Deployment.from_dict(data.get("deployment")),
+            deployment=Deployment.from_dict(identity.get("deployment")),
             accuracy_evals=[
                 AccuracyEval.from_dict(e) for e in data.get("accuracyEvals", [])
             ],
             scenarios=[Scenario.from_dict(s) for s in data.get("scenarios", [])],
-            meta=dict(data.get("meta", {})),
+            agentic_workloads=[
+                AgenticWorkload.from_dict(w)
+                for w in data.get("workloads", [])
+                if isinstance(w, Mapping) and w.get("kind") == "agentic"
+            ],
+            meta=dict(identity.get("meta", {})),
         )
 
 
@@ -324,12 +389,14 @@ def load_requirements(path: Union[str, Path]) -> RequirementsDoc:
         )
     doc = RequirementsDoc.from_dict(data)
     logger.info(
-        "Loaded requirements id=%s model=%s hardware=%s (%d evals, %d scenarios)",
+        "Loaded requirements id=%s model=%s hardware=%s "
+        "(%d evals, %d scenarios, %d agentic workloads)",
         doc.id,
         doc.model.name,
         doc.deployment.hardware,
         len(doc.accuracy_evals),
         len(doc.scenarios),
+        len(doc.agentic_workloads),
     )
     return doc
 
@@ -382,6 +449,8 @@ __all__ = [
     "Slo",
     "SweepPoint",
     "Scenario",
+    "AgenticSweepPoint",
+    "AgenticWorkload",
     "ModelInfo",
     "Deployment",
     "RequirementsDoc",

--- a/workflows/requirements_target_pack.py
+++ b/workflows/requirements_target_pack.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import replace
-from typing import Any, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from workflow_module.model_catalog import ModelSpecProvider
 from workflow_module.requirements_schema import (
@@ -33,6 +33,7 @@ from workflow_module.requirements_schema import (
     AccuracyEval,
     RequirementsDoc,
     Scenario,
+    Slo,
 )
 from workflow_module.target_pack import TargetPack
 
@@ -490,18 +491,49 @@ class RequirementsTargetPack(TargetPack):
                 )
         return config
 
-    # --- agentic traces (delegated, with template fallback) ---
+    # --- agentic traces (document sweep over a catalog/template base) ---
     def agentic_traces_config(self, model_spec: Any) -> Optional[Any]:
-        # The document has no agentic-traces section, so content comes from the
-        # catalog; for an off-catalog (synthesized) spec, borrow the Kimi
-        # K2.7-Code template rather than refusing to run.
+        # The run *shape* (scenario, dataset, InferenceX pin) still comes from
+        # the catalog, or from the Kimi K2.7-Code template for an off-catalog
+        # (synthesized) spec rather than refusing to run. What the document
+        # contributes is the sweep: which concurrencies to replay it at.
         from reference_config.agentic_traces.agentic_traces_config import (
             get_agentic_traces_config_or_template,
+            replace_agentic_runs,
         )
 
-        return self._delegate.agentic_traces_config(
+        base = self._delegate.agentic_traces_config(
             model_spec
         ) or get_agentic_traces_config_or_template(model_spec)
+        if base is None:
+            return None
+        return replace_agentic_runs(base, self._agentic_concurrencies())
+
+    def _agentic_concurrencies(self) -> List[int]:
+        """Concurrencies the document's agentic workloads ask for, in order.
+
+        Deduplicated because two workloads may share an operating point, and
+        replaying the same concurrency twice would just burn an hour per
+        duplicate.
+        """
+        seen: Dict[int, None] = {}
+        for workload in self._doc.agentic_workloads:
+            for point in workload.sweep:
+                if point.concurrency > 0:
+                    seen.setdefault(point.concurrency, None)
+        return sorted(seen)
+
+    def agentic_traces_goodput(self) -> Optional[str]:
+        """``--goodput`` constraints from the agentic workloads' SLOs.
+
+        Without SLOs there is nothing defining a "good" request, so AIPerf can
+        report no goodput -- even when the document sets a goodputPct target.
+        """
+        for workload in self._doc.agentic_workloads:
+            constraints = _slo_constraints(workload.slo)
+            if constraints:
+                return constraints
+        return None
 
     def resolve_agentic_run_specs(
         self,
@@ -601,14 +633,13 @@ def _capability_attach_points(scenario: Scenario, gates: dict) -> dict:
     return attach
 
 
-def _goodput_constraints(scenario: Scenario) -> Optional[str]:
-    """``vllm bench serve --goodput`` constraint string from the scenario's SLOs.
+def _slo_constraints(slo: Optional[Slo]) -> Optional[str]:
+    """``--goodput`` constraint string for a set of SLOs.
 
-    vLLM's keys are ttft/tpot/e2el in milliseconds — exactly the document's
-    SLO metrics. Returns None when the scenario declares no SLOs, in which
-    case goodput cannot be measured.
+    vLLM's and AIPerf's keys are ttft/tpot/e2el in milliseconds — exactly the
+    document's SLO metrics. Returns None when there are no SLOs, in which case
+    goodput cannot be measured: nothing defines a "good" request.
     """
-    slo = scenario.slo
     if slo is None:
         return None
     parts = []
@@ -620,6 +651,11 @@ def _goodput_constraints(scenario: Scenario) -> Optional[str]:
         if value is not None:
             parts.append(f"{key}:{value:g}")
     return " ".join(parts) or None
+
+
+def _goodput_constraints(scenario: Scenario) -> Optional[str]:
+    """``vllm bench serve --goodput`` constraint string from a scenario's SLOs."""
+    return _slo_constraints(scenario.slo)
 
 
 def _scenario_targets_goodput(scenario: Scenario) -> bool:


### PR DESCRIPTION
Parses agenticSweep points and agentic workloads out of the requirements document (AgenticSweepPoint / AgenticWorkload in the schema, tolerating both flat and document-envelope JSON) and expands the base agentic-traces config into one run spec per requested concurrency in RequirementsTargetPack.

Stack: part 4 of 6, based on #5082. Retarget to main once it merges.

Made with [Cursor](https://cursor.com)