### PR TITLE
Mount immutable Quetzal packages read-only

### DIFF
--- a/run.py
+++ b/run.py
@@ -411,6 +411,16 @@ def parse_arguments():
         "For --local-server, tensor cache/logs still use the host volume path.",
     )
     parser.add_argument(
+        "--quetzal-package-root",
+        type=str,
+        default=None,
+        help=(
+            "Host path to the selected immutable Quetzal package directory. "
+            "Required with --impl quetzal for Docker and local servers; Docker "
+            "mounts it read-only at the model spec's QUETZAL_PACKAGE_ROOT."
+        ),
+    )
+    parser.add_argument(
         "--custom-weights",
         type=str,
         default=None,
@@ -1019,6 +1029,7 @@ def format_cli_args_summary(runtime_config):
         f"  host_volume:                {runtime_config.host_volume}",
         f"  host_hf_cache:              {runtime_config.host_hf_cache}",
         f"  host_weights_dir:           {runtime_config.host_weights_dir}",
+        f"  quetzal_package_root:       {runtime_config.quetzal_package_root}",
         f"  custom_weights:             {runtime_config.custom_weights}"
         if runtime_config.custom_weights
         else None,
@@ -1063,7 +1074,11 @@ def resolve_runtime(args):
             f"{args.runtime_model_spec_json}"
         )
         model_spec = ModelSpec.from_json(args.runtime_model_spec_json)
-        runtime_config = RuntimeConfig.from_args(args)
+        runtime_config = RuntimeConfig.from_args(
+            args,
+            impl=model_spec.impl.impl_name,
+            engine=model_spec.inference_engine,
+        )
         if model_spec.hf_model_repo:
             args.model = model_spec.hf_model_repo
     else:
@@ -1127,6 +1142,16 @@ def resolve_runtime(args):
     runtime_config.runtime_model_spec = model_spec.get_serialized_dict()
 
     return runtime_config, model_spec
+
+
+def should_mount_runtime_model_spec(model_spec, runtime_config):
+    """Whether Docker must consume the exact spec resolved by this invocation."""
+    return bool(
+        runtime_config.dev_mode
+        or runtime_config.custom_weights
+        or runtime_config.runtime_model_spec_json
+        or model_spec.impl.impl_id == "quetzal"
+    )
 
 
 def handle_maintenance_args(args):
@@ -1237,9 +1262,10 @@ def main():
     server_launch = None
     if runtime_config.docker_server:
         docker_json_fpath = None
-        # dev mode and --custom-weights both need the container to use this spec
-        # rather than resolving --model against the baked catalog.
-        if runtime_config.dev_mode or runtime_config.custom_weights:
+        # A Quetzal launch must bind the exact host-resolved spec. The selected
+        # implementation can be absent from the image's baked catalog, and the
+        # immutable package identity belongs to this invocation.
+        if should_mount_runtime_model_spec(model_spec, runtime_config):
             docker_json_fpath = json_fpath
         if runtime_config.print_docker_cmd:
             if is_multihost_deployment(runtime_config):

