### PR TITLE
feat(agentic-traces): grade the measured sweep against requirements targets

### DIFF
--- a/llm_module/agentic_traces/runs.py
+++ b/llm_module/agentic_traces/runs.py
@@ -74,6 +74,10 @@ class AgenticTracesRun:
     mode: AgenticTracesMode
     # AIPerf ``--goodput`` SLO string; empty means this run measures none.
     goodput: str = ""
+    # The requirements document's expected ``agenticSweep`` (all points, so a
+    # report can call out the ones a truncated sweep never measured); empty
+    # when nothing grades this run.
+    expected_sweep: List[Dict[str, Any]] = field(default_factory=list)
     # SwarmOne swo-bench knobs. Unused by the InferenceX/AIPerf driver, so they
     # carry harmless defaults on ``inferencex_agentx`` runs.
     task: Optional[str] = None
@@ -191,6 +195,7 @@ def build_runs(
                 gpu_telemetry=spec.gpu_telemetry,
                 mode=mode,
                 goodput=spec.goodput,
+                expected_sweep=[dict(point) for point in spec.expected_sweep],
                 task=spec.task,
                 resident=spec.resident,
                 cache_mode=spec.cache_mode,

--- a/llm_module/agentic_traces/sweep_export.py
+++ b/llm_module/agentic_traces/sweep_export.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
@@ -141,6 +142,147 @@ def to_agentic_sweep(runs: Sequence[Mapping[str, Any]]) -> List[Dict[str, Any]]:
     return sorted(points, key=lambda point: point["concurrency"])
 
 
+# --- grading against a document's expected sweep -----------------------------
+
+# Every field a point can carry, in the document's own emission order. Used to
+# pick an expected point back out of a flattened report record.
+POINT_FIELDS: Tuple[str, ...] = (
+    tuple(field for field, _metric in _SWEEP_FIELD_TO_METRIC)
+    + ("kvCacheHitRatePct",)
+    + tuple(field for field, _metric in _INTVTY_FIELD_TO_METRIC)
+    + ("goodputPct",)
+)
+
+# The token-shape four describe the trace mix being replayed, not the server
+# under test: the reference curve and this run both replay the same traces, so
+# a mismatch says the replays diverged (already surfaced as OSL mismatch in Run
+# Health), not that the server is slow. They are shown but never graded.
+UNGRADED_POINT_FIELDS: Tuple[str, ...] = (
+    "inputTokensMean",
+    "inputTokensP95",
+    "outputTokensMean",
+    "outputTokensP95",
+)
+
+# Direction by family: latencies gate at or below the target, rates at or
+# above. Exact comparison, tolerance 0, matching how the requirements document
+# grades benchmark targets (its comparators are gte/lte).
+_LOWER_IS_BETTER_FIELDS = frozenset(
+    field for field in POINT_FIELDS if field.startswith(("ttft", "tpot", "e2el"))
+)
+_HIGHER_IS_BETTER_FIELDS = frozenset(POINT_FIELDS) - _LOWER_IS_BETTER_FIELDS
+
+
+@dataclass(frozen=True)
+class MetricVerdict:
+    """One graded field: target, what was measured, and the verdict."""
+
+    field: str
+    target: float
+    measured: Optional[float]  # None: the run never produced this metric
+    lower_is_better: bool
+
+    @property
+    def passed(self) -> Optional[bool]:
+        """True/False when graded, None when there is no measurement to grade."""
+        if self.measured is None:
+            return None
+        if self.lower_is_better:
+            return self.measured <= self.target
+        return self.measured >= self.target
+
+
+@dataclass(frozen=True)
+class PointVerdict:
+    """Every graded field at one concurrency, plus the point's own verdict."""
+
+    concurrency: int
+    verdicts: Tuple[MetricVerdict, ...]
+
+    @property
+    def graded(self) -> int:
+        return sum(1 for v in self.verdicts if v.passed is not None)
+
+    @property
+    def met(self) -> int:
+        return sum(1 for v in self.verdicts if v.passed is True)
+
+    @property
+    def passed(self) -> bool:
+        """A point passes when every graded field does."""
+        return self.graded > 0 and self.met == self.graded
+
+
+def grade_sweep_point(
+    measured: Mapping[str, Any],
+    expected: Mapping[str, Any],
+) -> PointVerdict:
+    """Grade one measured point against its expected counterpart.
+
+    Only fields the document states are graded, in document order; a field the
+    run did not measure is reported as ungraded rather than failed, so a
+    partial export reads as a gap in the measurement, not a regression.
+    """
+    concurrency = int(expected.get("concurrency") or measured.get("concurrency") or 0)
+    verdicts: List[MetricVerdict] = []
+    for field in POINT_FIELDS:
+        if field in UNGRADED_POINT_FIELDS:
+            continue
+        target = _number(expected.get(field))
+        if target is None:
+            continue
+        verdicts.append(
+            MetricVerdict(
+                field=field,
+                target=target,
+                measured=_number(measured.get(field)),
+                lower_is_better=field in _LOWER_IS_BETTER_FIELDS,
+            )
+        )
+    return PointVerdict(concurrency=concurrency, verdicts=tuple(verdicts))
+
+
+def grade_agentic_sweep(
+    measured_points: Sequence[Mapping[str, Any]],
+    expected_points: Sequence[Mapping[str, Any]],
+) -> Tuple[List[PointVerdict], List[int]]:
+    """Grade a measured sweep against the document's expected points.
+
+    Pairing is by concurrency. Returns the per-point verdicts plus the
+    concurrencies the document expected but the sweep never measured, so a
+    truncated sweep is called out instead of silently scoring a subset.
+    """
+    measured_by_concurrency = {
+        int(point.get("concurrency") or 0): point for point in measured_points
+    }
+    verdicts: List[PointVerdict] = []
+    missing: List[int] = []
+    for expected in expected_points:
+        concurrency = int(expected.get("concurrency") or 0)
+        measured = measured_by_concurrency.get(concurrency)
+        if measured is None:
+            missing.append(concurrency)
+            continue
+        verdicts.append(grade_sweep_point(measured, expected))
+    return verdicts, missing
+
+
+def expected_sweep_from_record(record: Mapping[str, Any]) -> Optional[List[Dict[str, Any]]]:
+    """The document's full expected sweep attached to a report record, if any.
+
+    Every run carries the whole sweep, not just its own point, so the report
+    can call out the concurrencies that were expected but never measured -- a
+    truncated sweep must not read as a complete one that simply scored less.
+    A list passes the report generator's block merge untouched (only mappings
+    are flattened), so the field survives in both the live and the persisted
+    shape.
+    """
+    sweep = record.get("expected_sweep")
+    if isinstance(sweep, list) and sweep:
+        return [dict(point) for point in sweep if isinstance(point, Mapping)] or None
+    return None
+
+
 def write_agentic_sweep(
     runs: Sequence[Mapping[str, Any]],
     output_dir: Path,
@@ -161,4 +303,15 @@ def write_agentic_sweep(
     return path
 
 
-__all__ = ["to_agentic_sweep", "to_agentic_sweep_point", "write_agentic_sweep"]
+__all__ = [
+    "POINT_FIELDS",
+    "UNGRADED_POINT_FIELDS",
+    "MetricVerdict",
+    "PointVerdict",
+    "expected_sweep_from_record",
+    "grade_agentic_sweep",
+    "grade_sweep_point",
+    "to_agentic_sweep",
+    "to_agentic_sweep_point",
+    "write_agentic_sweep",
+]

--- a/llm_module/drivers/aiperf_agentic_traces.py
+++ b/llm_module/drivers/aiperf_agentic_traces.py
@@ -763,6 +763,10 @@ def _build_payload(
         # The SLO bars goodput was graded against, so a goodput number is
         # never read without the definition of "good" that produced it.
         "goodput_slo": run.goodput,
+        # The document's expected sweep, so the report can grade each measured
+        # point against its target -- and call out the points a truncated
+        # sweep never measured. Empty when nothing grades the run.
+        "expected_sweep": [dict(point) for point in run.expected_sweep],
         "failed_request_threshold": run.failed_request_threshold,
         "trajectory_start_min_ratio": run.trajectory_start_min_ratio,
         "trajectory_start_max_ratio": run.trajectory_start_max_ratio,

--- a/reference_config/agentic_traces/agentic_traces_config.py
+++ b/reference_config/agentic_traces/agentic_traces_config.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field, replace
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from llm_module.agentic_traces.schema import TraceSource
 from workflows.utils import map_configs_by_attr
@@ -86,6 +86,11 @@ class AgenticTracesRunSpec:
     # goodput, since AIPerf reports it only when the bars are passed. Catalog
     # entries leave this empty; a requirements document supplies its SLOs.
     goodput: str = ""
+    # The document's expected ``agenticSweep``, kept verbatim (one camelCase
+    # point per concurrency) so the report can grade the measurement against
+    # it -- including the points a truncated sweep never reached. Empty for
+    # catalog runs, which have no expectations to grade against.
+    expected_sweep: List[Dict[str, Any]] = field(default_factory=list)
     # SwarmOne (``swo-bench replay``) knobs. Ignored by the InferenceX/AIPerf
     # driver, so they can stay at their defaults on ``inferencex_agentx`` specs.
     # ``task`` selects a single task from a multi-task swo-bench scenario (its
@@ -491,6 +496,7 @@ def replace_agentic_runs(
     config: AgenticTracesConfig,
     concurrencies: Sequence[int],
     goodput: str = "",
+    expected_sweep: Sequence[Mapping[str, Any]] = (),
 ) -> AgenticTracesConfig:
     """Replay ``config``'s runs at each of ``concurrencies``, grading ``goodput``.
 
@@ -501,12 +507,20 @@ def replace_agentic_runs(
     document with no agentic sweep keeps the catalog's single operating point.
 
     ``goodput`` applies to every run, since the SLOs are the workload's and do
-    not move with the operating point.
+    not move with the operating point. Every run carries the whole
+    ``expected_sweep`` rather than only its own point, so the report can call
+    out the points a truncated sweep never measured.
     """
     if not concurrencies:
         return config
+    expected = [dict(point) for point in expected_sweep]
     runs = tuple(
-        replace(run, concurrency=concurrency, goodput=goodput or run.goodput)
+        replace(
+            run,
+            concurrency=concurrency,
+            goodput=goodput or run.goodput,
+            expected_sweep=list(expected),
+        )
         for run in config.runs
         for concurrency in concurrencies
     )

--- a/report_module/agentic_traces_renderer.py
+++ b/report_module/agentic_traces_renderer.py
@@ -581,6 +581,10 @@ def render_agentic_traces(block: Block, metadata: Mapping[str, Any]) -> str:
     if sweep:
         parts.append(sweep)
 
+    targets = _targets_block(rows)
+    if targets:
+        parts.append(targets)
+
     parts.append(_definitions_block(rows))
 
     return "\n\n".join(parts)
@@ -616,6 +620,111 @@ def _agentic_sweep_block(rows: Sequence[Mapping[str, Any]]) -> str:
         "results as `agentic_sweep.json` too.\n\n"
         f"```json\n{body}\n```"
     )
+
+
+def _targets_block(rows: Sequence[Mapping[str, Any]]) -> str:
+    """Grade the measured sweep against the requirements document's targets.
+
+    When a requirements document drove the run, each InferenceX payload
+    carries the document's expected ``agenticSweep`` (see ``expected_sweep``
+    in the driver payload), so the measured point and the expected one grade
+    field for field here, and the points a truncated sweep never reached are
+    called out rather than silently absent. Catalog runs carry no
+    expectations and get no section.
+
+    Grading is exact (tolerance 0), matching how the document grades
+    benchmark targets: latencies gate at or below the target, rates at or
+    above. The token-shape fields (input/output token mean/p95) describe the
+    trace mix rather than the server, so they are never graded.
+    """
+    # Same import-cycle guard as ``_agentic_sweep_block``.
+    from llm_module.agentic_traces.sweep_export import (
+        expected_sweep_from_record,
+        grade_agentic_sweep,
+        to_agentic_sweep,
+    )
+
+    inferencex_rows = [
+        row for row in rows if str(row.get("trace_source") or "") == INFERENCEX_SOURCE
+    ]
+    expected_sweep: List[Dict[str, Any]] = []
+    for row in inferencex_rows:
+        sweep = expected_sweep_from_record(row)
+        if sweep:
+            expected_sweep = sweep
+            break
+    if not expected_sweep:
+        return ""
+
+    verdicts, missing = grade_agentic_sweep(
+        to_agentic_sweep(inferencex_rows), expected_sweep
+    )
+    if not verdicts and not missing:
+        return ""
+
+    parts = [
+        "#### Requirements Targets\n",
+        "Measured against the expected `agenticSweep` points from the "
+        "requirements document, exact (tolerance 0): latencies pass at or "
+        "below the target (↓), rates at or above (↑). Cells read "
+        "**measured** / target.",
+    ]
+
+    if verdicts:
+        summary = "; ".join(
+            f"**c{point.concurrency}**: {point.met}/{point.graded} targets met "
+            f"{'✅' if point.passed else '❌'}"
+            for point in verdicts
+        )
+        parts.append(summary)
+
+        headers = ["Metric"] + [
+            f"c{point.concurrency} ({point.met}/{point.graded})" for point in verdicts
+        ]
+        fields = [verdict.field for verdict in verdicts[0].verdicts]
+        table_rows: List[Dict[str, str]] = []
+        for field in fields:
+            per_point = [
+                next(v for v in point.verdicts if v.field == field)
+                for point in verdicts
+            ]
+            entry: Dict[str, str] = {"Metric": _target_field_label(per_point[0])}
+            for header, verdict in zip(headers[1:], per_point):
+                entry[header] = _target_cell(verdict)
+            table_rows.append(entry)
+        parts.append(build_markdown_table(table_rows))
+
+    if missing:
+        listed = ", ".join(f"c{concurrency}" for concurrency in missing)
+        parts.append(
+            f"The document also expects {listed}, which this sweep never "
+            "measured — those points are ungraded, not passed."
+        )
+    return "\n\n".join(parts)
+
+
+def _target_field_label(verdict: Any) -> str:
+    direction = "↓" if verdict.lower_is_better else "↑"
+    return f"`{verdict.field}` {direction}"
+
+
+def _target_cell(verdict: Any) -> str:
+    measured = (
+        _fmt_target_number(verdict.field, verdict.measured)
+        if verdict.measured is not None
+        else NA
+    )
+    target = _fmt_target_number(verdict.field, verdict.target)
+    glyph = {True: "✅", False: "❌", None: "➖"}[verdict.passed]
+    return f"**{measured}** / {target} {glyph}"
+
+
+def _fmt_target_number(field: str, value: float) -> str:
+    if field.endswith("Ms"):
+        return f"{value:,.0f}" if abs(value) >= 100 else f"{value:,.2f}"
+    if field == "reqThroughputRps":
+        return f"{value:.3f}"
+    return f"{value:,.2f}"
 
 
 def _definitions_block(rows: Sequence[Mapping[str, Any]]) -> str:

--- a/tests/llm_module/test_agentic_traces.py
+++ b/tests/llm_module/test_agentic_traces.py
@@ -1378,3 +1378,62 @@ class TestSwoBenchParser:
         assert block.data["mode"] == "ci"
         assert block.targets["device"] == "super_cluster"
         assert block.targets["timestamp"] == "2026-07-27 12:00:00"
+
+
+class TestExpectedSweepPlumbing:
+    """The document's expected sweep rides spec -> run -> payload, so the
+    report can grade the measurement against it (goodput_slo precedent)."""
+
+    _SWEEP = [{"concurrency": 4, "ttftMeanMs": 700.0}, {"concurrency": 8}]
+
+    def test_build_runs_carries_the_specs_expected_sweep(self):
+        config = AgenticTracesConfig(
+            model_id="id_test",
+            inferencex_git_ref="abc123",
+            runs=(
+                AgenticTracesRunSpec(concurrency=4, expected_sweep=list(self._SWEEP)),
+            ),
+        )
+
+        run = build_runs(config, _FakeModelSpec())[0]
+
+        assert run.expected_sweep == list(self._SWEEP)
+
+    def test_build_runs_defaults_to_no_expectation(self):
+        config = AgenticTracesConfig(
+            model_id="id_test",
+            inferencex_git_ref="abc123",
+            runs=(AgenticTracesRunSpec(),),
+        )
+
+        assert build_runs(config, _FakeModelSpec())[0].expected_sweep == []
+
+    def test_payload_carries_the_expected_sweep(self):
+        from llm_module.drivers.aiperf_agentic_traces import _build_payload
+
+        config = AgenticTracesConfig(
+            model_id="id_test",
+            inferencex_git_ref="abc123",
+            runs=(
+                AgenticTracesRunSpec(concurrency=4, expected_sweep=list(self._SWEEP)),
+            ),
+        )
+        run = build_runs(config, _FakeModelSpec())[0]
+
+        payload = _build_payload(
+            run=run, metrics={}, model_repo="org/model", artifact_dir=Path("/tmp/a")
+        )
+
+        assert payload["expected_sweep"] == list(self._SWEEP)
+
+    def test_payload_defaults_to_empty_expectation(self):
+        from llm_module.drivers.aiperf_agentic_traces import _build_payload
+
+        config = AGENTIC_TRACES_CONFIGS[KIMI_MODEL_ID]
+        run = build_runs(config, _FakeModelSpec(), mode=AgenticTracesMode.CI)[0]
+
+        payload = _build_payload(
+            run=run, metrics={}, model_repo="org/model", artifact_dir=Path("/tmp/a")
+        )
+
+        assert payload["expected_sweep"] == []

--- a/tests/llm_module/test_agentic_traces_sweep_export.py
+++ b/tests/llm_module/test_agentic_traces_sweep_export.py
@@ -185,3 +185,164 @@ class TestWriteAgenticSweep:
         )
 
         assert path.exists()
+
+
+class TestGradeSweepPoint:
+    """Grading is the report's pass/fail, so pin its rules exactly."""
+
+    _EXPECTED = {
+        "concurrency": 1,
+        "ttftMeanMs": 800.0,
+        "tpotMeanMs": 3.0,
+        "e2elP95Ms": 20500.0,
+        "reqThroughputRps": 0.076,
+        "decodeThroughputTps": 150.0,
+        "goodputPct": 90.0,
+        "kvCacheHitRatePct": 94.6,
+        "inputTokensMean": 275639.0,
+        "outputTokensP95": 6905.0,
+    }
+
+    def test_latency_passes_at_or_below_target(self):
+        from llm_module.agentic_traces.sweep_export import grade_sweep_point
+
+        verdict = grade_sweep_point(
+            {"concurrency": 1, "ttftMeanMs": 799.9}, self._EXPECTED
+        )
+        assert self._field(verdict, "ttftMeanMs").passed is True
+
+        verdict = grade_sweep_point(
+            {"concurrency": 1, "ttftMeanMs": 800.1}, self._EXPECTED
+        )
+        assert self._field(verdict, "ttftMeanMs").passed is False
+
+    def test_rate_passes_at_or_above_target(self):
+        from llm_module.agentic_traces.sweep_export import grade_sweep_point
+
+        verdict = grade_sweep_point(
+            {"concurrency": 1, "decodeThroughputTps": 150.0}, self._EXPECTED
+        )
+        assert self._field(verdict, "decodeThroughputTps").passed is True
+
+        verdict = grade_sweep_point(
+            {"concurrency": 1, "decodeThroughputTps": 149.9}, self._EXPECTED
+        )
+        assert self._field(verdict, "decodeThroughputTps").passed is False
+
+    def test_exact_match_passes(self):
+        """Tolerance is 0, so equality must pass in both directions."""
+        from llm_module.agentic_traces.sweep_export import grade_sweep_point
+
+        verdict = grade_sweep_point(
+            {"concurrency": 1, "ttftMeanMs": 800.0, "goodputPct": 90.0},
+            self._EXPECTED,
+        )
+        assert self._field(verdict, "ttftMeanMs").passed is True
+        assert self._field(verdict, "goodputPct").passed is True
+
+    def test_token_shape_fields_are_never_graded(self):
+        """ISL/OSL describe the trace mix, not the server -- wildly off is
+        still not a verdict."""
+        from llm_module.agentic_traces.sweep_export import grade_sweep_point
+
+        verdict = grade_sweep_point(
+            {"concurrency": 1, "inputTokensMean": 1.0, "outputTokensP95": 1.0},
+            self._EXPECTED,
+        )
+        assert all(
+            v.field not in ("inputTokensMean", "outputTokensP95")
+            for v in verdict.verdicts
+        )
+
+    def test_unmeasured_field_is_ungraded_not_failed(self):
+        from llm_module.agentic_traces.sweep_export import grade_sweep_point
+
+        verdict = grade_sweep_point({"concurrency": 1}, self._EXPECTED)
+        ttft = self._field(verdict, "ttftMeanMs")
+        assert ttft.measured is None
+        assert ttft.passed is None
+        assert verdict.graded == 0
+
+    def test_field_absent_from_the_document_is_not_graded(self):
+        from llm_module.agentic_traces.sweep_export import grade_sweep_point
+
+        expected = {"concurrency": 1, "ttftMeanMs": 800.0}
+        verdict = grade_sweep_point({"concurrency": 1, "tpotMeanMs": 99.0}, expected)
+        assert [v.field for v in verdict.verdicts] == ["ttftMeanMs"]
+
+    def test_point_passes_only_when_every_graded_field_does(self):
+        from llm_module.agentic_traces.sweep_export import grade_sweep_point
+
+        passing = grade_sweep_point(
+            {"concurrency": 1, "ttftMeanMs": 1.0, "goodputPct": 100.0},
+            {"concurrency": 1, "ttftMeanMs": 800.0, "goodputPct": 90.0},
+        )
+        assert passing.passed is True
+
+        failing = grade_sweep_point(
+            {"concurrency": 1, "ttftMeanMs": 1.0, "goodputPct": 10.0},
+            {"concurrency": 1, "ttftMeanMs": 800.0, "goodputPct": 90.0},
+        )
+        assert failing.met == 1 and failing.graded == 2
+        assert failing.passed is False
+
+    @staticmethod
+    def _field(verdict, name):
+        return next(v for v in verdict.verdicts if v.field == name)
+
+
+class TestGradeAgenticSweep:
+    def test_pairs_points_by_concurrency_and_reports_the_gap(self):
+        from llm_module.agentic_traces.sweep_export import grade_agentic_sweep
+
+        measured = [
+            {"concurrency": 4, "ttftMeanMs": 100.0},
+            {"concurrency": 1, "ttftMeanMs": 100.0},
+        ]
+        expected = [
+            {"concurrency": 1, "ttftMeanMs": 800.0},
+            {"concurrency": 4, "ttftMeanMs": 800.0},
+            {"concurrency": 16, "ttftMeanMs": 800.0},
+        ]
+
+        verdicts, missing = grade_agentic_sweep(measured, expected)
+
+        assert [v.concurrency for v in verdicts] == [1, 4]
+        assert all(v.passed for v in verdicts)
+        assert missing == [16]
+
+    def test_measured_points_the_document_does_not_expect_are_ignored(self):
+        from llm_module.agentic_traces.sweep_export import grade_agentic_sweep
+
+        verdicts, missing = grade_agentic_sweep(
+            [{"concurrency": 2, "ttftMeanMs": 100.0}],
+            [{"concurrency": 1, "ttftMeanMs": 800.0}],
+        )
+
+        assert verdicts == []
+        assert missing == [1]
+
+
+class TestExpectedSweepFromRecord:
+    def test_reads_the_attached_sweep(self):
+        from llm_module.agentic_traces.sweep_export import expected_sweep_from_record
+
+        sweep = [{"concurrency": 1, "ttftMeanMs": 800.0}, {"concurrency": 8}]
+        record = {"concurrency": 1, "expected_sweep": sweep}
+        assert expected_sweep_from_record(record) == sweep
+
+    def test_survives_the_block_merge_untouched(self):
+        """A list is not a mapping, so the generator's one-level flatten leaves
+        it alone -- the whole point of carrying the sweep as a list."""
+        from report_module.generator import _flatten_one_level
+        from llm_module.agentic_traces.sweep_export import expected_sweep_from_record
+
+        sweep = [{"concurrency": 1, "ttftMeanMs": 800.0}]
+        record = _flatten_one_level({"concurrency": 1, "expected_sweep": sweep})
+        assert expected_sweep_from_record(record) == sweep
+
+    def test_none_when_nothing_is_attached(self):
+        from llm_module.agentic_traces.sweep_export import expected_sweep_from_record
+
+        assert expected_sweep_from_record({"concurrency": 1}) is None
+        assert expected_sweep_from_record({"expected_sweep": []}) is None

--- a/tests/report_module/test_agentic_traces_renderer.py
+++ b/tests/report_module/test_agentic_traces_renderer.py
@@ -481,3 +481,61 @@ class TestMeasuredAgenticSweep:
         out = _render(_swo_record())
 
         assert "#### Measured `agenticSweep`" not in out
+
+
+class TestRequirementsTargets:
+    """Grading against the document's expected sweep, when one drove the run."""
+
+    _POINT = {
+        "concurrency": 1,
+        "ttftMeanMs": 8000.0,  # record measures 7868.93 -> pass
+        "tpotMeanMs": 3.0,  # record measures 11.8 -> fail
+        "goodputPct": 90.0,  # record measures none -> ungraded
+        "inputTokensMean": 999999.0,  # never graded
+    }
+
+    def test_absent_when_no_expectations_are_attached(self):
+        out = _render(_record())
+
+        assert "#### Requirements Targets" not in out
+
+    def test_grades_each_field_with_direction(self):
+        out = _render(_record(expected_sweep=[dict(self._POINT)]))
+
+        assert "#### Requirements Targets" in out
+        assert "**c1**: 1/2 targets met ❌" in out
+        # latency passes at/below target; rate-style fields at/above
+        assert "**7,869** / 8,000 ✅" in out
+        assert "**11.80** / 3.00 ❌" in out
+        # expected but unmeasured reads as a gap, not a failure
+        assert "**N/A** / 90.00 ➖" in out
+
+    def test_token_shape_fields_are_not_graded(self):
+        out = _render(_record(expected_sweep=[dict(self._POINT)]))
+
+        # Scoped to the grading section: the measured-sweep JSON block above
+        # it legitimately carries the token-shape fields.
+        section = out.split("#### Requirements Targets", 1)[1]
+        assert "inputTokensMean" not in section
+
+    def test_unmeasured_document_points_are_called_out(self):
+        """A truncated sweep must not read as a complete one that scored less."""
+        sweep = [dict(self._POINT), {"concurrency": 64, "ttftMeanMs": 700.0}]
+        out = _render(_record(expected_sweep=sweep))
+
+        assert "c64" in out
+        assert "never measured" in out
+
+    def test_each_measured_point_renders_its_own_column(self):
+        sweep = [dict(self._POINT), {**self._POINT, "concurrency": 4}]
+        out = _render(
+            _record(concurrency=1, expected_sweep=sweep),
+            _record(concurrency=4, expected_sweep=sweep),
+        )
+
+        assert "c1 (1/2)" in out and "c4 (1/2)" in out
+
+    def test_swarmone_rows_do_not_gain_a_section(self):
+        out = _render(_swo_record())
+
+        assert "#### Requirements Targets" not in out

--- a/tests/workflow_module/test_requirements_target_pack.py
+++ b/tests/workflow_module/test_requirements_target_pack.py
@@ -482,7 +482,7 @@ def test_requirements_pack_agentic_traces_config_uses_template(pack):
 # --- agentic sweep -----------------------------------------------------------
 
 
-def _agentic_pack(concurrencies, slo=None):
+def _agentic_pack(concurrencies, slo=None, sweep=None):
     """A pack whose document sweeps ``concurrencies`` for an agentic workload."""
     from workflow_module.requirements_schema import RequirementsDoc
 
@@ -498,7 +498,10 @@ def _agentic_pack(concurrencies, slo=None):
                 "kind": "agentic",
                 "id": "w1",
                 "slo": slo or {},
-                "agenticSweep": [{"concurrency": c} for c in concurrencies],
+                "agenticSweep": (
+                    sweep if sweep is not None
+                    else [{"concurrency": c} for c in concurrencies]
+                ),
             }
         ],
     }
