### PR TITLE
feat(quetzal): admit immutable runtime bundles

### DIFF
--- a/tests/test_model_catalog_yaml.py
+++ b/tests/test_model_catalog_yaml.py
@@ -18,6 +18,7 @@ from workflows.model_spec import (
     _build_template,
     get_model_spec_map,
     load_templates_from_yaml,
+    quetzal_impl,
     tt_transformers_impl,
 )
 from workflows.workflow_types import (
@@ -33,6 +34,7 @@ from workflows.workflow_types import (
 def test_impl_registry_is_populated():
     """Every ImplSpec instance defined at module scope must be in _IMPL_REGISTRY."""
     assert _IMPL_REGISTRY["tt_transformers"] is tt_transformers_impl
+    assert _IMPL_REGISTRY["quetzal"] is quetzal_impl
     # impl_id of each registry entry must match its key
     for impl_id, impl in _IMPL_REGISTRY.items():
         assert impl.impl_id == impl_id

--- a/tests/test_run_vllm_api_server.py
+++ b/tests/test_run_vllm_api_server.py
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 import argparse
+import builtins
 import importlib.util
 import json
 import os
@@ -84,8 +85,272 @@ def run_vllm_api_server_module(monkeypatch):
 
     assert spec is not None
     assert spec.loader is not None
-    spec.loader.exec_module(module)
+    real_import = builtins.__import__
+    vllm_imports = []
+
+    def track_vllm_import(name, *args, **kwargs):
+        if name == "vllm" or name.startswith("vllm."):
+            vllm_imports.append(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", track_vllm_import)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        monkeypatch.setattr(builtins, "__import__", real_import)
+    assert vllm_imports == []
     return module
+
+
+def _install_artifact_discovery_module(monkeypatch, resolver):
+    serving = types.ModuleType("serving")
+    serving.__path__ = []
+    artifact_discovery = types.ModuleType("serving.artifact_discovery")
+    artifact_discovery.resolve_package_artifacts = resolver
+    monkeypatch.setitem(sys.modules, "serving", serving)
+    monkeypatch.setitem(sys.modules, "serving.artifact_discovery", artifact_discovery)
+
+
+def _quetzal_model_spec(**overrides):
+    spec = {
+        "hf_model_repo": "meta-llama/Llama-3.2-1B-Instruct",
+        "device_type": "P300X2",
+        "impl": {"impl_id": "quetzal"},
+        "device_model_spec": {
+            "max_context": 32768,
+            "max_concurrency": 1,
+            "vllm_args": {
+                "max_model_len": "32768",
+                "max_num_seqs": "1",
+                "revision": "9" * 40,
+                "tokenizer_revision": "9" * 40,
+            },
+        },
+    }
+    spec.update(overrides)
+    return spec
+
+
+def _quetzal_provider_env():
+    return {
+        "MESH_DEVICE": "P150x4",
+        "QUETZAL_VLLM": "1",
+        "VLLM_PLUGINS": "quetzal_model_registry,tt",
+    }
+
+
+def _set_quetzal_provider_runtime_env(monkeypatch, tmp_path):
+    weights = tmp_path / "hf-snapshot"
+    weights.mkdir()
+    monkeypatch.setenv("MESH_DEVICE", "P150x4")
+    monkeypatch.setenv("MODEL_WEIGHTS_DIR", str(weights))
+    for name in (
+        "PYTHONSAFEPATH",
+        "QUETZAL_HF_REVISION",
+        "QUETZAL_HF_SNAPSHOT",
+        "QUETZAL_MODEL",
+        "TT_VLLM_BUILTIN_MODELS",
+    ):
+        monkeypatch.setenv(name, "stale")
+    monkeypatch.setenv("QUETZAL_CONTEXT_LEN", "32768")
+    return weights
+
+
+def _set_quetzal_bundle_env(monkeypatch, root, manifest_sha256="a" * 64):
+    monkeypatch.setenv("QUETZAL_PACKAGE_ROOT", str(root))
+    monkeypatch.setenv("QUETZAL_BUNDLE_MANIFEST_SHA256", manifest_sha256)
+    monkeypatch.delenv("QUETZAL_AUXILIARY_ROOTS_JSON", raising=False)
+    monkeypatch.delenv("QUETZAL_CONTEXT_LEN", raising=False)
+
+
+def _quetzal_main_args():
+    return argparse.Namespace(
+        model="meta-llama/Llama-3.2-1B-Instruct",
+        tt_device="p300x2",
+        device=None,
+        engine=None,
+        impl="quetzal",
+        no_auth=False,
+        disable_trace_capture=False,
+        service_port=None,
+    )
+
+
+def test_configure_quetzal_provider_exports_exact_catalog_selection(
+    monkeypatch, tmp_path, run_vllm_api_server_module
+):
+    monkeypatch.setenv("QUETZAL_VLLM", "stale")
+    monkeypatch.setenv("VLLM_PLUGINS", "tt_model_registry,tt")
+    model_spec = _quetzal_model_spec(
+        env_vars=_quetzal_provider_env(),
+    )
+    weights = _set_quetzal_provider_runtime_env(monkeypatch, tmp_path)
+
+    run_vllm_api_server_module.configure_quetzal_provider(model_spec)
+
+    assert os.environ["QUETZAL_VLLM"] == "1"
+    assert os.environ["VLLM_PLUGINS"] == "quetzal_model_registry,tt"
+    assert os.environ["TT_VLLM_BUILTIN_MODELS"] == "0"
+    assert os.environ["PYTHONSAFEPATH"] == "1"
+    assert os.environ["QUETZAL_MODEL"] == model_spec["hf_model_repo"]
+    assert os.environ["QUETZAL_CONTEXT_LEN"] == "32768"
+    assert os.environ["QUETZAL_HF_REVISION"] == "9" * 40
+    assert os.environ["QUETZAL_HF_SNAPSHOT"] == str(weights.resolve())
+    assert os.environ["MESH_DEVICE"] == "P150x4"
+
+
+def test_configure_quetzal_provider_rejects_logical_mesh_for_physical_catalog(
+    monkeypatch, tmp_path, run_vllm_api_server_module
+):
+    model_spec = _quetzal_model_spec(env_vars=_quetzal_provider_env())
+    _set_quetzal_provider_runtime_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("MESH_DEVICE", "P300x2")
+
+    with pytest.raises(RuntimeError, match="physical mesh"):
+        run_vllm_api_server_module.configure_quetzal_provider(model_spec)
+
+
+@pytest.mark.parametrize(
+    "env_vars",
+    [
+        {"VLLM_PLUGINS": "quetzal_model_registry,tt"},
+        dict(QUETZAL_VLLM="1", VLLM_PLUGINS="tt_model_registry,tt"),
+    ],
+)
+def test_configure_quetzal_provider_rejects_missing_or_wrong_catalog_selection(
+    monkeypatch, tmp_path, run_vllm_api_server_module, env_vars
+):
+    _set_quetzal_provider_runtime_env(monkeypatch, tmp_path)
+    with pytest.raises(RuntimeError, match="QUETZAL_VLLM|VLLM_PLUGINS"):
+        run_vllm_api_server_module.configure_quetzal_provider(
+            _quetzal_model_spec(env_vars=env_vars)
+        )
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_error"),
+    [
+        ("root", "requires QUETZAL_PACKAGE_ROOT"),
+        ("symlink", "is not a directory"),
+        ("digest", "lowercase SHA-256"),
+        ("model", "canonical hf_model_repo"),
+        ("context", "context identity"),
+        ("batch", "max_concurrency=max_num_seqs=1"),
+        ("device", "does not support device_type"),
+        ("environment", "context identity"),
+        ("auxiliary", "QUETZAL_AUXILIARY_ROOTS_JSON"),
+    ],
+)
+def test_admit_quetzal_bundle_rejects_bad_selection(
+    monkeypatch, tmp_path, run_vllm_api_server_module, failure, expected_error
+):
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    _set_quetzal_bundle_env(monkeypatch, bundle)
+    spec = _quetzal_model_spec()
+    if failure == "root":
+        monkeypatch.delenv("QUETZAL_PACKAGE_ROOT")
+    elif failure == "symlink":
+        link = tmp_path / "link"
+        link.symlink_to(bundle, target_is_directory=True)
+        monkeypatch.setenv("QUETZAL_PACKAGE_ROOT", str(link))
+    elif failure == "digest":
+        monkeypatch.delenv("QUETZAL_BUNDLE_MANIFEST_SHA256")
+    elif failure == "model":
+        spec["hf_model_repo"] = ""
+    elif failure in ("context", "batch"):
+        key = "max_model_len" if failure == "context" else "max_num_seqs"
+        spec["device_model_spec"]["vllm_args"][key] = "2"
+    elif failure == "device":
+        spec["device_type"] = "N300"
+    elif failure == "environment":
+        monkeypatch.setenv("QUETZAL_CONTEXT_LEN", "8192")
+    else:
+        monkeypatch.setenv("QUETZAL_AUXILIARY_ROOTS_JSON", "not-json")
+
+    with pytest.raises(RuntimeError, match=expected_error):
+        run_vllm_api_server_module.admit_quetzal_bundle(spec)
+
+
+def test_admit_quetzal_bundle_calls_public_runtime_resolver(
+    monkeypatch, tmp_path, run_vllm_api_server_module
+):
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    _set_quetzal_bundle_env(monkeypatch, bundle)
+    manifest_sha256 = "1" * 64
+    monkeypatch.setenv("QUETZAL_BUNDLE_MANIFEST_SHA256", manifest_sha256)
+    auxiliary_root = tmp_path / "sha256-experts"
+    monkeypatch.setenv(
+        "QUETZAL_AUXILIARY_ROOTS_JSON", json.dumps({"experts": str(auxiliary_root)})
+    )
+    monkeypatch.setenv("QUETZAL_WEIGHTS", "/untrusted/legacy/weights.pt")
+    resolver = MagicMock(
+        return_value={
+            "schema": "ttq.artifact_bundle/v2",
+            "manifest_sha256": manifest_sha256,
+            "identity": {"model_id": "meta-llama/Llama-3.2-1B-Instruct"},
+            "auxiliary": {"references": 1},
+        }
+    )
+    _install_artifact_discovery_module(monkeypatch, resolver)
+    mock_logger = MagicMock()
+    monkeypatch.setattr(run_vllm_api_server_module, "logger", mock_logger)
+
+    run_vllm_api_server_module.admit_quetzal_bundle(_quetzal_model_spec())
+
+    resolver.assert_called_once_with(
+        bundle,
+        expected_manifest_sha256=manifest_sha256,
+        model_id="meta-llama/Llama-3.2-1B-Instruct",
+        context_len=32768,
+        expected_variant="p150x4",
+        expected_batch_size=1,
+        auxiliary_roots={"experts": str(auxiliary_root)},
+    )
+    assert "weights.pt" not in repr(resolver.call_args)
+    mock_logger.info.assert_called_once()
+
+
+def test_admit_quetzal_bundle_uses_catalog_package_fallback(
+    monkeypatch, tmp_path, run_vllm_api_server_module
+):
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    auxiliary_root = tmp_path / "sha256-experts"
+    manifest_sha256 = "2" * 64
+    for name in run_vllm_api_server_module.QUETZAL_EXTERNAL_PACKAGE_ENV:
+        monkeypatch.delenv(name, raising=False)
+    spec = _quetzal_model_spec(
+        env_vars={
+            **_quetzal_provider_env(),
+            "QUETZAL_PACKAGE_ROOT": str(bundle),
+            "QUETZAL_BUNDLE_MANIFEST_SHA256": manifest_sha256,
+            "QUETZAL_AUXILIARY_ROOTS_JSON": json.dumps(
+                {"experts": str(auxiliary_root)}
+            ),
+        }
+    )
+    resolver = MagicMock(
+        return_value={
+            "schema": "ttq.artifact_bundle/v2",
+            "manifest_sha256": manifest_sha256,
+            "auxiliary": {"references": 1},
+        }
+    )
+    _install_artifact_discovery_module(monkeypatch, resolver)
+
+    run_vllm_api_server_module.admit_quetzal_bundle(spec)
+
+    resolver.assert_called_once_with(
+        bundle,
+        expected_manifest_sha256=manifest_sha256,
+        model_id="meta-llama/Llama-3.2-1B-Instruct",
+        context_len=32768,
+        expected_variant="p150x4",
+        expected_batch_size=1,
+        auxiliary_roots={"experts": str(auxiliary_root)},
+    )
 
 
 @pytest.mark.parametrize("wrapped_catalog", [False, True])
@@ -326,6 +591,49 @@ def test_model_spec_can_disable_and_clear_inherited_metal_timeout(
     assert "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE" not in os.environ
 
 
+@pytest.mark.parametrize(
+    "selected_root",
+    [
+        None,
+        "/mnt/models/quetzal/package",
+        "/home/container_app_user/quetzal/package",
+    ],
+)
+def test_runtime_env_preserves_external_package_or_uses_catalog_fallback(
+    monkeypatch, run_vllm_api_server_module, selected_root
+):
+    if selected_root:
+        monkeypatch.setenv("QUETZAL_PACKAGE_ROOT", selected_root)
+        monkeypatch.setenv("QUETZAL_BUNDLE_MANIFEST_SHA256", "a" * 64)
+        monkeypatch.setenv(
+            "QUETZAL_AUXILIARY_ROOTS_JSON", '{"experts":"/external/experts"}'
+        )
+    else:
+        monkeypatch.delenv("QUETZAL_PACKAGE_ROOT", raising=False)
+        monkeypatch.delenv("QUETZAL_BUNDLE_MANIFEST_SHA256", raising=False)
+        monkeypatch.delenv("QUETZAL_AUXILIARY_ROOTS_JSON", raising=False)
+    model_spec = {
+        "impl": {"impl_id": "quetzal"},
+        "env_vars": {
+            "QUETZAL_PACKAGE_ROOT": "/catalog/package",
+            "QUETZAL_BUNDLE_MANIFEST_SHA256": "b" * 64,
+            "QUETZAL_AUXILIARY_ROOTS_JSON": '{"experts":"/catalog/experts"}',
+        },
+    }
+
+    run_vllm_api_server_module.set_runtime_env_vars(model_spec)
+
+    assert (
+        os.environ["QUETZAL_PACKAGE_ROOT"],
+        os.environ["QUETZAL_BUNDLE_MANIFEST_SHA256"],
+    ) == (selected_root or "/catalog/package", ("a" if selected_root else "b") * 64)
+    assert os.environ["QUETZAL_AUXILIARY_ROOTS_JSON"] == (
+        '{"experts":"/external/experts"}'
+        if selected_root
+        else '{"experts":"/catalog/experts"}'
+    )
+
+
 def test_main_passes_passthrough_port_to_trace_capture(
     monkeypatch, run_vllm_api_server_module
 ):
@@ -357,7 +665,8 @@ def test_main_passes_passthrough_port_to_trace_capture(
     monkeypatch.setattr(
         run_vllm_api_server_module, "ensure_weights_available", MagicMock()
     )
-    monkeypatch.setattr(run_vllm_api_server_module, "register_tt_models", MagicMock())
+    register = MagicMock()
+    monkeypatch.setattr(run_vllm_api_server_module, "register_tt_models", register)
     env_setup_order = []
     monkeypatch.setattr(
         run_vllm_api_server_module,
@@ -385,6 +694,84 @@ def test_main_passes_passthrough_port_to_trace_capture(
         service_port=9001,
     )
     assert env_setup_order == ["runtime_env", "metal_timeout"]
+    register.assert_called_once_with("tt-transformers")
+
+
+def test_main_admits_quetzal_bundle_before_startup_side_effects(
+    monkeypatch, run_vllm_api_server_module
+):
+    spec = _quetzal_model_spec(
+        model_id="id_quetzal_Llama-3.2-1B-Instruct_p300x2",
+        env_vars=_quetzal_provider_env(),
+    )
+    module = run_vllm_api_server_module
+    monkeypatch.setattr(module, "parse_args", lambda: (_quetzal_main_args(), []))
+    monkeypatch.setattr(module, "load_model_spec", lambda **_kwargs: spec)
+    monkeypatch.setattr(
+        module,
+        "admit_quetzal_bundle",
+        MagicMock(side_effect=RuntimeError("bundle admission failed")),
+    )
+    later = MagicMock()
+    for name in (
+        "set_cache_paths",
+        "ensure_weights_available",
+        "register_tt_models",
+        "set_runtime_env_vars",
+        "configure_quetzal_provider",
+    ):
+        monkeypatch.setattr(module, name, later)
+
+    with pytest.raises(RuntimeError, match="bundle admission failed"):
+        module.main()
+
+    later.assert_not_called()
+
+
+def test_main_skips_native_registration_for_quetzal(
+    monkeypatch, tmp_path, run_vllm_api_server_module
+):
+    spec = _quetzal_model_spec(
+        model_id="id_quetzal_Llama-3.2-1B-Instruct_p300x2",
+        env_vars=_quetzal_provider_env(),
+    )
+    module = run_vllm_api_server_module
+    monkeypatch.setenv("TT_CACHE_PATH", "/cache")
+    weights = _set_quetzal_provider_runtime_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(module, "parse_args", lambda: (_quetzal_main_args(), []))
+    monkeypatch.setattr(module, "load_model_spec", lambda **_kwargs: spec)
+    register = MagicMock()
+    monkeypatch.setattr(module, "register_tt_models", register)
+    for name in (
+        "admit_quetzal_bundle",
+        "set_runtime_env_vars",
+        "set_metal_timeout_env_vars",
+        "runtime_settings",
+        "set_vllm_sys_argv",
+        "start_trace_capture",
+    ):
+        monkeypatch.setattr(module, name, MagicMock())
+
+    def assert_complete_provider_identity(*_args, **_kwargs):
+        assert os.environ["QUETZAL_VLLM"] == "1"
+        assert os.environ["VLLM_PLUGINS"] == "quetzal_model_registry,tt"
+        assert os.environ["TT_VLLM_BUILTIN_MODELS"] == "0"
+        assert os.environ["PYTHONSAFEPATH"] == "1"
+        assert os.environ["QUETZAL_MODEL"] == spec["hf_model_repo"]
+        assert os.environ["QUETZAL_CONTEXT_LEN"] == "32768"
+        assert os.environ["QUETZAL_HF_REVISION"] == "9" * 40
+        assert os.environ["QUETZAL_HF_SNAPSHOT"] == str(weights)
+        assert os.environ["MESH_DEVICE"] == "P150x4"
+
+    run_module = MagicMock(side_effect=assert_complete_provider_identity)
+    monkeypatch.setattr(module.runpy, "run_module", run_module)
+
+    module.main()
+
+    register.assert_not_called()
+    run_module.assert_called_once_with(
+        "vllm.entrypoints.openai.api_server", run_name="__main__"
+    )
 
 
 def _weights_spec():

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -7,6 +7,7 @@ import json
 import logging
 import multiprocessing
 import os
+import re
 import runpy
 import shlex
 import sys
@@ -14,7 +15,6 @@ from pathlib import Path
 from typing import Optional
 
 from huggingface_hub import snapshot_download
-from vllm import ModelRegistry
 
 from utils.cache_monitor import get_container_cache_dir
 from utils.device_utils import get_mesh_device_name
@@ -33,6 +33,261 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_VLLM_SERVER_PORT = "8000"
+QUETZAL_IMPL_ID = "quetzal"
+QUETZAL_PROVIDER_ENV = {
+    "QUETZAL_VLLM": "1",
+    "PYTHONSAFEPATH": "1",
+    "TT_VLLM_BUILTIN_MODELS": "0",
+    "VLLM_PLUGINS": "quetzal_model_registry,tt",
+}
+QUETZAL_EXTERNAL_PACKAGE_ENV = {
+    "QUETZAL_PACKAGE_ROOT",
+    "QUETZAL_BUNDLE_MANIFEST_SHA256",
+    "QUETZAL_AUXILIARY_ROOTS_JSON",
+}
+QUETZAL_VARIANT_BY_DEVICE = {
+    "P150": "1chip",
+    "P150X4": "p150x4",
+    "P300X2": "p150x4",
+}
+
+
+def _model_spec_env_vars(model_spec: dict) -> dict:
+    """Merge catalog environment using the runtime's precedence rules."""
+    device_spec = model_spec.get("device_model_spec", {})
+    nested = (
+        device_spec.get("env_vars", {}) or {} if isinstance(device_spec, dict) else {}
+    )
+    return {**nested, **(model_spec.get("env_vars", {}) or {})}
+
+
+def _quetzal_package_selection(model_spec: dict) -> dict:
+    """Resolve package selectors with explicit launch values taking precedence."""
+    catalog_env = _model_spec_env_vars(model_spec)
+    selection = {}
+    for name in QUETZAL_EXTERNAL_PACKAGE_ENV:
+        value = os.getenv(name)
+        if value is None:
+            value = catalog_env.get(name)
+        if value is not None:
+            selection[name] = value
+    return selection
+
+
+def configure_quetzal_provider(model_spec: dict) -> None:
+    """Export complete generated-provider identity before vLLM is imported."""
+    if model_spec.get("impl", {}).get("impl_id") != QUETZAL_IMPL_ID:
+        return
+    env_vars = _model_spec_env_vars(model_spec)
+    for name in ("QUETZAL_VLLM", "VLLM_PLUGINS"):
+        expected = QUETZAL_PROVIDER_ENV[name]
+        actual = env_vars.get(name)
+        if actual != expected:
+            raise RuntimeError(
+                f"impl=quetzal requires catalog {name}={expected!r}, got {actual!r}"
+            )
+
+    model_id = model_spec.get("hf_model_repo")
+    if not isinstance(model_id, str) or not model_id.strip():
+        raise RuntimeError("impl=quetzal requires a canonical hf_model_repo")
+    context_len = _quetzal_runtime_context(model_spec)
+    vllm_args = model_spec.get("device_model_spec", {}).get("vllm_args", {})
+    revision = vllm_args.get("revision")
+    tokenizer_revision = vllm_args.get("tokenizer_revision")
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40}", revision):
+        raise RuntimeError(
+            "impl=quetzal requires vLLM revision as an immutable lowercase "
+            "40-hex commit"
+        )
+    if tokenizer_revision != revision:
+        raise RuntimeError("impl=quetzal requires tokenizer_revision to match revision")
+    device_type = model_spec.get("device_type")
+    if not isinstance(device_type, str) or not device_type:
+        raise RuntimeError("impl=quetzal requires a canonical device_type")
+    mesh_device = env_vars.get("MESH_DEVICE")
+    if not isinstance(mesh_device, str) or not mesh_device.strip():
+        raise RuntimeError(
+            "impl=quetzal requires a physical MESH_DEVICE in the catalog"
+        )
+    runtime_mesh_device = os.getenv("MESH_DEVICE")
+    if runtime_mesh_device != mesh_device:
+        raise RuntimeError(
+            "impl=quetzal requires runtime MESH_DEVICE to match the catalog "
+            f"physical mesh ({mesh_device!r}), got {runtime_mesh_device!r}"
+        )
+    weights_dir = os.getenv("MODEL_WEIGHTS_DIR")
+    if not weights_dir or not Path(weights_dir).is_absolute():
+        raise RuntimeError(
+            "impl=quetzal requires MODEL_WEIGHTS_DIR as an absolute snapshot path"
+        )
+
+    os.environ.update(QUETZAL_PROVIDER_ENV)
+    os.environ.update(
+        {
+            "QUETZAL_CONTEXT_LEN": str(context_len),
+            "QUETZAL_HF_REVISION": revision,
+            "QUETZAL_HF_SNAPSHOT": str(Path(weights_dir).resolve()),
+            "QUETZAL_MODEL": model_id,
+            "MESH_DEVICE": mesh_device,
+        }
+    )
+
+
+def _quetzal_auxiliary_roots(raw=None) -> Optional[dict]:
+    """Return the v2 auxiliary-name to immutable-root mapping, when present."""
+    if raw is None:
+        raw = os.getenv("QUETZAL_AUXILIARY_ROOTS_JSON", "")
+    if not isinstance(raw, str):
+        raise RuntimeError("QUETZAL_AUXILIARY_ROOTS_JSON must be a JSON string")
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        roots = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("QUETZAL_AUXILIARY_ROOTS_JSON is not valid JSON") from error
+    if (
+        not isinstance(roots, dict)
+        or not roots
+        or not all(
+            isinstance(name, str) and name and isinstance(path, str) and path
+            for name, path in roots.items()
+        )
+    ):
+        raise RuntimeError(
+            "QUETZAL_AUXILIARY_ROOTS_JSON must map auxiliary names to paths"
+        )
+    return roots
+
+
+def _quetzal_manifest_sha256(expected_sha256=None) -> str:
+    if expected_sha256 is None:
+        expected_sha256 = os.getenv("QUETZAL_BUNDLE_MANIFEST_SHA256", "")
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_sha256):
+        raise RuntimeError(
+            "impl=quetzal requires QUETZAL_BUNDLE_MANIFEST_SHA256 as a "
+            "lowercase SHA-256"
+        )
+    return expected_sha256
+
+
+def _quetzal_positive_int(value, name: str) -> int:
+    try:
+        value = int(value)
+    except (TypeError, ValueError) as error:
+        raise RuntimeError(f"impl=quetzal requires a positive {name}") from error
+    if value <= 0:
+        raise RuntimeError(f"impl=quetzal requires a positive {name}")
+    return value
+
+
+def _quetzal_runtime_context(model_spec: dict) -> int:
+    device_spec = model_spec.get("device_model_spec", {})
+    catalog_context = _quetzal_positive_int(
+        device_spec.get("max_context"), "max_context"
+    )
+    vllm_context = _quetzal_positive_int(
+        device_spec.get("vllm_args", {}).get("max_model_len", catalog_context),
+        "vLLM max_model_len",
+    )
+    inherited_context = os.getenv("QUETZAL_CONTEXT_LEN")
+    if inherited_context is not None:
+        inherited_context = _quetzal_positive_int(
+            inherited_context, "QUETZAL_CONTEXT_LEN"
+        )
+    if vllm_context != catalog_context or inherited_context not in (
+        None,
+        catalog_context,
+    ):
+        raise RuntimeError(
+            "impl=quetzal requires catalog, vLLM, and environment context identity "
+            "to match"
+        )
+    return catalog_context
+
+
+def _validate_quetzal_scheduler_capacity(model_spec: dict) -> None:
+    device_spec = model_spec.get("device_model_spec", {})
+    max_concurrency = _quetzal_positive_int(
+        device_spec.get("max_concurrency"), "max_concurrency"
+    )
+    max_num_seqs = _quetzal_positive_int(
+        device_spec.get("vllm_args", {}).get("max_num_seqs", max_concurrency),
+        "vLLM max_num_seqs",
+    )
+    if max_concurrency != 1 or max_num_seqs != 1:
+        raise RuntimeError(
+            "impl=quetzal currently requires max_concurrency=max_num_seqs=1"
+        )
+
+
+def _quetzal_variant(model_spec: dict) -> str:
+    device_type = model_spec.get("device_type")
+    if not isinstance(device_type, str):
+        raise RuntimeError("impl=quetzal requires a canonical device_type")
+    try:
+        return QUETZAL_VARIANT_BY_DEVICE[device_type.upper()]
+    except KeyError:
+        raise RuntimeError(
+            f"impl=quetzal does not support device_type={device_type!r}"
+        ) from None
+
+
+def admit_quetzal_bundle(model_spec: dict) -> None:
+    """Admit the selected Quetzal package before device use."""
+    if model_spec.get("impl", {}).get("impl_id") != QUETZAL_IMPL_ID:
+        return
+
+    selection = _quetzal_package_selection(model_spec)
+    package_root = selection.get("QUETZAL_PACKAGE_ROOT")
+    if not package_root:
+        raise RuntimeError(
+            "impl=quetzal requires QUETZAL_PACKAGE_ROOT (the content-addressed "
+            "package directory)"
+        )
+    root = Path(package_root)
+    if root.is_symlink() or not root.is_dir():
+        raise RuntimeError(f"QUETZAL_PACKAGE_ROOT is not a directory: {package_root}")
+
+    model_id = model_spec.get("hf_model_repo")
+    if not isinstance(model_id, str) or not model_id.strip():
+        raise RuntimeError("impl=quetzal requires a canonical hf_model_repo")
+
+    expected_sha256 = _quetzal_manifest_sha256(
+        selection.get("QUETZAL_BUNDLE_MANIFEST_SHA256")
+    )
+    context_len = _quetzal_runtime_context(model_spec)
+    _validate_quetzal_scheduler_capacity(model_spec)
+    expected_variant = _quetzal_variant(model_spec)
+    auxiliary_roots = _quetzal_auxiliary_roots(
+        selection.get("QUETZAL_AUXILIARY_ROOTS_JSON")
+    )
+    try:
+        from serving.artifact_discovery import resolve_package_artifacts
+    except Exception as error:  # pragma: no cover - depends on the runtime image
+        raise RuntimeError(
+            "impl=quetzal requires the tt-quetzalcoatlus serving package in the "
+            f"runtime image, but it could not be imported: {error}"
+        ) from error
+
+    result = resolve_package_artifacts(
+        root,
+        expected_manifest_sha256=expected_sha256,
+        model_id=model_id,
+        context_len=context_len,
+        expected_variant=expected_variant,
+        expected_batch_size=1,
+        auxiliary_roots=auxiliary_roots,
+    )
+    logger.info(
+        "Quetzal content-address admission succeeded: state=%s schema=%s files=%s "
+        "manifest_sha256=%s auxiliary=%s",
+        result.get("state"),
+        result.get("schema"),
+        result.get("total_files"),
+        result.get("manifest_sha256"),
+        result.get("auxiliary"),
+    )
 
 
 def parse_args():
@@ -358,6 +613,8 @@ def register_tt_models(impl_id=None):
                  "llama3_70b_galaxy", "qwen3_32b_galaxy"). If None, defaults to
                  "tt_transformers".
     """
+    from vllm import ModelRegistry
+
     impl_id = impl_id or "tt_transformers"
 
     # Llama path selection based on impl_id
@@ -548,25 +805,25 @@ def set_runtime_env_vars(model_spec_json):
 
     Both locations are checked and merged, with top-level taking precedence.
     """
-    env_vars = {}
-
-    # Check nested location first (device_model_spec.env_vars)
-    device_model_spec = model_spec_json.get("device_model_spec", {})
-    if isinstance(device_model_spec, dict):
-        nested_env_vars = device_model_spec.get("env_vars", {})
-        if nested_env_vars:
-            env_vars.update(nested_env_vars)
-
-    # Check top-level location (takes precedence)
-    top_level_env_vars = model_spec_json.get("env_vars", {})
-    if top_level_env_vars:
-        env_vars.update(top_level_env_vars)
+    env_vars = _model_spec_env_vars(model_spec_json)
+    preserve_package_env = (
+        model_spec_json.get("impl", {}).get("impl_id") == QUETZAL_IMPL_ID
+    )
 
     if not env_vars:
         logger.info("No env_vars found in model spec")
         return
 
     for key, value in env_vars.items():
+        if preserve_package_env and key in QUETZAL_EXTERNAL_PACKAGE_ENV:
+            selected = os.getenv(key)
+            if selected is not None:
+                logger.info(
+                    "preserving externally selected Quetzal package value: %s=%s",
+                    key,
+                    selected,
+                )
+                continue
         if not isinstance(key, str):
             key = str(key)
             logger.warning(
@@ -769,6 +1026,8 @@ def main():
     elif args.device:
         device_type = normalize_device_type(args.device)
 
+    admit_quetzal_bundle(model_spec)
+
     if device_type and not os.getenv("TT_CACHE_PATH"):
         set_cache_paths(model_spec, device_type)
     # NOTE: In multihost deployments, model weights are expected to reside on shared
@@ -783,7 +1042,8 @@ def main():
 
     # Step 3: Register TT models (after lookup, with correct impl_id)
     impl_id = model_spec.get("impl", {}).get("impl_id")
-    register_tt_models(impl_id)
+    if impl_id != QUETZAL_IMPL_ID:
+        register_tt_models(impl_id)
 
     # Step 4: Set runtime environment variables and vLLM server args
     set_runtime_env_vars(model_spec)
@@ -791,6 +1051,7 @@ def main():
     runtime_settings(model_spec, no_auth=args.no_auth)
     default_vllm_args = model_spec["device_model_spec"]["vllm_args"]
     set_vllm_sys_argv(args, remaining_sys_argv, default_vllm_args)
+    configure_quetzal_provider(model_spec)
 
     # Step 5: Start trace capture if needed
     start_trace_capture(

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -380,7 +380,15 @@ training_lora_impl = ImplSpec(
     code_path="tt-media-server/tt_model_runners/forge_training_runners/training_lora_runner.py",
 )
 
+quetzal_impl = ImplSpec(
+    impl_id="quetzal",
+    impl_name="quetzal",
+    repo_url="https://github.com/tenstorrent/tt-quetzalcoatlus",
+    code_path="serving",
+)
+
 _IMPL_REGISTRY: Dict[str, ImplSpec] = {
+    "quetzal": quetzal_impl,
     "tt_transformers": tt_transformers_impl,
     "llama3_70b_galaxy": llama3_70b_galaxy_impl,
     "qwen3_32b_galaxy": qwen3_32b_galaxy_impl,


### PR DESCRIPTION
## Summary

- register `quetzal` as a TTIS implementation without adding a model row
- perform fail-closed package admission through the public Quetzal package API before cache, weights, model registration, runtime, trace, or device startup
- derive provider identity generically from the selected model, context, batch, mesh, revision, and manifest digest
- bind the Quetzal provider before vLLM plugin discovery and prevent native model registration from shadowing it
- preserve an externally selected package root and digest; catalog values are fallback selectors only

This PR is the admission/runtime seam only. It excludes package mounting, image construction, catalog enrollment, eval configuration, and Shield wiring.

## Ownership and behavior contract

- TTIS selects the implementation and passes deployment identity
- Quetzal alone interprets and verifies portable or installed package layouts
- native implementations are unchanged
- missing, mutable, symlinked, incomplete, or digest-mismatched packages fail before device side effects
- package mode has no fallback to a broad artifact store or handwritten model
- no model-name or compiler-version special case is introduced

## Validation

- 266 directly affected tests pass on the final two-PR stack
- repository-pinned Ruff lint and format checks pass
- `git diff --check origin/main...HEAD` passes
- clean Exabox QB2 replay used this exact admission commit with the stacked mount commit
- the admitted C32768 Llama-3.2-1B package launched on P300X2, loaded only `quetzal_model_registry`, rebound `LlamaForCausalLM` to the generated Quetzal provider, reported health 200, and returned two deterministic temperature-zero probes

The QB2 replay is serving and collecting corrected eval evidence. This is launch/admission evidence, not a claim that the full Models CI qualification gate has completed.

This supersedes only the runtime/admission portion of #5092.
