### PR TITLE
feat(agentic-traces): emit the measured sweep as agenticSweep

### DIFF
--- a/llm_module/agentic_traces/sweep_export.py
+++ b/llm_module/agentic_traces/sweep_export.py
@@ -14,7 +14,12 @@ One point per run, so a sweep over several concurrencies yields several points.
 
 from __future__ import annotations
 
+import json
+import logging
+from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
 
 # agenticSweep key -> the metric key produced by ``parse_aiperf_output``.
 #
@@ -40,8 +45,14 @@ _SWEEP_FIELD_TO_METRIC: Tuple[Tuple[str, str], ...] = (
     ("inputTokensP95", "p95_isl"),
     ("outputTokensMean", "mean_osl"),
     ("outputTokensP95", "p95_osl"),
-    # Percentiles of a rate, so these read the slow tail off the bottom of the
-    # distribution; see the note in ``parse_aiperf_output``.
+)
+
+# Emitted after the cache-hit rate, following the document's own field order so
+# a measured point and an expected one diff cleanly line for line.
+#
+# Percentiles of a rate, so these read the slow tail off the bottom of the
+# distribution; see the note in ``parse_aiperf_output``.
+_INTVTY_FIELD_TO_METRIC: Tuple[Tuple[str, str], ...] = (
     ("e2eNormIntvtyP75Tps", "p75_e2e_norm_intvty"),
     ("e2eNormIntvtyP90Tps", "p90_e2e_norm_intvty"),
 )
