### PR TITLE
Sanitize 4xx/5xx bodies from the vLLM API server (Cobalt PT40893_8, tt-cloud-console#1152)

### DIFF
--- a/tests/test_error_response_sanitizer.py
+++ b/tests/test_error_response_sanitizer.py
@@ -1,0 +1,477 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Tests for utils.error_response_sanitizer (tenstorrent/tt-cloud-console#1152).
+
+The first group drives the pure-ASGI middleware directly with a fake app so it
+needs no web framework. The last test rebuilds the tenstorrent/vllm fork's
+``validation_exception_handler`` on top of the installed FastAPI and checks that
+the exact body Cobalt reported (endpoint file path, container username, Pydantic
+wrap-validator marker) is cleaned end to end; it is skipped when FastAPI is not
+installed.
+"""
+
+import asyncio
+import json
+import re
+
+import pytest
+
+from utils import error_response_sanitizer as ers
+from utils.error_response_sanitizer import (
+    ERROR_SANITIZER_MIDDLEWARE,
+    ErrorResponseSanitizerMiddleware,
+    sanitize_error_body,
+    sanitize_error_text,
+)
+
+# Verbatim from Cobalt PT40893_8 (2026-08-29), response to `POST /tokenize {}`.
+COBALT_MESSAGE = (
+    "2 validation errors:\n"
+    "  {'type': 'missing', 'loc': ('body', 'function-wrap[__log_extra_fields__()]', "
+    "'prompt'), 'msg': 'Field required', 'input': {}}\n"
+    "  {'type': 'missing', 'loc': ('body', 'function-wrap[__log_extra_fields__()]', "
+    "'messages'), 'msg': 'Field required', 'input': {}}\n\n"
+    '  File "/home/container_app_user/vllm/vllm/entrypoints/utils.py", line 38, '
+    "in tokenize\n"
+    "    POST /tokenize [{'type': 'missing', 'loc': ('body', "
+    "'function-wrap[__log_extra_fields__()]', 'prompt'), 'msg': 'Field required', "
+    "'input': {}}, {'type': 'missing', 'loc': ('body', "
+    "'function-wrap[__log_extra_fields__()]', 'messages'), 'msg': 'Field required', "
+    "'input': {}}]"
+)
+
+LEAK_MARKERS = (
+    "container_app_user",
+    "/home/",
+    'File "',
+    "line 38",
+    "function-wrap",
+    "__log_extra_fields__",
+    "entrypoints/utils.py",
+    "POST /tokenize",
+)
+
+
+def assert_clean(text: str) -> None:
+    for marker in LEAK_MARKERS:
+        assert marker not in text, f"{marker!r} still present in {text!r}"
+
+
+# --------------------------------------------------------------------------- #
+# sanitize_error_text
+# --------------------------------------------------------------------------- #
+
+
+def test_sanitize_error_text_cleans_cobalt_validation_message():
+    cleaned = sanitize_error_text(COBALT_MESSAGE)
+
+    assert_clean(cleaned)
+    # The user-actionable part survives, with the internal loc marker removed.
+    assert cleaned == (
+        "2 validation errors:\n"
+        "  {'type': 'missing', 'loc': ('body', 'prompt'), 'msg': 'Field required', "
+        "'input': {}}\n"
+        "  {'type': 'missing', 'loc': ('body', 'messages'), 'msg': 'Field required', "
+        "'input': {}}"
+    )
+
+
+def test_sanitize_error_text_strips_traceback_but_keeps_exception_line():
+    message = (
+        "Traceback (most recent call last):\n"
+        '  File "/home/container_app_user/tt-metal/python_env/lib/python3.10/'
+        'site-packages/vllm/engine.py", line 42, in step\n'
+        "    x = foo()\n"
+        "        ^^^^^\n"
+        "ValueError: prompt too long <SamplingParams at 0x7f00deadbeef> "
+        "for /mnt/mldata/weights/model.safetensors"
+    )
+
+    cleaned = sanitize_error_text(message)
+
+    assert cleaned == "ValueError: prompt too long <SamplingParams> for <path>"
+
+
+def test_sanitize_error_text_handles_endpoint_only_context():
+    # FastAPI emits this form when it has the route path but no source info.
+    cleaned = sanitize_error_text(
+        "1 validation error:\n  {'x': 1}\n  Endpoint: /tokenize"
+    )
+    assert cleaned == "1 validation error:\n  {'x': 1}"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "",
+        "The model `meta-llama/Llama-3.1-8B-Instruct` does not exist.",
+        "Unsupported route. Try GET /v1/models or POST /v1/chat/completions.",
+        "max_tokens must be at least 1, got 0",
+        '{"error":"Unauthorized"}',
+    ],
+)
+def test_sanitize_error_text_leaves_legitimate_messages_alone(message):
+    assert sanitize_error_text(message) == message
+
+
+def test_sanitize_error_text_bounds_length():
+    cleaned = sanitize_error_text("x" * (ers.MAX_ERROR_STRING_CHARS + 500))
+    assert len(cleaned) == ers.MAX_ERROR_STRING_CHARS + len("...[truncated]")
+    assert cleaned.endswith("...[truncated]")
+
+
+# --------------------------------------------------------------------------- #
+# sanitize_error_body
+# --------------------------------------------------------------------------- #
+
+
+def _openai_envelope(message: str, status: int = 400) -> bytes:
+    return json.dumps(
+        {
+            "error": {
+                "message": message,
+                "type": "Bad Request",
+                "param": None,
+                "code": status,
+            }
+        }
+    ).encode()
+
+
+def test_sanitize_error_body_rewrites_openai_envelope_and_keeps_shape():
+    out = sanitize_error_body(_openai_envelope(COBALT_MESSAGE), 400, "application/json")
+
+    parsed = json.loads(out)
+    assert set(parsed["error"]) == {"message", "type", "param", "code"}
+    assert parsed["error"]["type"] == "Bad Request"
+    assert parsed["error"]["code"] == 400
+    assert_clean(parsed["error"]["message"])
+
+
+def test_sanitize_error_body_returns_identical_bytes_when_nothing_to_scrub():
+    body = _openai_envelope("max_tokens must be at least 1, got 0")
+    assert sanitize_error_body(body, 400, "application/json") is body
+
+
+def test_sanitize_error_body_handles_fastapi_detail_and_nested_lists():
+    body = json.dumps(
+        {
+            "detail": [
+                {
+                    "loc": ["body", "function-wrap[__log_extra_fields__()]", "prompt"],
+                    "msg": 'see File "/usr/lib/x.py", line 1, in f\n    boom',
+                }
+            ]
+        }
+    ).encode()
+
+    parsed = json.loads(sanitize_error_body(body, 422, "application/json"))
+
+    assert parsed["detail"][0]["msg"] == "see"
+    # Structure (a JSON list, not a repr'd tuple) is preserved; only strings change.
+    assert parsed["detail"][0]["loc"][0] == "body"
+
+
+def test_sanitize_error_body_scrubs_plain_text():
+    out = sanitize_error_body(
+        b'Internal Server Error\n  File "/opt/app/x.py", line 3, in g\n    raise',
+        500,
+        "text/plain; charset=utf-8",
+    )
+    assert out == b"Internal Server Error"
+
+
+def test_sanitize_error_body_leaves_binary_and_unknown_types_alone():
+    binary = b"\xff\xfe\x00binary"
+    assert sanitize_error_body(binary, 500, "application/octet-stream") is binary
+    html = b"<html>/home/container_app_user</html>"
+    assert sanitize_error_body(html, 502, "text/html") == b"<html><path></html>"
+    assert sanitize_error_body(b"", 500, "application/json") == b""
+
+
+# --------------------------------------------------------------------------- #
+# ErrorResponseSanitizerMiddleware (raw ASGI, no framework)
+# --------------------------------------------------------------------------- #
+
+
+def _run_asgi(app, method="POST", path="/tokenize"):
+    """Drive an ASGI app once and return (status, headers dict, body bytes)."""
+    scope = {"type": "http", "method": method, "path": path, "headers": []}
+    sent = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    asyncio.run(app(scope, receive, send))
+
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    body = b"".join(
+        m.get("body", b"") for m in sent if m["type"] == "http.response.body"
+    )
+    headers = {k.decode().lower(): v.decode() for k, v in start["headers"]}
+    return start["status"], headers, body, sent
+
+
+def _json_app(status: int, payload, chunks: int = 1, content_type=b"application/json"):
+    body = json.dumps(payload).encode()
+    sent_chunks = []
+
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [
+                    (b"content-type", content_type),
+                    (b"content-length", str(len(body)).encode()),
+                    (b"x-request-id", b"abc"),
+                ],
+            }
+        )
+        step = max(1, -(-len(body) // chunks))  # ceil -> at most `chunks` pieces
+        pieces = [body[i : i + step] for i in range(0, len(body), step)]
+        for piece in pieces[:-1]:
+            sent_chunks.append(piece)
+            await send({"type": "http.response.body", "body": piece, "more_body": True})
+        sent_chunks.append(pieces[-1])
+        await send(
+            {"type": "http.response.body", "body": pieces[-1], "more_body": False}
+        )
+
+    app.sent_chunks = sent_chunks
+    return app
+
+
+def test_middleware_rewrites_400_body_and_fixes_content_length():
+    app = ErrorResponseSanitizerMiddleware(
+        _json_app(
+            400,
+            {
+                "error": {
+                    "message": COBALT_MESSAGE,
+                    "type": "Bad Request",
+                    "param": None,
+                    "code": 400,
+                }
+            },
+        )
+    )
+
+    status, headers, body, _ = _run_asgi(app)
+
+    assert status == 400
+    assert headers["content-type"] == "application/json"
+    assert headers["x-request-id"] == "abc"  # other headers are preserved
+    assert int(headers["content-length"]) == len(body)
+    assert_clean(body.decode())
+    assert json.loads(body)["error"]["code"] == 400
+
+
+def test_middleware_reassembles_chunked_error_bodies():
+    payload = {
+        "error": {
+            "message": COBALT_MESSAGE,
+            "type": "Bad Request",
+            "param": None,
+            "code": 400,
+        }
+    }
+    app = ErrorResponseSanitizerMiddleware(_json_app(400, payload, chunks=7))
+
+    status, headers, body, sent = _run_asgi(app)
+
+    assert status == 400
+    assert int(headers["content-length"]) == len(body)
+    assert_clean(body.decode())
+    # One start + one body message reach the client, regardless of upstream chunking.
+    assert [m["type"] for m in sent] == ["http.response.start", "http.response.body"]
+
+
+def test_middleware_passes_success_responses_through_untouched_and_unbuffered():
+    leaky_but_ok = {
+        "choices": [{"text": 'File "/home/container_app_user/x.py", line 1, in f'}]
+    }
+    inner = _json_app(200, leaky_but_ok, chunks=3)
+    app = ErrorResponseSanitizerMiddleware(inner)
+
+    status, headers, body, sent = _run_asgi(app)
+
+    assert status == 200
+    assert json.loads(body) == leaky_but_ok  # model output is never rewritten
+    # Streaming shape preserved: start + every upstream chunk forwarded as-is.
+    assert len(inner.sent_chunks) > 1
+    assert [m.get("body") for m in sent[1:]] == inner.sent_chunks
+
+
+def test_middleware_passes_compressed_error_bodies_through():
+    body = b"\x1f\x8b-not-really-gzip-/home/container_app_user"
+
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 500,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-encoding", b"gzip"),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body, "more_body": False})
+
+    status, _, out, _ = _run_asgi(ErrorResponseSanitizerMiddleware(app))
+    assert status == 500
+    assert out == body  # cannot safely edit; do not corrupt it
+
+
+def test_middleware_replaces_oversized_error_body_with_bounded_generic_error(
+    monkeypatch,
+):
+    monkeypatch.setattr(ers, "MAX_BUFFERED_ERROR_BODY_BYTES", 1024)
+    huge = {
+        "error": {
+            "message": "x" * 5000,
+            "type": "Bad Request",
+            "param": None,
+            "code": 400,
+        }
+    }
+    app = ErrorResponseSanitizerMiddleware(_json_app(400, huge, chunks=10))
+
+    status, headers, body, sent = _run_asgi(app)
+
+    assert status == 400
+    assert len(body) < 1024
+    assert int(headers["content-length"]) == len(body)
+    parsed = json.loads(body)
+    assert parsed["error"]["code"] == 400
+    assert parsed["error"]["type"] == "Bad Request"
+    assert "withheld" in parsed["error"]["message"]
+    assert [m["type"] for m in sent] == ["http.response.start", "http.response.body"]
+
+
+def test_middleware_ignores_non_http_scopes():
+    seen = []
+
+    async def app(scope, receive, send):
+        seen.append(scope["type"])
+
+    asyncio.run(ErrorResponseSanitizerMiddleware(app)({"type": "lifespan"}, None, None))
+    assert seen == ["lifespan"]
+
+
+def test_middleware_logs_original_body_server_side(caplog):
+    app = ErrorResponseSanitizerMiddleware(
+        _json_app(
+            400,
+            {
+                "error": {
+                    "message": COBALT_MESSAGE,
+                    "type": "Bad Request",
+                    "param": None,
+                    "code": 400,
+                }
+            },
+        )
+    )
+    with caplog.at_level("WARNING", logger=ers.__name__):
+        _run_asgi(app)
+
+    assert any("container_app_user" in r.getMessage() for r in caplog.records), (
+        "verbose details must still reach the server log"
+    )
+
+
+def test_middleware_import_path_constant_resolves():
+    module_path, class_name = ERROR_SANITIZER_MIDDLEWARE.rsplit(".", 1)
+    assert module_path == ers.__name__
+    assert getattr(ers, class_name) is ErrorResponseSanitizerMiddleware
+
+
+# --------------------------------------------------------------------------- #
+# End to end with FastAPI: the fork's handler + FastAPI >= 0.124 endpoint context
+# --------------------------------------------------------------------------- #
+
+fastapi = pytest.importorskip("fastapi")
+
+
+def _build_fork_like_app():
+    """Replica of tenstorrent/vllm's validation_exception_handler (fork @7678b70)."""
+    from http import HTTPStatus
+
+    from fastapi import FastAPI, Request
+    from fastapi.exceptions import RequestValidationError
+    from fastapi.responses import JSONResponse
+    from pydantic import BaseModel, model_validator
+
+    def fork_sanitize_message(message: str) -> str:
+        return re.sub(r" at 0x[0-9a-f]+>", ">", message)
+
+    class OpenAIBaseModel(BaseModel):
+        @model_validator(mode="wrap")
+        @classmethod
+        def __log_extra_fields__(cls, data, handler):
+            return handler(data)
+
+    class TokenizeRequest(OpenAIBaseModel):
+        prompt: str
+        messages: list
+
+    app = FastAPI()
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(_: Request, exc: RequestValidationError):
+        errors = exc.errors()
+        exc_str = str(exc)
+        errors_str = str(errors)
+        if errors and errors_str and errors_str != exc_str:
+            message = f"{exc_str} {errors_str}"
+        else:
+            message = exc_str
+        return JSONResponse(
+            {
+                "error": {
+                    "message": fork_sanitize_message(message),
+                    "type": HTTPStatus.BAD_REQUEST.phrase,
+                    "param": None,
+                    "code": HTTPStatus.BAD_REQUEST,
+                }
+            },
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
+
+    @app.post("/tokenize")
+    async def tokenize(request: TokenizeRequest, raw_request: Request):
+        return {"count": 1}
+
+    return app
+
+
+def test_end_to_end_fastapi_tokenize_empty_body_no_longer_leaks():
+    from fastapi.testclient import TestClient
+
+    unprotected_app = _build_fork_like_app()
+    unprotected = (
+        TestClient(unprotected_app)
+        .post("/tokenize", json={})
+        .json()["error"]["message"]
+    )
+
+    protected_app = _build_fork_like_app()
+    # Same mechanism vLLM uses for `--middleware <Class>` (before startup).
+    protected_app.add_middleware(ErrorResponseSanitizerMiddleware)
+    response = TestClient(protected_app).post("/tokenize", json={})
+    protected = response.json()["error"]
+
+    assert response.status_code == 400
+    assert "Field required" in protected["message"]
+    assert_clean(protected["message"])
+    if 'File "' in unprotected:
+        # Installed FastAPI reproduces the leak (>= 0.124): prove we removed it.
+        assert __file__ in unprotected
+        assert __file__ not in protected["message"]

--- a/tests/test_run_vllm_api_server.py
+++ b/tests/test_run_vllm_api_server.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from utils.error_response_sanitizer import ERROR_SANITIZER_MIDDLEWARE
 from workflows.model_spec import load_templates_from_yaml
 from workflows.utils import get_repo_root_path
 
@@ -159,6 +160,8 @@ def test_set_vllm_sys_argv_merges_defaults_and_passthrough_overrides(
         "mistralai/Mistral-7B-Instruct-v0.3",
         "--seed",
         "9472",
+        "--middleware",
+        ERROR_SANITIZER_MIDDLEWARE,
     ]
 
 
@@ -188,6 +191,8 @@ def test_set_vllm_sys_argv_honors_equals_style_overrides(
         "64",
         "--port",
         "8000",
+        "--middleware",
+        ERROR_SANITIZER_MIDDLEWARE,
     ]
 
 
@@ -217,8 +222,87 @@ def test_set_vllm_sys_argv_logs_multiline_bash_command(
         "  --disable-log-requests \\\n"
         "  --served-model-name 'my model' \\\n"
         "  '--guided-decoding-backend=outlines backend' \\\n"
-        "  --port 8000"
+        "  --port 8000 \\\n"
+        f"  --middleware {ERROR_SANITIZER_MIDDLEWARE}"
     )
+
+
+def test_set_vllm_sys_argv_installs_error_sanitizer_middleware_last(
+    monkeypatch, run_vllm_api_server_module
+):
+    monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py"])
+
+    run_vllm_api_server_module.set_vllm_sys_argv(
+        argparse.Namespace(service_port=None),
+        ["--max-model-len", "4096"],
+        {"port": 8000},
+    )
+
+    assert sys.argv[-2:] == ["--middleware", ERROR_SANITIZER_MIDDLEWARE]
+    assert sys.argv.count("--middleware") == 1
+
+
+def test_set_vllm_sys_argv_honors_disable_error_sanitizer(
+    monkeypatch, run_vllm_api_server_module
+):
+    monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py"])
+
+    run_vllm_api_server_module.set_vllm_sys_argv(
+        argparse.Namespace(service_port=None, disable_error_sanitizer=True),
+        [],
+        {"port": 8000},
+    )
+
+    assert "--middleware" not in sys.argv
+    assert ERROR_SANITIZER_MIDDLEWARE not in sys.argv
+
+
+@pytest.mark.parametrize(
+    "passthrough",
+    [
+        ["--middleware", "my_pkg.MyMiddleware"],
+        ["--middleware=my_pkg.MyMiddleware"],
+    ],
+)
+def test_set_vllm_sys_argv_does_not_add_second_middleware_flag(
+    monkeypatch, run_vllm_api_server_module, passthrough
+):
+    # A second --middleware occurrence would silently replace the caller's on
+    # vLLM commits that parse the flag with nargs="+", so we leave argv alone.
+    monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py"])
+    mock_logger = MagicMock()
+    monkeypatch.setattr(run_vllm_api_server_module, "logger", mock_logger)
+
+    run_vllm_api_server_module.set_vllm_sys_argv(
+        argparse.Namespace(service_port=None), list(passthrough), {"port": 8000}
+    )
+
+    assert sys.argv[1 : 1 + len(passthrough)] == passthrough
+    assert ERROR_SANITIZER_MIDDLEWARE not in sys.argv
+    assert sum(tok.startswith("--middleware") for tok in sys.argv) == 1
+    assert mock_logger.warning.called
+
+
+def test_parse_args_accepts_disable_error_sanitizer(
+    monkeypatch, run_vllm_api_server_module
+):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_vllm_api_server.py",
+            "--tt-device",
+            "n150",
+            "--disable-error-sanitizer",
+            "--max-model-len",
+            "4096",
+        ],
+    )
+
+    args, remaining = run_vllm_api_server_module.parse_args()
+
+    assert args.disable_error_sanitizer is True
+    assert remaining == ["--max-model-len", "4096"]
 
 
 def test_diffusiongemma_launch_uses_standalone_plugin_vllm_024_contract(
@@ -337,6 +421,7 @@ def test_main_passes_passthrough_port_to_trace_capture(
         impl=None,
         no_auth=False,
         disable_trace_capture=False,
+        disable_error_sanitizer=False,
         service_port=None,
     )
     model_spec = {

--- a/utils/error_response_sanitizer.py
+++ b/utils/error_response_sanitizer.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Scrub server internals out of HTTP error responses.
+
+Pure-ASGI middleware for the vLLM API server. Every 4xx/5xx body that passes
+through it is rewritten so that it no longer discloses:
+
+* absolute filesystem paths (and with them the container username),
+* Python traceback frames (``File "...", line N, in func``) and headers,
+* the endpoint context FastAPI >= 0.124 appends to ``str(RequestValidationError)``,
+* Pydantic-internal validator markers in error ``loc`` tuples
+  (``'function-wrap[__log_extra_fields__()]'``),
+* object memory addresses.
+
+2xx/3xx responses (including SSE streams) are passed through untouched, chunk by
+chunk, so there is no cost on the hot path. Error bodies are buffered up to
+``MAX_BUFFERED_ERROR_BODY_BYTES``; anything larger is replaced by a generic,
+bounded error envelope so a malformed request can never amplify into a huge
+response. The original body is logged server-side before it is rewritten.
+
+The middleware has no third-party imports on purpose: it is installed via vLLM's
+``--middleware <import.path.Class>`` flag and has to work unchanged across every
+vLLM commit the release images pin (see ``run_vllm_api_server.py``).
+
+Why here and not in vLLM: the tenstorrent/vllm fork's ``validation_exception_handler``
+forwards ``str(exc)`` to the client, which since FastAPI 0.124 (Dec 2025) embeds the
+endpoint's source file, line number and function name. Upstream vLLM fixed that in
+vllm-project/vllm#46415 (v0.26.0+) but the fork never picked it up, and each release
+image pins a different fork commit, so a fix in the fork would need every image to
+move to a new vLLM. Wrapping the app instead fixes all of them on the next image
+build without changing the pinned engine.
+"""
+
+import json
+import logging
+import re
+from http import HTTPStatus
+from typing import Any, Awaitable, Callable, Dict, List, MutableMapping, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Import path handed to vLLM's ``--middleware`` flag by run_vllm_api_server.py.
+ERROR_SANITIZER_MIDDLEWARE = (
+    "utils.error_response_sanitizer.ErrorResponseSanitizerMiddleware"
+)
+
+# Error envelopes are small (a few hundred bytes to a few KB). Anything bigger is
+# either a bug or an amplification attempt; either way the client gets a bounded
+# generic body and the details stay in the server log.
+MAX_BUFFERED_ERROR_BODY_BYTES = 256 * 1024
+# Cap on any single string inside a JSON error body after sanitization.
+MAX_ERROR_STRING_CHARS = 4096
+# How much of the original body to keep in the server log when we rewrite it.
+LOG_ORIGINAL_BODY_CHARS = 2000
+
+_PATH_PLACEHOLDER = "<path>"
+
+# Python traceback frame + the indented source/context line that follows it.
+# Also matches FastAPI's endpoint context, which reuses the traceback format
+# ('  File "<file>", line <n>, in <func>\n    <METHOD> <path>').
+_TRACEBACK_FRAME_RE = re.compile(
+    r'\n?[ \t]*File "[^"\n]+", line \d+, in [^\n]+(\n[ \t]+[^\n]*)?'
+)
+_TRACEBACK_HEADER_RE = re.compile(
+    r"[ \t]*Traceback \(most recent call last\):[ \t]*\n?"
+)
+# Python 3.11+ caret lines under a traceback source line.
+_TRACEBACK_CARETS_RE = re.compile(r"\n[ \t]*[\^~]+[ \t]*(?=\n|$)")
+# FastAPI endpoint context when it has a path but no file information.
+_ENDPOINT_CONTEXT_RE = re.compile(r"\n?[ \t]*Endpoint: \S+")
+# Pydantic-internal validator markers inside a repr'd loc tuple, e.g.
+# ('body', 'function-wrap[__log_extra_fields__()]', 'prompt') -> ('body', 'prompt')
+_PYDANTIC_INTERNAL_LOC_RE = re.compile(r"'[\w-]+\[[^\]'\n]*\]',\s*")
+# Absolute filesystem paths. First the well-known roots (matches directories too,
+# so "/home/container_app_user" is caught even without a file name), then any
+# multi-segment absolute path that ends in a file with an extension.
+_KNOWN_ROOT_PATH_RE = re.compile(
+    r"/(?:home|usr|opt|var|tmp|root|lib|lib64|mnt|srv|app|workspace|proc|etc|data)"
+    r"(?:/[\w.\-]+)+"
+)
+_FILE_PATH_RE = re.compile(r"(?:/[\w\-]+)+/[\w\-]+\.\w+")
+_MEMORY_ADDRESS_RE = re.compile(r" at 0x[0-9a-fA-F]+>")
+_BLANK_LINES_RE = re.compile(r"\n[ \t]*\n(?:[ \t]*\n)+")
+
+_JSON_SEPARATORS = (",", ":")
+
+Scope = MutableMapping[str, Any]
+Message = MutableMapping[str, Any]
+Receive = Callable[[], Awaitable[Message]]
+Send = Callable[[Message], Awaitable[None]]
+ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+RawHeaders = List[Tuple[bytes, bytes]]
+
+
+def sanitize_error_text(message: str) -> str:
+    """Remove paths, traceback frames and internal markers from an error string."""
+    if not message:
+        return message
+    message = _TRACEBACK_HEADER_RE.sub("", message)
+    message = _TRACEBACK_FRAME_RE.sub("", message)
+    message = _TRACEBACK_CARETS_RE.sub("", message)
+    message = _ENDPOINT_CONTEXT_RE.sub("", message)
+    message = _PYDANTIC_INTERNAL_LOC_RE.sub("", message)
+    message = _KNOWN_ROOT_PATH_RE.sub(_PATH_PLACEHOLDER, message)
+    message = _FILE_PATH_RE.sub(_PATH_PLACEHOLDER, message)
+    message = _MEMORY_ADDRESS_RE.sub(">", message)
+    message = _BLANK_LINES_RE.sub("\n", message)
+    message = message.strip()
+    if len(message) > MAX_ERROR_STRING_CHARS:
+        message = message[:MAX_ERROR_STRING_CHARS] + "...[truncated]"
+    return message
+
+
+def _sanitize_json_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return sanitize_error_text(value)
+    if isinstance(value, dict):
+        return {key: _sanitize_json_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_json_value(item) for item in value]
+    return value
+
+
+def _status_phrase(status: int) -> str:
+    try:
+        return HTTPStatus(status).phrase
+    except ValueError:
+        return "Error"
+
+
+def generic_error_body(status: int, reason: str) -> bytes:
+    """OpenAI-shaped error envelope used when the original body cannot be kept."""
+    phrase = _status_phrase(status)
+    payload = {
+        "error": {
+            "message": f"{phrase}. {reason}",
+            "type": phrase,
+            "param": None,
+            "code": status,
+        }
+    }
+    return json.dumps(payload, separators=_JSON_SEPARATORS).encode("utf-8")
+
+
+def sanitize_error_body(body: bytes, status: int, content_type: str) -> bytes:
+    """Return a sanitized copy of an error response body.
+
+    JSON bodies are parsed and every string inside them is scrubbed, so the
+    OpenAI ``{"error": {...}}`` envelope, FastAPI's ``{"detail": ...}`` and any
+    other shape all keep their structure. Non-JSON text bodies are scrubbed as a
+    whole. Bodies that cannot be decoded are returned unchanged.
+    """
+    if not body:
+        return body
+    try:
+        text = body.decode("utf-8")
+    except UnicodeDecodeError:
+        return body
+
+    media_type = content_type.split(";", 1)[0].strip().lower()
+    looks_like_json = media_type.endswith("json") or text.lstrip()[:1] in "{["
+    if looks_like_json:
+        try:
+            parsed = json.loads(text)
+        except ValueError:
+            parsed = None
+        if parsed is not None and isinstance(parsed, (dict, list)):
+            sanitized = _sanitize_json_value(parsed)
+            if sanitized == parsed:
+                return body
+            return json.dumps(
+                sanitized, ensure_ascii=False, separators=_JSON_SEPARATORS
+            ).encode("utf-8")
+
+    if media_type.startswith("text/") or not media_type:
+        sanitized_text = sanitize_error_text(text)
+        if sanitized_text == text.strip():
+            return body
+        return sanitized_text.encode("utf-8")
+
+    return body
+
+
+def _header_value(headers: RawHeaders, name: bytes) -> str:
+    for key, value in headers:
+        if key.lower() == name:
+            return value.decode("latin-1")
+    return ""
+
+
+def _with_content_length(headers: RawHeaders, length: int) -> RawHeaders:
+    kept = [(key, value) for key, value in headers if key.lower() != b"content-length"]
+    kept.append((b"content-length", str(length).encode("latin-1")))
+    return kept
+
+
+class ErrorResponseSanitizerMiddleware:
+    """Pure ASGI middleware: rewrite 4xx/5xx bodies, pass everything else through."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        state: Dict[str, Any] = {
+            "start": None,  # held http.response.start for an error response
+            "chunks": [],
+            "buffered": 0,
+            "done": False,  # response fully forwarded; swallow trailing chunks
+            "passthrough": False,  # non-error (or undecodable) response
+        }
+
+        async def flush(body: bytes) -> None:
+            start = state["start"]
+            headers = _with_content_length(list(start.get("headers", [])), len(body))
+            await send({**start, "headers": headers})
+            await send({"type": "http.response.body", "body": body, "more_body": False})
+            state["done"] = True
+
+        async def send_wrapper(message: Message) -> None:
+            message_type = message["type"]
+
+            if message_type == "http.response.start":
+                status = int(message.get("status", 200))
+                headers = list(message.get("headers", []))
+                encoding = _header_value(headers, b"content-encoding").lower()
+                if status < 400 or (encoding and encoding != "identity"):
+                    state["passthrough"] = True
+                    await send(message)
+                    return
+                state["start"] = message
+                return
+
+            if message_type == "http.response.body" and state["start"] is not None:
+                if state["done"]:
+                    return
+                body = message.get("body", b"") or b""
+                state["chunks"].append(body)
+                state["buffered"] += len(body)
+                status = int(state["start"].get("status", 500))
+                if state["buffered"] > MAX_BUFFERED_ERROR_BODY_BYTES:
+                    logger.warning(
+                        "Replaced oversized %d error body (%d+ bytes) for %s %s",
+                        status,
+                        state["buffered"],
+                        scope.get("method", "?"),
+                        scope.get("path", "?"),
+                    )
+                    await flush(
+                        generic_error_body(
+                            status,
+                            "Error details were withheld because the response "
+                            "exceeded the size limit; see server logs.",
+                        )
+                    )
+                    return
+                if message.get("more_body", False):
+                    return
+
+                original = b"".join(state["chunks"])
+                content_type = _header_value(
+                    state["start"].get("headers", []), b"content-type"
+                )
+                sanitized = sanitize_error_body(original, status, content_type)
+                if sanitized != original:
+                    logger.warning(
+                        "Sanitized %d error body for %s %s; original: %s",
+                        status,
+                        scope.get("method", "?"),
+                        scope.get("path", "?"),
+                        original[:LOG_ORIGINAL_BODY_CHARS].decode("utf-8", "replace"),
+                    )
+                await flush(sanitized)
+                return
+
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -18,6 +18,7 @@ from vllm import ModelRegistry
 
 from utils.cache_monitor import get_container_cache_dir
 from utils.device_utils import get_mesh_device_name
+from utils.error_response_sanitizer import ERROR_SANITIZER_MIDDLEWARE
 from utils.logging_utils import set_vllm_logging_config
 from utils.prompt_client import run_background_trace_capture
 from utils.vllm_run_utils import (
@@ -74,6 +75,15 @@ def parse_args():
         "--disable-trace-capture",
         action="store_true",
         help="Disable automatic trace capture requests on server startup",
+    )
+    parser.add_argument(
+        "--disable-error-sanitizer",
+        action="store_true",
+        help=(
+            "Do not install the error-response sanitizer middleware that strips "
+            "file paths, stack frames and internal markers from 4xx/5xx bodies "
+            "(tenstorrent/tt-cloud-console#1152)"
+        ),
     )
     parser.add_argument(
         "--service-port",
@@ -690,6 +700,37 @@ def format_vllm_serve_command(argv) -> str:
     return " \\\n  ".join(command_lines)
 
 
+def add_error_sanitizer_middleware(
+    vllm_argv: list[str], disabled: bool = False
+) -> None:
+    """Install utils.error_response_sanitizer via vLLM's ``--middleware`` flag.
+
+    Every vLLM commit the release images pin accepts ``--middleware <import.path>``
+    (class -> ``app.add_middleware``), so this works without touching the pinned
+    engine. The flag's parsing differs across those commits (``action="append"``
+    on older ones, ``nargs="+"`` on newer ones) and a second ``--middleware``
+    occurrence would silently replace the first on the newer parser, so if the
+    caller already passes ``--middleware`` we leave argv alone and say so.
+    """
+    if disabled:
+        logger.warning(
+            "--disable-error-sanitizer is set: 4xx/5xx bodies may include file paths "
+            "and stack frames."
+        )
+        return
+    if any(
+        token == "--middleware" or token.startswith("--middleware=")
+        for token in vllm_argv
+    ):
+        logger.warning(
+            "--middleware already passed to vLLM; not adding %s. Append it to your "
+            "--middleware list to keep error responses sanitized.",
+            ERROR_SANITIZER_MIDDLEWARE,
+        )
+        return
+    vllm_argv.extend(["--middleware", ERROR_SANITIZER_MIDDLEWARE])
+
+
 def set_vllm_sys_argv(args, remaining_sys_argv, default_vllm_args):
     # runpy uses sys.argv, rebuild it with the merged vLLM args.
     vllm_argv = [sys.argv[0]]
@@ -744,6 +785,10 @@ def set_vllm_sys_argv(args, remaining_sys_argv, default_vllm_args):
     for key, value in remaining_default_vllm_args.items():
         cli_arg_name = f"--{key}"
         _append_vllm_arg(vllm_argv, cli_arg_name, value)
+
+    add_error_sanitizer_middleware(
+        vllm_argv, disabled=getattr(args, "disable_error_sanitizer", False)
+    )
 
     # finally set sys.argv to the vllm server args
     sys.argv = vllm_argv

--- a/workflows/run_docker_server.py
+++ b/workflows/run_docker_server.py
@@ -333,6 +333,7 @@ _RESERVED_WRAPPER_FLAGS = {
     "impl",
     "no-auth",
     "disable-trace-capture",
+    "disable-error-sanitizer",
     "service-port",
     "port",
     "host",


### PR DESCRIPTION
Fixes the root cause of Cobalt pentest finding **PT40893_8** (tenstorrent/tt-cloud-console#1152, Low, CVSS 3.7): the inference backend returned internal file paths, the container username and the vLLM module layout inside HTTP 400 bodies. Also the source-side fix tracked in #3872 / #3871.

## The finding

`POST /tokenize` with body `{}` on `qwen3vl32b--tenstorrent.workload.tenstorrent.com` (image `0.14.0-80180b9-7678b70`) returned:

```
"message": "2 validation errors:\n  {'type': 'missing', 'loc': ('body', 'function-wrap[__log_extra_fields__()]', 'prompt'), ...}\n ...
  File \"/home/container_app_user/vllm/vllm/entrypoints/utils.py\", line 38, in tokenize\n    POST /tokenize [...]"
```

## Root cause

- FastAPI 0.124.0 (2025-12-06, fastapi/fastapi#14306) started appending the endpoint's source file, line and function to `str(RequestValidationError)`.
- `validation_exception_handler` in **every** tenstorrent/vllm commit the release images pin (27 distinct commits, 2025-07 → 2026-08, incl. `dev` HEAD) builds the client message from `str(exc)`; its `sanitize_message` only strips memory addresses. The `function-wrap[__log_extra_fields__()]` marker is Pydantic's wrap-validator name leaking through `loc`.
- Upstream vLLM fixed this in vllm-project/vllm#46415 (builds the message from `exc.errors()`, hardens `sanitize_message`; in **v0.26.0+**) and bounded the body in #54684 (v0.29.0). The fork never picked either up.
- Reproduced locally with FastAPI 0.141.1 and the fork's handler: byte-for-byte the Cobalt body (see `test_end_to_end_fastapi_tokenize_empty_body_no_longer_leaks`).

## Why fix it here and not in vLLM

| Where | Reaches the fleet? |
|---|---|
| Backport #46415 into the tenstorrent/vllm fork | Fork is deprecated (2026-08-24) and each of the 127/129 vLLM release specs pins its own commit; every model would need a new engine pin + re-validation. |
| Move models to vllm-tt-plugin (upstream vLLM) | Right long-term direction, but 39 of 41 models are still on the fork, and the one plugin-based release image (`Qwen3-32B` galaxy, plugin `be7d805`) pins **vLLM 0.25.1**, which predates the upstream fix. Only plugin `main` (0.26.0) is clean. |
| Console proxy backstop (tt-cloud-console#596) | Already rewrites leaking bodies on the console API path, but Cobalt hit the workload host directly; ngrok-registered and in-cluster callers are also outside it. |
| **Wrapper middleware in this repo (this PR)** | Version-agnostic: `--middleware <import.path>` is accepted by all 27 pinned commits and by upstream vLLM. Ships on the next image build of each model without changing the pinned engine. Also covers 5xx tracebacks (#3872) that the upstream handler fix does not. No-op when a body is already clean. |

## What changes

- **`utils/error_response_sanitizer.py`** (new, stdlib only): pure-ASGI `ErrorResponseSanitizerMiddleware`.
  - Status `>= 400`: buffers the body (cap 256 KiB), parses JSON and scrubs every string (OpenAI `{"error":{...}}`, FastAPI `{"detail":...}`, any shape) or scrubs text bodies; fixes `content-length`; logs the original body server-side at WARNING so nothing is lost for debugging.
  - Removes: `Traceback ...` headers, `File "...", line N, in f` frames + the following context line (this is also FastAPI's endpoint-context format), `Endpoint: /path`, absolute paths → `<path>`, Pydantic `'function-wrap[...]',` loc markers, ` at 0x...>`. Regexes mirror upstream's hardened `sanitize_message`.
  - Status `< 400` (incl. SSE streams) and content-encoded bodies pass through untouched and unbuffered.
  - Bodies over the cap are replaced with a bounded generic envelope of the same status (defence against the #54684 amplification).
- **`vllm-tt-metal/src/run_vllm_api_server.py`**: appends `--middleware utils.error_response_sanitizer.ErrorResponseSanitizerMiddleware` to the vLLM argv; new wrapper flag `--disable-error-sanitizer`. If the caller already passes `--middleware`, argv is left alone with a warning (the flag is `action="append"` on older pinned commits and `nargs="+"` on newer ones, so a second occurrence would silently replace the caller's on the newer parser).
- **`workflows/run_docker_server.py`**: new flag added to `_RESERVED_WRAPPER_FLAGS` (drift test).
- **Tests**: 25 new (`tests/test_error_response_sanitizer.py`) incl. the verbatim Cobalt payload, a real-FastAPI end-to-end reproduction, chunked/streamed/compressed/oversized bodies; launcher tests updated/added for injection, opt-out, and the existing-`--middleware` case.

Result on the Cobalt payload:

```json
{"error":{"message":"2 validation errors:\n  {'type': 'missing', 'loc': ('body', 'prompt'), 'msg': 'Field required', 'input': {}}\n  {'type': 'missing', 'loc': ('body', 'messages'), 'msg': 'Field required', 'input': {}}","type":"Bad Request","param":null,"code":400}}
```

## Test plan

- [x] `ruff check .` / `ruff format --check .` clean
- [x] `pytest tests/test_error_response_sanitizer.py tests/test_run_vllm_api_server.py tests/test_setup_host.py tests/test_run_arguments.py` → 187 passed
- [x] Full `pytest tests/` has zero new failures vs `origin/main` (pre-existing collection errors from optional deps only)
- [ ] Build one release image from this branch and run the Cobalt repro against the live container: `POST /tokenize {}` → 400 with no path/frame/username; `/v1/chat/completions` streaming unchanged; `/health` unchanged
- [ ] Re-point the console catalog entry for `Qwen3-VL-32B-Instruct` (and the other pentested hosts) at the rebuilt tags, then ask Cobalt to retest

## Why draft

1. Needs a real image build + live check on a TT device (item above); I only have unit and FastAPI-level verification.
2. Decision for the inference team: default-on for every image (as here) vs. opt-in. I recommend default-on: the console already rewrites the same bodies, so no console client sees a change; the middleware only touches error responses.
3. Rebuild/re-pin sequencing across the 41 models is a release-team call; until then the Cloudflare WAF blocklist (cloud-infra#1301) 403s `/tokenize` on the CDN path, but the direct-origin path (tt-cloud-console#1128, Cobalt finding 9) and ngrok paths still reach the leaky handler.

Not in scope, tracked elsewhere: unauthenticated `/version` and the other non-`/v1` routes (default-deny middleware, tt-cloud-console#1128 layer 2).

Refs tenstorrent/tt-cloud-console#1152, #3872, #3871, vllm-project/vllm#46415, vllm-project/vllm#54684.
