### PR TITLE
models-ci: validate implementation identities

### DIFF
--- a/.github/workflows/models-ci-config-schema.json
+++ b/.github/workflows/models-ci-config-schema.json
@@ -4,6 +4,11 @@
   "description": "Schema for models CI configuration",
   "type": "object",
   "$defs": {
+    "implementation_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional model implementation selector. Required by semantic validation when a model has more than one entry for the same inference engine."
+    },
     "device_names": {
       "type": "string",
       "enum": ["N150", "N300", "T3K", "GALAXY", "BH_GALAXY", "P100", "P150", "P150X4", "P150X8", "P300", "P300X2", "DUAL_GALAXY", "QUAD_GALAXY"]
@@ -78,6 +83,9 @@
               "type": "object",
               "description": "Single-engine model configuration",
               "properties": {
+                "impl": {
+                  "$ref": "#/$defs/implementation_name"
+                },
                 "inference_engine": {
                   "type": "string",
                   "enum": ["vLLM", "MEDIA", "FORGE"],
@@ -118,6 +126,9 @@
                   "items": {
                     "type": "object",
                     "properties": {
+                      "impl": {
+                        "$ref": "#/$defs/implementation_name"
+                      },
                       "inference_engine": {
                         "type": "string",
                         "enum": ["vLLM", "MEDIA", "FORGE"],

--- a/.github/workflows/validate-models-ci-config.yml
+++ b/.github/workflows/validate-models-ci-config.yml
@@ -5,6 +5,10 @@ on:
     branches: ["main"]
     paths:
       - ".github/workflows/models-ci-config.json"
+      - ".github/workflows/models-ci-config-schema.json"
+      - ".github/workflows/validate-models-ci-config.yml"
+      - "scripts/validate_models_ci_config.py"
+      - "tests/test_models_ci_config_identity.py"
 
 jobs:
   validate:
@@ -24,24 +28,5 @@ jobs:
       - name: Install jsonschema
         run: pip install jsonschema
 
-      - name: Validate against schema
-        run: |
-          python - <<'EOF'
-          import json
-          import jsonschema
-          import sys
-
-          with open(".github/workflows/models-ci-config-schema.json") as f:
-              schema = json.load(f)
-
-          with open(".github/workflows/models-ci-config.json") as f:
-              config = json.load(f)
-
-          try:
-              jsonschema.validate(instance=config, schema=schema)
-              print("✅ models-ci-config.json is valid")
-          except jsonschema.ValidationError as e:
-              print(f"❌ Validation failed: {e.message}")
-              print(f"   Path: {' -> '.join(str(p) for p in e.absolute_path)}")
-              sys.exit(1)
-          EOF
+      - name: Validate schema and implementation identities
+        run: python scripts/validate_models_ci_config.py

--- a/scripts/validate_models_ci_config.py
+++ b/scripts/validate_models_ci_config.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Validate Models CI schema and implementation-aware identities."""
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Iterable, List, Optional, Set, Tuple
+
+
+def iter_implementations(model_entry: dict) -> Iterable[dict]:
+    """Yield either the flat model entry or its implementation entries."""
+    yield from model_entry.get("implementations", [model_entry])
+
+
+def validate_implementation_identities(config: dict) -> List[str]:
+    """Return errors for ambiguous or duplicate per-model engine identities.
+
+    A single row for an inference engine may omit ``impl`` and select that
+    engine's default implementation. When an engine is repeated for a model,
+    every row must provide ``impl`` and each ``(engine, impl)`` pair must be
+    unique.
+    """
+    errors: List[str] = []
+    for model, model_entry in config.get("models", {}).items():
+        implementations = list(iter_implementations(model_entry))
+        engine_counts = Counter(
+            str(item.get("inference_engine", "")).casefold() for item in implementations
+        )
+        identities: Set[Tuple[str, Optional[str]]] = set()
+
+        for index, item in enumerate(implementations):
+            engine = str(item.get("inference_engine", "")).casefold()
+            impl = item.get("impl")
+            path = f"models.{model}.implementations[{index}]"
+
+            if engine_counts[engine] > 1 and impl is None:
+                errors.append(
+                    f"{path}: impl is required because inference_engine="
+                    f"{item.get('inference_engine')!r} appears more than once"
+                )
+
+            identity = (engine, impl)
+            if identity in identities:
+                errors.append(
+                    f"{path}: duplicate Models CI identity "
+                    f"(inference_engine={item.get('inference_engine')!r}, "
+                    f"impl={impl!r})"
+                )
+            identities.add(identity)
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path(".github/workflows/models-ci-config.json"),
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=Path(".github/workflows/models-ci-config-schema.json"),
+    )
+    args = parser.parse_args()
+
+    import jsonschema
+
+    config = json.loads(args.config.read_text())
+    schema = json.loads(args.schema.read_text())
+    try:
+        jsonschema.validate(instance=config, schema=schema)
+    except jsonschema.ValidationError as error:
+        print(f"ERROR: schema validation failed: {error.message}")
+        print("Path: " + " -> ".join(str(part) for part in error.absolute_path))
+        return 1
+
+    errors = validate_implementation_identities(config)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+
+    print("models-ci-config.json schema and implementation identities are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_models_ci_config_identity.py
+++ b/tests/test_models_ci_config_identity.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from scripts.validate_models_ci_config import validate_implementation_identities
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = json.loads(
+    (REPO_ROOT / ".github/workflows/models-ci-config-schema.json").read_text()
+)
+SCHEDULE = {"nightly": {"devices": ["P300X2"]}}
+
+
+def _config(model_entry):
+    return {"models": {"model": model_entry}}
+
+
+@pytest.mark.parametrize(
+    "model_entry",
+    [
+        {"inference_engine": "vLLM", "impl": "quetzal", "ci": SCHEDULE},
+        {
+            "implementations": [
+                {
+                    "inference_engine": "vLLM",
+                    "impl": "quetzal",
+                    "ci": SCHEDULE,
+                }
+            ]
+        },
+    ],
+)
+def test_schema_accepts_optional_impl_for_flat_and_implementation_rows(model_entry):
+    jsonschema.validate(_config(model_entry), SCHEMA)
+
+
+@pytest.mark.parametrize(
+    "model_entry",
+    [
+        {"inference_engine": "vLLM", "impl": "", "ci": SCHEDULE},
+        {"implementations": [{"inference_engine": "vLLM", "impl": "", "ci": SCHEDULE}]},
+    ],
+)
+def test_schema_rejects_empty_impl(model_entry):
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(_config(model_entry), SCHEMA)
+
+
+def test_semantics_allow_unqualified_distinct_engines():
+    config = _config(
+        {
+            "implementations": [
+                {"inference_engine": "vLLM", "ci": SCHEDULE},
+                {"inference_engine": "FORGE", "ci": SCHEDULE},
+            ]
+        }
+    )
+
+    assert validate_implementation_identities(config) == []
+
+
+def test_semantics_allow_distinct_impls_for_same_engine():
+    config = _config(
+        {
+            "implementations": [
+                {
+                    "inference_engine": "vLLM",
+                    "impl": "tt-transformers",
+                    "ci": SCHEDULE,
+                },
+                {
+                    "inference_engine": "vLLM",
+                    "impl": "quetzal",
+                    "ci": SCHEDULE,
+                },
+            ]
+        }
+    )
+
+    assert validate_implementation_identities(config) == []
+
+
+def test_semantics_reject_ambiguous_unqualified_same_engine_row():
+    config = _config(
+        {
+            "implementations": [
+                {"inference_engine": "vLLM", "ci": SCHEDULE},
+                {
+                    "inference_engine": "vLLM",
+                    "impl": "quetzal",
+                    "ci": SCHEDULE,
+                },
+            ]
+        }
+    )
+
+    errors = validate_implementation_identities(config)
+
+    assert len(errors) == 1
+    assert "impl is required" in errors[0]
+
+
+def test_semantics_reject_duplicate_same_engine_impl_identity():
+    row = {"inference_engine": "vLLM", "impl": "quetzal", "ci": SCHEDULE}
+    config = _config({"implementations": [row, row]})
+
+    errors = validate_implementation_identities(config)
+
+    assert len(errors) == 1
+    assert "duplicate Models CI identity" in errors[0]
+
+
+def test_repository_config_has_unambiguous_implementation_identities():
+    config = json.loads(
+        (REPO_ROOT / ".github/workflows/models-ci-config.json").read_text()
+    )
+
+    assert validate_implementation_identities(config) == []


### PR DESCRIPTION
## Summary

- allow an optional nonempty `impl` on flat and `implementations[]` Model CI entries
- require explicit implementation names when one model repeats the same inference engine
- reject duplicate `(inference_engine, impl)` identities
- run the semantic validator from the existing config-validation workflow

This is configuration vocabulary only. It does not enroll Quetzal, add image/storage behavior, or change any current Model CI row.

## Why

Quetzal and native TT implementations both use `inference_engine: vLLM`. Without a first-class implementation identity, the two lanes are ambiguous before the Shield matrix is generated.

## Validation

- `uv run --with jsonschema --with pytest python -m pytest -q tests/test_models_ci_config_identity.py` — 9 passed
- `uv run --with jsonschema python scripts/validate_models_ci_config.py` — current repository config valid
- `ruff check` and `ruff format --check` using the repository-pinned 0.15.0
- `git diff --check origin/main...HEAD`

Follow-ups will preserve this field in tt-shield and separately add image/package execution. No model enrollment belongs in this PR.
