### PR TITLE
Honor model context when selecting agentic evals

### DIFF
--- a/llm_module/eval_configs.py
+++ b/llm_module/eval_configs.py
@@ -2,15 +2,14 @@
 #
 # SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
 
-"""Select the standard (lm-eval / lmms-eval) eval tasks for an LLM model."""
+"""Select standard and agentic eval tasks for an LLM model."""
 
 from __future__ import annotations
 
 import logging
 from typing import List
 
-from workflow_module.engine_types import EvalLimitMode
-from workflow_module.engine_types import WorkflowVenvType
+from workflow_module.engine_types import EvalLimitMode, WorkflowVenvType
 
 from .eval_command import _get_limit_mode, _parse_eval_samples_mapping
 
@@ -25,6 +24,149 @@ _STANDARD_EVAL_VENVS = frozenset(
         WorkflowVenvType.EVALS_VISION,
     }
 )
+
+# Aliases accepted by --agentic-benchmark. Keep selection beside context
+# reachability so release planning and the runtime agentic runner cannot choose
+# different task sets.
+_AGENTIC_BENCHMARK_PREFIX_ALIASES = {
+    "tau3": "tau3_bench_",
+    "swebench": "swe_bench_",
+}
+_AGENTIC_BENCHMARK_EXACT_ALIASES = {
+    "tb2.0": "terminal_bench_2",
+    "tb2.1": "terminal_bench_2_1",
+}
+
+
+def parse_agentic_benchmark(value: str) -> tuple:
+    """Parse --agentic-benchmark into task-name prefix and exact matchers."""
+    prefixes: list[str] = []
+    exacts = set()
+    for token in (part.strip().lower() for part in value.split(",")):
+        if not token or token == "all":
+            continue
+        if token in _AGENTIC_BENCHMARK_PREFIX_ALIASES:
+            prefixes.append(_AGENTIC_BENCHMARK_PREFIX_ALIASES[token])
+        elif token in _AGENTIC_BENCHMARK_EXACT_ALIASES:
+            exacts.add(_AGENTIC_BENCHMARK_EXACT_ALIASES[token])
+        else:
+            exacts.add(token)
+    return prefixes, exacts
+
+
+def filter_agentic_tasks_by_benchmark(tasks: list, selection: str) -> list:
+    """Return exactly the configured agentic tasks selected by the CLI."""
+    prefixes, exacts = parse_agentic_benchmark(selection)
+    if not prefixes and not exacts:
+        return tasks
+    selected = [
+        task
+        for task in tasks
+        if task.task_name in exacts
+        or any(task.task_name.startswith(prefix) for prefix in prefixes)
+    ]
+    if not selected:
+        available = [task.task_name for task in tasks]
+        raise RuntimeError(
+            f"--agentic-benchmark {selection!r} matched no EVALS_AGENTIC tasks. "
+            f"Available for this model: {available}. Aliases: "
+            f"{sorted(_AGENTIC_BENCHMARK_PREFIX_ALIASES)} + "
+            f"{sorted(_AGENTIC_BENCHMARK_EXACT_ALIASES)}."
+        )
+    logger.info(
+        "--agentic-benchmark %r selected %d of %d agentic task(s): %s",
+        selection,
+        len(selected),
+        len(tasks),
+        [task.task_name for task in selected],
+    )
+    return selected
+
+
+def _positive_token_budget(value):
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return None
+
+
+def agentic_task_required_context(task):
+    """Return a task's declared per-request context envelope, if known.
+
+    SWE-bench declares its limits directly. TerminalBench places the same
+    fields in ``agent_kwargs.model_info``. ``min_context_required`` remains an
+    optional explicit floor and wins when it reserves more headroom than the
+    harness input/output envelope.
+
+    An incomplete legacy task has no derived envelope and remains reachable
+    unless it declares ``min_context_required``. This preserves existing tasks
+    while making every fully declared agentic contract context-aware.
+    """
+    explicit = _positive_token_budget(getattr(task, "min_context_required", None))
+    max_input = max_output = None
+
+    swebench = getattr(task, "swebench_eval_config", None)
+    terminal = getattr(task, "agentic_eval_config", None)
+    if swebench is not None:
+        max_input = _positive_token_budget(getattr(swebench, "max_input_tokens", None))
+        max_output = _positive_token_budget(
+            getattr(swebench, "max_output_tokens", None)
+        )
+    elif terminal is not None:
+        agent_kwargs = getattr(terminal, "agent_kwargs", None)
+        model_info = (
+            agent_kwargs.get("model_info") if isinstance(agent_kwargs, dict) else None
+        )
+        if isinstance(model_info, dict):
+            max_input = _positive_token_budget(model_info.get("max_input_tokens"))
+            max_output = _positive_token_budget(model_info.get("max_output_tokens"))
+
+    envelope = (
+        max_input + max_output
+        if max_input is not None and max_output is not None
+        else None
+    )
+    if explicit is None:
+        return envelope
+    if envelope is None:
+        return explicit
+    return max(explicit, envelope)
+
+
+def filter_reachable_agentic_tasks(tasks: list, model_spec) -> list:
+    """Drop agentic tasks whose request envelope exceeds device max context."""
+    available = getattr(
+        getattr(model_spec, "device_model_spec", None), "max_context", None
+    )
+    if not isinstance(available, int) or isinstance(available, bool):
+        return tasks
+
+    selected = []
+    for task in tasks:
+        required = agentic_task_required_context(task)
+        if required is not None and available < required:
+            logger.info(
+                "Skipping agentic eval task %s: device max_context=%d is below "
+                "its required request context=%d",
+                task.task_name,
+                available,
+                required,
+            )
+            continue
+        selected.append(task)
+    return selected
+
+
+def select_agentic_eval_tasks(tasks: list, model_spec, runtime_config=None) -> list:
+    """Apply agentic type, explicit benchmark, and context selection."""
+    agentic = [
+        task
+        for task in tasks
+        if task.workflow_venv_type == WorkflowVenvType.EVALS_AGENTIC
+    ]
+    selection = getattr(runtime_config, "agentic_benchmark", None)
+    if isinstance(selection, str) and selection.strip():
+        agentic = filter_agentic_tasks_by_benchmark(agentic, selection)
+    return filter_reachable_agentic_tasks(agentic, model_spec)
 
 
 def _select_tasks(tasks: list, runtime_config) -> list:
