### PR TITLE
feat(quetzal): minimal run.py --impl quetzal serve path for bare QB2

### DIFF
--- a/docs/quetzal_bare_node_serve.md
+++ b/docs/quetzal_bare_node_serve.md
@@ -1,0 +1,88 @@
+# Serving a Quetzal-compiled model with `run.py --impl quetzal`
+
+This is the minimal serve path for a Quetzal-generated (compiled) model on a bare
+Exabox QB2 (`P300X2`, four Blackhole chips driven as a `P150x4` mesh). It is the
+carved-out serve subset of the larger `#5042` bundle; the release-image contract,
+Models CI enrollment, and release automation are deliberately **out of scope**
+here (see the PR description).
+
+## What must already exist
+
+1. **Quetzal wheel in the vLLM image.** The image must have the
+   `tt-quetzalcoatlus` wheel installed (it publishes the `quetzal_model_registry`
+   vLLM plugin entry point and the top-level `serving` package). The pinned
+   Quetzal commit must include the serve-required KV-cache-key patch —
+   `serving/e2e_pcc.py:discover_cache_keys` grouping `cache_layers_<N>_keys`
+   correctly (Quetzal commit `2f1490a4`, the source pin recorded in the row as
+   `QUETZAL_REQUIRED_SOURCE_REVISION` / `TT_QUETZAL_COMMIT_SHA`). This patch
+   **lives in the Quetzal package and is referenced, never vendored into ttis.**
+2. **A generated package.** A content-addressed Quetzal artifact bundle
+   (`sha256-<tree>-<manifest>`) with `compiled/…/{prefill,decode}/…`,
+   `compiled_weights/…/weights.pt`, and `qualification_manifest.yaml`.
+3. **The catalog row.** The `impl: quetzal` row for the model in
+   `workflows/model_specs/dev/llm.yaml`, generated from the Quetzal catalog
+   fragment — do not hand-edit the package paths:
+
+   ```bash
+   python3 scripts/generate_quetzal_model_row.py \
+       --catalog <tt-quetzalcoatlus>/serving/catalog/dev_llm_quetzal.yaml \
+       --model meta-llama/Llama-3.2-1B-Instruct \
+       --package-id sha256-<tree>-<manifest> \
+       --manifest-sha256 <hex> \
+       >> workflows/model_specs/dev/llm.yaml
+   ```
+
+## Package admission (the bare-node write-bit problem)
+
+The Quetzal plugin's default admission requires a **read-only mount point**
+(it rejects any directory with write bits set). That is satisfied in a container
+by a `:ro` bind mount, but a bundle staged by a bare `srun` sits on a **writable**
+filesystem and fails closed with *"mutable (write bits set)"*. Historically this
+was worked around ad-hoc with `fuse-overlayfs -o ro`.
+
+The serve path now admits the package **by content hash** instead: for
+`impl=quetzal`, `run_vllm_api_server.py` calls
+`serving.artifact_bundle.verify_bundle(QUETZAL_PACKAGE_ROOT,
+QUETZAL_BUNDLE_MANIFEST_SHA256)` before any device use. That reads and hashes
+every payload against the manifest, so it is **independent of file write bits**
+and works on a writable FS. It fails closed: a missing `QUETZAL_PACKAGE_ROOT`,
+a missing wheel, or a hash mismatch aborts before the device is opened. This is
+not an adapter around the plugin's gate — it selects the content-addressed
+admission path the Quetzal package already implements.
+
+### Fallback: read-only mount (if content-address admission is unavailable)
+
+If you must fall back to the mount-based gate, stage the bundle read-only with the
+supported helper (not an ad-hoc one-liner):
+
+```bash
+scripts/quetzal_stage_bundle.sh <src-package-dir> <ro-mount-target>
+```
+
+Point `QUETZAL_PACKAGE_ROOT` / `QZ_MODELS_ROOT` at `<ro-mount-target>`.
+
+## Offline weights / tokenizer
+
+The row sets `HF_HUB_OFFLINE=1` and `TRANSFORMERS_OFFLINE=1`; model weights come
+from the package (`QUETZAL_WEIGHTS`), and the tokenizer/config resolve from the
+HF cache (`HF_HOME`). `ensure_weights_available()` honors this: when offline it
+resolves the checkpoint from the populated HF cache
+(`snapshot_download(..., local_files_only=True)` with no `local_dir`) instead of
+re-planning a download into a fresh `local_dir`, which fails closed with no
+network even when every file is already cached.
+
+## Run
+
+```bash
+python run.py \
+    --model Llama-3.2-1B-Instruct \
+    --device P300X2 \
+    --impl quetzal \
+    --workflow serving \
+    --docker-server --dev-mode
+```
+
+`--impl quetzal` is mandatory: the row is `default_impl: false`, so omitting it
+keeps upstream's native tt-metal implementation. Tool calling
+(`--enable-auto-tool-choice --tool-call-parser llama3_json`) is wired from the
+row so SWE/agentic scores are not silently voided.

--- a/docs/quetzal_bare_node_serve.md
+++ b/docs/quetzal_bare_node_serve.md
@@ -41,14 +41,35 @@ filesystem and fails closed with *"mutable (write bits set)"*. Historically this
 was worked around ad-hoc with `fuse-overlayfs -o ro`.
 
 The serve path now admits the package **by content hash** instead: for
