### PR TITLE
[EXPERIMENTAL] Llama-3.2-1B-Instruct QUETZAL impl for QB2 Model CI

### DIFF
--- a/.github/workflows/models-ci-config.json
+++ b/.github/workflows/models-ci-config.json
@@ -83,16 +83,37 @@
       }
     },
     "Llama-3.2-1B-Instruct": {
-      "inference_engine": "vLLM",
-      "ci": {
-        "weekly": {
-          "devices": [
-            "N150",
-            "N300",
-            "T3K"
-          ]
+      "implementations": [
+        {
+          "inference_engine": "vLLM",
+          "impl": "tt-transformers",
+          "ci": {
+            "weekly": {
+              "devices": [
+                "N150",
+                "N300",
+                "T3K"
+              ]
+            }
+          }
+        },
+        {
+          "inference_engine": "vLLM",
+          "impl": "quetzal",
+          "ci": {
+            "nightly": {
+              "devices": [
+                "P300X2"
+              ],
+              "device-args": {
+                "P300X2": {
+                  "additional-args": "--quetzal-models-root /mnt/models/huggingface/quetzal/nkapre/packages/sha256-39b457511b7f55b51b9eed44dae0013d21a085e63b0a28ce8324dc25e1949e4a-1f7aaded6376be65d2f1f280547dd2160b334165792a87bab1ba14ecd8a3a032"
+                }
+              }
+            }
+          }
         }
-      }
+      ]
     },
     "Llama-3.2-3B-Instruct": {
       "implementations": [

--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -3805,6 +3805,75 @@ _eval_config_list = [
                     },
                 ),
             ),
+            # Agentic coding eval. Evals are keyed by model NAME with no impl
+            # or min_context dimension, so this task dispatches on EVERY 1B
+            # lane: the impl: quetzal lane (P300X2 / QB2) AND the native
+            # tt_transformers lanes (N150 / N300 / T3K). That cross-lane
+            # dispatch is intentional and accepted -- it establishes the
+            # SWE-bench eval pattern in the quetzal Model-CI flow so future,
+            # larger quetzal models inherit it. A 1B model is too weak for SWE
+            # at any context (~0 valid tool calls on silicon), so both the
+            # quetzal and native 1B lanes are expected to score ~0; this task
+            # exists to DEFINE a dispatchable agentic eval for the pattern, NOT
+            # because 1B is expected to pass. meta_gpqa (present above, fits
+            # 8192) remains the meaningful 1B eval; intake is serve-ability +
+            # a dispatchable eval, not a passing score.
+            # The running 1B quetzal serve (job 76426, qb2-120-p04t04) has a
+            # VERIFIED max_model_len=8192 (four sources: live /v1/models,
+            # runtime_model_spec, compiled decode metadata, and the package
+            # qualification_manifest context_length). The budget below fits
+            # 8192 with ~1K headroom so requests never exceed the serve. A real
+            # SWE-bench trajectory (~13K-30K input tokens) cannot fit at 8192
+            # and is not expected to pass; likewise the longbench_* tasks above
+            # (min_context_required=16384) will not run on this serve. Both are
+            # deliberately left defined-but-not-passing for the EXPERIMENTAL
+            # intake. mini_model_class="litellm" is set explicitly for
+            # comparability with the native lanes and so this 1B gate exercises
+            # the same client path as the larger quetzal lanes (per PR #27 the
+            # vLLM boundary rejects over-length requests before silicon, so the
+            # class choice is client-side accounting, not device safety).
+            EvalTask(
+                task_name="swe_bench_verified",
+                workflow_venv_type=WorkflowVenvType.EVALS_AGENTIC,
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref=None,
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["accuracy"],
+                        "unit": "percent",
+                    },
+                ),
+                swebench_eval_config=SWEbenchEvalConfig(
+                    dataset_name="SWE-bench/SWE-bench_Verified",
+                    sweagent_subset="verified",
+                    dataset_split="test",
+                    agent_backend="mini-swe-agent",
+                    n_concurrent_trials=64,
+                    max_workers=24,
+                    n_tasks=None,
+                    temperature=1.0,
+                    top_p=0.95,
+                    mini_model_class="litellm",
+                    # Fits the verified 8192 serve context with ~1K headroom.
+                    max_input_tokens=6144,
+                    max_output_tokens=1024,
+                    instance_ids_map={
+                        EvalLimitMode.CI_NIGHTLY: [
+                            "django__django-12143",
+                            "pytest-dev__pytest-5262",
+                            "django__django-14672",
+                            "sympy__sympy-13551",
+                            "sphinx-doc__sphinx-9281",
+                        ],
+                    },
+                ),
+                limit_samples_map={
+                    EvalLimitMode.SMOKE_TEST: 5,
+                },
+            ),
         ],
     ),
     EvalConfig(

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -154,6 +154,70 @@ templates:
       reasoning_parser_name: gemma4
       tool_call_parser_name: gemma4
 
+# Generated-Quetzal Llama-3.2-1B development lane. Behavioral serve/SWE
+# admission only (package qualification_state: investigating); native PCC is
+# not yet measured, so this stays EXPERIMENTAL and non-default. Unlike the
+# GPT-OSS lane this package is a plain, unpatched tt-metal build, so there is
+# no runtime patchset. Values below are the verified contract of the live 1B
+# serve (job 76426, node qb2-120-p04t04). The native tt_transformers
+# Llama-3.2-1B / Llama-3.2-1B-Instruct rows below are left unchanged.
+- weights:
+    - meta-llama/Llama-3.2-1B-Instruct
+  impl: quetzal
+  inference_engine: VLLM
+  model_type: LLM
+  supported_modalities: [text]
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 1
+      max_context: 8192
+      default_impl: false
+      env_vars:
+        ARCH_NAME: blackhole
+        MESH_DEVICE: P150x4
+        QUETZAL_VLLM: "1"
+        QUETZAL_MODEL: meta-llama/Llama-3.2-1B-Instruct
+        QUETZAL_HF_REVISION: 9213176726f574b556790deb65791e0c5aa438b6
+        QUETZAL_REQUIRED_SOURCE_REVISION: 4901ec4116b5ba5e69da9d02593f8ad75ff3abea
+        QUETZAL_REQUIRED_TT_METAL_COMMIT: f9377427c7f8ddbd3f4df1b2e47279a8b7626b46
+        # 1B is a plain unpatched tt-metal build: no runtime patchset (unlike
+        # the GPT-OSS lane). Keep status explicit so a future patched-runtime
+        # requirement fails closed rather than silently running unpatched.
+        QUETZAL_TT_METAL_PATCHSET_STATUS: none
+        QUETZAL_PACKAGE_ID: sha256-39b457511b7f55b51b9eed44dae0013d21a085e63b0a28ce8324dc25e1949e4a-1f7aaded6376be65d2f1f280547dd2160b334165792a87bab1ba14ecd8a3a032
+        QUETZAL_BUNDLE_MANIFEST_SHA256: 5e7c882ddd59777a4623689207b0ec9593a0550027ef123349fb188301eea63d
+        QUETZAL_PACKAGE_ROOT: /home/container_app_user/quetzal/packages/sha256-39b457511b7f55b51b9eed44dae0013d21a085e63b0a28ce8324dc25e1949e4a-1f7aaded6376be65d2f1f280547dd2160b334165792a87bab1ba14ecd8a3a032
+        QZ_MODELS_ROOT: /home/container_app_user/quetzal/packages/sha256-39b457511b7f55b51b9eed44dae0013d21a085e63b0a28ce8324dc25e1949e4a-1f7aaded6376be65d2f1f280547dd2160b334165792a87bab1ba14ecd8a3a032
+        QZ_QUALIFICATION_MANIFEST: /home/container_app_user/quetzal/packages/sha256-39b457511b7f55b51b9eed44dae0013d21a085e63b0a28ce8324dc25e1949e4a-1f7aaded6376be65d2f1f280547dd2160b334165792a87bab1ba14ecd8a3a032/qualification_manifest.yaml
+        # The compiled prefill/decode generated.py, metadata.json and weights
+        # are derived by the quetzal plugin from QZ_MODELS_ROOT -- this is
+        # exactly how the live 1B serve launched (--quetzal-models-root only,
+        # no per-artifact env). They are intentionally not hardcoded here to
+        # avoid asserting an unverified compiled-subdir model slug.
+        QZ_MMAP_WEIGHTS: "1"
+        TTQ_STREAM_WEIGHTS: "1"
+        HF_HUB_OFFLINE: "1"
+        TRANSFORMERS_OFFLINE: "1"
+        VLLM_PLUGINS: quetzal_model_registry,tt
+        TT_VLLM_BUILTIN_MODELS: "0"
+      vllm_args:
+        block_size: 64
+        max_model_len: 8192
+        max_num_seqs: 1
+        revision: 9213176726f574b556790deb65791e0c5aa438b6
+        tokenizer_revision: 9213176726f574b556790deb65791e0c5aa438b6
+        enable-auto-tool-choice: true
+        tool-call-parser: llama3_json
+      override_tt_config:
+        fabric_config: FABRIC_1D
+        l1_small_size: 16384
+        trace_region_size: 90000000
+  status: EXPERIMENTAL
+  has_builtin_warmup: false
+  metadata:
+    meta-llama/Llama-3.2-1B-Instruct:
+      tool_call_parser_name: llama3_json
+
 - weights:
     - openai/gpt-oss-20b
   impl: gpt_oss


### PR DESCRIPTION
## What

Makes `meta-llama/Llama-3.2-1B-Instruct` submittable to QB2 Model CI as a distinct `impl: quetzal` lane (vLLM, **P300X2 == QB2**), alongside the **unchanged** native `tt_transformers` row. Config only. **status EXPERIMENTAL** — not a promotion.

**DRAFT — do not merge / codeowner-gated. Do not self-approve.**

## The three edits

### 1. `workflows/model_specs/dev/llm.yaml`
New `impl: quetzal` row for `meta-llama/Llama-3.2-1B-Instruct` mirroring the Qwen/gemma/gpt quetzal war-room rows' schema:
- device **P300X2**, `max_context: 8192`, `max_concurrency: 1`, `status: EXPERIMENTAL`, `tool-call-parser: llama3_json`
- **No P150X4 device spec** — the sibling quetzal rows carry P150x4 only as the `MESH_DEVICE` env var, not a separate `device_model_spec`; this row matches (MESH_DEVICE: P150x4, device: P300X2).
- Env/contract values are the **verified** contract of the live 1B serve (job 76426, qb2-120-p04t04): `QUETZAL_HF_REVISION 9213176726f574b556790deb65791e0c5aa438b6`, `QUETZAL_REQUIRED_SOURCE_REVISION 4901ec4116b5ba5e69da9d02593f8ad75ff3abea`, `QUETZAL_REQUIRED_TT_METAL_COMMIT f9377427c7f8ddbd3f4df1b2e47279a8b7626b46`, `QUETZAL_PACKAGE_ID sha256-39b45751…49e4a-1f7aaded…a3a032`, `QUETZAL_BUNDLE_MANIFEST_SHA256 5e7c882d…ea63d`.
- **Unpatched build**: `QUETZAL_TT_METAL_PATCHSET_STATUS: none` (unlike the GPT-OSS lane, 1B needs no runtime patchset).
- Per-artifact compiled paths are intentionally **not** hardcoded — the quetzal plugin derives them from `QZ_MODELS_ROOT`, exactly how the live serve launched (`--quetzal-models-root` only), avoiding an unverified compiled-subdir model slug.
- **Native `Llama-3.2-1B` / `-1B-Instruct` `tt_transformers` row is untouched** (still FUNCTIONAL, N150/N300/T3K).

### 2. `reference_config/evals/eval_config.py`
Adds a `swe_bench_verified` `EvalTask` to the `Llama-3.2-1B-Instruct` `EvalConfig`, with `mini_model_class="litellm"` and budget `max_input_tokens=6144` / `max_output_tokens=1024` (fits the verified 8192 serve context with ~1K headroom).

**Cross-lane dispatch — stated plainly, not hidden:** this eval is keyed by model **name** with no impl dimension and no `min_context_required` guard, so it dispatches on **every** 1B lane — the `impl: quetzal` lane (P300X2) **and** the native `tt_transformers` lanes (**N150 / N300 / T3K**). That is **intentional and accepted**: it establishes the SWE-bench eval pattern inside the quetzal Model-CI flow so future, larger quetzal models inherit it. A 1B model is too weak for SWE at any context (~0 valid tool calls on silicon), so **both the quetzal and the native 1B lanes are expected to score ~0** — this task DEFINES a dispatchable agentic eval for the pattern; it is not expected to pass on 1B. `meta_gpqa` (already present, fits 8192) remains the meaningful 1B eval.

### 3. `.github/workflows/models-ci-config.json`
Converts `Llama-3.2-1B-Instruct` to an `implementations` list:
- native `tt-transformers` (vLLM, weekly N150/N300/T3K — **unchanged**)
- `quetzal` (vLLM, `ci.nightly.devices: ["P300X2"]`) with `device-args.P300X2.additional-args: "--quetzal-models-root /mnt/models/huggingface/quetzal/nkapre/packages/sha256-39b45751…49e4a-1f7aaded…a3a032"`
- The `/mnt/models` package root is **integrity-verified and staged** (basename byte-identical to what the live serve mounts). Nightly-only, no release lane — consistent with EXPERIMENTAL / not-a-promotion.

## Verified facts (from the live 1B quetzal serve, job 76426 on qb2-120-p04t04, read-only probe)
- `max_model_len` / qualified `context_length` = **8192**, multiply-confirmed (live `/v1/models`, runtime_model_spec, compiled decode metadata, package qualification_manifest; package-agent `artifact_equivalence:exact`).
- tool-call-parser = **llama3_json**; MESH_DEVICE P150x4; ARCH_NAME blackhole; fabric FABRIC_1D; l1_small_size 16384; trace_region_size 90000000; block_size 64; max_num_seqs 1.
- Package sha256 root: `sha256-39b457511b7f55b51b9eed44dae0013d21a085e63b0a28ce8324dc25e1949e4a-1f7aaded6376be65d2f1f280547dd2160b334165792a87bab1ba14ecd8a3a032`.

## Longbench reachability
The serve's 8192 ceiling is **below 16384**, so the pre-existing `longbench_*_e` tasks (which require 16384) will not run on the quetzal 1B serve. Left in place unchanged; noted as defined-but-not-passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)