### PR TITLE
fix(vllm): restrict inference routes and secure shared media fetching

### DIFF
--- a/charts/tt-inference-server/templates/_helpers.tpl
+++ b/charts/tt-inference-server/templates/_helpers.tpl
@@ -34,16 +34,16 @@ Validate required values and that model/engine/device/impl resolves.
 
 {{/*
 media/forge fall back to a well-known built-in key when API_KEY is unset, which
-looks authenticated but is not, so make the operator pick. vLLM needs no gate:
-it is open unless VLLM_API_KEY is set, which is what auth.apiKey sets.
+looks authenticated but is not, so make the operator pick. Patched vLLM also
+requires explicit credentials or the isolated-development --no-auth flag.
 */}}
 {{- $auth := .Values.auth | default dict }}
 {{- if and (dig "apiKey" "" $auth) (dig "disabled" false $auth) }}
   {{- fail "auth.apiKey and auth.disabled are contradictory: the server would honour NO_AUTH and serve unauthenticated while the key sits in the release Secret. Set one." }}
 {{- end }}
-{{- if or (eq $engine "media") (eq $engine "forge") }}
+{{- if or (eq $engine "media") (eq $engine "forge") (eq $engine "vllm") }}
   {{- if and (not (dig "apiKey" "" $auth)) (not (dig "disabled" false $auth)) }}
