### PR TITLE
Gemma4: MTP + dFlash speculative serving specs (P150X8 + BH Galaxy DP=4)

### DIFF
--- a/reference_config/benchmarking/benchmark_config.py
+++ b/reference_config/benchmarking/benchmark_config.py
@@ -98,12 +98,22 @@ BENCHMARK_ISL_OSL_PAIRS = [
     (8192, 1024),
     (10000, 1024),
     (16384, 128),
+    (16384, 1024),
     (32768, 128),
+    (32768, 1024),
     (65536, 128),
+    (65536, 1024),
     (131072, 128),
+    (131072, 1024),
     (196608, 128),  # 192K -- dFlash bounded 256K sweep
     (229376, 128),  # 224K
     (253952, 128),  # ~248K -- safe near-max for a 262144 context (leaves room for osl + block-output placeholder; 262016 crashes at zero margin)
+    (253952, 1024),
+    # High-ISL osl=1024 companions: with osl=128 the report's output-TPS column
+    # is ~entirely TTFT (prefill) -- e.g. 131072/128 = 128 tok over ~50 s prefill
+    # + 3.6 s decode -> 2.4 TPS while decode itself runs 35 tok/s/u. A 1024-token
+    # generation amortizes the one-time prefill/capture and reads out the
+    # steady-state decode rate. Filtered by isl+osl <= max_context like the rest.
 ]
 # Additional high-ISL sweep points appended only for remote SUPER_CLUSTER
 # endpoints, whose token budget is context*concurrency (see

--- a/reference_config/benchmarking/benchmark_config.py
+++ b/reference_config/benchmarking/benchmark_config.py
@@ -101,6 +101,9 @@ BENCHMARK_ISL_OSL_PAIRS = [
     (32768, 128),
     (65536, 128),
     (131072, 128),
+    (196608, 128),  # 192K -- dFlash bounded 256K sweep
+    (229376, 128),  # 224K
+    (253952, 128),  # ~248K -- safe near-max for a 262144 context (leaves room for osl + block-output placeholder; 262016 crashes at zero margin)
 ]
 # Additional high-ISL sweep points appended only for remote SUPER_CLUSTER
 # endpoints, whose token budget is context*concurrency (see

--- a/workflows/model_spec.py
+++ b/workflows/model_spec.py
@@ -374,8 +374,33 @@ training_lora_impl = ImplSpec(
     code_path="tt-media-server/tt_model_runners/forge_training_runners/training_lora_runner.py",
 )
 