@@ -103,4 +245,11 @@ def get_llm_eval_tasks(model_spec, runtime_config=None, device=None) -> List:
     return _select_tasks(standard, runtime_config)
 
 
-__all__ = ["get_llm_eval_tasks"]
+__all__ = [
+    "agentic_task_required_context",
+    "filter_agentic_tasks_by_benchmark",
+    "filter_reachable_agentic_tasks",
+    "get_llm_eval_tasks",
+    "parse_agentic_benchmark",
+    "select_agentic_eval_tasks",
+]

--- a/test_module/llm_tests/agentic_eval_tests.py
+++ b/test_module/llm_tests/agentic_eval_tests.py
@@ -18,10 +18,15 @@ from llm_module import (
     ServerConnection,
     make_agentic_driver,
 )
+from llm_module.eval_configs import (
+    filter_agentic_tasks_by_benchmark,
+    parse_agentic_benchmark,
+    select_agentic_eval_tasks,
+)
 from report_module.schema import Block
 from utils.auth_helpers import setup_tests_auth
-from workflow_module.engine_types import WorkflowVenvType
 from workflow_module import accept_blocks
+from workflow_module.engine_types import WorkflowVenvType
 
 from .._test_common import sweep_envelope
 from ..context import MediaContext
@@ -29,67 +34,14 @@ from ..context import MediaContext
 logger = logging.getLogger(__name__)
 
 
-# Aliases accepted by --agentic-benchmark, mapped to the EVALS_AGENTIC task
-# names they select. ``_PREFIX_ALIASES`` match by task_name prefix (a family of
-# tasks, e.g. every tau3_bench_* variant); ``_EXACT_ALIASES`` match one task
-# exactly (tb2.0 must not also pick up terminal_bench_2_1).
-_AGENTIC_BENCHMARK_PREFIX_ALIASES = {
-    "tau3": "tau3_bench_",
-    "swebench": "swe_bench_",
-}
-_AGENTIC_BENCHMARK_EXACT_ALIASES = {
-    "tb2.0": "terminal_bench_2",
-    "tb2.1": "terminal_bench_2_1",
-}
-
-
+# Retain the private bridge names imported by existing focused tests while the
+# implementation lives at the shared selection boundary.
 def _parse_agentic_benchmark(value: str) -> tuple:
