### PR TITLE
Build pinned Quetzal wheel into TTIS image

### DIFF
--- a/scripts/build_single_docker.sh
+++ b/scripts/build_single_docker.sh
@@ -74,6 +74,8 @@ UBUNTU_VERSION="20.04"
 CONTAINER_APP_UID=1000
 TT_METAL_COMMIT_SHA_OR_TAG=v0.56.0-rc6
 TT_VLLM_COMMIT_SHA_OR_TAG=b9564bf364e95a3850619fc7b2ed968cc71e30b7
+TT_QUETZAL_COMMIT_SHA=""
+TT_QUETZAL_SOURCE_DIR=""
 TAG_SUFFIX=""
 IMAGE_REPO="ghcr.io/tenstorrent/tt-inference-server"
 # ------------------------------------------------------------------------------
@@ -111,6 +113,22 @@ while [ $# -gt 0 ]; do
                 exit 1
             fi
             TT_VLLM_COMMIT_SHA_OR_TAG="$2"
+            shift
+            ;;
+        --quetzal-commit)
+            if [ $# -lt 2 ]; then
+                echo "⛔ Error: --quetzal-commit requires a value."
+                exit 1
+            fi
+            TT_QUETZAL_COMMIT_SHA="$2"
+            shift
+            ;;
+        --quetzal-source-dir)
+            if [ $# -lt 2 ]; then
+                echo "⛔ Error: --quetzal-source-dir requires a value."
+                exit 1
+            fi
+            TT_QUETZAL_SOURCE_DIR="$2"
             shift
             ;;
         --ubuntu-version)
