### PR TITLE
Evals: add deterministic GPT-OSS 32K SWE task

### DIFF
--- a/reference_config/evals/eval_config.py
+++ b/reference_config/evals/eval_config.py
@@ -5027,6 +5027,60 @@ _eval_config_list = [
                     "until": ["</s>"],
                 },
             ),
+            EvalTask(
+                task_name="swe_bench_verified_32k",
+                workflow_venv_type=WorkflowVenvType.EVALS_AGENTIC,
+                score=EvalTaskScore(
+                    published_score=None,
+                    published_score_ref=None,
+                    gpu_reference_score=None,
+                    gpu_reference_score_ref=None,
+                    score_func=score_task_single_key,
+                    score_func_kwargs={
+                        "result_keys": ["accuracy"],
+                        "unit": "percent",
+                    },
+                ),
+                # Generated Quetzal currently exposes deterministic on-device
+                # argmax only. Keep this as a separate 32K completion task so
+                # the native 128K stochastic recipe above remains unchanged.
+                swebench_eval_config=SWEbenchEvalConfig(
+                    dataset_name="SWE-bench/SWE-bench_Verified",
+                    sweagent_subset="verified",
+                    dataset_split="test",
+                    agent_backend="mini-swe-agent",
+                    n_concurrent_trials=1,
+                    max_workers=1,
+                    n_tasks=None,
+                    temperature=0.0,
+                    top_p=1.0,
+                    max_input_tokens=24 * 1024,
+                    max_output_tokens=8 * 1024,
+                    completion_kwargs={
+                        "extra_body": {
+                            "top_k": 0,
+                        },
+                    },
+                    llm_timeout_sec=30 * 60,
+                    shuffle=False,
+                    random_delay_multiplier=0.0,
+                    instance_ids_map={
+                        EvalLimitMode.SMOKE_TEST: [
+                            "django__django-11299",
+                        ],
+                        EvalLimitMode.CI_NIGHTLY: [
+                            "django__django-11299",
+                            "astropy__astropy-14096",
+                            "matplotlib__matplotlib-25332",
+                            "sympy__sympy-13551",
+                            "scikit-learn__scikit-learn-14629",
+                        ],
+                    },
+                ),
+                limit_samples_map={
+                    EvalLimitMode.SMOKE_TEST: 1,
+                },
+            ),
         ],
     ),
     EvalConfig(

--- a/tests/llm_module/test_gpt_oss_32k_swe_config.py
+++ b/tests/llm_module/test_gpt_oss_32k_swe_config.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 Tenstorrent AI ULC
+
+from types import SimpleNamespace
+
+from llm_module.eval_configs import (
+    agentic_task_required_context,
+    select_agentic_eval_tasks,
+)
+from reference_config.evals.eval_config import EVAL_CONFIGS
+from workflows.workflow_types import EvalLimitMode
+
+
+def _task():
+    config = EVAL_CONFIGS["gpt-oss-120b"]
+    return next(
+        task for task in config.tasks if task.task_name == "swe_bench_verified_32k"
+    )
+
+
+def _model_spec(max_context):
+    return SimpleNamespace(
+        device_model_spec=SimpleNamespace(max_context=max_context),
+    )
+
+
+def test_gpt_oss_32k_swe_task_has_exact_deterministic_envelope():
+    task = _task()
+    config = task.swebench_eval_config
+
+    assert config.max_input_tokens == 24 * 1024
+    assert config.max_output_tokens == 8 * 1024
+    assert agentic_task_required_context(task) == 32 * 1024
+    assert config.temperature == 0.0
+    assert config.top_p == 1.0
+    assert config.completion_kwargs == {"extra_body": {"top_k": 0}}
+    assert config.n_concurrent_trials == 1
+    assert config.max_workers == 1
+
+
+def test_gpt_oss_32k_swe_task_has_fixed_smoke_and_nightly_subsets():
+    subsets = _task().swebench_eval_config.instance_ids_map
+
+    assert subsets[EvalLimitMode.SMOKE_TEST] == ["django__django-11299"]
+    assert subsets[EvalLimitMode.CI_NIGHTLY] == [
+        "django__django-11299",
+        "astropy__astropy-14096",
+        "matplotlib__matplotlib-25332",
+        "sympy__sympy-13551",
+        "scikit-learn__scikit-learn-14629",
+    ]
+
+
+def test_gpt_oss_32k_swe_task_is_reachable_only_at_its_full_envelope():
+    task = _task()
+    runtime = SimpleNamespace(agentic_benchmark=task.task_name)
+
+    assert select_agentic_eval_tasks([task], _model_spec(32 * 1024), runtime) == [task]
+    assert select_agentic_eval_tasks([task], _model_spec(32 * 1024 - 1), runtime) == []


### PR DESCRIPTION
## Summary
- add a separate GPT-OSS-120B SWE-bench Verified task with an exact 24,576 input + 8,192 output envelope
- keep the existing native 128K stochastic evals unchanged
- use deterministic sampling for generated on-device argmax and fixed smoke/nightly instance subsets
- rely on the generic agentic context-reachability base so 32,767-token implementations omit the task and 32,768-token implementations admit it

Stacked on #5097.

## Tests
- `uv run --isolated --no-project --with-requirements requirements-dev.txt python -m pytest -q tests/llm_module/test_gpt_oss_32k_swe_config.py` (3 passed)
- same environment plus `aiohttp`: agentic/release/dispatch/requirements focused suite (204 passed)
- `ruff check` and `ruff format --check` on changed files