-    """Parse a comma-separated --agentic-benchmark value into (prefixes, exacts).
-
-    Recognized aliases map to task-name prefixes/exact names; anything else is
-    treated as a raw task name matched exactly. Returns empty matchers for
-    "all"/blank so callers can skip filtering.
-    """
-    prefixes: list[str] = []
-    exacts: set = set()
-    for token in (t.strip().lower() for t in value.split(",")):
-        if not token or token == "all":
-            continue
-        if token in _AGENTIC_BENCHMARK_PREFIX_ALIASES:
-            prefixes.append(_AGENTIC_BENCHMARK_PREFIX_ALIASES[token])
-        elif token in _AGENTIC_BENCHMARK_EXACT_ALIASES:
-            exacts.add(_AGENTIC_BENCHMARK_EXACT_ALIASES[token])
-        else:
-            exacts.add(token)
-    return prefixes, exacts
+    return parse_agentic_benchmark(value)
 
 
-def _filter_agentic_tasks_by_benchmark(agentic: list, selection: str) -> list:
-    """Keep only the EVALS_AGENTIC tasks selected by --agentic-benchmark."""
-    prefixes, exacts = _parse_agentic_benchmark(selection)
-    if not prefixes and not exacts:
-        return agentic
-    selected = [
-        t
-        for t in agentic
-        if t.task_name in exacts or any(t.task_name.startswith(p) for p in prefixes)
-    ]
-    if not selected:
-        available = [t.task_name for t in agentic]
-        raise RuntimeError(
-            f"--agentic-benchmark {selection!r} matched no EVALS_AGENTIC tasks. "
-            f"Available for this model: {available}. Aliases: "
-            f"{sorted(_AGENTIC_BENCHMARK_PREFIX_ALIASES)} + "
-            f"{sorted(_AGENTIC_BENCHMARK_EXACT_ALIASES)}."
-        )
-    logger.info(
-        "--agentic-benchmark %r selected %d of %d agentic task(s): %s",
-        selection,
-        len(selected),
-        len(agentic),
-        [t.task_name for t in selected],
-    )
-    return selected
+def _filter_agentic_tasks_by_benchmark(tasks: list, selection: str) -> list:
+    return filter_agentic_tasks_by_benchmark(tasks, selection)
 
 
 def _select_agentic_tasks(ctx: MediaContext) -> list:
@@ -104,12 +56,11 @@ def _select_agentic_tasks(ctx: MediaContext) -> list:
     would leave no way to run agentic evals in CI.
 
     When ``--agentic-benchmark`` is set, the agentic tasks are further narrowed