-    {{- fail (printf "engine '%s' authenticates its inference routes with a bearer key, and leaving it unset would silently use the server image's built-in default. Set auth.apiKey=<key> (stored in the release Secret as API_KEY), or auth.disabled=true to run without auth." $engine) }}
+    {{- fail (printf "engine '%s' requires explicit authentication configuration. Set auth.apiKey=<key> (stored in the release Secret), or auth.disabled=true for isolated development." $engine) }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/tt-inference-server/templates/configmap.yaml
+++ b/charts/tt-inference-server/templates/configmap.yaml
@@ -28,6 +28,11 @@ under CACHE_ROOT, so this mirrors run_docker_server.py's media/forge branch.
 {{- $_ := set $data .name (.value | toString) }}
 {{- end }}
 {{- end }}
+{{- if eq $engine "vllm" }}
+{{- /* Apply operator policy after model defaults / extraEnv. */}}
+{{- $_ := set $data "TT_ALLOWED_MEDIA_DOMAINS" (toJson .Values.media.allowedDomains) }}
+{{- $_ := set $data "VLLM_MEDIA_URL_ALLOW_REDIRECTS" "0" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/tt-inference-server/templates/deployment.yaml
+++ b/charts/tt-inference-server/templates/deployment.yaml
@@ -107,6 +107,9 @@ spec:
             - {{ .Values.model | quote }}
             - "--tt-device"
             - {{ .Values.device | quote }}
+            {{- if .Values.auth.disabled }}
+            - "--no-auth"
+            {{- end }}
           {{- end }}
           ports:
             - name: http

--- a/charts/tt-inference-server/values.yaml
+++ b/charts/tt-inference-server/values.yaml
@@ -32,13 +32,18 @@ hfCacheDir: ""
 # Inference-route authentication. media and forge servers check a literal
 # `Authorization: Bearer $API_KEY` (/health and /v1/models stay open) and fall
 # back to a well-known built-in key when unset, so one of these two is required
-# for those engines. vLLM is open unless VLLM_API_KEY is set.
+# for those engines. The patched vLLM launcher also requires an explicit choice.
 auth:
   # Bearer key clients must send. Stored in the release Secret as API_KEY
   # (media/forge) or VLLM_API_KEY (vllm).
   apiKey: ""
-  # Serve without authentication (NO_AUTH=1). media/forge only.
+  # Isolated development only: NO_AUTH=1 (media/forge), --no-auth (vLLM).
   disabled: false
+
+# Exact approved remote-media hosts. Empty denies remote fetching in the patched
+# vLLM connector; inline media remains supported. Requires a rebuilt workload image.
+media:
+  allowedDomains: []
 
 # Tenstorrent boards need 1Gi hugepages unless the cluster runs IOMMU + KMD
 # 1.29.0+, where they aren't required. When disabled, the chart drops the

--- a/docs/workflows_user_guide.md
+++ b/docs/workflows_user_guide.md
@@ -250,9 +250,61 @@ export JWT_SECRET=my-secret-string
 ```
 
 - **HF_TOKEN**: Required for access to gated HF repositories (get your token from https://huggingface.co, go to `Settings` -> `Access Tokens`).
-- **JWT_SECRET**: Your JWT Token secret for vLLM server authorization. Use `--no-auth` to disable authorization.
+- **JWT_SECRET**: Your JWT Token secret for vLLM server authorization. Use `--no-auth` only for isolated development. Startup requires this secret, `VLLM_API_KEY`, or `--api-key` unless `--no-auth` is explicitly selected.
 
 If not set via `.env` or environment, `run.py` will prompt interactively on first run.
+
+### Inference HTTP security
+
+The patched launcher requires credentials unless `--no-auth` is explicitly
+selected for isolated development. It exposes only `/v1/models`,
+`/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, and `/v1/audio/speech`
+by default. All require a bearer key. Health checks and metrics remain available;
+CORS preflights are permitted only for exposed routes. Other HTTP routes return
+404, and WebSocket connections are rejected.
+
+`TT_INFERENCE_ALLOWED_ROUTES` is an optional JSON array replacing the exposed
+route list. Include `/invocations`, `/tokenize`, or a deployment-specific
+`/tokenizer` route only if needed. Every opted-in route still requires
+credentials. Do not expose operational or development endpoints.
+
+Remote media is supported through a shared vLLM connector, selected with
+`VLLM_MEDIA_CONNECTOR=tt_secure`. Configure exact approved hostnames with the
+JSON-array environment variable `TT_ALLOWED_MEDIA_DOMAINS` or native
+`--allowed-media-domains` arguments. The environment policy takes precedence;
+conflicting CLI arguments cause startup to fail. An empty list denies remote
+fetching; inline data URIs remain supported. Never use an empty native vLLM
+allowlist alone as a deny-all policy: native vLLM treats it as unrestricted.
+
+The launcher applies the native domain allowlist and disables redirects. The
+shared connector additionally requires HTTPS on port 443, rejects credentials
+in URLs, rejects private/non-global DNS answers (including mixed public/private
+answers), and connects to the validated numeric address without another lookup.
+TLS certificate validation and SNI retain the approved hostname. No client
+credentials or cookies are forwarded to image hosts.
+
+Downloads accept image, audio, or video Content-Type headers, use a 20 MiB size
+cap and a five-second connection/download budget, and never follow redirects.
+The operating system controls DNS resolver timeouts. Compressed HTTP responses
+are rejected; hosts must honor `Accept-Encoding: identity`. Image decoding is
+limited to 16 megapixels through Pillow's decompression-bomb checks. The policy
+also applies in explicit `--no-auth` development mode.
+
+The full image must be rebuilt: it needs the patched launcher, `utils` modules,
+and the `tt_media_security` general plugin for spawned workers. It also requires
+a TT vLLM build with `MEDIA_CONNECTOR_REGISTRY`; unsupported builds fail startup.
+Starting vLLM outside the launcher does not install the HTTP route/auth guard.
+The Helm chart supplies `media.allowedDomains` and requires an explicit auth
+choice. Operators must also restrict workload ingress to the authenticated
+gateway and apply network egress restrictions in the workload cluster.
+
+Before closing an SSRF finding, run the native connector contract test
+(`tests/test_secure_media_vllm.py`) in the rebuilt TT image, then retest the actual
+workload ingress. Blocked routes must return 404; opted-in routes must return 401
+without credentials. With valid credentials, unapproved URLs, internal targets,
+redirects, and DNS rebinding must produce zero outbound requests to the forbidden
+target. Verify approved remote images and inline images still work. Unit tests
+alone do not establish that an existing deployed image has this protection.
 
 ##### Weights download
 

--- a/tests/test_chart/test_chart_resolver.py
+++ b/tests/test_chart/test_chart_resolver.py
@@ -113,3 +113,41 @@ def test_cache_hostpath_includes_impl():
     r = _render("model=Qwen3-32B", "device=galaxy", "impl=tt_transformers")
     assert r.returncode == 0, r.stderr
     assert "/opt/cache/Qwen3-32B-galaxy-tt_transformers" in r.stdout
+
+
+def test_vllm_requires_an_explicit_auth_choice():
+    result = _render("model=Llama-3.1-8B-Instruct", "device=galaxy", "auth.apiKey=")
+    assert result.returncode != 0
+    assert "requires explicit authentication configuration" in result.stderr
+
+
+def test_vllm_development_no_auth_is_explicit():
+    result = _render(
+        "model=Llama-3.1-8B-Instruct",
+        "device=galaxy",
+        "auth.apiKey=",
+        "auth.disabled=true",
+    )
+    assert result.returncode == 0, result.stderr
+    assert '"--no-auth"' in result.stdout
+
+
+def test_vllm_media_policy_is_rendered():
+    import json
+    import yaml
+
+    result = _render(
+        "model=Llama-3.1-8B-Instruct",
+        "device=galaxy",
+        "media.allowedDomains[0]=images.example.com",
+    )
+    assert result.returncode == 0, result.stderr
+    config = next(
+        doc
+        for doc in yaml.safe_load_all(result.stdout)
+        if doc and doc["kind"] == "ConfigMap"
+    )
+    assert json.loads(config["data"]["TT_ALLOWED_MEDIA_DOMAINS"]) == [
+        "images.example.com"
+    ]
+    assert config["data"]["VLLM_MEDIA_URL_ALLOW_REDIRECTS"] == "0"

--- a/tests/test_inference_security.py
+++ b/tests/test_inference_security.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+import asyncio
+import json
+import os
+
+import pytest
+
+from utils import inference_security as security
+from utils import secure_media
+
+
+@pytest.fixture(autouse=True)
+def policy_env(monkeypatch):
+    monkeypatch.setattr(os, "environ", os.environ.copy())
+    for name in (
+        "VLLM_API_KEY",
+        security._POLICY_ENV,
+        "TT_ALLOWED_MEDIA_DOMAINS",
+        "TT_INFERENCE_ALLOWED_ROUTES",
+        "VLLM_MEDIA_CONNECTOR",
+        "VLLM_PLUGINS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(secure_media, "register_media_connector", lambda: None)
+
+
+def call_guard(
+    monkeypatch,
+    path,
+    *,
+    headers=None,
+    method="POST",
+    routes=None,
+    root_path="",
+    no_auth=False,
+):
+    monkeypatch.setenv("VLLM_API_KEY", "" if no_auth else "test-key")
+    if routes is not None:
+        monkeypatch.setenv("TT_INFERENCE_ALLOWED_ROUTES", json.dumps(routes))
+    security.configure_inference_security(["server"], no_auth=no_auth)
+    sent, received, forwarded = [], [], []
+    body = b'{"messages":[{"content":[{"type":"image_url","image_url":{"url":"https://images.example.com/a.png"}}]}]}'
+
+    async def receive():
+        received.append(True)
+        return {"type": "http.request", "body": body}
+
+    async def send(event):
+        sent.append(event)
+
+    async def app(scope, receive, send):
+        forwarded.append(await receive())
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"first", "more_body": True})
+        await send({"type": "http.response.body", "body": b"last"})
+
+    scope = {
+        "type": "http",
+        "path": path,
+        "root_path": root_path,
+        "method": method,
+        "headers": headers
+        if headers is not None
+        else [(b"authorization", b"Bearer test-key")],
+    }
+    asyncio.run(security.InferenceSecurityMiddleware(app)(scope, receive, send))
+    return sent, received, forwarded, body
+
+
+@pytest.mark.parametrize(
+    "path", ["/invocations", "/tokenizer", "/tokenize", "/pause", "/v1/unknown"]
+)
+@pytest.mark.parametrize("headers", [[], [(b"authorization", b"Bearer test-key")]])
+def test_unused_routes_are_blocked_before_body_read(monkeypatch, path, headers):
+    sent, received, forwarded, _ = call_guard(monkeypatch, path, headers=headers)
+    assert sent[0]["status"] == 404
+    assert not received and not forwarded
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/invocations", "/tokenizer", "/tokenize", "/v1/chat/completions", "/v1/models"],
+)
+@pytest.mark.parametrize(
+    "headers",
+    [
+        [],
+        [(b"authorization", b"Bearer wrong")],
+        [(b"authorization", b"Basic test-key")],
+        [(b"authorization", b"Bearer test-key"), (b"authorization", b"Bearer wrong")],
+    ],
+)
+def test_opted_in_routes_require_authentication(monkeypatch, path, headers):
+    sent, received, forwarded, _ = call_guard(
+        monkeypatch, path, headers=headers, routes=[path]
+    )
+    assert sent[0]["status"] == 401
+    assert not received and not forwarded
+
+
+@pytest.mark.parametrize(
+    "path", ["/v1/chat/completions", "/invocations", "/tokenize", "/tokenizer"]
+)
+def test_allowed_requests_and_streams_are_untouched(monkeypatch, path):
+    sent, received, forwarded, body = call_guard(monkeypatch, path, routes=[path])
+    assert sent[0]["status"] == 200
+    assert received == [True]
+    assert forwarded == [{"type": "http.request", "body": body}]
+    assert sent[1:] == [
+        {"type": "http.response.body", "body": b"first", "more_body": True},
+        {"type": "http.response.body", "body": b"last"},
+    ]
+
+
+@pytest.mark.parametrize("path", ["/health", "/ping", "/metrics"])
+def test_health_and_metrics_are_public(monkeypatch, path):
+    assert (
+        call_guard(monkeypatch, path, method="GET", headers=[])[0][0]["status"] == 200
+    )
+
+
+@pytest.mark.parametrize("path", ["/models/qwen/tokenize", "/tokenize"])
+def test_root_path_keeps_route_policy(monkeypatch, path):
+    assert (
+        call_guard(monkeypatch, path, root_path="/models/qwen")[0][0]["status"] == 404
+    )
+    assert (
+        call_guard(
+            monkeypatch,
+            path,
+            root_path="/models/qwen",
+            routes=["/tokenize"],
+            headers=[],
+        )[0][0]["status"]
+        == 401
+    )
+
+
+def test_missing_auth_configuration_fails_closed():
+    with pytest.raises(RuntimeError, match="authentication requires"):
+        security.configure_inference_security(["server"])
+    with pytest.raises(RuntimeError, match="not configured"):
+        security.InferenceSecurityMiddleware(None)
+
+
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        (["server"], ["env-key"]),
+        (["server", "--api-key", "cli-key"], ["cli-key"]),
+        (["server", "--api-key=cli-key"], ["cli-key"]),
+        (["server", "--api-key", "one", "two", "--model", "model"], ["one", "two"]),
+    ],
+)
+def test_effective_keys_and_middleware(monkeypatch, argv, expected):
+    monkeypatch.setenv("VLLM_API_KEY", "env-key")
+    security.configure_inference_security(argv)
+    assert security.InferenceSecurityMiddleware(None).keys == [
+        key.encode() for key in expected
+    ]
+    assert argv[-2:] == ["--middleware", security._MIDDLEWARE]
+    assert json.loads(os.environ["TT_ALLOWED_MEDIA_DOMAINS"]) == []
+
+
+def test_explicit_development_no_auth_keeps_shared_media_policy(monkeypatch):
+    sent, _, _, _ = call_guard(
+        monkeypatch, "/v1/chat/completions", headers=[], no_auth=True
+    )
+    assert sent[0]["status"] == 200
+    assert os.environ["VLLM_MEDIA_CONNECTOR"] == secure_media.CONNECTOR_NAME
+
+
+def test_native_underscore_style_api_key(monkeypatch):
+    monkeypatch.setenv("VLLM_API_KEY", "env-key")
+    argv = ["server", "--api_key=cli_key"]
+    security.configure_inference_security(argv)
+    assert security.InferenceSecurityMiddleware(None).keys == [b"cli_key"]

