### PR TITLE
feat(agentic-traces): grade goodput against the document's SLOs

### DIFF
--- a/llm_module/agentic_traces/runs.py
+++ b/llm_module/agentic_traces/runs.py
@@ -72,6 +72,8 @@ class AgenticTracesRun:
     use_server_token_count: bool
     gpu_telemetry: bool
     mode: AgenticTracesMode
+    # AIPerf ``--goodput`` SLO string; empty means this run measures none.
+    goodput: str = ""
     # SwarmOne swo-bench knobs. Unused by the InferenceX/AIPerf driver, so they
     # carry harmless defaults on ``inferencex_agentx`` runs.
     task: Optional[str] = None
@@ -188,6 +190,7 @@ def build_runs(
                 use_server_token_count=spec.use_server_token_count,
                 gpu_telemetry=spec.gpu_telemetry,
                 mode=mode,
+                goodput=spec.goodput,
                 task=spec.task,
                 resident=spec.resident,
                 cache_mode=spec.cache_mode,

--- a/llm_module/agentic_traces/sweep_export.py
+++ b/llm_module/agentic_traces/sweep_export.py
@@ -18,11 +18,8 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 # agenticSweep key -> the metric key produced by ``parse_aiperf_output``.
 #
-# Only measurements appear here. ``goodputPct`` is absent because this run
-# never asks for it, not because it is unmeasurable: AIPerf reports goodput
-# only when the command carries ``--goodput`` SLO constraints, which the
-# benchmark driver passes and ``build_aiperf_cmd`` does not. Until those
-# constraints are threaded through, the export has no goodput to map.
+# Only measurements appear here. ``goodputPct`` is derived rather than mapped:
+# see ``_goodput_pct``.
 _SWEEP_FIELD_TO_METRIC: Tuple[Tuple[str, str], ...] = (
     ("ttftMeanMs", "mean_ttft_ms"),
     ("ttftP50Ms", "median_ttft_ms"),
@@ -65,6 +62,27 @@ def _number(value: Any) -> Optional[float]:
     return float(value)
 
 
+def _goodput_pct(metrics: Mapping[str, Any]) -> Optional[float]:
+    """Percentage of requests that met every SLO, or None if not graded.
+
+    AIPerf reports goodput as a rate (good requests/sec) while the document
+    states it as a share of requests, so the two are reconciled against total
+    request throughput.
+
+    A zero rate is reported honestly as 0% -- "no request met the SLOs" is a
+    measurement, not a gap. That is only distinguishable from "never graded"
+    because the run records the SLO bars it used: without them AIPerf emits no
+    goodput at all, and there is nothing to report.
+    """
+    if not str(metrics.get("goodput_slo") or "").strip():
+        return None
+    good = _number(metrics.get("goodput"))
+    total = _number(metrics.get("request_throughput"))
+    if good is None or not total:
+        return None
+    return round(good / total * 100, 2)
+
+
 def to_agentic_sweep_point(
     metrics: Mapping[str, Any],
     *,
@@ -80,6 +98,10 @@ def to_agentic_sweep_point(
         value = _number(metrics.get(metric))
         if value is not None:
             point[field] = value
+
+    goodput_pct = _goodput_pct(metrics)
+    if goodput_pct is not None:
+        point["goodputPct"] = goodput_pct
 
     for metric in _CACHE_HIT_METRICS:
         value = _number(metrics.get(metric))

--- a/llm_module/drivers/aiperf_agentic_traces.py
+++ b/llm_module/drivers/aiperf_agentic_traces.py
@@ -124,6 +124,7 @@ class AIPerfAgenticTracesDriver:
             artifact_dir=artifact_dir,
             auth_token=server.auth_token,
             metrics_urls=metrics_urls,
+            goodput=trace_run.goodput,
         )
         _log_run_header(trace_run)
 
@@ -194,6 +195,7 @@ def build_aiperf_cmd(
     artifact_dir: Path,
     auth_token: str = "",
     metrics_urls: Sequence[str] = (),
+    goodput: str = "",
 ) -> List[str]:
     """Construct the ``aiperf profile`` CLI for one agentic-trace run.
 
@@ -206,6 +208,11 @@ def build_aiperf_cmd(
     ``--server-metrics`` is additive, not a replacement: AIPerf always scrapes
     ``<url>/metrics`` from the load target and appends ``metrics_urls``, so
     passing them cannot turn the default scrape off.
+
+    ``goodput`` is a space-separated ``TAG:VALUE`` SLO string (AIPerf's tags:
+    ``time_to_first_token``, ``inter_token_latency``, ``request_latency`` in ms,
+    ``output_token_throughput_per_user`` in tokens/s). AIPerf reports goodput
+    only when it is passed, so an empty string means the run measures none.
     """
     if not url.startswith("http"):
         url = f"http://{url}"
@@ -266,6 +273,13 @@ def build_aiperf_cmd(
     if normalized_metrics_urls:
         cmd.append("--server-metrics")
         cmd.extend(normalized_metrics_urls)
+    # Unlike --server-metrics above, --goodput is NOT consume_multiple: its
+    # validator splits the one string itself, so the whole SLO must be a
+    # single argv element. Splitting it would make every pair after the first
+    # fall through as a positional arg. Same handling as the prefix-cache
+    # driver.
+    if goodput.strip():
+        cmd.extend(["--goodput", goodput.strip()])
     if run.streaming:
         cmd.append("--streaming")
     if run.use_server_token_count:
@@ -381,6 +395,9 @@ def parse_aiperf_output(
         "input_token_throughput": _stat("input_token_throughput"),
         "total_token_throughput": _stat("total_token_throughput"),
         "request_throughput": _stat("request_throughput"),
+        # Requests/sec meeting every --goodput SLO. AIPerf emits this only
+        # when those bars were passed, so it stays 0 for a run with no SLOs.
+        "goodput": _stat("goodput"),
         # Prefill/decode split, which is the main serving insight for
         # long-context agentic replay. "effective" averages over the whole run
         # including idle time; "active" only counts windows where that phase was
@@ -732,6 +749,9 @@ def _build_payload(
         "slice_duration": run.slice_duration,
         "max_context_length": run.max_context_length,
         "random_seed": run.random_seed,
+        # The SLO bars goodput was graded against, so a goodput number is
+        # never read without the definition of "good" that produced it.
+        "goodput_slo": run.goodput,
         "failed_request_threshold": run.failed_request_threshold,
         "trajectory_start_min_ratio": run.trajectory_start_min_ratio,
         "trajectory_start_max_ratio": run.trajectory_start_max_ratio,

--- a/reference_config/agentic_traces/agentic_traces_config.py
+++ b/reference_config/agentic_traces/agentic_traces_config.py
@@ -81,6 +81,11 @@ class AgenticTracesRunSpec:
     # instead, ``vllm bench serve`` style.
     use_server_token_count: bool = True
     gpu_telemetry: bool = False
+    # AIPerf ``--goodput`` SLO string: space-separated TAG:VALUE bars deciding
+    # whether a request counts as good. Empty means the run measures no
+    # goodput, since AIPerf reports it only when the bars are passed. Catalog
+    # entries leave this empty; a requirements document supplies its SLOs.
+    goodput: str = ""
     # SwarmOne (``swo-bench replay``) knobs. Ignored by the InferenceX/AIPerf
     # driver, so they can stay at their defaults on ``inferencex_agentx`` specs.
     # ``task`` selects a single task from a multi-task swo-bench scenario (its
@@ -485,19 +490,23 @@ def get_agentic_traces_config_or_template(model_spec) -> Optional[AgenticTracesC
 def replace_agentic_runs(
     config: AgenticTracesConfig,
     concurrencies: Sequence[int],
+    goodput: str = "",
 ) -> AgenticTracesConfig:
-    """Replay ``config``'s runs at each of ``concurrencies``.
+    """Replay ``config``'s runs at each of ``concurrencies``, grading ``goodput``.
 
     A requirements document sweeps concurrency while holding the run shape
     fixed, so each configured run is duplicated once per concurrency rather
     than replaced: a config carrying both an InferenceX and a SwarmOne spec
     still sweeps both. An empty ``concurrencies`` leaves the config alone, so a
     document with no agentic sweep keeps the catalog's single operating point.
+
+    ``goodput`` applies to every run, since the SLOs are the workload's and do
+    not move with the operating point.
     """
     if not concurrencies:
         return config
     runs = tuple(
-        replace(run, concurrency=concurrency)
+        replace(run, concurrency=concurrency, goodput=goodput or run.goodput)
         for run in config.runs
         for concurrency in concurrencies
     )

--- a/tests/llm_module/test_agentic_traces_sweep_export.py
+++ b/tests/llm_module/test_agentic_traces_sweep_export.py
@@ -89,15 +89,30 @@ class TestToAgenticSweepPoint:
 
         assert point == {"concurrency": 8, "ttftMeanMs": 100.0}
 
-    def test_omits_goodput_that_the_run_never_measured(self):
-        """AIPerf reports goodput only when the command passes --goodput SLOs.
-
-        The agentic-traces command passes none, so there is nothing to map. If
-        those constraints are ever threaded through, this is the test to change.
-        """
-        point = to_agentic_sweep_point({**_METRICS, "goodput_pct": 90}, concurrency=1)
+    def test_omits_goodput_when_no_slos_graded_the_run(self):
+        """AIPerf reports goodput only when the command passes --goodput SLOs."""
+        point = to_agentic_sweep_point({**_METRICS, "goodput": 0}, concurrency=1)
 
         assert "goodputPct" not in point
+
+    def test_derives_goodput_share_from_the_rate(self):
+        """AIPerf reports good requests/sec; the document wants a share."""
+        point = to_agentic_sweep_point(
+            {**_METRICS, "goodput_slo": "time_to_first_token:2000", "goodput": 0.06},
+            concurrency=1,
+        )
+
+        # 0.06 good req/s out of 0.07416 total.
+        assert point["goodputPct"] == 80.91
+
+    def test_reports_a_graded_zero_as_zero(self):
+        """No request meeting the SLOs is a measurement, not a missing value."""
+        point = to_agentic_sweep_point(
+            {**_METRICS, "goodput_slo": "time_to_first_token:1", "goodput": 0.0},
+            concurrency=1,
+        )
+
+        assert point["goodputPct"] == 0.0
 
     def test_prefers_the_measured_cache_hit_rate(self):
         point = to_agentic_sweep_point(

--- a/tests/workflow_module/test_requirements_target_pack.py
+++ b/tests/workflow_module/test_requirements_target_pack.py
@@ -18,6 +18,7 @@ from workflows.model_spec_provider import (
 from workflows.requirements_target_pack import (
     RequirementsModelSpecProvider,
     RequirementsTargetPack,
+    _goodput_constraints,
 )
 from workflows.target_pack_provider import TenstorrentTargetPack
 from workflows.workflow_types import DeviceTypes
@@ -550,7 +551,17 @@ def test_agentic_goodput_needs_slos():
     assert _agentic_pack([1]).agentic_traces_goodput() is None
 
 
-def test_agentic_goodput_built_from_workload_slos():
+def test_agentic_goodput_uses_aiperf_tag_names():
+    """AIPerf spells the bars out; vLLM's ttft/tpot/e2el keys are rejected."""
     pack = _agentic_pack([1], slo={"ttftMs": 2000, "tpotMs": 20, "e2elMs": 20000})
 
-    assert pack.agentic_traces_goodput() == "ttft:2000 tpot:20 e2el:20000"
+    assert pack.agentic_traces_goodput() == (
+        "time_to_first_token:2000 inter_token_latency:20 request_latency:20000"
+    )
+
+
+def test_vllm_goodput_keys_are_unchanged_by_the_aiperf_mapping():
+    """The benchmark sweep keeps naming the bars after the metrics themselves."""
+    (scenario,) = load_requirements(_FIXTURE).scenarios
+
+    assert _goodput_constraints(scenario) == "ttft:2000 tpot:20 e2el:20000"

--- a/workflows/requirements_target_pack.py
+++ b/workflows/requirements_target_pack.py
@@ -507,7 +507,11 @@ class RequirementsTargetPack(TargetPack):
         ) or get_agentic_traces_config_or_template(model_spec)
         if base is None:
             return None
-        return replace_agentic_runs(base, self._agentic_concurrencies())
+        return replace_agentic_runs(
+            base,
+            self._agentic_concurrencies(),
+            goodput=self.agentic_traces_goodput() or "",
+        )
 
     def _agentic_concurrencies(self) -> List[int]:
         """Concurrencies the document's agentic workloads ask for, in order.
@@ -524,13 +528,13 @@ class RequirementsTargetPack(TargetPack):
         return sorted(seen)
 
     def agentic_traces_goodput(self) -> Optional[str]:
-        """``--goodput`` constraints from the agentic workloads' SLOs.
+        """AIPerf ``--goodput`` constraints from the agentic workloads' SLOs.
 
         Without SLOs there is nothing defining a "good" request, so AIPerf can
         report no goodput -- even when the document sets a goodputPct target.
         """
         for workload in self._doc.agentic_workloads:
-            constraints = _slo_constraints(workload.slo)
+            constraints = _aiperf_slo_constraints(workload.slo)
             if constraints:
                 return constraints
         return None
@@ -633,29 +637,46 @@ def _capability_attach_points(scenario: Scenario, gates: dict) -> dict:
     return attach
 
 
-def _slo_constraints(slo: Optional[Slo]) -> Optional[str]:
-    """``--goodput`` constraint string for a set of SLOs.
+def _slo_constraints(slo: Optional[Slo], keys: Mapping[str, str]) -> Optional[str]:
+    """``--goodput`` constraint string for a set of SLOs, using ``keys``.
 
-    vLLM's and AIPerf's keys are ttft/tpot/e2el in milliseconds — exactly the
-    document's SLO metrics. Returns None when there are no SLOs, in which case
-    goodput cannot be measured: nothing defines a "good" request.
+    Returns None when there are no SLOs, in which case goodput cannot be
+    measured: nothing defines a "good" request.
     """
     if slo is None:
         return None
-    parts = []
-    for key, value in (
-        ("ttft", slo.ttft_ms),
-        ("tpot", slo.tpot_ms),
-        ("e2el", slo.e2el_ms),
-    ):
-        if value is not None:
-            parts.append(f"{key}:{value:g}")
+    values = {"ttft": slo.ttft_ms, "tpot": slo.tpot_ms, "e2el": slo.e2el_ms}
+    parts = [
+        f"{keys[metric]}:{values[metric]:g}"
+        for metric in ("ttft", "tpot", "e2el")
+        if values[metric] is not None
+    ]
     return " ".join(parts) or None
+
+
+# vLLM names the per-request bars after the metrics themselves, so its keys are
+# the document's SLO metrics verbatim.
+_VLLM_GOODPUT_KEYS = {"ttft": "ttft", "tpot": "tpot", "e2el": "e2el"}
+
+# AIPerf spells the same three bars out in full, and has no per-output-token
+# tag: inter-token latency is the same measurement under another name, and a
+# request's end-to-end latency is its request latency. Both remain in ms, as
+# the document states them.
+_AIPERF_GOODPUT_KEYS = {
+    "ttft": "time_to_first_token",
+    "tpot": "inter_token_latency",
+    "e2el": "request_latency",
+}
 
 
 def _goodput_constraints(scenario: Scenario) -> Optional[str]:
     """``vllm bench serve --goodput`` constraint string from a scenario's SLOs."""
-    return _slo_constraints(scenario.slo)
+    return _slo_constraints(scenario.slo, _VLLM_GOODPUT_KEYS)
+
+
+def _aiperf_slo_constraints(slo: Optional[Slo]) -> Optional[str]:
+    """AIPerf ``--goodput`` constraint string for a set of SLOs."""
+    return _slo_constraints(slo, _AIPERF_GOODPUT_KEYS)
 
 
 def _scenario_targets_goodput(scenario: Scenario) -> bool:


### PR DESCRIPTION
Threads the workload SLOs from the requirements document down to the AIPerf command as --goodput bars and back out through the parsed metrics, so a document asking for goodputPct actually gets graded.

Two non-obvious AIPerf behaviors are pinned by tests: --goodput takes the whole SLO string as ONE argv element (its validator splits it itself), and its tags are AIPerf's own (time_to_first_token / inter_token_latency / request_latency), not vLLM's ttft/tpot/e2el. Goodput comes back as a rate, so the export reconciles it against request throughput to report a percentage.

Stack: part 5 of 6, based on #5083. Retarget to main once it merges.

Made with [Cursor](https://cursor.com)