### PR TITLE
feat: default to port 443 if https and no port is provided

### DIFF
--- a/run.py
+++ b/run.py
@@ -199,15 +199,17 @@ def parse_arguments():
     parser.add_argument(
         "--service-port",
         type=str,
-        help="SERVICE_PORT",
-        default=os.getenv("SERVICE_PORT", "8000"),
+        default=None,
+        help="SERVICE_PORT. Defaults to the SERVICE_PORT env var, then 443 when "
+        "--server-url is an https URL without an explicit port, else 8000.",
     )
     parser.add_argument(
         "--server-url",
         type=str,
         default=None,
         help="Base URL of an already-running inference server to target (e.g. 'http://192.168.1.10'). "
-        "Overrides the default http://127.0.0.1. Use together with --service-port when not using --docker-server or --local-server.",
+        "Overrides the default http://127.0.0.1. Use together with --service-port when not using --docker-server or --local-server. "
+        "An explicit port in the URL wins; an https URL without a port defaults to 443 unless --service-port is given.",
     )
     parser.add_argument(
         "--bind-host",
@@ -732,6 +734,14 @@ def parse_arguments():
             args.server_url = normalize_server_url(args.server_url)
         except ValueError as e:
             parser.error(str(e))
+    if args.service_port is None:
+        # Precedence: explicit --service-port > SERVICE_PORT env > 443 for an
+        # https --server-url without a port > 8000.
+        from utils.url_helpers import default_service_port
+
+        args.service_port = os.getenv("SERVICE_PORT") or default_service_port(
+            args.server_url
+        )
     if args.custom_weights is not None:
         if not args.custom_weights.strip():
             parser.error("--custom-weights cannot be empty.")

--- a/run_workflows.py
+++ b/run_workflows.py
@@ -135,7 +135,15 @@ def parse_args() -> argparse.Namespace:
         parser.add_argument("--device", required=True, choices=valid_devices)
     parser.add_argument("--workflow", required=True, choices=valid_workflows)
     add_requirements_argument(parser)
-    parser.add_argument("--service-port", type=int, default=8000)
+    parser.add_argument(
+        "--service-port",
+        type=int,
+        default=None,
+        help=(
+            "Service port of the inference server. Defaults to 443 when "
+            "--server-url is an https URL without an explicit port, else 8000."
+        ),
+    )
     parser.add_argument(
         "--server-url",
         type=str,
@@ -144,7 +152,8 @@ def parse_args() -> argparse.Namespace:
             "Base URL of an already-running inference server to target "
             "(e.g. 'http://192.168.1.10'). Overrides the default localhost "
             "host; combine with --service-port unless the URL carries an "
-            "explicit port. Propagated from v1 run.py --server-url through "
+            "explicit port (an https URL without a port defaults to 443). "
+            "Propagated from v1 run.py --server-url through "
             "the workflow dispatch."
         ),
     )
@@ -525,6 +534,13 @@ def parse_args() -> argparse.Namespace:
             args.server_url = normalize_server_url(args.server_url)
         except ValueError as e:
             parser.error(str(e))
