### PR TITLE
Tests: enroll Llama 3.2 1B P300X2 spec suite

### DIFF
--- a/test_module/server_tests_config.json
+++ b/test_module/server_tests_config.json
@@ -438,6 +438,16 @@
                 "galaxy_t3k"
             ]
         },
+        "llama_3_2_1b": {
+            "id_name": "llama-3.2-1b",
+            "weights": [
+                "Llama-3.2-1B-Instruct"
+            ],
+            "category": "LLM",
+            "compatible_devices": [
+                "p300x2"
+            ]
+        },
         "mistral_small_24b": {
             "id_name": "mistral-small-3.1-24b",
             "weights": [

--- a/test_module/test_suites/llm.json
+++ b/test_module/test_suites/llm.json
@@ -6,6 +6,7 @@
             "models": [
                 "qwen3_32b",
                 "llama_3_1_8b",
+                "llama_3_2_1b",
                 "llama_70b_family",
                 "gpt_oss_20b"
             ],

--- a/tests/test_module/test_matrix_expansion.py
+++ b/tests/test_module/test_matrix_expansion.py
@@ -30,6 +30,22 @@ def test_diffusiongemma_llm_suite_uses_model_specific_conformance_test():
     assert {"param", "e2e", "slow", "heavy"} <= set(template["markers"])
 
 
+def test_llama_3_2_1b_p300x2_uses_vllm_param_conformance_suite():
+    suites = load_suite_files_by_category("llm")
+    matching = [
+        suite
+        for suite in suites
+        if suite["weights"] == ["Llama-3.2-1B-Instruct"]
+    ]
+
+    assert [(suite["id"], suite["device"]) for suite in matching] == [
+        ("llama-3.2-1b-p300x2", "p300x2")
+    ]
+    assert [case["template"] for case in matching[0]["test_cases"]] == [
+        "VLLMParamConformanceTest"
+    ]
+
+
 class TestImageMatrixExpansionSDXL:
     SDXL_SUITE_IDS = {
         "sdxl-n150",


### PR DESCRIPTION
## Summary

- add the Llama 3.2 1B model key for P300X2 server spec tests
- enroll it in the existing vLLM parameter-conformance matrix
- assert that exactly the P300X2 suite expands

## Evidence

The canonical Quetzal Llama release at TTIS `e952b722` logged:

```
No spec test suites match model='Llama-3.2-1B-Instruct' device='p300x2' — skipping spec_tests.
```

This makes the full release exercise the intended API compatibility surface instead of recording a clean no-op. PR #5103 should land first so unsupported stochastic requests are rejected at API validation rather than terminating EngineCore.

## Validation

- `python3 -m pytest -q tests/test_module/test_matrix_expansion.py`: 16 passed
- `ruff check tests/test_module/test_matrix_expansion.py`: passed
- `git diff --check`: passed

Stacked on #5102.