-    to the selected benchmark(s).
+    to the selected benchmark(s). Tasks whose declared input/output envelope
+    exceeds the selected device's max context are omitted in both the default
+    and explicit-selection paths.
     """
     tasks = getattr(ctx.all_params, "tasks", []) or []
-    agentic = [
-        t for t in tasks if t.workflow_venv_type == WorkflowVenvType.EVALS_AGENTIC
-    ]
     non_agentic = [
         t for t in tasks if t.workflow_venv_type != WorkflowVenvType.EVALS_AGENTIC
     ]
@@ -120,10 +71,11 @@ def _select_agentic_tasks(ctx: MediaContext) -> list:
             len(non_agentic),
             [t.task_name for t in non_agentic],
         )
-    selection = getattr(getattr(ctx, "runtime_config", None), "agentic_benchmark", None)
-    if isinstance(selection, str) and selection.strip():
-        agentic = _filter_agentic_tasks_by_benchmark(agentic, selection)
-    return agentic
+    return select_agentic_eval_tasks(
+        tasks,
+        ctx.model_spec,
+        getattr(ctx, "runtime_config", None),
+    )
 
 
 def _server_connection(ctx: MediaContext) -> ServerConnection:
@@ -205,15 +157,16 @@ def _require_openai_server(ctx: MediaContext) -> None:
 
 def run_llm_agentic_eval(ctx: MediaContext) -> List[Block]:
     """Run every EVALS_AGENTIC task for this model; return one Block per task."""
-    _configure_openai_env(ctx)
-    _require_openai_server(ctx)
-
     agentic_tasks = _select_agentic_tasks(ctx)
     if not agentic_tasks:
         raise RuntimeError(
-            f"No EVALS_AGENTIC tasks configured for {ctx.model_spec.model_name!r}. "
-            "Check reference_config/evals/eval_config.py."
+            "No context-reachable EVALS_AGENTIC tasks selected for "
+            f"{ctx.model_spec.model_name!r}. Check the task request envelopes "
+            "and DeviceModelSpec.max_context."
         )
+
+    _configure_openai_env(ctx)
+    _require_openai_server(ctx)
 
     runtime_config = getattr(ctx, "runtime_config", None)
     server = _server_connection(ctx)

--- a/tests/test_module/llm_tests/test_agentic_eval_tests.py
+++ b/tests/test_module/llm_tests/test_agentic_eval_tests.py
@@ -896,11 +896,21 @@ class TestAgenticLimitResolution:
 
 
 class TestSelectAgenticTasks:
-    def _ctx_with_tasks(self, tasks):
+    def _ctx_with_tasks(self, tasks, *, max_context=None, agentic_benchmark=None):
         ctx = MagicMock()
         ctx.all_params.tasks = tasks
         ctx.model_spec.model_name = "test-llm"
+        if max_context is not None:
+            ctx.model_spec.device_model_spec = SimpleNamespace(max_context=max_context)
+        ctx.runtime_config = SimpleNamespace(agentic_benchmark=agentic_benchmark)
         return ctx
+
+    @staticmethod
+    def _swe_192k_task():
+        task = _swebench_task()
+        task.swebench_eval_config.max_input_tokens = 160 * 1024
+        task.swebench_eval_config.max_output_tokens = 32 * 1024
+        return task
 
     def test_returns_only_agentic_tasks(self):
         t1 = _terminal_task()
@@ -925,6 +935,69 @@ class TestSelectAgenticTasks:
         ctx = self._ctx_with_tasks([t_agentic, t_other])
 
         assert _select_agentic_tasks(ctx) == [t_agentic]
+
+    def test_32k_context_excludes_192k_agentic_envelope(self):
+        task = self._swe_192k_task()
+
+        selected = _select_agentic_tasks(
+            self._ctx_with_tasks([task], max_context=32 * 1024)
+        )
+
+        assert selected == []
+
+    def test_sufficient_context_includes_192k_agentic_envelope(self):
+        task = self._swe_192k_task()
+
+        selected = _select_agentic_tasks(
+            self._ctx_with_tasks([task], max_context=192 * 1024)
+        )
+
+        assert selected == [task]
+
+    def test_exact_32768_token_envelope_is_reachable(self):
+        task = _swebench_task()
+        task.swebench_eval_config.max_input_tokens = 24 * 1024
+        task.swebench_eval_config.max_output_tokens = 8 * 1024
+
+        selected = _select_agentic_tasks(
+            self._ctx_with_tasks([task], max_context=32 * 1024)
+        )
+
+        assert selected == [task]
+
+    def test_32769_token_envelope_is_rejected_by_32768_context(self):
+        task = _swebench_task()
+        task.swebench_eval_config.max_input_tokens = 24 * 1024 + 1
+        task.swebench_eval_config.max_output_tokens = 8 * 1024
+
+        selected = _select_agentic_tasks(
+            self._ctx_with_tasks([task], max_context=32 * 1024)
+        )
+
+        assert selected == []
+
+    def test_native_256k_context_keeps_192k_agentic_task_reachable(self):
+        task = self._swe_192k_task()
+
+        selected = _select_agentic_tasks(
+            self._ctx_with_tasks([task], max_context=256 * 1024)
+        )
+
+        assert selected == [task]
+
+    def test_explicit_selection_uses_the_same_context_reachability(self):
+        terminal = _terminal_task()
+        swe = self._swe_192k_task()
+
+        selected = _select_agentic_tasks(
+            self._ctx_with_tasks(
+                [terminal, swe],
+                max_context=32 * 1024,
+                agentic_benchmark="swebench",
+            )
+        )
+
+        assert selected == []
 
 
 class TestAgenticBenchmarkSelection:

--- a/tests/workflow_module/test_release_workflow.py
+++ b/tests/workflow_module/test_release_workflow.py
@@ -116,6 +116,28 @@ class TestReleaseWorkflowChildSelection:
             "agentic",
         ]
 
+    def test_llm_omits_agentic_child_when_all_tasks_exceed_context(self):
+        ctx = _make_ctx(ModelType.LLM, agentic=True)
+        task = ctx.all_params.tasks[0]
+        task.task_name = "swe_bench_verified"
+        task.agentic_eval_config = None
+        task.swebench_eval_config = SimpleNamespace(
+            max_input_tokens=160 * 1024,
+            max_output_tokens=32 * 1024,
+        )
+        task.min_context_required = None
+        ctx.model_spec.device_model_spec = SimpleNamespace(max_context=32 * 1024)
+        ctx.runtime_config = SimpleNamespace(agentic_benchmark=None)
+
+        outcomes, classes, _acc, _meta = _run_release(ctx)
+
+        classes["agentic"].assert_not_called()
+        assert [outcome.task_type for outcome in outcomes] == [
+            "evals",
+            "benchmarks",
+            "spec_tests",
+        ]
+
     def test_agentic_traces_child_is_opt_in(self):
         """Without --agentic-traces the options are None, so no child runs: a
         full-mode replay is roughly an hour of profiling per configured run."""

--- a/tests/workflow_module/test_requirements_cli.py
+++ b/tests/workflow_module/test_requirements_cli.py
@@ -208,12 +208,15 @@ def test_dispatch_forwards_requirements_to_children(
         assert argv[argv.index("--requirements-json") + 1] == args.requirements_json
 
 
-def test_release_provisions_venvs_for_the_documents_evals(monkeypatch, restore_seams):
-    """The document's evals decide the venvs, not the (absent) catalog entry.
+def test_release_provisions_only_reachable_document_eval_venvs(
+    monkeypatch, restore_seams
+):
+    """The document's reachable evals decide the venvs.
 
-    The fixture asks for GPQA-Diamond plus two agentic harnesses, so a release
-    run has to build both the standard and the agentic eval venvs even though
-    the catalog has no eval config for this model at all.
+    The fixture asks for GPQA-Diamond plus two agentic harnesses, but declares a
+    128K context. The borrowed agentic templates require larger request
+    envelopes, so release provisions only the standard eval venv instead of
+    paying to install an agentic venv that cannot run.
     """
     import run
     from workflows.workflow_dispatch import _engine_dependency_venv_types
