### PR TITLE
logging: tolerate shutdown during handler construction

### DIFF
--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -29,6 +29,23 @@ def cleanup_handler():
 
 
 class TestAsyncLogHandler:
+    def test_vllm_import_logging_shutdown_during_init_is_safe(self, monkeypatch):
+        """A formatter import may close this handler before init completes."""
+
+        def formatter_that_reconfigures_logging():
+            logging.shutdown()
+            return logging.Formatter()
+
+        monkeypatch.setattr(
+            "utils.logging_utils._create_vllm_formatter",
+            formatter_that_reconfigures_logging,
+        )
+
+        handler = AsyncLogHandler()
+        assert handler._listener is not None
+        assert handler._listener._thread is not None
+        handler.close()
+
     def test_handler_emits_to_file(self, tmp_path):
         log_file = tmp_path / "test.log"
         handler = AsyncLogHandler(filename=str(log_file))

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -59,6 +59,10 @@ class AsyncLogHandler(logging.Handler):
 
     def __init__(self, filename=None, max_bytes=104857600, backup_count=5):
         super().__init__()
+        # Importing vLLM while creating its formatter can reconfigure logging,
+        # which closes every handler registered by ``Handler.__init__``.  Make
+        # close() safe during that partially constructed interval.
+        self._listener = None
         _safe_stop_listener(AsyncLogHandler._active_listener)
         AsyncLogHandler._active_listener = None
 


### PR DESCRIPTION
## Summary

- initialize `AsyncLogHandler` shutdown state before constructing its wrapped handler and formatter
- make cleanup safe if an imported dependency calls `logging.shutdown()` during handler construction
- preserve normal asynchronous logging behavior after successful initialization

## Why

Importing vLLM during a clean server launch can trigger logging shutdown while TTIS is still constructing `AsyncLogHandler`. Current `main` then accesses `_listener` before that attribute exists and aborts startup. The clean Exabox QB2 replay reproduced this deterministically before device serving and required this fix to reach health.

This is a generic logging lifecycle correction. It contains no Quetzal, model, device, or compiler special case.

## Validation

- 29 logging and server-launch tests pass
- the regression test shuts logging down during wrapped-handler construction and verifies cleanup remains safe
- repository Ruff, formatting, and `git diff --check` pass
- with the fix composed into job 80156, the C32768 server reached health in 65 seconds