@@ -565,3 +568,55 @@ def test_vllm_goodput_keys_are_unchanged_by_the_aiperf_mapping():
     (scenario,) = load_requirements(_FIXTURE).scenarios
 
     assert _goodput_constraints(scenario) == "ttft:2000 tpot:20 e2el:20000"
+
+
+def test_replace_agentic_runs_attaches_the_expected_sweep_to_every_run():
+    """Every run carries the whole sweep, so the report can call out the
+    points a truncated sweep never measured."""
+    from reference_config.agentic_traces.agentic_traces_config import (
+        replace_agentic_runs,
+    )
+
+    base = _base_config()
+    sweep = [{"concurrency": 1, "ttftMeanMs": 800.0}, {"concurrency": 8}]
+
+    swept = replace_agentic_runs(base, [1, 8], expected_sweep=sweep)
+
+    assert all(run.expected_sweep == sweep for run in swept.runs)
+
+
+def test_agentic_config_carries_the_documents_expected_sweep():
+    """The pack hands the run specs the document's expected points, so the
+    report can grade measured against expected field for field."""
+    from types import SimpleNamespace
+
+    sweep = [
+        {"concurrency": 1, "ttftMeanMs": 800.0, "goodputPct": 90.0},
+        {"concurrency": 8, "ttftMeanMs": 700.0, "goodputPct": 90.0},
+    ]
+    pack = _agentic_pack([], sweep=sweep)
+    spec = SimpleNamespace(
+        model_id="id_off-catalog",
+        impl=SimpleNamespace(impl_id="requirements_synthesized"),
+    )
+
+    config = pack.agentic_traces_config(spec)
+
+    assert config.runs
+    assert all(run.expected_sweep == sweep for run in config.runs)
+
+
+def test_agentic_expected_sweep_dedupes_first_workload_wins():
+    """Two workloads sharing an operating point grade against the first,
+    matching the concurrency dedupe that keeps the run from replaying twice."""
+    sweep = [
+        {"concurrency": 8, "ttftMeanMs": 700.0},
+        {"concurrency": 1, "ttftMeanMs": 800.0},
+        {"concurrency": 1, "ttftMeanMs": 999.0},
+    ]
+    pack = _agentic_pack([], sweep=sweep)
+
+    assert pack._agentic_expected_sweep() == [
+        {"concurrency": 1, "ttftMeanMs": 800.0},
+        {"concurrency": 8, "ttftMeanMs": 700.0},
+    ]