--- a/tests/test_run_vllm_api_server.py
+++ b/tests/test_run_vllm_api_server.py
@@ -370,6 +370,10 @@ def test_main_passes_passthrough_port_to_trace_capture(
         MagicMock(side_effect=lambda _spec: env_setup_order.append("runtime_env")),
     )
     monkeypatch.setattr(run_vllm_api_server_module, "runtime_settings", MagicMock())
+    security_setup = MagicMock()
+    monkeypatch.setattr(
+        run_vllm_api_server_module, "configure_inference_security", security_setup
+    )
     monkeypatch.setattr(run_vllm_api_server_module.runpy, "run_module", MagicMock())
     monkeypatch.setattr(sys, "argv", ["run_vllm_api_server.py"])
     start_trace_capture = MagicMock()
@@ -379,6 +383,7 @@ def test_main_passes_passthrough_port_to_trace_capture(
 
     run_vllm_api_server_module.main()
 
+    security_setup.assert_called_once_with(sys.argv, no_auth=False)
     start_trace_capture.assert_called_once_with(
         model_spec,
         disable_trace_capture=False,
@@ -447,3 +452,20 @@ def test_ensure_weights_available_raises_when_unreachable_and_no_weights(
 
     with pytest.raises(RuntimeError):
         run_vllm_api_server_module.ensure_weights_available(_weights_spec())
+
+
+def test_model_env_cannot_override_operator_security_policy(
+    monkeypatch, run_vllm_api_server_module
+):
+    monkeypatch.setenv("TT_ALLOWED_MEDIA_DOMAINS", '["images.example.com"]')
+    monkeypatch.setenv("TT_INFERENCE_ALLOWED_ROUTES", '["/v1/chat/completions"]')
+    run_vllm_api_server_module.set_runtime_env_vars(
+        {
+            "env_vars": {
+                "TT_ALLOWED_MEDIA_DOMAINS": '["unapproved.example"]',
+                "TT_INFERENCE_ALLOWED_ROUTES": '["/invocations"]',
+            }
+        }
+    )
+    assert os.environ["TT_ALLOWED_MEDIA_DOMAINS"] == '["images.example.com"]'
+    assert os.environ["TT_INFERENCE_ALLOWED_ROUTES"] == '["/v1/chat/completions"]'

--- a/tests/test_secure_media.py
+++ b/tests/test_secure_media.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+import asyncio
+import io
+import json
+import os
+import socket
+from unittest.mock import MagicMock
+
+import pytest
+
+from utils import secure_media as media
+
+HOST = "images.example.com"
+URL = "https://images.example.com/a.png?signature=test"
+PUBLIC_ADDRESS = (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))
+
+
+@pytest.fixture(autouse=True)
+def isolated_environment(monkeypatch):
+    monkeypatch.setattr(os, "environ", os.environ.copy())
+
+
+@pytest.fixture
+def transport(monkeypatch):
+    response = MagicMock()
+    response.status = 200
+    headers = {"Content-Type": "image/png"}
+    response.getheader.side_effect = lambda key, default=None: headers.get(key, default)
+    response.read1.side_effect = io.BytesIO(b"image bytes").read1
+    connection = MagicMock()
+    connection.tls_socket = None
+    connection.getresponse.return_value = response
+    factory = MagicMock(return_value=connection)
+    lookup = MagicMock(return_value=[PUBLIC_ADDRESS])
+    monkeypatch.setattr(media, "_PinnedHTTPSConnection", factory)
+    monkeypatch.setattr(media.socket, "getaddrinfo", lookup)
+    return (
+        media.SafeMediaHTTPConnection([HOST]),
+        lookup,
+        factory,
+        connection,
+        response,
+        headers,
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8000/health",
+        "http://127.0.0.1:8000/v1/models",
+        "http://127.0.0.1:8080/",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://kubernetes.default.svc/",
+        "https://10.233.0.1/",
+        "http://240.0.0.1/",
+        "https://[::1]/",
+        "https://[::ffff:127.0.0.1]/",
+        "https://2130706433/",
+        "https://0177.0.0.1/",
+        "file:///etc/passwd",
+        "//images.example.com/a",
+        "http://images.example.com/a",
+        "https://images.example.com:8000/a",
+        "https://images.example.com.evil.test/a",
+        "https://evil.test@images.example.com/a",
+        "https://127.0.0.1\\@images.example.com/a",
+        "https://images.example.com\\@127.0.0.1/a",
+        "https://images.example.com./a",
+        "https://images%2eexample.com/a",
+        " https://images.example.com/a",
+        "https://images.example.com/a\r\nHost: 127.0.0.1",
+        "https://images.example.com/a#fragment",
+    ],
+)
+def test_unapproved_urls_never_resolve_or_connect(transport, url):
+    client, lookup, factory, *_ = transport
+    with pytest.raises(ValueError, match="not permitted"):
+        client.get_bytes(url)
+    lookup.assert_not_called()
+    factory.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "127.0.0.1",
+        "10.0.0.1",
+        "172.16.0.1",
+        "192.168.0.1",
+        "169.254.169.254",
+        "100.64.0.1",
+        "0.0.0.0",
+        "240.0.0.1",
+        "224.0.0.1",
+        "::1",
+        "fe80::1",
+        "fd00::1",
+        "::ffff:127.0.0.1",
+        "64:ff9b::7f00:1",
+        "2002:7f00:1::1",
+    ],
+)
+def test_private_dns_answers_never_connect(transport, ip):
+    client, lookup, factory, *_ = transport
+    private = (
+        socket.AF_INET6 if ":" in ip else socket.AF_INET,
+        socket.SOCK_STREAM,
+        6,
+        "",
+        (ip, 443),
+    )
+    lookup.return_value = [PUBLIC_ADDRESS, private]
+    with pytest.raises(ValueError, match="Unable to fetch"):
+        client.get_bytes(URL)
+    factory.assert_not_called()
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_approved_https_fetch_pins_validated_resolution(transport, asynchronous):
+    client, lookup, factory, connection, *_ = transport
+    # A second resolution would rebind to loopback. It must never occur.
+    lookup.side_effect = [
+        [PUBLIC_ADDRESS],
+        [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 443))],
+    ]
+    result = (
+        asyncio.run(client.async_get_bytes(URL))
+        if asynchronous
+        else client.get_bytes(URL)
+    )
+    assert result == b"image bytes"
+    lookup.assert_called_once_with(HOST, 443, type=socket.SOCK_STREAM)
+    assert factory.call_args.args[:2] == (HOST, [PUBLIC_ADDRESS])
+    assert connection.request.call_args.args == ("GET", "/a.png?signature=test")
+    connection.close.assert_called_once()
+
+
+def test_dial_uses_numeric_ip_and_keeps_certificate_hostname(monkeypatch):
+    sock, tls, context = MagicMock(), MagicMock(), MagicMock()
+    context.wrap_socket.return_value = tls
+    factory = MagicMock(return_value=sock)
+    monkeypatch.setattr(media.socket, "socket", factory)
+    monkeypatch.setattr(media.ssl, "create_default_context", lambda: context)
+    connection = media._PinnedHTTPSConnection(
+        HOST, [PUBLIC_ADDRESS], media.time.monotonic() + 5
+    )
+    connection.connect()
+    sock.connect.assert_called_once_with(("93.184.216.34", 443))
+    context.wrap_socket.assert_called_once_with(sock, server_hostname=HOST)
+    assert connection.sock is tls
+    connection.close()
+
+
+@pytest.mark.parametrize("status", [301, 302, 307, 308, 401, 404, 500])
+def test_redirects_and_upstream_details_are_not_exposed(transport, status):
+    client, lookup, _, _, response, headers = transport
+    response.status = status
+    headers["Location"] = "http://127.0.0.1:8000/v1/models"
+    with pytest.raises(ValueError) as exc:
+        client.get_bytes(URL, allow_redirects=True)
+    assert str(exc.value) == media._FETCH_FAILED
+    assert lookup.call_count == 1
+    response.read1.assert_not_called()
+
+
+def test_unannounced_oversize_body_is_bounded(transport, monkeypatch):
+    client, _, _, connection, response, _ = transport
+    monkeypatch.setattr(media, "MAX_DOWNLOAD_BYTES", 8)
+    response.read1.side_effect = io.BytesIO(b"x" * 100).read1
+    with pytest.raises(ValueError, match="Unable to fetch"):
+        client.get_bytes(URL)
+    assert response.read1.call_args.args == (9,)
+    connection.close.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"Content-Length": "99999999999"},
+        {"Content-Type": "text/html"},
+        {"Content-Encoding": "gzip"},
+    ],
+)
+def test_response_headers_checked_before_read(transport, headers):
+    client, _, _, _, response, actual_headers = transport
+    actual_headers.update(headers)
+    with pytest.raises(ValueError, match="Unable to fetch"):
+        client.get_bytes(URL)
+    response.read1.assert_not_called()
+
+
+def test_expired_deadline_cannot_connect(transport):
+    client, _, _, connection, *_ = transport
+    # Factory is mocked, so assert the timeout while reading as well.
+    with pytest.raises(ValueError, match="Unable to fetch"):
+        client.get_bytes(URL, timeout=0)
+    connection.close.assert_called_once()
+
+
+def test_empty_policy_denies_every_remote_url(transport):
+    _, lookup, factory, *_ = transport
+    with pytest.raises(ValueError, match="not permitted"):
+        media.SafeMediaHTTPConnection([]).get_bytes(URL)
+    lookup.assert_not_called()
+    factory.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "domains",
+    [
+        ["*.example.com"],
+        ["https://example.com"],
+        ["example.com:443"],
+        ["127.0.0.1"],
+        ["localhost"],
+        ["example.com/"],
+        ["example.com."],
+        [None],
+        "example.com",
+    ],
+)
+def test_allowlist_rejects_ambiguous_configuration(domains):
+    with pytest.raises(ValueError):
+        media.allowed_domains(domains)
+
+
+def test_native_flags_and_worker_plugin_configuration(monkeypatch):
+    monkeypatch.setenv("TT_ALLOWED_MEDIA_DOMAINS", json.dumps([HOST]))
+    monkeypatch.setenv("VLLM_PLUGINS", "tt_model_registry")
+    register = MagicMock()
+    monkeypatch.setattr(media, "register_media_connector", register)
+    argv = ["server"]
+    media.configure_media_policy(argv)
+    assert argv == ["server", "--allowed-media-domains", HOST]
+    assert os.environ["VLLM_MEDIA_URL_ALLOW_REDIRECTS"] == "0"
+    assert os.environ["VLLM_MEDIA_CONNECTOR"] == "tt_secure"
+    assert os.environ["VLLM_PLUGINS"] == "tt_model_registry,tt_media_security"
+    register.assert_called_once()
+
+
+def test_cli_cannot_widen_an_operator_allowlist(monkeypatch):
+    monkeypatch.setenv("TT_ALLOWED_MEDIA_DOMAINS", json.dumps([HOST]))
+    with pytest.raises(ValueError, match="conflicts"):
+        media.configure_media_policy(["server"], ["unapproved.example"])
+
+
+def test_missing_shared_connector_support_fails_closed(monkeypatch):
+    import sys
+    import types
+
+    monkeypatch.setattr(media, "_registered", False)
+    monkeypatch.setitem(
+        sys.modules, "vllm.multimodal.media", types.ModuleType("vllm.multimodal.media")
+    )
+    with pytest.raises(RuntimeError, match="shared media-connector registry"):
+        media.register_media_connector()

