### PR TITLE
Resolve pinned Hugging Face snapshots offline

### DIFF
--- a/tests/test_run_vllm_api_server.py
+++ b/tests/test_run_vllm_api_server.py
@@ -747,7 +747,55 @@ def _weights_spec():
     return {
         "model_name": "Mistral-7B-Instruct-v0.3",
         "hf_model_repo": "mistralai/Mistral-7B-Instruct-v0.3",
+        "device_model_spec": {"vllm_args": {"revision": "pinned-revision"}},
     }
+
+
+def test_ensure_weights_available_resolves_pinned_offline_snapshot(
+    monkeypatch, tmp_path, run_vllm_api_server_module
+):
+    monkeypatch.delenv("MODEL_WEIGHTS_DIR", raising=False)
+    monkeypatch.setenv("HF_HOME", str(tmp_path / "huggingface"))
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
+    snapshot_path = tmp_path / "huggingface" / "hub" / "cached-snapshot"
+    run_vllm_api_server_module.snapshot_download.return_value = str(snapshot_path)
+    spec = _weights_spec()
+
+    result = run_vllm_api_server_module.ensure_weights_available(spec)
+
+    run_vllm_api_server_module.snapshot_download.assert_called_once_with(
+        repo_id=spec["hf_model_repo"],
+        revision="pinned-revision",
+        local_files_only=True,
+    )
+    assert result == snapshot_path
+    assert os.environ["MODEL_WEIGHTS_DIR"] == str(snapshot_path)
+
+
+def test_ensure_weights_available_reports_pinned_offline_cache_miss(
+    monkeypatch, tmp_path, run_vllm_api_server_module
+):
+    monkeypatch.delenv("MODEL_WEIGHTS_DIR", raising=False)
+    monkeypatch.setenv("HF_HOME", str(tmp_path / "huggingface"))
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "true")
+    run_vllm_api_server_module.snapshot_download.side_effect = RuntimeError(
+        "snapshot absent"
+    )
+    spec = _weights_spec()
+
+    with pytest.raises(RuntimeError) as error:
+        run_vllm_api_server_module.ensure_weights_available(spec)
+
+    message = str(error.value)
+    assert f"{spec['hf_model_repo']}@pinned-revision" in message
+    assert f"HF_HOME={tmp_path / 'huggingface'}" in message
+    run_vllm_api_server_module.snapshot_download.assert_called_once_with(
+        repo_id=spec["hf_model_repo"],
+        revision="pinned-revision",
+        local_files_only=True,
+    )
 
 
 def test_ensure_weights_available_resumes_partial_download(
@@ -757,6 +805,8 @@ def test_ensure_weights_available_resumes_partial_download(
     snapshot_download so missing files are fetched, rather than being treated
     as complete."""
     monkeypatch.delenv("MODEL_WEIGHTS_DIR", raising=False)
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
     monkeypatch.setenv("CACHE_ROOT", str(tmp_path))
     spec = _weights_spec()
     weights_path = tmp_path / "weights" / spec["model_name"]
@@ -779,6 +829,8 @@ def test_ensure_weights_available_falls_back_when_hub_unreachable(
     """If the hub is unreachable but weights already exist locally, startup
     proceeds with the existing weights instead of crashing."""
     monkeypatch.delenv("MODEL_WEIGHTS_DIR", raising=False)
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
     monkeypatch.setenv("CACHE_ROOT", str(tmp_path))
     run_vllm_api_server_module.snapshot_download.side_effect = RuntimeError("offline")
     spec = _weights_spec()
@@ -798,6 +850,8 @@ def test_ensure_weights_available_raises_when_unreachable_and_no_weights(
     """If the hub is unreachable and nothing is cached locally, the failure
     must surface rather than starting with no weights."""
     monkeypatch.delenv("MODEL_WEIGHTS_DIR", raising=False)
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
     monkeypatch.setenv("CACHE_ROOT", str(tmp_path))
     run_vllm_api_server_module.snapshot_download.side_effect = RuntimeError("offline")
 

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -51,6 +51,11 @@ QUETZAL_PACKAGE_PATH_ENV_VARS = (
 QUETZAL_INSTALLED_MANIFEST_DIR = ".quetzal-bundle-manifests"
 
 
+def _env_truthy(name: str) -> bool:
+    """True when an env var is set to a truthy value (1/true/yes/on)."""
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def prepare_quetzal_bundle_env(
     model_spec: dict, package_root_override: Optional[str]
 ) -> None:
@@ -531,6 +536,32 @@ def ensure_weights_available(model_spec: dict) -> Path:
         logger.info(f"Using pre-mounted weights from MODEL_WEIGHTS_DIR: {weights_path}")
         return weights_path
 
+    hf_repo = model_spec.get("hf_weights_repo") or model_spec["hf_model_repo"]
+    revision = (
+        model_spec.get("device_model_spec", {}).get("vllm_args", {}).get("revision")
+    )
+
+    # In offline mode, resolve the exact catalog-pinned snapshot from HF_HOME.
+    # Passing local_dir would instead target cache_root/weights and cannot reuse a
+    # standard Hugging Face cache even when the requested revision is present.
+    offline = _env_truthy("HF_HUB_OFFLINE") or _env_truthy("TRANSFORMERS_OFFLINE")
+    if offline:
+        try:
+            snapshot_path = Path(
+                snapshot_download(
+                    repo_id=hf_repo, revision=revision, local_files_only=True
+                )
+            )
+        except Exception as error:
+            raise RuntimeError(
+                "Offline weights requested (HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE) "
+                f"but {hf_repo}@{revision or 'main'} is not in the HF cache "
+                f"(HF_HOME={os.getenv('HF_HOME')}): {error}"
+            ) from error
+        logger.info(f"Using offline HF cache snapshot for {hf_repo}: {snapshot_path}")
+        os.environ["MODEL_WEIGHTS_DIR"] = str(snapshot_path)
+        return snapshot_path
+
     # Default: download weights into cache_root.
     # snapshot_download resumes partial downloads and skips files already present, so
     # always invoke it: a partially-downloaded directory looks non-empty but would crash
@@ -539,7 +570,6 @@ def ensure_weights_available(model_spec: dict) -> Path:
     cache_root = Path(os.getenv("CACHE_ROOT", "/home/container_app_user/cache_root"))
     model_name = model_spec["model_name"]
     weights_path = cache_root / "weights" / model_name
-    hf_repo = model_spec.get("hf_weights_repo") or model_spec["hf_model_repo"]
 
     weights_path.mkdir(parents=True, exist_ok=True)
     logger.info(f"Downloading weights from {hf_repo} to {weights_path}")


### PR DESCRIPTION
## Summary

- resolve the catalog-pinned model revision directly from HF_HOME when offline mode is enabled
- set MODEL_WEIGHTS_DIR to the cached snapshot returned by huggingface_hub
- report the missing repo, revision, and HF_HOME on an offline cache miss
- preserve the existing online download and fallback behavior

## Test plan

- python3 -m pytest -q tests/test_run_vllm_api_server.py
- ruff format --check vllm-tt-metal/src/run_vllm_api_server.py tests/test_run_vllm_api_server.py
- ruff check vllm-tt-metal/src/run_vllm_api_server.py tests/test_run_vllm_api_server.py

Stacked on #5098.