### PR TITLE
feat(agentic traces): prefill profiling set to max concurrency

### DIFF
--- a/llm_module/drivers/aiperf_agentic_traces.py
+++ b/llm_module/drivers/aiperf_agentic_traces.py
@@ -268,6 +268,7 @@ def build_aiperf_cmd(
         cmd.extend(normalized_metrics_urls)
     if run.streaming:
         cmd.append("--streaming")
+        cmd.extend(["--prefill-concurrency", str(run.concurrency)])
     if run.use_server_token_count:
         cmd.append("--use-server-token-count")
     if not run.gpu_telemetry:


### PR DESCRIPTION
- the stack rejects requests when concurrency is higher than `max_concurrency`
- set prefill concurrency so that we never get over that limit 

CI run https://github.com/tenstorrent/tt-shield/actions/runs/34390072320/job/102688638407