--- a/tests/test_secure_media_https.py
+++ b/tests/test_secure_media_https.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Exercise the pinned downloader over a real local TLS connection."""
+
+import shutil
+import socket
+import ssl
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from utils import secure_media
+
+
+@pytest.mark.skipif(
+    shutil.which("openssl") is None,
+    reason="openssl is needed for an ephemeral test certificate",
+)
+def test_https_connection_close_and_tls_hostname(tmp_path, monkeypatch):
+    cert, key = tmp_path / "cert.pem", tmp_path / "key.pem"
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-days",
+            "1",
+            "-subj",
+            "/CN=images.example.com",
+            "-addext",
+            "subjectAltName=DNS:images.example.com",
+            "-keyout",
+            str(key),
+            "-out",
+            str(cert),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    observed = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            observed.append((self.path, self.headers["Host"]))
+            self.send_response(200)
+            self.send_header("Content-Type", "image/png")
+            self.send_header("Content-Length", "5")
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(b"image")
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(cert, key)
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        trusted = ssl.create_default_context(cafile=str(cert))
+        monkeypatch.setattr(secure_media.ssl, "create_default_context", lambda: trusted)
+        monkeypatch.setattr(
+            secure_media.socket,
+            "getaddrinfo",
+            lambda *args, **kwargs: [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", server.server_address)
+            ],
+        )
+        # Only this TLS integration fixture allows localhost. Policy tests
+        # separately prove that production rejects this DNS answer before dialing.
+        monkeypatch.setattr(secure_media, "_public_ip", lambda _: True)
+        client = secure_media.SafeMediaHTTPConnection(["images.example.com"])
+        try:
+            assert client.get_bytes("https://images.example.com/a.png") == b"image"
+        except ValueError as exc:
+            raise AssertionError(f"HTTPS fixture failure: {exc.__context__!r}") from exc
+        assert observed == [("/a.png", "images.example.com")]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()

--- a/tests/test_secure_media_vllm.py
+++ b/tests/test_secure_media_vllm.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Run in the rebuilt TT workload image to verify the real vLLM connector contract."""
+
+import asyncio
+import base64
+import io
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+vllm_media = pytest.importorskip(
+    "vllm.multimodal.media", reason="requires the TT vLLM workload image"
+)
+from PIL import Image
+from utils import secure_media
+
+
+def test_native_shared_connector_rejects_urls_and_preserves_inline_images(monkeypatch):
+    monkeypatch.setenv("TT_ALLOWED_MEDIA_DOMAINS", json.dumps(["images.example.com"]))
+    secure_media.register_media_connector()
+    connector = vllm_media.MEDIA_CONNECTOR_REGISTRY.load("tt_secure")
+    lookup = MagicMock(side_effect=AssertionError("forbidden URL reached DNS"))
+    monkeypatch.setattr(secure_media.socket, "getaddrinfo", lookup)
+    for url in (
+        "http://127.0.0.1:8000/health",
+        "https://kubernetes.default.svc/",
+        "https://unapproved.example/a.png",
+        "http://images.example.com/a.png",
+    ):
+        with pytest.raises(ValueError):
+            connector.fetch_image(url)
+        with pytest.raises(ValueError):
+            asyncio.run(connector.fetch_image_async(url))
+    lookup.assert_not_called()
+    data = io.BytesIO()
+    Image.new("RGB", (1, 1)).save(data, format="PNG")
+    inline = "data:image/png;base64," + base64.b64encode(data.getvalue()).decode()
+    assert connector.fetch_image(inline).size == (1, 1)
+    assert asyncio.run(connector.fetch_image_async(inline)).size == (1, 1)