-`impl=quetzal`, `run_vllm_api_server.py` calls
-`serving.artifact_bundle.verify_bundle(QUETZAL_PACKAGE_ROOT,
-QUETZAL_BUNDLE_MANIFEST_SHA256)` before any device use. That reads and hashes
-every payload against the manifest, so it is **independent of file write bits**
-and works on a writable FS. It fails closed: a missing `QUETZAL_PACKAGE_ROOT`,
-a missing wheel, or a hash mismatch aborts before the device is opened. This is
-not an adapter around the plugin's gate — it selects the content-addressed
-admission path the Quetzal package already implements.
+`impl=quetzal`, `run_vllm_api_server.py::admit_quetzal_bundle` authenticates the
+package against its trusted-root manifest by SHA-256 (pinned to
+`QUETZAL_BUNDLE_MANIFEST_SHA256`) before any device use. It is **independent of
+file write bits** and works on a writable FS, and it fails closed: a missing
+`QUETZAL_PACKAGE_ROOT`, a missing wheel, a hash mismatch, or a v2 bundle whose
+`QUETZAL_AUXILIARY_ROOTS_JSON` is missing/mismatched aborts before the device is
+opened. This is not an adapter around the plugin's gate — it selects the
+content-addressed admission path the Quetzal package already implements.
+
+Two package layouts are admitted, both through `serving.artifact_bundle`:
+
+* **Portable object-store bundle** (`<root>/manifest.json` + `objects/`): handed
+  to `verify_bundle(root, expected_sha256=…, auxiliary_roots=…)`, which reads and
+  hashes every payload; `auxiliary_roots` authenticates any v2 externals. This is
+  the portable Llama-1B (v1) case.
+* **Installed / shared bundle** (the read-only shared layout used by gpt-oss and
+  the MoE models): there is no root `manifest.json` — the trusted-root proof is
+  `<root>/.quetzal-bundle-manifests/<QUETZAL_BUNDLE_MANIFEST_SHA256>.json` and the
+  payloads sit at their logical paths. `admit_quetzal_bundle` authenticates that
+  proof by its pinned SHA-256, then verifies every serve-loaded artifact (the
+  `QUETZAL_*`/`QZ_*` members) and any v2 `streamed_cache` auxiliary against the
+  trusted inventory, reusing `serving.artifact_bundle`'s own manifest validator
+  and hashing primitives.
+
+For a **v2** bundle (external MoE `streamed_cache`), the catalog row must set
+`QUETZAL_AUXILIARY_ROOTS_JSON` to the JSON map of auxiliary name → immutable,
+digest-addressed root (`{"…-streamed-cache": "…/sha256-<tree-digest>"}`); the
+admission hashes those external payloads too and fails closed if the digest,
+size, or content-addressed basename does not match the trusted proof.
 
 ### Fallback: read-only mount (if content-address admission is unavailable)
 