@@ -225,7 +228,7 @@ def test_release_provisions_venvs_for_the_documents_evals(monkeypatch, restore_s
         model_spec, WorkflowType.RELEASE, runtime_config
     )
     assert WorkflowVenvType.EVALS_COMMON in venv_types
-    assert WorkflowVenvType.EVALS_AGENTIC in venv_types
+    assert WorkflowVenvType.EVALS_AGENTIC not in venv_types
 
 
 def test_validation_accepts_the_off_catalog_requirements_model(

--- a/tests/workflows/test_workflow_dispatch_routing.py
+++ b/tests/workflows/test_workflow_dispatch_routing.py
@@ -155,7 +155,9 @@ def test_release_provisions_prefix_cache_and_spec_decode_venvs(monkeypatch):
         workflow_dispatch, "_llm_eval_venv_types", lambda ms, rc=None: []
     )
     monkeypatch.setattr(
-        workflow_dispatch, "_llm_release_includes_agentic", lambda ms: False
+        workflow_dispatch,
+        "_llm_release_includes_agentic",
+        lambda ms, rc=None: False,
     )
 
     venvs = workflow_dispatch._engine_dependency_venv_types(
@@ -177,7 +179,9 @@ def test_release_provisions_agentic_traces_venv_only_when_opted_in(monkeypatch):
         workflow_dispatch, "_llm_eval_venv_types", lambda ms, rc=None: []
     )
     monkeypatch.setattr(
-        workflow_dispatch, "_llm_release_includes_agentic", lambda ms: False
+        workflow_dispatch,
+        "_llm_release_includes_agentic",
+        lambda ms, rc=None: False,
     )
 
     opted_out = workflow_dispatch._engine_dependency_venv_types(
@@ -475,7 +479,9 @@ def test_release_child_forwards_the_metrics_urls(monkeypatch, tmp_path):
         workflow_dispatch, "get_default_workflow_root_log_dir", lambda: tmp_path
     )
     monkeypatch.setattr(
-        workflow_dispatch, "_llm_release_includes_agentic", lambda ms: False
+        workflow_dispatch,
+        "_llm_release_includes_agentic",
+        lambda ms, rc=None: False,
     )
 
     argv = workflow_dispatch.build_engine_commands(spec, rc, "/tmp/spec.json")[0].argv

