### PR TITLE
added hf download speed and current downloaded package size

### DIFF
--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -12,7 +12,7 @@ import shlex
 import shutil
 import subprocess
 import sys
-import time
+import threading
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -621,20 +621,26 @@ class HostSetupManager:
         # stalled transfer looks identical to a frozen process. Log the actual rate
         # every 5 min instead; in-flight bytes land in
         # .cache/huggingface/download/*.incomplete under host_weights_dir.
-        result = subprocess.Popen(cmd)
-        last_bytes, elapsed = _dir_bytes(host_weights_dir), 0
-        while result.poll() is None:
-            time.sleep(5)
-            elapsed += 5
-            if elapsed < 300:
-                continue
-            now_bytes = _dir_bytes(host_weights_dir)
-            logger.info(
-                f"hf download throughput: "
-                f"{(now_bytes - last_bytes) / elapsed / 1e6:.2f} MB/s "
-                f"({now_bytes / 1e9:.1f} GB on disk)"
-            )
-            last_bytes, elapsed = now_bytes, 0
+        done = threading.Event()
+
+        def _log_throughput():
+            last_bytes = _dir_bytes(host_weights_dir)
+            while not done.wait(300):
+                now_bytes = _dir_bytes(host_weights_dir)
+                logger.info(
+                    f"hf download throughput: "
+                    f"{(now_bytes - last_bytes) / 300 / 1e6:.2f} MB/s "
+                    f"({now_bytes / 1e9:.1f} GB on disk)"
+                )
+                last_bytes = now_bytes
+
+        reporter = threading.Thread(target=_log_throughput, daemon=True)
+        reporter.start()
+        try:
+            result = subprocess.run(cmd)
+        finally:
+            done.set()
+            reporter.join(timeout=5)
         if result.returncode != 0 and weights_complete:
             logger.warning(
                 f"Could not reach Hugging Face to verify weights; "

--- a/workflows/setup_host.py
+++ b/workflows/setup_host.py
@@ -12,6 +12,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -33,6 +34,18 @@ from workflows.workflow_types import ModelSource, WorkflowVenvType
 from workflows.workflow_venvs import VENV_CONFIGS
 
 logger = logging.getLogger("run_log")
+
+
+def _dir_bytes(path: Path) -> int:
+    """Total bytes under path, including partial *.incomplete download staging."""
+    total = 0
+    for f in path.rglob("*"):
+        try:
+            if f.is_file():
+                total += f.stat().st_size
+        except OSError:
+            continue  # renamed or removed mid-walk by the downloader
+    return total
 
 
 @dataclass
@@ -604,7 +617,24 @@ class HostSetupManager:
         ]
         logger.info(f"Downloading model to host volume: {hf_repo}")
         logger.info(f"Command: {shlex.join(cmd)}")
-        result = subprocess.run(cmd)
+        # `hf download` draws progress with \r, which CI log collectors buffer, so a
+        # stalled transfer looks identical to a frozen process. Log the actual rate
+        # every 5 min instead; in-flight bytes land in
+        # .cache/huggingface/download/*.incomplete under host_weights_dir.
+        result = subprocess.Popen(cmd)
+        last_bytes, elapsed = _dir_bytes(host_weights_dir), 0
+        while result.poll() is None:
+            time.sleep(5)
+            elapsed += 5
+            if elapsed < 300:
+                continue
+            now_bytes = _dir_bytes(host_weights_dir)
+            logger.info(
+                f"hf download throughput: "
+                f"{(now_bytes - last_bytes) / elapsed / 1e6:.2f} MB/s "
+                f"({now_bytes / 1e9:.1f} GB on disk)"
+            )
+            last_bytes, elapsed = now_bytes, 0
         if result.returncode != 0 and weights_complete:
             logger.warning(
                 f"Could not reach Hugging Face to verify weights; "


### PR DESCRIPTION
When testing `gemma4-31B` deployment on QB2 server, we have faced extremely slow weights download on `bh-qbge-11` server - approximately 0.8 MB/s.
We were not aware of it, both runs seem stuck to us, as there were no any progress/output after 5 and 17 hours (test duration outputs), and therefore we cancelled those jobs. Percentage value didn't progress at all.

https://github.com/tenstorrent/tt-shield/actions/runs/34097027376/job/101679029316#step:11:323
https://github.com/tenstorrent/tt-shield/actions/runs/34097427295/job/101664126905#step:11:291

It seemed like the server was facing some intermittent network issue.

In order to be aware that packages are being downloaded properly, we will print the current download speed and downloaded package size.

Example run:
https://github.com/tenstorrent/tt-shield/actions/runs/34402201322/job/102636660119#step:11:306

Fetching 29 files:  83%| 24/29 [02:04<02:05, 25.10s/it]
Fetching 29 files:  86% 25/29 [03:07<02:24, 36.18s/it]
**2026-09-09 20:50:10,583 - setup_host.py:632 - INFO: hf download throughput: 128.38 MB/s (38.5 GB on disk)**
Fetching 29 files:  90% | 26/29 [04:44<02:41, 53.88s/it]
Fetching 29 files:  93%| 27/29 [07:03<02:37, 78.83s/it]