@@ -172,6 +190,40 @@ if [[ "$CONTAINER_APP_UID" =~ ^[0-9]+$ ]] && (( $CONTAINER_APP_UID >= 1000 && $C
 else
     echo "CONTAINER_APP_UID=${CONTAINER_APP_UID} is not a number or outside expected range of 1000 to 59999."
 fi
+QUETZAL_SOURCE_CONTEXT=""
+QUETZAL_SOURCE_ARCHIVE=""
+cleanup_quetzal_source_context() {
+    if [[ -n "$QUETZAL_SOURCE_CONTEXT" && -d "$QUETZAL_SOURCE_CONTEXT" ]]; then
+        rm -rf -- "$QUETZAL_SOURCE_CONTEXT"
+    fi
+}
+trap cleanup_quetzal_source_context EXIT
+if [[ -n "$TT_QUETZAL_COMMIT_SHA" || -n "$TT_QUETZAL_SOURCE_DIR" ]]; then
+    if [[ ! "$TT_QUETZAL_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "⛔ Error: --quetzal-commit must be a lowercase 40-hex commit."
+        exit 1
+    fi
+    if [[ -z "$TT_QUETZAL_SOURCE_DIR" ]]; then
+        echo "⛔ Error: --quetzal-source-dir is required with --quetzal-commit."
+        exit 1
+    fi
+    if ! QUETZAL_SOURCE_HEAD=$(git -C "$TT_QUETZAL_SOURCE_DIR" rev-parse --verify HEAD 2>/dev/null); then
+        echo "⛔ Error: --quetzal-source-dir must be a Git checkout."
+        exit 1
+    fi
+    if [[ "$QUETZAL_SOURCE_HEAD" != "$TT_QUETZAL_COMMIT_SHA" ]]; then
+        echo "⛔ Error: Quetzal source HEAD does not match --quetzal-commit."
+        exit 1
+    fi
+    QUETZAL_SOURCE_CONTEXT=$(mktemp -d "${TMPDIR:-/tmp}/ttis-quetzal-source.XXXXXX")
+    QUETZAL_SOURCE_ARCHIVE="${QUETZAL_SOURCE_CONTEXT}/source.tar"
+    git -C "$TT_QUETZAL_SOURCE_DIR" archive --format=tar "$TT_QUETZAL_COMMIT_SHA" > "$QUETZAL_SOURCE_ARCHIVE"
+    if ! DOCKER_BUILDKIT=1 docker build --help 2>&1 | grep -q -- '--secret'; then
+        echo "⛔ Error: Quetzal image builds require Docker BuildKit support for --secret."
+        exit 1
+    fi
+    export DOCKER_BUILDKIT=1
+fi
 cd "$repo_root"
 
 # build image vars
@@ -179,6 +231,10 @@ UBUNTU_VERSION="${UBUNTU_VERSION}"
 OS_VERSION="ubuntu-${UBUNTU_VERSION}-amd64"
 TT_METAL_COMMIT_DOCKER_TAG=${TT_METAL_COMMIT_SHA_OR_TAG}
 TT_VLLM_COMMIT_DOCKER_TAG=${TT_VLLM_COMMIT_SHA_OR_TAG}
+QUETZAL_IMAGE_SUFFIX=""
+if [[ -n "$TT_QUETZAL_COMMIT_SHA" ]]; then
+    QUETZAL_IMAGE_SUFFIX="-qz-${TT_QUETZAL_COMMIT_SHA:0:12}"
+fi
 CONTAINER_APP_UID="${CONTAINER_APP_UID}"
 IMAGE_VERSION=$(cat VERSION)
 # TODO: use this local source build of tt-metal dev image until
@@ -186,14 +242,18 @@ IMAGE_VERSION=$(cat VERSION)
 TT_METAL_DOCKERFILE_URL=local/tt-metal/tt-metalium/${OS_VERSION}:${TT_METAL_COMMIT_SHA_OR_TAG}
 
 
-dev_image_tag=${IMAGE_REPO}/vllm-tt-metal-src-dev-${OS_VERSION}:${IMAGE_VERSION}-${TT_METAL_COMMIT_DOCKER_TAG}-${TT_VLLM_COMMIT_DOCKER_TAG}${TAG_SUFFIX:+-${TAG_SUFFIX}}
-release_image_tag=${IMAGE_REPO}/vllm-tt-metal-src-release-${OS_VERSION}:${IMAGE_VERSION}-${TT_METAL_COMMIT_DOCKER_TAG}-${TT_VLLM_COMMIT_DOCKER_TAG}${TAG_SUFFIX:+-${TAG_SUFFIX}}
+dev_image_tag=${IMAGE_REPO}/vllm-tt-metal-src-dev-${OS_VERSION}:${IMAGE_VERSION}-${TT_METAL_COMMIT_DOCKER_TAG}-${TT_VLLM_COMMIT_DOCKER_TAG}${QUETZAL_IMAGE_SUFFIX}${TAG_SUFFIX:+-${TAG_SUFFIX}}
+release_image_tag=${IMAGE_REPO}/vllm-tt-metal-src-release-${OS_VERSION}:${IMAGE_VERSION}-${TT_METAL_COMMIT_DOCKER_TAG}-${TT_VLLM_COMMIT_DOCKER_TAG}${QUETZAL_IMAGE_SUFFIX}${TAG_SUFFIX:+-${TAG_SUFFIX}}
 
 # Initialize flags for whether to build each image locally.
 build_dev_image=true
 build_release_image=true
 
-if [ "$force_build" = true ]; then
+if [[ -n "$TT_QUETZAL_COMMIT_SHA" ]]; then
+    build=true
+    force_push=true
+    echo "Quetzal source supplied; forcing an exact image rebuild."
+elif [ "$force_build" = true ]; then
     echo "Force build option provided (--force-build). Skipping remote image checks; all images will be built locally."
 else
     # Check for the images independently, negating check_image_exists return
@@ -274,11 +334,20 @@ generate_model_specs_json()
         fi
         echo "✅ Generated model_spec.json"
 
+        QUETZAL_BUILD_ARGS=()
+        if [[ -n "$TT_QUETZAL_COMMIT_SHA" ]]; then
+            QUETZAL_BUILD_ARGS+=(
+                --build-arg "TT_QUETZAL_COMMIT_SHA=${TT_QUETZAL_COMMIT_SHA}"
+                --secret "id=quetzal_source,src=${QUETZAL_SOURCE_ARCHIVE}"
+            )
+        fi
+
         docker build \
         -t ${dev_image_tag} \
         --build-arg TT_METAL_DOCKERFILE_URL="${TT_METAL_DOCKERFILE_URL}" \
         --build-arg TT_METAL_COMMIT_SHA_OR_TAG="${TT_METAL_COMMIT_SHA_OR_TAG}" \
         --build-arg TT_VLLM_COMMIT_SHA_OR_TAG="${TT_VLLM_COMMIT_SHA_OR_TAG}" \
+        "${QUETZAL_BUILD_ARGS[@]}" \
         --build-arg CONTAINER_APP_UID="${CONTAINER_APP_UID}" \
         . -f vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
 

--- a/tests/test_quetzal_image_build.py
+++ b/tests/test_quetzal_image_build.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUILD_SCRIPT = REPO_ROOT / "scripts" / "build_single_docker.sh"
+DOCKERFILE = REPO_ROOT / "vllm-tt-metal" / "vllm.tt-metal.src.dev.Dockerfile"
+
+
+def _run_builder(
+    cwd: Path, *args: str, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(BUILD_SCRIPT), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def _builder_worktree(tmp_path: Path) -> Path:
+    worktree = tmp_path / "tt-inference-server"
+    worktree.mkdir()
+    subprocess.run(["git", "init", "-q", str(worktree)], check=True)
+    (worktree / "VERSION").write_text("0.0.0\n")
+    (worktree / "scripts").symlink_to(REPO_ROOT / "scripts", target_is_directory=True)
+    (worktree / "workflows").symlink_to(
+        REPO_ROOT / "workflows", target_is_directory=True
+    )
+    return worktree
+
+
+@pytest.mark.parametrize("bad_ref", ["main", "A" * 40, "a" * 39])
+def test_build_script_is_valid_bash_and_rejects_unpinned_quetzal_ref(tmp_path, bad_ref):
+    subprocess.run(["bash", "-n", str(BUILD_SCRIPT)], check=True)
+
+    result = _run_builder(
+        _builder_worktree(tmp_path),
+        "--quetzal-commit",
+        bad_ref,
+        "--quetzal-source-dir",
+        str(REPO_ROOT),
+    )
+
+    assert result.returncode != 0
+    assert "lowercase 40-hex commit" in result.stdout
+
+
+def test_build_script_rejects_source_head_mismatch(tmp_path):
+    result = _run_builder(
+        _builder_worktree(tmp_path),
+        "--quetzal-commit",
+        "0" * 40,
+        "--quetzal-source-dir",
+        str(REPO_ROOT),
+    )
+
+    assert result.returncode != 0
+    assert "source HEAD does not match" in result.stdout
+
+
+def test_build_script_requires_external_source_with_pinned_commit(tmp_path):
+    source_head = subprocess.check_output(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"], text=True
+    ).strip()
+
+    result = _run_builder(_builder_worktree(tmp_path), "--quetzal-commit", source_head)
+
+    assert result.returncode != 0
+    assert "--quetzal-source-dir is required" in result.stdout
+
+
+def test_quetzal_rebuild_pushes_when_remote_tag_already_exists(tmp_path):
+    worktree = _builder_worktree(tmp_path)
+    source_head = subprocess.check_output(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"], text=True
+    ).strip()
+    docker_log = tmp_path / "docker.log"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        '#!/bin/bash\nprintf \'%s\\n\' "$*" >> "$DOCKER_LOG"\n'
+        'if [ "$1 $2" = "build --help" ]; then echo --secret; fi\n'
+    )
+    fake_docker.chmod(0o755)
+    env = {
+        **os.environ,
+        "DOCKER_LOG": str(docker_log),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+    }
+
+    result = _run_builder(
+        worktree,
+        "--push",
+        "--quetzal-commit",
+        source_head,
+        "--quetzal-source-dir",
+        str(REPO_ROOT),
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    docker_commands = docker_log.read_text().splitlines()
+    pushes = [line for line in docker_commands if line.startswith("push ")]
+    builds = [
+        line
+        for line in docker_commands
+        if line.startswith("build ") or line.startswith("buildx bake ")
+    ]
+    assert builds
+    assert len(pushes) == 1
+    assert docker_commands.index(builds[-1]) < docker_commands.index(pushes[0])
+    assert f"-qz-{source_head[:12]}" in pushes[0]
+
+    docker_log.write_text("")
+    native = _run_builder(worktree, "--push", env=env)
+    assert native.returncode == 0, native.stdout + native.stderr
+    assert not any(
+        line.startswith("push ") for line in docker_log.read_text().splitlines()
+    )
+
+
+def test_quetzal_image_build_contract_is_minimal_and_credential_free():
+    build_script = BUILD_SCRIPT.read_text()
+    dockerfile = DOCKERFILE.read_text()
+
+    assert 'git -C "$TT_QUETZAL_SOURCE_DIR" archive --format=tar' in build_script
+    assert '--secret "id=quetzal_source,src=${QUETZAL_SOURCE_ARCHIVE}"' in build_script
+    assert 'QUETZAL_IMAGE_SUFFIX="-qz-${TT_QUETZAL_COMMIT_SHA:0:12}"' in build_script
+    assert "DOCKER_BUILDKIT=1 docker build --help" in build_script
+    assert "export DOCKER_BUILDKIT=1" in build_script
+    assert 'if [[ -n "$TT_QUETZAL_COMMIT_SHA" ]]; then' in build_script
+    assert "forcing an exact image rebuild" in build_script
+    assert "build=true" in build_script
+    assert "force_push=true" in build_script
+
+    assert "RUN --mount=type=secret,id=quetzal_source,required=false" in dockerfile
+    assert "uv build --wheel --out-dir /tmp/quetzal-wheel" in dockerfile
+    assert 'uv pip install --no-cache-dir --no-deps "$1"' in dockerfile
+    assert "import serving.artifact_discovery" in dockerfile
+    assert "import tt_quetzalcoatlus.vllm_plugin" in dockerfile
+    assert 'e.name == "quetzal_model_registry"' in dockerfile
+    assert dockerfile.count("import serving.artifact_discovery") == 2
+    assert (
+        "org.opencontainers.image.quetzal.revision=${TT_QUETZAL_COMMIT_SHA}"
+        in dockerfile
+    )
+    assert "TT_QUETZAL_COMMIT_SHA=${TT_QUETZAL_COMMIT_SHA}" in dockerfile
+
+    combined = build_script + dockerfile
+    assert "tt-quetzalcoatlus.git" not in combined
+    assert "mesh_graph_descriptor" not in combined
+    assert "PATCHSET" not in combined

--- a/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
+++ b/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # SPDX-License-Identifier: Apache-2.0
 #
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
@@ -13,6 +14,7 @@ FROM ${TT_METAL_DOCKERFILE_URL} AS builder
 # Build arguments
 ARG TT_METAL_COMMIT_SHA_OR_TAG
 ARG TT_VLLM_COMMIT_SHA_OR_TAG
+ARG TT_QUETZAL_COMMIT_SHA=""
 ARG TT_SMI_COMMIT_SHA_OR_TAG=v3.1.1
 ARG CONTAINER_APP_UID=1000
 ARG DEBIAN_FRONTEND=noninteractive
@@ -110,6 +112,36 @@ RUN /bin/bash -c "git clone https://github.com/tenstorrent/vllm-tt-plugin.git ${
     && rm -rf ${vllm_tt_plugin_dir}/.git \
     && { uv cache clean || echo 'WARN: uv cache clean failed'; true; }"
 
+# The optional source archive is supplied by the authenticated caller as a
+# BuildKit secret, so neither Git metadata nor credentials enter an image layer.
+# Installing without dependencies preserves the image's pinned tt-metal/vLLM stack.
+RUN --mount=type=secret,id=quetzal_source,required=false,target=/tmp/quetzal-source.tar \
+    set -eu; \
+    if [ -n "${TT_QUETZAL_COMMIT_SHA}" ]; then \
+      printf '%s' "${TT_QUETZAL_COMMIT_SHA}" | grep -Eq '^[0-9a-f]{40}$' \
+        || { echo 'TT_QUETZAL_COMMIT_SHA must be a lowercase 40-hex commit' >&2; exit 1; }; \
+      test -s /tmp/quetzal-source.tar \
+        || { echo 'Quetzal source archive is required for a Quetzal build' >&2; exit 1; }; \
+      mkdir -p /tmp/quetzal-source /tmp/quetzal-wheel; \
+      tar -xf /tmp/quetzal-source.tar -C /tmp/quetzal-source; \
+      cd /tmp/quetzal-source; \
+      . "${PYTHON_ENV_DIR}/bin/activate"; \
+      uv build --wheel --out-dir /tmp/quetzal-wheel; \
+      set -- /tmp/quetzal-wheel/*.whl; \
+      [ "$#" -eq 1 ] && [ -f "$1" ] \
+        || { echo 'Quetzal build must produce exactly one wheel' >&2; exit 1; }; \
+      uv pip install --no-cache-dir --no-deps "$1"; \
+      python -c 'import importlib.metadata as m; import serving.artifact_discovery; import tt_quetzalcoatlus.vllm_plugin; eps = [e for e in m.entry_points(group="vllm.general_plugins") if e.name == "quetzal_model_registry"]; assert len(eps) == 1; assert eps[0].value == "tt_quetzalcoatlus.vllm_plugin:register"'; \
+      cd /; \
+      rm -rf /tmp/quetzal-source /tmp/quetzal-wheel; \
+      { uv cache clean || echo 'WARN: uv cache clean failed'; true; }; \
+    elif [ -e /tmp/quetzal-source.tar ]; then \
+      echo 'Quetzal source archive requires TT_QUETZAL_COMMIT_SHA' >&2; \
+      exit 1; \
+    else \
+      echo 'Building native-only image (TT_QUETZAL_COMMIT_SHA unset)'; \
+    fi
+
 # Build tt-smi in separate venv to avoid conflicts with tt-metal venv
 RUN /bin/bash -c "git clone https://github.com/tenstorrent/tt-smi.git ${TT_SMI_DIR} \
     && cd ${TT_SMI_DIR} \
@@ -126,8 +158,11 @@ RUN /bin/bash -c "git clone https://github.com/tenstorrent/tt-smi.git ${TT_SMI_D
 # ==============================================================================
 FROM ${TT_METAL_DOCKERFILE_URL} AS runtime
 
+ARG TT_QUETZAL_COMMIT_SHA=""
+
 LABEL maintainer="Tom Stesco <tstesco@tenstorrent.com>" \
-    org.opencontainers.image.source=https://github.com/tenstorrent/tt-inference-server
+    org.opencontainers.image.source=https://github.com/tenstorrent/tt-inference-server \
+    org.opencontainers.image.quetzal.revision=${TT_QUETZAL_COMMIT_SHA}
 
 # IDENTICAL arguments and environment as builder stage
 ARG TT_METAL_COMMIT_SHA_OR_TAG
@@ -139,6 +174,7 @@ ARG APP_DIR="${HOME_DIR}/app"
 
 # IDENTICAL environment variables as builder stage
 ENV TT_METAL_COMMIT_SHA_OR_TAG=${TT_METAL_COMMIT_SHA_OR_TAG} \
+    TT_QUETZAL_COMMIT_SHA=${TT_QUETZAL_COMMIT_SHA} \
     SHELL=/bin/bash \
     TZ=America/Los_Angeles \
     CONTAINER_APP_USERNAME=${CONTAINER_APP_USERNAME} \
@@ -217,6 +253,12 @@ RUN cd ${PYTHON_ENV_DIR}/bin \
     && uv pip install --no-cache-dir -r ${APP_DIR}/requirements.txt \
     && uv cache clean" \
     && chown -R ${CONTAINER_APP_USERNAME}:${CONTAINER_APP_USERNAME} ${PYTHON_ENV_DIR}
+
+# Prove the plugin survived the builder-to-runtime copy and final requirements install.
+RUN if [ -n "${TT_QUETZAL_COMMIT_SHA}" ]; then \
+      /bin/bash -c "source '${PYTHON_ENV_DIR}/bin/activate' \
+        && python -c 'import importlib.metadata as m; import serving.artifact_discovery; import tt_quetzalcoatlus.vllm_plugin; eps = [e for e in m.entry_points(group=\"vllm.general_plugins\") if e.name == \"quetzal_model_registry\"]; assert len(eps) == 1; assert eps[0].value == \"tt_quetzalcoatlus.vllm_plugin:register\"'"; \
+    fi
 
 # Fix venv permissions (COPY --chown can break symlink permissions)
 RUN chmod -R +x ${PYTHON_ENV_DIR}/bin


### PR DESCRIPTION
## Summary

- add an opt-in Quetzal source pin to the existing single-image builder
- require an authenticated source URL and an exact lowercase 40-hex commit
- export a clean source archive through a BuildKit secret, without copying credentials or `.git` into the build context
- build exactly one Quetzal wheel and install it into the existing TTIS vLLM image with `--no-deps`
- smoke-test the Quetzal import and exact `quetzal_model_registry` entry point in both builder and final runtime stages
- suffix Quetzal image tags and force both rebuild and push when that immutable tag already exists

Native image tags, cache behavior, push behavior, and `latest` handling remain unchanged.

## Scope

This PR is image construction only. It does not add runtime admission, package mounts, catalog rows, Models CI enrollment, or Shield workflow changes.

## Validation

- 7 focused image-contract tests pass
- 43 affected tests passed in the final preparation audit
- Bash syntax, ShellCheck, repository-pinned Ruff, formatting, and `git diff --check` pass
- an independent review found no blocker and confirmed that native behavior remains unchanged

Docker is unavailable on the preparation host, so the required next gate is the real builder CI producing a digest-pinned image followed by the existing Exabox launch contract. The PR does not claim that downstream image receipt yet.

This small prerequisite lets Shield select an exact Quetzal source commit without reviving the old broad #1003 integration stack.