+    if args.service_port is None:
+        # run.py always forwards --service-port when dispatching, so this
+        # default only fires on direct invocations: 443 for an https
+        # --server-url without a port, else 8000.
+        from utils.url_helpers import default_service_port
+
+        args.service_port = int(default_service_port(args.server_url))
     if args.prefix_cache and args.workflow not in ("benchmarks", "release"):
         parser.error(
             "--prefix-cache currently requires --workflow benchmarks or release "

--- a/tests/test_run_arguments.py
+++ b/tests/test_run_arguments.py
@@ -594,6 +594,59 @@ class TestModelSpecCliArgsCompatibility:
         assert args.host_hf_cache == "/home/user/.cache/huggingface"
         assert args.image_user == "15863"
 
+    def test_service_port_defaults_to_443_for_https_server_url(self, base_args):
+        """--server-url https://host without a port targets 443 by default."""
+        full_args = base_args + ["--server-url", "https://example.com"]
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SERVICE_PORT", None)
+            with patch("sys.argv", ["run.py"] + full_args):
+                args = parse_arguments()
+
+        assert args.server_url == "https://example.com"
+        assert args.service_port == "443"
+
+    def test_explicit_service_port_wins_over_https_default(self, base_args):
+        """An explicit --service-port is used even for https URLs."""
+        full_args = base_args + [
+            "--server-url",
+            "https://example.com",
+            "--service-port",
+            "9000",
+        ]
+        with patch("sys.argv", ["run.py"] + full_args):
+            args = parse_arguments()
+
+        assert args.service_port == "9000"
+
+    def test_service_port_env_wins_over_https_default(self, base_args):
+        """SERVICE_PORT env var beats the https 443 default."""
+        full_args = base_args + ["--server-url", "https://example.com"]
+        with patch.dict(os.environ, {"SERVICE_PORT": "9001"}, clear=False):
+            with patch("sys.argv", ["run.py"] + full_args):
+                args = parse_arguments()
+
+        assert args.service_port == "9001"
+
+    def test_service_port_stays_8000_for_https_url_with_port(self, base_args):
+        """A port in the URL wins downstream; service_port keeps the 8000 default."""
+        full_args = base_args + ["--server-url", "https://example.com:8443"]
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SERVICE_PORT", None)
+            with patch("sys.argv", ["run.py"] + full_args):
+                args = parse_arguments()
+
+        assert args.service_port == "8000"
+
+    def test_service_port_stays_8000_for_http_server_url(self, base_args):
+        """Plain http URLs keep the historical 8000 default."""
+        full_args = base_args + ["--server-url", "http://example.com"]
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SERVICE_PORT", None)
+            with patch("sys.argv", ["run.py"] + full_args):
+                args = parse_arguments()
+
+        assert args.service_port == "8000"
+
 
 class TestArgsInference:
     """Tests for argument inference and validation."""

--- a/utils/url_helpers.py
+++ b/utils/url_helpers.py
@@ -19,10 +19,12 @@ Resolution precedence (used by :func:`resolve_deploy_url`):
 from __future__ import annotations
 
 import os
-from typing import Tuple
+from typing import Optional, Tuple
 from urllib.parse import urlparse
 
 DEFAULT_DEPLOY_URL = "http://127.0.0.1"
+DEFAULT_SERVICE_PORT = "8000"
+DEFAULT_HTTPS_PORT = "443"
 
 
 def normalize_server_url(value: str) -> str:
@@ -45,6 +47,21 @@ def normalize_server_url(value: str) -> str:
             "--server-url must include a hostname (e.g. 'http://127.0.0.1')."
         )
     return server_url
+
+
+def default_service_port(deploy_url: Optional[str]) -> str:
+    """Default service port when neither the URL nor ``--service-port`` gives one.
+
+    An ``https`` URL without an explicit port defaults to 443 (standard TLS
+    port); everything else keeps the historical 8000. Callers must only use
+    this when the user did not pass ``--service-port`` (or ``SERVICE_PORT``)
+    explicitly — an explicit port always wins.
+    """
+    if deploy_url:
+        parsed = urlparse(deploy_url.rstrip("/"))
+        if parsed.scheme == "https" and parsed.port is None:
+            return DEFAULT_HTTPS_PORT
+    return DEFAULT_SERVICE_PORT
 
 
 def resolve_deploy_url(runtime_config=None) -> str:


### PR DESCRIPTION
## Summary

When targeting an already-running server with \`--server-url https://<host>` (no explicit port), the port resolution previously fell back to \`--service-port\`'s default of 8000 . This PR makes 443 the default for https (not http) URLs.

## Port resolution precedence (new)

1. Port explicitly in the URL (\`https://host:8443\`) — wins (unchanged)
2. Explicit \`--service-port\` flag — wins
3. \`SERVICE_PORT\` env var (run.py only, as before)
4. **\`https\` URL with no port → 443 (new)**
5. Otherwise → 8000 (unchanged)

## Implementation

- \`utils/url_helpers.py\`: new \`default_service_port()\` helper next to the existing port-wins logic (\`build_base_url\` / \`resolve_host_port\`).
- \`run.py\`: \`--service-port\` argparse default changed to \`None\` so an explicit user value is distinguishable from the default, then resolved post-parse (flag → env → scheme default).
- \`run_workflows.py\`: same default resolution for direct invocations. When dispatched from \`run.py\`, the resolved port is always forwarded explicitly via \`workflow_dispatch.py\`, so behavior is unchanged on that path.