--- a/workflows/requirements_target_pack.py
+++ b/workflows/requirements_target_pack.py
@@ -511,7 +511,23 @@ class RequirementsTargetPack(TargetPack):
             base,
             self._agentic_concurrencies(),
             goodput=self.agentic_traces_goodput() or "",
+            expected_sweep=self._agentic_expected_sweep(),
         )
+
+    def _agentic_expected_sweep(self) -> List[Dict[str, Any]]:
+        """The document's expected sweep points, verbatim and in order.
+
+        ``AgenticSweepPoint.reference`` is the point as the document stated
+        it, so what a run measures can be graded against its own operating
+        point in the report. First workload wins on a shared concurrency,
+        matching the dedupe in ``_agentic_concurrencies``.
+        """
+        points: Dict[int, Dict[str, Any]] = {}
+        for workload in self._doc.agentic_workloads:
+            for point in workload.sweep:
+                if point.concurrency > 0:
+                    points.setdefault(point.concurrency, dict(point.reference))
+        return [points[c] for c in sorted(points)]
 
     def _agentic_concurrencies(self) -> List[int]:
         """Concurrencies the document's agentic workloads ask for, in order.


### PR DESCRIPTION
A requirements document states its expectations as an `agenticSweep`: one point per concurrency with the metrics the measurement must meet. The report already emitted the measured sweep in that shape (#5085); this grades the two against each other.

- the pack hands the document's expected points (`AgenticSweepPoint.reference`, kept verbatim for exactly this) to `replace_agentic_runs`, which stamps the whole expected sweep on every run spec; it rides spec -> run -> driver payload as `expected_sweep`, the same path `goodput_slo` already took
- `sweep_export` grades measured vs expected field for field: exact (tolerance 0, matching the document's gte/lte comparators for benchmark targets), latencies at or below, rates at or above; the token-shape fields describe the trace mix rather than the server, so they are never graded
- the renderer adds a **Requirements Targets** section when expectations are present: per-point met/graded summary, one column per measured point, and a callout for the document points a truncated sweep never measured

Catalog runs carry no expectations and are unchanged: no section, no grading.

Stack: part 7 of 7, based on #5085. Retarget to main once it merges.

Made with [Cursor](https://cursor.com)