### PR TITLE
vLLM: reject unsupported TT sampling at request validation

### DIFF
--- a/tt-vllm-plugin/tests/test_platform_sampling.py
+++ b/tt-vllm-plugin/tests/test_platform_sampling.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
 from contextlib import contextmanager
 
 import pytest

--- a/tt-vllm-plugin/tests/test_platform_sampling.py
+++ b/tt-vllm-plugin/tests/test_platform_sampling.py
@@ -1,9 +1,8 @@
 from contextlib import contextmanager
 
 import pytest
-from vllm.sampling_params import SamplingParams
-
 from tt_vllm_plugin.platform import TTPlatform
+from vllm.sampling_params import SamplingParams
 
 
 @contextmanager
@@ -14,6 +13,16 @@ def _sampling_mode(mode):
         yield
     finally:
         TTPlatform.sample_on_device_mode = previous
+
+
+@contextmanager
+def _non_greedy_support(supported):
+    previous = getattr(TTPlatform, "non_greedy_decoding_on_device", None)
+    TTPlatform.non_greedy_decoding_on_device = supported
+    try:
+        yield
+    finally:
+        TTPlatform.non_greedy_decoding_on_device = previous
 
 
 @pytest.mark.parametrize(
@@ -39,8 +48,8 @@ def test_device_sampling_rejects_options_that_need_compatibility_sampling(modifi
         )
 
 
-def test_device_sampling_accepts_native_temperature_top_k_top_p():
-    with _sampling_mode("all"):
+def test_device_sampling_accepts_native_temperature_top_k_top_p_when_supported():
+    with _sampling_mode("all"), _non_greedy_support(True):
         TTPlatform.validate_request(
             prompt="hello",
             params=SamplingParams(temperature=0.7, top_k=10, top_p=0.9),
@@ -48,8 +57,29 @@ def test_device_sampling_accepts_native_temperature_top_k_top_p():
         )
 
 
+@pytest.mark.parametrize("mode", ["all", "decode_only"])
+def test_device_sampling_rejects_non_greedy_for_greedy_only_model(mode):
+    with _sampling_mode(mode), _non_greedy_support(False), pytest.raises(
+        ValueError, match="Non-greedy sampling is unsupported by this TT model"
+    ):
+        TTPlatform.validate_request(
+            prompt="hello",
+            params=SamplingParams(temperature=1.0, top_k=128256, top_p=0.9),
+            processed_inputs={},
+        )
+
+
+def test_device_sampling_accepts_greedy_for_greedy_only_model():
+    with _sampling_mode("all"), _non_greedy_support(False):
+        TTPlatform.validate_request(
+            prompt="hello",
+            params=SamplingParams(temperature=0.0),
+            processed_inputs={},
+        )
+
+
 def test_host_sampling_mode_keeps_compatibility_sampling_behavior():
-    with _sampling_mode(None):
+    with _sampling_mode(None), _non_greedy_support(False):
         TTPlatform.validate_request(
             prompt="hello",
             params=SamplingParams(presence_penalty=0.5),

--- a/tt-vllm-plugin/tests/test_platform_sampling.py
+++ b/tt-vllm-plugin/tests/test_platform_sampling.py
@@ -1,0 +1,57 @@
+from contextlib import contextmanager
+
+import pytest
+from vllm.sampling_params import SamplingParams
+
+from tt_vllm_plugin.platform import TTPlatform
+
+
+@contextmanager
+def _sampling_mode(mode):
+    previous = getattr(TTPlatform, "sample_on_device_mode", None)
+    TTPlatform.sample_on_device_mode = mode
+    try:
+        yield
+    finally:
+        TTPlatform.sample_on_device_mode = previous
+
+
+@pytest.mark.parametrize(
+    "modifier",
+    [
+        {"presence_penalty": 0.5},
+        {"frequency_penalty": 0.5},
+        {"repetition_penalty": 1.1},
+        {"min_p": 0.1},
+        {"logit_bias": {7: 1.0}},
+        {"allowed_token_ids": [7, 11]},
+        {"logprobs": 1},
+    ],
+)
+def test_device_sampling_rejects_options_that_need_compatibility_sampling(modifier):
+    with _sampling_mode("all"), pytest.raises(
+        ValueError, match="require vLLM compatibility sampling"
+    ):
+        TTPlatform.validate_request(
+            prompt="hello",
+            params=SamplingParams(**modifier),
+            processed_inputs={},
+        )
+
+
+def test_device_sampling_accepts_native_temperature_top_k_top_p():
+    with _sampling_mode("all"):
+        TTPlatform.validate_request(
+            prompt="hello",
+            params=SamplingParams(temperature=0.7, top_k=10, top_p=0.9),
+            processed_inputs={},
+        )
+
+
+def test_host_sampling_mode_keeps_compatibility_sampling_behavior():
+    with _sampling_mode(None):
+        TTPlatform.validate_request(
+            prompt="hello",
+            params=SamplingParams(presence_penalty=0.5),
+            processed_inputs={},
+        )

--- a/tt-vllm-plugin/tt_vllm_plugin/platform.py
+++ b/tt-vllm-plugin/tt_vllm_plugin/platform.py
@@ -210,6 +210,15 @@ class TTPlatform(Platform):
                 raise ValueError(
                     f"Currently not supporting prompt_logprobs on {cls.device_name}"
                 )
+            if getattr(cls, "sample_on_device_mode", None) in (
+                "all",
+                "decode_only",
+            ) and cls.compat_sampling_required(params):
+                raise ValueError(
+                    "Sampling options that require vLLM compatibility sampling "
+                    "are unsupported with TT sample_on_device_mode="
+                    f"{cls.sample_on_device_mode!r}"
+                )
 
     @staticmethod
     def compat_sampling_required(sampling_params) -> bool:

--- a/tt-vllm-plugin/tt_vllm_plugin/platform.py
+++ b/tt-vllm-plugin/tt_vllm_plugin/platform.py
@@ -8,7 +8,7 @@ import vllm.envs as envs
 from vllm.inputs import ProcessorInputs, PromptType
 from vllm.logger import init_logger
 from vllm.platforms.interface import Platform, PlatformEnum
-from vllm.sampling_params import SamplingParams
+from vllm.sampling_params import SamplingParams, SamplingType
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig
@@ -217,6 +217,19 @@ class TTPlatform(Platform):
                 raise ValueError(
                     "Sampling options that require vLLM compatibility sampling "
                     "are unsupported with TT sample_on_device_mode="
+                    f"{cls.sample_on_device_mode!r}"
+                )
+            if (
+                getattr(cls, "sample_on_device_mode", None) in (
+                    "all",
+                    "decode_only",
+                )
+                and not getattr(cls, "non_greedy_decoding_on_device", False)
+                and params.sampling_type is not SamplingType.GREEDY
+            ):
+                raise ValueError(
+                    "Non-greedy sampling is unsupported by this TT model with "
+                    "sample_on_device_mode="
                     f"{cls.sample_on_device_mode!r}"
                 )
 


### PR DESCRIPTION
## Summary

- reject options that require compatibility sampling before TT engine execution
- reject non-greedy requests when the selected TT model does not advertise on-device non-greedy support
- preserve stochastic requests for native-capable TT models and host-sampling mode

## Why

Generated Quetzal currently supports device-side greedy argmax only. A stochastic OpenAI request previously reached the EngineCore, raised during execution, and terminated the server. This uses the TT platform's existing model-derived `non_greedy_decoding_on_device` capability to return a request error before engine execution.

## Validation

- `python -m pytest -q tt-vllm-plugin/tests/test_platform_sampling.py` (vLLM 0.10.1.1): 12 passed
- `python -m ruff check --select I tt-vllm-plugin/tt_vllm_plugin/platform.py tt-vllm-plugin/tests/test_platform_sampling.py`: passed

Observed failing request preserved unchanged: temperature=1.0, top_p=0.9, top_k=128256. No eval sampling configuration was changed.