--- a/scripts/generate_quetzal_model_row.py
+++ b/scripts/generate_quetzal_model_row.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+"""Generate a Quetzal serve row for workflows/model_specs/<env>/llm.yaml.
+
+The single source of truth for a Quetzal serving profile is the catalog fragment
+shipped by the Quetzal package at ``serving/catalog/dev_llm_quetzal.yaml``. Every
+``QZ_*`` / ``QUETZAL_*`` path in a row is derived from one content-addressed
+package id, so the rows must never be edited by hand (a stale copy of the id in
+one path is the classic Quetzal mis-serve, documented in AUDIT.md).
+
+This tool loads a model's profile from the catalog fragment, re-points the
+content-addressed package paths at a given package id, and prints the resulting
+ttis ``llm.yaml`` row. It is deliberately mechanical: it does not invent env
+vars, only rewrites the ones the fragment already declares.
+
+Example
+-------
+  python3 scripts/generate_quetzal_model_row.py \
+      --catalog /path/to/tt-quetzalcoatlus/serving/catalog/dev_llm_quetzal.yaml \
+      --model meta-llama/Llama-3.2-1B-Instruct \
+      --package-id sha256-<tree>-<manifest> \
+      --manifest-sha256 <hex> \
+      >> workflows/model_specs/dev/llm.yaml
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+import yaml
+
+# Content prefix the catalog bakes into QUETZAL_PACKAGE_ROOT / QZ_* paths for a
+# container serve. Matches serving/serve_quetzal.py's CONTAINER_PKG_PREFIX.
+CONTAINER_PKG_PREFIX = "/home/container_app_user/cache_root/quetzal/packages"
+
+# A content-addressed Quetzal package id: sha256-<64hex>-<64hex> (v1) or the
+# v2 triple form. Used to swap one package id for another inside baked paths.
+_PACKAGE_ID_RE = re.compile(
+    r"sha256(?:-v2)?-[0-9a-f]{64}-[0-9a-f]{64}(?:-[0-9a-f]{64})?"
+)
+
+
+def _load_profiles(catalog_path: str) -> list[dict]:
+    with open(catalog_path) as stream:
+        doc = yaml.safe_load(stream)
+    # The fragment is a bare YAML list of profile dicts (each a `- weights:` row).
+    if isinstance(doc, dict) and "templates" in doc:
+        doc = doc["templates"]
+    if not isinstance(doc, list):
+        raise SystemExit(f"{catalog_path}: expected a list of profiles")
+    return [row for row in doc if isinstance(row, dict) and "weights" in row]
+
+
+def _select_profile(profiles: list[dict], model: str) -> dict:
+    """Match by full HF id or by basename (the ttis CLI resolves by basename)."""
+    base = model.rsplit("/", 1)[-1]
+    matches = [
+        row
+        for row in profiles
+        if any(
+            w == model or w.rsplit("/", 1)[-1] == base
+            for w in row.get("weights", [])
+        )
+    ]
+    if not matches:
+        available = sorted(
+            w for row in profiles for w in row.get("weights", [])
+        )
+        raise SystemExit(
+            f"no profile for {model!r} in catalog; available: {available}"
+        )
+    if len(matches) > 1:
+        raise SystemExit(f"ambiguous: {len(matches)} profiles match {model!r}")
+    return matches[0]
+
+
+def _repoint(value, package_id: str):
+    """Rewrite any baked package id inside a string to the target package id."""
+    if isinstance(value, str) and _PACKAGE_ID_RE.search(value):
+        return _PACKAGE_ID_RE.sub(package_id, value)
+    return value
+
+
+def retarget_profile(
+    profile: dict,
+    package_id: str,
+    manifest_sha256: str | None,
+    hf_revision: str | None,
+) -> dict:
+    row = yaml.safe_load(yaml.safe_dump(profile))  # deep copy via round-trip
+    for dms in row.get("device_model_specs", []):
+        env = dms.get("env_vars", {})
+        for key, val in list(env.items()):
+            env[key] = _repoint(val, package_id)
+        env["QUETZAL_PACKAGE_ID"] = package_id
+        env["QUETZAL_PACKAGE_ROOT"] = f"{CONTAINER_PKG_PREFIX}/{package_id}"
+        env["QZ_MODELS_ROOT"] = f"{CONTAINER_PKG_PREFIX}/{package_id}"
+        if manifest_sha256:
+            env["QUETZAL_BUNDLE_MANIFEST_SHA256"] = manifest_sha256
+        if hf_revision:
+            env["QUETZAL_HF_REVISION"] = hf_revision
+            vllm_args = dms.setdefault("vllm_args", {})
+            vllm_args["revision"] = hf_revision
+            vllm_args["tokenizer_revision"] = hf_revision
+    return row
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--catalog",
+        required=True,
+        help="Path to tt-quetzalcoatlus/serving/catalog/dev_llm_quetzal.yaml",
+    )
+    parser.add_argument("--model", required=True, help="HF model id or basename")
+    parser.add_argument(
+        "--package-id",
+        required=True,
+        help="Content-addressed package id (sha256-<tree>-<manifest>[-<aux>])",
+    )
+    parser.add_argument(
+        "--manifest-sha256",
+        default=None,
+        help="QUETZAL_BUNDLE_MANIFEST_SHA256 for this package (recommended)",
+    )
+    parser.add_argument(
+        "--hf-revision",
+        default=None,
+        help="Override the checkpoint revision baked in the profile",
+    )
+    args = parser.parse_args(argv)
+
+    if not _PACKAGE_ID_RE.fullmatch(args.package_id):
+        raise SystemExit(f"--package-id is not a content-addressed id: {args.package_id}")
+
+    profiles = _load_profiles(args.catalog)
+    profile = _select_profile(profiles, args.model)
+    row = retarget_profile(
+        profile, args.package_id, args.manifest_sha256, args.hf_revision
+    )
+
+    sys.stdout.write(
+        "# Generated by scripts/generate_quetzal_model_row.py from the Quetzal "
+        "catalog fragment.\n"
+        "# Do not edit the package paths by hand; regenerate with a new "
+        "--package-id.\n"
+    )
+    yaml.safe_dump([row], sys.stdout, sort_keys=False, default_flow_style=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_quetzal_model_row.py
+++ b/scripts/generate_quetzal_model_row.py
@@ -24,6 +24,7 @@ Example
       --manifest-sha256 <hex> \
       >> workflows/model_specs/dev/llm.yaml
 """
+
 from __future__ import annotations
 
 import argparse
@@ -61,17 +62,12 @@ def _select_profile(profiles: list[dict], model: str) -> dict:
         row
         for row in profiles
         if any(
-            w == model or w.rsplit("/", 1)[-1] == base
-            for w in row.get("weights", [])
+            w == model or w.rsplit("/", 1)[-1] == base for w in row.get("weights", [])
         )
     ]
     if not matches:
-        available = sorted(
-            w for row in profiles for w in row.get("weights", [])
-        )
-        raise SystemExit(
-            f"no profile for {model!r} in catalog; available: {available}"
-        )
+        available = sorted(w for row in profiles for w in row.get("weights", []))
+        raise SystemExit(f"no profile for {model!r} in catalog; available: {available}")
     if len(matches) > 1:
         raise SystemExit(f"ambiguous: {len(matches)} profiles match {model!r}")
     return matches[0]
@@ -134,7 +130,9 @@ def main(argv=None) -> int:
     args = parser.parse_args(argv)
 
     if not _PACKAGE_ID_RE.fullmatch(args.package_id):
-        raise SystemExit(f"--package-id is not a content-addressed id: {args.package_id}")
+        raise SystemExit(
+            f"--package-id is not a content-addressed id: {args.package_id}"
+        )
 
     profiles = _load_profiles(args.catalog)
     profile = _select_profile(profiles, args.model)