--- a/tt-vllm-plugin/pyproject.toml
+++ b/tt-vllm-plugin/pyproject.toml
@@ -46,6 +46,7 @@ tt = "tt_vllm_plugin:register"
 
 [project.entry-points."vllm.general_plugins"]
 tt_model_registry = "tt_vllm_plugin:register_models"
+tt_media_security = "tt_vllm_plugin:register_media_security"
 
 [tool.setuptools.packages.find]
 include = ["tt_vllm_plugin*"]

--- a/tt-vllm-plugin/tt_vllm_plugin/__init__.py
+++ b/tt-vllm-plugin/tt_vllm_plugin/__init__.py
@@ -8,6 +8,16 @@ def register():
     return "tt_vllm_plugin.platform.TTPlatform"
 
 
+def register_media_security():
+    """Register the shared media policy in spawned vLLM workers as well."""
+    import os
+
+    if os.environ.get("VLLM_MEDIA_CONNECTOR") == "tt_secure":
+        from utils.secure_media import register_media_connector
+
+        register_media_connector()
+
+
 def register_models():
     """Register custom models with ModelRegistry for online inference.
 

--- a/utils/inference_security.py
+++ b/utils/inference_security.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Route authentication and shared vLLM media-policy configuration."""
+
+import argparse
+import hmac
+import json
+import os
+
+
+_POLICY_ENV = "TT_INFERENCE_HTTP_AUTH_KEYS"
+_MIDDLEWARE = "utils.inference_security.InferenceSecurityMiddleware"
+# Only console-facing inference APIs are exposed by default. Utility routes
+# such as /invocations and /tokenize require an explicit operator opt-in.
+_DEFAULT_ROUTES = [
+    "/v1/models",
+    "/v1/chat/completions",
+    "/v1/completions",
+    "/v1/embeddings",
+    "/v1/audio/speech",
+]
+
+
+def configure_inference_security(argv, *, no_auth=False):
+    """Install the guard using the same effective keys as vLLM.
+
+    Called after model defaults and passthrough CLI arguments are merged. The
+    serialized keys are inherited by spawned API workers; missing configuration
+    is an error, not an implicit anonymous-serving mode. Never log this value.
+    """
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("--api-key", nargs="+")
+    parser.add_argument("--allowed-media-domains", nargs="+")
+    # Match vLLM's FlexibleArgumentParser, including underscore-style flags
+    # emitted by model-spec defaults. Do not normalize argument values.
+    normalized = []
+    for token in argv[1:]:
+        if token.startswith("--"):
+            name, separator, value = token.partition("=")
+            token = name.replace("_", "-") + separator + value
+        normalized.append(token)
+    args, _ = parser.parse_known_args(normalized)
+    keys = args.api_key or [os.environ.get("VLLM_API_KEY", "")]
+    keys = [key for key in keys if key]
+    if not keys and not no_auth:
+        raise RuntimeError(
+            "Inference authentication requires VLLM_API_KEY, JWT_SECRET, or "
+            "--api-key. Use --no-auth only for isolated development."
+        )
+    from utils.secure_media import configure_media_policy
+
+    configure_media_policy(argv, args.allowed_media_domains)
+    os.environ[_POLICY_ENV] = json.dumps(keys)
+    argv.extend(["--middleware", _MIDDLEWARE])
+
+
+async def _error(send, status, code, message):
+    body = json.dumps(
+        {"error": {"type": "invalid_request_error", "code": code, "message": message}}
+    ).encode()
+    headers = [
+        (b"content-type", b"application/json"),
+        (b"content-length", str(len(body)).encode()),
+    ]
+    if status == 401:
+        headers.append((b"www-authenticate", b"Bearer"))
+    await send({"type": "http.response.start", "status": status, "headers": headers})
+    await send({"type": "http.response.body", "body": body})
+
+
+class InferenceSecurityMiddleware:
+    """Pure ASGI middleware; response streams pass through without buffering."""
+
+    def __init__(self, app):
+        self.app = app
+        raw = os.environ.get(_POLICY_ENV)
+        if raw is None:
+            raise RuntimeError("Inference HTTP security was not configured")
+        keys = json.loads(raw)
+        if not isinstance(keys, list) or any(
+            not isinstance(key, str) or not key for key in keys
+        ):
+            raise RuntimeError("Invalid inference HTTP authentication configuration")
+        self.keys = [key.encode() for key in keys]
+        routes = json.loads(
+            os.environ.get("TT_INFERENCE_ALLOWED_ROUTES", json.dumps(_DEFAULT_ROUTES))
+        )
+        if not isinstance(routes, list) or any(
+            not isinstance(route, str)
+            or not route.startswith("/")
+            or "?" in route
+            or "#" in route
+            or "*" in route
+            for route in routes
+        ):
+            raise RuntimeError(
+                "TT_INFERENCE_ALLOWED_ROUTES must contain exact route paths"
+            )
+        self.routes = {route.rstrip("/") for route in routes}
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "websocket":
+            # This gateway exposes HTTP APIs only. Do not create an unauthenticated
+            # alternate transport when a newer vLLM version adds a WebSocket route.
+            return await send({"type": "websocket.close", "code": 1008})
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+        path = scope["path"]
+        root_path = scope.get("root_path", "").rstrip("/")
+        if root_path and (path == root_path or path.startswith(root_path + "/")):
+            path = path[len(root_path) :]
+        path = path.rstrip("/")
+        method = scope["method"]
+        # Keep health checks, metrics scrapes and CORS preflights usable. All
+        # other HTTP routes require authentication, including /invocations.
+        public = method in ("GET", "HEAD") and path in ("/health", "/ping", "/metrics")
+        if not public and path not in self.routes:
+            return await _error(send, 404, "not_found", "Not found")
+        public = public or method == "OPTIONS"
+        if self.keys and not public:
+            auth = [
+                value
+                for name, value in scope["headers"]
+                if name.lower() == b"authorization"
+            ]
+            scheme, _, token = (
+                auth[0].partition(b" ") if len(auth) == 1 else (b"", b"", b"")
+            )
+            if scheme.lower() != b"bearer" or not any(
+                hmac.compare_digest(token, key) for key in self.keys
+            ):
+                return await _error(
+                    send, 401, "invalid_api_key", "Invalid or missing API key"
+                )
+
+        # Media policy belongs in vLLM's shared connector, not in route-specific
+        # request parsing. Forward bodies and streamed responses untouched.
+        await self.app(scope, receive, send)

