### PR TITLE
ASR error on overlong audio

### DIFF
--- a/test_module/benchmark_tests/audio_benchmark_tests.py
+++ b/test_module/benchmark_tests/audio_benchmark_tests.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import sys
 import time
 from pathlib import Path
@@ -96,7 +97,7 @@ async def _transcribe_audio_streaming_off(
 
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = {
@@ -158,7 +159,7 @@ async def _transcribe_audio_streaming_on(
     hf_model_repo = ctx.model_spec.hf_model_repo
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = {

--- a/test_module/benchmark_tests/cnn_benchmark_tests.py
+++ b/test_module/benchmark_tests/cnn_benchmark_tests.py
@@ -9,6 +9,7 @@ import base64
 import itertools
 import json
 import logging
+import os
 import sys
 import time
 from pathlib import Path
@@ -174,7 +175,7 @@ def _analyze_image(ctx: MediaContext, image_path: Path) -> tuple[bool, float]:
 
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = {"prompt": image_payload}

--- a/test_module/benchmark_tests/embedding_benchmark_tests.py
+++ b/test_module/benchmark_tests/embedding_benchmark_tests.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 BENCHMARK_RESULT_START = "============ Serving Benchmark Result ============"
 BENCHMARK_RESULT_END = "=================================================="
-OPENAI_API_KEY = "your-secret-key"
+OPENAI_API_KEY = os.getenv("API_KEY", "your-secret-key")
 
 
 def _embedding_params(ctx: MediaContext) -> tuple[str, int, int, int]:

--- a/test_module/benchmark_tests/image_benchmark_tests.py
+++ b/test_module/benchmark_tests/image_benchmark_tests.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -72,7 +73,7 @@ def _generate_image(
     logger.info("🌅 Generating image")
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = {
@@ -112,7 +113,7 @@ def _generate_image_img2img(
     logger.info("🌆 Generating image with img2img")
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     with open(f"{ctx.test_payloads_path}/image_client_img2img_payload", "r") as f:
@@ -159,7 +160,7 @@ def _generate_image_inpainting(
     logger.info("🏞️ Generating image with inpainting")
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     with open(f"{ctx.test_payloads_path}/image_client_inpainting_payload", "r") as f:
@@ -338,7 +339,7 @@ def _generate_image_z_image_turbo(
 ) -> tuple[bool, float]:
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = {

--- a/test_module/benchmark_tests/tts_benchmark_tests.py
+++ b/test_module/benchmark_tests/tts_benchmark_tests.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+import os
 import sys
 import time
 from pathlib import Path
@@ -73,7 +74,7 @@ async def _generate_speech(
 
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = {"text": text, "response_format": "json"}

--- a/test_module/benchmark_tests/video_benchmark_tests.py
+++ b/test_module/benchmark_tests/video_benchmark_tests.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import time
 from pathlib import Path
@@ -136,7 +137,7 @@ def _generate_video(
     submit_endpoint = get_video_generation_submit_endpoint(model_name)
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = build_video_generation_payload(

--- a/test_module/eval_tests/audio_eval_tests.py
+++ b/test_module/eval_tests/audio_eval_tests.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import sys
 import time
 from pathlib import Path
@@ -58,7 +59,7 @@ async def _transcribe_audio_streaming_off(
 
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = {
@@ -116,7 +117,7 @@ async def _transcribe_audio_streaming_on(
     hf_model_repo = ctx.model_spec.hf_model_repo
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = {

--- a/test_module/eval_tests/cnn_eval_tests.py
+++ b/test_module/eval_tests/cnn_eval_tests.py
@@ -124,7 +124,7 @@ def _analyze_image(ctx: MediaContext, image_path: Path) -> tuple[bool, float]:
 
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = {"prompt": image_payload}
@@ -291,7 +291,7 @@ def _yolox_detect(ctx: MediaContext, image_jpeg: bytes) -> tuple[list, float]:
     encoded = base64.b64encode(image_jpeg).decode("ascii")
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = {

--- a/test_module/eval_tests/embedding_eval_tests.py
+++ b/test_module/eval_tests/embedding_eval_tests.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -26,7 +27,7 @@ from ..context import HardwareRequirement, MediaContext, require_health
 logger = logging.getLogger(__name__)
 
 
-OPENAI_API_KEY = "your-secret-key"
+OPENAI_API_KEY = os.getenv("API_KEY", "your-secret-key")
 MTEB_TASKS = ["STS12"]
 EMBEDDING_DIMENSIONS = 1000
 

--- a/test_module/eval_tests/image_eval_tests.py
+++ b/test_module/eval_tests/image_eval_tests.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import sys
 import time
 from pathlib import Path
@@ -73,7 +74,7 @@ async def _generate_image_eval_async(
     logger.info(f"🌅 Generating image for prompt: {prompt}")
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = {
@@ -181,7 +182,7 @@ async def _generate_image_img2img_eval_async(
     logger.info(f"🌆 Generating img2img image for prompt: {prompt}")
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = {
@@ -282,7 +283,7 @@ async def _generate_image_inpainting_eval_async(
     logger.info(f"🏞️ Generating inpainting image for prompt: {prompt}")
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer your-secret-key",
+        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
         "Content-Type": "application/json",
     }
     payload = {

--- a/test_module/eval_tests/tts_quality_test.py
+++ b/test_module/eval_tests/tts_quality_test.py
@@ -13,6 +13,7 @@ import base64
 import io
 import json
 import logging
+import os
 import re
 import shutil
 import time
@@ -33,7 +34,7 @@ DEFAULT_DATASET_SPLIT = "test.clean"
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/eval_tests/whisper_eval_test.py
+++ b/test_module/eval_tests/whisper_eval_test.py
@@ -43,7 +43,7 @@ class WhisperEvalTest(BaseTest):
     # Class-level configuration - use same settings as run_evals.py
     model_name: str = "whisper_tt"  # eval_class from eval_config.py
     hf_model_repo: str = "distil-whisper/distil-large-v3"
-    api_key: str = "your-secret-key"
+    api_key: str = os.getenv("API_KEY", "your-secret-key")
     base_url: str = "http://127.0.0.1:8000"
     batch_size: int = 1
     test_limit: int = None  # Remove limit to match real run_evals.py behavior

--- a/test_module/integration_tests/speecht5_tts_test.py
+++ b/test_module/integration_tests/speecht5_tts_test.py
@@ -17,8 +17,7 @@ from .._test_common import BaseTest, TestConfig
 if TYPE_CHECKING:
     from ..context import MediaContext
 
-DEFAULT_API_KEY = "your-secret-key"
-
+DEFAULT_API_KEY = os.getenv("API_KEY", "your-secret-key")
 HEADERS = {
     "accept": "application/json",
     "Content-Type": "application/json",

--- a/test_module/integration_tests/tts_integration_test.py
+++ b/test_module/integration_tests/tts_integration_test.py
@@ -17,6 +17,7 @@ Note: Basic TTS functionality is covered by speecht5_tts_test.py
 from __future__ import annotations
 
 import logging
+import os
 import time
 from typing import TYPE_CHECKING
 
@@ -34,7 +35,7 @@ logger = logging.getLogger(__name__)
 HEADERS = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/audio_transcription_load_test.py
+++ b/test_module/load_param_tests/audio_transcription_load_test.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -33,7 +34,7 @@ payload = {
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/audio_transcription_param_test.py
+++ b/test_module/load_param_tests/audio_transcription_param_test.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import os
 import time
 
 import aiohttp
@@ -109,7 +110,7 @@ combined_params_payload = {
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/cnn_load_test.py
+++ b/test_module/load_param_tests/cnn_load_test.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -32,7 +33,7 @@ payload = {
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/cnn_param_test.py
+++ b/test_module/load_param_tests/cnn_param_test.py
@@ -5,6 +5,7 @@
 import asyncio
 import base64
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -58,7 +59,7 @@ min_confidence_50_payload = {
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 
@@ -204,7 +205,7 @@ class CnnParamTest(BaseTest):
 
                     multipart_headers = {
                         "accept": "application/json",
-                        "Authorization": "Bearer your-secret-key",
+                        "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
                     }
 
                     async with session.post(

--- a/test_module/load_param_tests/embedding_load_test.py
+++ b/test_module/load_param_tests/embedding_load_test.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import os
 import time
 from typing import TYPE_CHECKING
 
@@ -22,7 +23,7 @@ DEFAULT_INPUT = "The quick brown fox jumps over the lazy dog"
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/embedding_param_test.py
+++ b/test_module/load_param_tests/embedding_param_test.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import os
 import time
 
 import aiohttp
@@ -34,7 +35,7 @@ dimensions_payload = {
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/image_generation_load_test.py
+++ b/test_module/load_param_tests/image_generation_load_test.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import os
 import time
 from typing import TYPE_CHECKING
 
@@ -30,7 +31,7 @@ payload = {
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/image_generation_param_test.py
+++ b/test_module/load_param_tests/image_generation_param_test.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import io
 import logging
+import os
 import time
 
 import aiohttp
@@ -50,7 +51,7 @@ guidance_scale_change_payload = {
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 DEFAULT_SAME_SEED_MIN_SSIM = 0.95

--- a/test_module/load_param_tests/img2img_generation_param_test.py
+++ b/test_module/load_param_tests/img2img_generation_param_test.py
@@ -5,6 +5,7 @@
 import asyncio
 import json
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -33,7 +34,7 @@ STRENGTH = 0.5
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/inpainting_generation_param_test.py
+++ b/test_module/load_param_tests/inpainting_generation_param_test.py
@@ -5,6 +5,7 @@
 import asyncio
 import json
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -38,7 +39,7 @@ STRENGTH = 0.6
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/server_helper.py
+++ b/test_module/load_param_tests/server_helper.py
@@ -13,7 +13,7 @@ SERVER_SHUTDOWN_TIMEOUT = 20
 SERVER_BASE_URL = "http://127.0.0.1:8000"
 # Full URL to CNN search-image endpoint
 SERVER_DEFAULT_URL = f"{SERVER_BASE_URL}/v1/cnn/search-image"
-DEFAULT_AUTHORIZATION = "your-secret-key"
+DEFAULT_AUTHORIZATION = os.getenv("API_KEY", "your-secret-key")
 TT_MEDIA_SERVER_DIR = Path(__file__).resolve().parents[2] / "tt-media-server"
 READY_LOG_TEXT = "All devices are warmed up and ready"
 LOG_DIR = Path(__file__).resolve().parent / "server_logs"

--- a/test_module/load_param_tests/tts_load_test.py
+++ b/test_module/load_param_tests/tts_load_test.py
@@ -5,6 +5,7 @@
 import asyncio
 import json
 import logging
+import os
 import shutil
 import time
 from pathlib import Path
@@ -28,7 +29,7 @@ DEFAULT_DATASET_SPLIT = "test.clean"
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/tts_param_test.py
+++ b/test_module/load_param_tests/tts_param_test.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import os
 import time
 
 import aiohttp
@@ -50,7 +51,7 @@ response_format_ogg_payload = {
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/video_generation_i2v_param_test.py
+++ b/test_module/load_param_tests/video_generation_i2v_param_test.py
@@ -24,6 +24,7 @@ import base64
 import copy
 import json
 import logging
+import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -57,7 +58,7 @@ WARMUP_AND_MEASURE_ITERATIONS = 2
 HEADERS = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/video_generation_i2v_test.py
+++ b/test_module/load_param_tests/video_generation_i2v_test.py
@@ -15,6 +15,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -51,7 +52,7 @@ HTTP_ACCEPTED = 202
 _HEADERS = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/video_generation_load_test.py
+++ b/test_module/load_param_tests/video_generation_load_test.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import os
 import time
 from typing import TYPE_CHECKING
 
@@ -28,7 +29,7 @@ payload = {
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/test_module/load_param_tests/video_generation_param_test.py
+++ b/test_module/load_param_tests/video_generation_param_test.py
@@ -5,6 +5,7 @@
 import asyncio
 import json
 import logging
+import os
 import time
 
 import aiohttp
@@ -65,7 +66,7 @@ different_prompt_payload = {
 headers = {
     "accept": "application/json",
     "Content-Type": "application/json",
-    "Authorization": "Bearer your-secret-key",
+    "Authorization": f"Bearer {os.getenv('API_KEY', 'your-secret-key')}",
 }
 
 

--- a/tt-media-server/config/settings.py
+++ b/tt-media-server/config/settings.py
@@ -168,8 +168,10 @@ class Settings(BaseSettings):
     )
     # Qwen3-ASR fans a long clip out across the 32 Galaxy runners in 10s windows,
     # so one wave = 32 * 10 = 320s. Capping here lets a single request saturate all
-    # 32 runners in one pass; audio beyond this is truncated (raise it if longer
-    # clips must be supported, at the cost of spilling into extra runner waves).
+    # 32 runners in one pass; audio beyond this is REJECTED with 400 (raise it if
+    # longer clips must be supported, at the cost of spilling into extra runner
+    # waves). It used to be truncated silently, which returned a head-only
+    # transcript the caller could not distinguish from a complete one.
     max_audio_duration_qwen3_asr_seconds: float = 320.0
     max_audio_size_bytes: int = 50 * 1024 * 1024
     default_sample_rate: int = 16000

--- a/tt-media-server/model_services/cpu_workload_handler.py
+++ b/tt-media-server/model_services/cpu_workload_handler.py
@@ -10,6 +10,7 @@ from threading import Lock
 
 from config.settings import settings
 from telemetry.multiprocess_setup import mark_worker_dead
+from utils.errors import reconstruct_worker_error
 from utils.logger import TTLogger
 from utils.runner_utils import setup_cpu_threading_limits
 
@@ -56,7 +57,9 @@ def _process_worker_tasks(
         except Exception as e:
             logger.error(f"Error in {worker_name} worker: {e}")
             if "task_id" in locals():
-                error_queue.put((task_id, str(e)))
+                # Class name rides along so the parent can rebuild the real type;
+                # a multiprocessing.Queue cannot carry the exception object.
+                error_queue.put((task_id, str(e), type(e).__name__))
 
     logger.info(f"{worker_name} worker stopped")
 
@@ -151,7 +154,11 @@ class CpuWorkloadHandler:
         """Listen for errors from worker processes"""
         while self.listener_running:
             try:
-                task_id, error = await asyncio.to_thread(self.error_queue.get)
+                payload = await asyncio.to_thread(self.error_queue.get)
+                # Shutdown sentinel is (None, None); worker failures are
+                # (task_id, message, type_name).
+                task_id, error = payload[0], payload[1]
+                error_type = payload[2] if len(payload) > 2 else None
 
                 if task_id is None:  # Shutdown signal
                     break
@@ -162,7 +169,7 @@ class CpuWorkloadHandler:
                     future = self.result_futures.pop(task_id, None)
 
                 if future and not future.cancelled():
-                    future.set_exception(Exception(error))
+                    future.set_exception(reconstruct_worker_error(error_type, error))
 
             except Exception as e:
                 self.logger.error(f"Error in {self.name} error listener: {e}")

--- a/tt-media-server/open_ai_api/audio.py
+++ b/tt-media-server/open_ai_api/audio.py
@@ -23,7 +23,7 @@ from fastapi.responses import StreamingResponse
 from model_services.base_service import BaseService
 from resolver.service_resolver import service_resolver
 from security.api_key_checker import get_api_key
-from utils.audio_manager import AudioTooLongError
+from utils.errors import AudioTooLongError
 
 
 async def parse_audio_request(

--- a/tt-media-server/open_ai_api/audio.py
+++ b/tt-media-server/open_ai_api/audio.py
@@ -23,6 +23,7 @@ from fastapi.responses import StreamingResponse
 from model_services.base_service import BaseService
 from resolver.service_resolver import service_resolver
 from security.api_key_checker import get_api_key
+from utils.audio_manager import AudioTooLongError
 
 
 async def parse_audio_request(
@@ -143,6 +144,10 @@ async def handle_audio_request(audio_request, service):
                 else "application/x-ndjson"
             )
             return StreamingResponse(result_stream(), media_type=media_type)
+    except AudioTooLongError as e:
+        # Client submitted audio past the runner's cap - a request error, not a
+        # server fault. Mirrors the download-cap mapping in open_ai_api/video.py.
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/tt-media-server/tests/test_audio_manager.py
+++ b/tt-media-server/tests/test_audio_manager.py
@@ -16,7 +16,7 @@ from config.constants import AudioInputFormat
 # audio_manager no longer imports torch/whisperx at module load time; those
 # packages live in the separate audio_venv and are only invoked through the
 # persistent worker subprocess. We can import freely without any workaround.
-from utils.audio_manager import AudioManager, AudioVenvWorker
+from utils.audio_manager import AudioManager, AudioTooLongError, AudioVenvWorker
 
 
 class DummySettings:
@@ -25,6 +25,7 @@ class DummySettings:
     max_audio_size_bytes = 1000000
     max_audio_duration_seconds = 60
     max_audio_duration_with_preprocessing_seconds = 120
+    max_audio_duration_qwen3_asr_seconds = 320
     audio_chunk_duration_seconds = 10
     model_service = "AUDIO"
     model_runner = "tt-whisper"
@@ -106,15 +107,83 @@ def test_validate_file_size():
 
 
 @patch("utils.audio_manager.settings", new=DummySettings())
-def test_validate_and_truncate_duration():
+def test_validate_duration_rejects_over_limit():
+    """Over-length audio errors instead of being silently truncated.
+
+    Truncating returned 200 with a head-only transcript and no signal to the
+    caller that the tail was dropped.
+    """
     manager = AudioManager()
     arr = np.zeros(DummySettings.default_sample_rate * 70, dtype=np.float32)
-    truncated, duration = manager._validate_and_truncate_duration(arr, False)
-    assert duration == DummySettings.max_audio_duration_seconds
-    assert (
-        len(truncated)
-        == DummySettings.default_sample_rate * DummySettings.max_audio_duration_seconds
-    )
+    with pytest.raises(AudioTooLongError) as excinfo:
+        manager._validate_duration(arr, False)
+    assert "70.00s" in str(excinfo.value)
+    assert str(DummySettings.max_audio_duration_seconds) in str(excinfo.value)
+
+
+@patch("utils.audio_manager.settings", new=DummySettings())
+def test_validate_duration_accepts_at_and_under_limit():
+    manager = AudioManager()
+    for seconds in (1, DummySettings.max_audio_duration_seconds):
+        arr = np.zeros(DummySettings.default_sample_rate * seconds, dtype=np.float32)
+        out, duration = manager._validate_duration(arr, False)
+        assert duration == seconds
+        assert len(out) == len(arr)
+
+
+class DummyQwenSettings(DummySettings):
+    model_runner = "qwen3-asr"
+
+
+@patch("utils.audio_manager.settings", new=DummyQwenSettings())
+def test_validate_duration_qwen3_asr_limit():
+    """Qwen3-ASR uses its own 320s cap (one 32-runner x 10s wave)."""
+    manager = AudioManager()
+    ok = np.zeros(DummySettings.default_sample_rate * 320, dtype=np.float32)
+    _, duration = manager._validate_duration(ok, False)
+    assert duration == 320
+
+    too_long = np.zeros(DummySettings.default_sample_rate * 321, dtype=np.float32)
+    with pytest.raises(AudioTooLongError):
+        manager._validate_duration(too_long, False)
+
+
+def _wav_bytes_of_seconds(seconds, sample_rate=16000):
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(b"\x00" * (2 * sample_rate * seconds))
+    return buffer.getvalue()
+
+
+class DummyBigFileSettings(DummySettings):
+    # Duration is what this test exercises; keep the byte cap out of the way so
+    # _validate_file_size does not fire first on the larger WAV.
+    max_audio_size_bytes = 100_000_000
+
+
+@patch("utils.audio_manager.settings", new=DummyBigFileSettings())
+def test_to_audio_array_propagates_too_long_error():
+    """The generic handler in to_audio_array must not flatten this.
+
+    It wraps every exception into ValueError("Failed to process audio data: ..."),
+    which the route maps to 500. AudioTooLongError has to survive intact so it
+    reaches the 400 branch with its actionable message.
+    """
+    manager = AudioManager()
+    over = _wav_bytes_of_seconds(DummySettings.max_audio_duration_seconds + 5)
+    with pytest.raises(AudioTooLongError) as excinfo:
+        manager.to_audio_array(over, False)
+    assert "Failed to process audio data" not in str(excinfo.value)
+    assert "exceeds the maximum" in str(excinfo.value)
+
+
+@patch("utils.audio_manager.settings", new=DummySettings())
+def test_audio_too_long_error_is_value_error():
+    """Existing `except ValueError` callers keep catching it."""
+    assert issubclass(AudioTooLongError, ValueError)
 
 
 @patch("utils.audio_manager.settings", new=DummySettings())

--- a/tt-media-server/tests/test_worker_error_propagation.py
+++ b/tt-media-server/tests/test_worker_error_propagation.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Worker failures must keep their type across the process boundary.
+
+CpuWorkloadHandler marshals errors through a multiprocessing.Queue, which cannot
+carry an exception object. Before the type name was sent alongside the message,
+every worker failure surfaced as a bare Exception, so a client-side mistake like
+over-length audio was reported as 500 instead of 400.
+"""
+
+import pytest
+from utils.errors import (
+    RECONSTRUCTIBLE_ERRORS,
+    AudioTooLongError,
+    reconstruct_worker_error,
+)
+
+
+def test_audio_too_long_error_is_reconstructed_by_name():
+    err = reconstruct_worker_error("AudioTooLongError", "audio is 600.00s")
+    assert isinstance(err, AudioTooLongError)
+    assert str(err) == "audio is 600.00s"
+
+
+def test_unknown_type_falls_back_to_generic_exception():
+    err = reconstruct_worker_error("SomeUnregisteredError", "boom")
+    assert type(err) is Exception
+    assert str(err) == "boom"
+
+
+def test_missing_type_name_falls_back():
+    """Covers a worker still sending the old two-element payload."""
+    err = reconstruct_worker_error(None, "boom")
+    assert type(err) is Exception
+
+
+def test_reconstructed_error_still_subclasses_value_error():
+    assert isinstance(reconstruct_worker_error("AudioTooLongError", "x"), ValueError)
+
+
+def test_registry_keys_match_class_names():
+    for name, cls in RECONSTRUCTIBLE_ERRORS.items():
+        assert name == cls.__name__
+
+
+def test_error_payload_shapes_unpack():
+    """The listener handles both the sentinel and the failure payload."""
+    for payload, expect_type in (
+        ((None, None), None),
+        (("t1", "msg"), None),
+        (("t1", "msg", "AudioTooLongError"), AudioTooLongError),
+    ):
+        task_id, error = payload[0], payload[1]
+        error_type = payload[2] if len(payload) > 2 else None
+        if task_id is None:
+            continue
+        err = reconstruct_worker_error(error_type, error)
+        if expect_type is None:
+            assert type(err) is Exception
+        else:
+            assert isinstance(err, expect_type)
+
+
+def test_audio_manager_reexport_is_same_class():
+    """Existing `from utils.audio_manager import AudioTooLongError` must not fork."""
+    pytest.importorskip("numpy")
+    from utils.audio_manager import AudioTooLongError as ReExported
+
+    assert ReExported is AudioTooLongError
+
+
+def _raise_too_long(_context, _payload):
+    """Module-level so it is picklable for the worker Process."""
+    from utils.errors import AudioTooLongError
+
+    raise AudioTooLongError("Audio duration 600.00s exceeds the maximum")
+
+
+def _raise_plain(_context, _payload):
+    raise RuntimeError("something else broke")
+
+
+@pytest.mark.asyncio
+async def test_real_worker_roundtrip_preserves_type():
+    """End-to-end through the actual multiprocessing queue.
+
+    The helper-level tests above passed even when the real path was broken - the
+    type was lost in the queue, not in reconstruction - so this exercises a live
+    CpuWorkloadHandler rather than the helper alone.
+    """
+    from model_services.cpu_workload_handler import CpuWorkloadHandler
+
+    handler = CpuWorkloadHandler("test-too-long", 1, _raise_too_long)
+    try:
+        with pytest.raises(AudioTooLongError) as excinfo:
+            await handler.execute_task(b"ignored")
+        assert "exceeds the maximum" in str(excinfo.value)
+    finally:
+        handler.stop_workers()
+
+
+@pytest.mark.asyncio
+async def test_real_worker_roundtrip_unregistered_stays_generic():
+    from model_services.cpu_workload_handler import CpuWorkloadHandler
+
+    handler = CpuWorkloadHandler("test-plain", 1, _raise_plain)
+    try:
+        with pytest.raises(Exception) as excinfo:
+            await handler.execute_task(b"ignored")
+        assert not isinstance(excinfo.value, AudioTooLongError)
+        assert "something else broke" in str(excinfo.value)
+    finally:
+        handler.stop_workers()

--- a/tt-media-server/utils/audio_manager.py
+++ b/tt-media-server/utils/audio_manager.py
@@ -29,6 +29,11 @@ from telemetry.telemetry_client import (
 )
 
 from utils.decorators import log_execution_time
+
+# Defined in utils.errors so cpu_workload_handler can rebuild it across the
+# worker-process boundary without importing this module. Re-exported here for
+# existing callers.
+from utils.errors import AudioTooLongError
 from utils.ffmpeg_utils import decode_to_wav as ffmpeg_decode_to_wav
 from utils.logger import TTLogger
 
@@ -41,14 +46,6 @@ AUDIO_VENV_PYTHON = os.getenv(
 
 # Path to the diarize.py script invoked inside the audio venv.
 DIARIZE_SCRIPT = Path(__file__).parent / "diarize.py"
-
-
-class AudioTooLongError(ValueError):
-    """Submitted audio exceeds the runner's maximum duration.
-
-    Subclasses ValueError so existing `except ValueError` callers still catch it;
-    the route layer maps it to 400 rather than the generic 500.
-    """
 
 
 class PreparedAudio(NamedTuple):

--- a/tt-media-server/utils/audio_manager.py
+++ b/tt-media-server/utils/audio_manager.py
@@ -43,6 +43,14 @@ AUDIO_VENV_PYTHON = os.getenv(
 DIARIZE_SCRIPT = Path(__file__).parent / "diarize.py"
 
 
+class AudioTooLongError(ValueError):
+    """Submitted audio exceeds the runner's maximum duration.
+
+    Subclasses ValueError so existing `except ValueError` callers still catch it;
+    the route layer maps it to 400 rather than the generic 500.
+    """
+
+
 class PreparedAudio(NamedTuple):
     """Decoded audio plus the operating point it was submitted at.
 
@@ -402,7 +410,7 @@ class AudioManager:
                 source_sample_rate,
                 source_channels,
             ) = self._convert_to_audio_array(audio_bytes, audio_format)
-            audio_array, duration_seconds = self._validate_and_truncate_duration(
+            audio_array, duration_seconds = self._validate_duration(
                 audio_array, should_preprocess
             )
             prepared = PreparedAudio(
@@ -411,6 +419,10 @@ class AudioManager:
                 source_sample_rate=source_sample_rate,
                 source_channels=source_channels,
             )
+        except AudioTooLongError:
+            # Already specific and actionable - let it reach the route layer
+            # intact so it maps to 400 instead of a generic 500.
+            raise
         except Exception as e:
             self._logger.error(f"Failed to decode audio data: {e}")
             raise ValueError(f"Failed to process audio data: {str(e)}")
@@ -444,7 +456,12 @@ class AudioManager:
             or end - start <= target_chunk_duration + 1e-6
         ):
             return [
-                {"start": float(start), "end": float(end), "text": "", "speaker": speaker}
+                {
+                    "start": float(start),
+                    "end": float(end),
+                    "text": "",
+                    "speaker": speaker,
+                }
             ]
         chunks = []
         t = float(start)
@@ -970,15 +987,23 @@ class AudioManager:
             self._logger.error(f"Failed to decode {format_name} file: {e}")
             raise ValueError(f"Could not decode {format_name} file: {str(e)}")
 
-    def _validate_and_truncate_duration(self, audio_array, should_preprocess):
+    def _validate_duration(self, audio_array, should_preprocess):
+        """Reject audio longer than the active runner's cap.
+
+        Previously this truncated and returned the shortened array, so an
+        over-length clip came back 200 with a transcript covering only the head
+        and no indication the tail was dropped (measured on Qwen3-ASR: a 600s
+        clip returned byte-identical output to a 320s one). Callers cannot
+        detect that, so it is an error now.
+        """
         duration_seconds = len(audio_array) / settings.default_sample_rate
 
         # Qwen3-ASR fans a long clip out across device runners using fixed-duration
         # windows, so it handles long audio without depending on the diarization
-        # model. Cap is one full Galaxy wave (320s = 32 runners * 10s). Without this
-        # Qwen branch, clips >max_audio_duration_seconds (60s) were silently
-        # truncated on boxes where the diarization model isn't loaded, dropping the
-        # tail (measured: 91.5s clip -> only first 60s transcribed, 86/251 words
+        # model. Cap is one full Galaxy wave (320s = 32 runners * 10s). The Qwen
+        # branch exists because clips >max_audio_duration_seconds (60s) were being
+        # cut on boxes where the diarization model isn't loaded, dropping the tail
+        # (measured: 91.5s clip -> only first 60s transcribed, 86/251 words
         # deleted). Whisper/other ASR keep the original diarization-gated limit.
         if settings.model_runner == ModelRunners.TT_QWEN3_ASR.value:
             max_duration = settings.max_audio_duration_qwen3_asr_seconds
@@ -988,11 +1013,14 @@ class AudioManager:
             max_duration = settings.max_audio_duration_seconds
 
         if duration_seconds > max_duration:
-            max_samples = int(max_duration * settings.default_sample_rate)
-            self._logger.warning(
-                f"Audio truncated from {duration_seconds:.2f}s to {max_duration}s"
+            self._logger.error(
+                f"Audio duration {duration_seconds:.2f}s exceeds maximum {max_duration}s"
             )
-            return audio_array[:max_samples], max_duration
+            raise AudioTooLongError(
+                f"Audio duration {duration_seconds:.2f}s exceeds the maximum "
+                f"supported duration of {max_duration}s for this model. "
+                f"Split the audio into shorter segments and submit them separately."
+            )
         return audio_array, duration_seconds
 
     @log_execution_time("Normalizing speaker IDs")

--- a/tt-media-server/utils/errors.py
+++ b/tt-media-server/utils/errors.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Exception types that must survive the worker-process boundary.
+
+``CpuWorkloadHandler`` runs service pre-processing in a separate process and
+marshals failures back to the event loop through a ``multiprocessing.Queue``,
+which cannot carry a live exception object. It therefore sends the message plus
+the exception's class name, and the parent rebuilds the type from
+:data:`RECONSTRUCTIBLE_ERRORS`.
+
+Without that, every worker failure arrived as a bare ``Exception`` and route
+handlers could only map it to 500 - including client mistakes like submitting
+over-length audio, which should be a 4xx.
+
+This module deliberately imports nothing from the package: ``cpu_workload_handler``
+imports it, so anything heavier would risk an import cycle.
+"""
+
+
+class AudioTooLongError(ValueError):
+    """Submitted audio exceeds the runner's maximum duration.
+
+    Subclasses ValueError so existing ``except ValueError`` callers still catch
+    it; the route layer maps it to 400 rather than the generic 500.
+    """
+
+
+# Only types listed here are rebuilt on the parent side. Anything else stays a
+# generic Exception, preserving the previous behaviour for unknown failures.
+RECONSTRUCTIBLE_ERRORS = {cls.__name__: cls for cls in (AudioTooLongError,)}
+
+
+def reconstruct_worker_error(type_name, message):
+    """Rebuild a worker exception from its class name, falling back to Exception.
+
+    ``type_name`` is None for workers that predate the three-element error
+    payload, so the fallback also covers a rolling upgrade.
+    """
+    error_class = RECONSTRUCTIBLE_ERRORS.get(type_name)
+    if error_class is None:
+        return Exception(message)
+    return error_class(message)


### PR DESCRIPTION
## Problem

`AudioManager._validate_and_truncate_duration` cut any clip past the active runner's
cap and returned the shortened array. The request then succeeded: the caller got
`200`, a transcript covering only the head of their audio, and nothing indicating the
tail had been dropped. The only trace was a server-side `WARNING` line.

Measured on a live Qwen3-ASR Galaxy deployment (cap 320s), submitting the same
LibriSpeech-derived clip at increasing lengths:

| Input | HTTP | Reported `duration` | Transcript |
|---|---|---|---|
| 300s | 200 | 300.0 | full |
| 320s | 200 | 320.0 | full |
| 321s | 200 | **320.0** | truncated |
| 480s | 200 | **320.0** | truncated |
| 600s | 200 | **320.0** | truncated |

Clips at 320s, 321s, 360s, 480s and 600s all returned **byte-identical** transcripts
(`sha256[:16] = 2f06f48b71bbe817`). A caller submitting a 10-minute recording received
a plausible, complete-looking transcript of the first 5m20s.

This was **not Qwen3-ASR specific** — `_validate_and_truncate_duration` was shared by
every audio runner. Whisper hit the same path at 60s (or 300s with the diarization
model loaded). Its extra check in `whisper_runner.py` only logs `"exceeds recommended
maximum"` and continues. No error path existed anywhere.

## Changes

**1. Reject over-length audio instead of truncating it** (`e514acdd`)

`_validate_and_truncate_duration` → `_validate_duration`, raising `AudioTooLongError`
with the actual and maximum durations and a "split into shorter segments" hint, mapped
to `400` in the route layer alongside the existing download-cap mappings in
`open_ai_api/video.py`. It subclasses `ValueError` so existing `except ValueError`
callers keep catching it, and `to_audio_array` re-raises it ahead of the generic
handler that would otherwise flatten it into a 500.

**2. Let the test harness authenticate with a non-default API key** (`47ac0f5c`)

The audio/media test paths hardcoded `Bearer your-secret-key` across 31 files and never
read the environment, so the harness could only talk to a server still on the published
default key. Running the release workflow against a hardened deployment produced 401s
that surfaced as *misleading results rather than auth errors* — `librispeech_test_other`
WER came back as **100.0** (published 96.46) because every request was rejected and
scored as an empty transcript. With `API_KEY` honoured, the same run gives WER **3.5513**
(score 96.4487, within the 0.05 tolerance) and 8/8 spec tests passing.

`"your-secret-key"` is kept as the fallback, so CI — which brings up its own server on
the default key — is unaffected. Matches the pattern already used by
`test_module/llm_tests/agentic_eval_tests.py`.

**3. Preserve worker exception types so the 400 actually reaches the client** (`273c606f`)

Change 1 was verified on a live deployment and returned **500, not 400**. Audio
pre-processing runs in a `CpuWorkloadHandler` worker *process*, and failures were
marshalled back through a `multiprocessing.Queue` as `(task_id, str(e))` then rebuilt as
a bare `Exception`. The message survived; the type did not, so `except AudioTooLongError`
never matched.

The class name now travels with the message and registered types are rebuilt on the
parent side. Only types in `RECONSTRUCTIBLE_ERRORS` are reconstructed — everything else
stays a generic `Exception`, preserving current behaviour for unrelated failures. The
listener tolerates both the old two-element payload and the `(None, None)` shutdown
sentinel.

`AudioTooLongError` moved to `utils/errors.py`, which imports nothing from the package:
`cpu_workload_handler` imports it, and pulling in `audio_manager` (numpy, ffmpeg) would
risk a cycle. It is re-exported from `utils.audio_manager`, and a test asserts both import
paths resolve to the same class object so they cannot silently fork.

## Verification

End-to-end against the deployed image on a Galaxy box:

| Input | Before | After |
|---|---|---|
| 300s | 200, dur=300 | 200, dur=300 |
| 320s | 200, dur=320 | 200, dur=320 |
| 321s | **200, dur=320** (silent truncation) | **400** |
| 480s | **200, dur=320** | **400** |
| 600s | **200, dur=320** | **400** |

Auth unregressed (no key → 401, real key → 200). Models CI release run against `47ac0f5c`:
acceptance PASS, evals 1/1, benchmarks 1/1 (all three tiers), spec tests 6/6, 8/8 at 100%.

The unit tests for change 1 passed while the real path was broken, because they call
`_validate_duration` in-process where nothing is ever marshalled. Change 3 therefore adds
tests that drive a **live `CpuWorkloadHandler` across a real process boundary**; the
type-preserving assertion fails with the handler fix reverted and passes with it.

## Reviewer notes

- **Breaking API change.** Clients relying on over-length audio quietly succeeding now
  receive `400`. Whisper's default cap is 60s, so this is a low bar — any existing caller
  or test submitting >60s to Whisper and expecting `200` will need updating.
- **`cpu_workload_handler.py` is shared** by the audio, video, image and TTS services.
  The change is narrow by construction (unregistered exceptions behave exactly as before),
  but only the Qwen3-ASR path is exercised by the release suite. A CI run covering the
  other media models before merge would be worthwhile.
- Models CI has been run against `47ac0f5c`, **not** against `273c606f`. That commit is
  covered by unit tests and the live end-to-end verification above.
- Raising the cap is a one-line settings change, but per the comment on
  `max_audio_duration_qwen3_asr_seconds` it spills into extra runner waves — throughput
  past 320s will not scale as it does within one wave.
