### PR TITLE
fix(swebench): recover in-container agent patch when mini-swe-agent crashes before submit

### DIFF
--- a/llm_module/agentic/mini_swe_capture.py
+++ b/llm_module/agentic/mini_swe_capture.py
@@ -99,9 +99,7 @@ def make_get_sb_environment_wrapper(original: Callable[..., Any]) -> Callable[..
     def wrapper(config: dict, instance: dict) -> Any:
         env = original(config, instance)
         try:
-            register_environment(
-                (instance or {}).get("instance_id", ""), env
-            )
+            register_environment((instance or {}).get("instance_id", ""), env)
         except Exception:  # noqa: BLE001 -- registration must never break a run
             logger.warning(
                 "mini-swe capture: failed to register environment", exc_info=True
@@ -116,7 +114,9 @@ def make_update_preds_file_wrapper(original: Callable[..., Any]) -> Callable[...
     """Wrap ``update_preds_file`` to backfill an empty crash result with the
     recovered in-container diff before it is persisted."""
 
-    def wrapper(output_path: Any, instance_id: str, model_name: str, result: str) -> Any:
+    def wrapper(
+        output_path: Any, instance_id: str, model_name: str, result: str
+    ) -> Any:
         env = pop_environment(instance_id)
         if not result and env is not None:
             recovered = recover_patch_from_env(env)
@@ -151,8 +151,7 @@ def install() -> bool:
         from minisweagent.run.benchmarks import swebench as runner
     except Exception:  # noqa: BLE001 -- absence of the dep must not break import
         logger.warning(
-            "mini-swe capture: minisweagent runner not importable; capture "
-            "inactive",
+            "mini-swe capture: minisweagent runner not importable; capture inactive",
             exc_info=True,
         )
         return False

--- a/llm_module/agentic/mini_swe_capture.py
+++ b/llm_module/agentic/mini_swe_capture.py
@@ -129,6 +129,17 @@ def make_update_preds_file_wrapper(original: Callable[..., Any]) -> Callable[...
                     instance_id,
                 )
                 result = recovered
+        elif not result and env is None:
+            # Empty prediction with no live environment to recover from: either a
+            # genuine pre-environment failure, or -- if this ever fires for an
+            # instance that reached the agent -- a sign the injection did not take
+            # (register_environment never ran). Log it so a broken shim is visible
+            # in the agent log instead of silently degrading to an empty patch.
+            logger.warning(
+                "mini-swe capture: empty prediction for %s and no live environment "
+                "was registered; cannot recover an in-container patch",
+                instance_id,
+            )
         return original(output_path, instance_id, model_name, result)
 
     wrapper._ttis_capture_wrapped = True  # type: ignore[attr-defined]
@@ -164,4 +175,11 @@ def install() -> bool:
             runner.update_preds_file
         )
     _INSTALLED = True
+    # Activation breadcrumb: makes a working injection visible in the agent log,
+    # so a run that produces an empty patch can be told apart from one where the
+    # shim never installed.
+    logger.info(
+        "mini-swe capture: installed in-container patch-recovery wrappers on the "
+        "mini-swe-agent SWE-bench runner"
+    )
     return True

--- a/llm_module/agentic/mini_swe_capture.py
+++ b/llm_module/agentic/mini_swe_capture.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Recover an agent's in-container edit when the mini-swe-agent SWE-bench runner
+crashes before it submits.
+
+The pinned upstream runner (``mini-swe-agent==2.2.8``,
+``minisweagent/run/benchmarks/swebench.py``) force-sets the prediction to the
+empty string on *any* exception in ``process_instance``::
+
+    except Exception as e:
+        ...
+        exit_status, result = type(e).__name__, ""
+
+Because ``get_sb_environment`` builds ``--rm`` containers, the still-running
+container that holds the agent's real, already-applied ``git diff`` is torn down
+right after, so completed work is discarded and scored as an empty patch. This
+is what threw away Qwen3.6-27B's correct edit at turn 71 and GPT-OSS-120B's at
+turn 4.
+
+The fix belongs in that shared runner (below every model and both ttis model
+classes -- litellm and the token-budget class -- so it benefits all equally),
+but the runner is a pinned third-party dependency. Rather than fork it or edit
+site-packages on a node (an uncommitted, unbankable change), this module wraps
+two stable seams of the runner from committed ttis code and is injected into the
+agent subprocess via a generated ``sitecustomize`` on ``PYTHONPATH`` -- the same
+mechanism ttis already uses for its SWE-bench harness patch
+(``llm_module.agentic.swebench._add_mini_swe_capture_patch_to_env``):
+
+* ``get_sb_environment(config, instance)`` -- remember the created environment,
+  keyed by ``instance_id``.
+* ``update_preds_file(path, instance_id, model_name, result)`` -- runs inside
+  ``process_instance``'s ``finally`` while the container is still alive (the
+  runner never calls ``env.cleanup``; teardown is deferred to ``__del__``). When
+  ``result`` is empty (the discarded-crash case) and a diff can be recovered
+  from the remembered container, substitute it before the prediction is written.
+
+The wrappers rewrite the runner module's globals, so ``process_instance``'s bare
+``get_sb_environment(...)`` / ``update_preds_file(...)`` calls resolve to them at
+call time. Recovery never raises and never masks the original crash.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# Mirrors how the mini-swe-agent SWE-bench config computes a submission diff
+# (repo working dir is ``/testbed``, which is the environment's configured cwd,
+# so ``env.execute`` runs there). ``git add -A`` also captures newly created
+# files so the recovered patch is applyable by the verifier.
+_RECOVER_COMMAND = "git add -A && git diff --cached"
+
+_REGISTRY_LOCK = threading.Lock()
+_ENV_BY_INSTANCE: dict[str, Any] = {}
+
+
+def recover_patch_from_env(env: Any) -> str:
+    """Best-effort snapshot of a live SWE-bench container's working-tree diff.
+
+    Returns ``""`` when there is no environment or nothing to recover. Never
+    raises: recovery must not mask the original crash.
+    """
+    if env is None:
+        return ""
+    try:
+        out = env.execute({"command": _RECOVER_COMMAND})
+    except Exception:  # noqa: BLE001 -- recovery is best-effort, never fatal
+        logger.warning(
+            "mini-swe capture: env.execute failed during patch recovery",
+            exc_info=True,
+        )
+        return ""
+    if not isinstance(out, dict) or out.get("returncode") != 0:
+        return ""
+    output = out.get("output")
+    return output if isinstance(output, str) else ""
+
+
+def register_environment(instance_id: str, env: Any) -> None:
+    if not instance_id:
+        return
+    with _REGISTRY_LOCK:
+        _ENV_BY_INSTANCE[instance_id] = env
+
+
+def pop_environment(instance_id: str) -> Any:
+    with _REGISTRY_LOCK:
+        return _ENV_BY_INSTANCE.pop(instance_id, None)
+
+
+def make_get_sb_environment_wrapper(original: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap ``get_sb_environment`` to remember each instance's live environment."""
+
+    def wrapper(config: dict, instance: dict) -> Any:
+        env = original(config, instance)
+        try:
+            register_environment(
+                (instance or {}).get("instance_id", ""), env
+            )
+        except Exception:  # noqa: BLE001 -- registration must never break a run
+            logger.warning(
+                "mini-swe capture: failed to register environment", exc_info=True
+            )
+        return env
+
+    wrapper._ttis_capture_wrapped = True  # type: ignore[attr-defined]
+    return wrapper
+
+
+def make_update_preds_file_wrapper(original: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap ``update_preds_file`` to backfill an empty crash result with the
+    recovered in-container diff before it is persisted."""
+
+    def wrapper(output_path: Any, instance_id: str, model_name: str, result: str) -> Any:
+        env = pop_environment(instance_id)
+        if not result and env is not None:
+            recovered = recover_patch_from_env(env)
+            if recovered.strip():
+                logger.warning(
+                    "mini-swe capture: recovered a %d-char in-container patch for "
+                    "%s that the runner would otherwise discard as an empty "
+                    "prediction on crash",
+                    len(recovered),
+                    instance_id,
+                )
+                result = recovered
+        return original(output_path, instance_id, model_name, result)
+
+    wrapper._ttis_capture_wrapped = True  # type: ignore[attr-defined]
+    return wrapper
+
+
+_INSTALLED = False
+
+
+def install() -> bool:
+    """Idempotently wrap the pinned mini-swe-agent SWE-bench runner seams.
+
+    Returns ``True`` once the wrappers are in place, ``False`` if the runner
+    cannot be imported (recovery is then simply inactive -- never fatal).
+    """
+    global _INSTALLED
+    if _INSTALLED:
+        return True
+    try:
+        from minisweagent.run.benchmarks import swebench as runner
+    except Exception:  # noqa: BLE001 -- absence of the dep must not break import
+        logger.warning(
+            "mini-swe capture: minisweagent runner not importable; capture "
+            "inactive",
+            exc_info=True,
+        )
+        return False
+    if not getattr(runner.get_sb_environment, "_ttis_capture_wrapped", False):
+        runner.get_sb_environment = make_get_sb_environment_wrapper(
+            runner.get_sb_environment
+        )
+    if not getattr(runner.update_preds_file, "_ttis_capture_wrapped", False):
+        runner.update_preds_file = make_update_preds_file_wrapper(
+            runner.update_preds_file
+        )
+    _INSTALLED = True
+    return True

--- a/llm_module/agentic/swebench.py
+++ b/llm_module/agentic/swebench.py
@@ -260,6 +260,52 @@ def _add_swebench_harness_patch_to_env(
     return patched_env
 
 
+def _write_mini_swe_capture_patch(output_dir: Path) -> Path:
+    """Generate a sitecustomize that installs the in-container patch-capture shim.
+
+    The pinned mini-swe-agent runner discards a real container ``git diff`` on any
+    mid-run crash (``process_instance`` sets ``result = ""`` in its exception
+    handler) and its ``--rm`` container is then torn down, so completed agent work
+    is scored as an empty patch. ``llm_module.agentic.mini_swe_capture`` wraps the
+    runner's ``get_sb_environment`` / ``update_preds_file`` seams to snapshot that
+    diff while the container is still alive. This is injected into the agent
+    subprocess on ``PYTHONPATH`` (the same committed mechanism as the harness
+    patch above); ``repo_root`` is already on the agent's ``PYTHONPATH``, so the
+    ``llm_module`` import resolves.
+    """
+    patch_dir = output_dir / "mini_swe_capture_patch"
+    patch_dir.mkdir(parents=True, exist_ok=True)
+    patch_path = patch_dir / "sitecustomize.py"
+    patch_path.write_text(
+        """
+# Injected via PYTHONPATH by llm_module.agentic.swebench for the mini-swe-agent
+# subprocess. Recovers an in-container agent edit that the pinned runner would
+# otherwise discard as an empty patch on a mid-run crash. Real logic lives in the
+# committed module llm_module/agentic/mini_swe_capture.py.
+try:
+    from llm_module.agentic.mini_swe_capture import install as _ttis_install
+
+    _ttis_install()
+except Exception:  # noqa: BLE001
+    pass
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return patch_dir
+
+
+def _add_mini_swe_capture_patch_to_env(
+    output_dir: Path, env: dict[str, str]
+) -> dict[str, str]:
+    patched_env = dict(env)
+    patch_dir = _write_mini_swe_capture_patch(output_dir)
+    python_path = patched_env.get("PYTHONPATH")
+    patched_env["PYTHONPATH"] = (
+        str(patch_dir) if not python_path else f"{patch_dir}{os.pathsep}{python_path}"
+    )
+    return patched_env
+
+
 def _write_sweagent_model_config(config: SWEbenchRunConfig) -> Path:
     model_config: dict[str, Any] = {
         "agent": {
@@ -735,10 +781,15 @@ def run(config: SWEbenchRunConfig) -> int:
         mini_cmd = build_mini_sweagent_command(
             config, mini_config_path, mini_output_dir
         )
+        # Agent-only env: inject the in-container patch-capture shim so a mid-run
+        # crash recovers the agent's edit instead of discarding it as an empty
+        # patch. Kept separate from ``env`` so the later verifier step's harness
+        # patch is unaffected.
+        agent_env = _add_mini_swe_capture_patch_to_env(config.output_dir, env)
         rc = run_with_progress(
             mini_cmd,
             cwd=config.output_dir,
-            env=env,
+            env=agent_env,
             probe=make_swebench_probe(mini_output_dir, _resolve_total(config)),
             label=config.task_name,
             per_task_budget_s=config.mini_container_timeout_sec,

--- a/tests/llm_module/test_mini_swe_capture.py
+++ b/tests/llm_module/test_mini_swe_capture.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Deterministic, silicon-free proof that the mini-swe-agent patch-capture shim
+recovers an agent's in-container edit when the runner crashes before submit.
+
+Reproduces the exact upstream bug shape (``mini-swe-agent==2.2.8``
+``process_instance``: ``exit_status, result = type(e).__name__, ""``) with a
+faithful in-memory fake of ``minisweagent.run.benchmarks.swebench`` whose
+``process_instance`` looks ``get_sb_environment`` / ``update_preds_file`` up as
+module globals at call time -- so ``install()``'s monkeypatch is exercised end to
+end. No container, no model, no device; runs in milliseconds.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from llm_module.agentic import mini_swe_capture as cap
+
+
+class _FakeEnv:
+    """Stands in for a live DockerEnvironment. ``execute`` returns the same dict
+    shape the real environment does (``output`` / ``returncode``)."""
+
+    def __init__(self, diff: str, returncode: int = 0, raise_exc: Exception | None = None):
+        self._diff = diff
+        self._rc = returncode
+        self._raise = raise_exc
+        self.calls: list[dict] = []
+
+    def execute(self, action, cwd: str = "", *, timeout=None):
+        self.calls.append(action)
+        if self._raise is not None:
+            raise self._raise
+        return {"output": self._diff, "returncode": self._rc, "exception_info": ""}
+
+
+@pytest.fixture(autouse=True)
+def _reset_capture_state():
+    """Each test starts from a clean, uninstalled shim."""
+    cap._INSTALLED = False
+    with cap._REGISTRY_LOCK:
+        cap._ENV_BY_INSTANCE.clear()
+    yield
+    cap._INSTALLED = False
+    with cap._REGISTRY_LOCK:
+        cap._ENV_BY_INSTANCE.clear()
+
+
+# --- unit level: the pure recovery helper --------------------------------------
+
+
+def test_recover_patch_returns_diff_on_success():
+    env = _FakeEnv(diff="diff --git a/x b/x\n+edit\n")
+    assert cap.recover_patch_from_env(env) == "diff --git a/x b/x\n+edit\n"
+    assert env.calls == [{"command": "git add -A && git diff --cached"}]
+
+
+def test_recover_patch_none_env_is_empty():
+    assert cap.recover_patch_from_env(None) == ""
+
+
+def test_recover_patch_nonzero_returncode_is_empty():
+    assert cap.recover_patch_from_env(_FakeEnv(diff="junk", returncode=1)) == ""
+
+
+def test_recover_patch_swallows_execute_exception():
+    assert cap.recover_patch_from_env(_FakeEnv(diff="", raise_exc=RuntimeError("boom"))) == ""
+
+
+# --- integration level: full crash path through a faithful fake runner ---------
+
+# Bodies are exec'd into the fake module's namespace so the bare-name calls to
+# ``get_sb_environment`` / ``update_preds_file`` resolve to *its* globals at call
+# time -- exactly like the real runner -- which is what makes monkeypatching the
+# module attributes take effect.
+_FAKE_RUNNER_SRC = '''
+def get_sb_environment(config, instance):
+    return config["_env"]
+
+
+def update_preds_file(output_path, instance_id, model_name, result):
+    _preds[instance_id] = {
+        "model_name_or_path": model_name,
+        "instance_id": instance_id,
+        "model_patch": result,
+    }
+
+
+def process_instance(instance, config):
+    """Mirror the upstream crash path: edit happened in the container, then an
+    exception fires before submit, and the handler discards the result."""
+    instance_id = instance["instance_id"]
+    result = None
+    try:
+        env = get_sb_environment(config, instance)
+        raise RuntimeError(config.get("_crash", "InputTokenBudgetExceeded"))
+    except Exception as e:  # noqa: BLE001 -- reproduces upstream behaviour
+        exit_status, result = type(e).__name__, ""
+    finally:
+        update_preds_file("preds.json", instance_id, "model", result)
+'''
+
+
+def _install_fake_runner(monkeypatch):
+    pkg_names = [
+        "minisweagent",
+        "minisweagent.run",
+        "minisweagent.run.benchmarks",
+    ]
+    for name in pkg_names:
+        module = types.ModuleType(name)
+        module.__path__ = []  # mark as package
+        monkeypatch.setitem(sys.modules, name, module)
+    runner = types.ModuleType("minisweagent.run.benchmarks.swebench")
+    runner._preds = {}
+    exec(compile(_FAKE_RUNNER_SRC, "<fake_runner>", "exec"), runner.__dict__)
+    monkeypatch.setitem(sys.modules, "minisweagent.run.benchmarks.swebench", runner)
+    sys.modules["minisweagent.run.benchmarks"].swebench = runner
+    return runner
+
+
+def test_install_recovers_patch_on_crash(monkeypatch):
+    runner = _install_fake_runner(monkeypatch)
+    assert cap.install() is True
+
+    env = _FakeEnv(diff="diff --git a/app.py b/app.py\n+real edit\n")
+    runner.process_instance({"instance_id": "django__django-11299"}, {"_env": env})
+
+    record = runner._preds["django__django-11299"]
+    # The bug would leave this "" (discarded). The shim backfills the live diff.
+    assert record["model_patch"] == "diff --git a/app.py b/app.py\n+real edit\n"
+    assert record["model_patch"].strip()  # non-empty -> ttis _valid_prediction passes
+    # Environment registry is drained so containers are not held alive.
+    assert cap._ENV_BY_INSTANCE == {}
+
+
+def test_install_leaves_genuine_empty_diff_empty(monkeypatch):
+    runner = _install_fake_runner(monkeypatch)
+    assert cap.install() is True
+
+    env = _FakeEnv(diff="")  # crashed with no edits made
+    runner.process_instance({"instance_id": "no__edits-1"}, {"_env": env})
+
+    assert runner._preds["no__edits-1"]["model_patch"] == ""
+
+
+def test_install_does_not_touch_successful_submission(monkeypatch):
+    runner = _install_fake_runner(monkeypatch)
+    assert cap.install() is True
+
+    # A run that submits normally calls update_preds_file with a real patch and
+    # never enters the crash handler; the shim must pass it through untouched even
+    # though it also pops the env registry.
+    env = _FakeEnv(diff="should NOT be used")
+    cap.register_environment("ok-1", env)
+    runner.update_preds_file("preds.json", "ok-1", "model", "submitted-patch")
+
+    assert runner._preds["ok-1"]["model_patch"] == "submitted-patch"
+    assert env.calls == []  # recovery not attempted on a non-empty result
+    assert cap._ENV_BY_INSTANCE == {}
+
+
+def test_install_is_idempotent(monkeypatch):
+    runner = _install_fake_runner(monkeypatch)
+    assert cap.install() is True
+    first_get, first_update = runner.get_sb_environment, runner.update_preds_file
+    assert cap.install() is True
+    # No double-wrapping on a second install.
+    assert runner.get_sb_environment is first_get
+    assert runner.update_preds_file is first_update
+
+
+def test_install_returns_false_without_runner(monkeypatch):
+    for name in [
+        "minisweagent",
+        "minisweagent.run",
+        "minisweagent.run.benchmarks",
+        "minisweagent.run.benchmarks.swebench",
+    ]:
+        monkeypatch.setitem(sys.modules, name, None)  # force ImportError
+    assert cap.install() is False

--- a/tests/llm_module/test_mini_swe_capture.py
+++ b/tests/llm_module/test_mini_swe_capture.py
@@ -15,12 +15,20 @@ end. No container, no model, no device; runs in milliseconds.
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
 import sys
+import textwrap
 import types
+from pathlib import Path
 
 import pytest
 
 from llm_module.agentic import mini_swe_capture as cap
+from llm_module.agentic import swebench as ttis_swebench
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class _FakeEnv:
@@ -190,3 +198,90 @@ def test_install_returns_false_without_runner(monkeypatch):
     ]:
         monkeypatch.setitem(sys.modules, name, None)  # force ImportError
     assert cap.install() is False
+
+
+# --- injection wiring: the generated sitecustomize actually auto-installs -------
+
+# The unit/integration tests above prove install() + the wrappers in-process. This
+# proves the *wiring*: that ttis's committed generator lands a sitecustomize on the
+# agent subprocess's PYTHONPATH and that a fresh interpreter auto-imports it and
+# runs install(). Without this, a broken injection would be indistinguishable from
+# success (both yield an empty patch), because the generated sitecustomize and
+# recover_patch_from_env both swallow exceptions.
+
+_FAKE_MINISWEAGENT_RUNNER = """
+def get_sb_environment(config, instance):
+    return None
+
+
+def update_preds_file(output_path, instance_id, model_name, result):
+    return None
+"""
+
+# Runs in the spawned interpreter *after* startup (so sitecustomize has already
+# run). Reports whether the real capture module was imported and whether the fake
+# runner's seams were actually wrapped by install().
+_SUBPROCESS_PROBE = textwrap.dedent(
+    """
+    import json, sys
+    import minisweagent.run.benchmarks.swebench as r
+
+    print(json.dumps({
+        "capture_imported": "llm_module.agentic.mini_swe_capture" in sys.modules,
+        "get_wrapped": getattr(r.get_sb_environment, "_ttis_capture_wrapped", False),
+        "update_wrapped": getattr(r.update_preds_file, "_ttis_capture_wrapped", False),
+    }))
+    """
+)
+
+
+def _write_fake_minisweagent(root: Path) -> Path:
+    """Create an importable stub ``minisweagent.run.benchmarks.swebench`` on disk
+    so the spawned interpreter's ``install()`` has a runner to wrap."""
+    pkg = root / "fake_minisweagent"
+    swebench_dir = pkg / "minisweagent" / "run" / "benchmarks"
+    swebench_dir.mkdir(parents=True)
+    (pkg / "minisweagent" / "__init__.py").write_text("")
+    (pkg / "minisweagent" / "run" / "__init__.py").write_text("")
+    (swebench_dir / "__init__.py").write_text("")
+    (swebench_dir / "swebench.py").write_text(_FAKE_MINISWEAGENT_RUNNER)
+    return pkg
+
+
+def test_generated_sitecustomize_auto_installs_in_subprocess(tmp_path):
+    # 1) Generate the real sitecustomize and put its dir on PYTHONPATH via the
+    #    real ttis helpers -- exactly what run() does for the agent subprocess.
+    base_env = os.environ.copy()
+    base_env["PYTHONPATH"] = os.pathsep.join(
+        [str(_REPO_ROOT), str(_write_fake_minisweagent(tmp_path))]
+    )
+    env = ttis_swebench._add_mini_swe_capture_patch_to_env(tmp_path, base_env)
+
+    # The generator must have written a sitecustomize that imports+installs.
+    sitecustomize = tmp_path / "mini_swe_capture_patch" / "sitecustomize.py"
+    assert sitecustomize.exists()
+    assert "from llm_module.agentic.mini_swe_capture import install" in (
+        sitecustomize.read_text()
+    )
+    # And its dir must be first on the subprocess PYTHONPATH.
+    assert env["PYTHONPATH"].split(os.pathsep)[0] == str(
+        tmp_path / "mini_swe_capture_patch"
+    )
+
+    # 2) Spawn a fresh interpreter with that env and confirm the shim auto-installed.
+    result = subprocess.run(
+        [sys.executable, "-c", _SUBPROCESS_PROBE],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"probe failed: rc={result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    report = json.loads(result.stdout.strip().splitlines()[-1])
+    assert report["capture_imported"] is True, result.stderr
+    assert report["get_wrapped"] is True, result.stderr
+    assert report["update_wrapped"] is True, result.stderr

--- a/tests/llm_module/test_mini_swe_capture.py
+++ b/tests/llm_module/test_mini_swe_capture.py
@@ -27,7 +27,9 @@ class _FakeEnv:
     """Stands in for a live DockerEnvironment. ``execute`` returns the same dict
     shape the real environment does (``output`` / ``returncode``)."""
 
-    def __init__(self, diff: str, returncode: int = 0, raise_exc: Exception | None = None):
+    def __init__(
+        self, diff: str, returncode: int = 0, raise_exc: Exception | None = None
+    ):
         self._diff = diff
         self._rc = returncode
         self._raise = raise_exc
@@ -70,7 +72,10 @@ def test_recover_patch_nonzero_returncode_is_empty():
 
 
 def test_recover_patch_swallows_execute_exception():
-    assert cap.recover_patch_from_env(_FakeEnv(diff="", raise_exc=RuntimeError("boom"))) == ""
+    assert (
+        cap.recover_patch_from_env(_FakeEnv(diff="", raise_exc=RuntimeError("boom")))
+        == ""
+    )
 
 
 # --- integration level: full crash path through a faithful fake runner ---------


### PR DESCRIPTION
## Problem

The pinned mini-swe-agent benchmark runner (`mini-swe-agent==2.2.8`, `minisweagent/run/benchmarks/swebench.py` `process_instance`) discards a real container `git diff` on **any** exception:

```python
except Exception as e:
    ...
    exit_status, result = type(e).__name__, ""   # <- forces empty patch
```

`get_sb_environment` builds `--rm` containers, so the still-live container holding the agent's already-applied edit is torn down right after, and completed work is scored as an empty patch. This threw away **Qwen3.6-27B's correct edit at turn 71** (`django__django-11299`, `InputTokenBudgetExceeded` before submit) and **GPT-OSS-120B's at turn 4**. See receipt `qwen36_swe_32k_20260903.json` line 78.

A ttis-side `preds.json` post-processor is **impossible**: the container is `--rm`'d before `preds.json` is readable by the parent. The diff can only be snapshotted while the container is alive, inside `process_instance`.

## Fix

The fix belongs in the shared runner — below every model and both ttis model classes (litellm + token-budget), so it benefits all equally. The runner is a pinned third-party dependency, so instead of forking it or editing site-packages on a node (an uncommitted, unbankable change), this wraps two stable runner seams from committed ttis code (`llm_module/agentic/mini_swe_capture.py`) and injects them into the agent subprocess via a generated `sitecustomize` on `PYTHONPATH` — the same committed mechanism already used for the SWE-bench harness patch:

- `get_sb_environment` → remember the created environment by `instance_id`
- `update_preds_file` → runs in `process_instance`'s `finally` while the container is still alive (the runner never calls `env.cleanup`; teardown is deferred to `__del__`); when `result` is empty, backfill it with `git add -A && git diff --cached` from the remembered container.

Recovery never raises and never masks the original crash. A genuine no-edit crash still records an empty patch; a successful submission is untouched; the env registry is drained so containers are not held alive.

## Test

Ships a deterministic, **silicon-free** test suite (`tests/llm_module/test_mini_swe_capture.py`), in two layers:

- **Recovery logic** — reproduces the exact upstream crash shape through a faithful in-memory fake runner (bare-name global lookups, like the real module) and asserts the discarded patch is recovered (non-empty `model_patch`); also that a genuine no-edit crash stays empty, a successful submission is untouched, the env registry is drained, and `install()` is idempotent / non-fatal when the runner is absent.
- **Injection wiring** — `test_generated_sitecustomize_auto_installs_in_subprocess` uses the real `_write_mini_swe_capture_patch` + `_add_mini_swe_capture_patch_to_env`, spawns a fresh interpreter with that `PYTHONPATH`, and asserts the capture module was imported and the runner seams were actually wrapped. This closes the gap where a broken injection would look identical to success (both yield an empty patch).

Scope note: this proves the recovery logic **and** that the generated sitecustomize auto-installs — it does not run the real end-to-end SWE-bench container path (that stays a silicon/integration concern). To keep a silently-broken injection observable rather than degrading invisibly to an empty patch, the shim logs on activation (wrappers installed) and warns when a prediction is empty but no live environment was registered.

## Upstream

The canonical long-term home is a PR to `SWE-agent/mini-swe-agent`; the ready-to-apply upstream diff is recorded in `tt-quetzalcoatlus/productization/minisweagent_swe_patch_discard_on_crash_20260904.patch` (bug id `TTQ-SWE-PATCHDISCARD-20260904`). This committed ttis shim lands the fix on our review cycle now, and can be retired once an upstream release ships and the pin is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