--- a/utils/secure_media.py
+++ b/utils/secure_media.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Shared media policy for TT vLLM, independent of the requesting API route."""
+
+import asyncio
+import http.client
+import ipaddress
+import json
+import os
+import re
+import socket
+import ssl
+import time
+import warnings
+from urllib.parse import urlsplit
+
+CONNECTOR_NAME = "tt_secure"
+MAX_DOWNLOAD_BYTES = 20 * 1024 * 1024
+FETCH_TIMEOUT_SECONDS = 5
+MAX_IMAGE_PIXELS = 16 * 1024 * 1024
+_DENIED = "Media URL is not permitted by the workload's media policy"
+_FETCH_FAILED = "Unable to fetch media from the approved host"
+_registered = False
+
+
+def allowed_domains(values):
+    if not isinstance(values, list):
+        raise ValueError(
+            "TT_ALLOWED_MEDIA_DOMAINS must be a JSON array of exact hostnames"
+        )
+    result = []
+    for value in values:
+        if not isinstance(value, str):
+            raise ValueError("Media domains must be exact hostnames")
+        host = value.lower()
+        labels = host.split(".")
+        if (
+            len(host) > 253
+            or len(labels) < 2
+            or any(
+                not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?", label)
+                for label in labels
+            )
+        ):
+            raise ValueError(
+                "Media domains must be exact DNS hostnames without ports or wildcards"
+            )
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            pass
+        else:
+            raise ValueError("Media domains must not be IP addresses")
+        if host not in result:
+            result.append(host)
+    return result
+
+
+def configure_media_policy(argv, cli_domains=None):
+    configured = os.environ.get("TT_ALLOWED_MEDIA_DOMAINS")
+    domains = allowed_domains(
+        json.loads(configured) if configured is not None else (cli_domains or [])
+    )
+    if (
+        configured is not None
+        and cli_domains is not None
+        and allowed_domains(cli_domains) != domains
+    ):
+        raise ValueError(
+            "--allowed-media-domains conflicts with the operator's TT_ALLOWED_MEDIA_DOMAINS policy"
+        )
+    os.environ["TT_ALLOWED_MEDIA_DOMAINS"] = json.dumps(domains)
+    if cli_domains is None and domains:
+        argv.extend(["--allowed-media-domains", *domains])
+    os.environ["VLLM_MEDIA_URL_ALLOW_REDIRECTS"] = "0"
+    os.environ["VLLM_MEDIA_CONNECTOR"] = CONNECTOR_NAME
+    if "VLLM_PLUGINS" in os.environ:
+        plugins = [name for name in os.environ["VLLM_PLUGINS"].split(",") if name]
+        if "tt_media_security" not in plugins:
+            plugins.append("tt_media_security")
+        os.environ["VLLM_PLUGINS"] = ",".join(plugins)
+    # An empty native allowlist means unrestricted. The mandatory connector
+    # below instead treats an empty policy as deny-all for remote media.
+    register_media_connector()
+
+
+def _public_ip(address):
+    ip = ipaddress.ip_address(address)
+    if not ip.is_global or ip.is_multicast:
+        return False
+    if isinstance(ip, ipaddress.IPv6Address):
+        # Do not allow alternate encodings/tunnels to reach IPv4 destinations.
+        if ip.ipv4_mapped or ip.sixtofour or ip.teredo:
+            return False
+        if ip in ipaddress.ip_network("64:ff9b::/96") or ip in ipaddress.ip_network(
+            "64:ff9b:1::/48"
+        ):
+            return False
+    return True
+
+
+def _remaining(deadline):
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError("Media fetch deadline exceeded")
+    return remaining
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """Connect only to previously validated addresses, retaining TLS SNI/verification."""
+
+    def __init__(self, host, addresses, deadline):
+        super().__init__(
+            host,
+            port=443,
+            timeout=_remaining(deadline),
+            context=ssl.create_default_context(),
+        )
+        self.addresses = addresses
+        self.deadline = deadline
+        self.tls_socket = None
+
+    def connect(self):
+        # socket.connect receives a numeric sockaddr from getaddrinfo, never a
+        # hostname. The HTTP Host and TLS certificate name remain the allowlisted
+        # hostname. There is no second DNS lookup between validation and dialing.
+        for family, socktype, proto, _, sockaddr in self.addresses:
+            sock = socket.socket(family, socktype, proto)
+            try:
+                sock.settimeout(_remaining(self.deadline))
+                sock.connect(sockaddr)
+                self.sock = self._context.wrap_socket(sock, server_hostname=self.host)
+                self.tls_socket = self.sock
+                return
+            except OSError:
+                sock.close()
+        raise OSError(_FETCH_FAILED)
+
+
+class SafeMediaHTTPConnection:
+    """The narrow get_bytes/async_get_bytes interface consumed by MediaConnector."""
+
+    def __init__(self, domains):
+        self.domains = frozenset(allowed_domains(domains))
+
+    def validate_url(self, url):
+        try:
+            if (
+                not isinstance(url, str)
+                or any(ord(c) <= 32 or ord(c) == 127 for c in url)
+                or "\\" in url
+            ):
+                raise ValueError(_DENIED)
+            parsed = urlsplit(url)
+            if (
+                parsed.scheme != "https"
+                or parsed.hostname not in self.domains
+                or parsed.username is not None
+                or parsed.password is not None
+                or parsed.port not in (None, 443)
+                or parsed.fragment
+            ):
+                raise ValueError(_DENIED)
+            return parsed
+        except (ValueError, UnicodeError):
+            raise ValueError(_DENIED) from None
+
+    def get_bytes(self, url, *, timeout=None, allow_redirects=False):
+        parsed = self.validate_url(url)
+        duration = min(
+            timeout if timeout is not None else FETCH_TIMEOUT_SECONDS,
+            FETCH_TIMEOUT_SECONDS,
+        )
+        deadline = time.monotonic() + duration
+        connection = None
+        response = None
+        try:
+            addresses = socket.getaddrinfo(
+                parsed.hostname, 443, type=socket.SOCK_STREAM
+            )
+            if not addresses or any(not _public_ip(item[4][0]) for item in addresses):
+                raise ValueError(_DENIED)
+            connection = _PinnedHTTPSConnection(parsed.hostname, addresses, deadline)
+            target = parsed.path or "/"
+            if parsed.query:
+                target += "?" + parsed.query
+            connection.request(
+                "GET",
+                target,
+                headers={
+                    "Accept": "image/*, audio/*, video/*",
+                    "Accept-Encoding": "identity",
+                    "User-Agent": "tt-inference-server-media",
+                },
+            )
+            response = connection.getresponse()
+            # Never follow redirects, even if a caller passes allow_redirects=True.
+            if response.status != 200:
+                raise ValueError(_FETCH_FAILED)
+            content_type = (
+                response.getheader("Content-Type", "").split(";", 1)[0].lower()
+            )
+            if not content_type.startswith(("image/", "audio/", "video/")):
+                raise ValueError(
+                    "Remote media must have an image, audio, or video content type"
+                )
+            if response.getheader("Content-Encoding", "identity").lower() != "identity":
+                raise ValueError("Encoded media HTTP responses are not supported")
+            length = response.getheader("Content-Length")
+            if length is not None and not 0 <= int(length) <= MAX_DOWNLOAD_BYTES:
+                raise ValueError("Media download exceeds the size limit")
+            data = bytearray()
+            while True:
+                remaining = _remaining(deadline)
+                if (
+                    connection.tls_socket is not None
+                    and connection.tls_socket.fileno() >= 0
+                ):
+                    connection.tls_socket.settimeout(remaining)
+                chunk = response.read1(min(65536, MAX_DOWNLOAD_BYTES + 1 - len(data)))
+                if not chunk:
+                    return bytes(data)
+                data.extend(chunk)
+                if len(data) > MAX_DOWNLOAD_BYTES:
+                    raise ValueError("Media download exceeds the size limit")
+        except (OSError, http.client.HTTPException, ValueError):
+            # Do not reflect internal DNS/connection/status details or signed URLs.
+            raise ValueError(_FETCH_FAILED) from None
+        finally:
+            if response is not None:
+                response.close()
+            if connection is not None:
+                connection.close()
+
+    async def async_get_bytes(self, url, *, timeout=None, allow_redirects=False):
+        return await asyncio.to_thread(
+            self.get_bytes, url, timeout=timeout, allow_redirects=allow_redirects
+        )
+
+
+def register_media_connector():
+    global _registered
+    if _registered:
+        return
+    try:
+        from PIL import Image
+        from vllm.multimodal.media import MEDIA_CONNECTOR_REGISTRY, MediaConnector
+    except ImportError as exc:
+        raise RuntimeError(
+            "This workload requires a TT vLLM build with the shared media-connector registry"
+        ) from exc
+
+    @MEDIA_CONNECTOR_REGISTRY.register(CONNECTOR_NAME)
+    class SecureMediaConnector(MediaConnector):
+        def __init__(
+            self,
+            media_io_kwargs=None,
+            connection=None,
+            *,
+            allowed_local_media_path="",
+            allowed_media_domains=None,
+        ):
+            domains = allowed_domains(
+                json.loads(os.environ.get("TT_ALLOWED_MEDIA_DOMAINS", "[]"))
+            )
+            if allowed_local_media_path:
+                raise ValueError("Local media paths are disabled for this workload")
+            super().__init__(
+                media_io_kwargs,
+                SafeMediaHTTPConnection(domains),
+                allowed_local_media_path="",
+                allowed_media_domains=domains,
+            )
+
+        def _assert_url_in_allowed_media_domains(self, url_spec):
+            super()._assert_url_in_allowed_media_domains(url_spec)
+            # Also run for an empty allowlist and before any native disk-cache hit.
+            self.connection.validate_url(url_spec.url)
+
+    Image.MAX_IMAGE_PIXELS = min(
+        Image.MAX_IMAGE_PIXELS or MAX_IMAGE_PIXELS, MAX_IMAGE_PIXELS
+    )
+    warnings.filterwarnings("error", category=Image.DecompressionBombWarning)
+    _registered = True

--- a/vllm-tt-metal/src/run_vllm_api_server.py
+++ b/vllm-tt-metal/src/run_vllm_api_server.py
@@ -18,6 +18,7 @@ from vllm import ModelRegistry
 
 from utils.cache_monitor import get_container_cache_dir
 from utils.device_utils import get_mesh_device_name
+from utils.inference_security import configure_inference_security
 from utils.logging_utils import set_vllm_logging_config
 from utils.prompt_client import run_background_trace_capture
 from utils.vllm_run_utils import (
@@ -567,6 +568,10 @@ def set_runtime_env_vars(model_spec_json):
         return
 
     for key, value in env_vars.items():
+        if key in ("TT_ALLOWED_MEDIA_DOMAINS", "TT_INFERENCE_ALLOWED_ROUTES"):
+            # These are operator policies, never defaults supplied by a model
+            # catalog. configure_inference_security reads the runtime values.
+            continue
         if not isinstance(key, str):
             key = str(key)
             logger.warning(
@@ -791,6 +796,9 @@ def main():
     runtime_settings(model_spec, no_auth=args.no_auth)
     default_vllm_args = model_spec["device_model_spec"]["vllm_args"]
     set_vllm_sys_argv(args, remaining_sys_argv, default_vllm_args)
+    # vLLM versions differ in which routes their API-key middleware protects.
+    # Guard every inference route (including /invocations) before media loading.
+    configure_inference_security(sys.argv, no_auth=args.no_auth)
 
     # Step 5: Start trace capture if needed
     start_trace_capture(


### PR DESCRIPTION
Direct workload requests can make vLLM fetch attacker-controlled media URLs, including internal destinations, through `/invocations` and tokenizer APIs. This change adds authentication and an explicit HTTP route allowlist, then enforces media policy through vLLM's shared connector so the policy also applies to tokenization and spawned workers.

- Expose console inference routes by default; block `/invocations`, `/tokenize`, `/tokenizer` and other unlisted routes. Explicitly enabled routes require authentication. Health checks, metrics and CORS preflights remain available.
- Allow remote media only from exact approved HTTPS hosts on port 443. Validate all resolved addresses, pin connections to validated addresses while preserving TLS verification, reject redirects, and bound media downloads and image decoding. An empty host list denies remote media; inline images remain supported.
- Wire operator policy through the launcher, worker plugin and Helm chart. Unsupported vLLM builds fail startup rather than silently omitting enforcement.

Related to https://github.com/tenstorrent/tt-cloud-console/issues/1137. Console companion: https://github.com/tenstorrent/tt-cloud-console/pull/1223. The console companion supplies this policy to newly deployed workloads; this PR supplies the enforcement.

Validation: 143 Python tests passed, including real local HTTPS transport, DNS/address rejection, route authentication, launcher and chart coverage. Ruff checks and formatting passed. One native vLLM integration module was skipped because the local environment has no vLLM installation.

Draft pending validation in a rebuilt compatible TT vLLM image, approved production media domains, and rollout to affected workloads. Run `tests/test_secure_media_vllm.py` in that image and verify enabled APIs with approved remote images and inline images. Existing image tags are not patched by configuration alone. External platform ingress/egress controls and live endpoint verification remain rollout requirements; no infrastructure has been deployed by this PR.