--- a/tests/test_quetzal_package_mount.py
+++ b/tests/test_quetzal_package_mount.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from workflows.quetzal_package import resolve_quetzal_package_mount
+from workflows.run_docker_server import generate_docker_run_command
+from workflows.run_local_server import generate_local_run_command
+from workflows.runtime_config import RuntimeConfig
+
+CATALOG_ROOT = Path("/opt/quetzal/package")
+MANIFEST_SHA256 = "a" * 64
+
+
+def _make_package(tmp_path):
+    package = tmp_path / "sha256-test"
+    package.mkdir()
+    return package
+
+
+def _model_spec(impl_id="quetzal", env_vars=None):
+    return SimpleNamespace(
+        impl=SimpleNamespace(impl_id=impl_id, impl_name=impl_id),
+        env_vars={
+            "QUETZAL_PACKAGE_ROOT": str(CATALOG_ROOT),
+            "QUETZAL_BUNDLE_MANIFEST_SHA256": MANIFEST_SHA256,
+            "QUETZAL_WEIGHTS": "/legacy/weights.pt",
+            "VLLM_PLUGINS": "quetzal_model_registry,tt",
+        }
+        if env_vars is None
+        else env_vars,
+        model_name="TestModel",
+        hf_model_repo="test/TestModel",
+        inference_engine="vLLM",
+        model_type=SimpleNamespace(name="LLM"),
+        subdevice_type=None,
+        docker_image="ghcr.io/tenstorrent/tt-inference-server/test:latest",
+    )
+
+
+def _runtime(package, *, docker=False, local=False, impl="quetzal"):
+    return RuntimeConfig(
+        model="TestModel",
+        workflow="server",
+        device="p300x2",
+        impl=impl,
+        engine="vLLM",
+        docker_server=docker,
+        local_server=local,
+        quetzal_package_root=str(package),
+        tt_metal_home="/opt/tt-metal",
+    )
+
+
+def test_package_root_is_required_for_quetzal_server(tmp_path):
+    runtime = _runtime(tmp_path, docker=True)
+    runtime.quetzal_package_root = None
+
+    with pytest.raises(ValueError, match="requires --quetzal-package-root"):
+        resolve_quetzal_package_mount(_model_spec(), runtime)
+
+
+def test_package_root_is_rejected_for_native_impl(tmp_path):
+    package = _make_package(tmp_path)
+
+    with pytest.raises(ValueError, match="only valid with --impl quetzal"):
+        resolve_quetzal_package_mount(
+            _model_spec(impl_id="tt_transformers"),
+            _runtime(package, docker=True, impl="tt-transformers"),
+        )
+
+
+def test_package_root_rejects_symlink(tmp_path):
+    package = _make_package(tmp_path)
+    package_link = tmp_path / "package-link"
+    package_link.symlink_to(package, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="existing real directory"):
+        resolve_quetzal_package_mount(
+            _model_spec(), _runtime(package_link, docker=True)
+        )
+
+
+@pytest.mark.parametrize(
+    "env_vars, error",
+    [
+        ({"QUETZAL_BUNDLE_MANIFEST_SHA256": MANIFEST_SHA256}, "absolute"),
+        (
+            {
+                "QUETZAL_PACKAGE_ROOT": str(CATALOG_ROOT),
+                "QUETZAL_BUNDLE_MANIFEST_SHA256": "latest",
+            },
+            "lowercase SHA-256",
+        ),
+    ],
+)
+def test_package_root_requires_catalog_destination_and_digest(
+    tmp_path, env_vars, error
+):
+    package = _make_package(tmp_path)
+
+    with pytest.raises(ValueError, match=error):
+        resolve_quetzal_package_mount(
+            _model_spec(env_vars=env_vars), _runtime(package, docker=True)
+        )
+
+
+def test_docker_mounts_exact_package_readonly_and_exports_only_selection(tmp_path):
+    package = _make_package(tmp_path)
+    command, _ = generate_docker_run_command(
+        _model_spec(), _runtime(package, docker=True)
+    )
+
+    assert f"type=bind,src={package.resolve()},dst={CATALOG_ROOT},readonly" in command
+    env_settings = {
+        command[index + 1] for index, value in enumerate(command[:-1]) if value == "-e"
+    }
+    assert f"QUETZAL_PACKAGE_ROOT={CATALOG_ROOT}" in env_settings
+    assert f"QUETZAL_BUNDLE_MANIFEST_SHA256={MANIFEST_SHA256}" in env_settings
+    assert not any(value.startswith("QUETZAL_WEIGHTS=") for value in env_settings)
+    assert not any(value.startswith("VLLM_PLUGINS=") for value in env_settings)
+    assert command[command.index("--impl") + 1] == "quetzal"
+
+
+def test_docker_uses_model_spec_impl_when_runtime_json_omits_cli_impl(tmp_path):
+    package = _make_package(tmp_path)
+    runtime = _runtime(package, docker=True, impl=None)
+
+    command, _ = generate_docker_run_command(_model_spec(), runtime)
+
+    assert command[command.index("--impl") + 1] == "quetzal"
+
+
+def test_printable_docker_command_contains_readonly_package_mount(tmp_path):
+    package = _make_package(tmp_path)
+    command, _ = generate_docker_run_command(
+        _model_spec(), _runtime(package, docker=True), str_cmd=True
+    )
+
+    assert "--mount" in command
+    assert f"src={package.resolve()},dst={CATALOG_ROOT},readonly" in command
+
+
+def test_local_server_selects_host_package_without_asset_fanout(tmp_path, monkeypatch):
+    monkeypatch.delenv("QUETZAL_WEIGHTS", raising=False)
+    package = _make_package(tmp_path)
+    tt_metal_home = tmp_path / "tt-metal"
+    runtime = _runtime(package, local=True)
+    runtime.tt_metal_home = str(tt_metal_home)
+    cache_root = tmp_path / "persistent" / "model-cache"
+    setup_config = SimpleNamespace(
+        host_model_volume_root=cache_root,
+        host_tt_metal_cache_dir=cache_root / "tt_metal_cache" / "cache_TestModel",
+        persistent_volume_root=cache_root.parent,
+        host_weights_dir=None,
+        host_hf_cache=None,
+        host_model_weights_snapshot_dir=None,
+        host_model_weights_mount_dir=None,
+    )
+    runtime_json = tmp_path / "runtime.json"
+    runtime_json.write_text("{}")
+
+    command, env, _ = generate_local_run_command(
+        _model_spec(), runtime, runtime_json, setup_config, repo_root=tmp_path
+    )
+
+    assert env["QUETZAL_PACKAGE_ROOT"] == str(package.resolve())
+    assert env["QUETZAL_BUNDLE_MANIFEST_SHA256"] == MANIFEST_SHA256
+    assert "QUETZAL_WEIGHTS" not in env
+    assert command[command.index("--impl") + 1] == "quetzal"
+    assert "--quetzal-package-root" not in command
+
+
+def test_local_server_uses_model_spec_impl_when_runtime_json_omits_cli_impl(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("QUETZAL_WEIGHTS", raising=False)
+    package = _make_package(tmp_path)
+    runtime = _runtime(package, local=True, impl=None)
+    runtime.tt_metal_home = str(tmp_path / "tt-metal")
+    cache_root = tmp_path / "persistent" / "model-cache"
+    setup_config = SimpleNamespace(
+        host_model_volume_root=cache_root,
+        host_tt_metal_cache_dir=cache_root / "tt_metal_cache" / "cache_TestModel",
+        persistent_volume_root=cache_root.parent,
+        host_weights_dir=None,
+        host_hf_cache=None,
+        host_model_weights_snapshot_dir=None,
+        host_model_weights_mount_dir=None,
+    )
+    runtime_json = tmp_path / "runtime.json"
+    runtime_json.write_text("{}")
+
+    command, _, _ = generate_local_run_command(
+        _model_spec(), runtime, runtime_json, setup_config, repo_root=tmp_path
+    )
+
+    assert command[command.index("--impl") + 1] == "quetzal"

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -20,6 +20,8 @@ from run import (
     handle_secrets,
     get_current_commit_sha,
     populate_model_spec_cli_args,
+    resolve_runtime,
+    should_mount_runtime_model_spec,
 )
 from workflows.validate_setup import (
     validate_runtime_args,
@@ -113,6 +115,48 @@ def mock_model_spec():
     mock_spec.to_json.return_value = "/tmp/test-model-spec.json"
 
     return mock_spec
+
+
+def test_quetzal_docker_always_mounts_resolved_runtime_spec(
+    mock_model_spec, mock_runtime_config
+):
+    mock_model_spec.impl.impl_id = "quetzal"
+    mock_runtime_config.dev_mode = False
+    mock_runtime_config.custom_weights = None
+    mock_runtime_config.runtime_model_spec_json = None
+
+    assert should_mount_runtime_model_spec(mock_model_spec, mock_runtime_config)
+
+
+def test_native_catalog_docker_can_use_baked_runtime_spec(
+    mock_model_spec, mock_runtime_config
+):
+    mock_model_spec.impl.impl_id = "tt_transformers"
+    mock_runtime_config.dev_mode = False
+    mock_runtime_config.custom_weights = None
+    mock_runtime_config.runtime_model_spec_json = None
+
+    assert not should_mount_runtime_model_spec(mock_model_spec, mock_runtime_config)
+
+
+def test_runtime_json_resolves_impl_and_engine_from_model_spec(
+    mock_args, mock_model_spec
+):
+    mock_args.runtime_model_spec_json = "/tmp/runtime-model-spec.json"
+    mock_args.impl = None
+    mock_args.engine = None
+    mock_model_spec.impl.impl_name = "quetzal"
+    mock_model_spec.inference_engine = "vLLM"
+    runtime_config = MagicMock()
+
+    with patch("run.ModelSpec.from_json", return_value=mock_model_spec), patch(
+        "run.RuntimeConfig.from_args", return_value=runtime_config
+    ) as from_args, patch("run.populate_model_spec_cli_args"):
+        resolved_runtime, resolved_spec = resolve_runtime(mock_args)
+
+    from_args.assert_called_once_with(mock_args, impl="quetzal", engine="vLLM")
+    assert resolved_runtime is runtime_config
+    assert resolved_spec is mock_model_spec
 
 
 @pytest.fixture
@@ -593,6 +637,17 @@ class TestModelSpecCliArgsCompatibility:
         assert args.host_volume == "/some/path"
         assert args.host_hf_cache == "/home/user/.cache/huggingface"
         assert args.image_user == "15863"
+
+    def test_quetzal_package_root_parsing(self, base_args):
+        with patch(
+            "sys.argv",
+            ["run.py"]
+            + base_args
+            + ["--quetzal-package-root", "/mnt/models/sha256-package"],
+        ):
+            args = parse_arguments()
+
+        assert args.quetzal_package_root == "/mnt/models/sha256-package"
 
 
 class TestArgsInference:

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -169,6 +169,7 @@ class TestValidateBindMountPermissions:
             "host_volume": None,
             "host_hf_cache": None,
             "host_weights_dir": None,
+            "quetzal_package_root": None,
         }
         defaults.update(overrides)
         return Namespace(**defaults)
@@ -253,6 +254,21 @@ class TestValidateBindMountPermissions:
         d.mkdir()
         args = self._make_args(host_weights_dir=str(d))
         validate_bind_mount_permissions(args)
+
+    def test_quetzal_package_mount_requires_read_only_access(self, tmp_path):
+        package = tmp_path / "package"
+        package.mkdir()
+        args = self._make_args(quetzal_package_root=str(package))
+
+        with patch(
+            "workflows.validate_setup.check_path_permissions_for_uid",
+            return_value=(True, ""),
+        ) as check_permissions:
+            validate_bind_mount_permissions(args)
+
+        check_permissions.assert_called_once_with(
+            str(package), os.getuid(), need_write=False
+        )
 
     def test_host_weights_dir_not_readable_raises_when_fix_fails(self, tmp_path):
         d = tmp_path / "weights_noperm"

--- a/workflows/quetzal_package.py
+++ b/workflows/quetzal_package.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Host-to-container mount contract for an immutable Quetzal package."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+QUETZAL_IMPL_ID = "quetzal"
+QUETZAL_PACKAGE_ROOT_ENV = "QUETZAL_PACKAGE_ROOT"
+QUETZAL_MANIFEST_SHA256_ENV = "QUETZAL_BUNDLE_MANIFEST_SHA256"
+
+
+@dataclass(frozen=True)
+class QuetzalPackageMount:
+    host_root: Path
+    runtime_root: Path
+    manifest_sha256: str
+
+
+def _is_quetzal(model_spec) -> bool:
+    return (
+        getattr(getattr(model_spec, "impl", None), "impl_id", None) == QUETZAL_IMPL_ID
+    )
+
+
+def resolve_quetzal_package_mount(
+    model_spec, runtime_config
+) -> Optional[QuetzalPackageMount]:
+    """Validate and resolve a host package and its catalog runtime location."""
+    configured = getattr(runtime_config, "quetzal_package_root", None)
+    is_quetzal = _is_quetzal(model_spec)
+    launches_server = bool(
+        getattr(runtime_config, "docker_server", False)
+        or getattr(runtime_config, "local_server", False)
+    )
+
+    if configured and not is_quetzal:
+        raise ValueError("--quetzal-package-root is only valid with --impl quetzal")
+    if configured and not launches_server:
+        raise ValueError(
+            "--quetzal-package-root requires --docker-server or --local-server"
+        )
+    if is_quetzal and launches_server and not configured:
+        raise ValueError("--impl quetzal requires --quetzal-package-root")
+    if not configured:
+        return None
+
+    supplied = Path(configured).expanduser()
+    if supplied.is_symlink() or not supplied.is_dir():
+        raise ValueError(
+            f"--quetzal-package-root must be an existing real directory: {supplied}"
+        )
+    host_root = supplied.resolve()
+
+    env_vars = model_spec.env_vars
+    runtime_root_value = env_vars.get(QUETZAL_PACKAGE_ROOT_ENV)
+    if not runtime_root_value:
+        raise ValueError(
+            "impl=quetzal model spec must define an absolute QUETZAL_PACKAGE_ROOT"
+        )
+    runtime_root = Path(runtime_root_value)
+    if not runtime_root.is_absolute() or runtime_root == Path("/"):
+        raise ValueError(
+            "impl=quetzal model spec must define a non-root absolute "
+            f"QUETZAL_PACKAGE_ROOT: {runtime_root_value}"
+        )
+
+    expected_sha256 = env_vars.get(QUETZAL_MANIFEST_SHA256_ENV, "")
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_sha256):
+        raise ValueError(
+            "impl=quetzal model spec must define "
+            "QUETZAL_BUNDLE_MANIFEST_SHA256 as a lowercase SHA-256"
+        )
+    return QuetzalPackageMount(
+        host_root=host_root,
+        runtime_root=runtime_root,
+        manifest_sha256=expected_sha256,
+    )
+
+
+def quetzal_package_env(
+    package: QuetzalPackageMount, *, local_server: bool
+) -> dict[str, str]:
+    """Return only the two values that select the admitted package."""
+    package_root = package.host_root if local_server else package.runtime_root
+    return {
+        QUETZAL_PACKAGE_ROOT_ENV: str(package_root),
+        QUETZAL_MANIFEST_SHA256_ENV: package.manifest_sha256,
+    }

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -25,6 +25,10 @@ from workflows.multihost_orchestrator import (
     is_multihost_deployment,
     setup_multihost_config,
 )