--- a/scripts/quetzal_stage_bundle.sh
+++ b/scripts/quetzal_stage_bundle.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# Stage a Quetzal artifact bundle read-only for the mount-based admission gate.
+#
+# This is the FALLBACK for hosts where content-address admission
+# (verify_bundle, the default in run_vllm_api_server.py) is unavailable. It
+# replaces the ad-hoc `fuse-overlayfs -o ro` one-liner with a supported,
+# reviewable step. Prefer content-address admission on a writable FS
+# (see docs/quetzal_bare_node_serve.md); use this only if you must.
+#
+# Usage:
+#   scripts/quetzal_stage_bundle.sh <src-package-dir> <ro-mount-target>
+#
+# Then point QUETZAL_PACKAGE_ROOT / QZ_MODELS_ROOT at <ro-mount-target>.
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <src-package-dir> <ro-mount-target>" >&2
+    exit 2
+fi
+
+SRC="$1"
+DST="$2"
+
+if [[ ! -d "$SRC" ]]; then
+    echo "error: source package dir does not exist: $SRC" >&2
+    exit 1
+fi
+
+mkdir -p "$DST"
+
+if command -v fuse-overlayfs >/dev/null 2>&1; then
+    # Rootless, read-only overlay: lowerdir is the writable package, the mount
+    # exposes it with write bits cleared so the mount-based gate admits it.
+    fuse-overlayfs -o "lowerdir=${SRC}",ro "$DST"
+    echo "staged (fuse-overlayfs ro): $SRC -> $DST"
+elif mountpoint -q "$DST" 2>/dev/null; then
+    echo "already mounted: $DST"
+else
+    # Fallback: read-only bind mount (requires privileges).
+    mount --bind "$SRC" "$DST"
+    mount -o remount,ro,bind "$DST"
+    echo "staged (ro bind mount): $SRC -> $DST"
+fi

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -70,9 +70,13 @@ def _quetzal_auxiliary_roots() -> Optional[dict]:
         roots = json.loads(raw)
     except json.JSONDecodeError as e:
         raise RuntimeError("QUETZAL_AUXILIARY_ROOTS_JSON is not valid JSON") from e
