### PR TITLE
Fix Quetzal source transport for image builds

### DIFF
--- a/scripts/build_single_docker.sh
+++ b/scripts/build_single_docker.sh
@@ -191,7 +191,6 @@ else
     echo "CONTAINER_APP_UID=${CONTAINER_APP_UID} is not a number or outside expected range of 1000 to 59999."
 fi
 QUETZAL_SOURCE_CONTEXT=""
-QUETZAL_SOURCE_ARCHIVE=""
 cleanup_quetzal_source_context() {
     if [[ -n "$QUETZAL_SOURCE_CONTEXT" && -d "$QUETZAL_SOURCE_CONTEXT" ]]; then
         rm -rf -- "$QUETZAL_SOURCE_CONTEXT"
@@ -216,10 +215,10 @@ if [[ -n "$TT_QUETZAL_COMMIT_SHA" || -n "$TT_QUETZAL_SOURCE_DIR" ]]; then
         exit 1
     fi
     QUETZAL_SOURCE_CONTEXT=$(mktemp -d "${TMPDIR:-/tmp}/ttis-quetzal-source.XXXXXX")
-    QUETZAL_SOURCE_ARCHIVE="${QUETZAL_SOURCE_CONTEXT}/source.tar"
-    git -C "$TT_QUETZAL_SOURCE_DIR" archive --format=tar "$TT_QUETZAL_COMMIT_SHA" > "$QUETZAL_SOURCE_ARCHIVE"
-    if ! DOCKER_BUILDKIT=1 docker build --help 2>&1 | grep -q -- '--secret'; then
-        echo "⛔ Error: Quetzal image builds require Docker BuildKit support for --secret."
+    git -C "$TT_QUETZAL_SOURCE_DIR" archive --format=tar "$TT_QUETZAL_COMMIT_SHA" \
+        | tar -xf - -C "$QUETZAL_SOURCE_CONTEXT"
+    if ! DOCKER_BUILDKIT=1 docker build --help 2>&1 | grep -q -- '--build-context'; then
+        echo "⛔ Error: Quetzal image builds require Docker BuildKit support for --build-context."
         exit 1
     fi
     export DOCKER_BUILDKIT=1
@@ -338,7 +337,7 @@ generate_model_specs_json()
         if [[ -n "$TT_QUETZAL_COMMIT_SHA" ]]; then
             QUETZAL_BUILD_ARGS+=(
                 --build-arg "TT_QUETZAL_COMMIT_SHA=${TT_QUETZAL_COMMIT_SHA}"
-                --secret "id=quetzal_source,src=${QUETZAL_SOURCE_ARCHIVE}"
+                --build-context "quetzal_source=${QUETZAL_SOURCE_CONTEXT}"
             )
         fi
 

--- a/tests/test_quetzal_image_build.py
+++ b/tests/test_quetzal_image_build.py
@@ -122,9 +122,7 @@ def test_quetzal_rebuild_pushes_when_remote_tag_already_exists(tmp_path):
     assert "--secret" not in quetzal_builds[0]
     pushes = [line for line in docker_commands if line.startswith("push ")]
     builds = [
-        line
-        for line in docker_commands
-        if line.startswith(("build ", "buildx bake "))
+        line for line in docker_commands if line.startswith(("build ", "buildx bake "))
     ]
     assert builds
     assert len(pushes) == 1
@@ -136,7 +134,9 @@ def test_quetzal_rebuild_pushes_when_remote_tag_already_exists(tmp_path):
     assert native.returncode == 0, native.stdout + native.stderr
     native_commands = docker_log.read_text().splitlines()
     assert not any(line.startswith("push ") for line in native_commands)
-    assert not any("--build-context quetzal_source=" in line for line in native_commands)
+    assert not any(
+        "--build-context quetzal_source=" in line for line in native_commands
+    )
 
 
 def test_quetzal_image_build_contract_is_minimal_and_credential_free():

--- a/tests/test_quetzal_image_build.py
+++ b/tests/test_quetzal_image_build.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BUILD_SCRIPT = REPO_ROOT / "scripts" / "build_single_docker.sh"
 DOCKERFILE = REPO_ROOT / "vllm-tt-metal" / "vllm.tt-metal.src.dev.Dockerfile"
@@ -92,7 +91,7 @@ def test_quetzal_rebuild_pushes_when_remote_tag_already_exists(tmp_path):
     fake_docker = fake_bin / "docker"
     fake_docker.write_text(
         '#!/bin/bash\nprintf \'%s\\n\' "$*" >> "$DOCKER_LOG"\n'
-        'if [ "$1 $2" = "build --help" ]; then echo --secret; fi\n'
+        'if [ "$1 $2" = "build --help" ]; then echo --build-context; fi\n'
     )
     fake_docker.chmod(0o755)
     env = {
@@ -113,11 +112,19 @@ def test_quetzal_rebuild_pushes_when_remote_tag_already_exists(tmp_path):
 
     assert result.returncode == 0, result.stdout + result.stderr
     docker_commands = docker_log.read_text().splitlines()
+    quetzal_builds = [
+        line
+        for line in docker_commands
+        if line.startswith("build ") and line != "build --help"
+    ]
+    assert len(quetzal_builds) == 1
+    assert "--build-context quetzal_source=" in quetzal_builds[0]
+    assert "--secret" not in quetzal_builds[0]
     pushes = [line for line in docker_commands if line.startswith("push ")]
     builds = [
         line
         for line in docker_commands
-        if line.startswith("build ") or line.startswith("buildx bake ")
+        if line.startswith(("build ", "buildx bake "))
     ]
     assert builds
     assert len(pushes) == 1
@@ -127,9 +134,9 @@ def test_quetzal_rebuild_pushes_when_remote_tag_already_exists(tmp_path):
     docker_log.write_text("")
     native = _run_builder(worktree, "--push", env=env)
     assert native.returncode == 0, native.stdout + native.stderr
-    assert not any(
-        line.startswith("push ") for line in docker_log.read_text().splitlines()
-    )
+    native_commands = docker_log.read_text().splitlines()
+    assert not any(line.startswith("push ") for line in native_commands)
+    assert not any("--build-context quetzal_source=" in line for line in native_commands)
 
 
 def test_quetzal_image_build_contract_is_minimal_and_credential_free():
@@ -137,7 +144,8 @@ def test_quetzal_image_build_contract_is_minimal_and_credential_free():
     dockerfile = DOCKERFILE.read_text()
 
     assert 'git -C "$TT_QUETZAL_SOURCE_DIR" archive --format=tar' in build_script
-    assert '--secret "id=quetzal_source,src=${QUETZAL_SOURCE_ARCHIVE}"' in build_script
+    assert '| tar -xf - -C "$QUETZAL_SOURCE_CONTEXT"' in build_script
+    assert '--build-context "quetzal_source=${QUETZAL_SOURCE_CONTEXT}"' in build_script
     assert 'QUETZAL_IMAGE_SUFFIX="-qz-${TT_QUETZAL_COMMIT_SHA:0:12}"' in build_script
     assert "DOCKER_BUILDKIT=1 docker build --help" in build_script
     assert "export DOCKER_BUILDKIT=1" in build_script
@@ -146,7 +154,10 @@ def test_quetzal_image_build_contract_is_minimal_and_credential_free():
     assert "build=true" in build_script
     assert "force_push=true" in build_script
 
-    assert "RUN --mount=type=secret,id=quetzal_source,required=false" in dockerfile
+    assert "FROM scratch AS quetzal_source" in dockerfile
+    assert "RUN --mount=type=bind,from=quetzal_source" in dockerfile
+    assert "target=/tmp/quetzal-source-ro,ro" in dockerfile
+    assert "cp -a /tmp/quetzal-source-ro/. /tmp/quetzal-source/" in dockerfile
     assert "uv build --wheel --out-dir /tmp/quetzal-wheel" in dockerfile
     assert 'uv pip install --no-cache-dir --no-deps "$1"' in dockerfile
     assert "import serving.artifact_discovery" in dockerfile
@@ -160,6 +171,8 @@ def test_quetzal_image_build_contract_is_minimal_and_credential_free():
     assert "TT_QUETZAL_COMMIT_SHA=${TT_QUETZAL_COMMIT_SHA}" in dockerfile
 
     combined = build_script + dockerfile
+    assert "--secret" not in combined
+    assert "type=secret" not in combined
     assert "tt-quetzalcoatlus.git" not in combined
     assert "mesh_graph_descriptor" not in combined
     assert "PATCHSET" not in combined

--- a/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
+++ b/vllm-tt-metal/vllm.tt-metal.src.dev.Dockerfile
@@ -6,6 +6,10 @@
 # Optimized multi-stage build for significantly smaller runtime images
 ARG TT_METAL_DOCKERFILE_URL
 
+# Native builds resolve this name to an empty stage. Quetzal builds override it
+# with a sanitized, exact-commit named context supplied by the build script.
+FROM scratch AS quetzal_source
+
 # ==============================================================================
 # BUILDER STAGE - Contains all build dependencies and artifacts
 # ==============================================================================
@@ -112,18 +116,18 @@ RUN /bin/bash -c "git clone https://github.com/tenstorrent/vllm-tt-plugin.git ${
     && rm -rf ${vllm_tt_plugin_dir}/.git \
     && { uv cache clean || echo 'WARN: uv cache clean failed'; true; }"
 
-# The optional source archive is supplied by the authenticated caller as a
-# BuildKit secret, so neither Git metadata nor credentials enter an image layer.
+# The optional source is supplied by the authenticated caller as a sanitized
+# exact-commit build context. Its read-only mount is not committed to a layer.
 # Installing without dependencies preserves the image's pinned tt-metal/vLLM stack.
-RUN --mount=type=secret,id=quetzal_source,required=false,target=/tmp/quetzal-source.tar \
+RUN --mount=type=bind,from=quetzal_source,source=.,target=/tmp/quetzal-source-ro,ro \
     set -eu; \
     if [ -n "${TT_QUETZAL_COMMIT_SHA}" ]; then \
       printf '%s' "${TT_QUETZAL_COMMIT_SHA}" | grep -Eq '^[0-9a-f]{40}$' \
         || { echo 'TT_QUETZAL_COMMIT_SHA must be a lowercase 40-hex commit' >&2; exit 1; }; \
-      test -s /tmp/quetzal-source.tar \
-        || { echo 'Quetzal source archive is required for a Quetzal build' >&2; exit 1; }; \
+      test -s /tmp/quetzal-source-ro/pyproject.toml \
+        || { echo 'Quetzal source context is required for a Quetzal build' >&2; exit 1; }; \
       mkdir -p /tmp/quetzal-source /tmp/quetzal-wheel; \
-      tar -xf /tmp/quetzal-source.tar -C /tmp/quetzal-source; \
+      cp -a /tmp/quetzal-source-ro/. /tmp/quetzal-source/; \
       cd /tmp/quetzal-source; \
       . "${PYTHON_ENV_DIR}/bin/activate"; \
       uv build --wheel --out-dir /tmp/quetzal-wheel; \
@@ -135,8 +139,8 @@ RUN --mount=type=secret,id=quetzal_source,required=false,target=/tmp/quetzal-sou
       cd /; \
       rm -rf /tmp/quetzal-source /tmp/quetzal-wheel; \
       { uv cache clean || echo 'WARN: uv cache clean failed'; true; }; \
-    elif [ -e /tmp/quetzal-source.tar ]; then \
-      echo 'Quetzal source archive requires TT_QUETZAL_COMMIT_SHA' >&2; \
+    elif [ -e /tmp/quetzal-source-ro/pyproject.toml ]; then \
+      echo 'Quetzal source context requires TT_QUETZAL_COMMIT_SHA' >&2; \
       exit 1; \
     else \
       echo 'Building native-only image (TT_QUETZAL_COMMIT_SHA unset)'; \


### PR DESCRIPTION
## Problem

Shield run 34532744115 proved that #5118 cannot build a Quetzal image: the exact Quetzal git archive is 104,427,520 bytes, while BuildKit rejects secrets above 500 KiB. The build failed before producing an image or reaching QB2.

## Fix

Replace the source-as-secret transport with a sanitized exact-commit named build context mounted read-only while the wheel is built. An empty scratch-stage fallback preserves native builds. The existing exact SHA/HEAD validation, dependency-free wheel install, plugin smoke test, opt-in behavior, and OCI revision label remain unchanged.

No Shield change is required.

## Validation

- `python3 -m pytest -q tests/test_quetzal_image_build.py`: 7 passed
- Ruff: passed
- `bash -n scripts/build_single_docker.sh`: passed
- `git diff --check`: passed
- Real Docker smoke: native fallback passed; 600,001-byte named context passed; mounted source absent from resulting container filesystem

A Shield dispatch against this unmerged exact SHA will provide the full image-build and QB2 evidence before this leaves draft.