### PR TITLE
[RUNNABLE-GATE] P300X2 benchmark target for Llama-3.2-1B-Instruct QUETZAL (PROVISIONAL)

### DIFF
--- a/reference_config/benchmarking/benchmark_targets/model_performance_reference.json
+++ b/reference_config/benchmarking/benchmark_targets/model_performance_reference.json
@@ -2915,6 +2915,25 @@
                     }
                 }
             }
+        ],
+        "p300x2": [
+            {
+                "isl": 128,
+                "osl": 128,
+                "max_concurrency": 1,
+                "num_prompts": 8,
+                "task_type": "text",
+                "image_height": null,
+                "image_width": null,
+                "images_per_prompt": null,
+                "targets": {
+                    "theoretical": {
+                        "ttft_ms": 5.0,
+                        "tput_user": 300.0,
+                        "tput": 9100.0
+                    }
+                }
+            }
         ]
     },
     "gemma-1.1-2b-it": {


### PR DESCRIPTION
## What this does

Adds a **P300X2** (`p300x2`) device target block to `Llama-3.2-1B-Instruct` in `reference_config/benchmarking/benchmark_targets/model_performance_reference.json`, so the **Benchmarks** acceptance category becomes **runnable/scored** for the Llama-3.2-1B-Instruct QUETZAL lane on P300X2 (QB2, MESH_DEVICE=P150x4 / device P300X2, context 8192, batch 1, max_concurrency 1).

Config-only, single file, `+19` lines.

## Verified gap (was actually missing)

- The model currently has target rows for `n300`, `p150`, `p100`, `t3k`, `galaxy`, `n150` — but **no `p300x2` row** (the device key is lowercase `p300x2`; the file has ~24 `p300x2` rows for other models).
- Per `workflows/model_spec.py` (`get_perf_reference`) + `llm_module/target_checks.py`: a device with no target row → `targets={}` → every benchmark sweep point is marked `status="na"` / `target_check=NA`. The whole Benchmarks category is then **ungraded (informational only)**; the `functional` tier can neither pass nor fail on P300X2.
- **Adding this row is what makes the functional tier scorable.** This was a real gap, not already covered.

## Schema fidelity

The `p300x2` entry mirrors the exact schema of the other device rows for this model: `isl=128 / osl=128`, `max_concurrency=1`, single `targets.theoretical` block. The `functional`/`complete` tiers are derived loosenings of the single `theoretical` block (`TIER_MULTIPLIERS`), so only `theoretical` is supplied. JSON validated (`json.load` OK, 92 models).

## Honesty about the numbers

The `ttft_ms=5.0 / tput_user=300.0 / tput=9100.0` values are **PROVISIONAL / needs-measurement** placeholders, bracketed by this model's existing Blackhole single-card `p150` (ttft 5.0 / tput_user 298) and `p100` (ttft 6.0 / tput_user 261) numbers. They are **provisional targets, not measured results**, and must be replaced with a hardware-measured target before the grade is relied upon. No measured number is presented as measured.

## This PR makes the gate RUNNABLE; it does NOT certify

- **Does NOT bump status to FUNCTIONAL.** The lane stays EXPERIMENTAL. Actual FUNCTIONAL status requires the nightly P300X2 benchmark to **PASS the functional tier on hardware**, followed by a separate status bump (not in this PR).
- **Known ceiling (not fixed here):** at 8192 serve context the longbench evals (`min_context 16384`) cannot run, so full-eval-suite COMPLETE certification will additionally need a >=16384 context re-emit of the serve. Flagged as a known ceiling; out of scope for this PR.

## Review

Codeowner-gated (default `*` owner). Draft, not for merge/self-approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)