### PR TITLE
[RUNNABLE-GATE] P300X2 spec-test coverage for Llama-3.2-1B-Instruct QUETZAL

### DIFF
--- a/test_module/server_tests_config.json
+++ b/test_module/server_tests_config.json
@@ -43,6 +43,7 @@
         "LLM": [
             "Qwen/Qwen3-32B",
             "meta-llama/Llama-3.1-8B-Instruct",
+            "meta-llama/Llama-3.2-1B-Instruct",
             "meta-llama/Llama-3.3-70B-Instruct",
             "openai/gpt-oss-20b",
             "google/diffusiongemma-26B-A4B-it",
@@ -450,6 +451,16 @@
                 "p300x2",
                 "galaxy",
                 "galaxy_t3k"
+            ]
+        },
+        "llama_3_2_1b": {
+            "id_name": "llama-3.2-1b",
+            "weights": [
+                "meta-llama/Llama-3.2-1B-Instruct"
+            ],
+            "category": "LLM",
+            "compatible_devices": [
+                "p300x2"
             ]
         },
         "mistral_small_24b": {

--- a/test_module/test_suites/llm.json
+++ b/test_module/test_suites/llm.json
@@ -6,6 +6,7 @@
             "models": [
                 "qwen3_32b",
                 "llama_3_1_8b",
+                "llama_3_2_1b",
                 "llama_70b_family",
                 "gpt_oss_20b"
             ],

--- a/tests/test_module/test_matrix_expansion.py
+++ b/tests/test_module/test_matrix_expansion.py
@@ -30,6 +30,22 @@ def test_diffusiongemma_llm_suite_uses_model_specific_conformance_test():
     assert {"param", "e2e", "slow", "heavy"} <= set(template["markers"])
 
 
+def test_llama_3_2_1b_p300x2_uses_vllm_param_conformance_suite():
+    suites = load_suite_files_by_category("llm")
+    matching = [
+        suite
+        for suite in suites
+        if suite["weights"] == ["meta-llama/Llama-3.2-1B-Instruct"]
+    ]
+
+    assert [(suite["id"], suite["device"]) for suite in matching] == [
+        ("llama-3.2-1b-p300x2", "p300x2")
+    ]
+    assert [case["template"] for case in matching[0]["test_cases"]] == [
+        "VLLMParamConformanceTest"
+    ]
+
+
 class TestImageMatrixExpansionSDXL:
     SDXL_SUITE_IDS = {
         "sdxl-n150",


### PR DESCRIPTION
## Summary

- enroll `Llama-3.2-1B-Instruct` in the shared LLM spec-test category
- add P300X2 to the compatible device set
- add the model to the existing vLLM parameter-conformance suite
- assert that the suite actually expands for the model and device, preventing a silent zero-test pass

This PR is spec-test wiring only. It does not add a catalog row, runtime integration, image build, eval configuration, or Models CI enrollment.

## Validation

- 16 matrix-expansion tests pass on current TTIS `main`
- full-repository Ruff 0.15 lint and format checks pass
- `git diff --check origin/main...HEAD` passes
- the cleaned diff is three files and 26 added lines

The target Quetzal catalog row is C32768 on P300X2 and remains `EXPERIMENTAL`. This wiring closes a fail-open test-discovery gap; it is not by itself a certification claim.

The useful matrix assertion from #5104 is folded here so the duplicate stacked PR can remain closed.