+# --- Gemma4 speculative-decoding serving profiles (same tt-metal code path) ---
+#
+# Same namespacing pattern as the qwen36 profiles above: these are NOT separate
+# implementations -- both point at models/demos/gemma4 -- but a model spec is
+# keyed by (impl_name, model_name, device), so offering the MTP (it-assistant
+# KV-shared drafter) and dFlash (z-lab block-diffusion drafter) speculative
+# profiles for the same weights needs distinct impl ids. The profile selects
+# the TT decode class via the plugin's TT_GEMMA4_SPEC env (set in the yaml
+# entry); speculation is TT-native (draft+verify inside one device step,
+# variable tokens/step) and does not use vLLM's speculative_config.
+gemma4_mtp_impl = ImplSpec(
+    impl_id="gemma4_mtp",
+    impl_name="gemma4-mtp",
+    repo_url="https://github.com/tenstorrent/tt-metal",
+    code_path="models/demos/gemma4",
+)
+gemma4_dflash_impl = ImplSpec(
+    impl_id="gemma4_dflash",
+    impl_name="gemma4-dflash",
+    repo_url="https://github.com/tenstorrent/tt-metal",
+    code_path="models/demos/gemma4",
+)
+
 _IMPL_REGISTRY: Dict[str, ImplSpec] = {
     "tt_transformers": tt_transformers_impl,
+    "gemma4_mtp": gemma4_mtp_impl,
+    "gemma4_dflash": gemma4_dflash_impl,
     "llama3_70b_galaxy": llama3_70b_galaxy_impl,
     "qwen3_32b_galaxy": qwen3_32b_galaxy_impl,
     "gpt_oss": gpt_oss_impl,

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -256,6 +256,50 @@ templates:
         enable_chunked_prefill: true
         max_num_batched_tokens: 65536
         long_prefill_token_threshold: 4096
+    # BH Galaxy (32x P150) native, DP=4 (2026-09-03 bring-up): the plugin's
+    # standard-DP discovery opens the native 8x4 mesh, create_submeshes
+    # reshapes to (4,8) and yields four physical-COLUMN (1,8) engines, each a
+    # separate process with TT_VISIBLE_DEVICES=<its column> and NO mesh-graph
+    # descriptor override (auto-discovery control plane handles constrained
+    # subsets; column-subset mesh_sanity byte-exact). Metal dp=4x tp=8 campaign:
+    # decode contention-free (31B b1 ~30 tok/s/u per replica), b32 TTFT within
+    # 2% of solo; 4 concurrent long prefills contend on HOST (TTFT up to 3.2x
+    # at 128k) — decode unaffected.
+    - device: BLACKHOLE_GALAXY
+      # Whole-box concurrency: 32 users x 4 DP engines. max_num_seqs below
+      # pins the per-engine ceiling (default inference would give 128/engine).
+      max_concurrency: 128
+      max_context: 262144  # 256 * 1024 per engine (same budget as P150X8)
+      default_impl: true
+      env_vars:
+        # Explicit linear CCL: topology settings do not transfer across device
+        # configs (the P150x8 entry inherits gemma4's ring default on the LB
+        # descriptor; the native galaxy column ring is unmeasured — A/B later).
+        GEMMA4_CCL_TOPOLOGY: "linear"
+        GEMMA4_PAGE_BLOCK_SIZE: "64"
+        GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
+        GEMMA4_VLLM_SINGLE_CHUNK: "0"
+        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
+      override_tt_config:
+        fabric_config: FABRIC_1D
+        trace_region_size: 512000000
+        l1_small_size: 24576  # all_gather semaphores into L1_SMALL (metal demo parity)
+        # On-device decode sampling required on TP so token ids >= 65536 are
+        # reachable (host sampling only sees device 0's vocab shard).
+        sample_on_device_mode: decode_only
+      vllm_args:
+        data_parallel_size: 4
+        max_num_seqs: 32  # per-engine; max_concurrency above is whole-box
+        # Overlap host schedule with device decode (metal supports_async_decode; #51186).
+        async_scheduling: true
+        enable-auto-tool-choice: true
+        tool-call-parser: gemma4
+        default-chat-template-kwargs: '{"enable_thinking": true}'
+        reasoning-parser: gemma4
+        # Token-chunked prefill; 65536/4096 parity with P150X8/P300X2.
+        enable_chunked_prefill: true
+        max_num_batched_tokens: 65536
+        long_prefill_token_threshold: 4096
     # GPU (H100 NVL) bring-your-own vLLM server (see docs/gpu_workflows.md); used
     # to collect GPU reference eval scores for GPQA-Diamond, Terminal-Bench 2.0,
     # and SWE-Bench Verified. Dev-only; no tt_metal_commit/version pin needed
@@ -454,6 +498,45 @@ templates:
         # 65536 = 32 users x 2048 ISL in one prefill step. Requires the trace cap
         # aligned to the shared planner (128Ki) so wide prefill stays TRACED;
         # at 4096 the batch-2 steps starve decode (TPOT 281ms -> 35ms measured).
+        max_num_batched_tokens: 65536
+        long_prefill_token_threshold: 4096
+    # BH Galaxy (32x P150) native, DP=4 (2026-09-03 bring-up): four physical-
+    # column (1,8) engines via the plugin's standard-DP discovery (see the 31B
+    # BLACKHOLE_GALAXY entry for the mechanism and gates). Config mirrors the
+    # 12B P150X8 target entry: bounded sliding + batched prefill + eager 4k
+    # chunks — gated/traced prefill wedges 12B under mixed prefill+decode
+    # concurrency (G7, cross-platform); same known wave-boundary issue applies.
+    - device: BLACKHOLE_GALAXY
+      # Whole-box concurrency: 32 users x 4 DP engines. max_num_seqs below
+      # pins the per-engine ceiling (default inference would give 128/engine).
+      max_concurrency: 128
+      max_context: 262144  # 256 * 1024 per engine (same budget as P150X8)
+      default_impl: true
+      env_vars:
+        G4_FORCE_BATCH_PREFILL: "1"
+        GEMMA4_BOUNDED_SLIDING_KV_CACHE: "1"
+        GEMMA4_CCL_TOPOLOGY: "linear"
+        GEMMA4_PAGE_BLOCK_SIZE: "64"
+        GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
+        GEMMA4_VLLM_SINGLE_CHUNK: "0"
+        GEMMA4_CHUNKED_PREFILL_TRACE: "0"  # eager chunks: no prefill traces under bounded
+      override_tt_config:
+        fabric_config: FABRIC_1D
+        trace_region_size: 512000000
+        l1_small_size: 24576  # all_gather semaphores into L1_SMALL (metal demo parity)
+        # On-device decode sampling required on TP so token ids >= 65536 are
+        # reachable (host sampling only sees device 0's vocab shard).
+        sample_on_device_mode: decode_only
+      vllm_args:
+        data_parallel_size: 4
+        max_num_seqs: 32  # per-engine; max_concurrency above is whole-box
+        # Overlap host schedule with device decode (metal supports_async_decode; #51186).
+        async_scheduling: true
+        enable-auto-tool-choice: true
+        tool-call-parser: gemma4
+        default-chat-template-kwargs: '{"enable_thinking": true}'
+        reasoning-parser: gemma4
+        enable_chunked_prefill: true
         max_num_batched_tokens: 65536
         long_prefill_token_threshold: 4096
     # GPU (H100 NVL) bring-your-own vLLM server (see docs/gpu_workflows.md); used

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -311,11 +311,14 @@ templates:
         sample_on_device_mode: decode_only  # spec: prefill anchor host-sampled, decode model-owned
       vllm_args:
         max_num_seqs: 32
-        # Sync default: the async submit/accept split is in place and coherent,
-        # but block-output disables the steady-decode overlap (output_tokens set)
-        # and dFlash's step is serially dependent, so async gives no gain yet.
-        # The real lever is reducing the ~135ms/iter vLLM host overhead.
-        no-async-scheduling: true
+        # Async overlaps host scheduling with the device decode for the BATCHED
+        # baseline fallback (conc>1) -- baseline-entry parity; sync cost it
+        # ~20-35% at conc-32. The solo spec block step returns committed host
+        # tokens (no read to overlap) and stays correct under the async
+        # schedule/commit lag because TTScheduler carries each step's block
+        # decision on its SchedulerOutput. Requires the model to declare
+        # supports_async_decode (Gemma4DFlash does).
+        async_scheduling: true
         enable-auto-tool-choice: true
         tool-call-parser: gemma4
         default-chat-template-kwargs: '{"enable_thinking": true}'
@@ -372,7 +375,7 @@ templates:
       vllm_args:
         data_parallel_size: 4
         max_num_seqs: 32  # per-engine; max_concurrency above is whole-box
-        no-async-scheduling: true  # block-output disables the steady-decode overlap (see P150X8 entry)
+        async_scheduling: true  # batched-fallback overlap; async-safe adaptive block (see P150X8 entry)
         enable-auto-tool-choice: true
         tool-call-parser: gemma4
         default-chat-template-kwargs: '{"enable_thinking": true}'

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -284,7 +284,7 @@ templates:
   device_model_specs:
     - device: P150X8
       max_concurrency: 32  # adaptive engine: solo=spec, batch=baseline
-      max_context: 131072  # spec DRAM frontier at max_num_seqs=32; nothing above it is admitted, so no ceiling downgrade breaks the block-output contract (>131072 is baseline-only -- serve it from the tt_transformers entry)
+      max_context: 262144  # full 256K: spec <=131072, baseline >131072 (see GEMMA4_DFLASH_MAX_SPEC_ISL)
       env_vars:
         MESH_DEVICE: "P150x8"
         # Generic serving-class override (plugin TT_MODEL_CLASS_OVERRIDES);
@@ -292,10 +292,11 @@ templates:
         TT_MODEL_CLASS_OVERRIDES: "Gemma4ForCausalLM=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,Gemma4ForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,Gemma4UnifiedForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,TTGemma4ForCausalLM=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,TTGemma4ForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM"
         GEMMA4_DFLASH_SHARD_ARGMAX: "1"  # bypass TTSampling in-body (server sampler is not argmax-forced)
         GEMMA4_DFLASH_SERVE_BLOCK: "64"  # spec block-output ON (adaptive: solo=spec, batch=baseline)
+        GEMMA4_DFLASH_MAX_SPEC_ISL: "131072"  # spec-capture DRAM frontier @ max_num_seqs=32; prompts above serve as plain baseline (the model declares this as tt_adaptive_block_max_prompt_tokens so the scheduler reserves width-1 for them)
         GEMMA4_DFLASH_VERIFY: "7"
         GEMMA4_DFLASH_SERVE_HORIZON: "2048"
         GEMMA4_PAGE_BLOCK_SIZE: "64"
-        GEMMA4_MAX_TOKENS_ALL_USERS: "131072"
+        GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
         # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
         # chunk replay skips it (empty taps -> request fails at ISL > one chunk).

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -279,16 +279,18 @@ templates:
   inference_engine: VLLM
   device_model_specs:
     - device: P150X8
-      max_concurrency: 1  # spec sessions are B=1 (fused trace per request)
-      max_context: 65536  # dFlash serving profile is unbounded-KV (<100k)
+      max_concurrency: 32  # adaptive engine: solo=spec, batch=baseline
+      max_context: 262144  # full-ISL adaptive engine
       env_vars:
         MESH_DEVICE: "P150x8"
         TT_GEMMA4_SPEC: "dflash"
         GEMMA4_DFLASH_SHARD_ARGMAX: "1"  # bypass TTSampling in-body (server sampler is not argmax-forced)
+        GEMMA4_DFLASH_SERVE_BLOCK: "64"  # spec block-output ON (adaptive: solo=spec, batch=baseline)
+        GEMMA4_DFLASH_MAX_SPEC_ISL: "131072"  # spec above this OOMs the capture at max_num_seqs=32; serve baseline instead
         GEMMA4_DFLASH_VERIFY: "7"
         GEMMA4_DFLASH_SERVE_HORIZON: "2048"
         GEMMA4_PAGE_BLOCK_SIZE: "64"
-        GEMMA4_MAX_TOKENS_ALL_USERS: "65536"  # B=1 x max_context pool
+        GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
         # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
         # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
@@ -302,7 +304,7 @@ templates:
         l1_small_size: 24576
         sample_on_device_mode: decode_only  # spec: prefill anchor host-sampled, decode model-owned
       vllm_args:
-        max_num_seqs: 1
+        max_num_seqs: 32
         # Sync default: the async submit/accept split is in place and coherent,
         # but block-output disables the steady-decode overlap (output_tokens set)
         # and dFlash's step is serially dependent, so async gives no gain yet.

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -264,6 +264,18 @@ templates:
   # checkpoint-bound). Prefill runs UNTRACED for this profile (the residual
   # tap hook is python-side; traced prefill replays skip it) and each request
   # pays a one-time fused-trace capture (~3 s) at first decode.
+  #
+  # OPERATING POINTS (one impl, two configs):
+  #   * LATENCY (this entry): block-output spec, max_num_seqs=1. B=1 spec
+  #     speedup -- server-measured 42 tok/s/u @128/128, 92 @128/1024 (up to
+  #     3.4x vs baseline). Aggregate does NOT scale with concurrency (B=1).
+  #   * THROUGHPUT: set env GEMMA4_DFLASH_SERVE_BLOCK=1 (turns block-output OFF)
+  #     and vllm_args max_num_seqs=32 (+ max_concurrency=32). The impl then
+  #     serves EVERY request via the plain baseline batched path -- "baseline
+  #     picks up for concurrency>1" -- measured 437 agg tok/s @128/128 conc-32.
+  #     A batched decode always falls back to baseline regardless of this env
+  #     (decode_forward gates on batch>1), so the spec path is never asked to
+  #     run B>1. (Speculation only pays bandwidth-bound / low batch anyway.)
   inference_engine: VLLM
   device_model_specs:
     - device: P150X8

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -322,6 +322,58 @@ templates:
         enable_chunked_prefill: false
         no-enable-prefix-caching: true
         max_num_batched_tokens: 65536
+    # BH Galaxy (32x P150) native, DP=4: four physical-column (1,8) engines via
+    # the plugin's standard-DP discovery (mechanism identical to the 31B
+    # tt_transformers BLACKHOLE_GALAXY entry -- TT_VISIBLE_DEVICES per rank, no
+    # descriptor override). Each engine runs the ADAPTIVE dFlash profile ported
+    # from the P150X8 entry above: solo decode = spec block-output, batch >1 =
+    # plain batched baseline; the plugin's DP gate admits adaptive block-output
+    # (each engine owns its own scheduler + solo-decode gate). Whole box: up to
+    # 4 concurrent conc-1 spec lanes, or 128 batched-baseline users.
+    # NOTE: dp=4 galaxy boots need the discovery-join timeout fix on the plugin
+    # (TT_DP_DISCOVERY_JOIN_TIMEOUT_S; a 32-chip mesh needs 10-20 s to close).
+    - device: BLACKHOLE_GALAXY
+      max_concurrency: 128  # 32 users x 4 DP engines (max_num_seqs pins per-engine)
+      # Bring-up budget 128K/engine. The 262144 LB budget is NOT ported yet:
+      # 2026-09-03 galaxy runs found true-262k prompts degenerate on 31B
+      # (native column and emulated LB alike) -- raise only after a 131k-262k
+      # band walk validates the band on this box.
+      max_context: 131072
+      env_vars:
+        TT_GEMMA4_SPEC: "dflash"
+        GEMMA4_DFLASH_SHARD_ARGMAX: "1"  # bypass TTSampling in-body (server sampler is not argmax-forced)
+        GEMMA4_DFLASH_SERVE_BLOCK: "64"  # spec block-output ON (adaptive: solo=spec, batch=baseline)
+        GEMMA4_DFLASH_MAX_SPEC_ISL: "131072"  # inert at this ctx; keeps the capture-OOM guard if ctx is raised
+        GEMMA4_DFLASH_VERIFY: "7"
+        GEMMA4_DFLASH_SERVE_HORIZON: "2048"
+        # Explicit linear CCL: the native galaxy column ring is unmeasured (see
+        # the 31B tt_transformers BLACKHOLE_GALAXY entry).
+        GEMMA4_CCL_TOPOLOGY: "linear"
+        GEMMA4_PAGE_BLOCK_SIZE: "64"
+        GEMMA4_MAX_TOKENS_ALL_USERS: "131072"  # per-engine pool = max_context
+        GEMMA4_VLLM_SINGLE_CHUNK: "0"
+        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
+        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
+        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
+        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (eager, tap-safe)
+      override_tt_config:
+        fabric_config: FABRIC_1D
+        trace_region_size: 512000000
+        l1_small_size: 24576  # all_gather semaphores into L1_SMALL (metal demo parity)
+        sample_on_device_mode: decode_only  # spec: prefill anchor host-sampled, decode model-owned
+      vllm_args:
+        data_parallel_size: 4
+        max_num_seqs: 32  # per-engine; max_concurrency above is whole-box
+        no-async-scheduling: true  # block-output disables the steady-decode overlap (see P150X8 entry)
+        enable-auto-tool-choice: true
+        tool-call-parser: gemma4
+        default-chat-template-kwargs: '{"enable_thinking": true}'
+        reasoning-parser: gemma4
+        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
+        # residual-tap hook sees the whole prompt (see P150X8 entry).
+        enable_chunked_prefill: false
+        no-enable-prefix-caching: true
+        max_num_batched_tokens: 65536
   status: EXPERIMENTAL
   has_builtin_warmup: true
 

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -262,6 +262,12 @@ templates:
 - weights:
     - google/gemma-4-31B-it
   impl: gemma4_dflash
+  # REQUIRES a SECOND checkpoint the workflow does not download: the z-lab
+  # drafter, resolved from the HF cache by glob (models--z-lab--gemma-4-31B-it-
+  # DFlash) or from GEMMA4_DFLASH_DRAFTER. It is loaded lazily at the FIRST
+  # request, so a box missing it boots healthy and then kills the engine on
+  # request 1 (EngineDeadError, no useful traceback). Fetch it before serving:
+  #   hf download z-lab/gemma-4-31B-it-DFlash
   # TT-native dFlash speculative serving (z-lab block-diffusion drafter,
   # verify V=7). B=1 latency profile; strongest on code-like content (4k:
   # 68.4 tok/s/u vs 28.8 plain; prose ~parity -- acceptance is content/

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -284,7 +284,7 @@ templates:
   device_model_specs:
     - device: P150X8
       max_concurrency: 32  # adaptive engine: solo=spec, batch=baseline
-      max_context: 262144  # full-ISL adaptive engine
+      max_context: 131072  # spec DRAM frontier at max_num_seqs=32; nothing above it is admitted, so no ceiling downgrade breaks the block-output contract (>131072 is baseline-only -- serve it from the tt_transformers entry)
       env_vars:
         MESH_DEVICE: "P150x8"
         # Generic serving-class override (plugin TT_MODEL_CLASS_OVERRIDES);
@@ -292,11 +292,10 @@ templates:
         TT_MODEL_CLASS_OVERRIDES: "Gemma4ForCausalLM=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,Gemma4ForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,Gemma4UnifiedForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,TTGemma4ForCausalLM=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,TTGemma4ForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM"
         GEMMA4_DFLASH_SHARD_ARGMAX: "1"  # bypass TTSampling in-body (server sampler is not argmax-forced)
         GEMMA4_DFLASH_SERVE_BLOCK: "64"  # spec block-output ON (adaptive: solo=spec, batch=baseline)
-        GEMMA4_DFLASH_MAX_SPEC_ISL: "131072"  # spec above this OOMs the capture at max_num_seqs=32; serve baseline instead
         GEMMA4_DFLASH_VERIFY: "7"
         GEMMA4_DFLASH_SERVE_HORIZON: "2048"
         GEMMA4_PAGE_BLOCK_SIZE: "64"
-        GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
+        GEMMA4_MAX_TOKENS_ALL_USERS: "131072"
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
         # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
         # chunk replay skips it (empty taps -> request fails at ISL > one chunk).

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -387,14 +387,9 @@ templates:
         # chunked 4k prompts hit pre-gate batched prefill and 32x more scheduler
         # rounds starved decode under async scheduling. 65536/4096 measured
         # coherent and faster on QB2/LB (2026-08-31 battery; galaxy re-run 09-01).
-        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
-        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
-        # prefill / prefix caching split or skip the prefill forward, which
-        # breaks the stateful drafter (empty taps -> request fails). The model
-        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
-        enable_chunked_prefill: false
-        no-enable-prefix-caching: true
+        enable_chunked_prefill: true
         max_num_batched_tokens: 65536
+        long_prefill_token_threshold: 4096
     # LoudBox (8x P150). Metal policy: unbounded through 64k; auto-bounded at
     # ≥128k (generator_trace). Prefill chunk default 4096; at ≥128k + bounded
     # → 2048. Scheduler tokens stay 2048 to match metal at long ISL. B=32 needs
@@ -431,14 +426,9 @@ templates:
         # chunked 4k prompts hit pre-gate batched prefill and 32x more scheduler
         # rounds starved decode under async scheduling. 65536/4096 measured
         # coherent and faster on QB2/LB (2026-08-31 battery; galaxy re-run 09-01).
-        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
-        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
-        # prefill / prefix caching split or skip the prefill forward, which
-        # breaks the stateful drafter (empty taps -> request fails). The model
-        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
-        enable_chunked_prefill: false
-        no-enable-prefix-caching: true
+        enable_chunked_prefill: true
         max_num_batched_tokens: 65536
+        long_prefill_token_threshold: 4096
     # BH Galaxy (32x P150) native, DP=4 (2026-09-03 bring-up): the plugin's
     # standard-DP discovery opens the native 8x4 mesh, create_submeshes
     # reshapes to (4,8) and yields four physical-COLUMN (1,8) engines, each a
@@ -462,12 +452,7 @@ templates:
         GEMMA4_PAGE_BLOCK_SIZE: "64"
         GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
-        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
-        # Force eager chunked prefill so every chunk fires the hook. Both this and
-        # the wrapper's enable_trace=False are needed (they gate different traces).
-        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
-        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (memory-safe to 32k; eager, tap hook fires per chunk)
+        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
       override_tt_config:
         fabric_config: FABRIC_1D
         trace_region_size: 512000000
@@ -485,14 +470,9 @@ templates:
         default-chat-template-kwargs: '{"enable_thinking": true}'
         reasoning-parser: gemma4
         # Token-chunked prefill; 65536/4096 parity with P150X8/P300X2.
-        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
-        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
-        # prefill / prefix caching split or skip the prefill forward, which
-        # breaks the stateful drafter (empty taps -> request fails). The model
-        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
-        enable_chunked_prefill: false
-        no-enable-prefix-caching: true
+        enable_chunked_prefill: true
         max_num_batched_tokens: 65536
+        long_prefill_token_threshold: 4096
     # GPU (H100 NVL) bring-your-own vLLM server (see docs/gpu_workflows.md); used
     # to collect GPU reference eval scores for GPQA-Diamond, Terminal-Bench 2.0,
     # and SWE-Bench Verified. Dev-only; no tt_metal_commit/version pin needed
@@ -526,12 +506,7 @@ templates:
         GEMMA4_PAGE_BLOCK_SIZE: "64"
         GEMMA4_MAX_TOKENS_ALL_USERS: "131072"
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
-        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
-        # Force eager chunked prefill so every chunk fires the hook. Both this and
-        # the wrapper's enable_trace=False are needed (they gate different traces).
-        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
-        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (memory-safe to 32k; eager, tap hook fires per chunk)
+        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
         # KNOWN BAD ON WORMHOLE — concurrent decode returns nondeterministic
         # garbage. Measured on T3K 12B (distinct arithmetic prompts, temp 0,
         # 3 repeats): every request completes, but correctness swings run to run
@@ -576,14 +551,43 @@ templates:
         # the parity re-run banked 9x b32@4k throughput (1.26 -> 11.7 tok/s/u)
         # and cleared the corruption bands the old 2048/2048 scheduler shadow
         # had masked.
-        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
-        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
-        # prefill / prefix caching split or skip the prefill forward, which
-        # breaks the stateful drafter (empty taps -> request fails). The model
-        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
-        enable_chunked_prefill: false
-        no-enable-prefix-caching: true
+        enable_chunked_prefill: true
         max_num_batched_tokens: 65536
+        long_prefill_token_threshold: 4096
+    # WH Galaxy (32x WH) DP=4 — same standard-DP mechanism as the
+    # BLACKHOLE_GALAXY entry above: MESH_DEVICE (4,8) splits into four (1,8)
+    # engines, each exactly a T3K. Per-engine knobs therefore mirror the
+    # validated T3K entry (12 GB/chip context cap, WH linear CCL, async decode
+    # pinned off, 200 MB trace region, tt-metal#55102 prose ceiling ~100k).
+    - device: GALAXY
+      # Whole-box: 32 users x 4 DP engines; max_num_seqs pins per-engine.
+      max_concurrency: 128
+      max_context: 131072  # per engine — same 12 GB/chip cap as T3K (262144 OOMs)
+      default_impl: true
+      env_vars:
+        MESH_DEVICE: "(4, 8)"  # Override default TG->(8,4) so DP carves (1,8) engines
+        GEMMA4_CCL_TOPOLOGY: "linear"
+        GEMMA4_PAGE_BLOCK_SIZE: "64"
+        GEMMA4_MAX_TOKENS_ALL_USERS: "131072"
+        GEMMA4_VLLM_SINGLE_CHUNK: "0"
+        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
+        # WH concurrent-decode caveat + async pin: see the T3K entry above.
+        GEMMA4_SUPPORTS_ASYNC_DECODE: "0"
+      override_tt_config:
+        fabric_config: FABRIC_1D
+        trace_region_size: 200000000  # WH budget (see T3K note); not BH's 512 MB
+        sample_on_device_mode: decode_only
+      vllm_args:
+        data_parallel_size: 4
+        max_num_seqs: 32  # per-engine; max_concurrency above is whole-box
+        # No async_scheduling on Wormhole — see the T3K entry above.
+        enable-auto-tool-choice: true
+        tool-call-parser: gemma4
+        default-chat-template-kwargs: '{"enable_thinking": true}'
+        reasoning-parser: gemma4
+        enable_chunked_prefill: true
+        max_num_batched_tokens: 65536
+        long_prefill_token_threshold: 4096
     - device: GPU
       max_concurrency: 32
       max_context: 204800  # 200 * 1024; native ctx is 256K but a single H100 NVL (94GB, bf16 KV) caps servable ctx at ~205K (KV cache = 210,605 tokens)
@@ -623,12 +627,7 @@ templates:
         GEMMA4_PAGE_BLOCK_SIZE: "64"
         GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
-        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
-        # Force eager chunked prefill so every chunk fires the hook. Both this and
-        # the wrapper's enable_trace=False are needed (they gate different traces).
-        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
-        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (memory-safe to 32k; eager, tap hook fires per chunk)
+        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
       override_tt_config:
         fabric_config: FABRIC_1D
         # B=32 decode traces (match 31B QB2 headroom).
@@ -656,14 +655,9 @@ templates:
         default-chat-template-kwargs: '{"enable_thinking": true}'
         reasoning-parser: gemma4
         # Token-chunked prefill (tenstorrent/vllm#448). Match metal 4096.
-        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
-        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
-        # prefill / prefix caching split or skip the prefill forward, which
-        # breaks the stateful drafter (empty taps -> request fails). The model
-        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
-        enable_chunked_prefill: false
-        no-enable-prefix-caching: true
+        enable_chunked_prefill: true
         max_num_batched_tokens: 65536
+        long_prefill_token_threshold: 4096
     # LoudBox: metal isl_sweep unbounded through 256k PASS for 12B; multi-chunk
     # prefill (4096) matches demo policy (no auto-bound until >256k).
     - device: P150X8
@@ -749,14 +743,9 @@ templates:
         tool-call-parser: gemma4
         default-chat-template-kwargs: '{"enable_thinking": true}'
         reasoning-parser: gemma4
-        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
-        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
-        # prefill / prefix caching split or skip the prefill forward, which
-        # breaks the stateful drafter (empty taps -> request fails). The model
-        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
-        enable_chunked_prefill: false
-        no-enable-prefix-caching: true
+        enable_chunked_prefill: true
         max_num_batched_tokens: 65536
+        long_prefill_token_threshold: 4096
     # GPU (H100 NVL) bring-your-own vLLM server (see docs/gpu_workflows.md); used
     # to collect GPU reference eval scores for GPQA-Diamond, Terminal-Bench 2.0,
     # and SWE-Bench Verified. Dev-only; no tt_metal_commit/version pin needed
@@ -842,14 +831,46 @@ templates:
         # the parity re-run banked 9x b32@4k throughput (1.26 -> 11.7 tok/s/u)
         # and cleared the corruption bands the old 2048/2048 scheduler shadow
         # had masked.
-        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
-        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
-        # prefill / prefix caching split or skip the prefill forward, which
-        # breaks the stateful drafter (empty taps -> request fails). The model
-        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
-        enable_chunked_prefill: false
-        no-enable-prefix-caching: true
+        enable_chunked_prefill: true
         max_num_batched_tokens: 65536
+        long_prefill_token_threshold: 4096
+    # WH Galaxy (32x WH) DP=4 — four (1,8) T3K-shaped engines (see the 31B
+    # GALAXY entry for the mechanism). Per-engine knobs mirror the validated
+    # 12B T3K entry above: bounded sliding + batched prefill (gated/traced
+    # prefill wedges 12B on 1x8 — G7, cross-platform), chunk 4096, WH linear
+    # CCL and async decode pinned off; same conc32 wave-boundary known issue.
+    - device: GALAXY
+      # Whole-box: 32 users x 4 DP engines; max_num_seqs pins per-engine.
+      max_concurrency: 128
+      max_context: 262144  # per engine — T3K-validated (bounded sliding); prose primes-verified only above ~110k (tt-metal#55102)
+      default_impl: true
+      env_vars:
+        MESH_DEVICE: "(4, 8)"  # Override default TG->(8,4) so DP carves (1,8) engines
+        G4_FORCE_BATCH_PREFILL: "1"
+        GEMMA4_BOUNDED_SLIDING_KV_CACHE: "1"
+        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # T3K-measured optimum (see T3K entry)
+        GEMMA4_CCL_TOPOLOGY: "linear"
+        GEMMA4_PAGE_BLOCK_SIZE: "64"
+        GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
+        GEMMA4_VLLM_SINGLE_CHUNK: "0"
+        GEMMA4_CHUNKED_PREFILL_TRACE: "0"  # inert under bounded; pinned 0 to mirror T3K/P150X8
+        # WH concurrent-decode caveat + async pin: see the T3K entry above.
+        GEMMA4_SUPPORTS_ASYNC_DECODE: "0"
+      override_tt_config:
+        fabric_config: FABRIC_1D
+        trace_region_size: 200000000  # WH budget (see T3K note); not BH's 512 MB
+        sample_on_device_mode: decode_only
+      vllm_args:
+        data_parallel_size: 4
+        max_num_seqs: 32  # per-engine; max_concurrency above is whole-box
+        # No async_scheduling on Wormhole — see the T3K entry above.
+        enable-auto-tool-choice: true
+        tool-call-parser: gemma4
+        default-chat-template-kwargs: '{"enable_thinking": true}'
+        reasoning-parser: gemma4
+        enable_chunked_prefill: true
+        max_num_batched_tokens: 65536
+        long_prefill_token_threshold: 4096
     # WH N300 (1x2 = one n300 card, 24 GB). 12B is the only Gemma4 variant that
     # fits a single WH card — 26B-A4B and 31B OOM here even at 4k. Measured
     # batch-1: 4k TTFT 11.4 s / 12.0 tok/s, 32k 60 s / 12.7 tok/s, 64k 99 s /
@@ -873,12 +894,7 @@ templates:
         GEMMA4_PAGE_BLOCK_SIZE: "64"
         GEMMA4_MAX_TOKENS_ALL_USERS: "8192"
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
-        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
-        # Force eager chunked prefill so every chunk fires the hook. Both this and
-        # the wrapper's enable_trace=False are needed (they gate different traces).
-        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
-        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (memory-safe to 32k; eager, tap hook fires per chunk)
+        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
         # KNOWN BAD ON WORMHOLE — concurrent decode returns nondeterministic
         # garbage. Measured on T3K 12B (distinct arithmetic prompts, temp 0,
         # 3 repeats): every request completes, but correctness swings run to run

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -293,7 +293,7 @@ templates:
         GEMMA4_DFLASH_SHARD_ARGMAX: "1"  # bypass TTSampling in-body (server sampler is not argmax-forced)
         GEMMA4_DFLASH_SERVE_BLOCK: "64"  # spec block-output ON (adaptive: solo=spec, batch=baseline)
         GEMMA4_DFLASH_MAX_SPEC_ISL: "131072"  # spec-capture DRAM frontier @ max_num_seqs=32; prompts above serve as plain baseline (the model declares this as tt_adaptive_block_max_prompt_tokens so the scheduler reserves width-1 for them)
-        GEMMA4_DFLASH_VERIFY: "7"
+        GEMMA4_DFLASH_VERIFY: "5"  # V=5: in-tile packed verify (P_v=6) -- +75% high-ISL vs V=7, higher acceptance (V=7 drifts off greedy at large S_k), acc ~3.3 < 5 so no cap
         GEMMA4_DFLASH_SERVE_HORIZON: "2048"
         GEMMA4_PAGE_BLOCK_SIZE: "64"
         GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
@@ -352,7 +352,7 @@ templates:
         GEMMA4_DFLASH_SHARD_ARGMAX: "1"  # bypass TTSampling in-body (server sampler is not argmax-forced)
         GEMMA4_DFLASH_SERVE_BLOCK: "64"  # spec block-output ON (adaptive: solo=spec, batch=baseline)
         GEMMA4_DFLASH_MAX_SPEC_ISL: "131072"  # inert at this ctx; keeps the capture-OOM guard if ctx is raised
-        GEMMA4_DFLASH_VERIFY: "7"
+        GEMMA4_DFLASH_VERIFY: "5"  # V=5: in-tile packed verify (P_v=6) -- +75% high-ISL vs V=7, higher acceptance (V=7 drifts off greedy at large S_k), acc ~3.3 < 5 so no cap
         GEMMA4_DFLASH_SERVE_HORIZON: "2048"
         # Explicit linear CCL: the native galaxy column ring is unmeasured (see
         # the 31B tt_transformers BLACKHOLE_GALAXY entry).

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -158,7 +158,7 @@ templates:
   # TT-native MTP speculative serving (it-assistant KV-shared drafter, K=5).
   # B=1 latency profile: speculation only pays bandwidth-bound (measured 4k:
   # code 67.5 tok/s/u vs 28.8 plain; prose is checkpoint-bound ~parity). The
-  # plugin routes Gemma4 to Gemma4MTPForCausalLM via TT_GEMMA4_SPEC; each
+  # plugin routes Gemma4 to Gemma4MTPForCausalLM via TT_MODEL_CLASS_OVERRIDES; each
   # engine step emits a VARIABLE accepted-prefix+bonus row (<= K+1), padded on
   # the wire and stripped by the runner (tt_spec_variable_output).
   inference_engine: VLLM
@@ -168,7 +168,9 @@ templates:
       max_context: 262144  # 256K bounded (requires the tt-metal MTP bounded page-table install)
       env_vars:
         MESH_DEVICE: "P150x8"
-        TT_GEMMA4_SPEC: "mtp"
+        # Generic serving-class override (plugin TT_MODEL_CLASS_OVERRIDES);
+        # replaces the removed model-specific TT_GEMMA4_SPEC env.
+        TT_MODEL_CLASS_OVERRIDES: "Gemma4ForCausalLM=models.demos.gemma4.tt.generator_vllm:Gemma4MTPForCausalLM,Gemma4ForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4MTPForCausalLM,Gemma4UnifiedForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4MTPForCausalLM,TTGemma4ForCausalLM=models.demos.gemma4.tt.generator_vllm:Gemma4MTPForCausalLM,TTGemma4ForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4MTPForCausalLM"
         GEMMA4_SPEC_DRAFT_LEN: "5"
         GEMMA4_MTP_SERVE_HORIZON: "2048"
         GEMMA4_PAGE_BLOCK_SIZE: "64"
@@ -220,7 +222,9 @@ templates:
       max_context: 65536  # KNOWN ISSUE: 12B MTP serving hangs the device (RoPE decode, fetch-queue timeout) during the FIRST bootstrap capture at ANY context (same at 65536 pre-bounded-fix, 2026-09-06 log identical) -- 0 sessions ever; pre-existing, independent of the bounded page-table install (31B MTP validated to 256K). Debug separately before raising.
       env_vars:
         MESH_DEVICE: "P150x8"
-        TT_GEMMA4_SPEC: "mtp"
+        # Generic serving-class override (plugin TT_MODEL_CLASS_OVERRIDES);
+        # replaces the removed model-specific TT_GEMMA4_SPEC env.
+        TT_MODEL_CLASS_OVERRIDES: "Gemma4ForCausalLM=models.demos.gemma4.tt.generator_vllm:Gemma4MTPForCausalLM,Gemma4ForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4MTPForCausalLM,Gemma4UnifiedForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4MTPForCausalLM,TTGemma4ForCausalLM=models.demos.gemma4.tt.generator_vllm:Gemma4MTPForCausalLM,TTGemma4ForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4MTPForCausalLM"
         GEMMA4_SPEC_DRAFT_LEN: "5"
         GEMMA4_MTP_SERVE_HORIZON: "2048"
         GEMMA4_PAGE_BLOCK_SIZE: "64"
@@ -283,7 +287,9 @@ templates:
       max_context: 262144  # full-ISL adaptive engine
       env_vars:
         MESH_DEVICE: "P150x8"
-        TT_GEMMA4_SPEC: "dflash"
+        # Generic serving-class override (plugin TT_MODEL_CLASS_OVERRIDES);
+        # replaces the removed model-specific TT_GEMMA4_SPEC env.
+        TT_MODEL_CLASS_OVERRIDES: "Gemma4ForCausalLM=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,Gemma4ForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,Gemma4UnifiedForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,TTGemma4ForCausalLM=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,TTGemma4ForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM"
         GEMMA4_DFLASH_SHARD_ARGMAX: "1"  # bypass TTSampling in-body (server sampler is not argmax-forced)
         GEMMA4_DFLASH_SERVE_BLOCK: "64"  # spec block-output ON (adaptive: solo=spec, batch=baseline)
         GEMMA4_DFLASH_MAX_SPEC_ISL: "131072"  # spec above this OOMs the capture at max_num_seqs=32; serve baseline instead
@@ -338,9 +344,11 @@ templates:
       # 2026-09-03 galaxy runs found true-262k prompts degenerate on 31B
       # (native column and emulated LB alike) -- raise only after a 131k-262k
       # band walk validates the band on this box.
-      max_context: 131072
+      max_context: 65536  # BRING-UP: warm-cache pool (131072 needs a single-rank warm boot first)
       env_vars:
-        TT_GEMMA4_SPEC: "dflash"
+        # Generic serving-class override (plugin TT_MODEL_CLASS_OVERRIDES);
+        # replaces the removed model-specific TT_GEMMA4_SPEC env.
+        TT_MODEL_CLASS_OVERRIDES: "Gemma4ForCausalLM=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,Gemma4ForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,Gemma4UnifiedForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,TTGemma4ForCausalLM=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM,TTGemma4ForConditionalGeneration=models.demos.gemma4.tt.generator_vllm:Gemma4DFlashForCausalLM"
         GEMMA4_DFLASH_SHARD_ARGMAX: "1"  # bypass TTSampling in-body (server sampler is not argmax-forced)
         GEMMA4_DFLASH_SERVE_BLOCK: "64"  # spec block-output ON (adaptive: solo=spec, batch=baseline)
         GEMMA4_DFLASH_MAX_SPEC_ISL: "131072"  # inert at this ctx; keeps the capture-OOM guard if ctx is raised
@@ -350,7 +358,7 @@ templates:
         # the 31B tt_transformers BLACKHOLE_GALAXY entry).
         GEMMA4_CCL_TOPOLOGY: "linear"
         GEMMA4_PAGE_BLOCK_SIZE: "64"
-        GEMMA4_MAX_TOKENS_ALL_USERS: "131072"  # per-engine pool = max_context
+        GEMMA4_MAX_TOKENS_ALL_USERS: "65536"  # BRING-UP pool
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
         # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
         # chunk replay skips it (empty taps -> request fails at ISL > one chunk).

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -165,14 +165,14 @@ templates:
   device_model_specs:
     - device: P150X8
       max_concurrency: 1  # spec sessions are B=1 (fused trace per request)
-      max_context: 65536
+      max_context: 262144  # 256K bounded (requires the tt-metal MTP bounded page-table install)
       env_vars:
         MESH_DEVICE: "P150x8"
         TT_GEMMA4_SPEC: "mtp"
         GEMMA4_SPEC_DRAFT_LEN: "5"
         GEMMA4_MTP_SERVE_HORIZON: "2048"
         GEMMA4_PAGE_BLOCK_SIZE: "64"
-        GEMMA4_MAX_TOKENS_ALL_USERS: "65536"  # B=1 x max_context pool
+        GEMMA4_MAX_TOKENS_ALL_USERS: "262144"  # B=1 x max_context pool
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
         # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
         # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
@@ -217,7 +217,7 @@ templates:
   device_model_specs:
     - device: P150X8
       max_concurrency: 1  # spec sessions are B=1 (fused trace per request)
-      max_context: 65536
+      max_context: 65536  # KNOWN ISSUE: 12B MTP serving hangs the device (RoPE decode, fetch-queue timeout) during the FIRST bootstrap capture at ANY context (same at 65536 pre-bounded-fix, 2026-09-06 log identical) -- 0 sessions ever; pre-existing, independent of the bounded page-table install (31B MTP validated to 256K). Debug separately before raising.
       env_vars:
         MESH_DEVICE: "P150x8"
         TT_GEMMA4_SPEC: "mtp"

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -182,11 +182,10 @@ templates:
         sample_on_device_mode: decode_only  # spec: prefill anchor host-sampled, decode model-owned
       vllm_args:
         max_num_seqs: 1
-        # Sync scheduling: async is coherent but gives no overlap until the
-        # fused decoder's step is split into non-blocking submit + deferred
-        # collect (dec.step blocks on the device readback today). The async
-        # infra is in place -- flip to async_scheduling + GEMMA4_SPEC_ASYNC=1
-        # once that split lands.
+        # Sync default: the async submit/accept split is in place and coherent,
+        # but block-output disables the steady-decode overlap (output_tokens set)
+        # and dFlash's step is serially dependent, so async gives no gain yet.
+        # The real lever is reducing the ~135ms/iter vLLM host overhead.
         no-async-scheduling: true
         enable-auto-tool-choice: true
         tool-call-parser: gemma4
@@ -229,11 +228,10 @@ templates:
         sample_on_device_mode: decode_only  # spec: prefill anchor host-sampled, decode model-owned
       vllm_args:
         max_num_seqs: 1
-        # Sync scheduling: async is coherent but gives no overlap until the
-        # fused decoder's step is split into non-blocking submit + deferred
-        # collect (dec.step blocks on the device readback today). The async
-        # infra is in place -- flip to async_scheduling + GEMMA4_SPEC_ASYNC=1
-        # once that split lands.
+        # Sync default: the async submit/accept split is in place and coherent,
+        # but block-output disables the steady-decode overlap (output_tokens set)
+        # and dFlash's step is serially dependent, so async gives no gain yet.
+        # The real lever is reducing the ~135ms/iter vLLM host overhead.
         no-async-scheduling: true
         enable-auto-tool-choice: true
         tool-call-parser: gemma4

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -154,6 +154,93 @@ templates:
 
 - weights:
     - google/gemma-4-31B-it
+  impl: gemma4_mtp
+  # TT-native MTP speculative serving (it-assistant KV-shared drafter, K=5).
+  # B=1 latency profile: speculation only pays bandwidth-bound (measured 4k:
+  # code 67.5 tok/s/u vs 28.8 plain; prose is checkpoint-bound ~parity). The
+  # plugin routes Gemma4 to Gemma4MTPForCausalLM via TT_GEMMA4_SPEC; each
+  # engine step emits a VARIABLE accepted-prefix+bonus row (<= K+1), padded on
+  # the wire and stripped by the runner (tt_spec_variable_output).
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P150X8
+      max_concurrency: 1  # spec sessions are B=1 (fused trace per request)
+      max_context: 65536
+      env_vars:
+        MESH_DEVICE: "P150x8"
+        TT_GEMMA4_SPEC: "mtp"
+        GEMMA4_SPEC_DRAFT_LEN: "5"
+        GEMMA4_MTP_SERVE_HORIZON: "2048"
+        GEMMA4_PAGE_BLOCK_SIZE: "64"
+        GEMMA4_MAX_TOKENS_ALL_USERS: "65536"  # B=1 x max_context pool
+        GEMMA4_VLLM_SINGLE_CHUNK: "0"
+        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
+      override_tt_config:
+        fabric_config: FABRIC_1D
+        trace_region_size: 512000000
+        l1_small_size: 24576
+        sample_on_device_mode: all  # block-output contract: model-owned sampler end-to-end
+      vllm_args:
+        max_num_seqs: 1
+        # False booleans are dropped by the launcher's arg emitter; the
+        # negative flag form actually reaches vLLM (block-output requires sync).
+        no-async-scheduling: true  # host acceptance loop each step
+        enable-auto-tool-choice: true
+        tool-call-parser: gemma4
+        default-chat-template-kwargs: '{"enable_thinking": true}'
+        reasoning-parser: gemma4
+        enable_chunked_prefill: true
+        max_num_batched_tokens: 65536
+        long_prefill_token_threshold: 4096
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+
+- weights:
+    - google/gemma-4-31B-it
+  impl: gemma4_dflash
+  # TT-native dFlash speculative serving (z-lab block-diffusion drafter,
+  # verify V=7). B=1 latency profile; strongest on code-like content (4k:
+  # 68.4 tok/s/u vs 28.8 plain; prose ~parity -- acceptance is content/
+  # checkpoint-bound). Prefill runs UNTRACED for this profile (the residual
+  # tap hook is python-side; traced prefill replays skip it) and each request
+  # pays a one-time fused-trace capture (~3 s) at first decode.
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P150X8
+      max_concurrency: 1  # spec sessions are B=1 (fused trace per request)
+      max_context: 65536  # dFlash serving profile is unbounded-KV (<100k)
+      env_vars:
+        MESH_DEVICE: "P150x8"
+        TT_GEMMA4_SPEC: "dflash"
+        GEMMA4_DFLASH_SHARD_ARGMAX: "1"  # bypass TTSampling in-body (server sampler is not argmax-forced)
+        GEMMA4_DFLASH_VERIFY: "7"
+        GEMMA4_DFLASH_SERVE_HORIZON: "2048"
+        GEMMA4_PAGE_BLOCK_SIZE: "64"
+        GEMMA4_MAX_TOKENS_ALL_USERS: "65536"  # B=1 x max_context pool
+        GEMMA4_VLLM_SINGLE_CHUNK: "0"
+        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
+      override_tt_config:
+        fabric_config: FABRIC_1D
+        trace_region_size: 512000000
+        l1_small_size: 24576
+        sample_on_device_mode: all  # block-output contract: model-owned sampler end-to-end
+      vllm_args:
+        max_num_seqs: 1
+        # False booleans are dropped by the launcher's arg emitter; the
+        # negative flag form actually reaches vLLM (block-output requires sync).
+        no-async-scheduling: true  # host acceptance loop each step
+        enable-auto-tool-choice: true
+        tool-call-parser: gemma4
+        default-chat-template-kwargs: '{"enable_thinking": true}'
+        reasoning-parser: gemma4
+        enable_chunked_prefill: true
+        max_num_batched_tokens: 65536
+        long_prefill_token_threshold: 4096
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+
+- weights:
+    - google/gemma-4-31B-it
   impl: tt_transformers
   # Dev specs omit tt_metal_commit/vllm_commit (base ModelSpecTemplate rejects
   # them; only prod specs carry commits). The image is supplied at runtime via

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -498,50 +498,6 @@ templates:
         enable_chunked_prefill: true
         max_num_batched_tokens: 65536
         long_prefill_token_threshold: 4096
-    # BH Galaxy (32x P150) native, DP=4 (2026-09-03 bring-up): the plugin's
-    # standard-DP discovery opens the native 8x4 mesh, create_submeshes
-    # reshapes to (4,8) and yields four physical-COLUMN (1,8) engines, each a
-    # separate process with TT_VISIBLE_DEVICES=<its column> and NO mesh-graph
-    # descriptor override (auto-discovery control plane handles constrained
-    # subsets; column-subset mesh_sanity byte-exact). Metal dp=4x tp=8 campaign:
-    # decode contention-free (31B b1 ~30 tok/s/u per replica), b32 TTFT within
-    # 2% of solo; 4 concurrent long prefills contend on HOST (TTFT up to 3.2x
-    # at 128k) — decode unaffected.
-    - device: BLACKHOLE_GALAXY
-      # Whole-box concurrency: 32 users x 4 DP engines. max_num_seqs below
-      # pins the per-engine ceiling (default inference would give 128/engine).
-      max_concurrency: 128
-      max_context: 262144  # 256 * 1024 per engine (same budget as P150X8)
-      default_impl: true
-      env_vars:
-        # Explicit linear CCL: topology settings do not transfer across device
-        # configs (the P150x8 entry inherits gemma4's ring default on the LB
-        # descriptor; the native galaxy column ring is unmeasured — A/B later).
-        GEMMA4_CCL_TOPOLOGY: "linear"
-        GEMMA4_PAGE_BLOCK_SIZE: "64"
-        GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
-        GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
-      override_tt_config:
-        fabric_config: FABRIC_1D
-        trace_region_size: 512000000
-        l1_small_size: 24576  # all_gather semaphores into L1_SMALL (metal demo parity)
-        # On-device decode sampling required on TP so token ids >= 65536 are
-        # reachable (host sampling only sees device 0's vocab shard).
-        sample_on_device_mode: decode_only
-      vllm_args:
-        data_parallel_size: 4
-        max_num_seqs: 32  # per-engine; max_concurrency above is whole-box
-        # Overlap host schedule with device decode (metal supports_async_decode; #51186).
-        async_scheduling: true
-        enable-auto-tool-choice: true
-        tool-call-parser: gemma4
-        default-chat-template-kwargs: '{"enable_thinking": true}'
-        reasoning-parser: gemma4
-        # Token-chunked prefill; 65536/4096 parity with P150X8/P300X2.
-        enable_chunked_prefill: true
-        max_num_batched_tokens: 65536
-        long_prefill_token_threshold: 4096
     # GPU (H100 NVL) bring-your-own vLLM server (see docs/gpu_workflows.md); used
     # to collect GPU reference eval scores for GPQA-Diamond, Terminal-Bench 2.0,
     # and SWE-Bench Verified. Dev-only; no tt_metal_commit/version pin needed
@@ -620,40 +576,6 @@ templates:
         # the parity re-run banked 9x b32@4k throughput (1.26 -> 11.7 tok/s/u)
         # and cleared the corruption bands the old 2048/2048 scheduler shadow
         # had masked.
-        enable_chunked_prefill: true
-        max_num_batched_tokens: 65536
-        long_prefill_token_threshold: 4096
-    # WH Galaxy (32x WH) DP=4 — same standard-DP mechanism as the
-    # BLACKHOLE_GALAXY entry above: MESH_DEVICE (4,8) splits into four (1,8)
-    # engines, each exactly a T3K. Per-engine knobs therefore mirror the
-    # validated T3K entry (12 GB/chip context cap, WH linear CCL, async decode
-    # pinned off, 200 MB trace region, tt-metal#55102 prose ceiling ~100k).
-    - device: GALAXY
-      # Whole-box: 32 users x 4 DP engines; max_num_seqs pins per-engine.
-      max_concurrency: 128
-      max_context: 131072  # per engine — same 12 GB/chip cap as T3K (262144 OOMs)
-      default_impl: true
-      env_vars:
-        MESH_DEVICE: "(4, 8)"  # Override default TG->(8,4) so DP carves (1,8) engines
-        GEMMA4_CCL_TOPOLOGY: "linear"
-        GEMMA4_PAGE_BLOCK_SIZE: "64"
-        GEMMA4_MAX_TOKENS_ALL_USERS: "131072"
-        GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
-        # WH concurrent-decode caveat + async pin: see the T3K entry above.
-        GEMMA4_SUPPORTS_ASYNC_DECODE: "0"
-      override_tt_config:
-        fabric_config: FABRIC_1D
-        trace_region_size: 200000000  # WH budget (see T3K note); not BH's 512 MB
-        sample_on_device_mode: decode_only
-      vllm_args:
-        data_parallel_size: 4
-        max_num_seqs: 32  # per-engine; max_concurrency above is whole-box
-        # No async_scheduling on Wormhole — see the T3K entry above.
-        enable-auto-tool-choice: true
-        tool-call-parser: gemma4
-        default-chat-template-kwargs: '{"enable_thinking": true}'
-        reasoning-parser: gemma4
         enable_chunked_prefill: true
         max_num_batched_tokens: 65536
         long_prefill_token_threshold: 4096
@@ -776,45 +698,6 @@ templates:
         # at 4096 the batch-2 steps starve decode (TPOT 281ms -> 35ms measured).
         max_num_batched_tokens: 65536
         long_prefill_token_threshold: 4096
-    # BH Galaxy (32x P150) native, DP=4 (2026-09-03 bring-up): four physical-
-    # column (1,8) engines via the plugin's standard-DP discovery (see the 31B
-    # BLACKHOLE_GALAXY entry for the mechanism and gates). Config mirrors the
-    # 12B P150X8 target entry: bounded sliding + batched prefill + eager 4k
-    # chunks — gated/traced prefill wedges 12B under mixed prefill+decode
-    # concurrency (G7, cross-platform); same known wave-boundary issue applies.
-    - device: BLACKHOLE_GALAXY
-      # Whole-box concurrency: 32 users x 4 DP engines. max_num_seqs below
-      # pins the per-engine ceiling (default inference would give 128/engine).
-      max_concurrency: 128
-      max_context: 262144  # 256 * 1024 per engine (same budget as P150X8)
-      default_impl: true
-      env_vars:
-        G4_FORCE_BATCH_PREFILL: "1"
-        GEMMA4_BOUNDED_SLIDING_KV_CACHE: "1"
-        GEMMA4_CCL_TOPOLOGY: "linear"
-        GEMMA4_PAGE_BLOCK_SIZE: "64"
-        GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
-        GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        GEMMA4_CHUNKED_PREFILL_TRACE: "0"  # eager chunks: no prefill traces under bounded
-      override_tt_config:
-        fabric_config: FABRIC_1D
-        trace_region_size: 512000000
-        l1_small_size: 24576  # all_gather semaphores into L1_SMALL (metal demo parity)
-        # On-device decode sampling required on TP so token ids >= 65536 are
-        # reachable (host sampling only sees device 0's vocab shard).
-        sample_on_device_mode: decode_only
-      vllm_args:
-        data_parallel_size: 4
-        max_num_seqs: 32  # per-engine; max_concurrency above is whole-box
-        # Overlap host schedule with device decode (metal supports_async_decode; #51186).
-        async_scheduling: true
-        enable-auto-tool-choice: true
-        tool-call-parser: gemma4
-        default-chat-template-kwargs: '{"enable_thinking": true}'
-        reasoning-parser: gemma4
-        enable_chunked_prefill: true
-        max_num_batched_tokens: 65536
-        long_prefill_token_threshold: 4096
     # GPU (H100 NVL) bring-your-own vLLM server (see docs/gpu_workflows.md); used
     # to collect GPU reference eval scores for GPQA-Diamond, Terminal-Bench 2.0,
     # and SWE-Bench Verified. Dev-only; no tt_metal_commit/version pin needed
@@ -900,43 +783,6 @@ templates:
         # the parity re-run banked 9x b32@4k throughput (1.26 -> 11.7 tok/s/u)
         # and cleared the corruption bands the old 2048/2048 scheduler shadow
         # had masked.
-        enable_chunked_prefill: true
-        max_num_batched_tokens: 65536
-        long_prefill_token_threshold: 4096
-    # WH Galaxy (32x WH) DP=4 — four (1,8) T3K-shaped engines (see the 31B
-    # GALAXY entry for the mechanism). Per-engine knobs mirror the validated
-    # 12B T3K entry above: bounded sliding + batched prefill (gated/traced
-    # prefill wedges 12B on 1x8 — G7, cross-platform), chunk 4096, WH linear
-    # CCL and async decode pinned off; same conc32 wave-boundary known issue.
-    - device: GALAXY
-      # Whole-box: 32 users x 4 DP engines; max_num_seqs pins per-engine.
-      max_concurrency: 128
-      max_context: 262144  # per engine — T3K-validated (bounded sliding); prose primes-verified only above ~110k (tt-metal#55102)
-      default_impl: true
-      env_vars:
-        MESH_DEVICE: "(4, 8)"  # Override default TG->(8,4) so DP carves (1,8) engines
-        G4_FORCE_BATCH_PREFILL: "1"
-        GEMMA4_BOUNDED_SLIDING_KV_CACHE: "1"
-        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # T3K-measured optimum (see T3K entry)
-        GEMMA4_CCL_TOPOLOGY: "linear"
-        GEMMA4_PAGE_BLOCK_SIZE: "64"
-        GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
-        GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        GEMMA4_CHUNKED_PREFILL_TRACE: "0"  # inert under bounded; pinned 0 to mirror T3K/P150X8
-        # WH concurrent-decode caveat + async pin: see the T3K entry above.
-        GEMMA4_SUPPORTS_ASYNC_DECODE: "0"
-      override_tt_config:
-        fabric_config: FABRIC_1D
-        trace_region_size: 200000000  # WH budget (see T3K note); not BH's 512 MB
-        sample_on_device_mode: decode_only
-      vllm_args:
-        data_parallel_size: 4
-        max_num_seqs: 32  # per-engine; max_concurrency above is whole-box
-        # No async_scheduling on Wormhole — see the T3K entry above.
-        enable-auto-tool-choice: true
-        tool-call-parser: gemma4
-        default-chat-template-kwargs: '{"enable_thinking": true}'
-        reasoning-parser: gemma4
         enable_chunked_prefill: true
         max_num_batched_tokens: 65536
         long_prefill_token_threshold: 4096
@@ -2273,12 +2119,7 @@ templates:
         GEMMA4_PAGE_BLOCK_SIZE: "64"
         GEMMA4_MAX_TOKENS_ALL_USERS: "32768"
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
-        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
-        # Force eager chunked prefill so every chunk fires the hook. Both this and
-        # the wrapper's enable_trace=False are needed (they gate different traces).
-        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
-        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (memory-safe to 32k; eager, tap hook fires per chunk)
+        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
         # KNOWN BAD ON WORMHOLE — concurrent decode returns nondeterministic
         # garbage. Measured on T3K 12B (distinct arithmetic prompts, temp 0,
         # 3 repeats): every request completes, but correctness swings run to run

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -174,7 +174,12 @@ templates:
         GEMMA4_PAGE_BLOCK_SIZE: "64"
         GEMMA4_MAX_TOKENS_ALL_USERS: "65536"  # B=1 x max_context pool
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
+        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
+        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
+        # Force eager chunked prefill so every chunk fires the hook. Both this and
+        # the wrapper's enable_trace=False are needed (they gate different traces).
+        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
+        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (memory-safe to 32k; eager, tap hook fires per chunk)
       override_tt_config:
         fabric_config: FABRIC_1D
         trace_region_size: 512000000
@@ -191,9 +196,62 @@ templates:
         tool-call-parser: gemma4
         default-chat-template-kwargs: '{"enable_thinking": true}'
         reasoning-parser: gemma4
-        enable_chunked_prefill: true
+        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
+        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
+        # prefill / prefix caching split or skip the prefill forward, which
+        # breaks the stateful drafter (empty taps -> request fails). The model
+        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
+        enable_chunked_prefill: false
+        no-enable-prefix-caching: true
         max_num_batched_tokens: 65536
-        long_prefill_token_threshold: 4096
+  status: EXPERIMENTAL
+  has_builtin_warmup: true
+
+- weights:
+    - google/gemma-4-12B-it
+  impl: gemma4_mtp
+  # 12B MTP speculative serving (google/gemma-4-12B-it-assistant KV-shared
+  # drafter, K=5). Same B=1 profile as 31B MTP. 12B has no z-lab dFlash
+  # checkpoint, so MTP is the only spec path for this size.
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P150X8
+      max_concurrency: 1  # spec sessions are B=1 (fused trace per request)
+      max_context: 65536
+      env_vars:
+        MESH_DEVICE: "P150x8"
+        TT_GEMMA4_SPEC: "mtp"
+        GEMMA4_SPEC_DRAFT_LEN: "5"
+        GEMMA4_MTP_SERVE_HORIZON: "2048"
+        GEMMA4_PAGE_BLOCK_SIZE: "64"
+        GEMMA4_MAX_TOKENS_ALL_USERS: "65536"  # B=1 x max_context pool
+        GEMMA4_VLLM_SINGLE_CHUNK: "0"
+        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
+        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
+        # Force eager chunked prefill so every chunk fires the hook. Both this and
+        # the wrapper's enable_trace=False are needed (they gate different traces).
+        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
+        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (memory-safe to 32k; eager, tap hook fires per chunk)
+      override_tt_config:
+        fabric_config: FABRIC_1D
+        trace_region_size: 512000000
+        l1_small_size: 24576
+        sample_on_device_mode: decode_only  # spec: prefill anchor host-sampled, decode model-owned
+      vllm_args:
+        max_num_seqs: 1
+        no-async-scheduling: true
+        enable-auto-tool-choice: true
+        tool-call-parser: gemma4
+        default-chat-template-kwargs: '{"enable_thinking": true}'
+        reasoning-parser: gemma4
+        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
+        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
+        # prefill / prefix caching split or skip the prefill forward, which
+        # breaks the stateful drafter (empty taps -> request fails). The model
+        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
+        enable_chunked_prefill: false
+        no-enable-prefix-caching: true
+        max_num_batched_tokens: 65536
   status: EXPERIMENTAL
   has_builtin_warmup: true
 
@@ -220,7 +278,12 @@ templates:
         GEMMA4_PAGE_BLOCK_SIZE: "64"
         GEMMA4_MAX_TOKENS_ALL_USERS: "65536"  # B=1 x max_context pool
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
+        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
+        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
+        # Force eager chunked prefill so every chunk fires the hook. Both this and
+        # the wrapper's enable_trace=False are needed (they gate different traces).
+        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
+        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (memory-safe to 32k; eager, tap hook fires per chunk)
       override_tt_config:
         fabric_config: FABRIC_1D
         trace_region_size: 512000000
@@ -237,9 +300,14 @@ templates:
         tool-call-parser: gemma4
         default-chat-template-kwargs: '{"enable_thinking": true}'
         reasoning-parser: gemma4
-        enable_chunked_prefill: true
+        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
+        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
+        # prefill / prefix caching split or skip the prefill forward, which
+        # breaks the stateful drafter (empty taps -> request fails). The model
+        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
+        enable_chunked_prefill: false
+        no-enable-prefix-caching: true
         max_num_batched_tokens: 65536
-        long_prefill_token_threshold: 4096
   status: EXPERIMENTAL
   has_builtin_warmup: true
 
@@ -305,9 +373,14 @@ templates:
         # chunked 4k prompts hit pre-gate batched prefill and 32x more scheduler
         # rounds starved decode under async scheduling. 65536/4096 measured
         # coherent and faster on QB2/LB (2026-08-31 battery; galaxy re-run 09-01).
-        enable_chunked_prefill: true
+        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
+        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
+        # prefill / prefix caching split or skip the prefill forward, which
+        # breaks the stateful drafter (empty taps -> request fails). The model
+        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
+        enable_chunked_prefill: false
+        no-enable-prefix-caching: true
         max_num_batched_tokens: 65536
-        long_prefill_token_threshold: 4096
     # LoudBox (8x P150). Metal policy: unbounded through 64k; auto-bounded at
     # ≥128k (generator_trace). Prefill chunk default 4096; at ≥128k + bounded
     # → 2048. Scheduler tokens stay 2048 to match metal at long ISL. B=32 needs
@@ -344,9 +417,14 @@ templates:
         # chunked 4k prompts hit pre-gate batched prefill and 32x more scheduler
         # rounds starved decode under async scheduling. 65536/4096 measured
         # coherent and faster on QB2/LB (2026-08-31 battery; galaxy re-run 09-01).
-        enable_chunked_prefill: true
+        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
+        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
+        # prefill / prefix caching split or skip the prefill forward, which
+        # breaks the stateful drafter (empty taps -> request fails). The model
+        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
+        enable_chunked_prefill: false
+        no-enable-prefix-caching: true
         max_num_batched_tokens: 65536
-        long_prefill_token_threshold: 4096
     # BH Galaxy (32x P150) native, DP=4 (2026-09-03 bring-up): the plugin's
     # standard-DP discovery opens the native 8x4 mesh, create_submeshes
     # reshapes to (4,8) and yields four physical-COLUMN (1,8) engines, each a
@@ -370,7 +448,12 @@ templates:
         GEMMA4_PAGE_BLOCK_SIZE: "64"
         GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
+        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
+        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
+        # Force eager chunked prefill so every chunk fires the hook. Both this and
+        # the wrapper's enable_trace=False are needed (they gate different traces).
+        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
+        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (memory-safe to 32k; eager, tap hook fires per chunk)
       override_tt_config:
         fabric_config: FABRIC_1D
         trace_region_size: 512000000
@@ -388,9 +471,14 @@ templates:
         default-chat-template-kwargs: '{"enable_thinking": true}'
         reasoning-parser: gemma4
         # Token-chunked prefill; 65536/4096 parity with P150X8/P300X2.
-        enable_chunked_prefill: true
+        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
+        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
+        # prefill / prefix caching split or skip the prefill forward, which
+        # breaks the stateful drafter (empty taps -> request fails). The model
+        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
+        enable_chunked_prefill: false
+        no-enable-prefix-caching: true
         max_num_batched_tokens: 65536
-        long_prefill_token_threshold: 4096
     # GPU (H100 NVL) bring-your-own vLLM server (see docs/gpu_workflows.md); used
     # to collect GPU reference eval scores for GPQA-Diamond, Terminal-Bench 2.0,
     # and SWE-Bench Verified. Dev-only; no tt_metal_commit/version pin needed
@@ -424,7 +512,12 @@ templates:
         GEMMA4_PAGE_BLOCK_SIZE: "64"
         GEMMA4_MAX_TOKENS_ALL_USERS: "131072"
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
+        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
+        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
+        # Force eager chunked prefill so every chunk fires the hook. Both this and
+        # the wrapper's enable_trace=False are needed (they gate different traces).
+        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
+        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (memory-safe to 32k; eager, tap hook fires per chunk)
         # KNOWN BAD ON WORMHOLE — concurrent decode returns nondeterministic
         # garbage. Measured on T3K 12B (distinct arithmetic prompts, temp 0,
         # 3 repeats): every request completes, but correctness swings run to run
@@ -469,9 +562,14 @@ templates:
         # the parity re-run banked 9x b32@4k throughput (1.26 -> 11.7 tok/s/u)
         # and cleared the corruption bands the old 2048/2048 scheduler shadow
         # had masked.
-        enable_chunked_prefill: true
+        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
+        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
+        # prefill / prefix caching split or skip the prefill forward, which
+        # breaks the stateful drafter (empty taps -> request fails). The model
+        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
+        enable_chunked_prefill: false
+        no-enable-prefix-caching: true
         max_num_batched_tokens: 65536
-        long_prefill_token_threshold: 4096
     - device: GPU
       max_concurrency: 32
       max_context: 204800  # 200 * 1024; native ctx is 256K but a single H100 NVL (94GB, bf16 KV) caps servable ctx at ~205K (KV cache = 210,605 tokens)
@@ -511,7 +609,12 @@ templates:
         GEMMA4_PAGE_BLOCK_SIZE: "64"
         GEMMA4_MAX_TOKENS_ALL_USERS: "262144"
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
+        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
+        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
+        # Force eager chunked prefill so every chunk fires the hook. Both this and
+        # the wrapper's enable_trace=False are needed (they gate different traces).
+        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
+        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (memory-safe to 32k; eager, tap hook fires per chunk)
       override_tt_config:
         fabric_config: FABRIC_1D
         # B=32 decode traces (match 31B QB2 headroom).
@@ -539,9 +642,14 @@ templates:
         default-chat-template-kwargs: '{"enable_thinking": true}'
         reasoning-parser: gemma4
         # Token-chunked prefill (tenstorrent/vllm#448). Match metal 4096.
-        enable_chunked_prefill: true
+        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
+        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
+        # prefill / prefix caching split or skip the prefill forward, which
+        # breaks the stateful drafter (empty taps -> request fails). The model
+        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
+        enable_chunked_prefill: false
+        no-enable-prefix-caching: true
         max_num_batched_tokens: 65536
-        long_prefill_token_threshold: 4096
     # LoudBox: metal isl_sweep unbounded through 256k PASS for 12B; multi-chunk
     # prefill (4096) matches demo policy (no auto-bound until >256k).
     - device: P150X8
@@ -627,9 +735,14 @@ templates:
         tool-call-parser: gemma4
         default-chat-template-kwargs: '{"enable_thinking": true}'
         reasoning-parser: gemma4
-        enable_chunked_prefill: true
+        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
+        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
+        # prefill / prefix caching split or skip the prefill forward, which
+        # breaks the stateful drafter (empty taps -> request fails). The model
+        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
+        enable_chunked_prefill: false
+        no-enable-prefix-caching: true
         max_num_batched_tokens: 65536
-        long_prefill_token_threshold: 4096
     # GPU (H100 NVL) bring-your-own vLLM server (see docs/gpu_workflows.md); used
     # to collect GPU reference eval scores for GPQA-Diamond, Terminal-Bench 2.0,
     # and SWE-Bench Verified. Dev-only; no tt_metal_commit/version pin needed
@@ -715,9 +828,14 @@ templates:
         # the parity re-run banked 9x b32@4k throughput (1.26 -> 11.7 tok/s/u)
         # and cleared the corruption bands the old 2048/2048 scheduler shadow
         # had masked.
-        enable_chunked_prefill: true
+        # B=1 single-stream spec: full prefill in ONE forward so the dFlash
+        # residual-tap hook (and MTP setup) see the whole prompt. vLLM chunked
+        # prefill / prefix caching split or skip the prefill forward, which
+        # breaks the stateful drafter (empty taps -> request fails). The model
+        # chunks the prefill internally (GEMMA4_GEN_PREFILL_CHUNK) for memory.
+        enable_chunked_prefill: false
+        no-enable-prefix-caching: true
         max_num_batched_tokens: 65536
-        long_prefill_token_threshold: 4096
     # WH N300 (1x2 = one n300 card, 24 GB). 12B is the only Gemma4 variant that
     # fits a single WH card — 26B-A4B and 31B OOM here even at 4k. Measured
     # batch-1: 4k TTFT 11.4 s / 12.0 tok/s, 32k 60 s / 12.7 tok/s, 64k 99 s /
@@ -741,7 +859,12 @@ templates:
         GEMMA4_PAGE_BLOCK_SIZE: "64"
         GEMMA4_MAX_TOKENS_ALL_USERS: "8192"
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
+        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
+        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
+        # Force eager chunked prefill so every chunk fires the hook. Both this and
+        # the wrapper's enable_trace=False are needed (they gate different traces).
+        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
+        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (memory-safe to 32k; eager, tap hook fires per chunk)
         # KNOWN BAD ON WORMHOLE — concurrent decode returns nondeterministic
         # garbage. Measured on T3K 12B (distinct arithmetic prompts, temp 0,
         # 3 repeats): every request completes, but correctness swings run to run
@@ -2051,7 +2174,12 @@ templates:
         GEMMA4_PAGE_BLOCK_SIZE: "64"
         GEMMA4_MAX_TOKENS_ALL_USERS: "32768"
         GEMMA4_VLLM_SINGLE_CHUNK: "0"
-        GEMMA4_CHUNKED_PREFILL_TRACE: "1"
+        # dFlash taps are captured by a PYTHON hook in the eager forward; a TRACED
+        # chunk replay skips it (empty taps -> request fails at ISL > one chunk).
+        # Force eager chunked prefill so every chunk fires the hook. Both this and
+        # the wrapper's enable_trace=False are needed (they gate different traces).
+        GEMMA4_CHUNKED_PREFILL_TRACE: "0"
+        GEMMA4_GEN_PREFILL_CHUNK: "4096"  # model-internal prefill chunking (memory-safe to 32k; eager, tap hook fires per chunk)
         # KNOWN BAD ON WORMHOLE — concurrent decode returns nondeterministic
         # garbage. Measured on T3K 12B (distinct arithmetic prompts, temp 0,
         # 3 repeats): every request completes, but correctness swings run to run

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -179,7 +179,7 @@ templates:
         fabric_config: FABRIC_1D
         trace_region_size: 512000000
         l1_small_size: 24576
-        sample_on_device_mode: all  # block-output contract: model-owned sampler end-to-end
+        sample_on_device_mode: decode_only  # spec: prefill anchor host-sampled, decode model-owned
       vllm_args:
         max_num_seqs: 1
         # False booleans are dropped by the launcher's arg emitter; the
@@ -223,7 +223,7 @@ templates:
         fabric_config: FABRIC_1D
         trace_region_size: 512000000
         l1_small_size: 24576
-        sample_on_device_mode: all  # block-output contract: model-owned sampler end-to-end
+        sample_on_device_mode: decode_only  # spec: prefill anchor host-sampled, decode model-owned
       vllm_args:
         max_num_seqs: 1
         # False booleans are dropped by the launcher's arg emitter; the

--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -182,9 +182,12 @@ templates:
         sample_on_device_mode: decode_only  # spec: prefill anchor host-sampled, decode model-owned
       vllm_args:
         max_num_seqs: 1
-        # False booleans are dropped by the launcher's arg emitter; the
-        # negative flag form actually reaches vLLM (block-output requires sync).
-        no-async-scheduling: true  # host acceptance loop each step
+        # Sync scheduling: async is coherent but gives no overlap until the
+        # fused decoder's step is split into non-blocking submit + deferred
+        # collect (dec.step blocks on the device readback today). The async
+        # infra is in place -- flip to async_scheduling + GEMMA4_SPEC_ASYNC=1
+        # once that split lands.
+        no-async-scheduling: true
         enable-auto-tool-choice: true
         tool-call-parser: gemma4
         default-chat-template-kwargs: '{"enable_thinking": true}'
@@ -226,9 +229,12 @@ templates:
         sample_on_device_mode: decode_only  # spec: prefill anchor host-sampled, decode model-owned
       vllm_args:
         max_num_seqs: 1
-        # False booleans are dropped by the launcher's arg emitter; the
-        # negative flag form actually reaches vLLM (block-output requires sync).
-        no-async-scheduling: true  # host acceptance loop each step
+        # Sync scheduling: async is coherent but gives no overlap until the
+        # fused decoder's step is split into non-blocking submit + deferred
+        # collect (dec.step blocks on the device readback today). The async
+        # infra is in place -- flip to async_scheduling + GEMMA4_SPEC_ASYNC=1
+        # once that split lands.
+        no-async-scheduling: true
         enable-auto-tool-choice: true
         tool-call-parser: gemma4
         default-chat-template-kwargs: '{"enable_thinking": true}'


### PR DESCRIPTION
Main model-spec entries for the gemma-4 speculative serving impls (gemma4_dflash, gemma4_mtp) — separate templates; 

- 31B dFlash P150X8: single adaptive 256K profile — conc-1 spec (3.6–5.2×), conc>1 batched baseline, MAX_SPEC_ISL guard.
- 31B dFlash BLACKHOLE_GALAXY: DP=4 (four (1,8) column engines) — validated: conc-1 spec ~106 tok/s/u per lane, 128-way batched fallback ~1.9K agg tok/s.
- 31B MTP: raised to 262144 (validated full ladder, no bounded collapse). 12B MTP held at 65536 with a documented pre-existing serving hang.
- benchmark_config: 192K/224K/248K rungs + OSL=1024 high-ISL companions (the output-TPS column is otherwise ~all prefill at high ISL); auto-filtered by each model's context cap.