-    if not isinstance(roots, dict) or not roots or not all(
-        isinstance(name, str) and isinstance(path, str)
-        for name, path in roots.items()
+    if (
+        not isinstance(roots, dict)
+        or not roots
+        or not all(
+            isinstance(name, str) and isinstance(path, str)
+            for name, path in roots.items()
+        )
     ):
         raise RuntimeError(
             "QUETZAL_AUXILIARY_ROOTS_JSON must map auxiliary names to paths"
@@ -209,9 +213,7 @@ def admit_quetzal_bundle(model_spec: dict) -> None:
         )
     root = Path(package_root)
     if root.is_symlink() or not root.is_dir():
-        raise RuntimeError(
-            f"QUETZAL_PACKAGE_ROOT is not a directory: {package_root}"
-        )
+        raise RuntimeError(f"QUETZAL_PACKAGE_ROOT is not a directory: {package_root}")
     expected_sha = os.getenv("QUETZAL_BUNDLE_MANIFEST_SHA256")
     auxiliary_roots = _quetzal_auxiliary_roots()
 
@@ -232,9 +234,7 @@ def admit_quetzal_bundle(model_spec: dict) -> None:
     else:
         # Installed / shared read-only layout: proof under
         # .quetzal-bundle-manifests/, payloads at logical paths.
-        result = _admit_installed_quetzal_bundle(
-            root, expected_sha, auxiliary_roots
-        )
+        result = _admit_installed_quetzal_bundle(root, expected_sha, auxiliary_roots)
     logger.info(
         "Quetzal content-address admit OK: schema=%s files=%s "
         "manifest_sha256=%s auxiliary=%s",

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -7,6 +7,7 @@ import json
 import logging
 import multiprocessing
 import os
+import re
 import runpy
 import shlex
 import sys
@@ -35,10 +36,141 @@ logger = logging.getLogger(__name__)
 DEFAULT_VLLM_SERVER_PORT = "8000"
 QUETZAL_IMPL_ID = "quetzal"
 
+# The package members the served vLLM process actually loads. Each is verified
+# against the trusted-root proof inventory before any device use.
+QUETZAL_ARTIFACT_ENV_VARS = (
+    "QZ_QUALIFICATION_MANIFEST",
+    "QUETZAL_PREFILL_GENERATED_PY",
+    "QUETZAL_DECODE_GENERATED_PY",
+    "QUETZAL_PREFILL_METADATA_JSON",
+    "QUETZAL_DECODE_METADATA_JSON",
+    "QUETZAL_WEIGHTS",
+)
+# Installed / shared bundles keep the trusted-root proof here instead of a root
+# manifest.json (the directory is read-only, 0555).
+QUETZAL_INSTALLED_MANIFEST_DIR = ".quetzal-bundle-manifests"
+
 
 def _env_truthy(name: str) -> bool:
     """True when an env var is set to a truthy value (1/true/yes/on)."""
     return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _quetzal_auxiliary_roots() -> Optional[dict]:
+    """Parse QUETZAL_AUXILIARY_ROOTS_JSON (name -> content-addressed root path).
+
+    A v2 bundle's MoE ``streamed_cache`` lives outside the package as an
+    immutable, digest-addressed auxiliary tree; the catalog row points at it
+    through this env var. Absent/empty means a v1 bundle (no externals).
+    """
+    raw = os.getenv("QUETZAL_AUXILIARY_ROOTS_JSON", "").strip()
+    if not raw:
+        return None
+    try:
+        roots = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise RuntimeError("QUETZAL_AUXILIARY_ROOTS_JSON is not valid JSON") from e
+    if not isinstance(roots, dict) or not roots or not all(
+        isinstance(name, str) and isinstance(path, str)
+        for name, path in roots.items()
+    ):
+        raise RuntimeError(
+            "QUETZAL_AUXILIARY_ROOTS_JSON must map auxiliary names to paths"
+        )
+    return roots
+
+
+def _admit_installed_quetzal_bundle(
+    root: Path, expected_sha256: Optional[str], auxiliary_roots: Optional[dict]
+) -> dict:
+    """Admit an installed/shared-layout Quetzal package (no root manifest.json).
+
+    Installed and shared bundles keep their trusted-root proof at
+    ``<root>/.quetzal-bundle-manifests/<sha>.json`` and lay their payloads out at
+    logical paths (``compiled/<name>/…``, ``compiled_weights/<name>/…``), so
+    verify_bundle's portable object-store layout does not apply. Authenticate the
+    proof by its pinned SHA-256, then verify every serve-loaded artifact — and any
+    v2 external auxiliary — against that trusted inventory. This reuses
+    serving.artifact_bundle's own manifest validator and hashing primitives; it
+    does not reimplement bundle internals or weaken the gate.
+    """
+    from serving.artifact_bundle import (
+        _canonical_json,
+        _sha256_file,
+        _validate_manifest,
+        _verify_or_admit_auxiliary_references,
+    )
+
+    if not (expected_sha256 and re.fullmatch(r"[0-9a-f]{64}", expected_sha256)):
+        raise RuntimeError(
+            "impl=quetzal installed bundle requires QUETZAL_BUNDLE_MANIFEST_SHA256 "
+            "as a lowercase SHA-256"
+        )
+    proof = root / QUETZAL_INSTALLED_MANIFEST_DIR / f"{expected_sha256}.json"
+    if proof.is_symlink() or not proof.is_file():
+        raise RuntimeError(
+            f"Quetzal trusted-root proof is missing or not a regular file: {proof}"
+        )
+    actual_sha256, size = _sha256_file(proof)
+    if size > 16 * 1024 * 1024 or actual_sha256 != expected_sha256:
+        raise RuntimeError("Quetzal trusted-root proof digest mismatch")
+    raw = proof.read_bytes()
+    try:
+        manifest = _validate_manifest(json.loads(raw))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise RuntimeError("Quetzal trusted-root proof is not valid JSON") from e
+    if raw != _canonical_json(manifest):
+        raise RuntimeError("Quetzal trusted-root proof is not canonical JSON")
+
+    inventory = {
+        f"{tree['role']}/{tree['name']}/{row['path']}": row
+        for tree in manifest["trees"]
+        for row in tree["files"]
+    }
+    root_resolved = root.resolve(strict=True)
+    verified = 0
+    for env_name in QUETZAL_ARTIFACT_ENV_VARS:
+        value = os.getenv(env_name)
+        if not value:
+            raise RuntimeError(f"impl=quetzal requires {env_name}")
+        member = Path(value)
+        if member.is_symlink():
+            raise RuntimeError(f"{env_name} may not be a symlink: {member}")
+        try:
+            resolved = member.resolve(strict=True)
+        except OSError as e:
+            raise RuntimeError(f"{env_name} is missing: {member}") from e
+        if not resolved.is_relative_to(root_resolved):
+            raise RuntimeError(f"{env_name} escapes the package root: {member}")
+        relative = resolved.relative_to(root_resolved).as_posix()
+        if env_name == "QZ_QUALIFICATION_MANIFEST":
+            row = manifest["qualification_manifest"]
+        else:
+            row = inventory.get(relative)
+        digest, fsize = _sha256_file(resolved)
+        if (
+            not isinstance(row, dict)
+            or row.get("size") != fsize
+            or row.get("sha256") != digest
+        ):
+            raise RuntimeError(
+                f"{env_name} failed trusted-root verification: {relative}"
+            )
+        verified += 1
+
+    auxiliary = _verify_or_admit_auxiliary_references(
+        manifest, auxiliary_roots, hash_payloads=True
+    )
+    result = {
+        "schema": manifest["schema"],
+        "manifest_sha256": actual_sha256,
+        "total_bytes": manifest["total_bytes"],
+        "total_files": manifest["total_files"],
+        "verified_artifacts": verified,
+    }
+    if auxiliary is not None:
+        result["auxiliary"] = auxiliary
+    return result
 
 
 def admit_quetzal_bundle(model_spec: dict) -> None:
@@ -48,14 +180,22 @@ def admit_quetzal_bundle(model_spec: dict) -> None:
     the plugin's read-only-mountpoint (write-bit) admission fails closed by
     design. Instead of the ad-hoc `fuse-overlayfs -o ro` remount, admit the
     package the way the Quetzal package itself does: verify every payload against
-    the manifest by SHA-256 (serving.artifact_bundle.verify_bundle), pinned to
-    the catalog's QUETZAL_BUNDLE_MANIFEST_SHA256. This is content-address
-    admission that is independent of file write bits — the AUDIT.md action item.
+    the trusted-root manifest by SHA-256, pinned to the catalog's
+    QUETZAL_BUNDLE_MANIFEST_SHA256. This is content-address admission that is
+    independent of file write bits — the AUDIT.md action item.
 
-    Fail-closed: an impl=quetzal spec without a package root, or a package whose
-    hashes do not match, aborts before any device use. This is not an adapter
-    around the plugin's own gate — it selects the content-addressed admission
-    path that already exists in the Quetzal package.
+    Two package layouts are admitted, both via serving.artifact_bundle:
+      * portable object-store bundle (``<root>/manifest.json`` + ``objects/``):
+        verify_bundle hashes every payload; auxiliary_roots covers v2 externals.
+      * installed / shared bundle (proof under ``.quetzal-bundle-manifests/`` with
+        payloads at logical paths, the read-only shared layout used by gpt-oss and
+        the MoE models): _admit_installed_quetzal_bundle verifies the serve-loaded
+        artifacts and any v2 streamed-cache auxiliary against the trusted proof.
+
+    Fail-closed: a missing package root, a missing wheel, an unmatched hash, or a
+    v2 bundle whose auxiliary_roots are missing/mismatched aborts before any
+    device use. This selects the content-addressed admission path the Quetzal
+    package already implements; it is not an adapter around the plugin's gate.
     """
     if model_spec.get("impl", {}).get("impl_id") != QUETZAL_IMPL_ID:
         return
@@ -67,7 +207,13 @@ def admit_quetzal_bundle(model_spec: dict) -> None:
             "package directory). Stage the bundle first; see "
             "docs/quetzal_bare_node_serve.md."
         )
+    root = Path(package_root)
+    if root.is_symlink() or not root.is_dir():
+        raise RuntimeError(
+            f"QUETZAL_PACKAGE_ROOT is not a directory: {package_root}"
+        )
     expected_sha = os.getenv("QUETZAL_BUNDLE_MANIFEST_SHA256")
+    auxiliary_roots = _quetzal_auxiliary_roots()
 
     try:
         from serving.artifact_bundle import verify_bundle
@@ -77,11 +223,25 @@ def admit_quetzal_bundle(model_spec: dict) -> None:
             f"installed in the image, but it could not be imported: {e}"
         ) from e
 
-    result = verify_bundle(package_root, expected_sha256=expected_sha)
+    if (root / "manifest.json").is_file():
+        # Portable object-store bundle: the library reads and hashes every
+        # payload, and auxiliary_roots authenticates any v2 externals.
+        result = verify_bundle(
+            root, expected_sha256=expected_sha, auxiliary_roots=auxiliary_roots
+        )
+    else:
+        # Installed / shared read-only layout: proof under
+        # .quetzal-bundle-manifests/, payloads at logical paths.
+        result = _admit_installed_quetzal_bundle(
+            root, expected_sha, auxiliary_roots
+        )
     logger.info(
-        "Quetzal content-address admit OK: %s files, manifest_sha256=%s",
+        "Quetzal content-address admit OK: schema=%s files=%s "
+        "manifest_sha256=%s auxiliary=%s",
+        result.get("schema"),
         result.get("total_files"),
         result.get("manifest_sha256"),
+        result.get("auxiliary"),
     )
 
 

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -33,6 +33,56 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_VLLM_SERVER_PORT = "8000"
+QUETZAL_IMPL_ID = "quetzal"
+
+
+def _env_truthy(name: str) -> bool:
+    """True when an env var is set to a truthy value (1/true/yes/on)."""
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def admit_quetzal_bundle(model_spec: dict) -> None:
+    """Content-address admission for an impl=quetzal package.
+
+    On a bare Exabox node the Quetzal package lives on a writable filesystem, so
+    the plugin's read-only-mountpoint (write-bit) admission fails closed by
+    design. Instead of the ad-hoc `fuse-overlayfs -o ro` remount, admit the
+    package the way the Quetzal package itself does: verify every payload against
+    the manifest by SHA-256 (serving.artifact_bundle.verify_bundle), pinned to
+    the catalog's QUETZAL_BUNDLE_MANIFEST_SHA256. This is content-address
+    admission that is independent of file write bits — the AUDIT.md action item.
+
+    Fail-closed: an impl=quetzal spec without a package root, or a package whose
+    hashes do not match, aborts before any device use. This is not an adapter
+    around the plugin's own gate — it selects the content-addressed admission
+    path that already exists in the Quetzal package.
+    """
+    if model_spec.get("impl", {}).get("impl_id") != QUETZAL_IMPL_ID:
+        return
+
+    package_root = os.getenv("QUETZAL_PACKAGE_ROOT")
+    if not package_root:
+        raise RuntimeError(
+            "impl=quetzal requires QUETZAL_PACKAGE_ROOT (the content-addressed "
+            "package directory). Stage the bundle first; see "
+            "docs/quetzal_bare_node_serve.md."
+        )
+    expected_sha = os.getenv("QUETZAL_BUNDLE_MANIFEST_SHA256")
+
+    try:
+        from serving.artifact_bundle import verify_bundle
+    except Exception as e:  # pragma: no cover - depends on installed wheel
+        raise RuntimeError(
+            "impl=quetzal requires the tt-quetzalcoatlus wheel (serving package) "
+            f"installed in the image, but it could not be imported: {e}"
+        ) from e
+
+    result = verify_bundle(package_root, expected_sha256=expected_sha)
+    logger.info(
+        "Quetzal content-address admit OK: %s files, manifest_sha256=%s",
+        result.get("total_files"),
+        result.get("manifest_sha256"),
+    )
 
 
 def parse_args():
@@ -302,6 +352,36 @@ def ensure_weights_available(model_spec: dict) -> Path:
         logger.info(f"Using pre-mounted weights from MODEL_WEIGHTS_DIR: {weights_path}")
         return weights_path
 
+    hf_repo = model_spec.get("hf_weights_repo") or model_spec["hf_model_repo"]
+    # Pin the exact checkpoint revision when the spec declares one, so an offline
+    # cache resolves the same commit the artifact was generated against.
+    revision = (
+        model_spec.get("device_model_spec", {}).get("vllm_args", {}).get("revision")
+    )
+
+    # Offline path (HF_HUB_OFFLINE / TRANSFORMERS_OFFLINE): resolve the checkpoint
+    # from the populated HF cache (HF_HOME) rather than copying into a fresh
+    # local_dir. snapshot_download(local_dir=...) re-plans a download and fails
+    # closed with no network even when every file is already cached; passing
+    # local_files_only=True with no local_dir returns the cached snapshot path.
+    offline = _env_truthy("HF_HUB_OFFLINE") or _env_truthy("TRANSFORMERS_OFFLINE")
+    if offline:
+        try:
+            snapshot_path = Path(
+                snapshot_download(
+                    repo_id=hf_repo, revision=revision, local_files_only=True
+                )
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"Offline weights requested (HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE) "
+                f"but {hf_repo}@{revision or 'main'} is not in the HF cache "
+                f"(HF_HOME={os.getenv('HF_HOME')}): {e}"
+            ) from e
+        logger.info(f"Using offline HF cache snapshot for {hf_repo}: {snapshot_path}")
+        os.environ["MODEL_WEIGHTS_DIR"] = str(snapshot_path)
+        return snapshot_path
+
     # Default: download weights into cache_root.
     # snapshot_download resumes partial downloads and skips files already present, so
     # always invoke it: a partially-downloaded directory looks non-empty but would crash
@@ -310,12 +390,11 @@ def ensure_weights_available(model_spec: dict) -> Path:
     cache_root = Path(os.getenv("CACHE_ROOT", "/home/container_app_user/cache_root"))
     model_name = model_spec["model_name"]
     weights_path = cache_root / "weights" / model_name
-    hf_repo = model_spec.get("hf_weights_repo") or model_spec["hf_model_repo"]
 
     weights_path.mkdir(parents=True, exist_ok=True)
     logger.info(f"Downloading weights from {hf_repo} to {weights_path}")
     try:
-        snapshot_download(repo_id=hf_repo, local_dir=weights_path)
+        snapshot_download(repo_id=hf_repo, revision=revision, local_dir=weights_path)
     except Exception as e:
         if any(weights_path.iterdir()):
             logger.warning(
@@ -768,6 +847,9 @@ def main():
         device_type = normalize_device_type(device_type)
     elif args.device:
         device_type = normalize_device_type(args.device)
+
+    # Admit an impl=quetzal package by content hash before any device use.
+    admit_quetzal_bundle(model_spec)
 
     if device_type and not os.getenv("TT_CACHE_PATH"):
         set_cache_paths(model_spec, device_type)

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -374,7 +374,20 @@ training_lora_impl = ImplSpec(
     code_path="tt-media-server/tt_model_runners/forge_training_runners/training_lora_runner.py",
 )
 
+# Quetzal-generated (compiled) serving lane. The served model class is bound
+# inside the vLLM process by the vllm-tt-plugin registration hook via the
+# `quetzal_model_registry` entry point (gated by QUETZAL_VLLM=1 in the model
+# spec env_vars); code_path is documentation-only and is never dereferenced by
+# the dev catalog. See docs/quetzal_bare_node_serve.md.
+quetzal_impl = ImplSpec(
+    impl_id="quetzal",
+    impl_name="quetzal",
+    repo_url="https://github.com/tenstorrent/tt-quetzalcoatlus",
+    code_path="serving",
+)
+
 _IMPL_REGISTRY: Dict[str, ImplSpec] = {
+    "quetzal": quetzal_impl,
     "tt_transformers": tt_transformers_impl,
     "llama3_70b_galaxy": llama3_70b_galaxy_impl,
     "qwen3_32b_galaxy": qwen3_32b_galaxy_impl,

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -2442,3 +2442,88 @@ templates:
     Qwen/Qwen3.5-27B:
       reasoning_parser_name: qwen3
       tool_call_parser_name: qwen3_coder
+
+# ---------------------------------------------------------------------------
+# Quetzal-generated (compiled) serve lane — meta-llama/Llama-3.2-1B-Instruct,
+# QB2 / P300X2 (four Blackhole chips driven as a P150x4 mesh).
+#
+# GENERATED, not hand-authored: emit this block with
+#   scripts/generate_quetzal_model_row.py \
+#       --catalog <tt-quetzalcoatlus>/serving/catalog/dev_llm_quetzal.yaml \
+#       --package-id sha256-...-... --model meta-llama/Llama-3.2-1B-Instruct
+# rather than editing the paths by hand — every QZ_/QUETZAL_ path is derived
+# from the one package id, so a stale copy is the classic mis-serve.
+#
+# All package paths are content-addressed under the package id. On a container
+# serve the package is bind-mounted read-only at QUETZAL_PACKAGE_ROOT; on a
+# bare Exabox node it is staged/admitted by content hash (verify_bundle +
+# QUETZAL_BUNDLE_MANIFEST_SHA256) — see docs/quetzal_bare_node_serve.md.
+#
+# default_impl is false: upstream already ships a native tt-metal impl for this
+# pair, so a Quetzal run MUST pass `--impl quetzal`; omission keeps the native
+# default.
+- weights:
+    - meta-llama/Llama-3.2-1B-Instruct
+  impl: quetzal
+  inference_engine: VLLM
+  model_type: LLM
+  supported_modalities:
+    - text
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 1
+      max_context: 4096
+      default_impl: false
+      env_vars:
+        ARCH_NAME: blackhole
+        MESH_DEVICE: P150x4
+        QUETZAL_VLLM: "1"
+        QUETZAL_MODEL: meta-llama/Llama-3.2-1B-Instruct
+        QUETZAL_HF_REVISION: 9213176726f574b556790deb65791e0c5aa438b6
+        # Pin the Quetzal source that emitted this package. The serve-required
+        # KV-cache-key patch (e2e_pcc.discover_cache_keys `cache_layers_<N>_keys`)
+        # lives IN the Quetzal package at this commit — referenced, not vendored.
+        QUETZAL_REQUIRED_SOURCE_REVISION: efa39286d1b94350ad97cba814b66d8601897524
+        TT_QUETZAL_COMMIT_SHA: efa39286d1b94350ad97cba814b66d8601897524
+        QUETZAL_REQUIRED_TT_METAL_COMMIT: 1c2aff5064f19936d70127c80fe9333d687cc427
+        TT_METAL_COMMIT_SHA_OR_TAG: 1c2aff5064f19936d70127c80fe9333d687cc427
+        QUETZAL_PACKAGE_ID: sha256-189fd3bbb381699ec59223d227e4b72854d8e0521db58d621f06866718bb9879-2e154513ea47ccc8cfde7b4512a258ef02c78ac0283115d2a6aaacb6f05d8f8f
+        QUETZAL_BUNDLE_MANIFEST_SHA256: c6a1426cfa7ff599d5b6271301a415544ae3ac0e7b4e4c1fdb5a5e4d1441c422
+        QUETZAL_PACKAGE_ROOT: /home/container_app_user/cache_root/quetzal/packages/sha256-189fd3bbb381699ec59223d227e4b72854d8e0521db58d621f06866718bb9879-2e154513ea47ccc8cfde7b4512a258ef02c78ac0283115d2a6aaacb6f05d8f8f
+        QZ_MODELS_ROOT: /home/container_app_user/cache_root/quetzal/packages/sha256-189fd3bbb381699ec59223d227e4b72854d8e0521db58d621f06866718bb9879-2e154513ea47ccc8cfde7b4512a258ef02c78ac0283115d2a6aaacb6f05d8f8f
+        QZ_QUALIFICATION_MANIFEST: /home/container_app_user/cache_root/quetzal/packages/sha256-189fd3bbb381699ec59223d227e4b72854d8e0521db58d621f06866718bb9879-2e154513ea47ccc8cfde7b4512a258ef02c78ac0283115d2a6aaacb6f05d8f8f/qualification_manifest.yaml
+        QUETZAL_PREFILL_GENERATED_PY: /home/container_app_user/cache_root/quetzal/packages/sha256-189fd3bbb381699ec59223d227e4b72854d8e0521db58d621f06866718bb9879-2e154513ea47ccc8cfde7b4512a258ef02c78ac0283115d2a6aaacb6f05d8f8f/compiled/meta-llama_Llama-3.2-1B-Instruct/full/prefill/generated.py
+        QUETZAL_DECODE_GENERATED_PY: /home/container_app_user/cache_root/quetzal/packages/sha256-189fd3bbb381699ec59223d227e4b72854d8e0521db58d621f06866718bb9879-2e154513ea47ccc8cfde7b4512a258ef02c78ac0283115d2a6aaacb6f05d8f8f/compiled/meta-llama_Llama-3.2-1B-Instruct/full/decode/generated.py
+        QUETZAL_PREFILL_METADATA_JSON: /home/container_app_user/cache_root/quetzal/packages/sha256-189fd3bbb381699ec59223d227e4b72854d8e0521db58d621f06866718bb9879-2e154513ea47ccc8cfde7b4512a258ef02c78ac0283115d2a6aaacb6f05d8f8f/compiled/meta-llama_Llama-3.2-1B-Instruct/full/prefill/metadata.json
+        QUETZAL_DECODE_METADATA_JSON: /home/container_app_user/cache_root/quetzal/packages/sha256-189fd3bbb381699ec59223d227e4b72854d8e0521db58d621f06866718bb9879-2e154513ea47ccc8cfde7b4512a258ef02c78ac0283115d2a6aaacb6f05d8f8f/compiled/meta-llama_Llama-3.2-1B-Instruct/full/decode/metadata.json
+        QUETZAL_WEIGHTS: /home/container_app_user/cache_root/quetzal/packages/sha256-189fd3bbb381699ec59223d227e4b72854d8e0521db58d621f06866718bb9879-2e154513ea47ccc8cfde7b4512a258ef02c78ac0283115d2a6aaacb6f05d8f8f/compiled_weights/meta-llama_Llama-3.2-1B-Instruct/full/weights.pt
+        QZ_MMAP_WEIGHTS: "1"
+        # Weights + tokenizer resolve offline from the package / HF cache.
+        HF_HUB_OFFLINE: "1"
+        TRANSFORMERS_OFFLINE: "1"
+        # Load the TT platform and the generated registry hook only; the
+        # handcrafted tt_model_registry is excluded so it cannot compete for the
+        # architecture alias.
+        VLLM_PLUGINS: quetzal_model_registry,tt
+        TT_VLLM_BUILTIN_MODELS: "0"
+      vllm_args:
+        block_size: 64
+        max_model_len: 4096
+        max_num_seqs: 1
+        revision: 9213176726f574b556790deb65791e0c5aa438b6
+        tokenizer_revision: 9213176726f574b556790deb65791e0c5aa438b6
+        # Tool calling for SWE/agentic. vLLM requires --tool-call-parser
+        # alongside --enable-auto-tool-choice; llama3_json is the built-in parser
+        # matching the catalog metadata tool_call_parser_name. Omitting it is the
+        # documented landmine that silently voids agentic/SWE scores.
+        enable-auto-tool-choice: true
+        tool-call-parser: llama3_json
+      override_tt_config:
+        fabric_config: FABRIC_1D
+        l1_small_size: 16384
+        trace_region_size: 90000000
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+  metadata:
+    meta-llama/Llama-3.2-1B-Instruct:
+      tool_call_parser_name: llama3_json


### PR DESCRIPTION
Minimal carve of the quetzal serve path (vs the unlandable #5042 monster: 81 files/+12.7K).

**What:** makes `run.py --impl quetzal` serve any quetzal-servable model on bare QB2 with no hand-hacks.
- quetzal ImplSpec in model_spec.py (makes --impl quetzal valid)
- scripts/generate_quetzal_model_row.py (rows generated from the quetzal catalog fragment)
- run_vllm_api_server.py: offline HF-cache weight resolution + content-address admission for BOTH v1 portable AND v2/installed-shared/MoE bundles (proven device-free on real llama-1b + gpt-oss bundles; fail-closed on tamper/byte-flip/missing-aux, write-bit independent)
- docs/quetzal_bare_node_serve.md

**Deliberately excluded** (follow-ups): release-image contract, models-ci enrollment/release automation, behavioral-topology/gpt120-preweight admission, agentic/eval wiring — the ~12K lines of #5042 that aren't the serve path.

**Diff:** ~6 files, +670/-20. For codeowner review — not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)