+from workflows.quetzal_package import (
+    quetzal_package_env,
+    resolve_quetzal_package_mount,
+)
 from workflows.utils import (
     default_dotenv_path,
     ensure_readwriteable_dir,
@@ -336,6 +340,7 @@ _RESERVED_WRAPPER_FLAGS = {
     "service-port",
     "port",
     "host",
+    "quetzal-package-root",
 }
 
 
@@ -428,6 +433,7 @@ def generate_docker_run_command(
     device = DeviceTypes.from_string(runtime_config.device)
     mesh_device_str = device.to_mesh_device_str()
     container_name = f"tt-inference-server-{short_uuid()}"
+    quetzal_package_mount = resolve_quetzal_package_mount(model_spec, runtime_config)
 
     # TODO: remove this once https://github.com/tenstorrent/tt-metal/issues/23785 has been closed
     device_cache_dir = (
@@ -492,11 +498,23 @@ def generate_docker_run_command(
             "--mount", f"type=bind,src={setup_config.host_model_weights_mount_dir},dst={setup_config.container_model_weights_mount_dir},readonly"
         ])
 
+    if quetzal_package_mount:
+        docker_command.extend([
+            "--mount",
+            "type=bind,"
+            f"src={quetzal_package_mount.host_root},"
+            f"dst={quetzal_package_mount.runtime_root},readonly",
+        ])
+
     if runtime_config.interactive:
         docker_command.append("-itd")
     # fmt: on
 
     docker_env_vars = {}
+    if quetzal_package_mount:
+        docker_env_vars.update(
+            quetzal_package_env(quetzal_package_mount, local_server=False)
+        )
     if setup_config:
         if (
             setup_config.container_model_weights_path
@@ -607,6 +625,8 @@ def generate_docker_run_command(
     if model_spec.inference_engine == InferenceEngine.VLLM.value:
         docker_command.extend(["--model", model_spec.hf_model_repo])
         docker_command.extend(["--tt-device", runtime_config.device])
+        if quetzal_package_mount:
+            docker_command.extend(["--impl", model_spec.impl.impl_name])
         if runtime_config.no_auth:
             docker_command.append("--no-auth")
         if runtime_config.disable_trace_capture:

--- a/workflows/run_local_server.py
+++ b/workflows/run_local_server.py
@@ -16,6 +16,10 @@ from pathlib import Path
 
 from workflows.bootstrap_uv import UV_EXEC
 from workflows.log_setup import clean_log_file
+from workflows.quetzal_package import (
+    quetzal_package_env,
+    resolve_quetzal_package_mount,
+)
 from workflows.setup_host import SetupConfig
 from workflows.utils import (
     ensure_readwriteable_dir,
@@ -164,6 +168,10 @@ def build_local_server_env(
     env["TT_METAL_LOGS_PATH"] = str(logs_path)
     env["RUNTIME_MODEL_SPEC_JSON_PATH"] = str(Path(json_fpath).resolve())
 
+    quetzal_package_mount = resolve_quetzal_package_mount(model_spec, runtime_config)
+    if quetzal_package_mount:
+        env.update(quetzal_package_env(quetzal_package_mount, local_server=True))
+
     if setup_config.host_weights_dir:
         env["MODEL_WEIGHTS_DIR"] = str(
             Path(setup_config.host_model_weights_mount_dir).resolve()
@@ -202,6 +210,7 @@ def generate_local_run_command(
             "--local-server currently supports only vLLM-backed model specs."
         )
 
+    quetzal_package_mount = resolve_quetzal_package_mount(model_spec, runtime_config)
     paths = get_local_server_paths(runtime_config, repo_root=repo_root)
     env = build_local_server_env(
         model_spec,
@@ -220,6 +229,8 @@ def generate_local_run_command(
         runtime_config.device,
     ]
 
+    if quetzal_package_mount:
+        command.extend(["--impl", model_spec.impl.impl_name])
     if runtime_config.no_auth:
         command.append("--no-auth")
     if runtime_config.disable_trace_capture:

--- a/workflows/runtime_config.py
+++ b/workflows/runtime_config.py
@@ -121,6 +121,8 @@ class RuntimeConfig:
     host_volume: Optional[str] = None
     host_hf_cache: Optional[str] = None
     host_weights_dir: Optional[str] = None
+    # Host path to the selected immutable Quetzal package directory.
+    quetzal_package_root: Optional[str] = None
     # Label giving custom weights a distinct identity; see derive_custom_weights_spec.
     custom_weights: Optional[str] = None
     image_user: str = "1000"
@@ -221,6 +223,7 @@ class RuntimeConfig:
             host_volume=args.host_volume,
             host_hf_cache=args.host_hf_cache,
             host_weights_dir=args.host_weights_dir,
+            quetzal_package_root=getattr(args, "quetzal_package_root", None),
             custom_weights=getattr(args, "custom_weights", None),
             image_user=args.image_user,
             skip_system_sw_validation=args.skip_system_sw_validation,

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -8,8 +8,8 @@ import stat
 from pathlib import Path
 
 from reference_config.benchmarking.benchmark_config import get_benchmark_config
-from workflows.workflow_dispatch import can_dispatch_to_engine
 from workflows.model_spec import MODEL_SPECS
+from workflows.quetzal_package import resolve_quetzal_package_mount
 from workflows.utils import (
     MIN_SUPPORTED_IMAGE_VERSION,
     check_path_permissions_for_uid,
@@ -27,6 +27,7 @@ from workflows.workflow_types import (
     WorkflowType,
     WorkflowVenvType,
 )
+from workflows.workflow_dispatch import can_dispatch_to_engine
 from workflows.workflow_venvs import VENV_CONFIGS
 
 logger = logging.getLogger("run_log")
@@ -138,6 +139,7 @@ def validate_runtime_args(model_spec, runtime_config):
     assert not (args.docker_server and args.local_server), (
         "Cannot run --docker-server and --local-server"
     )
+    resolve_quetzal_package_mount(model_spec, runtime_config)
 
     if workflow_type == WorkflowType.EVALS:
         assert _has_eval_config(model_spec.hf_model_repo), (
@@ -502,6 +504,8 @@ def validate_bind_mount_permissions(args):
         checks.append(("--host-hf-cache", args.host_hf_cache, False))
     if getattr(args, "host_weights_dir", None):
         checks.append(("--host-weights-dir", args.host_weights_dir, False))
+    if getattr(args, "quetzal_package_root", None):
+        checks.append(("--quetzal-package-root", args.quetzal_package_root, False))
 
     for flag, host_path, need_write in checks:
         ok, reason = check_path_permissions_for_uid(


### PR DESCRIPTION
## Summary

- add one supported host input: `--quetzal-package-root <selected-package-dir>`
- pass only `QUETZAL_PACKAGE_ROOT` and `QUETZAL_BUNDLE_MANIFEST_SHA256` as package selectors
- mount exactly that selected package read-only at the catalog-declared runtime root for Docker
- use the exact selected host package for trusted local-server validation
- forward `--impl quetzal`
- make `--print-docker-cmd` expose the exact mount and environment contract
- reject missing roots, native misuse, symlink roots, malformed identity, and path escape

This PR deliberately excludes broad `/mnt/models` mounts, loose artifact fanout, TTIS-owned manifest parsing, path rebasing, image construction, catalog enrollment, and Shield wiring.

## Stack

This PR is intentionally stacked on #5096. GitHub therefore shows only the immutable package handoff and mount layer here.

## Validation

- 266 directly affected tests pass on the final two-commit stack
- repository-pinned Ruff lint and format checks pass
- `git diff --check` passes
- the printed Docker command is covered for one exact read-only package mount with no broad models mount
- clean Exabox QB2 local-server replay used this exact commit with #5096
- the selected C32768 package served Llama-3.2-1B on P300X2 with health 200 and exact generated-provider identity

The local-server replay is trusted pre-submit evidence. The final container/image and Shield dispatch receipts remain separate downstream gates.