@@ -99,15 +110,20 @@ def to_agentic_sweep_point(
         if value is not None:
             point[field] = value
 
-    goodput_pct = _goodput_pct(metrics)
-    if goodput_pct is not None:
-        point["goodputPct"] = goodput_pct
-
     for metric in _CACHE_HIT_METRICS:
         value = _number(metrics.get(metric))
         if value is not None:
             point["kvCacheHitRatePct"] = value
             break
+
+    for field, metric in _INTVTY_FIELD_TO_METRIC:
+        value = _number(metrics.get(metric))
+        if value is not None:
+            point[field] = value
+
+    goodput_pct = _goodput_pct(metrics)
+    if goodput_pct is not None:
+        point["goodputPct"] = goodput_pct
 
     return point
 
@@ -125,4 +141,24 @@ def to_agentic_sweep(runs: Sequence[Mapping[str, Any]]) -> List[Dict[str, Any]]:
     return sorted(points, key=lambda point: point["concurrency"])
 
 
-__all__ = ["to_agentic_sweep", "to_agentic_sweep_point"]
+def write_agentic_sweep(
+    runs: Sequence[Mapping[str, Any]],
+    output_dir: Path,
+    filename: str = "agentic_sweep.json",
+) -> Path:
+    """Write ``runs`` as an ``agenticSweep`` JSON file and return its path.
+
+    Wrapped in the document's own ``{"agenticSweep": [...]}`` object so the file
+    can be pasted straight into a requirements document beside the expected
+    sweep. Always a list, even for a single point, so a file written mid-sweep
+    has the same shape as the final one and consumers need no special case.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / filename
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump({"agenticSweep": to_agentic_sweep(runs)}, handle, indent=2)
+    logger.info("Agentic sweep written to: %s", path)
+    return path
+
+
+__all__ = ["to_agentic_sweep", "to_agentic_sweep_point", "write_agentic_sweep"]

--- a/llm_module/drivers/aiperf_agentic_traces.py
+++ b/llm_module/drivers/aiperf_agentic_traces.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from ..agentic_traces import AgenticTracesRun
+from ..agentic_traces.sweep_export import write_agentic_sweep
 from ..config import DriverContext, ServerConnection
 from ._subprocess import load_json, run_command, safe_filename_part
 from .aiperf_prefix_cache import (
@@ -178,6 +179,16 @@ class AIPerfAgenticTracesDriver:
             output_dir=self.output_dir,
             model_id=self.model_id or self.model_repo,
             label=trace_run.filesafe_label(),
+        )
+        # This point's requirements-shaped view, written now rather than at the
+        # end of the sweep: each point costs an hour, so a later failure must
+        # not take the ones already measured with it.
+        write_agentic_sweep(
+            [payload],
+            self.output_dir,
+            filename=(
+                f"agentic_sweep_{safe_filename_part(trace_run.filesafe_label())}.json"
+            ),
         )
         _log_run_summary(trace_run, metrics)
         return AgenticTracesDriverResult(

--- a/report_module/agentic_traces_renderer.py
+++ b/report_module/agentic_traces_renderer.py
@@ -28,6 +28,7 @@ bottom of this module).
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
@@ -576,9 +577,45 @@ def render_agentic_traces(block: Block, metadata: Mapping[str, Any]) -> str:
             f"can be traced back to what produced it.\n\n{config}"
         )
 
+    sweep = _agentic_sweep_block(rows)
+    if sweep:
+        parts.append(sweep)
+
     parts.append(_definitions_block(rows))
 
     return "\n\n".join(parts)
+
+
+def _agentic_sweep_block(rows: Sequence[Mapping[str, Any]]) -> str:
+    """Emit the measured sweep in the requirements document's own shape.
+
+    The tables above are for reading; this is for comparing. A requirements
+    document states its expectations as an ``agenticSweep``, so emitting the
+    measurement in that same shape lets the expected point and the observed one
+    diff field for field instead of being eyeballed across a table.
+
+    Only the InferenceX rows: ``agenticSweep`` is defined over AIPerf's metric
+    set, and a swo-bench row would render as a point with nothing in it.
+    """
+    # Imported here, not at module scope: llm_module imports report_module.schema,
+    # so a module-level import back would close the cycle.
+    from llm_module.agentic_traces.sweep_export import to_agentic_sweep
+
+    inferencex_rows = [
+        row for row in rows if str(row.get("trace_source") or "") == INFERENCEX_SOURCE
+    ]
+    if not inferencex_rows:
+        return ""
+    sweep = to_agentic_sweep(inferencex_rows)
+    body = json.dumps({"agenticSweep": sweep}, indent=2)
+    return (
+        "#### Measured `agenticSweep`\n\n"
+        "The same runs in the shape a requirements document states its "
+        "expectations in, one object per concurrency, so an expected point and "
+        "the measured one line up field for field. Written alongside the raw "
+        "results as `agentic_sweep.json` too.\n\n"
+        f"```json\n{body}\n```"
+    )
 
 
 def _definitions_block(rows: Sequence[Mapping[str, Any]]) -> str:

--- a/test_module/llm_tests/agentic_traces_tests.py
+++ b/test_module/llm_tests/agentic_traces_tests.py
@@ -28,7 +28,7 @@ import time
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 from llm_module import ServerConnection
 from llm_module.agentic_traces import (
@@ -37,6 +37,7 @@ from llm_module.agentic_traces import (
     summarize_runs,
     total_planned_seconds,
 )
+from llm_module.agentic_traces.sweep_export import write_agentic_sweep
 from llm_module.config import DriverContext
 from llm_module.drivers.aiperf_agentic_traces import (
     AgenticTracesDriverResult,
@@ -225,6 +226,7 @@ def run_agentic_traces(
         result.return_codes.append(1)
         return result
 
+    payloads: List[Dict[str, Any]] = []
     for i, run in enumerate(runs, 1):
         if server_controller is not None and not _server_still_healthy(
             server_controller, result
@@ -259,7 +261,21 @@ def run_agentic_traces(
             )
             continue
 
+        # InferenceX only, matching the driver's per-run file and the report
+        # section. ``agenticSweep`` is defined over AIPerf's metric set, and
+        # swo-bench measures a different one: no TPOT (its inter-token latency
+        # is unusable -- see the note in its driver), no p95s, no goodput. A
+        # swo-bench point would be half-empty in ways that read as measured
+        # zeroes against a document's expectations.
+        if run.trace_source is TraceSource.INFERENCEX_AGENTX:
+            payloads.append(outcome.payload)
         result.blocks.append(parser.parse(outcome.payload, device=device_label))
+
+    # The sweep as the requirements document states one: every point measured,
+    # ordered by concurrency. Written from whatever succeeded, so a sweep that
+    # lost a point still yields the rest rather than nothing.
+    if payloads and output_root is not None:
+        write_agentic_sweep(payloads, Path(output_root))
 
     if not result.blocks:
         logger.error("[agentic-traces] No blocks produced -- sweep had zero successes.")

--- a/tests/llm_module/test_agentic_traces_sweep_export.py
+++ b/tests/llm_module/test_agentic_traces_sweep_export.py
@@ -21,9 +21,12 @@ ones that would silently break that comparison:
 
 from __future__ import annotations
 
+import json
+
 from llm_module.agentic_traces.sweep_export import (
     to_agentic_sweep,
     to_agentic_sweep_point,
+    write_agentic_sweep,
 )
 
 # Shaped like ``parse_aiperf_output`` output for a single completed run.
@@ -157,3 +160,28 @@ class TestToAgenticSweep:
 
     def test_empty_when_no_runs_completed(self):
         assert to_agentic_sweep([]) == []
+
+
+class TestWriteAgenticSweep:
+    def test_writes_a_list_even_for_one_point(self, tmp_path):
+        """A file written mid-sweep must not need special-casing to read."""
+        path = write_agentic_sweep([{**_METRICS, "concurrency": 4}], tmp_path)
+
+        assert json.loads(path.read_text()) == {
+            "agenticSweep": [to_agentic_sweep_point(_METRICS, concurrency=4)]
+        }
+
+    def test_orders_points_by_concurrency(self, tmp_path):
+        path = write_agentic_sweep(
+            [{**_METRICS, "concurrency": c} for c in (16, 1, 8)], tmp_path
+        )
+
+        points = json.loads(path.read_text())["agenticSweep"]
+        assert [p["concurrency"] for p in points] == [1, 8, 16]
+
+    def test_creates_the_output_directory(self, tmp_path):
+        path = write_agentic_sweep(
+            [{**_METRICS, "concurrency": 1}], tmp_path / "nested" / "dir"
+        )
+
+        assert path.exists()

--- a/tests/report_module/test_agentic_traces_renderer.py
+++ b/tests/report_module/test_agentic_traces_renderer.py
@@ -445,3 +445,39 @@ class TestMixedSweep:
         out = _render(_swo_record(), _record())
         latency = out.split("#### Per-run Throughput")[0]
         assert latency.index("| inferencex_agentx ") < latency.index("| swarmone ")
+
+
+class TestMeasuredAgenticSweep:
+    """The report also carries the sweep in the requirements document's shape.
+
+    The tables are for reading; this block is for diffing a measured point
+    against the expected one a document declares, so it must stay valid JSON
+    under the document's own key.
+    """
+
+    def test_sweep_block_is_included_by_default(self):
+        out = _render(_record())
+
+        assert "#### Measured `agenticSweep`" in out
+
+    def test_sweep_block_is_parseable_json_under_the_documents_key(self):
+        import json
+
+        out = _render(_record(concurrency=8))
+        body = out.split("```json", 1)[1].split("```", 1)[0]
+
+        assert [p["concurrency"] for p in json.loads(body)["agenticSweep"]] == [8]
+
+    def test_one_point_per_run_ordered_by_concurrency(self):
+        import json
+
+        out = _render(_record(concurrency=16), _record(concurrency=4))
+        body = out.split("```json", 1)[1].split("```", 1)[0]
+
+        assert [p["concurrency"] for p in json.loads(body)["agenticSweep"]] == [4, 16]
+
+    def test_swarmone_runs_are_left_out_of_the_sweep(self):
+        """agenticSweep is defined over AIPerf's metrics; swo-bench has none."""
+        out = _render(_swo_record())
+
+        assert "#### Measured `agenticSweep`" not in out

--- a/tests/test_module/llm_tests/test_agentic_traces_tests.py
+++ b/tests/test_module/llm_tests/test_agentic_traces_tests.py
@@ -16,6 +16,8 @@ run could otherwise be reported as a clean pass:
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -340,3 +342,69 @@ class TestTraceSourceDispatch:
         # The orchestrator creates the output root; the (mocked) driver would
         # create its own per-run artifact subtree.
         assert (tmp_path / "agentic_traces").is_dir()
+
+
+class TestAgenticSweepFile:
+    """The combined ``agentic_sweep.json`` the sweep leaves behind.
+
+    Must agree with the driver's per-run file and the report section, which are
+    both InferenceX-only: ``agenticSweep`` is defined over AIPerf's metric set,
+    so a swo-bench point would be half-empty in ways that read as measured
+    zeroes against a document's expectations.
+    """
+
+    def _sweep(self, tmp_path):
+        path = Path(tmp_path) / "agentic_traces" / "agentic_sweep.json"
+        return json.loads(path.read_text())["agenticSweep"] if path.exists() else None
+
+    def _both_drivers(self):
+        aiperf_driver = MagicMock()
+        aiperf_driver.run.return_value = AgenticTracesDriverResult(
+            return_code=0,
+            payload={**_ok_payload("aiperf"), "concurrency": 8},
+            raw_path=None,
+        )
+        swo_driver = MagicMock()
+        swo_driver.run.return_value = AgenticTracesDriverResult(
+            return_code=0,
+            payload={**_ok_payload("swo"), "concurrency": 99},
+            raw_path=None,
+        )
+        return patch.multiple(
+            agentic_traces_tests,
+            AIPerfAgenticTracesDriver=MagicMock(return_value=aiperf_driver),
+            SwoBenchAgenticTracesDriver=MagicMock(return_value=swo_driver),
+        )
+
+    def test_inferencex_run_is_written(self, tmp_path):
+        outcome = AgenticTracesDriverResult(
+            return_code=0, payload={**_ok_payload(), "concurrency": 4}, raw_path=None
+        )
+        patcher, _driver = _driver_returning(outcome)
+        with patcher:
+            run_agentic_traces(_ctx(tmp_path=tmp_path), mode="ci", inter_run_sleep_s=0)
+
+        assert [p["concurrency"] for p in self._sweep(tmp_path)] == [4]
+
+    def test_swarmone_run_is_left_out(self, tmp_path):
+        with self._both_drivers():
+            run_agentic_traces(
+                _ctx(tmp_path=tmp_path),
+                mode="ci",
+                trace_sources="swarmone",
+                inter_run_sleep_s=0,
+            )
+
+        # Nothing InferenceX ran, so there is no sweep to write at all.
+        assert self._sweep(tmp_path) is None
+
+    def test_mixed_sweep_keeps_only_the_inferencex_point(self, tmp_path):
+        with self._both_drivers():
+            run_agentic_traces(
+                _ctx(tmp_path=tmp_path),
+                mode="ci",
+                trace_sources="inferencex_agentx,swarmone",
+                inter_run_sleep_s=0,
+            )
+
+        assert [p["concurrency"] for p in self._sweep(tmp_path)] == [8]


### PR DESCRIPTION
Writes the measured sweep to disk as it completes: one agentic_sweep_<label>.json per run plus a combined agentic_sweep.json at the end, wrapped as {"agenticSweep": [...]} with fields ordered to match the InferenceX report. InferenceX rows only -- SwarmOne payloads are filtered so partial runs cannot leak incomplete points into the report artifact.

Stack: part 6 of 6, based on #5084. Retarget to main once it merges.

Made with [Cursor](https://cursor.com)