--- a/workflow_module/workflows.py
+++ b/workflow_module/workflows.py
@@ -89,13 +89,16 @@ def _run_sweep_task(logger, label: str, run_sweep) -> TaskOutcome:
 
 
 def _has_agentic_tasks(ctx) -> bool:
-    """True if the run's eval tasks include any EVALS_AGENTIC task."""
-    from .engine_types import WorkflowVenvType
+    """True if this run selects at least one context-reachable agentic task."""
+    from llm_module.eval_configs import select_agentic_eval_tasks
 
     tasks = getattr(getattr(ctx, "all_params", None), "tasks", None) or []
-    return any(
-        getattr(t, "workflow_venv_type", None) == WorkflowVenvType.EVALS_AGENTIC
-        for t in tasks
+    return bool(
+        select_agentic_eval_tasks(
+            tasks,
+            ctx.model_spec,
+            getattr(ctx, "runtime_config", None),
+        )
     )
 
 

--- a/workflows/workflow_dispatch.py
+++ b/workflows/workflow_dispatch.py
@@ -114,7 +114,7 @@ def _eval_config_for(model_spec):
     return get_target_pack().eval_config(model_spec.model_name)
 
 
-def _llm_release_includes_agentic(model_spec) -> bool:
+def _llm_release_includes_agentic(model_spec, runtime_config=None) -> bool:
     """True if an LLM release should also run agentic evals.
 
     Agentic evals (Terminal-Bench-2 / SWE-bench Verified) now run in-process as
@@ -129,9 +129,9 @@ def _llm_release_includes_agentic(model_spec) -> bool:
     cfg = _eval_config_for(model_spec)
     if cfg is None:
         return False
-    return any(
-        task.workflow_venv_type == WorkflowVenvType.EVALS_AGENTIC for task in cfg.tasks
-    )
+    from llm_module.eval_configs import select_agentic_eval_tasks
+
+    return bool(select_agentic_eval_tasks(cfg.tasks, model_spec, runtime_config))
 
 
 def _is_llm_eval_run(wf, model_spec) -> bool:
@@ -774,7 +774,7 @@ def _engine_dependency_venv_types(
             venv_types.append(WorkflowVenvType.AGENTIC_TRACES)
         # The agentic release child resolves harbor/sweagent from the
         # EVALS_AGENTIC venv, so it must exist before the engine subprocess runs.
-        if _llm_release_includes_agentic(model_spec):
+        if _llm_release_includes_agentic(model_spec, runtime_config):
             venv_types.append(WorkflowVenvType.EVALS_AGENTIC)
     return venv_types
 


### PR DESCRIPTION
## Summary

- derive agentic request reachability from SWE-bench and TerminalBench input/output budgets
- use one selector for runtime tasks, explicit benchmark selection, release-child planning, and venv provisioning
- omit the release agentic child when no task fits the selected device context
- preserve existing incomplete legacy task declarations and add no model-specific policy

This is generic Model CI plumbing. It intentionally adds no Quetzal catalog row or evaluation task.

## Why

Current release selection can attach a 192K/232K agentic recipe to a smaller-context serve merely because the model name matches. This makes a 32K lane unrunnable and can also provision an agentic child that has no valid task. The standard eval path already filters by context; agentic selection needs the same property.

Boundary tests prove that a 24,576-input + 8,192-output task fits a 32,768 context exactly, while a 32,769-token envelope is omitted. A native-like 256K context continues to select the existing 192K task.

## Validation

```text
uv run --no-project --with-requirements requirements-dev.txt --with aiohttp \
  python -m pytest -q \
  tests/test_module/llm_tests/test_agentic_eval_tests.py \
  tests/workflow_module/test_release_workflow.py \
  tests/workflows/test_workflow_dispatch_routing.py \
  tests/test_module/llm_tests/test_llm_eval_tests.py

221 passed, 1 warning
```

Repo-pinned Ruff 0.15.0 E/F checks and format checks pass; `git diff --check` passes.
