### PR TITLE
fix(gemma4 galaxy): mesh graph descriptor, fabric config, host-volume validation, KV pool, trace region

### DIFF
--- a/tests/test_run_vllm_api_server.py
+++ b/tests/test_run_vllm_api_server.py
@@ -344,3 +344,76 @@ def test_ensure_weights_available_raises_when_unreachable_and_no_weights(
 
     with pytest.raises(RuntimeError):
         run_vllm_api_server_module.ensure_weights_available(_weights_spec())
+
+
+def test_set_runtime_env_vars_expands_variable_references(
+    monkeypatch, run_vllm_api_server_module
+):
+    """A spec may name a path relative to an install root known only at runtime.
+
+    TT_MESH_GRAPH_DESC_PATH is the motivating case: tt-metal lives at
+    --tt-metal-home for a local server and somewhere else entirely in a
+    container image, so the spec cannot hard-code either.
+    """
+    monkeypatch.setenv("TT_METAL_HOME", "/opt/tt-metal")
+    monkeypatch.delenv("TT_MESH_GRAPH_DESC_PATH", raising=False)
+
+    run_vllm_api_server_module.set_runtime_env_vars(
+        {
+            "env_vars": {
+                "TT_MESH_GRAPH_DESC_PATH": (
+                    "${TT_METAL_HOME}/tt_metal/fabric/mesh_graph_descriptors/"
+                    "single_bh_galaxy_torus_xy_graph_descriptor.textproto"
+                )
+            }
+        }
+    )
+
+    assert os.environ["TT_MESH_GRAPH_DESC_PATH"] == (
+        "/opt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/"
+        "single_bh_galaxy_torus_xy_graph_descriptor.textproto"
+    )
+
+
+def test_set_runtime_env_vars_leaves_plain_values_untouched(
+    monkeypatch, run_vllm_api_server_module
+):
+    monkeypatch.delenv("MESH_DEVICE", raising=False)
+
+    run_vllm_api_server_module.set_runtime_env_vars(
+        {"env_vars": {"MESH_DEVICE": "BH-Galaxy"}}
+    )
+
+    assert os.environ["MESH_DEVICE"] == "BH-Galaxy"
+
+
+def test_set_runtime_env_vars_warns_but_sets_when_reference_unresolved(
+    monkeypatch, run_vllm_api_server_module, caplog
+):
+    """An unset reference must be reported here, not surface later as a
+    mysteriously missing file."""
+    monkeypatch.delenv("NOT_SET_ANYWHERE", raising=False)
+    monkeypatch.delenv("SOME_PATH", raising=False)
+
+    with caplog.at_level("WARNING"):
+        run_vllm_api_server_module.set_runtime_env_vars(
+            {"env_vars": {"SOME_PATH": "${NOT_SET_ANYWHERE}/descriptor.textproto"}}
+        )
+
+    assert "NOT_SET_ANYWHERE" in os.environ["SOME_PATH"]
+    assert any("still contains '$'" in r.message for r in caplog.records)
+
+
+def test_set_runtime_env_vars_expands_in_spec_order(
+    monkeypatch, run_vllm_api_server_module
+):
+    """Values are applied as they are read, so a later entry may reference an
+    earlier one."""
+    monkeypatch.delenv("TT_ROOT", raising=False)
+    monkeypatch.delenv("TT_DESC", raising=False)
+
+    run_vllm_api_server_module.set_runtime_env_vars(
+        {"env_vars": {"TT_ROOT": "/opt/tt-metal", "TT_DESC": "${TT_ROOT}/desc.textproto"}}
+    )
+
+    assert os.environ["TT_DESC"] == "/opt/tt-metal/desc.textproto"

--- a/tests/test_setup_host.py
+++ b/tests/test_setup_host.py
@@ -797,8 +797,13 @@ class TestSetupHostValidation:
         runtime_config = RuntimeConfig(**cli_defaults)
         return mock_spec, runtime_config
 
-    def test_mutual_exclusivity_host_volume_and_hf_cache(self):
-        """Setting both --host-volume and --host-hf-cache should raise."""
+    def test_host_volume_with_hf_cache_is_allowed(self):
+        """--host-volume says where CACHE_ROOT goes, not where weights come from.
+
+        Pairing it with an explicit weight source is the only way to keep the
+        converted-weight cache off the filesystem holding the checkout while
+        still loading weights from an already-verified HF cache.
+        """
         mock_spec, runtime_config = self._make_mock_model_spec_and_config(
             host_volume="/tmp/vol",
             host_hf_cache="/tmp/hf",
@@ -806,14 +811,9 @@ class TestSetupHostValidation:
         with patch.dict(
             "workflows.validate_setup.MODEL_SPECS", {mock_spec.model_id: mock_spec}
         ):
-            with pytest.raises(
-                ValueError,
-                match="Only one of --host-volume, --host-hf-cache, --host-weights-dir",
-            ):
-                validate_runtime_args(mock_spec, runtime_config)
+            validate_runtime_args(mock_spec, runtime_config)
 
-    def test_mutual_exclusivity_host_volume_and_weights_dir(self):
-        """Setting both --host-volume and --host-weights-dir should raise."""
+    def test_host_volume_with_weights_dir_is_allowed(self):
         mock_spec, runtime_config = self._make_mock_model_spec_and_config(
             host_volume="/tmp/vol",
             host_weights_dir="/tmp/weights",
@@ -821,11 +821,7 @@ class TestSetupHostValidation:
         with patch.dict(
             "workflows.validate_setup.MODEL_SPECS", {mock_spec.model_id: mock_spec}
         ):
-            with pytest.raises(
-                ValueError,
-                match="Only one of --host-volume, --host-hf-cache, --host-weights-dir",
-            ):
-                validate_runtime_args(mock_spec, runtime_config)
+            validate_runtime_args(mock_spec, runtime_config)
 
     def test_mutual_exclusivity_hf_cache_and_weights_dir(self):
         """Setting both --host-hf-cache and --host-weights-dir should raise."""
@@ -838,12 +834,12 @@ class TestSetupHostValidation:
         ):
             with pytest.raises(
                 ValueError,
-                match="Only one of --host-volume, --host-hf-cache, --host-weights-dir",
+                match="Only one of --host-hf-cache, --host-weights-dir",
             ):
                 validate_runtime_args(mock_spec, runtime_config)
 
     def test_all_three_set_raises(self):
-        """Setting all three weight source options should raise."""
+        """Two explicit weight sources still conflict, host_volume or not."""
         mock_spec, runtime_config = self._make_mock_model_spec_and_config(
             host_volume="/tmp/vol",
             host_hf_cache="/tmp/hf",
@@ -854,7 +850,7 @@ class TestSetupHostValidation:
         ):
             with pytest.raises(
                 ValueError,
-                match="Only one of --host-volume, --host-hf-cache, --host-weights-dir",
+                match="Only one of --host-hf-cache, --host-weights-dir",
             ):
                 validate_runtime_args(mock_spec, runtime_config)
 

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -532,6 +532,13 @@ def set_runtime_env_vars(model_spec_json):
     2. Nested: model_spec_json["device_model_spec"]["env_vars"] (raw JSON)
 
     Both locations are checked and merged, with top-level taking precedence.
+
+    Values may reference other environment variables in shell form ($VAR or
+    ${VAR}); they are expanded before being set. This lets a spec name a path
+    relative to an installation root that is only known at runtime — chiefly
+    TT_METAL_HOME, which differs between a local server (--tt-metal-home) and
+    a container image. Variables are expanded in spec order, so a later value
+    may reference one set earlier in the same spec.
     """
     env_vars = {}
 
@@ -562,6 +569,21 @@ def set_runtime_env_vars(model_spec_json):
                 f"env var value:={value} is not a string, converting to string: {value}"
             )
             value = str(value)
+
+        if "$" in value:
+            expanded = os.path.expandvars(value)
+            if "$" in expanded:
+                # expandvars leaves unknown names untouched, which would other-
+                # wise reach the consumer as a literal '$VAR' and fail somewhere
+                # far from here -- for a path, as a file that does not exist.
+                logger.warning(
+                    f"env var {key} still contains '$' after expansion: "
+                    f"{expanded!r} (from {value!r}); "
+                    "a referenced variable is not set"
+                )
+            else:
+                logger.info(f"expanded env var {key}: {value} -> {expanded}")
+            value = expanded
 
         original_value = os.getenv(key)
         if original_value is not None:

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -310,7 +310,15 @@ templates:
         # FABRIC_2D_TORUS_XY the mesh takes 10.6s to open -- the extra time is
         # the 2D routers actually being built -- and all_gather completes.
         fabric_config: FABRIC_2D_TORUS_XY
-        trace_region_size: 200000000
+        # Prefill trace capture on this mesh needs 222,085,120 B; at 200000000
+        # end_trace_capture aborts with
+        #   mesh_trace.cpp:81 get_trace_buffers_size() <= trace_region_size
+        # after the model has loaded, i.e. several minutes in. Warmup captures
+        # a trace per (batch size, sequence length) pair -- ISLs 128 through
+        # 4096 -- and the buffers accumulate, so this is sized with room for
+        # the set to grow rather than to the measured figure. 512 MiB is 1.6%
+        # of a P150's DRAM.
+        trace_region_size: 536870912  # 512 * 1024 * 1024
         # On-device decode sampling so token ids >= 65536 are reachable (host
         # sampling only sees device 0's vocab shard on a TP mesh).
         sample_on_device_mode: decode_only

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -266,7 +266,7 @@ templates:
       default_impl: true
       env_vars:
         # Fixed 4x8 2D torus mesh graph descriptor (RFP D.2). Not a partner choice.
-        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto"
+        TT_MESH_GRAPH_DESC_PATH: "${TT_METAL_HOME}/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto"
         # The logical mesh (MESH_DEVICE) is deliberately left to the operator
         # (RFP D.3); omit here to default to BH-Galaxy, or override per submission.
         GEMMA4_PAGE_BLOCK_SIZE: "64"
@@ -367,7 +367,7 @@ templates:
       default_impl: true
       env_vars:
         # Fixed 4x8 2D torus mesh graph descriptor (RFP D.2). Not a partner choice.
-        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto"
+        TT_MESH_GRAPH_DESC_PATH: "${TT_METAL_HOME}/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto"
         # Logical mesh (MESH_DEVICE) is the operator's choice (RFP D.3); omit to
         # default to BH-Galaxy, or set per submission.
       override_tt_config:
@@ -429,7 +429,7 @@ templates:
       default_impl: true
       env_vars:
         # Fixed 4x8 2D torus mesh graph descriptor (RFP D.2). Not a partner choice.
-        TT_MESH_GRAPH_DESC_PATH: "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto"
+        TT_MESH_GRAPH_DESC_PATH: "${TT_METAL_HOME}/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto"
         # Logical mesh (MESH_DEVICE) is the operator's choice (RFP D.3).
       override_tt_config:
         # Pinned for Milestone-0: 1D ring fabric (matches the vLLM plugin's

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -270,8 +270,35 @@ templates:
         # The logical mesh (MESH_DEVICE) is deliberately left to the operator
         # (RFP D.3); omit here to default to BH-Galaxy, or override per submission.
         GEMMA4_PAGE_BLOCK_SIZE: "64"
-        # Size the hybrid-off all-user KV pool to the full context on Galaxy DRAM.
-        GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
+        # Hybrid-off all-user KV pool. Every layer allocates a full-length
+        # buffer here, and the buffer is replicated to every device
+        # (ReplicateTensorToMesh), so the pool is bounded by ONE chip's DRAM
+        # (32 GB on a P150), not by the mesh's aggregate.
+        #
+        # Per token, per device, over the 60 layers at TP=4:
+        #   50 sliding x 4 kv x 256 hd x 2 B x 2 (K+V) = 204,800 B
+        #   10 full    x 1 kv x 512 hd x 2 B x 2 (K+V) =  20,480 B
+        #                                        total = 225,280 B
+        #
+        # 65,536 tokens is 14.8 GiB/device, against ~13 GiB of TP-sharded
+        # weights and the 200 MB trace region.
+        #
+        # This read 262144 while the plugin was allocating 1 KV head per
+        # device instead of 4 (16 // 32 devices rather than 16 // TP 4). At
+        # 71,680 B/token that fit in 18.8 GiB and masked the sizing; with the
+        # head count corrected the same value asks for 59 GiB and cannot be
+        # allocated. 262144 was never a Galaxy measurement — the comment it
+        # replaces claimed the full context fits, and at the true head count
+        # it does not.
+        #
+        # [TBD — Performance: raise to the measured ceiling. This is a
+        # bring-up value chosen to load, not a tuned one, and it caps servable
+        # context well below the graded sweep's top input lengths. Appendix
+        # B.1's loaded corner needs 32 x 262,016 tokens, which is three orders
+        # of magnitude beyond one chip's DRAM at this layout — closing that
+        # gap needs data parallelism across the 8 mesh rows, which are today
+        # replicas. Tracked separately.]
+        GEMMA4_MAX_TOKENS_ALL_USERS: "65536"
       override_tt_config:
         # Must agree with TT_MESH_GRAPH_DESC_PATH above, which declares a 4x8 2D
         # torus: 2D routing with deadlock avoidance on both wrapped axes. The
@@ -288,6 +315,30 @@ templates:
         # sampling only sees device 0's vocab shard on a TP mesh).
         sample_on_device_mode: decode_only
       vllm_args:
+        # Served context, which must fit the device KV pool above. vLLM refuses
+        # to start unless one max-length request fits
+        # (_check_enough_kv_cache_memory): the bound is
+        # num_blocks * block_size = 1056 * 64 = 67,584 tokens at
+        # GEMMA4_MAX_TOKENS_ALL_USERS 65536.
+        #
+        # Without this, max_model_len defaults to max_context (262144) and the
+        # engine exits during startup with "estimated maximum model length is
+        # 67584". Note vLLM's own figure in that message (220 GiB) is computed
+        # at tensor_parallel_size=1, i.e. the UNSHARDED head counts; the device
+        # holds a quarter of that at TP=4. The ratio is why the number looks
+        # unrecognisable next to the pool arithmetic above.
+        #
+        # max_context stays at the Appendix B.0 value: 262144 is the target
+        # this system is meant to reach, and overriding it here would hide the
+        # shortfall rather than record it.
+        #
+        # [TBD — Performance: this caps served context at 64K against a graded
+        # sweep whose top input lengths are 131,072 and 262,016, so four of the
+        # eighteen points cannot be served at any concurrency, and the loaded
+        # corner exceeds the pool from 4096 upward (32 x 4096 > 65,536). Not
+        # closable by tuning: see the pool comment above.]
+        max_model_len: "65536"
+        max_num_batched_tokens: "65536"
         enable-auto-tool-choice: true
         tool-call-parser: gemma4
         default-chat-template-kwargs: '{"enable_thinking": true}'

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -273,9 +273,16 @@ templates:
         # Size the hybrid-off all-user KV pool to the full context on Galaxy DRAM.
         GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
       override_tt_config:
-        # Pinned for Milestone-0: 1D ring fabric on the Galaxy. Matches the vLLM
-        # plugin's 6U-cluster default (tt_worker.get_fabric_config).
-        fabric_config: FABRIC_1D_RING
+        # Must agree with TT_MESH_GRAPH_DESC_PATH above, which declares a 4x8 2D
+        # torus: 2D routing with deadlock avoidance on both wrapped axes. The
+        # plugin's 6U default is FABRIC_1D_RING, which is 1D routing and cannot
+        # carry a 2D collective on a non-degenerate mesh -- all_gather asserts
+        # fabric_is_2d (all_gather_device_operation.cpp:44). Measured on a
+        # 32-chip BH Galaxy with this descriptor: under FABRIC_1D_RING the mesh
+        # opens in 0.9s and all_gather raises that assert; under
+        # FABRIC_2D_TORUS_XY the mesh takes 10.6s to open -- the extra time is
+        # the 2D routers actually being built -- and all_gather completes.
+        fabric_config: FABRIC_2D_TORUS_XY
         trace_region_size: 200000000
         # On-device decode sampling so token ids >= 65536 are reachable (host
         # sampling only sees device 0's vocab shard on a TP mesh).
@@ -371,9 +378,11 @@ templates:
         # Logical mesh (MESH_DEVICE) is the operator's choice (RFP D.3); omit to
         # default to BH-Galaxy, or set per submission.
       override_tt_config:
-        # Pinned for Milestone-0: 1D ring fabric (matches the vLLM plugin's
-        # 6U-Galaxy default).
-        fabric_config: FABRIC_1D_RING
+        # Must agree with the 4x8 2D torus named by TT_MESH_GRAPH_DESC_PATH
+        # above. FABRIC_1D_RING -- the plugin's 6U default -- is 1D routing and
+        # cannot carry a 2D collective on a non-degenerate mesh; see the
+        # BLACKHOLE_GALAXY entry for gemma-4-31B-it for the measurements.
+        fabric_config: FABRIC_2D_TORUS_XY
       # [TBD — Partner] vllm_args (reasoning/tool-call parsers, chat-template kwargs)
       # and a metadata block with reasoning_parser_name / tool_call_parser_name.
   # Milestone-0: FUNCTIONAL, not EXPERIMENTAL. required_target_tiers is EMPTY at
@@ -432,9 +441,11 @@ templates:
         TT_MESH_GRAPH_DESC_PATH: "${TT_METAL_HOME}/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto"
         # Logical mesh (MESH_DEVICE) is the operator's choice (RFP D.3).
       override_tt_config:
-        # Pinned for Milestone-0: 1D ring fabric (matches the vLLM plugin's
-        # 6U-Galaxy default).
-        fabric_config: FABRIC_1D_RING
+        # Must agree with the 4x8 2D torus named by TT_MESH_GRAPH_DESC_PATH
+        # above. FABRIC_1D_RING -- the plugin's 6U default -- is 1D routing and
+        # cannot carry a 2D collective on a non-degenerate mesh; see the
+        # BLACKHOLE_GALAXY entry for gemma-4-31B-it for the measurements.
+        fabric_config: FABRIC_2D_TORUS_XY
       # [TBD — Partner] vllm_args and a metadata block with the parser names.
   status: EXPERIMENTAL
 

--- a/workflows/validate_setup.py
+++ b/workflows/validate_setup.py
@@ -220,15 +220,31 @@ def validate_runtime_args(model_spec, runtime_config):
             "--local-server requires --tt-metal-home or TT_METAL_HOME to be set"
         )
 
-    # Validate mutual exclusivity of weight source options
-    weight_source_args = [
-        args.host_volume,
+    # Validate mutual exclusivity of weight source options.
+    #
+    # --host-hf-cache and --host-weights-dir are both weight sources and naming
+    # two of them is ambiguous.
+    #
+    # --host-volume is not a weight source. It is where CACHE_ROOT lives: the
+    # converted-weight cache, the logs and the weight symlink map. It only
+    # *implies* a source, because absent any other, weights are downloaded to
+    # cache_root/weights. Once a source is named explicitly there is nothing
+    # ambiguous about also saying where the cache goes, and the two are already
+    # handled by independent branches in SetupConfig (setup_host.py:83 sets the
+    # volume paths, :98 sets the weights mount).
+    #
+    # Refusing the combination left no way to express "weights from a specific,
+    # already-verified HF cache; converted-weight cache on a different volume"
+    # — which is what a host with a small root filesystem and a large data
+    # volume needs, and the converted-weight cache is the big one: it is
+    # rewritten per model *and* per mesh geometry.
+    explicit_weight_sources = [
         args.host_hf_cache,
         getattr(args, "host_weights_dir", None),
     ]
-    if sum(1 for a in weight_source_args if a) > 1:
+    if sum(1 for a in explicit_weight_sources if a) > 1:
         raise ValueError(
-            "Only one of --host-volume, --host-hf-cache, --host-weights-dir can be specified."
+            "Only one of --host-hf-cache, --host-weights-dir can be specified."
         )
 
     if "ENABLE_AUTO_TOOL_CHOICE" in os.environ:


### PR DESCRIPTION
## What

Five commits, each a wall the gemma-4-31B-it bring-up on a 32-chip Blackhole
Galaxy hit in this order. None is a tuning choice — every one is a
configuration that could not run at all without it:

- **`f6825f9d`** — `TT_MESH_GRAPH_DESC_PATH` resolved via `${TT_METAL_HOME}`.
  The catalog value was a relative path (`../../tt-metal/...`), and the local
  server runs from `<repo>/vllm-tt-metal/src`
  (`run_local_server.py:286`), so it resolved to a `tt-metal/` *inside* the
  inference-server checkout, which does not exist in either supported
  layout. `TT_FATAL @ metal_env.cpp:431`. `set_runtime_env_vars` now expands
  `$VAR`/`${VAR}` in spec `env_vars`, so a spec can name an install root only
  known at runtime — matching how `tt-media-server` and `tt-sglang-plugin`
  already build the same variable.
- **`1cd59742`** — `fabric_config: FABRIC_2D_TORUS_XY` for the three
  BLACKHOLE_GALAXY entries, to agree with the 4x8 torus descriptor the same
  entries name. They previously pinned `FABRIC_1D_RING` (the plugin's 6U
  default), which is 1D routing and cannot carry a 2D collective on a
  non-degenerate mesh: `all_gather` asserts `fabric_is_2d`
  (`all_gather_device_operation.cpp:44`). Measured on a 32-chip BH Galaxy:
  under `FABRIC_1D_RING` the mesh opens in 0.9s and `all_gather` raises that
  assert; under `FABRIC_2D_TORUS_XY` the mesh takes 10.6s (2D routers being
  built) and `all_gather` completes.
- **`c4f2bbf9`** — `--host-volume` is a cache location, not a weight source,
  so it may be given alongside `--host-hf-cache`. The prior validation
  refused the combination the Makefile needs to keep converted weights off
  root while pointing weights at a pre-verified HF cache.
- **`6c016b01`** — KV pool and served context sized to one chip's DRAM. The
  pool is replicated to every device (not sharded across the mesh), so it is
  bounded by one P150's DRAM, not by the mesh aggregate. The prior value
  (262144, full context) fit only because the plugin was allocating 1 KV
  head per device (`16 // 32`) instead of 4 (`16 // TP=4`); with the head
  count corrected (companion vllm-tt-plugin fix), the same value asks for 59
  GiB per device and vLLM refuses outright.
- **`df2d40f8`** — trace region 512 MiB. Prefill trace capture needs
  222,085,120 B and aborted at the previous 200,000,000 several minutes into
  the load, after weights were already converted.

## Testing

Confirmed on a real 32-chip Blackhole Galaxy (`tt-device blackhole_galaxy`):
mesh opens on all 32 devices in the committed `4x8_Mesh_flat_torus_xy`
topology, weights convert, KV cache allocates
(`num_gpu_blocks_override=1056`, 67,584 tokens), warm-up runs, and — with the
companion vllm-tt-plugin fixes — the server comes up and serves real
requests with 0 errors across a benchmark sweep.

Also files a separate blocker for what these five commits do not fix: a
device-side fabric hang reached during warm-up at 65,536 batched tokens
(`max_num_seqs: 32`, the graded concurrency for this model/device), isolated
to be state-dependent rather than caused by any of the above.