### PR TITLE
model_specs(dev): add Qwen3.6-27B impl=quetzal row for P300X2

### DIFF
--- a/workflows/model_specs/dev/llm.yaml
+++ b/workflows/model_specs/dev/llm.yaml
@@ -1023,6 +1023,40 @@ templates:
       tool_call_parser_name: qwen3_coder
 
 - weights:
+    - Qwen/Qwen3.6-27B
+  impl: quetzal
+  inference_engine: VLLM
+  device_model_specs:
+    - device: P300X2
+      max_concurrency: 1  # package mode is batch 1; higher cannot be served
+      max_context: 8192  # equals the artifact's decode context_len
+      default_impl: false
+      env_vars:
+        MESH_DEVICE: P150x4
+        QUETZAL_VLLM: "1"
+        QUETZAL_BUNDLE_MANIFEST_SHA256: d71abb2865d94511a1aaafbb02fabe1adfc5bd658ff9b876412f5f558111db4a
+        QUETZAL_PACKAGE_ROOT: /home/container_app_user/quetzal/package
+        VLLM_PLUGINS: quetzal_model_registry,tt
+      vllm_args:
+        # From the artifact's own checkpoint_revision; no Hugging Face lookup.
+        revision: 6a9e13bd6fc8f0983b9b99948120bc37f49c13e9
+        tokenizer_revision: 6a9e13bd6fc8f0983b9b99948120bc37f49c13e9
+        # NO tool_call_parser / reasoning_parser. Tool-use qualification is
+        # UNSUPPORTED for this row pending parser validation; ordinary evals do
+        # not require tool calling, so this is sufficient for a first
+        # EXPERIMENTAL evaluation run and for nothing beyond it.
+      override_tt_config:
+        sample_on_device_mode: all
+        l1_small_size: 16384  # from the artifact's parallelism_plan
+        # PROVISIONAL, inherited from the qwen36_blackhole P300X2 row above. NOT
+        # qualified performance evidence for the Quetzal artifact: that row was
+        # measured against a different implementation and a different context
+        # envelope (max_context 262144 against this artifact's 8192), so it
+        # over-reserves here. Replace once measured on this artifact's tuple.
+        trace_region_size: 1073741824
+  status: EXPERIMENTAL
+
+- weights:
     - Qwen/Qwen3-32B
   impl: qwen3_32b_galaxy
   inference_engine: VLLM


### PR DESCRIPTION
## Why

Shield dispatch for `Qwen/Qwen3.6-27B` on `P300X2` with `impl=quetzal` fails in `determine-server-type`, **before any runner is allocated**:

```
No model spec matches model='Qwen3.6-27B', device='P300X2', engine=None, impl='quetzal' in catalog
```

Evidence: **tt-shield run [34621576433](https://github.com/tenstorrent/tt-shield/actions/runs/34621576433)** — failed at `determine-server-type`, never reached a QuietBox, never loaded the package, produced no measurements.

The catalog has a `qwen36_blackhole` row for this repo but no `quetzal` row, so the run cannot resolve. This adds only that row.

## Verification

Resolved with this repository's own resolver against the dev catalog:

```
quetzal keys: ['id_quetzal_Qwen3.6-27B_p300x2', 'id_quetzal_Llama-3.2-1B-Instruct_p300x2']

resolve_model_spec(model='Qwen3.6-27B', device='P300X2', impl='quetzal')
  -> Qwen/Qwen3.6-27B, max_context 8192, max_concurrency 1
```

`tests/test_model_specification.py`: **60 passed**.

## Field provenance

The row is generated from the immutable Quetzal package `sha256-f1d6ceba…-0a8efa10…` plus a reviewed onboarding overlay — not hand-authored.

| field | source |
|---|---|
| `QUETZAL_BUNDLE_MANIFEST_SHA256` | the package's bundle-manifest digest (`d71abb28…`) |
| `max_context: 8192` | the artifact's decode `context_len`; admission compares these by **equality** |
| `revision` / `tokenizer_revision` | the artifact's own `checkpoint_revision` (`6a9e13bd…`) — no Hugging Face lookup, so it pins what was compiled rather than whatever `main` points at now |
| `l1_small_size: 16384` | the artifact's `parallelism_plan` |
| `max_concurrency: 1` | package mode is batch 1 at every call site |

Numerical evidence for this exact identity: PCC **0.9920749664** against the 0.99 charter floor, `pcc_status: pass`, hash-bound to this package id, root manifest digest and compiler commit.

## Deliberately not included

- **No `tool_call_parser` / `reasoning_parser`.** Tool-use qualification is **unsupported** for this row pending parser validation. Ordinary evals do not require tool calling, so this is sufficient for a first EXPERIMENTAL evaluation run and for nothing beyond it.
- **`trace_region_size: 1073741824` is PROVISIONAL**, inherited from the `qwen36_blackhole` P300X2 row. It is **not qualified performance evidence** for the Quetzal artifact: that row was measured against a different implementation and a different context envelope (`max_context 262144` against this artifact's 8192), so it over-reserves here. To be replaced once measured on this artifact's tuple (`P300X2`, tt-metal `b534549300fe…`, artifact `d71abb28…`).
- No Shield enrollment, spec-test wiring, performance targets, or unrelated cleanup.

## Scope

This unlocks Qwen **serving and Model CI resolution**. It does **not** qualify Qwen and does not make the Quetzal pipeline production-ready. `status: EXPERIMENTAL` and `default_impl: false`, so no existing default changes and nothing else in the catalog is affected.

Qwen's own qualification remains `investigating` upstream: complete GSM8K has not been run against this identity, and the trace reservation is unmeasured on its tuple.
